### PR TITLE
Medical machinery now properly checks if the occupant is present.

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -364,9 +364,10 @@
 		toggle_filter()
 	if(!occupant)
 		return
+	if(occupant in contents)
+		occupant.forceMove(loc)
 	occupant.in_stasis = null //disable stasis
 	stasis = FALSE
-	occupant.forceMove(loc)
 	occupant = null
 	stop_processing()
 	connected.stop_processing()

--- a/code/game/machinery/autodoc.dm
+++ b/code/game/machinery/autodoc.dm
@@ -705,7 +705,8 @@
 /obj/machinery/autodoc/proc/go_out(notice_code = FALSE)
 	if(!occupant)
 		return
-	occupant.forceMove(loc)
+	if(occupant in contents)
+		occupant.forceMove(loc)
 	if(connected.release_notice) //If auto-release notices are on as they should be, let the doctors know what's up
 		var/reason = "Reason for discharge: Procedural completion."
 		switch(notice_code)

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -336,7 +336,8 @@
 	if (occupant.client)
 		occupant.client.eye = occupant.client.mob
 		occupant.client.perspective = MOB_PERSPECTIVE
-	occupant.loc = get_step(loc, SOUTH)	//this doesn't account for walls or anything, but i don't forsee that being a problem.
+	if(occupant in contents)
+		occupant.loc = get_step(loc, SOUTH)	//this doesn't account for walls or anything, but i don't forsee that being a problem.
 	if (occupant.bodytemperature < 261 && occupant.bodytemperature >= 70) //Patch by Aranclanos to stop people from taking burn damage after being ejected
 		occupant.bodytemperature = 261									  // Changed to 70 from 140 by Zuhayr due to reoccurance of bug.
 	if(auto_eject) //Turn off and announce if auto-ejected because patient is recovered or dead.


### PR DESCRIPTION
:cl: LaKiller8
fix: Autodocs and similar no longer magically teleport you back.
/:cl: