### PR TITLE
Zombie language and christmas guns code cleanup.

### DIFF
--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -161,13 +161,6 @@
 		..()
 		reagents.add_reagent("antiZed", 30)
 
-/datum/language/zombie
-	name = "Zombie"
-	desc = "If you select this from the language screen, expect a ban."
-	colour = "green"
-	key = "4"
-	flags = RESTRICTED
-
 
 /obj/item/clothing/glasses/zombie_eyes
 	name = "zombie eyes"

--- a/code/game/objects/items/XMAS.dm
+++ b/code/game/objects/items/XMAS.dm
@@ -98,17 +98,18 @@
 
 /obj/item/weapon/gun/launcher/rocket/m57a4/XMAS
 	flags_gun_features = GUN_INTERNAL_MAG
-	able_to_fire(mob/living/user)
-		var/turf/current_turf = get_turf(user)
-		if (current_turf.z == 3 || current_turf.z == 4) //Can't fire on the Theseus, bub.
-			click_empty(user)
-			to_chat(user, "<span class='warning'>You can't fire that here!</span>")
-			return FALSE
-		else
-			return TRUE
+
+/obj/item/weapon/gun/launcher/rocket/m57a4/XMAS/able_to_fire(mob/living/user)
+	var/turf/current_turf = get_turf(user)
+	if (current_turf.z == 3 || current_turf.z == 4) //Can't fire on the Theseus, bub.
+		click_empty(user)
+		to_chat(user, "<span class='warning'>You can't fire that here!</span>")
+		return FALSE
+	else
+		return TRUE
 
 /obj/item/weapon/gun/rifle/sniper/elite/XMAS
 	flags_gun_features = GUN_INTERNAL_MAG
 
-	able_to_fire(mob/living/user)
-		return TRUE
+/obj/item/weapon/gun/rifle/sniper/elite/XMAS/able_to_fire(mob/living/user)
+	return TRUE

--- a/code/game/objects/items/XMAS.dm
+++ b/code/game/objects/items/XMAS.dm
@@ -97,7 +97,6 @@
 	return
 
 /obj/item/weapon/gun/launcher/rocket/m57a4/XMAS
-	..()
 	flags_gun_features = GUN_INTERNAL_MAG
 	able_to_fire(mob/living/user)
 		var/turf/current_turf = get_turf(user)
@@ -109,7 +108,6 @@
 			return TRUE
 
 /obj/item/weapon/gun/rifle/sniper/elite/XMAS
-	..()
 	flags_gun_features = GUN_INTERNAL_MAG
 
 	able_to_fire(mob/living/user)

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -240,7 +240,7 @@
 
 /datum/language/zombie
 	name = "Zombie"
-	desc = "Braaaains..."
+	desc = "If you select this from the language screen, expect braaaains..."
 	colour = "green"
 	key = "4"
 	flags = RESTRICTED

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -238,6 +238,13 @@
 	flags = RESTRICTED|HIVEMIND
 	drone_only = 1
 
+/datum/language/zombie
+	name = "Zombie"
+	desc = "If you select this from the language screen, expect a ban."
+	colour = "green"
+	key = "4"
+	flags = RESTRICTED
+
 // Language handling.
 /mob/proc/add_language(var/language)
 

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -240,7 +240,7 @@
 
 /datum/language/zombie
 	name = "Zombie"
-	desc = "If you select this from the language screen, expect a ban."
+	desc = "Braaaains..."
 	colour = "green"
 	key = "4"
 	flags = RESTRICTED


### PR DESCRIPTION
* Moved zombie language to language.dm, as it was erroring due to black_goo.dm, its origin, being read first.
* Instead of expecting a ban from using the zombie language, you can expect braaaains.
* Fixed erroring apop code for some christmas guns.