### PR TITLE
Unwielded fire from attachments nerf

### DIFF
--- a/code/modules/projectiles/updated_projectiles/gun_system.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_system.dm
@@ -627,11 +627,17 @@ and you're good to go.
 				to_chat(user, "<span class='warning'>[active_attachable] is empty!</span>")
 				to_chat(user, "<span class='notice'>You disable [active_attachable].</span>")
 				active_attachable.activate_attachment(src, null, TRUE)
-			else
-				active_attachable.fire_attachment(target,src,user) //Fire it.
-				user.camo_off_process(SCOUT_CLOAK_OFF_ATTACK) //Cause cloak to shimmer.
-				last_fired = world.time
-			return
+				return FALSE
+			if(!CHECK_BITFIELD(flags_item, WIELDED))
+				to_chat(user, "<span class='warning'>You need a more secure grip to fire [active_attachable]!")
+				return FALSE
+			if(!wielded_stable())
+				to_chat(user, "<span class='warning'>[active_attachable] is not ready to fire!</span>")
+				return FALSE
+			active_attachable.fire_attachment(target,src,user) //Fire it.
+			user.camo_off_process(SCOUT_CLOAK_OFF_ATTACK) //Cause cloak to shimmer.
+			last_fired = world.time
+			return TRUE
 			//If there's more to the attachment, it will be processed farther down, through in_chamber and regular bullet act.
 
 	/*


### PR DESCRIPTION
## Changelog
:cl:
balance: Due to IMDP memes the UGL and mini-flamer now require a stable two-handed wield to be fired.
/:cl: