### PR TITLE
synth repair

### DIFF
--- a/code/game/objects/items/stacks/cable_coil.dm
+++ b/code/game/objects/items/stacks/cable_coil.dm
@@ -135,7 +135,7 @@
 								"<span class='warning'>You repair some burn damage on \the [H]'s [S.display_name] with \the [src].</span>")
 			return
 		else
-			to_chat(user, "Nothing to fix!")
+			to_chat(user, "<span class='warning'>Nothing to fix!</span>")
 
 	else
 		return ..()

--- a/code/game/objects/items/stacks/cable_coil.dm
+++ b/code/game/objects/items/stacks/cable_coil.dm
@@ -128,7 +128,7 @@
 		
 		if(S.burn_dam > 0 && use(1))
 			if(issynth(H) && M == user)
-				if(user.action_busy || !do_after(user, 5 SECONDS, TRUE, 5, BUSY_ICON_BUILD))
+				if(user.action_busy || !do_after(user, 5 SECONDS, TRUE, src, BUSY_ICON_BUILD))
 					return
 			S.heal_damage(0,15,0,1)
 			user.visible_message("<span class='warning'>\The [user] repairs some burn damage on \the [H]'s [S.display_name] with \the [src].</span>", \

--- a/code/game/objects/items/stacks/cable_coil.dm
+++ b/code/game/objects/items/stacks/cable_coil.dm
@@ -122,7 +122,7 @@
 		var/datum/limb/S = M:get_limb(user.zone_selected)
 
 		if(!S) 
-		return
+			return
 		if(!(S.limb_status & LIMB_ROBOT) || user.a_intent == INTENT_HARM)
 			return ..()
 		

--- a/code/game/objects/items/stacks/cable_coil.dm
+++ b/code/game/objects/items/stacks/cable_coil.dm
@@ -118,20 +118,20 @@
     
 /obj/item/stack/cable_coil/attack(mob/M as mob, mob/user as mob)
 	if(hasorgans(M))
+		var/mob/living/carbon/human/H = M
 		var/datum/limb/S = M:get_limb(user.zone_selected)
+
+		if(!S) return
 		if(!(S.limb_status & LIMB_ROBOT) || user.a_intent == INTENT_HARM)
 			return ..()
-
-		if(istype(M,/mob/living/carbon/human))
-			var/mob/living/carbon/human/H = M
-			if(H.species.species_flags & IS_SYNTHETIC)
-				if(M == user)
-					to_chat(user, "<span class='warning'>You can't repair damage to your own body - it's against OH&S.</span>")
-					return
-
+		
 		if(S.burn_dam > 0 && use(1))
+			if(issynth(H) && M == user)
+				if(user.action_busy || !do_after(user, 5 SECONDS, TRUE, 5, BUSY_ICON_BUILD))
+					return
 			S.heal_damage(0,15,0,1)
-			user.visible_message("<span class='warning'> \The [user] repairs some burn damage on \the [M]'s [S.display_name] with \the [src].</span>")
+			user.visible_message("<span class='warning'>\The [user] repairs some burn damage on \the [H]'s [S.display_name] with \the [src].</span>", \
+								"<span class='warning'>You repair some burn damage on \the [H]'s [S.display_name] with \the [src].</span>")
 			return
 		else
 			to_chat(user, "Nothing to fix!")

--- a/code/game/objects/items/stacks/cable_coil.dm
+++ b/code/game/objects/items/stacks/cable_coil.dm
@@ -121,7 +121,8 @@
 		var/mob/living/carbon/human/H = M
 		var/datum/limb/S = M:get_limb(user.zone_selected)
 
-		if(!S) return
+		if(!S) 
+		return
 		if(!(S.limb_status & LIMB_ROBOT) || user.a_intent == INTENT_HARM)
 			return ..()
 		

--- a/code/game/objects/items/stacks/cable_coil.dm
+++ b/code/game/objects/items/stacks/cable_coil.dm
@@ -119,7 +119,7 @@
 /obj/item/stack/cable_coil/attack(mob/M as mob, mob/user as mob)
 	if(hasorgans(M))
 		var/mob/living/carbon/human/H = M
-		var/datum/limb/S = M:get_limb(user.zone_selected)
+		var/datum/limb/S = H.get_limb(user.zone_selected)
 
 		if(!S) 
 			return

--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -202,20 +202,19 @@
 		if(!(S.limb_status & LIMB_ROBOT) || user.a_intent != INTENT_HELP)
 			return ..()
 
-		if(issynth(H))
-			if(M == user)
-				to_chat(user, "<span class='warning'>You can't repair damage to your own body - it's against OH&S.</span>")
-				return
-
 		if(S.brute_dam && welding)
+			if(issynth(H) && M == user)
+				if(user.action_busy || !do_after(user, 5 SECONDS, TRUE, 5, BUSY_ICON_BUILD))
+					return
 			S.heal_damage(15,0,0,1)
 			H.UpdateDamageIcon()
 			user.visible_message("<span class='warning'>\The [user] patches some dents on \the [H]'s [S.display_name] with \the [src].</span>", \
 								"<span class='warning'>You patch some dents on \the [H]'s [S.display_name] with \the [src].</span>")
 			remove_fuel(1,user)
+			playsound(user.loc, 'sound/items/Welder2.ogg', 25, 1)
 			return
 		else
-			to_chat(user, "<span class='warning'>Nothing to fix!</span>")
+			to_chat(user, "Nothing to fix!")
 
 	else
 		return ..()

--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -204,7 +204,7 @@
 
 		if(S.brute_dam && welding)
 			if(issynth(H) && M == user)
-				if(user.action_busy || !do_after(user, 5 SECONDS, TRUE, 5, BUSY_ICON_BUILD))
+				if(user.action_busy || !do_after(user, 5 SECONDS, TRUE, src, BUSY_ICON_BUILD))
 					return
 			S.heal_damage(15,0,0,1)
 			H.UpdateDamageIcon()

--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -214,7 +214,7 @@
 			playsound(user.loc, 'sound/items/Welder2.ogg', 25, 1)
 			return
 		else
-			to_chat(user, "Nothing to fix!")
+			to_chat(user, "<span class='warning'>Nothing to fix!</span>")
 
 	else
 		return ..()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes the behavior of a synthetic using cable coil and/or welders on themselves. They can now repair their own brute and burn damage after a short delay. Having someone else repair them is still faster, though.

## Why It's Good For The Game

It gives synthetic players a bare amount of self-sufficiency, which can reduce their frustration and dependency on other players, especially during lowpop rounds where there may not be any engineers. The player experience is better overall because instead of not being able to repair themselves at all, they have the ability to albeit at a slow rate. It's important to have that self-sufficiency without eliminating any need for other players at all.

## Changelog
:cl:
tweak: Synth players rejoice! You no longer have to rely on pesky humans to repair your own body (however, they still do it faster than you can).
soundadd: repairing synths with a welder now makes the welding noise.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
