### PR TITLE
Makes the quick equip behavior less quirky.

### DIFF
--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -17,11 +17,9 @@
 				next_move = world.time + 3
 				return
 	else
-		if(s_active)
-			if(!s_active.can_be_inserted(I))
-				return
+		if(s_active && s_active.can_be_inserted(I))
 			s_active.handle_item_insertion(I, FALSE, src)
-			return 
+			return
 		if(client?.prefs?.preferred_slot)
 			if(equip_to_slot_if_possible(I, client.prefs.preferred_slot, FALSE, FALSE, FALSE))
 				return


### PR DESCRIPTION
It will only stop the usual equip chain behavior if item insertion is actually possible into the currently open inventory. People wanted this and it should bring back the QoL while not reintroducing the bug (tested locally)