### PR TITLE
MAC-15 Suppressor Fix

### DIFF
--- a/code/modules/projectiles/updated_projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/smgs.dm
@@ -249,7 +249,7 @@
 	fire_sound = 'sound/weapons/uzi.ogg'
 	current_mag = /obj/item/ammo_magazine/smg/uzi
 	flags_gun_features = GUN_AUTO_EJECTOR|GUN_CAN_POINTBLANK
-	attachable_offset = list("muzzle_x" = 30, "muzzle_y" = 21,"rail_x" = 11, "rail_y" = 22, "under_x" = 22, "under_y" = 16, "stock_x" = 22, "stock_y" = 16)
+	attachable_offset = list("muzzle_x" = 30, "muzzle_y" = 20,"rail_x" = 11, "rail_y" = 22, "under_x" = 22, "under_y" = 16, "stock_x" = 22, "stock_y" = 16)
 
 /obj/item/weapon/gun/smg/uzi/set_gun_config_values()
 	fire_delay = CONFIG_GET(number/combat_define/med_fire_delay)

--- a/code/modules/projectiles/updated_projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/smgs.dm
@@ -249,7 +249,7 @@
 	fire_sound = 'sound/weapons/uzi.ogg'
 	current_mag = /obj/item/ammo_magazine/smg/uzi
 	flags_gun_features = GUN_AUTO_EJECTOR|GUN_CAN_POINTBLANK
-	attachable_offset = list("muzzle_x" = 32, "muzzle_y" = 19,"rail_x" = 11, "rail_y" = 22, "under_x" = 22, "under_y" = 16, "stock_x" = 22, "stock_y" = 16)
+	attachable_offset = list("muzzle_x" = 30, "muzzle_y" = 21,"rail_x" = 11, "rail_y" = 22, "under_x" = 22, "under_y" = 16, "stock_x" = 22, "stock_y" = 16)
 
 /obj/item/weapon/gun/smg/uzi/set_gun_config_values()
 	fire_delay = CONFIG_GET(number/combat_define/med_fire_delay)


### PR DESCRIPTION
:cl: 
fix: Fixed attachable_offset for the MAC-15 so the suppressor is no longer mis-aligned
/:cl:

Before and after comparison: 
https://i.gyazo.com/b4849ca79566a0bf3e79ff5888c9a253.png
