### PR TITLE
Fixes a timer not being stoppable but being qdeleted

### DIFF
--- a/code/game/objects/items/radio/detpack.dm
+++ b/code/game/objects/items/radio/detpack.dm
@@ -131,7 +131,7 @@
 		armed = TRUE
 		//bombtick()
 		log_explosion("[key_name(usr)] triggered [src] explosion at [AREACOORD(loc)].")
-		detonation_pending = addtimer(CALLBACK(src, .proc/do_detonate), timer SECONDS)
+		detonation_pending = addtimer(CALLBACK(src, .proc/do_detonate), timer SECONDS, TIMER_STOPPABLE)
 		if(timer > 10)
 			sound_timer = addtimer(CALLBACK(src, .proc/do_play_sound_normal), 1 SECONDS, TIMER_LOOP)
 			addtimer(CALLBACK(src, .proc/change_to_loud_sound), timer-10)


### PR DESCRIPTION
```
[20:33:37] Runtime in timer.dm, line 503: Tried to delete a null timerid. Use TIMER_STOPPABLE flag
proc name: deltimer (/proc/deltimer)
usr: Crazy creeper/(Adrian Shepard)
usr.loc: (Infirmary (152, 164, 2))
src: null
call stack:
deltimer(-1)
the detonation pack (/obj/item/radio/detpack): Destroy(0)
qdel(the detonation pack (/obj/item/radio/detpack), 0)
the detonation pack (/obj/item/radio/detpack): do detonate()
/datum/callback (/datum/callback): Invoke()
world: PushUsr(Adrian Shepard (/mob/living/carbon/human), /datum/callback (/datum/callback))
/datum/callback (/datum/callback): InvokeAsync()
Timer (/datum/controller/subsystem/timer): fire(0)
Timer (/datum/controller/subsystem/timer): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop()
Master (/datum/controller/master): StartProcessing(0)
```