### PR TITLE
Fixes explosions deleting items

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -95,22 +95,6 @@
 	return ..()
 
 
-/obj/item/ex_act(severity)
-	if(CHECK_BITFIELD(resistance_flags, INDESTRUCTIBLE))
-		return
-	switch(severity)
-		if(1)
-			qdel(src)
-		if(2)
-			if(!prob(50))
-				return
-			qdel(src)
-		if(3)
-			if(!prob(5))
-				return
-			qdel(src)
-
-
 //user: The mob that is suiciding
 //damagetype: The type of damage the item will inflict on the user
 //BRUTELOSS = 1


### PR DESCRIPTION
/tg/ handles this via /obj damage which we don't have yet, and thus it does not make sense for us to have this qdel thing. It's not handled at the /item level which means that removing this won't make porting it any harder, in fact it will make it easier since there's one less piece of code to remove. Right now this is only causing issues.

Fixes: #2076