### PR TITLE
Fixes req elevator crates falling down

### DIFF
--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -37,7 +37,7 @@
 		return //can't move the thing you're sitting on.
 	if(istype(target, /obj/effect))//if you click a blood splatter with a grab instead of the turf,
 		target = get_turf(target)	//we still try to move the grabbed thing to the turf.
-	if(!isturf(target))
+	if(!isturf(target) || istype(target, /turf/open/floor/almayer/empty))
 		return
 	var/turf/T = target
 	if(T.density || !T.Adjacent(user))


### PR DESCRIPTION
Fixes #947
You could actually drag them through at any time, not just when there were no railings. This is the least hacky solution until the shuttle rework.