### PR TITLE
Distress call bugfixes.

### DIFF
--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -1,16 +1,20 @@
 //=================================================
 //Self destruct, nuke, and evacuation.
-#define EVACUATION_TIME_LOCK 36000
-#define DISTRESS_TIME_LOCK 3600
-#define SHUTTLE_TIME_LOCK 6000
-#define SHUTTLE_LOCK_COOLDOWN 6000
-#define SHUTTLE_LOCK_TIME_LOCK 27000
-#define EVACUATION_AUTOMATIC_DEPARTURE 1800 //All pods automatically depart in 10 minutes, unless they are full or unable to launch for some reason.
+#define EVACUATION_TIME_LOCK 60 MINUTES
+#define DISTRESS_TIME_LOCK 10 MINUTES
+#define SHUTTLE_TIME_LOCK 10 MINUTES
+#define SHUTTLE_LOCK_COOLDOWN 10 MINUTES
+#define SHUTTLE_LOCK_TIME_LOCK 45 MINUTES
+#define EVACUATION_AUTOMATIC_DEPARTURE 3 MINUTES //All pods automatically depart in 10 minutes, unless they are full or unable to launch for some reason.
 #define EVACUATION_ESTIMATE_DEPARTURE ((evac_time + EVACUATION_AUTOMATIC_DEPARTURE - world.time) * 0.1)
 #define EVACUATION_STATUS_STANDING_BY 0
 #define EVACUATION_STATUS_INITIATING 1
 #define EVACUATION_STATUS_IN_PROGRESS 2
 #define EVACUATION_STATUS_COMPLETE 3
+
+#define COOLDOWN_COMM_REQUEST 5 MINUTES
+#define COOLDOWN_COMM_MESSAGE 1 MINUTE
+#define COOLDOWN_COMM_CENTRAL 30 SECONDS
 
 #define NUKE_EXPLOSION_INACTIVE 0
 #define NUKE_EXPLOSION_ACTIVE	1

--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -5,8 +5,8 @@
 /datum/game_mode
 	var/list/datum/emergency_call/all_calls = list() //initialized at round start and stores the datums.
 	var/datum/emergency_call/picked_call = null //Which distress call is currently active
-	var/on_distress_cooldown = 0
-	var/waiting_for_candidates = 0
+	var/on_distress_cooldown = FALSE
+	var/waiting_for_candidates = FALSE
 
 //The distress call parent.
 /datum/emergency_call
@@ -43,9 +43,7 @@
 
 	for(var/S in total_calls)
 		var/datum/emergency_call/C = new S()
-		if(!C)	
-			continue
-		if(!C.name) 
+		if(!C?.name) 
 			continue //The default parent, don't add it
 		all_calls += C
 

--- a/code/datums/emergency_calls/pizza.dm
+++ b/code/datums/emergency_calls/pizza.dm
@@ -1,7 +1,6 @@
 //Terrified pizza delivery
 /datum/emergency_call/pizza
 	name = "Pizza Delivery"
-	mob_max = 1
 	arrival_message = "Incoming Transmission: 'That'll be.. sixteen orders of cheesy fries, eight large double topping pizzas, nine bottles of Four Loko.. hello? Is anyone on this ship? Your pizzas are getting cold.'"
 	objectives = "Make sure you get a tip!"
 	probability = 5

--- a/code/game/gamemodes/cm_self_destruct.dm
+++ b/code/game/gamemodes/cm_self_destruct.dm
@@ -68,7 +68,8 @@ var/global/datum/authority/branch/evacuation/EvacuationAuthority //This is initi
 		to_chat(world, "<span class='debuginfo'>ERROR CODE SD1: could not find master self-destruct console</span>")
 		return FALSE
 	dest_rods = new
-	for(var/obj/machinery/self_destruct/rod/I in dest_master.loc.loc) dest_rods += I
+	for(var/obj/machinery/self_destruct/rod/I in dest_master.loc.loc) 
+		dest_rods += I
 	if(!dest_rods.len)
 		log_debug("ERROR CODE SD2: could not find any self destruct rods")
 		to_chat(world, "<span class='debuginfo'>ERROR CODE SD2: could not find any self destruct rods</span>")
@@ -228,7 +229,7 @@ var/global/datum/authority/branch/evacuation/EvacuationAuthority //This is initi
 		var/mob/M
 		var/turf/T
 		for(M in player_list) //This only does something cool for the people about to die, but should prove pretty interesting.
-			if(!M || !M.loc) 
+			if(!M?.loc) 
 				continue //In case something changes when we sleep().
 			T = get_turf(M)
 			if(T.z in z_levels)
@@ -342,7 +343,8 @@ var/global/datum/authority/branch/evacuation/EvacuationAuthority //This is initi
 		ui_interact(user)
 
 /obj/machinery/self_destruct/console/Topic(href, href_list)
-	if(..()) 
+	. = ..()
+	if(.) 
 		return TRUE
 	switch(href_list["command"])
 		if("dest_start")
@@ -401,7 +403,8 @@ var/global/datum/authority/branch/evacuation/EvacuationAuthority //This is initi
 		layer = ABOVE_OBJ_LAYER
 
 /obj/machinery/self_destruct/rod/attack_hand(mob/user)
-	if(..())
+	. = ..()
+	if(.)
 		switch(active_state)
 			if(SELF_DESTRUCT_MACHINE_ACTIVE)
 				to_chat(user, "<span class='notice'>You twist and release the control rod, arming it.</span>")

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -137,7 +137,7 @@
 					to_chat(usr, "<span class='warning'>USCM protocol does not allow immediate evacuation. Please wait another [round((EVACUATION_TIME_LOCK-world.time)/600)] minutes before trying again.</span>")
 					return FALSE
 
-				if(!ticker || !ticker.mode)
+				if(!ticker?.mode)
 					to_chat(usr, "<span class='warning'>The [MAIN_SHIP_NAME]'s distress beacon must be activated prior to evacuation taking place.</span>")
 					return FALSE
 

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -10,10 +10,6 @@
 #define STATE_ALERT_LEVEL 9
 #define STATE_CONFIRM_LEVEL 10
 
-#define COOLDOWN_COMM_MESSAGE 600
-#define COOLDOWN_COMM_REQUEST 3000
-#define COOLDOWN_COMM_CENTRAL 300
-
 //Note: Commented out procs are things I left alone and did not revise. Usually AI-related interactions.
 
 // The communications computer
@@ -23,7 +19,7 @@
 	icon_state = "comm"
 	req_access = list(ACCESS_MARINE_BRIDGE)
 	circuit = "/obj/item/circuitboard/computer/communications"
-	var/prints_intercept = 1
+	var/prints_intercept = TRUE
 	var/authenticated = 0
 	var/list/messagetitle = list()
 	var/list/messagetext = list()
@@ -31,10 +27,11 @@
 	var/aicurrmsg = 0
 	var/state = STATE_DEFAULT
 	var/aistate = STATE_DEFAULT
-	var/cooldown_message = 0 //Based on world.time.
-	var/cooldown_request = 0
-	var/cooldown_central = 0
-	var/tmp_alertlevel = 0
+	var/cooldown_message = FALSE //Based on world.time.
+	var/cooldown_request = FALSE
+	var/cooldown_central = FALSE
+	var/just_called = FALSE
+	var/tmp_alertlevel = SEC_LEVEL_GREEN
 
 	var/status_display_freq = "1435"
 	var/stat_msg1
@@ -43,8 +40,8 @@
 	var/datum/announcement/priority/command/crew_announcement = new
 
 /obj/machinery/computer/communications/New()
-	..()
-	crew_announcement.newscast = 1
+	. = ..()
+	crew_announcement.newscast = TRUE
 	start_processing()
 
 /obj/machinery/computer/communications/process()
@@ -53,25 +50,30 @@
 			updateDialog()
 
 /obj/machinery/computer/communications/Topic(href, href_list)
-	if(..()) return FALSE
+	. = ..()
+	if(.)
+		return FALSE
 
 	usr.set_interaction(src)
 
 	switch(href_list["operation"])
-		if("main") state = STATE_DEFAULT
+		if("main") 
+			state = STATE_DEFAULT
 
 		if("login")
 			var/mob/living/carbon/human/C = usr
 			var/obj/item/card/id/I = C.get_active_hand()
 			if(istype(I))
-				if(check_access(I)) authenticated = 1
+				if(check_access(I)) 
+					authenticated = 1
 				if(ACCESS_MARINE_BRIDGE in I.access)
 					authenticated = 2
 					crew_announcement.announcer = GetNameAndAssignmentFromId(I)
 			else
 				I = C.wear_id
 				if(istype(I))
-					if(check_access(I)) authenticated = 1
+					if(check_access(I)) 
+						authenticated = 1
 					if(ACCESS_MARINE_BRIDGE in I.access)
 						authenticated = 2
 						crew_announcement.announcer = GetNameAndAssignmentFromId(I)
@@ -85,8 +87,10 @@
 			if(istype(I))
 				if(ACCESS_MARINE_COMMANDER in I.access || ACCESS_MARINE_BRIDGE in I.access) //Let heads change the alert level.
 					switch(tmp_alertlevel)
-						if(-INFINITY to SEC_LEVEL_GREEN) tmp_alertlevel = SEC_LEVEL_GREEN //Cannot go below green.
-						if(SEC_LEVEL_BLUE to INFINITY) tmp_alertlevel = SEC_LEVEL_BLUE //Cannot go above blue.
+						if(-INFINITY to SEC_LEVEL_GREEN) 
+							tmp_alertlevel = SEC_LEVEL_GREEN //Cannot go below green.
+						if(SEC_LEVEL_BLUE to INFINITY) 
+							tmp_alertlevel = SEC_LEVEL_BLUE //Cannot go above blue.
 
 					var/old_level = security_level
 					set_security_level(tmp_alertlevel)
@@ -95,8 +99,10 @@
 						log_game("[key_name(usr)] has changed the security level to [get_security_level()].")
 						message_admins("[key_name_admin(usr)] has changed the security level to [get_security_level()].")
 						switch(security_level)
-							if(SEC_LEVEL_GREEN) feedback_inc("alert_comms_green",1)
-							if(SEC_LEVEL_BLUE) feedback_inc("alert_comms_blue",1)
+							if(SEC_LEVEL_GREEN) 
+								feedback_inc("alert_comms_green",1)
+							if(SEC_LEVEL_BLUE) 
+								feedback_inc("alert_comms_blue",1)
 				else
 					to_chat(usr, "<span class='warning'>You are not authorized to do this.</span>")
 				tmp_alertlevel = SEC_LEVEL_GREEN //Reset to green.
@@ -109,8 +115,10 @@
 				if(world.time < cooldown_message + COOLDOWN_COMM_MESSAGE)
 					to_chat(usr, "<span class='warning'>Please allow at least [COOLDOWN_COMM_MESSAGE*0.1] second\s to pass between announcements.</span>")
 					return FALSE
+
 				var/input = input(usr, "Please write a message to announce to the station crew.", "Priority Announcement", "") as message|null
-				if(!input || !(usr in view(1,src)) || authenticated != 2 || world.time < cooldown_message + COOLDOWN_COMM_MESSAGE) return FALSE
+				if(!input || !(usr in view(1,src)) || authenticated != 2 || world.time < cooldown_message + COOLDOWN_COMM_MESSAGE) 
+					return FALSE
 
 				crew_announcement.Announce(input, to_xenos = 0)
 				cooldown_message = world.time
@@ -119,17 +127,17 @@
 			if(!usr.mind || usr.mind.assigned_role != "Commander")
 				to_chat(usr, "<span class='warning'>Only the Commander can award medals.</span>")
 				return
+
 			if(give_medal_award(loc))
 				visible_message("<span class='notice'>[src] prints a medal.</span>")
 
 		if("evacuation_start")
 			if(state == STATE_EVACUATION)
-
 				if(world.time < EVACUATION_TIME_LOCK) //Cannot call it early in the round.
 					to_chat(usr, "<span class='warning'>USCM protocol does not allow immediate evacuation. Please wait another [round((EVACUATION_TIME_LOCK-world.time)/600)] minutes before trying again.</span>")
 					return FALSE
 
-				if(!ticker || !ticker.mode || !ticker.mode.has_called_emergency)
+				if(!ticker || !ticker.mode)
 					to_chat(usr, "<span class='warning'>The [MAIN_SHIP_NAME]'s distress beacon must be activated prior to evacuation taking place.</span>")
 					return FALSE
 
@@ -175,33 +183,25 @@
 
 		if("distress")
 			if(state == STATE_DISTRESS)
-
 				//Comment to test
 				if(world.time < DISTRESS_TIME_LOCK)
 					to_chat(usr, "<span class='warning'>The distress beacon cannot be launched this early in the operation. Please wait another [round((DISTRESS_TIME_LOCK-world.time)/600)] minutes before trying again.</span>")
 					return FALSE
 
-				if(!ticker || !ticker.mode) return FALSE //Not a game mode?
+				if(!ticker?.mode) 
+					return FALSE //Not a game mode?
 
-				if(ticker.mode.has_called_emergency)
-					to_chat(usr, "<span class='warning'>The [MAIN_SHIP_NAME]'s distress beacon is already broadcasting.</span>")
+				if(just_called || ticker.mode.waiting_for_candidates)
+					to_chat(usr, "<span class='warning'>The distress beacon has been just launched.</span>")
 					return FALSE
 
-				if(ticker.mode.distress_cooldown)
+				if(ticker.mode.on_distress_cooldown)
 					to_chat(usr, "<span class='warning'>The distress beacon is currently recalibrating.</span>")
 					return FALSE
 
-				 //Comment block to test
-				if(world.time < cooldown_request + COOLDOWN_COMM_REQUEST)
-					to_chat(usr, "<span class='warning'>The distress beacon has recently broadcast a message. Please wait.</span>")
-					return FALSE
-
-				//Currently only counts aliens, but this will likely need to change with human opponents.
-				//I think this should instead count human losses, so that a distress beacon is available when a certain number of dead pile up.
-				//Comment block to test
 				var/L[] = ticker.mode.count_humans_and_xenos()
 				var/M[] = ticker.mode.count_humans_and_xenos(list(MAIN_SHIP_Z_LEVEL))
-				if((L[2] < round(L[1] * 0.8)) || (M[2] < round(M[1] * 0.5)))
+				if((L[2] < round(L[1] * 0.8)) && (M[2] < round(M[1] * 0.5))) //If there's less humans (weighted) than xenos, humans get home-turf advantage
 					log_game("[key_name(usr)] has attemped to call a distress beacon, but it was denied due to lack of threat.")
 					to_chat(usr, "<span class='warning'>The sensors aren't picking up enough of a threat to warrant a distress beacon.</span>")
 					return FALSE
@@ -213,11 +213,13 @@
 				to_chat(usr, "<span class='notice'>A distress beacon will launch in 60 seconds unless High Command responds otherwise.</span>")
 
 				distress_cancel = FALSE
-				spawn(600) //1 minute in deciseconds
+				just_called = TRUE
+				spawn(1 MINUTE)
 					if(!distress_cancel)
 						ticker.mode.activate_distress()
 						log_game("A distress beacon requested by [key_name_admin(usr)] was automatically sent due to not receiving an answer within 60 seconds.")
 						message_admins("A distress beacon requested by [key_name_admin(usr)] was automatically sent due to not receiving an answer within 60 seconds.", 1)
+					just_called = FALSE
 
 				cooldown_request = world.time
 				return TRUE
@@ -230,9 +232,11 @@
 
 		if("viewmessage")
 			state = STATE_VIEWMESSAGE
-			if (!currmsg)
-				if(href_list["message-num"]) 	currmsg = text2num(href_list["message-num"])
-				else 							state = STATE_MESSAGELIST
+			if(!currmsg)
+				if(href_list["message-num"]) 	
+					currmsg = text2num(href_list["message-num"])
+				else 							
+					state = STATE_MESSAGELIST
 
 		if("delmessage")
 			state = (currmsg) ? STATE_DELMESSAGE : STATE_MESSAGELIST
@@ -244,10 +248,12 @@
 					var/text  = messagetext[currmsg]
 					messagetitle.Remove(title)
 					messagetext.Remove(text)
-					if(currmsg == aicurrmsg) aicurrmsg = 0
+					if(currmsg == aicurrmsg) 
+						aicurrmsg = 0
 					currmsg = 0
 				state = STATE_MESSAGELIST
-			else state = STATE_VIEWMESSAGE
+			else 
+				state = STATE_VIEWMESSAGE
 
 
 		if("status")
@@ -277,7 +283,8 @@
 					to_chat(usr, "<span class='warning'>Arrays recycling.  Please stand by.</span>")
 					return FALSE
 				var/input = stripped_input(usr, "Please choose a message to transmit to USCM.  Please be aware that this process is very expensive, and abuse will lead to termination.  Transmission does not guarantee a response. There is a small delay before you may send another message. Be clear and concise.", "To abort, send an empty message.", "")
-				if(!input || !(usr in view(1,src)) || authenticated != 2 || world.time < cooldown_central + COOLDOWN_COMM_CENTRAL) return FALSE
+				if(!input || !(usr in view(1,src)) || authenticated != 2 || world.time < cooldown_central + COOLDOWN_COMM_CENTRAL) 
+					return FALSE
 
 				Centcomm_announce(input, usr)
 				to_chat(usr, "<span class='notice'>Message transmitted.</span>")
@@ -286,7 +293,8 @@
 
 		if("securitylevel")
 			tmp_alertlevel = text2num( href_list["newalertlevel"] )
-			if(!tmp_alertlevel) tmp_alertlevel = 0
+			if(!tmp_alertlevel) 
+				tmp_alertlevel = 0
 			state = STATE_CONFIRM_LEVEL
 
 		if("changeseclevel")
@@ -303,7 +311,8 @@
 	return attack_hand(user)
 
 /obj/machinery/computer/communications/attack_hand(var/mob/user as mob)
-	if(..()) return FALSE
+	if(..()) 
+		return FALSE
 
 	//Should be refactored later, if there's another ship that can appear during a mode with a comm console.
 	if(!istype(loc.loc, /area/almayer/command/cic)) //Has to be in the CIC. Can also be a generic CIC area to communicate, if wanted.
@@ -492,6 +501,3 @@
 #undef STATE_STATUSDISPLAY
 #undef STATE_ALERT_LEVEL
 #undef STATE_CONFIRM_LEVEL
-#undef COOLDOWN_COMM_MESSAGE
-#undef COOLDOWN_COMM_REQUEST
-#undef COOLDOWN_COMM_CENTRAL

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1191,7 +1191,7 @@ var/global/respawntime = 15
 	set name = "Distress Beacon"
 	set desc = "Call a distress beacon. This should not be done if the shuttle's already been called."
 
-	if(!ticker || !ticker.mode)
+	if(!ticker?.mode)
 		return
 
 	if(!check_rights(R_ADMIN))	

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -743,15 +743,21 @@ var/global/respawntime = 15
 /datum/admins/proc/announce()
 	set category = "Special Verbs"
 	set name = "Announce"
-	set desc="Announce your desires to the world"
-	if(!check_rights(0))	return
+	set desc= "Announce your desires to the world."
 
