### PR TITLE
Medevac beacons can no longer be overwritten while locked

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -622,8 +622,8 @@ var/global/list/activated_medevac_stretchers = list()
 	 return
 
 	if(istype(O, /obj/item/card/id))
-		if(!allowed(user))
-			to_chat(user, "<span class='warning'>Access denied.</span>")
+		if(locked)
+			to_chat(user, "<span class='warning'>[src]'s interface is locked! Only a Squad Leader, Corpsman, or Medical Officer can unlock it now.</span>")
 			playsound(loc,'sound/machines/buzz-two.ogg', 25, FALSE)
 			return
 		locked = !locked

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -631,7 +631,7 @@ var/global/list/activated_medevac_stretchers = list()
 		"<span class='notice'>You [locked ? "lock" : "unlock"] [src]'s interface.</span>")
 	else if(istype(O,/obj/item/roller/medevac))
 		if(locked)
-			to_chat(user, "<span class='warning'>[src]'s interface is locked! Only a Squad Leader, Corpsman, or Medical Officer can unlock it now.</span>")
+			to_chat(user, "<span class='warning'>Access denied.</span>")
 			playsound(loc,'sound/machines/buzz-two.ogg', 25, FALSE)
 			return
 		var/obj/item/roller/medevac/R = O

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -622,16 +622,16 @@ var/global/list/activated_medevac_stretchers = list()
 	 return
 
 	if(istype(O, /obj/item/card/id))
-		if(locked)
-			to_chat(user, "<span class='warning'>[src]'s interface is locked! Only a Squad Leader, Corpsman, or Medical Officer can unlock it now.</span>")
+		if(!allowed(user))
+			to_chat(user, "<span class='warning'>Access denied.</span>")
 			playsound(loc,'sound/machines/buzz-two.ogg', 25, FALSE)
 			return
 		locked = !locked
 		user.visible_message("<span class='notice'>[user] [locked ? "locks" : "unlocks"] [src]'s interface.</span>",
 		"<span class='notice'>You [locked ? "lock" : "unlock"] [src]'s interface.</span>")
 	else if(istype(O,/obj/item/roller/medevac))
-		if(locked && !allowed(user))
-			to_chat(user, "<span class='warning'>Access denied.</span>")
+		if(locked)
+			to_chat(user, "<span class='warning'>[src]'s interface is locked! Only a Squad Leader, Corpsman, or Medical Officer can unlock it now.</span>")
 			playsound(loc,'sound/machines/buzz-two.ogg', 25, FALSE)
 			return
 		var/obj/item/roller/medevac/R = O


### PR DESCRIPTION
## About The Pull Request

Can't overwrite a beacon while locked. Should prevent The Bad Thing:tm:.

## Why It's Good For The Game

I've seen it happen.

## Changelog
:cl:
tweak: Medevac beacons can no longer be linked/re-linked to a bed while locked.
/:cl:

<hr>
Note: This has not been tested. Shouldn't Break Anything, Though.:tm: