### PR TITLE
Fix for cooldown broken in certain xeno actions

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -191,7 +191,7 @@
 // ***************************************
 // *********** Crest defense
 // ***************************************
-/datum/action/xeno_action/activable/toggle_crest_defense
+/datum/action/xeno_action/toggle_crest_defense
 	name = "Toggle Crest Defense"
 	action_icon_state = "crest_defense"
 	mechanics_text = "Increase your resistance to projectiles at the cost of move speed. Can use abilities while in Crest Defense."
@@ -200,12 +200,12 @@
 	cooldown_timer = 1 SECONDS
 	keybind_signal = COMSIG_XENOABILITY_CREST_DEFENSE
 
-/datum/action/xeno_action/activable/toggle_crest_defense/on_cooldown_finish()
+/datum/action/xeno_action/toggle_crest_defense/on_cooldown_finish()
 	var/mob/living/carbon/xenomorph/defender/X = owner
 	to_chat(X, "<span class='notice'>You can [X.crest_defense ? "raise" : "lower"] your crest.</span>")
 	return ..()
 
-/datum/action/xeno_action/activable/toggle_crest_defense/action_activate()
+/datum/action/xeno_action/toggle_crest_defense/action_activate()
 	var/mob/living/carbon/xenomorph/defender/X = owner
 
 	if(X.crest_defense)
@@ -215,7 +215,7 @@
 
 	var/was_fortified = X.fortify
 	if(X.fortify)
-		var/datum/action/xeno_action/FT = X.actions_by_path[/datum/action/xeno_action/activable/fortify]
+		var/datum/action/xeno_action/FT = X.actions_by_path[/datum/action/xeno_action/fortify]
 		if(FT.on_cooldown)
 			to_chat(src, "<span class='xenowarning'>You cannot yet untuck yourself!</span>")
 			return fail_activate()
@@ -248,7 +248,7 @@
 // ***************************************
 // *********** Fortify
 // ***************************************
-/datum/action/xeno_action/activable/fortify
+/datum/action/xeno_action/fortify
 	name = "Fortify"
 	action_icon_state = "fortify"	// TODO
 	mechanics_text = "Plant yourself for a large defensive boost."
@@ -257,12 +257,12 @@
 	cooldown_timer = 1 SECONDS
 	keybind_signal = COMSIG_XENOABILITY_FORTIFY
 
-/datum/action/xeno_action/activable/fortify/on_cooldown_finish()
+/datum/action/xeno_action/fortify/on_cooldown_finish()
 	var/mob/living/carbon/xenomorph/X = owner
 	to_chat(X, "<span class='notice'>You can [X.fortify ? "stand up" : "fortify"] again.</span>")
 	return ..()
 
-/datum/action/xeno_action/activable/fortify/action_activate()
+/datum/action/xeno_action/fortify/action_activate()
 	var/mob/living/carbon/xenomorph/defender/X = owner
 
 	if(X.fortify)
@@ -272,7 +272,7 @@
 
 	var/was_crested = X.crest_defense
 	if(X.crest_defense)
-		var/datum/action/xeno_action/CD = X.actions_by_path[/datum/action/xeno_action/activable/toggle_crest_defense]
+		var/datum/action/xeno_action/CD = X.actions_by_path[/datum/action/xeno_action/toggle_crest_defense]
 		if(CD.on_cooldown)
 			to_chat(X, "<span class='xenowarning'>You cannot yet transition to a defensive stance!</span>")
 			return fail_activate()

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/defender.dm
@@ -16,8 +16,8 @@
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
 		/datum/action/xeno_action/regurgitate,
-		/datum/action/xeno_action/activable/toggle_crest_defense,
-		/datum/action/xeno_action/activable/fortify,
+		/datum/action/xeno_action/toggle_crest_defense,
+		/datum/action/xeno_action/fortify,
 		/datum/action/xeno_action/activable/forward_charge,
 		/datum/action/xeno_action/activable/tail_sweep
 		)

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -1,18 +1,18 @@
 // ***************************************
 // *********** Stealth
 // ***************************************
-/datum/action/xeno_action/activable/stealth
+/datum/action/xeno_action/stealth
 	name = "Toggle Stealth"
 	action_icon_state = "stealth_on"
 	mechanics_text = "Become harder to see, almost invisible if you stand still, and ready a sneak attack. Uses plasma to move."
 	ability_name = "stealth"
 	keybind_signal = COMSIG_XENOABILITY_TOGGLE_STEALTH
 
-/datum/action/xeno_action/activable/stealth/action_activate()
+/datum/action/xeno_action/stealth/action_activate()
 	var/mob/living/carbon/xenomorph/hunter/X = owner
 	X.Stealth()
 
-/datum/action/xeno_action/activable/stealth/action_cooldown_check()
+/datum/action/xeno_action/stealth/action_cooldown_check()
 	var/mob/living/carbon/xenomorph/hunter/X = owner
 	return !X.used_stealth
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/hunter.dm
@@ -18,7 +18,7 @@
 		/datum/action/xeno_action/xeno_resting,
 		/datum/action/xeno_action/regurgitate,
 		/datum/action/xeno_action/activable/pounce,
-		/datum/action/xeno_action/activable/stealth,
+		/datum/action/xeno_action/stealth,
 		)
 	inherent_verbs = list(
 		/mob/living/carbon/xenomorph/proc/vent_crawl,

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -99,7 +99,7 @@
 // ***************************************
 // *********** Second wind
 // ***************************************
-/datum/action/xeno_action/activable/second_wind
+/datum/action/xeno_action/second_wind
 	name = "Second Wind"
 	action_icon_state = "second_wind"
 	mechanics_text = "A channeled ability to restore health that uses plasma and rage. Must stand still for it to work."
@@ -107,15 +107,15 @@
 	var/last_rage = 0
 	keybind_signal = COMSIG_XENOABILITY_SECOND_WIND
 
-/datum/action/xeno_action/activable/second_wind/get_cooldown()
+/datum/action/xeno_action/second_wind/get_cooldown()
 	return cooldown_timer * round((1 - (last_rage * 0.015) ),0.01)
 
-/datum/action/xeno_action/activable/second_wind/on_cooldown_finish()
+/datum/action/xeno_action/second_wind/on_cooldown_finish()
 	to_chat(owner, "<span class='xenodanger'>You gather enough strength to use Second Wind again.</span>")
 	playsound(owner, "sound/effects/xeno_newlarva.ogg", 50, 0, 1)
 	return ..()
 
-/datum/action/xeno_action/activable/second_wind/action_activate(atom/A)
+/datum/action/xeno_action/second_wind/action_activate(atom/A)
 	var/mob/living/carbon/xenomorph/ravager/X = owner
 
 	to_chat(X, "<span class='xenodanger'>Your coursing adrenaline stimulates tissues into a spat of rapid regeneration...</span>")

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/ravager.dm
@@ -25,7 +25,7 @@
 		/datum/action/xeno_action/regurgitate,
 		/datum/action/xeno_action/activable/charge,
 		/datum/action/xeno_action/activable/ravage,
-		/datum/action/xeno_action/activable/second_wind,
+		/datum/action/xeno_action/second_wind,
 		)
 
 // ***************************************

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -1,7 +1,7 @@
 // ***************************************
 // *********** Agility
 // ***************************************
-/datum/action/xeno_action/activable/toggle_agility
+/datum/action/xeno_action/toggle_agility
 	name = "Toggle Agility"
 	action_icon_state = "agility_on"
 	mechanics_text = "Move an all fours for greater speed. Cannot use abilities while in this mode."
@@ -10,12 +10,12 @@
 	use_state_flags = XACT_USE_AGILITY
 	keybind_signal = COMSIG_XENOABILITY_TOGGLE_AGILITY
 
-/datum/action/xeno_action/activable/toggle_agility/on_cooldown_finish()
+/datum/action/xeno_action/toggle_agility/on_cooldown_finish()
 	var/mob/living/carbon/xenomorph/X = owner
 	to_chat(src, "<span class='notice'>You can [X.agility ? "raise yourself back up" : "lower yourself back down"] again.</span>")
 	return ..()
 
-/datum/action/xeno_action/activable/toggle_agility/action_activate()
+/datum/action/xeno_action/toggle_agility/action_activate()
 	var/mob/living/carbon/xenomorph/X = owner
 
 	X.agility = !X.agility

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/warrior.dm
@@ -15,7 +15,7 @@
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
 		/datum/action/xeno_action/regurgitate,
-		/datum/action/xeno_action/activable/toggle_agility,
+		/datum/action/xeno_action/toggle_agility,
 		/datum/action/xeno_action/activable/fling,
 		/datum/action/xeno_action/activable/lunge,
 		/datum/action/xeno_action/activable/punch


### PR DESCRIPTION
You could use Second Wind infinitely among others who were activable when they shouldn't.
