### PR TITLE
Makes humans jitter when larval stage increases

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -86,9 +86,9 @@
 		counter = 0
 		stage++
 		log_combat(affected_mob, null, "had their embryo advance to stage [stage]")
-		if(iscarbon(affected_mob))
-			var/mob/living/carbon/C = affected_mob
-			C.med_hud_set_status()
+		var/mob/living/carbon/C = affected_mob
+		C.med_hud_set_status()
+		affected_mob.jitter(stage * 5)
 
 	switch(stage)
 		if(2)


### PR DESCRIPTION
## About The Pull Request

So you can somewhat tell when you're about to burst.
Also removes a check that Lak said I could remove.

## Why It's Good For The Game

It isn't fun to suddenly drop unconscious and burst without warning.

## Changelog
:cl:
tweak: Humans now shake when a larvae inside them grows older.
/:cl: