### PR TITLE
Allow bullets to pass the fog barriers

### DIFF
--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -110,7 +110,7 @@
 
 
 /obj/effect/forcefield/fog/CanPass(atom/movable/mover, turf/target)
-	if(isxeno(mover))
+	if(isxeno(mover) || isobj(mover))
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
Allow bullets to pass the fog barriers


## Changelog
:cl:
balance: bullets are now able to pass the fog barriers
/:cl: