### PR TITLE
Fixes queen leader pheromones

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -77,14 +77,13 @@
 	update_canmove()
 
 	//Deal with devoured things and people
-	if(length(stomach_contents))
-		for(var/mob/M in stomach_contents)
+	if(stomach_contents.len)
+		for(var/atom/movable/M in stomach_contents)
 			if(world.time > devour_timer && ishuman(M) && !is_ventcrawling)
 				stomach_contents.Remove(M)
 				if(M.loc != src)
 					continue
 				M.forceMove(loc)
-				M.KnockDown(3)
 	return TRUE
 
 /mob/living/carbon/Xenomorph/Defender/update_stat()
@@ -289,20 +288,20 @@
 						if("recovery")
 							if(xeno_caste.aura_strength > Z.recovery_new)
 								Z.recovery_new = xeno_caste.aura_strength
-		if(leader_current_aura && !stat)
-			var/pheromone_range = round(6 + leader_aura_strength * 2)
-			for(var/mob/living/carbon/Xenomorph/Z in range(pheromone_range, src)) //Goes from 7 for Young Drone to 16 for Ancient Queen
-				if(Z.stat != DEAD && hivenumber == Z.hivenumber && !Z.on_fire)
-					switch(leader_current_aura)
-						if("frenzy")
-							if(leader_aura_strength > Z.frenzy_new)
-								Z.frenzy_new = leader_aura_strength
-						if("warding")
-							if(leader_aura_strength > Z.warding_new)
-								Z.warding_new = leader_aura_strength
-						if("recovery")
-							if(leader_aura_strength > Z.recovery_new)
-								Z.recovery_new = leader_aura_strength
+	if(leader_current_aura && !stat && !on_fire)
+		var/pheromone_range = round(6 + leader_aura_strength * 2)
+		for(var/mob/living/carbon/Xenomorph/Z in range(pheromone_range, src)) //Goes from 7 for Young Drone to 16 for Ancient Queen
+			if(Z.stat != DEAD && hivenumber == Z.hivenumber && !Z.on_fire)
+				switch(leader_current_aura)
+					if("frenzy")
+						if(leader_aura_strength > Z.frenzy_new)
+							Z.frenzy_new = leader_aura_strength
+					if("warding")
+						if(leader_aura_strength > Z.warding_new)
+							Z.warding_new = leader_aura_strength
+					if("recovery")
+						if(leader_aura_strength > Z.recovery_new)
+							Z.recovery_new = leader_aura_strength
 
 /mob/living/carbon/Xenomorph/proc/handle_aura_receiver()
 	if(frenzy_aura != frenzy_new || warding_aura != warding_new || recovery_aura != recovery_new)

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -77,13 +77,14 @@
 	update_canmove()
 
 	//Deal with devoured things and people
-	if(stomach_contents.len)
-		for(var/atom/movable/M in stomach_contents)
+	if(length(stomach_contents))
+		for(var/mob/M in stomach_contents)
 			if(world.time > devour_timer && ishuman(M) && !is_ventcrawling)
 				stomach_contents.Remove(M)
 				if(M.loc != src)
 					continue
 				M.forceMove(loc)
+				M.KnockDown(3)
 	return TRUE
 
 /mob/living/carbon/Xenomorph/Defender/update_stat()


### PR DESCRIPTION




## About The Pull Request

Fixes pheromones not applying to leaders , even when the queen has deployed an ovipositor.

Additionally adds a check if a leader is on fire for temporarily disabling emission of pheromones, to not require the queen to take action to have the leader emit pheromones again.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->


## Changelog
:cl:
fix: Leader pheromones now function again while the queen is ovipositored
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
