### PR TITLE
Surgical Painkiller Bugfix.

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -148,6 +148,8 @@ proc/do_surgery(mob/living/carbon/M, mob/living/user, obj/item/tool)
 							multipler += 0.25
 						if(PAIN_REDUCTION_VERY_HEAVY to PAIN_REDUCTION_FULL)
 							multipler += 0.40
+						if(PAIN_REDUCTION_FULL to INFINITY)
+							multipler += 0.45
 					if(M.shock_stage > 100) //Being near to unconsious is good in this case
 						multipler += 0.25
 				if(isSynth(M) || isYautja(M)) multipler = 1


### PR DESCRIPTION
:cl: Hughgent
fix: painkiller in excess of oxycodone now actually works for surgery.
/:cl:

[why]: Field surgery always felt off in the sense that there was always a high chance of failure for every step. turns out if a patient had oxycodone **and any other painkiller** in them they would fail every step about 60% of the time. This fixes that, I believe. (failure chance is about 15%)