### PR TITLE
Corrects misspelling of 'the'

### DIFF
--- a/code/game/jobs/job/shipside.dm
+++ b/code/game/jobs/job/shipside.dm
@@ -195,7 +195,7 @@ If you are not piloting, there is an autopilot fallback for command, but don't l
 	H.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/marine/tanker(H), SLOT_R_HAND)
 
 /datum/job/command/tank_crew/generate_entry_message(mob/living/carbon/human/H)
-	return {"Your job is to operate and maintain thee ship's armored vehicles.
+	return {"Your job is to operate and maintain the ship's armored vehicles.
 While you are an officer, your authority is limited to your own vehicle, where you have authority over the enlisted personnel. You will need MTs to repair and replace hardpoints."}
 
 


### PR DESCRIPTION
There, now I can say that I've officially contributed to TGMC.

:cl: Trexdude
spellcheck: Changed 'thee' to 'the', making the sentence 'Your job is to operate and maintain the ship's armored vehicles.' grammatically correct.
/:cl:

You're welcome, I'll add my patented ASCII signature later.