### PR TITLE
Fixes a camera init runtime

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -42,7 +42,8 @@
 	GLOB.cameranet.addCamera(src)
 
 	myarea = get_area(src)
-	LAZYADD(myarea.cameras, src)
+	if(myarea)
+		LAZYADD(myarea.cameras, src)
 
 	update_icon()
 


### PR DESCRIPTION
This happens when people are getting the preview icon in the prefs.
```
[03:33:23] Runtime in camera.dm, line 48: Cannot read null.cameras
proc name: Initialize (/obj/machinery/camera/Initialize)
usr: David Stormwell/(David Stormwell)
usr.loc: (start area (46, 34, 1))
src: the security camera (/obj/machinery/camera)
src.loc: the marine command radio heads... (/obj/item/radio/headset/almayer/mcom)
call stack:
the security camera (/obj/machinery/camera): Initialize(0, null)
Atoms (/datum/controller/subsystem/atoms): InitAtom(the security camera (/obj/machinery/camera), /list (/list))
the security camera (/obj/machinery/camera): New(0)
the marine command radio heads... (/obj/item/radio/headset/almayer/mcom): Initialize(0)
Atoms (/datum/controller/subsystem/atoms): InitAtom(the marine command radio heads... (/obj/item/radio/headset/almayer/mcom), /list (/list))
the marine command radio heads... (/obj/item/radio/headset/almayer/mcom): New(0)
Field Commander (/datum/outfit/job/command/fieldcommander): equip(David \'Snakeu\' Stormwell (/mob/living/carbon/human/dummy), 1)
David \'Snakeu\' Stormwell (/mob/living/carbon/human/dummy): equipOutfit(/datum/outfit/job/command/fiel... (/datum/outfit/job/command/fieldcommander), 1)
/datum/job/command/fieldcomman... (/datum/job/command/fieldcommander): equip(David \'Snakeu\' Stormwell (/mob/living/carbon/human/dummy), 1, 1, 0, null, David Stormwell (/client))
/datum/preferences (/datum/preferences): update preview icon()
/datum/preferences (/datum/preferences): ShowChoices(David Stormwell (/mob/new_player))
/datum/preferences (/datum/preferences): process link(David Stormwell (/mob/new_player), /list (/list))
David Stormwell (/client): Topic("_src_=prefs;preference=jobclos...", /list (/list), null)
David Stormwell (/client): Topic("_src_=prefs;preference=jobclos...", /list (/list))
```