### PR TITLE
Fixes initial damages not being applied on flamer_fire instanciation

### DIFF
--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -135,10 +135,8 @@ proc/flame_radius(radius = 1, turf/T, burn_intensity = 25, burn_duration = 25, b
 	dur_var = CLAMP(int_var, 0.1,0.5)
 	fire_stacks = rand(burn_damage*(0.5-int_var),burn_damage*(0.5+int_var) ) + rand(burn_damage*(0.5-int_var),burn_damage*(0.5+int_var) )
 	burn_damage = rand(burn_damage*(0.5-int_var),burn_damage*(0.5+int_var) ) + rand(burn_damage*(0.5-int_var),burn_damage*(0.5+int_var) )
-	for(var/obj/flamer_fire/F in range(radius,T)) // No stacking flames!
-		qdel(F)
 	for(var/turf/IT in diamondturfs(T,radius))
-		new /obj/flamer_fire(IT, rand(burn_intensity*(0.5-int_var), burn_intensity*(0.5+int_var)) + rand(burn_intensity*(0.5-int_var), burn_intensity*(0.5+int_var)), rand(burn_duration*(0.5-int_var), burn_duration*(0.5-int_var)) + rand(burn_duration*(0.5-int_var), burn_duration*(0.5-int_var)), colour, 0, burn_damage, fire_stacks)
+		IT.ignite(rand(burn_intensity*(0.5-int_var), burn_intensity*(0.5+int_var)) + rand(burn_intensity*(0.5-int_var), burn_intensity*(0.5+int_var)), rand(burn_duration*(0.5-int_var), burn_duration*(0.5-int_var)) + rand(burn_duration*(0.5-int_var), burn_duration*(0.5-int_var)), colour, burn_damage, fire_stacks)
 
 
 /obj/item/explosive/grenade/incendiary/molotov

--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -188,9 +188,7 @@
 		L.adjustFireLoss(120)
 		L.adjust_fire_stacks(20)
 		L.IgniteMob()
-	for(var/obj/flamer_fire/F in T) // No stacking flames!
-		qdel(F)
-	new/obj/flamer_fire(T, 5, 30) //short but intense
+	T.ignite(5, 30) //short but intense
 
 
 //Rockets
@@ -294,9 +292,7 @@
 		spawn(5)
 			explosion(impact,1,2,3,6,1,0) //relatively weak
 			for(var/turf/T in range(4,impact))
-				for(var/obj/flamer_fire/F in T) // No stacking flames!
-					qdel(F)
-				new/obj/flamer_fire(T, 60, 30) //cooking for a long time
+				T.ignite(60, 30) //cooking for a long time
 			qdel(src)
 
 
@@ -348,9 +344,7 @@
 	detonate_on(turf/impact)
 		..()
 		spawn(5)
-			for(var/obj/flamer_fire/F in impact) // No stacking flames!
-				qdel(F)
-			new/obj/flamer_fire(impact)
+			impact.ignite()
 
 /obj/structure/ship_ammo/minirocket/illumination
 	name = "illumination rocket-launched flare stack"

--- a/code/modules/mob/living/carbon/xenomorph/Castes/Ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Castes/Ravager.dm
@@ -305,10 +305,7 @@
 	if(!istype(T))
 		return
 
-	for(var/obj/flamer_fire/F in T) // No stacking flames!
-		qdel(F)
-
-	new/obj/flamer_fire(T)
+	T.ignite()
 
 	var/fire_mod
 	for(var/mob/living/carbon/M in T) //Deal bonus damage if someone's caught directly in initial stream

--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -220,9 +220,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	proc/drop_flame(turf/T) // ~Art updated fire 20JAN17
 		if(!istype(T))
 			return
-		for(var/obj/flamer_fire/F in T) // No stacking flames!
-			qdel(F)
-		new /obj/flamer_fire(T, 20, 20)
+		T.ignite(20, 20)
 
 
 /*

--- a/code/modules/projectiles/updated_projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_attachables.dm
@@ -1069,10 +1069,7 @@ Defined in conflicts.dm of the #defines folder.
 	if(!istype(T))
 		return
 
-	for(var/obj/flamer_fire/F in T) // No stacking flames!
-		qdel(F)
-
-	new/obj/flamer_fire(T)
+	T.ignite()
 
 	var/fire_mod
 	for(var/mob/living/carbon/M in T) //Deal bonus damage if someone's caught directly in initial stream

--- a/code/modules/projectiles/updated_projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/flamer.dm
@@ -489,12 +489,11 @@
 	for(var/mob/living/C in T)
 		if(C.fire_immune)
 			continue
-		else
-			C.adjust_fire_stacks(fire_stacks)
-			var/armor_block = C.run_armor_check("chest", "energy")
-			C.apply_damage(fire_damage, BURN, null, armor_block)
-			C.IgniteMob()
-			C.visible_message("<span class='danger'>[C] bursts into flames!</span>","[isxeno(C)?"<span class='xenodanger'>":"<span class='highdanger'>"]You burst into flames!</span>")
+
+		C.flamer_fire_act(fire_stacks,100)
+		var/armor_block = C.run_armor_check("chest", "energy")
+		C.apply_damage(fire_damage, BURN, null, armor_block)
+		C.visible_message("<span class='danger'>[C] bursts into flames!</span>","[isxeno(C)?"<span class='xenodanger'>":"<span class='highdanger'>"]You burst into flames!</span>")
 
 /obj/flamer_fire/Crossed(mob/living/M) //Only way to get it to reliable do it when you walk into it.
 	if(istype(M))

--- a/code/modules/reagents/chemistry_reactions/other.dm
+++ b/code/modules/reagents/chemistry_reactions/other.dm
@@ -184,9 +184,7 @@
 			continue
 		if(istype(T,/turf/open/space))
 			continue
-		for(var/obj/flamer_fire/F in T) // No stacking flames!
-			qdel(F)
-		new /obj/flamer_fire(T, 5 + rand(0,11))
+		T.ignite(5 + rand(0,11))
 
 
 /datum/chemical_reaction/chemsmoke


### PR DESCRIPTION

## About The Pull Request

Quickfix for initial damages on flame creation being overlooked in the fire range refactor.
Some light code cleaning, but the whole flame code is a mess and should be added on the refactor list, if not already.

## Changelog
:cl:
fix: Flame now applies initial damage correctly

/:cl:
