### PR TITLE
Removes neuro for queen, replaces by sticky.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
@@ -37,7 +37,7 @@
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.5 SECONDS
-	spit_types = list(/datum/ammo/xeno/sticky, /datum/ammo/xeno/acid/medium)
+	spit_types = list(/datum/ammo/xeno/sticky, /datum/ammo/xeno/acid/heavy)
 
 	// *** Pheromones *** //
 	aura_strength = 3 //The Queen's aura is strong and stays so, and gets devastating late game. Climbs by 1 to 5
@@ -78,8 +78,7 @@
 	armor_deflection = 50
 
 	// *** Ranged Attack *** //
-	spit_delay = 1.5 SECONDS
-	spit_types = list(/datum/ammo/xeno/sticky, /datum/ammo/xeno/acid/medium)
+	spit_delay = 1.3 SECONDS
 
 	// *** Pheromones *** //
 	aura_strength = 4
@@ -116,8 +115,7 @@
 	armor_deflection = 55
 
 	// *** Ranged Attack *** //
-	spit_delay = 1.5 SECONDS
-	spit_types = list(/datum/ammo/xeno/sticky, /datum/ammo/xeno/acid/medium)
+	spit_delay = 1.3 SECONDS
 
 	// *** Pheromones *** //
 	aura_strength = 4.7
@@ -154,8 +152,7 @@
 	armor_deflection = 60
 
 	// *** Ranged Attack *** //
-	spit_delay = 1.5 SECONDS
-	spit_types = list(/datum/ammo/xeno/sticky, /datum/ammo/xeno/acid/medium)
+	spit_delay = 1.3 SECONDS
 
 	// *** Pheromones *** //
 	aura_strength = 5

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
@@ -37,7 +37,7 @@
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.5 SECONDS
-	spit_types = list(/datum/ammo/xeno/toxin/medium, /datum/ammo/xeno/acid/medium)
+	spit_types = list(/datum/ammo/xeno/sticky, /datum/ammo/xeno/acid/medium)
 
 	// *** Pheromones *** //
 	aura_strength = 3 //The Queen's aura is strong and stays so, and gets devastating late game. Climbs by 1 to 5
@@ -79,7 +79,7 @@
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.5 SECONDS
-	spit_types = list(/datum/ammo/xeno/toxin/medium/upgrade1, /datum/ammo/xeno/acid/medium)
+	spit_types = list(/datum/ammo/xeno/sticky, /datum/ammo/xeno/acid/medium)
 
 	// *** Pheromones *** //
 	aura_strength = 4
@@ -117,7 +117,7 @@
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.5 SECONDS
-	spit_types = list(/datum/ammo/xeno/toxin/medium/upgrade2, /datum/ammo/xeno/acid/medium)
+	spit_types = list(/datum/ammo/xeno/sticky, /datum/ammo/xeno/acid/medium)
 
 	// *** Pheromones *** //
 	aura_strength = 4.7
@@ -155,11 +155,10 @@
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.5 SECONDS
-	spit_types = list(/datum/ammo/xeno/toxin/medium/upgrade3, /datum/ammo/xeno/acid/medium)
+	spit_types = list(/datum/ammo/xeno/sticky, /datum/ammo/xeno/acid/medium)
 
 	// *** Pheromones *** //
 	aura_strength = 5
 
 	// *** Queen Abilities *** //
 	queen_leader_limit = 4
-	


### PR DESCRIPTION
## About The Pull Request

Simply removes the ability for queen to spit neurotoxin, gives them sticky spit instead.
EDIT : Spit delay lowered from 1.5 to 1.3 once mature. Queen gains heavy spit for better offence. 

## Why It's Good For The Game

Pretty much axes combat queen capabilities. Just makes her more defensive/supportive without being able to easily solo and pick out single marines to kill. Should stop queen from reaching the highest kill-count in the game. They're slower at spitting sticky than a hivelord. EDIT : They're now on par at spitting sticky with the hivelord.

EDIT : Improved the acid spit of the queen to be on par with praetorians and spitters, as well as lowering her spit delay slightly once mature+. People are worried queen will loose her offensive capabilities without. I disagree, from what I've seen a competent queen is perfectly capable of winning without neuro spit. If anything sticky spit is better for bald queens as it increases survivability (deny chase) And now acid spit won't be a giant noob trap anymore. (negligible damage which was often getting absorbed completely by average marine armor)

## Changelog
:cl:
balance: Removes queen neurotoxin, adds queen sticky spit. Queen acid spit is now stronger.
/:cl:
