### PR TITLE
Cameras now start anchored

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -8,6 +8,7 @@
 	active_power_usage = 10
 	layer = WALL_OBJ_LAYER
 	resistance_flags = FIRE_PROOF
+	anchored = TRUE
 
 	var/list/network = list("marinemainship")
 	var/c_tag = null


### PR DESCRIPTION
My mistake when copypasting from /tg/, they define it a the machinery level but we don't, so everyone could move cameras until now.