### PR TITLE
Adds diffrent name/desc for adv hypo

### DIFF
--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -4,7 +4,7 @@
 
 /obj/item/reagent_container/hypospray
 	name = "\improper hypospray"
-	desc = "The hypospray is a sterile, air-needle reusable autoinjector for rapid administration of drugs to patients with customizable dosages. Comes complete with an internal reagent analyzer and digital labeler. Handy."
+	desc = "The hypospray is a sterile, air-needle reusable autoinjector for rapid administration of drugs to patients with customizable dosages."
 	icon = 'icons/obj/items/syringe.dmi'
 	item_state = "hypo"
 	icon_state = "hypo_base"
@@ -20,6 +20,11 @@
 	var/inject_mode = HYPOSPRAY_INJECT_MODE_INJECT
 	var/core_name = "hypospray"
 	var/label = null
+
+/obj/item/reagent_container/hypospray/advanced
+	name = "\improper advanced hypospray"
+	desc = "The hypospray is a sterile, air-needle reusable autoinjector for rapid administration of drugs to patients with customizable dosages. Comes complete with an internal reagent analyzer and digital labeler. Handy."
+	var/core_name = "hypospray"
 
 /obj/item/reagent_container/hypospray/advanced/attack_self(mob/user)
 	if(user.is_mob_incapacitated() || !user.IsAdvancedToolUser())

--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -3,7 +3,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 /obj/item/reagent_container/hypospray
-	name = "\improper hypospray"
+	name = "hypospray"
 	desc = "The hypospray is a sterile, air-needle reusable autoinjector for rapid administration of drugs to patients with customizable dosages."
 	icon = 'icons/obj/items/syringe.dmi'
 	item_state = "hypo"
@@ -22,9 +22,9 @@
 	var/label = null
 
 /obj/item/reagent_container/hypospray/advanced
-	name = "\improper advanced hypospray"
+	name = "advanced hypospray"
 	desc = "The hypospray is a sterile, air-needle reusable autoinjector for rapid administration of drugs to patients with customizable dosages. Comes complete with an internal reagent analyzer and digital labeler. Handy."
-	var/core_name = "hypospray"
+	core_name = "hypospray"
 
 /obj/item/reagent_container/hypospray/advanced/attack_self(mob/user)
 	if(user.is_mob_incapacitated() || !user.IsAdvancedToolUser())


### PR DESCRIPTION
## About The Pull Request

Adds in a seperate description/name for the adv hypo (vendors) than the regular hypo (table).

## Why It's Good For The Game

Both appear to be the same item, but only the advanced can be labled/analyzed.

## Changelog
:cl:
tweak: Advanced hyposprays now show as advanced hyposprays.
/:cl: