### PR TITLE
Hotfixes Distress

### DIFF
--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -141,7 +141,7 @@
 
 	ticker.mode.on_distress_cooldown = TRUE
 
-	spawn(1 MINUTE)
+	spawn(1 MINUTES)
 		if(length(candidates) < mob_min)
 			message_admins("Aborting distress beacon [name], not enough candidates. Found [length(candidates)].", 1)
 			ticker.mode.waiting_for_candidates = FALSE

--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -164,7 +164,7 @@
 					if(!length(candidates)) //We ran out of candidates.
 						break
 					var/datum/mind/M = pick(candidates) //Get a random candidate, then remove it from the candidates list.
-					if(M.current.stat != DEAD)
+					if(M?.current?.stat != DEAD)
 						candidates -= M //Strip them from the list, they aren't dead anymore.
 						continue
 					if(!istype(M)) //Something went horrifically wrong

--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -47,17 +47,20 @@
 //Randomizes and chooses a call datum.
 /datum/game_mode/proc/get_random_call()
 	var/datum/emergency_call/chosen_call
+	var/list/valid_calls
 
 	for(var/datum/emergency_call/E in all_calls) //Loop through all potential candidates
 		if(probability < 1) //Those that are meant to be admin-only
 			continue
+
+		valid_calls += E
 
 		if(prob(E.probability))
 			chosen_call = E
 			break
 
 	if(!istype(chosen_call))
-		chosen_call = pick(all_calls)
+		chosen_call = pick(valid_calls)
 		
 	return chosen_call
 

--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -167,11 +167,11 @@
 					if(!length(candidates)) //We ran out of candidates.
 						break
 					var/datum/mind/M = pick(candidates) //Get a random candidate, then remove it from the candidates list.
-					if(M?.current?.stat != DEAD)
-						candidates -= M //Strip them from the list, they aren't dead anymore.
-						continue
 					if(!istype(M)) //Something went horrifically wrong
 						candidates -= M
+						continue
+					if(M.current?.stat != DEAD)
+						candidates -= M //Strip them from the list, they aren't dead anymore.
 						continue
 					picked_candidates += M
 					candidates -= M

--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -176,7 +176,6 @@
 				if(length(candidates))
 					for(var/datum/mind/M in candidates)
 						if(M.current)
-							message_admins("ERROR: [M.key] didn't get pick even though they are in candidates.")
 							to_chat(M.current, "<span class='warning'>You didn't get selected to join the distress team. Better luck next time!</span>")
 
 			if(announce)

--- a/code/datums/emergency_calls/xeno.dm
+++ b/code/datums/emergency_calls/xeno.dm
@@ -23,9 +23,7 @@
 	if(!istype(spawn_loc)) 
 		return
 
-	var/mob/living/carbon/Xenomorph/new_xeno = new /mob/living/carbon/Xenomorph/Hunter/mature(spawn_loc)
-
-	new_xeno.key = M.key
+	var/mob/living/carbon/Xenomorph/new_xeno
 
 	if(original)
 		qdel(original)
@@ -35,12 +33,19 @@
 	if(!leader)
 		new_xeno = new /mob/living/carbon/Xenomorph/Ravager(spawn_loc)
 		leader = new_xeno
+		new_xeno.key = M.key
 		return
 
 	if(prob(35))
 		new_xeno = new /mob/living/carbon/Xenomorph/Drone/elder(spawn_loc)
+		new_xeno.key = M.key
 		return
 
 
 	if(prob(35))
 		new_xeno = new /mob/living/carbon/Xenomorph/Spitter/mature(spawn_loc)
+		new_xeno.key = M.key
+		return
+
+	 new_xeno = new /mob/living/carbon/Xenomorph/Hunter/mature(spawn_loc)
+	 new_xeno.key = M.key

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -214,7 +214,7 @@
 
 				distress_cancel = FALSE
 				just_called = TRUE
-				spawn(1 MINUTE)
+				spawn(1 MINUTES)
 					just_called = FALSE
 					cooldown_request = world.time
 					if(distress_cancel || ticker.mode.on_distress_cooldown || ticker.mode.waiting_for_candidates)

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -215,7 +215,7 @@
 				distress_cancel = FALSE
 				just_called = TRUE
 				spawn(1 MINUTE)
-					if(!distress_cancel)
+					if(!distress_cancel || !ticker.mode.on_distress_cooldown)
 						ticker.mode.activate_distress()
 						log_game("A distress beacon requested by [key_name_admin(usr)] was automatically sent due to not receiving an answer within 60 seconds.")
 						message_admins("A distress beacon requested by [key_name_admin(usr)] was automatically sent due to not receiving an answer within 60 seconds.", 1)

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -215,16 +215,16 @@
 				distress_cancel = FALSE
 				just_called = TRUE
 				spawn(1 MINUTE)
-					if(!distress_cancel || !ticker.mode.on_distress_cooldown)
+					just_called = FALSE
+					cooldown_request = world.time
+					if(distress_cancel || ticker.mode.on_distress_cooldown || ticker.mode.waiting_for_candidates)
+						return FALSE
+					else
 						ticker.mode.activate_distress()
+						state = STATE_DISTRESS
 						log_game("A distress beacon requested by [key_name_admin(usr)] was automatically sent due to not receiving an answer within 60 seconds.")
 						message_admins("A distress beacon requested by [key_name_admin(usr)] was automatically sent due to not receiving an answer within 60 seconds.", 1)
-					just_called = FALSE
-
-				cooldown_request = world.time
-				return TRUE
-
-			state = STATE_DISTRESS
+						return TRUE
 
 		if("messagelist")
 			currmsg = 0

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1212,11 +1212,11 @@ var/global/respawntime = 15
 		return
 
 	if(ticker.mode.picked_call)
-		ticker.mode.picked_call = null
 		ticker.mode.picked_call.members = list()
 		ticker.mode.picked_call.candidates = list()
 		ticker.mode.waiting_for_candidates = FALSE
 		ticker.mode.on_distress_cooldown = FALSE
+		ticker.mode.picked_call = null
 	
 
 	var/list/list_of_calls = list()

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2633,5 +2633,5 @@
 			return
 
 		ticker.mode.activate_distress()
-		log_game("[key_name_admin(usr)] has sent a randomized distress beacon, requested by [key_name_admin(ref_person)]")
-		message_admins("[key_name_admin(usr)] has sent a randomized distress beacon, requested by [key_name_admin(ref_person)]", 1)
+		log_game("[key_name_admin(usr)] has sent a randomized distress beacon early, requested by [key_name_admin(ref_person)]")
+		message_admins("[key_name_admin(usr)] has sent a randomized distress beacon early, requested by [key_name_admin(ref_person)]", 1)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2628,6 +2628,10 @@
 
 	if(href_list["distress"]) //Distress Beacon, sends a random distress beacon when pressed
 		var/mob/ref_person = locate(href_list["distress"])
+
+		if(ticker?.mode?.waiting_for_candidates)
+			return
+
 		ticker.mode.activate_distress()
 		log_game("[key_name_admin(usr)] has sent a randomized distress beacon, requested by [key_name_admin(ref_person)]")
 		message_admins("[key_name_admin(usr)] has sent a randomized distress beacon, requested by [key_name_admin(ref_person)]", 1)


### PR DESCRIPTION
:cl: LaKiller8
fix: Fixes a few issues regarding Distress beacons.
/:cl:

Xenos will no longer spawn an empty ones plus the type they roll.
Admins calling distress now will not runtime it if it was called previously.
Added a lot more checks to prevent runtimes in edge cases.

Related issues: #259 #260 