### PR TITLE
Minigun Burst Value Redefine

### DIFF
--- a/code/modules/projectiles/updated_projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/specialist.dm
@@ -958,7 +958,7 @@
 
 /obj/item/weapon/gun/minigun/set_gun_config_values()
 	fire_delay = CONFIG_GET(number/combat_define/low_fire_delay)
-	burst_amount = CONFIG_GET(number/combat_define/mhigh_burst_value) + CONFIG_GET(number/combat_define/mhigh_burst_value)
+	burst_amount = CONFIG_GET(number/combat_define/minigun_burst_value)
 	burst_delay = CONFIG_GET(number/combat_define/min_fire_delay)
 	accuracy_mult = CONFIG_GET(number/combat_define/base_hit_accuracy_mult)
 	accuracy_mult_unwielded = CONFIG_GET(number/combat_define/base_hit_accuracy_mult)


### PR DESCRIPTION
## About The Pull Request

Changes the minigun burst value from 2 configs to 1 config. 

## Why It's Good For The Game

Just a coding change, really. Doesn't, and shouldn't, alter how the weapon functions. 
## Changelog
No changelog necessary for this. 
