### PR TITLE
Auto-9 Magazine Fix

### DIFF
--- a/code/modules/projectiles/updated_projectiles/magazines/pistols.dm
+++ b/code/modules/projectiles/updated_projectiles/magazines/pistols.dm
@@ -179,7 +179,7 @@ It is a modified Beretta 93R, and can fire three round burst or single fire. Whe
 	name = "\improper Auto-9 magazine (9mm)"
 	default_ammo = /datum/ammo/bullet/pistol/squash
 	caliber = "9mm"
-	icon_state = "baretta"
+	icon_state = "beretta"
 	max_rounds = 50
 	gun_type = /obj/item/weapon/gun/pistol/auto9
 


### PR DESCRIPTION
## About The Pull Request
Fixes a typo in the pistol magazines that makes the Auto-9 magazine have no sprite. 

## Why It's Good For The Game
Kind of niche, adminspawn only item, but still. A bug is a bug and should be squashed. Like a bug. 
## Changelog
I don't think this needs a changelog since, y'know, adminspawn item. 

