### PR TITLE
renames areas

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -131,7 +131,7 @@ var/list/ghostteleportlocs = list()
 	lighting_use_dynamic = 0
 
 /area/shuttle/arrival
-	name = "\improper abandoned  Arrival Shuttle"
+	name = "\improper Abandoned Arrival Shuttle"
 
 /area/shuttle/arrival/pre_game
 	icon_state = "shuttle2"
@@ -140,19 +140,19 @@ var/list/ghostteleportlocs = list()
 	icon_state = "shuttle"
 
 /area/shuttle/escape
-	name = "\improper abandoned  Emergency Shuttle"
+	name = "\improper Abandoned Emergency Shuttle"
 	music = "music/escape.ogg"
 
 /area/shuttle/escape/station
-	name = "\improper abandoned  Emergency Shuttle Station"
+	name = "\improper Abandoned Emergency Shuttle Station"
 	icon_state = "shuttle2"
 
 /area/shuttle/escape/centcom
-	name = "\improper abandoned  Emergency Shuttle Centcom"
+	name = "\improper Abandoned Emergency Shuttle Centcom"
 	icon_state = "shuttle"
 
 /area/shuttle/escape/transit // the area to pass through for 3 minute transit
-	name = "\improper abandoned  Emergency Shuttle Transit"
+	name = "\improper Abandoned Emergency Shuttle Transit"
 	icon_state = "shuttle"
 
 /area/shuttle/escape_pod1
@@ -219,22 +219,22 @@ var/list/ghostteleportlocs = list()
 
 /area/shuttle/transport1/centcom
 	icon_state = "shuttle"
-	name = "\improper abandoned  Transport Shuttle Centcom"
+	name = "\improper Abandoned Transport Shuttle Centcom"
 
 /area/shuttle/transport1/station
 	icon_state = "shuttle"
-	name = "\improper abandoned  Transport Shuttle"
+	name = "\improper Abandoned Transport Shuttle"
 /*
 /area/shuttle/alien/base
 	icon_state = "shuttle"
-	name = "\improper abandoned  Alien Shuttle Base"
+	name = "\improper Abandoned Alien Shuttle Base"
 	requires_power = 1
 	luminosity = 0
 	lighting_use_dynamic = 1
 
 /area/shuttle/alien/mine
 	icon_state = "shuttle"
-	name = "\improper abandoned  Alien Shuttle Mine"
+	name = "\improper Abandoned Alien Shuttle Mine"
 	requires_power = 1
 	luminosity = 0
 	lighting_use_dynamic = 1
@@ -242,7 +242,7 @@ var/list/ghostteleportlocs = list()
 
 
 /area/shuttle/prison/
-	name = "\improper abandoned  Prison Shuttle"
+	name = "\improper Abandoned Prison Shuttle"
 
 /area/shuttle/prison/station
 	icon_state = "shuttle"
@@ -251,59 +251,59 @@ var/list/ghostteleportlocs = list()
 	icon_state = "shuttle2"
 
 /area/shuttle/specops/centcom
-	name = "\improper abandoned  Special Ops Shuttle"
+	name = "\improper Abandoned Special Ops Shuttle"
 	icon_state = "shuttlered"
 
 /area/shuttle/specops/station
-	name = "\improper abandoned  Special Ops Shuttle"
+	name = "\improper Abandoned Special Ops Shuttle"
 	icon_state = "shuttlered2"
 
 /area/shuttle/syndicate_elite/mothership
-	name = "\improper abandoned  Syndicate Elite Shuttle"
+	name = "\improper Abandoned Syndicate Elite Shuttle"
 	icon_state = "shuttlered"
 
 /area/shuttle/syndicate_elite/station
-	name = "\improper abandoned  Syndicate Elite Shuttle"
+	name = "\improper Abandoned Syndicate Elite Shuttle"
 	icon_state = "shuttlered2"
 
 /area/shuttle/administration/centcom
-	name = "\improper abandoned  Administration Shuttle Centcom"
+	name = "\improper Abandoned Administration Shuttle Centcom"
 	icon_state = "shuttlered"
 
 /area/shuttle/administration/station
-	name = "\improper abandoned  Administration Shuttle"
+	name = "\improper Abandoned Administration Shuttle"
 	icon_state = "shuttlered2"
 
 /area/shuttle/thunderdome
 	name = "honk"
 
 /area/shuttle/thunderdome/grnshuttle
-	name = "\improper abandoned  Thunderdome GRN Shuttle"
+	name = "\improper Abandoned Thunderdome GRN Shuttle"
 	icon_state = "green"
 
 /area/shuttle/thunderdome/grnshuttle/dome
-	name = "\improper abandoned  GRN Shuttle"
+	name = "\improper Abandoned GRN Shuttle"
 	icon_state = "shuttlegrn"
 
 /area/shuttle/thunderdome/grnshuttle/station
-	name = "\improper abandoned  GRN Station"
+	name = "\improper Abandoned GRN Station"
 	icon_state = "shuttlegrn2"
 
 /area/shuttle/thunderdome/redshuttle
-	name = "\improper abandoned  Thunderdome RED Shuttle"
+	name = "\improper Abandoned Thunderdome RED Shuttle"
 	icon_state = "red"
 
 /area/shuttle/thunderdome/redshuttle/dome
-	name = "\improper abandoned  RED Shuttle"
+	name = "\improper Abandoned RED Shuttle"
 	icon_state = "shuttlered"
 
 /area/shuttle/thunderdome/redshuttle/station
-	name = "\improper abandoned  RED Station"
+	name = "\improper Abandoned RED Station"
 	icon_state = "shuttlered2"
 // === Trying to remove these areas:
 /*
 /area/shuttle/research
-	name = "\improper abandoned  Research Shuttle"
+	name = "\improper Abandoned Research Shuttle"
 	music = "music/escape.ogg"
 
 /area/shuttle/research/station
@@ -313,7 +313,7 @@ var/list/ghostteleportlocs = list()
 	icon_state = "shuttle"
 */
 /area/shuttle/vox/station
-	name = "\improper abandoned  Vox Skipjack"
+	name = "\improper Abandoned Vox Skipjack"
 	icon_state = "yellow"
 	requires_power = 0
 
@@ -332,7 +332,7 @@ var/list/ghostteleportlocs = list()
 // === end remove
 /*
 /area/alien
-	name = "\improper abandoned  Alien base"
+	name = "\improper Abandoned Alien base"
 	icon_state = "yellow"
 	requires_power = 0
 */
@@ -371,7 +371,7 @@ var/list/ghostteleportlocs = list()
 	name = "Creed's Office"
 */
 /area/centcom/holding
-	name = "\improper abandoned  Holding Facility"
+	name = "\improper Abandoned Holding Facility"
 
 /area/centcom/solitary
 	name = "Solitary Confinement"
@@ -380,33 +380,33 @@ var/list/ghostteleportlocs = list()
 //SYNDICATES
 
 /area/syndicate_mothership
-	name = "\improper abandoned  Syndicate Base"
+	name = "\improper Abandoned Syndicate Base"
 	icon_state = "syndie-ship"
 	requires_power = 0
 	unlimited_power = 1
 
 /area/syndicate_mothership/control
-	name = "\improper abandoned  Syndicate Control Room"
+	name = "\improper Abandoned Syndicate Control Room"
 	icon_state = "syndie-control"
 
 /area/syndicate_mothership/elite_squad
-	name = "\improper abandoned  Syndicate Elite Squad"
+	name = "\improper Abandoned Syndicate Elite Squad"
 	icon_state = "syndie-elite"
 
 //EXTRA
 
 /area/asteroid					// -- TLE
-	name = "\improper abandoned  Asteroid"
+	name = "\improper Abandoned Asteroid"
 	icon_state = "asteroid"
 	requires_power = 0
 
 /area/asteroid/cave				// -- TLE
-	name = "\improper abandoned  Asteroid - Underground"
+	name = "\improper Abandoned Asteroid - Underground"
 	icon_state = "cave"
 	requires_power = 0
 
 /area/asteroid/artifactroom
-	name = "\improper abandoned  Asteroid - Artifact"
+	name = "\improper Abandoned Asteroid - Artifact"
 	icon_state = "cave"
 
 
@@ -424,29 +424,29 @@ var/list/ghostteleportlocs = list()
 
 /*
 /area/planet/clown
-	name = "\improper abandoned  Clown Planet"
+	name = "\improper Abandoned Clown Planet"
 	icon_state = "honk"
 	requires_power = 0
 */
 /area/tdome
-	name = "\improper abandoned  Thunderdome"
+	name = "\improper Abandoned Thunderdome"
 	icon_state = "thunder"
 	requires_power = 0
 
 /area/tdome/tdome1
-	name = "\improper abandoned  Thunderdome (Team 1)"
+	name = "\improper Abandoned Thunderdome (Team 1)"
 	icon_state = "green"
 
 /area/tdome/tdome2
-	name = "\improper abandoned  Thunderdome (Team 2)"
+	name = "\improper Abandoned Thunderdome (Team 2)"
 	icon_state = "yellow"
 
 /area/tdome/tdomeadmin
-	name = "\improper abandoned  Thunderdome (Admin.)"
+	name = "\improper Abandoned Thunderdome (Admin.)"
 	icon_state = "purple"
 
 /area/tdome/tdomeobserve
-	name = "\improper abandoned  Thunderdome (Observer.)"
+	name = "\improper Abandoned Thunderdome (Observer.)"
 	icon_state = "purple"
 
 
@@ -460,152 +460,152 @@ var/list/ghostteleportlocs = list()
 
 //names are used
 /area/syndicate_station
-	name = "\improper abandoned  Syndicate Station"
+	name = "\improper Abandoned Syndicate Station"
 	icon_state = "yellow"
 	requires_power = 0
 	unlimited_power = 1
 
 /area/syndicate_station/start
-	name = "\improper abandoned  Syndicate Forward Operating Base"
+	name = "\improper Abandoned Syndicate Forward Operating Base"
 	icon_state = "yellow"
 
 /area/syndicate_station/southwest
-	name = "\improper abandoned  south-west of SS13"
+	name = "\improper Abandoned south-west of SS13"
 	icon_state = "southwest"
 
 /area/syndicate_station/northwest
-	name = "\improper abandoned  north-west of SS13"
+	name = "\improper Abandoned north-west of SS13"
 	icon_state = "northwest"
 
 /area/syndicate_station/northeast
-	name = "\improper abandoned  north-east of SS13"
+	name = "\improper Abandoned north-east of SS13"
 	icon_state = "northeast"
 
 /area/syndicate_station/southeast
-	name = "\improper abandoned  south-east of SS13"
+	name = "\improper Abandoned south-east of SS13"
 	icon_state = "southeast"
 
 /area/syndicate_station/north
-	name = "\improper abandoned  north of SS13"
+	name = "\improper Abandoned north of SS13"
 	icon_state = "north"
 
 /area/syndicate_station/south
-	name = "\improper abandoned  south of SS13"
+	name = "\improper Abandoned south of SS13"
 	icon_state = "south"
 
 /area/syndicate_station/commssat
-	name = "\improper abandoned  south of the communication satellite"
+	name = "\improper Abandoned south of the communication satellite"
 	icon_state = "south"
 
 /area/syndicate_station/mining
-	name = "\improper abandoned  north east of the mining asteroid"
+	name = "\improper Abandoned north east of the mining asteroid"
 	icon_state = "north"
 
 /area/syndicate_station/transit
-	name = "\improper abandoned  hyperspace"
+	name = "\improper Abandoned hyperspace"
 	icon_state = "shuttle"
 
 /area/wizard_station
-	name = "\improper abandoned  Wizard's Den"
+	name = "\improper Abandoned Wizard's Den"
 	icon_state = "yellow"
 	requires_power = 0
 
 /area/vox_station/transit
-	name = "\improper abandoned  hyperspace"
+	name = "\improper Abandoned hyperspace"
 	icon_state = "shuttle"
 	requires_power = 0
 
 /area/vox_station/southwest_solars
-	name = "\improper abandoned  aft port solars"
+	name = "\improper Abandoned aft port solars"
 	icon_state = "southwest"
 	requires_power = 0
 
 /area/vox_station/northwest_solars
-	name = "\improper abandoned  fore port solars"
+	name = "\improper Abandoned fore port solars"
 	icon_state = "northwest"
 	requires_power = 0
 
 /area/vox_station/northeast_solars
-	name = "\improper abandoned  fore starboard solars"
+	name = "\improper Abandoned fore starboard solars"
 	icon_state = "northeast"
 	requires_power = 0
 
 /area/vox_station/southeast_solars
-	name = "\improper abandoned  aft starboard solars"
+	name = "\improper Abandoned aft starboard solars"
 	icon_state = "southeast"
 	requires_power = 0
 
 /area/vox_station/mining
-	name = "\improper abandoned  nearby mining asteroid"
+	name = "\improper Abandoned nearby mining asteroid"
 	icon_state = "north"
 	requires_power = 0
 
 //PRISON
 /*
 /area/prison
-	name = "\improper abandoned  Prison Station"
+	name = "\improper Abandoned Prison Station"
 	icon_state = "brig"
 
 /area/prison/arrival_airlock
-	name = "\improper abandoned  Prison Station Airlock"
+	name = "\improper Abandoned Prison Station Airlock"
 	icon_state = "green"
 	requires_power = 0
 
 /area/prison/control
-	name = "\improper abandoned  Prison Security Checkpoint"
+	name = "\improper Abandoned Prison Security Checkpoint"
 	icon_state = "security"
 
 /area/prison/crew_quarters
-	name = "\improper abandoned  Prison Security Quarters"
+	name = "\improper Abandoned Prison Security Quarters"
 	icon_state = "security"
 
 /area/prison/rec_room
-	name = "\improper abandoned  Prison Rec Room"
+	name = "\improper Abandoned Prison Rec Room"
 	icon_state = "green"
 
 /area/prison/closet
-	name = "\improper abandoned  Prison Supply Closet"
+	name = "\improper Abandoned Prison Supply Closet"
 	icon_state = "dk_yellow"
 
 /area/prison/hallway/fore
-	name = "\improper abandoned  Prison Fore Hallway"
+	name = "\improper Abandoned Prison Fore Hallway"
 	icon_state = "yellow"
 
 /area/prison/hallway/aft
-	name = "\improper abandoned  Prison Aft Hallway"
+	name = "\improper Abandoned Prison Aft Hallway"
 	icon_state = "yellow"
 
 /area/prison/hallway/port
-	name = "\improper abandoned  Prison Port Hallway"
+	name = "\improper Abandoned Prison Port Hallway"
 	icon_state = "yellow"
 
 /area/prison/hallway/starboard
-	name = "\improper abandoned  Prison Starboard Hallway"
+	name = "\improper Abandoned Prison Starboard Hallway"
 	icon_state = "yellow"
 
 /area/prison/morgue
-	name = "\improper abandoned  Prison Morgue"
+	name = "\improper Abandoned Prison Morgue"
 	icon_state = "morgue"
 
 /area/prison/medical_research
-	name = "\improper abandoned  Prison Genetic Research"
+	name = "\improper Abandoned Prison Genetic Research"
 	icon_state = "medresearch"
 
 /area/prison/medical
-	name = "\improper abandoned  Prison Medbay"
+	name = "\improper Abandoned Prison Medbay"
 	icon_state = "medbay"
 
 /area/prison/solar
-	name = "\improper abandoned  Prison Solar Array"
+	name = "\improper Abandoned Prison Solar Array"
 	icon_state = "storage"
 	requires_power = 0
 
 /area/prison/podbay
-	name = "\improper abandoned  Prison Podbay"
+	name = "\improper Abandoned Prison Podbay"
 	icon_state = "dk_yellow"
 
 /area/prison/solar_control
-	name = "\improper abandoned  Prison Solar Array Control"
+	name = "\improper Abandoned Prison Solar Array Control"
 	icon_state = "dk_yellow"
 
 /area/prison/solitary
@@ -713,7 +713,7 @@ var/list/ghostteleportlocs = list()
 	icon_state = "maint_engineering"
 
 /area/maintenance/evahallway
-	name = "\improper abandoned  EVA Maintenance"
+	name = "\improper Abandoned EVA Maintenance"
 	icon_state = "maint_eva"
 
 /area/maintenance/dormitory
@@ -721,7 +721,7 @@ var/list/ghostteleportlocs = list()
 	icon_state = "maint_dormitory"
 
 /area/maintenance/incinerator
-	name = "\improper abandoned  Incinerator"
+	name = "\improper Abandoned Incinerator"
 	icon_state = "disposal"
 
 /area/maintenance/locker
@@ -787,191 +787,191 @@ var/list/ghostteleportlocs = list()
 //Hallway
 
 /area/hallway/primary/fore
-	name = "\improper abandoned  Fore Primary Hallway"
+	name = "\improper Abandoned Fore Primary Hallway"
 	icon_state = "hallF"
 
 /area/hallway/primary/starboard
-	name = "\improper abandoned  Starboard Primary Hallway"
+	name = "\improper Abandoned Starboard Primary Hallway"
 	icon_state = "hallS"
 
 /area/hallway/primary/aft
-	name = "\improper abandoned  Aft Primary Hallway"
+	name = "\improper Abandoned Aft Primary Hallway"
 	icon_state = "hallA"
 
 /area/hallway/primary/port
-	name = "\improper abandoned  Port Primary Hallway"
+	name = "\improper Abandoned Port Primary Hallway"
 	icon_state = "hallP"
 
 /area/hallway/primary/central_one
-	name = "\improper abandoned  Central Primary Hallway"
+	name = "\improper Abandoned Central Primary Hallway"
 	icon_state = "hallC1"
 	ambience = list('sound/ambience/signal.ogg','sound/ambience/ambigen10.ogg','sound/ambience/ambigen11.ogg')
 
 /area/hallway/primary/central_two
-	name = "\improper abandoned  Central Primary Hallway"
+	name = "\improper Abandoned Central Primary Hallway"
 	icon_state = "hallC2"
 
 /area/hallway/primary/central_three
-	name = "\improper abandoned  Central Primary Hallway"
+	name = "\improper Abandoned Central Primary Hallway"
 	icon_state = "hallC3"
 
 /area/hallway/secondary/exit
-	name = "\improper abandoned  Escape Shuttle Hallway"
+	name = "\improper Abandoned Escape Shuttle Hallway"
 	icon_state = "escape"
 
 /area/hallway/secondary/construction
-	name = "\improper abandoned  Construction Area"
+	name = "\improper Abandoned Construction Area"
 	icon_state = "construction"
 
 /area/hallway/secondary/entry
-	name = "\improper abandoned  Arrival Shuttle Hallway"
+	name = "\improper Abandoned Arrival Shuttle Hallway"
 	icon_state = "entry"
 
 //Command
 
 /area/bridge
-	name = "\improper abandoned  Bridge"
+	name = "\improper Abandoned Bridge"
 	icon_state = "bridge"
 	music = "signal"
 
 /area/bridge/meeting_room
-	name = "\improper abandoned  Heads of Staff Meeting Room"
+	name = "\improper Abandoned Heads of Staff Meeting Room"
 	icon_state = "bridge"
 	music = null
 
 /area/crew_quarters/captain
-	name = "\improper abandoned  Captain's Office"
+	name = "\improper Abandoned Captain's Office"
 	icon_state = "captain"
 
 /area/crew_quarters/heads/hop
-	name = "\improper abandoned  Head of Personnel's Office"
+	name = "\improper Abandoned Head of Personnel's Office"
 	icon_state = "head_quarters"
 
 /area/crew_quarters/heads/hor
-	name = "\improper abandoned  Research Director's Office"
+	name = "\improper Abandoned Research Director's Office"
 	icon_state = "head_quarters"
 
 /area/crew_quarters/heads/chief
-	name = "\improper abandoned  Chief Engineer's Office"
+	name = "\improper Abandoned Chief Engineer's Office"
 	icon_state = "head_quarters"
 
 /area/crew_quarters/heads/hos
-	name = "\improper abandoned  Head of Security's Office"
+	name = "\improper Abandoned Head of Security's Office"
 	icon_state = "head_quarters"
 
 /area/crew_quarters/heads/cmo
-	name = "\improper abandoned  Chief Medical Officer's Office"
+	name = "\improper Abandoned Chief Medical Officer's Office"
 	icon_state = "head_quarters"
 
 /area/crew_quarters/courtroom
-	name = "\improper abandoned  Courtroom"
+	name = "\improper Abandoned Courtroom"
 	icon_state = "courtroom"
 
 /area/mint
-	name = "\improper abandoned  Mint"
+	name = "\improper Abandoned Mint"
 	icon_state = "green"
 
 /area/comms
-	name = "\improper abandoned  Communications Relay"
+	name = "\improper Abandoned Communications Relay"
 	icon_state = "tcomsatcham"
 
 /area/server
-	name = "\improper abandoned  Messaging Server Room"
+	name = "\improper Abandoned Messaging Server Room"
 	icon_state = "server"
 
 //Crew
 
 /area/crew_quarters
-	name = "\improper abandoned  Dormitories"
+	name = "\improper Abandoned Dormitories"
 	icon_state = "Sleep"
 
 /area/crew_quarters/toilet
-	name = "\improper abandoned  Dormitory Toilets"
+	name = "\improper Abandoned Dormitory Toilets"
 	icon_state = "toilet"
 
 /area/crew_quarters/sleep
-	name = "\improper abandoned  Dormitories"
+	name = "\improper Abandoned Dormitories"
 	icon_state = "Sleep"
 
 /area/crew_quarters/sleep/engi
-	name = "\improper abandoned  Engineering Dormitories"
+	name = "\improper Abandoned Engineering Dormitories"
 	icon_state = "Sleep"
 
 /area/crew_quarters/sleep/engi_wash
-	name = "\improper abandoned  Engineering Washroom"
+	name = "\improper Abandoned Engineering Washroom"
 	icon_state = "toilet"
 
 /area/crew_quarters/sleep/sec
-	name = "\improper abandoned  Security Dormitories"
+	name = "\improper Abandoned Security Dormitories"
 	icon_state = "Sleep"
 
 /area/crew_quarters/sleep/bedrooms
-	name = "\improper abandoned  Dormitory Bedroom"
+	name = "\improper Abandoned Dormitory Bedroom"
 	icon_state = "Sleep"
 
 /area/crew_quarters/sleep/cryo
-	name = "\improper abandoned  Cryogenic Storage"
+	name = "\improper Abandoned Cryogenic Storage"
 	icon_state = "Sleep"
 
 /area/crew_quarters/sleep_male
-	name = "\improper abandoned  Male Dorm"
+	name = "\improper Abandoned Male Dorm"
 	icon_state = "Sleep"
 /*
 /area/crew_quarters/sleep_male/toilet_male
-	name = "\improper abandoned  Male Toilets"
+	name = "\improper Abandoned Male Toilets"
 	icon_state = "toilet"
 
 /area/crew_quarters/sleep_female
-	name = "\improper abandoned  Female Dorm"
+	name = "\improper Abandoned Female Dorm"
 	icon_state = "Sleep"
 
 /area/crew_quarters/sleep_female/toilet_female
-	name = "\improper abandoned  Female Toilets"
+	name = "\improper Abandoned Female Toilets"
 	icon_state = "toilet"
 */
 /area/crew_quarters/locker
-	name = "\improper abandoned  Locker Room"
+	name = "\improper Abandoned Locker Room"
 	icon_state = "locker"
 
 /area/crew_quarters/locker/locker_toilet
-	name = "\improper abandoned  Locker Toilets"
+	name = "\improper Abandoned Locker Toilets"
 	icon_state = "toilet"
 
 /area/crew_quarters/fitness
-	name = "\improper abandoned  Fitness Room"
+	name = "\improper Abandoned Fitness Room"
 	icon_state = "fitness"
 
 /area/crew_quarters/cafeteria
-	name = "\improper abandoned  Cafeteria"
+	name = "\improper Abandoned Cafeteria"
 	icon_state = "cafeteria"
 
 /area/crew_quarters/kitchen
-	name = "\improper abandoned  Kitchen"
+	name = "\improper Abandoned Kitchen"
 	icon_state = "kitchen"
 
 /area/crew_quarters/bar
-	name = "\improper abandoned  Bar"
+	name = "\improper Abandoned Bar"
 	icon_state = "bar"
 
 /area/crew_quarters/theatre
-	name = "\improper abandoned  Theatre"
+	name = "\improper Abandoned Theatre"
 	icon_state = "Theatre"
 
 /area/library
- 	name = "\improper abandoned  Library"
+ 	name = "\improper Abandoned Library"
  	icon_state = "library"
 
 /area/chapel/main
-	name = "\improper abandoned  Chapel"
+	name = "\improper Abandoned Chapel"
 	icon_state = "chapel"
 	ambience = list('sound/ambience/ambicha1.ogg','sound/ambience/ambicha2.ogg','sound/ambience/ambicha3.ogg','sound/ambience/ambicha4.ogg')
 
 /area/chapel/office
-	name = "\improper abandoned  Chapel Office"
+	name = "\improper Abandoned Chapel Office"
 	icon_state = "chapeloffice"
 
 /area/lawoffice
-	name = "\improper abandoned  Internal Affairs"
+	name = "\improper Abandoned Internal Affairs"
 	icon_state = "law"
 
 
@@ -981,58 +981,58 @@ var/list/ghostteleportlocs = list()
 
 
 /area/holodeck
-	name = "\improper abandoned  Holodeck"
+	name = "\improper Abandoned Holodeck"
 	icon_state = "Holodeck"
 	luminosity = 1
 	lighting_use_dynamic = 0
 
 /area/holodeck/alphadeck
-	name = "\improper abandoned  Holodeck Alpha"
+	name = "\improper Abandoned Holodeck Alpha"
 
 
 /area/holodeck/source_plating
-	name = "\improper abandoned  Holodeck - Off"
+	name = "\improper Abandoned Holodeck - Off"
 	icon_state = "Holodeck"
 
 /area/holodeck/source_emptycourt
-	name = "\improper abandoned  Holodeck - Empty Court"
+	name = "\improper Abandoned Holodeck - Empty Court"
 
 /area/holodeck/source_boxingcourt
-	name = "\improper abandoned  Holodeck - Boxing Court"
+	name = "\improper Abandoned Holodeck - Boxing Court"
 
 /area/holodeck/source_basketball
-	name = "\improper abandoned  Holodeck - Basketball Court"
+	name = "\improper Abandoned Holodeck - Basketball Court"
 
 /area/holodeck/source_thunderdomecourt
-	name = "\improper abandoned  Holodeck - Thunderdome Court"
+	name = "\improper Abandoned Holodeck - Thunderdome Court"
 
 /area/holodeck/source_beach
-	name = "\improper abandoned  Holodeck - Beach"
+	name = "\improper Abandoned Holodeck - Beach"
 	icon_state = "Holodeck" // Lazy.
 
 /area/holodeck/source_burntest
-	name = "\improper abandoned  Holodeck - Atmospheric Burn Test"
+	name = "\improper Abandoned Holodeck - Atmospheric Burn Test"
 
 /area/holodeck/source_wildlife
-	name = "\improper abandoned  Holodeck - Wildlife Simulation"
+	name = "\improper Abandoned Holodeck - Wildlife Simulation"
 
 /area/holodeck/source_meetinghall
-	name = "\improper abandoned  Holodeck - Meeting Hall"
+	name = "\improper Abandoned Holodeck - Meeting Hall"
 
 /area/holodeck/source_theatre
-	name = "\improper abandoned  Holodeck - Theatre"
+	name = "\improper Abandoned Holodeck - Theatre"
 
 /area/holodeck/source_picnicarea
-	name = "\improper abandoned  Holodeck - Picnic Area"
+	name = "\improper Abandoned Holodeck - Picnic Area"
 
 /area/holodeck/source_snowfield
-	name = "\improper abandoned  Holodeck - Snow Field"
+	name = "\improper Abandoned Holodeck - Snow Field"
 
 /area/holodeck/source_desert
-	name = "\improper abandoned  Holodeck - Desert"
+	name = "\improper Abandoned Holodeck - Desert"
 
 /area/holodeck/source_space
-	name = "\improper abandoned  Holodeck - Space"
+	name = "\improper Abandoned Holodeck - Space"
 
 
 
@@ -1049,7 +1049,7 @@ var/list/ghostteleportlocs = list()
 /area/engine
 
 	drone_fabrication
-		name = "\improper abandoned  Drone Fabrication"
+		name = "\improper Abandoned Drone Fabrication"
 		icon_state = "engine"
 
 	engine_smes
@@ -1058,27 +1058,27 @@ var/list/ghostteleportlocs = list()
 //		requires_power = 0//This area only covers the batteries and they deal with their own power
 
 	engine_room
-		name = "\improper abandoned  Engine Room"
+		name = "\improper Abandoned Engine Room"
 		icon_state = "engine"
 
 	engine_airlock
-		name = "\improper abandoned  Engine Room Airlock"
+		name = "\improper Abandoned Engine Room Airlock"
 		icon_state = "engine"
 
 	engine_monitoring
-		name = "\improper abandoned  Engine Monitoring Room"
+		name = "\improper Abandoned Engine Monitoring Room"
 		icon_state = "engine_monitoring"
 
 	engine_waste
-		name = "\improper abandoned  Engine Waste Handling"
+		name = "\improper Abandoned Engine Waste Handling"
 		icon_state = "engine_waste"
 
 	engineering_monitoring
-		name = "\improper abandoned  Engineering Monitoring Room"
+		name = "\improper Abandoned Engineering Monitoring Room"
 		icon_state = "engine_monitoring"
 
 	atmos_monitoring
-		name = "\improper abandoned  Atmospherics Monitoring Room"
+		name = "\improper Abandoned Atmospherics Monitoring Room"
 		icon_state = "engine_monitoring"
 
 	engineering
@@ -1086,35 +1086,35 @@ var/list/ghostteleportlocs = list()
 		icon_state = "engine_smes"
 
 	engineering_foyer
-		name = "\improper abandoned  Engineering Foyer"
+		name = "\improper Abandoned Engineering Foyer"
 		icon_state = "engine"
 
 	break_room
-		name = "\improper abandoned  Engineering Break Room"
+		name = "\improper Abandoned Engineering Break Room"
 		icon_state = "engine"
 
 	hallway
-		name = "\improper abandoned  Engineering Hallway"
+		name = "\improper Abandoned Engineering Hallway"
 		icon_state = "engine_hallway"
 
 	engine_hallway
-		name = "\improper abandoned  Engine Room Hallway"
+		name = "\improper Abandoned Engine Room Hallway"
 		icon_state = "engine_hallway"
 
 	engine_eva
-		name = "\improper abandoned  Engine EVA"
+		name = "\improper Abandoned Engine EVA"
 		icon_state = "engine_eva"
 
 	engine_eva_maintenance
-		name = "\improper abandoned  Engine EVA Maintenance"
+		name = "\improper Abandoned Engine EVA Maintenance"
 		icon_state = "engine_eva"
 
 	workshop
-		name = "\improper abandoned  Engineering Workshop"
+		name = "\improper Abandoned Engineering Workshop"
 		icon_state = "engine_storage"
 
 	locker_room
-		name = "\improper abandoned  Engineering Locker Room"
+		name = "\improper Abandoned Engineering Locker Room"
 		icon_state = "engine_storage"
 
 
@@ -1127,27 +1127,27 @@ var/list/ghostteleportlocs = list()
 	lighting_use_dynamic = 0
 
 	auxport
-		name = "\improper abandoned  Fore Port Solar Array"
+		name = "\improper Abandoned Fore Port Solar Array"
 		icon_state = "panelsA"
 
 	auxstarboard
-		name = "\improper abandoned  Fore Starboard Solar Array"
+		name = "\improper Abandoned Fore Starboard Solar Array"
 		icon_state = "panelsA"
 
 	fore
-		name = "\improper abandoned  Fore Solar Array"
+		name = "\improper Abandoned Fore Solar Array"
 		icon_state = "yellow"
 
 	aft
-		name = "\improper abandoned  Aft Solar Array"
+		name = "\improper Abandoned Aft Solar Array"
 		icon_state = "aft"
 
 	starboard
-		name = "\improper abandoned  Aft Starboard Solar Array"
+		name = "\improper Abandoned Aft Starboard Solar Array"
 		icon_state = "panelsS"
 
 	port
-		name = "\improper abandoned  Aft Port Solar Array"
+		name = "\improper Abandoned Aft Port Solar Array"
 		icon_state = "panelsP"
 
 /area/maintenance/auxsolarport
@@ -1171,19 +1171,19 @@ var/list/ghostteleportlocs = list()
 	icon_state = "SolarcontrolA"
 
 /area/assembly/chargebay
-	name = "\improper abandoned  Mech Bay"
+	name = "\improper Abandoned Mech Bay"
 	icon_state = "mechbay"
 
 /area/assembly/showroom
-	name = "\improper abandoned  Robotics Showroom"
+	name = "\improper Abandoned Robotics Showroom"
 	icon_state = "showroom"
 
 /area/assembly/robotics
-	name = "\improper abandoned  Robotics Lab"
+	name = "\improper Abandoned Robotics Lab"
 	icon_state = "ass_line"
 
 /area/assembly/assembly_line //Derelict Assembly Line
-	name = "\improper abandoned  Assembly Line"
+	name = "\improper Abandoned Assembly Line"
 	icon_state = "ass_line"
 	power_equip = 0
 	power_light = 0
@@ -1192,17 +1192,17 @@ var/list/ghostteleportlocs = list()
 //Teleporter
 
 /area/teleporter
-	name = "\improper abandoned  Teleporter"
+	name = "\improper Abandoned Teleporter"
 	icon_state = "teleporter"
 	music = "signal"
 
 /area/gateway
-	name = "\improper abandoned  Gateway"
+	name = "\improper Abandoned Gateway"
 	icon_state = "teleporter"
 	music = "signal"
 
 /area/AIsattele
-	name = "\improper abandoned  AI Satellite Teleporter Room"
+	name = "\improper Abandoned AI Satellite Teleporter Room"
 	icon_state = "teleporter"
 	music = "signal"
 	ambience = list('sound/ambience/ambimalf.ogg')
@@ -1210,163 +1210,163 @@ var/list/ghostteleportlocs = list()
 //MedBay
 
 /area/medical/medbay
-	name = "\improper abandoned  Medbay"
+	name = "\improper Abandoned Medbay"
 	icon_state = "medbay"
 	music = 'sound/ambience/signal.ogg'
 
 //Medbay is a large area, these additional areas help level out APC load.
 /area/medical/medbay2
-	name = "\improper abandoned  Medbay"
+	name = "\improper Abandoned Medbay"
 	icon_state = "medbay2"
 	music = 'sound/ambience/signal.ogg'
 
 /area/medical/medbay3
-	name = "\improper abandoned  Medbay"
+	name = "\improper Abandoned Medbay"
 	icon_state = "medbay3"
 	music = 'sound/ambience/signal.ogg'
 
 /area/medical/biostorage
-	name = "\improper abandoned  Secondary Storage"
+	name = "\improper Abandoned Secondary Storage"
 	icon_state = "medbay2"
 	music = 'sound/ambience/signal.ogg'
 
 /area/medical/reception
-	name = "\improper abandoned  Medbay Reception"
+	name = "\improper Abandoned Medbay Reception"
 	icon_state = "medbay"
 	music = 'sound/ambience/signal.ogg'
 
 /area/medical/psych
-	name = "\improper abandoned  Psych Room"
+	name = "\improper Abandoned Psych Room"
 	icon_state = "medbay3"
 	music = 'sound/ambience/signal.ogg'
 
 /area/crew_quarters/medbreak
-	name = "\improper abandoned  Break Room"
+	name = "\improper Abandoned Break Room"
 	icon_state = "medbay3"
 	music = 'sound/ambience/signal.ogg'
 
 /area/medical/patients_rooms
-	name = "\improper abandoned  Patient's Rooms"
+	name = "\improper Abandoned Patient's Rooms"
 	icon_state = "patients"
 
 /area/medical/ward
-	name = "\improper abandoned  Recovery Ward"
+	name = "\improper Abandoned Recovery Ward"
 	icon_state = "patients"
 
 /area/medical/patient_a
-	name = "\improper abandoned  Isolation A"
+	name = "\improper Abandoned Isolation A"
 	icon_state = "patients"
 
 /area/medical/patient_b
-	name = "\improper abandoned  Isolation B"
+	name = "\improper Abandoned Isolation B"
 	icon_state = "patients"
 
 /area/medical/patient_c
-	name = "\improper abandoned  Isolation C"
+	name = "\improper Abandoned Isolation C"
 	icon_state = "patients"
 
 /area/medical/patient_wing
-	name = "\improper abandoned  Patient Wing"
+	name = "\improper Abandoned Patient Wing"
 	icon_state = "patients"
 
 /area/medical/cmostore
-	name = "\improper abandoned  Secure Storage"
+	name = "\improper Abandoned Secure Storage"
 	icon_state = "CMO"
 
 /area/medical/robotics
-	name = "\improper abandoned  Robotics"
+	name = "\improper Abandoned Robotics"
 	icon_state = "medresearch"
 
 /area/medical/virology
-	name = "\improper abandoned  Virology"
+	name = "\improper Abandoned Virology"
 	icon_state = "virology"
 
 /area/medical/virologyaccess
-	name = "\improper abandoned  Virology Access"
+	name = "\improper Abandoned Virology Access"
 	icon_state = "virology"
 
 /area/medical/morgue
-	name = "\improper abandoned  Morgue"
+	name = "\improper Abandoned Morgue"
 	icon_state = "morgue"
 	ambience = list('sound/ambience/ambimo1.ogg','sound/ambience/ambimo2.ogg')
 
 /area/medical/chemistry
-	name = "\improper abandoned  Chemistry"
+	name = "\improper Abandoned Chemistry"
 	icon_state = "chem"
 
 /area/medical/surgery
-	name = "\improper abandoned  Operating Theatre 1"
+	name = "\improper Abandoned Operating Theatre 1"
 	icon_state = "surgery"
 
 /area/medical/surgery2
-	name = "\improper abandoned  Operating Theatre 2"
+	name = "\improper Abandoned Operating Theatre 2"
 	icon_state = "surgery"
 
 /area/medical/surgeryobs
-	name = "\improper abandoned  Operation Observation Room"
+	name = "\improper Abandoned Operation Observation Room"
 	icon_state = "surgery"
 
 /area/medical/surgeryprep
-	name = "\improper abandoned  Pre-Op Prep Room"
+	name = "\improper Abandoned Pre-Op Prep Room"
 	icon_state = "surgery"
 
 /area/medical/cryo
-	name = "\improper abandoned  Cryogenics"
+	name = "\improper Abandoned Cryogenics"
 	icon_state = "cryo"
 
 /area/medical/exam_room
-	name = "\improper abandoned  Exam Room"
+	name = "\improper Abandoned Exam Room"
 	icon_state = "exam_room"
 
 /area/medical/genetics
-	name = "\improper abandoned  Genetics Lab"
+	name = "\improper Abandoned Genetics Lab"
 	icon_state = "genetics"
 
 /area/medical/genetics_cloning
-	name = "\improper abandoned  Cloning Lab"
+	name = "\improper Abandoned Cloning Lab"
 	icon_state = "cloning"
 
 /area/medical/sleeper
-	name = "\improper abandoned  Emergency Treatment Centre"
+	name = "\improper Abandoned Emergency Treatment Centre"
 	icon_state = "exam_room"
 
 //Security
 
 /area/security/main
-	name = "\improper abandoned  Security Office"
+	name = "\improper Abandoned Security Office"
 	icon_state = "security"
 
 /area/security/lobby
-	name = "\improper abandoned  Security lobby"
+	name = "\improper Abandoned Security lobby"
 	icon_state = "security"
 
 /area/security/brig
-	name = "\improper abandoned  Brig"
+	name = "\improper Abandoned Brig"
 	icon_state = "brig"
 
 /area/security/prison
-	name = "\improper abandoned  Prison Wing"
+	name = "\improper Abandoned Prison Wing"
 	icon_state = "sec_prison"
 
 
 /area/security/warden
-	name = "\improper abandoned  Warden"
+	name = "\improper Abandoned Warden"
 	icon_state = "Warden"
 
 /area/security/armoury
-	name = "\improper abandoned  Armory"
+	name = "\improper Abandoned Armory"
 	icon_state = "Warden"
 
 /area/security/detectives_office
-	name = "\improper abandoned  Detective's Office"
+	name = "\improper Abandoned Detective's Office"
 	icon_state = "detective"
 
 /area/security/range
-	name = "\improper abandoned  Firing Range"
+	name = "\improper Abandoned Firing Range"
 	icon_state = "firingrange"
 
 /area/security/tactical
-	name = "\improper abandoned  Tactical Equipment"
+	name = "\improper Abandoned Tactical Equipment"
 	icon_state = "Tactical"
 
 /*
@@ -1387,15 +1387,15 @@ var/list/ghostteleportlocs = list()
 */
 
 /area/security/nuke_storage
-	name = "\improper abandoned  Vault"
+	name = "\improper Abandoned Vault"
 	icon_state = "nuke_storage"
 
 /area/security/checkpoint
-	name = "\improper abandoned  Security Checkpoint"
+	name = "\improper Abandoned Security Checkpoint"
 	icon_state = "checkpoint1"
 
 /area/security/checkpoint2
-	name = "\improper abandoned  Security Checkpoint"
+	name = "\improper Abandoned Security Checkpoint"
 	icon_state = "security"
 
 /area/security/checkpoint/supply
@@ -1415,113 +1415,113 @@ var/list/ghostteleportlocs = list()
 	icon_state = "checkpoint1"
 
 /area/security/vacantoffice
-	name = "\improper abandoned  Vacant Office"
+	name = "\improper Abandoned Vacant Office"
 	icon_state = "security"
 
 /area/security/vacantoffice2
-	name = "\improper abandoned  Vacant Office"
+	name = "\improper Abandoned Vacant Office"
 	icon_state = "security"
 
 /area/quartermaster
-	name = "\improper abandoned  Quartermasters"
+	name = "\improper Abandoned Quartermasters"
 	icon_state = "quart"
 
 ///////////WORK IN PROGRESS//////////
 
 /area/quartermaster/sorting
-	name = "\improper abandoned  Delivery Office"
+	name = "\improper Abandoned Delivery Office"
 	icon_state = "quartstorage"
 
 ////////////WORK IN PROGRESS//////////
 
 /area/quartermaster/office
-	name = "\improper abandoned  Cargo Office"
+	name = "\improper Abandoned Cargo Office"
 	icon_state = "quartoffice"
 
 /area/quartermaster/storage
-	name = "\improper abandoned  Cargo Bay"
+	name = "\improper Abandoned Cargo Bay"
 	icon_state = "quartstorage"
 
 /area/quartermaster/qm
-	name = "\improper abandoned  Quartermaster's Office"
+	name = "\improper Abandoned Quartermaster's Office"
 	icon_state = "quart"
 
 /area/quartermaster/miningdock
-	name = "\improper abandoned  Mining Dock"
+	name = "\improper Abandoned Mining Dock"
 	icon_state = "mining"
 
 /area/quartermaster/miningstorage
-	name = "\improper abandoned  Mining Storage"
+	name = "\improper Abandoned Mining Storage"
 	icon_state = "green"
 
 /area/quartermaster/mechbay
-	name = "\improper abandoned  Mech Bay"
+	name = "\improper Abandoned Mech Bay"
 	icon_state = "yellow"
 
 /area/janitor/
-	name = "\improper abandoned  Custodial Closet"
+	name = "\improper Abandoned Custodial Closet"
 	icon_state = "janitor"
 
 /area/hydroponics
-	name = "\improper abandoned  Hydroponics"
+	name = "\improper Abandoned Hydroponics"
 	icon_state = "hydro"
 
 /area/hydroponics/garden
-	name = "\improper abandoned  Garden"
+	name = "\improper Abandoned Garden"
 	icon_state = "garden"
 
 //rnd (Research and Development
 
 /area/rnd/research
-	name = "\improper abandoned  Research and Development"
+	name = "\improper Abandoned Research and Development"
 	icon_state = "research"
 
 /area/rnd/docking
-	name = "\improper abandoned  Research Dock"
+	name = "\improper Abandoned Research Dock"
 	icon_state = "research_dock"
 
 /area/rnd/lab
-	name = "\improper abandoned  Research Lab"
+	name = "\improper Abandoned Research Lab"
 	icon_state = "toxlab"
 
 /area/rnd/rdoffice
-	name = "\improper abandoned  Research Director's Office"
+	name = "\improper Abandoned Research Director's Office"
 	icon_state = "head_quarters"
 
 /area/rnd/supermatter
-	name = "\improper abandoned  Supermatter Lab"
+	name = "\improper Abandoned Supermatter Lab"
 	icon_state = "toxlab"
 
 /area/rnd/xenobiology
-	name = "\improper abandoned  Xenobiology Lab"
+	name = "\improper Abandoned Xenobiology Lab"
 	icon_state = "xeno_lab"
 
 /area/rnd/xenobiology/xenoflora_storage
-	name = "\improper abandoned  Xenoflora Storage"
+	name = "\improper Abandoned Xenoflora Storage"
 	icon_state = "xeno_f_store"
 
 /area/rnd/xenobiology/xenoflora
-	name = "\improper abandoned  Xenoflora Lab"
+	name = "\improper Abandoned Xenoflora Lab"
 	icon_state = "xeno_f_lab"
 
 /area/rnd/storage
-	name = "\improper abandoned  Toxins Storage"
+	name = "\improper Abandoned Toxins Storage"
 	icon_state = "toxstorage"
 
 /area/rnd/test_area
-	name = "\improper abandoned  Toxins Test Area"
+	name = "\improper Abandoned Toxins Test Area"
 	icon_state = "toxtest"
 
 /area/rnd/mixing
-	name = "\improper abandoned  Toxins Mixing Room"
+	name = "\improper Abandoned Toxins Mixing Room"
 	icon_state = "toxmix"
 
 /area/rnd/misc_lab
-	name = "\improper abandoned  Miscellaneous Research"
+	name = "\improper Abandoned Miscellaneous Research"
 	icon_state = "toxmisc"
 
 /area/toxins/server
-	name = "\improper abandoned  Server Room"
+	name = "\improper Abandoned Server Room"
 	icon_state = "server"
 
 //Storage
@@ -1572,35 +1572,35 @@ var/list/ghostteleportlocs = list()
 
 /area/storage/testroom
 	requires_power = 0
-	name = "\improper abandoned  Test Room"
+	name = "\improper Abandoned Test Room"
 	icon_state = "storage"
 
 //DJSTATION
 
 /area/djstation
-	name = "\improper abandoned  Listening Post"
+	name = "\improper Abandoned Listening Post"
 	icon_state = "LP"
 
 /area/djstation/solars
-	name = "\improper abandoned  Listening Post Solars"
+	name = "\improper Abandoned Listening Post Solars"
 	icon_state = "LPS"
 
 //DERELICT
 /*
 /area/derelict
-	name = "\improper abandoned  Derelict Station"
+	name = "\improper Abandoned Derelict Station"
 	icon_state = "storage"
 
 /area/derelict/hallway/primary
-	name = "\improper abandoned  Derelict Primary Hallway"
+	name = "\improper Abandoned Derelict Primary Hallway"
 	icon_state = "hallP"
 
 /area/derelict/hallway/secondary
-	name = "\improper abandoned  Derelict Secondary Hallway"
+	name = "\improper Abandoned Derelict Secondary Hallway"
 	icon_state = "hallS"
 
 /area/derelict/arrival
-	name = "\improper abandoned  Derelict Arrival Centre"
+	name = "\improper Abandoned Derelict Arrival Centre"
 	icon_state = "yellow"
 
 /area/derelict/storage/equipment
@@ -1614,11 +1614,11 @@ var/list/ghostteleportlocs = list()
 	icon_state = "green"
 
 /area/derelict/bridge
-	name = "\improper abandoned  Derelict Control Room"
+	name = "\improper Abandoned Derelict Control Room"
 	icon_state = "bridge"
 
 /area/derelict/secret
-	name = "\improper abandoned  Derelict Secret Room"
+	name = "\improper Abandoned Derelict Secret Room"
 	icon_state = "library"
 
 /area/derelict/bridge/access
@@ -1626,15 +1626,15 @@ var/list/ghostteleportlocs = list()
 	icon_state = "auxstorage"
 
 /area/derelict/bridge/ai_upload
-	name = "\improper abandoned  Derelict Computer Core"
+	name = "\improper Abandoned Derelict Computer Core"
 	icon_state = "ai"
 
 /area/derelict/solar_control
-	name = "\improper abandoned  Derelict Solar Control"
+	name = "\improper Abandoned Derelict Solar Control"
 	icon_state = "engine"
 
 /area/derelict/crew_quarters
-	name = "\improper abandoned  Derelict Crew Quarters"
+	name = "\improper Abandoned Derelict Crew Quarters"
 	icon_state = "fitness"
 
 /area/derelict/medical
@@ -1642,15 +1642,15 @@ var/list/ghostteleportlocs = list()
 	icon_state = "medbay"
 
 /area/derelict/medical/morgue
-	name = "\improper abandoned  Derelict Morgue"
+	name = "\improper Abandoned Derelict Morgue"
 	icon_state = "morgue"
 
 /area/derelict/medical/chapel
-	name = "\improper abandoned  Derelict Chapel"
+	name = "\improper Abandoned Derelict Chapel"
 	icon_state = "chapel"
 
 /area/derelict/teleporter
-	name = "\improper abandoned  Derelict Teleporter"
+	name = "\improper Abandoned Derelict Teleporter"
 	icon_state = "teleporter"
 
 /area/derelict/eva
@@ -1658,98 +1658,98 @@ var/list/ghostteleportlocs = list()
 	icon_state = "eva"
 
 /area/derelict/ship
-	name = "\improper abandoned  Abandoned Ship"
+	name = "\improper Abandoned Abandoned Ship"
 	icon_state = "yellow"
 
 /area/solar/derelict_starboard
-	name = "\improper abandoned  Derelict Starboard Solar Array"
+	name = "\improper Abandoned Derelict Starboard Solar Array"
 	icon_state = "panelsS"
 
 /area/solar/derelict_aft
-	name = "\improper abandoned  Derelict Aft Solar Array"
+	name = "\improper Abandoned Derelict Aft Solar Array"
 	icon_state = "aft"
 
 /area/derelict/singularity_engine
-	name = "\improper abandoned  Derelict Singularity Engine"
+	name = "\improper Abandoned Derelict Singularity Engine"
 	icon_state = "engine"
 */
 //HALF-BUILT STATION (REPLACES DERELICT IN BAYCODE, ABOVE IS LEFT FOR DOWNSTREAM)
 /*
 /area/shuttle/constructionsite
-	name = "\improper abandoned  Construction Site Shuttle"
+	name = "\improper Abandoned Construction Site Shuttle"
 	icon_state = "yellow"
 
 /area/shuttle/constructionsite/station
-	name = "\improper abandoned  Construction Site Shuttle"
+	name = "\improper Abandoned Construction Site Shuttle"
 
 /area/shuttle/constructionsite/site
-	name = "\improper abandoned  Construction Site Shuttle"
+	name = "\improper Abandoned Construction Site Shuttle"
 
 /area/constructionsite
-	name = "\improper abandoned  Construction Site"
+	name = "\improper Abandoned Construction Site"
 	icon_state = "storage"
 
 /area/constructionsite/storage
-	name = "\improper abandoned  Construction Site Storage Area"
+	name = "\improper Abandoned Construction Site Storage Area"
 
 /area/constructionsite/science
-	name = "\improper abandoned  Construction Site Research"
+	name = "\improper Abandoned Construction Site Research"
 
 /area/constructionsite/bridge
-	name = "\improper abandoned  Construction Site Bridge"
+	name = "\improper Abandoned Construction Site Bridge"
 	icon_state = "bridge"
 
 /area/constructionsite/maintenance
-	name = "\improper abandoned  Construction Site Maintenance"
+	name = "\improper Abandoned Construction Site Maintenance"
 	icon_state = "yellow"
 
 /area/constructionsite/hallway/aft
-	name = "\improper abandoned  Construction Site Aft Hallway"
+	name = "\improper Abandoned Construction Site Aft Hallway"
 	icon_state = "hallP"
 
 /area/constructionsite/hallway/fore
-	name = "\improper abandoned  Construction Site Fore Hallway"
+	name = "\improper Abandoned Construction Site Fore Hallway"
 	icon_state = "hallS"
 
 /area/constructionsite/atmospherics
-	name = "\improper abandoned  Construction Site Atmospherics"
+	name = "\improper Abandoned Construction Site Atmospherics"
 	icon_state = "green"
 
 /area/constructionsite/medical
-	name = "\improper abandoned  Construction Site Medbay"
+	name = "\improper Abandoned Construction Site Medbay"
 	icon_state = "medbay"
 
 /area/constructionsite/ai
-	name = "\improper abandoned  Construction Computer Core"
+	name = "\improper Abandoned Construction Computer Core"
 	icon_state = "ai"
 
 /area/constructionsite/engineering
-	name = "\improper abandoned  Construction Site Engine Bay"
+	name = "\improper Abandoned Construction Site Engine Bay"
 	icon_state = "engine"
 
 /area/solar/constructionsite
-	name = "\improper abandoned  Construction Site Solars"
+	name = "\improper Abandoned Construction Site Solars"
 	icon_state = "aft"
 
 //area/constructionsite
-//	name = "\improper abandoned  Construction Site Shuttle"
+//	name = "\improper Abandoned Construction Site Shuttle"
 
 //area/constructionsite
-//	name = "\improper abandoned  Construction Site Shuttle"
+//	name = "\improper Abandoned Construction Site Shuttle"
 
 */
 //Construction
 
 /area/construction
-	name = "\improper abandoned  Construction Area"
+	name = "\improper Abandoned Construction Area"
 	icon_state = "yellow"
 
 /area/construction/supplyshuttle
-	name = "\improper abandoned  Supply Shuttle"
+	name = "\improper Abandoned Supply Shuttle"
 	icon_state = "yellow"
 
 /area/construction/quarters
-	name = "\improper abandoned  Engineer's Quarters"
+	name = "\improper Abandoned Engineer's Quarters"
 	icon_state = "yellow"
 
 /area/construction/qmaint
@@ -1757,15 +1757,15 @@ var/list/ghostteleportlocs = list()
 	icon_state = "yellow"
 
 /area/construction/hallway
-	name = "\improper abandoned  Hallway"
+	name = "\improper Abandoned Hallway"
 	icon_state = "yellow"
 
 /area/construction/solars
-	name = "\improper abandoned  Solar Panels"
+	name = "\improper Abandoned Solar Panels"
 	icon_state = "yellow"
 
 /area/construction/solarscontrol
-	name = "\improper abandoned  Solar Panel Control"
+	name = "\improper Abandoned Solar Panel Control"
 	icon_state = "yellow"
 
 /area/construction/Storage
@@ -1787,7 +1787,7 @@ var/list/ghostteleportlocs = list()
 	icon_state = "storage"
 
 /area/turret_protected/ai_upload
-	name = "\improper abandoned  AI Upload Chamber"
+	name = "\improper Abandoned AI Upload Chamber"
 	icon_state = "ai_upload"
 	ambience = list('sound/ambience/ambimalf.ogg')
 
@@ -1801,16 +1801,16 @@ var/list/ghostteleportlocs = list()
 	icon_state = "ai_server"
 
 /area/turret_protected/ai
-	name = "\improper abandoned  AI Chamber"
+	name = "\improper Abandoned AI Chamber"
 	icon_state = "ai_chamber"
 	ambience = list('sound/ambience/ambimalf.ogg')
 
 /area/turret_protected/ai_cyborg_station
-	name = "\improper abandoned  Cyborg Station"
+	name = "\improper Abandoned Cyborg Station"
 	icon_state = "ai_cyborg"
 
 /area/turret_protected/aisat
-	name = "\improper abandoned  AI Satellite"
+	name = "\improper Abandoned AI Satellite"
 	icon_state = "ai"
 
 


### PR DESCRIPTION
:cl:
spellcheck: fixes area names, no more "abandoned   Thunderdome"
/:cl:
 gets rid of "abandoned   Thunderdome" and others, changing it to "Abandoned Thunderdome"