### PR TITLE
Zoom and Vision refactor

### DIFF
--- a/code/__DEFINES/equipment.dm
+++ b/code/__DEFINES/equipment.dm
@@ -38,6 +38,8 @@
 #define TWOHANDED				(1<<4)	// The item is twohanded.
 #define WIELDED					(1<<5)	// The item is wielded with both hands.
 #define	ITEM_ABSTRACT			(1<<6)	//The item is abstract (grab, powerloader_clamp, etc)
+#define	ITEM_ZOOMED				(1<<7)	// Actively being used to zoom. For scoped guns and binoculars.
+#define ITEM_ZOOM_NIGHTVISION	(1<<8)	// While zooming this grants nightvision.
 
 //==========================================================================================
 

--- a/code/__DEFINES/equipment.dm
+++ b/code/__DEFINES/equipment.dm
@@ -38,8 +38,7 @@
 #define TWOHANDED				(1<<4)	// The item is twohanded.
 #define WIELDED					(1<<5)	// The item is wielded with both hands.
 #define	ITEM_ABSTRACT			(1<<6)	//The item is abstract (grab, powerloader_clamp, etc)
-#define	ITEM_ZOOMED				(1<<7)	// Actively being used to zoom. For scoped guns and binoculars.
-#define ITEM_ZOOM_NIGHTVISION	(1<<8)	// While zooming this grants nightvision.
+#define ITEM_ZOOM_NIGHTVISION	(1<<7)	// While zooming this grants nightvision.
 
 //==========================================================================================
 

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -545,7 +545,7 @@ datum/proc/dd_SortValue()
 #define LAZYACCESS(L, I) (L ? (isnum(I) ? (I > 0 && I <= length(L) ? L[I] : null) : L[I]) : null)
 #define LAZYSET(L, K, V) if(!L) { L = list(); } L[K] = V;
 #define LAZYLEN(L) length(L)
-#define LAZYCLEARLIST(L) if(L) L.Cut()
+#define LAZYCLEARLIST(L) ( L?.Cut() )
 #define SANITIZE_LIST(L) ( islist(L) ? L : list() )
 #define reverseList(L) reverseRange(L.Copy())
 

--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -167,7 +167,7 @@
 	icon = null
 	w_class = 2.0
 	vision_flags = SEE_MOBS
-	darkness_view = 7
+	glass_see_in_dark_modifier = 7
 	flags_item = NODROP|DELONDROP
 	fullscreen_vision = /obj/screen/fullscreen/nvg
 

--- a/code/datums/diseases/black_goo.dm
+++ b/code/datums/diseases/black_goo.dm
@@ -167,7 +167,7 @@
 	icon = null
 	w_class = 2.0
 	vision_flags = SEE_MOBS
-	glass_see_in_dark_modifier = 7
+	glasses_see_in_dark_modifier = 7
 	flags_item = NODROP|DELONDROP
 	fullscreen_vision = /obj/screen/fullscreen/nvg
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -77,10 +77,7 @@
 
 	if(active || force_key_move)
 		new_character.key = key		//now transfer the key to link the client to our new body
-		if(new_character.client)
-			new_character.client.change_view(world.view) //reset view range to default.
-			new_character.client.pixel_x = 0
-			new_character.client.pixel_y = 0
+		new_character.reset_client_sight()
 
 
 /datum/mind/proc/set_death_time()

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -329,8 +329,7 @@
 
 /mob/proc/unset_interaction()
 	if(interactee)
-		if(istype(interactee))
-			interactee.on_unset_interaction(src)
+		interactee.on_unset_interaction(src)
 		interactee = null
 
 

--- a/code/game/gamemodes/huntergames.dm
+++ b/code/game/gamemodes/huntergames.dm
@@ -118,9 +118,10 @@
 
 	H.loc = picked
 
+	H.reset_client_sight()
+
 	if(H.client)
 		H.name = H.client.prefs.real_name
-		H.client.change_view(world.view)
 
 	if(!H.mind)
 		H.mind = new /datum/mind(H.key)

--- a/code/game/jobs/job/deathsquad.dm
+++ b/code/game/jobs/job/deathsquad.dm
@@ -27,7 +27,7 @@
 	gloves = /obj/item/clothing/gloves/marine/veteran/PMC/commando
 	head = /obj/item/clothing/head/helmet/marine/veteran/PMC/commando
 	mask = /obj/item/clothing/mask/gas/PMC
-	glasses = /obj/item/clothing/glasses/m42_goggles
+	glasses = /obj/item/clothing/glasses/night/m42_night_goggles
 	suit_store = /obj/item/weapon/gun/rifle/m41a/elite
 	r_store = /obj/item/storage/pouch/magazine/large/pmc_rifle
 	l_store = /obj/item/storage/pouch/firstaid/full
@@ -73,7 +73,7 @@
 	gloves = /obj/item/clothing/gloves/marine/veteran/PMC/commando
 	head = /obj/item/clothing/head/helmet/marine/veteran/PMC/commando
 	mask = /obj/item/clothing/mask/gas/PMC
-	glasses = /obj/item/clothing/glasses/m42_goggles
+	glasses = /obj/item/clothing/glasses/night/m42_night_goggles
 	suit_store = /obj/item/weapon/gun/launcher/rocket/m57a4
 	r_store = /obj/item/storage/pouch/explosive
 	l_store = /obj/item/storage/pouch/firstaid/full

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -151,7 +151,7 @@
 			smoke_ready = 1
 	return
 
-/obj/mecha/combat/marauder/verb/zoom()
+/obj/mecha/combat/marauder/verb/mecha_zoom()
 	set category = "Exosuit Interface"
 	set name = "Zoom"
 	set src = usr.loc
@@ -207,5 +207,5 @@
 	if (href_list["smoke"])
 		src.smoke()
 	if (href_list["toggle_zoom"])
-		src.zoom()
+		src.mecha_zoom()
 	return

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -62,7 +62,7 @@
 
 	var/reach = 1
 
-	var/item_zoomed = 0 //Just how zoomed this item is (tileoffset + viewsize).
+	var/item_zoomed = 0 //Just how zoomed this item is.
 
 	/* Species-specific sprites, concept stolen from Paradise//vg/.
 	ex:
@@ -209,7 +209,7 @@
 // apparently called whenever an item is removed from a slot, container, or anything else.
 //the call happens after the item's potential loc change.
 /obj/item/proc/dropped(mob/user)
-	if(user && CHECK_BITFIELD(flags_item, ITEM_ZOOMED)) //Dropped when disconnected, whoops
+	if(user && CHECK_BITFIELD(flags_item, ITEM_ZOOMED))
 		user.unset_interaction()
 
 	for(var/X in actions)
@@ -662,11 +662,11 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	user.set_interaction(src)
 
 
-/obj/item/proc/unzoom(mob/living/user) //tileoffset is client view offset in the direction the user is facing. viewsize is how far out this thing zooms. 7 is normal view
+/obj/item/proc/unzoom(mob/living/user)
 	if(!user)
 		return
 
-	if(CHECK_BITFIELD(flags_item, ITEM_ZOOMED)) //If we are zoomed out, reset that parameter.
+	if(CHECK_BITFIELD(flags_item, ITEM_ZOOMED))
 		user.visible_message("<span class='notice'>[user] looks up from [src].</span>",
 		"<span class='notice'>You look up from [src].</span>")
 	

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -646,10 +646,12 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	"<span class='notice'>You peer through [src].</span>")
 	ENABLE_BITFIELD(flags_item, ITEM_ZOOMED)
 
-	user.set_client_sight(viewsize, tileoffset, CHECK_BITFIELD(flags_item, ITEM_ZOOM_NIGHTVISION))
+	user.set_client_sight(viewsize, tileoffset)
 
 	if(CHECK_BITFIELD(flags_item, ITEM_ZOOM_NIGHTVISION))
 		user.add_see_invisible(SEE_INVISIBLE_OBSERVER_NOLIGHTING)
+		user.add_see_in_dark_modifier(viewsize + tileoffset + 1)
+		user.update_see_in_dark()
 
 	if(user.interactee != src)
 		user.unset_interaction()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -648,6 +648,9 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 
 	user.set_client_sight(viewsize, tileoffset, CHECK_BITFIELD(flags_item, ITEM_ZOOM_NIGHTVISION))
 
+	if(CHECK_BITFIELD(flags_item, ITEM_ZOOM_NIGHTVISION))
+		user.add_see_invisible(SEE_INVISIBLE_OBSERVER_NOLIGHTING)
+
 	if(user.interactee != src)
 		user.unset_interaction()
 
@@ -662,6 +665,9 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 		user.visible_message("<span class='notice'>[user] looks up from [src].</span>",
 		"<span class='notice'>You look up from [src].</span>")
 	
+	if(CHECK_BITFIELD(flags_item, ITEM_ZOOM_NIGHTVISION))
+		user.remove_see_invisible(SEE_INVISIBLE_OBSERVER_NOLIGHTING)
+
 	DISABLE_BITFIELD(flags_item, ITEM_ZOOMED)
 	user.reset_client_sight()
 	user.zoom_cooldown = world.time + ZOOM_COOLDOWN

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -60,8 +60,9 @@
 	var/time_to_equip = 0 // set to ticks it takes to equip a worn suit.
 	var/time_to_unequip = 0 // set to ticks it takes to unequip a worn suit.
 
-
 	var/reach = 1
+
+	var/item_zoomed = 0 //Just how zoomed this item is (tileoffset + viewsize).
 
 	/* Species-specific sprites, concept stolen from Paradise//vg/.
 	ex:
@@ -648,9 +649,11 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 
 	user.set_client_sight(viewsize, tileoffset)
 
+	item_zoomed = viewsize + tileoffset + 1 //+1 to see the edge of the screen
+
 	if(CHECK_BITFIELD(flags_item, ITEM_ZOOM_NIGHTVISION))
 		user.add_see_invisible(SEE_INVISIBLE_OBSERVER_NOLIGHTING)
-		user.add_see_in_dark_modifier(viewsize + tileoffset + 1)
+		user.see_in_dark_modifiers.Add(item_zoomed)
 		user.update_see_in_dark()
 
 	if(user.interactee != src)
@@ -669,6 +672,10 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	
 	if(CHECK_BITFIELD(flags_item, ITEM_ZOOM_NIGHTVISION))
 		user.remove_see_invisible(SEE_INVISIBLE_OBSERVER_NOLIGHTING)
+		user.see_in_dark_modifiers.Remove(item_zoomed)
+		user.update_see_in_dark()
+
+	item_zoomed = 0
 
 	DISABLE_BITFIELD(flags_item, ITEM_ZOOMED)
 	user.reset_client_sight()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -615,7 +615,7 @@ modules/mob/mob_movement.dm if you move you will be zoomed out
 modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 */
 
-/obj/item/proc/zoom(mob/living/user, tileoffset = 11, viewsize = 12) //tileoffset is client view offset in the direction the user is facing. viewsize is how far out this thing zooms. 7 is normal view
+/obj/item/proc/zoom(mob/living/user, viewsize = 12, tileoffset = 11) //tileoffset is client view offset in the direction the user is facing. viewsize is how far out this thing zooms. 7 is normal view
 	if(!user)
 		return
 
@@ -646,7 +646,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	user.visible_message("<span class='notice'>[user] peers through [src].</span>",
 	"<span class='notice'>You peer through [src].</span>")
 
-	user.set_client_sight(viewsize, tileoffset)
+	user.zoom_in(viewsize, tileoffset)
 
 	item_zoomed = viewsize + tileoffset + 1 //+1 to see the edge of the screen
 
