### PR TITLE
adding tox bottles to med vendors

### DIFF
--- a/code/game/machinery/vending/vending_types.dm
+++ b/code/game/machinery/vending/vending_types.dm
@@ -191,7 +191,7 @@
 					/obj/item/stack/medical/splint = 5
 					)
 
-	contraband = list(/obj/item/reagent_container/glass/bottle/toxin = 2)
+	contraband = list(/obj/item/reagent_container/glass/bottle/toxin = 1)
 
 	idle_power_usage = 211 //refrigerator - believe it or not, this is actually the average power consumption of a refrigerated vending machine according to NRCan.
 

--- a/code/game/machinery/vending/vending_types.dm
+++ b/code/game/machinery/vending/vending_types.dm
@@ -191,7 +191,7 @@
 					/obj/item/stack/medical/splint = 5
 					)
 
-	contraband = list()
+	contraband = list(/obj/item/reagent_container/glass/bottle/toxin = 2)
 
 	idle_power_usage = 211 //refrigerator - believe it or not, this is actually the average power consumption of a refrigerated vending machine according to NRCan.
 

--- a/code/game/objects/items/reagent_containers/glass/bottle.dm
+++ b/code/game/objects/items/reagent_containers/glass/bottle.dm
@@ -58,91 +58,78 @@
 /obj/item/reagent_container/glass/bottle/inaprovaline
 	name = "\improper Inaprovaline bottle"
 	desc = "A small bottle. Contains inaprovaline - used to stabilize patients."
-	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "bottle19"
 	list_reagents = list("inaprovaline" = 60)
 
 /obj/item/reagent_container/glass/bottle/kelotane
 	name = "\improper Kelotane bottle"
 	desc = "A small bottle. Contains kelotane - used to treat burned areas."
-	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "bottle16"
 	list_reagents = list("kelotane" = 60)
 
 /obj/item/reagent_container/glass/bottle/dexalin
 	name = "\improper Dexaline bottle"
 	desc = "A small bottle. Contains dexalin - used to supply blood with oxygen."
-	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "bottle10"
 	list_reagents = list("dexalin" = 60)
 
 /obj/item/reagent_container/glass/bottle/spaceacillin
 	name = "\improper Spaceacillin bottle"
 	desc = "A small bottle. Contains spaceacillin - used to treat infected wounds."
-	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "bottle8"
 	list_reagents = list("spaceacillin" = 60)
 
 /obj/item/reagent_container/glass/bottle/toxin
 	name = "toxin bottle"
 	desc = "A small bottle of toxins. Do not drink, it is poisonous."
-	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "bottle12"
 	list_reagents = list("toxin" = 60)
 
 /obj/item/reagent_container/glass/bottle/cyanide
 	name = "cyanide bottle"
 	desc = "A small bottle of cyanide. Bitter almonds?"
-	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "bottle12"
 	list_reagents = list("cyanide" = 60)
 
 /obj/item/reagent_container/glass/bottle/sleeptoxin
 	name = "soporific bottle"
 	desc = "A small bottle of soporific. Just the fumes make you sleepy."
-	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "bottle20"
 	list_reagents = list("sleeptoxin" = 60)
 
 /obj/item/reagent_container/glass/bottle/chloralhydrate
 	name = "chloral hydrate bottle"
 	desc = "A small bottle of Choral Hydrate. Mickey's Favorite!"
-	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "bottle20"
 	list_reagents = list("chloralhydrate" = 60)
 
 /obj/item/reagent_container/glass/bottle/dylovene
 	name = "dylovene bottle"
 	desc = "A small bottle of dylovene. Used to counter poisons. Basically an anti-toxin."
-	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "bottle7"
 	list_reagents = list("dylovene" = 60)
 
 /obj/item/reagent_container/glass/bottle/mutagen
 	name = "unstable mutagen bottle"
 	desc = "A small bottle of unstable mutagen. Randomly changes the DNA structure of whoever comes in contact."
-	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "bottle7"
 	list_reagents = list("mutagen" = 60)
 
 /obj/item/reagent_container/glass/bottle/ammonia
 	name = "ammonia bottle"
-	desc = "A small bottle."
-	icon = 'icons/obj/items/chemistry.dmi'
+	desc = "A small bottle of ammonia. A colourless gas with a pungent smell."
 	icon_state = "bottle20"
 	list_reagents = list("ammonia" = 60)
 
 /obj/item/reagent_container/glass/bottle/diethylamine
 	name = "diethylamine bottle"
-	desc = "A small bottle."
-	icon = 'icons/obj/items/chemistry.dmi'
+	desc = "A small bottle of diethylamine. An organic compound obtained from ammonia and ethanol."
 	icon_state = "bottle17"
 	list_reagents = list("diethylamine" = 60)
 
 /obj/item/reagent_container/glass/bottle/flu_virion
 	name = "flu virion culture bottle"
 	desc = "A small bottle. Contains H13N1 flu virion culture in synthblood medium."
-	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "bottle3"
 
 /obj/item/reagent_container/glass/bottle/flu_virion/New()
@@ -154,7 +141,6 @@
 /obj/item/reagent_container/glass/bottle/epiglottis_virion
 	name = "epiglottis virion culture bottle"
 	desc = "A small bottle. Contains Epiglottis virion culture in synthblood medium."
-	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "bottle3"
 
 /obj/item/reagent_container/glass/bottle/epiglottis_virion/New()
@@ -166,7 +152,6 @@
 /obj/item/reagent_container/glass/bottle/liver_enhance_virion
 	name = "liver enhancement virion culture bottle"
 	desc = "A small bottle. Contains liver enhancement virion culture in synthblood medium."
-	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "bottle3"
 
 /obj/item/reagent_container/glass/bottle/liver_enhance_virion/New()
@@ -178,7 +163,6 @@
 /obj/item/reagent_container/glass/bottle/hullucigen_virion
 	name = "hullucigen virion culture bottle"
 	desc = "A small bottle. Contains hullucigen virion culture in synthblood medium."
-	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "bottle3"
 
 /obj/item/reagent_container/glass/bottle/hullucigen_virion/New()
@@ -190,7 +174,6 @@
 /obj/item/reagent_container/glass/bottle/pierrot_throat
 	name = "\improper Pierrot's Throat culture bottle"
 	desc = "A small bottle. Contains H0NI<42 virion culture in synthblood medium."
-	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "bottle3"
 
 /obj/item/reagent_container/glass/bottle/pierrot_throat/New()
@@ -202,7 +185,6 @@
 /obj/item/reagent_container/glass/bottle/cold
 	name = "rhinovirus culture bottle"
 	desc = "A small bottle. Contains XY-rhinovirus culture in synthblood medium."
-	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "bottle3"
 
 /obj/item/reagent_container/glass/bottle/cold/New()
@@ -214,7 +196,6 @@
 /obj/item/reagent_container/glass/bottle/random
 	name = "random culture bottle"
 	desc = "A small bottle. Contains a random disease."
-	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "bottle3"
 
 /obj/item/reagent_container/glass/bottle/random/New()
@@ -226,7 +207,6 @@
 /obj/item/reagent_container/glass/bottle/retrovirus
 	name = "retrovirus culture bottle"
 	desc = "A small bottle. Contains a retrovirus culture in a synthblood medium."
-	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "bottle3"
 
 /obj/item/reagent_container/glass/bottle/retrovirus/New()
@@ -238,7 +218,6 @@
 /obj/item/reagent_container/glass/bottle/gbs
 	name = "\improper GBS culture bottle"
 	desc = "A small bottle. Contains Gravitokinetic Bipotential SADS+ culture in synthblood medium."//Or simply - General BullShit
-	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "bottle3"
 	amount_per_transfer_from_this = 5
 
@@ -252,7 +231,6 @@
 /obj/item/reagent_container/glass/bottle/fake_gbs
 	name = "\improper GBS culture bottle"
 	desc = "A small bottle. Contains Gravitokinetic Bipotential SADS- culture in synthblood medium."//Or simply - General BullShit
-	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "bottle3"
 
 /obj/item/reagent_container/glass/bottle/fake_gbs/New()
@@ -261,11 +239,9 @@
 	var/list/data = list("viruses"= list(F))
 	reagents.add_reagent("blood", 20, data)
 
-/*
 /obj/item/reagent_container/glass/bottle/rhumba_beat
 	name = "Rhumba Beat culture bottle"
 	desc = "A small bottle. Contains The Rhumba Beat culture in synthblood medium."//Or simply - General BullShit
-	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "bottle3"
 	amount_per_transfer_from_this = 5
 
@@ -274,12 +250,10 @@
 	var/datum/disease/F = new /datum/disease/rhumba_beat(0)
 	var/list/data = list("virus"= list(F))
 	reagents.add_reagent("blood", 20, data)
-*/
 
 /obj/item/reagent_container/glass/bottle/brainrot
 	name = "\improper Brainrot culture bottle"
 	desc = "A small bottle. Contains Cryptococcus Cosmosis culture in synthblood medium."
-	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "bottle3"
 
 /obj/item/reagent_container/glass/bottle/brainrot/New()
@@ -291,7 +265,6 @@
 /obj/item/reagent_container/glass/bottle/magnitis
 	name = "\improper Magnitis culture bottle"
 	desc = "A small bottle. Contains a small dosage of Fukkos Miracos."
-	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "bottle3"
 
 /obj/item/reagent_container/glass/bottle/magnitis/New()
@@ -303,7 +276,6 @@
 /obj/item/reagent_container/glass/bottle/wizarditis
 	name = "\improper Wizarditis culture bottle"
 	desc = "A small bottle. Contains a sample of Rincewindus Vulgaris."
-	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "bottle3"
 
 /obj/item/reagent_container/glass/bottle/wizarditis/New()
@@ -315,42 +287,36 @@
 /obj/item/reagent_container/glass/bottle/pacid
 	name = "polytrinic acid bottle"
 	desc = "A small bottle. Contains a small amount of Polytrinic Acid"
-	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "bottle17"
 	list_reagents = list("pacid" = 60)
 
 /obj/item/reagent_container/glass/bottle/adminordrazine
 	name = "\improper Adminordrazine bottle"
 	desc = "A small bottle. Contains the liquid essence of the gods."
-	icon = 'icons/obj/items/drinks.dmi'
 	icon_state = "holyflask"
 	list_reagents = list("adminordrazine" = 60)
 
 /obj/item/reagent_container/glass/bottle/capsaicin
 	name = "\improper Capsaicin bottle"
 	desc = "A small bottle. Contains hot sauce."
-	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "bottle3"
 	list_reagents = list("capsaicin" = 60)
 
 /obj/item/reagent_container/glass/bottle/frostoil
 	name = "\improper Frost Oil bottle"
 	desc = "A small bottle. Contains cold sauce."
-	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "bottle17"
 	list_reagents = list("frostoil" = 60)
 
 /obj/item/reagent_container/glass/bottle/bicaridine
 	name = "\improper Bicaridine bottle"
 	desc = "A small bottle. Contains Bicaridine - Used to treat brute damage by doctors."
-	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "bottle17"
 	list_reagents = list("bicaridine" = 60)
 
 /obj/item/reagent_container/glass/bottle/peridaxon
 	name = "\improper Peridaxon bottle"
 	desc = "A small bottle. Contains Peridaxon - Used by lazy doctors to treat internal organ damage."
-	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "bottle4"
 	volume = 20
 	list_reagents = list("peridaxon" = 20)
@@ -358,7 +324,6 @@
 /obj/item/reagent_container/glass/bottle/tramadol
 	name = "\improper Tramadol bottle"
 	desc = "A small bottle. Contains Tramadol - Used as a basic painkiller."
-	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "bottle1"
 	volume = 20
 	list_reagents = list("tramadol" = 20)
@@ -366,7 +331,6 @@
 /obj/item/reagent_container/glass/bottle/oxycodone
 	name = "\improper Oxycodone bottle"
 	desc = "A very small bottle. Contains Oxycodone - Used as an Extreme Painkiller."
-	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "bottle2"
 	volume = 10
 	list_reagents = list("oxycodone" = 10)
@@ -374,7 +338,6 @@
 /obj/item/reagent_container/glass/bottle/hypervene
 	name = "\improper Hypervene bottle"
 	desc = "A very small bottle. Contains Hypervene - A purge chem for flushing toxins. Causes pain and vomiting."
-	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "bottle3"
 	volume = 10
 	list_reagents = list("hypervene" = 10)
@@ -382,13 +345,11 @@
 /obj/item/reagent_container/glass/bottle/tricordrazine
 	name = "\improper Tricordrazine bottle"
 	desc = "A small bottle. Contains tricordrazine - used as a generic treatment for injuries."
-	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "bottle18"
 	list_reagents = list("tricordrazine" = 60)
 
 /obj/item/reagent_container/glass/bottle/dermaline
 	name = "\improper Dermaline bottle"
 	desc = "A small bottle. Contains dermaline - used as a potent treatment against burns."
-	icon = 'icons/obj/items/chemistry.dmi'
 	icon_state = "bottle14"
 	list_reagents = list("dermaline" = 15)

--- a/code/modules/reagents/chemistry_reagents/toxin.dm
+++ b/code/modules/reagents/chemistry_reagents/toxin.dm
@@ -219,10 +219,9 @@
 	taste_multi = 1
 
 /datum/reagent/toxin/plantbgone/reaction_obj(obj/O, volume)
-	if(istype(O,/obj/effect/alien/weeds/))
-		var/obj/effect/alien/weeds/alien_weeds = O
-		alien_weeds.obj_integrity -= rand(15,35) // Kills alien weeds pretty fast
-		alien_weeds.healthcheck()
+	if(istype(O,/obj/effect/alien/weeds))
+		var/obj/effect/alien/A = O
+		A.take_damage(min(0.5 * volume))
 	else if(istype(O,/obj/effect/glowshroom)) //even a small amount is enough to kill it
 		qdel(O)
 	else if(istype(O,/obj/effect/plantsegment))


### PR DESCRIPTION
## About The Pull Request
Let "chemists" get their hands on the base toxin chemical which is required to have fun using plantbgone on alien weeds. Also balances plantbgone effects instead of simply nuking alien weeds. Additional code cleanup.
I refrained from balancing weeds health as it's done already in #1551.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Expanding the scope of the game. And the base toxin is also fairly weak, mediocre as grief tool compared to other poisons or ODs.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds a bottle of base toxin to the med-vendors contraband for your chemistry needs.
balance: Balanced plantbgone effects on resin structures to scale with volume.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
