### PR TITLE
Update marine_shoes.dm - Adds Armor protect flags to marine shoes and PMC shoes.

### DIFF
--- a/code/modules/clothing/shoes/marine_shoes.dm
+++ b/code/modules/clothing/shoes/marine_shoes.dm
@@ -5,6 +5,7 @@
 	desc = "Standard issue combat boots for combat scenarios or combat situations. All combat, all the time."
 	icon_state = "marine"
 	item_state = "marine"
+	flags_armor_protection = FEET
 	armor = list(melee = 60, bullet = 40, laser = 10,energy = 10, bomb = 10, bio = 10, rad = 0)
 	flags_cold_protection = FEET
 	flags_heat_protection = FEET
@@ -70,6 +71,7 @@
 	desc = "The height of fashion, but these look to be woven with protective fiber."
 	icon_state = "jackboots"
 	item_state = "jackboots"
+	flags_armor_protection = FEET
 	armor = list(melee = 60, bullet = 40, laser = 10,energy = 10, bomb = 10, bio = 10, rad = 0)
 	min_cold_protection_temperature = SHOE_min_cold_protection_temperature
 	max_heat_protection_temperature = SHOE_max_heat_protection_temperature
@@ -83,6 +85,11 @@
 	desc = "A pair of heavily armored, acid-resistant boots."
 	icon_state = "commando_boots"
 	permeability_coefficient = 0.01
+	flags_armor_protection = FEET
 	armor = list(melee = 90, bullet = 120, laser = 100, energy = 90, bomb = 50, bio = 30, rad = 30)
+	min_cold_protection_temperature = SHOE_min_cold_protection_temperature
+	max_heat_protection_temperature = SHOE_max_heat_protection_temperature
+	flags_cold_protection = FEET
+	flags_heat_protection = FEET
 	siemens_coefficient = 0.2
 	unacidable = 1


### PR DESCRIPTION
so all the boots are missing these flags.

also, the Commando boots were missing the cold and heat protection flags.

Tested the cold protection on ICE wearing PMC standard gear. because the FEET protection flag only covers a small small fraction of the body, you can walk around without shoes and not get cold. I do believe that having these flags is beneficial though. in case you wanted to send deathsquads down onto the Ice planet.

The commanders and chief officers shoes are also missing these flags, but I do believe they are not meant to be used in combat as they are dress shoes. Having armor values gives them armor, not by having the flags.

-side PR? (remove armor values for the CO's shoes, make him put on real combat boots if going in to combat.)