### PR TITLE
Clarifies PMC lore text.

### DIFF
--- a/code/datums/emergency_calls/pmc.dm
+++ b/code/datums/emergency_calls/pmc.dm
@@ -9,7 +9,7 @@
 	to_chat(H, "<B>Joining the ranks of Nanotrasen has proven to be very profitable for you.</b>")
 	to_chat(H, "<B>While you are officially an employee, much of your work is off the books. You work as a skilled mercenary.</b>")
 	to_chat(H, "")
-	to_chat(H, "<B>Make sure the Corporate Liaison is safe, but do not harm the marines.</b>")
+	to_chat(H, "<B>Make sure the Corporate Liaison is safe.</b>")
 	to_chat(H, "<B>If there is no Liaison, eliminate the threat and cooperate with the Captain before returning back home.</b>")
 
 

--- a/code/datums/emergency_calls/pmc.dm
+++ b/code/datums/emergency_calls/pmc.dm
@@ -9,9 +9,8 @@
 	to_chat(H, "<B>Joining the ranks of Nanotrasen has proven to be very profitable for you.</b>")
 	to_chat(H, "<B>While you are officially an employee, much of your work is off the books. You work as a skilled mercenary.</b>")
 	to_chat(H, "")
-	to_chat(H, "<B>Ensure no damage is incurred against Nanotrasen. Make sure the Corporate Liaison is safe.</b>")
+	to_chat(H, "<B>Make sure the Corporate Liaison is safe, but do not harm the marines.</b>")
 	to_chat(H, "<B>If there is no Liaison, eliminate the threat and cooperate with the Captain before returning back home.</b>")
-	to_chat(H, "<B>Deny Nanotrasen's involvement and do not trust the TGMC forces.</b>")
 
 
 /datum/emergency_call/pmc/create_member(datum/mind/M)


### PR DESCRIPTION
:cl: LaKiller8
grammar: Makes it absolutely clear the PMCs are on the same faction as marines and should not attack them in accordance to the rules.
/:cl: