### PR TITLE
Fixes Shotgun belt/pouches overloading

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -323,12 +323,10 @@
 				to_chat(user, "<span class='notice'>You start refilling [src] with [M].</span>")
 				if(!do_after(user, 15, TRUE, 5, BUSY_ICON_GENERIC))
 					return
-				var/cont
-				for(var/x = 1 to storage_slots)
-					cont = handle_item_insertion(M.create_handful(), 1, user)
+				for(var/x = 1 to (storage_slots - contents.len))
+					var/cont = handle_item_insertion(M.create_handful(), 1, user)
 					if(!cont)
 						break
-				M.update_icon()
 				playsound(user.loc, "rustle", 15, 1, 6)
 				to_chat(user, "<span class='notice'>You refill [src] with [M].</span>")
 			else

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -500,12 +500,10 @@
 				to_chat(user, "<span class='notice'>You start refilling [src] with [M].</span>")
 				if(!do_after(user, 15, TRUE, 5, BUSY_ICON_GENERIC))
 					return
-				var/cont
-				for(var/x = 1 to storage_slots)
-					cont = handle_item_insertion(M.create_handful(), 1, user)
+				for(var/x = 1 to (storage_slots - contents.len))
+					var/cont = handle_item_insertion(M.create_handful(), 1, user)
 					if(!cont)
 						break
-				M.update_icon()
 				playsound(user.loc, "rustle", 15, 1, 6)
 				to_chat(user, "<span class='notice'>You refill [src] with [M].</span>")
 			else


### PR DESCRIPTION
:cl:
fix: Fixes being able to fill shotgun belt and pouches beyond their storage capacity.
/:cl:

closes #347.

Quoted from storage.dm: 

> handle_item_insertion() handles items being inserted. It does not perform any checks of whether an item can or can't be inserted. That's done by can_be_inserted()

Which in this case we shouldn't use since the box doesn't actually contain the objects but rather spawns them, to point out a flaw of the system.
