### PR TITLE
Xeno leaders are now kept through evolutions (except queen)

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Evolution.dm
@@ -232,7 +232,7 @@
 
 	round_statistics.total_xenos_created-- //so an evolved xeno doesn't count as two.
 
-	if(queen_chosen_lead && new_caste_type == /mob/living/carbon/Xenomorph/Queen) // xeno leader is removed by Destroy()
+	if(queen_chosen_lead && new_caste_type != /mob/living/carbon/Xenomorph/Queen) // xeno leader is removed by Destroy()
 		new_xeno.queen_chosen_lead = TRUE
 		hive.xeno_leader_list += new_xeno
 		new_xeno.hud_set_queen_overwatch()


### PR DESCRIPTION
:cl: LaKiller8
fix: Xeno leaders are now persistent through evolutions.
/:cl:
Fixes #653