### PR TITLE
More client safety

### DIFF
--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -1,4 +1,6 @@
 /mob/Login()
+	if(!client) //Yes, this can happen. Thanks BYOND.
+		return
 	ip_address	= client.address
 	computer_id	= client.computer_id
 	GLOB.player_list |= src

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -3,7 +3,7 @@
 		to_chat(src, "<div class='motd'>[GLOB.motd]</div>")
 
 	if(CONFIG_GET(flag/use_exp_tracking))
-		client.set_exp_from_db()
+		client?.set_exp_from_db()
 
 	if(!mind)
 		mind = new /datum/mind(key)
@@ -15,4 +15,4 @@
 	sight |= SEE_TURFS
 
 	new_player_panel()
-	client.playtitlemusic()
+	client?.playtitlemusic()


### PR DESCRIPTION
```
[01:01:27] Runtime in login.dm, line 2: Cannot read null.address
[01:01:27] Runtime in login.dm, line 18: Cannot execute null.playtitlemusic().
```