### PR TITLE
Lil praetorian rebalance.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Castes/Praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Castes/Praetorian.dm
@@ -15,14 +15,14 @@
 	tackle_damage = 40
 
 	// *** Speed *** //
-	speed = -0.1
+	speed = -0.15
 
 	// *** Plasma *** //
 	plasma_max = 800
 	plasma_gain = 25
 
 	// *** Health *** //
-	max_health = 210
+	max_health = 200
 
 	// *** Evolution *** //
 	upgrade_threshold = 400
@@ -33,7 +33,7 @@
 	caste_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_GIVEN_PLASMA
 
 	// *** Defense *** //
-	armor_deflection = 35
+	armor_deflection = 30
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.5 SECONDS
@@ -59,20 +59,20 @@
 	tackle_damage = 45
 
 	// *** Speed *** //
-	speed = 0.0
+	speed = -0.25
 
 	// *** Plasma *** //
 	plasma_max = 900
 	plasma_gain = 30
 
 	// *** Health *** //
-	max_health = 225
+	max_health = 240
 
 	// *** Evolution *** //
 	upgrade_threshold = 800
 
 	// *** Defense *** //
-	armor_deflection = 40
+	armor_deflection = 35
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.5 SECONDS
@@ -94,7 +94,7 @@
 	tackle_damage = 50
 
 	// *** Speed *** //
-	speed = -0.1
+	speed = -0.3
 
 	// *** Plasma *** //
 	plasma_max = 1000
@@ -130,14 +130,14 @@
 	tackle_damage = 60
 
 	// *** Speed *** //
-	speed = -0.2
+	speed = -0.35
 
 	// *** Plasma *** //
 	plasma_max = 1000
 	plasma_gain = 50
 
 	// *** Health *** //
-	max_health = 250
+	max_health = 255
 
 	// *** Defense *** //
 	armor_deflection = 45


### PR DESCRIPTION
* Prae got a heavy hit to his health and speed in the past, supposedly as part of the rebalance.
* Prae is a ranged caste, and should feel like it. They're considerably slower than a spitter due to how heavily their speed was nerfed to make up for a boosted spray range. Praetorians are more than just a long cooldown spray, and should be able to skirmish fluidly like a spitter or a sentinel, it's very hard to dodge bullets at all, and easy to get punished. Pheromones barely make up for it.
They're squishier, and slower than defenders / warriors alike. A tier three shouldn't be a downgrade stat wise from a T2. Even a boiler gains more armor and health to make up for the lack in speed. Prae already experiences slowdown after spraying, making their speed inherently bad just makes it painful.
* Prae doesn't follow diminishing returns for main stats like other castes.
* Lasguns are too effective at killing praetorians, ignoring almost all effective armor. A spitter can almost take lasgun shots more easily than a prae.
* It makes more sense for ranged castes to have health > armor. they're usually going to be affected by bullets with a lot of falloff, which too much armor easily deflects. 

Summary of changes.
Nerfed initial health. Strong boost from young => mature to fall in line with other xenos.
Fixed speed curve. Prae actually got slower when maturing at first. Buffed it as well.

I'm not sure, but praes should probably be faster than defenders? The suggested changes are rather small. It may be best to just boost speed most, and leave health largely untouched.