### PR TITLE
Fixes xeno acid being overriden by weaker one

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -462,7 +462,7 @@
 	if(!current_acid)
 		return FALSE
 
-	if(initial(new_acid.acid_strength) >= current_acid.acid_strength)
+	if(initial(new_acid.acid_strength) < current_acid.acid_strength)
 		return FALSE
 	return TRUE
 
@@ -472,7 +472,7 @@
 	if(!current_acid)
 		return FALSE
 
-	if(initial(new_acid.acid_strength) >= current_acid.acid_strength)
+	if(initial(new_acid.acid_strength) < current_acid.acid_strength)
 		return FALSE
 	return TRUE
 


### PR DESCRIPTION
Fix: #1847
```
//Sentinel weakest acid
/obj/effect/xenomorph/acid/weak
	name = "weak acid"
	acid_strength = 2.5 //250% normal speed
	acid_damage = 75
	icon_state = "acid_weak"

//Superacid
/obj/effect/xenomorph/acid/strong
	name = "strong acid"
	acid_strength = 0.4 //20% normal speed
	acid_damage = 175
	icon_state = "acid_strong"
```