### PR TITLE
Removes the : in the headset HUD config menu

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -320,7 +320,7 @@
 	var/dat = {"<TT>
 	<b><A href='?src=\ref[src];headset_hud_on=1'>Squad HUD: [headset_hud_on ? "On" : "Off"]</A></b><BR>
 	<BR>
-	<b><A href='?src=\ref[src];sl_direction=1'>Turn Squad Leader Directional Indicator [sl_direction ? "Off" : "On"]</A></b><BR>
+	<b><A href='?src=\ref[src];sl_direction=1'>Squad Leader Directional Indicator: [sl_direction ? "On" : "Off"]</A></b><BR>
 	<BR>
 	</TT>"}
 	user << browse(dat, "window=radio")

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -318,7 +318,7 @@
 /obj/item/device/radio/headset/almayer/proc/handle_interface(mob/living/carbon/human/user, flag1)
 	user.set_interaction(src)
 	var/dat = {"<TT>
-	<b><A href='?src=\ref[src];headset_hud_on=1'>Turn Squad HUD [headset_hud_on ? "Off" : "On"]</A></b><BR>
+	<b><A href='?src=\ref[src];headset_hud_on=1'>Squad HUD: [headset_hud_on ? "On" : "Off"]</A></b><BR>
 	<BR>
 	<b><A href='?src=\ref[src];sl_direction=1'>Turn Squad Leader Directional Indicator [sl_direction ? "Off" : "On"]</A></b><BR>
 	<BR>

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -318,9 +318,9 @@
 /obj/item/device/radio/headset/almayer/proc/handle_interface(mob/living/carbon/human/user, flag1)
 	user.set_interaction(src)
 	var/dat = {"<TT>
-	<b><A href='?src=\ref[src];headset_hud_on=1'>Turn Squad HUD: [headset_hud_on ? "Off" : "On"]</A></b><BR>
+	<b><A href='?src=\ref[src];headset_hud_on=1'>Turn Squad HUD [headset_hud_on ? "Off" : "On"]</A></b><BR>
 	<BR>
-	<b><A href='?src=\ref[src];sl_direction=1'>Turn Squad Leader Directional Indicator: [sl_direction ? "Off" : "On"]</A></b><BR>
+	<b><A href='?src=\ref[src];sl_direction=1'>Turn Squad Leader Directional Indicator [sl_direction ? "Off" : "On"]</A></b><BR>
 	<BR>
 	</TT>"}
 	user << browse(dat, "window=radio")


### PR DESCRIPTION
## About The Pull Request

Removes a confusing : that didn't really need to be there.
![image](https://user-images.githubusercontent.com/44811257/53932703-85f56200-4060-11e9-8bcb-2f9c1bfb1e82.png)


## Why It's Good For The Game

Less confusing. I had to think about it for a bit, as you think the `: [OPPOSITE OF STATUS]` is the actual status of the toggle.

## Changelog
:cl:
spellcheck: Removed a : in the headset hud config menu, which caused some confusion.
/:cl: