### PR TITLE
Fix ravager keybind flags

### DIFF
--- a/code/datums/keybinding/xeno.dm
+++ b/code/datums/keybinding/xeno.dm
@@ -65,343 +65,343 @@
 /datum/keybinding/xeno/transfer_plasma
 	key = "Unbound"
 	name = "transfer_plasma"
-	full_name = "Transfer Plasma"
+	full_name = "Drone: Transfer Plasma"
 	description = "Give some of your plasma to a teammate."
 	keybind_signal = COMSIG_XENOABILITY_TRANSFER_PLASMA
 
 /datum/keybinding/xeno/larval_growth_sting
 	key = "Unbound"
 	name = "larval_growth_sting"
-	full_name = "Larval Growth Sting"
+	full_name = "Drone: Larval Growth Sting"
 	description = "Inject an impregnated host with growth serum, causing the larva inside to grow quicker."
 	keybind_signal = COMSIG_XENOABILITY_LARVAL_GROWTH_STING
 
 /datum/keybinding/xeno/shift_spits
 	key = "Unbound"
 	name = "shift_spits"
-	full_name = "Toggle Spit Type"
+	full_name = "Xeno: Toggle Spit Type"
 	description = "Switch from neurotoxin to acid spit."
 	keybind_signal = COMSIG_XENOABILITY_SHIFT_SPITS
 
 /datum/keybinding/xeno/corrosive_acid
 	key = "Unbound"
 	name = "corrosive_acid"
-	full_name = "Corrosive Acid"
+	full_name = "Xeno: Corrosive Acid"
 	description = "Cover an object with acid to slowly melt it. Takes a few seconds."
 	keybind_signal = COMSIG_XENOABILITY_CORROSIVE_ACID
 
 /datum/keybinding/xeno/spray_acid
 	key = "Unbound"
 	name = "spray_acid"
-	full_name = "Spray Acid"
+	full_name = "Xeon: Acid spary"
 	description = "Sprays some acid"
 	keybind_signal = COMSIG_XENOABILITY_SPRAY_ACID
 
 /datum/keybinding/xeno/xeno_spit
 	key = "Unbound"
 	name = "xeno_spit"
-	full_name = "Xeno Spit"
+	full_name = "Xeno: Spit"
 	description = "Spit neurotoxin or acid at your target up to 7 tiles away."
 	keybind_signal = COMSIG_XENOABILITY_XENO_SPIT
 
 /datum/keybinding/xeno/xenohide
 	key = "Unbound"
 	name = "xenohide"
-	full_name = "Hide"
+	full_name = "Xeno: Hide"
 	description = "Causes your sprite to hide behind certain objects and under tables. Not the same as stealth. Does not use plasma."
 	keybind_signal = COMSIG_XENOABILITY_HIDE
 
 /datum/keybinding/xeno/neurotox_sting
 	key = "Unbound"
 	name = "neurotox_sting"
-	full_name = "Neurotoxin Sting"
+	full_name = "Xeno: Neurotoxin Sting"
 	description = "A channeled melee attack that injects the target with neurotoxin over a few seconds, temporarily stunning them."
 	keybind_signal = COMSIG_XENOABILITY_NEUROTOX_STING
 	
 /datum/keybinding/xeno/long_range_sight
 	key = "Unbound"
 	name = "long_range_sight"
-	full_name = "Long Range Sight"
+	full_name = "Boiler: Long Range Sight"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_LONG_RANGE_SIGHT
 
 /datum/keybinding/xeno/toggle_bomb
 	key = "Unbound"
 	name = "toggle_bomb"
-	full_name = "Toggle Bombard Type"
+	full_name = "Boiler: Toggle Bombard Type"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_TOGGLE_BOMB
 
 /datum/keybinding/xeno/bombard
 	key = "Unbound"
 	name = "bombard"
-	full_name = "Bombard"
+	full_name = "Boiler: Bombard"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_BOMBARD
 
 /datum/keybinding/xeno/throw_hugger
 	key = "Unbound"
 	name = "throw_hugger"
-	full_name = "Throw Hugger"
+	full_name = "Carrier: Throw Hugger"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_THROW_HUGGER
 
 /datum/keybinding/xeno/retrieve_egg
 	key = "Unbound"
 	name = "retrieve_egg"
-	full_name = "Retrieve Egg"
+	full_name = "Carrier: Retrieve Egg"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_RETRIEVE_EGG
 
 /datum/keybinding/xeno/place_trap
 	key = "Unbound"
 	name = "place_trap"
-	full_name = "Place Trap"
+	full_name = "Carrier: Place Trap"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_PLACE_TRAP
 
 /datum/keybinding/xeno/spawn_hugger
 	key = "Unbound"
 	name = "spawn_hugger"
-	full_name = "Spawn Hugger"
+	full_name = "Carrier: Spawn Hugger"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_SPAWN_HUGGER
 
 /datum/keybinding/xeno/stomp
 	key = "Unbound"
 	name = "stomp"
-	full_name = "Stomp"
+	full_name = "Crusher: Stomp"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_STOMP
 
 /datum/keybinding/xeno/toggle_charge
 	key = "Unbound"
 	name = "toggle_charge"
-	full_name = "Toggle Charge"
+	full_name = "Crusher: Toggle Charge"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_TOGGLE_CHARGE
 
 /datum/keybinding/xeno/cresttoss
 	key = "Unbound"
 	name = "cresttoss"
-	full_name = "Crest Toss"
+	full_name = "Crusher: Crest Toss"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_CRESTTOSS
 
 /datum/keybinding/xeno/headbutt
 	key = "Unbound"
 	name = "headbutt"
-	full_name = "Headbutt"
+	full_name = "Defender: Headbutt"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_HEADBUTT
 
 /datum/keybinding/xeno/tail_sweep
 	key = "Unbound"
 	name = "tail_sweep"
-	full_name = "Tail Sweep"
+	full_name = "Defender: Tail Sweep"
 	description = "Hit all adjacent units around you, knocking them away and down."
 	keybind_signal = COMSIG_XENOABILITY_TAIL_SWEEP
 
 /datum/keybinding/xeno/crest_defense
 	key = "Unbound"
 	name = "crest_defense"
-	full_name = "Crest Defense"
+	full_name = "Defender: Crest Defense"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_CREST_DEFENSE
 
 /datum/keybinding/xeno/fortify
 	key = "Unbound"
 	name = "fortify"
-	full_name = "Fortify"
+	full_name = "Defender: Fortify"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_FORTIFY
 
 /datum/keybinding/xeno/neuroclaws
 	key = "Unbound"
 	name = "neuroclaws"
-	full_name = "Toggle Neuroclaws"
+	full_name = "Defiler: Toggle Neuroclaws"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_NEUROCLAWS
 
 /datum/keybinding/xeno/emit_neurogas
 	key = "Unbound"
 	name = "emit_neurogas"
-	full_name = "Emit Neurogas"
+	full_name = "Defiler: Emit Neurogas"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_EMIT_NEUROGAS
 
 /datum/keybinding/xeno/salvage_plasma
 	key = "Unbound"
 	name = "salvage_plasma"
-	full_name = "Salvage Plasma"
+	full_name = "Drone: Salvage Plasma"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_SALVAGE_PLASMA
 
 /datum/keybinding/xeno/resin_walker
 	key = "Unbound"
 	name = "resin_walker"
-	full_name = "Toggle Resin Walker"
+	full_name = "Hivelord: Toggle Resin Walker"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_RESIN_WALKER
 
 /datum/keybinding/xeno/build_tunnel
 	key = "Unbound"
 	name = "build_tunnel"
-	full_name = "Build Tunnel"
+	full_name = "Hivelord: Build Tunnel"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_BUILD_TUNNEL
 
 /datum/keybinding/xeno/toggle_stealth
 	key = "Unbound"
 	name = "toggle_stealth"
-	full_name = "Toggle Stealth"
+	full_name = "Hunter: Toggle Stealth"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_TOGGLE_STEALTH
 
 /datum/keybinding/xeno/screech
 	key = "Unbound"
 	name = "screech"
-	full_name = "Screech"
+	full_name = "Queen: Screech"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_SCREECH
 
 /datum/keybinding/xeno/grow_ovipositor
 	key = "Unbound"
 	name = "grow_ovipositor"
-	full_name = "grow_ovipositor"
+	full_name = "Queen: Grow Ovipositor"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_GROW_OVIPOSITOR
 
 /datum/keybinding/xeno/remove_eggsac
 	key = "Unbound"
 	name = "remove_eggsac"
-	full_name = "remove_eggsac"
+	full_name = "Queen: Remove eggsac"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_REMOVE_EGGSAC
 
 /datum/keybinding/xeno/watch_xeno
 	key = "Unbound"
 	name = "watch_xeno"
-	full_name = "watch_xeno"
+	full_name = "Queen: Watch xeno"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_WATCH_XENO
 
 /datum/keybinding/xeno/psychic_whisper
 	key = "Unbound"
 	name = "psychic_whisper"
-	full_name = "psychic_whisper"
+	full_name = "Queen: Psychic Whisper"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_WHISPER
 
 /datum/keybinding/xeno/toggle_queen_zoom
 	key = "Unbound"
 	name = "toggle_queen_zoom"
-	full_name = "toggle_queen_zoom"
+	full_name = "Queen: Toggle Zoom"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_TOGGLE_QUEEN_ZOOM
 
 /datum/keybinding/xeno/xeno_leaders
 	key = "Unbound"
 	name = "xeno_leaders"
-	full_name = "xeno_leaders"
+	full_name = "Queen: Set leader"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_XENO_LEADERS
 
 /datum/keybinding/xeno/queen_heal
 	key = "Unbound"
 	name = "queen_heal"
-	full_name = "queen_heal"
+	full_name = "Queen: Give heal"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_QUEEN_HEAL
 
 /datum/keybinding/xeno/queen_give_plasma
 	key = "Unbound"
 	name = "queen_give_plasma"
-	full_name = "queen_give_plasma"
+	full_name = "Queen: Give plasma"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_QUEEN_GIVE_PLASMA
 
 /datum/keybinding/xeno/queen_give_order
 	key = "Unbound"
 	name = "queen_give_order"
-	full_name = "queen_give_order"
+	full_name = "Queen: Give order"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_QUEEN_GIVE_ORDER
 
 /datum/keybinding/xeno/deevolve
 	key = "Unbound"
 	name = "deevolve"
-	full_name = "deevolve"
+	full_name = "Queen: Devolve xeno"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_DEEVOLVE
 
 /datum/keybinding/xeno/queen_larval_growth
 	key = "Unbound"
 	name = "queen_larval_growth"
-	full_name = "queen_larval_growth"
+	full_name = "Queen: Larva Growth"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_QUEEN_LARVAL_GROWTH
 
 /datum/keybinding/xeno/ravager_charge
 	key = "Unbound"
 	name = "ravager_charge"
-	full_name = "ravager_charge"
+	full_name = "Ravager: Charge"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_RAVAGER_CHARGE
 
 /datum/keybinding/xeno/ravage
 	key = "Unbound"
 	name = "ravage"
-	full_name = "ravage"
+	full_name = "Ravager: Ravage"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_RAVAGE
 
 /datum/keybinding/xeno/second_wind
 	key = "Unbound"
 	name = "second_wind"
-	full_name = "second_wind"
+	full_name = "Ravager: Second Wind"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_SECOND_WIND
 
 /datum/keybinding/xeno/toggle_savage
 	key = "Unbound"
 	name = "toggle_savage"
-	full_name = "toggle_savage"
+	full_name = "Ravager: Toggle Savage"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_TOGGLE_SAVAGE
 
 /datum/keybinding/xeno/pounce
 	key = "Unbound"
 	name = "pounce"
-	full_name = "pounce"
+	full_name = "Runner: Pounce"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_POUNCE
 
 /datum/keybinding/xeno/toggle_agility
 	key = "Unbound"
 	name = "toggle_agility"
-	full_name = "toggle_agility"
+	full_name = "Warrior: Toggle Agility"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_TOGGLE_AGILITY
 
 /datum/keybinding/xeno/lunge
 	key = "Unbound"
 	name = "lunge"
-	full_name = "lunge"
+	full_name = "Warrior: Lunge"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_LUNGE
 
 /datum/keybinding/xeno/fling
 	key = "Unbound"
 	name = "toggle_fling"
-	full_name = "toggle_fling"
+	full_name = "Warrior: Toggle Fling"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_FLING
 
 /datum/keybinding/xeno/punch
 	key = "Unbound"
 	name = "punch"
-	full_name = "punch"
+	full_name = "Warrior: Punch"
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_PUNCH
 

--- a/code/datums/keybinding/xeno.dm
+++ b/code/datums/keybinding/xeno.dm
@@ -72,7 +72,7 @@
 /datum/keybinding/xeno/larval_growth_sting
 	key = "Unbound"
 	name = "larval_growth_sting"
-	full_name = "Drone: Larval Growth Sting"
+	full_name = "Xeno: Larval Growth Sting"
 	description = "Inject an impregnated host with growth serum, causing the larva inside to grow quicker."
 	keybind_signal = COMSIG_XENOABILITY_LARVAL_GROWTH_STING
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -8,6 +8,7 @@
 	ability_name = "charge"
 	cooldown_timer = 30 SECONDS
 	plasma_cost = 80
+	keybind_flags = XACT_KEYBIND_USE_ABILITY | XACT_IGNORE_SELECTED_ABILITY
 	keybind_signal = COMSIG_XENOABILITY_RAVAGER_CHARGE
 
 /datum/action/xeno_action/activable/charge/can_use_ability(atom/A, silent = FALSE, override_flags)
@@ -48,6 +49,7 @@
 	plasma_cost = 40
 	var/last_victim_count = 0
 	cooldown_timer = 10 SECONDS
+	keybind_flags = XACT_KEYBIND_USE_ABILITY | XACT_IGNORE_SELECTED_ABILITY
 	keybind_signal = COMSIG_XENOABILITY_RAVAGE
 
 /datum/action/xeno_action/activable/ravage/on_cooldown_finish()
@@ -103,7 +105,6 @@
 	mechanics_text = "A channeled ability to restore health that uses plasma and rage. Must stand still for it to work."
 	cooldown_timer = 240 SECONDS
 	var/last_rage = 0
-	keybind_flags = XACT_KEYBIND_USE_ABILITY
 	keybind_signal = COMSIG_XENOABILITY_SECOND_WIND
 
 /datum/action/xeno_action/activable/second_wind/get_cooldown()


### PR DESCRIPTION
Fixes #2002 

Also updates the name of some of the xeno keybind abilities in settings.
Adding a the prefix allows them to be sorted, for better QOL.