### PR TITLE
Dummies get no armor

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -78,12 +78,20 @@ Contains most of the procs that are called when a mob is attacked by something
 		limb_to_check.armor = limb_to_check.armor.attachArmor(armor_item.armor)
 
 
+/mob/living/carbon/human/dummy/add_limb_armor(obj/item/armor_item)
+	return
+
+
 /mob/living/carbon/human/proc/remove_limb_armor(obj/item/armor_item)
 	for(var/i in limbs)
 		var/datum/limb/limb_to_check = i
 		if(!(limb_to_check.body_part & armor_item.flags_armor_protection))
 			continue
 		limb_to_check.armor = limb_to_check.armor.detachArmor(armor_item.armor)
+
+
+/mob/living/carbon/human/dummy/remove_limb_armor(obj/item/armor_item)
+	return
 
 
 //this proc returns the armour value for a particular external organ.


### PR DESCRIPTION
Fixes runtimes, and no need for human dummies to actually get armor protection. They are for visual/preview purposes only.