### PR TITLE
Toggle rail attachment now only toggles the gun in the active hand.

### DIFF
--- a/code/modules/projectiles/updated_projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_helpers.dm
@@ -747,7 +747,12 @@ should be alright.
 	if(!usr)
 		return
 
-	rail?.activate_attachment(src, usr)
+	var/obj/item/weapon/gun/W = usr.get_active_held_item()
+
+	if(!istype(W))
+		return
+
+	W.rail?.activate_attachment(W, usr)
 
 
 /obj/item/weapon/gun/verb/toggle_ammo_hud()


### PR DESCRIPTION
:cl: LaKiller8
fix: Toggle-rail-attachment now only toggles the gun in your active hand.
/:cl: