### PR TITLE
Fixes crusher/defender jolly co-op.

### DIFF
--- a/code/game/objects/structures/razorwire.dm
+++ b/code/game/objects/structures/razorwire.dm
@@ -53,7 +53,7 @@
 	M.entangle_delay = world.time + duration
 	M.visible_message("<span class='danger'>[M] gets entangled in the barbed wire!</span>",
 	"<span class='danger'>You get entangled in the barbed wire! Resist to untangle yourself after [(M.entangle_delay - world.time) * 0.1] seconds!</span>", null, 5)
-	M.frozen += 1
+	M.set_frozen(TRUE)
 	entangled_list += M //Add the entangled person to the trapped list.
 	M.entangled_by = src
 
@@ -66,7 +66,7 @@
 	entangled_list -= M
 	M.entangled_by = null
 	M.entangle_delay = null
-	M.frozen = FALSE
+	M.set_frozen(FALSE)
 	M.update_canmove()
 	M.apply_damage(rand(RAZORWIRE_BASE_DAMAGE * 0.8, RAZORWIRE_BASE_DAMAGE * 1.2), BRUTE, def_zone, armor_block, null, 1) //Apply damage as we tear free
 	M.next_move_slowdown += RAZORWIRE_SLOWDOWN //big slowdown
@@ -81,7 +81,7 @@
 /obj/structure/razorwire/Destroy()
 	. = ..()
 	for(var/mob/living/M in entangled_list)
-		M.frozen = FALSE
+		M.set_frozen(FALSE)
 		M.update_canmove()
 		if(M.entangled_by == src)
 			M.entangled_by = null

--- a/code/modules/mob/living/carbon/xenomorph/Powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Powers.dm
@@ -869,7 +869,7 @@
 			to_chat(src, "<span class='xenowarning'>You tuck yourself into a defensive stance.</span>")
 		armor_bonus += xeno_caste.fortify_armor
 		xeno_explosion_resistance = 3
-		frozen = TRUE
+		set_frozen(TRUE)
 		anchored = TRUE
 		update_canmove()
 		update_icons()
@@ -884,8 +884,8 @@
 	to_chat(src, "<span class='xenowarning'>You resume your normal stance.</span>")
 	armor_bonus -= xeno_caste.fortify_armor
 	xeno_explosion_resistance = 0
-	frozen = FALSE
 	fortify = FALSE
+	set_frozen(FALSE)
 	anchored = FALSE
 	playsound(loc, 'sound/effects/stonedoor_openclose.ogg', 30, 1)
 	update_canmove()
@@ -910,7 +910,7 @@
 	if (burrow)
 		// TODO Make immune to all damage here.
 		to_chat(src, "<span class='xenowarning'>You burrow yourself into the ground.</span>")
-		frozen = 1
+		set_frozen(TRUE)
 		invisibility = 101
 		anchored = 1
 		density = 0
@@ -936,7 +936,7 @@
 /mob/living/carbon/Xenomorph/proc/burrow_off()
 
 	to_chat(src, "<span class='notice'>You resurface.</span>")
-	frozen = 0
+	set_frozen(FALSE)
 	invisibility = 0
 	anchored = 0
 	density = 1
@@ -1691,15 +1691,6 @@
 	if(M.mob_size >= MOB_SIZE_BIG) //We can't fling big aliens/mobs
 		to_chat(src, "<span class='xenowarning'>[M] is too large to fling!</span>")
 		return
-	if(M.anchored)
-		visible_message("<span class='xenowarning'>[src] tries to fling [M] to no avail!</span>","<span class='xenowarning'>You try to fling [M] but [M.p_they()] happens to be stuck in place!</span>", null, 4)
-		cresttoss_used = TRUE
-		icon_state = "Crusher Charging"  //Momentarily lower the crest for visual effect
-		use_plasma(CRUSHER_CRESTTOSS_COST/2)
-		playsound(src, 'sound/weapons/alien_claw_swipe.ogg')
-		addtimer(CALLBACK(src, .cresttoss_cooldown), CRUSHER_CRESTTOSS_COOLDOWN)
-		addtimer(CALLBACK(src, .reset_intent_icon_state), 3)
-		return
 
 	face_atom(M) //Face towards the target so we don't look silly
 
@@ -1744,18 +1735,16 @@
 
 	M.throw_at(T, toss_distance, 1, src)
 
+	var/mob/living/carbon/Xenomorph/X = M
 	//Handle the damage
-	if(!isxeno(M)) //Friendly xenos don't take damage.
+	if(!istype(X) || hivenumber != X.hivenumber) //Friendly xenos don't take damage.
 		var/damage = toss_distance * 5
 		if(frenzy_aura)
 			damage *= (1 + round(frenzy_aura * 0.1,0.01)) //+10% damage per level of frenzy
 		var/armor_block = M.run_armor_check("chest", "melee")
+		M.take_overall_damage(rand(damage * 0.75, damage * 1.25) * 0.5, armor_block) //Armour functions against this.
 		if(ishuman(M))
-			var/mob/living/carbon/human/H = M
-			H.take_overall_damage(rand(damage * 0.75,damage * 1.25) * 0.5, armor_block) //Armour functions against this.
-		else
-			M.take_overall_damage(rand(damage * 0.75,damage * 1.25) * 0.5, armor_block) //Armour functions against this.
-		M.apply_damage(damage, HALLOSS) //...But decent armour ignoring Halloss
+			M.apply_damage(damage, HALLOSS) //...But decent armour ignoring Halloss
 		shake_camera(M, 2, 2)
 		playsound(M,pick('sound/weapons/alien_claw_block.ogg','sound/weapons/alien_bite2.ogg'), 50, 1)
 		M.KnockDown(1, 1)

--- a/code/modules/mob/living/carbon/xenomorph/Powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Powers.dm
@@ -1691,6 +1691,15 @@
 	if(M.mob_size >= MOB_SIZE_BIG) //We can't fling big aliens/mobs
 		to_chat(src, "<span class='xenowarning'>[M] is too large to fling!</span>")
 		return
+	if(M.anchored)
+		visible_message("<span class='xenowarning'>[src] tries to fling [M] to no avail!</span>","<span class='xenowarning'>You try to fling [M] but [M.p_they()] happens to be stuck in place!</span>", null, 4)
+		cresttoss_used = TRUE
+		icon_state = "Crusher Charging"  //Momentarily lower the crest for visual effect
+		use_plasma(CRUSHER_CRESTTOSS_COST/2)
+		playsound(src, 'sound/weapons/alien_claw_swipe.ogg')
+		addtimer(CALLBACK(src, .cresttoss_cooldown), CRUSHER_CRESTTOSS_COOLDOWN)
+		addtimer(CALLBACK(src, .reset_intent_icon_state), 3)
+		return
 
 	face_atom(M) //Face towards the target so we don't look silly
 
@@ -1699,7 +1708,7 @@
 	var/turf/T = loc
 	var/turf/temp = loc
 	if(a_intent == INTENT_HARM) //If we use the ability on hurt intent, we throw them in front; otherwise we throw them behind.
-		for (var/x = 0, x < toss_distance, x++)
+		for (var/x in 1 to toss_distance)
 			temp = get_step(T, facing)
 			if (!temp)
 				break

--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -313,12 +313,22 @@
 	return ..() //Do the parent otherwise, for turfs.
 
 /mob/living/carbon/Xenomorph/proc/reset_movement()
-	frozen = FALSE
+	set_frozen(FALSE)
 	update_canmove()
 
 /mob/living/carbon/Xenomorph/proc/stop_movement()
-	frozen = TRUE
+	set_frozen(TRUE)
 	update_canmove()
+
+/mob/living/carbon/Xenomorph/set_frozen(freeze = TRUE)
+	if(fortify && !freeze)
+		return FALSE
+	return ..()
+
+/mob/living/carbon/Xenomorph/Queen/set_frozen(freeze = TRUE)
+	if(ovipositor && !freeze)
+		return FALSE
+	return ..()
 
 //Bleuugh
 /mob/living/carbon/Xenomorph/proc/empty_gut()

--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -325,11 +325,6 @@
 		return FALSE
 	return ..()
 
-/mob/living/carbon/Xenomorph/Queen/set_frozen(freeze = TRUE)
-	if(ovipositor && !freeze)
-		return FALSE
-	return ..()
-
 //Bleuugh
 /mob/living/carbon/Xenomorph/proc/empty_gut()
 	if(stomach_contents.len)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -445,10 +445,10 @@
 	if(!target || !src)	return 0
 	if(pulling) stop_pulling() //being thrown breaks pulls.
 	if(pulledby) pulledby.stop_pulling()
-	frozen = TRUE //can't move while being thrown
+	set_frozen(TRUE) //can't move while being thrown
 	update_canmove()
 	. = ..()
-	frozen = FALSE
+	set_frozen(FALSE)
 	update_canmove()
 
 //to make an attack sprite appear on top of the target atom.

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -77,11 +77,11 @@
 	var/specset //Simple way to track which set has the player taken
 
 	var/overeatduration = 0		// How long this guy is overeating //Carbon
-	var/knocked_out = 0.0
-	var/stunned = 0.0
-	var/frozen = 0.0
-	var/knocked_down = 0.0
-	var/losebreath = 0.0//Carbon
+	var/knocked_out = 0.
+	var/stunned = 0
+	var/frozen = 0
+	var/knocked_down = 0
+	var/losebreath = 0 //Carbon
 	var/shakecamera = 0
 	var/a_intent = INTENT_HELP //Living
 	var/m_intent = MOVE_INTENT_RUN//Living

--- a/code/modules/mob/mob_status_procs.dm
+++ b/code/modules/mob/mob_status_procs.dm
@@ -69,6 +69,10 @@
 	resting = max(max(resting,amount),0)
 	return
 
+/mob/proc/set_frozen(freeze = TRUE)
+	frozen = freeze
+	return TRUE
+
 /mob/proc/SetResting(amount)
 	resting = max(amount,0)
 	return


### PR DESCRIPTION
:cl:
fix: Defender's fortify mode mobility shouldn't no more reset after being thrown around by a Crusher's crest toss.
fix: Crusher's crest toss should now properly damage enemy hives' xenos now.
/:cl:

Closes #595.
