### PR TITLE
Fixes instructions unclear for barrel crates.

### DIFF
--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -20,7 +20,7 @@
 
 /obj/structure/largecrate/attack_hand(mob/user as mob)
 	to_chat(user, "<span class='notice'>You need a crowbar to pry this open!</span>")
-	return
+	return FALSE
 
 /obj/structure/largecrate/attackby(obj/item/W as obj, mob/user as mob)
 	if(iscrowbar(W))
@@ -162,6 +162,7 @@
 
 /obj/structure/largecrate/random/barrel/attack_hand(mob/user)
 	to_chat(user, "<span class='notice'>You need a blowtorch to weld this open!</span>")
+	return FALSE
 
 /obj/structure/largecrate/random/barrel
 	name = "blue barrel"
@@ -216,6 +217,7 @@
 
 /obj/structure/largecrate/random/barrel/attack_hand(mob/user)
 	to_chat(user, "<span class='notice'>You need something sharp to cut off the straps.</span>")
+	return FALSE
 
 /obj/structure/largecrate/guns
 	name = "\improper TGMC firearms crate (x3)"

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -162,7 +162,6 @@
 
 /obj/structure/largecrate/random/barrel/attack_hand(mob/user)
 	to_chat(user, "<span class='notice'>You need a blowtorch to weld this open!</span>")
-	return
 
 /obj/structure/largecrate/random/barrel
 	name = "blue barrel"
@@ -202,12 +201,10 @@
 
 /obj/structure/largecrate/random/secure/attackby(var/obj/item/W as obj, var/mob/user as mob)
 	if (!strapped)
-		..()
-		return
+		return ..()
 
 	if (!W.sharp)
-		to_chat(user, "<span class='notice'>You need something sharp to cut off the straps.</span>")
-		return
+		return attack_hand(user)
 
 	to_chat(user, "<span class='notice'>You begin to cut the straps off \the [src]...</span>")
 
@@ -216,6 +213,9 @@
 		to_chat(user, "<span class='notice'>You cut the straps away.</span>")
 		icon_state = "secure_crate"
 		strapped = 0
+
+/obj/structure/largecrate/random/barrel/attack_hand(mob/user)
+	to_chat(user, "<span class='notice'>You need something sharp to cut off the straps.</span>")
 
 /obj/structure/largecrate/guns
 	name = "\improper TGMC firearms crate (x3)"

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -160,6 +160,10 @@
 	else
 		return attack_hand(user)
 
+/obj/structure/largecrate/random/barrel/attack_hand(mob/user)
+	to_chat(user, "<span class='notice'>You need a blowtorch to weld this open!</span>")
+	return
+
 /obj/structure/largecrate/random/barrel
 	name = "blue barrel"
 	desc = "A blue storage barrel"


### PR DESCRIPTION
:cl:
fix: clicking a red barrel/ without a blowtorch in the active hand won't give off wrong instructions anymore.
/:cl:

Closes #594.