### PR TITLE
Fixes firedoors acting like boder_only.

### DIFF
--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -238,9 +238,7 @@
 	},
 /area/almayer/evacuation/pod7)
 "aaI" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -682,9 +680,7 @@
 /turf/open/floor/carpet,
 /area/almayer/living/officer_rnr)
 "act" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/effect/decal/warning_stripes/thin{
@@ -1572,7 +1568,7 @@
 /turf/open/floor/wood,
 /area/almayer/living/commandbunks)
 "afm" = (
-/obj/machinery/door/firedoor/border_only/almayer{
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -1965,11 +1961,11 @@
 	},
 /area/almayer/living/officer_study)
 "agF" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer/mono,
 /area/almayer/living/officer_study)
 "agG" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer/mono,
 /area/almayer/hallways/aft_hallway)
 "agH" = (
@@ -2222,7 +2218,7 @@
 	dir = 4;
 	name = "\improper MP Bunks"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
 	tag = "icon-red";
 	icon_state = "red"
@@ -2288,17 +2284,13 @@
 /obj/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Garden Area"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer/mono,
 /area/almayer/living/starboard_garden)
 "ahC" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -2312,9 +2304,7 @@
 /obj/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Garden Area"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer/mono,
@@ -2355,9 +2345,7 @@
 /turf/open/floor/almayer,
 /area/almayer/living/officer_rnr)
 "ahQ" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/effect/decal/warning_stripes/thin{
@@ -2399,7 +2387,7 @@
 	dir = 2;
 	name = "\improper Officer's Study"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer/mono,
 /area/almayer/living/officer_study)
 "ahW" = (
@@ -2407,7 +2395,7 @@
 	dir = 2;
 	name = "\improper Officer's Cafeteria"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer/mono,
 /area/almayer/hallways/aft_hallway)
 "ahX" = (
@@ -2699,9 +2687,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer/mono,
@@ -2825,7 +2811,7 @@
 	},
 /area/almayer/hallways/aft_hallway)
 "aja" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
 	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
@@ -3152,9 +3138,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer,
@@ -3329,7 +3313,7 @@
 	},
 /area/almayer/hallways/aft_hallway)
 "akq" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -3541,9 +3525,7 @@
 /obj/machinery/door/airlock/multi_tile/almayer/comdoor{
 	name = "\improper Conference Room"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/structure/disposalpipe/segment,
@@ -3551,9 +3533,7 @@
 /turf/open/floor/almayer/mono,
 /area/almayer/living/officer_rnr)
 "akC" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer/mono,
@@ -3567,17 +3547,13 @@
 /obj/machinery/door/airlock/multi_tile/almayer/comdoor{
 	name = "\improper Officer's Study"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer/mono,
 /area/almayer/living/officer_study)
 "akE" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer/mono,
@@ -3600,9 +3576,7 @@
 /obj/machinery/door/airlock/multi_tile/almayer/comdoor{
 	name = "\improper Officer's Cafeteria"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -3614,9 +3588,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer/mono,
@@ -3719,7 +3691,7 @@
 	dir = 4;
 	name = "\improper MP Bunks"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
 	dir = 1;
 	icon_state = "red";
@@ -3967,9 +3939,7 @@
 /turf/closed/wall/almayer/white,
 /area/almayer/medical/upper_medical)
 "alx" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/door/airlock/multi_tile/almayer/medidoor{
@@ -3981,9 +3951,7 @@
 	},
 /area/almayer/medical/upper_medical)
 "aly" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -4220,7 +4188,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -4590,7 +4558,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -4698,7 +4666,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/stern_hallway)
 "amm" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
 	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
@@ -4863,7 +4831,7 @@
 /obj/machinery/door/airlock/almayer/security{
 	name = "\improper Execution Room"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
 	tag = "icon-sterile";
 	icon_state = "sterile"
@@ -5168,7 +5136,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -5367,9 +5335,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/structure/disposalpipe/segment,
@@ -5746,7 +5712,7 @@
 /turf/closed/wall/almayer,
 /area/almayer/engineering/upper_engineering)
 "aoN" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/door/airlock/almayer/engineering{
 	dir = 1;
 	name = "\improper Engineering Lobby";
@@ -5756,7 +5722,7 @@
 /area/almayer/engineering/upper_engineering)
 "aoO" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/door/airlock/almayer/engineering{
 	dir = 1;
 	name = "\improper Engineering Lobby";
@@ -5849,9 +5815,7 @@
 	dir = 2;
 	name = "\improper Interrogation"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -5864,9 +5828,7 @@
 	dir = 2;
 	name = "\improper Observation"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/plating/almayer,
@@ -6070,7 +6032,7 @@
 	},
 /area/almayer/command/cic)
 "apx" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
 	tag = "icon-sterile";
 	icon_state = "sterile"
@@ -6583,9 +6545,7 @@
 "aqK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/door/airlock/multi_tile/almayer/secdoor,
