### PR TITLE
AI now automatically gets unachored on crash

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai_verbs.dm
+++ b/code/modules/mob/living/silicon/ai/ai_verbs.dm
@@ -214,22 +214,6 @@
 	radio.interact(src)
 
 
-/mob/living/silicon/ai/verb/toggle_floor_bolts()
-	set category = "Silicon"
-	set name = "Toggle Floor Bolts"
-
-	if(!isturf(loc))
-		return
-
-	if(incapacitated())
-		return
-
-	anchored = !anchored
-
-	to_chat(src, "<span class='notice'>You are now [anchored ? "" : "un"]anchored.</span>")
-
-
-
 /mob/living/silicon/ai/verb/view_manifest()
 	set category = "Silicon"
 	set name = "View Crew Manifest"

--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -32,6 +32,11 @@
 			M.knock_down(3)
 		CHECK_TICK
 
+	for(var/i in GLOB.ai_list)
+		var/mob/living/silicon/ai/AI = i
+		AI.anchored = FALSE
+		CHECK_TICK
+
 	GLOB.enter_allowed = FALSE //No joining after dropship crash
 
 	//clear areas around the shuttle with explosions


### PR DESCRIPTION
:cl: LaKiller8
tweak: The AI can no longer toggle it's floor bolts, dropship crash disables them automatically.
/:cl: