### PR TITLE
Hunter Stealth Tweaks and Fixes

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -474,7 +474,7 @@ var/list/global_mutations = list() // list of hidden mutation things
 #define HUNTER_STEALTH_COOLDOWN					50 //5 seconds
 #define HUNTER_STEALTH_WALK_PLASMADRAIN			2
 #define HUNTER_STEALTH_RUN_PLASMADRAIN			5
-#define HUNTER_STEALTH_STILL_ALPHA				13 //95% transparency
+#define HUNTER_STEALTH_STILL_ALPHA				25 //90% transparency
 #define HUNTER_STEALTH_WALK_ALPHA				38 //85% transparency
 #define HUNTER_STEALTH_RUN_ALPHA				128 //50% transparency
 #define HUNTER_STEALTH_STEALTH_DELAY			30 //3 seconds before 95% stealth

--- a/code/modules/mob/living/carbon/xenomorph/Powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Powers.dm
@@ -1815,6 +1815,10 @@
 		to_chat(src, "<span class='xenodanger'>You're too disoriented from the shock to enter Stealth!</span>")
 		return
 
+	if(on_fire)
+		to_chat(src, "<span class='xenodanger'>You're too busy being on fire to enter Stealth!</span>")
+		return
+
 	if(!stealth)
 		if (!check_plasma(10))
 			return

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -173,12 +173,17 @@
 
 			if(M.stealth_router(HANDLE_STEALTH_CHECK)) //Cancel stealth if we have it due to aggro.
 				if(M.stealth_router(HANDLE_SNEAK_ATTACK_CHECK)) //Pouncing prevents us from making a sneak attack for 4 seconds
-					damage *= 3.5 //Massive damage on the sneak attack... hope you have armour.
+					if(m_intent == MOVE_INTENT_RUN)
+						damage *= 1.75 //Half the multiplier if running.
+						M.visible_message("<span class='danger'>\The [M] strikes [src] with vicious precision!</span>", \
+						"<span class='danger'>You strike [src] with vicious precision!</span>")
+					else
+						damage *= 3.5 //Massive damage on the sneak attack... hope you have armour.
+						M.visible_message("<span class='danger'>\The [M] strikes [src] with deadly precision!</span>", \
+						"<span class='danger'>You strike [src] with deadly precision!</span>")
 					KnockOut(2) //...And we knock them out
 					adjust_stagger(3)
 					add_slowdown(3)
-					M.visible_message("<span class='danger'>\The [M] strikes [src] with vicious precision!</span>", \
-					"<span class='danger'>You strike [src] with vicious precision!</span>")
 				M.stealth_router(HANDLE_STEALTH_CODE_CANCEL)
 
 			M.neuroclaw_router(src) //if we have neuroclaws...
@@ -220,11 +225,16 @@
 			if(M.stealth_router(HANDLE_STEALTH_CHECK))
 				if(M.stealth_router(HANDLE_SNEAK_ATTACK_CHECK))
 					KnockOut(2)
-					tackle_pain *= 3.5 //Halloss multiplied by 3.
+					if(m_intent == MOVE_INTENT_RUN)
+						tackle_pain *= 1.75 //Half the multiplier if running.
+						M.visible_message("<span class='danger'>\The [M] strikes [src] with vicious precision!</span>", \
+						"<span class='danger'>You strike [src] with vicious precision!</span>")
+					else
+						tackle_pain *= 3.5 //Massive damage on the sneak attack... hope you have armour.
+						M.visible_message("<span class='danger'>\The [M] strikes [src] with deadly precision!</span>", \
+						"<span class='danger'>You strike [src] with deadly precision!</span>")
 					adjust_stagger(3)
 					add_slowdown(3)
-					M.visible_message("<span class='danger'>\The [M] strikes [src] with vicious precision!</span>", \
-					"<span class='danger'>You strike [src] with vicious precision!</span>")
 				M.stealth_router(HANDLE_STEALTH_CODE_CANCEL)
 			M.neuroclaw_router(src) //if we have neuroclaws...
 			if(dam_bonus)

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -225,7 +225,7 @@
 			if(M.stealth_router(HANDLE_STEALTH_CHECK))
 				if(M.stealth_router(HANDLE_SNEAK_ATTACK_CHECK))
 					KnockOut(2)
-					if(m_intent == MOVE_INTENT_RUN)
+					if(m_intent == MOVE_INTENT_RUN && ( last_move_intent > (world.time - 20) ) ) //Allows us to slash while running... but only if we've been stationary for awhile
 						tackle_pain *= 1.75 //Half the multiplier if running.
 						M.visible_message("<span class='danger'>\The [M] strikes [src] with vicious precision!</span>", \
 						"<span class='danger'>You strike [src] with vicious precision!</span>")

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -99,17 +99,17 @@
 		return
 	//Initial stealth
 	if(last_stealth > world.time - HUNTER_STEALTH_INITIAL_DELAY) //We don't start out at max invisibility
-		alpha = HUNTER_STEALTH_RUN_ALPHA //50% invisible
+		alpha = HUNTER_STEALTH_RUN_ALPHA
 		return
 	//Stationary stealth
 	else if(last_move_intent < world.time - HUNTER_STEALTH_STEALTH_DELAY) //If we're standing still for 4 seconds we become almost completely invisible
-		alpha = HUNTER_STEALTH_STILL_ALPHA //90% invisible
+		alpha = HUNTER_STEALTH_STILL_ALPHA
 	//Walking stealth
 	else if(m_intent == MOVE_INTENT_WALK)
-		alpha = HUNTER_STEALTH_WALK_ALPHA //85% invisible
+		alpha = HUNTER_STEALTH_WALK_ALPHA
 	//Running stealth
 	else
-		alpha = HUNTER_STEALTH_RUN_ALPHA //50% invisible
+		alpha = HUNTER_STEALTH_RUN_ALPHA
 	//If we have 0 plasma after expending stealth's upkeep plasma, end stealth.
 	if(!plasma_stored)
 		to_chat(src, "<span class='xenodanger'>You lack sufficient plasma to remain camouflaged.</span>")

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -141,6 +141,8 @@
 	if(.)
 		return
 	if(!(xeno_caste.caste_flags & CASTE_FIRE_IMMUNE) && on_fire) //Sanity check; have to be on fire to actually take the damage.
+		if(stealth_router(HANDLE_STEALTH_CHECK)) //Cancel stealth if we have it due to y'know being on fire.
+			stealth_router(HANDLE_STEALTH_CODE_CANCEL)
 		adjustFireLoss((fire_stacks + 3) * CLAMP(xeno_caste.fire_resist + fire_resist_modifier, 0, 1) ) // modifier is negative
 
 /mob/living/carbon/Xenomorph/proc/handle_living_health_updates()

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -103,10 +103,10 @@
 		return
 	//Stationary stealth
 	else if(last_move_intent < world.time - HUNTER_STEALTH_STEALTH_DELAY) //If we're standing still for 4 seconds we become almost completely invisible
-		alpha = HUNTER_STEALTH_STILL_ALPHA //95% invisible
+		alpha = HUNTER_STEALTH_STILL_ALPHA //90% invisible
 	//Walking stealth
 	else if(m_intent == MOVE_INTENT_WALK)
-		alpha = HUNTER_STEALTH_WALK_ALPHA //80% invisible
+		alpha = HUNTER_STEALTH_WALK_ALPHA //85% invisible
 	//Running stealth
 	else
 		alpha = HUNTER_STEALTH_RUN_ALPHA //50% invisible


### PR DESCRIPTION
:cl: by Surrealistik
balance: Hunter max stealth transparency reduced from 95% to 90%. Subject to tweaking.
balance: Hunter sneak attack damage multipliers halved while on run intent, unless stationary for 2+ seconds.
fix: Being on fire removes stealth.
/:cl: