### PR TITLE
Changes xeno scaling to a smoother curve.

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -163,10 +163,14 @@
 	config_entry_value = 4
 	min_val = 1
 
+/datum/config_entry/number/min_xenos
+	config_entry_value = 5
+	min_val = 1
+
 /datum/config_entry/number/xeno_coefficient
 	integer = FALSE
 	config_entry_value = 0.04
-	min_val = 0.01
+	min_val = 0.001
 
 /datum/config_entry/number/survivor_coefficient
 	integer = FALSE

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -158,10 +158,15 @@
 
 /datum/config_entry/flag/tank_mouth_noise //Causes the tank to sound like a 5 year old child is driving it.
 
+/datum/config_entry/number/xeno_number
+	integer = FALSE
+	config_entry_value = 4
+	min_val = 1
+
 /datum/config_entry/number/xeno_coefficient
 	integer = FALSE
-	config_entry_value = 4.25
-	min_val = 1
+	config_entry_value = 0.04
+	min_val = 0.01
 
 /datum/config_entry/number/survivor_coefficient
 	integer = FALSE

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -94,7 +94,8 @@ Additional game mode variables.
 
 datum/game_mode/proc/initialize_special_clamps()
 	var/ready_players = ready_players() // Get all players that have "Ready" selected
-	xeno_starting_num = max((round(ready_players / CONFIG_GET(number/xeno_coefficient))), xeno_required_num)
+	var/max_xeno_num = round(ready_players / (CONFIG_GET(number/xeno_number) + CONFIG_GET(number/xeno_coefficient) * ready_players))
+	xeno_starting_num = max(max_xeno_num, xeno_required_num)
 	surv_starting_num = CLAMP((round(ready_players / CONFIG_GET(number/survivor_coefficient))), 0, 8)
 	merc_starting_num = max((round(ready_players / MERC_STARTING_COEF)), 1)
 	marine_starting_num = ready_players - xeno_starting_num - surv_starting_num - merc_starting_num

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -94,6 +94,7 @@ Additional game mode variables.
 
 datum/game_mode/proc/initialize_special_clamps()
 	var/ready_players = ready_players() // Get all players that have "Ready" selected
+	xeno_required_num = CONFIG_GET(number/min_xenos)
 	var/max_xeno_num = round(ready_players / (CONFIG_GET(number/xeno_number) + CONFIG_GET(number/xeno_coefficient) * ready_players))
 	xeno_starting_num = max(max_xeno_num, xeno_required_num)
 	surv_starting_num = CLAMP((round(ready_players / CONFIG_GET(number/survivor_coefficient))), 0, 8)

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -145,6 +145,9 @@ datum/game_mode/proc/initialize_special_clamps()
 	if(xenomorphs.len < xeno_required_num)
 		return FALSE
 
+	if(length(xenomorphs) < xeno_starting_num)
+		stored_larva += xeno_starting_num - length(xenomorphs)
+
 	return TRUE
 
 /datum/game_mode/proc/initialize_starting_queen_list()


### PR DESCRIPTION
:cl: LaKiller8
balance: Xeno scaling should now be more consistent across population levels, this should fix the current winrate issues.
balance: If all xeno slots don't get rolled roundstart, the difference is added to burrowed larva.
balance: The minimum amount of xenos is now configable and slightly higher.
/:cl: