### PR TITLE
Thin Sticky Rebalance

### DIFF
--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -145,7 +145,7 @@
 /obj/effect/alien/resin/sticky/thin
 	name = "thin sticky resin"
 	desc = "A thin layer of disgusting sticky slime."
-	health = 7
+	health = 6
 	slow_amt = 4
 
 


### PR DESCRIPTION
## About The Pull Request

Lowers thin sticky health by 1 point. The result of this is that it takes 1 combat knife hit to clear it instead of 2. 
## Why It's Good For The Game

Makes it easier to clear thin sticky, which is considerably more easily spammed than it used to be. 

## Changelog
:cl:
balance: Thin Sticky Resin clears in one knife hit
/:cl:
