### PR TITLE
Tank Tweak/Rebalance - TESTED

### DIFF
--- a/code/__DEFINES/objects.dm
+++ b/code/__DEFINES/objects.dm
@@ -226,3 +226,8 @@ var/list/RESTRICTED_CAMERA_NETWORKS = list( //Those networks can only be accesse
 //Lighter
 
 #define LIGHTER_LUMINOSITY	2
+
+//Tank
+
+#define TANK_OVERDRIVE_BOOST_DURATION	5 SECONDS
+#define TANK_OVERDRIVE_BOOST_COOLDOWN	20 SECONDS

--- a/code/modules/vehicles/multitile/cm_armored.dm
+++ b/code/modules/vehicles/multitile/cm_armored.dm
@@ -412,8 +412,8 @@ var/list/TANK_HARDPOINT_OFFSETS = list(
 	if(facing == CA.old_dir && istype(CA.hardpoints[HDPT_ARMOR], /obj/item/hardpoint/armor/snowplow) ) //Snowplow eliminates collision damage, and doubles damage dealt if we're facing the thing we're crushing
 		var/obj/item/hardpoint/armor/snowplow/SP = CA.hardpoints[HDPT_ARMOR]
 		if(SP.health)
-			damage = 60
-			tank_damage = 0
+			damage = 45
+			tank_damage = 1
 
 	take_damage(damage)
 	CA.take_damage_type(tank_damage, "blunt", src)


### PR DESCRIPTION
:cl: by Surrealistik
tweak: Overdrive now has nitros the driver can activate for a big, 5 second speed boost instead of a passive, continual speed increase. Has a cooldown of 20 seconds.
tweak: M56 Cupola ammo capacity increased to 1000 and fire rate increased to 3.33 shots / second up from 2 / second.
balance: Snowplow now takes half damage from wall collisions instead of no damage when facing walls, and destroys walls 50% faster down from 100% faster. Snowplow health increased by +100.
/:cl: