### PR TITLE
Fixes a race condition xeno action runtime

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -194,6 +194,7 @@
 	var/keybind_flags
 	var/image/cooldown_image
 	var/keybind_signal
+	var/cooldown_id
 
 /datum/action/xeno_action/New(Target)
 	. = ..()
@@ -213,6 +214,8 @@
 	. = ..()
 	if(keybind_signal)
 		UnregisterSignal(L, keybind_signal)
+	if(cooldown_id)
+		deltimer(cooldown_id)
 
 /datum/action/xeno_action/proc/keybind_activation()
 	if(can_use_action())
@@ -307,7 +310,7 @@
 	if(!length(active_timers)) // stop doubling up
 		last_use = world.time
 		on_cooldown = TRUE
-		addtimer(CALLBACK(src, .proc/on_cooldown_finish), get_cooldown())
+		cooldown_id = addtimer(CALLBACK(src, .proc/on_cooldown_finish), get_cooldown(), TIMER_STOPPABLE)
 		button.overlays += cooldown_image
 		update_button_icon()
 


### PR DESCRIPTION
```
[23:11:41] Runtime in action.dm, line 326: no button object on finishing xeno action cooldown
proc name: on cooldown finish (/datum/action/xeno_action/proc/on_cooldown_finish)
usr: Ragecrab/(Elder Queen)
usr.loc: (Virology Lab (32, 132, 2))
src: Screech (250) (/datum/action/xeno_action/activable/screech)
call stack:
Screech (250) (/datum/action/xeno_action/activable/screech): on cooldown finish()
Screech (250) (/datum/action/xeno_action/activable/screech): on cooldown finish()
/datum/callback (/datum/callback): Invoke()
world: PushUsr(Elder Queen (/mob/living/carbon/xenomorph/queen), /datum/callback (/datum/callback))
/datum/callback (/datum/callback): InvokeAsync()
Timer (/datum/controller/subsystem/timer): fire(0)
Timer (/datum/controller/subsystem/timer): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop()
Master (/datum/controller/master): StartProcessing(0)
```