### PR TITLE
Makes notes more consistent.

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -222,16 +222,19 @@ var/global/respawntime = 15
 /datum/admins/proc/player_notes_list()
 	set category = "Admin"
 	set name = "Player Notes List"
-	if (!istype(src,/datum/admins))
+
+	if(!istype(src,/datum/admins))
 		src = usr.client.holder
-	if (!istype(src,/datum/admins))
+
+	if(!istype(src,/datum/admins))
 		to_chat(usr, "Error: you are not an admin!")
 		return
+
 	PlayerNotesPage(1)
 
 /datum/admins/proc/PlayerNotesPage(page)
 	var/dat = "<B>Player notes</B><HR>"
-	var/savefile/S=new("data/player_notes.sav")
+	var/savefile/S = new("data/player_notes.sav")
 	var/list/note_keys
 	S >> note_keys
 	if(!note_keys)
@@ -280,13 +283,18 @@ var/global/respawntime = 15
 /datum/admins/proc/player_notes_show(var/key as text)
 	set category = "Admin"
 	set name = "Player Notes Show"
-	if (!istype(src,/datum/admins))
+
+	if(!istype(src, /datum/admins))
 		src = usr.client.holder
-	if (!istype(src,/datum/admins))
+
+	if(!istype(src, /datum/admins))
 		to_chat(usr, "Error: you are not an admin!")
 		return
+
 	var/dat = "<html><head><title>Info on [key]</title></head>"
 	dat += "<body>"
+
+	key = ckey(key)
 
 	var/savefile/info = new("data/player_saves/[copytext(key, 1, 2)]/[key]/info.sav")
 	var/list/infos

--- a/code/modules/admin/player_notes.dm
+++ b/code/modules/admin/player_notes.dm
@@ -89,6 +89,8 @@ datum/admins/proc/notes_gethtml(var/ckey)
 	if (!key || !note)
 		return
 
+	key = ckey(key)
+
 	//Loading list of notes for this key
 	var/savefile/info = new("data/player_saves/[copytext(key, 1, 2)]/[key]/info.sav")
 	var/list/infos
@@ -116,8 +118,8 @@ datum/admins/proc/notes_gethtml(var/ckey)
 		P.author = usr.key
 		P.rank = usr.client.holder.rank
 	else
-		P.author = "Adminbot"
-		P.rank = "Friendly Robot"
+		P.author = "TGMC Adminbot"
+		P.rank = "Silicon"
 	P.content = note
 	P.timestamp = "[hourminute_string] [copytext(full_date,1,day_loc)][day_string][copytext(full_date,day_loc+2)]"
 	P.hidden = FALSE
@@ -143,6 +145,7 @@ datum/admins/proc/notes_gethtml(var/ckey)
 
 
 /proc/notes_del(var/key, var/index)
+	key = ckey(key)
 	var/savefile/info = new("data/player_saves/[copytext(key, 1, 2)]/[key]/info.sav")
 	var/list/infos
 	info >> infos
@@ -159,6 +162,7 @@ datum/admins/proc/notes_gethtml(var/ckey)
 	qdel(info)
 
 /proc/notes_hide(var/key, var/index)
+	key = ckey(key)
 	var/savefile/info = new("data/player_saves/[copytext(key, 1, 2)]/[key]/info.sav")
 	var/list/infos
 	info >> infos
@@ -176,6 +180,7 @@ datum/admins/proc/notes_gethtml(var/ckey)
 	qdel(info)
 
 /proc/notes_unhide(var/key, var/index)
+	key = ckey(key)
 	var/savefile/info = new("data/player_saves/[copytext(key, 1, 2)]/[key]/info.sav")
 	var/list/infos
 	info >> infos
@@ -193,6 +198,7 @@ datum/admins/proc/notes_gethtml(var/ckey)
 	qdel(info)
 
 /proc/player_notes_show_irc(var/key as text)
+	key = ckey(key)
 	var/dat = "          Info on [key]%0D%0A"
 	var/savefile/info = new("data/player_saves/[copytext(key, 1, 2)]/[key]/info.sav")
 	var/list/infos

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2459,7 +2459,7 @@
 		if(!ckey)
 			var/mob/M = locate(href_list["mob"])
 			if(ismob(M))
-				ckey = M.ckey
+				ckey = M.key
 
 		switch(href_list["notes"])
 			if("show")

--- a/code/modules/mob/mob_verbs.dm
+++ b/code/modules/mob/mob_verbs.dm
@@ -199,10 +199,12 @@
 	set name = "View Admin Remarks"
 	set category = "OOC"
 
-	var/key = usr.ckey
+	var/key = usr.key
 
 	var/dat = "<html><head><title>Info on [key]</title></head>"
 	dat += "<body>"
+
+	key = ckey(key)
 
 	var/savefile/info = new("data/player_saves/[copytext(key, 1, 2)]/[key]/info.sav")
 	var/list/infos


### PR DESCRIPTION
:cl: LaKiller8
admin: Notes now correctly use the canonical form of the user's key, most notably in the Player Notes Show and OOC > View Admin Remarks. Renamed Adminbot to TGMC Adminbot.
/:cl: