### PR TITLE
Line of sight proc

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -726,7 +726,7 @@
 		if(1) //We can see our own tile
 			return TRUE
 	
-	var/turf/turf_to_check = turf_list[1] //The source's turf, do a first pass because opaques `ON_BORDER` facing our direction are fine this time.
+	var/turf/turf_to_check = turf_list[1] //The source's turf, do a first pass because opaques ON_BORDER facing the opposite direction are our only nemesis.
 	for(var/obj/stuff_in_turf in turf_to_check)
 		if(!stuff_in_turf.opacity)
 			continue //Transparent, we can see through it.
@@ -740,20 +740,20 @@
 		for(var/i in (length(turf_list) - 1))
 			turf_to_check = turf_list[i]
 			if(turf_to_check.opacity)
-				return FALSE //First a last turfs' opacity don't matter, but the ones in-between do.
+				return FALSE //First and last turfs' opacity don't matter, but the ones in-between do.
 			for(var/obj/stuff_in_turf in turf_to_check)
 				if(!stuff_in_turf.opacity)
 					continue //Transparent, we can see through it.
 				if(!CHECK_BITFIELD(stuff_in_turf.flags_atom, ON_BORDER))
 					return FALSE //Opaque and not on border. We can't see through this tile, it's over.
 				if(ISDIAGONALDIR(stuff_in_turf.dir))
-					return FALSE //Opaque window.
+					return FALSE //Opaque fulltile window.
 				if(CHECK_BITFIELD(dir, stuff_in_turf.dir))
 					return FALSE //Same direction and opaque, blocks our view.
 				if(CHECK_BITFIELD(dir, reverse_direction(stuff_in_turf.dir)))
-					return FALSE //Doesn't block this tile, but it does the next, and this is not the last pass.
+					return FALSE //Doesn't block this tile, but it does block the next, and this is not the last pass.
 
-	turf_to_check = turf_list[length(turf_list)]
+	turf_to_check = turf_list[length(turf_list)] //Last turf, inverse logic than the first.
 	for(var/obj/stuff_in_turf in turf_to_check)
 		if(!stuff_in_turf.opacity)
 			continue //Transparent, we can see through it.

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -713,10 +713,13 @@
 GLOBAL_VAR_INIT(los_switch, 0)
 
 /atom/movable/proc/line_of_sight(atom/target, view_dist = world.view)
-	if(GLOB.los_switch++ % 2)
-		line_of_sight_one(target, view_dist)
-	else
-		line_of_sight_two(target, view_dist)
+	switch(GLOB.los_switch++ % 3)
+		if(0)
+			return line_of_sight_one(target, view_dist)
+		if(1)
+			return line_of_sight_two(target, view_dist)
+		if(2)
+			return line_of_sight_three(target, view_dist)
 
 
 /atom/movable/proc/line_of_sight_one(atom/target, view_dist = world.view)
@@ -833,3 +836,7 @@ GLOBAL_VAR_INIT(los_switch, 0)
 			return FALSE //Same direction and opaque, blocks our view.
 
 	return TRUE
+
+
+/atom/movable/proc/line_of_sight_three(atom/target, view_dist = world.view)
+	return (target in view(view_dist))

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -713,65 +713,58 @@
 GLOBAL_VAR_INIT(los_switch, 0)
 
 /atom/movable/proc/line_of_sight(atom/target, view_dist = world.view)
-	switch(GLOB.los_switch++ % 3)
+	switch(GLOB.los_switch++ % 4)
 		if(0)
 			return line_of_sight_one(target, view_dist)
 		if(1)
 			return line_of_sight_two(target, view_dist)
 		if(2)
 			return line_of_sight_three(target, view_dist)
+		if(3)
+			return line_of_sight_four(target, view_dist)
 
 
 /atom/movable/proc/line_of_sight_one(atom/target, view_dist = world.view)
 	if(!isturf(loc) || QDELETED(target))
 		return FALSE
 
-	if(z != target.z || get_dist(src, target) > view_dist)
+	if(z != target.z)
 		return FALSE
+
+	var/total_distance = get_dist(src, target)
+
+	if(total_distance > view_dist)
+		return FALSE
+	
+	switch(total_distance)
+		if(-1)
+			if(target == src) //We can see ourselves alright.
+				return TRUE
+			else //Standard get_dist() error condition.
+				return FALSE
+		if(null) //Error, does not compute.
+			return FALSE
+		if(0, 1) //We can see our own tile and the next one regardless.
+			return TRUE
 
 	var/list/turf_list = getline(loc, get_turf(target))
 
-	switch(length(turf_list))
-		if(0) //Error, does not compute.
-			return FALSE
-		if(1) //We can see our own tile
-			return TRUE
-	
-	var/turf/turf_to_check = turf_list[1] //The source's turf, do a first pass because opaques ON_BORDER facing the opposite direction are our only nemesis.
-	for(var/obj/stuff_in_turf in turf_to_check)
-		if(!stuff_in_turf.opacity)
-			continue //Transparent, we can see through it.
-		if(!CHECK_BITFIELD(stuff_in_turf.flags_atom, ON_BORDER))
-			continue //Opaque and not on border. Doesn't block the first tile.
-		if(CHECK_BITFIELD(dir, reverse_direction(stuff_in_turf.dir)))
-			return FALSE //Reverse direction than ours, opaque, ON_BORDER, and in the same tile as us. Blocks our view.
-	turf_list.Cut(1, 2) //Remove the first element of the list, as the first turf is already checked.
+	turf_list.Cut(1,2) //First turf does not need to be checked.
+	turf_list.Cut(total_distance - 2) //Nor the last.
 
-	if(length(turf_list) > 1) //Let's do a custom last pass. Here we handle the in-beween if any.
-		for(var/i in (length(turf_list) - 1))
-			turf_to_check = turf_list[i]
-			if(turf_to_check.opacity)
-				return FALSE //First and last turfs' opacity don't matter, but the ones in-between do.
-			for(var/obj/stuff_in_turf in turf_to_check)
-				if(!stuff_in_turf.opacity)
-					continue //Transparent, we can see through it.
-				if(!CHECK_BITFIELD(stuff_in_turf.flags_atom, ON_BORDER))
-					return FALSE //Opaque and not on border. We can't see through this tile, it's over.
-				if(ISDIAGONALDIR(stuff_in_turf.dir))
-					return FALSE //Opaque fulltile window.
-				if(CHECK_BITFIELD(dir, stuff_in_turf.dir))
-					return FALSE //Same direction and opaque, blocks our view.
-				if(CHECK_BITFIELD(dir, reverse_direction(stuff_in_turf.dir)))
-					return FALSE //Doesn't block this tile, but it does block the next, and this is not the last pass.
-
-	turf_to_check = turf_list[length(turf_list)] //Last turf, inverse logic from the first.
-	for(var/obj/stuff_in_turf in turf_to_check)
-		if(!stuff_in_turf.opacity)
-			continue //Transparent, we can see through it.
-		if(!CHECK_BITFIELD(stuff_in_turf.flags_atom, ON_BORDER))
-			continue //Opaque and not on border. Doesn't block the last tile.
-		if(CHECK_BITFIELD(dir, stuff_in_turf.dir))
-			return FALSE //Same direction and opaque, blocks our view.
+	for(var/i in turf_list)
+		var/turf/turf_to_check = i
+		if(turf_to_check.opacity)
+			return FALSE //First and last turfs' opacity don't matter, but the ones in-between do.
+		for(var/obj/stuff_in_turf in turf_to_check)
+			if(!stuff_in_turf.opacity)
+				continue //Transparent, we can see through it.
+			if(!CHECK_BITFIELD(stuff_in_turf.flags_atom, ON_BORDER))
+				return FALSE //Opaque and not on border. We can't see through this tile, it's over.
+			if(ISDIAGONALDIR(stuff_in_turf.dir))
+				return FALSE //Opaque fulltile window.
+			if(CHECK_BITFIELD(dir, (stuff_in_turf.dir | reverse_direction(stuff_in_turf.dir))))
+				return FALSE //Same or opposite direction and opaque, blocks our view.
 
 	return TRUE
 
@@ -796,47 +789,34 @@ GLOBAL_VAR_INIT(los_switch, 0)
 				return FALSE
 		if(null) //Error, does not compute.
 			return FALSE
-		if(0) //We can see our own tile
+		if(0, 1) //We can see our own tile and the next one regardless.
 			return TRUE
 	
-	var/turf/turf_to_check = get_turf(src) //The source's turf, do a first pass because opaques ON_BORDER facing the opposite direction are our only nemesis.
-	for(var/obj/stuff_in_turf in turf_to_check)
-		if(!stuff_in_turf.opacity)
-			continue //Transparent, we can see through it.
-		if(!CHECK_BITFIELD(stuff_in_turf.flags_atom, ON_BORDER))
-			continue //Opaque and not on border. Doesn't block the first tile.
-		if(CHECK_BITFIELD(dir, reverse_direction(stuff_in_turf.dir)))
-			return FALSE //Reverse direction than ours, opaque, ON_BORDER, and in the same tile as us. Blocks our view.
-
+	var/turf/turf_to_check = get_turf(src)
 	var/turf/target_turf = get_turf(target)
 
-	if(total_distance > 1) //Let's do a custom last pass. Here we handle the in-beween if any.
-		for(var/i in 1 to total_distance - 1)
-			turf_to_check = get_step(turf_to_check, get_dir(turf_to_check, target_turf))
-			if(turf_to_check.opacity)
-				return FALSE //First and last turfs' opacity don't matter, but the ones in-between do.
-			for(var/obj/stuff_in_turf in turf_to_check)
-				if(!stuff_in_turf.opacity)
-					continue //Transparent, we can see through it.
-				if(!CHECK_BITFIELD(stuff_in_turf.flags_atom, ON_BORDER))
-					return FALSE //Opaque and not on border. We can't see through this tile, it's over.
-				if(ISDIAGONALDIR(stuff_in_turf.dir))
-					return FALSE //Opaque fulltile window.
-				if(CHECK_BITFIELD(dir, stuff_in_turf.dir))
-					return FALSE //Same direction and opaque, blocks our view.
-				if(CHECK_BITFIELD(dir, reverse_direction(stuff_in_turf.dir)))
-					return FALSE //Doesn't block this tile, but it does block the next, and this is not the last pass.
-
-	for(var/obj/stuff_in_turf in target_turf) //Last turf, inverse logic from the first.
-		if(!stuff_in_turf.opacity)
-			continue //Transparent, we can see through it.
-		if(!CHECK_BITFIELD(stuff_in_turf.flags_atom, ON_BORDER))
-			continue //Opaque and not on border. Doesn't block the last tile.
-		if(CHECK_BITFIELD(dir, stuff_in_turf.dir))
-			return FALSE //Same direction and opaque, blocks our view.
+	for(var/i in 1 to total_distance - 1)
+		turf_to_check = get_step(turf_to_check, get_dir(turf_to_check, target_turf))
+		if(turf_to_check.opacity)
+			return FALSE //First and last turfs' opacity don't matter, but the ones in-between do.
+		for(var/obj/stuff_in_turf in turf_to_check)
+			if(!stuff_in_turf.opacity)
+				continue //Transparent, we can see through it.
+			if(!CHECK_BITFIELD(stuff_in_turf.flags_atom, ON_BORDER))
+				return FALSE //Opaque and not on border. We can't see through this tile, it's over.
+			if(ISDIAGONALDIR(stuff_in_turf.dir))
+				return FALSE //Opaque fulltile window.
+			if(CHECK_BITFIELD(dir, stuff_in_turf.dir))
+				return FALSE //Same direction and opaque, blocks our view.
+			if(CHECK_BITFIELD(dir, reverse_direction(stuff_in_turf.dir)))
+				return FALSE //Doesn't block this tile, but it does block the next, and this is not the last pass.
 
 	return TRUE
 
 
 /atom/movable/proc/line_of_sight_three(atom/target, view_dist = world.view)
 	return (target in view(view_dist))
+
+
+/atom/movable/proc/line_of_sight_four(atom/target, view_dist = world.view)
+	return (target in viewers(view_dist))

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -144,15 +144,11 @@
 	X.create_shriekwave() //Adds the visual effect. Wom wom wom
 	//stop_momentum(charge_dir) //Screech kills a charge
 
-	var/list/nearby_living = list()
-	for(var/mob/living/L in hearers(world.view, X))
-		nearby_living.Add(L)
-
 	for(var/i in GLOB.mob_living_list)
 		var/mob/living/L = i
 		if(get_dist(L, X) > world.view)
 			continue
-		L.screech_act(X, world.view, L in nearby_living)
+		L.screech_act(X, world.view, X.line_of_sight(L))
 
 // ***************************************
 // *********** Gut

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -113,7 +113,7 @@
 	mechanics_text = "A large area knockdown that causes pain and screen-shake."
 	ability_name = "screech"
 	plasma_cost = 250
-	cooldown_timer = 50 SECONDS
+	cooldown_timer = 1 SECONDS
 	keybind_flags = XACT_KEYBIND_USE_ABILITY
 	keybind_signal = COMSIG_XENOABILITY_SCREECH
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -141,13 +141,9 @@
 	playsound(X.loc, 'sound/voice/alien_queen_screech.ogg', 75, 0)
 	X.visible_message("<span class='xenohighdanger'>\The [X] emits an ear-splitting guttural roar!</span>")
 	round_statistics.queen_screech++
-	X.create_shriekwave() //Adds the visual effect. Wom wom wom
 	//stop_momentum(charge_dir) //Screech kills a charge
 
-	for(var/i in GLOB.mob_living_list)
-		var/mob/living/L = i
-		if(get_dist(L, X) > world.view)
-			continue
+	for(var/mob/living/L in view(world.view + 2))
 		L.screech_act(X, world.view, X.line_of_sight(L))
 
 // ***************************************


### PR DESCRIPTION
An attempt at making an performant LoS proc, as /tg/'s seemed a bit expensive.

Could do a `get_step()` each time, but `getline()` uses `locate(x,y,z)` which is supposedly optimized, so I'm not sure if it would be better performant on all cases, specially considered I see this being used at range 7 by default. On long ranges where line of sight is cut early I can see the alternative being better.

This is for #1769 