### PR TITLE
Fixes unacidable and indestructible flags checks

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -7,7 +7,7 @@
 #define TOGGLE_BITFIELD(variable, flag) (variable ^= (flag))
 
 //check if all bitflags specified are present
-#define CHECK_MULTIPLE_BITFIELDS(flagvar, flags) ((flagvar & (flags)) == flags)
+#define CHECK_MULTIPLE_BITFIELDS(flagvar, flags) ((flagvar & (flags)) == (flags))
 
 GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768))
 

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -124,7 +124,7 @@ Class Procs:
 
 /obj/machinery/attackby(obj/item/C as obj, mob/user as mob)
 	. = ..()
-	if(istype(C, /obj/item/tool/pickaxe/plasmacutter) && !user.action_busy && !CHECK_MULTIPLE_BITFIELDS(resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
+	if(istype(C, /obj/item/tool/pickaxe/plasmacutter) && !user.action_busy && !CHECK_BITFIELD(resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
 		var/obj/item/tool/pickaxe/plasmacutter/P = C
 		if(!P.start_cut(user, name, src, PLASMACUTTER_BASE_COST * PLASMACUTTER_LOW_MOD))
 			return

--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -78,7 +78,7 @@
 		if(!action_checks(target)) return
 		if(isobj(target))
 			var/obj/target_obj = target
-			if(CHECK_MULTIPLE_BITFIELDS(target_obj.resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
+			if(CHECK_BITFIELD(target_obj.resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
 				return
 		set_ready_state(0)
 		chassis.use_power(energy_drain)
@@ -109,7 +109,7 @@
 		if(!action_checks(target)) return
 		if(isobj(target))
 			var/obj/target_obj = target
-			if(CHECK_MULTIPLE_BITFIELDS(target_obj.resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
+			if(CHECK_BITFIELD(target_obj.resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
 				return
 		set_ready_state(0)
 		chassis.use_power(energy_drain)

--- a/code/game/objects/items/devices/radio/detpack.dm
+++ b/code/game/objects/items/devices/radio/detpack.dm
@@ -228,7 +228,7 @@
 		return FALSE
 	if(isobj(target))
 		var/obj/O = target
-		if(CHECK_MULTIPLE_BITFIELDS(O.resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
+		if(CHECK_BITFIELD(O.resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
 			return FALSE
 	if(iswallturf(target))
 		var/turf/closed/wall/W = target

--- a/code/game/objects/items/explosives/plastique.dm
+++ b/code/game/objects/items/explosives/plastique.dm
@@ -43,7 +43,7 @@
 		return FALSE
 	if(isobj(target))
 		var/obj/O = target
-		if(CHECK_MULTIPLE_BITFIELDS(O.resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
+		if(CHECK_BITFIELD(O.resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
 			return FALSE
 	if(iswallturf(target))
 		var/turf/closed/wall/W = target

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -41,7 +41,7 @@
 
 /obj/structure/attackby(obj/item/C as obj, mob/user as mob)
 	. = ..()
-	if(istype(C, /obj/item/tool/pickaxe/plasmacutter) && !user.action_busy && breakable && !CHECK_MULTIPLE_BITFIELDS(resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
+	if(istype(C, /obj/item/tool/pickaxe/plasmacutter) && !user.action_busy && breakable && !CHECK_BITFIELD(resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
 		var/obj/item/tool/pickaxe/plasmacutter/P = C
 		if(!P.start_cut(user, name, src))
 			return

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -183,7 +183,7 @@
 		qdel(src)
 
 /obj/structure/closet/attack_alien(mob/living/carbon/Xenomorph/M)
-	if(M.a_intent == INTENT_HARM && !CHECK_MULTIPLE_BITFIELDS(resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
+	if(M.a_intent == INTENT_HARM && !CHECK_BITFIELD(resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
 		M.animation_attack_on(src)
 		if(!opened && prob(70))
 			break_open()

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -30,7 +30,7 @@
 	return 1
 
 /obj/structure/girder/attack_alien(mob/living/carbon/Xenomorph/M)
-	if(M.mob_size != MOB_SIZE_BIG || CHECK_MULTIPLE_BITFIELDS(resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
+	if(M.mob_size != MOB_SIZE_BIG || CHECK_BITFIELD(resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
 		to_chat(M, "<span class='warning'>Your claws aren't sharp enough to damage \the [src].</span>")
 		return FALSE
 	else

--- a/code/modules/cm_marines/Marine_Research/Marine_Research_Items.dm
+++ b/code/modules/cm_marines/Marine_Research/Marine_Research_Items.dm
@@ -96,7 +96,7 @@
 	if (!isobj(A))
 		to_chat(usr, "Doesn't work that way...")
 		return
-	if (CHECK_MULTIPLE_BITFIELDS(A.resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
+	if (CHECK_BITFIELD(A.resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
 		to_chat(usr, "It's already resistant to acid...")
 		return
 	if (istype(A, /obj/machinery/door))

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/crusher.dm
@@ -102,7 +102,7 @@
 /obj/charge_act(mob/living/carbon/Xenomorph/X)
 	. = ..()
 	if(.)
-		if(CHECK_MULTIPLE_BITFIELDS(resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
+		if(CHECK_BITFIELD(resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
 			X.stop_momentum(X.charge_dir)
 			return FALSE
 
@@ -144,7 +144,7 @@
 //Bumped() proc. ~Bmc777
 
 /obj/structure/window/charge_act(mob/living/carbon/Xenomorph/X)
-	if(CHECK_MULTIPLE_BITFIELDS(resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
+	if(CHECK_BITFIELD(resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
 		X.stop_momentum(X.charge_dir)
 		return FALSE
 	if(X.charge_speed < X.charge_speed_buildup * X.charge_turfs_to_charge)
@@ -158,7 +158,7 @@
 	return TRUE
 
 /obj/structure/grille/charge_act(mob/living/carbon/Xenomorph/X)
-	if(CHECK_MULTIPLE_BITFIELDS(resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
+	if(CHECK_BITFIELD(resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
 		X.stop_momentum(X.charge_dir)
 		return FALSE
 	if(X.charge_speed < X.charge_speed_buildup * X.charge_turfs_to_charge)
@@ -173,7 +173,7 @@
 
 /obj/machinery/vending/charge_act(mob/living/carbon/Xenomorph/X)
 	if(X.charge_speed > X.charge_speed_max/2) //Halfway to full speed or more
-		if(CHECK_MULTIPLE_BITFIELDS(resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
+		if(CHECK_BITFIELD(resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
 			X.stop_momentum(X.charge_dir, TRUE)
 			return FALSE
 		X.visible_message("<span class='danger'>[X] smashes straight into [src]!</span>",
@@ -190,7 +190,7 @@
 		return FALSE
 
 /obj/mecha/charge_act(mob/living/carbon/Xenomorph/X)
-	if(CHECK_MULTIPLE_BITFIELDS(resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
+	if(CHECK_BITFIELD(resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
 		X.stop_momentum(X.charge_dir, TRUE)
 		return FALSE
 	if(X.charge_speed < X.charge_speed_buildup * X.charge_turfs_to_charge)
@@ -207,7 +207,7 @@
 	return TRUE
 
 /obj/machinery/marine_turret/charge_act(mob/living/carbon/Xenomorph/X)
-	if(CHECK_MULTIPLE_BITFIELDS(resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
+	if(CHECK_BITFIELD(resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
 		X.stop_momentum(X.charge_dir, TRUE)
 		return FALSE
 	if(X.charge_speed < X.charge_speed_buildup * X.charge_turfs_to_charge)

--- a/code/modules/mob/living/carbon/xenomorph/powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/powers.dm
@@ -672,7 +672,7 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 		if(current_acid && !acid_check(new_acid, current_acid) )
 			return
 
-		if(CHECK_MULTIPLE_BITFIELDS(I.resistance_flags, UNACIDABLE|INDESTRUCTIBLE)) //So the aliens don't destroy energy fields/singularies/other aliens/etc with their acid.
+		if(CHECK_BITFIELD(I.resistance_flags, UNACIDABLE|INDESTRUCTIBLE)) //So the aliens don't destroy energy fields/singularies/other aliens/etc with their acid.
 			to_chat(src, "<span class='warning'>You cannot dissolve \the [I].</span>")
 			return
 		if(istype(O, /obj/structure/window_frame))

--- a/code/modules/reagents/chemistry_reagents/toxin.dm
+++ b/code/modules/reagents/chemistry_reagents/toxin.dm
@@ -394,7 +394,7 @@
 			var/mob/living/carbon/human/H = M
 
 			if(H.head)
-				if(prob(meltprob) && !CHECK_MULTIPLE_BITFIELDS(H.head.resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
+				if(prob(meltprob) && !CHECK_BITFIELD(H.head.resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
 					to_chat(H, "<span class='danger'>Your headgear melts away but protects you from the acid!</span>")
 					qdel(H.head)
 					H.update_inv_head(0)
@@ -404,7 +404,7 @@
 				return
 
 			if(H.wear_mask)
-				if(prob(meltprob) && !CHECK_MULTIPLE_BITFIELDS(H.wear_mask.resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
+				if(prob(meltprob) && !CHECK_BITFIELD(H.wear_mask.resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
 					to_chat(H, "<span class='danger'>Your mask melts away but protects you from the acid!</span>")
 					qdel(H.wear_mask)
 					H.update_inv_wear_mask(0)
@@ -414,7 +414,7 @@
 				return
 
 			if(H.glasses) //Doesn't protect you from the acid but can melt anyways!
-				if(prob(meltprob) && !CHECK_MULTIPLE_BITFIELDS(H.glasses.resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
+				if(prob(meltprob) && !CHECK_BITFIELD(H.glasses.resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
 					to_chat(H, "<span class='danger'>Your glasses melts away!</span>")
 					qdel(H.glasses)
 					H.update_inv_glasses(0)
@@ -422,7 +422,7 @@
 		else if(ismonkey(M))
 			var/mob/living/carbon/monkey/MK = M
 			if(MK.wear_mask)
-				if(!CHECK_MULTIPLE_BITFIELDS(MK.wear_mask.resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
+				if(!CHECK_BITFIELD(MK.wear_mask.resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
 					to_chat(MK, "<span class='danger'>Your mask melts away but protects you from the acid!</span>")
 					qdel(MK.wear_mask)
 					MK.update_inv_wear_mask(0)
@@ -450,7 +450,7 @@
 
 /datum/reagent/toxin/acid/reaction_obj(var/obj/O, var/volume)
 	if((istype(O,/obj/item) || istype(O,/obj/effect/glowshroom)) && prob(meltprob * 3))
-		if(!CHECK_MULTIPLE_BITFIELDS(O.resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
+		if(!CHECK_BITFIELD(O.resistance_flags, UNACIDABLE|INDESTRUCTIBLE))
 			var/obj/effect/decal/cleanable/molten_item/I = new/obj/effect/decal/cleanable/molten_item(O.loc)
 			I.desc = "Looks like this was \an [O] some time ago."
 			for(var/mob/M in viewers(5, O))


### PR DESCRIPTION
## About The Pull Request

Fixes `CHECK_MULTIPLE_BITFIELDS` not parenthesing the `==` rvalue.
Properly checks that `UNACIDABLE OR INDESTRUCTIBLE` flags are set instead of `AND`

Fixes  #1221.
Closes  #1224.

Discord teamwork PR.

## Changelog
:cl:
fix: acid should now properly work again
/:cl:
