### PR TITLE
Attachment vendor hackable. Supply console access hackable by pulsing.

### DIFF
--- a/code/game/machinery/vending/marine_vending.dm
+++ b/code/game/machinery/vending/marine_vending.dm
@@ -531,7 +531,6 @@
 /obj/machinery/vending/attachments
 	name = "\improper Armat Systems Attachments Vendor"
 	desc = "A subsidiary-owned vendor of weapon attachments. This can only be accessed by the Requisitions Officer and Cargo Techs."
-	hacking_safety = 1
 	product_ads = "If it moves, it's hostile!;How many enemies have you killed today?;Shoot first, perform autopsy later!;Your ammo is right here.;Guns!;Die, scumbag!;Don't shoot me bro!;Shoot them, bro.;Why not have a donut?"
 	req_access = list(ACCESS_MARINE_CARGO)
 	icon_state = "robotics"

--- a/code/game/objects/items/circuitboards/computer.dm
+++ b/code/game/objects/items/circuitboards/computer.dm
@@ -197,6 +197,10 @@
 /obj/item/circuitboard/computer/supplycomp/construct(var/obj/machinery/computer/supplycomp/SC)
 	if (..(SC))
 		SC.can_order_contraband = contraband_enabled
+		if(contraband_enabled)
+			SC.req_access = list()
+		else
+			SC.req_access = list(ACCESS_MARINE_LOGISTICS)
 
 /obj/item/circuitboard/computer/supplycomp/deconstruct(var/obj/machinery/computer/supplycomp/SC)
 	if (..(SC))


### PR DESCRIPTION
You can now hack the attachment vendor like any other vendor.

By deconstructing the supply console and pulsing it, switching it to broad now also removes the access requirement from it alongside enabling the hacked state.