### PR TITLE
Minigun ammo swap

### DIFF
--- a/code/modules/projectiles/updated_projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/updated_projectiles/magazines/specialist.dm
@@ -183,7 +183,7 @@
 	origin_tech = "combat=3;materials=3"
 	matter = list("metal" = 10000)
 	default_ammo = /datum/ammo/bullet/minigun
-	max_rounds = 500
+	max_rounds = 300
 	reload_delay = 50 //Hard to reload.
 	w_class = 3
 	gun_type = /obj/item/weapon/gun/minigun

--- a/code/modules/vehicles/hardpoints.dm
+++ b/code/modules/vehicles/hardpoints.dm
@@ -915,7 +915,7 @@ Currently only has the tank hardpoints
 	icon_state = "painless"
 	w_class = 10
 	default_ammo = /datum/ammo/bullet/minigun
-	max_rounds = 300
+	max_rounds = 500
 	point_cost = 25
 	gun_type = /obj/item/hardpoint/primary/minigun
 


### PR DESCRIPTION
## About The Pull Request

Swaps the ammo amount of the Vindicator Minigun magazine and the Tank Minigun magazine. 

## Why It's Good For The Game
It doesn't make much sense for the handheld minigun to hold that much more ammo than the tank minigun, so, here's a swap. If it's disliked, feel free to either not take it, or alter the specific numbers to your heart's content. 

## Changelog
:cl:
balance: Increased Tank Minigun magazine size to 500
balance: Reduced Vindicator Magazine size to 300
/:cl:
