### PR TITLE
Fixes an init runtime

### DIFF
--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -812,12 +812,6 @@ datum/game_mode/proc/initialize_post_queen_list()
 	anchored = TRUE
 	opacity = FALSE
 	density = TRUE
-	var/timeleft = 300 //Set to 0 for permanent forcefields (ugh)
-
-/obj/effect/forcefield/Initialize()
-	. = ..()
-	if(timeleft)
-		QDEL_IN(src, timeleft)
 
 /obj/effect/forcefield/fog
 	name = "dense fog"
@@ -825,7 +819,6 @@ datum/game_mode/proc/initialize_post_queen_list()
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "smoke"
 	opacity = TRUE
-	timeleft = 0
 
 /obj/effect/forcefield/fog/Initialize()
 	. = ..()


### PR DESCRIPTION
```runtime error: list index out of bounds
proc name: bucketJoin (/datum/timedevent/proc/bucketJoin)
  source file: timer.dm,434
  usr: null
  src: Timer: 2 (\[0x21001a78]), TTR:... (/datum/timedevent)
  call stack:
Timer: 2 (\[0x21001a78]), TTR:... (/datum/timedevent): bucketJoin()
Timer: 2 (\[0x21001a78]), TTR:... (/datum/timedevent): New(/datum/callback (/datum/callback), 300, 8, null)
addtimer(/datum/callback (/datum/callback), 300, 8)
Blocker (/obj/effect/forcefield): Initialize(1)
Atoms (/datum/controller/subsystem/atoms): InitAtom(Blocker (/obj/effect/forcefield), /list (/list))
Atoms (/datum/controller/subsystem/atoms): InitializeAtoms(null)
Atoms (/datum/controller/subsystem/atoms): Initialize(148036)
Master (/datum/controller/master): Initialize(10, 0, 1)```