### PR TITLE
Job Prefs: High To Medium When Overwriting

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -436,6 +436,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	if(!job.prefflag)
 		return FALSE
 	if(jobs_high && level == JOBS_PRIORITY_HIGH)
+		jobs_medium |= jobs_high
 		jobs_high = NOFLAGS
 	switch(level)
 		if(JOBS_PRIORITY_HIGH)


### PR DESCRIPTION
## About The Pull Request

Currently, if you have one job set to `High` priority, and you attempt to set another to high, the first one will reset to `Never`. This PR changes it to the (I think?) more often decrease from `High` to `Medium`.

Does not affect setting `High` to `Never`.

![image](https://i.imgur.com/d7kyffG.gif)


## Why It's Good For The Game

Less hassle, I suppose.

## Changelog
:cl:
tweak: Job preferences will now go back to Medium if it was set to High, and you try to change another to High.
/:cl:

It seems like this is your baby @DominikPanic, so have a ping.