### PR TITLE
Makes machines use START_PROCESSING instead of our snowflake variant

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -145,7 +145,7 @@
 			icon_state = M.pulse ? "table2-active" : "table2-idle"
 			return 1
 	victim = null
-	stop_processing()
+	STOP_PROCESSING(SSmachines, src)
 	icon_state = "table2-idle"
 	return 0
 
@@ -163,7 +163,7 @@
 	if(ishuman(C))
 		var/mob/living/carbon/human/H = C
 		victim = H
-		start_processing()
+		START_PROCESSING(SSmachines, src)
 		icon_state = H.pulse ? "table2-active" : "table2-idle"
 	else
 		icon_state = "table2-idle"

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -189,8 +189,6 @@
 /obj/machinery/sleeper/Destroy()
 	occupant?.in_stasis = FALSE //clean up; end stasis; remove from processing
 	occupant = null
-	STOP_PROCESSING(SSobj, src)
-	stop_processing()
 	return ..()
 
 /obj/machinery/sleeper/examine(mob/living/user)
@@ -248,7 +246,7 @@
 			occupant.in_stasis = null
 		stasis = FALSE
 		filtering = FALSE
-		stop_processing() //Shut down; stasis off, filtering off, stop processing.
+		STOP_PROCESSING(SSmachines, src) //Shut down; stasis off, filtering off, stop processing.
 		return
 
 	//Life support
@@ -304,8 +302,8 @@
 	visible_message("[user] puts [M] into the sleeper.", 3)
 	update_use_power(2)
 	occupant = M
-	start_processing()
-	connected.start_processing()
+	START_PROCESSING(SSmachines, src)
+	START_PROCESSING(SSmachines, connected)
 
 	if(orient == "RIGHT")
 		icon_state = "sleeper_1-r"
@@ -369,8 +367,8 @@
 	occupant.in_stasis = null //disable stasis
 	stasis = FALSE
 	occupant = null
-	stop_processing()
-	connected.stop_processing()
+	STOP_PROCESSING(SSmachines, src)
+	STOP_PROCESSING(SSmachines, connected)
 	update_use_power(1)
 	if(orient == "RIGHT")
 		icon_state = "sleeper_0-r"
@@ -463,8 +461,8 @@
 	visible_message("[user] climbs into the sleeper.", 3)
 	update_use_power(2)
 	occupant = usr
-	start_processing()
-	connected.start_processing()
+	START_PROCESSING(SSmachines, src)
+	START_PROCESSING(SSmachines, connected)
 	icon_state = "sleeper_1"
 	if(orient == "RIGHT")
 		icon_state = "sleeper_1-r"

--- a/code/game/machinery/autodoc.dm
+++ b/code/game/machinery/autodoc.dm
@@ -704,8 +704,8 @@
 		var/mob/living/carbon/human/H = occupant
 		var/doc_dat
 		med_scan(H, doc_dat, implants, TRUE)
-		start_processing()
-		connected.start_processing()
+		START_PROCESSING(SSmachines, src)
+		START_PROCESSING(SSmachines, connected)
 		for(var/obj/O in src)
 			qdel(O)
 
@@ -737,8 +737,8 @@
 	surgery_todo_list = list()
 	update_use_power(1)
 	update_icon()
-	stop_processing()
-	connected.stop_processing()
+	STOP_PROCESSING(SSmachines, src)
+	STOP_PROCESSING(SSmachines, connected)
 	connected.process() // one last update
 
 /obj/machinery/autodoc/attackby(obj/item/I, mob/user, params)
@@ -828,8 +828,8 @@
 	var/implants = list(/obj/item/implant/chem, /obj/item/implant/death_alarm, /obj/item/implant/loyalty, /obj/item/implant/tracking, /obj/item/implant/neurostim)
 	var/mob/living/carbon/human/H = occupant
 	med_scan(H, null, implants, TRUE)
-	start_processing()
-	connected.start_processing()
+	START_PROCESSING(SSmachines, src)
+	START_PROCESSING(SSmachines, connected)
 
 /////////////////////////////////////////////////////////////
 

--- a/code/game/machinery/bots/cleanbot.dm
+++ b/code/game/machinery/bots/cleanbot.dm
@@ -28,7 +28,7 @@
 	var/next_dest
 	var/next_dest_loc
 
-/obj/machinery/bot/cleanbot/New()
+/obj/machinery/bot/cleanbot/Initialize(mapload, ...)
 	..()
 	src.get_targets()
 	src.icon_state = "cleanbot[src.on]"
@@ -42,8 +42,6 @@
 
 	if(SSradio)
 		SSradio.add_object(src, beacon_freq, filter = RADIO_NAVBEACONS)
-
-	start_processing()
 
 
 /obj/machinery/bot/cleanbot/turn_on()

--- a/code/game/machinery/bots/floorbot.dm
+++ b/code/game/machinery/bots/floorbot.dm
@@ -25,10 +25,9 @@
 	var/targetdirection
 
 
-/obj/machinery/bot/floorbot/New()
-	..()
+/obj/machinery/bot/floorbot/Initialize(mapload, ...)
+	. = ..()
 	src.updateicon()
-	start_processing()
 
 /obj/machinery/bot/floorbot/turn_on()
 	. = ..()

--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -58,7 +58,7 @@
 
 	src.botcard = new /obj/item/card/id(src)
 	botcard.access = ALL_MARINE_ACCESS
-	start_processing()
+
 
 /obj/machinery/bot/medbot/turn_on()
 	. = ..()

--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -57,7 +57,7 @@
 			charging = I
 			user.visible_message("[user] inserts a cell into the charger.", "You insert a cell into the charger.")
 			chargelevel = -1
-			start_processing()
+			START_PROCESSING(SSmachines, src)
 
 		updateicon()
 
@@ -79,7 +79,7 @@
 		user.visible_message("[user] removes the cell from the charger.", "You remove the cell from the charger.")
 		chargelevel = -1
 		updateicon()
-		stop_processing()
+		STOP_PROCESSING(SSmachines, src)
 
 /obj/machinery/cell_charger/attack_ai(mob/user)
 	return

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -38,10 +38,6 @@
 	var/stat_msg2
 
 
-/obj/machinery/computer/communications/New()
-	. = ..()
-	start_processing()
-
 /obj/machinery/computer/communications/process()
 	if(..())
 		if(state != STATE_STATUSDISPLAY)

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -12,7 +12,6 @@
 
 /obj/machinery/computer/Initialize()
 	. = ..()
-	start_processing()
 	return INITIALIZE_HINT_LATELOAD
 
 

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -223,9 +223,8 @@
 
 /obj/machinery/cryopod/process()
 	if(QDELETED(occupant))
-		stop_processing()
 		update_icon()
-		return
+		return PROCESS_KILL
 
 	if(occupant.stat == DEAD) //Occupant is dead, abort.
 		go_out()
@@ -236,8 +235,8 @@
 		return
 
 	occupant.despawn(src)
-	stop_processing()
 	update_icon()
+	return PROCESS_KILL
 
 /mob/proc/despawn(obj/machinery/cryopod/pod, dept_console = CRYO_REQ)
 
@@ -470,7 +469,7 @@
 	to_chat(user, "<span class='notice'>You feel cool air surround you. You go numb as your senses turn inward.</span>")
 	to_chat(user, "<span class='boldnotice'>If you ghost, log out or close your client now, your character will shortly be permanently removed from the round.</span>")
 	time_entered = world.time
-	start_processing()
+	START_PROCESSING(SSmachines, src)
 	log_admin("[key_name(user)] has entered a stasis pod.")
 	message_admins("[ADMIN_TPMONTY(user)] has entered a stasis pod.")
 
@@ -487,5 +486,5 @@
 		A.forceMove(get_turf(src))
 
 	occupant = null
-	stop_processing()
+	STOP_PROCESSING(SSmachines, src)
 	update_icon()

--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -239,11 +239,10 @@
 	var/triggered = 0
 	use_power = 0
 
-/obj/machinery/door_control/timed_automatic/New()
-		..()
+/obj/machinery/door_control/timed_automatic/Initialize(mapload, ...)
+		. = ..()
 		trigger_time = world.time + trigger_delay*600
-		START_PROCESSING(SSobj, src)
-		//start_processing()  // should really be using this -spookydonut
+
 
 /obj/machinery/door_control/timed_automatic/process()
 	if (!triggered && world.time >= trigger_time)
@@ -259,8 +258,7 @@
 
 		desiredstate = !desiredstate
 		triggered = 1
-		STOP_PROCESSING(SSobj, src)
-		//stop_processing()
+		. = PROCESS_KILL
 		spawn(15)
 			if(!(machine_stat & NOPOWER))
 				icon_state = "doorctrl0"

--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -195,7 +195,6 @@ obj/machinery/airlock_sensor/proc/set_frequency(new_frequency)
 obj/machinery/airlock_sensor/Initialize()
 	. = ..()
 	set_frequency(frequency)
-	start_processing()
 
 obj/machinery/airlock_sensor/New()
 	..()

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -101,7 +101,7 @@
 		if(C.opened && !C.close())	continue
 		C.locked = 1
 		C.icon_state = C.icon_locked
-	start_processing()
+	START_PROCESSING(SSmachines, src)
 	return 1
 
 
@@ -122,7 +122,7 @@
 		if(C.opened)	continue
 		C.locked = 0
 		C.icon_state = C.icon_closed
-	stop_processing()
+	STOP_PROCESSING(SSmachines, src)
 	return 1
 
 

--- a/code/game/machinery/fuelcell_recycler.dm
+++ b/code/game/machinery/fuelcell_recycler.dm
@@ -19,11 +19,11 @@
 		if(!cell_left)
 			if(user.transferItemToLoc(I, src))
 				cell_left = I
-				start_processing()
+				START_PROCESSING(SSmachines, src)
 		else if(!cell_right)
 			if(user.transferItemToLoc(I, src))
 				cell_right = I
-				start_processing()
+				START_PROCESSING(SSmachines, src)
 		else
 			to_chat(user, "<span class='notice'>The recycler is full!</span>")
 		update_icon()
@@ -63,29 +63,29 @@
 	if(machine_stat & (BROKEN|NOPOWER))
 		update_use_power(NO_POWER_USE)
 		update_icon()
-		return
+		return PROCESS_KILL
+		
 	if(!cell_left && !cell_right)
 		update_use_power(IDLE_POWER_USE)
 		update_icon()
-		stop_processing()
-		return
-	else
-		var/active = FALSE
-		if(cell_left != null)
-			if(!cell_left.is_regenerated())
-				active = TRUE
-				cell_left.give(active_power_usage*(GLOB.CELLRATE * 0.1))
-		if(cell_right != null)
-			if(!cell_right.is_regenerated())
-				active = TRUE
-				cell_right.give(active_power_usage*(GLOB.CELLRATE * 0.1))
-		if(active)
-			update_use_power(ACTIVE_POWER_USE)
-		else
-			update_use_power(IDLE_POWER_USE)
-			stop_processing()
+		return PROCESS_KILL
 
-		update_icon()
+	var/active = FALSE
+	if(cell_left != null)
+		if(!cell_left.is_regenerated())
+			active = TRUE
+			cell_left.give(active_power_usage*(GLOB.CELLRATE * 0.1))
+	if(cell_right != null)
+		if(!cell_right.is_regenerated())
+			active = TRUE
+			cell_right.give(active_power_usage*(GLOB.CELLRATE * 0.1))
+	if(active)
+		update_use_power(ACTIVE_POWER_USE)
+	else
+		update_use_power(IDLE_POWER_USE)
+		. = PROCESS_KILL
+
+	update_icon()
 
 /obj/machinery/fuelcell_recycler/power_change()
 	..()

--- a/code/game/machinery/fusion_engine.dm
+++ b/code/game/machinery/fusion_engine.dm
@@ -30,7 +30,6 @@
 	is_on = TRUE
 	power_gen_percent = 99//will get to 100 on first tick, updating fuel_rate in the process
 	update_icon()
-	start_processing()
 
 /obj/machinery/power/fusion_engine/random/Initialize()
 	. = ..()
@@ -54,7 +53,7 @@
 			is_on = FALSE
 			power_gen_percent = 0
 			update_icon()
-			stop_processing()
+			return PROCESS_KILL
 		return FALSE
 	if (fusion_cell.fuel_amount <= 0)
 		visible_message("[icon2html(src, viewers(src))] <b>[src]</b> flashes that the fuel cell is empty as the engine seizes.")
@@ -64,8 +63,7 @@
 		power_gen_percent = 0
 		fail_rate+=2 //Each time the engine is allowed to seize up it's fail rate for the future increases because reasons.
 		update_icon()
-		stop_processing()
-		return FALSE
+		return PROCESS_KILL
 
 	if(!check_failure())
 
@@ -108,7 +106,7 @@
 		power_gen_percent = 0
 		cur_tick = 0
 		update_icon()
-		stop_processing()
+		STOP_PROCESSING(SSmachines, src)
 		return TRUE
 
 	if(!fusion_cell)
@@ -126,7 +124,7 @@
 	is_on = TRUE
 	cur_tick = 0
 	update_icon()
-	start_processing()
+	START_PROCESSING(SSmachines, src)
 	return TRUE
 
 /obj/machinery/power/fusion_engine/attackby(obj/item/I, mob/user, params)
@@ -319,7 +317,7 @@
 		is_on = FALSE
 		power_gen_percent = 0
 		update_icon()
-		stop_processing()
+		STOP_PROCESSING(SSmachines, src)
 
 		return TRUE
 	else

--- a/code/game/machinery/groundmap_geothermal.dm
+++ b/code/game/machinery/groundmap_geothermal.dm
@@ -88,7 +88,7 @@
 		power_gen_percent = 0
 		update_icon()
 		cur_tick = 0
-		stop_processing()
+		STOP_PROCESSING(SSmachines, src)
 		return TRUE
 	return FALSE //Nope, all fine
 
@@ -116,13 +116,13 @@
 		power_gen_percent = 0
 		cur_tick = 0
 		icon_state = "off"
-		stop_processing()
+		STOP_PROCESSING(SSmachines, src)
 		return TRUE
 	visible_message("[icon2html(src, viewers(src))] <span class='warning'><b>[src]</b> beeps loudly as [usr] turns on the turbines and the generator begins spinning up.")
 	icon_state = "on10"
 	is_on = TRUE
 	cur_tick = 0
-	start_processing()
+	START_PROCESSING(SSmachines, src)
 	return TRUE
 
 /obj/machinery/power/geothermal/attackby(obj/item/I, mob/user, params)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -14,6 +14,7 @@
 	var/power_channel = EQUIP
 	var/list/component_parts = list() //list of all the parts used to build it, if made from certain kinds of frames.
 
+	var/speed_process = FALSE
 	var/wrenchable = FALSE
 	var/damage = 0
 	var/damage_cap = 1000 //The point where things start breaking down.
@@ -28,10 +29,18 @@
 	if(A)
 		A.area_machines += src
 
+	if(!speed_process)
+		START_PROCESSING(SSmachines, src)
+	else
+		START_PROCESSING(SSfastprocess, src)
+
 
 /obj/machinery/Destroy()
 	GLOB.machines -= src
-	STOP_PROCESSING(SSmachines, src)
+	if(!speed_process)
+		STOP_PROCESSING(SSmachines, src)
+	else
+		STOP_PROCESSING(SSfastprocess, src)
 	var/area/A = get_area(src)
 	if(A)
 		A.area_machines -= src
@@ -80,14 +89,6 @@
 //called on machinery construction (i.e from frame to machinery) but not on initialization
 /obj/machinery/proc/on_construction()
 	return
-
-
-/obj/machinery/proc/start_processing()
-	START_PROCESSING(SSmachines, src)
-
-
-/obj/machinery/proc/stop_processing()
-	STOP_PROCESSING(SSmachines, src)
 
 
 /obj/machinery/process()//If you dont use process or power why are you here

--- a/code/game/machinery/nuclearbomb.dm
+++ b/code/game/machinery/nuclearbomb.dm
@@ -23,8 +23,8 @@ var/bomb_set
 
 
 
-/obj/machinery/nuclearbomb/New()
-	..()
+/obj/machinery/nuclearbomb/Initialize(mapload, ...)
+	. = ..()
 	r_code = "[rand(10000, 99999.0)]"//Creates a random code upon object spawn.
 
 /obj/machinery/nuclearbomb/process()
@@ -293,7 +293,7 @@ obj/machinery/nuclearbomb/proc/nukehack_win(mob/user as mob)
 					src.safety = !( src.safety )
 					if(safety)
 						src.timing = 0
-						stop_processing()
+						STOP_PROCESSING(SSmachines, src)
 						bomb_set = 0
 				if (href_list["anchor"])
 
@@ -323,7 +323,7 @@ obj/machinery/nuclearbomb/proc/nukehack_win(mob/user as mob)
 /obj/machinery/nuclearbomb/proc/explode()
 	if(safety)
 		timing = 0
-		stop_processing()
+		STOP_PROCESSING(SSmachines, src)
 		return FALSE
 	timing = -1.0
 	yes_code = 0

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -54,7 +54,7 @@ obj/machinery/recharger
 		return
 
 	charging = I
-	start_processing()
+	START_PROCESSING(SSmachines, src)
 	update_icon()
 
 
@@ -66,7 +66,7 @@ obj/machinery/recharger/attack_hand(mob/user as mob)
 		charging.update_icon()
 		user.put_in_hands(charging)
 		charging = null
-		stop_processing()
+		STOP_PROCESSING(SSmachines, src)
 		percent_charge_complete = 0
 		update_icon()
 

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -108,9 +108,9 @@
 	else
 		on = !on
 		if(on)
-			start_processing()
+			START_PROCESSING(SSmachines, src)
 		else
-			stop_processing()
+			STOP_PROCESSING(SSmachines, src)
 		user.visible_message("<span class='notice'> [user] switches [on ? "on" : "off"] the [src].</span>","<span class='notice'> You switch [on ? "on" : "off"] the [src].</span>")
 		update_icon()
 	return
@@ -167,5 +167,5 @@
 
 		else
 			on = 0
-			stop_processing()
 			update_icon()
+			return PROCESS_KILL

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -98,7 +98,7 @@
 /// Update the display and, if necessary, re-enable processing.
 /obj/machinery/status_display/proc/update()
 	if(process() != PROCESS_KILL)
-		start_processing()
+		START_PROCESSING(SSmachines, src)
 
 
 /obj/machinery/status_display/power_change()

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -87,7 +87,6 @@ GLOBAL_LIST_EMPTY(telecomms_list)
 /obj/machinery/telecomms/Initialize(mapload)
 	. = ..()
 	GLOB.telecomms_list += src
-	start_processing()
 	if(mapload && length(autolinkers))
 		return INITIALIZE_HINT_LATELOAD
 
@@ -100,7 +99,6 @@ GLOBAL_LIST_EMPTY(telecomms_list)
 
 /obj/machinery/telecomms/Destroy()
 	GLOB.telecomms_list -= src
-	stop_processing()
 	for(var/obj/machinery/telecomms/comm in GLOB.telecomms_list)
 		comm.links -= src
 	links = list()

--- a/code/game/machinery/vending/vending.dm
+++ b/code/game/machinery/vending/vending.dm
@@ -77,7 +77,6 @@
 		//Add hidden inventory
 	src.build_inventory(contraband, 1)
 	src.build_inventory(premium, 0, 1)
-	start_processing()
 	return INITIALIZE_HINT_LATELOAD
 
 

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -177,14 +177,14 @@
 	on = !on
 	update_icon()
 	if(on)
-		start_processing()
+		START_PROCESSING(SSmachines, src)
 		if (M.loc == loc)
 			wash(M)
 			check_heat(M)
 		for (var/atom/movable/G in src.loc)
 			G.clean_blood()
 	else
-		stop_processing()
+		STOP_PROCESSING(SSmachines, src)
 
 /obj/machinery/shower/attackby(obj/item/I, mob/user, params)
 	. = ..()

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -165,7 +165,7 @@
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/proc/turn_off()
 	on = FALSE
-	stop_processing()
+	STOP_PROCESSING(SSmachines, src)
 	update_icon()
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/process()
@@ -177,7 +177,7 @@
 
 	if(!on)
 		updateUsrDialog()
-		stop_processing()
+		STOP_PROCESSING(SSmachines, src)
 		return
 
 	if(occupant)
@@ -467,7 +467,7 @@
 		to_chat(usr, "<span class='warning'>The cryo cell is not functioning.</span>")
 		return
 	on = TRUE
-	start_processing()
+	START_PROCESSING(SSmachines, src)
 	update_icon()
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/Topic(href, href_list)

--- a/code/modules/cm_marines/equipment/sentries.dm
+++ b/code/modules/cm_marines/equipment/sentries.dm
@@ -307,8 +307,7 @@
 	target = null
 	alert_list = list()
 	SetLuminosity(0)
-	stop_processing()
-	. = ..()
+	return ..()
 
 /obj/machinery/marine_turret/attack_hand(mob/user as mob)
 
@@ -697,7 +696,7 @@
 		DISABLE_BITFIELD(turret_flags, TURRET_ON)
 		density = FALSE
 		icon_state = "sentry_fallen"
-		stop_processing()
+		STOP_PROCESSING(SSmachines, src)
 		return
 	else
 		density = initial(density)
@@ -710,7 +709,7 @@
 
 	if(!cell || cell.charge <= 0)
 		DISABLE_BITFIELD(turret_flags, TURRET_ON)
-		stop_processing()
+		STOP_PROCESSING(SSmachines, src)
 		overlays += battery_black
 		return
 
@@ -725,11 +724,11 @@
 			overlays += battery_red
 
 	if(CHECK_BITFIELD(turret_flags, TURRET_ON))
-		start_processing()
+		START_PROCESSING(SSmachines, src)
 		overlays += active
 
 	else
-		stop_processing()
+		STOP_PROCESSING(SSmachines, src)
 
 /obj/machinery/marine_turret/proc/update_health(var/damage) //Negative damage restores health.
 
@@ -1245,7 +1244,7 @@
 		DISABLE_BITFIELD(turret_flags, TURRET_ON)
 		density = FALSE
 		icon_state = "minisentry_fallen"
-		stop_processing()
+		START_PROCESSING(SSmachines, src)
 		return
 	else
 		icon_state = "minisentry_off"
@@ -1253,18 +1252,18 @@
 
 	if(!cell)
 		DISABLE_BITFIELD(turret_flags, TURRET_ON)
-		stop_processing()
+		STOP_PROCESSING(SSmachines, src)
 		icon_state = "minisentry_nobat"
 		return
 
 	if(cell.charge <= 0)
 		DISABLE_BITFIELD(turret_flags, TURRET_ON)
-		stop_processing()
+		STOP_PROCESSING(SSmachines, src)
 		icon_state = "minisentry_nobat"
 		return
 
 	if(CHECK_BITFIELD(turret_flags, TURRET_ON))
-		start_processing()
+		STOP_PROCESSING(SSmachines, src)
 		if(!rounds)
 			icon_state = "minisentry_noammo"
 		else
@@ -1272,7 +1271,7 @@
 
 	else
 		icon_state = "minisentry_off"
-		stop_processing()
+		STOP_PROCESSING(SSmachines, src)
 
 
 /obj/item/marine_turret/mini

--- a/code/modules/detectivework/scanning_console.dm
+++ b/code/modules/detectivework/scanning_console.dm
@@ -249,7 +249,7 @@
 		if("scan")
 			if(scanning)
 				scan_progress = 10
-				start_processing()
+				START_PROCESSING(SSmachines, src)
 		if("cancel")
 			scan_progress = -1
 		if("card")
@@ -291,5 +291,5 @@
 			visible_message("Scan complete.")
 			var/datum/data/record/forensic/fresh = new(scanning)
 			add_record(fresh)
-			stop_processing()
 			updateUsrDialog()
+			return PROCESS_KILL

--- a/code/modules/economy/ATM.dm
+++ b/code/modules/economy/ATM.dm
@@ -40,7 +40,6 @@ log transactions
 	spark_system = new /datum/effect_system/spark_spread
 	spark_system.set_up(5, 0, src)
 	spark_system.attach(src)
-	start_processing()
 
 /obj/machinery/atm/process()
 	if(machine_stat & NOPOWER)

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -123,14 +123,13 @@
 		"mutagen" = 15
 		)
 
-/obj/machinery/portable_atmospherics/hydroponics/New()
-	..()
+/obj/machinery/portable_atmospherics/hydroponics/Initialize(mapload, ...)
+	. = ..()
 	temp_chem_holder = new()
 	temp_chem_holder.create_reagents(10)
 	create_reagents(200, AMOUNT_VISIBLE|REFILLABLE)
 	connect()
 	update_icon()
-	start_processing()
 
 /obj/machinery/portable_atmospherics/hydroponics/bullet_act(var/obj/item/projectile/Proj)
 

--- a/code/modules/hydroponics/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines.dm
@@ -78,7 +78,7 @@
 			loaded_disk.loc = get_turf(src)
 			visible_message("[icon2html(src, viewers(src))] [src] beeps and spits out [loaded_disk].")
 			loaded_disk = null
-	stop_processing()
+	STOP_PROCESSING(SSmachines, src)
 
 /obj/machinery/botany/attackby(obj/item/I, mob/user, params)
 	. = ..()
@@ -212,7 +212,7 @@
 
 		last_action = world.time
 		active = 1
-		start_processing()
+		START_PROCESSING(SSmachines, src)
 
 		if(seed && seed.seed)
 			genetics = seed.seed
@@ -227,7 +227,7 @@
 
 		last_action = world.time
 		active = 1
-		start_processing()
+		START_PROCESSING(SSmachines, src)
 
 		var/datum/plantgene/P = genetics.get_gene(href_list["get_gene"])
 		if(!P) return
@@ -312,7 +312,7 @@
 
 		last_action = world.time
 		active = 1
-		start_processing()
+		START_PROCESSING(SSmachines, src)
 
 		if(!isnull(GLOB.seed_types[seed.seed.name]))
 			seed.seed = seed.seed.diverge(1)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -132,8 +132,6 @@
 		update_icon()
 		addtimer(CALLBACK(src, .proc/update), 5)
 
-	start_processing()
-
 	. = ..()
 
 	if(mapload)

--- a/code/modules/power/batteryrack.dm
+++ b/code/modules/power/batteryrack.dm
@@ -38,7 +38,6 @@
 	..()
 	add_parts()
 	RefreshParts()
-	start_processing()
 	return
 
 

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -19,7 +19,6 @@
 	. = ..()
 
 	reconnect()
-	start_processing()
 
 //generators connect in dir and reverse_dir(dir) directions
 //mnemonic to determine circulator/generator directions: the cirulators orbit clockwise around the generator

--- a/code/modules/power/generator_type2.dm
+++ b/code/modules/power/generator_type2.dm
@@ -20,7 +20,6 @@
 	//if(!input1 || !input2)
 	//	machine_stat |= BROKEN
 	updateicon()
-	start_processing()
 
 
 /obj/machinery/power/generator_type2/proc/updateicon()

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -39,7 +39,7 @@
 	else if(HasFuel())
 		active = TRUE
 		update_icon()
-		start_processing()
+		START_PROCESSING(SSmachines, src)
 
 /obj/machinery/power/port_gen/update_icon()
 	icon_state = "portgen[active]"
@@ -163,7 +163,7 @@
 /obj/machinery/power/port_gen/pacman/handleInactive()
 	heat = max(heat - 2, 0)
 	if(heat == 0)
-		stop_processing()
+		STOP_PROCESSING(SSmachines, src)
 
 /obj/machinery/power/port_gen/pacman/proc/overheat()
 	explosion(src.loc, 2, 5, 2, -1)

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -55,7 +55,6 @@
 	if(!terminal.powernet)
 		terminal.connect_to_network()
 	update_icon()
-	start_processing()
 
 /obj/machinery/power/smes/Destroy()
 	if(terminal)

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -42,11 +42,10 @@
 	else
 		recharged -= 1
 
-/obj/machinery/chem_dispenser/New()
-	..()
+/obj/machinery/chem_dispenser/Initialize(mapload, ...)
+	. = ..()
 	recharge()
 	dispensable_reagents = sortList(dispensable_reagents)
-	start_processing()
 
 
 /obj/machinery/chem_dispenser/ex_act(severity)

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -65,7 +65,7 @@
 	if(machine_stat & BROKEN)
 		icon_state = "conveyor-broken"
 		operating = 0
-		stop_processing()
+		STOP_PROCESSING(SSmachines, src)
 		return
 
 	if(!operable || (machine_stat & NOPOWER))
@@ -73,10 +73,10 @@
 
 	if(operating)
 		if(!CHECK_BITFIELD(datum_flags, DF_ISPROCESSING))
-			start_processing()
+			START_PROCESSING(SSmachines, src)
 	else
 		if(CHECK_BITFIELD(datum_flags, DF_ISPROCESSING))
-			stop_processing()
+			STOP_PROCESSING(SSmachines, src)
 
 	icon_state = "conveyor[operating]"
 
@@ -155,7 +155,8 @@
 	if(id != match_id)
 		return
 	operable = op
-	if(operable) start_processing()
+	if(operable) 
+		START_PROCESSING(SSmachines, src)
 
 	update()
 	var/obj/machinery/conveyor/C = locate() in get_step(src, stepdir)
@@ -193,16 +194,18 @@
 
 
 
-/obj/machinery/conveyor_switch/New()
-	..()
+/obj/machinery/conveyor_switch/Initialize(mapload, ...)
+	. = ..()
 	update()
 
-	spawn(5)		// allow map load
-		conveyors = list()
-		for(var/obj/machinery/conveyor/C in GLOB.machines)
-			if(C.id == id)
-				conveyors += C
-	start_processing()
+	return INITIALIZE_HINT_LATELOAD
+
+
+/obj/machinery/conveyor_switch/LateInitialize()
+	conveyors = list()
+	for(var/obj/machinery/conveyor/C in GLOB.machines)
+		if(C.id == id)
+			conveyors += C
 
 // update the icon depending on the position
 

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -35,7 +35,6 @@
 		trunk.linked = src	//Link the pipe trunk to self
 
 	update()
-	start_processing()
 
 //Attack by item places it in to disposal
 /obj/machinery/disposal/attackby(obj/item/I, mob/user, params)


### PR DESCRIPTION
The way /tg/ does it is that in Init it starts processing, but most machines have the default /process that returns PROCESS_KILL. This is a more elegant way to do it, and will unshitcode our codebase in the long term.

Here I'm either:
making New into Init for machines
Removing start_processing for init in machines since it's included at the base
Changing the calls from start_stop to START_STOP
If it's in process I'm returning the PROCESS_KILL