### PR TITLE
Mortar restriction for synth

### DIFF
--- a/code/modules/cm_marines/equipment/mortars.dm
+++ b/code/modules/cm_marines/equipment/mortars.dm
@@ -118,6 +118,9 @@
 			"<span class='notice'>You fumble around figuring out how to fire [src].</span>")
 			var/fumbling_time = 30 * ( SKILL_ENGINEER_ENGI - user.mind.cm_skills.engineer )
 			if(!do_after(user, fumbling_time, TRUE, 5, BUSY_ICON_BUILD)) return
+		if(isSynth(user) && !config.allow_synthetic_gun_use)
+			to_chat(user, "<span class='warning'>Your programming restricts operating heavy weaponry.</span>")
+			return
 		if(busy)
 			to_chat(user, "<span class='warning'>Someone else is currently using [src].</span>")
 			return


### PR DESCRIPTION
Restricted Synths from using mortar. Toggleable via Toggle Synthetic Gun Use in Server tab.
[Example](https://i.imgur.com/h9RlK0W.gifv)