### PR TITLE
Tank Rebalance

### DIFF
--- a/code/modules/vehicles/cm_armored.dm
+++ b/code/modules/vehicles/cm_armored.dm
@@ -420,11 +420,11 @@ var/list/TANK_HARDPOINT_OFFSETS = list(
 		H?.livingmob_interact(src)
 
 /turf/closed/wall/tank_collision(obj/vehicle/multitile/hitbox/cm_armored/C, facing, turf/T, turf/temp)
-	var/obj/vehicle/multitile/root/cm_armored/CA = C.root
+	var/obj/vehicle/multitile/root/cm_armored/tank/CA = C.root
 	var/damage = 30
 	var/tank_damage = 2
 
-	if(facing == get_dir(CA.loc, src) && istype(CA.hardpoints[HDPT_ARMOR], /obj/item/hardpoint/armor/snowplow) ) //Snowplow eliminates collision damage, and doubles damage dealt if we're facing the thing we're crushing
+	if(facing == CA.old_dir && istype(CA.hardpoints[HDPT_ARMOR], /obj/item/hardpoint/armor/snowplow) ) //Snowplow eliminates collision damage, and doubles damage dealt if we're facing the thing we're crushing
 		var/obj/item/hardpoint/armor/snowplow/SP = CA.hardpoints[HDPT_ARMOR]
 		if(SP.health > 0)
 			damage = 60
@@ -437,11 +437,11 @@ var/list/TANK_HARDPOINT_OFFSETS = list(
 		C.lastsound = world.time
 
 /obj/machinery/tank_collision(obj/vehicle/multitile/hitbox/cm_armored/C, facing, turf/T, turf/temp)
-	var/obj/vehicle/multitile/root/cm_armored/CA = C.root
+	var/obj/vehicle/multitile/root/cm_armored/tank/CA = C.root
 	var/damage = 30
 	var/tank_damage = 2
 
-	if(facing == get_dir(CA.loc, src) && istype(CA.hardpoints[HDPT_ARMOR], /obj/item/hardpoint/armor/snowplow) ) //Snowplow eliminates collision damage, and doubles damage dealt if we're facing the thing we're crushing
+	if(facing == CA.old_dir && istype(CA.hardpoints[HDPT_ARMOR], /obj/item/hardpoint/armor/snowplow) ) //Snowplow eliminates collision damage, and doubles damage dealt if we're facing the thing we're crushing
 		var/obj/item/hardpoint/armor/snowplow/SP = CA.hardpoints[HDPT_ARMOR]
 		if(SP.health > 0)
 			damage = 60
@@ -455,11 +455,11 @@ var/list/TANK_HARDPOINT_OFFSETS = list(
 		C.lastsound = world.time
 
 /obj/structure/tank_collision(obj/vehicle/multitile/hitbox/cm_armored/C, facing, turf/T, turf/temp)
-	var/obj/vehicle/multitile/root/cm_armored/CA = C.root
+	var/obj/vehicle/multitile/root/cm_armored/tank/CA = C.root
 	var/damage = 30
 	var/tank_damage = 2
 
-	if(facing == get_dir(CA.loc, src) && istype(CA.hardpoints[HDPT_ARMOR], /obj/item/hardpoint/armor/snowplow) ) //Snowplow eliminates collision damage, and doubles damage dealt if we're facing the thing we're crushing
+	if(facing == CA.old_dir && istype(CA.hardpoints[HDPT_ARMOR], /obj/item/hardpoint/armor/snowplow) ) //Snowplow eliminates collision damage, and doubles damage dealt if we're facing the thing we're crushing
 		var/obj/item/hardpoint/armor/snowplow/SP = CA.hardpoints[HDPT_ARMOR]
 		if(SP.health > 0)
 			damage = 60

--- a/code/modules/vehicles/cm_armored.dm
+++ b/code/modules/vehicles/cm_armored.dm
@@ -360,9 +360,11 @@ var/list/TANK_HARDPOINT_OFFSETS = list(
 	if(loc == C.loc) // treaded over.
 		if(!knocked_down)
 			KnockDown(1)
-		temp = get_step(T, facing)
+		var/target_dir = turn(get_dir(src, C), 180)
+		temp = get_step(loc, target_dir)
 		T = temp
-		T = get_step(T, pick(cardinal))
+		T = get_step(T, target_dir)
+		face_atom(T)
 		throw_at(T, 2, 1, C, 0)
 		apply_damage(rand(5, 7.5), BRUTE)
 		return

--- a/code/modules/vehicles/cm_armored.dm
+++ b/code/modules/vehicles/cm_armored.dm
@@ -357,15 +357,18 @@ var/list/TANK_HARDPOINT_OFFSETS = list(
 	return
 
 /mob/living/tank_collision(obj/vehicle/multitile/hitbox/cm_armored/C, facing, turf/T, turf/temp)
+	if(isdead(src)) //We don't care about the dead
+		return
 	if(loc == C.loc) // treaded over.
 		if(!knocked_down)
 			KnockDown(1)
-		var/target_dir = turn(get_dir(src, C), 180)
-		temp = get_step(loc, target_dir)
+		var/target_dir = turn(C.dir, 180)
+		temp = get_step(C.loc, target_dir)
 		T = temp
+		target_dir = turn(C.dir, 180)
 		T = get_step(T, target_dir)
 		face_atom(T)
-		throw_at(T, 2, 1, C, 0)
+		throw_at(T, 2, 1, C, 1)
 		apply_damage(rand(5, 7.5), BRUTE)
 		return
 	if(!lying)

--- a/code/modules/vehicles/cm_armored.dm
+++ b/code/modules/vehicles/cm_armored.dm
@@ -357,7 +357,7 @@ var/list/TANK_HARDPOINT_OFFSETS = list(
 	return
 
 /mob/living/tank_collision(obj/vehicle/multitile/hitbox/cm_armored/C, facing, turf/T, turf/temp)
-	if(isdead(src)) //We don't care about the dead
+	if(stat == DEAD) //We don't care about the dead
 		return
 	if(loc == C.loc) // treaded over.
 		if(!knocked_down)

--- a/code/modules/vehicles/cm_armored.dm
+++ b/code/modules/vehicles/cm_armored.dm
@@ -424,7 +424,7 @@ var/list/TANK_HARDPOINT_OFFSETS = list(
 	var/damage = 30
 	var/tank_damage = 2
 
-	if(facing == get_dir(loc, get_turf(src)) && istype(CA.hardpoints[HDPT_ARMOR], /obj/item/hardpoint/armor/snowplow) ) //Snowplow eliminates collision damage, and doubles damage dealt if we're facing the thing we're crushing
+	if(facing == get_dir(CA.loc, src) && istype(CA.hardpoints[HDPT_ARMOR], /obj/item/hardpoint/armor/snowplow) ) //Snowplow eliminates collision damage, and doubles damage dealt if we're facing the thing we're crushing
 		var/obj/item/hardpoint/armor/snowplow/SP = CA.hardpoints[HDPT_ARMOR]
 		if(SP.health > 0)
 			damage = 60
@@ -441,7 +441,7 @@ var/list/TANK_HARDPOINT_OFFSETS = list(
 	var/damage = 30
 	var/tank_damage = 2
 
-	if(facing == get_dir(loc, get_turf(src)) && istype(CA.hardpoints[HDPT_ARMOR], /obj/item/hardpoint/armor/snowplow) ) //Snowplow eliminates collision damage, and doubles damage dealt if we're facing the thing we're crushing
+	if(facing == get_dir(CA.loc, src) && istype(CA.hardpoints[HDPT_ARMOR], /obj/item/hardpoint/armor/snowplow) ) //Snowplow eliminates collision damage, and doubles damage dealt if we're facing the thing we're crushing
 		var/obj/item/hardpoint/armor/snowplow/SP = CA.hardpoints[HDPT_ARMOR]
 		if(SP.health > 0)
 			damage = 60
@@ -459,7 +459,7 @@ var/list/TANK_HARDPOINT_OFFSETS = list(
 	var/damage = 30
 	var/tank_damage = 2
 
-	if(facing == get_dir(loc, get_turf(src)) && istype(CA.hardpoints[HDPT_ARMOR], /obj/item/hardpoint/armor/snowplow) ) //Snowplow eliminates collision damage, and doubles damage dealt if we're facing the thing we're crushing
+	if(facing == get_dir(CA.loc, src) && istype(CA.hardpoints[HDPT_ARMOR], /obj/item/hardpoint/armor/snowplow) ) //Snowplow eliminates collision damage, and doubles damage dealt if we're facing the thing we're crushing
 		var/obj/item/hardpoint/armor/snowplow/SP = CA.hardpoints[HDPT_ARMOR]
 		if(SP.health > 0)
 			damage = 60

--- a/code/modules/vehicles/cm_armored.dm
+++ b/code/modules/vehicles/cm_armored.dm
@@ -368,7 +368,7 @@ var/list/TANK_HARDPOINT_OFFSETS = list(
 		target_dir = turn(C.dir, 180)
 		T = get_step(T, target_dir)
 		face_atom(T)
-		throw_at(T, 2, 1, C, 1)
+		throw_at(T, 3, 2, C, 1)
 		apply_damage(rand(5, 7.5), BRUTE)
 		return
 	if(!lying)
@@ -376,9 +376,9 @@ var/list/TANK_HARDPOINT_OFFSETS = list(
 		T = temp
 		T = get_step(T, pick(cardinal))
 		if(mob_size == MOB_SIZE_BIG)
-			throw_at(T, 2, 1, C, 0)
+			throw_at(T, 3, 2, C, 0)
 		else
-			throw_at(T, 2, 1, C, 1)
+			throw_at(T, 3, 2, C, 1)
 		if(!knocked_down)
 			KnockDown(1)
 		apply_damage(rand(10, 15), BRUTE)
@@ -395,7 +395,7 @@ var/list/TANK_HARDPOINT_OFFSETS = list(
 	temp = get_step(T, facing)
 	T = temp
 	T = get_step(T, pick(cardinal))
-	throw_at(T, 2, 1, C, 0)
+	throw_at(T, 2, 2, C, 0)
 	visible_message("<span class='danger'>[C] bumps into [src], pushing [p_them()] away!</span>", "<span class='danger'>[C] bumps into you!</span>")
 
 /mob/living/carbon/Xenomorph/Crusher/tank_collision(obj/vehicle/multitile/hitbox/cm_armored/C, facing, turf/T, turf/temp)
@@ -404,7 +404,7 @@ var/list/TANK_HARDPOINT_OFFSETS = list(
 	temp = get_step(T, facing)
 	T = temp
 	T = get_step(T, pick(cardinal))
-	throw_at(T, 2, 1, C, 0)
+	throw_at(T, 2, 2, C, 0)
 	visible_message("<span class='danger'>[C] bumps into [src], pushing [p_them()] away!</span>", "<span class='danger'>[C] bumps into you!</span>")
 
 /mob/living/carbon/Xenomorph/Larva/tank_collision(obj/vehicle/multitile/hitbox/cm_armored/C, facing, turf/T, turf/temp)

--- a/code/modules/vehicles/cm_armored.dm
+++ b/code/modules/vehicles/cm_armored.dm
@@ -359,7 +359,11 @@ var/list/TANK_HARDPOINT_OFFSETS = list(
 /mob/living/tank_collision(obj/vehicle/multitile/hitbox/cm_armored/C, facing, turf/T, turf/temp)
 	if(loc == C.loc) // treaded over.
 		if(!knocked_down)
-			KnockDown(12)
+			KnockDown(1)
+		temp = get_step(T, facing)
+		T = temp
+		T = get_step(T, pick(cardinal))
+		throw_at(T, 2, 1, C, 0)
 		apply_damage(rand(5, 7.5), BRUTE)
 		return
 	if(!lying)
@@ -370,7 +374,8 @@ var/list/TANK_HARDPOINT_OFFSETS = list(
 			throw_at(T, 2, 1, C, 0)
 		else
 			throw_at(T, 2, 1, C, 1)
-		KnockDown(1)
+		if(!knocked_down)
+			KnockDown(1)
 		apply_damage(rand(10, 15), BRUTE)
 		visible_message("<span class='danger'>[C] bumps into [src], throwing [p_them()] away!</span>", "<span class='danger'>[C] violently bumps into you!</span>")
 	var/obj/vehicle/multitile/root/cm_armored/CA = C.root
@@ -400,7 +405,7 @@ var/list/TANK_HARDPOINT_OFFSETS = list(
 /mob/living/carbon/Xenomorph/Larva/tank_collision(obj/vehicle/multitile/hitbox/cm_armored/C, facing, turf/T, turf/temp)
 	if(loc == C.loc) // treaded over.
 		if(!knocked_down)
-			KnockDown(12)
+			KnockDown(1)
 		apply_damage(rand(5, 7.5), BRUTE)
 		return
 	var/obj/vehicle/multitile/root/cm_armored/CA = C.root
@@ -410,26 +415,53 @@ var/list/TANK_HARDPOINT_OFFSETS = list(
 		H?.livingmob_interact(src)
 
 /turf/closed/wall/tank_collision(obj/vehicle/multitile/hitbox/cm_armored/C, facing, turf/T, turf/temp)
-	take_damage(30)
 	var/obj/vehicle/multitile/root/cm_armored/CA = C.root
-	CA.take_damage_type(10, "blunt", src)
+	var/damage = 30
+	var/tank_damage = 2
+
+	if(facing == get_dir(loc, get_turf(src)) && istype(CA.hardpoints[HDPT_ARMOR], /obj/item/hardpoint/armor/snowplow) ) //Snowplow eliminates collision damage, and doubles damage dealt if we're facing the thing we're crushing
+		var/obj/item/hardpoint/armor/snowplow/SP = CA.hardpoints[HDPT_ARMOR]
+		if(SP.health > 0)
+			damage = 60
+			tank_damage = 0
+
+	take_damage(damage)
+	CA.take_damage_type(tank_damage, "blunt", src)
 	if(world.time > C.lastsound + 1 SECONDS)
 		playsound(src, 'sound/effects/metal_crash.ogg', 35)
 		C.lastsound = world.time
 
 /obj/machinery/tank_collision(obj/vehicle/multitile/hitbox/cm_armored/C, facing, turf/T, turf/temp)
-	take_damage(30)
 	var/obj/vehicle/multitile/root/cm_armored/CA = C.root
-	CA.take_damage_type(2, "blunt", src)
+	var/damage = 30
+	var/tank_damage = 2
+
+	if(facing == get_dir(loc, get_turf(src)) && istype(CA.hardpoints[HDPT_ARMOR], /obj/item/hardpoint/armor/snowplow) ) //Snowplow eliminates collision damage, and doubles damage dealt if we're facing the thing we're crushing
+		var/obj/item/hardpoint/armor/snowplow/SP = CA.hardpoints[HDPT_ARMOR]
+		if(SP.health > 0)
+			damage = 60
+			tank_damage = 0
+
+	take_damage(damage)
+	CA.take_damage_type(tank_damage, "blunt", src)
 	if(world.time > C.lastsound + 1 SECONDS)
 		visible_message("<span class='danger'>[C.root] rams into \the [src]!</span>")
 		playsound(src, 'sound/effects/metal_crash.ogg', 35)
 		C.lastsound = world.time
 
 /obj/structure/tank_collision(obj/vehicle/multitile/hitbox/cm_armored/C, facing, turf/T, turf/temp)
-	take_damage(30)
 	var/obj/vehicle/multitile/root/cm_armored/CA = C.root
-	CA.take_damage_type(2, "blunt", src)
+	var/damage = 30
+	var/tank_damage = 2
+
+	if(facing == get_dir(loc, get_turf(src)) && istype(CA.hardpoints[HDPT_ARMOR], /obj/item/hardpoint/armor/snowplow) ) //Snowplow eliminates collision damage, and doubles damage dealt if we're facing the thing we're crushing
+		var/obj/item/hardpoint/armor/snowplow/SP = CA.hardpoints[HDPT_ARMOR]
+		if(SP.health > 0)
+			damage = 60
+			tank_damage = 0
+
+	take_damage(damage)
+	CA.take_damage_type(tank_damage, "blunt", src)
 	if(world.time > C.lastsound + 1 SECONDS)
 		visible_message("<span class='danger'>[C.root] crushes \the [src]!</span>")
 		playsound(src, 'sound/effects/metal_crash.ogg', 35)


### PR DESCRIPTION
:cl: by Surrealistik
balance: Knockdown stacks for mobs crushed by the tank reduced from 12 to 1, and they are displaced behind the tank. Tanks do not apply knockdown stacks to knocked down mobs. Mobs crushed are displaced away from the tank.
balance: Tank takes no collision damage while running over objects/walls it is facing with the snowplow , and the damage it deals to them is doubled.
/:cl: