### PR TITLE
Fix handcuff runtime

### DIFF
--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -5,7 +5,7 @@
 		stop_pulling()
 		handcuffed = restraints
 		handcuffed.RegisterSignal(src, COMSIG_LIVING_DO_RESIST, /obj/item/restraints/.proc/resisted_against)
-	else
+	else if(handcuffed)
 		handcuffed.UnregisterSignal(src, COMSIG_LIVING_DO_RESIST)
 		handcuffed = null
 	update_inv_handcuffed()


### PR DESCRIPTION
Fixes a runtime
```
Runtime in inventory.dm, line 9: Cannot execute null.UnregisterSignal().
proc name: update handcuffed (/mob/living/carbon/proc/update_handcuffed)
src: Young Shrike (/mob/living/carbon/xenomorph/shrike)
src.loc: the river (125,75,1) (/turf/open/ground/river)
call stack:
Young Shrike (/mob/living/carbon/xenomorph/shrike): update handcuffed(null)
Young Shrike (/mob/living/carbon/xenomorph/shrike): revive()
Young Shrike (/mob/living/carbon/xenomorph/shrike): revive()
Distress Signal (/datum/game_mode/distress): end of round deathmatch()
Distress Signal (/datum/game_mode/distress): declare completion(0)
Distress Signal (/datum/game_mode/distress): declare completion(0)
Ticker (/datum/controller/subsystem/ticker): fire(0)
Ticker (/datum/controller/subsystem/ticker): ignite(0)
```