### PR TITLE
Fixes guns Initialize() runtimes.

### DIFF
--- a/code/modules/projectiles/updated_projectiles/gun_system.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_system.dm
@@ -114,9 +114,9 @@
 			current_mag = null
 			update_icon()
 		else
-			current_mag = new current_mag(src, spawn_empty ? 1 : 0)
+			current_mag = new current_mag(src, spawn_empty ? TRUE : FALSE)
 			ammo = current_mag.default_ammo ? GLOB.ammo_list[current_mag.default_ammo] : GLOB.ammo_list[/datum/ammo/bullet] //Latter should never happen, adding as a precaution.
-		if(flags_gun_features & GUN_LOAD_INTO_CHAMBER && current_mag.current_rounds > 0)
+		if(flags_gun_features & GUN_LOAD_INTO_CHAMBER && current_mag?.current_rounds > 0)
 			load_into_chamber()
 	else
 		ammo = GLOB.ammo_list[ammo] //If they don't have a mag, they fire off their own thing.


### PR DESCRIPTION
:cl:
fix: Fixes a seriously mean runtime on vendors' dispensed guns.
/:cl:

Closes #702.
