### PR TITLE
Hydro Tray Tweak

### DIFF
--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -4,7 +4,7 @@
 	name = "hydroponics tray"
 	icon = 'icons/obj/machines/hydroponics.dmi'
 	icon_state = "hydrotray3"
-	density = 1
+	density = 0
 	anchored = 1
 	container_type = AMOUNT_VISIBLE|REFILLABLE
 	volume = 100


### PR DESCRIPTION
removes the density on hydro trays

upside: 
-tank can now stroll over these without needing them moved aside and mobs can walk atop of them now

downside:
-they're no longer viable for using in defenses