### PR TITLE
Blockers rework

### DIFF
--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -25261,6 +25261,14 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
+"ggp" = (
+/obj/machinery/button/door/open_only/landing_zone,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/bigredv2/outside/space_port)
 "ggV" = (
 /obj/machinery/door/airlock/almayer/engineering{
 	dir = 4;
@@ -25416,17 +25424,6 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves)
-"hGl" = (
-/obj/machinery/button/door/open_only/landing_zone,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/bigredv2/outside/space_port)
 "hHN" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/tile/dark/yellow2/corner{
@@ -25734,6 +25731,26 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
+"mKt" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/button/door/open_only/landing_zone/lz2{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/marking/asteroidwarning{
+	dir = 4
+	},
+/area/bigredv2/outside/sw)
 "mSx" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/wall/r_wall,
@@ -26192,21 +26209,6 @@
 "shZ" = (
 /obj/machinery/landinglight/ds2/delaytwo{
 	dir = 4
-	},
-/turf/open/floor/marking/asteroidwarning{
-	dir = 4
-	},
-/area/bigredv2/outside/sw)
-"skR" = (
-/obj/machinery/button/door/open_only/landing_zone/lz2{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
 	},
 /turf/open/floor/marking/asteroidwarning{
 	dir = 4
@@ -35687,11 +35689,11 @@ bdZ
 bpv
 bsa
 ehV
-skR
+brc
 brc
 brc
 boC
-bpw
+mKt
 bpw
 bpw
 bqF
@@ -37313,7 +37315,7 @@ aad
 aad
 hzx
 plF
-hGl
+aaO
 aaO
 aaO
 abg
@@ -37756,7 +37758,7 @@ sGO
 sGO
 sGO
 aae
-aah
+ggp
 acj
 aah
 aah

--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -100,9 +100,6 @@
 /area/bigredv2/outside/space_port)
 "aay" = (
 /obj/machinery/vending/cigarette/colony,
-/turf/open/floor/tile/dark,
-/area/bigredv2/outside/space_port)
-"aaz" = (
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
@@ -584,6 +581,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/table/reinforced,
+/obj/machinery/computer/shuttle/shuttle_control/dropship1,
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/space_port)
 "aca" = (
@@ -702,6 +701,7 @@
 /obj/item/shard,
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/structure/window_frame/colony/reinforced,
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
 /area/bigredv2/outside/marshal_office)
 "act" = (
@@ -2255,6 +2255,9 @@
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/telecomm)
 "ahe" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
 /turf/open/floor/marking/asteroidwarning{
 	dir = 8
 	},
@@ -2266,14 +2269,23 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/space_port)
 "ahg" = (
 /obj/item/stack/sheet/metal,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
 /turf/open/floor/plating/dmg3,
 /area/bigredv2/outside/space_port)
 "ahh" = (
 /obj/structure/girder/reinforced,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/space_port)
 "ahj" = (
@@ -5925,6 +5937,7 @@
 /area/bigredv2/caves/lambda_lab)
 "arL" = (
 /obj/effect/glowshroom,
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves)
 "arM" = (
@@ -10822,6 +10835,7 @@
 /area/bigredv2/caves/lambda_lab)
 "aGo" = (
 /obj/structure/fence,
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves)
 "aGp" = (
@@ -11055,6 +11069,7 @@
 /area/bigredv2/caves/lambda_lab)
 "aHf" = (
 /obj/structure/fence,
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 4
 	},
@@ -15339,6 +15354,7 @@
 /area/bigredv2/caves/lambda_lab)
 "aUK" = (
 /obj/structure/mineral_door/resin,
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/lambda_lab)
 "aUL" = (
@@ -17134,6 +17150,7 @@
 /area/bigredv2/outside/w)
 "bbd" = (
 /obj/structure/window_frame/colony,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating,
 /area/bigredv2/outside/cargo)
 "bbe" = (
@@ -17445,6 +17462,7 @@
 /obj/structure/barricade/wooden/lv_snowflake{
 	dir = 8
 	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating,
 /area/bigredv2/outside/cargo)
 "bcu" = (
@@ -20791,6 +20809,7 @@
 	dir = 1;
 	name = "\improper Engineering Complex"
 	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
 "boE" = (
@@ -21240,6 +21259,7 @@
 /area/bigredv2/outside/se)
 "bpZ" = (
 /obj/structure/fence,
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/se)
 "bqa" = (
@@ -24801,6 +24821,7 @@
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "bEr" = (
 /obj/structure/mineral_door/resin,
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 1
 	},
@@ -24960,6 +24981,12 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/se)
+"cmR" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/bigredv2/outside/sw)
 "cuW" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -24971,9 +24998,19 @@
 	},
 /turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/nw)
+"cuX" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/mars/cavetodirt{
+	dir = 1
+	},
+/area/bigredv2/outside/se)
 "cBD" = (
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/bigredv2/outside/sw)
+"cWF" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/mineral/bigred,
+/area/bigredv2/outside/se)
 "cXq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -24985,6 +25022,9 @@
 "cXu" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/bigredv2/outside/se)
+"daV" = (
+/turf/open/space/basic,
+/area/lv624/lazarus/quartstorage/outdoors)
 "djN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -25012,6 +25052,12 @@
 	},
 /turf/open/floor/tile/darkish,
 /area/bigredv2/outside/chapel)
+"dBp" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/outside/sw)
 "dGd" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -25028,12 +25074,24 @@
 /obj/effect/landmark/start/surv_spawn,
 /turf/open/floor/grimy,
 /area/bigredv2/outside/marshal_office)
+"dWa" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/closed/mineral/bigred,
+/area/bigredv2/caves)
 "dXh" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/nw)
+"dXK" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/closed/wall/r_wall,
+/area/bigredv2/outside/sw)
 "dZi" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/tile/dark/yellow2/corner{
@@ -25047,6 +25105,24 @@
 /obj/structure/sign/safety/medical_supplies,
 /turf/closed/wall/r_wall,
 /area/bigredv2/caves/lambda_lab)
+"ehV" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/shuttle/shuttle_control/dropship1,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 4
+	},
+/area/bigredv2/outside/sw)
+"ekR" = (
+/obj/item/stack/rods,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/floor/plating/dmg3,
+/area/bigredv2/outside/space_port)
+"eqy" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/closed/wall,
+/area/bigredv2/outside/cargo)
 "exJ" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 8
@@ -25090,6 +25166,12 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"fgX" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/closed/wall,
+/area/bigredv2/outside/cargo)
 "fil" = (
 /obj/machinery/landinglight/ds2/delayone{
 	dir = 4
@@ -25119,6 +25201,18 @@
 	},
 /turf/open/floor/wood,
 /area/bigredv2/outside/library)
+"fwi" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 1
+	},
+/turf/closed/mineral/bigred,
+/area/bigredv2/outside/w)
+"fDZ" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/caves)
 "fJR" = (
 /obj/item/tool/warning_cone,
 /turf/open/floor/asteroidfloor,
@@ -25133,6 +25227,12 @@
 /obj/structure/sign/safety/breakroom,
 /turf/closed/wall,
 /area/bigredv2/outside/engineering)
+"fSQ" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/closed/wall/r_wall,
+/area/bigredv2/outside/telecomm)
 "fVM" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -25153,6 +25253,14 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
+"gbD" = (
+/obj/machinery/door/airlock/multi_tile/almayer/generic{
+	dir = 1;
+	name = "\improper Cargo Bay"
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor,
+/area/bigredv2/outside/cargo)
 "ggV" = (
 /obj/machinery/door/airlock/almayer/engineering{
 	dir = 4;
@@ -25188,11 +25296,28 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/general_store)
+"gqX" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/caves)
+"gva" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/closed/wall/r_wall,
+/area/bigredv2/outside/sw)
 "gBV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"gOG" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor,
+/area/bigredv2/outside/cargo)
 "gON" = (
 /turf/closed/mineral/bigred,
 /area/bigredv2/outside/nw)
@@ -25245,6 +25370,11 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/ne)
+"heW" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating,
+/area/bigredv2/outside/nanotrasen_lab/inside)
 "hiJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -25254,6 +25384,10 @@
 	dir = 2
 	},
 /area/bigredv2/outside/admin_building)
+"hkk" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves)
 "hlD" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 5
@@ -25278,6 +25412,21 @@
 	dir = 4
 	},
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"hzx" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/mineral/bigred,
+/area/bigredv2/caves)
+"hGl" = (
+/obj/machinery/button/door/open_only/landing_zone,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/bigredv2/outside/space_port)
 "hHN" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/tile/dark/yellow2/corner{
@@ -25290,6 +25439,12 @@
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"hRh" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/bigredv2/outside/virology)
 "hVb" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable{
@@ -25311,6 +25466,12 @@
 /turf/open/floor/wood,
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "iug" = (
+/turf/closed/mineral/bigred,
+/area/bigredv2/outside/virology)
+"iBK" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 1
+	},
 /turf/closed/mineral/bigred,
 /area/bigredv2/outside/virology)
 "iNd" = (
@@ -25356,6 +25517,10 @@
 	dir = 5
 	},
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"jHL" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/closed/mineral/bigred,
+/area/bigredv2/caves)
 "jKb" = (
 /obj/structure/sign/safety/blast_door,
 /turf/open/floor/tile/dark/purple2/corner{
@@ -25400,6 +25565,10 @@
 	},
 /turf/open/floor/plating,
 /area/bigredv2/outside/engineering)
+"kel" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor,
+/area/bigredv2/outside/engineering)
 "knF" = (
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/outside/engineering)
@@ -25407,6 +25576,16 @@
 /obj/effect/alien/weeds/node,
 /turf/open/floor/wood,
 /area/bigredv2/caves/lambda_lab)
+"kpV" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/mars/random/cave/rock,
+/area/bigredv2/outside/s)
+"kvs" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/closed/mineral/bigred,
+/area/bigredv2/caves)
 "kxe" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 4
@@ -25415,6 +25594,9 @@
 "kEZ" = (
 /turf/open/floor/plating,
 /area/bigredv2/outside/engineering)
+"kHc" = (
+/turf/open/space/basic,
+/area/shuttle/drop2/lz2)
 "kIY" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 1
@@ -25426,6 +25608,9 @@
 	},
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/c)
+"kMZ" = (
+/turf/open/space/basic,
+/area/space)
 "kOq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/lightreplacer,
@@ -25433,6 +25618,7 @@
 /area/bigredv2/outside/engineering)
 "kQy" = (
 /obj/structure/mineral_door/resin,
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "kRt" = (
@@ -25442,6 +25628,18 @@
 	},
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/medical)
+"kUZ" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 1
+	},
+/turf/closed/wall,
+/area/bigredv2/outside/cargo)
+"loF" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/floor/plating/dmg2,
+/area/bigredv2/outside/space_port)
 "loH" = (
 /obj/structure/sign/safety/rad_hazard{
 	dir = 2
@@ -25470,6 +25668,9 @@
 	},
 /turf/open/floor/plating,
 /area/bigredv2/caves/lambda_lab)
+"lDc" = (
+/turf/open/space/basic,
+/area/lv624/ground/jungle3)
 "lFT" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable{
@@ -25533,6 +25734,10 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
+"mSx" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/closed/wall/r_wall,
+/area/bigredv2/outside/telecomm)
 "mXK" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 10
@@ -25553,6 +25758,14 @@
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/general_offices)
+"nlp" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/mineral/bigred,
+/area/bigredv2/outside/virology)
+"nts" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating,
+/area/bigredv2/caves)
 "nvv" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -25584,6 +25797,12 @@
 	},
 /turf/open/floor/tile/darkish,
 /area/bigredv2/caves/lambda_lab)
+"nSc" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/bigredv2/outside/w)
 "nTN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
@@ -25606,6 +25825,12 @@
 	},
 /turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/virology)
+"osC" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 8
+	},
+/turf/closed/mineral/bigred,
+/area/bigredv2/caves)
 "oto" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -25644,6 +25869,14 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"owL" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 1
+	},
+/turf/open/floor/marking/asteroidwarning{
+	dir = 8
+	},
+/area/bigredv2/outside/w)
 "oFB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -25696,6 +25929,58 @@
 	dir = 8
 	},
 /area/bigredv2/caves/lambda_lab)
+"pgl" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 1
+	},
+/turf/open/floor/marking/asteroidwarning{
+	dir = 4
+	},
+/area/bigredv2/outside/w)
+"plF" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
+	},
+/turf/closed/wall/r_wall,
+/area/bigredv2/outside/space_port)
+"ptA" = (
+/turf/open/space/basic,
+/area/shuttle/drop1/lz1)
+"pvw" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/closed/wall/r_wall,
+/area/bigredv2/outside/w)
+"pzV" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 8
+	},
+/turf/closed/mineral/bigred,
+/area/bigredv2/outside/w)
+"pKv" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves)
+"pQZ" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/wall/r_wall,
+/area/bigredv2/outside/marshal_office)
+"pRU" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/machinery/door/poddoor/shutters/almayer{
+	dir = 2;
+	id = "Marshal Offices";
+	name = "\improper Marshal Offices Shutters"
+	},
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating,
+/area/bigredv2/outside/marshal_office)
 "pZW" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -25752,6 +26037,10 @@
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/medical)
+"qvO" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/wall/r_wall,
+/area/bigredv2/outside/nanotrasen_lab/inside)
 "qxt" = (
 /obj/item/trash/candy,
 /turf/open/floor,
@@ -25764,6 +26053,18 @@
 	},
 /obj/structure/sign/safety/high_radiation,
 /turf/open/floor,
+/area/bigredv2/outside/engineering)
+"qFg" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/machinery/door/poddoor/shutters/almayer{
+	dir = 2;
+	id = "Engineering";
+	name = "\improper Engineering Shutters"
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/bigredv2/outside/engineering)
 "qHT" = (
 /obj/structure/cable{
@@ -25782,6 +26083,14 @@
 /obj/effect/landmark/monkey_spawn,
 /turf/open/floor/tile/darkish,
 /area/bigredv2/caves/lambda_lab)
+"qNm" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 4
+	},
+/area/bigredv2/outside/w)
 "qQd" = (
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/tile/dark/purple2/corner{
@@ -25814,6 +26123,12 @@
 /obj/item/trash/tray,
 /turf/open/floor/tile/yellow/full,
 /area/bigredv2/outside/hydroponics)
+"rdl" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/bigredv2/outside/w)
 "riz" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 8
@@ -25850,6 +26165,19 @@
 	dir = 8
 	},
 /area/bigredv2/caves/lambda_lab)
+"rZf" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/marking/asteroidwarning{
+	dir = 4
+	},
+/area/bigredv2/outside/sw)
 "rZO" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -25864,6 +26192,21 @@
 "shZ" = (
 /obj/machinery/landinglight/ds2/delaytwo{
 	dir = 4
+	},
+/turf/open/floor/marking/asteroidwarning{
+	dir = 4
+	},
+/area/bigredv2/outside/sw)
+"skR" = (
+/obj/machinery/button/door/open_only/landing_zone/lz2{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/open/floor/marking/asteroidwarning{
 	dir = 4
@@ -25913,6 +26256,10 @@
 	},
 /turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/se)
+"sGO" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/closed/wall/r_wall,
+/area/bigredv2/outside/space_port)
 "sUd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -25926,10 +26273,24 @@
 "tku" = (
 /turf/closed/wall/indestructible/mineral,
 /area/storage/testroom)
+"tnE" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/closed/wall/r_wall,
+/area/bigredv2/outside/engineering)
 "twQ" = (
 /obj/effect/spawner/random/tool,
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
+"txn" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/machinery/door/poddoor/shutters/almayer{
+	dir = 4;
+	id = "Engineering";
+	name = "\improper Engineering Shutters"
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/plating,
+/area/bigredv2/outside/engineering)
 "txt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -25976,6 +26337,12 @@
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/tile/white,
 /area/bigredv2/caves/lambda_lab)
+"tSl" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/closed/wall/r_wall,
+/area/bigredv2/outside/space_port)
 "tVO" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -25995,10 +26362,15 @@
 /area/bigredv2/outside/c)
 "udw" = (
 /obj/structure/fence,
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/marking/asteroidwarning{
 	dir = 1
 	},
 /area/bigredv2/caves)
+"ued" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/wall,
+/area/bigredv2/outside/marshal_office)
 "ufT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
@@ -26012,17 +26384,68 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
+"ujn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/closed/wall/r_wall,
+/area/bigredv2/outside/telecomm)
+"ukJ" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/mineral/bigred,
+/area/bigredv2/outside/s)
+"uwp" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/marking/asteroidwarning{
+	dir = 8
+	},
+/area/bigredv2/outside/sw)
+"uxP" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/wall/r_wall,
+/area/bigredv2/outside/se)
+"uAE" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/outside/w)
 "uHK" = (
 /obj/item/tool/wet_sign,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor,
 /area/bigredv2/outside/hydroponics)
+"uJV" = (
+/obj/structure/window/framed/colony,
+/obj/machinery/door/poddoor/shutters/almayer{
+	dir = 4;
+	id = "Cargonia";
+	name = "\improper Cargo Shutters"
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/plating,
+/area/bigredv2/outside/cargo)
+"uKS" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 1
+	},
+/turf/closed/wall/r_wall,
+/area/bigredv2/outside/virology)
+"uOJ" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/mineral/bigred,
+/area/bigredv2/outside/w)
 "uTl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	on = 1
 	},
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
+"uWN" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/outside/s)
 "veE" = (
 /obj/structure/table,
 /obj/effect/spawner/random/toolbox,
@@ -26047,6 +26470,10 @@
 /obj/effect/alien/weeds/node,
 /turf/open/ground/jungle/clear,
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"vTV" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/mars/random/cave/rock,
+/area/bigredv2/caves)
 "vUH" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 8
@@ -26081,6 +26508,12 @@
 	dir = 1
 	},
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"wof" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 8
+	},
+/turf/closed/mineral/bigred,
+/area/bigredv2/outside/virology)
 "wxA" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno/down,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -26126,6 +26559,11 @@
 /obj/effect/landmark/start/surv_spawn,
 /turf/open/floor,
 /area/bigredv2/outside/general_store)
+"xjd" = (
+/obj/effect/glowshroom,
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves)
 "xji" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -26181,6 +26619,10 @@
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"xHR" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/outside/sw)
 "xRR" = (
 /obj/machinery/light{
 	dir = 1
@@ -26201,6 +26643,18 @@
 	dir = 2
 	},
 /area/bigredv2/caves/lambda_lab)
+"xXV" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/floor/marking/asteroidwarning{
+	dir = 4
+	},
+/area/bigredv2/outside/space_port)
+"yek" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/outside/se)
 "yjP" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -26693,6 +27147,7 @@ aac
 aac
 aac
 aac
+kvs
 aac
 aac
 aac
@@ -26706,8 +27161,7 @@ aac
 aac
 aac
 aac
-aac
-aac
+hzx
 aac
 aac
 aac
@@ -26910,6 +27364,7 @@ aac
 aac
 aac
 aac
+kvs
 aac
 aac
 aac
@@ -26923,8 +27378,7 @@ aac
 aac
 aac
 aac
-aac
-aac
+hzx
 aac
 aac
 aac
@@ -27127,6 +27581,7 @@ aac
 aac
 aac
 aac
+kvs
 aac
 aac
 aac
@@ -27140,8 +27595,7 @@ aac
 aac
 aac
 aac
-aac
-aac
+hzx
 aac
 aac
 aac
@@ -27344,6 +27798,7 @@ aac
 aac
 aac
 aac
+kvs
 aac
 aac
 aac
@@ -27357,8 +27812,7 @@ aac
 aac
 aac
 aac
-aac
-aac
+hzx
 aac
 aac
 aac
@@ -27561,6 +28015,7 @@ aac
 aac
 aac
 aac
+kvs
 aac
 aac
 aac
@@ -27574,8 +28029,7 @@ aac
 aac
 aac
 aac
-aac
-aac
+hzx
 aac
 aac
 aac
@@ -27778,6 +28232,7 @@ aac
 aac
 aac
 aac
+kvs
 aac
 aac
 aac
@@ -27792,8 +28247,7 @@ aac
 aac
 aac
 aac
-aac
-aac
+hzx
 aac
 aac
 aac
@@ -27995,7 +28449,7 @@ aac
 aac
 aac
 aac
-aac
+kvs
 aac
 aac
 aac
@@ -28011,7 +28465,7 @@ aac
 aac
 aac
 aad
-aad
+hkk
 aad
 aad
 aad
@@ -28212,6 +28666,7 @@ aac
 aac
 aac
 aac
+kvs
 aac
 aac
 aac
@@ -28219,7 +28674,6 @@ aac
 aac
 aac
 aac
-aac
 aad
 aad
 aad
@@ -28229,7 +28683,7 @@ aad
 aad
 aad
 aad
-aad
+hkk
 aad
 aad
 aad
@@ -28429,7 +28883,7 @@ acA
 acA
 acA
 ahN
-acA
+fSQ
 abq
 abq
 aad
@@ -28447,7 +28901,7 @@ aad
 aad
 aad
 aad
-aad
+hkk
 abq
 aad
 aad
@@ -28646,7 +29100,7 @@ ahd
 ahd
 ahd
 amw
-acA
+fSQ
 aad
 aad
 aad
@@ -28664,7 +29118,7 @@ aad
 aad
 aad
 aad
-aad
+hkk
 aad
 aad
 aad
@@ -28863,7 +29317,7 @@ aas
 ahd
 ahd
 all
-acA
+fSQ
 aad
 aad
 aad
@@ -28882,7 +29336,7 @@ aad
 aad
 aad
 aad
-aad
+hkk
 aad
 aad
 aad
@@ -29080,7 +29534,7 @@ aas
 aas
 aas
 all
-acA
+fSQ
 aad
 aad
 aad
@@ -29099,7 +29553,7 @@ aad
 aad
 aad
 abq
-aad
+hkk
 aad
 aad
 aad
@@ -29297,7 +29751,7 @@ aas
 ahd
 aas
 all
-acA
+fSQ
 aad
 aad
 aad
@@ -29316,7 +29770,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -29514,7 +29968,7 @@ aas
 ahd
 aas
 all
-acA
+fSQ
 aac
 aad
 aad
@@ -29534,21 +29988,21 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
 aad
 aac
-aac
+hzx
 aGo
 aHf
-aac
-aac
-aac
-aac
-aac
-aac
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
 aac
 aac
 aac
@@ -29731,7 +30185,7 @@ aas
 ahd
 aas
 amw
-acA
+fSQ
 aac
 aad
 aad
@@ -29752,11 +30206,11 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
+hzx
+hzx
+hzx
+hzx
+hzx
 aac
 aGp
 aFs
@@ -29766,22 +30220,22 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-abq
-aad
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-amE
-aad
-aac
+hzx
+hzx
+hzx
+hzx
+vTV
+hkk
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+nts
+hkk
+hzx
 aac
 aac
 aac
@@ -29941,13 +30395,13 @@ acQ
 acQ
 acQ
 acA
-ahN
-acA
-acA
-acA
-acA
-acA
-acA
+ujn
+mSx
+mSx
+mSx
+mSx
+mSx
+mSx
 acA
 aac
 aac
@@ -29999,7 +30453,7 @@ aMz
 aRD
 aRD
 aMz
-iug
+nlp
 iug
 iug
 iug
@@ -30157,7 +30611,7 @@ aaf
 aaf
 aaf
 aaf
-aae
+tSl
 aac
 aac
 aac
@@ -30217,28 +30671,28 @@ aYz
 aRE
 aMz
 iug
-iug
-iug
-iug
-iug
-iug
-iug
-iug
-iug
-vDI
-vDI
-vDI
-vDI
-aac
-aac
-aac
-aac
-abq
-aad
-abq
-abq
-abq
-aad
+nlp
+nlp
+nlp
+nlp
+nlp
+nlp
+nlp
+nlp
+uOJ
+uOJ
+uOJ
+uOJ
+hzx
+hzx
+hzx
+hzx
+vTV
+hkk
+vTV
+vTV
+vTV
+hkk
 aad
 aad
 aad
@@ -30374,7 +30828,7 @@ aeg
 aeg
 aeg
 agn
-aae
+tSl
 aac
 aac
 aac
@@ -30439,24 +30893,24 @@ iug
 iug
 iug
 iug
-iug
-iug
-iug
-iug
-vDI
-vDI
-vDI
-vDI
-aac
-aac
+wof
+wof
+wof
+wof
+pzV
+pzV
+pzV
+pzV
+osC
+osC
+nSc
+nSc
+nSc
+nSc
+nSc
+nSc
 biG
-biG
-biG
-biG
-biG
-biG
-biG
-aac
+hzx
 aac
 aac
 aac
@@ -30591,7 +31045,7 @@ aag
 aaf
 aaf
 acJ
-aae
+tSl
 aac
 aac
 aac
@@ -30655,7 +31109,7 @@ iug
 iug
 iug
 iug
-iug
+iBK
 iug
 iug
 iug
@@ -30672,9 +31126,9 @@ aQF
 aQF
 aQF
 aQF
-biG
+pvw
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -30808,7 +31262,7 @@ aaf
 aaf
 aaf
 acJ
-aae
+tSl
 aac
 aac
 aac
@@ -30872,7 +31326,7 @@ iug
 iug
 iug
 iug
-iug
+iBK
 iug
 iug
 iug
@@ -30889,24 +31343,24 @@ aQF
 aQF
 aQF
 aQF
-biG
+pvw
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
 aac
 aac
 aac
@@ -31025,7 +31479,7 @@ aaf
 aaf
 aaf
 acJ
-aae
+tSl
 aac
 aac
 aac
@@ -31089,11 +31543,11 @@ iug
 iug
 iug
 iug
+iBK
 iug
 iug
 iug
 iug
-iug
 aQF
 aQF
 aQF
@@ -31106,7 +31560,7 @@ aQF
 aQF
 aQF
 aQF
-biG
+pvw
 aac
 aac
 aac
@@ -31124,7 +31578,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 abq
@@ -31242,7 +31696,7 @@ aaf
 aaf
 aaf
 acJ
-aae
+tSl
 aac
 aac
 aad
@@ -31306,7 +31760,7 @@ iug
 iug
 iug
 iug
-iug
+iBK
 iug
 iug
 iug
@@ -31324,25 +31778,25 @@ aQF
 aQF
 aQF
 biG
-bmc
-bmc
-bmc
-bmc
-bmc
-bmc
-bmc
-bmc
-bmc
-bmc
-bmc
-bmc
-bmc
-bmc
+cmR
+cmR
+cmR
+cmR
+cmR
+cmR
+cmR
+cmR
+cmR
+cmR
+cmR
+cmR
+cmR
+cmR
 bmc
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -31459,7 +31913,7 @@ aaf
 aaf
 aaf
 acJ
-aae
+tSl
 aad
 aad
 aad
@@ -31523,7 +31977,7 @@ iug
 iug
 iug
 iug
-iug
+iBK
 iug
 aFv
 aFv
@@ -31555,12 +32009,12 @@ bcp
 wZg
 cBD
 bme
-bmc
+dXK
 aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -31603,9 +32057,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+kMZ
+kMZ
+kMZ
 aaa
 aaa
 aaa
@@ -31676,7 +32130,7 @@ aaf
 aaf
 aaf
 amb
-aae
+tSl
 aad
 abq
 aad
@@ -31740,7 +32194,7 @@ aMz
 aMz
 aMz
 aMz
-aMz
+uKS
 aFv
 aFv
 aFv
@@ -31773,11 +32227,11 @@ brG
 brG
 aWk
 bmc
-bmc
-bmc
+cmR
+cmR
 bmc
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -31820,9 +32274,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+kMZ
+kHc
+kMZ
 aaa
 aaa
 aaa
@@ -31893,7 +32347,7 @@ aaf
 aaf
 aaf
 acJ
-aae
+tSl
 aad
 aad
 aac
@@ -31957,7 +32411,7 @@ aRF
 aNc
 bco
 aNc
-aMz
+uKS
 aFv
 aFv
 aFv
@@ -31992,9 +32446,9 @@ bpv
 bpv
 bpv
 bpv
-bmc
+dXK
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -32037,9 +32491,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+kHc
+kHc
+lDc
 aaa
 aaa
 aaa
@@ -32110,7 +32564,7 @@ aaf
 aaf
 aaf
 acJ
-aae
+tSl
 aac
 aac
 aac
@@ -32174,7 +32628,7 @@ aNc
 aNc
 aNc
 aNc
-aMz
+uKS
 aFv
 aFv
 aFv
@@ -32209,9 +32663,9 @@ bsa
 bpv
 bpv
 bpv
-bmc
+dXK
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -32254,9 +32708,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+kMZ
+kHc
+kMZ
 aaa
 aaa
 aaa
@@ -32327,7 +32781,7 @@ aaf
 aaf
 aaf
 acJ
-aae
+tSl
 aac
 aac
 aac
@@ -32391,7 +32845,7 @@ aNc
 aNc
 aNc
 aNc
-aMz
+uKS
 aFv
 aFv
 aFv
@@ -32426,9 +32880,9 @@ bsb
 bpv
 bpv
 bpv
-bmc
+dXK
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -32471,9 +32925,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+kMZ
+kMZ
+kMZ
 aaa
 aaa
 aaa
@@ -32544,7 +32998,7 @@ aaf
 aaf
 aaf
 acJ
-aae
+tSl
 aac
 aac
 aac
@@ -32608,7 +33062,7 @@ aXx
 aMz
 aWj
 aXx
-aMz
+uKS
 aFv
 aFv
 aFv
@@ -32643,9 +33097,9 @@ bsc
 bpv
 bpv
 bpv
-bmc
+dXK
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -32688,9 +33142,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+kMZ
+kMZ
+kMZ
 aaa
 aaa
 aaa
@@ -32761,7 +33215,7 @@ aaf
 aaf
 aaf
 acJ
-aae
+tSl
 aac
 aac
 aac
@@ -32825,7 +33279,7 @@ aNi
 aWj
 aYC
 aNi
-aMz
+uKS
 aFv
 aFv
 aFv
@@ -32860,9 +33314,9 @@ bsd
 bpv
 bpv
 bpv
-bmc
+dXK
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -32905,9 +33359,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+kMZ
+kMZ
+kMZ
 aaa
 aaa
 aaa
@@ -32978,7 +33432,7 @@ aaf
 aaf
 aaf
 acJ
-aae
+tSl
 aac
 aac
 aac
@@ -33042,7 +33496,7 @@ aXy
 aWj
 aWT
 aXy
-aMz
+uKS
 aFv
 aFv
 aFv
@@ -33077,9 +33531,9 @@ bse
 bpv
 bpv
 bpv
-bmc
+dXK
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -33122,9 +33576,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+kHc
+ptA
+kMZ
 aaa
 aaa
 aaa
@@ -33195,7 +33649,7 @@ aaf
 aaf
 aaf
 acJ
-aae
+tSl
 aac
 aac
 aac
@@ -33259,7 +33713,7 @@ aXz
 aWj
 aWU
 aXz
-aMz
+uKS
 aFv
 aFv
 aFv
@@ -33294,9 +33748,9 @@ bsb
 bpv
 bpv
 bpv
-bmc
+dXK
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -33339,9 +33793,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+daV
+ptA
+ptA
 aaa
 aaa
 aaa
@@ -33412,7 +33866,7 @@ aaf
 aaf
 aaf
 acJ
-aae
+tSl
 aac
 aac
 aeI
@@ -33471,11 +33925,11 @@ aMz
 aMz
 aMz
 aMz
-aMz
-aMz
-aMz
-aMz
-aMz
+hRh
+hRh
+hRh
+hRh
+hRh
 aMz
 riz
 riz
@@ -33511,9 +33965,9 @@ bsc
 bpv
 bpv
 bpv
-bmc
+dXK
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -33556,9 +34010,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+kMZ
+ptA
+kMZ
 aaa
 aaa
 aaa
@@ -33629,7 +34083,7 @@ aag
 aam
 aam
 ago
-aae
+tSl
 aeI
 aeI
 aeI
@@ -33687,7 +34141,7 @@ vDI
 vDI
 vDI
 vDI
-vDI
+fwi
 aSB
 aSB
 aSB
@@ -33728,9 +34182,9 @@ bsd
 bpv
 bpv
 bpv
-bmc
+dXK
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -33846,7 +34300,7 @@ aah
 aah
 aah
 agp
-aae
+tSl
 aeI
 aeI
 aeI
@@ -33904,7 +34358,7 @@ aSB
 aSB
 aSB
 aSB
-aSB
+rdl
 aSB
 aSB
 aSB
@@ -33945,9 +34399,9 @@ bse
 bpv
 bpv
 bpv
-bmc
+dXK
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -34063,7 +34517,7 @@ aah
 aah
 aah
 agp
-aae
+tSl
 ahO
 aeI
 aeI
@@ -34121,7 +34575,7 @@ aWk
 aWk
 aWk
 aVI
-aWk
+owL
 aWk
 aWk
 aVI
@@ -34162,9 +34616,9 @@ bsb
 bpv
 bpv
 bpv
-bmc
+dXK
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -34280,7 +34734,7 @@ aah
 aah
 aah
 agp
-aae
+tSl
 ahP
 ahO
 aeI
@@ -34338,7 +34792,7 @@ aXA
 aXA
 aWV
 aXA
-aXA
+pgl
 aWV
 bba
 aXA
@@ -34379,9 +34833,9 @@ bsc
 bpv
 bpv
 bpv
-bmc
+dXK
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -34497,7 +34951,7 @@ aah
 aah
 aah
 agp
-aae
+tSl
 ahQ
 ahP
 ahO
@@ -34555,7 +35009,7 @@ aSB
 aSB
 aYE
 aYE
-aYE
+qNm
 aYE
 aYE
 aSB
@@ -34596,9 +35050,9 @@ bsd
 bpv
 bpv
 bpv
-bmc
+dXK
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -34679,15 +35133,15 @@ aaa
 (40,1,1) = {"
 aaa
 aab
-aac
-aac
-aac
-aac
-aac
-aad
-aae
-aae
-aae
+jHL
+jHL
+jHL
+jHL
+jHL
+pKv
+sGO
+sGO
+sGO
 aae
 aah
 aah
@@ -34714,7 +35168,7 @@ aah
 aah
 aah
 agp
-aae
+tSl
 ahR
 ahP
 ahP
@@ -34772,7 +35226,7 @@ aSB
 aXY
 aQF
 aQF
-aQF
+uAE
 aQF
 aQF
 bbJ
@@ -34813,9 +35267,9 @@ bsa
 bpv
 bpv
 bpv
-bmc
+dXK
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -34896,16 +35350,16 @@ aaa
 (41,1,1) = {"
 aaa
 aab
-aac
-aac
-aac
-aac
-aad
-aad
-aad
-aad
-aad
-aae
+hzx
+hzx
+hzx
+hzx
+hkk
+hkk
+hkk
+hkk
+hkk
+plF
 aah
 aah
 aah
@@ -34989,7 +35443,7 @@ aMB
 aMB
 aXK
 aXK
-aXK
+kUZ
 aQF
 aQF
 aQF
@@ -35030,9 +35484,9 @@ bpv
 bpv
 bpv
 bpv
-bmc
+dXK
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -35121,8 +35575,8 @@ aad
 aad
 aad
 aad
-aad
-aae
+hkk
+plF
 aaq
 aaK
 aaV
@@ -35206,7 +35660,7 @@ aXB
 aMB
 aXH
 aXH
-aXK
+kUZ
 aQF
 aQF
 aQF
@@ -35232,8 +35686,8 @@ bdZ
 bdZ
 bpv
 bsa
-brc
-brc
+ehV
+skR
 brc
 brc
 boC
@@ -35247,9 +35701,9 @@ brc
 brc
 brc
 brc
-bmc
+dXK
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -35338,8 +35792,8 @@ aad
 aad
 aad
 aad
-aad
-aae
+hkk
+plF
 abR
 agp
 aah
@@ -35365,7 +35819,7 @@ aah
 aah
 aah
 ags
-aam
+xXV
 ahT
 aiy
 aiy
@@ -35423,7 +35877,7 @@ aXC
 aMB
 aXH
 aXH
-aXK
+kUZ
 aQF
 aQF
 aQF
@@ -35437,22 +35891,22 @@ aSB
 aSB
 aSB
 aXK
-aXK
-aXK
-bih
-bbg
-aXK
-aZy
-aZy
-aZy
-aZy
-aZy
-aXK
-bmc
-bmc
-bmc
-blJ
-bmi
+eqy
+eqy
+gOG
+gbD
+eqy
+uJV
+uJV
+uJV
+uJV
+uJV
+eqy
+gva
+gva
+gva
+tnE
+kel
 boD
 blJ
 wZg
@@ -35464,9 +35918,9 @@ wZg
 wZg
 bpx
 bme
+dWa
 aac
-aac
-aac
+hzx
 aac
 aac
 aac
@@ -35555,8 +36009,8 @@ aad
 aad
 aad
 aad
-aad
-aae
+hkk
+plF
 aaw
 aaM
 aaW
@@ -35582,7 +36036,7 @@ aah
 aah
 aah
 aah
-aae
+tSl
 ahU
 ahP
 ahP
@@ -35640,7 +36094,7 @@ aXD
 aMB
 aXH
 aXH
-aXK
+kUZ
 aQF
 bbb
 aQF
@@ -35653,7 +36107,7 @@ beQ
 aSB
 aSB
 aSB
-aXK
+fgX
 aZt
 aZt
 bih
@@ -35671,7 +36125,7 @@ bmd
 asT
 bmi
 boE
-asT
+qFg
 wZg
 wZg
 bqG
@@ -35681,22 +36135,22 @@ wZg
 cBD
 bme
 bme
-akx
+fDZ
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
 aac
 aac
 aac
@@ -35772,8 +36226,8 @@ aad
 aad
 aad
 aad
-aad
-aae
+hkk
+plF
 aax
 aaN
 aaX
@@ -35799,7 +36253,7 @@ aah
 aah
 aah
 aah
-aae
+tSl
 ahT
 ahP
 ahP
@@ -35857,7 +36311,7 @@ aXE
 aMB
 aXH
 aXH
-aXK
+kUZ
 aQF
 aQF
 dLO
@@ -35870,7 +36324,7 @@ beQ
 aSB
 aSB
 aSB
-aXK
+fgX
 bhb
 bhb
 bii
@@ -35888,7 +36342,7 @@ bmd
 asT
 bmi
 boE
-asT
+qFg
 wZg
 wZg
 bqG
@@ -35898,7 +36352,7 @@ wZg
 wZg
 mXK
 bme
-akx
+fDZ
 aac
 aac
 aac
@@ -35914,7 +36368,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -35989,8 +36443,8 @@ aad
 aad
 aad
 aad
-aad
-aae
+hkk
+plF
 aay
 sqy
 aaO
@@ -36016,7 +36470,7 @@ aah
 aah
 aah
 afN
-aae
+tSl
 ahV
 ahV
 ahP
@@ -36074,7 +36528,7 @@ aXF
 aXZ
 aYG
 aXH
-aXK
+kUZ
 aQF
 dLO
 aSB
@@ -36087,7 +36541,7 @@ beQ
 aSB
 aSB
 aSB
-aXK
+fgX
 bhc
 bbe
 bij
@@ -36105,7 +36559,7 @@ bme
 asT
 bmi
 boE
-asT
+qFg
 wZg
 wZg
 bqG
@@ -36115,7 +36569,7 @@ brG
 brG
 brG
 brG
-brG
+uwp
 brG
 brG
 brG
@@ -36131,7 +36585,7 @@ blJ
 blJ
 blJ
 blJ
-aac
+hzx
 aac
 aac
 aac
@@ -36206,9 +36660,9 @@ aad
 aad
 aad
 aad
-aad
-aae
-aaz
+hkk
+plF
+aaB
 iNd
 aaP
 aaO
@@ -36291,7 +36745,7 @@ aXa
 aMB
 aYH
 aXH
-aXK
+kUZ
 vUH
 aSB
 bbK
@@ -36304,7 +36758,7 @@ beR
 aSB
 aSB
 aSB
-aXK
+fgX
 bhd
 bhD
 bik
@@ -36322,7 +36776,7 @@ bme
 bnP
 bmi
 boE
-asT
+qFg
 bpy
 wZg
 bqH
@@ -36332,7 +36786,7 @@ bpw
 bpw
 bpw
 bpw
-bpw
+rZf
 bpw
 bpw
 bpw
@@ -36348,7 +36802,7 @@ bvS
 bvS
 bvS
 blJ
-aad
+hkk
 aac
 aac
 aac
@@ -36423,9 +36877,9 @@ aad
 aad
 aad
 aad
-aad
-aae
-aaA
+hkk
+plF
+aaB
 aaP
 aaP
 abf
@@ -36450,7 +36904,7 @@ aah
 aah
 afM
 agw
-agv
+loF
 ahX
 ahX
 aiA
@@ -36508,7 +36962,7 @@ aXG
 aMB
 aYI
 aXH
-aXK
+kUZ
 aSB
 aSB
 bbL
@@ -36521,7 +36975,7 @@ beS
 aSB
 aSB
 aSB
-aXK
+fgX
 aZs
 aZs
 bil
@@ -36539,7 +36993,7 @@ bme
 asT
 bmi
 boE
-asT
+qFg
 bme
 bpy
 wZg
@@ -36549,7 +37003,7 @@ wZg
 wZg
 cBD
 bme
-bme
+dBp
 bmd
 bmd
 bmd
@@ -36565,7 +37019,7 @@ buF
 buF
 buF
 blJ
-aad
+hkk
 aac
 aac
 aac
@@ -36640,11 +37094,11 @@ aad
 aad
 aad
 aad
-aac
-aae
-aaB
+hzx
+plF
+aaA
 aaO
-aaO
+aaP
 aaO
 abo
 aaO
@@ -36667,7 +37121,7 @@ aah
 aah
 aah
 agx
-agv
+loF
 ahY
 aeI
 aiA
@@ -36726,18 +37180,18 @@ aMB
 aYH
 aXH
 aXK
-aZy
+uJV
 bbd
-aXK
+eqy
 bct
 bct
 bct
 bct
 bct
-aXK
-aZy
-aZy
-aZy
+eqy
+uJV
+uJV
+uJV
 aXK
 aXK
 aXK
@@ -36757,16 +37211,16 @@ asT
 bmi
 boE
 blJ
-boi
-blJ
-blJ
-boi
-boi
-boi
-blJ
-blJ
-bme
-bme
+txn
+tnE
+tnE
+txn
+txn
+txn
+tnE
+tnE
+xHR
+xHR
 bmd
 bmd
 bmd
@@ -36782,7 +37236,7 @@ bvT
 bvT
 bwo
 blJ
-aad
+hkk
 aac
 aac
 aac
@@ -36857,9 +37311,9 @@ aad
 aad
 aad
 aad
-aac
-aae
-aaB
+hzx
+plF
+hGl
 aaO
 aaO
 abg
@@ -36884,7 +37338,7 @@ aah
 aah
 aah
 afM
-agw
+ekR
 aeI
 ahX
 aiA
@@ -36999,7 +37453,7 @@ buF
 buF
 buF
 blJ
-aad
+hkk
 abq
 aac
 aac
@@ -37074,8 +37528,8 @@ aad
 aad
 aad
 aad
-aac
-aae
+hzx
+plF
 aaC
 aaQ
 aaQ
@@ -37101,7 +37555,7 @@ aah
 aah
 afN
 afh
-agv
+loF
 ahZ
 aeI
 aiA
@@ -37216,7 +37670,7 @@ bvU
 bvU
 bvU
 blJ
-aad
+hkk
 abq
 aac
 aac
@@ -37291,16 +37745,16 @@ aad
 aad
 aad
 aad
-aac
+hzx
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+sGO
+sGO
+sGO
+sGO
+sGO
+sGO
+sGO
+sGO
 aae
 aah
 acj
@@ -37433,7 +37887,7 @@ blJ
 blJ
 blJ
 blJ
-aad
+hkk
 aad
 abq
 abq
@@ -37509,32 +37963,32 @@ aad
 aad
 aad
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+sGO
+sGO
+sGO
+sGO
+sGO
+sGO
+sGO
+sGO
+sGO
+sGO
+sGO
+sGO
+sGO
+sGO
+sGO
+sGO
+sGO
 aae
 ahX
 aeI
@@ -37650,7 +38104,7 @@ buj
 buj
 buj
 buj
-aad
+hkk
 aad
 aad
 abq
@@ -37735,19 +38189,19 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aad
-aad
-aac
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hkk
+hkk
+hzx
 aac
 aac
 aac
@@ -37867,7 +38321,7 @@ buk
 buk
 buk
 buk
-aad
+hkk
 abq
 aad
 aad
@@ -37965,7 +38419,7 @@ aad
 aad
 aad
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -38084,7 +38538,7 @@ buk
 buk
 buk
 buk
-abq
+vTV
 aad
 aad
 aad
@@ -38182,7 +38636,7 @@ aad
 aad
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -38301,7 +38755,7 @@ buk
 buk
 buk
 buj
-aac
+hzx
 aac
 aac
 aac
@@ -38399,7 +38853,7 @@ aad
 aad
 aad
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -38519,7 +38973,7 @@ buk
 buk
 buj
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -38616,7 +39070,7 @@ aad
 aad
 aad
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -38737,8 +39191,8 @@ buj
 bmd
 aac
 aac
-aac
-aac
+hzx
+hzx
 aac
 aac
 aac
@@ -38833,7 +39287,7 @@ aad
 aad
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -38956,7 +39410,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -39045,11 +39499,11 @@ aac
 aac
 aad
 aad
-aad
-aad
-aad
-aac
-aac
+hkk
+hkk
+hkk
+hzx
+hzx
 aac
 aac
 aeI
@@ -39174,7 +39628,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -39261,7 +39715,7 @@ aac
 aac
 aac
 aad
-aad
+hkk
 acp
 acp
 acp
@@ -39392,7 +39846,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -39478,7 +39932,7 @@ aac
 aac
 aac
 aad
-aad
+hkk
 acp
 adh
 ady
@@ -39609,7 +40063,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -39695,7 +40149,7 @@ aac
 aac
 aac
 aad
-aad
+hkk
 acp
 adh
 adh
@@ -39826,7 +40280,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -39912,7 +40366,7 @@ aac
 aac
 aad
 aad
-aad
+hkk
 acp
 adi
 adz
@@ -40043,7 +40497,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -40129,7 +40583,7 @@ aac
 aad
 aad
 aad
-aad
+hkk
 acp
 adj
 adA
@@ -40260,7 +40714,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -40346,7 +40800,7 @@ aad
 aad
 aad
 aad
-aad
+hkk
 acp
 adk
 adk
@@ -40477,7 +40931,7 @@ aad
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -40563,7 +41017,7 @@ aad
 abq
 aad
 aad
-aad
+hkk
 acp
 adl
 adB
@@ -40694,7 +41148,7 @@ aad
 aad
 aad
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -40779,8 +41233,8 @@ aad
 aad
 aad
 aad
-aad
-aad
+hkk
+hkk
 acp
 acp
 acp
@@ -40911,7 +41365,7 @@ aad
 aad
 aad
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -40994,8 +41448,8 @@ aad
 aad
 aad
 aad
-aad
-aad
+hkk
+hkk
 acp
 acp
 acp
@@ -41128,7 +41582,7 @@ aad
 aad
 aad
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -41210,7 +41664,7 @@ aad
 aad
 aad
 aad
-acp
+pQZ
 acp
 acp
 acp
@@ -41345,7 +41799,7 @@ aad
 aad
 aad
 aac
-aac
+hzx
 aac
 aac
 aad
@@ -41427,7 +41881,7 @@ aad
 aad
 aad
 aad
-acp
+pQZ
 acy
 acC
 acE
@@ -41562,7 +42016,7 @@ aad
 aad
 aad
 aac
-aac
+hzx
 aac
 aac
 aad
@@ -41644,7 +42098,7 @@ aad
 aad
 aad
 aad
-agm
+pRU
 acy
 acC
 acE
@@ -41779,7 +42233,7 @@ aad
 aad
 aad
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -41861,7 +42315,7 @@ aad
 aad
 aad
 aad
-acr
+ued
 acy
 acC
 acE
@@ -41996,7 +42450,7 @@ aad
 aad
 aad
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -42213,7 +42667,7 @@ aad
 aad
 aad
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -42295,7 +42749,7 @@ aad
 aad
 aad
 aad
-acp
+pQZ
 acz
 acD
 acF
@@ -42430,7 +42884,7 @@ aad
 aad
 aad
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -42512,7 +42966,7 @@ aad
 aad
 aad
 aad
-agm
+pRU
 acz
 acD
 acG
@@ -42647,7 +43101,7 @@ aad
 aad
 aad
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -42729,7 +43183,7 @@ aad
 aad
 aad
 aad
-acp
+pQZ
 acy
 acC
 acE
@@ -42864,7 +43318,7 @@ aad
 aad
 aad
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -42946,7 +43400,7 @@ aad
 abq
 aad
 abq
-agm
+pRU
 acy
 acC
 acE
@@ -43081,7 +43535,7 @@ aad
 aad
 aad
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -43163,7 +43617,7 @@ aad
 aad
 aad
 abq
-acp
+pQZ
 acy
 acC
 acE
@@ -43298,7 +43752,7 @@ aad
 aad
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -43380,7 +43834,7 @@ aad
 aad
 aad
 abq
-acp
+pQZ
 acp
 acp
 acp
@@ -43515,7 +43969,7 @@ aad
 aad
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -43597,7 +44051,7 @@ aad
 abq
 aad
 aad
-aac
+hzx
 aac
 aac
 aac
@@ -43732,7 +44186,7 @@ aad
 aad
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -43815,7 +44269,7 @@ abq
 aad
 aad
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -43949,7 +44403,7 @@ aad
 aad
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -44033,7 +44487,7 @@ aad
 aad
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -44166,7 +44620,7 @@ aad
 aad
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -44250,7 +44704,7 @@ aad
 aad
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -44383,7 +44837,7 @@ aad
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -44467,7 +44921,7 @@ aad
 aad
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -44600,7 +45054,7 @@ aad
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -44684,7 +45138,7 @@ aad
 aad
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -44817,7 +45271,7 @@ aad
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -44901,7 +45355,7 @@ aad
 aad
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -45034,7 +45488,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -45118,7 +45572,7 @@ aad
 aad
 aac
 aac
-aac
+hzx
 aac
 aac
 acP
@@ -45251,7 +45705,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -45335,7 +45789,7 @@ aad
 aad
 aac
 aac
-aac
+hzx
 aac
 aac
 acP
@@ -45468,7 +45922,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -45552,7 +46006,7 @@ aad
 aad
 aac
 aac
-aac
+hzx
 aac
 aac
 acP
@@ -45685,44 +46139,44 @@ tco
 tco
 aEu
 aac
-aac
-aac
-aac
-aac
-aac
-abq
-amE
-amE
-aad
-aad
-aad
-abq
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+hzx
+hzx
+hzx
+hzx
+hzx
+vTV
+nts
+nts
+hkk
+hkk
+hkk
+vTV
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
 aac
 aac
 abq
@@ -45769,7 +46223,7 @@ aad
 aad
 aac
 aac
-aac
+hzx
 aac
 aac
 acP
@@ -45940,7 +46394,7 @@ bwF
 bwF
 bwF
 bwF
-bwF
+qvO
 aac
 aad
 aad
@@ -45986,7 +46440,7 @@ aad
 aad
 aac
 aac
-aac
+hzx
 aac
 aac
 acP
@@ -46157,7 +46611,7 @@ bwF
 bvP
 bDk
 bvP
-bwF
+qvO
 aac
 aad
 aad
@@ -46203,7 +46657,7 @@ aad
 aad
 aac
 aac
-aac
+hzx
 aac
 acP
 acP
@@ -46420,7 +46874,7 @@ aad
 aad
 aac
 aac
-aac
+hzx
 aac
 acP
 acP
@@ -46591,7 +47045,7 @@ bwF
 bvP
 bwj
 bvP
-bwF
+qvO
 aad
 aad
 aad
@@ -46637,7 +47091,7 @@ abq
 aad
 aac
 aac
-aac
+hzx
 aac
 acP
 acP
@@ -46808,7 +47262,7 @@ bwF
 bwJ
 bBH
 bwJ
-bwF
+qvO
 aad
 aad
 aad
@@ -46854,7 +47308,7 @@ abq
 aad
 aac
 aac
-aac
+hzx
 aac
 aac
 acP
@@ -47025,7 +47479,7 @@ bxN
 bDb
 bxg
 bDb
-bwF
+qvO
 aad
 aad
 aad
@@ -47072,7 +47526,7 @@ aad
 aac
 aac
 aac
-aac
+hzx
 aac
 acP
 acP
@@ -47242,7 +47696,7 @@ bBR
 bBR
 bxo
 bBR
-bwF
+qvO
 aad
 aad
 aad
@@ -47289,7 +47743,7 @@ aad
 aac
 aac
 aac
-aac
+hzx
 aac
 acP
 acP
@@ -47459,7 +47913,7 @@ bxg
 bxo
 bxg
 bxg
-bwF
+qvO
 aad
 aad
 aad
@@ -47506,7 +47960,7 @@ aad
 aac
 aac
 aac
-aac
+hzx
 aac
 acP
 acP
@@ -47723,7 +48177,7 @@ aad
 aac
 aac
 aac
-aac
+hzx
 aac
 acP
 acP
@@ -47893,7 +48347,7 @@ bxN
 bDd
 bxg
 bDd
-bwF
+qvO
 aac
 abq
 aad
@@ -47940,7 +48394,7 @@ aad
 aac
 aac
 aac
-aac
+hzx
 aac
 acP
 acP
@@ -48110,7 +48564,7 @@ bwF
 bwJ
 bBH
 bwJ
-bwF
+qvO
 aac
 aac
 aac
@@ -48157,7 +48611,7 @@ abq
 aac
 aac
 aac
-aac
+hzx
 aac
 acP
 acP
@@ -48327,7 +48781,7 @@ bwF
 bBp
 bBC
 bBp
-bwF
+qvO
 aac
 aac
 aac
@@ -48374,7 +48828,7 @@ abq
 aac
 aac
 aac
-aac
+hzx
 aac
 acP
 acP
@@ -48544,7 +48998,7 @@ bwF
 bBp
 bBp
 bBp
-bwF
+qvO
 aac
 aac
 aac
@@ -48591,7 +49045,7 @@ abq
 aac
 aac
 aac
-aac
+hzx
 aac
 acP
 acP
@@ -48761,14 +49215,14 @@ bwF
 vTU
 bBI
 bBC
-bwF
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+qvO
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
 aac
 aad
 aad
@@ -48808,7 +49262,7 @@ aad
 abq
 aac
 aac
-aac
+hzx
 aac
 aac
 acP
@@ -48985,7 +49439,7 @@ bwF
 bwF
 bwF
 bwF
-aac
+hzx
 aac
 aad
 aad
@@ -49025,7 +49479,7 @@ aad
 abq
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -49202,7 +49656,7 @@ bCX
 bCX
 bDm
 bwF
-aac
+hzx
 aac
 aad
 aad
@@ -49242,7 +49696,7 @@ aad
 abq
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -49419,7 +49873,7 @@ bEh
 bEJ
 bCZ
 bwF
-aac
+hzx
 aac
 aad
 aad
@@ -49459,7 +49913,7 @@ aad
 abq
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -49636,7 +50090,7 @@ bxN
 bEK
 bCZ
 bwF
-aac
+hzx
 aac
 aad
 aad
@@ -49676,7 +50130,7 @@ aad
 abq
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -49853,7 +50307,7 @@ bzS
 bEK
 bEO
 bwF
-aac
+hzx
 aac
 aad
 ahw
@@ -49893,7 +50347,7 @@ abq
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -50070,7 +50524,7 @@ bxN
 bEK
 bCZ
 bwF
-aac
+hzx
 aac
 aad
 aad
@@ -50111,7 +50565,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -50287,7 +50741,7 @@ bxN
 bEK
 bEP
 bwF
-aac
+hzx
 aac
 aad
 aad
@@ -50329,7 +50783,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -50504,7 +50958,7 @@ bxN
 bEK
 bCZ
 bwF
-aac
+hzx
 aac
 aad
 aad
@@ -50547,7 +51001,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -50721,7 +51175,7 @@ bxN
 bEK
 bCZ
 bwF
-aac
+hzx
 aac
 aad
 aad
@@ -50765,7 +51219,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -50938,7 +51392,7 @@ bxN
 bEK
 bCZ
 bwF
-aac
+hzx
 aac
 aac
 aad
@@ -50983,7 +51437,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -51155,7 +51609,7 @@ bxN
 bEK
 bEO
 bwF
-aac
+hzx
 aac
 aac
 aad
@@ -51201,7 +51655,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -51372,7 +51826,7 @@ bxN
 bEK
 bDN
 bwF
-aac
+hzx
 aac
 aac
 aad
@@ -51419,7 +51873,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -51530,22 +51984,22 @@ buv
 buv
 buv
 bue
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
 bwF
 bxR
 bxS
@@ -51589,7 +52043,7 @@ bxN
 bEM
 bDN
 bwF
-aac
+hzx
 aac
 aac
 aad
@@ -51637,7 +52091,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -51746,7 +52200,7 @@ bjy
 buu
 buv
 buv
-bue
+kpV
 aac
 aac
 aac
@@ -51762,7 +52216,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 bwF
 bxS
 gTX
@@ -51806,7 +52260,7 @@ bxN
 bEM
 bEQ
 bwF
-aac
+hzx
 aac
 aac
 aad
@@ -51855,7 +52309,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -51961,8 +52415,8 @@ btS
 bjy
 bud
 buv
-buv
-buv
+uWN
+uWN
 bue
 aac
 aac
@@ -51979,7 +52433,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 bwF
 bxR
 byc
@@ -52023,7 +52477,7 @@ bxN
 bEK
 bDN
 bwF
-aac
+hzx
 aac
 aac
 aad
@@ -52073,7 +52527,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -52177,7 +52631,7 @@ blv
 btS
 bjy
 buu
-buv
+uWN
 buv
 buv
 bue
@@ -52196,7 +52650,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 bwF
 bxS
 byd
@@ -52240,7 +52694,7 @@ bxN
 bEK
 bDN
 bwF
-aac
+hzx
 aac
 aac
 aad
@@ -52291,7 +52745,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -52393,7 +52847,7 @@ bjA
 blv
 btR
 bud
-buv
+uWN
 buv
 buv
 buv
@@ -52413,7 +52867,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 bwF
 bxR
 bxS
@@ -52457,7 +52911,7 @@ bxN
 bEK
 bER
 bwF
-aac
+hzx
 aac
 aac
 aad
@@ -52509,7 +52963,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -52610,7 +53064,7 @@ bjA
 blv
 btP
 bue
-buv
+uWN
 buv
 buv
 bue
@@ -52630,7 +53084,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 bwF
 bwF
 bwF
@@ -52674,7 +53128,7 @@ bxN
 bEM
 bDN
 bwF
-aac
+hzx
 aac
 aac
 aad
@@ -52727,7 +53181,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -52826,7 +53280,7 @@ btm
 bjA
 bjy
 btP
-btP
+ukJ
 buv
 buv
 buv
@@ -52848,10 +53302,10 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
+hzx
+hzx
+hzx
+hzx
 bwF
 byW
 bzj
@@ -52891,7 +53345,7 @@ bEG
 byO
 bDN
 bwF
-aac
+hzx
 aac
 aac
 aad
@@ -52945,7 +53399,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -53043,7 +53497,7 @@ btm
 bjA
 bjy
 btP
-btP
+ukJ
 buv
 buv
 buv
@@ -53068,7 +53522,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 bwF
 bww
 bzl
@@ -53108,7 +53562,7 @@ bDZ
 bCZ
 bDz
 bwF
-aac
+hzx
 aac
 aac
 aad
@@ -53163,7 +53617,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -53260,7 +53714,7 @@ btm
 bjA
 blv
 btP
-bue
+kpV
 buv
 buL
 buv
@@ -53285,7 +53739,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 bwF
 wmL
 bzl
@@ -53325,7 +53779,7 @@ bEH
 bxN
 bxN
 bwF
-aac
+hzx
 aac
 aac
 aad
@@ -53381,7 +53835,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 acP
@@ -53478,7 +53932,7 @@ bjA
 blv
 btR
 bug
-buv
+uWN
 buv
 buv
 buv
@@ -53502,7 +53956,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 bwF
 byX
 bzm
@@ -53542,7 +53996,7 @@ xtN
 byh
 bES
 bwF
-aac
+hzx
 aac
 aac
 aad
@@ -53599,7 +54053,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -53695,7 +54149,7 @@ bes
 bki
 btU
 beq
-bkW
+cuX
 bux
 bux
 bux
@@ -53719,7 +54173,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 bwF
 byY
 bzn
@@ -53759,7 +54213,7 @@ bEI
 bEN
 bxc
 bwF
-aac
+hzx
 aac
 aac
 aad
@@ -53817,8 +54271,8 @@ aac
 aac
 aac
 aac
-aac
-aac
+hzx
+hzx
 aac
 anI
 aot
@@ -53913,7 +54367,7 @@ bki
 btU
 beq
 bkW
-bux
+yek
 bux
 bux
 bux
@@ -53936,7 +54390,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 bwF
 bwF
 bwF
@@ -53947,36 +54401,36 @@ bwF
 bwF
 bwF
 bwF
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-abq
-abq
-abq
-abq
-aac
-aac
-aac
-aac
-aac
-bwF
-bwF
-bwF
-bwF
-bwF
-bwF
-bwF
-bwF
-bwJ
-bwJ
-bwF
-bwF
-bwF
-aac
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+vTV
+vTV
+vTV
+vTV
+hzx
+hzx
+hzx
+hzx
+hzx
+qvO
+qvO
+qvO
+qvO
+qvO
+qvO
+qvO
+qvO
+heW
+heW
+qvO
+qvO
+qvO
+hzx
 aac
 aac
 aad
@@ -54036,7 +54490,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 anI
 aos
 ape
@@ -54129,7 +54583,7 @@ bkh
 beq
 btU
 bky
-bux
+yek
 bux
 bux
 bux
@@ -54154,16 +54608,16 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aad
-aad
-aad
-aac
-aac
-aac
+hzx
+hzx
+hzx
+hzx
+hkk
+hkk
+hkk
+hzx
+hzx
+hzx
 aac
 aac
 aac
@@ -54253,7 +54707,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 anI
 anI
 anI
@@ -54347,7 +54801,7 @@ beq
 btU
 bkW
 bux
-bux
+yek
 bux
 bux
 bux
@@ -54470,7 +54924,7 @@ aac
 aac
 aac
 akx
-amE
+nts
 akx
 aou
 acl
@@ -54564,7 +55018,7 @@ beq
 btU
 bkW
 bfx
-bfx
+cWF
 bux
 bux
 bux
@@ -54687,7 +55141,7 @@ aac
 aac
 aac
 akx
-akx
+gqX
 amE
 aou
 api
@@ -54780,7 +55234,7 @@ beq
 beq
 bfx
 bfx
-bfx
+cWF
 bfx
 bux
 bux
@@ -54904,7 +55358,7 @@ aac
 akx
 akx
 amE
-akx
+gqX
 anI
 anI
 apj
@@ -54997,7 +55451,7 @@ beq
 beq
 bfx
 bfx
-bfx
+cWF
 bfx
 bux
 bux
@@ -55121,7 +55575,7 @@ akx
 akx
 akx
 akx
-akx
+gqX
 anI
 aov
 qZK
@@ -55214,7 +55668,7 @@ beq
 beq
 bfx
 bfx
-bfx
+cWF
 bfx
 bux
 bux
@@ -55338,7 +55792,7 @@ akx
 akx
 akx
 akx
-akx
+gqX
 anI
 aov
 qZK
@@ -55431,7 +55885,7 @@ bqZ
 bfx
 bfx
 bfx
-bfx
+cWF
 bfx
 bux
 bux
@@ -55555,7 +56009,7 @@ akx
 akW
 alG
 akx
-akx
+gqX
 anI
 aow
 jSv
@@ -55648,7 +56102,7 @@ brD
 bfx
 bfx
 bfx
-bfx
+cWF
 bfx
 buM
 bux
@@ -55772,7 +56226,7 @@ aac
 akX
 akX
 amF
-aac
+hzx
 anI
 aov
 gjg
@@ -55865,7 +56319,7 @@ brD
 brD
 bfx
 bfx
-bfx
+cWF
 bfx
 bfx
 bux
@@ -55989,7 +56443,7 @@ aac
 akX
 akX
 akX
-aac
+hzx
 anI
 aov
 apk
@@ -56082,7 +56536,7 @@ brD
 bfx
 bfx
 bfx
-bfx
+cWF
 bfx
 bfx
 buM
@@ -56206,7 +56660,7 @@ abq
 akZ
 alI
 akX
-aac
+hzx
 anI
 aov
 apk
@@ -56299,7 +56753,7 @@ brD
 bfx
 bfx
 bfx
-bfx
+cWF
 bfx
 bfx
 bfx
@@ -56423,7 +56877,7 @@ aad
 aad
 alJ
 akX
-aac
+hzx
 anI
 aoy
 apk
@@ -56516,7 +56970,7 @@ bqZ
 bqZ
 bfx
 bfx
-bfx
+cWF
 bfx
 bfx
 bfx
@@ -56640,7 +57094,7 @@ aad
 aad
 alJ
 akX
-aac
+hzx
 anK
 aoz
 apm
@@ -56733,7 +57187,7 @@ brD
 bfx
 bfx
 bfx
-bfx
+cWF
 bfx
 bfx
 bfx
@@ -56857,7 +57311,7 @@ aad
 aad
 abq
 aac
-aac
+hzx
 anK
 aoA
 apk
@@ -56950,7 +57404,7 @@ bfx
 bfx
 bfx
 bfx
-bfx
+cWF
 bfx
 bfx
 bfx
@@ -57074,7 +57528,7 @@ abq
 aad
 aac
 aac
-aac
+hzx
 anK
 aoB
 apk
@@ -57167,7 +57621,7 @@ bfx
 bfx
 bfx
 bfx
-bfx
+cWF
 bfx
 bfx
 bfx
@@ -57291,7 +57745,7 @@ aad
 aad
 aac
 aac
-aac
+hzx
 anK
 aoB
 apn
@@ -57384,7 +57838,7 @@ bfx
 bfx
 bfx
 bfx
-bfx
+cWF
 bfx
 bfx
 bfx
@@ -57508,7 +57962,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 anK
 aoC
 aoB
@@ -57581,13 +58035,13 @@ bes
 bes
 bkh
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
 udw
 bpZ
 bpZ
@@ -57601,7 +58055,7 @@ brD
 brE
 bfx
 bfx
-bfx
+cWF
 bfx
 bfx
 bfx
@@ -57725,7 +58179,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 anK
 anK
 anK
@@ -57797,7 +58251,7 @@ bes
 bes
 bkh
 beq
-aac
+hzx
 aac
 aac
 aac
@@ -57808,8 +58262,8 @@ abq
 bpt
 bqc
 bqc
-bqZ
-bqZ
+uxP
+uxP
 bqZ
 bqZ
 bqZ
@@ -57818,7 +58272,7 @@ bqZ
 bqZ
 bfx
 bfx
-bfx
+cWF
 bfx
 bfx
 bfx
@@ -57942,7 +58396,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 apo
@@ -58027,15 +58481,15 @@ abq
 abq
 abq
 abq
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-bfx
-bfx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+cWF
+cWF
 bfx
 bfx
 bfx
@@ -58160,7 +58614,7 @@ aac
 aac
 aad
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -58378,9 +58832,9 @@ aac
 aad
 abq
 abq
-aac
-aac
-aac
+hzx
+hzx
+hzx
 aac
 aac
 aac
@@ -58597,7 +59051,7 @@ aad
 aad
 abq
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -58815,7 +59269,7 @@ aad
 aad
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -59032,7 +59486,7 @@ aad
 aad
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -59099,7 +59553,7 @@ bes
 aac
 aac
 aac
-aac
+hzx
 aad
 aad
 aad
@@ -59250,7 +59704,7 @@ aad
 aad
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -59316,7 +59770,7 @@ bes
 aac
 aac
 aac
-aac
+hzx
 aad
 aad
 aad
@@ -59468,7 +59922,7 @@ aad
 aad
 aac
 aac
-aac
+hzx
 aac
 aac
 arD
@@ -59533,7 +59987,7 @@ bes
 bes
 aac
 aac
-aac
+hzx
 aad
 aad
 aad
@@ -59685,7 +60139,7 @@ aad
 aad
 aac
 aac
-aac
+hzx
 aac
 arD
 arD
@@ -59750,7 +60204,7 @@ bes
 bes
 bes
 aac
-aac
+hzx
 aac
 aad
 aad
@@ -59902,7 +60356,7 @@ aad
 aad
 aad
 aad
-aac
+hzx
 aac
 arD
 arD
@@ -59967,7 +60421,7 @@ bes
 bes
 bes
 aac
-aac
+hzx
 aac
 aac
 aad
@@ -60119,7 +60573,7 @@ aad
 ahw
 aad
 aad
-aac
+hzx
 aac
 aac
 aac
@@ -60184,7 +60638,7 @@ bes
 bes
 bes
 aac
-aac
+hzx
 aac
 aac
 aad
@@ -60337,7 +60791,7 @@ aad
 aad
 aad
 aad
-aac
+hzx
 aac
 aac
 arD
@@ -60401,7 +60855,7 @@ bes
 bes
 bes
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -60555,7 +61009,7 @@ aad
 aad
 aad
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -60618,7 +61072,7 @@ bes
 bes
 bes
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -60773,13 +61227,13 @@ ahw
 aad
 aad
 aad
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
 aac
 aac
 arD
@@ -60835,7 +61289,7 @@ bes
 bes
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -60997,7 +61451,7 @@ aad
 abq
 abq
 aac
-aac
+hzx
 aac
 arD
 arD
@@ -61052,7 +61506,7 @@ bes
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -61184,10 +61638,10 @@ aad
 aad
 aac
 aac
-aac
-aac
-aac
-abq
+hzx
+hzx
+hzx
+vTV
 aad
 ahw
 aad
@@ -61197,9 +61651,9 @@ aad
 ahw
 aad
 aad
-aad
-aad
-aad
+hkk
+hkk
+hkk
 aad
 aad
 aad
@@ -61215,7 +61669,7 @@ aad
 aad
 abq
 aac
-aac
+hzx
 aac
 aac
 arD
@@ -61269,7 +61723,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -61400,25 +61854,25 @@ aad
 aad
 aad
 aac
-aac
+hzx
 aac
 aac
 aac
 aad
-aad
-aad
+hkk
+hkk
 abq
 aac
 abq
 aad
 aad
 aad
+hkk
 aad
 aad
 aad
-aad
-aad
-aad
+hkk
+hkk
 abq
 ahw
 abq
@@ -61433,7 +61887,7 @@ aad
 aad
 aad
 abq
-aac
+hzx
 aac
 aac
 arD
@@ -61486,7 +61940,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -61616,42 +62070,42 @@ aad
 aad
 aad
 aac
+hzx
+aac
+aac
+aac
+aac
+aad
+aad
+aad
+vTV
+aac
+aac
+abq
+aad
+hkk
+aEu
+aEu
+aad
+aad
+aEu
+aEu
+hzx
+aad
 aac
 aac
 aac
 aac
 aac
+aac
+aac
+aad
+aad
 aad
 aad
 aad
 abq
-aac
-aac
-abq
-aad
-aad
-aEu
-aEu
-aad
-aad
-aEu
-aEu
-aac
-aad
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aad
-aad
-aad
-aad
-aad
-abq
-aac
+hzx
 aac
 aac
 aac
@@ -61703,7 +62157,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -61832,7 +62286,7 @@ aad
 aad
 aad
 aac
-aac
+hzx
 aac
 aac
 adZ
@@ -61842,10 +62296,10 @@ afX
 afY
 adZ
 adZ
-aac
-aac
-aac
-aac
+hzx
+hzx
+hzx
+hzx
 aac
 adZ
 ank
@@ -61853,23 +62307,23 @@ afz
 ann
 app
 adZ
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aad
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hkk
 aad
 afZ
 aad
 aad
 abq
-aac
+hzx
 aac
 aac
 aac
@@ -61920,7 +62374,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -62049,7 +62503,7 @@ aad
 aad
 aad
 aac
-aac
+hzx
 aac
 adZ
 adZ
@@ -62081,13 +62535,13 @@ adZ
 adZ
 adZ
 adZ
-aad
+hkk
 aad
 abq
 aad
 aad
 aad
-aac
+hzx
 aac
 aac
 aac
@@ -62137,7 +62591,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -62266,7 +62720,7 @@ aad
 aad
 aad
 aac
-aac
+hzx
 aac
 adZ
 aeS
@@ -62298,13 +62752,13 @@ avM
 aqc
 axn
 adZ
-aad
+hkk
 aad
 aad
 abq
 aad
 aad
-aad
+hkk
 abq
 aac
 aac
@@ -62354,7 +62808,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -62483,7 +62937,7 @@ aad
 aad
 aad
 aac
-aac
+hzx
 aac
 adZ
 aeS
@@ -62515,13 +62969,13 @@ auY
 asq
 arH
 adZ
-aac
+hzx
 aad
 aad
 aad
 aad
 aad
-aad
+hkk
 aad
 abq
 abq
@@ -62571,7 +63025,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -62700,7 +63154,7 @@ aad
 aad
 aad
 aac
-aac
+hzx
 aac
 adZ
 aeT
@@ -62732,12 +63186,12 @@ avN
 awA
 axo
 adZ
-aac
+hzx
 aad
 aad
 aad
 aad
-aad
+hkk
 aad
 aad
 aad
@@ -62774,21 +63228,21 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
 aac
 aac
 aac
@@ -62917,7 +63371,7 @@ aad
 aad
 aad
 aac
-aac
+hzx
 aac
 adZ
 adZ
@@ -62949,12 +63403,12 @@ auY
 awB
 kpd
 adZ
-aac
+hzx
 aac
 aad
 aad
 ahw
-aad
+hkk
 abq
 aad
 ahw
@@ -62990,7 +63444,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -63134,7 +63588,7 @@ aad
 aad
 aad
 aac
-aac
+hzx
 aac
 aac
 adZ
@@ -63167,10 +63621,10 @@ aqc
 aqc
 adZ
 aac
-aac
-aac
-aad
-aad
+hzx
+hzx
+hkk
+hkk
 abq
 aad
 aad
@@ -63207,7 +63661,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -63351,7 +63805,7 @@ aad
 aad
 aad
 aac
-aac
+hzx
 aac
 aac
 adZ
@@ -63424,7 +63878,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 abq
 abq
@@ -63568,7 +64022,7 @@ aad
 aad
 aad
 aac
-aac
+hzx
 aac
 aac
 adZ
@@ -63641,7 +64095,7 @@ abq
 aac
 aac
 aac
-aac
+hzx
 aac
 aad
 aad
@@ -63785,7 +64239,7 @@ aad
 aad
 aad
 aac
-aac
+hzx
 adZ
 adZ
 adZ
@@ -63858,7 +64312,7 @@ abq
 aac
 aac
 aac
-aac
+hzx
 aac
 abq
 aad
@@ -64002,7 +64456,7 @@ aad
 aad
 aad
 aac
-aac
+hzx
 adZ
 afz
 anL
@@ -64075,7 +64529,7 @@ abq
 aad
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -64219,7 +64673,7 @@ aad
 aad
 aad
 aac
-aac
+hzx
 adZ
 aew
 aeV
@@ -64292,7 +64746,7 @@ aad
 abq
 abq
 abq
-aac
+hzx
 aac
 aac
 aac
@@ -64436,7 +64890,7 @@ aad
 aad
 aad
 aac
-aac
+hzx
 adZ
 aex
 aex
@@ -64508,7 +64962,7 @@ aad
 aad
 aad
 aad
-aad
+hkk
 abq
 abq
 abq
@@ -64653,7 +65107,7 @@ aad
 aad
 aad
 aac
-aac
+hzx
 adZ
 adZ
 adZ
@@ -64724,7 +65178,7 @@ aad
 aad
 aad
 aad
-aad
+hkk
 aad
 aad
 aad
@@ -64870,7 +65324,7 @@ aad
 aad
 aad
 aac
-aac
+hzx
 adZ
 aey
 abr
@@ -64941,7 +65395,7 @@ aac
 aad
 abq
 aad
-aad
+hkk
 aad
 aad
 aad
@@ -65087,7 +65541,7 @@ aad
 aad
 aad
 aad
-aac
+hzx
 adZ
 aez
 aeX
@@ -65156,8 +65610,8 @@ aac
 aac
 aac
 aad
-aad
-aad
+hkk
+hkk
 aad
 bet
 aad
@@ -65304,7 +65758,7 @@ aad
 aad
 aad
 aad
-aac
+hzx
 adZ
 aez
 aeY
@@ -65372,7 +65826,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 abq
 aad
 aad
@@ -65521,7 +65975,7 @@ aad
 aad
 aad
 aac
-aac
+hzx
 adZ
 aeA
 aeZ
@@ -65588,7 +66042,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -65738,7 +66192,7 @@ aad
 aad
 aad
 aac
-aac
+hzx
 adZ
 adZ
 afa
@@ -65805,7 +66259,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -65956,7 +66410,7 @@ aad
 aad
 aac
 aac
-aac
+hzx
 adZ
 adZ
 adZ
@@ -66022,7 +66476,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -66174,7 +66628,7 @@ aad
 aad
 aad
 aac
-aac
+hzx
 aac
 aac
 adZ
@@ -66239,7 +66693,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -66392,7 +66846,7 @@ aad
 aad
 aad
 abq
-abq
+vTV
 aac
 aac
 adZ
@@ -66456,7 +66910,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -66609,7 +67063,7 @@ aad
 aad
 aad
 aad
-aad
+hkk
 abq
 aac
 aac
@@ -66673,7 +67127,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -66826,7 +67280,7 @@ aad
 aad
 aad
 aad
-aad
+hkk
 adZ
 adZ
 adZ
@@ -66890,7 +67344,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -67043,7 +67497,7 @@ aad
 aad
 aad
 aad
-abq
+vTV
 afv
 agh
 agd
@@ -67107,7 +67561,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -67260,7 +67714,7 @@ aad
 aad
 aad
 aad
-abq
+vTV
 afv
 agi
 agZ
@@ -67324,7 +67778,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -67477,7 +67931,7 @@ aad
 aad
 aad
 aad
-abq
+vTV
 adZ
 adZ
 adZ
@@ -67535,12 +67989,12 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
 aac
 aac
 aac
@@ -67694,7 +68148,7 @@ aad
 aad
 aad
 aad
-abq
+vTV
 afv
 agi
 aha
@@ -67714,15 +68168,15 @@ oWn
 aqn
 adZ
 aac
-aac
+hzx
 aac
 adZ
 auz
 avm
 adZ
 aac
-aac
-abq
+hzx
+vTV
 aad
 aac
 adZ
@@ -67751,7 +68205,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -67911,7 +68365,7 @@ aad
 aad
 aad
 aad
-abq
+vTV
 afH
 agj
 cca
@@ -67930,17 +68384,17 @@ aoM
 apA
 aqo
 adZ
+hzx
 aac
-aac
-abq
+vTV
 atP
 auA
 avn
 atP
+vTV
 abq
 abq
-abq
-aad
+hkk
 adZ
 adZ
 aAU
@@ -67968,7 +68422,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -68128,7 +68582,7 @@ aad
 aad
 aad
 aad
-abq
+vTV
 adZ
 adZ
 adZ
@@ -68154,10 +68608,10 @@ atP
 auB
 avo
 atP
+hkk
 aad
 aad
-aad
-abq
+vTV
 adZ
 aAT
 aAY
@@ -68185,7 +68639,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -68345,7 +68799,7 @@ aad
 aad
 aad
 aad
-abq
+vTV
 afv
 agj
 agd
@@ -68363,18 +68817,18 @@ adZ
 adZ
 adZ
 adZ
-aac
+hzx
 arM
 aad
-abq
+vTV
 adZ
 auC
 avp
 adZ
-arM
+xjd
 abq
 axU
-aad
+hkk
 adZ
 aAU
 aAU
@@ -68402,7 +68856,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -68562,7 +69016,7 @@ aac
 aad
 aad
 aad
-abq
+vTV
 afv
 agi
 agZ
@@ -68572,26 +69026,26 @@ aiU
 adZ
 adZ
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
 aac
 aad
 arM
-abq
+vTV
 atP
 auB
 avq
 atP
+hkk
 aad
 aad
-aad
-aad
+hkk
 adZ
 afv
 afv
@@ -68619,7 +69073,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -68779,7 +69233,7 @@ aac
 aad
 aad
 aad
-abq
+vTV
 adZ
 adZ
 adZ
@@ -68788,7 +69242,7 @@ ais
 agl
 ahb
 adZ
-aac
+hzx
 aac
 aac
 aac
@@ -68800,15 +69254,15 @@ abq
 abq
 abq
 aad
-aad
+hkk
 atP
 auA
 avn
 atP
-abq
+vTV
 aad
 arM
-aad
+hkk
 afv
 aAV
 aBG
@@ -68836,7 +69290,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -68996,7 +69450,7 @@ aac
 aad
 aad
 aad
-abq
+vTV
 afv
 agk
 agk
@@ -69005,9 +69459,9 @@ ait
 aiV
 tKU
 adZ
+hzx
 aac
 aac
-aac
 abq
 abq
 abq
@@ -69017,15 +69471,15 @@ aad
 aad
 abq
 aad
-aad
+hkk
 adZ
 auD
 jKb
 adZ
-aac
+hzx
 aac
 arM
-aad
+hkk
 afv
 aAW
 aBH
@@ -69053,7 +69507,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -69213,7 +69667,7 @@ aac
 aad
 aad
 aad
-abq
+vTV
 afv
 agl
 ahb
@@ -69222,7 +69676,7 @@ aiu
 aiu
 aiu
 adZ
-aac
+hzx
 aac
 aac
 aad
@@ -69234,15 +69688,15 @@ aad
 abq
 aad
 aad
-aad
+hkk
 adZ
 adZ
 adZ
 adZ
+hzx
 aac
-aac
 aad
-aad
+hkk
 adZ
 afv
 afv
@@ -69270,7 +69724,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -69430,7 +69884,7 @@ aac
 aad
 aad
 aad
-aad
+hkk
 adZ
 adZ
 adZ
@@ -69439,7 +69893,7 @@ adZ
 adZ
 adZ
 adZ
-aac
+hzx
 abq
 abq
 aad
@@ -69452,14 +69906,14 @@ aad
 aad
 aac
 aac
-aac
-aac
-aac
-aac
+hzx
+hzx
+hzx
+hzx
 aac
 aac
 abq
-aad
+hkk
 adZ
 aAU
 aAU
@@ -69487,7 +69941,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -69648,6 +70102,21 @@ aad
 aad
 abq
 aad
+hkk
+vTV
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+aac
+aad
+aad
+aad
+aad
+aad
+aad
 aad
 abq
 aac
@@ -69657,26 +70126,11 @@ aac
 aac
 aac
 aac
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-abq
-aac
-aac
-aac
-aac
-aac
-aac
-aac
 aac
 aac
 aac
 aad
-aad
+hkk
 adZ
 aAY
 aAU
@@ -69704,7 +70158,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -69893,7 +70347,7 @@ aac
 aac
 aac
 aad
-aad
+hkk
 adZ
 adZ
 aAU
@@ -69921,7 +70375,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -70111,7 +70565,7 @@ aac
 aac
 abq
 aad
-abq
+vTV
 adZ
 adZ
 adZ
@@ -70138,7 +70592,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -70329,10 +70783,10 @@ aac
 aad
 aad
 aad
-abq
-aac
-aac
-aac
+vTV
+hzx
+hzx
+hzx
 aac
 aac
 aac
@@ -70355,7 +70809,7 @@ aac
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -70550,7 +71004,7 @@ aad
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 aac
@@ -70572,7 +71026,7 @@ adZ
 adZ
 aac
 aac
-aac
+hzx
 aac
 aac
 aad
@@ -70767,7 +71221,7 @@ aad
 aac
 aac
 aac
-aac
+hzx
 aac
 aac
 adZ
@@ -70789,7 +71243,7 @@ aUD
 adZ
 adZ
 aac
-aac
+hzx
 aac
 aac
 aad
@@ -70984,7 +71438,7 @@ aad
 aac
 aac
 aac
-aac
+hzx
 aac
 adZ
 adZ
@@ -71006,7 +71460,7 @@ aUE
 aVx
 adZ
 adZ
-aac
+hzx
 aac
 aac
 aad
@@ -71201,7 +71655,7 @@ aad
 aac
 aac
 aac
-aac
+hzx
 aEu
 adZ
 aeG
@@ -71223,7 +71677,7 @@ aUF
 aVy
 aVZ
 adZ
-aac
+hzx
 aac
 aad
 aad
@@ -71418,7 +71872,7 @@ aad
 aad
 aac
 aac
-aac
+hzx
 aEu
 aFq
 aGl
@@ -71440,7 +71894,7 @@ aUG
 aVz
 agT
 adZ
-aac
+hzx
 aac
 aad
 aad
@@ -71635,7 +72089,7 @@ aad
 aad
 aac
 aac
-aac
+hzx
 aEu
 aFr
 aGm
@@ -71657,7 +72111,7 @@ wfD
 xWK
 aWb
 adZ
-aac
+hzx
 aac
 aad
 aad
@@ -71852,7 +72306,7 @@ aad
 aad
 aac
 aac
-aac
+hzx
 aEu
 adZ
 aGn
@@ -71874,7 +72328,7 @@ aUH
 aVA
 aWc
 adZ
-aac
+hzx
 aac
 aad
 aad
@@ -72069,7 +72523,7 @@ aad
 aad
 aac
 aac
-aac
+hzx
 aac
 adZ
 adZ
@@ -72091,7 +72545,7 @@ aUI
 aVB
 adZ
 adZ
-aac
+hzx
 aac
 aad
 aad
@@ -72287,7 +72741,7 @@ aad
 aac
 aac
 aac
-aac
+hzx
 aac
 adZ
 adZ
@@ -72307,7 +72761,7 @@ afx
 aUJ
 adZ
 adZ
-aac
+hzx
 aac
 aad
 aad
@@ -72505,7 +72959,7 @@ aad
 aad
 aad
 aac
-aac
+hzx
 aac
 adZ
 adZ
@@ -72523,7 +72977,7 @@ adZ
 adZ
 aUK
 aUK
-aad
+hkk
 aad
 aad
 aad
@@ -72723,21 +73177,21 @@ aad
 aad
 aad
 aac
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aac
-aac
-aac
-aac
-aac
-aac
-aad
+hkk
+hkk
+hkk
+hkk
+hkk
+hkk
+hkk
+hkk
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hkk
 aad
 aad
 aad

--- a/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -28,6 +28,7 @@
 /turf/closed/ice_rock/eastWall,
 /area/ice_colony/exterior/surface/cliff)
 "aah" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/wall/r_wall,
 /area/ice_colony/exterior/surface/cliff)
 "aai" = (
@@ -814,10 +815,6 @@
 "acY" = (
 /turf/closed/wall/r_wall,
 /area/ice_colony/surface/requesitions)
-"acZ" = (
-/obj/effect/landmark/xeno_tunnel,
-/turf/open/floor/plating/ground/snow/layer3,
-/area/ice_colony/exterior/surface/valley/northwest)
 "ada" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
@@ -917,6 +914,7 @@
 /obj/effect/turf_overlay/icerock{
 	dir = 8
 	},
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/ice_rock/corners,
 /area/ice_colony/exterior/surface/cliff)
 "adr" = (
@@ -1167,6 +1165,7 @@
 /turf/closed/wall,
 /area/ice_colony/surface/engineering/tool)
 "aee" = (
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/ice_rock/singleEnd{
 	dir = 4
 	},
@@ -2585,6 +2584,7 @@
 /turf/closed/ice/straight,
 /area/ice_colony/exterior/surface/clearing/pass)
 "ahG" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/wall/r_wall,
 /area/ice_colony/exterior/surface/valley/northwest)
 "ahH" = (
@@ -4163,6 +4163,7 @@
 /area/ice_colony/surface/mining)
 "alF" = (
 /obj/effect/turf_underlay/icefloor,
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/ice/thin/end,
 /area/ice_colony/surface/mining)
 "alG" = (
@@ -4354,6 +4355,7 @@
 /area/ice_colony/surface/mining)
 "aml" = (
 /obj/effect/turf_underlay/icefloor,
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/ice/thin/corner,
 /area/ice_colony/surface/mining)
 "amm" = (
@@ -4473,6 +4475,7 @@
 /area/ice_colony/surface/dorms/restroom_e)
 "amz" = (
 /obj/effect/turf_underlay/icefloor,
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/ice/thin/straight,
 /area/ice_colony/surface/mining)
 "amA" = (
@@ -6258,6 +6261,7 @@
 	d1 = 4;
 	d2 = 8
 	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/snow/layer2,
 /area/ice_colony/exterior/surface/valley/northwest)
 "aqS" = (
@@ -18571,6 +18575,7 @@
 /area/ice_colony/exterior/surface/valley/southwest)
 "aWz" = (
 /obj/structure/fence,
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/snow/layer3,
 /area/ice_colony/exterior/surface/valley/southwest)
 "aWA" = (
@@ -18969,6 +18974,9 @@
 "aXz" = (
 /obj/effect/turf_overlay/icerock{
 	dir = 4
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
 	},
 /turf/closed/ice_rock/singlePart{
 	dir = 4
@@ -22627,6 +22635,7 @@
 /area/ice_colony/exterior/surface/valley/south)
 "bhS" = (
 /obj/structure/fence,
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/snow/layer2,
 /area/ice_colony/exterior/surface/valley/southwest)
 "bhT" = (
@@ -24168,6 +24177,7 @@
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/responsehangar)
 "bmb" = (
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/ice/straight{
 	dir = 4
 	},
@@ -38187,6 +38197,7 @@
 /area/ice_colony/surface/excavationbarracks)
 "bWT" = (
 /obj/effect/turf_underlay/icefloor,
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/ice/thin/straight,
 /area/ice_colony/underground/maintenance/east)
 "bWU" = (
@@ -39927,6 +39938,12 @@
 	},
 /turf/open/floor/plating/icefloor/warnplate,
 /area/ice_colony/exterior/surface/landing_pad)
+"cdY" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/straight{
+	dir = 4
+	},
+/area/ice_colony/underground/maintenance/east)
 "cea" = (
 /obj/effect/decal/mecha_wreckage/ripley,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -39987,9 +40004,35 @@
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/hallway/south_east)
+"cqm" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/corner{
+	dir = 1
+	},
+/area/ice_colony/exterior/surface/valley/west)
+"cxW" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice_rock/westWall,
+/area/ice_colony/exterior/surface/cliff)
+"czW" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
+	},
+/turf/closed/ice_rock/singlePart{
+	dir = 6
+	},
+/area/ice_colony/exterior/surface/cliff)
 "cLf" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/storage/testroom)
+"cND" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice_rock/northWall,
+/area/ice_colony/exterior/surface/cliff)
+"dfk" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/closed/wall/r_wall/unmeltable,
+/area/ice_colony/exterior/surface/cliff)
 "dfU" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -40003,10 +40046,290 @@
 	dir = 4
 	},
 /area/ice_colony/underground/hallway/north_west)
+"dtg" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice_rock/eastWall,
+/area/ice_colony/exterior/surface/cliff)
+"dAY" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/corner{
+	dir = 8
+	},
+/area/ice_colony/underground/maintenance/east)
+"dRL" = (
+/obj/structure/mineral_door/resin,
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/ice,
+/area/ice_colony/underground/maintenance/east)
+"esg" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/corner,
+/area/ice_colony/underground/maintenance/east)
+"etV" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/corner,
+/area/ice_colony/exterior/underground/caves)
+"eOo" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/ice,
+/area/ice_colony/exterior/surface/valley/northeast)
+"fiU" = (
+/obj/effect/turf_underlay/icefloor,
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/thin/straight,
+/area/ice_colony/exterior/surface/valley/south/excavation)
+"fjG" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/straight{
+	dir = 4
+	},
+/area/ice_colony/exterior/underground/caves)
+"fol" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/corner{
+	dir = 1
+	},
+/area/ice_colony/underground/maintenance/east)
+"fzT" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice_rock/corners{
+	dir = 6
+	},
+/area/ice_colony/exterior/surface/cliff)
+"fEh" = (
+/obj/effect/turf_underlay/icefloor,
+/obj/effect/landmark/xeno_tunnel,
+/turf/closed/ice/thin/end{
+	dir = 8
+	},
+/area/ice_colony/exterior/surface/valley/west)
+"fGg" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/snow/layer3,
+/area/ice_colony/exterior/surface/valley/northwest)
+"fNR" = (
+/obj/effect/turf_underlay/icefloor,
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/thin/end{
+	dir = 1
+	},
+/area/ice_colony/exterior/underground/caves)
+"fPF" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice_rock/corners{
+	dir = 10
+	},
+/area/ice_colony/exterior/surface/cliff)
+"fRw" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/plating/ground/snow/layer3,
+/area/ice_colony/exterior/surface/valley/northwest)
+"fSR" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/snow/layer3,
+/area/ice_colony/exterior/surface/valley/north)
+"fVu" = (
+/turf/open/space/basic,
+/area/space)
+"fYM" = (
+/obj/effect/turf_underlay/icefloor,
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/thin/end{
+	dir = 8
+	},
+/area/ice_colony/exterior/surface/valley/north)
+"gqo" = (
+/obj/effect/turf_underlay/icefloor,
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/thin/end{
+	dir = 1
+	},
+/area/ice_colony/underground/maintenance/east)
+"gtM" = (
+/obj/effect/turf_overlay/icerock{
+	dir = 1
+	},
+/obj/effect/turf_overlay/icerock{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
+	},
+/turf/closed/ice_rock/corners,
+/area/ice_colony/exterior/surface/cliff)
+"gxG" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/closed/ice_rock/corners,
+/area/ice_colony/exterior/surface/valley/west)
+"gEI" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/closed/ice_rock/corners,
+/area/ice_colony/exterior/surface/cliff)
+"gFB" = (
+/obj/effect/turf_underlay/icefloor,
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/thin/end{
+	dir = 4
+	},
+/area/ice_colony/exterior/underground/caves)
+"gGw" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/straight{
+	dir = 4
+	},
+/area/ice_colony/exterior/surface/cliff)
+"gXG" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/straight,
+/area/ice_colony/exterior/surface/cliff)
+"hcN" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice_rock/corners{
+	dir = 6
+	},
+/area/ice_colony/exterior/underground/caves)
+"hgM" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/closed/ice_rock/corners,
+/area/ice_colony/exterior/surface/valley/west)
 "hot" = (
 /obj/structure/sign/greencross,
 /turf/open/floor/tile/darkgreen/darkgreen2,
 /area/ice_colony/underground/hallway/north_west)
+"htK" = (
+/obj/structure/fence,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/plating/ground/ice,
+/area/ice_colony/exterior/surface/valley/southeast)
+"hDJ" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 8
+	},
+/turf/open/floor/plating/icefloor,
+/area/ice_colony/exterior/surface/landing_pad)
+"hKh" = (
+/obj/effect/turf_underlay/icefloor,
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/thin/end{
+	dir = 8
+	},
+/area/ice_colony/exterior/underground/caves)
+"hLk" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/closed/ice_rock/southWall,
+/area/ice_colony/exterior/surface/cliff)
+"hTx" = (
+/obj/effect/turf_overlay/icerock{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/closed/ice_rock/corners,
+/area/ice_colony/exterior/surface/cliff)
+"iao" = (
+/obj/machinery/landinglight/ds1{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/computer/shuttle/shuttle_control/dropship1,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 4
+	},
+/area/ice_colony/exterior/surface/landing_pad)
+"ijr" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/closed/ice_rock/northWall,
+/area/ice_colony/exterior/surface/cliff)
+"inT" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/ice,
+/area/ice_colony/underground/maintenance/east)
+"ioJ" = (
+/obj/effect/turf_overlay/icerock{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
+	},
+/turf/closed/ice_rock/northWall,
+/area/ice_colony/exterior/surface/cliff)
+"iyH" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/button/door/open_only/landing_zone/lz2{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/ice,
+/area/ice_colony/exterior/surface/landing_pad_external)
+"iJZ" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/ice,
+/area/ice_colony/exterior/surface/valley/west)
+"iVB" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 8
+	},
+/turf/closed/ice_rock/northWall,
+/area/ice_colony/exterior/surface/cliff)
+"jgT" = (
+/obj/effect/turf_underlay/icefloor,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 8
+	},
+/turf/closed/ice/thin/end,
+/area/ice_colony/exterior/surface/landing_pad_external)
+"jhp" = (
+/obj/effect/turf_underlay/icefloor,
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/thin/single,
+/area/ice_colony/underground/maintenance/east)
+"jqu" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice_rock/westWall,
+/area/ice_colony/exterior/surface/valley/north)
+"jvd" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/corner{
+	dir = 4
+	},
+/area/ice_colony/underground/maintenance/east)
+"jyB" = (
+/obj/effect/turf_underlay/icefloor,
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/thin/single,
+/area/ice_colony/exterior/surface/valley/south/excavation)
+"jzH" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/corner{
+	dir = 1
+	},
+/area/ice_colony/exterior/underground/caves)
+"jAc" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/end{
+	dir = 4
+	},
+/area/ice_colony/exterior/surface/cliff)
+"jQk" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/closed/wall/r_wall/unmeltable,
+/area/ice_colony/exterior/surface/cliff)
 "jQI" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -40014,6 +40337,52 @@
 /obj/structure/sign/electricshock,
 /turf/open/floor/plating/ground/snow/layer2,
 /area/ice_colony/exterior/surface/valley/south/excavation)
+"kdu" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/end{
+	dir = 1
+	},
+/area/ice_colony/exterior/surface/cliff)
+"kfQ" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/ice_colony/exterior/surface/valley/northwest)
+"ktc" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 8
+	},
+/turf/open/floor/plating/icefloor/warnplate,
+/area/ice_colony/exterior/surface/landing_pad)
+"ktI" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice_rock/southWall,
+/area/ice_colony/exterior/surface/cliff)
+"kvW" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/junction{
+	dir = 8
+	},
+/area/ice_colony/exterior/surface/cliff)
+"kwG" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 8
+	},
+/turf/closed/ice/end{
+	dir = 8
+	},
+/area/ice_colony/exterior/surface/cliff)
+"kQw" = (
+/obj/effect/turf_underlay/icefloor,
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/thin/straight{
+	dir = 4
+	},
+/area/ice_colony/exterior/surface/valley/south/excavation)
+"lap" = (
+/obj/effect/turf_underlay/icefloor,
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/thin/single,
+/area/ice_colony/exterior/surface/valley/northeast)
 "lbl" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -40026,10 +40395,178 @@
 /obj/structure/sign/electricshock,
 /turf/open/floor/plating/ground/snow/layer2,
 /area/ice_colony/exterior/surface/valley/south/excavation)
+"lph" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 8
+	},
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 1
+	},
+/area/ice_colony/exterior/surface/landing_pad)
+"luT" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/ice_colony/surface/hangar/beta)
+"lxk" = (
+/obj/effect/turf_underlay/icefloor,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 8
+	},
+/turf/closed/ice/thin/corner{
+	dir = 1
+	},
+/area/ice_colony/exterior/surface/landing_pad_external)
+"lJL" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice_rock/northWall,
+/area/ice_colony/exterior/underground/caves)
+"mbE" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice_rock/singlePart{
+	dir = 6
+	},
+/area/ice_colony/exterior/surface/cliff)
+"mgJ" = (
+/obj/effect/turf_overlay/icerock{
+	dir = 8
+	},
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice_rock/corners,
+/area/ice_colony/exterior/surface/cliff)
+"mkx" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice,
+/area/ice_colony/exterior/underground/caves/open)
+"myL" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/wall/r_wall,
+/area/ice_colony/surface/research/tech_storage)
+"myP" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
+	},
+/turf/closed/ice_rock/eastWall,
+/area/ice_colony/exterior/surface/cliff)
+"mLj" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
+	},
+/turf/closed/ice_rock/corners{
+	dir = 10
+	},
+/area/ice_colony/exterior/surface/cliff)
+"mLS" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/ice,
+/area/ice_colony/exterior/underground/caves)
+"mXX" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/ice,
+/area/ice_colony/exterior/surface/landing_pad_external)
+"ndU" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
+	},
+/turf/closed/ice_rock/westWall,
+/area/ice_colony/exterior/surface/cliff)
+"neY" = (
+/obj/effect/turf_overlay/icerock{
+	dir = 1
+	},
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice_rock/corners,
+/area/ice_colony/exterior/surface/cliff)
+"nBB" = (
+/obj/effect/turf_overlay/icerock{
+	dir = 4
+	},
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice_rock/corners,
+/area/ice_colony/exterior/surface/cliff)
+"nIz" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice_rock/corners{
+	dir = 6
+	},
+/area/ice_colony/exterior/underground/caves/open)
+"nKI" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice,
+/area/ice_colony/underground/maintenance/east)
+"okD" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/straight,
+/area/ice_colony/exterior/surface/valley/west)
+"oFx" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/corner{
+	dir = 1
+	},
+/area/ice_colony/exterior/surface/cliff)
+"php" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/closed/wall/r_wall,
+/area/ice_colony/surface/tcomms)
+"puR" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/closed/ice_rock/southWall,
+/area/ice_colony/exterior/surface/cliff)
+"qFz" = (
+/obj/effect/turf_underlay/icefloor,
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/thin/end{
+	dir = 4
+	},
+/area/ice_colony/underground/maintenance/east)
+"qIM" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice_rock/singlePart{
+	dir = 1
+	},
+/area/ice_colony/exterior/surface/cliff)
+"qLM" = (
+/obj/effect/turf_overlay/icerock,
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice_rock/corners,
+/area/ice_colony/exterior/surface/cliff)
+"qMH" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice_rock/corners{
+	dir = 5
+	},
+/area/ice_colony/exterior/surface/cliff)
+"qPe" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/closed/ice_rock/corners,
+/area/ice_colony/exterior/surface/cliff)
+"qUJ" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/junction{
+	dir = 4
+	},
+/area/ice_colony/exterior/surface/cliff)
 "rcI" = (
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/floor/plating/icefloor,
 /area/storage/testroom)
+"rjH" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
+	},
+/turf/closed/ice,
+/area/ice_colony/exterior/surface/cliff)
+"rls" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 8
+	},
+/turf/closed/ice_rock/corners,
+/area/ice_colony/exterior/surface/cliff)
 "rpH" = (
 /obj/structure/cable{
 	icon_state = "4-8";
@@ -40039,6 +40576,237 @@
 /obj/structure/sign/electricshock,
 /turf/open/floor/plating/icefloor,
 /area/ice_colony/underground/hangar)
+"rtq" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice_rock/southWall,
+/area/ice_colony/exterior/surface/valley/west)
+"rJA" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 8
+	},
+/turf/closed/ice_rock/singlePart{
+	dir = 6
+	},
+/area/ice_colony/exterior/surface/cliff)
+"rKF" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/ice,
+/area/ice_colony/underground/maintenance/engineering)
+"rMt" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
+	},
+/turf/closed/ice_rock/corners,
+/area/ice_colony/exterior/surface/cliff)
+"rSi" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice_rock/singleEnd{
+	dir = 8
+	},
+/area/ice_colony/exterior/surface/cliff)
+"sfn" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/corner{
+	dir = 4
+	},
+/area/ice_colony/exterior/underground/caves)
+"spj" = (
+/obj/effect/turf_underlay/icefloor,
+/obj/effect/landmark/xeno_tunnel,
+/turf/closed/ice/thin/single,
+/area/ice_colony/exterior/surface/cliff)
+"svd" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
+	},
+/turf/closed/ice_rock/singleEnd{
+	dir = 4
+	},
+/area/ice_colony/exterior/surface/cliff)
+"sBu" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice_rock/corners,
+/area/ice_colony/exterior/surface/valley/north)
+"sKH" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/straight,
+/area/ice_colony/underground/maintenance/east)
+"sMq" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 8
+	},
+/turf/closed/ice_rock/westWall,
+/area/ice_colony/exterior/surface/cliff)
+"tbQ" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice,
+/area/ice_colony/exterior/surface/cliff)
+"tmI" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 8
+	},
+/turf/closed/ice_rock/singleEnd,
+/area/ice_colony/exterior/surface/cliff)
+"toB" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/ice_colony/exterior/surface/valley/south/excavation)
+"tto" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice_rock/corners,
+/area/ice_colony/exterior/surface/cliff)
+"twy" = (
+/obj/effect/turf_underlay/icefloor,
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/thin/end,
+/area/ice_colony/underground/maintenance/east)
+"tMa" = (
+/obj/structure/fence,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/ice,
+/area/ice_colony/exterior/surface/valley/southeast)
+"tQs" = (
+/obj/effect/turf_overlay/icerock{
+	dir = 8
+	},
+/obj/effect/turf_overlay/icerock{
+	dir = 1
+	},
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice_rock/corners,
+/area/ice_colony/exterior/surface/cliff)
+"tTa" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/straight,
+/area/ice_colony/exterior/underground/caves)
+"ucO" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
+	},
+/turf/closed/ice_rock/singleEnd{
+	dir = 8
+	},
+/area/ice_colony/exterior/surface/cliff)
+"uvI" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/corner{
+	dir = 4
+	},
+/area/ice_colony/exterior/surface/cliff)
+"uwB" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/ice,
+/area/ice_colony/surface/mining)
+"uxL" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/corner,
+/area/ice_colony/exterior/surface/cliff)
+"uyX" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating,
+/area/ice_colony/exterior/underground/caves/open)
+"uEl" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice_rock/corners{
+	dir = 9
+	},
+/area/ice_colony/exterior/surface/cliff)
+"uOC" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice,
+/area/ice_colony/exterior/underground/caves)
+"uPx" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/corner{
+	dir = 8
+	},
+/area/ice_colony/exterior/surface/cliff)
+"vdz" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
+	},
+/turf/closed/ice_rock/northWall,
+/area/ice_colony/exterior/surface/cliff)
+"veR" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/closed/ice_rock/corners{
+	dir = 6
+	},
+/area/ice_colony/exterior/surface/cliff)
+"vnY" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/corner{
+	dir = 8
+	},
+/area/ice_colony/exterior/underground/caves)
+"vqL" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice_rock/corners,
+/area/ice_colony/exterior/underground/caves)
+"vrG" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/ice_colony/exterior/surface/valley/south/excavation)
+"wmQ" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice_rock/corners{
+	dir = 5
+	},
+/area/ice_colony/exterior/underground/caves/open)
+"wHH" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/closed/wall/r_wall,
+/area/ice_colony/surface/requesitions)
+"wPe" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/wall/r_wall,
+/area/ice_colony/underground/hangar)
+"xaL" = (
+/obj/machinery/button/door/open_only/landing_zone,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/ice_colony/exterior/surface/landing_pad2)
+"xfJ" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice_rock/southWall,
+/area/ice_colony/exterior/surface/valley/north)
+"xjB" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/end{
+	dir = 4
+	},
+/area/ice_colony/exterior/underground/caves)
+"xQi" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/ice,
+/area/ice_colony/exterior/underground/caves/open)
+"xUy" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/ice/end{
+	dir = 1
+	},
+/area/ice_colony/exterior/surface/valley/west)
+"yem" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/ice_colony/exterior/surface/valley/northwest)
+"yft" = (
+/obj/structure/fence,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/ice,
+/area/ice_colony/exterior/surface/landing_pad_external)
 
 (1,1,1) = {"
 aaa
@@ -42137,9 +42905,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+fVu
+fVu
+fVu
 aaa
 aaa
 bSw
@@ -42175,7 +42943,7 @@ acj
 aac
 aac
 aac
-aac
+gEI
 aac
 aac
 aac
@@ -42195,7 +42963,7 @@ aac
 aac
 aac
 aac
-aac
+tto
 aac
 aac
 aad
@@ -42394,9 +43162,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+fVu
+fVu
+fVu
 aaa
 aaa
 bSw
@@ -42432,7 +43200,7 @@ abb
 acD
 aac
 aac
-aac
+gEI
 aac
 aac
 aac
@@ -42452,7 +43220,7 @@ aag
 aag
 acD
 aac
-aac
+tto
 aac
 aac
 aae
@@ -42651,9 +43419,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+fVu
+fVu
+fVu
 aaa
 aaa
 bSw
@@ -42689,7 +43457,7 @@ aaR
 acj
 acD
 aac
-aac
+gEI
 aac
 aac
 aac
@@ -42709,7 +43477,7 @@ aCs
 aEz
 acj
 acD
-aad
+qLM
 aag
 bdn
 bdn
@@ -42908,9 +43676,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+fVu
+fVu
+fVu
 aaa
 aaa
 bSw
@@ -42946,7 +43714,7 @@ ace
 aaC
 acj
 acD
-aac
+gEI
 aac
 aac
 aac
@@ -42961,12 +43729,12 @@ aaC
 aaQ
 alJ
 alJ
-aWV
+alJ
 alJ
 alJ
 alJ
 acm
-aae
+ktI
 axf
 aCs
 aCs
@@ -43165,9 +43933,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+fVu
+fVu
+fVu
 aaa
 aaa
 bSw
@@ -43203,7 +43971,7 @@ abH
 abb
 aaC
 acm
-aac
+gEI
 aac
 aac
 aac
@@ -43223,7 +43991,7 @@ alJ
 alJ
 alJ
 acm
-bgb
+rtq
 axg
 amB
 alJ
@@ -43422,9 +44190,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+fVu
+fVu
+fVu
 aaa
 aaa
 bSw
@@ -43460,7 +44228,7 @@ aBi
 aBi
 aBi
 aBi
-aBi
+php
 aac
 aac
 aac
@@ -43487,7 +44255,7 @@ alJ
 alJ
 alJ
 alJ
-apg
+fEh
 aBK
 alJ
 alJ
@@ -43679,9 +44447,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+fVu
+fVu
+fVu
 aaa
 aaa
 bSw
@@ -43717,7 +44485,7 @@ alx
 aoe
 asg
 asg
-aBi
+php
 aca
 abb
 aac
@@ -43736,7 +44504,7 @@ alJ
 alJ
 alJ
 acm
-aae
+ktI
 and
 ane
 alJ
@@ -43936,9 +44704,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+fVu
+fVu
+fVu
 aaa
 aaa
 bSw
@@ -43974,7 +44742,7 @@ aFh
 arS
 avM
 axM
-aBi
+php
 alJ
 aaR
 abb
@@ -43993,7 +44761,7 @@ alJ
 alJ
 aBE
 acm
-aae
+ktI
 aph
 alJ
 alJ
@@ -44018,7 +44786,7 @@ aph
 aaQ
 aaR
 abb
-alJ
+aWV
 aaC
 alJ
 alJ
@@ -44193,9 +44961,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+fVu
+fVu
+fVu
 aaa
 aaa
 bSw
@@ -44231,7 +44999,7 @@ aFh
 aFn
 avN
 bVb
-aBi
+php
 alJ
 alJ
 aaR
@@ -44250,7 +45018,7 @@ alJ
 axf
 ayu
 acj
-aaU
+uEl
 alJ
 alJ
 alJ
@@ -44488,7 +45256,7 @@ bUQ
 adY
 avN
 bVc
-aBi
+php
 alJ
 alJ
 alJ
@@ -44508,7 +45276,7 @@ ayo
 apg
 alJ
 alJ
-alJ
+iJZ
 alJ
 alJ
 amB
@@ -44745,7 +45513,7 @@ anX
 bUO
 avN
 bVd
-aBi
+php
 alJ
 alJ
 alJ
@@ -44754,7 +45522,7 @@ alJ
 alJ
 alJ
 alJ
-aWV
+alJ
 alJ
 alJ
 alJ
@@ -44765,11 +45533,11 @@ axg
 aph
 alJ
 alJ
-alJ
+iJZ
 alJ
 amB
-aca
-aaZ
+kdu
+uPx
 alJ
 alJ
 alJ
@@ -44835,34 +45603,34 @@ bmU
 bmU
 bmU
 bmU
-bmU
-bmU
-bTG
-bTK
-bnV
-bmU
-bmU
-bnV
-bnV
-bGw
-bGw
-bGw
-bGw
-bGw
-bGw
-bGw
-bGw
-bmU
-bmU
-bmU
-bRL
-bGw
-bGw
-bGw
-bGw
-bGw
-bGw
-aZF
+xQi
+xQi
+nIz
+wmQ
+mkx
+xQi
+xQi
+mkx
+mkx
+vqL
+vqL
+vqL
+vqL
+vqL
+vqL
+vqL
+vqL
+xQi
+xQi
+xQi
+hcN
+vqL
+vqL
+vqL
+vqL
+vqL
+vqL
+uOC
 aZF
 bmT
 bmT
@@ -45002,7 +45770,7 @@ aFh
 bUO
 aoc
 bVe
-aBi
+php
 alJ
 alJ
 alJ
@@ -45023,11 +45791,11 @@ alJ
 alJ
 alJ
 amB
-aaP
-abb
+uvI
+uxL
 amB
 alI
-alJ
+iJZ
 alJ
 alJ
 alJ
@@ -45091,7 +45859,7 @@ bmU
 bmU
 bmU
 bmU
-bmU
+xQi
 bdb
 bdb
 bdb
@@ -45120,7 +45888,7 @@ biy
 bkJ
 bkJ
 bkJ
-aZF
+uOC
 bmT
 bmU
 bmU
@@ -45259,7 +46027,7 @@ aon
 arU
 ajj
 ayq
-aBi
+php
 alJ
 aik
 bca
@@ -45285,8 +46053,8 @@ aaZ
 alI
 alI
 alI
-alJ
-alJ
+iJZ
+iJZ
 alJ
 afO
 aaP
@@ -45348,7 +46116,7 @@ bmU
 bmU
 bmU
 bmU
-bmU
+xQi
 bdb
 bcg
 bcH
@@ -45377,7 +46145,7 @@ biy
 blD
 bmr
 bkJ
-bmi
+vnY
 bmU
 bmU
 bmU
@@ -45516,7 +46284,7 @@ aBi
 aBi
 aBi
 aBi
-aBi
+php
 aac
 aac
 aTO
@@ -45544,7 +46312,7 @@ alI
 alI
 alI
 alJ
-aFz
+xUy
 aCt
 ayu
 aaQ
@@ -45605,7 +46373,7 @@ bmU
 bmU
 bmU
 bmU
-bnV
+mkx
 bdb
 aYN
 bcH
@@ -45634,7 +46402,7 @@ biy
 blD
 bms
 blD
-bmU
+xQi
 bmU
 bmU
 bmU
@@ -45773,7 +46541,7 @@ afO
 aaP
 abM
 abn
-acm
+ijr
 aac
 aac
 bfl
@@ -45802,8 +46570,8 @@ alI
 alI
 alJ
 alJ
-aBL
-aCs
+cqm
+okD
 ayo
 amB
 alJ
@@ -45862,7 +46630,7 @@ bmU
 bmU
 bmU
 bmU
-bnV
+mkx
 bdb
 bch
 bcI
@@ -45891,7 +46659,7 @@ biy
 blF
 bms
 blD
-bmU
+xQi
 bmU
 bov
 bmU
@@ -46030,7 +46798,7 @@ afO
 afx
 aaQ
 aaU
-abG
+hTx
 bfl
 bfZ
 bdn
@@ -46061,7 +46829,7 @@ alJ
 alI
 alI
 alI
-aBL
+cqm
 aPj
 alJ
 alJ
@@ -46119,7 +46887,7 @@ bmU
 bmU
 bmU
 bmU
-bnV
+mkx
 bdc
 bcn
 bcK
@@ -46148,7 +46916,7 @@ blh
 blD
 bms
 bkJ
-bml
+etV
 bmU
 bmU
 bmU
@@ -46287,7 +47055,7 @@ aaC
 aaR
 aaZ
 alR
-bfl
+hgM
 bfl
 beE
 and
@@ -46319,7 +47087,7 @@ alI
 alI
 alJ
 alJ
-alJ
+iJZ
 alJ
 alJ
 alJ
@@ -46376,7 +47144,7 @@ bmU
 bmU
 bmU
 bnV
-bnV
+mkx
 bdc
 bdb
 bdb
@@ -46405,7 +47173,7 @@ biy
 blG
 bms
 bkJ
-bmm
+jzH
 bml
 bmU
 bmU
@@ -46544,7 +47312,7 @@ abZ
 aac
 aac
 bfl
-bfl
+hgM
 beE
 aok
 ane
@@ -46577,7 +47345,7 @@ alI
 alI
 alJ
 alJ
-alJ
+iJZ
 alJ
 alJ
 alJ
@@ -46633,7 +47401,7 @@ bmU
 bmU
 bmU
 bnV
-bnV
+mkx
 bce
 bcr
 bcX
@@ -46662,7 +47430,7 @@ biy
 blG
 bms
 bkJ
-aZF
+uOC
 bmm
 bml
 bnU
@@ -46798,9 +47566,9 @@ aaJ
 atq
 ahk
 aae
-aac
-aac
-bfl
+qPe
+qPe
+gxG
 beE
 beE
 alJ
@@ -46834,14 +47602,14 @@ alI
 alI
 alI
 alI
-alJ
+iJZ
 alJ
 amA
 apS
-aaP
-amC
-aba
-amC
+uvI
+kvW
+gXG
+kvW
 abb
 amA
 aok
@@ -46890,7 +47658,7 @@ bmU
 bmU
 bmU
 bnV
-bnV
+mkx
 bce
 bde
 bdL
@@ -46919,7 +47687,7 @@ biy
 blG
 bms
 bkJ
-aZF
+uOC
 aZF
 bmm
 bnT
@@ -47054,7 +47822,7 @@ agW
 aaJ
 atx
 aKD
-aae
+hLk
 bfl
 bfl
 beE
@@ -47092,19 +47860,19 @@ alI
 alI
 alI
 aca
-aba
-aba
-aba
+gXG
+gXG
+gXG
 aaZ
 amB
 alK
 alK
-aaR
-aba
-aba
-aba
-abM
-abb
+oFx
+gXG
+gXG
+gXG
+qUJ
+uxL
 amB
 alJ
 alJ
@@ -47147,7 +47915,7 @@ bmU
 bmU
 bmU
 bmU
-bnV
+mkx
 bce
 bde
 bdL
@@ -47177,15 +47945,15 @@ blH
 bms
 bkJ
 aZF
-aZF
-aZF
-aZF
-aZF
-aZF
-aZF
-bmm
-bnT
-bnT
+uOC
+uOC
+uOC
+uOC
+uOC
+uOC
+jzH
+tTa
+tTa
 bml
 bnT
 bmi
@@ -47285,7 +48053,7 @@ aaa
 bSw
 aae
 aai
-abm
+xaL
 abm
 adb
 abm
@@ -47311,7 +48079,7 @@ aaJ
 aaJ
 atx
 agC
-aaB
+veR
 bfl
 beE
 beE
@@ -47362,7 +48130,7 @@ amA
 apS
 aaR
 amC
-abb
+uxL
 alJ
 alJ
 alJ
@@ -47404,7 +48172,7 @@ bmU
 bmU
 bmU
 bmU
-bnV
+mkx
 bce
 bde
 bdL
@@ -47443,45 +48211,45 @@ bkt
 bkt
 bkt
 bkt
-aZF
-aZF
-aZF
-aZF
-aZF
-aZF
-aZF
-aZF
-aZF
-aZF
-aZF
-aZF
-aZF
-aZF
-bmQ
-bmU
-bmU
-bmU
+uOC
+uOC
+uOC
+uOC
+uOC
+uOC
+uOC
+uOC
+uOC
+uOC
+uOC
+uOC
+uOC
+uOC
+fjG
+xQi
+xQi
+xQi
 bmb
-aZF
-aZF
-aZF
-aZF
-aZF
-aZF
-aZF
-aZF
-aZF
-bbq
-bbq
-bbq
-bbq
-bbq
-bbq
-bmm
-bnT
-bnT
-bnT
-bjZ
+uOC
+uOC
+uOC
+uOC
+uOC
+uOC
+uOC
+uOC
+uOC
+uyX
+uyX
+uyX
+uyX
+uyX
+uyX
+jzH
+tTa
+tTa
+tTa
+lJL
 bSw
 aaa
 aaa
@@ -47568,7 +48336,7 @@ aaJ
 aaJ
 atx
 bco
-aaB
+veR
 bfl
 bgb
 amA
@@ -47620,7 +48388,7 @@ alI
 amA
 apS
 abc
-alJ
+iJZ
 alJ
 apR
 alJ
@@ -47661,7 +48429,7 @@ bmU
 bmU
 bmU
 bmU
-aZF
+uOC
 bce
 bde
 bdd
@@ -47825,7 +48593,7 @@ aaJ
 aaJ
 aaJ
 aaI
-acm
+ijr
 aac
 bgb
 alJ
@@ -47878,8 +48646,8 @@ alJ
 alJ
 alJ
 alJ
-alJ
-alJ
+iJZ
+iJZ
 alJ
 alJ
 alJ
@@ -47918,7 +48686,7 @@ bmU
 bmU
 bFZ
 bmU
-aZF
+uOC
 bce
 bde
 bdf
@@ -48082,7 +48850,7 @@ aaJ
 aaJ
 aaJ
 aaI
-acm
+ijr
 aac
 beE
 amB
@@ -48137,8 +48905,8 @@ alJ
 alJ
 alJ
 alJ
-alJ
-alJ
+iJZ
+iJZ
 alJ
 alJ
 alJ
@@ -48175,7 +48943,7 @@ bmU
 bmU
 bFZ
 bFZ
-aZF
+uOC
 bce
 bde
 bnZ
@@ -48339,7 +49107,7 @@ aaJ
 aaJ
 aaJ
 aaI
-acm
+ijr
 aac
 alJ
 aaP
@@ -48396,10 +49164,10 @@ alJ
 alJ
 amA
 apS
-aca
-aba
-abM
-aba
+kdu
+gXG
+qUJ
+gXG
 amC
 abb
 apg
@@ -48432,7 +49200,7 @@ bFZ
 bmU
 bFZ
 bFZ
-aZF
+uOC
 bce
 bcy
 boL
@@ -48596,7 +49364,7 @@ aaJ
 aaJ
 aaJ
 aaI
-acm
+ijr
 aad
 alJ
 amC
@@ -48657,28 +49425,28 @@ amA
 apS
 aaR
 abb
-aaC
+tbQ
 aaQ
 aqs
 alJ
 alJ
 alJ
 aaP
-aaZ
-aaC
-aaC
-aaC
-acj
-aag
-aae
-bmU
-bmU
-bmU
-acm
-aag
-aag
-aag
-acD
+uPx
+tbQ
+tbQ
+tbQ
+fPF
+dtg
+ktI
+xQi
+xQi
+xQi
+cND
+dtg
+dtg
+dtg
+nBB
 aac
 aac
 aaC
@@ -48689,7 +49457,7 @@ bFZ
 bFZ
 bFZ
 bFZ
-aZF
+uOC
 bdg
 bcl
 boL
@@ -48835,24 +49603,24 @@ abB
 abB
 aby
 acY
-acY
-acY
-acY
-acY
-acY
-acY
-acY
-acY
-acY
-acY
-acY
-acY
-agd
+wHH
+wHH
+wHH
+wHH
+wHH
+wHH
+wHH
+wHH
+wHH
+wHH
+wHH
+wHH
+kfQ
 aqR
-aaJ
-aaJ
-aaJ
-aaI
+yem
+yem
+yem
+fRw
 acm
 aae
 alJ
@@ -48915,12 +49683,12 @@ alI
 apg
 aaQ
 aaC
-aaQ
+gGw
 aph
 alJ
 alJ
 aaP
-aaZ
+uPx
 aMX
 aMX
 aMX
@@ -48936,7 +49704,7 @@ aUc
 aUc
 aUc
 acj
-acD
+nBB
 aac
 aaC
 aaC
@@ -48946,7 +49714,7 @@ aLu
 aLu
 bFZ
 aZF
-aZF
+uOC
 bdg
 bcz
 bez
@@ -49091,7 +49859,7 @@ aby
 abB
 abB
 adK
-aai
+jQk
 bdy
 aaU
 aar
@@ -49173,10 +49941,10 @@ aph
 aaR
 aba
 arC
-abb
+uxL
 amA
 apS
-aaQ
+gGw
 aMX
 aMX
 aOX
@@ -49194,7 +49962,7 @@ aWG
 aUc
 aUc
 acm
-aac
+tto
 aac
 aac
 aac
@@ -49203,7 +49971,7 @@ aLu
 aJL
 aZF
 aZF
-aZF
+uOC
 bdg
 bdR
 beA
@@ -49339,8 +50107,8 @@ aaa
 aaa
 aaa
 bSw
-aae
-aai
+puR
+dfk
 ahG
 ahG
 ahG
@@ -49431,8 +50199,8 @@ amA
 aJM
 aaR
 arC
-aba
-aba
+gXG
+gXG
 aaZ
 aMX
 aNW
@@ -49452,7 +50220,7 @@ aWG
 aUc
 acm
 aac
-aac
+tto
 aad
 aag
 aLu
@@ -49460,7 +50228,7 @@ aJL
 aJL
 aZF
 aZF
-aZF
+uOC
 bdg
 bdg
 bdg
@@ -49709,7 +50477,7 @@ aWX
 aUc
 acj
 acD
-aad
+qLM
 aaU
 aca
 aJL
@@ -49717,7 +50485,7 @@ aJL
 aJL
 aZF
 aZF
-aZF
+uOC
 aZF
 aZF
 aiQ
@@ -49966,7 +50734,7 @@ aWY
 aUc
 aUc
 acm
-aaU
+uEl
 aaS
 afO
 aJL
@@ -49974,7 +50742,7 @@ aJL
 aJL
 aZF
 aZF
-aZF
+uOC
 aZF
 aZF
 aiQ
@@ -50223,7 +50991,7 @@ aWZ
 aXC
 aUc
 acn
-aaC
+tbQ
 aaQ
 afO
 aJL
@@ -50231,7 +50999,7 @@ aJL
 aJL
 aZF
 aZF
-aZF
+uOC
 aZF
 aZF
 aiQ
@@ -50480,7 +51248,7 @@ aXa
 aXD
 aUc
 aaC
-aaC
+tbQ
 aaQ
 afO
 aJL
@@ -50488,7 +51256,7 @@ aJL
 aJL
 boS
 bmT
-aZF
+uOC
 aZF
 aZF
 aiQ
@@ -50737,7 +51505,7 @@ aXb
 aXF
 aUc
 aaC
-aaC
+tbQ
 abj
 abn
 aJL
@@ -50745,7 +51513,7 @@ aJL
 aJL
 bmQ
 bmT
-aZF
+uOC
 aZF
 aZF
 aiQ
@@ -50994,7 +51762,7 @@ aUW
 aUW
 aUZ
 aUZ
-aUZ
+myL
 aaQ
 afO
 aJL
@@ -51002,7 +51770,7 @@ aJL
 aJL
 bmQ
 bmT
-aZF
+uOC
 aZF
 aZF
 aiQ
@@ -51150,7 +51918,7 @@ aaS
 aiS
 aaI
 aaI
-acZ
+aaI
 aaI
 aaS
 acm
@@ -51251,7 +52019,7 @@ aXc
 aVO
 aXS
 aYq
-aUZ
+myL
 abc
 aik
 aJL
@@ -51259,7 +52027,7 @@ aJL
 aJL
 bIy
 bnn
-aZF
+uOC
 aZF
 aZF
 bgU
@@ -51508,7 +52276,7 @@ aXf
 aVP
 aXT
 aYr
-aUZ
+myL
 aJL
 aJL
 aJL
@@ -51516,7 +52284,7 @@ aJL
 aJL
 bmQ
 bmT
-aZF
+uOC
 aZF
 aZF
 bgU
@@ -51765,15 +52533,15 @@ aXg
 aVP
 aXT
 aYt
-aUZ
+myL
 aJL
 aJL
 aJL
 aJL
 aJL
-bvT
-bnU
-aZF
+xjB
+fNR
+uOC
 aZF
 aZF
 bgU
@@ -52022,13 +52790,13 @@ aVp
 aVP
 aXT
 aYu
-aUZ
+myL
 aJL
 bbc
 aJL
 aJL
 aJL
-beB
+wPe
 beB
 beB
 beB
@@ -52279,13 +53047,13 @@ aVp
 aVP
 aXT
 aYA
-aUZ
+myL
 aJL
 aJL
 aJL
 aJL
 aJL
-beB
+wPe
 alP
 alP
 alP
@@ -52536,13 +53304,13 @@ aXj
 aXj
 aXU
 aWS
-aUZ
+myL
 aJL
 aJL
 aJL
 aJL
 aJL
-beB
+wPe
 alP
 bao
 baJ
@@ -52793,13 +53561,13 @@ aXl
 aVP
 aXV
 aYP
-aUZ
+myL
 aJL
 aJL
 aJL
 aJL
 aJL
-beB
+wPe
 alP
 ale
 alP
@@ -53051,12 +53819,12 @@ aVP
 aVP
 aYR
 aUZ
+myL
 aUZ
-aUZ
 aJL
 aJL
 aJL
-beB
+wPe
 alP
 ale
 alP
@@ -53309,11 +54077,11 @@ aVP
 aYU
 aVO
 baE
-aUZ
+myL
 aJL
 aJL
 aJL
-beB
+wPe
 alP
 bHx
 bNe
@@ -53566,11 +54334,11 @@ aVQ
 aVQ
 aVP
 baH
-aUZ
+myL
 aJL
 aJL
 aJL
-beB
+wPe
 alP
 ale
 bJN
@@ -53823,11 +54591,11 @@ aVO
 aVO
 aVP
 baI
-aUZ
+myL
 aJL
 aJL
 aJL
-beB
+wPe
 bGU
 ale
 bJO
@@ -58591,14 +59359,14 @@ aaa
 aaa
 aaa
 bSw
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aaQ
+tto
+tto
+tto
+tto
+tto
+tto
+tto
+gGw
 aaI
 aaI
 aaI
@@ -58856,7 +59624,7 @@ aac
 aac
 aac
 aaQ
-aaI
+fGg
 aaI
 aaI
 aaI
@@ -59114,7 +59882,7 @@ aac
 aac
 aaQ
 aaI
-aaI
+fGg
 aaI
 aaI
 aaI
@@ -59368,10 +60136,10 @@ aac
 aac
 aaf
 aar
-afO
+spj
 aaI
 aaI
-aaI
+fGg
 aaI
 aaI
 aaI
@@ -59627,7 +60395,7 @@ aac
 aae
 aaI
 aaI
-aaI
+fGg
 aaI
 aaI
 aaI
@@ -59884,7 +60652,7 @@ aac
 aac
 aac
 aaI
-aaI
+fGg
 aaI
 aaI
 aaI
@@ -60133,14 +60901,14 @@ aaa
 aaa
 aaa
 bSw
-aac
-aac
-aac
-aac
-aad
-aaB
-abc
-aaI
+tto
+tto
+tto
+tto
+qLM
+fzT
+jAc
+fGg
 aaI
 aaI
 aaI
@@ -68015,9 +68783,9 @@ bml
 aZF
 aZF
 aZF
-aZF
-aZF
-aZF
+uOC
+uOC
+uOC
 aZF
 bCg
 bEe
@@ -68271,11 +69039,11 @@ byc
 bmm
 bml
 aZF
-aZF
+uOC
 bmh
 bnT
 bml
-aZF
+uOC
 bCg
 bEe
 bCI
@@ -68527,12 +69295,12 @@ bqP
 byc
 bmT
 bmm
-bnT
+tTa
 bnT
 bmi
 bmT
 bmQ
-aZF
+uOC
 bCg
 bEe
 bCI
@@ -68783,13 +69551,13 @@ bsf
 bqP
 byc
 byc
-byc
+rKF
 byl
 bza
 boB
 byc
 bmm
-bml
+etV
 bCg
 bBP
 bCJ
@@ -69040,13 +69808,13 @@ bsf
 bqP
 byc
 byc
-byc
+rKF
 bym
 bzb
 byc
 byc
 byc
-bmQ
+fjG
 bCg
 bEe
 bCI
@@ -69128,9 +69896,9 @@ aaa
 aaa
 aaa
 bSw
-aac
-agX
-aaE
+tto
+xfJ
+fSR
 aaE
 aaE
 aaE
@@ -69298,12 +70066,12 @@ buX
 byc
 bRV
 byc
-bmk
+gFB
 byc
 byc
 bRV
 byc
-bmQ
+fjG
 bCg
 bEe
 bCI
@@ -69388,7 +70156,7 @@ bSw
 aad
 adh
 aaE
-aaE
+fSR
 aaE
 aaE
 aaE
@@ -69555,25 +70323,25 @@ buX
 byc
 byc
 byc
-byc
+rKF
 byc
 byc
 biF
 byc
-bmQ
+fjG
 bCg
 bEe
 bCI
 bCg
-bmO
-bmO
-bmO
-bmO
-bmO
-bmO
-bmO
-bmO
-bmO
+nKI
+nKI
+nKI
+nKI
+nKI
+nKI
+nKI
+nKI
+nKI
 bMs
 bMW
 bNq
@@ -69646,7 +70414,7 @@ aae
 aaE
 aaE
 aaE
-aaE
+fSR
 aaE
 aaE
 aeq
@@ -69813,16 +70581,16 @@ bqP
 buX
 buX
 byc
+rKF
 byc
 byc
 byc
-byc
-bmQ
+fjG
 bCg
 bEe
 bCI
 bCg
-bmO
+nKI
 bmO
 bmO
 bmO
@@ -69830,7 +70598,7 @@ bmO
 bmO
 bpj
 bns
-bzR
+esg
 bMs
 bMX
 bNr
@@ -69903,7 +70671,7 @@ aae
 aaF
 aaE
 aaE
-abd
+fYM
 aaE
 aaE
 aaE
@@ -70071,15 +70839,15 @@ byc
 buX
 bRV
 byc
+rKF
 byc
-byc
-bmh
+sfn
 bmi
 bCg
 bEe
 bCI
 bCg
-bmO
+nKI
 bmO
 bpj
 bns
@@ -70087,7 +70855,7 @@ bns
 bns
 bxc
 bnG
-bwy
+fol
 bMs
 bMY
 bNs
@@ -70329,14 +71097,14 @@ bxV
 byc
 byc
 byc
-bmj
+hKh
 bmQ
 aZF
 bCg
 bEe
 bCI
 bCg
-bmO
+nKI
 bpj
 bxc
 bKH
@@ -70344,7 +71112,7 @@ cal
 bFH
 bFH
 bFH
-bnG
+jhp
 bMs
 bMs
 bMs
@@ -70415,7 +71183,7 @@ aaa
 bSw
 aaf
 adl
-adl
+jqu
 aef
 abu
 aaE
@@ -70593,7 +71361,7 @@ bCg
 bEe
 bCI
 bCg
-bmO
+nKI
 bpk
 bnG
 bTM
@@ -70601,12 +71369,12 @@ bFH
 bFH
 bFH
 bFH
-bFH
-bFH
-bwy
-bns
-bzR
-bmO
+inT
+inT
+fol
+sKH
+esg
+nKI
 bOX
 bPE
 bQh
@@ -70672,7 +71440,7 @@ aaa
 bSw
 aac
 aac
-acJ
+sBu
 agX
 aaX
 aaE
@@ -70850,7 +71618,7 @@ bCg
 bEe
 bCI
 bCg
-bmO
+nKI
 bwy
 bzR
 bFH
@@ -70863,7 +71631,7 @@ bFH
 bFH
 bFH
 bwy
-bzR
+esg
 bOX
 bPF
 bQi
@@ -70927,8 +71695,8 @@ aaa
 aaa
 aaa
 bSw
-aac
-aac
+tto
+tto
 acJ
 agX
 aeq
@@ -71107,7 +71875,7 @@ bCg
 bEe
 bCI
 bCg
-bmO
+nKI
 bpj
 bBQ
 bUp
@@ -71120,7 +71888,7 @@ bFH
 bFH
 bFH
 caq
-bpk
+cdY
 bOX
 bPG
 bQj
@@ -71364,7 +72132,7 @@ bCg
 bEe
 bCI
 bCg
-bmO
+nKI
 bpk
 bEx
 bFH
@@ -71377,7 +72145,7 @@ bFH
 bEx
 bFH
 can
-bpk
+cdY
 bOX
 bPH
 bPH
@@ -71621,7 +72389,7 @@ bCg
 bEe
 bCI
 bCg
-bns
+sKH
 bxc
 bnG
 bFH
@@ -71634,7 +72402,7 @@ bFH
 bFH
 bFH
 bpj
-bxc
+dAY
 bOX
 bOX
 bOX
@@ -71878,7 +72646,7 @@ bCg
 bEe
 bCI
 bCg
-bnG
+jhp
 bFH
 bFH
 bFH
@@ -71891,7 +72659,7 @@ bFH
 cao
 bnG
 bpk
-bmO
+nKI
 bmO
 bmO
 bmO
@@ -72135,7 +72903,7 @@ bCg
 bEe
 bCI
 bCg
-bFH
+inT
 bFH
 bFH
 bFH
@@ -72148,7 +72916,7 @@ cal
 cap
 bns
 bxc
-bmO
+nKI
 bmO
 bmO
 bmO
@@ -72393,19 +73161,19 @@ bEe
 bCI
 bFH
 bFH
-bFH
-bKH
+inT
+gqo
 bWT
-cal
+twy
 bFH
 bFH
-bFH
-can
-bpj
-bxc
-bmO
-bmO
-bmO
+inT
+qFz
+jvd
+dAY
+nKI
+nKI
+nKI
 bmO
 bmO
 bmO
@@ -72654,8 +73422,8 @@ bCg
 bCg
 bCg
 bCg
-bJK
-bJK
+dRL
+dRL
 bJK
 bJK
 bCg
@@ -74698,8 +75466,8 @@ bnU
 boB
 bmh
 bml
-bwK
-bmU
+mLS
+xQi
 bmU
 bmU
 bmU
@@ -74954,10 +75722,10 @@ bmm
 bnT
 bnT
 bmi
-bmQ
+fjG
 bmT
 bov
-bmU
+xQi
 bmU
 bmU
 bmU
@@ -75210,12 +75978,12 @@ aZF
 aZF
 aZF
 aZF
-aZF
+uOC
 bmm
 bml
 bmT
 bmh
-bnT
+tTa
 bml
 bnU
 boB
@@ -75467,12 +76235,12 @@ aZF
 aZF
 aZF
 aZF
-aZF
+uOC
 aZF
 bmm
 bnT
 bmi
-aZF
+uOC
 bmm
 bnT
 bnT
@@ -75724,12 +76492,12 @@ aZF
 aZF
 aZF
 aZF
+uOC
 aZF
 aZF
 aZF
 aZF
-aZF
-aZF
+uOC
 aZF
 aZF
 aZF
@@ -75981,12 +76749,12 @@ bGw
 bGw
 bGw
 bGw
+vqL
 bGw
 bGw
 bGw
 bGw
-bGw
-bGw
+vqL
 bGw
 bGw
 bGw
@@ -80953,16 +81721,16 @@ aaa
 aaa
 aaa
 bSw
-aac
-aac
-aae
-aaC
-acn
-aaP
-aba
-aaZ
-acv
-acC
+tto
+tto
+ktI
+tbQ
+rSi
+uvI
+gXG
+uPx
+mbE
+qIM
 acC
 aeT
 aag
@@ -81220,7 +81988,7 @@ adz
 acO
 acn
 adj
-adj
+eOo
 adj
 adj
 adj
@@ -81478,7 +82246,7 @@ adj
 adj
 adj
 adj
-adj
+eOo
 adj
 aeA
 adj
@@ -81600,8 +82368,8 @@ aaC
 aaC
 aar
 aaS
-bbX
-bbJ
+kQw
+toB
 bbK
 bbK
 bbK
@@ -81735,7 +82503,7 @@ adj
 ade
 adj
 adj
-aaU
+uEl
 adj
 adj
 adj
@@ -81856,11 +82624,11 @@ aac
 aac
 aac
 aae
-aaQ
+gGw
 bbY
 bcY
-bbK
-bbK
+vrG
+vrG
 bbK
 bbK
 bbK
@@ -81992,7 +82760,7 @@ adj
 adj
 adj
 aaU
-aeH
+tQs
 aar
 adj
 adj
@@ -82093,32 +82861,32 @@ aPT
 aXw
 bww
 aOj
-aYB
-aYC
-aYC
-aYC
-aYC
-aYC
-aYC
-aYC
-aYC
-aYC
-aZR
-aUP
-aYa
-aYs
-aaS
-acm
+lph
+hDJ
+hDJ
+hDJ
+hDJ
+hDJ
+hDJ
+hDJ
+hDJ
+hDJ
+ktc
+mXX
+lxk
+jgT
+kwG
+iVB
+rls
+rls
 aac
-aac
-aac
-aae
+ktI
 aaR
 abb
 bbX
 bMO
 bbJ
-bbJ
+toB
 bgd
 bgr
 bXB
@@ -82248,7 +83016,7 @@ adA
 adj
 aaU
 aaG
-abG
+mgJ
 aad
 aaB
 adj
@@ -82348,8 +83116,8 @@ aTb
 aTb
 aWO
 aXx
-aOj
-aOj
+luT
+luT
 aYI
 aYO
 aYC
@@ -82368,15 +83136,15 @@ afx
 acj
 aac
 aac
-aac
-aae
+gEI
+ktI
 aaC
 aaQ
 bbX
 bbJ
 bbW
 bcq
-bcq
+fiU
 bcq
 bcq
 bcp
@@ -82505,7 +83273,7 @@ adA
 abZ
 acC
 acD
-aad
+qLM
 aaB
 acQ
 adj
@@ -82603,10 +83371,10 @@ aSo
 aSo
 aSo
 aOj
+luT
+luT
 aOj
-aOj
-aOj
-aUP
+iyH
 aUP
 aVf
 ccR
@@ -82625,8 +83393,8 @@ aaR
 aba
 abb
 acm
-aac
-aaf
+gEI
+neY
 aar
 aaQ
 bbY
@@ -82634,7 +83402,7 @@ bcq
 bcp
 aaS
 bbI
-bbI
+jyB
 aaP
 aba
 aaZ
@@ -82762,7 +83530,7 @@ acR
 aaP
 abb
 acj
-aaB
+fzT
 aaS
 adA
 adj
@@ -82859,7 +83627,7 @@ awL
 awL
 awL
 awL
-aYJ
+yft
 aUP
 aUP
 aUP
@@ -82883,15 +83651,15 @@ aUN
 aaQ
 acm
 aac
-aac
-aae
+gEI
+ktI
 aaR
 abb
 bbI
 aaP
 amC
 aba
-aba
+gXG
 aaZ
 aaC
 aaC
@@ -83019,7 +83787,7 @@ aba
 aaZ
 aaR
 aba
-aba
+gXG
 afx
 acR
 adj
@@ -83116,7 +83884,7 @@ awL
 awL
 awL
 awL
-aYJ
+yft
 aUP
 aUP
 aUP
@@ -83140,15 +83908,15 @@ bcE
 aaQ
 acj
 acD
-aac
-aae
+gEI
+ktI
 aaC
 aaR
 beU
 bfi
 aaC
 aaC
-aaC
+tbQ
 aaC
 aaC
 aaC
@@ -83276,7 +84044,7 @@ aar
 aaC
 aaC
 aaC
-aaC
+tbQ
 aaR
 abn
 adk
@@ -83373,7 +84141,7 @@ awL
 awL
 awL
 awL
-aYJ
+yft
 aUP
 aUP
 aUP
@@ -83397,15 +84165,15 @@ aZM
 aaQ
 aaC
 acm
-aac
-aaf
+gEI
+neY
 aaG
 aar
 aaC
 aaC
 aaU
 aaG
-aar
+qMH
 aaC
 aaC
 aaC
@@ -83533,7 +84301,7 @@ aaf
 aaG
 aaG
 aaG
-aaG
+cxW
 aaG
 aar
 aaS
@@ -83630,7 +84398,7 @@ awL
 awL
 awL
 awL
-aYJ
+yft
 aUP
 aUP
 aUP
@@ -83655,14 +84423,14 @@ amC
 abn
 acj
 acD
-aac
-aac
+gEI
+tto
 aae
 aaC
 aaC
 acm
 aac
-aae
+ktI
 aaC
 aaC
 aaC
@@ -83790,7 +84558,7 @@ aac
 aac
 aac
 aac
-aac
+tto
 aac
 aae
 aaR
@@ -83887,7 +84655,7 @@ awL
 awL
 awL
 awL
-aYJ
+yft
 aUP
 aZr
 baC
@@ -83912,14 +84680,14 @@ bbs
 baC
 afO
 acm
-aac
-aac
+gEI
+tto
 aaf
 aaG
 aaG
 abG
 aac
-aaf
+neY
 aar
 aaC
 aaC
@@ -84144,7 +84912,7 @@ awL
 awL
 awL
 awL
-aYJ
+yft
 aUP
 aUP
 aYa
@@ -84169,14 +84937,14 @@ aUP
 bcE
 afO
 acm
+gEI
+tto
 aac
 aac
 aac
 aac
 aac
-aac
-aac
-aac
+tto
 aaf
 aaG
 aaG
@@ -84399,8 +85167,8 @@ awL
 awL
 awf
 awM
-acv
-abN
+rJA
+tmI
 aYJ
 aUP
 aUP
@@ -84426,14 +85194,14 @@ aUP
 bcE
 afO
 acm
+gEI
+tto
 aac
 aac
 aac
 aac
 aac
-aac
-aac
-aac
+tto
 aac
 aac
 aac
@@ -84655,7 +85423,7 @@ awL
 awL
 awU
 acp
-acv
+czW
 abg
 bhN
 aUP
@@ -85168,7 +85936,7 @@ awL
 awL
 auW
 aEC
-aaG
+sMq
 aMY
 aWp
 bdz
@@ -85424,7 +86192,7 @@ aMt
 aMt
 aMt
 aaU
-aaG
+sMq
 aad
 aaU
 aWr
@@ -85680,7 +86448,7 @@ aae
 awL
 awL
 awL
-acm
+vdz
 aad
 aaU
 afO
@@ -85937,7 +86705,7 @@ aae
 awL
 awL
 awL
-acm
+vdz
 aae
 aUN
 aUP
@@ -86194,7 +86962,7 @@ aae
 awL
 awL
 awL
-acm
+vdz
 aae
 aWF
 aUP
@@ -86451,7 +87219,7 @@ aae
 awL
 awL
 awL
-acm
+vdz
 aae
 aPk
 aUP
@@ -86708,7 +87476,7 @@ aaU
 aMt
 aMt
 aMt
-acj
+mLj
 aJb
 bam
 aUP
@@ -86966,7 +87734,7 @@ awL
 awL
 awL
 aEA
-atK
+ioJ
 aar
 aUP
 bbb
@@ -87223,7 +87991,7 @@ awL
 awL
 awU
 aLH
-acm
+vdz
 aae
 aUq
 bgT
@@ -87480,7 +88248,7 @@ awL
 awL
 awO
 aLH
-acm
+vdz
 aae
 aPk
 bir
@@ -87737,7 +88505,7 @@ awL
 awL
 aGf
 aVg
-acj
+mLj
 aCw
 bam
 aWQ
@@ -87995,7 +88763,7 @@ awL
 auW
 aDv
 acp
-acn
+ucO
 aUP
 bbb
 aXR
@@ -88252,7 +89020,7 @@ awL
 awL
 awL
 awL
-aMt
+tMa
 aUP
 aWp
 bmg
@@ -88426,11 +89194,11 @@ aaa
 aaa
 aaa
 bSw
-aac
-aac
-aae
-aaP
-aba
+tto
+tto
+ktI
+uvI
+gXG
 alE
 amj
 amK
@@ -88509,7 +89277,7 @@ aui
 aui
 awL
 awL
-aMt
+tMa
 aUP
 aUP
 aUP
@@ -88520,7 +89288,7 @@ aUP
 aUP
 aUP
 bbg
-aYp
+iao
 aXA
 aZw
 bbQ
@@ -88767,9 +89535,9 @@ aui
 awL
 aLJ
 aMt
-aMt
-aMt
-aMt
+htK
+htK
+htK
 aaC
 aUP
 aUP
@@ -88946,7 +89714,7 @@ aaC
 acQ
 adj
 alz
-alz
+uwB
 amk
 amk
 anU
@@ -89027,7 +89795,7 @@ awL
 awL
 awL
 aEC
-abf
+svd
 aaC
 aUN
 aUP
@@ -89203,7 +89971,7 @@ adk
 acR
 adj
 alz
-alz
+uwB
 amk
 amk
 amk
@@ -89284,7 +90052,7 @@ awL
 awL
 auW
 aaU
-apf
+gtM
 aar
 aWF
 aUP
@@ -89459,7 +90227,7 @@ aae
 aaS
 adj
 adj
-alz
+uwB
 alE
 amk
 amk
@@ -89541,7 +90309,7 @@ awL
 awU
 aaU
 abG
-aac
+rMt
 aaf
 aaG
 aar
@@ -89798,7 +90566,7 @@ awL
 awO
 acm
 aac
-aac
+rMt
 aad
 aag
 aaU
@@ -90055,7 +90823,7 @@ awL
 aEA
 acm
 aad
-aag
+myP
 aaU
 aaC
 aYc
@@ -90235,7 +91003,7 @@ abb
 adk
 adk
 adk
-adk
+lap
 aaP
 aba
 abb
@@ -90312,7 +91080,7 @@ awL
 aLH
 acm
 aae
-aaC
+rjH
 aaC
 aaC
 aYc
@@ -90493,7 +91261,7 @@ aba
 aba
 aba
 aba
-aaZ
+uPx
 abf
 abc
 aaz
@@ -90569,7 +91337,7 @@ aGf
 aLI
 acm
 aae
-aaC
+rjH
 aaC
 aaC
 aaC
@@ -90750,7 +91518,7 @@ aar
 aaC
 aaC
 aaC
-aaU
+uEl
 apf
 aar
 aca
@@ -90826,7 +91594,7 @@ aaU
 aaG
 aco
 aaU
-aaC
+rjH
 aaC
 aaC
 aaC
@@ -91007,7 +91775,7 @@ aaf
 aaG
 aaG
 aaG
-abG
+mgJ
 aac
 aaf
 aaG
@@ -91083,7 +91851,7 @@ acm
 aac
 aae
 aaC
-aaC
+rjH
 aaC
 aaC
 aaC
@@ -91340,7 +92108,7 @@ acm
 aac
 aae
 aaC
-aaC
+rjH
 aaC
 aaC
 aaC
@@ -91597,7 +92365,7 @@ abG
 aac
 aac
 aaf
-aaG
+ndU
 aaG
 aaG
 aaG

--- a/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -40271,7 +40271,7 @@
 	dir = 4
 	},
 /obj/machinery/button/door/open_only/landing_zone/lz2{
-	dir = 1
+	dir = 2
 	},
 /turf/open/floor/plating/ground/ice,
 /area/ice_colony/exterior/surface/landing_pad_external)

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -2536,11 +2536,6 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand2)
-"ajm" = (
-/obj/structure/jungle/vines,
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/open/ground/river,
-/area/lv624/ground/river3)
 "ajn" = (
 /obj/structure/jungle/vines/heavy,
 /turf/open/ground/coast,
@@ -2707,11 +2702,6 @@
 "ajT" = (
 /turf/closed/mineral,
 /area/lv624/ground/sand8)
-"ajU" = (
-/obj/structure/jungle/vines/heavy,
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/open/ground/river,
-/area/lv624/ground/river3)
 "ajV" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable/yellow{
@@ -2722,12 +2712,6 @@
 	dir = 9
 	},
 /area/lv624/lazarus/comms)
-"ajW" = (
-/obj/structure/jungle/vines/heavy,
-/obj/structure/jungle/vines/heavy,
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/open/ground/river,
-/area/lv624/ground/river3)
 "ajX" = (
 /turf/open/floor/mech_bay_recharge_floor/asteroid,
 /area/lv624/ground/caves/west1)
@@ -2759,24 +2743,9 @@
 /obj/item/explosive/grenade/incendiary,
 /turf/open/floor/plating,
 /area/lv624/ground/sand2)
-"akd" = (
-/obj/structure/jungle/vines,
-/obj/structure/jungle/vines/heavy,
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/open/ground/river,
-/area/lv624/ground/river3)
 "ake" = (
 /obj/structure/jungle/vines,
 /obj/structure/jungle/vines/heavy,
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/closed/gm/dense,
-/area/lv624/ground/river3)
-"akf" = (
-/obj/structure/jungle/vines/heavy,
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/closed/gm/dense,
-/area/lv624/ground/river3)
-"akg" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/gm/dense,
 /area/lv624/ground/river3)
@@ -3951,12 +3920,6 @@
 "aod" = (
 /turf/open/floor/plating/catwalk,
 /area/lv624/ground/river2)
-"aoe" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/open/floor/plating/warning{
-	dir = 10
-	},
-/area/lv624/ground/river2)
 "aof" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/tile/vault{
@@ -4331,10 +4294,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor,
 /area/lv624/ground/river2)
-"apD" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/open/ground/river,
-/area/lv624/ground/river2)
 "apE" = (
 /obj/structure/flora/ausbushes/palebush,
 /turf/open/ground/river,
@@ -4415,10 +4374,6 @@
 /obj/structure/girder/displaced,
 /turf/open/ground/river,
 /area/lv624/ground/river2)
-"apS" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/open/ground/river,
-/area/lv624/ground/river3)
 "apT" = (
 /turf/open/floor/plating/ground/dirtgrassborder2/corner{
 	dir = 4
@@ -4455,10 +4410,6 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/ground/river,
 /area/lv624/ground/river2)
-"aqc" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/open/floor/plating,
-/area/lv624/ground/river3)
 "aqd" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/ground/dirtgrassborder2/corner{
@@ -4556,10 +4507,6 @@
 /obj/structure/jungle/vines,
 /turf/closed/wall/wood,
 /area/lv624/ground/jungle8)
-"aqC" = (
-/obj/effect/alien/weeds/node,
-/turf/closed/mineral,
-/area/lv624/ground/sand1)
 "aqD" = (
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand1)
@@ -4576,10 +4523,6 @@
 /obj/structure/ore_box,
 /turf/open/ground/river,
 /area/lv624/ground/sand4)
-"aqH" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/open/floor/plating,
-/area/lv624/ground/river2)
 "aqI" = (
 /turf/open/ground/coast{
 	dir = 9
@@ -4618,12 +4561,6 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/ground/coast/corner2{
 	dir = 4
-	},
-/area/lv624/ground/river3)
-"aqQ" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/open/ground/coast{
-	dir = 9
 	},
 /area/lv624/ground/river3)
 "aqS" = (
@@ -4721,12 +4658,6 @@
 	dir = 8
 	},
 /area/lv624/ground/river3)
-"aru" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/open/ground/coast{
-	dir = 1
-	},
-/area/lv624/ground/river3)
 "arv" = (
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -4745,12 +4676,6 @@
 	dir = 1
 	},
 /area/lv624/ground/jungle5)
-"ary" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/open/ground/coast/corner{
-	dir = 4
-	},
-/area/lv624/ground/river3)
 "arz" = (
 /obj/structure/jungle/plantbot1/alien,
 /turf/open/floor/plating/ground/dirtgrassborder2/corner{
@@ -4799,10 +4724,6 @@
 	dir = 4
 	},
 /area/lv624/ground/sand1)
-"arJ" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/open/ground/river,
-/area/lv624/ground/river1)
 "arL" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 2
@@ -4890,11 +4811,6 @@
 	dir = 8
 	},
 /area/lv624/ground/jungle7)
-"asc" = (
-/obj/structure/jungle/vines/heavy,
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/open/ground/river,
-/area/lv624/ground/river1)
 "ase" = (
 /obj/structure/jungle/vines,
 /turf/open/ground/river,
@@ -5022,12 +4938,6 @@
 	dir = 1
 	},
 /area/lv624/ground/jungle6)
-"asK" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/open/ground/coast/corner{
-	dir = 4
-	},
-/area/lv624/ground/river2)
 "asL" = (
 /obj/structure/jungle/vines,
 /turf/open/ground/coast/corner{
@@ -5121,10 +5031,6 @@
 "atg" = (
 /obj/effect/landmark/monkey_spawn,
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/sand1)
-"ath" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/open/ground/river,
 /area/lv624/ground/sand1)
 "ati" = (
 /turf/open/floor/plating/ground/dirtgrassborder/corner{
@@ -5486,6 +5392,9 @@
 /area/lv624/lazarus/research)
 "auz" = (
 /obj/structure/fence,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 1
+	},
 /turf/open/floor/plating/ground/dirtgrassborder,
 /area/shuttle/drop2/lz2)
 "auA" = (
@@ -5573,6 +5482,9 @@
 /area/lv624/ground/jungle7)
 "auU" = (
 /obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 1
+	},
 /turf/open/floor/plating/ground/dirtgrassborder,
 /area/shuttle/drop2/lz2)
 "auV" = (
@@ -7079,6 +6991,9 @@
 "azT" = (
 /obj/structure/jungle/vines,
 /obj/structure/fence,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 8
+	},
 /turf/open/ground/grass,
 /area/shuttle/drop1/lz1)
 "azU" = (
@@ -7087,15 +7002,13 @@
 /area/lv624/ground/river1)
 "azV" = (
 /obj/structure/fence,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
 /turf/open/floor/plating/ground/dirtgrassborder/corner{
 	dir = 8
 	},
 /area/shuttle/drop1/lz1)
-"azW" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/open/ground/river,
-/area/lv624/ground/river1)
 "azY" = (
 /obj/structure/jungle/vines,
 /obj/structure/jungle/vines/heavy,
@@ -7191,6 +7104,9 @@
 /area/lv624/ground/jungle5)
 "aAu" = (
 /obj/structure/fence,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
 /turf/open/floor/plating/ground/dirt,
 /area/shuttle/drop1/lz1)
 "aAw" = (
@@ -7753,11 +7669,6 @@
 /area/lv624/ground/jungle5)
 "aCQ" = (
 /obj/structure/jungle/vines/heavy,
-/turf/open/ground/river,
-/area/lv624/ground/river1)
-"aCT" = (
-/obj/structure/jungle/vines,
-/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/ground/river,
 /area/lv624/ground/river1)
 "aCV" = (
@@ -11783,6 +11694,9 @@
 /area/lv624/lazarus/quartstorage)
 "aRS" = (
 /obj/structure/fence,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
+	},
 /turf/open/floor/plating/ground/dirtgrassborder,
 /area/shuttle/drop1/lz1)
 "aRT" = (
@@ -12036,6 +11950,7 @@
 /area/shuttle/drop1/lz1)
 "aSD" = (
 /obj/structure/fence,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 8
 	},
@@ -12057,6 +11972,9 @@
 /area/lv624/ground/jungle4)
 "aSK" = (
 /obj/structure/fence,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/dirtgrassborder2/corner,
 /area/shuttle/drop2/lz2)
 "aSL" = (
@@ -12084,6 +12002,9 @@
 	req_one_access_txt = "0"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/robotics)
 "aSO" = (
@@ -12324,6 +12245,9 @@
 /area/lv624/ground/jungle4)
 "aTz" = (
 /obj/structure/fence,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/dirt,
 /area/shuttle/drop2/lz2)
 "aTA" = (
@@ -12462,6 +12386,8 @@
 	},
 /area/shuttle/drop2/lz2)
 "aUb" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/shuttle/shuttle_control/dropship1,
 /turf/open/floor/plating/ground/dirtgrassborder2/corner{
 	dir = 4
 	},
@@ -12474,6 +12400,7 @@
 /area/shuttle/drop2/lz2)
 "aUf" = (
 /obj/structure/fence,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/dirtgrassborder2/corner{
 	dir = 4
 	},
@@ -12619,6 +12546,9 @@
 /area/lv624/ground/jungle4)
 "aUG" = (
 /obj/structure/fence,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/dirtgrassborder2/corner{
 	dir = 8
 	},
@@ -12792,10 +12722,16 @@
 	req_access_txt = "0";
 	req_one_access_txt = "0"
 	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
+	},
 /turf/open/floor/vault,
 /area/lv624/lazarus/quartstorage)
 "aVh" = (
 /obj/structure/window_frame/colony/reinforced,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/quartstorage)
 "aVi" = (
@@ -12956,6 +12892,9 @@
 "aVL" = (
 /obj/item/shard,
 /obj/structure/window_frame/colony/reinforced,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/quartstorage)
 "aVM" = (
@@ -13002,6 +12941,9 @@
 /area/lv624/ground/jungle4)
 "aVV" = (
 /obj/structure/jungle/vines,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 1
+	},
 /turf/closed/wall,
 /area/shuttle/drop2/lz2)
 "aVZ" = (
@@ -13147,6 +13089,7 @@
 "aWx" = (
 /obj/structure/jungle/vines,
 /obj/structure/fence,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 8
 	},
@@ -13320,6 +13263,7 @@
 /area/shuttle/drop2/lz2)
 "aXd" = (
 /obj/structure/fence,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/dirtgrassborder2/corner{
 	dir = 1
 	},
@@ -13654,6 +13598,9 @@
 	name = "\improper Nexus Blast Door";
 	opacity = 0
 	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 8
+	},
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/main_hall)
 "aYi" = (
@@ -13872,6 +13819,9 @@
 	id = "nexus_blast";
 	name = "\improper Nexus Blast Door";
 	opacity = 0
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 8
 	},
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/main_hall)
@@ -15003,6 +14953,7 @@
 	dir = 4;
 	name = "Corporate Dome"
 	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating,
 /area/lv624/lazarus/internal_affairs)
 "bcs" = (
@@ -15634,7 +15585,9 @@
 /turf/open/ground/grass,
 /area/lv624/ground/jungle3)
 "bek" = (
-/obj/structure/barricade/wooden,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
 /turf/open/floor/plating/asteroidfloor,
 /area/shuttle/drop2/lz2)
 "bem" = (
@@ -15854,6 +15807,9 @@
 	id = "nexus_blast";
 	name = "\improper Nexus Blast Door";
 	opacity = 0
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 8
 	},
 /turf/open/floor/plating/platebotc,
 /area/lv624/lazarus/canteen)
@@ -17091,6 +17047,9 @@
 /area/lv624/lazarus/canteen)
 "bjt" = (
 /obj/structure/fence,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 8
+	},
 /turf/open/ground/grass,
 /area/shuttle/drop1/lz1)
 "bju" = (
@@ -17305,24 +17264,36 @@
 /area/lv624/lazarus/canteen)
 "bkb" = (
 /obj/structure/fence,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 1
 	},
 /area/shuttle/drop1/lz1)
 "bkc" = (
 /obj/structure/fence,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
 /turf/open/floor/plating/ground/dirtgrassborder2/corner{
 	dir = 8
 	},
 /area/shuttle/drop1/lz1)
 "bkd" = (
 /obj/structure/fence,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
 /turf/open/floor/plating/ground/dirtgrassborder2/corner{
 	dir = 1
 	},
 /area/shuttle/drop1/lz1)
 "bke" = (
 /obj/structure/barricade/wooden,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
 /turf/open/floor/plating/ground/dirtgrassborder2/corner{
 	dir = 1
 	},
@@ -17332,12 +17303,18 @@
 	dir = 4
 	},
 /obj/structure/barricade/wooden,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
 /turf/open/floor/plating/ground/dirtgrassborder2/corner{
 	dir = 8
 	},
 /area/shuttle/drop1/lz1)
 "bkg" = (
 /obj/structure/barricade/wooden,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
 /turf/open/floor,
 /area/shuttle/drop1/lz1)
 "bkh" = (
@@ -17345,12 +17322,18 @@
 	dir = 8
 	},
 /obj/structure/barricade/wooden,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
 /turf/open/floor/plating/ground/dirtgrassborder2/corner{
 	dir = 1
 	},
 /area/shuttle/drop1/lz1)
 "bki" = (
 /obj/structure/barricade/wooden,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
 /turf/open/floor/plating/ground/dirtgrassborder2/corner{
 	dir = 8
 	},
@@ -19938,12 +19921,64 @@
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/floor,
 /area/storage/testroom)
+"bsH" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 8
+	},
+/turf/closed/wall,
+/area/lv624/lazarus/quartstorage)
+"bCp" = (
+/obj/structure/jungle/vines,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
 "bHX" = (
 /obj/structure/jungle/vines/heavy,
 /turf/open/floor/plating/ground/dirtgrassborder2/corner{
 	dir = 1
 	},
 /area/lv624/ground/jungle7)
+"bJn" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating,
+/area/lv624/ground/river3)
+"bUz" = (
+/obj/structure/jungle/vines/heavy,
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/ground/river,
+/area/lv624/ground/river1)
+"bVE" = (
+/obj/structure/fence,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/dirtgrassborder2/corner{
+	dir = 8
+	},
+/area/shuttle/drop2/lz2)
+"ciV" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 1
+	},
+/turf/closed/wall,
+/area/shuttle/drop2/lz2)
+"cnd" = (
+/obj/structure/jungle/vines,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/closed/wall,
+/area/shuttle/drop1/lz1)
+"csn" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/machinery/door/poddoor/almayer{
+	dir = 4;
+	id = "corporate_blast";
+	name = "\improper Corporate Dome Blast Door"
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/plating,
+/area/lv624/lazarus/internal_affairs)
 "cyG" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/sign/botany{
@@ -19951,6 +19986,35 @@
 	},
 /turf/open/ground/grass,
 /area/lv624/ground/jungle7)
+"cSo" = (
+/obj/structure/window/framed/colony,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"cVi" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating,
+/area/lv624/ground/river2)
+"cYJ" = (
+/obj/effect/alien/weeds/node,
+/turf/closed/mineral,
+/area/lv624/ground/sand1)
+"drz" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/ground/river,
+/area/lv624/ground/river1)
+"dBG" = (
+/obj/structure/fence,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 4
+	},
+/area/shuttle/drop2/lz2)
 "evP" = (
 /obj/structure/sign/atmosplaque{
 	dir = 1
@@ -19959,12 +20023,138 @@
 	dir = 9
 	},
 /area/lv624/lazarus/comms)
+"eLi" = (
+/obj/machinery/door/airlock/almayer/engineering{
+	density = 1;
+	dir = 1;
+	icon_state = "door_closed";
+	name = "\improper Storage Dome";
+	req_access_txt = "0";
+	req_one_access_txt = "0"
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
+	},
+/turf/open/floor/vault,
+/area/lv624/lazarus/quartstorage)
+"eNq" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/canteen)
+"eRR" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
+	},
+/turf/closed/wall,
+/area/lv624/lazarus/quartstorage/outdoors)
+"eXq" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 1
+	},
+/turf/open/ground/grass,
+/area/lv624/ground/jungle6)
+"fyJ" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/ground/river,
+/area/lv624/ground/river3)
+"fRf" = (
+/obj/structure/jungle/vines,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/closed/wall,
+/area/shuttle/drop2/lz2)
+"fWG" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirtgrassborder,
+/area/shuttle/drop2/lz2)
+"gyq" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/robotics)
+"gWo" = (
+/obj/structure/fence,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/shuttle/drop2/lz2)
+"hVU" = (
+/obj/structure/window/framed/colony,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"iqK" = (
+/obj/structure/jungle/vines/heavy,
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/ground/river,
+/area/lv624/ground/river3)
+"jca" = (
+/obj/structure/jungle/vines/heavy,
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/gm/dense,
+/area/lv624/ground/river3)
+"jeQ" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/ground/river,
+/area/lv624/ground/sand1)
+"jgW" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 8
+	},
+/turf/closed/wall,
+/area/lv624/lazarus/main_hall)
+"jAE" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/machinery/door/poddoor/almayer{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "nexus_blast";
+	name = "\improper Nexus Blast Door";
+	opacity = 0
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/main_hall)
 "jCY" = (
 /obj/structure/sign/redcross{
 	dir = 8
 	},
 /turf/open/floor,
 /area/lv624/ground/compound/n)
+"jFm" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/ground/river,
+/area/lv624/ground/river2)
+"jFT" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/ground/river,
+/area/lv624/ground/river1)
+"jOz" = (
+/obj/structure/jungle/vines,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 8
+	},
+/turf/closed/wall,
+/area/shuttle/drop2/lz2)
+"jPR" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/ground/coast/corner{
+	dir = 4
+	},
+/area/lv624/ground/river3)
 "kFH" = (
 /obj/structure/sign/redcross{
 	dir = 4
@@ -19985,6 +20175,19 @@
 	dir = 1
 	},
 /area/lv624/ground/jungle7)
+"lFi" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/warning{
+	dir = 10
+	},
+/area/lv624/ground/river2)
+"lYR" = (
+/obj/structure/fence,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/quartstorage/outdoors)
 "miq" = (
 /obj/structure/sign/redcross,
 /turf/open/ground/grass,
@@ -19995,12 +20198,34 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/n)
-"ncP" = (
+"mrH" = (
+/obj/structure/jungle/vines,
 /obj/effect/landmark/lv624/fog_blocker,
-/turf/open/ground/coast{
-	dir = 1
+/turf/open/ground/river,
+/area/lv624/ground/river1)
+"mBX" = (
+/obj/structure/jungle/vines,
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/ground/river,
+/area/lv624/ground/river3)
+"mGd" = (
+/obj/structure/jungle/vines,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 8
 	},
-/area/lv624/ground/river2)
+/turf/closed/wall/r_wall,
+/area/shuttle/drop1/lz1)
+"nfB" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/closed/wall,
+/area/shuttle/drop2/lz2)
+"nny" = (
+/obj/structure/fence,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 8
+	},
+/area/shuttle/drop2/lz2)
 "nEg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -20010,6 +20235,12 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/n)
+"oyC" = (
+/obj/structure/jungle/vines/heavy,
+/obj/structure/jungle/vines/heavy,
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/ground/river,
+/area/lv624/ground/river3)
 "oVq" = (
 /obj/structure/sign/botany{
 	dir = 4
@@ -20021,6 +20252,127 @@
 /obj/structure/sign/botany,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle7)
+"ptc" = (
+/obj/structure/fence,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/dirtgrassborder2/corner{
+	dir = 1
+	},
+/area/shuttle/drop2/lz2)
+"pNb" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/plating,
+/area/lv624/lazarus/robotics)
+"qQj" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/closed/wall,
+/area/lv624/lazarus/robotics)
+"qSA" = (
+/obj/machinery/button/door/open_only/landing_zone,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/marking/warning{
+	dir = 5
+	},
+/area/shuttle/drop1/lz1)
+"qYr" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/machinery/door/poddoor/almayer{
+	dir = 1;
+	id = "corporate_blast";
+	name = "\improper Corporate Dome Blast Door"
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/internal_affairs)
+"rpH" = (
+/obj/structure/jungle/vines,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/internal_affairs)
+"rxi" = (
+/obj/machinery/door/poddoor/almayer{
+	dir = 1;
+	id = "corporate_blast";
+	name = "\improper Corporate Dome Blast Door"
+	},
+/obj/machinery/door/airlock/almayer/generic/corporate{
+	dir = 1;
+	name = "Corporate Dome"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/internal_affairs)
+"rAF" = (
+/obj/structure/jungle/vines,
+/obj/structure/jungle/vines/heavy,
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/ground/river,
+/area/lv624/ground/river3)
+"syO" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/ground/coast{
+	dir = 9
+	},
+/area/lv624/ground/river3)
+"sGt" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/main_hall)
+"sWZ" = (
+/obj/machinery/button/door/open_only/landing_zone/lz2{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/shuttle/drop2/lz2)
+"usu" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 1
+	},
+/turf/closed/wall,
+/area/lv624/lazarus/robotics)
+"uwN" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
+	},
+/turf/closed/wall,
+/area/lv624/lazarus/quartstorage)
+"vzU" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/closed/wall,
+/area/shuttle/drop1/lz1)
+"vGH" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/internal_affairs)
 "vTe" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/sign/botany{
@@ -20028,6 +20380,38 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle7)
+"waH" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/ground/coast/corner{
+	dir = 4
+	},
+/area/lv624/ground/river2)
+"wix" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/ground/coast{
+	dir = 1
+	},
+/area/lv624/ground/river3)
+"wNe" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 8
+	},
+/turf/closed/wall,
+/area/shuttle/drop2/lz2)
+"xis" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/ground/coast{
+	dir = 1
+	},
+/area/lv624/ground/river2)
+"xqG" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/gm/dense,
+/area/lv624/ground/river3)
+"xsY" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/closed/wall,
+/area/shuttle/drop1/lz1)
 "xMw" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/sign/redcross{
@@ -20035,6 +20419,12 @@
 	},
 /turf/open/ground/grass,
 /area/lv624/ground/jungle6)
+"ybc" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/closed/wall,
+/area/shuttle/drop2/lz2)
 
 (1,1,1) = {"
 aaa
@@ -20738,7 +21128,7 @@ awg
 azv
 aDU
 aDU
-asc
+bUz
 aCQ
 aDU
 aCQ
@@ -20995,9 +21385,9 @@ awg
 azv
 aDU
 are
-asc
+bUz
 are
-asc
+bUz
 aCQ
 aDU
 axQ
@@ -21252,9 +21642,9 @@ awg
 azv
 aDU
 aCQ
-asc
+bUz
 aCQ
-aCT
+mrH
 ase
 aDU
 axQ
@@ -21509,9 +21899,9 @@ awg
 awg
 aDU
 aCQ
-aCT
+mrH
 ase
-arJ
+jFT
 aCQ
 aDU
 axQ
@@ -21766,9 +22156,9 @@ awg
 awg
 aDU
 aCQ
-asc
+bUz
 are
-asc
+bUz
 aCQ
 aDU
 axQ
@@ -22023,9 +22413,9 @@ awg
 awg
 awg
 aDU
-asc
+bUz
 ase
-aCT
+mrH
 ase
 aCQ
 axQ
@@ -22280,10 +22670,10 @@ awg
 awg
 awg
 aDU
-arJ
+jFT
 ase
 ase
-aCT
+mrH
 ase
 asB
 axQ
@@ -22538,9 +22928,9 @@ awg
 awg
 aCQ
 aCQ
-arJ
+jFT
 are
-arJ
+jFT
 are
 asJ
 aCV
@@ -22795,9 +23185,9 @@ awg
 awg
 arT
 ase
-arJ
+jFT
 are
-arJ
+jFT
 avb
 asL
 aEa
@@ -23052,9 +23442,9 @@ awg
 awg
 aEI
 aBd
-arJ
+jFT
 are
-arJ
+jFT
 awZ
 ayo
 ayY
@@ -23309,9 +23699,9 @@ awg
 awg
 aAA
 auZ
-arJ
+jFT
 are
-arJ
+jFT
 aDt
 aFM
 ata
@@ -23566,9 +23956,9 @@ awg
 awg
 aAB
 auZ
-arJ
+jFT
 are
-arJ
+jFT
 are
 aFN
 asY
@@ -23823,9 +24213,9 @@ awg
 awg
 awC
 auZ
-arJ
+jFT
 atA
-arJ
+jFT
 atA
 aFN
 aHG
@@ -24080,9 +24470,9 @@ awg
 awC
 awC
 auZ
-arJ
+jFT
 are
-arJ
+jFT
 are
 aFN
 aFN
@@ -24337,9 +24727,9 @@ awg
 awC
 awC
 auZ
-arJ
+jFT
 are
-arJ
+jFT
 are
 aJO
 aFN
@@ -24594,9 +24984,9 @@ awg
 awX
 awC
 auZ
-arJ
+jFT
 are
-arJ
+jFT
 axM
 asS
 aFO
@@ -24851,9 +25241,9 @@ awC
 awC
 awC
 auZ
-arJ
+jFT
 are
-arJ
+jFT
 are
 asY
 atc
@@ -25108,9 +25498,9 @@ awC
 awC
 awC
 auZ
-arJ
+jFT
 are
-arJ
+jFT
 aDu
 awZ
 atH
@@ -25365,9 +25755,9 @@ awC
 awC
 aAD
 ava
-arJ
+jFT
 are
-arJ
+jFT
 atz
 awZ
 auH
@@ -25622,9 +26012,9 @@ awC
 awC
 auZ
 atA
-arJ
+jFT
 are
-arJ
+jFT
 are
 awZ
 auH
@@ -25879,9 +26269,9 @@ awC
 azU
 ava
 are
-arJ
+jFT
 aCk
-arJ
+jFT
 are
 awZ
 auH
@@ -26136,9 +26526,9 @@ awC
 auZ
 are
 are
-arJ
+jFT
 are
-arJ
+jFT
 atA
 awZ
 auH
@@ -26393,9 +26783,9 @@ awC
 auZ
 are
 are
-arJ
+jFT
 are
-arJ
+jFT
 are
 aDZ
 auH
@@ -26650,9 +27040,9 @@ awC
 auZ
 are
 are
-arJ
+jFT
 atA
-arJ
+jFT
 avb
 avc
 auH
@@ -26907,9 +27297,9 @@ awC
 auZ
 are
 atA
-arJ
+jFT
 are
-arJ
+jFT
 awZ
 avO
 auH
@@ -27164,9 +27554,9 @@ awC
 auZ
 are
 are
-arJ
+jFT
 are
-arJ
+jFT
 awZ
 atH
 auk
@@ -27420,10 +27810,10 @@ awC
 awC
 auZ
 atA
-arJ
+jFT
 are
 are
-arJ
+jFT
 awZ
 auH
 avd
@@ -27440,29 +27830,29 @@ avd
 avd
 avd
 aPP
-aNO
-aNO
-aPP
-aNO
-aNO
-aPP
+dBG
+dBG
+wNe
+dBG
+dBG
+wNe
 aSK
 aTz
-aOW
+wNe
 aUG
-aNO
-aVV
-aNO
-aNO
-aPP
-aNO
-aNO
-aVV
-aNO
-aNO
-aPP
-aNO
-aNO
+dBG
+jOz
+dBG
+dBG
+wNe
+dBG
+dBG
+jOz
+dBG
+dBG
+wNe
+dBG
+dBG
 aPP
 bch
 bfM
@@ -27676,11 +28066,11 @@ awC
 awC
 awC
 auZ
-arJ
+jFT
 are
 are
 are
-arJ
+jFT
 aDv
 auH
 aEp
@@ -27720,7 +28110,7 @@ aQL
 aRs
 bco
 aNP
-aUG
+bVE
 beY
 bfN
 bfb
@@ -27933,11 +28323,11 @@ awC
 awC
 awC
 auZ
-arJ
+jFT
 atA
 are
 aCl
-arJ
+jFT
 awZ
 auH
 avd
@@ -27977,7 +28367,7 @@ aOW
 aOW
 aOW
 bdp
-aTz
+gWo
 beZ
 bch
 bcm
@@ -28190,11 +28580,11 @@ awC
 awC
 azx
 auZ
-arJ
+jFT
 are
 are
 are
-arJ
+jFT
 awZ
 auH
 axb
@@ -28234,7 +28624,7 @@ aRt
 aOW
 aOW
 bdq
-aTz
+gWo
 bfa
 bcm
 bch
@@ -28447,10 +28837,10 @@ aqD
 auY
 avM
 ava
-arJ
+jFT
 are
 are
-arJ
+jFT
 atA
 awZ
 aEa
@@ -28491,7 +28881,7 @@ aOW
 aOW
 aOW
 bdr
-aXd
+ptc
 bfb
 bfO
 bch
@@ -28703,10 +29093,10 @@ aqD
 aqD
 auZ
 are
-arJ
+jFT
 are
 are
-arJ
+jFT
 aCm
 are
 awZ
@@ -28724,7 +29114,7 @@ aJT
 avT
 axc
 aLZ
-aPP
+ciV
 aNT
 aOW
 aOW
@@ -28748,7 +29138,7 @@ aOW
 aOW
 aOW
 bds
-aPP
+ybc
 bfc
 bfP
 bch
@@ -28960,10 +29350,10 @@ aqD
 aqD
 auZ
 are
-arJ
+jFT
 are
 are
-arJ
+jFT
 are
 are
 awZ
@@ -28981,7 +29371,7 @@ aCr
 aCr
 ayY
 awk
-aUc
+fWG
 aNU
 aOW
 aOW
@@ -29216,11 +29606,11 @@ aqD
 aqD
 auY
 ava
-arJ
+jFT
 are
 are
 atA
-arJ
+jFT
 atA
 are
 awZ
@@ -29473,11 +29863,11 @@ aqD
 aqD
 auZ
 are
-arJ
+jFT
 atA
 are
 are
-arJ
+jFT
 are
 are
 awZ
@@ -29729,12 +30119,12 @@ aqD
 auY
 avM
 ava
-arJ
+jFT
 are
 are
 are
 are
-arJ
+jFT
 are
 atA
 awZ
@@ -29752,7 +30142,7 @@ axQ
 auJ
 avd
 avd
-aPP
+ciV
 aNT
 aOW
 aOW
@@ -29776,7 +30166,7 @@ aOW
 aOW
 aOW
 bds
-aPP
+ybc
 bfe
 bfR
 bch
@@ -29986,12 +30376,12 @@ aqD
 auZ
 are
 are
-arJ
+jFT
 atA
 are
 are
 atz
-arJ
+jFT
 are
 are
 awZ
@@ -30033,7 +30423,7 @@ aOW
 aOW
 aOW
 bdt
-aUG
+bVE
 beY
 bch
 bch
@@ -30242,12 +30632,12 @@ aqD
 auC
 auZ
 are
-arJ
+jFT
 are
 are
 are
 are
-arJ
+jFT
 are
 are
 avb
@@ -30290,7 +30680,7 @@ aRt
 aOW
 aOW
 bdq
-aTz
+gWo
 bfa
 bcm
 bch
@@ -30498,12 +30888,12 @@ avL
 auY
 avM
 ava
-arJ
+jFT
 are
 are
 are
 are
-arJ
+jFT
 avb
 auf
 auf
@@ -30547,7 +30937,7 @@ aOW
 aOW
 aOW
 bdr
-aTz
+gWo
 bfa
 bch
 bcj
@@ -30754,12 +31144,12 @@ aqD
 avL
 auZ
 are
-arJ
+jFT
 are
 are
 are
 are
-azW
+drz
 avb
 atC
 atH
@@ -30804,7 +31194,7 @@ aQM
 aRu
 aRX
 aNP
-aXd
+ptc
 bfb
 bch
 bch
@@ -31010,12 +31400,12 @@ aqD
 avL
 auY
 ava
-arJ
+jFT
 are
 are
 are
-arJ
-arJ
+jFT
+jFT
 avb
 avc
 atH
@@ -31049,7 +31439,7 @@ aPP
 aUb
 aTC
 aTC
-aTC
+sWZ
 aPP
 aNW
 aNW
@@ -31061,7 +31451,7 @@ aPP
 aNW
 aNW
 aNW
-aVV
+fRf
 bcm
 bch
 bch
@@ -31266,11 +31656,11 @@ aqD
 auY
 avM
 ava
-arJ
+jFT
 are
 are
 are
-arJ
+jFT
 ayX
 avb
 avc
@@ -31294,7 +31684,7 @@ axb
 avd
 avd
 axb
-avd
+eXq
 aES
 aES
 aES
@@ -31318,7 +31708,7 @@ aET
 aES
 beX
 bch
-bck
+bCp
 bch
 bch
 bcm
@@ -31523,11 +31913,11 @@ aqD
 auZ
 are
 are
-arJ
+jFT
 are
 are
 axM
-arJ
+jFT
 are
 awZ
 avL
@@ -31552,8 +31942,8 @@ avd
 aHI
 aHJ
 aNa
-aHJ
-aHI
+pNb
+qQj
 aES
 aES
 aFD
@@ -31575,7 +31965,7 @@ bbl
 aES
 bch
 bch
-bck
+bCp
 bch
 bch
 bch
@@ -31779,11 +32169,11 @@ auC
 auY
 avv
 are
-arJ
+jFT
 are
 are
 are
-arJ
+jFT
 are
 are
 awZ
@@ -31811,9 +32201,9 @@ aMc
 aNb
 aNX
 aHI
-aHJ
-aHJ
-aHJ
+pNb
+pNb
+pNb
 aHI
 aES
 aTB
@@ -31828,10 +32218,10 @@ aLc
 aES
 aES
 aES
-aYu
-aZa
+rpH
+csn
 bcr
-aZa
+csn
 aYu
 bch
 bch
@@ -32036,11 +32426,11 @@ aqD
 auZ
 are
 are
-arJ
+jFT
 are
 are
 are
-arJ
+jFT
 avb
 auf
 avc
@@ -32071,7 +32461,7 @@ aHI
 aPR
 aQN
 aRv
-aHJ
+gyq
 aSM
 aEy
 aUc
@@ -32082,9 +32472,9 @@ aEy
 aES
 aFD
 aXP
-aZa
-aZa
-aZa
+csn
+csn
+csn
 aXP
 bbF
 bcs
@@ -32292,11 +32682,11 @@ aqD
 aqD
 auZ
 are
-arJ
+jFT
 are
 are
 are
-arJ
+jFT
 axN
 avc
 axO
@@ -32328,7 +32718,7 @@ aLq
 aJa
 aJa
 aRv
-aHJ
+gyq
 aES
 aTB
 aUc
@@ -32338,7 +32728,7 @@ aTC
 aEz
 aFD
 aSM
-aXQ
+qYr
 aZb
 aZO
 baD
@@ -32538,7 +32928,7 @@ abb
 abb
 abb
 ahU
-aqC
+cYJ
 aqD
 aqD
 aqD
@@ -32549,10 +32939,10 @@ aqD
 aqD
 auZ
 are
-arJ
+jFT
 are
 atA
-arJ
+jFT
 are
 awZ
 avL
@@ -32585,7 +32975,7 @@ aHI
 aPS
 aJa
 aRw
-aHJ
+gyq
 aES
 aTB
 aUc
@@ -32595,7 +32985,7 @@ aTC
 aWC
 aES
 aES
-aXQ
+qYr
 aZc
 aZP
 baE
@@ -32806,10 +33196,10 @@ aqD
 auD
 auZ
 are
-arJ
+jFT
 are
 are
-arJ
+jFT
 avb
 avc
 avL
@@ -32843,7 +33233,7 @@ aHI
 aJX
 aHI
 aHI
-aHI
+usu
 aNO
 aUd
 aTC
@@ -32852,7 +33242,7 @@ aTC
 aWC
 aES
 aFD
-aXQ
+qYr
 aZc
 aZP
 baF
@@ -33063,10 +33453,10 @@ aqD
 aqD
 auZ
 are
-arJ
+jFT
 are
 atA
-arJ
+jFT
 awZ
 avL
 avL
@@ -33100,7 +33490,7 @@ aJd
 aLr
 aJd
 aRZ
-aHJ
+gyq
 aTC
 aTC
 aTC
@@ -33108,7 +33498,7 @@ aTC
 aTC
 aPP
 aNO
-aXP
+vGH
 aXP
 aZd
 aZQ
@@ -33320,10 +33710,10 @@ aqD
 aqD
 auZ
 atA
-arJ
+jFT
 are
 atz
-arJ
+jFT
 awZ
 axO
 atH
@@ -33365,7 +33755,7 @@ aVr
 aTC
 aTC
 aTC
-aXQ
+qYr
 aYr
 aZe
 aZe
@@ -33577,10 +33967,10 @@ aqD
 aqD
 auZ
 are
-arJ
+jFT
 are
 are
-arJ
+jFT
 awZ
 avL
 auH
@@ -33614,7 +34004,7 @@ aPT
 aJd
 aRx
 aSb
-aHJ
+gyq
 aTC
 aTC
 aUK
@@ -33622,7 +34012,7 @@ aTD
 aTD
 aTD
 aTD
-aXR
+rxi
 aYs
 aZf
 aZR
@@ -33834,10 +34224,10 @@ aqD
 auD
 auZ
 are
-arJ
+jFT
 are
 are
-arJ
+jFT
 awZ
 avL
 auH
@@ -33872,14 +34262,14 @@ aQO
 aHI
 aHI
 aHI
-aNW
+nny
 aUf
 aTC
 aTC
 aTC
 aTC
 aTC
-aXQ
+qYr
 aYt
 aZg
 aZS
@@ -34090,11 +34480,11 @@ aqD
 aqD
 arb
 ava
-arJ
+jFT
 are
 are
 are
-arJ
+jFT
 awZ
 avL
 auH
@@ -34131,11 +34521,11 @@ aHJ
 aES
 aES
 aPP
-aNW
+nny
 aUf
-aPP
+nfB
 aXd
-aNW
+nny
 aXP
 aXP
 aZd
@@ -34347,11 +34737,11 @@ aty
 arI
 arc
 atz
-arJ
+jFT
 are
 atA
 are
-arJ
+jFT
 awZ
 avL
 auH
@@ -34603,12 +34993,12 @@ arb
 arc
 ard
 ard
-arJ
+jFT
 are
 are
 are
 are
-arJ
+jFT
 awZ
 avL
 auH
@@ -34859,13 +35249,13 @@ arI
 arc
 ard
 asG
-arJ
+jFT
 are
 are
 atA
 are
 awF
-arJ
+jFT
 awZ
 atH
 auk
@@ -35114,14 +35504,14 @@ ard
 ard
 ard
 ard
-ath
-ath
+jeQ
+jeQ
 are
 are
 are
 are
 are
-arJ
+jFT
 are
 awZ
 auH
@@ -35370,14 +35760,14 @@ ard
 ard
 ard
 ard
-ath
+jeQ
 atz
 are
 are
 are
 are
 are
-arJ
+jFT
 atz
 awY
 avc
@@ -35627,13 +36017,13 @@ ard
 ard
 asm
 asG
-arJ
+jFT
 are
 are
 are
 are
 atA
-arJ
+jFT
 are
 are
 awZ
@@ -35883,13 +36273,13 @@ apY
 are
 are
 are
-arJ
+jFT
 are
 are
 are
 are
 are
-arJ
+jFT
 are
 are
 avb
@@ -36139,13 +36529,13 @@ apY
 apY
 are
 are
-arJ
+jFT
 are
 are
 atA
 are
 are
-arJ
+jFT
 are
 avN
 avb
@@ -36395,13 +36785,13 @@ ajz
 ajz
 ajz
 ajz
-apD
+jFm
 ajz
 ajz
 ajz
 ajz
 ajz
-arJ
+jFT
 atz
 avb
 auf
@@ -36652,12 +37042,12 @@ ajz
 ajz
 ajz
 ajz
-apD
+jFm
 ajz
-apD
+jFm
 ajz
-apD
-apD
+jFm
+jFm
 are
 avb
 avc
@@ -36910,9 +37300,9 @@ aqm
 akp
 ajz
 ajz
-apD
+jFm
 aqm
-apD
+jFm
 alc
 ajA
 auf
@@ -37169,7 +37559,7 @@ alL
 alQ
 alL
 alQ
-aoe
+lFi
 aoy
 arU
 auF
@@ -37426,7 +37816,7 @@ ajS
 alS
 alS
 alS
-aqH
+cVi
 aoB
 aoQ
 auG
@@ -38197,7 +38587,7 @@ alS
 alS
 alS
 alS
-aqH
+cVi
 atG
 auj
 auI
@@ -38706,11 +39096,11 @@ ajz
 ajz
 ajz
 arO
-apD
-apD
+jFm
+jFm
 arO
 aqI
-asK
+waH
 aro
 arV
 atX
@@ -38962,11 +39352,11 @@ ajz
 ajz
 ajz
 ajz
-apD
+jFm
 ajz
 ajz
-apD
-ncP
+jFm
+xis
 arU
 arV
 arW
@@ -39219,10 +39609,10 @@ ajz
 ajK
 ajz
 akp
-apD
+jFm
 ajK
 ajz
-apD
+jFm
 alb
 arp
 arW
@@ -39476,10 +39866,10 @@ ajz
 ajz
 amw
 ajz
-apD
+jFm
 ajz
 ajz
-apD
+jFm
 alb
 arp
 atl
@@ -39733,10 +40123,10 @@ ajz
 ajz
 ajz
 ajz
-apD
+jFm
 ajz
 ajz
-apD
+jFm
 alb
 arp
 arW
@@ -39990,10 +40380,10 @@ apf
 ajz
 ajz
 ajz
-apD
+jFm
 ajz
 ajz
-apD
+jFm
 alb
 arp
 atm
@@ -40247,9 +40637,9 @@ ajz
 ajz
 ajz
 ajz
-apD
+jFm
 apf
-apD
+jFm
 arP
 alb
 arp
@@ -40503,10 +40893,10 @@ alu
 ajz
 ajz
 ajz
-apD
+jFm
 ajz
 ajz
-apD
+jFm
 aqI
 ald
 arq
@@ -40760,10 +41150,10 @@ alu
 ajz
 ajz
 ajz
-apD
+jFm
 ajz
 ajz
-apD
+jFm
 arQ
 ala
 arl
@@ -41017,10 +41407,10 @@ alu
 apf
 ajz
 ajz
-apD
+jFm
 ajz
 ajz
-apD
+jFm
 ajz
 alb
 arl
@@ -41274,10 +41664,10 @@ alu
 ajz
 ajz
 ajz
-apD
+jFm
 apf
 ajz
-apD
+jFm
 ajz
 alb
 aro
@@ -41531,10 +41921,10 @@ alu
 ajz
 ajz
 ajz
-apD
+jFm
 ajz
 ajz
-apD
+jFm
 aqI
 ald
 arp
@@ -41788,10 +42178,10 @@ alu
 ajz
 ajz
 ajz
-apD
+jFm
 ajz
 ajz
-apD
+jFm
 arR
 aiJ
 arp
@@ -42045,10 +42435,10 @@ alu
 ajz
 ajz
 ajz
-apD
+jFm
 akp
 ajz
-apD
+jFm
 alb
 aiJ
 arp
@@ -42302,9 +42692,9 @@ akW
 amw
 ajz
 ajz
-apD
+jFm
 ajz
-apD
+jFm
 ajz
 arS
 asp
@@ -42560,7 +42950,7 @@ all
 alS
 ajS
 ajS
-apD
+jFm
 aqa
 ajS
 ajS
@@ -42816,7 +43206,7 @@ aoE
 aji
 ajj
 ajS
-apD
+jFm
 ajz
 ajz
 aji
@@ -43587,7 +43977,7 @@ aoH
 aph
 aph
 aph
-apD
+jFm
 ajj
 ajS
 ajz
@@ -43843,7 +44233,7 @@ akI
 aoI
 ajS
 ajS
-apD
+jFm
 ajS
 ajj
 alS
@@ -44100,8 +44490,8 @@ anZ
 akW
 amw
 ajz
-apD
-apD
+jFm
+jFm
 ajz
 ajz
 ajz
@@ -44357,9 +44747,9 @@ ane
 alu
 ajz
 ajz
-apD
+jFm
 ajS
-apD
+jFm
 ajz
 ajz
 aqb
@@ -44614,10 +45004,10 @@ ane
 aoz
 ajz
 akp
-apD
+jFm
 ajz
 ajz
-apD
+jFm
 ajz
 ajz
 ass
@@ -44870,12 +45260,12 @@ akq
 alU
 alu
 ajz
-apD
+jFm
 apR
 ajz
 ajz
 ajz
-apD
+jFm
 ajz
 ajz
 alb
@@ -45127,13 +45517,13 @@ ang
 akI
 alu
 ajz
-apD
+jFm
 ajz
 ajz
 ajz
 ajS
 akp
-apD
+jFm
 ajz
 alb
 arp
@@ -45384,13 +45774,13 @@ ang
 anZ
 alu
 akp
-apD
+jFm
 ajz
 ajz
 aqu
 ajz
 ajz
-apD
+jFm
 ajz
 alb
 arp
@@ -45641,13 +46031,13 @@ alm
 anZ
 alu
 ajz
-apD
+jFm
 ajz
 ajz
 ajz
 ajz
 ajz
-apD
+jFm
 ajz
 alb
 arq
@@ -45899,12 +46289,12 @@ ane
 alu
 ajz
 ajz
-apD
+jFm
 aqa
 ajz
 ajz
 ajz
-apD
+jFm
 ajz
 akC
 ats
@@ -46156,12 +46546,12 @@ akI
 alu
 ajz
 ajz
-apD
+jFm
 ajz
 ajz
 ajz
 apf
-apD
+jFm
 ajz
 ajz
 alb
@@ -46413,12 +46803,12 @@ aob
 akW
 ajz
 ajz
-apD
+jFm
 akG
 ajz
 ajz
 ajz
-apD
+jFm
 ajz
 ajz
 alb
@@ -46670,12 +47060,12 @@ akq
 aoz
 ajz
 amw
-apD
+jFm
 ajz
 ajz
 ajz
 ajz
-apD
+jFm
 ajz
 ajz
 alb
@@ -46927,12 +47317,12 @@ ajR
 aoz
 ajz
 ajz
-apD
+jFm
 ajz
 ajz
 ajz
 ajz
-apD
+jFm
 ajz
 ajz
 aqJ
@@ -47184,12 +47574,12 @@ ajR
 aoz
 ajz
 ajz
-apD
+jFm
 ajz
 ajz
 ajz
 ajz
-apD
+jFm
 ajz
 ajz
 alb
@@ -47441,12 +47831,12 @@ ane
 alu
 ajz
 ajz
-apD
+jFm
 ajz
 ajz
 apR
 ajz
-apD
+jFm
 ajz
 aqI
 ald
@@ -47698,12 +48088,12 @@ anZ
 alu
 akp
 ajz
-apD
+jFm
 ajz
 ajz
 ajz
 ajz
-apD
+jFm
 ajz
 alb
 aiJ
@@ -47955,12 +48345,12 @@ aoc
 alu
 ajz
 ajz
-apD
+jFm
 ajz
 ajz
 ajz
 ajz
-apD
+jFm
 ajz
 akC
 ala
@@ -48212,12 +48602,12 @@ alS
 alv
 api
 ajz
-apD
+jFm
 ajz
 ajz
 akp
 ajz
-apD
+jFm
 ast
 asT
 alb
@@ -48469,12 +48859,12 @@ aod
 alu
 amw
 ajz
-apD
+jFm
 ajz
 ajz
 ajz
 ajz
-apD
+jFm
 ajz
 ajz
 alb
@@ -48726,12 +49116,12 @@ aod
 alu
 amw
 ajz
-apD
+jFm
 ajz
 ajz
 ajz
 ajz
-apD
+jFm
 ajz
 ajz
 akC
@@ -48983,12 +49373,12 @@ akn
 alx
 amw
 ajz
-apD
+jFm
 ajz
 ajz
 ajz
 akp
-apD
+jFm
 ajz
 ajz
 ajz
@@ -49240,12 +49630,12 @@ alS
 aoL
 apj
 ajz
-apD
+jFm
 ajz
 ajz
 ajz
 ajz
-apD
+jFm
 ajz
 ajz
 alc
@@ -49497,12 +49887,12 @@ alS
 ajz
 ajz
 ajz
-apD
+jFm
 ajz
 ajz
 ajz
 ajz
-apD
+jFm
 ajz
 alc
 ald
@@ -49754,11 +50144,11 @@ aof
 ajz
 ajz
 ajz
-apD
+jFm
 ajz
 ajz
 apf
-apD
+jFm
 aqI
 ajA
 ald
@@ -50011,10 +50401,10 @@ aog
 aoM
 aoN
 ajz
-apD
+jFm
 ajz
 ajz
-apD
+jFm
 alc
 ald
 arU
@@ -50268,9 +50658,9 @@ aog
 aoM
 apk
 ajz
-apD
+jFm
 akp
-apD
+jFm
 ajz
 alb
 arU
@@ -50525,9 +50915,9 @@ aoh
 ajz
 ajz
 ajz
-apD
+jFm
 ajz
-apD
+jFm
 ajz
 alb
 arp
@@ -50782,9 +51172,9 @@ alS
 ajz
 ajz
 akp
-apD
+jFm
 ajz
-apD
+jFm
 aqI
 ark
 arp
@@ -51039,9 +51429,9 @@ aof
 ajz
 ajz
 ajz
-apD
+jFm
 ajz
-apD
+jFm
 aqJ
 arl
 arp
@@ -51296,9 +51686,9 @@ aof
 ajz
 ajz
 ajz
-apD
+jFm
 ajz
-apD
+jFm
 alb
 arl
 arp
@@ -51553,9 +51943,9 @@ aof
 ajz
 ajz
 ajz
-apD
+jFm
 ajz
-apD
+jFm
 alb
 arl
 arp
@@ -51810,9 +52200,9 @@ aof
 ajz
 ajz
 apE
-apD
+jFm
 ajz
-apD
+jFm
 akC
 arm
 arp
@@ -52067,9 +52457,9 @@ alS
 ajz
 ajz
 ajz
-apD
+jFm
 ajz
-apD
+jFm
 apf
 arn
 arp
@@ -52324,9 +52714,9 @@ alS
 ajz
 akp
 ajz
-apD
+jFm
 ajz
-apD
+jFm
 aqI
 ark
 arp
@@ -52581,9 +52971,9 @@ aog
 aoN
 ajz
 ajz
-apD
+jFm
 aqb
-apD
+jFm
 alb
 aro
 arV
@@ -52838,9 +53228,9 @@ aog
 aoN
 ajz
 ajz
-apD
+jFm
 ajz
-apD
+jFm
 alb
 arp
 arW
@@ -53095,9 +53485,9 @@ aof
 ajz
 akG
 ajz
-apD
+jFm
 akp
-apD
+jFm
 alb
 arp
 arX
@@ -53352,9 +53742,9 @@ alS
 ajz
 ajz
 ajz
-apD
+jFm
 ajz
-apD
+jFm
 alb
 arp
 arX
@@ -53609,9 +53999,9 @@ alS
 ajz
 ajz
 ajz
-apD
+jFm
 ajz
-apD
+jFm
 alb
 arp
 arY
@@ -53866,9 +54256,9 @@ aoi
 aoO
 aoO
 aoO
-apS
+fyJ
 aoO
-apS
+fyJ
 aqf
 arq
 arZ
@@ -54123,9 +54513,9 @@ aoi
 aoO
 apl
 aoO
-apS
+fyJ
 apm
-apS
+fyJ
 aqM
 arm
 arp
@@ -54380,9 +54770,9 @@ aoi
 aoO
 aoO
 aoO
-apS
+fyJ
 aoO
-apS
+fyJ
 aoO
 arn
 arp
@@ -54637,9 +55027,9 @@ aoi
 aoO
 apl
 aoO
-apS
+fyJ
 apm
-apS
+fyJ
 aqN
 ark
 arp
@@ -54894,9 +55284,9 @@ aoi
 aoO
 aoO
 aoO
-apS
+fyJ
 aoO
-apS
+fyJ
 aqf
 aro
 arV
@@ -55151,9 +55541,9 @@ aoi
 aoO
 apm
 aoO
-apS
+fyJ
 aoO
-apS
+fyJ
 aqf
 arq
 arZ
@@ -55221,8 +55611,8 @@ bdf
 bcc
 beP
 bec
-bec
-axZ
+eNq
+mGd
 azT
 azT
 bjt
@@ -55408,7 +55798,7 @@ aoj
 aoO
 aoO
 aoO
-apS
+fyJ
 aoO
 aoO
 aqP
@@ -55462,10 +55852,10 @@ aSx
 aEk
 aEB
 aEk
-aKy
+eLi
 aSz
 aWq
-aDL
+bsH
 aXC
 aYg
 aYR
@@ -55475,9 +55865,9 @@ aYR
 aYR
 aYg
 aLL
-bec
+eNq
 beQ
-axZ
+mGd
 bgw
 bgw
 bgw
@@ -55665,10 +56055,10 @@ aoj
 aoO
 aoO
 aoO
-apS
+fyJ
 aoO
 aoO
-apS
+fyJ
 aqf
 arp
 arW
@@ -55723,15 +56113,15 @@ aVg
 aSB
 aWr
 aWq
-aXC
+jgW
 aYh
 aYS
-aZy
-aZy
-aZy
+jAE
+jAE
+jAE
 aYh
 aYS
-aLL
+sGt
 bed
 beR
 bfE
@@ -55923,10 +56313,10 @@ aoO
 aoO
 aoO
 aoO
-apS
+fyJ
 aoO
 aoO
-aru
+wix
 arq
 arZ
 arW
@@ -55990,8 +56380,8 @@ aTn
 aTn
 aTn
 aSB
-beS
-bfF
+aWs
+aWs
 bgy
 aWs
 bhL
@@ -56232,9 +56622,9 @@ aON
 aKA
 aTm
 aLj
+uwN
 aDL
-aDL
-aSC
+qSA
 aTt
 aTt
 aXD
@@ -56247,14 +56637,14 @@ aYT
 aYi
 aWs
 aSB
-beT
-bfG
+beS
+bfF
 bgz
 aWs
 bhM
 biG
 bjv
-aUB
+vzU
 bkS
 bkj
 bmn
@@ -56437,7 +56827,7 @@ aoS
 aoS
 aoS
 aoS
-aqc
+bJn
 aoS
 aoS
 aoS
@@ -56489,7 +56879,7 @@ aRo
 aKB
 aEk
 aTO
-aEj
+hVU
 aVi
 aVN
 aVN
@@ -56504,8 +56894,8 @@ aWs
 aYi
 aWs
 aSB
-beU
-bfH
+beT
+bfG
 bgz
 aWs
 bhN
@@ -56746,7 +57136,7 @@ aRR
 aKB
 aEk
 aTP
-aEj
+hVU
 aVj
 aVO
 aVO
@@ -56761,8 +57151,8 @@ aWs
 aYi
 aWs
 aSB
-aWs
-aWs
+beU
+bfH
 aWs
 aWs
 aWs
@@ -56951,7 +57341,7 @@ aom
 app
 app
 app
-aqc
+bJn
 app
 app
 app
@@ -57003,7 +57393,7 @@ aFK
 aKD
 aEk
 aEk
-aEj
+hVU
 aVj
 aVO
 aVO
@@ -57257,9 +57647,9 @@ aEk
 aEk
 aEk
 aDL
-aEj
-aEj
-aEj
+cSo
+cSo
+cSo
 aDL
 aVk
 aVP
@@ -57282,7 +57672,7 @@ aWs
 aWs
 aWs
 bjv
-aUB
+vzU
 bjz
 bkY
 bmo
@@ -57465,7 +57855,7 @@ aol
 aoS
 aoS
 app
-apS
+fyJ
 aoS
 aoS
 aoS
@@ -57513,7 +57903,7 @@ aDL
 aGU
 aQx
 aGU
-aDL
+uwN
 aSz
 aTn
 aTn
@@ -57721,7 +58111,7 @@ akO
 alz
 alI
 anB
-apS
+fyJ
 aoO
 aml
 aly
@@ -57770,7 +58160,7 @@ azK
 aAk
 aAk
 aAk
-aHv
+lYR
 aSA
 aTo
 aTQ
@@ -57977,12 +58367,12 @@ aoO
 aoO
 aoO
 aoO
-apS
+fyJ
 amR
 apm
 aoO
-aqQ
-ary
+syO
+jPR
 aro
 arV
 arW
@@ -58027,7 +58417,7 @@ azK
 aAk
 aAk
 aAk
-aHv
+lYR
 aSB
 aTp
 aTR
@@ -58232,12 +58622,12 @@ amL
 anl
 aoO
 aoO
-apS
-apS
+fyJ
+fyJ
 aoO
 aoO
-apS
-apS
+fyJ
+fyJ
 aqf
 aro
 arV
@@ -58284,7 +58674,7 @@ azJ
 aAk
 aAk
 aAk
-azJ
+eRR
 aSB
 aTq
 aTR
@@ -58310,7 +58700,7 @@ aTR
 aTR
 biI
 bjv
-aUB
+vzU
 bkU
 bkk
 bdi
@@ -58488,11 +58878,11 @@ ajB
 apl
 aoO
 aoO
-apS
+fyJ
 amR
 aoO
 apo
-apS
+fyJ
 aqN
 aqw
 aqg
@@ -58541,7 +58931,7 @@ azK
 aAk
 aAk
 aAk
-aHv
+lYR
 aSB
 aTr
 aTR
@@ -58744,11 +59134,11 @@ aoO
 aoO
 aoO
 aoO
-apS
+fyJ
 aoO
 aoO
 aoO
-apS
+fyJ
 aoO
 aqf
 anM
@@ -58798,7 +59188,7 @@ azK
 aAk
 aAk
 aAk
-aHv
+lYR
 aSB
 aTs
 aTR
@@ -59000,11 +59390,11 @@ aoO
 aoO
 akM
 aoO
-apS
+fyJ
 aoO
 apm
 aoO
-apS
+fyJ
 aoO
 aqN
 aqg
@@ -59055,7 +59445,7 @@ azJ
 aAk
 aAk
 aAk
-aHv
+lYR
 aSB
 aTp
 aTR
@@ -59256,11 +59646,11 @@ aoO
 aoO
 aoO
 aoO
-apS
+fyJ
 ajB
 aoO
 aoO
-apS
+fyJ
 aoO
 aqN
 aqg
@@ -59312,7 +59702,7 @@ aAk
 aAk
 aAk
 aAk
-azJ
+eRR
 aSB
 aTq
 aTR
@@ -59512,11 +59902,11 @@ aoO
 aoO
 aoO
 aoO
-apS
+fyJ
 apm
 aoO
 aoO
-apS
+fyJ
 aoO
 aoO
 aqf
@@ -59569,7 +59959,7 @@ aAk
 aAk
 aAk
 aAk
-aHv
+lYR
 aSB
 aTr
 aTR
@@ -59768,11 +60158,11 @@ aoO
 aoO
 aoO
 akM
-apS
+fyJ
 aoO
 aoO
 aoO
-apS
+fyJ
 aoO
 aoO
 aqN
@@ -59826,7 +60216,7 @@ aAk
 aAk
 aAk
 aAk
-aHv
+lYR
 aSB
 aTs
 aTR
@@ -60025,10 +60415,10 @@ aoO
 aiU
 aoO
 apm
-apS
+fyJ
 aoO
 aoO
-apS
+fyJ
 aoO
 ajB
 aqN
@@ -60083,7 +60473,7 @@ aNN
 azJ
 aNN
 aNN
-azJ
+eRR
 aSB
 aTp
 aTR
@@ -60281,11 +60671,11 @@ aoO
 aoO
 aoO
 ajB
-apS
+fyJ
 aoO
 aoO
 apm
-apS
+fyJ
 aoO
 aoO
 aqf
@@ -60366,7 +60756,7 @@ aTR
 aTR
 biI
 bjv
-aUB
+vzU
 bkT
 bkk
 bdk
@@ -60537,11 +60927,11 @@ aij
 aoO
 ajB
 aoO
-apS
+fyJ
 aoO
 aoO
 aoO
-apS
+fyJ
 aoO
 aoO
 aqN
@@ -60792,12 +61182,12 @@ atb
 abl
 aiT
 aoO
-apS
-apS
+fyJ
+fyJ
 aku
 aoO
 aoO
-apS
+fyJ
 akh
 aoO
 aqN
@@ -61049,12 +61439,12 @@ atb
 ahQ
 aoO
 aoO
-apS
+fyJ
 ajB
 aoO
 aoO
 apm
-apS
+fyJ
 aoO
 aqN
 aqg
@@ -61306,11 +61696,11 @@ atb
 ahQ
 aoO
 aiU
-apS
+fyJ
 aoO
 aoO
 aoO
-apS
+fyJ
 aoO
 aoO
 aqf
@@ -61372,25 +61762,25 @@ aRT
 aSD
 aSD
 aSD
-aUB
+xsY
 aSD
 aSD
 aWx
-aUB
+xsY
 aSD
 aSD
-aUB
+xsY
 aSD
 aWx
 aSD
-aUB
+xsY
 aWx
 aSD
-aUB
+xsY
 aSD
 aSD
 aSD
-aRT
+cnd
 aSD
 aSD
 aSD
@@ -61562,12 +61952,12 @@ aiw
 atb
 aik
 aoO
-apS
+fyJ
 aoO
 aoO
 aoO
 aoO
-apS
+fyJ
 aoO
 aoO
 als
@@ -61819,12 +62209,12 @@ aiw
 auA
 ahQ
 aoO
-apS
+fyJ
 apm
 aoO
 aoO
 aoO
-apS
+fyJ
 aoO
 aix
 alt
@@ -62076,12 +62466,12 @@ aiw
 atb
 aiv
 aij
-apS
+fyJ
 aoO
 aoO
 aoO
 aix
-ajm
+mBX
 aix
 aix
 anr
@@ -62333,12 +62723,12 @@ aiw
 atb
 atb
 ahQ
-ajm
+mBX
 aix
 aix
 aix
 aki
-ajm
+mBX
 akT
 atb
 anr
@@ -62590,12 +62980,12 @@ aiw
 atb
 atb
 aik
-ajm
+mBX
 aix
 aix
 aix
 aki
-ajm
+mBX
 akU
 atb
 anr
@@ -62848,11 +63238,11 @@ atb
 atb
 aiv
 aix
-ajU
+iqK
 aki
 aki
 aki
-ajm
+mBX
 akV
 alq
 anr
@@ -63105,11 +63495,11 @@ aiz
 atb
 atb
 ajn
-ajU
+iqK
 akj
 akw
 aix
-ajU
+iqK
 aki
 alr
 anr
@@ -63362,11 +63752,11 @@ atb
 atb
 atb
 aik
-ajW
+oyC
 aki
 aki
 akt
-ajU
+iqK
 aki
 alr
 anr
@@ -63619,11 +64009,11 @@ atb
 atb
 atb
 atb
-ajU
+iqK
 aki
 aki
 aki
-ajm
+mBX
 aki
 atb
 anr
@@ -63876,11 +64266,11 @@ atb
 atb
 atb
 atb
-akd
+rAF
 aix
 aix
 aki
-ajU
+iqK
 aki
 atb
 anr
@@ -64137,7 +64527,7 @@ ake
 akt
 atb
 aki
-akd
+rAF
 atb
 atb
 anr
@@ -64390,11 +64780,11 @@ atb
 atb
 atb
 atb
-akf
+jca
 atb
 atb
 atb
-akf
+jca
 atb
 atb
 anr
@@ -64647,11 +65037,11 @@ aiw
 atb
 atb
 atb
-akg
+xqG
 atb
 atb
 atb
-akg
+xqG
 atb
 atb
 anr

--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -2,6 +2,10 @@
 "aab" = (
 /turf/open/beach/water,
 /area/space)
+"abk" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/wall/r_wall/prison,
+/area/prison/chapel)
 "acD" = (
 /obj/effect/step_trigger/teleporter/random{
 	name = "tele_space";
@@ -4595,6 +4599,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/prison/hangar/civilian)
@@ -11396,10 +11403,12 @@
 	name = "Security Booth";
 	req_access_txt = "0"
 	},
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison,
 /area/prison/security/checkpoint/maxsec)
 "aEi" = (
 /obj/structure/window/framed/prison/reinforced,
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
 /area/prison/security/checkpoint/maxsec)
 "aEj" = (
@@ -11407,6 +11416,7 @@
 	name = "Maximum-Security Wing";
 	req_access_txt = "0"
 	},
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/checkpoint/maxsec)
 "aEk" = (
@@ -11418,6 +11428,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/checkpoint/maxsec)
 "aEm" = (
@@ -11792,6 +11803,7 @@
 	},
 /area/prison/security/checkpoint/maxsec)
 "aFr" = (
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/prison,
 /area/prison/security/checkpoint/maxsec)
 "aFs" = (
@@ -12269,6 +12281,7 @@
 /obj/machinery/door/airlock/almayer/security{
 	name = "Security Office"
 	},
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison,
 /area/prison/security/checkpoint/maxsec)
 "aGC" = (
@@ -13310,6 +13323,7 @@
 /obj/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "Chapel"
 	},
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison{
 	icon_state = "bright_clean";
 	dir = 10
@@ -13831,6 +13845,7 @@
 /turf/open/floor/wood,
 /area/prison/storage/highsec/n)
 "aJT" = (
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall/prison,
 /area/prison/medbay/foyer)
 "aJU" = (
@@ -13903,6 +13918,7 @@
 /obj/machinery/door/poddoor/timed_late{
 	dir = 2
 	},
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison{
 	icon_state = "rampbottom"
 	},
@@ -13919,6 +13935,7 @@
 /obj/machinery/door/poddoor/timed_late{
 	dir = 2
 	},
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison{
 	icon_state = "rampbottom"
 	},
@@ -14204,6 +14221,7 @@
 /obj/machinery/door/poddoor/shutters/timed_late{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
 /area/prison/security/checkpoint/highsec/n)
 "aKN" = (
@@ -15661,6 +15679,7 @@
 /obj/machinery/door/poddoor/timed_late{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison{
 	icon_state = "bright_clean2";
 	dir = 10
@@ -16141,6 +16160,7 @@
 	dir = 2;
 	name = "North High-Security Cellblock"
 	},
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison,
 /area/prison/security/checkpoint/highsec/n)
 "aPl" = (
@@ -16452,6 +16472,7 @@
 /obj/machinery/door/poddoor/timed_late{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison{
 	icon_state = "bright_clean";
 	dir = 10
@@ -17053,6 +17074,7 @@
 /obj/machinery/door/poddoor/timed_late{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison{
 	icon_state = "bright_clean";
 	dir = 10
@@ -20099,6 +20121,9 @@
 	},
 /area/prison/command/quarters)
 "aYL" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 8
+	},
 /turf/closed/wall/r_wall/prison,
 /area/prison/hangar/main)
 "aYM" = (
@@ -22826,6 +22851,7 @@
 /obj/machinery/door/poddoor/timed_late{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison{
 	icon_state = "bright_clean2";
 	dir = 10
@@ -23874,6 +23900,7 @@
 /obj/machinery/door/poddoor/timed_late{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison{
 	icon_state = "bright_clean2";
 	dir = 10
@@ -25514,6 +25541,7 @@
 	name = "Storage";
 	req_one_access_txt = "0"
 	},
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison,
 /area/prison/storage/vip)
 "ble" = (
@@ -25756,6 +25784,7 @@
 	dir = 2;
 	name = "Civilian Residences Hangar"
 	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/prison,
 /area/prison/residential/central)
 "blJ" = (
@@ -26037,6 +26066,7 @@
 /obj/machinery/door/poddoor/timed_late{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison/blue{
 	dir = 9
 	},
@@ -26401,6 +26431,7 @@
 /obj/machinery/door/poddoor/timed_late{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison/blue/full,
 /area/prison/security/checkpoint/vip)
 "bnu" = (
@@ -26538,6 +26569,9 @@
 /obj/machinery/door/airlock/multi_tile/almayer/generic{
 	dir = 2;
 	name = "Entrance Hallway"
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 8
 	},
 /turf/open/floor/prison,
 /area/prison/hangar/main)
@@ -26911,6 +26945,7 @@
 /obj/machinery/door/poddoor/timed_late{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison/blue/full,
 /area/prison/security/checkpoint/vip)
 "boq" = (
@@ -27186,6 +27221,9 @@
 /obj/machinery/door/airlock/multi_tile/almayer/generic{
 	dir = 2;
 	name = "Entrance Hallway"
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 8
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hangar/main)
@@ -27514,6 +27552,7 @@
 /obj/machinery/door/poddoor/timed_late{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison/blue{
 	dir = 10
 	},
@@ -27924,6 +27963,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 8
 	},
 /turf/open/floor/prison,
 /area/prison/hangar/main)
@@ -28558,6 +28600,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/prison/hangar/main)
@@ -31101,6 +31146,9 @@
 /obj/machinery/door/airlock/almayer/security{
 	name = "Main Hangar Traffic Control"
 	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 8
+	},
 /turf/open/floor/prison,
 /area/prison/security/checkpoint/hangar)
 "byv" = (
@@ -31394,6 +31442,9 @@
 	name = "Hangar-Barracks Maintenance";
 	req_one_access_txt = "0"
 	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
 /turf/open/floor/plating,
 /area/prison/hangar/main)
 "bzi" = (
@@ -31629,6 +31680,7 @@
 /obj/machinery/door/poddoor/shutters/timed_late{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
 /area/prison/security/checkpoint/highsec/s)
 "bzS" = (
@@ -32809,6 +32861,7 @@
 /obj/machinery/door/poddoor/timed_late{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison{
 	icon_state = "bright_clean2";
 	dir = 10
@@ -32981,6 +33034,9 @@
 /turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
 "bDb" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 8
+	},
 /turf/closed/wall/prison,
 /area/prison/security/checkpoint/hangar)
 "bDc" = (
@@ -33121,6 +33177,7 @@
 	},
 /area/prison/security)
 "bDt" = (
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall/prison,
 /area/prison/holding/holding1)
 "bDv" = (
@@ -33584,6 +33641,7 @@
 /obj/machinery/door/poddoor/timed_late{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison{
 	icon_state = "bright_clean";
 	dir = 10
@@ -33756,6 +33814,7 @@
 /obj/machinery/door/poddoor/timed_late{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison{
 	icon_state = "bright_clean";
 	dir = 10
@@ -33872,6 +33931,18 @@
 /area/prison/console)
 "bEP" = (
 /obj/structure/table/reinforced,
+/obj/machinery/button/door/open_only/landing_zone{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/checkpoint/hangar)
 "bEQ" = (
@@ -33940,6 +34011,7 @@
 /area/prison/maintenance/residential/se)
 "bEY" = (
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall/prison,
 /area/prison/holding/holding2)
 "bEZ" = (
@@ -34165,6 +34237,12 @@
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/east)
+"bFG" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 1
+	},
+/turf/closed/wall/r_wall/prison_unmeltable,
+/area/prison/hangar/civilian)
 "bFH" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -34966,6 +35044,7 @@
 /obj/machinery/door/poddoor/timed_late{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison/red{
 	dir = 1
 	},
@@ -35449,6 +35528,7 @@
 /obj/machinery/door/poddoor/timed_late{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison,
 /area/prison/security/checkpoint/highsec/s)
 "bIz" = (
@@ -36013,6 +36093,7 @@
 /obj/machinery/door/poddoor/timed_late{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison,
 /area/prison/security/checkpoint/highsec/s)
 "bJM" = (
@@ -36328,6 +36409,7 @@
 /obj/machinery/door/poddoor/timed_late{
 	dir = 4
 	},
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison/red,
 /area/prison/security/checkpoint/highsec/s)
 "bKA" = (
@@ -37994,16 +38076,19 @@
 	},
 /area/prison/security/checkpoint/medsec)
 "bOz" = (
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall/prison_unmeltable,
 /area/prison/storage/medsec)
 "bOA" = (
 /obj/structure/window/framed/prison/reinforced/hull,
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
 /area/prison/storage/medsec)
 "bOB" = (
 /obj/machinery/door/poddoor/timed_late{
 	dir = 2
 	},
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison/blue,
 /area/prison/hallway/central)
 "bOC" = (
@@ -38018,6 +38103,7 @@
 /obj/machinery/door/poddoor/timed_late{
 	dir = 2
 	},
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison/blue,
 /area/prison/hallway/central)
 "bOD" = (
@@ -38035,6 +38121,7 @@
 /obj/machinery/door/poddoor/timed_late{
 	dir = 2
 	},
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison{
 	icon_state = "bright_clean2";
 	dir = 10
@@ -38051,6 +38138,7 @@
 /obj/machinery/door/poddoor/timed_late{
 	dir = 2
 	},
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison{
 	icon_state = "bright_clean2";
 	dir = 10
@@ -38407,6 +38495,7 @@
 /obj/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "Laundry"
 	},
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison,
 /area/prison/laundry)
 "bPy" = (
@@ -38418,6 +38507,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison,
 /area/prison/laundry)
 "bPz" = (
@@ -40969,6 +41059,7 @@
 	},
 /area/prison/laundry)
 "bVI" = (
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/prison,
 /area/prison/security/checkpoint/medsec)
 "bVJ" = (
@@ -40980,10 +41071,12 @@
 	name = "Security Booth";
 	req_access_txt = "0"
 	},
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/checkpoint/medsec)
 "bVK" = (
 /obj/structure/window/framed/prison/reinforced,
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
 /area/prison/security/checkpoint/medsec)
 "bVL" = (
@@ -40993,6 +41086,7 @@
 /obj/machinery/door/airlock/multi_tile/almayer/generic{
 	name = "Medium-Security Cellblock"
 	},
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison,
 /area/prison/security/checkpoint/medsec)
 "bVM" = (
@@ -41007,6 +41101,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison,
 /area/prison/security/checkpoint/medsec)
 "bVN" = (
@@ -41017,6 +41112,7 @@
 	name = "Security Booth";
 	req_access_txt = "0"
 	},
+/obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/checkpoint/medsec)
 "bVO" = (
@@ -50622,6 +50718,9 @@
 	dir = 2;
 	req_one_access_txt = "0"
 	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
 /turf/open/floor/plating,
 /area/prison/hangar/civilian)
 "cty" = (
@@ -52962,6 +53061,30 @@
 	dir = 6
 	},
 /area/prison/security/monitoring/medsec/south)
+"dil" = (
+/obj/structure/window/framed/prison/reinforced/hull,
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating,
+/area/prison/medbay)
+"dpL" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/closed/wall/prison,
+/area/prison/residential/central)
+"dqy" = (
+/obj/structure/window/framed/prison/reinforced/hull,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/prison/hangar/main)
+"dZt" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/wall/r_wall/prison,
+/area/prison/medbay)
+"elB" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/wall/r_wall/prison,
+/area/prison/security/checkpoint/medsec)
 "exP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -52988,6 +53111,12 @@
 	},
 /turf/open/floor/prison,
 /area/prison/cellblock/mediumsec/north)
+"fug" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/closed/wall/r_wall/prison,
+/area/prison/security/checkpoint/hangar)
 "fvh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -53000,11 +53129,48 @@
 	dir = 4
 	},
 /area/prison/cellblock/highsec/north/north)
+"fBs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/hangar/main)
+"geX" = (
+/obj/structure/window/framed/prison/reinforced,
+/obj/machinery/door/poddoor/shutters/timed_late{
+	dir = 2
+	},
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating,
+/area/prison/security/checkpoint/highsec/n)
 "gnb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison/red/corner,
 /area/prison/cellblock/highsec/north/south)
+"gHF" = (
+/obj/structure/window/framed/prison/reinforced,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/prison/hangar/main)
+"hHw" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/closed/wall/r_wall/prison_unmeltable,
+/area/prison/hangar/civilian)
+"hOV" = (
+/obj/structure/window/framed/prison/reinforced/hull,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/prison/hangar/main)
 "hYD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -53031,6 +53197,10 @@
 	},
 /turf/open/floor/prison/red/corner,
 /area/prison/cellblock/highsec/south/north)
+"izb" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/wall/r_wall/prison,
+/area/prison/laundry)
 "iOM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -53040,6 +53210,12 @@
 	},
 /turf/open/floor/prison/red,
 /area/prison/cellblock/highsec/north/north)
+"iVk" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 8
+	},
+/turf/closed/wall/r_wall/prison_unmeltable,
+/area/prison/hangar/main)
 "jlg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
@@ -53075,6 +53251,26 @@
 	dir = 1
 	},
 /area/prison/cellblock/highsec/north/south)
+"jNN" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/wall/r_wall/prison,
+/area/prison/security/checkpoint/highsec/n)
+"jUb" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/wall/r_wall/prison,
+/area/prison/security/checkpoint/maxsec)
+"jWq" = (
+/obj/structure/window/framed/prison/reinforced,
+/obj/machinery/door/poddoor/shutters/timed_late{
+	dir = 2
+	},
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating,
+/area/prison/security/checkpoint/highsec/s)
+"keG" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/wall/r_wall/prison,
+/area/prison/holding/holding2)
 "kxK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -53099,6 +53295,18 @@
 	dir = 4
 	},
 /area/prison/cellblock/highsec/north/south)
+"kVF" = (
+/obj/machinery/button/door/open_only/landing_zone/lz2{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/prison/hangar/civilian)
 "laO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -53111,6 +53319,11 @@
 	dir = 1
 	},
 /area/prison/cellblock/highsec/south/north)
+"lue" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/shuttle/shuttle_control/dropship1,
+/turf/open/floor/plating,
+/area/prison/hangar/civilian)
 "mrj" = (
 /obj/effect/landmark/corpsespawner/prison_security,
 /turf/open/floor/prison/yellow/corner{
@@ -53146,6 +53359,12 @@
 	dir = 8
 	},
 /area/prison/cellblock/mediumsec/north)
+"nYp" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
+	},
+/turf/closed/wall/r_wall/prison_unmeltable,
+/area/prison/hangar/main)
 "oiK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -53153,6 +53372,13 @@
 	dir = 4
 	},
 /area/prison/cellblock/mediumsec/south)
+"pOU" = (
+/obj/structure/window/framed/prison/reinforced/hull,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/prison/hangar/main)
 "pWz" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
@@ -53169,6 +53395,18 @@
 	dir = 8
 	},
 /area/prison/cellblock/mediumsec/south)
+"rqn" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/wall/r_wall/prison,
+/area/prison/quarters/research)
+"rtx" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/wall/r_wall/prison_unmeltable,
+/area/prison/hallway/central)
+"rQL" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/wall/r_wall/prison,
+/area/prison/security/checkpoint/highsec/s)
 "rTg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -53181,6 +53419,10 @@
 	dir = 4
 	},
 /area/prison/cellblock/mediumsec/south)
+"shN" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/prison,
+/area/prison/residential/central)
 "sjM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -53196,6 +53438,22 @@
 	dir = 4
 	},
 /area/prison/cellblock/mediumsec/west)
+"sXw" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/wall/r_wall/prison,
+/area/prison/library)
+"tow" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/wall/r_wall/prison,
+/area/prison/engineering)
+"tGu" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/wall/r_wall/prison,
+/area/prison/storage/medsec)
+"tPJ" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/wall/r_wall/prison_unmeltable,
+/area/prison/canteen)
 "udZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -53209,6 +53467,16 @@
 	icon_state = "bright_clean";
 	dir = 10
 	},
+/area/prison/hallway/central)
+"upV" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 8
+	},
+/turf/closed/wall/r_wall/prison,
+/area/prison/security/checkpoint/hangar)
+"uFs" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/wall/r_wall/prison,
 /area/prison/hallway/central)
 "uUB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -53252,6 +53520,25 @@
 	},
 /turf/open/floor/prison,
 /area/prison/cellblock/vip)
+"vpQ" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/prison{
+	icon_state = "bright_clean";
+	dir = 10
+	},
+/area/prison/chapel)
+"vqR" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/wall/r_wall/prison,
+/area/prison/research)
+"vNM" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/prison,
+/area/prison/security/checkpoint/highsec/n)
+"vPu" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/wall/r_wall/prison,
+/area/prison/canteen)
 "xHS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -53259,6 +53546,10 @@
 	dir = 4
 	},
 /area/prison/cellblock/highsec/south/north)
+"xRY" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/wall/r_wall/prison,
+/area/prison/storage/vip)
 "yhS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -53271,6 +53562,11 @@
 	dir = 1
 	},
 /area/prison/cellblock/mediumsec/south)
+"ykl" = (
+/obj/structure/window/framed/prison/reinforced,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/plating,
+/area/prison/residential/central)
 
 (1,1,1) = {"
 aab
@@ -55200,6 +55496,7 @@ aok
 aok
 aok
 aok
+lue
 aok
 aok
 aok
@@ -55215,8 +55512,7 @@ aok
 aok
 aok
 aok
-aok
-aok
+kVF
 amu
 aab
 aab
@@ -58788,7 +59084,7 @@ aSN
 aEv
 aSN
 aSN
-amu
+bFG
 apA
 aok
 aAB
@@ -58815,7 +59111,7 @@ bcM
 cts
 aok
 aok
-amu
+hHw
 bxf
 bxf
 bfX
@@ -59302,7 +59598,7 @@ aEJ
 aRS
 aRS
 aRS
-amu
+bFG
 aqj
 ays
 ays
@@ -59329,7 +59625,7 @@ aQP
 ays
 ays
 ays
-amu
+hHw
 bwu
 bwu
 bwu
@@ -59559,7 +59855,7 @@ aTW
 aRS
 aab
 aab
-amu
+bFG
 aqk
 ays
 aAC
@@ -59586,7 +59882,7 @@ aAC
 aAC
 aAC
 aAC
-amu
+hHw
 aab
 aab
 bwu
@@ -59817,32 +60113,32 @@ aRS
 aWn
 aWn
 aZP
-aWr
-aWr
-aWr
-aWr
-aWr
-aWr
-bga
-bga
-bga
-aWr
-bcQ
+dpL
+dpL
+dpL
+dpL
+dpL
+dpL
+ykl
+ykl
+ykl
+dpL
+shN
 blI
-bga
-bga
-bcQ
+ykl
+ykl
+shN
 blI
-aWr
-bga
-bga
-bga
-aWr
-aWr
-aWr
-aWr
-aWr
-aWr
+dpL
+ykl
+ykl
+ykl
+dpL
+dpL
+dpL
+dpL
+dpL
+dpL
 aZP
 aWn
 aWn
@@ -81929,12 +82225,12 @@ bgN
 bgN
 bfp
 bkj
-bfq
+xRY
 bmu
 bgN
 boq
 bpD
-bfq
+xRY
 bqZ
 bfp
 bfp
@@ -82165,10 +82461,10 @@ aKH
 aKd
 aLY
 aKH
-aKH
-bcb
+jNN
+vNM
 aPk
-aKH
+jNN
 aKH
 aLY
 aLY
@@ -82421,12 +82717,12 @@ axM
 aKI
 aKn
 aLZ
-aKH
+jNN
 aNl
 aNO
 aPn
 aQL
-aKH
+jNN
 aTe
 aUj
 aUj
@@ -82443,12 +82739,12 @@ bgN
 bfp
 bfp
 bkl
-bfq
+xRY
 bdh
 bnv
 bor
 bpF
-bfq
+xRY
 brb
 bfp
 bfp
@@ -82678,12 +82974,12 @@ axM
 aKJ
 aLn
 aMa
-aov
+geX
 aNj
 aAk
 aPp
 aQJ
-aov
+geX
 aTf
 aUk
 aVx
@@ -82695,22 +82991,22 @@ bbj
 bcc
 bcb
 bfq
-bfq
-bfq
-bfq
-bfq
-bfq
+xRY
+xRY
+xRY
+xRY
+xRY
 bfq
 bmx
 bmx
 bos
 bmx
 bfq
-bfq
-bfq
-bfq
-bfq
-bfq
+xRY
+xRY
+xRY
+xRY
+xRY
 bfq
 bwN
 bwN
@@ -82935,12 +83231,12 @@ axM
 aKK
 aLo
 aMb
-aov
+geX
 aNm
 aAo
 aPq
 aQM
-aov
+geX
 aMb
 aUp
 aVV
@@ -82951,7 +83247,7 @@ aKK
 bbg
 bbg
 bbg
-bsY
+uFs
 aKN
 aAR
 aKN
@@ -82968,7 +83264,7 @@ aKN
 aKN
 aKN
 aAR
-bsY
+uFs
 bvN
 bvN
 bvN
@@ -83192,22 +83488,22 @@ axM
 aKL
 aLp
 aMc
-aov
+geX
 aNn
 aNO
 aPr
 aQN
-aov
+geX
 aMc
 aUm
 aVz
 aVz
 aYc
-aKH
-aKH
-aKH
-aKH
-aKH
+jNN
+jNN
+jNN
+jNN
+jNN
 bsY
 aKN
 aKN
@@ -83226,22 +83522,22 @@ aKN
 aKN
 aKN
 bsY
-bvM
-bvM
-bvM
-bvM
+rQL
+rQL
+rQL
+rQL
 bvM
 bzQ
 bBf
 bCn
 bDM
 bFi
-aqp
+jWq
 bHv
 bIz
 bJK
 bKA
-aqp
+jWq
 bFi
 bBf
 bNC
@@ -83487,7 +83783,7 @@ bvc
 bvc
 bvc
 bvc
-bvM
+rQL
 bzR
 bzR
 bzR
@@ -83702,7 +83998,7 @@ ayI
 aBn
 ayI
 aBn
-axM
+abk
 aKN
 aAR
 aKN
@@ -83759,7 +84055,7 @@ aKN
 aKN
 aKN
 aMM
-bOq
+izb
 bNN
 bQW
 bSE
@@ -83959,7 +84255,7 @@ ayH
 azB
 ayH
 azo
-axM
+abk
 aKN
 azC
 aLu
@@ -84016,7 +84312,7 @@ aLu
 aLu
 bAe
 aKN
-bOq
+izb
 bQV
 bQV
 bSA
@@ -84473,7 +84769,7 @@ aCH
 aCH
 aCH
 aCH
-aCH
+vpQ
 aKP
 aPt
 aKN
@@ -84730,7 +85026,7 @@ aEa
 aEa
 aHI
 axM
-axM
+abk
 aKN
 aPt
 aKN
@@ -84787,7 +85083,7 @@ aKN
 aKN
 aPt
 aKN
-bOq
+izb
 bQV
 bRb
 bSA
@@ -84987,7 +85283,7 @@ aFk
 auK
 aHJ
 azA
-axM
+abk
 aKQ
 aPt
 aKN
@@ -85044,7 +85340,7 @@ aKN
 aOj
 aPt
 aOj
-bOq
+izb
 bGP
 bIj
 bKG
@@ -85240,10 +85536,10 @@ aAm
 axM
 axM
 axM
-axM
-axM
-axM
-axM
+abk
+abk
+abk
+abk
 axM
 aIH
 aPt
@@ -85302,10 +85598,10 @@ aOj
 aPt
 aKN
 bPz
-bPz
-bPz
-bPz
-bPz
+elB
+elB
+elB
+elB
 bPz
 bGm
 bXf
@@ -85496,7 +85792,7 @@ axO
 aAn
 aBp
 aCK
-aCW
+jUb
 aFl
 axN
 aHK
@@ -86524,7 +86820,7 @@ axO
 axO
 axO
 axY
-aCW
+jUb
 aCW
 aGx
 aGx
@@ -86591,7 +86887,7 @@ bPE
 bPE
 bPE
 bPz
-bPz
+elB
 bNH
 bXe
 cae
@@ -86781,7 +87077,7 @@ axO
 azZ
 axO
 aCO
-aCW
+jUb
 aGy
 aGa
 aGa
@@ -86848,7 +87144,7 @@ bvQ
 bAo
 bBE
 bHB
-bPz
+elB
 bTI
 ccW
 caf
@@ -87552,7 +87848,7 @@ axO
 axO
 axO
 aCR
-aCW
+jUb
 aGy
 aGa
 aGa
@@ -87619,7 +87915,7 @@ bAl
 bIP
 bJQ
 bHB
-bPz
+elB
 bKk
 ccU
 cai
@@ -87809,7 +88105,7 @@ axO
 axO
 axO
 aCR
-aCW
+jUb
 aCW
 aGx
 aGx
@@ -87876,7 +88172,7 @@ bPE
 bPE
 bPE
 bPz
-bPz
+elB
 bUh
 bXe
 cae
@@ -88647,7 +88943,7 @@ bPB
 bRm
 bSQ
 bUv
-bPz
+elB
 bXe
 bXe
 cak
@@ -88837,7 +89133,7 @@ axR
 axR
 aBq
 aCV
-aCW
+jUb
 aCZ
 aGq
 aHR
@@ -88904,7 +89200,7 @@ bPK
 bRn
 bSR
 bUw
-bPz
+elB
 bXe
 bXe
 cae
@@ -89157,10 +89453,10 @@ aKP
 bKT
 aKT
 bPL
-bPL
-bPL
-bPL
-bPL
+tGu
+tGu
+tGu
+tGu
 bPL
 bIg
 bPL
@@ -89356,7 +89652,7 @@ aFs
 aGD
 aHS
 aFt
-aCW
+jUb
 aKQ
 aPt
 aKN
@@ -89413,7 +89709,7 @@ aKN
 aKN
 aPt
 aKN
-bPL
+tGu
 bPM
 bPN
 bSS
@@ -89613,7 +89909,7 @@ axO
 axO
 aHT
 aGF
-aCW
+jUb
 aKN
 aPt
 aOj
@@ -89670,7 +89966,7 @@ aKN
 aKN
 aPt
 aKN
-bPL
+tGu
 bHl
 bPN
 bPN
@@ -89870,7 +90166,7 @@ axR
 aGE
 aHU
 aIX
-aCW
+jUb
 aKN
 aLl
 aLx
@@ -89927,7 +90223,7 @@ btr
 btr
 aMe
 aKN
-bPL
+tGu
 bPO
 bRo
 bMy
@@ -90127,7 +90423,7 @@ aFt
 aGF
 axj
 aIY
-aCW
+jUb
 aKN
 aKN
 aKN
@@ -90184,7 +90480,7 @@ aKN
 aKN
 aKN
 aKN
-bPL
+tGu
 bPP
 bRp
 bQw
@@ -90384,7 +90680,7 @@ apt
 apt
 aHV
 apt
-apt
+dZt
 aKU
 aKU
 aKU
@@ -90641,7 +90937,7 @@ aFu
 aGG
 aqv
 aIZ
-ayN
+dil
 aab
 aab
 aab
@@ -90898,7 +91194,7 @@ apM
 aqY
 aHW
 aJa
-ayN
+dil
 aab
 aab
 aab
@@ -91155,7 +91451,7 @@ aFv
 aGH
 aHX
 aJb
-apt
+dZt
 aKU
 aKU
 aKU
@@ -91412,7 +91708,7 @@ aFw
 aGI
 aHY
 aJc
-apt
+dZt
 aKN
 aKN
 aKN
@@ -91469,7 +91765,7 @@ aKN
 aKN
 aKN
 aAR
-bPL
+tGu
 bPT
 bPT
 bQy
@@ -91669,7 +91965,7 @@ aFx
 aGJ
 aFx
 aFx
-apt
+dZt
 aAR
 aLm
 aLx
@@ -91726,7 +92022,7 @@ btr
 btr
 aLz
 aKN
-bPL
+tGu
 bPO
 bRo
 bSY
@@ -91983,7 +92279,7 @@ aKN
 aKN
 aPt
 aKN
-bPL
+tGu
 bHl
 bPN
 bPN
@@ -92240,7 +92536,7 @@ aKN
 aKN
 aPt
 aKN
-bPL
+tGu
 bPU
 bPN
 bPN
@@ -92497,7 +92793,7 @@ aKT
 aKN
 bKU
 aKT
-bPL
+tGu
 bPN
 bPN
 bSZ
@@ -92754,7 +93050,7 @@ bLj
 aLv
 bAB
 bND
-bPL
+tGu
 bPL
 bPL
 bPL
@@ -93525,7 +93821,7 @@ aKN
 aKN
 aPt
 aMM
-bPX
+sXw
 bPX
 bPX
 bPX
@@ -93782,7 +94078,7 @@ aKN
 aKN
 aPt
 aKN
-bPX
+sXw
 bPY
 bRu
 bTc
@@ -94039,7 +94335,7 @@ aKN
 aKN
 aPt
 aKN
-bPX
+sXw
 bPY
 bRv
 bRv
@@ -94296,7 +94592,7 @@ aKN
 aKN
 aPt
 aOj
-bPX
+sXw
 bPY
 bRu
 bRv
@@ -94553,7 +94849,7 @@ bLj
 aLv
 bAB
 bND
-bPX
+sXw
 bPZ
 bIW
 bRv
@@ -94753,7 +95049,7 @@ aAc
 aGN
 aFz
 aIc
-bsY
+uFs
 aKR
 aJZ
 aLv
@@ -95524,7 +95820,7 @@ aqn
 aGP
 aIc
 aIc
-bsY
+uFs
 aKN
 aPt
 aKN
@@ -95781,7 +96077,7 @@ avB
 aGR
 aId
 avB
-aAv
+vqR
 aKN
 aPt
 aKN
@@ -95838,7 +96134,7 @@ aKN
 aKN
 aPt
 aKN
-bPX
+sXw
 bPZ
 bPY
 bTe
@@ -96038,7 +96334,7 @@ aFI
 aGR
 avE
 aJg
-aAv
+vqR
 aKN
 aLr
 aKN
@@ -96095,7 +96391,7 @@ aKN
 aAR
 aPt
 aKN
-bPX
+sXw
 bQc
 bRv
 bTf
@@ -96295,7 +96591,7 @@ aFJ
 aGT
 aIe
 aJh
-aAv
+vqR
 aIH
 aPt
 aKN
@@ -96352,7 +96648,7 @@ aKN
 aKN
 aPt
 aKN
-bPX
+sXw
 bQd
 bRv
 bRv
@@ -96552,7 +96848,7 @@ aFK
 aGR
 avE
 aJi
-aAv
+vqR
 aKN
 aPt
 aKN
@@ -96609,7 +96905,7 @@ aKN
 aKN
 aPt
 aOj
-bPX
+sXw
 bQd
 bRv
 bTg
@@ -96809,7 +97105,7 @@ avB
 aGR
 aIf
 avB
-aAv
+vqR
 aKN
 aPt
 aKN
@@ -96866,7 +97162,7 @@ aKN
 aKN
 aPt
 aKN
-bPX
+sXw
 bPX
 bPX
 bPX
@@ -97066,7 +97362,7 @@ aEs
 aGU
 aIg
 aJj
-aAv
+vqR
 aKN
 aPt
 aKN
@@ -97123,7 +97419,7 @@ aKN
 aKN
 aPt
 aKN
-bQi
+tow
 bQe
 bQe
 bQe
@@ -97323,7 +97619,7 @@ aFL
 aGS
 arQ
 aJk
-aAv
+vqR
 aKQ
 aPt
 aKN
@@ -97380,7 +97676,7 @@ aKN
 aKN
 aPt
 aKN
-bQi
+tow
 bQf
 bRA
 bRA
@@ -97580,7 +97876,7 @@ arR
 aGW
 atM
 aIF
-aAv
+vqR
 aKN
 aLt
 aLu
@@ -97637,7 +97933,7 @@ aLu
 aLu
 bCM
 aKN
-bQi
+tow
 bHo
 cuT
 cuT
@@ -97837,7 +98133,7 @@ aFM
 aGX
 aIh
 aIx
-aAv
+vqR
 aKN
 aKN
 aKN
@@ -97894,7 +98190,7 @@ aKN
 bcq
 aKN
 aKN
-bQi
+tow
 bQh
 bQh
 bQh
@@ -98095,16 +98391,16 @@ aDy
 aDy
 aJm
 aDA
-aDA
-aDA
-aDA
-aDA
-aDA
+rqn
+rqn
+rqn
+rqn
+rqn
 aOk
 aPL
 aRf
 aOk
-aKa
+rtx
 bkO
 aVS
 bkO
@@ -98143,14 +98439,14 @@ bCG
 bEy
 bEm
 bCG
-bDz
+keG
 bEY
-bDz
-bDz
-bDz
-bDz
-bDz
-bDz
+keG
+keG
+keG
+keG
+keG
+keG
 bDz
 bQi
 bRC
@@ -98361,7 +98657,7 @@ aOl
 aPM
 aOl
 aOl
-aKa
+rtx
 aUZ
 aVS
 aUZ
@@ -98386,7 +98682,7 @@ aKN
 aKN
 aVS
 aUZ
-bsY
+uFs
 btZ
 buX
 bvV
@@ -98618,7 +98914,7 @@ aOm
 aPN
 aRg
 aOm
-aKa
+rtx
 aUZ
 aVS
 aUZ
@@ -98628,12 +98924,12 @@ aVS
 aUZ
 aVS
 aUZ
-aKa
+rtx
 aVa
 aVa
 bhP
 aVa
-aKa
+rtx
 aUZ
 aUZ
 aUZ
@@ -98643,7 +98939,7 @@ aKN
 aKN
 aVS
 aUZ
-bsY
+uFs
 bua
 bua
 bua
@@ -98876,30 +99172,30 @@ aPO
 aRh
 aSq
 aTE
-aTE
-aTE
-aTE
-aTE
-aTE
-aTE
-aTE
-aTE
-aTE
+tPJ
+tPJ
+tPJ
+tPJ
+tPJ
+tPJ
+tPJ
+tPJ
+tPJ
 aTE
 bfC
 bha
 big
 bfC
 aTF
-aTF
-aTF
-aTF
-aTF
-aTF
-aTF
-aTF
-aTF
-aTF
+vPu
+vPu
+vPu
+vPu
+vPu
+vPu
+vPu
+vPu
+vPu
 aTF
 bub
 bua
@@ -110195,22 +110491,22 @@ adO
 adO
 adO
 aXu
-aXu
-aXu
-aXu
-aXt
-bhw
-bkD
+dqy
+dqy
+dqy
+iVk
+gHF
+fBs
 bnN
-bhw
-bhw
+gHF
+gHF
 bqD
 boJ
 bsc
-aXt
-aXu
-aXu
-aXu
+iVk
+dqy
+dqy
+dqy
 aXu
 adO
 adO
@@ -110451,7 +110747,7 @@ aXr
 aab
 aab
 aab
-aXu
+hOV
 bht
 bfU
 bjH
@@ -110468,7 +110764,7 @@ bhw
 btu
 but
 bvi
-aXu
+pOU
 aab
 aab
 aab
@@ -110708,7 +111004,7 @@ aXr
 aab
 aab
 aab
-aXu
+hOV
 bhu
 biI
 bjI
@@ -110725,7 +111021,7 @@ bsT
 bjI
 buu
 bvj
-aXu
+pOU
 aab
 aab
 aab
@@ -110965,7 +111261,7 @@ aXr
 aab
 aab
 aab
-aXu
+hOV
 bhv
 biJ
 bjJ
@@ -110982,7 +111278,7 @@ bhw
 btv
 biJ
 bvk
-aXu
+pOU
 aab
 aab
 aab
@@ -111221,7 +111517,7 @@ aXp
 aXr
 adO
 aXt
-aXu
+dqy
 bfS
 bhw
 bhw
@@ -111240,9 +111536,9 @@ bhw
 bhw
 bhw
 aXt
-aXu
-aXu
-aXu
+dqy
+dqy
+dqy
 aXt
 bAG
 bBI
@@ -111477,7 +111773,7 @@ aZN
 baD
 aXr
 aab
-aXt
+nYp
 beu
 bcD
 aYM
@@ -111732,8 +112028,8 @@ aXt
 aYL
 aYL
 aYL
-aXt
-aXt
+iVk
+iVk
 aXt
 aVm
 aYM
@@ -111758,10 +112054,10 @@ bnQ
 bnQ
 bmw
 bzi
-bzi
+upV
 byu
 bDb
-bzi
+upV
 bzi
 bDQ
 bGK
@@ -112019,7 +112315,7 @@ bAI
 byv
 bBj
 bAN
-bzi
+fug
 bDR
 bGL
 bHZ
@@ -112276,7 +112572,7 @@ bAJ
 bBM
 bDd
 bBQ
-bzi
+fug
 bGI
 bGL
 bIa
@@ -112533,7 +112829,7 @@ bAK
 bzU
 bDe
 bDh
-bzi
+fug
 bzS
 bGM
 bIb
@@ -112790,7 +113086,7 @@ bAL
 bBO
 bDf
 bEO
-bzi
+fug
 bEF
 bGO
 bIc

--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -27,6 +27,7 @@
 
 #define SPACE_LAYER 1.8
 
+#define UNDER_TURF_LAYER 1.99
 #define ABOVE_TURF_LAYER 2.01
 
 #define LATTICE_LAYER 2.15

--- a/code/datums/gamemodes/game_mode.dm
+++ b/code/datums/gamemodes/game_mode.dm
@@ -291,7 +291,7 @@
 		while(GLOB.fog_blocker_locations.len)
 			T = GLOB.fog_blocker_locations[GLOB.fog_blocker_locations.len]
 			GLOB.fog_blocker_locations.len--
-			new /obj/effect/forcefield/fog/xeno(T)
+			new /obj/effect/forcefield/fog(T)
 		addtimer(CALLBACK(src, .proc/remove_fog), FOG_DELAY_INTERVAL + SSticker.round_start_time + rand(-5 MINUTES, 5 MINUTES))
 
 		addtimer(CALLBACK(GLOBAL_PROC, .proc/send_global_signal, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_LATE), SSticker.round_start_time + 50 MINUTES)

--- a/code/datums/gamemodes/game_mode.dm
+++ b/code/datums/gamemodes/game_mode.dm
@@ -291,7 +291,7 @@
 		while(GLOB.fog_blocker_locations.len)
 			T = GLOB.fog_blocker_locations[GLOB.fog_blocker_locations.len]
 			GLOB.fog_blocker_locations.len--
-			new /obj/effect/forcefield/fog(T)
+			new /obj/effect/forcefield/fog/xeno(T)
 		addtimer(CALLBACK(src, .proc/remove_fog), FOG_DELAY_INTERVAL + SSticker.round_start_time + rand(-5 MINUTES, 5 MINUTES))
 
 		addtimer(CALLBACK(GLOBAL_PROC, .proc/send_global_signal, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_LATE), SSticker.round_start_time + 50 MINUTES)

--- a/code/datums/gamemodes/game_mode.dm
+++ b/code/datums/gamemodes/game_mode.dm
@@ -294,9 +294,7 @@
 			new /obj/effect/forcefield/fog(T)
 		addtimer(CALLBACK(src, .proc/remove_fog), FOG_DELAY_INTERVAL + SSticker.round_start_time + rand(-5 MINUTES, 5 MINUTES))
 
-	switch(SSmapping.configs[GROUND_MAP].map_name)
-		if(MAP_PRISON_STATION)
-			addtimer(CALLBACK(GLOBAL_PROC, .proc/send_global_signal, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_LATE), SSticker.round_start_time + 50 MINUTES)
+		addtimer(CALLBACK(GLOBAL_PROC, .proc/send_global_signal, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_LATE), SSticker.round_start_time + 50 MINUTES)
 			//Called late because there used to be shutters opened earlier. To re-add them just copy the logic.
 
 

--- a/code/game/objects/effects/landmarks/mode.dm
+++ b/code/game/objects/effects/landmarks/mode.dm
@@ -13,6 +13,10 @@
 	return INITIALIZE_HINT_QDEL
 
 
+/obj/effect/landmark/lv624/fog_blocker/xeno
+	name = "xeno fog blocker"
+
+
 /obj/effect/landmark/xeno_tunnel
 	name = "xeno tunnel"
 	icon_state = "tunnel_spawn"

--- a/code/game/objects/effects/landmarks/mode.dm
+++ b/code/game/objects/effects/landmarks/mode.dm
@@ -13,10 +13,6 @@
 	return INITIALIZE_HINT_QDEL
 
 
-/obj/effect/landmark/lv624/fog_blocker/xeno
-	name = "xeno fog blocker"
-
-
 /obj/effect/landmark/xeno_tunnel
 	name = "xeno tunnel"
 	icon_state = "tunnel_spawn"

--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -108,6 +108,13 @@
 /obj/effect/forcefield/fog/attack_animal(M)
 	return attack_hand(M)
 
+
+/obj/effect/forcefield/fog/xeno/CanPass(atom/movable/mover, turf/target)
+	if(isxeno(mover))
+		return TRUE
+	return FALSE
+
+
 //used to control opacity of multitiles doors
 /obj/effect/opacifier
 	density = FALSE

--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -109,7 +109,7 @@
 	return attack_hand(M)
 
 
-/obj/effect/forcefield/fog/xeno/CanPass(atom/movable/mover, turf/target)
+/obj/effect/forcefield/fog/CanPass(atom/movable/mover, turf/target)
 	if(isxeno(mover))
 		return TRUE
 	return FALSE

--- a/code/game/objects/machinery/buttons.dm
+++ b/code/game/objects/machinery/buttons.dm
@@ -98,6 +98,7 @@
 /obj/machinery/button/door/open_only/landing_zone
 	name = "lockdown override"
 	id = "landing_zone"
+	use_power = NO_POWER_USE
 
 
 /obj/machinery/button/door/open_only/landing_zone/lz2

--- a/code/game/objects/machinery/buttons.dm
+++ b/code/game/objects/machinery/buttons.dm
@@ -95,6 +95,15 @@
 	specialfunctions = DOOR_FLAG_OPEN_ONLY
 
 
+/obj/machinery/button/door/open_only/landing_zone
+	name = "lockdown override"
+	id = "landing_zone"
+
+
+/obj/machinery/button/door/open_only/landing_zone/lz2
+	id = "landing_zone_2"
+
+
 /obj/machinery/driver_button
 	name = "mass driver button"
 	icon = 'icons/obj/objects.dmi'

--- a/code/game/objects/machinery/doors/poddoor.dm
+++ b/code/game/objects/machinery/doors/poddoor.dm
@@ -117,3 +117,19 @@
 /obj/machinery/door/poddoor/timed_late/Initialize()
 	RegisterSignal(SSdcs, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_LATE, .proc/open)
 	return ..()
+
+
+/obj/machinery/door/poddoor/timed_late/containment
+	name = "Containment shutters"
+	desc = "Safety shutters triggered by some kind of lockdown event."
+	resistance_flags = UNACIDABLE|INDESTRUCTIBLE
+	open_layer = UNDER_TURF_LAYER //No longer needs to be interacted with.
+	closed_layer = ABOVE_WINDOW_LAYER //Higher than usual, this is only around on the start of the round.
+
+
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone
+	id = "landing_zone"
+
+
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2
+	id = "landing_zone_2"


### PR DESCRIPTION
The intent here is dealing with early rushes.
The marine shutters should give the engineers some time to build a minimal FOB.
The fog should allow xenos to retain a safe haven from where to stage attacks.
Both should be gone by around one hour into the round.
If this goes well we can expand it on other maps and remove the anti-rush rules.

## Changelog
:cl:
add: Tweaked all ground maps. They will all have LV-like fog protecting areas, but it can be crossed by xenos at will. The marines gain shutters on both landing zones only they can open (and not close), from inside.
add: Added a dropship consoles to every LZ.
/:cl:
