### PR TITLE
Fixes race condition mapload runtime

### DIFF
--- a/code/game/objects/items/reagent_containers/pill.dm
+++ b/code/game/objects/items/reagent_containers/pill.dm
@@ -132,7 +132,7 @@ var/global/list/randomized_pill_icons
 	pill_desc = "A dylovene pill. It neutralizes many common toxins."
 	list_reagents = list("dylovene" = 15)
 
-/obj/item/reagent_container/pill/dylovene/New()
+/obj/item/reagent_container/pill/dylovene/Initialize(mapload, ...)
 	. = ..()
 	icon_state = randomized_pill_icons[1]
 
@@ -140,7 +140,7 @@ var/global/list/randomized_pill_icons
 	pill_desc = "A toxins pill. It's highly toxic."
 	list_reagents = list("toxin" = 50)
 
-/obj/item/reagent_container/pill/tox/New()
+/obj/item/reagent_container/pill/tox/Initialize(mapload, ...)
 	. = ..()
 	icon_state = randomized_pill_icons[2]
 
@@ -149,7 +149,7 @@ var/global/list/randomized_pill_icons
 	pill_desc = null//so even non medics can see what this pill is.
 	list_reagents = list("cyanide" = 50)
 
-/obj/item/reagent_container/pill/cyanide/New()
+/obj/item/reagent_container/pill/cyanide/Initialize(mapload, ...)
 	. = ..()
 	icon_state = randomized_pill_icons[2]
 
@@ -157,7 +157,7 @@ var/global/list/randomized_pill_icons
 	pill_desc = "An adminordrazine pill. It's magic. We don't have to explain it."
 	list_reagents = list("adminordrazine" = 50)
 
-/obj/item/reagent_container/pill/adminordrazine/New()
+/obj/item/reagent_container/pill/adminordrazine/Initialize(mapload, ...)
 	. = ..()
 	icon_state = randomized_pill_icons[3]
 
@@ -165,7 +165,7 @@ var/global/list/randomized_pill_icons
 	pill_desc = "A sleeping pill commonly used to treat insomnia."
 	list_reagents = list("sleeptoxin" = 15)
 
-/obj/item/reagent_container/pill/sleeptox/New()
+/obj/item/reagent_container/pill/sleeptox/Initialize(mapload, ...)
 	. = ..()
 	icon_state = randomized_pill_icons[4]
 
@@ -173,7 +173,7 @@ var/global/list/randomized_pill_icons
 	pill_desc = "A kelotane pill. Used to treat burns."
 	list_reagents = list("kelotane" = 15)
 
-/obj/item/reagent_container/pill/kelotane/New()
+/obj/item/reagent_container/pill/kelotane/Initialize(mapload, ...)
 	. = ..()
 	icon_state = randomized_pill_icons[5]
 
@@ -181,7 +181,7 @@ var/global/list/randomized_pill_icons
 	pill_desc = "A paracetamol pill. Painkiller for the ages."
 	list_reagents = list("paracetamol" = 15)
 
-/obj/item/reagent_container/pill/paracetamol/New()
+/obj/item/reagent_container/pill/paracetamol/Initialize(mapload, ...)
 	. = ..()
 	icon_state = randomized_pill_icons[6]
 
@@ -189,7 +189,7 @@ var/global/list/randomized_pill_icons
 	pill_desc = "A tramadol pill. A simple painkiller."
 	list_reagents = list("tramadol" = 15)
 
-/obj/item/reagent_container/pill/tramadol/New()
+/obj/item/reagent_container/pill/tramadol/Initialize(mapload, ...)
 	. = ..()
 	icon_state = randomized_pill_icons[7]
 
@@ -198,7 +198,7 @@ var/global/list/randomized_pill_icons
 	pill_desc = "A methylphenidate pill. This improves the ability to concentrate."
 	list_reagents = list("methylphenidate" = 15)
 
-/obj/item/reagent_container/pill/methylphenidate/New()
+/obj/item/reagent_container/pill/methylphenidate/Initialize(mapload, ...)
 	. = ..()
 	icon_state = randomized_pill_icons[8]
 
@@ -206,7 +206,7 @@ var/global/list/randomized_pill_icons
 	pill_desc = "A citalopram pill. A mild anti-depressant."
 	list_reagents = list("citalopram" = 15)
 
-/obj/item/reagent_container/pill/citalopram/New()
+/obj/item/reagent_container/pill/citalopram/Initialize(mapload, ...)
 	. = ..()
 	icon_state = randomized_pill_icons[9]
 
@@ -215,7 +215,7 @@ var/global/list/randomized_pill_icons
 	pill_desc = "An inaprovaline pill. Used to stabilize patients."
 	list_reagents = list("inaprovaline" = 30)
 
-/obj/item/reagent_container/pill/inaprovaline/New()
+/obj/item/reagent_container/pill/inaprovaline/Initialize(mapload, ...)
 	. = ..()
 	icon_state = randomized_pill_icons[10]
 
@@ -223,7 +223,7 @@ var/global/list/randomized_pill_icons
 	pill_desc = "A dexalin pill. Used to treat oxygen deprivation."
 	list_reagents = list("dexalin" = 15)
 
-/obj/item/reagent_container/pill/dexalin/New()
+/obj/item/reagent_container/pill/dexalin/Initialize(mapload, ...)
 	. = ..()
 	icon_state = randomized_pill_icons[11]
 
@@ -231,7 +231,7 @@ var/global/list/randomized_pill_icons
 	pill_desc = "A spaceacillin pill. Used to treat infected wounds and slow down viral infections."
 	list_reagents = list("spaceacillin" = 10)
 
-/obj/item/reagent_container/pill/spaceacillin/New()
+/obj/item/reagent_container/pill/spaceacillin/Initialize(mapload, ...)
 	. = ..()
 	icon_state = randomized_pill_icons[12]
 
@@ -239,7 +239,7 @@ var/global/list/randomized_pill_icons
 	pill_desc = "A Happy Pill! Happy happy joy joy!"
 	list_reagents = list("space_drugs" = 15, "sugar" = 15, "laughter" = 5)
 
-/obj/item/reagent_container/pill/happy/New()
+/obj/item/reagent_container/pill/happy/Initialize(mapload, ...)
 	. = ..()
 	icon_state = randomized_pill_icons[13]
 
@@ -247,7 +247,7 @@ var/global/list/randomized_pill_icons
 	pill_desc = "A Zoom pill! Gotta go fast!"
 	list_reagents = list("synaptizine" = 5, "hyperzine" = 5, "nutriment" = 2)
 
-/obj/item/reagent_container/pill/zoom/New()
+/obj/item/reagent_container/pill/zoom/Initialize(mapload, ...)
 	. = ..()
 	icon_state = randomized_pill_icons[14]
 
@@ -255,7 +255,7 @@ var/global/list/randomized_pill_icons
 	pill_desc = "A Russian Red pill. A very dangerous radiation-countering substance."
 	list_reagents = list("russianred" = 10)
 
-/obj/item/reagent_container/pill/russianRed/New()
+/obj/item/reagent_container/pill/russianRed/Initialize(mapload, ...)
 	. = ..()
 	icon_state = randomized_pill_icons[15]
 
@@ -264,7 +264,7 @@ var/global/list/randomized_pill_icons
 	pill_desc = "A peridaxon pill. Heals internal organ damage."
 	list_reagents = list("peridaxon" = 10)
 
-/obj/item/reagent_container/pill/peridaxon/New()
+/obj/item/reagent_container/pill/peridaxon/Initialize(mapload, ...)
 	. = ..()
 	icon_state = randomized_pill_icons[16]
 
@@ -273,7 +273,7 @@ var/global/list/randomized_pill_icons
 	pill_desc = "An imidazoline pill. Heals eye damage."
 	list_reagents = list("imidazoline" = 10)
 
-/obj/item/reagent_container/pill/imidazoline/New()
+/obj/item/reagent_container/pill/imidazoline/Initialize(mapload, ...)
 	. = ..()
 	icon_state = randomized_pill_icons[17]
 
@@ -282,7 +282,7 @@ var/global/list/randomized_pill_icons
 	pill_desc = "An Alkysine pill. Heals brain damage."
 	list_reagents = list("alkysine" = 10)
 
-/obj/item/reagent_container/pill/alkysine/New()
+/obj/item/reagent_container/pill/alkysine/Initialize(mapload, ...)
 	. = ..()
 	icon_state = randomized_pill_icons[18]
 
@@ -291,7 +291,7 @@ var/global/list/randomized_pill_icons
 	pill_desc = "A bicaridine pill. Heals brute damage."
 	list_reagents = list("bicaridine" = 15)
 
-/obj/item/reagent_container/pill/bicaridine/New()
+/obj/item/reagent_container/pill/bicaridine/Initialize(mapload, ...)
 	. = ..()
 	icon_state = randomized_pill_icons[19]
 
@@ -299,7 +299,7 @@ var/global/list/randomized_pill_icons
 	pill_desc = "A quick-clot pill. Stabilizes internal bleeding temporarily."
 	list_reagents = list("quickclot" = 10)
 
-/obj/item/reagent_container/pill/quickclot/New()
+/obj/item/reagent_container/pill/quickclot/Initialize(mapload, ...)
 	. = ..()
 	icon_state = randomized_pill_icons[20]
 
@@ -307,7 +307,7 @@ var/global/list/randomized_pill_icons
 	pill_desc = "A tricordrazine pill. Broad spectrum medication that slowly heals all damage types."
 	list_reagents = list("tricordrazine" = 15)
 
-/obj/item/reagent_container/pill/tricordrazine/New()
+/obj/item/reagent_container/pill/tricordrazine/Initialize(mapload, ...)
 	. = ..()
 	icon_state = randomized_pill_icons[9]
 
@@ -315,7 +315,7 @@ var/global/list/randomized_pill_icons
 	pill_desc = "A hypervene pill. A purge medication used to treat overdoses and rapidly remove toxins. Causes pain and vomiting."
 	list_reagents = list("hypervene" = 3)
 
-/obj/item/reagent_container/pill/hypervene/New()
+/obj/item/reagent_container/pill/hypervene/Initialize(mapload, ...)
 	. = ..()
 	icon_state = randomized_pill_icons[14]
 
@@ -323,6 +323,6 @@ var/global/list/randomized_pill_icons
 	//pill_desc = "An ultrazine pill. A highly-potent, long-lasting combination CNS and muscle stimulant. Extremely addictive."
 	list_reagents = list("ultrazine" = 5)
 
-/obj/item/reagent_container/pill/ultrazine/New()
+/obj/item/reagent_container/pill/ultrazine/Initialize(mapload, ...)
 	. = ..()
 	icon_state = randomized_pill_icons[21]


### PR DESCRIPTION
The base pill uses init which makes a list, the child pills use new so the list may not exist yet during loadtime.
```
[20:19:30] Runtime in pill.dm, line 244: cannot read from list
proc name: New (/obj/item/reagent_container/pill/happy/New)
src: the pill (/obj/item/reagent_container/pill/happy)
src.loc: the floor (71,147,2) (/turf/open/floor/tile/white)
call stack:
the pill (/obj/item/reagent_container/pill/happy): New(the floor (71,147,2) (/turf/open/floor/tile/white))
/datum/parsed_map (/datum/parsed_map): create atom(/obj/item/reagent_container/pi... (/obj/item/reagent_container/pill/happy), the floor (71,147,2) (/turf/open/floor/tile/white))
/datum/parsed_map (/datum/parsed_map): instance atom(/obj/item/reagent_container/pi... (/obj/item/reagent_container/pill/happy), /list (/list), the floor (71,147,2) (/turf/open/floor/tile/white), 1, 0, 0)
/datum/parsed_map (/datum/parsed_map): build coordinate(/list (/list), /list (/list), the floor (71,147,2) (/turf/open/floor/tile/white), 1, 0, 0)
/datum/parsed_map (/datum/parsed_map): load impl(1, 1, 2, 0, 1, -1e+031, 1e+031, -1e+031, 1e+031, 0, 0)
/datum/parsed_map (/datum/parsed_map): load(1, 1, 2, null, 1, null, null, null, null, null, null)
Mapping (/datum/controller/subsystem/mapping): LoadGroup(/list (/list), "Big Red", "map_files/BigRed_v2", /list (/list), /list (/list), /list (/list), 0)
Mapping (/datum/controller/subsystem/mapping): loadWorld()
Mapping (/datum/controller/subsystem/mapping): Initialize(731684)
Master (/datum/controller/master): Initialize(10, 0, 1)
```