### PR TITLE
Copies Now Show The Correct Paper Icon

### DIFF
--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -232,6 +232,7 @@
 		copy.overlays += img
 	copy.updateinfolinks()
 	toner--
+	copy.update_icon()
 	return copy
 
 


### PR DESCRIPTION
## About The Pull Request

Photocopiers now show paper that has been written on as being written on, when copying.

## Why It's Good For The Game

I want to see my beautiful lines.

## Changelog
:cl:
fix: Fixed photocopiers showing the wrong paper icon after copying.
/:cl: