### PR TITLE
Fixes a garbage collection runtime

### DIFF
--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -264,7 +264,7 @@
 	var/need_mob_update = 0
 	for(var/reagent in cached_reagents)
 		var/datum/reagent/R = reagent
-		if(R.holder.gc_destroyed)
+		if(QDELETED(R.holder))
 			continue
 		if(liverless && !R.self_consuming) //need to be metabolized
 			continue


### PR DESCRIPTION
```
[20:46:48] Runtime in Chemistry-Holder.dm, line 267: Cannot read null.gc_destroyed
proc name: metabolize (/datum/reagents/proc/metabolize)
src: /datum/reagents (/datum/reagents)
call stack:
/datum/reagents (/datum/reagents): metabolize(Adrian Shepard (/mob/living/carbon/human), 1, 0)
Adrian Shepard (/mob/living/carbon/human): handle organs()
Adrian Shepard (/mob/living/carbon/human): Life(2, 1231)
Adrian Shepard (/mob/living/carbon/human): Life(2, 1231)
Adrian Shepard (/mob/living/carbon/human): Life(2, 1231)
Mobs (/datum/controller/subsystem/mobs): fire(0)
Mobs (/datum/controller/subsystem/mobs): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop()
Master (/datum/controller/master): StartProcessing(0)
```