### PR TITLE
Cleanup wording for bioscan in admin log

### DIFF
--- a/code/game/gamemodes/distress.dm
+++ b/code/game/gamemodes/distress.dm
@@ -696,8 +696,8 @@ Sensors indicate [numXenosShip ? "[numXenosShip]" : "no"] unknown lifeform signa
 [numHostsPlanet] human\s on the planet.
 [numHostsShip] human\s on the ship.</span>"})
 
-	message_admins("Bioscan - Humans received: [numHostsPlanet] on the planet[hostLocationP ? ". Location:[hostLocationP]":""]. [numHostsShipr] on the ship.[numHostsShipr && hostLocationS ? " Location: [hostLocationS].":""]")
-	message_admins("Bioscan - Xenos received: [numXenosPlanetr] on the planet[numXenosPlanetr > 0 && xenoLocationP ? ". Location:[xenoLocationP]":""]. [numXenosShip] on the ship.[xenoLocationS ? " Location: [xenoLocationS].":""]")
+	message_admins("Bioscan - Humans: [numHostsPlanet] on the planet[hostLocationP ? ". Location:[hostLocationP]":""]. [numHostsShipr] on the ship.[numHostsShipr && hostLocationS ? " Location: [hostLocationS].":""]")
+	message_admins("Bioscan - Xenos: [numXenosPlanetr] on the planet[numXenosPlanetr > 0 && xenoLocationP ? ". Location:[xenoLocationP]":""]. [numXenosShip] on the ship.[xenoLocationS ? " Location: [xenoLocationS].":""]")
 
 
 


### PR DESCRIPTION
## About The Pull Request

Cleanup wording in the admin log for bioscans,

## Why It's Good For The Game

As an admin was confusing to receieve
```
ADMIN LOG:  Bioscan - Humans received: 9 on the planet. Location:the Space Port. 7 on the ship. Location: the Squad Delta Preparation. 
ADMIN LOG:  Bioscan - Xenos received: 2 on the planet. Location:the Unknown Area. 0 on the ship. 
```

It makes you think its what was told to them, but its describing those groups.