### PR TITLE
Fixes unconscious xenos sight.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -53,11 +53,14 @@
 			death()
 		return
 
-	if(knocked_out || sleeping || health < 0)
+	if(knocked_out || sleeping || health < get_crit_threshold())
+		if(stat != UNCONSCIOUS)
+			blind_eyes(1)
 		stat = UNCONSCIOUS
 		see_in_dark = 5
-	else
+	else if(stat == UNCONSCIOUS)
 		stat = CONSCIOUS
+		adjust_blindness(-1)
 		see_in_dark = 8
 	update_canmove()
 


### PR DESCRIPTION
## About The Pull Request
Fixing stuff since someone made xeno update_stat override parent's

## Why It's Good For The Game
Unconscious xeno sight is not a feature. Since when was this a thing without getting reported?

## Changelog
:cl:
fix: Fixes xenomorphs being able to see their surroundings even while unconscious.
/:cl:
