### PR TITLE
Tweaks on xeno sting and larval growth serum.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/powers.dm
@@ -925,6 +925,10 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 		face_atom(C)
 		if(stagger)
 			return FALSE
+		body_tox = C.reagents.get_reagent(toxin)
+		if(CHECK_BITFIELD(C.status_flags, XENO_HOST) && body_tox && body_tox.volume > body_tox.overdose_threshold)
+			to_chat(src, "<span class='warning'>You sense the infected host is saturated with [body_tox.name] and cease your attempt to inoculate it further to preserve the little one inside.</span>")
+			return FALSE
 		animation_attack_on(C)
 		playsound(C, 'sound/effects/spray3.ogg', 15, 1)
 		playsound(C, pick('sound/voice/alien_drool1.ogg', 'sound/voice/alien_drool2.ogg'), 15, 1)

--- a/code/modules/reagents/chemistry_reagents/other.dm
+++ b/code/modules/reagents/chemistry_reagents/other.dm
@@ -812,6 +812,17 @@
 	scannable = TRUE
 
 
+/datum/reagent/xeno_growthtoxin/on_mob_life(mob/living/L)
+	if(L.getOxyLoss())
+		L.adjustOxyLoss(-REM)
+	if(L.getBruteLoss() || L.getFireLoss())
+		L.heal_limb_damage(REM, REM)
+	if(L.getToxLoss())
+		L.adjustToxLoss(-REM)
+	L.reagent_pain_modifier += PAIN_REDUCTION_VERY_HEAVY
+	return ..()
+
+
 /datum/reagent/xeno_growthtoxin/overdose_process(mob/living/M)
 	M.adjustOxyLoss(2)
 	M.Jitter(4) //Lets Xenos know they're ODing and should probably stop.

--- a/code/modules/reagents/chemistry_reagents/other.dm
+++ b/code/modules/reagents/chemistry_reagents/other.dm
@@ -813,7 +813,7 @@
 
 
 /datum/reagent/xeno_growthtoxin/overdose_process(mob/living/M)
-	M.adjustOxyLoss(3)
+	M.adjustOxyLoss(2)
 	M.Jitter(4) //Lets Xenos know they're ODing and should probably stop.
 
 


### PR DESCRIPTION
As requested by @Ketrai .
This will have to be tested for balance, as it can make a marine with tricord and tramadol quite the tank for as long as they last before bursting.

## Changelog
:cl:
balance: Xeno stings will stop injecting chems on overdosed infected hosts.
balance: Larval growth serum provides decent healing and strong analgesic properties to the host, both stacking with other chems. OD made a little softer. Still able to push you over if you are at the edge.
/:cl: