### PR TITLE
Stomp Damage Fix

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -526,6 +526,8 @@ var/list/global_mutations = list() // list of hidden mutation things
 #define CRUSHER_CRESTTOSS_COOLDOWN		6 SECONDS
 #define CRUSHER_STOMP_COST				80
 #define CRUSHER_STOMP_COOLDOWN 			20 SECONDS
+#define CRUSHER_STOMP_LOWER_DMG			80
+#define CRUSHER_STOMP_UPPER_DMG			100
 
 //carrier defines
 

--- a/code/modules/mob/living/carbon/xenomorph/Castes/Crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Castes/Crusher.dm
@@ -199,17 +199,17 @@
 		if(isxeno(M) || M.stat == DEAD || ((M.status_flags & XENO_HOST) && istype(M.buckled, /obj/structure/bed/nest)))
 			continue
 		var/distance = get_dist(M, loc)
-		var/damage = rand(CRUSHER_STOMP_LOWER_DMG, CRUSHER_STOMP_UPPER_DMG) / max(1,distance + 1)
+		var/damage = (rand(CRUSHER_STOMP_LOWER_DMG, CRUSHER_STOMP_UPPER_DMG) * (1 + upgrade * 0.05)) / max(1,distance + 1)
 		if(frenzy_aura > 0)
 			damage *= (1 + round(frenzy_aura * 0.1,0.01)) //+10% per level of Frenzy
 		if(distance == 0) //If we're on top of our victim, give him the full impact
 			round_statistics.crusher_stomp_victims++
-			var/armor_block = M.run_armor_check("chest", "melee") * 0.5 //Only 75% armor applies vs stomp brute damage
+			var/armor_block = M.run_armor_check("chest", "melee") * 0.5 //Only 50% armor applies vs stomp brute damage
 			if(ishuman(M))
 				var/mob/living/carbon/human/H = M
-				H.take_overall_damage(rand(damage * 0.75,damage * 1.25), null, 0, 0, 0, armor_block) //Armour functions against this.
+				H.take_overall_damage(rand(damage), null, 0, 0, 0, armor_block) //Armour functions against this.
 			else
-				M.take_overall_damage(rand(damage * 0.75,damage * 1.25), 0, null, armor_block) //Armour functions against this.
+				M.take_overall_damage(rand(damage), 0, null, armor_block) //Armour functions against this.
 			to_chat(M, "<span class='highdanger'>You are stomped on by [src]!</span>")
 			shake_camera(M, 3, 3)
 		else

--- a/code/modules/mob/living/carbon/xenomorph/Castes/Crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Castes/Crusher.dm
@@ -199,12 +199,12 @@
 		if(isxeno(M) || M.stat == DEAD || ((M.status_flags & XENO_HOST) && istype(M.buckled, /obj/structure/bed/nest)))
 			continue
 		var/distance = get_dist(M, loc)
-		var/damage = (rand(xeno_caste.melee_damage_lower, xeno_caste.melee_damage_upper) * 1.5) / max(1,distance + 1)
+		var/damage = rand(CRUSHER_STOMP_LOWER_DMG, CRUSHER_STOMP_UPPER_DMG) / max(1,distance + 1)
 		if(frenzy_aura > 0)
 			damage *= (1 + round(frenzy_aura * 0.1,0.01)) //+10% per level of Frenzy
 		if(distance == 0) //If we're on top of our victim, give him the full impact
 			round_statistics.crusher_stomp_victims++
-			var/armor_block = M.run_armor_check("chest", "melee")
+			var/armor_block = M.run_armor_check("chest", "melee") * 0.5 //Only 75% armor applies vs stomp brute damage
 			if(ishuman(M))
 				var/mob/living/carbon/human/H = M
 				H.take_overall_damage(rand(damage * 0.75,damage * 1.25), null, 0, 0, 0, armor_block) //Armour functions against this.
@@ -220,7 +220,7 @@
 			M.KnockDown(1)
 		else
 			M.Stun(1) //Otherwise we just get stunned.
-		M.apply_damage(rand(damage * 0.75 , damage * 1.25), HALLOSS) //Armour ignoring Halloss
+		M.apply_damage(damage, HALLOSS) //Armour ignoring Halloss
 
 
 //The atom collided with is passed to this proc, all types of collisions are dealt with here.


### PR DESCRIPTION
:cl: by Surrealistik
balance: A direct stomp hit wasn't doing intended damage; this has been fixed. Now deals 80-100 melee brute damage, with half of armor applying. Each upgrade level increases damage by 5%.
/:cl: