### PR TITLE
Fixes Chem Master Pills Not Having Names

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -436,6 +436,7 @@
 			while (count--)
 				var/obj/item/reagent_container/pill/P = new/obj/item/reagent_container/pill(loc)
 				if(!name) name = reagents.get_master_reagent_name()
+				P.name = name
 				P.pill_desc = "A [name] pill."
 				P.pixel_x = rand(-7, 7) //random position
 				P.pixel_y = rand(-7, 7)


### PR DESCRIPTION
## About The Pull Request

Seems like someone forgot to set the pill's name.
It now gets set, so you can bask in your glorious Sugar (15u), Sugar (7.5u) and, Not A Sugar Pill (15u) pills. 

## Why It's Good For The Game

Why would there be a prompt asking you to name your pills if you... can't?
Also fixes #922 

## Changelog
:cl:
fix: Chem Masters will now dispense pills with the name you set.
/:cl: