### PR TITLE
Removes squad role limits on overwatch console

### DIFF
--- a/code/game/objects/machinery/overwatch.dm
+++ b/code/game/objects/machinery/overwatch.dm
@@ -630,29 +630,6 @@ GLOBAL_LIST_EMPTY(active_laser_targets)
 		to_chat(usr, "[icon2html(src, usr)] <span class='warning'>[transfer_marine] is already in [new_squad]!</span>")
 		return
 
-
-	var/no_place = FALSE
-	switch(transfer_marine.mind.assigned_role)
-		if(SQUAD_LEADER)
-			if(new_squad.num_leaders == new_squad.max_leaders)
-				no_place = TRUE
-		if(SQUAD_SPECIALIST)
-			if(new_squad.num_specialists == new_squad.max_specialists)
-				no_place = TRUE
-		if(SQUAD_ENGINEER)
-			if(new_squad.num_engineers >= new_squad.max_engineers)
-				no_place = TRUE
-		if(SQUAD_CORPSMAN)
-			if(new_squad.num_medics >= new_squad.max_medics)
-				no_place = TRUE
-		if(SQUAD_SMARTGUNNER)
-			if(new_squad.num_smartgun == new_squad.max_smartgun)
-				no_place = TRUE
-
-	if(no_place)
-		to_chat(usr, "[icon2html(src, usr)] <span class='warning'>Transfer aborted. [new_squad] can't have another [transfer_marine.mind.assigned_role].</span>")
-		return
-
 	old_squad.remove_from_squad(transfer_marine)
 	new_squad.insert_into_squad(transfer_marine)
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so that all roles can transferred to a different squad. 

## Why It's Good For The Game

On lower pop, COs like to assign all marines to one squad instead of having 4 squads of 2-3. Can't truly do that if overwatch consoles restrict squad transfer for specs, smartgunners, etc.

## Changelog
:cl:
tweak: Overwatch consoles can now reassign any limited role to other squads.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
