### PR TITLE
Adds weed decay

### DIFF
--- a/code/controllers/subsystem/weeds_decay.dm
+++ b/code/controllers/subsystem/weeds_decay.dm
@@ -1,0 +1,51 @@
+SUBSYSTEM_DEF(weeds_decay)
+	name = "Weed Decay"
+	priority = FIRE_PRIORITY_WEED
+	runlevels = RUNLEVEL_LOBBY|RUNLEVEL_SETUP|RUNLEVEL_GAME|RUNLEVEL_POSTGAME
+	wait = 15 SECONDS
+
+	// This is a list of nodes on the map.
+	var/list/decaying = list()
+
+/datum/controller/subsystem/weeds_decay/stat_entry()
+	return ..("Decay Nodes: [length(decaying)]")
+
+/datum/controller/subsystem/weeds_decay/fire(resumed = FALSE)
+
+	for(var/A in decaying)
+		if(MC_TICK_CHECK)
+			return
+
+		var/turf/T = A
+		if(QDELETED(T))
+			decaying -= T
+			continue
+
+		var/obj/effect/alien/weeds/W = locate() in T
+		if(QDELETED(W) || W.parent_node)
+			decaying -= T
+			continue
+
+		var/decay_chance = 100
+		for(var/direction in GLOB.cardinals) 
+			var/turf/adj = get_step(T, direction)
+			if(locate(/obj/effect/alien/weeds) in adj)
+				decay_chance -= rand(25, 40)
+
+		if(decay_chance > 0 && prob(decay_chance))
+			W.parent_node = null // So it wont try to regrow
+			addtimer(CALLBACK(GLOBAL_PROC, .proc/qdel, W), rand(0, 7 SECONDS))
+			decaying -= T
+
+/datum/controller/subsystem/weeds_decay/proc/decay_weeds(list/obj/effect/alien/weeds/node_turfs)
+	for(var/X in node_turfs)
+		var/turf/T = X
+
+		// Skip if there is not a weed there
+		var/obj/effect/alien/weeds/W = locate() in T
+		if(!W)
+			continue
+
+		W.parent_node = null // mark this null otherwise the weed regrows
+		decaying += T
+

--- a/code/controllers/subsystem/weeds_decay.dm
+++ b/code/controllers/subsystem/weeds_decay.dm
@@ -22,7 +22,7 @@ SUBSYSTEM_DEF(weeds_decay)
 			continue
 
 		var/obj/effect/alien/weeds/W = locate() in T
-		if(QDELETED(W) || W.parent_node)
+		if(QDELETED(W) || W.parent_node || istype(W, /obj/effect/alien/weeds/node))
 			decaying -= T
 			continue
 

--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -27,7 +27,8 @@
 
 
 /obj/effect/alien/weeds/Destroy()
-	SSweeds.add_weed(src)
+	if(parent_node)
+		SSweeds.add_weed(src)
 
 	var/oldloc = loc
 	. = ..()
@@ -183,6 +184,12 @@
 	max_integrity = 15
 
 	var/node_turfs = list() // list of all potential turfs that we can expand to
+
+/obj/effect/alien/weeds/node/Destroy()
+	. = ..()
+
+	SSweeds.decay_weeds(node_turfs)
+
 
 
 /obj/effect/alien/weeds/node/update_icon()

--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -187,9 +187,7 @@
 
 /obj/effect/alien/weeds/node/Destroy()
 	. = ..()
-
-	SSweeds.decay_weeds(node_turfs)
-
+	SSweeds_decay.decay_weeds(node_turfs)
 
 
 /obj/effect/alien/weeds/node/update_icon()

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -183,6 +183,7 @@
 #include "code\controllers\subsystem\timer.dm"
 #include "code\controllers\subsystem\vote.dm"
 #include "code\controllers\subsystem\weeds.dm"
+#include "code\controllers\subsystem\weeds_decay.dm"
 #include "code\controllers\subsystem\processing\fastprocess.dm"
 #include "code\controllers\subsystem\processing\obj.dm"
 #include "code\controllers\subsystem\processing\processing.dm"


### PR DESCRIPTION
## About The Pull Request

This adds that when a weed node is destroyed the weeds connected within its graph slowly die out.
This happens every 3rd tick of the subsystem which makes decay much slower than growth.

Also adds some changes to ensure new nodes take over orphaned weeds, so they can continue to live on.

## Why It's Good For The Game

This helps combat weed creep, and reduces the power of the weeds.

## Changelog
:cl:
balance: Weeds will now decay over time if their node is destroyed, at a rate of about 3 times slower than the growth speed.
/:cl:


---

https://streamable.com/4d9jq