-	var/message = input("Global message to send:", "Admin Announce", null, null)  as message
-	if(message)
-		if(!check_rights(R_SERVER,0))
-			message = adminscrub(message,500)
-		to_chat(world, "\blue <b>[usr.client.holder.fakekey ? "Administrator" : usr.key] Announces:</b>\n \t [message]")
-		log_admin("Announce: [key_name(usr)] : [message]")
+	if(!check_rights(0))	
+		return
+
+	var/message = input("Global message to send:", "Admin Announce") as message|null
+
+	if(!message)
+		return
+
+	if(!check_rights(R_SERVER,0))
+		message = adminscrub(message,500)
+
+	to_chat(world, "\blue <b>[usr.client.holder.fakekey ? "Administrator" : usr.key] Announces:</b>\n \t [message]")
+	log_admin("Announce: [key_name(usr)] : [message]")
 	feedback_add_details("admin_verb","A") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /datum/admins/proc/toggleooc()
@@ -1185,10 +1191,11 @@ var/global/respawntime = 15
 	set name = "Distress Beacon"
 	set desc = "Call a distress beacon. This should not be done if the shuttle's already been called."
 
-	if (!ticker  || !ticker.mode)
+	if(!ticker || !ticker.mode)
 		return
 
-	if(!check_rights(R_ADMIN))	return
+	if(!check_rights(R_ADMIN))	
+		return
 
 	if(ticker.mode.picked_call)
 		var/confirm = alert(src, "There's already been a distress call sent. Are you sure you want to send another one? This will probably break things.", "Send a distress call?", "Yes", "No")
@@ -1197,8 +1204,8 @@ var/global/respawntime = 15
 		//Reset the distress call
 		ticker.mode.picked_call.members = list()
 		ticker.mode.picked_call.candidates = list()
-		ticker.mode.waiting_for_candidates = 0
-		ticker.mode.has_called_emergency = 0
+		ticker.mode.waiting_for_candidates = FALSE
+		ticker.mode.on_distress_cooldown = FALSE
 		ticker.mode.picked_call = null
 
 	var/list/list_of_calls = list()

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1,5 +1,5 @@
 /datum/admins/Topic(href, href_list)
-	..()
+	. = ..()
 
 	if(usr.client != src.owner || !check_rights(0))
 		log_admin("[key_name(usr)] tried to use the admin panel without authorization.")
@@ -2617,7 +2617,6 @@
 			if((R_ADMIN|R_MOD) & X.holder.rights)
 				to_chat(X, msg)
 
-		//unanswered_distress -= ref_person
 
 	if(href_list["ccdeny"]) // CentComm-deny. The distress call is denied, without any further conditions
 		var/mob/ref_person = locate(href_list["ccdeny"])
@@ -2626,29 +2625,9 @@
 		log_game("[key_name_admin(usr)] has denied a distress beacon, requested by [key_name_admin(ref_person)]")
 		message_admins("[key_name_admin(usr)] has denied a distress beacon, requested by [key_name_admin(ref_person)]", 1)
 
-		//unanswered_distress -= ref_person
-
-	if(href_list["distresscancel"])
-		if(distress_cancel)
-			to_chat(usr, "The distress beacon was already canceled.")
-			return
-		if(ticker.mode.waiting_for_candidates)
-			to_chat(usr, "Too late! The distress beacon was launched.")
-			return
-		log_game("[key_name_admin(usr)] has canceled the distress beacon.")
-		message_admins("[key_name_admin(usr)] has canceled the distress beacon.")
-		distress_cancel = TRUE
-		return
 
 	if(href_list["distress"]) //Distress Beacon, sends a random distress beacon when pressed
-		distress_cancel = FALSE
-		message_admins("[key_name_admin(usr)] has opted to SEND a distress beacon! Launching in 10 seconds... (<A HREF='?_src_=holder;distresscancel=\ref[usr]'>CANCEL</A>)")
-		spawn(100)
-			if(distress_cancel) 
-				return
-			var/mob/ref_person = locate(href_list["distress"])
-			ticker.mode.activate_distress()
-			distress_cancel = TRUE
-			log_game("[key_name_admin(usr)] has sent a randomized distress beacon, requested by [key_name_admin(ref_person)]")
-			message_admins("[key_name_admin(usr)] has sent a randomized distress beacon, requested by [key_name_admin(ref_person)]", 1)
-		//unanswered_distress -= ref_person
+		var/mob/ref_person = locate(href_list["distress"])
+		ticker.mode.activate_distress()
+		log_game("[key_name_admin(usr)] has sent a randomized distress beacon, requested by [key_name_admin(ref_person)]")
+		message_admins("[key_name_admin(usr)] has sent a randomized distress beacon, requested by [key_name_admin(ref_person)]", 1)

--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -45,7 +45,7 @@
 				broadcast_request() //This is the device making the initial event request. It needs to broadcast to other devices
 
 /obj/machinery/keycard_auth/power_change()
-	..()
+	. = ..()
 	if(stat &NOPOWER)
 		icon_state = "auth_off"
 
@@ -82,7 +82,7 @@
 
 
 /obj/machinery/keycard_auth/Topic(href, href_list)
-	..()
+	. = ..()
 	if(busy)
 		to_chat(usr, "This device is busy.")
 		return

--- a/code/modules/security levels/security levels.dm
+++ b/code/modules/security levels/security levels.dm
@@ -23,7 +23,8 @@
 	if(level >= SEC_LEVEL_GREEN && level <= SEC_LEVEL_DELTA && level != security_level)
 		switch(level)
 			if(SEC_LEVEL_GREEN)
-				if(announce) ai_system.Announce("Attention: Security level lowered to GREEN - all clear.", no_sound ? null : 'sound/AI/code_green.ogg')
+				if(announce) 
+					command_announcement.Announce("Attention: Security level lowered to GREEN - all clear.", "Priority Alert", no_sound ? null : 'sound/AI/code_green.ogg')
 				security_level = SEC_LEVEL_GREEN
 				for(var/obj/machinery/firealarm/FA in machines)
 					if(FA.z == MAIN_SHIP_Z_LEVEL)
@@ -34,9 +35,9 @@
 						SD.set_picture("default")
 			if(SEC_LEVEL_BLUE)
 				if(security_level < SEC_LEVEL_BLUE)
-					if(announce) ai_system.Announce("Attention: Security level elevated to BLUE - potentially hostile activity on board.", no_sound ? null : 'sound/AI/code_blue_elevated.ogg')
+					if(announce) command_announcement.Announce("Attention: Security level elevated to BLUE - potentially hostile activity on board.", "Priority Alert", no_sound ? null : 'sound/AI/code_blue_elevated.ogg')
 				else
-					if(announce) ai_system.Announce("Attention: Security level lowered to BLUE - potentially hostile activity on board.", no_sound ? null : 'sound/AI/code_blue_lowered.ogg')
+					if(announce) command_announcement.Announce("Attention: Security level lowered to BLUE - potentially hostile activity on board.", "Priority Alert", no_sound ? null : 'sound/AI/code_blue_lowered.ogg')
 				security_level = SEC_LEVEL_BLUE
 				for(var/obj/machinery/firealarm/FA in machines)
 					if(FA.z == MAIN_SHIP_Z_LEVEL)
@@ -47,9 +48,9 @@
 						SD.set_picture("default")
 			if(SEC_LEVEL_RED)
 				if(security_level < SEC_LEVEL_RED)
-					if(announce) ai_system.Announce("Attention: Security level elevated to RED - there is an immediate threat to the ship.", no_sound ? null : 'sound/AI/code_red_elevated.ogg')
+					if(announce) command_announcement.Announce("Attention: Security level elevated to RED - there is an immediate threat to the ship.", "Priority Alert", no_sound ? null : 'sound/AI/code_red_elevated.ogg')
 				else
