### PR TITLE
Fixes the unilateral muhrin armor lamp overlay.

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -727,7 +727,7 @@ var/global/list/damage_icon_parts = list()
 				for(var/i in marine_armor.armor_overlays)
 					I = marine_armor.armor_overlays[i]
 					if(I)
-						I = image(I.icon,src,I.icon_state)
+						I = image('icons/mob/suit_1.dmi',src,I.icon_state)
 						standing.overlays += I
 
 		if(wear_suit.blood_DNA)


### PR DESCRIPTION
:cl:
fix: Fixes the on-mob marine armor lamp overlay only having one direction.
/:cl:

Old issue resurfacing yet again. Closes #603.
