### PR TITLE
Adds a medic webbing, adjusts the white webbing

### DIFF
--- a/code/game/machinery/vending/marine_vending.dm
+++ b/code/game/machinery/vending/marine_vending.dm
@@ -87,6 +87,7 @@
 					/obj/item/storage/belt/shotgun = 10,
 					/obj/item/clothing/tie/storage/webbing = 3,
 					/obj/item/clothing/tie/storage/brown_vest = 1,
+					/obj/item/clothing/tie/storage/white_vest/medic = 1,
 					/obj/item/clothing/tie/holster = 1,
 					/obj/item/storage/belt/gun/m4a3 = 10,
 					/obj/item/storage/belt/gun/m44 = 5,
@@ -742,6 +743,7 @@
 					/obj/item/storage/pouch/construction = 10,
 					/obj/item/storage/pouch/tools/full = 10,
 					/obj/item/clothing/tie/storage/brown_vest = 10,
+					/obj/item/clothing/tie/storage/white_vest/medic = 10,
 					/obj/item/clothing/tie/storage/webbing = 10,
 					/obj/item/clothing/tie/holster = 10
 					)

--- a/code/game/machinery/vending/new_marine_vendors.dm
+++ b/code/game/machinery/vending/new_marine_vendors.dm
@@ -453,6 +453,7 @@
 							list("Backpack", 0, /obj/item/storage/backpack/marine/corpsman, MARINE_CAN_BUY_BACKPACK, "black"),
 							list("WEBBING (choose 1)", 0, null, null, null),
 							list("Tactical Brown Vest", 0, /obj/item/clothing/tie/storage/brown_vest, MARINE_CAN_BUY_WEBBING, "orange"),
+							list("Corpsman White Vest", 0, /obj/item/clothing/tie/storage/white_vest/medic, MARINE_CAN_BUY_WEBBING, "black"),
 							list("Tactical Webbing", 0, /obj/item/clothing/tie/storage/webbing, MARINE_CAN_BUY_WEBBING, "black"),
 							list("Shoulder Handgun Holster", 0, /obj/item/clothing/tie/holster, MARINE_CAN_BUY_WEBBING, "black"),
 							list("BELT (choose 1)", 0, null, null, null),

--- a/code/modules/clothing/under/ties.dm
+++ b/code/modules/clothing/under/ties.dm
@@ -509,13 +509,41 @@
 	icon_state = "vest_white"
 	hold = /obj/item/storage/internal/tie/white_vest
 
+/obj/item/clothing/tie/storage/white_vest
+	name = "surgical vest"
+	desc = "A clean white Nylon vest with large pockets specially designed for holding surgical supplies."
+	icon_state = "vest_white"
+	hold = /obj/item/storage/internal/tie/white_vest
+
 /obj/item/storage/internal/tie/white_vest
 	storage_slots = 8
 	can_hold = list(
 		/obj/item/tool/surgery, 
-		/obj/item/stack/medical/advanced/bruise_pack, 
-		/obj/item/stack/medical/advanced/ointment, 
+		/obj/item/stack/medical/advanced, 
+		/obj/item/clothing/mask/surgical,
+		/obj/item/clothing/gloves/latex,
 		/obj/item/stack/nanopaste)
+
+/obj/item/clothing/tie/storage/white_vest/medic
+	name = "corpsman webbing"
+	desc = "A clean white Nylon vest with large pockets specially designed for holding common medical supplies."
+	hold = /obj/item/storage/internal/tie/white_vest/medic
+
+/obj/item/storage/internal/tie/white_vest/medic
+	storage_slots = 6 //one more than the brown webbing but you lose out on being able to hold non-medic stuff
+	can_hold = list(
+	/obj/item/stack/medical,
+	/obj/item/healthanalyzer,
+	/obj/item/reagent_container/dropper,
+	/obj/item/reagent_container/glass/beaker,
+	/obj/item/reagent_container/glass/bottle,
+	/obj/item/reagent_container/pill,
+	/obj/item/reagent_container/syringe,
+	/obj/item/storage/pill_bottle,
+	/obj/item/reagent_container/hypospray,
+	/obj/item/bodybag,
+	/obj/item/roller,
+	/obj/item/clothing/glasses/hud/health)
 
 /obj/item/clothing/tie/storage/knifeharness
 	name = "decorated harness"


### PR DESCRIPTION
About The Pull Request

Renames the white webbing vest to the surgical vest, creates a new subtype of the white webbing for corpsmen - sacrificing the variety of the brown webbing for 1 extra slot. Will need to be added to vendors if this PR is deemed acceptable.
Why It's Good For The Game

Adds some more variety to loadout choices, the corpsmen webbing sacrifices variety in what it can hold to be better optimised at carrying just one more piece of medical equipment, without outstripping the existing vest options.
Changelog

:cl:
add: Adds the corpsmen webbing, a vest with one extra slot but can't carry non-medical equipment.
tweak: Renames the white webbing vest to the surgical vest and allows it to carry surgical masks and gloves
/:cl: