### PR TITLE
Fixes medevac stretcher "accidental" deconstructions.

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -297,6 +297,7 @@ var/global/list/activated_medevac_stretchers = list()
 	icon = 'icons/obj/rollerbed.dmi'
 	icon_state = "stretcher_down"
 	buckling_y = 6
+	buildstacktype = null
 	foldabletype = /obj/item/roller/medevac
 	base_bed_icon = "stretcher"
 	accepts_bodybag = TRUE


### PR DESCRIPTION
:cl:
fix: The rather special medevac roller beds can't be accidentally deconstructed with a wrench anymore.
/:cl:
