### PR TITLE
Ports SDQL2 selector arrays

### DIFF
--- a/code/modules/admin/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/SDQL2/SDQL_2.dm
@@ -61,6 +61,10 @@
 
 	"SELECT /mob WHERE client MAP client WHERE holder MAP holder"
 
+	You can also generate a new list on the fly using a selector array. @[] will generate a list of objects based off the selector provided.
+
+	"SELECT /mob/living IN @[/area/crew_quarters/bar MAP contents]"
+
 	What if some dumbass admin spawned a bajillion spiders and you need to kill them all?
 	Oh yeah you'd rather not delete all the spiders in maintenace. Only that one room the spiders were
 	spawned in.
@@ -552,6 +556,8 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/SDQL2_VV_all, new(null
 					objs[j] = SDQL_expression(x, expression)
 					SDQL2_TICK_CHECK
 					SDQL2_HALT_CHECK
+				if(length(objs) == 1 && islist(objs[1]))
+					objs = objs[1]
 
 			if ("where")
 				where_switched = TRUE
@@ -906,12 +912,27 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/SDQL2_VV_all, new(null
 				dummy[result] = assoc
 				result = dummy
 			val += result
+
+	else if(expression[i] == "@\[")
+		var/list/search_tree = expression[++i]
+		var/already_searching = (state == SDQL2_STATE_SEARCHING) //In case we nest, don't want to break out of the searching state until we're all done.
+
+		if(!already_searching)
+			state = SDQL2_STATE_SEARCHING
+
+		val = Search(search_tree)
+		SDQL2_STAGE_SWITCH_CHECK
+
+		if(!already_searching)
+			state = SDQL2_STATE_EXECUTING
+		else
+			state = SDQL2_STATE_SEARCHING
+
 	else
 		val = world.SDQL_var(object, expression, i, object, superuser, src)
 		i = expression.len
 
 	return list("val" = val, "i" = i)
-
 
 /proc/SDQL_parse(list/query_list)
 	var/datum/SDQL_parser/parser = new()
@@ -1080,7 +1101,8 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/SDQL2_VV_all, new(null
 					"=" = list("", "="),
 					"<" = list("", "=", ">"),
 					">" = list("", "="),
-					"!" = list("", "="))
+					"!" = list("", "="),
+					"@" = list("\["))
 
 	var/word = ""
 	var/list/query_list = list()


### PR DESCRIPTION
The source pull request is not merged yet, if changes are necessary I will mirror them here if possible.

# From tgstation/tgstation#43383

## About The Pull Request

I've added a selector array query. It's a special construct formed like this:
```bnf
'@[' <selectors> ']'
```
The `<selectors>` is the very same way that you normally use to select datums for all of the queries.
```bnf
UPDATE <selectors> SET <assignments>
SELECT <selectors>
```

I chose `@[ ]` because it's adding an @ sign to the existing SDQL list symbols, since it still generates a list.

## Why It's Good For The Game

It adds more flexibility to SDQL, allowing admins to do more with the language. I find it very convenient in testing to really narrow down the search to say, an /area, so SDQL will only look for datums in that /area's .contents, when paired with MAP.

![Screenshot_20190328_123436](https://user-images.githubusercontent.com/5211576/55175684-274e7000-5156-11e9-9391-b42dfcfd182f.png)

![Screenshot_20190328_123333](https://user-images.githubusercontent.com/5211576/55175698-2e757e00-5156-11e9-8430-d27a389f393e.png)

## Changelog
:cl: JJRcop
add: SDQL2 now features a list constructor that takes a selector query. 
tweak: The MAP statement will unwrap lone lists that are the only result. This means the parent query begins directly iterating over the list rather than a list that contains the list.
/:cl:

i stayed up too late