### PR TITLE
Prevents pod runtime for admins

### DIFF
--- a/code/modules/admin/verbs/podlauncher.dm
+++ b/code/modules/admin/verbs/podlauncher.dm
@@ -60,6 +60,9 @@
 
 
 /datum/podlauncher/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui, force_open = TRUE, datum/nanoui/master_ui, datum/topic_state/state = GLOB.admin_state)
+	if(!temp_pod)
+		SSnano.close_user_uis(user, src, ui_key)
+		return
 	var/list/data = list()
 	var/B = (istype(bay, /area/centcom/supplypod/loading/one)) ? 1 : (istype(bay, /area/centcom/supplypod/loading/two)) ? 2 : (istype(bay, /area/centcom/supplypod/loading/three)) ? 3 : (istype(bay, /area/centcom/supplypod/loading/four)) ? 4 : (istype(bay, /area/centcom/supplypod/loading/ert)) ? 5 : 0
 	data["bay"] = bay


### PR DESCRIPTION
if the temp pod gets deleted for some reason(can realistically happen if admins are fucking around) this will close the UI, forcing admins to re-open it to spawn a new one.

The reason I didn't just recreate is so that it gets done properly rather than risking more quirkiness.