### PR TITLE
Add a new define for skill fumble time

### DIFF
--- a/code/__DEFINES/skills.dm
+++ b/code/__DEFINES/skills.dm
@@ -171,3 +171,6 @@
 #define SKILL_TASK_DIFFICULT	100
 #define SKILL_TASK_CHALLENGING	150
 #define SKILL_TASK_FORMIDABLE	200
+
+
+#define SKILL_FUMBLE_TIME(usr_skill, skill_req, task_diff) (usr_skill ? (max(0, task_diff * (skill_req - usr_skill))) : 0)

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -152,7 +152,7 @@
 	if(usr.mind?.cm_skills && usr.mind.cm_skills.engineer < SKILL_ENGINEER_ENGI)
 		usr.visible_message("<span class='notice'>[usr] fumbles around figuring out the wiring.</span>",
 		"<span class='notice'>You fumble around figuring out the wiring.</span>")
-		var/fumbling_time = 20 * (SKILL_ENGINEER_ENGI - usr.mind.cm_skills.engineer)
+		var/fumbling_time = SKILL_FUMBLE_TIME(usr.mind?.cm_skills.engineer, SKILL_ENGINEER_ENGI, SKILL_TASK_VERY_EASY)
 		if(!do_after(usr, fumbling_time, TRUE, holder, BUSY_ICON_UNSKILLED))
 			return
 


### PR DESCRIPTION
This PR is currently a draft, looking for feedback around the idea of it not the implementation.
Implementation is added for context mainly.

Suggestions for implementation are welcome however.

## About The Pull Request

Looking at the implementations of fumble time, it's different across the codebase.
This provides a helper to standardize how fumble time is worked out.

## Why It's Good For The Game

Consistent timing for fumbling across all actions

## Changelog
:cl:
tweak: fumbling time has been standardized across all actions 
/:cl:
