### PR TITLE
Fixes vote action runtime

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -341,7 +341,7 @@ SUBSYSTEM_DEF(vote)
 /datum/controller/subsystem/vote/proc/remove_action_buttons()
 	for(var/v in generated_actions)
 		var/datum/action/innate/vote/V = v
-		if(!QDELETED(V))
+		if(!QDELETED(V?.owner))
 			V.remove_from_client()
 			V.remove_action(V.owner)
 	generated_actions = list()

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -341,9 +341,10 @@ SUBSYSTEM_DEF(vote)
 /datum/controller/subsystem/vote/proc/remove_action_buttons()
 	for(var/v in generated_actions)
 		var/datum/action/innate/vote/V = v
-		if(!QDELETED(V?.owner))
+		if(!QDELETED(V))
 			V.remove_from_client()
-			V.remove_action(V.owner)
+			if(!QDELETED(V.owner))
+				V.remove_action(V.owner)
 	generated_actions = list()
 
 


### PR DESCRIPTION
1. vote gets started, action gets added to a mob, added to a list
2. mob gets deleted, time passes
3. time for removing the action calls, it gets looped but tries to remove it with a null owner, runtime happens

```
[23:38:05] Runtime in action.dm, line 61: Cannot read null.client
proc name: remove action (/datum/action/proc/remove_action)
src: Vote: asdf (/datum/action/innate/vote)
call stack:
Vote: asdf (/datum/action/innate/vote): remove action(null)
Vote (/datum/controller/subsystem/vote): remove action buttons()
Vote (/datum/controller/subsystem/vote): announce result()
Vote (/datum/controller/subsystem/vote): result()
Vote (/datum/controller/subsystem/vote): fire(0)
Vote (/datum/controller/subsystem/vote): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop()
Master (/datum/controller/master): StartProcessing(0)
```