### PR TITLE
Remove failsafe for ssdir

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -70,9 +70,7 @@
 
 
 /mob/living/carbon/human/Destroy()
-	if(assigned_squad)
-		SSdirection.stop_tracking(assigned_squad.tracking_id, src) // failsafe to ensure they're definite not in the list
-	assigned_squad?.clean_marine_from_squad(src,FALSE)
+	assigned_squad?.clean_marine_from_squad(src, FALSE)
 	remove_from_all_mob_huds()
 	GLOB.human_mob_list -= src
 	GLOB.alive_human_list -= src


### PR DESCRIPTION
There shouldn't be failsafes just good code, especially when we are throwing stack_traces to catch these.