### PR TITLE
Fixes detpack timer issue

### DIFF
--- a/code/game/objects/items/radio/detpack.dm
+++ b/code/game/objects/items/radio/detpack.dm
@@ -133,10 +133,10 @@
 		log_explosion("[key_name(usr)] triggered [src] explosion at [AREACOORD(loc)].")
 		detonation_pending = addtimer(CALLBACK(src, .proc/do_detonate), timer SECONDS, TIMER_STOPPABLE)
 		if(timer > 10)
-			sound_timer = addtimer(CALLBACK(src, .proc/do_play_sound_normal), 1 SECONDS, TIMER_LOOP)
+			sound_timer = addtimer(CALLBACK(src, .proc/do_play_sound_normal), 1 SECONDS, TIMER_LOOP|TIMER_STOPPABLE)
 			addtimer(CALLBACK(src, .proc/change_to_loud_sound), timer-10)
 		else
-			sound_timer = addtimer(CALLBACK(src, .proc/do_play_sound_loud), 1 SECONDS, TIMER_LOOP)
+			sound_timer = addtimer(CALLBACK(src, .proc/do_play_sound_loud), 1 SECONDS, TIMER_LOOP|TIMER_STOPPABLE)
 		update_icon()
 	else
 		armed = FALSE


### PR DESCRIPTION
```
[23:38:49] Runtime in timer.dm, line 505: Tried to delete a null timerid. Use TIMER_STOPPABLE flag
proc name: deltimer (/proc/deltimer)
usr: InterroLouis/(Harry Cowper)
usr.loc: (Colony Northern Clearing (121, 167, 2))
src: null
call stack:
deltimer(-1)
the detonation pack (/obj/item/radio/detpack): Destroy(0)
qdel(the detonation pack (/obj/item/radio/detpack), 0)
the detonation pack (/obj/item/radio/detpack): do detonate()
/datum/callback (/datum/callback): Invoke()
world: PushUsr(Harry Cowper (/mob/living/carbon/human), /datum/callback (/datum/callback))
/datum/callback (/datum/callback): InvokeAsync()
Timer (/datum/controller/subsystem/timer): fire(0)
Timer (/datum/controller/subsystem/timer): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop()
Master (/datum/controller/master): StartProcessing(0)
```