### PR TITLE
Adds shutdown server admin verb.

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -247,3 +247,7 @@ Legacy - work on reworking/removing these.
 
 /datum/config_entry/flag/allow_shutdown
 	protection = CONFIG_ENTRY_LOCKED
+
+/datum/config_entry/string/tgs3_commandline_path
+	protection = CONFIG_ENTRY_LOCKED | CONFIG_ENTRY_HIDDEN
+	config_entry_value = "C:\\Program Files (x86)\\TG Station Server\\TGCommandLine.exe"

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -244,3 +244,6 @@ Legacy - work on reworking/removing these.
 /datum/config_entry/flag/usealienwhitelist
 
 /datum/config_entry/flag/load_legacy_ranks_only
+
+/datum/config_entry/flag/allow_shutdown
+	protection = CONFIG_ENTRY_LOCKED

--- a/code/modules/admin/holder.dm
+++ b/code/modules/admin/holder.dm
@@ -348,6 +348,7 @@ GLOBAL_LIST_INIT(admin_verbs_server, world.AVserver())
 /world/proc/AVserver()
 	return list(
 	/datum/admins/proc/restart,
+	/datum/admins/proc/shutdown_server,
 	/datum/admins/proc/toggle_ooc,
 	/datum/admins/proc/toggle_looc,
 	/datum/admins/proc/toggle_deadchat,

--- a/code/modules/admin/server_verbs.dm
+++ b/code/modules/admin/server_verbs.dm
@@ -90,12 +90,31 @@
 		return
 
 	to_chat(world, "<span class='danger'>Server shutting down.</span> <span class='notice'>Initiated by: [shuttingdown]</span>")
+	log_game("Server shutting down. Initiated by: [shuttingdown]")
 
+#ifdef TGS_V3_API
 	if (GLOB.tgs)
 		var/datum/tgs_api/TA = GLOB.tgs
-		TA.EndProcess()
+		var/tgs3_path = CONFIG_GET(string/tgs3_commandline_path)
+		if (fexists(tgs3_path))
+			var/instancename = TA.InstanceName()
+			if (instancename)
+				shell("[tgs3_path] --instance [instancename] dd stop --graceful") //this tells tgstation-server to ignore us shutting down
+			else
+				var/msg = "WARNING: Couldn't find tgstation-server3 instancename, server might restart after shutdown."
+				message_admins(msg)
+				log_game(msg)
+		else
+			var/msg = "WARNING: Couldn't find tgstation-server3 command line interface, server will very likely restart after shutdown."
+			message_admins(msg)
+			log_game(msg)
+	else
+		var/msg = "WARNING: Couldn't find tgstation-server3 api object, server could restart after shutdown, but it will very likely be just fine"
+		message_admins(msg)
+		log_game(msg)
+#endif
 
-	sleep(world.tick_lag)
+	sleep(world.tick_lag) //so messages can get sent to players.
 	qdel(world) //there are a few ways to shutdown the server, but this is by far my favorite
 
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -24,6 +24,13 @@ ADMIN_LEGACY_SYSTEM
 ## Add a # infront of this to disable the shutdown server verb.
 ALLOW_SHUTDOWN
 
+## If you use /tg/station-server 3 and you want to allow the shutdown server verb, 
+##	the server needs to be able to tell tgs3 that the shutdown is not a crash.
+## This should be the path to the TGCommandLine.exe program in your tgstation-server install.
+## Defaults to C:\Program Files (x86)\TG Station Server\TGCommandLine.exe if not set.
+## 32 bit OS users use: C:\Program Files\TG Station Server\TGCommandLine.exe
+#TGS3_COMMANDLINE_PATH
+
 
 ## Add a # infront of this if you want to use the SQL based banning system. The legacy systems use the files in the data folder. You need to set up your database to use the SQL based system.
 BAN_LEGACY_SYSTEM

--- a/config/config.txt
+++ b/config/config.txt
@@ -21,6 +21,10 @@ HUBPASSWORD kMZy3U5jJHSiBQjr
 ## Add a # infront of this if you want to use the SQL based admin system, the legacy system uses admins.txt. You need to set up your database to use the SQL based system.
 ADMIN_LEGACY_SYSTEM
 
+## Add a # infront of this to disable the shutdown server verb.
+ALLOW_SHUTDOWN
+
+
 ## Add a # infront of this if you want to use the SQL based banning system. The legacy systems use the files in the data folder. You need to set up your database to use the SQL based system.
 BAN_LEGACY_SYSTEM
 


### PR DESCRIPTION
Requires the server be at pregame or endround.

Requires the start/end be delayed

Requires two confirmations from the same admin, 30 seconds apart.

During the first 30 second delay, all admins are notified and alerted and those with +SERVER can cancel the process within those 30 seconds

After that final confirmation, it announces the shutdown to players, and waits another 30 seconds where admins can cancel the shutdown still.

Requires the `ALLOW_SHUTDOWN` config. This config is protected from runtime editing via VV.

![image](https://user-images.githubusercontent.com/7069733/52991778-03637600-33c3-11e9-8dc0-e4458e20291a.png)
