### PR TITLE
Fixes a gun action runtime

### DIFF
--- a/code/modules/projectiles/updated_projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_helpers.dm
@@ -764,7 +764,7 @@ should be alright.
 		if(!A || A.loc != src)
 			return
 	if(A)
-		A.ui_action_click(usr, src)
+		A.ui_action_click(usr, null, src)
 
 
 /obj/item/weapon/gun/verb/toggle_rail_attachment()


### PR DESCRIPTION
```
[23:41:22] Runtime in gun_attachables.dm, line 1255: Cannot read null.aim_slowdown
proc name: activate attachment (/obj/item/attachable/bipod/activate_attachment)
usr: Socialized Gundo/(Mekhi Rhinehart)
usr.loc: (Alamo Landing Zone (140, 34, 2))
src: the bipod (/obj/item/attachable/bipod)
src.loc: the M56B smartgun (/obj/item/weapon/gun/smartgun)
call stack:
the bipod (/obj/item/attachable/bipod): activate attachment(null, Mekhi Rhinehart (/mob/living/carbon/human), null)
the bipod (/obj/item/attachable/bipod): ui action click(Mekhi Rhinehart (/mob/living/carbon/human), the M56B smartgun (/obj/item/weapon/gun/smartgun), null)
the M56B smartgun (/obj/item/weapon/gun/smartgun): Load From Attachment()
Activate weapon attachment (/obj/screen/firearms/attachment): Click(null, "mapwindow.map", "icon-x=18;icon-y=10;left=1;scr...")
Socialized Gundo (/client): Click(Activate weapon attachment (/obj/screen/firearms/attachment), null, "mapwindow.map", "icon-x=18;icon-y=10;left=1;scr...")
```
@Rohesie arguments were swapped in the attachment ui_click_action, this is the cleanest way to make it work