-					if(announce) ai_system.Announce("Attention: Security level lowered to RED - there is an immediate threat to the ship.", no_sound ? null : 'sound/AI/code_red_lowered.ogg')
+					if(announce) command_announcement.Announce("Attention: Security level lowered to RED - there is an immediate threat to the ship.", "Priority Alert", no_sound ? null : 'sound/AI/code_red_lowered.ogg')
 					/*
 					var/area/A
 					for(var/obj/machinery/power/apc/O in machines)
@@ -68,7 +69,8 @@
 					if(SD.z == MAIN_SHIP_Z_LEVEL)
 						SD.set_picture("redalert")
 			if(SEC_LEVEL_DELTA)
-				if(announce) ai_system.Announce("Attention! Delta security level reached! " + config.alert_desc_delta)
+				if(announce) 
+					command_announcement.Announce("Attention! Delta security level reached! " + config.alert_desc_delta, "Priority Alert")
 				security_level = SEC_LEVEL_DELTA
 				spawn(0)
 					for(var/obj/machinery/door/poddoor/shutters/almayer/D in machines)
@@ -116,15 +118,3 @@
 			return SEC_LEVEL_RED
 		if("delta")
 			return SEC_LEVEL_DELTA
-
-
-/*DEBUG
-/mob/verb/set_thing0()
-	set_security_level(0)
-/mob/verb/set_thing1()
-	set_security_level(1)
-/mob/verb/set_thing2()
-	set_security_level(2)
-/mob/verb/set_thing3()
-	set_security_level(3)
-*/

--- a/code/modules/security levels/security levels.dm
+++ b/code/modules/security levels/security levels.dm
@@ -35,9 +35,11 @@
 						SD.set_picture("default")
 			if(SEC_LEVEL_BLUE)
 				if(security_level < SEC_LEVEL_BLUE)
-					if(announce) command_announcement.Announce("Attention: Security level elevated to BLUE - potentially hostile activity on board.", "Priority Alert", no_sound ? null : 'sound/AI/code_blue_elevated.ogg')
+					if(announce) 
+						command_announcement.Announce("Attention: Security level elevated to BLUE - potentially hostile activity on board.", "Priority Alert", no_sound ? null : 'sound/AI/code_blue_elevated.ogg')
 				else
-					if(announce) command_announcement.Announce("Attention: Security level lowered to BLUE - potentially hostile activity on board.", "Priority Alert", no_sound ? null : 'sound/AI/code_blue_lowered.ogg')
+					if(announce) 
+						command_announcement.Announce("Attention: Security level lowered to BLUE - potentially hostile activity on board.", "Priority Alert", no_sound ? null : 'sound/AI/code_blue_lowered.ogg')
 				security_level = SEC_LEVEL_BLUE
 				for(var/obj/machinery/firealarm/FA in machines)
 					if(FA.z == MAIN_SHIP_Z_LEVEL)
@@ -48,9 +50,11 @@
 						SD.set_picture("default")
 			if(SEC_LEVEL_RED)
 				if(security_level < SEC_LEVEL_RED)
-					if(announce) command_announcement.Announce("Attention: Security level elevated to RED - there is an immediate threat to the ship.", "Priority Alert", no_sound ? null : 'sound/AI/code_red_elevated.ogg')
+					if(announce) 
+						command_announcement.Announce("Attention: Security level elevated to RED - there is an immediate threat to the ship.", "Priority Alert", no_sound ? null : 'sound/AI/code_red_elevated.ogg')
 				else
-					if(announce) command_announcement.Announce("Attention: Security level lowered to RED - there is an immediate threat to the ship.", "Priority Alert", no_sound ? null : 'sound/AI/code_red_lowered.ogg')
+					if(announce) 
+						command_announcement.Announce("Attention: Security level lowered to RED - there is an immediate threat to the ship.", "Priority Alert", no_sound ? null : 'sound/AI/code_red_lowered.ogg')
 					/*
 					var/area/A
 					for(var/obj/machinery/power/apc/O in machines)


### PR DESCRIPTION
Exported from the previous repo, basically attempts to unfuck distress by enabling marines to call it based on 2 conditions, 1 for the planet and 1 for the ship only. 

Comms console announcements now always use command_announcement instead of the AI one that gets disabled post-crash.

Reworks the rolling for ERT removing hidden discrimination and basically unfucking it as much as possible.

Changes the admin tools slightly to accompany these changes.

Stupid variables have been moved/repurposed/removed.

Defines are now in minutes and seconds instead of just numbers.