### PR TITLE
Hardening bits checks against unexpected uses

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -1,13 +1,13 @@
 #define ALL (~0) //For convenience.
 #define NONE 0
 
-#define ENABLE_BITFIELD(variable, flag) (variable |= (flag))
-#define DISABLE_BITFIELD(variable, flag) (variable &= ~(flag))
-#define CHECK_BITFIELD(variable, flag) (variable & (flag))
-#define TOGGLE_BITFIELD(variable, flag) (variable ^= (flag))
+#define ENABLE_BITFIELD(variable, flag)  ((variable) |= (flag))
+#define DISABLE_BITFIELD(variable, flag) ((variable) &= ~(flag))
+#define CHECK_BITFIELD(variable, flag)   ((variable) & (flag))
+#define TOGGLE_BITFIELD(variable, flag)  ((variable) ^= (flag))
 
 //check if all bitflags specified are present
-#define CHECK_MULTIPLE_BITFIELDS(flagvar, flags) ((flagvar & (flags)) == (flags))
+#define CHECK_MULTIPLE_BITFIELDS(flagvar, flags) (((flagvar) & (flags)) == (flags))
 
 GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768))
 


### PR DESCRIPTION
## About The Pull Request

Following a remark from @SpaceManiac , protects the bits checks from potential fancy uses (e.g `CHECK_BITFIELD(resistance_flags | atoms_flags, bug_prone_shared_flag)`).
