### PR TITLE
Fixes xeno interaction with closets and crates.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -194,7 +194,7 @@
 			"<span class='danger'>You smash \the [src]!</span>", null, 5)
 		if(M.stealth_router(HANDLE_STEALTH_CHECK)) //Cancel stealth if we have it due to aggro.
 			M.stealth_router(HANDLE_STEALTH_CODE_CANCEL)
-	else
+	else if(!opened)
 		return attack_paw(M)
 
 /obj/structure/closet/attackby(obj/item/W, mob/living/user)
@@ -294,11 +294,6 @@
 
 /obj/structure/closet/attack_paw(mob/user as mob)
 	return attack_hand(user)
-
-/obj/structure/closet/attack_alien(mob/user as mob)
-	if(opened)
-		return FALSE // stop xeno closing things
-	return src.attack_hand(user)
 
 /obj/structure/closet/attack_hand(mob/living/user)
 	add_fingerprint(user)

--- a/code/game/objects/structures/crates_lockers/closets/secure/cm_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cm_closets.dm
@@ -135,9 +135,8 @@
 // MARINE ENGINEER
 
 /obj/structure/closet/secure_closet/marine/engi
-	slotlocked = 1
-	slotlocktype = "engi"
-	health = 100000 // just no
+	slotlocked = TRUE
+	resistance_flags = INDESTRUCTIBLE
 
 /obj/structure/closet/secure_closet/marine/engi/Initialize()
 	. = ..()
@@ -192,11 +191,10 @@
 
 
 
-// SQUAD CORPSMAN-''
+// SQUAD CORPSMAN
 /obj/structure/closet/secure_closet/marine/medic
-	slotlocked = 1
-	slotlocktype = "medic"
-	health = 100000 // just no
+	slotlocked = TRUE
+	resistance_flags = INDESTRUCTIBLE
 
 /obj/structure/closet/secure_closet/marine/medic/Initialize()
 	. = ..()

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -14,7 +14,6 @@
 	var/icon_off = "secureoff"
 	health = 100
 	var/slotlocked = 0
-	var/slotlocktype = null
 
 /obj/structure/closet/secure_closet/can_open()
 	if(src.locked)
@@ -45,37 +44,28 @@
 	..()
 
 /obj/structure/closet/secure_closet/proc/togglelock(mob/living/user)
-	if(src.opened)
+	if(!user.IsAdvancedToolUser())
+		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
+		return
+	if(opened)
 		to_chat(user, "<span class='notice'>Close the locker first.</span>")
 		return
-	if(src.broken)
+	if(broken)
 		to_chat(user, "<span class='warning'>The locker appears to be broken.</span>")
 		return
 	if(user.loc == src)
 		to_chat(user, "<span class='notice'>You can't reach the lock from inside.</span>")
 		return
-	if(src.allowed(user))
-		if(slotlocked && ishuman(user))
-			var/mob/living/carbon/human/H = user
-			if(H.wear_id)
-				var/obj/item/card/id/I = H.wear_id
-				if(I.claimedgear)
-					return
-				switch(slotlocktype)
-					if("engi")
-						if(H.mind.assigned_role != "Squad Engineer")
-							return // stop people giving medics engineer prep access or IDs somehow
-					if("medic")
-						if(H.mind.assigned_role != "Squad Corpsman")
-							return // same here
-				I.claimedgear = 1 // you only get one locker, all other roles have this set 1 by default
-				slotlocked = 0 // now permanently unlockable
-			else
-				return // they have no ID on, fuck them.
-		src.locked = !src.locked
-		for(var/mob/O in viewers(user, 3))
-			if(O.client && !is_blind(O))
-				to_chat(O, "<span class='notice'>The locker has been [locked ? null : "un"]locked by [user].</span>")
+	if(allowed(user))
+		if(slotlocked)
+			var/obj/item/card/id/I = user.get_idcard(TRUE)
+			if(!I || I.claimedgear)
+				return
+			I.claimedgear = TRUE // you only get one locker, all other roles have this set 1 by default
+			slotlocked = FALSE // now permanently unlockable
+		locked = !locked
+		user.visible_message("<span class='notice'>\the [src] has been [locked ? "" : "un"]locked by [user].</span>", \
+							"<span class='notice'>You [locked ? "" : "un"]lock \the [src].</span>", null, 3)
 		update_icon()
 	else
 		to_chat(user, "<span class='notice'>Access Denied</span>")
@@ -102,21 +92,18 @@
 		desc = "It appears to be broken."
 		icon_state = icon_off
 		flick(icon_broken, src)
-		for(var/mob/O in viewers(user, 3))
-			O.show_message("<span class='warning'>The locker has been broken by [user] with an electromagnetic card!</span>", 1, "You hear a faint electrical spark.", 2)
-	else if(istype(W,/obj/item/packageWrap) || istype(W,/obj/item/tool/weldingtool))
-		return ..(W,user)
+		user.visible_message("<span class='warning'>\the [src] has been broken by [user] with \the [W]!</span>", "<span class='notice'>You break \the [src]'s with \the [W]!</span>", "You hear a faint electrical spark.", 3)
+	else if(istype(W,/obj/item/packageWrap) || istype(W,/obj/item/tool/weldingtool) || user.a_intent == INTENT_HARM)
+		return ..()
 	else
 		togglelock(user)
 
 /obj/structure/closet/secure_closet/attack_hand(mob/living/user)
-	src.add_fingerprint(user)
-	if(src.locked)
-		src.togglelock(user)
+	add_fingerprint(user)
+	if(locked)
+		togglelock(user)
 	else
-		if(opened && isxeno(user))
-			return // stop xeno closing them
-		src.toggle(user)
+		toggle(user)
 
 /obj/structure/closet/secure_closet/attack_paw(mob/user as mob)
 	return src.attack_hand(user)
@@ -126,26 +113,19 @@
 	set category = "Object"
 	set name = "Toggle Lock"
 
-	if(!usr.canmove || usr.stat || usr.restrained()) // Don't use it if you're not able to! Checks for stuns, ghost and restrain
+	if(usr.incapacitated())
 		return
+	add_fingerprint(usr)
+	togglelock(usr)
 
-	if(ishuman(usr))
-		src.add_fingerprint(usr)
-		src.togglelock(usr)
-	else
-		to_chat(usr, "<span class='warning'>This mob type can't use this verb.</span>")
-
-/obj/structure/closet/secure_closet/update_icon()//Putting the welded stuff in updateicon() so it's easy to overwrite for special cases (Fridges, cabinets, and whatnot)
+/obj/structure/closet/crate/secure/update_icon()
 	overlays.Cut()
-	if(!opened)
-		if(locked)
-			icon_state = icon_locked
-		else
-			icon_state = icon_closed
-		if(welded)
-			overlays += "welded"
-	else
+	if(opened)
 		icon_state = icon_opened
+	else
+		icon_state = locked ? icon_locked : icon_closed
+	if(welded)
+		overlays += overlay_welded
 
 /obj/structure/closet/secure_closet/break_open()
 	broken = TRUE

--- a/code/game/objects/structures/crates_lockers/secure_crates.dm
+++ b/code/game/objects/structures/crates_lockers/secure_crates.dm
@@ -20,30 +20,30 @@
 	overlays.Cut()
 	if(opened)
 		icon_state = icon_opened
-	else if(locked)
-		icon_state = icon_locked
 	else
-		icon_state = icon_unlocked
+		icon_state = locked ? icon_locked : icon_unlocked
 	if(welded)
-		overlays += "welded"
+		overlays += overlay_welded
 
 
 /obj/structure/closet/crate/secure/can_open()
 	return !locked
 
-/obj/structure/closet/crate/secure/proc/togglelock(mob/user as mob)
-	if(src.opened)
+/obj/structure/closet/crate/secure/proc/togglelock(mob/user)
+	add_fingerprint(user)
+	if(!user.IsAdvancedToolUser())
+		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
+		return
+	if(opened)
 		to_chat(user, "<span class='notice'>Close the crate first.</span>")
 		return
-	if(src.broken)
+	if(broken)
 		to_chat(user, "<span class='warning'>The crate appears to be broken.</span>")
 		return
-	if(src.allowed(user))
-		src.locked = !src.locked
-		for(var/mob/O in viewers(user, 3))
-			if(O.client && !is_blind(O))
-				to_chat(O, "<span class='notice'>The crate has been [locked ? null : "un"]locked by [user].</span>")
-		icon_state = locked ? icon_locked : icon_unlocked
+	if(allowed(user))
+		locked = !locked
+		user.visible_message("<span class='notice'>\the [src] has been [locked ? "" : "un"]locked by [user].</span>", null, 3)
+		update_icon()
 	else
 		to_chat(user, "<span class='notice'>Access Denied</span>")
 
@@ -52,21 +52,15 @@
 	set category = "Object"
 	set name = "Toggle Lock"
 
-	if(!usr.canmove || usr.stat || usr.restrained()) // Don't use it if you're not able to! Checks for stuns, ghost and restrain
+	if(usr.incapacitated())
 		return
+	togglelock(usr)
 
-	if(ishuman(usr))
-		src.add_fingerprint(usr)
-		src.togglelock(usr)
-	else
-		to_chat(usr, "<span class='warning'>This mob type can't use this verb.</span>")
-
-/obj/structure/closet/crate/secure/attack_hand(mob/user as mob)
-	src.add_fingerprint(user)
+/obj/structure/closet/crate/secure/attack_hand(mob/user)
 	if(locked)
-		src.togglelock(user)
+		togglelock(user)
 	else
-		src.toggle(user)
+		toggle(user)
 
 /obj/structure/closet/crate/secure/attackby(obj/item/W as obj, mob/user as mob)
 	if(is_type_in_list(W, list(/obj/item/packageWrap, /obj/item/stack/cable_coil, /obj/item/radio/electropack, /obj/item/tool/wirecutters, /obj/item/tool/weldingtool)))
@@ -82,8 +76,8 @@
 		update_icon()
 		to_chat(user, "<span class='notice'>You unlock \the [src].</span>")
 		return
-	if(!opened)
-		src.togglelock(user)
+	if(!opened && user.a_intent != INTENT_HARM)
+		togglelock(user)
 		return
 	return ..()
 

--- a/code/game/objects/structures/crates_lockers/secure_crates.dm
+++ b/code/game/objects/structures/crates_lockers/secure_crates.dm
@@ -30,7 +30,6 @@
 	return !locked
 
 /obj/structure/closet/crate/secure/proc/togglelock(mob/user)
-	add_fingerprint(user)
 	if(!user.IsAdvancedToolUser())
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return
@@ -42,7 +41,8 @@
 		return
 	if(allowed(user))
 		locked = !locked
-		user.visible_message("<span class='notice'>\the [src] has been [locked ? "" : "un"]locked by [user].</span>", null, 3)
+		user.visible_message("<span class='notice'>\the [src] has been [locked ? "" : "un"]locked by [user].</span>", \
+							"<span class='notice'>You [locked ? "" : "un"]lock \the [src].</span>", null, 3)
 		update_icon()
 	else
 		to_chat(user, "<span class='notice'>Access Denied</span>")
@@ -54,9 +54,11 @@
 
 	if(usr.incapacitated())
 		return
+	add_fingerprint(usr)
 	togglelock(usr)
 
 /obj/structure/closet/crate/secure/attack_hand(mob/user)
+	add_fingerprint(user)
 	if(locked)
 		togglelock(user)
 	else


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #1361. There was a duplicate of /obj/structure/closet/attack_alien() that overrode the newer one.
Also older code on secure crates and closets that had to be dealt with.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugfixing, improvement.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes some xeno interaction with closets: Harm intent will now properly break closets open, while locked secure closets/crates won't be manually unlockable by them anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
