### PR TITLE
Removes purrbation

### DIFF
--- a/code/modules/admin/verbs/datumvars.dm
+++ b/code/modules/admin/verbs/datumvars.dm
@@ -1104,18 +1104,6 @@
 		message_admins("[ADMIN_TPMONTY(usr)] has removed [rem_language] from [ADMIN_TPMONTY(L)].")
 
 
-	else if(href_list["purrbation"])
-		if(!check_rights(R_FUN))
-			return
-
-		var/mob/living/carbon/human/H = locate(href_list["purrbation"])
-		if(!istype(H))
-			to_chat(usr, "<span class='warning'>Target is no longer valid.</span>")
-			return
-
-		H.purrbate()
-
-
 	else if(href_list["getatom"])
 		if(!check_rights(R_DEBUG))
 			return

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -150,7 +150,6 @@
 	. = ..()
 	. += "---"
 	.["Set Species"] = "?_src_=vars;[HrefToken()];setspecies=[REF(src)]"
-	.["Purrbation"] = "?_src_=vars;[HrefToken()];purrbation=[REF(src)]"
 	.["Drop Everything"] = "?_src_=vars;[HrefToken()];dropeverything=[REF(src)]"
 	.["Copy Outfit"] = "?_src_=vars;[HrefToken()];copyoutfit=[REF(src)]"
 
@@ -1762,21 +1761,3 @@
 	hud_set_squad()
 
 	return TRUE
-
-
-/mob/living/carbon/human/proc/purrbate()
-	if(overlays_standing["purrbation"])
-		remove_overlay("purrbation")
-		log_admin("[key_name(usr)] has removed purrbation from [key_name(src)].")
-		message_admins("[ADMIN_TPMONTY(usr)] has removed purrbation from [ADMIN_TPMONTY(src)].")
-	else
-		var/icon/ears = new /icon("icon" = 'icons/mob/head_0.dmi', "icon_state" = "kitty")
-		var/icon/earbit = new /icon("icon" = 'icons/mob/head_0.dmi', "icon_state" = "kittyinner")
-
-		ears.Blend(rgb(r_hair, g_hair, b_hair), ICON_ADD)
-		ears.Blend(earbit, ICON_OVERLAY)
-
-		overlays_standing["purrbation"] = ears
-		apply_overlay("purrbation")
-		log_admin("[key_name(usr)] has purrbated [key_name(src)].")
-		message_admins("[ADMIN_TPMONTY(usr)] has purrbated [ADMIN_TPMONTY(src)].")


### PR DESCRIPTION
Kind of not really fitting for our game mode and the tone of our game.

Besides, if we want to add cosmetic items, it must be for everyone, and not just for some. This set bad precedents, as some people would be denied felinid aesthetics while others would be granted, depending on admin mood, stance and preference. Too much room for problems, and really bad for RP immersion.

If Felinids are added to the code will be a larger decision, and it will follow some RP standards. Or we'll throw the RP rules out of the window. Can't really be saying much about LRP if we are doing this as an administration.

## Changelog
:cl:
del: Removes purrbation. No more felinid ears and tail on prayer-demand.
/:cl: