### PR TITLE
Fixes queen shuttle calldown quirkiness

### DIFF
--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -196,9 +196,18 @@
 
 /obj/docking_port/mobile/marine_dropship/afterShuttleMove(turf/oldT, rotation)
 	. = ..()
-	if(hijack_state == HIJACK_STATE_CALLED_DOWN)
+	if(hijack_state != HIJACK_STATE_CALLED_DOWN)
+		return
+	unlock_all()
+
+/obj/docking_port/mobile/marine_dropship/onTransitZ(old_z, new_z)
+	. = ..()
+	if(hijack_state != HIJACK_STATE_CALLED_DOWN)
+		return
+	if(is_ground_level(new_z))
 		addtimer(CALLBACK(src, .proc/reset_hijack), LOCKDOWN_TIME)
-		unlock_all()
+	else if(is_mainship_level(new_z))
+		addtimer(CALLBACK(src, .proc/reset_hijack), 30 SECONDS)
 
 /obj/docking_port/mobile/marine_dropship/proc/reset_hijack()
 	if(hijack_state == HIJACK_STATE_CALLED_DOWN)


### PR DESCRIPTION
Fixes: #2231
Lockdown will now only start if the shuttle actually lands at the ground zlevel, otherwise it will get reset instantly to prevent marine memery.