### PR TITLE
Removes TM info from MOTD

### DIFF
--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -241,11 +241,7 @@
 
 
 /datum/controller/configuration/proc/LoadMOTD()
-	var/motd = file2text("[directory]/motd.txt")
-	var/tm_info = GLOB.revdata.GetTestMergeInfo()
-	if(motd || tm_info)
-		motd = motd ? "[motd]<br>[tm_info]" : tm_info
-	GLOB.motd = motd
+	GLOB.motd = file2text("[directory]/motd.txt")
 
 
 /datum/controller/configuration/proc/loadmaplist(filename, maptype)


### PR DESCRIPTION
This causes useful info to be missed as we usually have 10+ PRs at the same time