### PR TITLE
Tweaks the previously pred-restricted snatch-facehugger-mid-air feature into an intentional one.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -324,7 +324,7 @@
 
 	return TRUE
 
-/obj/item/clothing/mask/facehugger/proc/Attach(mob/living/carbon/M, self_done = FALSE)
+/obj/item/clothing/mask/facehugger/proc/Attach(mob/living/carbon/M)
 
 	throwing = FALSE
 	leaping = FALSE
@@ -338,13 +338,27 @@
 
 	if(M.status_flags & XENO_HOST || isxeno(M))
 		return FALSE
-	if(!self_done)
-		M.visible_message("<span class='danger'>[src] leaps at [M]'s face!</span>")
+	M.visible_message("<span class='danger'>[src] leaps at [M]'s face!</span>")
 
 	if(isxeno(loc)) //Being carried? Drop it
 		var/mob/living/carbon/Xenomorph/X = loc
 		X.dropItemToGround(src)
 		X.update_icons()
+
+	if(M.in_throw_mode && M.dir != dir && !M.incapacitated() && !M.get_active_held_item())
+		var/catch_chance = 40
+		if(M.dir == reverse_dir[dir])
+			catch_chance += 20
+		if(M.lying)
+			catch_chance -= 50
+		catch_chance -= M.shock_stage * 0.3
+		if(M.get_inactive_held_item())
+			catch_chance  -= 25
+
+		if(prob(catch_chance)) //Not facing away
+			M.visible_message("<span class='notice'>[M] snatches [src] out of the air and [pickweight("clobbers" = 30, "kills" = 30, "squashes" = 25, "dunks" = 10, "dribbles" = 5)] it!")
+			Die()
+			return TRUE
 
 	var/blocked = null //To determine if the hugger just rips off the protection or can infect.
 	if(ishuman(M))
@@ -353,24 +367,6 @@
 		if(!H.has_limb(HEAD))
 			visible_message("<span class='warning'>[src] looks for a face to hug on [H], but finds none!</span>")
 			return FALSE
-
-		if(!self_done)
-			var/catch_chance = 50
-			if(H.dir == reverse_dir[dir])
-				catch_chance += 20
-			if(H.lying)
-				catch_chance -= 50
-			catch_chance -= ((H.maxHealth - H.health) / 3)
-			if(H.get_active_held_item())
-				catch_chance  -= 25
-			if(H.get_inactive_held_item())
-				catch_chance  -= 25
-
-			if(!H.stat && H.dir != dir && prob(catch_chance)) //Not facing away
-				H.visible_message("<span class='notice'>[H] snatches [src] out of the air and squashes it!")
-				Die()
-				loc = H.loc
-				return TRUE
 
 		if(H.head)
 			var/obj/item/clothing/head/D = H.head

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -241,7 +241,7 @@
 		if(leaping && M.can_be_facehugged(src)) //Standard leaping behaviour, not attributable to being _thrown_ such as by a Carrier.
 			if(!Attach(M))
 				GoIdle()
-				return
+			return
 		else
 			step(src, turn(dir, 180)) //We want the hugger to bounce off if it hits a mob.
 			addtimer(CALLBACK(src, .proc/fast_activate), 1.5 SECONDS)
@@ -338,7 +338,6 @@
 
 	if(M.status_flags & XENO_HOST || isxeno(M))
 		return FALSE
-	M.visible_message("<span class='danger'>[src] leaps at [M]'s face!</span>")
 
 	if(isxeno(loc)) //Being carried? Drop it
 		var/mob/living/carbon/Xenomorph/X = loc
@@ -346,7 +345,7 @@
 		X.update_icons()
 
 	if(M.in_throw_mode && M.dir != dir && !M.incapacitated() && !M.get_active_held_item())
-		var/catch_chance = 40
+		var/catch_chance = 50
 		if(M.dir == reverse_dir[dir])
 			catch_chance += 20
 		if(M.lying)
@@ -356,7 +355,7 @@
 			catch_chance  -= 25
 
 		if(prob(catch_chance))
-			M.visible_message("<span class='notice'>[M] snatches [src] out of the air and [pickweight("clobbers" = 30, "kills" = 30, "squashes" = 25, "dunks" = 10, "dribbles" = 5)] it!")
+			M.visible_message("<span class='notice'>[M] snatches [src] out of the air and [pickweight(list("clobbers" = 30, "kills" = 30, "squashes" = 25, "dunks" = 10, "dribbles" = 5))] it!")
 			Die()
 			return TRUE
 

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -348,8 +348,6 @@
 		var/catch_chance = 50
 		if(M.dir == reverse_dir[dir])
 			catch_chance += 20
-		if(M.lying)
-			catch_chance -= 50
 		catch_chance -= M.shock_stage * 0.3
 		if(M.get_inactive_held_item())
 			catch_chance  -= 25

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -355,7 +355,7 @@
 		if(M.get_inactive_held_item())
 			catch_chance  -= 25
 
-		if(prob(catch_chance)) //Not facing away
+		if(prob(catch_chance))
 			M.visible_message("<span class='notice'>[M] snatches [src] out of the air and [pickweight("clobbers" = 30, "kills" = 30, "squashes" = 25, "dunks" = 10, "dribbles" = 5)] it!")
 			Die()
 			return TRUE


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When the rred removal PR did go through, this was one of the few things accidentally left over. I thought this wouldn't make a bad feature with a little tweaking.
Made the "action" require throw mode on, have the active hand empty and not be incapacitated, tweaked the prob modifiers, and unrestricted this feature from the human

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Improve, not remove. Closes #1245.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Tweaked the unintended feature (left over from preds removal) of snatching and killing facehuggers mid-attaching into an intentional one. It also requires a free active hand, throw mode on, and can't be done while incapacitated.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
