### PR TITLE
More podlauncher runtimes

### DIFF
--- a/code/modules/admin/verbs/podlauncher.dm
+++ b/code/modules/admin/verbs/podlauncher.dm
@@ -583,6 +583,10 @@
 
 
 /datum/podlauncher/InterceptClickOn(user, params, atom/target)
+	if(!temp_pod)
+		updateCursor(FALSE)
+		return FALSE
+
 	var/list/pa = params2list(params)
 	var/left_click = pa.Find("left")
 	if(launcherActivated)


### PR DESCRIPTION
Fixes: #2742

This happens if: you are already ready to shoot the pod, but it gets deleted.

The topic side already protects this, this is the intercept_click_on side.