### PR TITLE
Runner balance tweaks

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -241,8 +241,12 @@
 			add_slowdown(staggerslow_stacks)
 		X.stealth_router(HANDLE_STEALTH_CODE_CANCEL)
 
-	damage = X.hit_and_run_bonus(damage) //Apply Runner hit and run bonus damage if applicable
-	apply_damage(damage, BRUTE, affecting, armor_block, sharp = 1, edge = 1) //This should slicey dicey
+	if(dam_bonus)
+		damage += dam_bonus
+	else //We avoid stacking, like hit-and-run and savage.
+		damage = X.hit_and_run_bonus(damage) //Apply Runner hit and run bonus damage if applicable
+
+	apply_damage(damage, BRUTE, affecting, armor_block, sharp = TRUE, edge = TRUE) //This should slicey dicey
 	updatehealth()
 
 /mob/living/silicon/attack_alien_harm(mob/living/carbon/Xenomorph/X, dam_bonus, set_location = FALSE, random_location = FALSE, no_head = FALSE, no_crit = FALSE, force_intent = null)

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
@@ -19,7 +19,7 @@
 	tackle_damage = 25
 
 	// *** Speed *** //
-	speed = -1.8
+	speed = -1.7
 
 	// *** Plasma *** //
 	plasma_max = 100
@@ -65,7 +65,7 @@
 	tackle_damage = 30
 
 	// *** Speed *** //
-	speed = -1.9
+	speed = -1.8
 
 	// *** Plasma *** //
 	plasma_max = 150
@@ -99,7 +99,7 @@
 	tackle_damage = 35
 
 	// *** Speed *** //
-	speed = -2.0
+	speed = -1.9
 
 	// *** Plasma *** //
 	plasma_max = 200
@@ -134,7 +134,7 @@
 	tackle_damage = 40
 
 	// *** Speed *** //
-	speed = -2.1
+	speed = -2
 
 	// *** Plasma *** //
 	plasma_max = 200

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/runner.dm
@@ -33,7 +33,7 @@
 	var/bonus
 	if(last_move && last_move < world.time - 5) //If we haven't moved in the last 500 ms, we lose our bonus
 		hit_and_run = 1
-	bonus = CLAMP(hit_and_run, 1, 2)//Runner deals +5% damage per tile moved in rapid succession to a maximum of +100%. Damage bonus is lost on attacking.
+	bonus = min(hit_and_run, 2)//Runner deals +5% damage per tile moved in rapid succession to a maximum of +100%. Damage bonus is lost on attacking.
 	switch(bonus)
 		if(2)
 			visible_message("<span class='danger'>\The [src] strikes with lethal speed!</span>", \

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/runner.dm
@@ -7,7 +7,7 @@
 	health = 100
 	maxHealth = 100
 	plasma_stored = 50
-	speed = -1.8
+	speed = -1.7
 	flags_pass = PASSTABLE
 	tier = XENO_TIER_ONE
 	upgrade = XENO_UPGRADE_ZERO

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -231,7 +231,7 @@
 		. -= (frenzy_aura * 0.05)
 
 	if(hit_and_run) //We need to have the hit and run ability before we do anything
-		hit_and_run = min(2, hit_and_run + 0.05) //increment the damage of our next attack by +5% up to 200%
+		hit_and_run += 0.05 //increment the damage of our next attack by +5%
 
 	if(is_charging)
 		if(legcuffed)


### PR DESCRIPTION
## Changelog
:cl:
balance: Runner speed got a tiny nerf. Their savage skill no longer stacks with the hit-and-run damage bonus either.
fix: Fixes a bug preventing xenos with special attacks from dealing extra damage, like ravager's rage and runner hit-and-run.
/:cl: