### PR TITLE
Buckle parent logic

### DIFF
--- a/code/game/objects/machinery/OpTable.dm
+++ b/code/game/objects/machinery/OpTable.dm
@@ -65,9 +65,6 @@
 	. = ..()
 	if(.)
 		return
-	if(buckled_mob)
-		unbuckle(user)
-		return
 	if(anes_tank)
 		user.put_in_active_hand(anes_tank)
 		to_chat(user, "<span class='notice'>You remove \the [anes_tank] from \the [src].</span>")

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -138,7 +138,7 @@
 
 /obj/proc/unbuckle(mob/user, silent = TRUE)
 	if(!buckled_mob || buckled_mob.buckled != src)
-		CRASH("[src] called unbuckle() with [user ? user : "no"] user and [buckled_mob ? (buckled_mob.buckled ? " with [buckled_mob.buckled] as buckled_mob.buckled" : "no buckled_mob.buckled") : "no buckled_mob"].")
+		CRASH("[src] called unbuckle() with [user ? user : "no"] user and [buckled_mob ? (buckled_mob.buckled ? "with [buckled_mob.buckled] as buckled_mob.buckled" : "no buckled_mob.buckled") : "no buckled_mob"].")
 	buckled_mob.buckled = null
 	buckled_mob.anchored = initial(buckled_mob.anchored)
 	buckled_mob.update_canmove()
@@ -146,13 +146,13 @@
 	if(!silent)
 		if(buckled_mob == user)
 			buckled_mob.visible_message(
-			"<span class='notice'>[buckled_mob.name] was unbuckled by [user]!</span>",
-			"<span class='notice'>You were unbuckled from [src] by [user].</span>",
-			"<span class='notice'>You hear metal clanking.</span>"
+			"<span class='notice'>[buckled_mob] unbuckled [buckled_mob.p_them()]self!</span>",
+			"<span class='notice'>You unbuckle yourself from [src].</span>",
+			"<span class='notice'>You hear metal clanking</span>"
 			)
 		else
 			buckled_mob.visible_message(
-			"<span class='notice'>[buckled_mob.name] was unbuckled by [user]!</span>",
+			"<span class='notice'>[buckled_mob] was unbuckled by [user]!</span>",
 			"<span class='notice'>You were unbuckled from [src] by [user].</span>",
 			"<span class='notice'>You hear metal clanking.</span>"
 			)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -113,9 +113,9 @@
 /obj/attack_hand(mob/living/user)
 	. = ..()
 	if(.)
-		return
+		return FALSE
 	if(can_buckle) 
-		manual_unbuckle(user)
+		return manual_unbuckle(user)
 
 
 /obj/proc/handle_rotation()
@@ -135,17 +135,32 @@
 	handle_rotation()
 	return buckled_mob
 
-/obj/proc/unbuckle()
-	if(buckled_mob)
-		if(buckled_mob.buckled == src)	//this is probably unneccesary, but it doesn't hurt
-			buckled_mob.buckled = null
-			buckled_mob.anchored = initial(buckled_mob.anchored)
-			buckled_mob.update_canmove()
 
-			var/M = buckled_mob
-			buckled_mob = null
-			UnregisterSignal(M, COMSIG_LIVING_DO_RESIST)
-			afterbuckle(M)
+/obj/proc/unbuckle(mob/user, silent = TRUE)
+	if(!buckled_mob || buckled_mob.buckled != src)
+		CRASH("[src] called unbuckle() with [user ? user : "no"] user and [buckled_mob ? (buckled_mob.buckled ? " with [buckled_mob.buckled] as buckled_mob.buckled" : "no buckled_mob.buckled") : "no buckled_mob"].")
+	buckled_mob.buckled = null
+	buckled_mob.anchored = initial(buckled_mob.anchored)
+	buckled_mob.update_canmove()
+
+	if(!silent)
+		if(buckled_mob == user)
+			buckled_mob.visible_message(
+			"<span class='notice'>[buckled_mob.name] was unbuckled by [user]!</span>",
+			"<span class='notice'>You were unbuckled from [src] by [user].</span>",
+			"<span class='notice'>You hear metal clanking.</span>"
+			)
+		else
+			buckled_mob.visible_message(
+			"<span class='notice'>[buckled_mob.name] was unbuckled by [user]!</span>",
+			"<span class='notice'>You were unbuckled from [src] by [user].</span>",
+			"<span class='notice'>You hear metal clanking.</span>"
+			)
+
+	var/buckled_mob_backup = buckled_mob
+	buckled_mob = null
+	UnregisterSignal(buckled_mob_backup, COMSIG_LIVING_DO_RESIST)
+	afterbuckle(buckled_mob_backup)
 
 
 /obj/proc/resisted_against(datum/source, mob/user) //COMSIG_LIVING_DO_RESIST
@@ -154,23 +169,11 @@
 	manual_unbuckle(user)
 
 
-/obj/proc/manual_unbuckle(mob/user as mob)
-	if(buckled_mob)
-		if(buckled_mob.buckled == src)
-			if(buckled_mob != user)
-				buckled_mob.visible_message(\
-					"<span class='notice'>[buckled_mob.name] was unbuckled by [user.name]!</span>",\
-					"<span class='notice'>You were unbuckled from [src] by [user.name].</span>",\
-					"<span class='notice'>You hear metal clanking.</span>")
-			else
-				buckled_mob.visible_message(\
-					"<span class='notice'>[buckled_mob.name] unbuckled [buckled_mob.p_them()]self!</span>",\
-					"<span class='notice'>You unbuckle yourself from [src].</span>",\
-					"<span class='notice'>You hear metal clanking</span>")
-			unbuckle()
-			return 1
-
-	return 0
+/obj/proc/manual_unbuckle(mob/user)
+	if(!buckled_mob || buckled_mob.buckled != src)
+		return FALSE
+	unbuckle(user, FALSE)
+	return TRUE
 
 
 //trying to buckle a mob

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -32,7 +32,7 @@
 			icon_state = "[base_bed_icon]_down"
 
 obj/structure/bed/Destroy()
-	if(buckled_bodybag)
+	if(buckled_mob || buckled_bodybag)
 		unbuckle()
 	. = ..()
 
@@ -156,7 +156,8 @@ obj/structure/bed/Destroy()
 		playsound(src, hit_bed_sound, 25, 1)
 		M.visible_message("<span class='danger'>[M] slices [src] apart!</span>",
 		"<span class='danger'>We slice [src] apart!</span>", null, 5)
-		unbuckle()
+		if(buckled_mob || buckled_bodybag)
+			unbuckle()
 		destroy_structure()
 		SEND_SIGNAL(M, COMSIG_XENOMORPH_ATTACK_BED)
 	else attack_hand(M)
@@ -322,7 +323,8 @@ GLOBAL_LIST_EMPTY(activated_medevac_stretchers)
 	radio = new(src)
 
 /obj/structure/bed/medevac_stretcher/attack_alien(mob/living/carbon/xenomorph/M)
-	unbuckle()
+	if(buckled_mob || buckled_bodybag)
+		unbuckle()
 
 /obj/structure/bed/medevac_stretcher/Destroy()
 	QDEL_NULL(radio)

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -207,7 +207,8 @@
 		is_animating = 1
 		flick("shuttle_chair_new_folding", src)
 		is_animating = 0
-		unbuckle()
+		if(buckled_mob)
+			unbuckle()
 		if(break_it)
 			chair_state = DROPSHIP_CHAIR_BROKEN
 		else

--- a/code/modules/atmospherics/machinery/pipes/pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipes.dm
@@ -8,8 +8,6 @@
 	can_unwrench = 1
 	var/datum/pipeline/parent = null
 
-	//Buckling
-	can_buckle = FALSE
 	//buckle_requires_restraints = 1
 	buckle_lying = -1
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -682,8 +682,7 @@ mob/proc/yank_out_object()
 	if(!.)
 		return
 	stop_pulling()
-	if(buckled)
-		buckled.unbuckle()
+	buckled?.unbuckle()
 
 
 /mob/proc/trainteleport(atom/destination)

--- a/code/modules/vehicles/powerloader.dm
+++ b/code/modules/vehicles/powerloader.dm
@@ -39,14 +39,6 @@
 	. = ..()
 	if(.)
 		return
-	if(buckled_mob && user != buckled_mob)
-		buckled_mob.visible_message("<span class='warning'>[user] tries to move [buckled_mob] out of [src].</span>",\
-		"<span class='danger'>[user] tries to move you out of [src]!</span>")
-		var/olddir = dir
-		var/old_buckled_mob = buckled_mob
-		if(do_after(user, 30, TRUE, src, BUSY_ICON_HOSTILE) && dir == olddir && buckled_mob == old_buckled_mob)
-			manual_unbuckle(user)
-			playsound(loc, 'sound/mecha/powerloader_unbuckle.ogg', 25)
 	if(panel_open)
 		if(cell)
 			usr.put_in_hands(cell)
@@ -93,6 +85,26 @@
 		to_chat(user, "There is a [cell] in the [src] containing [cell.charge] charge.")
 	else
 		to_chat(user, "There is no power cell in the [src].")
+
+
+/obj/vehicle/powerloader/manual_unbuckle(mob/user)
+	if(!buckled_mob || buckled_mob.buckled != src)
+		return FALSE
+	if(user == buckled_mob)
+		playsound(loc, 'sound/mecha/powerloader_unbuckle.ogg', 25)
+		return ..()
+	buckled_mob.visible_message(
+		"<span class='warning'>[user] tries to move [buckled_mob] out of [src].</span>",
+		"<span class='danger'>[user] tries to move you out of [src]!</span>"
+		)
+	var/olddir = dir
+	var/old_buckled_mob = buckled_mob
+	if(!do_after(user, 3 SECONDS, TRUE, src, BUSY_ICON_HOSTILE) || dir != olddir || buckled_mob != old_buckled_mob)
+		return TRUE //True to intercept the click. No need for further actions after this.
+	. = ..()
+	if(.)
+		playsound(loc, 'sound/mecha/powerloader_unbuckle.ogg', 25)
+
 
 /obj/vehicle/powerloader/afterbuckle(mob/M)
 	. = ..()


### PR DESCRIPTION
Makes certain buckles follow parent logic where it was broken.

Fixes #2239 .
Also fixes the unreported bug of powerloader unbuckling of others not behaving correctly for the same reason.
Removes the useless `can_buckle = FALSE` definition from pipes, when that value is already such by default in the parents.

Should substitute #2259 .