### PR TITLE
Fixes mulebot wire runtime

### DIFF
--- a/code/game/objects/machinery/bots/mulebot.dm
+++ b/code/game/objects/machinery/bots/mulebot.dm
@@ -125,11 +125,9 @@
 	unload(0)
 	switch(severity)
 		if(2)
-			wires &= ~(1 << rand(0,9))
-			wires &= ~(1 << rand(0,9))
-			wires &= ~(1 << rand(0,9))
+			wires.cut_all()
 		if(3)
-			wires &= ~(1 << rand(0,9))
+			wires.cut_random()
 	..()
 	return
 
@@ -138,11 +136,7 @@
 		unload(0)
 	if(prob(25))
 		src.visible_message("<span class='warning'> Something shorts out inside [src]!</span>")
-		var/index = 1<< (rand(0,9))
-		if(wires & index)
-			wires &= ~index
-		else
-			wires |= index
+		wires.cut_random()
 	..()
 	return 1
 


### PR DESCRIPTION
```

[21:10:18] Runtime in mulebot.dm, line 142: type mismatch: /datum/wires/mulebot (/datum/wires/mulebot) & 512
proc name: bullet act (/obj/machinery/bot/mulebot/bullet_act)
usr: Noggin Clontith/(Gene Ric)
usr.loc: (Cargo Bay (135, 37, 2))
src: Mulebot (#1) (/obj/machinery/bot/mulebot)
src.loc: the floor (125,39,2) (/turf/open/floor/tile/whiteyellow/full)
call stack:
Mulebot (#1) (/obj/machinery/bot/mulebot): bullet act(the rifle bullet (/obj/item/projectile))
the rifle bullet (/obj/item/projectile): scan a turf(the floor (125,39,2) (/turf/open/floor/tile/whiteyellow/full))
the rifle bullet (/obj/item/projectile): follow flightpath(6, -4, 1, 20
```