### PR TITLE
Fixes a HUD runtime

### DIFF
--- a/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_regular_hud_updates.dm
@@ -77,7 +77,7 @@
 		else
 			clear_fullscreen("brute")
 
-	if(hud_used.healths)
+	if(hud_used?.healths)
 		if(analgesic)
 			hud_used.healths.icon_state = "health_numb"
 		else


### PR DESCRIPTION
Toggling to a different style of hud means this won't always be present, and thus this check is necessary.