### PR TITLE
Huggers render above more things

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -80,7 +80,7 @@
 
 //#define MOB_LAYER 4
 
-#define FACEHUGGER_LAYER 4.1
+#define FACEHUGGER_LAYER 4.05
 
 #define ABOVE_MOB_LAYER 4.1
 

--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -80,6 +80,8 @@
 
 //#define MOB_LAYER 4
 
+#define FACEHUGGER_LAYER 4.1
+
 #define ABOVE_MOB_LAYER 4.1
 
 //#define FLY_LAYER 5

--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -19,7 +19,7 @@
 	flags_atom = NOFLAGS
 	flags_item = NOBLUDGEON
 	throw_range = 1
-	layer = ABOVE_MOB_LAYER
+	layer = FACEHUGGER_LAYER
 
 	var/stat = CONSCIOUS //UNCONSCIOUS is the idle state in this case
 	var/hugger_tick = 0

--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -19,7 +19,7 @@
 	flags_atom = NOFLAGS
 	flags_item = NOBLUDGEON
 	throw_range = 1
-	layer = MOB_LAYER
+	layer = ABOVE_MOB_LAYER
 
 	var/stat = CONSCIOUS //UNCONSCIOUS is the idle state in this case
 	var/hugger_tick = 0


### PR DESCRIPTION
Huggers thrown onto a barricade now render above the barricade, instead of being  hidden. This has the side effect of making huggers always render above humans and xenos.

Closes:#486