### PR TITLE
Bodybag/Cryobag/Tarp Rework

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -115,6 +115,7 @@
 	#define COMSIG_GRAB_SUCCESSFUL_SELF_ATTACK (1<<0)
 
 // /mob signals
+#define COMSIG_MOB_DEATH "mob_death"							//from base of mob/death(): (gibbed)
 #define COMSIG_MOB_CLICKON "mob_clickon"						//from base of mob/clickon(): (atom/A, params)
 	#define COMSIG_MOB_CANCEL_CLICKON 1
 #define COMSIG_MOB_ATTACK_RANGED "mob_attack_ranged"			//from base of mob/RangedAttack(): (atom/A, params)

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -257,10 +257,10 @@
 	. = ..()
 	if(bodybag_occupant)
 		bodybag_occupant.in_stasis = STASIS_IN_BAG
-		RegisterSignal(bodybag_occupant, list(COMSIG_MOB_DEATH, COMSIG_PARENT_QDELETED), .proc/on_stasis_mob_death)
+		RegisterSignal(bodybag_occupant, list(COMSIG_MOB_DEATH, COMSIG_PARENT_QDELETED), .proc/on_bodybag_occupant_death)
 
 
-/obj/structure/closet/bodybag/cryobag/proc/on_stasis_mob_death(datum/source)
+/obj/structure/closet/bodybag/cryobag/proc/on_bodybag_occupant_death(datum/source, gibbed)
 	if(!QDELETED(bodybag_occupant))
 		visible_message("<span class='notice'>\The [src] rejects the corpse.</span>")
 	open()

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -246,10 +246,10 @@
 
 
 /obj/structure/closet/bodybag/cryobag/closet_special_handling(mob/living/mob_to_stuff) // overriding this
-	if(mob_to_stuff.stat == DEAD) // dead, nope
-		return FALSE
 	if(!ishuman(mob_to_stuff))
 		return FALSE //Humans only.
+	if(mob_to_stuff.stat == DEAD) // dead, nope
+		return FALSE
 	return TRUE
 
 

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -118,12 +118,13 @@
 		overlays.Cut()
 
 
-/obj/structure/closet/bodybag/closet_special_handling(mob/living/carbon/human/mob_to_stuff) // overriding this
+/obj/structure/closet/bodybag/closet_special_handling(mob/living/mob_to_stuff) // overriding this
 	if(!ishuman(mob_to_stuff))
 		return FALSE //Only humans.
 	if(mob_to_stuff.stat != DEAD) //Only the dead for bodybags.
 		return FALSE
-	if((!check_tod(mob_to_stuff) || issynth(mob_to_stuff)) && mob_to_stuff.is_revivable())
+	var/mob/living/carbon/human/human_to_stuff = mob_to_stuff
+	if((!check_tod(human_to_stuff) || issynth(human_to_stuff)) && human_to_stuff.is_revivable())
 		return FALSE //We don't want to store those that can be revived.
 	return TRUE
 

--- a/code/game/objects/items/marine_gear.dm
+++ b/code/game/objects/items/marine_gear.dm
@@ -60,10 +60,10 @@
 
 
 /obj/structure/closet/bodybag/tarp/closet_special_handling(mob/living/mob_to_stuff) // overriding this
-	if(mob_to_stuff.stat == DEAD) //Only the dead for bodybags.
-		return FALSE
 	if(!ishuman(mob_to_stuff))
 		return FALSE //Humans only.
+	if(mob_to_stuff.stat == DEAD) //Only the dead for bodybags.
+		return FALSE
 	return TRUE
 
 

--- a/code/game/objects/items/marine_gear.dm
+++ b/code/game/objects/items/marine_gear.dm
@@ -40,32 +40,12 @@
 	closet_stun_delay = 0
 
 
-#define TARP_TIME_PER_CYCLE 1.5 SECONDS
-
 /obj/structure/closet/bodybag/tarp/close()
 	. = ..()
 	if(!opened && bodybag_occupant)
 		anchored = TRUE
 		playsound(loc,'sound/effects/cloak_scout_on.ogg', 15, 1) //stealth mode engaged!
-		addtimer(CALLBACK(src, .proc/gradual_fade_out), TARP_TIME_PER_CYCLE)
-
-
-#define TARP_ALPHA_LOSS_PER_CYCLE 85
-#define TARP_MINIMUM_ALPHA 13
-
-/obj/structure/closet/bodybag/tarp/proc/gradual_fade_out(iterations = 0)
-	if(opened || !bodybag_occupant)
-		return
-	if(alpha != (initial(alpha) - (TARP_ALPHA_LOSS_PER_CYCLE * iterations)))
-		return //There's likely more than one such process running around, such as when someone opens and closes the tarp quickly. Let's kill this one.
-	if(alpha <= TARP_MINIMUM_ALPHA)
-		return //Natural end of the cycle, reaching maximum concealment. Starting with 255 alpha and losing 85 each time it takes 3 iterations.
-	alpha = max(TARP_MINIMUM_ALPHA, alpha - TARP_ALPHA_LOSS_PER_CYCLE)
-	addtimer(CALLBACK(src, .proc/gradual_fade_out, ++iterations), TARP_TIME_PER_CYCLE)
-
-#undef TARP_ALPHA_LOSS_PER_CYCLE
-#undef TARP_MINIMUM_ALPHA
-#undef TARP_TIME_PER_CYCLE
+		animate(src, alpha = 13, time = 4 SECONDS) //Fade out gradually.
 
 
 /obj/structure/closet/bodybag/tarp/open()
@@ -73,6 +53,7 @@
 	if(alpha != initial(alpha))
 		playsound(loc,'sound/effects/cloak_scout_off.ogg', 15, 1)
 		alpha = initial(alpha) //stealth mode disengaged
+		animate(src) //Cancel the fade out if still ongoing.
 	if(bodybag_occupant)
 		UnregisterSignal(bodybag_occupant, list(COMSIG_MOB_DEATH, COMSIG_PARENT_QDELETED))
 	return ..()

--- a/code/game/objects/items/marine_gear.dm
+++ b/code/game/objects/items/marine_gear.dm
@@ -70,10 +70,10 @@
 /obj/structure/closet/bodybag/tarp/close()
 	. = ..()
 	if(bodybag_occupant)
-		RegisterSignal(bodybag_occupant, list(COMSIG_MOB_DEATH, COMSIG_PARENT_QDELETED), .proc/on_stasis_mob_death)
+		RegisterSignal(bodybag_occupant, list(COMSIG_MOB_DEATH, COMSIG_PARENT_QDELETED), .proc/on_bodybag_occupant_death)
 
 
-/obj/structure/closet/bodybag/tarp/proc/on_stasis_mob_death(datum/source)
+/obj/structure/closet/bodybag/tarp/proc/on_bodybag_occupant_death(datum/source, gibbed)
 	open()
 
 

--- a/code/game/objects/machinery/OpTable.dm
+++ b/code/game/objects/machinery/OpTable.dm
@@ -206,9 +206,9 @@
 			return
 	else if(istype(G.grabbed_thing, /obj/structure/closet/bodybag/cryobag))
 		var/obj/structure/closet/bodybag/cryobag/C = G.grabbed_thing
-		if(!C.stasis_mob)
+		if(!C.bodybag_occupant)
 			return
-		M = C.stasis_mob
+		M = C.bodybag_occupant
 		C.open()
 		user.stop_pulling()
 		user.start_pulling(M)

--- a/code/game/objects/machinery/adv_med.dm
+++ b/code/game/objects/machinery/adv_med.dm
@@ -89,10 +89,10 @@
 	var/obj/item/grab/G = I
 	if(istype(G.grabbed_thing,/obj/structure/closet/bodybag/cryobag))
 		var/obj/structure/closet/bodybag/cryobag/C = G.grabbed_thing
-		if(!C.stasis_mob)
+		if(!C.bodybag_occupant)
 			to_chat(user, "<span class='warning'>The stasis bag is empty!</span>")
 			return
-		M = C.stasis_mob
+		M = C.bodybag_occupant
 		C.open()
 		user.start_pulling(M)
 	else if(ismob(G.grabbed_thing))

--- a/code/game/objects/machinery/autodoc.dm
+++ b/code/game/objects/machinery/autodoc.dm
@@ -782,10 +782,10 @@
 		M = G.grabbed_thing
 	else if(istype(G.grabbed_thing, /obj/structure/closet/bodybag/cryobag))
 		var/obj/structure/closet/bodybag/cryobag/C = G.grabbed_thing
-		if(!C.stasis_mob)
+		if(!C.bodybag_occupant)
 			to_chat(user, "<span class='warning'>The stasis bag is empty!</span>")
 			return
-		M = C.stasis_mob
+		M = C.bodybag_occupant
 		C.open()
 		user.start_pulling(M)
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -325,10 +325,10 @@
 
 	else if(istype(G.grabbed_thing,/obj/structure/closet/bodybag/cryobag))
 		var/obj/structure/closet/bodybag/cryobag/C = G.grabbed_thing
-		if(!C.stasis_mob)
+		if(!C.bodybag_occupant)
 			to_chat(user, "<span class='warning'>The stasis bag is empty!</span>")
 			return
-		M = C.stasis_mob
+		M = C.bodybag_occupant
 		C.open()
 		user.start_pulling(M)
 

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -36,6 +36,7 @@
 
 
 /mob/proc/death(gibbed, deathmessage = "seizes up and falls limp...")
+	SEND_SIGNAL(src, COMSIG_MOB_DEATH, gibbed)
 	log_combat(src, src, "[deathmessage]")
 	if(stat == DEAD)
 		return FALSE


### PR DESCRIPTION
closes #2152

* Refactored bodybags, cryobags and tarps, removing useless processing and reducing qdels to lighten SSgarbage.
* Added a mob death signal, so things can react to them. Cryobags and tarps do, for example, opening if the mob dies inside them.
* What's in the changelog.

## Changelog
:cl:
del: Removed an unknown feature: cryobags actually had a lifetime of around an hour of holding mobs inside them. Maybe more.
balance: Tarps now fade out gradually instead of in janky steps. They don't accept dead bodies in them anymore (and will spit out whoever dies inside them). You can now drag them even if closed, as long as they don't contain someone. They will no longer show the name of the person inside.
/:cl: