### PR TITLE
Sacrifices sanity to preserve the user experience

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -178,6 +178,7 @@
 	try
 		WRITE_FILE(S["savefile_write_test"], "lebowskilebowski")
 	catch
+		to_chat(parent, "<span class='warning'>Writing to the savefile failed, please try again.</span>")
 		return FALSE
 
 	WRITE_FILE(S["version"], savefile_version)
@@ -371,6 +372,7 @@
 	try
 		WRITE_FILE(S["savefile_write_test"], "lebowskilebowski")
 	catch
+		to_chat(parent, "<span class='warning'>Writing to the savefile failed, please try again.</span>")
 		return FALSE
 
 	be_special		= sanitize_integer(be_special, NONE, MAX_BITFLAG, initial(be_special))

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -177,7 +177,7 @@
 
 	try
 		WRITE_FILE(S["savefile_write_test"], "lebowskilebowski")
-	catch()
+	catch
 		return FALSE
 
 	WRITE_FILE(S["version"], savefile_version)
@@ -370,7 +370,7 @@
 
 	try
 		WRITE_FILE(S["savefile_write_test"], "lebowskilebowski")
-	catch()
+	catch
 		return FALSE
 
 	be_special		= sanitize_integer(be_special, NONE, MAX_BITFLAG, initial(be_special))

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -173,8 +173,13 @@
 	var/savefile/S = new /savefile(path)
 	if(!S)
 		return FALSE
-
 	S.cd = "/"
+
+	try
+		WRITE_FILE(S["savefile_write_test"], "lebowskilebowski")
+	catch()
+		return FALSE
+
 	WRITE_FILE(S["version"], savefile_version)
 
 	default_slot	= sanitize_integer(default_slot, 1, MAX_SAVE_SLOTS, initial(default_slot))
@@ -362,6 +367,11 @@
 	if(!S)
 		return FALSE
 	S.cd = "/character[default_slot]"
+
+	try
+		WRITE_FILE(S["savefile_write_test"], "lebowskilebowski")
+	catch()
+		return FALSE
 
 	be_special		= sanitize_integer(be_special, NONE, MAX_BITFLAG, initial(be_special))
 


### PR DESCRIPTION
Sometimes, writing to a savefile can fail due to it being locked. So far even after a shitton of hours I haven't been able to reproduce when exactly it happens and from speaking with Lummox he said it happens when the savefile is locked. But here's the thing - you can't tell when, why, or because of what it's locked. Nothing in our code uses the same savefile at the same time, so perhaps it may be related to writing to it in sequence often. Whatever the cause is, there's no clean solution here really and I don't want to remove user QoL of every change saving right away just to avoid this bug. It's not pretty but it works.

Fixes: #2281