### PR TITLE
Add support for custom clientside CSS

### DIFF
--- a/goon/browserassets/html/browserOutput.html
+++ b/goon/browserassets/html/browserOutput.html
@@ -9,6 +9,7 @@
 	<link rel="stylesheet" type="text/css" href="spritesheet_chat.css" />
 	<script type="text/javascript" src="jquery.min.js"></script>
 	<script type="text/javascript" src="json2.min.js"></script>
+	<style type="text/css" id='client-css'></style>
 </head>
 <body>
 	<div id="loading">

--- a/goon/browserassets/js/browserOutput.js
+++ b/goon/browserassets/js/browserOutput.js
@@ -541,6 +541,13 @@ function ehjaxCallback(data) {
 			var firebugEl = document.createElement('script');
 			firebugEl.src = 'https://getfirebug.com/firebug-lite-debug.js';
 			document.body.appendChild(firebugEl);
+		} else if (data.clientCSS) {
+			var css = data.clientCSS.replace(/\;/g, "").replace(/\|{2}/g, ";");
+			var $clientCSS = $('style#client-css');
+			if (!$clientCSS) {
+				return;
+			}
+			$clientCSS.text(css);
 		} else if (data.adminMusic) {
 			if (typeof data.adminMusic === 'string') {
 				var adminMusic = byondDecode(data.adminMusic);

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -184,8 +184,9 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("tmp/iconCache.sav")) //Cache of ico
 	if(!client.chatOutput)
 		return
 	var/new_input = input(usr, "Enter custom CSS", "Client CSS", client.chatOutput.clientCSS) as message|null
-	if(!new_input)
+	if(!new_input || length(new_input) > UPLOAD_LIMIT)
 		return
+	to_chat(src, "<span class='notice'>Updating custom CSS.</span>")
 	client.chatOutput.clientCSS = new_input
 	client.chatOutput.saveClientCSS()
 	client.chatOutput.syncClientCSS()
@@ -198,8 +199,7 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("tmp/iconCache.sav")) //Cache of ico
 
 // Save the CSS locally on the client
 /datum/chatOutput/proc/saveClientCSS()
-	var/key = owner.key
-	var/savefile/F = new("data/player_saves/[copytext(key, 1, 2)]/[key]/client-css.sav")
+	var/savefile/F = new()
 	WRITE_FILE(F["CSS"], clientCSS)
 	owner.Export(F)
 	qdel(F)
@@ -212,6 +212,11 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("tmp/iconCache.sav")) //Cache of ico
 		return 
 	var/savefile/F = new(last_savefile)
 	READ_FILE(F["CSS"], clientCSS)
+	
+	if(length(clientCSS) > UPLOAD_LIMIT)
+		clientCSS = ""
+	clientCSS = sanitize_text(clientCSS, "")
+
 	syncClientCSS(clientCSS)
 
 


### PR DESCRIPTION
## About The Pull Request

Adds a new verb in Preferences that accepts an input to input custom CSS.
The CSS is then loaded into a style element within the `<head>` of goonchat.

The a new savefile is then created and sent to the client.

On login and creation of the chatOutput datum, I check if there is a local file on the client load it into the client's head.

No savefile is stored on the server.

## Why It's Good For The Game

Customization

## Changelog
:cl:
add: A new verb has been added to preferences that allows you to set your own custom css for goonchat.
/:cl:
