### PR TITLE
Quickfixes a few tarps problems.

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -110,7 +110,7 @@ obj/structure/bed/Destroy()
 /obj/structure/bed/MouseDrop_T(atom/dropping, mob/user)
 	if(accepts_bodybag && !buckled_bodybag && !buckled_mob && istype(dropping,/obj/structure/closet/bodybag) && ishuman(user))
 		var/obj/structure/closet/bodybag/B = dropping
-		if(!B.roller_buckled)
+		if(!B.roller_buckled && !B.anchored)
 			do_buckle_bodybag(B, user)
 			return TRUE
 	else

--- a/code/modules/cm_marines/equipment/gear.dm
+++ b/code/modules/cm_marines/equipment/gear.dm
@@ -19,7 +19,11 @@
 	w_class = 3.0
 	unfolded_path = /obj/structure/closet/bodybag/tarp
 
-
+/obj/item/tarp/deploy_bodybag(mob/user, atom/location)
+	if(locate(obj/structure/closet) in location)
+		to_chat(user, "<span class='warning'>\the [src] can't be deployed here.</span>")
+		return
+	return ..()
 
 /obj/item/bodybag/tarp/snow
 	icon = 'icons/obj/bodybag.dmi'

--- a/code/modules/cm_marines/equipment/gear.dm
+++ b/code/modules/cm_marines/equipment/gear.dm
@@ -19,8 +19,8 @@
 	w_class = 3.0
 	unfolded_path = /obj/structure/closet/bodybag/tarp
 
-/obj/item/tarp/deploy_bodybag(mob/user, atom/location)
-	if(locate(obj/structure/closet) in location)
+/obj/item/bodybag/tarp/deploy_bodybag(mob/user, atom/location)
+	if(locate(/obj/structure/closet) in location)
 		to_chat(user, "<span class='warning'>\the [src] can't be deployed here.</span>")
 		return
 	return ..()


### PR DESCRIPTION
:cl:
fix: Tarps can't be deployed on top of closet subtypes anymore, to prevent them from being unretrievable.
fix: Fixes anchored bodybag types (ergo tarps) from being bucklable to roller beds.
/:cl:

fixes #391 
