### PR TITLE
Lowers the default music volume to 10%.

### DIFF
--- a/goon/browserassets/js/browserOutput.js
+++ b/goon/browserassets/js/browserOutput.js
@@ -66,7 +66,7 @@ var opts = {
 	'volumeUpdating': false, //True if volume update function set to fire
 	'updatedVolume': 0, //The volume level that is sent to the server
 	
-	'defaultMusicVolume': 25,
+	'defaultMusicVolume': 10,
 
 	'messageCombining': true,
 

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -13,7 +13,7 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("tmp/iconCache.sav")) //Cache of ico
 	var/cookieSent   = FALSE // Has the client sent a cookie for analysis
 	var/broken       = FALSE
 	var/list/connectionHistory //Contains the connection history passed from chat cookie
-	var/adminMusicVolume = 25 //This is for the Play Global Sound verb
+	var/adminMusicVolume = 10 //This is for the Play Global Sound verb
 
 /datum/chatOutput/New(client/C)
 	owner = C


### PR DESCRIPTION
:cl: LaKiller8
tweak: The default goonchat music volume is now 10% (lowered from 25%)
/:cl: