### PR TITLE
Fixes an issue with xeno cooldown abilities

### DIFF
--- a/code/datums/actions/xeno_action.dm
+++ b/code/datums/actions/xeno_action.dm
@@ -114,13 +114,17 @@
 /datum/action/xeno_action/proc/action_cooldown_check()
 	return !on_cooldown
 
+
 /datum/action/xeno_action/proc/clear_cooldown()
-	for(var/timer in active_timers)
-		qdel(timer)
-		on_cooldown_finish()
+	if(!cooldown_id)
+		return
+	deltimer(cooldown_id)
+	on_cooldown_finish()
+
 
 /datum/action/xeno_action/proc/get_cooldown()
 	return cooldown_timer
+
 
 /datum/action/xeno_action/proc/add_cooldown()
 	if(on_cooldown) // stop doubling up
@@ -131,11 +135,10 @@
 	button.overlays += cooldown_image
 	update_button_icon()
 
+
 /datum/action/xeno_action/proc/cooldown_remaining()
-	for(var/i in active_timers)
-		var/datum/timedevent/timer = i
-		return (timer.timeToRun - world.time) * 0.1
-	return 0
+	return timeleft(cooldown_id) * 0.1
+
 
 //override this for cooldown completion.
 /datum/action/xeno_action/proc/on_cooldown_finish()

--- a/code/datums/actions/xeno_action.dm
+++ b/code/datums/actions/xeno_action.dm
@@ -123,12 +123,13 @@
 	return cooldown_timer
 
 /datum/action/xeno_action/proc/add_cooldown()
-	if(!length(active_timers)) // stop doubling up
-		last_use = world.time
-		on_cooldown = TRUE
-		cooldown_id = addtimer(CALLBACK(src, .proc/on_cooldown_finish), get_cooldown(), TIMER_STOPPABLE)
-		button.overlays += cooldown_image
-		update_button_icon()
+	if(on_cooldown) // stop doubling up
+		return
+	last_use = world.time
+	on_cooldown = TRUE
+	cooldown_id = addtimer(CALLBACK(src, .proc/on_cooldown_finish), get_cooldown(), TIMER_STOPPABLE)
+	button.overlays += cooldown_image
+	update_button_icon()
 
 /datum/action/xeno_action/proc/cooldown_remaining()
 	for(var/i in active_timers)

--- a/code/datums/actions/xeno_action.dm
+++ b/code/datums/actions/xeno_action.dm
@@ -3,7 +3,6 @@
 	var/plasma_cost = 0
 	var/mechanics_text = "This ability not found in codex." //codex. If you are going to add an explanation for an ability. don't use stats, give a very brief explanation of how to use it.
 	var/use_state_flags = NONE // bypass use limitations checked by can_use_action()
-	var/on_cooldown
 	var/last_use
 	var/cooldown_timer
 	var/ability_name
@@ -112,7 +111,7 @@
 //checks if the linked ability is on some cooldown.
 //The action can still be activated by clicking the button
 /datum/action/xeno_action/proc/action_cooldown_check()
-	return !on_cooldown
+	return !cooldown_id
 
 
 /datum/action/xeno_action/proc/clear_cooldown()
@@ -127,10 +126,9 @@
 
 
 /datum/action/xeno_action/proc/add_cooldown()
-	if(on_cooldown) // stop doubling up
+	if(cooldown_id) // stop doubling up
 		return
 	last_use = world.time
-	on_cooldown = TRUE
 	cooldown_id = addtimer(CALLBACK(src, .proc/on_cooldown_finish), get_cooldown(), TIMER_STOPPABLE)
 	button.overlays += cooldown_image
 	update_button_icon()
@@ -142,7 +140,7 @@
 
 //override this for cooldown completion.
 /datum/action/xeno_action/proc/on_cooldown_finish()
-	on_cooldown = FALSE
+	cooldown_id = null
 	if(!button)
 		CRASH("no button object on finishing xeno action cooldown")
 	button.overlays -= cooldown_image

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
@@ -48,7 +48,7 @@
 		to_chat(X, "<span class='warning'>We need a facehugger in our hand to throw one!</span>")
 		return fail_activate()
 
-	if(!on_cooldown)
+	if(!cooldown_id)
 		X.dropItemToGround(F)
 		playsound(X, 'sound/effects/throw.ogg', 30, 1)
 		F.throw_at(A, CARRIER_HUGGER_THROW_DISTANCE, CARRIER_HUGGER_THROW_SPEED)

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -216,7 +216,7 @@
 	var/was_fortified = X.fortify
 	if(X.fortify)
 		var/datum/action/xeno_action/FT = X.actions_by_path[/datum/action/xeno_action/fortify]
-		if(FT.on_cooldown)
+		if(FT.cooldown_id)
 			to_chat(src, "<span class='xenowarning'>We cannot yet untuck ourselves!</span>")
 			return fail_activate()
 		X.set_fortify(FALSE, TRUE)
@@ -273,7 +273,7 @@
 	var/was_crested = X.crest_defense
 	if(X.crest_defense)
 		var/datum/action/xeno_action/CD = X.actions_by_path[/datum/action/xeno_action/toggle_crest_defense]
-		if(CD.on_cooldown)
+		if(CD.cooldown_id)
 			to_chat(X, "<span class='xenowarning'>We cannot yet transition to a defensive stance!</span>")
 			return fail_activate()
 		X.set_crest_defense(FALSE, TRUE)


### PR DESCRIPTION
Also removes hopefully the last runtime from the Shrike.

In short, `add_cooldown()` was returning if there were any `active_timers`. Which meant that an ability with a `CALLBACK` would simply fail to add cooldown.
Since `on_cooldown` will always be `TRUE` when the timer is running and `FALSE` otherwise, this will avoid the runtimes the original check wanted to.

Fixed a few other places where it would take or delete any timer disrespecting ids.