### PR TITLE
Fixes xeno tunnel destroy runtime.

### DIFF
--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -715,11 +715,12 @@ TUNNEL
 
 /obj/structure/tunnel/Destroy()
     GLOB.xeno_tunnels -= src
-    creator.tunnels -= src
+    if(creator)
+    	creator.tunnels -= src
     if(other)
         other.other = null
         qdel(other)
-    . = ..()
+    return ..()
 
 /obj/structure/tunnel/examine(mob/user)
 	..()

--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -714,13 +714,13 @@ TUNNEL
 
 
 /obj/structure/tunnel/Destroy()
-    GLOB.xeno_tunnels -= src
-    if(creator)
+	GLOB.xeno_tunnels -= src
+	if(creator)
 		creator.tunnels -= src
-    if(other)
-        other.other = null
-        qdel(other)
-    return ..()
+	if(other)
+		other.other = null
+		qdel(other)
+	return ..()
 
 /obj/structure/tunnel/examine(mob/user)
 	..()

--- a/code/modules/cm_aliens/XenoStructures.dm
+++ b/code/modules/cm_aliens/XenoStructures.dm
@@ -716,7 +716,7 @@ TUNNEL
 /obj/structure/tunnel/Destroy()
     GLOB.xeno_tunnels -= src
     if(creator)
-    	creator.tunnels -= src
+		creator.tunnels -= src
     if(other)
         other.other = null
         qdel(other)


### PR DESCRIPTION
The hivelord may not exist at the time their tunnel is destroyed
```

[19:51:57] Runtime in XenoStructures.dm, line 719: Cannot read null.tunnels
proc name: Destroy (/obj/structure/tunnel/Destroy)
usr: Leite_Qualhado/(Daniel Gran)
usr.loc: (Cargo Bay (136, 44, 2))
src: the tunnel (/obj/structure/tunnel)
src.loc: the grass (135,53,2) (/turf/open/ground/grass)
call stack:
the tunnel (/obj/structure/tunnel): Destroy(0)
qdel(the tunnel (/obj/structure/tunnel), 0)
the tunnel (/obj/structure/tunnel): healthcheck()
the tunnel (/obj/structure/tunnel): ex act(1)
the plastic explosives (/obj/item/explosive/plastique): afterattack(the tunnel (/obj/structure/tunnel), Daniel Gran (/mob/living/carbon/human), 1, "icon-x=15;icon-y=17;left=1;scr...")
```