### PR TITLE
Deleted objects no longer checked for Adjacency in MouseDrop

### DIFF
--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -12,7 +12,6 @@
 		return // should stop you from dragging through windows
 
 	over.MouseDrop_T(src,usr)
-	return
 
 
 // recieve a mousedrop

--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -5,14 +5,15 @@
 	recieving object instead, so that's the default action.  This allows you to drag
 	almost anything into a trash can.
 */
-/atom/MouseDrop(atom/over)
-	if(!usr || !over) return
-	if(!Adjacent(usr) || !over.Adjacent(usr)) return // should stop you from dragging through windows
+/atom/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)
+	if(!usr || !over || QDELETED(src))
+		return
+	if(!Adjacent(usr) || !over.Adjacent(usr))
+		return // should stop you from dragging through windows
 
-	spawn(0)
-		if(over)
-			over.MouseDrop_T(src,usr)
+	over.MouseDrop_T(src,usr)
 	return
+
 
 // recieve a mousedrop
 /atom/proc/MouseDrop_T(atom/dropping, mob/user)


### PR DESCRIPTION
Fixes some runtimes that happened whenever someone would click and drag an object who'd be deleted before releasing the mouse button.
Before the item Adjacent rework that would be culled during the proc, but this should never even check for Adjacency ideally.