### PR TITLE
Add end of round stats to PRs

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -301,6 +301,10 @@ Master controller and performance related.
 
 /datum/config_entry/flag/use_recursive_explosions
 
+/datum/config_entry/string/github_pr_bot
+	// Example: bot.com/<secret>
+	protection = CONFIG_ENTRY_LOCKED|CONFIG_ENTRY_HIDDEN
+
 /*
 System command that invokes youtube-dl, used by Play Internet Sound.
 You can install youtube-dl with

--- a/code/controllers/stonedmc/subsystem/blackbox.dm
+++ b/code/controllers/stonedmc/subsystem/blackbox.dm
@@ -42,7 +42,8 @@ SUBSYSTEM_DEF(blackbox)
 /datum/controller/subsystem/blackbox/proc/send_pr_stats()
 	var/bot_url = CONFIG_GET(string/github_pr_bot)
 	if(!bot_url)
-		return
+		stack_trace("Warning: `string/github_pr_bot` not set")
+		return FALSE
 
 	var/round_id = GLOB.round_id
 	var/datum/getrev/revdata = GLOB.revdata
@@ -57,3 +58,4 @@ SUBSYSTEM_DEF(blackbox)
 
 
 	world.Export("http://[bot_url]?roundId=[round_id]&commit=[revdata.commit]&prs=[prs.Join(",")]&totalRuntimes=[total_runtimes]&uniqueRuntimes=[unique_runtimes]")
+	return TRUE

--- a/code/controllers/stonedmc/subsystem/blackbox.dm
+++ b/code/controllers/stonedmc/subsystem/blackbox.dm
@@ -38,3 +38,22 @@ SUBSYSTEM_DEF(blackbox)
 
 /datum/controller/subsystem/blackbox/vv_edit_var(var_name, var_value)
 	return FALSE
+
+/datum/controller/subsystem/blackbox/proc/send_pr_stats()
+	var/bot_url = CONFIG_GET(string/github_pr_bot)
+	if(!bot_url)
+		return
+
+	var/round_id = GLOB.round_id
+	var/datum/getrev/revdata = GLOB.revdata
+
+	var/total_runtimes = GLOB.total_runtimes
+	var/unique_runtimes = total_runtimes - GLOB.total_runtimes_skipped
+
+	var/list/prs = list()
+	for(var/line in revdata.testmerge)
+		var/datum/tgs_revision_information/test_merge/tm = line
+		prs.Add(tm.number)
+
+
+	world.Export("http://[bot_url]?roundId=[round_id]&commit=[revdata.commit]&prs=[prs.Join(",")]&totalRuntimes=[total_runtimes]&uniqueRuntimes=[unique_runtimes]")

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -154,6 +154,7 @@
 
 /datum/game_mode/proc/declare_completion()
 	SSdbcore.SetRoundEnd()
+	SSblackbox.send_pr_stats()
 	end_of_round_deathmatch()
 	return TRUE
 

--- a/code/game/gamemodes/huntergames.dm
+++ b/code/game/gamemodes/huntergames.dm
@@ -185,6 +185,7 @@
 //Announces the end of the game with all relevant information stated//
 //////////////////////////////////////////////////////////////////////
 /datum/game_mode/huntergames/declare_completion()
+	. = ..()
 	var/mob/living/carbon/winner = null
 
 	for(var/mob/living/carbon/human/Q in GLOB.alive_human_list)


### PR DESCRIPTION
## About The Pull Request

This will send a HTTP GET before the end of round deathmatch. It will send a list of merged PRs, number of runtimes (unique and total) along with the current commit and round Id.

This will get sent to a server that will add it to each PR to record rounds.

See https://github.com/psykzz/tgmc-server/pull/2 for an example (and for server code)

## Why It's Good For The Game

More data and tracking around rounds played with a test merge.

## Changelog
:cl:
server: End of round stats are sent and added to test merges.
/:cl:
