### PR TITLE
Mateba and M44 belt fix

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -562,7 +562,6 @@
 	desc = "The M276 is the standard load-bearing equipment of the TGMC. It consists of a modular belt with various clips. This version is for the M44 magnum revolver, along with three pouches for speedloaders. It faintly smells of hay."
 	icon_state = "m44_holster"
 	item_state = "m44_holster"
-	max_w_class = 7
 	can_hold = list(
 		"/obj/item/weapon/gun/revolver/m44",
 		"/obj/item/ammo_magazine/revolver"

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -498,13 +498,13 @@
 		return
 	if(istype(W,/obj/item/weapon/gun)) //Is it a gun?
 		if(holds_guns_now == holds_guns_max) //Are we at our gun capacity?
-			if(warning) 
+			if(warning)
 				to_chat(usr, "<span class='warning'>[src] already holds a gun.</span>")
 			return FALSE
 	else //Must be ammo.
 	//We have slots open for the gun, so in total we should have storage_slots - guns_max in slots, plus whatever is already in the belt.
 		if(((storage_slots - holds_guns_max) + holds_guns_now) <= length(contents)) // We're over capacity, and the space is reserved for a gun.
-			if(warning) 
+			if(warning)
 				to_chat(usr, "<span class='warning'>[src] can't hold any more magazines.</span>")
 			return FALSE
 	return TRUE
@@ -585,7 +585,6 @@
 	desc = "The M276 is the standard load-bearing equipment of the TGMC. It consists of a modular belt with various clips. This version is for the powerful Mateba magnum revolver, along with three pouches for speedloaders. This one is aging poorly, and seems to be surplus equipment. This one is stamped '3rd 'Dust Raiders' Battalion'."
 	icon_state = "s_cmateba_holster"
 	item_state = "s_cmateba_holster"
-	max_w_class = 7
 	can_hold = list(
 		"/obj/item/weapon/gun/revolver/mateba",
 		"/obj/item/ammo_magazine/revolver/mateba"


### PR DESCRIPTION
Should fix the M44 and Mateba (Not that the Mateba can have a stock or slot increasing attachment I believe) being to be held in the belt while having a stock or other slot increasing attachable.
:cl: MJP
fix: M44 and mateba belts can now only hold things of proper size
/:cl:
EDIT:Cleaned up my engrish and added :Cl: and Fix: