### PR TITLE
Slight Projectile Speed Increase

### DIFF
--- a/code/controllers/configuration/entries/combat_defines.dm
+++ b/code/controllers/configuration/entries/combat_defines.dm
@@ -414,22 +414,22 @@ Speed.
 How quick the projectile travels, or more accurately how many turfs per sleep(1) it travels.
 */
 /datum/config_entry/number/combat_define/min_shell_speed
-	config_entry_value = 0.1
-
-/datum/config_entry/number/combat_define/slow_shell_speed
 	config_entry_value = 1
 
-/datum/config_entry/number/combat_define/reg_shell_speed
+/datum/config_entry/number/combat_define/slow_shell_speed
 	config_entry_value = 2
 
-/datum/config_entry/number/combat_define/fast_shell_speed
+/datum/config_entry/number/combat_define/reg_shell_speed
 	config_entry_value = 3
 
-/datum/config_entry/number/combat_define/super_shell_speed
+/datum/config_entry/number/combat_define/fast_shell_speed
 	config_entry_value = 4
 
-/datum/config_entry/number/combat_define/ultra_shell_speed
+/datum/config_entry/number/combat_define/super_shell_speed
 	config_entry_value = 5
+
+/datum/config_entry/number/combat_define/ultra_shell_speed
+	config_entry_value = 6
 
 /*
 Penetration.

--- a/code/modules/projectiles/updated_projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_attachables.dm
@@ -349,7 +349,7 @@ Defined in conflicts.dm of the #defines folder.
 	. = ..()
 	accuracy_mod = -CONFIG_GET(number/combat_define/hmed_hit_accuracy_mult)
 	damage_mod = CONFIG_GET(number/combat_define/hmed_hit_damage_mult)
-	attach_shell_speed_mod = CONFIG_GET(number/combat_define/slow_shell_speed) //increases projectile speed by +2
+	attach_shell_speed_mod = CONFIG_GET(number/combat_define/slow_shell_speed)
 	delay_mod = CONFIG_GET(number/combat_define/low_fire_delay)
 	accuracy_unwielded_mod = -CONFIG_GET(number/combat_define/high_hit_accuracy_mult)
 

--- a/code/modules/projectiles/updated_projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_attachables.dm
@@ -349,7 +349,7 @@ Defined in conflicts.dm of the #defines folder.
 	. = ..()
 	accuracy_mod = -CONFIG_GET(number/combat_define/hmed_hit_accuracy_mult)
 	damage_mod = CONFIG_GET(number/combat_define/hmed_hit_damage_mult)
-	attach_shell_speed_mod = CONFIG_GET(number/combat_define/slow_shell_speed) //increases projectile speed by +1
+	attach_shell_speed_mod = CONFIG_GET(number/combat_define/slow_shell_speed) //increases projectile speed by +2
 	delay_mod = CONFIG_GET(number/combat_define/low_fire_delay)
 	accuracy_unwielded_mod = -CONFIG_GET(number/combat_define/high_hit_accuracy_mult)
 


### PR DESCRIPTION
:cl: by Surrealistik
tweak: Projectile speed parameters increased by +1 across the board (they will travel +1 tile per decisecond).
tweak: Barrel Charger projectile speed adjustment increased from +1 to +2. Extended Barrel adjustment increased from +0.1 to +1. Suppressor adjustment decreased from -0.1 to -1.
/:cl: