### PR TITLE
ups grey medical belt size

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -101,7 +101,7 @@
 	item_state = "medical"
 	storage_slots = 14 //can hold 2 "rows" of very limited medical equipment and ammo.
 	max_w_class = 3
-	max_storage_space = 28
+	max_storage_space = 29
 
 	can_hold = list(
 		"/obj/item/device/healthanalyzer",
@@ -145,6 +145,7 @@
 	new /obj/item/storage/pill_bottle/tramadol(src)
 	new /obj/item/storage/pill_bottle/peridaxon(src)
 	new /obj/item/storage/pill_bottle/quickclot(src)
+	new /obj/item/device/healthanalyzer(src)
 
 
 /obj/item/storage/belt/combatLifesaver


### PR DESCRIPTION
:cl: Hughgent
tweak: grey medical belt can now hold slightly more.
tweak: grey medical belt now starts with a HF2.
/:cl:

[why]: was always mildly annoyed that the belt was yellow when there was a defib in it. Also annoyed that I had to remember to get a HF2.

![image](https://user-images.githubusercontent.com/45076386/52441344-f5217a00-2ae5-11e9-9b05-31fd86f5877e.png)

This can insert and remove without issue.