### PR TITLE
Fixes a few more deltimer issues

### DIFF
--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -161,7 +161,7 @@
 
 	SSticker.mode.on_distress_cooldown = TRUE
 
-	candidate_timer = addtimer(CALLBACK(src, .do_activate, announce), 1 MINUTES)
+	candidate_timer = addtimer(CALLBACK(src, .do_activate, announce), 1 MINUTES, TIMER_STOPPABLE)
 
 /datum/emergency_call/proc/do_activate(announce = TRUE)
 	candidate_timer = null
@@ -197,7 +197,7 @@
 		SSticker.mode.picked_call = null
 		SSticker.mode.on_distress_cooldown = TRUE
 
-		cooldown_timer = addtimer(CALLBACK(src, .reset), COOLDOWN_COMM_REQUEST)
+		cooldown_timer = addtimer(CALLBACK(src, .reset), COOLDOWN_COMM_REQUEST, TIMER_STOPPABLE)
 		return
 
 	var/datum/mind/picked_candidates = list()


### PR DESCRIPTION
```
[22:32:50] Runtime in timer.dm, line 503: Tried to delete a null timerid. Use TIMER_STOPPABLE flag
proc name: deltimer (/proc/deltimer)
usr: Tesora/(Louis 'Eli' Daniels)
usr.loc: (Combat Information Center (64, 186, 3))
src: null
call stack:
deltimer(-1)
Pizza Delivery (/datum/emergency_call/pizza): reset()
/datum/callback (/datum/callback): Invoke()
world: PushUsr(Louis \'Eli\' Daniels (/mob/living/carbon/human), /datum/callback (/datum/callback))
/datum/callback (/datum/callback): InvokeAsync()
Timer (/datum/controller/subsystem/timer): fire(0)
Timer (/datum/controller/subsystem/timer): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop()
Master (/datum/controller/master): StartProcessing(0)
```