### PR TITLE
Lockers rework

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -91,9 +91,13 @@
 	#define COMPONENT_MOVABLE_BLOCK_UNCROSS 1
 #define COMSIG_MOVABLE_UNCROSSED "movable_uncrossed"            //from base of atom/movable/Uncrossed(): (/atom/movable)
 #define COMSIG_MOVABLE_RELEASED_FROM_STOMACH "movable_released_from_stomach" //from base of mob/living/carbon/xenomorph/proc/empty_gut(): (prey, predator)
+#define COMSIG_MOVABLE_CLOSET_DUMPED "movable_closet_dumped"
 
 // /turf signals
 #define COMSIG_TURF_CHANGE "turf_change"						//from base of turf/ChangeTurf(): (path, list/new_baseturfs, flags, list/transferring_comps)
+
+// /obj signals
+#define COMSIG_OBJ_SETANCHORED "obj_setanchored"				//called in /obj/structure/setAnchored(): (value)
 
 // /obj/item signals
 #define COMSIG_ITEM_ATTACK "item_attack"						//from base of obj/item/attack(): (/mob/living/target, /mob/living/user)

--- a/code/__DEFINES/objects.dm
+++ b/code/__DEFINES/objects.dm
@@ -186,3 +186,8 @@ GLOBAL_LIST_INIT(restricted_camera_networks, list( //Those networks can only be 
 
 #define TANK_OVERDRIVE_BOOST_DURATION	5 SECONDS
 #define TANK_OVERDRIVE_BOOST_COOLDOWN	20 SECONDS
+
+//Closets
+#define CLOSET_ALLOW_OBJS (1<<0)
+#define CLOSET_ALLOW_DENSE_OBJ (1<<1)
+#define CLOSET_IS_SECURE (1<<2)

--- a/code/controllers/stonedmc/subsystem/atoms.dm
+++ b/code/controllers/stonedmc/subsystem/atoms.dm
@@ -49,10 +49,10 @@ SUBSYSTEM_DEF(atoms)
 
 	initialized = INITIALIZATION_INNEW_REGULAR
 
-	if(late_loaders.len)
+	if(length(late_loaders))
 		for(var/I in late_loaders)
 			var/atom/A = I
-			A.LateInitialize()
+			A.LateInitialize(TRUE)
 		late_loaders.Cut()
 
 /datum/controller/subsystem/atoms/proc/InitAtom(atom/A, list/arguments)
@@ -76,7 +76,7 @@ SUBSYSTEM_DEF(atoms)
 				if(arguments[1])	//mapload
 					late_loaders += A
 				else
-					A.LateInitialize()
+					A.LateInitialize(FALSE)
 			if(INITIALIZE_HINT_QDEL)
 				qdel(A)
 				qdeleted = TRUE

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -472,7 +472,7 @@ Proc for attack log creation, because really why not
 
 
 //called if Initialize returns INITIALIZE_HINT_LATELOAD
-/atom/proc/LateInitialize()
+/atom/proc/LateInitialize(mapload)
 	return
 
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -853,7 +853,10 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 /obj/item/proc/play_tool_sound(atom/target, volume)
 	if(!target || !usesound || !volume)
 		return
-	playsound(target, usesound, volume, 1)
+	var/played_sound = usesound
+	if(islist(usesound))
+		played_sound = pick(usesound)
+	playsound(target, played_sound, volume, 1)
 
 
 // Used in a callback that is passed by use_tool into do_after call. Do not override, do not call manually.

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -66,12 +66,13 @@
 	open_sound = 'sound/items/zip.ogg'
 	close_sound = 'sound/items/zip.ogg'
 	var/item_path = /obj/item/bodybag
-	density = 0
-	storage_capacity = (mob_size * 2) - 1
-	anchored = 0
+	density = FALSE
+	mob_storage_capacity = 1
+	storage_capacity = 3 //Just room enough for that stripped armor, gun and whatnot.
+	anchored = FALSE
 	drag_delay = 2 //slightly easier than to drag the body directly.
 	var/obj/structure/bed/roller/roller_buckled //the roller bed this bodybag is attached to.
-	store_items = FALSE
+
 
 /obj/structure/closet/bodybag/proc/update_name()
 	if(opened)
@@ -107,27 +108,15 @@
 		overlays.Cut()
 
 
-/obj/structure/closet/bodybag/store_mobs(stored_units) // overriding this
-	var/list/dead_mobs = list()
-	for(var/mob/living/M in loc)
-		if(M.buckled)
-			continue
-		if(M.stat != DEAD) // covers alive mobs
-			continue
-		if(!ishuman(M)) // all the dead other shit
-			dead_mobs += M
-			continue
-		var/mob/living/carbon/human/H = M
-		if(check_tod(H) || issynth(H)) // revivable
-			if(H.is_revivable() && H.get_ghost()) // definitely revivable
-				continue
-		dead_mobs += M
-	var/mob/living/mob_to_store
-	if(dead_mobs.len)
-		mob_to_store = pick(dead_mobs)
-		mob_to_store.forceMove(src)
-		stored_units += mob_size
-	return stored_units
+/obj/structure/closet/bodybag/closet_special_handling(mob/living/mob_to_stuff) // overriding this
+	if(mob_to_stuff.stat != DEAD) //Only the dead for bodybags.
+		return FALSE
+	if(ishuman(mob_to_stuff))
+		var/mob/living/carbon/human/human_to_stuff = mob_to_stuff
+		if((!human_to_stuff.undefibbable || issynth(human_to_stuff)))
+			return FALSE //We don't want to store those that can be revived.
+	return TRUE
+
 
 /obj/structure/closet/bodybag/close()
 	if(..())
@@ -190,7 +179,6 @@
 	desc = "A reusable plastic bag designed to prevent additional damage to an occupant."
 	icon = 'icons/obj/cryobag.dmi'
 	item_path = /obj/item/bodybag/cryobag
-	store_items = FALSE
 	var/mob/living/carbon/human/stasis_mob //the mob in stasis
 	var/used = 0
 	var/last_use = 0 //remembers the value of used, to delay crostasis start.
@@ -242,20 +230,12 @@
 		new /obj/item/trash/used_stasis_bag(loc)
 		qdel(src)
 
-/obj/structure/closet/bodybag/cryobag/store_mobs(stored_units) // overriding this
-	var/list/mobs_can_store = list()
-	for(var/mob/living/carbon/human/H in loc)
-		if(H.buckled)
-			continue
-		if(H.stat == DEAD) // dead, nope
-			continue
-		mobs_can_store += H
-	var/mob/living/carbon/human/mob_to_store
-	if(mobs_can_store.len)
-		mob_to_store = pick(mobs_can_store)
-		mob_to_store.forceMove(src)
-		stored_units += mob_size
-	return stored_units
+
+/obj/structure/closet/bodybag/cryobag/closet_special_handling(mob/living/mob_to_stuff) // overriding this
+	if(mob_to_stuff.stat == DEAD) // dead, nope
+		return FALSE
+	return TRUE
+
 
 /obj/structure/closet/bodybag/cryobag/close()
 	. = ..()

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -113,7 +113,7 @@
 		return FALSE
 	if(ishuman(mob_to_stuff))
 		var/mob/living/carbon/human/human_to_stuff = mob_to_stuff
-		if((!human_to_stuff.undefibbable || issynth(human_to_stuff)))
+		if((!check_tod(human_to_stuff) || issynth(human_to_stuff)) && human_to_stuff.is_revivable())
 			return FALSE //We don't want to store those that can be revived.
 	return TRUE
 

--- a/code/game/objects/items/marine_gear.dm
+++ b/code/game/objects/items/marine_gear.dm
@@ -98,18 +98,6 @@
 		playsound(loc,'sound/effects/cloak_scout_off.ogg', 15, 1)
 		alpha = initial(alpha) //stealth mode disengaged
 
-/obj/structure/closet/bodybag/tarp/store_mobs(stored_units)
-	var/list/mobs_can_store = list()
-	for(var/mob/living/carbon/human/H in loc)
-		if(H.buckled)
-			continue
-		mobs_can_store += H
-	var/mob/living/carbon/human/mob_to_store
-	if(mobs_can_store.len)
-		mob_to_store = pick(mobs_can_store)
-		mob_to_store.forceMove(src)
-		stored_units += mob_size
-	return stored_units
 
 /obj/structure/closet/bodybag/tarp/snow
 	icon_state = "snowtarp_closed"

--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -23,9 +23,10 @@
 	icon_state = "wrench"
 	flags_atom = CONDUCT
 	flags_equip_slot = ITEM_SLOT_BELT
-	force = 5.0
-	throwforce = 7.0
-	w_class = 2.0
+	force = 5
+	throwforce = 7
+	w_class = WEIGHT_CLASS_SMALL
+	usesound = 'sound/items/ratchet.ogg'
 	matter = list("metal" = 150)
 	origin_tech = "materials=1;engineering=1"
 	attack_verb = list("bashed", "battered", "bludgeoned", "whacked")
@@ -143,11 +144,12 @@
 	flags_equip_slot = ITEM_SLOT_BELT
 
 	//Amount of OUCH when it's thrown
-	force = 3.0
-	throwforce = 5.0
+	force = 3
+	throwforce = 5
+	usesound = list('sound/items/welder.ogg', 'sound/items/welder2.ogg')
 	throw_speed = 1
 	throw_range = 5
-	w_class = 2.0
+	w_class = WEIGHT_CLASS_SMALL
 	tool_behaviour = TOOL_WELDER
 
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -42,6 +42,10 @@
 		unbuckle()
 	return ..()
 
+/obj/proc/setAnchored(anchorvalue)
+	SEND_SIGNAL(src, COMSIG_OBJ_SETANCHORED, anchorvalue)
+	anchored = anchorvalue
+
 /obj/ex_act()
 	if(CHECK_BITFIELD(resistance_flags, INDESTRUCTIBLE))
 		return

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -417,7 +417,6 @@
 			to_chat(user, "<span class='notice'>Access Denied</span>")
 		return FALSE
 
-	add_fingerprint(user)
 	locked = !locked
 	user.visible_message("<span class='notice'>[user] [locked ? null : "un"]locks [src].</span>",
 						"<span class='notice'>You [locked ? null : "un"]lock [src].</span>")

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -24,7 +24,7 @@
 	var/closet_flags = NONE
 	var/max_mob_size = MOB_SIZE_HUMAN //Biggest mob_size accepted by the container
 	var/mob_storage_capacity = 1 // how many max_mob_size'd mob/living can fit together inside a closet.
-	var/storage_capacity = 30 //This is so that someone can't pack hundreds of items in a locker/crate
+	var/storage_capacity = 50 //This is so that someone can't pack hundreds of items in a locker/crate
 							//then open it in a populated area to crash clients.
 	var/mob_size_counter = 0
 	var/item_size_counter = 0
@@ -219,40 +219,10 @@
 			MouseDrop_T(G.grabbed_thing, user)      //act like they were dragged onto the closet
 			return
 
-		if(iswelder(I))
-			var/obj/item/tool/weldingtool/WT = I
-			if(!WT.remove_fuel(0, user))
-				to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
-				return
-			new /obj/item/stack/sheet/metal(drop_location())
-			visible_message("<span class='notice'>\The [src] has been cut apart by [user] with [WT].</span>", "You hear welding.")
-			qdel(src)
-			return
-
 		user.transferItemToLoc(I, drop_location())
 		return
 
 	if(istype(I, /obj/item/packageWrap))
-		return
-
-	if(iswelder(I))
-		var/obj/item/tool/weldingtool/WT = I
-		if(!WT.remove_fuel(0,user))
-			to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
-			return
-		welded = !welded
-		update_icon()
-		visible_message("<span class='warning'>[src] has been [welded ? "welded shut" : "unwelded"] by [user.name].</span>", "You hear welding.")
-		return
-
-	if(iswrench(I))
-		if(isspaceturf(loc) && !anchored)
-			return
-		setAnchored(!anchored)
-		I.play_tool_sound(src, 75)
-		user.visible_message("<span class='notice'>[user] [anchored ? "anchored" : "unanchored"] \the [src] [anchored ? "to" : "from"] the ground.</span>", \
-						"<span class='notice'>You [anchored ? "anchored" : "unanchored"] \the [src] [anchored ? "to" : "from"] the ground.</span>", \
-						"<span class='italics'>You hear a ratchet.</span>")
 		return
 
 	if(I.GetID())
@@ -261,6 +231,42 @@
 		return
 
 	return FALSE
+
+
+/obj/structure/closet/welder_act(mob/living/user, obj/item/tool/weldingtool/welder)
+	if(!welder.isOn())
+		return FALSE
+
+	if(opened)
+		if(!welder.remove_fuel(0, user))
+			to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
+			return TRUE
+		new /obj/item/stack/sheet/metal(drop_location())
+		visible_message("<span class='notice'>\The [src] has been cut apart by [user] with [welder].</span>", "You hear welding.")
+		qdel(src)
+		return TRUE
+
+	if(!welder.remove_fuel(0,user))
+		to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
+		return TRUE
+	welded = !welded
+	update_icon()
+	visible_message("<span class='warning'>[src] has been [welded ? "welded shut" : "unwelded"] by [user.name].</span>", "You hear welding.")
+	return TRUE
+
+
+/obj/structure/closet/wrench_act(mob/living/user, obj/item/tool/wrench/wrenchy_tool)
+	if(opened)
+		return FALSE
+	if(isspaceturf(loc) && !anchored)
+		to_chat(user, "<span class='warning'>You need a firmer floor to wrench [src] down.</span>")
+		return TRUE
+	setAnchored(!anchored)
+	wrenchy_tool.play_tool_sound(src, 75)
+	user.visible_message("<span class='notice'>[user] [anchored ? "anchored" : "unanchored"] \the [src] [anchored ? "to" : "from"] the ground.</span>", \
+					"<span class='notice'>You [anchored ? "anchored" : "unanchored"] \the [src] [anchored ? "to" : "from"] the ground.</span>", \
+					"<span class='italics'>You hear a ratchet.</span>")
+	return TRUE
 
 
 /obj/structure/closet/MouseDrop_T(atom/movable/O, mob/user)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -201,36 +201,23 @@
 /obj/structure/closet/attackby(obj/item/I, mob/user, params)
 	if(user in src)
 		return FALSE
-	if(tool_interact(I, user))
-		return TRUE // No afterattack
-	return ..()
-
-
-/obj/structure/closet/proc/tool_interact(obj/item/I, mob/user)
-	. = TRUE //returns TRUE if attackBy call shouldnt be continued (because tool was used/closet was of wrong type), FALSE if otherwise
 	if(opened)
-		if(I.flags_item & ITEM_ABSTRACT)
-			return FALSE
-
 		if(istype(I, /obj/item/grab))
 			var/obj/item/grab/G = I
 			if(!G.grabbed_thing)
 				CRASH("/obj/item/grab without a grabbed_thing in tool_interact()")
 			MouseDrop_T(G.grabbed_thing, user)      //act like they were dragged onto the closet
-			return
-
+			return ..()
+		if(I.flags_item & ITEM_ABSTRACT)
+			return ..()
 		user.transferItemToLoc(I, drop_location())
-		return
-
-	if(istype(I, /obj/item/packageWrap))
-		return
+		return ..()
 
 	if(I.GetID())
 		if(!togglelock(user, TRUE))
 			toggle(user)
-		return
 
-	return FALSE
+	return ..()
 
 
 /obj/structure/closet/welder_act(mob/living/user, obj/item/tool/weldingtool/welder)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -1,3 +1,8 @@
+#define CLOSET_INSERT_END -1
+#define CLOSET_INSERT_FAIL 0
+#define CLOSET_INSERT_SUCCESS 1
+
+
 /obj/structure/closet
 	name = "closet"
 	desc = "It's a basic storage unit."
@@ -12,35 +17,47 @@
 	var/welded = FALSE
 	var/locked = FALSE
 	var/wall_mounted = FALSE //never solid (You can always pass over it)
-	max_integrity = 100
+	max_integrity = 200
+	armor = list("melee" = 20, "bullet" = 10, "laser" = 10, "energy" = 0, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 70, "acid" = 60)
 	var/breakout_time = 2 MINUTES
 	var/lastbang = FALSE
+	var/closet_flags = NONE
+	var/max_mob_size = MOB_SIZE_HUMAN //Biggest mob_size accepted by the container
+	var/mob_storage_capacity = 1 // how many max_mob_size'd mob/living can fit together inside a closet.
 	var/storage_capacity = 30 //This is so that someone can't pack hundreds of items in a locker/crate
 							//then open it in a populated area to crash clients.
+	var/mob_size_counter = 0
+	var/item_size_counter = 0
 	var/open_sound = 'sound/machines/click.ogg'
 	var/close_sound = 'sound/machines/click.ogg'
-
-	var/store_items = TRUE
-	var/store_mobs = TRUE
 
 	var/closet_stun_delay = 1
 
 	anchored = TRUE
 
-	var/const/mob_size = 15
+
+/obj/structure/closet/Initialize(mapload, ...)
+	. = ..()
+	return INITIALIZE_HINT_LATELOAD
+
+
+/obj/structure/closet/LateInitialize(mapload)
+	. = ..()
+	if(mapload && !opened)		// if closed, any item at the crate's loc is put in the contents
+		take_contents()
+		update_icon()
+	PopulateContents()
+
+
+//USE THIS TO FILL IT, NOT INITIALIZE OR NEW
+/obj/structure/closet/proc/PopulateContents()
+	return
+
 
 /obj/structure/closet/open
 	icon_state = "open"
 	density = FALSE
 	opened = TRUE
-
-/obj/structure/closet/Initialize()
-	. = ..()
-	if(!opened)		// if closed, any item at the crate's loc is put in the contents
-		for(var/obj/item/I in loc)
-			if(I.density || I.anchored || I == src)
-				continue
-			I.loc = src
 
 
 /obj/structure/closet/CanPass(atom/movable/mover, turf/target)
@@ -49,96 +66,82 @@
 	else
 		return !density
 
-/obj/structure/closet/proc/can_open()
-	if(src.welded)
+/obj/structure/closet/proc/can_open(mob/living/user)
+	if(welded || locked)
+		if(user)
+			to_chat(user, "<span class='notice'>It won't budge!</span>")
 		return FALSE
 	return TRUE
 
-/obj/structure/closet/proc/can_close()
-	for(var/obj/structure/closet/closet in get_turf(src))
+
+/obj/structure/closet/proc/can_close(mob/living/user)
+	for(var/obj/structure/closet/closet in loc)
 		if(closet != src && !closet.wall_mounted)
+			if(user)
+				to_chat(user, "<span class='danger'>There's more than one closet here, it's too cramped to close.</span>" )
 			return FALSE
-	for(var/mob/living/carbon/xenomorph/Xeno in get_turf(src))
-		return FALSE
+	for(var/mob/living/mob_to_stuff in loc)
+		if(mob_to_stuff.anchored || mob_to_stuff.mob_size > max_mob_size)
+			if(user)
+				to_chat(user, "<span class='danger'>[mob_to_stuff] is preventing [src] from closing.</span>")
+			return FALSE
 	return TRUE
+
 
 /obj/structure/closet/proc/dump_contents()
-
-	for(var/obj/I in src)
-		I.forceMove(loc)
-
-	for(var/mob/living/L in src)
-		L.forceMove(loc)
-		L.Stun(closet_stun_delay)//Action delay when going out of a closet
-		if(!L.lying && L.stunned)
-			L.visible_message("<span class='warning'>[L] suddenly gets out of [src]!",
-			"<span class='warning'>You get out of [src] and get your bearings!")
-		UnregisterSignal(L, COMSIG_LIVING_DO_RESIST)
+	var/atom/drop_loc = drop_location()
+	for(var/thing in src)
+		var/atom/movable/stuffed_thing = thing
+		stuffed_thing.forceMove(drop_loc)
+		SEND_SIGNAL(stuffed_thing, COMSIG_MOVABLE_CLOSET_DUMPED, src)
+		if(throwing) // you keep some momentum when getting out of a thrown closet
+			step(stuffed_thing, dir)
+	mob_size_counter = 0
+	item_size_counter = 0
 
 
-/obj/structure/closet/proc/open()
-	if(opened)
+/obj/structure/closet/proc/take_contents()
+	for(var/mapped_thing in drop_location())
+		if(mapped_thing == src)
+			continue
+		if(insert(mapped_thing) == CLOSET_INSERT_END) // limit reached
+			break
+
+
+/obj/structure/closet/proc/open(mob/living/user)
+	if(opened || !can_open(user))
 		return FALSE
-
-	if(!can_open())
-		return FALSE
-
-	dump_contents()
-
 	opened = TRUE
+	density = FALSE
+	dump_contents()
 	update_icon()
 	playsound(loc, open_sound, 15, 1)
-	density = FALSE
 	return TRUE
 
-/obj/structure/closet/proc/close()
-	if(!src.opened)
+
+/obj/structure/closet/proc/insert(atom/movable/thing_to_insert)
+	if(length(contents) >= storage_capacity)
+		return CLOSET_INSERT_END
+	if(!thing_to_insert.closet_insertion_allowed(src))
+		return CLOSET_INSERT_FAIL
+	thing_to_insert.forceMove(src)
+	return CLOSET_INSERT_SUCCESS
+
+
+/obj/structure/closet/proc/close(mob/living/user)
+	if(!opened || !can_close(user))
 		return FALSE
-	if(!src.can_close())
-		return FALSE
-
-	var/stored_units = 0
-	if(store_items)
-		stored_units = store_items(stored_units)
-	if(store_mobs)
-		stored_units = store_mobs(stored_units)
-
-	opened = FALSE
-	update_icon()
-
+	take_contents()
 	playsound(loc, close_sound, 15, 1)
+	opened = FALSE
 	density = TRUE
+	update_icon()
 	return TRUE
 
-/obj/structure/closet/proc/store_items(stored_units)
-	for(var/obj/item/I in loc)
-		var/item_size = CEILING(I.w_class / 2, 1)
-		if(stored_units + item_size > storage_capacity)
-			continue
-		if(!I.anchored)
-			I.loc = src
-			stored_units += item_size
-	return stored_units
-
-/obj/structure/closet/proc/store_mobs(stored_units)
-	for(var/mob/living/L in loc)
-		if(stored_units + mob_size > storage_capacity)
-			break
-		if(L.buckled)
-			continue
-		L.smokecloak_off()
-		RegisterSignal(L, COMSIG_LIVING_DO_RESIST, .proc/resisted_against)
-		L.forceMove(src)
-
-		stored_units += mob_size
-	return stored_units
 
 /obj/structure/closet/proc/toggle(mob/living/user)
-	user.next_move = world.time + 5
-	if(!(src.opened ? src.close() : src.open()))
-		to_chat(user, "<span class='notice'>It won't budge!</span>")
-		return FALSE
-	return TRUE
+	return opened ? close(user) : open(user)
+
 
 // this should probably use dump_contents()
 /obj/structure/closet/ex_act(severity)
@@ -178,8 +181,7 @@
 /obj/structure/closet/attack_animal(mob/living/user)
 	if(user.wall_smash)
 		visible_message("<span class='warning'> [user] destroys the [src]. </span>")
-		for(var/atom/movable/A as mob|obj in src)
-			A.loc = loc
+		dump_contents()
 		qdel(src)
 
 /obj/structure/closet/attack_alien(mob/living/carbon/xenomorph/M)
@@ -197,36 +199,43 @@
 		return attack_paw(M)
 
 /obj/structure/closet/attackby(obj/item/I, mob/user, params)
-	. = ..()
+	if(user in src)
+		return FALSE
+	if(tool_interact(I, user))
+		return TRUE // No afterattack
+	return ..()
 
+
+/obj/structure/closet/proc/tool_interact(obj/item/I, mob/user)
+	. = TRUE //returns TRUE if attackBy call shouldnt be continued (because tool was used/closet was of wrong type), FALSE if otherwise
 	if(opened)
-		if(istype(I, /obj/item/grab))
-			if(isxeno(user))
-				return
-			var/obj/item/grab/G = I
-			if(!G.grabbed_thing)
-				return
-
-			MouseDrop_T(G.grabbed_thing, user)      //act like they were dragged onto the closet
-
-		else if(I.flags_item & ITEM_ABSTRACT)
+		if(I.flags_item & ITEM_ABSTRACT)
 			return FALSE
 
-		else if(iswelder(I))
+		if(istype(I, /obj/item/grab))
+			var/obj/item/grab/G = I
+			if(!G.grabbed_thing)
+				CRASH("/obj/item/grab without a grabbed_thing in tool_interact()")
+			MouseDrop_T(G.grabbed_thing, user)      //act like they were dragged onto the closet
+			return
+
+		if(iswelder(I))
 			var/obj/item/tool/weldingtool/WT = I
 			if(!WT.remove_fuel(0, user))
 				to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
 				return
-			new /obj/item/stack/sheet/metal(loc)
+			new /obj/item/stack/sheet/metal(drop_location())
 			visible_message("<span class='notice'>\The [src] has been cut apart by [user] with [WT].</span>", "You hear welding.")
 			qdel(src)
+			return
 
-		user.transferItemToLoc(I, loc)
-
-	else if(istype(I, /obj/item/packageWrap))
+		user.transferItemToLoc(I, drop_location())
 		return
 
-	else if(iswelder(I))
+	if(istype(I, /obj/item/packageWrap))
+		return
+
+	if(iswelder(I))
 		var/obj/item/tool/weldingtool/WT = I
 		if(!WT.remove_fuel(0,user))
 			to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
@@ -234,8 +243,24 @@
 		welded = !welded
 		update_icon()
 		visible_message("<span class='warning'>[src] has been [welded ? "welded shut" : "unwelded"] by [user.name].</span>", "You hear welding.")
-	else
-		return attack_hand(user)
+		return
+
+	if(iswrench(I))
+		if(isspaceturf(loc) && !anchored)
+			return
+		setAnchored(!anchored)
+		I.play_tool_sound(src, 75)
+		user.visible_message("<span class='notice'>[user] [anchored ? "anchored" : "unanchored"] \the [src] [anchored ? "to" : "from"] the ground.</span>", \
+						"<span class='notice'>You [anchored ? "anchored" : "unanchored"] \the [src] [anchored ? "to" : "from"] the ground.</span>", \
+						"<span class='italics'>You hear a ratchet.</span>")
+		return
+
+	if(I.GetID())
+		if(!togglelock(user, TRUE))
+			toggle(user)
+		return
+
+	return FALSE
 
 
 /obj/structure/closet/MouseDrop_T(atom/movable/O, mob/user)
@@ -289,11 +314,13 @@
 /obj/structure/closet/attack_paw(mob/user as mob)
 	return attack_hand(user)
 
+
 /obj/structure/closet/attack_hand(mob/living/user)
 	. = ..()
 	if(.)
 		return
 	return toggle(user)
+
 
 /obj/structure/closet/verb/verb_toggleopen()
 	set src in oview(1)
@@ -364,7 +391,108 @@
 		update_icon()
 
 
+/obj/structure/closet/AltClick(mob/user)
+	. = ..()
+	return togglelock(user)
+
+
+/obj/structure/closet/proc/togglelock(mob/living/user, silent)
+	if(!CHECK_BITFIELD(closet_flags, CLOSET_IS_SECURE))
+		return FALSE
+	if(!user.IsAdvancedToolUser())
+		if(!silent)
+			to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
+		return
+	if(opened)
+		if(!silent)
+			to_chat(user, "<span class='notice'>Close \the [src] first.</span>")
+		return
+	if(broken)
+		if(!silent)
+			to_chat(user, "<span class='warning'>\The [src] is broken!</span>")
+		return FALSE
+
+	if(!allowed(user))
+		if(!silent)
+			to_chat(user, "<span class='notice'>Access Denied</span>")
+		return FALSE
+
+	add_fingerprint(user)
+	locked = !locked
+	user.visible_message("<span class='notice'>[user] [locked ? null : "un"]locks [src].</span>",
+						"<span class='notice'>You [locked ? null : "un"]lock [src].</span>")
+	update_icon()
+	return TRUE
+
+
 /obj/structure/closet/contents_explosion(severity, target)
 	for(var/i in contents)
 		var/atom/A = i
 		A.ex_act(severity, target)
+
+
+/obj/structure/closet/proc/closet_special_handling(mob/living/mob_to_stuff)
+	return TRUE //We are permisive by default.
+
+
+//Redefined procs for closets
+
+/atom/movable/proc/closet_insertion_allowed(obj/structure/closet/destination)
+	return FALSE
+
+
+/mob/living/closet_insertion_allowed(obj/structure/closet/destination)
+	if(anchored || buckled)
+		return FALSE
+	if(mob_size + destination.mob_size_counter > destination.mob_storage_capacity * destination.max_mob_size)
+		return FALSE
+	if(!destination.closet_special_handling(src))
+		return FALSE
+	destination.mob_size_counter += mob_size
+	stop_pulling()
+	smokecloak_off()
+	destination.RegisterSignal(src, COMSIG_LIVING_DO_RESIST, /obj/structure/closet/.proc/resisted_against)
+	RegisterSignal(src, COMSIG_MOVABLE_CLOSET_DUMPED, .proc/on_closet_dump)
+	return TRUE
+
+
+/obj/closet_insertion_allowed(obj/structure/closet/destination)
+	if(!CHECK_BITFIELD(destination.closet_flags, CLOSET_ALLOW_OBJS))
+		return FALSE
+	if(anchored)
+		return FALSE
+	if((!CHECK_BITFIELD(destination.closet_flags, CLOSET_ALLOW_DENSE_OBJ) && density))
+		return FALSE
+	return TRUE
+
+
+/obj/item/closet_insertion_allowed(obj/structure/closet/destination)
+	if(anchored)
+		return FALSE
+	if((!CHECK_BITFIELD(destination.closet_flags, CLOSET_ALLOW_DENSE_OBJ) && density))
+		return FALSE
+	if(CHECK_BITFIELD(flags_item, DELONDROP))
+		return FALSE
+	var/item_size = CEILING(w_class * 0.5, 1)
+	if(item_size + destination.item_size_counter > destination.storage_capacity)
+		return FALSE
+	destination.item_size_counter += item_size
+	return TRUE
+
+
+/obj/structure/closet/closet_insertion_allowed(obj/structure/closet/destination)
+	return FALSE
+
+
+/mob/living/proc/on_closet_dump(datum/source, obj/structure/closet/origin)
+	Stun(origin.closet_stun_delay)//Action delay when going out of a closet
+	if(!lying && stunned)
+		visible_message("<span class='warning'>[src] suddenly gets out of [origin]!",
+		"<span class='warning'>You get out of [origin] and get your bearings!")
+	origin.UnregisterSignal(src, COMSIG_LIVING_DO_RESIST)
+	UnregisterSignal(src, COMSIG_MOVABLE_CLOSET_DUMPED)
+
+
+#undef CLOSET_INSERT_END
+#undef CLOSET_INSERT_FAIL
+#undef CLOSET_INSERT_SUCCESS

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -225,7 +225,7 @@
 		return FALSE
 
 	if(opened)
-		if(!welder.remove_fuel(0, user))
+		if(!welder.use_tool(src, user, 2 SECONDS, 1, 50))
 			to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
 			return TRUE
 		new /obj/item/stack/sheet/metal(drop_location())
@@ -233,7 +233,7 @@
 		qdel(src)
 		return TRUE
 
-	if(!welder.remove_fuel(0,user))
+	if(!welder.use_tool(src, user, 2 SECONDS, 1, 50))
 		to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
 		return TRUE
 	welded = !welded

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -466,7 +466,7 @@
 		return FALSE
 	if(anchored)
 		return FALSE
-	if((!CHECK_BITFIELD(destination.closet_flags, CLOSET_ALLOW_DENSE_OBJ) && density))
+	if(!CHECK_BITFIELD(destination.closet_flags, CLOSET_ALLOW_DENSE_OBJ) && density)
 		return FALSE
 	return TRUE
 
@@ -474,7 +474,7 @@
 /obj/item/closet_insertion_allowed(obj/structure/closet/destination)
 	if(anchored)
 		return FALSE
-	if((!CHECK_BITFIELD(destination.closet_flags, CLOSET_ALLOW_DENSE_OBJ) && density))
+	if(!CHECK_BITFIELD(destination.closet_flags, CLOSET_ALLOW_DENSE_OBJ) && density)
 		return FALSE
 	if(CHECK_BITFIELD(flags_item, DELONDROP))
 		return FALSE

--- a/code/game/objects/structures/crates_lockers/closets/secure/cm_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cm_closets.dm
@@ -14,10 +14,6 @@
 
 /obj/structure/closet/secure_closet/marine/Initialize()
 	. = ..()
-	new /obj/item/clothing/shoes/marine(src)
-	switch(SSmapping.config.map_name)
-		if(MAP_ICE_COLONY)
-			new /obj/item/clothing/mask/rebreather/scarf(src)
 	if(closet_squad)
 		icon_state = "squad_[closet_squad]_locked"
 		icon_closed = "squad_[closet_squad]_unlocked"
@@ -26,9 +22,17 @@
 		icon_broken = "squad_[closet_squad]_emmaged"
 		icon_off = "squad_[closet_squad]_off"
 
+
+/obj/structure/closet/secure_closet/marine/PopulateContents()
+	new /obj/item/clothing/shoes/marine(src)
+	switch(SSmapping.config.map_name)
+		if(MAP_ICE_COLONY)
+			new /obj/item/clothing/mask/rebreather/scarf(src)
+
+
 // STANDARD MARINE
 
-/obj/structure/closet/secure_closet/marine/standard/Initialize()
+/obj/structure/closet/secure_closet/marine/standard/PopulateContents()
 	. = ..()
 	new /obj/item/clothing/suit/storage/marine(src)
 	new /obj/item/storage/belt/marine(src)
@@ -40,7 +44,7 @@
 	req_access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_ALPHA)
 	closet_squad = "alpha"
 
-/obj/structure/closet/secure_closet/marine/standard/alpha/Initialize()
+/obj/structure/closet/secure_closet/marine/standard/alpha/PopulateContents()
 	. = ..()
 	new /obj/item/radio/headset/almayer/marine/alpha(src)
 	new /obj/item/clothing/gloves/marine/alpha(src)
@@ -51,7 +55,7 @@
 	req_access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_BRAVO)
 	closet_squad = "bravo"
 
-/obj/structure/closet/secure_closet/marine/standard/bravo/Initialize()
+/obj/structure/closet/secure_closet/marine/standard/bravo/PopulateContents()
 	. = ..()
 	new /obj/item/radio/headset/almayer/marine/bravo(src)
 	new /obj/item/clothing/gloves/marine/bravo(src)
@@ -62,7 +66,7 @@
 	req_access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_CHARLIE)
 	closet_squad = "charlie"
 
-/obj/structure/closet/secure_closet/marine/standard/charlie/Initialize()
+/obj/structure/closet/secure_closet/marine/standard/charlie/PopulateContents()
 	. = ..()
 	new /obj/item/radio/headset/almayer/marine/charlie(src)
 	new /obj/item/clothing/gloves/marine/charlie(src)
@@ -73,7 +77,7 @@
 	req_access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_DELTA)
 	closet_squad = "delta"
 
-/obj/structure/closet/secure_closet/marine/standard/delta/Initialize()
+/obj/structure/closet/secure_closet/marine/standard/delta/PopulateContents()
 	. = ..()
 	new /obj/item/radio/headset/almayer/marine/delta(src)
 	new /obj/item/clothing/gloves/marine/delta(src)
@@ -81,7 +85,7 @@
 
 // MARINE LEADER
 
-/obj/structure/closet/secure_closet/marine/leader/Initialize()
+/obj/structure/closet/secure_closet/marine/leader/PopulateContents()
 	. = ..()
 	new /obj/item/clothing/suit/storage/marine/leader(src)
 	new /obj/item/storage/belt/marine(src)
@@ -93,7 +97,7 @@
 	req_access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_ALPHA, ACCESS_MARINE_LEADER)
 	closet_squad = "alpha"
 
-/obj/structure/closet/secure_closet/marine/leader/alpha/Initialize()
+/obj/structure/closet/secure_closet/marine/leader/alpha/PopulateContents()
 	. = ..()
 	new /obj/item/clothing/gloves/marine/alpha(src)
 	new /obj/item/radio/headset/almayer/marine/alpha/lead(src)
@@ -104,7 +108,7 @@
 	req_access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_BRAVO, ACCESS_MARINE_LEADER)
 	closet_squad = "bravo"
 
-/obj/structure/closet/secure_closet/marine/leader/bravo/Initialize()
+/obj/structure/closet/secure_closet/marine/leader/bravo/PopulateContents()
 	. = ..()
 	new /obj/item/clothing/gloves/marine/bravo(src)
 	new /obj/item/radio/headset/almayer/marine/bravo/lead(src)
@@ -115,7 +119,7 @@
 	req_access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_CHARLIE, ACCESS_MARINE_LEADER)
 	closet_squad = "charlie"
 
-/obj/structure/closet/secure_closet/marine/leader/charlie/Initialize()
+/obj/structure/closet/secure_closet/marine/leader/charlie/PopulateContents()
 	. = ..()
 	new /obj/item/clothing/gloves/marine/charlie(src)
 	new /obj/item/radio/headset/almayer/marine/charlie/lead(src)
@@ -125,7 +129,7 @@
 	req_access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_DELTA, ACCESS_MARINE_LEADER)
 	closet_squad = "delta"
 
-/obj/structure/closet/secure_closet/marine/leader/delta/Initialize()
+/obj/structure/closet/secure_closet/marine/leader/delta/PopulateContents()
 	. = ..()
 	new /obj/item/clothing/gloves/marine/delta(src)
 	new /obj/item/radio/headset/almayer/marine/delta/lead(src)
@@ -138,7 +142,7 @@
 	slotlocked = TRUE
 	resistance_flags = INDESTRUCTIBLE
 
-/obj/structure/closet/secure_closet/marine/engi/Initialize()
+/obj/structure/closet/secure_closet/marine/engi/PopulateContents()
 	. = ..()
 	new /obj/item/storage/belt/utility/full(src)
 	new /obj/item/clothing/glasses/welding(src)
@@ -152,7 +156,7 @@
 	req_access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_ALPHA, ACCESS_MARINE_ENGPREP)
 	closet_squad = "alpha"
 
-/obj/structure/closet/secure_closet/marine/engi/alpha/Initialize()
+/obj/structure/closet/secure_closet/marine/engi/alpha/PopulateContents()
 	. = ..()
 	new /obj/item/clothing/gloves/marine/alpha/insulated(src)
 	new /obj/item/radio/headset/almayer/marine/alpha/engi(src)
@@ -163,7 +167,7 @@
 	req_access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_BRAVO, ACCESS_MARINE_ENGPREP)
 	closet_squad = "bravo"
 
-/obj/structure/closet/secure_closet/marine/engi/bravo/Initialize()
+/obj/structure/closet/secure_closet/marine/engi/bravo/PopulateContents()
 	. = ..()
 	new /obj/item/clothing/gloves/marine/bravo/insulated(src)
 	new /obj/item/radio/headset/almayer/marine/bravo/engi(src)
@@ -174,7 +178,7 @@
 	req_access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_CHARLIE, ACCESS_MARINE_ENGPREP)
 	closet_squad = "charlie"
 
-/obj/structure/closet/secure_closet/marine/engi/charlie/Initialize()
+/obj/structure/closet/secure_closet/marine/engi/charlie/PopulateContents()
 	. = ..()
 	new /obj/item/clothing/gloves/marine/charlie/insulated(src)
 	new /obj/item/radio/headset/almayer/marine/charlie/engi(src)
@@ -184,7 +188,7 @@
 	req_access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_DELTA, ACCESS_MARINE_ENGPREP)
 	closet_squad = "delta"
 
-/obj/structure/closet/secure_closet/marine/engi/delta/Initialize()
+/obj/structure/closet/secure_closet/marine/engi/delta/PopulateContents()
 	. = ..()
 	new /obj/item/clothing/gloves/marine/delta/insulated(src)
 	new /obj/item/radio/headset/almayer/marine/delta/engi(src)
@@ -196,7 +200,7 @@
 	slotlocked = TRUE
 	resistance_flags = INDESTRUCTIBLE
 
-/obj/structure/closet/secure_closet/marine/medic/Initialize()
+/obj/structure/closet/secure_closet/marine/medic/PopulateContents()
 	. = ..()
 	new /obj/item/storage/belt/combatLifesaver(src)
 	new /obj/item/clothing/glasses/hud/health(src)
@@ -212,7 +216,7 @@
 	req_access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_ALPHA, ACCESS_MARINE_MEDPREP)
 	closet_squad = "alpha"
 
-/obj/structure/closet/secure_closet/marine/medic/alpha/Initialize()
+/obj/structure/closet/secure_closet/marine/medic/alpha/PopulateContents()
 	. = ..()
 	new /obj/item/clothing/gloves/marine/alpha(src)
 	new /obj/item/radio/headset/almayer/marine/alpha/med(src)
@@ -223,7 +227,7 @@
 	req_access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_BRAVO, ACCESS_MARINE_MEDPREP)
 	closet_squad = "bravo"
 
-/obj/structure/closet/secure_closet/marine/medic/bravo/Initialize()
+/obj/structure/closet/secure_closet/marine/medic/bravo/PopulateContents()
 	. = ..()
 	new /obj/item/clothing/gloves/marine/bravo(src)
 	new /obj/item/radio/headset/almayer/marine/bravo/med(src)
@@ -234,7 +238,7 @@
 	req_access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_CHARLIE, ACCESS_MARINE_MEDPREP)
 	closet_squad = "charlie"
 
-/obj/structure/closet/secure_closet/marine/medic/charlie/Initialize()
+/obj/structure/closet/secure_closet/marine/medic/charlie/PopulateContents()
 	. = ..()
 	new /obj/item/clothing/gloves/marine/charlie(src)
 	new /obj/item/radio/headset/almayer/marine/charlie/med(src)
@@ -245,7 +249,7 @@
 	req_access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_DELTA, ACCESS_MARINE_MEDPREP)
 	closet_squad = "delta"
 
-/obj/structure/closet/secure_closet/marine/medic/delta/Initialize()
+/obj/structure/closet/secure_closet/marine/medic/delta/PopulateContents()
 	. = ..()
 	new /obj/item/clothing/gloves/marine/delta(src)
 	new /obj/item/radio/headset/almayer/marine/delta/med(src)
@@ -267,8 +271,7 @@
 	icon_broken = "secure_locked_commander"
 	icon_off = "secure_closed_commander"
 
-/obj/structure/closet/secure_closet/captain/Initialize()
-	. = ..()
+/obj/structure/closet/secure_closet/captain/PopulateContents()
 	new /obj/item/storage/backpack/captain(src)
 	new /obj/item/clothing/shoes/marinechief/captain(src)
 	new /obj/item/clothing/gloves/marine/techofficer/captain(src)
@@ -302,8 +305,7 @@
 	icon_broken = "secure_locked_staff"
 	icon_off = "secure_closed_staff"
 
-/obj/structure/closet/secure_closet/staff_officer/Initialize()
-	. = ..()
+/obj/structure/closet/secure_closet/staff_officer/PopulateContents()
 	new /obj/item/clothing/head/tgmcberet(src)
 	new /obj/item/clothing/head/tgmcberet/tan(src)
 	new /obj/item/clothing/head/tgmccap/ro(src)
@@ -329,8 +331,7 @@
 	icon_broken = "secure_locked_pilot"
 	icon_off = "secure_closed_pilot"
 
-/obj/structure/closet/secure_closet/pilot_officer/Initialize()
-	. = ..()
+/obj/structure/closet/secure_closet/pilot_officer/PopulateContents()
 	new /obj/item/attachable/stock/vp70(src)
 	new /obj/item/clothing/head/helmet/marine/pilot(src)
 	new /obj/item/radio/headset/almayer/mcom(src)
@@ -361,8 +362,7 @@
 	icon_broken = "secure_broken_police"
 	icon_off = "secure_closed_police"
 
-/obj/structure/closet/secure_closet/military_police/Initialize()
-	. = ..()
+/obj/structure/closet/secure_closet/military_police/PopulateContents()
 	new /obj/item/clothing/head/tgmcberet/red(src)
 	new /obj/item/clothing/head/tgmcberet/red(src)
 	new /obj/item/clothing/gloves/black(src)
@@ -392,8 +392,7 @@
 	icon_broken = "secure_locked_warrant"
 	icon_off = "secure_closed_warrant"
 
-/obj/structure/closet/secure_closet/warrant_officer/Initialize()
-	. = ..()
+/obj/structure/closet/secure_closet/warrant_officer/PopulateContents()
 	new /obj/item/clothing/head/tgmcberet/wo(src)
 	new /obj/item/clothing/tie/holster/armpit(src)
 	new /obj/item/clothing/shoes/marine(src)
@@ -421,8 +420,7 @@
 	icon_broken = "secure_locked_warrant"
 	icon_off = "secure_closed_warrant"
 
-/obj/structure/closet/secure_closet/military_officer_spare/Initialize()
-	. = ..()
+/obj/structure/closet/secure_closet/military_officer_spare/PopulateContents()
 	new /obj/item/clothing/tie/holster/armpit(src)
 	new /obj/item/storage/backpack/security(src)
 	new /obj/item/clothing/shoes/marine(src)
@@ -451,10 +449,11 @@
 	icon_broken = "secure_broken_medical"
 	icon_off = "secure_closed_medical"
 
-/obj/structure/closet/secure_closet/medical_doctor/Initialize()
-	. = ..()
+
+/obj/structure/closet/secure_closet/medical_doctor/PopulateContents()
 	new /obj/item/storage/backpack/marine/satchel(src)
-	if(!is_ground_level(z)) new /obj/item/radio/headset/almayer/doc(src)
+	if(!is_ground_level(z))
+		new /obj/item/radio/headset/almayer/doc(src)
 	new /obj/item/clothing/shoes/white(src)
 	new /obj/item/clothing/shoes/white(src)
 	new /obj/item/storage/belt/medical(src)
@@ -469,6 +468,7 @@
 			new /obj/item/clothing/suit/storage/snow_suit/doctor(src)
 			new /obj/item/clothing/mask/rebreather/scarf(src)
 
+
 //ALAMAYER CARGO CLOSET
 /obj/structure/closet/secure_closet/req_officer
 	name = "\improper RO's Locker"
@@ -480,8 +480,7 @@
 	icon_broken = "secure_broken_cargo"
 	icon_off = "secure_off_cargo"
 
-/obj/structure/closet/secure_closet/req_officer/Initialize()
-	. = ..()
+/obj/structure/closet/secure_closet/req_officer/PopulateContents()
 	new /obj/item/radio/headset/almayer/mcom(src)
 	new /obj/item/clothing/under/rank/ro_suit(src)
 	new /obj/item/clothing/shoes/marine(src)
@@ -506,8 +505,7 @@
 	icon_broken = "secure_broken_cargo"
 	icon_off = "secure_off_cargo"
 
-/obj/structure/closet/secure_closet/cargotech/Initialize()
-	. = ..()
+/obj/structure/closet/secure_closet/cargotech/PopulateContents()
 	new /obj/item/clothing/under/rank/cargotech(src)
 	new /obj/item/clothing/shoes/marine(src)
 	new /obj/item/radio/headset/almayer/ct(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -3,9 +3,10 @@
 	desc = "It's an immobile card-locked storage unit."
 	icon_state = "secure1"
 	density = TRUE
-	opened = 0
+	opened = FALSE
 	locked = TRUE
 	broken = FALSE
+	closet_flags = CLOSET_IS_SECURE
 	var/large = 1
 	icon_closed = "secure"
 	var/icon_locked = "secure1"
@@ -15,10 +16,6 @@
 	max_integrity = 100
 	var/slotlocked = 0
 
-/obj/structure/closet/secure_closet/can_open()
-	if(src.locked)
-		return 0
-	return ..()
 
 /obj/structure/closet/secure_closet/close()
 	if(..())
@@ -43,48 +40,6 @@
 				src.req_access += pick(get_all_accesses())
 	..()
 
-/obj/structure/closet/secure_closet/proc/togglelock(mob/living/user)
-	if(!user.IsAdvancedToolUser())
-		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
-		return
-	if(opened)
-		to_chat(user, "<span class='notice'>Close the locker first.</span>")
-		return
-	if(broken)
-		to_chat(user, "<span class='warning'>The locker appears to be broken.</span>")
-		return
-	if(user.loc == src)
-		to_chat(user, "<span class='notice'>You can't reach the lock from inside.</span>")
-		return
-	if(allowed(user))
-		if(slotlocked)
-			var/obj/item/card/id/I = user.get_idcard(TRUE)
-			if(!I || I.claimedgear)
-				return
-			I.claimedgear = TRUE // you only get one locker, all other roles have this set 1 by default
-			slotlocked = FALSE // now permanently unlockable
-		locked = !locked
-		user.visible_message("<span class='notice'>\the [src] has been [locked ? "" : "un"]locked by [user].</span>", \
-							"<span class='notice'>You [locked ? "" : "un"]lock \the [src].</span>", null, 3)
-		update_icon()
-	else
-		to_chat(user, "<span class='notice'>Access Denied</span>")
-
-/obj/structure/closet/secure_closet/attackby(obj/item/I, mob/user, params)
-	. = ..()
-
-	if(istype(I, /obj/item/card/emag))
-		if(broken) 
-			return
-		broken = TRUE
-		locked = FALSE
-		desc = "It appears to be broken."
-		icon_state = icon_off
-		flick(icon_broken, src)
-		visible_message("<span class='warning'>The locker has been broken by [user] with an electromagnetic card!</span>", "You hear a faint electrical spark.")
-	
-	else
-		togglelock(user)
 
 /obj/structure/closet/secure_closet/attack_paw(mob/user as mob)
 	return src.attack_hand(user)

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -12,7 +12,7 @@
 	anchored = 0
 	mob_storage_capacity = 0
 	var/rigged = 0
-	closet_flags = CLOSET_ALLOW_OBJS | CLOSET_ALLOW_DENSE_OBJ
+	closet_flags = CLOSET_ALLOW_OBJS|CLOSET_ALLOW_DENSE_OBJ
 
 /obj/structure/closet/crate/can_open()
 	return 1

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -10,8 +10,9 @@
 	climbable = 1
 	climb_delay = 20 //Doesn't need as long to climb over a crate
 	anchored = 0
-	store_mobs = FALSE
+	mob_storage_capacity = 0
 	var/rigged = 0
+	closet_flags = CLOSET_ALLOW_OBJS | CLOSET_ALLOW_DENSE_OBJ
 
 /obj/structure/closet/crate/can_open()
 	return 1

--- a/code/game/objects/structures/crates_lockers/secure_crates.dm
+++ b/code/game/objects/structures/crates_lockers/secure_crates.dm
@@ -4,14 +4,18 @@
 	icon_state = "secure_locked_basic"
 	icon_opened = "secure_open_basic"
 	icon_closed = "secure_locked_basic"
+	closet_flags = CLOSET_ALLOW_OBJS | CLOSET_ALLOW_DENSE_OBJ | CLOSET_IS_SECURE
 	var/icon_locked = "secure_locked_basic"
 	var/icon_unlocked = "secure_unlocked_basic"
 	var/sparks = "securecratesparks"
 	var/emag = "securecrateemag"
 	locked = TRUE
+	max_integrity = 500
+	armor = list("melee" = 30, "bullet" = 50, "laser" = 50, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 80)
 
-/obj/structure/closet/crate/secure/New()
-	..()
+
+/obj/structure/closet/crate/secure/Initialize(mapload, ...)
+	. = ..()
 	update_icon()
 
 
@@ -28,23 +32,6 @@
 /obj/structure/closet/crate/secure/can_open()
 	return !locked
 
-/obj/structure/closet/crate/secure/proc/togglelock(mob/user)
-	if(!user.IsAdvancedToolUser())
-		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
-		return
-	if(opened)
-		to_chat(user, "<span class='notice'>Close the crate first.</span>")
-		return
-	if(broken)
-		to_chat(user, "<span class='warning'>The crate appears to be broken.</span>")
-		return
-	if(allowed(user))
-		locked = !locked
-		user.visible_message("<span class='notice'>\the [src] has been [locked ? "" : "un"]locked by [user].</span>", \
-							"<span class='notice'>You [locked ? "" : "un"]lock \the [src].</span>", null, 3)
-		update_icon()
-	else
-		to_chat(user, "<span class='notice'>Access Denied</span>")
 
 /obj/structure/closet/crate/secure/verb/verb_togglelock()
 	set src in oview(1) // One square distance
@@ -55,22 +42,6 @@
 		return
 	togglelock(usr)
 
-
-/obj/structure/closet/crate/secure/attackby(obj/item/I, mob/user, params)
-	. = ..()
-
-	if(locked && istype(I, /obj/item/card/emag))
-		overlays.Cut()
-		overlays += emag
-		flick(src, sparks)
-		playsound(loc, "sparks", 25, 1)
-		locked = FALSE
-		broken = TRUE
-		update_icon()
-		to_chat(user, "<span class='notice'>You unlock \the [src].</span>")
-
-	else if(!opened)
-		togglelock(user)
 
 /obj/structure/closet/crate/secure/emp_act(severity)
 	for(var/obj/O in src)

--- a/code/game/objects/structures/crates_lockers/secure_crates.dm
+++ b/code/game/objects/structures/crates_lockers/secure_crates.dm
@@ -4,7 +4,7 @@
 	icon_state = "secure_locked_basic"
 	icon_opened = "secure_open_basic"
 	icon_closed = "secure_locked_basic"
-	closet_flags = CLOSET_ALLOW_OBJS | CLOSET_ALLOW_DENSE_OBJ | CLOSET_IS_SECURE
+	closet_flags = CLOSET_ALLOW_OBJS|CLOSET_ALLOW_DENSE_OBJ|CLOSET_IS_SECURE
 	var/icon_locked = "secure_locked_basic"
 	var/icon_unlocked = "secure_unlocked_basic"
 	var/sparks = "securecratesparks"

--- a/code/game/objects/structures/crates_lockers/walllocker.dm
+++ b/code/game/objects/structures/crates_lockers/walllocker.dm
@@ -9,7 +9,7 @@
 	anchored = TRUE
 	icon_closed = "walllocker"
 	icon_opened = "walllockeropen"
-	store_mobs = FALSE
+	mob_storage_capacity = 0
 	wall_mounted = TRUE
 	storage_capacity = 20
 	overlay_welded = "walllockerwelded"
@@ -99,7 +99,7 @@
 	overlay_welded = "emergwelded"
 	density = FALSE
 	anchored = TRUE
-	store_mobs = FALSE
+	mob_storage_capacity = 0
 	wall_mounted = TRUE
 	large = FALSE
 	storage_capacity = 20
@@ -159,7 +159,7 @@
 	overlay_welded = "emergwelded"
 	density = FALSE
 	anchored = TRUE
-	store_mobs = FALSE
+	mob_storage_capacity = 0
 	wall_mounted = TRUE
 	large = FALSE
 	storage_capacity = 20

--- a/code/game/objects/structures/supplypod.dm
+++ b/code/game/objects/structures/supplypod.dm
@@ -44,7 +44,7 @@
 	pixel_x = -16
 	pixel_y = -5
 	layer = TABLE_LAYER
-	closet_flags = CLOSET_ALLOW_OBJS | CLOSET_ALLOW_DENSE_OBJ
+	closet_flags = CLOSET_ALLOW_OBJS|CLOSET_ALLOW_DENSE_OBJ
 	armor = list("melee" = 30, "bullet" = 50, "laser" = 50, "energy" = 100, "bomb" = 100, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 80)
 	anchored = TRUE
 	var/adminNamed = FALSE

--- a/code/game/objects/structures/supplypod.dm
+++ b/code/game/objects/structures/supplypod.dm
@@ -44,6 +44,7 @@
 	pixel_x = -16
 	pixel_y = -5
 	layer = TABLE_LAYER
+	closet_flags = CLOSET_ALLOW_OBJS | CLOSET_ALLOW_DENSE_OBJ
 	armor = list("melee" = 30, "bullet" = 50, "laser" = 50, "energy" = 100, "bomb" = 100, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 80)
 	anchored = TRUE
 	var/adminNamed = FALSE

--- a/code/modules/vehicles/powerloader.dm
+++ b/code/modules/vehicles/powerloader.dm
@@ -218,20 +218,20 @@
 
 	else if(istype(target, /obj/structure/closet/crate))
 		var/obj/structure/closet/crate/C = target
-		if(!C.anchored && !C.store_mobs)
-			for(var/X in C)
-				if(ismob(X)) //just in case.
-					to_chat(user, "<span class='warning'>Can't grab [loaded], it has a creature inside!</span>")
-					return
-			if(linked_powerloader)
-				C.forceMove(linked_powerloader)
-				loaded = C
-				playsound(src, 'sound/machines/hydraulics_2.ogg', 40, 1)
-				update_icon()
-				user.visible_message("<span class='notice'>[user] grabs [loaded] with [src].</span>",
-				"<span class='notice'>You grab [loaded] with [src].</span>")
-		else
+		if(C.mob_size_counter)
+			to_chat(user, "<span class='warning'>Can't grab [loaded], it has a creature inside!</span>")
+			return
+		if(C.anchored)
 			to_chat(user, "<span class='warning'>Can't grab [loaded].</span>")
+			return
+		if(!linked_powerloader)
+			CRASH("[src] called afterattack on [C] without a linked_powerloader")
+		C.forceMove(linked_powerloader)
+		loaded = C
+		playsound(src, 'sound/machines/hydraulics_2.ogg', 40, 1)
+		update_icon()
+		user.visible_message("<span class='notice'>[user] grabs [loaded] with [src].</span>",
+		"<span class='notice'>You grab [loaded] with [src].</span>")
 
 	else if(istype(target, /obj/structure/largecrate))
 		var/obj/structure/largecrate/LC = target


### PR DESCRIPTION
closes #2059 
closes #2070

## Changelog
:cl:
tweak: Players can now toggle closet/crate locks with alt+click, provided they have access.
balance: Lockers can now be wrenched and unwrenched, no longer fully immobile, but they can hold less objects. The total is calculated based on the size/weight of each item, not merely their amount.
/:cl: