### PR TITLE
Warrior Balance Tweak

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Castes/Warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Castes/Warrior.dm
@@ -18,7 +18,7 @@
 	speed = -0.3
 
 	// *** Plasma *** //
-	plasma_max = 100
+	plasma_max = 80
 	plasma_gain = 8
 
 	// *** Health *** //
@@ -51,17 +51,17 @@
 	melee_damage_upper = 45
 
 	// *** Tackle *** //
-	tackle_damage = 45
+	tackle_damage = 50
 
 	// *** Speed *** //
 	speed = -0.4
 
 	// *** Plasma *** //
 	plasma_max = 100
-	plasma_gain = 8
+	plasma_gain = 10
 
 	// *** Health *** //
-	max_health = 250
+	max_health = 240
 
 	// *** Evolution *** //
 	upgrade_threshold = 400
@@ -82,14 +82,14 @@
 	melee_damage_upper = 45
 
 	// *** Tackle *** //
-	tackle_damage = 50
+	tackle_damage = 53
 
 	// *** Speed *** //
-	speed = -0.4
+	speed = -0.45
 
 	// *** Plasma *** //
-	plasma_max = 100
-	plasma_gain = 8
+	plasma_max = 115
+	plasma_gain = 11
 
 	// *** Health *** //
 	max_health = 260
@@ -120,11 +120,11 @@
 	speed = -0.5
 
 	// *** Plasma *** //
-	plasma_max = 100
-	plasma_gain = 8
+	plasma_max = 120
+	plasma_gain = 12
 
 	// *** Health *** //
-	max_health = 265
+	max_health = 270
 
 	// *** Evolution *** //
 	upgrade_threshold = 800

--- a/code/modules/mob/living/carbon/xenomorph/Castes/Warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Castes/Warrior.dm
@@ -215,7 +215,7 @@
 			round_statistics.warrior_grabs++
 			grab_level = GRAB_NECK
 			L.drop_all_held_items()
-			L.KnockDown(3)
+			L.KnockDown(2)
 			visible_message("<span class='xenowarning'>\The [src] grabs [L] by the throat!</span>", \
 			"<span class='xenowarning'>You grab [L] by the throat!</span>")
 

--- a/code/modules/mob/living/carbon/xenomorph/Powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Powers.dm
@@ -373,7 +373,7 @@
 // Warrior Fling
 /mob/living/carbon/Xenomorph/proc/fling(atom/A)
 
-	if (!A || !ishuman(A) || !check_state() || agility || !check_plasma(10) || !Adjacent(A))
+	if (!A || !ishuman(A) || !check_state() || agility || !check_plasma(30) || !Adjacent(A))
 		return
 
 	if (used_fling)
@@ -393,7 +393,7 @@
 	"<span class='xenowarning'>You effortlessly fling [H] to the side!</span>")
 	playsound(H,'sound/weapons/alien_claw_block.ogg', 75, 1)
 	used_fling = TRUE
-	use_plasma(10)
+	use_plasma(30)
 	H.apply_effects(1,2) 	// Stun
 	shake_camera(H, 2, 1)
 
@@ -429,7 +429,7 @@
 		to_chat(src, "<span class='xenowarning'>You must gather your strength before punching.</span>")
 		return
 
-	if (!check_plasma(20))
+	if (!check_plasma(30))
 		return
 
 	if (!Adjacent(M))
@@ -451,7 +451,7 @@
 	var/armor_block = M.run_armor_check(target_zone)
 	var/damage = rand(xeno_caste.melee_damage_lower, xeno_caste.melee_damage_upper)
 	used_punch = TRUE
-	use_plasma(20)
+	use_plasma(30)
 	playsound(M, S, 50, 1)
 
 	if(!ishuman(M))


### PR DESCRIPTION
:cl: by Surrealistik
tweak: Lunge knockdown duration reduced from 3 ticks to 2 ticks.
tweak: Warrior stat progression smoothed out; starts with less plasma capacity but gains more at higher tiers, as well as higher plasma regeneration.
tweak: Punch plasma cost increased to 30 from 20. Lunge plasma cost increased to 30 from 10.
/:cl: