### PR TITLE
Fixes c4 runtime

### DIFF
--- a/code/game/objects/items/explosives/plastique.dm
+++ b/code/game/objects/items/explosives/plastique.dm
@@ -132,6 +132,9 @@
 		qdel(src)
 		return
 	explosion(plant_target, -1, -1, 3)
+	if(QDELETED(plant_target))
+		qdel(src)
+		return
 	if(istype(plant_target,/turf/closed/wall))
 		var/turf/closed/wall/W = plant_target
 		W.ChangeTurf(/turf/open/floor/plating)


### PR DESCRIPTION
Explosion can delete stuff, the second check is necessary
```
[22:33:45] Runtime in plastique.dm, line 141: Cannot execute null.ex act().
proc name: detonate (/obj/item/explosive/plastique/proc/detonate)
usr: Cloaker_Joker115/(Fedir Ruda)
usr.loc: (Communications Relay (68, 15, 2))
src: the plastic explosives (/obj/item/explosive/plastique)
src.loc: null
call stack:
the plastic explosives (/obj/item/explosive/plastique): detonate()
/datum/callback (/datum/callback): Invoke()
world: PushUsr(Fedir Ruda (/mob/living/carbon/human), /datum/callback (/datum/callback))
/datum/callback (/datum/callback): InvokeAsync()
Timer (/datum/controller/subsystem/timer): fire(0)
Timer (/datum/controller/subsystem/timer): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop()
Master (/datum/controller/master): StartProcessing(0)
```