### PR TITLE
Fixes not being able to screw back autolathe

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -130,7 +130,7 @@
 /obj/machinery/autolathe/attackby(obj/item/I, mob/user, params)
 	. = ..()
 
-	if(machine_stat)
+	if(!is_operational())
 		return
 
 	if(busy)


### PR DESCRIPTION
Caused by adding PANEL_OPEN to machine _stat.