### PR TITLE
Meralyne

### DIFF
--- a/code/modules/reagents/chemistry_reactions/medical.dm
+++ b/code/modules/reagents/chemistry_reactions/medical.dm
@@ -37,6 +37,12 @@
 	results = list("bicaridine" = 2)
 	required_reagents = list("inaprovaline" = 1, "carbon" = 1)
 
+/datum/chemical_reaction/meralyne
+	name = "Meralyne"
+	id = "meralyne"
+	results = list("meralyne" = 2)
+	required_reagents = list("inaprovaline" = 1, "bicaridine" = 1, "iron" = 1)
+
 /datum/chemical_reaction/hyperzine
 	name = "Hyperzine"
 	id = "hyperzine"

--- a/code/modules/reagents/chemistry_reagents/medical.dm
+++ b/code/modules/reagents/chemistry_reagents/medical.dm
@@ -640,7 +640,7 @@ datum/reagent/medicine/synaptizine/overdose_crit_process(mob/living/M, alien)
 	M.heal_limb_damage(4 * REM, 0)
 	M.reagent_move_delay_modifier += 1
 	
-	..()
+	return ..()
 
 /datum/reagent/medicine/meralyne/overdose_process(mob/living/M, alien)
 	M.apply_damage(2, BURN)

--- a/code/modules/reagents/chemistry_reagents/medical.dm
+++ b/code/modules/reagents/chemistry_reagents/medical.dm
@@ -639,8 +639,9 @@ datum/reagent/medicine/synaptizine/overdose_crit_process(mob/living/M, alien)
 /datum/reagent/medicine/meralyne/on_mob_life(mob/living/M, alien)
 	. = ..()
 	M.heal_limb_damage(4 * REM, 0)
-	slowdown = 1.5
-
+	M.reagent_move_delay_modifier += 1
+	
+..()
 
 /datum/reagent/medicine/meralyne/overdose_process(mob/living/M, alien)
 	M.apply_damage(2, BURN)

--- a/code/modules/reagents/chemistry_reagents/medical.dm
+++ b/code/modules/reagents/chemistry_reagents/medical.dm
@@ -639,6 +639,7 @@ datum/reagent/medicine/synaptizine/overdose_crit_process(mob/living/M, alien)
 /datum/reagent/medicine/meralyne/on_mob_life(mob/living/M, alien)
 	. = ..()
 	M.heal_limb_damage(4 * REM, 0)
+	slowdown = 1.5
 
 
 /datum/reagent/medicine/meralyne/overdose_process(mob/living/M, alien)

--- a/code/modules/reagents/chemistry_reagents/medical.dm
+++ b/code/modules/reagents/chemistry_reagents/medical.dm
@@ -637,11 +637,10 @@ datum/reagent/medicine/synaptizine/overdose_crit_process(mob/living/M, alien)
 	scannable = TRUE
 
 /datum/reagent/medicine/meralyne/on_mob_life(mob/living/M, alien)
-	. = ..()
 	M.heal_limb_damage(4 * REM, 0)
 	M.reagent_move_delay_modifier += 1
 	
-..()
+	..()
 
 /datum/reagent/medicine/meralyne/overdose_process(mob/living/M, alien)
 	M.apply_damage(2, BURN)

--- a/code/modules/reagents/chemistry_reagents/medical.dm
+++ b/code/modules/reagents/chemistry_reagents/medical.dm
@@ -638,7 +638,7 @@ datum/reagent/medicine/synaptizine/overdose_crit_process(mob/living/M, alien)
 
 /datum/reagent/medicine/meralyne/on_mob_life(mob/living/L, alien)
 	L.heal_limb_damage(4 * REM, 0)
-	M.reagent_move_delay_modifier += 1
+	L.reagent_move_delay_modifier += 1
 	
 	return ..()
 

--- a/code/modules/reagents/chemistry_reagents/medical.dm
+++ b/code/modules/reagents/chemistry_reagents/medical.dm
@@ -646,7 +646,7 @@ datum/reagent/medicine/synaptizine/overdose_crit_process(mob/living/M, alien)
 	L.apply_damage(2, BURN)
 
 /datum/reagent/medicine/meralyne/overdose_crit_process(mob/living/L, alien)
-	M.apply_damages(2, 6, 4)
+	L.apply_damages(2, 6, 4)
 
 /datum/reagent/medicine/quickclot
 	name = "Quick Clot"

--- a/code/modules/reagents/chemistry_reagents/medical.dm
+++ b/code/modules/reagents/chemistry_reagents/medical.dm
@@ -643,7 +643,7 @@ datum/reagent/medicine/synaptizine/overdose_crit_process(mob/living/M, alien)
 	return ..()
 
 /datum/reagent/medicine/meralyne/overdose_process(mob/living/L, alien)
-	M.apply_damage(2, BURN)
+	L.apply_damage(2, BURN)
 
 /datum/reagent/medicine/meralyne/overdose_crit_process(mob/living/M, alien)
 	M.apply_damages(2, 6, 4)

--- a/code/modules/reagents/chemistry_reagents/medical.dm
+++ b/code/modules/reagents/chemistry_reagents/medical.dm
@@ -642,7 +642,7 @@ datum/reagent/medicine/synaptizine/overdose_crit_process(mob/living/M, alien)
 	
 	return ..()
 
-/datum/reagent/medicine/meralyne/overdose_process(mob/living/M, alien)
+/datum/reagent/medicine/meralyne/overdose_process(mob/living/L, alien)
 	M.apply_damage(2, BURN)
 
 /datum/reagent/medicine/meralyne/overdose_crit_process(mob/living/M, alien)

--- a/code/modules/reagents/chemistry_reagents/medical.dm
+++ b/code/modules/reagents/chemistry_reagents/medical.dm
@@ -637,7 +637,7 @@ datum/reagent/medicine/synaptizine/overdose_crit_process(mob/living/M, alien)
 	scannable = TRUE
 
 /datum/reagent/medicine/meralyne/on_mob_life(mob/living/L, alien)
-	M.heal_limb_damage(4 * REM, 0)
+	L.heal_limb_damage(4 * REM, 0)
 	M.reagent_move_delay_modifier += 1
 	
 	return ..()

--- a/code/modules/reagents/chemistry_reagents/medical.dm
+++ b/code/modules/reagents/chemistry_reagents/medical.dm
@@ -636,7 +636,7 @@ datum/reagent/medicine/synaptizine/overdose_crit_process(mob/living/M, alien)
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL*0.5
 	scannable = TRUE
 
-/datum/reagent/medicine/meralyne/on_mob_life(mob/living/M, alien)
+/datum/reagent/medicine/meralyne/on_mob_life(mob/living/L, alien)
 	M.heal_limb_damage(4 * REM, 0)
 	M.reagent_move_delay_modifier += 1
 	

--- a/code/modules/reagents/chemistry_reagents/medical.dm
+++ b/code/modules/reagents/chemistry_reagents/medical.dm
@@ -645,7 +645,7 @@ datum/reagent/medicine/synaptizine/overdose_crit_process(mob/living/M, alien)
 /datum/reagent/medicine/meralyne/overdose_process(mob/living/L, alien)
 	L.apply_damage(2, BURN)
 
-/datum/reagent/medicine/meralyne/overdose_crit_process(mob/living/M, alien)
+/datum/reagent/medicine/meralyne/overdose_crit_process(mob/living/L, alien)
 	M.apply_damages(2, 6, 4)
 
 /datum/reagent/medicine/quickclot

--- a/code/modules/reagents/chemistry_reagents/medical.dm
+++ b/code/modules/reagents/chemistry_reagents/medical.dm
@@ -627,6 +627,26 @@ datum/reagent/medicine/synaptizine/overdose_crit_process(mob/living/M, alien)
 /datum/reagent/medicine/bicaridine/overdose_crit_process(mob/living/M, alien)
 	M.apply_damages(1, 3, 2)
 
+/datum/reagent/medicine/meralyne
+	name = "Meralyne"
+	id = "meralyne"
+	description = "Meralyne is a concentrated form of bicardine and can be used to treat extensive blunt trauma."
+	color = "#E6666C"
+	overdose_threshold = REAGENTS_OVERDOSE*0.5
+	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL*0.5
+	scannable = TRUE
+
+/datum/reagent/medicine/meralyne/on_mob_life(mob/living/M, alien)
+	. = ..()
+	M.heal_limb_damage(4 * REM, 0)
+
+
+/datum/reagent/medicine/meralyne/overdose_process(mob/living/M, alien)
+	M.apply_damage(2, BURN)
+
+/datum/reagent/medicine/meralyne/overdose_crit_process(mob/living/M, alien)
+	M.apply_damages(2, 6, 4)
+
 /datum/reagent/medicine/quickclot
 	name = "Quick Clot"
 	id = "quickclot"

--- a/html/changelogs/AutoChangeLog-pr-412.yml
+++ b/html/changelogs/AutoChangeLog-pr-412.yml
@@ -1,0 +1,4 @@
+author: "Ghommie"
+delete-after: True
+changes: 
+  - bugfix: "The rather special medevac roller beds can't be accidentally deconstructed with a wrench anymore."


### PR DESCRIPTION
## About The Pull Request

Nerfs Meralyne as part of a planned medical overhaul by adding a slowdown debuff by around 100%. It increments speed (i.e. M.reagent_move_delay_modifier) by 1.0, resulting in a 2 second slowdown over a 12 second, 5 lap, ~15 tile test run.

## Why It's Good For The Game

The nerf is part of a planned future overhaul to give kelotane/bicaridine more of a longer-term, better healing role while having patches implemented for faster, but smaller healing. This keep Meralyne's potency while reducing its effectiveness as a combat chem: making it more for situational non-combat effectiive healing and giving both the planned patches and kelobica a more combat-focused role.

## Changelog
:cl:
balance: Gave Meralyne a mild slowdown effect as part of its duration, lending it more for non-combat usage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
