### PR TITLE
Code cleanup.

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -102,31 +102,3 @@
 	icon_state = "disk_kit"
 	spawn_type = /obj/item/disk/data
 	spawn_number = 7
-
-/*
- *	Manual -- A big ol' manual.
- */
-
-/obj/item/paper/Cloning
-	name = "H-87 Cloning Apparatus Manual"
-	info = {"<h4>Getting Started</h4>
-	Congratulations, your station has purchased the H-87 industrial cloning device!<br>
-	Using the H-87 is almost as simple as brain surgery! Simply insert the target humanoid into the scanning chamber and select the scan option to create a new profile!<br>
-	<b>That's all there is to it!</b><br>
-	<i>Notice, cloning system cannot scan inorganic life or small primates.  Scan may fail if subject has suffered extreme brain damage.</i><br>
-	<p>Clone profiles may be viewed through the profiles menu. Scanning implants a complementary HEALTH MONITOR IMPLANT into the subject, which may be viewed from each profile.
-	Profile Deletion has been restricted to \[Station Head\] level access.</p>
-	<h4>Cloning from a profile</h4>
-	Cloning is as simple as pressing the CLONE option at the bottom of the desired profile.<br>
-	Per your company's EMPLOYEE PRIVACY RIGHTS agreement, the H-87 has been blocked from cloning crewmembers while they are still alive.<br>
-	<br>
-	<p>The provided CLONEPOD SYSTEM will produce the desired clone.  Standard clone maturation times (With SPEEDCLONE technology) are roughly 90 seconds.
-	The cloning pod may be unlocked early with any \[Medical Researcher\] ID after initial maturation is complete.</p><br>
-	<i>Please note that resulting clones may have a small DEVELOPMENTAL DEFECT as a result of genetic drift.</i><br>
-	<h4>Profile Management</h4>
-	<p>The H-87 (as well as your station's standard genetics machine) can accept STANDARD DATA DISKETTES.
-	These diskettes are used to transfer genetic information between machines and profiles.
-	A load/save dialog will become available in each profile if a disk is inserted.</p><br>
-	<i>A good diskette is a great way to counter aforementioned genetic drift!</i><br>
-	<br>
-	<font size=1>This technology produced under license from Thinktronic Systems, LTD.</font>"}

--- a/code/game/objects/items/paint.dm
+++ b/code/game/objects/items/paint.dm
@@ -171,66 +171,65 @@ var/global/list/cached_icons = list()
 		return
 */
 
-datum/reagent/paint
+/datum/reagent/paint
 	name = "Paint"
 	id = "paint_"
 	reagent_state = 2
 	color = "#808080"
 	description = "This paint will only adhere to floor tiles."
 
-	reaction_turf(var/turf/T, var/volume)
-		if(!istype(T) || isspaceturf(T))
-			return
-		T.color = color
+/datum/reagent/paint/reaction_turf(turf/T, volume)
+	if(!istype(T) || isspaceturf(T))
+		return
+	T.color = color
 
-	reaction_obj(var/obj/O, var/volume)
-		..()
-		if(istype(O,/obj/item/light_bulb))
-			O.color = color
+/datum/reagent/paint/reaction_obj(obj/O, volume)
+	. = ..()
+	if(istype(O,/obj/item/light_bulb))
+		O.color = color
 
-	red
-		name = "Red Paint"
-		id = "paint_red"
-		color = "#FE191A"
+/datum/reagent/paint/red
+	name = "Red Paint"
+	id = "paint_red"
+	color = "#FE191A"
 
-	green
-		name = "Green Paint"
-		color = "#18A31A"
-		id = "paint_green"
+/datum/reagent/paint/green
+	name = "Green Paint"
+	color = "#18A31A"
+	id = "paint_green"
 
-	blue
-		name = "Blue Paint"
-		color = "#247CFF"
-		id = "paint_blue"
+/datum/reagent/paint/blue
+	name = "Blue Paint"
+	color = "#247CFF"
+	id = "paint_blue"
 
-	yellow
-		name = "Yellow Paint"
-		color = "#FDFE7D"
-		id = "paint_yellow"
+/datum/reagent/paint/yellow
+	name = "Yellow Paint"
+	color = "#FDFE7D"
+	id = "paint_yellow"
 
-	violet
-		name = "Violet Paint"
-		color = "#CC0099"
-		id = "paint_violet"
+/datum/reagent/paint/violet
+	name = "Violet Paint"
+	color = "#CC0099"
+	id = "paint_violet"
 
-	black
-		name = "Black Paint"
-		color = "#333333"
-		id = "paint_black"
+/datum/reagent/paint/black
+	name = "Black Paint"
+	color = "#333333"
+	id = "paint_black"
 
-	white
-		name = "White Paint"
-		color = "#F0F8FF"
-		id = "paint_white"
+/datum/reagent/paint/white
+	name = "White Paint"
+	color = "#F0F8FF"
+	id = "paint_white"
 
-datum/reagent/paint_remover
+/datum/reagent/paint_remover
 	name = "Paint Remover"
 	id = "paint_remover"
 	description = "Paint remover is used to remove floor paint from floor tiles."
 	reagent_state = 2
 	color = "#808080"
 
-	reaction_turf(var/turf/T, var/volume)
-		if(istype(T) && T.icon != initial(T.icon))
-			T.icon = initial(T.icon)
-		return
+/datum/reagent/paint_remover/reaction_turf(turf/T, volume)
+	if(istype(T) && T.icon != initial(T.icon))
+		T.icon = initial(T.icon)

--- a/code/global.dm
+++ b/code/global.dm
@@ -1,6 +1,6 @@
 #define GAME_YEAR 2386
 
-var/global/defer_powernet_rebuild = 0		// true if net rebuild will be called manually after an event
+var/global/defer_powernet_rebuild = FALSE		// true if net rebuild will be called manually after an event
 
 var/global/list/global_map = null
 	//list/global_map = list(list(1,5),list(4,3))//an array of map Z levels.

--- a/code/global.dm
+++ b/code/global.dm
@@ -1,9 +1,5 @@
 #define GAME_YEAR 2386
 
-var/global/obj/effect/datacore/GLOB.datacore = null
-
-		//items that ask to be called every cycle
-
 var/global/defer_powernet_rebuild = 0		// true if net rebuild will be called manually after an event
 
 var/global/list/global_map = null

--- a/code/modules/nano/JSON_Reader.dm
+++ b/code/modules/nano/JSON_Reader.dm
@@ -198,7 +198,7 @@
 		CRASH("Unterminated array.")
 
 
-/datum/json_reader/proc/die(json_token/T)
+/datum/json_reader/proc/die(datum/json_token/T)
 	if(!T)
 		T = JSON_GET_TOKEN(i)
 	CRASH("Unexpected token: [T.value].")

--- a/code/modules/nano/JSON_Reader.dm
+++ b/code/modules/nano/JSON_Reader.dm
@@ -4,24 +4,24 @@
 #define JSON_NEXT_TOKEN(tokens, i) ( tokens[++i] )
 
 
-/json_token
+/datum/json_token
 	var/value
 
-/json_token/New(v)
+/datum/json_token/New(v)
 	value = v
 
-/json_token/text
+/datum/json_token/text
 
-/json_token/number
+/datum/json_token/number
 
-/json_token/word
+/datum/json_token/word
 
-/json_token/symbol
+/datum/json_token/symbol
 
-/json_token/eof
+/datum/json_token/eof
 
 
-/json_reader
+/datum/json_reader
 	var/list/string	= list("'", "\"")
 	var/list/symbols = list("{", "}", "\[", "]", ":", "\"", "'", ",")
 	var/list/sequences = list("b" = 8, "t" = 9, "n" = 10, "f" = 12, "r" = 13)
@@ -30,7 +30,7 @@
 	var/i
 
 
-/json_reader/proc/ScanJson(json)
+/datum/json_reader/proc/ScanJson(json)
 	src.json = json
 	. = new/list()
 	i = 1
@@ -41,25 +41,25 @@
 		if(string.Find(char))
 			. += read_string(char)
 		else if(symbols.Find(char))
-			. += new/json_token/symbol(char)
+			. += new/datum/json_token/symbol(char)
 		else if(is_digit(char))
 			. += read_number()
 		else
 			. += read_word()
-	. += new/json_token/eof()
+	. += new/datum/json_token/eof()
 
 
-/json_reader/proc/read_word()
+/datum/json_reader/proc/read_word()
 	var/val = ""
 	for(i, i <= lentext(json), i++)
 		var/char = JSON_GET_CHAR(json, i)
 		if(JSON_IS_WHITESPACE(char) || symbols.Find(char))
 			i-- // let scanner handle this character
-			return new/json_token/word(val)
+			return new/datum/json_token/word(val)
 		val += char
 
 
-/json_reader/proc/read_string(delim)
+/datum/json_reader/proc/read_string(delim)
 	var/escape 	= FALSE
 	var/val		= ""
 	while(++i <= lentext(json))
@@ -74,14 +74,14 @@
 					val += ascii2text(sequences[char])
 		else
 			if(char == delim)
-				return new/json_token/text(val)
+				return new/datum/json_token/text(val)
 			else if(char == "\\")
 				escape = TRUE
 			else
 				val += char
 	CRASH("Unterminated string.")
 
-/json_reader/proc/read_number()
+/datum/json_reader/proc/read_number()
 	var/val = ""
 	var/char = JSON_GET_CHAR(json, i)
 	while(is_digit(char) || char == "." || lowertext(char) == "e")
@@ -89,30 +89,30 @@
 		i++
 		char = JSON_GET_CHAR(json, i)
 	i-- // allow scanner to read the first non-number character
-	return new/json_token/number(text2num(val))
+	return new/datum/json_token/number(text2num(val))
 
 
-/json_reader/proc/is_digit(char)
+/datum/json_reader/proc/is_digit(char)
 	var/c = text2ascii(char)
 	return ( 48 <= c && c <= 57 || char == "+" || char == "-" )
 
 
 // parser
-/json_reader/proc/ReadObject(list/tokens)
+/datum/json_reader/proc/ReadObject(list/tokens)
 	src.tokens = tokens
 	. = new/list()
 	i = 1
-	read_token("{", /json_token/symbol)
+	read_token("{", /datum/json_token/symbol)
 	while(i <= tokens.len)
-		var/json_token/K = JSON_GET_TOKEN(i)
-		check_type(/json_token/word, /json_token/text)
+		var/datum/json_token/K = JSON_GET_TOKEN(i)
+		check_type(/datum/json_token/word, /datum/json_token/text)
 		JSON_NEXT_TOKEN(tokens, i)
-		read_token(":", /json_token/symbol)
+		read_token(":", /datum/json_token/symbol)
 
 		.[K.value] = read_value()
 
-		var/json_token/S = JSON_GET_TOKEN(i)
-		check_type(/json_token/symbol)
+		var/datum/json_token/S = JSON_GET_TOKEN(i)
+		check_type(/datum/json_token/symbol)
 		switch(S.value)
 			if(",")
 				JSON_NEXT_TOKEN(tokens, i)
@@ -124,40 +124,40 @@
 				die(S)
 
 
-/json_reader/proc/read_token(val, type)
-	var/json_token/T = JSON_GET_TOKEN(i)
+/datum/json_reader/proc/read_token(val, type)
+	var/datum/json_token/T = JSON_GET_TOKEN(i)
 	if(!(T.value == val && istype(T, type)))
 		CRASH("Expected '[val]', found '[T.value]'.")
 	JSON_NEXT_TOKEN(tokens, i)
 	return T
 
 
-/json_reader/proc/check_type(...)
-	var/json_token/T = JSON_GET_TOKEN(i)
+/datum/json_reader/proc/check_type(...)
+	var/datum/json_token/T = JSON_GET_TOKEN(i)
 	for(var/type in args)
 		if(istype(T, type))
 			return
 	CRASH("Bad token type: [T.type].")
 
 
-/json_reader/proc/check_value(...)
-	var/json_token/T = JSON_GET_TOKEN(i)
+/datum/json_reader/proc/check_value(...)
+	var/datum/json_token/T = JSON_GET_TOKEN(i)
 	ASSERT(args.Find(T.value))
 
 
-/json_reader/proc/read_key()
+/datum/json_reader/proc/read_key()
 	var/char = JSON_GET_CHAR(json, i)
 	if(char == "\"" || char == "'")
 		return read_string(char)
 
 
-/json_reader/proc/read_value()
-	var/json_token/T = JSON_GET_TOKEN(i)
+/datum/json_reader/proc/read_value()
+	var/datum/json_token/T = JSON_GET_TOKEN(i)
 	switch(T.type)
-		if(/json_token/text, /json_token/number)
+		if(/datum/json_token/text, /datum/json_token/number)
 			JSON_NEXT_TOKEN(tokens, i)
 			return T.value
-		if(/json_token/word)
+		if(/datum/json_token/word)
 			JSON_NEXT_TOKEN(tokens, i)
 			switch(T.value)
 				if("true")
@@ -166,7 +166,7 @@
 					return FALSE
 				if("null")
 					return null
-		if(/json_token/symbol)
+		if(/datum/json_token/symbol)
 			switch(T.value)
 				if("\[")
 					return read_array()
@@ -175,16 +175,16 @@
 	die(T)
 
 
-/json_reader/proc/read_array()
-	read_token("\[", /json_token/symbol)
+/datum/json_reader/proc/read_array()
+	read_token("\[", /datum/json_token/symbol)
 	. = new/list()
 	var/list/L = .
 	while(i <= tokens.len)
 		// Avoid using Add() or += in case a list is returned.
 		L.len++
 		L[L.len] = read_value()
-		var/json_token/T = JSON_GET_TOKEN(i)
-		check_type(/json_token/symbol)
+		var/datum/json_token/T = JSON_GET_TOKEN(i)
+		check_type(/datum/json_token/symbol)
 		switch(T.value)
 			if(",")
 				JSON_NEXT_TOKEN(tokens, i)
@@ -198,7 +198,7 @@
 		CRASH("Unterminated array.")
 
 
-/json_reader/proc/die(json_token/T)
+/datum/json_reader/proc/die(json_token/T)
 	if(!T)
 		T = JSON_GET_TOKEN(i)
 	CRASH("Unexpected token: [T.value].")

--- a/code/modules/nano/JSON_Reader.dm
+++ b/code/modules/nano/JSON_Reader.dm
@@ -1,204 +1,210 @@
-json_token
-	var
-		value
-	New(v)
-		src.value = v
-	text
-	number
-	word
-	symbol
-	eof
-
-json_reader
-	var
-		list
-			string		= list("'", "\"")
-			symbols 	= list("{", "}", "\[", "]", ":", "\"", "'", ",")
-			sequences 	= list("b" = 8, "t" = 9, "n" = 10, "f" = 12, "r" = 13)
-			tokens
-		json
-		i = 1
+#define JSON_GET_CHAR(json, i) ( copytext(json, i, i + 1) )
+#define JSON_IS_WHITESPACE(char) ( char == " " || char == "\t" || char == "\n" || text2ascii(char) == 13 )
+#define JSON_GET_TOKEN(i) ( tokens[i] )
+#define JSON_NEXT_TOKEN(tokens, i) ( tokens[++i] )
 
 
-	proc
-		// scanner
-		ScanJson(json)
-			src.json = json
-			. = new/list()
-			src.i = 1
-			while(src.i <= lentext(json))
-				var/char = get_char()
-				if(is_whitespace(char))
-					i++
-					continue
-				if(string.Find(char))
-					. += read_string(char)
-				else if(symbols.Find(char))
-					. += new/json_token/symbol(char)
-				else if(is_digit(char))
-					. += read_number()
+/json_token
+	var/value
+
+/json_token/New(v)
+	value = v
+
+/json_token/text
+
+/json_token/number
+
+/json_token/word
+
+/json_token/symbol
+
+/json_token/eof
+
+
+/json_reader
+	var/list/string	= list("'", "\"")
+	var/list/symbols = list("{", "}", "\[", "]", ":", "\"", "'", ",")
+	var/list/sequences = list("b" = 8, "t" = 9, "n" = 10, "f" = 12, "r" = 13)
+	var/list/tokens
+	var/json
+	var/i
+
+
+/json_reader/proc/ScanJson(json)
+	src.json = json
+	. = new/list()
+	i = 1
+	for(i, i <= lentext(json), i++)
+		var/char = JSON_GET_CHAR(json, i)
+		if(JSON_IS_WHITESPACE(char))
+			continue
+		if(string.Find(char))
+			. += read_string(char)
+		else if(symbols.Find(char))
+			. += new/json_token/symbol(char)
+		else if(is_digit(char))
+			. += read_number()
+		else
+			. += read_word()
+	. += new/json_token/eof()
+
+
+/json_reader/proc/read_word()
+	var/val = ""
+	for(i, i <= lentext(json), i++)
+		var/char = JSON_GET_CHAR(json, i)
+		if(JSON_IS_WHITESPACE(char) || symbols.Find(char))
+			i-- // let scanner handle this character
+			return new/json_token/word(val)
+		val += char
+
+
+/json_reader/proc/read_string(delim)
+	var/escape 	= FALSE
+	var/val		= ""
+	while(++i <= lentext(json))
+		var/char = JSON_GET_CHAR(json, i)
+		if(escape)
+			switch(char)
+				if("\\", "'", "\"", "/", "u")
+					val += char
 				else
-					. += read_word()
-				i++
-			. += new/json_token/eof()
-
-		read_word()
-			var/val = ""
-			while(i <= lentext(json))
-				var/char = get_char()
-				if(is_whitespace(char) || symbols.Find(char))
-					i-- // let scanner handle this character
-					return new/json_token/word(val)
+					// TODO: support octal, hex, unicode sequences
+					ASSERT(sequences.Find(char))
+					val += ascii2text(sequences[char])
+		else
+			if(char == delim)
+				return new/json_token/text(val)
+			else if(char == "\\")
+				escape = TRUE
+			else
 				val += char
-				i++
+	CRASH("Unterminated string.")
 
-		read_string(delim)
-			var/escape 	= FALSE
-			var/val		= ""
-			while(++i <= lentext(json))
-				var/char = get_char()
-				if(escape)
-					switch(char)
-						if("\\", "'", "\"", "/", "u")
-							val += char
-						else
-							// TODO: support octal, hex, unicode sequences
-							ASSERT(sequences.Find(char))
-							val += ascii2text(sequences[char])
-				else
-					if(char == delim)
-						return new/json_token/text(val)
-					else if(char == "\\")
-						escape = TRUE
-					else
-						val += char
-			CRASH("Unterminated string.")
-
-		read_number()
-			var/val = ""
-			var/char = get_char()
-			while(is_digit(char) || char == "." || lowertext(char) == "e")
-				val += char
-				i++
-				char = get_char()
-			i-- // allow scanner to read the first non-number character
-			return new/json_token/number(text2num(val))
-
-		check_char()
-			ASSERT(args.Find(get_char()))
-
-		get_char()
-			return copytext(json, i, i+1)
-
-		is_whitespace(char)
-			return char == " " || char == "\t" || char == "\n" || text2ascii(char) == 13
-
-		is_digit(char)
-			var/c = text2ascii(char)
-			return 48 <= c && c <= 57 || char == "+" || char == "-"
+/json_reader/proc/read_number()
+	var/val = ""
+	var/char = JSON_GET_CHAR(json, i)
+	while(is_digit(char) || char == "." || lowertext(char) == "e")
+		val += char
+		i++
+		char = JSON_GET_CHAR(json, i)
+	i-- // allow scanner to read the first non-number character
+	return new/json_token/number(text2num(val))
 
 
-		// parser
-		ReadObject(list/tokens)
-			src.tokens = tokens
-			. = new/list()
-			i = 1
-			read_token("{", /json_token/symbol)
-			while(i <= tokens.len)
-				var/json_token/K = get_token()
-				check_type(/json_token/word, /json_token/text)
-				next_token()
-				read_token(":", /json_token/symbol)
-
-				.[K.value] = read_value()
-
-				var/json_token/S = get_token()
-				check_type(/json_token/symbol)
-				switch(S.value)
-					if(",")
-						next_token()
-						continue
-					if("}")
-						next_token()
-						return
-					else
-						die()
-
-		get_token()
-			return tokens[i]
-
-		next_token()
-			return tokens[++i]
-
-		read_token(val, type)
-			var/json_token/T = get_token()
-			if(!(T.value == val && istype(T, type)))
-				CRASH("Expected '[val]', found '[T.value]'.")
-			next_token()
-			return T
-
-		check_type(...)
-			var/json_token/T = get_token()
-			for(var/type in args)
-				if(istype(T, type))
-					return
-			CRASH("Bad token type: [T.type].")
-
-		check_value(...)
-			var/json_token/T = get_token()
-			ASSERT(args.Find(T.value))
-
-		read_key()
-			var/char = get_char()
-			if(char == "\"" || char == "'")
-				return read_string(char)
-
-		read_value()
-			var/json_token/T = get_token()
-			switch(T.type)
-				if(/json_token/text, /json_token/number)
-					next_token()
-					return T.value
-				if(/json_token/word)
-					next_token()
-					switch(T.value)
-						if("true")
-							return TRUE
-						if("false")
-							return FALSE
-						if("null")
-							return null
-				if(/json_token/symbol)
-					switch(T.value)
-						if("\[")
-							return read_array()
-						if("{")
-							return ReadObject(tokens.Copy(i))
-			die()
-
-		read_array()
-			read_token("\[", /json_token/symbol)
-			. = new/list()
-			var/list/L = .
-			while(i <= tokens.len)
-				// Avoid using Add() or += in case a list is returned.
-				L.len++
-				L[L.len] = read_value()
-				var/json_token/T = get_token()
-				check_type(/json_token/symbol)
-				switch(T.value)
-					if(",")
-						next_token()
-						continue
-					if("]")
-						next_token()
-						return
-					else
-						die()
-						next_token()
-				CRASH("Unterminated array.")
+/json_reader/proc/is_digit(char)
+	var/c = text2ascii(char)
+	return ( 48 <= c && c <= 57 || char == "+" || char == "-" )
 
 
-		die(json_token/T)
-			if(!T) T = get_token()
-			CRASH("Unexpected token: [T.value].")
+// parser
+/json_reader/proc/ReadObject(list/tokens)
+	src.tokens = tokens
+	. = new/list()
+	i = 1
+	read_token("{", /json_token/symbol)
+	while(i <= tokens.len)
+		var/json_token/K = JSON_GET_TOKEN(i)
+		check_type(/json_token/word, /json_token/text)
+		JSON_NEXT_TOKEN(tokens, i)
+		read_token(":", /json_token/symbol)
+
+		.[K.value] = read_value()
+
+		var/json_token/S = JSON_GET_TOKEN(i)
+		check_type(/json_token/symbol)
+		switch(S.value)
+			if(",")
+				JSON_NEXT_TOKEN(tokens, i)
+				continue
+			if("}")
+				JSON_NEXT_TOKEN(tokens, i)
+				return
+			else
+				die(S)
+
+
+/json_reader/proc/read_token(val, type)
+	var/json_token/T = JSON_GET_TOKEN(i)
+	if(!(T.value == val && istype(T, type)))
+		CRASH("Expected '[val]', found '[T.value]'.")
+	JSON_NEXT_TOKEN(tokens, i)
+	return T
+
+
+/json_reader/proc/check_type(...)
+	var/json_token/T = JSON_GET_TOKEN(i)
+	for(var/type in args)
+		if(istype(T, type))
+			return
+	CRASH("Bad token type: [T.type].")
+
+
+/json_reader/proc/check_value(...)
+	var/json_token/T = JSON_GET_TOKEN(i)
+	ASSERT(args.Find(T.value))
+
+
+/json_reader/proc/read_key()
+	var/char = JSON_GET_CHAR(json, i)
+	if(char == "\"" || char == "'")
+		return read_string(char)
+
+
+/json_reader/proc/read_value()
+	var/json_token/T = JSON_GET_TOKEN(i)
+	switch(T.type)
+		if(/json_token/text, /json_token/number)
+			JSON_NEXT_TOKEN(tokens, i)
+			return T.value
+		if(/json_token/word)
+			JSON_NEXT_TOKEN(tokens, i)
+			switch(T.value)
+				if("true")
+					return TRUE
+				if("false")
+					return FALSE
+				if("null")
+					return null
+		if(/json_token/symbol)
+			switch(T.value)
+				if("\[")
+					return read_array()
+				if("{")
+					return ReadObject(tokens.Copy(i))
+	die(T)
+
+
+/json_reader/proc/read_array()
+	read_token("\[", /json_token/symbol)
+	. = new/list()
+	var/list/L = .
+	while(i <= tokens.len)
+		// Avoid using Add() or += in case a list is returned.
+		L.len++
+		L[L.len] = read_value()
+		var/json_token/T = JSON_GET_TOKEN(i)
+		check_type(/json_token/symbol)
+		switch(T.value)
+			if(",")
+				JSON_NEXT_TOKEN(tokens, i)
+				continue
+			if("]")
+				JSON_NEXT_TOKEN(tokens, i)
+				return
+			else
+				die(T)
+				JSON_NEXT_TOKEN(tokens, i)
+		CRASH("Unterminated array.")
+
+
+/json_reader/proc/die(json_token/T)
+	if(!T)
+		T = JSON_GET_TOKEN(i)
+	CRASH("Unexpected token: [T.value].")
+
+
+#undef JSON_GET_CHAR
+#undef JSON_IS_WHITESPACE
+#undef JSON_GET_TOKEN
+#undef JSON_NEXT_TOKEN

--- a/code/modules/nano/JSON_Writer.dm
+++ b/code/modules/nano/JSON_Writer.dm
@@ -1,59 +1,60 @@
+/datum/json_writer/proc/WriteObject(list/L)
+	. = "{"
+	var/i = 1
+	for(var/k in L)
+		var/val = L[k]
+		. += "\"[k]\":[write(val)]"
+		if(i++ < length(L))
+			. += ","
+	.+= "}"
 
-json_writer
-	proc
-		WriteObject(list/L)
-			. = "{"
-			var/i = 1
-			for(var/k in L)
-				var/val = L[k]
-				. += {"\"[k]\":[write(val)]"}
-				if(i++ < L.len)
-					. += ","
-			.+= "}"
 
-		write(val)
-			if(isnum(val))
-				return num2text(val, 100)
-			else if(isnull(val))
-				return "null"
-			else if(istype(val, /list))
-				if(is_associative(val))
-					return WriteObject(val)
-				else
-					return write_array(val)
+/datum/json_writer/proc/write(val)
+	if(isnum(val))
+		return num2text(val, 100)
+	else if(isnull(val))
+		return "null"
+	else if(istype(val, /list))
+		if(is_associative(val))
+			return WriteObject(val)
+		else
+			return write_array(val)
+	else
+		. += write_string("[val]")
+
+
+/datum/json_writer/proc/write_array(list/L)
+	. = "\["
+	for(var/i = 1 to length(L))
+		. += write(L[i])
+		if(i < length(L))
+			. += ","
+	. += "]"
+
+
+/datum/json_writer/proc/write_string(txt)
+	var/static/list/json_escape = list("\\", "\"", "'", "\n")
+	for(var/targ in json_escape)
+		var/start = 1
+		while(start <= lentext(txt))
+			var/i = findtext(txt, targ, start)
+			if(!i)
+				break
+			if(targ == "\n")
+				txt = copytext(txt, 1, i) + "\\n" + copytext(txt, i+2)
+				start = i + 1 // 1 character added
+			if(targ == "'")
+				txt = copytext(txt, 1, i) + "`" + copytext(txt, i+1) // apostrophies fuck shit up...
+				start = i + 1 // 1 character added
 			else
-				. += write_string("[val]")
-
-		write_array(list/L)
-			. = "\["
-			for(var/i = 1 to L.len)
-				. += write(L[i])
-				if(i < L.len)
-					. += ","
-			. += "]"
-
-		write_string(txt)
-			var/static/list/json_escape = list("\\", "\"", "'", "\n")
-			for(var/targ in json_escape)
-				var/start = 1
-				while(start <= lentext(txt))
-					var/i = findtext(txt, targ, start)
-					if(!i)
-						break
-					if(targ == "\n")
-						txt = copytext(txt, 1, i) + "\\n" + copytext(txt, i+2)
-						start = i + 1 // 1 character added
-					if(targ == "'")
-						txt = copytext(txt, 1, i) + "`" + copytext(txt, i+1) // apostrophies fuck shit up...
-						start = i + 1 // 1 character added
-					else
-						txt = copytext(txt, 1, i) + "\\" + copytext(txt, i)
-						start = i + 2 // 2 characters added
+				txt = copytext(txt, 1, i) + "\\" + copytext(txt, i)
+				start = i + 2 // 2 characters added
 					
-			return {""[txt]""}
+	return "\"[txt]\""
 
-		is_associative(list/L)
-			for(var/key in L)
-				// if the key is a list that means it's actually an array of lists (stupid Byond...)
-				if(!isnum(key) && !istype(key, /list))
-					return TRUE
+
+/datum/json_writer/proc/is_associative(list/L)
+	for(var/key in L)
+		// if the key is a list that means it's actually an array of lists (stupid Byond...)
+		if(!isnum(key) && !istype(key, /list))
+			return TRUE

--- a/code/modules/nano/_JSON.dm
+++ b/code/modules/nano/_JSON.dm
@@ -3,9 +3,9 @@ n_Json v11.3.21
 */
 
 /proc/json2list(json)
-	var/static/json_reader/_jsonr = new()
+	var/static/datum/json_reader/_jsonr = new()
 	return _jsonr.ReadObject(_jsonr.ScanJson(json))
 
 /proc/list2json(list/L)
-	var/static/json_writer/_jsonw = new()
+	var/static/datum/json_writer/_jsonw = new()
 	return _jsonw.WriteObject(L)

--- a/code/modules/nano/_JSON.dm
+++ b/code/modules/nano/_JSON.dm
@@ -2,11 +2,10 @@
 n_Json v11.3.21
 */
 
-proc
-	json2list(json)
-		var/static/json_reader/_jsonr = new()
-		return _jsonr.ReadObject(_jsonr.ScanJson(json))
+/proc/json2list(json)
+	var/static/json_reader/_jsonr = new()
+	return _jsonr.ReadObject(_jsonr.ScanJson(json))
 
-	list2json(list/L)
-		var/static/json_writer/_jsonw = new()
-		return _jsonw.WriteObject(L)
+/proc/list2json(list/L)
+	var/static/json_writer/_jsonw = new()
+	return _jsonw.WriteObject(L)

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -325,9 +325,7 @@
 
 /obj/machinery/power/supermatter/proc/supermatter_pull()
 
-	//following is adapted from singulo code
-	if(defer_powernet_rebuild != 2)
-		defer_powernet_rebuild = 1
+	defer_powernet_rebuild = TRUE
 	// Let's just make this one loop.
 	for(var/atom/X in orange(pull_radius,src))
 		// Movable atoms only
@@ -354,6 +352,5 @@
 				step_towards(H,src) //step twice
 				step_towards(H,src)
 
-	if(defer_powernet_rebuild != 2)
-		defer_powernet_rebuild = 0
+	defer_powernet_rebuild = FALSE
 	return


### PR DESCRIPTION
Periodic small code cleanup.

* Unused cloning paper-manual was giving off a warning, likely being defined before papers were. Just removed it.
* Old paint code was giving warnings. Just cleaned it up to standards.
* `var/global/obj/effect/datacore/GLOB.datacore` was leftover. Already defined by `GLOBAL_DATUM_INIT(datacore, /datum/datacore, new)`, so simply removed.
* json ancientcode was giving some errors. Cleaned it up to standards, turned a few tiny procs into defines and cleaned tidied it up a little. Worked fine in local tests.