### PR TITLE
Fixes busy icons displaying over screen objects.

### DIFF
--- a/code/__DEFINES/progress_display.dm
+++ b/code/__DEFINES/progress_display.dm
@@ -28,13 +28,13 @@
 
 //busy icons defines
 
-#define BUSY_ICON_GENERIC		/image/progress/display
-#define BUSY_ICON_MEDICAL		/image/progress/display/medical
-#define BUSY_ICON_BUILD			/image/progress/display/construction
-#define BUSY_ICON_FRIENDLY		/image/progress/display/friendly
-#define BUSY_ICON_HOSTILE		/image/progress/display/hostile
-#define BUSY_ICON_CLOCK			/image/progress/display/clock
-#define BUSY_ICON_CLOCK_ALT		/image/progress/display/clock/alt
-#define BUSY_ICON_DANGER 		/image/progress/display/danger
-#define BUSY_ICON_BAR			/image/progress/display/bar
-#define BUSY_ICON_UNSKILLED		/image/progress/display/unskilled
+#define BUSY_ICON_GENERIC		/image/progdisplay
+#define BUSY_ICON_MEDICAL		/image/progdisplay/medical
+#define BUSY_ICON_BUILD			/image/progdisplay/construction
+#define BUSY_ICON_FRIENDLY		/image/progdisplay/friendly
+#define BUSY_ICON_HOSTILE		/image/progdisplay/hostile
+#define BUSY_ICON_CLOCK			/image/progdisplay/clock
+#define BUSY_ICON_CLOCK_ALT		/image/progdisplay/clock/alt
+#define BUSY_ICON_DANGER 		/image/progdisplay/danger
+#define BUSY_ICON_BAR			/image/progdisplay/bar
+#define BUSY_ICON_UNSKILLED		/image/progdisplay/unskilled

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -138,6 +138,7 @@
 		name = "[name] ([plasma_cost])"
 	button.overlays += image('icons/mob/actions.dmi', button, action_icon_state)
 	cooldown_image = image('icons/effects/progressicons.dmi', null, "busy_clock")
+	cooldown_image.pixel_y = 7
 	cooldown_image.appearance_flags = RESET_COLOR|RESET_ALPHA
 
 /datum/action/xeno_action/can_use_action(silent = FALSE, override_flags)

--- a/code/datums/progressbar.dm
+++ b/code/datums/progressbar.dm
@@ -191,18 +191,18 @@
 	icon_state = "prog_bar_4"
 
 /datum/progressicon
-	var/image/progress/display/display
-	var/image/progress/display/display_tag = BUSY_ICON_GENERIC
+	var/image/progdisplay/display
+	var/image/progdisplay/display_tag = BUSY_ICON_GENERIC
 	var/atom/target
 
-/datum/progressicon/New(atom/T, image/progress/display/new_display)
+/datum/progressicon/New(atom/T, image/progdisplay/new_display)
 	. = ..()
 	if(new_display)
 		display_tag = new_display
 	target = T
 	LAZYINITLIST(target.display_icons)
 	for(var/A in target.display_icons)
-		var/image/progress/display/D = A
+		var/image/progdisplay/D = A
 		if(D.icon_state == initial(display_tag.icon_state))
 			display = D
 			break
@@ -223,38 +223,38 @@
 		QDEL_NULL(display)
 	return ..()
 
-/image/progress/display
+/image/progdisplay
 	icon = 'icons/effects/progressicons.dmi'
 	icon_state = "busy_generic"
-	plane = GAME_PLANE
+	appearance_flags = APPEARANCE_UI
 	alpha = 255
 	pixel_y = 32
 
-/image/progress/display/medical
+/image/progdisplay/medical
 	icon_state = "busy_medical"
 	pixel_y = 0
 
-/image/progress/display/construction
+/image/progdisplay/construction
 	icon_state = "busy_build"
 
-/image/progress/display/friendly
+/image/progdisplay/friendly
 	icon_state = "busy_friendly"
 
-/image/progress/display/hostile
+/image/progdisplay/hostile
 	icon_state = "busy_hostile"
 
-/image/progress/display/clock
+/image/progdisplay/clock
 	icon_state = "busy_clock"
 
-/image/progress/display/clock/alt
+/image/progdisplay/clock/alt
 	icon_state = "busy_clock2"
 
-/image/progress/display/danger
+/image/progdisplay/danger
 	icon_state = "busy_danger"
 
-/image/progress/display/bar
+/image/progdisplay/bar
 	icon_state = "busy_bar"
 
-/image/progress/display/unskilled
+/image/progdisplay/unskilled
 	icon_state = "busy_questionmark"
 

--- a/code/datums/progressbar.dm
+++ b/code/datums/progressbar.dm
@@ -226,7 +226,7 @@
 /image/progress/display
 	icon = 'icons/effects/progressicons.dmi'
 	icon_state = "busy_generic"
-	plane = FLY_LAYER
+	plane = GAME_PLANE
 	alpha = 255
 	pixel_y = 32
 


### PR DESCRIPTION
## About The Pull Request
Closes #1583. Also centers the cooldown clock icon on abilities.

## Why It's Good For The Game
Bugfixing, screen_objects don't use planes yet on master yet. Also makes the cooldown action buttons look better.

## Changelog
:cl:
fix: Fixes busy icons displaying over screen overlays such as blindness/crit etc., Also they should now respect the user invisibility/transparency.
fix: Centers the cooldown clock icon on action buttons.
/:cl:
