### PR TITLE
Fixes pre-entering of keys in Focus Chat, Adds limited FC Hotkey support

### DIFF
--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -12,7 +12,8 @@
 	// Check if chat should have focus but doesn't, give it focus and pre-enter the key.
 	if(prefs.focus_chat && !winget(src, null, "input.focus"))
 		winset(src, null, "input.focus=true")
-		winset(src, null, "input=[list2params(list(text = _key))]")
+		if(length(_key) == 1) //Keys longer than 1 aren't printable
+			winset(src, "input", "text=[url_encode(_key)]")
 		return
 
 	// Client-level keybindings are ones anyone should be able to do at any time

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -13,7 +13,7 @@
 	//Otherwise, return focus to chat window if it isn't already, and relay the character.
 	if(prefs.focus_chat && !winget(src, null, "input.focus") && length(_key) == 1)
 		winset(src, null, "input.focus=true")
-		winset(src, "input", "text=[url_encode(_key)]")
+		winset(src, null, "input.text=[url_encode(_key)]")
 		return
 
 	// Client-level keybindings are ones anyone should be able to do at any time

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -9,11 +9,11 @@
 	if(!(next_move_dir_sub & movement) && !keys_held["Ctrl"])
 		next_move_dir_add |= movement
 
-	// Check if chat should have focus but doesn't, give it focus and pre-enter the key.
-	if(prefs.focus_chat && !winget(src, null, "input.focus"))
+	//Keys longer than 1 aren't printable, so we process them normally, regardless of Focus Chat.
+	//Otherwise, return focus to chat window if it isn't already, and relay the character.
+	if(prefs.focus_chat && !winget(src, null, "input.focus") && length(_key) == 1)
 		winset(src, null, "input.focus=true")
-		if(length(_key) == 1) //Keys longer than 1 aren't printable
-			winset(src, "input", "text=[url_encode(_key)]")
+		winset(src, "input", "text=[url_encode(_key)]")
 		return
 
 	// Client-level keybindings are ones anyone should be able to do at any time


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes `focus_chat`'s failure to properly input keys, And allows the use of non-printable characters as hotkeys.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl: Francinum
fix: Focus Chat now relays text to the input.
add: Focus Chat now allows unprintable keys to be used as hotkeys.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
