### PR TITLE
Fixes a runtime when clicking with null turf in the clickcatcher

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -833,7 +833,7 @@ GLOBAL_LIST_INIT(common_tools, typecacheof(list(
 
 
 /proc/params2turf(scr_loc, turf/origin, client/C)
-	if(!scr_loc)
+	if(!scr_loc || !origin)
 		return
 	var/tX = splittext(scr_loc, ",")
 	var/tY = splittext(tX[2], ":")

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -511,9 +511,10 @@
 		var/mob/living/carbon/human/H = usr
 		H.swap_hand()
 	else
-		var/turf/T = params2turf(modifiers["screen-loc"], get_turf(usr.client?.eye ? usr.client.eye : usr), usr.client)
+		var/turf/T = params2turf(modifiers["screen-loc"], get_turf(usr.client ? usr.client.eye : usr), usr.client)
 		params += "&catcher=1"
-		T?.Click(location, control, params)
+		if(T)
+			T.Click(location, control, params)
 	. = TRUE
 
 


### PR DESCRIPTION
The origin turf can be null due to a variety of things, like during the initial mapload if you click fast enough before the titlescreen is loaded. There are some other intended uses, so it's impossible to distinguish whether the current null is intended or not.

This also means the eye check be without the ?, unless I'm missing something.

Anyway, we'll see in testing.