### PR TITLE
Fixes xeno hud not showing synths and dead humans

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -204,8 +204,8 @@
 			infection_hud.icon_state = "infected[E.stage]"
 		else if(locate(/mob/living/carbon/xenomorph/larva) in src)
 			infection_hud.icon_state = "infected6"
-		else
-			infection_hud.icon_state = ""
+	else if(stat == DEAD)
+		infection_hud.icon_state = "huddead"
 	else
 		infection_hud.icon_state = ""
 

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -195,7 +195,7 @@
 
 	if(species.species_flags & IS_SYNTHETIC)
 		status_hud.icon_state = "hudsynth"
-		infection_hud.icon_state = ""
+		infection_hud.icon_state = "hudsynth"
 		return TRUE
 
 	if(status_flags & XENO_HOST)


### PR DESCRIPTION
## About The Pull Request

Per title.

## Changelog
:cl:
fix: Xeno hud now properly shows synths and dead humans.
/:cl:
