### PR TITLE
Cargo technician rework

### DIFF
--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -41618,7 +41618,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "caB" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/structure/closet/secure_closet/kitchencrew,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "caC" = (
@@ -47061,6 +47061,10 @@
 	},
 /turf/open/floor/mainship,
 /area/mainship/squads/req)
+"rYn" = (
+/obj/structure/closet/secure_closet/kitchencrew,
+/turf/open/floor/mainship/mono,
+/area/mainship/living/captain_mess)
 "sby" = (
 /turf/open/floor/mainship{
 	dir = 2;
@@ -69142,7 +69146,7 @@ aMd
 azR
 ann
 aDk
-aLs
+rYn
 aGi
 aHF
 aDk

--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -39,7 +39,7 @@
 #define SYNTHETIC "Synthetic"
 #define MASTER_AT_ARMS "Master at Arms"
 #define SHIP_ENGINEER "Ship Engineer"
-#define CARGO_TECHNICIAN "Cargo Technician"
+#define CARGO_TECHNICIAN "Serviceman"
 #define MEDICAL_OFFICER "Medical Officer"
 #define MEDICAL_RESEARCHER "Medical Researcher"
 #define SQUAD_LEADER "Squad Leader"

--- a/code/datums/jobs/access.dm
+++ b/code/datums/jobs/access.dm
@@ -219,6 +219,8 @@
 			. = size ? "Dr. " : "Doctor"
 		if("CCMO")
 			. = size ? "Prof. " : "Professor"
+		if ("CMN")
+			. = size ? "CMN" : "Crewman"
 		if("PMC1")
 			. = size ? "PMC " : "PM Contractor"
 		if("PMC2")
@@ -237,6 +239,8 @@
 			. = size ? "PVT " : "Private"
 		if("E2")
 			. = size ? "PFC " : "Private First Class"
+		if("E2.5")
+			. = size ? "SPR" : "Sapper"
 		if("E3")
 			. = size ? "LCPL " : "Lance Corporal"
 		if("E4")
@@ -263,6 +267,8 @@
 			. = size ? "LT " : "Lieutenant"
 		if("O4")
 			. = size ? "LCDR " : "Lieutenant Commander"
+		if("O4.5")
+			. = size ? "LCSG" : "Lieutenant Commander Senior Grade"
 		if("O5")
 			. = size ? "CDR " : "Commander"
 		if("O6")

--- a/code/datums/jobs/access.dm
+++ b/code/datums/jobs/access.dm
@@ -239,8 +239,6 @@
 			. = size ? "PVT " : "Private"
 		if("E2")
 			. = size ? "PFC " : "Private First Class"
-		if("E2.5")
-			. = size ? "SPR" : "Sapper"
 		if("E3")
 			. = size ? "LCPL " : "Lance Corporal"
 		if("E4")
@@ -267,8 +265,6 @@
 			. = size ? "LT " : "Lieutenant"
 		if("O4")
 			. = size ? "LCDR " : "Lieutenant Commander"
-		if("O4.5")
-			. = size ? "LCSG" : "Lieutenant Commander Senior Grade"
 		if("O5")
 			. = size ? "CDR " : "Commander"
 		if("O6")

--- a/code/datums/jobs/access.dm
+++ b/code/datums/jobs/access.dm
@@ -219,7 +219,7 @@
 			. = size ? "Dr. " : "Doctor"
 		if("CCMO")
 			. = size ? "Prof. " : "Professor"
-		if ("CMN")
+		if("CMN")
 			. = size ? "CMN" : "Crewman"
 		if("PMC1")
 			. = size ? "PMC " : "PM Contractor"

--- a/code/datums/jobs/job/marines.dm
+++ b/code/datums/jobs/job/marines.dm
@@ -46,7 +46,7 @@ What you lack alone, you gain standing shoulder to shoulder with the men and wom
 //Squad Engineer
 /datum/job/marine/engineer
 	title = SQUAD_ENGINEER
-	paygrade = "E3"
+	paygrade = "E2.5"
 	comm_title = "Eng"
 	total_positions = 12
 	access = list(ACCESS_IFF_MARINE, ACCESS_MARINE_PREP, ACCESS_MARINE_ENGPREP, ACCESS_CIVILIAN_ENGINEERING)
@@ -100,7 +100,7 @@ You may not be a fully-fledged doctor, but you stand between life and death when
 //Squad Smartgunner
 /datum/job/marine/smartgunner
 	title = SQUAD_SMARTGUNNER
-	paygrade = "E4"
+	paygrade = "E3"
 	comm_title = "SGnr"
 	total_positions = 4
 	access = list(ACCESS_IFF_MARINE, ACCESS_MARINE_PREP, ACCESS_MARINE_SMARTPREP)
@@ -126,7 +126,7 @@ You may not be a fully-fledged doctor, but you stand between life and death when
 //Squad Specialist
 /datum/job/marine/specialist
 	title = SQUAD_SPECIALIST
-	paygrade = "E5"
+	paygrade = "E4"
 	comm_title = "Spec"
 	total_positions = 4
 	access = list(ACCESS_IFF_MARINE, ACCESS_MARINE_PREP, ACCESS_MARINE_SPECPREP)
@@ -156,7 +156,7 @@ You can serve a variety of roles, so choose carefully."})
 //Squad Leader
 /datum/job/marine/leader
 	title = SQUAD_LEADER
-	paygrade = "E6"
+	paygrade = "E5"
 	comm_title = "SL"
 	total_positions = 4
 	supervisors = "the acting field commander"

--- a/code/datums/jobs/job/marines.dm
+++ b/code/datums/jobs/job/marines.dm
@@ -46,7 +46,7 @@ What you lack alone, you gain standing shoulder to shoulder with the men and wom
 //Squad Engineer
 /datum/job/marine/engineer
 	title = SQUAD_ENGINEER
-	paygrade = "E2.5"
+	paygrade = "E3"
 	comm_title = "Eng"
 	total_positions = 12
 	access = list(ACCESS_IFF_MARINE, ACCESS_MARINE_PREP, ACCESS_MARINE_ENGPREP, ACCESS_CIVILIAN_ENGINEERING)
@@ -100,7 +100,7 @@ You may not be a fully-fledged doctor, but you stand between life and death when
 //Squad Smartgunner
 /datum/job/marine/smartgunner
 	title = SQUAD_SMARTGUNNER
-	paygrade = "E3"
+	paygrade = "E4"
 	comm_title = "SGnr"
 	total_positions = 4
 	access = list(ACCESS_IFF_MARINE, ACCESS_MARINE_PREP, ACCESS_MARINE_SMARTPREP)
@@ -126,7 +126,7 @@ You may not be a fully-fledged doctor, but you stand between life and death when
 //Squad Specialist
 /datum/job/marine/specialist
 	title = SQUAD_SPECIALIST
-	paygrade = "E4"
+	paygrade = "E5"
 	comm_title = "Spec"
 	total_positions = 4
 	access = list(ACCESS_IFF_MARINE, ACCESS_MARINE_PREP, ACCESS_MARINE_SPECPREP)
@@ -156,7 +156,7 @@ You can serve a variety of roles, so choose carefully."})
 //Squad Leader
 /datum/job/marine/leader
 	title = SQUAD_LEADER
-	paygrade = "E5"
+	paygrade = "E6"
 	comm_title = "SL"
 	total_positions = 4
 	supervisors = "the acting field commander"

--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -430,12 +430,12 @@ A happy ship is a well-functioning ship."})
 /datum/job/requisitions/tech
 	title = CARGO_TECHNICIAN
 	paygrade = "CMN"
-	comm_title = "Ord"
+	comm_title = "Ord"	
 	total_positions = 4
 	supervisors = "the requisitions officer"
 	selection_color = "#BAAFD9"
-	access = list(ACCESS_IFF_MARINE, ACCESS_MARINE_CARGO, ACCESS_MARINE_ALPHA)
-	minimal_access = list(ACCESS_IFF_MARINE, ACCESS_MARINE_CARGO, ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_MEDBAY, ACCESS_MARINE_DROPSHIP)
+	access = list(ACCESS_IFF_MARINE, ACCESS_MARINE_CARGO, ACCESS_MARINE_ENGINEERING)
+	minimal_access = list(ACCESS_IFF_MARINE, ACCESS_MARINE_CARGO, ACCESS_MARINE_MEDBAY, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_ENGINEERING)
 	skills_type = /datum/skills/CT
 	display_order = JOB_DISPLAY_ORDER_CARGO_TECH
 	outfit = /datum/outfit/job/requisitions/tech

--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -95,7 +95,7 @@ Make the TGMC proud!"})
 //Intelligence Officer
 /datum/job/command/intelligenceofficer
 	title = INTELLIGENCE_OFFICER
-	paygrade = "O3"
+	paygrade = "O4.5"
 	comm_title = "IO"
 	total_positions = 4
 	access = list(ACCESS_IFF_MARINE, ACCESS_MARINE_BRIDGE, ACCESS_MARINE_BRIG, ACCESS_MARINE_CARGO, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_ALPHA, ACCESS_MARINE_BRAVO, ACCESS_MARINE_CHARLIE, ACCESS_MARINE_DELTA)
@@ -304,7 +304,7 @@ In addition, you are tasked with the security of high-ranking personnel, includi
 //Chief Ship Engineer
 /datum/job/engineering/chief
 	title = CHIEF_SHIP_ENGINEER
-	paygrade = "O3"
+	paygrade = "O4"
 	comm_title = "CSE"
 	selection_color = "#ffeeaa"
 	access = list(ACCESS_IFF_MARINE, ACCESS_MARINE_CE, ACCESS_MARINE_ENGINEERING, ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_BRIDGE, ACCESS_CIVILIAN_ENGINEERING, ACCESS_MARINE_CARGO, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_PREP)
@@ -429,7 +429,7 @@ A happy ship is a well-functioning ship."})
 //Cargo Tech
 /datum/job/requisitions/tech
 	title = CARGO_TECHNICIAN
-	paygrade = "PO"
+	paygrade = "CMN"
 	comm_title = "CT"
 	total_positions = 2
 	supervisors = "the requisitions officer"
@@ -473,7 +473,7 @@ Listen to the radio in case someone requests a supply drop via the overwatch sys
 /datum/job/medical/professor
 	title = CHIEF_MEDICAL_OFFICER
 	comm_title = "CMO"
-	paygrade = "O3"
+	paygrade = "O4"
 	total_positions = 1
 	supervisors = "the acting captain"
 	selection_color = "#99FF99"

--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -430,7 +430,7 @@ A happy ship is a well-functioning ship."})
 /datum/job/requisitions/tech
 	title = CARGO_TECHNICIAN
 	paygrade = "CMN"
-	comm_title = "Ord"	
+	comm_title = "Ord"
 	total_positions = 4
 	supervisors = "the requisitions officer"
 	selection_color = "#BAAFD9"

--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -95,7 +95,7 @@ Make the TGMC proud!"})
 //Intelligence Officer
 /datum/job/command/intelligenceofficer
 	title = INTELLIGENCE_OFFICER
-	paygrade = "O4.5"
+	paygrade = "O3"
 	comm_title = "IO"
 	total_positions = 4
 	access = list(ACCESS_IFF_MARINE, ACCESS_MARINE_BRIDGE, ACCESS_MARINE_BRIG, ACCESS_MARINE_CARGO, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_ALPHA, ACCESS_MARINE_BRAVO, ACCESS_MARINE_CHARLIE, ACCESS_MARINE_DELTA)
@@ -304,7 +304,7 @@ In addition, you are tasked with the security of high-ranking personnel, includi
 //Chief Ship Engineer
 /datum/job/engineering/chief
 	title = CHIEF_SHIP_ENGINEER
-	paygrade = "O4"
+	paygrade = "O3"
 	comm_title = "CSE"
 	selection_color = "#ffeeaa"
 	access = list(ACCESS_IFF_MARINE, ACCESS_MARINE_CE, ACCESS_MARINE_ENGINEERING, ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_BRIDGE, ACCESS_CIVILIAN_ENGINEERING, ACCESS_MARINE_CARGO, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_PREP)
@@ -430,12 +430,12 @@ A happy ship is a well-functioning ship."})
 /datum/job/requisitions/tech
 	title = CARGO_TECHNICIAN
 	paygrade = "CMN"
-	comm_title = "CT"
-	total_positions = 2
+	comm_title = "Ord"
+	total_positions = 4
 	supervisors = "the requisitions officer"
 	selection_color = "#BAAFD9"
-	access = list(ACCESS_IFF_MARINE, ACCESS_MARINE_CARGO)
-	minimal_access = list(ACCESS_IFF_MARINE, ACCESS_MARINE_CARGO, ACCESS_MARINE_MEDBAY, ACCESS_MARINE_DROPSHIP)
+	access = list(ACCESS_IFF_MARINE, ACCESS_MARINE_CARGO, ACCESS_MARINE_ALPHA)
+	minimal_access = list(ACCESS_IFF_MARINE, ACCESS_MARINE_CARGO, ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_MEDBAY, ACCESS_MARINE_DROPSHIP)
 	skills_type = /datum/skills/CT
 	display_order = JOB_DISPLAY_ORDER_CARGO_TECH
 	outfit = /datum/outfit/job/requisitions/tech
@@ -443,9 +443,8 @@ A happy ship is a well-functioning ship."})
 
 /datum/job/requisitions/tech/radio_help_message(mob/M)
 	. = ..()
-	to_chat(M, {"Your job is to dispense supplies to the marines, including weapon attachments.
-Stay in your department when possible to ensure the marines have full access to the supplies they may require.
-Listen to the radio in case someone requests a supply drop via the overwatch system."})
+	to_chat(M, {"You are part of the service crew abord the Theseus, your main tasks will be supplying the marines
+in the field using the requisitions office. Your other tasks may consist of cleaning the station or serving food and drinks."})
 
 
 /datum/outfit/job/requisitions/tech
@@ -456,10 +455,8 @@ Listen to the radio in case someone requests a supply drop via the overwatch sys
 	belt = /obj/item/clothing/tie/holster/m4a3
 	ears = /obj/item/radio/headset/mainship/ct
 	w_uniform = /obj/item/clothing/under/rank/cargotech
-	wear_suit = /obj/item/clothing/suit/storage/marine/MP
 	shoes = /obj/item/clothing/shoes/marine
 	gloves = /obj/item/clothing/gloves/yellow
-	head = /obj/item/clothing/head/beanie
 	r_store = /obj/item/storage/pouch/general/medium
 	l_store = /obj/item/storage/pouch/magazine/pistol/large/full
 	back = /obj/item/storage/backpack/marine/satchel
@@ -473,7 +470,7 @@ Listen to the radio in case someone requests a supply drop via the overwatch sys
 /datum/job/medical/professor
 	title = CHIEF_MEDICAL_OFFICER
 	comm_title = "CMO"
-	paygrade = "O4"
+	paygrade = "O3"
 	total_positions = 1
 	supervisors = "the acting captain"
 	selection_color = "#99FF99"

--- a/code/game/objects/structures/crates_lockers/closets/secure/cm_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cm_closets.dm
@@ -493,7 +493,7 @@
 	new /obj/item/clothing/head/white_dress(src)
 
 /obj/structure/closet/secure_closet/cargotech
-	name = "Cargo Technician's Locker"
+	name = "Serviceman's Locker"
 	req_access = list(ACCESS_MARINE_CARGO)
 	icon_state = "secure_locked_cargo"
 	icon_closed = "secure_unlocked_cargo"
@@ -508,6 +508,8 @@
 	new /obj/item/radio/headset/mainship/ct(src)
 	new /obj/item/clothing/gloves/yellow(src)
 	new /obj/item/clothing/head/beanie(src)
+	new /obj/item/clothing/suit/storage/marine/MP(src)
+	new /obj/item/clothing/head/beanie(src)
 	new /obj/item/flashlight(src)
 	new /obj/item/storage/backpack/marine/satchel(src)
 	new /obj/item/clothing/tie/storage/webbing(src)
@@ -515,3 +517,11 @@
 	new /obj/item/clothing/gloves/white(src)
 	new /obj/item/clothing/under/whites(src)
 	new /obj/item/clothing/head/white_dress(src)
+
+/obj/structure/closet/secure_closet/kitchencrew/PopulateContents()
+	name = "Chef's locker"
+	req_access = list(ACCESS_MARINE_CARGO)
+	new /obj/item/clothing/suit/chef(src)
+	new /obj/item/clothing/head/chefhat(src)
+	new /obj/item/book/manual/chef_recipes(src)
+	new /obj/item/clothing/suit/apron(src)

--- a/code/modules/clothing/under/jobs/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian.dm
@@ -21,7 +21,7 @@
 	item_state = "lb_suit"
 
 /obj/item/clothing/under/rank/cargotech
-	name = "cargo technician's jumpsuit"
+	name = "Serviceman's jumpsuit"
 	desc = "Shooooorts! They're comfy and easy to wear!"
 	icon_state = "cargotech"
 	item_state = "lb_suit"


### PR DESCRIPTION
## About The Pull Request

Gives more choices for the cargo technician to do except for supply, also increases the slots from 2 to 4

## Why It's Good For The Game
Not only it's been a suggested change, then also it's a major fluff to the cargo technician and the ship, who now becomes a Serviceman and is tasked mainly with still being supply technician, but can also take upon janitorial or cooking tasks
## Changelog
:cl:
add: Locker of a chef, requiring cargo tech access, both placed in the kitchen backrooms of upper and lower deck (2 in total)
add: Added maint access to CT so he can access janitorial and hydroponics
del: one fridge from kitchen backroom lower deck to create space for the locker
tweak: Cargo tech is now called serviceman, his armour and hat have been put into CT locker, which is now named Serviceman's locker
/:cl: