### PR TITLE
Fixes a supply computer deconstruction runtime

### DIFF
--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -241,7 +241,7 @@ GLOBAL_LIST_EMPTY(exports_types)
 	icon = 'icons/obj/machines/computer.dmi'
 	icon_state = "supply"
 	req_access = list(ACCESS_MARINE_CARGO)
-	circuit = "/obj/item/circuitboard/computer/supplycomp"
+	circuit = null
 	var/temp = null
 	var/reqtime = 0 //Cooldown for requisitions - Quarxink
 	var/hacked = 0
@@ -252,7 +252,7 @@ GLOBAL_LIST_EMPTY(exports_types)
 	name = "Supply ordering console"
 	icon = 'icons/obj/machines/computer.dmi'
 	icon_state = "request"
-	circuit = "/obj/item/circuitboard/computer/ordercomp"
+	circuit = null
 	var/temp = null
 	var/reqtime = 0 //Cooldown for requisitions - Quarxink
 	var/last_viewed_group = "categories"


### PR DESCRIPTION
Not sure when these were removed, possibly with spooky's req shuttle rework.
```
[19:41:02] Runtime in computer.dm, line 113: Cannot create objects of type null.
proc name: attackby (/obj/machinery/computer/attackby)
usr: Seroza/(Isaac Clark)
usr.loc: (Requisitions (154, 59, 3))
src: ASRS console (/obj/machinery/computer/supplycomp)
src.loc: the floor (153,59,3) (/turf/open/floor/almayer/mono)
call stack:
ASRS console (/obj/machinery/computer/supplycomp): attackby(the screwdriver (/obj/item/tool/screwdriver), Isaac Clark (/mob/living/carbon/human), "icon-x=23;icon-y=24;left=1;scr...")
ASRS console (/obj/machinery/computer/supplycomp): attackby(the screwdriver (/obj/item/tool/screwdriver), Isaac Clark (/mob/living/carbon/human), "icon-x=23;icon-y=24;left=1;scr...")
the screwdriver (/obj/item/tool/screwdriver): melee attack chain(Isaac Clark (/mob/living/carbon/human), ASRS console (/obj/machinery/computer/supplycomp), "icon-x=23;icon-y=24;left=1;scr...")
Isaac Clark (/mob/living/carbon/human): ClickOn(ASRS console (/obj/machinery/computer/supplycomp), "icon-x=23;icon-y=24;left=1;scr...")
ASRS console (/obj/machinery/computer/supplycomp): Click(the floor (153,59,3) (/turf/open/floor/almayer/mono), "mapwindow.map", "icon-x=23;icon-y=24;left=1;scr...")
```