@@ -6664,7 +6624,7 @@
 	opacity = 0
 	},
 /obj/structure/window/framed/almayer,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/plating,
 /area/almayer/shipboard/brig)
 "aqQ" = (
@@ -6706,9 +6666,7 @@
 /obj/machinery/door/airlock/almayer/command{
 	dir = 2
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -6896,7 +6854,7 @@
 /obj/machinery/door/airlock/almayer/command{
 	name = "\improper Combat Information Center"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/door/poddoor/almayer{
 	density = 0;
 	dir = 4;
@@ -6994,7 +6952,7 @@
 /area/almayer/medical/upper_medical)
 "arG" = (
 /obj/structure/window/framed/almayer/white,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/door/poddoor/shutters/almayer{
 	dir = 4;
 	id = "eorprivacyshutter";
@@ -7131,9 +7089,7 @@
 /area/almayer/command/telecomms)
 "arX" = (
 /obj/machinery/door/airlock/almayer/secure,
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open (WEST)";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 8
 	},
 /obj/structure/cable{
@@ -7387,7 +7343,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/door/airlock/multi_tile/almayer/secdoor{
 	dir = 2
 	},
@@ -7453,7 +7409,7 @@
 	dir = 4;
 	name = "\improper Security Office"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
 	tag = "icon-sterile";
 	icon_state = "sterile"
@@ -7495,9 +7451,7 @@
 	},
 /area/almayer/shipboard/brig)
 "asN" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -7510,9 +7464,7 @@
 /obj/machinery/door/airlock/almayer/security/CMA{
 	dir = 2
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -7521,9 +7473,7 @@
 	},
 /area/almayer/shipboard/chief_mp_office)
 "asP" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/door/airlock/multi_tile/almayer/secdoor,
@@ -7535,9 +7485,7 @@
 "asQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -7919,7 +7867,7 @@
 	name = "Telecommuncation Power";
 	pixel_x = -25
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/door/airlock/almayer/secure{
@@ -8313,9 +8261,7 @@
 /area/almayer/shipboard/brig)
 "auy" = (
 /obj/structure/window/framed/almayer,
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/plating,
@@ -8456,9 +8402,7 @@
 	dir = 2;
 	name = "\improper Conference Room"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -8597,9 +8541,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/aft_hallway)
 "avd" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/door/airlock/almayer/command/CPTmess{
@@ -8740,7 +8682,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/holosign/surgery{
 	id = "eorsign"
 	},
@@ -9064,9 +9006,7 @@
 	dir = 2;
 	name = "\improper Conference Room"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -9400,7 +9340,7 @@
 /area/almayer/engineering/upper_engineering)
 "awP" = (
 /obj/structure/window/framed/almayer,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/plating,
 /area/almayer/engineering/upper_engineering)
 "awQ" = (
@@ -9881,7 +9821,7 @@
 	name = "\improper Brig Lockdown Podlocks";
 	opacity = 0
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer/mono,
 /area/almayer/shipboard/brig)
 "axZ" = (
@@ -10074,7 +10014,7 @@
 	id = "containmentlockdown";
 	name = "\improper Containment Lockdown"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/door/airlock/almayer/research{
 	name = "\improper Research Pens"
 	},
@@ -10622,7 +10562,7 @@
 	name = "\improper Combat Information Center Blast Door";
 	opacity = 0
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/plating,
 /area/almayer/command/cic)
 "azs" = (
@@ -10714,7 +10654,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer/mono,
 /area/almayer/hallways/aft_hallway)
 "azA" = (
@@ -10994,14 +10934,14 @@
 	req_access_txt = "20";
 	req_one_access_txt = "0"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer/mono,
 /area/almayer/medical/upper_medical)
 "azZ" = (
 /obj/structure/window/framed/almayer/white,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/door/poddoor/shutters/almayer/open{
 	dir = 4;
 	id = "researchlockdownext";
@@ -11054,7 +10994,7 @@
 	},
 /area/almayer/medical/medical_science)
 "aAe" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
 	dir = 2;
 	icon_state = "sterile_green_side";
@@ -11263,9 +11203,7 @@
 	name = "Telecommunications";
 	req_access_txt = "6"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open (WEST)";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -11325,7 +11263,7 @@
 /obj/item/folder/yellow,
 /obj/item/folder/yellow,
 /obj/item/tool/pen,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastleft{
 	req_one_access_txt = "0"
@@ -11375,9 +11313,7 @@
 /obj/machinery/door/airlock/almayer/engineering{
 	name = "\improper Engineering Lobby"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open (WEST)";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 8
 	},
 /obj/structure/cable{
@@ -11719,9 +11655,7 @@
 	name = "\improper Privacy Shutters";
 	opacity = 0
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -12024,7 +11958,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/door/airlock/multi_tile/almayer/medidoor{
 	dir = 2;
 	name = "Research Wing";
@@ -12075,7 +12009,7 @@
 	id = "containmentlockdown";
 	name = "\improper Containment Lockdown"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/door/airlock/almayer/research{
 	name = "\improper Research Pens"
 	},
@@ -12264,7 +12198,7 @@
 	req_one_access_txt = "0"
 	},
 /obj/machinery/door/window/westright,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
 	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
@@ -12755,7 +12689,7 @@
 /area/almayer/medical/upper_medical)
 "aDo" = (
 /obj/structure/window/framed/almayer/white,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/plating,
 /area/almayer/medical/upper_medical)
 "aDp" = (
@@ -12788,7 +12722,7 @@
 /turf/open/floor/wood,
 /area/almayer/medical/upper_medical)
 "aDt" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/door/window/westright,
 /obj/machinery/door/window/eastleft{
 	req_one_access_txt = "0"
@@ -12881,7 +12815,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer/mono,
 /area/almayer/shipboard/brig)
 "aDA" = (
@@ -12963,9 +12897,7 @@
 	dir = 1;
 	name = "\improper Engineering Reception"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open (WEST)";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 8
 	},
 /obj/structure/cable{
@@ -13173,7 +13105,7 @@
 /obj/machinery/door/airlock/almayer/command{
 	name = "\improper Combat Information Center"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer,
 /area/almayer/command/cic)
 "aEj" = (
@@ -13235,9 +13167,7 @@
 	dir = 2;
 	name = "\improper Security Office"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -13252,9 +13182,7 @@
 	dir = 2;
 	name = "\improper Security Office"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -13445,7 +13373,7 @@
 	name = "\improper Combat Information Center Blast Door";
 	opacity = 0
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer/mono,
 /area/almayer/hallways/aft_hallway)
 "aED" = (
@@ -13564,7 +13492,7 @@
 /obj/machinery/door/airlock/almayer/medical/glass{
 	name = "\improper Medical Research Lounge"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/wood,
 /area/almayer/medical/upper_medical)
 "aEV" = (
@@ -13585,7 +13513,7 @@
 /area/almayer/medical/medical_science)
 "aEX" = (
 /obj/structure/window/framed/almayer/white,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/plating,
 /area/almayer/medical/medical_science)
 "aEY" = (
@@ -13853,7 +13781,7 @@
 	name = "\improper Combat Information Center Blast Door";
 	opacity = 0
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer/mono,
 /area/almayer/hallways/aft_hallway)
 "aFv" = (
@@ -13945,7 +13873,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
 	tag = "icon-sterile";
 	icon_state = "sterile"
@@ -13985,9 +13913,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -14047,7 +13973,7 @@
 	name = "\improper Cryoslation Chamber";
 	opacity = 0
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
 	tag = "icon-sterile";
 	icon_state = "sterile"
@@ -14089,9 +14015,7 @@
 /area/almayer/command/cic)
 "aFQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/door/airlock/multi_tile/almayer/secdoor,
@@ -14337,7 +14261,7 @@
 	req_access_txt = "20";
 	req_one_access_txt = "0"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -14539,7 +14463,7 @@
 /turf/open/floor/plating/almayer,
 /area/almayer/command/telecomms)
 "aGO" = (
-/obj/machinery/door/firedoor/border_only/almayer{
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/door/airlock/almayer/secure{
@@ -14711,9 +14635,7 @@
 /area/almayer/command/self_destruct)
 "aHn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -14742,9 +14664,7 @@
 	dir = 2;
 	name = "\improper Permabrig"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -14845,7 +14765,7 @@
 /obj/machinery/door/airlock/almayer/command{
 	name = "\improper Combat Information Center"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/door/poddoor/almayer{
 	density = 0;
 	dir = 4;
@@ -14866,7 +14786,7 @@
 /turf/open/floor/almayer/mono,
 /area/almayer/command/cic)
 "aHD" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/door/airlock/multi_tile/almayer/secdoor{
 	dir = 2
 	},
@@ -14939,18 +14859,14 @@
 /area/almayer/living/captain_mess)
 "aHK" = (
 /obj/structure/window/framed/almayer/white,
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/plating,
 /area/almayer/medical/upper_medical)
 "aHL" = (
 /obj/structure/window/framed/almayer/white,
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/plating,
@@ -14962,9 +14878,7 @@
 	req_access_txt = "5";
 	req_one_access_txt = "0"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -15147,9 +15061,7 @@
 /area/almayer/command/telecomms)
 "aIf" = (
 /obj/machinery/door/airlock/almayer/secure,
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open (WEST)";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 8
 	},
 /turf/open/floor/plating/almayer,
@@ -15525,7 +15437,7 @@
 /area/almayer/medical/lower_medical)
 "aJa" = (
 /obj/structure/window/framed/almayer/white,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/plating,
 /area/almayer/medical/lower_medical)
 "aJb" = (
@@ -15549,7 +15461,7 @@
 	},
 /area/almayer/medical/upper_medical)
 "aJd" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/door/poddoor/shutters/almayer/open{
 	dir = 4;
 	id = "researchlockdownext";
@@ -16262,7 +16174,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/door/poddoor/shutters/almayer/open{
 	dir = 4;
 	id = "researchlockdownext";
@@ -16474,7 +16386,7 @@
 	name = "\improper Engineering Lobby";
 	req_one_access_txt = "0"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -16693,7 +16605,7 @@
 	req_access_txt = "5";
 	req_one_access_txt = "0"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
 	icon_state = "dark_sterile";
 	tag = "icon-sterile"
@@ -16997,7 +16909,7 @@
 	},
 /area/almayer/hallways/aft_hallway)
 "aMc" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -17137,7 +17049,7 @@
 	dir = 4;
 	name = "\improper Permabrig"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
 	tag = "icon-sterile";
 	icon_state = "sterile"
@@ -17201,7 +17113,7 @@
 	opacity = 0
 	},
 /obj/structure/window/framed/almayer/requisitions,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/plating,
 /area/almayer/shipboard/brig_cells)
 "aMF" = (
@@ -17275,9 +17187,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -17323,7 +17233,7 @@
 	name = "Morgue Waiting Room";
 	req_one_access_txt = "0"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -17335,9 +17245,7 @@
 /obj/machinery/door/airlock/multi_tile/almayer/medidoor{
 	name = "\improper Medical Bay"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -17351,9 +17259,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -17495,7 +17401,7 @@
 	},
 /area/almayer/hallways/aft_hallway)
 "aNf" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -17789,14 +17695,14 @@
 /area/almayer/command/cic)
 "aNF" = (
 /obj/structure/window/framed/almayer,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/plating,
 /area/almayer/living/captain_mess)
 "aNG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/door/airlock/multi_tile/almayer/comdoor{
 	dir = 2;
 	name = "\improper Officer's Cafeteria"
@@ -18115,9 +18021,7 @@
 /obj/machinery/door/airlock/almayer/command/FCDRoffice{
 	dir = 2
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -18721,9 +18625,7 @@
 	name = "\improper Combat Information Center Blast Door";
 	opacity = 0
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/plating/almayer,
@@ -19397,7 +19299,7 @@
 /turf/open/floor/almayer/mono,
 /area/almayer/shipboard/starboard_point_defense)
 "aRU" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -20160,9 +20062,7 @@
 /turf/closed/wall/almayer,
 /area/almayer/hull/upper_hull)
 "aUl" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/effect/decal/warning_stripes/thin{
@@ -20380,9 +20280,7 @@
 /turf/open/floor/almayer/mono,
 /area/almayer/hull/upper_hull)
 "aUU" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/structure/disposalpipe/segment,
@@ -20425,9 +20323,7 @@
 /turf/open/floor/almayer/mono,
 /area/almayer/hull/upper_hull)
 "aVa" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/effect/decal/warning_stripes/thin{
@@ -20888,7 +20784,7 @@
 	id = "laddernortheast";
 	name = "\improper North East Ladders Shutters"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer/mono,
 /area/almayer/hull/lower_hull)
 "aWr" = (
@@ -20999,7 +20895,7 @@
 /turf/open/floor/almayer/mono,
 /area/almayer/hull/lower_hull)
 "aWD" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -21038,9 +20934,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hull/lower_hull)
 "aWG" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/door/poddoor/shutters/almayer{
@@ -21748,7 +21642,7 @@
 /obj/machinery/door/airlock/almayer/generic{
 	name = "\improper Extended Operations Bunks"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -21785,7 +21679,7 @@
 /area/almayer/hallways/starboard_hallway)
 "aYF" = (
 /obj/machinery/door/airlock/almayer/marine/alpha,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer/mono,
 /area/almayer/squads/alpha)
 "aYG" = (
@@ -21873,7 +21767,7 @@
 /area/almayer/squads/alpha)
 "aYP" = (
 /obj/machinery/door/airlock/almayer/marine/alpha,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -22149,7 +22043,7 @@
 /area/almayer/squads/alpha)
 "aZs" = (
 /obj/machinery/door/airlock/almayer/marine/alpha,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -22596,7 +22490,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer,
 /area/almayer/living/basketball)
 "bap" = (
@@ -22799,7 +22693,7 @@
 	dir = 2;
 	name = "\improper Recreation Area"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer,
 /area/almayer/living/basketball)
 "baL" = (
@@ -23379,7 +23273,7 @@
 /area/almayer/hallways/starboard_hallway)
 "bct" = (
 /obj/machinery/door/airlock/almayer/marine/bravo,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer/mono,
 /area/almayer/squads/bravo)
 "bcu" = (
@@ -23533,7 +23427,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/almayer/marine/bravo,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -23889,7 +23783,7 @@
 /area/almayer/squads/bravo)
 "bdw" = (
 /obj/machinery/door/airlock/almayer/marine/bravo,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -24095,9 +23989,7 @@
 	id = "laddernorthwest";
 	name = "\improper North West Ladders Shutters"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/structure/disposalpipe/segment,
@@ -24117,9 +24009,7 @@
 	id = "laddernorthwest";
 	name = "\improper North West Ladders Shutters"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -24320,7 +24210,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/starboard_hallway)
 "beF" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer/mono,
 /area/almayer/living/cafeteria_starboard)
 "beG" = (
@@ -24664,7 +24554,7 @@
 /obj/machinery/door/airlock/almayer/generic{
 	name = "\improper Extended Operations Bunks"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -24748,7 +24638,7 @@
 	dir = 2;
 	name = "\improper Canteen"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer/mono,
 /area/almayer/living/cafeteria_starboard)
 "bfK" = (
@@ -25220,7 +25110,7 @@
 /area/almayer/squads/bravo)
 "bgS" = (
 /obj/structure/window/framed/almayer,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/plating,
 /area/almayer/living/cafeteria_starboard)
 "bgT" = (
@@ -25280,7 +25170,7 @@
 /obj/machinery/door/airlock/almayer/generic{
 	name = "\improper Permabrig Bunks"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
 	tag = "icon-sterile";
 	icon_state = "sterile"
@@ -25513,9 +25403,7 @@
 	},
 /area/almayer/living/basketball)
 "bhA" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -25526,9 +25414,7 @@
 	},
 /area/almayer/hallways/starboard_hallway)
 "bhB" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -25543,9 +25429,7 @@
 	},
 /area/almayer/hallways/starboard_hallway)
 "bhC" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -25554,9 +25438,7 @@
 	},
 /area/almayer/hallways/starboard_hallway)
 "bhD" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -25712,9 +25594,7 @@
 /turf/open/floor/engine,
 /area/almayer/engineering/lower_engineering)
 "bhW" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -25728,9 +25608,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -25841,9 +25719,7 @@
 /turf/open/floor/almayer,
 /area/almayer/shipboard/firing_range)
 "bih" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/door/poddoor/shutters/almayer{
@@ -25864,9 +25740,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/door/poddoor/shutters/almayer{
@@ -25881,9 +25755,7 @@
 /area/almayer/hallways/starboard_hallway)
 "bij" = (
 /obj/structure/window/framed/almayer,
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/plating,
@@ -25892,17 +25764,13 @@
 /obj/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Recreation Area"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/starboard_hallway)
 "bil" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -25910,9 +25778,7 @@
 /turf/open/floor/almayer,
 /area/almayer/hallways/starboard_hallway)
 "bim" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/door/airlock/multi_tile/almayer/generic{
@@ -25921,9 +25787,7 @@
 /turf/open/floor/almayer,
 /area/almayer/hallways/starboard_hallway)
 "bin" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/structure/cable{
@@ -25975,7 +25839,7 @@
 /turf/open/floor/almayer/mono,
 /area/almayer/hallways/starboard_hallway)
 "biv" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
 	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
@@ -25999,9 +25863,7 @@
 /area/almayer/hallways/starboard_hallway)
 "biz" = (
 /obj/structure/window/framed/almayer,
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/plating,
@@ -26010,17 +25872,13 @@
 /obj/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Canteen"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer/mono,
 /area/almayer/living/cafeteria_starboard)
 "biB" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -26039,9 +25897,7 @@
 /obj/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Canteen"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/structure/disposalpipe/segment,