@@ -676,7 +676,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 
 	item_zoomed = 0
 
-	user.reset_client_sight()
+	user.zoom_out()
 	user.zoom_cooldown = world.time + ZOOM_COOLDOWN
 	
 	

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -209,7 +209,7 @@
 // apparently called whenever an item is removed from a slot, container, or anything else.
 //the call happens after the item's potential loc change.
 /obj/item/proc/dropped(mob/user)
-	if(user && CHECK_BITFIELD(flags_item, ITEM_ZOOMED))
+	if(user && item_zoomed)
 		user.unset_interaction()
 
 	for(var/X in actions)
@@ -623,7 +623,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 		to_chat(user, "<span class='warning'>You are already looking through [user.interactee].</span>")
 		return //Return in the interest of not unzooming the other item. Check first in the interest of not fucking with the other clauses
 
-	if(CHECK_BITFIELD(flags_item, ITEM_ZOOMED)) //If we are already zoomed out, unzoom.
+	if(item_zoomed) //If we are already zoomed out, unzoom.
 		user.unset_interaction()
 		return
 
@@ -645,7 +645,6 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 
 	user.visible_message("<span class='notice'>[user] peers through [src].</span>",
 	"<span class='notice'>You peer through [src].</span>")
-	ENABLE_BITFIELD(flags_item, ITEM_ZOOMED)
 
 	user.set_client_sight(viewsize, tileoffset)
 
@@ -666,7 +665,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	if(!user)
 		return
 
-	if(CHECK_BITFIELD(flags_item, ITEM_ZOOMED))
+	if(item_zoomed)
 		user.visible_message("<span class='notice'>[user] looks up from [src].</span>",
 		"<span class='notice'>You look up from [src].</span>")
 	
@@ -677,7 +676,6 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 
 	item_zoomed = 0
 
-	DISABLE_BITFIELD(flags_item, ITEM_ZOOMED)
 	user.reset_client_sight()
 	user.zoom_cooldown = world.time + ZOOM_COOLDOWN
 	

--- a/code/game/objects/items/binoculars.dm
+++ b/code/game/objects/items/binoculars.dm
@@ -3,7 +3,7 @@
 	name = "binoculars"
 	desc = "A pair of binoculars."
 	icon_state = "binoculars"
-
+	flags_item = ITEM_ZOOM_NIGHTVISION
 	flags_atom = CONDUCT
 	force = 5.0
 	w_class = 2.0
@@ -11,9 +11,15 @@
 	throw_range = 15
 	throw_speed = 3
 
-	//matter = list("metal" = 50,"glass" = 50)
+
+/obj/item/binoculars/on_unset_interaction(mob/user)
+	unzoom(user)
+
 
 /obj/item/binoculars/attack_self(mob/user)
+	if(CHECK_BITFIELD(flags_item, ITEM_ZOOMED))
+		user.unset_interaction()
+		return
 	zoom(user, 11, 12)
 
 
@@ -63,7 +69,6 @@
 
 /obj/item/binoculars/tactical/on_unset_interaction(mob/user)
 	. = ..()
-	user.reset_client_sight()
 	if(laser)
 		qdel(laser)
 	if(coord)
@@ -90,7 +95,7 @@
 		to_chat(user, "These binoculars only have one mode.")
 		return
 
-	if(!zoomed)
+	if(!CHECK_BITFIELD(flags_item, ITEM_ZOOMED))
 		mode = !mode
 		to_chat(user, "<span class='notice'>You switch [src] to [mode? "range finder" : "CAS marking" ] mode.</span>")
 		update_icon()

--- a/code/game/objects/items/binoculars.dm
+++ b/code/game/objects/items/binoculars.dm
@@ -17,7 +17,7 @@
 
 
 /obj/item/binoculars/attack_self(mob/user)
-	if(CHECK_BITFIELD(flags_item, ITEM_ZOOMED))
+	if(item_zoomed)
 		user.unset_interaction()
 		return
 	zoom(user, 11, 12)
@@ -95,7 +95,7 @@
 		to_chat(user, "These binoculars only have one mode.")
 		return
 
-	if(!CHECK_BITFIELD(flags_item, ITEM_ZOOMED))
+	if(!item_zoomed)
 		mode = !mode
 		to_chat(user, "<span class='notice'>You switch [src] to [mode? "range finder" : "CAS marking" ] mode.</span>")
 		update_icon()

--- a/code/game/objects/items/binoculars.dm
+++ b/code/game/objects/items/binoculars.dm
@@ -63,14 +63,7 @@
 
 /obj/item/binoculars/tactical/on_unset_interaction(mob/user)
 	. = ..()
-
-	if(!user?.client)
-		return
-
-	user.client.click_intercept = null
-
-	if(zoom)
-		return
+	user.reset_client_sight()
 	if(laser)
 		qdel(laser)
 	if(coord)
@@ -97,7 +90,7 @@
 		to_chat(user, "These binoculars only have one mode.")
 		return
 
-	if(!zoom)
+	if(!zoomed)
 		mode = !mode
 		to_chat(user, "<span class='notice'>You switch [src] to [mode? "range finder" : "CAS marking" ] mode.</span>")
 		update_icon()

--- a/code/game/objects/items/binoculars.dm
+++ b/code/game/objects/items/binoculars.dm
@@ -20,7 +20,7 @@
 	if(item_zoomed)
 		user.unset_interaction()
 		return
-	zoom(user, 11, 12)
+	zoom(user, 12, 11)
 
 
 /obj/item/binoculars/tactical

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -17,7 +17,7 @@
 		ghost.reenter_corpse()
 		return
 
-	M.client.change_view(world.view)
+	M.reset_client_sight()
 
 	var/oldkey = M.key
 
@@ -93,8 +93,7 @@
 
 	M.ghostize(FALSE)
 	M.ckey = ckey(new_ckey)
-	if(M.client)
-		M.client.change_view(world.view)
+	M.reset_client_sight()
 
 	log_admin("[key_name(usr)] changed [M.name] ckey to [new_ckey].")
 	message_admins("[ADMIN_TPMONTY(usr)] changed [M.name] ckey to [new_ckey].")

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -535,8 +535,7 @@ Status: [status ? status : "Unknown"] | Damage: [health ? health : "None"]
 		M.client.screen.Cut()
 		NP.key = M.key
 		NP.name = M.key
-		if(NP.client)
-			NP.client.change_view(world.view)
+		NP.reset_client_sight()
 		if(isobserver(M))
 			qdel(M)
 		else

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -98,15 +98,6 @@
 		icon = initial(icon)
 
 
-/obj/item/clothing/equipped(mob/user)
-	wearer = user
-	return ..()
-
-
-/obj/item/clothing/dropped(mob/user)
-	. = ..()
-	wearer = null
-
 ///////////////////////////////////////////////////////////////////////
 // Ears: headsets, earmuffs and tiny objects
 /obj/item/clothing/ears

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -1,6 +1,7 @@
 /obj/item/clothing
 	name = "clothing"
 	var/list/species_restricted = null //Only these species can wear this kit.
+	var/mob/living/carbon/wearer
 
 	/*
 		Sprites used when the clothing item is refit. This is done by setting icon_override.
@@ -95,6 +96,16 @@
 		icon = sprite_sheets_obj[target_species]
 	else
 		icon = initial(icon)
+
+
+/obj/item/clothing/equipped(mob/user)
+	wearer = user
+	return ..()
+
+
+/obj/item/clothing/dropped(mob/user)
+	. = ..()
+	wearer = null
 
 ///////////////////////////////////////////////////////////////////////
 // Ears: headsets, earmuffs and tiny objects

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -3,13 +3,13 @@
 	name = "glasses"
 	icon = 'icons/obj/clothing/glasses.dmi'
 	w_class = 2.0
-	var/vision_flags = 0
-	var/darkness_view = 0//Base human is 2
+	var/vision_flags = NOFLAGS
+	var/glass_see_in_dark_modifier = 0//Base human is 2
 	var/see_invisible = 0
 	sprite_sheets = list("Vox" = 'icons/mob/species/vox/eyes.dmi')
 	var/prescription = 0
-	var/toggleable = 0
-	var/active = 1
+	var/toggleable = FALSE
+	var/active = TRUE
 	flags_inventory = COVEREYES
 	flags_equip_slot = ITEM_SLOT_EYES
 	flags_armor_protection = EYES
@@ -23,27 +23,60 @@
 		M.update_inv_glasses()
 
 
+/obj/item/clothing/glasses/proc/activate_optical_matrix(mob/user)
+	if(vision_flags)
+		ENABLE_BITFIELD(user.sight, vision_flags)
+	if(glass_see_in_dark_modifier)
+		wearer.see_in_dark_modifier += glass_see_in_dark_modifier
+	if(see_invisible)
+		user.add_see_invisible(see_invisible)
+	if(tint)
+		wearer.update_tint()
+	if(fullscreen_vision)
+		user.overlay_fullscreen("glasses_vision", fullscreen_vision)
+	wearer.update_inv_glasses()
+
+
+/obj/item/clothing/glasses/proc/deactivate_optical_matrix(mob/user)
+	if(vision_flags)
+		DISABLE_BITFIELD(user.sight, vision_flags)
+	if(glass_see_in_dark_modifier)
+		wearer.see_in_dark_modifier -= glass_see_in_dark_modifier
+	if(see_invisible)
+		user.remove_see_invisible(see_invisible)
+	if(tint)
+		wearer.update_tint()
+	if(fullscreen_vision)
+		user.clear_fullscreen("glasses_vision", 0)
+	wearer.update_inv_glasses()
+
+
 /obj/item/clothing/glasses/attack_self(mob/user)
-	if(toggleable)
-		if(active)
-			active = 0
-			icon_state = deactive_state
-			user.update_inv_glasses()
-			to_chat(user, "You deactivate the optical matrix on [src].")
-		else
-			active = 1
-			icon_state = initial(icon_state)
-			user.update_inv_glasses()
-			to_chat(user, "You activate the optical matrix on [src].")
+	if(!toggleable)
+		return
 
-		if(ishuman(loc))
-			var/mob/living/carbon/human/H = loc
-			if(H.glasses == src)
-				H.update_tint()
-				H.update_sight()
+	if(active)
+		active = FALSE
+		icon_state = deactive_state
+		activate_optical_matrix(user)
+		to_chat(user, "You deactivate the optical matrix on [src].")
+	else
+		active = TRUE
+		icon_state = initial(icon_state)
+		deactivate_optical_matrix(user)
+		to_chat(user, "You activate the optical matrix on [src].")
 
-		update_action_button_icons()
+	update_action_button_icons()
 
+
+/obj/item/clothing/glasses/equipped(mob/user)
+	. = ..()
+	activate_optical_matrix(user)
+
+
+/obj/item/clothing/glasses/dropped(mob/user)
+	deactivate_optical_matrix(user)
+	return ..()
 
 
 /obj/item/clothing/glasses/science
@@ -116,18 +149,6 @@
 	icon_state = "mgoggles"
 	item_state = "mgoggles"
 	prescription = 1
-
-/obj/item/clothing/glasses/m42_goggles
-	name = "\improper M42 scout sight"
-	desc = "A headset and goggles system for the M42 Scout Rifle. Allows highlighted imaging of surroundings. Click it to toggle."
-	icon = 'icons/obj/clothing/glasses.dmi'
-	icon_state = "m56_goggles"
-	deactive_state = "m56_goggles_0"
-	vision_flags = SEE_TURFS
-	toggleable = 1
-	actions_types = list(/datum/action/item_action/toggle)
-
-
 
 //welding goggles
 

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -24,31 +24,44 @@
 
 
 /obj/item/clothing/glasses/proc/activate_optical_matrix(mob/user)
-	if(vision_flags)
-		ENABLE_BITFIELD(user.sight, vision_flags)
-	if(glass_see_in_dark_modifier)
-		wearer.see_in_dark_modifier += glass_see_in_dark_modifier
-	if(see_invisible)
-		user.add_see_invisible(see_invisible)
-	if(tint)
-		wearer.update_tint()
-	if(fullscreen_vision)
-		user.overlay_fullscreen("glasses_vision", fullscreen_vision)
-	wearer.update_inv_glasses()
+	if(active)
+		return
+	active = TRUE
+	icon_state = initial(icon_state)
+	to_chat(user, "You activate the optical matrix on [src].")
 
 
 /obj/item/clothing/glasses/proc/deactivate_optical_matrix(mob/user)
-	if(vision_flags)
-		DISABLE_BITFIELD(user.sight, vision_flags)
-	if(glass_see_in_dark_modifier)
-		wearer.see_in_dark_modifier -= glass_see_in_dark_modifier
-	if(see_invisible)
-		user.remove_see_invisible(see_invisible)
-	if(tint)
-		wearer.update_tint()
-	if(fullscreen_vision)
-		user.clear_fullscreen("glasses_vision", 0)
-	wearer.update_inv_glasses()
+	active = FALSE
+	icon_state = deactive_state
+	to_chat(user, "You deactivate the optical matrix on [src].")
+
+
+/obj/item/clothing/glasses/proc/update_optical_matrix(mob/user)
+	if(active)
+		if(vision_flags)
+			ENABLE_BITFIELD(user.sight, vision_flags)
+		if(glass_see_in_dark_modifier)
+			wearer.see_in_dark_modifier += glass_see_in_dark_modifier
+		if(see_invisible)
+			user.add_see_invisible(see_invisible)
+		if(tint)
+			wearer.update_tint()
+		if(fullscreen_vision)
+			user.overlay_fullscreen("glasses_vision", fullscreen_vision)
+		wearer.update_inv_glasses()
+	else
+		if(vision_flags)
+			DISABLE_BITFIELD(user.sight, vision_flags)
+		if(glass_see_in_dark_modifier)
+			wearer.see_in_dark_modifier -= glass_see_in_dark_modifier
+		if(see_invisible)
+			user.remove_see_invisible(see_invisible)
+		if(tint)
+			wearer.update_tint()
+		if(fullscreen_vision)
+			user.clear_fullscreen("glasses_vision", 0)
+		wearer.update_inv_glasses()
 
 
 /obj/item/clothing/glasses/attack_self(mob/user)
@@ -56,28 +69,33 @@
 		return
 
 	if(active)
-		active = FALSE
-		icon_state = deactive_state
-		activate_optical_matrix(user)
-		to_chat(user, "You deactivate the optical matrix on [src].")
-	else
-		active = TRUE
-		icon_state = initial(icon_state)
 		deactivate_optical_matrix(user)
-		to_chat(user, "You activate the optical matrix on [src].")
-
+	else
+		activate_optical_matrix(user)
+	if(wearer)
+		update_optical_matrix(wearer)
 	update_action_button_icons()
 
 
-/obj/item/clothing/glasses/equipped(mob/user)
+/obj/item/clothing/glasses/equipped(mob/user, slot)
 	. = ..()
-	activate_optical_matrix(user)
+	if(slot != SLOT_GLASSES || !toggleable)
+		return
+	wearer = user
+	if(active)
+		return
+	activate_optical_matrix()
+	update_optical_matrix(wearer)
 
 
 /obj/item/clothing/glasses/dropped(mob/user)
-	deactivate_optical_matrix(user)
-	return ..()
-
+	. = ..()
+	if(!toggleable)
+		return
+	deactivate_optical_matrix()
+	update_optical_matrix(wearer)
+	wearer = null
+	
 
 /obj/item/clothing/glasses/science
 	name = "science goggles"

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -4,8 +4,8 @@
 	icon = 'icons/obj/clothing/glasses.dmi'
 	w_class = 2.0
 	var/vision_flags = NOFLAGS
-	var/glass_see_in_dark_modifier = 0//Base human is 2
-	var/see_invisible = 0
+	var/glasses_see_in_dark_modifier = 0//Base human is 2
+	var/glasses_see_invisible_modifier = 0
 	sprite_sheets = list("Vox" = 'icons/mob/species/vox/eyes.dmi')
 	var/prescription = 0
 	var/toggleable = FALSE
@@ -41,10 +41,11 @@
 	if(active)
 		if(vision_flags)
 			ENABLE_BITFIELD(user.sight, vision_flags)
-		if(glass_see_in_dark_modifier)
-			wearer.see_in_dark_modifier += glass_see_in_dark_modifier
-		if(see_invisible)
-			user.add_see_invisible(see_invisible)
+		if(glasses_see_in_dark_modifier)
+			wearer.see_in_dark_modifier += glasses_see_in_dark_modifier
+			wearer.update_see_in_dark()
+		if(glasses_see_invisible_modifier)
+			wearer.add_see_invisible(glasses_see_invisible_modifier)
 		if(tint)
 			wearer.update_tint()
 		if(fullscreen_vision)
@@ -53,10 +54,11 @@
 	else
 		if(vision_flags)
 			DISABLE_BITFIELD(user.sight, vision_flags)
-		if(glass_see_in_dark_modifier)
-			wearer.see_in_dark_modifier -= glass_see_in_dark_modifier
-		if(see_invisible)
-			user.remove_see_invisible(see_invisible)
+		if(glasses_see_in_dark_modifier)
+			wearer.see_in_dark_modifier -= glasses_see_in_dark_modifier
+			wearer.update_see_in_dark()
+		if(glasses_see_invisible_modifier)
+			wearer.remove_see_invisible(glasses_see_invisible_modifier)
 		if(tint)
 			wearer.update_tint()
 		if(fullscreen_vision)
@@ -83,6 +85,8 @@
 		return
 	wearer = user
 	if(active)
+		icon_state = initial(icon_state)
+		update_optical_matrix(wearer)
 		return
 	activate_optical_matrix()
 	update_optical_matrix(wearer)

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -42,7 +42,7 @@
 		if(vision_flags)
 			ENABLE_BITFIELD(user.sight, vision_flags)
 		if(glasses_see_in_dark_modifier)
-			wearer.see_in_dark_modifier += glasses_see_in_dark_modifier
+			wearer.see_in_dark_modifiers.Add(glasses_see_in_dark_modifier)
 			wearer.update_see_in_dark()
 		if(glasses_see_invisible_modifier)
 			wearer.add_see_invisible(glasses_see_invisible_modifier)
@@ -55,7 +55,7 @@
 		if(vision_flags)
 			DISABLE_BITFIELD(user.sight, vision_flags)
 		if(glasses_see_in_dark_modifier)
-			wearer.see_in_dark_modifier -= glasses_see_in_dark_modifier
+			wearer.see_in_dark_modifiers.Remove(glasses_see_in_dark_modifier)
 			wearer.update_see_in_dark()
 		if(glasses_see_invisible_modifier)
 			wearer.remove_see_invisible(glasses_see_invisible_modifier)

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -56,7 +56,7 @@
 	icon_state = "jensenshades"
 	item_state = "jensenshades"
 	vision_flags = SEE_MOBS
-	see_invisible = SEE_INVISIBLE_OBSERVER_NOLIGHTING // the define name is just misleading, don't worry
+	glasses_see_invisible_modifier = SEE_INVISIBLE_OBSERVER_NOLIGHTING // the define name is just misleading, don't worry
 	toggleable = 0
 	actions_types = list()
 

--- a/code/modules/clothing/glasses/night.dm
+++ b/code/modules/clothing/glasses/night.dm
@@ -18,9 +18,8 @@
 	icon = 'icons/obj/clothing/glasses.dmi'
 	icon_state = "m56_goggles"
 	deactive_state = "m56_goggles_0"
-	vision_flags = SEE_TURFS
-	darkness_view = 12
-	toggleable = 1
+	darkness_view = 13
+	toggleable = TRUE
 	fullscreen_vision = null
 	actions_types = list(/datum/action/item_action/toggle)
 
@@ -31,9 +30,8 @@
 	icon = 'icons/obj/clothing/glasses.dmi'
 	icon_state = "m56_goggles"
 	deactive_state = "m56_goggles_0"
-	vision_flags = SEE_TURFS
 	darkness_view = 24
-	toggleable = 1
+	toggleable = TRUE
 	fullscreen_vision = null
 	actions_types = list(/datum/action/item_action/toggle)
 
@@ -52,10 +50,10 @@
 	icon_state = "m56_goggles"
 	deactive_state = "m56_goggles_0"
 	darkness_view = 8
-	toggleable = 1
+	toggleable = TRUE
 	actions_types = list(/datum/action/item_action/toggle)
-	vision_flags = SEE_TURFS
 	fullscreen_vision = null //Nulled out due to general dislike for the overlay.
+
 
 /obj/item/clothing/glasses/night/m56_goggles/mob_can_equip(mob/user, slot)
 	if(slot == SLOT_GLASSES)

--- a/code/modules/clothing/glasses/night.dm
+++ b/code/modules/clothing/glasses/night.dm
@@ -7,8 +7,8 @@
 	icon_state = "night"
 	item_state = "glasses"
 	origin_tech = "magnets=2"
-	glass_see_in_dark_modifier = 7
-	see_invisible = SEE_INVISIBLE_OBSERVER_NOLIGHTING // Needed for no darkness overlay
+	glasses_see_invisible_modifier = SEE_INVISIBLE_OBSERVER_NOLIGHTING // Needed for no darkness overlay
+	glasses_see_in_dark_modifier = 7
 	fullscreen_vision = /obj/screen/fullscreen/nvg
 
 
@@ -18,7 +18,7 @@
 	icon = 'icons/obj/clothing/glasses.dmi'
 	icon_state = "m56_goggles"
 	deactive_state = "m56_goggles_0"
-	glass_see_in_dark_modifier = 13
+	glasses_see_in_dark_modifier = 13
 	toggleable = TRUE
 	fullscreen_vision = null
 	actions_types = list(/datum/action/item_action/toggle)
@@ -30,7 +30,7 @@
 	icon = 'icons/obj/clothing/glasses.dmi'
 	icon_state = "m56_goggles"
 	deactive_state = "m56_goggles_0"
-	glass_see_in_dark_modifier = 24
+	glasses_see_in_dark_modifier = 24
 	toggleable = TRUE
 	fullscreen_vision = null
 	actions_types = list(/datum/action/item_action/toggle)
@@ -49,7 +49,7 @@
 	icon = 'icons/obj/clothing/glasses.dmi'
 	icon_state = "m56_goggles"
 	deactive_state = "m56_goggles_0"
-	glass_see_in_dark_modifier = 8
+	glasses_see_in_dark_modifier = 8
 	toggleable = TRUE
 	actions_types = list(/datum/action/item_action/toggle)
 	fullscreen_vision = null //Nulled out due to general dislike for the overlay.

--- a/code/modules/clothing/glasses/night.dm
+++ b/code/modules/clothing/glasses/night.dm
@@ -7,7 +7,7 @@
 	icon_state = "night"
 	item_state = "glasses"
 	origin_tech = "magnets=2"
-	darkness_view = 7
+	glass_see_in_dark_modifier = 7
 	see_invisible = SEE_INVISIBLE_OBSERVER_NOLIGHTING // Needed for no darkness overlay
 	fullscreen_vision = /obj/screen/fullscreen/nvg
 
@@ -18,7 +18,7 @@
 	icon = 'icons/obj/clothing/glasses.dmi'
 	icon_state = "m56_goggles"
 	deactive_state = "m56_goggles_0"
-	darkness_view = 13
+	glass_see_in_dark_modifier = 13
 	toggleable = TRUE
 	fullscreen_vision = null
 	actions_types = list(/datum/action/item_action/toggle)
@@ -30,7 +30,7 @@
 	icon = 'icons/obj/clothing/glasses.dmi'
 	icon_state = "m56_goggles"
 	deactive_state = "m56_goggles_0"
-	darkness_view = 24
+	glass_see_in_dark_modifier = 24
 	toggleable = TRUE
 	fullscreen_vision = null
 	actions_types = list(/datum/action/item_action/toggle)
@@ -49,7 +49,7 @@
 	icon = 'icons/obj/clothing/glasses.dmi'
 	icon_state = "m56_goggles"
 	deactive_state = "m56_goggles_0"
-	darkness_view = 8
+	glass_see_in_dark_modifier = 8
 	toggleable = TRUE
 	actions_types = list(/datum/action/item_action/toggle)
 	fullscreen_vision = null //Nulled out due to general dislike for the overlay.

--- a/code/modules/clothing/glasses/thermal.dm
+++ b/code/modules/clothing/glasses/thermal.dm
@@ -9,7 +9,7 @@
 	origin_tech = "magnets=3"
 	toggleable = 1
 	vision_flags = SEE_MOBS
-	see_invisible = SEE_INVISIBLE_OBSERVER_NOLIGHTING
+	glasses_see_invisible_modifier = SEE_INVISIBLE_OBSERVER_NOLIGHTING
 	eye_protection = -1
 	deactive_state = "goggles_off"
 	fullscreen_vision = /obj/screen/fullscreen/thermal

--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -282,7 +282,6 @@ var/list/squad_colors = list(rgb(230,25,25), rgb(255,195,45), rgb(200,100,200), 
 	flags_cold_protection = CHEST|GROIN|ARMS|LEGS|FEET
 	flags_heat_protection = CHEST|GROIN|ARMS|LEGS|FEET
 	slowdown = SLOWDOWN_ARMOR_HEAVY
-	var/mob/living/carbon/human/wearer = null
 	var/B18_burn_cooldown = null
 	var/B18_oxy_cooldown = null
 	var/B18_brute_cooldown = null

--- a/code/modules/cm_marines/equipment/weapons.dm
+++ b/code/modules/cm_marines/equipment/weapons.dm
@@ -225,7 +225,7 @@
 /obj/item/storage/box/m42c_system_Jungle/Initialize(mapload, ...)
 	. = ..()
 	new /obj/item/clothing/suit/storage/marine/sniper/jungle(src)
-	new /obj/item/clothing/glasses/m42_goggles(src)
+	new /obj/item/clothing/glasses/night/m42_night_goggles(src)
 	new /obj/item/clothing/head/helmet/durag/jungle(src)
 	new /obj/item/ammo_magazine/sniper(src)
 	new /obj/item/ammo_magazine/sniper(src)

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -555,11 +555,7 @@
 	user.client.click_intercept = src
 
 /obj/machinery/m56d_hmg/on_unset_interaction(mob/user)
-	if(user.client)
-		user.client.change_view(world.view)
-		user.client.pixel_x = 0
-		user.client.pixel_y = 0
-		user.client.click_intercept = null
+	user.reset_client_sight()
 	if(operator == user)
 		operator = null
 	user.verbs -= /mob/living/proc/toogle_mg_burst_fire

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -50,12 +50,9 @@
 	dizziness = 0
 	jitteriness = 0
 
-	if(client)
-		client.change_view(world.view) //just so we never get stuck with a large view somehow
+	reset_client_sight()
 
 	hide_fullscreens()
-
-	update_sight()
 
 	drop_r_hand()
 	drop_l_hand()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -133,7 +133,7 @@
 			to_chat(src, "<span class='warning'>Your other hand is too busy holding \the [offhand.name]</span>")
 			return
 		else wielded_item.unwield(src) //Get rid of it.
-	if(wielded_item && wielded_item.zoom) //Adding this here while we're at it
+	if(wielded_item && wielded_item.zoomed) //Adding this here while we're at it
 		wielded_item.zoom(src)
 	hand = !hand
 	if(hud_used.l_hand_hud_object && hud_used.r_hand_hud_object)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -134,7 +134,7 @@
 				to_chat(src, "<span class='warning'>Your other hand is too busy holding \the [offhand.name]</span>")
 				return
 			wielded_item.unwield(src) //Get rid of it.
-		if(CHECK_BITFIELD(wielded_item.flags_item, ITEM_ZOOMED)) //Adding this here while we're at it
+		if(wielded_item.item_zoomed) //Adding this here while we're at it
 			unset_interaction()
 	hand = !hand
 	if(hud_used.l_hand_hud_object && hud_used.r_hand_hud_object)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -127,14 +127,15 @@
 
 /mob/living/carbon/proc/swap_hand()
 	var/obj/item/wielded_item = get_active_held_item()
-	if(wielded_item && (wielded_item.flags_item & WIELDED)) //this segment checks if the item in your hand is twohanded.
-		var/obj/item/weapon/twohanded/offhand/offhand = get_inactive_held_item()
-		if(offhand && (offhand.flags_item & WIELDED))
-			to_chat(src, "<span class='warning'>Your other hand is too busy holding \the [offhand.name]</span>")
-			return
-		else wielded_item.unwield(src) //Get rid of it.
-	if(wielded_item && wielded_item.zoomed) //Adding this here while we're at it
-		wielded_item.zoom(src)
+	if(wielded_item)
+		if(CHECK_BITFIELD(wielded_item.flags_item, WIELDED)) //this segment checks if the item in your hand is twohanded.
+			var/obj/item/weapon/twohanded/offhand/offhand = get_inactive_held_item()
+			if(offhand && (offhand.flags_item & WIELDED))
+				to_chat(src, "<span class='warning'>Your other hand is too busy holding \the [offhand.name]</span>")
+				return
+			else wielded_item.unwield(src) //Get rid of it.
+		if(CHECK_BITFIELD(wielded_item.flags_item, ITEM_ZOOMED)) //Adding this here while we're at it
+			unset_interaction()
 	hand = !hand
 	if(hud_used.l_hand_hud_object && hud_used.r_hand_hud_object)
 		if(hand)	//This being 1 means the left hand is in use

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -133,7 +133,7 @@
 			if(offhand && (offhand.flags_item & WIELDED))
 				to_chat(src, "<span class='warning'>Your other hand is too busy holding \the [offhand.name]</span>")
 				return
-			else wielded_item.unwield(src) //Get rid of it.
+			wielded_item.unwield(src) //Get rid of it.
 		if(CHECK_BITFIELD(wielded_item.flags_item, ITEM_ZOOMED)) //Adding this here while we're at it
 			unset_interaction()
 	hand = !hand

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1532,53 +1532,6 @@
 		return initial(pixel_y)
 
 
-/mob/proc/update_sight()
-	return
-
-/mob/living/carbon/human/update_sight()
-	if(!client)
-		return
-	if(stat == DEAD)
-		sight = (SEE_TURFS|SEE_MOBS|SEE_OBJS)
-		see_in_dark = 8
-		see_invisible = SEE_INVISIBLE_LEVEL_TWO
-		return
-
-	sight = initial(sight)
-	see_in_dark = species.darksight
-	see_invisible = see_in_dark > 2 ? SEE_INVISIBLE_LEVEL_ONE : SEE_INVISIBLE_LIVING
-	if(dna)
-		switch(dna.mutantrace)
-			if("slime")
-				see_in_dark = 3
-				see_invisible = SEE_INVISIBLE_LEVEL_ONE
-			if("shadow")
-				see_in_dark = 8
-				see_invisible = SEE_INVISIBLE_LEVEL_ONE
-
-
-	if(glasses)
-		var/obj/item/clothing/glasses/G = glasses
-		//prescription applies regardless of it the glasses are active
-		if(G.active)
-			see_in_dark = max(G.darkness_view, see_in_dark)
-			sight |= G.vision_flags
-			if(G.fullscreen_vision)
-				overlay_fullscreen("glasses_vision", G.fullscreen_vision)
-			else
-				clear_fullscreen("glasses_vision", 0)
-			if(G.see_invisible)
-				see_invisible = min(G.see_invisible, see_invisible)
-	else
-		clear_fullscreen("glasses_vision", 0)
-
-
-	if(XRAY in mutations)
-		sight |= (SEE_TURFS|SEE_MOBS|SEE_OBJS)
-		see_in_dark = max(see_in_dark, 8)
-
-
-
 /mob/living/carbon/human/get_total_tint()
 	. = ..()
 	var/obj/item/clothing/C

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -171,12 +171,6 @@
 		update_inv_gloves()
 	else if (I == glasses)
 		glasses = null
-		var/obj/item/clothing/glasses/G = I
-		if(G.vision_flags || G.darkness_view || G.see_invisible)
-			update_sight()
-		if(G.tint)
-			update_tint()
-		update_inv_glasses()
 	else if (I == wear_ear)
 		wear_ear = null
 		update_inv_ears()
@@ -288,12 +282,6 @@
 		if(SLOT_GLASSES)
 			glasses = W
 			W.equipped(src, slot)
-			var/obj/item/clothing/glasses/G = W
-			if(G.vision_flags || G.darkness_view || G.see_invisible)
-				update_sight()
-			if(G.tint)
-				update_tint()
-			update_inv_glasses()
 		if(SLOT_GLOVES)
 			gloves = W
 			W.equipped(src, slot)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -171,6 +171,7 @@
 		update_inv_gloves()
 	else if (I == glasses)
 		glasses = null
+		update_inv_glasses()
 	else if (I == wear_ear)
 		wear_ear = null
 		update_inv_ears()

--- a/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
@@ -7,8 +7,6 @@
 
 	if(stat != DEAD) //the dead get zero fullscreens
 
-		update_sight()
-
 		if(stat == UNCONSCIOUS && health <= get_crit_threshold())
 			var/severity = 0
 			switch(health)

--- a/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
@@ -141,14 +141,5 @@
 						hud_used.bodytemp_icon.icon_state = "temp0"
 
 
-		if(interactee)
-			interactee.check_eye(src)
-		else
-			var/isRemoteObserve = 0
-			if((mRemote in mutations) && remoteview_target)
-				if(remoteview_target.stat == CONSCIOUS)
-					isRemoteObserve = 1
-			if(!isRemoteObserve && client && !client.adminobs)
-				remoteview_target = null
-				reset_view(null)
-	return 1
+		interactee?.check_eye(src)
+	return TRUE

--- a/code/modules/mob/living/carbon/human/login.dm
+++ b/code/modules/mob/living/carbon/human/login.dm
@@ -1,3 +1,3 @@
 /mob/living/carbon/human/Login()
-	. = ..()
-	species?.handle_login_special(src)
+	..()
+	if(species) species.handle_login_special(src)

--- a/code/modules/mob/living/carbon/human/login.dm
+++ b/code/modules/mob/living/carbon/human/login.dm
@@ -1,3 +1,3 @@
 /mob/living/carbon/human/Login()
-	..()
-	if(species) species.handle_login_special(src)
+	. = ..()
+	species?.handle_login_special(src)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -554,6 +554,7 @@ var/global/list/damage_icon_parts = list()
 
 		apply_overlay(GLASSES_LAYER)
 
+
 /mob/living/carbon/human/update_inv_ears()
 	remove_overlay(EARS_LAYER)
 	if(wear_ear)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -554,7 +554,6 @@ var/global/list/damage_icon_parts = list()
 
 		apply_overlay(GLASSES_LAYER)
 
-
 /mob/living/carbon/human/update_inv_ears()
 	remove_overlay(EARS_LAYER)
 	if(wear_ear)

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/boiler.dm
@@ -38,7 +38,6 @@
 	SetLuminosity(BOILER_LUMINOSITY)
 	smoke = new /datum/effect_system/smoke_spread/xeno_acid
 	smoke.attach(src)
-	see_in_dark = 20
 	ammo = GLOB.ammo_list[/datum/ammo/xeno/boiler_gas]
 
 /mob/living/carbon/Xenomorph/Boiler/Destroy()
@@ -47,11 +46,3 @@
 		qdel(smoke)
 		smoke = null
 	return ..()
-
-// ***************************************
-// *********** Life overrides
-// ***************************************
-/mob/living/carbon/Xenomorph/Boiler/update_stat()
-	. = ..()
-	if(stat == CONSCIOUS)
-		see_in_dark = 20

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -504,7 +504,7 @@
 	if(X.is_zoomed)
 		X.zoom_out()
 	else
-		X.zoom_in(0, 12)
+		X.zoom_in(12, 0)
 
 // ***************************************
 // *********** Set leader

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -735,10 +735,7 @@
 		T.mind.transfer_to(new_xeno)
 	else
 		new_xeno.key = T.key
-		if(new_xeno.client)
-			new_xeno.client.change_view(world.view)
-			new_xeno.client.pixel_x = 0
-			new_xeno.client.pixel_y = 0
+		new_xeno.reset_client_sight()
 
 	//Pass on the unique nicknumber, then regenerate the new mob's name now that our player is inside
 	new_xeno.nicknumber = T.nicknumber

--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -148,8 +148,7 @@
 	if(picked)
 		new_xeno.key = picked
 
-		if(new_xeno.client)
-			new_xeno.client.change_view(world.view)
+		new_xeno.reset_client_sight()
 
 		to_chat(new_xeno, "<span class='xenoannounce'>You are a xenomorph larva inside a host! Move to burst out of it!</span>")
 		new_xeno << sound('sound/effects/xeno_newlarva.ogg')

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -397,8 +397,7 @@ to_chat will check for valid clients itself already so no need to double check f
 			SEND_SOUND(new_xeno, sound('sound/effects/xeno_newlarva.ogg'))
 			new_xeno.key = picked
 
-			if(new_xeno.client)
-				new_xeno.client.change_view(world.view)
+			new_xeno.reset_client_sight()
 
 			to_chat(new_xeno, "<span class='xenoannounce'>You are a xenomorph larva awakened from slumber!</span>")
 			SEND_SOUND(new_xeno, sound('sound/effects/xeno_newlarva.ogg'))

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -50,10 +50,8 @@
 
 	if(knocked_out || sleeping || health < 0)
 		stat = UNCONSCIOUS
-		see_in_dark = 5
 	else
 		stat = CONSCIOUS
-		see_in_dark = 8
 	update_canmove()
 
 	//Deal with devoured things and people

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -175,8 +175,6 @@
 	var/warding_aura = 0
 	var/recovery_aura = 0
 
-	var/is_zoomed = 0
-	var/zoom_turf = null
 	var/autopsied = 0
 	var/attack_delay = 0 //Bonus or pen to time in between attacks. + makes slashes slower.
 	var/speed = -0.5 //Regular xeno speed modifier. Positive makes you go slower. (1.5 is equivalent to FAT mutation)

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -389,35 +389,6 @@
 		update_see_in_dark()
 
 
-
-/mob/living/carbon/Xenomorph/proc/zoom_in(tileoffset = 5, viewsize = 12)
-	if(stat || resting)
-		if(is_zoomed)
-			is_zoomed = FALSE
-			zoom_out()
-			return
-		return
-	if(is_zoomed)
-		return
-	if(!client)
-		return
-	zoom_turf = get_turf(src)
-	is_zoomed = TRUE
-	see_in_dark_modifiers.Add(viewsize + tileoffset + 1)
-	update_see_in_dark()
-	set_client_sight(viewsize, tileoffset)
-
-
-/mob/living/carbon/Xenomorph/proc/zoom_out()
-	is_zoomed = FALSE
-	zoom_turf = null
-	if(!client)
-		return
-	see_in_dark_modifiers.Cut()
-	update_see_in_dark()
-	reset_client_sight()
-
-
 /mob/living/carbon/Xenomorph/drop_held_item()
 	var/obj/item/clothing/mask/facehugger/F = get_active_held_item()
 	if(istype(F))

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -392,10 +392,10 @@
 
 
 
-/mob/living/carbon/Xenomorph/proc/zoom_in(var/tileoffset = 5, var/viewsize = 12)
+/mob/living/carbon/Xenomorph/proc/zoom_in(tileoffset = 5, viewsize = 12)
 	if(stat || resting)
 		if(is_zoomed)
-			is_zoomed = 0
+			is_zoomed = FALSE
 			zoom_out()
 			return
 		return
@@ -404,31 +404,17 @@
 	if(!client)
 		return
 	zoom_turf = get_turf(src)
-	is_zoomed = 1
-	client.change_view(viewsize)
-	var/viewoffset = 32 * tileoffset
-	switch(dir)
-		if(NORTH)
-			client.pixel_x = 0
-			client.pixel_y = viewoffset
-		if(SOUTH)
-			client.pixel_x = 0
-			client.pixel_y = -viewoffset
-		if(EAST)
-			client.pixel_x = viewoffset
-			client.pixel_y = 0
-		if(WEST)
-			client.pixel_x = -viewoffset
-			client.pixel_y = 0
+	is_zoomed = TRUE
+	set_client_sight(viewsize, tileoffset, TRUE)
+
 
 /mob/living/carbon/Xenomorph/proc/zoom_out()
-	is_zoomed = 0
+	is_zoomed = FALSE
 	zoom_turf = null
 	if(!client)
 		return
-	client.change_view(world.view)
-	client.pixel_x = 0
-	client.pixel_y = 0
+	reset_client_sight()
+
 
 /mob/living/carbon/Xenomorph/drop_held_item()
 	var/obj/item/clothing/mask/facehugger/F = get_active_held_item()

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -381,14 +381,12 @@
 /mob/living/carbon/Xenomorph/proc/toggle_nightvision()
 	if(see_invisible == SEE_INVISIBLE_MINIMUM)
 		see_invisible = SEE_INVISIBLE_LEVEL_TWO //Turn it off.
-		see_in_dark = 4
-		sight |= SEE_MOBS
-		sight &= ~SEE_TURFS
-		sight &= ~SEE_OBJS
+		see_in_dark_modifier -= 6
+		update_see_in_dark()
 	else
 		see_invisible = SEE_INVISIBLE_MINIMUM
-		see_in_dark = 8
-		sight |= SEE_MOBS
+		see_in_dark_modifier += 6
+		update_see_in_dark()
 
 
 
@@ -405,7 +403,9 @@
 		return
 	zoom_turf = get_turf(src)
 	is_zoomed = TRUE
-	set_client_sight(viewsize, tileoffset, TRUE)
+	add_see_in_dark_modifier(viewsize + tileoffset + 1)
+	update_see_in_dark()
+	set_client_sight(viewsize, tileoffset)
 
 
 /mob/living/carbon/Xenomorph/proc/zoom_out()
@@ -413,6 +413,8 @@
 	zoom_turf = null
 	if(!client)
 		return
+	see_in_dark_modifier = 0
+	update_see_in_dark()
 	reset_client_sight()
 
 

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -381,11 +381,11 @@
 /mob/living/carbon/Xenomorph/proc/toggle_nightvision()
 	if(see_invisible == SEE_INVISIBLE_MINIMUM)
 		see_invisible = SEE_INVISIBLE_LEVEL_TWO //Turn it off.
-		see_in_dark_modifier -= 6
-		update_see_in_dark()
+		see_in_dark_modifiers.Add(-6)
+		update_see_in_dark(TRUE)
 	else
 		see_invisible = SEE_INVISIBLE_MINIMUM
-		see_in_dark_modifier += 6
+		see_in_dark_modifiers.Remove(-6)
 		update_see_in_dark()
 
 
@@ -403,7 +403,7 @@
 		return
 	zoom_turf = get_turf(src)
 	is_zoomed = TRUE
-	add_see_in_dark_modifier(viewsize + tileoffset + 1)
+	see_in_dark_modifiers.Add(viewsize + tileoffset + 1)
 	update_see_in_dark()
 	set_client_sight(viewsize, tileoffset)
 
@@ -413,7 +413,7 @@
 	zoom_turf = null
 	if(!client)
 		return
-	see_in_dark_modifier = 0
+	see_in_dark_modifiers.Cut()
 	update_see_in_dark()
 	reset_client_sight()
 

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -1,5 +1,6 @@
 /mob/living
 	see_invisible = SEE_INVISIBLE_LIVING
+	see_in_dark = 2
 
 	var/resize = 1 //Badminnery resize
 

--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -1,11 +1,11 @@
 
 /mob/living/Login()
-	. = ..()
+	..()
 	//Mind updates
 	mind_initialize()	//updates the mind (or creates and initializes one if one doesn't exist)
-	mind.active = TRUE		//indicates that the mind is currently synced with a client
+	mind.active = 1		//indicates that the mind is currently synced with a client
 
-	if(length(pipes_shown)) //ventcrawling, need to reapply pipe vision
+	if(pipes_shown && pipes_shown.len) //ventcrawling, need to reapply pipe vision
 		var/obj/machinery/atmospherics/A = loc
 		if(istype(A)) //a sanity check just to be safe
 			remove_ventcrawl()

--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -1,11 +1,11 @@
 
 /mob/living/Login()
-	..()
+	. = ..()
 	//Mind updates
 	mind_initialize()	//updates the mind (or creates and initializes one if one doesn't exist)
-	mind.active = 1		//indicates that the mind is currently synced with a client
+	mind.active = TRUE		//indicates that the mind is currently synced with a client
 
-	if(pipes_shown && pipes_shown.len) //ventcrawling, need to reapply pipe vision
+	if(length(pipes_shown)) //ventcrawling, need to reapply pipe vision
 		var/obj/machinery/atmospherics/A = loc
 		if(istype(A)) //a sanity check just to be safe
 			remove_ventcrawl()

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -35,8 +35,7 @@
 	client.screen = list()				//remove hud items just in case
 	if(!hud_used) 
 		create_hud()
-	if(hud_used) 
-		hud_used.show_hud(hud_used.hud_version)
+	hud_used?.show_hud(hud_used.hud_version)
 
 	log_message("[src] has logged in.", LOG_OOC)
 
@@ -46,12 +45,12 @@
 	sight |= SEE_SELF
 	. = ..()
 
-	reset_view(loc)
+	regenerate_client_view()
 
 	add_click_catcher()
 	refresh_huds()
 
-	if(client?.player_details)
+	if(client.player_details)
 		for(var/foo in client.player_details.post_login_callbacks)
 			var/datum/callback/CB = foo
 			CB.Invoke()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -190,7 +190,7 @@
 					W.flags_item |= NODROP
 				if(W.loc == start_loc && get_active_held_item() != W)
 					//They moved it from hands to an inv slot or vice versa. This will unzoom and unwield items -without- triggering lights.
-					if(CHECK_BITFIELD(W.flags_item, ITEM_ZOOMED))
+					if(W.item_zoomed)
 						unset_interaction()
 					if(W.flags_item & TWOHANDED)
 						W.unwield(src)
@@ -201,7 +201,7 @@
 			W.flags_item |= NODROP
 		if(W.loc == start_loc && get_active_held_item() != W)
 			//They moved it from hands to an inv slot or vice versa. This will unzoom and unwield items -without- triggering lights.
-			if(CHECK_BITFIELD(W.flags_item, ITEM_ZOOMED))
+			if(W.item_zoomed)
 				unset_interaction()
 			if(W.flags_item & TWOHANDED)
 				W.unwield(src)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -190,8 +190,8 @@
 					W.flags_item |= NODROP
 				if(W.loc == start_loc && get_active_held_item() != W)
 					//They moved it from hands to an inv slot or vice versa. This will unzoom and unwield items -without- triggering lights.
-					if(W.zoomed)
-						W.zoom(src)
+					if(CHECK_BITFIELD(W.flags_item, ITEM_ZOOMED))
+						unset_interaction()
 					if(W.flags_item & TWOHANDED)
 						W.unwield(src)
 		return TRUE
@@ -201,8 +201,8 @@
 			W.flags_item |= NODROP
 		if(W.loc == start_loc && get_active_held_item() != W)
 			//They moved it from hands to an inv slot or vice versa. This will unzoom and unwield items -without- triggering lights.
-			if(W.zoomed)
-				W.zoom(src)
+			if(CHECK_BITFIELD(W.flags_item, ITEM_ZOOMED))
+				unset_interaction()
 			if(W.flags_item & TWOHANDED)
 				W.unwield(src)
 		return TRUE

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -190,7 +190,7 @@
 					W.flags_item |= NODROP
 				if(W.loc == start_loc && get_active_held_item() != W)
 					//They moved it from hands to an inv slot or vice versa. This will unzoom and unwield items -without- triggering lights.
-					if(W.zoom)
+					if(W.zoomed)
 						W.zoom(src)
 					if(W.flags_item & TWOHANDED)
 						W.unwield(src)
@@ -201,7 +201,7 @@
 			W.flags_item |= NODROP
 		if(W.loc == start_loc && get_active_held_item() != W)
 			//They moved it from hands to an inv slot or vice versa. This will unzoom and unwield items -without- triggering lights.
-			if(W.zoom)
+			if(W.zoomed)
 				W.zoom(src)
 			if(W.flags_item & TWOHANDED)
 				W.unwield(src)
@@ -290,21 +290,6 @@
 		doUnEquip(I)
 		put_in_hands(I)
 		return TRUE
-
-
-/mob/proc/reset_view(atom/A)
-	if (client)
-		if (ismovableatom(A))
-			client.perspective = EYE_PERSPECTIVE
-			client.eye = A
-		else
-			if (isturf(loc))
-				client.eye = client.mob
-				client.perspective = MOB_PERSPECTIVE
-			else
-				client.perspective = EYE_PERSPECTIVE
-				client.eye = loc
-	return
 
 
 /mob/proc/show_inv(mob/user)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -6,6 +6,8 @@
 	animate_movement = 2
 	datum_flags = DF_USE_TAG
 	var/datum/mind/mind
+	var/list/client_vars = list()
+	var/obj/item/zoom
 
 	var/datum/click_intercept
 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -196,3 +196,6 @@
 	var/typing
 	var/last_typed
 	var/last_typed_time
+
+	var/is_zoomed = 0
+	var/zoom_turf

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -184,7 +184,7 @@
 
 	var/accuracy_modifier = 0 //Applies a penalty or bonus to projectile accuracy in projectile.dm
 	var/scatter_modifier = 0 //Applies a penalty or bonus to scatter probability in gun_system.dm
-	var/see_in_dark_modifier = 0 //Somthing has modified the basic sight of this mob.
+	var/list/see_in_dark_modifiers = list() //Somthing has modified the basic sight of this mob.
 	var/list/see_invisible_modifiers = list()
 
 	var/list/fullscreens = list()

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -7,7 +7,6 @@
 	datum_flags = DF_USE_TAG
 	var/datum/mind/mind
 	var/list/client_vars = list()
-	var/obj/item/zoom
 
 	var/datum/click_intercept
 
@@ -185,6 +184,8 @@
 
 	var/accuracy_modifier = 0 //Applies a penalty or bonus to projectile accuracy in projectile.dm
 	var/scatter_modifier = 0 //Applies a penalty or bonus to scatter probability in gun_system.dm
+	var/see_in_dark_modifier = 0 //Somthing has modified the basic sight of this mob.
+	var/list/see_invisible_modifiers = list()
 
 	var/list/fullscreens = list()
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -152,7 +152,7 @@
 	// If mob moves while zoomed in with device, unzoom them.
 	if(view != world.view || pixel_x || pixel_y)
 		for(var/obj/item/item in mob.contents)
-			if(item.zoom)
+			if(item.zoomed)
 				item.zoom(mob)
 				click_intercept = null
 				break

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -152,9 +152,8 @@
 	// If mob moves while zoomed in with device, unzoom them.
 	if(view != world.view || pixel_x || pixel_y)
 		for(var/obj/item/item in mob.contents)
-			if(item.zoomed)
-				item.zoom(mob)
-				click_intercept = null
+			if(CHECK_BITFIELD(item.flags_item, ITEM_ZOOMED))
+				mob.unset_interaction()
 				break
 
 	//Check if you are being grabbed and if so attemps to break it

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -152,7 +152,7 @@
 	// If mob moves while zoomed in with device, unzoom them.
 	if(view != world.view || pixel_x || pixel_y)
 		for(var/obj/item/item in mob.contents)
-			if(CHECK_BITFIELD(item.flags_item, ITEM_ZOOMED))
+			if(item.item_zoomed)
 				mob.unset_interaction()
 				break
 

--- a/code/modules/mob/mob_procs.dm
+++ b/code/modules/mob/mob_procs.dm
@@ -1,0 +1,159 @@
+#define CLIENT_VIEW_INDEX "view"
+#define CLIENT_PIXEL_X_INDEX "pixel_x"
+#define CLIENT_PIXEL_Y_INDEX "pixel_y"
+#define CLIENT_CLICK_INTERCEPT_INDEX "click_intercept"
+#define CLIENT_PERSPECTIVE_INDEX "perspective"
+#define CLIENT_EYE_INDEX "eye"
+
+#define TILESIZE 32
+
+
+/mob/proc/regenerate_client_sight()
+
+
+/mob/proc/reset_client_sight()
+    see_in_dark = initial(see_in_dark)
+    see_invisible = see_in_dark > 2 ? SEE_INVISIBLE_LEVEL_ONE : SEE_INVISIBLE_LIVING
+    if(!client)
+        reset_client_sight_no_client() //Preserve the values in case they return.
+        return
+    client.change_view(world.view)
+    client.pixel_x = 0
+    client.pixel_y = 0
+    client.click_intercept = null
+    client_vars.Remove(CLIENT_VIEW_INDEX, CLIENT_PIXEL_X_INDEX, CLIENT_PIXEL_Y_INDEX, CLIENT_CLICK_INTERCEPT_INDEX) //No need to store the info in the mob anymore.
+
+
+/mob/proc/reset_client_sight_no_client()
+    client_vars[CLIENT_VIEW_INDEX] = world.view
+    client_vars[CLIENT_PIXEL_X_INDEX] = 0
+    client_vars[CLIENT_PIXEL_Y_INDEX] = 0
+    client_vars[CLIENT_CLICK_INTERCEPT_INDEX] = null
+
+
+/mob/proc/set_client_sight(viewsize, tileoffset)
+    see_in_dark = viewsize + tileoffset + 1 //That extra one so they can see the edge of the screen.
+    see_invisible = min(see_invisible, SEE_INVISIBLE_OBSERVER_NOLIGHTING)
+    if(!client)
+        set_client_sight_no_client(viewsize, tileoffset)
+        return
+    client.change_view(viewsize)
+    var/viewoffset = TILESIZE * tileoffset
+    switch(dir)
+        if(NORTH)
+            client.pixel_x = 0
+            client.pixel_y = viewoffset
+        if(SOUTH)
+            client.pixel_x = 0
+            client.pixel_y = -viewoffset
+        if(EAST)
+            client.pixel_x = viewoffset
+            client.pixel_y = 0
+        if(WEST)
+            client.pixel_x = -viewoffset
+            client.pixel_y = 0
+
+
+/mob/proc/set_client_sight_no_client(viewsize, tileoffset)
+    client_vars[CLIENT_VIEW_INDEX] = viewsize
+    var/viewoffset = TILESIZE * tileoffset
+    switch(dir)
+        if(NORTH)
+            client_vars[CLIENT_PIXEL_X_INDEX] = 0
+            client_vars[CLIENT_PIXEL_Y_INDEX] = viewoffset
+        if(SOUTH)
+            client_vars[CLIENT_PIXEL_X_INDEX] = 0
+            client_vars[CLIENT_PIXEL_Y_INDEX] = -viewoffset
+        if(EAST)
+            client_vars[CLIENT_PIXEL_X_INDEX] = viewoffset
+            client_vars[CLIENT_PIXEL_Y_INDEX] = 0
+        if(WEST)
+            client_vars[CLIENT_PIXEL_X_INDEX] = -viewoffset
+            client_vars[CLIENT_PIXEL_Y_INDEX] = 0
+
+
+/mob/proc/regenerate_client_view()
+    if(client_vars[CLIENT_PERSPECTIVE_INDEX] && client_vars[CLIENT_EYE_INDEX]) //Check if we've saved a view to load from.
+        client.perspective = client_vars[CLIENT_PERSPECTIVE_INDEX]
+        client.eye = client_vars[CLIENT_EYE_INDEX]
+        return
+    reset_view(loc) //If we haven't, reset to normal.
+
+
+/mob/living/carbon/Xenomorph/Queen/regenerate_client_view()
+    reset_view(loc) //Queens have their own handling, with observed_xeno and all.
+
+
+/mob/proc/reset_view(atom/A)
+    if(!client)
+        reset_view_no_client(A)
+        return
+    if(ismovableatom(A))
+        client.perspective = EYE_PERSPECTIVE
+        client.eye = A
+    else if(isturf(loc))
+        client.perspective = MOB_PERSPECTIVE
+        client.eye = client.mob
+    else
+        client.perspective = EYE_PERSPECTIVE
+        client.eye = loc
+    client_vars.Remove(CLIENT_PERSPECTIVE_INDEX, CLIENT_EYE_INDEX) //Clean saved client vars, as we are resetting.
+
+
+/mob/living/carbon/Xenomorph/Queen/reset_view(atom/A)
+	if(!client)
+		reset_view_no_client(A)
+	if(ovipositor && observed_xeno && !stat)
+		client.perspective = EYE_PERSPECTIVE
+		client.eye = observed_xeno
+	else
+		return ..()
+
+
+/mob/proc/reset_view_no_client(atom/A)
+    if(ismovableatom(A))
+        client_vars[CLIENT_PERSPECTIVE_INDEX] = EYE_PERSPECTIVE
+        client_vars[CLIENT_EYE_INDEX] = A
+    else if(isturf(loc))
+        client_vars[CLIENT_PERSPECTIVE_INDEX] = MOB_PERSPECTIVE
+        client_vars[CLIENT_EYE_INDEX] = src
+    else
+        client_vars[CLIENT_PERSPECTIVE_INDEX] = EYE_PERSPECTIVE
+        client_vars[CLIENT_EYE_INDEX] = loc
+
+
+/mob/living/carbon/Xenomorph/Queen/reset_view_no_client(atom/A)
+	if(ovipositor && observed_xeno && !stat)
+		client_vars[CLIENT_PERSPECTIVE_INDEX] = EYE_PERSPECTIVE
+        client_vars[CLIENT_EYE_INDEX] = observed_xeno
+	else
+		return ..()
+
+
+//==//==//
+
+/mob/proc/save_client_sight()
+    client_vars[CLIENT_VIEW_INDEX] = client.view
+    client_vars[CLIENT_PIXEL_X_INDEX] = client.pixel_x
+    client_vars[CLIENT_PIXEL_Y_INDEX] = client.pixel_y
+    client_vars[CLIENT_CLICK_INTERCEPT_INDEX] = client.click_intercept
+
+
+/mob/proc/load_client_sight()
+    for(var/i in client_vars)
+        switch(i)
+            if(CLIENT_VIEW_INDEX)
+                client.view = client_vars[CLIENT_VIEW_INDEX]
+            if(CLIENT_PIXEL_X_INDEX)
+                client.pixel_x = client_vars[CLIENT_PIXEL_X_INDEX]
+            if(CLIENT_PIXEL_Y_INDEX)
+                client.pixel_y = client_vars[CLIENT_PIXEL_Y_INDEX]
+            if(CLIENT_CLICK_INTERCEPT_INDEX)
+                client.click_intercept = client_vars[CLIENT_CLICK_INTERCEPT_INDEX]
+
+
+
+#undef CLIENT_VIEW_INDEX
+#undef CLIENT_PIXEL_X_INDEX
+#undef CLIENT_PIXEL_Y_INDEX
+#undef CLIENT_CLICK_INTERCEPT_INDEX

--- a/code/modules/mob/mob_procs.dm
+++ b/code/modules/mob/mob_procs.dm
@@ -169,6 +169,40 @@
 	return
 
 
+/mob/proc/zoom_in(viewsize = 12, tileoffset = 11)
+	set_client_sight(viewsize, tileoffset)
+    is_zoomed = TRUE
+    zoom_turf = get_turf(src)
+
+
+/mob/living/carbon/Xenomorph/zoom_in(viewsize = 12, tileoffset = 5)
+	if(stat || resting)
+		if(is_zoomed)
+			is_zoomed = FALSE
+			zoom_out()
+			return
+		return
+	if(is_zoomed)
+		return
+	if(!client)
+		return
+	see_in_dark_modifiers.Add(viewsize + tileoffset + 1)
+	update_see_in_dark()
+	return ..()
+
+
+/mob/proc/zoom_out()
+    reset_client_sight()
+	is_zoomed = FALSE
+	zoom_turf = null
+
+
+/mob/living/carbon/Xenomorph/zoom_out()
+	see_in_dark_modifiers.Cut()
+	update_see_in_dark()
+	return ..()
+
+
 #undef CLIENT_VIEW_INDEX
 #undef CLIENT_PIXEL_X_INDEX
 #undef CLIENT_PIXEL_Y_INDEX

--- a/code/modules/mob/mob_procs.dm
+++ b/code/modules/mob/mob_procs.dm
@@ -10,7 +10,6 @@
 
 /mob/proc/reset_client_sight()
     see_in_dark = initial(see_in_dark) + see_in_dark_modifier
-    see_invisible = see_in_dark > 2 ? SEE_INVISIBLE_LEVEL_ONE : SEE_INVISIBLE_LIVING
     if(!client)
         reset_client_sight_no_client() //Preserve the values in case they return.
         return
@@ -44,7 +43,6 @@
 /mob/proc/set_client_sight(viewsize, tileoffset, darkvision)
     if(darkvision)
         see_in_dark = max(viewsize + tileoffset + 1, see_in_dark + see_in_dark_modifier) //That extra one so they can see the edge of the screen.
-        see_invisible = min(see_invisible, SEE_INVISIBLE_OBSERVER_NOLIGHTING)
     if(!client)
         set_client_sight_no_client(viewsize, tileoffset)
         return

--- a/code/modules/mob/mob_procs.dm
+++ b/code/modules/mob/mob_procs.dm
@@ -8,20 +8,18 @@
 #define TILESIZE 32
 
 
-/mob/proc/update_see_in_dark()
-    see_in_dark = initial(see_in_dark) + see_in_dark_modifier
+/mob/proc/update_see_in_dark(choose_minium_value = FALSE)
+    var/modifier = 0
+    if(choose_minium_value)
+        for(var/i in see_in_dark_modifiers)
+            if(i < modifier)
+                modifier = i
+    else
+        for(var/i in see_in_dark_modifiers)
+            if(i > modifier)
+                modifier = i
+    see_in_dark = initial(see_in_dark) + modifier
 
-
-/mob/proc/add_see_in_dark_modifier(value)
-    if(value <= 0)
-        return
-    see_in_dark_modifier += value
-
-
-/mob/proc/remove_see_in_dark_modifier(value)
-    if(value >= 0)
-        return
-    see_in_dark_modifier -= value
 
 /mob/proc/reset_client_sight()
     update_see_in_dark()

--- a/code/modules/mob/mob_procs.dm
+++ b/code/modules/mob/mob_procs.dm
@@ -8,8 +8,23 @@
 #define TILESIZE 32
 
 
-/mob/proc/reset_client_sight()
+/mob/proc/update_see_in_dark()
     see_in_dark = initial(see_in_dark) + see_in_dark_modifier
+
+
+/mob/proc/add_see_in_dark_modifier(value)
+    if(value <= 0)
+        return
+    see_in_dark_modifier += value
+
+
+/mob/proc/remove_see_in_dark_modifier(value)
+    if(value >= 0)
+        return
+    see_in_dark_modifier -= value
+
+/mob/proc/reset_client_sight()
+    update_see_in_dark()
     if(!client)
         reset_client_sight_no_client() //Preserve the values in case they return.
         return
@@ -40,9 +55,7 @@
                 client.click_intercept = client_vars[CLIENT_CLICK_INTERCEPT_INDEX]
 
 
-/mob/proc/set_client_sight(viewsize, tileoffset, darkvision)
-    if(darkvision)
-        see_in_dark = max(viewsize + tileoffset + 1, see_in_dark + see_in_dark_modifier) //That extra one so they can see the edge of the screen.
+/mob/proc/set_client_sight(viewsize, tileoffset)
     if(!client)
         set_client_sight_no_client(viewsize, tileoffset)
         return
@@ -152,31 +165,6 @@
 	for(var/i in see_invisible_modifiers)
 		if(i < see_invisible)
 			see_invisible = i
-
-
-//==//==//
-
-/mob/proc/save_client_sight()
-    client_vars[CLIENT_VIEW_INDEX] = client.view
-    client_vars[CLIENT_PIXEL_X_INDEX] = client.pixel_x
-    client_vars[CLIENT_PIXEL_Y_INDEX] = client.pixel_y
-    client_vars[CLIENT_CLICK_INTERCEPT_INDEX] = client.click_intercept
-
-
-/mob/proc/load_client_sight()
-    for(var/i in client_vars)
-        switch(i)
-            if(CLIENT_VIEW_INDEX)
-                client.view = client_vars[CLIENT_VIEW_INDEX]
-            if(CLIENT_PIXEL_X_INDEX)
-                client.pixel_x = client_vars[CLIENT_PIXEL_X_INDEX]
-            if(CLIENT_PIXEL_Y_INDEX)
-                client.pixel_y = client_vars[CLIENT_PIXEL_Y_INDEX]
-            if(CLIENT_CLICK_INTERCEPT_INDEX)
-                client.click_intercept = client_vars[CLIENT_CLICK_INTERCEPT_INDEX]
-
-
-//==//==//
 
 
 /mob/proc/update_sight()

--- a/code/modules/mob/mob_transformation_simple.dm
+++ b/code/modules/mob/mob_transformation_simple.dm
@@ -24,8 +24,7 @@
 		mind.transfer_to(M, TRUE)
 	else
 		M.key = key
-		if(M.client) 
-			M.client.change_view(world.view)
+		M.reset_client_sight()
 
 	if(istext(new_name))
 		M.name = new_name

--- a/code/modules/mob/mob_verbs.dm
+++ b/code/modules/mob/mob_verbs.dm
@@ -124,8 +124,7 @@
 		return
 
 	M.key = key
-	if(M.client)
-		M.client.change_view(world.view)
+	M.reset_client_sight()
 	return
 
 

--- a/code/modules/projectiles/updated_projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_attachables.dm
@@ -554,11 +554,11 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/scope/activate_attachment(obj/item/weapon/gun/G, mob/living/carbon/user, turn_off)
 	if(turn_off)
-		if(G.zoom)
+		if(G.zoomed)
 			G.zoom(user, zoom_offset, zoom_viewsize)
 		return TRUE
 
-	if(!G.zoom && !(G.flags_item & WIELDED))
+	if(!G.zoomed && !(G.flags_item & WIELDED))
 		if(user)
 			to_chat(user, "<span class='warning'>You must hold [G] with two hands to use [src].</span>")
 		return FALSE
@@ -1356,7 +1356,7 @@ Defined in conflicts.dm of the #defines folder.
 	. = ..()
 	if(istype(rail,/obj/item/attachable/scope))
 		var/obj/item/attachable/scope/S = rail
-		if(zoom)
+		if(zoomed)
 			S.accuracy_mod = S.zoom_accuracy
 		else
 			S.accuracy_mod = 0

--- a/code/modules/projectiles/updated_projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_attachables.dm
@@ -558,11 +558,11 @@ Defined in conflicts.dm of the #defines folder.
 			to_chat(user, "<span class='warning'>You must hold [G] with two hands to use [src].</span>")
 		return FALSE
 	
-	zoom(user, zoom_offset, zoom_viewsize, CHECK_BITFIELD(flags_item, ITEM_ZOOM_NIGHTVISION))
+	zoom(user, zoom_viewsize, zoom_offset, CHECK_BITFIELD(flags_item, ITEM_ZOOM_NIGHTVISION))
 	return TRUE
 
 
-/obj/item/attachable/scope/zoom(mob/living/user, tileoffset = 11, viewsize = 12) //this is so the accuracy modifiers for the scopes apply correctly
+/obj/item/attachable/scope/zoom(mob/living/user, viewsize = 12, tileoffset = 11) //this is so the accuracy modifiers for the scopes apply correctly
 	. = ..()
 	attached_to.accuracy_mod += zoom_accuracy
 

--- a/code/modules/projectiles/updated_projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_attachables.dm
@@ -549,7 +549,7 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/scope/activate_attachment(obj/item/weapon/gun/G, mob/living/carbon/user, turn_off)
 	if(turn_off)
-		if(CHECK_BITFIELD(flags_item, ITEM_ZOOMED))
+		if(item_zoomed)
 			user.unset_interaction()
 		return TRUE
 

--- a/code/modules/projectiles/updated_projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_helpers.dm
@@ -539,7 +539,7 @@ should be alright.
 	if(usr.action_busy)
 		return
 
-	if(CHECK_BITFIELD(flags_item, ITEM_ZOOMED))
+	if(item_zoomed)
 		to_chat(usr, "<span class='warning'>You cannot conceviably do that while looking down \the [src]'s scope!</span>")
 		return
 
@@ -577,7 +577,7 @@ should be alright.
 	if(usr.action_busy)
 		return
 
-	if(CHECK_BITFIELD(flags_item, ITEM_ZOOMED))
+	if(item_zoomed)
 		return
 
 	if(A != rail && A != muzzle && A != under && A != stock)
@@ -604,7 +604,7 @@ should be alright.
 	if(!(A.flags_attach_features & ATTACH_REMOVABLE))
 		return
 
-	if(CHECK_BITFIELD(flags_item, ITEM_ZOOMED))
+	if(item_zoomed)
 		return
 
 	usr.visible_message("<span class='notice'>[usr] strips [A] from [src].</span>",

--- a/code/modules/projectiles/updated_projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_helpers.dm
@@ -539,7 +539,7 @@ should be alright.
 	if(usr.action_busy)
 		return
 
-	if(zoom)
+	if(zoomed)
 		to_chat(usr, "<span class='warning'>You cannot conceviably do that while looking down \the [src]'s scope!</span>")
 		return
 
@@ -577,7 +577,7 @@ should be alright.
 	if(usr.action_busy)
 		return
 
-	if(zoom)
+	if(zoomed)
 		return
 
 	if(A != rail && A != muzzle && A != under && A != stock)
@@ -604,7 +604,7 @@ should be alright.
 	if(!(A.flags_attach_features & ATTACH_REMOVABLE))
 		return
 
-	if(zoom)
+	if(zoomed)
 		return
 
 	usr.visible_message("<span class='notice'>[usr] strips [A] from [src].</span>",

--- a/code/modules/projectiles/updated_projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_helpers.dm
@@ -539,7 +539,7 @@ should be alright.
 	if(usr.action_busy)
 		return
 
-	if(zoomed)
+	if(CHECK_BITFIELD(flags_item, ITEM_ZOOMED))
 		to_chat(usr, "<span class='warning'>You cannot conceviably do that while looking down \the [src]'s scope!</span>")
 		return
 
@@ -577,7 +577,7 @@ should be alright.
 	if(usr.action_busy)
 		return
 
-	if(zoomed)
+	if(CHECK_BITFIELD(flags_item, ITEM_ZOOMED))
 		return
 
 	if(A != rail && A != muzzle && A != under && A != stock)
@@ -604,7 +604,7 @@ should be alright.
 	if(!(A.flags_attach_features & ATTACH_REMOVABLE))
 		return
 
-	if(zoomed)
+	if(CHECK_BITFIELD(flags_item, ITEM_ZOOMED))
 		return
 
 	usr.visible_message("<span class='notice'>[usr] strips [A] from [src].</span>",

--- a/code/modules/projectiles/updated_projectiles/gun_system.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_system.dm
@@ -291,7 +291,7 @@
 
 	if((flags_item|TWOHANDED|WIELDED) != flags_item)
 		return //Have to be actually a twohander and wielded.
-	if(CHECK_BITFIELD(flags_item, ITEM_ZOOMED))
+	if(item_zoomed)
 		user.unset_interaction()
 	flags_item ^= WIELDED
 	name 	    = copytext(name, 1, -10)

--- a/code/modules/projectiles/updated_projectiles/gun_system.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_system.dm
@@ -291,7 +291,7 @@
 
 	if((flags_item|TWOHANDED|WIELDED) != flags_item)
 		return //Have to be actually a twohander and wielded.
-	if(zoom)
+	if(zoomed)
 		zoom(user)
 	flags_item ^= WIELDED
 	name 	    = copytext(name, 1, -10)

--- a/code/modules/projectiles/updated_projectiles/gun_system.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_system.dm
@@ -291,8 +291,8 @@
 
 	if((flags_item|TWOHANDED|WIELDED) != flags_item)
 		return //Have to be actually a twohander and wielded.
-	if(zoomed)
-		zoom(user)
+	if(CHECK_BITFIELD(flags_item, ITEM_ZOOMED))
+		user.unset_interaction()
 	flags_item ^= WIELDED
 	name 	    = copytext(name, 1, -10)
 	item_state  = copytext(item_state, 1, -2)

--- a/code/modules/projectiles/updated_projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/specialist.dm
@@ -23,7 +23,6 @@
 	current_mag = /obj/item/ammo_magazine/sniper
 	force = 12
 	wield_delay = 12 //Ends up being 1.6 seconds due to scope
-	zoomdevicename = "scope"
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 18,"rail_x" = 12, "rail_y" = 20, "under_x" = 19, "under_y" = 14, "stock_x" = 19, "stock_y" = 14)
 	var/targetmarker_on = FALSE
 	var/targetmarker_primed = FALSE
@@ -122,7 +121,7 @@
 	. = ..()
 
 /obj/item/weapon/gun/rifle/sniper/M42A/process()
-	if(!zoomed)
+	if(!CHECK_BITFIELD(flags_item, ITEM_ZOOMED))
 		laser_off()
 		return
 	var/mob/living/user = loc
@@ -140,7 +139,7 @@
 
 /obj/item/weapon/gun/rifle/sniper/M42A/zoom(mob/living/user, tileoffset = 11, viewsize = 12) //tileoffset is client view offset in the direction the user is facing. viewsize is how far out this thing zooms. 7 is normal view
 	. = ..()
-	if(!zoomed && (targetmarker_on || targetmarker_primed) )
+	if(!CHECK_BITFIELD(flags_item, ITEM_ZOOMED) && (targetmarker_on || targetmarker_primed) )
 		laser_off(user)
 
 /atom/proc/sniper_target(atom/A)
@@ -155,7 +154,7 @@
 		return TRUE
 
 /obj/item/weapon/gun/rifle/sniper/M42A/proc/laser_on(mob/user)
-	if(!zoomed) //Can only use and prime the laser targeter when zoomed.
+	if(!CHECK_BITFIELD(flags_item, ITEM_ZOOMED)) //Can only use and prime the laser targeter when zoomed.
 		to_chat(user, "<span class='warning'>You must be zoomed in to use your target marker!</span>")
 		return
 	targetmarker_primed = TRUE //We prime the target laser
@@ -202,7 +201,6 @@
 	fire_sound = 'sound/weapons/sniper_heavy.ogg'
 	current_mag = /obj/item/ammo_magazine/sniper/elite
 	force = 17
-	zoomdevicename = "scope"
 	attachable_allowed = list()
 	flags_gun_features = GUN_AUTO_EJECTOR|GUN_WIELDED_FIRING_ONLY
 	attachable_offset = list("muzzle_x" = 32, "muzzle_y" = 18,"rail_x" = 15, "rail_y" = 19, "under_x" = 20, "under_y" = 15, "stock_x" = 20, "stock_y" = 15)

--- a/code/modules/projectiles/updated_projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/specialist.dm
@@ -122,7 +122,7 @@
 	. = ..()
 
 /obj/item/weapon/gun/rifle/sniper/M42A/process()
-	if(!zoom)
+	if(!zoomed)
 		laser_off()
 		return
 	var/mob/living/user = loc
@@ -140,7 +140,7 @@
 
 /obj/item/weapon/gun/rifle/sniper/M42A/zoom(mob/living/user, tileoffset = 11, viewsize = 12) //tileoffset is client view offset in the direction the user is facing. viewsize is how far out this thing zooms. 7 is normal view
 	. = ..()
-	if(!zoom && (targetmarker_on || targetmarker_primed) )
+	if(!zoomed && (targetmarker_on || targetmarker_primed) )
 		laser_off(user)
 
 /atom/proc/sniper_target(atom/A)
@@ -155,7 +155,7 @@
 		return TRUE
 
 /obj/item/weapon/gun/rifle/sniper/M42A/proc/laser_on(mob/user)
-	if(!zoom) //Can only use and prime the laser targeter when zoomed.
+	if(!zoomed) //Can only use and prime the laser targeter when zoomed.
 		to_chat(user, "<span class='warning'>You must be zoomed in to use your target marker!</span>")
 		return
 	targetmarker_primed = TRUE //We prime the target laser

--- a/code/modules/projectiles/updated_projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/specialist.dm
@@ -137,7 +137,7 @@
 		to_chat(user, "<span class='danger'>You lose sight of your target!</span>")
 		playsound(user,'sound/machines/click.ogg', 25, 1)
 
-/obj/item/weapon/gun/rifle/sniper/M42A/zoom(mob/living/user, tileoffset = 11, viewsize = 12) //tileoffset is client view offset in the direction the user is facing. viewsize is how far out this thing zooms. 7 is normal view
+/obj/item/weapon/gun/rifle/sniper/M42A/zoom(mob/living/user, viewsize = 12, tileoffset = 11) //tileoffset is client view offset in the direction the user is facing. viewsize is how far out this thing zooms. 7 is normal view
 	. = ..()
 	if(!item_zoomed && (targetmarker_on || targetmarker_primed) )
 		laser_off(user)

--- a/code/modules/projectiles/updated_projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/specialist.dm
@@ -121,7 +121,7 @@
 	. = ..()
 
 /obj/item/weapon/gun/rifle/sniper/M42A/process()
-	if(!CHECK_BITFIELD(flags_item, ITEM_ZOOMED))
+	if(!item_zoomed)
 		laser_off()
 		return
 	var/mob/living/user = loc
@@ -139,7 +139,7 @@
 
 /obj/item/weapon/gun/rifle/sniper/M42A/zoom(mob/living/user, tileoffset = 11, viewsize = 12) //tileoffset is client view offset in the direction the user is facing. viewsize is how far out this thing zooms. 7 is normal view
 	. = ..()
-	if(!CHECK_BITFIELD(flags_item, ITEM_ZOOMED) && (targetmarker_on || targetmarker_primed) )
+	if(!item_zoomed && (targetmarker_on || targetmarker_primed) )
 		laser_off(user)
 
 /atom/proc/sniper_target(atom/A)
@@ -154,7 +154,7 @@
 		return TRUE
 
 /obj/item/weapon/gun/rifle/sniper/M42A/proc/laser_on(mob/user)
-	if(!CHECK_BITFIELD(flags_item, ITEM_ZOOMED)) //Can only use and prime the laser targeter when zoomed.
+	if(!item_zoomed) //Can only use and prime the laser targeter when zoomed.
 		to_chat(user, "<span class='warning'>You must be zoomed in to use your target marker!</span>")
 		return
 	targetmarker_primed = TRUE //We prime the target laser

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -1049,6 +1049,7 @@
 #include "code\modules\mob\mob_grab.dm"
 #include "code\modules\mob\mob_helpers.dm"
 #include "code\modules\mob\mob_movement.dm"
+#include "code\modules\mob\mob_procs.dm"
 #include "code\modules\mob\mob_status_procs.dm"
 #include "code\modules\mob\mob_transformation_simple.dm"
 #include "code\modules\mob\mob_verbs.dm"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This all started with me trying to give binoculars night vision, prevent clients disconnecting from causing vision bugs, and finding a lot of things that could be improved on the way.

* Moved client procs to mob procs, in case the mob's client disconnects. In some cases the variables are saved and will be regenerated when the client returns.
* Sort of standardized sight/vision procs to have less repeated code.
* Removed periodic life-proc vision updates in favor of the things altering them updating them.
* Added modifiers list mob vars to track for when several things modify the same thing on a mob (like several items that impact on night vision on the same mob).
* Zooming attachables are now interacted with directly, instead of through the gun.

## Why It's Good For The Game

It's an attempt to make things a little more sane, but I'm skeptical I've gotten too far with it.

## Changelog
:cl:
tweak: Binoculars offer nightvision. Useful for spotters.
balance: Night-vision googles lost their meson-sight (seeing the terrain past dense obstacles). The smartgunner, though, gets nightvision up to the edge of the screen now.
/:cl: