### PR TITLE
Facehuggers won't attach to someone on fire

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -307,6 +307,9 @@
 		if(species?.species_flags & IS_SYNTHETIC)
 			return FALSE
 
+	if(on_fire)
+		return FALSE
+
 	if(check_mask)
 		if(wear_mask)
 			var/obj/item/W = wear_mask


### PR DESCRIPTION
## About The Pull Request

Facehuggers won't attach to someone on fire

## Why It's Good For The Game

Closer to reality everyday

## Changelog
:cl:
balance: Facehuggers will no longer attach to a host on fire.
/:cl:
