### PR TITLE
Makes the scout shotgun hold 10 rounds total counting the one shell in the chamber

### DIFF
--- a/code/modules/projectiles/updated_projectiles/magazines/shotguns.dm
+++ b/code/modules/projectiles/updated_projectiles/magazines/shotguns.dm
@@ -92,5 +92,5 @@ also doesn't really matter. You can only reload them with handfuls.
 	max_rounds = 5
 
 /obj/item/ammo_magazine/internal/shotgun/scout
-	max_rounds = 10
+	max_rounds = 9
 	current_rounds = 0


### PR DESCRIPTION
The scout shotgun's internal mag now holds 9 rounds, meaning that the scout shotgun now holds 10 rounds total counting the one in the chamber, before this it held 11 counting the one in the chamber, this pissed me off endlessly whenever i used it.


:cl: Borisvanmemes
balance: The scout shotgun now holds 10 rounds total, counting the one in the chamber, down from 11 counting the one in the chamber.
/:cl:

[why]: It's just one round too many to be able to be fully reloaded in two handfuls and that's just so fucking annoying, this fixes that.

also this is a untested webediter PR but it's also just a one line change so it shouldn't break anything