### PR TITLE
Fixes ranged warrior punch

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -187,6 +187,8 @@
 		return FALSE
 	if(!isliving(A))
 		return FALSE
+	if(!owner.Adjacent(A))
+		return FALSE
 	var/mob/living/L = A
 	if(L.stat == DEAD || isnestedhost(L)) //Can't bully the dead/nested hosts.
 		return FALSE


### PR DESCRIPTION
For some reason warriors could deliver mighty ranged punches. This is a patch to fix it for next round.
Closes #2089