### PR TITLE
Cuter help intents

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -151,8 +151,8 @@
 
 /datum/species/proc/hug(var/mob/living/carbon/human/H,var/mob/living/target)
 	if(H.zone_selected == "head")
-		H.visible_message("<span class='notice'>[H] pats [target] on the head affectionately.</span>", \
-					"<span class='notice'>You pat [target] on the head affectionately.</span>", null, 4)	
+		H.visible_message("<span class='notice'>[H] pats [target] on the head.</span>", \
+					"<span class='notice'>You pat [target] on the head.</span>", null, 4)	
 	else
 		H.visible_message("<span class='notice'>[H] hugs [target] to make [target.p_them()] feel better!</span>", \
 					"<span class='notice'>You hug [target] to make [target.p_them()] feel better!</span>", null, 4)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -150,8 +150,11 @@
 
 
 /datum/species/proc/hug(var/mob/living/carbon/human/H,var/mob/living/target)
-
-	H.visible_message("<span class='notice'>[H] hugs [target] to make [target.p_them()] feel better!</span>", \
+	if(H.zone_selected == "head")
+		H.visible_message("<span class='notice'>[H] pats [target] on the head affectionately.</span>", \
+					"<span class='notice'>You pat [target] on the head affectionately.</span>", null, 4)	
+	else
+		H.visible_message("<span class='notice'>[H] hugs [target] to make [target.p_them()] feel better!</span>", \
 					"<span class='notice'>You hug [target] to make [target.p_them()] feel better!</span>", null, 4)
 
 /datum/species/proc/random_name(gender)

--- a/code/modules/mob/living/carbon/xenomorph/xenoattacks.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoattacks.dm
@@ -52,8 +52,8 @@
 				M.visible_message("<span class='warning'>\The [M] pokes \the [src], but nothing happens.</span>", \
 				"<span class='warning'>You poke \the [src], but nothing happens.</span>", null, 5)
 			else
-				M.visible_message("<span class='warning'>\The [M] pokes \the [src].</span>", \
-				"<span class='warning'>You poke \the [src].</span>", null, 5)
+				M.visible_message("<span class='notice'>\The [M] pets \the [src].</span>", \
+					"<span class='notice'>You pet \the [src].</span>", null, 5)
 
 		if(INTENT_GRAB)
 			if(M == src || anchored)


### PR DESCRIPTION
*adds headpatting

*changes poking xenos to petting them

<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Made some changes to help intent interactions, including petting when a human help-intents on a xeno and headpatting each other when the head is targeted.

## Why It's Good For The Game

It's cute dammit. 



plus LaK said I could :3

## Changelog
:cl:
add: You can now headpat by using help intent on someone's head
tweak: help intent on a xeno changed from "poke" to "pet"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
