### PR TITLE
Set-transfer-amount automatically selects the active hand.

### DIFF
--- a/code/game/objects/items/reagent_containers/food/cans.dm
+++ b/code/game/objects/items/reagent_containers/food/cans.dm
@@ -11,11 +11,10 @@
 		canopened = TRUE
 		container_type = OPENCONTAINER_NOUNIT
 		return
-	else
-		var/obj/item/reagent_container/H = usr.get_active_held_item()
-		var/N = input("Amount per transfer from this:","[H]") as null|anything in H.possible_transfer_amounts
-		if (N)
-			H.amount_per_transfer_from_this = N
+	var/obj/item/reagent_container/H = usr.get_active_held_item()
+	var/N = input("Amount per transfer from this:","[H]") as null|anything in H.possible_transfer_amounts
+	if (N)
+		H.amount_per_transfer_from_this = N
 
 /obj/item/reagent_container/food/drinks/cans/attack(mob/M as mob, mob/user as mob, def_zone)
 	if (canopened == FALSE)

--- a/code/game/objects/items/reagent_containers/food/cans.dm
+++ b/code/game/objects/items/reagent_containers/food/cans.dm
@@ -11,6 +11,11 @@
 		canopened = TRUE
 		container_type = OPENCONTAINER_NOUNIT
 		return
+	else
+		var/obj/item/reagent_container/H = usr.get_active_held_item()
+		var/N = input("Amount per transfer from this:","[H]") as null|anything in H.possible_transfer_amounts
+		if (N)
+			H.amount_per_transfer_from_this = N
 
 /obj/item/reagent_container/food/drinks/cans/attack(mob/M as mob, mob/user as mob, def_zone)
 	if (canopened == FALSE)

--- a/code/game/objects/items/reagent_containers/food/drinks.dm
+++ b/code/game/objects/items/reagent_containers/food/drinks.dm
@@ -15,9 +15,6 @@
 	if (gulp_size < 5) gulp_size = 5
 	else gulp_size = max(round(reagents.total_volume / 5), 5)
 
-/obj/item/reagent_container/food/drinks/attack_self(mob/user as mob)
-	return
-
 /obj/item/reagent_container/food/drinks/attack(mob/M as mob, mob/user as mob, def_zone)
 	var/datum/reagents/R = src.reagents
 	var/fillevel = gulp_size

--- a/code/game/objects/items/reagent_containers/glass.dm
+++ b/code/game/objects/items/reagent_containers/glass.dm
@@ -26,8 +26,9 @@
 		if(!is_open_container())
 			to_chat(user, "<span class='info'>An airtight lid seals it completely.</span>")
 
-/obj/item/reagent_container/glass/attack_self()
-	..()
+/obj/item/reagent_container/glass/verb/attach_lid()
+	set name = "Attach/Detach lid"
+	set category = "Object"
 	if(is_open_container())
 		to_chat(usr, "<span class='notice'>You put the lid on \the [src].</span>")
 		container_type ^= OPENCONTAINER

--- a/code/game/objects/items/reagent_containers/reagent_container.dm
+++ b/code/game/objects/items/reagent_containers/reagent_container.dm
@@ -15,15 +15,22 @@
 /obj/item/reagent_container/verb/set_APTFT() //set amount_per_transfer_from_this
 	set name = "Set transfer amount"
 	set category = "Object"
-	set src in range(0)
-	var/N = input("Amount per transfer from this:","[src]") as null|anything in possible_transfer_amounts
+	var/obj/item/reagent_container/H = usr.get_active_held_item()
+	var/N = input("Amount per transfer from this:","[H]") as null|anything in possible_transfer_amounts
 	if (N)
 		amount_per_transfer_from_this = N
+
+/obj/item/reagent_container/verb/set_APTFT_60() //set amount_per_transfer_from_this
+	set name = "Set transfer amount 60"
+	set category = "Object"
+	usr.get_active_held_item()
+	amount_per_transfer_from_this = 60
 
 /obj/item/reagent_container/New()
 	. = ..()
 	if (!possible_transfer_amounts)
 		verbs -= /obj/item/reagent_container/verb/set_APTFT //which objects actually uses it?
+		verbs -= /obj/item/reagent_container/verb/set_APTFT_60
 	create_reagents(volume)
 
 	add_initial_reagents()

--- a/code/game/objects/items/reagent_containers/reagent_container.dm
+++ b/code/game/objects/items/reagent_containers/reagent_container.dm
@@ -12,27 +12,22 @@
 	var/volume = 30
 	var/liquifier = FALSE //Can liquify/grind pills without needing fluid to dissolve.
 
-/obj/item/reagent_container/verb/set_APTFT() //set amount_per_transfer_from_this
-	set name = "Set transfer amount"
-	set category = "Object"
+/obj/item/reagent_container/attack_self()
+	. = ..()
+	var/obj/item/reagent_container/H = usr.get_active_held_item()
+	var/N = input("Amount per transfer from this:","[H]") as null|anything in H.possible_transfer_amounts
+	if (N)
+		H.amount_per_transfer_from_this = N
+
+/obj/item/reagent_container/proc/set_APTFT() //set amount_per_transfer_from_this - used in many .dm about individual transfer amounts.
 	var/obj/item/reagent_container/H = usr.get_active_held_item()
 	var/N = input("Amount per transfer from this:","[H]") as null|anything in possible_transfer_amounts
 	if (N)
 		amount_per_transfer_from_this = N
 
-/obj/item/reagent_container/verb/set_APTFT_60() //set amount_per_transfer_from_this
-	set name = "Set transfer amount 60"
-	set category = "Object"
-	usr.get_active_held_item()
-	amount_per_transfer_from_this = 60
-
 /obj/item/reagent_container/New()
 	. = ..()
-	if (!possible_transfer_amounts)
-		verbs -= /obj/item/reagent_container/verb/set_APTFT //which objects actually uses it?
-		verbs -= /obj/item/reagent_container/verb/set_APTFT_60
 	create_reagents(volume)
-
 	add_initial_reagents()
 
 //returns a text listing the reagents (and their volume) in the atom. Used by Attack logs for reagents in pills

--- a/code/game/objects/items/reagent_containers/spray.dm
+++ b/code/game/objects/items/reagent_containers/spray.dm
@@ -21,7 +21,7 @@
 
 /obj/item/reagent_container/spray/New()
 	..()
-	src.verbs -= /obj/item/reagent_container/verb/set_APTFT
+	src.verbs -= /obj/item/reagent_container/proc/set_APTFT
 
 /obj/item/reagent_container/spray/afterattack(atom/A as mob|obj, mob/user)
 	//this is what you get for using afterattack() TODO: make is so this is only called if attackby() returns 0 or something


### PR DESCRIPTION
:cl: Hughgent
refactor: set-transfer-amount is no more, it has been changed to the attack_self() proc. Activate-held-object or clicking the container also works.
fix: No more selecting transfer amounts for containers not in your active hand.
/:cl:

[why]: Because as a chemist I often hold the Bluespace beaker and a medicine bottle at the same time while changing the medicine bottle to 60. thus it would be nice to only select the medicine bottle when activating the verb.

**Or at least that would be nice to say if it actually worked. cause apparently this always brings back both hands contents as a list. Do not merge as is.**

**I need help from someone who understands why this is happening.**