### PR TITLE
Fixes PMC skill types.

### DIFF
--- a/code/game/jobs/job/pmc.dm
+++ b/code/game/jobs/job/pmc.dm
@@ -2,7 +2,7 @@
 	department_flag = J_FLAG_PMC
 	access = ALL_MARINE_ACCESS
 	minimal_access = ALL_MARINE_ACCESS
-	skills_type = /datum/skills/pfc/crafty
+	skills_type = /datum/skills/pfc/pmc
 	faction = "Nanotrasen"
 
 


### PR DESCRIPTION
:cl: LaKiller8
fix: PMC standards can now use stun batons again.
/:cl:
Fixes #854