### PR TITLE
Pseudo-pixel projectiles

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -150,6 +150,11 @@
 #define COMSIG_GRAB_SELF_ATTACK "grab_self_attack"				//from base of obj/item/grab/attack() if attacked is the same as attacker: (mob/living/user)
 	#define COMSIG_GRAB_SUCCESSFUL_SELF_ATTACK (1<<0)
 
+// /obj/item/projectile signals
+#define COMSIG_PROJ_SCANTURF "proj_scanturf"
+	#define COMPONENT_PROJ_SCANTURF_TURFCLEAR (1<<0)
+	#define COMPONENT_PROJ_SCANTURF_TARGETFOUND (1<<1)
+
 // /mob signals
 #define COMSIG_MOB_DEATH "mob_death"							//from base of mob/death(): (gibbed)
 #define COMSIG_MOB_CLICKON "mob_clickon"						//from base of mob/clickon(): (atom/A, params)

--- a/code/__DEFINES/coordinates.dm
+++ b/code/__DEFINES/coordinates.dm
@@ -1,0 +1,7 @@
+
+////Tile coordinates (x, y) to absolute coordinates (in number of pixels). Center of a tile is generally assumed to be (16,16), but can be offset.
+#define ABS_COOR(c) (((c - 1) * 32) + 16)
+#define ABS_COOR_OFFSET(c, o) (((c - 1) * 32) + o)
+
+//Absolute pixel coordinate to relative. If MODULUS is zero, then we want to return 32, as pixel coordinates range from 1 to 32 within a tile.
+#define ABS_PIXEL_TO_REL(apc) (MODULUS(apc, 32) || 32)

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -91,7 +91,3 @@ GLOBAL_VAR_INIT(global_unique_id, 1)
 #define LUMA_R 0.213
 #define LUMA_G 0.715
 #define LUMA_B 0.072
-
-////Tile coordinates (x, y) to absolute coordinates (in number of pixels). Center of a tile is generally assumed to be (16,16), but can be offset.
-#define ABS_COOR(c) (((c - 1) * 32) + 16) 
-#define ABS_COOR_OFFSET(c, o) (((c - 1) * 32) + o) 

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -91,3 +91,7 @@ GLOBAL_VAR_INIT(global_unique_id, 1)
 #define LUMA_R 0.213
 #define LUMA_G 0.715
 #define LUMA_B 0.072
+
+////Tile coordinates (x, y) to absolute coordinates (in number of pixels). Center of a tile is generally assumed to be (16,16), but can be offset.
+#define ABS_COOR(c) (((c - 1) * 32) + 16) 
+#define ABS_COOR_OFFSET(c, o) (((c - 1) * 32) + o) 

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1072,13 +1072,3 @@ ColorTone(rgb, tone)
 		return out_icon
 	else
 		return humanoid_icon_cache[icon_id]
-
-
-/proc/Get_Pixel_Angle(y, x)
-	if(!y)
-		return (x >= 0) ? 90 : 270
-	. = arctan(x / y)
-	if(y < 0)
-		. += 180
-	else if(x < 0)
-		. += 360

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -100,13 +100,11 @@ GLOBAL_REAL_VAR(list/stack_trace_storage)
 
 /proc/Get_Angle(atom/start, atom/end)//For beams.
 	if(!start || !end) 
-		return FALSE
+		CRASH("Get_Angle called for inexisting atoms: [isnull(start) ? "null" : start] to [isnull(end) ? "null" : end].")
 	if(!start.z || !end.z) 
-		return FALSE //Atoms are not on turfs.
-	var/dy
-	var/dx
-	dy = (32 * end.y + end.pixel_y) - (32 * start.y + start.pixel_y)
-	dx = (32 * end.x + end.pixel_x) - (32 * start.x + start.pixel_x)
+		CRASH("Get_Angle called for inexisting atoms: [isnull(start.loc) ? "null loc" : start.loc] [start] to [isnull(end.loc) ? "null loc" : end.loc] [end].") //Atoms are not on turfs.
+	var/dy = (32 * end.y + end.pixel_y) - (32 * start.y + start.pixel_y)
+	var/dx = (32 * end.x + end.pixel_x) - (32 * start.x + start.pixel_x)
 	if(!dy)
 		return (dx >= 0) ? 90 : 270
 	. = arctan(dx / dy)
@@ -114,6 +112,11 @@ GLOBAL_REAL_VAR(list/stack_trace_storage)
 		. += 180
 	else if(dx < 0)
 		. += 360
+
+
+/proc/Get_Pixel_Angle(dx, dy)//for getting the angle when animating something's pixel_x and pixel_y
+	var/da = (90 - ATAN2(dx, dy))
+	return (da >= 0 ? da : da + 360)
 
 
 /proc/LinkBlocked(turf/A, turf/B)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -99,9 +99,9 @@ GLOBAL_REAL_VAR(list/stack_trace_storage)
 
 
 /proc/Get_Angle(atom/start, atom/end)//For beams.
-	if(!start || !end) 
+	if(!start || !end)
 		CRASH("Get_Angle called for inexisting atoms: [isnull(start) ? "null" : start] to [isnull(end) ? "null" : end].")
-	if(!start.z || !end.z) 
+	if(!start.z || !end.z)
 		CRASH("Get_Angle called for inexisting atoms: [isnull(start.loc) ? "null loc" : start.loc] [start] to [isnull(end.loc) ? "null loc" : end.loc] [end].") //Atoms are not on turfs.
 	var/dy = (32 * end.y + end.pixel_y) - (32 * start.y + start.pixel_y)
 	var/dx = (32 * end.x + end.pixel_x) - (32 * start.x + start.pixel_x)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -132,6 +132,29 @@ GLOBAL_REAL_VAR(list/stack_trace_storage)
 	. = round(((90 - ATAN2(end_apx - ABS_COOR(start.x), end_apy - ABS_COOR(start.y))) + scatter), 1)
 	if(. < 0)
 		. += 360
+	else if(. >= 360)
+		. -= 360
+
+
+/proc/angle_to_dir(angle)
+	switch(angle)
+		if(338 to 360, 0 to 22)
+			return NORTH
+		if(23 to 67)
+			return NORTHEAST
+		if(68 to 112)
+			return EAST
+		if(113 to 157)
+			return SOUTHEAST
+		if(158 to 202)
+			return SOUTH
+		if(203 to 247)
+			return SOUTHWEST
+		if(248 to 292)
+			return WEST
+		if(293 to 337)
+			return NORTHWEST
+		
 
 
 /proc/LinkBlocked(turf/A, turf/B)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -119,7 +119,7 @@ GLOBAL_REAL_VAR(list/stack_trace_storage)
 	return (da >= 0 ? da : da + 360)
 
 
-/proc/get_angle_with_scatter(atom/start, atom/end, scatter, y_offset = 16, x_offset = 16)
+/proc/get_angle_with_scatter(atom/start, atom/end, scatter, x_offset = 16, y_offset = 16)
 	var/end_apx
 	var/end_apy
 	if(isliving(end)) //Center mass.
@@ -129,7 +129,7 @@ GLOBAL_REAL_VAR(list/stack_trace_storage)
 		end_apx = ABS_COOR_OFFSET(end.x, x_offset)
 		end_apy = ABS_COOR_OFFSET(end.y, y_offset)
 	scatter = ( (rand(0, min(scatter, 45))) * (prob(50) ? 1 : -1) ) //Up to 45 degrees deviation to either side.
-	. = round(((90 - ATAN2(end_apx - ABS_COOR(start.x), end_apy - ABS_COOR(start.y))) + scatter), 1)
+	. = round((90 - ATAN2(end_apx - ABS_COOR(start.x), end_apy - ABS_COOR(start.y))), 1) + scatter
 	if(. < 0)
 		. += 360
 	else if(. >= 360)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -119,6 +119,21 @@ GLOBAL_REAL_VAR(list/stack_trace_storage)
 	return (da >= 0 ? da : da + 360)
 
 
+/proc/get_angle_with_scatter(atom/start, atom/end, scatter, y_offset = 16, x_offset = 16)
+	var/end_apx
+	var/end_apy
+	if(isliving(end)) //Center mass.
+		end_apx = ABS_COOR(end.x)
+		end_apy = ABS_COOR(end.y)
+	else //Exact pixel.
+		end_apx = ABS_COOR_OFFSET(end.x, x_offset)
+		end_apy = ABS_COOR_OFFSET(end.y, y_offset)
+	scatter = ( (rand(0, min(scatter, 45))) * (prob(50) ? 1 : -1) ) //Up to 45 degrees deviation to either side.
+	. = round(((90 - ATAN2(end_apx - ABS_COOR(start.x), end_apy - ABS_COOR(start.y))) + scatter), 1)
+	if(. < 0)
+		. += 360
+
+
 /proc/LinkBlocked(turf/A, turf/B)
 	if(isnull(A) || isnull(B))
 		return TRUE

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -101,8 +101,14 @@ GLOBAL_REAL_VAR(list/stack_trace_storage)
 /proc/Get_Angle(atom/start, atom/end)//For beams.
 	if(!start || !end)
 		CRASH("Get_Angle called for inexisting atoms: [isnull(start) ? "null" : start] to [isnull(end) ? "null" : end].")
-	if(!start.z || !end.z)
-		CRASH("Get_Angle called for inexisting atoms: [isnull(start.loc) ? "null loc" : start.loc] [start] to [isnull(end.loc) ? "null loc" : end.loc] [end].") //Atoms are not on turfs.
+	if(!start.z)
+		start = get_turf(start)
+		if(!start)
+			CRASH("Get_Angle called for inexisting atoms (start): [isnull(start.loc) ? "null loc" : start.loc] [start] to [isnull(end.loc) ? "null loc" : end.loc] [end].") //Atoms are not on turfs.
+	if(!end.z)
+		end = get_turf(end)
+		if(!end)
+			CRASH("Get_Angle called for inexisting atoms (end): [isnull(start.loc) ? "null loc" : start.loc] [start] to [isnull(end.loc) ? "null loc" : end.loc] [end].") //Atoms are not on turfs.
 	var/dy = (32 * end.y + end.pixel_y) - (32 * start.y + start.pixel_y)
 	var/dx = (32 * end.x + end.pixel_x) - (32 * start.x + start.pixel_x)
 	if(!dy)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -519,7 +519,10 @@
 		var/turf/T = params2turf(modifiers["screen-loc"], get_turf(usr.client ? usr.client.eye : usr), usr.client)
 		params += "&catcher=1"
 		if(T)
-			T.Click(location, control, params)
+			//icon-x/y is relative to the object clicked. click_catcher may occupy several tiles. Here we convert them to the proper offsets relative to the tile.
+			modifiers["icon-x"] = num2text(ABS_PIXEL_TO_REL(text2num(modifiers["icon-x"])))
+			modifiers["icon-y"] = num2text(ABS_PIXEL_TO_REL(text2num(modifiers["icon-y"])))
+			T.Click(location, control, list2params(modifiers))
 	. = TRUE
 
 

--- a/code/controllers/configuration/entries/combat_defines.dm
+++ b/code/controllers/configuration/entries/combat_defines.dm
@@ -411,7 +411,7 @@ Number of tiles.
 
 /*
 Speed.
-How quick the projectile travels, or more accurately how many turfs per sleep(1) it travels.
+How quick the projectile travels, or more accurately how many turfs per decisecond it travels.
 */
 /datum/config_entry/number/combat_define/min_shell_speed
 	config_entry_value = 1

--- a/code/controllers/configuration/entries/combat_defines.dm
+++ b/code/controllers/configuration/entries/combat_defines.dm
@@ -409,27 +409,6 @@ Number of tiles.
 /datum/config_entry/number/combat_define/max_shell_range
 	config_entry_value = 40
 
-/*
-Speed.
-How quick the projectile travels, or more accurately how many turfs per decisecond it travels.
-*/
-/datum/config_entry/number/combat_define/min_shell_speed
-	config_entry_value = 1
-
-/datum/config_entry/number/combat_define/slow_shell_speed
-	config_entry_value = 2
-
-/datum/config_entry/number/combat_define/reg_shell_speed
-	config_entry_value = 3
-
-/datum/config_entry/number/combat_define/fast_shell_speed
-	config_entry_value = 4
-
-/datum/config_entry/number/combat_define/super_shell_speed
-	config_entry_value = 5
-
-/datum/config_entry/number/combat_define/ultra_shell_speed
-	config_entry_value = 6
 
 /*
 Penetration.

--- a/code/controllers/configuration/entries/combat_defines.dm
+++ b/code/controllers/configuration/entries/combat_defines.dm
@@ -450,33 +450,6 @@ Flat number subtracted from target armor before damage calculations take place.
 /datum/config_entry/number/combat_define/ltb_armor_penetration
 	config_entry_value = 200
 
-/*
-Extra projectiles.
-How many extra projectiles the projectile spawn when fired. Extra projectiles scatter when fired.
-*/
-/datum/config_entry/number/combat_define/min_proj_extra
-	config_entry_value = 1
-
-/datum/config_entry/number/combat_define/low_proj_extra
-	config_entry_value = 2
-
-/datum/config_entry/number/combat_define/med_proj_extra
-	config_entry_value = 3
-
-/datum/config_entry/number/combat_define/hmed_proj_extra
-	config_entry_value = 4
-
-/datum/config_entry/number/combat_define/high_proj_extra
-	config_entry_value = 5
-
-/datum/config_entry/number/combat_define/mhigh_proj_extra
-	config_entry_value = 6
-
-/datum/config_entry/number/combat_define/vhigh_proj_extra
-	config_entry_value = 7
-
-/datum/config_entry/number/combat_define/max_proj_extra
-	config_entry_value = 8
 
 /*
 Projectile variance.

--- a/code/controllers/subsystem/processing/projectiles.dm
+++ b/code/controllers/subsystem/processing/projectiles.dm
@@ -1,0 +1,6 @@
+PROCESSING_SUBSYSTEM_DEF(projectiles)
+	name = "Projectiles"
+	wait = 2
+	stat_tag = "PP"
+	flags = SS_NO_INIT|SS_TICKER
+	var/global_max_tick_moves = 10

--- a/code/datums/components/full_auto_fire.dm
+++ b/code/datums/components/full_auto_fire.dm
@@ -332,7 +332,6 @@
 		akimbo_gun.Fire(target, shooter, params, FALSE, dual_wield)
 	apply_gun_modifiers(projectile_to_fire, target)
 	setup_bullet_accuracy(projectile_to_fire, shooter, shots_fired, dual_wield)
-	target = simulate_scatter(projectile_to_fire, target, get_turf(target), shooter)
 	var/list/mouse_control = params2list(params)
 	if(mouse_control["icon-x"])
 		projectile_to_fire.p_x = text2num(mouse_control["icon-x"])
@@ -340,9 +339,10 @@
 		projectile_to_fire.p_y = text2num(mouse_control["icon-y"])
 	simulate_recoil(0 , shooter)
 	play_fire_sound(shooter)
-	projectile_to_fire.fire_at(target, shooter, src, projectile_to_fire.ammo.max_range, projectile_to_fire.ammo.shell_speed)
+	var/firing_angle = get_angle_with_scatter(shooter, target, get_scatter(projectile_to_fire.scatter, target, shooter), projectile_to_fire.p_x, projectile_to_fire.p_y)
+	muzzle_flash(firing_angle, shooter)
+	projectile_to_fire.fire_at(target, shooter, src, projectile_to_fire.ammo.max_range, projectile_to_fire.ammo.shell_speed, firing_angle)
 	last_fired = world.time
-	muzzle_flash(Get_Angle(shooter, target), shooter)
 	if(!reload_into_chamber(shooter))
 		click_empty(shooter)
 		return NONE

--- a/code/datums/components/full_auto_fire.dm
+++ b/code/datums/components/full_auto_fire.dm
@@ -141,6 +141,10 @@
 		target = params2turf(modifiers["screen-loc"], get_turf(source.eye), source)
 		if(!target)
 			CRASH("Failed to get the turf under clickcatcher")
+		//icon-x/y is relative to the object clicked. click_catcher may occupy several tiles. Here we convert them to the proper offsets relative to the tile.
+		modifiers["icon-x"] = num2text(ABS_PIXEL_TO_REL(text2num(modifiers["icon-x"])))
+		modifiers["icon-y"] = num2text(ABS_PIXEL_TO_REL(text2num(modifiers["icon-y"])))
+		params = list2params(modifiers)
 	
 	if(SEND_SIGNAL(src, COMSIG_AUTOFIRE_ONMOUSEDOWN, source, target, location, control, params) & COMPONENT_AUTOFIRE_ONMOUSEDOWN_BYPASS)
 		return
@@ -339,7 +343,7 @@
 		projectile_to_fire.p_y = text2num(mouse_control["icon-y"])
 	simulate_recoil(0 , shooter)
 	play_fire_sound(shooter)
-	var/firing_angle = get_angle_with_scatter(shooter, target, get_scatter(projectile_to_fire.scatter, target, shooter), projectile_to_fire.p_x, projectile_to_fire.p_y)
+	var/firing_angle = get_angle_with_scatter(shooter, target, get_scatter(projectile_to_fire.scatter, shooter), projectile_to_fire.p_x, projectile_to_fire.p_y)
 	muzzle_flash(firing_angle, shooter)
 	projectile_to_fire.fire_at(target, shooter, src, projectile_to_fire.ammo.max_range, projectile_to_fire.ammo.shell_speed, firing_angle)
 	last_fired = world.time

--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -68,7 +68,7 @@
 			return
 		else if(istype(AM, /obj/item/projectile))
 			var/obj/item/projectile/P = AM
-			if(P.original != parent)
+			if(P.original_target != parent)
 				return
 
 	if(isobserver(AM))

--- a/code/game/objects/machinery/sentries.dm
+++ b/code/game/objects/machinery/sentries.dm
@@ -838,12 +838,19 @@
 	return
 
 /obj/machinery/marine_turret/proc/load_into_chamber()
-	if(in_chamber) return 1 //Already set!
-	if(!CHECK_BITFIELD(turret_flags, TURRET_ON) || !cell || rounds == 0 || machine_stat == 1) return 0
+	if(in_chamber)
+		return TRUE //Already set!
+	if(!CHECK_BITFIELD(turret_flags, TURRET_ON) || !cell || rounds == 0 || machine_stat & (NOPOWER|BROKEN))
+		return FALSE
 
-	in_chamber = new /obj/item/projectile(loc) //New bullet!
+	create_bullet()
+	return TRUE
+
+
+/obj/machinery/marine_turret/proc/create_bullet()
+	in_chamber = new /obj/item/projectile(src) //New bullet!
 	in_chamber.generate_bullet(ammo)
-	return 1
+
 
 /obj/machinery/marine_turret/proc/process_shot()
 	set waitfor = 0
@@ -922,7 +929,7 @@
 				in_chamber.ammo.penetration = round(in_chamber.ammo.penetration * 1.5, 0.01)
 
 			//Setup projectile
-			in_chamber.original = target
+			in_chamber.original_target = target
 			in_chamber.setDir(dir)
 			in_chamber.def_zone = pick("chest", "chest", "chest", "head")
 

--- a/code/game/objects/machinery/smartgun_mount.dm
+++ b/code/game/objects/machinery/smartgun_mount.dm
@@ -348,7 +348,7 @@
 	in_chamber.generate_bullet(ammo)
 
 
-/obj/machinery/m56d_hmg/proc/process_shot()
+/obj/machinery/m56d_hmg/proc/process_shot(mob/user)
 	set waitfor = 0
 
 	if(isnull(target))
@@ -362,7 +362,7 @@
 		if(rounds > 3)
 			for(var/i = 1 to 3)
 				is_bursting = 1
-				fire_shot()
+				fire_shot(user)
 				sleep(2)
 			last_fired = TRUE
 			addtimer(VARSET_CALLBACK(src, last_fired, FALSE), fire_delay)
@@ -370,13 +370,13 @@
 		is_bursting = 0
 
 	if(!burst_fire && target && !last_fired)
-		fire_shot()
+		fire_shot(user)
 	if(burst_fire_toggled)
 		burst_fire = !burst_fire
 		burst_fire_toggled = FALSE
 	target = null
 
-/obj/machinery/m56d_hmg/proc/fire_shot() //Bang Bang
+/obj/machinery/m56d_hmg/proc/fire_shot(mob/user) //Bang Bang
 	if(!ammo)
 		return //No ammo.
 	if(last_fired)
@@ -406,7 +406,7 @@
 			in_chamber.setDir(dir)
 			in_chamber.def_zone = pick("chest","chest","chest","head")
 			playsound(src.loc, 'sound/weapons/guns/fire/hmg.ogg', 75, 1)
-			in_chamber.fire_at(U,src,null,ammo.max_range,ammo.shell_speed)
+			in_chamber.fire_at(U, user, src, ammo.max_range, ammo.shell_speed)
 			if(target)
 				var/angle = round(Get_Angle(src,target))
 				muzzle_flash(angle)
@@ -500,7 +500,7 @@
 			to_chat(user, "<span class='warning'><b>*click*</b></span>")
 			playsound(src, 'sound/weapons/guns/fire/empty.ogg', 25, 1, 5)
 		else
-			process_shot()
+			process_shot(user)
 		return TRUE
 
 	if(burst_fire_toggled)

--- a/code/game/objects/machinery/smartgun_mount.dm
+++ b/code/game/objects/machinery/smartgun_mount.dm
@@ -331,6 +331,7 @@
 	SEND_SIGNAL(M, COMSIG_XENOMORPH_ATTACK_M56)
 	return ..()
 
+
 /obj/machinery/m56d_hmg/proc/load_into_chamber()
 	if(in_chamber)
 		return TRUE //Already set!
@@ -338,9 +339,14 @@
 		update_icon() //make sure the user can see the lack of ammo.
 		return FALSE //Out of ammo.
 
-	in_chamber = new /obj/item/projectile(loc) //New bullet!
+	create_bullet()
+	return TRUE
+
+
+/obj/machinery/m56d_hmg/proc/create_bullet()
+	in_chamber = new /obj/item/projectile(src) //New bullet!
 	in_chamber.generate_bullet(ammo)
-	return 1
+
 
 /obj/machinery/m56d_hmg/proc/process_shot()
 	set waitfor = 0
@@ -396,7 +402,7 @@
 
 	if(load_into_chamber() == 1)
 		if(istype(in_chamber,/obj/item/projectile))
-			in_chamber.original = target
+			in_chamber.original_target = target
 			in_chamber.setDir(dir)
 			in_chamber.def_zone = pick("chest","chest","chest","head")
 			playsound(src.loc, 'sound/weapons/guns/fire/hmg.ogg', 75, 1)

--- a/code/game/objects/ovipositor.dm
+++ b/code/game/objects/ovipositor.dm
@@ -34,5 +34,5 @@
 			take_damage(75)
 
 // Density override
-/obj/ovipositor/get_projectile_hit_chance(obj/item/projectile/P)
+/obj/ovipositor/projectile_hit(obj/item/projectile/P)
 	return TRUE

--- a/code/game/visual_objects.dm
+++ b/code/game/visual_objects.dm
@@ -1,11 +1,11 @@
 /atom/movable/vis_obj
-	layer = HUD_LAYER
-	plane = HUD_PLANE
 	appearance_flags = NO_CLIENT_COLOR
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 
 /atom/movable/vis_obj/action
+	layer = HUD_LAYER
+	plane = HUD_PLANE
 	icon = 'icons/mob/actions.dmi'
 
 
@@ -24,3 +24,11 @@
 
 /atom/movable/vis_obj/action/fmode_burst_auto
 	icon_state = "fmode_burst_auto"
+
+
+/atom/movable/vis_obj/effect/muzzle_flash
+	icon = 'icons/obj/items/projectiles.dmi'
+	icon_state = "muzzle_flash"
+	layer = ABOVE_LYING_MOB_LAYER
+	plane = GAME_PLANE
+	var/applied = FALSE

--- a/code/modules/codex/entries/guns_codex.dm
+++ b/code/modules/codex/entries/guns_codex.dm
@@ -1,9 +1,3 @@
-/obj/item/weapon/gun
-	var/general_codex_key = "guns"
-
-/obj/item/weapon/gun/energy
-	general_codex_key = "energy weapons"
-
 /obj/item/weapon/gun/get_antag_info()
 	var/list/entries = SScodex.retrieve_entries_for_string(general_codex_key)
 	var/datum/codex_entry/general_entry = LAZYACCESS(entries, 1)

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -680,7 +680,7 @@
 	newspit.permutated += X
 	newspit.def_zone = X.get_limbzone_target()
 
-	newspit.fire_at(A, X, X, X.ammo.max_range, X.ammo.shell_speed)
+	newspit.fire_at(A, X, null, X.ammo.max_range, X.ammo.shell_speed)
 
 	add_cooldown()
 

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -388,7 +388,7 @@
 	var/obj/item/projectile/P = new(startloc)
 	playsound(src, projectilesound, 100, 1)
 	P.generate_bullet(GLOB.ammo_list[ammotype])
-	P.fire_at(targeted_atom, src, src)
+	P.fire_at(targeted_atom, src)
 
 
 /mob/living/simple_animal/hostile/proc/CanSmashTurfs(turf/T)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -118,7 +118,7 @@
 	if(stat == CONSCIOUS && !target && AIStatus != AI_OFF && !client)
 		if(P.firer && get_dist(src, P.firer) <= aggro_vision_range)
 			FindTarget(list(P.firer), 1)
-		Goto(P.starting, move_to_delay, 3)
+		Goto(P.starting_turf, move_to_delay, 3)
 	return ..()
 
 //////////////HOSTILE MOB TARGETTING AND AGGRESSION////////////

--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -343,7 +343,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage_type = BURN
 	debilitate = list(4,4,0,0,0,0,0,0)
 	flags_ammo_behavior = AMMO_INCENDIARY|AMMO_IGNORE_ARMOR
-	shell_speed = 1
+	shell_speed = 2
 
 /datum/ammo/bullet/pistol/mankey/New()
 	..()

--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -69,9 +69,6 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	shell_speed 		= CONFIG_GET(number/combat_define/slow_shell_speed) 	// How fast the projectile moves.
 
 
-/datum/ammo/proc/do_at_half_range(obj/item/projectile/proj)
-	return
-
 /datum/ammo/proc/do_at_max_range(obj/item/projectile/proj)
 	return
 
@@ -198,15 +195,15 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 		if(prob(new_proj.scatter))
 			var/scatter_x = rand(-1, 1)
 			var/scatter_y = rand(-1, 1)
-			new_target = locate(original_P.target_turf.x + round(scatter_x), original_P.target_turf.y + round(scatter_y), original_P.target_turf.z)
+			new_target = locate(original_P.original_target_turf.x + round(scatter_x), original_P.original_target_turf.y + round(scatter_y), original_P.original_target_turf.z)
 			if(!istype(new_target))
 				continue	//If we didn't find anything, make another pass.
-			new_proj.original = new_target
+			new_proj.original_target = new_target
 
 		new_proj.accuracy = round(new_proj.accuracy * original_P.accuracy/initial(original_P.accuracy)) //if the gun changes the accuracy of the main projectile, it also affects the bonus ones.
 
 		if(!new_target)
-			new_target = original_P.target_turf
+			new_target = original_P.original_target_turf
 		new_proj.fire_at(new_target,original_P.firer, original_P.shot_from, new_proj.ammo.max_range, new_proj.ammo.shell_speed) //Fire!
 
 	//This is sort of a workaround for now. There are better ways of doing this ~N.
@@ -780,7 +777,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	..()
 	accuracy = CONFIG_GET(number/combat_define/max_hit_accuracy)
 	damage = CONFIG_GET(number/combat_define/super_hit_damage)
-	shell_speed = CONFIG_GET(number/combat_define/ultra_shell_speed) + 1
+	shell_speed = CONFIG_GET(number/combat_define/ultra_shell_speed)
 
 /*
 //================================================

--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -47,7 +47,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	var/damage_type 				= BRUTE 	// BRUTE, BURN, TOX, OXY, CLONE are the only things that should be in here
 	var/penetration					= 0 		// How much armor it ignores before calculations take place
 	var/shrapnel_chance 			= 0 		// The % chance it will imbed in a human
-	var/shell_speed 				= 0 		// How fast the projectile moves
+	var/shell_speed 				= 2 		// How fast the projectile moves
 	var/bonus_projectiles_type 					// Type path of the extra projectiles
 	var/bonus_projectiles_amount 	= 0 		// How many extra projectiles it shoots out. Works kind of like firing on burst, but all of the projectiles travel together
 	var/debilitate[]				= null 		// Stun,knockdown,knockout,irradiate,stutter,eyeblur,drowsy,agony
@@ -66,7 +66,6 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage_var_low		= CONFIG_GET(number/combat_define/min_proj_variance) 	// Same as with accuracy variance.
 	damage_var_high		= CONFIG_GET(number/combat_define/min_proj_variance)
 	damage_falloff 		= CONFIG_GET(number/combat_define/reg_damage_falloff) 	// How much damage the bullet loses per turf traveled.
-	shell_speed 		= CONFIG_GET(number/combat_define/slow_shell_speed) 	// How fast the projectile moves.
 
 
 /datum/ammo/proc/do_at_max_range(obj/item/projectile/proj)
@@ -243,12 +242,12 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	sound_bounce = "ballistic_bounce"
 	point_blank_range = 2
 	accurate_range_min = 0
+	shell_speed = 3
 
 /datum/ammo/bullet/New()
 	..()
 	damage = CONFIG_GET(number/combat_define/base_hit_damage)
 	shrapnel_chance = CONFIG_GET(number/combat_define/low_shrapnel_chance)
-	shell_speed = CONFIG_GET(number/combat_define/super_shell_speed)
 
 /*
 //================================================
@@ -344,12 +343,13 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage_type = BURN
 	debilitate = list(4,4,0,0,0,0,0,0)
 	flags_ammo_behavior = AMMO_INCENDIARY|AMMO_IGNORE_ARMOR
+	shell_speed = 1
 
 /datum/ammo/bullet/pistol/mankey/New()
 	..()
 	damage = CONFIG_GET(number/combat_define/min_hit_damage)
 	damage_var_high = CONFIG_GET(number/combat_define/high_proj_variance)
-	shell_speed = CONFIG_GET(number/combat_define/reg_shell_speed)
+
 
 /datum/ammo/bullet/pistol/mankey/on_hit_mob(mob/M,obj/item/projectile/P)
 	if(P && P.loc && !M.stat && !istype(M,/mob/living/carbon/monkey))
@@ -515,7 +515,6 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage = CONFIG_GET(number/combat_define/hmed_hit_damage)
 	scatter = -CONFIG_GET(number/combat_define/low_scatter_value)
 	penetration = CONFIG_GET(number/combat_define/med_armor_penetration)
-	shell_speed = CONFIG_GET(number/combat_define/fast_shell_speed)
 
 /datum/ammo/bullet/rifle/m4ra/incendiary
 	name = "A19 high velocity incendiary bullet"
@@ -560,10 +559,13 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 
 /datum/ammo/bullet/shotgun
 	hud_state_empty = "shotgun_empty"
+	shell_speed = 2
+
 
 /datum/ammo/bullet/shotgun/slug
 	name = "shotgun slug"
 	hud_state = "shotgun_slug"
+	shell_speed = 3
 
 /datum/ammo/bullet/shotgun/slug/New()
 	..()
@@ -586,7 +588,6 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	max_range = CONFIG_GET(number/combat_define/short_shell_range)
 	shrapnel_chance = 0
 	accuracy = CONFIG_GET(number/combat_define/med_hit_accuracy)
-	shell_speed = CONFIG_GET(number/combat_define/fast_shell_speed)
 
 /datum/ammo/bullet/shotgun/beanbag/on_hit_mob(mob/M, obj/item/projectile/P)
 	if(!M || M == P.firer)
@@ -661,6 +662,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	hud_state = "shotgun_buckshot"
 	bonus_projectiles_type = /datum/ammo/bullet/shotgun/spread
 
+
 /datum/ammo/bullet/shotgun/buckshot/New()
 	..()
 	accuracy_var_low = CONFIG_GET(number/combat_define/high_proj_variance)
@@ -673,7 +675,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage_falloff = CONFIG_GET(number/combat_define/buckshot_damage_falloff)
 	penetration	= -CONFIG_GET(number/combat_define/mlow_armor_penetration)
 	bonus_projectiles_amount = CONFIG_GET(number/combat_define/low_proj_extra)
-	shell_speed = CONFIG_GET(number/combat_define/reg_shell_speed)
+
 
 /datum/ammo/bullet/shotgun/buckshot/on_hit_mob(mob/M,obj/item/projectile/P)
 	knockback(M,P)
@@ -689,6 +691,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 /datum/ammo/bullet/shotgun/spread
 	name = "additional buckshot"
 	icon_state = "buckshot"
+	shell_speed = 2
 
 /datum/ammo/bullet/shotgun/spread/New()
 	..()
@@ -701,7 +704,6 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage_var_high = CONFIG_GET(number/combat_define/med_proj_variance)
 	damage_falloff = CONFIG_GET(number/combat_define/buckshot_damage_falloff)
 	penetration	= -CONFIG_GET(number/combat_define/mlow_armor_penetration)
-	shell_speed = CONFIG_GET(number/combat_define/reg_shell_speed)
 	scatter = CONFIG_GET(number/combat_define/max_scatter_value)*1.5 //bonus projectiles run their own scatter chance
 
 /datum/ammo/bullet/shotgun/spread/masterkey/New()
@@ -723,6 +725,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	iff_signal = ACCESS_IFF_MARINE
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SNIPER|AMMO_SKIPS_HUMANS
 	accurate_range_min = 5
+	shell_speed = 4
 
 /datum/ammo/bullet/sniper/New()
 	..()
@@ -731,7 +734,6 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	scatter = -CONFIG_GET(number/combat_define/med_scatter_value)
 	damage = CONFIG_GET(number/combat_define/mhigh_hit_damage)
 	penetration= CONFIG_GET(number/combat_define/mhigh_armor_penetration)
-	shell_speed = CONFIG_GET(number/combat_define/ultra_shell_speed)
 
 /datum/ammo/bullet/sniper/incendiary
 	name = "incendiary sniper bullet"
@@ -777,7 +779,6 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	..()
 	accuracy = CONFIG_GET(number/combat_define/max_hit_accuracy)
 	damage = CONFIG_GET(number/combat_define/super_hit_damage)
-	shell_speed = CONFIG_GET(number/combat_define/ultra_shell_speed)
 
 /*
 //================================================
@@ -897,9 +898,10 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	hud_state_empty = "rocket_empty"
 	ping = null //no bounce off.
 	sound_bounce	= "rocket_bounce"
-	damage_falloff = 0
 	flags_ammo_behavior = AMMO_EXPLOSIVE|AMMO_ROCKET
 	armor_type = "bomb"
+	damage_falloff = 0
+	shell_speed = 2
 	var/datum/effect_system/smoke_spread/smoke
 
 /datum/ammo/rocket/New()
@@ -910,7 +912,6 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	max_range = CONFIG_GET(number/combat_define/long_shell_range)
 	damage = CONFIG_GET(number/combat_define/med_hit_damage)
 	penetration = CONFIG_GET(number/combat_define/max_armor_penetration)
-	shell_speed = CONFIG_GET(number/combat_define/slow_shell_speed)
 
 /datum/ammo/rocket/set_smoke()
 	smoke = new
@@ -962,7 +963,6 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	max_range = CONFIG_GET(number/combat_define/max_shell_range)
 	penetration = CONFIG_GET(number/combat_define/ltb_armor_penetration)
 	damage = CONFIG_GET(number/combat_define/ltb_hit_damage)
-	shell_speed = CONFIG_GET(number/combat_define/fast_shell_speed)
 
 /datum/ammo/rocket/ltb/drop_nade(turf/T)
 	explosion(T, -1, 3, 5, 6)
@@ -1058,6 +1058,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	icon_state = "laser"
 	hud_state = "laser"
 	armor_type = "laser"
+	shell_speed = 4
 
 /datum/ammo/energy/lasgun/New()
 	. = ..()
@@ -1065,7 +1066,6 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage = CONFIG_GET(number/combat_define/llow_hit_damage)
 	penetration = CONFIG_GET(number/combat_define/mlow_armor_penetration)
 	max_range = CONFIG_GET(number/combat_define/long_shell_range)
-	shell_speed = CONFIG_GET(number/combat_define/ultra_shell_speed)
 	accuracy_var_low = CONFIG_GET(number/combat_define/low_proj_variance)
 	accuracy_var_high = CONFIG_GET(number/combat_define/low_proj_variance)
 	damage_var_low = CONFIG_GET(number/combat_define/low_proj_variance)
@@ -1103,12 +1103,13 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	var/added_spit_delay = 0 //used to make cooldown of the different spits vary.
 	var/spit_cost
 	armor_type = "bio"
+	shell_speed = 1
+
 
 /datum/ammo/xeno/New()
 	. = ..()
 	accuracy = CONFIG_GET(number/combat_define/max_hit_accuracy)
 	accurate_range = CONFIG_GET(number/combat_define/short_shell_range)
-	shell_speed = CONFIG_GET(number/combat_define/reg_shell_speed)
 	max_range = CONFIG_GET(number/combat_define/short_shell_range)
 	accuracy_var_low = CONFIG_GET(number/combat_define/low_proj_variance)
 	accuracy_var_high = CONFIG_GET(number/combat_define/low_proj_variance)
@@ -1124,7 +1125,6 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 
 /datum/ammo/xeno/toxin/New()
 	accuracy = CONFIG_GET(number/combat_define/max_hit_accuracy)
-	shell_speed = CONFIG_GET(number/combat_define/reg_shell_speed)
 	accurate_range = CONFIG_GET(number/combat_define/close_shell_range)
 	max_range = CONFIG_GET(number/combat_define/near_shell_range)
 	accuracy_var_low = CONFIG_GET(number/combat_define/low_proj_variance)
@@ -1213,11 +1213,12 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	sound_hit 	 = "alien_resin_build2"
 	sound_bounce	= "alien_resin_build3"
 
+
 /datum/ammo/xeno/sticky/New()
 	..()
-	shell_speed = CONFIG_GET(number/combat_define/fast_shell_speed)
 	damage = CONFIG_GET(number/combat_define/base_hit_damage) //minor; this is mostly just to provide confirmation of a hit
 	max_range = CONFIG_GET(number/combat_define/max_shell_range)
+
 
 /datum/ammo/xeno/sticky/on_hit_mob(mob/M,obj/item/projectile/P)
 	drop_resin(get_turf(M))
@@ -1227,6 +1228,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 			return
 		C.add_slowdown(3) //slow em down
 		C.next_move_slowdown += 8 //really slow down their next move, as if they stepped in sticky doo doo
+
 
 /datum/ammo/xeno/sticky/on_hit_obj(obj/O,obj/item/projectile/P)
 	var/turf/T = get_turf(O)

--- a/code/modules/projectiles/updated_projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_attachables.dm
@@ -261,6 +261,7 @@ Defined in conflicts.dm of the #defines folder.
 	silence_mod = 1
 	pixel_shift_y = 16
 	attach_icon = "suppressor_a"
+	attach_shell_speed_mod = -1
 
 /obj/item/attachable/suppressor/unremovable
 	flags_attach_features = NONE
@@ -280,7 +281,6 @@ Defined in conflicts.dm of the #defines folder.
 	damage_mod = -CONFIG_GET(number/combat_define/min_hit_damage_mult)
 	recoil_mod = -CONFIG_GET(number/combat_define/min_recoil_value)
 	scatter_mod = -CONFIG_GET(number/combat_define/min_scatter_value)
-	attach_shell_speed_mod = -CONFIG_GET(number/combat_define/min_shell_speed)
 	attach_icon = pick("suppressor_a","suppressor2_a")
 
 	accuracy_unwielded_mod = -CONFIG_GET(number/combat_define/min_hit_accuracy_mult)
@@ -332,12 +332,12 @@ Defined in conflicts.dm of the #defines folder.
 	slot = "muzzle"
 	icon_state = "ebarrel"
 	attach_icon = "ebarrel_a"
+	attach_shell_speed_mod = -1
 
 /obj/item/attachable/extended_barrel/Initialize()
 	. = ..()
 	accuracy_mod = CONFIG_GET(number/combat_define/med_hit_accuracy_mult)
 	accuracy_unwielded_mod = CONFIG_GET(number/combat_define/low_hit_accuracy_mult)
-	attach_shell_speed_mod = CONFIG_GET(number/combat_define/min_shell_speed)
 	damage_mod = -CONFIG_GET(number/combat_define/min_hit_damage_mult)
 	scatter_mod = -CONFIG_GET(number/combat_define/min_scatter_value)
 	size_mod = 1
@@ -349,12 +349,13 @@ Defined in conflicts.dm of the #defines folder.
 	slot = "muzzle"
 	icon_state = "hbarrel"
 	attach_icon = "hbarrel_a"
+	attach_shell_speed_mod = 1
+
 
 /obj/item/attachable/heavy_barrel/Initialize()
 	. = ..()
 	accuracy_mod = -CONFIG_GET(number/combat_define/hmed_hit_accuracy_mult)
 	damage_mod = CONFIG_GET(number/combat_define/hmed_hit_damage_mult)
-	attach_shell_speed_mod = CONFIG_GET(number/combat_define/slow_shell_speed)
 	delay_mod = CONFIG_GET(number/combat_define/low_fire_delay)
 	scatter_mod = CONFIG_GET(number/combat_define/min_scatter_value)
 	accuracy_unwielded_mod = -CONFIG_GET(number/combat_define/high_hit_accuracy_mult)

--- a/code/modules/projectiles/updated_projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_helpers.dm
@@ -186,8 +186,6 @@ should be alright.
 
 /obj/item/weapon/gun/attack_self(mob/user)
 	. = ..()
-	if(target)
-		return
 
 	//There are only two ways to interact here.
 	if(flags_item & TWOHANDED)
@@ -402,14 +400,6 @@ should be alright.
 		overlays += I
 	else
 		attachable_overlays["mag"] = null
-
-
-/obj/item/weapon/gun/proc/update_special_overlay(new_icon_state)
-	overlays -= attachable_overlays["special"]
-	qdel(attachable_overlays["special"])
-	var/image/I = image(icon,src,new_icon_state)
-	attachable_overlays["special"] = I
-	overlays += I
 
 
 /obj/item/weapon/gun/proc/update_force_list()

--- a/code/modules/projectiles/updated_projectiles/gun_system.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_system.dm
@@ -72,19 +72,10 @@
 
 	var/shell_speed_mod	= 0						//Modifies the speed of projectiles fired.
 
-	//Targeting.
-	var/tmp/list/mob/living/target				//List of who yer targeting.
-	var/tmp/mob/living/last_moved_mob			//Used to fire faster at more than one person.
-	var/tmp/lock_time 		= -100
-	var/automatic 			= 0					//Used to determine if you can target multiple people.
-	var/tmp/told_cant_shoot = 0					//So that it doesn't spam them with the fact they cannot hit them.
-	var/firerate 			= 0					//0 for keep shooting until aim is lowered
-												//1 for one bullet after target moves and aim is lowered
-
 	//Attachments.
-	var/attachable_overlays[] 		= null		//List of overlays so we can switch them in an out, instead of using Cut() on overlays.
-	var/attachable_offset[] 		= null		//Is a list, see examples of from the other files. Initiated on New() because lists don't initial() properly.
-	var/attachable_allowed[]		= null		//Must be the exact path to the attachment present in the list. Empty list for a default.
+	var/list/attachable_overlays	= list("muzzle", "rail", "under", "stock", "mag") //List of overlays so we can switch them in an out, instead of using Cut() on overlays.
+	var/list/attachable_offset 		= null		//Is a list, see examples of from the other files. Initiated on New() because lists don't initial() properly.
+	var/list/attachable_allowed		= null		//Must be the exact path to the attachment present in the list. Empty list for a default.
 	var/obj/item/attachable/muzzle 	= null		//Attachable slots. Only one item per slot.
 	var/obj/item/attachable/rail 	= null
 	var/obj/item/attachable/under 	= null
@@ -116,7 +107,6 @@
 /obj/item/weapon/gun/Initialize(mapload, spawn_empty) //You can pass on spawn_empty to make the sure the gun has no bullets or mag or anything when created.
 	. = ..()					//This only affects guns you can get from vendors for now. Special guns spawn with their own things regardless.
 	base_gun_icon = icon_state
-	attachable_overlays = list("muzzle", "rail", "under", "stock", "mag", "special")
 	if(current_mag)
 		if(spawn_empty && !(flags_gun_features & GUN_INTERNAL_MAG)) //Internal mags will still spawn, but they won't be filled.
 			current_mag = null
@@ -163,16 +153,22 @@
 
 
 /obj/item/weapon/gun/Destroy()
-	in_chamber 		= null
-	ammo 			= null
-	current_mag 	= null
-	target 			= null
-	last_moved_mob 	= null
-	muzzle 			= null
-	rail 			= null
-	under 			= null
-	stock 			= null
-	attachable_overlays = null
+	ammo = null
+	active_attachable = null
+	if(muzzle)
+		QDEL_NULL(muzzle)
+	if(rail)
+		QDEL_NULL(rail)
+	if(under)
+		QDEL_NULL(under)
+	if(stock)
+		QDEL_NULL(stock)
+	if(in_chamber)
+		QDEL_NULL(in_chamber)
+	if(current_mag)
+		QDEL_NULL(current_mag)
+	if(muzzle_flash)
+		QDEL_NULL(muzzle_flash)
 	return ..()
 
 /obj/item/weapon/gun/emp_act(severity)

--- a/code/modules/projectiles/updated_projectiles/gun_system.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_system.dm
@@ -16,7 +16,7 @@
 	flags_atom = CONDUCT
 	flags_item = TWOHANDED
 
-	var/atom/movable/vis_obj/effect/muzzle_flash/muzzle_flash = new
+	var/atom/movable/vis_obj/effect/muzzle_flash/muzzle_flash
 	var/muzzle_flash_lum = 3 //muzzle flash brightness
 
 	var/fire_sound 		= 'sound/weapons/guns/fire/gunshot.ogg'
@@ -125,6 +125,8 @@
 
 	setup_firemodes()
 	AddComponent(/datum/component/automatic_fire, fire_delay, burst_delay, burst_amount, gun_firemode, loc) //This should go after set_gun_config_values(), handle_starting_attachment() and setup_firemodes() to get the proper values set.
+
+	muzzle_flash = new()
 
 
 //Called by the gun's New(), set the gun variables' values.
@@ -1134,44 +1136,6 @@ and you're good to go.
 	if(!QDELETED(flash_loc))
 		flash_loc.vis_contents -= muzzle_flash
 	muzzle_flash.applied = FALSE
-
-/*
-	var/mutable_appearance/flash_img = new(muzzle_flash)
-	flash_img
-	var/matrix/rotate = matrix() //Change the flash angle.
-	rotate.Translate(0, 5)
-
-	var/image/I = image('icons/obj/items/projectiles.dmi', src, muzzle_flash, flash_loc.layer + 0.1)
-	var/matrix/rotate = matrix() //Change the flash angle.
-	rotate.Translate(0, 5)
-	rotate.Turn(angle)
-	I.transform = rotate
-	flick_overlay_view(I, flash_loc, 3)
-
-
-
-/obj/item/weapon/gun/proc/muzzle_flash(angle,mob/user, x_offset = 0, y_offset = 5)
-	if(!muzzle_flash || flags_gun_features & GUN_SILENCED || isnull(angle))
-		return //We have to check for null angle here, as 0 can also be an angle.
-	if(!istype(user) || !istype(user.loc,/turf))
-		return
-
-	var/prev_light = light_range
-	if(light_range <= muzzle_flash_lum)
-		set_light(muzzle_flash_lum)
-		spawn(10)
-			set_light(prev_light)
-
-	if(prob(65)) //Not all the time.
-		var/image_layer = (user && user.dir == SOUTH) ? MOB_LAYER+0.1 : MOB_LAYER-0.1
-		var/image/I = image('icons/obj/items/projectiles.dmi',user,muzzle_flash,image_layer)
-		var/matrix/rotate = matrix() //Change the flash angle.
-		rotate.Translate(x,y)
-		rotate.Turn(angle)
-		I.transform = rotate
-
-		flick_overlay_view(I, user, 3)
-*/
 
 
 /obj/item/weapon/gun/on_enter_storage(obj/item/I)

--- a/code/modules/projectiles/updated_projectiles/gun_system.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_system.dm
@@ -1042,7 +1042,7 @@ and you're good to go.
 			if(new_target)
 				target = new_target//Looks like we found a turf.
 
-	projectile_to_fire.original = target
+	projectile_to_fire.original_target = target
 	return target
 
 

--- a/code/modules/projectiles/updated_projectiles/gun_system.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_system.dm
@@ -668,7 +668,7 @@ and you're good to go.
 			if(mouse_control["icon-y"])
 				projectile_to_fire.p_y = text2num(mouse_control["icon-y"])
 
-		var/firing_angle = get_angle_with_scatter((user || get_turf(src)), target, get_scatter(projectile_to_fire.scatter, target, user), projectile_to_fire.p_x, projectile_to_fire.p_y)
+		var/firing_angle = get_angle_with_scatter((user || get_turf(src)), target, get_scatter(projectile_to_fire.scatter, user), projectile_to_fire.p_x, projectile_to_fire.p_y)
 
 		//Finally, make with the pew pew!
 		if(!projectile_to_fire || !istype(projectile_to_fire,/obj))
@@ -970,25 +970,18 @@ and you're good to go.
 
 
 
-/obj/item/weapon/gun/proc/get_scatter(starting_scatter, atom/target, mob/user)
+/obj/item/weapon/gun/proc/get_scatter(starting_scatter, mob/user)
 	. = starting_scatter //projectile_to_fire.scatter
 
 	if(. <= 0) //Not if the gun doesn't scatter at all, or negative scatter.
 		return 0
 
-	var/targdist = get_dist(target, get_turf(src))
-
 	switch(gun_firemode)
-		if(GUN_FIREMODE_BURSTFIRE) //Much higher chance on a burst.
+		if(GUN_FIREMODE_BURSTFIRE, GUN_FIREMODE_AUTOBURST, GUN_FIREMODE_AUTOMATIC) //Much higher chance on a burst or similar.
 			if(flags_item & WIELDED && wielded_stable())
 				. += burst_amount * burst_scatter_mult
 			else
 				. += burst_amount * burst_scatter_mult * 5
-			if(targdist > world.view) //Long range burst shots have more chance to scatter.
-				. += 25
-		if(GUN_FIREMODE_SEMIAUTO)
-			if(targdist < 4) //No scatter on single fire for close targets.
-				return 0
 
 	if(user?.mind?.cm_skills)
 		if(user.mind.cm_skills.firearms <= 0) //no training in any firearms

--- a/code/modules/projectiles/updated_projectiles/guns/energy.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/energy.dm
@@ -8,6 +8,7 @@
 	var/charge_cost = 10 //100 shots.
 	var/cell_type = /obj/item/cell
 	flags_gun_features = GUN_AMMO_COUNTER
+	general_codex_key = "energy weapons"
 
 /obj/item/weapon/gun/energy/examine_ammo_count(mob/user)
 	var/list/dat = list()

--- a/code/modules/projectiles/updated_projectiles/projectile.dm
+++ b/code/modules/projectiles/updated_projectiles/projectile.dm
@@ -149,7 +149,7 @@
 	y_offset = round(cos(dir_angle), 0.01)
 
 	var/proj_dir
-	switch(dir_angle) //The projectile starts at the edge of the firer's tile (still inside it), roughly where the muzzle flash shows.
+	switch(dir_angle) //The projectile starts at the edge of the firer's tile (still inside it).
 		if(0, 360)
 			proj_dir = NORTH
 			pixel_x = 0
@@ -403,7 +403,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 
 	var/new_pixel_x = PROJ_ABS_PIXEL_TO_REL(apx) //The final pixel offset after this movement. Float value.
 	var/new_pixel_y = PROJ_ABS_PIXEL_TO_REL(apy)
-	if(projectile_speed >= 4) //At this speed the animation barely shows. Changing the vars through animation alone takes almost 5 times the CPU than setting them directly. No need for that if there's nothing to show for it.
+	if(projectile_speed > 5) //At this speed the animation barely shows. Changing the vars through animation alone takes almost 5 times the CPU than setting them directly. No need for that if there's nothing to show for it.
 		pixel_x = CEILING(new_pixel_x, 1) - 16
 		pixel_y = CEILING(new_pixel_y, 1) - 16
 		forceMove(last_processed_turf)

--- a/code/modules/projectiles/updated_projectiles/projectile.dm
+++ b/code/modules/projectiles/updated_projectiles/projectile.dm
@@ -415,7 +415,6 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 	return FALSE //No hits ...yet!
 
 #undef PROJ_ABS_PIXEL_TO_TURF
-#undef ABS_PIXEL_TO_REL
 #undef PROJ_ANIMATION_SPEED
 
 

--- a/code/modules/projectiles/updated_projectiles/projectile.dm
+++ b/code/modules/projectiles/updated_projectiles/projectile.dm
@@ -140,11 +140,11 @@
 	apx = (((x - 1) * 32) + 16) //Set the absolute coordinates. Center of a tile is assumed to be (16,16)
 	apy = (((y - 1) * 32) + 16)
 
-	//If we clicked on a turf, aim for the clicked pixel. Else use the clicked atom tile's center for maximum accuracy.
-	if(isturf(target))
-		dir_angle = round(Get_Pixel_Angle(((((target.x - 1) * 32) + p_x) - apx), ((((target.y - 1) * 32) + p_y) - apy))) //Using absolute pixel coordinates.
+	//If we clicked on a living mob, use the clicked atom tile's center for maximum accuracy. Else aim for the clicked pixel. 
+	if(isliving(target))
+		dir_angle = round(Get_Pixel_Angle(((((target.x - 1) * 32) + 16) - apx), ((((target.y - 1) * 32) + 16) - apy))) //Using absolute pixel coordinates.
 	else
-		dir_angle = round(Get_Pixel_Angle(((((target.x - 1) * 32) + 16) - apx), ((((target.y - 1) * 32) + 16) - apy)))
+		dir_angle = round(Get_Pixel_Angle(((((target.x - 1) * 32) + p_x) - apx), ((((target.y - 1) * 32) + p_y) - apy)))
 	x_offset = round(sin(dir_angle), 0.01)
 	y_offset = round(cos(dir_angle), 0.01)
 

--- a/code/modules/projectiles/updated_projectiles/projectile.dm
+++ b/code/modules/projectiles/updated_projectiles/projectile.dm
@@ -99,7 +99,7 @@
 	armor_type = ammo.armor_type
 
 //Target, firer, shot from. Ie the gun
-/obj/item/projectile/proc/fire_at(atom/target, atom/shooter, atom/source, range, speed)
+/obj/item/projectile/proc/fire_at(atom/target, atom/shooter, atom/source, range, speed, angle)
 	if(!isnull(speed))
 		projectile_speed = speed
 	if(!isnull(range))
@@ -139,14 +139,18 @@
 		qdel(src)
 		return
 
-	apx = (((x - 1) * 32) + 16) //Set the absolute coordinates. Center of a tile is assumed to be (16,16)
-	apy = (((y - 1) * 32) + 16)
+	apx = ABS_COOR(x) //Set the absolute coordinates. Center of a tile is assumed to be (16,16)
+	apy = ABS_COOR(y)
 
 	//If we clicked on a living mob, use the clicked atom tile's center for maximum accuracy. Else aim for the clicked pixel. 
-	if(isliving(target))
-		dir_angle = round(Get_Pixel_Angle(((((target.x - 1) * 32) + 16) - apx), ((((target.y - 1) * 32) + 16) - apy))) //Using absolute pixel coordinates.
+	if(isnum(angle))
+		dir_angle = angle
 	else
-		dir_angle = round(Get_Pixel_Angle(((((target.x - 1) * 32) + p_x) - apx), ((((target.y - 1) * 32) + p_y) - apy)))
+		if(isliving(target))
+			dir_angle = round(Get_Pixel_Angle((ABS_COOR(target.x) - apx), (ABS_COOR(target.y) - apy))) //Using absolute pixel coordinates.
+		else
+			dir_angle = round(Get_Pixel_Angle(((((target.x - 1) * 32) + p_x) - apx), ((((target.y - 1) * 32) + p_y) - apy)))
+
 	x_offset = round(sin(dir_angle), 0.01)
 	y_offset = round(cos(dir_angle), 0.01)
 

--- a/code/modules/projectiles/updated_projectiles/projectile.dm
+++ b/code/modules/projectiles/updated_projectiles/projectile.dm
@@ -295,12 +295,8 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 	var/y_pixel_dist_travelled = 0
 	for(var/i in 1 to required_moves)
 		distance_travelled++
-		var/apx_to_check
-		var/apy_to_check
-		apx_to_check = (apx + x_pixel_dist_travelled + (32 * x_offset))
-		apy_to_check = (apy + y_pixel_dist_travelled + (32 * y_offset))
 		//Here we take the projectile's absolute pixel coordinate + the travelled distance and use PROJ_ABS_PIXEL_TO_TURF to first convert it into tile coordinates, and then use those to locate the turf.
-		var/turf/next_turf = PROJ_ABS_PIXEL_TO_TURF(apx_to_check, apy_to_check, z)
+		var/turf/next_turf = PROJ_ABS_PIXEL_TO_TURF((apx + x_pixel_dist_travelled + (32 * x_offset)), (apy + y_pixel_dist_travelled + (32 * y_offset)), z)
 		if(!next_turf) //Map limit.
 			end_of_movement = (i-- || 1)
 			break

--- a/code/modules/projectiles/updated_projectiles/projectile.dm
+++ b/code/modules/projectiles/updated_projectiles/projectile.dm
@@ -1,9 +1,10 @@
-
 //Some debug variables. Toggle them to 1 in order to see the related debug messages. Helpful when testing out formulas.
 #define DEBUG_HIT_CHANCE	0
 #define DEBUG_HUMAN_DEFENSE	0
 #define DEBUG_XENO_DEFENSE	0
 #define DEBUG_CREST_DEFENSE	0
+
+#define PROJ_REQMOVES_FAIL -1
 
 //The actual bullet objects.
 /obj/item/projectile
@@ -14,30 +15,27 @@
 	resistance_flags = UNACIDABLE|INDESTRUCTIBLE
 	anchored = TRUE //You will not have me, space wind!
 	flags_atom = NOINTERACT //No real need for this, but whatever. Maybe this flag will do something useful in the future.
-	mouse_opacity = 0
-	invisibility = 100 // We want this thing to be invisible when it drops on a turf because it will be on the user's turf. We then want to make it visible as it travels.
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	invisibility = INVISIBILITY_MAXIMUM // We want this thing to be invisible when it drops on a turf because it will be on the user's turf. We then want to make it visible as it travels.
 	layer = FLY_LAYER
+	animate_movement = NO_STEPS
 
 	var/datum/ammo/ammo //The ammo data which holds most of the actual info.
 
 	var/def_zone = "chest"	//So we're not getting empty strings.
 
-	var/yo = null
-	var/xo = null
-
 	var/p_x = 16
 	var/p_y = 16 // the pixel location of the tile that the player clicked. Default is the center
+	var/apx //Pixel location in absolute coordinates. This is (((x - 1) * 32) + 16 + pixel_x)
+	var/apy //These values are floats, not integers. They need to be converted through CEILING or such when translated to relative pixel coordinates.
 
-	var/current 		 = null
 	var/atom/shot_from 	 = null // the object which shot us
-	var/atom/original 	 = null // the original target clicked
+	var/turf/starting_turf = null // the projectile's starting turf
+	var/atom/original_target = null // the original target clicked
+	var/turf/original_target_turf = null // the original target's starting turf
 	var/atom/firer 		 = null // Who shot it
 
-	var/turf/target_turf = null
-	var/turf/starting 	 = null // the projectile's starting turf
-
-	var/turf/path[]  	 = null
-	var/permutated[] 	 = null // we've passed through these atoms, don't try to hit them again
+	var/list/permutated = list() // we've passed through these atoms, don't try to hit them again
 
 	var/damage = 0
 	var/accuracy = 85 //Base projectile accuracy. Can maybe be later taken from the mob if desired.
@@ -47,34 +45,40 @@
 	var/scatter = 0
 
 	var/distance_travelled = 0
-	var/in_flight = 0
 
-	var/projectile_speed = 0
+	var/projectile_speed = 1 //Tiles travelled per full tick.
 	var/armor_type = null
 
-/obj/item/projectile/New()
-	. = ..()
-	path = list()
-	permutated = list()
+	//Fired processing vars
+	var/last_projectile_move = 0
+	var/stored_moves = 0
+	var/dir_angle //0 is north, 90 is east, 180 is south, 270 is west. BYOND angles and all.
+	var/x_offset //Float, not integer.
+	var/y_offset
+
+	var/proj_max_range = 30
+
 
 /obj/item/projectile/Destroy()
-	in_flight = 0
+	STOP_PROCESSING(SSprojectiles, src)
 	ammo = null
 	shot_from = null
-	original = null
-	target_turf = null
-	starting = null
+	original_target = null
 	permutated = null
-	path = null
+	original_target_turf = null
+	starting_turf = null
 	return ..()
 
-/obj/item/projectile/Bumped(atom/A as mob|obj|turf|area)
-	if(A && !A in permutated)
-		scan_a_turf(A.loc)
 
-/obj/item/projectile/Crossed(AM as mob|obj)
-	if(AM && !AM in permutated)
-		scan_a_turf(get_turf(AM))
+/obj/item/projectile/Crossed(atom/movable/AM) //A mob moving on a tile with a projectile is hit by it.
+	. = ..()
+	if(AM in permutated) //If we've already handled this atom, don't do it again.
+		return
+	if(AM.projectile_hit(src))
+		AM.do_projectile_hit(src)
+		return
+	permutated += AM //Don't want to hit them again.
+
 
 /obj/item/projectile/effect_smoke(obj/effect/particle_effect/smoke/S)
 	. = ..()
@@ -96,23 +100,128 @@
 	armor_type = ammo.armor_type
 
 //Target, firer, shot from. Ie the gun
-/obj/item/projectile/proc/fire_at(atom/target,atom/F, atom/S, range = 30,speed = 1)
-	projectile_speed += speed
-	if(!original) original = target
-	if(!loc) loc = get_turf(F)
-	starting = get_turf(src)
-	if(starting != loc) loc = starting //Put us on the turf, if we're not.
-	target_turf = get_turf(target)
-	if(!target_turf || target_turf == starting) //This shouldn't happen, but it can.
+/obj/item/projectile/proc/fire_at(atom/target, atom/shooter, atom/source, range, speed)
+	if(!isnull(speed))
+		projectile_speed = speed
+	if(!isnull(range))
+		proj_max_range = range
+	if(!original_target)
+		original_target = target
+
+	// VVVVVVVVVVV
+	if(projectile_speed < 1)
+		CRASH("[src] achieved [projectile_speed] velocity somehow at fire_at. Type: [type]. From: [target]. Shot by: [shooter].")
+
+	if(!shooter) //This was checked for. Let's investigate if it  has a reason to be.
+		qdel(src)
+		CRASH("[src] triggered fire_at without a shooter. target: [target]. source: [source]")
+
+	if(!loc) //This was checked for. Let's investigate if it  has a reason to be.
+		qdel(src)
+		CRASH("[src] triggered fire_at without a loc. target: [target]. shooter: [shooter]. source: [source]")
+	// ^^^^^^^^^^^
+
+	shot_from = source
+	firer = shooter
+	permutated += firer //Don't hit the shooter
+	permutated += src //Don't try to hit self.
+	if(!isturf(loc))
+		forceMove(get_turf(src))
+	starting_turf = loc
+	original_target_turf = get_turf(target)
+
+	// VVVVVVVVVVV
+	if(!original_target_turf) //This shouldn't happen, but it can. //If that's true, then let's fix it.
+		qdel(src)
+		CRASH("[src] triggered fire_at without a original_target_turf. target: [target]. shooter: [shooter]. source: [source]")
+	// ^^^^^^^^^^^
+
+	if(original_target_turf == loc) //Shooting from and towards the same tile. Why not?
+		scan_a_turf(original_target_turf)
 		qdel(src)
 		return
-	firer = F
-	if(F) permutated += F //Don't hit the shooter (firer)
-	permutated += src //Don't try to hit self.
-	shot_from = S
-	in_flight = 1
 
-	setDir(get_dir(loc, target_turf))
+	apx = (((x - 1) * 32) + 16) //Set the absolute coordinates. Center of a tile is assumed to be (16,16)
+	apy = (((y - 1) * 32) + 16)
+
+	//If we clicked on a turf, aim for the clicked pixel. Else use the clicked atom pixel location.
+	if(isturf(target))
+		dir_angle = round(Get_Pixel_Angle(((((target.x - 1) * 32) + p_x) - apx), ((((target.y - 1) * 32) + p_y) - apy))) //Using absolute pixel coordinates.
+	else
+		dir_angle = round(Get_Pixel_Angle(((((target.x - 1) * 32) + 16 + target.pixel_x) - apx), ((((target.y - 1) * 32) + 16 + target.pixel_y) - apy)))
+	x_offset = round(sin(dir_angle), 0.01)
+	y_offset = round(cos(dir_angle), 0.01)
+
+	var/proj_dir
+	switch(dir_angle) //The projectile starts at the edge of the firer's tile.
+		if(0, 360)
+			proj_dir = NORTH
+			pixel_x = 0
+			pixel_y = 16
+		if(1 to 44)
+			proj_dir = NORTHEAST
+			pixel_x = round(16 * ((dir_angle) / 45))
+			pixel_y = 16
+		if(45)
+			proj_dir = NORTHEAST
+			pixel_x = 16
+			pixel_y = 16
+		if(46 to 89)
+			proj_dir = NORTHEAST
+			pixel_x = 16
+			pixel_y = round(16 * ((90 - dir_angle) / 45))
+		if(90)
+			proj_dir = EAST
+			pixel_x = 16
+			pixel_y = 0
+		if(91 to 134)
+			proj_dir = SOUTHEAST
+			pixel_x = 16
+			pixel_y = round(-15 * ((dir_angle - 90) / 45))
+		if(135)
+			proj_dir = SOUTHEAST
+			pixel_x = 16
+			pixel_y = -15
+		if(136 to 179)
+			proj_dir = SOUTHEAST
+			pixel_x = round(16 * ((180 - dir_angle) / 45))
+			pixel_y = -15
+		if(180)
+			proj_dir = SOUTH
+			pixel_x = 0
+			pixel_y = -15
+		if(181 to 224)
+			proj_dir = SOUTHWEST
+			pixel_x = round(-15 * ((dir_angle - 180) / 45))
+			pixel_y = -15
+		if(225)
+			proj_dir = SOUTHWEST
+			pixel_x = -15
+			pixel_y = -15
+		if(226 to 269)
+			proj_dir = SOUTHWEST
+			pixel_x = -15
+			pixel_y = round(-15 * ((270 - dir_angle) / 45))
+		if(270)
+			proj_dir = WEST
+			pixel_x = -15
+			pixel_y = 0
+		if(271 to 314)
+			proj_dir = NORTHWEST
+			pixel_x = -15
+			pixel_y = round(16 * ((dir_angle - 270) / 45))
+		if(315)
+			proj_dir = NORTHWEST
+			pixel_x = -15
+			pixel_y = 16
+		if(316 to 359)
+			proj_dir = NORTHWEST
+			pixel_x = round(-15 * ((360 - dir_angle) / 45))
+			pixel_y = 16
+	setDir(proj_dir)
+
+	apx += pixel_x //Update the absolute pixels with the offset.
+	apy += pixel_y
 
 	GLOB.round_statistics.total_projectiles_fired++
 	if(ammo.flags_ammo_behavior & AMMO_BALLISTIC)
@@ -121,190 +230,229 @@
 			GLOB.round_statistics.total_bullets_fired += ammo.bonus_projectiles_amount
 
 	//If we have the the right kind of ammo, we can fire several projectiles at once.
-	if(ammo.bonus_projectiles_amount && ammo.bonus_projectiles_type) ammo.fire_bonus_projectiles(src)
-
-	path = getline(starting,target_turf)
-
-	var/change_x = target_turf.x - starting.x
-	var/change_y = target_turf.y - starting.y
-
-	var/angle = round(Get_Angle(starting,target_turf))
+	if(ammo.bonus_projectiles_amount && ammo.bonus_projectiles_type)
+		ammo.fire_bonus_projectiles(src)
 
 	var/matrix/rotate = matrix() //Change the bullet angle.
-	rotate.Turn(angle)
-	src.transform = rotate
+	rotate.Turn(dir_angle)
+	transform = rotate
 
-	follow_flightpath(projectile_speed,change_x,change_y,range) //pyew!
+	var/first_moves = projectile_speed
+	if(projectile_batch_move(1)) //Hit on first tile travelled.
+		qdel(src)
+		return
+	invisibility = 0 //Let there be light (visibility).
+	if(--first_moves && projectile_batch_move(first_moves)) //First movement batch happens on the same tick.
+		qdel(src)
+		return
 
-/obj/item/projectile/proc/each_turf(speed = 1)
-	var/new_speed = speed
-	distance_travelled++
-	if(invisibility && distance_travelled > 1) invisibility = 0 //Let there be light (visibility).
-	if(distance_travelled == round(ammo.max_range / 2) && loc) ammo.do_at_half_range(src)
-	if(ammo.flags_ammo_behavior & AMMO_ROCKET) //Just rockets for now. Not all explosive ammo will travel like this.
-		switch(speed) //Get more speed the longer it travels. Travels pretty quick at full swing.
-			if(1)
-				if(distance_travelled > 2) new_speed++
-			if(2)
-				if(distance_travelled > 8) new_speed++
-	return new_speed //Need for speed.
+	START_PROCESSING(SSprojectiles, src) //If no hits on the first moves, enter the processing queue for next.
 
-/obj/item/projectile/proc/follow_flightpath(speed = 1, change_x, change_y, range) //Everytime we reach the end of the turf list, we slap a new one and keep going.
-	set waitfor = 0
 
-	var/dist_since_sleep = 5 //Just so we always see the bullet.
+/obj/item/projectile/process()
+	if(QDELETED(src))
+		return PROCESS_KILL
 
-	var/turf/current_turf = get_turf(src)
-	var/turf/next_turf
-	var/this_iteration = 0
-	in_flight = 1
-	for(next_turf in path)
-		if(!loc || gc_destroyed || !in_flight) return
-
-		if(distance_travelled >= range)
-			ammo.do_at_max_range(src)
+	var/required_moves = required_moves_calc()
+	switch(required_moves)
+		if(0)
+			return //Slowpoke. Maybe next tick.
+		if(-INFINITY to -1)
+			stack_trace("[src] called process with [required_moves] required_moves somehow. Type: [type]. Shot from: [shot_from]. Speed: [projectile_speed].")
 			qdel(src)
-			return
+			return PROCESS_KILL //Error, such as PROJ_REQMOVES_FAIL
 
-		var/proj_dir = get_dir(current_turf, next_turf)
-		if(proj_dir & (proj_dir-1)) //diagonal direction
-			if(!current_turf.Adjacent(next_turf)) //we can't reach the next turf
-				ammo.on_hit_turf(current_turf,src)
-				current_turf.bullet_act(src)
-				in_flight = 0
-				sleep(0)
-				qdel(src)
-				return
+	if(projectile_batch_move(required_moves))
+		qdel(src)
+		return PROCESS_KILL
 
-		if(scan_a_turf(next_turf)) //We hit something! Get out of all of this.
-			in_flight = 0
-			sleep(0)
-			qdel(src)
-			return
 
-		loc = next_turf
-		speed = each_turf(speed)
+/obj/item/projectile/proc/required_moves_calc()
+	if(projectile_speed < 1)
+		return PROJ_REQMOVES_FAIL
 
-		this_iteration++
-		if(++dist_since_sleep >= speed)
-			//TO DO: Adjust flight position every time we see the projectile.
-			//I wonder if I can leave sleep out and just have it stall based on adjustment proc.
-			//Might still be too fast though.
-			dist_since_sleep = 0
-			sleep(1)
+	var/elapsed_time_deciseconds = world.time - last_projectile_move
+	if(!elapsed_time_deciseconds)
+		return 0 //No moves needed if not a tick has passed.
+	var/required_moves = (elapsed_time_deciseconds * projectile_speed) + stored_moves
+	stored_moves = 0
+	var/modulus_excess = MODULUS(required_moves, 1) //Fractions of a move.
+	if(modulus_excess)
+		required_moves -= modulus_excess
+		stored_moves += modulus_excess
+	
+	if(required_moves > SSprojectiles.global_max_tick_moves)
+		stored_moves += required_moves - SSprojectiles.global_max_tick_moves
+		required_moves = SSprojectiles.global_max_tick_moves
 
-		current_turf = get_turf(src)
-		if(this_iteration == path.len)
-			next_turf = locate(current_turf.x + change_x, current_turf.y + change_y, current_turf.z)
-			if(current_turf && next_turf)
-				path = getline(current_turf,next_turf) //Build a new flight path.
-				if(path.len && src) //TODO look into this. This should always be true, but it can fail, apparently, against DCed people who fall down. Better yet, redo this.
-					distance_travelled-- //because the new follow_flightpath() repeats the last step.
-					follow_flightpath(speed, change_x, change_y, range) //Onwards!
+	return required_moves
+
+/*
+CEILING() is used on some contexts:
+1) For absolute pixel locations to tile conversions, as the coordinates are read from left-to-right (from low to high numbers) and each tile occupies 32 pixels. 
+So if we are in the 32th absolute pixel coordinate we are in tile 1, but if we are in the 33th (to 64th) then we are then in the second tile.
+2) For relative pixel coordinates as floats to integers. No special reason, we could use FLOOR()/round() instead and it would tend to offset things a little down instead of up.
+3) For number of pixel moves, as it is counting number of full (pixel) moves required.
+*/
+#define PROJ_ABS_PIXEL_TO_TURF(abspx, abspy, zlevel) (locate(CEILING((abspx / 32), 1), CEILING((abspy / 32), 1), zlevel))
+#define PROJ_ABS_PIXEL_TO_REL(apc) (MODULUS(apc, 32) || 32) //Absolute pixel coordinate to relative. If MODULUS is zero, then we want to return 32, as pixel coordinates within a tile range from 1 to 32.
+#define PROJ_ANIMATION_SPEED ((end_of_movement/projectile_speed) || (required_moves/projectile_speed)) //Movements made times deciseconds per movement.
+
+/obj/item/projectile/proc/projectile_batch_move(required_moves)
+	var/end_of_movement = 0 //In batch moves this loop, only if the projectile stopped.
+	var/turf/last_processed_turf = loc
+	var/x_pixel_dist_travelled = 0
+	var/y_pixel_dist_travelled = 0
+	for(var/i in 1 to required_moves)
+		distance_travelled++
+		var/apx_to_check
+		var/apy_to_check
+		apx_to_check = (apx + x_pixel_dist_travelled + (32 * x_offset))
+		apy_to_check = (apy + y_pixel_dist_travelled + (32 * y_offset))
+		//Here we take the projectile's absolute pixel coordinate + the travelled distance and use PROJ_ABS_PIXEL_TO_TURF to first convert it into tile coordinates, and then use those to locate the turf.
+		var/turf/next_turf = PROJ_ABS_PIXEL_TO_TURF(apx_to_check, apy_to_check, z)
+		if(!next_turf) //Map limit.
+			end_of_movement = i
+			break
+		if(next_turf == last_processed_turf)
+			x_pixel_dist_travelled += 32 * x_offset
+			y_pixel_dist_travelled += 32 * y_offset
+			continue //Pixel movement only, didn't manage to change turf.
+		var/movement_dir = get_dir(last_processed_turf, next_turf)
+		
+		if(ISDIAGONALDIR(movement_dir)) //Diagonal case. We need to check the turf to cross to get there.
+			if(!x_offset || !y_offset) //Unless a coder screws up this won't happen. Buf if they do, it will cause an infinite processing loop due to division by zero so better safe than sorry.
+				stack_trace("projectile_batch_move called with diagonal movement_dir and offset-lacking. x_offset: [x_offset], y_offset: [y_offset].")
+				return TRUE
+			var/turf/turf_crossed_by
+			var/rel_pixel_x_pre = PROJ_ABS_PIXEL_TO_REL(apx + x_pixel_dist_travelled)
+			var/rel_pixel_y_pre = PROJ_ABS_PIXEL_TO_REL(apy + y_pixel_dist_travelled)
+			var/pixel_moves_until_crossing_x_border
+			var/pixel_moves_until_crossing_y_border
+			switch(movement_dir)
+				if(NORTHEAST)
+					pixel_moves_until_crossing_x_border = CEILING(((33 - rel_pixel_x_pre) / x_offset), 1)
+					pixel_moves_until_crossing_y_border = CEILING(((33 - rel_pixel_y_pre) / y_offset), 1)
+					if(pixel_moves_until_crossing_y_border < pixel_moves_until_crossing_x_border) //Escapes through the Y border.
+						turf_crossed_by = get_step(last_processed_turf, NORTH)
+					else if(pixel_moves_until_crossing_x_border < pixel_moves_until_crossing_y_border) //Escapes through the X border.
+						turf_crossed_by = get_step(last_processed_turf, EAST)
+					else //Escapes both borders at the same time, perfectly diagonal.
+						turf_crossed_by = get_step(last_processed_turf, pick(NORTH, EAST)) //So choose at random to avoid quirkiness.
+				if(SOUTHEAST)
+					pixel_moves_until_crossing_x_border = CEILING(((33 - rel_pixel_x_pre) / x_offset), 1)
+					pixel_moves_until_crossing_y_border = CEILING(((0 - rel_pixel_y_pre) / y_offset), 1)
+					if(pixel_moves_until_crossing_y_border < pixel_moves_until_crossing_x_border)
+						turf_crossed_by = get_step(last_processed_turf, SOUTH)
+					else if(pixel_moves_until_crossing_x_border < pixel_moves_until_crossing_y_border)
+						turf_crossed_by = get_step(last_processed_turf, EAST)
+					else
+						turf_crossed_by = get_step(last_processed_turf, pick(SOUTH, EAST))
+				if(SOUTHWEST)
+					pixel_moves_until_crossing_x_border = CEILING(((0 - rel_pixel_x_pre) / x_offset), 1)
+					pixel_moves_until_crossing_y_border = CEILING(((0 - rel_pixel_y_pre) / y_offset), 1)
+					if(pixel_moves_until_crossing_y_border < pixel_moves_until_crossing_x_border)
+						turf_crossed_by = get_step(last_processed_turf, SOUTH)
+					else if(pixel_moves_until_crossing_x_border < pixel_moves_until_crossing_y_border)
+						turf_crossed_by = get_step(last_processed_turf, WEST)
+					else
+						turf_crossed_by = get_step(last_processed_turf, pick(SOUTH, WEST))
+				if(NORTHWEST)
+					pixel_moves_until_crossing_x_border = CEILING(((0 - rel_pixel_x_pre) / x_offset), 1)
+					pixel_moves_until_crossing_y_border = CEILING(((33 - rel_pixel_y_pre) / y_offset), 1)
+					if(pixel_moves_until_crossing_y_border < pixel_moves_until_crossing_x_border)
+						turf_crossed_by = get_step(last_processed_turf, NORTH)
+					else if(pixel_moves_until_crossing_x_border < pixel_moves_until_crossing_y_border)
+						turf_crossed_by = get_step(last_processed_turf, WEST)
+					else
+						turf_crossed_by = get_step(last_processed_turf, pick(NORTH, WEST))
+			if(scan_a_turf(turf_crossed_by))
+				last_processed_turf = turf_crossed_by
+				if(pixel_moves_until_crossing_x_border <= pixel_moves_until_crossing_y_border) //Escapes through X or pure diagonal.
+					x_pixel_dist_travelled += pixel_moves_until_crossing_x_border * x_offset
+					y_pixel_dist_travelled += pixel_moves_until_crossing_x_border * y_offset
 				else
-					qdel(src)
-					return
-			else //To prevent bullets from getting stuck in maps like WO.
-				qdel(src)
-				return
+					x_pixel_dist_travelled += pixel_moves_until_crossing_y_border * x_offset
+					y_pixel_dist_travelled += pixel_moves_until_crossing_y_border * y_offset
+				end_of_movement = i
+				break
+		last_processed_turf = next_turf
+		x_pixel_dist_travelled += 32 * x_offset
+		y_pixel_dist_travelled += 32 * y_offset
+		if(next_turf == original_target_turf && ammo.flags_ammo_behavior & AMMO_EXPLOSIVE)
+			ammo.on_hit_turf(next_turf, src)
+			next_turf.bullet_act(src)
+			end_of_movement = i
+			break
+		if(scan_a_turf(next_turf))
+			end_of_movement = i
+			break
+		if(distance_travelled >= proj_max_range)
+			ammo.do_at_max_range(src)
+			end_of_movement = i
+			break
 
-/obj/item/projectile/proc/scan_a_turf(turf/T)
-	// Not a turf, keep moving
-	if(!istype(T))
-		return FALSE
-
-	if(T.density) // Handle wall hit
-		ammo.on_hit_turf(T,src)
-
-		if(T?.loc)
-			T.bullet_act(src)
-
+	if(last_processed_turf == loc && end_of_movement)
+		last_projectile_move = world.time
 		return TRUE
 
-	// Firer's turf, keep moving
-	if(firer && T == firer.loc)
-		return FALSE
+	apx += x_pixel_dist_travelled
+	apy += y_pixel_dist_travelled
 
-	// Explosive ammo always explodes on the turf of the clicked target
-	if(!QDELETED(src) && ammo.flags_ammo_behavior & AMMO_EXPLOSIVE && T == target_turf)
-		ammo.on_hit_turf(T,src)
-		if(T?.loc)
-			T.bullet_act(src)
+	var/new_pixel_x = PROJ_ABS_PIXEL_TO_REL(apx) //The final pixel offset after this movement. Float value.
+	var/new_pixel_y = PROJ_ABS_PIXEL_TO_REL(apy)
+	if(projectile_speed >= 4) //At this speed the projectile is not even a blur. Changing the var through animation alone takes almost 5 times the CPU than setting them directly. No need for that if there's nothing to show for it.
+		pixel_x = CEILING(new_pixel_x, 1) - 16
+		pixel_y = CEILING(new_pixel_y, 1) - 16
+		forceMove(last_processed_turf)
+	else //Pixel shifts during the animation, which happens after the fact has happened. Light travels slowly here...
+		animate(src, flags = ANIMATION_END_NOW) //End old animation if any.
+		var/old_pixel_x = new_pixel_x - x_pixel_dist_travelled //The pixel offset relative to the new position of where we came from. Float value.
+		var/old_pixel_y = new_pixel_y - y_pixel_dist_travelled
+		pixel_x = CEILING(old_pixel_x, 1) - 16 //Projectile's sprite is displaced back to where it came from through relative pixel offset. Integer value.
+		pixel_y = CEILING(old_pixel_y, 1) - 16 //We substract 16 because this value should range from 1 to 32, but pixel offset usually ranges within the same tile from -15 to 16 (depending on the sprite).
+		forceMove(last_processed_turf)
+		animate(src, pixel_x = (CEILING(new_pixel_x, 1) - 16), pixel_y = (CEILING(new_pixel_y, 1) - 16), time = PROJ_ANIMATION_SPEED) //Then we represent the movement through the animation, which updates the position to the new and correct one.
+
+	last_projectile_move = world.time
+	if(end_of_movement) //We hit something ...probably!
+		return TRUE
+	return FALSE //No hits ...yet!
+
+#undef PROJ_ABS_PIXEL_TO_TURF
+#undef PROJ_ABS_PIXEL_TO_REL
+#undef PROJ_ANIMATION_SPEED
+
+
+/obj/item/projectile/proc/scan_a_turf(turf/turf_to_scan)
+	if(turf_to_scan.density) //Handle wall hit.
+		ammo.on_hit_turf(turf_to_scan, src)
+		turf_to_scan.bullet_act(src)
 		return TRUE
 
-	// Empty turf, keep moving
-	if(!length(T.contents))
-		return FALSE
+	if(shot_from)
+		switch(SEND_SIGNAL(shot_from, COMSIG_PROJ_SCANTURF, turf_to_scan))
+			if(COMPONENT_PROJ_SCANTURF_TURFCLEAR)
+				return FALSE
+			if(COMPONENT_PROJ_SCANTURF_TARGETFOUND)
+				original_target.do_projectile_hit(src)
+				return TRUE
 
-	for(var/a in T)
-		var/atom/movable/A = a
-		// If we've already handled this atom, don't do it again
-		if(A in permutated)
+	for(var/i in turf_to_scan)
+		if(i in permutated) //If we've already handled this atom, don't do it again.
+			continue
+		permutated += i //Don't want to hit them again, no matter what the outcome.
+
+		var/atom/movable/thing_to_hit = i
+
+		if(!thing_to_hit.projectile_hit(src)) //Calculated from combination of both ammo accuracy and gun accuracy.
 			continue
 
-		permutated += A // Don't want to hit them again, no matter what the outcome
+		thing_to_hit.do_projectile_hit(src)
+		return TRUE
 
-		var/hit_chance = A.get_projectile_hit_chance(src) // Calculated from combination of both ammo accuracy and gun accuracy
+	return FALSE
 
-		if(!hit_chance)
-			continue
-
-		if(isobj(A))
-			ammo.on_hit_obj(A,src)
-			if(A?.loc)
-				A.bullet_act(src)
-			return TRUE
-
-		if(!isliving(A))
-			continue
-
-		if(shot_from?.sniper_target(A) && A != shot_from.sniper_target(A)) //First check to see if we've actually got anyone targeted; If we've singled out someone with a targeting laser, forsake all others
-			continue
-		var/mob_is_hit = FALSE
-		var/mob/living/L = A
-
-		var/hit_roll
-		var/critical_miss = rand(CONFIG_GET(number/combat_define/critical_chance_low), CONFIG_GET(number/combat_define/critical_chance_high))
-		var/i = 0
-		while(++i <= 2 && hit_chance > 0) // This runs twice if necessary
-			hit_roll 					= rand(0, 99) //Our randomly generated roll
-			#if DEBUG_HIT_CHANCE
-			to_chat(world, "DEBUG: Hit Chance 1: [hit_chance], Hit Roll: [hit_roll]")
-			#endif
-			if(hit_roll < 25) //Sniper targets more likely to hit
-				if(shot_from && !shot_from.sniper_target(A) || !shot_from) //Avoid sentry run times
-					def_zone = pick(GLOB.base_miss_chance)	// Still hit but now we might hit the wrong body part
-
-			if(shot_from && !shot_from.sniper_target(A)) //Avoid sentry run times
-				hit_chance -= GLOB.base_miss_chance[def_zone] // Reduce accuracy based on spot.
-				#if DEBUG_HIT_CHANCE
-				to_chat(world, "Hit Chance 2: [hit_chance]")
-				#endif
-
-			switch(i)
-				if(1)
-					if(hit_chance > hit_roll)
-						mob_is_hit = TRUE
-						break //Hit
-					if( hit_chance < (hit_roll - 20) )
-						break //Outright miss.
-					def_zone 	  = pick(GLOB.base_miss_chance) //We're going to pick a new target and let this run one more time.
-					hit_chance   -= 10 //If you missed once, the next go around will be harder to hit.
-				if(2)
-					if(prob(critical_miss) )
-						break //Critical miss on the second go around.
-					if(hit_chance > hit_roll)
-						mob_is_hit = TRUE
-						break
-		if(mob_is_hit)
-			ammo.on_hit_mob(L,src)
-			if(L?.loc)
-				L.bullet_act(src)
-			return TRUE
-		else if (!L.lying)
-			animatation_displace_reset(L)
-			if(ammo.sound_miss) L.playsound_local(get_turf(L), ammo.sound_miss, 75, 1)
-			L.visible_message("<span class='avoidharm'>[src] misses [L]!</span>","<span class='avoidharm'>[src] narrowly misses you!</span>", null, 4)
 
 //----------------------------------------------------------
 			//				    	\\
@@ -315,142 +463,172 @@
 
 
 //returns probability for the projectile to hit us.
-/atom/movable/proc/get_projectile_hit_chance(obj/item/projectile/P)
-	return 0
+/atom/proc/projectile_hit(obj/item/projectile/proj)
+	return FALSE
 
-//obj version just returns true or false.
-/obj/get_projectile_hit_chance(obj/item/projectile/P)
+/atom/proc/do_projectile_hit(obj/item/projectile/proj)
+	return
+
+
+/obj/projectile_hit(obj/item/projectile/proj)
 	if(!density)
 		return FALSE
-
-	if(layer >= OBJ_LAYER || src == P.original)
+	if(layer >= OBJ_LAYER || src == proj.original_target)
 		return TRUE
+	return FALSE
 
-/obj/structure/get_projectile_hit_chance(obj/item/projectile/P)
+/obj/do_projectile_hit(obj/item/projectile/proj)
+	proj.ammo.on_hit_obj(src, proj)
+	bullet_act(proj)
+
+
+/obj/structure/projectile_hit(obj/item/projectile/proj)
 	if(!density) //structure is passable
 		return FALSE
-
-	if(src == P.original) //clicking on the structure itself hits the structure
+	if(src == proj.original_target) //clicking on the structure itself hits the structure
 		return TRUE
-
 	if(!anchored) //unanchored structure offers no protection.
 		return FALSE
-
 	if(!throwpass)
 		return TRUE
-
-	if(P.ammo.flags_ammo_behavior & AMMO_SNIPER || P.ammo.flags_ammo_behavior & AMMO_SKIPS_HUMANS || P.ammo.flags_ammo_behavior & AMMO_ROCKET) //sniper, rockets and IFF rounds bypass cover
+	if(proj.ammo.flags_ammo_behavior & AMMO_SNIPER || proj.ammo.flags_ammo_behavior & AMMO_SKIPS_HUMANS || proj.ammo.flags_ammo_behavior & AMMO_ROCKET) //sniper, rockets and IFF rounds bypass cover
 		return FALSE
-
 	if(!(flags_atom & ON_BORDER))
 		return FALSE //window frames, unflipped tables
-
-	if(!( P.dir & reverse_direction(dir) || P.dir & dir))
+	if(!(proj.dir & dir|REVERSE_DIR(dir)))
 		return FALSE //no effect if bullet direction is perpendicular to barricade
-
-	var/distance = P.distance_travelled - 1
-	if(distance < P.ammo.barricade_clear_distance)
+	var/distance = proj.distance_travelled - 1
+	if(distance < proj.ammo.barricade_clear_distance)
 		return FALSE
-
 	var/coverage = 90 //maximum probability of blocking projectile
 	var/distance_limit = 6 //number of tiles needed to max out block probability
 	var/accuracy_factor = 50 //degree to which accuracy affects probability   (if accuracy is 100, probability is unaffected. Lower accuracies will increase block chance)
-
-	var/hitchance = min(coverage, (coverage * distance/distance_limit) + accuracy_factor * (1 - P.accuracy/100))
-	//to_chat(world, "Distance travelled: [distance]  |  Accuracy: [P.accuracy]  |  Hit chance: [hitchance]")
+	var/hitchance = min(coverage, (coverage * distance/distance_limit) + accuracy_factor * (1 - proj.accuracy/100))
 	return prob(hitchance)
 
-/obj/structure/window/get_projectile_hit_chance(obj/item/projectile/P)
-	if(P.ammo.flags_ammo_behavior & AMMO_ENERGY || ( (flags_atom & ON_BORDER) && P.dir != dir && P.dir != reverse_direction(dir) ) )
+
+/obj/structure/window/projectile_hit(obj/item/projectile/proj)
+	if(proj.ammo.flags_ammo_behavior & AMMO_ENERGY || ((flags_atom & ON_BORDER) && !(proj.dir & dir|REVERSE_DIR(dir))))
 		return FALSE
-	else
-		return TRUE
+	return TRUE
 
-/obj/machinery/door/poddoor/railing/get_projectile_hit_chance(obj/item/projectile/P)
-	return src == P.original
 
-/obj/effect/alien/egg/get_projectile_hit_chance(obj/item/projectile/P)
-	return src == P.original
+/obj/machinery/door/poddoor/railing/projectile_hit(obj/item/projectile/proj)
+	return src == proj.original_target
 
-/obj/effect/alien/resin/trap/get_projectile_hit_chance(obj/item/projectile/P)
-	return src == P.original
+/obj/effect/alien/egg/projectile_hit(obj/item/projectile/proj)
+	return src == proj.original_target
 
-/obj/item/clothing/mask/facehugger/get_projectile_hit_chance(obj/item/projectile/P)
-	return src == P.original
+/obj/effect/alien/resin/trap/projectile_hit(obj/item/projectile/proj)
+	return src == proj.original_target
 
-/mob/living/get_projectile_hit_chance(obj/item/projectile/P)
+/obj/item/clothing/mask/facehugger/projectile_hit(obj/item/projectile/proj)
+	return src == proj.original_target
 
-	if(lying && src != P.original)
-		return 0
 
-	if(P.ammo.flags_ammo_behavior & (AMMO_XENO_ACID|AMMO_XENO_TOX))
-		if(isnestedhost(src) || stat == DEAD)
-			return FALSE
-
-	. = P.accuracy //We want a temporary variable so accuracy doesn't change every time the bullet misses.
+/mob/living/projectile_hit(obj/item/projectile/proj)
+	if(lying && src != proj.original_target)
+		return FALSE
+	if(proj.ammo.flags_ammo_behavior & (AMMO_XENO_ACID|AMMO_XENO_TOX) && (isnestedhost(src) || stat == DEAD))
+		return FALSE
+	. += proj.accuracy //We want a temporary variable so accuracy doesn't change every time the bullet misses.
 	#if DEBUG_HIT_CHANCE
 	to_chat(world, "<span class='debuginfo'>Base accuracy is <b>[P.accuracy]; scatter:[P.scatter]; distance:[P.distance_travelled]</b></span>")
 	#endif
 
-	if (P.distance_travelled <= P.ammo.accurate_range + rand(0, 2))
-	// If bullet stays within max accurate range + random variance
-		if (P.distance_travelled <= P.ammo.point_blank_range)
-			//If bullet within point blank range, big accuracy buff
+	if(proj.distance_travelled <= proj.ammo.accurate_range) //If bullet stays within max accurate range + random variance.
+		if(proj.distance_travelled <= proj.ammo.point_blank_range) //If bullet within point blank range, big accuracy buff.
 			. += 25
-		else if ((P.ammo.flags_ammo_behavior & AMMO_SNIPER) && P.distance_travelled <= P.ammo.accurate_range_min)
-			// Snipers have accuracy falloff at closer range before point blank
-			. -= (P.ammo.accurate_range_min - P.distance_travelled) * 5
+		else if((proj.ammo.flags_ammo_behavior & AMMO_SNIPER) && proj.distance_travelled <= proj.ammo.accurate_range_min) //Snipers have accuracy falloff at closer range before point blank
+			. -= (proj.ammo.accurate_range_min - proj.distance_travelled) * 5
 	else
-		. -= (P.ammo.flags_ammo_behavior & AMMO_SNIPER) ? (P.distance_travelled * 3) : (P.distance_travelled * 5)
-		// Snipers have a smaller falloff constant due to longer max range
-
+		. -= (proj.ammo.flags_ammo_behavior & AMMO_SNIPER) ? (proj.distance_travelled * 3) : (proj.distance_travelled * 5) //Snipers have a smaller falloff constant due to longer max range
 
 	#if DEBUG_HIT_CHANCE
 	to_chat(world, "<span class='debuginfo'>Final accuracy is <b>[.]</b></span>")
 	#endif
 
 	. = max(5, .) //default hit chance is at least 5%.
-	if(lying && stat) . += 15 //Bonus hit against unconscious people.
+	if(lying && stat == UNCONSCIOUS)
+		. += 15 //Bonus hit against unconscious people.
 
-	if(isliving(P.firer))
-		var/mob/living/shooter_living = P.firer
-		if( !can_see(shooter_living,src) )
+	if(isliving(proj.firer))
+		var/mob/living/shooter_living = proj.firer
+		if(!can_see(shooter_living, src, world.view))
 			. -= 15 //Can't see the target (Opaque thing between shooter and target)
-		if(shooter_living.last_move_intent < world.time - 20) //We get a nice accuracy bonus for standing still.
+		if(shooter_living.last_move_intent < world.time - 2 SECONDS) //We get a nice accuracy bonus for standing still.
 			. += 15
 		else if(shooter_living.m_intent == MOVE_INTENT_WALK) //We get a decent accuracy bonus for walking
 			. += 10
+		if(ishuman(proj.firer))
+			var/mob/living/carbon/human/shooter_human = shooter_living
+			. -= round(max(30,(shooter_human.traumatic_shock) * 0.2)) //Chance to hit declines with pain, being reduced by 0.2% per point of pain.
+			if(shooter_human.stagger)
+				. -= 30 //Being staggered fucks your aim.
+			if(shooter_human.marksman_aura) //Accuracy bonus from active focus order: flat bonus + bonus per tile traveled
+				. += shooter_human.marksman_aura * CONFIG_GET(number/combat_define/focus_base_bonus)
+				. += proj.distance_travelled * shooter_human.marksman_aura * CONFIG_GET(number/combat_define/focus_per_tile_bonus)
 
-	if(ishuman(P.firer))
-		var/mob/living/carbon/human/shooter_human = P.firer
-		. -= round(max(30,(shooter_human.traumatic_shock) * 0.2)) //Chance to hit declines with pain, being reduced by 0.2% per point of pain.
-		if(shooter_human.stagger)
-			. -= 30 //Being staggered fucks your aim.
-		if(shooter_human.marksman_aura) // Accuracy bonus from active focus order: flat bonus + bonus per tile traveled
-			. += shooter_human.marksman_aura * CONFIG_GET(number/combat_define/focus_base_bonus)
-			. += P.distance_travelled * shooter_human.marksman_aura * CONFIG_GET(number/combat_define/focus_per_tile_bonus)
+	. -= GLOB.base_miss_chance[proj.def_zone] //Reduce accuracy based on spot.
+
+	if(. <= 0) //If by now the sum is zero or negative, we won't be hitting at all.
+		return FALSE
+
+	var/hit_roll = rand(0, 99) //Our randomly generated roll
+
+	if(. > hit_roll) //Hit
+		return TRUE
+	
+	if((hit_roll - .) < 25) //Small difference, one more chance on a random bodypart, with penalties.
+		var/new_def_zone = pick(GLOB.base_miss_chance)
+		. -= GLOB.base_miss_chance[new_def_zone]
+		if(prob(.))
+			proj.def_zone = new_def_zone
+			return TRUE 
+
+	if(!lying) //Narrow miss!
+		animatation_displace_reset(src)
+		if(proj.ammo.sound_miss)
+			playsound_local(get_turf(src), proj.ammo.sound_miss, 75, 1)
+		on_dodged_bullet(proj)
+
+	return FALSE
 
 
-/mob/living/carbon/human/get_projectile_hit_chance(obj/item/projectile/P)
-	. = ..()
-	if(.)
-		if(P.ammo.flags_ammo_behavior & AMMO_SKIPS_HUMANS && get_target_lock(P.ammo.iff_signal))
-			return 0
-		if(mobility_aura)
-			. -= mobility_aura * 5
-		var/mob/living/carbon/human/shooter_human = P.firer
-		if(istype(shooter_human))
-			if(shooter_human.faction == faction || m_intent == MOVE_INTENT_WALK)
-				. -= 15
+/mob/living/proc/on_dodged_bullet(obj/item/projectile/proj)
+		visible_message("<span class='avoidharm'>[proj] misses [src]!</span>", 
+		"<span class='avoidharm'>[src] narrowly misses you!</span>", null, 4)
+
+/mob/living/carbon/xenomorph/on_dodged_bullet(obj/item/projectile/proj)
+		visible_message("<span class='avoidharm'>[proj] misses [src]!</span>", 
+		"<span class='avoidharm'>[src] narrowly misses us!</span>", null, 4)
 
 
-/mob/living/carbon/xenomorph/get_projectile_hit_chance(obj/item/projectile/P)
-	. = ..()
-	if(.)
-		if(P.ammo.flags_ammo_behavior & AMMO_SKIPS_ALIENS)
-			return 0
-		if(mob_size == MOB_SIZE_BIG)	. += 10
-		else							. -= 10
+/mob/living/do_projectile_hit(obj/item/projectile/proj)
+	proj.ammo.on_hit_mob(src, proj)
+	bullet_act(proj)
+
+
+/mob/living/carbon/human/projectile_hit(obj/item/projectile/proj)
+	if(proj.ammo.flags_ammo_behavior & AMMO_SKIPS_HUMANS && get_target_lock(proj.ammo.iff_signal))
+		return FALSE
+	if(mobility_aura)
+		. -= mobility_aura * 5
+	if(ishuman(proj.firer))
+		var/mob/living/carbon/human/shooter_human = proj.firer
+		if(shooter_human.faction == faction || m_intent == MOVE_INTENT_WALK)
+			. -= 15
+	return ..()
+
+
+/mob/living/carbon/xenomorph/projectile_hit(obj/item/projectile/proj)
+	if(proj.ammo.flags_ammo_behavior & AMMO_SKIPS_ALIENS)
+		return FALSE
+	if(mob_size == MOB_SIZE_BIG)
+		. += 10
+	else
+		. -= 10
+	return ..()
 
 
 /obj/item/projectile/proc/play_damage_effect(mob/M)
@@ -700,25 +878,23 @@ Normal range for a defender's bullet resist should be something around 30-50. ~N
 
 	return 1
 
-/turf/bullet_act(obj/item/projectile/P)
-	if(!P || !density) return //It's just an empty turf
+/turf/bullet_act(obj/item/projectile/proj)
+	bullet_ping(proj)
 
-	bullet_ping(P)
+	var/list/livings_list = list() //Let's built a list of mobs on the bullet turf and grab one.
+	for(var/mob/living/L in src)
+		if(L in proj.permutated)
+			continue
+		livings_list += L
 
-	var/turf/target_turf = P.loc
-	if(!istype(target_turf)) return //The bullet's not on a turf somehow.
+	if(!length(livings_list))
+		return TRUE
 
-	var/list/mobs_list = list() //Let's built a list of mobs on the bullet turf and grab one.
-	for(var/mob/living/L in target_turf)
-		if(L in P.permutated) continue
-		mobs_list += L
+	var/mob/living/picked_mob = pick(livings_list)
+	if(proj.projectile_hit(picked_mob))
+		picked_mob.bullet_act(proj)
+	return TRUE
 
-	if(mobs_list.len)
-		var/mob/living/picked_mob = pick(mobs_list) //Hit a mob, if there is one.
-		if(istype(picked_mob) && P.firer && prob(P.get_projectile_hit_chance(P.firer,picked_mob)))
-			picked_mob.bullet_act(P)
-			return 1
-	return 1
 
 // walls can get shot and damaged, but bullets (vs energy guns) do much less.
 /turf/closed/wall/bullet_act(obj/item/projectile/P)
@@ -824,3 +1000,4 @@ Normal range for a defender's bullet resist should be something around 30-50. ~N
 #undef DEBUG_HIT_CHANCE
 #undef DEBUG_HUMAN_DEFENSE
 #undef DEBUG_XENO_DEFENSE
+#undef PROJ_REQMOVES_FAIL

--- a/code/modules/projectiles/updated_projectiles/projectile.dm
+++ b/code/modules/projectiles/updated_projectiles/projectile.dm
@@ -543,7 +543,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 	#endif
 
 	. = max(5, .) //default hit chance is at least 5%.
-	if(lying && stat == UNCONSCIOUS)
+	if(lying && stat != CONSCIOUS)
 		. += 15 //Bonus hit against unconscious people.
 
 	if(isliving(proj.firer))

--- a/code/modules/projectiles/updated_projectiles/projectile.dm
+++ b/code/modules/projectiles/updated_projectiles/projectile.dm
@@ -142,7 +142,7 @@
 		if(isliving(target)) //If we clicked on a living mob, use the clicked atom tile's center for maximum accuracy. Else aim for the clicked pixel. 
 			dir_angle = round(Get_Pixel_Angle((ABS_COOR(target.x) - apx), (ABS_COOR(target.y) - apy))) //Using absolute pixel coordinates.
 		else
-			dir_angle = round(Get_Pixel_Angle(((((target.x - 1) * 32) + p_x) - apx), ((((target.y - 1) * 32) + p_y) - apy)))
+			dir_angle = round(Get_Pixel_Angle((ABS_COOR_OFFSET(target.x, p_x) - apx), (ABS_COOR_OFFSET(target.y, p_y) - apy)))
 
 	x_offset = round(sin(dir_angle), 0.01)
 	y_offset = round(cos(dir_angle), 0.01)
@@ -283,7 +283,6 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 2) For number of pixel moves, as it is counting number of full (pixel) moves required.
 */
 #define PROJ_ABS_PIXEL_TO_TURF(abspx, abspy, zlevel) (locate(CEILING((abspx / 32), 1), CEILING((abspy / 32), 1), zlevel))
-#define PROJ_ABS_PIXEL_TO_REL(apc) (MODULUS(apc, 32) || 32) //Absolute pixel coordinate to relative. If MODULUS is zero, then we want to return 32, as pixel coordinates range from 1 to 32 within a tile.
 #define PROJ_ANIMATION_SPEED ((end_of_movement/projectile_speed) || (required_moves/projectile_speed)) //Movements made times deciseconds per movement.
 
 /obj/item/projectile/proc/projectile_batch_move(required_moves)
@@ -309,8 +308,8 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 				stack_trace("projectile_batch_move called with diagonal movement_dir and offset-lacking. x_offset: [x_offset], y_offset: [y_offset].")
 				return TRUE
 			var/turf/turf_crossed_by
-			var/rel_pixel_x_pre = PROJ_ABS_PIXEL_TO_REL(apx + x_pixel_dist_travelled)
-			var/rel_pixel_y_pre = PROJ_ABS_PIXEL_TO_REL(apy + y_pixel_dist_travelled)
+			var/rel_pixel_x_pre = ABS_PIXEL_TO_REL(apx + x_pixel_dist_travelled)
+			var/rel_pixel_y_pre = ABS_PIXEL_TO_REL(apy + y_pixel_dist_travelled)
 			var/pixel_moves_until_crossing_x_border
 			var/pixel_moves_until_crossing_y_border
 			switch(movement_dir)
@@ -395,8 +394,8 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 	apx += x_pixel_dist_travelled
 	apy += y_pixel_dist_travelled
 
-	var/new_pixel_x = PROJ_ABS_PIXEL_TO_REL(apx) //The final pixel offset after this movement. Float value.
-	var/new_pixel_y = PROJ_ABS_PIXEL_TO_REL(apy)
+	var/new_pixel_x = ABS_PIXEL_TO_REL(apx) //The final pixel offset after this movement. Float value.
+	var/new_pixel_y = ABS_PIXEL_TO_REL(apy)
 	if(projectile_speed > 5) //At this speed the animation barely shows. Changing the vars through animation alone takes almost 5 times the CPU than setting them directly. No need for that if there's nothing to show for it.
 		pixel_x = round(new_pixel_x, 1) - 16
 		pixel_y = round(new_pixel_y, 1) - 16
@@ -416,7 +415,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 	return FALSE //No hits ...yet!
 
 #undef PROJ_ABS_PIXEL_TO_TURF
-#undef PROJ_ABS_PIXEL_TO_REL
+#undef ABS_PIXEL_TO_REL
 #undef PROJ_ANIMATION_SPEED
 
 

--- a/code/modules/vehicles/multitile/cm_armored.dm
+++ b/code/modules/vehicles/multitile/cm_armored.dm
@@ -472,8 +472,8 @@ GLOBAL_LIST_INIT(armorvic_dmg_distributions, list(
 			M.tank_collision(src)
 
 //Can't hit yourself with your own bullet
-/obj/vehicle/multitile/hitbox/cm_armored/get_projectile_hit_chance(obj/item/projectile/P)
-	if(P.firer == root) //Don't hit our own hitboxes
+/obj/vehicle/multitile/hitbox/cm_armored/projectile_hit(obj/item/projectile/proj)
+	if(proj.firer == root) //Don't hit our own hitboxes
 		return FALSE
 
 	return ..()
@@ -531,8 +531,8 @@ GLOBAL_LIST_INIT(armorvic_dmg_distributions, list(
 	else
 		log_attack("[src] took [damage] [type] damage from [attacker].")
 
-/obj/vehicle/multitile/root/cm_armored/get_projectile_hit_chance(obj/item/projectile/P)
-	if(P.firer == src) //Don't hit ourself.
+/obj/vehicle/multitile/root/cm_armored/projectile_hit(obj/item/projectile/proj)
+	if(proj.firer == src) //Don't hit ourself.
 		return FALSE
 
 	return ..()

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -32,6 +32,7 @@
 #include "code\__DEFINES\configuration.dm"
 #include "code\__DEFINES\conflict.dm"
 #include "code\__DEFINES\construction.dm"
+#include "code\__DEFINES\coordinates.dm"
 #include "code\__DEFINES\equipment.dm"
 #include "code\__DEFINES\flags.dm"
 #include "code\__DEFINES\is_helpers.dm"

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -190,6 +190,7 @@
 #include "code\controllers\subsystem\processing\fastprocess.dm"
 #include "code\controllers\subsystem\processing\obj.dm"
 #include "code\controllers\subsystem\processing\processing.dm"
+#include "code\controllers\subsystem\processing\projectiles.dm"
 #include "code\datums\armor.dm"
 #include "code\datums\atom_hud.dm"
 #include "code\datums\browser.dm"


### PR DESCRIPTION
## About The Pull Request

* Projectiles now process through a subsystem.
* Their interaction is still tile-based (they will scan any tile they enter for possible collision with their contents), but movement is calculated through a pixel-based line, which makes it a bit more accurate.
* Their movement is animated for speeds up to 4. For that and over the animation is a bit too fast, so they look the same as current ones, but the flicks seen are on a correct pixel offset instead of in the middle of the tile. It shouldn't be too expensive to increase this, but over 6 it's just fails to bring any benefit.
* ~~Because these are intended to be kept cheap the animation is called only on batch moves, which makes them look janky at speeds under 2, unlike /tg/ projectiles. They are _much_ cheaper, though. And they still look much less janky than old CM projectiles at the same speed.~~ They look pretty good.
* Chance to hit living mobs was oddly divided into `scan_a_turf()` and `get_projectile_hit_chance()`. Cleared it up and unified it into `projectile_hit()`, leaving the effects of the hit in case the former succeeds for `do_projectile_hit()` (which was meshed up in `scan_a_turf()` before).
*  Did small tweaks on accuracy/hit chance, and a small rework on the sniper laser targeting, incidentally.
* `fire_at()` now allows for shooting towards the same tile, so there's no need to be super snowflakey on pointblanking.
* There is now support for super slow projectiles. Under 0.2 movement may get a bit stuttery, but it works. There are optimizations to be made if that speeds under 1 start being used.
* Removes the shell speed configs. The plan is to move in that direction and remove the obscurity those configs create. They have are no longer really useful.
* muzzle_flash is aligned to use the same angle as the fired shot, plus using visual contents for better performance (at some memory cost, each gun having a movable atom associated).

## Changelog
:cl:
add: Reworked projectiles to use pixel movement (but not collisions, those are still tile-based), tracking the clicked pixel (unless a mob is clicked, in which case it will aim for the center of the target's tile for maximum accuracy, or unless scatter happens) in a straight line. For most bullets (rifles, SMGs, pistols, revolvers) the difference will be subtle at best, given how fast they are. It is more noticeable in tasers. For lasguns and faster projectiles the moving animation is outright disabled.
fix: Fixed a speed inconsistency of old projectiles, which would make bullet speed lower if you clicked closer to your own sprite.
balance: Tweaked accuracy to make the calculations a bit more sane. This may impact on it as reproducing the exact same behavior is hard, but it can be more easily adjusted now.
balance: Once a sniper acquires a target through its laser market it will no longer need to click on it to aim it. Any shots while active will be auto-targeted to it.
balance: Projectile speeds reduced all round the board. Xeno projectiles are slow, so you can see them traveling. Non-slug shotgun shells are slow and more visible. Slugs and regular bullets are fast, and hard to see. Sniper bullets and lasers are very fast, and even harder to see.
balance: Scatter is now angle-based, so it doesn't matter if the target (where you click) is near or far. Maximum scatter is 45 degrees in either direction. Extra projectiles (additional buckshot and flechettes) have a smoother, less random scatter, firing in a cone.
/:cl:

Short range pixel shot, using values taken from testing, position adjusted:
![firefox_jXKIytPgPU](https://user-images.githubusercontent.com/42041276/63131560-893c3480-bf94-11e9-98f5-75e6c855e4a5.png)
```
X1: 5857
Y1: 1569
X2: 5828.2
Y2: 1554.92
X3: 5799.4
Y3: 1540.84
X4: 5770.6
Y4: 1526.76
```
Shot is from the upper-right point towards the bottom-left one.
Animation is called three times, from P1 to P2, from P2 to P3 and from P3 to P4.
In tile coordinates, the shot is fired from (4, 3), scans (3,3), (3, 2), (2, 2) and (2, 1) before finally colliding at (1, 1). Namely all the turfs it crosses.
If the shot is perfectly diagonal it will choose an appropriate cardinal tile to cross at random, to preserve behavior of no fully diagonal move allowed.

~~Despite the math seems sound, slow-moving projectiles still look janky. I assume it's an issue on the times pixel offset and loc are updated visually.
This could be easily fixed by going the /tg/ way and updating them more often, in smaller time frames, but the idea here is to keep it cheap.
Their projectiles have a speed of 1.25 by default (lasers, bullets, energy projectiles) in our measurement (tiles traveled per tick/decisecond), while our rifle bullets have speed 5, lasgun lasers 6, and tasers 2. If we don't count attachment modifiers.
Because of that, and because shooting is much less common than for us, their system is more focused towards smoothness and ours towards performance.
If /tg/ projectiles were fast as ours their cost would be prohibitive. If old CM projectiles were as slow as /tg/'s they'd look terrible. This allows us to slowdown projectiles a bit if needed, but not to the point of matching /tg/'s. Up to 3 I'd say should be pretty smooth, possibly less.~~

Actually this seems smooth enough at speed 1:
![StZBclgRLv](https://user-images.githubusercontent.com/42041276/63133849-62363080-bf9d-11e9-9281-cedbee60c065.gif)
