### PR TITLE
Removes neurotoxin from defiler's defile sting

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Powers.dm
@@ -2195,10 +2195,9 @@
 
 	face_atom(H)
 	animation_attack_on(H)
-	H.reagents.add_reagent("xeno_toxin", DEFILER_STING_AMOUNT_INITIAL) //15 units transferred initially.
 	H.reagents.add_reagent("xeno_growthtoxin", DEFILER_STING_AMOUNT_INITIAL) //15 units transferred initially.
 	to_chat(H, "<span class='danger'>You feel a tiny prick.</span>")
-	to_chat(src, "<span class='xenowarning'>Your stinger injects your victim with neurotoxin and larval growth serum!</span>")
+	to_chat(src, "<span class='xenowarning'>Your stinger injects your victim with larval growth serum!</span>")
 	playsound(H, 'sound/effects/spray3.ogg', 15, 1)
 	playsound(H, pick('sound/voice/alien_drool1.ogg', 'sound/voice/alien_drool2.ogg'), 15, 1)
 
@@ -2221,7 +2220,6 @@
 			return
 		animation_attack_on(H)
 		playsound(H, pick('sound/voice/alien_drool1.ogg', 'sound/voice/alien_drool2.ogg'), 15, 1)
-		H.reagents.add_reagent("xeno_toxin", DEFILER_STING_AMOUNT_RECURRING) //10 units transferred.
 		H.reagents.add_reagent("xeno_growthtoxin", DEFILER_STING_AMOUNT_RECURRING)
 		overdose_check(H)
 		overdose_check(H, "xeno_growthtoxin")


### PR DESCRIPTION
Defilers already have a melee neurotoxin injection method, and the very large amount injected by defile made it very hard to not lethally overdose humans, especially if they were previously pacified using neurotoxin and still had some inside of themselves.