### PR TITLE
Added Automag Attachments

### DIFF
--- a/code/modules/projectiles/updated_projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/pistols.dm
@@ -314,6 +314,7 @@
 	force = 10
 	flags_gun_features = GUN_AUTO_EJECTOR|GUN_CAN_POINTBLANK
 	attachable_offset = list("muzzle_x" = 27, "muzzle_y" = 20,"rail_x" = 8, "rail_y" = 22, "under_x" = 16, "under_y" = 15, "stock_x" = 16, "stock_y" = 15)
+	attachable_offset = list("muzzle_x" = 27, "muzzle_y" = 20,"rail_x" = 8, "rail_y" = 22, "under_x" = 18, "under_y" = 15, "stock_x" = 16, "stock_y" = 15)
 
 /obj/item/weapon/gun/pistol/highpower/set_gun_config_values()
 	fire_delay = CONFIG_GET(number/combat_define/high_fire_delay) * 2

--- a/code/modules/projectiles/updated_projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/pistols.dm
@@ -312,7 +312,6 @@
 	fire_sound = 'sound/weapons/gun_kt42.ogg'
 	current_mag = /obj/item/ammo_magazine/pistol/highpower
 	force = 10
-	attachable_allowed = list()
 	flags_gun_features = GUN_AUTO_EJECTOR|GUN_CAN_POINTBLANK
 	attachable_offset = list("muzzle_x" = 27, "muzzle_y" = 20,"rail_x" = 8, "rail_y" = 22, "under_x" = 16, "under_y" = 15, "stock_x" = 16, "stock_y" = 15)
 

--- a/code/modules/projectiles/updated_projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/pistols.dm
@@ -313,7 +313,6 @@
 	current_mag = /obj/item/ammo_magazine/pistol/highpower
 	force = 10
 	flags_gun_features = GUN_AUTO_EJECTOR|GUN_CAN_POINTBLANK
-	attachable_offset = list("muzzle_x" = 27, "muzzle_y" = 20,"rail_x" = 8, "rail_y" = 22, "under_x" = 16, "under_y" = 15, "stock_x" = 16, "stock_y" = 15)
 	attachable_offset = list("muzzle_x" = 27, "muzzle_y" = 20,"rail_x" = 8, "rail_y" = 22, "under_x" = 18, "under_y" = 15, "stock_x" = 16, "stock_y" = 15)
 
 /obj/item/weapon/gun/pistol/highpower/set_gun_config_values()


### PR DESCRIPTION
Highpower Automag (9mm) can now take all default pistol attachments

:cl: 

tweak: Made Highpower Automag(9mm) able to take every attachment a standard M4A3 can take

/:cl:

[why]: Enabling of attachments should allow more usability of Highpowers looted planetside. Will potentially assist survivors if they can find an armory that has attachments, but mostly will benefit Marines dissatisfied with standard sidearm options. 