### PR TITLE
Timers out of bounds.

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -202,7 +202,7 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 	// Sort subsystems by display setting for easy access.
 	sortTim(subsystems, /proc/cmp_subsystem_display)
 	// Set world options.
-	world.fps = CONFIG_GET(number/fps)
+	world.change_fps( CONFIG_GET(number/fps) )
 	var/initialized_tod = REALTIMEOFDAY
 
 	if(sleep_offline_after_initializations)

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -429,10 +429,6 @@ SUBSYSTEM_DEF(timer)
 	//get the list of buckets
 	var/list/bucket_list = SStimer.bucket_list
 
-	if(length(bucket_list) != BUCKET_LEN)
-		SStimer.reset_buckets()
-		bucket_list = SStimer.bucket_list
-
 	//calculate our place in the bucket list
 	var/bucket_pos = BUCKET_POS(src)
 

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -46,7 +46,9 @@ SUBSYSTEM_DEF(timer)
 
 	if(lit && lit < last_check && head_offset < last_check && last_invoke_warning < last_check)
 		last_invoke_warning = world.time
-		message_admins("No regular timers processed in the last [BUCKET_LEN * 1.5] ticks[bucket_auto_reset ? ", resetting buckets" : ""].")
+		var/msg = "No regular timers processed in the last [BUCKET_LEN * 1.5] ticks[bucket_auto_reset ? ", resetting buckets" : ""]."
+		message_admins(msg)
+		WARNING(msg)
 		if(bucket_auto_reset)
 			bucket_resolution = 0
 
@@ -426,6 +428,10 @@ SUBSYSTEM_DEF(timer)
 
 	//get the list of buckets
 	var/list/bucket_list = SStimer.bucket_list
+
+	if(length(bucket_list) != BUCKET_LEN)
+		SStimer.reset_buckets()
+		bucket_list = SStimer.bucket_list
 
 	//calculate our place in the bucket list
 	var/bucket_pos = BUCKET_POS(src)

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -206,3 +206,14 @@ GLOBAL_VAR_INIT(bypass_tgs_reboot, world.system_type == UNIX && world.byond_buil
 		hub_password = "kMZy3U5jJHSiBQjr"
 	else
 		hub_password = "SORRYNOPASSWORD"
+
+
+/world/proc/change_fps(new_value = 20)
+	if(new_value <= 0)
+		CRASH("change_fps() called with [new_value] new_value.")
+	if(fps == new_value)
+		return //No change required.
+
+	fps = new_value
+
+	SStimer?.reset_buckets()

--- a/code/world.dm
+++ b/code/world.dm
@@ -5,5 +5,6 @@
 	view = "15x15"
 	cache_lifespan = 0	//stops player uploaded stuff from being kept in the rsc past the current session
 	hub = "Exadv1.spacestation13"
+	fps = 20
 
 #define RECOMMENDED_VERSION 511


### PR DESCRIPTION
`/datum/controller/subsystem/timer/PreInit()` is ran before world.
In there it is defined that `bucket_list.len = BUCKET_LEN`
`BUCKET_LEN` is `(world.fps*1*60)`
When `PreInit` happens, `fps` will have not been set yet, so it will depend on local configs. In my case it starts at `10` before later on it is set to `20`.
By the time `bucketJoin()` is called the first times, that has already happened, so you have a list whose length is 600 in my case (10 fps times 60).
But the position for this first new bucket will use the fps of its time:
`var/bucket_pos = BUCKET_POS(src)`
`BUCKET_POS(timer)` is `(((round((timer.timeToRun - SStimer.head_offset) / world.tick_lag)+1) % BUCKET_LEN)||BUCKET_LEN)`
By that time `BUCKET_LEN` will be 1200, as `world.fps` is 20.

This adds a check that is already present in the timer process looping, to adjust in case the world fps settings change.