### PR TITLE
Adds the armor protection feet flag to marine combat boots

### DIFF
--- a/code/modules/clothing/shoes/marine_shoes.dm
+++ b/code/modules/clothing/shoes/marine_shoes.dm
@@ -5,6 +5,7 @@
 	desc = "Standard issue combat boots for combat scenarios or combat situations. All combat, all the time."
 	icon_state = "marine"
 	item_state = "marine"
+	flags_armor_protection = FEET
 	armor = list(melee = 60, bullet = 40, laser = 10,energy = 10, bomb = 10, bio = 10, rad = 0)
 	flags_cold_protection = FEET
 	flags_heat_protection = FEET


### PR DESCRIPTION
This adds the armor protection flag to the marine combat boots.

all other marine armor has it for the rest of the body parts. now combat boots do to!

the boots were providing armor before so this isn't a balance change.