### PR TITLE
Revert "Makes some object mob verbs living instead (#2674)"

### DIFF
--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -127,10 +127,8 @@
 	description = "Uses whatever item you have inhand"
 
 /datum/keybinding/mob/activate_inhand/down(client/user)
-	var/mob/living/L = user.mob
-	if(!istype(L))
-		return
-	L.mode()
+	var/mob/M = user.mob
+	M.mode()
 	return TRUE
 
 /datum/keybinding/mob/drop_item

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -14,13 +14,10 @@
 
 
 /client/verb/attack_self()
-	set hidden = TRUE
-
-	if(!isliving(mob))
-		return
-
-	var/mob/living/L = mob
-	L.mode()
+	set hidden = 1
+	if(mob)
+		mob.mode()
+	return
 
 
 /client/verb/toggle_throw_mode()

--- a/code/modules/mob/mob_verbs.dm
+++ b/code/modules/mob/mob_verbs.dm
@@ -1,4 +1,4 @@
-/mob/living/verb/mode()
+/mob/verb/mode()
 	set name = "Activate Held Object"
 	set category = "Object"
 	set src = usr
@@ -90,7 +90,7 @@
 	M.key = key
 
 
-/mob/living/verb/cancel_camera()
+/mob/verb/cancel_camera()
 	set name = "Cancel Camera View"
 	set category = "Object"
 	reset_perspective(null)


### PR DESCRIPTION
This reverts commit b4fd7e8a56614444dd916c57d74ab2b9f7b8a3a0.

Turns out on the live server with many players, creating/destroying an entire tab is VERY laggy.

After further investigation the source of this is the `set src in oview(1)` which cannot be changed into our own variant that would exclude observers, so we're stuck with this ugly little thing.