### PR TITLE
Resolves runtimes caused by the new SL tracker

### DIFF
--- a/code/controllers/stonedmc/subsystem/direction.dm
+++ b/code/controllers/stonedmc/subsystem/direction.dm
@@ -45,7 +45,7 @@ SUBSYSTEM_DEF(direction)
 				H = currentrun[L][currentrun[L].len]
 				currentrun[L].len--
 				if(!H)
-					stack_trace("null in squad tracking")
+					processing_mobs[L].Remove(H)
 					continue
 				H.update_leader_tracking(C)
 				if(MC_TICK_CHECK)

--- a/code/controllers/stonedmc/subsystem/direction.dm
+++ b/code/controllers/stonedmc/subsystem/direction.dm
@@ -1,3 +1,5 @@
+#define SLDIR_DEBUG
+
 SUBSYSTEM_DEF(direction)
 	name = "Direction"
 	priority = FIRE_PRIORITY_DIRECTION
@@ -10,6 +12,10 @@ SUBSYSTEM_DEF(direction)
 	// this is a two d list of defines to lists of mobs tracking that leader
 	// eg; list(CHARLIE_SL = list(<list of references to squad marines), XENO_NORMAL_QUEEN = list(<list of xeno mob refs))
 	var/list/processing_mobs = list()
+
+	#ifdef SLDIR_DEBUG
+	var/list/mobs_in_processing = list()
+	#endif
 
 	// the purpose of separating these two things is it avoids having to do anything for mobs tracking a particular
 	//  leader when the leader changes, and its cached to avoid looking up via hive/squad datums.
@@ -60,9 +66,18 @@ SUBSYSTEM_DEF(direction)
 	if(!H)
 		stack_trace("SSdirection.start_tracking called with a null mob")
 		return
+	#ifdef SLDIR_DEBUG
+	if(mobs_in_processing[H])
+		stack_trace("trying to add a mob already being tracked")
+		return
+	mobs_in_processing[H] = TRUE
+	#endif
 	processing_mobs[squad_id].Add(H)
 
 /datum/controller/subsystem/direction/proc/stop_tracking(squad_id, mob/living/carbon/human/H, deep=FALSE)
+	#ifdef SLDIR_DEBUG
+	mobs_in_processing[H] = FALSE
+	#endif
 	if(!deep)
 		processing_mobs[squad_id].Remove(H)
 		return

--- a/code/controllers/stonedmc/subsystem/direction.dm
+++ b/code/controllers/stonedmc/subsystem/direction.dm
@@ -1,18 +1,3 @@
-#define START_TRACK_LEADER(squad, mob) \
-	SSdirection.processing_mobs[squad].Add(mob);
-
-#define STOP_TRACK_LEADER(squad, mob) \
-	SSdirection.processing_mobs[squad].Remove(mob);
-
-#define SET_TRACK_LEADER(squad, mob) \
-	SSdirection.leader_mapping[squad] = mob;
-
-#define CLEAR_TRACK_LEADER(squad) \
-	SSdirection.leader_mapping[squad] = null;
-
-#define SETUP_LEADER_MAP(squad) \
-	SSdirection.leader_mapping.Add(squad);
-
 SUBSYSTEM_DEF(direction)
 	name = "Direction"
 	priority = FIRE_PRIORITY_DIRECTION
@@ -57,6 +42,9 @@ SUBSYSTEM_DEF(direction)
 			while(currentrun[L].len)
 				H = currentrun[L][currentrun[L].len]
 				currentrun[L].len--
+				if(!H)
+					stack_trace("null in squad tracking")
+					continue
 				H.update_leader_tracking(C)
 				if(MC_TICK_CHECK)
 					return
@@ -67,3 +55,25 @@ SUBSYSTEM_DEF(direction)
 				H.clear_leader_tracking()
 				if(MC_TICK_CHECK)
 					return	
+
+/datum/controller/subsystem/direction/proc/start_tracking(squad_id, mob/living/carbon/human/H)
+	if(!H)
+		stack_trace("SSdirection.start_tracking called with a null mob")
+		return
+	processing_mobs[squad_id].Add(H)
+
+/datum/controller/subsystem/direction/proc/stop_tracking(squad_id, mob/living/carbon/human/H, deep=FALSE)
+	if(!deep)
+		processing_mobs[squad_id].Remove(H)
+		return
+	for(var/A in processing_mobs)
+		if(islist(processing_mobs[A]))
+			processing_mobs[A].Remove(H)
+
+/datum/controller/subsystem/direction/proc/set_leader(squad_id, mob/living/carbon/human/H)
+	if(leader_mapping[squad_id])
+		clear_leader(squad_id)
+	leader_mapping[squad_id] = H
+
+/datum/controller/subsystem/direction/proc/clear_leader(squad_id)
+	leader_mapping[squad_id] = null

--- a/code/game/jobs/squads.dm
+++ b/code/game/jobs/squads.dm
@@ -181,7 +181,7 @@
 /datum/squad/proc/clean_marine_from_squad(mob/living/carbon/human/H, wipe = FALSE)
 	if(!H.assigned_squad || !(H in marines_list))
 		return FALSE
-	STOP_TRACK_LEADER(tracking_id, wearer) // failsafe
+	STOP_TRACK_LEADER(tracking_id, H) // failsafe
 	marines_list -= src
 	if(!wipe)
 		var/role = "unknown"

--- a/code/game/jobs/squads.dm
+++ b/code/game/jobs/squads.dm
@@ -111,7 +111,7 @@
 			if(squad_leader && (!squad_leader.mind || squad_leader.mind.assigned_role != "Squad Leader")) //field promoted SL
 				demote_squad_leader() //replaced by the real one
 			squad_leader = H
-			SET_TRACK_LEADER(tracking_id, H)
+			SSdirection.set_leader(tracking_id, H)
 			if(H.mind.assigned_role == "Squad Leader") //field promoted SL don't count as real ones
 				num_leaders++
 
@@ -125,7 +125,7 @@
 	if(istype(H.wear_ear, /obj/item/device/radio/headset/almayer)) // they've been transferred
 		var/obj/item/device/radio/headset/almayer/headset = H.wear_ear
 		if(headset.sl_direction)
-			START_TRACK_LEADER(src, H)
+			SSdirection.start_tracking(tracking_id, H)
 
 	var/c_oldass = C.assignment
 	C.access += access //Add their squad access to their ID
@@ -153,14 +153,14 @@
 	count--
 	marines_list -= H
 
-	STOP_TRACK_LEADER(tracking_id, H) // covers squad transfers
+	SSdirection.stop_tracking(tracking_id, H) // covers squad transfers
 
 	if(H.assigned_squad.squad_leader == H)
 		if(H.mind.assigned_role != "Squad Leader") //a field promoted SL, not a real one
 			demote_squad_leader()
 		else
 			H.assigned_squad.squad_leader = null
-			CLEAR_TRACK_LEADER(tracking_id)
+			SSdirection.clear_leader(tracking_id)
 
 	H.assigned_squad = null
 
@@ -181,7 +181,7 @@
 /datum/squad/proc/clean_marine_from_squad(mob/living/carbon/human/H, wipe = FALSE)
 	if(!H.assigned_squad || !(H in marines_list))
 		return FALSE
-	STOP_TRACK_LEADER(tracking_id, H) // failsafe
+	SSdirection.stop_tracking(tracking_id, H)// failsafe
 	marines_list -= src
 	if(!wipe)
 		var/role = "unknown"
@@ -190,7 +190,7 @@
 		gibbed_marines_list[H.name] = role
 	if(squad_leader == src)
 		squad_leader = null
-		CLEAR_TRACK_LEADER(tracking_id)
+		SSdirection.clear_leader(tracking_id)
 	H.assigned_squad = null
 	return TRUE
 
@@ -198,7 +198,7 @@
 /datum/squad/proc/demote_squad_leader(leader_killed)
 	var/mob/living/carbon/human/old_lead = squad_leader
 	squad_leader = null
-	CLEAR_TRACK_LEADER(tracking_id)
+	SSdirection.clear_leader(tracking_id)
 	if(old_lead.mind.assigned_role)
 		if(old_lead.mind.cm_skills)
 			if(old_lead.mind.assigned_role == ("Squad Specialist" || "Squad Engineer" || "Squad Medic" || "Squad Smartgunner"))

--- a/code/game/jobs/squads.dm
+++ b/code/game/jobs/squads.dm
@@ -153,7 +153,7 @@
 	count--
 	marines_list -= H
 
-	STOP_TRACK_LEADER(src, H) // covers squad transfers
+	STOP_TRACK_LEADER(src.tracking_id, H) // covers squad transfers
 
 	if(H.assigned_squad.squad_leader == H)
 		if(H.mind.assigned_role != "Squad Leader") //a field promoted SL, not a real one

--- a/code/game/jobs/squads.dm
+++ b/code/game/jobs/squads.dm
@@ -153,7 +153,7 @@
 	count--
 	marines_list -= H
 
-	STOP_TRACK_LEADER(src.tracking_id, H) // covers squad transfers
+	STOP_TRACK_LEADER(tracking_id, H) // covers squad transfers
 
 	if(H.assigned_squad.squad_leader == H)
 		if(H.mind.assigned_role != "Squad Leader") //a field promoted SL, not a real one
@@ -181,6 +181,7 @@
 /datum/squad/proc/clean_marine_from_squad(mob/living/carbon/human/H, wipe = FALSE)
 	if(!H.assigned_squad || !(H in marines_list))
 		return FALSE
+	STOP_TRACK_LEADER(tracking_id, wearer) // failsafe
 	marines_list -= src
 	if(!wipe)
 		var/role = "unknown"

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -259,7 +259,7 @@
 			squadhud.remove_hud_from(wearer)
 			wearer.SL_directional = null
 			if(wearer.assigned_squad)
-				STOP_TRACK_LEADER(wearer.assigned_squad.tracking_id, wearer)
+				SSdirection.stop_tracking(wearer.assigned_squad.tracking_id, wearer)
 			wearer = null
 	squadhud = null
 	headset_hud_on = FALSE
@@ -292,14 +292,14 @@
 	if(sl_direction)
 		if(user.mind && user.assigned_squad && user.hud_used?.SL_locator)
 			user.hud_used.SL_locator.alpha = 0
-			STOP_TRACK_LEADER(user.assigned_squad.tracking_id, user)
+			SSdirection.stop_tracking(user.assigned_squad.tracking_id, user)
 		sl_direction = FALSE
 		to_chat(user, "<span class='notice'>You toggle the SL directional display off.</span>")
 		playsound(src.loc, 'sound/machines/click.ogg', 15, 0, 1)
 	else
 		if(user.mind && user.assigned_squad && user.hud_used?.SL_locator)
 			user.hud_used.SL_locator.alpha = 128
-			START_TRACK_LEADER(user.assigned_squad.tracking_id, user)
+			SSdirection.start_tracking(user.assigned_squad.tracking_id, user)
 		sl_direction = TRUE
 		to_chat(user, "<span class='notice'>You toggle the SL directional display on.</span>")
 		playsound(src.loc, 'sound/machines/click.ogg', 15, 0, 1)

--- a/code/modules/cm_marines/overwatch.dm
+++ b/code/modules/cm_marines/overwatch.dm
@@ -623,7 +623,7 @@
 	to_chat(H, "[icon2html(src, H)] <font size='3' color='blue'><B>\[Overwatch\]: You've been promoted to \'[H.mind.assigned_role == "Squad Leader" ? "SQUAD LEADER" : "ACTING SQUAD LEADER"]\' for [current_squad.name]. Your headset has access to the command channel (:v).</B></font>")
 	to_chat(usr, "[icon2html(src, usr)] [H.real_name] is [current_squad]'s new leader!")
 	current_squad.squad_leader = H
-	SET_TRACK_LEADER(current_squad.tracking_id, H)
+	SSdirection.set_leader(current_squad.tracking_id, H)
 	if(H.mind.assigned_role == "Squad Leader")
 		H.mind.comm_title = "SL"
 	else

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -162,7 +162,7 @@
 
 
 /mob/living/carbon/human/Destroy()
-	
+	SSdirection.stop_tracking(null, src, TRUE) // failsafe to ensure they're definite not in the list
 	assigned_squad?.clean_marine_from_squad(src,FALSE)
 	remove_from_all_mob_huds()
 	GLOB.human_mob_list -= src

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -162,7 +162,8 @@
 
 
 /mob/living/carbon/human/Destroy()
-	SSdirection.stop_tracking(null, src, TRUE) // failsafe to ensure they're definite not in the list
+	if(assigned_squad)
+		SSdirection.stop_tracking(assigned_squad.tracking_id, src) // failsafe to ensure they're definite not in the list
 	assigned_squad?.clean_marine_from_squad(src,FALSE)
 	remove_from_all_mob_huds()
 	GLOB.human_mob_list -= src

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -162,6 +162,7 @@
 
 
 /mob/living/carbon/human/Destroy()
+	
 	assigned_squad?.clean_marine_from_squad(src,FALSE)
 	remove_from_all_mob_huds()
 	GLOB.human_mob_list -= src


### PR DESCRIPTION
Fixes the following runtime.
Fixes #831 
```runtime error: Cannot execute null.Remove().
proc name: remove marine from squad (/datum/squad/proc/remove_marine_from_squad)
  source file: squads.dm,156
  usr: Thomas Echard (/mob/dead/observer)
  src: Alpha (/datum/squad/alpha)
  usr.loc: the catwalk (149,60,3) (/turf/open/floor/plating/plating_catwalk)
  call stack:
Alpha (/datum/squad/alpha): remove marine from squad(Danny Poehler (/mob/living/carbon/human))
LaKiller8 (/client): Change Squad(Danny Poehler (/mob/living/carbon/human))```