### PR TITLE
Un-dumbs synthetic grenade restrictions

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -232,6 +232,8 @@ var/global/datum/controller/gameticker/ticker
 				to_chat(world, "<span class='warning'><b>The OOC channel has been globally enabled due to round end!</b></span>")
 				ooc_allowed = TRUE
 
+			config.allow_synthetic_gun_use = TRUE
+
 			if(blackbox)
 				blackbox.save_all_data_to_sql()
 

--- a/code/game/objects/items/explosives/grenades/chem_grenade.dm
+++ b/code/game/objects/items/explosives/grenades/chem_grenade.dm
@@ -174,6 +174,7 @@
 /obj/item/explosive/grenade/chem_grenade/metalfoam
 	name = "Metal-Foam Grenade"
 	desc = "Used for emergency sealing of air breaches."
+	dangerous = FALSE
 	path = 1
 	stage = 2
 
@@ -220,6 +221,7 @@
 /obj/item/explosive/grenade/chem_grenade/antiweed
 	name = "weedkiller grenade"
 	desc = "Used for purging large areas of invasive plant species. Contents under pressure. Do not directly inhale contents."
+	dangerous = FALSE
 	path = 1
 	stage = 2
 
@@ -243,6 +245,7 @@
 /obj/item/explosive/grenade/chem_grenade/cleaner
 	name = "cleaner grenade"
 	desc = "BLAM!-brand foaming space cleaner. In a special applicator for rapid cleaning of wide areas."
+	dangerous = FALSE
 	stage = 2
 	path = 1
 

--- a/code/game/objects/items/explosives/grenades/emgrenade.dm
+++ b/code/game/objects/items/explosives/grenades/emgrenade.dm
@@ -3,7 +3,6 @@
 	icon_state = "emp"
 	item_state = "emp"
 	origin_tech = "materials=2;magnets=3"
-	dangerous = TRUE
 
 /obj/item/explosive/grenade/empgrenade/prime()
 	..()

--- a/code/game/objects/items/explosives/grenades/emgrenade.dm
+++ b/code/game/objects/items/explosives/grenades/emgrenade.dm
@@ -3,10 +3,11 @@
 	icon_state = "emp"
 	item_state = "emp"
 	origin_tech = "materials=2;magnets=3"
+	dangerous = TRUE
 
-	prime()
-		..()
-		if(empulse(src, 4, 10))
-			qdel(src)
-		return
+/obj/item/explosive/grenade/empgrenade/prime()
+	..()
+	if(empulse(src, 4, 10))
+		qdel(src)
+	return
 

--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -25,35 +25,34 @@
 	det_time = rand(det_time - 10, det_time + 10)
 
 /obj/item/explosive/grenade/attack_self(mob/user)
-	if(!active)
+	if(active)
+		return
 
-		if(!user.IsAdvancedToolUser())
-			to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
-			return
+	if(!user.IsAdvancedToolUser())
+		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
+		return
 
-		if(ishuman(user))
-			var/mob/living/carbon/human/S = user
-			if(S.species.flags & IS_SYNTHETIC && dangerous)
-				to_chat(user, "<span class='warning'>Your programming prevents you from operating this device!</span>")
-				return
+	if(isSynth(user) && dangerous && !config.allow_synthetic_gun_use)
+		to_chat(user, "<span class='warning'>Your programming prevents you from operating this device!</span>")
+		return
 
-		add_fingerprint(user)
-		activate(user)
-		if((CLUMSY in user.mutations) && prob(50))
-			to_chat(user, "<span class='warning'>Huh? How does this thing work?</span>")
-			spawn(5) prime()
+	add_fingerprint(user)
+	activate(user)
+	if((CLUMSY in user.mutations) && prob(50))
+		to_chat(user, "<span class='warning'>Huh? How does this thing work?</span>")
+		spawn(5) prime()
 
-		else
-			user.visible_message("<span class='warning'>[user] primes \a [name]!</span>", \
-			"<span class='warning'>You prime \a [name]!</span>")
-			if(initial(dangerous) && has_species(user, "Human"))
-				var/nade_sound = user.gender == FEMALE ? get_sfx("female_fragout") : get_sfx("male_fragout")
+	else
+		user.visible_message("<span class='warning'>[user] primes \a [name]!</span>", \
+		"<span class='warning'>You prime \a [name]!</span>")
+		if(initial(dangerous) && has_species(user, "Human"))
+			var/nade_sound = user.gender == FEMALE ? get_sfx("female_fragout") : get_sfx("male_fragout")
 
-				for(var/mob/living/carbon/human/H in hearers(6,user))
-					H.playsound_local(user, nade_sound, 35)
-			if(iscarbon(user))
-				var/mob/living/carbon/C = user
-				C.throw_mode_on()
+			for(var/mob/living/carbon/human/H in hearers(6,user))
+				H.playsound_local(user, nade_sound, 35)
+		if(iscarbon(user))
+			var/mob/living/carbon/C = user
+			C.throw_mode_on()
 
 
 /obj/item/explosive/grenade/proc/activate(mob/user as mob)

--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -12,7 +12,7 @@
 	hitsound = 'sound/weapons/smash.ogg'
 	var/active = 0
 	var/det_time = 50
-	var/dangerous = 0		//Make an danger overlay for humans?
+	var/dangerous = FALSE 	//Does it make a danger overlay for humans? Can synths use it?
 	var/arm_sound = 'sound/weapons/armbomb.ogg'
 	var/underslug_launchable = FALSE
 	var/hud_state = "grenade_he"
@@ -33,7 +33,7 @@
 
 		if(ishuman(user))
 			var/mob/living/carbon/human/S = user
-			if(S.species.flags & IS_SYNTHETIC)
+			if(S.species.flags & IS_SYNTHETIC && dangerous)
 				to_chat(user, "<span class='warning'>Your programming prevents you from operating this device!</span>")
 				return
 

--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -40,7 +40,8 @@
 	activate(user)
 	if((CLUMSY in user.mutations) && prob(50))
 		to_chat(user, "<span class='warning'>Huh? How does this thing work?</span>")
-		spawn(5) prime()
+		spawn(5)
+			prime()
 
 	else
 		user.visible_message("<span class='warning'>[user] primes \a [name]!</span>", \

--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -12,7 +12,7 @@
 	hitsound = 'sound/weapons/smash.ogg'
 	var/active = 0
 	var/det_time = 50
-	var/dangerous = FALSE 	//Does it make a danger overlay for humans? Can synths use it?
+	var/dangerous = TRUE 	//Does it make a danger overlay for humans? Can synths use it?
 	var/arm_sound = 'sound/weapons/armbomb.ogg'
 	var/underslug_launchable = FALSE
 	var/hud_state = "grenade_he"

--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -6,7 +6,7 @@
 	icon_state = "grenade"
 	det_time = 40
 	item_state = "grenade"
-	dangerous = 1
+	dangerous = TRUE
 	underslug_launchable = TRUE
 
 /obj/item/explosive/grenade/frag/prime()
@@ -28,7 +28,7 @@
 	icon_state = "training_grenade"
 	item_state = "grenade"
 	hud_state = "grenade_dummy"
-	dangerous = 0
+	dangerous = FALSE
 
 /obj/item/explosive/grenade/frag/training/prime()
 	spawn(0)

--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -6,7 +6,6 @@
 	icon_state = "grenade"
 	det_time = 40
 	item_state = "grenade"
-	dangerous = TRUE
 	underslug_launchable = TRUE
 
 /obj/item/explosive/grenade/frag/prime()
@@ -119,7 +118,6 @@
 	item_state = "grenade_fire"
 	hud_state = "grenade_fire"
 	flags_equip_slot = SLOT_WAIST
-	dangerous = 1
 	underslug_launchable = TRUE
 
 /obj/item/explosive/grenade/incendiary/prime()
@@ -172,6 +170,7 @@ proc/flame_radius(radius = 1, turf/T, burn_intensity = 25, burn_duration = 25, b
 	item_state = "grenade_smoke"
 	hud_state = "grenade_smoke"
 	underslug_launchable = TRUE
+	dangerous = FALSE
 	var/datum/effect_system/smoke_spread/bad/smoke
 
 /obj/item/explosive/grenade/smokebomb/New()
@@ -193,6 +192,7 @@ proc/flame_radius(radius = 1, turf/T, burn_intensity = 25, burn_duration = 25, b
 	det_time = 20
 	item_state = "grenade_cloak"
 	hud_state = "grenade_hide"
+	dangerous = FALSE
 	underslug_launchable = TRUE
 	var/datum/effect_system/smoke_spread/tactical/smoke
 

--- a/code/game/objects/items/explosives/grenades/spawnergrenade.dm
+++ b/code/game/objects/items/explosives/grenades/spawnergrenade.dm
@@ -7,27 +7,28 @@
 	var/banglet = 0
 	var/spawner_type = null // must be an object path
 	var/deliveryamt = 1 // amount of type to deliver
+	dangerous = TRUE
 
-	prime()													// Prime now just handles the two loops that query for people in lockers and people who can see it.
+/obj/item/explosive/grenade/spawnergrenade/prime()	// Prime now just handles the two loops that query for people in lockers and people who can see it.
 
-		if(spawner_type && deliveryamt)
-			// Make a quick flash
-			var/turf/T = get_turf(src)
-			playsound(T, 'sound/effects/phasein.ogg', 25, 1)
-			for(var/mob/living/carbon/human/M in viewers(T, null))
-				M.flash_eyes(1, TRUE)
+	if(spawner_type && deliveryamt)
+		// Make a quick flash
+		var/turf/T = get_turf(src)
+		playsound(T, 'sound/effects/phasein.ogg', 25, 1)
+		for(var/mob/living/carbon/human/M in viewers(T, null))
+			M.flash_eyes(1, TRUE)
 
-			for(var/i=1, i<=deliveryamt, i++)
-				var/atom/movable/x = new spawner_type
-				x.loc = T
-				if(prob(50))
-					for(var/j = 1, j <= rand(1, 3), j++)
-						step(x, pick(NORTH,SOUTH,EAST,WEST))
+		for(var/i=1, i<=deliveryamt, i++)
+			var/atom/movable/x = new spawner_type
+			x.loc = T
+			if(prob(50))
+				for(var/j = 1, j <= rand(1, 3), j++)
+					step(x, pick(NORTH,SOUTH,EAST,WEST))
 
-				// Spawn some hostile syndicate critters
+			// Spawn some hostile syndicate critters
 
-		qdel(src)
-		return
+	qdel(src)
+	return
 
 /obj/item/explosive/grenade/spawnergrenade/manhacks
 	name = "manhack delivery grenade"

--- a/code/game/objects/items/explosives/grenades/spawnergrenade.dm
+++ b/code/game/objects/items/explosives/grenades/spawnergrenade.dm
@@ -7,7 +7,6 @@
 	var/banglet = 0
 	var/spawner_type = null // must be an object path
 	var/deliveryamt = 1 // amount of type to deliver
-	dangerous = TRUE
 
 /obj/item/explosive/grenade/spawnergrenade/prime()	// Prime now just handles the two loops that query for people in lockers and people who can see it.
 


### PR DESCRIPTION
:cl: Ghommie
bugfix: certain actually meanie grenades such as EMP and spawners are now considered dangerous.
tweak: Synthetics can now use non-dangerous grenades (and dangerous ones if the "allow synthetic gun usage" button is toggled.)
tweak: Synth restrictions now go foul themselves upon round end.
bugfix: the back-end machine (ergo IPCs) race is no more affected by grenade restrictions.
/:cl: