### PR TITLE
Fixes a duplicate log

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -33,8 +33,6 @@ GLOBAL_VAR_INIT(bypass_tgs_reboot, world.system_type == UNIX && world.byond_buil
 	SSdbcore.SetRoundID()
 	SetupLogs()
 
-	world.log = file("[GLOB.log_directory]/runtime.log")
-
 	LoadVerbs(/datum/verbs/menu)
 	load_admins()
 


### PR DESCRIPTION
Previously everything was getting logged twice into the runtime log.
Log_world already sends it to the runtime.log so this is unnecessary (and having 2 duplicate files doing the same thing would be pretty dumb)