### PR TITLE
Regurgitate ability now deals an one tick knock down

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Abilities.dm
@@ -93,6 +93,7 @@
 			if(M.loc != X)
 				continue
 			M.forceMove(X.loc)
+			M.KnockDown(1)
 
 		X.visible_message("<span class='xenowarning'>\The [X] hurls out the contents of their stomach!</span>", \
 		"<span class='xenowarning'>You hurl out the contents of your stomach!</span>", null, 5)


### PR DESCRIPTION
:cl:
balance: The regurgitate ability now deals a very brief knock down to the victim.
/:cl:

Reason simply being someone complaining they get promptly buckshotted to death the moment they regurgitate a host. I'll replace the knock down with a stun if this proves to be too much.
