### PR TITLE
New/Only Pizza Company: Zippy Pizza

### DIFF
--- a/code/datums/emergency_calls/pizza.dm
+++ b/code/datums/emergency_calls/pizza.dm
@@ -4,9 +4,9 @@
 	probability = 5
 
 /datum/emergency_call/pizza/print_backstory(mob/living/carbon/human/H)
-	to_chat(H, "<B>You are a pizza deliverer! Your employer is the [pick("Discount Pizza","Pizza Kingdom","Papa Pizza")] Corporation.</b>")
-	to_chat(H, "<B>Your job is to deliver your pizzas. You're PRETTY sure this is the right place..</b>")
-	to_chat(H, "<B>Make sure you get a tip.</b>")
+	to_chat(H, "<B>You are a pizza deliverer! Your employer is the Zippy Pizza Corporation.</b>")
+	to_chat(H, "<B>Your job is to deliver your pizzas. You're PRETTY sure this is the right place...</b>")
+	to_chat(H, "<B>Make sure you collect a tip.</b>")
 
 /datum/emergency_call/pizza/create_member(datum/mind/M)
 	var/turf/spawn_loc = get_spawn_point()


### PR DESCRIPTION
## About The Pull Request

Zippy Pizza becomes the only corporation to pick once Pizza Delivery is selected. The text has been reworded for better sounding.

## Why It's Good For The Game

It helps to focus on only one, popular corporation, instead of three. There is whole lore about Zippy Pizza in the works, in #lore.

It would be great to have a read, I'm sure you would be intrigued by the change.

## Changelog
:cl:
add: Added Zippy Pizza Corporation, and reworded new text.
del: Deleted three corporations in favor of one.
/:cl: