### PR TITLE
Adds medbay access to lock/unlock televac beacons

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -551,7 +551,7 @@ var/global/list/activated_medevac_stretchers = list()
 	var/locked = FALSE
 	var/obj/item/roller/medevac/linked_bed = null
 	var/obj/structure/bed/medevac_stretcher/linked_bed_deployed = null
-	req_one_access = list(ACCESS_MARINE_MEDPREP, ACCESS_MARINE_LEADER)
+	req_one_access = list(ACCESS_MARINE_MEDPREP, ACCESS_MARINE_LEADER, ACCESS_MARINE_MEDBAY)
 
 
 /obj/item/device/medevac_beacon/examine(mob/user)


### PR DESCRIPTION
:cl:
tweak: Anyone with medbay access can now lock/unlock televac beacons.
/:cl:


Currently, the people who can actually move them are either busy (Command) or on the ground (The marines themselves). It doesn't make sense that the people who make use of them the most can't move them in event of an emergency.

(If you can vend from the vendors in medical storage, you can lock/unlock the beacons)