### PR TITLE
Removes Spit Swap Ability Button For Hivelord

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Castes/Hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Castes/Hivelord.dm
@@ -182,7 +182,6 @@
 		/datum/action/xeno_action/build_tunnel,
 		/datum/action/xeno_action/toggle_speed,
 		/datum/action/xeno_action/toggle_pheromones,
-		/datum/action/xeno_action/shift_spits,
 		/datum/action/xeno_action/activable/xeno_spit
 		)
 


### PR DESCRIPTION
## About The Pull Request

Removes the swap spit ability button, as hivelords don't have more than one spit type anyways. 
## Why It's Good For The Game

_Shadow used Action Removal._
_Hivelord (582) is no longer confused!_

## Changelog
:cl:
del: Hivelord "switch spit type" action button. (They only have one type)
/:cl: