### PR TITLE
Fixes being able to splash from a lidded beaker

### DIFF
--- a/code/game/objects/items/reagent_containers/glass.dm
+++ b/code/game/objects/items/reagent_containers/glass.dm
@@ -72,6 +72,10 @@
 		to_chat(user, "<span class='notice'>You fill [src] with [trans] unit\s of the contents of [target].</span>")
 
 	if(user.a_intent == INTENT_HARM)
+		if(!is_open_container()) //Can't splash stuff from a sealed container. I dare you to try.
+			to_chat(user, "<span class='warning'>An airtight seal prevents you from splashing the solution!</span>")
+			return
+
 		if(ismob(target) && target.reagents && reagents.total_volume)
 			to_chat(user, "<span class='notice'>You splash the solution onto [target].</span>")
 			playsound(target, 'sound/effects/slosh.ogg', 25, 1)


### PR DESCRIPTION
## About The Pull Request

See title.

## Why It's Good For The Game

No more splashing chems with lidded beakers.
Fixes #984.

## Changelog
:cl:
fix: Fixed beakers being able to splash when it has a lid.
/:cl: