### PR TITLE
Dead people no longer get AFK noticed

### DIFF
--- a/code/modules/admin/holder.dm
+++ b/code/modules/admin/holder.dm
@@ -543,6 +543,8 @@ GLOBAL_PROTECT(admin_verbs_spawn)
 /proc/afk_message(mob/living/carbon/human/H)
 	if(QDELETED(H))
 		return
+	if(H.stat == DEAD)
+		return
 	if(isclientedaghost(H))
 		return
 	log_admin("[key_name(H)] (Job: [H.job]) has been away for 15 minutes.")


### PR DESCRIPTION
Suicides are logged and admin messaged, shouldn't cause issues.