### PR TITLE
Fixes more bad do_afters

### DIFF
--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -178,7 +178,7 @@
 		user.visible_message("<span class='notice'>[user] begin removing the barbed wire on [src].</span>",
 		"<span class='notice'>You begin removing the barbed wire on [src].</span>")
 
-		if(!do_after(user, 20, TRUE, 5, BUSY_ICON_BUILD))
+		if(!do_after(user, 20, TRUE, src, BUSY_ICON_BUILD))
 			return
 
 		playsound(loc, 'sound/items/wirecutter.ogg', 25, 1)
@@ -746,7 +746,7 @@
 		playsound(loc, 'sound/items/welder2.ogg', 25, 1)
 		busy = TRUE
 
-		if(!do_after(user, 50, TRUE, 5, BUSY_ICON_FRIENDLY))
+		if(!do_after(user, 50, TRUE, src, BUSY_ICON_FRIENDLY))
 			busy = FALSE
 			return
 


### PR DESCRIPTION
Another number instead of an atom reference.
```
[02:06:27] Runtime in mobs.dm, line 107: Cannot read 5.loc
proc name: do after (/proc/do_after)
usr: /()
usr.loc: (Colony Telecommunications (20, 179, 2))
src: null
call stack:
do after( (/mob/living/carbon/human), 20, 1, 5, /image/progdisplay/constructio... (/image/progdisplay/construction), null, /datum/progressbar (/datum/progressbar), null)
the metal barricade (/obj/structure/barricade/metal): attackby(the wirecutters (/obj/item/tool/wirecutters),  (/mob/living/carbon/human), "icon-x=18;icon-y=10;left=1;scr...")
the metal barricade (/obj/structure/barricade/metal): attackby(the wirecutters (/obj/item/tool/wirecutters), Beau Prevatt (/mob/living/carbon/human), "icon-x=18;icon-y=10;left=1;scr...")
the wirecutters (/obj/item/tool/wirecutters): melee attack chain(Beau Prevatt (/mob/living/carbon/human), the metal barricade (/obj/structure/barricade/metal), "icon-x=18;icon-y=10;left=1;scr...")
Beau Prevatt (/mob/living/carbon/human): ClickOn(the metal barricade (/obj/structure/barricade/metal), "icon-x=18;icon-y=10;left=1;scr...")
the metal barricade (/obj/structure/barricade/metal): Click(the plating (21,178,2) (/turf/open/floor/plating/icefloor/warnplate), "mapwindow.map", "icon-x=18;icon-y=10;left=1;scr...")
ArcaneCarrot (/client): Click(the metal barricade (/obj/structure/barricade/metal), the plating (21,178,2) (/turf/open/floor/plating/icefloor/warnplate), "mapwindow.map", "icon-x=18;icon-y=10;left=1;scr...")
```