### PR TITLE
Hunters Must Be on Same Z Level As Queen to Regen Plasma Off Weeds

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -223,7 +223,9 @@
 		if(recovery_aura)
 			plasma_stored += round(xeno_caste.plasma_gain * recovery_aura * 0.25 * modifier) //Divided by four because it gets massive fast. 1 is equivalent to weed regen! Only the strongest pheromones should bypass weeds
 	else
-		plasma_stored++
+		var/datum/hive_status/hive = hive_datum[hivenumber]
+		if(!hive.living_xeno_queen || hive.living_xeno_queen.loc.z == loc.z) //We only regenerate plasma off weeds while on the same Z level as the queen; if one's alive
+			plasma_stored++
 	if(plasma_stored > xeno_caste.plasma_max)
 		plasma_stored = xeno_caste.plasma_max
 	else if(plasma_stored < 0)


### PR DESCRIPTION
:cl: by Surrealistik
balance: While a Queen is alive, Hunters must be on the same Z level to regain plasma off-weeds.
/:cl: