### PR TITLE
Buffs the CHUNK box

### DIFF
--- a/code/game/objects/items/reagent_containers/food/snacks.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks.dm
@@ -2747,10 +2747,10 @@
 	name = "CHUNK box"
 	desc = "A bar of \"The <b>CHUNK</b>\" brand chocolate. <i>\"The densest chocolate permitted to exist according to federal law. We are legally required to ask you not to use this blunt object for anything other than nutrition.\"</i>"
 	icon_state = "chunk"
-	force = 10 //LEGAL LIMIT OF CHOCOLATE
+	force = 35 //LEGAL LIMIT OF CHOCOLATE
 	bitesize = 3
 	wrapper = /obj/item/trash/chunk
-	list_reagents = list("nutriment" = 5, "coco" = 10)
+	list_reagents = list("nutriment" = 10, "coco" = 10)
 	tastes = list("compressed matter" = 1)
 
 /obj/item/reagent_container/food/snacks/wrapped/barcardine

--- a/code/game/objects/items/reagent_containers/food/snacks.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks.dm
@@ -2750,7 +2750,7 @@
 	force = 35 //LEGAL LIMIT OF CHOCOLATE
 	bitesize = 3
 	wrapper = /obj/item/trash/chunk
-	list_reagents = list("nutriment" = 10, "coco" = 10)
+	list_reagents = list("nutriment" = 5, "coco" = 10)
 	tastes = list("compressed matter" = 1)
 
 /obj/item/reagent_container/food/snacks/wrapped/barcardine


### PR DESCRIPTION
🆑 Plapatin
add:The FDA has loosened restrictions on the legal limit of chocolate density, allowing CHUNK to give you even more chocolate per square nanometer! We still kindly ask you to NOT use our chocolate to bludgeon others.
/🆑

Chunk boxes can't be shoved into a helmet or a boot, so I figured buffing their force would be a good trade-off and more of an incentive to beat xenos to death with a chocolate bar.