### PR TITLE
Smartgun Sight Change

### DIFF
--- a/code/modules/clothing/glasses/night.dm
+++ b/code/modules/clothing/glasses/night.dm
@@ -51,7 +51,7 @@
 	icon = 'icons/obj/clothing/glasses.dmi'
 	icon_state = "m56_goggles"
 	deactive_state = "m56_goggles_0"
-	darkness_view = 5
+	darkness_view = 8
 	toggleable = 1
 	actions_types = list(/datum/action/item_action/toggle)
 	vision_flags = SEE_TURFS


### PR DESCRIPTION

## About The Pull Request

Increases the smartgun sight darkvision to the full sight range. 

## Why It's Good For The Game

Lets them see targets better, while also not making it useful for scoped fire. 
## Changelog
:cl:
balance: Smartgun NVG reached to the end of their screen now
/:cl:

