### PR TITLE
Tactical Shotgun UGL is now detachable (+minor revolver attachments change)

### DIFF
--- a/code/modules/projectiles/updated_projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/revolvers.dm
@@ -376,9 +376,11 @@
 	attachable_allowed = list(
 						/obj/item/attachable/reddot,
 						/obj/item/attachable/flashlight,
-						/obj/item/attachable/heavy_barrel,
 						/obj/item/attachable/quickfire,
-						/obj/item/attachable/compensator)
+						/obj/item/attachable/heavy_barrel,
+						/obj/item/attachable/compensator,
+						/obj/item/attachable/lasersight
+						)
 
 	flags_gun_features = GUN_CAN_POINTBLANK|GUN_INTERNAL_MAG
 
@@ -428,10 +430,12 @@
 	attachable_allowed = list(
 						/obj/item/attachable/reddot,
 						/obj/item/attachable/flashlight,
+						/obj/item/attachable/quickfire,
 						/obj/item/attachable/extended_barrel,
 						/obj/item/attachable/heavy_barrel,
-						/obj/item/attachable/quickfire,
-						/obj/item/attachable/compensator)
+						/obj/item/attachable/compensator,
+						/obj/item/attachable/lasersight
+						)
 
 /obj/item/weapon/gun/revolver/cmb/New()
 	..()

--- a/code/modules/projectiles/updated_projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/shotguns.dm
@@ -195,23 +195,23 @@ can cause issues with ammo types getting mixed up during the burst.
 	current_mag = /obj/item/ammo_magazine/internal/shotgun/combat
 	attachable_allowed = list(
 						/obj/item/attachable/bayonet,
-						/obj/item/attachable/reddot,
-						/obj/item/attachable/flashlight,
 						/obj/item/attachable/extended_barrel,
 						/obj/item/attachable/compensator,
+						/obj/item/attachable/reddot,
+						/obj/item/attachable/flashlight,
 						/obj/item/attachable/magnetic_harness,
+						/obj/item/attachable/verticalgrip,
+						/obj/item/attachable/angledgrip,
+						/obj/item/attachable/attached_gun/grenade,
+						/obj/item/attachable/attached_gun/flamer,
+						/obj/item/attachable/attached_gun/shotgun,
 						/obj/item/attachable/stock/tactical)
+
+	starting_attachment_types = list(/obj/item/attachable/attached_gun/grenade)
 
 /obj/item/weapon/gun/shotgun/combat/New()
 	..()
-	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 19,"rail_x" = 10, "rail_y" = 21, "under_x" = 14, "under_y" = 16, "stock_x" = 14, "stock_y" = 16)
-	var/obj/item/attachable/attached_gun/grenade/G = new(src)
-	G.flags_attach_features &= ~ATTACH_REMOVABLE
-	G.attach_icon = "" //gun already has a better one
-	G.icon_state = ""
-	G.Attach(src)
-	update_attachable(G.slot)
-	G.icon_state = initial(G.icon_state)
+	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 19,"rail_x" = 10, "rail_y" = 21, "under_x" = 22, "under_y" = 14, "stock_x" = 14, "stock_y" = 16)
 	if(current_mag && current_mag.current_rounds > 0) load_into_chamber()
 
 


### PR DESCRIPTION
#whenyoucodeit
Made tactical shotgun UGL detachable:
-  Modified tactical shotgun sprite because someone thought that drawing different UGL on tactical shotgun (same with sniper rifle scope i believe) and then making actual UGL in code invicible is a good idea. I guess old TS UGL sprite was better, but i have no idea how to implement custom attachment sprite for a single weapon.
-  Fixed missing aligning for tactical shotgun underbarrel attachments, it looks OK.
-  Tactical shotgun still starts with UGL but you can remove/replace it now.
-  Masterkey shotgun, underbarrel grenade launcher, mini-flamer, angled grip, vertical grip are allowed for tactical shotgun.

I got idea about making custom undetachable UGL for tactical shotgun which can hold four nades (like original rifle). This way we could make it worth shit without messing with balance so much, but agian, i have no idea how to implement it.

Also, as a minor change, added laser sight to allowed attachment lists of CMB (marshal) and Mateba revolvers. Because why not?

Any suggestions regarding improvment of code/balance is appreciated.