### PR TITLE
Stops people from teleporting to CC via televac.

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -414,6 +414,11 @@ var/global/list/activated_medevac_stretchers = list()
 		playsound(loc,'sound/machines/buzz-two.ogg', 25, FALSE)
 		to_chat(user, "<span class='warning'>[src]'s bluespace engine linked medvac beacon is unpowered.</span>")
 		return
+	
+	if(linked_beacon.z == ADMIN_Z_LEVEL) // No. No using teleportation to teleport to the adminzone.
+		playsound(loc,'sound/machines/buzz-two.ogg', 25, FALSE)
+		to_chat(user, "<span class='warning'>[src]'s beacon is out of range!</span>")
+		return
 
 	user.visible_message("<span class='warning'>[user] activates [src]'s bluespace engine, causing it to rev to life.</span>",
 	"<span class='warning'>You activate [src]'s bluespace engine, causing it to rev to life.</span>")


### PR DESCRIPTION
:cl:
fix: Fixed being able to use televacs to reach Central Command.
/:cl:

CC is an admin-only area, and people can (currently) use medevac stretchers to televac to there, if they leave an activated beacon on the cargo elevator.