### PR TITLE
Moves in a subsystem mistakenly forgotten during component port

### DIFF
--- a/code/controllers/stonedmc/subsystem/dcs.dm
+++ b/code/controllers/stonedmc/subsystem/dcs.dm
@@ -1,0 +1,6 @@
+SUBSYSTEM_DEF(dcs)
+	name = "Datum Component System"
+	flags = SS_NO_INIT | SS_NO_FIRE
+
+/datum/controller/subsystem/dcs/Recover()
+	comp_lookup = SSdcs.comp_lookup

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -153,6 +153,7 @@
 #include "code\controllers\stonedmc\subsystem\chat.dm"
 #include "code\controllers\stonedmc\subsystem\codex.dm"
 #include "code\controllers\stonedmc\subsystem\dbcore.dm"
+#include "code\controllers\stonedmc\subsystem\dcs.dm"
 #include "code\controllers\stonedmc\subsystem\direction.dm"
 #include "code\controllers\stonedmc\subsystem\evacuation.dm"
 #include "code\controllers\stonedmc\subsystem\garbage.dm"


### PR DESCRIPTION
This is the subsystem for component management. If we end up wanting to make components process we could turn this into a processing subsystem. Otherwise it's mainly used for globally accessible signals like getting notified when someone dies or something.

Yeah we don't have any of those signals but here's the subsystem for that to match the define already there.