### PR TITLE
Fixes an ancient init runtime

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -30,13 +30,13 @@ var/global/list/image/splatter_cache=list()
 		return
 	if(istype(src, /obj/effect/decal/cleanable/blood/tracks))
 		return // We handle our own drying.
-	if(src.type == /obj/effect/decal/cleanable/blood)
-		if(src.loc && isturf(src.loc))
-			for(var/obj/effect/decal/cleanable/blood/B in src.loc)
-				if(B != src)
-					if (B.blood_DNA)
-						blood_DNA |= B.blood_DNA.Copy()
-					qdel(B)
+	if(isturf(loc))
+		for(var/obj/effect/decal/cleanable/blood/B in loc)
+			if(B == src)
+				continue
+			if(blood_DNA)
+				B.blood_DNA |= blood_DNA.Copy()
+			return INITIALIZE_HINT_QDEL
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/effect/decal/cleanable/blood/LateInitialize()


### PR DESCRIPTION
```
[22:56:35] Runtime in unsorted.dm, line 1246: addtimer called with a callback assigned to a qdeleted object. In the future such timers will not be supported and may refuse to run or run with a 0 wait
proc name: stack trace (/proc/stack_trace)
src: null
call stack:
stack trace("addtimer called with a callbac...")
addtimer(/datum/callback (/datum/callback), 9000, 0)
the blood (/obj/effect/decal/cleanable/blood/splatter): LateInitialize()
Atoms (/datum/controller/subsystem/atoms): InitializeAtoms(null)
Atoms (/datum/controller/subsystem/atoms): Initialize(825888)
Master (/datum/controller/master): Initialize(10, 0, 1)
```