### PR TITLE
Makes orders macro-able using the issue-order "order" verb

### DIFF
--- a/code/modules/cm_marines/overwatch.dm
+++ b/code/modules/cm_marines/overwatch.dm
@@ -1015,7 +1015,7 @@
 
 //This is perhaps one of the weirdest places imaginable to put it, but it's a leadership skill, so
 
-/mob/living/carbon/human/verb/issue_order()
+/mob/living/carbon/human/verb/issue_order(which as null|text)
 	set name = "Issue Order"
 	set desc = "Issue an order to nearby humans, using your authority to strengthen their resolve."
 	set category = "IC"
@@ -1032,51 +1032,16 @@
 		to_chat(src, "<span class='warning'>You have recently given an order. Calm down.</span>")
 		return
 
-	var/choice = input(src, "Choose an order") in command_aura_allowed + "help" + "cancel"
-	if(choice == "help")
-		to_chat(src, "<span class='notice'><br>Orders give a buff to nearby soldiers for a short period of time, followed by a cooldown, as follows:<br><B>Move</B> - Increased mobility and chance to dodge projectiles.<br><B>Hold</B> - Increased resistance to pain and combat wounds.<br><B>Focus</B> - Increased gun accuracy and effective range.<br></span>")
-		return
-	if(choice == "cancel") 
-		return
-	command_aura = choice
-	command_aura_cooldown = 45 //45 ticks
-	command_aura_tick = 10 //10 ticks
-	var/message = ""
-	switch(command_aura)
-		if("move")
-			message = pick(";GET MOVING!", ";GO, GO, GO!", ";WE ARE ON THE MOVE!", ";MOVE IT!", ";DOUBLE TIME!")
-			say(message)
-		if("hold")
-			message = pick(";DUCK AND COVER!", ";HOLD THE LINE!", ";HOLD POSITION!", ";STAND YOUR GROUND!", ";STAND AND FIGHT!")
-			say(message)
-		if("focus")
-			message = pick(";FOCUS FIRE!", ";PICK YOUR TARGETS!", ";CENTER MASS!", ";CONTROLLED BURSTS!", ";AIM YOUR SHOTS!")
-			say(message)
-	update_action_buttons()
-
-
-/mob/living/carbon/human/verb/issue_order_macro(which as text)
-	set name = "Issue Order Macro"
-	set desc = "Issue an order to nearby humans, using your authority to strengthen their resolve."
-	set category = "IC"
-	set hidden = TRUE
-
 	if(!which)
-		return
-
-	if(!mind.cm_skills || (mind.cm_skills && mind.cm_skills.leadership < SKILL_LEAD_TRAINED))
-		to_chat(src, "<span class='warning'>You are not competent enough in leadership to issue an order.</span>")
-		return
-
-	if(stat)
-		to_chat(src, "<span class='warning'>You cannot give an order in your current state.</span>")
-		return
-
-	if(command_aura_cooldown > 0)
-		to_chat(src, "<span class='warning'>You have recently given an order. Calm down.</span>")
-		return
-
-	command_aura = which
+		var/choice = input(src, "Choose an order") in command_aura_allowed + "help" + "cancel"
+		if(choice == "help")
+			to_chat(src, "<span class='notice'><br>Orders give a buff to nearby soldiers for a short period of time, followed by a cooldown, as follows:<br><B>Move</B> - Increased mobility and chance to dodge projectiles.<br><B>Hold</B> - Increased resistance to pain and combat wounds.<br><B>Focus</B> - Increased gun accuracy and effective range.<br></span>")
+			return
+		if(choice == "cancel") 
+			return
+		command_aura = choice
+	else
+		command_aura = which
 	command_aura_cooldown = 45 //45 ticks
 	command_aura_tick = 10 //10 ticks
 	var/message = ""
@@ -1091,6 +1056,7 @@
 			message = pick(";FOCUS FIRE!", ";PICK YOUR TARGETS!", ";CENTER MASS!", ";CONTROLLED BURSTS!", ";AIM YOUR SHOTS!")
 			say(message)
 	update_action_buttons()
+
 
 /datum/action/skill/issue_order
 	name = "Issue Order"

--- a/code/modules/cm_marines/overwatch.dm
+++ b/code/modules/cm_marines/overwatch.dm
@@ -1016,7 +1016,6 @@
 //This is perhaps one of the weirdest places imaginable to put it, but it's a leadership skill, so
 
 /mob/living/carbon/human/verb/issue_order()
-
 	set name = "Issue Order"
 	set desc = "Issue an order to nearby humans, using your authority to strengthen their resolve."
 	set category = "IC"
@@ -1037,8 +1036,47 @@
 	if(choice == "help")
 		to_chat(src, "<span class='notice'><br>Orders give a buff to nearby soldiers for a short period of time, followed by a cooldown, as follows:<br><B>Move</B> - Increased mobility and chance to dodge projectiles.<br><B>Hold</B> - Increased resistance to pain and combat wounds.<br><B>Focus</B> - Increased gun accuracy and effective range.<br></span>")
 		return
-	if(choice == "cancel") return
+	if(choice == "cancel") 
+		return
 	command_aura = choice
+	command_aura_cooldown = 45 //45 ticks
+	command_aura_tick = 10 //10 ticks
+	var/message = ""
+	switch(command_aura)
+		if("move")
+			message = pick(";GET MOVING!", ";GO, GO, GO!", ";WE ARE ON THE MOVE!", ";MOVE IT!", ";DOUBLE TIME!")
+			say(message)
+		if("hold")
+			message = pick(";DUCK AND COVER!", ";HOLD THE LINE!", ";HOLD POSITION!", ";STAND YOUR GROUND!", ";STAND AND FIGHT!")
+			say(message)
+		if("focus")
+			message = pick(";FOCUS FIRE!", ";PICK YOUR TARGETS!", ";CENTER MASS!", ";CONTROLLED BURSTS!", ";AIM YOUR SHOTS!")
+			say(message)
+	update_action_buttons()
+
+
+/mob/living/carbon/human/verb/issue_order_macro(which as text)
+	set name = "Issue Order Macro"
+	set desc = "Issue an order to nearby humans, using your authority to strengthen their resolve."
+	set category = "IC"
+	set hidden = TRUE
+
+	if(!which)
+		return
+
+	if(!mind.cm_skills || (mind.cm_skills && mind.cm_skills.leadership < SKILL_LEAD_TRAINED))
+		to_chat(src, "<span class='warning'>You are not competent enough in leadership to issue an order.</span>")
+		return
+
+	if(stat)
+		to_chat(src, "<span class='warning'>You cannot give an order in your current state.</span>")
+		return
+
+	if(command_aura_cooldown > 0)
+		to_chat(src, "<span class='warning'>You have recently given an order. Calm down.</span>")
+		return
+
+	command_aura = which
 	command_aura_cooldown = 45 //45 ticks
 	command_aura_tick = 10 //10 ticks
 	var/message = ""


### PR DESCRIPTION
Alright now it's not hacky anymore, yay!

Usage: issue-order "order name" which is optional, if you don't provide any you get the regular popup dialog.