### PR TITLE
Fixes chat early client DC issue

### DIFF
--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -92,6 +92,9 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("tmp/iconCache.sav")) //Cache of ico
 	if(loaded)
 		return
 
+	if(!owner)
+		return FALSE
+
 	loaded = TRUE
 	showChat()
 


### PR DESCRIPTION
Client may get fucked during connecting which is a confirmed BYOND bug we can't really solve, which means we'll have to add checks to a few extra places relating to early client init. This fixes like 3 related runtimes