### PR TITLE
Map tags removal

### DIFF
--- a/_maps/WIP/Z.01.Desert-Dam.dmm
+++ b/_maps/WIP/Z.01.Desert-Dam.dmm
@@ -604,7 +604,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull (NORTHEAST)";
 	icon_state = "whitebluefull";
 	dir = 5
 	},
@@ -615,7 +614,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull (NORTHEAST)";
 	icon_state = "whitebluefull";
 	dir = 5
 	},
@@ -626,7 +624,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (EAST)";
 	icon_state = "whitegreen";
 	dir = 4
 	},
@@ -697,7 +694,6 @@
 	dir = 2
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull (NORTHEAST)";
 	icon_state = "whitebluefull";
 	dir = 5
 	},
@@ -1507,7 +1503,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/space)
@@ -1522,7 +1517,6 @@
 	layer = 2.4
 	},
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/space)
@@ -1532,7 +1526,6 @@
 	layer = 2.4
 	},
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/space)
@@ -1542,7 +1535,6 @@
 	on = 1
 	},
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/space)
@@ -1607,8 +1599,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
@@ -2049,7 +2040,6 @@
 /area/desert_dam/exterior/river/riverside_northeast)
 "ahq" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (NORTH)";
 	icon_state = "platform_deco";
 	dir = 1
 	},
@@ -2063,8 +2053,7 @@
 	},
 /turf/open/floor{
 	dir = 9;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTHEAST)"
+	icon_state = "whiteblue"
 	},
 /area/desert_dam/building/lab_northwest/cafeteria)
 "ahs" = (
@@ -2073,14 +2062,12 @@
 	pixel_y = 30
 	},
 /turf/open/floor{
-	tag = "icon-whiteblue (NORTH)";
 	icon_state = "whiteblue";
 	dir = 1
 	},
 /area/desert_dam/building/lab_northwest/cafeteria)
 "aht" = (
 /turf/open/floor{
-	tag = "icon-whiteblue (NORTH)";
 	icon_state = "whiteblue";
 	dir = 1
 	},
@@ -2096,7 +2083,6 @@
 "ahv" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-whiteblue (NORTH)";
 	icon_state = "whiteblue";
 	dir = 1
 	},
@@ -2106,7 +2092,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-whiteblue (NORTH)";
 	icon_state = "whiteblue";
 	dir = 1
 	},
@@ -2193,8 +2178,7 @@
 "ahN" = (
 /turf/open/floor{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/desert_dam/building/lab_northwest/cafeteria)
 "ahO" = (
@@ -2258,8 +2242,7 @@
 "ahW" = (
 /turf/open/floor{
 	dir = 2;
-	icon_state = "whitebluecorner";
-	tag = "icon-whiteblue (EAST)"
+	icon_state = "whitebluecorner"
 	},
 /area/desert_dam/building/lab_northwest/cafeteria)
 "ahX" = (
@@ -2275,7 +2258,6 @@
 /area/desert_dam/building/lab_northwest/kitchen)
 "ahY" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -2341,7 +2323,6 @@
 	dir = 2
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
@@ -2353,14 +2334,12 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
 "aij" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
@@ -2371,7 +2350,6 @@
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
@@ -2379,14 +2357,12 @@
 /obj/machinery/atmospherics/components/unary/portables_connector,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
 "aim" = (
 /obj/structure/filingcabinet/security,
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTH)";
 	icon_state = "darkred2";
 	dir = 1
 	},
@@ -2396,7 +2372,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTH)";
 	icon_state = "darkred2";
 	dir = 1
 	},
@@ -2404,7 +2379,6 @@
 "aio" = (
 /obj/structure/closet/secure_closet/security,
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTH)";
 	icon_state = "darkred2";
 	dir = 1
 	},
@@ -2454,7 +2428,6 @@
 /area/desert_dam/building/lab_northwest/cafeteria)
 "aiv" = (
 /turf/open/floor{
-	tag = "icon-whiteblue (EAST)";
 	icon_state = "whiteblue";
 	dir = 4
 	},
@@ -2571,8 +2544,7 @@
 /obj/item/stack/sheet/mineral/phoron,
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
 "aiM" = (
@@ -2582,24 +2554,21 @@
 	},
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
 "aiN" = (
 /obj/machinery/chem_dispenser,
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
 "aiO" = (
 /obj/machinery/smartfridge/chemistry,
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
 "aiP" = (
@@ -2607,8 +2576,7 @@
 /obj/structure/sink,
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
 "aiQ" = (
@@ -2616,8 +2584,7 @@
 /obj/item/storage/box/beakers,
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
 "aiR" = (
@@ -2628,27 +2595,23 @@
 	},
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
 "aiS" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	tag = "icon-intact (NORTHEAST)";
 	dir = 5
 	},
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
 "aiT" = (
 /obj/machinery/atmospherics/pipe/manifold,
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
 "aiU" = (
@@ -2661,13 +2624,11 @@
 /area/desert_dam/building/medical/lobby)
 "aiV" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	tag = "icon-intact (NORTHWEST)";
 	dir = 9
 	},
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
 "aiW" = (
@@ -2676,25 +2637,21 @@
 	},
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
 "aiX" = (
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
 "aiY" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
 /turf/open/floor{
-	tag = "icon-whiteblue (NORTH)";
 	icon_state = "whiteblue";
 	dir = 1
 	},
@@ -2702,22 +2659,19 @@
 "aiZ" = (
 /turf/open/floor{
 	dir = 5;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
 "aja" = (
 /obj/structure/table,
 /obj/machinery/computer/security,
 /turf/open/floor{
-	tag = "icon-darkred2 (WEST)";
 	icon_state = "darkred2";
 	dir = 8
 	},
 /area/desert_dam/building/lab_northwest/lobby)
 "ajb" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/lab_northwest/lobby)
@@ -2726,7 +2680,6 @@
 	name = "\improper Security Checkpoint"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/lab_northwest/west_wing_hallway)
@@ -2866,14 +2819,12 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/box/syringes,
 /turf/open/floor{
-	tag = "icon-darkpurple2 (WEST)";
 	icon_state = "darkpurple2";
 	dir = 8
 	},
 /area/desert_dam/interior/lab_northeast/biology)
 "ajw" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
@@ -2882,34 +2833,29 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
 "ajy" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
 "ajz" = (
 /turf/open/floor{
-	tag = "icon-darkpurplecorners2";
 	icon_state = "darkpurplecorners2";
 	dir = 2
 	},
 /area/desert_dam/interior/lab_northeast/biology)
 "ajA" = (
 /turf/open/floor{
-	tag = "icon-darkpurple2";
 	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
 "ajB" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
@@ -2935,7 +2881,6 @@
 /area/desert_dam/building/lab_northwest/kitchen)
 "ajE" = (
 /turf/open/floor{
-	tag = "icon-darkpurplecorners2 (WEST)";
 	icon_state = "darkpurplecorners2";
 	dir = 8
 	},
@@ -2943,14 +2888,12 @@
 "ajF" = (
 /obj/machinery/autodoc,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
 "ajG" = (
 /obj/machinery/autodoc_console,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
@@ -2961,13 +2904,11 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
 "ajI" = (
 /turf/open/floor{
-	tag = "icon-darkpurplecorners2 (EAST)";
 	icon_state = "darkpurplecorners2";
 	dir = 4
 	},
@@ -2977,14 +2918,12 @@
 /obj/machinery/recharger,
 /turf/open/floor{
 	dir = 5;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
 "ajK" = (
 /obj/structure/table,
 /turf/open/floor{
-	tag = "icon-darkred2 (SOUTHWEST)";
 	icon_state = "darkred2";
 	dir = 10
 	},
@@ -2992,13 +2931,11 @@
 "ajL" = (
 /obj/structure/bed/chair/office/dark,
 /turf/open/floor{
-	tag = "icon-darkred2";
 	icon_state = "darkred2"
 	},
 /area/desert_dam/building/lab_northwest/lobby)
 "ajM" = (
 /turf/open/floor{
-	tag = "icon-darkred2";
 	icon_state = "darkred2"
 	},
 /area/desert_dam/building/lab_northwest/lobby)
@@ -3014,37 +2951,32 @@
 "ajP" = (
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-whiteblue (SOUTHWEST)";
 	icon_state = "whiteblue";
 	dir = 10
 	},
 /area/desert_dam/building/lab_northwest/cafeteria)
 "ajQ" = (
 /turf/open/floor{
-	tag = "icon-whiteblue";
 	icon_state = "whiteblue"
 	},
 /area/desert_dam/building/lab_northwest/cafeteria)
 "ajR" = (
 /turf/open/floor{
 	dir = 8;
-	icon_state = "whitebluecorner";
-	tag = "icon-whiteblue (EAST)"
+	icon_state = "whitebluecorner"
 	},
 /area/desert_dam/building/lab_northwest/cafeteria)
 "ajS" = (
 /turf/open/floor{
 	dir = 2;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitebluecorner"
 	},
 /area/desert_dam/building/lab_northwest/cafeteria)
 "ajT" = (
 /obj/machinery/light,
 /turf/open/floor{
 	dir = 6;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+	icon_state = "whiteblue"
 	},
 /area/desert_dam/building/lab_northwest/cafeteria)
 "ajU" = (
@@ -3063,7 +2995,6 @@
 /area/desert_dam/building/lab_northwest/kitchen)
 "ajV" = (
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -3186,7 +3117,6 @@
 /area/desert_dam/interior/caves/northern_caves)
 "akp" = (
 /turf/open/floor{
-	tag = "icon-darkpurple2 (WEST)";
 	icon_state = "darkpurple2";
 	dir = 8
 	},
@@ -3194,15 +3124,13 @@
 "akq" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-darkpurple2";
 	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
 "akr" = (
 /turf/open/floor{
 	dir = 6;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
 "aks" = (
@@ -3214,8 +3142,7 @@
 "akt" = (
 /turf/open/floor{
 	dir = 10;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
 "aku" = (
@@ -3225,7 +3152,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor{
-	tag = "icon-darkpurple2";
 	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
@@ -3234,7 +3160,6 @@
 /obj/item/reagent_container/hypospray,
 /obj/item/reagent_container/spray/cleaner,
 /turf/open/floor{
-	tag = "icon-darkpurple2 (EAST)";
 	icon_state = "darkpurple2";
 	dir = 4
 	},
@@ -3345,8 +3270,7 @@
 /obj/machinery/power/apc/drained,
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
 "akJ" = (
@@ -3415,7 +3339,6 @@
 /area/desert_dam/interior/lab_northeast/containment)
 "akW" = (
 /turf/open/floor/plating{
-	tag = "icon-warnplate (EAST)";
 	icon_state = "warnplate";
 	dir = 4
 	},
@@ -3432,7 +3355,6 @@
 /obj/item/roller,
 /obj/item/roller,
 /turf/open/floor{
-	tag = "icon-darkpurple2 (WEST)";
 	icon_state = "darkpurple2";
 	dir = 8
 	},
@@ -3440,14 +3362,12 @@
 "akZ" = (
 /obj/machinery/sleeper,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
 "ala" = (
 /obj/machinery/sleep_console,
 /turf/open/floor{
-	tag = "icon-darkpurple2 (EAST)";
 	icon_state = "darkpurple2";
 	dir = 4
 	},
@@ -3536,7 +3456,6 @@
 /obj/item/defibrillator,
 /obj/item/defibrillator,
 /turf/open/floor{
-	tag = "icon-darkpurple2 (EAST)";
 	icon_state = "darkpurple2";
 	dir = 4
 	},
@@ -3546,7 +3465,6 @@
 /area/desert_dam/building/lab_northwest/lobby)
 "alj" = (
 /obj/structure/bed/chair{
-	tag = "icon-chair (EAST)";
 	icon_state = "chair";
 	dir = 4
 	},
@@ -3561,7 +3479,6 @@
 "alk" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /turf/open/floor,
@@ -3625,7 +3542,6 @@
 /area/desert_dam/building/lab_northwest/west_wing_hallway)
 "alt" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
@@ -3642,7 +3558,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (NORTH)";
 	icon_state = "pipe-c";
 	dir = 1
 	},
@@ -3680,7 +3595,6 @@
 /area/desert_dam/building/lab_northwest/dormitory)
 "aly" = (
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (NORTHWEST)";
 	icon_state = "carpetside";
 	dir = 9
 	},
@@ -3688,14 +3602,12 @@
 "alz" = (
 /obj/structure/bed/chair,
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (NORTH)";
 	icon_state = "carpetside";
 	dir = 1
 	},
 /area/desert_dam/building/lab_northwest/dormitory)
 "alA" = (
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (NORTHEAST)";
 	icon_state = "carpetside";
 	dir = 5
 	},
@@ -3772,14 +3684,12 @@
 /area/desert_dam/exterior/river/riverside_northeast)
 "alM" = (
 /turf/open/floor{
-	tag = "icon-darkpurple2 (EAST)";
 	icon_state = "darkpurple2";
 	dir = 4
 	},
 /area/desert_dam/interior/lab_northeast/biology)
 "alN" = (
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (NORTH)";
 	icon_state = "pipe-c";
 	dir = 1
 	},
@@ -3816,14 +3726,12 @@
 /obj/structure/table/reinforced,
 /obj/item/reagent_container/hypospray,
 /turf/open/floor{
-	tag = "icon-darkpurple2 (EAST)";
 	icon_state = "darkpurple2";
 	dir = 4
 	},
 /area/desert_dam/interior/lab_northeast/biology)
 "alR" = (
 /obj/structure/bed/chair{
-	tag = "icon-chair (EAST)";
 	icon_state = "chair";
 	dir = 4
 	},
@@ -3844,7 +3752,6 @@
 /area/desert_dam/building/lab_northwest/lobby)
 "alT" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -3854,7 +3761,6 @@
 /area/desert_dam/building/lab_northwest/lobby)
 "alU" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -3868,7 +3774,6 @@
 /area/desert_dam/building/lab_northwest/lobby)
 "alV" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -3882,7 +3787,6 @@
 /area/desert_dam/building/lab_northwest/lobby)
 "alW" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -3900,7 +3804,6 @@
 /area/desert_dam/building/lab_northwest/lobby)
 "alX" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -3912,14 +3815,12 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitepurplefull";
 	icon_state = "whitepurplefull";
 	dir = 2
 	},
 /area/desert_dam/building/lab_northwest/west_wing_hallway)
 "alY" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -3936,7 +3837,6 @@
 /area/desert_dam/building/lab_northwest/west_wing_hallway)
 "alZ" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -3957,7 +3857,6 @@
 	icon_state = "1-4"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -3971,7 +3870,6 @@
 /area/desert_dam/building/lab_northwest/west_wing_hallway)
 "amb" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -3986,7 +3884,6 @@
 /area/desert_dam/building/lab_northwest/west_wing_hallway)
 "amc" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -4009,7 +3906,6 @@
 	icon_state = "1-4"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -4031,7 +3927,6 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -4086,7 +3981,6 @@
 /area/desert_dam/building/lab_northwest/dormitory)
 "amj" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -4102,7 +3996,6 @@
 /area/desert_dam/building/lab_northwest/dormitory)
 "aml" = (
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (WEST)";
 	icon_state = "carpetside";
 	dir = 8
 	},
@@ -4116,7 +4009,6 @@
 	dir = 8
 	},
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (EAST)";
 	icon_state = "carpetside";
 	dir = 4
 	},
@@ -4157,7 +4049,6 @@
 /area/desert_dam/exterior/valley/valley_north_west)
 "amt" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -4178,20 +4069,17 @@
 /area/desert_dam/interior/lab_northeast/containment)
 "amx" = (
 /turf/open/floor/plating{
-	tag = "icon-warnplate (SOUTHWEST)";
 	icon_state = "warnplate";
 	dir = 10
 	},
 /area/desert_dam/interior/lab_northeast/containment)
 "amy" = (
 /turf/open/floor/plating{
-	tag = "icon-warnplate";
 	icon_state = "warnplate"
 	},
 /area/desert_dam/interior/lab_northeast/containment)
 "amz" = (
 /turf/open/floor/plating{
-	tag = "icon-warnplate (SOUTHEAST)";
 	icon_state = "warnplate";
 	dir = 6
 	},
@@ -4224,32 +4112,28 @@
 "amF" = (
 /turf/open/floor{
 	dir = 9;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
 "amG" = (
 /obj/machinery/light,
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
 "amH" = (
 /obj/machinery/bodyscanner,
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
 "amI" = (
 /obj/machinery/body_scanconsole,
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/biology)
 "amJ" = (
@@ -4273,7 +4157,6 @@
 	layer = 2.4
 	},
 /turf/open/floor{
-	tag = "icon-whitepurplefull";
 	icon_state = "whitepurplefull";
 	dir = 2
 	},
@@ -4376,7 +4259,6 @@
 /area/desert_dam/building/lab_northwest/dormitory)
 "amX" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -4416,12 +4298,10 @@
 /area/desert_dam/building/lab_northwest/dormitory)
 "anb" = (
 /obj/structure/bed/chair{
-	tag = "icon-chair (EAST)";
 	icon_state = "chair";
 	dir = 4
 	},
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (SOUTHWEST)";
 	icon_state = "carpetside";
 	dir = 10
 	},
@@ -4434,7 +4314,6 @@
 /area/desert_dam/building/lab_northwest/dormitory)
 "and" = (
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (SOUTHEAST)";
 	icon_state = "carpetside";
 	dir = 6
 	},
@@ -4460,7 +4339,6 @@
 /area/desert_dam/exterior/valley/valley_north_west)
 "anh" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (NORTH)";
 	icon_state = "platform_deco";
 	dir = 1
 	},
@@ -4486,8 +4364,7 @@
 "anl" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/floor/plating/ground/desertdam/desert{
 	icon_state = "desert10"
@@ -4504,7 +4381,6 @@
 /area/desert_dam/exterior/valley/valley_north_west)
 "ann" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/containment)
@@ -4513,7 +4389,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/containment)
@@ -4576,7 +4451,6 @@
 	name = "\improper Observation"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/surgury)
@@ -4724,7 +4598,6 @@
 /area/desert_dam/exterior/river/riverside_northeast)
 "anT" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (NORTH)";
 	icon_state = "platform_deco";
 	dir = 1
 	},
@@ -4823,14 +4696,12 @@
 	stored_metal = 1000
 	},
 /turf/open/floor{
-	tag = "icon-whitered (NORTHWEST)";
 	icon_state = "whitered";
 	dir = 9
 	},
 /area/desert_dam/interior/lab_northeast/surgury)
 "aoj" = (
 /turf/open/floor{
-	tag = "icon-whiteredcorner (NORTH)";
 	icon_state = "whiteredcorner";
 	dir = 1
 	},
@@ -4849,8 +4720,7 @@
 "aol" = (
 /turf/open/floor{
 	dir = 4;
-	icon_state = "whiteredcorner";
-	tag = "icon-whiteredcorner (NORTH)"
+	icon_state = "whiteredcorner"
 	},
 /area/desert_dam/interior/lab_northeast/surgury)
 "aom" = (
@@ -4860,14 +4730,12 @@
 	pixel_y = -5
 	},
 /turf/open/floor{
-	tag = "icon-whitered (NORTHEAST)";
 	icon_state = "whitered";
 	dir = 5
 	},
 /area/desert_dam/interior/lab_northeast/surgury)
 "aon" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/surgury)
@@ -5063,7 +4931,6 @@
 /area/desert_dam/interior/lab_northeast/east_hallway)
 "aoS" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
@@ -5105,7 +4972,6 @@
 /obj/item/tool/surgery/scalpel/manager,
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-whitered (EAST)";
 	icon_state = "whitered";
 	dir = 4
 	},
@@ -5115,7 +4981,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/surgury)
@@ -5157,14 +5022,12 @@
 "apd" = (
 /obj/machinery/recharge_station,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/lab_northwest/robotics_mechbay)
 "ape" = (
 /obj/machinery/mech_bay_recharge_port,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/lab_northwest/robotics_mechbay)
@@ -5174,7 +5037,6 @@
 "apg" = (
 /obj/machinery/computer/mech_bay_power_console,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/lab_northwest/robotics_mechbay)
@@ -5187,7 +5049,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitered (WEST)";
 	icon_state = "whitered";
 	dir = 8
 	},
@@ -5197,7 +5058,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/lab_northwest/robotics_mechbay)
@@ -5295,12 +5155,10 @@
 /area/desert_dam/building/lab_northwest/east_wing_hallway)
 "apu" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/lab_northwest/robotics_mechbay)
@@ -5406,8 +5264,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -5425,7 +5282,6 @@
 	pixel_y = 0
 	},
 /turf/open/floor{
-	tag = "icon-whitered (WEST)";
 	icon_state = "whitered";
 	dir = 8
 	},
@@ -5445,7 +5301,6 @@
 /obj/item/stack/nanopaste,
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-whitered (EAST)";
 	icon_state = "whitered";
 	dir = 4
 	},
@@ -5483,7 +5338,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/lab_northwest/robotics_mechbay)
@@ -5518,7 +5372,6 @@
 /area/desert_dam/building/lab_northwest/robotics_mechbay)
 "apT" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -5536,7 +5389,6 @@
 /area/desert_dam/building/lab_northwest/robotics_mechbay)
 "apU" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -5555,8 +5407,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /obj/structure/disposalpipe/segment{
@@ -5624,7 +5475,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (NORTH)";
 	icon_state = "pipe-c";
 	dir = 1
 	},
@@ -5634,7 +5484,6 @@
 /area/desert_dam/building/lab_northwest/west_wing_hallway)
 "aqb" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -5651,7 +5500,6 @@
 /area/desert_dam/building/lab_northwest/east_wing_hallway)
 "aqc" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -5674,7 +5522,6 @@
 /area/desert_dam/building/lab_northwest/east_wing_hallway)
 "aqd" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -5692,7 +5539,6 @@
 /area/desert_dam/building/lab_northwest/east_wing_hallway)
 "aqe" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -5708,7 +5554,6 @@
 /area/desert_dam/building/lab_northwest/east_wing_hallway)
 "aqf" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -5731,7 +5576,6 @@
 	icon_state = "1-4"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -5751,7 +5595,6 @@
 	icon_state = "1-4"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -5811,7 +5654,6 @@
 "aqm" = (
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/containment)
@@ -5825,8 +5667,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
@@ -5836,7 +5677,6 @@
 /area/desert_dam/interior/lab_northeast/east_hallway)
 "aqp" = (
 /turf/open/floor{
-	tag = "icon-whitered (WEST)";
 	icon_state = "whitered";
 	dir = 8
 	},
@@ -5857,7 +5697,6 @@
 	name = "Surgery Cleaner"
 	},
 /turf/open/floor{
-	tag = "icon-whitered (EAST)";
 	icon_state = "whitered";
 	dir = 4
 	},
@@ -5931,7 +5770,6 @@
 /area/desert_dam/building/lab_northwest/robotics_mechbay)
 "aqB" = (
 /turf/open/floor/plating{
-	tag = "icon-warnplate (NORTHEAST)";
 	icon_state = "warnplate";
 	dir = 5
 	},
@@ -5990,8 +5828,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
@@ -6042,26 +5879,22 @@
 /area/desert_dam/interior/lab_northeast/east_hallway)
 "aqN" = (
 /turf/open/floor{
-	tag = "icon-whitered (SOUTHWEST)";
 	icon_state = "whitered";
 	dir = 10
 	},
 /area/desert_dam/interior/lab_northeast/surgury)
 "aqO" = (
 /turf/open/floor{
-	tag = "icon-whitered";
 	icon_state = "whitered";
 	dir = 2
 	},
 /area/desert_dam/interior/lab_northeast/surgury)
 "aqP" = (
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (NORTH)";
 	icon_state = "pipe-c";
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-whitered";
 	icon_state = "whitered";
 	dir = 2
 	},
@@ -6072,7 +5905,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitered";
 	icon_state = "whitered";
 	dir = 2
 	},
@@ -6080,12 +5912,10 @@
 "aqR" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
-	tag = "icon-pipe-t (WEST)";
 	icon_state = "pipe-t";
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whitered (SOUTHEAST)";
 	icon_state = "whitered";
 	dir = 6
 	},
@@ -6116,7 +5946,6 @@
 /area/desert_dam/exterior/valley/valley_north_west)
 "aqW" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /obj/structure/desertdam/decals/road_stop{
@@ -6127,7 +5956,6 @@
 /area/desert_dam/exterior/valley/valley_north_west)
 "aqX" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /obj/structure/desertdam/decals/road_stop,
@@ -6135,7 +5963,6 @@
 /area/desert_dam/exterior/valley/valley_north_west)
 "aqY" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -6143,7 +5970,6 @@
 "aqZ" = (
 /obj/machinery/door/poddoor/shutters,
 /turf/open/floor/plating{
-	tag = "icon-warnplate (SOUTHWEST)";
 	icon_state = "warnplate";
 	dir = 10
 	},
@@ -6159,7 +5985,6 @@
 /area/desert_dam/building/lab_northwest/robotics_mechbay)
 "arc" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/lab_northwest/robotics_mechbay)
@@ -6265,8 +6090,7 @@
 /obj/effect/spawner/random/technology_scanner,
 /turf/open/floor{
 	dir = 9;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/xenobiology)
 "aru" = (
@@ -6276,22 +6100,19 @@
 	},
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/xenobiology)
 "arv" = (
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/xenobiology)
 "arw" = (
 /turf/open/floor{
 	dir = 5;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/xenobiology)
 "arx" = (
@@ -6316,7 +6137,6 @@
 /area/desert_dam/exterior/valley/valley_north_west)
 "arB" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /obj/structure/desertdam/decals/road_stop{
@@ -6327,7 +6147,6 @@
 /area/desert_dam/exterior/valley/valley_north_west)
 "arC" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /obj/structure/desertdam/decals/road_stop{
@@ -6338,7 +6157,6 @@
 /area/desert_dam/exterior/valley/valley_north_west)
 "arD" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -6348,7 +6166,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/lab_northwest/robotics_mechbay)
@@ -6411,14 +6228,12 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/window{
 	dir = 1;
-	icon_state = "left";
-	tag = "icon-left"
+	icon_state = "left"
 	},
 /obj/machinery/door/poddoor/shutters{
 	dir = 2;
 	icon_state = "shutter1";
-	id = "chem_lock";
-	tag = "icon-shutter1"
+	id = "chem_lock"
 	},
 /obj/machinery/door/window/brigdoor/northleft{
 	dir = 2
@@ -6489,7 +6304,6 @@
 /area/desert_dam/exterior/valley/valley_north_west)
 "asa" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (NORTH)";
 	icon_state = "platform_deco";
 	dir = 1
 	},
@@ -6551,16 +6365,14 @@
 "asl" = (
 /turf/open/floor{
 	dir = 9;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/xenobiology)
 "asm" = (
 /obj/machinery/chem_master,
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/xenobiology)
 "asn" = (
@@ -6570,8 +6382,7 @@
 	},
 /turf/open/floor{
 	dir = 5;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/xenobiology)
 "aso" = (
@@ -6579,8 +6390,7 @@
 /obj/structure/xenoautopsy,
 /turf/open/floor{
 	dir = 5;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/xenobiology)
 "asp" = (
@@ -6588,7 +6398,6 @@
 /obj/item/tool/pen,
 /obj/item/reagent_container/glass/beaker/vial,
 /turf/open/floor{
-	tag = "icon-darkpurple2 (WEST)";
 	icon_state = "darkpurple2";
 	dir = 8
 	},
@@ -6598,28 +6407,24 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-darkpurplecorners2";
 	icon_state = "darkpurplecorners2";
 	dir = 2
 	},
 /area/desert_dam/interior/lab_northeast/xenobiology)
 "asr" = (
 /turf/open/floor{
-	tag = "icon-darkpurple2";
 	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/xenobiology)
 "ass" = (
 /obj/machinery/recharge_station,
 /turf/open/floor{
-	tag = "icon-darkpurple2 (NORTHWEST)";
 	icon_state = "darkpurple2";
 	dir = 9
 	},
 /area/desert_dam/interior/lab_northeast/excavation)
 "ast" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
@@ -6634,16 +6439,14 @@
 	},
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/excavation)
 "asv" = (
 /obj/structure/closet/radiation,
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/excavation)
 "asw" = (
@@ -6651,8 +6454,7 @@
 /obj/item/clothing/gloves/yellow,
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/excavation)
 "asx" = (
@@ -6660,16 +6462,14 @@
 /obj/item/reagent_scanner,
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/excavation)
 "asy" = (
 /obj/structure/table,
 /turf/open/floor{
 	dir = 5;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/excavation)
 "asz" = (
@@ -6745,26 +6545,22 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/lab_northwest/robotics)
 "asJ" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/excavation)
 "asK" = (
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/lab_northwest/robotics)
@@ -6772,21 +6568,18 @@
 /obj/structure/table/reinforced,
 /obj/item/book/manual/robotics_cyborgs,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/lab_northwest/robotics)
 "asM" = (
 /obj/machinery/computer/robotics,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/lab_northwest/robotics)
 "asN" = (
 /obj/machinery/computer/rdconsole/robotics,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/lab_northwest/robotics)
@@ -6795,14 +6588,12 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/lab_northwest/robotics)
 "asP" = (
 /obj/machinery/vending/robotics,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/lab_northwest/robotics)
@@ -6812,14 +6603,12 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/lab_northwest/robotics)
 "asR" = (
 /obj/machinery/optable,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/lab_northwest/robotics)
@@ -6827,7 +6616,6 @@
 /obj/structure/table/reinforced,
 /obj/item/organ/eyes/prosthetic,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/lab_northwest/robotics)
@@ -6841,12 +6629,10 @@
 /area/desert_dam/building/lab_northwest/maintenance)
 "asU" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/lab_northwest/robotics)
@@ -6866,14 +6652,12 @@
 "asY" = (
 /obj/machinery/chem_dispenser,
 /turf/open/floor{
-	tag = "icon-whiteyellow (NORTHWEST)";
 	icon_state = "whiteyellow";
 	dir = 9
 	},
 /area/desert_dam/building/lab_northwest/chemistry)
 "asZ" = (
 /turf/open/floor{
-	tag = "icon-whiteyellow (NORTH)";
 	icon_state = "whiteyellow";
 	dir = 1
 	},
@@ -6881,7 +6665,6 @@
 "ata" = (
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-whiteyellow (NORTH)";
 	icon_state = "whiteyellow";
 	dir = 1
 	},
@@ -6891,19 +6674,16 @@
 /obj/item/tool/stamp,
 /obj/item/paper_bin,
 /turf/open/floor{
-	tag = "icon-whiteyellow (NORTH)";
 	icon_state = "whiteyellow";
 	dir = 1
 	},
 /area/desert_dam/building/lab_northwest/chemistry)
 "atc" = (
 /obj/structure/bed/chair/office/dark{
-	tag = "icon-officechair_dark (NORTH)";
 	icon_state = "officechair_dark";
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-whiteyellow (NORTH)";
 	icon_state = "whiteyellow";
 	dir = 1
 	},
@@ -6913,7 +6693,6 @@
 /obj/item/packageWrap,
 /obj/item/tool/hand_labeler,
 /turf/open/floor{
-	tag = "icon-whiteyellow (NORTH)";
 	icon_state = "whiteyellow";
 	dir = 1
 	},
@@ -6921,7 +6700,6 @@
 "ate" = (
 /obj/machinery/vending/medical,
 /turf/open/floor{
-	tag = "icon-whiteyellow (NORTH)";
 	icon_state = "whiteyellow";
 	dir = 1
 	},
@@ -6929,7 +6707,6 @@
 "atf" = (
 /obj/structure/closet/secure_closet/chemical,
 /turf/open/floor{
-	tag = "icon-whiteyellow (NORTH)";
 	icon_state = "whiteyellow";
 	dir = 1
 	},
@@ -6937,7 +6714,6 @@
 "atg" = (
 /obj/structure/closet/secure_closet/chemical,
 /turf/open/floor{
-	tag = "icon-whiteyellow (NORTHEAST)";
 	icon_state = "whiteyellow";
 	dir = 5
 	},
@@ -7039,8 +6815,7 @@
 "atw" = (
 /turf/open/floor{
 	dir = 6;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/xenobiology)
 "atx" = (
@@ -7048,7 +6823,6 @@
 	dir = 4
 	},
 /turf/open/floor/plating{
-	tag = "icon-warnplate (EAST)";
 	icon_state = "warnplate";
 	dir = 4
 	},
@@ -7056,8 +6830,7 @@
 "aty" = (
 /turf/open/floor{
 	dir = 10;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/xenobiology)
 "atz" = (
@@ -7065,7 +6838,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-darkpurplecorners2 (WEST)";
 	icon_state = "darkpurplecorners2";
 	dir = 8
 	},
@@ -7073,7 +6845,6 @@
 "atA" = (
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-darkpurple2 (EAST)";
 	icon_state = "darkpurple2";
 	dir = 4
 	},
@@ -7091,8 +6862,7 @@
 "atC" = (
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2 (EAST)"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/excavation)
 "atD" = (
@@ -7114,7 +6884,6 @@
 /area/desert_dam/interior/lab_northeast/excavation)
 "atF" = (
 /turf/open/floor{
-	tag = "icon-darkpurplecorners2 (EAST)";
 	icon_state = "darkpurplecorners2";
 	dir = 4
 	},
@@ -7122,24 +6891,21 @@
 "atG" = (
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/excavation)
 "atH" = (
 /obj/structure/closet/crate,
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/excavation)
 "atI" = (
 /obj/structure/closet/crate,
 /turf/open/floor{
 	dir = 5;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/excavation)
 "atJ" = (
@@ -7169,8 +6935,7 @@
 "atN" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
-	pixel_x = 0;
-	tag = "icon-E-corner"
+	pixel_x = 0
 	},
 /obj/structure/desertdam/decals/road_stop{
 	dir = 1;
@@ -7184,7 +6949,6 @@
 	icon_state = "stop_decal5"
 	},
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -7237,7 +7001,6 @@
 /area/desert_dam/building/lab_northwest/robotics_mechbay)
 "atT" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -7246,7 +7009,6 @@
 	layer = 2.4
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -7260,7 +7022,6 @@
 	name = "\improper Robotics"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -7269,7 +7030,6 @@
 	layer = 2.4
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -7279,7 +7039,6 @@
 /area/desert_dam/building/lab_northwest/robotics)
 "atV" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -7300,8 +7059,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4;
@@ -7342,7 +7100,6 @@
 /obj/structure/table/reinforced,
 /obj/item/organ/lungs/prosthetic,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/lab_northwest/robotics)
@@ -7358,7 +7115,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whiteyellow (WEST)";
 	icon_state = "whiteyellow";
 	dir = 8
 	},
@@ -7371,7 +7127,6 @@
 /area/desert_dam/building/lab_northwest/chemistry)
 "aue" = (
 /turf/open/floor{
-	tag = "icon-whiteyellowcorner (EAST)";
 	icon_state = "whiteyellowcorner";
 	dir = 4
 	},
@@ -7392,7 +7147,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (NORTH)";
 	icon_state = "pipe-c";
 	dir = 1
 	},
@@ -7411,12 +7165,10 @@
 /area/desert_dam/building/lab_northwest/east_wing_hallway)
 "aui" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
 /turf/open/floor{
-	tag = "icon-whiteyellow (NORTH)";
 	icon_state = "whiteyellow";
 	dir = 1
 	},
@@ -7463,7 +7215,6 @@
 /area/desert_dam/interior/lab_northeast/containment)
 "auq" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (NORTH)";
 	icon_state = "platform_deco";
 	dir = 1
 	},
@@ -7484,21 +7235,18 @@
 /obj/structure/table/reinforced,
 /obj/item/paper,
 /turf/open/floor{
-	tag = "icon-darkpurple2 (WEST)";
 	icon_state = "darkpurple2";
 	dir = 8
 	},
 /area/desert_dam/interior/lab_northeast/xenobiology)
 "auu" = (
 /turf/open/floor{
-	tag = "icon-darkpurple2 (EAST)";
 	icon_state = "darkpurple2";
 	dir = 4
 	},
 /area/desert_dam/interior/lab_northeast/xenobiology)
 "auv" = (
 /turf/open/floor{
-	tag = "icon-darkpurple2 (WEST)";
 	icon_state = "darkpurple2";
 	dir = 8
 	},
@@ -7507,21 +7255,18 @@
 /obj/structure/closet/secure_closet/scientist,
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	tag = "icon-tube1 (EAST)"
+	icon_state = "tube1"
 	},
 /turf/open/floor{
 	dir = 9;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/xenobiology)
 "aux" = (
 /obj/structure/closet/secure_closet/scientist,
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/xenobiology)
 "auy" = (
@@ -7529,7 +7274,6 @@
 /obj/item/multitool,
 /obj/item/storage/belt/utility/full,
 /turf/open/floor{
-	tag = "icon-darkpurple2";
 	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/excavation)
@@ -7538,7 +7282,6 @@
 /obj/item/flashlight,
 /obj/item/t_scanner,
 /turf/open/floor{
-	tag = "icon-darkpurple2 (EAST)";
 	icon_state = "darkpurple2";
 	dir = 4
 	},
@@ -7602,7 +7345,6 @@
 /obj/structure/table/reinforced,
 /obj/item/organ/liver/prosthetic,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/lab_northwest/robotics)
@@ -7616,7 +7358,6 @@
 /area/desert_dam/building/lab_northwest/chemistry)
 "auK" = (
 /turf/open/floor{
-	tag = "icon-whiteyellow (WEST)";
 	icon_state = "whiteyellow";
 	dir = 8
 	},
@@ -7652,14 +7393,12 @@
 	layer = 2.4
 	},
 /turf/open/floor{
-	tag = "icon-whiteyellow (WEST)";
 	icon_state = "whiteyellow";
 	dir = 8
 	},
 /area/desert_dam/building/lab_northwest/chemistry)
 "auO" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -7673,7 +7412,6 @@
 /area/desert_dam/building/lab_northwest/chemistry)
 "auP" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -7717,7 +7455,6 @@
 /area/desert_dam/building/lab_northwest/east_wing_hallway)
 "auR" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -7726,7 +7463,6 @@
 	layer = 2.4
 	},
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j1 (WEST)";
 	icon_state = "pipe-j1";
 	dir = 8
 	},
@@ -7736,7 +7472,6 @@
 /area/desert_dam/building/lab_northwest/east_wing_hallway)
 "auS" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -7755,8 +7490,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4;
@@ -7848,7 +7582,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/containment)
@@ -7859,14 +7592,12 @@
 	},
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/xenobiology)
 "ave" = (
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-darkpurplecorners2 (NORTH)";
 	icon_state = "darkpurplecorners2";
 	dir = 1
 	},
@@ -7876,7 +7607,6 @@
 /obj/item/flashlight,
 /obj/item/tool/hand_labeler,
 /turf/open/floor{
-	tag = "icon-darkpurple2 (EAST)";
 	icon_state = "darkpurple2";
 	dir = 4
 	},
@@ -7894,8 +7624,7 @@
 "avi" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/ground/desertdam/river/toxic/shallow_water_desert_coast_toxic{
 	icon_state = "shallow_water_desert_coast_toxic6"
@@ -7911,7 +7640,6 @@
 /area/desert_dam/exterior/river/riverside_northwest)
 "avk" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -7922,8 +7650,7 @@
 "avl" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/floor/plating/ground/desertdam/desert,
 /area/desert_dam/exterior/river/riverside_northwest)
@@ -7952,7 +7679,6 @@
 "avp" = (
 /obj/machinery/conveyor_switch,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/lab_northwest/robotics)
@@ -7965,7 +7691,6 @@
 /area/desert_dam/building/lab_northwest/robotics)
 "avr" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/lab_northwest/robotics)
@@ -7993,7 +7718,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whiteyellow (WEST)";
 	icon_state = "whiteyellow";
 	dir = 8
 	},
@@ -8069,7 +7793,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/containment)
@@ -8090,7 +7813,6 @@
 /obj/structure/table/reinforced,
 /obj/item/alienjar,
 /turf/open/floor{
-	tag = "icon-darkpurple2 (EAST)";
 	icon_state = "darkpurple2";
 	dir = 4
 	},
@@ -8105,33 +7827,28 @@
 /obj/item/tool/shovel/snow,
 /obj/effect/landmark/random_item/crap,
 /turf/open/floor{
-	tag = "icon-darkpurple2";
 	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/excavation)
 "avK" = (
 /turf/open/floor{
-	tag = "icon-darkpurplecorners2";
 	icon_state = "darkpurplecorners2";
 	dir = 2
 	},
 /area/desert_dam/interior/lab_northeast/excavation)
 "avL" = (
 /turf/open/floor{
-	tag = "icon-darkpurple2";
 	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/excavation)
 "avM" = (
 /obj/structure/largecrate/random,
 /turf/open/floor{
-	tag = "icon-darkpurple2";
 	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/excavation)
 "avN" = (
 /turf/open/floor{
-	tag = "icon-darkpurplecorners2 (WEST)";
 	icon_state = "darkpurplecorners2";
 	dir = 8
 	},
@@ -8172,7 +7889,6 @@
 /area/desert_dam/exterior/river/riverside_northwest)
 "avV" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -8183,13 +7899,11 @@
 "avW" = (
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/lab_northwest/robotics_mechbay)
 "avX" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /obj/machinery/conveyor{
@@ -8197,7 +7911,6 @@
 	id = "cargo_container"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/lab_northwest/robotics_mechbay)
@@ -8207,15 +7920,12 @@
 	id = "cargo_container"
 	},
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/lab_northwest/robotics_mechbay)
@@ -8225,16 +7935,13 @@
 	id = "cargo_container"
 	},
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/lab_northwest/robotics_mechbay)
@@ -8244,11 +7951,9 @@
 	id = "cargo_container"
 	},
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /obj/structure/plasticflaps,
@@ -8261,7 +7966,6 @@
 	},
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/lab_northwest/robotics)
@@ -8271,14 +7975,12 @@
 	id = "cargo_container"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/lab_northwest/robotics)
 "awd" = (
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/lab_northwest/robotics)
@@ -8309,7 +8011,6 @@
 	pixel_y = -10
 	},
 /turf/open/floor{
-	tag = "icon-whiteyellow";
 	icon_state = "whiteyellow";
 	dir = 2
 	},
@@ -8322,7 +8023,6 @@
 /obj/item/stack/sheet/mineral/phoron,
 /obj/item/stack/sheet/mineral/phoron,
 /turf/open/floor{
-	tag = "icon-whiteyellow";
 	icon_state = "whiteyellow";
 	dir = 2
 	},
@@ -8331,14 +8031,12 @@
 /obj/structure/table/reinforced,
 /obj/item/reagent_container/glass/beaker/bluespace,
 /turf/open/floor{
-	tag = "icon-whiteyellow";
 	icon_state = "whiteyellow";
 	dir = 2
 	},
 /area/desert_dam/building/lab_northwest/chemistry)
 "awk" = (
 /turf/open/floor{
-	tag = "icon-whiteyellow";
 	icon_state = "whiteyellow";
 	dir = 2
 	},
@@ -8349,7 +8047,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-whiteyellow";
 	icon_state = "whiteyellow";
 	dir = 2
 	},
@@ -8357,7 +8054,6 @@
 "awm" = (
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-whiteyellow";
 	icon_state = "whiteyellow";
 	dir = 2
 	},
@@ -8407,7 +8103,6 @@
 /area/desert_dam/exterior/valley/valley_north_west)
 "aws" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
@@ -8451,7 +8146,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-darkpurple2 (EAST)";
 	icon_state = "darkpurple2";
 	dir = 4
 	},
@@ -8535,8 +8229,7 @@
 "awK" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/ground/desertdam/river/toxic/shallow_water_desert_coast_toxic{
 	icon_state = "shallow_water_desert_coast_toxic2"
@@ -8591,7 +8284,6 @@
 	name = "\improper Xenoflora"
 	},
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
@@ -8625,7 +8317,6 @@
 "awV" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-darkpurplecorners2 (EAST)";
 	icon_state = "darkpurplecorners2";
 	dir = 4
 	},
@@ -8638,7 +8329,6 @@
 	},
 /obj/machinery/power/apc/drained,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/containment)
@@ -8651,8 +8341,7 @@
 /obj/machinery/power/apc/drained,
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/xenobiology)
 "awY" = (
@@ -8813,8 +8502,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/open/floor{
 	dir = 5;
@@ -8850,14 +8538,12 @@
 	},
 /turf/open/floor{
 	dir = 5;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/xenobiology)
 "axx" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-darkpurple2";
 	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/xenobiology)
@@ -8868,25 +8554,21 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor{
-	tag = "icon-darkpurple2";
 	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/xenobiology)
 "axz" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	tag = "icon-tube1 (EAST)"
+	icon_state = "tube1"
 	},
 /turf/open/floor{
 	dir = 10;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/xenobiology)
 "axA" = (
 /turf/open/floor{
-	tag = "icon-darkpurplecorners2 (WEST)";
 	icon_state = "darkpurplecorners2";
 	dir = 8
 	},
@@ -8894,20 +8576,17 @@
 "axB" = (
 /obj/structure/xenoautopsy/tank,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/xenobiology)
 "axC" = (
 /obj/structure/xenoautopsy/tank/hugger,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/xenobiology)
 "axD" = (
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (NORTH)";
 	icon_state = "pipe-c";
 	dir = 1
 	},
@@ -8948,8 +8627,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -9038,8 +8716,7 @@
 "axQ" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/ground/desertdam/river/toxic/shallow_edge_toxic{
 	icon_state = "shallow_to_deep_toxic_water5"
@@ -9081,7 +8758,6 @@
 /area/desert_dam/exterior/river/riverside_northeast)
 "axW" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -9176,7 +8852,6 @@
 /area/desert_dam/exterior/valley/valley_north_west)
 "ayg" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -9192,8 +8867,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -9207,7 +8881,6 @@
 "ayi" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating{
-	tag = "icon-platingdmg3 (WEST)";
 	icon_state = "platingdmg3";
 	dir = 8
 	},
@@ -9230,21 +8903,18 @@
 /area/desert_dam/exterior/river/riverside_northeast)
 "ayl" = (
 /obj/structure/cargo_container{
-	tag = "icon-green 0,0";
 	icon_state = "green 0,0"
 	},
 /turf/open/floor,
 /area/desert_dam/exterior/valley/valley_north_west)
 "aym" = (
 /obj/structure/cargo_container{
-	tag = "icon-green 1,0";
 	icon_state = "green 1,0"
 	},
 /turf/open/floor,
 /area/desert_dam/exterior/valley/valley_north_west)
 "ayn" = (
 /obj/structure/cargo_container{
-	tag = "icon-green 2,0";
 	icon_state = "green 2,0"
 	},
 /turf/open/floor,
@@ -9332,8 +9002,7 @@
 "ayA" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/ground/desertdam/river/toxic/shallow_water_toxic,
 /area/desert_dam/exterior/river/riverside_northwest)
@@ -9358,21 +9027,18 @@
 /area/desert_dam/exterior/river/riverside_northwest)
 "ayD" = (
 /obj/structure/cargo_container{
-	tag = "icon-blue 0,0";
 	icon_state = "blue 0,0"
 	},
 /turf/open/floor,
 /area/desert_dam/exterior/valley/valley_north_west)
 "ayE" = (
 /obj/structure/cargo_container{
-	tag = "icon-blue 1,0";
 	icon_state = "blue 1,0"
 	},
 /turf/open/floor,
 /area/desert_dam/exterior/valley/valley_north_west)
 "ayF" = (
 /obj/structure/cargo_container{
-	tag = "icon-blue 2,0";
 	icon_state = "blue 2,0"
 	},
 /turf/open/floor,
@@ -9450,7 +9116,6 @@
 /area/desert_dam/interior/lab_northeast/xenobiology)
 "ayO" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/xenobiology)
@@ -9580,7 +9245,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTHWEST)";
 	icon_state = "darkyellow2";
 	dir = 9
 	},
@@ -9589,7 +9253,6 @@
 /obj/structure/table,
 /obj/effect/spawner/random/tech_supply,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -9597,7 +9260,6 @@
 "azi" = (
 /obj/machinery/vending/engineering,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -9605,7 +9267,6 @@
 "azj" = (
 /obj/machinery/vending/engivend,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -9613,7 +9274,6 @@
 "azk" = (
 /obj/machinery/recharge_station,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -9624,7 +9284,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -9632,7 +9291,6 @@
 "azm" = (
 /obj/structure/rack,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -9640,7 +9298,6 @@
 "azn" = (
 /obj/structure/sink,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -9660,7 +9317,6 @@
 "azp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -9669,7 +9325,6 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTHEAST)";
 	icon_state = "darkyellow2";
 	dir = 5
 	},
@@ -9857,7 +9512,6 @@
 /obj/machinery/computer/guestpass,
 /obj/machinery/computer/security,
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTHWEST)";
 	icon_state = "darkred2";
 	dir = 9
 	},
@@ -9865,14 +9519,12 @@
 "azE" = (
 /obj/machinery/computer/prisoner,
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTH)";
 	icon_state = "darkred2";
 	dir = 1
 	},
 /area/desert_dam/interior/lab_northeast/security_office)
 "azF" = (
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTH)";
 	icon_state = "darkred2";
 	dir = 1
 	},
@@ -9880,7 +9532,6 @@
 "azG" = (
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTH)";
 	icon_state = "darkred2";
 	dir = 1
 	},
@@ -9888,14 +9539,12 @@
 "azH" = (
 /obj/machinery/vending/snack,
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTH)";
 	icon_state = "darkred2";
 	dir = 1
 	},
 /area/desert_dam/interior/lab_northeast/security_office)
 "azI" = (
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTH)";
 	icon_state = "darkred2";
 	dir = 1
 	},
@@ -9909,14 +9558,12 @@
 	},
 /obj/machinery/power/apc,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
 /area/desert_dam/interior/lab_northeast/workshop)
 "azK" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/east_entrance)
@@ -9925,7 +9572,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTH)";
 	icon_state = "darkred2";
 	dir = 1
 	},
@@ -9934,7 +9580,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security,
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTHEAST)";
 	icon_state = "darkred2";
 	dir = 5
 	},
@@ -9996,7 +9641,6 @@
 /area/desert_dam/exterior/river/riverside_northwest)
 "azX" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -10005,8 +9649,7 @@
 "azY" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/floor/plating/ground/desertdam/desert{
 	icon_state = "desert16"
@@ -10022,7 +9665,6 @@
 /area/desert_dam/exterior/river/riverside_northwest)
 "aAa" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -10041,8 +9683,7 @@
 "aAd" = (
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/west_entrance)
 "aAe" = (
@@ -10068,7 +9709,6 @@
 /area/desert_dam/interior/lab_northeast/west_hallway)
 "aAh" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
 	icon_state = "tube1";
 	dir = 4
 	},
@@ -10089,7 +9729,6 @@
 /obj/structure/table,
 /obj/item/tool/surgery/retractor,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (WEST)";
 	icon_state = "darkyellow2";
 	dir = 8
 	},
@@ -10116,8 +9755,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
 	dir = 4;
-	icon_state = "darkyellowcorners2";
-	tag = "icon-darkyellowcorners2 (NORTH)"
+	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/lab_northeast/workshop)
 "aAn" = (
@@ -10134,7 +9772,6 @@
 /area/desert_dam/interior/lab_northeast/central_hallway)
 "aAo" = (
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (NORTH)";
 	icon_state = "pipe-c";
 	dir = 1
 	},
@@ -10154,7 +9791,6 @@
 "aAq" = (
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-darkpurple2";
 	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/xenobiology)
@@ -10162,14 +9798,12 @@
 /obj/structure/table/reinforced,
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-darkpurple2";
 	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/xenobiology)
 "aAs" = (
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-darkpurple2";
 	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/xenobiology)
@@ -10183,13 +9817,11 @@
 /area/desert_dam/interior/lab_northeast/security_armory)
 "aAu" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/security_armory)
 "aAv" = (
 /turf/open/floor{
-	tag = "icon-darkredcorners2 (NORTH)";
 	icon_state = "darkredcorners2";
 	dir = 1
 	},
@@ -10256,7 +9888,6 @@
 	pixel_x = 0
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/east_entrance)
@@ -10264,18 +9895,15 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/east_entrance)
 "aAD" = (
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-darkred2 (EAST)";
 	icon_state = "darkred2";
 	dir = 4
 	},
@@ -10315,8 +9943,7 @@
 "aAK" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/ground/desertdam/river/toxic/shallow_water_toxic,
 /area/desert_dam/exterior/river/riverside_northeast)
@@ -10374,14 +10001,12 @@
 /area/desert_dam/interior/lab_northeast/west_hallway)
 "aAS" = (
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2 (NORTH)";
 	icon_state = "darkyellowcorners2";
 	dir = 1
 	},
 /area/desert_dam/interior/lab_northeast/workshop)
 "aAT" = (
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (NORTH)";
 	icon_state = "pipe-c";
 	dir = 1
 	},
@@ -10426,8 +10051,7 @@
 	},
 /turf/open/floor{
 	dir = 6;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/xenobiology)
 "aAY" = (
@@ -10437,8 +10061,7 @@
 	},
 /turf/open/floor{
 	dir = 9;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/xenobiology)
 "aAZ" = (
@@ -10494,21 +10117,18 @@
 /area/desert_dam/interior/lab_northeast/security_armory)
 "aBg" = (
 /turf/open/floor{
-	tag = "icon-darkred2 (SOUTHWEST)";
 	icon_state = "darkred2";
 	dir = 10
 	},
 /area/desert_dam/interior/lab_northeast/east_entrance)
 "aBh" = (
 /turf/open/floor{
-	tag = "icon-darkred2";
 	icon_state = "darkred2"
 	},
 /area/desert_dam/interior/lab_northeast/east_entrance)
 "aBi" = (
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-darkred2 (SOUTHEAST)";
 	icon_state = "darkred2";
 	dir = 6
 	},
@@ -10564,8 +10184,7 @@
 "aBr" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/floor/plating/ground/desertdam/desert{
 	icon_state = "desert7"
@@ -10582,7 +10201,6 @@
 /area/desert_dam/exterior/valley/valley_north_west)
 "aBt" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
 	icon_state = "tube1";
 	dir = 4
 	},
@@ -10633,7 +10251,6 @@
 /area/desert_dam/interior/lab_northeast/xenobiology)
 "aBA" = (
 /turf/open/floor{
-	tag = "icon-darkredcorners2";
 	icon_state = "darkredcorners2"
 	},
 /area/desert_dam/interior/lab_northeast/security_office)
@@ -10721,7 +10338,6 @@
 /area/desert_dam/exterior/valley/valley_north_west)
 "aBP" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (NORTH)";
 	icon_state = "platform_deco";
 	dir = 1
 	},
@@ -10746,8 +10362,7 @@
 /obj/machinery/door/poddoor/four_tile_ver,
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/west_entrance)
 "aBT" = (
@@ -10772,7 +10387,6 @@
 /area/desert_dam/interior/lab_northeast/storage)
 "aBW" = (
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2";
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/lab_northeast/workshop)
@@ -10780,28 +10394,24 @@
 /obj/machinery/field/generator,
 /turf/open/floor{
 	dir = 9;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/storage)
 "aBY" = (
 /obj/machinery/field/generator,
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/storage)
 "aBZ" = (
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/storage)
 "aCa" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/storage)
@@ -10815,28 +10425,24 @@
 /obj/structure/closet/radiation,
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/storage)
 "aCd" = (
 /obj/structure/closet/radiation,
 /turf/open/floor{
 	dir = 5;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/storage)
 "aCe" = (
 /turf/open/floor{
-	tag = "icon-darkredcorners2 (WEST)";
 	icon_state = "darkredcorners2";
 	dir = 8
 	},
 /area/desert_dam/interior/lab_northeast/security_office)
 "aCf" = (
 /turf/open/floor{
-	tag = "icon-darkred2 (EAST)";
 	icon_state = "darkred2";
 	dir = 4
 	},
@@ -10883,14 +10489,12 @@
 "aCl" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
-	pixel_x = 0;
-	tag = "icon-E-corner"
+	pixel_x = 0
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
 /area/desert_dam/exterior/valley/valley_north_west)
 "aCm" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -10934,7 +10538,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/west_entrance)
@@ -10953,7 +10556,6 @@
 /area/desert_dam/interior/lab_northeast/west_hallway)
 "aCv" = (
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2 (WEST)";
 	icon_state = "darkyellowcorners2";
 	dir = 8
 	},
@@ -10962,7 +10564,6 @@
 /obj/structure/table,
 /obj/effect/spawner/random/tool,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (SOUTHEAST)";
 	icon_state = "darkyellow2";
 	dir = 6
 	},
@@ -10971,13 +10572,11 @@
 /obj/machinery/field/generator,
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2 (EAST)"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/storage)
 "aCy" = (
 /turf/open/floor{
-	tag = "icon-darkpurple2 (EAST)";
 	icon_state = "darkpurple2";
 	dir = 4
 	},
@@ -11001,19 +10600,16 @@
 /area/desert_dam/interior/lab_northeast/xenobiology)
 "aCC" = (
 /turf/open/floor/plating{
-	tag = "icon-warnplate (EAST)";
 	icon_state = "warnplate";
 	dir = 4
 	},
 /area/desert_dam/interior/lab_northeast/xenobiology)
 "aCD" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTH)";
 	icon_state = "darkred2";
 	dir = 1
 	},
@@ -11042,7 +10638,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-darkred2 (WEST)";
 	icon_state = "darkred2";
 	dir = 8
 	},
@@ -11066,7 +10661,6 @@
 /area/desert_dam/interior/lab_northeast/security_office)
 "aCJ" = (
 /turf/open/floor{
-	tag = "icon-darkredcorners2 (EAST)";
 	icon_state = "darkredcorners2";
 	dir = 4
 	},
@@ -11074,7 +10668,6 @@
 "aCK" = (
 /obj/structure/filingcabinet,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/security_office)
@@ -11082,7 +10675,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/computer/guestpass,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/security_office)
@@ -11090,14 +10682,12 @@
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/security_office)
 "aCN" = (
 /obj/structure/closet/secure_closet/security,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/security_office)
@@ -11197,7 +10787,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security,
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTHEAST)";
 	icon_state = "darkred2";
 	dir = 5
 	},
@@ -11207,21 +10796,18 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTH)";
 	icon_state = "darkred2";
 	dir = 1
 	},
 /area/desert_dam/interior/lab_northeast/west_entrance)
 "aDh" = (
 /turf/open/floor{
-	tag = "icon-darkredcorners2 (NORTH)";
 	icon_state = "darkredcorners2";
 	dir = 1
 	},
 /area/desert_dam/interior/lab_northeast/west_entrance)
 "aDi" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/west_entrance)
@@ -11234,7 +10820,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/security_armory)
@@ -11242,7 +10827,6 @@
 /obj/machinery/r_n_d/protolathe,
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (SOUTHWEST)";
 	icon_state = "darkyellow2";
 	dir = 10
 	},
@@ -11251,7 +10835,6 @@
 /obj/structure/table,
 /obj/effect/spawner/random/tool,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
@@ -11259,7 +10842,6 @@
 "aDm" = (
 /obj/structure/table,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
@@ -11267,14 +10849,12 @@
 "aDn" = (
 /obj/machinery/autolathe,
 /turf/open/floor{
-	tag = "icon-darkyellow2";
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/lab_northeast/workshop)
 "aDo" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2 (WEST)";
 	icon_state = "darkyellowcorners2";
 	dir = 8
 	},
@@ -11292,12 +10872,10 @@
 /area/desert_dam/interior/lab_northeast/workshop)
 "aDq" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
 	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
@@ -11308,8 +10886,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/open/floor{
 	icon_state = "white"
@@ -11318,8 +10895,7 @@
 "aDs" = (
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2 (EAST)"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/storage)
 "aDt" = (
@@ -11336,7 +10912,6 @@
 "aDu" = (
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-darkred2 (WEST)";
 	icon_state = "darkred2";
 	dir = 8
 	},
@@ -11349,7 +10924,6 @@
 /area/desert_dam/interior/lab_northeast/security_office)
 "aDw" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/security_office)
@@ -11367,7 +10941,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/security_office)
@@ -11428,7 +11001,6 @@
 "aDI" = (
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-darkred2 (EAST)";
 	icon_state = "darkred2";
 	dir = 4
 	},
@@ -11437,11 +11009,9 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/west_entrance)
@@ -11454,7 +11024,6 @@
 	pixel_x = 0
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/west_entrance)
@@ -11506,8 +11075,7 @@
 /obj/machinery/shield_gen,
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2 (EAST)"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/storage)
 "aDR" = (
@@ -11542,8 +11110,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -11592,7 +11159,6 @@
 /obj/item/storage/donut_box,
 /obj/item/reagent_container/food/snacks/donut,
 /turf/open/floor{
-	tag = "icon-darkred2 (WEST)";
 	icon_state = "darkred2";
 	dir = 8
 	},
@@ -11634,8 +11200,7 @@
 "aEf" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/floor/plating/ground/desertdam/desert,
 /area/desert_dam/exterior/valley/valley_north_west)
@@ -11674,7 +11239,6 @@
 /area/desert_dam/exterior/river/riverside_northwest)
 "aEm" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (NORTH)";
 	icon_state = "platform_deco";
 	dir = 1
 	},
@@ -11695,21 +11259,18 @@
 "aEp" = (
 /obj/structure/closet/secure_closet/security,
 /turf/open/floor{
-	tag = "icon-darkred2 (SOUTHWEST)";
 	icon_state = "darkred2";
 	dir = 10
 	},
 /area/desert_dam/interior/lab_northeast/west_entrance)
 "aEq" = (
 /turf/open/floor{
-	tag = "icon-darkred2";
 	icon_state = "darkred2"
 	},
 /area/desert_dam/interior/lab_northeast/west_entrance)
 "aEr" = (
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-darkred2";
 	icon_state = "darkred2"
 	},
 /area/desert_dam/interior/lab_northeast/west_entrance)
@@ -11725,12 +11286,10 @@
 /area/desert_dam/interior/lab_northeast/west_hallway)
 "aEt" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
 /turf/open/floor{
-	tag = "icon-darkredcorners2 (EAST)";
 	icon_state = "darkredcorners2";
 	dir = 4
 	},
@@ -11747,13 +11306,11 @@
 /obj/machinery/shield_gen,
 /turf/open/floor{
 	dir = 10;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/storage)
 "aEx" = (
 /turf/open/floor{
-	tag = "icon-darkpurple2";
 	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/storage)
@@ -11766,7 +11323,6 @@
 	},
 /obj/structure/cable,
 /turf/open/floor{
-	tag = "icon-darkpurple2";
 	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/storage)
@@ -11785,7 +11341,6 @@
 "aEA" = (
 /obj/structure/rack,
 /turf/open/floor{
-	tag = "icon-darkpurple2";
 	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/storage)
@@ -11793,15 +11348,13 @@
 /obj/structure/rack,
 /obj/item/clothing/mask/gas,
 /turf/open/floor{
-	tag = "icon-darkpurple2";
 	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/storage)
 "aEC" = (
 /turf/open/floor{
 	dir = 6;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/storage)
 "aED" = (
@@ -11878,8 +11431,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -11898,7 +11450,6 @@
 "aEI" = (
 /obj/structure/filingcabinet,
 /turf/open/floor{
-	tag = "icon-darkred2 (WEST)";
 	icon_state = "darkred2";
 	dir = 8
 	},
@@ -11924,14 +11475,12 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-darkpurple2";
 	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/storage)
 "aEM" = (
 /obj/structure/closet/secure_closet/security,
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTH)";
 	icon_state = "darkred2";
 	dir = 1
 	},
@@ -11939,7 +11488,6 @@
 "aEN" = (
 /obj/structure/filingcabinet,
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTH)";
 	icon_state = "darkred2";
 	dir = 1
 	},
@@ -11955,7 +11503,6 @@
 	},
 /obj/item/tool/stamp,
 /turf/open/floor{
-	tag = "icon-darkredcorners2 (NORTH)";
 	icon_state = "darkredcorners2";
 	dir = 1
 	},
@@ -11990,7 +11537,6 @@
 	},
 /obj/machinery/power/apc/drained,
 /turf/open/floor{
-	tag = "icon-darkredcorners2 (EAST)";
 	icon_state = "darkredcorners2";
 	dir = 4
 	},
@@ -12097,8 +11643,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4;
@@ -12179,8 +11724,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 1;
@@ -12201,7 +11745,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-darkred2 (WEST)";
 	icon_state = "darkred2";
 	dir = 8
 	},
@@ -12243,8 +11786,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12377,7 +11919,6 @@
 "aFJ" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTHWEST)";
 	icon_state = "whitegreen";
 	dir = 9
 	},
@@ -12387,7 +11928,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
@@ -12395,7 +11935,6 @@
 "aFL" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
@@ -12406,14 +11945,12 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
 /area/desert_dam/building/lab_northwest/xenoflora)
 "aFN" = (
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
@@ -12435,7 +11972,6 @@
 "aFQ" = (
 /obj/machinery/botany/extractor,
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
@@ -12446,7 +11982,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
@@ -12454,14 +11989,12 @@
 "aFS" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTHEAST)";
 	icon_state = "whitegreen";
 	dir = 5
 	},
 /area/desert_dam/building/lab_northwest/xenoflora)
 "aFT" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (NORTH)";
 	icon_state = "tube1";
 	dir = 1
 	},
@@ -12489,8 +12022,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
@@ -12502,7 +12034,6 @@
 /obj/machinery/computer/guestpass,
 /obj/machinery/computer/security,
 /turf/open/floor{
-	tag = "icon-darkred2 (WEST)";
 	icon_state = "darkred2";
 	dir = 8
 	},
@@ -12580,7 +12111,6 @@
 /area/desert_dam/exterior/valley/valley_north_west)
 "aGh" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (NORTH)";
 	icon_state = "platform_deco";
 	dir = 1
 	},
@@ -12598,18 +12128,15 @@
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	tag = "icon-tube1 (EAST)"
+	icon_state = "tube1"
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (WEST)";
 	icon_state = "whitegreen";
 	dir = 8
 	},
 /area/desert_dam/building/lab_northwest/xenoflora)
 "aGk" = (
 /turf/open/floor{
-	tag = "icon-white";
 	icon_state = "white";
 	dir = 2
 	},
@@ -12620,7 +12147,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (EAST)";
 	icon_state = "whitegreen";
 	dir = 4
 	},
@@ -12685,7 +12211,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door_control,
 /turf/open/floor{
-	tag = "icon-darkred2 (WEST)";
 	icon_state = "darkred2";
 	dir = 8
 	},
@@ -12705,20 +12230,17 @@
 "aGx" = (
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-darkredcorners2";
 	icon_state = "darkredcorners2"
 	},
 /area/desert_dam/interior/lab_northeast)
 "aGy" = (
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-darkred2";
 	icon_state = "darkred2"
 	},
 /area/desert_dam/interior/lab_northeast/security_office)
 "aGz" = (
 /turf/open/floor{
-	tag = "icon-darkred2";
 	icon_state = "darkred2"
 	},
 /area/desert_dam/interior/lab_northeast/security_office)
@@ -12758,28 +12280,24 @@
 /area/desert_dam/exterior/river/riverside_northwest)
 "aGF" = (
 /turf/open/floor{
-	tag = "icon-whitegreen (WEST)";
 	icon_state = "whitegreen";
 	dir = 8
 	},
 /area/desert_dam/building/lab_northwest/xenoflora)
 "aGG" = (
 /turf/open/floor{
-	tag = "icon-whitegreencorner";
 	icon_state = "whitegreencorner";
 	dir = 2
 	},
 /area/desert_dam/building/lab_northwest/xenoflora)
 "aGH" = (
 /turf/open/floor{
-	tag = "icon-whitegreen";
 	icon_state = "whitegreen";
 	dir = 2
 	},
 /area/desert_dam/building/lab_northwest/xenoflora)
 "aGI" = (
 /turf/open/floor{
-	tag = "icon-whitegreencorner (WEST)";
 	icon_state = "whitegreencorner";
 	dir = 8
 	},
@@ -12787,7 +12305,6 @@
 "aGJ" = (
 /obj/structure/table,
 /turf/open/floor{
-	tag = "icon-whitegreen (EAST)";
 	icon_state = "whitegreen";
 	dir = 4
 	},
@@ -12821,13 +12338,11 @@
 	req_one_access_txt = "14"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/RND)
 "aGP" = (
 /turf/open/floor{
-	tag = "icon-darkpurple2 (WEST)";
 	icon_state = "darkpurple2";
 	dir = 8
 	},
@@ -12844,11 +12359,9 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/open/floor{
-	tag = "icon-darkpurplecorners2";
 	icon_state = "darkpurplecorners2";
 	dir = 2
 	},
@@ -12861,7 +12374,6 @@
 	pixel_x = 0
 	},
 /turf/open/floor{
-	tag = "icon-darkpurplecorners2 (EAST)";
 	icon_state = "darkpurplecorners2";
 	dir = 4
 	},
@@ -12875,8 +12387,7 @@
 	},
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/RND)
 "aGU" = (
@@ -12888,7 +12399,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-darkred2 (EAST)";
 	icon_state = "darkred2";
 	dir = 4
 	},
@@ -12900,8 +12410,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
@@ -12960,7 +12469,6 @@
 /area/desert_dam/exterior/river/riverside_northwest)
 "aHb" = (
 /turf/open/floor{
-	tag = "icon-whitepurplefull";
 	icon_state = "whitepurplefull";
 	dir = 2
 	},
@@ -12968,14 +12476,12 @@
 "aHc" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/open/floor{
-	tag = "icon-white";
 	icon_state = "white";
 	dir = 2
 	},
 /area/desert_dam/building/lab_northwest/xenoflora)
 "aHd" = (
 /turf/open/floor{
-	tag = "icon-whitegreen (EAST)";
 	icon_state = "whitegreen";
 	dir = 4
 	},
@@ -12984,7 +12490,6 @@
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	tag = "icon-white";
 	icon_state = "white";
 	dir = 2
 	},
@@ -13024,7 +12529,6 @@
 /area/desert_dam/interior/lab_northeast/west_hallway)
 "aHm" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (NORTH)";
 	icon_state = "tube1";
 	dir = 1
 	},
@@ -13040,7 +12544,6 @@
 /area/desert_dam/interior/lab_northeast/west_hallway)
 "aHo" = (
 /obj/structure/showcase{
-	tag = "icon-mechfab1";
 	icon_state = "mechfab1"
 	},
 /turf/open/floor{
@@ -13058,7 +12561,6 @@
 /area/desert_dam/interior/lab_northeast/west_hallway)
 "aHq" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -13077,13 +12579,11 @@
 "aHr" = (
 /obj/machinery/chem_master,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/RND)
 "aHs" = (
 /turf/open/floor{
-	tag = "icon-darkpurplecorners2 (EAST)";
 	icon_state = "darkpurplecorners2";
 	dir = 4
 	},
@@ -13091,27 +12591,23 @@
 "aHt" = (
 /turf/open/floor{
 	dir = 5;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/RND)
 "aHu" = (
 /obj/structure/flora/pottedplant,
 /turf/open/floor{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/desert_dam/interior/lab_northeast/lobby)
 "aHv" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (NORTH)";
 	icon_state = "pipe-c";
 	dir = 1
 	},
@@ -13131,13 +12627,11 @@
 "aHx" = (
 /turf/open/floor{
 	dir = 4;
-	icon_state = "whitebluecorner";
-	tag = "icon-whiteblue (EAST)"
+	icon_state = "whitebluecorner"
 	},
 /area/desert_dam/interior/lab_northeast/lobby)
 "aHy" = (
 /turf/open/floor{
-	tag = "icon-whiteblue (NORTH)";
 	icon_state = "whiteblue";
 	dir = 1
 	},
@@ -13150,15 +12644,13 @@
 /obj/machinery/power/apc/drained,
 /turf/open/floor{
 	dir = 5;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/RND)
 "aHA" = (
 /turf/open/floor{
 	dir = 1;
-	icon_state = "whitebluecorner";
-	tag = "icon-whiteblue (EAST)"
+	icon_state = "whitebluecorner"
 	},
 /area/desert_dam/interior/lab_northeast/lobby)
 "aHB" = (
@@ -13180,7 +12672,6 @@
 "aHD" = (
 /obj/structure/flora/pottedplant,
 /turf/open/floor{
-	tag = "icon-whiteblue (EAST)";
 	icon_state = "whiteblue";
 	dir = 4
 	},
@@ -13208,7 +12699,6 @@
 	name = "\improper Xenoflora"
 	},
 /turf/open/floor{
-	tag = "icon-whitepurplefull";
 	icon_state = "whitepurplefull";
 	dir = 2
 	},
@@ -13229,7 +12719,6 @@
 /area/desert_dam/exterior/valley/valley_north_west)
 "aHK" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (NORTH)";
 	icon_state = "platform_deco";
 	dir = 1
 	},
@@ -13245,7 +12734,6 @@
 /area/desert_dam/exterior/river/riverside_northwest)
 "aHM" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (NORTH)";
 	icon_state = "platform_deco";
 	dir = 1
 	},
@@ -13302,21 +12790,18 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/machinery/chem_dispenser,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/RND)
 "aHW" = (
 /obj/machinery/r_n_d/destructive_analyzer,
 /turf/open/floor{
-	tag = "icon-darkpurplecorners2";
 	icon_state = "darkpurplecorners2";
 	dir = 2
 	},
 /area/desert_dam/interior/lab_northeast/RND)
 "aHX" = (
 /turf/open/floor{
-	tag = "icon-darkpurplecorners2";
 	icon_state = "darkpurplecorners2";
 	dir = 2
 	},
@@ -13324,7 +12809,6 @@
 "aHY" = (
 /obj/machinery/r_n_d/protolathe,
 /turf/open/floor{
-	tag = "icon-darkpurplecorners2";
 	icon_state = "darkpurplecorners2";
 	dir = 2
 	},
@@ -13332,13 +12816,11 @@
 "aHZ" = (
 /obj/machinery/r_n_d/circuit_imprinter,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/RND)
 "aIa" = (
 /turf/open/floor{
-	tag = "icon-darkpurple2 (EAST)";
 	icon_state = "darkpurple2";
 	dir = 4
 	},
@@ -13346,16 +12828,14 @@
 "aIb" = (
 /turf/open/floor{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/desert_dam/interior/lab_northeast/lobby)
 "aIc" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -13379,7 +12859,6 @@
 	pixel_x = 0
 	},
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j1 (WEST)";
 	icon_state = "pipe-j1";
 	dir = 8
 	},
@@ -13439,7 +12918,6 @@
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j1 (WEST)";
 	icon_state = "pipe-j1";
 	dir = 8
 	},
@@ -13453,7 +12931,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whiteblue (EAST)";
 	icon_state = "whiteblue";
 	dir = 4
 	},
@@ -13504,14 +12981,12 @@
 /area/desert_dam/exterior/valley/valley_north_west)
 "aIp" = (
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
 /area/desert_dam/building/lab_northwest/xenoflora)
 "aIq" = (
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
@@ -13524,14 +12999,12 @@
 	},
 /obj/machinery/power/apc/drained,
 /turf/open/floor{
-	tag = "icon-whiteblue (NORTH)";
 	icon_state = "whiteblue";
 	dir = 1
 	},
 /area/desert_dam/interior/lab_northeast/lobby)
 "aIs" = (
 /turf/open/floor{
-	tag = "icon-whitegreencorner (NORTH)";
 	icon_state = "whitegreencorner";
 	dir = 1
 	},
@@ -13583,28 +13056,24 @@
 	amount = 30
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/RND)
 "aIA" = (
 /turf/open/floor{
 	dir = 10;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/RND)
 "aIB" = (
 /turf/open/floor{
-	tag = "icon-darkpurple2";
 	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/RND)
 "aIC" = (
 /turf/open/floor{
 	dir = 6;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/lab_northeast/RND)
 "aID" = (
@@ -13613,16 +13082,14 @@
 	},
 /turf/open/floor{
 	dir = 8;
-	icon_state = "whiteblue";
-	tag = "icon-whiteblue (NORTH)"
+	icon_state = "whiteblue"
 	},
 /area/desert_dam/interior/lab_northeast/lobby)
 "aIE" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
@@ -13647,7 +13114,6 @@
 /area/desert_dam/interior/lab_northeast/lobby)
 "aII" = (
 /turf/open/floor{
-	tag = "icon-whiteblue (EAST)";
 	icon_state = "whiteblue";
 	dir = 4
 	},
@@ -13664,7 +13130,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor{
-	tag = "icon-white";
 	icon_state = "white";
 	dir = 2
 	},
@@ -13695,7 +13160,6 @@
 "aIP" = (
 /obj/structure/showcase,
 /turf/open/floor{
-	tag = "icon-carpet6-2 (WEST)";
 	icon_state = "carpet6-2";
 	dir = 8
 	},
@@ -13704,8 +13168,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
@@ -13738,7 +13201,6 @@
 "aIU" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/open/floor{
-	tag = "icon-whitegreen (SOUTHWEST)";
 	icon_state = "whitegreen";
 	dir = 10
 	},
@@ -13746,7 +13208,6 @@
 "aIV" = (
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-whitegreen";
 	icon_state = "whitegreen";
 	dir = 2
 	},
@@ -13754,7 +13215,6 @@
 "aIW" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/open/floor{
-	tag = "icon-whitegreen";
 	icon_state = "whitegreen";
 	dir = 2
 	},
@@ -13762,7 +13222,6 @@
 "aIX" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/open/floor{
-	tag = "icon-whitegreen (SOUTHEAST)";
 	icon_state = "whitegreen";
 	dir = 6
 	},
@@ -13837,7 +13296,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
@@ -13851,14 +13309,12 @@
 /obj/machinery/computer/aifixer,
 /turf/open/floor{
 	dir = 9;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/interior/lab_northeast/RD_office)
 "aJk" = (
 /obj/structure/closet/secure_closet/RD,
 /turf/open/floor{
-	tag = "icon-darkblue2 (NORTH)";
 	icon_state = "darkblue2";
 	dir = 1
 	},
@@ -13867,7 +13323,6 @@
 /obj/structure/table,
 /obj/machinery/computer/guestpass,
 /turf/open/floor{
-	tag = "icon-darkblue2 (NORTH)";
 	icon_state = "darkblue2";
 	dir = 1
 	},
@@ -13877,7 +13332,6 @@
 /obj/effect/spawner/random/tech_supply,
 /obj/item/phone,
 /turf/open/floor{
-	tag = "icon-darkblue2 (NORTH)";
 	icon_state = "darkblue2";
 	dir = 1
 	},
@@ -13887,7 +13341,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-darkblue2 (NORTH)";
 	icon_state = "darkblue2";
 	dir = 1
 	},
@@ -13897,8 +13350,7 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor{
 	dir = 5;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/interior/lab_northeast/RD_office)
 "aJp" = (
@@ -13917,14 +13369,12 @@
 "aJr" = (
 /turf/open/floor{
 	dir = 2;
-	icon_state = "whitebluecorner";
-	tag = "icon-whiteblue (EAST)"
+	icon_state = "whitebluecorner"
 	},
 /area/desert_dam/interior/lab_northeast/lobby)
 "aJs" = (
 /obj/structure/flora/pottedplant,
 /turf/open/floor{
-	tag = "icon-whiteblue";
 	icon_state = "whiteblue"
 	},
 /area/desert_dam/interior/lab_northeast/lobby)
@@ -13933,15 +13383,13 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-whiteblue";
 	icon_state = "whiteblue"
 	},
 /area/desert_dam/interior/lab_northeast/lobby)
 "aJu" = (
 /turf/open/floor{
 	dir = 8;
-	icon_state = "whitebluecorner";
-	tag = "icon-whiteblue (EAST)"
+	icon_state = "whitebluecorner"
 	},
 /area/desert_dam/interior/lab_northeast/lobby)
 "aJv" = (
@@ -14003,7 +13451,6 @@
 /area/desert_dam/exterior/valley/valley_north_west)
 "aJC" = (
 /obj/structure/cargo_container{
-	tag = "icon-red 0,0";
 	icon_state = "red 0,0"
 	},
 /turf/open/floor/plating{
@@ -14013,7 +13460,6 @@
 /area/desert_dam/exterior/valley/valley_north_west)
 "aJD" = (
 /obj/structure/cargo_container{
-	tag = "icon-red 1,0";
 	icon_state = "red 1,0"
 	},
 /turf/open/floor/plating{
@@ -14023,7 +13469,6 @@
 /area/desert_dam/exterior/valley/valley_north_west)
 "aJE" = (
 /obj/structure/cargo_container{
-	tag = "icon-red 2,0";
 	icon_state = "red 2,0"
 	},
 /turf/open/floor/plating{
@@ -14034,18 +13479,15 @@
 "aJF" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	tag = "icon-tube1 (EAST)"
+	icon_state = "tube1"
 	},
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/interior/lab_northeast/RD_office)
 "aJG" = (
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
@@ -14055,7 +13497,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
@@ -14065,7 +13506,6 @@
 /obj/item/paper_bin,
 /obj/item/disk/nuclear,
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
@@ -14074,8 +13514,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
 	dir = 4;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/interior/lab_northeast/RD_office)
 "aJK" = (
@@ -14120,8 +13559,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
@@ -14208,14 +13646,12 @@
 "aKb" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
-	pixel_x = 0;
-	tag = "icon-E-corner"
+	pixel_x = 0
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
 /area/desert_dam/exterior/landing_pad_one_external)
 "aKc" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -14250,12 +13686,10 @@
 /area/desert_dam/exterior/valley/valley_north_west)
 "aKg" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -14266,7 +13700,6 @@
 /area/desert_dam/exterior/valley/valley_north_west)
 "aKh" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -14276,7 +13709,6 @@
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -14316,12 +13748,10 @@
 /area/desert_dam/exterior/valley/valley_north_west)
 "aKl" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
@@ -14334,7 +13764,6 @@
 	pixel_x = 0
 	},
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
@@ -14349,7 +13778,6 @@
 	pixel_x = 0
 	},
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
@@ -14365,7 +13793,6 @@
 	pixel_x = 0
 	},
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
@@ -14383,8 +13810,7 @@
 	},
 /turf/open/floor{
 	dir = 4;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/interior/lab_northeast/RD_office)
 "aKq" = (
@@ -14398,7 +13824,6 @@
 	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -14415,7 +13840,6 @@
 	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -14432,7 +13856,6 @@
 	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -14479,8 +13902,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating{
@@ -14582,13 +14004,11 @@
 /obj/structure/lamarr,
 /turf/open/floor{
 	dir = 10;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/interior/lab_northeast/RD_office)
 "aKO" = (
 /turf/open/floor{
-	tag = "icon-darkblue2";
 	icon_state = "darkblue2";
 	dir = 2
 	},
@@ -14596,8 +14016,7 @@
 "aKP" = (
 /turf/open/floor{
 	dir = 6;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/interior/lab_northeast/RD_office)
 "aKQ" = (
@@ -14710,7 +14129,6 @@
 /area/desert_dam/exterior/landing_pad_one_external)
 "aLi" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -14811,8 +14229,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -14883,7 +14300,6 @@
 /area/desert_dam/exterior/valley/valley_north_west)
 "aLH" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (NORTH)";
 	icon_state = "platform_deco";
 	dir = 1
 	},
@@ -14905,7 +14321,6 @@
 /area/desert_dam/exterior/valley/valley_north_east)
 "aLK" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (NORTH)";
 	icon_state = "platform_deco";
 	dir = 1
 	},
@@ -14944,8 +14359,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -15109,31 +14523,26 @@
 /area/desert_dam/exterior/valley/valley_crashsite)
 "aMq" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
 /area/desert_dam/exterior/landing_pad_one)
 "aMr" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
 /area/desert_dam/exterior/landing_pad_one)
 "aMs" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
-	pixel_x = 0;
-	tag = "icon-E-corner"
+	pixel_x = 0
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
 /area/desert_dam/exterior/landing_pad_one)
@@ -15205,7 +14614,6 @@
 /area/desert_dam/exterior/valley/valley_north_east)
 "aMD" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -15216,8 +14624,7 @@
 "aME" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/ground/desertdam/river/toxic/shallow_edge_toxic{
 	icon_state = "shallow_to_deep_toxic_water2"
@@ -15241,7 +14648,6 @@
 /area/desert_dam/exterior/valley/valley_north_east)
 "aMH" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -15314,14 +14720,12 @@
 "aMT" = (
 /obj/machinery/floodlight/landing,
 /turf/open/floor{
-	tag = "icon-asteroidplating";
 	icon_state = "asteroidplating";
 	dir = 2
 	},
 /area/desert_dam/exterior/landing_pad_one)
 "aMU" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -15332,8 +14736,7 @@
 "aMW" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
-	pixel_x = 0;
-	tag = "icon-E-corner"
+	pixel_x = 0
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
 /area/desert_dam/exterior/landing_pad_one)
@@ -15474,7 +14877,6 @@
 /area/desert_dam/exterior/valley/valley_north_east)
 "aNt" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -15503,8 +14905,7 @@
 /area/desert_dam/interior/caves/east_caves)
 "aNy" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "E";
-	tag = "icon-W"
+	icon_state = "E"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
 /area/desert_dam/exterior/landing_pad_one)
@@ -15523,8 +14924,7 @@
 "aNB" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/ground/desertdam/river/toxic/shallow_water_desert_coast_toxic{
 	icon_state = "shallow_water_desert_coast_toxic10"
@@ -15540,7 +14940,6 @@
 /area/desert_dam/exterior/river/riverside_central_north)
 "aND" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -15684,8 +15083,7 @@
 "aNW" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
-	pixel_x = 0;
-	tag = "icon-E-corner"
+	pixel_x = 0
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -15765,8 +15163,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
 /area/desert_dam/exterior/valley/valley_north_east)
@@ -15784,14 +15181,12 @@
 /area/desert_dam/exterior/valley/valley_crashsite)
 "aOl" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
 /area/desert_dam/exterior/landing_pad_one)
 "aOm" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -15811,7 +15206,6 @@
 /area/desert_dam/exterior/valley/valley_north_east)
 "aOp" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -15876,7 +15270,6 @@
 /area/desert_dam/exterior/valley/valley_crashsite)
 "aOz" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -15963,8 +15356,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -16023,8 +15415,7 @@
 "aOS" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/ground/desertdam/river/toxic/shallow_edge_toxic{
 	icon_state = "shallow_to_deep_toxic_water2"
@@ -16122,8 +15513,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/desert_dam/building/lab_northeast/garage)
@@ -16188,14 +15578,12 @@
 "aPs" = (
 /obj/machinery/vending/security,
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTHWEST)";
 	icon_state = "darkred2";
 	dir = 9
 	},
 /area/desert_dam/building/lab_northeast/checkpoint)
 "aPt" = (
 /turf/open/floor{
-	tag = "icon-darkredcorners2 (NORTH)";
 	icon_state = "darkredcorners2";
 	dir = 1
 	},
@@ -16207,7 +15595,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/lab_northeast/checkpoint)
@@ -16215,7 +15602,6 @@
 /obj/machinery/computer/secure_data,
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-darkredcorners2 (EAST)";
 	icon_state = "darkredcorners2";
 	dir = 4
 	},
@@ -16226,7 +15612,6 @@
 	},
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTHEAST)";
 	icon_state = "darkred2";
 	dir = 5
 	},
@@ -16248,8 +15633,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating{
 	dir = 1;
@@ -16317,8 +15701,7 @@
 	},
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/interior/lab_northeast/RD_office)
 "aPK" = (
@@ -16352,7 +15735,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-darkred2 (EAST)";
 	icon_state = "darkred2";
 	dir = 4
 	},
@@ -16378,14 +15760,12 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-darkred2 (WEST)";
 	icon_state = "darkred2";
 	dir = 8
 	},
 /area/desert_dam/building/lab_northeast/checkpoint)
 "aPQ" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -16393,7 +15773,6 @@
 /area/desert_dam/building/lab_northeast/garage)
 "aPR" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -16412,7 +15791,6 @@
 /area/desert_dam/building/lab_northeast/garage)
 "aPT" = (
 /turf/open/floor/plating{
-	tag = "icon-warnplate (EAST)";
 	icon_state = "warnplate";
 	dir = 4
 	},
@@ -16451,7 +15829,6 @@
 /area/desert_dam/exterior/valley/valley_crashsite)
 "aPZ" = (
 /turf/open/floor{
-	tag = "icon-asteroidwarning";
 	icon_state = "asteroidwarning"
 	},
 /area/desert_dam/exterior/landing_pad_one)
@@ -16467,7 +15844,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-carpet7-3 (WEST)";
 	icon_state = "carpet7-3";
 	dir = 8
 	},
@@ -16476,7 +15852,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/computer/med_data/laptop,
 /turf/open/floor{
-	tag = "icon-carpet15-15 (WEST)";
 	icon_state = "carpet15-15";
 	dir = 8
 	},
@@ -16485,7 +15860,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/computer/guestpass,
 /turf/open/floor{
-	tag = "icon-carpet11-12 (WEST)";
 	icon_state = "carpet11-12";
 	dir = 8
 	},
@@ -16574,7 +15948,6 @@
 /area/desert_dam/exterior/valley/valley_north_east)
 "aQr" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -16590,14 +15963,12 @@
 "aQt" = (
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-darkred2 (WEST)";
 	icon_state = "darkred2";
 	dir = 8
 	},
 /area/desert_dam/building/lab_northeast/checkpoint)
 "aQu" = (
 /turf/open/floor{
-	tag = "icon-darkred2 (EAST)";
 	icon_state = "darkred2";
 	dir = 4
 	},
@@ -16605,21 +15976,18 @@
 "aQv" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
-	pixel_x = 0;
-	tag = "icon-E-corner"
+	pixel_x = 0
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
 /area/desert_dam/exterior/valley/valley_north_east)
 "aQw" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -16642,7 +16010,6 @@
 /area/desert_dam/exterior/valley/valley_crashsite)
 "aQz" = (
 /turf/open/floor{
-	tag = "icon-asteroidwarning (EAST)";
 	icon_state = "asteroidwarning";
 	dir = 4
 	},
@@ -16652,7 +16019,6 @@
 /area/desert_dam/exterior/landing_pad_one)
 "aQB" = (
 /turf/open/floor{
-	tag = "icon-asteroidwarning (WEST)";
 	icon_state = "asteroidwarning";
 	dir = 8
 	},
@@ -16665,7 +16031,6 @@
 	pixel_y = 0
 	},
 /turf/open/floor{
-	tag = "icon-darkblue2 (NORTHWEST)";
 	icon_state = "darkblue2";
 	dir = 9
 	},
@@ -16673,7 +16038,6 @@
 "aQD" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor{
-	tag = "icon-darkblue2 (NORTH)";
 	icon_state = "darkblue2";
 	dir = 1
 	},
@@ -16682,7 +16046,6 @@
 /obj/structure/table,
 /obj/effect/spawner/random/tool,
 /turf/open/floor{
-	tag = "icon-darkblue2 (NORTH)";
 	icon_state = "darkblue2";
 	dir = 1
 	},
@@ -16692,7 +16055,6 @@
 /obj/effect/spawner/random/toolbox,
 /obj/effect/spawner/random/tool,
 /turf/open/floor{
-	tag = "icon-darkblue2 (NORTH)";
 	icon_state = "darkblue2";
 	dir = 1
 	},
@@ -16701,7 +16063,6 @@
 /obj/structure/table,
 /obj/machinery/computer/shuttle_control/dropship1,
 /turf/open/floor{
-	tag = "icon-darkblue2 (NORTH)";
 	icon_state = "darkblue2";
 	dir = 1
 	},
@@ -16710,7 +16071,6 @@
 /obj/structure/table,
 /obj/machinery/faxmachine,
 /turf/open/floor{
-	tag = "icon-darkblue2 (NORTH)";
 	icon_state = "darkblue2";
 	dir = 1
 	},
@@ -16721,8 +16081,7 @@
 /obj/effect/spawner/random/tech_supply,
 /turf/open/floor{
 	dir = 5;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/building/administration/control_room)
 "aQJ" = (
@@ -16734,7 +16093,6 @@
 	layer = 3.25
 	},
 /turf/open/floor{
-	tag = "icon-carpet7-3 (WEST)";
 	icon_state = "carpet7-3";
 	dir = 8
 	},
@@ -16742,7 +16100,6 @@
 "aQL" = (
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-carpet15-15 (WEST)";
 	icon_state = "carpet15-15";
 	dir = 8
 	},
@@ -16752,7 +16109,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-carpet11-12 (WEST)";
 	icon_state = "carpet11-12";
 	dir = 8
 	},
@@ -16790,7 +16146,6 @@
 /area/desert_dam/exterior/valley/valley_north_east)
 "aQS" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -16806,21 +16161,18 @@
 "aQU" = (
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-darkred2 (SOUTHWEST)";
 	icon_state = "darkred2";
 	dir = 10
 	},
 /area/desert_dam/building/lab_northeast/checkpoint)
 "aQV" = (
 /turf/open/floor{
-	tag = "icon-darkred2";
 	icon_state = "darkred2"
 	},
 /area/desert_dam/building/lab_northeast/checkpoint)
 "aQW" = (
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-darkred2";
 	icon_state = "darkred2"
 	},
 /area/desert_dam/building/lab_northeast/checkpoint)
@@ -16831,7 +16183,6 @@
 	pixel_y = 7
 	},
 /turf/open/floor{
-	tag = "icon-darkred2";
 	icon_state = "darkred2"
 	},
 /area/desert_dam/building/lab_northeast/checkpoint)
@@ -16843,14 +16194,12 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber,
 /turf/open/floor{
-	tag = "icon-darkred2 (SOUTHEAST)";
 	icon_state = "darkred2";
 	dir = 6
 	},
 /area/desert_dam/building/lab_northeast/checkpoint)
 "aQZ" = (
 /turf/open/floor/plating{
-	tag = "icon-warnplate (SOUTHWEST)";
 	icon_state = "warnplate";
 	dir = 10
 	},
@@ -16863,7 +16212,6 @@
 /area/desert_dam/building/lab_northeast/garage)
 "aRb" = (
 /turf/open/floor/plating{
-	tag = "icon-warnplate (SOUTHEAST)";
 	icon_state = "warnplate";
 	dir = 6
 	},
@@ -16875,8 +16223,7 @@
 "aRd" = (
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkbluecorners2";
-	tag = "icon-darkblue2"
+	icon_state = "darkbluecorners2"
 	},
 /area/desert_dam/building/administration/control_room)
 "aRe" = (
@@ -16897,27 +16244,23 @@
 "aRg" = (
 /turf/open/floor{
 	dir = 4;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/building/administration/control_room)
 "aRh" = (
 /turf/open/floor{
-	tag = "icon-carpet5-1 (WEST)";
 	icon_state = "carpet5-1";
 	dir = 8
 	},
 /area/desert_dam/building/administration/office)
 "aRi" = (
 /turf/open/floor{
-	tag = "icon-carpet13-5 (WEST)";
 	icon_state = "carpet13-5";
 	dir = 8
 	},
 /area/desert_dam/building/administration/office)
 "aRj" = (
 /turf/open/floor{
-	tag = "icon-carpet9-4 (WEST)";
 	icon_state = "carpet9-4";
 	dir = 8
 	},
@@ -16931,7 +16274,6 @@
 /area/desert_dam/building/administration/office)
 "aRl" = (
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -16941,11 +16283,9 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -16969,7 +16309,6 @@
 /area/desert_dam/building/administration/hallway)
 "aRp" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -17016,14 +16355,12 @@
 /area/desert_dam/exterior/valley/valley_crashsite)
 "aRv" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
 	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor{
 	dir = 4;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/building/administration/control_room)
 "aRw" = (
@@ -17113,7 +16450,6 @@
 /area/desert_dam/building/administration/control_room)
 "aRH" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
@@ -17130,7 +16466,6 @@
 	req_access_txt = "100"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/administration/office)
@@ -17152,21 +16487,18 @@
 	req_access_txt = "100"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/administration/office)
 "aRM" = (
 /obj/machinery/vending/cola,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/administration/hallway)
 "aRN" = (
 /obj/machinery/vending/cigarette/colony,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/administration/hallway)
@@ -17175,7 +16507,6 @@
 /obj/structure/disposalpipe/trunk,
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/administration/hallway)
@@ -17191,8 +16522,7 @@
 "aRQ" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/ground/desertdam/river/toxic/shallow_water_desert_coast_toxic{
 	icon_state = "shallow_water_desert_coast_toxic3"
@@ -17235,8 +16565,7 @@
 "aRW" = (
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkbluecorners2";
-	tag = "icon-darkblue2"
+	icon_state = "darkbluecorners2"
 	},
 /area/desert_dam/building/administration/control_room)
 "aRX" = (
@@ -17253,8 +16582,7 @@
 "aRY" = (
 /turf/open/floor{
 	dir = 4;
-	icon_state = "darkbluecorners2";
-	tag = "icon-darkblue2"
+	icon_state = "darkbluecorners2"
 	},
 /area/desert_dam/building/administration/control_room)
 "aRZ" = (
@@ -17262,7 +16590,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-darkblue2 (NORTH)";
 	icon_state = "darkblue2";
 	dir = 1
 	},
@@ -17270,26 +16597,22 @@
 "aSa" = (
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkbluecorners2";
-	tag = "icon-darkblue2"
+	icon_state = "darkbluecorners2"
 	},
 /area/desert_dam/building/administration/hallway)
 "aSb" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/administration/hallway)
 "aSc" = (
 /turf/open/floor{
 	dir = 4;
-	icon_state = "darkbluecorners2";
-	tag = "icon-darkblue2"
+	icon_state = "darkbluecorners2"
 	},
 /area/desert_dam/building/administration/hallway)
 "aSd" = (
 /turf/open/floor{
-	tag = "icon-darkblue2 (NORTH)";
 	icon_state = "darkblue2";
 	dir = 1
 	},
@@ -17303,7 +16626,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/administration/hallway)
@@ -17313,7 +16635,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor{
-	tag = "icon-darkblue2 (NORTH)";
 	icon_state = "darkblue2";
 	dir = 1
 	},
@@ -17324,7 +16645,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor{
-	tag = "icon-darkblue2 (NORTH)";
 	icon_state = "darkblue2";
 	dir = 1
 	},
@@ -17400,8 +16720,7 @@
 "aSr" = (
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/building/administration/control_room)
 "aSs" = (
@@ -17421,7 +16740,6 @@
 /area/desert_dam/building/administration/control_room)
 "aSt" = (
 /obj/structure/window/reinforced/tinted{
-	tag = "icon-twindow (WEST)";
 	icon_state = "twindow";
 	dir = 8
 	},
@@ -17463,7 +16781,6 @@
 /area/desert_dam/building/administration/control_room)
 "aSw" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -17483,12 +16800,10 @@
 "aSx" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -17503,12 +16818,10 @@
 /area/desert_dam/building/administration/control_room)
 "aSy" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -17523,7 +16836,6 @@
 /area/desert_dam/building/administration/hallway)
 "aSz" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -17541,7 +16853,6 @@
 /area/desert_dam/building/administration/hallway)
 "aSA" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -17603,7 +16914,6 @@
 	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -17611,7 +16921,6 @@
 /area/desert_dam/exterior/valley/valley_north_east)
 "aSG" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /obj/structure/cable{
@@ -17621,7 +16930,6 @@
 	pixel_x = 0
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -17647,7 +16955,6 @@
 /area/desert_dam/exterior/valley/valley_crashsite)
 "aSJ" = (
 /obj/structure/bed/chair/office/light{
-	tag = "icon-officechair_white (EAST)";
 	icon_state = "officechair_white";
 	dir = 4
 	},
@@ -17668,7 +16975,6 @@
 /area/desert_dam/building/administration/control_room)
 "aSL" = (
 /obj/structure/window/reinforced/tinted{
-	tag = "icon-twindow (WEST)";
 	icon_state = "twindow";
 	dir = 8
 	},
@@ -17681,8 +16987,7 @@
 "aSM" = (
 /obj/structure/bed/chair/office/light{
 	dir = 8;
-	icon_state = "officechair_white";
-	tag = "icon-officechair_white (EAST)"
+	icon_state = "officechair_white"
 	},
 /turf/open/floor{
 	dir = 5;
@@ -17737,7 +17042,6 @@
 /area/desert_dam/building/administration/hallway)
 "aSS" = (
 /turf/open/floor{
-	tag = "icon-darkbluecorners2";
 	icon_state = "darkbluecorners2";
 	dir = 2
 	},
@@ -17837,7 +17141,6 @@
 /area/desert_dam/building/administration/control_room)
 "aTg" = (
 /obj/structure/window/reinforced/tinted{
-	tag = "icon-twindow (WEST)";
 	icon_state = "twindow";
 	dir = 8
 	},
@@ -17853,7 +17156,6 @@
 "aTh" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-darkbluecorners2";
 	icon_state = "darkbluecorners2";
 	dir = 2
 	},
@@ -17861,15 +17163,13 @@
 "aTi" = (
 /turf/open/floor{
 	dir = 2;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/building/administration/hallway)
 "aTj" = (
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkbluecorners2";
-	tag = "icon-darkblue2"
+	icon_state = "darkbluecorners2"
 	},
 /area/desert_dam/building/administration/hallway)
 "aTk" = (
@@ -17900,8 +17200,7 @@
 "aTm" = (
 /turf/open/floor{
 	dir = 4;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/building/administration/hallway)
 "aTn" = (
@@ -17958,8 +17257,7 @@
 	},
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/building/administration/control_room)
 "aTv" = (
@@ -17969,8 +17267,7 @@
 	},
 /turf/open/floor{
 	dir = 4;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/building/administration/control_room)
 "aTw" = (
@@ -17995,7 +17292,6 @@
 "aTz" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/administration/hallway)
@@ -18009,13 +17305,11 @@
 	},
 /turf/open/floor{
 	dir = 4;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/building/administration/control_room)
 "aTB" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -18057,14 +17351,12 @@
 	pixel_y = -1
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/administration/archives)
 "aTE" = (
 /obj/structure/filingcabinet,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/administration/archives)
@@ -18078,13 +17370,11 @@
 	},
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/building/administration/hallway)
 "aTG" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/administration/archives)
@@ -18093,7 +17383,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/administration/archives)
@@ -18101,7 +17390,6 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/administration/archives)
@@ -18157,15 +17445,13 @@
 	},
 /turf/open/floor{
 	dir = 4;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/building/administration/control_room)
 "aTR" = (
 /obj/structure/flora/pottedplant,
 /obj/structure/closet/walllocker/hydrant,
 /turf/open/floor{
-	tag = "icon-darkblue2 (NORTHWEST)";
 	icon_state = "darkblue2";
 	dir = 9
 	},
@@ -18173,8 +17459,7 @@
 "aTS" = (
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkbluecorners2";
-	tag = "icon-darkblue2"
+	icon_state = "darkbluecorners2"
 	},
 /area/desert_dam/building/administration/lobby)
 "aTT" = (
@@ -18186,21 +17471,18 @@
 "aTU" = (
 /turf/open/floor{
 	dir = 4;
-	icon_state = "darkbluecorners2";
-	tag = "icon-darkblue2"
+	icon_state = "darkbluecorners2"
 	},
 /area/desert_dam/building/administration/lobby)
 "aTV" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/administration/lobby)
 "aTW" = (
 /obj/machinery/computer/security,
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTHWEST)";
 	icon_state = "darkred2";
 	dir = 9
 	},
@@ -18208,7 +17490,6 @@
 "aTX" = (
 /obj/structure/filingcabinet,
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTH)";
 	icon_state = "darkred2";
 	dir = 1
 	},
@@ -18216,7 +17497,6 @@
 "aTY" = (
 /obj/structure/closet/secure_closet/security,
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTH)";
 	icon_state = "darkred2";
 	dir = 1
 	},
@@ -18229,15 +17509,13 @@
 	},
 /obj/machinery/power/apc/drained,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/administration/archives)
 "aUa" = (
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/building/administration/hallway)
 "aUb" = (
@@ -18253,7 +17531,6 @@
 	pixel_y = 0
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/administration/archives)
@@ -18268,18 +17545,15 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/administration/archives)
 "aUd" = (
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/administration/archives)
@@ -18289,7 +17563,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/administration/archives)
@@ -18299,7 +17572,6 @@
 	icon_state = "tube1"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/administration/archives)
@@ -18323,8 +17595,7 @@
 /obj/machinery/faxmachine,
 /turf/open/floor{
 	dir = 4;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/building/administration/control_room)
 "aUk" = (
@@ -18333,8 +17604,7 @@
 	},
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/building/administration/lobby)
 "aUl" = (
@@ -18352,7 +17622,6 @@
 	pixel_x = -6
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/administration/lobby)
@@ -18361,7 +17630,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-darkred2 (WEST)";
 	icon_state = "darkred2";
 	dir = 8
 	},
@@ -18373,7 +17641,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor{
-	tag = "icon-darkredcorners2 (EAST)";
 	icon_state = "darkredcorners2";
 	dir = 4
 	},
@@ -18382,7 +17649,6 @@
 /obj/structure/table,
 /obj/item/tool/hand_labeler,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/administration/archives)
@@ -18395,7 +17661,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/administration/archives)
@@ -18404,7 +17669,6 @@
 /obj/item/paper_bin,
 /obj/item/tool/pen/blue,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/administration/archives)
@@ -18440,13 +17704,11 @@
 /obj/effect/landmark/random_item/crap,
 /turf/open/floor{
 	dir = 4;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/building/administration/control_room)
 "aUw" = (
 /turf/open/floor{
-	tag = "icon-darkred2 (WEST)";
 	icon_state = "darkred2";
 	dir = 8
 	},
@@ -18485,12 +17747,10 @@
 	name = "\improper Security Checkpoint"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -18526,11 +17786,9 @@
 "aUB" = (
 /obj/structure/table,
 /obj/item/tool/stamp{
-	tag = "icon-stamp-ce";
 	icon_state = "stamp-ce"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/administration/archives)
@@ -18544,14 +17802,12 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/administration/archives)
 "aUD" = (
 /obj/structure/table,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/administration/archives)
@@ -18559,7 +17815,6 @@
 /obj/structure/table,
 /obj/item/paper,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/administration/archives)
@@ -18580,48 +17835,41 @@
 "aUH" = (
 /turf/open/floor{
 	dir = 10;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/building/administration/control_room)
 "aUI" = (
 /turf/open/floor{
 	dir = 2;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/building/administration/control_room)
 "aUJ" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor{
 	dir = 6;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/building/administration/control_room)
 "aUK" = (
 /obj/structure/table,
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	tag = "icon-tube1 (EAST)"
+	icon_state = "tube1"
 	},
 /turf/open/floor{
 	dir = 10;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/building/administration/lobby)
 "aUL" = (
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkbluecorners2";
-	tag = "icon-darkblue2"
+	icon_state = "darkbluecorners2"
 	},
 /area/desert_dam/building/administration/lobby)
 "aUM" = (
 /turf/open/floor{
-	tag = "icon-darkbluecorners2";
 	icon_state = "darkbluecorners2";
 	dir = 2
 	},
@@ -18630,15 +17878,13 @@
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor{
 	dir = 2;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/building/administration/lobby)
 "aUO" = (
 /obj/structure/table,
 /obj/item/tool/stamp,
 /turf/open/floor{
-	tag = "icon-darkred2 (SOUTHWEST)";
 	icon_state = "darkred2";
 	dir = 10
 	},
@@ -18647,14 +17893,12 @@
 /obj/structure/table,
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-darkred2";
 	icon_state = "darkred2"
 	},
 /area/desert_dam/building/administration/lobby)
 "aUQ" = (
 /obj/structure/rack,
 /turf/open/floor{
-	tag = "icon-darkred2";
 	icon_state = "darkred2"
 	},
 /area/desert_dam/building/administration/lobby)
@@ -18664,7 +17908,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-darkred2";
 	icon_state = "darkred2"
 	},
 /area/desert_dam/building/administration/lobby)
@@ -18689,8 +17932,7 @@
 	},
 /turf/open/floor{
 	dir = 4;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/building/administration/hallway)
 "aUU" = (
@@ -18706,7 +17948,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/administration/archives)
@@ -18716,7 +17957,6 @@
 	name = "\improper Colony Archives"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/administration/archives)
@@ -18733,7 +17973,6 @@
 /area/desert_dam/exterior/valley/valley_north_west)
 "aUX" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -18860,7 +18099,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/administration/hallway)
@@ -18962,7 +18200,6 @@
 /area/desert_dam/interior/caves/east_caves)
 "aVB" = (
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (NORTH)";
 	icon_state = "pipe-c";
 	dir = 1
 	},
@@ -18996,7 +18233,6 @@
 /area/desert_dam/building/administration/hallway)
 "aVD" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -19015,7 +18251,6 @@
 /area/desert_dam/building/administration/hallway)
 "aVE" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -19036,7 +18271,6 @@
 /area/desert_dam/building/administration/hallway)
 "aVF" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -19055,12 +18289,10 @@
 /area/desert_dam/building/administration/hallway)
 "aVG" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -19074,7 +18306,6 @@
 /area/desert_dam/building/administration/hallway)
 "aVH" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -19097,12 +18328,10 @@
 /area/desert_dam/building/administration/hallway)
 "aVI" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -19114,12 +18343,10 @@
 "aVJ" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -19136,12 +18363,10 @@
 	dir = 1
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -19152,17 +18377,14 @@
 /area/desert_dam/exterior/valley/valley_north_west)
 "aVL" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -19173,7 +18395,6 @@
 /area/desert_dam/exterior/valley/valley_north_west)
 "aVM" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -19193,7 +18414,6 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -19209,12 +18429,10 @@
 "aVO" = (
 /obj/structure/desertdam/decals/road_edge,
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -19224,8 +18442,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -19267,7 +18484,6 @@
 /area/desert_dam/exterior/rock)
 "aVV" = (
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -19299,7 +18515,6 @@
 /area/desert_dam/building/administration/hallway)
 "aVY" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (NORTH)";
 	icon_state = "platform_deco";
 	dir = 1
 	},
@@ -19370,7 +18585,6 @@
 /area/desert_dam/exterior/valley/valley_north_east)
 "aWg" = (
 /turf/open/floor/plating{
-	tag = "icon-warnplate (EAST)";
 	icon_state = "warnplate";
 	dir = 4
 	},
@@ -19384,8 +18598,7 @@
 /obj/machinery/light,
 /turf/open/floor{
 	dir = 2;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/building/administration/hallway)
 "aWj" = (
@@ -19436,8 +18649,7 @@
 "aWq" = (
 /turf/open/floor{
 	dir = 10;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/building/administration/hallway)
 "aWr" = (
@@ -19553,7 +18765,6 @@
 	req_access_txt = "100"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/administration/overseer_office)
@@ -19578,7 +18789,6 @@
 /area/desert_dam/building/administration/meetingrooom)
 "aWK" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -19586,12 +18796,10 @@
 /area/desert_dam/building/administration/meetingrooom)
 "aWL" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTHEAST)";
 	icon_state = "darkred2";
 	dir = 5
 	},
@@ -19685,7 +18893,6 @@
 /area/desert_dam/building/administration/overseer_office)
 "aWZ" = (
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -19693,7 +18900,6 @@
 /area/desert_dam/building/administration/overseer_office)
 "aXa" = (
 /obj/structure/disposalpipe/trunk{
-	tag = "icon-pipe-t (WEST)";
 	icon_state = "pipe-t";
 	dir = 8
 	},
@@ -19722,7 +18928,6 @@
 /area/desert_dam/building/administration/meetingrooom)
 "aXe" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /obj/structure/cable{
@@ -19792,7 +18997,6 @@
 "aXn" = (
 /obj/structure/fence,
 /turf/open/floor/plating{
-	tag = "icon-warnplate (EAST)";
 	icon_state = "warnplate";
 	dir = 4
 	},
@@ -19812,7 +19016,6 @@
 	on = 1
 	},
 /turf/open/floor{
-	tag = "icon-carpet6-2 (WEST)";
 	icon_state = "carpet6-2";
 	dir = 8
 	},
@@ -19821,14 +19024,12 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
 	},
 /turf/open/floor{
-	tag = "icon-carpet14-10 (WEST)";
 	icon_state = "carpet14-10";
 	dir = 8
 	},
@@ -19841,7 +19042,6 @@
 	pixel_x = 0
 	},
 /turf/open/floor{
-	tag = "icon-carpet10-8 (WEST)";
 	icon_state = "carpet10-8";
 	dir = 8
 	},
@@ -19862,8 +19062,7 @@
 	},
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/building/administration/hallway)
 "aXv" = (
@@ -19875,14 +19074,12 @@
 "aXw" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (NORTHWEST)";
 	icon_state = "carpetside";
 	dir = 9
 	},
 /area/desert_dam/building/administration/meetingrooom)
 "aXx" = (
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (NORTH)";
 	icon_state = "carpetside";
 	dir = 1
 	},
@@ -19890,14 +19087,12 @@
 "aXy" = (
 /obj/structure/bed/chair/wood/normal,
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (NORTH)";
 	icon_state = "carpetside";
 	dir = 1
 	},
 /area/desert_dam/building/administration/meetingrooom)
 "aXz" = (
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (NORTHEAST)";
 	icon_state = "carpetside";
 	dir = 5
 	},
@@ -19955,7 +19150,6 @@
 /area/desert_dam/exterior/valley/valley_north_east)
 "aXG" = (
 /turf/open/floor{
-	tag = "icon-asteroidwarning (NORTH)";
 	icon_state = "asteroidwarning";
 	dir = 1
 	},
@@ -19976,7 +19170,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security/wooden_tv,
 /turf/open/floor{
-	tag = "icon-carpet7-3 (WEST)";
 	icon_state = "carpet7-3";
 	dir = 8
 	},
@@ -19985,14 +19178,12 @@
 /obj/structure/table/reinforced,
 /obj/machinery/computer/med_data/laptop,
 /turf/open/floor{
-	tag = "icon-carpet15-15 (WEST)";
 	icon_state = "carpet15-15";
 	dir = 8
 	},
 /area/desert_dam/building/administration/overseer_office)
 "aXL" = (
 /turf/open/floor{
-	tag = "icon-carpet11-12 (WEST)";
 	icon_state = "carpet11-12";
 	dir = 8
 	},
@@ -20010,7 +19201,6 @@
 "aXN" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (WEST)";
 	icon_state = "carpetside";
 	dir = 8
 	},
@@ -20027,7 +19217,6 @@
 /area/desert_dam/building/administration/meetingrooom)
 "aXQ" = (
 /obj/structure/bed/chair/wood/normal{
-	tag = "icon-wooden_chair (WEST)";
 	icon_state = "wooden_chair";
 	dir = 8
 	},
@@ -20035,7 +19224,6 @@
 /area/desert_dam/building/administration/meetingrooom)
 "aXR" = (
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (EAST)";
 	icon_state = "carpetside";
 	dir = 4
 	},
@@ -20099,7 +19287,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-carpet7-3 (WEST)";
 	icon_state = "carpet7-3";
 	dir = 8
 	},
@@ -20107,7 +19294,6 @@
 "aYb" = (
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-carpet15-15 (WEST)";
 	icon_state = "carpet15-15";
 	dir = 8
 	},
@@ -20117,7 +19303,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-carpet11-12 (WEST)";
 	icon_state = "carpet11-12";
 	dir = 8
 	},
@@ -20140,7 +19325,6 @@
 /area/desert_dam/building/administration/meetingrooom)
 "aYf" = (
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -20152,7 +19336,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (WEST)";
 	icon_state = "carpetside";
 	dir = 8
 	},
@@ -20231,7 +19414,6 @@
 /area/desert_dam/exterior/valley/valley_north_west)
 "aYr" = (
 /turf/open/floor{
-	tag = "icon-carpet5-1 (WEST)";
 	icon_state = "carpet5-1";
 	dir = 8
 	},
@@ -20239,14 +19421,12 @@
 "aYs" = (
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-carpet13-5 (WEST)";
 	icon_state = "carpet13-5";
 	dir = 8
 	},
 /area/desert_dam/building/administration/overseer_office)
 "aYt" = (
 /turf/open/floor{
-	tag = "icon-carpet9-4 (WEST)";
 	icon_state = "carpet9-4";
 	dir = 8
 	},
@@ -20259,7 +19439,6 @@
 /area/desert_dam/building/administration/meetingrooom)
 "aYv" = (
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (SOUTHWEST)";
 	icon_state = "carpetside";
 	dir = 10
 	},
@@ -20279,7 +19458,6 @@
 /area/desert_dam/building/administration/meetingrooom)
 "aYy" = (
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (SOUTHEAST)";
 	icon_state = "carpetside";
 	dir = 6
 	},
@@ -20302,7 +19480,6 @@
 /area/desert_dam/exterior/river/riverside_central_north)
 "aYB" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /obj/structure/cable{
@@ -20318,11 +19495,9 @@
 /area/desert_dam/exterior/valley/valley_north_east)
 "aYC" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -20333,7 +19508,6 @@
 /area/desert_dam/exterior/valley/valley_north_east)
 "aYD" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -20344,11 +19518,9 @@
 /area/desert_dam/exterior/valley/valley_north_east)
 "aYE" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "E";
-	tag = "icon-W"
+	icon_state = "E"
 	},
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -20448,8 +19620,7 @@
 "aYT" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/floor/plating{
 	dir = 1;
@@ -20467,7 +19638,6 @@
 /area/desert_dam/exterior/valley/valley_north_west)
 "aYV" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -20479,8 +19649,7 @@
 "aYW" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/ground/desertdam/river/toxic/shallow_water_toxic,
 /area/desert_dam/exterior/river/riverside_central_north)
@@ -20675,14 +19844,12 @@
 /area/desert_dam/interior/caves/central_caves)
 "aZC" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
 /area/desert_dam/interior/caves/central_caves)
 "aZD" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -20713,11 +19880,9 @@
 /area/desert_dam/exterior/valley/valley_north_east)
 "aZH" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "E";
-	tag = "icon-W"
+	icon_state = "E"
 	},
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -20763,7 +19928,6 @@
 /area/desert_dam/interior/caves/central_caves)
 "aZN" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -20774,11 +19938,9 @@
 /area/desert_dam/interior/caves/central_caves)
 "aZO" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -20789,7 +19951,6 @@
 /area/desert_dam/interior/caves/central_caves)
 "aZP" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -20800,11 +19961,9 @@
 /area/desert_dam/interior/caves/central_caves/entrances/east_tunnel_entrance)
 "aZQ" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -20815,11 +19974,9 @@
 /area/desert_dam/interior/caves/central_caves/entrances/east_tunnel_entrance)
 "aZR" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -20830,7 +19987,6 @@
 /area/desert_dam/exterior/valley/valley_north_east)
 "aZS" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -20844,7 +20000,6 @@
 /area/desert_dam/exterior/valley/valley_north_east)
 "aZT" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -20855,7 +20010,6 @@
 /area/desert_dam/exterior/valley/valley_north_east)
 "aZU" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -20900,7 +20054,6 @@
 /area/desert_dam/exterior/valley/valley_north_east)
 "baa" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /turf/open/floor/plating{
@@ -20911,8 +20064,7 @@
 "bab" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
-	pixel_x = 0;
-	tag = "icon-E-corner"
+	pixel_x = 0
 	},
 /turf/open/floor/plating{
 	dir = 1;
@@ -20933,8 +20085,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -20998,14 +20149,12 @@
 	name = "\improper Hangar Shutters"
 	},
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/hanger)
 "bap" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /obj/machinery/door/poddoor/shutters/almayer{
@@ -21040,32 +20189,27 @@
 /area/desert_dam/interior/dam_interior/hanger)
 "bau" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bav" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
-	pixel_x = 0;
-	tag = "icon-E-corner"
+	pixel_x = 0
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
 /area/desert_dam/interior/caves/central_caves)
 "baw" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -21094,35 +20238,30 @@
 "baA" = (
 /obj/structure/largecrate/random/barrel/blue,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "baB" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
-	pixel_x = 0;
-	tag = "icon-E-corner"
+	pixel_x = 0
 	},
 /obj/item/tool/warning_cone,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "baC" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "baD" = (
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
@@ -21130,13 +20269,11 @@
 "baE" = (
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "baF" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /obj/item/tool/warning_cone,
@@ -21145,13 +20282,11 @@
 	},
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "baG" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -21203,24 +20338,20 @@
 "baM" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
-	pixel_x = 0;
-	tag = "icon-E-corner"
+	pixel_x = 0
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "baN" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "baO" = (
@@ -21240,7 +20371,6 @@
 /area/desert_dam/exterior/valley/valley_north_west)
 "baQ" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (NORTH)";
 	icon_state = "platform_deco";
 	dir = 1
 	},
@@ -21272,18 +20402,15 @@
 /area/desert_dam/interior/caves/central_caves/entrances/west_tunnel_entrance)
 "baV" = (
 /turf/open/floor{
-	tag = "icon-darkbrown2 (EAST)";
 	icon_state = "darkbrown2";
 	dir = 4
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "baW" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /turf/closed/shuttle{
-	tag = "icon-swall_f6";
 	icon_state = "swall_f6"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
@@ -21293,17 +20420,14 @@
 /area/desert_dam/interior/dam_interior/hanger)
 "baY" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /turf/closed/shuttle{
-	tag = "icon-swall_f10";
 	icon_state = "swall_f10"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "baZ" = (
 /turf/open/floor{
-	tag = "icon-darkbrown2 (WEST)";
 	icon_state = "darkbrown2";
 	dir = 8
 	},
@@ -21328,16 +20452,13 @@
 /area/desert_dam/exterior/valley/valley_north_west)
 "bbc" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -21345,12 +20466,10 @@
 /area/desert_dam/exterior/valley/valley_north_west)
 "bbd" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -21386,34 +20505,28 @@
 	pixel_y = 0
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bbi" = (
 /turf/open/shuttle{
-	tag = "icon-floor6";
 	icon_state = "floor6"
 	},
 /turf/closed/shuttle{
-	tag = "icon-swall_f9";
 	icon_state = "swall_f9"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bbj" = (
 /obj/structure/computerframe,
 /turf/open/shuttle{
-	tag = "icon-floor6";
 	icon_state = "floor6"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bbk" = (
 /turf/open/shuttle{
-	tag = "icon-floor6";
 	icon_state = "floor6"
 	},
 /turf/closed/shuttle{
-	tag = "icon-swall_f5";
 	icon_state = "swall_f5"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
@@ -21422,7 +20535,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
@@ -21451,21 +20563,18 @@
 /area/desert_dam/exterior/valley/valley_north_east)
 "bbp" = (
 /turf/closed/shuttle{
-	tag = "icon-swall3";
 	icon_state = "swall3"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bbq" = (
 /obj/machinery/light,
 /turf/open/shuttle{
-	tag = "icon-floor6";
 	icon_state = "floor6"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bbr" = (
 /obj/machinery/door/airlock/unpowered/shuttle,
 /turf/open/shuttle{
-	tag = "icon-floor6";
 	icon_state = "floor6"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
@@ -21478,7 +20587,6 @@
 /area/desert_dam/exterior/valley/valley_north_east)
 "bbt" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -21487,8 +20595,7 @@
 "bbu" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/ground/desertdam/river/toxic/shallow_edge_toxic{
 	icon_state = "shallow_to_deep_toxic_water3"
@@ -21502,48 +20609,40 @@
 /area/desert_dam/exterior/valley/valley_north_east)
 "bbw" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "E";
-	tag = "icon-W"
+	icon_state = "E"
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bbx" = (
 /turf/closed/shuttle{
-	tag = "icon-swall7";
 	icon_state = "swall7"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bby" = (
 /turf/closed/shuttle{
-	tag = "icon-swall8";
 	icon_state = "swall8"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bbz" = (
 /turf/open/shuttle{
-	tag = "icon-floor6";
 	icon_state = "floor6"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bbA" = (
 /turf/closed/shuttle{
-	tag = "icon-swall4";
 	icon_state = "swall4"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bbB" = (
 /turf/closed/shuttle{
-	tag = "icon-swall11";
 	icon_state = "swall11"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bbC" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /obj/machinery/light{
@@ -21551,14 +20650,12 @@
 	},
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bbD" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "E";
-	tag = "icon-W"
+	icon_state = "E"
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -21566,7 +20663,6 @@
 	pixel_y = 0
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
@@ -21574,7 +20670,6 @@
 "bbE" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
@@ -21600,7 +20695,6 @@
 /area/desert_dam/exterior/river/riverside_central_north)
 "bbI" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -21611,8 +20705,7 @@
 "bbJ" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/floor/plating/ground/desertdam/desert{
 	icon_state = "desert4"
@@ -21654,33 +20747,27 @@
 /area/desert_dam/interior/caves/central_caves)
 "bbQ" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
 	icon_state = "tube1";
 	dir = 8
 	},
 /obj/structure/bed/chair{
-	tag = "icon-chair (EAST)";
 	icon_state = "chair";
 	dir = 4
 	},
 /turf/open/shuttle{
-	tag = "icon-floor6";
 	icon_state = "floor6"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bbR" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
 	icon_state = "tube1";
 	dir = 4
 	},
 /obj/structure/bed/chair{
-	tag = "icon-chair (WEST)";
 	icon_state = "chair";
 	dir = 8
 	},
 /turf/open/shuttle{
-	tag = "icon-floor6";
 	icon_state = "floor6"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
@@ -21703,50 +20790,41 @@
 /area/desert_dam/interior/caves/central_caves/entrances/west_tunnel_entrance)
 "bbW" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
 /area/desert_dam/interior/caves/central_caves/entrances/west_tunnel_entrance)
 "bbX" = (
 /turf/closed/shuttle{
-	tag = "icon-swall0";
 	icon_state = "swall0"
 	},
 /turf/closed/shuttle{
-	tag = "icon-swall_f9";
 	icon_state = "swall_f9"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bbY" = (
 /obj/structure/bed/chair{
-	tag = "icon-chair (EAST)";
 	icon_state = "chair";
 	dir = 4
 	},
 /turf/open/shuttle{
-	tag = "icon-floor6";
 	icon_state = "floor6"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bbZ" = (
 /obj/structure/bed/chair{
-	tag = "icon-chair (WEST)";
 	icon_state = "chair";
 	dir = 8
 	},
 /turf/open/shuttle{
-	tag = "icon-floor6";
 	icon_state = "floor6"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bca" = (
 /turf/closed/shuttle{
-	tag = "icon-swall0";
 	icon_state = "swall0"
 	},
 /turf/closed/shuttle{
-	tag = "icon-swall_f5";
 	icon_state = "swall_f5"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
@@ -21773,30 +20851,25 @@
 /area/desert_dam/exterior/river/riverside_central_north)
 "bce" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
 /area/desert_dam/interior/caves/central_caves/entrances/west_tunnel_entrance)
 "bcf" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
 /area/desert_dam/interior/caves/central_caves)
 "bcg" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -21804,12 +20877,10 @@
 /area/desert_dam/interior/caves/central_caves)
 "bch" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -21834,18 +20905,15 @@
 	pixel_y = 0
 	},
 /turf/open/floor{
-	tag = "icon-darkbrown2 (EAST)";
 	icon_state = "darkbrown2";
 	dir = 4
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bck" = (
 /turf/closed/shuttle{
-	tag = "icon-swall0";
 	icon_state = "swall0"
 	},
 /turf/closed/shuttle{
-	tag = "icon-heater";
 	icon_state = "heater"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
@@ -21854,7 +20922,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-darkbrown2 (WEST)";
 	icon_state = "darkbrown2";
 	dir = 8
 	},
@@ -21958,30 +21025,25 @@
 /area/desert_dam/interior/caves/central_caves)
 "bcE" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "E";
-	tag = "icon-W"
+	icon_state = "E"
 	},
 /obj/item/tool/warning_cone,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bcF" = (
 /turf/closed/shuttle{
-	tag = "icon-swall1";
 	icon_state = "swall1"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bcG" = (
 /turf/open/floor/plating,
 /turf/closed/shuttle{
-	tag = "icon-burst_l";
 	icon_state = "burst_l"
 	},
 /turf/closed/shuttle{
-	tag = "icon-platform (NORTH)";
 	icon_state = "platform";
 	dir = 1
 	},
@@ -21989,31 +21051,26 @@
 "bcH" = (
 /turf/open/floor/plating,
 /turf/closed/shuttle{
-	tag = "icon-burst_r";
 	icon_state = "burst_r"
 	},
 /turf/closed/shuttle{
-	tag = "icon-platform (NORTH)";
 	icon_state = "platform";
 	dir = 1
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bcI" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /obj/item/tool/warning_cone,
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bcJ" = (
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTHWEST)";
 	icon_state = "darkred2";
 	dir = 9
 	},
@@ -22022,7 +21079,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security,
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTH)";
 	icon_state = "darkred2";
 	dir = 1
 	},
@@ -22047,14 +21103,12 @@
 "bcO" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
-	pixel_x = 0;
-	tag = "icon-E-corner"
+	pixel_x = 0
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
 /area/desert_dam/interior/dam_interior/north_tunnel_entrance)
 "bcP" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -22075,8 +21129,7 @@
 "bcS" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
-	pixel_x = 0;
-	tag = "icon-E-corner"
+	pixel_x = 0
 	},
 /obj/structure/desertdam/decals/road_stop{
 	dir = 1;
@@ -22090,14 +21143,12 @@
 	icon_state = "stop_decal5"
 	},
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -22123,26 +21174,22 @@
 "bcX" = (
 /obj/structure/closet/secure_closet/security,
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTHWEST)";
 	icon_state = "darkred2";
 	dir = 9
 	},
 /area/desert_dam/interior/dam_interior/north_tunnel_entrance)
 "bcY" = (
 /turf/open/floor{
-	tag = "icon-darkredcorners2 (NORTH)";
 	icon_state = "darkredcorners2";
 	dir = 1
 	},
 /area/desert_dam/interior/dam_interior/north_tunnel_entrance)
 "bcZ" = (
 /obj/structure/bed/chair/office/light{
-	tag = "icon-officechair_white (EAST)";
 	icon_state = "officechair_white";
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/north_tunnel_entrance)
@@ -22159,7 +21206,6 @@
 	name = "Security Desk"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/north_tunnel_entrance)
@@ -22194,8 +21240,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -22219,7 +21264,6 @@
 /area/desert_dam/interior/caves/central_caves)
 "bdj" = (
 /turf/open/floor/plating{
-	tag = "icon-warnplate (EAST)";
 	icon_state = "warnplate";
 	dir = 4
 	},
@@ -22233,14 +21277,12 @@
 /obj/structure/dispenser,
 /turf/open/floor{
 	dir = 9;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/interior/dam_interior/tech_storage)
 "bdm" = (
 /obj/structure/dispenser,
 /turf/open/floor{
-	tag = "icon-darkblue2 (NORTH)";
 	icon_state = "darkblue2";
 	dir = 1
 	},
@@ -22250,7 +21292,6 @@
 /obj/item/weapon/katana/replica,
 /obj/item/reagent_container/food/drinks/bottle/absinthe,
 /turf/open/floor{
-	tag = "icon-darkblue2 (NORTH)";
 	icon_state = "darkblue2";
 	dir = 1
 	},
@@ -22264,7 +21305,6 @@
 	amount = 15
 	},
 /turf/open/floor{
-	tag = "icon-darkblue2 (NORTH)";
 	icon_state = "darkblue2";
 	dir = 1
 	},
@@ -22276,21 +21316,18 @@
 	},
 /turf/open/floor{
 	dir = 5;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/interior/dam_interior/tech_storage)
 "bdq" = (
 /obj/structure/rack,
 /turf/open/floor{
-	tag = "icon-darkred2 (WEST)";
 	icon_state = "darkred2";
 	dir = 8
 	},
 /area/desert_dam/interior/dam_interior/north_tunnel_entrance)
 "bdr" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/north_tunnel_entrance)
@@ -22314,13 +21351,11 @@
 	layer = 2.44
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/north_tunnel_entrance)
 "bdt" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -22351,7 +21386,6 @@
 /area/desert_dam/exterior/valley/valley_north_east)
 "bdz" = (
 /turf/closed/shuttle{
-	tag = "icon-swall2";
 	icon_state = "swall2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
@@ -22359,36 +21393,31 @@
 /obj/machinery/vending/engivend,
 /turf/open/floor{
 	dir = 9;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/interior/dam_interior/tech_storage)
 "bdB" = (
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkbluecorners2";
-	tag = "icon-darkblue2"
+	icon_state = "darkbluecorners2"
 	},
 /area/desert_dam/interior/dam_interior/tech_storage)
 "bdC" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/tech_storage)
 "bdD" = (
 /turf/open/floor{
 	dir = 4;
-	icon_state = "darkbluecorners2";
-	tag = "icon-darkblue2"
+	icon_state = "darkbluecorners2"
 	},
 /area/desert_dam/interior/dam_interior/tech_storage)
 "bdE" = (
 /obj/machinery/vending/tool,
 /turf/open/floor{
 	dir = 5;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/interior/dam_interior/tech_storage)
 "bdF" = (
@@ -22404,7 +21433,6 @@
 "bdG" = (
 /obj/structure/desertdam/decals/road_edge,
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -22413,8 +21441,7 @@
 "bdH" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
-	pixel_x = 0;
-	tag = "icon-E-corner"
+	pixel_x = 0
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -22425,7 +21452,6 @@
 /area/desert_dam/interior/dam_interior/north_tunnel_entrance)
 "bdI" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -22433,8 +21459,7 @@
 "bdJ" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/ground/desertdam/river/toxic/shallow_water_toxic,
 /area/desert_dam/interior/caves/central_caves)
@@ -22454,65 +21479,52 @@
 /area/desert_dam/building/mining/maintenance_north)
 "bdN" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /turf/closed/shuttle{
-	tag = "icon-swall_f5";
 	icon_state = "swall_f5"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bdO" = (
 /turf/open/shuttle{
-	tag = "icon-floor6";
 	icon_state = "floor6"
 	},
 /turf/closed/shuttle{
-	tag = "icon-swall_f10";
 	icon_state = "swall_f10"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bdP" = (
 /turf/open/shuttle{
-	tag = "icon-floor6";
 	icon_state = "floor6"
 	},
 /turf/closed/shuttle{
-	tag = "icon-swall_f6";
 	icon_state = "swall_f6"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bdQ" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /turf/closed/shuttle{
-	tag = "icon-swall_f9";
 	icon_state = "swall_f9"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bdR" = (
 /obj/structure/cargo_container{
-	tag = "icon-gorg 0,0";
 	icon_state = "gorg 0,0"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bdS" = (
 /obj/structure/cargo_container{
-	tag = "icon-gorg 2,0";
 	icon_state = "gorg 2,0"
 	},
 /obj/effect/decal/warning_stripes{
-	icon_state = "E";
-	tag = "icon-W"
+	icon_state = "E"
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
@@ -22524,8 +21536,7 @@
 /obj/machinery/vending/assist,
 /turf/open/floor{
 	dir = 9;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/interior/dam_interior/tech_storage)
 "bdV" = (
@@ -22533,14 +21544,12 @@
 /obj/item/circuitboard/computer/crew,
 /turf/open/floor{
 	dir = 5;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/interior/dam_interior/tech_storage)
 "bdW" = (
 /obj/structure/filingcabinet,
 /turf/open/floor{
-	tag = "icon-darkred2 (WEST)";
 	icon_state = "darkred2";
 	dir = 8
 	},
@@ -22629,25 +21638,21 @@
 /area/desert_dam/building/mining/maintenance_north)
 "bek" = (
 /turf/closed/shuttle{
-	tag = "icon-swall14";
 	icon_state = "swall14"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bel" = (
 /obj/structure/largecrate/random/secure,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bem" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "E";
-	tag = "icon-W"
+	icon_state = "E"
 	},
 /obj/structure/largecrate/random/case,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
@@ -22657,7 +21662,6 @@
 /obj/item/tool/lighter/zippo,
 /obj/item/tool/lighter/zippo,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -22665,7 +21669,6 @@
 "beo" = (
 /obj/structure/table,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -22673,7 +21676,6 @@
 "bep" = (
 /obj/machinery/vending/engivend,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -22681,7 +21683,6 @@
 "beq" = (
 /obj/machinery/vending/tool,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTHEAST)";
 	icon_state = "darkyellow2";
 	dir = 5
 	},
@@ -22701,12 +21702,10 @@
 /area/desert_dam/interior/dam_interior/north_tunnel_entrance)
 "bes" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/tech_storage)
@@ -22714,7 +21713,6 @@
 /obj/structure/rack,
 /obj/item/circuitboard/computer/atmos_alert,
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -22722,7 +21720,6 @@
 /area/desert_dam/interior/dam_interior/tech_storage)
 "beu" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -22754,13 +21751,11 @@
 /obj/item/circuitboard/airlock,
 /turf/open/floor{
 	dir = 4;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/interior/dam_interior/tech_storage)
 "bez" = (
 /turf/open/floor{
-	tag = "icon-darkred2 (WEST)";
 	icon_state = "darkred2";
 	dir = 8
 	},
@@ -22802,34 +21797,28 @@
 	},
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/interior/dam_interior/tech_storage)
 "beH" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /turf/closed/shuttle{
-	tag = "icon-wall (NORTHWEST)";
 	icon_state = "wall";
 	dir = 9
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "beI" = (
 /turf/closed/shuttle{
-	tag = "icon-swall13";
 	icon_state = "swall13"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "beJ" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /turf/closed/shuttle{
-	tag = "icon-wall (NORTHEAST)";
 	icon_state = "wall";
 	dir = 5
 	},
@@ -22840,7 +21829,6 @@
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
 "beL" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
@@ -22848,13 +21836,11 @@
 /area/desert_dam/building/mining/maintenance_north)
 "beM" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
 "beN" = (
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
@@ -22864,8 +21850,7 @@
 /obj/item/storage/box/trackimp,
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/interior/dam_interior/tech_storage)
 "beP" = (
@@ -22892,7 +21877,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/north_tunnel_entrance)
@@ -23023,8 +22007,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/desert_dam/building/mining/maintenance_north)
@@ -23054,22 +22037,18 @@
 /area/desert_dam/building/mining/maintenance_north)
 "bfr" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /turf/closed/shuttle{
-	tag = "icon-wall (SOUTHEAST)";
 	icon_state = "wall";
 	dir = 6
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bfs" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /turf/closed/shuttle{
-	tag = "icon-wall (SOUTHWEST)";
 	icon_state = "wall";
 	dir = 10
 	},
@@ -23084,16 +22063,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
 "bfv" = (
 /obj/structure/table/reinforced,
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/interior/dam_interior/tech_storage)
 "bfw" = (
@@ -23114,8 +22091,7 @@
 /obj/structure/rack,
 /turf/open/floor{
 	dir = 4;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/interior/dam_interior/tech_storage)
 "bfz" = (
@@ -23137,14 +22113,12 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2 (SOUTHWEST)";
 	icon_state = "darkyellow2";
 	dir = 10
 	},
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
 "bfC" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (NORTH)";
 	icon_state = "tube1";
 	dir = 1
 	},
@@ -23222,7 +22196,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
@@ -23236,7 +22209,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
@@ -23246,7 +22218,6 @@
 	amount = 25
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
@@ -23254,7 +22225,6 @@
 /obj/structure/table,
 /obj/item/stack/cable_coil,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
@@ -23264,7 +22234,6 @@
 	amount = 15
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
@@ -23274,7 +22243,6 @@
 	amount = 10
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
@@ -23287,14 +22255,12 @@
 	amount = 15
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
 "bfU" = (
 /obj/structure/table,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
@@ -23325,8 +22291,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/desert_dam/building/mining/maintenance_north)
@@ -23352,15 +22317,13 @@
 /obj/effect/spawner/random/toolbox,
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
 "bgf" = (
 /obj/structure/rack,
 /obj/item/cell/high/empty,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
@@ -23370,8 +22333,7 @@
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/interior/dam_interior/tech_storage)
 "bgh" = (
@@ -23381,15 +22343,13 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/tech_storage)
 "bgi" = (
 /turf/open/floor{
 	dir = 4;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/interior/dam_interior/tech_storage)
 "bgj" = (
@@ -23414,14 +22374,12 @@
 /area/desert_dam/interior/dam_interior/north_tunnel)
 "bgl" = (
 /turf/open/floor{
-	tag = "icon-darkyellow2 (WEST)";
 	icon_state = "darkyellow2";
 	dir = 8
 	},
 /area/desert_dam/interior/dam_interior/engine_west_wing)
 "bgm" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/engine_west_wing)
@@ -23439,7 +22397,6 @@
 /area/desert_dam/interior/dam_interior/engine_west_wing)
 "bgo" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
@@ -23503,7 +22460,6 @@
 /area/desert_dam/exterior/valley/valley_north_east)
 "bgA" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -23511,7 +22467,6 @@
 /area/desert_dam/exterior/valley/valley_north_east)
 "bgB" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -23520,7 +22475,6 @@
 /area/desert_dam/building/mining/maintenance_north)
 "bgC" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -23530,8 +22484,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
 /area/desert_dam/building/mining/maintenance_north)
@@ -23558,7 +22511,6 @@
 "bgI" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating{
@@ -23576,29 +22528,24 @@
 /area/desert_dam/building/mining/foremans_office)
 "bgL" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bgM" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bgN" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
@@ -23609,8 +22556,7 @@
 /obj/effect/spawner/random/tool,
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
 "bgP" = (
@@ -23618,7 +22564,6 @@
 /obj/item/cell/high/empty,
 /obj/effect/landmark/random_item/crap,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
@@ -23627,14 +22572,12 @@
 /obj/structure/table/reinforced,
 /turf/open/floor{
 	dir = 10;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/interior/dam_interior/tech_storage)
 "bgR" = (
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-darkblue2";
 	icon_state = "darkblue2";
 	dir = 2
 	},
@@ -23642,14 +22585,12 @@
 "bgS" = (
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkbluecorners2";
-	tag = "icon-darkblue2"
+	icon_state = "darkbluecorners2"
 	},
 /area/desert_dam/interior/dam_interior/tech_storage)
 "bgT" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	tag = "icon-darkbluecorners2";
 	icon_state = "darkbluecorners2";
 	dir = 2
 	},
@@ -23657,7 +22598,6 @@
 "bgU" = (
 /obj/structure/rack,
 /turf/open/floor{
-	tag = "icon-darkblue2";
 	icon_state = "darkblue2";
 	dir = 2
 	},
@@ -23666,8 +22606,7 @@
 /obj/structure/rack,
 /turf/open/floor{
 	dir = 6;
-	icon_state = "darkblue2";
-	tag = "icon-darkblue2"
+	icon_state = "darkblue2"
 	},
 /area/desert_dam/interior/dam_interior/tech_storage)
 "bgW" = (
@@ -23702,8 +22641,7 @@
 "bha" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
-	pixel_x = 0;
-	tag = "icon-E-corner"
+	pixel_x = 0
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -23714,7 +22652,6 @@
 /area/desert_dam/interior/dam_interior/north_tunnel)
 "bhb" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -23726,7 +22663,6 @@
 	pixel_y = 0
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2 (WEST)";
 	icon_state = "darkyellow2";
 	dir = 8
 	},
@@ -23736,18 +22672,15 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/engine_west_wing)
 "bhe" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	tag = "icon-tube1 (EAST)"
+	icon_state = "tube1"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
@@ -23801,8 +22734,7 @@
 /obj/structure/table/reinforced,
 /turf/open/floor{
 	dir = 9;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "bhn" = (
@@ -23813,16 +22745,14 @@
 "bho" = (
 /turf/open/floor{
 	dir = 4;
-	icon_state = "darkyellowcorners2";
-	tag = "icon-darkyellowcorners2 (NORTH)"
+	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "bhp" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor{
 	dir = 5;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "bhq" = (
@@ -23877,8 +22807,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/open/floor,
 /area/desert_dam/exterior/valley/valley_north_east)
@@ -23922,20 +22851,17 @@
 "bhF" = (
 /turf/open/floor{
 	dir = 4;
-	icon_state = "darkyellowcorners2";
-	tag = "icon-darkyellowcorners2 (NORTH)"
+	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bhG" = (
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bhH" = (
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2 (NORTH)";
 	icon_state = "darkyellowcorners2";
 	dir = 1
 	},
@@ -23947,7 +22873,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
@@ -23955,14 +22880,12 @@
 /obj/structure/table,
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
 "bhK" = (
 /obj/structure/rack,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
@@ -23978,7 +22901,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/tech_storage)
@@ -23988,8 +22910,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	tag = "icon-tube1 (EAST)"
+	icon_state = "tube1"
 	},
 /turf/open/floor/plating{
 	dir = 1;
@@ -23998,7 +22919,6 @@
 /area/desert_dam/interior/dam_interior/north_tunnel)
 "bhN" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /obj/structure/cable{
@@ -24010,7 +22930,6 @@
 /area/desert_dam/interior/dam_interior/north_tunnel)
 "bhO" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -24066,7 +22985,6 @@
 /area/desert_dam/interior/dam_interior/smes_main)
 "bhU" = (
 /obj/machinery/power/terminal{
-	tag = "icon-term (WEST)";
 	icon_state = "term";
 	dir = 8
 	},
@@ -24075,7 +22993,6 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor{
-	tag = "icon-platebot";
 	icon_state = "platebot"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
@@ -24112,14 +23029,12 @@
 	},
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "bhY" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
@@ -24156,8 +23071,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/open/floor{
 	dir = 8;
@@ -24168,8 +23082,7 @@
 /obj/machinery/conveyor{
 	dir = 10;
 	icon_state = "conveyor0";
-	id = "anomalybelt";
-	tag = "icon-conveyor0 (NORTHWEST)"
+	id = "anomalybelt"
 	},
 /turf/open/floor/plating,
 /area/desert_dam/building/mining/maintenance_north)
@@ -24200,8 +23113,7 @@
 "bij" = (
 /turf/open/floor{
 	dir = 9;
-	icon_state = "darkbrown2";
-	tag = "icon-darkbrown2"
+	icon_state = "darkbrown2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bik" = (
@@ -24209,20 +23121,17 @@
 	on = 1
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bil" = (
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (EAST)";
 	icon_state = "darkbrowncorners2";
 	dir = 4
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bim" = (
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (NORTH)";
 	icon_state = "darkbrowncorners2";
 	dir = 1
 	},
@@ -24234,14 +23143,12 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (EAST)";
 	icon_state = "darkbrowncorners2";
 	dir = 4
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bio" = (
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2 (NORTH)";
 	icon_state = "darkyellowcorners2";
 	dir = 1
 	},
@@ -24249,25 +23156,21 @@
 "bip" = (
 /turf/open/floor{
 	dir = 4;
-	icon_state = "darkyellowcorners2";
-	tag = "icon-darkyellowcorners2 (NORTH)"
+	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
 "biq" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bir" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -24275,7 +23178,6 @@
 "bis" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -24285,7 +23187,6 @@
 	on = 1
 	},
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2 (NORTH)";
 	icon_state = "darkyellowcorners2";
 	dir = 1
 	},
@@ -24297,14 +23198,12 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
 "biv" = (
 /obj/structure/closet/secure_closet/engineering_welding,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -24312,7 +23211,6 @@
 "biw" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -24324,7 +23222,6 @@
 	icon_state = "tube1"
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTHEAST)";
 	icon_state = "darkyellow2";
 	dir = 5
 	},
@@ -24339,7 +23236,6 @@
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "biz" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -24347,29 +23243,24 @@
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "biA" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "biB" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -24379,8 +23270,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
@@ -24434,8 +23324,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -24443,7 +23332,6 @@
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -24483,7 +23371,6 @@
 	icon_state = "tube1"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
@@ -24500,7 +23387,6 @@
 	name = "\improper Engine Room"
 	},
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
@@ -24520,8 +23406,7 @@
 	},
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "biR" = (
@@ -24537,7 +23422,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
@@ -24596,8 +23480,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/open/floor,
 /area/desert_dam/exterior/valley/valley_north_east)
@@ -24625,7 +23508,6 @@
 /area/desert_dam/building/mining/foremans_office)
 "bjf" = (
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -24679,7 +23561,6 @@
 /area/desert_dam/interior/dam_interior/hanger)
 "bjk" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -24688,7 +23569,6 @@
 	layer = 2.4
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -24704,7 +23584,6 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -24712,7 +23591,6 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -24723,7 +23601,6 @@
 /area/desert_dam/interior/dam_interior/hanger)
 "bjm" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -24737,7 +23614,6 @@
 	layer = 2.4
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -24748,13 +23624,11 @@
 /area/desert_dam/interior/dam_interior/hanger)
 "bjn" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -24765,7 +23639,6 @@
 /area/desert_dam/interior/dam_interior/hanger)
 "bjo" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -24774,7 +23647,6 @@
 	layer = 2.4
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -24785,7 +23657,6 @@
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
 "bjp" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -24799,7 +23670,6 @@
 	layer = 2.4
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -24810,13 +23680,11 @@
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
 "bjq" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -24827,15 +23695,13 @@
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
 "bjr" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4;
@@ -24852,7 +23718,6 @@
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
 "bjs" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -24909,7 +23774,6 @@
 "bjz" = (
 /obj/machinery/vending/engivend,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTHWEST)";
 	icon_state = "darkyellow2";
 	dir = 9
 	},
@@ -24917,7 +23781,6 @@
 "bjA" = (
 /obj/machinery/vending/tool,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -24925,14 +23788,12 @@
 "bjB" = (
 /obj/machinery/vending/assist,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
 /area/desert_dam/interior/dam_interior/engine_west_wing)
 "bjC" = (
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2 (NORTH)";
 	icon_state = "darkyellowcorners2";
 	dir = 1
 	},
@@ -25029,14 +23890,12 @@
 	layer = 2.2
 	},
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
 "bjL" = (
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
@@ -25049,7 +23908,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
@@ -25065,8 +23923,7 @@
 /obj/effect/spawner/random/tool,
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "bjQ" = (
@@ -25094,7 +23951,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
@@ -25147,8 +24003,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating{
 	dir = 1;
@@ -25162,8 +24017,7 @@
 	},
 /turf/open/floor{
 	dir = 9;
-	icon_state = "darkbrown2";
-	tag = "icon-darkbrown2"
+	icon_state = "darkbrown2"
 	},
 /area/desert_dam/building/mining/front_desk)
 "bkb" = (
@@ -25171,7 +24025,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-darkbrown2 (NORTH)";
 	icon_state = "darkbrown2";
 	dir = 1
 	},
@@ -25182,7 +24035,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor{
-	tag = "icon-darkbrown2 (NORTH)";
 	icon_state = "darkbrown2";
 	dir = 1
 	},
@@ -25190,7 +24042,6 @@
 "bkd" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor{
-	tag = "icon-darkbrown2 (NORTH)";
 	icon_state = "darkbrown2";
 	dir = 1
 	},
@@ -25199,20 +24050,17 @@
 /obj/machinery/vending/cigarette/colony,
 /turf/open/floor{
 	dir = 5;
-	icon_state = "darkbrown2";
-	tag = "icon-darkbrown2"
+	icon_state = "darkbrown2"
 	},
 /area/desert_dam/building/mining/front_desk)
 "bkf" = (
 /turf/open/floor{
-	tag = "icon-darkbrown2 (WEST)";
 	icon_state = "darkbrown2";
 	dir = 8
 	},
 /area/desert_dam/building/mining/front_desk)
 "bkg" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/mining/front_desk)
@@ -25337,7 +24185,6 @@
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "bkv" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (NORTH)";
 	icon_state = "platform_deco";
 	dir = 1
 	},
@@ -25352,7 +24199,6 @@
 /obj/item/circuitboard/airlock,
 /obj/effect/landmark/random_item/crap,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTHWEST)";
 	icon_state = "darkyellow2";
 	dir = 9
 	},
@@ -25360,7 +24206,6 @@
 "bkx" = (
 /obj/machinery/recharge_station,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -25369,7 +24214,6 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -25382,7 +24226,6 @@
 /obj/item/storage/toolbox/emergency,
 /obj/item/circuitboard/firealarm,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -25395,7 +24238,6 @@
 /obj/item/assembly/signaler,
 /obj/item/circuitboard/airlock,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -25405,26 +24247,22 @@
 /obj/item/assembly/infra,
 /obj/item/assembly/voice,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTHEAST)";
 	icon_state = "darkyellow2";
 	dir = 5
 	},
 /area/desert_dam/interior/dam_interior/engine_west_wing)
 "bkC" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
 "bkD" = (
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2";
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/engine_west_wing)
@@ -25448,7 +24286,6 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
@@ -25465,7 +24302,6 @@
 	layer = 2.1
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
@@ -25477,7 +24313,6 @@
 	layer = 2.1
 	},
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
@@ -25497,8 +24332,7 @@
 /obj/item/reagent_container/food/drinks/cans/thirteenloko,
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "bkL" = (
@@ -25512,7 +24346,6 @@
 "bkM" = (
 /obj/machinery/power/port_gen/pacman/super,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -25520,7 +24353,6 @@
 "bkN" = (
 /obj/machinery/power/port_gen/pacman/super,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTHEAST)";
 	icon_state = "darkyellow2";
 	dir = 5
 	},
@@ -25554,14 +24386,12 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-darkbrown2 (WEST)";
 	icon_state = "darkbrown2";
 	dir = 8
 	},
 /area/desert_dam/building/mining/front_desk)
 "bkS" = (
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (WEST)";
 	icon_state = "darkbrowncorners2";
 	dir = 8
 	},
@@ -25569,7 +24399,6 @@
 "bkT" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (WEST)";
 	icon_state = "darkbrowncorners2";
 	dir = 8
 	},
@@ -25579,7 +24408,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (EAST)";
 	icon_state = "darkbrowncorners2";
 	dir = 4
 	},
@@ -25591,19 +24419,16 @@
 /area/desert_dam/building/mining/front_desk)
 "bkW" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
 /area/desert_dam/interior/dam_interior/engine_west_wing)
 "bkX" = (
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (NORTH)";
 	icon_state = "darkbrowncorners2";
 	dir = 1
 	},
@@ -25617,7 +24442,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (EAST)";
 	icon_state = "darkbrowncorners2";
 	dir = 4
 	},
@@ -25625,16 +24449,14 @@
 "bkZ" = (
 /turf/open/floor{
 	dir = 5;
-	icon_state = "darkbrown2";
-	tag = "icon-darkbrown2"
+	icon_state = "darkbrown2"
 	},
 /area/desert_dam/building/mining/front_desk)
 "bla" = (
 /obj/machinery/conveyor{
 	dir = 5;
 	icon_state = "conveyor0";
-	id = "anomalybelt";
-	tag = "icon-conveyor0 (NORTHWEST)"
+	id = "anomalybelt"
 	},
 /turf/open/floor/plating,
 /area/desert_dam/building/mining/maintenance_east)
@@ -25649,8 +24471,7 @@
 /obj/machinery/conveyor{
 	dir = 10;
 	icon_state = "conveyor0";
-	id = "anomalybelt";
-	tag = "icon-conveyor0 (NORTHWEST)"
+	id = "anomalybelt"
 	},
 /turf/open/floor/plating,
 /area/desert_dam/building/mining/maintenance_east)
@@ -25660,27 +24481,23 @@
 "ble" = (
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "blf" = (
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (WEST)";
 	icon_state = "darkbrowncorners2";
 	dir = 8
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "blg" = (
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2";
 	icon_state = "darkbrowncorners2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "blh" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
@@ -25688,7 +24505,6 @@
 /obj/structure/largecrate/random/barrel/white,
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
@@ -25696,49 +24512,41 @@
 /obj/structure/largecrate/random/barrel/blue,
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "blk" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bll" = (
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "blm" = (
 /obj/structure/cargo_container{
-	tag = "icon-gorg 0,0";
 	icon_state = "gorg 0,0"
 	},
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (WEST)";
 	icon_state = "darkbrowncorners2";
 	dir = 8
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "bln" = (
 /obj/structure/cargo_container{
-	tag = "icon-gorg 2,0";
 	icon_state = "gorg 2,0"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "blo" = (
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2";
 	icon_state = "darkbrowncorners2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
@@ -25747,27 +24555,23 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (WEST)";
 	icon_state = "darkbrowncorners2";
 	dir = 8
 	},
 /area/desert_dam/interior/dam_interior/hanger)
 "blq" = (
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2 (WEST)";
 	icon_state = "darkyellowcorners2";
 	dir = 8
 	},
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
 "blr" = (
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2";
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
 "bls" = (
 /turf/open/floor{
-	tag = "icon-darkyellow2";
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
@@ -25776,14 +24580,12 @@
 /obj/effect/spawner/random/tool,
 /obj/effect/spawner/random/toolbox,
 /turf/open/floor{
-	tag = "icon-darkyellow2";
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
 "blu" = (
 /obj/structure/table,
 /turf/open/floor{
-	tag = "icon-darkyellow2";
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
@@ -25797,7 +24599,6 @@
 /obj/effect/spawner/random/technology_scanner,
 /obj/effect/spawner/random/tool,
 /turf/open/floor{
-	tag = "icon-darkyellow2";
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
@@ -25807,7 +24608,6 @@
 /obj/effect/spawner/random/toolbox,
 /obj/effect/spawner/random/tool,
 /turf/open/floor{
-	tag = "icon-darkyellow2";
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
@@ -25817,14 +24617,12 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2";
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
 "bly" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
@@ -25832,14 +24630,12 @@
 "blz" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
-	pixel_x = 0;
-	tag = "icon-E-corner"
+	pixel_x = 0
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
 /area/desert_dam/interior/dam_interior/north_tunnel)
 "blA" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /obj/structure/cable{
@@ -25894,7 +24690,6 @@
 /obj/item/explosive/grenade/chem_grenade/metalfoam,
 /obj/item/flashlight,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTHWEST)";
 	icon_state = "darkyellow2";
 	dir = 9
 	},
@@ -25922,19 +24717,16 @@
 /area/desert_dam/interior/dam_interior/engine_west_wing)
 "blK" = (
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
 /area/desert_dam/interior/dam_interior/engine_west_wing)
 "blL" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (EAST)";
 	icon_state = "darkbrowncorners2";
 	dir = 4
 	},
@@ -25948,8 +24740,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
@@ -25966,7 +24757,6 @@
 	layer = 2.2
 	},
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
@@ -26011,8 +24801,7 @@
 /obj/item/radio,
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "blT" = (
@@ -26025,14 +24814,12 @@
 /obj/effect/spawner/random/powercell,
 /turf/open/floor{
 	dir = 4;
-	icon_state = "darkyellowcorners2";
-	tag = "icon-darkyellowcorners2 (NORTH)"
+	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "blV" = (
 /obj/structure/table,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTHEAST)";
 	icon_state = "darkyellow2";
 	dir = 5
 	},
@@ -26040,8 +24827,7 @@
 "blW" = (
 /turf/open/floor{
 	dir = 5;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "blX" = (
@@ -26060,7 +24846,6 @@
 "blZ" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-darkbrown2 (WEST)";
 	icon_state = "darkbrown2";
 	dir = 8
 	},
@@ -26088,7 +24873,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-darkbrown2 (WEST)";
 	icon_state = "darkbrown2";
 	dir = 8
 	},
@@ -26097,33 +24881,27 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/mining/front_desk)
 "bme" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/mining/front_desk)
 "bmf" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (NORTH)";
 	icon_state = "darkbrowncorners2";
 	dir = 1
 	},
@@ -26142,14 +24920,12 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (EAST)";
 	icon_state = "darkbrowncorners2";
 	dir = 4
 	},
 /area/desert_dam/building/mining/front_desk)
 "bmh" = (
 /turf/open/floor{
-	tag = "icon-darkbrown2 (EAST)";
 	icon_state = "darkbrown2";
 	dir = 4
 	},
@@ -26184,14 +24960,12 @@
 "bmp" = (
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/auxilary_tool_storage)
 "bmq" = (
 /obj/structure/table,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
@@ -26206,7 +24980,6 @@
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "bms" = (
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTHWEST)";
 	icon_state = "darkyellow2";
 	dir = 9
 	},
@@ -26242,8 +25015,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4;
@@ -26256,7 +25028,6 @@
 /area/desert_dam/interior/dam_interior/engine_west_wing)
 "bmw" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -26296,8 +25067,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "\improper Backup SMES"
@@ -26331,7 +25101,6 @@
 	pixel_y = 0
 	},
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
@@ -26394,7 +25163,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
@@ -26405,13 +25173,11 @@
 /obj/item/flash,
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "bmI" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
@@ -26420,7 +25186,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
@@ -26437,12 +25202,10 @@
 "bmM" = (
 /obj/structure/flora/pottedplant,
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
 	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (NORTH)";
 	icon_state = "darkbrowncorners2";
 	dir = 1
 	},
@@ -26453,14 +25216,12 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (NORTH)";
 	icon_state = "darkbrowncorners2";
 	dir = 1
 	},
 /area/desert_dam/building/mining/front_desk)
 "bmO" = (
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2";
 	icon_state = "darkbrowncorners2"
 	},
 /area/desert_dam/building/mining/front_desk)
@@ -26470,8 +25231,7 @@
 /obj/item/paper_bin,
 /turf/open/floor{
 	dir = 10;
-	icon_state = "darkbrown2";
-	tag = "icon-darkbrown2"
+	icon_state = "darkbrown2"
 	},
 /area/desert_dam/building/mining/front_desk)
 "bmQ" = (
@@ -26479,7 +25239,6 @@
 /obj/item/packageWrap,
 /obj/item/tool/hand_labeler,
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (WEST)";
 	icon_state = "darkbrowncorners2";
 	dir = 8
 	},
@@ -26490,18 +25249,15 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-darkbrown2";
 	icon_state = "darkbrown2"
 	},
 /area/desert_dam/building/mining/front_desk)
 "bmS" = (
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (WEST)";
 	icon_state = "darkbrowncorners2";
 	dir = 8
 	},
@@ -26512,12 +25268,10 @@
 	on = 1
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (WEST)";
 	icon_state = "darkbrowncorners2";
 	dir = 8
 	},
@@ -26533,7 +25287,6 @@
 	},
 /obj/structure/disposalpipe/junction,
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2";
 	icon_state = "darkbrowncorners2"
 	},
 /area/desert_dam/building/mining/front_desk)
@@ -26552,7 +25305,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/smes_main)
@@ -26569,13 +25321,11 @@
 	pixel_y = 0
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
 "bmZ" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
@@ -26590,7 +25340,6 @@
 /area/desert_dam/building/mining/maintenance_east)
 "bnb" = (
 /turf/open/floor{
-	tag = "icon-darkbrown2 (WEST)";
 	icon_state = "darkbrown2";
 	dir = 8
 	},
@@ -26616,7 +25365,6 @@
 /area/desert_dam/interior/dam_interior/hangar_storage)
 "bne" = (
 /turf/open/floor{
-	tag = "icon-darkbrown2 (EAST)";
 	icon_state = "darkbrown2";
 	dir = 4
 	},
@@ -26672,14 +25420,12 @@
 /area/desert_dam/interior/dam_interior/northwestern_tunnel)
 "bnm" = (
 /obj/structure/cargo_container{
-	tag = "icon-gorg 0,0";
 	icon_state = "gorg 0,0"
 	},
 /turf/open/floor,
 /area/desert_dam/interior/dam_interior/northwestern_tunnel)
 "bnn" = (
 /obj/structure/cargo_container{
-	tag = "icon-gorg 2,0";
 	icon_state = "gorg 2,0"
 	},
 /turf/open/floor,
@@ -26785,22 +25531,19 @@
 	},
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 "bnC" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
@@ -26814,8 +25557,7 @@
 /obj/structure/table,
 /turf/open/floor{
 	dir = 4;
-	icon_state = "darkyellowcorners2";
-	tag = "icon-darkyellowcorners2 (NORTH)"
+	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 "bnE" = (
@@ -26827,7 +25569,6 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -26836,7 +25577,6 @@
 /obj/structure/table,
 /obj/item/analyzer,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -26848,7 +25588,6 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -26858,8 +25597,7 @@
 /obj/structure/table,
 /turf/open/floor{
 	dir = 5;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 "bnI" = (
@@ -26867,14 +25605,12 @@
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "bnJ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (NORTH)";
 	icon_state = "pipe-c";
 	dir = 1
 	},
@@ -26910,7 +25646,6 @@
 /area/desert_dam/exterior/valley/valley_north_east)
 "bnO" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /obj/item/tool/warning_cone,
@@ -26920,8 +25655,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/open/floor/plating{
 	dir = 1;
@@ -26936,7 +25670,6 @@
 	pixel_x = 0
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/mining/front_desk)
@@ -26948,7 +25681,6 @@
 	pixel_x = 0
 	},
 /turf/open/floor{
-	tag = "icon-darkbrown2 (WEST)";
 	icon_state = "darkbrown2";
 	dir = 8
 	},
@@ -26962,7 +25694,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-darkbrown2 (WEST)";
 	icon_state = "darkbrown2";
 	dir = 8
 	},
@@ -26972,7 +25703,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-darkbrown2 (EAST)";
 	icon_state = "darkbrown2";
 	dir = 4
 	},
@@ -26984,7 +25714,6 @@
 	pixel_y = 0
 	},
 /turf/open/floor{
-	tag = "icon-darkbrown2 (WEST)";
 	icon_state = "darkbrown2";
 	dir = 8
 	},
@@ -26998,7 +25727,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/mining/front_desk)
@@ -27016,8 +25744,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/desert_dam/building/mining/maintenance_east)
@@ -27029,7 +25756,6 @@
 "boa" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
@@ -27040,29 +25766,24 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
 "boc" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
 "bod" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /turf/open/floor{
-	tag = "icon-darkbrown2 (WEST)";
 	icon_state = "darkbrown2";
 	dir = 8
 	},
@@ -27071,8 +25792,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
@@ -27099,7 +25819,6 @@
 /area/desert_dam/interior/dam_interior/northwestern_tunnel)
 "boh" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -27107,26 +25826,22 @@
 /area/desert_dam/interior/dam_interior/northwestern_tunnel)
 "boi" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
 "boj" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
-	pixel_x = 0;
-	tag = "icon-E-corner"
+	pixel_x = 0
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
 /area/desert_dam/interior/dam_interior/northwestern_tunnel)
 "bok" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -27161,19 +25876,16 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor{
 	dir = 10;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/engine_west_wing)
 "boq" = (
 /turf/open/floor{
-	tag = "icon-darkyellow2";
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/engine_west_wing)
 "bor" = (
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2 (WEST)";
 	icon_state = "darkyellowcorners2";
 	dir = 8
 	},
@@ -27181,44 +25893,38 @@
 "bos" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor{
-	tag = "icon-darkyellow2";
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/engine_west_wing)
 "bot" = (
 /obj/machinery/pipedispenser,
 /turf/open/floor{
-	tag = "icon-darkyellow2";
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/engine_west_wing)
 "bou" = (
 /obj/machinery/space_heater,
 /turf/open/floor{
-	tag = "icon-darkyellow2";
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/engine_west_wing)
 "bov" = (
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-darkyellow2";
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/engine_west_wing)
 "bow" = (
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 "box" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
@@ -27229,7 +25935,6 @@
 /area/desert_dam/interior/dam_interior/control_room)
 "boy" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
@@ -27244,13 +25949,11 @@
 	layer = 2.2
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 "boA" = (
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
@@ -27269,8 +25972,7 @@
 /obj/item/storage/box/lightstick,
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "boD" = (
@@ -27297,7 +25999,6 @@
 	pixel_x = 0
 	},
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j1 (WEST)";
 	icon_state = "pipe-j1";
 	dir = 8
 	},
@@ -27393,7 +26094,6 @@
 	name = "\improper Mining Lobby"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/mining/front_desk)
@@ -27401,20 +26101,17 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-darkbrown2 (WEST)";
 	icon_state = "darkbrown2";
 	dir = 8
 	},
 /area/desert_dam/building/mining/front_desk)
 "boN" = (
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (EAST)";
 	icon_state = "darkbrowncorners2";
 	dir = 4
 	},
@@ -27429,7 +26126,6 @@
 /area/desert_dam/interior/dam_interior/northwestern_tunnel)
 "boP" = (
 /turf/open/floor{
-	tag = "icon-darkbrown2 (NORTH)";
 	icon_state = "darkbrown2";
 	dir = 1
 	},
@@ -27487,7 +26183,6 @@
 /area/desert_dam/interior/dam_interior/northwestern_tunnel)
 "boW" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -27509,8 +26204,7 @@
 "boZ" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/floor/plating{
 	dir = 1;
@@ -27570,12 +26264,10 @@
 /area/desert_dam/interior/dam_interior/engine_west_wing)
 "bpg" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
 /turf/open/floor{
-	tag = "icon-darkbrown2 (NORTH)";
 	icon_state = "darkbrown2";
 	dir = 1
 	},
@@ -27584,14 +26276,12 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
@@ -27620,7 +26310,6 @@
 	layer = 2.2
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
@@ -27636,7 +26325,6 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
@@ -27724,8 +26412,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
@@ -27742,7 +26429,6 @@
 	},
 /obj/machinery/cell_charger,
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2";
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
@@ -27750,33 +26436,28 @@
 /obj/structure/table,
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-darkyellow2";
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "bpw" = (
 /obj/structure/table,
 /turf/open/floor{
-	tag = "icon-darkyellow2";
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "bpx" = (
 /turf/open/floor{
-	tag = "icon-darkyellow2";
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "bpy" = (
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "bpz" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -27784,8 +26465,7 @@
 "bpA" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/ground/desertdam/river/toxic/deep_water_toxic,
 /area/desert_dam/interior/caves/central_caves)
@@ -27805,7 +26485,6 @@
 /area/desert_dam/interior/caves/central_caves)
 "bpD" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -27823,12 +26502,10 @@
 "bpG" = (
 /obj/structure/flora/pottedplant,
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
 	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (WEST)";
 	icon_state = "darkbrowncorners2";
 	dir = 8
 	},
@@ -27837,13 +26514,11 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (WEST)";
 	icon_state = "darkbrowncorners2";
 	dir = 8
 	},
@@ -27855,7 +26530,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2";
 	icon_state = "darkbrowncorners2"
 	},
 /area/desert_dam/building/mining/front_desk)
@@ -27868,7 +26542,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2";
 	icon_state = "darkbrowncorners2"
 	},
 /area/desert_dam/building/mining/front_desk)
@@ -27884,14 +26557,12 @@
 /obj/structure/powerloader_wreckage,
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
 "bpN" = (
 /obj/structure/largecrate/random/secure,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
@@ -27914,7 +26585,6 @@
 /area/desert_dam/interior/dam_interior/northwestern_tunnel)
 "bpQ" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (NORTH)";
 	icon_state = "platform_deco";
 	dir = 1
 	},
@@ -27947,13 +26617,11 @@
 	},
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 "bpU" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
@@ -27979,7 +26647,6 @@
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "bpY" = (
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2 (NORTH)";
 	icon_state = "darkyellowcorners2";
 	dir = 1
 	},
@@ -28006,13 +26673,11 @@
 "bqb" = (
 /turf/open/floor{
 	dir = 4;
-	icon_state = "darkyellowcorners2";
-	tag = "icon-darkyellowcorners2 (NORTH)"
+	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/lobby)
 "bqc" = (
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2 (NORTH)";
 	icon_state = "darkyellowcorners2";
 	dir = 1
 	},
@@ -28020,8 +26685,7 @@
 "bqd" = (
 /turf/open/floor{
 	dir = 4;
-	icon_state = "darkyellowcorners2";
-	tag = "icon-darkyellowcorners2 (NORTH)"
+	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 "bqe" = (
@@ -28050,7 +26714,6 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "bqh" = (
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2 (NORTH)";
 	icon_state = "darkyellowcorners2";
 	dir = 1
 	},
@@ -28081,7 +26744,6 @@
 	},
 /obj/machinery/cell_charger,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
@@ -28107,8 +26769,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
@@ -28118,7 +26779,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor{
-	tag = "icon-darkbrown2 (WEST)";
 	icon_state = "darkbrown2";
 	dir = 8
 	},
@@ -28135,12 +26795,10 @@
 	layer = 2.4
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-darkbrown2 (WEST)";
 	icon_state = "darkbrown2";
 	dir = 8
 	},
@@ -28157,12 +26815,10 @@
 	layer = 2.4
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/mining/front_desk)
@@ -28170,8 +26826,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -28184,18 +26839,15 @@
 	layer = 2.4
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/mining/front_desk)
 "bqs" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -28204,7 +26856,6 @@
 	layer = 2.4
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -28212,7 +26863,6 @@
 /area/desert_dam/building/mining/front_desk)
 "bqt" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -28221,12 +26871,10 @@
 	layer = 2.4
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/mining/front_desk)
@@ -28247,37 +26895,30 @@
 	},
 /obj/structure/disposalpipe/junction,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/mining/front_desk)
 "bqv" = (
 /obj/structure/cargo_container{
-	tag = "icon-HD_blue 0,0";
 	icon_state = "HD_blue 0,0"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
 "bqw" = (
 /obj/structure/cargo_container{
-	tag = "icon-HD_blue 0,1";
 	icon_state = "HD_blue 0,1"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
 "bqx" = (
 /obj/structure/cargo_container{
-	tag = "icon-HD_blue 0,2";
 	icon_state = "HD_blue 0,2"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
@@ -28295,7 +26936,6 @@
 /area/desert_dam/interior/dam_interior/north_tunnel)
 "bqA" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -28303,7 +26943,6 @@
 /area/desert_dam/interior/dam_interior/north_tunnel)
 "bqB" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -28319,7 +26958,6 @@
 	icon_state = "1-4"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -28336,7 +26974,6 @@
 	dir = 1
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -28347,12 +26984,10 @@
 /area/desert_dam/interior/dam_interior/north_tunnel)
 "bqE" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -28363,7 +26998,6 @@
 /area/desert_dam/interior/dam_interior/north_tunnel)
 "bqF" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -28373,7 +27007,6 @@
 /area/desert_dam/interior/dam_interior/north_tunnel)
 "bqG" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -28388,7 +27021,6 @@
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "bqH" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -28399,11 +27031,9 @@
 "bqI" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -28420,7 +27050,6 @@
 	dir = 1
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -28428,7 +27057,6 @@
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "bqK" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -28439,7 +27067,6 @@
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "bqL" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -28459,7 +27086,6 @@
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "bqM" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -28473,7 +27099,6 @@
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "bqN" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -28492,7 +27117,6 @@
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "bqO" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -28500,7 +27124,6 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j1 (WEST)";
 	icon_state = "pipe-j1";
 	dir = 8
 	},
@@ -28511,7 +27134,6 @@
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "bqP" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -28529,7 +27151,6 @@
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "bqQ" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -28548,7 +27169,6 @@
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "bqR" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -28566,7 +27186,6 @@
 /area/desert_dam/interior/dam_interior/lobby)
 "bqS" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -28594,13 +27213,11 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j1 (WEST)";
 	icon_state = "pipe-j1";
 	dir = 8
 	},
@@ -28611,7 +27228,6 @@
 /area/desert_dam/interior/dam_interior/lobby)
 "bqU" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -28630,7 +27246,6 @@
 /area/desert_dam/interior/dam_interior/lobby)
 "bqV" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -28645,7 +27260,6 @@
 /area/desert_dam/interior/dam_interior/lobby)
 "bqW" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -28662,14 +27276,12 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -28751,7 +27363,6 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "bre" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
@@ -28767,8 +27378,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -28785,7 +27395,6 @@
 "brh" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /turf/open/floor{
@@ -28799,24 +27408,21 @@
 /obj/machinery/vending/engivend,
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "brk" = (
 /obj/machinery/vending/tool,
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "brl" = (
 /obj/machinery/vending/assist,
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "brm" = (
@@ -28829,24 +27435,21 @@
 	},
 /turf/open/floor{
 	dir = 4;
-	icon_state = "darkyellowcorners2";
-	tag = "icon-darkyellowcorners2 (NORTH)"
+	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "brn" = (
 /obj/machinery/floodlight,
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "bro" = (
 /obj/machinery/floodlight,
 /turf/open/floor{
 	dir = 5;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "brp" = (
@@ -28935,7 +27538,6 @@
 /area/desert_dam/interior/dam_interior/north_tunnel)
 "brB" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (NORTH)";
 	icon_state = "platform_deco";
 	dir = 1
 	},
@@ -29087,7 +27689,6 @@
 	dir = 5
 	},
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j1 (WEST)";
 	icon_state = "pipe-j1";
 	dir = 8
 	},
@@ -29103,7 +27704,6 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -29122,7 +27722,6 @@
 /area/desert_dam/interior/dam_interior/control_room)
 "brR" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -29145,7 +27744,6 @@
 /area/desert_dam/interior/dam_interior/control_room)
 "brS" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -29163,7 +27761,6 @@
 /area/desert_dam/interior/dam_interior/control_room)
 "brT" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -29187,7 +27784,6 @@
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -29205,7 +27801,6 @@
 /area/desert_dam/interior/dam_interior/control_room)
 "brV" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -29228,7 +27823,6 @@
 /area/desert_dam/interior/dam_interior/control_room)
 "brW" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -29250,7 +27844,6 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "brX" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -29268,7 +27861,6 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "brY" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -29286,7 +27878,6 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "brZ" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -29301,7 +27892,6 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "bsa" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -29318,15 +27908,13 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "bsb" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -29340,7 +27928,6 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "bsc" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -29357,7 +27944,6 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "bsd" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -29380,7 +27966,6 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -29398,7 +27983,6 @@
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "bsf" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -29408,7 +27992,6 @@
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "bsg" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -29416,18 +27999,15 @@
 	name = "\improper Atmospheric Storage"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "bsh" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
@@ -29435,24 +28015,20 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "bsj" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "bsk" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor{
-	tag = "icon-darkpurple2 (EAST)";
 	icon_state = "darkpurple2";
 	dir = 4
 	},
@@ -29504,20 +28080,17 @@
 	},
 /turf/open/floor{
 	dir = 10;
-	icon_state = "darkbrown2";
-	tag = "icon-darkbrown2"
+	icon_state = "darkbrown2"
 	},
 /area/desert_dam/building/mining/front_desk)
 "bss" = (
 /turf/open/floor{
-	tag = "icon-darkbrown2";
 	icon_state = "darkbrown2"
 	},
 /area/desert_dam/building/mining/front_desk)
 "bst" = (
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-darkbrown2";
 	icon_state = "darkbrown2"
 	},
 /area/desert_dam/building/mining/front_desk)
@@ -29525,8 +28098,7 @@
 /obj/machinery/conveyor{
 	dir = 6;
 	icon_state = "conveyor0";
-	id = "anomalybelt";
-	tag = "icon-conveyor0 (NORTHWEST)"
+	id = "anomalybelt"
 	},
 /turf/open/floor/plating,
 /area/desert_dam/building/mining/maintenance_east)
@@ -29538,8 +28110,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/desert_dam/building/mining/maintenance_east)
@@ -29553,7 +28124,6 @@
 "bsx" = (
 /obj/structure/largecrate/random/barrel/white,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
@@ -29563,7 +28133,6 @@
 	on = 1
 	},
 /turf/open/floor{
-	tag = "icon-darkbrown2 (WEST)";
 	icon_state = "darkbrown2";
 	dir = 8
 	},
@@ -29580,14 +28149,12 @@
 /area/desert_dam/interior/dam_interior/hangar_storage)
 "bsA" = (
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (EAST)";
 	icon_state = "darkbrowncorners2";
 	dir = 4
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
 "bsB" = (
 /turf/open/floor{
-	tag = "icon-darkbrown2 (NORTH)";
 	icon_state = "darkbrown2";
 	dir = 1
 	},
@@ -29623,8 +28190,7 @@
 "bsF" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/floor/plating{
 	dir = 1;
@@ -29649,7 +28215,6 @@
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "bsI" = (
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2 (WEST)";
 	icon_state = "darkyellowcorners2";
 	dir = 8
 	},
@@ -29669,19 +28234,16 @@
 "bsK" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2";
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/lobby)
 "bsL" = (
 /turf/open/floor{
-	tag = "icon-darkyellow2";
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
 "bsM" = (
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2 (WEST)";
 	icon_state = "darkyellowcorners2";
 	dir = 8
 	},
@@ -29690,8 +28252,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
@@ -29714,7 +28275,6 @@
 /area/desert_dam/interior/dam_interior/control_room)
 "bsP" = (
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2";
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
@@ -29724,7 +28284,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2";
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
@@ -29733,7 +28292,6 @@
 /obj/machinery/cell_charger,
 /obj/structure/cable,
 /turf/open/floor{
-	tag = "icon-darkyellow2";
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/control_room)
@@ -29748,7 +28306,6 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "bsT" = (
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2 (WEST)";
 	icon_state = "darkyellowcorners2";
 	dir = 8
 	},
@@ -29768,14 +28325,12 @@
 	name = "\improper Atmospheric Storage"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "bsW" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
@@ -29812,7 +28367,6 @@
 "btc" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/mining/boxing_room)
@@ -29821,7 +28375,6 @@
 	name = "\improper Mining Hallway"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/mining/boxing_room)
@@ -29834,7 +28387,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/mining/boxing_room)
@@ -29858,28 +28410,23 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/desert_dam/building/mining/maintenance_east)
 "btk" = (
 /obj/structure/cargo_container{
-	tag = "icon-gorg 0,0";
 	icon_state = "gorg 0,0"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
 "btl" = (
 /obj/structure/cargo_container{
-	tag = "icon-gorg 2,0";
 	icon_state = "gorg 2,0"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
@@ -29942,7 +28489,6 @@
 /area/desert_dam/interior/dam_interior/northwestern_tunnel)
 "btt" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -30015,13 +28561,11 @@
 "btE" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /turf/open/floor{
 	dir = 1;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "btF" = (
@@ -30045,8 +28589,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
@@ -30060,7 +28603,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
@@ -30071,7 +28613,6 @@
 "btJ" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
@@ -30116,7 +28657,6 @@
 	pixel_y = 0
 	},
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
@@ -30143,13 +28683,11 @@
 /obj/structure/table,
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	tag = "icon-tube1 (EAST)"
+	icon_state = "tube1"
 	},
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "btS" = (
@@ -30157,13 +28695,11 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2";
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "btT" = (
 /turf/open/floor{
-	tag = "icon-darkpurplecorners2 (WEST)";
 	icon_state = "darkpurplecorners2";
 	dir = 8
 	},
@@ -30184,7 +28720,6 @@
 /obj/item/storage/briefcase/inflatable,
 /obj/machinery/camera/autoname/almayer,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
@@ -30203,7 +28738,6 @@
 	},
 /obj/item/storage/briefcase/inflatable,
 /turf/open/floor{
-	tag = "icon-darkpurple2 (EAST)";
 	icon_state = "darkpurple2";
 	dir = 4
 	},
@@ -30222,7 +28756,6 @@
 "btY" = (
 /obj/structure/toilet,
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/mining/break_room)
@@ -30230,7 +28763,6 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor{
-	tag = "icon-whiteyellow (NORTHWEST)";
 	icon_state = "whiteyellow";
 	dir = 9
 	},
@@ -30238,36 +28770,31 @@
 "bua" = (
 /turf/open/floor{
 	dir = 1;
-	icon_state = "whiteyellow";
-	tag = "icon-whiteredcorner (NORTH)"
+	icon_state = "whiteyellow"
 	},
 /area/desert_dam/building/mining/break_room)
 "bub" = (
 /obj/machinery/vending/cola,
 /turf/open/floor{
 	dir = 1;
-	icon_state = "whiteyellow";
-	tag = "icon-whiteredcorner (NORTH)"
+	icon_state = "whiteyellow"
 	},
 /area/desert_dam/building/mining/break_room)
 "buc" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor{
-	tag = "icon-whiteyellow (NORTHEAST)";
 	icon_state = "whiteyellow";
 	dir = 5
 	},
 /area/desert_dam/building/mining/break_room)
 "bud" = (
 /turf/open/floor{
-	tag = "icon-darkbrown2 (WEST)";
 	icon_state = "darkbrown2";
 	dir = 8
 	},
 /area/desert_dam/building/mining/boxing_room)
 "bue" = (
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (WEST)";
 	icon_state = "darkbrowncorners2";
 	dir = 8
 	},
@@ -30281,13 +28808,11 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2";
 	icon_state = "darkbrowncorners2"
 	},
 /area/desert_dam/building/mining/boxing_room)
 "bug" = (
 /turf/open/floor{
-	tag = "icon-darkbrown2 (EAST)";
 	icon_state = "darkbrown2";
 	dir = 4
 	},
@@ -30304,8 +28829,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
 /area/desert_dam/building/mining/maintenance_east)
@@ -30336,13 +28860,11 @@
 "bun" = (
 /turf/open/floor{
 	dir = 9;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
 "buo" = (
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2 (NORTH)";
 	icon_state = "darkyellowcorners2";
 	dir = 1
 	},
@@ -30362,8 +28884,7 @@
 "buq" = (
 /turf/open/floor{
 	dir = 4;
-	icon_state = "darkyellowcorners2";
-	tag = "icon-darkyellowcorners2 (NORTH)"
+	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
 "bur" = (
@@ -30372,7 +28893,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -30380,7 +28900,6 @@
 "bus" = (
 /obj/structure/rack,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -30388,7 +28907,6 @@
 "but" = (
 /obj/structure/closet/secure_closet/engineering_welding,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -30399,14 +28917,12 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
 "buv" = (
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
@@ -30426,7 +28942,6 @@
 "buz" = (
 /obj/structure/filingcabinet,
 /turf/open/floor{
-	tag = "icon-whiteyellow (WEST)";
 	icon_state = "whiteyellow";
 	dir = 8
 	},
@@ -30439,7 +28954,6 @@
 /area/desert_dam/interior/dam_interior/lobby)
 "buB" = (
 /turf/open/floor{
-	tag = "icon-whiteyellowcorner (EAST)";
 	icon_state = "whiteyellowcorner";
 	dir = 4
 	},
@@ -30447,7 +28961,6 @@
 "buC" = (
 /obj/machinery/computer/security,
 /turf/open/floor{
-	tag = "icon-whiteyellow (NORTH)";
 	icon_state = "whiteyellow";
 	dir = 1
 	},
@@ -30458,7 +28971,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whiteyellow (NORTHEAST)";
 	icon_state = "whiteyellow";
 	dir = 5
 	},
@@ -30468,7 +28980,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
@@ -30482,7 +28993,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2 (WEST)";
 	icon_state = "darkyellow2";
 	dir = 8
 	},
@@ -30494,12 +29004,10 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
@@ -30507,8 +29015,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
@@ -30541,7 +29048,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
@@ -30583,7 +29089,6 @@
 "buN" = (
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
@@ -30592,13 +29097,11 @@
 /obj/structure/table,
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/engine_east_wing)
 "buP" = (
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
@@ -30608,29 +29111,25 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor{
 	dir = 10;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "buR" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/gas,
 /turf/open/floor{
-	tag = "icon-darkpurple2";
 	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "buS" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor{
-	tag = "icon-darkpurple2";
 	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "buT" = (
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor{
-	tag = "icon-darkpurple2";
 	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
@@ -30638,8 +29137,7 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor{
 	dir = 6;
-	icon_state = "darkpurple2";
-	tag = "icon-darkpurple2"
+	icon_state = "darkpurple2"
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "buV" = (
@@ -30653,14 +29151,12 @@
 "buX" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
-	pixel_x = 0;
-	tag = "icon-E-corner"
+	pixel_x = 0
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
 /area/desert_dam/interior/caves/central_caves/entrances/south_tunnel_entrance)
 "buY" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -30694,7 +29190,6 @@
 /area/desert_dam/exterior/river/riverside_northeast)
 "bvd" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (NORTH)";
 	icon_state = "platform_deco";
 	dir = 1
 	},
@@ -30711,14 +29206,12 @@
 	name = "\improper Toilet Unit"
 	},
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/mining/break_room)
 "bvg" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-whiteyellow (WEST)";
 	icon_state = "whiteyellow";
 	dir = 8
 	},
@@ -30730,7 +29223,6 @@
 /area/desert_dam/building/mining/break_room)
 "bvi" = (
 /turf/open/floor{
-	tag = "icon-whiteyellowcorner (EAST)";
 	icon_state = "whiteyellowcorner";
 	dir = 4
 	},
@@ -30743,7 +29235,6 @@
 /area/desert_dam/building/mining/break_room)
 "bvk" = (
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (NORTH)";
 	icon_state = "darkbrowncorners2";
 	dir = 1
 	},
@@ -30757,7 +29248,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (EAST)";
 	icon_state = "darkbrowncorners2";
 	dir = 4
 	},
@@ -30766,8 +29256,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/almayer/maint{
 	dir = 2;
@@ -30785,43 +29274,35 @@
 /area/desert_dam/building/mining/boxing_room)
 "bvo" = (
 /obj/structure/cargo_container{
-	tag = "icon-green 0,0";
 	icon_state = "green 0,0"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
 "bvp" = (
 /obj/structure/cargo_container{
-	tag = "icon-green 1,0";
 	icon_state = "green 1,0"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
 "bvq" = (
 /obj/structure/cargo_container{
-	tag = "icon-green 2,0";
 	icon_state = "green 2,0"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
 "bvr" = (
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2";
 	icon_state = "darkbrowncorners2"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
 "bvs" = (
 /turf/open/floor{
-	tag = "icon-darkbrown2";
 	icon_state = "darkbrown2"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
@@ -30884,20 +29365,17 @@
 "bvz" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
 	icon_state = "tube1";
 	dir = 8
 	},
 /obj/item/clothing/glasses/welding,
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
 "bvA" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
@@ -30907,7 +29385,6 @@
 	icon_state = "tube1"
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
@@ -30922,7 +29399,6 @@
 /area/desert_dam/interior/dam_interior/northeastern_tunnel)
 "bvE" = (
 /turf/open/floor{
-	tag = "icon-whiteyellow (WEST)";
 	icon_state = "whiteyellow";
 	dir = 8
 	},
@@ -30947,13 +29423,11 @@
 	},
 /turf/open/floor{
 	dir = 4;
-	icon_state = "whiteyellow";
-	tag = "icon-whiteredcorner (NORTH)"
+	icon_state = "whiteyellow"
 	},
 /area/desert_dam/interior/dam_interior/lobby)
 "bvI" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/lobby)
@@ -30961,19 +29435,16 @@
 /obj/structure/bed/stool,
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
 "bvK" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
@@ -31013,7 +29484,6 @@
 /area/desert_dam/interior/dam_interior/smes_backup)
 "bvN" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
@@ -31057,7 +29527,6 @@
 /area/desert_dam/building/construction_site)
 "bvV" = (
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/mining/break_room)
@@ -31066,7 +29535,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/mining/break_room)
@@ -31078,13 +29546,11 @@
 	},
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
 "bvY" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -31101,7 +29567,6 @@
 /area/desert_dam/building/mining/break_room)
 "bvZ" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -31118,7 +29583,6 @@
 /area/desert_dam/building/mining/break_room)
 "bwa" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -31133,7 +29597,6 @@
 /area/desert_dam/building/mining/break_room)
 "bwb" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -31145,14 +29608,12 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-darkbrown2 (WEST)";
 	icon_state = "darkbrown2";
 	dir = 8
 	},
 /area/desert_dam/building/mining/boxing_room)
 "bwc" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -31164,7 +29625,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (WEST)";
 	icon_state = "darkbrowncorners2";
 	dir = 8
 	},
@@ -31186,13 +29646,11 @@
 	},
 /obj/structure/disposalpipe/junction,
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2";
 	icon_state = "darkbrowncorners2"
 	},
 /area/desert_dam/building/mining/boxing_room)
 "bwe" = (
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (EAST)";
 	icon_state = "darkbrowncorners2";
 	dir = 4
 	},
@@ -31202,7 +29660,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-darkbrown2 (NORTH)";
 	icon_state = "darkbrown2";
 	dir = 1
 	},
@@ -31221,32 +29678,27 @@
 	},
 /turf/open/floor{
 	dir = 1;
-	icon_state = "whiteyellowcorner";
-	tag = "icon-whiteyellowcorner (EAST)"
+	icon_state = "whiteyellowcorner"
 	},
 /area/desert_dam/building/mining/break_room)
 "bwh" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/open/floor{
-	tag = "icon-darkbrown2 (NORTH)";
 	icon_state = "darkbrown2";
 	dir = 1
 	},
 /area/desert_dam/building/mining/boxing_room)
 "bwi" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "E";
-	tag = "icon-W"
+	icon_state = "E"
 	},
 /turf/open/floor{
 	dir = 5;
-	icon_state = "darkbrown2";
-	tag = "icon-darkbrown2"
+	icon_state = "darkbrown2"
 	},
 /area/desert_dam/building/mining/boxing_room)
 "bwj" = (
@@ -31263,21 +29715,18 @@
 	pixel_y = 0
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
 "bwl" = (
 /obj/structure/largecrate/random/case,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
 "bwm" = (
 /obj/structure/table/almayer,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
@@ -31287,7 +29736,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hangar_storage)
@@ -31332,7 +29780,6 @@
 /area/desert_dam/interior/dam_interior/north_tunnel)
 "bwt" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -31344,8 +29791,7 @@
 "bwu" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/floor/plating{
 	dir = 1;
@@ -31361,14 +29807,12 @@
 /obj/effect/spawner/random/technology_scanner,
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
 "bwx" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
@@ -31384,8 +29828,7 @@
 	},
 /turf/open/floor{
 	dir = 4;
-	icon_state = "whiteyellow";
-	tag = "icon-whiteredcorner (NORTH)"
+	icon_state = "whiteyellow"
 	},
 /area/desert_dam/interior/dam_interior/lobby)
 "bwA" = (
@@ -31396,7 +29839,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
@@ -31409,22 +29851,19 @@
 	},
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
 "bwC" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
@@ -31436,7 +29875,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
@@ -31444,7 +29882,6 @@
 /obj/machinery/power/terminal,
 /obj/structure/cable/yellow,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
@@ -31481,7 +29918,6 @@
 	name = "\improper Restroom"
 	},
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/mining/break_room)
@@ -31507,25 +29943,21 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (EAST)";
 	icon_state = "darkbrowncorners2";
 	dir = 4
 	},
 /area/desert_dam/building/mining/boxing_room)
 "bwO" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/mining/boxing_room)
 "bwP" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -31537,15 +29969,13 @@
 /area/desert_dam/building/mining/boxing_room)
 "bwQ" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/open/floor{
 	icon_state = "vault";
@@ -31556,8 +29986,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/open/floor{
 	icon_state = "vault";
@@ -31566,11 +29995,9 @@
 /area/desert_dam/building/mining/boxing_room)
 "bwS" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "E";
-	tag = "icon-W"
+	icon_state = "E"
 	},
 /turf/open/floor{
-	tag = "icon-darkbrown2 (EAST)";
 	icon_state = "darkbrown2";
 	dir = 4
 	},
@@ -31581,7 +30008,6 @@
 	name = "\improper Workshop"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -31614,8 +30040,7 @@
 /obj/item/lightreplacer,
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
 "bwY" = (
@@ -31666,42 +30091,36 @@
 /obj/structure/table,
 /turf/open/floor{
 	dir = 10;
-	icon_state = "whiteyellow";
-	tag = "icon-whiteredcorner (NORTH)"
+	icon_state = "whiteyellow"
 	},
 /area/desert_dam/interior/dam_interior/lobby)
 "bxf" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
-	tag = "icon-pipe-t (NORTH)";
 	icon_state = "pipe-t";
 	dir = 1
 	},
 /turf/open/floor{
 	dir = 2;
-	icon_state = "whiteyellow";
-	tag = "icon-whiteredcorner (NORTH)"
+	icon_state = "whiteyellow"
 	},
 /area/desert_dam/interior/dam_interior/lobby)
 "bxg" = (
 /obj/structure/table,
 /turf/open/floor{
 	dir = 2;
-	icon_state = "whiteyellow";
-	tag = "icon-whiteredcorner (NORTH)"
+	icon_state = "whiteyellow"
 	},
 /area/desert_dam/interior/dam_interior/lobby)
 "bxh" = (
 /obj/structure/flora/pottedplant,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (WEST)";
 	icon_state = "darkyellow2";
 	dir = 8
 	},
 /area/desert_dam/interior/dam_interior/lobby)
 "bxi" = (
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2";
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/lobby)
@@ -31709,8 +30128,7 @@
 /obj/structure/flora/pottedplant,
 /turf/open/floor{
 	dir = 6;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/lobby)
 "bxk" = (
@@ -31718,8 +30136,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
 "bxl" = (
@@ -31729,7 +30146,6 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
@@ -31744,13 +30160,11 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
 "bxn" = (
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2";
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
@@ -31811,7 +30225,6 @@
 	pixel_y = 0
 	},
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/mining/break_room)
@@ -31821,13 +30234,11 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	tag = "icon-tube1 (EAST)"
+	icon_state = "tube1"
 	},
 /turf/open/floor{
 	dir = 8;
-	icon_state = "whiteyellowcorner";
-	tag = "icon-whiteyellowcorner (EAST)"
+	icon_state = "whiteyellowcorner"
 	},
 /area/desert_dam/building/mining/break_room)
 "bxw" = (
@@ -31846,19 +30257,16 @@
 /area/desert_dam/building/mining/break_room)
 "bxy" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
 	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor{
 	dir = 2;
-	icon_state = "whiteyellowcorner";
-	tag = "icon-whiteyellowcorner (EAST)"
+	icon_state = "whiteyellowcorner"
 	},
 /area/desert_dam/building/mining/break_room)
 "bxz" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/mining/boxing_room)
@@ -31887,7 +30295,6 @@
 /area/desert_dam/interior/dam_interior/workshop)
 "bxE" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -31896,7 +30303,6 @@
 	layer = 2.4
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -31941,7 +30347,6 @@
 /area/desert_dam/interior/dam_interior/northwestern_tunnel)
 "bxK" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -31954,8 +30359,7 @@
 /obj/structure/table/reinforced,
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
 "bxN" = (
@@ -32040,7 +30444,6 @@
 "bxV" = (
 /obj/machinery/door/airlock/multi_tile/almayer/generic,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/lobby)
@@ -32052,7 +30455,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/lobby)
@@ -32067,14 +30469,12 @@
 	pixel_y = 0
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2 (SOUTHWEST)";
 	icon_state = "darkyellow2";
 	dir = 10
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
 "bxY" = (
 /turf/open/floor{
-	tag = "icon-darkyellow2";
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
@@ -32084,7 +30484,6 @@
 	amount = 50
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2";
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/smes_backup)
@@ -32094,7 +30493,6 @@
 	icon_state = "tube1"
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2 (SOUTHEAST)";
 	icon_state = "darkyellow2";
 	dir = 6
 	},
@@ -32136,7 +30534,6 @@
 "byh" = (
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/mining/break_room)
@@ -32146,14 +30543,12 @@
 	},
 /turf/open/floor{
 	dir = 10;
-	icon_state = "whiteyellow";
-	tag = "icon-whiteredcorner (NORTH)"
+	icon_state = "whiteyellow"
 	},
 /area/desert_dam/building/mining/break_room)
 "byj" = (
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-whiteyellow";
 	icon_state = "whiteyellow";
 	dir = 2
 	},
@@ -32163,14 +30558,12 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whiteyellow";
 	icon_state = "whiteyellow";
 	dir = 2
 	},
 /area/desert_dam/building/mining/break_room)
 "byl" = (
 /turf/open/floor{
-	tag = "icon-whiteyellow (SOUTHEAST)";
 	icon_state = "whiteyellow";
 	dir = 6
 	},
@@ -32182,7 +30575,6 @@
 	pixel_y = 0
 	},
 /turf/open/floor{
-	tag = "icon-darkbrown2 (WEST)";
 	icon_state = "darkbrown2";
 	dir = 8
 	},
@@ -32198,7 +30590,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (EAST)";
 	icon_state = "darkbrowncorners2";
 	dir = 4
 	},
@@ -32209,7 +30600,6 @@
 	on = 1
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/mining/boxing_room)
@@ -32235,14 +30625,12 @@
 /area/desert_dam/interior/dam_interior/workshop)
 "byt" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
 /area/desert_dam/interior/dam_interior/north_tunnel)
 "byu" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -32254,8 +30642,7 @@
 	},
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
 "byw" = (
@@ -32354,14 +30741,12 @@
 /area/desert_dam/interior/dam_interior/central_tunnel)
 "byJ" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
 	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
 "byK" = (
@@ -32370,8 +30755,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/open/floor{
 	dir = 5;
@@ -32381,14 +30765,12 @@
 "byL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
 "byM" = (
 /obj/structure/bed/chair/office/light,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
@@ -32396,7 +30778,6 @@
 /obj/structure/table/reinforced,
 /obj/item/assembly/prox_sensor,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
@@ -32423,7 +30804,6 @@
 /area/desert_dam/exterior/river/riverside_central_south)
 "byR" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -32432,8 +30812,7 @@
 "byS" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/ground/desertdam/river/toxic/shallow_edge_toxic{
 	icon_state = "shallow_to_deep_toxic_water3"
@@ -32471,15 +30850,13 @@
 	},
 /turf/open/floor{
 	dir = 9;
-	icon_state = "darkbrown2";
-	tag = "icon-darkbrown2"
+	icon_state = "darkbrown2"
 	},
 /area/desert_dam/building/mining/locker_room)
 "byY" = (
 /obj/structure/table/reinforced,
 /obj/structure/bedsheetbin,
 /turf/open/floor{
-	tag = "icon-darkbrown2 (NORTH)";
 	icon_state = "darkbrown2";
 	dir = 1
 	},
@@ -32487,7 +30864,6 @@
 "byZ" = (
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-darkbrown2 (NORTH)";
 	icon_state = "darkbrown2";
 	dir = 1
 	},
@@ -32500,7 +30876,6 @@
 	},
 /obj/machinery/power/apc/drained,
 /turf/open/floor{
-	tag = "icon-darkbrown2 (NORTH)";
 	icon_state = "darkbrown2";
 	dir = 1
 	},
@@ -32508,7 +30883,6 @@
 "bzb" = (
 /obj/structure/closet/secure_closet/cargotech,
 /turf/open/floor{
-	tag = "icon-darkbrown2 (NORTH)";
 	icon_state = "darkbrown2";
 	dir = 1
 	},
@@ -32516,34 +30890,28 @@
 "bzc" = (
 /obj/structure/closet/secure_closet/cargotech,
 /turf/open/floor{
-	tag = "icon-darkbrown2";
 	icon_state = "darkbrown2"
 	},
 /area/desert_dam/building/mining/locker_room)
 "bzd" = (
 /obj/structure/closet/secure_closet/cargotech,
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
 	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-darkbrown2 (NORTH)";
 	icon_state = "darkbrown2";
 	dir = 1
 	},
 /area/desert_dam/building/mining/locker_room)
 "bze" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "E";
-	tag = "icon-W"
+	icon_state = "E"
 	},
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /turf/open/floor{
-	tag = "icon-darkbrown2 (EAST)";
 	icon_state = "darkbrown2";
 	dir = 4
 	},
@@ -32603,7 +30971,6 @@
 /area/desert_dam/interior/dam_interior/central_tunnel)
 "bzm" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (NORTH)";
 	icon_state = "platform_deco";
 	dir = 1
 	},
@@ -32625,26 +30992,22 @@
 "bzo" = (
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
 "bzp" = (
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2";
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
 "bzq" = (
 /turf/open/floor{
-	tag = "icon-darkyellow2";
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
 "bzr" = (
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-darkyellow2";
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
@@ -32655,7 +31018,6 @@
 	amount = 30
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2";
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
@@ -32664,7 +31026,6 @@
 	icon_state = "box_1"
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2";
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
@@ -32672,14 +31033,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/constructable_frame,
 /turf/open/floor{
-	tag = "icon-darkyellow2";
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
 "bzv" = (
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-darkyellow2";
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
@@ -32690,7 +31049,6 @@
 	},
 /obj/effect/spawner/random/tool,
 /turf/open/floor{
-	tag = "icon-darkyellow2";
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
@@ -32699,8 +31057,7 @@
 /obj/item/multitool,
 /turf/open/floor{
 	dir = 6;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
 "bzy" = (
@@ -32761,14 +31118,12 @@
 /area/desert_dam/building/mining/locker_room)
 "bzI" = (
 /turf/open/floor{
-	tag = "icon-darkbrown2 (WEST)";
 	icon_state = "darkbrown2";
 	dir = 8
 	},
 /area/desert_dam/building/mining/locker_room)
 "bzJ" = (
 /turf/open/floor{
-	tag = "icon-darkbrown2";
 	icon_state = "darkbrown2"
 	},
 /area/desert_dam/building/mining/locker_room)
@@ -32779,24 +31134,20 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor{
-	tag = "icon-darkbrown2";
 	icon_state = "darkbrown2"
 	},
 /area/desert_dam/building/mining/locker_room)
 "bzL" = (
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2";
 	icon_state = "darkbrowncorners2"
 	},
 /area/desert_dam/building/mining/boxing_room)
 "bzM" = (
 /obj/machinery/conveyor_switch,
 /obj/effect/decal/warning_stripes{
-	icon_state = "E";
-	tag = "icon-W"
+	icon_state = "E"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/mining/boxing_room)
@@ -32804,8 +31155,7 @@
 /obj/machinery/conveyor{
 	dir = 5;
 	icon_state = "conveyor0";
-	id = "anomalybelt";
-	tag = "icon-conveyor0 (NORTHWEST)"
+	id = "anomalybelt"
 	},
 /turf/open/floor{
 	icon_state = "vault";
@@ -32816,8 +31166,7 @@
 /obj/machinery/conveyor{
 	dir = 10;
 	icon_state = "conveyor0";
-	id = "anomalybelt";
-	tag = "icon-conveyor0 (NORTHWEST)"
+	id = "anomalybelt"
 	},
 /turf/open/floor{
 	icon_state = "vault";
@@ -32841,7 +31190,6 @@
 	name = "\improper Workshop"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -32933,13 +31281,11 @@
 	},
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
 "bAf" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -32965,8 +31311,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/open/floor{
 	dir = 5;
@@ -32975,12 +31320,10 @@
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
 "bAh" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
 /turf/open/floor{
-	tag = "icon-darkbrown2 (NORTH)";
 	icon_state = "darkbrown2";
 	dir = 1
 	},
@@ -33005,7 +31348,6 @@
 "bAk" = (
 /obj/structure/desertdam/decals/road_edge,
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -33122,18 +31464,15 @@
 /area/desert_dam/exterior/valley/valley_north_east)
 "bAD" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/mining/locker_room)
 "bAE" = (
 /obj/item/stool,
 /obj/effect/decal/warning_stripes{
-	icon_state = "E";
-	tag = "icon-W"
+	icon_state = "E"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/mining/boxing_room)
@@ -33174,7 +31513,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
@@ -33231,26 +31569,22 @@
 	name = "Main Power Grid Monitoring"
 	},
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
 	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor{
 	dir = 9;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/CE_office)
 "bAU" = (
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
 /area/desert_dam/interior/dam_interior/CE_office)
 "bAV" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
@@ -33258,7 +31592,6 @@
 /area/desert_dam/interior/dam_interior/workshop)
 "bAW" = (
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -33271,7 +31604,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2 (NORTH)";
 	icon_state = "darkyellowcorners2";
 	dir = 1
 	},
@@ -33286,21 +31618,18 @@
 "bAZ" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
 "bBa" = (
 /obj/machinery/washing_machine,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
 "bBb" = (
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
@@ -33388,7 +31717,6 @@
 	on = 1
 	},
 /turf/open/floor{
-	tag = "icon-darkbrown2";
 	icon_state = "darkbrown2"
 	},
 /area/desert_dam/building/mining/locker_room)
@@ -33396,21 +31724,18 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4;
 	layer = 2.4
 	},
 /turf/open/floor{
-	tag = "icon-darkbrown2";
 	icon_state = "darkbrown2"
 	},
 /area/desert_dam/building/mining/locker_room)
 "bBp" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -33419,13 +31744,11 @@
 	layer = 2.4
 	},
 /turf/open/floor{
-	tag = "icon-darkbrown2";
 	icon_state = "darkbrown2"
 	},
 /area/desert_dam/building/mining/locker_room)
 "bBq" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -33438,7 +31761,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor{
-	tag = "icon-darkbrown2";
 	icon_state = "darkbrown2"
 	},
 /area/desert_dam/building/mining/locker_room)
@@ -33448,7 +31770,6 @@
 	name = "\improper Locker Room"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -33460,13 +31781,11 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/mining/locker_room)
 "bBs" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -33478,7 +31797,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/mining/boxing_room)
@@ -33498,7 +31816,6 @@
 	},
 /obj/structure/disposalpipe/junction,
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2";
 	icon_state = "darkbrowncorners2"
 	},
 /area/desert_dam/building/mining/boxing_room)
@@ -33535,14 +31852,12 @@
 	icon_state = "tube1"
 	},
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
 /turf/open/floor{
 	dir = 5;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/CE_office)
 "bBA" = (
@@ -33565,14 +31880,12 @@
 "bBD" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /turf/open/floor,
 /area/desert_dam/interior/dam_interior/western_dam_cave)
 "bBE" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -33604,8 +31917,7 @@
 "bBI" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
-	pixel_x = 0;
-	tag = "icon-E-corner"
+	pixel_x = 0
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
 /area/desert_dam/interior/dam_interior/west_tunnel)
@@ -33617,13 +31929,11 @@
 "bBK" = (
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/CE_office)
 "bBL" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/CE_office)
@@ -33631,7 +31941,6 @@
 /obj/structure/table/almayer,
 /obj/machinery/computer/emails,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/CE_office)
@@ -33643,8 +31952,7 @@
 	},
 /turf/open/floor{
 	dir = 4;
-	icon_state = "darkyellowcorners2";
-	tag = "icon-darkyellowcorners2 (NORTH)"
+	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/CE_office)
 "bBO" = (
@@ -33758,19 +32066,16 @@
 "bCd" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	tag = "icon-tube1 (EAST)"
+	icon_state = "tube1"
 	},
 /turf/open/floor{
 	dir = 10;
-	icon_state = "darkbrown2";
-	tag = "icon-darkbrown2"
+	icon_state = "darkbrown2"
 	},
 /area/desert_dam/building/mining/locker_room)
 "bCe" = (
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-darkbrown2";
 	icon_state = "darkbrown2"
 	},
 /area/desert_dam/building/mining/locker_room)
@@ -33780,22 +32085,18 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
 	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-darkbrown2";
 	icon_state = "darkbrown2"
 	},
 /area/desert_dam/building/mining/locker_room)
 "bCg" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "E";
-	tag = "icon-W"
+	icon_state = "E"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/mining/boxing_room)
@@ -33804,7 +32105,6 @@
 	id = "anomalybelt"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/mining/boxing_room)
@@ -33914,7 +32214,6 @@
 	layer = 3.25
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/CE_office)
@@ -33924,7 +32223,6 @@
 /obj/item/tool/pen,
 /obj/item/folder/black,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/CE_office)
@@ -33937,7 +32235,6 @@
 	on = 1
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/CE_office)
@@ -33956,7 +32253,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/CE_office)
@@ -33965,7 +32261,6 @@
 	name = "\improper CE Office"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -33980,7 +32275,6 @@
 /area/desert_dam/interior/dam_interior/CE_office)
 "bCA" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -34005,8 +32299,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -34065,7 +32358,6 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "bCH" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -34075,7 +32367,6 @@
 /area/desert_dam/exterior/river/riverside_central_south)
 "bCJ" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -34097,7 +32388,6 @@
 	name = "\improper Showers"
 	},
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/mining/locker_room)
@@ -34133,7 +32423,6 @@
 /area/desert_dam/interior/dam_interior/western_dam_cave)
 "bCS" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -34146,11 +32435,9 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -34165,7 +32452,6 @@
 	name = "\improper Workshop"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -34176,7 +32462,6 @@
 /area/desert_dam/interior/dam_interior/workshop)
 "bCV" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -34187,7 +32472,6 @@
 /area/desert_dam/interior/dam_interior/workshop)
 "bCW" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -34205,7 +32489,6 @@
 /area/desert_dam/interior/dam_interior/workshop)
 "bCX" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -34223,7 +32506,6 @@
 /area/desert_dam/interior/dam_interior/workshop)
 "bCY" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -34242,7 +32524,6 @@
 /area/desert_dam/interior/dam_interior/workshop)
 "bCZ" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -34262,7 +32543,6 @@
 	icon_state = "1-4"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -34320,7 +32600,6 @@
 /obj/structure/table/almayer,
 /obj/item/storage/fancy/cigarettes/kpack,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/CE_office)
@@ -34329,14 +32608,12 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/CE_office)
 "bDi" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2";
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/CE_office)
@@ -34348,7 +32625,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (NORTH)";
 	icon_state = "pipe-c";
 	dir = 1
 	},
@@ -34367,18 +32643,15 @@
 "bDl" = (
 /obj/structure/table,
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2";
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
 "bDm" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
 	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
@@ -34388,7 +32661,6 @@
 	icon_state = "tube1"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
@@ -34408,7 +32680,6 @@
 "bDr" = (
 /obj/structure/desertdam/decals/road_edge,
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (NORTH)";
 	icon_state = "pipe-c";
 	dir = 1
 	},
@@ -34440,7 +32711,6 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "bDu" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -34451,11 +32721,9 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "bDv" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -34466,7 +32734,6 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "bDw" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -34477,7 +32744,6 @@
 /area/desert_dam/exterior/river/riverside_central_south)
 "bDx" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -34488,11 +32754,9 @@
 /area/desert_dam/exterior/river/riverside_central_south)
 "bDy" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -34525,20 +32789,17 @@
 /area/desert_dam/exterior/valley/valley_north_east)
 "bDC" = (
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/mining/locker_room)
 "bDD" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/mining/locker_room)
 "bDE" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/mining/loading_room)
@@ -34547,20 +32808,17 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-darkbrown2 (WEST)";
 	icon_state = "darkbrown2";
 	dir = 8
 	},
 /area/desert_dam/building/mining/loading_room)
 "bDG" = (
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2";
 	icon_state = "darkbrowncorners2"
 	},
 /area/desert_dam/building/mining/loading_room)
 "bDH" = (
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (WEST)";
 	icon_state = "darkbrowncorners2";
 	dir = 8
 	},
@@ -34574,7 +32832,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2";
 	icon_state = "darkbrowncorners2"
 	},
 /area/desert_dam/building/mining/loading_room)
@@ -34599,14 +32856,12 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-darkbrown2 (NORTH)";
 	icon_state = "darkbrown2";
 	dir = 1
 	},
 /area/desert_dam/building/mining/loading_room)
 "bDM" = (
 /turf/open/floor{
-	tag = "icon-darkbrown2 (NORTH)";
 	icon_state = "darkbrown2";
 	dir = 1
 	},
@@ -34614,8 +32869,7 @@
 "bDN" = (
 /turf/open/floor{
 	dir = 5;
-	icon_state = "darkbrown2";
-	tag = "icon-darkbrown2"
+	icon_state = "darkbrown2"
 	},
 /area/desert_dam/building/mining/loading_room)
 "bDO" = (
@@ -34688,19 +32942,16 @@
 /area/desert_dam/interior/dam_interior/central_tunnel)
 "bDX" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
 	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor{
 	dir = 10;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/CE_office)
 "bDY" = (
 /turf/open/floor{
-	tag = "icon-darkyellow2";
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/CE_office)
@@ -34715,13 +32966,11 @@
 	},
 /turf/open/floor{
 	dir = 6;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/CE_office)
 "bEa" = (
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2 (WEST)";
 	icon_state = "darkyellowcorners2";
 	dir = 8
 	},
@@ -34746,8 +32995,7 @@
 /obj/structure/table,
 /turf/open/floor{
 	dir = 6;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
 "bEd" = (
@@ -34773,14 +33021,12 @@
 "bEh" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
-	pixel_x = 0;
-	tag = "icon-E-corner"
+	pixel_x = 0
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
 /area/desert_dam/exterior/valley/valley_south_west)
 "bEi" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /obj/structure/cable{
@@ -34843,21 +33089,18 @@
 /area/desert_dam/exterior/valley/valley_north_east)
 "bEq" = (
 /obj/structure/cargo_container{
-	tag = "icon-blue 0,0";
 	icon_state = "blue 0,0"
 	},
 /turf/open/floor,
 /area/desert_dam/exterior/valley/valley_north_east)
 "bEr" = (
 /obj/structure/cargo_container{
-	tag = "icon-blue 1,0";
 	icon_state = "blue 1,0"
 	},
 /turf/open/floor,
 /area/desert_dam/exterior/valley/valley_north_east)
 "bEs" = (
 /obj/structure/cargo_container{
-	tag = "icon-blue 2,0";
 	icon_state = "blue 2,0"
 	},
 /turf/open/floor,
@@ -34869,7 +33112,6 @@
 	pixel_y = 0
 	},
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/mining/locker_room)
@@ -34878,7 +33120,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/mining/locker_room)
@@ -34888,20 +33129,17 @@
 	},
 /obj/item/stack/sheet/metal,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/mining/loading_room)
 "bEw" = (
 /turf/open/floor{
-	tag = "icon-darkbrown2 (WEST)";
 	icon_state = "darkbrown2";
 	dir = 8
 	},
 /area/desert_dam/building/mining/loading_room)
 "bEx" = (
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (EAST)";
 	icon_state = "darkbrowncorners2";
 	dir = 4
 	},
@@ -34912,7 +33150,6 @@
 	on = 1
 	},
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (NORTH)";
 	icon_state = "darkbrowncorners2";
 	dir = 1
 	},
@@ -34921,8 +33158,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /obj/structure/disposalpipe/segment{
@@ -34930,14 +33166,12 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (EAST)";
 	icon_state = "darkbrowncorners2";
 	dir = 4
 	},
 /area/desert_dam/building/mining/loading_room)
 "bEA" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -34949,14 +33183,12 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (NORTH)";
 	icon_state = "darkbrowncorners2";
 	dir = 1
 	},
 /area/desert_dam/building/mining/loading_room)
 "bEB" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -34968,7 +33200,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (EAST)";
 	icon_state = "darkbrowncorners2";
 	dir = 4
 	},
@@ -34992,21 +33223,18 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (NORTH)";
 	icon_state = "darkbrowncorners2";
 	dir = 1
 	},
 /area/desert_dam/building/mining/loading_room)
 "bED" = (
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (NORTH)";
 	icon_state = "darkbrowncorners2";
 	dir = 1
 	},
 /area/desert_dam/building/mining/loading_room)
 "bEE" = (
 /turf/open/floor{
-	tag = "icon-darkbrown2 (EAST)";
 	icon_state = "darkbrown2";
 	dir = 4
 	},
@@ -35053,7 +33281,6 @@
 /area/desert_dam/interior/dam_interior/workshop)
 "bEL" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -35072,7 +33299,6 @@
 /area/desert_dam/interior/dam_interior/workshop)
 "bEM" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -35090,7 +33316,6 @@
 /area/desert_dam/interior/dam_interior/west_tunnel)
 "bEN" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -35175,7 +33400,6 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "bEU" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /obj/structure/cable{
@@ -35196,22 +33420,19 @@
 /area/desert_dam/exterior/valley/valley_north_east)
 "bEW" = (
 /obj/structure/cargo_container{
-	icon_state = "HD 1,0";
-	tag = "icon-WY 2,0"
+	icon_state = "HD 1,0"
 	},
 /turf/open/floor,
 /area/desert_dam/exterior/valley/valley_north_east)
 "bEX" = (
 /obj/structure/cargo_container{
-	icon_state = "HD 2,0";
-	tag = "icon-WY 2,0"
+	icon_state = "HD 2,0"
 	},
 /turf/open/floor,
 /area/desert_dam/exterior/valley/valley_north_east)
 "bEY" = (
 /obj/structure/cargo_container{
-	icon_state = "HD 3,0";
-	tag = "icon-WY 2,0"
+	icon_state = "HD 3,0"
 	},
 /turf/open/floor,
 /area/desert_dam/exterior/valley/valley_north_east)
@@ -35225,7 +33446,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/mining/locker_room)
@@ -35238,7 +33458,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (WEST)";
 	icon_state = "darkbrowncorners2";
 	dir = 8
 	},
@@ -35289,7 +33508,6 @@
 /area/desert_dam/interior/dam_interior/workshop)
 "bFk" = (
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (NORTH)";
 	icon_state = "pipe-c";
 	dir = 1
 	},
@@ -35349,11 +33567,9 @@
 "bFr" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (WEST)";
 	icon_state = "darkbrowncorners2";
 	dir = 8
 	},
@@ -35495,7 +33711,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2 (NORTH)";
 	icon_state = "darkbrowncorners2";
 	dir = 1
 	},
@@ -35554,7 +33769,6 @@
 /area/desert_dam/interior/dam_interior/west_tunnel)
 "bFQ" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -35574,7 +33788,6 @@
 	dir = 1
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -35588,12 +33801,10 @@
 /area/desert_dam/interior/dam_interior/west_tunnel)
 "bFS" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -35607,7 +33818,6 @@
 /area/desert_dam/interior/dam_interior/west_tunnel)
 "bFT" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -35620,7 +33830,6 @@
 /area/desert_dam/interior/dam_interior/west_tunnel)
 "bFU" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -35638,7 +33847,6 @@
 /area/desert_dam/interior/dam_interior/central_tunnel)
 "bFV" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -35652,11 +33860,9 @@
 "bFW" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -35676,7 +33882,6 @@
 	dir = 1
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -35690,7 +33895,6 @@
 /area/desert_dam/interior/dam_interior/central_tunnel)
 "bFY" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -35704,7 +33908,6 @@
 /area/desert_dam/interior/dam_interior/central_tunnel)
 "bFZ" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -35722,7 +33925,6 @@
 /area/desert_dam/interior/dam_interior/central_tunnel)
 "bGa" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -35744,7 +33946,6 @@
 /area/desert_dam/interior/dam_interior/central_tunnel)
 "bGb" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -35768,7 +33969,6 @@
 /area/desert_dam/interior/dam_interior/central_tunnel)
 "bGc" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -35788,14 +33988,12 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /obj/structure/disposalpipe/segment{
@@ -35808,7 +34006,6 @@
 /area/desert_dam/interior/dam_interior/central_tunnel)
 "bGe" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -35817,7 +34014,6 @@
 	layer = 2.4
 	},
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j1 (WEST)";
 	icon_state = "pipe-j1";
 	dir = 8
 	},
@@ -35955,7 +34151,6 @@
 /area/desert_dam/interior/dam_interior/west_tunnel)
 "bGy" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (NORTH)";
 	icon_state = "platform_deco";
 	dir = 1
 	},
@@ -36060,8 +34255,7 @@
 "bGL" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/ground/desertdam/river/toxic/shallow_edge_toxic{
 	icon_state = "shallow_to_deep_toxic_water2"
@@ -36123,7 +34317,6 @@
 /area/desert_dam/exterior/river/riverside_east)
 "bGT" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -36134,8 +34327,7 @@
 "bGU" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/floor/plating/ground/desertdam/desert{
 	icon_state = "desert3"
@@ -36207,7 +34399,6 @@
 /area/desert_dam/exterior/river/riverside_east)
 "bHd" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -36217,7 +34408,6 @@
 /area/desert_dam/exterior/river/riverside_east)
 "bHe" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -36228,8 +34418,7 @@
 "bHf" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/ground/desertdam/river/toxic/shallow_edge_toxic{
 	icon_state = "shallow_to_deep_toxic_water2"
@@ -36267,22 +34456,19 @@
 /area/desert_dam/exterior/valley/valley_north_east)
 "bHk" = (
 /obj/structure/cargo_container{
-	icon_state = "ch_red 0,0";
-	tag = "icon-WY 2,0"
+	icon_state = "ch_red 0,0"
 	},
 /turf/open/floor,
 /area/desert_dam/exterior/valley/valley_north_east)
 "bHl" = (
 /obj/structure/cargo_container{
-	icon_state = "ch_red 0,1";
-	tag = "icon-WY 2,0"
+	icon_state = "ch_red 0,1"
 	},
 /turf/open/floor,
 /area/desert_dam/exterior/valley/valley_north_east)
 "bHm" = (
 /obj/structure/cargo_container{
-	icon_state = "ch_red 0,2";
-	tag = "icon-WY 2,0"
+	icon_state = "ch_red 0,2"
 	},
 /turf/open/floor,
 /area/desert_dam/exterior/valley/valley_north_east)
@@ -36294,13 +34480,11 @@
 	layer = 2.5
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/mining/loading_room)
 "bHo" = (
 /turf/open/floor{
-	tag = "icon-darkbrown2";
 	icon_state = "darkbrown2"
 	},
 /area/desert_dam/building/mining/loading_room)
@@ -36313,7 +34497,6 @@
 /area/desert_dam/interior/dam_interior/disposals)
 "bHr" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
@@ -36328,8 +34511,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/plating{
@@ -36378,7 +34560,6 @@
 /area/desert_dam/exterior/river/riverside_central_south)
 "bHy" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -36461,8 +34642,7 @@
 "bHM" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/floor/plating/ground/desertdam/cave/desert_into_outer_cave_floor,
 /area/desert_dam/exterior/valley/valley_north_east)
@@ -36487,21 +34667,18 @@
 /area/desert_dam/exterior/valley/valley_north_east)
 "bHP" = (
 /obj/structure/cargo_container{
-	tag = "icon-green 0,0";
 	icon_state = "green 0,0"
 	},
 /turf/open/floor,
 /area/desert_dam/exterior/valley/valley_north_east)
 "bHQ" = (
 /obj/structure/cargo_container{
-	tag = "icon-green 1,0";
 	icon_state = "green 1,0"
 	},
 /turf/open/floor,
 /area/desert_dam/exterior/valley/valley_north_east)
 "bHR" = (
 /obj/structure/cargo_container{
-	tag = "icon-green 2,0";
 	icon_state = "green 2,0"
 	},
 /turf/open/floor,
@@ -36509,7 +34686,6 @@
 "bHS" = (
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-darkbrown2 (NORTH)";
 	icon_state = "darkbrown2";
 	dir = 1
 	},
@@ -36523,22 +34699,19 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/mining/loading_room)
 "bHU" = (
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-darkbrown2";
 	icon_state = "darkbrown2"
 	},
 /area/desert_dam/building/mining/loading_room)
 "bHV" = (
 /turf/open/floor{
 	dir = 6;
-	icon_state = "darkbrown2";
-	tag = "icon-darkbrown2"
+	icon_state = "darkbrown2"
 	},
 /area/desert_dam/building/mining/loading_room)
 "bHW" = (
@@ -36572,8 +34745,7 @@
 	},
 /turf/open/floor{
 	dir = 9;
-	icon_state = "darkbrown2";
-	tag = "icon-darkbrown2"
+	icon_state = "darkbrown2"
 	},
 /area/desert_dam/interior/dam_interior/disposals)
 "bIb" = (
@@ -36591,7 +34763,6 @@
 /obj/item/flashlight,
 /obj/item/flashlight/flare,
 /turf/open/floor{
-	tag = "icon-darkbrown2 (NORTH)";
 	icon_state = "darkbrown2";
 	dir = 1
 	},
@@ -36604,7 +34775,6 @@
 /area/desert_dam/interior/dam_interior/west_tunnel)
 "bIe" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /obj/structure/cable{
@@ -36717,7 +34887,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2";
 	icon_state = "darkbrowncorners2"
 	},
 /area/desert_dam/building/mining/garage)
@@ -36742,7 +34911,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-darkbrown2 (WEST)";
 	icon_state = "darkbrown2";
 	dir = 8
 	},
@@ -36759,7 +34927,6 @@
 /area/desert_dam/interior/dam_interior/disposals)
 "bIA" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -36769,7 +34936,6 @@
 /area/desert_dam/interior/dam_interior/disposals)
 "bIB" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -36780,7 +34946,6 @@
 /area/desert_dam/interior/dam_interior/disposals)
 "bIC" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -36793,8 +34958,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/plating{
@@ -36811,36 +34975,30 @@
 "bIF" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /turf/open/floor{
-	tag = "icon-darkbrown2 (NORTH)";
 	icon_state = "darkbrown2";
 	dir = 1
 	},
 /area/desert_dam/interior/dam_interior/disposals)
 "bIG" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /turf/open/floor{
-	tag = "icon-whiteyellow (NORTH)";
 	icon_state = "whiteyellow";
 	dir = 1
 	},
 /area/desert_dam/interior/dam_interior/break_room)
 "bIH" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor{
-	tag = "icon-whiteyellow (NORTH)";
 	icon_state = "whiteyellow";
 	dir = 1
 	},
@@ -36849,16 +35007,13 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (NORTH)";
 	icon_state = "pipe-c";
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-whiteyellow (NORTH)";
 	icon_state = "whiteyellow";
 	dir = 1
 	},
@@ -36868,7 +35023,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whiteyellow (NORTH)";
 	icon_state = "whiteyellow";
 	dir = 1
 	},
@@ -36879,7 +35033,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whiteyellow (NORTH)";
 	icon_state = "whiteyellow";
 	dir = 1
 	},
@@ -36887,7 +35040,6 @@
 "bIL" = (
 /obj/machinery/vending/cigarette/colony,
 /turf/open/floor{
-	tag = "icon-whiteyellow (NORTH)";
 	icon_state = "whiteyellow";
 	dir = 1
 	},
@@ -36895,7 +35047,6 @@
 "bIM" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor{
-	tag = "icon-whiteyellow (NORTH)";
 	icon_state = "whiteyellow";
 	dir = 1
 	},
@@ -36904,8 +35055,7 @@
 /obj/machinery/vending/snack,
 /turf/open/floor{
 	dir = 5;
-	icon_state = "whiteyellow";
-	tag = "icon-whiteredcorner (NORTH)"
+	icon_state = "whiteyellow"
 	},
 /area/desert_dam/interior/dam_interior/break_room)
 "bIO" = (
@@ -36950,7 +35100,6 @@
 /area/desert_dam/exterior/valley/valley_north_east)
 "bIT" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -36959,8 +35108,7 @@
 "bIU" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/floor/plating/ground/desertdam/desert{
 	icon_state = "desert9"
@@ -37052,14 +35200,12 @@
 /area/desert_dam/interior/dam_interior/break_room)
 "bJf" = (
 /turf/open/floor{
-	tag = "icon-whiteyellow (WEST)";
 	icon_state = "whiteyellow";
 	dir = 8
 	},
 /area/desert_dam/interior/dam_interior/break_room)
 "bJg" = (
 /turf/open/floor{
-	tag = "icon-whiteyellowcorner (EAST)";
 	icon_state = "whiteyellowcorner";
 	dir = 4
 	},
@@ -37067,7 +35213,6 @@
 "bJh" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor{
-	tag = "icon-whiteyellowcorner (EAST)";
 	icon_state = "whiteyellowcorner";
 	dir = 4
 	},
@@ -37075,8 +35220,7 @@
 "bJi" = (
 /turf/open/floor{
 	dir = 4;
-	icon_state = "whiteyellow";
-	tag = "icon-whiteredcorner (NORTH)"
+	icon_state = "whiteyellow"
 	},
 /area/desert_dam/interior/dam_interior/break_room)
 "bJj" = (
@@ -37099,8 +35243,7 @@
 "bJl" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/floor/plating/ground/desertdam/desert,
 /area/desert_dam/exterior/valley/valley_north_east)
@@ -37137,7 +35280,6 @@
 	icon_state = "road_edge_decal2"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -37151,7 +35293,6 @@
 	name = "\improper Loading"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -37165,7 +35306,6 @@
 /area/desert_dam/building/mining/garage)
 "bJs" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -37179,7 +35319,6 @@
 /area/desert_dam/building/mining/garage)
 "bJt" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -37194,15 +35333,13 @@
 /area/desert_dam/building/mining/garage)
 "bJu" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment{
@@ -37221,7 +35358,6 @@
 	},
 /obj/machinery/power/apc/drained,
 /turf/open/floor{
-	tag = "icon-whiteyellow (NORTHWEST)";
 	icon_state = "whiteyellow";
 	dir = 9
 	},
@@ -37239,7 +35375,6 @@
 /area/desert_dam/interior/dam_interior/disposals)
 "bJy" = (
 /turf/open/floor{
-	tag = "icon-darkbrowncorners2";
 	icon_state = "darkbrowncorners2"
 	},
 /area/desert_dam/interior/dam_interior/disposals)
@@ -37360,7 +35495,6 @@
 /obj/item/lightreplacer,
 /obj/item/clothing/mask/rebreather,
 /turf/open/floor{
-	tag = "icon-darkbrown2 (EAST)";
 	icon_state = "darkbrown2";
 	dir = 4
 	},
@@ -37387,7 +35521,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/random_item/crap,
 /turf/open/floor{
-	tag = "icon-whiteyellowcorner (EAST)";
 	icon_state = "whiteyellowcorner";
 	dir = 4
 	},
@@ -37401,7 +35534,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whiteyellowcorner (EAST)";
 	icon_state = "whiteyellowcorner";
 	dir = 4
 	},
@@ -37414,7 +35546,6 @@
 	layer = 2.4
 	},
 /turf/open/floor{
-	tag = "icon-whiteyellowcorner (EAST)";
 	icon_state = "whiteyellowcorner";
 	dir = 4
 	},
@@ -37428,7 +35559,6 @@
 	layer = 2.4
 	},
 /turf/open/floor{
-	tag = "icon-whiteyellowcorner (EAST)";
 	icon_state = "whiteyellowcorner";
 	dir = 4
 	},
@@ -37438,7 +35568,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-whiteyellowcorner (EAST)";
 	icon_state = "whiteyellowcorner";
 	dir = 4
 	},
@@ -37449,7 +35578,6 @@
 	layer = 2.4
 	},
 /turf/open/floor{
-	tag = "icon-whiteyellowcorner (EAST)";
 	icon_state = "whiteyellowcorner";
 	dir = 4
 	},
@@ -37461,8 +35589,7 @@
 	},
 /turf/open/floor{
 	dir = 4;
-	icon_state = "whiteyellow";
-	tag = "icon-whiteredcorner (NORTH)"
+	icon_state = "whiteyellow"
 	},
 /area/desert_dam/interior/dam_interior/break_room)
 "bKa" = (
@@ -37582,7 +35709,6 @@
 /area/desert_dam/interior/dam_interior/western_dam_cave)
 "bKq" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
 	icon_state = "tube1";
 	dir = 4
 	},
@@ -37601,7 +35727,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-darkbrown2 (WEST)";
 	icon_state = "darkbrown2";
 	dir = 8
 	},
@@ -37612,7 +35737,6 @@
 /obj/item/radio,
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor{
-	tag = "icon-darkbrown2 (EAST)";
 	icon_state = "darkbrown2";
 	dir = 4
 	},
@@ -37651,7 +35775,6 @@
 	layer = 2.4
 	},
 /turf/open/floor{
-	tag = "icon-whiteyellow (WEST)";
 	icon_state = "whiteyellow";
 	dir = 8
 	},
@@ -37665,7 +35788,6 @@
 	layer = 2.4
 	},
 /turf/open/floor{
-	tag = "icon-whiteyellowcorner (EAST)";
 	icon_state = "whiteyellowcorner";
 	dir = 4
 	},
@@ -37678,7 +35800,6 @@
 	dir = 9
 	},
 /turf/open/floor{
-	tag = "icon-whiteyellowcorner (EAST)";
 	icon_state = "whiteyellowcorner";
 	dir = 4
 	},
@@ -37687,7 +35808,6 @@
 /obj/structure/table,
 /obj/item/clothing/ears/earmuffs,
 /turf/open/floor{
-	tag = "icon-whiteyellowcorner (EAST)";
 	icon_state = "whiteyellowcorner";
 	dir = 4
 	},
@@ -37697,7 +35817,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whiteyellowcorner (EAST)";
 	icon_state = "whiteyellowcorner";
 	dir = 4
 	},
@@ -37708,7 +35827,6 @@
 	on = 1
 	},
 /turf/open/floor{
-	tag = "icon-whiteyellowcorner (EAST)";
 	icon_state = "whiteyellowcorner";
 	dir = 4
 	},
@@ -37762,7 +35880,6 @@
 /area/desert_dam/exterior/river/riverside_central_south)
 "bKN" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (NORTH)";
 	icon_state = "platform_deco";
 	dir = 1
 	},
@@ -37801,7 +35918,6 @@
 /area/desert_dam/building/mining/garage)
 "bKU" = (
 /turf/open/floor/plating{
-	tag = "icon-warnplate (EAST)";
 	icon_state = "warnplate";
 	dir = 4
 	},
@@ -37836,8 +35952,7 @@
 /obj/machinery/light,
 /turf/open/floor{
 	dir = 10;
-	icon_state = "darkbrown2";
-	tag = "icon-darkbrown2"
+	icon_state = "darkbrown2"
 	},
 /area/desert_dam/interior/dam_interior/disposals)
 "bLa" = (
@@ -37845,7 +35960,6 @@
 /obj/item/storage/box/lightstick/red,
 /obj/effect/landmark/random_item/good,
 /turf/open/floor{
-	tag = "icon-darkbrown2";
 	icon_state = "darkbrown2"
 	},
 /area/desert_dam/interior/dam_interior/disposals)
@@ -37855,15 +35969,13 @@
 /obj/effect/spawner/random/tool,
 /turf/open/floor{
 	dir = 6;
-	icon_state = "darkbrown2";
-	tag = "icon-darkbrown2"
+	icon_state = "darkbrown2"
 	},
 /area/desert_dam/interior/dam_interior/disposals)
 "bLc" = (
 /turf/open/floor{
 	dir = 10;
-	icon_state = "whiteyellow";
-	tag = "icon-whiteredcorner (NORTH)"
+	icon_state = "whiteyellow"
 	},
 /area/desert_dam/interior/dam_interior/break_room)
 "bLd" = (
@@ -37871,7 +35983,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whiteyellow";
 	icon_state = "whiteyellow";
 	dir = 2
 	},
@@ -37879,7 +35990,6 @@
 "bLe" = (
 /obj/structure/table,
 /turf/open/floor{
-	tag = "icon-whiteyellow";
 	icon_state = "whiteyellow";
 	dir = 2
 	},
@@ -37892,7 +36002,6 @@
 	on = 1
 	},
 /turf/open/floor{
-	tag = "icon-whiteyellow";
 	icon_state = "whiteyellow";
 	dir = 2
 	},
@@ -37902,14 +36011,12 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whiteyellow";
 	icon_state = "whiteyellow";
 	dir = 2
 	},
 /area/desert_dam/interior/dam_interior/break_room)
 "bLh" = (
 /turf/open/floor{
-	tag = "icon-whiteyellow";
 	icon_state = "whiteyellow";
 	dir = 2
 	},
@@ -37917,7 +36024,6 @@
 "bLi" = (
 /obj/structure/table,
 /turf/open/floor{
-	tag = "icon-whiteyellow (SOUTHEAST)";
 	icon_state = "whiteyellow";
 	dir = 6
 	},
@@ -37948,7 +36054,6 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "bLn" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (NORTH)";
 	icon_state = "platform_deco";
 	dir = 1
 	},
@@ -38066,7 +36171,6 @@
 "bLF" = (
 /obj/machinery/door/poddoor/shutters,
 /turf/open/floor/plating{
-	tag = "icon-warnplate (SOUTHWEST)";
 	icon_state = "warnplate";
 	dir = 10
 	},
@@ -38079,14 +36183,12 @@
 /area/desert_dam/building/mining/garage)
 "bLH" = (
 /turf/open/floor/plating{
-	tag = "icon-warnplate (SOUTHEAST)";
 	icon_state = "warnplate";
 	dir = 6
 	},
 /area/desert_dam/building/mining/garage)
 "bLI" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -38101,14 +36203,12 @@
 "bLK" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
-	pixel_x = 0;
-	tag = "icon-E-corner"
+	pixel_x = 0
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
 /area/desert_dam/interior/dam_interior/western_dam_cave)
 "bLL" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /obj/structure/cable{
@@ -38200,14 +36300,12 @@
 "bLZ" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	tag = "icon-tube1 (EAST)"
+	icon_state = "tube1"
 	},
 /turf/open/floor/plating,
 /area/desert_dam/building/mining/garage)
 "bMa" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (NORTH)";
 	icon_state = "platform_deco";
 	dir = 1
 	},
@@ -38284,7 +36382,6 @@
 /area/desert_dam/interior/dam_interior/central_tunnel)
 "bMj" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -38296,8 +36393,7 @@
 "bMk" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -38328,7 +36424,6 @@
 /area/desert_dam/interior/dam_interior/central_tunnel)
 "bMn" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -38413,7 +36508,6 @@
 /area/desert_dam/building/mining/garage)
 "bMz" = (
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -38464,7 +36558,6 @@
 /area/desert_dam/interior/dam_interior/west_tunnel)
 "bMG" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -38476,8 +36569,7 @@
 "bMH" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/floor/plating{
 	dir = 1;
@@ -38542,7 +36634,6 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "bMP" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /obj/structure/cable{
@@ -38585,7 +36676,6 @@
 /area/desert_dam/building/mining/garage)
 "bMW" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -38751,8 +36841,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/open/floor{
 	icon_state = "delivery"
@@ -38760,7 +36849,6 @@
 /area/desert_dam/interior/dam_interior/central_tunnel)
 "bNw" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -38771,11 +36859,9 @@
 /area/desert_dam/interior/dam_interior/central_tunnel)
 "bNx" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -38789,7 +36875,6 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -38800,7 +36885,6 @@
 /area/desert_dam/interior/dam_interior/east_tunnel_entrance)
 "bNz" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -38811,11 +36895,9 @@
 /area/desert_dam/interior/dam_interior/east_tunnel_entrance)
 "bNA" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -38828,8 +36910,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38838,7 +36919,6 @@
 /area/desert_dam/interior/dam_interior/east_tunnel_entrance)
 "bNC" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /obj/structure/disposalpipe/segment{
@@ -38857,7 +36937,6 @@
 /area/desert_dam/interior/dam_interior/east_tunnel_entrance)
 "bNE" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /obj/structure/disposalpipe/segment{
@@ -38945,7 +37024,6 @@
 /area/desert_dam/exterior/river/riverside_east)
 "bNP" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -39026,18 +37104,15 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
 /area/desert_dam/interior/dam_interior/south_tunnel)
 "bOe" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -39045,7 +37120,6 @@
 /area/desert_dam/interior/dam_interior/south_tunnel)
 "bOf" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -39061,7 +37135,6 @@
 /area/desert_dam/interior/dam_interior/south_tunnel)
 "bOh" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -39082,14 +37155,12 @@
 /area/desert_dam/interior/dam_interior/east_tunnel_entrance)
 "bOl" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
 /area/desert_dam/interior/dam_interior/east_tunnel_entrance)
 "bOm" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -39116,7 +37187,6 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "bOp" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -39135,11 +37205,9 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (NORTH)";
 	icon_state = "pipe-c";
 	dir = 1
 	},
@@ -39274,8 +37342,7 @@
 "bOJ" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/closed/desertdamrockwall,
 /area/desert_dam/exterior/rock)
@@ -39327,7 +37394,6 @@
 /area/desert_dam/exterior/river/riverside_east)
 "bOP" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -39349,8 +37415,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/open/floor/plating{
 	dir = 1;
@@ -39359,7 +37424,6 @@
 /area/desert_dam/exterior/valley/valley_telecoms)
 "bOT" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -39416,7 +37480,6 @@
 /area/desert_dam/exterior/river/riverside_south)
 "bPa" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (NORTH)";
 	icon_state = "platform_deco";
 	dir = 1
 	},
@@ -39432,7 +37495,6 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "bPc" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -39487,7 +37549,6 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "bPl" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -39533,7 +37594,6 @@
 /area/desert_dam/building/medical/break_room)
 "bPu" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (NORTH)";
 	icon_state = "platform_deco";
 	dir = 1
 	},
@@ -39543,7 +37603,6 @@
 /area/desert_dam/exterior/river/riverside_east)
 "bPv" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /obj/structure/cable{
@@ -39554,8 +37613,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
 /area/desert_dam/interior/dam_interior/south_tunnel)
@@ -39564,7 +37622,6 @@
 	icon_state = "road_edge_decal2"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -39572,7 +37629,6 @@
 /area/desert_dam/interior/dam_interior/south_tunnel)
 "bPx" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -39613,7 +37669,6 @@
 "bPC" = (
 /obj/machinery/vending/medical,
 /turf/open/floor{
-	tag = "icon-whitepurplecorner (EAST)";
 	icon_state = "whitepurplecorner";
 	dir = 4
 	},
@@ -39623,7 +37678,6 @@
 /obj/item/tool/stamp,
 /obj/item/paper_bin,
 /turf/open/floor{
-	tag = "icon-whitepurplecorner (EAST)";
 	icon_state = "whitepurplecorner";
 	dir = 4
 	},
@@ -39633,14 +37687,12 @@
 /obj/item/packageWrap,
 /obj/item/tool/hand_labeler,
 /turf/open/floor{
-	tag = "icon-whitepurplecorner (EAST)";
 	icon_state = "whitepurplecorner";
 	dir = 4
 	},
 /area/desert_dam/building/medical/chemistry)
 "bPF" = (
 /turf/open/floor{
-	tag = "icon-whitepurple (NORTH)";
 	icon_state = "whitepurple";
 	dir = 1
 	},
@@ -39648,7 +37700,6 @@
 "bPG" = (
 /obj/structure/closet/secure_closet/chemical,
 /turf/open/floor{
-	tag = "icon-whitepurple (NORTH)";
 	icon_state = "whitepurple";
 	dir = 1
 	},
@@ -39702,37 +37753,32 @@
 /obj/structure/table,
 /turf/open/floor{
 	dir = 1;
-	icon_state = "whiteyellow";
-	tag = "icon-whiteredcorner (NORTH)"
+	icon_state = "whiteyellow"
 	},
 /area/desert_dam/building/medical/break_room)
 "bPO" = (
 /obj/machinery/vending/snack,
 /turf/open/floor{
 	dir = 1;
-	icon_state = "whiteyellow";
-	tag = "icon-whiteredcorner (NORTH)"
+	icon_state = "whiteyellow"
 	},
 /area/desert_dam/building/medical/break_room)
 "bPP" = (
 /obj/machinery/vending/cola,
 /turf/open/floor{
 	dir = 1;
-	icon_state = "whiteyellow";
-	tag = "icon-whiteredcorner (NORTH)"
+	icon_state = "whiteyellow"
 	},
 /area/desert_dam/building/medical/break_room)
 "bPQ" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor{
 	dir = 1;
-	icon_state = "whiteyellow";
-	tag = "icon-whiteredcorner (NORTH)"
+	icon_state = "whiteyellow"
 	},
 /area/desert_dam/building/medical/break_room)
 "bPR" = (
 /turf/open/floor{
-	tag = "icon-whiteyellow (NORTHEAST)";
 	icon_state = "whiteyellow";
 	dir = 5
 	},
@@ -39787,14 +37833,12 @@
 "bPX" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
-	pixel_x = 0;
-	tag = "icon-E-corner"
+	pixel_x = 0
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
 /area/desert_dam/interior/dam_interior/south_tunnel)
 "bPY" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /obj/structure/cable{
@@ -39806,7 +37850,6 @@
 /area/desert_dam/interior/dam_interior/south_tunnel)
 "bPZ" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
@@ -39832,14 +37875,12 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whitepurple (NORTH)";
 	icon_state = "whitepurple";
 	dir = 1
 	},
 /area/desert_dam/building/medical/chemistry)
 "bQd" = (
 /turf/open/floor{
-	tag = "icon-whitegreencorner (NORTH)";
 	icon_state = "whitegreencorner";
 	dir = 1
 	},
@@ -39854,7 +37895,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (EAST)";
 	icon_state = "whitegreen";
 	dir = 4
 	},
@@ -39872,7 +37912,6 @@
 /area/desert_dam/building/medical/morgue)
 "bQi" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (NORTH)";
 	icon_state = "tube1";
 	dir = 1
 	},
@@ -39899,7 +37938,6 @@
 /area/desert_dam/interior/dam_interior/south_tunnel)
 "bQl" = (
 /obj/structure/morgue{
-	tag = "icon-morgue1 (WEST)";
 	icon_state = "morgue1";
 	dir = 8
 	},
@@ -39929,16 +37967,14 @@
 "bQp" = (
 /turf/open/floor{
 	dir = 4;
-	icon_state = "whiteyellow";
-	tag = "icon-whiteredcorner (NORTH)"
+	icon_state = "whiteyellow"
 	},
 /area/desert_dam/building/medical/break_room)
 "bQq" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/open/floor/wood,
 /area/desert_dam/building/medical/break_room)
@@ -39999,7 +38035,6 @@
 /area/desert_dam/exterior/valley/valley_telecoms)
 "bQz" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -40016,8 +38051,7 @@
 "bQA" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/floor/plating{
 	dir = 1;
@@ -40061,7 +38095,6 @@
 "bQG" = (
 /obj/machinery/computer/crew,
 /turf/open/floor{
-	tag = "icon-whitered (NORTHWEST)";
 	icon_state = "whitered";
 	dir = 9
 	},
@@ -40069,12 +38102,10 @@
 "bQH" = (
 /obj/machinery/computer/med_data,
 /obj/machinery/light{
-	tag = "icon-tube1 (NORTH)";
 	icon_state = "tube1";
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-whitered (NORTH)";
 	icon_state = "whitered";
 	dir = 1
 	},
@@ -40082,7 +38113,6 @@
 "bQI" = (
 /obj/structure/closet/secure_closet/medical_doctor,
 /turf/open/floor{
-	tag = "icon-whitered (NORTH)";
 	icon_state = "whitered";
 	dir = 1
 	},
@@ -40090,7 +38120,6 @@
 "bQJ" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /turf/open/floor{
@@ -40099,7 +38128,6 @@
 /area/desert_dam/building/medical/morgue)
 "bQK" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -40109,7 +38137,6 @@
 /area/desert_dam/building/medical/chemistry)
 "bQL" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -40123,7 +38150,6 @@
 /area/desert_dam/building/medical/chemistry)
 "bQM" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -40136,7 +38162,6 @@
 /area/desert_dam/building/medical/chemistry)
 "bQN" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -40153,7 +38178,6 @@
 /area/desert_dam/building/medical/chemistry)
 "bQO" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -40170,7 +38194,6 @@
 /area/desert_dam/building/medical/chemistry)
 "bQP" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -40187,7 +38210,6 @@
 /area/desert_dam/building/medical/west_wing_hallway)
 "bQQ" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -40199,7 +38221,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (NORTH)";
 	icon_state = "whitegreencorner";
 	dir = 1
 	},
@@ -40213,8 +38234,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 10
@@ -40224,14 +38244,12 @@
 	icon_state = "pipe-j2"
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
 /area/desert_dam/building/medical/west_wing_hallway)
 "bQS" = (
 /turf/open/floor{
-	tag = "icon-whitegreen (EAST)";
 	icon_state = "whitegreen";
 	dir = 4
 	},
@@ -40268,8 +38286,7 @@
 	},
 /turf/open/floor{
 	dir = 8;
-	icon_state = "whiteyellowcorner";
-	tag = "icon-whiteyellowcorner (EAST)"
+	icon_state = "whiteyellowcorner"
 	},
 /area/desert_dam/building/medical/break_room)
 "bQX" = (
@@ -40285,14 +38302,12 @@
 /area/desert_dam/building/medical/break_room)
 "bQY" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /turf/open/floor{
 	dir = 4;
-	icon_state = "whiteyellow";
-	tag = "icon-whiteredcorner (NORTH)"
+	icon_state = "whiteyellow"
 	},
 /area/desert_dam/building/medical/break_room)
 "bQZ" = (
@@ -40339,7 +38354,6 @@
 /area/desert_dam/exterior/river/riverside_east)
 "bRg" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (NORTH)";
 	icon_state = "platform_deco";
 	dir = 1
 	},
@@ -40382,8 +38396,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/open/floor/plating{
 	dir = 1;
@@ -40405,8 +38418,7 @@
 "bRn" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -40470,7 +38482,6 @@
 /obj/item/paper_bin,
 /obj/item/tool/pen,
 /turf/open/floor{
-	tag = "icon-whitered (WEST)";
 	icon_state = "whitered";
 	dir = 8
 	},
@@ -40527,7 +38538,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
@@ -40551,7 +38561,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whiteyellow (WEST)";
 	icon_state = "whiteyellow";
 	dir = 8
 	},
@@ -40617,8 +38626,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating{
 	dir = 1;
@@ -40634,7 +38642,6 @@
 	name = "\improper Security Checkpoint"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/south_tunnel_entrance)
@@ -40648,7 +38655,6 @@
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp/green,
 /turf/open/floor{
-	tag = "icon-whitered (WEST)";
 	icon_state = "whitered";
 	dir = 8
 	},
@@ -40693,7 +38699,6 @@
 /area/desert_dam/building/medical/morgue)
 "bRV" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -40705,8 +38710,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/open/floor{
 	icon_state = "freezerfloor"
@@ -40724,7 +38728,6 @@
 "bRY" = (
 /obj/structure/table,
 /turf/open/floor{
-	tag = "icon-whiteyellow (WEST)";
 	icon_state = "whiteyellow";
 	dir = 8
 	},
@@ -40749,7 +38752,6 @@
 /area/desert_dam/building/medical/break_room)
 "bSb" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -40763,8 +38765,7 @@
 "bSd" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/floor/plating/ground/desertdam/desert{
 	icon_state = "desert6"
@@ -40803,7 +38804,6 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "bSi" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -40874,14 +38874,12 @@
 /area/desert_dam/interior/dam_interior/south_tunnel_entrance)
 "bSu" = (
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTHWEST)";
 	icon_state = "darkred2";
 	dir = 9
 	},
 /area/desert_dam/interior/dam_interior/south_tunnel_entrance)
 "bSv" = (
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTH)";
 	icon_state = "darkred2";
 	dir = 1
 	},
@@ -40889,7 +38887,6 @@
 "bSw" = (
 /obj/structure/closet/secure_closet/security,
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTHEAST)";
 	icon_state = "darkred2";
 	dir = 5
 	},
@@ -40926,14 +38923,12 @@
 /area/desert_dam/exterior/river/riverside_south)
 "bSC" = (
 /turf/open/floor{
-	tag = "icon-whitered (WEST)";
 	icon_state = "whitered";
 	dir = 8
 	},
 /area/desert_dam/building/medical/chemistry)
 "bSD" = (
 /turf/open/floor{
-	tag = "icon-whitepurple";
 	icon_state = "whitepurple";
 	dir = 2
 	},
@@ -40941,7 +38936,6 @@
 "bSE" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-whitepurple";
 	icon_state = "whitepurple";
 	dir = 2
 	},
@@ -40952,7 +38946,6 @@
 	icon_state = "tube1"
 	},
 /turf/open/floor{
-	tag = "icon-whitepurple";
 	icon_state = "whitepurple";
 	dir = 2
 	},
@@ -40967,7 +38960,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (NORTH)";
 	icon_state = "whitegreencorner";
 	dir = 1
 	},
@@ -40980,7 +38972,6 @@
 /area/desert_dam/building/medical/morgue)
 "bSJ" = (
 /obj/structure/toilet{
-	tag = "icon-toilet00 (NORTH)";
 	icon_state = "toilet00";
 	dir = 1
 	},
@@ -40992,7 +38983,6 @@
 /obj/structure/table,
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-whiteyellow (SOUTHWEST)";
 	icon_state = "whiteyellow";
 	dir = 10
 	},
@@ -41000,8 +38990,7 @@
 "bSL" = (
 /turf/open/floor{
 	dir = 8;
-	icon_state = "whiteyellowcorner";
-	tag = "icon-whiteyellowcorner (EAST)"
+	icon_state = "whiteyellowcorner"
 	},
 /area/desert_dam/building/medical/break_room)
 "bSM" = (
@@ -41010,7 +38999,6 @@
 /area/desert_dam/building/medical/break_room)
 "bSN" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (NORTH)";
 	icon_state = "platform_deco";
 	dir = 1
 	},
@@ -41111,20 +39099,17 @@
 /area/desert_dam/interior/dam_interior/south_tunnel_entrance)
 "bTc" = (
 /turf/open/floor{
-	tag = "icon-darkred2 (WEST)";
 	icon_state = "darkred2";
 	dir = 8
 	},
 /area/desert_dam/interior/dam_interior/south_tunnel_entrance)
 "bTd" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/south_tunnel_entrance)
 "bTe" = (
 /turf/open/floor{
-	tag = "icon-darkred2 (EAST)";
 	icon_state = "darkred2";
 	dir = 4
 	},
@@ -41144,7 +39129,6 @@
 "bTh" = (
 /obj/machinery/photocopier,
 /turf/open/floor{
-	tag = "icon-whitered (WEST)";
 	icon_state = "whitered";
 	dir = 8
 	},
@@ -41158,14 +39142,12 @@
 "bTj" = (
 /obj/machinery/chem_master,
 /turf/open/floor{
-	tag = "icon-whitepurplecorner";
 	icon_state = "whitepurplecorner";
 	dir = 2
 	},
 /area/desert_dam/building/medical/chemistry)
 "bTk" = (
 /turf/open/floor{
-	tag = "icon-whitepurplecorner";
 	icon_state = "whitepurplecorner";
 	dir = 2
 	},
@@ -41173,12 +39155,10 @@
 "bTl" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
-	tag = "icon-pipe-t (NORTH)";
 	icon_state = "pipe-t";
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-whitepurplecorner";
 	icon_state = "whitepurplecorner";
 	dir = 2
 	},
@@ -41186,7 +39166,6 @@
 "bTm" = (
 /obj/structure/bed/stool,
 /turf/open/floor{
-	tag = "icon-whitepurplecorner";
 	icon_state = "whitepurplecorner";
 	dir = 2
 	},
@@ -41307,7 +39286,6 @@
 "bTE" = (
 /obj/structure/desertdam/decals/road_edge,
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -41316,11 +39294,9 @@
 "bTF" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
-	pixel_x = 0;
-	tag = "icon-E-corner"
+	pixel_x = 0
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -41328,14 +39304,12 @@
 /area/desert_dam/interior/dam_interior/south_tunnel_entrance)
 "bTG" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
 /area/desert_dam/interior/dam_interior/south_tunnel_entrance)
@@ -41349,7 +39323,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security,
 /turf/open/floor{
-	tag = "icon-darkred2 (WEST)";
 	icon_state = "darkred2";
 	dir = 8
 	},
@@ -41367,7 +39340,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-whitered (SOUTHWEST)";
 	icon_state = "whitered";
 	dir = 10
 	},
@@ -41375,7 +39347,6 @@
 "bTM" = (
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-whitered";
 	icon_state = "whitered";
 	dir = 2
 	},
@@ -41383,7 +39354,6 @@
 "bTN" = (
 /obj/machinery/disposal,
 /turf/open/floor{
-	tag = "icon-whitered";
 	icon_state = "whitered";
 	dir = 2
 	},
@@ -41391,7 +39361,6 @@
 "bTO" = (
 /obj/machinery/chem_dispenser,
 /turf/open/floor{
-	tag = "icon-whitepurplecorner";
 	icon_state = "whitepurplecorner";
 	dir = 2
 	},
@@ -41399,7 +39368,6 @@
 "bTP" = (
 /obj/structure/bed/chair/office/light,
 /turf/open/floor{
-	tag = "icon-whitepurplecorner";
 	icon_state = "whitepurplecorner";
 	dir = 2
 	},
@@ -41407,7 +39375,6 @@
 "bTQ" = (
 /obj/machinery/reagentgrinder,
 /turf/open/floor{
-	tag = "icon-whitepurplecorner";
 	icon_state = "whitepurplecorner";
 	dir = 2
 	},
@@ -41415,7 +39382,6 @@
 "bTR" = (
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-whitepurplecorner";
 	icon_state = "whitepurplecorner";
 	dir = 2
 	},
@@ -41426,7 +39392,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (NORTH)";
 	icon_state = "whitegreencorner";
 	dir = 1
 	},
@@ -41443,14 +39408,12 @@
 	icon_state = "pipe-j2"
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
 /area/desert_dam/building/medical/west_wing_hallway)
 "bTU" = (
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
@@ -41461,14 +39424,12 @@
 /area/desert_dam/building/medical/north_wing_hallway)
 "bTW" = (
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
 /area/desert_dam/building/medical/north_wing_hallway)
 "bTX" = (
 /turf/open/floor{
-	tag = "icon-whitegreencorner (NORTH)";
 	icon_state = "whitegreencorner";
 	dir = 1
 	},
@@ -41485,7 +39446,6 @@
 /area/desert_dam/building/medical/north_wing_hallway)
 "bTZ" = (
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
@@ -41495,7 +39455,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
@@ -41553,7 +39512,6 @@
 "bUh" = (
 /obj/structure/table,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTHWEST)";
 	icon_state = "darkyellow2";
 	dir = 9
 	},
@@ -41561,7 +39519,6 @@
 "bUi" = (
 /obj/structure/table,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -41569,7 +39526,6 @@
 "bUj" = (
 /obj/structure/closet/secure_closet/engineering_welding,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -41590,8 +39546,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating{
 	icon_state = "warnplate";
@@ -41611,7 +39566,6 @@
 	name = "Security Desk"
 	},
 /obj/machinery/door/window/brigdoor/westleft{
-	tag = "icon-leftsecure (EAST)";
 	icon_state = "leftsecure";
 	dir = 4;
 	id = "brg"
@@ -41627,7 +39581,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-darkred2 (WEST)";
 	icon_state = "darkred2";
 	dir = 8
 	},
@@ -41638,7 +39591,6 @@
 	icon_state = "tube1"
 	},
 /turf/open/floor{
-	tag = "icon-darkred2 (EAST)";
 	icon_state = "darkred2";
 	dir = 4
 	},
@@ -41684,7 +39636,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (WEST)";
 	icon_state = "whitegreen";
 	dir = 8
 	},
@@ -41692,7 +39643,6 @@
 "bUx" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-whitegreencorner (NORTH)";
 	icon_state = "whitegreencorner";
 	dir = 1
 	},
@@ -41716,14 +39666,12 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
 /area/desert_dam/building/medical/west_wing_hallway)
 "bUz" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -41740,7 +39688,6 @@
 /area/desert_dam/building/medical/north_wing_hallway)
 "bUA" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -41752,22 +39699,19 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
 /area/desert_dam/building/medical/north_wing_hallway)
 "bUB" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4;
@@ -41777,14 +39721,12 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
 /area/desert_dam/building/medical/north_wing_hallway)
 "bUC" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -41795,14 +39737,12 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
 /area/desert_dam/building/medical/north_wing_hallway)
 "bUD" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -41822,8 +39762,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -41854,11 +39793,9 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (NORTH)";
 	icon_state = "pipe-c";
 	dir = 1
 	},
@@ -41869,7 +39806,6 @@
 	icon_state = "stop_decal3"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -41908,7 +39844,6 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "bUM" = (
 /obj/structure/showcase{
-	tag = "icon-bus";
 	icon_state = "bus"
 	},
 /turf/open/floor/greengrid,
@@ -41921,8 +39856,7 @@
 	},
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/building/telecommunication)
 "bUO" = (
@@ -41937,7 +39871,6 @@
 /area/desert_dam/building/telecommunication)
 "bUP" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -41947,7 +39880,6 @@
 /area/desert_dam/building/telecommunication)
 "bUQ" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -41989,7 +39921,6 @@
 "bUV" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
@@ -41998,25 +39929,21 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/desert_dam/building/telecommunication_platform)
 "bUX" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
@@ -42028,7 +39955,6 @@
 	name = "Security Desk"
 	},
 /obj/machinery/door/window/brigdoor/westleft{
-	tag = "icon-leftsecure (EAST)";
 	icon_state = "leftsecure";
 	dir = 4;
 	id = "brg"
@@ -42070,14 +39996,12 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
 /area/desert_dam/building/medical/lobby)
 "bVe" = (
 /turf/open/floor{
-	tag = "icon-whitegreencorner (NORTH)";
 	icon_state = "whitegreencorner";
 	dir = 1
 	},
@@ -42089,7 +40013,6 @@
 /area/desert_dam/building/medical/lobby)
 "bVg" = (
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
@@ -42103,19 +40026,16 @@
 	dir = 8
 	},
 /turf/open/floor/plating{
-	tag = "icon-warnplate (EAST)";
 	icon_state = "warnplate";
 	dir = 4
 	},
 /area/desert_dam/building/telecommunication_platform)
 "bVi" = (
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (NORTH)";
 	icon_state = "pipe-c";
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (NORTH)";
 	icon_state = "whitegreencorner";
 	dir = 1
 	},
@@ -42132,7 +40052,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
@@ -42238,7 +40157,6 @@
 /area/desert_dam/building/telecommunication)
 "bVy" = (
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2 (NORTH)";
 	icon_state = "darkyellowcorners2";
 	dir = 1
 	},
@@ -42247,8 +40165,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+	icon_state = "1-2"
 	},
 /turf/open/floor{
 	icon_state = "dark"
@@ -42261,7 +40178,6 @@
 /area/desert_dam/building/telecommunication)
 "bVB" = (
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2";
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/building/telecommunication)
@@ -42304,8 +40220,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
 /area/desert_dam/building/telecommunication_platform)
@@ -42319,7 +40234,6 @@
 /area/desert_dam/building/telecommunication_platform)
 "bVH" = (
 /turf/open/floor/plating{
-	tag = "icon-warnplate (EAST)";
 	icon_state = "warnplate";
 	dir = 4
 	},
@@ -42334,14 +40248,12 @@
 "bVJ" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
-	pixel_x = 0;
-	tag = "icon-E-corner"
+	pixel_x = 0
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
 /area/desert_dam/interior/dam_interior/south_tunnel_entrance)
 "bVK" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -42349,7 +40261,6 @@
 "bVL" = (
 /obj/structure/filingcabinet,
 /turf/open/floor{
-	tag = "icon-darkred2 (SOUTHWEST)";
 	icon_state = "darkred2";
 	dir = 10
 	},
@@ -42357,14 +40268,12 @@
 "bVM" = (
 /obj/structure/rack,
 /turf/open/floor{
-	tag = "icon-darkred2";
 	icon_state = "darkred2"
 	},
 /area/desert_dam/interior/dam_interior/south_tunnel_entrance)
 "bVN" = (
 /obj/structure/rack,
 /turf/open/floor{
-	tag = "icon-darkred2 (SOUTHEAST)";
 	icon_state = "darkred2";
 	dir = 6
 	},
@@ -42383,7 +40292,6 @@
 	on = 1
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (NORTH)";
 	icon_state = "whitegreencorner";
 	dir = 1
 	},
@@ -42399,14 +40307,12 @@
 	layer = 2.4
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (NORTH)";
 	icon_state = "whitegreencorner";
 	dir = 1
 	},
 /area/desert_dam/building/medical/lobby)
 "bVR" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -42415,14 +40321,12 @@
 	layer = 2.4
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (NORTH)";
 	icon_state = "whitegreencorner";
 	dir = 1
 	},
 /area/desert_dam/building/medical/lobby)
 "bVS" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -42436,7 +40340,6 @@
 /area/desert_dam/building/medical/west_wing_hallway)
 "bVT" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -42445,7 +40348,6 @@
 	layer = 2.4
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (NORTH)";
 	icon_state = "whitegreencorner";
 	dir = 1
 	},
@@ -42459,15 +40361,13 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
@@ -42544,8 +40444,7 @@
 "bWe" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 8;
-	icon_state = "wooden_chair";
-	tag = ""
+	icon_state = "wooden_chair"
 	},
 /turf/open/floor{
 	icon_state = "dark"
@@ -42579,8 +40478,7 @@
 	},
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/building/telecommunication)
 "bWj" = (
@@ -42643,14 +40541,12 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
 /area/desert_dam/building/medical/west_wing_hallway)
 "bWr" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
@@ -42674,14 +40570,12 @@
 	name = "\improper Observation"
 	},
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
 /area/desert_dam/building/medical/surgury_observation)
 "bWw" = (
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
@@ -42749,8 +40643,7 @@
 "bWG" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 4;
-	icon_state = "wooden_chair";
-	tag = ""
+	icon_state = "wooden_chair"
 	},
 /turf/open/floor{
 	dir = 1;
@@ -42760,8 +40653,7 @@
 "bWH" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 4;
-	icon_state = "wooden_chair";
-	tag = ""
+	icon_state = "wooden_chair"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -42774,8 +40666,7 @@
 "bWI" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 4;
-	icon_state = "wooden_chair";
-	tag = ""
+	icon_state = "wooden_chair"
 	},
 /turf/open/floor{
 	dir = 4;
@@ -42785,8 +40676,7 @@
 "bWJ" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 4;
-	icon_state = "wooden_chair";
-	tag = ""
+	icon_state = "wooden_chair"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -42845,14 +40735,12 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "bWR" = (
 /obj/structure/showcase{
-	tag = "icon-broadcaster_send";
 	icon_state = "broadcaster_send"
 	},
 /turf/open/floor/greengrid,
 /area/desert_dam/building/telecommunication)
 "bWS" = (
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2 (WEST)";
 	icon_state = "darkyellowcorners2";
 	dir = 8
 	},
@@ -42861,7 +40749,6 @@
 /obj/structure/table,
 /obj/item/analyzer,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
@@ -42890,7 +40777,6 @@
 /area/desert_dam/building/telecommunication_platform)
 "bWX" = (
 /turf/open/floor/plating{
-	tag = "icon-warnplate (SOUTHEAST)";
 	icon_state = "warnplate";
 	dir = 6
 	},
@@ -42965,7 +40851,6 @@
 /obj/structure/table/reinforced,
 /obj/item/clothing/glasses/hud/health,
 /turf/open/floor{
-	tag = "icon-whitegreen (EAST)";
 	icon_state = "whitegreen";
 	dir = 4
 	},
@@ -42973,7 +40858,6 @@
 "bXi" = (
 /obj/machinery/vending/medical,
 /turf/open/floor{
-	tag = "icon-whitered (NORTHWEST)";
 	icon_state = "whitered";
 	dir = 9
 	},
@@ -42981,7 +40865,6 @@
 "bXj" = (
 /obj/machinery/vending/medical,
 /turf/open/floor{
-	tag = "icon-whitered (NORTH)";
 	icon_state = "whitered";
 	dir = 1
 	},
@@ -42989,7 +40872,6 @@
 "bXk" = (
 /obj/machinery/vending/MarineMed/Blood,
 /turf/open/floor{
-	tag = "icon-whitered (NORTHEAST)";
 	icon_state = "whitered";
 	dir = 5
 	},
@@ -42999,7 +40881,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
@@ -43016,7 +40897,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (EAST)";
 	icon_state = "whitegreen";
 	dir = 4
 	},
@@ -43024,11 +40904,9 @@
 "bXn" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	tag = "icon-tube1 (EAST)"
+	icon_state = "tube1"
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (WEST)";
 	icon_state = "whitegreen";
 	dir = 8
 	},
@@ -43041,7 +40919,6 @@
 /area/desert_dam/building/medical/east_wing_hallway)
 "bXp" = (
 /turf/open/floor{
-	tag = "icon-whitegreen (EAST)";
 	icon_state = "whitegreen";
 	dir = 4
 	},
@@ -43105,12 +40982,10 @@
 /area/desert_dam/building/church)
 "bXA" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
@@ -43118,8 +40993,7 @@
 "bXB" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 4;
-	icon_state = "wooden_chair";
-	tag = ""
+	icon_state = "wooden_chair"
 	},
 /turf/open/floor{
 	dir = 8;
@@ -43129,8 +41003,7 @@
 "bXC" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 4;
-	icon_state = "wooden_chair";
-	tag = ""
+	icon_state = "wooden_chair"
 	},
 /turf/open/floor{
 	icon_state = "chapel"
@@ -43169,7 +41042,6 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "bXH" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained{
@@ -43193,7 +41065,6 @@
 /obj/structure/table,
 /obj/item/encryptionkey,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
@@ -43230,24 +41101,20 @@
 /area/desert_dam/building/medical/lobby)
 "bXP" = (
 /obj/structure/bed/chair{
-	tag = "icon-chair (EAST)";
 	icon_state = "chair";
 	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	tag = "icon-tube1 (EAST)"
+	icon_state = "tube1"
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (WEST)";
 	icon_state = "whitegreen";
 	dir = 8
 	},
 /area/desert_dam/building/medical/lobby)
 "bXQ" = (
 /turf/open/floor{
-	tag = "icon-whitegreen (EAST)";
 	icon_state = "whitegreen";
 	dir = 4
 	},
@@ -43255,7 +41122,6 @@
 "bXR" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
 	icon_state = "rwindow";
 	dir = 1
 	},
@@ -43269,7 +41135,6 @@
 "bXS" = (
 /obj/machinery/computer/med_data,
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
 	icon_state = "rwindow";
 	dir = 1
 	},
@@ -43280,12 +41145,10 @@
 "bXT" = (
 /obj/machinery/computer/crew,
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
 	icon_state = "rwindow";
 	dir = 1
 	},
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
 	icon_state = "tube1";
 	dir = 4
 	},
@@ -43299,11 +41162,9 @@
 "bXV" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	tag = "icon-tube1 (EAST)"
+	icon_state = "tube1"
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (NORTH)";
 	icon_state = "whitegreencorner";
 	dir = 1
 	},
@@ -43314,14 +41175,12 @@
 /obj/item/roller,
 /obj/item/roller,
 /turf/open/floor{
-	tag = "icon-whitegreen (EAST)";
 	icon_state = "whitegreen";
 	dir = 4
 	},
 /area/desert_dam/building/medical/west_wing_hallway)
 "bXX" = (
 /turf/open/floor{
-	tag = "icon-whitered (WEST)";
 	icon_state = "whitered";
 	dir = 8
 	},
@@ -43333,7 +41192,6 @@
 /area/desert_dam/building/medical/primary_storage)
 "bXZ" = (
 /turf/open/floor{
-	tag = "icon-whitered (EAST)";
 	icon_state = "whitered";
 	dir = 4
 	},
@@ -43341,7 +41199,6 @@
 "bYa" = (
 /obj/structure/bed/chair,
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
@@ -43354,26 +41211,22 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
 /area/desert_dam/building/medical/surgury_observation)
 "bYc" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
 /area/desert_dam/building/medical/surgury_observation)
 "bYd" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -43381,26 +41234,22 @@
 	name = "\improper Observation"
 	},
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
 /area/desert_dam/building/medical/surgury_observation)
 "bYe" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (WEST)";
 	icon_state = "whitegreen";
 	dir = 8
 	},
 /area/desert_dam/building/medical/east_wing_hallway)
 "bYf" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -43417,8 +41266,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -43437,7 +41285,6 @@
 /area/desert_dam/building/medical/east_wing_hallway)
 "bYh" = (
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
@@ -43475,21 +41322,18 @@
 /area/desert_dam/building/church)
 "bYn" = (
 /turf/open/floor{
-	tag = "icon-carpet6-2 (WEST)";
 	icon_state = "carpet6-2";
 	dir = 8
 	},
 /area/desert_dam/building/church)
 "bYo" = (
 /turf/open/floor{
-	tag = "icon-carpet14-10 (WEST)";
 	icon_state = "carpet14-10";
 	dir = 8
 	},
 /area/desert_dam/building/church)
 "bYp" = (
 /turf/open/floor{
-	tag = "icon-carpet10-8 (WEST)";
 	icon_state = "carpet10-8";
 	dir = 8
 	},
@@ -43508,8 +41352,7 @@
 "bYs" = (
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/building/telecommunication)
 "bYt" = (
@@ -43520,7 +41363,6 @@
 	pixel_y = 2
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
@@ -43552,7 +41394,6 @@
 /area/desert_dam/exterior/valley/valley_telecoms)
 "bYx" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /obj/structure/cable{
@@ -43570,8 +41411,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -43589,12 +41429,10 @@
 /area/desert_dam/exterior/river/riverside_south)
 "bYA" = (
 /obj/structure/bed/chair{
-	tag = "icon-chair (EAST)";
 	icon_state = "chair";
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (WEST)";
 	icon_state = "whitegreen";
 	dir = 8
 	},
@@ -43626,7 +41464,6 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/box/pillbottles,
 /turf/open/floor{
-	tag = "icon-whitegreen (EAST)";
 	icon_state = "whitegreen";
 	dir = 4
 	},
@@ -43634,7 +41471,6 @@
 "bYF" = (
 /obj/structure/bed/chair/wheelchair,
 /turf/open/floor{
-	tag = "icon-whitered (WEST)";
 	icon_state = "whitered";
 	dir = 8
 	},
@@ -43654,37 +41490,31 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whitered (EAST)";
 	icon_state = "whitered";
 	dir = 4
 	},
 /area/desert_dam/building/medical/primary_storage)
 "bYI" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
 /area/desert_dam/building/medical/surgury_observation)
 "bYJ" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
 /area/desert_dam/building/medical/surgury_observation)
 "bYK" = (
 /turf/open/floor{
-	tag = "icon-whitegreen (WEST)";
 	icon_state = "whitegreen";
 	dir = 8
 	},
@@ -43706,7 +41536,6 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (NORTH)";
 	icon_state = "pipe-c";
 	dir = 1
 	},
@@ -43717,7 +41546,6 @@
 /area/desert_dam/building/medical/east_wing_hallway)
 "bYN" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -43734,7 +41562,6 @@
 /area/desert_dam/building/medical/east_wing_hallway)
 "bYO" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -43754,7 +41581,6 @@
 /area/desert_dam/building/medical/CMO)
 "bYP" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -43769,7 +41595,6 @@
 /area/desert_dam/building/medical/CMO)
 "bYQ" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -43786,7 +41611,6 @@
 "bYR" = (
 /obj/structure/table/woodentable,
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -43794,7 +41618,6 @@
 /area/desert_dam/building/medical/CMO)
 "bYS" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -43810,13 +41633,11 @@
 	},
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/building/telecommunication)
 "bYU" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /obj/structure/cable{
@@ -43827,8 +41648,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -43838,7 +41658,6 @@
 	icon_state = "road_edge_decal2"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -43846,7 +41665,6 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "bYW" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -43866,7 +41684,6 @@
 /area/desert_dam/building/church)
 "bYY" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -43878,8 +41695,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/open/floor{
 	icon_state = "dark"
@@ -43887,21 +41703,18 @@
 /area/desert_dam/building/church)
 "bZa" = (
 /turf/open/floor{
-	tag = "icon-carpet5-1 (WEST)";
 	icon_state = "carpet5-1";
 	dir = 8
 	},
 /area/desert_dam/building/church)
 "bZb" = (
 /turf/open/floor{
-	tag = "icon-carpet13-5 (WEST)";
 	icon_state = "carpet13-5";
 	dir = 8
 	},
 /area/desert_dam/building/church)
 "bZc" = (
 /turf/open/floor{
-	tag = "icon-carpet9-4 (WEST)";
 	icon_state = "carpet9-4";
 	dir = 8
 	},
@@ -43948,7 +41761,6 @@
 	req_one_access_txt = "19;200"
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTHWEST)";
 	icon_state = "darkyellow2";
 	dir = 9
 	},
@@ -43959,7 +41771,6 @@
 	req_one_access_txt = "19;200"
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -43969,21 +41780,18 @@
 	req_one_access_txt = "19;200"
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
 /area/desert_dam/building/telecommunication)
 "bZl" = (
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
 /area/desert_dam/building/telecommunication)
 "bZm" = (
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
@@ -43991,8 +41799,7 @@
 "bZn" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/floor/plating/ground/desertdam/desert{
 	icon_state = "desert6"
@@ -44008,7 +41815,6 @@
 /area/desert_dam/exterior/valley/valley_telecoms)
 "bZp" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -44028,7 +41834,6 @@
 "bZr" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor{
-	tag = "icon-whitepurplecorner";
 	icon_state = "whitepurplecorner";
 	dir = 2
 	},
@@ -44046,7 +41851,6 @@
 /area/desert_dam/building/medical/lobby)
 "bZt" = (
 /turf/open/floor{
-	tag = "icon-whiteredcorner (NORTH)";
 	icon_state = "whiteredcorner";
 	dir = 1
 	},
@@ -44067,7 +41871,6 @@
 	pixel_x = 7
 	},
 /turf/open/floor{
-	tag = "icon-whitered (EAST)";
 	icon_state = "whitered";
 	dir = 4
 	},
@@ -44078,7 +41881,6 @@
 /area/desert_dam/building/medical/surgury_observation)
 "bZx" = (
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (NORTH)";
 	icon_state = "pipe-c";
 	dir = 1
 	},
@@ -44140,8 +41942,7 @@
 /obj/item/flashlight,
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/building/telecommunication)
 "bZH" = (
@@ -44155,8 +41956,7 @@
 "bZI" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/floor,
 /area/desert_dam/exterior/valley/valley_telecoms)
@@ -44233,7 +42033,6 @@
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
 	icon_state = "tube1";
 	dir = 4
 	},
@@ -44244,8 +42043,7 @@
 "bZT" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	tag = "icon-tube1 (EAST)"
+	icon_state = "tube1"
 	},
 /turf/open/floor{
 	dir = 8;
@@ -44267,19 +42065,16 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (NORTH)";
 	icon_state = "pipe-c";
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
 /area/desert_dam/building/medical/west_wing_hallway)
 "bZV" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -44297,7 +42092,6 @@
 /area/desert_dam/building/medical/west_wing_hallway)
 "bZW" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -44306,7 +42100,6 @@
 	layer = 2.4
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -44316,7 +42109,6 @@
 /area/desert_dam/building/medical/primary_storage)
 "bZX" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -44347,14 +42139,12 @@
 	stored_metal = 1000
 	},
 /turf/open/floor{
-	tag = "icon-whitered (NORTHWEST)";
 	icon_state = "whitered";
 	dir = 9
 	},
 /area/desert_dam/building/medical/surgery_room_one)
 "caa" = (
 /turf/open/floor{
-	tag = "icon-whitered (NORTH)";
 	icon_state = "whitered";
 	dir = 1
 	},
@@ -44365,7 +42155,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-whitered (NORTH)";
 	icon_state = "whitered";
 	dir = 1
 	},
@@ -44377,7 +42166,6 @@
 	pixel_y = -5
 	},
 /turf/open/floor{
-	tag = "icon-whitered (NORTHEAST)";
 	icon_state = "whitered";
 	dir = 5
 	},
@@ -44390,14 +42178,12 @@
 	stored_metal = 1000
 	},
 /turf/open/floor{
-	tag = "icon-whitered (NORTHWEST)";
 	icon_state = "whitered";
 	dir = 9
 	},
 /area/desert_dam/building/medical/surgery_room_two)
 "caf" = (
 /turf/open/floor{
-	tag = "icon-whitered (NORTH)";
 	icon_state = "whitered";
 	dir = 1
 	},
@@ -44405,7 +42191,6 @@
 "cag" = (
 /obj/machinery/iv_drip,
 /turf/open/floor{
-	tag = "icon-whitered (NORTH)";
 	icon_state = "whitered";
 	dir = 1
 	},
@@ -44417,7 +42202,6 @@
 	pixel_y = -5
 	},
 /turf/open/floor{
-	tag = "icon-whitered (NORTHEAST)";
 	icon_state = "whitered";
 	dir = 5
 	},
@@ -44447,8 +42231,7 @@
 "cam" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 4;
-	icon_state = "wooden_chair";
-	tag = ""
+	icon_state = "wooden_chair"
 	},
 /obj/machinery/light,
 /turf/open/floor{
@@ -44458,8 +42241,7 @@
 "can" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 4;
-	icon_state = "wooden_chair";
-	tag = ""
+	icon_state = "wooden_chair"
 	},
 /obj/machinery/light,
 /turf/open/floor{
@@ -44521,7 +42303,6 @@
 /area/desert_dam/exterior/river/riverside_south)
 "caw" = (
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
@@ -44538,7 +42319,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
@@ -44569,14 +42349,12 @@
 	pixel_y = 3
 	},
 /turf/open/floor{
-	tag = "icon-whitered (EAST)";
 	icon_state = "whitered";
 	dir = 4
 	},
 /area/desert_dam/building/medical/primary_storage)
 "caB" = (
 /turf/open/floor{
-	tag = "icon-whitered (WEST)";
 	icon_state = "whitered";
 	dir = 8
 	},
@@ -44594,14 +42372,12 @@
 /obj/item/stack/nanopaste,
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-whitered (EAST)";
 	icon_state = "whitered";
 	dir = 4
 	},
 /area/desert_dam/building/medical/surgery_room_one)
 "caE" = (
 /turf/open/floor{
-	tag = "icon-whitered (WEST)";
 	icon_state = "whitered";
 	dir = 8
 	},
@@ -44619,7 +42395,6 @@
 /obj/item/stack/nanopaste,
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-whitered (EAST)";
 	icon_state = "whitered";
 	dir = 4
 	},
@@ -44629,7 +42404,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (EAST)";
 	icon_state = "whitegreen";
 	dir = 4
 	},
@@ -44664,8 +42438,7 @@
 /obj/item/folder/black_random,
 /turf/open/floor{
 	dir = 10;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/building/telecommunication)
 "caP" = (
@@ -44673,7 +42446,6 @@
 /obj/item/folder/yellow,
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-darkyellow2";
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/building/telecommunication)
@@ -44681,7 +42453,6 @@
 /obj/structure/table,
 /obj/item/encryptionkey,
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2 (WEST)";
 	icon_state = "darkyellowcorners2";
 	dir = 8
 	},
@@ -44691,7 +42462,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2";
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/building/telecommunication)
@@ -44764,8 +42534,7 @@
 	},
 /turf/open/floor{
 	dir = 8;
-	icon_state = "whiteredcorner";
-	tag = "icon-whiteredcorner (NORTH)"
+	icon_state = "whiteredcorner"
 	},
 /area/desert_dam/building/medical/primary_storage)
 "cba" = (
@@ -44778,7 +42547,6 @@
 	pixel_x = 5
 	},
 /turf/open/floor{
-	tag = "icon-whitered (EAST)";
 	icon_state = "whitered";
 	dir = 4
 	},
@@ -44789,7 +42557,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whitered (WEST)";
 	icon_state = "whitered";
 	dir = 8
 	},
@@ -44803,7 +42570,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitered (EAST)";
 	icon_state = "whitered";
 	dir = 4
 	},
@@ -44814,7 +42580,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whitered (WEST)";
 	icon_state = "whitered";
 	dir = 8
 	},
@@ -44828,7 +42593,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitered (EAST)";
 	icon_state = "whitered";
 	dir = 4
 	},
@@ -44839,7 +42603,6 @@
 "cbg" = (
 /obj/machinery/computer/crew,
 /turf/open/floor{
-	tag = "icon-whitered (NORTHWEST)";
 	icon_state = "whitered";
 	dir = 9
 	},
@@ -44847,7 +42610,6 @@
 "cbh" = (
 /obj/machinery/computer/med_data,
 /turf/open/floor{
-	tag = "icon-whitered (NORTH)";
 	icon_state = "whitered";
 	dir = 1
 	},
@@ -44855,7 +42617,6 @@
 "cbi" = (
 /obj/structure/closet/secure_closet/medical_doctor,
 /turf/open/floor{
-	tag = "icon-whitered (NORTH)";
 	icon_state = "whitered";
 	dir = 1
 	},
@@ -44863,7 +42624,6 @@
 "cbj" = (
 /obj/structure/closet,
 /turf/open/floor{
-	tag = "icon-whitered (NORTHEAST)";
 	icon_state = "whitered";
 	dir = 5
 	},
@@ -44871,7 +42631,6 @@
 "cbk" = (
 /obj/machinery/computer/crew,
 /turf/open/floor{
-	tag = "icon-whitered (NORTHWEST)";
 	icon_state = "whitered";
 	dir = 9
 	},
@@ -44879,7 +42638,6 @@
 "cbl" = (
 /obj/machinery/computer/med_data,
 /turf/open/floor{
-	tag = "icon-whitered (NORTH)";
 	icon_state = "whitered";
 	dir = 1
 	},
@@ -44887,7 +42645,6 @@
 "cbm" = (
 /obj/structure/closet/secure_closet/medical_doctor,
 /turf/open/floor{
-	tag = "icon-whitered (NORTH)";
 	icon_state = "whitered";
 	dir = 1
 	},
@@ -44895,7 +42652,6 @@
 "cbn" = (
 /obj/structure/closet,
 /turf/open/floor{
-	tag = "icon-whitered (NORTHEAST)";
 	icon_state = "whitered";
 	dir = 5
 	},
@@ -44922,7 +42678,6 @@
 	dir = 8
 	},
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (EAST)";
 	icon_state = "bulb1";
 	dir = 4
 	},
@@ -44977,8 +42732,7 @@
 /obj/item/tool/hand_labeler,
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/building/telecommunication)
 "cbA" = (
@@ -44987,7 +42741,6 @@
 	amount = 50
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2";
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/building/telecommunication)
@@ -44997,7 +42750,6 @@
 	amount = 50
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2 (SOUTHEAST)";
 	icon_state = "darkyellow2";
 	dir = 6
 	},
@@ -45072,8 +42824,7 @@
 "cbL" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/ground/desertdam/river/toxic/deep_water_toxic,
 /area/desert_dam/exterior/river/riverside_south)
@@ -45136,7 +42887,6 @@
 /obj/item/bodybag/cryobag,
 /obj/item/storage/box/syringes,
 /turf/open/floor{
-	tag = "icon-whitered (WEST)";
 	icon_state = "whitered";
 	dir = 8
 	},
@@ -45144,7 +42894,6 @@
 "cbU" = (
 /obj/structure/closet/secure_closet/medical3/colony,
 /turf/open/floor{
-	tag = "icon-whitered (EAST)";
 	icon_state = "whitered";
 	dir = 4
 	},
@@ -45157,7 +42906,6 @@
 	pixel_y = 0
 	},
 /turf/open/floor{
-	tag = "icon-whitered (WEST)";
 	icon_state = "whitered";
 	dir = 8
 	},
@@ -45178,7 +42926,6 @@
 	name = "Surgery Cleaner"
 	},
 /turf/open/floor{
-	tag = "icon-whitered (EAST)";
 	icon_state = "whitered";
 	dir = 4
 	},
@@ -45191,7 +42938,6 @@
 	pixel_y = 0
 	},
 /turf/open/floor{
-	tag = "icon-whitered (WEST)";
 	icon_state = "whitered";
 	dir = 8
 	},
@@ -45212,7 +42958,6 @@
 	name = "Surgery Cleaner"
 	},
 /turf/open/floor{
-	tag = "icon-whitered (EAST)";
 	icon_state = "whitered";
 	dir = 4
 	},
@@ -45220,7 +42965,6 @@
 "ccb" = (
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-whitered (WEST)";
 	icon_state = "whitered";
 	dir = 8
 	},
@@ -45243,7 +42987,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitered (EAST)";
 	icon_state = "whitered";
 	dir = 4
 	},
@@ -45251,7 +42994,6 @@
 "ccf" = (
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-whitered (WEST)";
 	icon_state = "whitered";
 	dir = 8
 	},
@@ -45274,7 +43016,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitered (EAST)";
 	icon_state = "whitered";
 	dir = 4
 	},
@@ -45369,7 +43110,6 @@
 /area/desert_dam/building/water_treatment_two)
 "ccw" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -45469,7 +43209,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whitered (EAST)";
 	icon_state = "whitered";
 	dir = 4
 	},
@@ -45483,7 +43222,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitered (WEST)";
 	icon_state = "whitered";
 	dir = 8
 	},
@@ -45497,7 +43235,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitered (WEST)";
 	icon_state = "whitered";
 	dir = 8
 	},
@@ -45518,7 +43255,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whitered (EAST)";
 	icon_state = "whitered";
 	dir = 4
 	},
@@ -45532,7 +43268,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whitered (EAST)";
 	icon_state = "whitered";
 	dir = 4
 	},
@@ -45550,7 +43285,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (EAST)";
 	icon_state = "whitegreen";
 	dir = 4
 	},
@@ -45558,12 +43292,10 @@
 "ccT" = (
 /obj/machinery/iv_drip,
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTHWEST)";
 	icon_state = "whitegreen";
 	dir = 9
 	},
@@ -45576,26 +43308,22 @@
 	pixel_y = 3
 	},
 /turf/open/floor{
-	tag = "icon-whitered (WEST)";
 	icon_state = "whitered";
 	dir = 8
 	},
 /area/desert_dam/building/medical/primary_storage)
 "ccV" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
 /area/desert_dam/building/medical/east_wing_hallway)
 "ccW" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -45623,26 +43351,22 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whitered (EAST)";
 	icon_state = "whitered";
 	dir = 4
 	},
 /area/desert_dam/building/medical/surgery_room_one)
 "ccZ" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
 /turf/open/floor{
-	tag = "icon-whitegreencorner (NORTH)";
 	icon_state = "whitegreencorner";
 	dir = 1
 	},
 /area/desert_dam/building/medical/patient_wing)
 "cda" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -45670,7 +43394,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whitered (EAST)";
 	icon_state = "whitered";
 	dir = 4
 	},
@@ -45678,7 +43401,6 @@
 "cdd" = (
 /obj/structure/bed,
 /turf/open/floor{
-	tag = "icon-whitered (EAST)";
 	icon_state = "whitered";
 	dir = 4
 	},
@@ -45686,7 +43408,6 @@
 "cde" = (
 /obj/structure/bed,
 /turf/open/floor{
-	tag = "icon-whitered (EAST)";
 	icon_state = "whitered";
 	dir = 4
 	},
@@ -45798,7 +43519,6 @@
 /area/desert_dam/building/medical/emergency_room)
 "cdv" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/medical/emergency_room)
@@ -45837,7 +43557,6 @@
 /obj/item/defibrillator,
 /obj/structure/table,
 /turf/open/floor{
-	tag = "icon-whitered (SOUTHWEST)";
 	icon_state = "whitered";
 	dir = 10
 	},
@@ -45845,7 +43564,6 @@
 "cdA" = (
 /obj/machinery/iv_drip,
 /turf/open/floor{
-	tag = "icon-whitered";
 	icon_state = "whitered";
 	dir = 2
 	},
@@ -45853,7 +43571,6 @@
 "cdB" = (
 /obj/structure/closet/secure_closet/medical3/colony,
 /turf/open/floor{
-	tag = "icon-whitered (SOUTHEAST)";
 	icon_state = "whitered";
 	dir = 6
 	},
@@ -45861,7 +43578,6 @@
 "cdC" = (
 /obj/machinery/bodyscanner,
 /turf/open/floor{
-	tag = "icon-whitered (SOUTHWEST)";
 	icon_state = "whitered";
 	dir = 10
 	},
@@ -45870,8 +43586,7 @@
 /obj/machinery/body_scanconsole,
 /turf/open/floor{
 	dir = 8;
-	icon_state = "whiteredcorner";
-	tag = "icon-whiteredcorner (NORTH)"
+	icon_state = "whiteredcorner"
 	},
 /area/desert_dam/building/medical/surgery_room_one)
 "cdE" = (
@@ -45887,7 +43602,6 @@
 /area/desert_dam/building/medical/surgery_room_one)
 "cdF" = (
 /turf/open/floor{
-	tag = "icon-whitered (EAST)";
 	icon_state = "whitered";
 	dir = 4
 	},
@@ -45895,7 +43609,6 @@
 "cdG" = (
 /obj/machinery/bodyscanner,
 /turf/open/floor{
-	tag = "icon-whitered (SOUTHWEST)";
 	icon_state = "whitered";
 	dir = 10
 	},
@@ -45904,8 +43617,7 @@
 /obj/machinery/body_scanconsole,
 /turf/open/floor{
 	dir = 8;
-	icon_state = "whiteredcorner";
-	tag = "icon-whiteredcorner (NORTH)"
+	icon_state = "whiteredcorner"
 	},
 /area/desert_dam/building/medical/surgery_room_two)
 "cdI" = (
@@ -45921,14 +43633,12 @@
 /area/desert_dam/building/medical/surgery_room_two)
 "cdJ" = (
 /turf/open/floor{
-	tag = "icon-whitered (EAST)";
 	icon_state = "whitered";
 	dir = 4
 	},
 /area/desert_dam/building/medical/surgery_room_two)
 "cdK" = (
 /turf/open/floor{
-	tag = "icon-whitered (WEST)";
 	icon_state = "whitered";
 	dir = 8
 	},
@@ -45945,7 +43655,6 @@
 /area/desert_dam/building/medical/office1)
 "cdM" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained{
@@ -45955,7 +43664,6 @@
 /area/desert_dam/building/medical/garage)
 "cdN" = (
 /turf/open/floor{
-	tag = "icon-whitered (WEST)";
 	icon_state = "whitered";
 	dir = 8
 	},
@@ -45972,7 +43680,6 @@
 /area/desert_dam/building/medical/office2)
 "cdP" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
@@ -46052,7 +43759,6 @@
 	dir = 1
 	},
 /turf/open/floor/plating{
-	tag = "icon-warnplate (EAST)";
 	icon_state = "warnplate";
 	dir = 4
 	},
@@ -46073,7 +43779,6 @@
 /obj/structure/table/reinforced,
 /obj/item/reagent_container/hypospray,
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTHWEST)";
 	icon_state = "whitegreen";
 	dir = 9
 	},
@@ -46083,7 +43788,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (NORTH)";
 	icon_state = "whitegreencorner";
 	dir = 1
 	},
@@ -46095,7 +43799,6 @@
 /area/desert_dam/building/medical/emergency_room)
 "cef" = (
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
@@ -46109,7 +43812,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (EAST)";
 	icon_state = "whitegreen";
 	dir = 4
 	},
@@ -46122,14 +43824,12 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
 /area/desert_dam/building/medical/emergency_room)
 "cei" = (
 /turf/open/floor{
-	tag = "icon-whitegreencorner (NORTH)";
 	icon_state = "whitegreencorner";
 	dir = 1
 	},
@@ -46138,7 +43838,6 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor{
-	tag = "icon-whitegreen (EAST)";
 	icon_state = "whitegreen";
 	dir = 4
 	},
@@ -46247,7 +43946,6 @@
 /area/desert_dam/building/medical/patient_wing)
 "cex" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /obj/structure/desertdam/decals/road_stop{
@@ -46258,7 +43956,6 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "cey" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /obj/structure/desertdam/decals/road_stop,
@@ -46323,7 +44020,6 @@
 /area/desert_dam/building/medical/garage)
 "ceH" = (
 /turf/open/floor/plating{
-	tag = "icon-warnplate (EAST)";
 	icon_state = "warnplate";
 	dir = 4
 	},
@@ -46354,7 +44050,6 @@
 	pixel_y = 5
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (WEST)";
 	icon_state = "whitegreen";
 	dir = 8
 	},
@@ -46388,7 +44083,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
@@ -46409,7 +44103,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
@@ -46417,7 +44110,6 @@
 "ceP" = (
 /obj/machinery/vending/medical,
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
@@ -46425,7 +44117,6 @@
 "ceQ" = (
 /obj/machinery/vending/MarineMed/Blood,
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
@@ -46433,7 +44124,6 @@
 "ceR" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /turf/open/floor{
@@ -46442,14 +44132,12 @@
 /area/desert_dam/building/library/library)
 "ceS" = (
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
 /area/desert_dam/building/medical/treatment_room)
 "ceT" = (
 /turf/open/floor{
-	tag = "icon-whitegreencorner (NORTH)";
 	icon_state = "whitegreencorner";
 	dir = 1
 	},
@@ -46467,7 +44155,6 @@
 /area/desert_dam/building/medical/treatment_room)
 "ceV" = (
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
@@ -46477,7 +44164,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
@@ -46492,7 +44178,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen";
 	icon_state = "whitegreen";
 	dir = 2
 	},
@@ -46511,7 +44196,6 @@
 /area/desert_dam/building/medical/east_wing_hallway)
 "cfb" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
@@ -46521,14 +44205,12 @@
 /area/desert_dam/building/bar/bar_restroom)
 "cfc" = (
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
 /area/desert_dam/building/medical/east_wing_hallway)
 "cfd" = (
 /turf/open/floor{
-	tag = "icon-whitegreencorner (NORTH)";
 	icon_state = "whitegreencorner";
 	dir = 1
 	},
@@ -46549,14 +44231,12 @@
 /area/desert_dam/building/medical/patient_wing)
 "cfg" = (
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
 /area/desert_dam/building/medical/patient_wing)
 "cfh" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
@@ -46572,7 +44252,6 @@
 /area/desert_dam/building/medical/patient_wing)
 "cfj" = (
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
@@ -46580,14 +44259,12 @@
 "cfk" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
 /area/desert_dam/building/medical/patient_wing)
 "cfl" = (
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTHEAST)";
 	icon_state = "whitegreen";
 	dir = 5
 	},
@@ -46600,8 +44277,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -46611,7 +44287,6 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "cfo" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /obj/structure/desertdam/decals/road_stop{
@@ -46619,7 +44294,6 @@
 	icon_state = "stop_decal5"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -46630,7 +44304,6 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "cfp" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /obj/structure/desertdam/decals/road_stop{
@@ -46699,13 +44372,11 @@
 	},
 /turf/open/floor{
 	dir = 1;
-	icon_state = "whiteyellowcorner";
-	tag = "icon-whiteyellowcorner (EAST)"
+	icon_state = "whiteyellowcorner"
 	},
 /area/desert_dam/building/warehouse/breakroom)
 "cfz" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
@@ -46713,7 +44384,6 @@
 /area/desert_dam/building/warehouse/warehouse)
 "cfA" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
@@ -46743,7 +44413,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
@@ -46751,7 +44420,6 @@
 "cfE" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
@@ -46763,7 +44431,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (NORTH)";
 	icon_state = "whitegreencorner";
 	dir = 1
 	},
@@ -46777,7 +44444,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
@@ -46790,7 +44456,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
@@ -46825,14 +44490,12 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (NORTH)";
 	icon_state = "whitegreencorner";
 	dir = 1
 	},
 /area/desert_dam/building/medical/east_wing_hallway)
 "cfM" = (
 /turf/open/floor{
-	tag = "icon-whitegreencorner (NORTH)";
 	icon_state = "whitegreencorner";
 	dir = 1
 	},
@@ -46844,7 +44507,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (NORTH)";
 	icon_state = "whitegreencorner";
 	dir = 1
 	},
@@ -46858,14 +44520,12 @@
 "cfP" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-whitegreencorner (NORTH)";
 	icon_state = "whitegreencorner";
 	dir = 1
 	},
 /area/desert_dam/building/medical/patient_wing)
 "cfQ" = (
 /turf/open/floor{
-	tag = "icon-whitegreen (EAST)";
 	icon_state = "whitegreen";
 	dir = 4
 	},
@@ -46923,18 +44583,15 @@
 /area/desert_dam/building/cafeteria/cold_room)
 "cfY" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/hydroponics/hydroponics_loading)
 "cfZ" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -46944,19 +44601,16 @@
 /area/desert_dam/building/medical/emergency_room)
 "cga" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (NORTH)";
 	icon_state = "whitegreencorner";
 	dir = 1
 	},
 /area/desert_dam/building/medical/emergency_room)
 "cgb" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -46970,7 +44624,6 @@
 /area/desert_dam/building/medical/emergency_room)
 "cgc" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -46984,7 +44637,6 @@
 /area/desert_dam/building/medical/emergency_room)
 "cgd" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -46993,7 +44645,6 @@
 	layer = 2.4
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
@@ -47002,8 +44653,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -47011,27 +44661,23 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
 /area/desert_dam/building/medical/emergency_room)
 "cgf" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained{
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/hydroponics/hydroponics_storage)
 "cgg" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -47040,7 +44686,6 @@
 	layer = 2.4
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -47050,7 +44695,6 @@
 /area/desert_dam/building/medical/emergency_room)
 "cgh" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -47059,46 +44703,39 @@
 	layer = 2.4
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
 /area/desert_dam/building/medical/treatment_room)
 "cgi" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4;
 	layer = 2.4
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
 /area/desert_dam/building/medical/treatment_room)
 "cgj" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -47107,7 +44744,6 @@
 	layer = 2.4
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -47117,19 +44753,16 @@
 /area/desert_dam/building/medical/treatment_room)
 "cgk" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j1 (WEST)";
 	icon_state = "pipe-j1";
 	dir = 8
 	},
@@ -47139,22 +44772,19 @@
 /area/desert_dam/building/medical/treatment_room)
 "cgl" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4;
 	layer = 2.4
 	},
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j1 (WEST)";
 	icon_state = "pipe-j1";
 	dir = 8
 	},
@@ -47178,7 +44808,6 @@
 /area/desert_dam/building/cafeteria/loading)
 "cgo" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -47200,13 +44829,11 @@
 /area/desert_dam/building/medical/east_wing_hallway)
 "cgp" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j1 (WEST)";
 	icon_state = "pipe-j1";
 	dir = 8
 	},
@@ -47216,13 +44843,11 @@
 /area/desert_dam/building/medical/east_wing_hallway)
 "cgq" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -47232,22 +44857,19 @@
 /area/desert_dam/building/medical/east_wing_hallway)
 "cgr" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4;
 	layer = 2.4
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -47258,7 +44880,6 @@
 /area/desert_dam/building/medical/east_wing_hallway)
 "cgs" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -47267,7 +44888,6 @@
 	layer = 2.4
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -47280,8 +44900,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -47289,7 +44908,6 @@
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -47311,7 +44929,6 @@
 	name = "\improper Patient Wing"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -47320,7 +44937,6 @@
 	layer = 2.4
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -47330,7 +44946,6 @@
 /area/desert_dam/building/medical/patient_wing)
 "cgv" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -47339,7 +44954,6 @@
 	layer = 2.4
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -47350,7 +44964,6 @@
 /area/desert_dam/building/medical/patient_wing)
 "cgw" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -47359,12 +44972,10 @@
 	layer = 2.4
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (NORTH)";
 	icon_state = "whitegreencorner";
 	dir = 1
 	},
@@ -47373,15 +44984,13 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4;
 	layer = 2.4
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -47396,7 +45005,6 @@
 	on = 1
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -47407,7 +45015,6 @@
 /area/desert_dam/building/medical/patient_wing)
 "cgz" = (
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -47429,8 +45036,7 @@
 "cgB" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
-	pixel_x = 0;
-	tag = "icon-E-corner"
+	pixel_x = 0
 	},
 /obj/structure/desertdam/decals/road_stop{
 	dir = 1;
@@ -47450,7 +45056,6 @@
 	icon_state = "stop_decal5"
 	},
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -47486,7 +45091,6 @@
 /area/desert_dam/building/security/lobby)
 "cgH" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
@@ -47537,7 +45141,6 @@
 /area/desert_dam/building/medical/treatment_room)
 "cgN" = (
 /turf/open/floor{
-	tag = "icon-whitegreen (EAST)";
 	icon_state = "whitegreen";
 	dir = 4
 	},
@@ -47588,7 +45191,6 @@
 "cgT" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor{
-	tag = "icon-whitepurple (SOUTHEAST)";
 	icon_state = "whitepurple";
 	dir = 6
 	},
@@ -47675,7 +45277,6 @@
 /obj/item/defibrillator,
 /obj/item/defibrillator,
 /turf/open/floor{
-	tag = "icon-whitegreen";
 	icon_state = "whitegreen";
 	dir = 2
 	},
@@ -47709,7 +45310,6 @@
 /obj/item/roller,
 /obj/item/roller,
 /turf/open/floor{
-	tag = "icon-whitegreen";
 	icon_state = "whitegreen";
 	dir = 2
 	},
@@ -47717,7 +45317,6 @@
 "chl" = (
 /obj/machinery/sleeper,
 /turf/open/floor{
-	tag = "icon-whitegreen";
 	icon_state = "whitegreen";
 	dir = 2
 	},
@@ -47725,7 +45324,6 @@
 "chm" = (
 /obj/machinery/sleep_console,
 /turf/open/floor{
-	tag = "icon-whitegreen";
 	icon_state = "whitegreen";
 	dir = 2
 	},
@@ -47733,14 +45331,12 @@
 "chn" = (
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-whitegreen";
 	icon_state = "whitegreen";
 	dir = 2
 	},
 /area/desert_dam/building/medical/emergency_room)
 "cho" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
@@ -47751,7 +45347,6 @@
 /area/desert_dam/building/security/northern_hallway)
 "chp" = (
 /turf/open/floor{
-	tag = "icon-whitegreen";
 	icon_state = "whitegreen";
 	dir = 2
 	},
@@ -47765,14 +45360,12 @@
 "chr" = (
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-whitegreen";
 	icon_state = "whitegreen";
 	dir = 2
 	},
 /area/desert_dam/building/medical/treatment_room)
 "chs" = (
 /turf/open/floor{
-	tag = "icon-whitegreen (SOUTHEAST)";
 	icon_state = "whitegreen";
 	dir = 6
 	},
@@ -47869,7 +45462,6 @@
 /area/desert_dam/building/library/library)
 "chI" = (
 /turf/open/floor/plating{
-	tag = "icon-warnplate (SOUTHWEST)";
 	icon_state = "warnplate";
 	dir = 10
 	},
@@ -47961,8 +45553,7 @@
 /obj/item/roller,
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	tag = "icon-tube1 (EAST)"
+	icon_state = "tube1"
 	},
 /turf/open/floor/plating,
 /area/desert_dam/building/medical/garage)
@@ -47983,7 +45574,6 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
@@ -47996,7 +45586,6 @@
 /obj/machinery/recharger,
 /obj/item/reagent_container/spray/cleaner,
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
@@ -48004,21 +45593,18 @@
 "cib" = (
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-whitegreen (SOUTHWEST)";
 	icon_state = "whitegreen";
 	dir = 10
 	},
 /area/desert_dam/building/medical/emergency_room)
 "cic" = (
 /turf/open/floor{
-	tag = "icon-whitegreen";
 	icon_state = "whitegreen";
 	dir = 2
 	},
 /area/desert_dam/building/medical/emergency_room)
 "cid" = (
 /turf/open/floor{
-	tag = "icon-whitegreen (SOUTHEAST)";
 	icon_state = "whitegreen";
 	dir = 6
 	},
@@ -48035,7 +45621,6 @@
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
@@ -48043,7 +45628,6 @@
 "cig" = (
 /obj/machinery/iv_drip,
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
@@ -48052,7 +45636,6 @@
 /obj/machinery/iv_drip,
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
@@ -48073,7 +45656,6 @@
 "cik" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTHWEST)";
 	icon_state = "whitegreen";
 	dir = 9
 	},
@@ -48081,7 +45663,6 @@
 "cil" = (
 /obj/machinery/computer/crew,
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
@@ -48089,14 +45670,12 @@
 "cim" = (
 /obj/machinery/computer/med_data,
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
 /area/desert_dam/building/medical/virology_wing)
 "cin" = (
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
@@ -48105,7 +45684,6 @@
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTHEAST)";
 	icon_state = "whitegreen";
 	dir = 5
 	},
@@ -48116,14 +45694,12 @@
 /area/desert_dam/building/medical/virology_wing)
 "ciq" = (
 /turf/open/floor{
-	tag = "icon-whitegreen (WEST)";
 	icon_state = "whitegreen";
 	dir = 8
 	},
 /area/desert_dam/building/medical/virology_wing)
 "cir" = (
 /turf/open/floor{
-	tag = "icon-whitegreen";
 	icon_state = "whitegreen";
 	dir = 2
 	},
@@ -48137,14 +45713,12 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-whitegreen";
 	icon_state = "whitegreen";
 	dir = 2
 	},
 /area/desert_dam/building/medical/virology_wing)
 "cit" = (
 /turf/open/floor{
-	tag = "icon-whitegreen (EAST)";
 	icon_state = "whitegreen";
 	dir = 4
 	},
@@ -48180,7 +45754,6 @@
 "ciz" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /turf/open/floor{
@@ -48205,8 +45778,7 @@
 "ciC" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
-	pixel_x = 0;
-	tag = "icon-E-corner"
+	pixel_x = 0
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -48291,7 +45863,6 @@
 	pixel_y = 8
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTHWEST)";
 	icon_state = "whitegreen";
 	dir = 9
 	},
@@ -48302,7 +45873,6 @@
 	pixel_y = 3
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (NORTH)";
 	icon_state = "whitegreencorner";
 	dir = 1
 	},
@@ -48310,7 +45880,6 @@
 "ciO" = (
 /obj/machinery/computer/crew,
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
@@ -48318,7 +45887,6 @@
 "ciP" = (
 /obj/machinery/computer/med_data,
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTHEAST)";
 	icon_state = "whitegreen";
 	dir = 5
 	},
@@ -48348,14 +45916,12 @@
 "ciT" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
 /area/desert_dam/building/medical/virology_wing)
 "ciU" = (
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
@@ -48369,7 +45935,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
@@ -48382,7 +45947,6 @@
 /area/desert_dam/building/medical/patient_wing)
 "ciX" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
@@ -48420,8 +45984,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4;
@@ -48431,7 +45994,6 @@
 /area/desert_dam/building/bar/backroom)
 "cjc" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -48447,7 +46009,6 @@
 /area/desert_dam/building/bar/backroom)
 "cjd" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -48571,7 +46132,6 @@
 /area/desert_dam/building/library/studyroom)
 "cjt" = (
 /obj/structure/bed/chair/comfy/black{
-	tag = "icon-comfychair (WEST)";
 	icon_state = "comfychair";
 	dir = 8
 	},
@@ -48605,7 +46165,6 @@
 /area/desert_dam/exterior/valley/valley_telecoms)
 "cjx" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (NORTH)";
 	icon_state = "platform_deco";
 	dir = 1
 	},
@@ -48640,7 +46199,6 @@
 	pixel_y = 10
 	},
 /turf/open/floor/prison{
-	tag = "icon-whitegreenfull (SOUTHWEST)";
 	icon_state = "whitegreenfull";
 	dir = 10
 	},
@@ -48675,7 +46233,6 @@
 	req_access_txt = "0"
 	},
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
@@ -48696,7 +46253,6 @@
 /area/desert_dam/building/medical/virology_wing)
 "cjH" = (
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (NORTH)";
 	icon_state = "pipe-c";
 	dir = 1
 	},
@@ -48707,7 +46263,6 @@
 "cjI" = (
 /obj/machinery/door/airlock/almayer/generic,
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -48717,24 +46272,20 @@
 /area/desert_dam/building/medical/virology_wing)
 "cjJ" = (
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (WEST)";
 	icon_state = "whitegreen";
 	dir = 8
 	},
 /area/desert_dam/building/medical/virology_wing)
 "cjK" = (
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
@@ -48743,8 +46294,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/junction{
@@ -48752,7 +46302,6 @@
 	icon_state = "pipe-j2"
 	},
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
@@ -48778,8 +46327,7 @@
 "cjO" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 4;
-	icon_state = "wooden_chair";
-	tag = ""
+	icon_state = "wooden_chair"
 	},
 /turf/open/floor{
 	icon_state = "wood"
@@ -48794,8 +46342,7 @@
 "cjQ" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 8;
-	icon_state = "wooden_chair";
-	tag = ""
+	icon_state = "wooden_chair"
 	},
 /obj/machinery/light,
 /turf/open/floor{
@@ -48820,7 +46367,6 @@
 /area/desert_dam/building/bar/bar)
 "cjT" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained{
@@ -48832,7 +46378,6 @@
 /area/desert_dam/building/security/courtroom)
 "cjU" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -48842,7 +46387,6 @@
 /area/desert_dam/building/library/restroom)
 "cjV" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -48856,7 +46400,6 @@
 /area/desert_dam/building/library/restroom)
 "cjW" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -48871,7 +46414,6 @@
 "cjX" = (
 /obj/machinery/door/airlock/almayer/generic,
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -48940,8 +46482,7 @@
 "ckf" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/ground/desertdam/river/toxic/shallow_edge_toxic{
 	icon_state = "shallow_to_deep_toxic_water5"
@@ -48960,12 +46501,10 @@
 /area/desert_dam/exterior/river/riverside_south)
 "ckh" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
 	icon_state = "tube1";
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (WEST)";
 	icon_state = "whitegreen";
 	dir = 8
 	},
@@ -48995,7 +46534,6 @@
 /area/desert_dam/building/bar/bar_restroom)
 "ckm" = (
 /turf/open/floor{
-	tag = "icon-whitegreen (SOUTHWEST)";
 	icon_state = "whitegreen";
 	dir = 10
 	},
@@ -49004,14 +46542,12 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
 /area/desert_dam/building/medical/virology_wing)
 "cko" = (
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
@@ -49043,7 +46579,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-darkredcorners2";
 	icon_state = "darkredcorners2"
 	},
 /area/desert_dam/building/security/southern_hallway)
@@ -49081,7 +46616,6 @@
 /area/desert_dam/building/library/restroom)
 "ckx" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
 	icon_state = "tube1";
 	dir = 4
 	},
@@ -49110,7 +46644,6 @@
 /area/desert_dam/building/library/library)
 "ckA" = (
 /obj/structure/bed/chair/comfy/black{
-	tag = "icon-comfychair (NORTH)";
 	icon_state = "comfychair";
 	dir = 1
 	},
@@ -49118,7 +46651,6 @@
 /area/desert_dam/building/library/studyroom)
 "ckB" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -49145,7 +46677,6 @@
 "ckE" = (
 /obj/machinery/photocopier,
 /turf/open/floor{
-	tag = "icon-whitegreen (SOUTHWEST)";
 	icon_state = "whitegreen";
 	dir = 10
 	},
@@ -49154,7 +46685,6 @@
 /obj/structure/table/reinforced,
 /obj/item/book/manual/medical_diagnostics_manual,
 /turf/open/floor{
-	tag = "icon-whitegreen";
 	icon_state = "whitegreen";
 	dir = 2
 	},
@@ -49163,7 +46693,6 @@
 /obj/structure/table/reinforced,
 /obj/item/defibrillator,
 /turf/open/floor{
-	tag = "icon-whitegreen";
 	icon_state = "whitegreen";
 	dir = 2
 	},
@@ -49176,7 +46705,6 @@
 	pixel_y = 3
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen";
 	icon_state = "whitegreen";
 	dir = 2
 	},
@@ -49186,7 +46714,6 @@
 /obj/item/bodybag/cryobag,
 /obj/item/storage/box/syringes,
 /turf/open/floor{
-	tag = "icon-whitegreen (SOUTHEAST)";
 	icon_state = "whitegreen";
 	dir = 6
 	},
@@ -49203,7 +46730,6 @@
 /area/desert_dam/building/medical/virology_isolation)
 "ckL" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -49224,7 +46750,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (WEST)";
 	icon_state = "whitegreen";
 	dir = 8
 	},
@@ -49295,12 +46820,10 @@
 /area/desert_dam/building/library/studyroom)
 "ckY" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
 /turf/open/floor{
-	tag = "icon-darkredcorners2 (WEST)";
 	icon_state = "darkredcorners2";
 	dir = 8
 	},
@@ -49346,7 +46869,6 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "clf" = (
 /turf/open/floor/plating{
-	tag = "icon-warnplate (NORTHEAST)";
 	icon_state = "warnplate";
 	dir = 5
 	},
@@ -49374,14 +46896,12 @@
 "cli" = (
 /obj/structure/table,
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTHWEST)";
 	icon_state = "whitegreen";
 	dir = 9
 	},
 /area/desert_dam/building/medical/virology_isolation)
 "clj" = (
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
@@ -49390,7 +46910,6 @@
 /obj/structure/table,
 /obj/item/tool/weedkiller/D24,
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
@@ -49398,7 +46917,6 @@
 "cll" = (
 /obj/machinery/computer/operating,
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
@@ -49407,7 +46925,6 @@
 /obj/structure/table,
 /obj/item/storage/pill_bottle/spaceacillin,
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
@@ -49418,19 +46935,16 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
 /area/desert_dam/building/medical/virology_isolation)
 "clo" = (
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
@@ -49467,14 +46981,12 @@
 "cls" = (
 /obj/structure/closet/l3closet/virology,
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
 /area/desert_dam/building/medical/virology_wing)
 "clt" = (
 /turf/open/floor{
-	tag = "icon-whitegreencorner (NORTH)";
 	icon_state = "whitegreencorner";
 	dir = 1
 	},
@@ -49485,7 +46997,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
@@ -49496,7 +47007,6 @@
 	on = 1
 	},
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
@@ -49570,35 +47080,30 @@
 /area/desert_dam/exterior/valley/valley_telecoms)
 "clF" = (
 /obj/structure/cargo_container{
-	tag = "icon-red 0,0";
 	icon_state = "red 0,0"
 	},
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/valley_south_west)
 "clG" = (
 /obj/structure/cargo_container{
-	tag = "icon-red 1,0";
 	icon_state = "red 1,0"
 	},
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/valley_south_west)
 "clH" = (
 /obj/structure/cargo_container{
-	tag = "icon-red 2,0";
 	icon_state = "red 2,0"
 	},
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/valley_south_west)
 "clI" = (
 /turf/open/floor/plating{
-	tag = "icon-warnplate (EAST)";
 	icon_state = "warnplate";
 	dir = 4
 	},
 /area/desert_dam/exterior/valley/valley_south_west)
 "clJ" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -49609,8 +47114,7 @@
 "clK" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/floor/plating/ground/desertdam/desert{
 	icon_state = "desert5"
@@ -49619,14 +47123,12 @@
 "clL" = (
 /obj/structure/table,
 /turf/open/floor{
-	tag = "icon-whitegreen (WEST)";
 	icon_state = "whitegreen";
 	dir = 8
 	},
 /area/desert_dam/building/medical/virology_isolation)
 "clM" = (
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
@@ -49634,7 +47136,6 @@
 "clN" = (
 /obj/structure/bed/stool,
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
@@ -49643,21 +47144,18 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
 /area/desert_dam/building/medical/virology_isolation)
 "clP" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -49666,7 +47164,6 @@
 	layer = 2.4
 	},
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
@@ -49677,7 +47174,6 @@
 	layer = 2.4
 	},
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
@@ -49693,7 +47189,6 @@
 	layer = 2.4
 	},
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
@@ -49704,7 +47199,6 @@
 	layer = 2.4
 	},
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
@@ -49716,7 +47210,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
@@ -49724,14 +47217,12 @@
 "clU" = (
 /obj/machinery/chem_dispenser,
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
 /area/desert_dam/building/medical/virology_wing)
 "clV" = (
 /turf/open/floor{
-	tag = "icon-whitegreencorner";
 	icon_state = "whitegreencorner";
 	dir = 2
 	},
@@ -49750,7 +47241,6 @@
 /area/desert_dam/building/library/library)
 "clY" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
@@ -49772,22 +47262,19 @@
 /area/desert_dam/exterior/valley/valley_telecoms)
 "cmb" = (
 /obj/structure/cargo_container{
-	icon_state = "HD 1,0";
-	tag = "icon-WY 2,0"
+	icon_state = "HD 1,0"
 	},
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/valley_south_west)
 "cmc" = (
 /obj/structure/cargo_container{
-	icon_state = "HD 2,0";
-	tag = "icon-WY 2,0"
+	icon_state = "HD 2,0"
 	},
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/valley_south_west)
 "cmd" = (
 /obj/structure/cargo_container{
-	icon_state = "HD 3,0";
-	tag = "icon-WY 2,0"
+	icon_state = "HD 3,0"
 	},
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/valley_south_west)
@@ -49805,7 +47292,6 @@
 	on = 1
 	},
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
@@ -49815,7 +47301,6 @@
 	dir = 2
 	},
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
@@ -49827,7 +47312,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
@@ -49837,7 +47321,6 @@
 	dir = 2
 	},
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
@@ -49846,7 +47329,6 @@
 /obj/structure/bed/stool,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
@@ -49856,7 +47338,6 @@
 /obj/item/tank/anesthetic,
 /obj/item/storage/pill_bottle/spaceacillin,
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
@@ -49867,21 +47348,18 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-carpet6-2 (WEST)";
 	icon_state = "carpet6-2";
 	dir = 8
 	},
 /area/desert_dam/building/bar/bar)
 "cmm" = (
 /turf/open/floor{
-	tag = "icon-carpet14-10 (WEST)";
 	icon_state = "carpet14-10";
 	dir = 8
 	},
 /area/desert_dam/building/bar/bar)
 "cmn" = (
 /turf/open/floor{
-	tag = "icon-carpet10-8 (WEST)";
 	icon_state = "carpet10-8";
 	dir = 8
 	},
@@ -49908,7 +47386,6 @@
 /area/desert_dam/building/library/library)
 "cmq" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -49918,15 +47395,13 @@
 /area/desert_dam/building/library/library)
 "cmr" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/open/floor{
 	icon_state = "grimy"
@@ -49936,8 +47411,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor{
@@ -49947,14 +47421,12 @@
 "cmt" = (
 /obj/structure/table,
 /turf/open/floor{
-	tag = "icon-whitegreen (SOUTHWEST)";
 	icon_state = "whitegreen";
 	dir = 10
 	},
 /area/desert_dam/building/medical/virology_isolation)
 "cmu" = (
 /turf/open/floor{
-	tag = "icon-whitegreen";
 	icon_state = "whitegreen";
 	dir = 2
 	},
@@ -49962,7 +47434,6 @@
 "cmv" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor{
-	tag = "icon-whitegreen";
 	icon_state = "whitegreen";
 	dir = 2
 	},
@@ -49974,7 +47445,6 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor{
-	tag = "icon-darkred2 (EAST)";
 	icon_state = "darkred2";
 	dir = 4
 	},
@@ -49982,7 +47452,6 @@
 "cmx" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor{
-	tag = "icon-whitegreen";
 	icon_state = "whitegreen";
 	dir = 2
 	},
@@ -49993,7 +47462,6 @@
 /area/desert_dam/building/medical/virology_wing)
 "cmz" = (
 /turf/open/floor{
-	tag = "icon-whitegreencorner (WEST)";
 	icon_state = "whitegreencorner";
 	dir = 8
 	},
@@ -50003,7 +47471,6 @@
 /obj/machinery/reagentgrinder,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
@@ -50012,14 +47479,12 @@
 /obj/structure/table,
 /obj/item/storage/pill_bottle/spaceacillin,
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
 /area/desert_dam/building/medical/virology_wing)
 "cmC" = (
 /turf/open/floor{
-	tag = "icon-carpet7-3 (WEST)";
 	icon_state = "carpet7-3";
 	dir = 8
 	},
@@ -50027,7 +47492,6 @@
 "cmD" = (
 /obj/structure/device/piano,
 /turf/open/floor{
-	tag = "icon-carpet15-15 (WEST)";
 	icon_state = "carpet15-15";
 	dir = 8
 	},
@@ -50035,25 +47499,21 @@
 "cmE" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 8;
-	icon_state = "wooden_chair";
-	tag = ""
+	icon_state = "wooden_chair"
 	},
 /turf/open/floor{
-	tag = "icon-carpet15-15 (WEST)";
 	icon_state = "carpet15-15";
 	dir = 8
 	},
 /area/desert_dam/building/bar/bar)
 "cmF" = (
 /turf/open/floor{
-	tag = "icon-carpet11-12 (WEST)";
 	icon_state = "carpet11-12";
 	dir = 8
 	},
 /area/desert_dam/building/bar/bar)
 "cmG" = (
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (NORTH)";
 	icon_state = "pipe-c";
 	dir = 1
 	},
@@ -50062,8 +47522,7 @@
 "cmH" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 4;
-	icon_state = "wooden_chair";
-	tag = ""
+	icon_state = "wooden_chair"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50084,14 +47543,12 @@
 "cmJ" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 8;
-	icon_state = "wooden_chair";
-	tag = ""
+	icon_state = "wooden_chair"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -50108,7 +47565,6 @@
 /area/desert_dam/building/bar/bar)
 "cmK" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -50120,11 +47576,9 @@
 "cmL" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 4;
-	icon_state = "wooden_chair";
-	tag = ""
+	icon_state = "wooden_chair"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -50138,7 +47592,6 @@
 "cmM" = (
 /obj/structure/table/woodentable,
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -50152,11 +47605,9 @@
 "cmN" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 8;
-	icon_state = "wooden_chair";
-	tag = ""
+	icon_state = "wooden_chair"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -50169,7 +47620,6 @@
 /area/desert_dam/building/bar/bar)
 "cmO" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -50180,7 +47630,6 @@
 /area/desert_dam/building/bar/bar)
 "cmP" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -50195,7 +47644,6 @@
 "cmQ" = (
 /obj/structure/desertdam/decals/road_edge,
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -50208,8 +47656,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -50240,7 +47687,6 @@
 /area/desert_dam/building/library/library)
 "cmU" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -50251,7 +47697,6 @@
 "cmV" = (
 /obj/structure/table/woodentable,
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -50384,21 +47829,18 @@
 /area/desert_dam/exterior/landing_pad_two_external)
 "cnn" = (
 /obj/structure/cargo_container{
-	tag = "icon-WY 0,0";
 	icon_state = "WY 0,0"
 	},
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/valley_south_west)
 "cno" = (
 /obj/structure/cargo_container{
-	tag = "icon-WY 1,0";
 	icon_state = "WY 1,0"
 	},
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/valley_south_west)
 "cnp" = (
 /obj/structure/cargo_container{
-	tag = "icon-WY 2,0";
 	icon_state = "WY 2,0"
 	},
 /turf/open/floor/plating,
@@ -50408,7 +47850,6 @@
 	name = "\improper Showers"
 	},
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/security/staffroom)
@@ -50437,7 +47878,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitegreenfull";
 	icon_state = "whitegreenfull";
 	dir = 2
 	},
@@ -50447,7 +47887,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (SOUTHWEST)";
 	icon_state = "whitegreen";
 	dir = 10
 	},
@@ -50457,7 +47896,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen";
 	icon_state = "whitegreen";
 	dir = 2
 	},
@@ -50468,35 +47906,30 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen";
 	icon_state = "whitegreen";
 	dir = 2
 	},
 /area/desert_dam/building/medical/virology_wing)
 "cny" = (
 /turf/open/floor{
-	tag = "icon-whitegreen (SOUTHEAST)";
 	icon_state = "whitegreen";
 	dir = 6
 	},
 /area/desert_dam/building/medical/virology_wing)
 "cnz" = (
 /turf/open/floor{
-	tag = "icon-carpet5-1 (WEST)";
 	icon_state = "carpet5-1";
 	dir = 8
 	},
 /area/desert_dam/building/bar/bar)
 "cnA" = (
 /turf/open/floor{
-	tag = "icon-carpet13-5 (WEST)";
 	icon_state = "carpet13-5";
 	dir = 8
 	},
 /area/desert_dam/building/bar/bar)
 "cnB" = (
 /turf/open/floor{
-	tag = "icon-carpet9-4 (WEST)";
 	icon_state = "carpet9-4";
 	dir = 8
 	},
@@ -50504,8 +47937,7 @@
 "cnC" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 1;
-	icon_state = "wooden_chair";
-	tag = ""
+	icon_state = "wooden_chair"
 	},
 /turf/open/floor/wood,
 /area/desert_dam/building/bar/bar)
@@ -50540,7 +47972,6 @@
 /area/desert_dam/building/library/library)
 "cnH" = (
 /turf/open/floor/plating{
-	tag = "icon-warnplate";
 	icon_state = "warnplate"
 	},
 /area/desert_dam/interior/lab_northeast/xenobiology)
@@ -50586,14 +48017,12 @@
 "cnN" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
-	pixel_x = 0;
-	tag = "icon-E-corner"
+	pixel_x = 0
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
 /area/desert_dam/exterior/landing_pad_two_external)
 "cnO" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -50630,8 +48059,7 @@
 "cnV" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
-	pixel_x = 0;
-	tag = "icon-E-corner"
+	pixel_x = 0
 	},
 /obj/structure/desertdam/decals/road_stop{
 	icon_state = "stop_decal5"
@@ -50640,7 +48068,6 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "cnW" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /obj/structure/desertdam/decals/road_stop{
@@ -50800,12 +48227,10 @@
 /area/desert_dam/building/hydroponics/hydroponics_breakroom)
 "cot" = (
 /obj/structure/toilet{
-	tag = "icon-toilet00 (NORTH)";
 	icon_state = "toilet00";
 	dir = 1
 	},
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
 	icon_state = "tube1";
 	dir = 8
 	},
@@ -50842,7 +48267,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/warden)
@@ -50863,8 +48287,7 @@
 "coz" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 4;
-	icon_state = "wooden_chair";
-	tag = ""
+	icon_state = "wooden_chair"
 	},
 /turf/open/floor/wood,
 /area/desert_dam/building/bar/bar)
@@ -50875,8 +48298,7 @@
 "coB" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 8;
-	icon_state = "wooden_chair";
-	tag = ""
+	icon_state = "wooden_chair"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -50889,8 +48311,7 @@
 "coC" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 8;
-	icon_state = "wooden_chair";
-	tag = ""
+	icon_state = "wooden_chair"
 	},
 /turf/open/floor/wood,
 /area/desert_dam/building/bar/bar)
@@ -50941,8 +48362,7 @@
 "coJ" = (
 /obj/machinery/shower{
 	dir = 8;
-	icon_state = "shower";
-	tag = "icon-shower (NORTH)"
+	icon_state = "shower"
 	},
 /turf/open/floor/plating/catwalk,
 /area/desert_dam/building/water_treatment_two)
@@ -50987,25 +48407,21 @@
 /area/desert_dam/exterior/landing_pad_two_external)
 "coQ" = (
 /obj/structure/cargo_container{
-	icon_state = "ch_green 0,0";
-	tag = "icon-WY 2,0"
+	icon_state = "ch_green 0,0"
 	},
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/valley_south_west)
 "coR" = (
 /obj/structure/cargo_container{
-	icon_state = "ch_green 0,1";
-	tag = "icon-WY 2,0"
+	icon_state = "ch_green 0,1"
 	},
 /turf/open/floor/plating,
 /area/desert_dam/exterior/valley/valley_south_west)
 "coS" = (
 /obj/structure/cargo_container{
-	icon_state = "ch_green 0,2";
-	tag = "icon-WY 2,0"
+	icon_state = "ch_green 0,2"
 	},
 /turf/open/floor/plating{
-	tag = "icon-warnplate (EAST)";
 	icon_state = "warnplate";
 	dir = 4
 	},
@@ -51029,7 +48445,6 @@
 "coV" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
-	tag = "icon-pipe-t (EAST)";
 	icon_state = "pipe-t";
 	dir = 4
 	},
@@ -51054,8 +48469,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/open/floor{
 	icon_state = "freezerfloor"
@@ -51063,7 +48477,6 @@
 /area/desert_dam/building/bar/bar_restroom)
 "coZ" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -51073,7 +48486,6 @@
 /area/desert_dam/building/bar/bar_restroom)
 "cpa" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -51087,7 +48499,6 @@
 /area/desert_dam/building/bar/bar_restroom)
 "cpb" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -51105,13 +48516,11 @@
 	name = "\improper Solitary"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/deathrow)
 "cpd" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -51124,11 +48533,9 @@
 "cpe" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 1;
-	icon_state = "wooden_chair";
-	tag = ""
+	icon_state = "wooden_chair"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -51142,8 +48549,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /turf/open/floor/wood,
@@ -51162,8 +48568,7 @@
 	},
 /obj/structure/bed/chair/wood/normal{
 	dir = 1;
-	icon_state = "wooden_chair";
-	tag = ""
+	icon_state = "wooden_chair"
 	},
 /turf/open/floor/wood,
 /area/desert_dam/building/bar/bar)
@@ -51183,15 +48588,13 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/ground/desertdam/asphault,
 /area/desert_dam/exterior/valley/valley_south_west)
 "cpk" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -51199,7 +48602,6 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "cpl" = (
 /turf/open/floor/plating{
-	tag = "icon-warnplate (SOUTHEAST)";
 	icon_state = "warnplate";
 	dir = 6
 	},
@@ -51208,8 +48610,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/open/floor{
 	icon_state = "wood"
@@ -51217,12 +48618,10 @@
 /area/desert_dam/building/library/library)
 "cpn" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -51230,16 +48629,13 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "cpo" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -51250,12 +48646,10 @@
 	icon_state = "stop_decal3"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -51263,7 +48657,6 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "cpq" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /obj/structure/desertdam/decals/road_stop{
@@ -51271,12 +48664,10 @@
 	icon_state = "stop_decal5"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -51284,7 +48675,6 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "cpr" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -51303,8 +48693,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -51318,7 +48707,6 @@
 /area/desert_dam/building/water_treatment_two)
 "cpu" = (
 /obj/structure/bed/chair/office/dark{
-	tag = "icon-officechair_dark (NORTH)";
 	icon_state = "officechair_dark";
 	dir = 1
 	},
@@ -51389,7 +48777,6 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "cpF" = (
 /turf/open/floor/plating{
-	tag = "icon-warnplate (SOUTHEAST)";
 	icon_state = "warnplate";
 	dir = 6
 	},
@@ -51450,7 +48837,6 @@
 /area/desert_dam/building/bar/bar)
 "cpO" = (
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (NORTH)";
 	icon_state = "pipe-c";
 	dir = 1
 	},
@@ -51482,7 +48868,6 @@
 /area/desert_dam/exterior/landing_pad_two_external)
 "cpS" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -51557,7 +48942,6 @@
 /area/desert_dam/exterior/landing_pad_two_external)
 "cqe" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -51673,28 +49057,24 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "cqu" = (
 /turf/open/floor{
-	tag = "icon-darkgreen2 (NORTH)";
 	icon_state = "darkgreen2";
 	dir = 1
 	},
 /area/desert_dam/building/water_treatment_two)
 "cqv" = (
 /turf/open/floor{
-	tag = "icon-darkgreencorners2 (NORTH)";
 	icon_state = "darkgreencorners2";
 	dir = 1
 	},
 /area/desert_dam/building/water_treatment_two)
 "cqw" = (
 /turf/open/floor{
-	tag = "icon-darkgreencorners2 (EAST)";
 	icon_state = "darkgreencorners2";
 	dir = 4
 	},
 /area/desert_dam/building/water_treatment_two)
 "cqx" = (
 /turf/open/floor{
-	tag = "icon-darkgreen2 (EAST)";
 	icon_state = "darkgreen2";
 	dir = 4
 	},
@@ -51747,7 +49127,6 @@
 	},
 /obj/machinery/power/apc/drained,
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2 (NORTH)";
 	icon_state = "darkyellowcorners2";
 	dir = 1
 	},
@@ -51837,7 +49216,6 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "cqQ" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /obj/structure/cable{
@@ -51959,8 +49337,7 @@
 "crj" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
-	pixel_x = 0;
-	tag = "icon-E-corner"
+	pixel_x = 0
 	},
 /obj/structure/desertdam/decals/road_stop{
 	icon_state = "stop_decal5"
@@ -51971,7 +49348,6 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (NORTH)";
 	icon_state = "pipe-c";
 	dir = 1
 	},
@@ -51979,7 +49355,6 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "crk" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /obj/structure/desertdam/decals/road_stop{
@@ -51993,7 +49368,6 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "crl" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /obj/structure/desertdam/decals/road_stop{
@@ -52025,21 +49399,18 @@
 "crp" = (
 /obj/machinery/floodlight/landing,
 /turf/open/floor{
-	tag = "icon-asteroidplating";
 	icon_state = "asteroidplating";
 	dir = 2
 	},
 /area/desert_dam/exterior/landing_pad_two)
 "crq" = (
 /turf/open/floor{
-	tag = "icon-asteroidwarning";
 	icon_state = "asteroidwarning"
 	},
 /area/desert_dam/exterior/landing_pad_two)
 "crr" = (
 /obj/structure/table,
 /turf/open/floor{
-	tag = "icon-whiteyellow (NORTH)";
 	icon_state = "whiteyellow";
 	dir = 1
 	},
@@ -52047,26 +49418,22 @@
 "crs" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
-	tag = "icon-pipe-u";
 	icon_state = "pipe-u";
 	dir = 2
 	},
 /turf/open/floor{
-	tag = "icon-whiteyellow (NORTH)";
 	icon_state = "whiteyellow";
 	dir = 1
 	},
 /area/desert_dam/building/warehouse/breakroom)
 "crt" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained{
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-darkredcorners2 (EAST)";
 	icon_state = "darkredcorners2";
 	dir = 4
 	},
@@ -52086,7 +49453,6 @@
 "crw" = (
 /obj/machinery/vending/cola,
 /turf/open/floor{
-	tag = "icon-whiteyellow (NORTH)";
 	icon_state = "whiteyellow";
 	dir = 1
 	},
@@ -52094,7 +49460,6 @@
 "crx" = (
 /obj/machinery/vending/snack,
 /turf/open/floor{
-	tag = "icon-whiteyellow (NORTH)";
 	icon_state = "whiteyellow";
 	dir = 1
 	},
@@ -52102,7 +49467,6 @@
 "cry" = (
 /obj/machinery/vending/cigarette/colony,
 /turf/open/floor{
-	tag = "icon-whiteyellow (NORTH)";
 	icon_state = "whiteyellow";
 	dir = 1
 	},
@@ -52200,26 +49564,22 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "crK" = (
 /turf/open/floor{
-	tag = "icon-darkgreen2";
 	icon_state = "darkgreen2"
 	},
 /area/desert_dam/building/water_treatment_two)
 "crL" = (
 /turf/open/floor{
-	tag = "icon-darkgreencorners2 (WEST)";
 	icon_state = "darkgreencorners2";
 	dir = 8
 	},
 /area/desert_dam/building/water_treatment_two)
 "crM" = (
 /turf/open/floor{
-	tag = "icon-darkgreencorners2";
 	icon_state = "darkgreencorners2"
 	},
 /area/desert_dam/building/water_treatment_two)
 "crN" = (
 /turf/open/floor{
-	tag = "icon-asteroidwarning (EAST)";
 	icon_state = "asteroidwarning";
 	dir = 4
 	},
@@ -52229,7 +49589,6 @@
 /area/desert_dam/exterior/landing_pad_two)
 "crP" = (
 /turf/open/floor{
-	tag = "icon-asteroidwarning (WEST)";
 	icon_state = "asteroidwarning";
 	dir = 8
 	},
@@ -52296,7 +49655,6 @@
 "crX" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
-	tag = "icon-pipe-t (EAST)";
 	icon_state = "pipe-t";
 	dir = 4
 	},
@@ -52377,7 +49735,6 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "csg" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -52389,7 +49746,6 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "csh" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /obj/structure/desertdam/decals/road_stop{
@@ -52397,7 +49753,6 @@
 	icon_state = "stop_decal5"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -52409,7 +49764,6 @@
 "csi" = (
 /obj/structure/desertdam/decals/road_stop,
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -52420,11 +49774,9 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "csj" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -52435,7 +49787,6 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "csk" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -52456,7 +49807,6 @@
 	icon_state = "stop_decal5"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -52468,11 +49818,9 @@
 "csm" = (
 /obj/structure/desertdam/decals/road_stop,
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -52526,8 +49874,7 @@
 "csu" = (
 /turf/open/floor{
 	dir = 8;
-	icon_state = "whiteyellowcorner";
-	tag = "icon-whiteyellowcorner (EAST)"
+	icon_state = "whiteyellowcorner"
 	},
 /area/desert_dam/building/warehouse/breakroom)
 "csv" = (
@@ -52617,7 +49964,6 @@
 /area/desert_dam/exterior/river/riverside_south)
 "csG" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (NORTH)";
 	icon_state = "platform_deco";
 	dir = 1
 	},
@@ -52653,7 +49999,6 @@
 /area/desert_dam/exterior/river/riverside_south)
 "csM" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (NORTH)";
 	icon_state = "platform_deco";
 	dir = 1
 	},
@@ -52669,7 +50014,6 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "csO" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /obj/structure/desertdam/decals/road_stop{
@@ -52719,7 +50063,6 @@
 /area/desert_dam/building/water_treatment_two)
 "csV" = (
 /turf/open/floor/plating{
-	tag = "icon-warnplate (EAST)";
 	icon_state = "warnplate";
 	dir = 4
 	},
@@ -52746,42 +50089,36 @@
 /area/desert_dam/building/warehouse/warehouse)
 "cta" = (
 /obj/structure/cargo_container{
-	icon_state = "ch_green 0,0";
-	tag = "icon-WY 2,0"
+	icon_state = "ch_green 0,0"
 	},
 /turf/open/floor,
 /area/desert_dam/building/warehouse/warehouse)
 "ctb" = (
 /obj/structure/cargo_container{
-	icon_state = "ch_green 0,1";
-	tag = "icon-WY 2,0"
+	icon_state = "ch_green 0,1"
 	},
 /turf/open/floor,
 /area/desert_dam/building/warehouse/warehouse)
 "ctc" = (
 /obj/structure/cargo_container{
-	icon_state = "ch_green 0,2";
-	tag = "icon-WY 2,0"
+	icon_state = "ch_green 0,2"
 	},
 /turf/open/floor,
 /area/desert_dam/building/warehouse/warehouse)
 "ctd" = (
 /obj/structure/cargo_container{
-	tag = "icon-WY 0,0";
 	icon_state = "WY 0,0"
 	},
 /turf/open/floor,
 /area/desert_dam/building/warehouse/warehouse)
 "cte" = (
 /obj/structure/cargo_container{
-	tag = "icon-WY 1,0";
 	icon_state = "WY 1,0"
 	},
 /turf/open/floor,
 /area/desert_dam/building/warehouse/warehouse)
 "ctf" = (
 /obj/structure/cargo_container{
-	tag = "icon-WY 2,0";
 	icon_state = "WY 2,0"
 	},
 /turf/open/floor,
@@ -52799,7 +50136,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whiteyellow (WEST)";
 	icon_state = "whiteyellow";
 	dir = 8
 	},
@@ -52916,21 +50252,18 @@
 /area/desert_dam/building/warehouse/warehouse)
 "ctw" = (
 /obj/structure/cargo_container{
-	tag = "icon-red 0,0";
 	icon_state = "red 0,0"
 	},
 /turf/open/floor,
 /area/desert_dam/building/warehouse/warehouse)
 "ctx" = (
 /obj/structure/cargo_container{
-	tag = "icon-red 1,0";
 	icon_state = "red 1,0"
 	},
 /turf/open/floor,
 /area/desert_dam/building/warehouse/warehouse)
 "cty" = (
 /obj/structure/cargo_container{
-	tag = "icon-red 2,0";
 	icon_state = "red 2,0"
 	},
 /turf/open/floor,
@@ -52945,13 +50278,11 @@
 	},
 /turf/open/floor{
 	dir = 4;
-	icon_state = "whiteyellow";
-	tag = "icon-whiteredcorner (NORTH)"
+	icon_state = "whiteyellow"
 	},
 /area/desert_dam/building/water_treatment_one)
 "ctA" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (NORTH)";
 	icon_state = "tube1";
 	dir = 1
 	},
@@ -52962,7 +50293,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whiteyellow (SOUTHWEST)";
 	icon_state = "whiteyellow";
 	dir = 10
 	},
@@ -52970,7 +50300,6 @@
 "ctC" = (
 /obj/structure/table,
 /turf/open/floor{
-	tag = "icon-whiteyellow";
 	icon_state = "whiteyellow";
 	dir = 2
 	},
@@ -52980,7 +50309,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whiteyellow";
 	icon_state = "whiteyellow";
 	dir = 2
 	},
@@ -53000,8 +50328,7 @@
 "ctF" = (
 /turf/open/floor{
 	dir = 2;
-	icon_state = "whiteyellowcorner";
-	tag = "icon-whiteyellowcorner (EAST)"
+	icon_state = "whiteyellowcorner"
 	},
 /area/desert_dam/building/warehouse/breakroom)
 "ctG" = (
@@ -53038,7 +50365,6 @@
 /area/desert_dam/exterior/river/riverside_south)
 "ctL" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (NORTH)";
 	icon_state = "platform_deco";
 	dir = 1
 	},
@@ -53126,11 +50452,9 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (NORTH)";
 	icon_state = "pipe-c";
 	dir = 1
 	},
@@ -53142,7 +50466,6 @@
 	icon_state = "pipe-j2"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -53152,8 +50475,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -53273,12 +50595,10 @@
 /area/desert_dam/building/warehouse/loading)
 "cup" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/execution_chamber)
@@ -53320,7 +50640,6 @@
 /area/desert_dam/exterior/river/riverside_south)
 "cuw" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (NORTH)";
 	icon_state = "platform_deco";
 	dir = 1
 	},
@@ -53360,19 +50679,16 @@
 /area/desert_dam/building/warehouse/warehouse)
 "cuD" = (
 /turf/open/floor{
-	tag = "icon-asteroidplating";
 	icon_state = "asteroidplating";
 	dir = 2
 	},
 /area/desert_dam/building/warehouse/warehouse)
 "cuE" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (NORTH)";
 	icon_state = "tube1";
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-asteroidplating";
 	icon_state = "asteroidplating";
 	dir = 2
 	},
@@ -53384,7 +50700,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor{
-	tag = "icon-asteroidplating";
 	icon_state = "asteroidplating";
 	dir = 2
 	},
@@ -53396,14 +50711,12 @@
 	name = "\improper Cargo Bay Hangar"
 	},
 /turf/open/floor{
-	tag = "icon-asteroidplating";
 	icon_state = "asteroidplating";
 	dir = 2
 	},
 /area/desert_dam/building/warehouse/warehouse)
 "cuH" = (
 /turf/open/floor{
-	tag = "icon-asteroidplating";
 	icon_state = "asteroidplating";
 	dir = 2
 	},
@@ -53417,7 +50730,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-asteroidplating";
 	icon_state = "asteroidplating";
 	dir = 2
 	},
@@ -53429,7 +50741,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor{
-	tag = "icon-asteroidplating";
 	icon_state = "asteroidplating";
 	dir = 2
 	},
@@ -53484,7 +50795,6 @@
 "cuT" = (
 /obj/machinery/gibber,
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/cafeteria/cold_room)
@@ -53523,7 +50833,6 @@
 	name = "\improper Observation"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/execution_chamber)
@@ -53532,7 +50841,6 @@
 	dir = 6
 	},
 /turf/open/floor{
-	tag = "icon-asteroidplating";
 	icon_state = "asteroidplating";
 	dir = 2
 	},
@@ -53543,7 +50851,6 @@
 	layer = 2.4
 	},
 /turf/open/floor{
-	tag = "icon-asteroidplating";
 	icon_state = "asteroidplating";
 	dir = 2
 	},
@@ -53552,22 +50859,19 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4;
 	layer = 2.4
 	},
 /turf/open/floor{
-	tag = "icon-asteroidplating";
 	icon_state = "asteroidplating";
 	dir = 2
 	},
 /area/desert_dam/building/warehouse/warehouse)
 "cvc" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -53576,7 +50880,6 @@
 	layer = 2.4
 	},
 /turf/open/floor{
-	tag = "icon-asteroidplating";
 	icon_state = "asteroidplating";
 	dir = 2
 	},
@@ -53588,7 +50891,6 @@
 	name = "\improper Cargo Bay Hangar"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -53597,14 +50899,12 @@
 	layer = 2.4
 	},
 /turf/open/floor{
-	tag = "icon-asteroidplating";
 	icon_state = "asteroidplating";
 	dir = 2
 	},
 /area/desert_dam/building/warehouse/warehouse)
 "cve" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -53613,40 +50913,34 @@
 	layer = 2.4
 	},
 /turf/open/floor{
-	tag = "icon-asteroidplating";
 	icon_state = "asteroidplating";
 	dir = 2
 	},
 /area/desert_dam/building/warehouse/loading)
 "cvf" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (NORTH)";
 	icon_state = "pipe-c";
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-asteroidplating";
 	icon_state = "asteroidplating";
 	dir = 2
 	},
 /area/desert_dam/building/warehouse/loading)
 "cvg" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -53654,28 +50948,24 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-asteroidplating";
 	icon_state = "asteroidplating";
 	dir = 2
 	},
 /area/desert_dam/building/warehouse/loading)
 "cvh" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-asteroidplating";
 	icon_state = "asteroidplating";
 	dir = 2
 	},
@@ -53687,7 +50977,6 @@
 	name = "\improper Cargo Bay Hangar"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -53705,8 +50994,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 1;
@@ -53724,7 +51012,6 @@
 "cvl" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/machinery/light{
-	tag = "icon-tube1 (NORTH)";
 	icon_state = "tube1";
 	dir = 1
 	},
@@ -53772,7 +51059,6 @@
 /obj/structure/table/reinforced,
 /obj/item/reagent_container/food/snacks/bigbiteburger,
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/cafeteria/cafeteria)
@@ -53800,20 +51086,17 @@
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder,
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/cafeteria/cafeteria)
 "cvw" = (
 /obj/machinery/chem_master/condimaster,
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/cafeteria/cafeteria)
 "cvx" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc,
@@ -53887,16 +51170,13 @@
 	pixel_y = 2
 	},
 /obj/effect/decal/cleanable/blood{
-	tag = "icon-gib6";
 	icon_state = "gib6"
 	},
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (EAST)";
 	icon_state = "bulb1";
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/cafeteria/cold_room)
@@ -53908,7 +51188,6 @@
 "cvI" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor{
-	tag = "icon-asteroidplating";
 	icon_state = "asteroidplating";
 	dir = 2
 	},
@@ -53916,7 +51195,6 @@
 "cvJ" = (
 /obj/vehicle/train/cargo/trolley,
 /turf/open/floor{
-	tag = "icon-asteroidplating";
 	icon_state = "asteroidplating";
 	dir = 2
 	},
@@ -53924,7 +51202,6 @@
 "cvK" = (
 /obj/vehicle/train/cargo/engine,
 /turf/open/floor{
-	tag = "icon-asteroidplating";
 	icon_state = "asteroidplating";
 	dir = 2
 	},
@@ -53932,7 +51209,6 @@
 "cvL" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor{
-	tag = "icon-asteroidplating";
 	icon_state = "asteroidplating";
 	dir = 2
 	},
@@ -53983,7 +51259,6 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "cvT" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (NORTH)";
 	icon_state = "tube1";
 	dir = 1
 	},
@@ -54001,7 +51276,6 @@
 /area/desert_dam/building/water_treatment_one)
 "cvV" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -54010,7 +51284,6 @@
 "cvW" = (
 /obj/machinery/door/airlock/almayer/maint,
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -54020,7 +51293,6 @@
 /area/desert_dam/building/cafeteria/backroom)
 "cvX" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -54062,7 +51334,6 @@
 /area/desert_dam/building/cafeteria/cold_room)
 "cwc" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
 	icon_state = "tube1";
 	dir = 4
 	},
@@ -54087,7 +51358,6 @@
 "cwf" = (
 /obj/structure/largecrate,
 /turf/open/floor{
-	tag = "icon-asteroidplating";
 	icon_state = "asteroidplating";
 	dir = 2
 	},
@@ -54095,7 +51365,6 @@
 "cwg" = (
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-asteroidplating";
 	icon_state = "asteroidplating";
 	dir = 2
 	},
@@ -54181,7 +51450,6 @@
 /area/desert_dam/building/hydroponics/hydroponics_storage)
 "cwr" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/hydroponics/hydroponics_storage)
@@ -54190,7 +51458,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/hydroponics/hydroponics_storage)
@@ -54232,22 +51499,19 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-darkgreen2 (WEST)";
 	icon_state = "darkgreen2";
 	dir = 8
 	},
 /area/desert_dam/building/water_treatment_one)
 "cwz" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -54259,7 +51523,6 @@
 /area/desert_dam/building/cafeteria/cafeteria)
 "cwA" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -54272,7 +51535,6 @@
 /area/desert_dam/building/cafeteria/cafeteria)
 "cwB" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -54288,7 +51550,6 @@
 /area/desert_dam/building/cafeteria/cafeteria)
 "cwC" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -54309,7 +51570,6 @@
 	layer = 2.4
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -54322,7 +51582,6 @@
 /area/desert_dam/building/cafeteria/cafeteria)
 "cwE" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -54340,7 +51599,6 @@
 /area/desert_dam/building/cafeteria/cafeteria)
 "cwF" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -54357,7 +51615,6 @@
 /area/desert_dam/building/cafeteria/loading)
 "cwG" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -54403,7 +51660,6 @@
 	name = "\improper Freezer"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -54417,7 +51673,6 @@
 /area/desert_dam/building/cafeteria/cold_room)
 "cwJ" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -54435,7 +51690,6 @@
 	on = 1
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -54445,7 +51699,6 @@
 /area/desert_dam/building/cafeteria/cold_room)
 "cwL" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -54510,7 +51763,6 @@
 /area/desert_dam/building/warehouse/loading)
 "cwT" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
 	icon_state = "tube1";
 	dir = 4
 	},
@@ -54518,7 +51770,6 @@
 /area/desert_dam/building/warehouse/loading)
 "cwU" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (NORTH)";
 	icon_state = "tube1";
 	dir = 1
 	},
@@ -54542,7 +51793,6 @@
 /area/desert_dam/building/hydroponics/hydroponics_storage)
 "cwX" = (
 /obj/machinery/conveyor{
-	tag = "icon-conveyor-1 (EAST)";
 	icon_state = "conveyor-1";
 	dir = 4
 	},
@@ -54550,7 +51800,6 @@
 /area/desert_dam/building/hydroponics/hydroponics_storage)
 "cwY" = (
 /obj/machinery/conveyor{
-	tag = "icon-conveyor-1 (EAST)";
 	icon_state = "conveyor-1";
 	dir = 4
 	},
@@ -54559,7 +51808,6 @@
 /area/desert_dam/building/hydroponics/hydroponics_storage)
 "cwZ" = (
 /obj/machinery/conveyor{
-	tag = "icon-conveyor-1 (EAST)";
 	icon_state = "conveyor-1";
 	dir = 4
 	},
@@ -54567,7 +51815,6 @@
 /area/desert_dam/building/hydroponics/hydroponics_loading)
 "cxa" = (
 /obj/machinery/conveyor{
-	tag = "icon-conveyor-1 (EAST)";
 	icon_state = "conveyor-1";
 	dir = 4
 	},
@@ -54575,7 +51822,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/hydroponics/hydroponics_loading)
@@ -54600,7 +51846,6 @@
 /area/desert_dam/building/dorms/hallway_eastwing)
 "cxd" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/hydroponics/hydroponics_loading)
@@ -54609,7 +51854,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/hydroponics/hydroponics_loading)
@@ -54623,7 +51867,6 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "cxg" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -54637,7 +51880,6 @@
 	opacity = 0
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/deathrow)
@@ -54679,7 +51921,6 @@
 "cxm" = (
 /obj/structure/closet/crate/freezer/rations,
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/cafeteria/cold_room)
@@ -54713,7 +51954,6 @@
 /area/desert_dam/building/warehouse/warehouse)
 "cxr" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (NORTH)";
 	icon_state = "tube1";
 	dir = 1
 	},
@@ -54728,12 +51968,10 @@
 	dir = 2
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -54771,7 +52009,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/hydroponics/hydroponics_loading)
@@ -54872,7 +52109,6 @@
 /area/desert_dam/building/security/lobby)
 "cxP" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -54886,7 +52122,6 @@
 	opacity = 0
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/execution_chamber)
@@ -54927,22 +52162,19 @@
 /area/desert_dam/exterior/landing_pad_two_external)
 "cxW" = (
 /obj/structure/cargo_container{
-	icon_state = "HD 1,0";
-	tag = "icon-WY 2,0"
+	icon_state = "HD 1,0"
 	},
 /turf/open/floor,
 /area/desert_dam/building/warehouse/warehouse)
 "cxX" = (
 /obj/structure/cargo_container{
-	icon_state = "HD 2,0";
-	tag = "icon-WY 2,0"
+	icon_state = "HD 2,0"
 	},
 /turf/open/floor,
 /area/desert_dam/building/warehouse/warehouse)
 "cxY" = (
 /obj/structure/cargo_container{
-	icon_state = "HD 3,0";
-	tag = "icon-WY 2,0"
+	icon_state = "HD 3,0"
 	},
 /turf/open/floor,
 /area/desert_dam/building/warehouse/warehouse)
@@ -54966,7 +52198,6 @@
 "cyc" = (
 /obj/structure/table,
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
 	icon_state = "tube1";
 	dir = 4
 	},
@@ -54984,12 +52215,10 @@
 /area/desert_dam/building/hydroponics/hydroponics)
 "cye" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/drained,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/deathrow)
@@ -55072,7 +52301,6 @@
 /area/desert_dam/building/cafeteria/cafeteria)
 "cyq" = (
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (NORTH)";
 	icon_state = "pipe-c";
 	dir = 1
 	},
@@ -55202,15 +52430,13 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor,
 /area/desert_dam/building/security/lobby)
 "cyG" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -55226,7 +52452,6 @@
 	d2 = 4
 	},
 /turf/open/floor{
-	tag = "icon-darkgreen2 (NORTH)";
 	icon_state = "darkgreen2";
 	dir = 1
 	},
@@ -55241,31 +52466,25 @@
 /area/desert_dam/building/security/marshals_office)
 "cyK" = (
 /obj/structure/cargo_container{
-	tag = "icon-HD_blue 0,0";
 	icon_state = "HD_blue 0,0"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/warehouse/warehouse)
 "cyL" = (
 /obj/structure/cargo_container{
-	tag = "icon-HD_blue 0,1";
 	icon_state = "HD_blue 0,1"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/warehouse/warehouse)
 "cyM" = (
 /obj/structure/cargo_container{
-	tag = "icon-HD_blue 0,2";
 	icon_state = "HD_blue 0,2"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/warehouse/warehouse)
@@ -55292,7 +52511,6 @@
 /obj/structure/table,
 /obj/item/tool/shovel/spade,
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
 	icon_state = "tube1";
 	dir = 4
 	},
@@ -55314,7 +52532,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/hydroponics/hydroponics_storage)
@@ -55325,7 +52542,6 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/hydroponics/hydroponics_loading)
@@ -55337,7 +52553,6 @@
 	pixel_x = 0
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/hydroponics/hydroponics_loading)
@@ -55345,11 +52560,9 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/hydroponics/hydroponics_loading)
@@ -55566,7 +52779,6 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "czz" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /turf/open/floor,
@@ -55872,7 +53084,6 @@
 /area/desert_dam/building/warehouse/loading)
 "cAr" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /obj/structure/cable{
@@ -55895,7 +53106,6 @@
 /area/desert_dam/building/hydroponics/hydroponics)
 "cAt" = (
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (NORTH)";
 	icon_state = "pipe-c";
 	dir = 1
 	},
@@ -55903,7 +53113,6 @@
 /area/desert_dam/building/hydroponics/hydroponics)
 "cAu" = (
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -55916,7 +53125,6 @@
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -55926,16 +53134,13 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -55943,12 +53148,10 @@
 /area/desert_dam/building/hydroponics/hydroponics)
 "cAx" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -55956,12 +53159,10 @@
 /area/desert_dam/building/hydroponics/hydroponics)
 "cAy" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -55973,12 +53174,10 @@
 "cAz" = (
 /obj/machinery/light,
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -55993,7 +53192,6 @@
 	name = "\improper Loading"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/hydroponics/hydroponics_loading)
@@ -56001,11 +53199,9 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -56020,7 +53216,6 @@
 /area/desert_dam/building/hydroponics/hydroponics_storage)
 "cAC" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -56034,7 +53229,6 @@
 	dir = 2
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -56045,7 +53239,6 @@
 /area/desert_dam/building/hydroponics/hydroponics_storage)
 "cAE" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -56062,7 +53255,6 @@
 /area/desert_dam/building/hydroponics/hydroponics_loading)
 "cAG" = (
 /turf/open/floor/plating{
-	tag = "icon-warnplate (EAST)";
 	icon_state = "warnplate";
 	dir = 4
 	},
@@ -56215,7 +53407,6 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "cAZ" = (
 /turf/open/floor/plating{
-	tag = "icon-warnplate (SOUTHWEST)";
 	icon_state = "warnplate";
 	dir = 10
 	},
@@ -56229,18 +53420,15 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "cBb" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /turf/open/floor/plating,
 /area/desert_dam/exterior/landing_pad_two_external)
 "cBc" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /obj/item/stool,
@@ -56251,7 +53439,6 @@
 	id = "cargo_landing"
 	},
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /turf/open/floor/plating,
@@ -56277,31 +53464,26 @@
 /area/desert_dam/building/warehouse/warehouse)
 "cBh" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /turf/open/floor/plating,
 /area/desert_dam/building/warehouse/loading)
 "cBi" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /turf/open/floor/plating,
 /area/desert_dam/building/warehouse/loading)
 "cBj" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
-	pixel_x = 0;
-	tag = "icon-E-corner"
+	pixel_x = 0
 	},
 /turf/open/floor/plating,
 /area/desert_dam/building/warehouse/loading)
@@ -56334,13 +53516,11 @@
 /obj/structure/table,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/hydroponics/hydroponics_storage)
 "cBo" = (
 /turf/open/floor/plating{
-	tag = "icon-warnplate (SOUTHWEST)";
 	icon_state = "warnplate";
 	dir = 10
 	},
@@ -56386,7 +53566,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (NORTH)";
 	icon_state = "whitegreencorner";
 	dir = 1
 	},
@@ -56473,7 +53652,6 @@
 /area/desert_dam/exterior/landing_pad_two_external)
 "cBE" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /turf/open/floor/plating,
@@ -56484,11 +53662,9 @@
 	id = "cargo_container"
 	},
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /turf/open/floor/plating,
@@ -56499,11 +53675,9 @@
 	id = "cargo_container"
 	},
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /obj/structure/plasticflaps,
@@ -56511,11 +53685,9 @@
 /area/desert_dam/building/warehouse/warehouse)
 "cBH" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /obj/machinery/conveyor{
@@ -56523,7 +53695,6 @@
 	id = "cargo_container"
 	},
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /obj/structure/largecrate,
@@ -56535,11 +53706,9 @@
 	id = "cargo_storage"
 	},
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /turf/open/floor/plating,
@@ -56550,11 +53719,9 @@
 	id = "cargo_storage"
 	},
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /obj/structure/plasticflaps,
@@ -56573,8 +53740,7 @@
 "cBM" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
-	pixel_x = 0;
-	tag = "icon-E-corner"
+	pixel_x = 0
 	},
 /turf/open/floor/plating,
 /area/desert_dam/building/warehouse/loading)
@@ -56614,7 +53780,6 @@
 "cBS" = (
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/hydroponics/hydroponics_loading)
@@ -56715,7 +53880,6 @@
 /area/desert_dam/building/security/detective)
 "cCf" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -56736,7 +53900,6 @@
 /area/desert_dam/building/security/staffroom)
 "cCh" = (
 /obj/structure/bed/chair/comfy/black{
-	tag = "icon-comfychair (NORTH)";
 	icon_state = "comfychair";
 	dir = 1
 	},
@@ -56756,7 +53919,6 @@
 /area/desert_dam/building/security/marshals_office)
 "cCj" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -56791,14 +53953,12 @@
 	},
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/hydroponics/hydroponics_storage)
 "cCo" = (
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/hydroponics/hydroponics_storage)
@@ -56845,8 +54005,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -56862,7 +54021,6 @@
 /area/desert_dam/building/cafeteria/loading)
 "cCv" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -56876,7 +54034,6 @@
 /area/desert_dam/building/cafeteria/loading)
 "cCw" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -56889,7 +54046,6 @@
 /area/desert_dam/building/cafeteria/loading)
 "cCx" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -56906,7 +54062,6 @@
 	name = "\improper Delivery"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -56920,7 +54075,6 @@
 /area/desert_dam/building/cafeteria/loading)
 "cCz" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -56937,7 +54091,6 @@
 	icon_state = "road_edge_decal3"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -56951,7 +54104,6 @@
 	icon_state = "road_edge_decal6"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -56963,14 +54115,12 @@
 "cCC" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
-	pixel_x = 0;
-	tag = "icon-E-corner"
+	pixel_x = 0
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -57018,7 +54168,6 @@
 "cCJ" = (
 /obj/structure/largecrate/random/barrel/white,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/dam_interior/hanger)
@@ -57100,25 +54249,21 @@
 /area/desert_dam/building/security/marshals_office)
 "cCT" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W";
 	icon_state = "W"
 	},
 /turf/open/floor/plating,
 /area/desert_dam/exterior/landing_pad_two_external)
 "cCU" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /turf/open/floor/plating,
 /area/desert_dam/exterior/landing_pad_two_external)
 "cCV" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /turf/open/floor/plating,
@@ -57126,11 +54271,9 @@
 "cCW" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
-	pixel_x = 0;
-	tag = "icon-E-corner"
+	pixel_x = 0
 	},
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /turf/open/floor/plating,
@@ -57148,7 +54291,6 @@
 	name = "\improper Toilet Unit"
 	},
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/security/staffroom)
@@ -57364,8 +54506,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4;
@@ -57375,7 +54516,6 @@
 /area/desert_dam/building/security/northern_hallway)
 "cDD" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -57390,7 +54530,6 @@
 /area/desert_dam/building/security/northern_hallway)
 "cDE" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -57405,7 +54544,6 @@
 /area/desert_dam/building/security/northern_hallway)
 "cDF" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -57417,15 +54555,13 @@
 /area/desert_dam/building/security/northern_hallway)
 "cDG" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4;
@@ -57437,14 +54573,12 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /obj/structure/disposalpipe/segment{
@@ -57458,7 +54592,6 @@
 /area/desert_dam/building/security/northern_hallway)
 "cDI" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -57467,7 +54600,6 @@
 	layer = 2.4
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -57475,7 +54607,6 @@
 /area/desert_dam/building/security/northern_hallway)
 "cDJ" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -57484,7 +54615,6 @@
 	layer = 2.4
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -57495,7 +54625,6 @@
 /area/desert_dam/building/security/northern_hallway)
 "cDK" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -57504,7 +54633,6 @@
 	layer = 2.4
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -57515,22 +54643,19 @@
 /area/desert_dam/building/security/northern_hallway)
 "cDL" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4;
 	layer = 2.4
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -57548,8 +54673,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -57575,7 +54699,6 @@
 /area/desert_dam/building/security/northern_hallway)
 "cDO" = (
 /turf/open/floor{
-	tag = "icon-asteroidwarning (NORTH)";
 	icon_state = "asteroidwarning";
 	dir = 1
 	},
@@ -57644,7 +54767,6 @@
 	name = "\improper Armoury"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/armory)
@@ -57719,7 +54841,6 @@
 /area/desert_dam/building/warehouse/loading)
 "cEk" = (
 /turf/open/floor/plating{
-	tag = "icon-warnplate (EAST)";
 	icon_state = "warnplate";
 	dir = 4
 	},
@@ -57749,7 +54870,6 @@
 /area/desert_dam/building/cafeteria/cafeteria)
 "cEo" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
 	icon_state = "tube1";
 	dir = 4
 	},
@@ -57788,7 +54908,6 @@
 /area/desert_dam/building/cafeteria/loading)
 "cEt" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
 	icon_state = "tube1";
 	dir = 4
 	},
@@ -57862,7 +54981,6 @@
 	name = "\improper Armoury"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -57881,7 +54999,6 @@
 /area/desert_dam/building/cafeteria/loading)
 "cEH" = (
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -57958,7 +55075,6 @@
 	name = "\improper Marshal Office"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -57976,20 +55092,17 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/security/staffroom)
 "cEY" = (
 /obj/structure/sink,
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/security/staffroom)
 "cEZ" = (
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/security/staffroom)
@@ -57999,7 +55112,6 @@
 	name = "\improper Visitation"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/southern_hallway)
@@ -58008,18 +55120,15 @@
 	dir = 8
 	},
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (EAST)";
 	icon_state = "bulb1";
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/security/staffroom)
 "cFc" = (
 /turf/open/floor/plating{
-	tag = "icon-warnplate (SOUTHWEST)";
 	icon_state = "warnplate";
 	dir = 10
 	},
@@ -58032,7 +55141,6 @@
 /area/desert_dam/building/warehouse/loading)
 "cFe" = (
 /turf/open/floor/plating{
-	tag = "icon-warnplate (SOUTHEAST)";
 	icon_state = "warnplate";
 	dir = 6
 	},
@@ -58043,7 +55151,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /obj/structure/cable{
@@ -58061,12 +55168,10 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "cFg" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N";
 	icon_state = "N"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
@@ -58075,8 +55180,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/open/floor/plating/ground/desertdam/asphault,
 /area/desert_dam/exterior/valley/valley_south_west)
@@ -58212,7 +55316,6 @@
 /area/desert_dam/building/security/holding)
 "cFF" = (
 /turf/open/floor{
-	tag = "icon-darkredcorners2";
 	icon_state = "darkredcorners2"
 	},
 /area/desert_dam/building/security/southern_hallway)
@@ -58225,19 +55328,16 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/southern_hallway)
 "cFH" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/southern_hallway)
 "cFI" = (
 /turf/open/floor{
-	tag = "icon-darkredcorners2 (WEST)";
 	icon_state = "darkredcorners2";
 	dir = 8
 	},
@@ -58248,7 +55348,6 @@
 "cFK" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/security/staffroom)
@@ -58361,8 +55460,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -58372,7 +55470,6 @@
 /area/desert_dam/building/security/holding)
 "cGc" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -58387,7 +55484,6 @@
 /area/desert_dam/building/security/holding)
 "cGd" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -58395,7 +55491,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-darkredcorners2";
 	icon_state = "darkredcorners2"
 	},
 /area/desert_dam/building/security/southern_hallway)
@@ -58408,8 +55503,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/junction{
@@ -58417,7 +55511,6 @@
 	icon_state = "pipe-j2"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/southern_hallway)
@@ -58427,7 +55520,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/security/staffroom)
@@ -58487,7 +55579,6 @@
 /area/desert_dam/building/security/evidence)
 "cGm" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
 	icon_state = "tube1";
 	dir = 4
 	},
@@ -58513,7 +55604,6 @@
 	dir = 2
 	},
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/security/staffroom)
@@ -58521,16 +55611,14 @@
 /obj/structure/closet/secure_closet/security,
 /turf/open/floor{
 	dir = 1;
-	icon_state = "floor4";
-	tag = "icon-floor4"
+	icon_state = "floor4"
 	},
 /area/desert_dam/building/security/staffroom)
 "cGr" = (
 /obj/structure/closet/bombclosetsecurity,
 /turf/open/floor{
 	dir = 1;
-	icon_state = "floor4";
-	tag = "icon-floor4"
+	icon_state = "floor4"
 	},
 /area/desert_dam/building/security/staffroom)
 "cGs" = (
@@ -58670,7 +55758,6 @@
 /area/desert_dam/building/security/holding)
 "cGK" = (
 /obj/structure/disposalpipe/trunk{
-	tag = "icon-pipe-t (NORTH)";
 	icon_state = "pipe-t";
 	dir = 1
 	},
@@ -58682,7 +55769,6 @@
 /area/desert_dam/building/security/holding)
 "cGL" = (
 /obj/machinery/shower{
-	tag = "icon-shower (NORTH)";
 	icon_state = "shower";
 	dir = 1
 	},
@@ -58702,7 +55788,6 @@
 /area/desert_dam/building/security/staffroom)
 "cGP" = (
 /obj/structure/disposalpipe/trunk{
-	tag = "icon-pipe-u";
 	icon_state = "pipe-u";
 	dir = 2
 	},
@@ -58742,7 +55827,6 @@
 /area/desert_dam/building/security/staffroom)
 "cGU" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
 	icon_state = "tube1";
 	dir = 4
 	},
@@ -58820,7 +55904,6 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "cHg" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-S";
 	icon_state = "S"
 	},
 /obj/structure/desertdam/decals/road_stop{
@@ -58828,7 +55911,6 @@
 	icon_state = "stop_decal5"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -58875,24 +55957,20 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/southern_hallway)
 "cHn" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
 	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-darkredcorners2 (WEST)";
 	icon_state = "darkredcorners2";
 	dir = 8
 	},
@@ -58911,7 +55989,6 @@
 /obj/structure/closet/secure_closet/marshal,
 /obj/item/clothing/suit/storage/CMB,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/desert_dam/building/security/staffroom)
@@ -58933,7 +56010,6 @@
 /area/desert_dam/exterior/landing_pad_two_external)
 "cHu" = (
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
@@ -58946,7 +56022,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
@@ -58962,7 +56037,6 @@
 /area/desert_dam/building/water_treatment_one)
 "cHy" = (
 /turf/open/floor/plating{
-	tag = "icon-warnplate (EAST)";
 	icon_state = "warnplate";
 	dir = 4
 	},
@@ -58970,7 +56044,6 @@
 "cHz" = (
 /obj/structure/table,
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
@@ -58992,7 +56065,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor{
-	tag = "icon-darkredcorners2 (WEST)";
 	icon_state = "darkredcorners2";
 	dir = 8
 	},
@@ -59002,7 +56074,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-darkredcorners2 (WEST)";
 	icon_state = "darkredcorners2";
 	dir = 8
 	},
@@ -59100,8 +56171,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4;
@@ -59117,13 +56187,11 @@
 	name = "\improper Marshal Office"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/southern_hallway)
 "cHV" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -59132,34 +56200,29 @@
 	layer = 2.4
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/southern_hallway)
 "cHW" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4;
 	layer = 2.4
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/southern_hallway)
 "cHX" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -59173,15 +56236,13 @@
 /area/desert_dam/building/security/southern_hallway)
 "cHY" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4;
@@ -59193,7 +56254,6 @@
 /area/desert_dam/building/security/southern_hallway)
 "cHZ" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -59215,15 +56275,13 @@
 /area/desert_dam/building/security/southern_hallway)
 "cIa" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4;
@@ -59233,13 +56291,11 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/southern_hallway)
 "cIb" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -59251,21 +56307,18 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/southern_hallway)
 "cIc" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -59274,13 +56327,11 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/southern_hallway)
 "cId" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -59297,13 +56348,11 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/southern_hallway)
 "cIe" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -59311,7 +56360,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/southern_hallway)
@@ -59320,27 +56368,23 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 1;
 	icon_state = "pipe-j2"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/southern_hallway)
 "cIg" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -59353,13 +56397,11 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/southern_hallway)
 "cIh" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -59376,7 +56418,6 @@
 /area/desert_dam/building/security/southern_hallway)
 "cIi" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -59393,8 +56434,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4;
@@ -59411,7 +56451,6 @@
 	layer = 2.4
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -59423,7 +56462,6 @@
 	on = 1
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -59431,7 +56469,6 @@
 /area/desert_dam/building/security/staffroom)
 "cIm" = (
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -59441,7 +56478,6 @@
 /obj/structure/table,
 /obj/item/trash/kepler,
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -59495,7 +56531,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
@@ -59511,7 +56546,6 @@
 	icon_state = "pipe-j2"
 	},
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
@@ -59542,7 +56576,6 @@
 	on = 1
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/southern_hallway)
@@ -59552,7 +56585,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/southern_hallway)
@@ -59562,7 +56594,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/southern_hallway)
@@ -59615,20 +56646,17 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "cIM" = (
 /turf/open/floor/plating{
-	tag = "icon-warnplate (SOUTHWEST)";
 	icon_state = "warnplate";
 	dir = 10
 	},
 /area/desert_dam/building/water_treatment_one)
 "cIN" = (
 /turf/open/floor/plating{
-	tag = "icon-warnplate";
 	icon_state = "warnplate"
 	},
 /area/desert_dam/building/water_treatment_one)
 "cIO" = (
 /turf/open/floor/plating{
-	tag = "icon-warnplate (SOUTHEAST)";
 	icon_state = "warnplate";
 	dir = 6
 	},
@@ -59698,14 +56726,12 @@
 /area/desert_dam/building/security/prison)
 "cIY" = (
 /turf/open/floor{
-	tag = "icon-darkredcorners2 (EAST)";
 	icon_state = "darkredcorners2";
 	dir = 4
 	},
 /area/desert_dam/building/security/southern_hallway)
 "cIZ" = (
 /turf/open/floor{
-	tag = "icon-darkredcorners2 (NORTH)";
 	icon_state = "darkredcorners2";
 	dir = 1
 	},
@@ -59812,7 +56838,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-darkred2 (WEST)";
 	icon_state = "darkred2";
 	dir = 8
 	},
@@ -59836,7 +56861,6 @@
 /area/desert_dam/building/security/prison)
 "cJs" = (
 /turf/open/floor{
-	tag = "icon-darkred2 (EAST)";
 	icon_state = "darkred2";
 	dir = 4
 	},
@@ -59844,7 +56868,6 @@
 "cJt" = (
 /obj/machinery/computer/prisoner,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/prison)
@@ -59854,18 +56877,15 @@
 	network = list("PRISON")
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/prison)
 "cJv" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
 	icon_state = "tube1";
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-darkredcorners2 (NORTH)";
 	icon_state = "darkredcorners2";
 	dir = 1
 	},
@@ -59989,7 +57009,6 @@
 /area/desert_dam/building/security/prison)
 "cJO" = (
 /turf/open/floor{
-	tag = "icon-darkred2 (WEST)";
 	icon_state = "darkred2";
 	dir = 8
 	},
@@ -60006,27 +57025,23 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/prison)
 "cJR" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/prison)
 "cJS" = (
 /obj/machinery/door/airlock/almayer/security/glass,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/prison)
 "cJT" = (
 /obj/machinery/computer/prisoner,
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTHWEST)";
 	icon_state = "darkred2";
 	dir = 9
 	},
@@ -60035,7 +57050,6 @@
 /obj/machinery/computer/secure_data,
 /obj/structure/table,
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTH)";
 	icon_state = "darkred2";
 	dir = 1
 	},
@@ -60046,27 +57060,23 @@
 	network = list("PRISON")
 	},
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTH)";
 	icon_state = "darkred2";
 	dir = 1
 	},
 /area/desert_dam/building/security/warden)
 "cJW" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/warden)
 "cJX" = (
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTH)";
 	icon_state = "darkred2";
 	dir = 1
 	},
 /area/desert_dam/building/security/warden)
 "cJY" = (
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTHEAST)";
 	icon_state = "darkred2";
 	dir = 5
 	},
@@ -60087,23 +57097,19 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (NORTH)";
 	icon_state = "pipe-c";
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
 /area/desert_dam/building/water_treatment_one)
 "cKd" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -60111,14 +57117,12 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
 /area/desert_dam/building/water_treatment_one)
 "cKe" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -60137,7 +57141,6 @@
 /area/desert_dam/building/water_treatment_one)
 "cKf" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -60181,7 +57184,6 @@
 "cKl" = (
 /obj/structure/bed,
 /obj/machinery/light{
-	tag = "icon-tube1 (NORTH)";
 	icon_state = "tube1";
 	dir = 1
 	},
@@ -60228,7 +57230,6 @@
 "cKr" = (
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/prison)
@@ -60243,7 +57244,6 @@
 	pixel_y = 2
 	},
 /turf/open/floor{
-	tag = "icon-darkred2 (WEST)";
 	icon_state = "darkred2";
 	dir = 8
 	},
@@ -60253,13 +57253,11 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/warden)
 "cKu" = (
 /turf/open/floor{
-	tag = "icon-darkredcorners2 (EAST)";
 	icon_state = "darkredcorners2";
 	dir = 4
 	},
@@ -60268,7 +57266,6 @@
 /obj/structure/rack,
 /obj/item/clothing/mask/gas,
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTHWEST)";
 	icon_state = "darkred2";
 	dir = 9
 	},
@@ -60278,7 +57275,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-darkredcorners2 (NORTH)";
 	icon_state = "darkredcorners2";
 	dir = 1
 	},
@@ -60287,8 +57283,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -60296,14 +57291,12 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/armory)
 "cKz" = (
 /obj/structure/closet/l3closet/security,
 /obj/machinery/light{
-	tag = "icon-tube1 (NORTH)";
 	icon_state = "tube1";
 	dir = 1
 	},
@@ -60334,7 +57327,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
@@ -60366,7 +57358,6 @@
 /area/desert_dam/exterior/river/riverside_south)
 "cKG" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (NORTH)";
 	icon_state = "platform_deco";
 	dir = 1
 	},
@@ -60417,7 +57408,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-darkred2 (WEST)";
 	icon_state = "darkred2";
 	dir = 8
 	},
@@ -60428,7 +57418,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/warden)
@@ -60437,7 +57426,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/warden)
@@ -60450,7 +57438,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-darkred2 (EAST)";
 	icon_state = "darkred2";
 	dir = 4
 	},
@@ -60459,14 +57446,12 @@
 /obj/structure/rack,
 /obj/item/clothing/mask/gas,
 /turf/open/floor{
-	tag = "icon-darkred2 (WEST)";
 	icon_state = "darkred2";
 	dir = 8
 	},
 /area/desert_dam/building/security/armory)
 "cKT" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/armory)
@@ -60477,39 +57462,33 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/armory)
 "cKV" = (
 /turf/open/floor{
-	tag = "icon-darkredcorners2 (EAST)";
 	icon_state = "darkredcorners2";
 	dir = 4
 	},
 /area/desert_dam/building/security/armory)
 "cKW" = (
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTH)";
 	icon_state = "darkred2";
 	dir = 1
 	},
 /area/desert_dam/building/security/armory)
 "cKX" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (NORTH)";
 	icon_state = "tube1";
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTH)";
 	icon_state = "darkred2";
 	dir = 1
 	},
 /area/desert_dam/building/security/armory)
 "cKY" = (
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTHEAST)";
 	icon_state = "darkred2";
 	dir = 5
 	},
@@ -60642,7 +57621,6 @@
 "cLp" = (
 /obj/machinery/washing_machine,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTHWEST)";
 	icon_state = "darkyellow2";
 	dir = 9
 	},
@@ -60654,7 +57632,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -60662,7 +57639,6 @@
 "cLr" = (
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -60670,7 +57646,6 @@
 "cLs" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -60678,7 +57653,6 @@
 "cLt" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -60686,7 +57660,6 @@
 "cLu" = (
 /obj/machinery/vending/snack,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -60697,7 +57670,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2 (NORTH)";
 	icon_state = "darkyellow2";
 	dir = 1
 	},
@@ -60706,8 +57678,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
@@ -60718,8 +57689,7 @@
 "cLy" = (
 /turf/open/floor{
 	dir = 4;
-	icon_state = "darkyellowcorners2";
-	tag = "icon-darkyellowcorners2 (NORTH)"
+	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/building/security/prison)
 "cLz" = (
@@ -60744,7 +57714,6 @@
 /area/desert_dam/building/security/prison)
 "cLB" = (
 /turf/open/floor{
-	tag = "icon-darkredcorners2 (NORTH)";
 	icon_state = "darkredcorners2";
 	dir = 1
 	},
@@ -60752,20 +57721,17 @@
 "cLC" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/warden)
 "cLE" = (
 /turf/open/floor{
-	tag = "icon-darkredcorners2 (NORTH)";
 	icon_state = "darkredcorners2";
 	dir = 1
 	},
 /area/desert_dam/building/security/armory)
 "cLF" = (
 /turf/open/floor{
-	tag = "icon-darkred2 (EAST)";
 	icon_state = "darkred2";
 	dir = 4
 	},
@@ -60781,7 +57747,6 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor{
-	tag = "icon-whiteyellow (NORTHWEST)";
 	icon_state = "whiteyellow";
 	dir = 9
 	},
@@ -60790,22 +57755,19 @@
 /obj/machinery/vending/snack,
 /turf/open/floor{
 	dir = 1;
-	icon_state = "whiteyellow";
-	tag = "icon-whiteredcorner (NORTH)"
+	icon_state = "whiteyellow"
 	},
 /area/desert_dam/building/water_treatment_one)
 "cLJ" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor{
 	dir = 5;
-	icon_state = "whiteyellow";
-	tag = "icon-whiteredcorner (NORTH)"
+	icon_state = "whiteyellow"
 	},
 /area/desert_dam/building/water_treatment_one)
 "cLK" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor{
-	tag = "icon-whiteyellow (NORTH)";
 	icon_state = "whiteyellow";
 	dir = 1
 	},
@@ -60813,8 +57775,7 @@
 "cLL" = (
 /turf/open/floor{
 	dir = 1;
-	icon_state = "whiteyellowcorner";
-	tag = "icon-whiteyellowcorner (EAST)"
+	icon_state = "whiteyellowcorner"
 	},
 /area/desert_dam/building/water_treatment_one)
 "cLM" = (
@@ -60831,27 +57792,23 @@
 "cLN" = (
 /turf/open/floor{
 	dir = 4;
-	icon_state = "whiteyellow";
-	tag = "icon-whiteredcorner (NORTH)"
+	icon_state = "whiteyellow"
 	},
 /area/desert_dam/building/water_treatment_one)
 "cLO" = (
 /turf/open/floor{
-	tag = "icon-darkgreen2 (WEST)";
 	icon_state = "darkgreen2";
 	dir = 8
 	},
 /area/desert_dam/building/water_treatment_one)
 "cLP" = (
 /turf/open/floor{
-	tag = "icon-darkgreencorners2 (EAST)";
 	icon_state = "darkgreencorners2";
 	dir = 4
 	},
 /area/desert_dam/building/water_treatment_one)
 "cLQ" = (
 /turf/open/floor{
-	tag = "icon-darkgreen2 (NORTH)";
 	icon_state = "darkgreen2";
 	dir = 1
 	},
@@ -60876,8 +57833,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = "90Curve"
+	icon_state = "1-4"
 	},
 /turf/open/floor,
 /area/desert_dam/building/dorms/hallway_northwing)
@@ -60885,8 +57841,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/open/floor,
 /area/desert_dam/building/dorms/hallway_northwing)
@@ -60911,8 +57866,7 @@
 "cLY" = (
 /turf/open/floor{
 	dir = 8;
-	icon_state = "darkyellow2";
-	tag = "icon-darkyellow2 (EAST)"
+	icon_state = "darkyellow2"
 	},
 /area/desert_dam/building/security/prison)
 "cLZ" = (
@@ -60930,7 +57884,6 @@
 	name = "\improper Cell 1"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/prison)
@@ -60954,7 +57907,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/southern_hallway)
@@ -60967,7 +57919,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-darkredcorners2 (NORTH)";
 	icon_state = "darkredcorners2";
 	dir = 1
 	},
@@ -60985,7 +57936,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/warden)
@@ -60998,7 +57948,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/warden)
@@ -61008,7 +57957,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/warden)
@@ -61016,11 +57964,9 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/warden)
@@ -61032,12 +57978,10 @@
 /area/desert_dam/exterior/landing_pad_one_external)
 "cMk" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/armory)
@@ -61053,11 +57997,9 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/armory)
@@ -61071,7 +58013,6 @@
 	},
 /obj/item/ammo_magazine/pistol/holdout,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/armory)
@@ -61088,7 +58029,6 @@
 	pixel_y = -4
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/armory)
@@ -61096,7 +58036,6 @@
 /obj/structure/rack,
 /obj/item/ammo_magazine/shotgun/incendiary,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/armory)
@@ -61108,7 +58047,6 @@
 	pixel_y = -2
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/armory)
@@ -61116,7 +58054,6 @@
 /obj/structure/rack,
 /obj/item/explosive/plastique,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/armory)
@@ -61126,7 +58063,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor{
-	tag = "icon-whiteyellow (WEST)";
 	icon_state = "whiteyellow";
 	dir = 8
 	},
@@ -61143,8 +58079,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -61198,7 +58133,6 @@
 /area/desert_dam/building/dorms/hallway_northwing)
 "cMA" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -61210,7 +58144,6 @@
 /area/desert_dam/building/dorms/hallway_northwing)
 "cMB" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -61226,7 +58159,6 @@
 /area/desert_dam/building/dorms/hallway_northwing)
 "cMC" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -61240,7 +58172,6 @@
 /area/desert_dam/building/dorms/hallway_northwing)
 "cMD" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -61260,7 +58191,6 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -61277,14 +58207,12 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4;
@@ -61347,7 +58275,6 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "cMM" = (
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2 (NORTH)";
 	icon_state = "darkyellowcorners2";
 	dir = 1
 	},
@@ -61380,7 +58307,6 @@
 /area/desert_dam/building/security/prison)
 "cMQ" = (
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2";
 	icon_state = "darkyellowcorners2"
 	},
 /area/desert_dam/building/security/prison)
@@ -61406,13 +58332,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/southern_hallway)
 "cMU" = (
 /turf/open/floor{
-	tag = "icon-darkred2";
 	icon_state = "darkred2"
 	},
 /area/desert_dam/building/security/warden)
@@ -61420,7 +58344,6 @@
 /obj/structure/table,
 /obj/item/ammo_magazine/shotgun,
 /turf/open/floor{
-	tag = "icon-darkred2";
 	icon_state = "darkred2"
 	},
 /area/desert_dam/building/security/warden)
@@ -61428,7 +58351,6 @@
 /obj/structure/table,
 /obj/item/handcuffs,
 /turf/open/floor{
-	tag = "icon-darkred2";
 	icon_state = "darkred2"
 	},
 /area/desert_dam/building/security/warden)
@@ -61440,7 +58362,6 @@
 /obj/item/ammo_magazine/shotgun,
 /obj/item/ammo_magazine/shotgun/buckshot,
 /turf/open/floor{
-	tag = "icon-darkred2";
 	icon_state = "darkred2"
 	},
 /area/desert_dam/building/security/warden)
@@ -61449,33 +58370,28 @@
 /obj/item/ammo_magazine/shotgun/buckshot,
 /obj/item/clothing/head/beret/sec/warden,
 /turf/open/floor{
-	tag = "icon-darkred2";
 	icon_state = "darkred2"
 	},
 /area/desert_dam/building/security/warden)
 "cMZ" = (
 /turf/open/floor{
-	tag = "icon-darkred2";
 	icon_state = "darkred2"
 	},
 /area/desert_dam/building/security/armory)
 "cNa" = (
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-darkred2";
 	icon_state = "darkred2"
 	},
 /area/desert_dam/building/security/armory)
 "cNb" = (
 /turf/open/floor{
-	tag = "icon-darkred2 (SOUTHEAST)";
 	icon_state = "darkred2";
 	dir = 6
 	},
 /area/desert_dam/building/security/armory)
 "cNc" = (
 /turf/open/floor{
-	tag = "icon-whiteyellow (WEST)";
 	icon_state = "whiteyellow";
 	dir = 8
 	},
@@ -61497,14 +58413,12 @@
 /area/desert_dam/building/water_treatment_one)
 "cNf" = (
 /turf/open/floor{
-	tag = "icon-whiteyellowcorner (EAST)";
 	icon_state = "whiteyellowcorner";
 	dir = 4
 	},
 /area/desert_dam/building/water_treatment_one)
 "cNg" = (
 /turf/open/floor{
-	tag = "icon-darkgreencorners2 (NORTH)";
 	icon_state = "darkgreencorners2";
 	dir = 1
 	},
@@ -61514,7 +58428,6 @@
 	dir = 2
 	},
 /turf/open/floor{
-	tag = "icon-dark";
 	icon_state = "dark";
 	dir = 2
 	},
@@ -61630,7 +58543,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-darkyellow2 (EAST)";
 	icon_state = "darkyellow2";
 	dir = 4
 	},
@@ -61641,7 +58553,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-darkredcorners2 (EAST)";
 	icon_state = "darkredcorners2";
 	dir = 4
 	},
@@ -61700,7 +58611,6 @@
 /area/desert_dam/building/security/armory)
 "cNE" = (
 /obj/structure/bed/chair{
-	tag = "icon-chair (EAST)";
 	icon_state = "chair";
 	dir = 4
 	},
@@ -61716,7 +58626,6 @@
 /area/desert_dam/building/water_treatment_one)
 "cNG" = (
 /obj/structure/bed/chair{
-	tag = "icon-chair (WEST)";
 	icon_state = "chair";
 	dir = 8
 	},
@@ -61726,7 +58635,6 @@
 /area/desert_dam/building/water_treatment_one)
 "cNH" = (
 /turf/open/floor{
-	tag = "icon-darkgreencorners2";
 	icon_state = "darkgreencorners2"
 	},
 /area/desert_dam/building/water_treatment_one)
@@ -61746,7 +58654,6 @@
 	name = "\improper Toilet Unit"
 	},
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/security/prison)
@@ -61757,7 +58664,6 @@
 "cNM" = (
 /obj/machinery/door/airlock/multi_tile/almayer/generic,
 /turf/open/floor{
-	tag = "icon-white";
 	icon_state = "white";
 	dir = 2
 	},
@@ -61770,7 +58676,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor{
-	tag = "icon-white";
 	icon_state = "white";
 	dir = 2
 	},
@@ -61840,7 +58745,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor{
-	tag = "icon-white";
 	icon_state = "white";
 	dir = 2
 	},
@@ -61859,7 +58763,6 @@
 /obj/item/paper_bin,
 /obj/item/tool/pen,
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTHWEST)";
 	icon_state = "darkred2";
 	dir = 9
 	},
@@ -61870,7 +58773,6 @@
 	},
 /obj/structure/closet/secure_closet/brig,
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTH)";
 	icon_state = "darkred2";
 	dir = 1
 	},
@@ -61878,14 +58780,12 @@
 "cOe" = (
 /obj/structure/toilet,
 /turf/open/floor{
-	tag = "icon-darkred2 (NORTHEAST)";
 	icon_state = "darkred2";
 	dir = 5
 	},
 /area/desert_dam/building/security/deathrow)
 "cOf" = (
 /turf/open/floor{
-	tag = "icon-darkgreen2 (SOUTHEAST)";
 	icon_state = "darkgreen2";
 	dir = 6
 	},
@@ -61947,7 +58847,6 @@
 	dir = 8
 	},
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (EAST)";
 	icon_state = "bulb1";
 	dir = 4
 	},
@@ -61979,7 +58878,6 @@
 /area/desert_dam/building/dorms/hallway_eastwing)
 "cOs" = (
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2 (WEST)";
 	icon_state = "darkyellowcorners2";
 	dir = 8
 	},
@@ -61995,21 +58893,18 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-darkred2 (WEST)";
 	icon_state = "darkred2";
 	dir = 8
 	},
 /area/desert_dam/building/security/deathrow)
 "cOv" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/deathrow)
 "cOw" = (
 /obj/structure/bed,
 /turf/open/floor{
-	tag = "icon-darkred2 (EAST)";
 	icon_state = "darkred2";
 	dir = 4
 	},
@@ -62019,14 +58914,12 @@
 /area/desert_dam/building/security/execution_chamber)
 "cOy" = (
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/execution_chamber)
 "cOA" = (
 /obj/structure/bed/chair,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/execution_chamber)
@@ -62036,7 +58929,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/execution_chamber)
@@ -62046,22 +58938,19 @@
 "cOD" = (
 /turf/open/floor{
 	dir = 10;
-	icon_state = "whiteyellow";
-	tag = "icon-whiteredcorner (NORTH)"
+	icon_state = "whiteyellow"
 	},
 /area/desert_dam/building/water_treatment_one)
 "cOE" = (
 /turf/open/floor{
 	dir = 2;
-	icon_state = "whiteyellow";
-	tag = "icon-whiteredcorner (NORTH)"
+	icon_state = "whiteyellow"
 	},
 /area/desert_dam/building/water_treatment_one)
 "cOF" = (
 /turf/open/floor{
 	dir = 2;
-	icon_state = "whiteyellowcorner";
-	tag = "icon-whiteyellowcorner (EAST)"
+	icon_state = "whiteyellowcorner"
 	},
 /area/desert_dam/building/water_treatment_one)
 "cOG" = (
@@ -62070,14 +58959,12 @@
 /area/desert_dam/building/water_treatment_one)
 "cOH" = (
 /turf/open/floor{
-	tag = "icon-darkgreencorners2 (WEST)";
 	icon_state = "darkgreencorners2";
 	dir = 8
 	},
 /area/desert_dam/building/water_treatment_one)
 "cOI" = (
 /turf/open/floor{
-	tag = "icon-darkgreen2 (EAST)";
 	icon_state = "darkgreen2";
 	dir = 4
 	},
@@ -62138,7 +59025,6 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/trunk{
-	tag = "icon-pipe-t (WEST)";
 	icon_state = "pipe-t";
 	dir = 8
 	},
@@ -62190,7 +59076,6 @@
 "cOX" = (
 /obj/structure/table/reinforced,
 /turf/open/floor{
-	tag = "icon-darkyellow2 (SOUTHWEST)";
 	icon_state = "darkyellow2";
 	dir = 10
 	},
@@ -62199,27 +59084,23 @@
 /obj/structure/table/reinforced,
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-darkyellowcorners2 (WEST)";
 	icon_state = "darkyellowcorners2";
 	dir = 8
 	},
 /area/desert_dam/building/security/prison)
 "cOZ" = (
 /obj/structure/disposalpipe/trunk{
-	tag = "icon-pipe-t (NORTH)";
 	icon_state = "pipe-t";
 	dir = 1
 	},
 /obj/machinery/disposal,
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-darkyellow2";
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/building/security/prison)
 "cPa" = (
 /turf/open/floor{
-	tag = "icon-darkyellow2";
 	icon_state = "darkyellow2"
 	},
 /area/desert_dam/building/security/prison)
@@ -62229,14 +59110,12 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-darkred2 (WEST)";
 	icon_state = "darkred2";
 	dir = 8
 	},
 /area/desert_dam/building/security/deathrow)
 "cPc" = (
 /turf/open/floor{
-	tag = "icon-darkred2 (EAST)";
 	icon_state = "darkred2";
 	dir = 4
 	},
@@ -62248,14 +59127,12 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/execution_chamber)
 "cPe" = (
 /obj/machinery/door/airlock/almayer/security/glass,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/execution_chamber)
@@ -62311,7 +59188,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/deathrow)
@@ -62321,7 +59197,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/execution_chamber)
@@ -62358,8 +59233,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/open/floor{
 	icon_state = "freezerfloor"
@@ -62385,14 +59259,12 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/open/floor{
 	icon_state = "dark"
@@ -62402,8 +59274,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/open/floor{
 	icon_state = "white"
@@ -62471,7 +59342,6 @@
 /area/desert_dam/building/dorms/hallway_westwing)
 "cPI" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -62490,8 +59360,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor,
@@ -62522,13 +59391,11 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/security/prison)
 "cPQ" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -62550,7 +59417,6 @@
 /area/desert_dam/interior/dam_interior/engine_room)
 "cPR" = (
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/security/prison)
@@ -62559,7 +59425,6 @@
 	pixel_y = 32
 	},
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/security/prison)
@@ -62571,7 +59436,6 @@
 	pixel_y = 0
 	},
 /turf/open/floor{
-	tag = "icon-freezerfloor";
 	icon_state = "freezerfloor"
 	},
 /area/desert_dam/building/security/prison)
@@ -62610,7 +59474,6 @@
 	name = "\improper Lethal Injection"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/execution_chamber)
@@ -62664,8 +59527,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
@@ -62675,7 +59537,6 @@
 /area/desert_dam/building/dorms/restroom)
 "cQh" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (WEST)";
 	icon_state = "tube1";
 	dir = 8
 	},
@@ -62703,20 +59564,17 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/southern_hallway)
 "cQm" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -62725,7 +59583,6 @@
 	layer = 2.4
 	},
 /turf/open/floor{
-	tag = "icon-darkredcorners2 (NORTH)";
 	icon_state = "darkredcorners2";
 	dir = 1
 	},
@@ -62738,7 +59595,6 @@
 /area/desert_dam/exterior/landing_pad_one_external)
 "cQo" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -62747,28 +59603,24 @@
 	layer = 2.4
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/deathrow)
 "cQp" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4;
 	layer = 2.4
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/deathrow)
@@ -62780,7 +59632,6 @@
 /area/desert_dam/exterior/valley/valley_north_west)
 "cQr" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -62789,7 +59640,6 @@
 	layer = 2.4
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/execution_chamber)
@@ -62797,21 +59647,18 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 10
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/execution_chamber)
 "cQt" = (
 /obj/structure/bed,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/execution_chamber)
@@ -62849,8 +59696,7 @@
 "cQy" = (
 /obj/machinery/shower{
 	dir = 8;
-	icon_state = "shower";
-	tag = "icon-shower (NORTH)"
+	icon_state = "shower"
 	},
 /turf/open/floor/plating/catwalk,
 /area/desert_dam/building/dorms/restroom)
@@ -62898,7 +59744,6 @@
 /area/desert_dam/building/dorms/hallway_westwing)
 "cQD" = (
 /obj/machinery/shower{
-	tag = "icon-shower (NORTH)";
 	icon_state = "shower";
 	dir = 1
 	},
@@ -62906,7 +59751,6 @@
 /area/desert_dam/building/security/prison)
 "cQE" = (
 /turf/open/floor{
-	tag = "icon-darkyellow2 (SOUTHWEST)";
 	icon_state = "darkyellow2";
 	dir = 10
 	},
@@ -62917,14 +59761,12 @@
 	on = 1
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/execution_chamber)
 "cQG" = (
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/execution_chamber)
@@ -62987,7 +59829,6 @@
 "cQP" = (
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/deathrow)
@@ -62995,7 +59836,6 @@
 /obj/structure/table/reinforced,
 /obj/item/clothing/mask/muzzle,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/deathrow)
@@ -63003,7 +59843,6 @@
 /obj/structure/table/reinforced,
 /obj/item/clothing/suit/straight_jacket,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/deathrow)
@@ -63011,25 +59850,21 @@
 /obj/structure/table/reinforced,
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/deathrow)
 "cQT" = (
 /turf/open/floor{
-	tag = "icon-darkgreen2 (NORTHWEST)";
 	icon_state = "darkgreen2";
 	dir = 9
 	},
 /area/desert_dam/building/water_treatment_one)
 "cQV" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
 /turf/open/floor{
-	tag = "icon-darkgreencorners2 (NORTH)";
 	icon_state = "darkgreencorners2";
 	dir = 1
 	},
@@ -63043,8 +59878,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/open/floor{
 	icon_state = "dark"
@@ -63071,7 +59905,6 @@
 /area/desert_dam/exterior/river/riverside_south)
 "cRa" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -63082,8 +59915,7 @@
 "cRb" = (
 /obj/structure/platform_decoration{
 	dir = 8;
-	icon_state = "platform_deco";
-	tag = "icon-platform_deco (EAST)"
+	icon_state = "platform_deco"
 	},
 /turf/open/ground/desertdam/river/toxic/shallow_water_desert_coast_toxic{
 	icon_state = "shallow_water_desert_coast_toxic2"
@@ -63107,7 +59939,6 @@
 /area/desert_dam/exterior/river/riverside_south)
 "cRe" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -63224,8 +60055,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "1-4"
 	},
 /turf/open/floor{
 	icon_state = "dark"
@@ -63234,7 +60064,6 @@
 "cRw" = (
 /obj/machinery/door/airlock/almayer/medical/glass,
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -63242,7 +60071,6 @@
 /area/desert_dam/building/water_treatment_one)
 "cRx" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -63252,7 +60080,6 @@
 /area/desert_dam/building/water_treatment_one)
 "cRy" = (
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -63262,8 +60089,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
 /area/desert_dam/building/water_treatment_one)
@@ -63275,7 +60101,6 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/trunk{
-	tag = "icon-pipe-t (WEST)";
 	icon_state = "pipe-t";
 	dir = 8
 	},
@@ -63316,7 +60141,6 @@
 "cRG" = (
 /obj/machinery/door/airlock/multi_tile/almayer/generic,
 /turf/open/floor{
-	tag = "icon-white";
 	icon_state = "white";
 	dir = 2
 	},
@@ -63324,7 +60148,6 @@
 "cRH" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor{
-	tag = "icon-white";
 	icon_state = "white";
 	dir = 2
 	},
@@ -63358,14 +60181,12 @@
 /obj/machinery/door/airlock/multi_tile/almayer/generic,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor{
-	tag = "icon-white";
 	icon_state = "white";
 	dir = 2
 	},
 /area/desert_dam/building/dorms/pool)
 "cRL" = (
 /turf/open/floor{
-	tag = "icon-white";
 	icon_state = "white";
 	dir = 2
 	},
@@ -63381,20 +60202,17 @@
 /area/desert_dam/interior/dam_interior/hanger)
 "cRN" = (
 /turf/open/floor{
-	tag = "icon-darkgreen2 (SOUTHWEST)";
 	icon_state = "darkgreen2";
 	dir = 10
 	},
 /area/desert_dam/building/water_treatment_one)
 "cRO" = (
 /turf/open/floor{
-	tag = "icon-darkgreen2";
 	icon_state = "darkgreen2"
 	},
 /area/desert_dam/building/water_treatment_one)
 "cRP" = (
 /obj/machinery/shower{
-	tag = "icon-shower (NORTH)";
 	icon_state = "shower";
 	dir = 1
 	},
@@ -63402,7 +60220,6 @@
 /area/desert_dam/building/water_treatment_one)
 "cRQ" = (
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-c (NORTH)";
 	icon_state = "pipe-c";
 	dir = 1
 	},
@@ -63414,7 +60231,6 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/trunk{
-	tag = "icon-pipe-t (WEST)";
 	icon_state = "pipe-t";
 	dir = 8
 	},
@@ -63430,14 +60246,12 @@
 /area/desert_dam/exterior/valley/valley_south_west)
 "cRT" = (
 /turf/open/floor{
-	tag = "icon-whitegreen (WEST)";
 	icon_state = "whitegreen";
 	dir = 8
 	},
 /area/desert_dam/building/dorms/pool)
 "cRU" = (
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
@@ -63447,7 +60261,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
@@ -63458,14 +60271,12 @@
 	pixel_y = 30
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
 /area/desert_dam/building/dorms/pool)
 "cRX" = (
 /turf/open/floor{
-	tag = "icon-whitegreencorner (NORTH)";
 	icon_state = "whitegreencorner";
 	dir = 1
 	},
@@ -63476,7 +60287,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
@@ -63490,7 +60300,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
@@ -63504,7 +60313,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
@@ -63513,8 +60321,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment{
@@ -63522,7 +60329,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor{
-	tag = "icon-white";
 	icon_state = "white";
 	dir = 2
 	},
@@ -63530,7 +60336,6 @@
 "cSd" = (
 /obj/structure/closet/lasertag/red,
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
@@ -63538,14 +60343,12 @@
 "cSe" = (
 /obj/structure/closet/lasertag/blue,
 /turf/open/floor{
-	tag = "icon-whitegreen (NORTH)";
 	icon_state = "whitegreen";
 	dir = 1
 	},
 /area/desert_dam/building/dorms/pool)
 "cSf" = (
 /turf/open/floor{
-	tag = "icon-whitegreen (EAST)";
 	icon_state = "whitegreen";
 	dir = 4
 	},
@@ -63567,7 +60370,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
@@ -63578,7 +60380,6 @@
 	layer = 2.4
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
@@ -63589,7 +60390,6 @@
 	layer = 2.4
 	},
 /turf/open/floor{
-	tag = "icon-white";
 	icon_state = "white";
 	dir = 2
 	},
@@ -63597,7 +60397,6 @@
 "cSl" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /turf/open/floor{
-	tag = "icon-white";
 	icon_state = "white";
 	dir = 2
 	},
@@ -63608,7 +60407,6 @@
 	layer = 2.4
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (NORTH)";
 	icon_state = "whitegreencorner";
 	dir = 1
 	},
@@ -63618,7 +60416,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (NORTH)";
 	icon_state = "whitegreencorner";
 	dir = 1
 	},
@@ -63629,7 +60426,6 @@
 	layer = 2.5
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (EAST)";
 	icon_state = "whitegreen";
 	dir = 4
 	},
@@ -63654,7 +60450,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (WEST)";
 	icon_state = "whitegreen";
 	dir = 8
 	},
@@ -63662,7 +60457,6 @@
 "cSs" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
@@ -63676,7 +60470,6 @@
 "cSu" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor{
-	tag = "icon-whitegreencorner (NORTH)";
 	icon_state = "whitegreencorner";
 	dir = 1
 	},
@@ -63693,7 +60486,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (EAST)";
 	icon_state = "whitegreen";
 	dir = 4
 	},
@@ -63704,7 +60496,6 @@
 	on = 1
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (EAST)";
 	icon_state = "whitegreencorner";
 	dir = 4
 	},
@@ -63722,7 +60513,6 @@
 	on = 1
 	},
 /turf/open/floor{
-	tag = "icon-whitegreencorner (NORTH)";
 	icon_state = "whitegreencorner";
 	dir = 1
 	},
@@ -63732,7 +60522,6 @@
 	layer = 2.5
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (EAST)";
 	icon_state = "whitegreen";
 	dir = 4
 	},
@@ -63740,7 +60529,6 @@
 "cSB" = (
 /obj/structure/table,
 /turf/open/floor{
-	tag = "icon-whitegreen (SOUTHWEST)";
 	icon_state = "whitegreen";
 	dir = 10
 	},
@@ -63748,14 +60536,12 @@
 "cSC" = (
 /obj/structure/table,
 /turf/open/floor{
-	tag = "icon-whitegreen";
 	icon_state = "whitegreen";
 	dir = 2
 	},
 /area/desert_dam/building/dorms/pool)
 "cSD" = (
 /turf/open/floor{
-	tag = "icon-whitegreencorner (WEST)";
 	icon_state = "whitegreencorner";
 	dir = 8
 	},
@@ -63769,7 +60555,6 @@
 /area/desert_dam/building/dorms/pool)
 "cSF" = (
 /turf/open/floor{
-	tag = "icon-whitegreencorner";
 	icon_state = "whitegreencorner";
 	dir = 2
 	},
@@ -63777,7 +60562,6 @@
 "cSG" = (
 /obj/structure/table,
 /turf/open/floor{
-	tag = "icon-whitegreen (SOUTHEAST)";
 	icon_state = "whitegreen";
 	dir = 6
 	},
@@ -63789,7 +60573,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (WEST)";
 	icon_state = "whitegreen";
 	dir = 8
 	},
@@ -63799,14 +60582,12 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitegreen (EAST)";
 	icon_state = "whitegreen";
 	dir = 4
 	},
 /area/desert_dam/building/dorms/pool)
 "cSJ" = (
 /turf/open/floor{
-	tag = "icon-whitegreen";
 	icon_state = "whitegreen";
 	dir = 2
 	},
@@ -63820,7 +60601,6 @@
 /area/desert_dam/building/dorms/pool)
 "cSL" = (
 /turf/open/floor{
-	tag = "icon-whitegreen (SOUTHEAST)";
 	icon_state = "whitegreen";
 	dir = 6
 	},
@@ -63840,8 +60620,7 @@
 "cSO" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "E";
-	pixel_x = 0;
-	tag = "icon-E-corner"
+	pixel_x = 0
 	},
 /obj/structure/desertdam/decals/road_edge{
 	icon_state = "road_edge_decal14"
@@ -64034,7 +60813,6 @@
 /area/desert_dam/exterior/valley/valley_north_east)
 "cTv" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (NORTH)";
 	icon_state = "platform_deco";
 	dir = 1
 	},
@@ -64106,7 +60884,6 @@
 /area/desert_dam/interior/caves/central_caves)
 "cTF" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (EAST)";
 	icon_state = "platform_deco";
 	dir = 4
 	},
@@ -64221,7 +60998,6 @@
 /area/desert_dam/exterior/river/riverside_east)
 "cTX" = (
 /obj/structure/platform_decoration{
-	tag = "icon-platform_deco (NORTH)";
 	icon_state = "platform_deco";
 	dir = 1
 	},
@@ -64313,7 +61089,6 @@
 /area/space)
 "cXj" = (
 /obj/structure/showcase{
-	tag = "icon-bus";
 	icon_state = "bus"
 	},
 /turf/open/floor/greengrid,
@@ -64403,7 +61178,6 @@
 "cXu" = (
 /obj/structure/table,
 /obj/machinery/light{
-	tag = "icon-tube1 (EAST)";
 	icon_state = "tube1";
 	dir = 4
 	},
@@ -64454,7 +61228,6 @@
 /area/space)
 "cXA" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W-corner";
 	icon_state = "W-corner"
 	},
 /turf/open/floor{
@@ -64578,7 +61351,6 @@
 /area/space)
 "cXP" = (
 /obj/structure/showcase{
-	tag = "icon-broadcaster_send";
 	icon_state = "broadcaster_send"
 	},
 /turf/open/floor/greengrid,
@@ -64657,7 +61429,6 @@
 	name = "\improper Chapel"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -64702,7 +61473,6 @@
 	name = "\improper Security Office"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/interior/lab_northeast/security_office)
@@ -64722,7 +61492,6 @@
 	name = "\improper Surgery"
 	},
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -64731,7 +61500,6 @@
 	layer = 2.4
 	},
 /obj/structure/disposalpipe/segment{
-	tag = "icon-pipe-s (WEST)";
 	icon_state = "pipe-s";
 	dir = 8
 	},
@@ -64773,7 +61541,6 @@
 	name = "\improper Cell 2"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/prison)
@@ -64790,7 +61557,6 @@
 	name = "\improper Cell 3"
 	},
 /turf/open/floor{
-	tag = "icon-dark2";
 	icon_state = "dark2"
 	},
 /area/desert_dam/building/security/prison)

--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -935,7 +935,6 @@
 /area/bigredv2/outside/telecomm)
 "ada" = (
 /obj/structure/showcase{
-	tag = "icon-bus";
 	icon_state = "bus"
 	},
 /turf/open/floor/greengrid,
@@ -1242,7 +1241,6 @@
 /area/bigredv2/outside/telecomm)
 "aed" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W-corner";
 	icon_state = "W-corner"
 	},
 /turf/open/floor/tile/dark,
@@ -1590,7 +1588,6 @@
 	},
 /obj/machinery/power/apc/drained,
 /turf/open/floor/bluegrid{
-	tag = "icon-bcircuitoff";
 	icon_state = "bcircuitoff"
 	},
 /area/bigredv2/caves/lambda_lab)
@@ -1718,7 +1715,6 @@
 /area/bigredv2/caves/lambda_lab)
 "afw" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W-corner";
 	icon_state = "W-corner"
 	},
 /obj/structure/bed/chair{
@@ -1821,7 +1817,6 @@
 /area/bigredv2/outside/telecomm)
 "afL" = (
 /obj/structure/showcase{
-	tag = "icon-broadcaster_send";
 	icon_state = "broadcaster_send"
 	},
 /turf/open/floor/greengrid,
@@ -1933,7 +1928,6 @@
 "agf" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window{
-	tag = "icon-left";
 	icon_state = "left";
 	dir = 2
 	},
@@ -2186,7 +2180,6 @@
 /area/bigredv2/caves/lambda_lab)
 "agN" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W-corner";
 	icon_state = "W-corner"
 	},
 /obj/item/shard,
@@ -7097,7 +7090,6 @@
 /area/bigredv2/caves/lambda_lab)
 "auv" = (
 /obj/structure/showcase{
-	tag = "icon-bus";
 	icon_state = "bus"
 	},
 /obj/structure/cable{
@@ -7114,7 +7106,6 @@
 /area/bigredv2/caves/lambda_lab)
 "auw" = (
 /obj/structure/showcase{
-	tag = "icon-mechfab1";
 	icon_state = "mechfab1"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -7383,7 +7374,6 @@
 /area/bigredv2/caves/lambda_lab)
 "avj" = (
 /obj/structure/showcase{
-	tag = "icon-broadcaster_send";
 	icon_state = "broadcaster_send"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -8090,7 +8080,6 @@
 /area/bigredv2/caves/lambda_lab)
 "axp" = (
 /obj/structure/bed/chair/comfy/lime{
-	tag = "icon-comfychair (EAST)";
 	icon_state = "comfychair";
 	dir = 4
 	},
@@ -9313,7 +9302,6 @@
 /area/bigredv2/caves/lambda_lab)
 "aAP" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W-corner";
 	icon_state = "W-corner"
 	},
 /turf/open/floor/tile/purple/whitepurple{
@@ -9327,7 +9315,6 @@
 /area/bigredv2/caves/lambda_lab)
 "aAR" = (
 /obj/structure/barricade/metal{
-	tag = "icon-barricade (EAST)";
 	icon_state = "barricade";
 	dir = 4
 	},
@@ -9356,8 +9343,7 @@
 /obj/machinery/conveyor{
 	dir = 9;
 	icon_state = "conveyor0";
-	id = "anomalybelt";
-	tag = "icon-conveyor0 (NORTHWEST)"
+	id = "anomalybelt"
 	},
 /obj/effect/alien/weeds/node,
 /turf/open/floor/tile/dark,
@@ -9529,7 +9515,6 @@
 /area/bigredv2/outside/library)
 "aBA" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W-corner";
 	icon_state = "W-corner"
 	},
 /obj/structure/cable{
@@ -9594,7 +9579,6 @@
 /area/bigredv2/caves/lambda_lab)
 "aBG" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-U-S";
 	icon_state = "U-S"
 	},
 /turf/open/floor/tile/dark,
@@ -9800,7 +9784,6 @@
 /area/bigredv2/caves/lambda_lab)
 "aCs" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W-corner";
 	icon_state = "W-corner"
 	},
 /obj/item/clipboard,
@@ -9819,7 +9802,6 @@
 /area/bigredv2/caves/lambda_lab)
 "aCu" = (
 /obj/structure/barricade/metal{
-	tag = "icon-barricade (EAST)";
 	icon_state = "barricade";
 	dir = 4
 	},
@@ -9859,11 +9841,9 @@
 /obj/machinery/power/emitter{
 	anchored = 1;
 	dir = 1;
-	icon_state = "emitter";
-	tag = "icon-emitter (NORTH)"
+	icon_state = "emitter"
 	},
 /obj/effect/decal/warning_stripes{
-	tag = "icon-U-N";
 	icon_state = "U-N"
 	},
 /turf/open/floor/tile/dark,
@@ -10093,7 +10073,6 @@
 /area/bigredv2/caves/lambda_lab)
 "aDj" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W-corner";
 	icon_state = "W-corner"
 	},
 /obj/structure/cable{
@@ -10119,7 +10098,6 @@
 /area/bigredv2/caves/lambda_lab)
 "aDm" = (
 /obj/structure/barricade/metal{
-	tag = "icon-barricade (EAST)";
 	icon_state = "barricade";
 	dir = 4
 	},
@@ -11433,12 +11411,10 @@
 /area/bigredv2/caves/lambda_lab)
 "aHb" = (
 /obj/structure/window/reinforced/toughened{
-	tag = "icon-fwindow (NORTH)";
 	icon_state = "fwindow";
 	dir = 1
 	},
 /obj/structure/window/reinforced/toughened{
-	tag = "icon-rwindow (WEST)";
 	icon_state = "rwindow";
 	dir = 8
 	},
@@ -11449,12 +11425,10 @@
 /area/bigredv2/caves/lambda_lab)
 "aHc" = (
 /obj/structure/window/reinforced/toughened{
-	tag = "icon-fwindow (NORTH)";
 	icon_state = "fwindow";
 	dir = 1
 	},
 /obj/structure/window/reinforced/toughened{
-	tag = "icon-rwindow (EAST)";
 	icon_state = "rwindow";
 	dir = 4
 	},
@@ -11716,12 +11690,10 @@
 /area/bigredv2/caves/lambda_lab)
 "aHU" = (
 /obj/structure/window/reinforced/toughened{
-	tag = "icon-rwindow (WEST)";
 	icon_state = "rwindow";
 	dir = 8
 	},
 /obj/structure/window/reinforced/toughened{
-	tag = "icon-fwindow (NORTH)";
 	icon_state = "fwindow";
 	dir = 1
 	},
@@ -11749,12 +11721,10 @@
 /area/bigredv2/caves/lambda_lab)
 "aHX" = (
 /obj/structure/window/reinforced/toughened{
-	tag = "icon-rwindow (EAST)";
 	icon_state = "rwindow";
 	dir = 4
 	},
 /obj/structure/window/reinforced/toughened{
-	tag = "icon-fwindow (NORTH)";
 	icon_state = "fwindow";
 	dir = 1
 	},
@@ -12051,7 +12021,6 @@
 /area/bigredv2/caves/lambda_lab)
 "aIQ" = (
 /turf/open/floor/bluegrid{
-	tag = "icon-damaged5";
 	icon_state = "damaged5"
 	},
 /area/bigredv2/caves/lambda_lab)
@@ -12060,7 +12029,6 @@
 /obj/effect/alien/weeds/node,
 /obj/structure/mineral_door/resin,
 /turf/open/floor/bluegrid{
-	tag = "icon-damaged4";
 	icon_state = "damaged4"
 	},
 /area/bigredv2/caves/lambda_lab)
@@ -12134,7 +12102,6 @@
 /area/bigredv2/caves/lambda_lab)
 "aJa" = (
 /obj/structure/window/reinforced/toughened{
-	tag = "icon-fwindow (NORTH)";
 	icon_state = "fwindow";
 	dir = 1
 	},
@@ -12163,7 +12130,6 @@
 /area/bigredv2/caves/lambda_lab)
 "aJe" = (
 /obj/structure/window/reinforced/toughened{
-	tag = "icon-fwindow (NORTH)";
 	icon_state = "fwindow";
 	dir = 1
 	},
@@ -12467,7 +12433,6 @@
 	dir = 4
 	},
 /turf/open/floor/bluegrid{
-	tag = "icon-damaged3";
 	icon_state = "damaged3"
 	},
 /area/bigredv2/caves/lambda_lab)
@@ -12945,7 +12910,6 @@
 /area/bigredv2/caves/lambda_lab)
 "aKV" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-SW-in";
 	icon_state = "SW-in"
 	},
 /turf/open/floor/tile/green/whitegreencorner{
@@ -12954,7 +12918,6 @@
 /area/bigredv2/caves/lambda_lab)
 "aKW" = (
 /obj/structure/window/reinforced/toughened{
-	tag = "icon-rwindow (WEST)";
 	icon_state = "rwindow";
 	dir = 8
 	},
@@ -12987,7 +12950,6 @@
 /area/bigredv2/caves/lambda_lab)
 "aKZ" = (
 /obj/structure/window/reinforced/toughened{
-	tag = "icon-rwindow (EAST)";
 	icon_state = "rwindow";
 	dir = 4
 	},
@@ -13217,13 +13179,11 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/bluegrid{
-	tag = "icon-bcircuitoff";
 	icon_state = "bcircuitoff"
 	},
 /area/bigredv2/caves/lambda_lab)
 "aLJ" = (
 /turf/open/floor/bluegrid{
-	tag = "icon-bcircuitoff";
 	icon_state = "bcircuitoff"
 	},
 /area/bigredv2/caves/lambda_lab)
@@ -13238,7 +13198,6 @@
 /area/bigredv2/caves/lambda_lab)
 "aLM" = (
 /obj/machinery/shower{
-	tag = "icon-shower (NORTH)";
 	icon_state = "shower";
 	dir = 1
 	},
@@ -13251,8 +13210,7 @@
 /obj/machinery/door/window{
 	dir = 1;
 	icon_state = "left";
-	opacity = 1;
-	tag = "icon-left (NORTH)"
+	opacity = 1
 	},
 /turf/open/floor/tile/white/warningstripe{
 	dir = 2
@@ -13275,7 +13233,6 @@
 /area/bigredv2/caves/lambda_lab)
 "aLP" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-SW-in";
 	icon_state = "SW-in"
 	},
 /obj/structure/cable{
@@ -13289,12 +13246,10 @@
 /area/bigredv2/caves/lambda_lab)
 "aLQ" = (
 /obj/structure/window/reinforced/toughened{
-	tag = "icon-fwindow";
 	icon_state = "fwindow";
 	dir = 2
 	},
 /obj/structure/window/reinforced/toughened{
-	tag = "icon-rwindow (WEST)";
 	icon_state = "rwindow";
 	dir = 8
 	},
@@ -13305,12 +13260,10 @@
 /area/bigredv2/caves/lambda_lab)
 "aLR" = (
 /obj/structure/window/reinforced/toughened{
-	tag = "icon-fwindow";
 	icon_state = "fwindow";
 	dir = 2
 	},
 /obj/structure/window/reinforced/toughened{
-	tag = "icon-rwindow (EAST)";
 	icon_state = "rwindow";
 	dir = 4
 	},
@@ -13614,7 +13567,6 @@
 /obj/effect/landmark/monkey_spawn,
 /obj/effect/alien/weeds/node,
 /turf/open/floor/bluegrid{
-	tag = "icon-bcircuitoff";
 	icon_state = "bcircuitoff"
 	},
 /area/bigredv2/caves/lambda_lab)
@@ -15662,7 +15614,6 @@
 /area/bigredv2/outside/admin_building)
 "aUa" = (
 /turf/open/floor{
-	tag = "icon-darkredcorners2";
 	icon_state = "darkredcorners2"
 	},
 /area/bigredv2/outside/admin_building)
@@ -16483,7 +16434,6 @@
 /area/bigredv2/outside/admin_building)
 "aWE" = (
 /turf/open/floor{
-	tag = "icon-darkbluecorners2";
 	icon_state = "darkbluecorners2";
 	dir = 2
 	},
@@ -17496,7 +17446,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor{
-	tag = "icon-darkredcorners2";
 	icon_state = "darkredcorners2"
 	},
 /area/bigredv2/outside/admin_building)
@@ -18458,7 +18407,6 @@
 /area/bigredv2/outside/office_complex)
 "bdy" = (
 /obj/structure/bed/chair/comfy/lime{
-	tag = "icon-comfychair (EAST)";
 	icon_state = "comfychair";
 	dir = 4
 	},
@@ -19279,8 +19227,7 @@
 /obj/structure/table,
 /obj/structure/flora/pottedplant{
 	icon_state = "plant-15";
-	pixel_y = 10;
-	tag = "icon-plant-15"
+	pixel_y = 10
 	},
 /turf/open/floor/grimy,
 /area/bigredv2/outside/office_complex)
@@ -20379,7 +20326,6 @@
 /area/bigredv2/outside/cargo)
 "bjQ" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-W-corner";
 	icon_state = "W-corner"
 	},
 /turf/open/floor,
@@ -20590,14 +20536,12 @@
 	name = "\improper coolant feed"
 	},
 /turf/open/floor/bluegrid{
-	tag = "icon-bcircuitoff";
 	icon_state = "bcircuitoff"
 	},
 /area/bigredv2/outside/filtration_plant)
 "bkJ" = (
 /obj/structure/cryofeed,
 /turf/open/floor/bluegrid{
-	tag = "icon-bcircuitoff";
 	icon_state = "bcircuitoff"
 	},
 /area/bigredv2/outside/filtration_plant)
@@ -21181,7 +21125,6 @@
 	dir = 4
 	},
 /turf/open/floor/bluegrid{
-	tag = "icon-bcircuitoff";
 	icon_state = "bcircuitoff"
 	},
 /area/bigredv2/outside/filtration_plant)
@@ -22284,7 +22227,6 @@
 /area/bigredv2/outside/filtration_plant)
 "bqw" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-E-corner";
 	icon_state = "E-corner"
 	},
 /obj/structure/cable{
@@ -25064,7 +25006,6 @@
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "bBP" = (
 /turf/open/floor{
-	tag = "icon-darkredcorners2";
 	icon_state = "darkredcorners2"
 	},
 /area/bigredv2/outside/nanotrasen_lab/inside)
@@ -25180,7 +25121,6 @@
 /obj/structure/table,
 /obj/item/paper,
 /turf/open/floor{
-	tag = "icon-darkredcorners2";
 	icon_state = "darkredcorners2"
 	},
 /area/bigredv2/outside/nanotrasen_lab/inside)
@@ -25366,7 +25306,6 @@
 "bCN" = (
 /obj/structure/closet/crate/secure,
 /turf/open/floor{
-	tag = "icon-darkredcorners2";
 	icon_state = "darkredcorners2"
 	},
 /area/bigredv2/outside/nanotrasen_lab/inside)
@@ -25424,7 +25363,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	tag = "icon-darkredcorners2";
 	icon_state = "darkredcorners2"
 	},
 /area/bigredv2/outside/nanotrasen_lab/inside)
@@ -25451,7 +25389,6 @@
 "bDc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor{
-	tag = "icon-darkredcorners2";
 	icon_state = "darkredcorners2"
 	},
 /area/bigredv2/outside/nanotrasen_lab/inside)
@@ -25672,7 +25609,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/alien/weeds/node,
 /turf/open/floor{
-	tag = "icon-darkredcorners2";
 	icon_state = "darkredcorners2"
 	},
 /area/bigredv2/outside/nanotrasen_lab/inside)
@@ -25755,14 +25691,12 @@
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "bEl" = (
 /obj/structure/showcase{
-	tag = "icon-mechfab1";
 	icon_state = "mechfab1"
 	},
 /turf/open/floor/carpet/edge2,
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "bEm" = (
 /obj/structure/showcase{
-	tag = "icon-bus";
 	icon_state = "bus"
 	},
 /turf/open/floor/carpet/edge2,

--- a/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -2539,7 +2539,6 @@
 /area/ice_colony/surface/substation/smes)
 "ahy" = (
 /obj/machinery/power/terminal{
-	tag = "icon-term (EAST)";
 	icon_state = "term";
 	dir = 4
 	},
@@ -2592,7 +2591,6 @@
 /area/ice_colony/surface/substation/smes)
 "ahD" = (
 /obj/machinery/power/terminal{
-	tag = "icon-term (NORTH)";
 	icon_state = "term";
 	dir = 1
 	},
@@ -3026,7 +3024,6 @@
 /area/ice_colony/surface/substation/smes)
 "aiK" = (
 /obj/machinery/power/terminal{
-	tag = "icon-term (NORTH)";
 	icon_state = "term";
 	dir = 1
 	},
@@ -3132,7 +3129,6 @@
 /area/ice_colony/surface/engineering)
 "aiW" = (
 /obj/machinery/power/terminal{
-	tag = "icon-term (WEST)";
 	icon_state = "term";
 	dir = 8
 	},
@@ -3193,7 +3189,6 @@
 /area/ice_colony/surface/substation/smes)
 "ajd" = (
 /obj/machinery/power/terminal{
-	tag = "icon-term (EAST)";
 	icon_state = "term";
 	dir = 4
 	},
@@ -3241,7 +3236,6 @@
 /area/ice_colony/exterior/surface/valley/northwest)
 "aji" = (
 /obj/machinery/conveyor{
-	tag = "icon-conveyor-1 (EAST)";
 	icon_state = "conveyor-1";
 	dir = 4
 	},
@@ -3285,7 +3279,6 @@
 /area/ice_colony/surface/hydroponics/north)
 "ajo" = (
 /obj/machinery/conveyor{
-	tag = "icon-conveyor-1 (EAST)";
 	icon_state = "conveyor-1";
 	dir = 4
 	},
@@ -3355,7 +3348,6 @@
 /area/ice_colony/surface/engineering)
 "ajw" = (
 /obj/machinery/power/terminal{
-	tag = "icon-term (WEST)";
 	icon_state = "term";
 	dir = 8
 	},
@@ -5111,7 +5103,6 @@
 /area/ice_colony/surface/clinic/treatment)
 "aoc" = (
 /obj/machinery/power/terminal{
-	tag = "icon-term (EAST)";
 	icon_state = "term";
 	dir = 4
 	},
@@ -5626,7 +5617,6 @@
 /area/ice_colony/surface/hydroponics/north)
 "apj" = (
 /obj/effect/decal/cleanable/blood/oil{
-	tag = "icon-armorblood";
 	icon_state = "armorblood"
 	},
 /turf/open/floor/plating/icefloor,
@@ -9082,7 +9072,6 @@
 /area/ice_colony/surface/disposals)
 "axF" = (
 /obj/structure/disposaloutlet{
-	tag = "icon-outlet (EAST)";
 	icon_state = "outlet";
 	dir = 4
 	},
@@ -10666,7 +10655,6 @@
 /area/ice_colony/surface/garage/one)
 "aBQ" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N-corner";
 	icon_state = "N-corner"
 	},
 /turf/open/floor/tile/dark/brown2{
@@ -10675,7 +10663,6 @@
 /area/ice_colony/surface/garage/one)
 "aBR" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N-corner";
 	icon_state = "N-corner"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -10685,7 +10672,6 @@
 /area/ice_colony/surface/garage/one)
 "aBS" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N-corner";
 	icon_state = "N-corner"
 	},
 /obj/structure/cable{
@@ -10714,7 +10700,6 @@
 /area/ice_colony/surface/garage/one)
 "aBV" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N-corner";
 	icon_state = "N-corner"
 	},
 /turf/open/floor/tile/dark/brown2{
@@ -10734,7 +10719,6 @@
 /area/ice_colony/surface/garage/two)
 "aBY" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N-corner";
 	icon_state = "N-corner"
 	},
 /obj/structure/disposalpipe/segment,
@@ -11073,7 +11057,6 @@
 /area/ice_colony/surface/garage/two)
 "aCT" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N-corner";
 	icon_state = "N-corner"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -11083,7 +11066,6 @@
 /area/ice_colony/surface/garage/two)
 "aCU" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N-corner";
 	icon_state = "N-corner"
 	},
 /obj/structure/cable{
@@ -14205,7 +14187,6 @@
 /area/ice_colony/surface/garage/one)
 "aKW" = (
 /turf/open/floor{
-	tag = "icon-darkredcorners2";
 	icon_state = "darkredcorners2"
 	},
 /area/ice_colony/underground/responsehangar)
@@ -15998,7 +15979,6 @@
 "aPI" = (
 /obj/effect/turf_underlay/tiles/dark2,
 /turf/closed/shuttle{
-	tag = "icon-swall_f6";
 	icon_state = "swall_f6"
 	},
 /area/ice_colony/surface/hangar/alpha)
@@ -16014,7 +15994,6 @@
 "aPK" = (
 /obj/effect/turf_underlay/tiles/dark2,
 /turf/closed/shuttle{
-	tag = "icon-swall_f10";
 	icon_state = "swall_f10"
 	},
 /area/ice_colony/surface/hangar/alpha)
@@ -16087,7 +16066,6 @@
 "aPW" = (
 /obj/effect/turf_underlay/tiles/dark2,
 /turf/closed/shuttle{
-	tag = "icon-swall_f10";
 	icon_state = "swall_f10"
 	},
 /area/ice_colony/surface/hangar/beta)
@@ -16343,7 +16321,6 @@
 "aQD" = (
 /obj/effect/turf_underlay/shuttle/floor6,
 /turf/closed/shuttle{
-	tag = "icon-swall_f5";
 	icon_state = "swall_f5"
 	},
 /area/ice_colony/surface/hangar/alpha)
@@ -16441,7 +16418,6 @@
 "aQM" = (
 /obj/effect/turf_underlay/shuttle/floor6,
 /turf/closed/shuttle{
-	tag = "icon-swall_f5";
 	icon_state = "swall_f5"
 	},
 /area/ice_colony/surface/hangar/beta)
@@ -16745,14 +16721,12 @@
 /area/ice_colony/surface/bar/bar)
 "aRy" = (
 /turf/closed/shuttle{
-	tag = "icon-swall3";
 	icon_state = "swall3"
 	},
 /area/ice_colony/surface/hangar/alpha)
 "aRz" = (
 /obj/machinery/light,
 /turf/open/shuttle{
-	tag = "icon-floor6";
 	icon_state = "floor6"
 	},
 /area/ice_colony/surface/hangar/alpha)
@@ -16782,13 +16756,11 @@
 "aRD" = (
 /obj/effect/turf_underlay/tiles/dark2,
 /turf/closed/shuttle{
-	tag = "icon-swall_f6";
 	icon_state = "swall_f6"
 	},
 /area/ice_colony/surface/hangar/beta)
 "aRE" = (
 /turf/closed/shuttle{
-	tag = "icon-swall3";
 	icon_state = "swall3"
 	},
 /area/ice_colony/surface/hangar/beta)
@@ -16813,7 +16785,6 @@
 /obj/machinery/light,
 /obj/item/weapon/gun/pistol/holdout,
 /turf/open/shuttle{
-	tag = "icon-floor6";
 	icon_state = "floor6"
 	},
 /area/ice_colony/surface/hangar/beta)
@@ -16837,7 +16808,6 @@
 /area/ice_colony/surface/research/field_gear)
 "aRK" = (
 /obj/machinery/door/airlock/almayer/engineering{
-	tag = "icon-door_closed (WEST)";
 	name = "\improper Omicron Field Gear Storage";
 	icon_state = "door_closed";
 	dir = 8;
@@ -17020,7 +16990,6 @@
 /area/ice_colony/exterior/surface/clearing/pass)
 "aSa" = (
 /obj/structure/device/piano{
-	tag = "icon-pianobroken";
 	icon_state = "pianobroken"
 	},
 /turf/open/floor/wood,
@@ -17056,7 +17025,6 @@
 /area/ice_colony/surface/hangar/alpha)
 "aSg" = (
 /turf/closed/shuttle{
-	tag = "icon-swall7";
 	icon_state = "swall7"
 	},
 /area/ice_colony/surface/hangar/alpha)
@@ -17072,19 +17040,16 @@
 "aSi" = (
 /obj/machinery/door/airlock/unpowered/shuttle,
 /turf/open/shuttle{
-	tag = "icon-floor6";
 	icon_state = "floor6"
 	},
 /area/ice_colony/surface/hangar/alpha)
 "aSj" = (
 /turf/closed/shuttle{
-	tag = "icon-swall4";
 	icon_state = "swall4"
 	},
 /area/ice_colony/surface/hangar/alpha)
 "aSk" = (
 /turf/closed/shuttle{
-	tag = "icon-swall11";
 	icon_state = "swall11"
 	},
 /area/ice_colony/surface/hangar/alpha)
@@ -17108,33 +17073,28 @@
 /area/ice_colony/surface/hangar/beta)
 "aSp" = (
 /turf/closed/shuttle{
-	tag = "icon-swall7";
 	icon_state = "swall7"
 	},
 /area/ice_colony/surface/hangar/beta)
 "aSq" = (
 /obj/effect/turf_underlay/shuttle/floor6,
 /turf/closed/shuttle{
-	tag = "icon-swall_f9";
 	icon_state = "swall_f9"
 	},
 /area/ice_colony/surface/hangar/alpha)
 "aSr" = (
 /obj/machinery/door/airlock/unpowered/shuttle,
 /turf/open/shuttle{
-	tag = "icon-floor6";
 	icon_state = "floor6"
 	},
 /area/ice_colony/surface/hangar/beta)
 "aSs" = (
 /turf/closed/shuttle{
-	tag = "icon-swall4";
 	icon_state = "swall4"
 	},
 /area/ice_colony/surface/hangar/beta)
 "aSt" = (
 /turf/closed/shuttle{
-	tag = "icon-swall11";
 	icon_state = "swall11"
 	},
 /area/ice_colony/surface/hangar/beta)
@@ -17148,7 +17108,6 @@
 "aSv" = (
 /obj/structure/computerframe,
 /turf/open/shuttle{
-	tag = "icon-floor6";
 	icon_state = "floor6"
 	},
 /area/ice_colony/surface/hangar/alpha)
@@ -17180,14 +17139,12 @@
 "aSy" = (
 /obj/effect/turf_underlay/shuttle/floor6,
 /turf/closed/shuttle{
-	tag = "icon-swall_f9";
 	icon_state = "swall_f9"
 	},
 /area/ice_colony/surface/hangar/beta)
 "aSz" = (
 /obj/structure/computerframe,
 /turf/open/shuttle{
-	tag = "icon-floor6";
 	icon_state = "floor6"
 	},
 /area/ice_colony/surface/hangar/beta)
@@ -17355,7 +17312,6 @@
 /area/ice_colony/exterior/surface/clearing/south)
 "aSV" = (
 /turf/open/shuttle{
-	tag = "icon-floor6";
 	icon_state = "floor6"
 	},
 /area/ice_colony/surface/hangar/alpha)
@@ -17387,7 +17343,6 @@
 /area/ice_colony/exterior/surface/clearing/south)
 "aSZ" = (
 /turf/open/shuttle{
-	tag = "icon-floor6";
 	icon_state = "floor6"
 	},
 /area/ice_colony/surface/hangar/beta)
@@ -17464,7 +17419,6 @@
 /area/ice_colony/surface/research)
 "aTn" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-N-corner";
 	icon_state = "N-corner"
 	},
 /turf/open/floor/tile/dark/purple2{
@@ -17493,7 +17447,6 @@
 	dir = 1
 	},
 /turf/open/shuttle{
-	tag = "icon-floor6";
 	icon_state = "floor6"
 	},
 /area/ice_colony/surface/hangar/alpha)
@@ -17525,7 +17478,6 @@
 "aTv" = (
 /obj/machinery/light,
 /turf/open/shuttle{
-	tag = "icon-floor6";
 	icon_state = "floor6"
 	},
 /area/ice_colony/surface/hangar/beta)
@@ -17535,7 +17487,6 @@
 	},
 /obj/effect/landmark/start/surv_spawn,
 /turf/open/shuttle{
-	tag = "icon-floor6";
 	icon_state = "floor6"
 	},
 /area/ice_colony/surface/hangar/beta)
@@ -17554,7 +17505,6 @@
 /area/ice_colony/surface/research)
 "aTy" = (
 /turf/closed/shuttle{
-	tag = "icon-swall0";
 	icon_state = "swall0"
 	},
 /area/ice_colony/surface/hangar/alpha)
@@ -17785,14 +17735,12 @@
 "aTW" = (
 /obj/effect/turf_overlay/shuttle/heater,
 /turf/closed/shuttle{
-	tag = "icon-swall0";
 	icon_state = "swall0"
 	},
 /area/ice_colony/surface/hangar/alpha)
 "aTX" = (
 /obj/effect/turf_overlay/shuttle/heater,
 /turf/closed/shuttle{
-	tag = "icon-swall0";
 	icon_state = "swall0"
 	},
 /area/ice_colony/surface/hangar/beta)
@@ -17801,13 +17749,11 @@
 /area/ice_colony/exterior/surface/cliff)
 "aTZ" = (
 /turf/closed/shuttle{
-	tag = "icon-swall8";
 	icon_state = "swall8"
 	},
 /area/ice_colony/surface/hangar/alpha)
 "aUa" = (
 /turf/closed/shuttle{
-	tag = "icon-swall8";
 	icon_state = "swall8"
 	},
 /area/ice_colony/surface/hangar/beta)
@@ -17854,7 +17800,6 @@
 /area/ice_colony/surface/research/temporary)
 "aUh" = (
 /turf/closed/shuttle{
-	tag = "icon-swall1";
 	icon_state = "swall1"
 	},
 /area/ice_colony/surface/hangar/alpha)
@@ -17864,7 +17809,6 @@
 	dir = 1
 	},
 /turf/closed/shuttle{
-	tag = "icon-burst_l";
 	icon_state = "burst_l"
 	},
 /area/ice_colony/surface/hangar/alpha)
@@ -17874,7 +17818,6 @@
 	dir = 1
 	},
 /turf/closed/shuttle{
-	tag = "icon-burst_r";
 	icon_state = "burst_r"
 	},
 /area/ice_colony/surface/hangar/alpha)
@@ -17905,7 +17848,6 @@
 /area/ice_colony/exterior/surface/valley/southeast)
 "aUn" = (
 /turf/closed/shuttle{
-	tag = "icon-swall1";
 	icon_state = "swall1"
 	},
 /area/ice_colony/surface/hangar/beta)
@@ -17927,7 +17869,6 @@
 	dir = 1
 	},
 /turf/closed/shuttle{
-	tag = "icon-burst_r";
 	icon_state = "burst_r"
 	},
 /area/ice_colony/surface/hangar/beta)
@@ -18207,7 +18148,6 @@
 /area/ice_colony/surface/bar/bar)
 "aVd" = (
 /turf/closed/shuttle{
-	tag = "icon-swall0";
 	icon_state = "swall0"
 	},
 /area/ice_colony/surface/hangar/beta)
@@ -18388,7 +18328,6 @@
 /area/ice_colony/exterior/surface/container_yard)
 "aVy" = (
 /turf/closed/shuttle{
-	tag = "icon-swall2";
 	icon_state = "swall2"
 	},
 /area/ice_colony/surface/hangar/alpha)
@@ -18424,7 +18363,6 @@
 /area/ice_colony/surface/research/temporary)
 "aVD" = (
 /turf/closed/shuttle{
-	tag = "icon-swall2";
 	icon_state = "swall2"
 	},
 /area/ice_colony/surface/hangar/beta)
@@ -18542,7 +18480,6 @@
 	dir = 1
 	},
 /turf/closed/shuttle{
-	tag = "icon-burst_l";
 	icon_state = "burst_l"
 	},
 /area/ice_colony/surface/hangar/beta)
@@ -18616,7 +18553,6 @@
 "aWb" = (
 /obj/effect/turf_underlay/tiles/dark2,
 /turf/closed/shuttle{
-	tag = "icon-swall_f5";
 	icon_state = "swall_f5"
 	},
 /area/ice_colony/surface/hangar/alpha)
@@ -18631,14 +18567,12 @@
 "aWd" = (
 /obj/effect/turf_underlay/shuttle/floor6,
 /turf/closed/shuttle{
-	tag = "icon-swall_f6";
 	icon_state = "swall_f6"
 	},
 /area/ice_colony/surface/hangar/alpha)
 "aWe" = (
 /obj/effect/turf_underlay/tiles/dark2,
 /turf/closed/shuttle{
-	tag = "icon-swall_f9";
 	icon_state = "swall_f9"
 	},
 /area/ice_colony/surface/hangar/alpha)
@@ -18698,14 +18632,12 @@
 "aWm" = (
 /obj/effect/turf_underlay/shuttle/floor6,
 /turf/closed/shuttle{
-	tag = "icon-swall_f6";
 	icon_state = "swall_f6"
 	},
 /area/ice_colony/surface/hangar/beta)
 "aWn" = (
 /obj/effect/turf_underlay/tiles/dark2,
 /turf/closed/shuttle{
-	tag = "icon-swall_f9";
 	icon_state = "swall_f9"
 	},
 /area/ice_colony/surface/hangar/beta)
@@ -18849,7 +18781,6 @@
 	pixel_y = -4
 	},
 /turf/open/shuttle{
-	tag = "icon-floor6";
 	icon_state = "floor6"
 	},
 /area/ice_colony/surface/hangar/beta)
@@ -19091,7 +19022,6 @@
 "aXn" = (
 /obj/effect/turf_underlay/tiles/dark2,
 /turf/closed/shuttle{
-	tag = "icon-wall (NORTHEAST)";
 	icon_state = "wall";
 	dir = 5
 	},
@@ -19166,7 +19096,6 @@
 "aXv" = (
 /obj/effect/turf_underlay/tiles/dark2,
 /turf/closed/shuttle{
-	tag = "icon-wall (NORTHEAST)";
 	icon_state = "wall";
 	dir = 5
 	},
@@ -19284,7 +19213,6 @@
 "aXL" = (
 /obj/effect/turf_underlay/shuttle/floor6,
 /turf/closed/shuttle{
-	tag = "icon-swall_f10";
 	icon_state = "swall_f10"
 	},
 /area/ice_colony/surface/hangar/alpha)
@@ -19315,14 +19243,12 @@
 "aXP" = (
 /obj/effect/turf_underlay/tiles/dark2,
 /turf/closed/shuttle{
-	tag = "icon-swall_f5";
 	icon_state = "swall_f5"
 	},
 /area/ice_colony/surface/hangar/beta)
 "aXQ" = (
 /obj/effect/turf_underlay/shuttle/floor6,
 /turf/closed/shuttle{
-	tag = "icon-swall_f10";
 	icon_state = "swall_f10"
 	},
 /area/ice_colony/surface/hangar/beta)
@@ -19438,7 +19364,6 @@
 /area/ice_colony/surface/hangar/alpha)
 "aYg" = (
 /turf/closed/shuttle{
-	tag = "icon-swall14";
 	icon_state = "swall14"
 	},
 /area/ice_colony/surface/hangar/alpha)
@@ -19465,7 +19390,6 @@
 /area/ice_colony/surface/hangar/beta)
 "aYk" = (
 /turf/closed/shuttle{
-	tag = "icon-swall14";
 	icon_state = "swall14"
 	},
 /area/ice_colony/surface/hangar/beta)
@@ -19694,7 +19618,6 @@
 "aZc" = (
 /obj/effect/turf_underlay/tiles/dark2,
 /turf/closed/shuttle{
-	tag = "icon-wall (NORTHWEST)";
 	icon_state = "wall";
 	dir = 9
 	},
@@ -19732,7 +19655,6 @@
 /area/ice_colony/exterior/surface/landing_pad)
 "aZg" = (
 /turf/closed/shuttle{
-	tag = "icon-swall13";
 	icon_state = "swall13"
 	},
 /area/ice_colony/surface/hangar/alpha)
@@ -19791,14 +19713,12 @@
 "aZp" = (
 /obj/effect/turf_underlay/tiles/dark2,
 /turf/closed/shuttle{
-	tag = "icon-wall (NORTHWEST)";
 	icon_state = "wall";
 	dir = 9
 	},
 /area/ice_colony/surface/hangar/beta)
 "aZq" = (
 /turf/closed/shuttle{
-	tag = "icon-swall13";
 	icon_state = "swall13"
 	},
 /area/ice_colony/surface/hangar/beta)
@@ -19958,7 +19878,6 @@
 "aZO" = (
 /obj/effect/turf_underlay/tiles/dark2,
 /turf/closed/shuttle{
-	tag = "icon-wall (SOUTHEAST)";
 	icon_state = "wall";
 	dir = 6
 	},
@@ -19966,7 +19885,6 @@
 "aZP" = (
 /obj/effect/turf_underlay/tiles/dark2,
 /turf/closed/shuttle{
-	tag = "icon-wall (SOUTHWEST)";
 	icon_state = "wall";
 	dir = 10
 	},
@@ -20146,7 +20064,6 @@
 "bap" = (
 /obj/effect/turf_underlay/tiles/dark2,
 /turf/closed/shuttle{
-	tag = "icon-wall (SOUTHEAST)";
 	icon_state = "wall";
 	dir = 6
 	},
@@ -20154,7 +20071,6 @@
 "baq" = (
 /obj/effect/turf_underlay/tiles/dark2,
 /turf/closed/shuttle{
-	tag = "icon-wall (SOUTHWEST)";
 	icon_state = "wall";
 	dir = 10
 	},
@@ -22425,7 +22341,6 @@
 "bgA" = (
 /obj/machinery/conveyor_switch,
 /obj/effect/decal/warning_stripes{
-	tag = "icon-E-corner";
 	icon_state = "E-corner"
 	},
 /turf/open/floor/tile/dark2,
@@ -22448,14 +22363,12 @@
 /area/ice_colony/underground/requesition)
 "bgE" = (
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
 	},
 /area/ice_colony/underground/responsehangar)
 "bgF" = (
 /obj/machinery/computer3,
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
 	},
 /area/ice_colony/underground/responsehangar)
@@ -22496,7 +22409,6 @@
 /area/ice_colony/surface/excavation)
 "bgM" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-E-corner";
 	icon_state = "E-corner"
 	},
 /turf/open/floor/tile/dark2,
@@ -23093,15 +23005,13 @@
 /area/ice_colony/underground/requesition/lobby)
 "biq" = (
 /obj/structure/table/woodentable{
-	tag = "icon-reinf_table";
 	icon_state = "reinf_table"
 	},
 /obj/machinery/door/window/brigdoor/westleft{
 	dir = 1;
 	icon_state = "leftsecure";
 	id = null;
-	name = "Requesitions Desk";
-	tag = "icon-leftsecure (NORTH)"
+	name = "Requesitions Desk"
 	},
 /obj/machinery/door/window/northright{
 	dir = 2;
@@ -23161,7 +23071,6 @@
 /area/ice_colony/underground/hangar)
 "biw" = (
 /obj/machinery/power/terminal{
-	tag = "icon-term (WEST)";
 	icon_state = "term";
 	dir = 8
 	},
@@ -23320,13 +23229,11 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/multitool,
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
 	},
 /area/ice_colony/underground/responsehangar)
 "biP" = (
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin6";
 	icon_state = "rasputin6"
 	},
 /area/ice_colony/underground/responsehangar)
@@ -23344,7 +23251,6 @@
 /area/ice_colony/underground/requesition/lobby)
 "biS" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-E-corner";
 	icon_state = "E-corner"
 	},
 /turf/open/floor/tile/dark/brown2{
@@ -23377,7 +23283,6 @@
 /area/ice_colony/underground/hangar)
 "biW" = (
 /obj/machinery/power/terminal{
-	tag = "icon-term (WEST)";
 	icon_state = "term";
 	dir = 8
 	},
@@ -23421,8 +23326,7 @@
 "bjb" = (
 /obj/effect/landmark/start/surv_spawn,
 /turf/open/shuttle/dropship{
-	icon_state = "floor8";
-	tag = "icon-rasputin7"
+	icon_state = "floor8"
 	},
 /area/ice_colony/underground/responsehangar)
 "bjc" = (
@@ -23507,7 +23411,6 @@
 /area/ice_colony/underground/requesition/sec_storage)
 "bjp" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-E-corner";
 	icon_state = "E-corner"
 	},
 /obj/structure/cable/yellow{
@@ -23593,7 +23496,6 @@
 /area/ice_colony/underground/hangar)
 "bjx" = (
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin7";
 	icon_state = "rasputin7"
 	},
 /area/ice_colony/underground/responsehangar)
@@ -23736,7 +23638,6 @@
 "bjT" = (
 /obj/structure/rack,
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
 	},
 /area/ice_colony/underground/responsehangar)
@@ -24103,7 +24004,6 @@
 "blf" = (
 /obj/machinery/door/airlock/almayer/generic,
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin3";
 	icon_state = "rasputin3"
 	},
 /area/ice_colony/underground/responsehangar)
@@ -24168,7 +24068,6 @@
 /area/ice_colony/underground/hallway/north_west)
 "bll" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-21"
 	},
 /turf/open/floor/tile/darkgreen/darkgreen2{
@@ -24237,7 +24136,6 @@
 "blx" = (
 /obj/structure/bed/chair/dropship/passenger,
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
 	},
 /area/ice_colony/underground/responsehangar)
@@ -24470,7 +24368,6 @@
 	dir = 4
 	},
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
 	},
 /area/ice_colony/underground/responsehangar)
@@ -24563,7 +24460,6 @@
 /area/ice_colony/underground/crew/library)
 "bmq" = (
 /obj/structure/table/woodentable{
-	tag = "icon-reinf_table";
 	icon_state = "reinf_table"
 	},
 /obj/item/frame/light_fixture,
@@ -24683,7 +24579,6 @@
 	dir = 4
 	},
 /turf/open/shuttle{
-	tag = "icon-floor6";
 	icon_state = "floor6"
 	},
 /area/ice_colony/surface/hangar/alpha)
@@ -24695,7 +24590,6 @@
 	dir = 8
 	},
 /turf/open/shuttle{
-	tag = "icon-floor6";
 	icon_state = "floor6"
 	},
 /area/ice_colony/surface/hangar/alpha)
@@ -24712,7 +24606,6 @@
 	dir = 8
 	},
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
 	},
 /area/ice_colony/underground/responsehangar)
@@ -24908,7 +24801,6 @@
 	dir = 4
 	},
 /turf/open/shuttle{
-	tag = "icon-floor6";
 	icon_state = "floor6"
 	},
 /area/ice_colony/surface/hangar/beta)
@@ -24955,7 +24847,6 @@
 	dir = 8
 	},
 /turf/open/shuttle{
-	tag = "icon-floor6";
 	icon_state = "floor6"
 	},
 /area/ice_colony/surface/hangar/beta)
@@ -24964,7 +24855,6 @@
 	dir = 4
 	},
 /turf/open/shuttle{
-	tag = "icon-floor6";
 	icon_state = "floor6"
 	},
 /area/ice_colony/surface/hangar/alpha)
@@ -24993,7 +24883,6 @@
 	dir = 8
 	},
 /turf/open/shuttle{
-	tag = "icon-floor6";
 	icon_state = "floor6"
 	},
 /area/ice_colony/surface/hangar/alpha)
@@ -25002,7 +24891,6 @@
 	dir = 4
 	},
 /turf/open/shuttle{
-	tag = "icon-floor6";
 	icon_state = "floor6"
 	},
 /area/ice_colony/surface/hangar/beta)
@@ -25011,7 +24899,6 @@
 	dir = 8
 	},
 /turf/open/shuttle{
-	tag = "icon-floor6";
 	icon_state = "floor6"
 	},
 /area/ice_colony/surface/hangar/beta)
@@ -25093,7 +24980,6 @@
 /area/ice_colony/underground/hallway/north_west)
 "bnO" = (
 /obj/structure/table/woodentable{
-	tag = "icon-reinf_table";
 	icon_state = "reinf_table"
 	},
 /obj/item/storage/box/lightstick,
@@ -25103,7 +24989,6 @@
 /area/ice_colony/underground/engineering)
 "bnP" = (
 /obj/structure/table/woodentable{
-	tag = "icon-reinf_table";
 	icon_state = "reinf_table"
 	},
 /obj/item/inflatable,
@@ -25115,7 +25000,6 @@
 /area/ice_colony/underground/engineering)
 "bnQ" = (
 /obj/structure/table/woodentable{
-	tag = "icon-reinf_table";
 	icon_state = "reinf_table"
 	},
 /obj/item/stack/cable_coil/blue,
@@ -25879,7 +25763,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/warning_stripes{
-	tag = "icon-E-corner";
 	icon_state = "E-corner"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -25897,7 +25780,6 @@
 "bpY" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor/westleft{
-	tag = "icon-leftsecure (EAST)";
 	icon_state = "leftsecure";
 	dir = 4;
 	id = "brg"
@@ -26090,7 +25972,6 @@
 "bqv" = (
 /obj/effect/landmark/monkey_spawn,
 /turf/open/shuttle{
-	tag = "icon-floor6";
 	icon_state = "floor6"
 	},
 /area/ice_colony/surface/hangar/alpha)
@@ -26308,7 +26189,6 @@
 /area/ice_colony/underground/engineering)
 "brd" = (
 /obj/structure/table/woodentable{
-	tag = "icon-reinf_table";
 	icon_state = "reinf_table"
 	},
 /obj/item/storage/box/lights,
@@ -26933,8 +26813,7 @@
 	dir = 2;
 	icon_state = "leftsecure";
 	id = "brg";
-	name = "Security Desk";
-	tag = "icon-leftsecure (NORTH)"
+	name = "Security Desk"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/machinery/door/window/northright{
@@ -27162,8 +27041,7 @@
 	dir = 1
 	},
 /obj/effect/decal/warning_stripes{
-	icon_state = "E-corner";
-	tag = "icon-E-corner"
+	icon_state = "E-corner"
 	},
 /obj/structure/window/reinforced{
 	dir = 1
@@ -27172,7 +27050,6 @@
 /area/ice_colony/underground/crew/bball)
 "bty" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-E-corner";
 	icon_state = "E-corner"
 	},
 /obj/effect/decal/warning_stripes/thin{
@@ -27417,7 +27294,6 @@
 /area/ice_colony/underground/crew/bball)
 "bue" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-E-corner";
 	icon_state = "E-corner"
 	},
 /obj/machinery/door/window/eastleft{
@@ -27592,8 +27468,7 @@
 /area/ice_colony/underground/crew/bball)
 "buB" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "NS-center";
-	tag = "icon-W"
+	icon_state = "NS-center"
 	},
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -27715,8 +27590,7 @@
 /area/ice_colony/underground/crew/bball)
 "buS" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "NS-center";
-	tag = "icon-W"
+	icon_state = "NS-center"
 	},
 /obj/effect/decal/warning_stripes,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -27726,14 +27600,12 @@
 /area/ice_colony/underground/crew/bball)
 "buT" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-E-corner";
 	icon_state = "E-corner"
 	},
 /obj/effect/decal/warning_stripes,
 /obj/structure/holohoop{
 	dir = 8;
-	icon_state = "hoop";
-	tag = "icon-hoop (NORTH)"
+	icon_state = "hoop"
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -27881,8 +27753,7 @@
 /area/ice_colony/underground/crew/bball)
 "bvo" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "E-corner";
-	tag = "icon-E-corner"
+	icon_state = "E-corner"
 	},
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -27891,8 +27762,7 @@
 /area/ice_colony/underground/crew/bball)
 "bvp" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "NS-center";
-	tag = "icon-W"
+	icon_state = "NS-center"
 	},
 /turf/open/floor/wood,
 /area/ice_colony/underground/crew/bball)
@@ -28010,7 +27880,6 @@
 /area/ice_colony/underground/crew/bball)
 "bvC" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-E-corner";
 	icon_state = "E-corner"
 	},
 /obj/machinery/door/window/eastright{
@@ -28122,8 +27991,7 @@
 /obj/effect/decal/warning_stripes,
 /obj/structure/holohoop{
 	dir = 4;
-	icon_state = "hoop";
-	tag = "icon-hoop (NORTH)"
+	icon_state = "hoop"
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -28132,16 +28000,14 @@
 /area/ice_colony/underground/crew/bball)
 "bvR" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "NS-center";
-	tag = "icon-W"
+	icon_state = "NS-center"
 	},
 /obj/effect/decal/warning_stripes,
 /turf/open/floor/wood,
 /area/ice_colony/underground/crew/bball)
 "bvS" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "NS-center";
-	tag = "icon-W"
+	icon_state = "NS-center"
 	},
 /obj/effect/decal/warning_stripes,
 /obj/item/toy/beach_ball/holoball,
@@ -28214,15 +28080,13 @@
 	dir = 1
 	},
 /obj/effect/decal/warning_stripes{
-	icon_state = "E-corner";
-	tag = "icon-E-corner"
+	icon_state = "E-corner"
 	},
 /obj/structure/window/reinforced,
 /turf/open/floor/wood,
 /area/ice_colony/underground/crew/bball)
 "bwc" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-E-corner";
 	icon_state = "E-corner"
 	},
 /obj/effect/decal/warning_stripes/thin{
@@ -28399,8 +28263,7 @@
 /area/ice_colony/underground/crew/bball)
 "bwA" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "E-corner";
-	tag = "icon-E-corner"
+	icon_state = "E-corner"
 	},
 /turf/open/floor/wood,
 /area/ice_colony/underground/crew/bball)
@@ -28586,8 +28449,7 @@
 /area/ice_colony/underground/crew/bball)
 "bwW" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "NS-center";
-	tag = "icon-W"
+	icon_state = "NS-center"
 	},
 /obj/effect/decal/warning_stripes/thin{
 	dir = 2
@@ -30738,7 +30600,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor{
-	tag = "icon-darkredcorners2";
 	icon_state = "darkredcorners2"
 	},
 /area/ice_colony/underground/security/hallway)
@@ -32244,7 +32105,6 @@
 "bGg" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor/westleft{
-	tag = "icon-leftsecure (EAST)";
 	icon_state = "leftsecure";
 	dir = 4;
 	id = "brg"
@@ -32423,7 +32283,6 @@
 /obj/structure/rack,
 /obj/item/storage/firstaid/regular,
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
 	},
 /area/ice_colony/underground/responsehangar)
@@ -33062,8 +32921,7 @@
 /area/ice_colony/underground/medical/treatment)
 "bId" = (
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin4";
-	tag = "icon-rasputin7"
+	icon_state = "rasputin4"
 	},
 /area/ice_colony/underground/responsehangar)
 "bIe" = (
@@ -33416,8 +33274,7 @@
 /area/ice_colony/underground/command/checkpoint)
 "bIY" = (
 /turf/open/shuttle/dropship{
-	icon_state = "floor8";
-	tag = "icon-rasputin7"
+	icon_state = "floor8"
 	},
 /area/ice_colony/underground/responsehangar)
 "bIZ" = (
@@ -33752,8 +33609,7 @@
 /area/ice_colony/underground/storage)
 "bJJ" = (
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin8";
-	tag = "icon-rasputin7"
+	icon_state = "rasputin8"
 	},
 /area/ice_colony/underground/responsehangar)
 "bJK" = (
@@ -34250,7 +34106,6 @@
 "bKR" = (
 /obj/structure/table,
 /obj/item/tool/stamp{
-	tag = "icon-stamp-ce";
 	icon_state = "stamp-ce"
 	},
 /obj/machinery/firealarm{
@@ -34339,7 +34194,6 @@
 /area/ice_colony/underground/security/brig)
 "bLf" = (
 /obj/machinery/door/window/brigdoor/westleft{
-	tag = "icon-leftsecure (EAST)";
 	icon_state = "leftsecure";
 	dir = 4;
 	id = "brg"
@@ -34984,7 +34838,6 @@
 /area/ice_colony/underground/security/armory)
 "bMQ" = (
 /obj/machinery/door/window/brigdoor/westleft{
-	tag = "icon-leftsecure (NORTH)";
 	icon_state = "leftsecure";
 	dir = 1;
 	id = "brg"
@@ -35677,7 +35530,6 @@
 	dir = 1
 	},
 /obj/structure/disposaloutlet{
-	tag = "icon-outlet (EAST)";
 	icon_state = "outlet";
 	dir = 4
 	},
@@ -36252,7 +36104,6 @@
 /area/ice_colony/surface/excavationbarracks)
 "bQA" = (
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin3";
 	icon_state = "rasputin3"
 	},
 /area/ice_colony/underground/responsehangar)
@@ -36398,7 +36249,6 @@
 	dir = 2
 	},
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
 	},
 /area/ice_colony/underground/responsehangar)
@@ -37268,7 +37118,6 @@
 /area/ice_colony/underground/hallway/north_west)
 "bTf" = (
 /obj/machinery/power/terminal{
-	tag = "icon-term (EAST)";
 	icon_state = "term";
 	dir = 4
 	},
@@ -37294,7 +37143,6 @@
 /area/ice_colony/underground/engineering/substation)
 "bTh" = (
 /obj/machinery/power/terminal{
-	tag = "icon-term (EAST)";
 	icon_state = "term";
 	dir = 4
 	},
@@ -38158,7 +38006,6 @@
 /area/ice_colony/surface/excavationbarracks)
 "bVL" = (
 /obj/machinery/shower{
-	tag = "icon-shower (EAST)";
 	icon_state = "shower";
 	dir = 4
 	},
@@ -38406,7 +38253,6 @@
 /area/ice_colony/surface/excavationbarracks)
 "bWo" = (
 /obj/structure/bed/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (NORTH)";
 	icon_state = "wooden_chair_wings";
 	dir = 1
 	},
@@ -38523,7 +38369,6 @@
 /area/ice_colony/exterior/surface/valley/southeast)
 "bWG" = (
 /obj/machinery/shower{
-	tag = "icon-shower (EAST)";
 	icon_state = "shower";
 	dir = 4
 	},
@@ -38627,7 +38472,6 @@
 /area/ice_colony/exterior/surface/landing_pad)
 "bWV" = (
 /obj/effect/decal/cleanable/blood/oil{
-	tag = "icon-armorblood";
 	icon_state = "armorblood"
 	},
 /obj/machinery/landinglight/ds2/delaythree{

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -11941,7 +11941,6 @@
 /area/lv624/lazarus/sleep_male)
 "aRF" = (
 /obj/structure/bed/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (NORTH)";
 	icon_state = "wooden_chair_wings";
 	dir = 1
 	},

--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -249,7 +249,6 @@
 /area/space)
 "abb" = (
 /obj/effect/decal/warning_stripes{
-	tag = "icon-SW-in";
 	icon_state = "SW-in"
 	},
 /turf/open/beach/water,
@@ -4006,7 +4005,6 @@
 /area/prison/cellblock/maxsec/north)
 "alc" = (
 /obj/structure/bed/chair/wood/normal{
-	tag = "icon-wooden_chair (NORTH)";
 	icon_state = "wooden_chair";
 	dir = 1
 	},
@@ -5437,7 +5435,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -6147,7 +6144,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -6160,7 +6156,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -8525,7 +8520,6 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -9003,7 +8997,6 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/research)
@@ -9011,7 +9004,6 @@
 /obj/structure/table/reinforced,
 /obj/item/reagent_container/food/snacks/grilledcheese,
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/research)
@@ -9019,14 +9011,12 @@
 /obj/machinery/microwave,
 /obj/structure/table/reinforced,
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/research)
 "awY" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/research)
@@ -9169,7 +9159,6 @@
 	},
 /obj/machinery/power/apc/drained,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -9244,7 +9233,6 @@
 /area/prison/research)
 "axy" = (
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/research)
@@ -9405,7 +9393,6 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -9460,7 +9447,6 @@
 /obj/structure/table/reinforced,
 /obj/item/clothing/suit/chef/classic,
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/research)
@@ -9663,7 +9649,6 @@
 /area/prison/chapel)
 "ayH" = (
 /obj/structure/bed/chair/wood/normal{
-	tag = "icon-wooden_chair (WEST)";
 	icon_state = "wooden_chair";
 	dir = 8
 	},
@@ -9675,7 +9660,6 @@
 /area/prison/chapel)
 "ayI" = (
 /obj/structure/bed/chair/wood/normal{
-	tag = "icon-wooden_chair (WEST)";
 	icon_state = "wooden_chair";
 	dir = 8
 	},
@@ -9706,7 +9690,6 @@
 	},
 /obj/effect/landmark/random_item/good,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -9758,12 +9741,10 @@
 /area/prison/residential/north)
 "ayS" = (
 /obj/structure/bed/chair/wood/normal{
-	tag = "icon-wooden_chair (WEST)";
 	icon_state = "wooden_chair";
 	dir = 8
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -9839,7 +9820,6 @@
 	dir = 6
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/research)
@@ -9849,7 +9829,6 @@
 	on = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/research)
@@ -9866,7 +9845,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/research)
@@ -9947,7 +9925,6 @@
 /area/prison/maintenance/residential/access/north)
 "azo" = (
 /obj/structure/bed/chair/wood/normal{
-	tag = "icon-wooden_chair (WEST)";
 	icon_state = "wooden_chair";
 	dir = 8
 	},
@@ -10057,7 +10034,6 @@
 /area/prison/chapel)
 "azB" = (
 /obj/structure/bed/chair/wood/normal{
-	tag = "icon-wooden_chair (WEST)";
 	icon_state = "wooden_chair";
 	dir = 8
 	},
@@ -10082,7 +10058,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -10099,7 +10074,6 @@
 	name = "Central Ring"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -10108,7 +10082,6 @@
 /obj/structure/bed/chair,
 /obj/machinery/alarm,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -10190,7 +10163,6 @@
 /area/prison/chapel)
 "azO" = (
 /obj/structure/bed/chair/wood/normal{
-	tag = "icon-wooden_chair (WEST)";
 	icon_state = "wooden_chair";
 	dir = 8
 	},
@@ -10207,7 +10179,6 @@
 /area/prison/chapel)
 "azP" = (
 /obj/structure/bed/chair/wood/normal{
-	tag = "icon-wooden_chair (WEST)";
 	icon_state = "wooden_chair";
 	dir = 8
 	},
@@ -10228,7 +10199,6 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/research)
@@ -10255,7 +10225,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/research)
@@ -10311,7 +10280,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -10528,7 +10496,6 @@
 	dir = 9
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/research)
@@ -10551,7 +10518,6 @@
 "aAK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -10600,7 +10566,6 @@
 "aAR" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -10837,7 +10802,6 @@
 /area/prison/chapel)
 "aBn" = (
 /obj/structure/bed/chair/wood/normal{
-	tag = "icon-wooden_chair (WEST)";
 	icon_state = "wooden_chair";
 	dir = 8
 	},
@@ -11058,14 +11022,12 @@
 "aBI" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/research)
 "aBJ" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/research)
@@ -11172,7 +11134,6 @@
 "aBT" = (
 /obj/structure/flora/pottedplant/ten,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -11181,14 +11142,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
 /area/prison/residential/north)
 "aBV" = (
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -11225,7 +11184,6 @@
 "aCa" = (
 /obj/structure/flora/pottedplant,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -11270,7 +11228,6 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -11351,7 +11308,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -11406,20 +11362,17 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/recreation/highsec/n)
 "aCz" = (
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/recreation/highsec/n)
 "aCA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -11428,7 +11381,6 @@
 /obj/structure/table/reinforced,
 /obj/item/reagent_container/food/drinks/bottle/holywater,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -11458,7 +11410,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -11474,14 +11425,12 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/chapel)
 "aCH" = (
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -11794,7 +11743,6 @@
 "aDr" = (
 /obj/machinery/alarm,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -11804,7 +11752,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/recreation/highsec/n)
@@ -11956,7 +11903,6 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -11974,7 +11920,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -12002,7 +11947,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -12110,7 +12054,6 @@
 	req_one_access_txt = "0"
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/recreation/highsec/n)
@@ -12133,7 +12076,6 @@
 "aEd" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -12144,7 +12086,6 @@
 	on = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -12160,7 +12101,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -12489,7 +12429,6 @@
 "aFc" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/recreation/highsec/n)
@@ -12498,7 +12437,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/recreation/highsec/n)
@@ -12542,7 +12480,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -12639,7 +12576,6 @@
 /area/prison/hallway/entrance)
 "aFz" = (
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -12654,7 +12590,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -12664,7 +12599,6 @@
 	on = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -12672,7 +12606,6 @@
 "aFC" = (
 /obj/structure/bed/chair,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -12682,7 +12615,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -12704,7 +12636,6 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -12720,7 +12651,6 @@
 "aFG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -12841,7 +12771,6 @@
 /area/prison/residential/north)
 "aGa" = (
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -13071,7 +13000,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -13122,7 +13050,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -13172,7 +13099,6 @@
 /area/prison/medbay)
 "aGI" = (
 /obj/structure/bed/chair/office/light{
-	tag = "icon-officechair_white (EAST)";
 	icon_state = "officechair_white";
 	dir = 4
 	},
@@ -13204,7 +13130,6 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -13223,7 +13148,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -13249,7 +13173,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -13269,7 +13192,6 @@
 	},
 /obj/effect/landmark/random_item/crap,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -13290,7 +13212,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -13314,7 +13235,6 @@
 	icon_state = "pipe-y"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -13541,7 +13461,6 @@
 	on = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -13549,7 +13468,6 @@
 "aHp" = (
 /obj/effect/landmark/start/xeno_spawn,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -13557,7 +13475,6 @@
 "aHq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -13567,7 +13484,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -13575,7 +13491,6 @@
 "aHs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -13583,7 +13498,6 @@
 "aHt" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -13678,7 +13592,6 @@
 /area/prison/chapel)
 "aHG" = (
 /obj/structure/bed/chair/wood/normal{
-	tag = "icon-wooden_chair (WEST)";
 	icon_state = "wooden_chair";
 	dir = 8
 	},
@@ -13691,7 +13604,6 @@
 /area/prison/chapel)
 "aHH" = (
 /obj/structure/bed/chair/wood/normal{
-	tag = "icon-wooden_chair (WEST)";
 	icon_state = "wooden_chair";
 	dir = 8
 	},
@@ -13821,7 +13733,6 @@
 "aHZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -13833,7 +13744,6 @@
 	req_one_access_txt = "0"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -13848,14 +13758,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/medbay/foyer)
 "aIc" = (
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -13993,7 +13901,6 @@
 "aIv" = (
 /obj/structure/mineral_door/resin,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -14028,7 +13935,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/mineral_door/resin,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -14045,7 +13951,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -14094,7 +13999,6 @@
 "aIH" = (
 /obj/machinery/alarm,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -14168,7 +14072,6 @@
 /area/prison/chapel)
 "aIR" = (
 /obj/structure/bed/chair/wood/normal{
-	tag = "icon-wooden_chair (NORTH)";
 	icon_state = "wooden_chair";
 	dir = 1
 	},
@@ -14190,7 +14093,6 @@
 	name = "Chapel"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -14281,7 +14183,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -14291,7 +14192,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -14571,7 +14471,6 @@
 	dir = 5
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -14616,7 +14515,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -14629,7 +14527,6 @@
 	dir = 9
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -14637,7 +14534,6 @@
 "aJI" = (
 /obj/machinery/light,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -14742,7 +14638,6 @@
 	name = "Central Ring"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -14779,7 +14674,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -14913,7 +14807,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -15044,7 +14937,6 @@
 	},
 /obj/machinery/power/apc/drained,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -15107,7 +14999,6 @@
 /area/prison/security/checkpoint/highsec/n)
 "aKN" = (
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -15121,14 +15012,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
 "aKP" = (
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -15138,7 +15027,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -15146,7 +15034,6 @@
 "aKR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -15161,7 +15048,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -15316,7 +15202,6 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -15337,7 +15222,6 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -15378,7 +15262,6 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -15401,7 +15284,6 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -15422,7 +15304,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -15443,7 +15324,6 @@
 	dir = 2
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -15458,7 +15338,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -15466,7 +15345,6 @@
 "aLv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -15490,7 +15368,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -15510,7 +15387,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -15531,7 +15407,6 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -15563,7 +15438,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -15770,7 +15644,6 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -15791,7 +15664,6 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -15831,7 +15703,6 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -15850,7 +15721,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -15864,7 +15734,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -15873,7 +15742,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -15899,7 +15767,6 @@
 	icon_state = "pipe-j2"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -15981,7 +15848,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -16094,7 +15960,6 @@
 "aMM" = (
 /obj/machinery/light,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -16105,7 +15970,6 @@
 	on = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -16315,7 +16179,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -16324,7 +16187,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -16342,7 +16204,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -16468,7 +16329,6 @@
 "aNP" = (
 /obj/effect/landmark/monkey_spawn,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -16541,7 +16401,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -16560,7 +16419,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -16604,7 +16462,6 @@
 "aOj" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -16617,14 +16474,12 @@
 	use_power = 0
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
 /area/prison/cleaning)
 "aOl" = (
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -16636,7 +16491,6 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -17260,7 +17114,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -17281,7 +17134,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -17296,7 +17148,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -17421,7 +17272,6 @@
 	use_power = 0
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -17442,7 +17292,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -17481,7 +17330,6 @@
 	icon_state = "pipe-y"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -17499,7 +17347,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -17920,7 +17767,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -17985,7 +17831,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -18035,7 +17880,6 @@
 	use_power = 0
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -18050,7 +17894,6 @@
 "aRh" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -18058,7 +17901,6 @@
 "aRi" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -18443,7 +18285,6 @@
 	name = "Low-Security"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -18499,14 +18340,12 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/cleaning)
 "aSr" = (
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -18672,7 +18511,6 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -18924,7 +18762,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -19024,7 +18861,6 @@
 "aTR" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -19438,7 +19274,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -19672,7 +19507,6 @@
 /area/prison/hallway/central)
 "aVa" = (
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -19681,7 +19515,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -19691,7 +19524,6 @@
 	on = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -19702,7 +19534,6 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -19783,7 +19614,6 @@
 "aVq" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -19813,7 +19643,6 @@
 	dir = 5
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -19995,7 +19824,6 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -20006,7 +19834,6 @@
 "aVT" = (
 /obj/structure/bed/chair,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -20042,7 +19869,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -20052,7 +19878,6 @@
 	dir = 9
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -20081,7 +19906,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -20265,7 +20089,6 @@
 /area/prison/residential/central)
 "aWv" = (
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -20363,7 +20186,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -20386,7 +20208,6 @@
 	on = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -20440,7 +20261,6 @@
 /area/prison/cellblock/lowsec/nw)
 "aWR" = (
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -20505,7 +20325,6 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -20516,7 +20335,6 @@
 	on = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -20536,7 +20354,6 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -20544,7 +20361,6 @@
 "aXd" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -20553,14 +20369,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/canteen)
 "aXf" = (
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -20583,7 +20397,6 @@
 	dir = 6
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
@@ -20690,7 +20503,6 @@
 "aXw" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -20723,7 +20535,6 @@
 	on = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -20738,7 +20549,6 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -20844,7 +20654,6 @@
 "aXY" = (
 /obj/machinery/alarm,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -20977,7 +20786,6 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -20987,7 +20795,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -20998,7 +20805,6 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -21107,7 +20913,6 @@
 "aYG" = (
 /obj/machinery/alarm,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -21131,7 +20936,6 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/command/quarters)
@@ -21198,7 +21002,6 @@
 /obj/effect/decal/cleanable/blood,
 /obj/structure/mineral_door/resin,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -21308,7 +21111,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -21363,7 +21165,6 @@
 	id = "canteen"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -21371,7 +21172,6 @@
 "aZv" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -21381,7 +21181,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -21586,7 +21385,6 @@
 	pixel_x = 28
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/command/quarters)
@@ -21714,7 +21512,6 @@
 	icon_state = "pipe-y"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -21763,7 +21560,6 @@
 "bap" = (
 /obj/effect/landmark/huntergames_primary_spawn,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -21772,7 +21568,6 @@
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -21867,7 +21662,6 @@
 	},
 /obj/machinery/door/window/northright,
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/command/quarters)
@@ -22010,7 +21804,6 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -22174,7 +21967,6 @@
 "bbs" = (
 /obj/effect/landmark/monkey_spawn,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -22229,7 +22021,6 @@
 	name = "Staff Hallway"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -22254,7 +22045,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -22512,7 +22302,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -22644,7 +22433,6 @@
 	name = "Yard"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -22813,7 +22601,6 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -22823,7 +22610,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -22833,7 +22619,6 @@
 	dir = 10
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -22904,7 +22689,6 @@
 "bdt" = (
 /obj/effect/landmark/start/xeno_spawn,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -22932,7 +22716,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -22968,7 +22751,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -23008,7 +22790,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -23131,7 +22912,6 @@
 	dir = 5
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
@@ -23147,7 +22927,6 @@
 	name = "Central Ring"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -23174,7 +22953,6 @@
 	dir = 6
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -23209,7 +22987,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -23222,7 +22999,6 @@
 	dir = 10
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -23260,7 +23036,6 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -23271,7 +23046,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -23281,7 +23055,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -23295,7 +23068,6 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -23307,7 +23079,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -23318,7 +23089,6 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -23326,7 +23096,6 @@
 "bei" = (
 /obj/structure/rack,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -23337,7 +23106,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -23345,7 +23113,6 @@
 "bek" = (
 /obj/structure/closet/crate/freezer,
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
@@ -23360,7 +23127,6 @@
 /area/prison/cellblock/maxsec/north)
 "bem" = (
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
@@ -23374,14 +23140,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
 "beo" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
@@ -23391,7 +23155,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
@@ -23486,7 +23249,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/mineral_door/resin,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -23504,7 +23266,6 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -23514,7 +23275,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -23541,7 +23301,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
@@ -23558,7 +23317,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
@@ -23860,7 +23618,6 @@
 	on = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -23870,7 +23627,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -23881,7 +23637,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -23899,7 +23654,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -23910,7 +23664,6 @@
 	on = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -23929,7 +23682,6 @@
 	use_power = 0
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -23944,7 +23696,6 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -23957,7 +23708,6 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -24034,7 +23784,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
@@ -24074,7 +23823,6 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
@@ -24108,7 +23856,6 @@
 	dir = 10
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
@@ -24119,7 +23866,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
@@ -24290,7 +24036,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -24539,7 +24284,6 @@
 /area/prison/cellblock/lowsec/nw)
 "bgQ" = (
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -24549,7 +24293,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -24576,7 +24319,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -24587,7 +24329,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -24597,7 +24338,6 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -24646,7 +24386,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -24681,7 +24420,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
@@ -24697,14 +24435,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
 "bhk" = (
 /obj/effect/landmark/random_item/crap,
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
@@ -24730,7 +24466,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
@@ -24738,7 +24473,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder,
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
@@ -24756,7 +24490,6 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
@@ -24765,7 +24498,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
@@ -24779,7 +24511,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/landmark/monkey_spawn,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -25016,7 +24747,6 @@
 	use_power = 0
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -25037,7 +24767,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -25115,7 +24844,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -25127,7 +24855,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -25137,7 +24864,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -25145,7 +24871,6 @@
 "bie" = (
 /obj/effect/landmark/huntergames_primary_spawn,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -25171,7 +24896,6 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -25213,7 +24937,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -25237,7 +24960,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -25259,7 +24981,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -25284,7 +25005,6 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -25301,7 +25021,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -25322,7 +25041,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -25346,7 +25064,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -25394,7 +25111,6 @@
 	pixel_y = -24
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -25452,7 +25168,6 @@
 	req_access_txt = "0"
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
@@ -25515,7 +25230,6 @@
 "biz" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
@@ -25532,14 +25246,12 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
 "biB" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
@@ -25548,7 +25260,6 @@
 	dir = 5
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
@@ -25558,7 +25269,6 @@
 	on = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
@@ -25604,7 +25314,6 @@
 	dir = 5
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -25667,7 +25376,6 @@
 	},
 /obj/effect/landmark/huntergames_secondary_spawn,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -25791,7 +25499,6 @@
 "bjf" = (
 /obj/effect/landmark/monkey_spawn,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -25801,7 +25508,6 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -25810,7 +25516,6 @@
 /obj/item/ammo_casing,
 /obj/effect/landmark/random_item/crap,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -25820,7 +25525,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -25828,7 +25532,6 @@
 "bjj" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -25837,7 +25540,6 @@
 /obj/item/ammo_casing,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -25847,7 +25549,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -25856,7 +25557,6 @@
 /obj/effect/decal/cleanable/blood,
 /obj/item/ammo_magazine/rifle/m16,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -25866,7 +25566,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -25903,7 +25602,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -25920,7 +25618,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -25943,7 +25640,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -25965,7 +25661,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
@@ -25975,7 +25670,6 @@
 	},
 /obj/effect/landmark/corpsespawner/chef,
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
@@ -25984,7 +25678,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
@@ -25993,7 +25686,6 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
@@ -26002,7 +25694,6 @@
 	dir = 2
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
@@ -26017,7 +25708,6 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -26028,7 +25718,6 @@
 	name = "Kitchen"
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
@@ -26098,7 +25787,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -26112,7 +25800,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -26174,7 +25861,6 @@
 "bjU" = (
 /obj/machinery/alarm,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -26189,7 +25875,6 @@
 "bjW" = (
 /obj/machinery/alarm,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -26234,7 +25919,6 @@
 	dir = 5
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -26337,7 +26021,6 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -26391,7 +26074,6 @@
 	dir = 9
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -26399,7 +26081,6 @@
 "bku" = (
 /obj/item/ammo_magazine/rifle/m16,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -26439,7 +26120,6 @@
 "bkz" = (
 /obj/effect/landmark/huntergames_primary_spawn,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -26456,7 +26136,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -26469,7 +26148,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -26486,7 +26164,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
@@ -26494,7 +26171,6 @@
 /obj/structure/closet/crate/freezer,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
@@ -26564,7 +26240,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -26588,7 +26263,6 @@
 "bkQ" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -26607,7 +26281,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -26702,7 +26375,6 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -26794,7 +26466,6 @@
 	name = "Yard"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -26803,7 +26474,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -26811,7 +26481,6 @@
 "blk" = (
 /obj/item/frame/table/reinforced,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -26819,7 +26488,6 @@
 "bll" = (
 /obj/item/ammo_casing,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -26828,7 +26496,6 @@
 /obj/structure/table/reinforced,
 /obj/effect/landmark/random_item/good,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -26838,7 +26505,6 @@
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/effect/landmark/random_item/good,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -26850,7 +26516,6 @@
 	name = "Yard"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -26863,7 +26528,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -26886,7 +26550,6 @@
 "bls" = (
 /obj/effect/landmark/random_item/crap,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -26900,7 +26563,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -26959,7 +26621,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -27355,7 +27016,6 @@
 /obj/structure/table/reinforced,
 /obj/item/ammo_casing,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -27363,7 +27023,6 @@
 "bmB" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -27372,7 +27031,6 @@
 /obj/item/ammo_casing,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -27410,7 +27068,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/toilet/canteen)
@@ -27419,7 +27076,6 @@
 	pixel_y = 15
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/toilet/canteen)
@@ -27428,7 +27084,6 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/toilet/canteen)
@@ -27516,7 +27171,6 @@
 	dir = 2
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -27700,7 +27354,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -27722,7 +27375,6 @@
 "bnx" = (
 /obj/effect/landmark/huntergames_secondary_spawn,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -27730,7 +27382,6 @@
 "bny" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -27741,7 +27392,6 @@
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/effect/landmark/random_item/good,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -27750,7 +27400,6 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/landmark/random_item/good,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -27761,7 +27410,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -27785,7 +27433,6 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -27793,7 +27440,6 @@
 "bnE" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -27828,7 +27474,6 @@
 	},
 /obj/machinery/light/small,
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/toilet/canteen)
@@ -27848,7 +27493,6 @@
 /area/prison/hallway/entrance)
 "bnM" = (
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -27862,7 +27506,6 @@
 /area/prison/hangar/main)
 "bnO" = (
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -27924,7 +27567,6 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -28275,7 +27917,6 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -28335,7 +27976,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -28357,7 +27997,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -28404,7 +28043,6 @@
 	name = "Low-Security"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -28417,7 +28055,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -28430,7 +28067,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -28478,7 +28114,6 @@
 /obj/effect/landmark/huntergames_primary_spawn,
 /obj/structure/mineral_door/resin,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -28497,7 +28132,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -28511,7 +28145,6 @@
 	},
 /obj/structure/mineral_door/resin,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -28557,7 +28190,6 @@
 /obj/item/ammo_casing,
 /obj/item/ammo_magazine/rifle/m16,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -28581,7 +28213,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -28594,7 +28225,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -28602,7 +28232,6 @@
 "boP" = (
 /obj/effect/landmark/random_item/good,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -28615,7 +28244,6 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -28636,7 +28264,6 @@
 	id = "canteen"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -28654,7 +28281,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -28710,7 +28336,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -28742,7 +28367,6 @@
 /area/prison/residential/central)
 "bpg" = (
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/toilet/canteen)
@@ -28897,7 +28521,6 @@
 /area/prison/storage/vip)
 "bpF" = (
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -28906,7 +28529,6 @@
 /obj/structure/table/reinforced,
 /obj/item/weapon/gun/shotgun/pump/cmb,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -28914,7 +28536,6 @@
 "bpH" = (
 /obj/item/ammo_magazine/shotgun/buckshot,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -28931,7 +28552,6 @@
 "bpK" = (
 /obj/effect/landmark/random_item/crap,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -28963,7 +28583,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -28977,7 +28596,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -29003,7 +28621,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -29018,7 +28635,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -29038,7 +28654,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -29241,7 +28856,6 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -29261,7 +28875,6 @@
 	on = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -29281,7 +28894,6 @@
 "bqw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -29290,7 +28902,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/landmark/huntergames_primary_spawn,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -29401,7 +29012,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -29543,7 +29153,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -29593,7 +29202,6 @@
 	},
 /obj/structure/disposalpipe/junction,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -29601,7 +29209,6 @@
 "bri" = (
 /obj/item/weapon/gun/rifle/m16,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -29623,7 +29230,6 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -29657,7 +29263,6 @@
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -29665,7 +29270,6 @@
 "brp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -29705,7 +29309,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -29735,7 +29338,6 @@
 	dir = 5
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
@@ -29890,7 +29492,6 @@
 "brS" = (
 /obj/item/ammo_casing,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -29944,7 +29545,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/toilet/canteen)
@@ -30192,7 +29792,6 @@
 	dir = 2
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -30204,7 +29803,6 @@
 	dir = 2
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -30215,7 +29813,6 @@
 	dir = 2
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -30262,7 +29859,6 @@
 	on = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -30273,7 +29869,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -30289,7 +29884,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/toilet/canteen)
@@ -30480,7 +30074,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -30624,7 +30217,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -30718,14 +30310,12 @@
 "btZ" = (
 /obj/structure/bed,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
 /area/prison/holding/holding1)
 "bua" = (
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -30733,7 +30323,6 @@
 "bub" = (
 /obj/structure/bed/chair,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -30760,7 +30349,6 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -30773,7 +30361,6 @@
 /obj/item/reagent_container/food/drinks/coffee,
 /obj/item/reagent_container/food/drinks/coffee,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -30781,7 +30368,6 @@
 "bui" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -30790,7 +30376,6 @@
 /obj/structure/table/reinforced,
 /obj/item/reagent_container/food/drinks/milk,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -30799,14 +30384,12 @@
 /obj/structure/table/reinforced,
 /obj/item/reagent_container/food/drinks/cans/cola,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/store)
 "bul" = (
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -30816,7 +30399,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -30836,7 +30418,6 @@
 	dir = 6
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -30846,7 +30427,6 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -30857,7 +30437,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -30912,7 +30491,6 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/kitchen)
@@ -30946,7 +30524,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -31028,7 +30605,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -31046,7 +30622,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -31089,7 +30664,6 @@
 	name = "Central Ring"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -31136,7 +30710,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -31172,7 +30745,6 @@
 "buW" = (
 /obj/effect/landmark/random_item/crap,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -31181,7 +30753,6 @@
 /obj/structure/bed,
 /obj/effect/landmark/corpsespawner/prisoner,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -31205,14 +30776,12 @@
 "bva" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
 /area/prison/holding/holding1)
 "bvb" = (
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -31224,7 +30793,6 @@
 /area/prison/hallway/central)
 "bvd" = (
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -31236,7 +30804,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -31244,7 +30811,6 @@
 "bvf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -31314,7 +30880,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/random_item/crap,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -31332,7 +30897,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -31573,7 +31137,6 @@
 	name = "Yard"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -31598,7 +31161,6 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -31607,7 +31169,6 @@
 /obj/structure/rack,
 /obj/item/reagent_container/food/snacks/packaged_burrito,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -31615,7 +31176,6 @@
 "bvX" = (
 /obj/effect/landmark/random_item/crap,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -31624,7 +31184,6 @@
 /obj/structure/rack,
 /obj/item/reagent_container/food/snacks/chocolatebar,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -31632,7 +31191,6 @@
 "bvZ" = (
 /obj/structure/bed/chair/office/dark,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -31647,7 +31205,6 @@
 	on = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -31657,7 +31214,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -31672,7 +31228,6 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -31724,7 +31279,6 @@
 	dir = 5
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -31737,7 +31291,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -31946,7 +31499,6 @@
 "bwQ" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -31955,7 +31507,6 @@
 /obj/structure/table/reinforced,
 /obj/effect/landmark/random_item/crap,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -31966,7 +31517,6 @@
 	on = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -31976,7 +31526,6 @@
 	dir = 10
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -31987,7 +31536,6 @@
 "bwV" = (
 /obj/structure/rack,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -32008,7 +31556,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -32124,7 +31671,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -32169,7 +31715,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -32195,7 +31740,6 @@
 	name = "Holding Cell 1"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -32240,7 +31784,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -32249,7 +31792,6 @@
 /obj/structure/rack,
 /obj/item/reagent_container/food/snacks/no_raisin,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -32259,7 +31801,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -32446,7 +31987,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -32455,7 +31995,6 @@
 /obj/structure/rack,
 /obj/item/reagent_container/food/snacks/chips,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -32769,7 +32308,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -32859,7 +32397,6 @@
 "byW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -32870,7 +32407,6 @@
 	req_access_txt = "0"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -33243,7 +32779,6 @@
 "bzX" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -33309,7 +32844,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -33317,7 +32851,6 @@
 "bAf" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -33327,7 +32860,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -33343,7 +32875,6 @@
 /area/prison/security/monitoring/lowsec/sw)
 "bAi" = (
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -33358,7 +32889,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -33387,7 +32917,6 @@
 	on = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -33397,7 +32926,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -33428,7 +32956,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -33438,7 +32965,6 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -33446,7 +32972,6 @@
 "bAr" = (
 /obj/machinery/light,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -33475,7 +33000,6 @@
 "bAx" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -33483,7 +33007,6 @@
 "bAy" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -33497,14 +33020,12 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/east)
 "bAA" = (
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -33523,7 +33044,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -33617,7 +33137,6 @@
 "bAQ" = (
 /obj/machinery/alarm,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -33752,7 +33271,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -33797,7 +33315,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -33889,7 +33406,6 @@
 	name = "Prison Store"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -33911,7 +33427,6 @@
 	name = "Visitation"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -33934,7 +33449,6 @@
 	req_access_txt = "0"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -34045,7 +33559,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -34136,7 +33649,6 @@
 /area/prison/cellblock/lowsec/sw)
 "bCb" = (
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -34399,14 +33911,12 @@
 	use_power = 0
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
 /area/prison/hallway/east)
 "bCH" = (
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -34421,7 +33931,6 @@
 	on = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -34431,7 +33940,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -34446,7 +33954,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -34467,7 +33974,6 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -34475,7 +33981,6 @@
 "bCN" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -34504,7 +34009,6 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -34623,13 +34127,11 @@
 	dir = 4
 	},
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
 	},
 /area/prison/monorail/east)
 "bDk" = (
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin3";
 	icon_state = "rasputin3"
 	},
 /area/prison/monorail/east)
@@ -34638,7 +34140,6 @@
 	dir = 8
 	},
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
 	},
 /area/prison/monorail/east)
@@ -34673,7 +34174,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -34972,7 +34472,6 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -35104,7 +34603,6 @@
 "bEg" = (
 /obj/machinery/alarm,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -35195,7 +34693,6 @@
 	use_power = 0
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -35216,7 +34713,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -35256,7 +34752,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -35310,7 +34805,6 @@
 /obj/effect/landmark/random_item/crap,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -35375,7 +34869,6 @@
 	use_power = 0
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -35548,7 +35041,6 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -35573,7 +35065,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -35733,7 +35224,6 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -35760,7 +35250,6 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -35862,7 +35351,6 @@
 	name = "Security Barracks"
 	},
 /turf/open/floor/prison{
-	tag = "icon-darkbrownfull2";
 	icon_state = "darkbrownfull2"
 	},
 /area/prison/quarters/security)
@@ -36035,7 +35523,6 @@
 	req_access_txt = "0"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -36043,7 +35530,6 @@
 "bFW" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -36141,7 +35627,6 @@
 /area/prison/maintenance/hangar_barracks)
 "bGh" = (
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
 	},
 /area/prison/monorail/east)
@@ -36153,7 +35638,6 @@
 	opacity = 0
 	},
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin3";
 	icon_state = "rasputin3"
 	},
 /area/prison/monorail/east)
@@ -36251,7 +35735,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -36260,7 +35743,6 @@
 /obj/effect/landmark/corpsespawner/prisoner,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -36271,7 +35753,6 @@
 	on = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -36279,7 +35760,6 @@
 "bGB" = (
 /obj/machinery/light,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -36395,7 +35875,6 @@
 "bGP" = (
 /obj/machinery/alarm,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -36453,7 +35932,6 @@
 	on = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -36468,7 +35946,6 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -36738,7 +36215,6 @@
 	name = "Parole"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -36904,7 +36380,6 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -37430,14 +36905,12 @@
 "bIY" = (
 /obj/structure/bed,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/holding/holding2)
 "bIZ" = (
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -37445,7 +36918,6 @@
 "bJa" = (
 /obj/structure/bed/chair,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -37467,7 +36939,6 @@
 /area/prison/residential/south)
 "bJd" = (
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -37482,7 +36953,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -37513,7 +36983,6 @@
 "bJk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -37575,7 +37044,6 @@
 	dir = 6
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -37588,7 +37056,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -37754,7 +37221,6 @@
 /obj/structure/bed,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -37764,7 +37230,6 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -37775,7 +37240,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -38061,7 +37525,6 @@
 "bKD" = (
 /obj/effect/landmark/start/surv_spawn,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -38071,7 +37534,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -38086,7 +37548,6 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -38112,7 +37573,6 @@
 	dir = 2
 	},
 /turf/open/floor/prison{
-	tag = "icon-darkbrownfull2";
 	icon_state = "darkbrownfull2"
 	},
 /area/prison/hallway/east)
@@ -38123,7 +37583,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -38174,7 +37633,6 @@
 	dir = 10
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -38209,7 +37667,6 @@
 	name = "Central Ring"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -38235,7 +37692,6 @@
 	name = "Central Ring"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -38328,7 +37784,6 @@
 	on = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -38339,7 +37794,6 @@
 "bLl" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -38351,7 +37805,6 @@
 /obj/effect/landmark/random_item/crap,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -38380,7 +37833,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -38466,7 +37918,6 @@
 	},
 /obj/machinery/light/small,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -38593,7 +38044,6 @@
 	dir = 5
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -38643,7 +38093,6 @@
 /obj/effect/landmark/corpsespawner/prisoner,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -38654,7 +38103,6 @@
 	on = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -38664,7 +38112,6 @@
 	dir = 9
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -38675,7 +38122,6 @@
 	name = "Holding Cell 2"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -38684,7 +38130,6 @@
 /obj/effect/landmark/corpsespawner/prisoner,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -38692,7 +38137,6 @@
 "bMe" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -38768,7 +38212,6 @@
 	name = "Intake Processing"
 	},
 /turf/open/floor/prison{
-	tag = "icon-darkbrownfull2";
 	icon_state = "darkbrownfull2"
 	},
 /area/prison/intake)
@@ -38779,7 +38222,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/prison{
-	tag = "icon-darkbrownfull2";
 	icon_state = "darkbrownfull2"
 	},
 /area/prison/intake)
@@ -38955,7 +38397,6 @@
 	name = "Parole"
 	},
 /turf/open/floor/prison{
-	tag = "icon-darkbrownfull2";
 	icon_state = "darkbrownfull2"
 	},
 /area/prison/parole/main)
@@ -38987,7 +38428,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -39056,7 +38496,6 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -39064,7 +38503,6 @@
 "bMX" = (
 /obj/effect/landmark/random_item/crap,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -39077,7 +38515,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -39288,7 +38725,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -39296,7 +38732,6 @@
 "bNE" = (
 /obj/effect/landmark/random_item/good,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -39304,7 +38739,6 @@
 "bNF" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -39312,7 +38746,6 @@
 "bNG" = (
 /obj/structure/toilet,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -39390,7 +38823,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -39449,7 +38881,6 @@
 	opacity = 0
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -39541,7 +38972,6 @@
 	req_one_access_txt = "0"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -39565,7 +38995,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -39574,7 +39003,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -39582,7 +39010,6 @@
 "bOe" = (
 /obj/machinery/alarm,
 /turf/open/floor/prison{
-	tag = "icon-bluefull (WEST)";
 	icon_state = "bluefull";
 	dir = 8
 	},
@@ -39610,7 +39037,6 @@
 	dir = 6
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -39628,7 +39054,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -39708,7 +39133,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -39810,7 +39234,6 @@
 	use_power = 0
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -39830,7 +39253,6 @@
 	use_power = 0
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -39848,7 +39270,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -39865,7 +39286,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -39924,14 +39344,12 @@
 	},
 /obj/effect/landmark/corpsespawner/prison_security,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
 /area/prison/toilet/security)
 "bOR" = (
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -39944,7 +39362,6 @@
 	pixel_y = 28
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -40160,7 +39577,6 @@
 "bPt" = (
 /obj/structure/closet/wardrobe/orange,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -40169,7 +39585,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -40178,7 +39593,6 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -40601,7 +40015,6 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -40611,7 +40024,6 @@
 	on = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -40648,7 +40060,6 @@
 	on = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -40656,7 +40067,6 @@
 "bQH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -40664,7 +40074,6 @@
 "bQI" = (
 /obj/machinery/light,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -40680,7 +40089,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -40751,7 +40159,6 @@
 /area/prison/recreation/highsec/s)
 "bQV" = (
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -40761,7 +40168,6 @@
 	on = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -40769,7 +40175,6 @@
 "bQX" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -40788,7 +40193,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -40800,7 +40204,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -41028,7 +40431,6 @@
 /area/prison/engineering)
 "bRH" = (
 /obj/machinery/atmospherics/components/unary/tank/oxygen{
-	tag = "icon-o2_map (EAST)";
 	dir = 4
 	},
 /turf/open/floor/prison,
@@ -41042,8 +40444,7 @@
 /area/prison/engineering/atmos)
 "bRJ" = (
 /obj/machinery/atmospherics/components/unary/tank/oxygen{
-	dir = 8;
-	tag = "icon-o2_map (WEST)"
+	dir = 8
 	},
 /turf/open/floor/prison,
 /area/prison/engineering/atmos)
@@ -41150,7 +40551,6 @@
 	dir = 5
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -41160,7 +40560,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -41173,7 +40572,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -41186,7 +40584,6 @@
 	dir = 9
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -41194,7 +40591,6 @@
 "bSf" = (
 /obj/effect/landmark/huntergames_primary_spawn,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -41211,7 +40607,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -41224,7 +40619,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -41256,7 +40650,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -41269,7 +40662,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -41284,7 +40676,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -41302,7 +40693,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -41319,7 +40709,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -41335,7 +40724,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -41353,7 +40741,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -41411,7 +40798,6 @@
 "bSA" = (
 /obj/structure/rack,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -41430,7 +40816,6 @@
 	dir = 10
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -41439,7 +40824,6 @@
 /obj/structure/rack,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -41447,7 +40831,6 @@
 "bSE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -41455,7 +40838,6 @@
 "bSF" = (
 /obj/effect/landmark/monkey_spawn,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -41465,7 +40847,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -41779,7 +41160,6 @@
 /area/prison/engineering)
 "bTl" = (
 /obj/machinery/atmospherics/components/unary/tank/oxygen{
-	tag = "icon-o2_map (EAST)";
 	dir = 4
 	},
 /obj/structure/window/reinforced,
@@ -41792,8 +41172,7 @@
 /area/prison/engineering/atmos)
 "bTn" = (
 /obj/machinery/atmospherics/components/unary/tank/oxygen{
-	dir = 8;
-	tag = "icon-o2_map (WEST)"
+	dir = 8
 	},
 /obj/structure/window/reinforced,
 /turf/open/floor/prison,
@@ -42086,7 +41465,6 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -42157,7 +41535,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -42175,7 +41552,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -42194,7 +41570,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -42211,7 +41586,6 @@
 	dir = 9
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -42654,7 +42028,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -42682,7 +42055,6 @@
 	opacity = 0
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -42706,7 +42078,6 @@
 	opacity = 0
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -42799,7 +42170,6 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -42810,7 +42180,6 @@
 	},
 /obj/effect/landmark/huntergames_primary_spawn,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -42819,7 +42188,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -42829,7 +42197,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -43149,7 +42516,6 @@
 "bWC" = (
 /obj/structure/flora/pottedplant,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -43161,7 +42527,6 @@
 "bWE" = (
 /obj/structure/flora/pottedplant/ten,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -43209,7 +42574,6 @@
 	dir = 5
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -43219,7 +42583,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -43230,7 +42593,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -43246,7 +42608,6 @@
 	dir = 9
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -43360,7 +42721,6 @@
 "bXc" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -43483,7 +42843,6 @@
 /area/prison/storage/medsec)
 "bXu" = (
 /turf/open/floor/prison{
-	tag = "icon-bluefull (WEST)";
 	icon_state = "bluefull";
 	dir = 8
 	},
@@ -43778,7 +43137,6 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -43913,7 +43271,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -44099,7 +43456,6 @@
 "bYK" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/prison{
-	tag = "icon-bluefull (WEST)";
 	icon_state = "bluefull";
 	dir = 8
 	},
@@ -44425,7 +43781,6 @@
 	dir = 6
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -44435,7 +43790,6 @@
 	dir = 2
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -44446,7 +43800,6 @@
 	dir = 2
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -44462,7 +43815,6 @@
 	dir = 10
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -44590,7 +43942,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/recreation/medsec)
@@ -44599,7 +43950,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/recreation/medsec)
@@ -45054,7 +44404,6 @@
 /area/prison/recreation/medsec)
 "cbo" = (
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/recreation/medsec)
@@ -45887,7 +45236,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bluefull (WEST)";
 	icon_state = "bluefull";
 	dir = 8
 	},
@@ -46091,7 +45439,6 @@
 	req_one_access_txt = "0"
 	},
 /turf/open/floor/prison{
-	tag = "icon-darkbrownfull2";
 	icon_state = "darkbrownfull2"
 	},
 /area/prison/hallway/engineering)
@@ -46487,7 +45834,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/cellblock/mediumsec/north)
@@ -46496,7 +45842,6 @@
 	pixel_y = 15
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/cellblock/mediumsec/north)
@@ -46505,7 +45850,6 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/cellblock/mediumsec/north)
@@ -46615,7 +45959,6 @@
 	req_one_access_txt = "0"
 	},
 /turf/open/floor/prison{
-	tag = "icon-darkbrownfull2";
 	icon_state = "darkbrownfull2"
 	},
 /area/prison/hallway/engineering)
@@ -46623,8 +45966,7 @@
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = "icon-1-4"
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -47079,7 +46421,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/cellblock/mediumsec/north)
@@ -47400,7 +46741,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/cellblock/mediumsec/north)
@@ -47806,7 +47146,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/cellblock/protective)
@@ -47815,7 +47154,6 @@
 	pixel_y = 15
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/cellblock/protective)
@@ -47824,7 +47162,6 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/cellblock/protective)
@@ -48270,7 +47607,6 @@
 	},
 /obj/machinery/light,
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/cellblock/mediumsec/north)
@@ -48338,7 +47674,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-kitchen";
 	icon_state = "kitchen"
 	},
 /area/prison/cellblock/protective)
@@ -48623,7 +47958,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bluefull (WEST)";
 	icon_state = "bluefull";
 	dir = 8
 	},
@@ -48875,8 +48209,7 @@
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = "icon-1-8"
+	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -49042,7 +48375,6 @@
 	on = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bluefull (WEST)";
 	icon_state = "bluefull";
 	dir = 8
 	},
@@ -49957,7 +49289,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -51105,7 +50436,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -51126,7 +50456,6 @@
 	dir = 9
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -51160,7 +50489,6 @@
 	dir = 5
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -51170,7 +50498,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -51181,7 +50508,6 @@
 	on = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -51389,7 +50715,6 @@
 /area/prison/disposal)
 "cqp" = (
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -51627,7 +50952,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -51664,7 +50988,6 @@
 	pixel_x = 24
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -51683,7 +51006,6 @@
 /area/prison/cellblock/highsec/south/south)
 "crj" = (
 /obj/structure/shuttle/engine/router{
-	tag = "icon-router (NORTH)";
 	icon_state = "router";
 	dir = 1
 	},
@@ -51868,7 +51190,6 @@
 /obj/item/healthanalyzer,
 /obj/structure/table/reinforced,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -51876,7 +51197,6 @@
 "crH" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -51887,7 +51207,6 @@
 	frequency = 1449
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -51897,7 +51216,6 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -53266,7 +52584,6 @@
 "cvs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison{
-	tag = "icon-bright_clean2 (SOUTHWEST)";
 	icon_state = "bright_clean2";
 	dir = 10
 	},
@@ -53328,7 +52645,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -53915,12 +53231,10 @@
 	},
 /obj/effect/decal/warning_stripes,
 /obj/structure/window/reinforced/toughened{
-	tag = "icon-rwindow (EAST)";
 	icon_state = "rwindow";
 	dir = 4
 	},
 /obj/structure/window/reinforced/toughened{
-	tag = "icon-rwindow (NORTH)";
 	icon_state = "rwindow";
 	dir = 1
 	},
@@ -53949,8 +53263,7 @@
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = "icon-1-8"
+	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -53960,7 +53273,6 @@
 /area/prison/pirate)
 "cxd" = (
 /obj/structure/cable/green{
-	tag = "icon-1-8";
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -53973,11 +53285,9 @@
 /area/prison/pirate)
 "cxe" = (
 /obj/structure/cable/pink{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/terminal{
-	tag = "icon-term (NORTH)";
 	icon_state = "term";
 	dir = 1
 	},
@@ -53988,7 +53298,6 @@
 /area/prison/pirate)
 "cxf" = (
 /obj/structure/cable/green{
-	tag = "icon-1-4";
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -54003,8 +53312,7 @@
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = "icon-1-4"
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -54026,7 +53334,6 @@
 	},
 /obj/effect/decal/warning_stripes,
 /obj/structure/window/reinforced/toughened{
-	tag = "icon-rwindow (WEST)";
 	icon_state = "rwindow";
 	dir = 8
 	},
@@ -54061,7 +53368,6 @@
 	},
 /obj/effect/decal/warning_stripes,
 /obj/structure/window/reinforced/toughened{
-	tag = "icon-rwindow (EAST)";
 	icon_state = "rwindow";
 	dir = 4
 	},
@@ -54084,7 +53390,6 @@
 /area/prison/pirate)
 "cxq" = (
 /obj/structure/cable/green{
-	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -54096,8 +53401,7 @@
 "cxr" = (
 /obj/machinery/atmospherics/components/binary/circulator{
 	anchored = 1;
-	dir = 1;
-	tag = "icon-circ-off (NORTH)"
+	dir = 1
 	},
 /obj/effect/decal/warning_stripes,
 /obj/structure/lattice,
@@ -54113,7 +53417,6 @@
 /area/prison/pirate)
 "cxt" = (
 /obj/structure/cable/green{
-	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -54134,7 +53437,6 @@
 	},
 /obj/effect/decal/warning_stripes,
 /obj/structure/window/reinforced/toughened{
-	tag = "icon-rwindow (WEST)";
 	icon_state = "rwindow";
 	dir = 8
 	},
@@ -54192,7 +53494,6 @@
 /area/prison/pirate)
 "cxE" = (
 /obj/structure/cable/green{
-	tag = "icon-1-4";
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
@@ -54204,8 +53505,7 @@
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8";
-	tag = "icon-1-4"
+	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
 /area/prison/pirate)
@@ -54228,14 +53528,12 @@
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-4";
-	tag = "icon-1-8"
+	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
 /area/prison/pirate)
 "cxJ" = (
 /obj/structure/cable/green{
-	tag = "icon-1-8";
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
@@ -54326,7 +53624,6 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
-	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -54346,7 +53643,6 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
-	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -54378,7 +53674,6 @@
 /area/prison/pirate)
 "cyk" = (
 /obj/structure/cable/green{
-	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -54389,8 +53684,7 @@
 /area/prison/pirate)
 "cym" = (
 /obj/machinery/atmospherics/components/unary/tank/oxygen{
-	dir = 1;
-	tag = "icon-o2_map (WEST)"
+	dir = 1
 	},
 /turf/open/floor/plating/platebot,
 /area/prison/pirate)
@@ -54431,7 +53725,6 @@
 "cyu" = (
 /obj/structure/window/framed/prison/reinforced/hull,
 /obj/structure/cable/green{
-	tag = "icon-1-2";
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
@@ -54467,7 +53760,6 @@
 /obj/structure/shuttle/engine/heater,
 /obj/effect/decal/warning_stripes,
 /obj/structure/window/reinforced/toughened{
-	tag = "icon-rwindow (NORTH)";
 	icon_state = "rwindow";
 	dir = 1
 	},
@@ -54477,7 +53769,6 @@
 /obj/structure/shuttle/engine/heater,
 /obj/effect/decal/warning_stripes,
 /obj/structure/window/reinforced/toughened{
-	tag = "icon-rwindow (NORTH)";
 	icon_state = "rwindow";
 	dir = 1
 	},
@@ -54489,7 +53780,6 @@
 /obj/effect/decal/warning_stripes,
 /obj/machinery/atmospherics/pipe/simple/violet,
 /obj/structure/window/reinforced/toughened{
-	tag = "icon-rwindow (NORTH)";
 	icon_state = "rwindow";
 	dir = 1
 	},
@@ -54507,7 +53797,6 @@
 /area/prison/cellblock/mediumsec/south)
 "cyK" = (
 /obj/structure/shuttle/engine/router{
-	tag = "icon-router (NORTH)";
 	icon_state = "router";
 	dir = 1
 	},
@@ -55183,7 +54472,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},
@@ -55260,7 +54548,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/prison{
-	tag = "icon-bright_clean (SOUTHWEST)";
 	icon_state = "bright_clean";
 	dir = 10
 	},

--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -278,7 +278,6 @@
 "aaO" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor{
-	tag = "icon-platebot";
 	icon_state = "platebot"
 	},
 /area/sulaco/cargo)
@@ -411,13 +410,11 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-platebot";
 	icon_state = "platebot"
 	},
 /area/sulaco/cargo)
 "abi" = (
 /obj/machinery/disposal/deliveryChute{
-	tag = "icon-intake (EAST)";
 	icon_state = "intake";
 	dir = 4
 	},
@@ -528,7 +525,6 @@
 "abw" = (
 /obj/structure/closet/crate,
 /turf/open/floor{
-	tag = "icon-platebot";
 	icon_state = "platebot"
 	},
 /area/sulaco/cargo)
@@ -568,7 +564,6 @@
 "abE" = (
 /obj/structure/closet/secure_closet/medical3,
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/storage)
@@ -589,7 +584,6 @@
 /area/sulaco/medbay/storage)
 "abG" = (
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/storage)
@@ -755,7 +749,6 @@
 "acd" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/west)
@@ -774,8 +767,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 6;
-	icon_state = "intact";
-	tag = "icon-intact (NORTHEAST)"
+	icon_state = "intact"
 	},
 /obj/item/storage/pill_bottle/peridaxon,
 /obj/item/storage/pill_bottle/dylovene,
@@ -791,7 +783,6 @@
 	on = 0
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/west)
@@ -816,7 +807,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/storage)
@@ -836,7 +826,6 @@
 /obj/item/reagent_container/spray/cleaner,
 /obj/item/reagent_container/spray/cleaner,
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -868,7 +857,6 @@
 	},
 /obj/item/storage/box/syringes,
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -884,7 +872,6 @@
 "acn" = (
 /obj/machinery/alarm,
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -899,7 +886,6 @@
 	density = 0
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -916,7 +902,6 @@
 "acr" = (
 /obj/machinery/sleeper,
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -1166,12 +1151,10 @@
 /area/sulaco/medbay/surgery_one)
 "acV" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	tag = "icon-intact (NORTHEAST)";
 	icon_state = "intact";
 	dir = 5
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/west)
@@ -1194,7 +1177,6 @@
 	layer = 2.3
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/west)
@@ -1218,7 +1200,6 @@
 "ada" = (
 /obj/machinery/vending/MarineMed/Blood,
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/storage)
@@ -1246,7 +1227,6 @@
 	name = "Doctor"
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -1257,7 +1237,6 @@
 /area/sulaco/medbay)
 "adf" = (
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -1269,7 +1248,6 @@
 	layer = 2.1
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -1279,7 +1257,6 @@
 	icon_state = "tube1"
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -1420,14 +1397,12 @@
 /area/sulaco/disposal)
 "ady" = (
 /turf/closed/shuttle{
-	tag = "icon-wall3 (EAST)";
 	icon_state = "wall3";
 	dir = 4
 	},
 /area/sulaco/disposal)
 "adz" = (
 /turf/closed/shuttle{
-	tag = "icon-wall3 (EAST)";
 	icon_state = "wall3";
 	dir = 4
 	},
@@ -1493,7 +1468,6 @@
 	layer = 2.1
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/west)
@@ -1504,7 +1478,6 @@
 /area/sulaco/medbay/west)
 "adI" = (
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/west)
@@ -1514,7 +1487,6 @@
 	},
 /obj/machinery/vending/medical,
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/west)
@@ -1534,14 +1506,12 @@
 	dir = 2
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/storage)
 "adL" = (
 /obj/machinery/iv_drip,
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -1714,7 +1684,6 @@
 /area/sulaco/engineering/ce)
 "aei" = (
 /turf/closed/shuttle{
-	tag = "icon-wall3 (EAST)";
 	icon_state = "wall3";
 	dir = 4
 	},
@@ -1740,11 +1709,9 @@
 "ael" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10;
-	icon_state = "intact";
-	tag = "icon-intact (NORTHWEST)"
+	icon_state = "intact"
 	},
 /turf/closed/shuttle{
-	tag = "icon-wall3 (EAST)";
 	icon_state = "wall3";
 	dir = 4
 	},
@@ -1832,7 +1799,6 @@
 "aev" = (
 /obj/machinery/iv_drip,
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/west)
@@ -1853,7 +1819,6 @@
 "aex" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/west)
@@ -1866,7 +1831,6 @@
 	},
 /obj/structure/bed/roller,
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/west)
@@ -1889,7 +1853,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/west)
@@ -1906,21 +1869,18 @@
 	},
 /obj/structure/bed/roller,
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/west)
 "aeD" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
 "aeE" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -1931,7 +1891,6 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -1958,7 +1917,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -2087,7 +2045,6 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering/ce)
@@ -2102,7 +2059,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering/ce)
@@ -2118,7 +2074,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering/ce)
@@ -2137,7 +2092,6 @@
 	pixel_x = 30
 	},
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering/ce)
@@ -2148,7 +2102,6 @@
 	icon_state = "2-8"
 	},
 /turf/closed/shuttle{
-	tag = "icon-wall3 (EAST)";
 	icon_state = "wall3";
 	dir = 4
 	},
@@ -2169,7 +2122,6 @@
 "afc" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/closed/shuttle{
-	tag = "icon-wall3 (EAST)";
 	icon_state = "wall3";
 	dir = 4
 	},
@@ -2274,7 +2226,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/west)
@@ -2291,7 +2242,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/west)
@@ -2310,7 +2260,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/west)
@@ -2321,7 +2270,6 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/west)
@@ -2362,7 +2310,6 @@
 	layer = 2.2
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -2374,7 +2321,6 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -2474,7 +2420,6 @@
 	},
 /obj/item/clothing/head/welding,
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering/ce)
@@ -2488,7 +2433,6 @@
 	},
 /obj/item/tool/stamp/ce,
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering/ce)
@@ -2501,7 +2445,6 @@
 /obj/item/tool/pen,
 /obj/item/storage/briefcase/inflatable,
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering/ce)
@@ -2514,7 +2457,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering/ce)
@@ -2525,7 +2467,6 @@
 	icon_state = "1-2"
 	},
 /turf/closed/shuttle{
-	tag = "icon-wall3 (EAST)";
 	icon_state = "wall3";
 	dir = 4
 	},
@@ -2684,7 +2625,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/west)
@@ -2722,7 +2662,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/west)
@@ -2750,7 +2689,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/west)
@@ -2785,7 +2723,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/west)
@@ -2838,7 +2775,6 @@
 	layer = 2
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/west)
@@ -2892,7 +2828,6 @@
 	layer = 2
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -2934,7 +2869,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -2975,7 +2909,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -3209,20 +3142,17 @@
 	},
 /obj/structure/closet/secure_closet/engineering_chief,
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering/ce)
 "agV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering/ce)
 "agW" = (
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering/ce)
@@ -3240,7 +3170,6 @@
 	pixel_x = 30
 	},
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering/ce)
@@ -3255,7 +3184,6 @@
 "agZ" = (
 /obj/machinery/pipedispenser,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	tag = "icon-intact (NORTHEAST)";
 	icon_state = "intact";
 	dir = 5
 	},
@@ -3264,8 +3192,7 @@
 "aha" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10;
-	icon_state = "intact";
-	tag = "icon-intact (NORTHWEST)"
+	icon_state = "intact"
 	},
 /turf/open/floor,
 /area/sulaco/engineering/atmos)
@@ -3365,7 +3292,6 @@
 	dir = 4
 	},
 /turf/closed/shuttle{
-	tag = "icon-wall3 (EAST)";
 	icon_state = "wall3";
 	dir = 4
 	},
@@ -3435,7 +3361,6 @@
 "ahv" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/west)
@@ -3522,7 +3447,6 @@
 	opacity = 0
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -3550,7 +3474,6 @@
 	opacity = 0
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -3573,7 +3496,6 @@
 	opacity = 0
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -3949,7 +3871,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/machinery/bodyscanner,
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/west)
@@ -3967,7 +3888,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -3986,7 +3906,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -4012,14 +3931,12 @@
 "aix" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
 "aiy" = (
 /obj/structure/closet/walllocker/hydrant,
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -4546,7 +4463,6 @@
 	dir = 4
 	},
 /turf/closed/shuttle{
-	tag = "icon-wall3 (EAST)";
 	icon_state = "wall3";
 	dir = 4
 	},
@@ -4632,14 +4548,12 @@
 	},
 /obj/machinery/iv_drip,
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/west)
 "ajE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/west)
@@ -4697,7 +4611,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -4716,7 +4629,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -4734,7 +4646,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -5023,7 +4934,6 @@
 	dir = 9
 	},
 /turf/closed/shuttle{
-	tag = "icon-wall3 (EAST)";
 	icon_state = "wall3";
 	dir = 4
 	},
@@ -5155,7 +5065,6 @@
 	layer = 2
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/west)
@@ -5172,7 +5081,6 @@
 "akF" = (
 /obj/machinery/atmospherics/pipe/manifold4w/green/hidden,
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/west)
@@ -5223,7 +5131,6 @@
 	layer = 2
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -5245,7 +5152,6 @@
 	layer = 2
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -5268,7 +5174,6 @@
 	layer = 2
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -5293,7 +5198,6 @@
 	layer = 2
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -5586,7 +5490,6 @@
 "alw" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	tag = "icon-intact (NORTHWEST)";
 	icon_state = "intact";
 	dir = 9
 	},
@@ -5713,7 +5616,6 @@
 	opacity = 0
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/west)
@@ -5728,7 +5630,6 @@
 "alK" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/hidden,
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/west)
@@ -5749,7 +5650,6 @@
 	density = 0
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/west)
@@ -5802,7 +5702,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -5844,7 +5743,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -5863,7 +5761,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -5879,7 +5776,6 @@
 "alW" = (
 /obj/machinery/vending/MarineMed,
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -6489,7 +6385,6 @@
 	opacity = 0
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -6516,7 +6411,6 @@
 	opacity = 0
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay)
@@ -6964,7 +6858,6 @@
 "anU" = (
 /obj/structure/sign/prop1,
 /turf/closed/shuttle{
-	tag = "icon-wall3 (EAST)";
 	icon_state = "wall3";
 	dir = 4
 	},
@@ -6980,7 +6873,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whiteredfull";
 	icon_state = "whiteredfull";
 	dir = 2
 	},
@@ -6993,7 +6885,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-whiteredfull";
 	icon_state = "whiteredfull";
 	dir = 2
 	},
@@ -7026,7 +6917,6 @@
 /obj/item/ammo_magazine/smg/m39,
 /obj/item/ammo_magazine/smg/m39,
 /turf/open/floor{
-	tag = "icon-whiteredfull";
 	icon_state = "whiteredfull";
 	dir = 2
 	},
@@ -7416,7 +7306,6 @@
 "aoY" = (
 /obj/item/tool/hand_labeler,
 /turf/open/floor{
-	tag = "icon-platebot";
 	icon_state = "platebot"
 	},
 /area/sulaco/cargo)
@@ -7425,12 +7314,10 @@
 /area/sulaco/cargo/office)
 "apa" = (
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (EAST)";
 	icon_state = "bulb1";
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-platebot";
 	icon_state = "platebot"
 	},
 /area/sulaco/cargo/office)
@@ -7532,7 +7419,6 @@
 	},
 /obj/structure/table,
 /turf/open/floor{
-	tag = "icon-whitered (NORTHWEST)";
 	icon_state = "whitered";
 	dir = 9
 	},
@@ -7541,7 +7427,6 @@
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
 /turf/open/floor{
-	tag = "icon-whitered (NORTH)";
 	icon_state = "whitered";
 	dir = 1
 	},
@@ -7549,7 +7434,6 @@
 "app" = (
 /obj/machinery/alarm,
 /turf/open/floor{
-	tag = "icon-whitered (NORTH)";
 	icon_state = "whitered";
 	dir = 1
 	},
@@ -7562,7 +7446,6 @@
 	pixel_y = 28
 	},
 /turf/open/floor{
-	tag = "icon-whitered (NORTH)";
 	icon_state = "whitered";
 	dir = 1
 	},
@@ -7573,7 +7456,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-whitered (NORTH)";
 	icon_state = "whitered";
 	dir = 1
 	},
@@ -7588,7 +7470,6 @@
 	req_one_access_txt = "0"
 	},
 /turf/open/floor{
-	tag = "icon-rampbottom (WEST)";
 	icon_state = "rampbottom";
 	dir = 8
 	},
@@ -7596,21 +7477,18 @@
 "apt" = (
 /obj/machinery/status_display,
 /turf/open/floor{
-	tag = "icon-whitered (NORTH)";
 	icon_state = "whitered";
 	dir = 1
 	},
 /area/sulaco/bridge)
 "apu" = (
 /turf/open/floor{
-	tag = "icon-whitered (NORTH)";
 	icon_state = "whitered";
 	dir = 1
 	},
 /area/sulaco/bridge)
 "apv" = (
 /turf/open/floor{
-	tag = "icon-whitered (NORTHEAST)";
 	icon_state = "whitered";
 	dir = 5
 	},
@@ -7739,8 +7617,7 @@
 "apH" = (
 /turf/open/floor{
 	dir = 4;
-	icon_state = "loadingarea";
-	tag = "loading"
+	icon_state = "loadingarea"
 	},
 /area/sulaco/hallway/central_hall2)
 "apI" = (
@@ -8070,7 +7947,6 @@
 	dir = 8
 	},
 /obj/machinery/light/small{
-	tag = "icon-bulb1 (EAST)";
 	icon_state = "bulb1";
 	dir = 4
 	},
@@ -8082,7 +7958,6 @@
 	},
 /obj/structure/closet/crate/internals,
 /turf/open/floor{
-	tag = "icon-platebot";
 	icon_state = "platebot"
 	},
 /area/sulaco/cargo)
@@ -8103,7 +7978,6 @@
 "aqu" = (
 /obj/structure/closet/crate/freezer/rations,
 /turf/open/floor{
-	tag = "icon-platebot";
 	icon_state = "platebot"
 	},
 /area/sulaco/cargo)
@@ -8247,7 +8121,6 @@
 	},
 /obj/structure/table,
 /turf/open/floor{
-	tag = "icon-whitered (NORTHWEST)";
 	icon_state = "whitered";
 	dir = 9
 	},
@@ -8260,7 +8133,6 @@
 	layer = 2.1
 	},
 /turf/open/floor{
-	tag = "icon-whiteredcorner (NORTH)";
 	icon_state = "whiteredcorner";
 	dir = 1
 	},
@@ -8310,7 +8182,6 @@
 	layer = 2
 	},
 /turf/open/floor{
-	tag = "icon-rampbottom (WEST)";
 	icon_state = "rampbottom";
 	dir = 8
 	},
@@ -8345,7 +8216,6 @@
 	pixel_y = 30
 	},
 /turf/open/floor{
-	tag = "icon-whiteredcorner (EAST)";
 	icon_state = "whiteredcorner";
 	dir = 4
 	},
@@ -8355,7 +8225,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitered (NORTHEAST)";
 	icon_state = "whitered";
 	dir = 5
 	},
@@ -8740,7 +8609,6 @@
 "arI" = (
 /obj/structure/closet/crate/internals,
 /turf/open/floor{
-	tag = "icon-platebot";
 	icon_state = "platebot"
 	},
 /area/sulaco/cargo)
@@ -8759,7 +8627,6 @@
 "arL" = (
 /obj/structure/closet/crate/medical,
 /turf/open/floor{
-	tag = "icon-platebot";
 	icon_state = "platebot"
 	},
 /area/sulaco/cargo)
@@ -8960,11 +8827,9 @@
 /obj/structure/table,
 /obj/structure/flora/pottedplant{
 	icon_state = "plant-15";
-	pixel_y = 10;
-	tag = "icon-plant-15"
+	pixel_y = 10
 	},
 /turf/open/floor{
-	tag = "icon-whitered (NORTHWEST)";
 	icon_state = "whitered";
 	dir = 9
 	},
@@ -8975,14 +8840,12 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-whitered (NORTH)";
 	icon_state = "whitered";
 	dir = 1
 	},
 /area/sulaco/bridge)
 "asb" = (
 /turf/open/floor{
-	tag = "icon-whiteredcorner (NORTH)";
 	icon_state = "whiteredcorner";
 	dir = 1
 	},
@@ -9028,7 +8891,6 @@
 	},
 /obj/machinery/computer/security,
 /turf/open/floor{
-	tag = "icon-whiteredfull";
 	icon_state = "whiteredfull";
 	dir = 2
 	},
@@ -9046,7 +8908,6 @@
 	icon_state = "tube1"
 	},
 /turf/open/floor{
-	tag = "icon-whitered (EAST)";
 	icon_state = "whitered";
 	dir = 4
 	},
@@ -9613,7 +9474,6 @@
 	},
 /obj/machinery/computer/station_alert,
 /turf/open/floor{
-	tag = "icon-whiteredfull";
 	icon_state = "whiteredfull";
 	dir = 2
 	},
@@ -9642,7 +9502,6 @@
 	},
 /obj/machinery/computer/security,
 /turf/open/floor{
-	tag = "icon-whitegreenfull (NORTHEAST)";
 	icon_state = "whitegreenfull";
 	dir = 5
 	},
@@ -9655,7 +9514,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull (NORTHEAST)";
 	icon_state = "whitebluefull";
 	dir = 5
 	},
@@ -9678,7 +9536,6 @@
 	req_access_txt = "19"
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull (NORTHEAST)";
 	icon_state = "whitebluefull";
 	dir = 5
 	},
@@ -9692,7 +9549,6 @@
 	},
 /obj/machinery/computer/crew,
 /turf/open/floor{
-	tag = "icon-whitebluefull (NORTHEAST)";
 	icon_state = "whitebluefull";
 	dir = 5
 	},
@@ -9701,7 +9557,6 @@
 /obj/machinery/computer/camera_advanced/overwatch,
 /obj/structure/window/reinforced,
 /turf/open/floor{
-	tag = "icon-whiteredfull";
 	icon_state = "whiteredfull";
 	dir = 2
 	},
@@ -9772,7 +9627,6 @@
 	layer = 2
 	},
 /turf/open/floor{
-	tag = "icon-whitered (EAST)";
 	icon_state = "whitered";
 	dir = 4
 	},
@@ -10487,8 +10341,7 @@
 	},
 /turf/open/floor{
 	dir = 4;
-	icon_state = "loadingarea";
-	tag = "loading"
+	icon_state = "loadingarea"
 	},
 /area/sulaco/hallway/central_hall3)
 "auE" = (
@@ -10591,7 +10444,6 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering/smes)
@@ -10698,7 +10550,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whiteredfull";
 	icon_state = "whiteredfull";
 	dir = 2
 	},
@@ -10734,7 +10585,6 @@
 	},
 /obj/machinery/computer/camera_advanced/overwatch,
 /turf/open/floor{
-	tag = "icon-whitegreenfull (NORTHEAST)";
 	icon_state = "whitegreenfull";
 	dir = 5
 	},
@@ -10745,7 +10595,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull (NORTHEAST)";
 	icon_state = "whitebluefull";
 	dir = 5
 	},
@@ -10769,14 +10618,12 @@
 	req_access_txt = "19"
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull (NORTHEAST)";
 	icon_state = "whitebluefull";
 	dir = 5
 	},
 /area/sulaco/bridge)
 "ava" = (
 /turf/open/floor{
-	tag = "icon-whitebluefull (NORTHEAST)";
 	icon_state = "whitebluefull";
 	dir = 5
 	},
@@ -10788,7 +10635,6 @@
 	req_one_access_txt = "0"
 	},
 /turf/open/floor{
-	tag = "icon-rampbottom (WEST)";
 	icon_state = "rampbottom";
 	dir = 8
 	},
@@ -10834,7 +10680,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whitered (EAST)";
 	icon_state = "whitered";
 	dir = 4
 	},
@@ -11347,13 +11192,11 @@
 	pixel_y = 30
 	},
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering)
 "awe" = (
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering)
@@ -11376,7 +11219,6 @@
 	req_one_access_txt = "0"
 	},
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering)
@@ -11390,7 +11232,6 @@
 /obj/machinery/camera/autoname,
 /obj/item/storage/firstaid/toxin,
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering)
@@ -11439,7 +11280,6 @@
 "awj" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/structure/cable{
-	tag = "icon-4-8";
 	icon_state = "4-8";
 	d2 = 8
 	},
@@ -11515,7 +11355,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whiteredfull";
 	icon_state = "whiteredfull";
 	dir = 2
 	},
@@ -11546,7 +11385,6 @@
 	dir = 10
 	},
 /turf/open/floor{
-	tag = "icon-whitegreenfull (NORTHEAST)";
 	icon_state = "whitegreenfull";
 	dir = 5
 	},
@@ -11557,7 +11395,6 @@
 	},
 /obj/structure/window/reinforced,
 /turf/open/floor{
-	tag = "icon-whitebluefull (NORTHEAST)";
 	icon_state = "whitebluefull";
 	dir = 5
 	},
@@ -11566,7 +11403,6 @@
 /obj/structure/window/reinforced,
 /obj/structure/table,
 /turf/open/floor{
-	tag = "icon-whitebluefull (NORTHEAST)";
 	icon_state = "whitebluefull";
 	dir = 5
 	},
@@ -11578,7 +11414,6 @@
 /obj/structure/window/reinforced,
 /obj/machinery/computer/security,
 /turf/open/floor{
-	tag = "icon-whitebluefull (NORTHEAST)";
 	icon_state = "whitebluefull";
 	dir = 5
 	},
@@ -11589,7 +11424,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-whiteredfull";
 	icon_state = "whiteredfull";
 	dir = 2
 	},
@@ -11658,7 +11492,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whitered (EAST)";
 	icon_state = "whitered";
 	dir = 4
 	},
@@ -12841,7 +12674,6 @@
 	pixel_y = 3
 	},
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering)
@@ -12854,7 +12686,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering)
@@ -12867,7 +12698,6 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering)
@@ -12897,8 +12727,7 @@
 "ayh" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 6;
-	icon_state = "intact";
-	tag = "icon-intact (NORTHEAST)"
+	icon_state = "intact"
 	},
 /obj/structure/rack,
 /obj/item/tool/wrench,
@@ -12972,8 +12801,7 @@
 	initialize_directions = 2;
 	on = 1;
 	pressure_checks = 0;
-	pump_direction = 0;
-	tag = "icon-map_vent_in (WEST)"
+	pump_direction = 0
 	},
 /turf/open/floor/plating/airless,
 /area/sulaco/engineering/engine)
@@ -13012,11 +12840,9 @@
 /obj/structure/table,
 /obj/structure/flora/pottedplant{
 	icon_state = "plant-23";
-	pixel_y = 12;
-	tag = "icon-plant-23"
+	pixel_y = 12
 	},
 /turf/open/floor{
-	tag = "icon-whitered (SOUTHWEST)";
 	icon_state = "whitered";
 	dir = 10
 	},
@@ -13025,14 +12851,12 @@
 /obj/structure/table,
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-whitered";
 	icon_state = "whitered";
 	dir = 2
 	},
 /area/sulaco/bridge)
 "ays" = (
 /turf/open/floor{
-	tag = "icon-whiteredcorner (WEST)";
 	icon_state = "whiteredcorner";
 	dir = 8
 	},
@@ -13063,7 +12887,6 @@
 /obj/structure/window/reinforced,
 /obj/machinery/computer/security,
 /turf/open/floor{
-	tag = "icon-whiteredfull";
 	icon_state = "whiteredfull";
 	dir = 2
 	},
@@ -13468,7 +13291,6 @@
 	amount = 50
 	},
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering)
@@ -13481,7 +13303,6 @@
 	sensors = list("core_sensor" = "Tank")
 	},
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering)
@@ -13515,7 +13336,6 @@
 	req_access_txt = "7"
 	},
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering)
@@ -13525,7 +13345,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering)
@@ -13614,7 +13433,6 @@
 	},
 /obj/item/storage/donut_box,
 /turf/open/floor{
-	tag = "icon-whitered (SOUTHWEST)";
 	icon_state = "whitered";
 	dir = 10
 	},
@@ -13653,7 +13471,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-rampbottom (WEST)";
 	icon_state = "rampbottom";
 	dir = 8
 	},
@@ -13669,14 +13486,12 @@
 /area/sulaco/bridge)
 "azE" = (
 /turf/open/floor{
-	tag = "icon-whiteredcorner (NORTHEAST)";
 	icon_state = "whiteredcorner";
 	dir = 5
 	},
 /area/sulaco/bridge)
 "azF" = (
 /turf/open/floor{
-	tag = "icon-whitered (SOUTHEAST)";
 	icon_state = "whitered";
 	dir = 6
 	},
@@ -14199,7 +14014,6 @@
 	layer = 2
 	},
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering)
@@ -14208,7 +14022,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering)
@@ -14223,7 +14036,6 @@
 /obj/item/book/manual/supermatter_engine,
 /obj/item/clothing/glasses/meson,
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering)
@@ -14251,8 +14063,7 @@
 "aAI" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 6;
-	icon_state = "intact";
-	tag = "icon-intact (NORTHEAST)"
+	icon_state = "intact"
 	},
 /turf/open/floor/plating,
 /area/sulaco/engineering/engine)
@@ -14297,7 +14108,6 @@
 "aAN" = (
 /obj/structure/table,
 /turf/open/floor{
-	tag = "icon-whitered (SOUTHWEST)";
 	icon_state = "whitered";
 	dir = 10
 	},
@@ -14313,7 +14123,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-whitered";
 	icon_state = "whitered";
 	dir = 2
 	},
@@ -14325,7 +14134,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor{
-	tag = "icon-whitered";
 	icon_state = "whitered";
 	dir = 2
 	},
@@ -14340,7 +14148,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-whitered";
 	icon_state = "whitered";
 	dir = 2
 	},
@@ -14357,7 +14164,6 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor{
-	tag = "icon-rampbottom (WEST)";
 	icon_state = "rampbottom";
 	dir = 8
 	},
@@ -14371,14 +14177,12 @@
 	},
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-whitered";
 	icon_state = "whitered";
 	dir = 2
 	},
 /area/sulaco/bridge)
 "aAU" = (
 /turf/open/floor{
-	tag = "icon-whitered";
 	icon_state = "whitered";
 	dir = 2
 	},
@@ -14390,7 +14194,6 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor{
-	tag = "icon-whitered";
 	icon_state = "whitered";
 	dir = 2
 	},
@@ -14402,7 +14205,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor{
-	tag = "icon-whitered (SOUTHEAST)";
 	icon_state = "whitered";
 	dir = 6
 	},
@@ -14628,8 +14430,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor{
 	dir = 4;
-	icon_state = "loadingarea";
-	tag = "loading"
+	icon_state = "loadingarea"
 	},
 /area/sulaco/hallway/central_hall2)
 "aBp" = (
@@ -14935,7 +14736,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering)
@@ -14944,7 +14744,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering)
@@ -14953,7 +14752,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering)
@@ -14962,7 +14760,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering)
@@ -14971,7 +14768,6 @@
 	pixel_y = 32
 	},
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering)
@@ -15005,7 +14801,6 @@
 /area/sulaco/engineering/engine)
 "aCg" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	tag = "icon-intact (NORTHEAST)";
 	icon_state = "intact";
 	dir = 5
 	},
@@ -15014,8 +14809,7 @@
 "aCh" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10;
-	icon_state = "intact";
-	tag = "icon-intact (NORTHWEST)"
+	icon_state = "intact"
 	},
 /turf/open/floor/plating,
 /area/sulaco/engineering/engine)
@@ -15074,7 +14868,6 @@
 /obj/structure/window/reinforced,
 /obj/machinery/door/window/northleft,
 /turf/open/floor{
-	tag = "icon-bcircuit";
 	icon_state = "bcircuit";
 	dir = 2
 	},
@@ -15087,7 +14880,6 @@
 /obj/structure/window/reinforced,
 /obj/machinery/door/window/northright,
 /turf/open/floor{
-	tag = "icon-bcircuit";
 	icon_state = "bcircuit";
 	dir = 2
 	},
@@ -15127,7 +14919,6 @@
 	},
 /obj/machinery/door/window/northright,
 /turf/open/floor{
-	tag = "icon-bcircuit";
 	icon_state = "bcircuit";
 	dir = 2
 	},
@@ -15143,7 +14934,6 @@
 	},
 /obj/structure/window/reinforced,
 /turf/open/floor{
-	tag = "icon-whiteredfull";
 	icon_state = "whiteredfull";
 	dir = 2
 	},
@@ -15154,7 +14944,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-whiteredfull";
 	icon_state = "whiteredfull";
 	dir = 2
 	},
@@ -15168,7 +14957,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-whiteredfull";
 	icon_state = "whiteredfull";
 	dir = 2
 	},
@@ -15497,7 +15285,6 @@
 "aDc" = (
 /obj/structure/closet/radiation,
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering)
@@ -15506,14 +15293,12 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering)
 "aDe" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering)
@@ -15527,7 +15312,6 @@
 	specialfunctions = 4
 	},
 /turf/open/floor{
-	tag = "icon-yellowfull";
 	icon_state = "yellowfull"
 	},
 /area/sulaco/engineering)
@@ -15777,7 +15561,6 @@
 	req_access_txt = "0"
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -16132,7 +15915,6 @@
 "aEq" = (
 /obj/machinery/vending/security,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -16143,7 +15925,6 @@
 /obj/item/flash,
 /obj/item/clothing/glasses/sunglasses,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -16154,7 +15935,6 @@
 /obj/item/reagent_container/spray/pepper,
 /obj/item/clothing/glasses/sunglasses,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -16164,7 +15944,6 @@
 	},
 /obj/structure/closet/walllocker/hydrant,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -16173,7 +15952,6 @@
 /obj/item/storage/box/bodybags,
 /obj/item/storage/box/handcuffs,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -16181,7 +15959,6 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /obj/machinery/vending/security,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -16190,7 +15967,6 @@
 /area/sulaco/brig)
 "aEx" = (
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -16208,7 +15984,6 @@
 	req_access_txt = "3"
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -16217,14 +15992,12 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
 "aEA" = (
 /obj/machinery/computer/secure_data,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -16234,7 +16007,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/item/hailer,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -16247,7 +16019,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/item/hailer,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -16263,7 +16034,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -16789,7 +16559,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -16799,7 +16568,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -16812,14 +16580,12 @@
 	req_access_txt = "3"
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
 "aFL" = (
 /obj/machinery/computer/security,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -16833,14 +16599,12 @@
 /obj/item/weapon/baton,
 /obj/item/hailer,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
 "aFN" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -16862,7 +16626,6 @@
 	req_access_txt = "3"
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -17019,8 +16782,7 @@
 	icon_state = "door_closed";
 	name = "Delta Squad Prep Room";
 	req_access_txt = "9";
-	req_one_access_txt = "2;18";
-	tag = "icon-door_closed (WEST)"
+	req_one_access_txt = "2;18"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 2
@@ -17241,7 +17003,6 @@
 /obj/item/paper_bin,
 /obj/item/tool/pen,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -17249,7 +17010,6 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /obj/structure/filingcabinet/security,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -17260,7 +17020,6 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -17276,7 +17035,6 @@
 	req_access_txt = "3"
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -17288,7 +17046,6 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
 	icon_state = "rwindow";
 	dir = 1
 	},
@@ -17303,7 +17060,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -17333,7 +17089,6 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -17349,7 +17104,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -17372,7 +17126,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -17646,7 +17399,6 @@
 /area/sulaco/engineering/engine)
 "aHv" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	tag = "icon-intact (NORTHWEST)";
 	icon_state = "intact";
 	dir = 9
 	},
@@ -17681,7 +17433,6 @@
 "aHB" = (
 /obj/machinery/computer/forensic_scanning,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -17690,7 +17441,6 @@
 	dir = 5
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -17705,7 +17455,6 @@
 	pixel_y = 30
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -17714,7 +17463,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -17729,7 +17477,6 @@
 /obj/structure/cable/yellow,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
 	icon_state = "rwindow";
 	dir = 1
 	},
@@ -17748,7 +17495,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -17760,7 +17506,6 @@
 /obj/item/weapon/baton,
 /obj/item/hailer,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -17775,7 +17520,6 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -17789,7 +17533,6 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -17801,7 +17544,6 @@
 	name = "Military Police"
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -17816,7 +17558,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -18130,14 +17871,12 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
 "aIB" = (
 /obj/structure/bed/chair/office/dark,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -18162,7 +17901,6 @@
 "aID" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -18177,14 +17915,12 @@
 	pixel_y = 5
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
 "aIF" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -18193,7 +17929,6 @@
 	name = "Military Police"
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -18269,8 +18004,7 @@
 	icon_state = "door_closed";
 	name = "Charlie Squad Prep Room";
 	req_access_txt = "9";
-	req_one_access_txt = "2;17";
-	tag = "icon-door_closed (WEST)"
+	req_one_access_txt = "2;17"
 	},
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -18337,8 +18071,7 @@
 	icon_state = "door_closed";
 	name = "Bravo Squad Prep Room";
 	req_access_txt = "9";
-	req_one_access_txt = "2;16";
-	tag = "icon-door_closed (WEST)"
+	req_one_access_txt = "2;16"
 	},
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -18409,8 +18142,7 @@
 	icon_state = "door_closed";
 	name = "Alpha Squad Prep Room";
 	req_access_txt = "9";
-	req_one_access_txt = "2;15";
-	tag = "icon-door_closed (WEST)"
+	req_one_access_txt = "2;15"
 	},
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -18502,7 +18234,6 @@
 	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
-	tag = "icon-pipe-t (EAST)";
 	icon_state = "pipe-t";
 	dir = 4
 	},
@@ -18775,7 +18506,6 @@
 /obj/item/ammo_magazine/shotgun/buckshot,
 /obj/item/weapon/gun/shotgun/combat,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -18785,7 +18515,6 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
 	icon_state = "rwindow";
 	dir = 1
 	},
@@ -18808,7 +18537,6 @@
 /obj/item/folder/red,
 /obj/item/paper_bin,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -18816,7 +18544,6 @@
 /obj/structure/table/reinforced,
 /obj/item/book/manual/marine_law,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -18825,7 +18552,6 @@
 /obj/item/book/manual/marine_law,
 /obj/item/tool/taperoll/police,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -18837,7 +18563,6 @@
 /obj/item/tool/pen,
 /obj/item/folder/red,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -18846,7 +18571,6 @@
 	dir = 6
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -18856,7 +18580,6 @@
 	layer = 2
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -18875,7 +18598,6 @@
 	req_access_txt = "3"
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -18886,7 +18608,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -18895,7 +18616,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -18913,7 +18633,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -19112,7 +18831,6 @@
 	req_access_txt = "3"
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -19120,7 +18838,6 @@
 /obj/structure/table/reinforced,
 /obj/item/tool/pen,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -19129,7 +18846,6 @@
 /obj/item/clipboard,
 /obj/item/taperecorder,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -19141,7 +18857,6 @@
 /obj/item/folder/red,
 /obj/item/tool/taperoll/police,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -19155,7 +18870,6 @@
 	layer = 2
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -19164,7 +18878,6 @@
 	dir = 9
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -19197,7 +18910,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -19209,7 +18921,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -19395,7 +19106,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -19417,7 +19127,6 @@
 "aKW" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
 	icon_state = "rwindow";
 	dir = 1
 	},
@@ -19440,7 +19149,6 @@
 "aKX" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
 	icon_state = "rwindow";
 	dir = 1
 	},
@@ -19463,7 +19171,6 @@
 "aKY" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
 	icon_state = "rwindow";
 	dir = 1
 	},
@@ -19502,7 +19209,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -19513,7 +19219,6 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
 	icon_state = "rwindow";
 	dir = 1
 	},
@@ -19536,7 +19241,6 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
 	icon_state = "rwindow";
 	dir = 1
 	},
@@ -19737,7 +19441,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -19911,14 +19614,12 @@
 	},
 /obj/structure/closet/walllocker/hydrant,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
 "aLT" = (
 /obj/machinery/light,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -19927,7 +19628,6 @@
 	dir = 5
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -19938,7 +19638,6 @@
 	layer = 2
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -19950,7 +19649,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -20168,7 +19866,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -20179,7 +19876,6 @@
 /obj/machinery/camera/autoname,
 /obj/item/book/manual/marine_law,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -20189,7 +19885,6 @@
 	req_access_txt = "3"
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -20212,7 +19907,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -20222,7 +19916,6 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	tag = "icon-rwindow (NORTH)";
 	icon_state = "rwindow";
 	dir = 1
 	},
@@ -20262,7 +19955,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -20286,7 +19978,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -20310,7 +20001,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -20334,7 +20024,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -20360,7 +20049,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -20486,7 +20174,6 @@
 	pixel_x = -30
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -20508,7 +20195,6 @@
 	opacity = 0
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -20520,7 +20206,6 @@
 	pixel_y = 30
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -20532,7 +20217,6 @@
 	pixel_x = 30
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -20544,7 +20228,6 @@
 	pixel_x = 30
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -20556,7 +20239,6 @@
 	pixel_x = 30
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -20568,7 +20250,6 @@
 	pixel_x = 30
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -20580,7 +20261,6 @@
 	pixel_x = 30
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -20590,7 +20270,6 @@
 	dir = 5
 	},
 /turf/open/floor{
-	tag = "icon-floorgrime (EAST)";
 	icon_state = "floorgrime";
 	dir = 4
 	},
@@ -20604,7 +20283,6 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-floorgrime (EAST)";
 	icon_state = "floorgrime";
 	dir = 4
 	},
@@ -20614,7 +20292,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-floorgrime (EAST)";
 	icon_state = "floorgrime";
 	dir = 4
 	},
@@ -20629,7 +20306,6 @@
 	},
 /obj/effect/decal/cleanable/cobweb2,
 /turf/open/floor{
-	tag = "icon-floorgrime (EAST)";
 	icon_state = "floorgrime";
 	dir = 4
 	},
@@ -20767,14 +20443,12 @@
 "aNJ" = (
 /obj/structure/bed,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
 "aNK" = (
 /obj/structure/closet/secure_closet/brig,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -20810,7 +20484,6 @@
 	pixel_y = -4
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -20819,7 +20492,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -20827,7 +20499,6 @@
 /obj/machinery/light/small,
 /obj/structure/bed,
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -20837,7 +20508,6 @@
 	name = "Cell 1"
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -20847,7 +20517,6 @@
 	name = "Cell 2"
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -20857,7 +20526,6 @@
 	name = "Cell 3"
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -20867,7 +20535,6 @@
 	name = "Cell 4"
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
@@ -20877,14 +20544,12 @@
 	name = "Cell 5"
 	},
 /turf/open/floor{
-	tag = "icon-floor4";
 	icon_state = "floor4"
 	},
 /area/sulaco/brig)
 "aNT" = (
 /obj/structure/window/reinforced,
 /turf/open/floor{
-	tag = "icon-floorgrimecaution";
 	icon_state = "floorgrimecaution";
 	dir = 2
 	},
@@ -20895,7 +20560,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor{
-	tag = "icon-floorgrimecaution";
 	icon_state = "floorgrimecaution";
 	dir = 2
 	},
@@ -20910,7 +20574,6 @@
 	req_access_txt = "1"
 	},
 /turf/open/floor{
-	tag = "icon-floorgrimecaution";
 	icon_state = "floorgrimecaution";
 	dir = 2
 	},
@@ -21178,7 +20841,6 @@
 /area/sulaco/command/eva)
 "aOw" = (
 /turf/open/floor{
-	tag = "icon-podhatch (NORTHWEST)";
 	icon_state = "podhatch";
 	dir = 9
 	},
@@ -21188,14 +20850,12 @@
 	dir = 1
 	},
 /turf/open/floor{
-	tag = "icon-podhatch (NORTH)";
 	icon_state = "podhatch";
 	dir = 1
 	},
 /area/sulaco/brig)
 "aOy" = (
 /turf/open/floor{
-	tag = "icon-podhatch (NORTHEAST)";
 	icon_state = "podhatch";
 	dir = 5
 	},
@@ -21311,7 +20971,6 @@
 	dir = 8
 	},
 /turf/open/floor{
-	tag = "icon-podhatch (WEST)";
 	icon_state = "podhatch";
 	dir = 8
 	},
@@ -21320,7 +20979,6 @@
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor{
-	tag = "icon-podhatchfloor";
 	icon_state = "podhatchfloor";
 	dir = 2
 	},
@@ -21330,7 +20988,6 @@
 	dir = 4
 	},
 /turf/open/floor{
-	tag = "icon-podhatch (EAST)";
 	icon_state = "podhatch";
 	dir = 4
 	},
@@ -21413,14 +21070,12 @@
 	pixel_y = -32
 	},
 /turf/open/floor{
-	tag = "icon-podhatch (SOUTHWEST)";
 	icon_state = "podhatch";
 	dir = 10
 	},
 /area/sulaco/brig)
 "aOZ" = (
 /turf/open/floor{
-	tag = "icon-podhatch";
 	icon_state = "podhatch";
 	dir = 2
 	},
@@ -21430,7 +21085,6 @@
 	pixel_y = -32
 	},
 /turf/open/floor{
-	tag = "icon-podhatch (SOUTHEAST)";
 	icon_state = "podhatch";
 	dir = 6
 	},
@@ -21723,7 +21377,6 @@
 /area/sulaco/marine/alpha)
 "aPK" = (
 /turf/closed/shuttle{
-	tag = "icon-wall_space";
 	icon_state = "wall_space";
 	dir = 2
 	},
@@ -21747,14 +21400,12 @@
 /area/shuttle/escape_pod1/station)
 "aPM" = (
 /turf/closed/shuttle{
-	tag = "icon-wall_space (EAST)";
 	icon_state = "wall_space";
 	dir = 4
 	},
 /area/shuttle/escape_pod1/station)
 "aPN" = (
 /turf/closed/shuttle{
-	tag = "icon-wall_space";
 	icon_state = "wall_space";
 	dir = 2
 	},
@@ -21778,14 +21429,12 @@
 /area/shuttle/escape_pod2/station)
 "aPP" = (
 /turf/closed/shuttle{
-	tag = "icon-wall_space (EAST)";
 	icon_state = "wall_space";
 	dir = 4
 	},
 /area/shuttle/escape_pod2/station)
 "aPQ" = (
 /turf/closed/shuttle{
-	tag = "icon-wall_space";
 	icon_state = "wall_space";
 	dir = 2
 	},
@@ -21809,7 +21458,6 @@
 /area/shuttle/escape_pod3/station)
 "aPS" = (
 /turf/closed/shuttle{
-	tag = "icon-wall_space (EAST)";
 	icon_state = "wall_space";
 	dir = 4
 	},
@@ -21910,20 +21558,17 @@
 "aQk" = (
 /turf/open/floor/plating,
 /turf/closed/shuttle/dropship{
-	tag = "icon-diagrasputin (EAST)";
 	icon_state = "diagrasputin";
 	dir = 4
 	},
 /area/shuttle/drop2/sulaco)
 "aQl" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin14";
 	icon_state = "rasputin14"
 	},
 /area/shuttle/drop2/sulaco)
 "aQm" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin8";
 	icon_state = "rasputin8"
 	},
 /area/shuttle/drop2/sulaco)
@@ -21944,20 +21589,17 @@
 	opacity = 0
 	},
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin14";
 	icon_state = "rasputin14"
 	},
 /area/shuttle/drop2/sulaco)
 "aQo" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin4";
 	icon_state = "rasputin4"
 	},
 /area/shuttle/drop2/sulaco)
 "aQp" = (
 /turf/open/floor/plating,
 /turf/closed/shuttle/dropship{
-	tag = "icon-diagrasputin (NORTH)";
 	icon_state = "diagrasputin";
 	dir = 1
 	},
@@ -22033,13 +21675,11 @@
 /area/sulaco/morgue)
 "aQB" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin5";
 	icon_state = "rasputin5"
 	},
 /area/shuttle/drop2/sulaco)
 "aQC" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin9";
 	icon_state = "rasputin9"
 	},
 /area/shuttle/drop2/sulaco)
@@ -22049,13 +21689,11 @@
 	},
 /obj/structure/bed/chair/dropship/passenger,
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin14";
 	icon_state = "rasputin14"
 	},
 /area/shuttle/drop2/sulaco)
 "aQE" = (
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin3";
 	icon_state = "rasputin3"
 	},
 /area/shuttle/drop2/sulaco)
@@ -22180,41 +21818,34 @@
 /area/shuttle/drop2/sulaco)
 "aQT" = (
 /obj/structure/bed/chair/dropship/passenger{
-	tag = "icon-shuttle_chair (EAST)";
 	icon_state = "shuttle_chair";
 	dir = 4
 	},
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin14";
 	icon_state = "rasputin14"
 	},
 /area/shuttle/drop2/sulaco)
 "aQU" = (
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin6";
 	icon_state = "rasputin6"
 	},
 /area/shuttle/drop2/sulaco)
 "aQV" = (
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin13";
 	icon_state = "rasputin13"
 	},
 /area/shuttle/drop2/sulaco)
 "aQW" = (
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin7";
 	icon_state = "rasputin7"
 	},
 /area/shuttle/drop2/sulaco)
 "aQX" = (
 /obj/structure/bed/chair/dropship/passenger{
-	tag = "icon-shuttle_chair (WEST)";
 	icon_state = "shuttle_chair";
 	dir = 8
 	},
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin14";
 	icon_state = "rasputin14"
 	},
 /area/shuttle/drop2/sulaco)
@@ -22246,7 +21877,6 @@
 "aRa" = (
 /obj/machinery/vending/medical,
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/hangar)
@@ -22265,7 +21895,6 @@
 /obj/machinery/computer/operating,
 /obj/structure/closet/walllocker/emerglocker,
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/hangar)
@@ -22353,26 +21982,22 @@
 	opacity = 0
 	},
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin14";
 	icon_state = "rasputin14"
 	},
 /area/shuttle/drop2/sulaco)
 "aRp" = (
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin5";
 	icon_state = "rasputin5"
 	},
 /area/shuttle/drop2/sulaco)
 "aRq" = (
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin12";
 	icon_state = "rasputin12"
 	},
 /area/shuttle/drop2/sulaco)
 "aRr" = (
 /obj/machinery/computer/shuttle_control,
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin13";
 	icon_state = "rasputin13"
 	},
 /area/shuttle/drop2/sulaco)
@@ -22393,7 +22018,6 @@
 	opacity = 0
 	},
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin14";
 	icon_state = "rasputin14"
 	},
 /area/shuttle/drop2/sulaco)
@@ -22527,13 +22151,11 @@
 /area/sulaco/morgue)
 "aRK" = (
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin4";
 	icon_state = "rasputin4"
 	},
 /area/shuttle/drop2/sulaco)
 "aRL" = (
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin8";
 	icon_state = "rasputin8"
 	},
 /area/shuttle/drop2/sulaco)
@@ -22551,7 +22173,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/hangar)
@@ -22563,7 +22184,6 @@
 /area/sulaco/medbay/hangar)
 "aRP" = (
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/hangar)
@@ -22576,7 +22196,6 @@
 "aRR" = (
 /turf/open/floor/plating,
 /turf/closed/shuttle/dropship{
-	tag = "icon-diagrasputin (EAST)";
 	icon_state = "diagrasputin";
 	dir = 4
 	},
@@ -22607,7 +22226,6 @@
 "aRT" = (
 /turf/open/floor/plating,
 /turf/closed/shuttle/dropship{
-	tag = "icon-diagrasputin (NORTH)";
 	icon_state = "diagrasputin";
 	dir = 1
 	},
@@ -22823,7 +22441,6 @@
 	pixel_y = 32
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/research)
@@ -22848,24 +22465,20 @@
 /area/sulaco/morgue)
 "aSt" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin6";
 	icon_state = "rasputin6"
 	},
 /area/shuttle/drop2/sulaco)
 "aSu" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin10";
 	icon_state = "rasputin10"
 	},
 /area/shuttle/drop2/sulaco)
 "aSv" = (
 /obj/structure/bed/chair/dropship/passenger{
-	tag = "icon-shuttle_chair (NORTH)";
 	icon_state = "shuttle_chair";
 	dir = 1
 	},
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin14";
 	icon_state = "rasputin14"
 	},
 /area/shuttle/drop2/sulaco)
@@ -22877,12 +22490,10 @@
 	req_one_access_txt = "12;22"
 	},
 /obj/structure/bed/chair/dropship/passenger{
-	tag = "icon-shuttle_chair (NORTH)";
 	icon_state = "shuttle_chair";
 	dir = 1
 	},
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin14";
 	icon_state = "rasputin14"
 	},
 /area/shuttle/drop2/sulaco)
@@ -22894,7 +22505,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/hangar)
@@ -22920,7 +22530,6 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/hangar)
@@ -22950,7 +22559,6 @@
 "aSC" = (
 /obj/machinery/computer/shuttle_control,
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
 	},
 /area/shuttle/drop1/sulaco)
@@ -23149,7 +22757,6 @@
 	name = "Sulaco Chemist"
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/research)
@@ -23186,13 +22793,11 @@
 "aTd" = (
 /turf/open/floor/plating,
 /turf/closed/shuttle/dropship{
-	tag = "icon-diagrasputin";
 	icon_state = "diagrasputin"
 	},
 /area/shuttle/drop2/sulaco)
 "aTe" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin13";
 	icon_state = "rasputin13"
 	},
 /area/shuttle/drop2/sulaco)
@@ -23212,14 +22817,12 @@
 	icon_state = "shutter0"
 	},
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin14";
 	icon_state = "rasputin14"
 	},
 /area/shuttle/drop2/sulaco)
 "aTg" = (
 /turf/open/floor/plating,
 /turf/closed/shuttle/dropship{
-	tag = "icon-diagrasputin (WEST)";
 	icon_state = "diagrasputin";
 	dir = 8
 	},
@@ -23242,7 +22845,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/hangar)
@@ -23273,7 +22875,6 @@
 	pixel_y = 6
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/medbay/hangar)
@@ -23293,12 +22894,10 @@
 /area/shuttle/drop1/sulaco)
 "aTn" = (
 /obj/structure/bed/chair/dropship/pilot{
-	tag = "icon-pilot_chair (NORTH)";
 	icon_state = "pilot_chair";
 	dir = 1
 	},
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
 	},
 /area/shuttle/drop1/sulaco)
@@ -23418,7 +23017,6 @@
 /area/sulaco/research)
 "aTB" = (
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/research)
@@ -23469,19 +23067,16 @@
 /area/sulaco/medbay/hangar)
 "aTJ" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin_nose";
 	icon_state = "rasputin_nose"
 	},
 /area/shuttle/drop1/sulaco)
 "aTK" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin_light";
 	icon_state = "rasputin_light"
 	},
 /area/shuttle/drop1/sulaco)
 "aTL" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin8";
 	icon_state = "rasputin8"
 	},
 /area/shuttle/drop1/sulaco)
@@ -23492,19 +23087,16 @@
 	req_one_access_txt = "0"
 	},
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
 	},
 /area/shuttle/drop1/sulaco)
 "aTN" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin4";
 	icon_state = "rasputin4"
 	},
 /area/shuttle/drop1/sulaco)
 "aTO" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin10";
 	icon_state = "rasputin10"
 	},
 /area/shuttle/drop1/sulaco)
@@ -23655,47 +23247,39 @@
 /area/shuttle/drop1/sulaco)
 "aUh" = (
 /obj/structure/bed/chair/dropship/passenger{
-	tag = "icon-shuttle_chair (EAST)";
 	icon_state = "shuttle_chair";
 	dir = 4
 	},
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
 	},
 /area/shuttle/drop1/sulaco)
 "aUi" = (
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin6";
 	icon_state = "rasputin6"
 	},
 /area/shuttle/drop1/sulaco)
 "aUj" = (
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin5";
 	icon_state = "rasputin5"
 	},
 /area/shuttle/drop1/sulaco)
 "aUk" = (
 /turf/open/shuttle/dropship{
-	tag = "icon-floor8";
 	icon_state = "floor8"
 	},
 /area/shuttle/drop1/sulaco)
 "aUl" = (
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin7";
 	icon_state = "rasputin7"
 	},
 /area/shuttle/drop1/sulaco)
 "aUm" = (
 /obj/structure/bed/chair/dropship/passenger{
-	tag = "icon-shuttle_chair (WEST)";
 	icon_state = "shuttle_chair";
 	dir = 8
 	},
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
 	},
 /area/shuttle/drop1/sulaco)
@@ -23787,7 +23371,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor{
-	tag = "icon-podhatch (NORTHWEST)";
 	icon_state = "podhatch";
 	dir = 9
 	},
@@ -23806,7 +23389,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor{
-	tag = "icon-podhatch (NORTHEAST)";
 	icon_state = "podhatch";
 	dir = 5
 	},
@@ -23873,7 +23455,6 @@
 /obj/item/reagent_container/glass/beaker,
 /obj/item/reagent_container/glass/beaker/bluespace,
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/research)
@@ -23891,13 +23472,11 @@
 /area/sulaco/hangar)
 "aUI" = (
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin3";
 	icon_state = "rasputin3"
 	},
 /area/shuttle/drop1/sulaco)
 "aUJ" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin0";
 	icon_state = "rasputin0"
 	},
 /area/shuttle/drop1/sulaco)
@@ -24263,7 +23842,6 @@
 /area/sulaco/hangar)
 "aVz" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin2";
 	icon_state = "rasputin2"
 	},
 /area/shuttle/drop1/sulaco)
@@ -24421,7 +23999,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor{
-	tag = "icon-whitebluefull";
 	icon_state = "whitebluefull"
 	},
 /area/sulaco/research)
@@ -25333,13 +24910,11 @@
 /area/sulaco/hangar)
 "aXK" = (
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin4";
 	icon_state = "rasputin4"
 	},
 /area/shuttle/drop1/sulaco)
 "aXL" = (
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin8";
 	icon_state = "rasputin8"
 	},
 /area/shuttle/drop1/sulaco)
@@ -25630,7 +25205,6 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor{
-	tag = "icon-podhatch (NORTH)";
 	icon_state = "podhatch";
 	dir = 1
 	},
@@ -25803,13 +25377,11 @@
 /area/sulaco/hangar)
 "aYB" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin5";
 	icon_state = "rasputin5"
 	},
 /area/shuttle/drop1/sulaco)
 "aYC" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin12";
 	icon_state = "rasputin12"
 	},
 /area/shuttle/drop1/sulaco)
@@ -25818,13 +25390,11 @@
 	name = "Dropship Hatch"
 	},
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
 	},
 /area/shuttle/drop1/sulaco)
 "aYE" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin9";
 	icon_state = "rasputin9"
 	},
 /area/shuttle/drop1/sulaco)
@@ -25904,7 +25474,6 @@
 	},
 /obj/effect/decal/warning_stripes,
 /turf/open/floor{
-	tag = "icon-platebot";
 	icon_state = "platebot"
 	},
 /area/sulaco/telecomms)
@@ -26151,7 +25720,6 @@
 	opacity = 0
 	},
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
 	},
 /area/shuttle/drop1/sulaco)
@@ -26163,7 +25731,6 @@
 	req_access_txt = "22"
 	},
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin10";
 	icon_state = "rasputin10"
 	},
 /area/shuttle/drop1/sulaco)
@@ -26185,7 +25752,6 @@
 	icon_state = "shutter0"
 	},
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
 	},
 /area/shuttle/drop1/sulaco)
@@ -26348,7 +25914,6 @@
 	req_one_access_txt = "2;6;200"
 	},
 /turf/open/floor{
-	tag = "icon-podhatch";
 	icon_state = "podhatch"
 	},
 /area/sulaco/telecomms)
@@ -26522,7 +26087,6 @@
 /area/sulaco/hangar)
 "bak" = (
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin13";
 	icon_state = "rasputin13"
 	},
 /area/shuttle/drop1/sulaco)
@@ -26797,7 +26361,6 @@
 /area/sulaco/hangar)
 "baW" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin6";
 	icon_state = "rasputin6"
 	},
 /area/shuttle/drop1/sulaco)
@@ -26806,12 +26369,10 @@
 	pixel_x = -32
 	},
 /obj/structure/bed/chair/dropship/passenger{
-	tag = "icon-shuttle_chair (EAST)";
 	icon_state = "shuttle_chair";
 	dir = 4
 	},
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
 	},
 /area/shuttle/drop1/sulaco)
@@ -26820,12 +26381,10 @@
 	pixel_x = 32
 	},
 /obj/structure/bed/chair/dropship/passenger{
-	tag = "icon-shuttle_chair (WEST)";
 	icon_state = "shuttle_chair";
 	dir = 8
 	},
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
 	},
 /area/shuttle/drop1/sulaco)
@@ -27119,13 +26678,11 @@
 /area/sulaco/liaison)
 "bbJ" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin11";
 	icon_state = "rasputin11"
 	},
 /area/shuttle/drop1/sulaco)
 "bbK" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin7";
 	icon_state = "rasputin7"
 	},
 /area/shuttle/drop1/sulaco)
@@ -27199,8 +26756,7 @@
 "bbS" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10;
-	icon_state = "intact";
-	tag = "icon-intact (NORTHEAST)"
+	icon_state = "intact"
 	},
 /turf/open/floor/plating,
 /area/sulaco/hangar/two)
@@ -27487,7 +27043,6 @@
 /area/sulaco/hangar)
 "bcv" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin14";
 	icon_state = "rasputin14"
 	},
 /area/shuttle/drop1/sulaco)
@@ -27659,7 +27214,6 @@
 /area/shuttle/drop1/sulaco)
 "bcX" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin3";
 	icon_state = "rasputin3"
 	},
 /area/shuttle/drop1/sulaco)
@@ -27785,7 +27339,6 @@
 /area/sulaco/hangar)
 "bdq" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin13";
 	icon_state = "rasputin13"
 	},
 /area/shuttle/drop1/sulaco)

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -118,8 +118,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
 "aau" = (
@@ -152,8 +151,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
 "aay" = (
@@ -196,8 +194,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
 "aaD" = (
@@ -226,8 +223,7 @@
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
 "aaG" = (
@@ -237,8 +233,7 @@
 "aaH" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/starboard_missiles)
 "aaI" = (
@@ -246,7 +241,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/aft_hallway)
@@ -259,7 +253,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/exoarmor)
@@ -274,7 +267,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/exoarmor)
@@ -303,7 +295,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/shipboard/starboard_missiles)
@@ -313,8 +304,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/starboard_missiles)
 "aaR" = (
@@ -329,7 +319,6 @@
 /obj/machinery/door/firedoor/theseus,
 /obj/machinery/camera/autoname/almayer,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/weapon_room)
@@ -339,8 +328,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
 "aaT" = (
@@ -349,8 +337,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
 "aaU" = (
@@ -377,7 +364,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/weapon_room)
@@ -388,8 +374,7 @@
 /obj/machinery/camera/autoname/almayer,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/port_missiles)
 "aaY" = (
@@ -399,15 +384,13 @@
 /obj/machinery/camera/autoname/almayer,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/port_missiles)
 "aaZ" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/port_missiles)
 "aba" = (
@@ -444,8 +427,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
 "abg" = (
@@ -457,8 +439,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
 "abh" = (
@@ -486,8 +467,7 @@
 /obj/machinery/camera/autoname/almayer,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/hallways/starboard_hallway)
 "abl" = (
@@ -515,8 +495,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hull/lower_hull)
 "abo" = (
@@ -532,7 +511,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (WEST)";
 	icon_state = "redcorner";
 	dir = 8
 	},
@@ -549,8 +527,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hull/lower_hull)
 "abs" = (
@@ -568,8 +545,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
 "abv" = (
@@ -578,7 +554,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-greencorner";
 	icon_state = "greencorner";
 	dir = 2
 	},
@@ -615,8 +590,7 @@
 /obj/machinery/power/apc/almayer,
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/numbertwobunks)
 "abC" = (
@@ -625,7 +599,6 @@
 	},
 /obj/machinery/firealarm,
 /turf/open/floor/almayer{
-	tag = "icon-green (NORTH)";
 	icon_state = "green";
 	dir = 1
 	},
@@ -666,8 +639,7 @@
 /obj/machinery/alarm,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/living/cafeteria_officer)
 "abJ" = (
@@ -683,8 +655,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "abL" = (
@@ -693,8 +664,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "abM" = (
@@ -708,8 +678,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hull/upper_hull)
 "abN" = (
@@ -723,8 +692,7 @@
 /obj/machinery/camera/autoname/almayer,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "abP" = (
@@ -737,7 +705,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (WEST)";
 	icon_state = "greencorner";
 	dir = 8
 	},
@@ -797,7 +764,6 @@
 	},
 /obj/machinery/alarm,
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (NORTH)";
 	icon_state = "orangecorner";
 	dir = 1
 	},
@@ -814,7 +780,6 @@
 	},
 /obj/machinery/firealarm,
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -843,7 +808,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig)
@@ -851,14 +815,12 @@
 /obj/machinery/alarm,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/corporateliaison)
 "acj" = (
 /obj/machinery/alarm,
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (NORTH)";
 	icon_state = "greencorner";
 	dir = 1
 	},
@@ -867,8 +829,7 @@
 /obj/machinery/alarm,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
 "acl" = (
@@ -884,16 +845,14 @@
 /obj/machinery/firealarm,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "acn" = (
 /obj/machinery/alarm,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/stern_hallway)
 "aco" = (
@@ -914,8 +873,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/hallways/aft_hallway)
 "acp" = (
@@ -949,7 +907,6 @@
 	dir = 10
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/aft_hallway)
@@ -1017,7 +974,6 @@
 /obj/machinery/door/firedoor/theseus,
 /obj/machinery/camera/autoname/almayer,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/living/briefing)
@@ -1083,7 +1039,6 @@
 /area/almayer/living/numbertwobunks)
 "acL" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-21"
 	},
 /obj/machinery/light{
@@ -1093,7 +1048,6 @@
 /area/almayer/living/numbertwobunks)
 "acM" = (
 /obj/structure/bed/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (EAST)";
 	icon_state = "wooden_chair_wings";
 	dir = 4
 	},
@@ -1110,7 +1064,6 @@
 /area/almayer/living/commandbunks)
 "acO" = (
 /obj/structure/bed/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (WEST)";
 	icon_state = "wooden_chair_wings";
 	dir = 8
 	},
@@ -1182,7 +1135,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-blue";
 	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
@@ -1214,7 +1166,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/living/briefing)
@@ -1234,7 +1185,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/squads/req)
@@ -1275,8 +1225,7 @@
 /obj/machinery/firealarm,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "adn" = (
@@ -1303,16 +1252,14 @@
 /obj/machinery/firealarm,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "ads" = (
 /obj/machinery/firealarm,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "adt" = (
@@ -1365,14 +1312,12 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-greencorner";
 	icon_state = "greencorner";
 	dir = 2
 	},
 /area/almayer/hallways/aft_hallway)
 "adB" = (
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (WEST)";
 	icon_state = "greencorner";
 	dir = 8
 	},
@@ -1422,8 +1367,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
 "adI" = (
@@ -1432,8 +1376,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
 "adJ" = (
@@ -1469,12 +1412,10 @@
 /area/almayer/hull/upper_hull)
 "adN" = (
 /obj/machinery/shower{
-	tag = "icon-shower (EAST)";
 	icon_state = "shower";
 	dir = 4
 	},
 /obj/structure/window/reinforced/tinted/frosted{
-	tag = "icon-fwindow (NORTH)";
 	icon_state = "fwindow";
 	dir = 1
 	},
@@ -1538,8 +1479,7 @@
 /obj/machinery/firealarm,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/ce_room)
 "adV" = (
@@ -1569,8 +1509,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/hallways/aft_hallway)
 "aeb" = (
@@ -1579,8 +1518,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/hallways/aft_hallway)
 "aec" = (
@@ -1598,8 +1536,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/ce_room)
 "aee" = (
@@ -1617,8 +1554,7 @@
 /obj/machinery/camera/autoname/almayer,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/surgery_hallway)
 "aeg" = (
@@ -1627,8 +1563,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/operating_room_one)
 "aeh" = (
@@ -1646,8 +1581,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/chemistry)
 "aei" = (
@@ -1656,8 +1590,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/surgery_hallway)
 "aej" = (
@@ -1666,8 +1599,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/operating_room_two)
 "aek" = (
@@ -1676,8 +1608,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/operating_room_three)
 "ael" = (
@@ -1697,8 +1628,7 @@
 /obj/machinery/alarm,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aeo" = (
@@ -1709,7 +1639,6 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-green (NORTH)";
 	icon_state = "green";
 	dir = 1
 	},
@@ -1726,8 +1655,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_corner";
-	tag = "icon-sterile_green_corner (NORTH)"
+	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/medical_science)
 "aeq" = (
@@ -1785,8 +1713,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "aez" = (
@@ -1798,7 +1725,6 @@
 "aeA" = (
 /obj/machinery/firealarm,
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (NORTH)";
 	icon_state = "redcorner";
 	dir = 1
 	},
@@ -1834,7 +1760,6 @@
 /area/almayer/hallways/aft_hallway)
 "aeF" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-21"
 	},
 /obj/structure/cable{
@@ -1857,7 +1782,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (EAST)";
 	icon_state = "redcorner";
 	dir = 4
 	},
@@ -1868,8 +1792,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/surgery_hallway)
 "aeI" = (
@@ -1881,8 +1804,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
 "aeK" = (
@@ -1891,8 +1813,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/operating_room_four)
 "aeL" = (
@@ -1911,22 +1832,19 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
 "aeO" = (
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/starboard_atmos)
 "aeP" = (
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/starboard_atmos)
 "aeQ" = (
@@ -2028,7 +1946,6 @@
 /area/almayer/living/numbertwobunks)
 "afc" = (
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (NORTH)";
 	icon_state = "carpetside";
 	dir = 1
 	},
@@ -2038,7 +1955,6 @@
 /obj/item/flashlight/lamp/green,
 /obj/item/storage/bible,
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (NORTH)";
 	icon_state = "carpetside";
 	dir = 1
 	},
@@ -2056,7 +1972,6 @@
 /area/almayer/living/commandbunks)
 "afg" = (
 /obj/structure/bed/chair/comfy/black{
-	tag = "icon-comfychair (NORTH)";
 	icon_state = "comfychair";
 	dir = 1
 	},
@@ -2088,8 +2003,7 @@
 /obj/machinery/alarm,
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "afl" = (
@@ -2102,7 +2016,6 @@
 	d2 = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/chief_mp_office)
@@ -2115,16 +2028,14 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
 "afn" = (
 /obj/machinery/alarm,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "afo" = (
@@ -2140,8 +2051,7 @@
 	req_one_access_txt = "19"
 	},
 /turf/open/floor/almayer{
-	icon_state = "ai_floors";
-	tag = "icon-sterile"
+	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "afp" = (
@@ -2174,8 +2084,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "afs" = (
@@ -2229,8 +2138,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/hallways/aft_hallway)
 "afy" = (
@@ -2250,15 +2158,13 @@
 "afA" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
 "afB" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
 "afC" = (
@@ -2332,7 +2238,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig_cells)
@@ -2345,14 +2250,12 @@
 "afM" = (
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/starboard_atmos)
 "afN" = (
 /obj/machinery/light,
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/starboard_atmos)
@@ -2381,8 +2284,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/starboard_atmos)
 "afS" = (
@@ -2423,8 +2325,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hull/upper_hull)
 "afY" = (
@@ -2433,8 +2334,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "afZ" = (
@@ -2452,8 +2352,7 @@
 /obj/machinery/firealarm,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
 "agb" = (
@@ -2473,13 +2372,11 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/living/commandbunks)
 "age" = (
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/living/commandbunks)
@@ -2488,7 +2385,6 @@
 	name = "\improper Bathroom"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/living/commandbunks)
@@ -2529,8 +2425,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_corner";
-	tag = "icon-sterile_green_corner"
+	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/medical_science)
 "agj" = (
@@ -2538,8 +2433,7 @@
 /obj/machinery/vending/medical,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_corner";
-	tag = "icon-sterile_green_corner (NORTH)"
+	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/medical_science)
 "agk" = (
@@ -2552,15 +2446,13 @@
 /obj/machinery/alarm,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "agl" = (
 /obj/machinery/bodyscanner,
 /obj/machinery/firealarm,
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (NORTH)";
 	icon_state = "sterile_green_corner";
 	dir = 1
 	},
@@ -2580,15 +2472,13 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/hallways/aft_hallway)
 "agp" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/hallways/aft_hallway)
 "agq" = (
@@ -2637,8 +2527,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
 "agx" = (
@@ -2654,8 +2543,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "agy" = (
@@ -2700,16 +2588,14 @@
 	},
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/living/officer_study)
 "agE" = (
 /obj/structure/bed/chair,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/living/officer_study)
 "agF" = (
@@ -2757,8 +2643,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/living/cafeteria_officer)
 "agN" = (
@@ -2780,7 +2665,6 @@
 /area/almayer/engineering/starboard_atmos)
 "agQ" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/engineering/starboard_atmos)
@@ -2794,8 +2678,7 @@
 "agS" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/starboard_atmos)
 "agT" = (
@@ -2827,13 +2710,11 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/hull/upper_hull)
 "agX" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (WEST)";
 	icon_state = "orangecorner";
 	dir = 8
 	},
@@ -2853,7 +2734,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/hull/upper_hull)
@@ -2866,7 +2746,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/hull/upper_hull)
@@ -2882,7 +2761,6 @@
 /area/almayer/shipboard/brig_cells)
 "ahd" = (
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig_cells)
@@ -2944,8 +2822,7 @@
 /obj/machinery/alarm,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/stern_hallway)
 "ahl" = (
@@ -2967,7 +2844,6 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (NORTH)";
 	icon_state = "orangecorner";
 	dir = 1
 	},
@@ -2995,7 +2871,6 @@
 	},
 /obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
@@ -3022,8 +2897,7 @@
 /obj/machinery/firealarm,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/shipboard/brig_cells)
 "aht" = (
@@ -3034,11 +2908,9 @@
 /area/almayer/hull/upper_hull)
 "ahu" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-22"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-green";
 	icon_state = "green";
 	dir = 2
 	},
@@ -3069,8 +2941,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "ahy" = (
@@ -3138,8 +3009,7 @@
 "ahG" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/hallways/aft_hallway)
 "ahH" = (
@@ -3184,8 +3054,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
 "ahL" = (
@@ -3194,8 +3063,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
 "ahM" = (
@@ -3208,7 +3076,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -3220,8 +3087,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/port_atmos)
 "ahO" = (
@@ -3245,7 +3111,6 @@
 	dir = 6
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/aft_hallway)
@@ -3268,8 +3133,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/living/officer_study)
 "ahU" = (
@@ -3314,8 +3178,7 @@
 /obj/structure/table/almayer,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/living/cafeteria_officer)
 "aic" = (
@@ -3324,7 +3187,6 @@
 	},
 /obj/machinery/meter,
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -3335,8 +3197,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/starboard_atmos)
 "aie" = (
@@ -3345,8 +3206,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/starboard_atmos)
 "aif" = (
@@ -3358,8 +3218,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/starboard_atmos)
 "aig" = (
@@ -3369,8 +3228,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/port_atmos)
 "aih" = (
@@ -3391,7 +3249,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (NORTH)";
 	icon_state = "orangecorner";
 	dir = 1
 	},
@@ -3402,7 +3259,6 @@
 	},
 /obj/machinery/meter,
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/engineering/starboard_atmos)
@@ -3412,8 +3268,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/starboard_atmos)
 "aim" = (
@@ -3442,8 +3297,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hull/upper_hull)
 "aiq" = (
@@ -3464,8 +3318,7 @@
 /obj/item/reagent_container/spray/cleaner,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hull/upper_hull)
 "ais" = (
@@ -3476,13 +3329,11 @@
 /area/almayer/hull/upper_hull)
 "ait" = (
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/chief_mp_office)
 "aiu" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-18"
 	},
 /obj/machinery/light,
@@ -3497,8 +3348,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "aiw" = (
@@ -3506,7 +3356,6 @@
 /area/almayer/shipboard/brig)
 "aix" = (
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig)
@@ -3575,8 +3424,7 @@
 /obj/machinery/firealarm,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/living/bridgebunks)
 "aiH" = (
@@ -3590,16 +3438,14 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/living/bridgebunks)
 "aiI" = (
 /obj/machinery/firealarm,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/shipboard/ex_firing_range)
 "aiJ" = (
@@ -3652,8 +3498,7 @@
 /obj/item/seeds/goldappleseed,
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/corporateliaison)
 "aiQ" = (
@@ -3664,7 +3509,6 @@
 /area/almayer/living/numbertwobunks)
 "aiR" = (
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (NORTH)";
 	icon_state = "greencorner";
 	dir = 1
 	},
@@ -3690,7 +3534,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-bluecorner";
 	icon_state = "bluecorner";
 	dir = 1
 	},
@@ -3700,7 +3543,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (NORTH)";
 	icon_state = "greencorner";
 	dir = 1
 	},
@@ -3708,7 +3550,6 @@
 "aiX" = (
 /obj/machinery/firealarm,
 /turf/open/floor/almayer{
-	tag = "icon-blue (NORTH)";
 	icon_state = "blue";
 	dir = 1
 	},
@@ -3724,7 +3565,6 @@
 	pixel_y = 25
 	},
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (NORTH)";
 	icon_state = "greencorner";
 	dir = 1
 	},
@@ -3732,22 +3572,19 @@
 "aja" = (
 /obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/aft_hallway)
 "ajb" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/hallways/aft_hallway)
 "ajc" = (
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
 "ajd" = (
@@ -3772,13 +3609,11 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
 "ajg" = (
 /turf/open/floor/almayer{
-	tag = "icon-bluecorner";
 	icon_state = "bluecorner";
 	dir = 1
 	},
@@ -3791,8 +3626,7 @@
 /obj/machinery/power/apc/almayer,
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/basketball)
 "aji" = (
@@ -3801,8 +3635,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
 "ajj" = (
@@ -3848,8 +3681,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
 "ajo" = (
@@ -3872,7 +3704,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-silvercorner";
 	icon_state = "silvercorner";
 	dir = 2
 	},
@@ -3881,14 +3712,12 @@
 /obj/machinery/camera/autoname/almayer,
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/starboard_atmos)
 "ajs" = (
 /obj/structure/bed/chair,
 /turf/open/floor/almayer{
-	tag = "icon-silver";
 	icon_state = "silver";
 	dir = 2
 	},
@@ -3897,8 +3726,7 @@
 /obj/structure/bed/chair,
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/living/cafeteria_officer)
 "aju" = (
@@ -3917,7 +3745,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/engineering/starboard_atmos)
@@ -3927,21 +3754,18 @@
 	dir = 9
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/starboard_atmos)
 "ajx" = (
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/starboard_atmos)
 "ajy" = (
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/starboard_atmos)
 "ajz" = (
@@ -3982,7 +3806,6 @@
 /area/almayer/hull/upper_hull)
 "ajE" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner";
 	icon_state = "redcorner"
 	},
 /area/almayer/shipboard/brig)
@@ -4016,8 +3839,7 @@
 /obj/machinery/door_timer/cell_1,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig_cells)
 "ajK" = (
@@ -4057,8 +3879,7 @@
 "ajO" = (
 /obj/structure/bed/chair,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/shipboard/brig)
 "ajP" = (
@@ -4078,8 +3899,7 @@
 "ajQ" = (
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "ajR" = (
@@ -4117,7 +3937,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-silver";
 	icon_state = "silver";
 	dir = 2
 	},
@@ -4144,19 +3963,16 @@
 /area/almayer/command/corporateliaison)
 "aka" = (
 /turf/open/floor/almayer{
-	tag = "icon-silvercorner (EAST)";
 	icon_state = "silvercorner";
 	dir = 4
 	},
 /area/almayer/command/corporateliaison)
 "akb" = (
 /obj/machinery/shower{
-	tag = "icon-shower (EAST)";
 	icon_state = "shower";
 	dir = 4
 	},
 /obj/structure/window/reinforced/tinted/frosted{
-	tag = "icon-fwindow (NORTH)";
 	icon_state = "fwindow";
 	dir = 1
 	},
@@ -4182,7 +3998,6 @@
 /area/almayer/living/starboard_emb)
 "akg" = (
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (EAST)";
 	icon_state = "greencorner";
 	dir = 4
 	},
@@ -4210,8 +4025,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/starboard_hallway)
 "akj" = (
@@ -4256,21 +4070,18 @@
 /obj/machinery/firealarm,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/squads/alpha)
 "akm" = (
 /obj/machinery/alarm,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/squads/alpha)
 "akn" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/almayer{
@@ -4304,8 +4115,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/hallways/aft_hallway)
 "akq" = (
@@ -4325,7 +4135,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/aft_hallway)
@@ -4346,8 +4155,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/hallways/aft_hallway)
 "aks" = (
@@ -4371,7 +4179,6 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-blue";
 	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
@@ -4426,7 +4233,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-blue";
 	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
@@ -4463,7 +4269,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-blue";
 	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
@@ -4484,8 +4289,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/hallways/aft_hallway)
 "akz" = (
@@ -4508,8 +4312,7 @@
 "akA" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
 "akB" = (
@@ -4556,14 +4359,12 @@
 /area/almayer/living/officer_study)
 "akF" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (EAST)";
 	icon_state = "redcorner";
 	dir = 4
 	},
 /area/almayer/hallways/aft_hallway)
 "akG" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (NORTH)";
 	icon_state = "redcorner";
 	dir = 1
 	},
@@ -4614,7 +4415,6 @@
 /area/almayer/squads/bravo)
 "akL" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -4624,7 +4424,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -4632,7 +4431,6 @@
 "akN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -4642,7 +4440,6 @@
 	pixel_y = 25
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -4654,7 +4451,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -4696,8 +4492,7 @@
 /obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "akV" = (
@@ -4712,8 +4507,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "akX" = (
@@ -4732,8 +4526,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "ala" = (
@@ -4742,8 +4535,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "alb" = (
@@ -4755,16 +4547,14 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/shipboard/brig)
 "ald" = (
 /obj/structure/table/reinforced,
 /obj/item/taperecorder,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/shipboard/brig)
 "ale" = (
@@ -4782,8 +4572,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "alg" = (
@@ -4800,8 +4589,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "ali" = (
@@ -4813,20 +4601,17 @@
 	},
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "alj" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "alk" = (
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/command/cic)
@@ -4836,13 +4621,11 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "alm" = (
 /turf/open/floor/almayer{
-	tag = "icon-silver";
 	icon_state = "silver";
 	dir = 2
 	},
@@ -4854,7 +4637,6 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-silver";
 	icon_state = "silver";
 	dir = 2
 	},
@@ -4866,7 +4648,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-silver";
 	icon_state = "silver";
 	dir = 2
 	},
@@ -4888,15 +4669,13 @@
 	},
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "alr" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "silvercorner";
-	tag = "icon-silvercorner (NORTH)"
+	icon_state = "silvercorner"
 	},
 /area/almayer/command/cic)
 "als" = (
@@ -4928,8 +4707,7 @@
 	name = "\improper Medical Bay"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/upper_medical)
 "aly" = (
@@ -4940,8 +4718,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/upper_medical)
 "alz" = (
@@ -4950,8 +4727,7 @@
 "alA" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
 "alB" = (
@@ -4988,8 +4764,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/hallways/aft_hallway)
 "alD" = (
@@ -5012,8 +4787,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
 "alE" = (
@@ -5035,7 +4809,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-bluecorner";
 	icon_state = "bluecorner";
 	dir = 1
 	},
@@ -5057,8 +4830,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/hallways/aft_hallway)
 "alG" = (
@@ -5098,7 +4870,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-bluecorner";
 	icon_state = "bluecorner";
 	dir = 1
 	},
@@ -5166,7 +4937,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/aft_hallway)
@@ -5187,8 +4957,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/hallways/aft_hallway)
 "alP" = (
@@ -5267,8 +5036,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/hallways/aft_hallway)
 "alT" = (
@@ -5285,7 +5053,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-bluecorner";
 	icon_state = "bluecorner";
 	dir = 1
 	},
@@ -5312,8 +5079,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/hallways/aft_hallway)
 "alV" = (
@@ -5515,8 +5281,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/stern_hallway)
 "amg" = (
@@ -5536,7 +5301,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/stern_hallway)
@@ -5557,8 +5321,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/stern_hallway)
 "ami" = (
@@ -5635,7 +5398,6 @@
 "amm" = (
 /obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/stern_hallway)
@@ -5644,7 +5406,6 @@
 	pixel_y = 30
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -5673,7 +5434,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor5";
 	icon_state = "test_floor5"
 	},
 /area/almayer/squads/req)
@@ -5711,8 +5471,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/firing_range)
 "amw" = (
@@ -5736,8 +5495,7 @@
 "amy" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/stern_hallway)
 "amz" = (
@@ -5751,7 +5509,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/shipboard/brig)
@@ -5764,8 +5521,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "amB" = (
@@ -5777,8 +5533,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "amC" = (
@@ -5792,7 +5547,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/shipboard/brig)
@@ -5801,8 +5555,7 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/shipboard/brig)
 "amE" = (
@@ -5834,8 +5587,7 @@
 /obj/structure/bed/chair,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "amJ" = (
@@ -5850,7 +5602,6 @@
 	},
 /obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig)
@@ -5942,8 +5693,7 @@
 "amX" = (
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
 "amY" = (
@@ -5952,8 +5702,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
 "amZ" = (
@@ -5962,13 +5711,11 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
 "ana" = (
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (NORTHWEST)";
 	icon_state = "sterile_green_side";
 	dir = 9
 	},
@@ -5978,15 +5725,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/upper_medical)
 "anc" = (
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "and" = (
@@ -5995,16 +5740,14 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "ane" = (
 /obj/machinery/camera/autoname/almayer,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_corner";
-	tag = "icon-sterile_green_corner (NORTH)"
+	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/medical_science)
 "anf" = (
@@ -6012,29 +5755,25 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	icon_state = "sterile_green";
-	tag = "icon-sterile"
+	icon_state = "sterile_green"
 	},
 /area/almayer/medical/medical_science)
 "ang" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/almayer{
-	icon_state = "sterile_green";
-	tag = "icon-sterile"
+	icon_state = "sterile_green"
 	},
 /area/almayer/medical/medical_science)
 "anh" = (
 /obj/machinery/botany/editor,
 /turf/open/floor/almayer{
-	icon_state = "sterile_green";
-	tag = "icon-sterile"
+	icon_state = "sterile_green"
 	},
 /area/almayer/medical/medical_science)
 "ani" = (
 /obj/machinery/botany/extractor,
 /turf/open/floor/almayer{
-	icon_state = "sterile_green";
-	tag = "icon-sterile"
+	icon_state = "sterile_green"
 	},
 /area/almayer/medical/medical_science)
 "anj" = (
@@ -6043,53 +5782,45 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	icon_state = "sterile_green";
-	tag = "icon-sterile"
+	icon_state = "sterile_green"
 	},
 /area/almayer/medical/medical_science)
 "ank" = (
 /obj/machinery/vending/hydroseeds,
 /turf/open/floor/almayer{
-	icon_state = "sterile_green";
-	tag = "icon-sterile"
+	icon_state = "sterile_green"
 	},
 /area/almayer/medical/medical_science)
 "anl" = (
 /turf/open/floor/almayer{
-	tag = "icon-bluecorner";
 	icon_state = "bluecorner"
 	},
 /area/almayer/hallways/aft_hallway)
 "anm" = (
 /obj/machinery/light,
 /turf/open/floor/almayer{
-	tag = "icon-blue";
 	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
 "ann" = (
 /turf/open/floor/almayer{
-	tag = "icon-blue";
 	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
 "ano" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/hallways/aft_hallway)
 "anp" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-22"
 	},
 /obj/machinery/camera/autoname/almayer,
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/squads/req)
 "anq" = (
@@ -6099,26 +5830,22 @@
 "anr" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/stern_hallway)
 "ans" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/stern_hallway)
 "ant" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/hallways/stern_hallway)
 "anu" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (WEST)";
 	icon_state = "orangecorner";
 	dir = 8
 	},
@@ -6137,7 +5864,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/hallways/stern_hallway)
@@ -6149,7 +5875,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (WEST)";
 	icon_state = "orangecorner";
 	dir = 8
 	},
@@ -6163,7 +5888,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/stern_hallway)
@@ -6175,7 +5899,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (WEST)";
 	icon_state = "orangecorner";
 	dir = 8
 	},
@@ -6186,20 +5909,17 @@
 	dir = 10
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/hallways/stern_hallway)
 "anA" = (
 /obj/machinery/light,
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/hallways/stern_hallway)
 "anB" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (WEST)";
 	icon_state = "redcorner";
 	dir = 8
 	},
@@ -6225,8 +5945,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "anF" = (
@@ -6239,8 +5958,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/command/cic)
 "anH" = (
@@ -6249,8 +5967,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/command/cic)
 "anI" = (
@@ -6258,7 +5975,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig)
@@ -6267,7 +5983,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig)
@@ -6277,8 +5992,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "anL" = (
@@ -6291,8 +6005,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "anN" = (
@@ -6301,8 +6014,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "anO" = (
@@ -6327,8 +6039,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "anS" = (
@@ -6342,7 +6053,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig)
@@ -6377,7 +6087,6 @@
 /obj/item/storage/pouch/medkit,
 /obj/item/storage/pouch/medkit,
 /turf/open/floor/almayer{
-	tag = "icon-bluefull";
 	icon_state = "bluefull"
 	},
 /area/almayer/command/cic)
@@ -6391,7 +6100,6 @@
 	pixel_y = 25
 	},
 /turf/open/floor/almayer{
-	tag = "icon-bluefull";
 	icon_state = "bluefull"
 	},
 /area/almayer/command/cic)
@@ -6407,7 +6115,6 @@
 "anX" = (
 /obj/machinery/vending/engineering,
 /turf/open/floor/almayer{
-	tag = "icon-orangefull";
 	icon_state = "orangefull"
 	},
 /area/almayer/command/cic)
@@ -6419,8 +6126,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "anZ" = (
@@ -6444,8 +6150,7 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "aob" = (
@@ -6459,8 +6164,7 @@
 /obj/structure/prop/almayer/mapping_computer,
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/command/cic)
 "aod" = (
@@ -6474,8 +6178,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "aoe" = (
@@ -6489,8 +6192,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "aof" = (
@@ -6500,8 +6202,7 @@
 /obj/structure/prop/almayer/mapping_computer,
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/command/cic)
 "aog" = (
@@ -6513,8 +6214,7 @@
 /obj/machinery/camera/autoname/almayer,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "aoh" = (
@@ -6526,8 +6226,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "aoj" = (
@@ -6562,8 +6261,7 @@
 "aoo" = (
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/corporateliaison)
 "aop" = (
@@ -6576,13 +6274,11 @@
 "aor" = (
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
 "aos" = (
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (SOUTHWEST)";
 	icon_state = "sterile_green_side";
 	dir = 10
 	},
@@ -6596,8 +6292,7 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/upper_medical)
 "aou" = (
@@ -6608,7 +6303,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (SOUTHEAST)";
 	icon_state = "sterile_green_side";
 	dir = 6
 	},
@@ -6628,8 +6322,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aow" = (
@@ -6641,8 +6334,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aox" = (
@@ -6653,7 +6345,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (SOUTHWEST)";
 	icon_state = "sterile_green_side";
 	dir = 10
 	},
@@ -6664,14 +6355,12 @@
 	on = 1
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/medical_science)
 "aoz" = (
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/medical_science)
 "aoA" = (
@@ -6679,8 +6368,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "sterile_green";
-	tag = "icon-sterile"
+	icon_state = "sterile_green"
 	},
 /area/almayer/medical/medical_science)
 "aoB" = (
@@ -6702,8 +6390,7 @@
 "aoE" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "silvercorner";
-	tag = "icon-silvercorner (NORTH)"
+	icon_state = "silvercorner"
 	},
 /area/almayer/medical/medical_science)
 "aoF" = (
@@ -6716,7 +6403,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-silvercorner";
 	icon_state = "silvercorner";
 	dir = 2
 	},
@@ -6732,7 +6418,6 @@
 /area/almayer/command/telecomms)
 "aoK" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (NORTH)";
 	icon_state = "orangecorner";
 	dir = 1
 	},
@@ -6747,7 +6432,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -6781,13 +6465,11 @@
 "aoQ" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/stern_hallway)
 "aoR" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (EAST)";
 	icon_state = "redcorner";
 	dir = 4
 	},
@@ -6795,8 +6477,7 @@
 "aoS" = (
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/stern_hallway)
 "aoT" = (
@@ -6805,8 +6486,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/stern_hallway)
 "aoU" = (
@@ -6816,8 +6496,7 @@
 "aoV" = (
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/command/self_destruct)
 "aoW" = (
@@ -6840,7 +6519,6 @@
 	dir = 9
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig)
@@ -6858,8 +6536,7 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/shipboard/brig)
 "apc" = (
@@ -6884,8 +6561,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "apf" = (
@@ -6900,7 +6576,6 @@
 /obj/item/tool/taperoll/police,
 /obj/item/roller,
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (WEST)";
 	icon_state = "carpetside";
 	dir = 8
 	},
@@ -6920,8 +6595,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "apk" = (
@@ -6974,7 +6648,6 @@
 /area/almayer/command/cic)
 "apo" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (EAST)";
 	icon_state = "redcorner";
 	dir = 4
 	},
@@ -6983,8 +6656,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "apq" = (
@@ -6993,8 +6665,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/command/cic)
 "apr" = (
@@ -7007,8 +6678,7 @@
 /obj/machinery/computer/camera_advanced/overwatch/alpha,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/command/cic)
 "aps" = (
@@ -7021,8 +6691,7 @@
 /obj/structure/table/almayer,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/command/cic)
 "apt" = (
@@ -7031,8 +6700,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/command/cic)
 "apu" = (
@@ -7040,8 +6708,7 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/command/cic)
 "apv" = (
@@ -7062,14 +6729,12 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "apx" = (
 /obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig)
@@ -7123,8 +6788,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
 "apG" = (
@@ -7137,15 +6801,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/upper_medical)
 "apH" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
 "apI" = (
@@ -7154,8 +6816,7 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	icon_state = "sterile_green";
-	tag = "icon-sterile"
+	icon_state = "sterile_green"
 	},
 /area/almayer/medical/medical_science)
 "apJ" = (
@@ -7163,22 +6824,19 @@
 /obj/item/storage/box/botanydisk,
 /obj/item/tool/hand_labeler,
 /turf/open/floor/almayer{
-	icon_state = "sterile_green";
-	tag = "icon-sterile"
+	icon_state = "sterile_green"
 	},
 /area/almayer/medical/medical_science)
 "apK" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/open/floor/almayer{
-	icon_state = "sterile_green";
-	tag = "icon-sterile"
+	icon_state = "sterile_green"
 	},
 /area/almayer/medical/medical_science)
 "apL" = (
 /obj/machinery/biogenerator,
 /turf/open/floor/almayer{
-	icon_state = "sterile_green";
-	tag = "icon-sterile"
+	icon_state = "sterile_green"
 	},
 /area/almayer/medical/medical_science)
 "apM" = (
@@ -7189,8 +6847,7 @@
 /obj/item/tool/hatchet,
 /obj/item/tool/shovel/spade,
 /turf/open/floor/almayer{
-	icon_state = "sterile_green";
-	tag = "icon-sterile"
+	icon_state = "sterile_green"
 	},
 /area/almayer/medical/medical_science)
 "apN" = (
@@ -7209,8 +6866,7 @@
 "apQ" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/medical/medical_science)
 "apR" = (
@@ -7221,8 +6877,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/hull/upper_hull)
 "apS" = (
@@ -7265,8 +6920,7 @@
 /obj/machinery/firealarm,
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/weapon_room)
 "apZ" = (
@@ -7302,13 +6956,11 @@
 /obj/effect/spawner/random/tool,
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "aqd" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (NORTH)";
 	icon_state = "orangecorner";
 	dir = 1
 	},
@@ -7317,7 +6969,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/engineering/upper_engineering)
@@ -7331,16 +6982,14 @@
 "aqg" = (
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "aqh" = (
 /obj/item/clothing/mask/gas,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "aqi" = (
@@ -7354,8 +7003,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/basketball)
 "aqj" = (
@@ -7368,7 +7016,6 @@
 "aqk" = (
 /obj/structure/largecrate/random/barrel/red,
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/engineering/upper_engineering)
@@ -7376,14 +7023,12 @@
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/bulletproof,
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/engineering/upper_engineering)
 "aqm" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/engineering/upper_engineering)
@@ -7391,8 +7036,7 @@
 /obj/machinery/suit_storage_unit/carbon_unit,
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/ce_room)
 "aqo" = (
@@ -7400,8 +7044,7 @@
 /obj/effect/landmark/start/marine/chiefshipengineer,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/ce_room)
 "aqp" = (
@@ -7410,27 +7053,23 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/ce_room)
 "aqq" = (
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/ce_room)
 "aqr" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-21"
 	},
 /obj/machinery/alarm,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "aqs" = (
@@ -7441,8 +7080,7 @@
 /obj/machinery/power/apc/almayer,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/surgery_hallway)
 "aqt" = (
@@ -7454,8 +7092,7 @@
 "aqu" = (
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/stern_hallway)
 "aqv" = (
@@ -7465,7 +7102,6 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/hallways/stern_hallway)
@@ -7477,7 +7113,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/hallways/stern_hallway)
@@ -7488,7 +7123,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/hallways/stern_hallway)
@@ -7499,7 +7133,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (WEST)";
 	icon_state = "redcorner";
 	dir = 8
 	},
@@ -7508,8 +7141,7 @@
 /obj/machinery/firealarm,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/surgery_hallway)
 "aqA" = (
@@ -7522,7 +7154,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redcorner";
 	icon_state = "redcorner"
 	},
 /area/almayer/hallways/stern_hallway)
@@ -7535,15 +7166,13 @@
 /obj/item/storage/surgical_tray,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/operating_room_one)
 "aqC" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/command/self_destruct)
 "aqD" = (
@@ -7566,8 +7195,7 @@
 /obj/machinery/power/apc/almayer,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/starboard_hallway)
 "aqG" = (
@@ -7606,8 +7234,7 @@
 /obj/machinery/door/airlock/multi_tile/almayer/secdoor,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "aqL" = (
@@ -7627,8 +7254,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/command/cic)
 "aqN" = (
@@ -7643,8 +7269,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/weapon_room)
 "aqP" = (
@@ -7671,13 +7296,11 @@
 "aqQ" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig)
 "aqR" = (
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (WEST)";
 	icon_state = "carpetside";
 	dir = 8
 	},
@@ -7691,15 +7314,13 @@
 "aqT" = (
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "aqU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig)
@@ -7711,26 +7332,22 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/command/cic)
 "aqW" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/shipboard/brig)
 "aqX" = (
 /obj/structure/table/almayer,
 /obj/structure/flora/pottedplant{
 	icon_state = "plant-18";
-	pixel_y = 10;
-	tag = "icon-plant-10"
+	pixel_y = 10
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig)
@@ -7740,7 +7357,6 @@
 /obj/item/tool/pen,
 /obj/item/folder/red,
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig)
@@ -7761,8 +7377,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/shipboard/brig)
 "arb" = (
@@ -7799,7 +7414,6 @@
 /obj/item/storage/belt/combatLifesaver,
 /obj/item/storage/belt/combatLifesaver,
 /turf/open/floor/almayer{
-	tag = "icon-bluefull";
 	icon_state = "bluefull"
 	},
 /area/almayer/command/cic)
@@ -7823,7 +7437,6 @@
 	pixel_y = 10
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangefull";
 	icon_state = "orangefull"
 	},
 /area/almayer/command/cic)
@@ -7841,41 +7454,35 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "ark" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/almayer,
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/starboard_missiles)
 "arl" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/command/cic)
 "arm" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/command/cic)
 "arn" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/command/cic)
 "aro" = (
@@ -7890,7 +7497,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-silver";
 	icon_state = "silver";
 	dir = 2
 	},
@@ -7913,8 +7519,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/operating_room_one)
 "arr" = (
@@ -7944,8 +7549,7 @@
 /obj/machinery/firealarm,
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/squads/req)
 "aru" = (
@@ -7956,8 +7560,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "arv" = (
@@ -8017,7 +7620,6 @@
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/bulletproof,
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/medical/upper_medical)
@@ -8028,15 +7630,13 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/medical/upper_medical)
 "arE" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
 "arF" = (
@@ -8059,7 +7659,6 @@
 	pixel_y = -5
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (NORTH)";
 	icon_state = "sterile_green_corner";
 	dir = 1
 	},
@@ -8068,8 +7667,7 @@
 /obj/machinery/robotic_fabricator,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "arJ" = (
@@ -8082,8 +7680,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_corner";
-	tag = "icon-sterile_green_corner (NORTH)"
+	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/medical_science)
 "arL" = (
@@ -8092,8 +7689,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "sterile_green";
-	tag = "icon-sterile"
+	icon_state = "sterile_green"
 	},
 /area/almayer/medical/medical_science)
 "arM" = (
@@ -8102,8 +7698,7 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	icon_state = "sterile_green";
-	tag = "icon-sterile"
+	icon_state = "sterile_green"
 	},
 /area/almayer/medical/medical_science)
 "arN" = (
@@ -8215,8 +7810,7 @@
 /obj/effect/spawner/random/toolbox,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "asc" = (
@@ -8227,8 +7821,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "ase" = (
@@ -8243,8 +7836,7 @@
 "asf" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "asg" = (
@@ -8253,8 +7845,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "ash" = (
@@ -8280,7 +7871,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/engineering/upper_engineering)
@@ -8322,7 +7912,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/engineering/upper_engineering)
@@ -8334,8 +7923,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/ce_room)
 "aso" = (
@@ -8364,8 +7952,7 @@
 "ass" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/ce_room)
 "ast" = (
@@ -8435,7 +8022,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig)
@@ -8448,7 +8034,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/almayer{
-	tag = "icon-redcorner";
 	icon_state = "redcorner"
 	},
 /area/almayer/shipboard/brig)
@@ -8457,7 +8042,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
@@ -8467,7 +8051,6 @@
 	},
 /obj/machinery/light,
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
@@ -8482,8 +8065,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "asI" = (
@@ -8498,7 +8080,6 @@
 	},
 /obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig)
@@ -8507,7 +8088,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig)
@@ -8524,8 +8104,7 @@
 /obj/machinery/camera/autoname/almayer,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig_cells)
 "asL" = (
@@ -8533,7 +8112,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-blue (NORTH)";
 	icon_state = "blue";
 	dir = 1
 	},
@@ -8543,7 +8121,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-bluecorner";
 	icon_state = "bluecorner";
 	dir = 1
 	},
@@ -8554,8 +8131,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "asO" = (
@@ -8566,7 +8142,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/chief_mp_office)
@@ -8576,7 +8151,6 @@
 	},
 /obj/machinery/door/airlock/multi_tile/almayer/secdoor,
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig)
@@ -8587,7 +8161,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig)
@@ -8600,7 +8173,6 @@
 "asS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig)
@@ -8615,15 +8187,13 @@
 	},
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/chief_mp_office)
 "asV" = (
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/command/cic)
 "asW" = (
@@ -8647,22 +8217,19 @@
 	},
 /obj/item/storage/firstaid/adv,
 /turf/open/floor/almayer{
-	tag = "icon-bluefull";
 	icon_state = "bluefull"
 	},
 /area/almayer/command/cic)
 "asX" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/almayer{
-	tag = "icon-orangefull";
 	icon_state = "orangefull"
 	},
 /area/almayer/command/cic)
 "asY" = (
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "asZ" = (
@@ -8671,21 +8238,18 @@
 /area/almayer/command/cic)
 "ata" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-22"
 	},
 /turf/open/floor/almayer/mono,
 /area/almayer/shipboard/chief_mp_office)
 "atb" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (NORTH)";
 	icon_state = "redcorner";
 	dir = 1
 	},
 /area/almayer/command/cic)
 "atc" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (EAST)";
 	icon_state = "redcorner";
 	dir = 4
 	},
@@ -8696,14 +8260,12 @@
 /area/almayer/command/cic)
 "ate" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (NORTH)";
 	icon_state = "orangecorner";
 	dir = 1
 	},
 /area/almayer/command/cic)
 "atf" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -8711,13 +8273,11 @@
 "atg" = (
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "ath" = (
 /turf/open/floor/almayer{
-	tag = "icon-silvercorner";
 	icon_state = "silvercorner";
 	dir = 2
 	},
@@ -8727,7 +8287,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/starboard_atmos)
@@ -8736,8 +8295,7 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/command/cic)
 "atk" = (
@@ -8762,7 +8320,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (EAST)";
 	icon_state = "sterile_green_corner";
 	dir = 4
 	},
@@ -8801,7 +8358,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (NORTH)";
 	icon_state = "greencorner";
 	dir = 1
 	},
@@ -8827,7 +8383,6 @@
 /obj/item/weapon/gun/pistol/m4a3,
 /obj/item/weapon/gun/pistol/m4a3,
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/medical/upper_medical)
@@ -8854,27 +8409,23 @@
 /obj/item/weapon/gun/smg/m39,
 /obj/item/weapon/gun/smg/m39,
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/medical/upper_medical)
 "atw" = (
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (NORTHEAST)";
 	icon_state = "sterile_green_side";
 	dir = 5
 	},
 /area/almayer/medical/upper_medical)
 "atx" = (
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (NORTHWEST)";
 	icon_state = "sterile_green_side";
 	dir = 9
 	},
 /area/almayer/medical/medical_science)
 "aty" = (
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (NORTHEAST)";
 	icon_state = "sterile_green_side";
 	dir = 5
 	},
@@ -8892,8 +8443,7 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	icon_state = "sterile_green";
-	tag = "icon-sterile"
+	icon_state = "sterile_green"
 	},
 /area/almayer/medical/medical_science)
 "atB" = (
@@ -8904,7 +8454,6 @@
 /obj/item/clipboard,
 /obj/item/camera,
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (NORTH)";
 	icon_state = "sterile_green_corner";
 	dir = 1
 	},
@@ -8915,13 +8464,11 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/hallways/aft_hallway)
 "atD" = (
 /turf/closed/wall/almayer/research/containment/wall/purple{
-	tag = "icon-containment_window (WEST)";
 	icon_state = "containment_window";
 	dir = 8
 	},
@@ -8959,8 +8506,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/hull/upper_hull)
 "atJ" = (
@@ -9000,8 +8546,7 @@
 /obj/effect/spawner/random/technology_scanner,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "atM" = (
@@ -9024,19 +8569,16 @@
 /obj/machinery/power/apc/almayer,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/engine_core)
 "atO" = (
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "atP" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (WEST)";
 	icon_state = "orangecorner";
 	dir = 8
 	},
@@ -9044,7 +8586,6 @@
 "atQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -9068,7 +8609,6 @@
 	req_access_txt = "3"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/engineering/upper_engineering)
@@ -9111,15 +8651,13 @@
 /obj/item/weapon/gun/pistol/m4a3,
 /obj/item/weapon/gun/pistol/m4a3,
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/engineering/upper_engineering)
 "atX" = (
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/ce_room)
 "atY" = (
@@ -9127,13 +8665,11 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/ce_room)
 "atZ" = (
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/ce_room)
@@ -9149,7 +8685,6 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (WEST)";
 	icon_state = "orangecorner";
 	dir = 8
 	},
@@ -9163,8 +8698,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/ce_room)
 "auc" = (
@@ -9181,8 +8715,7 @@
 /obj/structure/closet/toolcloset,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "aue" = (
@@ -9191,8 +8724,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/basketball)
 "auf" = (
@@ -9203,8 +8735,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "aug" = (
@@ -9214,7 +8745,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (NORTH)";
 	icon_state = "orangecorner";
 	dir = 1
 	},
@@ -9222,7 +8752,6 @@
 "auh" = (
 /obj/machinery/alarm,
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (NORTH)";
 	icon_state = "orangecorner";
 	dir = 1
 	},
@@ -9259,7 +8788,6 @@
 	name = "\improper Self Destruct Control Room"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/command/self_destruct)
@@ -9300,23 +8828,20 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/chief_mp_office)
 "aus" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/chief_mp_office)
 "aut" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig_cells)
 "auu" = (
@@ -9374,7 +8899,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig)
@@ -9391,7 +8915,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig)
@@ -9431,8 +8954,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
 "auD" = (
@@ -9467,15 +8989,13 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/shipboard/brig)
 "auH" = (
 /obj/machinery/computer/forensic_scanning,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/shipboard/brig)
 "auI" = (
@@ -9487,8 +9007,7 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/shipboard/brig)
 "auJ" = (
@@ -9496,7 +9015,6 @@
 	dir = 5
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (NORTH)";
 	icon_state = "redcorner";
 	dir = 1
 	},
@@ -9507,8 +9025,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/numbertwobunks)
 "auL" = (
@@ -9532,15 +9049,13 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig)
 "auN" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/chief_mp_office)
 "auO" = (
@@ -9571,14 +9086,12 @@
 	},
 /obj/item/storage/firstaid/toxin,
 /turf/open/floor/almayer{
-	tag = "icon-bluefull";
 	icon_state = "bluefull"
 	},
 /area/almayer/command/cic)
 "auQ" = (
 /obj/structure/closet/secure_closet/engineering_welding,
 /turf/open/floor/almayer{
-	tag = "icon-orangefull";
 	icon_state = "orangefull"
 	},
 /area/almayer/command/cic)
@@ -9603,14 +9116,12 @@
 /area/almayer/command/cic)
 "auU" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/almayer,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/weapon_room)
 "auV" = (
@@ -9640,16 +9151,14 @@
 /obj/item/tool/pen,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "auY" = (
 /obj/machinery/firealarm,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/weapon_room)
 "auZ" = (
@@ -9667,8 +9176,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/chemistry)
 "ava" = (
@@ -9678,7 +9186,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (WEST)";
 	icon_state = "greencorner";
 	dir = 8
 	},
@@ -9686,8 +9193,7 @@
 "avb" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/corporateliaison)
 "avc" = (
@@ -9809,8 +9315,7 @@
 /area/almayer/medical/upper_medical)
 "avp" = (
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/upper_medical)
 "avq" = (
@@ -9822,8 +9327,7 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/upper_medical)
 "avr" = (
@@ -9834,8 +9338,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/upper_medical)
 "avs" = (
@@ -9858,8 +9361,7 @@
 	name = "\improper Experimental Operating Theatre"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/medical_science)
 "avt" = (
@@ -9870,8 +9372,7 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/medical_science)
 "avu" = (
@@ -9879,8 +9380,7 @@
 /obj/item/tank/anesthetic,
 /obj/item/clothing/mask/breath/medical,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/medical_science)
 "avv" = (
@@ -9898,15 +9398,13 @@
 /obj/item/reagent_container/spray/cleaner,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "avw" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "avx" = (
@@ -9921,8 +9419,7 @@
 	name = "\improper Containment Cell 3"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/medical_science)
 "avy" = (
@@ -9948,7 +9445,6 @@
 	dir = 6
 	},
 /turf/open/floor/almayer{
-	tag = "icon-silvercorner";
 	icon_state = "silvercorner";
 	dir = 2
 	},
@@ -10000,8 +9496,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/basketball)
 "avJ" = (
@@ -10019,8 +9514,7 @@
 "avL" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/command/telecomms)
 "avM" = (
@@ -10030,8 +9524,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "avN" = (
@@ -10047,8 +9540,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "avP" = (
@@ -10095,8 +9587,7 @@
 /obj/item/storage/surgical_tray,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/operating_room_two)
 "avU" = (
@@ -10107,8 +9598,7 @@
 /obj/machinery/camera/autoname/almayer,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/squads/req)
 "avV" = (
@@ -10135,7 +9625,6 @@
 /area/almayer/command/self_destruct)
 "avY" = (
 /turf/open/shuttle/escapepod{
-	tag = "icon-floor8";
 	icon_state = "floor8"
 	},
 /area/almayer/command/self_destruct)
@@ -10166,7 +9655,6 @@
 "awd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/chief_mp_office)
@@ -10190,7 +9678,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig)
@@ -10199,7 +9686,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig)
@@ -10208,15 +9694,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "awi" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/numbertwobunks)
 "awj" = (
@@ -10238,8 +9722,7 @@
 /obj/item/clothing/gloves/latex,
 /obj/item/tool/taperoll/police,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/shipboard/brig)
 "awl" = (
@@ -10248,8 +9731,7 @@
 	},
 /obj/structure/window/reinforced,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/shipboard/brig)
 "awm" = (
@@ -10289,15 +9771,13 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "awq" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/shipboard/brig)
 "awr" = (
@@ -10308,8 +9788,7 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/shipboard/brig)
 "aws" = (
@@ -10318,8 +9797,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "awt" = (
@@ -10336,7 +9814,6 @@
 /obj/item/reagent_container/food/snacks/meatsteak,
 /obj/item/tool/crowbar,
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (WEST)";
 	icon_state = "carpetside";
 	dir = 8
 	},
@@ -10344,8 +9821,7 @@
 "awv" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/numbertwobunks)
 "aww" = (
@@ -10358,7 +9834,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/command/cic)
@@ -10377,14 +9852,12 @@
 	req_access_txt = "14"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (SOUTHWEST)";
 	icon_state = "sterile_green_side";
 	dir = 10
 	},
 /area/almayer/medical/upper_medical)
 "awz" = (
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (SOUTHEAST)";
 	icon_state = "sterile_green_side";
 	dir = 6
 	},
@@ -10396,15 +9869,13 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "awB" = (
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "awC" = (
@@ -10413,8 +9884,7 @@
 	req_access_txt = "20"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/medical_science)
 "awD" = (
@@ -10425,7 +9895,6 @@
 /obj/item/weapon/gun/flamer,
 /obj/item/explosive/grenade/incendiary,
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (NORTH)";
 	icon_state = "sterile_green_corner";
 	dir = 1
 	},
@@ -10433,13 +9902,11 @@
 "awE" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "awF" = (
 /turf/closed/wall/almayer/research/containment/wall/purple{
-	tag = "icon-containment_window (EAST)";
 	icon_state = "containment_window";
 	dir = 4
 	},
@@ -10467,8 +9934,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/hull/upper_hull)
 "awK" = (
@@ -10493,7 +9959,6 @@
 /area/almayer/command/telecomms)
 "awO" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-22"
 	},
 /obj/machinery/light{
@@ -10501,8 +9966,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "awP" = (
@@ -10551,8 +10015,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "awW" = (
@@ -10565,7 +10028,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
@@ -10578,8 +10040,7 @@
 "awY" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "awZ" = (
@@ -10627,13 +10088,11 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "axg" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -10648,8 +10107,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/operating_room_two)
 "axi" = (
@@ -10681,7 +10139,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (EAST)";
 	icon_state = "sterile_green_corner";
 	dir = 4
 	},
@@ -10694,7 +10151,6 @@
 /area/almayer/command/self_destruct)
 "axn" = (
 /turf/open/shuttle/escapepod{
-	tag = "icon-floor1";
 	icon_state = "floor1"
 	},
 /area/almayer/command/self_destruct)
@@ -10716,7 +10172,6 @@
 "axq" = (
 /obj/machinery/alarm,
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -10746,7 +10201,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (NORTH)";
 	icon_state = "redcorner";
 	dir = 1
 	},
@@ -10754,7 +10208,6 @@
 "axu" = (
 /obj/structure/flora/pottedplant/ten,
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/shipboard/brig)
@@ -10762,8 +10215,7 @@
 /obj/structure/bed/chair,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "axw" = (
@@ -10778,8 +10230,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/chief_mp_office)
 "axy" = (
@@ -10796,7 +10247,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/chief_mp_office)
@@ -10806,7 +10256,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (EAST)";
 	icon_state = "redcorner";
 	dir = 4
 	},
@@ -10824,8 +10273,7 @@
 /obj/machinery/alarm,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "axC" = (
@@ -10840,13 +10288,11 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/chief_mp_office)
 "axD" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (WEST)";
 	icon_state = "redcorner";
 	dir = 8
 	},
@@ -10855,14 +10301,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "axF" = (
 /obj/machinery/light,
 /turf/open/floor/almayer{
-	tag = "icon-greencorner";
 	icon_state = "greencorner";
 	dir = 2
 	},
@@ -10870,7 +10314,6 @@
 "axG" = (
 /obj/structure/bed/chair/office/dark,
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
@@ -10879,7 +10322,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
@@ -10899,7 +10341,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/command/cic)
@@ -10908,7 +10349,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
@@ -10916,8 +10356,7 @@
 /obj/structure/bed/chair,
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "axL" = (
@@ -10931,7 +10370,6 @@
 	dir = 9
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (EAST)";
 	icon_state = "redcorner";
 	dir = 4
 	},
@@ -10951,8 +10389,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "axP" = (
@@ -10966,7 +10403,6 @@
 /area/almayer/command/cic)
 "axQ" = (
 /turf/open/floor/almayer{
-	tag = "icon-silvercorner (NORTH)";
 	icon_state = "silvercorner";
 	dir = 1
 	},
@@ -11049,8 +10485,7 @@
 /obj/item/storage/surgical_tray,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/operating_room_three)
 "axY" = (
@@ -11075,8 +10510,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/operating_room_three)
 "aya" = (
@@ -11084,15 +10518,13 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/aft_hallway)
 "ayb" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/hallways/aft_hallway)
 "ayc" = (
@@ -11105,7 +10537,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/aft_hallway)
@@ -11117,8 +10548,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/hallways/aft_hallway)
 "aye" = (
@@ -11129,8 +10559,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
 "ayf" = (
@@ -11165,8 +10594,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
 "ayi" = (
@@ -11188,7 +10616,6 @@
 	req_one_access_txt = "3"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/medical/upper_medical)
@@ -11196,7 +10623,6 @@
 /obj/machinery/light,
 /obj/structure/closet/secure_closet/animal,
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/medical/upper_medical)
@@ -11206,8 +10632,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
 "ayo" = (
@@ -11215,7 +10640,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (EAST)";
 	icon_state = "sterile_green_corner";
 	dir = 4
 	},
@@ -11227,16 +10651,14 @@
 /obj/structure/closet/l3closet/general,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "ayq" = (
 /obj/structure/closet/l3closet/virology,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "ayr" = (
@@ -11250,8 +10672,7 @@
 	name = "\improper Research Pens"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/medical_science)
 "ays" = (
@@ -11259,8 +10680,7 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/medical_science)
 "ayt" = (
@@ -11273,8 +10693,7 @@
 	name = "\improper Containment Lockdown"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/medical_science)
 "ayu" = (
@@ -11284,8 +10703,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "ayv" = (
@@ -11331,8 +10749,7 @@
 	req_one_access_txt = "19"
 	},
 /turf/open/floor/almayer{
-	icon_state = "ai_floors";
-	tag = "icon-sterile"
+	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "ayA" = (
@@ -11351,8 +10768,7 @@
 	},
 /mob/living/silicon/decoy/ship_ai,
 /turf/open/floor/almayer{
-	icon_state = "ai_floors";
-	tag = "icon-sterile"
+	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "ayC" = (
@@ -11380,8 +10796,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_corner";
-	tag = "icon-sterile_green_corner"
+	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/lower_medical)
 "ayD" = (
@@ -11418,7 +10833,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (EAST)";
 	icon_state = "sterile_green_corner";
 	dir = 4
 	},
@@ -11429,8 +10843,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/repair_bay)
 "ayJ" = (
@@ -11438,7 +10851,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -11448,7 +10860,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (NORTH)";
 	icon_state = "orangecorner";
 	dir = 1
 	},
@@ -11457,8 +10868,7 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "ayM" = (
@@ -11467,8 +10877,7 @@
 "ayN" = (
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "ayO" = (
@@ -11477,15 +10886,13 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "ayP" = (
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "ayQ" = (
@@ -11507,8 +10914,7 @@
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "ayS" = (
@@ -11523,8 +10929,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "ayU" = (
@@ -11533,8 +10938,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "ayV" = (
@@ -11544,8 +10948,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "ayW" = (
@@ -11560,7 +10963,6 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (NORTH)";
 	icon_state = "orangecorner";
 	dir = 1
 	},
@@ -11580,7 +10982,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -11611,7 +11012,6 @@
 	dir = 6
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (NORTH)";
 	icon_state = "orangecorner";
 	dir = 1
 	},
@@ -11649,7 +11049,6 @@
 	dir = 10
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -11666,7 +11065,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orange (NORTH)";
 	icon_state = "orange";
 	dir = 1
 	},
@@ -11691,8 +11089,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/command/self_destruct)
 "azh" = (
@@ -11725,8 +11122,7 @@
 /obj/machinery/power/apc/almayer,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/port_hallway)
 "azk" = (
@@ -11742,8 +11138,7 @@
 /obj/machinery/power/apc/almayer,
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engineering)
 "azm" = (
@@ -11751,7 +11146,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (WEST)";
 	icon_state = "redcorner";
 	dir = 8
 	},
@@ -11761,7 +11155,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig)
@@ -11770,7 +11163,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig)
@@ -11779,20 +11171,17 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig)
 "azq" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-21"
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/chief_mp_office)
 "azr" = (
@@ -11817,8 +11206,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "azt" = (
@@ -11833,7 +11221,6 @@
 	on = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/chief_mp_office)
@@ -12034,8 +11421,7 @@
 /obj/item/whistle,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "azM" = (
@@ -12078,8 +11464,7 @@
 /obj/structure/bed/chair/office/dark,
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "azR" = (
@@ -12111,8 +11496,7 @@
 /obj/machinery/firealarm,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engine_monitoring)
 "azU" = (
@@ -12137,8 +11521,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/hallways/aft_hallway)
 "azV" = (
@@ -12158,8 +11541,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/hallways/aft_hallway)
 "azW" = (
@@ -12203,7 +11585,6 @@
 "aAa" = (
 /obj/machinery/chem_master,
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (NORTH)";
 	icon_state = "sterile_green_corner";
 	dir = 1
 	},
@@ -12212,8 +11593,7 @@
 /obj/machinery/computer/pandemic,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aAc" = (
@@ -12221,19 +11601,16 @@
 	dir = 1
 	},
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-22"
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aAd" = (
 /obj/machinery/power/apc/almayer,
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/door_control{
@@ -12245,16 +11622,14 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/cryo_tubes)
 "aAe" = (
 /obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aAf" = (
@@ -12263,8 +11638,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aAg" = (
@@ -12272,8 +11646,7 @@
 	on = 1
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/medical_science)
 "aAh" = (
@@ -12282,8 +11655,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aAi" = (
@@ -12292,8 +11664,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aAj" = (
@@ -12303,8 +11674,7 @@
 	req_one_access_txt = "0"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/medical_science)
 "aAk" = (
@@ -12313,8 +11683,7 @@
 	},
 /obj/structure/closet/secure_closet/animal,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/medical_science)
 "aAl" = (
@@ -12344,8 +11713,7 @@
 	name = "\improper ARES Core Shutters"
 	},
 /turf/open/floor/almayer{
-	icon_state = "ai_floors";
-	tag = "icon-sterile"
+	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "aAn" = (
@@ -12355,8 +11723,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	icon_state = "ai_floors";
-	tag = "icon-sterile"
+	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "aAo" = (
@@ -12366,8 +11733,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/almayer{
-	icon_state = "ai_floors";
-	tag = "icon-sterile"
+	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "aAp" = (
@@ -12377,8 +11743,7 @@
 	name = "\improper ARES Core Shutters"
 	},
 /turf/open/floor/almayer{
-	icon_state = "ai_floors";
-	tag = "icon-sterile"
+	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "aAq" = (
@@ -12386,8 +11751,7 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	icon_state = "ai_floors";
-	tag = "icon-sterile"
+	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "aAr" = (
@@ -12400,7 +11764,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-silvercorner";
 	icon_state = "silvercorner";
 	dir = 2
 	},
@@ -12510,8 +11873,7 @@
 /obj/machinery/vending/snack,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "aAA" = (
@@ -12530,7 +11892,6 @@
 	},
 /obj/machinery/door/window/westright,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/engineering/upper_engineering)
@@ -12540,7 +11901,6 @@
 	},
 /obj/effect/landmark/start/marine/maintenancetech,
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (NORTH)";
 	icon_state = "orangecorner";
 	dir = 1
 	},
@@ -12564,7 +11924,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -12682,7 +12041,6 @@
 /area/almayer/engineering/upper_engineering)
 "aAP" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/engineering/upper_engineering)
@@ -12696,8 +12054,7 @@
 /obj/item/storage/surgical_tray,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/operating_room_four)
 "aAR" = (
@@ -12740,16 +12097,14 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "aAV" = (
 /obj/machinery/alarm,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engineering)
 "aAW" = (
@@ -12812,8 +12167,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/operating_room_four)
 "aBe" = (
@@ -12833,7 +12187,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/shipboard/chief_mp_office)
@@ -12848,7 +12201,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (WEST)";
 	icon_state = "redcorner";
 	dir = 8
 	},
@@ -12860,8 +12212,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "aBi" = (
@@ -12872,8 +12223,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "aBj" = (
@@ -12889,8 +12239,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "aBk" = (
@@ -12947,7 +12296,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/chief_mp_office)
@@ -12982,7 +12330,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
@@ -12997,7 +12344,6 @@
 /obj/item/storage/fancy/cigar,
 /obj/item/tool/lighter/zippo,
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig)
@@ -13063,8 +12409,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/port_missiles)
 "aBA" = (
@@ -13088,8 +12433,7 @@
 /obj/item/camera_film,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "aBD" = (
@@ -13103,20 +12447,17 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/command/cic)
 "aBF" = (
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
 "aBG" = (
 /obj/machinery/light,
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
@@ -13124,8 +12465,7 @@
 /obj/machinery/light,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/hallways/aft_hallway)
 "aBI" = (
@@ -13133,7 +12473,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (EAST)";
 	icon_state = "sterile_green_corner";
 	dir = 4
 	},
@@ -13141,17 +12480,14 @@
 "aBJ" = (
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_corner";
-	tag = "icon-sterile_green_corner (NORTH)"
+	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/upper_medical)
 "aBK" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-21"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (NORTH)";
 	icon_state = "sterile_green_corner";
 	dir = 1
 	},
@@ -13165,8 +12501,7 @@
 /obj/item/tool/pen,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_corner";
-	tag = "icon-sterile_green_corner (NORTH)"
+	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/upper_medical)
 "aBM" = (
@@ -13174,16 +12509,14 @@
 /obj/machinery/microwave,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
 "aBN" = (
 /obj/structure/table/almayer,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
 "aBO" = (
@@ -13193,16 +12526,14 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
 "aBP" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
 "aBQ" = (
@@ -13213,8 +12544,7 @@
 	name = "\improper Research Lockdown"
 	},
 /turf/open/floor/almayer{
-	icon_state = "sterile_green";
-	tag = "icon-sterile"
+	icon_state = "sterile_green"
 	},
 /area/almayer/medical/medical_science)
 "aBR" = (
@@ -13223,8 +12553,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aBS" = (
@@ -13232,8 +12561,7 @@
 	dir = 6
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/medical_science)
 "aBT" = (
@@ -13246,8 +12574,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/medical_science)
 "aBU" = (
@@ -13255,7 +12582,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (SOUTHEAST)";
 	icon_state = "sterile_green_side";
 	dir = 6
 	},
@@ -13273,8 +12599,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aBW" = (
@@ -13282,7 +12607,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (SOUTHWEST)";
 	icon_state = "sterile_green_side";
 	dir = 10
 	},
@@ -13292,8 +12616,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/medical_science)
 "aBY" = (
@@ -13302,8 +12625,7 @@
 	},
 /obj/structure/bed/chair/office/dark,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/medical_science)
 "aBZ" = (
@@ -13320,8 +12642,7 @@
 	name = "\improper Research Pens"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/medical_science)
 "aCa" = (
@@ -13330,8 +12651,7 @@
 	},
 /obj/machinery/light,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/medical_science)
 "aCb" = (
@@ -13344,8 +12664,7 @@
 	name = "\improper Research Pens"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/medical_science)
 "aCc" = (
@@ -13355,8 +12674,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aCd" = (
@@ -13371,8 +12689,7 @@
 /area/almayer/hull/upper_hull)
 "aCe" = (
 /turf/open/floor/almayer{
-	icon_state = "ai_floors";
-	tag = "icon-sterile"
+	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "aCf" = (
@@ -13383,16 +12700,14 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	icon_state = "ai_floors";
-	tag = "icon-sterile"
+	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "aCg" = (
 /obj/structure/table/almayer,
 /obj/machinery/computer/station_alert,
 /turf/open/floor/almayer{
-	icon_state = "ai_floors";
-	tag = "icon-sterile"
+	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "aCh" = (
@@ -13400,8 +12715,7 @@
 /obj/item/paper_bin,
 /obj/item/tool/pen,
 /turf/open/floor/almayer{
-	icon_state = "ai_floors";
-	tag = "icon-sterile"
+	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "aCi" = (
@@ -13437,8 +12751,7 @@
 /obj/machinery/camera/autoname/almayer,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/repair_bay)
 "aCn" = (
@@ -13459,8 +12772,7 @@
 /obj/machinery/camera/autoname/almayer,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_corner";
-	tag = "icon-sterile_green_corner (NORTH)"
+	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/medical_science)
 "aCq" = (
@@ -13474,8 +12786,7 @@
 /obj/machinery/disposal,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "aCs" = (
@@ -13499,7 +12810,6 @@
 /obj/machinery/door/window/westright,
 /obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/engineering/upper_engineering)
@@ -13508,7 +12818,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
@@ -13521,7 +12830,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (WEST)";
 	icon_state = "orangecorner";
 	dir = 8
 	},
@@ -13529,7 +12837,6 @@
 "aCx" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
@@ -13546,7 +12853,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (WEST)";
 	icon_state = "orangecorner";
 	dir = 8
 	},
@@ -13564,7 +12870,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/engineering/upper_engineering)
@@ -13581,7 +12886,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
@@ -13620,7 +12924,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
@@ -13640,7 +12943,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
@@ -13660,7 +12962,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
@@ -13680,7 +12981,6 @@
 	dir = 10
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (WEST)";
 	icon_state = "orangecorner";
 	dir = 8
 	},
@@ -13739,8 +13039,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "aCM" = (
@@ -13781,7 +13080,6 @@
 /obj/machinery/light,
 /obj/structure/flora/pottedplant,
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
@@ -13813,7 +13111,6 @@
 	pixel_y = -30
 	},
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
@@ -13824,7 +13121,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (WEST)";
 	icon_state = "redcorner";
 	dir = 8
 	},
@@ -13917,13 +13213,11 @@
 	},
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/repair_bay)
 "aDb" = (
 /obj/structure/bed/chair/comfy/black{
-	tag = "icon-comfychair (NORTH)";
 	icon_state = "comfychair";
 	dir = 1
 	},
@@ -13931,7 +13225,6 @@
 /area/almayer/command/cic)
 "aDc" = (
 /obj/structure/bed/chair/comfy/black{
-	tag = "icon-comfychair (NORTH)";
 	icon_state = "comfychair";
 	dir = 1
 	},
@@ -13939,7 +13232,6 @@
 /area/almayer/command/cic)
 "aDd" = (
 /obj/structure/bed/chair/comfy/black{
-	tag = "icon-comfychair (NORTH)";
 	icon_state = "comfychair";
 	dir = 1
 	},
@@ -13948,8 +13240,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "aDe" = (
@@ -13979,7 +13270,6 @@
 /obj/item/paper_bin,
 /obj/item/tool/pen/blue,
 /obj/machinery/door/window/brigdoor/westleft{
-	tag = "icon-leftsecure (NORTH)";
 	icon_state = "leftsecure";
 	dir = 1;
 	id = "brg"
@@ -13988,8 +13278,7 @@
 	dir = 2;
 	icon_state = "leftsecure";
 	id = "brg";
-	name = "Security Desk";
-	tag = "icon-leftsecure (NORTH)"
+	name = "Security Desk"
 	},
 /turf/open/floor/tile/dark2,
 /area/almayer/hallways/aft_hallway)
@@ -14016,8 +13305,7 @@
 "aDm" = (
 /obj/machinery/optable,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/upper_medical)
 "aDn" = (
@@ -14026,8 +13314,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
 "aDo" = (
@@ -14039,8 +13326,7 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
 "aDq" = (
@@ -14048,8 +13334,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/upper_medical)
 "aDr" = (
@@ -14057,8 +13342,7 @@
 /obj/machinery/computer/med_data/laptop,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
 "aDs" = (
@@ -14077,15 +13361,13 @@
 	name = "\improper Research Lockdown"
 	},
 /turf/open/floor/almayer{
-	icon_state = "sterile_green";
-	tag = "icon-sterile"
+	icon_state = "sterile_green"
 	},
 /area/almayer/medical/medical_science)
 "aDu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/medical_science)
 "aDv" = (
@@ -14095,8 +13377,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/medical_science)
 "aDw" = (
@@ -14108,8 +13389,7 @@
 /obj/item/storage/box/masks,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aDx" = (
@@ -14121,8 +13401,7 @@
 /obj/item/assembly/signaler,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aDy" = (
@@ -14131,8 +13410,7 @@
 /obj/item/stack/cable_coil/orange,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aDz" = (
@@ -14165,8 +13443,7 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aDB" = (
@@ -14175,8 +13452,7 @@
 /obj/item/radio,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aDC" = (
@@ -14187,7 +13463,6 @@
 	req_one_access_txt = "19"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (EAST)";
 	icon_state = "sterile_green_corner";
 	dir = 4
 	},
@@ -14201,13 +13476,11 @@
 /obj/item/explosive/grenade/incendiary,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_corner";
-	tag = "icon-sterile_green_corner"
+	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/medical_science)
 "aDE" = (
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (SOUTHWEST)";
 	icon_state = "sterile_green_side";
 	dir = 10
 	},
@@ -14230,8 +13503,7 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "aDI" = (
@@ -14273,8 +13545,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "aDN" = (
@@ -14322,8 +13593,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "aDU" = (
@@ -14336,8 +13606,7 @@
 /obj/item/tool/pen,
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "aDW" = (
@@ -14374,7 +13643,6 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/engineering/upper_engineering)
@@ -14383,7 +13651,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-blue";
 	icon_state = "blue"
 	},
 /area/almayer/living/pilotbunks)
@@ -14395,8 +13662,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "aEd" = (
@@ -14418,8 +13684,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "aEg" = (
@@ -14445,7 +13710,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/brig)
@@ -14540,7 +13804,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig)
@@ -14555,7 +13818,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig)
@@ -14588,7 +13850,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redcorner";
 	icon_state = "redcorner"
 	},
 /area/almayer/shipboard/chief_mp_office)
@@ -14602,8 +13863,7 @@
 /obj/item/tool/hand_labeler,
 /obj/item/reagent_container/spray/cleaner,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/shipboard/brig)
 "aEt" = (
@@ -14621,7 +13881,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (NORTH)";
 	icon_state = "redcorner";
 	dir = 1
 	},
@@ -14643,7 +13902,6 @@
 	range = 3
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (EAST)";
 	icon_state = "redcorner";
 	dir = 4
 	},
@@ -14660,8 +13918,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig_cells)
 "aEx" = (
@@ -14680,7 +13937,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig_cells)
@@ -14701,8 +13957,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig_cells)
 "aEz" = (
@@ -14714,7 +13969,6 @@
 /obj/item/ammo_magazine/shotgun/buckshot,
 /obj/structure/closet/secure_closet/guncabinet,
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/command/cic)
@@ -14725,7 +13979,6 @@
 "aEB" = (
 /obj/structure/closet/secure_closet/staff_officer,
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/command/cic)
@@ -14753,8 +14006,7 @@
 "aED" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig_cells)
 "aEE" = (
@@ -14776,8 +14028,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
 "aEH" = (
@@ -14794,15 +14045,13 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
 "aEJ" = (
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
 "aEK" = (
@@ -14847,7 +14096,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (WEST)";
 	icon_state = "greencorner";
 	dir = 8
 	},
@@ -14856,14 +14104,12 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_corner";
-	tag = "icon-sterile_green_corner"
+	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/upper_medical)
 "aER" = (
 /obj/machinery/camera/autoname/almayer,
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -14873,7 +14119,6 @@
 /obj/item/clipboard,
 /obj/item/tool/hand_labeler,
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (EAST)";
 	icon_state = "sterile_green_corner";
 	dir = 4
 	},
@@ -14895,16 +14140,14 @@
 /obj/structure/bed/chair/office/dark,
 /obj/effect/landmark/start/marine/researcher,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/medical_science)
 "aEW" = (
 /obj/structure/closet/secure_closet/medical1,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aEX" = (
@@ -14924,8 +14167,7 @@
 	name = "\improper Containment Cell 4"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/medical_science)
 "aEZ" = (
@@ -14933,7 +14175,6 @@
 	dir = 5
 	},
 /turf/open/floor/almayer{
-	tag = "icon-silvercorner (EAST)";
 	icon_state = "silvercorner";
 	dir = 4
 	},
@@ -14997,7 +14238,6 @@
 	dir = 5
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -15017,8 +14257,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "aFj" = (
@@ -15036,8 +14275,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "aFk" = (
@@ -15053,7 +14291,6 @@
 	dir = 9
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (NORTH)";
 	icon_state = "orangecorner";
 	dir = 1
 	},
@@ -15160,8 +14397,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig_cells)
 "aFu" = (
@@ -15187,7 +14423,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig)
@@ -15199,7 +14434,6 @@
 	dir = 9
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig)
@@ -15212,8 +14446,7 @@
 /obj/machinery/faxmachine/research,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aFz" = (
@@ -15240,8 +14473,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/command/cic)
 "aFB" = (
@@ -15273,21 +14505,18 @@
 	},
 /obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig)
 "aFE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig_cells)
 "aFF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig_cells)
@@ -15315,7 +14544,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/command/cic)
@@ -15332,8 +14560,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "aFJ" = (
@@ -15365,7 +14592,6 @@
 /obj/item/ammo_magazine/rifle/m41aMK1,
 /obj/structure/closet/secure_closet/guncabinet,
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/command/cic)
@@ -15377,7 +14603,6 @@
 	},
 /obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig_cells)
@@ -15389,7 +14614,6 @@
 /obj/item/tool/extinguisher/mini,
 /obj/machinery/camera/autoname/almayer,
 /turf/open/floor/almayer{
-	tag = "icon-orangefull";
 	icon_state = "orangefull"
 	},
 /area/almayer/command/cic)
@@ -15400,7 +14624,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-silvercorner (NORTH)";
 	icon_state = "silvercorner";
 	dir = 1
 	},
@@ -15412,7 +14635,6 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-silvercorner";
 	icon_state = "silvercorner";
 	dir = 2
 	},
@@ -15424,7 +14646,6 @@
 	},
 /obj/machinery/door/airlock/multi_tile/almayer/secdoor,
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (WEST)";
 	icon_state = "redcorner";
 	dir = 8
 	},
@@ -15432,13 +14653,11 @@
 "aFR" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "emeraldcorner";
-	tag = "icon-emeraldcorner (EAST)"
+	icon_state = "emeraldcorner"
 	},
 /area/almayer/command/cic)
 "aFS" = (
 /turf/open/floor/almayer{
-	tag = "icon-emeraldcorner";
 	icon_state = "emeraldcorner"
 	},
 /area/almayer/command/cic)
@@ -15451,20 +14670,17 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/command/cic)
 "aFU" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/command/cic)
 "aFV" = (
 /turf/open/floor/almayer{
-	tag = "icon-bluecorner";
 	icon_state = "bluecorner"
 	},
 /area/almayer/command/cic)
@@ -15476,8 +14692,7 @@
 /obj/machinery/firealarm,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/repair_bay)
 "aFY" = (
@@ -15487,8 +14702,7 @@
 /obj/item/storage/box/ids,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "aFZ" = (
@@ -15500,7 +14714,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (WEST)";
 	icon_state = "orangecorner";
 	dir = 8
 	},
@@ -15509,14 +14722,12 @@
 /obj/machinery/firealarm,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/squads/charlie)
 "aGb" = (
 /obj/machinery/alarm,
 /turf/open/floor/almayer{
-	tag = "icon-emeraldcorner (EAST)";
 	icon_state = "emeraldcorner";
 	dir = 4
 	},
@@ -15526,7 +14737,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/command/cic)
@@ -15541,8 +14751,7 @@
 /obj/machinery/camera/autoname/almayer,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
 "aGf" = (
@@ -15566,8 +14775,7 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
 "aGh" = (
@@ -15596,8 +14804,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "aGl" = (
@@ -15627,8 +14834,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "aGn" = (
@@ -15681,8 +14887,7 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_corner";
-	tag = "icon-sterile_green_corner"
+	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/upper_medical)
 "aGr" = (
@@ -15692,8 +14897,7 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
 "aGs" = (
@@ -15701,8 +14905,7 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
 "aGt" = (
@@ -15716,8 +14919,7 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	icon_state = "sterile_green";
-	tag = "icon-sterile"
+	icon_state = "sterile_green"
 	},
 /area/almayer/medical/upper_medical)
 "aGu" = (
@@ -15750,8 +14952,7 @@
 /obj/machinery/light,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aGz" = (
@@ -15759,14 +14960,12 @@
 /obj/machinery/computer/med_data/laptop,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aGA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (SOUTHWEST)";
 	icon_state = "sterile_green_side";
 	dir = 10
 	},
@@ -15777,8 +14976,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aGC" = (
@@ -15793,7 +14991,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (NORTH)";
 	icon_state = "sterile_green_corner";
 	dir = 1
 	},
@@ -15807,16 +15004,14 @@
 /obj/item/healthanalyzer,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aGE" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aGF" = (
@@ -15824,8 +15019,7 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aGG" = (
@@ -15835,8 +15029,7 @@
 /obj/machinery/chem_dispenser,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aGH" = (
@@ -15852,8 +15045,7 @@
 /obj/item/reagent_container/spray/cleaner,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_corner";
-	tag = "icon-sterile_green_corner"
+	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/medical_science)
 "aGJ" = (
@@ -15864,7 +15056,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (EAST)";
 	icon_state = "sterile_green_corner";
 	dir = 4
 	},
@@ -15899,7 +15090,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (EAST)";
 	icon_state = "redcorner";
 	dir = 4
 	},
@@ -15924,8 +15114,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "aGQ" = (
@@ -15933,7 +15122,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
@@ -15962,8 +15150,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/squads/alpha)
 "aGU" = (
@@ -15994,8 +15181,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "aHa" = (
@@ -16004,8 +15190,7 @@
 /obj/item/clothing/glasses/meson,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "aHb" = (
@@ -16014,8 +15199,7 @@
 /obj/item/clothing/glasses/welding,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "aHc" = (
@@ -16035,25 +15219,21 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/squads/alpha)
 "aHd" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-05"
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "aHe" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (NORTH)";
 	icon_state = "orangecorner";
 	dir = 1
 	},
@@ -16110,8 +15290,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/squads/bravo)
 "aHm" = (
@@ -16129,7 +15308,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redcorner";
 	icon_state = "redcorner"
 	},
 /area/almayer/shipboard/brig_cells)
@@ -16146,8 +15324,7 @@
 	name = "\improper Prisoner Treatment Center"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/shipboard/brig_cells)
 "aHr" = (
@@ -16161,7 +15338,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig_cells)
@@ -16186,7 +15362,6 @@
 /obj/item/ammo_magazine/rifle/lmg,
 /obj/item/weapon/gun/rifle/lmg,
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/command/cic)
@@ -16197,22 +15372,19 @@
 /obj/item/clothing/suit/armor/bulletproof,
 /obj/item/clothing/suit/armor/bulletproof,
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/command/cic)
 "aHw" = (
 /obj/machinery/light,
 /turf/open/floor/almayer{
-	tag = "icon-bluecorner";
 	icon_state = "bluecorner"
 	},
 /area/almayer/hallways/aft_hallway)
 "aHx" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/command/cic)
 "aHy" = (
@@ -16221,8 +15393,7 @@
 /obj/item/whistle,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/command/cic)
 "aHz" = (
@@ -16231,15 +15402,13 @@
 /obj/item/whistle,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/command/cic)
 "aHA" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/command/cic)
 "aHB" = (
@@ -16284,7 +15453,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig)
@@ -16379,8 +15547,7 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/upper_medical)
 "aHN" = (
@@ -16391,7 +15558,6 @@
 /area/almayer/medical/upper_medical)
 "aHO" = (
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (NORTH)";
 	icon_state = "sterile_green_corner";
 	dir = 1
 	},
@@ -16403,8 +15569,7 @@
 /obj/structure/bed/chair,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
 "aHQ" = (
@@ -16414,8 +15579,7 @@
 /obj/structure/bed/chair,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
 "aHR" = (
@@ -16423,8 +15587,7 @@
 /obj/item/paper_bin,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_corner";
-	tag = "icon-sterile_green_corner (NORTH)"
+	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/upper_medical)
 "aHS" = (
@@ -16444,8 +15607,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aHU" = (
@@ -16458,8 +15620,7 @@
 /obj/item/tool/screwdriver,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aHV" = (
@@ -16476,8 +15637,7 @@
 /obj/item/reagent_container/dropper,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aHW" = (
@@ -16485,15 +15645,13 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/medical_science)
 "aHX" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/medical_science)
 "aHY" = (
@@ -16502,8 +15660,7 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/medical_science)
 "aHZ" = (
@@ -16512,8 +15669,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aIa" = (
@@ -16535,7 +15691,6 @@
 /area/almayer/hull/upper_hull)
 "aIc" = (
 /turf/open/floor/almayer{
-	tag = "icon-silvercorner (EAST)";
 	icon_state = "silvercorner";
 	dir = 4
 	},
@@ -16569,8 +15724,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "aIi" = (
@@ -16701,16 +15855,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig_cells)
 "aIA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig_cells)
 "aIB" = (
@@ -16734,7 +15886,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/command/cic)
@@ -16744,8 +15895,7 @@
 /obj/machinery/computer/security/marinemainship,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
 "aIE" = (
@@ -16758,14 +15908,12 @@
 	pixel_y = 25
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/shipboard/brig_cells)
 "aIG" = (
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/shipboard/brig_cells)
 "aIH" = (
@@ -16815,7 +15963,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/squads/bravo)
@@ -16823,8 +15970,7 @@
 /obj/structure/bed/chair/office/dark,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/command/cic)
 "aIM" = (
@@ -16832,8 +15978,7 @@
 /obj/machinery/computer/camera_advanced/overwatch/charlie,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/command/cic)
 "aIN" = (
@@ -16841,16 +15986,14 @@
 /obj/machinery/computer/camera_advanced/overwatch/delta,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/command/cic)
 "aIO" = (
 /obj/structure/bed/chair/office/dark,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/command/cic)
 "aIP" = (
@@ -16871,7 +16014,6 @@
 	dir = 1
 	},
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-18"
 	},
 /turf/open/floor/wood,
@@ -16915,7 +16057,6 @@
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clipboard,
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (NORTH)";
 	icon_state = "sterile_green_corner";
 	dir = 1
 	},
@@ -16924,14 +16065,12 @@
 /obj/machinery/photocopier,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
 "aIZ" = (
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "aJa" = (
@@ -16942,8 +16081,7 @@
 "aJb" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "aJc" = (
@@ -16955,8 +16093,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
 "aJd" = (
@@ -16968,8 +16105,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aJe" = (
@@ -16989,7 +16125,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (NORTHWEST)";
 	icon_state = "sterile_green_side";
 	dir = 9
 	},
@@ -16999,7 +16134,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (NORTHEAST)";
 	icon_state = "sterile_green_side";
 	dir = 5
 	},
@@ -17010,8 +16144,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aJi" = (
@@ -17019,7 +16152,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (NORTHWEST)";
 	icon_state = "sterile_green_side";
 	dir = 9
 	},
@@ -17028,8 +16160,7 @@
 /obj/machinery/chem_master,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aJk" = (
@@ -17093,8 +16224,7 @@
 /obj/item/tool/pen,
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "aJt" = (
@@ -17104,17 +16234,14 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/engineering/upper_engineering)
 "aJu" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-21"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
@@ -17123,7 +16250,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
@@ -17133,8 +16259,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "aJx" = (
@@ -17232,13 +16357,11 @@
 "aJJ" = (
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/stern_hallway)
 "aJK" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (NORTH)";
 	icon_state = "redcorner";
 	dir = 1
 	},
@@ -17297,14 +16420,12 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_corner";
-	tag = "icon-sterile_green_corner (NORTH)"
+	icon_state = "sterile_green_corner"
 	},
 /area/almayer/shipboard/brig_cells)
 "aJT" = (
 /obj/machinery/light,
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig_cells)
@@ -17322,7 +16443,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/aft_hallway)
@@ -17338,8 +16458,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/hallways/aft_hallway)
 "aJW" = (
@@ -17356,8 +16475,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/shipboard/brig_cells)
 "aJY" = (
@@ -17373,14 +16491,12 @@
 /obj/machinery/camera/autoname/almayer,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "aKb" = (
 /obj/structure/bed,
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig_cells)
@@ -17394,7 +16510,6 @@
 "aKd" = (
 /obj/machinery/vending/marine,
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/command/cic)
@@ -17408,14 +16523,12 @@
 /obj/item/smartgun_powerpack/fancy,
 /obj/item/clothing/suit/storage/marine/smartgunner/fancy,
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/command/cic)
 "aKg" = (
 /obj/machinery/vending/uniform_supply,
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/command/cic)
@@ -17447,8 +16560,7 @@
 /obj/machinery/light,
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "aKk" = (
@@ -17461,8 +16573,7 @@
 /obj/structure/prop/almayer/mapping_computer,
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/command/cic)
 "aKl" = (
@@ -17470,7 +16581,6 @@
 	dir = 6
 	},
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/command/cic)
@@ -17480,7 +16590,6 @@
 	dir = 10
 	},
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/command/cic)
@@ -17494,8 +16603,7 @@
 /obj/structure/prop/almayer/mapping_computer,
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/command/cic)
 "aKo" = (
@@ -17508,8 +16616,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/squads/charlie)
 "aKp" = (
@@ -17534,7 +16641,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-emerald";
 	icon_state = "emerald"
 	},
 /area/almayer/squads/charlie)
@@ -17551,7 +16657,6 @@
 	dir = 4
 	},
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (NORTHWEST)";
 	icon_state = "carpetside";
 	dir = 9
 	},
@@ -17563,19 +16668,16 @@
 	pixel_x = 8
 	},
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (NORTH)";
 	icon_state = "carpetside";
 	dir = 1
 	},
 /area/almayer/living/captain_mess)
 "aKu" = (
 /obj/structure/bed/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (WEST)";
 	icon_state = "wooden_chair_wings";
 	dir = 8
 	},
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (NORTHEAST)";
 	icon_state = "carpetside";
 	dir = 5
 	},
@@ -17604,8 +16706,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/squads/delta)
 "aKx" = (
@@ -17641,7 +16742,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-blue";
 	icon_state = "blue"
 	},
 /area/almayer/squads/delta)
@@ -17651,8 +16751,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "aKC" = (
@@ -17669,8 +16768,7 @@
 /obj/item/clipboard,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
 "aKD" = (
@@ -17679,8 +16777,7 @@
 	},
 /obj/effect/landmark/start/marine/cmo,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/upper_medical)
 "aKE" = (
@@ -17688,7 +16785,6 @@
 	dir = 6
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (SOUTHEAST)";
 	icon_state = "sterile_green_side";
 	dir = 6
 	},
@@ -17699,8 +16795,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
 "aKG" = (
@@ -17708,7 +16803,6 @@
 	dir = 10
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (SOUTHWEST)";
 	icon_state = "sterile_green_side";
 	dir = 10
 	},
@@ -17719,8 +16813,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "orange";
-	tag = "icon-orange (NORTH)"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "aKI" = (
@@ -17730,7 +16823,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (NORTHWEST)";
 	icon_state = "sterile_green_side";
 	dir = 9
 	},
@@ -17754,8 +16846,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/upper_medical)
 "aKK" = (
@@ -17771,7 +16862,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (SOUTHEAST)";
 	icon_state = "sterile_green_side";
 	dir = 6
 	},
@@ -17802,8 +16892,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aKM" = (
@@ -17819,7 +16908,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (SOUTHWEST)";
 	icon_state = "sterile_green_side";
 	dir = 10
 	},
@@ -17837,7 +16925,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (SOUTHEAST)";
 	icon_state = "sterile_green_side";
 	dir = 6
 	},
@@ -17849,8 +16936,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "aKP" = (
@@ -17866,7 +16952,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (SOUTHWEST)";
 	icon_state = "sterile_green_side";
 	dir = 10
 	},
@@ -17881,8 +16966,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/medical_science)
 "aKR" = (
@@ -17890,7 +16974,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (SOUTHEAST)";
 	icon_state = "sterile_green_side";
 	dir = 6
 	},
@@ -17907,8 +16990,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aKT" = (
@@ -17916,7 +16998,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (SOUTHWEST)";
 	icon_state = "sterile_green_side";
 	dir = 10
 	},
@@ -17926,8 +17007,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/medical_science)
 "aKV" = (
@@ -17935,8 +17015,7 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/medical_science)
 "aKW" = (
@@ -17944,8 +17023,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/medical_science)
 "aKX" = (
@@ -17953,14 +17031,12 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (WEST)";
 	icon_state = "orangecorner";
 	dir = 8
 	},
 /area/almayer/engineering/lower_engineering)
 "aKY" = (
 /turf/open/floor/almayer{
-	tag = "icon-silvercorner (NORTH)";
 	icon_state = "silvercorner";
 	dir = 1
 	},
@@ -17975,7 +17051,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/hallways/stern_hallway)
@@ -17995,28 +17070,24 @@
 /area/almayer/engineering/upper_engineering)
 "aLb" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner";
 	icon_state = "redcorner"
 	},
 /area/almayer/hallways/stern_hallway)
 "aLc" = (
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/hallways/stern_hallway)
 "aLd" = (
 /obj/machinery/light,
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/hallways/stern_hallway)
 "aLe" = (
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/stern_hallway)
 "aLf" = (
@@ -18024,7 +17095,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (NORTH)";
 	icon_state = "redcorner";
 	dir = 1
 	},
@@ -18035,7 +17105,6 @@
 	on = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (EAST)";
 	icon_state = "redcorner";
 	dir = 4
 	},
@@ -18066,8 +17135,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/shipboard/brig_cells)
 "aLk" = (
@@ -18075,7 +17143,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-greencorner";
 	icon_state = "greencorner";
 	dir = 2
 	},
@@ -18088,7 +17155,6 @@
 	dir = 5
 	},
 /turf/open/floor/almayer{
-	tag = "icon-green";
 	icon_state = "green";
 	dir = 2
 	},
@@ -18109,7 +17175,6 @@
 	dir = 5
 	},
 /turf/open/floor/almayer{
-	tag = "icon-green";
 	icon_state = "green";
 	dir = 2
 	},
@@ -18133,8 +17198,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/starboard_hallway)
 "aLp" = (
@@ -18232,16 +17296,14 @@
 	},
 /obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/upper_medical)
 "aLy" = (
 /obj/structure/closet/secure_closet/CMO,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_corner";
-	tag = "icon-sterile_green_corner"
+	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/upper_medical)
 "aLz" = (
@@ -18250,23 +17312,20 @@
 /obj/item/megaphone,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
 "aLA" = (
 /obj/machinery/computer/crew,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
 "aLB" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_corner";
-	tag = "icon-sterile_green_corner"
+	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/lower_medical)
 "aLC" = (
@@ -18274,7 +17333,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (EAST)";
 	icon_state = "sterile_green_corner";
 	dir = 4
 	},
@@ -18299,8 +17357,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_corner";
-	tag = "icon-sterile_green_corner"
+	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/upper_medical)
 "aLG" = (
@@ -18310,16 +17367,14 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
 "aLH" = (
 /obj/machinery/light,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
 "aLI" = (
@@ -18330,11 +17385,9 @@
 /area/almayer/engineering/engineering_workshop)
 "aLJ" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-22"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (EAST)";
 	icon_state = "sterile_green_corner";
 	dir = 4
 	},
@@ -18343,14 +17396,12 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_corner";
-	tag = "icon-sterile_green_corner"
+	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/medical_science)
 "aLL" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (EAST)";
 	icon_state = "sterile_green_corner";
 	dir = 4
 	},
@@ -18364,8 +17415,7 @@
 /obj/item/storage/firstaid/adv,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_corner";
-	tag = "icon-sterile_green_corner"
+	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/medical_science)
 "aLN" = (
@@ -18381,20 +17431,17 @@
 	},
 /obj/item/storage/firstaid/adv,
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (EAST)";
 	icon_state = "sterile_green_corner";
 	dir = 4
 	},
 /area/almayer/medical/medical_science)
 "aLO" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-21"
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_corner";
-	tag = "icon-sterile_green_corner"
+	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/medical_science)
 "aLP" = (
@@ -18408,8 +17455,7 @@
 /obj/item/mass_spectrometer,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aLQ" = (
@@ -18420,8 +17466,7 @@
 /obj/item/reagent_container/glass/beaker/bluespace,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aLR" = (
@@ -18433,7 +17478,6 @@
 	},
 /obj/item/storage/box/monkeycubes,
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (EAST)";
 	icon_state = "sterile_green_corner";
 	dir = 4
 	},
@@ -18444,8 +17488,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
 "aLT" = (
@@ -18460,8 +17503,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/hallways/aft_hallway)
 "aLV" = (
@@ -18473,8 +17515,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
 "aLW" = (
@@ -18494,8 +17535,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
 "aLZ" = (
@@ -18520,8 +17560,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
 "aMa" = (
@@ -18542,8 +17581,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/hallways/aft_hallway)
 "aMc" = (
@@ -18552,7 +17590,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/aft_hallway)
@@ -18567,8 +17604,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
 "aMe" = (
@@ -18585,8 +17621,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/hallways/aft_hallway)
 "aMf" = (
@@ -18599,8 +17634,7 @@
 /obj/machinery/camera/autoname/almayer,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/squads/alpha)
 "aMh" = (
@@ -18635,7 +17669,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/squads/bravo)
@@ -18666,7 +17699,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/squads/bravo)
@@ -18674,8 +17706,7 @@
 /obj/machinery/camera/autoname/almayer,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/squads/charlie)
 "aMs" = (
@@ -18689,8 +17720,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
 "aMt" = (
@@ -18698,7 +17728,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-blue";
 	icon_state = "blue"
 	},
 /area/almayer/squads/delta)
@@ -18721,7 +17750,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (WEST)";
 	icon_state = "greencorner";
 	dir = 8
 	},
@@ -18739,7 +17767,6 @@
 	},
 /obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig_cells)
@@ -18751,7 +17778,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (EAST)";
 	icon_state = "greencorner";
 	dir = 4
 	},
@@ -18765,8 +17791,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/shipboard/brig_cells)
 "aMA" = (
@@ -18778,8 +17803,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/shipboard/brig_cells)
 "aMB" = (
@@ -18790,7 +17814,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-blue";
 	icon_state = "blue"
 	},
 /area/almayer/squads/delta)
@@ -18859,8 +17882,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "aMI" = (
@@ -18873,7 +17895,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/command/cic)
@@ -18897,7 +17918,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/command/cic)
@@ -18918,7 +17938,6 @@
 	dir = 4
 	},
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (WEST)";
 	icon_state = "carpetside";
 	dir = 8
 	},
@@ -18950,8 +17969,7 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	icon_state = "sterile_green";
-	tag = "icon-sterile"
+	icon_state = "sterile_green"
 	},
 /area/almayer/medical/upper_medical)
 "aMT" = (
@@ -18962,8 +17980,7 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/upper_medical)
 "aMU" = (
@@ -18979,8 +17996,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/upper_medical)
 "aMV" = (
@@ -19021,8 +18037,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "aMZ" = (
@@ -19038,7 +18053,6 @@
 	d2 = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-bluecorner";
 	icon_state = "bluecorner"
 	},
 /area/almayer/hallways/aft_hallway)
@@ -19055,7 +18069,6 @@
 	d2 = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-blue";
 	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
@@ -19074,8 +18087,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/hallways/aft_hallway)
 "aNc" = (
@@ -19114,8 +18126,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/hallways/aft_hallway)
 "aNf" = (
@@ -19132,7 +18143,6 @@
 	d2 = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/aft_hallway)
@@ -19158,7 +18168,6 @@
 "aNi" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
@@ -19219,8 +18228,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/stern_hallway)
 "aNm" = (
@@ -19292,8 +18300,7 @@
 "aNr" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/port_hallway)
 "aNs" = (
@@ -19304,7 +18311,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/port_hallway)
@@ -19312,16 +18318,14 @@
 /obj/machinery/autodoc,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_corner";
-	tag = "icon-sterile_green_corner"
+	icon_state = "sterile_green_corner"
 	},
 /area/almayer/shipboard/brig_cells)
 "aNu" = (
 /obj/machinery/autodoc_console,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/shipboard/brig_cells)
 "aNv" = (
@@ -19330,8 +18334,7 @@
 /obj/item/clothing/mask/breath/medical,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/shipboard/brig_cells)
 "aNw" = (
@@ -19340,7 +18343,6 @@
 /obj/item/reagent_container/spray/surgery,
 /obj/item/autopsy_scanner,
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (EAST)";
 	icon_state = "sterile_green_corner";
 	dir = 4
 	},
@@ -19364,7 +18366,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig_cells)
@@ -19376,7 +18377,6 @@
 "aNB" = (
 /obj/machinery/light,
 /turf/open/floor/almayer{
-	tag = "icon-silver";
 	icon_state = "silver";
 	dir = 2
 	},
@@ -19384,18 +18384,15 @@
 "aNC" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/shipboard/brig_cells)
 "aND" = (
 /obj/structure/bed/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (WEST)";
 	icon_state = "wooden_chair_wings";
 	dir = 8
 	},
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (EAST)";
 	icon_state = "carpetside";
 	dir = 4
 	},
@@ -19410,7 +18407,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/command/cic)
@@ -19512,7 +18508,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engine_monitoring)
@@ -19539,8 +18534,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engine_monitoring)
 "aNR" = (
@@ -19567,14 +18561,12 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/hallways/aft_hallway)
 "aNT" = (
 /obj/machinery/light,
 /turf/open/floor/almayer{
-	tag = "icon-redcorner";
 	icon_state = "redcorner"
 	},
 /area/almayer/shipboard/brig_cells)
@@ -19598,8 +18590,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
 "aNV" = (
@@ -19622,8 +18613,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
 "aNW" = (
@@ -19646,8 +18636,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
 "aNX" = (
@@ -19666,7 +18655,6 @@
 	d2 = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-bluecorner";
 	icon_state = "bluecorner";
 	dir = 1
 	},
@@ -19698,7 +18686,6 @@
 	},
 /obj/machinery/camera/autoname/almayer,
 /turf/open/floor/almayer{
-	tag = "icon-blue (NORTH)";
 	icon_state = "blue";
 	dir = 1
 	},
@@ -19718,14 +18705,12 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-bluecorner";
 	icon_state = "bluecorner";
 	dir = 1
 	},
 /area/almayer/hallways/aft_hallway)
 "aOd" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (WEST)";
 	icon_state = "redcorner";
 	dir = 8
 	},
@@ -19735,7 +18720,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redcorner";
 	icon_state = "redcorner"
 	},
 /area/almayer/shipboard/brig_cells)
@@ -19771,7 +18755,6 @@
 	on = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/hallways/stern_hallway)
@@ -19780,13 +18763,11 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/hallways/stern_hallway)
 "aOk" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-22"
 	},
 /obj/machinery/light{
@@ -19804,7 +18785,6 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/donut_box,
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
@@ -19824,7 +18804,6 @@
 /area/almayer/shipboard/brig_cells)
 "aOp" = (
 /obj/machinery/shower{
-	tag = "icon-shower (EAST)";
 	icon_state = "shower";
 	dir = 4
 	},
@@ -19837,7 +18816,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (WEST)";
 	icon_state = "redcorner";
 	dir = 8
 	},
@@ -19866,8 +18844,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "aOv" = (
@@ -19878,7 +18855,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redcorner";
 	icon_state = "redcorner"
 	},
 /area/almayer/hallways/aft_hallway)
@@ -19902,7 +18878,6 @@
 /area/almayer/living/captain_mess)
 "aOB" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-22"
 	},
 /obj/machinery/light,
@@ -19960,8 +18935,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/hallways/port_hallway)
 "aOI" = (
@@ -19973,14 +18947,12 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/command/cic)
 "aOJ" = (
 /obj/machinery/light,
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (WEST)";
 	icon_state = "greencorner";
 	dir = 8
 	},
@@ -19991,14 +18963,12 @@
 	},
 /obj/machinery/camera/autoname/almayer,
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (EAST)";
 	icon_state = "greencorner";
 	dir = 4
 	},
 /area/almayer/shipboard/brig_cells)
 "aOL" = (
 /turf/open/floor/almayer{
-	tag = "icon-greencorner";
 	icon_state = "greencorner";
 	dir = 2
 	},
@@ -20008,7 +18978,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig_cells)
@@ -20055,7 +19024,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-silver";
 	icon_state = "silver";
 	dir = 2
 	},
@@ -20068,7 +19036,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (NORTH)";
 	icon_state = "sterile_green_corner";
 	dir = 1
 	},
@@ -20082,14 +19049,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/hallways/aft_hallway)
 "aOT" = (
 /obj/machinery/camera/autoname/almayer,
 /turf/open/floor/almayer{
-	tag = "icon-blue";
 	icon_state = "blue"
 	},
 /area/almayer/shipboard/ex_firing_range)
@@ -20101,7 +19066,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/aft_hallway)
@@ -20110,7 +19074,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-blue (EAST)";
 	icon_state = "blue";
 	dir = 4
 	},
@@ -20124,8 +19087,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "aOX" = (
@@ -20133,7 +19095,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-blue (NORTH)";
 	icon_state = "blue";
 	dir = 1
 	},
@@ -20165,7 +19126,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/aft_hallway)
@@ -20176,8 +19136,7 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	icon_state = "ai_floors";
-	tag = "icon-sterile"
+	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "aPd" = (
@@ -20188,8 +19147,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/hallways/aft_hallway)
 "aPe" = (
@@ -20201,8 +19159,7 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	icon_state = "ai_floors";
-	tag = "icon-sterile"
+	icon_state = "ai_floors"
 	},
 /area/almayer/command/airoom)
 "aPg" = (
@@ -20234,7 +19191,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-silvercorner (EAST)";
 	icon_state = "silvercorner";
 	dir = 4
 	},
@@ -20248,13 +19204,11 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/port_atmos)
 "aPm" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-22"
 	},
 /obj/machinery/camera/autoname/almayer{
@@ -20262,8 +19216,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "aPn" = (
@@ -20275,8 +19228,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/port_atmos)
 "aPo" = (
@@ -20285,8 +19237,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/port_atmos)
 "aPp" = (
@@ -20295,8 +19246,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "aPq" = (
@@ -20308,8 +19258,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/port_atmos)
 "aPr" = (
@@ -20318,8 +19267,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
 "aPs" = (
@@ -20328,8 +19276,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/port_atmos)
 "aPt" = (
@@ -20358,14 +19305,12 @@
 /area/almayer/hull/upper_hull)
 "aPz" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (NORTH)";
 	icon_state = "redcorner";
 	dir = 1
 	},
 /area/almayer/shipboard/brig_cells)
 "aPA" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (EAST)";
 	icon_state = "redcorner";
 	dir = 4
 	},
@@ -20389,7 +19334,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig_cells)
@@ -20398,7 +19342,6 @@
 	name = "\improper Bathroom"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig_cells)
@@ -20407,7 +19350,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-blue";
 	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
@@ -20417,8 +19359,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/command/cic)
 "aPH" = (
@@ -20436,7 +19377,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (NORTH)";
 	icon_state = "greencorner";
 	dir = 1
 	},
@@ -20449,8 +19389,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "orange";
-	tag = "icon-orange (NORTH)"
+	icon_state = "orange"
 	},
 /area/almayer/hull/upper_hull)
 "aPK" = (
@@ -20464,7 +19403,6 @@
 	pixel_y = 25
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig_cells)
@@ -20531,8 +19469,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "aPU" = (
@@ -20540,12 +19477,10 @@
 /area/almayer/living/bridgebunks)
 "aPV" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-21";
 	pixel_x = 31
 	},
 /turf/open/floor/almayer{
-	tag = "icon-silvercorner (EAST)";
 	icon_state = "silvercorner";
 	dir = 4
 	},
@@ -20630,7 +19565,6 @@
 /area/almayer/shipboard/brig_cells)
 "aQc" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner";
 	icon_state = "redcorner"
 	},
 /area/almayer/command/cic)
@@ -20646,7 +19580,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-silver";
 	icon_state = "silver";
 	dir = 2
 	},
@@ -20677,7 +19610,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (WEST)";
 	icon_state = "greencorner";
 	dir = 8
 	},
@@ -20694,8 +19626,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
 "aQm" = (
@@ -20742,7 +19673,6 @@
 /area/almayer/engineering/port_atmos)
 "aQt" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/engineering/port_atmos)
@@ -20757,7 +19687,6 @@
 /area/almayer/engineering/port_atmos)
 "aQv" = (
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/port_atmos)
@@ -20767,7 +19696,6 @@
 	},
 /obj/machinery/meter,
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/port_atmos)
@@ -20788,7 +19716,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/port_atmos)
@@ -20799,7 +19726,6 @@
 	on = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/port_atmos)
@@ -20808,7 +19734,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/port_atmos)
@@ -20818,7 +19743,6 @@
 	},
 /obj/machinery/meter,
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (WEST)";
 	icon_state = "orangecorner";
 	dir = 8
 	},
@@ -20828,7 +19752,6 @@
 	dir = 5
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -20839,8 +19762,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/port_atmos)
 "aQE" = (
@@ -20873,8 +19795,7 @@
 "aQJ" = (
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/shipboard/brig_cells)
 "aQK" = (
@@ -20892,8 +19813,7 @@
 /obj/machinery/camera/autoname/almayer,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
 "aQN" = (
@@ -20923,8 +19843,7 @@
 /obj/machinery/camera/autoname/almayer,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/hallways/aft_hallway)
 "aQR" = (
@@ -20936,8 +19855,7 @@
 /obj/item/storage/firstaid/fire,
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/shipboard/ex_firing_range)
 "aQS" = (
@@ -20948,8 +19866,7 @@
 /obj/item/cell/lasgun/M43/highcap,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/shipboard/ex_firing_range)
 "aQU" = (
@@ -20957,7 +19874,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-bluecorner";
 	icon_state = "bluecorner"
 	},
 /area/almayer/hallways/aft_hallway)
@@ -21014,7 +19930,6 @@
 /area/almayer/living/numbertwobunks)
 "aRd" = (
 /obj/structure/toilet{
-	tag = "icon-toilet00 (WEST)";
 	icon_state = "toilet00";
 	dir = 8
 	},
@@ -21035,8 +19950,7 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/port_atmos)
 "aRh" = (
@@ -21068,7 +19982,6 @@
 /area/almayer/living/bridgebunks)
 "aRl" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-22"
 	},
 /turf/open/floor/almayer/mono,
@@ -21090,8 +20003,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aRn" = (
@@ -21106,7 +20018,6 @@
 /area/almayer/command/cic)
 "aRp" = (
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/command/cic)
@@ -21115,8 +20026,7 @@
 /obj/machinery/cell_charger,
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/shipboard/ex_firing_range)
 "aRr" = (
@@ -21124,7 +20034,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig)
@@ -21133,13 +20042,11 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-blue";
 	icon_state = "blue"
 	},
 /area/almayer/shipboard/ex_firing_range)
 "aRt" = (
 /turf/open/floor/almayer{
-	tag = "icon-blue";
 	icon_state = "blue"
 	},
 /area/almayer/shipboard/ex_firing_range)
@@ -21153,8 +20060,7 @@
 /obj/machinery/camera/autoname/almayer,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/stern_hallway)
 "aRw" = (
@@ -21162,7 +20068,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/hallways/stern_hallway)
@@ -21176,8 +20081,7 @@
 /obj/item/whistle,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/command/cic)
 "aRz" = (
@@ -21269,8 +20173,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/port_atmos)
 "aRK" = (
@@ -21285,8 +20188,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/port_atmos)
 "aRM" = (
@@ -21318,7 +20220,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/hallways/stern_hallway)
@@ -21366,7 +20267,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/aft_hallway)
@@ -21379,8 +20279,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
 "aRW" = (
@@ -21414,8 +20313,7 @@
 /obj/item/whistle,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/command/cic)
 "aSb" = (
@@ -21440,7 +20338,6 @@
 /area/almayer/living/bridgebunks)
 "aSf" = (
 /obj/structure/bed/chair/comfy/black{
-	tag = "icon-comfychair (EAST)";
 	icon_state = "comfychair";
 	dir = 4
 	},
@@ -21505,16 +20402,14 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
 "aSq" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "aSr" = (
@@ -21526,8 +20421,7 @@
 "aSs" = (
 /obj/machinery/camera/autoname/almayer,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/medical_science)
 "aSt" = (
@@ -21537,8 +20431,7 @@
 /obj/machinery/light/small,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/shipboard/brig)
 "aSu" = (
@@ -21558,8 +20451,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
 "aSw" = (
@@ -21570,7 +20462,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
@@ -21579,8 +20470,7 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/medical_science)
 "aSy" = (
@@ -21589,8 +20479,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/command/self_destruct)
 "aSz" = (
@@ -21599,8 +20488,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aSA" = (
@@ -21609,8 +20497,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
 "aSB" = (
@@ -21669,8 +20556,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "aSK" = (
@@ -21686,8 +20572,7 @@
 /obj/item/tool/pen,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/shipboard/ex_firing_range)
 "aSM" = (
@@ -21720,8 +20605,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/medical_science)
 "aSR" = (
@@ -21741,7 +20625,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/command/telecomms)
@@ -21758,8 +20641,7 @@
 /obj/machinery/camera/autoname/almayer,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/port_atmos)
 "aSW" = (
@@ -21837,7 +20719,6 @@
 	name = "\improper Vehicle Garage 1"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/hangar)
@@ -21887,7 +20768,6 @@
 /area/almayer/living/bridgebunks)
 "aTj" = (
 /obj/structure/bed/chair/comfy/black{
-	tag = "icon-comfychair (EAST)";
 	icon_state = "comfychair";
 	dir = 4
 	},
@@ -21919,8 +20799,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/shipboard/brig_cells)
 "aTo" = (
@@ -21929,7 +20808,6 @@
 /area/almayer/command/corporateliaison)
 "aTp" = (
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/ex_firing_range)
@@ -21957,7 +20835,6 @@
 	name = "\improper Vehicle Garage 2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/hangar)
@@ -21976,7 +20853,6 @@
 	name = "\improper Vehicle Garage 2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/hangar)
@@ -21987,7 +20863,6 @@
 	name = "\improper Vehicle Garage 1"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/hangar)
@@ -21995,8 +20870,7 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/shipboard/ex_firing_range)
 "aTw" = (
@@ -22005,7 +20879,6 @@
 /obj/item/cell/lasgun/M43,
 /obj/item/cell/lasgun/M43,
 /turf/open/floor/almayer{
-	tag = "icon-blue";
 	icon_state = "blue"
 	},
 /area/almayer/shipboard/ex_firing_range)
@@ -22016,7 +20889,6 @@
 /obj/item/cell/lasgun/M43,
 /obj/item/cell/lasgun/M43,
 /turf/open/floor/almayer{
-	tag = "icon-blue";
 	icon_state = "blue"
 	},
 /area/almayer/shipboard/ex_firing_range)
@@ -22107,7 +20979,6 @@
 "aTG" = (
 /obj/machinery/vending/lasgun,
 /turf/open/floor/almayer{
-	tag = "icon-blue";
 	icon_state = "blue"
 	},
 /area/almayer/shipboard/ex_firing_range)
@@ -22115,7 +20986,6 @@
 /obj/structure/table/almayer,
 /obj/machinery/cell_charger,
 /turf/open/floor/almayer{
-	tag = "icon-blue (EAST)";
 	icon_state = "blue";
 	dir = 4
 	},
@@ -22132,8 +21002,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/shipboard/brig_cells)
 "aTJ" = (
@@ -22147,7 +21016,6 @@
 /area/almayer/living/bridgebunks)
 "aTK" = (
 /obj/structure/bed/chair/comfy/black{
-	tag = "icon-comfychair (NORTH)";
 	icon_state = "comfychair";
 	dir = 1
 	},
@@ -22161,8 +21029,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/shipboard/ex_firing_range)
 "aTM" = (
@@ -22175,7 +21042,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-blue (WEST)";
 	icon_state = "blue";
 	dir = 8
 	},
@@ -22217,8 +21083,7 @@
 	dir = 4;
 	icon_state = "hoop";
 	id = "basketball";
-	side = "left";
-	tag = "icon-hoop (NORTH)"
+	side = "left"
 	},
 /turf/open/floor/almayer/mono,
 /area/almayer/shipboard/brig_cells)
@@ -22246,7 +21111,6 @@
 /area/almayer/hallways/stern_hallway)
 "aTY" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner";
 	icon_state = "redcorner"
 	},
 /area/almayer/hallways/aft_hallway)
@@ -22263,7 +21127,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-blue (NORTH)";
 	icon_state = "blue";
 	dir = 1
 	},
@@ -22307,7 +21170,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/aft_hallway)
@@ -22328,7 +21190,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/aft_hallway)
@@ -22341,8 +21202,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
 "aVe" = (
@@ -22613,8 +21473,7 @@
 "aWl" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/hallways/starboard_hallway)
 "aWn" = (
@@ -22626,8 +21485,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/hallways/starboard_hallway)
 "aWo" = (
@@ -22664,8 +21522,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/hallways/starboard_hallway)
 "aWt" = (
@@ -22719,7 +21576,6 @@
 	throw_range = 15
 	},
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (NORTH)";
 	icon_state = "greencorner";
 	dir = 1
 	},
@@ -22736,7 +21592,6 @@
 	dir = 5
 	},
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (EAST)";
 	icon_state = "greencorner";
 	dir = 4
 	},
@@ -22778,7 +21633,6 @@
 	opacity = 0
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hull/lower_hull)
@@ -22811,7 +21665,6 @@
 	name = "\improper North East Ladders Shutters"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/starboard_hallway)
@@ -22877,8 +21730,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/squads/alpha)
 "aWU" = (
@@ -22914,8 +21766,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/starboard_hallway)
 "aXa" = (
@@ -22958,8 +21809,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/squads/alpha)
 "aXf" = (
@@ -22968,8 +21818,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/squads/alpha)
 "aXh" = (
@@ -23045,8 +21894,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/starboard_hallway)
 "aXw" = (
@@ -23064,8 +21912,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/basketball)
 "aXz" = (
@@ -23112,8 +21959,7 @@
 /area/almayer/living/basketball)
 "aXE" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "NS-center";
-	tag = "icon-W"
+	icon_state = "NS-center"
 	},
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -23191,8 +22037,7 @@
 "aXT" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/starboard_hallway)
 "aXU" = (
@@ -23201,15 +22046,13 @@
 	},
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/squads/alpha)
 "aXV" = (
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/squads/alpha)
 "aXW" = (
@@ -23218,8 +22061,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/squads/alpha)
 "aXX" = (
@@ -23245,15 +22087,13 @@
 "aYc" = (
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/starboard_hallway)
 "aYd" = (
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/starboard_hallway)
 "aYf" = (
@@ -23286,8 +22126,7 @@
 "aYj" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hull/lower_hull)
 "aYk" = (
@@ -23312,8 +22151,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/starboard_hallway)
 "aYo" = (
@@ -23324,8 +22162,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/basketball)
 "aYp" = (
@@ -23337,8 +22174,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/basketball)
 "aYq" = (
@@ -23352,8 +22188,7 @@
 /area/almayer/living/basketball)
 "aYs" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "NS-center";
-	tag = "icon-W"
+	icon_state = "NS-center"
 	},
 /turf/open/floor/wood,
 /area/almayer/living/basketball)
@@ -23365,7 +22200,6 @@
 /area/almayer/living/basketball)
 "aYu" = (
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/living/starboard_emb)
@@ -23374,15 +22208,13 @@
 	name = "\improper Bathroom"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/living/starboard_emb)
 "aYw" = (
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/living/starboard_emb)
 "aYx" = (
@@ -23392,8 +22224,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/living/starboard_emb)
 "aYy" = (
@@ -23407,8 +22238,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/living/starboard_emb)
 "aYz" = (
@@ -23422,8 +22252,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/living/starboard_emb)
 "aYA" = (
@@ -23436,7 +22265,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (NORTH)";
 	icon_state = "redcorner";
 	dir = 1
 	},
@@ -23480,21 +22308,18 @@
 /area/almayer/hallways/starboard_hallway)
 "aYE" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (EAST)";
 	icon_state = "redcorner";
 	dir = 4
 	},
 /area/almayer/hallways/starboard_hallway)
 "aYG" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (NORTH)";
 	icon_state = "redcorner";
 	dir = 1
 	},
 /area/almayer/squads/alpha)
 "aYH" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (EAST)";
 	icon_state = "redcorner";
 	dir = 4
 	},
@@ -23505,8 +22330,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/squads/alpha)
 "aYJ" = (
@@ -23515,8 +22339,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/squads/alpha)
 "aYL" = (
@@ -23525,8 +22348,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/squads/alpha)
 "aYM" = (
@@ -23544,8 +22366,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/squads/alpha)
 "aYO" = (
@@ -23554,8 +22375,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/squads/alpha)
 "aYQ" = (
@@ -23563,7 +22383,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (NORTH)";
 	icon_state = "redcorner";
 	dir = 1
 	},
@@ -23615,8 +22434,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/starboard_hallway)
 "aYZ" = (
@@ -23632,23 +22450,20 @@
 	dir = 4;
 	icon_state = "hoop";
 	id = "basketball";
-	side = "left";
-	tag = "icon-hoop (NORTH)"
+	side = "left"
 	},
 /turf/open/floor/wood,
 /area/almayer/living/basketball)
 "aZb" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "NS-center";
-	tag = "icon-W"
+	icon_state = "NS-center"
 	},
 /obj/effect/decal/warning_stripes,
 /turf/open/floor/wood,
 /area/almayer/living/basketball)
 "aZc" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "NS-center";
-	tag = "icon-W"
+	icon_state = "NS-center"
 	},
 /obj/effect/decal/warning_stripes,
 /obj/item/toy/beach_ball/holoball,
@@ -23663,8 +22478,7 @@
 	dir = 8;
 	icon_state = "hoop";
 	id = "basketball";
-	side = "right";
-	tag = "icon-hoop (NORTH)"
+	side = "right"
 	},
 /turf/open/floor/wood,
 /area/almayer/living/basketball)
@@ -23675,14 +22489,12 @@
 /area/almayer/living/starboard_emb)
 "aZf" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (WEST)";
 	icon_state = "redcorner";
 	dir = 8
 	},
 /area/almayer/living/starboard_emb)
 "aZg" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner";
 	icon_state = "redcorner"
 	},
 /area/almayer/living/starboard_emb)
@@ -23697,7 +22509,6 @@
 /area/almayer/hallways/starboard_hallway)
 "aZi" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner";
 	icon_state = "redcorner"
 	},
 /area/almayer/hallways/starboard_hallway)
@@ -23706,7 +22517,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/squads/alpha)
@@ -23715,7 +22525,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/squads/alpha)
@@ -23752,7 +22561,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/squads/alpha)
@@ -23784,7 +22592,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/squads/alpha)
@@ -23801,7 +22608,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/squads/alpha)
@@ -23835,7 +22641,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (WEST)";
 	icon_state = "redcorner";
 	dir = 8
 	},
@@ -23868,8 +22673,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/starboard_hallway)
 "aZw" = (
@@ -23901,8 +22705,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/firing_range)
 "aZB" = (
@@ -23911,14 +22714,12 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/firing_range)
 "aZC" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (NORTH)";
 	icon_state = "orangecorner";
 	dir = 1
 	},
@@ -23938,8 +22739,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/basketball)
 "aZF" = (
@@ -23952,15 +22752,13 @@
 "aZG" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/living/starboard_emb)
 "aZH" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/living/starboard_emb)
 "aZI" = (
@@ -24017,8 +22815,7 @@
 "aZR" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/starboard_hallway)
 "aZS" = (
@@ -24040,8 +22837,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/starboard_hallway)
 "aZU" = (
@@ -24103,7 +22899,6 @@
 /area/almayer/hallways/starboard_umbilical)
 "bab" = (
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/starboard_umbilical)
@@ -24114,7 +22909,6 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/starboard_umbilical)
@@ -24125,7 +22919,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/starboard_umbilical)
@@ -24173,7 +22966,6 @@
 /obj/item/weapon/gun/rifle/m41a,
 /obj/structure/table/almayer,
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/shipboard/firing_range)
@@ -24185,7 +22977,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/shipboard/firing_range)
@@ -24196,14 +22987,12 @@
 /obj/item/weapon/gun/smg/m39,
 /obj/structure/table/almayer,
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/shipboard/firing_range)
 "bal" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/shipboard/firing_range)
@@ -24232,8 +23021,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/basketball)
 "baq" = (
@@ -24274,8 +23062,7 @@
 /area/almayer/living/basketball)
 "bau" = (
 /obj/effect/decal/warning_stripes{
-	icon_state = "NS-center";
-	tag = "icon-W"
+	icon_state = "NS-center"
 	},
 /obj/effect/decal/warning_stripes/thin{
 	dir = 2
@@ -24308,7 +23095,6 @@
 /area/almayer/living/basketball)
 "bax" = (
 /obj/structure/toilet{
-	tag = "icon-toilet00 (NORTH)";
 	icon_state = "toilet00";
 	dir = 1
 	},
@@ -24317,14 +23103,12 @@
 /area/almayer/living/starboard_emb)
 "bay" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (NORTH)";
 	icon_state = "redcorner";
 	dir = 1
 	},
 /area/almayer/living/starboard_emb)
 "baz" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (EAST)";
 	icon_state = "redcorner";
 	dir = 4
 	},
@@ -24335,8 +23119,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/starboard_hallway)
 "baB" = (
@@ -24384,7 +23167,6 @@
 /obj/item/target/syndicate,
 /obj/structure/closet/crate,
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/shipboard/firing_range)
@@ -24393,8 +23175,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/hallways/starboard_hallway)
 "baJ" = (
@@ -24417,13 +23198,11 @@
 "baL" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/basketball)
 "baM" = (
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (EAST)";
 	icon_state = "greencorner";
 	dir = 4
 	},
@@ -24435,8 +23214,7 @@
 /obj/structure/bed/chair,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/basketball)
 "baO" = (
@@ -24452,8 +23230,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/basketball)
 "baQ" = (
@@ -24480,8 +23257,7 @@
 "baU" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/starboard_hallway)
 "baV" = (
@@ -24523,8 +23299,7 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/squads/bravo)
 "bbe" = (
@@ -24621,7 +23396,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (WEST)";
 	icon_state = "orangecorner";
 	dir = 8
 	},
@@ -24647,13 +23421,11 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/hallways/starboard_umbilical)
 "bbC" = (
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/exoarmor)
@@ -24775,15 +23547,13 @@
 "bca" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/firing_range)
 "bcb" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/firing_range)
 "bcc" = (
@@ -24801,7 +23571,6 @@
 /obj/item/target,
 /obj/structure/closet/crate,
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/shipboard/firing_range)
@@ -24810,8 +23579,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/hallways/starboard_hallway)
 "bcf" = (
@@ -24825,20 +23593,17 @@
 "bcg" = (
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/basketball)
 "bch" = (
 /turf/open/floor/almayer{
-	tag = "icon-green";
 	icon_state = "green";
 	dir = 2
 	},
 /area/almayer/living/basketball)
 "bci" = (
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (WEST)";
 	icon_state = "greencorner";
 	dir = 8
 	},
@@ -24849,8 +23614,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/basketball)
 "bcl" = (
@@ -24869,14 +23633,12 @@
 /area/almayer/living/starboard_emb)
 "bcp" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (WEST)";
 	icon_state = "orangecorner";
 	dir = 8
 	},
 /area/almayer/living/starboard_emb)
 "bcq" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/living/starboard_emb)
@@ -24888,7 +23650,6 @@
 /area/almayer/living/starboard_emb)
 "bcs" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -24899,8 +23660,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/squads/bravo)
 "bcv" = (
@@ -24909,8 +23669,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/squads/bravo)
 "bcw" = (
@@ -24941,7 +23700,6 @@
 "bcy" = (
 /obj/machinery/computer/med_data,
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (EAST)";
 	icon_state = "sterile_green_corner";
 	dir = 4
 	},
@@ -24957,15 +23715,13 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/squads/bravo)
 "bcA" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_corner";
-	tag = "icon-sterile_green_corner"
+	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/upper_medical)
 "bcB" = (
@@ -24997,8 +23753,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/squads/bravo)
 "bcD" = (
@@ -25015,8 +23770,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/squads/bravo)
 "bcE" = (
@@ -25050,7 +23804,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (NORTH)";
 	icon_state = "orangecorner";
 	dir = 1
 	},
@@ -25098,8 +23851,7 @@
 "bcM" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/starboard_umbilical)
 "bcN" = (
@@ -25113,8 +23865,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/starboard_umbilical)
 "bcP" = (
@@ -25124,7 +23875,6 @@
 	name = "\improper Tank Garage Shutters"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/exoarmor)
@@ -25149,7 +23899,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/exoarmor)
@@ -25160,7 +23909,6 @@
 	pixel_x = 25
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/exoarmor)
@@ -25168,7 +23916,6 @@
 /obj/structure/table/almayer,
 /obj/machinery/door/window/northleft,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/firing_range)
@@ -25176,7 +23923,6 @@
 /obj/structure/table/almayer,
 /obj/machinery/door/window/northright,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/firing_range)
@@ -25205,7 +23951,6 @@
 /obj/structure/rack,
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/shipboard/firing_range)
@@ -25220,7 +23965,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (NORTH)";
 	icon_state = "greencorner";
 	dir = 1
 	},
@@ -25246,7 +23990,6 @@
 /area/almayer/living/basketball)
 "bdd" = (
 /turf/open/floor/almayer{
-	tag = "icon-greencorner";
 	icon_state = "greencorner";
 	dir = 2
 	},
@@ -25254,7 +23997,6 @@
 "bde" = (
 /obj/structure/bed/chair,
 /turf/open/floor/almayer{
-	tag = "icon-green";
 	icon_state = "green";
 	dir = 2
 	},
@@ -25263,8 +24005,7 @@
 /obj/structure/closet/masks,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/basketball)
 "bdg" = (
@@ -25297,26 +24038,22 @@
 "bdk" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/living/starboard_emb)
 "bdl" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/living/starboard_emb)
 "bdm" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/hallways/starboard_hallway)
 "bdn" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (WEST)";
 	icon_state = "orangecorner";
 	dir = 8
 	},
@@ -25326,20 +24063,17 @@
 /area/almayer/squads/bravo)
 "bdp" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/squads/bravo)
 "bdq" = (
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/squads/bravo)
 "bdr" = (
 /obj/machinery/light,
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/squads/bravo)
@@ -25349,7 +24083,6 @@
 	on = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/squads/bravo)
@@ -25364,7 +24097,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/squads/bravo)
@@ -25374,7 +24106,6 @@
 	},
 /obj/machinery/light,
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/squads/bravo)
@@ -25383,7 +24114,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (WEST)";
 	icon_state = "orangecorner";
 	dir = 8
 	},
@@ -25477,7 +24207,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/exoarmor)
@@ -25491,7 +24220,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/exoarmor)
@@ -25571,7 +24299,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/starboard_hallway)
@@ -25590,7 +24317,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/starboard_hallway)
@@ -25599,8 +24325,7 @@
 /obj/item/tool/hand_labeler,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/basketball)
 "bei" = (
@@ -25610,8 +24335,7 @@
 /obj/item/storage/fancy/crayons,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/basketball)
 "bej" = (
@@ -25620,8 +24344,7 @@
 /obj/item/camera_film,
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/basketball)
 "bek" = (
@@ -25630,16 +24353,14 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/basketball)
 "bel" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/basketball)
 "bem" = (
@@ -25651,8 +24372,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/living/basketball)
 "ben" = (
@@ -25661,8 +24381,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/living/basketball)
 "beo" = (
@@ -25674,24 +24393,21 @@
 	},
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/living/basketball)
 "bep" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/basketball)
 "beq" = (
 /obj/structure/closet/boxinggloves,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/basketball)
 "ber" = (
@@ -25716,14 +24432,12 @@
 /area/almayer/living/chapel)
 "beu" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (NORTH)";
 	icon_state = "orangecorner";
 	dir = 1
 	},
 /area/almayer/living/starboard_emb)
 "bev" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -25734,8 +24448,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/squads/bravo)
 "bex" = (
@@ -25744,8 +24457,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/squads/bravo)
 "bey" = (
@@ -25771,8 +24483,7 @@
 "beD" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/starboard_hallway)
 "beE" = (
@@ -25793,16 +24504,14 @@
 "beG" = (
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/living/cafeteria_starboard)
 "beH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/living/cafeteria_starboard)
 "beI" = (
@@ -25854,7 +24563,6 @@
 	name = "\improper Tank Garage Shutters"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/exoarmor)
@@ -25886,7 +24594,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (WEST)";
 	icon_state = "redcorner";
 	dir = 8
 	},
@@ -25911,14 +24618,12 @@
 	on = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (NORTH)";
 	icon_state = "redcorner";
 	dir = 1
 	},
 /area/almayer/shipboard/firing_range)
 "bfb" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner";
 	icon_state = "redcorner"
 	},
 /area/almayer/shipboard/firing_range)
@@ -25948,7 +24653,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (WEST)";
 	icon_state = "greencorner";
 	dir = 8
 	},
@@ -25963,7 +24667,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-greencorner";
 	icon_state = "greencorner";
 	dir = 2
 	},
@@ -25979,8 +24682,7 @@
 /obj/machinery/computer/arcade,
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/basketball)
 "bfi" = (
@@ -25988,7 +24690,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (NORTH)";
 	icon_state = "greencorner";
 	dir = 1
 	},
@@ -26000,16 +24701,14 @@
 "bfk" = (
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/basketball)
 "bfl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/basketball)
 "bfm" = (
@@ -26018,13 +24717,11 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/living/basketball)
 "bfn" = (
 /turf/open/floor/almayer{
-	tag = "icon-silvercorner";
 	icon_state = "silvercorner";
 	dir = 2
 	},
@@ -26032,8 +24729,7 @@
 "bfo" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "silvercorner";
-	tag = "icon-silvercorner (NORTH)"
+	icon_state = "silvercorner"
 	},
 /area/almayer/living/basketball)
 "bfp" = (
@@ -26044,8 +24740,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/basketball)
 "bfr" = (
@@ -26053,7 +24748,6 @@
 /area/almayer/living/chapel)
 "bfs" = (
 /obj/structure/bed/chair/wood/normal{
-	tag = "icon-wooden_chair (NORTH)";
 	icon_state = "wooden_chair";
 	dir = 1
 	},
@@ -26061,7 +24755,6 @@
 /area/almayer/living/chapel)
 "bft" = (
 /obj/structure/bed/chair/wood/normal{
-	tag = "icon-wooden_chair (NORTH)";
 	icon_state = "wooden_chair";
 	dir = 1
 	},
@@ -26074,7 +24767,6 @@
 /area/almayer/living/chapel)
 "bfu" = (
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/living/starboard_emb)
@@ -26083,7 +24775,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/living/starboard_emb)
@@ -26092,7 +24783,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/living/starboard_emb)
@@ -26104,7 +24794,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (WEST)";
 	icon_state = "orangecorner";
 	dir = 8
 	},
@@ -26170,8 +24859,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/squads/bravo)
 "bfF" = (
@@ -26180,8 +24868,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/squads/bravo)
 "bfH" = (
@@ -26202,7 +24889,6 @@
 /area/almayer/living/cafeteria_starboard)
 "bfK" = (
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/living/cafeteria_starboard)
@@ -26211,7 +24897,6 @@
 	on = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (WEST)";
 	icon_state = "orangecorner";
 	dir = 8
 	},
@@ -26223,8 +24908,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/living/cafeteria_starboard)
 "bfO" = (
@@ -26241,7 +24925,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (NORTH)";
 	icon_state = "orangecorner";
 	dir = 1
 	},
@@ -26262,7 +24945,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -26291,7 +24973,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/exoarmor)
@@ -26325,7 +25006,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/hangar)
@@ -26341,7 +25021,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/hangar)
@@ -26351,13 +25030,11 @@
 	},
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/firing_range)
 "bgf" = (
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/shipboard/firing_range)
@@ -26368,7 +25045,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (WEST)";
 	icon_state = "redcorner";
 	dir = 8
 	},
@@ -26416,8 +25092,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/basketball)
 "bgn" = (
@@ -26432,7 +25107,6 @@
 	name = "\improper Arcade"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-green";
 	icon_state = "green";
 	dir = 2
 	},
@@ -26444,8 +25118,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/basketball)
 "bgq" = (
@@ -26460,7 +25133,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-silvercorner (EAST)";
 	icon_state = "silvercorner";
 	dir = 4
 	},
@@ -26470,7 +25142,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-silvercorner (NORTH)";
 	icon_state = "silvercorner";
 	dir = 1
 	},
@@ -26484,16 +25155,14 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/living/basketball)
 "bgu" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/basketball)
 "bgv" = (
@@ -26517,7 +25186,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-greencorner";
 	icon_state = "greencorner";
 	dir = 2
 	},
@@ -26536,7 +25204,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-green";
 	icon_state = "green";
 	dir = 2
 	},
@@ -26668,8 +25335,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/living/cafeteria_starboard)
 "bgU" = (
@@ -26723,7 +25389,6 @@
 	},
 /obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig_cells)
@@ -26780,8 +25445,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/firing_range)
 "bhk" = (
@@ -26790,7 +25454,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redcorner";
 	icon_state = "redcorner"
 	},
 /area/almayer/shipboard/firing_range)
@@ -26800,8 +25463,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/firing_range)
 "bhm" = (
@@ -26825,7 +25487,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (NORTH)";
 	icon_state = "greencorner";
 	dir = 1
 	},
@@ -26840,7 +25501,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (EAST)";
 	icon_state = "greencorner";
 	dir = 4
 	},
@@ -26863,8 +25523,7 @@
 /obj/machinery/computer/arcade,
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/basketball)
 "bhs" = (
@@ -26872,7 +25531,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-green";
 	icon_state = "green";
 	dir = 2
 	},
@@ -26882,8 +25540,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/basketball)
 "bhv" = (
@@ -26893,14 +25550,12 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/living/basketball)
 "bhw" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/almayer{
-	tag = "icon-silver";
 	icon_state = "silver";
 	dir = 2
 	},
@@ -26912,8 +25567,7 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/living/basketball)
 "bhy" = (
@@ -26934,8 +25588,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/basketball)
 "bhA" = (
@@ -26945,7 +25598,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/starboard_hallway)
@@ -26960,7 +25612,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/starboard_hallway)
@@ -26969,7 +25620,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/starboard_hallway)
@@ -26986,7 +25636,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/starboard_hallway)
@@ -27010,8 +25659,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/living/cafeteria_starboard)
 "bhG" = (
@@ -27114,7 +25762,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/starboard_umbilical)
@@ -27128,13 +25775,11 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/starboard_umbilical)
 "bia" = (
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/hangar)
@@ -27146,7 +25791,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/hangar)
@@ -27159,7 +25803,6 @@
 	throw_range = 15
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/hangar)
@@ -27192,7 +25835,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/starboard_hallway)
@@ -27211,7 +25853,6 @@
 	name = "\improper North West Ladders Shutters"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/starboard_hallway)
@@ -27297,7 +25938,6 @@
 "biv" = (
 /obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/starboard_hallway)
@@ -27336,8 +25976,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/living/cafeteria_starboard)
 "biC" = (
@@ -27356,8 +25995,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/living/cafeteria_starboard)
 "biD" = (
@@ -27460,7 +26098,6 @@
 	opacity = 0
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/hangar)
@@ -27472,7 +26109,6 @@
 	name = "\improper North Hangar Shutters"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/starboard_hallway)
@@ -27535,7 +26171,6 @@
 /area/almayer/hallways/starboard_hallway)
 "bji" = (
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/starboard_hallway)
@@ -27549,7 +26184,6 @@
 	opacity = 0
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/hallways/starboard_hallway)
@@ -27568,8 +26202,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/starboard_hallway)
 "bjn" = (
@@ -27582,8 +26215,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/starboard_hallway)
 "bjp" = (
@@ -27605,7 +26237,6 @@
 /area/almayer/engineering/lower_engineering)
 "bjr" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -27613,8 +26244,7 @@
 "bjs" = (
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engineering)
 "bjt" = (
@@ -27623,8 +26253,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engineering)
 "bju" = (
@@ -27633,14 +26262,12 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engineering)
 "bjv" = (
 /obj/machinery/atmospherics/components/binary/pump/on,
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (NORTH)";
 	icon_state = "orangecorner";
 	dir = 1
 	},
@@ -27802,7 +26429,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/hangar)
@@ -27842,7 +26468,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/starboard_hallway)
@@ -28075,7 +26700,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/starboard_hallway)
@@ -28103,7 +26727,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/hallways/starboard_hallway)
@@ -28235,7 +26858,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/starboard_hallway)
@@ -28452,24 +27074,21 @@
 /obj/item/tool/wirecutters,
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/weapon_room)
 "bkB" = (
 /obj/structure/largecrate/random/barrel/red,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/weapon_room)
 "bkC" = (
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/weapon_room)
 "bkD" = (
@@ -28479,16 +27098,14 @@
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/weapon_room)
 "bkE" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/weapon_room)
 "bkH" = (
@@ -28605,7 +27222,6 @@
 	},
 /obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/starboard_hallway)
@@ -28634,8 +27250,7 @@
 "blh" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/weapon_room)
 "bli" = (
@@ -28661,13 +27276,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/starboard_hallway)
 "bll" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (WEST)";
 	icon_state = "redcorner";
 	dir = 8
 	},
@@ -28698,8 +27311,7 @@
 "blp" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/weapon_room)
 "blq" = (
@@ -28717,8 +27329,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/starboard_missiles)
 "blv" = (
@@ -28727,8 +27338,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/starboard_missiles)
 "blw" = (
@@ -28737,8 +27347,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/starboard_missiles)
 "blx" = (
@@ -28839,7 +27448,6 @@
 /area/almayer/hull/lower_hull)
 "blT" = (
 /turf/open/floor/almayer{
-	tag = "icon-greencorner";
 	icon_state = "greencorner";
 	dir = 2
 	},
@@ -28860,7 +27468,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor5";
 	icon_state = "test_floor5"
 	},
 /area/almayer/hallways/starboard_hallway)
@@ -28934,7 +27541,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/starboard_hallway)
@@ -29083,8 +27689,7 @@
 "bmB" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/starboard_missiles)
 "bmD" = (
@@ -29116,16 +27721,14 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bmN" = (
 /obj/structure/closet/secure_closet/medical1,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bmO" = (
@@ -29135,24 +27738,21 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bmP" = (
 /obj/structure/closet/secure_closet/medical_doctor,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bmQ" = (
 /obj/structure/closet/secure_closet/medical_doctor,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_corner";
-	tag = "icon-sterile_green_corner (NORTH)"
+	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/lower_medical)
 "bmR" = (
@@ -29172,24 +27772,21 @@
 /obj/item/reagent_container/spray/cleaner,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bmV" = (
 /obj/machinery/sleeper,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bmW" = (
 /obj/machinery/sleep_console,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bmX" = (
@@ -29222,7 +27819,6 @@
 /obj/item/tool/extinguisher,
 /obj/item/tool/extinguisher,
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (NORTH)";
 	icon_state = "sterile_green_corner";
 	dir = 1
 	},
@@ -29234,8 +27830,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bnd" = (
@@ -29246,8 +27841,7 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bnf" = (
@@ -29255,8 +27849,7 @@
 /obj/item/bedsheet/medical,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/surgery_hallway)
 "bng" = (
@@ -29267,19 +27860,16 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/surgery_hallway)
 "bnj" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-21"
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bnm" = (
@@ -29299,7 +27889,6 @@
 	pixel_y = -5
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (NORTH)";
 	icon_state = "sterile_green_corner";
 	dir = 1
 	},
@@ -29314,7 +27903,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/living/captain_mess)
@@ -29324,13 +27912,11 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_corner";
-	tag = "icon-sterile_green_corner (NORTH)"
+	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/operating_room_one)
 "bnr" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (WEST)";
 	icon_state = "redcorner";
 	dir = 8
 	},
@@ -29351,7 +27937,6 @@
 /area/almayer/hull/lower_hull)
 "bnu" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner";
 	icon_state = "redcorner"
 	},
 /area/almayer/hull/lower_hull)
@@ -29404,7 +27989,6 @@
 /area/almayer/living/briefing)
 "bnB" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-21"
 	},
 /turf/open/floor/almayer,
@@ -29415,8 +27999,7 @@
 "bnD" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/squads/req)
 "bnE" = (
@@ -29424,7 +28007,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor5";
 	icon_state = "test_floor5"
 	},
 /area/almayer/squads/req)
@@ -29487,14 +28069,12 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangefull";
 	icon_state = "orangefull"
 	},
 /area/almayer/living/cryo_cells)
 "bnN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/almayer{
-	tag = "icon-orangefull";
 	icon_state = "orangefull"
 	},
 /area/almayer/living/cryo_cells)
@@ -29506,7 +28086,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/living/cryo_cells)
@@ -29516,7 +28095,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/living/cryo_cells)
@@ -29631,8 +28209,7 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/starboard_missiles)
 "bof" = (
@@ -29712,8 +28289,7 @@
 "boB" = (
 /obj/effect/landmark/start/marine/medicalofficer,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "boC" = (
@@ -29722,8 +28298,7 @@
 	on = 1
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "boE" = (
@@ -29733,8 +28308,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/surgery_hallway)
 "boF" = (
@@ -29742,16 +28316,14 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "boG" = (
 /obj/machinery/vending/MarineMed/Blood,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_corner";
-	tag = "icon-sterile_green_corner (NORTH)"
+	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/surgery_hallway)
 "boH" = (
@@ -29777,8 +28349,7 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "boJ" = (
@@ -29800,8 +28371,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "boL" = (
@@ -29831,8 +28401,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/surgery_hallway)
 "boO" = (
@@ -29856,8 +28425,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/surgery_hallway)
 "boP" = (
@@ -29876,27 +28444,23 @@
 	dir = 10
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/surgery_hallway)
 "boQ" = (
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/surgery_hallway)
 "boR" = (
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (NORTHWEST)";
 	icon_state = "sterile_green_side";
 	dir = 9
 	},
 /area/almayer/medical/operating_room_one)
 "boT" = (
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/operating_room_one)
 "boV" = (
@@ -29912,8 +28476,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hull/lower_hull)
 "boW" = (
@@ -29940,8 +28503,7 @@
 "boZ" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hull/lower_hull)
 "bpa" = (
@@ -30034,7 +28596,6 @@
 /area/almayer/squads/req)
 "bps" = (
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (NORTH)";
 	icon_state = "greencorner";
 	dir = 1
 	},
@@ -30051,7 +28612,6 @@
 /area/almayer/squads/req)
 "bpu" = (
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (EAST)";
 	icon_state = "greencorner";
 	dir = 4
 	},
@@ -30062,8 +28622,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/squads/req)
 "bpw" = (
@@ -30168,8 +28727,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/living/cryo_cells)
 "bpJ" = (
@@ -30178,8 +28736,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/living/cryo_cells)
 "bpK" = (
@@ -30197,8 +28754,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/living/cryo_cells)
 "bpM" = (
@@ -30208,8 +28764,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/living/cryo_cells)
 "bpN" = (
@@ -30230,7 +28785,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -30239,13 +28793,11 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engineering)
 "bpR" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (NORTH)";
 	icon_state = "orangecorner";
 	dir = 1
 	},
@@ -30262,7 +28814,6 @@
 "bpT" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -30275,8 +28826,7 @@
 /obj/item/lightreplacer,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engineering)
 "bpV" = (
@@ -30287,8 +28837,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engineering)
 "bpW" = (
@@ -30296,8 +28845,7 @@
 /obj/item/frame/fire_alarm,
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engineering)
 "bpX" = (
@@ -30417,7 +28965,6 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/command/cic)
@@ -30447,24 +28994,21 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bqD" = (
 /obj/machinery/light,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bqE" = (
 /obj/machinery/computer/crew,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bqF" = (
@@ -30475,8 +29019,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bqG" = (
@@ -30488,8 +29031,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bqH" = (
@@ -30500,8 +29042,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bqI" = (
@@ -30520,8 +29061,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bqJ" = (
@@ -30541,8 +29081,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/surgery_hallway)
 "bqK" = (
@@ -30555,8 +29094,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/surgery_hallway)
 "bqL" = (
@@ -30576,8 +29114,7 @@
 	id = "or1sign"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/operating_room_one)
 "bqM" = (
@@ -30590,8 +29127,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/operating_room_one)
 "bqN" = (
@@ -30601,8 +29137,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/operating_room_one)
 "bqO" = (
@@ -30615,8 +29150,7 @@
 /obj/item/tank/anesthetic,
 /obj/item/clothing/mask/breath/medical,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/operating_room_one)
 "bqP" = (
@@ -30631,8 +29165,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/operating_room_one)
 "bqQ" = (
@@ -30648,8 +29181,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hull/lower_hull)
 "bqR" = (
@@ -30717,13 +29249,11 @@
 "bre" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/squads/req)
 "brf" = (
 /turf/open/floor/almayer{
-	tag = "icon-greencorner";
 	icon_state = "greencorner";
 	dir = 2
 	},
@@ -30733,8 +29263,7 @@
 /obj/effect/landmark/start/marine/requisitionsofficer,
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/squads/req)
 "brh" = (
@@ -30842,8 +29371,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/living/cryo_cells)
 "brv" = (
@@ -30852,8 +29380,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/living/cryo_cells)
 "brw" = (
@@ -30866,16 +29393,14 @@
 "brx" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/living/cryo_cells)
 "bry" = (
 /obj/effect/landmark/start/latejoin_cryo,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/living/cryo_cells)
 "brz" = (
@@ -31050,7 +29575,6 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -31062,8 +29586,7 @@
 /obj/item/frame/fire_alarm,
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engineering)
 "brN" = (
@@ -31141,7 +29664,6 @@
 /area/almayer/shipboard/starboard_missiles)
 "brY" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (NORTH)";
 	icon_state = "redcorner";
 	dir = 1
 	},
@@ -31155,8 +29677,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/aft_hallway)
 "bsa" = (
@@ -31199,14 +29720,12 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bsw" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (SOUTHEAST)";
 	icon_state = "sterile_green_side";
 	dir = 6
 	},
@@ -31215,8 +29734,7 @@
 /obj/machinery/computer/med_data,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bsz" = (
@@ -31240,24 +29758,21 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bsA" = (
 /obj/machinery/bodyscanner,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bsB" = (
 /obj/machinery/body_scanconsole,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bsC" = (
@@ -31280,8 +29795,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bsE" = (
@@ -31301,8 +29815,7 @@
 	},
 /obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bsG" = (
@@ -31315,8 +29828,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/surgery_hallway)
 "bsI" = (
@@ -31326,16 +29838,14 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/operating_room_one)
 "bsJ" = (
 /obj/machinery/light,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/operating_room_one)
 "bsN" = (
@@ -31385,7 +29895,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-22"
 	},
 /turf/open/floor/almayer/mono,
@@ -31460,15 +29969,13 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/living/cryo_cells)
 "btf" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/living/cryo_cells)
 "btg" = (
@@ -31483,8 +29990,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/living/cryo_cells)
 "bti" = (
@@ -31500,13 +30006,11 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/hallways/starboard_hallway)
 "btl" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (WEST)";
 	icon_state = "orangecorner";
 	dir = 8
 	},
@@ -31518,7 +30022,6 @@
 "btn" = (
 /obj/machinery/light,
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engineering)
@@ -31532,7 +30035,6 @@
 /area/almayer/engineering/lower_engineering)
 "btp" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/engineering/lower_engineering)
@@ -31553,7 +30055,6 @@
 /obj/structure/table/almayer,
 /obj/item/t_scanner,
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -31655,8 +30156,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "btK" = (
@@ -31665,8 +30165,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
 "btL" = (
@@ -31703,13 +30202,11 @@
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/cryo_tubes)
 "buo" = (
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (NORTHWEST)";
 	icon_state = "sterile_green_side";
 	dir = 9
 	},
@@ -31720,8 +30217,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "buq" = (
@@ -31742,8 +30238,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/chemistry)
 "bus" = (
@@ -31781,8 +30276,7 @@
 	},
 /obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "buy" = (
@@ -31795,8 +30289,7 @@
 /obj/machinery/vending/security,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hull/lower_hull)
 "buA" = (
@@ -31804,7 +30297,6 @@
 	pixel_y = 30
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (NORTH)";
 	icon_state = "redcorner";
 	dir = 1
 	},
@@ -31859,8 +30351,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/living/cryo_cells)
 "buK" = (
@@ -31870,8 +30361,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/living/cryo_cells)
 "buM" = (
@@ -31909,8 +30399,7 @@
 "buR" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engineering)
 "buS" = (
@@ -31928,7 +30417,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -31991,7 +30479,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/engineering/lower_engine_monitoring)
@@ -32020,7 +30507,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engine_monitoring)
@@ -32034,7 +30520,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engine_monitoring)
@@ -32070,7 +30555,6 @@
 /area/almayer/living/commandbunks)
 "bvg" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (EAST)";
 	icon_state = "redcorner";
 	dir = 4
 	},
@@ -32083,8 +30567,7 @@
 "bvi" = (
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/corporateliaison)
 "bvj" = (
@@ -32105,8 +30588,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/weapon_room)
 "bvC" = (
@@ -32117,12 +30599,10 @@
 /area/almayer/hallways/hangar)
 "bvD" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-22"
 	},
 /obj/machinery/light,
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (SOUTHEAST)";
 	icon_state = "sterile_green_side";
 	dir = 6
 	},
@@ -32133,8 +30613,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/surgery_hallway)
 "bvF" = (
@@ -32142,7 +30621,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (NORTH)";
 	icon_state = "sterile_green_corner";
 	dir = 1
 	},
@@ -32153,14 +30631,12 @@
 /obj/item/roller,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bvI" = (
 /obj/machinery/chem_dispenser,
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (NORTH)";
 	icon_state = "sterile_green_corner";
 	dir = 1
 	},
@@ -32175,8 +30651,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/chemistry)
 "bvK" = (
@@ -32187,8 +30662,7 @@
 /obj/item/storage/box/bodybags,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bvL" = (
@@ -32196,8 +30670,7 @@
 /obj/item/bedsheet/medical,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/surgery_hallway)
 "bvM" = (
@@ -32207,8 +30680,7 @@
 /obj/machinery/disposal,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/chemistry)
 "bvN" = (
@@ -32217,8 +30689,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/surgery_hallway)
 "bvO" = (
@@ -32238,7 +30709,6 @@
 	pixel_y = -5
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (NORTH)";
 	icon_state = "sterile_green_corner";
 	dir = 1
 	},
@@ -32253,8 +30723,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/command/cic)
 "bvS" = (
@@ -32263,8 +30732,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_corner";
-	tag = "icon-sterile_green_corner (NORTH)"
+	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/operating_room_two)
 "bvT" = (
@@ -32276,8 +30744,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hull/lower_hull)
 "bvV" = (
@@ -32329,13 +30796,11 @@
 "bwc" = (
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/squads/req)
 "bwd" = (
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/squads/req)
@@ -32345,8 +30810,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/squads/req)
 "bwf" = (
@@ -32372,8 +30836,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/living/cryo_cells)
 "bws" = (
@@ -32383,8 +30846,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/living/cryo_cells)
 "bwt" = (
@@ -32403,8 +30865,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/engineering_workshop)
 "bwy" = (
@@ -32415,8 +30876,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/engineering_workshop)
 "bwz" = (
@@ -32440,8 +30900,7 @@
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engineering)
 "bwC" = (
@@ -32469,7 +30928,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/engineering/lower_engineering)
@@ -32492,7 +30950,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engine_monitoring)
@@ -32504,7 +30961,6 @@
 	dir = 9
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (WEST)";
 	icon_state = "orangecorner";
 	dir = 8
 	},
@@ -32519,7 +30975,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/engineering/lower_engine_monitoring)
@@ -32528,7 +30983,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engine_monitoring)
@@ -32560,8 +31014,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_corner";
-	tag = "icon-sterile_green_corner (NORTH)"
+	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/chemistry)
 "bwN" = (
@@ -32599,13 +31052,11 @@
 /area/almayer/shipboard/weapon_room)
 "bwU" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-22"
 	},
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/corporateliaison)
 "bwW" = (
@@ -32747,8 +31198,7 @@
 /obj/effect/spawner/random/bomb_supply,
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/shipboard/ex_firing_range)
 "bxq" = (
@@ -32763,8 +31213,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/surgery_hallway)
 "bxt" = (
@@ -32772,8 +31221,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bxu" = (
@@ -32781,8 +31229,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bxv" = (
@@ -32796,23 +31243,20 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bxw" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bxy" = (
 /obj/structure/bed/stool,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/chemistry)
 "bxz" = (
@@ -32822,8 +31266,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/chemistry)
 "bxA" = (
@@ -32833,8 +31276,7 @@
 	d2 = 8
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/chemistry)
 "bxB" = (
@@ -32844,21 +31286,18 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/chemistry)
 "bxC" = (
 /obj/machinery/smartfridge/chemistry,
 /turf/open/floor/almayer{
-	icon_state = "sterile_green";
-	tag = "icon-sterile"
+	icon_state = "sterile_green"
 	},
 /area/almayer/medical/lower_medical)
 "bxD" = (
 /obj/machinery/cryopod/right,
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (NORTH)";
 	icon_state = "sterile_green_corner";
 	dir = 1
 	},
@@ -32867,35 +31306,30 @@
 /obj/machinery/cryopod/right,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/surgery_hallway)
 "bxG" = (
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (NORTHWEST)";
 	icon_state = "sterile_green_side";
 	dir = 9
 	},
 /area/almayer/medical/surgery_hallway)
 "bxH" = (
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (NORTHEAST)";
 	icon_state = "sterile_green_side";
 	dir = 5
 	},
 /area/almayer/medical/surgery_hallway)
 "bxI" = (
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (NORTHWEST)";
 	icon_state = "sterile_green_side";
 	dir = 9
 	},
 /area/almayer/medical/operating_room_two)
 "bxK" = (
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/operating_room_two)
 "bxM" = (
@@ -32907,8 +31341,7 @@
 /obj/item/handcuffs,
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hull/lower_hull)
 "bxN" = (
@@ -32919,15 +31352,13 @@
 	},
 /obj/item/storage/box/handcuffs,
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/hull/lower_hull)
 "bxP" = (
 /obj/machinery/door/airlock/almayer/medical/glass,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/surgery_hallway)
 "bxQ" = (
@@ -32938,7 +31369,6 @@
 	},
 /obj/machinery/power/fusion_engine/random,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/engineering/engine_core)
@@ -32949,14 +31379,12 @@
 	},
 /obj/machinery/power/fusion_engine/random,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/engineering/engine_core)
 "bxS" = (
 /obj/structure/bed/chair/reinforced,
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/living/briefing)
@@ -33075,8 +31503,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/living/cryo_cells)
 "byl" = (
@@ -33089,14 +31516,12 @@
 "byn" = (
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/engineering_workshop)
 "byo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (NORTH)";
 	icon_state = "orangecorner";
 	dir = 1
 	},
@@ -33106,7 +31531,6 @@
 /area/almayer/engineering/engineering_workshop)
 "byq" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -33114,15 +31538,13 @@
 "byr" = (
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/engineering_workshop)
 "bys" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engineering)
 "byt" = (
@@ -33134,8 +31556,7 @@
 "byu" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engine_monitoring)
 "byv" = (
@@ -33146,8 +31567,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engine_monitoring)
 "byw" = (
@@ -33159,8 +31579,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engine_monitoring)
 "byx" = (
@@ -33174,8 +31593,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engine_monitoring)
 "byy" = (
@@ -33261,13 +31679,11 @@
 /obj/structure/ob_ammo/ob_fuel,
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/weapon_room)
 "byE" = (
 /turf/open/floor/almayer{
-	tag = "icon-silver";
 	icon_state = "silver";
 	dir = 2
 	},
@@ -33279,8 +31695,7 @@
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/starboard_missiles)
 "byQ" = (
@@ -33301,15 +31716,13 @@
 "byT" = (
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "byU" = (
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_corner";
-	tag = "icon-sterile_green_corner (NORTH)"
+	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/lower_medical)
 "byV" = (
@@ -33321,24 +31734,21 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "byW" = (
 /obj/machinery/chem_master,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_corner";
-	tag = "icon-sterile_green_corner"
+	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/chemistry)
 "byX" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/chemistry)
 "byY" = (
@@ -33348,8 +31758,7 @@
 /obj/item/reagent_container/glass/beaker/bluespace,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/chemistry)
 "byZ" = (
@@ -33360,8 +31769,7 @@
 /obj/item/reagent_container/glass/beaker,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/chemistry)
 "bza" = (
@@ -33374,7 +31782,6 @@
 /obj/item/reagent_container/spray/cleaner,
 /obj/item/storage/box/pillbottles,
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (EAST)";
 	icon_state = "sterile_green_corner";
 	dir = 4
 	},
@@ -33383,8 +31790,7 @@
 /obj/machinery/cryopod/right,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_corner";
-	tag = "icon-sterile_green_corner"
+	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/surgery_hallway)
 "bzc" = (
@@ -33406,8 +31812,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/surgery_hallway)
 "bzd" = (
@@ -33420,8 +31825,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/surgery_hallway)
 "bze" = (
@@ -33441,8 +31845,7 @@
 	name = "Operating Theatre 2"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/operating_room_two)
 "bzf" = (
@@ -33455,8 +31858,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/operating_room_two)
 "bzg" = (
@@ -33466,8 +31868,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/operating_room_two)
 "bzh" = (
@@ -33480,8 +31881,7 @@
 /obj/item/tank/anesthetic,
 /obj/item/clothing/mask/breath/medical,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/operating_room_two)
 "bzj" = (
@@ -33513,8 +31913,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/squads/req)
 "bzo" = (
@@ -33562,8 +31961,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/living/cryo_cells)
 "bzx" = (
@@ -33580,8 +31978,7 @@
 "bzA" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/engineering_workshop)
 "bzB" = (
@@ -33596,8 +31993,7 @@
 /obj/item/multitool,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/engineering_workshop)
 "bzE" = (
@@ -33610,8 +32006,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engineering)
 "bzG" = (
@@ -33638,8 +32033,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engine_monitoring)
 "bzJ" = (
@@ -33647,8 +32041,7 @@
 /obj/item/radio,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engine_monitoring)
 "bzK" = (
@@ -33658,13 +32051,11 @@
 /obj/structure/ob_ammo/warhead/incendiary,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/weapon_room)
 "bzL" = (
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/shipboard/starboard_missiles)
@@ -33744,7 +32135,6 @@
 	},
 /obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/weapon_room)
@@ -33844,7 +32234,6 @@
 	throw_range = 15
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/hangar)
@@ -33861,19 +32250,16 @@
 	req_one_access_txt = "0"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bAk" = (
 /turf/open/floor/almayer{
-	icon_state = "sterile_green";
-	tag = "icon-sterile"
+	icon_state = "sterile_green"
 	},
 /area/almayer/medical/lower_medical)
 "bAl" = (
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (NORTHEAST)";
 	icon_state = "sterile_green_side";
 	dir = 5
 	},
@@ -33887,16 +32273,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bAn" = (
 /obj/machinery/vending/MarineMed,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bAo" = (
@@ -33917,7 +32301,6 @@
 /obj/item/storage/firstaid/fire,
 /obj/item/storage/firstaid/fire,
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (NORTH)";
 	icon_state = "sterile_green_corner";
 	dir = 1
 	},
@@ -33944,21 +32327,18 @@
 /obj/item/storage/box/masks,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bAq" = (
 /obj/machinery/cryopod/right,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/surgery_hallway)
 "bAr" = (
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (SOUTHWEST)";
 	icon_state = "sterile_green_side";
 	dir = 10
 	},
@@ -33973,13 +32353,11 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/surgery_hallway)
 "bAt" = (
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (SOUTHEAST)";
 	icon_state = "sterile_green_side";
 	dir = 6
 	},
@@ -33991,23 +32369,20 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/operating_room_two)
 "bAv" = (
 /obj/machinery/light,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/operating_room_two)
 "bAx" = (
 /obj/structure/target_stake,
 /obj/item/target,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/ex_firing_range)
@@ -34025,14 +32400,12 @@
 	req_access_txt = "19"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-silvercorner (EAST)";
 	icon_state = "silvercorner";
 	dir = 4
 	},
 /area/almayer/living/briefing)
 "bAC" = (
 /obj/structure/bed/chair/comfy{
-	tag = "icon-comfychair (NORTH)";
 	icon_state = "comfychair";
 	dir = 1
 	},
@@ -34041,8 +32414,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/living/briefing)
 "bAD" = (
@@ -34051,8 +32423,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/living/briefing)
 "bAE" = (
@@ -34067,14 +32438,12 @@
 	},
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/living/briefing)
 "bAF" = (
 /obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/living/briefing)
@@ -34083,7 +32452,6 @@
 	id = "line1"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor5";
 	icon_state = "test_floor5"
 	},
 /area/almayer/squads/req)
@@ -34100,7 +32468,6 @@
 	},
 /obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/squads/req)
@@ -34120,8 +32487,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/squads/req)
 "bAK" = (
@@ -34150,14 +32516,12 @@
 	dir = 9
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
 /area/almayer/living/cryo_cells)
 "bAQ" = (
 /turf/open/floor/almayer{
-	tag = "icon-silvercorner";
 	icon_state = "silvercorner";
 	dir = 2
 	},
@@ -34165,8 +32529,7 @@
 "bAR" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "silvercorner";
-	tag = "icon-silvercorner (NORTH)"
+	icon_state = "silvercorner"
 	},
 /area/almayer/living/cryo_cells)
 "bAS" = (
@@ -34176,7 +32539,6 @@
 	dir = 5
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (NORTH)";
 	icon_state = "redcorner";
 	dir = 1
 	},
@@ -34194,13 +32556,11 @@
 /area/almayer/shipboard/brig_cells)
 "bAU" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangefull";
 	icon_state = "orangefull"
 	},
 /area/almayer/engineering/engineering_workshop)
 "bAV" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (NORTH)";
 	icon_state = "orangecorner";
 	dir = 1
 	},
@@ -34240,8 +32600,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engine_monitoring)
 "bBc" = (
@@ -34258,13 +32617,11 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engine_monitoring)
 "bBf" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (NORTH)";
 	icon_state = "orangecorner";
 	dir = 1
 	},
@@ -34274,8 +32631,7 @@
 /obj/structure/table/almayer,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engine_monitoring)
 "bBh" = (
@@ -34318,14 +32674,12 @@
 /obj/structure/ob_ammo/warhead/cluster,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/weapon_room)
 "bBl" = (
 /obj/structure/largecrate/random/case,
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/shipboard/starboard_missiles)
@@ -34348,8 +32702,7 @@
 /obj/machinery/computer/shuttle_control/dropship2,
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/hangar)
 "bBw" = (
@@ -34357,8 +32710,7 @@
 /obj/machinery/computer/shuttle_control/dropship1,
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/hangar)
 "bBx" = (
@@ -34371,7 +32723,6 @@
 /area/almayer/hallways/hangar)
 "bBB" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-22"
 	},
 /obj/machinery/light{
@@ -34379,8 +32730,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bBC" = (
@@ -34390,8 +32740,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bBD" = (
@@ -34403,16 +32752,14 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bBG" = (
 /obj/machinery/vending/MarineMed/Blood,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bBH" = (
@@ -34426,8 +32773,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bBI" = (
@@ -34560,7 +32906,6 @@
 	},
 /obj/machinery/power/fusion_engine/preset,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/engineering/engine_core)
@@ -34627,8 +32972,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engineering)
 "bCo" = (
@@ -34654,8 +32998,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engineering)
 "bCq" = (
@@ -34677,8 +33020,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engine_monitoring)
 "bCs" = (
@@ -34722,8 +33064,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engine_monitoring)
 "bCx" = (
@@ -34860,7 +33201,6 @@
 	},
 /obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/weapon_room)
@@ -34888,8 +33228,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/hangar)
 "bCU" = (
@@ -34898,8 +33237,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/hangar)
 "bCV" = (
@@ -34908,21 +33246,18 @@
 /area/almayer/hallways/hangar)
 "bDb" = (
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (SOUTHWEST)";
 	icon_state = "sterile_green_side";
 	dir = 10
 	},
 /area/almayer/medical/lower_medical)
 "bDc" = (
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (SOUTHEAST)";
 	icon_state = "sterile_green_side";
 	dir = 6
 	},
 /area/almayer/medical/lower_medical)
 "bDd" = (
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (EAST)";
 	icon_state = "sterile_green_corner";
 	dir = 4
 	},
@@ -34936,16 +33271,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bDf" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bDg" = (
@@ -34974,8 +33307,7 @@
 	},
 /obj/item/storage/firstaid/adv,
 /turf/open/floor/almayer{
-	icon_state = "sterile_green";
-	tag = "icon-sterile"
+	icon_state = "sterile_green"
 	},
 /area/almayer/medical/lower_medical)
 "bDj" = (
@@ -34988,8 +33320,7 @@
 /obj/item/tool/weldingtool/largetank,
 /obj/item/clothing/head/welding,
 /turf/open/floor/almayer{
-	icon_state = "sterile_green";
-	tag = "icon-sterile"
+	icon_state = "sterile_green"
 	},
 /area/almayer/medical/lower_medical)
 "bDk" = (
@@ -34997,8 +33328,7 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	icon_state = "sterile_green";
-	tag = "icon-sterile"
+	icon_state = "sterile_green"
 	},
 /area/almayer/medical/lower_medical)
 "bDl" = (
@@ -35022,7 +33352,6 @@
 	pixel_y = -5
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (NORTH)";
 	icon_state = "sterile_green_corner";
 	dir = 1
 	},
@@ -35037,8 +33366,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/command/cic)
 "bDq" = (
@@ -35047,8 +33375,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_corner";
-	tag = "icon-sterile_green_corner (NORTH)"
+	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/operating_room_three)
 "bDr" = (
@@ -35058,7 +33385,6 @@
 /area/almayer/living/briefing)
 "bDs" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-22"
 	},
 /turf/open/floor/almayer/mono,
@@ -35069,7 +33395,6 @@
 	req_access_txt = "19"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-silvercorner";
 	icon_state = "silvercorner";
 	dir = 2
 	},
@@ -35078,7 +33403,6 @@
 /obj/structure/bed/chair/comfy,
 /obj/structure/window/reinforced/toughened,
 /turf/open/floor/almayer{
-	tag = "icon-silver";
 	icon_state = "silver";
 	dir = 2
 	},
@@ -35086,7 +33410,6 @@
 "bDv" = (
 /obj/structure/window/reinforced/toughened,
 /turf/open/floor/almayer{
-	tag = "icon-silver";
 	icon_state = "silver";
 	dir = 2
 	},
@@ -35094,7 +33417,6 @@
 "bDw" = (
 /obj/structure/bed/chair/reinforced,
 /turf/open/floor/almayer{
-	tag = "icon-orangefull";
 	icon_state = "orangefull"
 	},
 /area/almayer/living/briefing)
@@ -35102,7 +33424,6 @@
 /obj/structure/bed/chair/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/almayer{
-	tag = "icon-orangefull";
 	icon_state = "orangefull"
 	},
 /area/almayer/living/briefing)
@@ -35110,7 +33431,6 @@
 /obj/structure/bed/chair/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/almayer{
-	tag = "icon-orangefull";
 	icon_state = "orangefull"
 	},
 /area/almayer/living/briefing)
@@ -35121,7 +33441,6 @@
 	},
 /obj/machinery/power/fusion_engine/preset,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/engineering/engine_core)
@@ -35131,7 +33450,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/living/briefing)
@@ -35143,7 +33461,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor5";
 	icon_state = "test_floor5"
 	},
 /area/almayer/squads/req)
@@ -35160,7 +33477,6 @@
 	},
 /obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/squads/req)
@@ -35174,8 +33490,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/squads/req)
 "bDE" = (
@@ -35205,20 +33520,17 @@
 	dir = 10
 	},
 /turf/open/floor/almayer{
-	tag = "icon-emeraldcorner";
 	icon_state = "emeraldcorner"
 	},
 /area/almayer/living/cryo_cells)
 "bDJ" = (
 /turf/open/floor/almayer{
-	tag = "icon-silvercorner (EAST)";
 	icon_state = "silvercorner";
 	dir = 4
 	},
 /area/almayer/living/cryo_cells)
 "bDK" = (
 /turf/open/floor/almayer{
-	tag = "icon-silvercorner (NORTH)";
 	icon_state = "silvercorner";
 	dir = 1
 	},
@@ -35231,8 +33543,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/living/cryo_cells)
 "bDN" = (
@@ -35245,7 +33556,6 @@
 /area/almayer/engineering/engineering_workshop)
 "bDO" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (WEST)";
 	icon_state = "orangecorner";
 	dir = 8
 	},
@@ -35273,7 +33583,6 @@
 /area/almayer/engineering/engineering_workshop)
 "bDS" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/engineering/engineering_workshop)
@@ -35308,8 +33617,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engine_monitoring)
 "bDW" = (
@@ -35317,13 +33625,11 @@
 /area/almayer/engineering/lower_engine_monitoring)
 "bDX" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/engineering/lower_engine_monitoring)
 "bDZ" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (WEST)";
 	icon_state = "orangecorner";
 	dir = 8
 	},
@@ -35333,8 +33639,7 @@
 /obj/structure/table/almayer,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engine_monitoring)
 "bEb" = (
@@ -35381,8 +33686,7 @@
 /obj/structure/ob_ammo/ob_fuel,
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/weapon_room)
 "bEk" = (
@@ -35408,8 +33712,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/hangar)
 "bEr" = (
@@ -35429,8 +33732,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/hangar)
 "bEy" = (
@@ -35442,16 +33744,14 @@
 "bEz" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/almayer{
-	icon_state = "sterile_green";
-	tag = "icon-sterile"
+	icon_state = "sterile_green"
 	},
 /area/almayer/medical/lower_medical)
 "bEA" = (
 /obj/machinery/door/airlock/almayer/medical/glass,
 /obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/surgery_hallway)
 "bEB" = (
@@ -35465,15 +33765,13 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bEC" = (
 /obj/machinery/bodyscanner,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bED" = (
@@ -35483,8 +33781,7 @@
 /obj/item/defibrillator,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bEE" = (
@@ -35495,8 +33792,7 @@
 /obj/item/reagent_scanner,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bEH" = (
@@ -35507,16 +33803,14 @@
 /obj/item/storage/belt/combatLifesaver,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bEI" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bEJ" = (
@@ -35528,21 +33822,18 @@
 /obj/item/storage/belt/medical,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bEK" = (
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (NORTHWEST)";
 	icon_state = "sterile_green_side";
 	dir = 9
 	},
 /area/almayer/medical/operating_room_three)
 "bEM" = (
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/operating_room_three)
 "bEO" = (
@@ -35573,22 +33864,19 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/living/cryo_cells)
 "bES" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/living/cryo_cells)
 "bET" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/living/cryo_cells)
 "bEU" = (
@@ -35598,8 +33886,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/living/cryo_cells)
 "bEV" = (
@@ -35621,8 +33908,7 @@
 "bEY" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/engineering_workshop)
 "bEZ" = (
@@ -35649,8 +33935,7 @@
 /obj/item/folder/yellow,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engine_monitoring)
 "bFc" = (
@@ -35819,8 +34104,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/hangar)
 "bFB" = (
@@ -35838,8 +34122,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bFN" = (
@@ -35847,8 +34130,7 @@
 /obj/machinery/recharger,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bFQ" = (
@@ -35871,8 +34153,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bFT" = (
@@ -35884,8 +34165,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_corner";
-	tag = "icon-sterile_green_corner"
+	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/lower_medical)
 "bFU" = (
@@ -35894,8 +34174,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bFV" = (
@@ -35917,8 +34196,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/surgery_hallway)
 "bFW" = (
@@ -35938,8 +34216,7 @@
 	id = "or3sign"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/operating_room_three)
 "bFX" = (
@@ -35952,8 +34229,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/operating_room_three)
 "bFY" = (
@@ -35963,8 +34239,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/operating_room_three)
 "bFZ" = (
@@ -35977,8 +34252,7 @@
 /obj/item/tank/anesthetic,
 /obj/item/clothing/mask/breath/medical,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/operating_room_three)
 "bGa" = (
@@ -36000,8 +34274,7 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/operating_room_one)
 "bGb" = (
@@ -36010,8 +34283,7 @@
 /obj/item/tool/hand_labeler,
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hull/lower_hull)
 "bGc" = (
@@ -36019,8 +34291,7 @@
 /obj/item/storage/box/ids,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hull/lower_hull)
 "bGd" = (
@@ -36030,7 +34301,6 @@
 	pixel_y = 30
 	},
 /turf/open/floor/almayer{
-	tag = "icon-bluecorner";
 	icon_state = "bluecorner";
 	dir = 1
 	},
@@ -36038,8 +34308,7 @@
 "bGe" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hull/lower_hull)
 "bGg" = (
@@ -36102,8 +34371,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/living/cryo_cells)
 "bGp" = (
@@ -36113,8 +34381,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/living/cryo_cells)
 "bGq" = (
@@ -36133,22 +34400,19 @@
 "bGt" = (
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/engineering_workshop)
 "bGu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/engineering/engineering_workshop)
 "bGv" = (
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/engineering_workshop)
 "bGx" = (
@@ -36160,15 +34424,13 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engine_monitoring)
 "bGy" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engine_monitoring)
 "bGz" = (
@@ -36186,8 +34448,7 @@
 /obj/item/book/manual/engineering_particle_accelerator,
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engine_monitoring)
 "bGB" = (
@@ -36196,8 +34457,7 @@
 /obj/item/clipboard,
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engine_monitoring)
 "bGC" = (
@@ -36230,7 +34490,6 @@
 	dir = 10
 	},
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/shipboard/weapon_room)
@@ -36243,8 +34502,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/corporateliaison)
 "bGR" = (
@@ -36254,14 +34512,12 @@
 "bGS" = (
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/hangar)
 "bGY" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (NORTH)";
 	icon_state = "sterile_green_corner";
 	dir = 1
 	},
@@ -36269,22 +34525,19 @@
 "bGZ" = (
 /obj/machinery/body_scanconsole,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bHa" = (
 /obj/machinery/sleeper,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bHb" = (
 /obj/machinery/sleep_console,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bHc" = (
@@ -36293,8 +34546,7 @@
 /obj/item/reagent_container/spray/cleaner,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bHf" = (
@@ -36303,8 +34555,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bHh" = (
@@ -36328,8 +34579,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bHi" = (
@@ -36339,16 +34589,14 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/operating_room_three)
 "bHj" = (
 /obj/machinery/light,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/operating_room_three)
 "bHk" = (
@@ -36356,7 +34604,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-bluefull";
 	icon_state = "bluefull"
 	},
 /area/almayer/living/briefing)
@@ -36366,8 +34613,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/command/cic)
 "bHm" = (
@@ -36376,8 +34622,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hull/lower_hull)
 "bHn" = (
@@ -36391,7 +34636,6 @@
 /obj/machinery/door/window/eastleft,
 /obj/machinery/door/window/westleft,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hull/lower_hull)
@@ -36414,7 +34658,6 @@
 "bHs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/squads/req)
@@ -36424,7 +34667,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-green";
 	icon_state = "green";
 	dir = 2
 	},
@@ -36451,8 +34693,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/living/cryo_cells)
 "bHz" = (
@@ -36462,8 +34703,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/living/cryo_cells)
 "bHB" = (
@@ -36488,8 +34728,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/engineering_workshop)
 "bHE" = (
@@ -36503,8 +34742,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/engineering_workshop)
 "bHG" = (
@@ -36525,7 +34763,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (NORTH)";
 	icon_state = "orangecorner";
 	dir = 1
 	},
@@ -36582,8 +34819,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engine_monitoring)
 "bHO" = (
@@ -36599,7 +34835,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (NORTH)";
 	icon_state = "orangecorner";
 	dir = 1
 	},
@@ -36609,7 +34844,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -36673,8 +34907,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
 "bHZ" = (
@@ -36682,7 +34915,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/starboard_missiles)
@@ -36700,8 +34932,7 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bIp" = (
@@ -36736,15 +34967,13 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bIr" = (
 /obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bIs" = (
@@ -36754,8 +34983,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/surgery_hallway)
 "bIt" = (
@@ -36763,7 +34991,6 @@
 	dir = 6
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (SOUTHEAST)";
 	icon_state = "sterile_green_side";
 	dir = 6
 	},
@@ -36784,8 +35011,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bIw" = (
@@ -36794,15 +35020,13 @@
 /obj/item/tool/pen,
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hull/lower_hull)
 "bIx" = (
 /obj/structure/table/almayer,
 /obj/item/book/manual/marine_law,
 /turf/open/floor/almayer{
-	tag = "icon-blue";
 	icon_state = "blue"
 	},
 /area/almayer/hull/lower_hull)
@@ -36811,8 +35035,7 @@
 /obj/machinery/computer/squad_changer,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/hull/lower_hull)
 "bIz" = (
@@ -36820,7 +35043,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangefull";
 	icon_state = "orangefull"
 	},
 /area/almayer/living/briefing)
@@ -36830,7 +35052,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/almayer{
-	tag = "icon-bluefull";
 	icon_state = "bluefull"
 	},
 /area/almayer/living/briefing)
@@ -36842,7 +35063,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/squads/req)
@@ -36852,7 +35072,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/squads/req)
@@ -36864,7 +35083,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/squads/req)
@@ -36909,8 +35127,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/living/cryo_cells)
 "bIK" = (
@@ -36921,8 +35138,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/port_hallway)
 "bIL" = (
@@ -36978,7 +35194,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/engineering/lower_engineering)
@@ -37005,7 +35220,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (WEST)";
 	icon_state = "orangecorner";
 	dir = 8
 	},
@@ -37020,7 +35234,6 @@
 /area/almayer/engineering/lower_engine_monitoring)
 "bIT" = (
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/engineering/lower_engine_monitoring)
@@ -37033,13 +35246,11 @@
 "bIW" = (
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engine_monitoring)
 "bIX" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (EAST)";
 	icon_state = "redcorner";
 	dir = 4
 	},
@@ -37103,7 +35314,6 @@
 "bJv" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (NORTHEAST)";
 	icon_state = "sterile_green_side";
 	dir = 5
 	},
@@ -37129,8 +35339,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/surgery_hallway)
 "bJy" = (
@@ -37164,24 +35373,21 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/surgery_hallway)
 "bJz" = (
 /obj/machinery/bodyscanner,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bJA" = (
 /obj/machinery/body_scanconsole,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bJB" = (
@@ -37189,11 +35395,9 @@
 	dir = 4
 	},
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-21"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (EAST)";
 	icon_state = "sterile_green_corner";
 	dir = 4
 	},
@@ -37215,7 +35419,6 @@
 	pixel_y = -5
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_corner (NORTH)";
 	icon_state = "sterile_green_corner";
 	dir = 1
 	},
@@ -37226,8 +35429,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_corner";
-	tag = "icon-sterile_green_corner (NORTH)"
+	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/operating_room_four)
 "bJH" = (
@@ -37237,16 +35439,14 @@
 "bJI" = (
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "plating_striped";
-	tag = "icon-plating_striped (EAST)"
+	icon_state = "plating_striped"
 	},
 /area/almayer/squads/req)
 "bJJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "plating_striped";
-	tag = "icon-plating_striped (EAST)"
+	icon_state = "plating_striped"
 	},
 /area/almayer/squads/req)
 "bJK" = (
@@ -37255,7 +35455,6 @@
 /area/almayer/squads/req)
 "bJL" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-21"
 	},
 /turf/open/floor/almayer/mono,
@@ -37276,7 +35475,6 @@
 /obj/item/paper_bin,
 /obj/item/tool/pen,
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (NORTH)";
 	icon_state = "greencorner";
 	dir = 1
 	},
@@ -37290,7 +35488,6 @@
 /obj/item/storage/box/uscm_mre,
 /obj/item/storage/fancy/cigarettes/lucky_strikes,
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (EAST)";
 	icon_state = "greencorner";
 	dir = 4
 	},
@@ -37305,7 +35502,6 @@
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/bulletproof,
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/squads/req)
@@ -37316,8 +35512,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/living/cryo_cells)
 "bJT" = (
@@ -37328,8 +35523,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/living/cryo_cells)
 "bJU" = (
@@ -37345,7 +35539,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -37355,7 +35548,6 @@
 	pixel_y = 25
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (NORTH)";
 	icon_state = "orangecorner";
 	dir = 1
 	},
@@ -37370,8 +35562,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engineering)
 "bJY" = (
@@ -37384,7 +35575,6 @@
 /area/almayer/engineering/lower_engineering)
 "bKc" = (
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engine_monitoring)
@@ -37392,7 +35582,6 @@
 /obj/structure/bed/chair/office/light,
 /obj/effect/landmark/start/marine/maintenancetech,
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engine_monitoring)
@@ -37411,13 +35600,11 @@
 /area/almayer/engineering/lower_engine_monitoring)
 "bKg" = (
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/engine_core)
 "bKh" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (WEST)";
 	icon_state = "orangecorner";
 	dir = 8
 	},
@@ -37445,8 +35632,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/operating_room_two)
 "bKl" = (
@@ -37462,7 +35648,6 @@
 	dir = 10
 	},
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/shipboard/starboard_missiles)
@@ -37483,8 +35668,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bKA" = (
@@ -37503,23 +35687,20 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bKB" = (
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/surgery_hallway)
 "bKC" = (
 /obj/machinery/light,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/surgery_hallway)
 "bKD" = (
@@ -37538,16 +35719,14 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bKE" = (
 /obj/machinery/bodyscanner,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/surgery_hallway)
 "bKF" = (
@@ -37560,21 +35739,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/surgery_hallway)
 "bKG" = (
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (NORTHWEST)";
 	icon_state = "sterile_green_side";
 	dir = 9
 	},
 /area/almayer/medical/operating_room_four)
 "bKI" = (
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/operating_room_four)
 "bKK" = (
@@ -37599,8 +35775,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/hallways/aft_hallway)
 "bKN" = (
@@ -37669,7 +35844,6 @@
 	req_one_access_txt = "22;2;7"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/squads/req)
@@ -37679,8 +35853,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/living/cryo_cells)
 "bKY" = (
@@ -37689,16 +35862,14 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/living/cryo_cells)
 "bKZ" = (
 /obj/effect/landmark/start/latejoin_cryo,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/living/cryo_cells)
 "bLa" = (
@@ -37923,15 +36094,13 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/engineering/lower_engineering)
 "bLn" = (
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engineering)
 "bLo" = (
@@ -38003,7 +36172,6 @@
 /area/almayer/hallways/hangar)
 "bLA" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (WEST)";
 	icon_state = "redcorner";
 	dir = 8
 	},
@@ -38017,7 +36185,6 @@
 /area/almayer/shipboard/port_missiles)
 "bLC" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner";
 	icon_state = "redcorner"
 	},
 /area/almayer/shipboard/port_missiles)
@@ -38027,7 +36194,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/starboard_missiles)
@@ -38066,23 +36232,20 @@
 "bLX" = (
 /obj/machinery/autodoc_console,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bLY" = (
 /obj/machinery/autodoc,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bLZ" = (
 /obj/machinery/body_scanconsole,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/surgery_hallway)
 "bMa" = (
@@ -38091,8 +36254,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bMb" = (
@@ -38100,7 +36262,6 @@
 	dir = 10
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile_green_side (SOUTHWEST)";
 	icon_state = "sterile_green_side";
 	dir = 10
 	},
@@ -38108,8 +36269,7 @@
 "bMc" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bMd" = (
@@ -38133,16 +36293,14 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bMe" = (
 /obj/machinery/sleep_console,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/surgery_hallway)
 "bMf" = (
@@ -38161,8 +36319,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/surgery_hallway)
 "bMg" = (
@@ -38181,8 +36338,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/surgery_hallway)
 "bMh" = (
@@ -38206,8 +36362,7 @@
 	dir = 9
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/surgery_hallway)
 "bMj" = (
@@ -38227,8 +36382,7 @@
 	id = "or4sign"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/operating_room_four)
 "bMk" = (
@@ -38241,8 +36395,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/operating_room_four)
 "bMl" = (
@@ -38252,8 +36405,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/operating_room_four)
 "bMm" = (
@@ -38266,8 +36418,7 @@
 /obj/item/tank/anesthetic,
 /obj/item/clothing/mask/breath/medical,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/operating_room_four)
 "bMn" = (
@@ -38287,8 +36438,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hull/lower_hull)
 "bMp" = (
@@ -38304,8 +36454,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hull/lower_hull)
 "bMr" = (
@@ -38318,7 +36467,6 @@
 	},
 /obj/structure/closet/firecloset,
 /turf/open/floor/almayer{
-	tag = "icon-green";
 	icon_state = "green";
 	dir = 2
 	},
@@ -38372,7 +36520,6 @@
 /area/almayer/squads/req)
 "bMC" = (
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (WEST)";
 	icon_state = "greencorner";
 	dir = 8
 	},
@@ -38387,7 +36534,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-green";
 	icon_state = "green";
 	dir = 2
 	},
@@ -38409,7 +36555,6 @@
 	},
 /obj/machinery/light,
 /turf/open/floor/almayer{
-	tag = "icon-green";
 	icon_state = "green";
 	dir = 2
 	},
@@ -38420,7 +36565,6 @@
 	},
 /obj/effect/landmark/start/marine/cargotechnician,
 /turf/open/floor/almayer{
-	tag = "icon-green";
 	icon_state = "green";
 	dir = 2
 	},
@@ -38433,7 +36577,6 @@
 /obj/item/tool/lighter/zippo,
 /obj/item/clothing/mask/cigarette/cigar,
 /turf/open/floor/almayer{
-	tag = "icon-green";
 	icon_state = "green";
 	dir = 2
 	},
@@ -38447,7 +36590,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-green";
 	icon_state = "green";
 	dir = 2
 	},
@@ -38459,8 +36601,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/living/cryo_cells)
 "bMM" = (
@@ -38469,8 +36610,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/living/cryo_cells)
 "bMN" = (
@@ -38488,8 +36628,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/living/cryo_cells)
 "bMP" = (
@@ -38499,8 +36638,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/living/cryo_cells)
 "bMQ" = (
@@ -38519,20 +36657,17 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/hallways/port_hallway)
 "bMS" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engineering)
 "bMT" = (
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engineering)
@@ -38548,7 +36683,6 @@
 "bMV" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/engineering/lower_engineering)
@@ -38556,7 +36690,6 @@
 /obj/structure/table/almayer,
 /obj/machinery/cell_charger,
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engineering)
@@ -38565,7 +36698,6 @@
 /obj/item/folder/black_random,
 /obj/machinery/light,
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engineering)
@@ -38575,8 +36707,7 @@
 /obj/item/clothing/glasses/welding,
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engineering)
 "bMZ" = (
@@ -38613,8 +36744,7 @@
 "bNf" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/port_missiles)
 "bNh" = (
@@ -38656,16 +36786,14 @@
 "bNt" = (
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bNu" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/surgery_hallway)
 "bNv" = (
@@ -38687,29 +36815,25 @@
 	dir = 8
 	},
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-21"
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_corner";
-	tag = "icon-sterile_green_corner"
+	icon_state = "sterile_green_corner"
 	},
 /area/almayer/medical/lower_medical)
 "bNy" = (
 /obj/machinery/sleeper,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bNz" = (
 /obj/machinery/sleep_console,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bNA" = (
@@ -38720,8 +36844,7 @@
 /obj/machinery/light,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bNC" = (
@@ -38730,8 +36853,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "bND" = (
@@ -38747,8 +36869,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bNE" = (
@@ -38761,8 +36882,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bNF" = (
@@ -38864,8 +36984,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "bNL" = (
@@ -38875,21 +36994,18 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/operating_room_four)
 "bNM" = (
 /obj/machinery/light,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/operating_room_four)
 "bNP" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (NORTH)";
 	icon_state = "redcorner";
 	dir = 1
 	},
@@ -38905,7 +37021,6 @@
 /area/almayer/hull/lower_hull)
 "bNR" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (EAST)";
 	icon_state = "redcorner";
 	dir = 4
 	},
@@ -38968,21 +37083,18 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-emeraldfull";
 	icon_state = "emeraldfull"
 	},
 /area/almayer/living/cryo_cells)
 "bNZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/almayer{
-	tag = "icon-emeraldfull";
 	icon_state = "emeraldfull"
 	},
 /area/almayer/living/cryo_cells)
 "bOa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/almayer{
-	tag = "icon-bluefull";
 	icon_state = "bluefull"
 	},
 /area/almayer/living/cryo_cells)
@@ -38992,7 +37104,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-bluefull";
 	icon_state = "bluefull"
 	},
 /area/almayer/living/cryo_cells)
@@ -39040,14 +37151,12 @@
 /obj/structure/bed/chair,
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/port_missiles)
 "bOk" = (
 /obj/structure/bed/chair,
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/shipboard/port_missiles)
@@ -39055,8 +37164,7 @@
 /obj/structure/bed/chair,
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/port_missiles)
 "bOt" = (
@@ -39084,7 +37192,6 @@
 /area/almayer/hallways/port_hallway)
 "bOJ" = (
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (EAST)";
 	icon_state = "greencorner";
 	dir = 4
 	},
@@ -39103,7 +37210,6 @@
 "bOL" = (
 /obj/structure/barricade/metal,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor5";
 	icon_state = "test_floor5"
 	},
 /area/almayer/hallways/port_hallway)
@@ -39113,7 +37219,6 @@
 	},
 /obj/structure/barricade/metal,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor5";
 	icon_state = "test_floor5"
 	},
 /area/almayer/hallways/port_hallway)
@@ -39129,7 +37234,6 @@
 /area/almayer/hallways/port_hallway)
 "bOO" = (
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (NORTH)";
 	icon_state = "greencorner";
 	dir = 1
 	},
@@ -39142,7 +37246,6 @@
 "bOQ" = (
 /obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/port_hallway)
@@ -39169,7 +37272,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/port_hallway)
@@ -39186,7 +37288,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/port_hallway)
@@ -39232,8 +37333,7 @@
 "bOZ" = (
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/weapon_room)
 "bPc" = (
@@ -39242,7 +37342,6 @@
 /obj/item/book/manual/orbital_cannon_manual,
 /obj/machinery/light,
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/shipboard/weapon_room)
@@ -39252,7 +37351,6 @@
 /obj/structure/ob_ammo/ob_fuel,
 /obj/structure/ob_ammo/ob_fuel,
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/shipboard/weapon_room)
@@ -39366,7 +37464,6 @@
 	name = "\improper South Hangar Shutters"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/port_hallway)
@@ -39399,7 +37496,6 @@
 /area/almayer/hallways/port_hallway)
 "bPC" = (
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/port_hallway)
@@ -39413,7 +37509,6 @@
 	opacity = 0
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/hallways/port_hallway)
@@ -39425,7 +37520,6 @@
 /area/almayer/hallways/port_hallway)
 "bPH" = (
 /turf/open/floor/almayer{
-	tag = "icon-emeraldcorner (EAST)";
 	icon_state = "emeraldcorner";
 	dir = 4
 	},
@@ -39434,21 +37528,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/hallways/port_hallway)
 "bPJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/port_hallway)
 "bPK" = (
 /turf/open/floor/almayer{
-	tag = "icon-bluecorner";
 	icon_state = "bluecorner";
 	dir = 1
 	},
@@ -39609,7 +37700,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/hangar)
@@ -39649,7 +37739,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/port_hallway)
@@ -39829,7 +37918,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/port_hallway)
@@ -39857,7 +37945,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/hallways/port_hallway)
@@ -40032,7 +38119,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/port_hallway)
@@ -40375,8 +38461,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/hallways/port_hallway)
 "bRo" = (
@@ -40385,8 +38470,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/port_hallway)
 "bRp" = (
@@ -40416,7 +38500,6 @@
 	},
 /obj/machinery/meter,
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engineering)
@@ -40425,7 +38508,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engineering)
@@ -40436,7 +38518,6 @@
 	on = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engineering)
@@ -40445,7 +38526,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engineering)
@@ -40455,14 +38535,12 @@
 	},
 /obj/machinery/meter,
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/engineering/lower_engineering)
 "bRx" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (WEST)";
 	icon_state = "orangecorner";
 	dir = 8
 	},
@@ -40482,7 +38560,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/port_umbilical)
@@ -40496,7 +38573,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/port_umbilical)
@@ -40538,7 +38614,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/port_hallway)
@@ -40552,7 +38627,6 @@
 	name = "\improper South West Ladders Shutters"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/port_hallway)
@@ -40696,7 +38770,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/hangar)
@@ -40711,7 +38784,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/hangar)
@@ -40723,7 +38795,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/repair_bay)
@@ -40745,7 +38816,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/hallways/repair_bay)
@@ -40760,7 +38830,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/hallways/repair_bay)
@@ -40768,8 +38837,7 @@
 /obj/machinery/vending/engivend,
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/repair_bay)
 "bSm" = (
@@ -40779,8 +38847,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/repair_bay)
 "bSn" = (
@@ -40804,16 +38871,14 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/repair_bay)
 "bSr" = (
 /obj/machinery/vending/engineering,
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/repair_bay)
 "bSs" = (
@@ -40835,7 +38900,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (WEST)";
 	icon_state = "greencorner";
 	dir = 8
 	},
@@ -40845,7 +38909,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-greencorner";
 	icon_state = "greencorner";
 	dir = 2
 	},
@@ -40908,7 +38971,6 @@
 /area/almayer/living/grunt_rnr)
 "bSE" = (
 /obj/structure/bed/chair/wood/normal{
-	tag = "icon-wooden_chair (EAST)";
 	icon_state = "wooden_chair";
 	dir = 4
 	},
@@ -40925,7 +38987,6 @@
 /area/almayer/living/grunt_rnr)
 "bSG" = (
 /obj/structure/bed/chair/wood/normal{
-	tag = "icon-wooden_chair (WEST)";
 	icon_state = "wooden_chair";
 	dir = 8
 	},
@@ -40975,7 +39036,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/port_hallway)
@@ -40994,8 +39054,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/living/cafeteria_port)
 "bSV" = (
@@ -41004,8 +39063,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/living/cafeteria_port)
 "bSW" = (
@@ -41128,7 +39186,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (WEST)";
 	icon_state = "orangecorner";
 	dir = 8
 	},
@@ -41149,7 +39206,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/hallways/port_umbilical)
@@ -41162,7 +39218,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/living/tankerbunks)
@@ -41177,7 +39232,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/living/tankerbunks)
@@ -41295,12 +39349,10 @@
 /area/almayer/hallways/repair_bay)
 "bTO" = (
 /obj/machinery/shower{
-	tag = "icon-shower (EAST)";
 	icon_state = "shower";
 	dir = 4
 	},
 /obj/structure/window/reinforced/tinted/frosted{
-	tag = "icon-fwindow (NORTH)";
 	icon_state = "fwindow";
 	dir = 1
 	},
@@ -41309,7 +39361,6 @@
 /area/almayer/hallways/repair_bay)
 "bTP" = (
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/hallways/repair_bay)
@@ -41322,8 +39373,7 @@
 "bTR" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/repair_bay)
 "bTS" = (
@@ -41356,8 +39406,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/repair_bay)
 "bTX" = (
@@ -41413,7 +39462,6 @@
 /area/almayer/living/grunt_rnr)
 "bUf" = (
 /obj/structure/bed/chair/wood/normal{
-	tag = "icon-wooden_chair (EAST)";
 	icon_state = "wooden_chair";
 	dir = 4
 	},
@@ -41431,7 +39479,6 @@
 /area/almayer/living/grunt_rnr)
 "bUi" = (
 /obj/structure/bed/chair/wood/normal{
-	tag = "icon-wooden_chair (WEST)";
 	icon_state = "wooden_chair";
 	dir = 8
 	},
@@ -41463,8 +39510,7 @@
 "bUq" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/hallways/port_hallway)
 "bUr" = (
@@ -41532,8 +39578,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/squads/charlie)
 "bUE" = (
@@ -41546,13 +39591,11 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/hallways/port_hallway)
 "bUG" = (
 /turf/open/floor/almayer{
-	tag = "icon-emeraldcorner";
 	icon_state = "emeraldcorner"
 	},
 /area/almayer/hallways/port_hallway)
@@ -41570,8 +39613,7 @@
 "bUK" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/living/cafeteria_port)
 "bUL" = (
@@ -41597,8 +39639,7 @@
 "bUO" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/port_umbilical)
 "bUP" = (
@@ -41609,8 +39650,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/port_umbilical)
 "bUQ" = (
@@ -41623,12 +39663,10 @@
 /area/almayer/hallways/port_umbilical)
 "bUR" = (
 /obj/machinery/shower{
-	tag = "icon-shower (EAST)";
 	icon_state = "shower";
 	dir = 4
 	},
 /obj/structure/window/reinforced/tinted/frosted{
-	tag = "icon-fwindow (NORTH)";
 	icon_state = "fwindow";
 	dir = 1
 	},
@@ -41637,7 +39675,6 @@
 /area/almayer/living/tankerbunks)
 "bUS" = (
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/living/tankerbunks)
@@ -41841,8 +39878,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/operating_room_three)
 "bVo" = (
@@ -41865,8 +39901,7 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/operating_room_three)
 "bVr" = (
@@ -41875,8 +39910,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/repair_bay)
 "bVs" = (
@@ -41890,8 +39924,7 @@
 /obj/item/storage/firstaid/regular,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/repair_bay)
 "bVu" = (
@@ -41913,7 +39946,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (NORTH)";
 	icon_state = "greencorner";
 	dir = 1
 	},
@@ -41923,7 +39955,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (EAST)";
 	icon_state = "greencorner";
 	dir = 4
 	},
@@ -41971,7 +40002,6 @@
 /area/almayer/living/grunt_rnr)
 "bVB" = (
 /obj/structure/bed/chair/wood/normal{
-	tag = "icon-wooden_chair (EAST)";
 	icon_state = "wooden_chair";
 	dir = 4
 	},
@@ -42000,7 +40030,6 @@
 /area/almayer/living/grunt_rnr)
 "bVF" = (
 /obj/structure/bed/chair/wood/normal{
-	tag = "icon-wooden_chair (EAST)";
 	icon_state = "wooden_chair";
 	dir = 4
 	},
@@ -42028,7 +40057,6 @@
 /area/almayer/living/grunt_rnr)
 "bVI" = (
 /obj/structure/bed/chair/wood/normal{
-	tag = "icon-wooden_chair (WEST)";
 	icon_state = "wooden_chair";
 	dir = 8
 	},
@@ -42057,8 +40085,7 @@
 "bVM" = (
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/living/port_emb)
 "bVN" = (
@@ -42068,8 +40095,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/living/port_emb)
 "bVO" = (
@@ -42083,8 +40109,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/living/port_emb)
 "bVP" = (
@@ -42098,8 +40123,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/living/port_emb)
 "bVQ" = (
@@ -42116,8 +40140,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "emeraldcorner";
-	tag = "icon-emeraldcorner"
+	icon_state = "emeraldcorner"
 	},
 /area/almayer/living/port_emb)
 "bVR" = (
@@ -42194,8 +40217,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/squads/charlie)
 "bVY" = (
@@ -42204,8 +40226,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/squads/charlie)
 "bVZ" = (
@@ -42219,8 +40240,7 @@
 "bWb" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/hallways/port_hallway)
 "bWc" = (
@@ -42241,16 +40261,14 @@
 "bWe" = (
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/living/cafeteria_port)
 "bWf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/living/cafeteria_port)
 "bWg" = (
@@ -42259,8 +40277,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "emeraldcorner";
-	tag = "icon-emeraldcorner"
+	icon_state = "emeraldcorner"
 	},
 /area/almayer/living/cafeteria_port)
 "bWh" = (
@@ -42276,8 +40293,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/living/cafeteria_port)
 "bWk" = (
@@ -42368,7 +40384,6 @@
 	},
 /obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/repair_bay)
@@ -42391,8 +40406,7 @@
 /obj/item/tool/extinguisher,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/repair_bay)
 "bWC" = (
@@ -42412,7 +40426,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/port_hallway)
@@ -42426,7 +40439,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/port_hallway)
@@ -42477,7 +40489,6 @@
 /area/almayer/living/grunt_rnr)
 "bWM" = (
 /obj/structure/bed/chair/wood/normal{
-	tag = "icon-wooden_chair (NORTH)";
 	icon_state = "wooden_chair";
 	dir = 1
 	},
@@ -42491,13 +40502,11 @@
 "bWO" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "emeraldcorner";
-	tag = "icon-emeraldcorner (EAST)"
+	icon_state = "emeraldcorner"
 	},
 /area/almayer/living/port_emb)
 "bWP" = (
 /turf/open/floor/almayer{
-	tag = "icon-emeraldcorner";
 	icon_state = "emeraldcorner"
 	},
 /area/almayer/living/port_emb)
@@ -42513,15 +40522,13 @@
 	},
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/squads/charlie)
 "bWS" = (
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/squads/charlie)
 "bWT" = (
@@ -42530,8 +40537,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/squads/charlie)
 "bWU" = (
@@ -42556,7 +40562,6 @@
 /area/almayer/squads/charlie)
 "bXa" = (
 /turf/open/floor/almayer{
-	tag = "icon-bluecorner";
 	icon_state = "bluecorner"
 	},
 /area/almayer/hallways/port_hallway)
@@ -42570,7 +40575,6 @@
 /area/almayer/living/cafeteria_port)
 "bXc" = (
 /turf/open/floor/almayer{
-	tag = "icon-blue";
 	icon_state = "blue"
 	},
 /area/almayer/living/cafeteria_port)
@@ -42579,15 +40583,13 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-blue";
 	icon_state = "blue"
 	},
 /area/almayer/living/cafeteria_port)
 "bXe" = (
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/living/cafeteria_port)
 "bXf" = (
@@ -42610,7 +40612,6 @@
 "bXh" = (
 /obj/machinery/vending/marine,
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/living/tankerbunks)
@@ -42620,7 +40621,6 @@
 /area/almayer/engineering/upper_engineering)
 "bXj" = (
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/living/tankerbunks)
@@ -42644,7 +40644,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/living/pilotbunks)
@@ -42656,7 +40655,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/living/pilotbunks)
@@ -42674,7 +40672,6 @@
 	name = "\improper Pilot Workshop Shutters"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/repair_bay)
@@ -42687,13 +40684,11 @@
 "bXw" = (
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/repair_bay)
 "bXx" = (
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/hallways/repair_bay)
@@ -42708,7 +40703,6 @@
 "bXA" = (
 /obj/machinery/light,
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/hallways/repair_bay)
@@ -42718,8 +40712,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/repair_bay)
 "bXC" = (
@@ -42740,7 +40733,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redcorner";
 	icon_state = "redcorner"
 	},
 /area/almayer/hallways/port_hallway)
@@ -42753,7 +40745,6 @@
 	throw_range = 15
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (WEST)";
 	icon_state = "redcorner";
 	dir = 8
 	},
@@ -42792,15 +40783,13 @@
 "bXK" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/living/port_emb)
 "bXL" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/living/port_emb)
 "bXM" = (
@@ -42815,13 +40804,11 @@
 "bXO" = (
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "emeraldcorner";
-	tag = "icon-emeraldcorner"
+	icon_state = "emeraldcorner"
 	},
 /area/almayer/squads/charlie)
 "bXP" = (
 /turf/open/floor/almayer{
-	tag = "icon-emeraldcorner (EAST)";
 	icon_state = "emeraldcorner";
 	dir = 4
 	},
@@ -42832,8 +40819,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/squads/charlie)
 "bXT" = (
@@ -42842,8 +40828,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/squads/charlie)
 "bXU" = (
@@ -42852,8 +40837,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "emeraldcorner";
-	tag = "icon-emeraldcorner"
+	icon_state = "emeraldcorner"
 	},
 /area/almayer/squads/charlie)
 "bXV" = (
@@ -42868,8 +40852,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/squads/charlie)
 "bXX" = (
@@ -42877,7 +40860,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-emeraldcorner (EAST)";
 	icon_state = "emeraldcorner";
 	dir = 4
 	},
@@ -42888,8 +40870,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "emeraldcorner";
-	tag = "icon-emeraldcorner"
+	icon_state = "emeraldcorner"
 	},
 /area/almayer/hallways/port_hallway)
 "bYa" = (
@@ -42908,8 +40889,7 @@
 "bYb" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/port_hallway)
 "bYc" = (
@@ -42970,7 +40950,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (NORTH)";
 	icon_state = "orangecorner";
 	dir = 1
 	},
@@ -42991,7 +40970,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -42999,7 +40977,6 @@
 "bYp" = (
 /obj/machinery/vending/uniform_supply,
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/living/tankerbunks)
@@ -43012,7 +40989,6 @@
 /obj/item/clothing/glasses/welding,
 /obj/item/clothing/glasses/welding,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/exoarmor)
@@ -43045,8 +41021,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/command/cic)
 "bYw" = (
@@ -43077,12 +41052,10 @@
 /area/almayer/shipboard/ex_firing_range)
 "bYB" = (
 /obj/machinery/shower{
-	tag = "icon-shower (EAST)";
 	icon_state = "shower";
 	dir = 4
 	},
 /obj/structure/window/reinforced/tinted/frosted{
-	tag = "icon-fwindow (NORTH)";
 	icon_state = "fwindow";
 	dir = 1
 	},
@@ -43092,7 +41065,6 @@
 "bYC" = (
 /obj/machinery/light,
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/living/pilotbunks)
@@ -43170,7 +41142,6 @@
 "bYN" = (
 /obj/machinery/light,
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-18"
 	},
 /turf/open/floor/almayer,
@@ -43208,8 +41179,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/port_hallway)
 "bYR" = (
@@ -43218,8 +41188,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/port_hallway)
 "bYS" = (
@@ -43240,7 +41209,6 @@
 /area/almayer/living/grunt_rnr)
 "bYV" = (
 /obj/structure/bed/chair/wood/normal{
-	tag = "icon-wooden_chair (EAST)";
 	icon_state = "wooden_chair";
 	dir = 4
 	},
@@ -43280,13 +41248,11 @@
 "bZd" = (
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "emeraldcorner";
-	tag = "icon-emeraldcorner"
+	icon_state = "emeraldcorner"
 	},
 /area/almayer/living/port_emb)
 "bZe" = (
 /turf/open/floor/almayer{
-	tag = "icon-emeraldcorner (EAST)";
 	icon_state = "emeraldcorner";
 	dir = 4
 	},
@@ -43302,7 +41268,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-emerald";
 	icon_state = "emerald"
 	},
 /area/almayer/squads/charlie)
@@ -43311,7 +41276,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-emerald";
 	icon_state = "emerald"
 	},
 /area/almayer/squads/charlie)
@@ -43348,7 +41312,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-emerald";
 	icon_state = "emerald"
 	},
 /area/almayer/squads/charlie)
@@ -43380,7 +41343,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-emerald";
 	icon_state = "emerald"
 	},
 /area/almayer/squads/charlie)
@@ -43397,7 +41359,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-emerald";
 	icon_state = "emerald"
 	},
 /area/almayer/squads/charlie)
@@ -43431,7 +41392,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-emeraldcorner";
 	icon_state = "emeraldcorner"
 	},
 /area/almayer/squads/charlie)
@@ -43449,8 +41409,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "emeraldcorner";
-	tag = "icon-emeraldcorner (EAST)"
+	icon_state = "emeraldcorner"
 	},
 /area/almayer/hallways/port_hallway)
 "bZs" = (
@@ -43488,8 +41447,7 @@
 /obj/machinery/vending/snack,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/living/pilotbunks)
 "bZz" = (
@@ -43499,8 +41457,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/living/pilotbunks)
 "bZA" = (
@@ -43513,16 +41470,14 @@
 /obj/item/storage/fancy/cigar,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/living/pilotbunks)
 "bZC" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/living/pilotbunks)
 "bZD" = (
@@ -43544,8 +41499,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/living/pilotbunks)
 "bZF" = (
@@ -43556,8 +41510,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/living/pilotbunks)
 "bZG" = (
@@ -43592,15 +41545,13 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/port_hallway)
 "bZJ" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/port_hallway)
 "bZK" = (
@@ -43692,8 +41643,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/port_hallway)
 "caa" = (
@@ -43730,7 +41680,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/port_umbilical)
@@ -43744,7 +41693,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/port_umbilical)
@@ -43758,7 +41706,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/port_umbilical)
@@ -43883,8 +41830,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/port_hallway)
 "cav" = (
@@ -43893,8 +41839,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/port_hallway)
 "caA" = (
@@ -43944,13 +41889,11 @@
 "caI" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/living/port_emb)
 "caJ" = (
 /turf/open/floor/almayer{
-	tag = "icon-bluecorner";
 	icon_state = "bluecorner"
 	},
 /area/almayer/living/port_emb)
@@ -43960,15 +41903,13 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/port_hallway)
 "caL" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/port_hallway)
 "caM" = (
@@ -43999,7 +41940,6 @@
 /obj/structure/table/almayer,
 /obj/machinery/computer/emails,
 /turf/open/floor/almayer{
-	tag = "icon-bluecorner";
 	icon_state = "bluecorner";
 	dir = 1
 	},
@@ -44008,8 +41948,7 @@
 /obj/structure/table/almayer,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/living/pilotbunks)
 "caS" = (
@@ -44022,7 +41961,6 @@
 /obj/item/camera,
 /obj/item/camera_film,
 /turf/open/floor/almayer{
-	tag = "icon-bluecorner";
 	icon_state = "bluecorner";
 	dir = 1
 	},
@@ -44030,8 +41968,7 @@
 "caU" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/living/pilotbunks)
 "caV" = (
@@ -44043,7 +41980,6 @@
 /area/almayer/living/pilotbunks)
 "caW" = (
 /turf/open/floor/almayer{
-	tag = "icon-blue";
 	icon_state = "blue"
 	},
 /area/almayer/living/pilotbunks)
@@ -44055,8 +41991,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/port_hallway)
 "caZ" = (
@@ -44065,8 +42000,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/port_hallway)
 "cbe" = (
@@ -44099,15 +42033,13 @@
 "cbj" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/living/port_emb)
 "cbk" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/living/port_emb)
 "cbm" = (
@@ -44193,8 +42125,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/operating_room_four)
 "cbC" = (
@@ -44250,13 +42181,11 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/living/pilotbunks)
 "cbK" = (
 /turf/open/floor/almayer{
-	tag = "icon-bluecorner";
 	icon_state = "bluecorner"
 	},
 /area/almayer/living/pilotbunks)
@@ -44272,15 +42201,13 @@
 /obj/item/folder/black_random,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/living/pilotbunks)
 "cbN" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/living/pilotbunks)
 "cbO" = (
@@ -44353,7 +42280,6 @@
 /area/almayer/living/port_emb)
 "cbZ" = (
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/living/port_emb)
@@ -44368,7 +42294,6 @@
 /area/almayer/living/port_emb)
 "ccb" = (
 /turf/open/floor/almayer{
-	tag = "icon-bluecorner";
 	icon_state = "bluecorner";
 	dir = 1
 	},
@@ -44376,15 +42301,13 @@
 "ccc" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/living/port_emb)
 "ccd" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/hallways/port_hallway)
 "ccf" = (
@@ -44393,8 +42316,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/squads/delta)
 "ccg" = (
@@ -44403,8 +42325,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/squads/delta)
 "cch" = (
@@ -44458,8 +42379,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/squads/delta)
 "ccn" = (
@@ -44476,8 +42396,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/squads/delta)
 "cco" = (
@@ -44494,8 +42413,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/squads/delta)
 "ccp" = (
@@ -44529,7 +42447,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-bluecorner";
 	icon_state = "bluecorner";
 	dir = 1
 	},
@@ -44570,8 +42487,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/port_hallway)
 "ccu" = (
@@ -44655,8 +42571,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/port_hallway)
 "ccG" = (
@@ -44668,8 +42583,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/port_hallway)
 "ccI" = (
@@ -44696,8 +42610,7 @@
 "ccK" = (
 /obj/machinery/cryopod/right,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/shipboard/brig_cells)
 "ccL" = (
@@ -44705,13 +42618,11 @@
 	name = "\improper Bathroom"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/living/port_emb)
 "ccM" = (
 /turf/open/floor/almayer{
-	tag = "icon-blue";
 	icon_state = "blue"
 	},
 /area/almayer/living/port_emb)
@@ -44725,15 +42636,13 @@
 "ccO" = (
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/hallways/port_hallway)
 "ccP" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/squads/delta)
 "ccQ" = (
@@ -44741,20 +42650,17 @@
 /area/almayer/squads/delta)
 "ccR" = (
 /turf/open/floor/almayer{
-	tag = "icon-bluecorner";
 	icon_state = "bluecorner"
 	},
 /area/almayer/squads/delta)
 "ccS" = (
 /turf/open/floor/almayer{
-	tag = "icon-blue";
 	icon_state = "blue"
 	},
 /area/almayer/squads/delta)
 "ccT" = (
 /obj/machinery/light,
 /turf/open/floor/almayer{
-	tag = "icon-blue";
 	icon_state = "blue"
 	},
 /area/almayer/squads/delta)
@@ -44763,7 +42669,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-blue";
 	icon_state = "blue"
 	},
 /area/almayer/squads/delta)
@@ -44773,7 +42678,6 @@
 	},
 /obj/machinery/light,
 /turf/open/floor/almayer{
-	tag = "icon-blue";
 	icon_state = "blue"
 	},
 /area/almayer/squads/delta)
@@ -44789,8 +42693,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/hallways/port_hallway)
 "cda" = (
@@ -44834,7 +42737,6 @@
 "cdg" = (
 /obj/machinery/light,
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-22"
 	},
 /turf/open/floor/plating/plating_catwalk,
@@ -44861,7 +42763,6 @@
 "cdl" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (EAST)";
 	icon_state = "redcorner";
 	dir = 4
 	},
@@ -44871,7 +42772,6 @@
 	dir = 5
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (NORTH)";
 	icon_state = "redcorner";
 	dir = 1
 	},
@@ -44922,8 +42822,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/squads/delta)
 "cdy" = (
@@ -44932,8 +42831,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/squads/delta)
 "cdz" = (
@@ -44959,21 +42857,18 @@
 "cdE" = (
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/port_hallway)
 "cdF" = (
 /turf/open/floor/almayer{
-	tag = "icon-blue";
 	icon_state = "blue"
 	},
 /area/almayer/hallways/port_hallway)
 "cdG" = (
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/port_hallway)
 "cdH" = (
@@ -45015,8 +42910,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/port_hallway)
 "cdM" = (
@@ -45055,8 +42949,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/squads/delta)
 "cdQ" = (
@@ -45065,8 +42958,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/squads/delta)
 "cdS" = (
@@ -45135,7 +43027,6 @@
 	opacity = 0
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hull/lower_hull)
@@ -45174,7 +43065,6 @@
 	name = "\improper South East Ladders Shutters"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/port_hallway)
@@ -45254,7 +43144,6 @@
 	throw_range = 15
 	},
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (WEST)";
 	icon_state = "greencorner";
 	dir = 8
 	},
@@ -45271,7 +43160,6 @@
 	dir = 6
 	},
 /turf/open/floor/almayer{
-	tag = "icon-greencorner";
 	icon_state = "greencorner";
 	dir = 2
 	},
@@ -45323,8 +43211,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/hallways/port_hallway)
 "cew" = (
@@ -45343,8 +43230,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/hallways/port_hallway)
 "cey" = (
@@ -45423,8 +43309,7 @@
 /obj/machinery/light,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/hallways/port_hallway)
 "ceI" = (
@@ -45574,7 +43459,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/starboard_missiles)
@@ -45627,8 +43511,7 @@
 "cfC" = (
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/repair_bay)
 "cfD" = (
@@ -45655,8 +43538,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "cfH" = (
@@ -45678,8 +43560,7 @@
 /obj/item/whistle,
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/living/briefing)
 "cfJ" = (
@@ -45689,8 +43570,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/shipboard/brig_cells)
 "cfK" = (
@@ -45721,7 +43601,6 @@
 "cfP" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/exoarmor)
@@ -45748,7 +43627,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (WEST)";
 	icon_state = "greencorner";
 	dir = 8
 	},
@@ -45758,13 +43636,11 @@
 	dir = 5
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig_cells)
 "cfV" = (
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig_cells)
@@ -45774,8 +43650,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/shipboard/brig_cells)
 "cfX" = (
@@ -45788,8 +43663,7 @@
 "cfY" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "cfZ" = (
@@ -45812,8 +43686,7 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/operating_room_four)
 "cga" = (
@@ -45829,8 +43702,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/command/cic)
 "cgc" = (
@@ -45849,14 +43721,12 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-emeraldfull";
 	icon_state = "emeraldfull"
 	},
 /area/almayer/living/briefing)
 "cgl" = (
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/shipboard/brig)
 "cgm" = (
@@ -45867,7 +43737,6 @@
 /area/almayer/shipboard/brig_cells)
 "cgn" = (
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
@@ -45878,8 +43747,7 @@
 "cgp" = (
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/shipboard/brig_cells)
 "cgq" = (
@@ -45887,7 +43755,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/brig)
@@ -45896,13 +43763,11 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/command/cic)
 "cgs" = (
 /turf/open/floor/almayer{
-	tag = "icon-green";
 	icon_state = "green";
 	dir = 2
 	},
@@ -45910,8 +43775,7 @@
 "cgt" = (
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/shipboard/brig_cells)
 "cgu" = (
@@ -45944,7 +43808,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/command/cic)
@@ -45954,15 +43817,13 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "cgz" = (
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
 "cgA" = (
@@ -45977,7 +43838,6 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/shipboard/brig)
@@ -45993,7 +43853,6 @@
 "cgE" = (
 /obj/machinery/light,
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig_cells)
@@ -46044,8 +43903,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "cgK" = (
@@ -46083,8 +43941,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/chief_mp_office)
 "cgM" = (
@@ -46125,7 +43982,6 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (EAST)";
 	icon_state = "redcorner";
 	dir = 4
 	},
@@ -46145,8 +44001,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/shipboard/brig_cells)
 "cgR" = (
@@ -46190,8 +44045,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "cgV" = (
@@ -46218,14 +44072,12 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-silvercorner (NORTH)";
 	icon_state = "silvercorner";
 	dir = 1
 	},
 /area/almayer/command/cic)
 "cgX" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner";
 	icon_state = "redcorner"
 	},
 /area/almayer/shipboard/brig_cells)
@@ -46239,7 +44091,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/command/cic)
@@ -46259,8 +44110,7 @@
 /obj/machinery/door_timer/cell_4,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig_cells)
 "chc" = (
@@ -46270,7 +44120,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-silvercorner (EAST)";
 	icon_state = "silvercorner";
 	dir = 4
 	},
@@ -46278,7 +44127,6 @@
 "chd" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/almayer{
-	tag = "icon-redfull";
 	icon_state = "redfull"
 	},
 /area/almayer/shipboard/brig)
@@ -46293,7 +44141,6 @@
 	pixel_x = -17
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redcorner";
 	icon_state = "redcorner"
 	},
 /area/almayer/shipboard/brig)
@@ -46315,7 +44162,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-silver (NORTH)";
 	icon_state = "silver";
 	dir = 1
 	},
@@ -46362,7 +44208,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (SOUTHWEST)";
 	icon_state = "carpetside";
 	dir = 10
 	},
@@ -46423,8 +44268,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/shipboard/brig_cells)
 "chu" = (
@@ -46433,8 +44277,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/shipboard/brig_cells)
 "chv" = (
@@ -46454,8 +44297,7 @@
 /obj/machinery/door_timer/cell_3,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig_cells)
 "chy" = (
@@ -46463,7 +44305,6 @@
 	dir = 4
 	},
 /obj/structure/toilet{
-	tag = "icon-toilet00 (NORTH)";
 	icon_state = "toilet00";
 	dir = 1
 	},
@@ -46507,13 +44348,11 @@
 /obj/item/tool/wrench,
 /obj/item/tool/crowbar,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/exoarmor)
 "chG" = (
 /obj/structure/bed/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (WEST)";
 	icon_state = "wooden_chair_wings";
 	dir = 8
 	},
@@ -46523,7 +44362,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (SOUTHEAST)";
 	icon_state = "carpetside";
 	dir = 6
 	},
@@ -46563,13 +44401,11 @@
 /area/almayer/shipboard/weapon_room)
 "chM" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-22"
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/living/bridgebunks)
 "chO" = (
@@ -46670,7 +44506,6 @@
 /area/almayer/hull/upper_hull)
 "cik" = (
 /obj/machinery/shower{
-	tag = "icon-shower (EAST)";
 	icon_state = "shower";
 	dir = 4
 	},
@@ -46702,12 +44537,10 @@
 /area/almayer/living/bridgebunks)
 "cir" = (
 /obj/machinery/shower{
-	tag = "icon-shower (EAST)";
 	icon_state = "shower";
 	dir = 4
 	},
 /obj/structure/window/reinforced/tinted/frosted{
-	tag = "icon-fwindow (NORTH)";
 	icon_state = "fwindow";
 	dir = 1
 	},
@@ -46731,7 +44564,6 @@
 	},
 /obj/machinery/light,
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (EAST)";
 	icon_state = "greencorner";
 	dir = 4
 	},
@@ -46741,7 +44573,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (NORTH)";
 	icon_state = "greencorner";
 	dir = 1
 	},
@@ -46792,7 +44623,6 @@
 "ciC" = (
 /obj/machinery/light,
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/command/cic)
@@ -46803,14 +44633,12 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/command/cic)
 "ciE" = (
 /obj/structure/sign/electricshock,
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/command/cic)
@@ -46839,7 +44667,6 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-silver";
 	icon_state = "silver";
 	dir = 2
 	},
@@ -46855,8 +44682,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "silvercorner";
-	tag = "icon-silvercorner (NORTH)"
+	icon_state = "silvercorner"
 	},
 /area/almayer/command/cic)
 "ciJ" = (
@@ -46868,7 +44694,6 @@
 /obj/item/clothing/glasses/welding,
 /obj/item/clothing/glasses/welding,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/exoarmor)
@@ -46878,7 +44703,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/almayer{
-	tag = "icon-emeraldfull";
 	icon_state = "emeraldfull"
 	},
 /area/almayer/living/briefing)
@@ -46888,8 +44712,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/repair_bay)
 "ciN" = (
@@ -46903,8 +44726,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "orange";
-	tag = "icon-orange (NORTH)"
+	icon_state = "orange"
 	},
 /area/almayer/hull/upper_hull)
 "ciO" = (
@@ -46915,14 +44737,12 @@
 	},
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "orange";
-	tag = "icon-orange (NORTH)"
+	icon_state = "orange"
 	},
 /area/almayer/hull/upper_hull)
 "ciQ" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/exoarmor)
@@ -47019,13 +44839,11 @@
 /obj/structure/rack,
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/repair_bay)
 "cje" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (NORTH)";
 	icon_state = "orangecorner";
 	dir = 1
 	},
@@ -47058,8 +44876,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/hangar)
 "cjp" = (
@@ -47070,8 +44887,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/hangar)
 "cjr" = (
@@ -47126,7 +44942,6 @@
 /area/almayer/shipboard/weapon_room)
 "cjx" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner";
 	icon_state = "redcorner"
 	},
 /area/almayer/shipboard/weapon_room)
@@ -47154,23 +44969,20 @@
 /obj/structure/largecrate/random/case,
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/port_missiles)
 "cjB" = (
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/port_missiles)
 "cjD" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/port_missiles)
 "cjE" = (
@@ -47203,8 +45015,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/port_missiles)
 "cjK" = (
@@ -47233,8 +45044,7 @@
 /obj/structure/ob_ammo/ob_fuel,
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/weapon_room)
 "cjP" = (
@@ -47248,7 +45058,6 @@
 	},
 /obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/weapon_room)
@@ -47284,8 +45093,7 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/operating_room_two)
 "cjU" = (
@@ -47509,7 +45317,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/weapon_room)
@@ -47529,7 +45336,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/almayer{
-	tag = "icon-orangefull";
 	icon_state = "orangefull"
 	},
 /area/almayer/living/briefing)
@@ -47541,7 +45347,6 @@
 	},
 /obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/weapon_room)
@@ -47575,7 +45380,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/port_missiles)
@@ -47585,7 +45389,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/port_missiles)
@@ -47595,7 +45398,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/port_missiles)
@@ -47605,7 +45407,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/almayer{
-	tag = "icon-orangefull";
 	icon_state = "orangefull"
 	},
 /area/almayer/living/briefing)
@@ -47615,7 +45416,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/almayer{
-	tag = "icon-emeraldfull";
 	icon_state = "emeraldfull"
 	},
 /area/almayer/living/briefing)
@@ -47629,7 +45429,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/almayer{
-	tag = "icon-emeraldfull";
 	icon_state = "emeraldfull"
 	},
 /area/almayer/living/briefing)
@@ -47638,7 +45437,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-emeraldfull";
 	icon_state = "emeraldfull"
 	},
 /area/almayer/living/briefing)
@@ -47689,8 +45487,7 @@
 	d2 = 8
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "cBn" = (
@@ -47721,8 +45518,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/hallways/aft_hallway)
 "cIn" = (
@@ -47732,7 +45528,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/engineering/upper_engineering)
@@ -47755,8 +45550,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
 "dya" = (
@@ -47798,7 +45592,6 @@
 	d2 = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-bluecorner";
 	icon_state = "bluecorner"
 	},
 /area/almayer/hallways/aft_hallway)
@@ -47812,7 +45605,6 @@
 "dKt" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
-	tag = "icon-silvercorner (EAST)";
 	icon_state = "silvercorner";
 	dir = 4
 	},
@@ -47839,8 +45631,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/hallways/aft_hallway)
 "dQE" = (
@@ -47853,7 +45644,6 @@
 /area/almayer/living/bridgebunks)
 "dUd" = (
 /turf/open/floor/almayer{
-	tag = "icon-blue (NORTH)";
 	icon_state = "blue";
 	dir = 1
 	},
@@ -47871,8 +45661,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "emC" = (
@@ -47923,8 +45712,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/hull/upper_hull)
 "eQc" = (
@@ -47944,8 +45732,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/stern_hallway)
 "eRg" = (
@@ -47956,8 +45743,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/stern_hallway)
 "eUu" = (
@@ -47982,8 +45768,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "fiO" = (
@@ -48004,7 +45789,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor5";
 	icon_state = "test_floor5"
 	},
 /area/almayer/squads/req)
@@ -48017,7 +45801,6 @@
 	},
 /obj/machinery/light,
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/living/commandbunks)
@@ -48031,8 +45814,7 @@
 "fqn" = (
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/repair_bay)
 "frn" = (
@@ -48055,8 +45837,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "fCG" = (
@@ -48095,8 +45876,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
 "gas" = (
@@ -48121,7 +45901,6 @@
 	d2 = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-blue";
 	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
@@ -48131,15 +45910,13 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/weapon_room)
 "gjm" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/hull/upper_hull)
 "gkB" = (
@@ -48157,8 +45934,7 @@
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/command/cic)
 "gEh" = (
@@ -48216,8 +45992,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/hallways/aft_hallway)
 "hhR" = (
@@ -48277,8 +46052,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/stern_hallway)
 "hBd" = (
@@ -48317,8 +46091,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/stern_hallway)
 "hIs" = (
@@ -48332,8 +46105,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/stern_hallway)
 "hKL" = (
@@ -48428,7 +46200,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/living/starboard_emb)
@@ -48442,7 +46213,6 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-silver";
 	icon_state = "silver";
 	dir = 2
 	},
@@ -48462,7 +46232,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/starboard_missiles)
@@ -48477,8 +46246,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "jiY" = (
@@ -48497,7 +46265,6 @@
 	d2 = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/hallways/stern_hallway)
@@ -48506,8 +46273,7 @@
 /obj/item/weapon/gun/energy/lasgun/M43/stripped,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/shipboard/ex_firing_range)
 "jzF" = (
@@ -48517,7 +46283,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-greencorner (NORTH)";
 	icon_state = "greencorner";
 	dir = 1
 	},
@@ -48534,8 +46299,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/shipboard/ex_firing_range)
 "jER" = (
@@ -48558,8 +46322,7 @@
 "jOd" = (
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "orange";
-	tag = "icon-orange (NORTH)"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/repair_bay)
 "jSM" = (
@@ -48571,7 +46334,6 @@
 "kaw" = (
 /obj/structure/dropship_equipment/sentry_holder,
 /turf/open/floor/almayer{
-	tag = "icon-orange";
 	icon_state = "orange"
 	},
 /area/almayer/hallways/repair_bay)
@@ -48631,22 +46393,19 @@
 	on = 1
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/surgery_hallway)
 "kyc" = (
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/shipboard/ex_firing_range)
 "kCn" = (
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/command/self_destruct)
 "kNU" = (
@@ -48666,8 +46425,7 @@
 /obj/item/reagent_container/glass/beaker/cryoxadone,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/cryo_tubes)
 "kWq" = (
@@ -48676,7 +46434,6 @@
 /area/almayer/squads/req)
 "lhN" = (
 /turf/open/floor/almayer{
-	tag = "icon-redcorner (WEST)";
 	icon_state = "redcorner";
 	dir = 8
 	},
@@ -48742,7 +46499,6 @@
 	d2 = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/stern_hallway)
@@ -48758,7 +46514,6 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/hallways/stern_hallway)
@@ -48774,7 +46529,6 @@
 	name = "\improper Self Destruct Lockdown"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/stern_hallway)
@@ -48783,7 +46537,6 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/hallways/stern_hallway)
@@ -48819,7 +46572,6 @@
 /area/almayer/engineering/upper_engineering)
 "lAe" = (
 /turf/open/shuttle/escapepod{
-	tag = "icon-floor5";
 	icon_state = "floor5"
 	},
 /area/almayer/command/self_destruct)
@@ -48844,8 +46596,7 @@
 "lNO" = (
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "green";
-	tag = "icon-green"
+	icon_state = "green"
 	},
 /area/almayer/living/numbertwobunks)
 "lPq" = (
@@ -48857,8 +46608,7 @@
 "lYB" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/shipboard/ex_firing_range)
 "lZh" = (
@@ -48866,7 +46616,6 @@
 	dir = 6
 	},
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/shipboard/weapon_room)
@@ -48924,8 +46673,7 @@
 "mGX" = (
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/weapon_room)
 "mIw" = (
@@ -48942,7 +46690,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-silver";
 	icon_state = "silver";
 	dir = 2
 	},
@@ -48978,8 +46725,7 @@
 "mVF" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 8;
-	icon_state = "comfychair";
-	tag = "icon-comfychair (NORTH)"
+	icon_state = "comfychair"
 	},
 /turf/open/floor/almayer,
 /area/almayer/living/bridgebunks)
@@ -49016,8 +46762,7 @@
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/upper_medical)
 "nlp" = (
@@ -49026,7 +46771,6 @@
 	icon_state = "officechair_white"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/almayer/engineering/upper_engineering)
@@ -49042,23 +46786,20 @@
 /obj/machinery/door_timer/cell_2,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig_cells)
 "nAR" = (
 /obj/machinery/sleeper,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/surgery_hallway)
 "nDN" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "nMj" = (
@@ -49092,8 +46833,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/weapon_room)
 "nUy" = (
@@ -49117,8 +46857,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "olm" = (
@@ -49150,8 +46889,7 @@
 /obj/structure/closet/toolcloset,
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "oye" = (
@@ -49211,7 +46949,6 @@
 	d2 = 8
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/stern_hallway)
@@ -49219,8 +46956,7 @@
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/living/cryo_cells)
 "oXs" = (
@@ -49245,8 +46981,7 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "pbF" = (
@@ -49257,8 +46992,7 @@
 	},
 /obj/machinery/door/firedoor/theseus,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "poE" = (
@@ -49267,7 +47001,6 @@
 	on = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-blue";
 	icon_state = "blue"
 	},
 /area/almayer/squads/delta)
@@ -49275,8 +47008,7 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/cryo_tubes)
 "psm" = (
@@ -49293,7 +47025,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-redcorner";
 	icon_state = "redcorner"
 	},
 /area/almayer/hallways/stern_hallway)
@@ -49303,8 +47034,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/command/self_destruct)
 "pyR" = (
@@ -49317,8 +47047,7 @@
 /obj/machinery/vending/MarineMed/Blood,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/surgery_hallway)
 "pGw" = (
@@ -49366,7 +47095,6 @@
 /area/almayer/shipboard/weapon_room)
 "pNG" = (
 /turf/open/shuttle/escapepod{
-	tag = "icon-floor11";
 	icon_state = "floor11"
 	},
 /area/almayer/command/self_destruct)
@@ -49402,8 +47130,7 @@
 /obj/structure/closet/secure_closet/engineering_welding,
 /turf/open/floor/almayer{
 	dir = 10;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "qeT" = (
@@ -49495,8 +47222,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/surgery_hallway)
 "qVi" = (
@@ -49533,7 +47259,6 @@
 	name = "\improper Self Destruct Lockdown"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/stern_hallway)
@@ -49564,8 +47289,7 @@
 "sby" = (
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "orange";
-	tag = "icon-orange (NORTH)"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "seI" = (
@@ -49616,8 +47340,7 @@
 /obj/structure/closet/secure_closet/engineering_welding,
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "orange";
-	tag = "icon-orange (NORTH)"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "sTf" = (
@@ -49628,8 +47351,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "sUb" = (
@@ -49663,7 +47385,6 @@
 /area/almayer/command/telecomms)
 "tjY" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-22"
 	},
 /turf/open/floor/almayer/mono,
@@ -49682,8 +47403,7 @@
 /obj/machinery/keycard_auth,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "silver";
-	tag = "icon-silver"
+	icon_state = "silver"
 	},
 /area/almayer/command/cic)
 "tIh" = (
@@ -49703,8 +47423,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "tRQ" = (
@@ -49714,8 +47433,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig_cells)
 "tUM" = (
@@ -49730,7 +47448,6 @@
 	name = "\improper Self Destruct Lockdown"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/hallways/stern_hallway)
@@ -49752,8 +47469,7 @@
 	req_one_access_txt = "0"
 	},
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/lower_medical)
 "ukw" = (
@@ -49763,8 +47479,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/brig_cells)
 "unv" = (
@@ -49783,8 +47498,7 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "uAE" = (
@@ -49794,7 +47508,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-silver";
 	icon_state = "silver";
 	dir = 2
 	},
@@ -49806,8 +47519,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/hallways/starboard_hallway)
 "uGj" = (
@@ -49820,8 +47532,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/almayer{
-	icon_state = "dark_sterile";
-	tag = "icon-sterile"
+	icon_state = "dark_sterile"
 	},
 /area/almayer/medical/upper_medical)
 "uSH" = (
@@ -49854,7 +47565,6 @@
 /area/almayer/shipboard/weapon_room)
 "vkk" = (
 /turf/open/floor/almayer{
-	tag = "icon-green (NORTH)";
 	icon_state = "green";
 	dir = 1
 	},
@@ -49867,7 +47577,6 @@
 /area/almayer/command/cic)
 "vsz" = (
 /turf/open/floor/almayer{
-	tag = "icon-red";
 	icon_state = "red"
 	},
 /area/almayer/shipboard/weapon_room)
@@ -49904,8 +47613,7 @@
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/squads/charlie)
 "vBC" = (
@@ -49922,7 +47630,6 @@
 	},
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/open/floor/almayer{
-	tag = "icon-orangefull";
 	icon_state = "orangefull"
 	},
 /area/almayer/living/briefing)
@@ -49956,8 +47663,7 @@
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/hallways/port_hallway)
 "vMb" = (
@@ -49970,7 +47676,6 @@
 	dir = 5
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (WEST)";
 	icon_state = "orangecorner";
 	dir = 8
 	},
@@ -49983,8 +47688,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 6;
-	icon_state = "orange";
-	tag = "icon-orange"
+	icon_state = "orange"
 	},
 /area/almayer/engineering/upper_engineering)
 "vOH" = (
@@ -50009,7 +47713,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-silvercorner (NORTH)";
 	icon_state = "silvercorner";
 	dir = 1
 	},
@@ -50024,7 +47727,6 @@
 /area/almayer/engineering/upper_engineering)
 "wdE" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -50056,8 +47758,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "bluecorner";
-	tag = "icon-bluecorner"
+	icon_state = "bluecorner"
 	},
 /area/almayer/hallways/aft_hallway)
 "wLi" = (
@@ -50117,7 +47818,6 @@
 	on = 1
 	},
 /turf/open/floor/almayer{
-	tag = "icon-sterile";
 	icon_state = "sterile"
 	},
 /area/almayer/shipboard/brig_cells)
@@ -50142,7 +47842,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/almayer/shipboard/port_missiles)
@@ -50154,8 +47853,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/hallways/stern_hallway)
 "xkA" = (
@@ -50182,8 +47880,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "silvercorner";
-	tag = "icon-silvercorner (NORTH)"
+	icon_state = "silvercorner"
 	},
 /area/almayer/command/cic)
 "xtn" = (
@@ -50192,8 +47889,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "emerald";
-	tag = "icon-emerald"
+	icon_state = "emerald"
 	},
 /area/almayer/living/port_emb)
 "xtT" = (
@@ -50202,8 +47898,7 @@
 /obj/item/reagent_container/hypospray,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "sterile_green_side";
-	tag = "icon-sterile_green_side"
+	icon_state = "sterile_green_side"
 	},
 /area/almayer/medical/lower_medical)
 "xGM" = (
@@ -50226,8 +47921,7 @@
 	},
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "blue";
-	tag = "icon-blue"
+	icon_state = "blue"
 	},
 /area/almayer/hallways/aft_hallway)
 "ybU" = (
@@ -50243,8 +47937,7 @@
 /obj/structure/ob_ammo/warhead/explosive,
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-red"
+	icon_state = "red"
 	},
 /area/almayer/shipboard/weapon_room)
 "yiQ" = (

--- a/_maps/map_files/Whiskey_Outpost/Whiskey_Outpost_v2.dmm
+++ b/_maps/map_files/Whiskey_Outpost/Whiskey_Outpost_v2.dmm
@@ -291,7 +291,6 @@
 "aQ" = (
 /obj/machinery/light,
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (EAST)";
 	icon_state = "sandbag";
 	dir = 4
 	},
@@ -730,8 +729,7 @@
 "bX" = (
 /obj/structure/barricade/metal{
 	dir = 8;
-	icon_state = "barricade2";
-	tag = "icon-barricade (WEST)"
+	icon_state = "barricade2"
 	},
 /turf/open/floor/plating/asteroidwarning{
 	dir = 8
@@ -929,7 +927,6 @@
 /area/whiskey_outpost)
 "ct" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (NORTH)";
 	icon_state = "tube1";
 	dir = 1
 	},
@@ -938,8 +935,7 @@
 "cu" = (
 /obj/structure/barricade/metal{
 	dir = 4;
-	icon_state = "barricade2";
-	tag = "icon-barricade (EAST)"
+	icon_state = "barricade2"
 	},
 /turf/open/floor/plating/asteroidwarning{
 	dir = 4
@@ -980,12 +976,10 @@
 /area/whiskey_outpost/outside/north)
 "cz" = (
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (NORTH)";
 	icon_state = "sandbag";
 	dir = 1
 	},
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (WEST)";
 	icon_state = "sandbag";
 	dir = 8
 	},
@@ -1000,7 +994,6 @@
 /area/whiskey_outpost)
 "cB" = (
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (WEST)";
 	icon_state = "sandbag";
 	dir = 8
 	},
@@ -1089,8 +1082,7 @@
 "cL" = (
 /obj/machinery/m56d_hmg/mg_turret{
 	dir = 8;
-	icon_state = "towergun";
-	tag = ""
+	icon_state = "towergun"
 	},
 /turf/open/floor/plating/asteroidwarning{
 	dir = 8
@@ -1188,7 +1180,6 @@
 /area/whiskey_outpost/outside/north)
 "cY" = (
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (WEST)";
 	icon_state = "sandbag";
 	dir = 8
 	},
@@ -1201,7 +1192,6 @@
 "cZ" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (WEST)";
 	icon_state = "sandbag";
 	dir = 8
 	},
@@ -1264,7 +1254,6 @@
 /area/whiskey_outpost)
 "di" = (
 /turf/open/ground/coast{
-	tag = "icon-beachcorner";
 	icon_state = "beachcorner";
 	dir = 2
 	},
@@ -1374,7 +1363,6 @@
 /area/whiskey_outpost)
 "dy" = (
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (EAST)";
 	icon_state = "sandbag";
 	dir = 4
 	},
@@ -1390,7 +1378,6 @@
 /area/whiskey_outpost)
 "dA" = (
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (EAST)";
 	icon_state = "sandbag";
 	dir = 4
 	},
@@ -1402,7 +1389,6 @@
 /area/whiskey_outpost)
 "dB" = (
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (EAST)";
 	icon_state = "sandbag";
 	dir = 4
 	},
@@ -1422,12 +1408,10 @@
 /area/whiskey_outpost)
 "dE" = (
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (NORTH)";
 	icon_state = "sandbag";
 	dir = 1
 	},
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (WEST)";
 	icon_state = "sandbag";
 	dir = 8
 	},
@@ -1441,7 +1425,6 @@
 /area/whiskey_outpost)
 "dF" = (
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (NORTH)";
 	icon_state = "sandbag";
 	dir = 1
 	},
@@ -1455,12 +1438,10 @@
 /area/whiskey_outpost)
 "dG" = (
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (NORTH)";
 	icon_state = "sandbag";
 	dir = 1
 	},
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (EAST)";
 	icon_state = "sandbag";
 	dir = 4
 	},
@@ -1479,12 +1460,10 @@
 /area/whiskey_outpost)
 "dI" = (
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (NORTH)";
 	icon_state = "sandbag";
 	dir = 1
 	},
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (EAST)";
 	icon_state = "sandbag";
 	dir = 4
 	},
@@ -1494,7 +1473,6 @@
 /area/whiskey_outpost)
 "dJ" = (
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (EAST)";
 	icon_state = "sandbag";
 	dir = 4
 	},
@@ -1506,7 +1484,6 @@
 /area/whiskey_outpost/outside/north)
 "dK" = (
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (WEST)";
 	icon_state = "sandbag";
 	dir = 8
 	},
@@ -1525,7 +1502,6 @@
 /area/whiskey_outpost)
 "dM" = (
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (EAST)";
 	icon_state = "sandbag";
 	dir = 4
 	},
@@ -1540,8 +1516,7 @@
 "dN" = (
 /obj/machinery/m56d_hmg/mg_turret{
 	dir = 4;
-	icon_state = "towergun";
-	tag = ""
+	icon_state = "towergun"
 	},
 /turf/open/floor/plating/asteroidwarning{
 	dir = 4
@@ -1571,12 +1546,10 @@
 /area/whiskey_outpost/outside/north)
 "dS" = (
 /obj/machinery/light{
-	tag = "icon-tube1 (NORTH)";
 	icon_state = "tube1";
 	dir = 1
 	},
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (EAST)";
 	icon_state = "sandbag";
 	dir = 4
 	},
@@ -1589,7 +1562,6 @@
 "dT" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (EAST)";
 	icon_state = "sandbag";
 	dir = 4
 	},
@@ -1761,8 +1733,7 @@
 "ey" = (
 /obj/machinery/m56d_hmg/mg_turret{
 	dir = 8;
-	icon_state = "towergun";
-	tag = ""
+	icon_state = "towergun"
 	},
 /turf/open/floor/plating/asteroidwarning{
 	dir = 8
@@ -1862,8 +1833,7 @@
 "eL" = (
 /obj/structure/barricade/metal{
 	dir = 4;
-	icon_state = "barricade2";
-	tag = "icon-barricade (EAST)"
+	icon_state = "barricade2"
 	},
 /obj/structure/barricade/metal,
 /turf/open/floor/plating/asteroidwarning{
@@ -1872,7 +1842,6 @@
 /area/whiskey_outpost)
 "eM" = (
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (WEST)";
 	icon_state = "sandbag";
 	dir = 8
 	},
@@ -2104,7 +2073,6 @@
 /area/whiskey_outpost)
 "fh" = (
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (NORTH)";
 	icon_state = "sandbag";
 	dir = 1
 	},
@@ -2303,7 +2271,6 @@
 /area/whiskey_outpost)
 "fK" = (
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (WEST)";
 	icon_state = "sandbag";
 	dir = 8
 	},
@@ -2340,8 +2307,7 @@
 /obj/structure/barricade/metal,
 /obj/structure/barricade/metal{
 	dir = 8;
-	icon_state = "barricade2";
-	tag = "icon-barricade (WEST)"
+	icon_state = "barricade2"
 	},
 /turf/open/floor/plating/asteroidwarning{
 	dir = 10
@@ -2351,8 +2317,7 @@
 /obj/structure/barricade/metal,
 /obj/structure/barricade/metal{
 	dir = 4;
-	icon_state = "barricade2";
-	tag = "icon-barricade (EAST)"
+	icon_state = "barricade2"
 	},
 /turf/open/floor/plating/asteroidwarning{
 	dir = 6
@@ -2391,7 +2356,6 @@
 "fY" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (WEST)";
 	icon_state = "sandbag";
 	dir = 8
 	},
@@ -2414,7 +2378,6 @@
 /area/whiskey_outpost/outside/north)
 "gb" = (
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (EAST)";
 	icon_state = "sandbag";
 	dir = 4
 	},
@@ -2442,12 +2405,10 @@
 /area/whiskey_outpost/outside/north)
 "gg" = (
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (NORTH)";
 	icon_state = "sandbag";
 	dir = 1
 	},
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (WEST)";
 	icon_state = "sandbag";
 	dir = 8
 	},
@@ -2457,7 +2418,6 @@
 /area/whiskey_outpost/outside/north)
 "gh" = (
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (NORTH)";
 	icon_state = "sandbag";
 	dir = 1
 	},
@@ -2467,12 +2427,10 @@
 /area/whiskey_outpost/outside/north)
 "gi" = (
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (NORTH)";
 	icon_state = "sandbag";
 	dir = 1
 	},
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (EAST)";
 	icon_state = "sandbag";
 	dir = 4
 	},
@@ -2490,7 +2448,6 @@
 /area/whiskey_outpost/outside/north)
 "gk" = (
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (EAST)";
 	icon_state = "sandbag";
 	dir = 4
 	},
@@ -2504,7 +2461,6 @@
 "gl" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (WEST)";
 	icon_state = "sandbag";
 	dir = 8
 	},
@@ -2517,7 +2473,6 @@
 "gn" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (EAST)";
 	icon_state = "sandbag";
 	dir = 4
 	},
@@ -2531,8 +2486,7 @@
 "gp" = (
 /obj/machinery/m56d_hmg/mg_turret{
 	dir = 8;
-	icon_state = "towergun";
-	tag = ""
+	icon_state = "towergun"
 	},
 /turf/open/floor/plating/warning{
 	dir = 8
@@ -2560,7 +2514,6 @@
 /area/whiskey_outpost/outside/north)
 "gt" = (
 /turf/open/ground/coast{
-	tag = "icon-beach (SOUTHWEST)";
 	icon_state = "beach";
 	dir = 10
 	},
@@ -2578,7 +2531,6 @@
 "gw" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (WEST)";
 	icon_state = "sandbag";
 	dir = 8
 	},
@@ -2595,7 +2547,6 @@
 "gy" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (EAST)";
 	icon_state = "sandbag";
 	dir = 4
 	},
@@ -2605,12 +2556,10 @@
 /area/whiskey_outpost/outside/north)
 "gz" = (
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (NORTH)";
 	icon_state = "sandbag";
 	dir = 1
 	},
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (WEST)";
 	icon_state = "sandbag";
 	dir = 8
 	},
@@ -2625,12 +2574,10 @@
 /area/whiskey_outpost)
 "gB" = (
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (EAST)";
 	icon_state = "sandbag";
 	dir = 4
 	},
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (NORTH)";
 	icon_state = "sandbag";
 	dir = 1
 	},
@@ -2641,7 +2588,6 @@
 "gC" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (EAST)";
 	icon_state = "sandbag";
 	dir = 4
 	},
@@ -2653,7 +2599,6 @@
 /area/whiskey_outpost/outside/north)
 "gD" = (
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (WEST)";
 	icon_state = "sandbag";
 	dir = 8
 	},
@@ -2672,7 +2617,6 @@
 /area/whiskey_outpost)
 "gG" = (
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (EAST)";
 	icon_state = "sandbag";
 	dir = 4
 	},
@@ -2693,7 +2637,6 @@
 /area/whiskey_outpost/outside/north)
 "gJ" = (
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (WEST)";
 	icon_state = "sandbag";
 	dir = 8
 	},
@@ -2714,7 +2657,6 @@
 /area/whiskey_outpost)
 "gL" = (
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (EAST)";
 	icon_state = "sandbag";
 	dir = 4
 	},
@@ -2740,7 +2682,6 @@
 "gO" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (WEST)";
 	icon_state = "sandbag";
 	dir = 8
 	},
@@ -2763,7 +2704,6 @@
 "gR" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (EAST)";
 	icon_state = "sandbag";
 	dir = 4
 	},
@@ -2910,7 +2850,6 @@
 "hv" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (EAST)";
 	icon_state = "sandbag";
 	dir = 4
 	},
@@ -3026,7 +2965,6 @@
 /area/whiskey_outpost/outside/west)
 "hU" = (
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (WEST)";
 	icon_state = "sandbag";
 	dir = 8
 	},
@@ -3034,7 +2972,6 @@
 /area/whiskey_outpost/outside/west)
 "hV" = (
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (EAST)";
 	icon_state = "sandbag";
 	dir = 4
 	},
@@ -3065,7 +3002,6 @@
 "ib" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (WEST)";
 	icon_state = "sandbag";
 	dir = 8
 	},
@@ -3074,7 +3010,6 @@
 "ic" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (EAST)";
 	icon_state = "sandbag";
 	dir = 4
 	},
@@ -3082,7 +3017,6 @@
 /area/whiskey_outpost/outside/west)
 "id" = (
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (WEST)";
 	icon_state = "sandbag";
 	dir = 8
 	},
@@ -3099,7 +3033,6 @@
 /area/whiskey_outpost/outside/west)
 "ig" = (
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (WEST)";
 	icon_state = "sandbag";
 	dir = 8
 	},
@@ -3217,7 +3150,6 @@
 "iE" = (
 /turf/open/ground/river,
 /turf/closed/shuttle/dropship{
-	tag = "icon-diagrasputin (EAST)";
 	icon_state = "diagrasputin";
 	dir = 4
 	},
@@ -3242,7 +3174,6 @@
 "iG" = (
 /turf/open/ground/river,
 /turf/closed/shuttle/dropship{
-	tag = "icon-diagrasputin (NORTH)";
 	icon_state = "diagrasputin";
 	dir = 1
 	},
@@ -3282,7 +3213,6 @@
 /area/whiskey_outpost/outside/east)
 "iL" = (
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
 	},
 /area/whiskey_outpost/outside/east)
@@ -3316,38 +3246,32 @@
 /area/whiskey_outpost/outside/east)
 "iP" = (
 /obj/structure/bed/chair/dropship/pilot{
-	tag = "icon-pilot_chair (NORTH)";
 	icon_state = "pilot_chair";
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood,
 /obj/effect/spawner/gibspawner/human,
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
 	},
 /area/whiskey_outpost/outside/east)
 "iQ" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin_nose";
 	icon_state = "rasputin_nose"
 	},
 /area/whiskey_outpost/outside/east)
 "iR" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin_light";
 	icon_state = "rasputin_light"
 	},
 /area/whiskey_outpost/outside/east)
 "iS" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin8";
 	icon_state = "rasputin8"
 	},
 /area/whiskey_outpost/outside/east)
 "iT" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin4";
 	icon_state = "rasputin4"
 	},
 /area/whiskey_outpost/outside/east)
@@ -3356,7 +3280,6 @@
 /area/whiskey_outpost/outside/east)
 "iV" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin10";
 	icon_state = "rasputin10"
 	},
 /area/whiskey_outpost/outside/east)
@@ -3375,37 +3298,31 @@
 /area/whiskey_outpost/outside/east)
 "iZ" = (
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin6";
 	icon_state = "rasputin6"
 	},
 /area/whiskey_outpost/outside/east)
 "ja" = (
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin5";
 	icon_state = "rasputin5"
 	},
 /area/whiskey_outpost/outside/east)
 "jb" = (
 /turf/open/shuttle/dropship{
-	tag = "icon-floor8";
 	icon_state = "floor8"
 	},
 /area/whiskey_outpost/outside/east)
 "jc" = (
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin7";
 	icon_state = "rasputin7"
 	},
 /area/whiskey_outpost/outside/east)
 "jd" = (
 /obj/structure/bed/chair/dropship/passenger{
-	tag = "icon-shuttle_chair (WEST)";
 	icon_state = "shuttle_chair";
 	dir = 8
 	},
 /obj/item/storage/box/sentry,
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
 	},
 /area/whiskey_outpost/outside/east)
@@ -3418,41 +3335,34 @@
 /area/whiskey_outpost/outside/west)
 "jf" = (
 /obj/structure/bed/chair/dropship/passenger{
-	tag = "icon-shuttle_chair (WEST)";
 	icon_state = "shuttle_chair";
 	dir = 8
 	},
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
 	},
 /area/whiskey_outpost/outside/east)
 "jg" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin0";
 	icon_state = "rasputin0"
 	},
 /area/whiskey_outpost/outside/east)
 "jh" = (
 /obj/structure/bed/chair/dropship/passenger{
-	tag = "icon-shuttle_chair (EAST)";
 	icon_state = "shuttle_chair";
 	dir = 4
 	},
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
 	},
 /area/whiskey_outpost/outside/east)
 "ji" = (
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin3";
 	icon_state = "rasputin3"
 	},
 /area/whiskey_outpost/outside/east)
 "jj" = (
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (EAST)";
 	icon_state = "sandbag";
 	dir = 4
 	},
@@ -3460,7 +3370,6 @@
 /area/whiskey_outpost/outside/east)
 "jk" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin2";
 	icon_state = "rasputin2"
 	},
 /area/whiskey_outpost/outside/east)
@@ -3474,13 +3383,11 @@
 /area/whiskey_outpost/outside/east)
 "jm" = (
 /obj/structure/bed/chair/dropship/passenger{
-	tag = "icon-shuttle_chair (WEST)";
 	icon_state = "shuttle_chair";
 	dir = 8
 	},
 /obj/item/cell/high,
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
 	},
 /area/whiskey_outpost/outside/east)
@@ -3496,7 +3403,6 @@
 "jp" = (
 /obj/item/cell/high,
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin3";
 	icon_state = "rasputin3"
 	},
 /area/whiskey_outpost/outside/east)
@@ -3517,13 +3423,11 @@
 "js" = (
 /obj/item/storage/box/m94,
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin3";
 	icon_state = "rasputin3"
 	},
 /area/whiskey_outpost/outside/east)
 "jt" = (
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (EAST)";
 	icon_state = "sandbag";
 	dir = 4
 	},
@@ -3539,7 +3443,6 @@
 "jv" = (
 /obj/item/storage/box/m94,
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin5";
 	icon_state = "rasputin5"
 	},
 /area/whiskey_outpost/outside/east)
@@ -3570,13 +3473,11 @@
 	name = "Dropship Hatch"
 	},
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
 	},
 /area/whiskey_outpost/outside/east)
 "jB" = (
 /obj/structure/barricade/sandbags{
-	tag = "icon-sandbag (EAST)";
 	icon_state = "sandbag";
 	dir = 4
 	},
@@ -3613,7 +3514,6 @@
 /area/whiskey_outpost)
 "jG" = (
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin10";
 	icon_state = "rasputin10"
 	},
 /area/whiskey_outpost/outside/east)
@@ -3678,20 +3578,17 @@
 /area/whiskey_outpost)
 "jP" = (
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin4";
 	icon_state = "rasputin4"
 	},
 /area/whiskey_outpost/outside/east)
 "jQ" = (
 /obj/item/cell/high,
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin13";
 	icon_state = "rasputin13"
 	},
 /area/whiskey_outpost/outside/east)
 "jR" = (
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin8";
 	icon_state = "rasputin8"
 	},
 /area/whiskey_outpost/outside/east)
@@ -3759,12 +3656,10 @@
 	pixel_x = -32
 	},
 /obj/structure/bed/chair/dropship/passenger{
-	tag = "icon-shuttle_chair (EAST)";
 	icon_state = "shuttle_chair";
 	dir = 4
 	},
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
 	},
 /area/whiskey_outpost/outside/east)
@@ -3773,18 +3668,15 @@
 	pixel_x = 32
 	},
 /obj/structure/bed/chair/dropship/passenger{
-	tag = "icon-shuttle_chair (WEST)";
 	icon_state = "shuttle_chair";
 	dir = 8
 	},
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
 	},
 /area/whiskey_outpost/outside/east)
 "kd" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin6";
 	icon_state = "rasputin6"
 	},
 /area/whiskey_outpost/outside/east)
@@ -3847,44 +3739,37 @@
 /area/whiskey_outpost/outside/south)
 "kr" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin11";
 	icon_state = "rasputin11"
 	},
 /area/whiskey_outpost/outside/south)
 "ks" = (
 /obj/structure/bed/chair/dropship/passenger{
-	tag = "icon-shuttle_chair (EAST)";
 	icon_state = "shuttle_chair";
 	dir = 4
 	},
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
 	},
 /area/whiskey_outpost/outside/south)
 "kt" = (
 /obj/item/cell/high,
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin3";
 	icon_state = "rasputin3"
 	},
 /area/whiskey_outpost/outside/south)
 "ku" = (
 /obj/structure/bed/chair/dropship/passenger{
-	tag = "icon-shuttle_chair (WEST)";
 	icon_state = "shuttle_chair";
 	dir = 8
 	},
 /obj/item/weapon/gun/rifle/lmg,
 /obj/item/weapon/gun/rifle/lmg,
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin15";
 	icon_state = "rasputin15"
 	},
 /area/whiskey_outpost/outside/east)
 "kv" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin7";
 	icon_state = "rasputin7"
 	},
 /area/whiskey_outpost/outside/east)
@@ -3916,37 +3801,31 @@
 /area/whiskey_outpost/outside/south)
 "kC" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin5";
 	icon_state = "rasputin5"
 	},
 /area/whiskey_outpost/outside/south)
 "kD" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin12";
 	icon_state = "rasputin12"
 	},
 /area/whiskey_outpost/outside/south)
 "kE" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin14";
 	icon_state = "rasputin14"
 	},
 /area/whiskey_outpost/outside/south)
 "kF" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin12";
 	icon_state = "rasputin12"
 	},
 /area/whiskey_outpost/outside/east)
 "kG" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin9";
 	icon_state = "rasputin9"
 	},
 /area/whiskey_outpost/outside/east)
 "kH" = (
 /turf/open/ground/coast{
-	tag = "icon-beachcorner";
 	icon_state = "beachcorner";
 	dir = 2
 	},
@@ -3981,7 +3860,6 @@
 /area/whiskey_outpost/outside/east)
 "kM" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin3";
 	icon_state = "rasputin3"
 	},
 /area/whiskey_outpost/outside/east)
@@ -4204,7 +4082,6 @@
 /area/whiskey_outpost/outside/south)
 "lF" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin3";
 	icon_state = "rasputin3"
 	},
 /area/whiskey_outpost/outside/south)
@@ -4232,21 +4109,18 @@
 "lJ" = (
 /turf/open/ground/jungle,
 /turf/closed/shuttle/dropship{
-	tag = "icon-diagrasputin (EAST)";
 	icon_state = "diagrasputin";
 	dir = 4
 	},
 /area/whiskey_outpost/outside/south)
 "lK" = (
 /turf/closed/shuttle/dropship{
-	tag = "icon-rasputin13";
 	icon_state = "rasputin13"
 	},
 /area/whiskey_outpost/outside/south)
 "lL" = (
 /turf/open/ground/jungle,
 /turf/closed/shuttle/dropship{
-	tag = "icon-diagrasputin (NORTH)";
 	icon_state = "diagrasputin";
 	dir = 1
 	},
@@ -4262,7 +4136,6 @@
 /area/whiskey_outpost/outside/south)
 "lO" = (
 /obj/effect/decal/cleanable/blood/writing{
-	tag = "icon-tracks (NORTH)";
 	icon_state = "tracks";
 	dir = 1
 	},
@@ -4270,7 +4143,6 @@
 /area/whiskey_outpost/outside/south)
 "lQ" = (
 /obj/effect/decal/cleanable/blood/writing{
-	tag = "icon-tracks (NORTH)";
 	icon_state = "tracks";
 	dir = 1
 	},
@@ -4301,7 +4173,6 @@
 "lV" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/blood/writing{
-	tag = "icon-tracks (NORTH)";
 	icon_state = "tracks";
 	dir = 1
 	},
@@ -4323,7 +4194,6 @@
 /area/whiskey_outpost/outside/south)
 "lY" = (
 /obj/effect/decal/cleanable/blood/writing{
-	tag = "icon-tracks (NORTH)";
 	icon_state = "tracks";
 	dir = 1
 	},
@@ -4333,7 +4203,6 @@
 /area/whiskey_outpost/outside/south)
 "lZ" = (
 /obj/effect/decal/cleanable/blood/writing{
-	tag = "icon-tracks (NORTHWEST)";
 	icon_state = "tracks";
 	dir = 9
 	},
@@ -4341,7 +4210,6 @@
 /area/whiskey_outpost/outside/south)
 "ma" = (
 /obj/effect/decal/cleanable/blood/writing{
-	tag = "icon-tracks (EAST)";
 	icon_state = "tracks";
 	dir = 4
 	},
@@ -4349,7 +4217,6 @@
 /area/whiskey_outpost/outside/south)
 "mb" = (
 /obj/effect/decal/cleanable/blood/writing{
-	tag = "icon-tracks (EAST)";
 	icon_state = "tracks";
 	dir = 4
 	},
@@ -4360,7 +4227,6 @@
 /area/whiskey_outpost/outside/south)
 "mc" = (
 /obj/effect/decal/cleanable/blood/writing{
-	tag = "icon-tracks (SOUTHWEST)";
 	icon_state = "tracks";
 	dir = 10
 	},
@@ -4371,7 +4237,6 @@
 /area/whiskey_outpost/outside/south)
 "md" = (
 /obj/effect/decal/cleanable/blood/writing{
-	tag = "icon-tracks (NORTHEAST)";
 	icon_state = "tracks";
 	dir = 5
 	},
@@ -4379,7 +4244,6 @@
 /area/whiskey_outpost/outside/south)
 "me" = (
 /obj/effect/decal/cleanable/blood/writing{
-	tag = "icon-tracks (SOUTHWEST)";
 	icon_state = "tracks";
 	dir = 10
 	},
@@ -4402,7 +4266,6 @@
 /area/whiskey_outpost/outside/south)
 "mh" = (
 /obj/effect/decal/cleanable/blood/writing{
-	tag = "icon-tracks (EAST)";
 	icon_state = "tracks";
 	dir = 4
 	},

--- a/_maps/map_files/debugdalus/tgs_debugdalus.dmm
+++ b/_maps/map_files/debugdalus/tgs_debugdalus.dmm
@@ -1146,7 +1146,6 @@
 /area/almayer/engineering/engine_core)
 "acF" = (
 /obj/structure/cable{
-	tag = "icon-0-2";
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/almayer{
@@ -5089,7 +5088,6 @@
 /area/almayer/command/self_destruct)
 "avY" = (
 /turf/open/shuttle/escapepod{
-	tag = "icon-floor8";
 	icon_state = "floor8"
 	},
 /area/almayer/command/self_destruct)
@@ -5099,7 +5097,6 @@
 /area/almayer/command/telecomms)
 "axn" = (
 /turf/open/shuttle/escapepod{
-	tag = "icon-floor1";
 	icon_state = "floor1"
 	},
 /area/almayer/command/self_destruct)
@@ -5224,13 +5221,11 @@
 /area/almayer/squads/req)
 "lAe" = (
 /turf/open/shuttle/escapepod{
-	tag = "icon-floor5";
 	icon_state = "floor5"
 	},
 /area/almayer/command/self_destruct)
 "pNG" = (
 /turf/open/shuttle/escapepod{
-	tag = "icon-floor11";
 	icon_state = "floor11"
 	},
 /area/almayer/command/self_destruct)

--- a/_maps/map_files/generic/Admin_Level.dmm
+++ b/_maps/map_files/generic/Admin_Level.dmm
@@ -215,7 +215,6 @@
 /area/centcom/supplypod/loading/two)
 "aH" = (
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/centcom/supplypod/loading/one)
@@ -258,7 +257,6 @@
 /area/centcom)
 "aO" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-21"
 	},
 /turf/open/floor/almayer,
@@ -320,7 +318,6 @@
 "ba" = (
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/floor/almayer{
-	tag = "icon-blue (NORTHEAST)";
 	icon_state = "plating";
 	dir = 5
 	},
@@ -365,13 +362,11 @@
 /area/centcom)
 "bi" = (
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/centcom/supplypod/loading/two)
 "bj" = (
 /turf/open/floor/almayer{
-	tag = "icon-blue (NORTHWEST)";
 	icon_state = "blue";
 	dir = 9
 	},
@@ -427,7 +422,6 @@
 /area/tdome/tdomeadmin)
 "bs" = (
 /turf/open/floor/almayer{
-	tag = "icon-blue (SOUTHWEST)";
 	icon_state = "blue";
 	dir = 10
 	},
@@ -610,8 +604,7 @@
 /obj/item/weapon/gun/rifle/lmg,
 /turf/open/floor/almayer{
 	dir = 9;
-	icon_state = "red";
-	tag = "icon-blue (NORTHWEST)"
+	icon_state = "red"
 	},
 /area/centcom)
 "bY" = (
@@ -622,8 +615,7 @@
 /obj/item/ammo_magazine/rocket/m57a4,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-blue (NORTH)"
+	icon_state = "red"
 	},
 /area/centcom)
 "bZ" = (
@@ -632,14 +624,12 @@
 /obj/item/storage/box/flashbangs,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-blue (NORTH)"
+	icon_state = "red"
 	},
 /area/centcom)
 "ca" = (
 /obj/machinery/door/airlock/almayer/command,
 /turf/open/floor/almayer{
-	tag = "icon-blue";
 	icon_state = "blue"
 	},
 /area/centcom)
@@ -660,8 +650,7 @@
 /obj/item/storage/box/explosive_mines,
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "red";
-	tag = "icon-blue (NORTH)"
+	icon_state = "red"
 	},
 /area/centcom)
 "cd" = (
@@ -675,8 +664,7 @@
 /obj/item/storage/box/spec/sniper,
 /turf/open/floor/almayer{
 	dir = 5;
-	icon_state = "red";
-	tag = "icon-blue (NORTHEAST)"
+	icon_state = "red"
 	},
 /area/centcom)
 "ce" = (
@@ -688,13 +676,11 @@
 /area/centcom)
 "cf" = (
 /turf/open/floor/almayer{
-	tag = "icon-test_floor5";
 	icon_state = "test_floor5"
 	},
 /area/centcom/supplypod/podStorage)
 "cg" = (
 /turf/open/floor/almayer{
-	tag = "icon-test_floor5";
 	icon_state = "test_floor5"
 	},
 /area/centcom/supplypod/flyMeToTheMoon)
@@ -735,7 +721,6 @@
 /area/centcom)
 "cl" = (
 /obj/structure/bed/chair/comfy{
-	tag = "icon-comfychair (NORTH)";
 	icon_state = "comfychair";
 	dir = 1
 	},
@@ -760,13 +745,11 @@
 /area/centcom)
 "cp" = (
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/centcom/supplypod/loading/three)
 "cq" = (
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/centcom/supplypod/loading/four)
@@ -822,14 +805,12 @@
 	name = "ultra-reinforced window"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-blue (NORTHEAST)";
 	icon_state = "plating";
 	dir = 5
 	},
 /area/centcom)
 "ej" = (
 /turf/open/floor/plating{
-	tag = "icon-test_floor5";
 	icon_state = "test_floor5"
 	},
 /area/centcom/supply)
@@ -871,7 +852,6 @@
 "fe" = (
 /obj/structure/window/framed/almayer/toughened,
 /turf/open/floor/almayer{
-	tag = "icon-blue (NORTHEAST)";
 	icon_state = "plating";
 	dir = 5
 	},
@@ -886,7 +866,6 @@
 /area/centcom/control)
 "fh" = (
 /turf/open/floor/almayer{
-	tag = "icon-blue (NORTHEAST)";
 	icon_state = "plating";
 	dir = 5
 	},
@@ -920,8 +899,7 @@
 "fY" = (
 /turf/open/floor/almayer{
 	dir = 2;
-	icon_state = "orange";
-	tag = "icon-orange (NORTH)"
+	icon_state = "orange"
 	},
 /area/centcom)
 "fZ" = (
@@ -934,7 +912,6 @@
 /area/centcom)
 "gc" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (WEST)";
 	icon_state = "orangecorner";
 	dir = 8
 	},
@@ -970,28 +947,24 @@
 /area/centcom/supply)
 "gl" = (
 /turf/open/floor/almayer{
-	tag = "icon-blue (NORTHEAST)";
 	icon_state = "blue";
 	dir = 5
 	},
 /area/centcom)
 "gn" = (
 /turf/open/floor/almayer{
-	tag = "icon-blue (NORTH)";
 	icon_state = "blue";
 	dir = 1
 	},
 /area/centcom)
 "gv" = (
 /turf/open/floor/almayer{
-	tag = "icon-blue (EAST)";
 	icon_state = "blue";
 	dir = 4
 	},
 /area/centcom)
 "gw" = (
 /turf/open/floor/almayer{
-	tag = "icon-blue (WEST)";
 	icon_state = "blue";
 	dir = 8
 	},
@@ -1014,15 +987,13 @@
 /area/start)
 "in" = (
 /turf/open/floor/almayer{
-	tag = "icon-test_floor4";
 	icon_state = "test_floor4"
 	},
 /area/centcom/supply)
 "ip" = (
 /turf/open/floor/almayer{
 	dir = 8;
-	icon_state = "red";
-	tag = "icon-blue (WEST)"
+	icon_state = "red"
 	},
 /area/centcom)
 "ir" = (
@@ -1040,7 +1011,6 @@
 /area/shuttle/distress/start_big)
 "iV" = (
 /turf/open/floor/almayer{
-	tag = "icon-blue";
 	icon_state = "blue"
 	},
 /area/centcom)
@@ -1051,8 +1021,7 @@
 "je" = (
 /obj/structure/closet/crate,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "ji" = (
@@ -1067,25 +1036,21 @@
 /area/shuttle/distress/start_big)
 "kd" = (
 /turf/open/floor/almayer{
-	tag = "icon-bluecorner";
 	icon_state = "bluecorner"
 	},
 /area/centcom)
 "kj" = (
 /turf/open/floor/almayer{
-	tag = "icon-blue (SOUTHEAST)";
 	icon_state = "blue";
 	dir = 6
 	},
 /area/centcom)
 "kp" = (
 /obj/structure/bed/chair/wood/normal{
-	tag = "icon-wooden_chair (EAST)";
 	icon_state = "wooden_chair";
 	dir = 4
 	},
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (NORTH)";
 	icon_state = "carpetside";
 	dir = 1
 	},
@@ -1102,16 +1067,14 @@
 "ky" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "kz" = (
 /obj/structure/table/almayer,
 /obj/item/flashlight/lamp,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "kA" = (
@@ -1120,15 +1083,13 @@
 	},
 /obj/structure/rack,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "kB" = (
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "kC" = (
@@ -1136,15 +1097,13 @@
 	stored_metal = 1000
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "kD" = (
 /obj/structure/sink,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "kE" = (
@@ -1154,24 +1113,21 @@
 	pixel_y = -5
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "kF" = (
 /obj/item/storage/surgical_tray,
 /obj/structure/table/almayer,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "kG" = (
 /obj/machinery/microwave,
 /obj/structure/table/almayer,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "kH" = (
@@ -1188,14 +1144,12 @@
 "kJ" = (
 /obj/structure/largecrate/random/barrel/blue,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "kK" = (
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "kL" = (
@@ -1204,8 +1158,7 @@
 	req_one_access_txt = "0"
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "kM" = (
@@ -1216,8 +1169,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "kN" = (
@@ -1225,8 +1177,7 @@
 /obj/item/storage/box/donkpockets,
 /obj/item/storage/box/donkpockets,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "kO" = (
@@ -1261,8 +1212,7 @@
 "kS" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "kT" = (
@@ -1273,8 +1223,7 @@
 /obj/item/reagent_container/blood/OMinus,
 /obj/item/reagent_container/blood/OMinus,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "kU" = (
@@ -1287,8 +1236,7 @@
 /obj/item/storage/belt/combatLifesaver,
 /obj/item/reagent_container/spray/surgery,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "kV" = (
@@ -1329,8 +1277,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "lb" = (
@@ -1338,8 +1285,7 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "lc" = (
@@ -1349,8 +1295,7 @@
 	req_one_access_txt = "0"
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "ld" = (
@@ -1384,8 +1329,7 @@
 /obj/item/cell/infinite,
 /obj/item/cell/infinite,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "lh" = (
@@ -1397,15 +1341,13 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "li" = (
 /obj/structure/rack,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "lj" = (
@@ -1420,8 +1362,7 @@
 "lk" = (
 /obj/structure/bed/chair/dropship/passenger,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "ll" = (
@@ -1430,8 +1371,7 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "lm" = (
@@ -1439,8 +1379,7 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/radio,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "ln" = (
@@ -1448,13 +1387,11 @@
 /obj/item/storage/firstaid/regular,
 /obj/item/storage/belt/combatLifesaver,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "lo" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-21"
 	},
 /turf/open/floor/wood,
@@ -1476,8 +1413,7 @@
 /obj/structure/table/almayer,
 /obj/machinery/computer/security,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "ls" = (
@@ -1488,23 +1424,20 @@
 /obj/item/handcuffs,
 /obj/item/handcuffs,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "lt" = (
 /obj/structure/table/almayer,
 /obj/machinery/computer/secure_data,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "lu" = (
 /obj/machinery/autolathe,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "lv" = (
@@ -1584,7 +1517,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-blue (NORTHEAST)";
 	icon_state = "plating";
 	dir = 5
 	},
@@ -1639,8 +1571,7 @@
 /obj/structure/table/almayer,
 /obj/machinery/computer/card,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "lJ" = (
@@ -1810,8 +1741,7 @@
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "lX" = (
@@ -1904,8 +1834,7 @@
 /obj/structure/table/almayer,
 /obj/machinery/computer/communications,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "mh" = (
@@ -1917,8 +1846,7 @@
 /obj/item/clothing/glasses/welding,
 /obj/item/clothing/glasses/welding,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "mi" = (
@@ -1927,32 +1855,28 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "mj" = (
 /obj/structure/rack,
 /obj/item/storage/firstaid/adv,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "mk" = (
 /obj/structure/bed/chair/dropship/passenger,
 /obj/machinery/light,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "ml" = (
 /obj/structure/table/almayer,
 /obj/item/clothing/suit/armor/bulletproof,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "mm" = (
@@ -1966,8 +1890,7 @@
 /obj/item/weapon/gun/shotgun/combat,
 /obj/item/weapon/gun/shotgun/combat,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "mo" = (
@@ -1977,8 +1900,7 @@
 /obj/item/ammo_magazine/smg/m39,
 /obj/item/weapon/gun/smg/m39/elite,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "mp" = (
@@ -1988,15 +1910,13 @@
 /obj/structure/table/almayer,
 /obj/machinery/computer/med_data/laptop,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "mq" = (
 /obj/machinery/computer/crew,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "mr" = (
@@ -2006,8 +1926,7 @@
 /obj/item/tool/pen,
 /obj/item/tool/pen,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "ms" = (
@@ -2039,8 +1958,7 @@
 	pixel_y = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "mv" = (
@@ -2073,15 +1991,13 @@
 	name = "captain's secure box"
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "my" = (
 /obj/machinery/cryopod/right,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "mz" = (
@@ -2098,15 +2014,13 @@
 /obj/item/storage/box/m94,
 /obj/item/storage/box/zipcuffs,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "mA" = (
 /obj/structure/closet,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "mB" = (
@@ -2114,14 +2028,12 @@
 	dir = 2
 	},
 /obj/machinery/shower{
-	tag = "icon-shower (EAST)";
 	icon_state = "shower";
 	dir = 4
 	},
 /obj/item/tool/soap,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "mC" = (
@@ -2130,8 +2042,7 @@
 /obj/item/ammo_magazine/smg/m39,
 /obj/item/weapon/gun/smg/m39/elite,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "mD" = (
@@ -2162,15 +2073,13 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "mG" = (
 /obj/structure/largecrate/random/barrel/white,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "mH" = (
@@ -2179,8 +2088,7 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "mI" = (
@@ -2224,8 +2132,7 @@
 /obj/item/tool/pen,
 /obj/item/tool/pen,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "mM" = (
@@ -2239,8 +2146,7 @@
 /obj/item/tool/hand_labeler,
 /obj/item/tool/hand_labeler,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "mN" = (
@@ -2259,8 +2165,7 @@
 /obj/item/radio,
 /obj/item/radio,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "mO" = (
@@ -2269,20 +2174,17 @@
 	},
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "mP" = (
 /obj/structure/table/almayer,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "mQ" = (
 /obj/structure/toilet{
-	tag = "icon-toilet00 (NORTH)";
 	icon_state = "toilet00";
 	dir = 1
 	},
@@ -2290,19 +2192,16 @@
 /area/shuttle/distress/start_big)
 "mR" = (
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (NORTHWEST)";
 	icon_state = "carpetside";
 	dir = 9
 	},
 /area/centcom)
 "mS" = (
 /obj/structure/bed/chair/wood/normal{
-	tag = "icon-wooden_chair (WEST)";
 	icon_state = "wooden_chair";
 	dir = 8
 	},
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (NORTH)";
 	icon_state = "carpetside";
 	dir = 1
 	},
@@ -2310,28 +2209,24 @@
 "mT" = (
 /obj/structure/table/woodentable,
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (NORTH)";
 	icon_state = "carpetside";
 	dir = 1
 	},
 /area/centcom)
 "mU" = (
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (NORTH)";
 	icon_state = "carpetside";
 	dir = 1
 	},
 /area/centcom)
 "mV" = (
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (NORTHEAST)";
 	icon_state = "carpetside";
 	dir = 5
 	},
 /area/centcom)
 "na" = (
 /obj/structure/bed/chair/wood/normal{
-	tag = "icon-wooden_chair (EAST)";
 	icon_state = "wooden_chair";
 	dir = 4
 	},
@@ -2339,14 +2234,12 @@
 /area/centcom)
 "nb" = (
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (WEST)";
 	icon_state = "carpetside";
 	dir = 8
 	},
 /area/centcom)
 "nc" = (
 /obj/structure/bed/chair/wood/normal{
-	tag = "icon-wooden_chair (WEST)";
 	icon_state = "wooden_chair";
 	dir = 8
 	},
@@ -2361,7 +2254,6 @@
 /area/centcom)
 "nf" = (
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (EAST)";
 	icon_state = "carpetside";
 	dir = 4
 	},
@@ -2388,13 +2280,11 @@
 	pixel_x = 32
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "nk" = (
 /turf/open/floor/almayer{
-	tag = "icon-bluecorner (EAST)";
 	icon_state = "bluecorner";
 	dir = 4
 	},
@@ -2415,7 +2305,6 @@
 /area/centcom/supply)
 "nr" = (
 /turf/open/floor/almayer{
-	tag = "icon-bluecorner";
 	icon_state = "bluecorner";
 	dir = 8
 	},
@@ -2473,7 +2362,6 @@
 /area/centcom)
 "nP" = (
 /obj/structure/bed/chair/wood/normal{
-	tag = "icon-wooden_chair (EAST)";
 	icon_state = "wooden_chair";
 	dir = 4
 	},
@@ -2483,14 +2371,12 @@
 /area/centcom)
 "nQ" = (
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (SOUTHWEST)";
 	icon_state = "carpetside";
 	dir = 10
 	},
 /area/centcom)
 "nR" = (
 /obj/structure/bed/chair/wood/normal{
-	tag = "icon-wooden_chair (WEST)";
 	icon_state = "wooden_chair";
 	dir = 8
 	},
@@ -2511,7 +2397,6 @@
 /area/centcom)
 "nU" = (
 /turf/open/floor/carpet{
-	tag = "icon-carpetside (SOUTHEAST)";
 	icon_state = "carpetside";
 	dir = 6
 	},
@@ -2538,7 +2423,6 @@
 /area/centcom/ferry)
 "od" = (
 /turf/open/floor/almayer{
-	tag = "icon-orange (NORTH)";
 	icon_state = "orange";
 	dir = 1
 	},
@@ -2553,7 +2437,6 @@
 /area/centcom)
 "of" = (
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (NORTH)";
 	icon_state = "orangecorner";
 	dir = 1
 	},
@@ -2577,13 +2460,11 @@
 	pixel_x = 32
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/distress/start_big)
 "oW" = (
 /turf/open/floor/almayer{
-	tag = "icon-bluecorner";
 	icon_state = "bluecorner";
 	dir = 1
 	},
@@ -2604,7 +2485,6 @@
 	name = "\improper Hangar Shutters"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner";
 	icon_state = "orangecorner"
 	},
 /area/centcom)
@@ -2615,7 +2495,6 @@
 	name = "\improper Hangar Shutters"
 	},
 /turf/open/floor/almayer{
-	tag = "icon-orangecorner (EAST)";
 	icon_state = "orangecorner";
 	dir = 4
 	},
@@ -3214,28 +3093,24 @@
 "sO" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "red";
-	tag = "icon-blue (EAST)"
+	icon_state = "red"
 	},
 /area/centcom)
 "zQ" = (
 /turf/open/floor/almayer{
 	dir = 4;
-	icon_state = "redcorner";
-	tag = "icon-bluecorner (EAST)"
+	icon_state = "redcorner"
 	},
 /area/centcom)
 "Pw" = (
 /turf/open/floor/almayer{
 	dir = 1;
-	icon_state = "redcorner";
-	tag = "icon-bluecorner"
+	icon_state = "redcorner"
 	},
 /area/centcom)
 "TC" = (
 /obj/docking_port/stationary/supply,
 /turf/open/floor/plating{
-	tag = "icon-test_floor5";
 	icon_state = "test_floor5"
 	},
 /area/centcom/supply)

--- a/_maps/shuttles/big_ert.dmm
+++ b/_maps/shuttles/big_ert.dmm
@@ -26,8 +26,7 @@
 "ah" = (
 /obj/structure/closet/crate,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "ai" = (
@@ -50,23 +49,20 @@
 	pixel_x = 32
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "am" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "an" = (
 /obj/structure/table/almayer,
 /obj/item/flashlight/lamp,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "ao" = (
@@ -75,15 +71,13 @@
 	},
 /obj/structure/rack,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "ap" = (
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "aq" = (
@@ -91,15 +85,13 @@
 	stored_metal = 1000
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "ar" = (
 /obj/structure/sink,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "as" = (
@@ -109,24 +101,21 @@
 	pixel_y = -5
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "at" = (
 /obj/item/storage/surgical_tray,
 /obj/structure/table/almayer,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "au" = (
 /obj/machinery/microwave,
 /obj/structure/table/almayer,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "av" = (
@@ -143,14 +132,12 @@
 "ax" = (
 /obj/structure/largecrate/random/barrel/blue,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "ay" = (
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "az" = (
@@ -159,8 +146,7 @@
 	req_one_access_txt = "0"
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "aA" = (
@@ -171,8 +157,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "aB" = (
@@ -180,8 +165,7 @@
 /obj/item/storage/box/donkpockets,
 /obj/item/storage/box/donkpockets,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "aC" = (
@@ -216,8 +200,7 @@
 "aG" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "aH" = (
@@ -228,8 +211,7 @@
 /obj/item/reagent_container/blood/OMinus,
 /obj/item/reagent_container/blood/OMinus,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "aI" = (
@@ -242,8 +224,7 @@
 /obj/item/storage/belt/combatLifesaver,
 /obj/item/reagent_container/spray/surgery,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "aJ" = (
@@ -284,8 +265,7 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "aP" = (
@@ -293,8 +273,7 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "aQ" = (
@@ -304,8 +283,7 @@
 	req_one_access_txt = "0"
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "aR" = (
@@ -339,8 +317,7 @@
 /obj/item/cell/infinite,
 /obj/item/cell/infinite,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "aV" = (
@@ -352,15 +329,13 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "aW" = (
 /obj/structure/rack,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "aX" = (
@@ -375,8 +350,7 @@
 "aY" = (
 /obj/structure/bed/chair/dropship/passenger,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "aZ" = (
@@ -385,8 +359,7 @@
 	dir = 1
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "ba" = (
@@ -394,8 +367,7 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/radio,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "bb" = (
@@ -403,13 +375,11 @@
 /obj/item/storage/firstaid/regular,
 /obj/item/storage/belt/combatLifesaver,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "bc" = (
 /obj/structure/flora/pottedplant{
-	tag = "icon-plant-10";
 	icon_state = "plant-21"
 	},
 /turf/open/floor/wood,
@@ -431,8 +401,7 @@
 /obj/structure/table/almayer,
 /obj/machinery/computer/security,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "bg" = (
@@ -443,23 +412,20 @@
 /obj/item/handcuffs,
 /obj/item/handcuffs,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "bh" = (
 /obj/structure/table/almayer,
 /obj/machinery/computer/secure_data,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "bi" = (
 /obj/machinery/autolathe,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "bj" = (
@@ -539,7 +505,6 @@
 	dir = 2
 	},
 /turf/open/floor/almayer{
-	tag = "icon-blue (NORTHEAST)";
 	icon_state = "plating";
 	dir = 5
 	},
@@ -594,8 +559,7 @@
 /obj/structure/table/almayer,
 /obj/machinery/computer/card,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "bx" = (
@@ -765,8 +729,7 @@
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "bL" = (
@@ -859,8 +822,7 @@
 /obj/structure/table/almayer,
 /obj/machinery/computer/communications,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "bV" = (
@@ -872,8 +834,7 @@
 /obj/item/clothing/glasses/welding,
 /obj/item/clothing/glasses/welding,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "bW" = (
@@ -882,32 +843,28 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "bX" = (
 /obj/structure/rack,
 /obj/item/storage/firstaid/adv,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "bY" = (
 /obj/structure/bed/chair/dropship/passenger,
 /obj/machinery/light,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "bZ" = (
 /obj/structure/table/almayer,
 /obj/item/clothing/suit/armor/bulletproof,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "ca" = (
@@ -921,8 +878,7 @@
 /obj/item/weapon/gun/shotgun/combat,
 /obj/item/weapon/gun/shotgun/combat,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "cb" = (
@@ -932,8 +888,7 @@
 /obj/item/ammo_magazine/smg/m39,
 /obj/item/weapon/gun/smg/m39/elite,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "cc" = (
@@ -943,15 +898,13 @@
 /obj/structure/table/almayer,
 /obj/machinery/computer/med_data/laptop,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "cd" = (
 /obj/machinery/computer/crew,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "ce" = (
@@ -961,8 +914,7 @@
 /obj/item/tool/pen,
 /obj/item/tool/pen,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "cf" = (
@@ -994,8 +946,7 @@
 	pixel_y = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "ci" = (
@@ -1028,15 +979,13 @@
 	name = "captain's secure box"
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "cl" = (
 /obj/machinery/cryopod/right,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "cm" = (
@@ -1053,15 +1002,13 @@
 /obj/item/storage/box/m94,
 /obj/item/storage/box/zipcuffs,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "cn" = (
 /obj/structure/closet,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "co" = (
@@ -1069,14 +1016,12 @@
 	dir = 2
 	},
 /obj/machinery/shower{
-	tag = "icon-shower (EAST)";
 	icon_state = "shower";
 	dir = 4
 	},
 /obj/item/tool/soap,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "cp" = (
@@ -1085,8 +1030,7 @@
 /obj/item/ammo_magazine/smg/m39,
 /obj/item/weapon/gun/smg/m39/elite,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "cs" = (
@@ -1117,15 +1061,13 @@
 	dir = 4
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "cv" = (
 /obj/structure/largecrate/random/barrel/white,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "cw" = (
@@ -1134,8 +1076,7 @@
 	dir = 8
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "cx" = (
@@ -1179,8 +1120,7 @@
 /obj/item/tool/pen,
 /obj/item/tool/pen,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "cB" = (
@@ -1194,8 +1134,7 @@
 /obj/item/tool/hand_labeler,
 /obj/item/tool/hand_labeler,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "cC" = (
@@ -1214,8 +1153,7 @@
 /obj/item/radio,
 /obj/item/radio,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "cD" = (
@@ -1224,20 +1162,17 @@
 	},
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "cE" = (
 /obj/structure/table/almayer,
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "cF" = (
 /obj/structure/toilet{
-	tag = "icon-toilet00 (NORTH)";
 	icon_state = "toilet00";
 	dir = 1
 	},
@@ -1251,8 +1186,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/almayer{
-	icon_state = "plate";
-	tag = "icon-sterile"
+	icon_state = "plate"
 	},
 /area/shuttle/big_ert)
 "cI" = (

--- a/_maps/shuttles/distress_pmc.dmm
+++ b/_maps/shuttles/distress_pmc.dmm
@@ -92,7 +92,6 @@
 "q" = (
 /obj/effect/landmark/distress,
 /turf/open/shuttle/dropship{
-	tag = "icon-rasputin3";
 	icon_state = "rasputin3"
 	},
 /area/shuttle/ert/pmc)
@@ -128,8 +127,7 @@
 /area/shuttle/ert/pmc)
 "v" = (
 /turf/open/shuttle/dropship{
-	icon_state = "rasputin4";
-	tag = "icon-rasputin7"
+	icon_state = "rasputin4"
 	},
 /area/shuttle/ert/pmc)
 "w" = (

--- a/_maps/shuttles/escape_pod.dmm
+++ b/_maps/shuttles/escape_pod.dmm
@@ -1,32 +1,27 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/closed/shuttle/escapepod{
-	tag = "icon-wall13";
 	icon_state = "wall13"
 	},
 /area/shuttle/escape_pod)
 "b" = (
 /turf/closed/shuttle/escapepod{
-	tag = "icon-wall1";
 	icon_state = "wall1"
 	},
 /area/shuttle/escape_pod)
 "c" = (
 /obj/machinery/computer/shuttle/escape_pod,
 /turf/closed/shuttle/escapepod{
-	tag = "icon-wall2";
 	icon_state = "wall2"
 	},
 /area/shuttle/escape_pod)
 "d" = (
 /turf/closed/shuttle/escapepod{
-	tag = "icon-wall3";
 	icon_state = "wall3"
 	},
 /area/shuttle/escape_pod)
 "e" = (
 /turf/closed/shuttle/escapepod{
-	tag = "icon-wall12";
 	icon_state = "wall12"
 	},
 /area/shuttle/escape_pod)
@@ -36,25 +31,21 @@
 /area/shuttle/escape_pod)
 "g" = (
 /turf/open/shuttle/escapepod{
-	tag = "icon-floor0";
 	icon_state = "floor0"
 	},
 /area/shuttle/escape_pod)
 "h" = (
 /turf/closed/shuttle/escapepod{
-	tag = "icon-wall4";
 	icon_state = "wall4"
 	},
 /area/shuttle/escape_pod)
 "i" = (
 /turf/closed/shuttle/escapepod{
-	tag = "icon-wall11";
 	icon_state = "wall11"
 	},
 /area/shuttle/escape_pod)
 "j" = (
 /turf/open/shuttle/escapepod{
-	tag = "icon-floor1";
 	icon_state = "floor1"
 	},
 /area/shuttle/escape_pod)
@@ -65,44 +56,37 @@
 /area/shuttle/escape_pod)
 "l" = (
 /turf/open/shuttle/escapepod{
-	tag = "icon-floor10";
 	icon_state = "floor10"
 	},
 /area/shuttle/escape_pod)
 "m" = (
 /turf/closed/shuttle/escapepod{
-	tag = "icon-wall9";
 	icon_state = "wall9"
 	},
 /area/shuttle/escape_pod)
 "n" = (
 /turf/closed/shuttle/escapepod{
-	tag = "icon-wall7";
 	icon_state = "wall7"
 	},
 /area/shuttle/escape_pod)
 "o" = (
 /turf/closed/shuttle/escapepod{
-	tag = "icon-wall6";
 	icon_state = "wall6"
 	},
 /area/shuttle/escape_pod)
 "p" = (
 /turf/closed/shuttle/escapepod{
-	icon_state = "wall10";
-	tag = "icon-wall11"
+	icon_state = "wall10"
 	},
 /area/shuttle/escape_pod)
 "q" = (
 /turf/closed/shuttle/escapepod{
-	icon_state = "wall5";
-	tag = "icon-wall4"
+	icon_state = "wall5"
 	},
 /area/shuttle/escape_pod)
 "r" = (
 /turf/closed/shuttle/escapepod{
-	icon_state = "wall8";
-	tag = "icon-wall7"
+	icon_state = "wall8"
 	},
 /area/shuttle/escape_pod)
 

--- a/_maps/shuttles/supply.dmm
+++ b/_maps/shuttles/supply.dmm
@@ -4,7 +4,6 @@
 /area/shuttle/supply)
 "b" = (
 /turf/open/floor/plating{
-	tag = "icon-test_floor5";
 	icon_state = "test_floor5"
 	},
 /area/shuttle/supply)


### PR DESCRIPTION
Removes the tags from the maps via regex replacement, provided by @spookydonut 

Regex used:
* Find `\ttag = .+;\n` replace with nothing.
* Find `;\n\ttag = .+\n\t},` replace with `\n\t},`