### PR TITLE
Minisentry Now Auto-Unanchors When Retrieving

### DIFF
--- a/code/modules/cm_marines/equipment/sentries.dm
+++ b/code/modules/cm_marines/equipment/sentries.dm
@@ -1249,8 +1249,9 @@
 		return
 
 	if(anchored)
-		to_chat(user, "<span class='warning'>You must unanchor [src] to retrieve it!</span>")
-		return
+		to_chat(user, "<span class='warning'>The [src] disengages its anchor bolts as you initiate the retrieval process.</span>")
+		anchored = FALSE
+		update_icon()
 
 	if(on)
 		to_chat(user, "<span class='warning'>You depower [src] to facilitate its retrieval.</span>")


### PR DESCRIPTION
:cl: by Surrealistik
tweak: Minisentry auto-unanchors when retrieving with drag and drop.
/:cl: