### PR TITLE
Possibly fixes another runtime

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -446,7 +446,7 @@
 		var/mob/living/carbon/human/H = usr
 		H.swap_hand()
 	else
-		var/turf/T = params2turf(modifiers["screen-loc"], get_turf(usr.client ? usr.client.eye : usr), usr.client)
+		var/turf/T = params2turf(modifiers["screen-loc"], get_turf(usr.client?.eye ? usr.client.eye : usr), usr.client)
 		params += "&catcher=1"
 		T?.Click(location, control, params)
 	. = TRUE


### PR DESCRIPTION
```
[00:05:10] Runtime in unsorted.dm, line 1071: Cannot read null.z
proc name: params2turf (/proc/params2turf)
usr: Nwd72/(Nwd72)
src: null
call stack:
params2turf("10:18,6:23", null, Nwd72 (/client))
(/obj/screen/click_catcher): Click(null, "mapwindow.map", "icon-x=306;icon-y=183;left=1;s...")
Nwd72 (/client): Click( (/obj/screen/click_catcher), null, "mapwindow.map", "icon-x=306;icon-y=183;left=1;s...")
```
The eye may be null while in a race condition in the process of being set up