@@ -26053,9 +25909,7 @@
 	},
 /area/almayer/living/cafeteria_starboard)
 "biD" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer/mono,
@@ -26188,7 +26042,7 @@
 /turf/open/floor/almayer/mono,
 /area/almayer/hallways/starboard_hallway)
 "biW" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/door/poddoor/shutters/almayer{
 	dir = 4;
 	id = "hangarentrancenorth";
@@ -26413,9 +26267,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/door/airlock/almayer/generic{
@@ -26587,7 +26439,7 @@
 /turf/open/floor/almayer/mono,
 /area/almayer/hallways/starboard_hallway)
 "bjK" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/door/poddoor/shutters/almayer{
 	dir = 4;
 	id = "hangarentrancenorth";
@@ -26982,7 +26834,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/starboard_hallway)
 "bkg" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -27207,7 +27059,7 @@
 /area/almayer/engineering/lower_engineering)
 "bkz" = (
 /obj/structure/window/framed/almayer/hull,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/plating,
 /area/almayer/shipboard/weapon_room)
 "bkA" = (
@@ -27366,7 +27218,7 @@
 	id = "hangarentrancenorth";
 	name = "\improper North Hangar Shutters"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
 	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
@@ -27624,17 +27476,13 @@
 	dir = 2;
 	name = "\improper Security Checkpoint"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer/mono,
 /area/almayer/hull/lower_hull)
 "blS" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/structure/window/framed/almayer/toughened,
@@ -27680,9 +27528,7 @@
 /area/almayer/hallways/starboard_hallway)
 "blY" = (
 /obj/structure/window/framed/almayer,
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/plating,
@@ -27694,17 +27540,13 @@
 /obj/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Cryogenics Bay"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer/mono,
 /area/almayer/living/cryo_cells)
 "bmb" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -27719,26 +27561,20 @@
 /obj/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Cryogenics Bay"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/almayer/mono,
 /area/almayer/living/cryo_cells)
 "bmd" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer/mono,
 /area/almayer/living/cryo_cells)
 "bme" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -27990,9 +27826,7 @@
 	name = "\improper Medical Bay";
 	req_one_access_txt = "0"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -28188,7 +28022,7 @@
 /area/almayer/medical/lower_medical)
 "bnm" = (
 /obj/structure/window/framed/almayer/white,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/door/poddoor/shutters/almayer{
 	dir = 4;
 	id = "or1privacyshutter";
@@ -28283,17 +28117,13 @@
 /obj/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Briefing Room"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
 "bnw" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer,
@@ -28303,9 +28133,7 @@
 /area/almayer/living/briefing)
 "bny" = (
 /obj/structure/window/framed/almayer,
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/plating,
@@ -28314,18 +28142,14 @@
 /obj/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Briefing Room"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/almayer/mono,
 /area/almayer/living/briefing)
 "bnA" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/structure/disposalpipe/segment,
@@ -28361,9 +28185,7 @@
 /turf/closed/wall/almayer,
 /area/almayer/squads/req)
 "bnG" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/structure/window/framed/almayer/requisitions,
@@ -28379,9 +28201,7 @@
 	dir = 2;
 	name = "\improper Requisitions Bay"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -28474,7 +28294,7 @@
 /area/almayer/living/cryo_cells)
 "bnS" = (
 /obj/structure/window/framed/almayer,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/plating,
 /area/almayer/living/cryo_cells)
 "bnT" = (
@@ -29051,7 +28871,7 @@
 /area/almayer/living/briefing)
 "bpj" = (
 /obj/structure/window/framed/almayer,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/plating,
 /area/almayer/living/briefing)
 "bpk" = (
@@ -29601,9 +29421,7 @@
 	dir = 2;
 	name = "\improper Bridge Substation"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/structure/cable/yellow{
@@ -29774,7 +29592,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/door/airlock/almayer/medical{
 	name = "Operating Theatre 1"
 	},
@@ -30151,7 +29969,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -30612,7 +30430,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
 	icon_state = "dark_sterile";
 	tag = "icon-sterile"
@@ -31395,7 +31213,7 @@
 	name = "Surgery Hallway 1";
 	req_access_txt = "0"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
 	icon_state = "dark_sterile";
 	tag = "icon-sterile"
@@ -31434,9 +31252,7 @@
 /area/almayer/hull/lower_hull)
 "buE" = (
 /obj/structure/window/framed/almayer,
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/plating,
@@ -31448,9 +31264,7 @@
 	req_access_txt = "0";
 	req_one_access_txt = "1;26"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer/mono,
@@ -31568,7 +31382,7 @@
 /area/almayer/engineering/lower_engineering)
 "buU" = (
 /obj/machinery/door/airlock/almayer/engineering,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer/mono,
 /area/almayer/engineering/lower_engine_monitoring)
 "buV" = (
@@ -31947,7 +31761,7 @@
 /area/almayer/medical/surgery_hallway)
 "bvO" = (
 /obj/structure/window/framed/almayer/white,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/door/poddoor/shutters/almayer{
 	dir = 4;
 	id = "or2privacyshutter";
@@ -32059,7 +31873,7 @@
 	id = "ROlobby1";
 	name = "\improper RO Line 1"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/structure/window/framed/almayer/requisitions,
 /turf/open/floor/plating,
 /area/almayer/squads/req)
@@ -32271,7 +32085,7 @@
 /area/almayer/engineering/lower_engineering)
 "bwE" = (
 /obj/machinery/door/airlock/almayer/engineering,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -33098,7 +32912,7 @@
 /area/almayer/engineering/lower_engine_monitoring)
 "byy" = (
 /obj/structure/window/framed/almayer,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/plating,
 /area/almayer/engineering/lower_engine_monitoring)
 "byz" = (
@@ -33424,7 +33238,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/holosign/surgery{
 	id = "or2sign"
 	},
@@ -33487,9 +33301,7 @@
 	dir = 2;
 	name = "\improper Briefing Room"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer/mono,
@@ -33501,7 +33313,7 @@
 /turf/open/floor/almayer/mono,
 /area/almayer/living/briefing)
 "bzl" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/status_display{
 	pixel_y = 30
 	},
@@ -33578,7 +33390,7 @@
 /area/almayer/living/cryo_cells)
 "bzx" = (
 /obj/structure/window/framed/almayer,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/plating,
 /area/almayer/engineering/engineering_workshop)
 "bzy" = (
@@ -33760,7 +33572,7 @@
 	name = "\improper Hangar Lockdown Blast Door";
 	opacity = 0
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
 	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
@@ -33833,9 +33645,7 @@
 /area/almayer/hallways/hangar)
 "bAd" = (
 /obj/structure/window/framed/almayer,
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/plating,
@@ -33879,7 +33689,7 @@
 	id = "medicalemergency";
 	name = "\improper Medical Emergency Shutters"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/door/airlock/multi_tile/almayer/medidoor{
 	dir = 2;
 	name = "\improper Medical Bay";
@@ -34111,7 +33921,7 @@
 	},
 /area/almayer/living/briefing)
 "bAF" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
 	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
@@ -34137,7 +33947,7 @@
 	id = "ROlobby1";
 	name = "\improper RO Line 1"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
 	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
@@ -34416,7 +34226,7 @@
 /area/shuttle/drop2/sulaco)
 "bBu" = (
 /obj/structure/window/framed/almayer,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/plating,
 /area/almayer/hallways/hangar)
 "bBv" = (
@@ -34871,7 +34681,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/plating,
 /area/almayer/engineering/lower_engine_monitoring)
 "bCy" = (
@@ -34996,7 +34806,7 @@
 	name = "\improper Hangar Lockdown Blast Door";
 	opacity = 0
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
 	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
@@ -35158,7 +34968,7 @@
 /area/almayer/medical/lower_medical)
 "bDg" = (
 /obj/structure/window/framed/almayer/white,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/plating,
 /area/almayer/medical/surgery_hallway)
 "bDi" = (
@@ -35214,7 +35024,7 @@
 /turf/open/floor/plating,
 /area/almayer/medical/surgery_hallway)
 "bDm" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/door/poddoor/shutters/almayer{
 	dir = 4;
 	id = "or3privacyshutter";
@@ -35352,7 +35162,7 @@
 	},
 /area/almayer/engineering/engine_core)
 "bDA" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/item/device/radio/intercom/general{
 	dir = 1
 	},
@@ -35384,7 +35194,7 @@
 	id = "ROlobby2";
 	name = "\improper RO Line 2"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
 	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
@@ -35763,7 +35573,7 @@
 /area/almayer/medical/lower_medical)
 "bEA" = (
 /obj/machinery/door/airlock/almayer/medical/glass,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
 	icon_state = "dark_sterile";
 	tag = "icon-sterile"
@@ -35886,7 +35696,7 @@
 	id = "ROlobby2";
 	name = "\improper RO Line 2"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/structure/window/framed/almayer/requisitions,
 /turf/open/floor/plating,
 /area/almayer/squads/req)
@@ -36399,7 +36209,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/holosign/surgery{
 	id = "or3sign"
 	},
@@ -37207,7 +37017,7 @@
 /area/almayer/engineering/lower_engineering)
 "bHM" = (
 /obj/machinery/door/airlock/almayer/engineering,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -37332,9 +37142,7 @@
 	},
 /area/almayer/hallways/aft_hallway)
 "bHZ" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -37383,9 +37191,7 @@
 	req_access_txt = "0";
 	req_one_access_txt = "3;22"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/plating/plating_catwalk,
@@ -37443,9 +37249,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/door/airlock/multi_tile/almayer/comdoor{
@@ -37474,7 +37278,7 @@
 	},
 /area/almayer/medical/lower_medical)
 "bIr" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
 	icon_state = "dark_sterile";
 	tag = "icon-sterile"
@@ -37571,7 +37375,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -37581,7 +37385,7 @@
 /area/almayer/squads/req)
 "bIC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/firedoor/border_only/almayer{
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -37593,7 +37397,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -37723,7 +37527,7 @@
 /area/almayer/engineering/lower_engineering)
 "bIQ" = (
 /obj/machinery/door/airlock/almayer/engineering,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -38019,7 +37823,7 @@
 	},
 /area/almayer/medical/lower_medical)
 "bJC" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/door/poddoor/shutters/almayer{
 	dir = 4;
 	id = "or4privacyshutter";
@@ -38714,7 +38518,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -38962,9 +38766,7 @@
 /area/almayer/shipboard/port_missiles)
 "bLD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -39257,7 +39059,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/holosign/surgery{
 	id = "or4sign"
 	},
@@ -39815,9 +39617,7 @@
 	},
 /area/almayer/medical/lower_medical)
 "bND" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -39848,9 +39648,7 @@
 	},
 /area/almayer/medical/lower_medical)
 "bNF" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/structure/window/framed/almayer/white,
@@ -39932,7 +39730,7 @@
 	name = "Surgery Hallway 2";
 	req_access_txt = "0"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/structure/cable{
 	icon_state = "4-8";
 	d1 = 4;
@@ -40016,17 +39814,13 @@
 /obj/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Briefing Room"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer,
 /area/almayer/living/briefing)
 "bNT" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -40036,9 +39830,7 @@
 /obj/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Briefing Room"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer/mono,
@@ -40057,9 +39849,7 @@
 	dir = 2;
 	name = "\improper Requisitions Bay"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/structure/disposalpipe/segment,
@@ -40343,7 +40133,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/port_hallway)
 "bOQ" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
 	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
@@ -40361,18 +40151,14 @@
 /obj/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Cryogenics Bay"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/almayer/mono,
 /area/almayer/living/cryo_cells)
 "bOU" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -40381,9 +40167,7 @@
 	},
 /area/almayer/hallways/port_hallway)
 "bOV" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -40581,7 +40365,7 @@
 /turf/open/floor/almayer/mono,
 /area/almayer/hallways/port_hallway)
 "bPu" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/door/poddoor/shutters/almayer{
 	dir = 4;
 	id = "hangarentrancesouth";
@@ -40878,7 +40662,7 @@
 /turf/open/floor/almayer/mono,
 /area/almayer/hallways/port_hallway)
 "bQa" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/door/poddoor/shutters/almayer{
 	dir = 4;
 	id = "hangarentrancesouth";
@@ -41268,7 +41052,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -41551,7 +41335,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/door/poddoor/shutters/almayer{
 	dir = 4;
 	id = "hangarentrancesouth";
@@ -41777,9 +41561,7 @@
 /turf/closed/wall/almayer,
 /area/almayer/hallways/port_umbilical)
 "bRA" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -41793,9 +41575,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -41825,9 +41605,7 @@
 /turf/closed/wall/almayer,
 /area/almayer/hallways/port_hallway)
 "bRG" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/structure/disposalpipe/segment,
@@ -41848,9 +41626,7 @@
 	},
 /area/almayer/hallways/port_hallway)
 "bRH" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/door/poddoor/shutters/almayer{
@@ -41865,9 +41641,7 @@
 /area/almayer/hallways/port_hallway)
 "bRI" = (
 /obj/structure/window/framed/almayer,
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/plating,
@@ -41876,17 +41650,13 @@
 /obj/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Rest and Relaxation Area"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer,
 /area/almayer/hallways/port_hallway)
 "bRL" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -41896,9 +41666,7 @@
 /obj/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Rest and Relaxation Area"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/structure/disposalpipe/segment,
@@ -41906,9 +41674,7 @@
 /turf/open/floor/almayer,
 /area/almayer/hallways/port_hallway)
 "bRN" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/structure/cable{
@@ -41942,9 +41708,7 @@
 /area/almayer/living/cafeteria_port)
 "bRR" = (
 /obj/structure/window/framed/almayer,
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/plating,
@@ -41953,18 +41717,14 @@
 /obj/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Canteen"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/almayer/mono,
 /area/almayer/living/cafeteria_port)
 "bRT" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -41974,9 +41734,7 @@
 /obj/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Canteen"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/structure/disposalpipe/segment,
@@ -41988,9 +41746,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer/mono,
@@ -42039,9 +41795,7 @@
 /turf/closed/wall/almayer,
 /area/almayer/living/tankerbunks)
 "bSd" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -42050,9 +41804,7 @@
 	},
 /area/almayer/hallways/hangar)
 "bSe" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -42070,9 +41822,7 @@
 /turf/closed/wall/almayer,
 /area/almayer/living/pilotbunks)
 "bSg" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -42339,9 +42089,7 @@
 /turf/closed/wall/almayer,
 /area/almayer/living/port_emb)
 "bSP" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/structure/disposalpipe/segment,
@@ -42627,7 +42375,7 @@
 	name = "\improper Tanker Quarters";
 	req_one_access_txt = "22;2;7"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer/mono,
 /area/almayer/living/tankerbunks)
 "bTz" = (
@@ -42640,7 +42388,7 @@
 /turf/open/floor/almayer,
 /area/almayer/hallways/hangar)
 "bTA" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/door/airlock/almayer/generic{
 	dir = 4;
 	name = "\improper Pilot's Quarters";
@@ -43043,7 +42791,7 @@
 /area/almayer/hallways/port_hallway)
 "bUH" = (
 /obj/structure/window/framed/almayer,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/plating,
 /area/almayer/living/cafeteria_port)
 "bUI" = (
@@ -43176,7 +42924,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/door/airlock/almayer/generic{
 	dir = 4;
 	name = "\improper Tanker Quarters";
@@ -43244,7 +42992,7 @@
 /turf/open/floor/almayer,
 /area/almayer/hallways/hangar)
 "bVf" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/door/airlock/almayer/generic{
 	dir = 4;
 	name = "\improper Pilot's Quarters";
@@ -43632,7 +43380,7 @@
 /obj/machinery/door/airlock/almayer/generic{
 	name = "\improper Extended Operations Bunks"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -43738,7 +43486,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/hallways/port_hallway)
 "bWd" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer/mono,
 /area/almayer/living/cafeteria_port)
 "bWe" = (
@@ -43872,7 +43620,7 @@
 	id = "pilotentrance";
 	name = "\improper Pilot Workshop Shutters"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
 	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
@@ -43909,9 +43657,7 @@
 	id = "laddersouthwest";
 	name = "\improper South West Ladders Shutters"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/structure/cable{
@@ -43930,9 +43676,7 @@
 	id = "laddersouthwest";
 	name = "\improper South West Ladders Shutters"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -44079,7 +43823,7 @@
 	dir = 2;
 	name = "\improper Canteen"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer/mono,
 /area/almayer/living/cafeteria_port)
 "bXc" = (
@@ -44181,7 +43925,7 @@
 /turf/open/floor/almayer/mono,
 /area/almayer/hallways/repair_bay)
 "bXu" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/door/poddoor/shutters/almayer{
 	dir = 4;
 	id = "pilotentrance";
@@ -44340,7 +44084,7 @@
 /area/almayer/living/port_emb)
 "bXN" = (
 /obj/machinery/door/airlock/almayer/marine/charlie,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer/mono,
 /area/almayer/squads/charlie)
 "bXO" = (
@@ -44435,7 +44179,7 @@
 /area/almayer/squads/charlie)
 "bXY" = (
 /obj/machinery/door/airlock/almayer/marine/charlie,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -44740,9 +44484,7 @@
 /area/almayer/hallways/repair_bay)
 "bYO" = (
 /obj/structure/window/framed/almayer,
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/plating,
@@ -44753,9 +44495,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/door/airlock/almayer/generic{
@@ -45004,7 +44744,7 @@
 /area/almayer/squads/charlie)
 "bZq" = (
 /obj/machinery/door/airlock/almayer/marine/charlie,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -45188,7 +44928,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/door/airlock/almayer/generic{
 	dir = 4;
 	name = "\improper Pilot's Office";
@@ -45488,7 +45228,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/living/pilotbunks)
 "cat" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/door/airlock/almayer/generic{
 	dir = 4;
 	name = "\improper Pilot's Office";
@@ -46120,7 +45860,7 @@
 /area/almayer/hallways/port_hallway)
 "cce" = (
 /obj/machinery/door/airlock/almayer/marine/delta,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer/mono,
 /area/almayer/squads/delta)
 "ccf" = (
@@ -46275,7 +46015,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/almayer/marine/delta,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -46506,7 +46246,7 @@
 /obj/machinery/door/airlock/almayer/generic{
 	name = "\improper Extended Operations Bunks"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer/mono,
 /area/almayer/living/port_emb)
 "ccO" = (
@@ -46572,7 +46312,7 @@
 /area/almayer/squads/delta)
 "ccY" = (
 /obj/machinery/door/airlock/almayer/marine/delta,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -46946,7 +46686,7 @@
 /turf/open/floor/almayer/mono,
 /area/almayer/hull/lower_hull)
 "cdY" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -46994,9 +46734,7 @@
 /turf/open/floor/almayer/mono,
 /area/almayer/hull/lower_hull)
 "ceb" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/door/poddoor/shutters/almayer{
@@ -47142,7 +46880,7 @@
 	id = "laddersoutheast";
 	name = "\improper South East Ladders Shutters"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -47508,9 +47246,7 @@
 /area/almayer/shipboard/ex_firing_range)
 "cfq" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -47619,7 +47355,7 @@
 	name = "\improper Experimental Weaponry Storage";
 	req_one_access_txt = "0"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer,
 /area/almayer/shipboard/ex_firing_range)
 "cfI" = (
@@ -48336,7 +48072,7 @@
 /turf/open/floor/almayer/mono,
 /area/almayer/living/bridgebunks)
 "chk" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -48433,7 +48169,7 @@
 /area/almayer/shipboard/brig_cells)
 "chv" = (
 /obj/machinery/door/airlock/almayer/maint,
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer,
 /area/almayer/shipboard/ex_firing_range)
 "chw" = (
@@ -48441,7 +48177,7 @@
 	dir = 4;
 	name = "Tool Closet"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer,
 /area/almayer/shipboard/ex_firing_range)
 "chx" = (
@@ -49313,7 +49049,7 @@
 	name = "\improper Hangar Lockdown Blast Door";
 	opacity = 0
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
 	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
@@ -49667,9 +49403,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer,
@@ -49700,9 +49434,7 @@
 	id = "Solid_Fuel";
 	name = "\improper Solid Fuel Storage"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -49736,7 +49468,7 @@
 	id = "Solid_Fuel";
 	name = "\improper Solid Fuel Storage"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
 	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
@@ -49768,9 +49500,7 @@
 /turf/open/floor/almayer/mono,
 /area/almayer/shipboard/weapon_room)
 "ckP" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -49780,9 +49510,7 @@
 /area/almayer/shipboard/port_missiles)
 "ckQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -49792,9 +49520,7 @@
 /area/almayer/shipboard/port_missiles)
 "ckR" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer{
@@ -50557,9 +50283,7 @@
 	},
 /area/almayer/hull/upper_hull)
 "hMM" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -50673,9 +50397,7 @@
 	},
 /area/almayer/squads/alpha)
 "iZq" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/structure/cable{
@@ -50852,9 +50574,7 @@
 	name = "Bathroom"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/structure/cable/yellow{
@@ -50982,7 +50702,7 @@
 /turf/open/floor/almayer,
 /area/almayer/hallways/aft_hallway)
 "lol" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -51445,7 +51165,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/almayer/shipboard/weapon_room)
 "oTf" = (
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /obj/structure/cable{
 	icon_state = "4-8";
 	d1 = 4;
@@ -51473,7 +51193,7 @@
 	id = "medicalemergency";
 	name = "\improper Medical Emergency Shutters"
 	},
-/obj/machinery/door/firedoor/border_only/almayer,
+/obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
 	icon_state = "dark_sterile";
 	tag = "icon-sterile"
@@ -51656,9 +51376,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/structure/disposalpipe/segment,
@@ -51905,9 +51623,7 @@
 /turf/open/floor/almayer/mono,
 /area/almayer/command/cic)
 "uhG" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/machinery/door/airlock/multi_tile/almayer/medidoor{
@@ -52035,9 +51751,7 @@
 	},
 /area/almayer/shipboard/weapon_room)
 "vwd" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/structure/cable/yellow{
@@ -52176,9 +51890,7 @@
 /area/almayer/shipboard/weapon_room)
 "wpW" = (
 /obj/structure/window/framed/almayer,
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /turf/open/floor/almayer/mono,
@@ -52278,9 +51990,7 @@
 /turf/open/floor/almayer,
 /area/almayer/command/cic)
 "xjx" = (
-/obj/machinery/door/firedoor/border_only/almayer{
-	tag = "icon-door_open";
-	icon_state = "door_open";
+/obj/machinery/door/firedoor/theseus{
 	dir = 2
 	},
 /obj/structure/cable{

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -380,4 +380,4 @@
 	if(get_dir(loc, target) == dir)
 		return !density
 	else
-return TRUE
+		return TRUE

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -341,15 +341,11 @@
 	return
 
 
-/obj/machinery/door/firedoor/border_only
-
-
-//ALMAYER FIRE DOOR
-
-/obj/machinery/door/firedoor/border_only/almayer
+/obj/machinery/door/firedoor/theseus
 	name = "\improper Emergency Shutter"
 	desc = "Emergency air-tight shutter, capable of sealing off breached areas."
 	icon = 'icons/obj/doors/almayer/purinadoor.dmi'
+	icon_state = "door_open"
 	openspeed = 4
 
 
@@ -357,10 +353,31 @@
 	icon = 'icons/obj/doors/DoorHazard2x1.dmi'
 	width = 2
 
+
+/obj/machinery/door/firedoor/border_only
+	icon = 'icons/obj/doors/edge_Doorfire.dmi'
+	flags_atom = ON_BORDER
+
+
+/obj/machinery/door/firedoor/border_only/closed
+	icon_state = "door_closed"
+	opacity = TRUE
+	density = TRUE
+
+
 /obj/machinery/door/firedoor/border_only/CanPass(atom/movable/mover, turf/target)
-	if(istype(mover) && mover.checkpass(PASSGLASS))
+	if(istype(mover) && (mover.checkpass(PASSGLASS)))
 		return TRUE
 	if(get_dir(loc, target) == dir) //Make sure looking at appropriate border
 		return !density
 	else
 		return TRUE
+
+
+/obj/machinery/door/firedoor/border_only/CheckExit(atom/movable/mover as mob|obj, turf/target)
+	if(istype(mover) && (mover.checkpass(PASSGLASS)))
+		return TRUE
+	if(get_dir(loc, target) == dir)
+		return !density
+	else
+return TRUE


### PR DESCRIPTION
Fixes #1073 
Also re-adds border only doors, in case any mapper feels like using them. They exist in /tg/ as well.

What happened is that at some point CM substituted the boder_only firedoors for fulltille ones, but didn't remove the `boder_only` path. Kind of slapped them on top of the existing ones instead of creating new ones, leaving the misleading and useless path.