### PR TITLE
OB fix

### DIFF
--- a/_maps/prison_station_fop.json
+++ b/_maps/prison_station_fop.json
@@ -5,4 +5,3 @@
     "shuttles": {
     }
 }
-test test test

--- a/code/modules/cm_marines/orbital_cannon.dm
+++ b/code/modules/cm_marines/orbital_cannon.dm
@@ -142,8 +142,7 @@ var/obj/structure/ship_rail_gun/almayer_rail_gun
 	set waitfor = 0
 
 	if(!loaded_tray)
-		if(user)
-			to_chat(user, "<span class='warning'>You need to load the tray before chambering it.</span>")
+		to_chat(user, "<span class='warning'>You need to load the tray before chambering it.</span>")
 		return
 	
 	if(ob_cannon_busy)

--- a/code/modules/cm_marines/orbital_cannon.dm
+++ b/code/modules/cm_marines/orbital_cannon.dm
@@ -143,7 +143,7 @@ var/obj/structure/ship_rail_gun/almayer_rail_gun
 
 	if(!loaded_tray)
 		if(user)
-			to_chat(user, "You need to load the tray before chamber it.")
+			to_chat(user, "<span class='warning'>You need to load the tray before chambering it.</span>")
 		return
 	
 	if(ob_cannon_busy)

--- a/code/modules/cm_marines/orbital_cannon.dm
+++ b/code/modules/cm_marines/orbital_cannon.dm
@@ -142,7 +142,8 @@ var/obj/structure/ship_rail_gun/almayer_rail_gun
 	set waitfor = 0
 
 	if(!loaded_tray)
-			to_chat(user, "You need to load the tray to chamber it.")
+		if(user)
+			to_chat(user, "You need to load the tray before chamber it.")
 		return
 	
 	if(ob_cannon_busy)


### PR DESCRIPTION
## About The Pull Request
This fixes a bug where you can chamber the OB tray without loading the tray causing it to not use ammo or start the timer allowing you to use the OB as a machine gun.

## Why It's Good For The Game
Stops machine gun OB

## Changelog
🆑
fix: Makes the OB not be able to be fired like a machine gun.
/:cl: