### PR TITLE
makes tips purple again

### DIFF
--- a/goon/browserassets/css/browserOutput.css
+++ b/goon/browserassets/css/browserOutput.css
@@ -230,6 +230,7 @@ a.popt {text-decoration: none;}
 	{color: #638500;	text-decoration: underline;}
 .motd a, .motd a:link, .motd a:visited, .motd a:active, .motd a:hover
 	{color: #638500;}
+.tip					{color: #a000c4;	font-weight: bold;}
 
 .prefix					{					font-weight: bold;}
 


### PR DESCRIPTION
[why]: # They were purple before, but goonchat made them boring unnoticeable green. Now they are purple again.