### PR TITLE
Fixes stun from being released from a non-gibbed xeno while devoured

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/death.dm
+++ b/code/modules/mob/living/carbon/xenomorph/death.dm
@@ -32,6 +32,10 @@
 	for(var/atom/movable/A in stomach_contents)
 		stomach_contents.Remove(A)
 		A.forceMove(loc)
+		if(isliving(A))
+			var/mob/living/L = A
+			L.SetKnockeddown(1)
+			visible_message("<span class='danger'>[A] bursts out of [src]!</span>")
 
 	round_statistics.total_xeno_deaths++
 


### PR DESCRIPTION
Only a gib would set it to 1, now a death does too.