### PR TITLE
Sniper Uniform

### DIFF
--- a/code/modules/cm_marines/equipment/weapons.dm
+++ b/code/modules/cm_marines/equipment/weapons.dm
@@ -380,8 +380,10 @@
 				switch(SSmapping.config.map_name)
 					if(MAP_ICE_COLONY)
 						new /obj/item/clothing/head/helmet/marine(src)
+						new /obj/item/clothing/under/marine/sniper(src)
 					else
 						new /obj/item/clothing/head/helmet/durag(src)
+						new /obj/item/clothing/under/marine/sniper(src)
 						new /obj/item/facepaint/sniper(src)
 		..()
 


### PR DESCRIPTION
## About The Pull Request
Adds the TGMC sniper uniform to the Sniper Specialist kit. 
## Why It's Good For The Game
Lets snipers once more wear the sniper uniform. It has the same stats as a regular marine uniform, and the same...sprite, with the only real difference being that you can't roll down the sleeves on the sniper uniform. 
## Changelog
:cl:
add: Added the TGMC sniper uniform to the Sniper kit
/:cl:
