### PR TITLE
Small fixes to away time

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -641,7 +641,7 @@ below 100 is not dizzy
 
 // called when the client disconnects and is away.
 /mob/living/proc/begin_away()
-	away_time = set_away_time(world.time)
+	set_away_time(world.time)
 
 
 /mob/living/reset_perspective(atom/A)

--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -11,4 +11,4 @@
 			remove_ventcrawl()
 			add_ventcrawl(A)
 
-	away_time = set_away_time(0) //Reset away timer once back.
+	set_away_time(0) //Reset away timer once back.


### PR DESCRIPTION
Fixes small issues with away_time being set to null.
The proc sets the value and doesn't return anything, so it overrides it to null.