### PR TITLE
Prevent hive lists from readding a *living* xeno when revived

### DIFF
--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -220,5 +220,6 @@ mob/living/proc/adjustHalLoss(amount) //This only makes sense for carbon.
 	plasma_stored = xeno_caste.plasma_max
 	stagger = 0
 	slowdown = 0
-	hive?.on_xeno_revive(src)
+	if(stat == DEAD)
+		hive?.on_xeno_revive(src)
 	return ..()


### PR DESCRIPTION
## About The Pull Request

The lists handling should only happen when the revived xeno is dead or the xeno will be added a second time (and only one will be removed from the lists on, say, death).

This caused `null` in hive lists.