### PR TITLE
Smartgun IFF toggle changed to a safer mode.

### DIFF
--- a/code/modules/cm_marines/equipment/weapons.dm
+++ b/code/modules/cm_marines/equipment/weapons.dm
@@ -44,7 +44,7 @@
 
 	var/obj/item/weapon/gun/smartgun/mygun = user.get_active_held_item()
 
-	if(isnull(mygun) || !mygun || !istype(mygun))
+	if(!istype(mygun))
 		to_chat(user, "You must be holding an M56 Smartgun to begin the reload process.")
 		return
 	if(rounds_remaining < 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Unique-action (space) reloads smartguns
Alt+click toggles IFF safety

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Space is dangerous for those with fat fingers. Alt+click is safer.

## Changelog
:cl:
tweak: Unique-action (space bar) now reloads the smartgun. IFF is now toggled by alt+click
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
