### PR TITLE
Fixes a fingerprint runtime.

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -159,7 +159,6 @@
 		return
 
 	pickup(user)
-	add_fingerprint(user)
 	if(!user.put_in_active_hand(src))
 		dropped(user)
 


### PR DESCRIPTION
This is already handled in the parent call
```
[01:32:56] Runtime in atoms.dm, line 601: Attempted to add fingerprint without an action type.
proc name: add fingerprint (/atom/proc/add_fingerprint)
usr: /()
usr.loc: (Squad Charlie Preparation (152, 45, 3))
src: the heat absorbent coif (/obj/item/clothing/mask/rebreather/scarf)
src.loc: the floor (152,46,3) (/turf/open/floor/almayer/mono)
call stack:
the heat absorbent coif (/obj/item/clothing/mask/rebreather/scarf): add fingerprint(Gunner Hall (/mob/living/carbon/human), null, null)
the heat absorbent coif (/obj/item/clothing/mask/rebreather/scarf): attack hand(Gunner Hall (/mob/living/carbon/human))
Gunner Hall (/mob/living/carbon/human): UnarmedAttack(the heat absorbent coif (/obj/item/clothing/mask/rebreather/scarf), 1)
Gunner Hall (/mob/living/carbon/human): ClickOn(the heat absorbent coif (/obj/item/clothing/mask/rebreather/scarf), "icon-x=15;icon-y=16;left=1;scr...")
the heat absorbent coif (/obj/item/clothing/mask/rebreather/scarf): Click(the floor (152,46,3) (/turf/open/floor/almayer/mono), "mapwindow.map", "icon-x=15;icon-y=16;left=1;scr...")
Critica (/client): Click(the heat absorbent coif (/obj/item/clothing/mask/rebreather/scarf), the floor (152,46,3) (/turf/open/floor/almayer/mono), "mapwindow.map", "icon-x=15;icon-y=16;left=1;scr...")
(This error will now be silenced for 10 minutes)
```