### PR TITLE
Sentry Gun Rebalance 2.0

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -273,7 +273,7 @@ WEAPONS
 	contains = list(
 					/obj/item/storage/box/sentry
 					)
-	cost = RO_PRICE_VERY_PRICY
+	cost = RO_PRICE_MAX_PRICY
 	containertype = /obj/structure/closet/crate/weapon
 	containername = "\improper sentry crate"
 	group = "Weapons"

--- a/code/modules/cm_marines/equipment/sentries.dm
+++ b/code/modules/cm_marines/equipment/sentries.dm
@@ -953,7 +953,7 @@
 				var/scatter_chance = in_chamber.ammo.scatter
 				var/burst_value = CLAMP(burst_size - 1, 1, 5)
 				scatter_chance += (burst_value * burst_value * 2)
-				in_chamber.accuracy = round(in_chamber.accuracy - (burst_value * burst_value), 0.01) //Accuracy penalty scales with burst count.
+				in_chamber.accuracy = round(in_chamber.accuracy - (burst_value * burst_value * 1.2), 0.01) //Accuracy penalty scales with burst count.
 
 				if (prob(scatter_chance))
 					var/scatter_x = rand(-1, 1)
@@ -1235,7 +1235,7 @@
 	rounds = 500
 	rounds_max = 500
 	knockdown_threshold = 70 //lighter, not as well secured.
-	work_time = 20 //significantly faster than the big sentry
+	work_time = 10 //significantly faster than the big sentry
 	ammo = /datum/ammo/bullet/turret/mini //Similar to M39 AP rounds.
 	magazine_type = /obj/item/ammo_magazine/minisentry
 
@@ -1261,9 +1261,9 @@
 
 	user.visible_message("<span class='notice'>[user] begins to fold up and retrieve [src].</span>",
 	"<span class='notice'>You begin to fold up and retrieve [src].</span>")
-	if(!do_after(user, work_time * 1.5, TRUE, 5, BUSY_ICON_BUILD))
+	if(!do_after(user, work_time * 3, TRUE, 5, BUSY_ICON_BUILD))
 		return
-	if(!src || on || anchored || !Adjacent(user))//Check if we got exploded
+	if(!src || !Adjacent(user))//Check if we got exploded
 		return
 	to_chat(user, "<span class='notice'>You fold up and retrieve [src].</span>")
 	var/obj/item/device/marine_turret/mini/P = new(loc)
@@ -1332,10 +1332,11 @@
 		var/obj/machinery/marine_turret/mini/M = new /obj/machinery/marine_turret/mini(target)
 		M.setDir(user.dir)
 		user.visible_message("<span class='notice'>[user] deploys [M].</span>",
-		"<span class='notice'>You deploy [M].</span>")
+		"<span class='notice'>You deploy [M]. The [M]'s securing bolts automatically anchor it to the ground.</span>")
 		playsound(target, 'sound/weapons/mine_armed.ogg', 25)
 		M.health = health
-		M.update_icon()
+		M.anchored = TRUE
+		M.activate_turret()
 		qdel(src)
 
 /obj/item/ammo_magazine/minisentry
@@ -1369,4 +1370,15 @@
 		new /obj/item/tool/screwdriver(src) //screw the gun onto the post.
 		new /obj/item/ammo_magazine/minisentry(src)
 
-
+/obj/machinery/marine_turret/proc/activate_turret()
+	if(!anchored)
+		return FALSE
+	target = null
+	on = TRUE
+	SetLuminosity(7)
+	if(!camera)
+		camera = new /obj/machinery/camera(src)
+		camera.network = list("military")
+		camera.c_tag = src.name
+	update_icon()
+	return TRUE

--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -863,8 +863,8 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 
 /datum/ammo/bullet/turret/mini/New()
 	. = ..()
-	damage = CONFIG_GET(number/combat_define/hlow_hit_damage) //35
-	penetration= CONFIG_GET(number/combat_define/low_armor_penetration) //20
+	damage = CONFIG_GET(number/combat_define/hlow_hit_damage)
+	penetration= CONFIG_GET(number/combat_define/mlow_armor_penetration)
 
 
 /datum/ammo/bullet/machinegun //Adding this for the MG Nests (~Art)


### PR DESCRIPTION
:cl: by Surrealistik
balance: Sentry Guns now cost 120 Requisition up from 100.
tweak: Sentry Gun burst accuracy penalty increased from (burst amount - 1) ^ 2 to  (burst amount - 1) ^ 2 * 1.2
tweak: AP of minisentry reduced from 20 to 10, but it now deploys anchored and activated, can be undeployed while anchored and powered, and can be secured/unsecured with a screwdriver in 1 second down from 2.
/:cl: