### PR TITLE
Fixes seed extractor runtime

### DIFF
--- a/code/game/objects/machinery/seed_extractor.dm
+++ b/code/game/objects/machinery/seed_extractor.dm
@@ -26,7 +26,7 @@
 			to_chat(user, "<span class='notice'>You extract some seeds from [I].</span>")
 			var/produce = rand(1, 4)
 			for(var/i = 1 to produce)
-				var/obj/item/seeds/seeds = new(get_turf(src))
+				var/obj/item/seeds/seeds = new(get_turf(src), FALSE)
 				seeds.seed_type = new_seed_type.name
 				seeds.update_seed()
 		else

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -10,9 +10,10 @@
 	var/datum/seed/seed
 	var/modified = FALSE
 
-/obj/item/seeds/Initialize()
+/obj/item/seeds/Initialize(mapload, update = TRUE)
 	. = ..()
-	update_seed()
+	if(update)
+		update_seed()
 
 //Grabs the appropriate seed datum from the global list.
 /obj/item/seeds/proc/update_seed()


### PR DESCRIPTION
```
[00:27:20] Runtime in seeds.dm, line 24: Cannot read null.packet_icon
proc name: update appearance (/obj/item/seeds/proc/update_appearance)
usr: LaKiller8/(Thomas Echard)
usr.loc: (Abandoned Thunderdome (Team 1) (27, 38, 1))
src: the packet of seeds (/obj/item/seeds)
src.loc: the plating (28,37,1) (/turf/open/floor/plating)
call stack:
the packet of seeds (/obj/item/seeds): update appearance()
the packet of seeds (/obj/item/seeds): update seed()
the packet of seeds (/obj/item/seeds): Initialize(0)
Atoms (/datum/controller/subsystem/atoms): InitAtom(the packet of seeds (/obj/item/seeds), /list (/list))
the packet of seeds (/obj/item/seeds): New(0)
the seed extractor (/obj/machinery/seed_extractor): attackby(the plump-helmet (/obj/item/reagent_container/food/snacks/grown/mushroom/plumphelmet), Thomas Echard (/mob/living/carbon/human), "icon-x=18;icon-y=15;left=1;scr...")
the plump-helmet (/obj/item/reagent_container/food/snacks/grown/mushroom/plumphelmet): melee attack chain(Thomas Echard (/mob/living/carbon/human), the seed extractor (/obj/machinery/seed_extractor), "icon-x=18;icon-y=15;left=1;scr...")
Thomas Echard (/mob/living/carbon/human): ClickOn(the seed extractor (/obj/machinery/seed_extractor), "icon-x=18;icon-y=15;left=1;scr...")
the seed extractor (/obj/machinery/seed_extractor): Click(the plating (28,37,1) (/turf/open/floor/plating), "mapwindow.map", "icon-x=18;icon-y=15;left=1;scr...")
LaKiller8 (/client): Click(the seed extractor (/obj/machinery/seed_extractor), the plating (28,37,1) (/turf/open/floor/plating), "mapwindow.map", "icon-x=18;icon-y=15;left=1;scr...")
```