### PR TITLE
Fixes another runtime

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -22,7 +22,7 @@
 	origin_tech = "materials=1"
 
 
-/obj/item/stack/New(loc, new_amount)
+/obj/item/stack/Initialize(loc, new_amount)
 	. = ..()
 	if(new_amount)
 		amount = new_amount


### PR DESCRIPTION
```
runtime error: Cannot modify null.screen_loc.
proc name: slot orient objs (/obj/item/storage/proc/slot_orient_objs)
  source file: storage.dm,181
  usr: null
  src: the survival pouch (/obj/item/storage/pouch/survival/full)
  src.loc: Thomas Papillon (/mob/living/carbon/human)
  call stack:
the survival pouch (/obj/item/storage/pouch/survival/full): slot orient objs(0, 5, null)
the survival pouch (/obj/item/storage/pouch/survival/full): orient2hud()
the survival pouch (/obj/item/storage/pouch/survival/full): recalculate storage space()
the roll of gauze (/obj/item/stack/medical/bruise_pack): update weight()
the roll of gauze (/obj/item/stack/medical/bruise_pack): New(the survival pouch (/obj/item/storage/pouch/survival/full), 3)
the survival pouch (/obj/item/storage/pouch/survival/full): Initialize(0)
Atoms (/datum/controller/subsystem/atoms): InitAtom(the survival pouch (/obj/item/storage/pouch/survival/full), /list (/list))
the survival pouch (/obj/item/storage/pouch/survival/full): New(0)
the survival pouch (/obj/item/storage/pouch/survival/full): New(Thomas Papillon (/mob/living/carbon/human))
the survival pouch (/obj/item/storage/pouch/survival/full): New(Thomas Papillon (/mob/living/carbon/human))
the survival pouch (/obj/item/storage/pouch/survival/full): New(Thomas Papillon (/mob/living/carbon/human))
Distress Signal (/datum/game_mode/distress): transform survivor(Marilyn Jones (/datum/mind))
Distress Signal (/datum/game_mode/distress): pre setup()
Ticker (/datum/controller/subsystem/ticker): setup()
Ticker (/datum/controller/subsystem/ticker): fire(0)
Ticker (/datum/controller/subsystem/ticker): ignite(0)
```