### PR TITLE
Battle rifle balance tweaks

### DIFF
--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -515,7 +515,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	..()
 	damage = CONFIG_GET(number/combat_define/hmed_hit_damage)
 	scatter = -CONFIG_GET(number/combat_define/low_scatter_value)
-	penetration= CONFIG_GET(number/combat_define/med_armor_penetration)
+	penetration = CONFIG_GET(number/combat_define/med_armor_penetration)
 	shell_speed = CONFIG_GET(number/combat_define/fast_shell_speed)
 
 /datum/ammo/bullet/rifle/m4ra/incendiary
@@ -525,11 +525,9 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 
 /datum/ammo/bullet/rifle/m4ra/incendiary/New()
 	..()
-	damage = CONFIG_GET(number/combat_define/hmed_hit_damage)
-	accuracy = CONFIG_GET(number/combat_define/hmed_hit_accuracy)
-	scatter = -CONFIG_GET(number/combat_define/low_scatter_value)
-	penetration= CONFIG_GET(number/combat_define/low_armor_penetration)
-	shell_speed = CONFIG_GET(number/combat_define/fast_shell_speed)
+	damage = CONFIG_GET(number/combat_define/lmmed_hit_damage)
+	accuracy = CONFIG_GET(number/combat_define/low_hit_accuracy)
+	penetration = CONFIG_GET(number/combat_define/low_armor_penetration)
 
 /datum/ammo/bullet/rifle/m4ra/impact
 	name = "A19 high velocity impact bullet"
@@ -540,9 +538,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	..()
 	damage = CONFIG_GET(number/combat_define/med_hit_damage)
 	accuracy = -CONFIG_GET(number/combat_define/low_hit_accuracy)
-	scatter = -CONFIG_GET(number/combat_define/low_scatter_value)
-	penetration= CONFIG_GET(number/combat_define/low_armor_penetration)
-	shell_speed = CONFIG_GET(number/combat_define/fast_shell_speed)
+	penetration = CONFIG_GET(number/combat_define/low_armor_penetration)
 
 /datum/ammo/bullet/rifle/m4ra/impact/on_hit_mob(mob/M, obj/item/projectile/P)
 	staggerstun(M, P, CONFIG_GET(number/combat_define/max_shell_range), 0, 1, 1)

--- a/code/modules/projectiles/updated_projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/specialist.dm
@@ -303,7 +303,7 @@
 	burst_amount = CONFIG_GET(number/combat_define/low_burst_value)
 	burst_delay = CONFIG_GET(number/combat_define/min_fire_delay)
 	burst_accuracy_mult = CONFIG_GET(number/combat_define/min_burst_accuracy_penalty)
-	accuracy_mult = CONFIG_GET(number/combat_define/base_hit_accuracy_mult)
+	accuracy_mult = CONFIG_GET(number/combat_define/base_hit_accuracy_mult) + CONFIG_GET(number/combat_define/min_hit_accuracy_mult)
 	scatter = CONFIG_GET(number/combat_define/low_scatter_value)
 	damage_mult = CONFIG_GET(number/combat_define/base_hit_damage_mult)
 	recoil = CONFIG_GET(number/combat_define/min_recoil_value)


### PR DESCRIPTION
## About The Pull Request

Adds 0.05 accuracy multiplier to M4RA so total accuracy is 1.1 with stock. Incendiary ammo is no longer straight upgrade from default, nerfs damage and accuracy bonus by 10. This should be enough not to miss on screens edge.

## Changelog
:cl:
balance: Increased M4RA accuracy multiplier slightly.
balance: Nerfed high velocity incendiary bullet damage and accuracy bonus.
/:cl:
