### PR TITLE
Lobby Attention Buttons

### DIFF
--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -54,7 +54,6 @@
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "doorctrl0"
 	desc = "A button for alerting doctors that you require assistance."
-	var/id = null
 	var/active = FALSE
 	anchored = 1.0
 	use_power = 1
@@ -62,9 +61,9 @@
 	active_power_usage = 4
 
 /obj/machinery/medical_help_button/attack_hand(mob/living/carbon/human/user)
-	add_fingerprint(user)
 	if(!istype(user))
 		return
+	add_fingerprint(user)
 	if(machine_stat & (NOPOWER|BROKEN))
 		to_chat(user, "<span class='warning'>[src] doesn't seem to be working.</span>")
 		return
@@ -72,7 +71,6 @@
 		return
 	use_power(5)
 	icon_state = "doorctrl1"
-	add_fingerprint(user)
 
 	var/mob/living/silicon/ai/AI = new/mob/living/silicon/ai(src, null, null, 1)
 	AI.SetName("Lobby Notification System")

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -57,7 +57,6 @@
 	var/id = null
 	var/active = FALSE
 	anchored = 1.0
-	var/cooldown = FALSE
 	use_power = 1
 	idle_power_usage = 2
 	active_power_usage = 4
@@ -69,7 +68,7 @@
 	if(stat & (NOPOWER|BROKEN))
 		to_chat(user, "<span class='warning'>[src] doesn't seem to be working.</span>")
 		return
-	if(cooldown)
+	if(active)
 		return
 	use_power(5)
 	icon_state = "doorctrl1"
@@ -81,13 +80,11 @@
 	qdel(AI)	
 	visible_message("Remain calm, someone will be with you shortly.")
 
-	cooldown = TRUE
 	active = TRUE
 	addtimer(CALLBACK(src, .proc/icon_update_check), 10 SECONDS)
 
 /obj/machinery/medical_help_button/proc/icon_update_check()
 	active = FALSE
-	cooldown = FALSE
 	if(!(stat & NOPOWER))
 		icon_state = "doorctrl0"
 

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -65,7 +65,7 @@
 	add_fingerprint(user)
 	if(!istype(user))
 		return
-	if(stat & (NOPOWER|BROKEN))
+	if(machine_stat & (NOPOWER|BROKEN))
 		to_chat(user, "<span class='warning'>[src] doesn't seem to be working.</span>")
 		return
 	if(active)
@@ -85,12 +85,12 @@
 
 /obj/machinery/medical_help_button/proc/icon_update_check()
 	active = FALSE
-	if(!(stat & NOPOWER))
+	if(!(machine_stat & NOPOWER))
 		icon_state = "doorctrl0"
 
 /obj/machinery/medical_help_button/power_change()
-	..()
-	if(stat & NOPOWER)
+	. = ..()
+	if(machine_stat & NOPOWER)
 		icon_state = "doorctrl-p"
 	else
 		icon_state = "doorctrl0"

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -48,3 +48,36 @@
 
 	attack_paw(mob/user as mob)
 		return
+
+/obj/machinery/medical_help_button
+	name = "Medical attention required"
+	icon = 'icons/obj/stationobjs.dmi'
+	icon_state = "doorctrl0"
+	desc = "A button for alerting doctors that you require assitance."
+	var/id = null
+	var/active = 0
+	anchored = 1.0
+	use_power = 1
+	idle_power_usage = 2
+	active_power_usage = 4
+
+/obj/machinery/medical_help_button/attack_hand(mob/user)
+	src.add_fingerprint(user)
+	if(istype(user,/mob/living/carbon/Xenomorph))
+		return
+	if(stat & (NOPOWER|BROKEN))
+		to_chat(user, "<span class='warning'>[src] doesn't seem to be working.</span>")
+		return
+
+	use_power(5)
+	icon_state = "doorctrl1"
+	add_fingerprint(user)
+
+	var/mob/living/silicon/ai/AI = new/mob/living/silicon/ai(src, null, null, 1)
+	AI.SetName("Lobby Notification System")
+	AI.aiRadio.talk_into(AI,"<b>[user.name] is requesting medical attention at: [get_area(src)].</b>","MedSci","announces")
+	qdel(AI)	
+
+	spawn(15)
+		if(!(stat & NOPOWER))
+			icon_state = "doorctrl0"

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -62,7 +62,7 @@
 	active_power_usage = 4
 
 /obj/machinery/medical_help_button/attack_hand(mob/user)
-	src.add_fingerprint(user)
+	add_fingerprint(user)
 	if(istype(user,/mob/living/carbon/Xenomorph))
 		return
 	if(stat & (NOPOWER|BROKEN))

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -90,3 +90,10 @@
 	cooldown = FALSE
 	if(!(stat & NOPOWER))
 		icon_state = "doorctrl0"
+
+/obj/machinery/medical_help_button/power_change()
+	..()
+	if(stat & NOPOWER)
+		icon_state = "doorctrl-p"
+	else
+		icon_state = "doorctrl0"

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -55,8 +55,9 @@
 	icon_state = "doorctrl0"
 	desc = "A button for alerting doctors that you require assistance."
 	var/id = null
-	var/active = 0
+	var/active = FALSE
 	anchored = 1.0
+	var/cooldown = FALSE
 	use_power = 1
 	idle_power_usage = 2
 	active_power_usage = 4
@@ -68,7 +69,8 @@
 	if(stat & (NOPOWER|BROKEN))
 		to_chat(user, "<span class='warning'>[src] doesn't seem to be working.</span>")
 		return
-
+	if(cooldown)
+		return
 	use_power(5)
 	icon_state = "doorctrl1"
 	add_fingerprint(user)
@@ -77,7 +79,14 @@
 	AI.SetName("Lobby Notification System")
 	AI.aiRadio.talk_into(AI,"<b>[user.name] is requesting medical attention at: [get_area(src)].</b>","MedSci","announces")
 	qdel(AI)	
+	visible_message("Remain calm, someone will be with you shortly.")
 
-	spawn(15)
-		if(!(stat & NOPOWER))
-			icon_state = "doorctrl0"
+	cooldown = TRUE
+	active = TRUE
+	addtimer(CALLBACK(src, .proc/icon_update_check), 10 SECONDS)
+
+/obj/machinery/medical_help_button/proc/icon_update_check()
+	active = FALSE
+	cooldown = FALSE
+	if(!(stat & NOPOWER))
+		icon_state = "doorctrl0"

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -61,9 +61,9 @@
 	idle_power_usage = 2
 	active_power_usage = 4
 
-/obj/machinery/medical_help_button/attack_hand(mob/user)
+/obj/machinery/medical_help_button/attack_hand(mob/living/carbon/human/user)
 	add_fingerprint(user)
-	if(istype(user,/mob/living/carbon/Xenomorph))
+	if(!istype(user))
 		return
 	if(stat & (NOPOWER|BROKEN))
 		to_chat(user, "<span class='warning'>[src] doesn't seem to be working.</span>")

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -53,7 +53,7 @@
 	name = "Medical attention required"
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "doorctrl0"
-	desc = "A button for alerting doctors that you require assitance."
+	desc = "A button for alerting doctors that you require assistance."
 	var/id = null
 	var/active = 0
 	anchored = 1.0


### PR DESCRIPTION
## About The Pull Request

Saw people arguing about medbay. Came up with this idea.

Could also create a version for requisitions and engineering.

## Why It's Good For The Game

Allows doctors to be elsewhere and get notified when there are patients waiting for them. Could also be scattered about the ship allowing for people to ping a doctor directly rather than screaming over general comms.

## Changelog
:cl: Hughgent
add: Lobby notification button for medbay.
/:cl:

