### PR TITLE
Prevents Hyperzine from giving you negative nutrition.

### DIFF
--- a/code/modules/reagents/chemistry_reagents/medical.dm
+++ b/code/modules/reagents/chemistry_reagents/medical.dm
@@ -722,7 +722,7 @@ datum/reagent/medicine/synaptizine/overdose_crit_process(mob/living/M, alien)
 
 /datum/reagent/medicine/hyperzine/on_mob_life(mob/living/M)
 	M.reagent_move_delay_modifier -= min(2.5, volume * 0.5)
-	M.nutrition -= 3 * REM * volume //Body burns through energy fast
+	M.nutrition = max(M.nutrition-(3 * REM * volume), 0) //Body burns through energy fast (also can't go under 0 nutrition)
 	if(prob(1))
 		M.emote(pick("twitch","blink_r","shiver"))
 		if(ishuman(M))


### PR DESCRIPTION
## About The Pull Request

Prevents Hyperzine from giving you negative nutrition. No more -1500 nutition from a high overdose.

## Why It's Good For The Game

So you don't eat the entirety of the ship's food by yourself.

## Changelog
:cl:
fix: Hyperzine will no longer allow you to go under 0 nutrition.
/:cl: