### PR TITLE
Fixes Acid, crusher

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -7,7 +7,7 @@
 #define TOGGLE_BITFIELD(variable, flag) (variable ^= (flag))
 
 //check if all bitflags specified are present
-#define CHECK_MULTIPLE_BITFIELDS(flagvar, flags) ((flagvar & (flags)) == flags)
+#define CHECK_MULTIPLE_BITFIELDS(flagvar, flags) ((flagvar & (flags)) == (flags))
 
 GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768))
 


### PR DESCRIPTION

## About The Pull Request
https://github.com/tgstation/TerraGov-Marine-Corps/issues/1221
Fixes this

Due to #1174

## Changelog
:cl:
fix: fixes items and doors being unacidable, and crusher being unable to break lots of structures.
/:cl:

