### PR TITLE
Fixed areas runtimes on startup

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -13,7 +13,7 @@
 	var/temperature = T20C
 	var/pressure = ONE_ATMOSPHERE
 
-/area/Initialize()
+/area/New()
 	. = ..()
 
 	icon_state = "" //Used to reset the icon overlay, I assume.


### PR DESCRIPTION
Quick bandaid fix for the areas runtimes on startup, before we removed the `master` var from areas in the new maploader.

Should fix machinery not shutting down when losing power.