### PR TITLE
debunks snowflake wooden barricades.

### DIFF
--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -397,8 +397,8 @@
 	can_wire = FALSE
 
 /obj/structure/barricade/wooden/lv_snowflake
-	desc = "This barricade is heavily reinforced. Nothing short of blasting it open seems like it'll do the trick, that or melting the beams supporting it..."
-	max_integrity = 25000
+	desc = "A reinforced wooden barricade. Pretty good for keeping lousy neighbours away."
+	max_integrity = 400
 
 /obj/structure/barricade/wooden/attackby(obj/item/W as obj, mob/user as mob)
 	for(var/obj/effect/xenomorph/acid/A in src.loc)

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -397,7 +397,7 @@
 	can_wire = FALSE
 
 /obj/structure/barricade/wooden/lv_snowflake
-	desc = "A reinforced wooden barricade. Pretty good for keeping lousy neighbours away."
+	desc = "A reinforced wooden barricade. Pretty good at keeping neighbours away from your lawn."
 	max_integrity = 400
 
 /obj/structure/barricade/wooden/attackby(obj/item/W as obj, mob/user as mob)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Closes #1461.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes big red, lv etc premapped wooden barricades a bit less insane.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Sanitizes a handful of premapped snowflake wooden barricades' integrity from 25000 down to 400.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
