### PR TITLE
Changes assigned_role to be a /datum/job instead of a string

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -50,8 +50,8 @@
 #define ishumanbasic(H) (is_species(H, /datum/species/human))
 
 //Job/role helpers
-#define issurvivor(H) (H?.mind?.assigned_role == "Survivor")
-#define ismarine(H) (H?.faction == "Marine" && (H?.mind?.assigned_role in JOBS_MARINES))
+#define issurvivor(H) (istype(H?.mind?.assigned_role, /datum/job/survivor)
+#define ismarine(H) (H?.faction == "Marine" && (H?.mind?.assigned_role?.department_flag & (J_FLAG_MARINE|J_FLAG_SHIP)))
 #define ispmc(H) (H?.faction == "PMC")
 
 //more carbon mobs

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -50,7 +50,7 @@
 #define ishumanbasic(H) (is_species(H, /datum/species/human))
 
 //Job/role helpers
-#define issurvivor(H) (istype(H?.mind?.assigned_role, /datum/job/survivor)
+#define issurvivor(H) (istype(H?.mind?.assigned_role, /datum/job/survivor))
 #define ismarine(H) (H?.faction == "Marine" && (H?.mind?.assigned_role?.department_flag & (J_FLAG_MARINE|J_FLAG_SHIP)))
 #define ispmc(H) (H?.faction == "PMC")
 

--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -129,6 +129,7 @@
 #define JOB_DISPLAY_ORDER_SUQAD_ENGINEER 21
 #define JOB_DISPLAY_ORDER_SQUAD_MARINE 22
 
+#define JOBS_MARINE_ROLES (J_FLAG_MARINE|J_FLAG_SHIP)
 
 #define JOBS_COMMAND 		list("Commander", "Executive Officer", "Staff Officer", "Pilot Officer", "Tank Crewman", "Corporate Liaison", "Requisitions Officer", "Chief Engineer", "Chief Medical Officer", "Synthetic")
 #define JOBS_POLICE			list("Chief MP", "Military Police")
@@ -136,7 +137,7 @@
 #define JOBS_ENGINEERING 	list("Chief Engineer", "Maintenance Tech")
 #define JOBS_REQUISITIONS 	list("Requisitions Officer", "Cargo Technician")
 #define JOBS_MEDICAL 		list("Chief Medical Officer", "Doctor", "Medical Researcher")
-#define JOBS_MARINES		list("Squad Leader", "Squad Specialist", "Squad Smartgunner", "Squad Medic", "Squad Engineer", "Squad Marine")
+//#define JOBS_MARINES		list("Squad Leader", "Squad Specialist", "Squad Smartgunner", "Squad Medic", "Squad Engineer", "Squad Marine")
 #define JOBS_SQUADS			list("Alpha", "Bravo", "Charlie" ,"Delta")
-#define JOBS_REGULAR_ALL	JOBS_OFFICERS + JOBS_POLICE + JOBS_ENGINEERING + JOBS_REQUISITIONS + JOBS_MEDICAL + JOBS_MARINES
+//#define JOBS_REGULAR_ALL	JOBS_OFFICERS + JOBS_POLICE + JOBS_ENGINEERING + JOBS_REQUISITIONS + JOBS_MEDICAL + JOBS_MARINES
 #define JOBS_UNASSIGNED		list("Squad Marine")

--- a/code/controllers/stonedmc/subsystem/job.dm
+++ b/code/controllers/stonedmc/subsystem/job.dm
@@ -61,8 +61,8 @@ SUBSYSTEM_DEF(job)
 	return type_occupations[jobtype]
 
 
-/datum/controller/subsystem/job/proc/AssignRole(mob/new_player/player, job, latejoin = FALSE)
-	JobDebug("Running AR, Player: [player], Rank: [job.title], LJ: [latejoin]")
+/datum/controller/subsystem/job/proc/AssignRole(mob/new_player/player, datum/job/job, latejoin = FALSE)
+	JobDebug("Running AR, Player: [player], Rank: [job?.title], LJ: [latejoin]")
 	if(player?.mind)
 		if(!job)
 			return FALSE
