### PR TITLE
Fixes more bodybag/tarp related issues.

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -22,6 +22,10 @@
 /obj/item/bodybag/proc/deploy_bodybag(mob/user, atom/location)
 	if(!isturf(user.loc))
 		return FALSE
+	for(var/obj/O in location)
+		if(istype(O, /obj/structure/closet) || O.density)
+			to_chat(user, "<span class='warning'>\the [src] can't be deployed here.</span>")
+			return FALSE
 	var/obj/structure/closet/bodybag/R = new unfolded_path(location, src)
 	R.add_fingerprint(user)
 	R.open(user)

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -20,11 +20,14 @@
 			deploy_bodybag(user, T)
 
 /obj/item/bodybag/proc/deploy_bodybag(mob/user, atom/location)
+	if(!isturf(user.loc))
+		return FALSE
 	var/obj/structure/closet/bodybag/R = new unfolded_path(location, src)
 	R.add_fingerprint(user)
 	R.open(user)
 	user.temporarilyRemoveItemFromInventory(src)
 	qdel(src)
+	return TRUE
 
 
 /obj/item/bodybag/cryobag

--- a/code/modules/cm_marines/equipment/gear.dm
+++ b/code/modules/cm_marines/equipment/gear.dm
@@ -20,9 +20,10 @@
 	unfolded_path = /obj/structure/closet/bodybag/tarp
 
 /obj/item/bodybag/tarp/deploy_bodybag(mob/user, atom/location)
-	if(locate(/obj/structure/closet) in location)
-		to_chat(user, "<span class='warning'>\the [src] can't be deployed here.</span>")
-		return
+	for(var/obj/O in location)
+		if(istype(O, /obj/structure/closet) || O.density)
+			to_chat(user, "<span class='warning'>\the [src] can't be deployed here.</span>")
+			return FALSE
 	return ..()
 
 /obj/item/bodybag/tarp/snow

--- a/code/modules/cm_marines/equipment/gear.dm
+++ b/code/modules/cm_marines/equipment/gear.dm
@@ -19,13 +19,6 @@
 	w_class = 3.0
 	unfolded_path = /obj/structure/closet/bodybag/tarp
 
-/obj/item/bodybag/tarp/deploy_bodybag(mob/user, atom/location)
-	for(var/obj/O in location)
-		if(istype(O, /obj/structure/closet) || O.density)
-			to_chat(user, "<span class='warning'>\the [src] can't be deployed here.</span>")
-			return FALSE
-	return ..()
-
 /obj/item/bodybag/tarp/snow
 	icon = 'icons/obj/bodybag.dmi'
 	icon_state = "snowtarp_folded"


### PR DESCRIPTION
:cl:
fix: bodybags are now undeployable on turfs with dense objects, or while the user's location isn't one.
/:cl:
I couldn't exactly replicate #624, but I did found out it was possible to deploy more bodybags while inside one, thus reviving an older related issue. And it's no tacticool or logical purpose to shove a bodybag under a vendor or anything that could force you to alt click the tile.