### PR TITLE
Prison station tweaks

### DIFF
--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -636,9 +636,6 @@
 /obj/structure/disposalpipe/up{
 	dir = 1
 	},
-/obj/structure/sign/deathsposal{
-	dir = 4
-	},
 /turf/open/floor/prison/purple/whitepurple{
 	dir = 4
 	},
@@ -1358,9 +1355,6 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
-	},
-/obj/structure/sign/deathsposal{
-	dir = 8
 	},
 /turf/open/floor/prison/whitepurple/full,
 /area/prison/research/secret/bioengineering)
@@ -5187,6 +5181,14 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/button/door/open_only/landing_zone/lz2,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/prison/hangar/civilian)
 "apB" = (
@@ -6734,14 +6736,6 @@
 	dir = 1
 	},
 /area/prison/medbay)
-"atk" = (
-/obj/machinery/door/poddoor/four_tile_hor{
-	name = "Research Hangar Door"
-	},
-/turf/open/floor/prison/darkpurple{
-	dir = 4
-	},
-/area/prison/hangar_storage/research)
 "atl" = (
 /turf/open/floor/plating,
 /area/prison/hangar_storage/research)
@@ -9062,7 +9056,7 @@
 /area/prison/research)
 "ayZ" = (
 /obj/structure/table/reinforced,
-/obj/item/pizzabox,
+/obj/item/pizzabox/vegetable,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/research)
 "aza" = (
@@ -9684,30 +9678,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/research)
-"aAA" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 6
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/machinery/landinglight/ds2/delaythree{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/prison/hangar/civilian)
-"aAB" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 10
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/machinery/landinglight/ds2/delaythree{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/prison/hangar/civilian)
 "aAC" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
@@ -9794,6 +9764,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 4;
 	on = 1
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 9
 	},
 /turf/open/floor/plating,
 /area/prison/hangar_storage/research)
@@ -10646,7 +10619,7 @@
 /obj/machinery/power/apc/drained{
 	dir = 1
 	},
-/turf/open/floor/freezer,
+/turf/open/floor/prison/sterilewhite,
 /area/prison/toilet/research)
 "aCF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -11116,6 +11089,11 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/nw)
 "aDF" = (
@@ -11442,7 +11420,9 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/freezer,
+/turf/open/floor/prison{
+	icon_state = "kitchen"
+	},
 /area/prison/toilet/research)
 "aEv" = (
 /turf/open/floor/prison{
@@ -11453,15 +11433,15 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	on = 1
 	},
-/turf/open/floor/freezer,
+/turf/open/floor/prison/sterilewhite,
 /area/prison/toilet/research)
 "aEx" = (
 /obj/machinery/vending/nanomed,
-/turf/open/floor/freezer,
+/turf/open/floor/prison/sterilewhite,
 /area/prison/toilet/research)
 "aEy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber,
-/turf/open/floor/freezer,
+/turf/open/floor/prison/sterilewhite,
 /area/prison/toilet/research)
 "aEz" = (
 /obj/machinery/shower{
@@ -11470,7 +11450,9 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/freezer,
+/turf/open/floor/prison{
+	icon_state = "kitchen"
+	},
 /area/prison/toilet/research)
 "aEA" = (
 /obj/structure/bed,
@@ -11519,25 +11501,6 @@
 	},
 /turf/open/floor/prison,
 /area/prison/recreation/highsec/n)
-"aEJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/prison/maintenance/residential/nw)
 "aEK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
@@ -11916,10 +11879,10 @@
 	pixel_x = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/freezer,
+/turf/open/floor/prison/sterilewhite,
 /area/prison/toilet/research)
 "aFO" = (
-/turf/open/floor/freezer,
+/turf/open/floor/prison/sterilewhite,
 /area/prison/toilet/research)
 "aFP" = (
 /obj/structure/sink{
@@ -11929,7 +11892,7 @@
 	pixel_x = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/freezer,
+/turf/open/floor/prison/sterilewhite,
 /area/prison/toilet/research)
 "aFQ" = (
 /obj/machinery/light/small{
@@ -12560,14 +12523,14 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/open/floor/freezer,
+/turf/open/floor/prison/sterilewhite,
 /area/prison/toilet/research)
 "aHa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
 /obj/effect/decal/cleanable/blood,
-/turf/open/floor/freezer,
+/turf/open/floor/prison/sterilewhite,
 /area/prison/toilet/research)
 "aHb" = (
 /obj/structure/closet,
@@ -13918,7 +13881,7 @@
 /turf/open/floor/prison/green{
 	dir = 1
 	},
-/area/prison/cellblock/lowsec/sw)
+/area/prison/security/monitoring/lowsec/ne)
 "aKf" = (
 /obj/structure/flora/pottedplant,
 /turf/open/floor/prison/purple/whitepurple{
@@ -14082,7 +14045,7 @@
 	name = "Toilet";
 	opacity = 0
 	},
-/turf/open/floor/freezer,
+/turf/open/floor/prison/sterilewhite,
 /area/prison/toilet/research)
 "aKz" = (
 /turf/open/floor/prison/red{
@@ -14607,7 +14570,9 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/freezer,
+/turf/open/floor/prison{
+	icon_state = "kitchen"
+	},
 /area/prison/quarters/research)
 "aLD" = (
 /obj/structure/closet,
@@ -14925,7 +14890,9 @@
 /obj/structure/mirror{
 	pixel_x = -26
 	},
-/turf/open/floor/freezer,
+/turf/open/floor/prison{
+	icon_state = "kitchen"
+	},
 /area/prison/quarters/research)
 "aMm" = (
 /obj/structure/bed/chair/comfy,
@@ -15108,7 +15075,9 @@
 	dir = 4
 	},
 /obj/machinery/door/window/northright,
-/turf/open/floor/freezer,
+/turf/open/floor/prison{
+	icon_state = "kitchen"
+	},
 /area/prison/quarters/research)
 "aMP" = (
 /obj/structure/bookcase,
@@ -15420,9 +15389,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/highsec/north/south)
-"aNL" = (
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/prison/security/checkpoint/highsec/n)
 "aNM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -16034,20 +16000,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/highsec/north/south)
-"aPj" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/prison/security/checkpoint/highsec/n)
 "aPk" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -17048,13 +17000,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/prison/green/full,
-/area/prison/quarters/staff)
-"aRq" = (
-/obj/structure/bed,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/effect/landmark/corpsespawner/chef,
 /turf/open/floor/prison/green/full,
 /area/prison/quarters/staff)
@@ -17320,15 +17265,12 @@
 /turf/open/floor/prison/green{
 	dir = 5
 	},
-/area/prison/cellblock/lowsec/sw)
+/area/prison/security/monitoring/lowsec/ne)
 "aRZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison/cleanmarked,
 /area/prison/cellblock/highsec/north/south)
-"aSa" = (
-/turf/closed/wall/prison,
-/area/prison/security/checkpoint/highsec/n)
 "aSb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -18557,20 +18499,20 @@
 	req_one_access_txt = "0"
 	},
 /turf/open/floor/plating,
-/area/prison/cellblock/lowsec/sw)
+/area/prison/security/monitoring/lowsec/ne)
 "aUV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/prison/green,
-/area/prison/cellblock/lowsec/sw)
+/area/prison/security/monitoring/lowsec/ne)
 "aUW" = (
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/prison/green,
-/area/prison/cellblock/lowsec/sw)
+/area/prison/security/monitoring/lowsec/ne)
 "aUX" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -18579,7 +18521,7 @@
 /turf/open/floor/prison/green{
 	dir = 6
 	},
-/area/prison/cellblock/lowsec/sw)
+/area/prison/security/monitoring/lowsec/ne)
 "aUY" = (
 /obj/machinery/door/airlock/mainship/secure{
 	density = 0;
@@ -18721,7 +18663,7 @@
 /turf/open/floor/prison/green{
 	dir = 1
 	},
-/area/prison/cellblock/lowsec/sw)
+/area/prison/security/monitoring/lowsec/ne)
 "aVs" = (
 /obj/structure/bed/chair,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -19385,7 +19327,9 @@
 	name = "Toilet";
 	opacity = 0
 	},
-/turf/open/floor/freezer,
+/turf/open/floor/prison{
+	icon_state = "kitchen"
+	},
 /area/prison/quarters/research)
 "aWY" = (
 /obj/structure/cable{
@@ -20209,7 +20153,9 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/prison/sterilewhite,
+/turf/open/floor/prison{
+	icon_state = "kitchen"
+	},
 /area/prison/toilet/staff)
 "aZq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -23417,9 +23363,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/open/floor/prison/rampbottom{
-	dir = 8
-	},
+/turf/open/floor/prison/cleanmarked,
 /area/prison/canteen)
 "bhd" = (
 /turf/open/floor/prison/sterilewhite,
@@ -24117,9 +24061,7 @@
 	pixel_x = 24;
 	pixel_y = -24
 	},
-/turf/open/floor/prison/rampbottom{
-	dir = 8
-	},
+/turf/open/floor/prison/cleanmarked,
 /area/prison/canteen)
 "biq" = (
 /obj/structure/cable{
@@ -24170,7 +24112,7 @@
 	},
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 2;
-	name = "Canteen"
+	name = "Kitchen"
 	},
 /turf/open/floor/prison{
 	icon_state = "kitchen"
@@ -29377,7 +29319,7 @@
 /turf/open/floor/prison/green{
 	dir = 1
 	},
-/area/prison/cellblock/lowsec/sw)
+/area/prison/security/monitoring/lowsec/sw)
 "buD" = (
 /obj/machinery/door/airlock/mainship/generic,
 /obj/machinery/door/poddoor/shutters/transit,
@@ -29871,16 +29813,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -31616,11 +31548,6 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/open/floor/prison/trim/red{
 	dir = 1
 	},
@@ -32191,14 +32118,9 @@
 /turf/open/floor/plating,
 /area/prison/hallway/east)
 "bBD" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/multi_tile/mainship/comdoor{
-	name = "East Hallway";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 4;
+	name = "East Hallway"
 	},
 /turf/open/floor/prison{
 	icon_state = "bright_clean";
@@ -32482,13 +32404,8 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/open/floor/prison/green,
-/area/prison/cellblock/lowsec/sw)
+/area/prison/security/monitoring/lowsec/sw)
 "bCl" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
@@ -32514,7 +32431,7 @@
 /turf/open/floor/prison/green{
 	dir = 9
 	},
-/area/prison/cellblock/lowsec/sw)
+/area/prison/security/monitoring/lowsec/sw)
 "bCp" = (
 /obj/machinery/light{
 	dir = 1
@@ -32525,7 +32442,7 @@
 /turf/open/floor/prison/green{
 	dir = 1
 	},
-/area/prison/cellblock/lowsec/sw)
+/area/prison/security/monitoring/lowsec/sw)
 "bCq" = (
 /obj/machinery/power/apc/drained{
 	dir = 4
@@ -32542,7 +32459,7 @@
 /turf/open/floor/prison/green{
 	dir = 1
 	},
-/area/prison/cellblock/lowsec/sw)
+/area/prison/security/monitoring/lowsec/sw)
 "bCs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32598,7 +32515,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison/green,
-/area/prison/cellblock/lowsec/sw)
+/area/prison/security/monitoring/lowsec/sw)
 "bCy" = (
 /obj/machinery/light{
 	dir = 1
@@ -33106,13 +33023,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /turf/open/floor/prison/green,
-/area/prison/cellblock/lowsec/sw)
+/area/prison/security/monitoring/lowsec/sw)
 "bDO" = (
 /obj/machinery/light{
 	dir = 1
@@ -33912,11 +33824,6 @@
 	name = "Southwest Low-Security Monitoring";
 	req_access_txt = "0"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/open/floor/prison,
 /area/prison/security/monitoring/lowsec/sw)
 "bFk" = (
@@ -34277,9 +34184,9 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/east)
 "bFV" = (
-/obj/machinery/door/airlock/multi_tile/mainship/comdoor{
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 2;
-	req_access_txt = "0"
+	name = "East Hallway"
 	},
 /turf/open/floor/prison{
 	icon_state = "bright_clean";
@@ -34429,10 +34336,7 @@
 	req_one_access_txt = "0"
 	},
 /turf/open/floor/plating,
-/area/prison/cellblock/mediumsec/north)
-"bGn" = (
-/turf/open/floor/prison,
-/area/prison/cellblock/mediumsec/north)
+/area/prison/laundry)
 "bGo" = (
 /turf/open/floor/prison/marked,
 /area/prison/cellblock/highsec/south/north)
@@ -34464,13 +34368,6 @@
 "bGt" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
-	dir = 8
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc/drained{
 	dir = 8
 	},
 /turf/open/floor/prison/trim/red{
@@ -34989,29 +34886,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/multi_tile/mainship/comdoor{
-	req_access_txt = "0"
-	},
-/turf/open/floor/prison,
-/area/prison/hallway/east)
-"bHP" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 4;
+	name = "East Hallway"
 	},
 /turf/open/floor/prison,
 /area/prison/hallway/east)
@@ -35643,7 +35523,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/open/floor/prison,
+/turf/open/floor/prison/plate,
 /area/prison/cellblock/mediumsec/north)
 "bIY" = (
 /obj/structure/bed,
@@ -35719,10 +35599,6 @@
 	},
 /turf/open/floor/wood,
 /area/prison/parole/main)
-"bJj" = (
-/obj/effect/landmark/monkey_spawn,
-/turf/open/floor/prison,
-/area/prison/cellblock/mediumsec/north)
 "bJk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison{
@@ -36015,7 +35891,7 @@
 /area/prison/hallway/east)
 "bJX" = (
 /obj/effect/alien/weeds/node,
-/turf/open/floor/prison,
+/turf/open/floor/prison/plate,
 /area/prison/cellblock/mediumsec/north)
 "bJY" = (
 /obj/structure/cable{
@@ -36129,15 +36005,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/open/floor/prison/yellow{
 	dir = 5
 	},
-/area/prison/cellblock/mediumsec/north)
+/area/prison/security/checkpoint/medsec)
 "bKl" = (
 /turf/closed/wall/r_wall/prison_unmeltable,
 /area/prison/residential/south)
@@ -36183,7 +36054,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/prison,
+/turf/open/floor/prison/plate,
 /area/prison/cellblock/mediumsec/south)
 "bKs" = (
 /turf/open/floor/prison,
@@ -36264,7 +36135,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/open/floor/prison,
+/turf/open/floor/prison/plate,
 /area/prison/cellblock/mediumsec/south)
 "bKD" = (
 /obj/effect/landmark/start/surv_spawn,
@@ -36314,7 +36185,8 @@
 /area/prison/hallway/east)
 "bKI" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	dir = 2
+	dir = 2;
+	name = "East Hallway"
 	},
 /turf/open/floor/prison{
 	icon_state = "darkbrownfull2"
@@ -36447,9 +36319,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/wood,
 /area/prison/residential/south)
-"bKW" = (
-/turf/open/floor/prison,
-/area/prison/cellblock/mediumsec/south)
 "bKX" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
@@ -36464,7 +36333,7 @@
 /area/prison/residential/south)
 "bKZ" = (
 /obj/effect/alien/weeds/node,
-/turf/open/floor/prison,
+/turf/open/floor/prison/plate,
 /area/prison/cellblock/mediumsec/south)
 "bLa" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -36495,7 +36364,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/open/floor/prison,
+/turf/open/floor/prison/plate,
 /area/prison/cellblock/highsec/south/north)
 "bLf" = (
 /obj/machinery/light{
@@ -36690,7 +36559,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
-/turf/open/floor/prison,
+/turf/open/floor/prison/plate,
 /area/prison/recreation/highsec/s)
 "bLI" = (
 /obj/structure/bed/chair/office/light{
@@ -36728,7 +36597,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/turf/open/floor/prison,
+/turf/open/floor/prison/plate,
 /area/prison/cellblock/mediumsec/south)
 "bLN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -36763,7 +36632,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/prison,
+/turf/open/floor/prison/plate,
 /area/prison/cellblock/mediumsec/south)
 "bLR" = (
 /obj/structure/sink{
@@ -36965,18 +36834,8 @@
 /area/prison/intake)
 "bMo" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/mainship/security/glass{
-	dir = 2;
-	name = "Security Department";
-	req_access_txt = "0"
-	},
-/turf/open/floor/prison/darkred/full,
-/area/prison/security)
-"bMp" = (
-/obj/machinery/door/airlock/mainship/security/glass{
-	dir = 2;
-	name = "Security Department";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/multi_tile/mainship/secdoor{
+	name = "Security Department"
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/security)
@@ -37273,7 +37132,7 @@
 	d2 = 4
 	},
 /turf/open/floor/prison/yellow/full,
-/area/prison/cellblock/mediumsec/north)
+/area/prison/security/checkpoint/medsec)
 "bNd" = (
 /turf/closed/wall/prison,
 /area/prison/intake)
@@ -37485,7 +37344,7 @@
 	},
 /obj/machinery/alarm,
 /turf/open/floor/prison/yellow/full,
-/area/prison/cellblock/mediumsec/north)
+/area/prison/security/checkpoint/medsec)
 "bNI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -37639,7 +37498,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison/yellow/full,
-/area/prison/cellblock/mediumsec/north)
+/area/prison/security/checkpoint/medsec)
 "bNY" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -37745,7 +37604,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/open/floor/prison,
+/turf/open/floor/prison/plate,
 /area/prison/cellblock/mediumsec/south)
 "bOg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -37855,10 +37714,6 @@
 	dir = 10
 	},
 /area/prison/toilet/security)
-"bOt" = (
-/obj/structure/window/framed/prison/reinforced/hull,
-/turf/open/beach/sea,
-/area/prison/residential/south)
 "bOu" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/prison/yellow{
@@ -37880,7 +37735,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/prison,
+/turf/open/floor/prison/plate,
 /area/prison/cellblock/mediumsec/south)
 "bOx" = (
 /turf/open/floor/prison/rampbottom{
@@ -37940,7 +37795,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/open/floor/prison,
+/turf/open/floor/prison/plate,
 /area/prison/cellblock/mediumsec/south)
 "bOE" = (
 /obj/machinery/door/poddoor/timed_late{
@@ -37975,7 +37830,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/open/floor/prison,
+/turf/open/floor/prison/plate,
 /area/prison/cellblock/mediumsec/south)
 "bOH" = (
 /obj/structure/bed/chair{
@@ -38124,7 +37979,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/prison,
+/turf/open/floor/prison/plate,
 /area/prison/recreation/highsec/s)
 "bOZ" = (
 /obj/structure/cable{
@@ -38153,7 +38008,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/prison,
+/turf/open/floor/prison/plate,
 /area/prison/recreation/highsec/s)
 "bPb" = (
 /obj/structure/cable{
@@ -38165,7 +38020,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/prison,
+/turf/open/floor/prison/plate,
 /area/prison/cellblock/mediumsec/south)
 "bPc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -38387,7 +38242,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/prison,
+/turf/open/floor/prison/plate,
 /area/prison/recreation/highsec/s)
 "bPH" = (
 /obj/structure/cable{
@@ -38818,10 +38673,7 @@
 /area/prison/recreation/highsec/s)
 "bQN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber,
-/turf/open/floor/prison,
-/area/prison/recreation/highsec/s)
-"bQO" = (
-/turf/open/floor/prison,
+/turf/open/floor/prison/plate,
 /area/prison/recreation/highsec/s)
 "bQP" = (
 /obj/structure/cable{
@@ -38829,7 +38681,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/open/floor/prison,
+/turf/open/floor/prison/plate,
 /area/prison/recreation/highsec/s)
 "bQQ" = (
 /turf/open/floor/prison/plate,
@@ -39624,15 +39476,10 @@
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/open/floor/prison/yellow{
 	dir = 1
 	},
-/area/prison/cellblock/mediumsec/north)
+/area/prison/security/checkpoint/medsec)
 "bSO" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -39649,11 +39496,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /turf/open/floor/prison/trim/red{
 	dir = 8
 	},
@@ -39662,21 +39504,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/open/floor/prison,
 /area/prison/security/checkpoint/medsec)
 "bSR" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc/drained{
-	dir = 8
-	},
 /turf/open/floor/prison/trim/red{
 	dir = 4
 	},
@@ -39751,7 +39581,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison/yellow/full,
-/area/prison/cellblock/mediumsec/north)
+/area/prison/security/checkpoint/medsec)
 "bSX" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -40037,7 +39867,7 @@
 /turf/open/floor/prison/yellow{
 	dir = 9
 	},
-/area/prison/cellblock/mediumsec/north)
+/area/prison/security/checkpoint/medsec)
 "bTJ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
@@ -40144,11 +39974,11 @@
 /area/prison/recreation/highsec/s)
 "bTY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/prison,
+/turf/open/floor/prison/plate,
 /area/prison/recreation/highsec/s)
 "bTZ" = (
 /obj/structure/table/gamblingtable,
-/turf/open/floor/prison,
+/turf/open/floor/prison/plate,
 /area/prison/recreation/highsec/s)
 "bUa" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
@@ -40206,7 +40036,7 @@
 /turf/open/floor/prison/yellow{
 	dir = 1
 	},
-/area/prison/cellblock/mediumsec/north)
+/area/prison/security/checkpoint/medsec)
 "bUg" = (
 /obj/structure/monorail{
 	dir = 10
@@ -40220,13 +40050,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/open/floor/prison/yellow/full,
-/area/prison/cellblock/mediumsec/north)
+/area/prison/security/checkpoint/medsec)
 "bUi" = (
 /obj/structure/toilet{
 	dir = 1
@@ -40375,11 +40200,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /turf/open/floor/prison/trim/red{
 	dir = 10
@@ -40889,7 +40709,7 @@
 	dir = 1;
 	on = 1
 	},
-/turf/open/floor/prison,
+/turf/open/floor/prison/plate,
 /area/prison/recreation/highsec/s)
 "bVE" = (
 /obj/machinery/light{
@@ -40972,11 +40792,6 @@
 	req_access_txt = "0"
 	},
 /obj/effect/landmark/lv624/fog_blocker,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/checkpoint/medsec)
 "bVO" = (
@@ -41453,18 +41268,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/open/floor/prison/yellow/full,
-/area/prison/cellblock/mediumsec/north)
+/area/prison/security/checkpoint/medsec)
 "bXe" = (
 /turf/open/floor/prison/yellow/full,
-/area/prison/cellblock/mediumsec/north)
-"bXf" = (
-/turf/closed/wall/r_wall/prison,
 /area/prison/cellblock/mediumsec/north)
 "bXh" = (
 /turf/open/beach/coastline,
@@ -42422,18 +42229,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/mainship/security/glass{
-	dir = 2;
-	name = "Intake Processing";
-	req_access_txt = "0"
-	},
-/turf/open/floor/prison/darkred/full,
-/area/prison/security)
-"bZr" = (
-/obj/machinery/door/airlock/mainship/security/glass{
-	dir = 2;
-	name = "Intake Processing";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/multi_tile/mainship/secdoor{
+	name = "Intake Processing"
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/security)
@@ -42805,20 +42602,6 @@
 	dir = 8
 	},
 /area/prison/cellblock/mediumsec/north)
-"cax" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/prison,
-/area/prison/cellblock/mediumsec/north)
 "cay" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -43174,10 +42957,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/security/glass{
-	name = "Security Department";
-	req_access_txt = "0"
-	},
 /turf/open/floor/prison,
 /area/prison/security)
 "cbs" = (
@@ -43503,7 +43282,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/security/glass,
 /turf/open/floor/prison,
 /area/prison/security)
 "ccf" = (
@@ -44340,9 +44118,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/mainship/security/glass{
-	name = "Security Department";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/multi_tile/mainship/secdoor{
+	dir = 2;
+	name = "Security Department"
 	},
 /turf/open/floor/prison,
 /area/prison/security)
@@ -44361,7 +44139,10 @@
 /turf/open/floor/prison,
 /area/prison/security)
 "cdC" = (
-/obj/machinery/door/airlock/mainship/security/glass,
+/obj/machinery/door/airlock/multi_tile/mainship/secdoor{
+	dir = 2;
+	name = "Security Department"
+	},
 /turf/open/floor/prison,
 /area/prison/security)
 "cdD" = (
@@ -45567,35 +45348,15 @@
 /turf/closed/wall/prison,
 /area/prison/security/briefing)
 "cgO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/airlock/multi_tile/mainship/secdoor{
+	name = "Briefing"
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/door/airlock/mainship/security/glass{
-	dir = 2;
-	name = "Briefing";
-	req_access_txt = "0"
-	},
-/turf/open/floor/prison/darkred/full,
-/area/prison/security/briefing)
-"cgP" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/mainship/security/glass{
-	dir = 2;
-	name = "Briefing";
-	req_access_txt = "0"
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/briefing)
@@ -45604,10 +45365,8 @@
 /turf/open/floor/plating,
 /area/prison/security/briefing)
 "cgR" = (
-/obj/machinery/door/airlock/mainship/security/glass{
-	dir = 2;
-	name = "Briefing";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/multi_tile/mainship/secdoor{
+	name = "Briefing"
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/briefing)
@@ -45674,7 +45433,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/turf/open/floor/prison,
+/turf/open/floor/prison/plate,
 /area/prison/cellblock/mediumsec/south)
 "chb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -46356,7 +46115,9 @@
 	},
 /area/prison/cellblock/protective)
 "ciP" = (
-/turf/open/floor/prison/sterilewhite,
+/turf/open/floor/prison{
+	icon_state = "kitchen"
+	},
 /area/prison/cellblock/protective)
 "ciQ" = (
 /obj/structure/table/reinforced,
@@ -47881,7 +47642,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/prison,
+/turf/open/floor/prison/plate,
 /area/prison/cellblock/mediumsec/north)
 "cmq" = (
 /obj/effect/landmark/monkey_spawn,
@@ -49946,7 +49707,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/prison,
+/turf/open/floor/prison/plate,
 /area/prison/cellblock/mediumsec/south)
 "crY" = (
 /obj/effect/decal/cleanable/blood,
@@ -51185,7 +50946,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/open/floor/prison,
+/turf/open/floor/prison/plate,
 /area/prison/cellblock/highsec/south/north)
 "cvo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -52939,6 +52700,10 @@
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/highsec/south/south)
+"eyC" = (
+/obj/effect/decal/warning_stripes/thin,
+/turf/open/floor/plating,
+/area/prison/hangar_storage/research)
 "eyF" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
@@ -52963,6 +52728,16 @@
 	},
 /turf/open/floor/prison,
 /area/prison/cellblock/mediumsec/north)
+"eLE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/prison/plate,
+/area/prison/cellblock/highsec/north/south)
 "fug" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -53003,6 +52778,22 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison/red/corner,
 /area/prison/cellblock/highsec/north/south)
+"gne" = (
+/obj/effect/decal/warning_stripes/thin,
+/obj/machinery/landinglight/ds2/delaythree,
+/turf/open/floor/plating,
+/area/prison/hangar/civilian)
+"grr" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/ne)
+"gCN" = (
+/obj/effect/decal/warning_stripes/thin,
+/obj/machinery/landinglight/ds2,
+/turf/open/floor/plating,
+/area/prison/hangar/civilian)
 "gHF" = (
 /obj/structure/window/framed/prison/reinforced,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
@@ -53022,6 +52813,11 @@
 	dir = 10
 	},
 /area/prison/yard)
+"hEZ" = (
+/obj/effect/decal/warning_stripes/thin,
+/obj/machinery/landinglight/ds2/delayone,
+/turf/open/floor/plating,
+/area/prison/hangar/civilian)
 "hHw" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -53051,6 +52847,11 @@
 	dir = 1
 	},
 /area/prison/cellblock/lowsec/se)
+"hZS" = (
+/obj/effect/decal/warning_stripes/thin,
+/obj/machinery/landinglight/ds2/delaytwo,
+/turf/open/floor/plating,
+/area/prison/hangar/civilian)
 "ilF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -53061,6 +52862,12 @@
 	},
 /turf/open/floor/prison/red/corner,
 /area/prison/cellblock/highsec/south/north)
+"inc" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 1
+	},
+/turf/closed/wall/r_wall/prison,
+/area/prison/hangar/civilian)
 "izb" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall/prison,
@@ -53115,6 +52922,10 @@
 	dir = 1
 	},
 /area/prison/cellblock/highsec/north/south)
+"jFi" = (
+/obj/structure/window/framed/prison/reinforced/hull,
+/turf/open/floor/plating,
+/area/prison/hangar/civilian)
 "jNN" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall/prison,
@@ -53135,6 +52946,14 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall/prison,
 /area/prison/holding/holding2)
+"kxi" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/nw)
 "kxK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -53159,18 +52978,10 @@
 	dir = 4
 	},
 /area/prison/cellblock/highsec/north/south)
-"kVF" = (
-/obj/machinery/button/door/open_only/landing_zone/lz2{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/prison/hangar/civilian)
+"kPu" = (
+/obj/machinery/vending/cigarette/colony,
+/turf/open/floor/prison/darkred/full,
+/area/prison/monorail/east)
 "laO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -53183,6 +52994,12 @@
 	dir = 1
 	},
 /area/prison/cellblock/highsec/south/north)
+"lhZ" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/prison/hangar_storage/research)
 "lue" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/shuttle/shuttle_control/dropship1,
@@ -53221,6 +53038,22 @@
 	dir = 10
 	},
 /area/prison/hallway/central)
+"neb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/prison/green{
+	dir = 1
+	},
+/area/prison/security/monitoring/lowsec/ne)
 "njY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -53232,6 +53065,16 @@
 /turf/open/floor/prison/yellow{
 	dir = 8
 	},
+/area/prison/cellblock/mediumsec/north)
+"nOc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/prison/plate,
 /area/prison/cellblock/mediumsec/north)
 "nOu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -53262,6 +53105,18 @@
 	dir = 10
 	},
 /area/prison/hangar/civilian)
+"pvO" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/closed/wall/r_wall/prison,
+/area/prison/hangar/civilian)
+"pBH" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/prison/hangar_storage/research)
 "pOU" = (
 /obj/structure/window/framed/prison/reinforced/hull,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
@@ -53285,6 +53140,39 @@
 	dir = 8
 	},
 /area/prison/cellblock/mediumsec/south)
+"qfo" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/nw)
+"qxc" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/sw)
+"qBi" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/prison/hangar/civilian)
+"qMm" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/prison/hangar_storage/research)
+"qWN" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/prison/hangar/civilian)
 "rqn" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall/prison,
@@ -53309,6 +53197,12 @@
 	dir = 4
 	},
 /area/prison/cellblock/mediumsec/south)
+"rZZ" = (
+/obj/machinery/door/poddoor/four_tile_ver{
+	name = "Civilian Hangar Door"
+	},
+/turf/open/floor/plating,
+/area/prison/hangar/civilian)
 "shN" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/prison,
@@ -53321,7 +53215,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/open/floor/prison,
+/turf/open/floor/prison/plate,
 /area/prison/cellblock/mediumsec/south)
 "swP" = (
 /obj/machinery/door/airlock/mainship/secure{
@@ -53338,6 +53232,29 @@
 	dir = 4
 	},
 /area/prison/cellblock/mediumsec/west)
+"sRe" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/prison/plate,
+/area/prison/cellblock/mediumsec/north)
+"sWQ" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/se)
 "sXw" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall/prison,
@@ -53350,6 +53267,12 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall/prison,
 /area/prison/engineering)
+"tsb" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/prison/hangar_storage/research)
 "tGu" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall/prison,
@@ -53439,6 +53362,12 @@
 	dir = 1
 	},
 /area/prison/cellblock/mediumsec/east)
+"vhu" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/prison/hangar_storage/research)
 "vhE" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
@@ -53485,6 +53414,12 @@
 	dir = 10
 	},
 /area/prison/hallway/central)
+"woW" = (
+/obj/machinery/door/airlock/mainship/maint{
+	req_one_access_txt = "0"
+	},
+/turf/open/floor/plating,
+/area/prison/security/monitoring/lowsec/sw)
 "wMM" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -53504,6 +53439,12 @@
 	dir = 4
 	},
 /area/prison/cellblock/highsec/south/north)
+"xRQ" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/prison/hangar/civilian)
 "xRY" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall/prison,
@@ -55194,30 +55135,30 @@ aab
 aab
 amu
 amu
-amu
-amu
-amu
-amu
-amu
-amu
-amu
-amu
-amu
-amu
-amu
-amu
-amu
-amu
-amu
-amu
-amu
-amu
-amu
-amu
-amu
-amu
-amu
-amu
+aok
+aok
+aok
+rZZ
+aok
+aok
+aok
+rZZ
+aok
+aok
+aok
+rZZ
+aok
+aok
+aok
+rZZ
+aok
+aok
+aok
+rZZ
+aok
+aok
+aok
+rZZ
 amu
 amu
 aab
@@ -55450,15 +55391,6 @@ aab
 aab
 aab
 amu
-aok
-aok
-aok
-aok
-aok
-aok
-aok
-aok
-aok
 lue
 aok
 aok
@@ -55475,7 +55407,16 @@ aok
 aok
 aok
 aok
-kVF
+aok
+aok
+aok
+aok
+aok
+aok
+aok
+aok
+aok
+aok
 amu
 aab
 aab
@@ -55706,7 +55647,7 @@ aab
 aab
 aab
 aab
-amu
+jFi
 aok
 aok
 aok
@@ -55733,7 +55674,7 @@ aok
 aok
 aok
 aok
-amu
+jFi
 aab
 aab
 aab
@@ -55963,10 +55904,10 @@ aab
 aab
 aab
 aab
-amu
+jFi
 aok
-aok
-aAA
+qWN
+bcJ
 aAD
 aTC
 bbL
@@ -55990,7 +55931,7 @@ bcJ
 bvp
 aok
 aok
-amu
+jFi
 aab
 aab
 aab
@@ -56220,9 +56161,9 @@ aab
 aab
 aab
 aab
-amu
-apf
+jFi
 aok
+hZS
 aok
 aok
 aok
@@ -56246,8 +56187,8 @@ aok
 aok
 ctn
 aok
-ctw
-amu
+aok
+jFi
 aab
 aab
 aab
@@ -56478,8 +56419,8 @@ aab
 aab
 aab
 amu
-aok
-aok
+apf
+hEZ
 aok
 aok
 aok
@@ -56503,7 +56444,7 @@ aok
 aok
 cto
 aok
-aok
+ctw
 amu
 aab
 aab
@@ -56734,9 +56675,9 @@ aab
 aab
 aab
 aab
-amu
+jFi
 aok
-aok
+gCN
 aok
 aok
 aok
@@ -56761,7 +56702,7 @@ aok
 ctq
 aok
 aok
-amu
+jFi
 aab
 aab
 aab
@@ -56991,9 +56932,9 @@ aab
 aab
 aab
 aab
-amu
-apf
+jFi
 aok
+gne
 aok
 aok
 aok
@@ -57017,8 +56958,8 @@ aok
 aok
 ctr
 aok
-ctw
-amu
+aok
+jFi
 aab
 aab
 aab
@@ -57248,9 +57189,9 @@ aab
 aab
 aab
 aab
-amu
+jFi
 aok
-aok
+hZS
 aok
 aok
 aok
@@ -57275,7 +57216,7 @@ aok
 ctn
 aok
 aok
-amu
+jFi
 aab
 aab
 aab
@@ -57506,8 +57447,8 @@ aab
 aab
 aab
 amu
-aok
-aok
+apf
+hEZ
 aok
 aok
 aok
@@ -57531,7 +57472,7 @@ aok
 aok
 cto
 aok
-aok
+ctw
 amu
 aab
 aab
@@ -57762,9 +57703,9 @@ aab
 aab
 aab
 aab
-amu
-apf
+jFi
 aok
+gCN
 aok
 aok
 aok
@@ -57788,8 +57729,8 @@ aok
 aok
 ctq
 aok
-ctw
-amu
+aok
+jFi
 aab
 aab
 aab
@@ -58019,9 +57960,9 @@ aab
 aab
 aab
 aab
-amu
+jFi
 aok
-aok
+gne
 aok
 aok
 aok
@@ -58046,7 +57987,7 @@ aok
 ctr
 aok
 aok
-amu
+jFi
 aab
 aab
 aab
@@ -58276,9 +58217,9 @@ aab
 aab
 aab
 aab
-amu
+jFi
 aok
-aok
+hZS
 aok
 aok
 aok
@@ -58303,7 +58244,7 @@ aok
 ctn
 aok
 aok
-amu
+jFi
 aab
 aab
 aab
@@ -58535,7 +58476,7 @@ aab
 aab
 amu
 aTk
-aok
+hEZ
 aok
 aok
 aok
@@ -58792,7 +58733,7 @@ aRS
 aRS
 amu
 apA
-aok
+gCN
 aok
 aok
 aok
@@ -59042,15 +58983,15 @@ aab
 aab
 aab
 aRS
-aSN
-aSN
+aNN
+kxi
 aEv
 aSN
 aSN
-bFG
-apA
-aok
-aAB
+inc
+qBi
+xRQ
+bcM
 aAE
 baV
 bcd
@@ -59073,8 +59014,8 @@ bcd
 bcM
 cts
 aok
-aok
-hHw
+ctw
+pvO
 bxf
 bxf
 bfX
@@ -59537,8 +59478,8 @@ awi
 axa
 avN
 ayh
-axb
-axa
+avK
+avK
 avN
 aBR
 aDD
@@ -59550,14 +59491,14 @@ aJt
 azg
 aLc
 azg
-axb
+avK
 avl
 aab
 aab
 aab
 aRS
-aNN
-aEJ
+qfo
+aTW
 aRS
 aRS
 aRS
@@ -59593,13 +59534,13 @@ bwu
 bwu
 bwu
 bBJ
-bxf
+qxc
 bwu
 aab
 aab
 aab
 bKl
-bJB
+bGR
 bLL
 bMB
 bLL
@@ -59611,8 +59552,8 @@ bTD
 bVl
 bWA
 bGU
-bJA
-bJB
+bGR
+bGR
 cct
 bGU
 bJA
@@ -59807,7 +59748,7 @@ aJt
 azg
 aLc
 azg
-axa
+avK
 avl
 aab
 aab
@@ -59856,7 +59797,7 @@ aab
 aab
 aab
 bKl
-bJA
+bGR
 bLL
 bMB
 bLL
@@ -60319,8 +60260,8 @@ aBV
 aBV
 aJG
 avN
-axa
-axb
+avK
+avK
 aMC
 avN
 axa
@@ -60335,8 +60276,8 @@ aXv
 aYQ
 aWr
 baK
-aYR
-aYQ
+aWo
+aWo
 aWr
 aWS
 aWI
@@ -60355,8 +60296,8 @@ aWI
 aWI
 aWS
 aWr
-aYQ
-aYR
+aWo
+aWo
 bxh
 aWr
 aYQ
@@ -60371,8 +60312,8 @@ bIf
 bJA
 bGU
 bKS
-bJB
-bJA
+bGR
+bGR
 bGU
 bMY
 bCb
@@ -61674,7 +61615,7 @@ bYs
 bYs
 bYs
 bYs
-bOt
+bGQ
 aab
 aab
 aab
@@ -61931,7 +61872,7 @@ bYs
 bYs
 bYs
 bYs
-bOt
+bGQ
 aab
 aab
 aab
@@ -62188,7 +62129,7 @@ bYs
 bYs
 bYs
 bYs
-bOt
+bGQ
 aab
 aab
 aab
@@ -62445,7 +62386,7 @@ bYs
 bYs
 bYs
 bYs
-bOt
+bGQ
 aab
 aab
 aab
@@ -62702,7 +62643,7 @@ bYs
 bYs
 bYs
 bYs
-bOt
+bGQ
 aab
 aab
 aab
@@ -62959,7 +62900,7 @@ bYs
 bYs
 bYs
 bYs
-bOt
+bGQ
 aab
 aab
 aab
@@ -63216,7 +63157,7 @@ bYs
 bYs
 bYs
 bYs
-bOt
+bGQ
 aab
 aab
 aab
@@ -63473,7 +63414,7 @@ bYs
 bYs
 bYs
 bYs
-bOt
+bGQ
 aab
 aab
 aab
@@ -63730,7 +63671,7 @@ bYs
 bYs
 bYs
 bYs
-bOt
+bGQ
 aab
 aab
 aab
@@ -64945,8 +64886,8 @@ aBV
 aBV
 aJG
 avN
-axa
-axb
+avK
+avK
 aMH
 avN
 axa
@@ -64961,8 +64902,8 @@ aXv
 aYQ
 aWr
 baQ
-aYR
-aYQ
+aWo
+aWo
 aWr
 aWS
 aWI
@@ -64981,8 +64922,8 @@ aWI
 aWI
 aWS
 aWr
-aYQ
-aYR
+aWo
+aWo
 bsj
 aWr
 aYQ
@@ -64997,8 +64938,8 @@ bIf
 bJA
 bGU
 bLa
-bJB
-bJA
+bGR
+bGR
 bGU
 bMY
 bCb
@@ -65461,7 +65402,7 @@ aJt
 azg
 aLc
 azg
-axa
+avK
 avl
 aab
 aab
@@ -65510,7 +65451,7 @@ aab
 aab
 aab
 bKl
-bJA
+bGR
 bLL
 bMB
 bLL
@@ -65705,8 +65646,8 @@ awi
 axa
 avN
 ayo
-axb
-axa
+avK
+avK
 axJ
 azX
 aAU
@@ -65718,7 +65659,7 @@ aJt
 azg
 aLc
 azg
-axb
+avK
 avl
 aab
 aab
@@ -65767,7 +65708,7 @@ aab
 aab
 aab
 bKl
-bJB
+bGR
 bLL
 bMB
 bLL
@@ -65779,8 +65720,8 @@ bTL
 bSV
 bTL
 bSj
-bJA
-bJB
+bGR
+bGR
 ccy
 bGU
 bJA
@@ -66018,7 +65959,7 @@ bxN
 bxN
 bxN
 bxy
-bzu
+sWQ
 bxN
 aab
 aab
@@ -66238,7 +66179,7 @@ aab
 aab
 aab
 aRV
-aSR
+grr
 aUl
 aRV
 aRV
@@ -67023,16 +66964,16 @@ aXv
 aYQ
 aWr
 baQ
-aYR
-aYQ
+aWo
+aWo
 aWr
 blN
 aWI
 bmc
 bpd
 aWr
-aYQ
-aYR
+aWo
+aWo
 bsj
 aWr
 aYQ
@@ -73674,8 +73615,8 @@ aon
 aor
 arZ
 aAe
-aAe
-aCi
+aox
+aGb
 aCi
 aES
 aCl
@@ -73744,8 +73685,8 @@ bwC
 bvA
 byC
 bKs
-bKs
-bYz
+bwA
+bZQ
 bYz
 cba
 bYC
@@ -73931,8 +73872,8 @@ aoo
 aor
 awC
 aAe
-aAe
-aCi
+aox
+aGb
 aCi
 aET
 aCl
@@ -74001,8 +73942,8 @@ bLc
 bvA
 bME
 bKs
-bKs
-bYz
+bwA
+bZQ
 bYz
 cbb
 bYC
@@ -74188,8 +74129,8 @@ aox
 aor
 azr
 aAe
-aAe
-aCi
+aox
+aGb
 aCi
 aET
 aCl
@@ -74258,8 +74199,8 @@ bwA
 bvA
 bTT
 bKs
-bKs
-bYz
+bwA
+bZQ
 bYz
 cbb
 bYC
@@ -74445,8 +74386,8 @@ aor
 aor
 azr
 aAe
-aAe
-aCi
+aox
+aGb
 aCi
 aET
 aCl
@@ -74515,8 +74456,8 @@ bvG
 bvA
 bTT
 bKs
-bKs
-bYz
+bwA
+bZQ
 bYz
 cba
 cbf
@@ -74702,8 +74643,8 @@ axK
 aor
 azr
 aAe
-aAe
-aCi
+aox
+aGb
 aCi
 aET
 aCl
@@ -74772,8 +74713,8 @@ bvA
 bvA
 bTT
 bKs
-bKs
-bYz
+bwA
+bZQ
 bYz
 cbc
 cbc
@@ -74959,8 +74900,8 @@ aox
 aor
 azr
 aAe
-aAe
-aCi
+aox
+aGb
 aCi
 aET
 aCl
@@ -75029,8 +74970,8 @@ bvC
 bvA
 bTT
 bKs
-bKs
-bYz
+bwA
+bZQ
 bYz
 cbc
 cbf
@@ -75216,8 +75157,8 @@ aot
 aor
 azr
 aAe
-aAe
-aCi
+aox
+aGb
 aCi
 aET
 aCl
@@ -75286,8 +75227,8 @@ bBr
 bvA
 bTT
 bKs
-bKs
-bYz
+bwA
+bZQ
 bYz
 cbc
 cbf
@@ -75473,8 +75414,8 @@ aon
 aor
 arZ
 aAe
-aAe
-aCi
+aox
+aGb
 aCi
 aES
 aCl
@@ -75543,8 +75484,8 @@ bvA
 bvA
 byC
 bKs
-bKs
-bYz
+bwA
+bZQ
 bYz
 cbc
 cbf
@@ -75998,8 +75939,8 @@ kyN
 kyN
 kyN
 jAv
-aCh
-aCh
+eLE
+eLE
 aNI
 aPf
 aQF
@@ -76303,8 +76244,8 @@ bvA
 bHh
 bFZ
 bwH
-bKs
-bKs
+bwA
+bwA
 bvw
 bvA
 bwC
@@ -76560,8 +76501,8 @@ bvA
 byC
 bGa
 bwH
-bKs
-bKs
+bwA
+bwA
 bvw
 bvA
 bNw
@@ -77852,10 +77793,10 @@ bvA
 bOW
 bOm
 bPi
-bQO
+bQQ
 bOY
 bTZ
-bQO
+bQQ
 bWU
 bOm
 bYC
@@ -78112,7 +78053,7 @@ bGN
 bQP
 bPa
 bTZ
-bQO
+bQQ
 bWV
 bOm
 bOI
@@ -78366,10 +78307,10 @@ bwF
 bzH
 bOm
 bPi
-bQO
+bQQ
 bPG
 bTZ
-bQO
+bQQ
 bWU
 bOm
 bZS
@@ -81910,21 +81851,21 @@ aJR
 aJR
 aJR
 aJR
-aNj
-aNL
-aPj
-aQJ
-aSa
-aSa
-aSa
-aSa
-aSa
-aSa
-aKH
-aKH
-aKH
-aKH
-aKH
+aLO
+aDS
+aPc
+aES
+aCl
+aCl
+aCl
+aCl
+aCl
+aCl
+aXL
+aXL
+aXL
+aXL
+aXL
 bdO
 bdO
 bdO
@@ -85034,8 +84975,8 @@ bql
 bql
 bql
 bql
-bql
-aUU
+bBh
+woW
 bBh
 bFk
 bFk
@@ -85567,7 +85508,7 @@ elB
 elB
 bPz
 bGm
-bXf
+bOq
 bxO
 cbp
 ccT
@@ -86863,8 +86804,8 @@ ccV
 cvh
 ccV
 ckr
-cls
-eIn
+sRe
+nOc
 cmZ
 uUB
 uUB
@@ -87131,8 +87072,8 @@ ccV
 cvh
 ccV
 csH
-bKW
-bKW
+cvA
+cvA
 ctT
 cuY
 cuY
@@ -87155,7 +87096,7 @@ cun
 cun
 cke
 bOD
-bKW
+cvA
 ctk
 czn
 czw
@@ -87367,17 +87308,17 @@ bCP
 bVL
 bUf
 bJX
-bGn
-cax
-bGn
-bGn
+cbA
+ciM
+cbA
+cbA
 bJX
-bGn
-bGn
-bGn
-bGn
-bGn
-cax
+cbA
+cbA
+cbA
+cbA
+cbA
+ciM
 bJX
 cna
 ccV
@@ -87389,7 +87330,7 @@ cdY
 ccV
 csH
 bKZ
-bKW
+cvA
 ctT
 cuY
 cvD
@@ -87400,7 +87341,7 @@ cvJ
 cwX
 cuY
 cxz
-bKW
+cvA
 crX
 cyq
 cun
@@ -87412,7 +87353,7 @@ cyx
 cun
 cki
 bOG
-bKW
+cvA
 crr
 czn
 czx
@@ -87626,16 +87567,16 @@ bSN
 cmp
 cmp
 bIX
-bJj
-bGn
-bGn
-bGn
-bGn
+cmq
+cbA
+cbA
+cbA
+cbA
 bJX
-bGn
-bGn
-cax
-bGn
+cbA
+cbA
+ciM
+cbA
 cna
 ccV
 cdY
@@ -87645,7 +87586,7 @@ ccV
 cdY
 ccV
 csH
-bKW
+cvA
 bKZ
 ctT
 cuY
@@ -87657,7 +87598,7 @@ cbN
 cwY
 cuY
 cxz
-bKW
+cvA
 crX
 cyq
 cun
@@ -87668,7 +87609,7 @@ cun
 cyx
 cun
 cxN
-bKW
+cvA
 bKZ
 crr
 czn
@@ -87902,8 +87843,8 @@ ccV
 ccV
 ccV
 chS
-bKW
-bKW
+cvA
+cvA
 ctT
 cuY
 cuY
@@ -87914,7 +87855,7 @@ cuY
 cuY
 cuY
 cxz
-bKW
+cvA
 crX
 cyq
 cun
@@ -87926,7 +87867,7 @@ cyz
 cun
 bnJ
 cha
-bKW
+cvA
 crr
 czn
 czz
@@ -88907,7 +88848,7 @@ bRm
 bSQ
 bUv
 elB
-bXe
+bqB
 bXe
 cak
 cbw
@@ -89164,7 +89105,7 @@ bRn
 bSR
 bUw
 elB
-bXe
+bqB
 bXe
 cae
 bYx
@@ -96053,7 +95994,7 @@ aSm
 aSm
 aVr
 aUV
-bql
+aNq
 aYp
 aSk
 aNq
@@ -96308,9 +96249,9 @@ aPH
 aRc
 aSn
 aNs
-aVy
+neb
 aUV
-bql
+aNq
 aYq
 aZs
 aNq
@@ -96567,7 +96508,7 @@ aSo
 aTB
 aKe
 aUW
-bql
+aNq
 aYr
 aYl
 aNq
@@ -96824,7 +96765,7 @@ aSp
 aSm
 aRY
 aUX
-bql
+aNq
 aYs
 aZm
 aNq
@@ -97080,8 +97021,8 @@ aNs
 aNs
 aSm
 aUU
-bql
-bql
+aSm
+aNq
 aNq
 aNq
 aNq
@@ -99619,7 +99560,7 @@ aab
 aab
 aab
 aab
-atk
+atC
 auo
 auo
 avg
@@ -100136,15 +100077,15 @@ aab
 atl
 atl
 atl
-atl
-atl
-atl
-atl
-atl
-atl
-atl
-atl
-atl
+lhZ
+lhZ
+lhZ
+lhZ
+lhZ
+lhZ
+lhZ
+lhZ
+qMm
 aBL
 aDz
 aEz
@@ -100392,6 +100333,7 @@ aab
 aab
 atl
 atl
+eyC
 atl
 atl
 atl
@@ -100400,8 +100342,7 @@ atl
 atl
 atl
 atl
-atl
-atl
+pBH
 aBL
 aDz
 aDy
@@ -100649,6 +100590,7 @@ aab
 aab
 atC
 atl
+eyC
 atl
 atl
 atl
@@ -100657,8 +100599,7 @@ atl
 atl
 atl
 atl
-atl
-atl
+pBH
 aBL
 aDA
 aEA
@@ -100906,6 +100847,7 @@ aab
 aab
 atl
 atl
+eyC
 atl
 atl
 atl
@@ -100914,8 +100856,7 @@ atl
 atl
 atl
 atl
-atl
-atl
+pBH
 aBL
 aDA
 aEB
@@ -101163,6 +101104,7 @@ aab
 aab
 atl
 atl
+eyC
 atl
 atl
 atl
@@ -101171,8 +101113,7 @@ atl
 atl
 atl
 atl
-atl
-atl
+pBH
 aBL
 aDA
 aEC
@@ -101420,6 +101361,7 @@ aab
 aab
 atl
 atl
+eyC
 atl
 atl
 atl
@@ -101428,8 +101370,7 @@ atl
 atl
 atl
 atl
-atl
-atl
+pBH
 aBL
 aDA
 aED
@@ -101677,6 +101618,7 @@ aab
 aab
 atC
 atl
+eyC
 atl
 atl
 atl
@@ -101685,8 +101627,7 @@ atl
 atl
 atl
 atl
-atl
-atl
+pBH
 aBL
 aDA
 aEA
@@ -101934,6 +101875,7 @@ aab
 aab
 atl
 atl
+eyC
 atl
 atl
 atl
@@ -101942,8 +101884,7 @@ atl
 atl
 atl
 atl
-atl
-atl
+pBH
 aBL
 aDA
 aEE
@@ -102191,6 +102132,7 @@ aab
 aab
 atl
 atl
+eyC
 atl
 atl
 atl
@@ -102199,8 +102141,7 @@ atl
 atl
 atl
 atl
-atl
-atl
+pBH
 aBL
 aDA
 aEF
@@ -102448,6 +102389,7 @@ aab
 aab
 atl
 atl
+eyC
 atl
 atl
 atl
@@ -102456,8 +102398,7 @@ atl
 atl
 atl
 atl
-atl
-atl
+pBH
 aBL
 aDA
 aED
@@ -102705,6 +102646,7 @@ aab
 aab
 atC
 atl
+eyC
 atl
 atl
 atl
@@ -102713,8 +102655,7 @@ atl
 atl
 atl
 atl
-atl
-atl
+pBH
 aBL
 aDA
 aEA
@@ -102962,6 +102903,7 @@ aab
 aab
 atl
 atl
+eyC
 atl
 atl
 atl
@@ -102970,8 +102912,7 @@ atl
 atl
 atl
 atl
-atl
-atl
+pBH
 aBL
 aDA
 aEB
@@ -103219,15 +103160,15 @@ aab
 aab
 atl
 atl
-atl
-atl
-atl
-atl
-atl
-atl
-atl
-atl
-atl
+vhu
+tsb
+tsb
+tsb
+tsb
+tsb
+tsb
+tsb
+tsb
 aAP
 aBM
 aDA
@@ -103758,7 +103699,7 @@ aEA
 aDA
 aOa
 aPX
-aRq
+aRo
 aSv
 aOt
 aVa
@@ -104827,7 +104768,7 @@ bAA
 bEA
 bEA
 bEA
-bHP
+bEI
 bEA
 bEs
 bEA
@@ -105276,11 +105217,11 @@ aab
 atU
 atU
 auJ
-atU
-atU
 auJ
 atU
 atU
+atU
+auJ
 auJ
 atU
 atU
@@ -105802,7 +105743,7 @@ aab
 aab
 aab
 aab
-aFV
+aFW
 aIi
 aIn
 aIn
@@ -106059,7 +106000,7 @@ aab
 aab
 aab
 aab
-aFV
+aFW
 aHk
 aIo
 aIo
@@ -106316,7 +106257,7 @@ aab
 aab
 aab
 aab
-aFW
+aFV
 aHk
 aIo
 aIp
@@ -106641,7 +106582,7 @@ bTz
 bVd
 bNR
 bTx
-bZr
+cdA
 bLz
 ccg
 cdB
@@ -106830,7 +106771,7 @@ aab
 aab
 aab
 aab
-aFV
+aFW
 aHk
 aIo
 aIp
@@ -106904,7 +106845,7 @@ cbu
 bWx
 cev
 bQp
-cgP
+coT
 chW
 cje
 cjY
@@ -107087,7 +107028,7 @@ aab
 aab
 aab
 aab
-aFV
+aFW
 aHk
 aIp
 aIo
@@ -107095,7 +107036,7 @@ aIp
 aIp
 aIp
 aMy
-aHh
+aMY
 aNB
 aOI
 aQk
@@ -107601,7 +107542,7 @@ aab
 aab
 aab
 aab
-aFW
+aFV
 aHk
 aIp
 aIo
@@ -107675,7 +107616,7 @@ ccb
 bNS
 bMu
 cfJ
-cgR
+coT
 chW
 cje
 cjY
@@ -107858,7 +107799,7 @@ aab
 aab
 aab
 aab
-aFV
+aFW
 aHk
 aIo
 aIp
@@ -108115,7 +108056,7 @@ aab
 aab
 aab
 aab
-aFV
+aFW
 aCN
 aIq
 aIq
@@ -108632,9 +108573,9 @@ aab
 aFV
 aFV
 aFV
-aFV
-aFV
-aFV
+aFW
+aFW
+aFW
 aFV
 aFV
 aFV
@@ -108944,7 +108885,7 @@ bEI
 bEI
 bEI
 bEI
-bMp
+cdA
 bNg
 bMu
 bMu
@@ -111012,7 +110953,7 @@ bWz
 bXZ
 bXZ
 bXZ
-bMq
+bWz
 bLz
 cci
 bQp
@@ -111265,11 +111206,11 @@ bNY
 bMu
 bTB
 bVi
-bWz
+bXZ
 bYa
 bZt
 caN
-bMq
+bXZ
 bLz
 ccg
 cfH
@@ -111522,11 +111463,11 @@ bNZ
 bNS
 bTC
 bVj
-bWz
+bXZ
 bYb
 bZu
 caO
-bZp
+bXZ
 cdG
 cdq
 cfK
@@ -116657,7 +116598,7 @@ bET
 bET
 bNq
 bzp
-bzp
+kPu
 bzm
 aab
 aab

--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -6396,10 +6396,13 @@
 /turf/open/floor/prison/sterilewhite,
 /area/prison/research/RD)
 "asG" = (
-/obj/effect/decal/warning_stripes/thick{
-	dir = 9
-	},
 /obj/effect/decal/cleanable/blood,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
 /turf/open/floor/prison,
 /area/prison/research/RD)
 "asH" = (
@@ -7028,14 +7031,15 @@
 /turf/open/floor/prison/sterilewhite,
 /area/prison/research/RD)
 "atR" = (
-/obj/effect/decal/warning_stripes/thick{
-	dir = 10
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/prison,
 /area/prison/research/RD)
 "atS" = (
@@ -9731,7 +9735,7 @@
 "aAF" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/prison/whitepurple/full,
-/area/prison/medbay/morgue)
+/area/prison/research)
 "aAG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -29882,7 +29886,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk/prison,
-/area/prison/hallway/east)
+/area/prison/hallway/entrance)
 "bvQ" = (
 /turf/open/floor/prison/yellow{
 	dir = 9
@@ -31751,14 +31755,14 @@
 	icon_state = "bright_clean";
 	dir = 10
 	},
-/area/prison/hallway/east)
+/area/prison/hallway/entrance)
 "bAy" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/prison{
 	icon_state = "bright_clean";
 	dir = 10
 	},
