### PR TITLE
Fixes an admin runtime.

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -950,7 +950,7 @@
 
 	var/datum/admin_help/AH = C.current_ticket
 
-	if(AH.tier == TICKET_ADMIN && !check_rights(R_ADMINTICKET, FALSE))
+	if(AH && AH.tier == TICKET_ADMIN && !check_rights(R_ADMINTICKET, FALSE))
 		return
 
 	if(AH && !AH.marked)


### PR DESCRIPTION
Avoided the ?. operator since it's comparison.
```
[06:59:19] Runtime in admin_verbs.dm, line 953: Cannot read null.tier
proc name: ticket reply (/client/proc/ticket_reply)
usr: Psykzz/(Matt Dowl)
usr.loc: (Entrance Hallway (221, 126, 2))
src: Psykzz (/client)
call stack:
Psykzz (/client): ticket reply(LaKiller8 (/client))
Some edginess: (F) \[Delta (Sp... (/datum/admin_help): Action("reply")
psykzz\'s admin datum (Admin O... (/datum/admins): Topic("_src_=holder;admin_token=82962...", /list (/list))
Psykzz (/client): Topic("_src_=holder;admin_token=82962...", /list (/list), psykzz\'s admin datum (Admin O... (/datum/admins))
Psykzz (/client): Topic("_src_=holder;admin_token=82962...", /list (/list), psykzz\'s admin datum (Admin O... (/datum/admins))
Psykzz (/client): Topic("_src_=holder;admin_token=82962...", /list (/list))
```