### PR TITLE
Queen Ovi Evolution Paused Message Removal

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Castes/Queen.dm
@@ -610,7 +610,7 @@
 		for(var/mob/living/carbon/Xenomorph/L in hive.xeno_leader_list)
 			L.handle_xeno_leader_pheromones(src)
 
-	xeno_message("<span class='xenoannounce'>The Queen has grown an ovipositor, evolution progress resumed.</span>", 3, hivenumber)
+	xeno_message("<span class='xenoannounce'>The Queen has grown an ovipositor.</span>", 3, hivenumber)
 
 /mob/living/carbon/Xenomorph/Queen/proc/dismount_ovipositor(instant_dismount)
 	set waitfor = 0
@@ -668,7 +668,7 @@
 				L.handle_xeno_leader_pheromones(src)
 
 		if(!instant_dismount)
-			xeno_message("<span class='xenoannounce'>The Queen has shed her ovipositor, evolution progress paused.</span>", 3, hivenumber)
+			xeno_message("<span class='xenoannounce'>The Queen has shed her ovipositor.</span>", 3, hivenumber)
 
 /mob/living/carbon/Xenomorph/Queen/update_canmove()
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -27,8 +27,6 @@
 				stat(null, "Evolve Progress (FINISHED)")
 			else if(!hive.living_xeno_queen)
 				stat(null, "Evolve Progress (HALTED - NO QUEEN)")
-			else if(!hive.living_xeno_queen.ovipositor)
-				stat(null, "Evolve Progress (HALTED - QUEEN HAS NO OVIPOSITOR)")
 			else
 				stat(null, "Evolve Progress: [evolution_stored]/[xeno_caste.evolution_threshold]")
 


### PR DESCRIPTION
## About The Pull Request

Removes the "queen has grown an ovi, evolution resumed" and it's accompanying message. (This only removes the evolution part, not the grown/shed part.)

Removes the check for queen ovi in the evolution status.

## Why It's Good For The Game

Keeps xeno players from thinking they can't evo when the queen isn't ovi'd, when they can.

## Changelog
:cl:
fix: Fixed the evolution status of xenos showing they cannot evolve without an ovi'd queen, even though they can.
del: Removes the "evolution progress started"/"evolution progress halted" parts of the queen's message when they grow/discard an ovipositor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
