### PR TITLE
Fixes spit icon not showing a spit type overlay

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Abilities.dm
@@ -57,6 +57,11 @@
 	action_icon_state = "shift_spit_neurotoxin"
 	plasma_cost = 0
 
+/datum/action/xeno_action/shift_spits/update_button_icon()
+	var/mob/living/carbon/Xenomorph/X = owner
+	button.overlays.Cut()
+	button.overlays += image('icons/mob/actions.dmi', button, "shift_spit_[X.ammo.icon_state]")
+
 /datum/action/xeno_action/shift_spits/action_activate()
 	var/mob/living/carbon/Xenomorph/X = owner
 	if(!X.check_state())

--- a/code/modules/mob/living/carbon/xenomorph/Castes/Hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Castes/Hivelord.dm
@@ -194,7 +194,3 @@
 	if(speed_activated)
 		if(locate(/obj/effect/alien/weeds) in loc)
 			. -= 1.5
-
-/mob/living/carbon/Xenomorph/Initialize()
-	. = ..()
-	update_spits()

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -74,6 +74,10 @@
 
 	toggle_xeno_mobhud() //This is a verb, but fuck it, it just werks
 
+	update_spits()
+
+	update_action_button_icons()
+
 /mob/living/carbon/Xenomorph/proc/set_datum()
 	if(!caste_base_type)
 		CRASH("xeno spawned without a caste_base_type set")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes issue discovered by #940
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: multispittype xenos now show a proper spit overlay on spawn
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
