### PR TITLE
CMO now has a command headset

### DIFF
--- a/code/game/jobs/job/shipside.dm
+++ b/code/game/jobs/job/shipside.dm
@@ -476,7 +476,7 @@ Make sure that the doctors and nurses are doing their jobs and keeping the marin
 
 	id = /obj/item/card/id
 	belt = /obj/item/storage/belt/medical
-	ears = /obj/item/radio/headset/almayer/cmo
+	ears = /obj/item/radio/headset/almayer/mcom
 	w_uniform = /obj/item/clothing/under/rank/medical/green
 	wear_suit = /obj/item/clothing/suit/storage/labcoat
 	shoes = /obj/item/clothing/shoes/white

--- a/code/game/objects/items/radio/encryptionkey.dm
+++ b/code/game/objects/items/radio/encryptionkey.dm
@@ -23,16 +23,6 @@
 	icon_state = "med_cypherkey"
 	channels = list(RADIO_CHANNEL_MEDICAL = TRUE)
 
-/obj/item/encryptionkey/ce
-	name = "Chief Ship Engineer's Encryption Key"
-	icon_state = "ce_cypherkey"
-	channels = list(RADIO_CHANNEL_ENGINEERING = TRUE, RADIO_CHANNEL_COMMAND = TRUE)
-
-/obj/item/encryptionkey/cmo
-	name = "Chief Medical Officer's Encryption Key"
-	icon_state = "cmo_cypherkey"
-	channels = list(RADIO_CHANNEL_MEDICAL = TRUE, RADIO_CHANNEL_COMMAND = TRUE)
-
 /obj/item/encryptionkey/req
 	name = "Supply Radio Encryption Key"
 	icon_state = "cargo_cypherkey"

--- a/code/game/objects/items/radio/headset.dm
+++ b/code/game/objects/items/radio/headset.dm
@@ -286,21 +286,6 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 		usr << browse(null, "window=radio")
 
 
-/obj/item/radio/headset/almayer/ce
-	name = "chief ship engineer's headset"
-	icon_state = "com_headset"
-	keyslot = new /obj/item/encryptionkey/ce
-	use_command = TRUE
-	command = TRUE
-
-
-/obj/item/radio/headset/almayer/cmo
-	name = "chief medical officer's headset"
-	icon_state = "com_headset"
-	keyslot = new /obj/item/encryptionkey/cmo
-	use_command = TRUE
-	command = TRUE
-
 
 /obj/item/radio/headset/almayer/mt
 	name = "engineering radio headset"

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -17,7 +17,7 @@
 	new /obj/item/clothing/head/welding(src)
 	new /obj/item/clothing/gloves/yellow(src)
 	if(is_mainship_or_low_orbit_level(z))
-		new /obj/item/radio/headset/almayer/ce(src)
+		new /obj/item/radio/headset/almayer/mcom(src)
 	new /obj/item/storage/toolbox/mechanical(src)
 	new /obj/item/clothing/suit/storage/hazardvest(src)
 	new /obj/item/clothing/mask/gas(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -101,7 +101,7 @@
 	new /obj/item/clothing/suit/storage/labcoat(src)
 	new /obj/item/clothing/mask/surgical(src)
 	new /obj/item/clothing/mask/breath(src)
-	new /obj/item/radio/headset/almayer/cmo(src)
+	new /obj/item/radio/headset/almayer/mcom(src)
 	new /obj/item/reagent_container/hypospray/advanced/tricordrazine(src)
 	new /obj/item/flash(src)
 	new /obj/item/storage/pouch/medical(src)


### PR DESCRIPTION
## About The Pull Request
CMO gets a command headset, and unused headsets/encryption keys are removed.


## Why It's Good For The Game

Command members should be able to see all radio channels. (They can still disable them via the headset menu.)

## Changelog
:cl:
tweak: CMO now starts with a command headset
del: Removed now unused command headsets and encryption keys.
/:cl: