### PR TITLE
Fixes being able to cheese with tank weapon switching.

### DIFF
--- a/code/modules/vehicles/multitile/hardpoints.dm
+++ b/code/modules/vehicles/multitile/hardpoints.dm
@@ -247,6 +247,9 @@ Currently only has the tank hardpoints
 		return
 
 	next_use = world.time + owner.cooldowns["primary"] * owner.misc_ratios["prim_cool"]
+	var/obj/item/hardpoint/secondary/towlauncher/HP = owner.hardpoints[HDPT_SECDGUN]
+	if(istype(HP))
+		HP.next_use = world.time + owner.cooldowns["secondary"] * owner.misc_ratios["secd_cool"]
 
 	var/delay = 5
 	var/turf/T = get_turf(A)
@@ -434,6 +437,10 @@ Currently only has the tank hardpoints
 	qdel(TL)
 
 	next_use = world.time + owner.cooldowns["secondary"] * owner.misc_ratios["secd_cool"]
+	var/obj/item/hardpoint/primary/cannon/HP = owner.hardpoints[HDPT_PRIMARY]
+	if(istype(HP))
+		HP.next_use = world.time + owner.cooldowns["primary"] * owner.misc_ratios["prim_cool"]
+
 	if(!prob(owner.accuracies["secondary"] * 100 * owner.misc_ratios["secd_acc"]))
 		T = get_step(T, pick(GLOB.cardinals))
 	var/obj/item/projectile/P = new


### PR DESCRIPTION
The reason I didn't do this as a do_after during hardpoint switching would be that it would be a huge nerf to moving and trying to switch.
Fixes: #1845