### PR TITLE
Fix: Scales ERT Reinforcements Property

### DIFF
--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -51,3 +51,5 @@
 //=================================================
 
 #define LATEJOIN_LARVA_DISABLED 0
+
+#define ERT_MARINE_TO_XENO_RATIO 3

--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -51,5 +51,3 @@
 //=================================================
 
 #define LATEJOIN_LARVA_DISABLED 0
-
-#define ERT_MARINE_TO_XENO_RATIO 3

--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -90,7 +90,7 @@
 		if(humans / max(1,xenos) > 3) //Humans don't need any further help as they already have advantageous/desirable numbers
 			return FALSE
 
-		var/reinforcements = CLAMP( (xenos - humans * 0.33 ) * ERT_MARINE_TO_XENO_RATIO, 1, 15) //We get the difference between the ideal ratio of 3 humans to 1 xeno, and the current xeno count, then multiply it by 3
+		var/reinforcements = CLAMP( ( xenos - humans * max(1, CONFIG_GET(number/xeno_coefficient) ) ) * CONFIG_GET(number/xeno_coefficient), 1, 15) //We get the difference per the ideal human to xeno ratio, and the current xeno count, then multiply it by the xeno coefficient
 
 		picked_call.mob_max = round(rand(reinforcements * 0.9, reinforcements * 1.1)) //Keep that RNG low
 

--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -12,7 +12,7 @@
 //The distress call parent.
 /datum/emergency_call
 	var/name = ""
-	var/mob_max = 20
+	var/mob_max = 10
 	var/mob_min = 1
 	var/dispatch_message = "An encrypted signal has been received from a nearby vessel. Stand by." //Message displayed to marines once the signal is finalized.
 	var/objectives = "" //Objectives to display to the members.
@@ -83,7 +83,15 @@
 	if(SSticker?.mode?.waiting_for_candidates) //It's already been activated
 		return FALSE
 
-	picked_call.mob_max = rand(5, 15)
+	var/xenos = length(GLOB.alive_xeno_list)
+	var/humans = length(GLOB.alive_human_list)
+
+	if(humans / max(1,xenos) > 3) //Humans don't need any further help as they already have advantageous/desirable numbers
+		return FALSE
+
+	var/reinforcements = CLAMP( (xenos - humans * 0.33 ) * 3, 1, 15) //We get the difference between the ideal ratio of 3 humans to 1 xeno, and subtract that from three times the number of xenos.
+
+	picked_call.mob_max = rand(reinforcements * 0.9, reinforcements * 1.1) //Keep that RNG low
 
 	picked_call.activate()
 
@@ -115,7 +123,7 @@
 		usr.mind.current = usr
 
 	if(usr.mind.key != usr.key) //This can happen when admin-switching people into afking people, leading to runtime errors for a clientless key.
-		usr.mind.key = usr.key 
+		usr.mind.key = usr.key
 
 	if(usr.mind in distress.candidates)
 		to_chat(usr, "<span class='warning'>You are already a candidate for this emergency response team.</span>")
@@ -211,16 +219,16 @@
 				return
 
 			candidates = list() //Blank out the candidates list for next time.
-			
+
 			spawn(COOLDOWN_COMM_REQUEST)
 				SSticker.mode.on_distress_cooldown = FALSE
 
 
 /datum/emergency_call/proc/add_candidate(var/mob/M)
-	if(!M.client) 
+	if(!M.client)
 		return FALSE  //Not connected
 
-	if(M.mind && M.mind in candidates) 
+	if(M.mind && M.mind in candidates)
 		return FALSE  //Already there.
 
 	if(M.stat != DEAD)

--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -84,8 +84,9 @@
 		return FALSE
 
 	if(istype(src, /datum/game_mode/colonialmarines) ) //If we're fighting benos
-		var/xenos = length(GLOB.alive_xeno_list)
-		var/humans = length(GLOB.alive_human_list)
+		var/list/total_count = count_humans_and_xenos()
+		var/xenos = total_count[2]
+		var/humans = total_count[1]
 
 		var/reinforcements = CLAMP( ( xenos - humans / max(1, CONFIG_GET(number/xeno_coefficient) ) ) * CONFIG_GET(number/xeno_coefficient), picked_call.mob_min, 15) //We get the difference per the ideal human to xeno ratio, and the current xeno count, then multiply it by the xeno coefficient
 

--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -83,15 +83,19 @@
 	if(SSticker?.mode?.waiting_for_candidates) //It's already been activated
 		return FALSE
 
-	var/xenos = length(GLOB.alive_xeno_list)
-	var/humans = length(GLOB.alive_human_list)
+	if(name == "Distress Signal") //If we're fighting benos
+		var/xenos = length(GLOB.alive_xeno_list)
+		var/humans = length(GLOB.alive_human_list)
 
-	if(humans / max(1,xenos) > 3) //Humans don't need any further help as they already have advantageous/desirable numbers
-		return FALSE
+		if(humans / max(1,xenos) > 3) //Humans don't need any further help as they already have advantageous/desirable numbers
+			return FALSE
 
-	var/reinforcements = CLAMP( (xenos - humans * 0.33 ) * 3, 1, 15) //We get the difference between the ideal ratio of 3 humans to 1 xeno, and subtract that from three times the number of xenos.
+		var/reinforcements = CLAMP( (xenos - humans * 0.33 ) * 3, 1, 15) //We get the difference between the ideal ratio of 3 humans to 1 xeno, and the current xeno count, then multiply it by 3
 
-	picked_call.mob_max = rand(reinforcements * 0.9, reinforcements * 1.1) //Keep that RNG low
+		picked_call.mob_max = round(rand(reinforcements * 0.9, reinforcements * 1.1)) //Keep that RNG low
+
+	else
+		picked_call.mob_max = round(5, 15) //Default otherwise
 
 	picked_call.activate()
 

--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -83,11 +83,11 @@
 	if(SSticker?.mode?.waiting_for_candidates) //It's already been activated
 		return FALSE
 
-	if(name == "Distress Signal") //If we're fighting benos
+	if(istype(src, /datum/game_mode/colonialmarines) ) //If we're fighting benos
 		var/xenos = length(GLOB.alive_xeno_list)
 		var/humans = length(GLOB.alive_human_list)
 
-		var/reinforcements = CLAMP( ( xenos - humans * max(1, CONFIG_GET(number/xeno_coefficient) ) ) * CONFIG_GET(number/xeno_coefficient), 1, 15) //We get the difference per the ideal human to xeno ratio, and the current xeno count, then multiply it by the xeno coefficient
+		var/reinforcements = CLAMP( ( xenos - humans / max(1, CONFIG_GET(number/xeno_coefficient) ) ) * CONFIG_GET(number/xeno_coefficient), picked_call.mob_min, 15) //We get the difference per the ideal human to xeno ratio, and the current xeno count, then multiply it by the xeno coefficient
 
 		picked_call.mob_max = round(rand(reinforcements * 0.9, reinforcements * 1.1)) //Keep that RNG low
 

--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -90,12 +90,12 @@
 		if(humans / max(1,xenos) > 3) //Humans don't need any further help as they already have advantageous/desirable numbers
 			return FALSE
 
-		var/reinforcements = CLAMP( (xenos - humans * 0.33 ) * 3, 1, 15) //We get the difference between the ideal ratio of 3 humans to 1 xeno, and the current xeno count, then multiply it by 3
+		var/reinforcements = CLAMP( (xenos - humans * 0.33 ) * ERT_MARINE_TO_XENO_RATIO, 1, 15) //We get the difference between the ideal ratio of 3 humans to 1 xeno, and the current xeno count, then multiply it by 3
 
 		picked_call.mob_max = round(rand(reinforcements * 0.9, reinforcements * 1.1)) //Keep that RNG low
 
 	else
-		picked_call.mob_max = round(5, 15) //Default otherwise
+		picked_call.mob_max = rand(5, 15) //Default otherwise
 
 	picked_call.activate()
 

--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -87,9 +87,6 @@
 		var/xenos = length(GLOB.alive_xeno_list)
 		var/humans = length(GLOB.alive_human_list)
 
-		if(humans / max(1,xenos) > 3) //Humans don't need any further help as they already have advantageous/desirable numbers
-			return FALSE
-
 		var/reinforcements = CLAMP( ( xenos - humans * max(1, CONFIG_GET(number/xeno_coefficient) ) ) * CONFIG_GET(number/xeno_coefficient), 1, 15) //We get the difference per the ideal human to xeno ratio, and the current xeno count, then multiply it by the xeno coefficient
 
 		picked_call.mob_max = round(rand(reinforcements * 0.9, reinforcements * 1.1)) //Keep that RNG low


### PR DESCRIPTION
:cl: by Surrealistik
balance: ERT reinforcements now scale in proportion to the difference between the number of xenos and marines. Further an ERT call will fail if humans outnumber Xenos more than 3 to 1.
/:cl:
