### PR TITLE
Removes the ability to purchase the spec minigun from req.

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -235,15 +235,6 @@ WEAPONS
 	containername = "\improper Sniper Specialist crate"
 	group = "Weapons"
 
-/datum/supply_packs/specminigun
-	name = "MIC-A7 Vindicator Minigun crate (MIC-A7 x1)"
-	contains = list(
-					/obj/item/weapon/gun/minigun
-					)
-	cost = RO_PRICE_VERY_PRICY
-	containertype = /obj/structure/closet/crate/weapon
-	containername = "\improper MIC A7 Vindicator Minigun crate"
-	group = "Weapons"
 
 /datum/supply_packs/specshotgun
 	name = "ZX-76 Assault Shotgun crate (ZX-76 x1)"


### PR DESCRIPTION
:cl: Ondrej008
del: The spec minigun cannot be purchased by req.
/:cl:

The spec minigun is the most OP spec weapon. It does more damage than any other spec weapon, the RPG does about 1/3 of the damage that a few minigun bullets do. Getting hit by a whole burst will kill you, no matter what you are, except for a fortified ancient defender or ancient crusher. Also I promised this to one particular person.
