### PR TITLE
Fixes Vendor Background Colors

### DIFF
--- a/nano/css/layout_basic.css
+++ b/nano/css/layout_basic.css
@@ -1,5 +1,5 @@
 body {
-    background: #252832 url(uiBasicBackground.png) 50% 0 repeat-x;
+    background: #272727 url(uiBasicBackground.png) 50% 0 repeat-x;
 }
 
 #uiContent {

--- a/nano/css/layout_default.css
+++ b/nano/css/layout_default.css
@@ -1,5 +1,5 @@
 body {
-    background: #252832 url(uiBackground.png) 50% 0 repeat-x;
+    background: #272727 url(uiBackground.png) 50% 0 repeat-x;
 }
 
 #uiWrapper {


### PR DESCRIPTION
:cl: Alterist
fix: Fixes the color of vendor backgrounds, no more jarring grey and blue, rejoice!
/:cl:

I changed the background image from WY to a NT related one a long time ago, finally found the css file that governs the bg color
