### PR TITLE
Fix up keybindings

### DIFF
--- a/code/datums/keybinding/client.dm
+++ b/code/datums/keybinding/client.dm
@@ -21,5 +21,5 @@
     description = "Take a screenshot."
     
 /datum/keybinding/client/screenshot/down(client/user)
-    winset(src, null, "command=.screenshot [!user.keys_held["shift"] ? "auto" : ""]")
+    winset(user, null, "command=.screenshot [!user.keys_held["shift"] ? "auto" : ""]")
     return TRUE

--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -2,9 +2,12 @@
 	category = CATEGORY_HUMAN
 	weight = WEIGHT_MOB
 
-/datum/keybinding/human/down(client/user)
+/datum/keybinding/human/New()
+	. = ..()
 	if(!keybind_signal)
 		CRASH("Keybind [src] called unredefined down() without a keybind_signal.")
+
+/datum/keybinding/human/down(client/user)
 	return CHECK_BITFIELD(SEND_SIGNAL(user.mob, keybind_signal), COMSIG_KB_ACTIVATED)
 
 

--- a/code/datums/keybinding/xeno.dm
+++ b/code/datums/keybinding/xeno.dm
@@ -2,6 +2,11 @@
 	category = CATEGORY_XENO
 	weight = WEIGHT_MOB
 
+/datum/keybinding/xeno/New()
+	. = ..()
+	if(!keybind_signal)
+		CRASH("Keybind [src] called unredefined down() without a keybind_signal.")
+
 /datum/keybinding/xeno/down(client/user)
 	if(SEND_SIGNAL(user.mob, keybind_signal) & COMSIG_KB_ACTIVATED)
 		return TRUE


### PR DESCRIPTION
## About The Pull Request

Fixes screenshot keybinding not working due to bad client
Moves check from `/down()` to `/New` to improve load.
 > As suggested by @ninjanomnom 

Note: I only moved it to human & xeno as that is the only place we are currently using the signals.

## Changelog
:cl:
fix: screenshot keybinding not working due to bad client
/:cl:

