### PR TITLE
Fixes hunter stealth

### DIFF
--- a/code/_onclick/ventcrawl.dm
+++ b/code/_onclick/ventcrawl.dm
@@ -117,10 +117,14 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, typecacheof(list(
 			client.images += A.pipe_vision_img
 			pipes_shown += A.pipe_vision_img
 	is_ventcrawling = TRUE
+	return TRUE
+
 
 /mob/living/carbon/xenomorph/hunter/add_ventcrawl(obj/machinery/atmospherics/starting_machine)
 	. = ..()
-	cancel_stealth()
+	if(.)
+		cancel_stealth()
+
 
 /mob/living/proc/remove_ventcrawl()
 	is_ventcrawling = FALSE


### PR DESCRIPTION
Fixes: #1844

```
/mob/living/update_pipe_vision(atom/new_loc = null)
	. = loc
	if(new_loc)
		. = new_loc
	remove_ventcrawl()
	add_ventcrawl(.)
```
is called periodically
```
/mob/living/carbon/xenomorph/hunter/add_ventcrawl(obj/machinery/atmospherics/starting_machine)
	. = ..()
	if(.)
		cancel_stealth()
```
we only want to cancel it if they actually entered the vent (ie it's not null)