### PR TITLE
Headset Cameras Added

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -220,7 +220,12 @@
 	item_state = "headset"
 	frequency = PUB_FREQ
 	var/headset_hud_on = 1
+	var/obj/machinery/camera/camera
 
+/obj/item/device/radio/headset/almayer/New()
+	..()
+	camera = new /obj/machinery/camera(src)
+	camera.network = list("LEADER")
 
 /obj/item/device/radio/headset/almayer/equipped(mob/living/carbon/human/user, slot)
 	if(slot == WEAR_EAR)
@@ -231,7 +236,8 @@
 			if(user.mind && user.assigned_squad && user.hud_used && user.hud_used.locate_leader)
 				user.hud_used.locate_leader.alpha = 255
 				user.hud_used.locate_leader.mouse_opacity = 1
-
+	if(camera)
+		camera.c_tag = user.name
 	..()
 
 /obj/item/device/radio/headset/almayer/dropped(mob/living/carbon/human/user)
@@ -243,7 +249,10 @@
 			if(user.hud_used && user.hud_used.locate_leader)
 				user.hud_used.locate_leader.alpha = 0
 				user.hud_used.locate_leader.mouse_opacity = 0
+	if(camera)
+		camera.c_tag = "Unknown"
 	..()
+
 
 
 /obj/item/device/radio/headset/almayer/verb/toggle_squadhud()
@@ -263,6 +272,7 @@
 				if(user.mind && user.assigned_squad && user.hud_used && user.hud_used.locate_leader)
 					user.hud_used.locate_leader.alpha = 255
 					user.hud_used.locate_leader.mouse_opacity = 1
+					camera.status = TRUE //Allows us to turn the camera back on.
 			else
 				H.remove_hud_from(usr)
 				if(user.hud_used && user.hud_used.locate_leader)

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -223,7 +223,7 @@
 	var/obj/machinery/camera/camera
 
 /obj/item/device/radio/headset/almayer/New()
-	..()
+	. = ..()
 	camera = new /obj/machinery/camera(src)
 	camera.network = list("LEADER")
 
@@ -238,7 +238,7 @@
 				user.hud_used.locate_leader.mouse_opacity = 1
 	if(camera)
 		camera.c_tag = user.name
-	..()
+	return ..()
 
 /obj/item/device/radio/headset/almayer/dropped(mob/living/carbon/human/user)
 	if(istype(user) && headset_hud_on)
@@ -251,7 +251,7 @@
 				user.hud_used.locate_leader.mouse_opacity = 0
 	if(camera)
 		camera.c_tag = "Unknown"
-	..()
+	return ..()
 
 
 

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -161,13 +161,12 @@
 
 /obj/item/clothing/head/helmet/marine
 	name = "\improper M10 pattern marine helmet"
-	desc = "A standard M10 Pattern Helmet. It reads on the label, 'The difference between an open-casket and closed-casket funeral. Wear on head for best results.'. Contains a small built-in camera."
+	desc = "A standard M10 Pattern Helmet. It reads on the label, 'The difference between an open-casket and closed-casket funeral. Wear on head for best results.'."
 	icon = 'icons/obj/clothing/cm_hats.dmi'
 	sprite_sheet_id = 1
 	icon_state = "helmet"
 	armor = list(melee = 65, bullet = 35, laser = 30, energy = 20, bomb = 25, bio = 0, rad = 0)
 	health = 5
-	var/obj/machinery/camera/camera
 	var/helmet_overlays[]
 	flags_inventory = BLOCKSHARPOBJ
 	flags_inv_hide = HIDEEARS
@@ -203,9 +202,6 @@
 	pockets.max_w_class = 1 //can hold tiny items only, EXCEPT for glasses & metal flask.
 	pockets.bypass_w_limit = list("/obj/item/clothing/glasses", "/obj/item/reagent_container/food/drinks/flask")
 	pockets.max_storage_space = 3
-
-	camera = new /obj/machinery/camera(src)
-	camera.network = list("LEADER")
 
 /obj/item/clothing/head/helmet/marine/attack_hand(mob/user)
 	if (pockets.handle_attack_hand(user))
@@ -251,16 +247,6 @@
 		var/mob/M = loc
 		M.update_inv_head()
 
-/obj/item/clothing/head/helmet/marine/equipped(var/mob/living/carbon/human/mob, slot)
-	if(camera)
-		camera.c_tag = mob.name
-	..()
-
-/obj/item/clothing/head/helmet/marine/dropped(var/mob/living/carbon/human/mob)
-	if(camera)
-		camera.c_tag = "Unknown"
-	..()
-
 
 /obj/item/clothing/head/helmet/marine/proc/add_hugger_damage() //This is called in XenoFacehuggers.dm to first add the overlay and set the var.
 	if(flags_marine_helmet & HELMET_DAMAGE_OVERLAY && !(flags_marine_helmet & HELMET_IS_DAMAGED))
@@ -290,7 +276,7 @@
 
 /obj/item/clothing/head/helmet/marine/leader
 	name = "\improper M11 pattern leader helmet"
-	desc = "A slightly fancier helmet for marine leaders. This one contains a small built-in camera and has cushioning to project your fragile brain."
+	desc = "A slightly fancier helmet for marine leaders. This one has cushioning to project your fragile brain."
 	armor = list(melee = 75, bullet = 45, laser = 40, energy = 40, bomb = 35, bio = 10, rad = 10)
 
 /obj/item/clothing/head/helmet/marine/leader/New(loc,expected_type 		= type,

--- a/code/modules/cm_marines/overwatch.dm
+++ b/code/modules/cm_marines/overwatch.dm
@@ -94,7 +94,7 @@
 						dat += "<A href='?src=\ref[src];operation=change_lead'>\[CHANGE SQUAD LEADER\]</a><BR><BR>"
 					else
 						dat += "<B>Squad Leader:</B> <font color=red>NONE</font> <A href='?src=\ref[src];operation=change_lead'>\[ASSIGN SQUAD LEADER\]</a><BR><BR>"
-		
+
 					dat += "<B>Primary Objective:</B> "
 					if(current_squad.primary_objective)
 						dat += "[current_squad.primary_objective] <a href='?src=\ref[src];operation=set_primary'>\[Set\]</a><br>"
@@ -143,7 +143,7 @@
 						dat += "<span class='warning'>None</span><br>"
 						selected_target = null
 					else
-						dat += "<font color='green'>[selected_target.name]</font><br>"		
+						dat += "<font color='green'>[selected_target.name]</font><br>"
 					dat += "<A href='?src=\ref[src];operation=shootrailgun'>\[FIRE!\]</a><br>"
 					dat += "----------------------<br></body>"
 					dat += "<br><br><a href='?src=\ref[src];operation=refresh'>{Refresh}</a></body>"
@@ -456,7 +456,7 @@
 					dat += "<span class='warning'>None</span><br>"
 					selected_target = null
 				else
-					dat += "<font color='green'>[selected_target.name]</font><br>"		
+					dat += "<font color='green'>[selected_target.name]</font><br>"
 				dat += "<A href='?src=\ref[src];operation=dropbomb'>\[FIRE!\]</a><br>"
 				dat += "----------------------<BR></Body>"
 				dat += "<A href='?src=\ref[src];operation=refresh'>{Refresh}</a></Body>"
@@ -478,13 +478,13 @@
 	cam = null
 	user.reset_view(null)
 
-//returns the helmet camera the human is wearing
+//returns the headset camera the human is wearing
 /obj/machinery/computer/overwatch/proc/get_camera_from_target(cam_target)
 	if(!cam_target)
 		return
 	var/mob/living/carbon/human/H = cam_target
 	if(istype(H) && current_squad)
-		var/obj/item/clothing/head/helmet/marine/helm = H.head
+		var/obj/item/device/radio/headset/almayer/helm = H.wear_ear
 		return helm?.camera
 	var/obj/effect/overlay/temp/laser_target/LT = cam_target
 	if(istype(LT))
@@ -1011,7 +1011,7 @@
 		H.visible_message("[H] deactivates [src]",
 		"You deactivate [src]")
 		H.put_in_active_hand(src)
-	
+
 
 //This is perhaps one of the weirdest places imaginable to put it, but it's a leadership skill, so
 
@@ -1037,7 +1037,7 @@
 		if(choice == "help")
 			to_chat(src, "<span class='notice'><br>Orders give a buff to nearby soldiers for a short period of time, followed by a cooldown, as follows:<br><B>Move</B> - Increased mobility and chance to dodge projectiles.<br><B>Hold</B> - Increased resistance to pain and combat wounds.<br><B>Focus</B> - Increased gun accuracy and effective range.<br></span>")
 			return
-		if(choice == "cancel") 
+		if(choice == "cancel")
 			return
 		command_aura = choice
 	else
@@ -1254,7 +1254,7 @@
 		dat += "<b><font color=red>NONE!</font></b><br>"
 	dat += get_squad_info_ending()
 	return dat
-	
+
 /obj/machinery/computer/overwatch/proc/get_squad_info_ending()
 	var/dat = ""
 	dat += "----------------------<br>"

--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -308,6 +308,13 @@
 				else
 					target.visible_message("<span class='danger'>[src] smashes against [target]'s [W.name] and rips it off!</span>")
 					target.drop_inv_item_on_ground(W)
+					if(ishuman(M)) //Check for camera; if we have one, turn it off.
+						var/mob/living/carbon/human/H = M
+						if(istype(H.wear_ear, /obj/item/device/radio/headset/almayer/marine))
+							var/obj/item/device/radio/headset/almayer/marine/R = H.wear_ear
+							if(R.camera.status)
+								R.camera.status = FALSE //Turn camera off.
+								to_chat(H, "<span class='danger'>Your headset camera flickers off; you'll need to reactivate it by rebooting your headset HUD!<span>")
 				if(W.anti_hug && prob(15)) //15% chance the hugger will go idle after ripping off a helmet. Otherwise it will keep going.
 					W.anti_hug = max(0, --W.anti_hug)
 					GoIdle()

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -120,7 +120,7 @@
 						var/obj/item/device/radio/headset/almayer/marine/R = H.wear_ear
 						if(R.camera.status)
 							R.camera.status = FALSE //Turn camera off.
-							to_chat(pulled, "<span class='danger'>Your headset camera flickers off as you are devoured; you'll need to reactivate it by rebooting your headset HUD!<span>")
+							to_chat(H, "<span class='danger'>Your headset camera flickers off as you are devoured; you'll need to reactivate it by rebooting your headset HUD!<span>")
 
 				return 1
 		if(!(pulled in X.stomach_contents))

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -114,6 +114,14 @@
 				//Then, we place the mob where it ought to be
 				X.stomach_contents.Add(pulled)
 				pulled.forceMove(X)
+				if(ishuman(pulled)) //Check for camera; if we have one, turn it off.
+					var/mob/living/carbon/human/H = pulled
+					if(istype(H.wear_ear, /obj/item/device/radio/headset/almayer/marine))
+						var/obj/item/device/radio/headset/almayer/marine/R = H.wear_ear
+						if(R.camera.status)
+							R.camera.status = FALSE //Turn camera off.
+							to_chat(pulled, "<span class='danger'>Your headset camera flickers off as you are devoured; you'll need to reactivate it by rebooting your headset HUD!<span>")
+
 				return 1
 		if(!(pulled in X.stomach_contents))
 			to_chat(X, "<span class='warning'>You stop devouring \the [pulled]. \He probably tasted gross anyways.</span>")


### PR DESCRIPTION
:cl: Surrealistik
tweak: Headset now has squad cameras instead of helmets. This allows for a greater diversity of fashion choices without crippling SOs/COs.
add: Squad cameras are now disabled by devouring or getting facehugged. A squad camera can be reactivated by resetting the squad HUD using the Toggle Headset HUD verb.
/:cl: