### PR TITLE
Fixes an ERT timer runtime

### DIFF
--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -265,7 +265,7 @@
 
 	candidates = list() //Blank out the candidates list for next time.
 
-	cooldown_timer = addtimer(CALLBACK(src, .reset), COOLDOWN_COMM_REQUEST)
+	cooldown_timer = addtimer(CALLBACK(src, .reset), COOLDOWN_COMM_REQUEST, TIMER_STOPPABLE)
 
 /datum/emergency_call/proc/add_candidate(var/mob/M)
 	if(!M.client)


### PR DESCRIPTION
Missed that there are two places where this one is used.
```
[2019-06-15 00:59:23.023] runtime error: Tried to delete a null timerid. Use TIMER_STOPPABLE flag
 - proc name: deltimer (/proc/deltimer)
 -   source file: timer.dm,503
 -   usr: Matt Dowl (/mob/dead/observer)
 -   src: null
 -   usr.loc: the floor (27,196,2) (/turf/open/shuttle/dropship/floor)
 -   call stack:
 - deltimer(-1)
 - Freelancers (/datum/emergency_call/freelancers): reset()
 - /datum/callback (/datum/callback): Invoke()
 - world: PushUsr(Matt Dowl (/mob/dead/observer), /datum/callback (/datum/callback))
 - /datum/callback (/datum/callback): InvokeAsync()
 - Timer (/datum/controller/subsystem/timer): fire(0)
 - Timer (/datum/controller/subsystem/timer): ignite(0)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop()
 - Master (/datum/controller/master): StartProcessing(0)
 - 
[2019-06-15 00:59:24.073] ## WARNING: check_dock failed on request for the marine dropship in code/modules/shuttle/shuttle.dm at line 397 src: the marine dropship usr: Elder Queen.
[2019-06-15 00:59:24.572] ## WARNING: check_dock failed on request for the marine dropship in code/modules/shuttle/shuttle.dm at line 397 src: the marine dropship usr: Elder Queen.
[2019-06-15 00:59:25.023] ## WARNING: check_dock failed on request for the marine dropship in code/modules/shuttle/shuttle.dm at line 397 src: the marine dropship usr: Elder Queen.
[2019-06-15 00:59:25.572] ## WARNING: check_dock failed on request for the marine dropship in code/modules/shuttle/shuttle.dm at line 397 src: the marine dropship usr: Elder Queen.
```