### PR TITLE
Morgue Trays don't accept living mobs.

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -52,12 +52,24 @@
 /obj/structure/morgue/attack_hand(mob/user)
 	toggle_morgue(user)
 
+/atom/movable/proc/can_be_morgue_trayed()
+	return TRUE
+
+/mob/living/can_be_morgue_trayed()
+	return stat == DEAD
+
+/obj/structure/closet/bodybag/can_be_morgue_trayed()
+	. = ..()
+	for(var/atom/movable/AM in contents)
+		if(!AM.can_be_morgue_trayed())
+			return FALSE
+
 /obj/structure/morgue/proc/toggle_morgue(mob/user)
 	add_fingerprint(user)
 	if(!connected) return
 	if(morgue_open)
 		for(var/atom/movable/A in connected.loc)
-			if(!A.anchored)
+			if(!A.anchored && A.can_be_morgue_trayed())
 				A.forceMove(src)
 		connected.loc = src
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Kind of hugboxing but stops living marines hiding or getting stuck inside morgue trays
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
tweak: Living mobs can no longer be put in morgue trays
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
