### PR TITLE
Xenos can now see better in the dark with nightvision disabled

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -159,9 +159,6 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define XENO_SLASHING_ALLOWED 1
 #define XENO_SLASHING_RESTRICTED 2
 
-
-#define XENO_NIGHTVISION_ENABLED 8
-#define XENO_NIGHTVISION_DISABLED 4
 //=================================================
 
 ///////////////////HUMAN BLOODTYPES///////////////////

--- a/code/_onclick/hud/alien.dm
+++ b/code/_onclick/hud/alien.dm
@@ -17,7 +17,7 @@
 		return
 	var/mob/living/carbon/xenomorph/X = usr
 	X.toggle_nightvision()
-	icon_state = X.see_in_dark == XENO_NIGHTVISION_DISABLED ? "nightvision0" : "nightvision1"
+	icon_state = X.lighting_alpha == LIGHTING_PLANE_ALPHA_NV_TRAIT ? "nightvision0" : "nightvision1"
 
 /obj/screen/alien/queen_locator
 	icon_state = "trackoff"

--- a/code/modules/mob/living/carbon/xenomorph/login.dm
+++ b/code/modules/mob/living/carbon/xenomorph/login.dm
@@ -4,9 +4,8 @@
 		deltimer(afk_timer_id)
 		afk_timer_id = null
 
-	if(see_in_dark == XENO_NIGHTVISION_ENABLED)
-		lighting_alpha = LIGHTING_PLANE_ALPHA_INVISIBLE
-		see_in_dark = XENO_NIGHTVISION_ENABLED
+	if(lighting_alpha == LIGHTING_PLANE_ALPHA_NV_TRAIT)
+		see_in_dark = 8
 		ENABLE_BITFIELD(sight, SEE_MOBS)
 		ENABLE_BITFIELD(sight, SEE_OBJS)
 		ENABLE_BITFIELD(sight, SEE_TURFS)

--- a/code/modules/mob/living/carbon/xenomorph/login.dm
+++ b/code/modules/mob/living/carbon/xenomorph/login.dm
@@ -5,7 +5,6 @@
 		afk_timer_id = null
 
 	if(lighting_alpha == LIGHTING_PLANE_ALPHA_NV_TRAIT)
-		see_in_dark = 8
 		ENABLE_BITFIELD(sight, SEE_MOBS)
 		ENABLE_BITFIELD(sight, SEE_OBJS)
 		ENABLE_BITFIELD(sight, SEE_TURFS)

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -118,6 +118,8 @@
 	mob_size = MOB_SIZE_XENO
 	hand = 1 //Make right hand active by default. 0 is left hand, mob defines it as null normally
 	see_in_dark = 8
+	lighting_alpha = LIGHTING_PLANE_ALPHA_INVISIBLE
+	sight = SEE_SELF|SEE_OBJS|SEE_TURFS|SEE_MOBS
 	see_infrared = TRUE
 	hud_type = /datum/hud/alien
 	hud_possible = list(HEALTH_HUD_XENO, PLASMA_HUD, PHEROMONE_HUD,QUEEN_OVERWATCH_HUD)

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -16,7 +16,8 @@
 	ENABLE_BITFIELD(sight, SEE_MOBS)
 	ENABLE_BITFIELD(sight, SEE_OBJS)
 	ENABLE_BITFIELD(sight, SEE_TURFS)
-	see_in_dark = XENO_NIGHTVISION_ENABLED
+	see_in_dark = 8
+	lighting_alpha = LIGHTING_PLANE_ALPHA_INVISIBLE
 
 	create_reagents(1000)
 	gender = NEUTER

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -13,12 +13,6 @@
 	add_inherent_verbs()
 	add_abilities()
 
-	ENABLE_BITFIELD(sight, SEE_MOBS)
-	ENABLE_BITFIELD(sight, SEE_OBJS)
-	ENABLE_BITFIELD(sight, SEE_TURFS)
-	see_in_dark = 8
-	lighting_alpha = LIGHTING_PLANE_ALPHA_INVISIBLE
-
 	create_reagents(1000)
 	gender = NEUTER
 

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -386,13 +386,11 @@
 /mob/living/carbon/xenomorph/proc/toggle_nightvision()
 	if(lighting_alpha == LIGHTING_PLANE_ALPHA_NV_TRAIT)
 		lighting_alpha = LIGHTING_PLANE_ALPHA_INVISIBLE
-		see_in_dark = 8
 		ENABLE_BITFIELD(sight, SEE_MOBS)
 		ENABLE_BITFIELD(sight, SEE_OBJS)
 		ENABLE_BITFIELD(sight, SEE_TURFS)
 	else
 		lighting_alpha = LIGHTING_PLANE_ALPHA_NV_TRAIT
-		see_in_dark = 8
 		ENABLE_BITFIELD(sight, SEE_MOBS)
 		DISABLE_BITFIELD(sight, SEE_OBJS)
 		DISABLE_BITFIELD(sight, SEE_TURFS)

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -384,15 +384,15 @@
 
 
 /mob/living/carbon/xenomorph/proc/toggle_nightvision()
-	if(see_in_dark == XENO_NIGHTVISION_DISABLED)
+	if(lighting_alpha == LIGHTING_PLANE_ALPHA_NV_TRAIT)
 		lighting_alpha = LIGHTING_PLANE_ALPHA_INVISIBLE
-		see_in_dark = XENO_NIGHTVISION_ENABLED
+		see_in_dark = 8
 		ENABLE_BITFIELD(sight, SEE_MOBS)
 		ENABLE_BITFIELD(sight, SEE_OBJS)
 		ENABLE_BITFIELD(sight, SEE_TURFS)
 	else
-		lighting_alpha = LIGHTING_PLANE_ALPHA_VISIBLE
-		see_in_dark = XENO_NIGHTVISION_DISABLED
+		lighting_alpha = LIGHTING_PLANE_ALPHA_NV_TRAIT
+		see_in_dark = 8
 		ENABLE_BITFIELD(sight, SEE_MOBS)
 		DISABLE_BITFIELD(sight, SEE_OBJS)
 		DISABLE_BITFIELD(sight, SEE_TURFS)


### PR DESCRIPTION
More useful to tell which place is dark or lit without compromising their ability too much.

:cl: LaKiller8
tweak: Xenos without night vision should now be able to tell if they are in a lit area better without being completely blinded.
/:cl: