### PR TITLE
Fixes a zone select runtime

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -280,6 +280,9 @@
 	set name = "body-l-arm"
 	set hidden = TRUE
 
+	if(!check_has_body_select())
+		return
+
 	var/next_in_line
 	switch(mob.zone_selected)
 		if(BODY_ZONE_L_ARM)


### PR DESCRIPTION
This lil bit was missing, the others have it
```
[20:55:10] Runtime in mob_movement.dm, line 291: Cannot execute null.set selected zone().
verb name: body-l-arm (/client/verb/body_l_arm)
usr: Psykzz/(Matt Smith)
usr.loc: (Marshal Offices (71, 167, 2))
src: Psykzz (/client)
call stack:
Psykzz (/client): body-l-arm()
target_left_arm (/datum/keybinding/mob/target_left_arm): down(Psykzz (/client))
Psykzz (/client): keyDown("Numpad6")
```