### PR TITLE
Removes focus chat

### DIFF
--- a/code/__DEFINES/colors.dm
+++ b/code/__DEFINES/colors.dm
@@ -1,6 +1,3 @@
-#define COLOR_INPUT_DISABLED	"#F0F0F0"
-#define COLOR_INPUT_ENABLED		"#D3B5B5"
-
 #define COLOR_WHITE            "#EEEEEE"
 #define COLOR_GRAY             "#808080"
 #define COLOR_BLACK            "#000000"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -34,7 +34,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	var/show_typing = TRUE
 	var/windowflashing = TRUE
-	var/focus_chat = FALSE
 	var/clientfps = 0
 
 	// Custom Keybindings
@@ -126,8 +125,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 /datum/preferences/proc/keybindings_setup(client/C)
 	var/choice = tgalert(C, "Would you prefer 'Hotkey' or 'Classic' defaults?", "Setup keybindings", "Hotkey", "Classic")
-	focus_chat = (choice == "Classic")
-	key_bindings = (!focus_chat) ? deepCopyList(GLOB.hotkey_keybinding_list_by_key) : deepCopyList(GLOB.classic_keybinding_list_by_key)
+	key_bindings = (!choice || choice == "Hotkey") ? deepCopyList(GLOB.hotkey_keybinding_list_by_key) : deepCopyList(GLOB.classic_keybinding_list_by_key)
 	save_preferences()
 
 
@@ -323,7 +321,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	dat += "<h2>Game Settings:</h2>"
 	dat += "<b>Window Flashing:</b> <a href='?_src_=prefs;preference=windowflashing'>[windowflashing ? "Yes" : "No"]</a><br>"
-	dat += "<b>Focus chat:</b> <a href='?_src_=prefs;preference=focus_chat'>[(focus_chat) ? "Enabled" : "Disabled"]</a><br>"
 	dat += "<b>Tooltips:</b> <a href='?_src_=prefs;preference=tooltips'>[(tooltips) ? "Shown" : "Hidden"]</a><br>"
 	dat += "<b>FPS:</b> <a href='?_src_=prefs;preference=clientfps'>[clientfps]</a><br>"
 
@@ -531,7 +528,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			var/bound_key = user_binds[kb.name]
 			bound_key = (bound_key) ? bound_key : "Unbound"
 
-			HTML += "<label>[kb.full_name]</label> <a href ='?_src_=prefs;preference=keybindings_capture;keybinding=[kb.name];old_key=[bound_key]'>[bound_key] Default: ( [focus_chat ? kb.hotkey_key : kb.classic_key] )</a>"
+			HTML += "<label>[kb.full_name]</label> <a href ='?_src_=prefs;preference=keybindings_capture;keybinding=[kb.name];old_key=[bound_key]'>[bound_key] Default: ([kb.hotkey_key])</a>"
 			HTML += "<br>"
 
 	HTML += "<br><br>"
@@ -938,13 +935,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		if("windowflashing")
 			windowflashing = !windowflashing
 
-		if("focus_chat")
-			focus_chat = !focus_chat
-			if(focus_chat)
-				winset(user, null, "input.focus=true input.background-color=[COLOR_INPUT_ENABLED]")
-			else
-				winset(user, null, "input.focus=false input.background-color=[COLOR_INPUT_DISABLED]")
-
 		if("clientfps")
 			var/desiredfps = input(user, "Choose your desired FPS. (0 = synced with server tick rate, currently:[world.fps])", "FPS", clientfps) as null|num
 			if(isnull(desiredfps))
@@ -1029,8 +1019,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			if (choice == "Cancel")
 				ShowKeybindings(user)
 				return
-			focus_chat = (choice == "Classic")
-			key_bindings = (!focus_chat) ? deepCopyList(GLOB.hotkey_keybinding_list_by_key) : deepCopyList(GLOB.classic_keybinding_list_by_key)
+			key_bindings = (!choice || choice == "Hotkey") ? deepCopyList(GLOB.hotkey_keybinding_list_by_key) : deepCopyList(GLOB.classic_keybinding_list_by_key)
 			save_preferences()
 			ShowKeybindings(user)
 			return

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -142,7 +142,6 @@
 	READ_FILE(S["ghost_form"], ghost_form)
 	READ_FILE(S["ghost_others"], ghost_others)
 	READ_FILE(S["observer_actions"], observer_actions)
-	READ_FILE(S["focus_chat"], focus_chat)
 	READ_FILE(S["clientfps"], clientfps)
 	READ_FILE(S["tooltips"], tooltips)
 	READ_FILE(S["key_bindings"], key_bindings)
@@ -166,7 +165,6 @@
 	ghost_form		= sanitize_inlist_assoc(ghost_form, GLOB.ghost_forms, initial(ghost_form))
 	ghost_others	= sanitize_inlist(ghost_others, GLOB.ghost_others_options, initial(ghost_others))
 	observer_actions= sanitize_integer(observer_actions, FALSE, TRUE, initial(observer_actions))
-	focus_chat		= sanitize_integer(focus_chat, FALSE, TRUE, initial(focus_chat))
 	clientfps		= sanitize_integer(clientfps, 0, 240, initial(clientfps))
 	tooltips		= sanitize_integer(tooltips, FALSE, TRUE, initial(tooltips))
 
@@ -210,7 +208,6 @@
 	ghost_form		= sanitize_inlist_assoc(ghost_form, GLOB.ghost_forms, initial(ghost_form))
 	ghost_others	= sanitize_inlist(ghost_others, GLOB.ghost_others_options, initial(ghost_others))
 	observer_actions= sanitize_integer(observer_actions, FALSE, TRUE, initial(observer_actions))
-	focus_chat		= sanitize_integer(focus_chat, FALSE, TRUE, initial(focus_chat))
 	clientfps		= sanitize_integer(clientfps, 0, 240, initial(clientfps))
 	tooltips		= sanitize_integer(tooltips, FALSE, TRUE, initial(tooltips))
 
@@ -234,7 +231,6 @@
 	WRITE_FILE(S["ghost_form"], ghost_form)
 	WRITE_FILE(S["ghost_others"], ghost_others)
 	WRITE_FILE(S["observer_actions"], observer_actions)
-	WRITE_FILE(S["focus_chat"], focus_chat)
 	WRITE_FILE(S["clientfps"], clientfps)
 	WRITE_FILE(S["tooltips"], tooltips)
 

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -9,13 +9,6 @@
 	if(!(next_move_dir_sub & movement) && !keys_held["Ctrl"])
 		next_move_dir_add |= movement
 
-	//Keys longer than 1 aren't printable, so we process them normally, regardless of Focus Chat.
-	//Otherwise, return focus to chat window if it isn't already, and relay the character.
-	if(prefs.focus_chat && !winget(src, null, "input.focus") && length(_key) == 1)
-		winset(src, null, "input.focus=true")
-		winset(src, null, "input.text=[url_encode(_key)]")
-		return
-
 	// Client-level keybindings are ones anyone should be able to do at any time
 	// Things like taking screenshots, hitting tab, and adminhelps.
 	var/AltMod = keys_held["Alt"] ? "Alt-" : ""

--- a/code/modules/keybindings/setup.dm
+++ b/code/modules/keybindings/setup.dm
@@ -32,8 +32,3 @@
 		var/key = macro_set[k]
 		var/command = macro_set[key]
 		winset(src, "default-[REF(key)]", "parent=default;name=[key];command=[command]")
-
-	if(prefs.focus_chat)
-		winset(src, null, "input.focus=true input.background-color=[COLOR_INPUT_ENABLED]")
-	else
-		winset(src, null, "input.focus=false input.background-color=[COLOR_INPUT_DISABLED]")

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -70,7 +70,7 @@ window "mainwindow"
 		size = 517x20
 		anchor1 = 0,100
 		anchor2 = 100,100
-		background-color = #d3b5b5
+		background-color = #f0f0f0
 		is-default = true
 		border = sunken
 		saved-params = "command"


### PR DESCRIPTION
Almost every single round there's at least 2 ahelps about this mode. It's just not feasible to support this code that so few players use for little benefit. It's doing more harm than good at the moment

:cl: LaKiller8
del: Focus chat has been removed, and much confusion has been prevented.
/:cl: