### PR TITLE
Sniper Kit Buffs

### DIFF
--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -105,8 +105,9 @@
 
 //Define sniper laser multipliers
 
-#define SNIPER_LASER_DAMAGE_MULTIPLIER	1.6 //+60% damage vs the aimed target
-#define SNIPER_LASER_ARMOR_MULTIPLIER	1.6 //+60% penetration vs the aimed target
+#define SNIPER_LASER_DAMAGE_MULTIPLIER	1.5 //+50% damage vs the aimed target
+#define SNIPER_LASER_ARMOR_MULTIPLIER	1.5 //+50% penetration vs the aimed target
+#define SNIPER_LASER_SLOWDOWN_STACKS	4
 
 //Define lasgun
 #define M37_STANDARD_AMMO_COST			20

--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -105,8 +105,8 @@
 
 //Define sniper laser multipliers
 
-#define SNIPER_LASER_DAMAGE_MULTIPLIER	1.5
-#define SNIPER_LASER_ARMOR_MULTIPLIER	1.5
+#define SNIPER_LASER_DAMAGE_MULTIPLIER	1.6 //+60% damage vs the aimed target
+#define SNIPER_LASER_ARMOR_MULTIPLIER	1.6 //+60% penetration vs the aimed target
 
 //Define lasgun
 #define M37_STANDARD_AMMO_COST			20

--- a/code/modules/clothing/glasses/night.dm
+++ b/code/modules/clothing/glasses/night.dm
@@ -32,7 +32,7 @@
 	icon_state = "m56_goggles"
 	deactive_state = "m56_goggles_0"
 	vision_flags = SEE_TURFS
-	darkness_view = 12
+	darkness_view = 24
 	toggleable = 1
 	fullscreen_vision = null
 	actions_types = list(/datum/action/item_action/toggle)

--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -736,9 +736,6 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	penetration= CONFIG_GET(number/combat_define/mhigh_armor_penetration)
 	shell_speed = CONFIG_GET(number/combat_define/ultra_shell_speed)
 
-/datum/ammo/bullet/sniper/on_hit_mob(mob/M,obj/item/projectile/P)
-	staggerstun(M, P, CONFIG_GET(number/combat_define/long_shell_range), 0, 0, 0, 3)
-
 /datum/ammo/bullet/sniper/incendiary
 	name = "incendiary sniper bullet"
 	hud_state = "sniper_fire"

--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -736,6 +736,9 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	penetration= CONFIG_GET(number/combat_define/mhigh_armor_penetration)
 	shell_speed = CONFIG_GET(number/combat_define/ultra_shell_speed)
 
+/datum/ammo/bullet/sniper/on_hit_mob(mob/M,obj/item/projectile/P)
+	staggerstun(M, P, CONFIG_GET(number/combat_define/long_shell_range), 0, 0, 0, 3)
+
 /datum/ammo/bullet/sniper/incendiary
 	name = "incendiary sniper bullet"
 	hud_state = "sniper_fire"

--- a/code/modules/projectiles/updated_projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/specialist.dm
@@ -126,7 +126,7 @@
 		laser_off(user)
 		playsound(user,'sound/machines/click.ogg', 25, 1)
 		return
-	if(!can_see(user, laser_target, length=23))
+	if(!can_see(user, laser_target, length=24))
 		laser_off()
 		to_chat(user, "<span class='danger'>You lose sight of your target!</span>")
 		playsound(user,'sound/machines/click.ogg', 25, 1)

--- a/code/modules/projectiles/updated_projectiles/projectile.dm
+++ b/code/modules/projectiles/updated_projectiles/projectile.dm
@@ -541,8 +541,8 @@ Normal range for a defender's bullet resist should be something around 30-50. ~N
 		#endif
 		var/penetration = P.ammo.penetration > 0 || armor > 0 ? P.ammo.penetration : 0
 		if(P.shot_from && src == P.shot_from.sniper_target(src)) //Runtimes bad
-			damage *= SNIPER_LASER_DAMAGE_MULTIPLIER //+50% damage vs the aimed target
-			penetration *= SNIPER_LASER_ARMOR_MULTIPLIER //+50% penetration vs the aimed target
+			damage *= SNIPER_LASER_DAMAGE_MULTIPLIER
+			penetration *= SNIPER_LASER_ARMOR_MULTIPLIER
 		armor -= penetration//Minus armor penetration from the bullet. If the bullet has negative penetration, adding to their armor, but they don't have armor, they get nothing.
 		#if DEBUG_HUMAN_DEFENSE
 		to_chat(world, "<span class='debuginfo'>Adjusted armor after penetration is: <b>[armor]</b></span>")
@@ -655,8 +655,8 @@ Normal range for a defender's bullet resist should be something around 30-50. ~N
 
 		var/penetration = P.ammo.penetration > 0 || armor > 0 ? P.ammo.penetration : 0
 		if(P.shot_from && src == P.shot_from.sniper_target(src))
-			damage *= SNIPER_LASER_DAMAGE_MULTIPLIER //+50% damage vs the aimed target
-			penetration *= SNIPER_LASER_ARMOR_MULTIPLIER //+50% penetration vs the aimed target
+			damage *= SNIPER_LASER_DAMAGE_MULTIPLIER
+			penetration *= SNIPER_LASER_ARMOR_MULTIPLIER
 
 		armor -= penetration
 

--- a/code/modules/projectiles/updated_projectiles/projectile.dm
+++ b/code/modules/projectiles/updated_projectiles/projectile.dm
@@ -543,6 +543,8 @@ Normal range for a defender's bullet resist should be something around 30-50. ~N
 		if(P.shot_from && src == P.shot_from.sniper_target(src)) //Runtimes bad
 			damage *= SNIPER_LASER_DAMAGE_MULTIPLIER
 			penetration *= SNIPER_LASER_ARMOR_MULTIPLIER
+			add_slowdown(SNIPER_LASER_SLOWDOWN_STACKS)
+
 		armor -= penetration//Minus armor penetration from the bullet. If the bullet has negative penetration, adding to their armor, but they don't have armor, they get nothing.
 		#if DEBUG_HUMAN_DEFENSE
 		to_chat(world, "<span class='debuginfo'>Adjusted armor after penetration is: <b>[armor]</b></span>")
@@ -657,6 +659,7 @@ Normal range for a defender's bullet resist should be something around 30-50. ~N
 		if(P.shot_from && src == P.shot_from.sniper_target(src))
 			damage *= SNIPER_LASER_DAMAGE_MULTIPLIER
 			penetration *= SNIPER_LASER_ARMOR_MULTIPLIER
+			add_slowdown(SNIPER_LASER_SLOWDOWN_STACKS)
 
 		armor -= penetration
 


### PR DESCRIPTION
:cl: by Surrealistik
balance: Sniper improved to be more on par with other spec kits.
tweak: Sniper NV range increased from 12 to 24 tiles. Laser targeting range increased from 23 to 24 tiles. Sniper rounds inflict 3 slow stacks on hit (subject to tweaks).
/:cl: