### PR TITLE
Hotfix for Rifle Accuracy

### DIFF
--- a/code/modules/projectiles/updated_projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/rifles.dm
@@ -83,7 +83,7 @@
 	fire_delay = CONFIG_GET(number/combat_define/med_fire_delay)
 	burst_amount = CONFIG_GET(number/combat_define/med_burst_value)
 	burst_delay = CONFIG_GET(number/combat_define/vlow_fire_delay)
-	accuracy_mult = CONFIG_GET(number/combat_define/base_hit_accuracy_mult) + CONFIG_GET(number/combat_define/low_hit_accuracy)
+	accuracy_mult = CONFIG_GET(number/combat_define/base_hit_accuracy_mult) + CONFIG_GET(number/combat_define/low_hit_accuracy_mult)
 	accuracy_mult_unwielded = CONFIG_GET(number/combat_define/base_hit_accuracy_mult) - CONFIG_GET(number/combat_define/high_hit_accuracy_mult)
 	scatter = CONFIG_GET(number/combat_define/med_scatter_value)
 	scatter_unwielded = CONFIG_GET(number/combat_define/max_scatter_value)


### PR DESCRIPTION
:cl: by Surrealistik
fix: Added missing section of accuracy modifier for the M41A.
/:cl: