### PR TITLE
Give survivors firearms 1

### DIFF
--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -46,6 +46,7 @@
 /datum/skills/civilian/survivor
 	name = "Survivor"
 	engineer = SKILL_ENGINEER_ENGI //to hack airlocks so they're never stuck in a room.
+	firearms = SKILL_FIREARMS_DEFAULT
 	construction = SKILL_CONSTRUCTION_METAL
 	medical = SKILL_MEDICAL_NOVICE
 

--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -54,15 +54,18 @@
 	name = "Survivor Doctor"
 	medical = SKILL_MEDICAL_COMPETENT
 	surgery = SKILL_SURGERY_EXPERT
+	firearms = SKILL_FIREARMS_UNTRAINED
 
 /datum/skills/civilian/survivor/scientist
 	name = "Survivor Scientist"
 	medical = SKILL_MEDICAL_PRACTICED
 	surgery = SKILL_SURGERY_PROFESSIONAL
+	firearms = SKILL_FIREARMS_UNTRAINED
 
 /datum/skills/civilian/survivor/chef
 	name = "Survivor Chef"
 	melee_weapons = SKILL_MELEE_TRAINED
+	firearms = SKILL_FIREARMS_UNTRAINED
 
 /datum/skills/civilian/survivor/miner
 	name = "Survivor Miner"
@@ -92,6 +95,7 @@
 	name = "Survivor Clown"
 	cqc = SKILL_CQC_MP
 	melee_weapons = SKILL_MELEE_SUPER
+	firearms = SKILL_FIREARMS_UNTRAINED
 
 
 /datum/skills/combat_engineer


### PR DESCRIPTION
On behalf of MJP ( **that guy from EU** )

## About The Pull Request

Adds firearm 1 to all survivors, except non specialist roles like doctor, scientist, clown, and chef.

## Why It's Good For The Game

```
[21:47] MJP (Amelia/Newskin/NOT EU): play survivor for a round and then miss a xeno 4 times at tile 2 with a SMG on prison
[21:47] MJP (Amelia/Newskin/NOT EU): then come back and youll see
[21:47] PsyKzz: Not a good enough reason for the PR.
[21:48] MJP (Amelia/Newskin/NOT EU): Because Survivor skills are retarded and firearms 0 makes the game literally unplayable
[21:48] MJP (Amelia/Newskin/NOT EU): Also because survivors need a buff considering how awful it is
[21:48] MJP (Amelia/Newskin/NOT EU): They can't fire the guns they get
```


## Changelog
:cl: MJP (Amelia/Newskin)
balance: Give all survivors firearms 1
/:cl:
