### PR TITLE
Small xeno takeover refactor

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -176,6 +176,7 @@
 
 // Admin
 #define isaghost(mob) ( copytext(mob.key, 1, 2) == "@" )
+#define isclientedaghost(mob) (isaghost(mob) && GLOB.directory[mob.key])
 
 // Shuttles
 #define isshuttleturf(T) (length(T.baseturfs) && (/turf/baseturf_skipover/shuttle in T.baseturfs))

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -98,7 +98,7 @@
 			continue
 
 		//Aghosted admins don't get picked
-		if(O.mind?.current && isaghost(O.mind.current))
+		if(O.mind?.current && isclientedaghost(O.mind.current))
 			continue
 
 		if(!picked)

--- a/code/datums/gamemodes/game_mode.dm
+++ b/code/datums/gamemodes/game_mode.dm
@@ -588,8 +588,8 @@
 		DEATHTIME_MESSAGE(xeno_candidate)
 		return FALSE
 
-	if(world.time - new_xeno.away_time < XENO_AFK_TIMER) //We do not want to occupy them if they've only been gone for a little bit.
-		to_chat(xeno_candidate, "<span class='warning'>That player hasn't been away long enough. Please wait [round((new_xeno.away_time + XENO_AFK_TIMER - world.time) * 0.1)] second\s longer.</span>")
+	if(new_xeno.afk_timer_id) //We do not want to occupy them if they've only been gone for a little bit.
+		to_chat(xeno_candidate, "<span class='warning'>That player hasn't been away long enough. Please wait [round(timeleft(new_xeno.afk_timer_id) * 0.1)] second\s longer.</span>")
 		return FALSE
 
 	return new_xeno

--- a/code/modules/admin/holder.dm
+++ b/code/modules/admin/holder.dm
@@ -543,7 +543,7 @@ GLOBAL_PROTECT(admin_verbs_spawn)
 /proc/afk_message(mob/living/carbon/human/H)
 	if(QDELETED(H))
 		return
-	if(isaghost(H) && GLOB.directory[H.key])
+	if(isclientedaghost(H))
 		return
 	log_admin("[key_name(H)] (Job: [H.job]) has been away for 15 minutes.")
 	message_admins("[ADMIN_TPMONTY(H)] (Job: [H.job]) has been away for 15 minutes.")

--- a/code/modules/admin/holder.dm
+++ b/code/modules/admin/holder.dm
@@ -543,6 +543,8 @@ GLOBAL_PROTECT(admin_verbs_spawn)
 /proc/afk_message(mob/living/carbon/human/H)
 	if(QDELETED(H))
 		return
+	if(isaghost(H) && GLOB.directory[H.key])
+		return
 	log_admin("[key_name(H)] (Job: [H.job]) has been away for 15 minutes.")
 	message_admins("[ADMIN_TPMONTY(H)] (Job: [H.job]) has been away for 15 minutes.")
 

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -42,3 +42,5 @@
 	var/blood_type
 
 	var/overeatduration = 0		// How long this guy is overeating
+
+	var/afk_timer_id

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -110,5 +110,3 @@
 	var/specset //Simple way to track which set has the player taken
 
 	hud_type = /datum/hud/human
-
-	var/afk_timer_id

--- a/code/modules/mob/living/carbon/human/logout.dm
+++ b/code/modules/mob/living/carbon/human/logout.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/human/Logout()
 	. = ..()
 	species?.handle_logout_special(src)
-	if(key && !(isaghost(src) && GLOB.directory[key])) //Disconnected.
+	if(key && !isclientedaghost(src)) //Disconnected.
 		afk_timer_id = addtimer(CALLBACK(GLOBAL_PROC, /proc/afk_message, src), 15 MINUTES, TIMER_STOPPABLE)

--- a/code/modules/mob/living/carbon/human/logout.dm
+++ b/code/modules/mob/living/carbon/human/logout.dm
@@ -1,4 +1,5 @@
 /mob/living/carbon/human/Logout()
 	. = ..()
 	species?.handle_logout_special(src)
-	afk_timer_id = addtimer(CALLBACK(GLOBAL_PROC, /proc/afk_message, src), 15 MINUTES, TIMER_STOPPABLE)
+	if(key && !(isaghost(src) && GLOB.directory[key])) //Disconnected.
+		afk_timer_id = addtimer(CALLBACK(GLOBAL_PROC, /proc/afk_message, src), 15 MINUTES, TIMER_STOPPABLE)

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -103,9 +103,9 @@
 				continue
 			if(X.client)
 				continue
-			if(!X.away_time) //To prevent adminghosted xenos to be snatched.
+			if(isaghost(X) && GLOB.directory[X.key]) //To prevent adminghosted xenos to be snatched.
 				continue
-			if(only_away && world.time - X.away_time < XENO_AFK_TIMER)
+			if(only_away && X.afk_timer_id)
 				continue
 			xenos += X
 	return xenos

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -103,7 +103,7 @@
 				continue
 			if(X.client)
 				continue
-			if(isaghost(X) && GLOB.directory[X.key]) //To prevent adminghosted xenos to be snatched.
+			if(isclientedaghost(X)) //To prevent adminghosted xenos to be snatched.
 				continue
 			if(only_away && X.afk_timer_id)
 				continue

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -332,7 +332,7 @@
 		return
 
 	if(afk_timer_id)
-		INVOKE_NEXT_TICK(src, /proc/deltimer, afk_timer_id)
+		INVOKE_NEXT_TICK(GLOBAL_PROC, /proc/deltimer, afk_timer_id)
 		afk_timer_id = null
 
 	SSticker.mode.transfer_xeno(picked, src)

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -320,7 +320,7 @@
 		adjustHalLoss(XENO_HALOSS_REGEN)
 
 /mob/living/carbon/xenomorph/proc/handle_afk_takeover()
-	if(client || world.time - away_time < XENO_AFK_TIMER)
+	if(client)
 		return
 	if(isaghost(src) && GLOB.directory[key]) // If aghosted, and admin still online
 		return
@@ -330,6 +330,10 @@
 	var/mob/picked = get_alien_candidate()
 	if(!picked)
 		return
+
+	if(afk_timer_id)
+		INVOKE_NEXT_TICK(src, /proc/deltimer, afk_timer_id)
+		afk_timer_id = null
 
 	SSticker.mode.transfer_xeno(picked, src)
 

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -322,7 +322,7 @@
 /mob/living/carbon/xenomorph/proc/handle_afk_takeover()
 	if(client)
 		return
-	if(isaghost(src) && GLOB.directory[key]) // If aghosted, and admin still online
+	if(isclientedaghost(src)) // If aghosted, and admin still online
 		return
 	if(stat == DEAD)
 		return

--- a/code/modules/mob/living/carbon/xenomorph/login.dm
+++ b/code/modules/mob/living/carbon/xenomorph/login.dm
@@ -1,5 +1,8 @@
 /mob/living/carbon/xenomorph/Login()
 	. = ..()
+	if(afk_timer_id)
+		deltimer(afk_timer_id)
+		afk_timer_id = null
 
 	if(see_in_dark == XENO_NIGHTVISION_ENABLED)
 		lighting_alpha = LIGHTING_PLANE_ALPHA_INVISIBLE

--- a/code/modules/mob/living/carbon/xenomorph/logout.dm
+++ b/code/modules/mob/living/carbon/xenomorph/logout.dm
@@ -1,3 +1,4 @@
 /mob/living/carbon/xenomorph/Logout()
 	. = ..()
-	addtimer(CALLBACK(src, .proc/handle_afk_takeover), XENO_AFK_TIMER)
+	if(key && !(isaghost(src) && GLOB.directory[key])) //Disconnected.
+		afk_timer_id = addtimer(CALLBACK(src, .proc/handle_afk_takeover), XENO_AFK_TIMER, TIMER_STOPPABLE)

--- a/code/modules/mob/living/carbon/xenomorph/logout.dm
+++ b/code/modules/mob/living/carbon/xenomorph/logout.dm
@@ -1,4 +1,4 @@
 /mob/living/carbon/xenomorph/Logout()
 	. = ..()
-	if(key && !(isaghost(src) && GLOB.directory[key])) //Disconnected.
+	if(key && !isclientedaghost(src)) //Disconnected.
 		afk_timer_id = addtimer(CALLBACK(src, .proc/handle_afk_takeover), XENO_AFK_TIMER, TIMER_STOPPABLE)

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -121,7 +121,6 @@
 	see_infrared = TRUE
 	hud_type = /datum/hud/alien
 	hud_possible = list(HEALTH_HUD_XENO, PLASMA_HUD, PHEROMONE_HUD,QUEEN_OVERWATCH_HUD)
-	var/away_time = -XENO_AFK_TIMER //Xenos start grabbable. This is reset on Login()
 	var/hivenumber = XENO_HIVE_NORMAL
 	job = ROLE_XENOMORPH
 


### PR DESCRIPTION
* Made it use `afk_timer_id` instead of `away_time` to match the changes for humans.
* Added checks for aghosting not to generate timers and messages in xenos or humans.