-/area/prison/hallway/east)
+/area/prison/hallway/entrance)
 "bAz" = (
 /obj/machinery/disposal,
 /obj/structure/window/reinforced{
@@ -31771,7 +31775,7 @@
 	icon_state = "bright_clean";
 	dir = 10
 	},
-/area/prison/hallway/east)
+/area/prison/hallway/entrance)
 "bAA" = (
 /turf/open/floor/prison{
 	icon_state = "bright_clean";
@@ -32200,7 +32204,7 @@
 	icon_state = "bright_clean";
 	dir = 10
 	},
-/area/prison/hallway/east)
+/area/prison/hallway/entrance)
 "bBE" = (
 /turf/open/floor/prison/yellow{
 	dir = 10
@@ -107645,7 +107649,7 @@ bkG
 bkG
 bsa
 bAx
-bBB
+bmM
 bCS
 bAA
 bAA
@@ -107902,7 +107906,7 @@ bcz
 bcz
 bcz
 bAy
-bBB
+bmM
 bCS
 bAA
 bAA
@@ -108159,7 +108163,7 @@ bdp
 bdp
 bxj
 bAz
-bBC
+bbC
 bCS
 bAA
 bAA
@@ -108415,7 +108419,7 @@ bcA
 bcA
 bcA
 bdK
-bAA
+bnM
 bBD
 bAA
 bAA
@@ -108672,7 +108676,7 @@ bcz
 bcz
 bcz
 buy
-bJm
+bdp
 bvP
 bEH
 bJm
@@ -108929,8 +108933,8 @@ bxb
 bxH
 bwk
 bjD
-bAA
-bBC
+bnM
+bbC
 bCS
 bEI
 bFJ
@@ -109186,8 +109190,8 @@ bxc
 bxc
 byg
 bcz
-bAA
-bBB
+bnM
+bmM
 bCV
 bEJ
 bFJ
@@ -109417,7 +109421,7 @@ aXo
 aND
 aQp
 bay
-bbC
+bbz
 bcz
 bcz
 bcz
@@ -109697,8 +109701,8 @@ bcC
 aFy
 bcC
 bcC
-aXu
-aXu
+bcC
+bcC
 bzg
 bAC
 bAE
@@ -110984,7 +110988,7 @@ pOU
 aab
 aab
 aab
-aXt
+bFX
 bAF
 bAF
 bAF
@@ -111241,7 +111245,7 @@ pOU
 aab
 aab
 aab
-aXt
+bFX
 bAG
 bAG
 bCY

--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aab" = (
-/turf/open/beach/water,
+/turf/open/beach/sea,
 /area/space)
 "abk" = (
 /obj/effect/landmark/lv624/fog_blocker,
@@ -16,7 +16,7 @@
 	teleport_z = 4;
 	teleport_z_offset = 4
 	},
-/turf/open/beach/water,
+/turf/open/beach/sea,
 /area/space)
 "acE" = (
 /turf/closed/wall/r_wall/prison_unmeltable,
@@ -113,6 +113,7 @@
 /obj/structure/window/framed/prison/reinforced,
 /obj/machinery/door/poddoor/shutters/mainship{
 	density = 0;
+	dir = 2;
 	icon_state = "shutter0";
 	id = "biological_testing_1";
 	opacity = 0
@@ -128,6 +129,7 @@
 /obj/item/stack/cable_coil/single,
 /obj/machinery/door/poddoor/shutters/mainship{
 	density = 0;
+	dir = 2;
 	icon_state = "shutter0";
 	id = "biological_testing_1";
 	opacity = 0
@@ -141,6 +143,7 @@
 /obj/machinery/door/window/northright,
 /obj/machinery/door/poddoor/shutters/mainship{
 	density = 0;
+	dir = 2;
 	icon_state = "shutter0";
 	id = "biological_testing_1";
 	opacity = 0
@@ -151,6 +154,7 @@
 /obj/structure/window/framed/prison/reinforced,
 /obj/machinery/door/poddoor/shutters/mainship{
 	density = 0;
+	dir = 2;
 	icon_state = "shutter0";
 	id = "biological_testing_2";
 	opacity = 0
@@ -163,6 +167,7 @@
 	},
 /obj/machinery/door/poddoor/shutters/mainship{
 	density = 0;
+	dir = 2;
 	icon_state = "shutter0";
 	id = "biological_testing_2";
 	opacity = 0
@@ -176,6 +181,7 @@
 	},
 /obj/machinery/door/poddoor/shutters/mainship{
 	density = 0;
+	dir = 2;
 	icon_state = "shutter0";
 	id = "biological_testing_2";
 	opacity = 0
@@ -483,7 +489,7 @@
 /area/prison/research/secret/testing)
 "adO" = (
 /obj/structure/lattice,
-/turf/open/beach/water,
+/turf/open/beach/sea,
 /area/space)
 "adP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -826,8 +832,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/structure/lattice,
-/turf/open/beach/water,
+/turf/open/floor/plating/catwalk,
 /area/prison/research/secret/testing)
 "aeK" = (
 /obj/structure/bed,
@@ -3233,7 +3238,10 @@
 	},
 /area/prison/research/secret)
 "akQ" = (
-/turf/open/floor/prison/darkpurple/corner,
+/turf/open/floor/prison/darkpurple/corner{
+	icon_state = "darkpurplecorners2";
+	dir = 8
+	},
 /area/prison/research/secret)
 "akR" = (
 /obj/structure/rack,
@@ -4015,10 +4023,6 @@
 	},
 /turf/open/floor/tile/white,
 /area/prison/research/secret/chemistry)
-"amS" = (
-/obj/structure/sign/vacuum,
-/turf/closed/wall/r_wall/prison,
-/area/prison/hangar_storage/research)
 "amT" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -4510,7 +4514,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison/darkpurple{
-	dir = 10
+	dir = 8
 	},
 /area/prison/research/secret)
 "anZ" = (
@@ -4525,7 +4529,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/prison/darkpurple/corner,
+/turf/open/floor/prison,
 /area/prison/research/secret)
 "aoa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -4980,7 +4984,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/prison/cleanmarked,
+/turf/open/floor/prison/darkpurple{
+	dir = 8
+	},
 /area/prison/research/secret)
 "aoV" = (
 /obj/structure/cable{
@@ -5016,27 +5022,6 @@
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/prison/medbay/surgery)
-"aoX" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/prison/darkpurple{
-	dir = 8
-	},
-/area/prison/research/secret)
 "aoY" = (
 /turf/closed/wall/prison,
 /area/prison/research/secret/chemistry)
@@ -5045,10 +5030,6 @@
 /obj/item/storage/box/beakers,
 /turf/open/floor/prison/darkpurple/full,
 /area/prison/research/secret/chemistry)
-"apa" = (
-/obj/machinery/alarm,
-/turf/open/floor/prison/cleanmarked,
-/area/prison/research)
 "apb" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_container/glass/beaker/bluespace,
@@ -5200,21 +5181,6 @@
 /obj/item/tool/surgery/scalpel,
 /turf/open/floor/prison,
 /area/prison/research/secret/dissection)
-"apx" = (
-/turf/open/floor/prison/cleanmarked,
-/area/prison/research/secret)
-"apy" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/prison/darkpurple{
-	dir = 8
-	},
-/area/prison/research/secret)
 "apA" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -5399,7 +5365,9 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 2
 	},
-/turf/open/floor/prison/cleanmarked,
+/turf/open/floor/prison/darkpurple{
+	dir = 10
+	},
 /area/prison/research/secret)
 "aqa" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -5412,9 +5380,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/prison/darkpurple{
-	dir = 10
-	},
+/turf/open/floor/prison/darkpurple,
 /area/prison/research/secret)
 "aqb" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -5647,12 +5613,10 @@
 /turf/closed/wall/prison,
 /area/prison/research/RD)
 "aqK" = (
-/obj/structure/disposalpipe/trunk,
 /obj/structure/disposaloutlet{
 	dir = 1
 	},
-/obj/structure/lattice,
-/turf/open/beach/water,
+/turf/open/floor/plating/catwalk,
 /area/prison/research/secret/bioengineering)
 "aqL" = (
 /obj/machinery/light/small{
@@ -5793,7 +5757,9 @@
 	},
 /area/prison/medbay/surgery)
 "arf" = (
-/turf/open/floor/prison/cleanmarked,
+/turf/open/floor/prison/purple/whitepurple{
+	dir = 9
+	},
 /area/prison/research)
 "arg" = (
 /obj/structure/cable{
@@ -5808,20 +5774,24 @@
 	dir = 4
 	},
 /turf/open/floor/prison/purple/whitepurple{
-	dir = 9
+	dir = 8
 	},
 /area/prison/research)
 "arh" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 5
 	},
-/turf/open/floor/prison/cleanmarked,
+/turf/open/floor/prison/purple/whitepurple{
+	dir = 1
+	},
 /area/prison/research)
 "ari" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
 	},
-/turf/open/floor/prison/cleanmarked,
+/turf/open/floor/prison/purple/whitepurple{
+	dir = 1
+	},
 /area/prison/research)
 "arj" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -5835,21 +5805,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison/purple/whitepurple{
-	dir = 8
-	},
-/area/prison/research)
-"ark" = (
-/obj/effect/decal/warning_stripes/thin{
 	dir = 1
 	},
-/turf/open/floor/prison/sterilewhite,
 /area/prison/research)
 "arl" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
 	},
 /turf/open/floor/prison/purple/whitepurple{
-	dir = 4
+	dir = 5
 	},
 /area/prison/research)
 "arm" = (
@@ -6024,22 +5988,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/medbay/surgery)
-"arJ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/prison/purple/whitepurple{
-	dir = 1
-	},
-/area/prison/research)
 "arL" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -6109,9 +6057,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/prison/whitepurple/corner{
-	dir = 4
-	},
+/turf/open/floor/prison/sterilewhite,
 /area/prison/research)
 "arQ" = (
 /turf/open/floor/prison/sterilewhite,
@@ -7372,9 +7318,6 @@
 /turf/open/floor/prison,
 /area/prison/medbay/morgue)
 "auE" = (
-/obj/structure/sign/vacuum{
-	dir = 1
-	},
 /turf/open/floor/prison/purple/whitepurple{
 	dir = 5
 	},
@@ -9367,7 +9310,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -9383,7 +9326,7 @@
 	name = "Central Ring"
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -9841,7 +9784,7 @@
 /area/prison/residential/north)
 "aAO" = (
 /obj/structure/window/framed/prison/reinforced/hull,
-/turf/open/beach/water,
+/turf/open/beach/sea,
 /area/prison/cellblock/maxsec/north)
 "aAP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -10524,7 +10467,7 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -11903,7 +11846,7 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -13871,7 +13814,7 @@
 	name = "Central Ring"
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -13907,7 +13850,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -14036,7 +13979,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -14429,7 +14372,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -14449,7 +14392,7 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -14489,7 +14432,7 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -14511,7 +14454,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -14551,28 +14494,14 @@
 	dir = 2
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
-	dir = 10
-	},
-/area/prison/hallway/central)
-"aLu" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
 "aLv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -14595,7 +14524,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -14614,7 +14543,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -14634,7 +14563,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -14665,7 +14594,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -14871,7 +14800,7 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -14891,7 +14820,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -14930,7 +14859,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -14949,19 +14878,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /turf/open/floor/prison{
 	icon_state = "bright_clean";
-	dir = 10
-	},
-/area/prison/hallway/central)
-"aMi" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/prison{
-	icon_state = "bright_clean2";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -14994,7 +14910,7 @@
 	icon_state = "pipe-j2"
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -15061,19 +14977,6 @@
 	},
 /turf/open/floor/prison/darkyellow/full,
 /area/prison/hangar_storage/main)
-"aMw" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/prison{
-	icon_state = "bright_clean2";
-	dir = 10
-	},
-/area/prison/hallway/central)
 "aMx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -15417,7 +15320,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -15538,7 +15441,7 @@
 "aNP" = (
 /obj/effect/landmark/monkey_spawn,
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -15610,7 +15513,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -15628,7 +15531,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -15900,7 +15803,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/prison/plate,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/staff)
 "aOI" = (
 /turf/open/floor/prison/plate,
@@ -15908,11 +15811,11 @@
 "aOJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/prison/plate,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/staff)
 "aOK" = (
 /obj/effect/decal/cleanable/blood,
-/turf/open/floor/prison/plate,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/staff)
 "aOL" = (
 /obj/structure/cable{
@@ -15922,7 +15825,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/prison/plate,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/staff)
 "aOM" = (
 /turf/open/floor/prison/green/corner{
@@ -16353,7 +16256,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -18772,7 +18675,7 @@
 /area/prison/recreation/staff)
 "aVm" = (
 /obj/machinery/alarm,
-/turf/open/floor/plating,
+/turf/open/floor/prison,
 /area/prison/hangar/main)
 "aVn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -19049,10 +18952,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/turf/open/floor/prison{
-	icon_state = "bright_clean";
-	dir = 10
-	},
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/canteen)
 "aVX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -19123,7 +19023,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/prison/plate,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/staff)
 "aWd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -19447,7 +19347,7 @@
 	},
 /area/prison/yard)
 "aWS" = (
-/obj/machinery/vending/snack,
+/obj/structure/flora/pottedplant,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/central)
 "aWT" = (
@@ -19592,7 +19492,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/prison/plate,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/staff)
 "aXj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -20056,7 +19956,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/plating_catwalk/prison,
+/turf/open/floor/prison/plate,
 /area/prison/hallway/staff)
 "aYC" = (
 /obj/effect/decal/cleanable/blood,
@@ -20136,9 +20036,6 @@
 /turf/open/floor/plating,
 /area/prison/hangar/main)
 "aYO" = (
-/obj/structure/sign/vacuum{
-	dir = 1
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -20211,10 +20108,6 @@
 "aYY" = (
 /turf/open/floor/prison,
 /area/prison/security/monitoring/highsec)
-"aYZ" = (
-/obj/machinery/vending/cola,
-/turf/open/floor/prison/sterilewhite,
-/area/prison/residential/central)
 "aZc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 1;
@@ -20348,10 +20241,7 @@
 /obj/machinery/flasher{
 	id = "canteen"
 	},
-/turf/open/floor/prison{
-	icon_state = "bright_clean";
-	dir = 10
-	},
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/canteen)
 "aZv" = (
 /obj/effect/decal/cleanable/blood,
@@ -20399,7 +20289,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/prison/plate,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/staff)
 "aZz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -20497,7 +20387,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating/plating_catwalk/prison,
+/turf/open/floor/prison/plate,
 /area/prison/hallway/staff)
 "aZG" = (
 /obj/structure/cable{
@@ -20670,9 +20560,7 @@
 "bag" = (
 /obj/item/phone,
 /obj/structure/table/reinforced,
-/turf/open/floor{
-	icon_state = "hydrofloor"
-	},
+/turf/open/floor/prison,
 /area/prison/hallway/central)
 "bah" = (
 /obj/structure/cable{
@@ -20696,7 +20584,7 @@
 	icon_state = "pipe-y"
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -20981,7 +20869,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -21139,10 +21027,7 @@
 /area/prison/cellblock/lowsec/ne)
 "bbs" = (
 /obj/effect/landmark/monkey_spawn,
-/turf/open/floor/prison{
-	icon_state = "bright_clean";
-	dir = 10
-	},
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/canteen)
 "bbt" = (
 /obj/item/reagent_container/glass/bucket,
@@ -21357,10 +21242,6 @@
 "bbV" = (
 /turf/open/floor/prison/trim/red,
 /area/prison/security/monitoring/highsec)
-"bbX" = (
-/obj/structure/window/framed/prison/reinforced,
-/turf/open/floor/plating,
-/area/prison/cellblock/highsec/north/south)
 "bbY" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -21773,10 +21654,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/open/floor/prison{
-	icon_state = "bright_clean2";
-	dir = 10
-	},
+/turf/open/floor/prison/blue/full,
 /area/prison/storage/vip)
 "bdi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -21911,23 +21789,6 @@
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/monitoring/maxsec/panopticon)
-"bdz" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/prison{
-	icon_state = "bright_clean2";
-	dir = 10
-	},
-/area/prison/hallway/central)
 "bdA" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4
@@ -22385,7 +22246,7 @@
 /area/prison/hallway/entrance)
 "beu" = (
 /obj/machinery/recharge_station,
-/turf/open/floor/plating,
+/turf/open/floor/prison,
 /area/prison/hangar/main)
 "bev" = (
 /turf/open/floor/prison/rampbottom{
@@ -22439,7 +22300,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -22791,7 +22652,7 @@
 	on = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/yard)
@@ -22837,7 +22698,7 @@
 	on = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/yard)
@@ -23552,15 +23413,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/open/floor/prison{
-	icon_state = "bright_clean";
-	dir = 10
-	},
-/area/prison/canteen)
-"bhd" = (
 /turf/open/floor/prison/rampbottom{
 	dir = 8
 	},
+/area/prison/canteen)
+"bhd" = (
+/turf/open/floor/prison/sterilewhite,
 /area/prison/canteen)
 "bhe" = (
 /turf/open/floor/prison/sterilewhite,
@@ -24044,7 +23902,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -24188,10 +24046,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/prison{
-	icon_state = "bright_clean";
-	dir = 10
-	},
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/canteen)
 "bin" = (
 /obj/structure/bed/chair{
@@ -24258,9 +24113,8 @@
 	pixel_x = 24;
 	pixel_y = -24
 	},
-/turf/open/floor/prison{
-	icon_state = "bright_clean";
-	dir = 10
+/turf/open/floor/prison/rampbottom{
+	dir = 8
 	},
 /area/prison/canteen)
 "biq" = (
@@ -24310,10 +24164,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/multi_tile/mainship/comdoor{
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 2;
-	name = "Canteen";
-	req_access_txt = "0"
+	name = "Canteen"
 	},
 /turf/open/floor/prison{
 	icon_state = "kitchen"
@@ -24519,7 +24372,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -24758,14 +24611,11 @@
 	},
 /area/prison/canteen)
 "bjt" = (
-/obj/machinery/door/airlock/multi_tile/mainship/comdoor{
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 2;
-	name = "Canteen";
-	req_access_txt = "0"
+	name = "Canteen"
 	},
-/turf/open/floor/prison/rampbottom{
-	dir = 8
-	},
+/turf/open/floor/prison/sterilewhite,
 /area/prison/canteen)
 "bju" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -25053,10 +24903,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/turf/open/floor/prison{
-	icon_state = "bright_clean";
-	dir = 10
-	},
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/canteen)
 "bkb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -25156,7 +25003,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -25189,7 +25036,7 @@
 "bkq" = (
 /obj/structure/lattice,
 /obj/structure/grille,
-/turf/open/beach/water,
+/turf/open/beach/sea,
 /area/space)
 "bkr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -25342,7 +25189,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison/darkyellow{
-	dir = 1
+	dir = 5
 	},
 /area/prison/hangar/main)
 "bkL" = (
@@ -25777,7 +25624,9 @@
 /obj/machinery/landinglight/ds1{
 	dir = 4
 	},
-/turf/open/floor/prison/darkyellow,
+/turf/open/floor/prison/darkyellow{
+	dir = 6
+	},
 /area/prison/hangar/main)
 "blI" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
@@ -26446,10 +26295,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/open/floor/prison{
-	icon_state = "bright_clean2";
-	dir = 10
-	},
+/turf/open/floor/prison/blue/full,
 /area/prison/storage/vip)
 "bnw" = (
 /obj/structure/cable{
@@ -26468,7 +26314,7 @@
 "bny" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/prison{
-	icon_state = "bright_clean";
+	icon_state = "bright_clean2";
 	dir = 10
 	},
 /area/prison/yard)
@@ -26509,7 +26355,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -26985,10 +26831,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/open/floor/prison{
-	icon_state = "bright_clean2";
-	dir = 10
-	},
+/turf/open/floor/prison/blue/full,
 /area/prison/storage/vip)
 "bos" = (
 /obj/structure/cable{
@@ -27187,7 +27030,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -27270,10 +27113,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/prison{
-	icon_state = "bright_clean";
-	dir = 10
-	},
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/canteen)
 "boO" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -27314,10 +27154,7 @@
 /obj/machinery/flasher{
 	id = "canteen"
 	},
-/turf/open/floor/prison{
-	icon_state = "bright_clean";
-	dir = 10
-	},
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/canteen)
 "boS" = (
 /obj/structure/cable{
@@ -27569,10 +27406,7 @@
 	},
 /area/prison/storage/vip)
 "bpF" = (
-/turf/open/floor/prison{
-	icon_state = "bright_clean2";
-	dir = 10
-	},
+/turf/open/floor/prison/blue/full,
 /area/prison/storage/vip)
 "bpG" = (
 /obj/structure/table/reinforced,
@@ -27624,10 +27458,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/prison{
-	icon_state = "bright_clean";
-	dir = 10
-	},
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/canteen)
 "bpN" = (
 /obj/structure/cable{
@@ -27663,7 +27494,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -27893,7 +27724,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/prison{
-	icon_state = "bright_clean";
+	icon_state = "bright_clean2";
 	dir = 10
 	},
 /area/prison/yard)
@@ -27930,10 +27761,7 @@
 /area/prison/hallway/central)
 "bqw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/prison{
-	icon_state = "bright_clean";
-	dir = 10
-	},
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/canteen)
 "bqy" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
@@ -28040,7 +27868,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -28181,7 +28009,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -28230,7 +28058,7 @@
 	},
 /obj/structure/disposalpipe/junction,
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -28258,7 +28086,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -28297,10 +28125,7 @@
 /area/prison/canteen)
 "brp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/prison{
-	icon_state = "bright_clean";
-	dir = 10
-	},
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/canteen)
 "brq" = (
 /obj/structure/cable{
@@ -28337,7 +28162,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -28969,7 +28794,7 @@
 "btd" = (
 /obj/structure/monorail,
 /obj/structure/lattice,
-/turf/open/beach/water,
+/turf/open/beach/sea,
 /area/space)
 "bte" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -29074,20 +28899,6 @@
 	dir = 4
 	},
 /area/prison/cellblock/lowsec/se)
-"btr" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/prison{
-	icon_state = "bright_clean2";
-	dir = 10
-	},
-/area/prison/hallway/central)
 "bts" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 2;
@@ -29223,7 +29034,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -30158,13 +29969,6 @@
 	dir = 10
 	},
 /area/prison/store)
-"bvZ" = (
-/obj/structure/bed/chair/office/dark,
-/turf/open/floor/prison{
-	icon_state = "bright_clean2";
-	dir = 10
-	},
-/area/prison/visitation)
 "bwa" = (
 /obj/structure/bed/chair/office/dark,
 /turf/open/floor/prison,
@@ -30986,12 +30790,6 @@
 	dir = 1
 	},
 /area/prison/hallway/entrance)
-"byh" = (
-/obj/structure/sign/vacuum{
-	dir = 2
-	},
-/turf/open/floor/prison/red/full,
-/area/prison/hallway/entrance)
 "byi" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -31038,15 +30836,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/prison/darkred/full,
-/area/prison/hangar/main)
-"byn" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/structure/sign/vacuum{
-	dir = 2
-	},
-/turf/open/floor/prison,
 /area/prison/hangar/main)
 "byo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -31798,7 +31587,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -31823,6 +31612,11 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/open/floor/prison/trim/red{
 	dir = 1
 	},
@@ -31910,7 +31704,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -31998,7 +31792,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -32086,7 +31880,7 @@
 "bAP" = (
 /obj/structure/grille,
 /obj/structure/lattice,
-/turf/open/beach/water,
+/turf/open/beach/sea,
 /area/space)
 "bAQ" = (
 /obj/machinery/alarm,
@@ -32225,7 +32019,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -32684,6 +32478,11 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/open/floor/prison/green,
 /area/prison/cellblock/lowsec/sw)
 "bCl" = (
@@ -32926,7 +32725,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
+	icon_state = "bright_clean";
 	dir = 10
 	},
 /area/prison/hallway/central)
@@ -33254,7 +33053,7 @@
 /area/prison/monorail/west)
 "bDE" = (
 /obj/structure/monorail,
-/turf/open/beach/water,
+/turf/open/beach/sea,
 /area/space)
 "bDF" = (
 /obj/machinery/light{
@@ -33302,6 +33101,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/open/floor/prison/green,
 /area/prison/cellblock/lowsec/sw)
@@ -34104,6 +33908,11 @@
 	name = "Southwest Low-Security Monitoring";
 	req_access_txt = "0"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/open/floor/prison,
 /area/prison/security/monitoring/lowsec/sw)
 "bFk" = (
@@ -34653,6 +34462,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 8
 	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/drained{
+	dir = 8
+	},
 /turf/open/floor/prison/trim/red{
 	dir = 5
 	},
@@ -34914,7 +34730,7 @@
 "bHd" = (
 /obj/structure/lattice,
 /obj/structure/lattice,
-/turf/open/beach/water,
+/turf/open/beach/sea,
 /area/space)
 "bHe" = (
 /obj/structure/cable{
@@ -36309,6 +36125,11 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/open/floor/prison/yellow{
 	dir = 5
 	},
@@ -37402,7 +37223,7 @@
 /obj/structure/lattice,
 /obj/structure/monorail,
 /obj/structure/lattice,
-/turf/open/beach/water,
+/turf/open/beach/sea,
 /area/space)
 "bMW" = (
 /obj/machinery/light{
@@ -38032,7 +37853,7 @@
 /area/prison/toilet/security)
 "bOt" = (
 /obj/structure/window/framed/prison/reinforced/hull,
-/turf/open/beach/water,
+/turf/open/beach/sea,
 /area/prison/residential/south)
 "bOu" = (
 /obj/effect/alien/weeds/node,
@@ -38403,7 +38224,7 @@
 /obj/structure/monorail{
 	dir = 6
 	},
-/turf/open/beach/water,
+/turf/open/beach/sea,
 /area/space)
 "bPl" = (
 /obj/structure/table/reinforced,
@@ -38920,13 +38741,13 @@
 /obj/structure/monorail{
 	dir = 9
 	},
-/turf/open/beach/water,
+/turf/open/beach/sea,
 /area/space)
 "bQD" = (
 /obj/structure/monorail{
 	dir = 5
 	},
-/turf/open/beach/water,
+/turf/open/beach/sea,
 /area/space)
 "bQE" = (
 /obj/machinery/washing_machine,
@@ -39799,6 +39620,11 @@
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/open/floor/prison/yellow{
 	dir = 1
 	},
@@ -39819,6 +39645,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/open/floor/prison/trim/red{
 	dir = 8
 	},
@@ -39827,9 +39658,21 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/open/floor/prison,
 /area/prison/security/checkpoint/medsec)
 "bSR" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/drained{
+	dir = 8
+	},
 /turf/open/floor/prison/trim/red{
 	dir = 4
 	},
@@ -40364,7 +40207,7 @@
 /obj/structure/monorail{
 	dir = 10
 	},
-/turf/open/beach/water,
+/turf/open/beach/sea,
 /area/space)
 "bUh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -40372,6 +40215,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/open/floor/prison/yellow/full,
 /area/prison/cellblock/mediumsec/north)
@@ -40523,6 +40371,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/open/floor/prison/trim/red{
 	dir = 10
@@ -40794,6 +40647,7 @@
 /area/prison/hallway/east)
 "bUZ" = (
 /obj/structure/table/reinforced,
+/obj/machinery/computer/secure_data,
 /turf/open/floor/prison/darkred/full,
 /area/prison/intake)
 "bVa" = (
@@ -41002,6 +40856,7 @@
 "bVz" = (
 /obj/structure/monorail,
 /obj/machinery/door/poddoor/shutters/mainship{
+	dir = 2;
 	name = "Monorail Passage Door"
 	},
 /turf/open/floor/plating,
@@ -41113,6 +40968,11 @@
 	req_access_txt = "0"
 	},
 /obj/effect/landmark/lv624/fog_blocker,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/checkpoint/medsec)
 "bVO" = (
@@ -41316,7 +41176,6 @@
 /turf/open/floor/plating,
 /area/prison/engineering/atmos)
 "bWr" = (
-/obj/machinery/computer/secure_data,
 /turf/open/floor/prison/trim/red{
 	dir = 8
 	},
@@ -41334,7 +41193,6 @@
 /turf/open/floor/prison,
 /area/prison/intake)
 "bWu" = (
-/obj/machinery/computer/secure_data,
 /turf/open/floor/prison/trim/red{
 	dir = 4
 	},
@@ -41590,6 +41448,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/open/floor/prison/yellow/full,
 /area/prison/cellblock/mediumsec/north)
@@ -42267,16 +42130,14 @@
 /area/prison/parole/protective_custody)
 "bYF" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/lattice,
-/turf/open/beach/water,
+/turf/open/floor/plating/catwalk,
 /area/prison/disposal)
 "bYG" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/up{
 	dir = 1
 	},
-/obj/structure/lattice,
-/turf/open/beach/water,
+/turf/open/floor/plating/catwalk,
 /area/prison/disposal)
 "bYH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -43134,6 +42995,7 @@
 /obj/structure/monorail,
 /obj/structure/lattice,
 /obj/machinery/door/poddoor/shutters/mainship{
+	dir = 2;
 	name = "Monorail Passage Door"
 	},
 /turf/open/floor/plating,
@@ -43884,7 +43746,7 @@
 	dir = 4
 	},
 /obj/structure/lattice,
-/turf/open/beach/water,
+/turf/open/beach/sea,
 /area/space)
 "ccA" = (
 /obj/structure/sink{
@@ -46876,9 +46738,6 @@
 /obj/item/weapon/gun/pistol/b92fs,
 /turf/open/floor/wood,
 /area/prison/security/head)
-"cjJ" = (
-/turf/open/floor/prison/marked,
-/area/prison/cellblock/protective)
 "cjK" = (
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/cobweb,
@@ -48524,15 +48383,7 @@
 /obj/structure/monorail{
 	dir = 4
 	},
-/turf/open/beach/water,
-/area/space)
-"cnD" = (
-/obj/machinery/disposal/deliveryChute{
-	dir = 1
-	},
-/obj/structure/lattice,
-/obj/structure/disposalpipe/trunk,
-/turf/open/beach/water,
+/turf/open/beach/sea,
 /area/space)
 "cnE" = (
 /obj/machinery/light{
@@ -48791,7 +48642,7 @@
 /turf/open/floor/prison,
 /area/prison/security/armory/lethal)
 "con" = (
-/turf/open/beach/water,
+/turf/open/beach/sea,
 /area/prison/pirate)
 "coq" = (
 /obj/structure/rack,
@@ -49928,7 +49779,9 @@
 /area/prison/cellblock/mediumsec/east)
 "cry" = (
 /obj/machinery/conveyor,
-/obj/machinery/door/poddoor,
+/obj/machinery/door/poddoor/mainship{
+	dir = 2
+	},
 /turf/open/floor/plating,
 /area/prison/disposal)
 "crz" = (
@@ -50195,8 +50048,7 @@
 	dir = 6
 	},
 /obj/structure/lattice,
-/obj/structure/disposalpipe/segment,
-/turf/open/beach/water,
+/turf/open/beach/sea,
 /area/space)
 "cst" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -50372,13 +50224,6 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/plating,
 /area/prison/disposal)
-"csR" = (
-/obj/structure/monorail{
-	dir = 6
-	},
-/obj/structure/lattice,
-/turf/open/beach/water,
-/area/space)
 "csS" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/donkpockets,
@@ -50728,8 +50573,7 @@
 	dir = 9
 	},
 /obj/structure/lattice,
-/obj/structure/disposalpipe/segment,
-/turf/open/beach/water,
+/turf/open/beach/sea,
 /area/space)
 "ctz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -50743,21 +50587,13 @@
 /obj/effect/decal/cleanable/blood,
 /turf/closed/wall/prison,
 /area/prison/cellblock/mediumsec/east)
-"ctB" = (
-/obj/structure/disposaloutlet,
-/obj/structure/disposalpipe/up{
-	dir = 1
-	},
-/obj/structure/lattice,
-/turf/open/beach/water,
-/area/space)
 "ctC" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector{
 	dir = 1;
 	name = "Waste Air Injector";
 	on = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk,
 /area/prison/disposal)
 "ctD" = (
 /obj/structure/table/reinforced,
@@ -50861,7 +50697,7 @@
 /area/prison/cellblock/mediumsec/south)
 "ctW" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/open/beach/water,
+/turf/open/beach/sea,
 /area/prison/pirate)
 "ctX" = (
 /turf/open/floor/prison/yellow/corner,
@@ -50899,7 +50735,7 @@
 /area/prison/cellblock/mediumsec/east)
 "cuf" = (
 /obj/item/stack/sheet/metal,
-/turf/open/beach/water,
+/turf/open/beach/sea,
 /area/space)
 "cug" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -50931,8 +50767,13 @@
 /turf/open/floor/carpet,
 /area/prison/pirate)
 "cuk" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Solitary Confinement"
+/obj/machinery/door/airlock/mainship/secure{
+	density = 0;
+	dir = 2;
+	icon_state = "door_open";
+	name = "Solitary Confinement";
+	opacity = 0;
+	req_access_txt = "0"
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/mediumsec/west)
@@ -51608,7 +51449,7 @@
 	opacity = 0;
 	req_access_txt = "0"
 	},
-/turf/open/floor/prison/blue/full,
+/turf/open/floor/plating,
 /area/prison/cellblock/protective)
 "cvY" = (
 /obj/machinery/door/airlock/mainship/generic{
@@ -52517,12 +52358,6 @@
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/mediumsec/south)
-"cyA" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Solitary Confinement"
-	},
-/turf/open/floor/prison/yellow/full,
-/area/prison/cellblock/mediumsec/south)
 "cyB" = (
 /obj/structure/shuttle/engine/heater,
 /obj/effect/decal/warning_stripes,
@@ -53061,6 +52896,12 @@
 	dir = 6
 	},
 /area/prison/security/monitoring/medsec/south)
+"cPY" = (
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/hallway/staff)
+"dbh" = (
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/canteen)
 "dil" = (
 /obj/structure/window/framed/prison/reinforced/hull,
 /obj/effect/landmark/lv624/fog_blocker,
@@ -53094,6 +52935,13 @@
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/highsec/south/south)
+"eyF" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2";
+	dir = 10
+	},
+/area/prison/yard)
 "eCA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -53158,6 +53006,18 @@
 	},
 /turf/open/floor/plating,
 /area/prison/hangar/main)
+"hfI" = (
+/obj/effect/landmark/corpsespawner/prisoner,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/hallway/east)
+"hwj" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2";
+	dir = 10
+	},
+/area/prison/yard)
 "hHw" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -53324,6 +53184,16 @@
 /obj/machinery/computer/shuttle/shuttle_control/dropship1,
 /turf/open/floor/plating,
 /area/prison/hangar/civilian)
+"lOX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/canteen)
+"mof" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/prison,
+/area/prison/execution)
 "mrj" = (
 /obj/effect/landmark/corpsespawner/prison_security,
 /turf/open/floor/prison/yellow/corner{
@@ -53359,6 +53229,11 @@
 	dir = 8
 	},
 /area/prison/cellblock/mediumsec/north)
+"nOu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/canteen)
 "nYp" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 1
@@ -53372,6 +53247,17 @@
 	dir = 4
 	},
 /area/prison/cellblock/mediumsec/south)
+"oRz" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/machinery/landinglight/ds2/delaytwo{
+	dir = 8
+	},
+/turf/open/floor/prison/darkyellow{
+	dir = 10
+	},
+/area/prison/hangar/civilian)
 "pOU" = (
 /obj/structure/window/framed/prison/reinforced/hull,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
@@ -53433,6 +53319,16 @@
 	},
 /turf/open/floor/prison,
 /area/prison/cellblock/mediumsec/south)
+"swP" = (
+/obj/machinery/door/airlock/mainship/secure{
+	density = 0;
+	icon_state = "door_open";
+	name = "Solitary Confinement";
+	opacity = 0;
+	req_access_txt = "0"
+	},
+/turf/open/floor/plating,
+/area/prison/cellblock/mediumsec/west)
 "sGS" = (
 /turf/open/floor/prison/yellow{
 	dir = 4
@@ -53442,6 +53338,10 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall/prison,
 /area/prison/library)
+"sZH" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/canteen)
 "tow" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall/prison,
@@ -53468,6 +53368,16 @@
 	dir = 10
 	},
 /area/prison/hallway/central)
+"ueY" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/canteen)
 "upV" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 8
@@ -53478,6 +53388,10 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall/prison,
 /area/prison/hallway/central)
+"uQX" = (
+/obj/machinery/vending/cigarette/colony,
+/turf/open/floor/prison,
+/area/prison/execution)
 "uUB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -53490,6 +53404,17 @@
 	dir = 4
 	},
 /area/prison/cellblock/mediumsec/north)
+"uWT" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/machinery/landinglight/ds2/delaythree{
+	dir = 8
+	},
+/turf/open/floor/prison/darkyellow{
+	dir = 9
+	},
+/area/prison/hangar/civilian)
 "vcw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -53520,6 +53445,12 @@
 	},
 /turf/open/floor/prison,
 /area/prison/cellblock/vip)
+"vnS" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/prison,
+/area/prison/hangar/main)
 "vpQ" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison{
@@ -53539,6 +53470,29 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall/prison,
 /area/prison/canteen)
+"wfY" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/prison{
+	icon_state = "bright_clean";
+	dir = 10
+	},
+/area/prison/hallway/central)
+"wMM" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/prison/rampbottom{
+	dir = 1
+	},
+/area/prison/maintenance/staff_research)
 "xHS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -53550,6 +53504,11 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall/prison,
 /area/prison/storage/vip)
+"ydX" = (
+/turf/open/floor/prison/rampbottom{
+	dir = 1
+	},
+/area/prison/maintenance/staff_research)
 "yhS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -59095,12 +59054,12 @@ bcM
 aAE
 baV
 bcd
-bcM
-aAE
+uWT
+oRz
 baV
 bcd
-bcM
-aAE
+uWT
+oRz
 baV
 bcd
 bcM
@@ -59356,8 +59315,8 @@ bgp
 bkv
 aok
 aok
-aok
-aok
+bgp
+bkv
 aok
 aok
 aok
@@ -59613,8 +59572,8 @@ bgp
 bkv
 ays
 ays
-ays
-ays
+bgp
+bkv
 ays
 ays
 ays
@@ -59870,8 +59829,8 @@ bgp
 bkv
 ays
 ays
-ays
-ays
+bgp
+bkv
 aAC
 aAC
 aAC
@@ -60390,7 +60349,7 @@ bjK
 aWI
 aWI
 aWI
-aWI
+aWS
 aWr
 aYQ
 aYR
@@ -65001,7 +64960,7 @@ baQ
 aYR
 aYQ
 aWr
-aYZ
+aWS
 aWI
 aWI
 aWI
@@ -65016,7 +64975,7 @@ bjO
 aWI
 aWI
 aWI
-aWI
+aWS
 aWr
 aYQ
 aYR
@@ -73451,8 +73410,8 @@ fvh
 fvh
 fvh
 fvh
+fvh
 azq
-aAd
 aAd
 aBc
 aCh
@@ -73736,7 +73695,7 @@ aUY
 aCl
 aCl
 aIs
-bbX
+aEV
 aCl
 bdI
 bdI
@@ -78947,9 +78906,9 @@ cqM
 cmN
 ctN
 cqK
-cuk
+swP
 cqK
-cuk
+swP
 cqK
 csB
 cwC
@@ -83508,16 +83467,16 @@ bsY
 aKN
 aKN
 aKN
-aKN
-aKN
-aKN
-aKN
-aKN
+aKP
+aKP
+aKP
+aKP
+aKP
 aLl
-aLu
-aLu
+aTD
+aTD
 aLz
-aKN
+aKP
 aKN
 aKN
 aKN
@@ -83765,16 +83724,16 @@ bsY
 aWG
 aKN
 aKN
+aKP
+aKP
 aKN
 aKN
 aKN
 aKN
 aKN
 aKN
-aKN
-aKN
-bou
-aOj
+aPu
+bnE
 aAR
 aKN
 aWG
@@ -84022,16 +83981,16 @@ aKT
 beC
 aKN
 aKN
-aKN
-aKN
+aKP
+aKP
 aKN
 aKU
 aKU
 aKU
 aKU
 aKN
-bou
-aKN
+aPu
+aKP
 aKN
 aKN
 beC
@@ -84258,28 +84217,28 @@ azo
 abk
 aKN
 azC
-aLu
-aLu
-aLu
-aLu
+aTD
+aTD
+aTD
+aTD
 aMg
-aMw
-aMw
-aMw
-aMw
-aMw
+aKO
+aKO
+aKO
+aKO
+aKO
 aNv
-aMw
-aMw
+aKO
+aKO
 aPv
-aMw
-aMw
-aMw
+aKO
+aKO
+aKO
 bdS
 aNv
-aMw
-aMw
-aMw
+aKO
+aKO
+aKO
 baU
 aKN
 aKU
@@ -84288,28 +84247,28 @@ aab
 aKU
 aAR
 bkm
-aLu
-aLu
-aLu
+aTD
+aTD
+aTD
 boF
 buN
-aLu
-aLu
-aLu
-aLu
-aLu
-aLu
+aTD
+aTD
+aTD
+aTD
+aTD
+aTD
 bqO
-aLu
-aLu
-aLu
-aLu
-aLu
+aTD
+aTD
+aTD
+aTD
+aTD
 brh
-aLu
+aTD
 brt
-aLu
-aLu
+aTD
+aTD
 bAe
 aKN
 izb
@@ -84515,59 +84474,59 @@ aFj
 aIS
 aKO
 aCe
-aKN
-aKN
-aKN
-aKN
-aKN
-aKN
-aKN
-aKN
-aOj
-aKN
-aOb
-aKN
-aKN
-aKN
-aKN
-aKN
-aKN
-aKN
-aOb
-aKN
-aKN
-aKN
-bdz
-aKN
-aKU
-aab
-aab
-aKU
-aKN
-bou
-aKN
-aKN
-aKN
+aKP
+aKP
+aKP
+aKP
+aKP
+aKP
+aKP
+aKP
+bnE
+aKP
 aOb
 aKP
-aKN
-aAR
-aKN
-aKN
-aAR
-aKN
+aKP
+aKP
+aKP
+aKP
+aKP
+aKP
 aOb
+aKP
+aKP
+aKP
+aUD
 aKN
-aAR
+aKU
+aab
+aab
+aKU
 aKN
+aPu
+aKP
+aKP
+aKP
+aOb
+aKP
+aKP
+aXw
+aKP
+aKP
+aXw
+aKP
+aOb
+aKP
+aXw
+aKP
 aNP
-aKN
-aKN
-aKN
-aKN
-aKN
-aKN
-aPt
+aKP
+aKP
+aKP
+aKP
+aKP
+aKP
+aLs
 aKP
 bPx
 bQV
@@ -84771,8 +84730,8 @@ aCH
 aCH
 vpQ
 aKP
-aPt
-aKN
+aLs
+aKP
 aAR
 aKN
 aAR
@@ -84793,16 +84752,16 @@ aKT
 aWJ
 aKN
 aAR
-aKN
-bdz
+aKP
+aUD
 aKN
 aKU
 aKU
 aKU
 aKU
 aKN
-bou
-aKN
+aPu
+aKP
 aKN
 aKN
 aWJ
@@ -84823,7 +84782,7 @@ aAR
 aKN
 aKN
 aAR
-aKN
+aKP
 bAp
 aTD
 bPy
@@ -85028,8 +84987,8 @@ aHI
 axM
 abk
 aKN
-aPt
-aKN
+aLs
+aKP
 aKN
 aNp
 aNp
@@ -85050,16 +85009,16 @@ aNp
 aNp
 aNp
 aKN
-aKN
-bdz
+aKP
+aUD
 aAR
 aKN
 aKN
 aKN
 aKN
 aKN
-bou
-aAR
+aPu
+aXw
 aKN
 bql
 bql
@@ -85080,8 +85039,8 @@ bIQ
 bFk
 bFk
 aKN
-aKN
-aPt
+aKP
+aLs
 aKN
 izb
 bQV
@@ -85285,8 +85244,8 @@ aHJ
 azA
 abk
 aKQ
-aPt
-aKN
+aLs
+aKP
 aKN
 aNp
 aNR
@@ -85307,16 +85266,16 @@ aNX
 aZI
 aNp
 aIH
-aKN
+aKP
 beB
-aMw
-aMw
-aMw
+aKO
+aKO
+aKO
 bif
-aLu
-aLu
+aTD
+aTD
 aMe
-aKN
+aKP
 aKN
 bql
 bsR
@@ -85337,8 +85296,8 @@ bIR
 bJM
 bFk
 aKN
-aOj
-aPt
+bnE
+aLs
 aOj
 izb
 bGP
@@ -85542,8 +85501,8 @@ abk
 abk
 axM
 aIH
-aPt
-aKN
+aLs
+aKP
 aKN
 aNp
 aNS
@@ -85564,16 +85523,16 @@ bbk
 aPC
 aNp
 aKN
-aKN
-aKN
-aKN
-aKN
-aKN
-bou
-aKN
-aKN
-aKN
-aKN
+aKP
+aKP
+aKP
+aKP
+aKP
+aPu
+aKP
+aKP
+aKP
+aKP
 aKN
 bql
 btM
@@ -85594,8 +85553,8 @@ bIS
 bJN
 bFk
 aAR
-aOj
-aPt
+bnE
+aLs
 aKN
 bPz
 elB
@@ -85799,8 +85758,8 @@ aHK
 aIT
 anT
 aKN
-aPt
-aOj
+aLs
+bnE
 aKN
 aNp
 aNT
@@ -85851,8 +85810,8 @@ bSz
 bJO
 bFk
 aKN
-aKN
-aPt
+aKP
+aLs
 aKN
 auu
 bPA
@@ -86057,7 +86016,7 @@ aAm
 anT
 aKN
 aFE
-aKN
+aKP
 aKN
 aNp
 aKC
@@ -86108,8 +86067,8 @@ bIU
 bJP
 bFk
 aKN
-aKN
-aPt
+aKP
+aLs
 aAR
 auu
 bPB
@@ -86313,8 +86272,8 @@ aGE
 aHU
 anT
 aKN
-aPt
-aKN
+aLs
+aKP
 aMM
 aNp
 aNT
@@ -86365,8 +86324,8 @@ bCa
 bCa
 bql
 aKQ
-aKN
-aPt
+aKP
+aLs
 aKN
 auu
 bPC
@@ -86570,8 +86529,8 @@ aFt
 aGF
 anT
 aKN
-aPt
-aKN
+aLs
+aKP
 aKN
 aNp
 aNT
@@ -86622,8 +86581,8 @@ bxP
 bsG
 bql
 aIH
-aKN
-aPt
+aKP
+aLs
 aKN
 auu
 bPD
@@ -87084,8 +87043,8 @@ aGa
 aGa
 aJX
 aKN
-aPt
-aKN
+aLs
+aKP
 aKN
 aNp
 aNp
@@ -87136,7 +87095,7 @@ bql
 bql
 bql
 aKN
-aKN
+aKP
 aFE
 aXw
 bOx
@@ -87341,8 +87300,8 @@ axO
 axO
 aJX
 aXw
-aPt
-aAR
+aLs
+aXw
 aKN
 aNp
 aNV
@@ -87393,8 +87352,8 @@ bxP
 bsG
 bql
 aKN
-aKN
-aPt
+aKP
+aLs
 aKP
 bOx
 bqB
@@ -87599,7 +87558,7 @@ aIV
 aJY
 aKS
 aKm
-aKN
+aKP
 aKN
 aNp
 aNW
@@ -87650,7 +87609,7 @@ brg
 brR
 bql
 aAR
-aKN
+aKP
 bAp
 aTD
 bOy
@@ -87855,8 +87814,8 @@ aGa
 aVq
 aJX
 aKN
-aPt
-aKN
+aLs
+aKP
 aAR
 aNp
 aNp
@@ -87907,8 +87866,8 @@ bql
 bql
 bql
 aKN
-aKN
-aPt
+aKP
+aLs
 aXw
 bOx
 bAl
@@ -88112,8 +88071,8 @@ aGx
 aGx
 anT
 aKN
-aPt
-aKN
+aLs
+aKP
 aKN
 aNp
 aNX
@@ -88164,8 +88123,8 @@ bxP
 bsG
 bql
 aKN
-aKN
-aPt
+aKP
+aLs
 aKN
 auu
 bPE
@@ -88369,8 +88328,8 @@ aFt
 aGF
 anT
 aKN
-aPt
-aKN
+aLs
+aKP
 aKN
 aNp
 aNY
@@ -88422,7 +88381,7 @@ brR
 bql
 aKN
 aNP
-aPt
+aLs
 aMM
 auu
 bPD
@@ -88626,8 +88585,8 @@ aHP
 aAl
 anT
 aAR
-aPt
-aKN
+aLs
+aKP
 aKN
 aNp
 aNp
@@ -88678,7 +88637,7 @@ bql
 bql
 bql
 aKN
-aKN
+aKP
 aFE
 aKN
 auu
@@ -88883,8 +88842,8 @@ aHQ
 aAm
 anT
 aKN
-aPt
-aKN
+aLs
+aKP
 aKN
 aNp
 aNX
@@ -88935,8 +88894,8 @@ bxP
 bsG
 bql
 aKN
-aKN
-aPt
+aKP
+aLs
 aKN
 auu
 bPB
@@ -89654,8 +89613,8 @@ aHS
 aFt
 jUb
 aKQ
-aPt
-aKN
+aLs
+aKP
 aKN
 aKN
 aKN
@@ -89706,8 +89665,8 @@ aKN
 aKN
 aKN
 aKN
-aKN
-aPt
+aKP
+aLs
 aKN
 tGu
 bPM
@@ -89911,12 +89870,12 @@ aHT
 aGF
 jUb
 aKN
-aPt
-aOj
-aKN
-aKN
-aKN
-aKN
+aLs
+bnE
+aKP
+aKP
+aKP
+aKP
 aMM
 aNp
 aSg
@@ -89959,12 +89918,12 @@ bDS
 bFr
 bql
 aKQ
-aKN
-aKN
-aKN
-aKN
-aKN
-aPt
+aKP
+aKP
+aKP
+aKP
+aKP
+aLs
 aKN
 tGu
 bHl
@@ -90173,7 +90132,7 @@ aLx
 aLx
 aLx
 aLz
-aKN
+aKP
 aKN
 aNp
 aNS
@@ -90216,11 +90175,11 @@ bDU
 bFs
 bql
 aKN
-aKN
+aKP
 aLm
-btr
-btr
-btr
+aKS
+aKS
+aKS
 aMe
 aKN
 tGu
@@ -90430,7 +90389,7 @@ aKN
 aKN
 aKN
 aLB
-aKN
+aKP
 aAR
 aNp
 aTr
@@ -90449,12 +90408,12 @@ aHp
 bib
 aTR
 bku
-aWR
-bjj
-aWR
-bjj
-aWR
-bjj
+bgQ
+eyF
+bgQ
+eyF
+bgQ
+eyF
 aWR
 bgQ
 blk
@@ -90473,8 +90432,8 @@ bDV
 aTr
 bql
 aKN
-aKN
-aPt
+aKP
+aLs
 aAR
 aKN
 aKN
@@ -90687,7 +90646,7 @@ aKU
 aKU
 aKN
 aLB
-aKN
+aKP
 aKP
 aKT
 aKP
@@ -90706,7 +90665,7 @@ aWR
 bib
 bgQ
 bku
-aWR
+bgQ
 bmB
 blk
 bmB
@@ -90730,8 +90689,8 @@ bDW
 aKP
 aKT
 aKP
-aKN
-aPt
+aKP
+aLs
 aKN
 aKU
 aKU
@@ -90944,7 +90903,7 @@ aab
 aKU
 aKN
 aLB
-aKN
+aKP
 aKP
 aSj
 aKP
@@ -90963,12 +90922,12 @@ aWR
 aWR
 aHp
 aWR
-bmB
+hwj
 bjj
 bny
-aWR
+bgQ
 bpG
-aWR
+bgQ
 bri
 bjj
 bsH
@@ -90987,8 +90946,8 @@ aUD
 aKP
 aSj
 aKP
-aKN
-aPt
+aKP
+aLs
 aKN
 aKU
 aab
@@ -91201,7 +91160,7 @@ aab
 aKU
 aKN
 aMd
-aMi
+aQX
 aQX
 aQX
 aQX
@@ -91220,12 +91179,12 @@ aWR
 bib
 bjj
 aWR
+bgQ
 aWR
+eyF
+bgQ
 aWR
-bjj
-aWR
-aWR
-bjj
+eyF
 bku
 bmC
 bsH
@@ -91244,7 +91203,7 @@ bxn
 aQX
 aQX
 aQX
-aMi
+aQX
 brj
 aKN
 aKU
@@ -91458,7 +91417,7 @@ aKU
 aKU
 aKN
 aLB
-aKN
+aKP
 aKP
 aKT
 aKP
@@ -91501,8 +91460,8 @@ aUD
 bnE
 aKT
 bnE
-aKN
-aPt
+aKP
+aLs
 aKN
 aKU
 aKU
@@ -91552,9 +91511,9 @@ cun
 cwk
 cuR
 cun
-cyA
+cyz
 cun
-cyA
+cyz
 cun
 cyR
 cvc
@@ -91715,7 +91674,7 @@ aKN
 aKN
 aKN
 aLB
-aKN
+aKP
 aKN
 aNq
 aTs
@@ -91734,12 +91693,12 @@ aWR
 bib
 bjk
 aWR
-aHt
-bmC
-aWR
-aWR
-aHp
-aWR
+aTR
+bjk
+bgQ
+bgQ
+bdt
+bgQ
 aWR
 bgQ
 bsH
@@ -91758,8 +91717,8 @@ bEh
 aTs
 bqs
 aKN
-aKN
-aPt
+aKP
+aLs
 aKN
 aKN
 aKN
@@ -91972,7 +91931,7 @@ aLx
 aLx
 aLx
 aMe
-aKN
+aKP
 aAR
 aNq
 aTt
@@ -92015,11 +91974,11 @@ bDX
 bFt
 bqs
 aIH
-aKN
+aKP
 aLl
-btr
-btr
-btr
+aKS
+aKS
+aKS
 aLz
 aKN
 tGu
@@ -92224,12 +92183,12 @@ aGK
 aGK
 aJT
 aKN
-aPt
-aKN
-aKN
-aKN
-aKN
-aKN
+aLs
+aKP
+aKP
+aKP
+aKP
+aKP
 aMM
 aNq
 aTu
@@ -92272,12 +92231,12 @@ bDY
 bFu
 bqs
 aKQ
-aKN
-aKN
-aKN
-aKN
-aKN
-aPt
+aKP
+aKP
+aKP
+aKP
+aKP
+aLs
 aKN
 tGu
 bHl
@@ -92481,8 +92440,8 @@ aFz
 aGK
 aJT
 aKN
-aPt
-aKN
+aLs
+aKP
 aKN
 aKN
 aKN
@@ -92533,8 +92492,8 @@ aKN
 aKN
 aKN
 aKN
-aKN
-aPt
+aKP
+aLs
 aKN
 tGu
 bPU
@@ -92790,7 +92749,7 @@ bqs
 bqs
 bqs
 aKT
-aKN
+aKP
 bKU
 aKT
 tGu
@@ -93252,8 +93211,8 @@ aFz
 aJe
 aJT
 aKN
-aPt
-aKN
+aLs
+aKP
 aKN
 aNr
 aOe
@@ -93304,8 +93263,8 @@ bIV
 bsK
 bqs
 aKN
-aKN
-aPt
+aKP
+aLs
 aKP
 bOB
 bPV
@@ -93509,8 +93468,8 @@ aFz
 aJe
 aJT
 aKN
-aPt
-aKN
+aLs
+aKP
 aKN
 aNq
 aNq
@@ -93561,7 +93520,7 @@ bqs
 bqs
 bqs
 aAR
-aKN
+aKP
 bAp
 aTD
 bOC
@@ -93766,8 +93725,8 @@ aFz
 aJe
 aJT
 aKQ
-aPt
-aKN
+aLs
+aKP
 aKN
 aNq
 aNZ
@@ -93818,8 +93777,8 @@ brl
 blQ
 bqs
 aKN
-aKN
-aPt
+aKP
+aLs
 aMM
 sXw
 bPX
@@ -94023,8 +93982,8 @@ aFz
 aJe
 aJT
 aKN
-aPt
-aKN
+aLs
+aKP
 aKN
 aNq
 aOe
@@ -94075,8 +94034,8 @@ bIV
 bsK
 bqs
 aKN
-aKN
-aPt
+aKP
+aLs
 aKN
 sXw
 bPY
@@ -94280,8 +94239,8 @@ aFz
 aJe
 aJT
 aKN
-aPt
-aKN
+aLs
+aKP
 aKN
 aNq
 aNq
@@ -94332,8 +94291,8 @@ bqs
 bqs
 bqs
 aKN
-aKN
-aPt
+aKP
+aLs
 aKN
 sXw
 bPY
@@ -94537,8 +94496,8 @@ aFz
 aqm
 aJT
 aKN
-aPt
-aKN
+aLs
+aKP
 aKN
 aNq
 aNZ
@@ -94589,8 +94548,8 @@ brl
 blQ
 bqs
 aKN
-aKN
-aPt
+aKP
+aLs
 aOj
 sXw
 bPY
@@ -94794,8 +94753,8 @@ aIa
 aIE
 aJT
 aKN
-aPt
-aKN
+aLs
+aKP
 aKN
 aNq
 aOe
@@ -95103,8 +95062,8 @@ bqs
 bqs
 bqs
 aKN
-aKN
-aPt
+aKP
+aLs
 aKN
 bOE
 bPZ
@@ -95283,8 +95242,8 @@ aoR
 alx
 apW
 alf
-arf
-arJ
+awS
+aGS
 asy
 atf
 apg
@@ -95308,7 +95267,7 @@ aFz
 aFz
 aKb
 aKP
-aPt
+aLs
 aNP
 aKN
 aNq
@@ -95360,8 +95319,8 @@ bFC
 bJR
 bqs
 aOj
-aKN
-aPt
+aKP
+aLs
 aKP
 bOE
 bQa
@@ -95540,8 +95499,8 @@ aoO
 alx
 apX
 alf
-arf
-arJ
+awS
+aGS
 asy
 atf
 atJ
@@ -95566,7 +95525,7 @@ aIb
 aKc
 aKS
 aKm
-aKN
+aKP
 aKN
 aNq
 aOe
@@ -95617,7 +95576,7 @@ bCD
 bGv
 bqs
 aIH
-aKN
+aKP
 bBg
 aKO
 bOF
@@ -95797,8 +95756,8 @@ aoS
 alx
 apY
 alf
-apa
-arJ
+atI
+aGS
 asz
 atf
 atf
@@ -95822,8 +95781,8 @@ aIc
 aIc
 uFs
 aKN
-aPt
-aKN
+aLs
+aKP
 aMM
 aNq
 aNq
@@ -95874,8 +95833,8 @@ bCD
 bGv
 bqs
 aKQ
-aKN
-aPt
+aKP
+aLs
 aKN
 bOE
 bPZ
@@ -96055,7 +96014,7 @@ alg
 alg
 alf
 arh
-arJ
+aGS
 asy
 aAF
 atf
@@ -96079,8 +96038,8 @@ aId
 avB
 vqR
 aKN
-aPt
-aKN
+aLs
+aKP
 aKN
 aNs
 aOr
@@ -96131,8 +96090,8 @@ bCD
 bGv
 bqs
 aKN
-aKN
-aPt
+aKP
+aLs
 aKN
 sXw
 bPZ
@@ -96308,11 +96267,11 @@ alZ
 alZ
 anY
 aoU
-apx
+alZ
 apZ
-apx
+aqE
 ari
-arJ
+aGS
 asA
 atg
 atL
@@ -96337,7 +96296,7 @@ aJg
 vqR
 aKN
 aLr
-aKN
+aKP
 aKN
 aNs
 aOg
@@ -96388,8 +96347,8 @@ bCE
 bGv
 bqs
 aKN
-aAR
-aPt
+aXw
+aLs
 aKN
 sXw
 bQc
@@ -96407,7 +96366,7 @@ bUC
 bPX
 chx
 ciP
-cjJ
+cod
 bXv
 cjE
 cmx
@@ -96564,8 +96523,8 @@ ama
 ama
 anq
 anZ
-aoX
-apy
+akD
+ama
 aqa
 aqD
 arj
@@ -96593,8 +96552,8 @@ aIe
 aJh
 vqR
 aIH
-aPt
-aKN
+aLs
+aKP
 aKN
 aNs
 aOh
@@ -96615,16 +96574,16 @@ aYr
 aYl
 aNq
 aKN
-aKN
-aKN
-aKN
-aKN
-aKN
-bou
-aKN
-aKN
-aKN
-aKN
+aKP
+aKP
+aKP
+aKP
+aKP
+aPu
+aKP
+aKP
+aKP
+aKP
 aKN
 bqs
 btS
@@ -96645,8 +96604,8 @@ bCD
 bGv
 bqs
 aKN
-aKN
-aPt
+aKP
+aLs
 aKN
 sXw
 bQd
@@ -96664,7 +96623,7 @@ bUC
 bPX
 chx
 ciP
-cjJ
+cod
 ckD
 cjC
 cht
@@ -96825,7 +96784,7 @@ ajG
 ajG
 aqb
 aqE
-ark
+ari
 arQ
 arQ
 asL
@@ -96850,8 +96809,8 @@ avE
 aJi
 vqR
 aKN
-aPt
-aKN
+aLs
+aKP
 aKN
 aNs
 aOi
@@ -96872,16 +96831,16 @@ aOe
 baR
 aNq
 aIH
-aKN
+aKP
 aLm
-aLu
-aLu
-aLu
+aTD
+aTD
+aTD
 biN
-aMw
-aMw
+aKO
+aKO
 baU
-aKN
+aKP
 aKN
 bqs
 btk
@@ -96902,8 +96861,8 @@ bEx
 bEx
 bqs
 aKN
-aKN
-aPt
+aKP
+aLs
 aOj
 sXw
 bQd
@@ -97107,8 +97066,8 @@ aIf
 avB
 vqR
 aKN
-aPt
-aKN
+aLs
+aKP
 aKN
 aNs
 aNs
@@ -97129,16 +97088,16 @@ aNq
 aNq
 aNq
 aKN
-aKN
-bou
-aKN
-aKN
+aKP
+aPu
 aKN
 aKN
 aKN
 aKN
-bdz
 aKN
+aKN
+aUD
+aKP
 aKN
 bqs
 bqs
@@ -97159,8 +97118,8 @@ bqs
 bqs
 bqs
 aKN
-aKN
-aPt
+aKP
+aLs
 aKN
 sXw
 bPX
@@ -97364,8 +97323,8 @@ aIg
 aJj
 vqR
 aKN
-aPt
-aKN
+aLs
+aKP
 aKN
 aNt
 aKN
@@ -97386,16 +97345,16 @@ aXa
 aKN
 aKN
 aKN
-aKN
-bou
+aKP
+aPu
 aKN
 aKU
 aKU
 aKU
 aKU
 aKN
-bdz
-aKN
+aUD
+aKP
 aKN
 aXa
 aKN
@@ -97416,8 +97375,8 @@ aKN
 aKN
 aKN
 aKN
-aKN
-aPt
+aKP
+aLs
 aKN
 tow
 bQe
@@ -97621,60 +97580,60 @@ arQ
 aJk
 vqR
 aKQ
-aPt
-aKN
-aKN
-aNt
-aKN
-aKN
-aKN
-aOj
+aLs
+aKP
+aKP
+wfY
+aKP
+aKP
+aKP
+bnE
 aJV
-aKN
-aKN
+aKP
+aKP
 aOb
-aKN
-aKN
+aKP
+aKP
 aNP
-aKN
-aKN
-aKN
+aKP
+aKP
+aKP
 aOb
-aKN
-aKN
-aKN
-aKN
-bou
+aKP
+aKP
+aKP
+aKP
+aPu
 aKN
 aKU
 aab
 aab
 aKU
 aKN
-bdz
-aKN
-aKN
+aUD
+aKP
+aKP
 aOb
-aKN
-aKN
-aOj
-aKN
-aKN
-aKN
-aKN
-aNt
+aKP
+aKP
+bnE
+aKP
+aKP
+aKP
+aKP
+wfY
 aOb
-aKN
-aKN
-aKN
-aKN
+aKP
+aKP
+aKP
+aKP
 aJV
-aKN
-aKN
-aKN
-aKN
-aKN
-aPt
+aKP
+aKP
+aKP
+aKP
+aKP
+aLs
 aKN
 tow
 bQf
@@ -97879,28 +97838,28 @@ aIF
 vqR
 aKN
 aLt
-aLu
-aLu
-aLy
-aLu
-aMk
-aLu
-aLu
 aTD
-aLu
-aLu
+aTD
+aLy
+aTD
+aMk
+aTD
+aTD
+aTD
+aTD
+aTD
 aOc
-aLu
-aLu
-aLu
-aLu
-aLu
-aLu
+aTD
+aTD
+aTD
+aTD
+aTD
+aTD
 aOc
-aLu
-aLu
+aTD
+aTD
 bah
-aLu
+aTD
 aMe
 aOj
 aKU
@@ -97909,28 +97868,28 @@ aab
 aKU
 aKN
 beB
-aMw
-aMw
+aKO
+aKO
 bnD
-aMw
-aMw
-aMw
-aMw
-aMw
-aMw
+aKO
+aKO
+aKO
+aKO
+aKO
+aKO
 aPv
 bpP
 bnD
-aMw
-aMw
+aKO
+aKO
 brc
-aLu
 aTD
-aLu
-aLu
+aTD
+aTD
+aTD
 btK
-aLu
-aLu
+aTD
+aTD
 bCM
 aKN
 tow
@@ -98748,7 +98707,7 @@ aab
 aab
 aab
 adO
-csR
+css
 bQC
 aab
 aab
@@ -99003,10 +98962,10 @@ aab
 aab
 aab
 aab
-cnD
+aab
 css
 cty
-ctB
+aab
 aab
 aab
 aab
@@ -99690,7 +99649,7 @@ aVa
 aVT
 aXd
 aYu
-aXf
+dbh
 aVT
 aXd
 aYu
@@ -99705,7 +99664,7 @@ aVX
 aVT
 aXd
 aYu
-aXf
+dbh
 aVT
 aXd
 aYu
@@ -99752,8 +99711,8 @@ cjK
 ciU
 ciU
 clm
-cnm
 ciU
+cnm
 chH
 cps
 cqk
@@ -99947,7 +99906,7 @@ aVa
 aVT
 aXd
 aYu
-aXf
+dbh
 aVT
 aXd
 aYu
@@ -99962,7 +99921,7 @@ aXf
 aVT
 aXd
 aYu
-aXf
+dbh
 aVT
 aXd
 aYu
@@ -99978,7 +99937,7 @@ bua
 bua
 bue
 bAA
-bAA
+bEA
 bEs
 bAA
 bHJ
@@ -100204,7 +100163,7 @@ aVb
 aVs
 aXd
 aYu
-aXf
+dbh
 aVT
 aXd
 aYu
@@ -100219,7 +100178,7 @@ aXf
 aVT
 aXd
 aYu
-aXf
+dbh
 aVT
 bro
 aYu
@@ -100461,7 +100420,7 @@ aVa
 aWa
 aXd
 aYu
-aXf
+dbh
 baq
 aXd
 aYu
@@ -100476,7 +100435,7 @@ aXf
 aVT
 aXd
 aYu
-aXf
+dbh
 aVT
 aXd
 aYu
@@ -100492,7 +100451,7 @@ byU
 byL
 bue
 bAA
-bAA
+bEA
 bEs
 bCN
 bHJ
@@ -100723,12 +100682,12 @@ aVT
 aXd
 aYu
 aXf
-aXf
-aXf
-aXf
+dbh
+dbh
+dbh
 bim
-aXf
-aXf
+dbh
+dbh
 aXf
 baq
 aXd
@@ -100749,7 +100708,7 @@ bue
 bue
 bue
 bCK
-bAA
+bEA
 bEs
 bGz
 bHJ
@@ -100975,7 +100934,7 @@ aVa
 aWa
 aXd
 aYv
-aXf
+dbh
 aVT
 aXd
 aYu
@@ -100990,7 +100949,7 @@ aXf
 aVT
 aXd
 aYu
-aXf
+dbh
 aVT
 aXd
 aYu
@@ -101232,7 +101191,7 @@ aVa
 aWa
 aXd
 aYu
-aXf
+dbh
 aVT
 aXd
 aYu
@@ -101247,7 +101206,7 @@ aXf
 aVT
 aXd
 aYu
-aXf
+dbh
 baq
 aXd
 aYu
@@ -101489,7 +101448,7 @@ aVa
 aWa
 aXd
 aYu
-aXf
+dbh
 aVT
 aXd
 aYu
@@ -101504,7 +101463,7 @@ aXf
 aVT
 aXd
 aYu
-aXf
+dbh
 aVT
 aXd
 aYu
@@ -101520,7 +101479,7 @@ bug
 bug
 bug
 bAA
-bAA
+bEA
 bEs
 bAA
 bHM
@@ -101744,12 +101703,12 @@ aSv
 aOt
 aVc
 aVW
-aXe
-aXe
-aXe
-aXe
-aXe
-aXe
+nOu
+nOu
+nOu
+nOu
+nOu
+nOu
 aXe
 beg
 bfE
@@ -101758,9 +101717,9 @@ bir
 bjs
 bjs
 blt
-blt
-blt
-blt
+ueY
+ueY
+ueY
 bka
 bqw
 bqw
@@ -102000,13 +101959,13 @@ aRn
 aSw
 aOt
 aVd
-aVX
-aXf
-aXf
-aXf
-aXf
+lOX
+dbh
+dbh
+dbh
+dbh
 bbs
-aXf
+dbh
 aXf
 beh
 beh
@@ -102015,9 +101974,9 @@ bio
 beh
 beh
 aXf
-aXf
-aXf
-aXf
+dbh
+dbh
+dbh
 bpM
 brp
 brp
@@ -102034,7 +101993,7 @@ bvb
 buM
 bBz
 bAA
-bAA
+bEA
 bEs
 bAA
 bHM
@@ -102260,7 +102219,7 @@ aVa
 aVT
 aXd
 aYu
-aZv
+sZH
 baq
 aXd
 aYu
@@ -102291,7 +102250,7 @@ bvb
 buM
 bui
 bAA
-bAA
+bEA
 bEs
 bAA
 bHN
@@ -102517,7 +102476,7 @@ aVa
 aVT
 aXd
 aYu
-aXf
+dbh
 aVT
 aXd
 aYu
@@ -102548,7 +102507,7 @@ byb
 bAm
 bui
 bAA
-bGz
+hfI
 bEs
 bCN
 bHM
@@ -102774,7 +102733,7 @@ aVa
 aVT
 aXd
 aYu
-aXf
+dbh
 aVT
 aXd
 aYu
@@ -102805,7 +102764,7 @@ btt
 btt
 btt
 bCN
-bCN
+bEG
 bEs
 bAA
 bHM
@@ -103053,8 +103012,8 @@ aYu
 aVa
 btt
 bul
-bul
-bvZ
+bvd
+bwa
 bwW
 bwZ
 byc
@@ -103062,7 +103021,7 @@ bvd
 bAn
 btt
 bAA
-bAA
+bEA
 bEs
 bAA
 bHM
@@ -103288,7 +103247,7 @@ aVa
 aVT
 aXd
 aYu
-aXf
+dbh
 aVT
 aXd
 aYu
@@ -103319,7 +103278,7 @@ bvd
 bwb
 btt
 bAA
-bAA
+bEA
 bEs
 bAA
 bHM
@@ -103545,7 +103504,7 @@ aVa
 aVT
 aXd
 aYu
-aXf
+dbh
 aVT
 aXd
 aYu
@@ -103601,7 +103560,7 @@ cdl
 cbY
 cbY
 cfD
-chO
+mof
 chQ
 chQ
 ckR
@@ -103769,7 +103728,7 @@ aab
 aab
 aab
 atU
-amS
+auq
 auI
 avI
 auq
@@ -103802,7 +103761,7 @@ aVa
 aVT
 aXd
 aYu
-aXf
+dbh
 aVT
 aXd
 aYu
@@ -103833,7 +103792,7 @@ bvd
 bys
 bvd
 bCQ
-bAA
+bEA
 bFH
 bGA
 bHM
@@ -104059,7 +104018,7 @@ aVa
 aVT
 aXd
 aYu
-aXf
+dbh
 aVT
 aXd
 aYu
@@ -104090,7 +104049,7 @@ bvd
 bAq
 btt
 bAA
-bAA
+bEA
 bFI
 bGB
 bHM
@@ -104347,7 +104306,7 @@ bvd
 bvd
 btt
 bAA
-bAA
+bEA
 bFI
 bAA
 bBC
@@ -104604,7 +104563,7 @@ bvd
 bAr
 btt
 bAA
-bCN
+bEG
 bFU
 bEH
 bHO
@@ -104809,7 +104768,7 @@ aur
 auq
 aAJ
 aBP
-aAJ
+ydX
 aAJ
 aAJ
 aHf
@@ -104861,11 +104820,11 @@ bvd
 bvd
 btt
 bAA
-bAA
-bAA
-bAA
+bEA
+bEA
+bEA
 bHP
-bEI
+bEA
 bEs
 bEA
 bEA
@@ -105066,7 +105025,7 @@ aur
 auq
 aAL
 aBQ
-aDB
+wMM
 aDB
 aDB
 aHg
@@ -105335,7 +105294,7 @@ aHh
 aHh
 aHh
 aNz
-aOI
+cPY
 aPS
 aRs
 aSx
@@ -105400,7 +105359,7 @@ cdz
 bMq
 bLv
 cfD
-chP
+uQX
 chQ
 caK
 ckR
@@ -105849,7 +105808,7 @@ aKY
 aLA
 aMW
 aNz
-aOI
+cPY
 aQg
 aRt
 aSy
@@ -106110,13 +106069,13 @@ aOJ
 aQi
 aRu
 aRD
-aRu
 aRD
+aRu
 aWc
 aXi
 aYw
 aZy
-aRu
+aRD
 aRu
 bax
 bdn
@@ -106363,7 +106322,7 @@ aIo
 aMy
 aHh
 aNz
-aOI
+cPY
 aQh
 aRv
 aQp
@@ -106877,7 +106836,7 @@ aIo
 aMy
 aMY
 aNz
-aOI
+cPY
 aQk
 aRx
 aSz
@@ -107391,7 +107350,7 @@ aIo
 aMy
 aHh
 aKg
-aOI
+cPY
 aQk
 aRz
 aSz
@@ -107406,7 +107365,7 @@ aVl
 bcw
 bdl
 bdl
-bdl
+biu
 bem
 bjC
 biu
@@ -108421,10 +108380,10 @@ aHh
 aND
 aOM
 aQo
-aRD
+aRu
 aSB
 aRD
-aRD
+aRu
 aRD
 aRD
 aYB
@@ -109482,7 +109441,7 @@ bbC
 bwk
 bxd
 bxI
-byh
+bwk
 bzf
 bzf
 bzf
@@ -110217,7 +110176,7 @@ aab
 aab
 aab
 aab
-aNG
+aNF
 aOS
 aQt
 aRI
@@ -111508,8 +111467,8 @@ aOT
 aRJ
 aOT
 aOT
-aab
-aab
+adO
+adO
 aXr
 aXp
 bkV
@@ -111766,7 +111725,7 @@ aRL
 aSI
 aNH
 aNH
-adO
+aab
 aXr
 aYK
 aZN
@@ -111775,17 +111734,17 @@ aXr
 aab
 nYp
 beu
-bcD
-aYM
-aYM
-aYM
-aYM
-aYM
-aYM
-aYM
+vnS
+bnQ
+bnQ
+bnQ
+bnQ
+bnQ
+bnQ
+bnQ
 bkJ
 blG
-aYM
+bnQ
 bnQ
 bnQ
 bnQ
@@ -112023,7 +111982,7 @@ aRM
 aOW
 aTP
 aNH
-adO
+aab
 aXt
 aYL
 aYL
@@ -112032,17 +111991,17 @@ iVk
 iVk
 aXt
 aVm
-aYM
-aYM
-aYM
-aYM
+bnQ
+bnQ
+bnQ
+bnQ
 bkI
 blE
 blE
 blE
 bpa
 blG
-aYM
+bnQ
 bnQ
 bnQ
 bnQ
@@ -112300,13 +112259,13 @@ bmU
 bmU
 bpZ
 aYM
-bnQ
-bnQ
-bnQ
-bnQ
-bnQ
-bnQ
-bnQ
+aYM
+aYM
+aYM
+aYM
+aYM
+aYM
+aYM
 bnQ
 bnQ
 bnQ
@@ -116678,7 +116637,7 @@ aZO
 aZO
 bxe
 bxe
-byn
+bxe
 bzn
 bAT
 bBY

--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -3399,7 +3399,7 @@
 "ali" = (
 /obj/machinery/vending/phoronresearch,
 /turf/open/floor/prison/whitepurple/full,
-/area/prison/research/secret/dissection)
+/area/prison/research/secret)
 "alj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -3530,9 +3530,6 @@
 	},
 /turf/open/floor/prison,
 /area/prison/research/secret/dissection)
-"alA" = (
-/turf/closed/wall/prison,
-/area/prison/research/secret)
 "alB" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -3614,12 +3611,6 @@
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/maxsec/south)
-"alL" = (
-/obj/structure/sink{
-	dir = 8
-	},
-/turf/open/floor/prison,
-/area/prison/research/secret/containment)
 "alM" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -4175,12 +4166,6 @@
 	dir = 4
 	},
 /area/prison/cellblock/maxsec/south)
-"anm" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/closed/wall/r_wall/prison,
-/area/prison/research/secret/containment)
 "ann" = (
 /obj/structure/sink{
 	dir = 8
@@ -4470,12 +4455,6 @@
 	},
 /turf/open/floor/plating,
 /area/prison/maintenance/research_medbay)
-"anS" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/prison/maintenance/research_medbay)
 "anT" = (
 /obj/structure/window/framed/prison/reinforced,
 /obj/machinery/door/poddoor/shutters/timed_late{
@@ -4483,12 +4462,6 @@
 	},
 /turf/open/floor/plating,
 /area/prison/security/checkpoint/maxsec)
-"anU" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/prison/maintenance/research_medbay)
 "anV" = (
 /turf/closed/wall/r_wall/prison,
 /area/prison/maintenance/research_medbay)
@@ -4806,9 +4779,6 @@
 /turf/open/floor/plating,
 /area/prison/maintenance/research_medbay)
 "aoK" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -4818,6 +4788,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -4839,9 +4812,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/prison/maintenance/research_medbay)
 "aoM" = (
@@ -4861,20 +4831,6 @@
 	req_one_access_txt = "0"
 	},
 /turf/open/floor/plating,
-/area/prison/maintenance/research_medbay)
-"aoN" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/prison,
 /area/prison/maintenance/research_medbay)
 "aoO" = (
 /obj/structure/cable{
@@ -8811,7 +8767,7 @@
 	name = "Infirmary Storage";
 	req_one_access_txt = "0"
 	},
-/turf/open/floor/prison/sterilewhite,
+/turf/open/floor/prison/whitegreen/full,
 /area/prison/medbay)
 "ayr" = (
 /obj/structure/closet/crate,
@@ -16818,17 +16774,6 @@
 	dir = 6
 	},
 /area/prison/security/checkpoint/highsec/n)
-"aQO" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/prison{
-	icon_state = "bright_clean2";
-	dir = 10
-	},
-/area/prison/residential/north)
 "aQP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 8
@@ -38167,7 +38112,7 @@
 "bPw" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 2;
-	name = "Canteen"
+	name = "Bar"
 	},
 /turf/open/floor/prison/kitchen,
 /area/prison/residential/central)
@@ -52683,10 +52628,21 @@
 	},
 /turf/open/floor/plating,
 /area/prison/hangar/main)
+"dOO" = (
+/obj/machinery/vending/cola,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2";
+	dir = 10
+	},
+/area/prison/residential/south)
 "dZt" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall/prison,
 /area/prison/medbay)
+"ecN" = (
+/obj/machinery/vending/cola,
+/turf/open/floor/prison/darkyellow/full,
+/area/prison/hallway/engineering)
 "elB" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall/prison,
@@ -52738,6 +52694,23 @@
 	},
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/highsec/north/south)
+"fkw" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/prison/maintenance/research_medbay)
 "fug" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -52852,6 +52825,23 @@
 /obj/machinery/landinglight/ds2/delaytwo,
 /turf/open/floor/plating,
 /area/prison/hangar/civilian)
+"icr" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/prison/cellblock/maxsec/south)
 "ilF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -52942,6 +52932,13 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
 /area/prison/security/checkpoint/highsec/s)
+"jYS" = (
+/obj/machinery/vending/cola,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2";
+	dir = 10
+	},
+/area/prison/residential/north)
 "keG" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall/prison,
@@ -53117,6 +53114,13 @@
 	},
 /turf/open/floor/plating,
 /area/prison/hangar_storage/research)
+"pLL" = (
+/obj/machinery/vending/snack,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2";
+	dir = 10
+	},
+/area/prison/residential/south)
 "pOU" = (
 /obj/structure/window/framed/prison/reinforced/hull,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
@@ -53146,6 +53150,13 @@
 	},
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/nw)
+"qlN" = (
+/obj/machinery/vending/snack,
+/turf/open/floor/prison{
+	icon_state = "bright_clean2";
+	dir = 10
+	},
+/area/prison/residential/north)
 "qxc" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -53420,6 +53431,17 @@
 	},
 /turf/open/floor/plating,
 /area/prison/security/monitoring/lowsec/sw)
+"wvr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/prison/whitegreen{
+	dir = 8
+	},
+/area/prison/medbay)
 "wMM" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -61023,7 +61045,7 @@ aym
 azj
 azW
 avN
-aBV
+qlN
 aBV
 aBV
 aBV
@@ -61092,7 +61114,7 @@ bCb
 bCb
 bCb
 bCb
-bCb
+pLL
 bGU
 bMD
 bLO
@@ -62603,7 +62625,7 @@ brr
 bPF
 aYR
 bRj
-bga
+aWr
 bhC
 bhC
 bsV
@@ -64107,8 +64129,8 @@ aym
 azj
 azW
 avN
-axp
-aDI
+jYS
+aBV
 aBV
 aBV
 aBV
@@ -64176,7 +64198,7 @@ bCb
 bCb
 bCb
 bCb
-bCb
+dOO
 bGU
 bMD
 bLO
@@ -64364,8 +64386,8 @@ axG
 axG
 axG
 avN
-aBV
-aQO
+axp
+aDI
 aBV
 aBV
 aBV
@@ -89520,7 +89542,7 @@ agJ
 agL
 agL
 agL
-akK
+agt
 ald
 alo
 amz
@@ -89777,7 +89799,7 @@ agJ
 agL
 agL
 agL
-akK
+agt
 akV
 akV
 alF
@@ -90300,7 +90322,7 @@ akV
 akV
 akV
 akV
-anr
+icr
 akV
 akV
 aqs
@@ -90814,7 +90836,7 @@ agL
 agL
 agt
 anP
-anJ
+fkw
 apt
 apH
 aqt
@@ -91563,10 +91585,10 @@ adG
 adG
 afP
 age
-acH
-acH
-acH
-acH
+agt
+agt
+agt
+agt
 ahz
 ahR
 agJ
@@ -92848,10 +92870,10 @@ adG
 adG
 afP
 aeX
-acH
-acH
-acH
-acH
+agt
+agt
+agt
+agt
 ahE
 ahY
 agJ
@@ -92869,7 +92891,7 @@ agL
 agL
 agL
 agt
-anS
+anP
 aoL
 apu
 apO
@@ -92885,7 +92907,7 @@ awM
 avu
 avu
 awM
-ayj
+aBo
 avw
 avw
 awG
@@ -93383,7 +93405,7 @@ alX
 agL
 agL
 agt
-anU
+anP
 aoK
 apv
 apQ
@@ -93399,7 +93421,7 @@ auS
 avv
 awb
 awb
-ayj
+wvr
 ayb
 apK
 azG
@@ -93639,7 +93661,7 @@ agt
 agt
 agt
 agt
-anm
+agt
 anV
 aoM
 apv
@@ -93890,15 +93912,15 @@ agt
 ajZ
 akx
 agt
-agt
-alL
-alL
-agL
+alf
+ann
+ann
+alx
 alx
 alx
 ann
 ann
-aoN
+aoO
 apv
 alu
 aqz
@@ -94142,7 +94164,7 @@ ahZ
 ahk
 ahb
 agL
-afM
+aiI
 ajz
 aka
 akz
@@ -94398,8 +94420,8 @@ agt
 aia
 agt
 agt
-afM
-afM
+agt
+aiI
 ajA
 akb
 aky
@@ -94656,7 +94678,7 @@ aib
 ain
 agv
 aiE
-afM
+aiI
 ajB
 aka
 akz
@@ -94913,7 +94935,7 @@ aiV
 agq
 ait
 aiF
-afM
+aiI
 aiI
 akc
 akA
@@ -95170,7 +95192,7 @@ aic
 agq
 aiu
 afv
-afM
+aiI
 ajC
 akd
 akB
@@ -95427,7 +95449,7 @@ aiV
 agq
 aiu
 afv
-afM
+aiI
 aiw
 ajG
 akC
@@ -95684,7 +95706,7 @@ aiV
 agq
 aiu
 afw
-afM
+aiI
 aju
 ake
 akX
@@ -95941,7 +95963,7 @@ aiV
 agq
 aiv
 afM
-afM
+aiI
 ajD
 ajG
 akC
@@ -96204,7 +96226,7 @@ ajG
 akC
 akQ
 akd
-alA
+alC
 alO
 alZ
 aml
@@ -100416,7 +100438,7 @@ bWe
 bWl
 bQg
 bRM
-cbO
+ecN
 cdf
 cbW
 cfw
@@ -107032,7 +107054,7 @@ aFW
 aHk
 aIp
 aIo
-aIp
+aKq
 aIp
 aIp
 aMy

--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -1911,12 +1911,6 @@
 /obj/item/stack/rods,
 /turf/open/floor/plating,
 /area/prison/research/secret/bioengineering)
-"ahM" = (
-/obj/structure/xenoautopsy/tank/larva{
-	pixel_y = 7
-	},
-/turf/open/floor/prison/marked,
-/area/prison/research/secret/bioengineering)
 "ahN" = (
 /turf/closed/wall/r_wall/prison_unmeltable,
 /area/prison/security/monitoring/maxsec/panopticon)
@@ -11560,17 +11554,7 @@
 /area/prison/recreation/highsec/n)
 "aFc" = (
 /obj/effect/decal/cleanable/blood,
-/turf/open/floor/prison{
-	icon_state = "kitchen"
-	},
-/area/prison/recreation/highsec/n)
-"aFd" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/prison{
-	icon_state = "kitchen"
-	},
+/turf/open/floor/prison,
 /area/prison/recreation/highsec/n)
 "aFe" = (
 /obj/structure/sink{
@@ -17198,9 +17182,6 @@
 	dir = 4
 	},
 /area/prison/cellblock/highsec/north/south)
-"aRX" = (
-/turf/open/floor/prison/cleanmarked,
-/area/prison/cellblock/highsec/north/south)
 "aRY" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable{
@@ -17214,7 +17195,7 @@
 "aRZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/prison/cleanmarked,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/highsec/north/south)
 "aSb" = (
 /obj/structure/cable{
@@ -17551,16 +17532,16 @@
 /turf/open/floor/prison/kitchen,
 /area/prison/cellblock/highsec/north/south)
 "aSZ" = (
-/turf/open/floor/prison/kitchen,
+/turf/open/floor/prison/sterilewhite,
 /area/prison/cellblock/highsec/north/south)
 "aTa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/prison/kitchen,
+/turf/open/floor/prison/sterilewhite,
 /area/prison/cellblock/highsec/north/south)
 "aTb" = (
 /obj/effect/decal/cleanable/blood,
-/turf/open/floor/prison/kitchen,
+/turf/open/floor/prison/sterilewhite,
 /area/prison/cellblock/highsec/north/south)
 "aTc" = (
 /obj/machinery/shower{
@@ -19592,7 +19573,7 @@
 	dir = 4;
 	on = 1
 	},
-/turf/open/floor/prison/kitchen,
+/turf/open/floor/prison/sterilewhite,
 /area/prison/cellblock/highsec/north/south)
 "aXV" = (
 /obj/machinery/shower{
@@ -19623,7 +19604,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 8
 	},
-/turf/open/floor/prison/kitchen,
+/turf/open/floor/prison/sterilewhite,
 /area/prison/cellblock/highsec/north/south)
 "aXY" = (
 /obj/machinery/alarm,
@@ -28936,7 +28917,9 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/prison/sterilewhite,
+/turf/open/floor/prison{
+	icon_state = "kitchen"
+	},
 /area/prison/holding/holding1)
 "btM" = (
 /obj/machinery/light/small{
@@ -29462,7 +29445,9 @@
 /obj/machinery/shower{
 	dir = 8
 	},
-/turf/open/floor/prison/sterilewhite,
+/turf/open/floor/prison{
+	icon_state = "kitchen"
+	},
 /area/prison/holding/holding1)
 "buZ" = (
 /obj/structure/cable{
@@ -30920,7 +30905,9 @@
 	dir = 4
 	},
 /obj/machinery/light/small,
-/turf/open/floor/prison/sterilewhite,
+/turf/open/floor/prison{
+	icon_state = "kitchen"
+	},
 /area/prison/holding/holding1)
 "byM" = (
 /obj/structure/cable{
@@ -30998,7 +30985,9 @@
 /area/prison/cellblock/lowsec/se)
 "byU" = (
 /obj/structure/toilet,
-/turf/open/floor/prison/sterilewhite,
+/turf/open/floor/prison{
+	icon_state = "kitchen"
+	},
 /area/prison/holding/holding1)
 "byV" = (
 /obj/structure/cable{
@@ -31939,8 +31928,7 @@
 	dir = 1
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
-	dir = 10
+	icon_state = "kitchen"
 	},
 /area/prison/holding/holding2)
 "bBn" = (
@@ -34282,13 +34270,10 @@
 	},
 /turf/open/floor/plating,
 /area/prison/laundry)
-"bGo" = (
-/turf/open/floor/prison/marked,
-/area/prison/cellblock/highsec/south/north)
 "bGp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/prison/marked,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/highsec/south/north)
 "bGr" = (
 /obj/machinery/vending/security,
@@ -35792,8 +35777,7 @@
 	dir = 8
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
-	dir = 10
+	icon_state = "kitchen"
 	},
 /area/prison/holding/holding2)
 "bJU" = (
@@ -36475,8 +36459,7 @@
 	},
 /obj/machinery/light/small,
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
-	dir = 10
+	icon_state = "kitchen"
 	},
 /area/prison/holding/holding2)
 "bLF" = (
@@ -37268,8 +37251,7 @@
 "bNG" = (
 /obj/structure/toilet,
 /turf/open/floor/prison{
-	icon_state = "bright_clean2";
-	dir = 10
+	icon_state = "kitchen"
 	},
 /area/prison/holding/holding2)
 "bNH" = (
@@ -37403,7 +37385,7 @@
 	opacity = 0
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean";
+	icon_state = "bright_clean2";
 	dir = 10
 	},
 /area/prison/holding/holding1)
@@ -39265,13 +39247,13 @@
 	},
 /area/prison/recreation/highsec/s)
 "bSw" = (
-/turf/open/floor/prison/kitchen,
+/turf/open/floor/prison,
 /area/prison/recreation/highsec/s)
 "bSx" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/prison/kitchen,
+/turf/open/floor/prison,
 /area/prison/recreation/highsec/s)
 "bSy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -39949,7 +39931,7 @@
 /area/prison/recreation/highsec/s)
 "bUd" = (
 /obj/effect/landmark/corpsespawner/prison_security,
-/turf/open/floor/prison/kitchen,
+/turf/open/floor/prison,
 /area/prison/recreation/highsec/s)
 "bUe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -40549,7 +40531,7 @@
 	opacity = 0
 	},
 /turf/open/floor/prison{
-	icon_state = "bright_clean";
+	icon_state = "bright_clean2";
 	dir = 10
 	},
 /area/prison/holding/holding2)
@@ -47125,25 +47107,6 @@
 	},
 /turf/open/floor/wood,
 /area/prison/parole/protective_custody)
-"cls" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/open/floor/prison,
-/area/prison/cellblock/mediumsec/north)
 "clt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -52674,16 +52637,6 @@
 	dir = 4
 	},
 /area/prison/cellblock/highsec/north/south)
-"eIn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/prison,
-/area/prison/cellblock/mediumsec/north)
 "eLE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -52975,6 +52928,9 @@
 	dir = 4
 	},
 /area/prison/cellblock/highsec/north/south)
+"kGQ" = (
+/turf/open/floor/prison,
+/area/prison/recreation/highsec/n)
 "kPu" = (
 /obj/machinery/vending/cigarette/colony,
 /turf/open/floor/prison/darkred/full,
@@ -80323,7 +80279,7 @@ aBg
 aBg
 aBg
 aFc
-aCz
+kGQ
 aBg
 aBg
 aBj
@@ -80579,7 +80535,7 @@ apl
 aBg
 aCy
 aBg
-aFd
+aCq
 aFc
 aBg
 aCy
@@ -80592,7 +80548,7 @@ aLO
 aDS
 aPc
 aES
-aRX
+aDS
 aSZ
 aSZ
 aSZ
@@ -80631,7 +80587,7 @@ bwJ
 bwJ
 bwJ
 bwJ
-bGo
+bwH
 byC
 bGf
 bwH
@@ -80849,7 +80805,7 @@ aNh
 aNK
 aPl
 aES
-aRX
+aDS
 aSZ
 aUf
 aVw
@@ -80888,7 +80844,7 @@ bwK
 bwK
 bwK
 bwJ
-bGo
+bwH
 byC
 bIF
 bJG
@@ -81363,7 +81319,7 @@ aLO
 aDS
 aPc
 aES
-aRX
+aDS
 aTb
 aSZ
 aSZ
@@ -81402,7 +81358,7 @@ bwJ
 bwJ
 bwJ
 bwJ
-bGo
+bwH
 byC
 bGf
 bwH
@@ -88111,8 +88067,8 @@ cfn
 ccV
 ccV
 cae
-cls
-eIn
+sRe
+nOc
 cnb
 njY
 njY
@@ -98271,7 +98227,7 @@ afS
 afw
 afS
 afS
-ahM
+afv
 afS
 afw
 afM

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -636,7 +636,4 @@
 	basestate = "prison_cellwindow"
 	desc = "A glass window with a special rod matrice inside a wall frame. This one was made out of exotic materials to prevent hull breaches. No way to get through here."
 	//icon_state = "rwindow0_debug" //Uncomment to check hull in the map editor
-	damageable = FALSE
-	deconstructable = FALSE
-	resistance_flags = UNACIDABLE|INDESTRUCTIBLE
-	max_integrity = 1000000 //Failsafe, shouldn't matter
+	max_integrity = 300

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -636,4 +636,7 @@
 	basestate = "prison_cellwindow"
 	desc = "A glass window with a special rod matrice inside a wall frame. This one was made out of exotic materials to prevent hull breaches. No way to get through here."
 	//icon_state = "rwindow0_debug" //Uncomment to check hull in the map editor
-	max_integrity = 300
+	damageable = FALSE
+	deconstructable = FALSE
+	resistance_flags = UNACIDABLE|INDESTRUCTIBLE
+	max_integrity = 1000000 //Failsafe, shouldn't matter

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -66,21 +66,21 @@
 // Beach
 
 /turf/open/beach
-	name = "Beach"
+	name = "beach"
 	icon = 'icons/misc/beach.dmi'
 
 
 /turf/open/beach/sand
-	name = "Sand"
+	name = "sand"
 	icon_state = "sand"
 
 /turf/open/beach/coastline
-	name = "Coastline"
+	name = "coastline"
 	icon = 'icons/misc/beach2.dmi'
 	icon_state = "sandwater"
 
 /turf/open/beach/water
-	name = "Water"
+	name = "water"
 	icon_state = "water"
 	can_bloody = FALSE
 
@@ -89,13 +89,18 @@
 	overlays += image("icon"='icons/misc/beach.dmi',"icon_state"="water2","layer"=MOB_LAYER+0.1)
 
 /turf/open/beach/water2
-	name = "Water"
+	name = "water"
 	icon_state = "water"
 	can_bloody = FALSE
 
 /turf/open/beach/water2/New()
 	..()
 	overlays += image("icon"='icons/misc/beach.dmi',"icon_state"="water5","layer"=MOB_LAYER+0.1)
+
+/turf/open/beach/sea
+	name = "sea"
+	icon_state = "seadeep"
+	can_bloody = FALSE
 
 
 //Nostromo turfs


### PR DESCRIPTION
## About The Pull Request

Fixes some zone that had 2 apc's at once and some which had none. Adds podlocks, landing lights and stripes to civilian hangar. Replaces ugly water sprite with sea. Fixes some floor tiles here and there. Adds some catwalks to canteen. Replaces empty pizza box at research break room with REAL pizza box. Anything else I don't remember.

## Changelog

:cl:
tweak: Prison station adjustments. Added catwalks to canteen. Added podlocks to civilian hangar. Deleted signs containing space refference. Replaced water sprite with sea. Fixed some areas having zero or more than one APC's.
/:cl:
