### PR TITLE
Projectiles hotfix

### DIFF
--- a/code/modules/projectiles/updated_projectiles/projectile.dm
+++ b/code/modules/projectiles/updated_projectiles/projectile.dm
@@ -236,8 +236,8 @@
 	if(!length(T.contents))
 		return FALSE
 
-	for(z in T)
-		var/atom/movable/A = z
+	for(var/a in T)
+		var/atom/movable/A = a
 		// If we've already handled this atom, don't do it again
 		if(A in permutated)
 			continue


### PR DESCRIPTION
Quick fix for projectiles. They'd runtime due to a little typo:
```
[03:30:16] Runtime in projectile.dm, line 247: Cannot execute 0.get projectile hit chance().
proc name: scan a turf (/obj/item/projectile/proc/scan_a_turf)
usr: Psykzz/(Queen)
usr.loc: (Hallway Aft (144, 179, 3))
src: the sticky resin spit (/obj/item/projectile)
src.loc: null
call stack:
the sticky resin spit (/obj/item/projectile): scan a turf(the floor (144,180,3) (/turf/open/floor/almayer))
the sticky resin spit (/obj/item/projectile): follow flightpath(4, 1, 3, 40)
```