### PR TITLE
Makes luchador masks protect from cold

### DIFF
--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -131,7 +131,7 @@
 	flags_inv_hide = HIDEFACE|HIDEALLHAIR
 	flags_armor_protection = HEAD|FACE
 	flags_cold_protection = HEAD
-	min_cold_protection_temperature = ICE_PLANET_MIN_COLD_PROTECTION_TEMPERATURE
+	min_cold_protection_temperature = ICE_PLANET_min_cold_protection_temperature
 	w_class = 2
 	siemens_coefficient = 3.0
 

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -127,10 +127,11 @@
 	desc = "Worn by robust fighters, flying high to defeat their foes!"
 	icon_state = "luchag"
 	item_state = "luchag"
+	flags_inventory = COVERMOUTH|ALLOWREBREATH
 	flags_inv_hide = HIDEFACE|HIDEALLHAIR
 	flags_armor_protection = HEAD|FACE
 	flags_cold_protection = HEAD
-	min_cold_protection_temperature = ICE_PLANET_min_cold_protection_temperature
+	min_cold_protection_temperature = ICE_PLANET_MIN_COLD_PROTECTION_TEMPERATURE
 	w_class = 2
 	siemens_coefficient = 3.0
 

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -129,6 +129,8 @@
 	item_state = "luchag"
 	flags_inv_hide = HIDEFACE|HIDEALLHAIR
 	flags_armor_protection = HEAD|FACE
+	flags_cold_protection = HEAD
+	min_cold_protection_temperature = ICE_PLANET_min_cold_protection_temperature
 	w_class = 2
 	siemens_coefficient = 3.0
 


### PR DESCRIPTION
## About The Pull Request

It just, uh, makes the luchador masks you can find in the Theseus boxing area protect from cold. 
## Why It's Good For The Game

Adds another choice for fashion minded people who wish to wear luchador masks on Ice instead of those balaclavas, rebreathers, or gas masks, which are for nerds. 

## Changelog
:cl:
tweak: Added cold protection to luchador masks. 
/:cl:

