### PR TITLE
Fixes spec rocked fire runtime

### DIFF
--- a/code/modules/projectiles/updated_projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/specialist.dm
@@ -771,7 +771,7 @@
 
 	//loaded_rocket.current_rounds = max(loaded_rocket.current_rounds - 1, 0)
 
-	if(!current_mag.current_rounds)
+	if(current_mag && !current_mag.current_rounds)
 		current_mag.loc = get_turf(src)
 		current_mag.update_icon()
 		current_mag = null


### PR DESCRIPTION
The current_mag could have been deleted by the parent call
```
[21:18:13] Runtime in specialist.dm, line 774: Cannot read null.current_rounds
proc name: Fire (/obj/item/weapon/gun/launcher/rocket/Fire)
usr: Tesora/(Louis 'Eli' Daniels)
usr.loc: (Hallway Stern (214, 195, 3))
src: the M5 RPG (Wielded) (/obj/item/weapon/gun/launcher/rocket)
src.loc: Louis \'Eli\' Daniels (/mob/living/carbon/human)
call stack:
the M5 RPG (Wielded) (/obj/item/weapon/gun/launcher/rocket): Fire(the Maintenance Hatch (/obj/machinery/door/airlock/almayer/maint), Louis \'Eli\' Daniels (/mob/living/carbon/human), "icon-x=31;icon-y=6;left=1;scre...", 0, null)
```