### PR TITLE
Balance patch - marine weapons nerf.

### DIFF
--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -482,7 +482,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	..()
 	accurate_range = CONFIG_GET(number/combat_define/short_shell_range)
 	damage = CONFIG_GET(number/combat_define/lmed_hit_damage)
-	penetration = CONFIG_GET(number/combat_define/mlow_armor_penetration)
+	penetration = CONFIG_GET(number/combat_define/min_armor_penetration)
 
 /datum/ammo/bullet/rifle/ap
 	name = "armor-piercing rifle bullet"
@@ -491,7 +491,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 /datum/ammo/bullet/rifle/ap/New()
 	..()
 	damage = CONFIG_GET(number/combat_define/low_hit_damage)
-	penetration = CONFIG_GET(number/combat_define/high_armor_penetration)
+	penetration = CONFIG_GET(number/combat_define/hmed_armor_penetration)
 
 /datum/ammo/bullet/rifle/incendiary
 	name = "incendiary rifle bullet"
@@ -635,11 +635,11 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	accuracy_var_low = CONFIG_GET(number/combat_define/med_proj_variance)
 	accuracy_var_high = CONFIG_GET(number/combat_define/med_proj_variance)
 	max_range = CONFIG_GET(number/combat_define/short_shell_range)
-	damage = CONFIG_GET(number/combat_define/lmmed_hit_damage)
+	damage = CONFIG_GET(number/combat_define/hlow_hit_damage)
 	damage_var_low = -CONFIG_GET(number/combat_define/low_proj_variance)
 	damage_var_high = CONFIG_GET(number/combat_define/low_proj_variance)
 	damage_falloff *= 0.5
-	penetration	= CONFIG_GET(number/combat_define/high_armor_penetration)
+	penetration	= CONFIG_GET(number/combat_define/med_armor_penetration)
 	bonus_projectiles_amount = CONFIG_GET(number/combat_define/low_proj_extra)
 
 /datum/ammo/bullet/shotgun/flechette_spread
@@ -655,7 +655,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage_var_low = -CONFIG_GET(number/combat_define/low_proj_variance)
 	damage_var_high = CONFIG_GET(number/combat_define/low_proj_variance)
 	damage_falloff *= 0.5
-	penetration	= CONFIG_GET(number/combat_define/high_armor_penetration)
+	penetration	= CONFIG_GET(number/combat_define/med_armor_penetration)
 	scatter = CONFIG_GET(number/combat_define/thirty_scatter_value) //bonus projectiles run their own scatter chance
 
 /datum/ammo/bullet/shotgun/buckshot
@@ -1065,7 +1065,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 /datum/ammo/energy/lasgun/New()
 	. = ..()
 	accurate_range = CONFIG_GET(number/combat_define/short_shell_range)
-	damage = CONFIG_GET(number/combat_define/mlow_hit_damage)
+	damage = CONFIG_GET(number/combat_define/llow_hit_damage)
 	penetration = CONFIG_GET(number/combat_define/mlow_armor_penetration)
 	max_range = CONFIG_GET(number/combat_define/long_shell_range)
 	shell_speed = CONFIG_GET(number/combat_define/ultra_shell_speed)
@@ -1080,7 +1080,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 
 /datum/ammo/energy/lasgun/M43/New()
 	. = ..()
-	penetration = CONFIG_GET(number/combat_define/med_armor_penetration)
+	penetration = CONFIG_GET(number/combat_define/lmed_armor_penetration)
 
 /datum/ammo/energy/lasgun/M43/overcharge
 	name = "overcharged laser bolt"
@@ -1089,9 +1089,9 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 
 /datum/ammo/energy/lasgun/M43/overcharge/New()
 	. = ..()
-	damage = CONFIG_GET(number/combat_define/med_hit_damage)
+	damage = CONFIG_GET(number/combat_define/lmed_hit_damage)
 	max_range = CONFIG_GET(number/combat_define/max_shell_range)
-	penetration = CONFIG_GET(number/combat_define/mhigh_armor_penetration)
+	penetration = CONFIG_GET(number/combat_define/hmed_armor_penetration)
 
 /*
 //================================================

--- a/code/modules/projectiles/updated_projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/specialist.dm
@@ -495,7 +495,7 @@
 		grenades += new /obj/item/explosive/grenade/frag(src)
 
 /obj/item/weapon/gun/launcher/m92/set_gun_config_values()
-	fire_delay = CONFIG_GET(number/combat_define/tacshottie_fire_delay)
+	fire_delay = CONFIG_GET(number/combat_define/scoutshottie_fire_delay)
 	accuracy_mult = CONFIG_GET(number/combat_define/base_hit_accuracy_mult)
 	accuracy_mult_unwielded = CONFIG_GET(number/combat_define/base_hit_accuracy_mult)
 	scatter = CONFIG_GET(number/combat_define/med_scatter_value)

--- a/code/modules/projectiles/updated_projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/specialist.dm
@@ -363,7 +363,7 @@
 	ammo_secondary = GLOB.ammo_list[ammo_secondary]
 
 /obj/item/weapon/gun/smartgun/set_gun_config_values()
-	fire_delay = CONFIG_GET(number/combat_define/low_fire_delay)
+	fire_delay = CONFIG_GET(number/combat_define/med_fire_delay)
 	burst_amount = CONFIG_GET(number/combat_define/med_burst_value)
 	burst_delay = CONFIG_GET(number/combat_define/min_fire_delay)
 	accuracy_mult = CONFIG_GET(number/combat_define/base_hit_accuracy_mult) + CONFIG_GET(number/combat_define/low_hit_accuracy_mult)


### PR DESCRIPTION
```
Damage/AP
* M41A normal: 40/10 to 40/5
* M41A AP: 30/50 to 30/40
* Lasgun normal: 25/30 to 20/25
* Lasgun overcharge: 50/60 to 40/40
* Flechettes: (45/50 + 2 * 35/50) to (3 * 35/30)
* Smartgun: Lowered firerate (now fires as fast as the rifle).
* Grenade launcher: Increase fire delay from 1.5 seconds to 2.
```

## Changelog
:cl:
balance: M41A, lasgun, flechettes, smartgun and grenade launcher nerfed to different degrees to account for the xeno warding nerf.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
