### PR TITLE
Patches up an issue with storage items and cryo.

### DIFF
--- a/code/game/objects/machinery/cryopod.dm
+++ b/code/game/objects/machinery/cryopod.dm
@@ -320,7 +320,7 @@
 
 	return ..()
 
-/obj/item/proc/store_in_cryo(list/items, move_loc = TRUE)
+/obj/item/proc/store_in_cryo(list/items, nullspace_it = TRUE)
 
 	//bandaid for special cases (mob_holders, intellicards etc.) which are NOT currently handled on their own.
 	if(locate(/mob) in src)
@@ -336,45 +336,45 @@
 	if(flags_item & (ITEM_ABSTRACT|NODROP|DELONDROP) || (is_type_in_typecache(src, GLOB.do_not_preserve_empty) && !length(contents)))
 		items -= src
 		qdel(src)
-	else if(move_loc)
-		loc = null
+	else if(nullspace_it)
+		moveToNullspace()
 	return items
 
-/obj/item/storage/store_in_cryo(list/items)
+/obj/item/storage/store_in_cryo(list/items, nullspace_it = TRUE)
 	for(var/O in src)
 		var/obj/item/I = O
 		items = I.store_in_cryo(items, FALSE)
 	return ..()
 
-/obj/item/clothing/suit/storage/store_in_cryo(list/items)
+/obj/item/clothing/suit/storage/store_in_cryo(list/items, nullspace_it = TRUE)
 	for(var/O in pockets)
 		var/obj/item/I = O
 		pockets.remove_from_storage(I, loc)
 		items = I.store_in_cryo(items)
 	return ..()
 
-/obj/item/clothing/under/store_in_cryo(list/items)
+/obj/item/clothing/under/store_in_cryo(list/items, nullspace_it = TRUE)
 	if(hastie)
 		var/obj/item/TIE = hastie
 		remove_accessory()
 		items = TIE.store_in_cryo(items)
 	return ..()
 
-/obj/item/clothing/shoes/marine/store_in_cryo(list/items)
+/obj/item/clothing/shoes/marine/store_in_cryo(list/items, nullspace_it = TRUE)
 	if(knife)
 		items = knife.store_in_cryo(items)
 		knife = null
 		update_icon()
 	return ..()
 
-/obj/item/clothing/tie/storage/store_in_cryo(list/items)
+/obj/item/clothing/tie/storage/store_in_cryo(list/items, nullspace_it = TRUE)
 	for(var/O in hold)
 		var/obj/item/I = O
 		hold.remove_from_storage(I, loc)
 		items = I.store_in_cryo(items)
 	return ..()
 
-/obj/item/clothing/tie/holster/store_in_cryo(list/items)
+/obj/item/clothing/tie/holster/store_in_cryo(list/items, nullspace_it = TRUE)
 	if(holstered)
 		items = holstered.store_in_cryo(items)
 		holstered = null

--- a/code/game/objects/machinery/cryopod.dm
+++ b/code/game/objects/machinery/cryopod.dm
@@ -320,7 +320,7 @@
 
 	return ..()
 
-/obj/item/proc/store_in_cryo(list/items)
+/obj/item/proc/store_in_cryo(list/items, move_loc = TRUE)
 
 	//bandaid for special cases (mob_holders, intellicards etc.) which are NOT currently handled on their own.
 	if(locate(/mob) in src)
@@ -336,15 +336,14 @@
 	if(flags_item & (ITEM_ABSTRACT|NODROP|DELONDROP) || (is_type_in_typecache(src, GLOB.do_not_preserve_empty) && !length(contents)))
 		items -= src
 		qdel(src)
-	else
+	else if(move_loc)
 		loc = null
 	return items
 
 /obj/item/storage/store_in_cryo(list/items)
 	for(var/O in src)
 		var/obj/item/I = O
-		remove_from_storage(I, loc)
-		items = I.store_in_cryo(items)
+		items = I.store_in_cryo(items, FALSE)
 	return ..()
 
 /obj/item/clothing/suit/storage/store_in_cryo(list/items)
@@ -428,7 +427,7 @@
 	go_out()
 
 /obj/machinery/cryopod/relaymove(mob/user)
-	if(user.incapacitated(TRUE)) 
+	if(user.incapacitated(TRUE))
 		return
 	go_out()
 
@@ -466,7 +465,7 @@
 	else
 		user.visible_message("<span class='notice'>[user] starts climbing into [src].</span>",
 		"<span class='notice'>You start climbing into [src].</span>")
-		
+
 
 	var/mob/initiator = helper ? helper : user
 	if(!do_after(initiator, 20, TRUE, user, BUSY_ICON_GENERIC))


### PR DESCRIPTION
## About The Pull Request
This PR will close #2744 by removing the functionality of cryopods of surgically removing any item from containers.

## Why It's Good For The Game
Said precision can lead to issues with pill bottles and other specific containers.
This is the easiest way to address this issue. After all, a bit of scavenging gameplay by rummaging backpacks doesn't hurt, plus this will have to be reworked into a component signal once and if the storage component is ported.

## Changelog
:cl:
fix: Patches up an issue with storage items and cryo. No more loadsa pills cluttering your stored items list, empty pill bottles, MREs etcetera.
/:cl: