### PR TITLE
Less infinite survivors.

### DIFF
--- a/code/game/gamemodes/distress.dm
+++ b/code/game/gamemodes/distress.dm
@@ -203,6 +203,8 @@
 			continue
 		new_survivor.assigned_role = "Survivor"
 		survivors += new_survivor
+		if(length(survivors) >= surv_starting_num)
+			break
 
 	if(!length(survivors))
 		return FALSE


### PR DESCRIPTION
Fix for unlimited survivors. The roundstart spawn proc was not taking into account the previously-defined max number of survivors.