### PR TITLE
Fixes fallen sentry icon state.

### DIFF
--- a/code/modules/cm_marines/equipment/sentries.dm
+++ b/code/modules/cm_marines/equipment/sentries.dm
@@ -716,6 +716,7 @@
 		return
 	else
 		density = initial(density)
+		icon_state = "sentry_base"
 
 	if(rounds)
 		overlays += ammo_full
@@ -1301,6 +1302,7 @@
 		stop_processing()
 		return
 	else
+		icon_state = "minisentry_off"
 		density = initial(density)
 
 	if(!cell)


### PR DESCRIPTION
:cl: LaKiller8
fix: Fixes sentry icon state when you set it straight.
/:cl: