### PR TITLE
Various Pouches and Belts changes

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -71,7 +71,15 @@
 		"/obj/item/stack/cable_coil",
 		"/obj/item/device/t_scanner",
 		"/obj/item/device/analyzer",
-		"/obj/item/tool/taperoll/engineering")
+		"/obj/item/tool/taperoll/engineering",
+		"/obj/item/clothing/glasses/welding",
+		"/obj/item/clothing/glasses/meson",
+		"/obj/item/clothing/gloves/yellow",
+		"/obj/item/clothing/gloves/marine/alpha/insulated",
+		"/obj/item/clothing/gloves/marine/bravo/insulated",
+		"/obj/item/clothing/gloves/marine/charlie/insulated",
+		"/obj/item/clothing/gloves/marine/delta/insulated"
+		)
 
 
 /obj/item/storage/belt/utility/full/New()
@@ -317,19 +325,25 @@
 
 /obj/item/storage/belt/knifepouch
 	name="\improper M276 pattern knife rig"
-	desc="The M276 is the standard load-bearing equipment of the USCM. It consists of a modular belt with various clips. This version is specially designed with four holsters to store throwing knives. Not commonly issued, but kept in service."
+	desc="The M276 is the standard load-bearing equipment of the USCM. It consists of a modular belt with various clips. This version is specially designed with holsters to store throwing knives, but can fit any combat knife or bayonet as well. Not commonly issued, but kept in service."
 	icon_state="knifebelt"
 	item_state="marine" // aslo temp, maybe somebody update these icons with better ones?
 	w_class = 3
-	storage_slots = 6
-	max_w_class = 1
-	max_storage_space = 6
+	storage_slots = 8
+	max_w_class = 2
+	max_storage_space = 16
+	can_hold=list(
+		"/obj/item/weapon/throwing_knife",
+		"/obj/item/weapon/combat_knife",
+		"/obj/item/attachable/bayonet"
+		)
 
-	can_hold=list("/obj/item/weapon/throwing_knife")
 	New()
 		select_gamemode_skin(type)
 		..()
 		item_state = "marinebelt" //PLACEHOLDER. Override, since it has no unique state.
+		new /obj/item/weapon/throwing_knife(src)
+		new /obj/item/weapon/throwing_knife(src)
 		new /obj/item/weapon/throwing_knife(src)
 		new /obj/item/weapon/throwing_knife(src)
 		new /obj/item/weapon/throwing_knife(src)
@@ -391,7 +405,8 @@
 /obj/item/storage/sparepouch
 	name="\improper G8 general utility pouch"
 	desc="A small, lightweight pouch that can be clipped onto Armat Systems M3 Pattern armor to provide additional storage. Unfortunately, this pouch uses the same securing system as most Armat platform weaponry, and thus only one can be clipped to the M3 Pattern Armor."
-	storage_slots = 3
+	storage_slots = null
+	max_storage_space = 15
 	w_class = 4
 	max_w_class = 3
 	icon = 'icons/obj/clothing/belts.dmi'

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -255,10 +255,11 @@
 	new /obj/item/explosive/grenade/frag (src)
 	new /obj/item/explosive/grenade/frag (src)
 	new /obj/item/explosive/grenade/frag (src)
-
+	new /obj/item/explosive/grenade/frag (src)
 
 /obj/item/storage/pouch/explosive/upp/New()
 	..()
+	new /obj/item/explosive/plastique(src)
 	new /obj/item/explosive/plastique(src)
 	new /obj/item/explosive/plastique(src)
 	new /obj/item/explosive/plastique(src)
@@ -403,7 +404,7 @@
 	new /obj/item/device/motiondetector (src)
 	new /obj/item/device/whistle (src)
 	new /obj/item/device/radio (src)
-	new /obj/item/map/current_map (src)
+	new /obj/item/device/megaphone (src)
 	new /obj/item/device/binoculars/tactical (src)
 
 


### PR DESCRIPTION
#whenyoucodeit
Changes as follow:
-  Toolbelt is now able to carry insulated gloves (including squad ones), meson goggles and welding goggles because it is a thing on other builds and seems like QoL change, why not?
-  Attempt to fix knife rig being worthless shit. It can now store 8 knifes up from 6 and not limited with throwing ones. If you want - you can carry 8 survival knifes or 7 throwing knifes and one bayonet for that CQC moments - no one gonna judge you for that (but it's still shitty choise for belt).
-  G8 pouch recieved significant buff due to it worthless. Previously it was pouch which goes on suit slot but can carry only three small items. Now it's basically a satchel, but for suit storage. Why would i waste my suit storage slot for only three small items? Well, now it's NOT useless and can carry as much as regular satchel. Pretty balanced, i'd say, because carrying it on suit slot makes me lose my magnetic harness advantage, not to mention everyone carry their guns in suit slot and etc.
-  Added one nade and one C4 to respective pre-filled explosives pouches which recieved capacity buff from @Surrealaser.
-  Replaced paper map in field pouch (SL use those) with megaphone because no one uses paper map anyway (why would you, use webmap) and megaphone is actually useful to organize baldies.