### PR TITLE
Roundstart xenos start at max upgrade

### DIFF
--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -160,6 +160,15 @@
 		computer_to_disable.machine_stat |= BROKEN
 		computer_to_disable.update_icon()
 
+	for(var/i in GLOB.alive_xeno_list)
+		if(isxenolarva(i)) // Larva
+			var/mob/living/carbon/xenomorph/larva/X = i
+			X.amount_grown = X.max_grown
+		else // Handles Shrike etc
+			var/mob/living/carbon/xenomorph/X = i
+			X.upgrade_stored = X.xeno_caste.upgrade_threshold
+		
+
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_OPEN_TIMED_SHUTTERS_CRASH)
 	RegisterSignal(SSdcs, COMSIG_GLOB_NUKE_EXPLODED, .proc/on_nuclear_explosion)
 


### PR DESCRIPTION
Roundstart xenos start at max upgrade

## Changelog
:cl:
balance: (Crash Only) Xenos now start with the first tier already unlocked.
/:cl: