### PR TITLE
Requisitions Elevator Sounds an Alarm When Decending

### DIFF
--- a/code/modules/shuttles/shuttle_supply.dm
+++ b/code/modules/shuttles/shuttle_supply.dm
@@ -47,7 +47,9 @@
 	if(!origin)
 		origin = get_location_area(location)
 
-	//it would be cool to play a sound here
+	if(at_station()) // Sound the alarm! The elevator is descending!
+		playsound(locate(SupplyElevator_x,SupplyElevator_y,SupplyElevator_z), 'sound/machines/warning-buzzer.ogg', 50, 0)
+
 	moving_status = SHUTTLE_WARMUP
 	spawn(warmup_time*10)
 		if (moving_status == SHUTTLE_IDLE)


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: optional name here
add: Added an alarm to the Requisitions elevator when it prepares to descend.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
It alerts anyone in requisitions to stay off the platform, as it's about to go down. It doesn't play when the elevator is coming up.