### PR TITLE
Balance boiler bombard

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
@@ -18,7 +18,7 @@
 	else
 		X.visible_message("<span class='notice'>[X] starts looking off into the distance.</span>", \
 			"<span class='notice'>We start focusing your sight to look off into the distance.</span>", null, 5)
-		if(!do_after(X, 20, FALSE, null, BUSY_ICON_GENERIC) || X.is_zoomed)
+		if(!do_after(X, 1 SECONDS, FALSE, null, BUSY_ICON_GENERIC) || X.is_zoomed)
 			return
 		X.zoom_in()
 		..()
@@ -78,7 +78,7 @@
 	var/mob/living/carbon/xenomorph/boiler/X = owner
 	X.visible_message("<span class='notice'>\The [X] begins digging their claws into the ground.</span>", \
 	"<span class='notice'>We begin digging ourselves into place.</span>", null, 5)
-	if(!do_after(X, 30, FALSE, null, BUSY_ICON_HOSTILE))
+	if(!do_after(X, 4 SECONDS, FALSE, null, BUSY_ICON_HOSTILE))
 		on_deactivation()
 		X.selected_ability = null
 		X.update_action_button_icons()
@@ -156,7 +156,7 @@
 
 	succeed_activate()
 
-	if(!do_after(X, 50, FALSE, target, BUSY_ICON_DANGER))
+	if(!do_after(X, 3 SECONDS, FALSE, target, BUSY_ICON_DANGER))
 		to_chat(X, "<span class='warning'>We decide not to launch any acid.</span>")
 		return fail_activate()
 


### PR DESCRIPTION
## About The Pull Request

This changes the timing of the boiler bombard ability

Long range: 2sec -> 1sec
Toggle ability: 3sec -> 4sec
Fire ability: 5sec -> 3sec

## Why It's Good For The Game

Boiler is in a really bad spot right now, this should help balancing by allow it to launch attacks faster after clicking, but generally keeps the cooldown around the same.

We removed 2seconds from the whole chain because of a stealth nerf during the xeno ability refactor. As you can now only perform one action at a time, previously you could toggle long range and toggle the ability at the same time.

## Changelog
:cl:
balance: rebalanced boiler bombard, overall reduced 2 seconds from total time needed to fire, but also frontloaded most of the wait to toggling the ability, and reduced the wait when firing.
/:cl:
