### PR TITLE
Makes queen mature faster

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Castes/Queen.dm
@@ -25,7 +25,7 @@
 	max_health = 300
 
 	// *** Evolution *** //
-	upgrade_threshold = 800
+	upgrade_threshold = 600
 
 	// *** Flags *** //
 	caste_flags = CASTE_IS_INTELLIGENT|CASTE_CAN_HOLD_FACEHUGGERS|CASTE_FIRE_IMMUNE
@@ -69,7 +69,7 @@
 	max_health = 325
 
 	// *** Evolution *** //
-	upgrade_threshold = 1600
+	upgrade_threshold = 1200
 
 	// *** Defense *** //
 	armor_deflection = 50
@@ -106,7 +106,7 @@
 	max_health = 350
 
 	// *** Evolution *** //
-	upgrade_threshold = 3200
+	upgrade_threshold = 2400
 
 	// *** Defense *** //
 	armor_deflection = 55


### PR DESCRIPTION
People seem to think that queens are currently a bit on the squishy side of things. And they don't really have great CC or speed to make up for it anymore. Since all other castes mature quicker now, why not the queen as well?

 Summary : Reduces aging times to 600 / 1200 / 2400 from 800 / 1600 / 3200