### PR TITLE
Small hud tweaks

### DIFF
--- a/code/__DEFINES/atom_hud.dm
+++ b/code/__DEFINES/atom_hud.dm
@@ -2,25 +2,23 @@
 //The number is the location of the image on the list hud_list of humans.
 // /datum/atom_hud expects these to be unique
 // these need to be strings in order to make them associative lists
-#define HEALTH_HUD			"1" // a simple line rounding the mob's number health
-#define STATUS_HUD			"2" // alive, dead, diseased, etc.
-#define ID_HUD				"3" // the job asigned to your ID
-#define WANTED_HUD			"4" // wanted, released, parroled, security status
-#define IMPLOYAL_HUD		"5" // loyality implant
-#define IMPCHEM_HUD			"6" // chemical implant
-#define IMPTRACK_HUD		"7" // tracking implant
-#define SPECIALROLE_HUD 	"8" // AntagHUD image
-#define STATUS_HUD_OOC		"9" // STATUS_HUD without virus db check for someone being ill.
-#define STATUS_HUD_XENO_INFECTION		"10" // STATUS_HUD without virus db check for someone being ill.
-#define HEALTH_HUD_XENO		"11" //health HUD for xenos
-#define SQUAD_HUD			"12" //squad hud showing who's leader, corpsman, etc for each squad.
-#define PLASMA_HUD			"13" //indicates the plasma level of xenos.
-#define PHEROMONE_HUD		"14" //indicates which pheromone is active on a xeno.
-#define QUEEN_OVERWATCH_HUD	"15" //indicates which xeno the queen is overwatching.
-#define STATUS_HUD_OBSERVER_INFECTION "16" //gives observers the xeno larval stage
-#define ORDER_HUD "17" //shows what orders are applied to marines
-#define AI_DETECT_HUD "18"
-#define PAIN_HUD "19" //A HUD to display human pain.
+#define HEALTH_HUD					"health_hud" // a simple line rounding the mob's number health
+#define STATUS_HUD					"status_hud" // alive, dead, diseased, etc.
+#define ID_HUD						"id_hud" // the job asigned to your ID
+#define WANTED_HUD					"wanted_hud" // wanted, released, parroled, security status
+#define IMPLOYAL_HUD				"loyalty_implant_hud" // loyality implant
+#define IMPCHEM_HUD					"chemical_implant_hud" // chemical implant
+#define IMPTRACK_HUD				"tracking_implant_hud" // tracking implant
+#define SPECIALROLE_HUD				"antag_hud" // AntagHUD image
+#define STATUS_HUD_XENO_INFECTION	"xeno_embryo_hud" // xeno larval stage.
+#define HEALTH_HUD_XENO				"xeno_health_hud" //health HUD for xenos
+#define SQUAD_HUD					"squad_hud" //squad hud showing who's leader, corpsman, etc for each squad.
+#define PLASMA_HUD					"xeno_plasma_hud" //indicates the plasma level of xenos.
+#define PHEROMONE_HUD				"xeno_pheromone_hud" //indicates which pheromone is active on a xeno.
+#define QUEEN_OVERWATCH_HUD			"xeno_overwatch_hud" //indicates which xeno the queen is overwatching.
+#define ORDER_HUD					"human_order_hud" //shows what orders are applied to marines
+#define AI_DETECT_HUD				"ai_detect_hud"
+#define PAIN_HUD					"pain_hud" //A HUD to display human pain.
 
 #define ADD_HUD_TO_COOLDOWN 20 //cooldown for being shown the images for any particular data hud
 

--- a/code/__DEFINES/atom_hud.dm
+++ b/code/__DEFINES/atom_hud.dm
@@ -10,7 +10,7 @@
 #define IMPCHEM_HUD					"chemical_implant_hud" // chemical implant
 #define IMPTRACK_HUD				"tracking_implant_hud" // tracking implant
 #define SPECIALROLE_HUD				"antag_hud" // AntagHUD image
-#define STATUS_HUD_XENO_INFECTION	"xeno_embryo_hud" // xeno larval stage.
+#define XENO_EMBRYO_HUD				"xeno_embryo_hud" // xeno larval stage.
 #define HEALTH_HUD_XENO				"xeno_health_hud" //health HUD for xenos
 #define SQUAD_HUD					"squad_hud" //squad hud showing who's leader, corpsman, etc for each squad.
 #define PLASMA_HUD					"xeno_plasma_hud" //indicates the plasma level of xenos.

--- a/code/__DEFINES/atom_hud.dm
+++ b/code/__DEFINES/atom_hud.dm
@@ -17,8 +17,8 @@
 #define PHEROMONE_HUD				"xeno_pheromone_hud" //indicates which pheromone is active on a xeno.
 #define QUEEN_OVERWATCH_HUD			"xeno_overwatch_hud" //indicates which xeno the queen is overwatching.
 #define ORDER_HUD					"human_order_hud" //shows what orders are applied to marines
-#define AI_DETECT_HUD				"ai_detect_hud"
-#define PAIN_HUD					"pain_hud" //A HUD to display human pain.
+#define AI_DETECT_HUD				"ai_detect_hud" //hud for displaying the AI eye's location
+#define PAIN_HUD					"pain_hud" //displays human pain / preceived health.
 
 #define ADD_HUD_TO_COOLDOWN 20 //cooldown for being shown the images for any particular data hud
 

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -20,8 +20,6 @@
 
 /mob/living/carbon/monkey/add_to_all_mob_huds()
 	for(var/datum/atom_hud/hud in GLOB.huds)
-		if(!istype(hud, /datum/atom_hud/xeno_infection)) //monkey only appear on this hud
-			continue
 		hud.add_to_hud(src)
 
 
@@ -45,8 +43,6 @@
 
 /mob/living/carbon/monkey/remove_from_all_mob_huds()
 	for(var/datum/atom_hud/hud in GLOB.huds)
-		if(!istype(hud, /datum/atom_hud/xeno_infection))
-			continue
 		hud.add_to_hud(src)
 
 
@@ -99,7 +95,7 @@
 
 //medical hud used by ghosts
 /datum/atom_hud/medical/observer
-	hud_icons = list(HEALTH_HUD, STATUS_HUD_OBSERVER_INFECTION, STATUS_HUD)
+	hud_icons = list(HEALTH_HUD, STATUS_HUD_XENO_INFECTION, STATUS_HUD)
 
 
 /datum/atom_hud/medical/pain
@@ -192,70 +188,45 @@
 	else
 		holder.icon_state = ""
 
+
 /mob/living/carbon/human/med_hud_set_status()
-	var/image/holder = hud_list[STATUS_HUD]
-	var/image/holder2 = hud_list[STATUS_HUD_OOC]
-	var/image/holder3 = hud_list[STATUS_HUD_XENO_INFECTION]
-	var/image/holder4 = hud_list[STATUS_HUD_OBSERVER_INFECTION]
+	var/image/status_hud = hud_list[STATUS_HUD]
+	var/image/infection_hud = hud_list[STATUS_HUD_XENO_INFECTION]
 
 	if(species.species_flags & IS_SYNTHETIC)
-		holder.icon_state = "hudsynth"
-		holder2.icon_state = "hudsynth"
-		holder3.icon_state = "hudsynth"
-	else
-		var/revive_enabled = TRUE
-		var/stage = 1
-		if(!check_tod(src) || !is_revivable())
-			revive_enabled = FALSE
-		else if(!client)
-			var/mob/dead/observer/G = get_ghost()
-			if(!istype(G))
-				revive_enabled = FALSE
+		status_hud.icon_state = "hudsynth"
+		infection_hud.icon_state = ""
+		return TRUE
 
-		if(stat == DEAD && !undefibbable)
+	if(status_flags & XENO_HOST)
+		var/obj/item/alien_embryo/E = locate(/obj/item/alien_embryo) in src
+		if(E)
+			infection_hud.icon_state = "infected[E.stage]"
+		else if(locate(/mob/living/carbon/xenomorph/larva) in src)
+			infection_hud.icon_state = "infected6"
+		else
+			infection_hud.icon_state = ""
+	else
+		infection_hud.icon_state = ""
+
+	switch(stat)
+
+		if(DEAD)
+
+			if(undefibbable || (!client && !get_ghost()))
+				status_hud.icon_state = "huddead"
+				return TRUE
+
+			var/stage = 1
 			if((world.time - timeofdeath) > (CONFIG_GET(number/revive_grace_period) * 0.4) && (world.time - timeofdeath) < (CONFIG_GET(number/revive_grace_period) * 0.8))
 				stage = 2
 			else if((world.time - timeofdeath) > (CONFIG_GET(number/revive_grace_period) * 0.8))
 				stage = 3
+			status_hud.icon_state = "huddeaddefib[stage]"
+			return TRUE
 
-		var/holder2_set = 0
-		if(status_flags & XENO_HOST)
-			holder2.icon_state = "hudxeno"//Observer and admin HUD only
-			holder2_set = 1
-			var/obj/item/alien_embryo/E = locate(/obj/item/alien_embryo) in src
-			if(E)
-				holder3.icon_state = "infected[E.stage]"
-				holder4.icon_state = "infected[E.stage]"
-			else if(locate(/mob/living/carbon/xenomorph/larva) in src)
-				holder.icon_state = "infected5"
-				holder4.icon_state = "infected5"
-			else
-				holder4.icon_state = ""
 		else
-			holder4.icon_state = ""
-
-		if(stat == DEAD)
-			if(revive_enabled)
-				holder.icon_state = "huddeaddefib[stage]"
-				if(!holder2_set)
-					holder2.icon_state = "huddeaddefib[stage]"
-					holder3.icon_state = "huddead"
-					holder2_set = 1
-			else
-				holder.icon_state = "huddead"
-				holder4.icon_state = ""
-				if(!holder2_set || check_tod(src))
-					holder2.icon_state = "huddead"
-					holder3.icon_state = "huddead"
-					holder2_set = 1
-
-			return
-
-
-		holder.icon_state = "hudhealthy"
-		if(!holder2_set)
-			holder2.icon_state = "hudhealthy"
-			holder3.icon_state = ""
+			status_hud.icon_state = "hudhealthy"
 
 
 /mob/proc/med_pain_set_perceived_health()
@@ -276,16 +247,8 @@
 	switch(perceived_health)
 		if(100 to INFINITY)
 			holder.icon_state = "hudhealth100"
-		if(80 to 100)
-			holder.icon_state = "hudhealth80"
-		if(60 to 80)
-			holder.icon_state = "hudhealth60"
-		if(40 to 60)
-			holder.icon_state = "hudhealth40"
-		if(20 to 40)
-			holder.icon_state = "hudhealth20"
-		if(0 to 20)
-			holder.icon_state = "hudhealth0"
+		if(0 to 100)
+			holder.icon_state = "hudhealth[round(perceived_health, 10)]"
 		if(-50 to 0)
 			holder.icon_state = "hudhealth-0"
 		else
@@ -294,7 +257,7 @@
 	return TRUE
 
 
-//infection status that appears on humans, viewed by xenos only.
+//infection status that appears on humans and monkeys, viewed by xenos only.
 /datum/atom_hud/xeno_infection
 	hud_icons = list(STATUS_HUD_XENO_INFECTION)
 

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -95,7 +95,7 @@
 
 //medical hud used by ghosts
 /datum/atom_hud/medical/observer
-	hud_icons = list(HEALTH_HUD, STATUS_HUD_XENO_INFECTION, STATUS_HUD)
+	hud_icons = list(HEALTH_HUD, XENO_EMBRYO_HUD, STATUS_HUD)
 
 
 /datum/atom_hud/medical/pain
@@ -176,7 +176,7 @@
 
 
 /mob/living/carbon/monkey/med_hud_set_status()
-	var/image/holder = hud_list[STATUS_HUD_XENO_INFECTION]
+	var/image/holder = hud_list[XENO_EMBRYO_HUD]
 	if(status_flags & XENO_HOST)
 		var/obj/item/alien_embryo/E = locate(/obj/item/alien_embryo) in src
 		if(E)
@@ -191,7 +191,7 @@
 
 /mob/living/carbon/human/med_hud_set_status()
 	var/image/status_hud = hud_list[STATUS_HUD]
-	var/image/infection_hud = hud_list[STATUS_HUD_XENO_INFECTION]
+	var/image/infection_hud = hud_list[XENO_EMBRYO_HUD]
 
 	if(species.species_flags & IS_SYNTHETIC)
 		status_hud.icon_state = "hudsynth"
@@ -259,7 +259,7 @@
 
 //infection status that appears on humans and monkeys, viewed by xenos only.
 /datum/atom_hud/xeno_infection
-	hud_icons = list(STATUS_HUD_XENO_INFECTION)
+	hud_icons = list(XENO_EMBRYO_HUD)
 
 
 //Xeno status hud, for xenos

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -5,7 +5,7 @@
 	real_name = "unknown"
 	icon = 'icons/mob/human.dmi'
 	icon_state = "body_m_s"
-	hud_possible = list(HEALTH_HUD,STATUS_HUD, STATUS_HUD_XENO_INFECTION,ID_HUD,WANTED_HUD,IMPLOYAL_HUD,IMPCHEM_HUD,IMPTRACK_HUD, SPECIALROLE_HUD, SQUAD_HUD, ORDER_HUD, PAIN_HUD)
+	hud_possible = list(HEALTH_HUD,STATUS_HUD, XENO_EMBRYO_HUD,ID_HUD,WANTED_HUD,IMPLOYAL_HUD,IMPCHEM_HUD,IMPTRACK_HUD, SPECIALROLE_HUD, SQUAD_HUD, ORDER_HUD, PAIN_HUD)
 	var/embedded_flag	  //To check if we've need to roll for damage on movement while an item is imbedded in us.
 
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -5,7 +5,7 @@
 	real_name = "unknown"
 	icon = 'icons/mob/human.dmi'
 	icon_state = "body_m_s"
-	hud_possible = list(HEALTH_HUD,STATUS_HUD, STATUS_HUD_OOC, STATUS_HUD_XENO_INFECTION,ID_HUD,WANTED_HUD,IMPLOYAL_HUD,IMPCHEM_HUD,IMPTRACK_HUD, SPECIALROLE_HUD, SQUAD_HUD, STATUS_HUD_OBSERVER_INFECTION, ORDER_HUD, PAIN_HUD)
+	hud_possible = list(HEALTH_HUD,STATUS_HUD, STATUS_HUD_XENO_INFECTION,ID_HUD,WANTED_HUD,IMPLOYAL_HUD,IMPCHEM_HUD,IMPTRACK_HUD, SPECIALROLE_HUD, SQUAD_HUD, ORDER_HUD, PAIN_HUD)
 	var/embedded_flag	  //To check if we've need to roll for damage on movement while an item is imbedded in us.
 
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -21,7 +21,7 @@
 			if(parasite) //The larva cannot survive without a host.
 				qdel(parasite)
 			DISABLE_BITFIELD(status_flags, XENO_HOST)
-		med_hud_set_status()
+			med_hud_set_status()
 		return TRUE
 	//No need to update all of these procs if the guy is dead.
 
@@ -56,7 +56,7 @@
 		else //Dead
 			if(!undefibbable && timeofdeath && life_tick > 5 && life_tick % 2 == 0)
 				if(timeofdeath < 5 || !check_tod(src) || !is_revivable())	//We are dead beyond revival, or we're junk mobs spawned like the clowns on the clown shuttle
-					undefibbable = TRUE
+					set_undefibbable()
 					med_hud_set_status()
 				else if((world.time - timeofdeath) > (CONFIG_GET(number/revive_grace_period) * 0.4) && (world.time - timeofdeath) < (CONFIG_GET(number/revive_grace_period) * 0.8))
 					med_hud_set_status()
@@ -69,3 +69,7 @@
 	handle_environment() //Optimized a good bit.
 
 	pulse = handle_pulse()
+
+
+/mob/living/carbon/human/proc/set_undefibbable()
+	undefibbable = TRUE

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -14,9 +14,15 @@
 	//update the current life tick, can be used to e.g. only do something every 4 ticks
 	life_tick++
 
-	if(stat == DEAD)
-		if(!check_tod(src))
-			SSmobs.stop_processing(src)
+	if(stat == DEAD && undefibbable)
+		SSmobs.stop_processing(src) //Last round of processing.
+		if(CHECK_BITFIELD(status_flags, XENO_HOST))
+			var/obj/item/alien_embryo/parasite = locate(/obj/item/alien_embryo) in src
+			if(parasite) //The larva cannot survive without a host.
+				qdel(parasite)
+			DISABLE_BITFIELD(status_flags, XENO_HOST)
+		med_hud_set_status()
+		return TRUE
 	//No need to update all of these procs if the guy is dead.
 
 	if(!in_stasis)
@@ -49,7 +55,7 @@
 
 		else //Dead
 			if(!undefibbable && timeofdeath && life_tick > 5 && life_tick % 2 == 0)
-				if(timeofdeath < 5 || !check_tod(src))	//We are dead beyond revival, or we're junk mobs spawned like the clowns on the clown shuttle
+				if(timeofdeath < 5 || !check_tod(src) || !is_revivable())	//We are dead beyond revival, or we're junk mobs spawned like the clowns on the clown shuttle
 					undefibbable = TRUE
 					med_hud_set_status()
 				else if((world.time - timeofdeath) > (CONFIG_GET(number/revive_grace_period) * 0.4) && (world.time - timeofdeath) < (CONFIG_GET(number/revive_grace_period) * 0.8))

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -14,17 +14,6 @@
 	//update the current life tick, can be used to e.g. only do something every 4 ticks
 	life_tick++
 
-	if(stat == DEAD && undefibbable)
-		SSmobs.stop_processing(src) //Last round of processing.
-		if(CHECK_BITFIELD(status_flags, XENO_HOST))
-			var/obj/item/alien_embryo/parasite = locate(/obj/item/alien_embryo) in src
-			if(parasite) //The larva cannot survive without a host.
-				qdel(parasite)
-			DISABLE_BITFIELD(status_flags, XENO_HOST)
-			med_hud_set_status()
-		return TRUE
-	//No need to update all of these procs if the guy is dead.
-
 	if(!in_stasis)
 		if(stat != DEAD)
 
@@ -57,7 +46,6 @@
 			if(!undefibbable && timeofdeath && life_tick > 5 && life_tick % 2 == 0)
 				if(timeofdeath < 5 || !check_tod(src) || !is_revivable())	//We are dead beyond revival, or we're junk mobs spawned like the clowns on the clown shuttle
 					set_undefibbable()
-					med_hud_set_status()
 				else if((world.time - timeofdeath) > (CONFIG_GET(number/revive_grace_period) * 0.4) && (world.time - timeofdeath) < (CONFIG_GET(number/revive_grace_period) * 0.8))
 					med_hud_set_status()
 				else if((world.time - timeofdeath) > (CONFIG_GET(number/revive_grace_period) * 0.8))
@@ -73,3 +61,12 @@
 
 /mob/living/carbon/human/proc/set_undefibbable()
 	undefibbable = TRUE
+	SSmobs.stop_processing(src) //Last round of processing.
+
+	if(CHECK_BITFIELD(status_flags, XENO_HOST))
+		var/obj/item/alien_embryo/parasite = locate(/obj/item/alien_embryo) in src
+		if(parasite) //The larva cannot survive without a host.
+			qdel(parasite)
+		DISABLE_BITFIELD(status_flags, XENO_HOST)
+
+	med_hud_set_status()

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -6,7 +6,7 @@
 	gender = NEUTER
 	flags_pass = PASSTABLE
 	hud_type = /datum/hud/monkey
-	hud_possible = list(STATUS_HUD_XENO_INFECTION)
+	hud_possible = list(XENO_EMBRYO_HUD)
 
 	var/obj/item/card/id/wear_id = null // Fix for station bounced radios -- Skie
 	var/greaterform_type = /datum/species/human

--- a/code/modules/projectiles/updated_projectiles/gun_system.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_system.dm
@@ -855,7 +855,7 @@ and you're good to go.
 		user.apply_damage(100, OXY)
 		if(ishuman(user) && user == M)
 			var/mob/living/carbon/human/HM = user
-			HM.undefibbable = TRUE //can't be defibbed back from self inflicted gunshot to head
+			HM.set_undefibbable() //can't be defibbed back from self inflicted gunshot to head
 		user.death()
 
 	user.log_message("commited suicide with [src]", LOG_ATTACK, "red") //Apply the attack log.


### PR DESCRIPTION
## About The Pull Request

Did a small refactor on the human HUD proc in order to pave the way for an unconscious state HUD, and maybe a basic one for every living mob to have, which tells you at a glance if the person is conscious and moving or not. If nothing else adding unconscious should aid the medics and docs.

Removed `STATUS_HUD_OOC`, which was unused, and `STATUS_HUD_OBSERVER_INFECTION`, which just diminished information for the observers.

## Changelog
:cl:
tweak: Xenos and ghosts can see the larva progression on monkeys as well as humans now.
/:cl: