### PR TITLE
Spitter plasma rebalance

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
@@ -19,8 +19,8 @@
 	speed = -0.5
 
 	// *** Plasma *** //
-	plasma_max = 800
-	plasma_gain = 25
+	plasma_max = 600
+	plasma_gain = 20
 
 	// *** Health *** //
 	max_health = 180
@@ -66,8 +66,8 @@
 	speed = -0.6
 
 	// *** Plasma *** //
-	plasma_max = 1000
-	plasma_gain = 30
+	plasma_max = 750
+	plasma_gain = 24
 
 	// *** Health *** //
 	max_health = 220
@@ -100,8 +100,8 @@
 	speed = -0.7
 
 	// *** Plasma *** //
-	plasma_max = 1100
-	plasma_gain = 33
+	plasma_max = 825
+	plasma_gain = 27
 
 	// *** Health *** //
 	max_health = 240
@@ -134,8 +134,8 @@
 	speed = -0.8
 
 	// *** Plasma *** //
-	plasma_max = 1150
-	plasma_gain = 35
+	plasma_max = 875
+	plasma_gain = 28
 
 	// *** Health *** //
 	max_health = 250

--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
@@ -19,8 +19,8 @@
 	speed = -0.5
 
 	// *** Plasma *** //
-	plasma_max = 600
-	plasma_gain = 20
+	plasma_max = 650
+	plasma_gain = 21
 
 	// *** Health *** //
 	max_health = 180
@@ -66,8 +66,8 @@
 	speed = -0.6
 
 	// *** Plasma *** //
-	plasma_max = 750
-	plasma_gain = 24
+	plasma_max = 800
+	plasma_gain = 25
 
 	// *** Health *** //
 	max_health = 220
@@ -100,8 +100,8 @@
 	speed = -0.7
 
 	// *** Plasma *** //
-	plasma_max = 825
-	plasma_gain = 27
+	plasma_max = 875
+	plasma_gain = 28
 
 	// *** Health *** //
 	max_health = 240
@@ -134,8 +134,8 @@
 	speed = -0.8
 
 	// *** Plasma *** //
-	plasma_max = 875
-	plasma_gain = 28
+	plasma_max = 925
+	plasma_gain = 29
 
 	// *** Health *** //
 	max_health = 250

--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
@@ -135,7 +135,7 @@
 
 	// *** Plasma *** //
 	plasma_max = 925
-	plasma_gain = 29
+	plasma_gain = 30
 
 	// *** Health *** //
 	max_health = 250

--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -1329,7 +1329,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 /datum/ammo/xeno/acid/heavy
 	name = "acid splash"
 	added_spit_delay = 8
-	spit_cost = 100
+	spit_cost = 75
 	flags_ammo_behavior = AMMO_XENO_ACID|AMMO_EXPLOSIVE
 
 /datum/ammo/xeno/acid/heavy/New()


### PR DESCRIPTION

## About The Pull Request

- Buffs heavy spit plasma cost from 100 to 75
- nerfs spitter plasma from 800 - 1150 to 650 - 925
- nerfs spitter plasma regen from 25 - 35 to 21 - 30

## Why It's Good For The Game

This makes it so the spitter doesn't have an obscene amount of plasma for seemingly no reason. This is mainly aimed at making drones and hivelords more useful as a support role. Currently at higher maturity levels spitter has so much plasma that drones and even hivelords struggle to fill them back up. They also had more plasma than praetorians, which makes little sense. This makes it so praetorians aren't necessarily worse at spitting than spitters, as their plasma remains the same.

I didn't nerf regen and plasma by 25% (about 15-20% instead) due to the existence of a 300 plasma acid spray. This ability is on a long cooldown, and shouldn't just be spammed like spit. I also felt like 30-ish seconds to recover your plasma as a spitter made gameplay a bit too slow unless you had recovery pheromones.

## Changelog
:cl:
balance:  Acid spit is now cheaper. Praetorians can spit acid longer, whilst spitters get lower plasma and regen to compensate. This should make it easier for drones and hivelords to keep spitters topped off.
/:cl:
