### PR TITLE
Adds in booping, as well as changes the human xeno help intent message.

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -48,6 +48,12 @@
 		if("blink_r")
 			message = "<B>[comm_paygrade][src]</B> blinks rapidly."
 
+		if("boop")
+			if(param)
+				message = "<B>[comm_paygrade][src]</B> boops [param]."
+			else
+				message = "<B>[comm_paygrade][src]</B> boops [p_them()]self."
+
 		if("bow")
 			if(!buckled)
 				if(param)
@@ -315,14 +321,14 @@
 		if("help")
 			//this is the default *help message
 			var/msg = {"<br><br><b>To use an emote, type an asterix (*) before a following word. Emotes with a sound are <span style='color: green;'>green</span>. Spamming emotes with sound will likely get you in trouble, don't do it.<br><br> \
-blink, blink_r, bow-(mob name), chuckle, <span style='color: green;'>clap</span>, collapse, cough, cry, drool, eyebrow, facepalm,
+blink, blink_r, boop-(mob name), bow-(mob name), chuckle, <span style='color: green;'>clap</span>, collapse, cough, cry, drool, eyebrow, facepalm,
 faint, frown, gasp, giggle, glare-(mob name), <span style='color: green;'>golfclap</span>, grin, grumble, handshake, hug-(mob name),
 laugh, look-(mob name), me, <span style='color: green;'>medic</span>, moan, mumble, nod, point, <span style='color: green;'>salute</span>,
 <span style='color: green;'>scream</span>, shakehead, shiver, shrug, sigh, signal-#1-10, smile, sneeze, snore, stare-(mob name), twitch, wave, yawn</b><br>"}
 			
 			if(CONFIG_GET(flag/fun_allowed)) //this is the *help message when fun_allowed = 1.
 				msg = {"<br><br><b>To use an emote, type an asterix (*) before a following word. Emotes with a sound are <span style='color: green;'>green</span>. Emotes that are <span style='color: red;'>RED</span> are done at your own risk. Spamming emotes with sound will likely get you in trouble, don't do it.<br><br> \
-blink, blink_r, bow-(mob name), chuckle, <span style='color: green;'>clap</span>, collapse, cough, cry, <span style='color: red;'>dab</span>, drool, eyebrow, facepalm, 
+blink, blink_r, boop-(mob name), bow-(mob name), chuckle, <span style='color: green;'>clap</span>, collapse, cough, cry, <span style='color: red;'>dab</span>, drool, eyebrow, facepalm, 
 faint, frown, gasp, giggle, glare-(mob name), <span style='color: green;'>golfclap</span>, grin, grumble, handshake, hug-(mob name), 
 laugh, look-(mob name), me, <span style='color: green;'>medic</span>, moan, mumble, nod, point, <span style='color: green;'>salute</span>, 
 <span style='color: green;'>scream</span>, shakehead, shiver, shrug, sigh, signal-#1-10, smile, sneeze, snore, stare-(mob name), twitch, wave, yawn</b><br>"}

--- a/code/modules/mob/living/carbon/xenomorph/XenoAttacks.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoAttacks.dm
@@ -49,11 +49,11 @@
 
 		if(INTENT_HELP)
 			if(stat == DEAD)
-				M.visible_message("<span class='warning'>\The [M] pokes \the [src], but nothing happens.</span>", \
-				"<span class='warning'>You poke \the [src], but nothing happens.</span>", null, 5)
+				M.visible_message("<span class='warning'>\The [M] pats \the [src], but nothing happens.</span>", \
+				"<span class='warning'>You pat \the [src], but nothing happens.</span>", null, 5)
 			else
-				M.visible_message("<span class='warning'>\The [M] pokes \the [src].</span>", \
-				"<span class='warning'>You poke \the [src].</span>", null, 5)
+				M.visible_message("<span class='warning'>\The [M] pats \the [src].</span>", \
+				"<span class='warning'>You pat \the [src].</span>", null, 5)
 
 		if(INTENT_GRAB)
 			if(M == src || anchored)


### PR DESCRIPTION
## About The Pull Request

Adds in booping. Usable via `*boop` or `*boop-(mob name)`.
Changes the xeno help intent message (when a _human_ clicks on a xeno.) to be pat(s) instead of poke(s).

![](https://i.imgur.com/kzK0sHN.gif)

## Why It's Good For The Game

Everyone needs a boop, and nobody likes poking xenomorphs.

## Changelog
:cl:
add: A boop emote. Usable via "*boop" or "*boop-(mob name)" for a targeted boop.
tweak: You will now pat xenos instead of poking them.
/:cl: