### PR TITLE
Buff to G8 pouch.

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -391,7 +391,8 @@
 /obj/item/storage/sparepouch
 	name="\improper G8 general utility pouch"
 	desc="A small, lightweight pouch that can be clipped onto Armat Systems M3 Pattern armor to provide additional storage. Unfortunately, this pouch uses the same securing system as most Armat platform weaponry, and thus only one can be clipped to the M3 Pattern Armor."
-	storage_slots = 3
+	storage_slots = null
+	max_storage_space = 15
 	w_class = 4
 	max_w_class = 3
 	icon = 'icons/obj/clothing/belts.dmi'


### PR DESCRIPTION
G8 pouch, which is similar to large general pouch but for suit storage slot (three items under or equal 3 w_class) gets buff which makes it equal to regular satchel.

Why? Because it takes an entire suit storage slot which can hold gun with magharness, it apparently deserves more than being an equivalent to large general pouch. Allows for more flexible loadout solutions.

Tested and working.