### PR TITLE
Changes the Evacuation timer stat panel

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -178,7 +178,7 @@
 		if(EvacuationAuthority)
 			var/eta_status = EvacuationAuthority.get_status_panel_eta()
 			if(eta_status)
-				stat(null, eta_status)
+				stat("Evacuation in:", eta_status)
 
 		if(internal)
 			stat("Internal Atmosphere Info", internal.name)


### PR DESCRIPTION
## About The Pull Request

It now reads "Evacuation In: [TIME HERE/NOW]"

## Why It's Good For The Game

Currently the evac timer is just a countdown in the stats tab. Nothing saying what it actually _is_.
This clarifies what that timer is.

## Changelog
:cl:
tweak: Evac timer (in the stat panel) is now actually says what it's for.
/:cl: