### PR TITLE
Fixing the runtime for ssdirection

### DIFF
--- a/code/controllers/subsystem/direction.dm
+++ b/code/controllers/subsystem/direction.dm
@@ -80,14 +80,15 @@ SUBSYSTEM_DEF(direction)
 	mobs_in_processing[C] = squad_id
 	processing_mobs[squad_id].Add(C)
 
-/datum/controller/subsystem/direction/proc/stop_tracking(squad_id, mob/living/carbon/C)
+/datum/controller/subsystem/direction/proc/stop_tracking(squad_id, mob/living/carbon/C, force = FALSE)
 	if(!mobs_in_processing[C])
 		return TRUE // already removed
 	var/tracking_id = mobs_in_processing[C]
 	mobs_in_processing[C] = FALSE
 
 	if(tracking_id != squad_id)
-		stack_trace("mismatch in tracking mobs by reference")
+		if(!force)
+			stack_trace("mismatch in tracking mobs by reference")
 		processing_mobs[squad_id].Remove(C)
 
 	processing_mobs[tracking_id].Remove(C)

--- a/code/datums/jobs/squads.dm
+++ b/code/datums/jobs/squads.dm
@@ -217,9 +217,9 @@ GLOBAL_LIST_EMPTY(helmetmarkings_sl)
 	if(squad_leader == src)
 		squad_leader = null
 		SSdirection.clear_leader(tracking_id)
-		SSdirection.stop_tracking("marine-sl", H)
+		SSdirection.stop_tracking("marine-sl", H, wipe)
 	else
-		SSdirection.stop_tracking(tracking_id, H)
+		SSdirection.stop_tracking(tracking_id, H, wipe)
 	H.assigned_squad = null
 	return TRUE
 

--- a/code/game/objects/machinery/cryopod.dm
+++ b/code/game/objects/machinery/cryopod.dm
@@ -316,7 +316,7 @@
 			if(istype(J, /datum/job/marine/leader))
 				assigned_squad.num_leaders--
 		assigned_squad.count--
-		assigned_squad.clean_marine_from_squad(src, TRUE) //Remove from squad recods, if any.
+		assigned_squad.clean_marine_from_squad(src, TRUE) //Remove from squad records, if any.
 
 	. = ..()
 


### PR DESCRIPTION
This removes the stack_trace when we force remove marines for example during cryo delete. The mob may logout beforehand and be removed or they may not have.