### PR TITLE
 Contrabands monkey soup and rewords bread MRE

### DIFF
--- a/code/game/machinery/vending/marine_vending.dm
+++ b/code/game/machinery/vending/marine_vending.dm
@@ -364,7 +364,6 @@
 					/obj/item/reagent_container/food/snacks/mre_pack/meal2 = 15,
 					/obj/item/reagent_container/food/snacks/mre_pack/meal3 = 15,
 					/obj/item/reagent_container/food/snacks/mre_pack/meal4 = 15,
-					/obj/item/reagent_container/food/snacks/mre_pack/meal5 = 15,
 					/obj/item/reagent_container/food/snacks/mre_pack/meal6 = 15,
 					/obj/item/storage/box/MRE = 10,
 					/obj/item/reagent_container/food/drinks/flask = 5)
@@ -373,7 +372,8 @@
 					/obj/item/reagent_container/food/snacks/mre_pack/xmas1 = 25,
 					/obj/item/reagent_container/food/snacks/mre_pack/xmas2 = 25,
 					/obj/item/reagent_container/food/snacks/mre_pack/xmas3 = 25)*/
-	contraband = list(/obj/item/reagent_container/food/drinks/flask/marine = 10)
+	contraband = list(/obj/item/reagent_container/food/drinks/flask/marine = 10,
+					/obj/item/reagent_container/food/snacks/mre_pack/meal5 = 15)
 	vend_delay = 15
 	//product_slogans = "Standard Issue Marine food!;It's good for you, and not the worst thing in the world.;Just fucking eat it.;"
 	product_ads = "Try the cornbread.;Try the pizza.;Try the pasta.;Try the tofu, wimp.;Try the pork."

--- a/code/modules/cm_marines/equipment/gear.dm
+++ b/code/modules/cm_marines/equipment/gear.dm
@@ -188,8 +188,8 @@
 	w_class = 2
 
 /obj/item/reagent_container/food/snacks/mre_pack/meal1
-	name = "\improper TGMC Prepared Meal (bread)"
-	desc = "A staple of the Clown Planet, every clown baby's first solid food is a slice of banana bread with cream pie spread."
+	name = "\improper TGMC Prepared Meal (banana bread)"
+	desc = "A slice of banana bread with cream pie spread. A slippery combination."
 	icon_state = "MREa"
 	filling_color = "#ED1169"
 	list_reagents = list("nutriment" = 9)


### PR DESCRIPTION
[why]: Diminishing the DMCA legacy a bit, making the jokes a little less direct and easily accessible.