@@ -79,7 +79,7 @@ SUBSYSTEM_DEF(job)
 		var/position_limit = job.total_positions
 		if(!latejoin)
 			position_limit = job.spawn_positions
-		JobDebug("Player: [player] is now Rank: [rank], JCP:[job.current_positions], JPL:[position_limit]")
+		JobDebug("Player: [player] is now Rank: [job.title], JCP:[job.current_positions], JPL:[position_limit]")
 		player.mind.assigned_role = job
 		unassigned -= player
 		job.current_positions++
@@ -254,7 +254,7 @@ SUBSYSTEM_DEF(job)
 
 
 //Gives the player the stuff he should have with his rank
-/datum/controller/subsystem/job/proc/EquipRank(mob/M, job, joined_late = FALSE)
+/datum/controller/subsystem/job/proc/EquipRank(mob/M, datum/job/job, joined_late = FALSE)
 	var/mob/new_player/N
 	var/mob/living/H
 	if(!joined_late)
@@ -273,12 +273,12 @@ SUBSYSTEM_DEF(job)
 				continue
 			S = pick(GLOB.marine_spawns_by_job[i])
 			break
-		if(length(GLOB.jobspawn_overrides[rank]))
-			S = pick(GLOB.jobspawn_overrides[rank])
+		if(length(GLOB.jobspawn_overrides[job.title]))
+			S = pick(GLOB.jobspawn_overrides[job.title])
 		if(S)
 			SendToAtom(H, S, buckle = FALSE)
 		if(!S) //if there isn't a spawnpoint send them to latejoin, if there's no latejoin go yell at your mapper
-			log_world("Couldn't find a round start spawn point for [rank]")
+			log_world("Couldn't find a round start spawn point for [job.title]")
 			SendToLateJoin(H)
 
 	if(job && H.mind)
@@ -290,12 +290,12 @@ SUBSYSTEM_DEF(job)
 				N.new_character = H
 			else
 				M = H
-		if(rank in JOBS_MARINES)
+		if(job.department_flag & J_FLAG_MARINE)
 			if(H.mind.assigned_squad)
 				var/datum/squad/S = H.mind.assigned_squad
 				S.put_marine_in_squad(H)
 			else
-				JobDebug("Failed to put marine role in squad. Player: [H.key] Rank: [rank]")
+				JobDebug("Failed to put marine role in squad. Player: [H.key] Rank: [job.title]")
 	if(ishuman(H))
 		//Give them an account in the database.
 		var/datum/money_account/A = create_account(H.real_name, rand(50,500) * 10, null)

--- a/code/controllers/stonedmc/subsystem/job.dm
+++ b/code/controllers/stonedmc/subsystem/job.dm
@@ -80,7 +80,7 @@ SUBSYSTEM_DEF(job)
 		if(!latejoin)
 			position_limit = job.spawn_positions
 		JobDebug("Player: [player] is now Rank: [rank], JCP:[job.current_positions], JPL:[position_limit]")
-		player.mind.assigned_role = rank
+		player.mind.assigned_role = job
 		unassigned -= player
 		job.current_positions++
 		return TRUE
@@ -254,7 +254,7 @@ SUBSYSTEM_DEF(job)
 
 
 //Gives the player the stuff he should have with his rank
-/datum/controller/subsystem/job/proc/EquipRank(mob/M, rank, joined_late = FALSE)
+/datum/controller/subsystem/job/proc/EquipRank(mob/M, job, joined_late = FALSE)
 	var/mob/new_player/N
 	var/mob/living/H
 	if(!joined_late)
@@ -263,9 +263,7 @@ SUBSYSTEM_DEF(job)
 	else
 		H = M
 
-	var/datum/job/job = GetJob(rank)
-
-	H.job = rank
+	H.job = job.title
 
 	//If we joined at roundstart we should be positioned at our workstation
 	if(!joined_late && job)
@@ -284,7 +282,7 @@ SUBSYSTEM_DEF(job)
 			SendToLateJoin(H)
 
 	if(job && H.mind)
-		H.mind.assigned_role = rank
+		//H.mind.assigned_role = job
 		var/new_mob = job.equip(H, null, null, joined_late , null, M.client)
 		if(ismob(new_mob))
 			H = new_mob

--- a/code/controllers/stonedmc/subsystem/ticker.dm
+++ b/code/controllers/stonedmc/subsystem/ticker.dm
@@ -266,7 +266,7 @@ SUBSYSTEM_DEF(ticker)
 	for(var/mob/new_player/N in GLOB.player_list)
 		var/mob/living/carbon/human/player = N.new_character
 		if(istype(player) && player.mind && player.mind.assigned_role)
-			if(istype(player.mind.assigned_role, /datum/job/command/commander)
+			if(istype(player.mind.assigned_role, /datum/job/command/commander))
 				captainless = FALSE
 			if(player.mind.assigned_role)
 				SSjob.EquipRank(N, player.mind.assigned_role, 0)

--- a/code/controllers/stonedmc/subsystem/ticker.dm
+++ b/code/controllers/stonedmc/subsystem/ticker.dm
@@ -266,7 +266,7 @@ SUBSYSTEM_DEF(ticker)
 	for(var/mob/new_player/N in GLOB.player_list)
 		var/mob/living/carbon/human/player = N.new_character
 		if(istype(player) && player.mind && player.mind.assigned_role)
-			if(player.mind.assigned_role == "Commander")
+			if(istype(player.mind.assigned_role, /datum/job/command/commander)
 				captainless = FALSE
 			if(player.mind.assigned_role)
 				SSjob.EquipRank(N, player.mind.assigned_role, 0)

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -220,7 +220,7 @@ var/global/list/PDA_Manifest = list()
 	if(PDA_Manifest.len)
 		PDA_Manifest.Cut()
 
-	if(H.mind && (H.mind.assigned_role != "MODE"))
+	if(H.mind)
 		var/assignment
 		if(H.mind.assigned_role)
 			assignment = H.mind.assigned_role

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -36,7 +36,7 @@
 
 	var/memory
 
-	var/assigned_role
+	var/datum/job/assigned_role
 	var/assigned_squad
 	var/comm_title
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -131,7 +131,7 @@
 		var/new_role = input("Select new role", "Assigned role", assigned_role) as null|anything in SSjob.name_occupations
 		if(!new_role)
 			return
-		assigned_role = new_role
+		assigned_role = SSjob.GetJob(new_role)
 
 	else if(href_list["memory_edit"])
 		var/new_memo = copytext(sanitize(input("Write new memory", "Memory", memory) as null|message),1,MAX_MESSAGE_LEN)
@@ -157,7 +157,7 @@
 	. = ..()
 	//if not, we give the mind default job_knowledge and assigned_role
 	if(!mind.assigned_role)
-		mind.assigned_role = "Squad Marine"	//default
+		mind.assigned_role = new /datum/job/marine/standard	//default
 		if(mind.cm_skills)
 			qdel(mind.cm_skills)
 		mind.cm_skills = new /datum/skills/pfc
@@ -165,14 +165,14 @@
 
 /mob/living/carbon/Xenomorph/mind_initialize()
 	. = ..()
-	mind.assigned_role = "Xenomorph"
+	mind.assigned_role = new /datum/job/other/xenomorph
 
 
 /mob/living/silicon/mind_initialize()
 	. = ..()
-	mind.assigned_role = "Silicon"
+	mind.assigned_role = new /datum/job/other/silicon
 
 
 /mob/living/simple_animal/mind_initialize()
 	. = ..()
-	mind.assigned_role = "Animal"
+	mind.assigned_role = new /datum/job/other/simple_animal

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -116,11 +116,6 @@ datum/game_mode/proc/initialize_special_clamps()
 	if(possible_xenomorphs.len < xeno_required_num) //We don't have enough aliens.
 		return FALSE
 
-	//Minds are not transferred at this point, so we have to clean out those who may be already picked to play.
-	for(var/datum/mind/A in possible_xenomorphs)
-		if(A.assigned_role == "MODE")
-			possible_xenomorphs -= A
-
 	var/i = xeno_starting_num
 	var/datum/mind/new_xeno
 	var/turf/larvae_spawn
@@ -149,18 +144,13 @@ datum/game_mode/proc/initialize_special_clamps()
 /datum/game_mode/proc/initialize_starting_queen_list()
 	var/list/datum/mind/possible_queens = get_players_for_role(BE_QUEEN)
 
-	//Minds are not transferred at this point, so we have to clean out those who may be already picked to play.
-	for(var/datum/mind/A in possible_queens)
-		if(A.assigned_role == "MODE")
-			possible_queens -= A
-
 	if(!length(possible_queens))
 		return FALSE
 
 	for(var/datum/mind/new_queen in possible_queens)
 		if(jobban_isbanned(new_queen.current))
 			continue
-		new_queen.assigned_role = "Queen"
+		new_queen.assigned_role = new /datum/job/other/xenomorph/queen
 		queen = new_queen
 		break
 
@@ -351,22 +341,17 @@ datum/game_mode/proc/initialize_post_queen_list()
 /datum/game_mode/proc/initialize_starting_survivor_list()
 	var/list/datum/mind/possible_survivors = get_players_for_role(BE_SURVIVOR)
 	if(possible_survivors.len) //We have some, it looks like.
-		for(var/datum/mind/A in possible_survivors) //Strip out any xenos first so we don't double-dip.
-			if(A.assigned_role == "MODE")
-				possible_survivors -= A
-
-		if(possible_survivors.len) //We may have stripped out all the contendors, so check again.
-			var/i = surv_starting_num
-			var/datum/mind/new_survivor
-			while(i > 0)
-				if(!length(possible_survivors))
-					break  //Ran out of candidates! Can't have a null pick(), so just stick with what we have.
-				new_survivor = pick(possible_survivors)
-				if(!new_survivor)
-					break  //We ran out of survivors!
-				survivors += new_survivor
-				possible_survivors -= new_survivor
-				i--
+		var/i = surv_starting_num
+		var/datum/mind/new_survivor
+		while(i > 0)
+			if(!length(possible_survivors))
+				break  //Ran out of candidates! Can't have a null pick(), so just stick with what we have.
+			new_survivor = pick(possible_survivors)
+			if(!new_survivor)
+				break  //We ran out of survivors!
+			survivors += new_survivor
+			possible_survivors -= new_survivor
+			i--
 
 /datum/game_mode/proc/initialize_post_survivor_list()
 	for(var/datum/mind/survivor in survivors)

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -129,7 +129,7 @@ datum/game_mode/proc/initialize_special_clamps()
 			new_xeno = pick(possible_xenomorphs)
 			if(!new_xeno)
 				break  //Looks like we didn't get anyone. Back out.
-			new_xeno.assigned_role = "Xenomorph"
+			new_xeno.assigned_role = new /datum/job/other/xenomorph
 			xenomorphs += new_xeno
 			possible_xenomorphs -= new_xeno
 		else //Out of candidates, spawn in empty larvas directly
@@ -364,7 +364,6 @@ datum/game_mode/proc/initialize_post_queen_list()
 				new_survivor = pick(possible_survivors)
 				if(!new_survivor)
 					break  //We ran out of survivors!
-				new_survivor.assigned_role = "Survivor"
 				survivors += new_survivor
 				possible_survivors -= new_survivor
 				i--
@@ -383,6 +382,7 @@ datum/game_mode/proc/initialize_post_queen_list()
 
 	var/survivor_job = pick(subtypesof(/datum/job/survivor))
 	var/datum/job/J = new survivor_job
+	ghost.assigned_role = J
 	J.equip(H)
 
 	if(GLOB.map_tag == MAP_ICE_COLONY)

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -13,7 +13,6 @@
 	var/found_xenos = initialize_starting_xenomorph_list()
 	if(!found_queen && !found_xenos)
 		return FALSE
-	initialize_starting_survivor_list()
 	latejoin_larva_drop = CONFIG_GET(number/latejoin_larva_required_num)
 	return TRUE
 
@@ -65,6 +64,7 @@
 /datum/game_mode/colonialmarines/post_setup()
 	initialize_post_queen_list()
 	initialize_post_xenomorph_list()
+	initialize_starting_survivor_list()
 	initialize_post_survivor_list()
 	initialize_post_marine_gear_list()
 

--- a/code/game/jobs/job/other.dm
+++ b/code/game/jobs/job/other.dm
@@ -4,6 +4,12 @@
 //Xeno
 /datum/job/other/xenomorph
 
+/datum/job/other/xenomorph/queen
+
+/datum/job/other/silicon
+
+/datum/job/other/simple_animal
+
 //Colonist
 /datum/job/other/colonist
 	title = "Colonist"

--- a/code/game/jobs/job/other.dm
+++ b/code/game/jobs/job/other.dm
@@ -1,6 +1,8 @@
 /datum/job/other
 	department_flag = J_FLAG_MISC
 
+//Xeno
+/datum/job/other/xenomorph
 
 //Colonist
 /datum/job/other/colonist

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -18,7 +18,7 @@
 		if(C.mob && C.mob.stat != DEAD)
 			if(ishuman(C.mob) && !iszombie(C.mob))
 				count_humans++
-				if(C.mob.mind.assigned_role in (JOBS_MARINES))
+				if(C.mob.mind.assigned_role.department_flag & J_FLAG_MARINE)
 					count_marine_humans++
 				if(C.mob.status_flags & XENO_HOST)
 					count_infectedhumans++

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -161,7 +161,7 @@
 	if(!istype(H) || !SSticker || !H.mind?.assigned_role)
 		return
 
-	if(!(H.mind.assigned_role in JOBS_MARINES))
+	if(!(H.mind.assigned_role.department_flag & J_FLAG_MARINE))
 		return
 
 	var/squad = input("Choose the marine's new squad") as null|anything in SSjob.squads

--- a/code/modules/admin/fun_verbs.dm
+++ b/code/modules/admin/fun_verbs.dm
@@ -751,7 +751,7 @@
 
 			H.equip_to_slot_or_del(I, SLOT_WEAR_ID)
 
-			SSjob.AssignRole(H, newrank)
+			SSjob.AssignRole(H, J)
 			O.post_equip(H)
 
 			log_admin("[key_name(usr)] has set the rank of [key_name(H)] to [newrank].")

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -356,7 +356,7 @@ datum/preferences
 	var/datum/job/job
 	for(var/i in sortList(SSjob.occupations, /proc/cmp_job_display_asc))
 		job = i
-		if(!(job.title in JOBS_REGULAR_ALL))
+		if(!(job.department_flag & JOBS_MARINE_ROLES))
 			continue
 		index += 1
 		if((index >= limit) || (job.title in splitJobs))

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -212,7 +212,7 @@
 	close_spawn_windows()
 	spawning = TRUE
 
-	if(!SSjob.AssignRole(src, rank, TRUE))
+	if(!SSjob.AssignRole(src, SSjob.GetJob(rank), TRUE))
 		to_chat(usr, "<span class='warning'>Failed to assign selected role.<spawn>")
 		return
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -258,7 +258,7 @@
 	var/datum/job/J
 	for(var/i in sortList(SSjob.occupations, /proc/cmp_job_display_asc))
 		J = i
-		if(!(J.title in JOBS_REGULAR_ALL))
+		if(!(J.department_flag & JOBS_MARINE_ROLES))
 			continue
 		if((J.current_positions >= J.spawn_positions) && J.spawn_positions != -1)
 			continue


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This changes mind.assigned_role to be job datums instead of strings
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This will simplify a lot of code that has to deal with assigned_role.  Also it will eliminate more string ids that are prone to undetectable bugs from misspellings.  Seeing the changes required by #666/#641/#539 was a heavy inspiration for this, eg; there shouldn't be hardcoded lists of names
