### PR TITLE
Properly prevent multiple APC from being constructed in the same area.

### DIFF
--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -352,7 +352,7 @@
 
 /area/proc/get_apc()
 	for(var/obj/machinery/power/apc/APC in GLOB.apcs_list)
-		if(APC.area == src)
+		if(APC.area == src.master)
 			return APC
 
 


### PR DESCRIPTION
## About The Pull Request

Out of curiosity, i checked the current state of APC construction and found the multiples APC bug was a one word fix, so there you go.
It's really time sub`areas` are removed.

## Changelog
:cl: Menshin
fix: you can no longer construct multiple APCs in the same area
/:cl:
