### PR TITLE
Fixes the unlawful autodoc spam.

### DIFF
--- a/code/game/machinery/autodoc.dm
+++ b/code/game/machinery/autodoc.dm
@@ -662,7 +662,8 @@
 	set category = "Object"
 	set src in oview(1)
 
-	if(usr.stat != 0 || !ishuman(usr)) return
+	if(usr.is_mob_incapacitated() || !ishuman(usr))
+		return
 
 	if(occupant)
 		to_chat(usr, "<span class='notice'>\ [src] is already occupied!</span>")

--- a/code/game/machinery/autodoc.dm
+++ b/code/game/machinery/autodoc.dm
@@ -60,7 +60,7 @@
 
 /obj/machinery/autodoc/power_change(var/area/master_area = null)
 	..()
-	if(stat & NOPOWER)
+	if(stat & NOPOWER && occupant)
 		visible_message("\ [src] engages the safety override, ejecting the occupant.")
 		surgery = 0
 		go_out(AUTODOC_NOTICE_NO_POWER)
@@ -620,7 +620,7 @@
 	set name = "Eject Med-Pod"
 	set category = "Object"
 	set src in oview(1)
-	if(usr.stat == DEAD)
+	if(usr.is_mob_incapacitated())
 		return // nooooooooooo
 	if(locked && !allowed(usr)) //Check access if locked.
 		to_chat(usr, "<span class='warning'>Access denied.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Less spam and wasteful processing when the autodoc loses power, plus proper usage of `is_mob_incapacitated()`.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The above description.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes autodoc spamming ejection messages on power loss and not properly checking if the user is incapacitated on certain actions.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
