### PR TITLE
Severely nerfs ceremonial sword.

### DIFF
--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -29,7 +29,7 @@
 	desc = "A fancy ceremonial sword passed down from generation to generation. Despite this, it has been very well cared for, and is in top condition."
 	icon_state = "mercsword"
 	item_state = "machete"
-	force = 65
+	force = 48
 
 /obj/item/weapon/claymore/mercsword/machete
 	name = "\improper M2132 machete"


### PR DESCRIPTION
## About The Pull Request

Synth was capable of getting 65 + 60% for 104 damage per swing thanks to weapon skills. For mps this is the same, and for specialists this is 82 damage per swing. Captains and other high command too.

People are starting to give the sword to the synth simply because they know synths can hit this much damage.

Machete has 40 damage, significantly lower, no other benefits.

I feel like 65 would've been fine if the captain just uses it for self-defence, but clearly we can't have nice things without abuse...

## Why It's Good For The Game

To mechanically prevent powergaming. 104 damage is a lot, it ignores armor. I don't see people roleplaying or anything, they just give the sword to the synth because of this high number. It also has no right being 50% stronger than a machete.

## Changelog
:cl:
balance: Reduces ceremonial sword damage from 65 to 48
/:cl:
