### PR TITLE
Removes the Dawsons Christian Song from the Lobby Music.

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -47,7 +47,6 @@ SUBSYSTEM_DEF(ticker)
 		'sound/music/ManOfWar.ogg',
 		'sound/music/PraiseTheLord.ogg',
 		'sound/music/BloodUponTheRisers.ogg',
-		'sound/music/DawsonChristian.ogg',
 	)
 
 	return ..()


### PR DESCRIPTION
## About The Pull Request
This is a teachable moment.

## Why It's Good For The Game

Ship music bad, fight me nerds.

## Changelog
:cl: Hughgent
del: Goodbye Dawsons Christian!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
