### PR TITLE
Fixes an access runtime

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -186,7 +186,6 @@
 		return
 	if(machine_stat & BROKEN)
 		return
-	var/mob/living/carbon/human/H = user
 	if(!allowed(user))
 		to_chat(user, "<span class='warning'>Access denied.</span>")
 		return

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -187,7 +187,7 @@
 	if(machine_stat & BROKEN)
 		return
 	var/mob/living/carbon/human/H = user
-	if(!check_access(H.wear_id))
+	if(!allowed(user))
 		to_chat(user, "<span class='warning'>Access denied.</span>")
 		return
 	ui_interact(user)


### PR DESCRIPTION
```
[22:30:28] Runtime in Chemistry-Machinery.dm, line 190: undefined variable /mob/living/silicon/ai/var/wear_id
proc name: attack hand (/obj/machinery/chem_dispenser/attack_hand)
usr: TheSpecialSnowflake/(ARES v3.2)
usr.loc: (AI Core (152, 188, 3))
src: the chem dispenser (/obj/machinery/chem_dispenser)
src.loc: the floor (106,66,3) (/turf/open/floor/almayer)
call stack:
the chem dispenser (/obj/machinery/chem_dispenser): attack hand(ARES v3.2 (/mob/living/silicon/ai))
the chem dispenser (/obj/machinery/chem_dispenser): attack ai(ARES v3.2 (/mob/living/silicon/ai))
ARES v3.2 (/mob/living/silicon/ai): ClickOn(the chem dispenser (/obj/machinery/chem_dispenser), "icon-x=12;icon-y=18;left=1;scr...")
the chem dispenser (/obj/machinery/chem_dispenser): Click(the floor (106,66,3) (/turf/open/floor/almayer), "mapwindow.map", "icon-x=12;icon-y=18;left=1;scr...")
TheSpecialSnowflake (/client): Click(the chem dispenser (/obj/machinery/chem_dispenser), the floor (106,66,3) (/turf/open/floor/almayer), "mapwindow.map", "icon-x=12;icon-y=18;left=1;scr...")
```