### PR TITLE
Ammunition codex

### DIFF
--- a/code/modules/codex/entries/ammunition.dm
+++ b/code/modules/codex/entries/ammunition.dm
@@ -10,14 +10,42 @@
 		 _associated_strings = list("[ammo_name]"))
 		
 		entry.mechanics_text += "<U>Basic statistics for this ammo is as follows</U>:<br>"
-		entry.mechanics_text += "Damage: [ammo.damage]<br>"
-		entry.mechanics_text += "Damage falloff: [ammo.damage_falloff] per tile<br>"
-		entry.mechanics_text += "Damage type: [ammo.damage_type]<br>"
-		entry.mechanics_text += "Armor penetration: [ammo.penetration]<br>"
-		entry.mechanics_text += "Armor type: [ammo.armor_type]<br>"
-		entry.mechanics_text += "Accuracy: [ammo.accuracy > 0 ? "+[ammo.accuracy]" : "[ammo.accuracy]"]%<br>"
-		entry.mechanics_text += "Effective range: [ammo.accurate_range]<br>"
-		entry.mechanics_text += "Maximum range: [ammo.max_range]<br>"
-		entry.mechanics_text += "Burst mode scatter chance: [ammo.scatter > 0 ? "+[ammo.scatter]" : "[ammo.scatter]"]%<br>"
+		if(ammo.damage)
+			entry.mechanics_text += "Damage: [ammo.damage]<br>"
+	
+		if(ammo.damage_falloff)
+			entry.mechanics_text += "Damage falloff: [ammo.damage_falloff] per tile<br>"
+	
+		if(ammo.damage_type)
+			entry.mechanics_text += "Damage type: [ammo.damage_type]<br>"
+	
+		if(ammo.flags_ammo_behavior & AMMO_INCENDIARY)
+			entry.mechanics_text += "Secondary effect: set target on fire.<br>"
+	
+		if(ammo.flags_ammo_behavior & AMMO_SKIPS_HUMANS)
+			entry.mechanics_text += "Secondary effect: ignores friendlies.<br>"
+	
+		if(ammo.flags_ammo_behavior & AMMO_EXPLOSIVE)
+			entry.mechanics_text += "Secondary effect: explosion.<br>"
+	
+		if(ammo.penetration)
+			entry.mechanics_text += "Armor penetration: [ammo.penetration]<br>"
+	
+		if(ammo.armor_type)
+			entry.mechanics_text += "Armor type: [ammo.armor_type]<br>"
+	
+		if(ammo.accuracy)
+			entry.mechanics_text += "Accuracy: [ammo.accuracy > 0 ? "+[ammo.accuracy]" : "[ammo.accuracy]"]%<br>"
+	
+		if(ammo.accurate_range_min)
+			entry.mechanics_text += "Effective range: [ammo.accurate_range_min] to [ammo.accurate_range]<br>"
+		else if(ammo.accurate_range)
+			entry.mechanics_text += "Effective range: [ammo.accurate_range]<br>"
+	
+		if(ammo.max_range)
+			entry.mechanics_text += "Maximum range: [ammo.max_range]<br>"
+	
+		if(ammo.scatter)
+			entry.mechanics_text += "Burst mode scatter chance: [ammo.scatter > 0 ? "+[ammo.scatter]" : "[ammo.scatter]"]%<br>"
 
 		SScodex.entries_by_string[entry.display_name] = entry

--- a/code/modules/codex/entries/ammunition.dm
+++ b/code/modules/codex/entries/ammunition.dm
@@ -1,0 +1,36 @@
+/obj/item/ammo_magazine/get_antag_info()
+	var/list/entries = SScodex.retrieve_entries_for_string(name)
+	var/datum/codex_entry/general_entry = LAZYACCESS(entries, 1)
+	if(general_entry && general_entry.antag_text)
+		return general_entry.antag_text
+
+/obj/item/ammo_magazine/get_lore_info()
+	var/list/entries = SScodex.retrieve_entries_for_string(name)
+	var/datum/codex_entry/general_entry = LAZYACCESS(entries, 1)
+	if(general_entry && general_entry.lore_text)
+		return general_entry.lore_text
+
+/obj/item/ammo_magazine/get_mechanics_info()
+	var/list/ammo_strings = list()
+
+	var/list/entries = SScodex.retrieve_entries_for_string(name)
+	var/datum/codex_entry/general_entry = LAZYACCESS(entries, 1)
+	if(general_entry && general_entry.mechanics_text)
+		ammo_strings += general_entry.mechanics_text + "<br>"
+
+	if(w_class)
+		ammo_strings += "Weight: [w_class]"
+
+	if(max_rounds)
+		ammo_strings += "Capacity: [max_rounds]."
+
+	if(caliber)
+		ammo_strings += "Caliber: [caliber]"
+
+	if(default_ammo.iff_signal)
+		ammo_strings += "IFF: Yes"
+	else
+		ammo_strings += "IFF: No"
+
+	. += jointext(ammo_strings, "<br>")
+

--- a/code/modules/codex/entries/ammunition.dm
+++ b/code/modules/codex/entries/ammunition.dm
@@ -1,9 +1,10 @@
 /datum/codex_category/ammo/New()
 
 	for(var/thing in subtypesof(/datum/ammo))
-		var/datum/ammo/ammo = new thing()
 		if(initial(ammo.hidden_from_codex))
 			continue
+		var/datum/ammo/ammo = new thing()
+
 		var/ammo_name = lowertext(initial(ammo.name))
 		var/datum/codex_entry/entry = new( \
 		 _display_name = "[ammo_name] (ammunition)", \

--- a/code/modules/codex/entries/ammunition.dm
+++ b/code/modules/codex/entries/ammunition.dm
@@ -1,36 +1,23 @@
-/obj/item/ammo_magazine/get_antag_info()
-	var/list/entries = SScodex.retrieve_entries_for_string(name)
-	var/datum/codex_entry/general_entry = LAZYACCESS(entries, 1)
-	if(general_entry && general_entry.antag_text)
-		return general_entry.antag_text
+/datum/codex_category/ammo/New()
 
-/obj/item/ammo_magazine/get_lore_info()
-	var/list/entries = SScodex.retrieve_entries_for_string(name)
-	var/datum/codex_entry/general_entry = LAZYACCESS(entries, 1)
-	if(general_entry && general_entry.lore_text)
-		return general_entry.lore_text
+	for(var/thing in subtypesof(/datum/ammo))
+		var/datum/ammo/ammo = new thing()
+		if(initial(ammo.hidden_from_codex))
+			continue
+		var/ammo_name = lowertext(initial(ammo.name))
+		var/datum/codex_entry/entry = new( \
+		 _display_name = "[ammo_name] (ammunition)", \
+		 _associated_strings = list("[ammo_name]"))
+		
+		entry.mechanics_text += "<U>Basic statistics for this ammo is as follows</U>:<br>"
+		entry.mechanics_text += "Damage: [ammo.damage]<br>"
+		entry.mechanics_text += "Damage falloff: [ammo.damage_falloff] per tile<br>"
+		entry.mechanics_text += "Damage type: [ammo.damage_type]<br>"
+		entry.mechanics_text += "Armor penetration: [ammo.penetration]<br>"
+		entry.mechanics_text += "Armor type: [ammo.armor_type]<br>"
+		entry.mechanics_text += "Accuracy: [ammo.accuracy > 0 ? "+[ammo.accuracy]" : "[ammo.accuracy]"]%<br>"
+		entry.mechanics_text += "Effective range: [ammo.accurate_range]<br>"
+		entry.mechanics_text += "Maximum range: [ammo.max_range]<br>"
+		entry.mechanics_text += "Burst mode scatter chance: [ammo.scatter > 0 ? "+[ammo.scatter]" : "[ammo.scatter]"]%<br>"
 
-/obj/item/ammo_magazine/get_mechanics_info()
-	var/list/ammo_strings = list()
-
-	var/list/entries = SScodex.retrieve_entries_for_string(name)
-	var/datum/codex_entry/general_entry = LAZYACCESS(entries, 1)
-	if(general_entry && general_entry.mechanics_text)
-		ammo_strings += general_entry.mechanics_text + "<br>"
-
-	if(w_class)
-		ammo_strings += "Weight: [w_class]"
-
-	if(max_rounds)
-		ammo_strings += "Capacity: [max_rounds]."
-
-	if(caliber)
-		ammo_strings += "Caliber: [caliber]"
-
-	if(default_ammo.iff_signal)
-		ammo_strings += "IFF: Yes"
-	else
-		ammo_strings += "IFF: No"
-
-	. += jointext(ammo_strings, "<br>")
-
+		SScodex.entries_by_string[entry.display_name] = entry

--- a/code/modules/codex/entries/ammunition.dm
+++ b/code/modules/codex/entries/ammunition.dm
@@ -1,10 +1,10 @@
 /datum/codex_category/ammo/New()
 
 	for(var/thing in subtypesof(/datum/ammo))
+		var/datum/ammo/ammo = thing
 		if(initial(ammo.hidden_from_codex))
-			continue
-		var/datum/ammo/ammo = new thing()
-
+			continue		
+		ammo = new thing()
 		var/ammo_name = lowertext(initial(ammo.name))
 		var/datum/codex_entry/entry = new( \
 		 _display_name = "[ammo_name] (ammunition)", \

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -970,6 +970,7 @@
 #include "code\modules\codex\categories\_category.dm"
 #include "code\modules\codex\categories\category_reagents.dm"
 #include "code\modules\codex\entries\_codex_entry.dm"
+#include "code\modules\codex\entries\ammunition.dm"
 #include "code\modules\codex\entries\atmospherics.dm"
 #include "code\modules\codex\entries\clothing.dm"
 #include "code\modules\codex\entries\engineering.dm"


### PR DESCRIPTION
## About The Pull Request

Had to make a new() instance of all the ammo's, else the initialize of them is null/0. Can't actually inspect a magazine for this information. you have to search for it in the IC tab.

## Why It's Good For The Game

More information for the player.

## Changelog
:cl: Hughgent
add: Codex now includes every type of projectile
/:cl:

