### PR TITLE
Fixes a world status runtime

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -178,7 +178,7 @@ GLOBAL_VAR_INIT(bypass_tgs_reboot, world.system_type == UNIX && world.byond_buil
 					s += "<br>Map: <a href='[CONFIG_GET(string/whiskeyoutposturl)]'><b>[map_name]</a></b>"
 				else
 					s += "<br>Map: <b>[map_name ? map_name : "Loading..."]</b>"
-			s += "<br>Mode: <b>[(Master.current_runlevel & RUNLEVELS_DEFAULT) ? SSticker.mode.name : "Lobby"]</b>"
+			s += "<br>Mode: <b>[SSticker.mode ? SSticker.mode.name : "Lobby"]</b>"
 			s += "<br>Round time: <b>[duration2text()]</b>"
 		else
 			s += "<br>Map: <b>[map_name ? map_name : "Loading..."]</b>"


### PR DESCRIPTION
```

[23:11:34] Runtime in world.dm, line 181: Cannot read null.name
proc name: update status (/world/proc/update_status)
usr: Trevorious/(Ellie 'Coffee' Weaver)
usr.loc: (Cryo Cells (179, 71, 3))
src: world
call stack:
world: update status()
Ellie \'Coffee\' Weaver (/mob/dead/observer): Login()
Ellie \'Coffee\' Weaver (/mob/dead/observer): Login()
/datum/mind (/datum/mind): transfer to(Ellie \'Coffee\' Weaver (/mob/dead/observer), 1)
Trevorious (/mob/new_player): Topic("src=\[mob_13];lobby_choice=obs...", /list (/list))
Trevorious (/client): Topic("src=\[mob_13];lobby_choice=obs...", /list (/list), Trevorious (/mob/new_player))
Trevorious (/client): Topic("src=\[mob_13];lobby_choice=obs...", /list (/list), Trevorious (/mob/new_player))
```