### PR TITLE
Fixes webbings being unable to hold medical stacks.

### DIFF
--- a/code/modules/clothing/under/ties.dm
+++ b/code/modules/clothing/under/ties.dm
@@ -484,7 +484,10 @@
 		/obj/item/ammo_magazine/sniper,
 		/obj/item/cell/lasgun)
 	cant_hold = list(
-		/obj/item/stack)
+		/obj/item/stack/razorwire,
+		/obj/item/stack/sheet,
+		/obj/item/stack/sandbags,
+		/obj/item/stack/snow)
 
 /obj/item/clothing/tie/storage/black_vest
 	name = "black webbing vest"
@@ -495,7 +498,10 @@
 /obj/item/storage/internal/tie/vest
 	storage_slots = 5
 	cant_hold = list(
-		/obj/item/stack)
+		/obj/item/stack/razorwire,
+		/obj/item/stack/sheet,
+		/obj/item/stack/sandbags,
+		/obj/item/stack/snow)
 
 /obj/item/clothing/tie/storage/brown_vest
 	name = "brown webbing vest"


### PR DESCRIPTION
Not really a fan of it, but eh.

## Changelog
:cl:
fix: Webbings can once again hold splints, kits and other stacks that are not razorwire, sheets, filled sandbags or snow.
/:cl: