### PR TITLE
Adds an MRE to the standard kit for squad marine roles. 

### DIFF
--- a/code/game/machinery/vending/new_marine_vendors.dm
+++ b/code/game/machinery/vending/new_marine_vendors.dm
@@ -1039,7 +1039,7 @@ var/list/available_specialist_sets = list("Scout Set", "Sniper Set", "Demolition
 	spawned_gear_list = list(
 						/obj/item/clothing/head/helmet/marine,
 						/obj/item/clothing/under/marine,
-						/obj/item/clothing/shoes/marine
+						/obj/item/clothing/shoes/marine,
 						/obj/item/storage/box/MRE
 						)
 
@@ -1048,14 +1048,14 @@ var/list/available_specialist_sets = list("Scout Set", "Sniper Set", "Demolition
 	spawned_gear_list = list(
 						/obj/item/clothing/head/helmet/marine,
 						/obj/item/clothing/under/marine,
-						/obj/item/clothing/shoes/marine
+						/obj/item/clothing/shoes/marine,
 						/obj/item/storage/box/MRE
 						)
 
 /obj/effect/essentials_set/basic_specialist
 	spawned_gear_list = list(
 						/obj/item/clothing/under/marine,
-						/obj/item/clothing/shoes/marine
+						/obj/item/clothing/shoes/marine,
 						/obj/item/storage/box/MRE
 						)
 
@@ -1065,7 +1065,7 @@ var/list/available_specialist_sets = list("Scout Set", "Sniper Set", "Demolition
 						/obj/item/clothing/head/helmet/marine/leader,
 						/obj/item/clothing/glasses/hud/health,
 						/obj/item/clothing/under/marine,
-						/obj/item/clothing/shoes/marine
+						/obj/item/clothing/shoes/marine,
 						/obj/item/storage/box/MRE
 						)
 
@@ -1074,7 +1074,7 @@ var/list/available_specialist_sets = list("Scout Set", "Sniper Set", "Demolition
 						/obj/item/clothing/head/helmet/marine/medic,
 						/obj/item/clothing/glasses/hud/health,
 						/obj/item/clothing/under/marine/medic,
-						/obj/item/clothing/shoes/marine
+						/obj/item/clothing/shoes/marine,
 						/obj/item/storage/box/MRE
 						)
 
@@ -1083,7 +1083,7 @@ var/list/available_specialist_sets = list("Scout Set", "Sniper Set", "Demolition
 						/obj/item/clothing/head/helmet/marine/tech,
 						/obj/item/clothing/glasses/welding,
 						/obj/item/clothing/under/marine/engineer,
-						/obj/item/clothing/shoes/marine
+						/obj/item/clothing/shoes/marine,
 						/obj/item/storage/box/MRE
 						)
 
@@ -1095,7 +1095,7 @@ var/list/available_specialist_sets = list("Scout Set", "Sniper Set", "Demolition
 						/obj/item/roller/medevac,
 						/obj/item/device/medevac_beacon,
 						/obj/item/roller,
-						/obj/item/reagent_container/hypospray/advanced/oxycodone
+						/obj/item/reagent_container/hypospray/advanced/oxycodone,
 						/obj/item/storage/box/MRE
 						)
 
@@ -1107,7 +1107,7 @@ var/list/available_specialist_sets = list("Scout Set", "Sniper Set", "Demolition
 						/obj/item/cell/high,
 						/obj/item/tool/shovel/etool,
 						/obj/item/device/lightreplacer,
-						/obj/item/circuitboard/general
+						/obj/item/circuitboard/general,
 						/obj/item/storage/box/MRE
 						)
 
@@ -1122,7 +1122,7 @@ var/list/available_specialist_sets = list("Scout Set", "Sniper Set", "Demolition
 						/obj/item/device/radio,
 						/obj/item/device/motiondetector,
 						/obj/item/map/current_map,
-						/obj/item/device/binoculars/tactical
+						/obj/item/device/binoculars/tactical,
 						/obj/item/storage/box/MRE
 						)
 

--- a/code/game/machinery/vending/new_marine_vendors.dm
+++ b/code/game/machinery/vending/new_marine_vendors.dm
@@ -1040,6 +1040,7 @@ var/list/available_specialist_sets = list("Scout Set", "Sniper Set", "Demolition
 						/obj/item/clothing/head/helmet/marine,
 						/obj/item/clothing/under/marine,
 						/obj/item/clothing/shoes/marine
+						/obj/item/storage/box/MRE
 						)
 
 
@@ -1048,12 +1049,14 @@ var/list/available_specialist_sets = list("Scout Set", "Sniper Set", "Demolition
 						/obj/item/clothing/head/helmet/marine,
 						/obj/item/clothing/under/marine,
 						/obj/item/clothing/shoes/marine
+						/obj/item/storage/box/MRE
 						)
 
 /obj/effect/essentials_set/basic_specialist
 	spawned_gear_list = list(
 						/obj/item/clothing/under/marine,
 						/obj/item/clothing/shoes/marine
+						/obj/item/storage/box/MRE
 						)
 
 /obj/effect/essentials_set/basic_squadleader
@@ -1063,6 +1066,7 @@ var/list/available_specialist_sets = list("Scout Set", "Sniper Set", "Demolition
 						/obj/item/clothing/glasses/hud/health,
 						/obj/item/clothing/under/marine,
 						/obj/item/clothing/shoes/marine
+						/obj/item/storage/box/MRE
 						)
 
 /obj/effect/essentials_set/basic_medic
@@ -1071,6 +1075,7 @@ var/list/available_specialist_sets = list("Scout Set", "Sniper Set", "Demolition
 						/obj/item/clothing/glasses/hud/health,
 						/obj/item/clothing/under/marine/medic,
 						/obj/item/clothing/shoes/marine
+						/obj/item/storage/box/MRE
 						)
 
 /obj/effect/essentials_set/basic_engineer
@@ -1079,6 +1084,7 @@ var/list/available_specialist_sets = list("Scout Set", "Sniper Set", "Demolition
 						/obj/item/clothing/glasses/welding,
 						/obj/item/clothing/under/marine/engineer,
 						/obj/item/clothing/shoes/marine
+						/obj/item/storage/box/MRE
 						)
 
 /obj/effect/essentials_set/medic
@@ -1090,6 +1096,7 @@ var/list/available_specialist_sets = list("Scout Set", "Sniper Set", "Demolition
 						/obj/item/device/medevac_beacon,
 						/obj/item/roller,
 						/obj/item/reagent_container/hypospray/advanced/oxycodone
+						/obj/item/storage/box/MRE
 						)
 
 /obj/effect/essentials_set/engi
@@ -1101,6 +1108,7 @@ var/list/available_specialist_sets = list("Scout Set", "Sniper Set", "Demolition
 						/obj/item/tool/shovel/etool,
 						/obj/item/device/lightreplacer,
 						/obj/item/circuitboard/general
+						/obj/item/storage/box/MRE
 						)
 
 
@@ -1115,6 +1123,7 @@ var/list/available_specialist_sets = list("Scout Set", "Sniper Set", "Demolition
 						/obj/item/device/motiondetector,
 						/obj/item/map/current_map,
 						/obj/item/device/binoculars/tactical
+						/obj/item/storage/box/MRE
 						)
 
 


### PR DESCRIPTION
## About The Pull Request

The name pretty much says it. Adds a single randomized MRE to the standard kits for PFC, Squad Medic, Squad Engineer, Squad Smartgunner, Squad Specialist, and Squad Leader. 

## Why It's Good For The Game

Marines should have food, really. 

## Changelog
:cl:
add: Added an MRE to marine standard kits. 

