### PR TITLE
Fixes the cause of the mysterious storage runtime

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -418,6 +418,9 @@
 /obj/item/storage/box/MRE/remove_from_storage()
 	. = ..()
 	if(. && !contents.len && !gc_destroyed)
+		if(istype(loc, /obj/item/storage))
+			var/obj/item/storage/S = loc
+			S.remove_from_storage(src)
 		qdel(src)
 
 /obj/item/storage/box/MRE/update_icon()


### PR DESCRIPTION
```
[21:25:04] Runtime in storage.dm, line 281: list index out of bounds
proc name: Click (/obj/screen/storage/Click)
usr: LostXeno/(Jesus Rathen)
usr.loc: (Canterbury (27, 28, 4))
src: the storage (/obj/screen/storage)
src.loc: null
call stack:
the storage (/obj/screen/storage): Click(null, "mapwindow.map", "icon-x=28;icon-y=15;vis-x=159;...")
LostXeno (/client): Click(the storage (/obj/screen/storage), null, "mapwindow.map", "icon-x=28;icon-y=15;vis-x=159;...")
```