### PR TITLE
Fixes Lamarr runtime

### DIFF
--- a/code/game/objects/structures/lamarr_cage.dm
+++ b/code/game/objects/structures/lamarr_cage.dm
@@ -93,8 +93,10 @@
 /obj/item/clothing/mask/facehugger/lamarr
 	name = "Lamarr"
 	desc = "The worst she might do is attempt to... couple with your head."//hope we don't get sued over a harmless reference, rite?
-	sterile = 1
+	sterile = TRUE
 	gender = FEMALE
+	stat = DEAD
 
-/obj/item/clothing/mask/facehugger/lamarr/New()//to prevent deleting it if aliums are disabled
+
+/obj/item/clothing/mask/facehugger/lamarr/update_icon()
 	return


### PR DESCRIPTION
```
[21:18:13] Runtime in clothing_codex.dm, line 45: Cannot execute null.getRating().
proc name: get mechanics info (/obj/item/clothing/get_mechanics_info)
usr: DarkBeyond/(Kuro Walker)
usr.loc: (Nanotrasen Research Lab (109, 44, 2))
src: Lamarr (/obj/item/clothing/mask/facehugger/lamarr)
src.loc: the floor (114,46,2) (/turf/open/floor/tile/dark)
call stack:
Lamarr (/obj/item/clothing/mask/facehugger/lamarr): get mechanics info()
Lamarr (/obj/item/clothing/mask/facehugger/lamarr): get specific codex entry()
Codex (/datum/controller/subsystem/codex): get codex entry(Lamarr (/obj/item/clothing/mask/facehugger/lamarr))
Lamarr (/obj/item/clothing/mask/facehugger/lamarr): examine(Kuro Walker (/mob/living/carbon/human), -1, "", "")
Lamarr (/obj/item/clothing/mask/facehugger/lamarr): examine(Kuro Walker (/mob/living/carbon/human))
Kuro Walker (/mob/living/carbon/human): Examine(Lamarr (/obj/item/clothing/mask/facehugger/lamarr))
```