### PR TITLE
Fixes brain emote runtime.

### DIFF
--- a/code/modules/mob/living/brain/emote.dm
+++ b/code/modules/mob/living/brain/emote.dm
@@ -3,7 +3,7 @@
 	mob_type_blacklist_typecache = list()
 
 
-/datum/emote/brain/can_run_emote(mob/user, status_check = TRUE)
+/datum/emote/brain/can_run_emote(mob/user, status_check = TRUE, intentional = FALSE)
 	. = ..()
 	var/mob/living/brain/B = user
 	if(!istype(B) || (!(B.container && istype(B.container, /obj/item/mmi))))


### PR DESCRIPTION
```
[06:51:18] Runtime in , line : bad arg name 'intentional'
proc name: can run emote (/datum/emote/brain/can_run_emote)
usr: Croike/(Ashrat Zahedi)
usr.loc: (Dropship Alamo Transit (67, 36, 4))
src: /datum/emote/brain/whistle (/datum/emote/brain/whistle)
call stack:
/datum/emote/brain/whistle (/datum/emote/brain/whistle): can run emote(Ashrat Zahedi (/mob/living/carbon/human), 0, null)
/datum/emote/help (/datum/emote/help): run emote(Ashrat Zahedi (/mob/living/carbon/human), null, null, 1)
Ashrat Zahedi (/mob/living/carbon/human): emote("help", null, null, 1)
Ashrat Zahedi (/mob/living/carbon/human): check emote("*help")
Ashrat Zahedi (/mob/living/carbon/human): say("*help", null, /list (/list), 1, null, 0, null)
Ashrat Zahedi (/mob/living/carbon/human): Say("*help")
```