### PR TITLE
[READY FOR MERGE][READY FOR TESTMERGE][TESTED][BALANCE][TWEAK] Adds OwO, Overhealth wellness Output, aka overheal, aka tactical headpats.

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -48,3 +48,8 @@
 		reagents.add_reagent(/datum/reagent/toxin/xeno_neurotoxin, round(reagent_amount * protection, 0.1))
 		if(prob(10 * S.strength * protection))
 			to_chat(src, "<span class='danger'>Your body goes numb where the gas touches it!</span>")
+
+/mob/living/carbon/proc/adjustOverhealth(amount, cap)
+	if(OwO >= cap) // Only add OwO if we have less than the cap
+		return
+	OwO = CLAMP(OwO + amount, 0, cap)

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -25,6 +25,7 @@
 	var/rotate_on_lying = TRUE
 
 	var/halloss = 0		//Hallucination damage. 'Fake' damage obtained through hallucinating or the holodeck. Sleeping should cause it to wear off.
+	var/OwO = 0 // Overhealth wellness Output, in short, overheal/overhealth that does not decay. Currently gained by headpats.
 
 	var/traumatic_shock = 0
 	var/shock_stage = 0

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -90,16 +90,6 @@
 	if(species && species.brute_mod && amount > 0)
 		amount = amount*species.brute_mod
 
-	message_admins("Amount: [amount] OwO: [OwO]")
-	if(amount > 0 && OwO > 0)
-		if(OwO > amount)
-			OwO -= amount
-			amount = 0
-		else
-			amount -= OwO
-			OwO = 0
-	message_admins("New amount: [amount] OwO: [OwO]")
-
 	if(amount > 0)
 		take_overall_damage(amount, 0)
 	else
@@ -110,16 +100,6 @@
 	if(species && species.burn_mod && amount > 0)
 		amount = amount*species.burn_mod
 
-	message_admins("Amount: [amount] OwO: [OwO]")
-	if(amount > 0 && OwO > 0)
-		if(OwO > amount)
-			OwO -= amount
-			amount = 0
-		else
-			amount -= OwO
-			OwO = 0
-	message_admins("New amount: [amount] OwO: [OwO]")
-
 	if(amount > 0)
 		take_overall_damage(0, amount)
 	else
@@ -129,16 +109,6 @@
 /mob/living/carbon/human/proc/adjustBruteLossByPart(amount, organ_name, obj/damage_source = null)
 	if(species && species.brute_mod && amount > 0)
 		amount = amount*species.brute_mod
-
-	message_admins("Amount: [amount] OwO: [OwO]")
-	if(amount > 0 && OwO > 0)
-		if(OwO > amount)
-			OwO -= amount
-			amount = 0
-		else
-			amount -= OwO
-			OwO = 0
-	message_admins("New amount: [amount] OwO: [OwO]")
 
 	for(var/X in limbs)
 		var/datum/limb/O = X
@@ -390,7 +360,6 @@ This function restores all limbs.
 			return EO
 
 /mob/living/carbon/human/apply_damage(damage = 0, damagetype = BRUTE, def_zone = null, blocked = 0, sharp = 0, edge = 0, obj/used_weapon = null)
-
 	if(blocked >= 1) //total negation
 		return 0
 
@@ -423,6 +392,16 @@ This function restores all limbs.
 		organ = get_limb(check_zone(def_zone))
 	if(!organ)
 		return FALSE
+
+	message_admins("Damage: [damage] OwO: [OwO]")
+	if(damage > 0 && OwO > 0)
+		if(OwO > damage)
+			OwO -= damage
+			damage = 0
+		else
+			damage -= OwO
+			OwO = 0
+	message_admins("New damage: [damage] OwO: [OwO]")
 
 	switch(damagetype)
 		if(BRUTE)

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -90,6 +90,16 @@
 	if(species && species.brute_mod && amount > 0)
 		amount = amount*species.brute_mod
 
+	message_admins("Amount: [amount] OwO: [OwO]")
+	if(amount > 0 && OwO > 0)
+		if(OwO > amount)
+			OwO -= amount
+			amount = 0
+		else
+			amount -= OwO
+			OwO = 0
+	message_admins("New amount: [amount] OwO: [OwO]")
+
 	if(amount > 0)
 		take_overall_damage(amount, 0)
 	else
@@ -100,6 +110,16 @@
 	if(species && species.burn_mod && amount > 0)
 		amount = amount*species.burn_mod
 
+	message_admins("Amount: [amount] OwO: [OwO]")
+	if(amount > 0 && OwO > 0)
+		if(OwO > amount)
+			OwO -= amount
+			amount = 0
+		else
+			amount -= OwO
+			OwO = 0
+	message_admins("New amount: [amount] OwO: [OwO]")
+
 	if(amount > 0)
 		take_overall_damage(0, amount)
 	else
@@ -109,6 +129,16 @@
 /mob/living/carbon/human/proc/adjustBruteLossByPart(amount, organ_name, obj/damage_source = null)
 	if(species && species.brute_mod && amount > 0)
 		amount = amount*species.brute_mod
+
+	message_admins("Amount: [amount] OwO: [OwO]")
+	if(amount > 0 && OwO > 0)
+		if(OwO > amount)
+			OwO -= amount
+			amount = 0
+		else
+			amount -= OwO
+			OwO = 0
+	message_admins("New amount: [amount] OwO: [OwO]")
 
 	for(var/X in limbs)
 		var/datum/limb/O = X

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -360,6 +360,7 @@ This function restores all limbs.
 			return EO
 
 /mob/living/carbon/human/apply_damage(damage = 0, damagetype = BRUTE, def_zone = null, blocked = 0, sharp = 0, edge = 0, obj/used_weapon = null)
+	
 	if(blocked >= 1) //total negation
 		return 0
 

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -393,7 +393,6 @@ This function restores all limbs.
 	if(!organ)
 		return FALSE
 
-	message_admins("Damage: [damage] OwO: [OwO]")
 	if(damage > 0 && OwO > 0)
 		if(OwO > damage)
 			OwO -= damage
@@ -401,7 +400,6 @@ This function restores all limbs.
 		else
 			damage -= OwO
 			OwO = 0
-	message_admins("New damage: [damage] OwO: [OwO]")
 
 	switch(damagetype)
 		if(BRUTE)

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -360,7 +360,7 @@ This function restores all limbs.
 			return EO
 
 /mob/living/carbon/human/apply_damage(damage = 0, damagetype = BRUTE, def_zone = null, blocked = 0, sharp = 0, edge = 0, obj/used_weapon = null)
-	
+
 	if(blocked >= 1) //total negation
 		return 0
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -153,8 +153,10 @@
 	if(H.zone_selected == "head")
 		H.visible_message("<span class='notice'>[H] pats [target] on the head.</span>", \
 					"<span class='notice'>You pat [target] on the head.</span>", null, 4)
-		target.adjustOverhealth(1, 10) // Add 1 overhealth per headpat, maximum of 10 overhealth from headpats.
-		target.heal_overall_damage(0.5, 0.5) // Headpats are a form of love. Love is said to have a healing effect.
+		if(istype(target, /mob/living/carbon))
+			var/mob/living/carbon/carb = target
+			carb.adjustOverhealth(1, 10) // Add 1 overhealth per headpat, maximum of 10 overhealth from headpats.
+			carb.heal_overall_damage(0.5, 0.5) // Headpats are a form of love. Love is said to have a healing effect.
 	else
 		H.visible_message("<span class='notice'>[H] hugs [target] to make [target.p_them()] feel better!</span>", \
 					"<span class='notice'>You hug [target] to make [target.p_them()] feel better!</span>", null, 4)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -153,6 +153,8 @@
 	if(H.zone_selected == "head")
 		H.visible_message("<span class='notice'>[H] pats [target] on the head.</span>", \
 					"<span class='notice'>You pat [target] on the head.</span>", null, 4)
+		H.adjustOverhealth(1, 10) // Add 1 overhealth per headpat, maximum of 10 overhealth from headpats.
+		H.heal_overall_damage(0.5, 0.5) // Headpats are a form of love. Love is said to have a healing effect.
 	else
 		H.visible_message("<span class='notice'>[H] hugs [target] to make [target.p_them()] feel better!</span>", \
 					"<span class='notice'>You hug [target] to make [target.p_them()] feel better!</span>", null, 4)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -153,8 +153,8 @@
 	if(H.zone_selected == "head")
 		H.visible_message("<span class='notice'>[H] pats [target] on the head.</span>", \
 					"<span class='notice'>You pat [target] on the head.</span>", null, 4)
-		H.adjustOverhealth(1, 10) // Add 1 overhealth per headpat, maximum of 10 overhealth from headpats.
-		H.heal_overall_damage(0.5, 0.5) // Headpats are a form of love. Love is said to have a healing effect.
+		target.adjustOverhealth(1, 10) // Add 1 overhealth per headpat, maximum of 10 overhealth from headpats.
+		target.heal_overall_damage(0.5, 0.5) // Headpats are a form of love. Love is said to have a healing effect.
 	else
 		H.visible_message("<span class='notice'>[H] hugs [target] to make [target.p_them()] feel better!</span>", \
 					"<span class='notice'>You hug [target] to make [target.p_them()] feel better!</span>", null, 4)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -155,7 +155,7 @@
 					"<span class='notice'>You pat [target] on the head.</span>", null, 4)
 		if(istype(target, /mob/living/carbon))
 			var/mob/living/carbon/carb = target
-			carb.adjustOverhealth(1, 10) // Add 1 overhealth per headpat, maximum of 10 overhealth from headpats.
+			carb.adjustOverhealth(0.5, 10) // Add 1 overhealth per headpat, maximum of 10 overhealth from headpats.
 			carb.heal_overall_damage(0.5, 0.5) // Headpats are a form of love. Love is said to have a healing effect.
 	else
 		H.visible_message("<span class='notice'>[H] hugs [target] to make [target.p_them()] feel better!</span>", \

--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -135,7 +135,6 @@
 	for(var/i in amount_mod)
 		amount -= i
 	
-	message_admins("Amount: [amount] OwO: [OwO]")
 	if(amount > 0 && OwO > 0)
 		if(OwO > amount)
 			OwO -= amount
@@ -143,7 +142,6 @@
 		else
 			amount -= OwO
 			OwO = 0
-	message_admins("New amount: [amount] OwO: [OwO]")
 	
 	bruteloss = CLAMP(bruteloss + amount, 0, maxHealth - xeno_caste.crit_health)
 
@@ -153,7 +151,6 @@
 	for(var/i in amount_mod)
 		amount -= i
 	
-	message_admins("Amount: [amount] OwO: [OwO]")
 	if(amount > 0 && OwO > 0)
 		if(OwO > amount)
 			OwO -= amount
@@ -161,7 +158,6 @@
 		else
 			amount -= OwO
 			OwO = 0
-	message_admins("New amount: [amount] OwO: [OwO]")
 
 	fireloss = CLAMP(fireloss + amount, 0, maxHealth - xeno_caste.crit_health)
 

--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -134,7 +134,7 @@
 	SEND_SIGNAL(src, COMSIG_XENOMORPH_BRUTE_DAMAGE, amount, amount_mod)
 	for(var/i in amount_mod)
 		amount -= i
-	
+
 	if(amount > 0 && OwO > 0)
 		if(OwO > amount)
 			OwO -= amount

--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -134,7 +134,17 @@
 	SEND_SIGNAL(src, COMSIG_XENOMORPH_BRUTE_DAMAGE, amount, amount_mod)
 	for(var/i in amount_mod)
 		amount -= i
-
+	
+	message_admins("Amount: [amount] OwO: [OwO]")
+	if(amount > 0 && OwO > 0)
+		if(OwO > amount)
+			OwO -= amount
+			amount = 0
+		else
+			amount -= OwO
+			OwO = 0
+	message_admins("New amount: [amount] OwO: [OwO]")
+	
 	bruteloss = CLAMP(bruteloss + amount, 0, maxHealth - xeno_caste.crit_health)
 
 /mob/living/carbon/xenomorph/adjustFireLoss(amount)
@@ -142,6 +152,16 @@
 	SEND_SIGNAL(src, COMSIG_XENOMORPH_BURN_DAMAGE, amount, amount_mod)
 	for(var/i in amount_mod)
 		amount -= i
+	
+	message_admins("Amount: [amount] OwO: [OwO]")
+	if(amount > 0 && OwO > 0)
+		if(OwO > amount)
+			OwO -= amount
+			amount = 0
+		else
+			amount -= OwO
+			OwO = 0
+	message_admins("New amount: [amount] OwO: [OwO]")
 
 	fireloss = CLAMP(fireloss + amount, 0, maxHealth - xeno_caste.crit_health)
 


### PR DESCRIPTION

## About The Pull Request

Headpatting humans adds OwO, which is overheal. It also heals them, slightly.
Each headpat heals 0.5 brute and 0.5 fire, and adds 0.5 OwO.
(If you have a problem with the variable names, I only accept renames from Reehesie)

## Why It's Good For The Game

Makes headpats more useful, allows for healing even when you are out of items, and every hitpoint counts. OwO is something that Reehesie wanted added, so I just put it in and made it a part of the game with headpats. OwO has a cap, which with headpats is 10, so they only prevent 10 damage from being taken, each headpat adds 0.5 OwO, so you need 20 headpats to reach the capacity.
Currently, OwO prevents brute and fire damage for xenos and humans, until it runs out.

## Changelog
:cl:
balance: headpats add OwO and heal
/:cl:
