### PR TITLE
Fixes break_lights() proc

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -162,7 +162,7 @@ Status: [status ? status : "Unknown"] | Damage: [health ? health : "None"]
 				log_admin("[key_name(usr)] broke all lights.")
 				message_admins("[ADMIN_TPMONTY(usr)] broke all lights.")
 				for(var/obj/machinery/power/apc/apc in GLOB.machines)
-					apc.overload_lighting()
+					apc.break_lights()
 			if("whiteout")
 				log_admin("[key_name(usr)] fixed all lights.")
 				message_admins("[ADMIN_TPMONTY(usr)] fixed all lights.")

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1248,11 +1248,12 @@
 		INVOKE_ASYNC(src, .proc/break_lights)
 
 /obj/machinery/power/apc/proc/break_lights()
-	for(var/obj/machinery/light/L in area.related)
-		L.on = TRUE
-		L.broken()
-		L.on = FALSE
-		stoplag()
+	for(var/a in area.related)
+		var/area/A = a
+		for(var/obj/machinery/light/L in A)
+			L.broken()
+			L.on = FALSE
+			stoplag()
 
 /obj/machinery/power/apc/disconnect_terminal()
 	if(terminal)


### PR DESCRIPTION
## About The Pull Request

Time to get rid of these sub`areas`...
Made the admin verb `break lights` works in every cases.

:cl:
fix: The break lights admin verb should now works correctly
/:cl: