### PR TITLE
Rebalances orbital beacons.

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -107,7 +107,16 @@
 			turfs += T
 	return turfs
 
+/proc/diamondturfs(center=usr, radius=3, check_view=FALSE)
+	var/turf/centerturf = get_turf(center)
+	if(radius < 0 || !centerturf)
+		return
 
+	var/list/turfs = list()
+	for(var/turf/T in check_view ? view(radius, centerturf) : range(radius, centerturf))
+		if(abs(T.x - centerturf.x) + abs(T.y - centerturf.y) <= radius)
+			turfs += T
+	. = turfs
 
 //var/debug_mob = 0
 

--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -137,7 +137,8 @@ proc/flame_radius(radius = 1, turf/T, burn_intensity = 25, burn_duration = 25, b
 	burn_damage = rand(burn_damage*(0.5-int_var),burn_damage*(0.5+int_var) ) + rand(burn_damage*(0.5-int_var),burn_damage*(0.5+int_var) )
 	for(var/obj/flamer_fire/F in range(radius,T)) // No stacking flames!
 		qdel(F)
-	new /obj/flamer_fire(T, rand(burn_intensity*(0.5-int_var), burn_intensity*(0.5+int_var)) + rand(burn_intensity*(0.5-int_var), burn_intensity*(0.5+int_var)), rand(burn_duration*(0.5-int_var), burn_duration*(0.5-int_var)) + rand(burn_duration*(0.5-int_var), burn_duration*(0.5-int_var)), colour, radius, burn_damage, fire_stacks) //Gaussian.
+	for(var/turf/IT in orange(T,radius))
+		new /obj/flamer_fire(IT, rand(burn_intensity*(0.5-int_var), burn_intensity*(0.5+int_var)) + rand(burn_intensity*(0.5-int_var), burn_intensity*(0.5+int_var)), rand(burn_duration*(0.5-int_var), burn_duration*(0.5-int_var)) + rand(burn_duration*(0.5-int_var), burn_duration*(0.5-int_var)), colour, 0, burn_damage, fire_stacks)
 
 
 /obj/item/explosive/grenade/incendiary/molotov

--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -137,7 +137,7 @@ proc/flame_radius(radius = 1, turf/T, burn_intensity = 25, burn_duration = 25, b
 	burn_damage = rand(burn_damage*(0.5-int_var),burn_damage*(0.5+int_var) ) + rand(burn_damage*(0.5-int_var),burn_damage*(0.5+int_var) )
 	for(var/obj/flamer_fire/F in range(radius,T)) // No stacking flames!
 		qdel(F)
-	for(var/turf/IT in orange(T,radius))
+	for(var/turf/IT in range(T,radius))
 		new /obj/flamer_fire(IT, rand(burn_intensity*(0.5-int_var), burn_intensity*(0.5+int_var)) + rand(burn_intensity*(0.5-int_var), burn_intensity*(0.5+int_var)), rand(burn_duration*(0.5-int_var), burn_duration*(0.5-int_var)) + rand(burn_duration*(0.5-int_var), burn_duration*(0.5-int_var)), colour, 0, burn_damage, fire_stacks)
 
 

--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -130,7 +130,7 @@
 proc/flame_radius(radius = 1, turf/T, burn_intensity = 25, burn_duration = 25, burn_damage = 25, fire_stacks = 15, int_var = 0.5, dur_var = 0.5, colour = "red") //~Art updated fire.
 	if(!T || !isturf(T))
 		return
-	radius = CLAMP(radius, 1, 7) //Sterilize inputs
+	radius = CLAMP(radius, 1, 50) //Sanitize inputs
 	int_var = CLAMP(int_var, 0.1,0.5)
 	dur_var = CLAMP(int_var, 0.1,0.5)
 	fire_stacks = rand(burn_damage*(0.5-int_var),burn_damage*(0.5+int_var) ) + rand(burn_damage*(0.5-int_var),burn_damage*(0.5+int_var) )

--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -137,7 +137,7 @@ proc/flame_radius(radius = 1, turf/T, burn_intensity = 25, burn_duration = 25, b
 	burn_damage = rand(burn_damage*(0.5-int_var),burn_damage*(0.5+int_var) ) + rand(burn_damage*(0.5-int_var),burn_damage*(0.5+int_var) )
 	for(var/obj/flamer_fire/F in range(radius,T)) // No stacking flames!
 		qdel(F)
-	for(var/turf/IT in range(T,radius))
+	for(var/turf/IT in diamondturfs(T,radius))
 		new /obj/flamer_fire(IT, rand(burn_intensity*(0.5-int_var), burn_intensity*(0.5+int_var)) + rand(burn_intensity*(0.5-int_var), burn_intensity*(0.5+int_var)), rand(burn_duration*(0.5-int_var), burn_duration*(0.5-int_var)) + rand(burn_duration*(0.5-int_var), burn_duration*(0.5-int_var)), colour, 0, burn_damage, fire_stacks)
 
 

--- a/code/modules/cm_marines/orbital_cannon.dm
+++ b/code/modules/cm_marines/orbital_cannon.dm
@@ -388,12 +388,10 @@ var/obj/structure/ship_rail_gun/almayer_rail_gun
 	warhead_kind = "incendiary"
 	icon_state = "ob_warhead_2"
 
+
 /obj/structure/ob_ammo/warhead/incendiary/warhead_impact(turf/target, inaccuracy_amt = 0)
-	var/range_num = max(8 - inaccuracy_amt*2, 3)
-	for(var/turf/TU in range(range_num,target))
-		for(var/obj/flamer_fire/F in TU) // No stacking flames!
-			qdel(F)
-		new/obj/flamer_fire(TU, 10, 50) //super hot flames
+	var/range_num = max(20 - inaccuracy_amt * 2, 15)
+	flame_radius(range_num, target, 10, 20, 10, 10)
 
 
 /obj/structure/ob_ammo/warhead/cluster

--- a/code/modules/cm_marines/orbital_cannon.dm
+++ b/code/modules/cm_marines/orbital_cannon.dm
@@ -401,11 +401,11 @@ var/obj/structure/ship_rail_gun/almayer_rail_gun
 /obj/structure/ob_ammo/warhead/cluster/warhead_impact(turf/target, inaccuracy_amt = 0)
 	set waitfor = FALSE
 
-	var/range_num = max(10 - inaccuracy_amt, 7)
+	var/range_num = max(9 - inaccuracy_amt, 6)
 	var/list/turf_list = list()
 	for(var/turf/T in range(range_num, target))
 		turf_list += T
-	var/total_amt = max(30 - inaccuracy_amt, 25)
+	var/total_amt = max(25 - inaccuracy_amt, 20)
 	for(var/i = 1 to total_amt)
 		var/turf/U = pick_n_take(turf_list)
 		explosion(U, 1, 3, 5, 6, 1, 0) //rocket barrage

--- a/code/modules/cm_marines/orbital_cannon.dm
+++ b/code/modules/cm_marines/orbital_cannon.dm
@@ -378,8 +378,7 @@ var/obj/structure/ship_rail_gun/almayer_rail_gun
 	icon_state = "ob_warhead_1"
 
 /obj/structure/ob_ammo/warhead/explosive/warhead_impact(turf/target, inaccuracy_amt = 0)
-	var/reduc = min(inaccuracy_amt*3, 5)
-	explosion(target,5 - reduc,7 - reduc,10 - reduc,12 - reduc,1,0) //massive boom
+	explosion(target, 4 - inaccuracy_amt, 6 - inaccuracy_amt, 9 - inaccuracy_amt, 11 - inaccuracy_amt, 1, 0)
 
 
 
@@ -390,8 +389,8 @@ var/obj/structure/ship_rail_gun/almayer_rail_gun
 
 
 /obj/structure/ob_ammo/warhead/incendiary/warhead_impact(turf/target, inaccuracy_amt = 0)
-	var/range_num = max(20 - inaccuracy_amt * 2, 15)
-	flame_radius(range_num, target, 10, 20, 10, 10)
+	var/range_num = max(15 - inaccuracy_amt, 12)
+	flame_radius(range_num, target)
 
 
 /obj/structure/ob_ammo/warhead/cluster
@@ -400,16 +399,16 @@ var/obj/structure/ship_rail_gun/almayer_rail_gun
 	icon_state = "ob_warhead_3"
 
 /obj/structure/ob_ammo/warhead/cluster/warhead_impact(turf/target, inaccuracy_amt = 0)
-	set waitfor = 0
+	set waitfor = FALSE
 
-	var/range_num = max(8 - inaccuracy_amt*2, 3)
+	var/range_num = max(10 - inaccuracy_amt, 7)
 	var/list/turf_list = list()
-	for(var/turf/T in range(range_num,target))
+	for(var/turf/T in range(range_num, target))
 		turf_list += T
-	var/total_amt = max(8 - inaccuracy_amt*3, 2)
+	var/total_amt = max(30 - inaccuracy_amt, 25)
 	for(var/i = 1 to total_amt)
 		var/turf/U = pick_n_take(turf_list)
-		explosion(U,1,3,5,6,1,0) //rocket barrage
+		explosion(U, 1, 3, 5, 6, 1, 0) //rocket barrage
 		sleep(1)
 
 

--- a/code/modules/cm_marines/overwatch.dm
+++ b/code/modules/cm_marines/overwatch.dm
@@ -570,7 +570,7 @@
 	state("<span class='boldnotice'>Orbital bombardment request accepted. Orbital cannons are now calibrating.</span>")
 	send_to_squads("Initializing fire coordinates...")
 	if(selected_target)
-		playsound(selected_target.loc,'sound/effects/alert.ogg', 25, 1)  //Placeholder
+		playsound(selected_target.loc,'sound/effects/alert.ogg', 50, 1, 20)  //Placeholder
 	addtimer(CALLBACK(src, .send_to_squads, "Transmitting beacon feed..."), 1.5 SECONDS)
 	addtimer(CALLBACK(src, .send_to_squads, "Calibrating trajectory window..."), 3 SECONDS)
 	addtimer(CALLBACK(src, .do_fire_bombard, T, usr), 4.1 SECONDS)


### PR DESCRIPTION
:cl: LaKiller8
balance: All orbital warheads should now be roughly equal in strength, each one more useful in certain situations.
/:cl:
It now uses the proper flame proc and should hit even buckled people.
Fixes #868