### PR TITLE
Buffing neuro smoke again just a very little.

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -39,7 +39,7 @@
 			to_chat(src, "<span class='danger'>Your eyes sting. You can't see!</span>")
 		blur_eyes(4)
 		blind_eyes(2)
-		var/reagent_amount = 4 + S.strength * 2
+		var/reagent_amount = 5 + S.strength * 2
 		reagents.add_reagent("xeno_toxin", reagent_amount)
 		if(prob(10 * S.strength)) //Likely to momentarily freeze up/fall due to arms/hands seizing up
 			to_chat(src, "<span class='danger'>You feel your body going numb and lifeless!</span>")
@@ -55,7 +55,7 @@
 			to_chat(src, "<span class='danger'>Your skin feels like it is melting away!</span>")
 		adjustFireLoss(S.strength * rand(20, 23) * protection)
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO_NEURO) && (internal || has_smoke_protection())) //either inhaled or this.
-		var/reagent_amount = 2 + S.strength
+		var/reagent_amount = 3 + S.strength
 		reagents.add_reagent("xeno_toxin", round(reagent_amount * protection, 0.1))
 		if(prob(10 * S.strength * protection))
 			to_chat(src, "<span class='danger'>Your body goes numb where the gas touches it!</span>")


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I had a slight doubt that neurotoxin was a little too weak when refactored it. Then someone pinged me on it. I guess it makes sense, given how xeno neurotoxin has a quick depletion rate of 1.5 u per cycle.
Otherwise it seems fair given the blinding side effect.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Making this a more even option compared to acidic smokes.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: sligthy buffed boiler neurotoxin smoke to account the fast depletion rate of the associated chemical.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
