### PR TITLE
Fixes Evac ending the round

### DIFF
--- a/code/game/gamemodes/cm_self_destruct.dm
+++ b/code/game/gamemodes/cm_self_destruct.dm
@@ -58,7 +58,7 @@ var/global/datum/authority/branch/evacuation/EvacuationAuthority //This is initi
 	var/dest_index = 1	//What rod the thing is currently on.
 	var/dest_status = NUKE_EXPLOSION_INACTIVE
 
-	var/flags_scuttle = NOFLAGS
+	var/flags_scuttle = FLAGS_EVACUATION_DENY|FLAGS_SELF_DESTRUCT_DENY
 
 /datum/authority/branch/evacuation/New()
 	. = ..()

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -123,7 +123,7 @@
 
 	if(EvacuationAuthority.dest_status == NUKE_EXPLOSION_FINISHED) //Nuke went off, ending the round.
 		round_finished = MODE_GENERIC_DRAW_NUKE
-	else if(!num_humans) && num_xenos)
+	else if(!num_humans && num_xenos)
 		round_finished = MODE_INFESTATION_X_MAJOR //No humans remain alive.
 	else if(num_humans && !num_xenos)
 		round_finished = MODE_INFESTATION_M_MAJOR //Humans destroyed the xenomorphs.

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -122,12 +122,16 @@
 	var/num_xenos = living_player_list[2]
 
 	if(EvacuationAuthority.dest_status == NUKE_EXPLOSION_FINISHED) //Nuke went off, ending the round.
+		message_admins("Round finished: [MODE_GENERIC_DRAW_NUKE]")
 		round_finished = MODE_GENERIC_DRAW_NUKE
 	else if(!num_humans && num_xenos)
+		message_admins("Round finished: [MODE_INFESTATION_X_MAJOR]")
 		round_finished = MODE_INFESTATION_X_MAJOR //No humans remain alive.
 	else if(num_humans && !num_xenos)
+		message_admins("Round finished: [MODE_INFESTATION_M_MAJOR]")
 		round_finished = MODE_INFESTATION_M_MAJOR //Humans destroyed the xenomorphs.
 	else if(num_humans && num_xenos)
+		message_admins("Round finished: [MODE_INFESTATION_DRAW_DEATH]")
 		round_finished = MODE_INFESTATION_DRAW_DEATH //Both were somehow destroyed.
 
 

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -125,11 +125,11 @@
 		round_finished = MODE_GENERIC_DRAW_NUKE
 		return
 
-	if(!length(num_humans) && length(num_xenos))
+	if(!num_humans) && num_xenos)
 		round_finished = MODE_INFESTATION_X_MAJOR //No humans remain alive.
-	else if(length(num_humans) && !length(num_xenos))
+	else if(num_humans && !num_xenos)
 		round_finished = MODE_INFESTATION_M_MAJOR //Humans destroyed the xenomorphs.
-	else if(!length(num_humans) && !length(num_xenos))
+	else if(num_humans && num_xenos)
 		round_finished = MODE_INFESTATION_DRAW_DEATH //Both were somehow destroyed.
 
 

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -123,13 +123,14 @@
 
 	if(EvacuationAuthority.dest_status == NUKE_EXPLOSION_FINISHED) //Nuke went off, ending the round.
 		round_finished = MODE_GENERIC_DRAW_NUKE
-	else if(EvacuationAuthority.dest_status < NUKE_EXPLOSION_IN_PROGRESS) //If the nuke ISN'T in progress. We do not want to end the round before it detonates.
-		if(!num_humans && num_xenos)
-			round_finished = MODE_INFESTATION_X_MAJOR //No humans remain alive.
-		else if(num_humans && !num_xenos)
-			round_finished = MODE_INFESTATION_M_MAJOR //Humans destroyed the xenomorphs.
-		else if(!num_humans && !num_xenos)
-			round_finished = MODE_INFESTATION_DRAW_DEATH //Both were somehow destroyed.
+		return
+
+	if(!length(num_humans) && length(num_xenos))
+		round_finished = MODE_INFESTATION_X_MAJOR //No humans remain alive.
+	else if(length(num_humans) && !length(num_xenos))
+		round_finished = MODE_INFESTATION_M_MAJOR //Humans destroyed the xenomorphs.
+	else if(!length(num_humans) && !length(num_xenos))
+		round_finished = MODE_INFESTATION_DRAW_DEATH //Both were somehow destroyed.
 
 
 /datum/game_mode/colonialmarines/check_queen_status(queen_time)

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -130,7 +130,7 @@
 	else if(num_humans && !num_xenos)
 		message_admins("Round finished: [MODE_INFESTATION_M_MAJOR]")
 		round_finished = MODE_INFESTATION_M_MAJOR //Humans destroyed the xenomorphs.
-	else if(num_humans && num_xenos)
+	else if(!num_humans && !num_xenos)
 		message_admins("Round finished: [MODE_INFESTATION_DRAW_DEATH]")
 		round_finished = MODE_INFESTATION_DRAW_DEATH //Both were somehow destroyed.
 

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -123,9 +123,7 @@
 
 	if(EvacuationAuthority.dest_status == NUKE_EXPLOSION_FINISHED) //Nuke went off, ending the round.
 		round_finished = MODE_GENERIC_DRAW_NUKE
-		return
-
-	if(!num_humans) && num_xenos)
+	else if(!num_humans) && num_xenos)
 		round_finished = MODE_INFESTATION_X_MAJOR //No humans remain alive.
 	else if(num_humans && !num_xenos)
 		round_finished = MODE_INFESTATION_M_MAJOR //Humans destroyed the xenomorphs.

--- a/code/modules/shuttles/marine_ferry.dm
+++ b/code/modules/shuttles/marine_ferry.dm
@@ -432,7 +432,11 @@
 
 	sleep(travel_time) //Wait while we fly, but give extra time for crashing announcements etc
 
-	if(EvacuationAuthority.dest_status >= NUKE_EXPLOSION_IN_PROGRESS) return FALSE //If a nuke is in progress, don't attempt a landing.
+	if(EvacuationAuthority.dest_status >= NUKE_EXPLOSION_IN_PROGRESS) 
+		return FALSE //If a nuke is in progress, don't attempt a landing.
+
+	EvacuationAuthority.flags_scuffle &= FLAGS_EVACUATION_DENY
+	EvacuationAuthority.flags_scuffle &= FLAGS_SELF_DESTRUCT_DENY
 
 	//This is where things change and shit gets real
 

--- a/code/modules/shuttles/marine_ferry.dm
+++ b/code/modules/shuttles/marine_ferry.dm
@@ -430,10 +430,6 @@
 
 	sleep(travel_time) //Wait while we fly, but give extra time for crashing announcements etc
 
-	if(EvacuationAuthority.dest_status >= NUKE_EXPLOSION_IN_PROGRESS) 
-		return FALSE //If a nuke is in progress, don't attempt a landing.
-
-
 	//This is where things change and shit gets real
 
 	command_announcement.Announce("DROPSHIP ON COLLISION COURSE. CRASH IMMINENT." , "EMERGENCY", new_sound='sound/AI/dropship_emergency.ogg')

--- a/code/modules/shuttles/marine_ferry.dm
+++ b/code/modules/shuttles/marine_ferry.dm
@@ -267,8 +267,6 @@
 
 	sleep(travel_time) //Wait while we fly
 
-	if(EvacuationAuthority.dest_status >= NUKE_EXPLOSION_IN_PROGRESS) return FALSE //If a nuke is in progress, don't attempt a landing.
-
 	playsound(turfs_int[sound_target], sound_landing, 60, 0)
 	playsound(turfs_trg[sound_target], sound_landing, 60, 0)
 

--- a/code/modules/shuttles/marine_ferry.dm
+++ b/code/modules/shuttles/marine_ferry.dm
@@ -435,8 +435,8 @@
 	if(EvacuationAuthority.dest_status >= NUKE_EXPLOSION_IN_PROGRESS) 
 		return FALSE //If a nuke is in progress, don't attempt a landing.
 
-	EvacuationAuthority.flags_scuffle &= FLAGS_EVACUATION_DENY
-	EvacuationAuthority.flags_scuffle &= FLAGS_SELF_DESTRUCT_DENY
+	EvacuationAuthority.flags_scuttle &= FLAGS_EVACUATION_DENY
+	EvacuationAuthority.flags_scuttle &= FLAGS_SELF_DESTRUCT_DENY
 
 	//This is where things change and shit gets real
 

--- a/code/modules/shuttles/marine_ferry.dm
+++ b/code/modules/shuttles/marine_ferry.dm
@@ -435,8 +435,6 @@
 	if(EvacuationAuthority.dest_status >= NUKE_EXPLOSION_IN_PROGRESS) 
 		return FALSE //If a nuke is in progress, don't attempt a landing.
 
-	EvacuationAuthority.flags_scuttle &= FLAGS_EVACUATION_DENY
-	EvacuationAuthority.flags_scuttle &= FLAGS_SELF_DESTRUCT_DENY
 
 	//This is where things change and shit gets real
 

--- a/code/modules/shuttles/shuttle_console.dm
+++ b/code/modules/shuttles/shuttle_console.dm
@@ -172,6 +172,8 @@
 					var/mob/living/carbon/Xenomorph/Queen/Q = usr // typechecked above
 					xeno_message("<span class='xenoannounce'>The Queen has commanded the metal bird to depart for the metal hive in the sky! Rejoice!</span>",3,Q.hivenumber)
 					playsound(src, 'sound/misc/queen_alarm.ogg')
+					EvacuationAuthority.flags_scuttle &= FLAGS_EVACUATION_DENY
+					EvacuationAuthority.flags_scuttle &= FLAGS_SELF_DESTRUCT_DENY
 				else if(i == "No")
 					return
 				else


### PR DESCRIPTION
I made this PR at 6AM while coughing my lungs out I don't even know if it works or not but hey such is life
EDIT: It actually fixes it
:cl: LaKiller8
tweak: Marines can now only start evac and SD after crash.
fix: Evac no longer ends the round.
/:cl: