### PR TITLE
Removes var-edits from nanomeds

### DIFF
--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -2509,8 +2509,8 @@
 	},
 /area/bigredv2/caves/lambda_lab)
 "ahE" = (
-/obj/machinery/vending/wallmed1{
-	pixel_y = -32
+/obj/machinery/vending/wallmed{
+	dir = 1
 	},
 /obj/machinery/light,
 /obj/effect/alien/weeds/node,
@@ -4485,10 +4485,8 @@
 	},
 /area/bigredv2/outside/marshal_office)
 "ane" = (
-/obj/machinery/vending/wallmed1{
-	name = "Emergency NanoMed";
-	pixel_x = 30;
-	req_access_txt = "0"
+/obj/machinery/vending/wallmed{
+	dir = 8
 	},
 /turf/open/floor/tile/red/redtaupe{
 	dir = 6
@@ -5552,8 +5550,8 @@
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/general_offices)
 "apY" = (
-/obj/machinery/vending/wallmed1{
-	pixel_x = -30
+/obj/machinery/vending/wallmed{
+	dir = 4
 	},
 /obj/machinery/light/built{
 	dir = 1
@@ -5867,8 +5865,8 @@
 /turf/open/floor,
 /area/bigredv2/outside/general_offices)
 "aqQ" = (
-/obj/machinery/vending/wallmed1{
-	pixel_x = 30
+/obj/machinery/vending/wallmed{
+	dir = 8
 	},
 /obj/machinery/light/built{
 	dir = 1

--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -2509,7 +2509,7 @@
 	},
 /area/bigredv2/caves/lambda_lab)
 "ahE" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/nanomed{
 	dir = 1
 	},
 /obj/machinery/light,
@@ -4485,7 +4485,7 @@
 	},
 /area/bigredv2/outside/marshal_office)
 "ane" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/nanomed{
 	dir = 8
 	},
 /turf/open/floor/tile/red/redtaupe{
@@ -5550,7 +5550,7 @@
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/general_offices)
 "apY" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/nanomed{
 	dir = 4
 	},
 /obj/machinery/light/built{
@@ -5865,7 +5865,7 @@
 /turf/open/floor,
 /area/bigredv2/outside/general_offices)
 "aqQ" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/nanomed{
 	dir = 8
 	},
 /obj/machinery/light/built{

--- a/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -5284,7 +5284,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/floor/tile/red/whitered{
 	dir = 1
 	},
@@ -7394,7 +7394,7 @@
 	},
 /area/ice_colony/underground/hangar)
 "atA" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/nanomed{
 	dir = 4
 	},
 /turf/open/floor/tile/red/whitered{
@@ -37991,7 +37991,7 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/ice_colony/exterior/surface/clearing/south)
 "bVK" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/nanomed{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood/drip,

--- a/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -5284,9 +5284,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/vending/wallmed1{
-	pixel_y = 17
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/floor/tile/red/whitered{
 	dir = 1
 	},
@@ -7396,8 +7394,8 @@
 	},
 /area/ice_colony/underground/hangar)
 "atA" = (
-/obj/machinery/vending/wallmed1{
-	pixel_x = -32
+/obj/machinery/vending/wallmed{
+	dir = 4
 	},
 /turf/open/floor/tile/red/whitered{
 	dir = 8
@@ -37993,8 +37991,8 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/ice_colony/exterior/surface/clearing/south)
 "bVK" = (
-/obj/machinery/vending/wallmed1{
-	pixel_x = 26
+/obj/machinery/vending/wallmed{
+	dir = 8
 	},
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/drip,

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -10061,7 +10061,7 @@
 	},
 /area/lv624/lazarus/fitness)
 "aLH" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/nanomed{
 	dir = 8
 	},
 /obj/structure/reagent_dispensers/watertank,

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -10061,8 +10061,8 @@
 	},
 /area/lv624/lazarus/fitness)
 "aLH" = (
-/obj/machinery/vending/wallmed1{
-	pixel_x = 29
+/obj/machinery/vending/wallmed{
+	dir = 8
 	},
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/tile/purple/whitepurplecorner{

--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -7791,7 +7791,7 @@
 	},
 /area/prison/medbay)
 "avu" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/nanomed{
 	dir = 8
 	},
 /turf/open/floor/prison/whitegreen{
@@ -10937,7 +10937,7 @@
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/checkpoint/maxsec)
 "aCR" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/nanomed{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -11611,7 +11611,7 @@
 /turf/open/floor/freezer,
 /area/prison/toilet/research)
 "aEx" = (
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/floor/freezer,
 /area/prison/toilet/research)
 "aEy" = (
@@ -19213,7 +19213,7 @@
 	},
 /area/prison/canteen)
 "aVY" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/nanomed{
 	dir = 4
 	},
 /turf/open/floor/prison/sterilewhite,
@@ -39816,7 +39816,7 @@
 	},
 /area/prison/hallway/engineering)
 "bSb" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/nanomed{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -39837,7 +39837,7 @@
 	},
 /area/prison/toilet/security)
 "bSd" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/nanomed{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{

--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -7791,8 +7791,8 @@
 	},
 /area/prison/medbay)
 "avu" = (
-/obj/machinery/vending/wallmed1{
-	pixel_x = 28
+/obj/machinery/vending/wallmed{
+	dir = 8
 	},
 /turf/open/floor/prison/whitegreen{
 	dir = 4
@@ -10937,8 +10937,8 @@
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/checkpoint/maxsec)
 "aCR" = (
-/obj/machinery/vending/wallmed1{
-	pixel_y = -28
+/obj/machinery/vending/wallmed{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -11611,9 +11611,7 @@
 /turf/open/floor/freezer,
 /area/prison/toilet/research)
 "aEx" = (
-/obj/machinery/vending/wallmed1{
-	pixel_y = 28
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/floor/freezer,
 /area/prison/toilet/research)
 "aEy" = (
@@ -19215,8 +19213,8 @@
 	},
 /area/prison/canteen)
 "aVY" = (
-/obj/machinery/vending/wallmed1{
-	pixel_x = -28
+/obj/machinery/vending/wallmed{
+	dir = 4
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/prison/toilet/staff)
@@ -39818,8 +39816,8 @@
 	},
 /area/prison/hallway/engineering)
 "bSb" = (
-/obj/machinery/vending/wallmed1{
-	pixel_y = -28
+/obj/machinery/vending/wallmed{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -39839,8 +39837,8 @@
 	},
 /area/prison/toilet/security)
 "bSd" = (
-/obj/machinery/vending/wallmed1{
-	pixel_y = -28
+/obj/machinery/vending/wallmed{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4

--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -155,7 +155,7 @@
 /obj/effect/landmark/start{
 	name = "Squad Leader"
 	},
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/floor{
 	icon_state = "warnwhite";
 	dir = 1
@@ -182,7 +182,7 @@
 /obj/effect/landmark/start{
 	name = "Squad Specialist"
 	},
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/floor{
 	icon_state = "warnwhite";
 	dir = 1
@@ -1402,7 +1402,7 @@
 "adB" = (
 /obj/structure/table,
 /obj/item/tool/surgery/surgicaldrill,
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /obj/item/tool/surgery/FixOVein,
 /turf/open/floor{
 	icon_state = "white"
@@ -3037,7 +3037,7 @@
 /area/sulaco/showers)
 "agK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/nanomed{
 	dir = 8
 	},
 /turf/open/floor{
@@ -3517,7 +3517,7 @@
 /obj/structure/bed/chair/wheelchair{
 	dir = 4
 	},
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/nanomed{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -3968,7 +3968,7 @@
 /obj/structure/bed/chair/wheelchair{
 	dir = 4
 	},
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/nanomed{
 	dir = 8
 	},
 /turf/open/floor{
@@ -4970,7 +4970,7 @@
 /obj/structure/table,
 /obj/item/tool/surgery/bonesetter,
 /obj/item/tool/surgery/bonegel,
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/nanomed{
 	dir = 8
 	},
 /turf/open/floor{
@@ -7126,7 +7126,7 @@
 	},
 /area/sulaco/cafeteria)
 "aoJ" = (
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/floor{
 	icon_state = "cafeteria";
 	dir = 2
@@ -7369,7 +7369,7 @@
 	},
 /area/sulaco/engineering/engine)
 "apn" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/nanomed{
 	dir = 4
 	},
 /obj/structure/table,
@@ -10724,7 +10724,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/nanomed{
 	dir = 8
 	},
 /turf/open/floor{
@@ -14704,7 +14704,7 @@
 	},
 /area/sulaco/engineering)
 "aCd" = (
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/floor{
 	icon_state = "yellowfull"
 	},
@@ -16283,7 +16283,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
 	},
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/floor,
 /area/sulaco/marine)
 "aFi" = (
@@ -17372,7 +17372,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
 	},
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/floor{
 	icon_state = "floor4"
 	},
@@ -17542,7 +17542,7 @@
 /turf/open/floor,
 /area/sulaco/marine/delta)
 "aHT" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/nanomed{
 	dir = 8
 	},
 /obj/structure/table/reinforced{
@@ -18128,7 +18128,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/bed/chair,
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/floor,
 /area/sulaco/hallway/central_hall3)
 "aJe" = (
@@ -18179,7 +18179,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/bed/chair,
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
 	},
@@ -20294,7 +20294,7 @@
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/shuttle{
 	icon_state = "floor7"
 	},
@@ -20312,7 +20312,7 @@
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/shuttle{
 	icon_state = "floor7"
 	},
@@ -20330,7 +20330,7 @@
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/shuttle{
 	icon_state = "floor7"
 	},
@@ -21601,7 +21601,7 @@
 	},
 /area/shuttle/drop2/sulaco)
 "aQD" = (
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /obj/structure/bed/chair/dropship/passenger,
 /turf/open/shuttle/dropship{
 	icon_state = "rasputin14"
@@ -22032,7 +22032,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/floor{
 	icon_state = "white"
 	},
@@ -22364,7 +22364,7 @@
 /obj/item/stack/sheet/mineral/phoron,
 /obj/item/stack/sheet/mineral/phoron,
 /obj/item/stack/sheet/mineral/phoron,
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/floor{
 	icon_state = "whitebluefull"
 	},
@@ -24286,7 +24286,7 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 1
 	},
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/floor{
 	icon_state = "vault"
 	},
@@ -24372,7 +24372,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/floor{
 	icon_state = "vault"
 	},
@@ -24860,7 +24860,7 @@
 	},
 /area/shuttle/drop1/sulaco)
 "aXM" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/nanomed{
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
@@ -26272,7 +26272,7 @@
 	},
 /area/shuttle/drop1/sulaco)
 "baX" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/nanomed{
 	dir = 8
 	},
 /obj/structure/bed/chair/dropship/passenger{
@@ -26284,7 +26284,7 @@
 	},
 /area/shuttle/drop1/sulaco)
 "baY" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/nanomed{
 	dir = 4
 	},
 /obj/structure/bed/chair/dropship/passenger{

--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -155,9 +155,7 @@
 /obj/effect/landmark/start{
 	name = "Squad Leader"
 	},
-/obj/machinery/vending/wallmed1{
-	pixel_y = 32
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/floor{
 	icon_state = "warnwhite";
 	dir = 1
@@ -184,9 +182,7 @@
 /obj/effect/landmark/start{
 	name = "Squad Specialist"
 	},
-/obj/machinery/vending/wallmed1{
-	pixel_y = 32
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/floor{
 	icon_state = "warnwhite";
 	dir = 1
@@ -1406,9 +1402,7 @@
 "adB" = (
 /obj/structure/table,
 /obj/item/tool/surgery/surgicaldrill,
-/obj/machinery/vending/wallmed1{
-	pixel_x = -32
-	},
+/obj/machinery/vending/wallmed,
 /obj/item/tool/surgery/FixOVein,
 /turf/open/floor{
 	icon_state = "white"
@@ -3043,8 +3037,8 @@
 /area/sulaco/showers)
 "agK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/machinery/vending/wallmed1{
-	pixel_x = -32
+/obj/machinery/vending/wallmed{
+	dir = 8
 	},
 /turf/open/floor{
 	icon_state = "freezerfloor"
@@ -3523,8 +3517,8 @@
 /obj/structure/bed/chair/wheelchair{
 	dir = 4
 	},
-/obj/machinery/vending/wallmed1{
-	pixel_x = -32
+/obj/machinery/vending/wallmed{
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -3974,8 +3968,8 @@
 /obj/structure/bed/chair/wheelchair{
 	dir = 4
 	},
-/obj/machinery/vending/wallmed1{
-	pixel_x = -32
+/obj/machinery/vending/wallmed{
+	dir = 8
 	},
 /turf/open/floor{
 	icon_state = "white"
@@ -4976,8 +4970,8 @@
 /obj/structure/table,
 /obj/item/tool/surgery/bonesetter,
 /obj/item/tool/surgery/bonegel,
-/obj/machinery/vending/wallmed1{
-	pixel_x = -32
+/obj/machinery/vending/wallmed{
+	dir = 8
 	},
 /turf/open/floor{
 	icon_state = "white"
@@ -7132,9 +7126,7 @@
 	},
 /area/sulaco/cafeteria)
 "aoJ" = (
-/obj/machinery/vending/wallmed1{
-	pixel_y = 32
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/floor{
 	icon_state = "cafeteria";
 	dir = 2
@@ -7377,8 +7369,8 @@
 	},
 /area/sulaco/engineering/engine)
 "apn" = (
-/obj/machinery/vending/wallmed1{
-	pixel_x = -30
+/obj/machinery/vending/wallmed{
+	dir = 4
 	},
 /obj/structure/table,
 /turf/open/floor{
@@ -10732,8 +10724,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/vending/wallmed1{
-	pixel_x = -32
+/obj/machinery/vending/wallmed{
+	dir = 8
 	},
 /turf/open/floor{
 	icon_state = "red";
@@ -14712,9 +14704,7 @@
 	},
 /area/sulaco/engineering)
 "aCd" = (
-/obj/machinery/vending/wallmed1{
-	pixel_y = 32
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/floor{
 	icon_state = "yellowfull"
 	},
@@ -16293,9 +16283,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
 	},
-/obj/machinery/vending/wallmed1{
-	pixel_y = 32
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/floor,
 /area/sulaco/marine)
 "aFi" = (
@@ -17384,9 +17372,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
 	},
-/obj/machinery/vending/wallmed1{
-	pixel_y = 30
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/floor{
 	icon_state = "floor4"
 	},
@@ -17556,8 +17542,8 @@
 /turf/open/floor,
 /area/sulaco/marine/delta)
 "aHT" = (
-/obj/machinery/vending/wallmed1{
-	pixel_x = -32
+/obj/machinery/vending/wallmed{
+	dir = 8
 	},
 /obj/structure/table/reinforced{
 	icon_state = "table"
@@ -18142,9 +18128,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/bed/chair,
-/obj/machinery/vending/wallmed1{
-	pixel_y = 32
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/floor,
 /area/sulaco/hallway/central_hall3)
 "aJe" = (
@@ -18195,9 +18179,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/bed/chair,
-/obj/machinery/vending/wallmed1{
-	pixel_y = 32
-	},
+/obj/machinery/vending/wallmed,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
 	},
@@ -20312,9 +20294,7 @@
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/obj/machinery/vending/wallmed1{
-	pixel_y = 32
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/shuttle{
 	icon_state = "floor7"
 	},
@@ -20332,9 +20312,7 @@
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/obj/machinery/vending/wallmed1{
-	pixel_y = 32
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/shuttle{
 	icon_state = "floor7"
 	},
@@ -20352,9 +20330,7 @@
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/obj/machinery/vending/wallmed1{
-	pixel_y = 32
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/shuttle{
 	icon_state = "floor7"
 	},
@@ -21625,9 +21601,7 @@
 	},
 /area/shuttle/drop2/sulaco)
 "aQD" = (
-/obj/machinery/vending/wallmed1{
-	pixel_y = 32
-	},
+/obj/machinery/vending/wallmed,
 /obj/structure/bed/chair/dropship/passenger,
 /turf/open/shuttle/dropship{
 	icon_state = "rasputin14"
@@ -22058,9 +22032,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/vending/wallmed1{
-	pixel_y = 32
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/floor{
 	icon_state = "white"
 	},
@@ -22392,9 +22364,7 @@
 /obj/item/stack/sheet/mineral/phoron,
 /obj/item/stack/sheet/mineral/phoron,
 /obj/item/stack/sheet/mineral/phoron,
-/obj/machinery/vending/wallmed1{
-	pixel_y = 32
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/floor{
 	icon_state = "whitebluefull"
 	},
@@ -24316,9 +24286,7 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 1
 	},
-/obj/machinery/vending/wallmed1{
-	pixel_y = 32
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/floor{
 	icon_state = "vault"
 	},
@@ -24404,9 +24372,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/obj/machinery/vending/wallmed1{
-	pixel_y = 32
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/floor{
 	icon_state = "vault"
 	},
@@ -24894,9 +24860,8 @@
 	},
 /area/shuttle/drop1/sulaco)
 "aXM" = (
-/obj/machinery/vending/wallmed1{
-	name = "Emergency NanoMed";
-	pixel_x = 30
+/obj/machinery/vending/wallmed{
+	dir = 8
 	},
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -26307,8 +26272,8 @@
 	},
 /area/shuttle/drop1/sulaco)
 "baX" = (
-/obj/machinery/vending/wallmed1{
-	pixel_x = -32
+/obj/machinery/vending/wallmed{
+	dir = 8
 	},
 /obj/structure/bed/chair/dropship/passenger{
 	icon_state = "shuttle_chair";
@@ -26319,8 +26284,8 @@
 	},
 /area/shuttle/drop1/sulaco)
 "baY" = (
-/obj/machinery/vending/wallmed1{
-	pixel_x = 32
+/obj/machinery/vending/wallmed{
+	dir = 4
 	},
 /obj/structure/bed/chair/dropship/passenger{
 	icon_state = "shuttle_chair";

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -212,7 +212,7 @@
 /turf/open/floor/plating,
 /area/almayer/hull/upper_hull)
 "aaF" = (
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -1321,7 +1321,7 @@
 	height = 2;
 	id = "l4"
 	},
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/floor/plating/almayer,
 /area/almayer/hallways/aft_hallway)
 "adD" = (
@@ -3548,7 +3548,7 @@
 /turf/open/floor/wood,
 /area/almayer/living/commandbunks)
 "aiZ" = (
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/floor/almayer{
 	icon_state = "greencorner";
 	dir = 1
@@ -4414,7 +4414,7 @@
 	},
 /area/almayer/hallways/stern_hallway)
 "akO" = (
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/floor/almayer{
 	icon_state = "orangecorner";
 	dir = 4
@@ -4752,7 +4752,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -5052,7 +5052,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -6055,7 +6055,7 @@
 /obj/item/storage/pouch/medical,
 /obj/item/storage/pouch/medical,
 /obj/item/storage/pouch/medical,
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/floor/almayer{
 	icon_state = "bluefull"
 	},
@@ -6147,7 +6147,7 @@
 	},
 /area/almayer/command/cic)
 "aoe" = (
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -7536,7 +7536,7 @@
 	},
 /area/almayer/shipboard/starboard_missiles)
 "arx" = (
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /obj/machinery/vending/cigarette,
 /turf/open/floor/almayer/mono,
 /area/almayer/shipboard/brig)
@@ -8134,7 +8134,7 @@
 /turf/open/floor/almayer/mono,
 /area/almayer/shipboard/chief_mp_office)
 "asU" = (
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/floor/almayer{
 	dir = 9;
 	icon_state = "red"
@@ -15052,7 +15052,7 @@
 	},
 /area/almayer/engineering/upper_engineering)
 "aGS" = (
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
@@ -15820,7 +15820,7 @@
 /area/almayer/squads/delta)
 "aIF" = (
 /obj/machinery/body_scanconsole,
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/floor/almayer{
 	icon_state = "dark_sterile"
 	},
@@ -17550,7 +17550,7 @@
 /turf/open/floor/almayer,
 /area/almayer/living/cafeteria_starboard)
 "aMi" = (
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/floor/almayer,
 /area/almayer/hallways/stern_hallway)
 "aMj" = (
@@ -18389,7 +18389,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -18471,7 +18471,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -19276,7 +19276,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/floor/almayer{
 	icon_state = "sterile"
 	},
@@ -19723,7 +19723,7 @@
 /area/almayer/hallways/aft_hallway)
 "aQR" = (
 /obj/structure/table/almayer,
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /obj/item/storage/firstaid/fire,
 /obj/item/storage/firstaid/fire,
 /turf/open/floor/almayer{
@@ -20101,7 +20101,7 @@
 	height = 2;
 	id = "l7"
 	},
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/floor/plating/almayer,
 /area/almayer/hallways/aft_hallway)
 "aRR" = (
@@ -22031,7 +22031,7 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
 	},
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/floor/wood,
 /area/almayer/living/basketball)
 "aXE" = (
@@ -25961,7 +25961,7 @@
 /turf/open/floor/almayer,
 /area/almayer/hallways/starboard_hallway)
 "bir" = (
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/floor/almayer,
 /area/almayer/hallways/starboard_hallway)
 "bit" = (
@@ -25986,7 +25986,7 @@
 /turf/open/floor/almayer/mono,
 /area/almayer/hallways/starboard_hallway)
 "biy" = (
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/floor/almayer/mono,
 /area/almayer/hallways/starboard_hallway)
 "biz" = (
@@ -26119,7 +26119,7 @@
 /turf/open/floor/almayer/mono,
 /area/almayer/hallways/hangar)
 "biT" = (
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/floor/almayer/mono,
 /area/almayer/hallways/hangar)
 "biU" = (
@@ -28241,7 +28241,7 @@
 /turf/open/floor/almayer,
 /area/almayer/hallways/hangar)
 "bog" = (
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/floor/almayer/mono,
 /area/almayer/living/briefing)
 "boh" = (
@@ -28827,7 +28827,7 @@
 /area/almayer/engineering/lower_engineering)
 "bpU" = (
 /obj/structure/table/almayer,
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /obj/item/lightreplacer,
 /turf/open/floor/almayer{
 	dir = 1;
@@ -35192,7 +35192,7 @@
 /turf/open/floor/almayer,
 /area/almayer/hallways/hangar)
 "bJo" = (
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -35431,7 +35431,7 @@
 	},
 /area/almayer/hallways/port_hallway)
 "bJV" = (
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/floor/almayer{
 	icon_state = "orangecorner";
 	dir = 1
@@ -37102,7 +37102,7 @@
 	},
 /area/almayer/hallways/port_hallway)
 "bON" = (
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/floor/almayer{
 	dir = 8;
 	icon_regular_floor = "cargo_arrow";
@@ -37366,7 +37366,7 @@
 /turf/open/floor/almayer,
 /area/almayer/hallways/port_hallway)
 "bPB" = (
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/floor/almayer,
 /area/almayer/hallways/port_hallway)
 "bPC" = (
@@ -43719,7 +43719,7 @@
 /turf/open/floor/almayer/mono,
 /area/almayer/shipboard/brig_cells)
 "cgJ" = (
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -44249,7 +44249,7 @@
 /obj/item/megaphone,
 /obj/item/megaphone,
 /obj/effect/landmark/map_item,
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/floor/almayer/mono,
 /area/almayer/living/bridgebunks)
 "chR" = (

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -212,9 +212,7 @@
 /turf/open/floor/plating,
 /area/almayer/hull/upper_hull)
 "aaF" = (
-/obj/machinery/vending/wallmed1{
-	pixel_y = 25
-	},
+/obj/machinery/vending/wallmed,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -1323,9 +1321,7 @@
 	height = 2;
 	id = "l4"
 	},
-/obj/machinery/vending/wallmed1{
-	pixel_y = 25
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/floor/plating/almayer,
 /area/almayer/hallways/aft_hallway)
 "adD" = (
@@ -3552,9 +3548,7 @@
 /turf/open/floor/wood,
 /area/almayer/living/commandbunks)
 "aiZ" = (
-/obj/machinery/vending/wallmed1{
-	pixel_y = 25
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/floor/almayer{
 	icon_state = "greencorner";
 	dir = 1
@@ -4420,9 +4414,7 @@
 	},
 /area/almayer/hallways/stern_hallway)
 "akO" = (
-/obj/machinery/vending/wallmed1{
-	pixel_y = 25
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/floor/almayer{
 	icon_state = "orangecorner";
 	dir = 4
@@ -4760,9 +4752,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/vending/wallmed1{
-	pixel_y = 25
-	},
+/obj/machinery/vending/wallmed,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -5062,9 +5052,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/vending/wallmed1{
-	pixel_y = 25
-	},
+/obj/machinery/vending/wallmed,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -6067,9 +6055,7 @@
 /obj/item/storage/pouch/medical,
 /obj/item/storage/pouch/medical,
 /obj/item/storage/pouch/medical,
-/obj/machinery/vending/wallmed1{
-	pixel_y = 25
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/floor/almayer{
 	icon_state = "bluefull"
 	},
@@ -6161,9 +6147,7 @@
 	},
 /area/almayer/command/cic)
 "aoe" = (
-/obj/machinery/vending/wallmed1{
-	pixel_y = 25
-	},
+/obj/machinery/vending/wallmed,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -7552,9 +7536,7 @@
 	},
 /area/almayer/shipboard/starboard_missiles)
 "arx" = (
-/obj/machinery/vending/wallmed1{
-	pixel_y = 25
-	},
+/obj/machinery/vending/wallmed,
 /obj/machinery/vending/cigarette,
 /turf/open/floor/almayer/mono,
 /area/almayer/shipboard/brig)
@@ -8152,9 +8134,7 @@
 /turf/open/floor/almayer/mono,
 /area/almayer/shipboard/chief_mp_office)
 "asU" = (
-/obj/machinery/vending/wallmed1{
-	pixel_y = 25
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/floor/almayer{
 	dir = 9;
 	icon_state = "red"
@@ -15072,9 +15052,7 @@
 	},
 /area/almayer/engineering/upper_engineering)
 "aGS" = (
-/obj/machinery/vending/wallmed1{
-	pixel_y = 25
-	},
+/obj/machinery/vending/wallmed,
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
@@ -15842,9 +15820,7 @@
 /area/almayer/squads/delta)
 "aIF" = (
 /obj/machinery/body_scanconsole,
-/obj/machinery/vending/wallmed1{
-	pixel_y = 25
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/floor/almayer{
 	icon_state = "dark_sterile"
 	},
@@ -17574,9 +17550,7 @@
 /turf/open/floor/almayer,
 /area/almayer/living/cafeteria_starboard)
 "aMi" = (
-/obj/machinery/vending/wallmed1{
-	pixel_y = 25
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/floor/almayer,
 /area/almayer/hallways/stern_hallway)
 "aMj" = (
@@ -18415,9 +18389,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/vending/wallmed1{
-	pixel_y = 25
-	},
+/obj/machinery/vending/wallmed,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -18499,9 +18471,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/vending/wallmed1{
-	pixel_y = 25
-	},
+/obj/machinery/vending/wallmed,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -19306,9 +19276,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/vending/wallmed1{
-	pixel_y = 25
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/floor/almayer{
 	icon_state = "sterile"
 	},
@@ -19755,9 +19723,7 @@
 /area/almayer/hallways/aft_hallway)
 "aQR" = (
 /obj/structure/table/almayer,
-/obj/machinery/vending/wallmed1{
-	pixel_y = 25
-	},
+/obj/machinery/vending/wallmed,
 /obj/item/storage/firstaid/fire,
 /obj/item/storage/firstaid/fire,
 /turf/open/floor/almayer{
@@ -20135,9 +20101,7 @@
 	height = 2;
 	id = "l7"
 	},
-/obj/machinery/vending/wallmed1{
-	pixel_y = 25
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/floor/plating/almayer,
 /area/almayer/hallways/aft_hallway)
 "aRR" = (
@@ -22067,9 +22031,7 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
 	},
-/obj/machinery/vending/wallmed1{
-	pixel_y = 25
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/floor/wood,
 /area/almayer/living/basketball)
 "aXE" = (
@@ -25999,9 +25961,7 @@
 /turf/open/floor/almayer,
 /area/almayer/hallways/starboard_hallway)
 "bir" = (
-/obj/machinery/vending/wallmed1{
-	pixel_y = 25
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/floor/almayer,
 /area/almayer/hallways/starboard_hallway)
 "bit" = (
@@ -26026,9 +25986,7 @@
 /turf/open/floor/almayer/mono,
 /area/almayer/hallways/starboard_hallway)
 "biy" = (
-/obj/machinery/vending/wallmed1{
-	pixel_y = 25
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/floor/almayer/mono,
 /area/almayer/hallways/starboard_hallway)
 "biz" = (
@@ -26161,9 +26119,7 @@
 /turf/open/floor/almayer/mono,
 /area/almayer/hallways/hangar)
 "biT" = (
-/obj/machinery/vending/wallmed1{
-	pixel_y = 25
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/floor/almayer/mono,
 /area/almayer/hallways/hangar)
 "biU" = (
@@ -28285,9 +28241,7 @@
 /turf/open/floor/almayer,
 /area/almayer/hallways/hangar)
 "bog" = (
-/obj/machinery/vending/wallmed1{
-	pixel_y = 25
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/floor/almayer/mono,
 /area/almayer/living/briefing)
 "boh" = (
@@ -28873,9 +28827,7 @@
 /area/almayer/engineering/lower_engineering)
 "bpU" = (
 /obj/structure/table/almayer,
-/obj/machinery/vending/wallmed1{
-	pixel_y = 25
-	},
+/obj/machinery/vending/wallmed,
 /obj/item/lightreplacer,
 /turf/open/floor/almayer{
 	dir = 1;
@@ -35240,9 +35192,7 @@
 /turf/open/floor/almayer,
 /area/almayer/hallways/hangar)
 "bJo" = (
-/obj/machinery/vending/wallmed1{
-	pixel_y = 25
-	},
+/obj/machinery/vending/wallmed,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -35481,9 +35431,7 @@
 	},
 /area/almayer/hallways/port_hallway)
 "bJV" = (
-/obj/machinery/vending/wallmed1{
-	pixel_y = 25
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/floor/almayer{
 	icon_state = "orangecorner";
 	dir = 1
@@ -37154,9 +37102,7 @@
 	},
 /area/almayer/hallways/port_hallway)
 "bON" = (
-/obj/machinery/vending/wallmed1{
-	pixel_y = 25
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/floor/almayer{
 	dir = 8;
 	icon_regular_floor = "cargo_arrow";
@@ -37420,9 +37366,7 @@
 /turf/open/floor/almayer,
 /area/almayer/hallways/port_hallway)
 "bPB" = (
-/obj/machinery/vending/wallmed1{
-	pixel_y = 25
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/floor/almayer,
 /area/almayer/hallways/port_hallway)
 "bPC" = (
@@ -43775,9 +43719,7 @@
 /turf/open/floor/almayer/mono,
 /area/almayer/shipboard/brig_cells)
 "cgJ" = (
-/obj/machinery/vending/wallmed1{
-	pixel_y = 25
-	},
+/obj/machinery/vending/wallmed,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -44307,9 +44249,7 @@
 /obj/item/megaphone,
 /obj/item/megaphone,
 /obj/effect/landmark/map_item,
-/obj/machinery/vending/wallmed1{
-	pixel_y = 25
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/floor/almayer/mono,
 /area/almayer/living/bridgebunks)
 "chR" = (

--- a/_maps/map_files/Whiskey_Outpost/Whiskey_Outpost_v2.dmm
+++ b/_maps/map_files/Whiskey_Outpost/Whiskey_Outpost_v2.dmm
@@ -3501,10 +3501,8 @@
 	},
 /area/whiskey_outpost)
 "jE" = (
-/obj/machinery/vending/wallmed1{
-	name = "Emergency NanoMed";
-	pixel_x = 30;
-	req_access_txt = "0"
+/obj/machinery/vending/wallmed{
+	dir = 8
 	},
 /obj/item/storage/firstaid/regular,
 /turf/open/floor{
@@ -3565,10 +3563,8 @@
 	},
 /area/whiskey_outpost)
 "jO" = (
-/obj/machinery/vending/wallmed1{
-	name = "Emergency NanoMed";
-	pixel_x = 30;
-	req_access_txt = "0"
+/obj/machinery/vending/wallmed{
+	dir = 8
 	},
 /obj/item/roller,
 /turf/open/floor{
@@ -3638,10 +3634,8 @@
 	},
 /area/whiskey_outpost)
 "jZ" = (
-/obj/machinery/vending/wallmed1{
-	name = "Emergency NanoMed";
-	pixel_x = 30;
-	req_access_txt = "0"
+/obj/machinery/vending/wallmed{
+	dir = 8
 	},
 /obj/item/storage/box/sentry,
 /obj/item/flashlight,
@@ -3652,9 +3646,7 @@
 	},
 /area/whiskey_outpost)
 "kb" = (
-/obj/machinery/vending/wallmed1{
-	pixel_x = -32
-	},
+/obj/machinery/vending/wallmed,
 /obj/structure/bed/chair/dropship/passenger{
 	icon_state = "shuttle_chair";
 	dir = 4
@@ -3664,8 +3656,8 @@
 	},
 /area/whiskey_outpost/outside/east)
 "kc" = (
-/obj/machinery/vending/wallmed1{
-	pixel_x = 32
+/obj/machinery/vending/wallmed{
+	dir = 4
 	},
 /obj/structure/bed/chair/dropship/passenger{
 	icon_state = "shuttle_chair";

--- a/_maps/map_files/Whiskey_Outpost/Whiskey_Outpost_v2.dmm
+++ b/_maps/map_files/Whiskey_Outpost/Whiskey_Outpost_v2.dmm
@@ -3501,7 +3501,7 @@
 	},
 /area/whiskey_outpost)
 "jE" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/nanomed{
 	dir = 8
 	},
 /obj/item/storage/firstaid/regular,
@@ -3563,7 +3563,7 @@
 	},
 /area/whiskey_outpost)
 "jO" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/nanomed{
 	dir = 8
 	},
 /obj/item/roller,
@@ -3634,7 +3634,7 @@
 	},
 /area/whiskey_outpost)
 "jZ" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/nanomed{
 	dir = 8
 	},
 /obj/item/storage/box/sentry,
@@ -3646,7 +3646,7 @@
 	},
 /area/whiskey_outpost)
 "kb" = (
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /obj/structure/bed/chair/dropship/passenger{
 	icon_state = "shuttle_chair";
 	dir = 4
@@ -3656,7 +3656,7 @@
 	},
 /area/whiskey_outpost/outside/east)
 "kc" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/nanomed{
 	dir = 4
 	},
 /obj/structure/bed/chair/dropship/passenger{

--- a/_maps/shuttles/alamo.dmm
+++ b/_maps/shuttles/alamo.dmm
@@ -399,7 +399,7 @@
 /obj/structure/bed/chair/dropship/passenger{
 	dir = 4
 	},
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/nanomed{
 	dir = 4
 	},
 /turf/open/shuttle/dropship/floor,
@@ -412,7 +412,7 @@
 /obj/structure/bed/chair/dropship/passenger{
 	dir = 8
 	},
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/nanomed{
 	dir = 8
 	},
 /turf/open/shuttle/dropship/floor,

--- a/_maps/shuttles/alamo.dmm
+++ b/_maps/shuttles/alamo.dmm
@@ -399,8 +399,8 @@
 /obj/structure/bed/chair/dropship/passenger{
 	dir = 4
 	},
-/obj/machinery/vending/wallmed1{
-	pixel_x = -30
+/obj/machinery/vending/wallmed{
+	dir = 4
 	},
 /turf/open/shuttle/dropship/floor,
 /area/shuttle/dropship/alamo)
@@ -412,8 +412,8 @@
 /obj/structure/bed/chair/dropship/passenger{
 	dir = 8
 	},
-/obj/machinery/vending/wallmed1{
-	pixel_x = 30
+/obj/machinery/vending/wallmed{
+	dir = 8
 	},
 /turf/open/shuttle/dropship/floor,
 /area/shuttle/dropship/alamo)

--- a/_maps/shuttles/tgs_canterbury.dmm
+++ b/_maps/shuttles/tgs_canterbury.dmm
@@ -528,7 +528,7 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 9
 	},
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/floor/almayer{
 	dir = 4;
 	icon_regular_floor = "cargo_arrow";
@@ -953,7 +953,7 @@
 	},
 /area/shuttle/canterbury/general)
 "bR" = (
-/obj/machinery/vending/wallmed,
+/obj/machinery/vending/nanomed,
 /turf/open/floor/almayer{
 	icon_state = "orangefull"
 	},

--- a/_maps/shuttles/tgs_canterbury.dmm
+++ b/_maps/shuttles/tgs_canterbury.dmm
@@ -528,9 +528,7 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 9
 	},
-/obj/machinery/vending/wallmed1{
-	pixel_y = 25
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/floor/almayer{
 	dir = 4;
 	icon_regular_floor = "cargo_arrow";
@@ -955,9 +953,7 @@
 	},
 /area/shuttle/canterbury/general)
 "bR" = (
-/obj/machinery/vending/wallmed1{
-	pixel_y = 25
-	},
+/obj/machinery/vending/wallmed,
 /turf/open/floor/almayer{
 	icon_state = "orangefull"
 	},

--- a/code/game/objects/machinery/vending/vending_types.dm
+++ b/code/game/objects/machinery/vending/vending_types.dm
@@ -204,7 +204,7 @@
 					/obj/item/transfer_valve = 6,/obj/item/assembly/timer = 6,/obj/item/assembly/signaler = 6,
 					/obj/item/assembly/prox_sensor = 6,/obj/item/assembly/igniter = 6)
 
-/obj/machinery/vending/wallmed
+/obj/machinery/vending/nanomed
 	name = "NanoMed"
 	desc = "Wall-mounted Medical Equipment dispenser."
 	product_ads = "Go save some lives!;The best stuff for your medbay.;Only the finest tools.;Natural chemicals!;This stuff saves lives.;Don't you want some?"
@@ -222,15 +222,15 @@
 						/obj/item/reagent_container/syringe/antiviral = 2)
 
 
-/obj/machinery/vending/wallmed/Initialize(mapload, ...)
+/obj/machinery/vending/nanomed/Initialize(mapload, ...)
 	. = ..()
 	switch(dir)
 		if(NORTH)
-			pixel_y = -25
+			pixel_y = -28
 		if(SOUTH)
-			pixel_y = 25
+			pixel_y = 26
 		if(EAST)
-			pixel_x = -25
+			pixel_x = -30
 		if(WEST)
 			pixel_x = 25
 

--- a/code/game/objects/machinery/vending/vending_types.dm
+++ b/code/game/objects/machinery/vending/vending_types.dm
@@ -204,7 +204,7 @@
 					/obj/item/transfer_valve = 6,/obj/item/assembly/timer = 6,/obj/item/assembly/signaler = 6,
 					/obj/item/assembly/prox_sensor = 6,/obj/item/assembly/igniter = 6)
 
-/obj/machinery/vending/wallmed1
+/obj/machinery/vending/wallmed
 	name = "NanoMed"
 	desc = "Wall-mounted Medical Equipment dispenser."
 	product_ads = "Go save some lives!;The best stuff for your medbay.;Only the finest tools.;Natural chemicals!;This stuff saves lives.;Don't you want some?"
@@ -221,21 +221,19 @@
 	contraband = list(/obj/item/reagent_container/syringe/dylovene = 2,
 						/obj/item/reagent_container/syringe/antiviral = 2)
 
-/obj/machinery/vending/wallmed2
-	name = "NanoMed"
-	desc = "Wall-mounted Medical Equipment dispenser."
-	icon_state = "wallmed"
-	icon_deny = "wallmed-deny"
-	density = FALSE //It is wall-mounted, and thus, not dense. --Superxpdude
-	wrenchable = FALSE
-	products = list(/obj/item/reagent_container/hypospray/autoinjector/tricordrazine = 1,
-					/obj/item/reagent_container/hypospray/autoinjector/tramadol = 1,
-					/obj/item/reagent_container/syringe/dylovene = 3,
-					/obj/item/stack/medical/bruise_pack = 3,
-					/obj/item/stack/medical/ointment =3,
-					/obj/item/healthanalyzer = 3,
-					/obj/item/stack/medical/splint = 1)
-	contraband = list(/obj/item/reagent_container/pill/tox = 3)
+
+/obj/machinery/vending/wallmed/Initialize(mapload, ...)
+	. = ..()
+	switch(dir)
+		if(NORTH)
+			pixel_y = -25
+		if(SOUTH)
+			pixel_y = 25
+		if(EAST)
+			pixel_x = -25
+		if(WEST)
+			pixel_x = 25
+
 
 /obj/machinery/vending/security
 	name = "SecTech"

--- a/code/game/objects/machinery/vending/vending_types.dm
+++ b/code/game/objects/machinery/vending/vending_types.dm
@@ -210,7 +210,7 @@
 	product_ads = "Go save some lives!;The best stuff for your medbay.;Only the finest tools.;Natural chemicals!;This stuff saves lives.;Don't you want some?"
 	icon_state = "wallmed"
 	icon_deny = "wallmed-deny"
-	density = FALSE //It is wall-mounted, and thus, not dense. --Superxpdude
+	density = FALSE
 	wrenchable = FALSE
 	products = list(/obj/item/reagent_container/hypospray/autoinjector/tricordrazine = 1,
 					/obj/item/reagent_container/hypospray/autoinjector/tramadol = 1,


### PR DESCRIPTION
Also removes an unused second type.

Should make making new maps without var-edits easier.

They don't look much better than before because the sprite was not meant to be directional, but at least they are not pixel edited now. Should make it easier to change that in the future.