### PR TITLE
M42A minimum accurate range reduction. 

### DIFF
--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -725,7 +725,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage_falloff = 0
 	iff_signal = ACCESS_IFF_MARINE
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SNIPER|AMMO_SKIPS_HUMANS
-	accurate_range_min = 10
+	accurate_range_min = 5
 
 /datum/ammo/bullet/sniper/New()
 	..()


### PR DESCRIPTION
## About The Pull Request

Reduces the M42A minimum accurate range from 10 tiles to 5 tiles. What this means is that, when before the sniper would lose significant accuracy within 10 tiles, that accuracy loss is restricted to within 5 tiles. Ought to make it at least somewhat more viable of a choice compared to the other kits. 

## Why It's Good For The Game

Might make the M42A get chosen slightly more, and maybe less as a 'people chose the good ones and this is what I'm left with' kind of thing. 

## Changelog
:cl:
balance: Reduced minimum accurate range of M42A from 10 tiles to 5 tiles. 
/:cl:


