### PR TITLE
Fix counts for distress to show total number instead of shipside

### DIFF
--- a/code/game/objects/machinery/computer/communications.dm
+++ b/code/game/objects/machinery/computer/communications.dm
@@ -215,7 +215,7 @@
 					var/client/C = i
 					if(check_other_rights(C, R_ADMIN, FALSE))
 						SEND_SOUND(C, 'sound/effects/sos-morse-code.ogg')
-						to_chat(C, "<span class='notice'><b><font color='purple'>DISTRESS:</font> [ADMIN_TPMONTY(usr)] has called a Distress Beacon. It will be sent in 60 seconds unless denied or sent early. Humans: [ShipMarines], Xenos: [ShipXenos]. (<A HREF='?src=[REF(C.holder)];[HrefToken(TRUE)];distress=[REF(usr)]'>SEND</A>) (<A HREF='?src=[REF(C.holder)];[HrefToken(TRUE)];deny=[REF(usr)]'>DENY</A>) (<a href='?src=[REF(C.holder)];[HrefToken(TRUE)];reply=[REF(usr)]'>REPLY</a>).</b></span>")
+						to_chat(C, "<span class='notice'><b><font color='purple'>DISTRESS:</font> [ADMIN_TPMONTY(usr)] has called a Distress Beacon. It will be sent in 60 seconds unless denied or sent early. Humans: [ShipMarines + PlanetMarines], Xenos: [ShipXenos + PlanetXenos]. (<A HREF='?src=[REF(C.holder)];[HrefToken(TRUE)];distress=[REF(usr)]'>SEND</A>) (<A HREF='?src=[REF(C.holder)];[HrefToken(TRUE)];deny=[REF(usr)]'>DENY</A>) (<a href='?src=[REF(C.holder)];[HrefToken(TRUE)];reply=[REF(usr)]'>REPLY</a>).</b></span>")
 				to_chat(usr, "<span class='boldnotice'>A distress beacon will launch in 60 seconds unless High Command responds otherwise.</span>")
 
 				SSticker.mode.distress_cancelled = FALSE


### PR DESCRIPTION
Fixes distress beacon numbers to show all humans & xenos instead of just shipside.