### PR TITLE
Fixes APC runtime

### DIFF
--- a/code/datums/wires/apc.dm
+++ b/code/datums/wires/apc.dm
@@ -45,7 +45,7 @@
 
 /datum/wires/apc/on_cut(index, mend)	
 	var/obj/machinery/power/apc/A = holder
-	var/charge_percent = CLAMP(round(A.cell.percent()), 0, 100)
+	var/charge_percent = CLAMP(round(A.cell?.percent()), 0, 100)
 	switch(index)
 		if(WIRE_POWER1, WIRE_POWER2) // Short out.
 			if(mend && !is_cut(WIRE_POWER1) && !is_cut(WIRE_POWER2))


### PR DESCRIPTION
Not all APCs will have a cell when cutting wires, CLAMP will still return 0 properly