### PR TITLE
Hand Labeler rework

### DIFF
--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -351,13 +351,6 @@
 				to_chat(usr, "<span class='notice'>[src] cannot hold [W].</span>")
 			return FALSE
 
-	if(istype(W, /obj/item/tool/hand_labeler))
-		var/obj/item/tool/hand_labeler/L = W
-		if(L.on)
-			return FALSE
-		else
-			return TRUE
-
 	for(var/A in cant_hold) //Check for specific items which this container can't hold.
 		if(istype(W, text2path(A) ))
 			if(warning)
@@ -390,6 +383,13 @@
 			if(warning)
 				to_chat(usr, "<span class='notice'>[src] cannot hold [W] as it's a storage item of the same size.</span>")
 			return FALSE //To prevent the stacking of same sized storage items.
+
+	if(istype(W, /obj/item/tool/hand_labeler))
+		var/obj/item/tool/hand_labeler/L = W
+		if(L.on)
+			return FALSE
+		else
+			return TRUE
 
 	return TRUE
 

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -347,14 +347,16 @@
 				ok = TRUE
 				break
 		if(!ok)
-			if(istype(W, /obj/item/tool/hand_labeler))
-				var/obj/item/tool/hand_labeler/L = W
-				if(!L.mode)
-					return TRUE
-				to_chat(usr, "<span class='warning'>You must turn off the [L] first.</span>")
-			else if(warning)
+			if(warning)
 				to_chat(usr, "<span class='notice'>[src] cannot hold [W].</span>")
 			return FALSE
+
+	if(istype(W, /obj/item/tool/hand_labeler))
+		var/obj/item/tool/hand_labeler/L = W
+		if(L.on)
+			return FALSE
+		else
+			return TRUE
 
 	for(var/A in cant_hold) //Check for specific items which this container can't hold.
 		if(istype(W, text2path(A) ))

--- a/code/game/objects/items/tools/misc_tools.dm
+++ b/code/game/objects/items/tools/misc_tools.dm
@@ -1,29 +1,21 @@
-
-
-
-
-
-/////////////////////// Hand Labeler ////////////////////////////////
-
-
 /obj/item/tool/hand_labeler
 	name = "hand labeler"
 	icon = 'icons/obj/items/paper.dmi'
 	icon_state = "labeler0"
 	item_state = "flight"
+
 	var/label = null
 	var/labels_left = 50
-	var/mode = 0	//off or on.
+	var/on = FALSE
+
 
 /obj/item/tool/hand_labeler/afterattack(atom/A, mob/user as mob, proximity)
 	if(!proximity)
 		return
-	if(!mode)	//if it's off, give up.
+	if(!on)
 		return
-	if(A == loc)	// if placing the labeller into something (e.g. backpack)
-		return		// don't set a label
-	if(!label || !length(label))
-		to_chat(user, "<span class='notice'>No text set.</span>")
+	if(!label)
+		to_chat(user, "<span class='notice'>No label set.</span>")
 		return
 	if(length(A.name) + length(label) > 64)
 		to_chat(user, "<span class='notice'>Label too big.</span>")
@@ -34,24 +26,27 @@
 	if(isturf(A) || ismob(A))
 		to_chat(user, "<span class='notice'>The label won't stick to that.</span>")
 		return
+	if(A.name == "[initial(A.name)] ([label])")
+		to_chat(user, "<span class='notice'>It already has the same label.</span>")
+		return
 
 	user.visible_message("<span class='notice'>[user] labels [A] as \"[label]\".</span>", \
 						 "<span class='notice'>You label [A] as \"[label]\".</span>")
-	A.name = "[A.name] ([label])"
+	A.name = "[initial(A.name)] ([label])"
 	labels_left--
 
+
 /obj/item/tool/hand_labeler/attack_self(mob/user as mob)
-	mode = !mode
-	icon_state = "labeler[mode]"
-	if(mode)
+	on = !on
+	icon_state = "labeler[on]"
+	if(on)
 		to_chat(user, "<span class='notice'>You turn on \the [src].</span>")
-		//Now let them chose the text.
-		var/str = copytext(reject_bad_text(input(user,"Label text?", "Set label", "")), 1, MAX_NAME_LEN)
-		if(!str || !length(str))
-			to_chat(user, "<span class='notice'>Invalid text.</span>")
+		var/str = copytext(sanitize(input(user,"What do you want to label things as?", "Label Text", "")), 1, MAX_NAME_LEN)
+		if(!str)
+			to_chat(user, "<span class='notice'>Invalid label.</span>")
 			return
 		label = str
-		to_chat(user, "<span class='notice'>You set the text to '[str]'.</span>")
+		to_chat(user, "<span class='notice'>You set the label text to '[str]'.</span>")
 	else
 		to_chat(user, "<span class='notice'>You turn off \the [src].</span>")
 
@@ -61,7 +56,12 @@
 	if(istype(I, /obj/item/paper))
 		to_chat(user, "<span class='notice'>You insert [I] into [src].</span>")
 		qdel(I)
-		labels_left = min(labels_left+5, initial(labels_left))
+		labels_left = min(labels_left + 5, initial(labels_left))
+
+
+/obj/item/tool/hand_labeler/examine(mob/user)
+	. = ..()
+	to_chat(user, "<span class='notice'>It has [labels_left] out of [initial(labels_left)] labels left.")
 
 
 


### PR DESCRIPTION
:cl: LaKiller8
fix: Hand labeler can now label backpacks without them having to be full first. Every item can only have one label now.
/:cl:
Fixes #591 