### PR TITLE
Removes a frustrating warning when using acid spray

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -602,7 +602,7 @@
 	var/turf/T2 = get_turf(A)
 	if(T == T2)
 		if(!silent)
-			to_chat(owner, "<span class='xenowarning'>That's far too close!</span>")
+			to_chat(owner, "<span class='warning'>That's far too close!</span>")
 		return FALSE
 
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -602,20 +602,8 @@
 	var/turf/T2 = get_turf(A)
 	if(T == T2)
 		if(!silent)
-			to_chat(owner, "<span class='warning'>That's far too close!</span>")
+			to_chat(owner, "<span class='xenowarning'>That's far too close!</span>")
 		return FALSE
-
-	var/facing = get_cardinal_dir(T, T2)
-	for(var/i in 1 to get_dist(T2, T))
-		var/turf/next_T = get_step(T, facing)
-		T = next_T
-		if(!T.density)
-			continue
-		if(!silent)
-			to_chat(owner, "<span class='xenowarning'>There is something in the way!</span>")
-
-		return FALSE
-
 
 
 /datum/action/xeno_action/activable/spray_acid/on_cooldown_finish()


### PR DESCRIPTION
Fixes: #2749

If there's 3 valid tiles in front of you, then a wall, and you aim behind that wall, this would prevent you from spraying for zero benefit basically, this should and is handled by the acid itself not passing through walls and obstacles.