### PR TITLE
Ports in trait accessors defines

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -1,0 +1,59 @@
+// trait accessor defines
+#define ADD_TRAIT(target, trait, source) \
+	do { \
+		var/list/_L; \
+		if (!target.status_traits) { \
+			target.status_traits = list(); \
+			_L = target.status_traits; \
+			_L[trait] = list(source); \
+		} else { \
+			_L = target.status_traits; \
+			if (_L[trait]) { \
+				_L[trait] |= list(source); \
+			} else { \
+				_L[trait] = list(source); \
+			} \
+		} \
+	} while (0)
+#define REMOVE_TRAIT(target, trait, sources) \
+	do { \
+		var/list/_L = target.status_traits; \
+		var/list/_S; \
+		if (sources && !islist(sources)) { \
+			_S = list(sources); \
+		} else { \
+			_S = sources\
+		}; \
+		if (_L && _L[trait]) { \
+			for (var/_T in _L[trait]) { \
+				if ((!_S && (_T != ROUNDSTART_TRAIT)) || (_T in _S)) { \
+					_L[trait] -= _T \
+				} \
+			};\
+			if (!length(_L[trait])) { \
+				_L -= trait \
+			}; \
+			if (!length(_L)) { \
+				target.status_traits = null \
+			}; \
+		} \
+	} while (0)
+#define REMOVE_TRAITS_NOT_IN(target, sources) \
+	do { \
+		var/list/_L = target.status_traits; \
+		var/list/_S = sources; \
+		if (_L) { \
+			for (var/_T in _L) { \
+				_L[_T] &= _S;\
+				if (!length(_L[_T])) { \
+					_L -= _T } \
+				};\
+				if (!length(_L)) { \
+					target.status_traits = null\
+				};\
+		}\
+	} while (0)
+#define HAS_TRAIT(target, trait) (target.status_traits ? (target.status_traits[trait] ? TRUE : FALSE) : FALSE)
+#define HAS_TRAIT_FROM(target, trait, source) (target.status_traits ? (target.status_traits[trait] ? (source in target.status_traits[trait]) : FALSE) : FALSE)
+
+

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -56,4 +56,5 @@
 #define HAS_TRAIT(target, trait) (target.status_traits ? (target.status_traits[trait] ? TRUE : FALSE) : FALSE)
 #define HAS_TRAIT_FROM(target, trait, source) (target.status_traits ? (target.status_traits[trait] ? (source in target.status_traits[trait]) : FALSE) : FALSE)
 
-
+// common trait sources
+#define ROUNDSTART_TRAIT "roundstart" //cannot be removed without admin intervention

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -63,6 +63,7 @@
 #include "code\__DEFINES\tgs.dm"
 #include "code\__DEFINES\time.dm"
 #include "code\__DEFINES\tools.dm"
+#include "code\__DEFINES\traits.dm"
 #include "code\__DEFINES\turf_flags.dm"
 #include "code\__DEFINES\typeids.dm"
 #include "code\__DEFINES\vv.dm"


### PR DESCRIPTION
## About The Pull Request
What's said on the tin. We already happen to have the status_traits list on datum.dm due to copy n paste.
Only adding the base stuff for now, so it's faster to merge.

## Why It's Good For The Game
This is a much more reliable general solution for storing, checking and manipulating quirks, statuses and the such while avoiding a handful of issues such as flags, which can't store store the status' sources, and snowflake, istype & co checks.

## ~~Changelog~~