### PR TITLE
Adds a medic webbing, adjusts the white webbing

### DIFF
--- a/code/modules/clothing/under/ties.dm
+++ b/code/modules/clothing/under/ties.dm
@@ -523,7 +523,7 @@
 	desc = "A clean white Nylon vest with large pockets specially designed for holding common medical supplies."
 	hold = /obj/item/storage/internal/tie/white_vest/medic
 
-	/obj/item/storage/internal/tie/white_vest/medic
+/obj/item/storage/internal/tie/white_vest/medic
 	storage_slots = 6 //one more than the brown webbing but you lose out on being able to hold non-medic stuff
 	can_hold = list(
 	/obj/item/stack/medical,

--- a/code/modules/clothing/under/ties.dm
+++ b/code/modules/clothing/under/ties.dm
@@ -504,8 +504,8 @@
 	hold = /obj/item/storage/internal/tie/vest
 
 /obj/item/clothing/tie/storage/white_vest
-	name = "white webbing vest"
-	desc = "A clean white Nylon vest with large pockets specially designed for medical supplies"
+	name = "surgical vest"
+	desc = "A clean white Nylon vest with large pockets specially designed for holding surgical supplies."
 	icon_state = "vest_white"
 	hold = /obj/item/storage/internal/tie/white_vest
 
@@ -513,9 +513,31 @@
 	storage_slots = 8
 	can_hold = list(
 		/obj/item/tool/surgery, 
-		/obj/item/stack/medical/advanced/bruise_pack, 
-		/obj/item/stack/medical/advanced/ointment, 
+		/obj/item/stack/medical/advanced, 
+		/obj/item/clothing/mask/surgical,
+		/obj/item/clothing/gloves/latex,
 		/obj/item/stack/nanopaste)
+
+/obj/item/storage/internal/tie/white_vest/medic
+	name = "corpsman webbing"
+	desc = "A clean white Nylon vest with large pockets specially designed for holding common medical supplies."
+	hold = /obj/item/storage/internal/tie/white_vest/medic
+
+	/obj/item/storage/internal/tie/white_vest/medic
+	storage_slots = 6 //one more than the brown webbing but you lose out on being able to hold non-medic stuff
+	can_hold = list(
+	/obj/item/stack/medical,
+	/obj/item/healthanalyzer,
+	/obj/item/reagent_container/dropper,
+	/obj/item/reagent_container/glass/beaker,
+	/obj/item/reagent_container/glass/bottle,
+	/obj/item/reagent_container/pill,
+	/obj/item/reagent_container/syringe,
+	/obj/item/storage/pill_bottle,
+	/obj/item/reagent_container/hypospray,
+	/obj/item/bodybag,
+	/obj/item/roller,
+	/obj/item/clothing/glasses/hud/health)
 
 /obj/item/clothing/tie/storage/knifeharness
 	name = "decorated harness"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Renames the white webbing vest to the surgical vest, creates a new subtype of the white webbing for corpsmen - sacrificing the variety of the brown webbing for 1 extra slot.  Will need to be added to vendors if this PR is deemed acceptable. 

## Why It's Good For The Game

Adds some more variety to loadout choices, the corpsmen webbing sacrifices variety in what it can hold to be better optimised at carrying just one more piece of medical equipment, without outstripping the existing vest options. 

## Changelog
:cl:
add: Adds the corpsmen webbing, a vest with one extra slot but can't carry non-medical equipment. 
tweak: Renames the white webbing vest to the surgical vest and allows it to carry surgical masks and gloves
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
