### PR TITLE
Fix runtime when swapping a squad for a SL

### DIFF
--- a/code/game/jobs/squads.dm
+++ b/code/game/jobs/squads.dm
@@ -206,7 +206,6 @@ GLOBAL_LIST_EMPTY(helmetmarkings_sl)
 /datum/squad/proc/clean_marine_from_squad(mob/living/carbon/human/H, wipe)
 	if(!H.assigned_squad || !(H in marines_list))
 		return FALSE
-	SSdirection.stop_tracking(tracking_id, H)// failsafe
 	marines_list -= src
 	if(!wipe)
 		var/role = "unknown"
@@ -217,6 +216,9 @@ GLOBAL_LIST_EMPTY(helmetmarkings_sl)
 		squad_leader = null
 		SSdirection.clear_leader(tracking_id)
 		SSdirection.stop_tracking("marine-sl", src)
+	else
+		SSdirection.stop_tracking(tracking_id, H)
+
 	H.assigned_squad = null
 	return TRUE
 


### PR DESCRIPTION
Fixes runtime
```
[22:19:31] Runtime in unsorted.dm, line 37: mismatch in tracking mobs by reference
proc name: stack trace (/datum/proc/stack_trace)
usr: LaKiller8/(Thomas Echard)
usr.loc: (North Central Barrens (111, 122, 2))
src: Direction (/datum/controller/subsystem/direction)
call stack:
Direction (/datum/controller/subsystem/direction): stack trace("mismatch in tracking mobs by r...")
Direction (/datum/controller/subsystem/direction): stop tracking("faction_1", Cherry Fields (/mob/living/carbon/human))
Bravo (/datum/squad/bravo): clean marine from squad(Cherry Fields (/mob/living/carbon/human), null)
Cherry Fields (/mob/living/carbon/human): change squad("Alpha")
lakiller8\'s admin datum (Head... (/datum/admins): Topic("src=\[0x210009a7];admin_token=...", /list (/list))
LaKiller8 (/client): Topic("src=\[0x210009a7];admin_token=...", /list (/list), lakiller8\'s admin datum (Head... (/datum/admins))
LaKiller8 (/client): Topic("src=\[0x210009a7];admin_token=...", /list (/list), lakiller8\'s admin datum (Head... (/datum/admins))
LaKiller8 (/client): Topic("src=\[0x210009a7];admin_token=...", /list (/list), lakiller8\'s admin datum (Head... (/datum/admins))
```