### PR TITLE
Incendiary Slugs now deal brute damage on impact

### DIFF
--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -603,7 +603,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 /datum/ammo/bullet/shotgun/incendiary
 	name = "incendiary slug"
 	hud_state = "shotgun_fire"
-	damage_type = BURN
+	damage_type = BRUTE
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_INCENDIARY
 
 /datum/ammo/bullet/shotgun/incendiary/New()


### PR DESCRIPTION
Minor change which totally won't break everything. Tested!

## About The Pull Request

Changes ONE line of text to make incendiary slugs deal brute damage.

## Why It's Good For The Game

Makes more sense, as the payload for what-sets-you-on-fire is still a slug.

## Changelog
:cl: DoctorMad
tweak: Shotgun's incendiary slugs now deal brute damage when hitting someone. Still sets them on fire.
/:cl:
