### PR TITLE
Defiler Neuroclaw Inject Amount Increased to Offset Faster Metarate

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -561,7 +561,7 @@ var/list/global_mutations = list() // list of hidden mutation things
 #define DEFILER_GAS_DELAY					1 SECONDS
 #define DEFILER_GAS_CLOUD_COUNT				2
 #define DEFILER_STING_CHANNEL_TIME			1.5 SECONDS
-#define DEFILER_CLAW_AMOUNT					6
+#define DEFILER_CLAW_AMOUNT					6.5
 #define DEFILER_STING_AMOUNT_INITIAL		15
 #define DEFILER_STING_AMOUNT_RECURRING		10
 #define DEFILER_STING_GROWTH_AMOUNT			30

--- a/code/modules/mob/living/carbon/xenomorph/Castes/Defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Castes/Defiler.dm
@@ -68,7 +68,7 @@
 	armor_deflection = 35
 
 	// *** Defiler Abilities *** //
-	neuro_claws_amount = 7
+	neuro_claws_amount = 7.5
 
 /datum/xeno_caste/defiler/elder
 	upgrade_name = "Elder"
@@ -100,7 +100,7 @@
 	armor_deflection = 38
 
 	// *** Defiler Abilities *** //
-	neuro_claws_amount = 7.7
+	neuro_claws_amount = 8.2
 
 /datum/xeno_caste/defiler/ancient
 	upgrade_name = "Ancient"
@@ -132,7 +132,7 @@
 	armor_deflection = 40
 
 	// *** Defiler Abilities *** //
-	neuro_claws_amount = 8
+	neuro_claws_amount = 8.5
 
 /mob/living/carbon/Xenomorph/Defiler
 	caste_base_type = /mob/living/carbon/Xenomorph/Defiler


### PR DESCRIPTION
:cl: by Surrealistik
tweak: The amount of neurotox injected by the Defiler's neuroclaws has been increased by 0.5 at each upgrade level to offset the higher neuro meta rate.
/:cl: