### PR TITLE
Boiler Bombard Time "rebalance"

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
@@ -78,7 +78,7 @@
 	var/mob/living/carbon/xenomorph/boiler/X = owner
 	X.visible_message("<span class='notice'>\The [X] begins digging their claws into the ground.</span>", \
 	"<span class='notice'>We begin digging ourselves into place.</span>", null, 5)
-	if(!do_after(X, 4 SECONDS, FALSE, null, BUSY_ICON_HOSTILE))
+	if(!do_after(X, 3 SECONDS, FALSE, null, BUSY_ICON_HOSTILE))
 		on_deactivation()
 		X.selected_ability = null
 		X.update_action_button_icons()
@@ -156,7 +156,7 @@
 
 	succeed_activate()
 
-	if(!do_after(X, 3 SECONDS, FALSE, target, BUSY_ICON_DANGER))
+	if(!do_after(X, 2 SECONDS, FALSE, target, BUSY_ICON_DANGER))
 		to_chat(X, "<span class='warning'>We decide not to launch any acid.</span>")
 		return fail_activate()
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
@@ -44,7 +44,7 @@
 	// *** Boiler Abilities *** //
 	bomb_strength = 1 //Multiplier to the effectiveness of the boiler glob. Improves by 0.5 per upgrade
 	acid_delay = 9 SECONDS //9 seconds delay on acid. Reduced by -1 per upgrade down to 5 seconds
-	bomb_delay = 20 SECONDS //20 seconds per glob at Young, -2.5 per upgrade down to 10 seconds
+	bomb_delay = 30 SECONDS //20 seconds per glob at Young, -2.5 per upgrade down to 10 seconds
 
 /datum/xeno_caste/boiler/young
 	upgrade_name = "Young"
@@ -85,7 +85,7 @@
 	// *** Boiler Abilities *** //
 	bomb_strength = 1.5
 	acid_delay = 9 SECONDS //9 seconds delay on acid. Reduced by -1 per upgrade down to 5 seconds
-	bomb_delay = 20 SECONDS //20 seconds per glob at Young, -2.5 per upgrade down to 10 seconds
+	bomb_delay = 30 SECONDS //20 seconds per glob at Young, -2.5 per upgrade down to 10 seconds
 
 /datum/xeno_caste/boiler/elder
 	upgrade_name = "Elder"
@@ -121,7 +121,7 @@
 	// *** Boiler Abilities *** //
 	bomb_strength = 2
 	acid_delay = 9 SECONDS //9 seconds delay on acid. Reduced by -1 per upgrade down to 5 seconds
-	bomb_delay = 20 SECONDS //20 seconds per glob at Young, -2.5 per upgrade down to 10 seconds
+	bomb_delay = 30 SECONDS //20 seconds per glob at Young, -2.5 per upgrade down to 10 seconds
 
 /datum/xeno_caste/boiler/ancient
 	upgrade_name = "Ancient"
@@ -155,4 +155,4 @@
 	// *** Boiler Abilities *** //
 	bomb_strength = 2.5
 	acid_delay = 9 SECONDS //9 seconds delay on acid. Reduced by -1 per upgrade down to 5 seconds
-	bomb_delay = 20 SECONDS //20 seconds per glob at Young, -2.5 per upgrade down to 10 seconds
+	bomb_delay = 30 SECONDS //20 seconds per glob at Young, -2.5 per upgrade down to 10 seconds


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Decreases the boiler's time to dig and glob launch.

Digging changed from 4 seconds to 3 seconds.
Bombard Launch changed from 3 seconds to 2 seconds.
The cooldown between bombards was changed from 20 to 30.

Total time it takes to setup and bombard is ~6 seconds excluding the time it takes to click the longsight and find where you want to fire.

These changes will most likely change if too much or too little.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes the boiler not take ~10 seconds to launch the globs to give boilers an easier time when trying to launch under pressure. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Decreased the time it takes to dig into the ground and acid blob launch by 1 seconds each. And increases the cooldown between bombards by 10 seconds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
