### PR TITLE
Attachment ammo runtimes

### DIFF
--- a/code/modules/projectiles/updated_projectiles/guns/energy.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/energy.dm
@@ -238,7 +238,7 @@
 
 /obj/item/weapon/gun/energy/lasgun/load_into_chamber(mob/user)
 		//Let's check on the active attachable. It loads ammo on the go, so it never chambers anything
-	if(active_attachable)
+	if(active_attachable && active_attachable.flags_attach_features & ATTACH_PROJECTILE)
 		if(active_attachable.current_rounds > 0) //If it's still got ammo and stuff.
 			active_attachable.current_rounds--
 			return create_bullet(active_attachable.ammo)
@@ -260,7 +260,7 @@
 	This should only apply to the masterkey, since it's the only attachment that shoots through Fire()
 	instead of its own thing through fire_attachment(). If any other bullet attachments are added, they would fire here.
 	*/
-	if(active_attachable)
+	if(active_attachable && active_attachable.flags_attach_features & ATTACH_PROJECTILE)
 		make_casing(active_attachable.type_of_casings) // Attachables can drop their own casings.
 
 	if(!active_attachable && cell) //We don't need to check for the mag if an attachment was used to shoot.

--- a/code/modules/projectiles/updated_projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/revolvers.dm
@@ -178,7 +178,6 @@
 			return in_chamber
 
 /obj/item/weapon/gun/revolver/load_into_chamber(mob/user)
-//		if(active_attachable) active_attachable = null
 	if(ready_in_chamber())
 		return in_chamber
 	rotate_cylinder() //If we fail to return to chamber the round, we just move the firing pin some.

--- a/code/modules/projectiles/updated_projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/shotguns.dm
@@ -149,7 +149,7 @@ can cause issues with ammo types getting mixed up during the burst.
 	return ready_shotgun_tube()
 
 /obj/item/weapon/gun/shotgun/reload_into_chamber(mob/user)
-	if(active_attachable)
+	if(active_attachable && active_attachable.flags_attach_features & ATTACH_PROJECTILE)
 		make_casing(active_attachable.type_of_casings)
 	else
 		make_casing(type_of_casings)
@@ -476,7 +476,7 @@ can cause issues with ammo types getting mixed up during the burst.
 
 
 /obj/item/weapon/gun/shotgun/pump/reload_into_chamber(mob/user)
-	if(active_attachable)
+	if(active_attachable && active_attachable.flags_attach_features & ATTACH_PROJECTILE)
 		make_casing(active_attachable.type_of_casings)
 	else
 		pump_lock = FALSE //fired successfully; unlock the pump
@@ -630,7 +630,7 @@ can cause issues with ammo types getting mixed up during the burst.
 
 
 /obj/item/weapon/gun/shotgun/pump/reload_into_chamber(mob/user)
-	if(active_attachable)
+	if(active_attachable && active_attachable.flags_attach_features & ATTACH_PROJECTILE)
 		make_casing(active_attachable.type_of_casings)
 	else
 		pump_lock = FALSE //fired successfully; unlock the pump

--- a/code/modules/projectiles/updated_projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/specialist.dm
@@ -378,7 +378,6 @@
 			return FALSE
 
 /obj/item/weapon/gun/smartgun/load_into_chamber(mob/user)
-//	if(active_attachable) active_attachable = null
 	return ready_in_chamber()
 
 /obj/item/weapon/gun/smartgun/reload_into_chamber(mob/living/carbon/user)
@@ -809,7 +808,6 @@
 
 
 /obj/item/weapon/gun/launcher/rocket/load_into_chamber(mob/user)
-//	if(active_attachable) active_attachable = null
 	return ready_in_chamber()
 
 


### PR DESCRIPTION
Fixes some attachment ammo runtimes and removes some commented code.
Hopefully in the long run we'll be able to remove this attachment snowflake code and make guns more generic.