### PR TITLE
Fixes a camera runtime

### DIFF
--- a/code/modules/mob/living/silicon/ai/multicam.dm
+++ b/code/modules/mob/living/silicon/ai/multicam.dm
@@ -168,7 +168,7 @@ GLOBAL_DATUM(ai_camera_room_landmark, /obj/effect/landmark/ai_multicam_room)
 		var/datum/camerachunk/CC = VV
 		for(var/V in CC.cameras)
 			var/obj/machinery/camera/C = V
-			if(!C.can_use() || (get_dist(C, src) > telegraph_range))
+			if(QDELETED(C) || !C.can_use() || (get_dist(C, src) > telegraph_range))
 				continue
 			visible |= C
 


### PR DESCRIPTION
This check was missing, is already present in other places (likely me fuckup during porting)
```
[23:52:10] Runtime in multicam.dm, line 171: Cannot execute null.can use().
proc name: update camera telegraphing (/mob/camera/aiEye/pic_in_pic/proc/update_camera_telegraphing)
src: Secondary AI Eye (/mob/camera/aiEye/pic_in_pic)
src.loc: the deep snow layer (66,143,2) (/turf/open/floor/plating/ground/snow/layer2)
call stack:
Secondary AI Eye (/mob/camera/aiEye/pic_in_pic): update camera telegraphing()
Secondary AI Eye (/mob/camera/aiEye/pic_in_pic): setLoc(the deep snow layer (66,143,2) (/turf/open/floor/plating/ground/snow/layer2))
Picture-in-picture (/obj/screen/movable/pic_in_pic/ai): refresh view()
ARES v3.2 (AI Eye) (/mob/camera/aiEye): setLoc(the deep snow layer (66,143,2) (/turf/open/floor/plating/ground/snow/layer2), 0)
DalekThePerson (/client): AIMove(the floor (152,189,3) (/turf/open/floor/almayer), 1, ARES v3.2 (/mob/living/silicon/ai))
DalekThePerson (/client): Move(the floor (152,189,3) (/turf/open/floor/almayer), 1)
ARES v3.2 (/mob/living/silicon/ai): keyLoop(DalekThePerson (/client))
DalekThePerson (/client): keyLoop()
Input (/datum/controller/subsystem/input): fire(0)
Input (/datum/controller/subsystem/input): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop()
Master (/datum/controller/master): StartProcessing(0)
```