### PR TITLE
Fixes another timer issue

### DIFF
--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -100,7 +100,7 @@
 			handle_pod()
 
 	desiredstate = !desiredstate
-	addtimer(CALLBACK(src, .proc/unpress), 15, TIMER_OVERRIDE)
+	addtimer(CALLBACK(src, .proc/unpress), 15, TIMER_OVERRIDE|TIMER_UNIQUE)
 
 /obj/machinery/door_control/proc/unpress()
 	pressed = FALSE


### PR DESCRIPTION
```
[18:05:35] Runtime in unsorted.dm, line 33: TIMER_OVERRIDE used without TIMER_UNIQUE
proc name: stack trace (/proc/stack_trace)
usr: Jerkmilder/(Eli Musk)
usr.loc: (Hangar (93, 64, 3))
src: null
call stack:
stack trace("TIMER_OVERRIDE used without TI...")
addtimer(/datum/callback (/datum/callback), 15, 2)
Medical Emergency Shutters (/obj/machinery/door_control): attack hand(Eli Musk (/mob/living/carbon/human))
Eli Musk (/mob/living/carbon/human): UnarmedAttack(Medical Emergency Shutters (/obj/machinery/door_control), 1)
Eli Musk (/mob/living/carbon/human): ClickOn(Medical Emergency Shutters (/obj/machinery/door_control), "icon-x=17;icon-y=18;left=1;scr...")
Medical Emergency Shutters (/obj/machinery/door_control): Click(the floor (94,64,3) (/turf/open/floor/almayer), "mapwindow.map", "icon-x=17;icon-y=18;left=1;scr...")
Jerkmilder (/client): Click(Medical Emergency Shutters (/obj/machinery/door_control), the floor (94,64,3) (/turf/open/floor/almayer), "mapwindow.map", "icon-x=17;icon-y=18;left=1;scr...")
```