### PR TITLE
Fixing zone selection UI icon issues.

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -350,7 +350,7 @@
 	icon_state = "zone_sel"
 	screen_loc = ui_zonesel
 	var/selecting = "chest"
-	var/static/list/hover_overlays_cache = list()
+	var/list/hover_overlays_cache = list()
 	var/hovering
 	var/z_prefix
 


### PR DESCRIPTION
## About The Pull Request
#1741 reported inconsistent hovering overlays on the zone selection UI. The nasty static list may be cause, I presume.

## Why It's Good For The Game
Bug fixing. Closes #1741, the other half of the bug report was said to be a feature.

## Changelog
:cl:
fix: fixes the zone_sel ui overlays possibly being of improper tonalities when hovered over with the pointer.
/:cl: