### PR TITLE
Overwatch: Laser Battery Orbital Support Option

### DIFF
--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -36060,7 +36060,7 @@
 /turf/open/floor/almayer,
 /area/almayer/hallways/hangar)
 "bFh" = (
-/obj/structure/ship_rail_gun,
+/obj/machinery/ship_rail_gun,
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
 	},

--- a/code/__DEFINES/machines.dm
+++ b/code/__DEFINES/machines.dm
@@ -87,3 +87,5 @@
 #define MEDIUM		(1<<4)
 #define FULL		(1<<5)
 #define DANGER		(1<<6)
+
+#define ORBITAL_LASER_COST 10000

--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -149,6 +149,7 @@
 	warning_sound = 'sound/effects/nightvision.ogg'
 	point_cost = 300
 
+/obj/structure/ship_ammo/laser_battery/orbital
 
 /obj/structure/ship_ammo/laser_battery/examine(mob/user)
 	..()
@@ -191,6 +192,15 @@
 	for(var/obj/flamer_fire/F in T) // No stacking flames!
 		qdel(F)
 	new/obj/flamer_fire(T, 5, 30) //short but intense
+
+/obj/structure/ship_ammo/laser_battery/orbital/laser_burn(turf/T)
+	for(var/mob/living/L in T)
+		L.adjustFireLoss(40)
+		L.adjust_fire_stacks(30)
+		L.IgniteMob()
+	for(var/obj/flamer_fire/F in T) // No stacking flames!
+		qdel(F)
+	new/obj/flamer_fire(T, 10, 40) //short but intense
 
 
 //Rockets

--- a/code/modules/cm_marines/orbital_cannon.dm
+++ b/code/modules/cm_marines/orbital_cannon.dm
@@ -533,7 +533,7 @@ var/obj/machinery/ship_rail_gun/almayer_rail_gun
 	bound_height = 64
 	bound_y = 64
 	unacidable = TRUE
-	use_power = 1
+	use_power = TRUE
 	idle_power_usage = 10
 	active_power_usage = 100
 	machine_current_charge = 50000
@@ -576,7 +576,7 @@ var/obj/machinery/ship_rail_gun/almayer_rail_gun
 	return
 
 /obj/machinery/ship_rail_gun/proc/fire_laser_battery(turf/T, mob/user)
-	set waitfor = 0
+	set waitfor = FALSE
 	if(cannon_busy)
 		return
 	if(ORBITAL_LASER_COST > machine_current_charge)

--- a/code/modules/cm_marines/overwatch.dm
+++ b/code/modules/cm_marines/overwatch.dm
@@ -118,15 +118,21 @@
 					dat += "<a href='?src=\ref[src];operation=supplies'>Supply Drop Control</a><br>"
 					dat += "<a href='?src=\ref[src];operation=monitor'>Squad Monitor</a><br>"
 					dat += "----------------------<br>"
-					dat += "<b>Rail Gun Control</b><br>"
-					dat += "<b>Current Rail Gun Status:</b> "
+					dat += "<b>Ground Support Weapon Control</b><br>"
+					dat += "<b>Current Rail Gun and Laser Battery Status:</b> "
 					var/cooldown_left = (almayer_rail_gun.last_firing + 600) - world.time // 60 seconds between shots
 					if(cooldown_left > 0)
-						dat += "Rail Gun on cooldown ([round(cooldown_left/10)] seconds)<br>"
-					else if(!almayer_rail_gun.rail_gun_ammo?.ammo_count)
-						dat += "<font color='red'>Ammo depleted.</font><br>"
+						dat += "Ground support weaponry on cooldown: ([round(cooldown_left/10)] seconds)<br>"
 					else
-						dat += "<font color='green'>Ready!</font><br>"
+						if(!almayer_rail_gun.rail_gun_ammo?.ammo_count)
+							dat += "<font color='red'>Rail gun ammo depleted.</font><br>"
+						else
+							dat += "<font color='green'>Rail gun ready!</font><br>"
+						if(!almayer_rail_gun.machine_current_charge < ORBITAL_LASER_COST)
+							dat += "<font color='red'>Laser battery charge depleted.</font><br>"
+						else
+							dat += "<font color='green'>Laser battery ready!</font><br>"
+
 					dat += "<B>[current_squad.name] Laser Targets:</b><br>"
 					if(active_laser_targets.len)
 						for(var/obj/effect/overlay/temp/laser_target/LT in current_squad.squad_laser_targets)
@@ -151,7 +157,9 @@
 						selected_target = null
 					else
 						dat += "<font color='green'>[selected_target.name]</font><br>"
-					dat += "<A href='?src=\ref[src];operation=shootrailgun'>\[FIRE!\]</a><br>"
+					dat += "<A href='?src=\ref[src];operation=shootrailgun'>\[FIRE RAILGUN\]</a><br>"
+					dat += "----------------------<br>"
+					dat += "<A href='?src=\ref[src];operation=firelasers'>\[FIRE LASER BATTERY\]</a><br>"
 					dat += "----------------------<br>"
 					dat += "<br><br><a href='?src=\ref[src];operation=refresh'>{Refresh}</a>"
 			if(OW_MONITOR)//Info screen.
@@ -348,7 +356,7 @@
 			else
 				to_chat(usr, "[icon2html(src, usr)] <span class='notice'>Dead marines are now shown again.</span>")
 		if("choose_z")
-			switch(z_hidden) 
+			switch(z_hidden)
 				if(HIDE_NONE)
 					z_hidden = HIDE_ON_SHIP
 					to_chat(usr, "[icon2html(src, usr)] <span class='notice'>Marines on the [MAIN_SHIP_NAME] are now hidden.</span>")
@@ -383,6 +391,13 @@
 				to_chat(usr, "[icon2html(src, usr)] <span class='warning'>No target detected!</span>")
 			else
 				almayer_rail_gun.fire_rail_gun(get_turf(selected_target),usr)
+		if("firelasers")
+			if((almayer_rail_gun.last_firing + 600) > world.time)
+				to_chat(usr, "[icon2html(src, usr)] <span class='warning'>The Laser Battery hasn't cooled down yet!</span>")
+			else if(!selected_target)
+				to_chat(usr, "[icon2html(src, usr)] <span class='warning'>No target detected!</span>")
+			else
+				almayer_rail_gun.fire_laser_battery(get_turf(selected_target),usr)
 		if("back")
 			state = OW_MAIN
 		if("use_cam")


### PR DESCRIPTION
:cl: by Surrealistik
add: Orbital laser battery orbital fire support added. Has a shared cooldown with the rail gun. Ignites xenos and starts fires instead of staggering/slowing/knocking down. Laser is powered by the ship weapon APC and draws on the power grid instead of using limited ammo.
/:cl: