### PR TITLE
Bipod, and scatter rework, attachment refactor

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -569,7 +569,7 @@
 	if(!G)
 		return
 	var/obj/item/attachable/flashlight/F = G.rail
-	if(F?.activate_attachment(G, usr))
+	if(F?.activate_attachment(usr))
 		playsound(usr, F.activation_sound, 15, 1)
 
 /obj/screen/firearms/magazine

--- a/code/controllers/configuration/entries/combat_defines.dm
+++ b/code/controllers/configuration/entries/combat_defines.dm
@@ -540,7 +540,10 @@ Movement accuracy penalty.
 Scatter penalty while bursting.
 */
 /datum/config_entry/number/combat_define/low_burst_scatter_penalty
-	config_entry_value = 0.25
+	config_entry_value = 1
+
+/datum/config_entry/number/combat_define/high_burst_scatter_penalty
+	config_entry_value = 3
 
 /*
 Accuracy penalty while bursting.

--- a/code/modules/projectiles/updated_projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_attachables.dm
@@ -79,10 +79,11 @@ Defined in conflicts.dm of the #defines folder.
 	var/current_rounds 	= 0 //How much it has.
 	var/max_rounds 		= 0 //How much ammo it can store
 	var/max_range		= 0
-	var/attach_applied = FALSE //Prevents it from getting picked up after being attached
 
 	var/attachment_action_type
 	var/scope_zoom_mod = FALSE //codex
+
+	var/obj/item/weapon/gun/master_gun
 
 
 /obj/item/attachable/attackby(obj/item/I, mob/user, params)
@@ -97,18 +98,15 @@ Defined in conflicts.dm of the #defines folder.
 
 
 /obj/item/attachable/attack_hand(mob/living/user)
-	if(src.attach_applied == TRUE)
+	if(master_gun)
 		return
-	else
-		..()
+	return ..()
 
 
-
-/obj/item/attachable/proc/Attach(obj/item/weapon/gun/G, mob/user)
-	if(!istype(G))
+/obj/item/attachable/proc/Attach(obj/item/weapon/gun/gun_to_attach, mob/user)
+	if(!istype(gun_to_attach))
 		return //Guns only
-	attach_applied = TRUE
-
+	master_gun = gun_to_attach
 	/*
 	This does not check if the attachment can be removed.
 	Instead of checking individual attachments, I simply removed
@@ -119,131 +117,132 @@ Defined in conflicts.dm of the #defines folder.
 	*/
 	switch(slot)
 		if("rail")
-			G.rail?.Detach(G, user)
-			G.rail = src
+			master_gun.rail?.Detach(user)
+			master_gun.rail = src
 		if("muzzle")
-			G.muzzle?.Detach(G, user)
-			G.muzzle = src
+			master_gun.muzzle?.Detach(user)
+			master_gun.muzzle = src
 		if("under")
-			G.under?.Detach(G, user)
-			G.under = src
+			master_gun.under?.Detach(user)
+			master_gun.under = src
 		if("stock")
-			G.stock?.Detach(G, user)
-			G.stock = src
+			master_gun.stock?.Detach(user)
+			master_gun.stock = src
 
 	if(ishuman(user))
 		var/mob/living/carbon/human/wielder = user
 		wielder.drop_held_item(src)
-	forceMove(G)
 
-	G.accuracy_mult		+= accuracy_mod
-	G.accuracy_mult_unwielded += accuracy_unwielded_mod
-	G.damage_mult		+= damage_mod
-	G.damage_falloff_mult += damage_falloff_mod
-	G.w_class 			+= size_mod
-	G.scatter			+= scatter_mod
-	G.scatter_unwielded += scatter_unwielded_mod
-	G.fire_delay 		+= delay_mod
-	G.burst_delay 	+= burst_delay_mod
-	G.burst_amount 		+= burst_mod
-	G.recoil 			+= recoil_mod
-	G.recoil_unwielded	+= recoil_unwielded_mod
-	G.force 			+= melee_mod
-	G.aim_slowdown		+= aim_speed_mod
-	G.wield_delay		+= wield_delay_mod
-	G.burst_scatter_mult += burst_scatter_mod
-	G.movement_acc_penalty_mult += movement_acc_penalty_mod
-	G.shell_speed_mod	+= attach_shell_speed_mod
-	G.scope_zoom 		+= scope_zoom_mod
+	forceMove(master_gun)
 
-	G.update_force_list() //This updates the gun to use proper force verbs.
+	master_gun.accuracy_mult				+= accuracy_mod
+	master_gun.accuracy_mult_unwielded		+= accuracy_unwielded_mod
+	master_gun.damage_mult					+= damage_mod
+	master_gun.damage_falloff_mult			+= damage_falloff_mod
+	master_gun.w_class						+= size_mod
+	master_gun.scatter						+= scatter_mod
+	master_gun.scatter_unwielded			+= scatter_unwielded_mod
+	master_gun.fire_delay					+= delay_mod
+	master_gun.burst_delay					+= burst_delay_mod
+	master_gun.burst_amount					+= burst_mod
+	master_gun.recoil						+= recoil_mod
+	master_gun.recoil_unwielded				+= recoil_unwielded_mod
+	master_gun.force						+= melee_mod
+	master_gun.aim_slowdown					+= aim_speed_mod
+	master_gun.wield_delay					+= wield_delay_mod
+	master_gun.burst_scatter_mult			+= burst_scatter_mod
+	master_gun.movement_acc_penalty_mult	+= movement_acc_penalty_mod
+	master_gun.shell_speed_mod				+= attach_shell_speed_mod
+	master_gun.scope_zoom					+= scope_zoom_mod
+
+	master_gun.update_force_list() //This updates the gun to use proper force verbs.
 
 	if(silence_mod)
-		G.flags_gun_features |= GUN_SILENCED
-		G.muzzle_flash = null
-		G.fire_sound = "gun_silenced"
+		master_gun.flags_gun_features |= GUN_SILENCED
+		master_gun.muzzle_flash = null
+		master_gun.fire_sound = "gun_silenced"
 
-	G.update_attachable(slot)
+	master_gun.update_attachable(slot)
 
 	if(burst_mod)
-		on_burst_amount_change(G, user)
+		on_burst_amount_change(user)
 
 	if(attachment_action_type)
-		var/datum/action/A = new attachment_action_type(src, G)
-		if(isliving(G.loc))
-			var/mob/living/L = G.loc
-			if(G == L.l_hand || G == L.r_hand)
-				A.give_action(G.loc)
+		var/datum/action/action_to_update = new attachment_action_type(src, master_gun)
+		if(isliving(master_gun.loc))
+			var/mob/living/living_user = master_gun.loc
+			if(master_gun == living_user.l_hand || master_gun == living_user.r_hand)
+				action_to_update.give_action(living_user)
 
 
-
-/obj/item/attachable/proc/Detach(obj/item/weapon/gun/G, mob/user)
-	if(!istype(G))
-		return //Guns only
-	attach_applied = FALSE
-
+/obj/item/attachable/proc/Detach(mob/user)
 	if(flags_attach_features & ATTACH_ACTIVATION)
-		activate_attachment(G, null, TRUE)
+		activate_attachment(null, TRUE)
 
-	switch(slot) //I am removing checks for the attachment being src.
-		if("rail") 		G.rail = null//If it's being called on by this proc, it has to be that attachment. ~N
-		if("muzzle") 	G.muzzle = null
-		if("under")		G.under = null
-		if("stock")		G.stock = null
+	switch(slot)
+		if("rail")
+			master_gun.rail = null
+		if("muzzle")
+			master_gun.muzzle = null
+		if("under")
+			master_gun.under = null
+		if("stock")
+			master_gun.stock = null
 
-	G.accuracy_mult		-= accuracy_mod
-	G.accuracy_mult_unwielded -= accuracy_unwielded_mod
-	G.damage_mult		-= damage_mod
-	G.damage_falloff_mult -= damage_falloff_mod
-	G.w_class 			-= size_mod
-	G.scatter			-= scatter_mod
-	G.scatter_unwielded -= scatter_unwielded_mod
-	G.fire_delay 		-= delay_mod
-	G.burst_delay 		-= burst_delay_mod
-	G.burst_amount 		-= burst_mod
-	G.recoil 			-= recoil_mod
-	G.recoil_unwielded	-= recoil_unwielded_mod
-	G.force 			-= melee_mod
-	G.aim_slowdown		-= aim_speed_mod
-	G.wield_delay		-= wield_delay_mod
-	G.burst_scatter_mult -= burst_scatter_mod
-	G.movement_acc_penalty_mult -= movement_acc_penalty_mod
-	G.shell_speed_mod	-=attach_shell_speed_mod
-	G.scope_zoom 		-= scope_zoom_mod
-	G.update_force_list()
+	master_gun.accuracy_mult				-= accuracy_mod
+	master_gun.accuracy_mult_unwielded		-= accuracy_unwielded_mod
+	master_gun.damage_mult					-= damage_mod
+	master_gun.damage_falloff_mult			-= damage_falloff_mod
+	master_gun.w_class						-= size_mod
+	master_gun.scatter						-= scatter_mod
+	master_gun.scatter_unwielded			-= scatter_unwielded_mod
+	master_gun.fire_delay					-= delay_mod
+	master_gun.burst_delay					-= burst_delay_mod
+	master_gun.burst_amount					-= burst_mod
+	master_gun.recoil						-= recoil_mod
+	master_gun.recoil_unwielded				-= recoil_unwielded_mod
+	master_gun.force						-= melee_mod
+	master_gun.aim_slowdown					-= aim_speed_mod
+	master_gun.wield_delay					-= wield_delay_mod
+	master_gun.burst_scatter_mult			-= burst_scatter_mod
+	master_gun.movement_acc_penalty_mult	-= movement_acc_penalty_mod
+	master_gun.shell_speed_mod				-=attach_shell_speed_mod
+	master_gun.scope_zoom					-= scope_zoom_mod
+
+	master_gun.update_force_list()
 
 	if(burst_mod)
-		on_burst_amount_change(G, user)
+		on_burst_amount_change(user)
 
 	if(silence_mod) //Built in silencers always come as an attach, so the gun can't be silenced right off the bat.
-		G.flags_gun_features &= ~GUN_SILENCED
-		G.muzzle_flash = initial(G.muzzle_flash)
-		G.fire_sound = initial(G.fire_sound)
+		master_gun.flags_gun_features &= ~GUN_SILENCED
+		master_gun.muzzle_flash = initial(master_gun.muzzle_flash)
+		master_gun.fire_sound = initial(master_gun.fire_sound)
 
-	for(var/X in G.actions)
-		var/datum/action/DA = X
-		if(DA.target == src)
-			qdel(X)
-			break
+	for(var/i in master_gun.actions)
+		var/datum/action/action_to_update = i
+		if(action_to_update.target != src)
+			continue
+		qdel(action_to_update)
+		break
 
-	//turn_off_light()
-	//G.flags_gun_features &= ~GUN_FLASHLIGHT_ON
+	forceMove(get_turf(master_gun))
 
-	loc = get_turf(G)
+	master_gun = null
 
 
-/obj/item/attachable/proc/on_burst_amount_change(obj/item/weapon/gun/shoota, mob/user)
-	if(shoota.burst_amount < 2)
-		if(GUN_FIREMODE_BURSTFIRE in shoota.gun_firemode_list)
-			shoota.remove_firemode(GUN_FIREMODE_BURSTFIRE, user)
+/obj/item/attachable/proc/on_burst_amount_change(mob/user)
+	if(master_gun.burst_amount < 2)
+		if(GUN_FIREMODE_BURSTFIRE in master_gun.gun_firemode_list)
+			master_gun.remove_firemode(GUN_FIREMODE_BURSTFIRE, user)
 	else
-		if(!(GUN_FIREMODE_BURSTFIRE in shoota.gun_firemode_list))
-			shoota.add_firemode(GUN_FIREMODE_BURSTFIRE, user)
+		if(!(GUN_FIREMODE_BURSTFIRE in master_gun.gun_firemode_list))
+			master_gun.add_firemode(GUN_FIREMODE_BURSTFIRE, user)
 
 
 /obj/item/attachable/ui_action_click(mob/living/user, datum/action/item_action/action, obj/item/weapon/gun/G)
 	if(G == user.get_active_held_item() || G == user.get_inactive_held_item())
-		if(activate_attachment(G, user)) //success
+		if(activate_attachment(user)) //success
 			playsound(user, activation_sound, 15, 1)
 	else
 		to_chat(user, "<span class='warning'>[G] must be in our hands to do this.</span>")
@@ -251,7 +250,7 @@ Defined in conflicts.dm of the #defines folder.
 
 
 
-/obj/item/attachable/proc/activate_attachment(atom/target, mob/user) //This is for activating stuff like flamethrowers, or switching weapon modes.
+/obj/item/attachable/proc/activate_attachment(mob/user, turn_off) //This is for activating stuff like flamethrowers, or switching weapon modes.
 	return
 
 /obj/item/attachable/proc/reload_attachment(obj/item/I, mob/user)
@@ -468,27 +467,27 @@ Defined in conflicts.dm of the #defines folder.
 	attachment_action_type = /datum/action/item_action/toggle
 	activation_sound = 'sound/items/flashlight.ogg'
 
-/obj/item/attachable/flashlight/activate_attachment(obj/item/weapon/gun/G, mob/living/user, turn_off)
-	if(turn_off && !(G.flags_gun_features & GUN_FLASHLIGHT_ON))
+/obj/item/attachable/flashlight/activate_attachment(mob/living/user, turn_off)
+	if(turn_off && !(master_gun.flags_gun_features & GUN_FLASHLIGHT_ON))
 		return
 
-	if(ismob(G.loc) && !user)
-		user = G.loc
+	if(ismob(master_gun.loc) && !user)
+		user = master_gun.loc
 
-	if(G.flags_gun_features & GUN_FLASHLIGHT_ON)
+	if(master_gun.flags_gun_features & GUN_FLASHLIGHT_ON)
 		icon_state = "flashlight"
 		attach_icon = "flashlight_a"
-		G.set_light(0)
+		master_gun.set_light(0)
 	else
 		icon_state = "flashlight-on"
 		attach_icon = "flashlight_a-on"
-		G.set_light(light_mod)
+		master_gun.set_light(light_mod)
 
-	G.flags_gun_features ^= GUN_FLASHLIGHT_ON
+	master_gun.flags_gun_features ^= GUN_FLASHLIGHT_ON
 
-	G.update_attachable(slot)
+	master_gun.update_attachable(slot)
 
-	for(var/X in G.actions)
+	for(var/X in master_gun.actions)
 		var/datum/action/A = X
 		A.update_button_icon()
 	return TRUE
@@ -562,18 +561,18 @@ Defined in conflicts.dm of the #defines folder.
 	accuracy_unwielded_mod = -CONFIG_GET(number/combat_define/min_hit_accuracy_mult)
 
 
-/obj/item/attachable/scope/activate_attachment(obj/item/weapon/gun/G, mob/living/carbon/user, turn_off)
+/obj/item/attachable/scope/activate_attachment(mob/living/carbon/user, turn_off)
 	if(turn_off)
-		if(G.zoom)
-			G.zoom(user, zoom_offset, zoom_viewsize)
+		if(master_gun.zoom)
+			master_gun.zoom(user, zoom_offset, zoom_viewsize)
 		return TRUE
 
-	if(!G.zoom && !(G.flags_item & WIELDED))
+	if(!master_gun.zoom && !(master_gun.flags_item & WIELDED))
 		if(user)
-			to_chat(user, "<span class='warning'>You must hold [G] with two hands to use [src].</span>")
+			to_chat(user, "<span class='warning'>You must hold [master_gun] with two hands to use [src].</span>")
 		return FALSE
 	else
-		G.zoom(user, zoom_offset, zoom_viewsize)
+		master_gun.zoom(user, zoom_offset, zoom_viewsize)
 	return TRUE
 
 
@@ -859,19 +858,19 @@ Defined in conflicts.dm of the #defines folder.
 
 
 
-/obj/item/attachable/attached_gun/activate_attachment(obj/item/weapon/gun/G, mob/living/user, turn_off)
-	if(G.active_attachable == src)
+/obj/item/attachable/attached_gun/activate_attachment(mob/living/user, turn_off)
+	if(master_gun.active_attachable == src)
 		if(user)
 			to_chat(user, "<span class='notice'>You are no longer using [src].</span>")
-		G.on_gun_attachment_detach(src)
+		master_gun.on_gun_attachment_detach(src)
 		icon_state = initial(icon_state)
 	else if(!turn_off)
 		if(user)
 			to_chat(user, "<span class='notice'>You are now using [src].</span>")
-		G.on_gun_attachment_attach(src)
+		master_gun.on_gun_attachment_attach(src)
 		icon_state += "-on"
 
-	for(var/X in G.actions)
+	for(var/X in master_gun.actions)
 		var/datum/action/A = X
 		A.update_button_icon()
 	return TRUE
@@ -1225,8 +1224,6 @@ Defined in conflicts.dm of the #defines folder.
 	accuracy_unwielded_mod = CONFIG_GET(number/combat_define/med_hit_accuracy_mult)
 
 
-
-
 /obj/item/attachable/bipod
 	name = "bipod"
 	desc = "A simple set of telescopic poles to keep a weapon stabilized during firing. \nGreatly increases accuracy and reduces recoil when properly placed, but also increases weapon size and slows firing speed."
@@ -1238,49 +1235,72 @@ Defined in conflicts.dm of the #defines folder.
 	melee_mod = -10
 	flags_attach_features = ATTACH_REMOVABLE|ATTACH_ACTIVATION
 	attachment_action_type = /datum/action/item_action/toggle
+	var/mob/living/master_user
+	var/deployment_accuracy_mod
+	var/deployment_recoil_mod
+	var/deployment_scatter_mod
+	var/deployment_burst_scatter_mod
 
 
 /obj/item/attachable/bipod/Initialize()
 	. = ..()
-	size_mod = 1
+	deployment_accuracy_mod = CONFIG_GET(number/combat_define/hmed_hit_accuracy_mult)
+	deployment_recoil_mod = -CONFIG_GET(number/combat_define/min_recoil_value)
+	deployment_scatter_mod = -CONFIG_GET(number/combat_define/med_scatter_value)
+	deployment_burst_scatter_mod = -CONFIG_GET(number/combat_define/high_burst_scatter_penalty)
 
-/obj/item/attachable/bipod/activate_attachment(obj/item/weapon/gun/G,mob/living/user, turn_off)
-	if(turn_off)
-		if(bipod_deployed)
-			bipod_deployed = FALSE
-			G.aim_slowdown -= SLOWDOWN_ADS_SCOPE
-			G.wield_delay -= WIELD_DELAY_FAST
-	else if(bipod_deployed)
-		to_chat(user, "<span class='notice'>You retract [src].</span>")
-		G.aim_slowdown -= SLOWDOWN_ADS_SCOPE
-		G.wield_delay -= WIELD_DELAY_FAST
-		bipod_deployed = !bipod_deployed
-	else if(do_after(user, 10, TRUE, src))
-		if(bipod_deployed)
-			return
-		bipod_deployed = !bipod_deployed
-		to_chat(user, "<span class='notice'>You deploy [src].</span>")
-		G.aim_slowdown += SLOWDOWN_ADS_SCOPE
-		G.wield_delay += WIELD_DELAY_FAST
-	G.update_slowdown()
 
-	//var/image/targeting_icon = image('icons/mob/mob.dmi', null, "busy_targeting", "pixel_y" = 22) //on hold until the bipod is fixed
+/obj/item/attachable/bipod/activate_attachment(mob/living/user, turn_off)
 	if(bipod_deployed)
-		icon_state = "bipod-on"
-		attach_icon = "bipod_a-on"
-		//user.overlays += targeting_icon
-	else
+		bipod_deployed = FALSE
+		to_chat(user, "<span class='notice'>You retract [src].</span>")
+		master_gun.aim_slowdown -= SLOWDOWN_ADS_SCOPE
+		master_gun.wield_delay -= WIELD_DELAY_FAST
+		master_gun.accuracy_mult -= deployment_accuracy_mod
+		master_gun.recoil -= deployment_recoil_mod
+		master_gun.scatter -= deployment_scatter_mod
+		master_gun.burst_scatter_mult -= deployment_burst_scatter_mod
 		icon_state = "bipod"
 		attach_icon = "bipod_a"
-		//user.overlays -= targeting_icon
+		UnregisterSignal(master_gun, list(COMSIG_ITEM_DROPPED, COMSIG_ITEM_EQUIPPED))
+		UnregisterSignal(master_user, COMSIG_MOVABLE_MOVED)
+		master_user = null
+	else if(turn_off)
+		return //Was already offB
+	else
+		if(user.action_busy)
+			return
+		if(!do_after(user, 1 SECONDS, TRUE, src, BUSY_ICON_BAR))
+			return
+		if(bipod_deployed)
+			return
+		bipod_deployed = TRUE
+		to_chat(user, "<span class='notice'>You deploy [src].</span>")
+		master_user = user
+		RegisterSignal(master_user, COMSIG_MOVABLE_MOVED, .proc/retract_bipod)
+		RegisterSignal(master_gun, list(COMSIG_ITEM_DROPPED, COMSIG_ITEM_EQUIPPED), .proc/retract_bipod)
+		master_gun.aim_slowdown += SLOWDOWN_ADS_SCOPE
+		master_gun.wield_delay += WIELD_DELAY_FAST
+		master_gun.accuracy_mult += deployment_accuracy_mod
+		master_gun.recoil += deployment_recoil_mod
+		master_gun.scatter += deployment_scatter_mod
+		master_gun.burst_scatter_mult += deployment_burst_scatter_mod
+		icon_state = "bipod-on"
+		attach_icon = "bipod_a-on"
 
-	G.update_attachable(slot)
+	master_gun.update_slowdown()
+	master_gun.update_attachable(slot)
 
-	for(var/X in G.actions)
-		var/datum/action/A = X
-		A.update_button_icon()
+	for(var/i in master_gun.actions)
+		var/datum/action/action_to_update = i
+		action_to_update.update_button_icon()
 	return TRUE
 
+
+/obj/item/attachable/bipod/proc/retract_bipod(datum/source)
+	activate_attachment(source, TRUE)
+	to_chat(source, "<span class='warning'>Losing support, the bipod retracts!</span>")
+	playsound(source, 'sound/machines/click.ogg', 15, 1, 4)
 
 
 //when user fires the gun, we check if they have something to support the gun's bipod.
@@ -1331,19 +1351,19 @@ Defined in conflicts.dm of the #defines folder.
 	var/max_water = 200
 	var/last_use
 
-/obj/item/attachable/hydro_cannon/activate_attachment(obj/item/weapon/gun/G, mob/living/user, turn_off)
-	if(G.active_attachable == src)
+/obj/item/attachable/hydro_cannon/activate_attachment(mob/living/user, turn_off)
+	if(master_gun.active_attachable == src)
 		if(user)
 			to_chat(user, "<span class='notice'>You are no longer using [src].</span>")
-		G.active_attachable = null
+		master_gun.active_attachable = null
 		icon_state = initial(icon_state)
 	else if(!turn_off)
 		if(user)
 			to_chat(user, "<span class='notice'>You are now using [src].</span>")
-		G.active_attachable = src
+		master_gun.active_attachable = src
 		icon_state += "-on"
 
-	for(var/X in G.actions)
+	for(var/X in master_gun.actions)
 		var/datum/action/A = X
 		A.update_button_icon()
 	return TRUE

--- a/code/modules/projectiles/updated_projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_attachables.dm
@@ -365,6 +365,7 @@ Defined in conflicts.dm of the #defines folder.
 	damage_mod = CONFIG_GET(number/combat_define/hmed_hit_damage_mult)
 	attach_shell_speed_mod = CONFIG_GET(number/combat_define/slow_shell_speed)
 	delay_mod = CONFIG_GET(number/combat_define/low_fire_delay)
+	scatter_mod = CONFIG_GET(number/combat_define/min_scatter_value)
 	accuracy_unwielded_mod = -CONFIG_GET(number/combat_define/high_hit_accuracy_mult)
 
 

--- a/code/modules/projectiles/updated_projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_helpers.dm
@@ -539,7 +539,7 @@ should be alright.
 
 	usr.visible_message("<span class='notice'>[usr] strips [A] from [src].</span>",
 	"<span class='notice'>You strip [A] from [src].</span>", null, 4)
-	A.Detach(src, usr)
+	A.Detach(usr)
 
 	playsound(src, 'sound/machines/click.ogg', 15, 1, 4)
 	update_attachables()
@@ -781,7 +781,7 @@ should be alright.
 		to_chat(usr, "<span class='warning'>[src] does not have any usable rail attachment!</span>")
 		return
 
-	G.rail.activate_attachment(G, usr)
+	G.rail.activate_attachment(usr)
 
 
 /obj/item/weapon/gun/verb/toggle_ammo_hud()

--- a/code/modules/projectiles/updated_projectiles/gun_system.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_system.dm
@@ -1030,7 +1030,6 @@ and you're good to go.
 				total_scatter -= scatter_tweak * CONFIG_GET(number/combat_define/low_scatter_value)
 
 	if(prob(total_scatter)) //Scattered?
-		to_chat(user, "Projectile scattered? [total_scatter]")
 		var/scatter_x = abs(16 - projectile_to_fire.p_x) //The value starts in pixels, depending on where the user clicked.
 		var/scatter_y = abs(16 - projectile_to_fire.p_y) //Distance to the center of the tile.
 		switch(get_dir(get_turf(src), target)) //Projectile direction.
@@ -1049,7 +1048,6 @@ and you're good to go.
 			var/turf/new_target = locate(targloc.x + (rand(0, 1) ? scatter_x : -scatter_x), targloc.y + (rand(0, 1) ? scatter_y : -scatter_y), targloc.z) //Locate an adjacent turf.
 			if(new_target)
 				target = new_target//Looks like we found a turf.
-				to_chat(user, "Projectile scattered: [scatter_x] || [scatter_y]")
 
 	projectile_to_fire.original = target
 	return target

--- a/code/modules/projectiles/updated_projectiles/gun_system.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_system.dm
@@ -1041,8 +1041,8 @@ and you're good to go.
 				scatter_x += total_scatter * 0.5
 				scatter_y += total_scatter * 0.5
 		
-		scatter_x = rand(0, round(scatter_x / 32) + 1) //Value is turned into tiles.
-		scatter_y = rand(0, round(scatter_y / 32) + 1)
+		scatter_x = min(rand(0, round(scatter_x / 32) + 1), targdist - 1) //Value is turned into tiles.
+		scatter_y = min(rand(0, round(scatter_y / 32) + 1), targdist - 1)
 
 		if(scatter_x || scatter_y) //Scattered!
 			var/turf/new_target = locate(targloc.x + (rand(0, 1) ? scatter_x : -scatter_x), targloc.y + (rand(0, 1) ? scatter_y : -scatter_y), targloc.z) //Locate an adjacent turf.

--- a/code/modules/projectiles/updated_projectiles/gun_system.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_system.dm
@@ -532,7 +532,7 @@ and you're good to go.
 		to_chat(user, "<span class='warning'>[active_attachable] is empty!</span>")
 		to_chat(user, "<span class='notice'>You disable [active_attachable].</span>")
 		playsound(user, active_attachable.activation_sound, 15, 1)
-		active_attachable.activate_attachment(src, null, TRUE)
+		active_attachable.activate_attachment(null, TRUE)
 		return
 
 	if(in_chamber) //If we have a round chambered and no active attachable, we're good to go.
@@ -661,33 +661,15 @@ and you're good to go.
 
 		apply_bullet_effects(projectile_to_fire, user, i, reflex, dual_wield) //User can be passed as null.
 
-
-		//BIPODS BEGINS HERE
-		var/scatter_chance_mod = 0
-		var/burst_scatter_chance_mod = 0
-		//They decrease scatter chance and increase accuracy a tad. Can also increase damage.
-		if(flags_item & WIELDED && user && under?.bipod_deployed) //Let's get to work on the bipod. I'm not really concerned if they are the same person as the previous user. It doesn't matter.
-			if(under.check_bipod_support(src, user))
-				//Passive accuracy and recoil buff, but only when firing in position.
-				projectile_to_fire.accuracy *= CONFIG_GET(number/combat_define/base_hit_accuracy_mult) + CONFIG_GET(number/combat_define/hmed_hit_accuracy_mult) //More accuracy.
-				recoil_comp-- //Less recoil.
-				scatter_chance_mod -= CONFIG_GET(number/combat_define/med_scatter_value)
-				burst_scatter_chance_mod = -3
-				if(prob(30))
-					projectile_to_fire.damage *= CONFIG_GET(number/combat_define/base_hit_damage_mult) + CONFIG_GET(number/combat_define/low_hit_damage_mult) //Lower chance of a damage buff.
-				if(i == 1)
-					to_chat(user, "<span class='notice'>Your bipod keeps [src] steady!</span>")
-		//End of bipods.
-
-		target = original_target ? original_target : targloc
-		target = simulate_scatter(projectile_to_fire, target, targloc, scatter_chance_mod, user, burst_scatter_chance_mod)
-
 		if(params)
 			var/list/mouse_control = params2list(params)
 			if(mouse_control["icon-x"])
 				projectile_to_fire.p_x = text2num(mouse_control["icon-x"])
 			if(mouse_control["icon-y"])
 				projectile_to_fire.p_y = text2num(mouse_control["icon-y"])
+
+		target = original_target ? original_target : targloc
+		target = simulate_scatter(projectile_to_fire, target, targloc, user)
 
 		//Finally, make with the pew pew!
 		if(!projectile_to_fire || !istype(projectile_to_fire,/obj))
@@ -749,7 +731,7 @@ and you're good to go.
 		DISABLE_BITFIELD(flags_gun_features, GUN_BURST_FIRING)
 		//Point blanking simulates firing the bullet proper but without actually firing it.
 		if(active_attachable && !CHECK_BITFIELD(active_attachable.flags_attach_features, ATTACH_PROJECTILE))
-			active_attachable.activate_attachment(src, null, TRUE)//No way.
+			active_attachable.activate_attachment(null, TRUE)//No way.
 		var/obj/item/projectile/projectile_to_fire = load_into_chamber(user)
 		if(!projectile_to_fire) //We actually have a projectile, let's move on. We're going to simulate the fire cycle.
 			return // no ..(), already invoked above
@@ -800,7 +782,7 @@ and you're good to go.
 		return
 
 	if(active_attachable && !CHECK_BITFIELD(active_attachable.flags_attach_features, ATTACH_PROJECTILE))
-		active_attachable.activate_attachment(src, null, TRUE)//We're not firing off a nade into our mouth.
+		active_attachable.activate_attachment(null, TRUE)//We're not firing off a nade into our mouth.
 	var/obj/item/projectile/projectile_to_fire = load_into_chamber(user)
 
 	if(!projectile_to_fire) //We actually have a projectile, let's move on.
@@ -1004,56 +986,74 @@ and you're good to go.
 
 	return TRUE
 
-/obj/item/weapon/gun/proc/simulate_scatter(obj/item/projectile/projectile_to_fire, atom/target, turf/targloc, total_scatter_chance = 0, mob/user, burst_scatter_bonus = 0)
-	total_scatter_chance += projectile_to_fire.scatter
+/obj/item/weapon/gun/proc/simulate_scatter(obj/item/projectile/projectile_to_fire, atom/target, turf/targloc, mob/user)
+	var/total_scatter = projectile_to_fire.scatter
 
-	//Not if the gun doesn't scatter at all, or negative scatter.
-	if(total_scatter_chance > 0)
-		var/targdist = get_dist(target, user)
-		if(gun_firemode == GUN_FIREMODE_BURSTFIRE && burst_amount > 1)//Much higher chance on a burst.
-			total_scatter_chance += (flags_item & WIELDED && wielded_stable()) ? burst_amount * (burst_scatter_mult + burst_scatter_bonus) : burst_amount * (5+burst_scatter_bonus)
+	if(total_scatter <= 0) //Not if the gun doesn't scatter at all, or negative scatter.
+		return target
 
-			//long range burst shots have more chance to scatter
-			if(targdist > 7)
-				total_scatter_chance += min(targdist*2, 15)
+	var/targdist = get_dist(target, get_turf(src))
 
-		else if(user && targdist <= (4 + rand(-1,1))) //no scatter on single fire for close targets
-			return target
-
-
-		if(user && user.mind && user.mind.cm_skills)
-
-			if(user.mind.cm_skills.firearms == 0) //no training in any firearms
-				total_scatter_chance += CONFIG_GET(number/combat_define/low_scatter_value)
+	switch(gun_firemode)
+		if(GUN_FIREMODE_BURSTFIRE) //Much higher chance on a burst.
+			if(flags_item & WIELDED && wielded_stable())
+				total_scatter += burst_amount * burst_scatter_mult
 			else
-				var/scatter_tweak = 0
-				switch(gun_skill_category)
-					if(GUN_SKILL_PISTOLS)
-						scatter_tweak = user.mind.cm_skills.pistols
-					if(GUN_SKILL_SMGS)
-						scatter_tweak = user.mind.cm_skills.smgs
-					if(GUN_SKILL_RIFLES)
-						scatter_tweak = user.mind.cm_skills.rifles
-					if(GUN_SKILL_SHOTGUNS)
-						scatter_tweak = user.mind.cm_skills.shotguns
-					if(GUN_SKILL_HEAVY_WEAPONS)
-						scatter_tweak = user.mind.cm_skills.heavy_weapons
-					if(GUN_SKILL_SMARTGUN)
-						scatter_tweak = user.mind.cm_skills.smartgun
-					if(GUN_SKILL_SPEC)
-						scatter_tweak = user.mind.cm_skills.spec_weapons
-				if(scatter_tweak)
-					total_scatter_chance -= scatter_tweak * CONFIG_GET(number/combat_define/low_scatter_value)
+				total_scatter += burst_amount * burst_scatter_mult * 5
+			if(targdist > world.view) //Long range burst shots have more chance to scatter.
+				total_scatter += 25
+		if(GUN_FIREMODE_SEMIAUTO)
+			if(targdist < 4) //No scatter on single fire for close targets.
+				return target
 
-		if(prob(total_scatter_chance)) //Scattered!
-			var/scatter_x = rand(-1,1)
-			var/scatter_y = rand(-1,1)
-			var/turf/new_target = locate(targloc.x + round(scatter_x),targloc.y + round(scatter_y),targloc.z) //Locate an adjacent turf.
+	if(user?.mind?.cm_skills)
+		if(user.mind.cm_skills.firearms <= 0) //no training in any firearms
+			total_scatter += CONFIG_GET(number/combat_define/low_scatter_value)
+		else
+			var/scatter_tweak = 0
+			switch(gun_skill_category)
+				if(GUN_SKILL_PISTOLS)
+					scatter_tweak = user.mind.cm_skills.pistols
+				if(GUN_SKILL_SMGS)
+					scatter_tweak = user.mind.cm_skills.smgs
+				if(GUN_SKILL_RIFLES)
+					scatter_tweak = user.mind.cm_skills.rifles
+				if(GUN_SKILL_SHOTGUNS)
+					scatter_tweak = user.mind.cm_skills.shotguns
+				if(GUN_SKILL_HEAVY_WEAPONS)
+					scatter_tweak = user.mind.cm_skills.heavy_weapons
+				if(GUN_SKILL_SMARTGUN)
+					scatter_tweak = user.mind.cm_skills.smartgun
+				if(GUN_SKILL_SPEC)
+					scatter_tweak = user.mind.cm_skills.spec_weapons
+			if(scatter_tweak)
+				total_scatter -= scatter_tweak * CONFIG_GET(number/combat_define/low_scatter_value)
+
+	if(prob(total_scatter)) //Scattered?
+		to_chat(user, "Projectile scattered? [total_scatter]")
+		var/scatter_x = abs(16 - projectile_to_fire.p_x) //The value starts in pixels, depending on where the user clicked.
+		var/scatter_y = abs(16 - projectile_to_fire.p_y) //Distance to the center of the tile.
+		switch(get_dir(get_turf(src), target)) //Projectile direction.
+			if(NORTH, SOUTH)
+				scatter_x += total_scatter //The higher the scatter chance, the higher deviation.
+			if(EAST, WEST)
+				scatter_y += total_scatter
+			if(NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST)
+				scatter_x += total_scatter * 0.5
+				scatter_y += total_scatter * 0.5
+		
+		scatter_x = rand(0, round(scatter_x / 32) + 1) //Value is turned into tiles.
+		scatter_y = rand(0, round(scatter_y / 32) + 1)
+
+		if(scatter_x || scatter_y) //Scattered!
+			var/turf/new_target = locate(targloc.x + (rand(0, 1) ? scatter_x : -scatter_x), targloc.y + (rand(0, 1) ? scatter_y : -scatter_y), targloc.z) //Locate an adjacent turf.
 			if(new_target)
 				target = new_target//Looks like we found a turf.
+				to_chat(user, "Projectile scattered: [scatter_x] || [scatter_y]")
 
 	projectile_to_fire.original = target
 	return target
+
 
 /obj/item/weapon/gun/proc/simulate_recoil(recoil_bonus = 0, mob/user)
 	var/total_recoil = recoil_bonus

--- a/code/modules/projectiles/updated_projectiles/guns/energy.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/energy.dm
@@ -246,7 +246,7 @@
 			to_chat(user, "<span class='warning'>[active_attachable] is empty!</span>")
 			to_chat(user, "<span class='notice'>You disable [active_attachable].</span>")
 			playsound(user, active_attachable.activation_sound, 15, 1)
-			active_attachable.activate_attachment(src, null, TRUE)
+			active_attachable.activate_attachment(null, TRUE)
 
 	if(!cell?.use(charge_cost))
 		return


### PR DESCRIPTION
## Changelog
:cl:
balance: Bipods can be deployed anywhere (after a second-long delay), granting bonuses while deployed. It will auto-retract once the user moves, or drops or equips the weapon.
balance: Scatter reworked to be a bit more organic. Instead of a random adjacent tile it will take into account the pixel clicked on the tile and the shooting direction. The bullet can deviate several tiles (on edge cases, such as untrained dual-wielding on burst, even up to 4 or more).
balance: Suppressors, extended barrels, stocks, grips and recoil compensators provide a little better effect against scatter. Quickfire and barrel chargers a bit worse.
/:cl:

A bit unatomized, and this will conflict with the autofire PR, but a rework and cleanup was needed here.
The PR is not so big nor controversial that warrants atomization, IMO.