### PR TITLE
Fixes a floor runtime

### DIFF
--- a/code/game/turfs/floor.dm
+++ b/code/game/turfs/floor.dm
@@ -400,7 +400,7 @@ GLOBAL_LIST_INIT(wood_icons, list("wood", "wood-broken"))
 			update_icon()
 			to_chat(user, "<span class='notice'>You replace the light bulb.</span>")
 
-	else if(iscrowbar(I) && !is_plating())
+	else if(iscrowbar(I) && !is_plating() && floor_tile)
 		if(broken || burnt)
 			to_chat(user, "<span class='warning'>You remove the broken plating.</span>")
 			return


### PR DESCRIPTION
Not all floors have a floor_tile, like the grass turfs on most maps.
```
[21:28:26] Runtime in floor.dm, line 412: Cannot read null.type
proc name: attackby (/turf/open/floor/attackby)
usr: Ragecrab/(Paul Denton)
usr.loc: (Southwest NT Compound (61, 26, 2))
src: the grass (61,25,2) (/turf/open/floor/plating/ground/dirtgrassborder)
call stack:
the grass (61,25,2) (/turf/open/floor/plating/ground/dirtgrassborder): attackby(the crowbar (/obj/item/tool/crowbar), Paul Denton (/mob/living/carbon/human), "icon-x=9;icon-y=19;left=1;scre...")
the crowbar (/obj/item/tool/crowbar): melee attack chain(Paul Denton (/mob/living/carbon/human), the grass (61,25,2) (/turf/open/floor/plating/ground/dirtgrassborder), "icon-x=9;icon-y=19;left=1;scre...")
Paul Denton (/mob/living/carbon/human): ClickOn(the grass (61,25,2) (/turf/open/floor/plating/ground/dirtgrassborder), "icon-x=9;icon-y=19;left=1;scre...")
the grass (61,25,2) (/turf/open/floor/plating/ground/dirtgrassborder): Click(the grass (61,25,2) (/turf/open/floor/plating/ground/dirtgrassborder), "mapwindow.map", "icon-x=9;icon-y=19;left=1;scre...")
Ragecrab (/client): Click(the grass (61,25,2) (/turf/open/floor/plating/ground/dirtgrassborder), the grass (61,25,2) (/turf/open/floor/plating/ground/dirtgrassborder), "mapwindow.map", "icon-x=9;icon-y=19;left=1;scre...")
```