### PR TITLE
Moves the Razor wire assembly to be ontop of all obj's

### DIFF
--- a/code/game/objects/structures/razorwire.dm
+++ b/code/game/objects/structures/razorwire.dm
@@ -6,7 +6,7 @@
 	var/base_icon_state = "barbedwire_x"
 	density = TRUE
 	anchored = TRUE
-	layer = TABLE_LAYER
+	layer = ABOVE_OBJ_LAYER
 	throwpass = TRUE	//You can throw objects over this
 	climbable = TRUE
 	breakable = TRUE


### PR DESCRIPTION
🆑 Hughgent
fix: Moves the layer of Razorwire to be on top of objects.
/🆑 

From:
![razor wire under girder](https://user-images.githubusercontent.com/45076386/50658286-7d988200-0f5e-11e9-92df-be15bc55130f.PNG)
To:
![razor wire over girder](https://user-images.githubusercontent.com/45076386/50658333-a587e580-0f5e-11e9-8643-41bc51320e49.PNG)

Noticed this during the last test on Prison, hiding Razorwire under a destroyed wall seems off.