### PR TITLE
Chairs no longer rotate at the speed of light.

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -35,7 +35,6 @@
 		return 1
 
 	next_move = world.time + 8
-	// You are responsible for checking config.ghost_interaction when you override this function
 	// Not all of them require checking, see below
 	if(!mods["shift"])
 		A.attack_ghost(src)

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -143,8 +143,6 @@
 
 /datum/config_entry/flag/bones_can_break
 
-/datum/config_entry/flag/ghost_interaction
-
 /datum/config_entry/flag/unlimited_rotate_speed
 
 /datum/config_entry/flag/allow_random_events

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -143,6 +143,10 @@
 
 /datum/config_entry/flag/bones_can_break
 
+/datum/config_entry/flag/ghost_interaction
+
+/datum/config_entry/flag/unlimited_rotate_speed
+
 /datum/config_entry/flag/allow_random_events
 
 /datum/config_entry/flag/allow_synthetic_gun_use

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -39,19 +39,21 @@
 	set category = "Object"
 	set src in view(0)
 
-	if(CONFIG_GET(flag/ghost_interaction))
+	if(isobserver(usr) && CONFIG_GET(flag/ghost_interaction))
 		setDir(turn(dir, 90))
-		return FALSE
+		return TRUE
 	
 	var/mob/living/carbon/user = usr
 
-	if(!istype(user) || !isturf(user.loc) || user.stat || user.is_mob_restrained())
+	if(!istype(user) || !isturf(user.loc) || user.is_mob_incapacitated())
 		return FALSE
 
-	if (world.time <= user.next_move)
+	if(!CONFIG_GET(flag/unlimited_rotate_speed) && world.time <= user.next_move)
 		return FALSE
 
-	user.next_move = world.time + 3
+	if(!CONFIG_GET(flag/unlimited_rotate_speed))
+		user.next_move = world.time + 3
+
 	setDir(turn(dir, 90))
 
 //Chair types

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -48,10 +48,9 @@
 	if(!istype(user) || !isturf(user.loc) || user.is_mob_incapacitated())
 		return FALSE
 
-	if(!CONFIG_GET(flag/unlimited_rotate_speed) && world.time <= user.next_move)
-		return FALSE
-
 	if(!CONFIG_GET(flag/unlimited_rotate_speed))
+		if(world.time <= user.next_move)
+			return FALSE
 		user.next_move = world.time + 3
 
 	setDir(turn(dir, 90))

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -37,17 +37,22 @@
 /obj/structure/bed/chair/verb/rotate()
 	set name = "Rotate Chair"
 	set category = "Object"
-	set src in oview(1)
+	set src in view(0)
 
+	if(CONFIG_GET(flag/ghost_interaction))
+		setDir(turn(dir, 90))
+		return FALSE
+	
+	var/mob/living/carbon/user = usr
 
-	if(istype(usr, /mob/living/simple_animal/mouse))
-		return
-	if(!usr || !isturf(usr.loc))
-		return
-	if(usr.stat || usr.is_mob_restrained())
-		return
+	if(!istype(user) || !isturf(user.loc) || user.stat || user.is_mob_restrained())
+		return FALSE
 
-	setDir(turn(src.dir, 90))
+	if (world.time <= user.next_move)
+		return FALSE
+
+	user.next_move = world.time + 3
+	setDir(turn(dir, 90))
 
 //Chair types
 /obj/structure/bed/chair/reinforced

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -38,10 +38,6 @@
 	set name = "Rotate Chair"
 	set category = "Object"
 	set src in view(0)
-
-	if(isobserver(usr) && CONFIG_GET(flag/ghost_interaction))
-		setDir(turn(dir, 90))
-		return TRUE
 	
 	var/mob/living/carbon/user = usr
 


### PR DESCRIPTION
[Changelogs]: 
tweak: Chairs no longer rotate at the speed of light. You need to be in the same tile as them to do it.
/:cl:

[why]: Objects behave more uniformly.