### PR TITLE
Boiler smoke duration increased by 50%

### DIFF
--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -274,7 +274,7 @@
 
 //Xeno acid smoke.
 /obj/effect/particle_effect/smoke/xeno_burn
-	time_to_live = 6
+	time_to_live = 9
 	color = "#86B028" //Mostly green?
 	anchored = 1
 	spread_speed = 7


### PR DESCRIPTION
:cl: by Surrealistik
balance: Acid smoke average duration increased from 6 to 9 seconds.
/:cl: