### PR TITLE
Supply drops begone.

### DIFF
--- a/code/datums/emergency_calls/supplies.dm
+++ b/code/datums/emergency_calls/supplies.dm
@@ -41,7 +41,7 @@
 	name = "Supply Drop"
 	mob_max = 0
 	mob_min = 0
-	probability = 5
+	probability = 0
 	auto_shuttle_launch = TRUE
 
 


### PR DESCRIPTION
I have no idea why this was a ever a thing.

## Changelog
:cl:
del: There is no longer a 5% chance of the distress beacon returning just a couple of supply crates instead of an ERT with actual people in it.
/:cl: