### PR TITLE
Add an editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+# Editorconfig.org
+root = true
+
+[*]
+insert_final_newline = false
+indent_style = tab
+indent_size = 4


### PR DESCRIPTION

## About The Pull Request

Add an editorconfig.

Editorconfigs are loaded by most IDEs (if not by default there is an extension).
These preset your editor to the correct style for things like
 - Tab / Spaces
 - Tab size
 - New line at eof
 - Default charset

Right now, this applies the default of Tab's, 4 character wide, and with no new line at the end of the file.

More information: https://editorconfig.org/