### PR TITLE
Fixes RPG reloading issues

### DIFF
--- a/code/modules/projectiles/updated_projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/specialist.dm
@@ -800,6 +800,17 @@
 		current_mag.current_rounds++
 	return TRUE
 
+
+/obj/item/weapon/gun/launcher/rocket/replace_magazine(mob/user, obj/item/ammo_magazine/magazine)
+	user.transferItemToLoc(magazine, src) //Click!
+	current_mag = magazine
+	user.visible_message("<span class='notice'>[user] loads [magazine] into [src]!</span>",
+	"<span class='notice'>You load [magazine] into [src]!</span>", null, 3)
+	if(reload_sound)
+		playsound(user, reload_sound, 25, 1, 5)
+	update_icon()
+
+
 /obj/item/weapon/gun/launcher/rocket/unload(mob/user)
 	if(!user)
 		return


### PR DESCRIPTION
A snowflake override is needed since RPGs are not using their chambers for reloading just for firing and reloading manually would break it.

:cl: LaKiller8
fix: You can now unload and reload RPGs properly again
/:cl:
Fixes: #1164 