### PR TITLE
Adds laughter, makes contraband pills not so bad.

### DIFF
--- a/code/game/objects/items/reagent_containers/pill.dm
+++ b/code/game/objects/items/reagent_containers/pill.dm
@@ -245,7 +245,7 @@ var/global/list/randomized_pill_icons
 
 /obj/item/reagent_container/pill/zoom
 	pill_desc = "A Zoom pill! Gotta go fast!"
-	list_reagents = list("synaptizine" = 5, "hyperzine" = 5, "nutriment" = 2, "ultrazine" = 1)
+	list_reagents = list("synaptizine" = 5, "hyperzine" = 5, "nutriment" = 2)
 
 /obj/item/reagent_container/pill/zoom/New()
 	. = ..()

--- a/code/game/objects/items/reagent_containers/pill.dm
+++ b/code/game/objects/items/reagent_containers/pill.dm
@@ -237,7 +237,7 @@ var/global/list/randomized_pill_icons
 
 /obj/item/reagent_container/pill/happy
 	pill_desc = "A Happy Pill! Happy happy joy joy!"
-	list_reagents = list("space_drugs" = 15, "sugar" = 15)
+	list_reagents = list("space_drugs" = 15, "sugar" = 15, "laughter" = 5)
 
 /obj/item/reagent_container/pill/happy/New()
 	. = ..()
@@ -245,7 +245,7 @@ var/global/list/randomized_pill_icons
 
 /obj/item/reagent_container/pill/zoom
 	pill_desc = "A Zoom pill! Gotta go fast!"
-	list_reagents = list("impedrezene" = 10, "synaptizine" = 5, "hyperzine" = 5)
+	list_reagents = list("synaptizine" = 5, "hyperzine" = 5, "nutriment" = 2, "ultrazine" = 1)
 
 /obj/item/reagent_container/pill/zoom/New()
 	. = ..()

--- a/code/modules/reagents/chemistry_reactions/other.dm
+++ b/code/modules/reagents/chemistry_reactions/other.dm
@@ -363,3 +363,9 @@
 	id = "plantbgone"
 	results = list("plantbgone" = 5)
 	required_reagents = list("toxin" = 1, "water" = 4)
+
+/datum/chemical_reaction/laughter
+	name = "laughter"
+	id = "laughter"
+	results = list("laughter" = 5)
+	required_reagents = list("sugar" = 1, "banana" = 1)

--- a/code/modules/reagents/chemistry_reagents/drink.dm
+++ b/code/modules/reagents/chemistry_reagents/drink.dm
@@ -153,6 +153,19 @@
 	description = "Absolutely nothing."
 	taste_description = "nothing"
 
+
+/datum/reagent/consumable/laughter
+	name = "Laughter"
+	id = "laughter"
+	description = "Some say that this is the best medicine, but recent studies have proven that to be untrue."
+	custom_metabolism = INFINITY
+	color = "#FF4DD2"
+	taste_description = "laughter"
+
+/datum/reagent/consumable/laughter/on_mob_life(mob/living/carbon/M)
+	M.emote("laugh")
+	return ..()
+
 /datum/reagent/consumable/drink/potato_juice
 	name = "Potato Juice"
 	id = "potato"


### PR DESCRIPTION
## About The Pull Request
Been a long time when I first said contraband pill bottles needed a boost.
Removed the Impredrezene from zoom pills, added in 2 units of nutriment (softly balancing the effects of hyperzine). Ported the laughter chem and added it to happy pills since I'm not in the mood of coding a big reference to videogames right now.

## Why It's Good For The Game
Makes these stuff less garbage.

## Changelog
:cl:
add: Ported the laughter reagent, made by combining 1u of banana juice and 1u of sugar, resulting in 5u instead of 2u. Can be now found in happy pills.
balance: Balanced zoom pills not to be as garbage. removed the brain-crippling 10u of Impedrezene and added 2u of nutriment.
/:cl:
