### PR TITLE
Add a warning if you try to evac before a nuke is planted

### DIFF
--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -885,6 +885,5 @@
 	if(nuke_set && alert(usr, "Are you sure you want to launch the shuttle? Without sufficiently dealing with the threat, you will be in direct violation of your orders!", "Are you sure?", "Yes", "Cancel") != "Yes")
 		return
 
-	var/datum/game_mode/crash/C = SSticker.mode
 	C.marines_evac = CRASH_EVAC_INPROGRESS
 	addtimer(VARSET_CALLBACK(C, marines_evac, CRASH_EVAC_COMPLETED), 2 MINUTES)

--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -873,7 +873,18 @@
 
 	if(!href_list["move"] || !iscrashgamemode(SSticker.mode))
 		return
-		
+	var/datum/game_mode/crash/C = SSticker.mode
+
+	var/nuke_set = FALSE
+	for(var/i in GLOB.nuke_list)
+		var/obj/machinery/nuclearbomb/bomb = i
+		if(bomb.timer_enabled)
+			nuke_set = TRUE
+			break
+
+	if(nuke_set && alert(usr, "Are you sure you want to launch the shuttle? Without sufficiently dealing with the threat, you will be in direct violation of your orders!", "Are you sure?", "Yes", "Cancel") != "Yes")
+		return
+
 	var/datum/game_mode/crash/C = SSticker.mode
 	C.marines_evac = CRASH_EVAC_INPROGRESS
 	addtimer(VARSET_CALLBACK(C, marines_evac, CRASH_EVAC_COMPLETED), 2 MINUTES)


### PR DESCRIPTION
## About The Pull Request

Add a warning if you try to evac before a nuke is planted

## Why It's Good For The Game

Stops marines just leaving and causing a xeno minor
