### PR TITLE
Delays crash xeno bioscan

### DIFF
--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -220,7 +220,8 @@
 /datum/game_mode/crash/proc/crash_shuttle(obj/docking_port/stationary/target)
 	shuttle_landed = TRUE
 
-	announce_bioscans(TRUE, 0, FALSE, TRUE) // Announce exact information to the xenos.
+	// We delay this a little because the shuttle takes some time to land, and we want to the xenos to know the position of the marines.
+	addtimer(CALLBACK(src, .proc/announce_bioscans, TRUE, 0, FALSE, TRUE), 30 SECONDS)  // Announce exact information to the xenos.
 	addtimer(CALLBACK(src, .proc/announce_bioscans, TRUE, 0, FALSE, TRUE), 5 MINUTES, TIMER_LOOP)
 
 


### PR DESCRIPTION
Fixes crash xeno bioscan to alert after marines land, instead of just before resulting in a 0 marines result.