### PR TITLE
adds semicolon to squad headset desc

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -336,92 +336,92 @@
 
 /obj/item/device/radio/headset/almayer/marine/alpha
 	name = "marine alpha radio headset"
-	desc = "This is used by alpha squad members. Channels are as follows: :z - general chat."
+	desc = "This is used by alpha squad members. Channels are as follows: ; - Alpha squad :z - general chat."
 	icon_state = "sec_headset"
 	frequency = ALPHA_FREQ //default frequency is alpha squad channel, not PUB_FREQ
 
 /obj/item/device/radio/headset/almayer/marine/alpha/lead
 	name = "marine alpha leader radio headset"
-	desc = "This is used by the marine alpha squad leader. Channels are as follows: :v - marine command, :z - general chat."
+	desc = "This is used by the marine alpha squad leader. Channels are as follows: ; - Alpha squad :v - marine command, :z - general chat."
 	keyslot2 = new /obj/item/device/encryptionkey/squadlead
 
 /obj/item/device/radio/headset/almayer/marine/alpha/engi
 	name = "marine alpha engineer radio headset"
-	desc = "This is used by the marine alpha combat engineers. Channels are as follows: :e - engineering, :z - general chat."
+	desc = "This is used by the marine alpha combat engineers. Channels are as follows: ; - Alpha squad :e - engineering, :z - general chat."
 	keyslot2 = new /obj/item/device/encryptionkey/engi
 
 /obj/item/device/radio/headset/almayer/marine/alpha/med
 	name = "marine alpha medic radio headset"
-	desc = "This is used by the marine alpha combat medics. Channels are as follows: :m - medical, :z - general chat."
+	desc = "This is used by the marine alpha combat medics. Channels are as follows: ; - Alpha Squad :m - medical, :z - general chat."
 	keyslot2 = new /obj/item/device/encryptionkey/med
 
 
 
 /obj/item/device/radio/headset/almayer/marine/bravo
 	name = "marine bravo radio headset"
-	desc = "This is used by bravo squad members. Channels are as follows: :z - general chat."
+	desc = "This is used by bravo squad members. Channels are as follows: ; - Bravo Squad :z - general chat."
 	icon_state = "eng_headset"
 	frequency = BRAVO_FREQ
 
 /obj/item/device/radio/headset/almayer/marine/bravo/lead
 	name = "marine bravo leader radio headset"
-	desc = "This is used by the marine bravo squad leader. Channels are as follows: :v - marine command, :z - general chat."
+	desc = "This is used by the marine bravo squad leader. Channels are as follows: ; - Bravo Squad :v - marine command, :z - general chat."
 	keyslot2 = new /obj/item/device/encryptionkey/squadlead
 
 /obj/item/device/radio/headset/almayer/marine/bravo/engi
 	name = "marine bravo engineer radio headset"
-	desc = "This is used by the marine bravo combat engineers. Channels are as follows: :e - engineering, :z - general chat."
+	desc = "This is used by the marine bravo combat engineers. Channels are as follows: ; - Bravo Squad :e - engineering, :z - general chat."
 	keyslot2 = new /obj/item/device/encryptionkey/engi
 
 /obj/item/device/radio/headset/almayer/marine/bravo/med
 	name = "marine bravo medic radio headset"
-	desc = "This is used by the marine bravo combat medics. Channels are as follows: :m - medical, :z - general chat."
+	desc = "This is used by the marine bravo combat medics. Channels are as follows: ; - Bravo Squad :m - medical, :z - general chat."
 	keyslot2 = new /obj/item/device/encryptionkey/med
 
 
 
 /obj/item/device/radio/headset/almayer/marine/charlie
 	name = "marine charlie radio headset"
-	desc = "This is used by charlie squad members. Channels are as follows: :z - general chat."
+	desc = "This is used by charlie squad members. Channels are as follows: ; - Charlie Squad :z - general chat."
 	icon_state = "charlie_headset"
 	frequency = CHARLIE_FREQ
 
 /obj/item/device/radio/headset/almayer/marine/charlie/lead
 	name = "marine charlie leader radio headset"
-	desc = "This is used by the marine charlie squad leader. Channels are as follows: :v - marine command, :z - general chat."
+	desc = "This is used by the marine charlie squad leader. Channels are as follows: ; - Charlie Squad :v - marine command, :z - general chat."
 	keyslot2 = new /obj/item/device/encryptionkey/squadlead
 
 /obj/item/device/radio/headset/almayer/marine/charlie/engi
 	name = "marine charlie engineer radio headset"
-	desc = "This is used by the marine charlie combat engineers. Channels are as follows: :e - engineering, :z - general chat."
+	desc = "This is used by the marine charlie combat engineers. Channels are as follows: ; - Charlie Squad :e - engineering, :z - general chat."
 	keyslot2 = new /obj/item/device/encryptionkey/engi
 
 /obj/item/device/radio/headset/almayer/marine/charlie/med
 	name = "marine charlie medic radio headset"
-	desc = "This is used by the marine charlie combat medics. Channels are as follows: :m - medical, :z - general chat."
+	desc = "This is used by the marine charlie combat medics. Channels are as follows: ; - Charlie Squad :m - medical, :z - general chat."
 	keyslot2 = new /obj/item/device/encryptionkey/med
 
 
 
 /obj/item/device/radio/headset/almayer/marine/delta
 	name = "marine delta radio headset"
-	desc = "This is used by delta squad members. Channels are as follows: :z - general chat."
+	desc = "This is used by delta squad members. Channels are as follows: ; - Delta Squad :z - general chat."
 	icon_state = "com_headset"
 	frequency = DELTA_FREQ
 
 /obj/item/device/radio/headset/almayer/marine/delta/lead
 	name = "marine delta leader radio headset"
-	desc = "This is used by the marine delta squad leader. Channels are as follows: :v - marine command, :z - general chat."
+	desc = "This is used by the marine delta squad leader. Channels are as follows: ; - Delta Squad :v - marine command, :z - general chat."
 	keyslot2 = new /obj/item/device/encryptionkey/squadlead
 
 /obj/item/device/radio/headset/almayer/marine/delta/engi
 	name = "marine delta engineer radio headset"
-	desc = "This is used by the marine delta combat engineers. Channels are as follows: :e - engineering, :z - general chat."
+	desc = "This is used by the marine delta combat engineers. Channels are as follows: ; - Delta Squad :e - engineering, :z - general chat."
 	keyslot2 = new /obj/item/device/encryptionkey/engi
 
 /obj/item/device/radio/headset/almayer/marine/delta/med
 	name = "marine delta medic radio headset"
-	desc = "This is used by the marine delta combat medics. Channels are as follows: :m - medical, :z - general chat."
+	desc = "This is used by the marine delta combat medics. Channels are as follows: ; - Delta Squad :m - medical, :z - general chat."
 	keyslot2 = new /obj/item/device/encryptionkey/med
 
 


### PR DESCRIPTION
[why]: adds the semicolon squad to the description for squad headsets.