### PR TITLE
Shift xenos to use armor datums

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -143,6 +143,8 @@
 	var/time_of_birth
 
 	var/devour_timer = 0
+	
+	var/datum/armor/armor
 
 	var/evolution_stored = 0 //How much evolution they have stored
 


### PR DESCRIPTION
will require xeno signals to be done first.