### PR TITLE
Add a MC read only permission

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -39,8 +39,9 @@
 #define R_SOUND			(1<<10)
 #define R_SPAWN			(1<<11)
 #define R_DBRANKS		(1<<12)
+#define R_MC_READONLY   (1<<13)
 
-#define R_EVERYTHING 	(1<<13)-1 //the sum of all other rank permissions, used for +EVERYTHING
+#define R_EVERYTHING 	(1<<14)-1 //the sum of all other rank permissions, used for +EVERYTHING
 
 #define ADMIN_QUE(user) "(<a href='?_src_=holder;[HrefToken(TRUE)];moreinfo=[REF(user)]'>?</a>)"
 #define ADMIN_FLW(user) "(<a href='?_src_=holder;[HrefToken(TRUE)];observefollow=[REF(user)]'>FLW</a>)"

--- a/code/_globalvars/bitfields.dm
+++ b/code/_globalvars/bitfields.dm
@@ -12,7 +12,8 @@ GLOBAL_LIST_INIT(bitfields, list(
 		"VAREDIT" = R_VAREDIT,
 		"SOUND" = R_SOUND,
 		"SPAWN" = R_SPAWN,
-		"DBRANKS" = R_DBRANKS
+		"DBRANKS" = R_DBRANKS,
+		"MC_READONLY" = R_MC_READONLY
 		),
 	"machine_stat" = list(
 		"BROKEN" = BROKEN,

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -26,7 +26,7 @@
 
 
 	if(client?.holder?.rank?.rights)
-		if(client.holder.rank.rights & (R_ADMIN|R_DEBUG))
+		if(client.holder.rank.rights & (R_ADMIN|R_DEBUG|R_MC_READONLY))
 			if(statpanel("MC"))
 				stat("CPU:", "[world.cpu]")
 				stat("Instances:", "[num2text(length(world.contents), 10)]")


### PR DESCRIPTION

## About The Pull Request

Add a MC read only permission

## Why It's Good For The Game

Allows coders to see the health of the server without giving additional permissions.

## Changelog
:cl:
add: Add a read only master controller permissions.
/:cl:
