### PR TITLE
Prevents event roles from showing up in the crew manifest

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -77,7 +77,7 @@
 			squads[name] = squad_name
 			mar[name] = rank
 			department = 1
-		if(!department && !(name in heads))
+		if(!department && !(name in heads) && (real_rank in ROLES_REGULAR_ALL))
 			misc[name] = rank
 	if(heads.len > 0)
 		dat += "<tr><th colspan=3>Command Staff</th></tr>"


### PR DESCRIPTION
:cl: LaKiller8
fix: Event roles no longer show in the crew manifest, potentially ruining the surprise.
/:cl:
Fixes #455