### PR TITLE
Disables the goonchat ping display

### DIFF
--- a/code/controllers/subsystem/ping.dm
+++ b/code/controllers/subsystem/ping.dm
@@ -1,33 +1,32 @@
 SUBSYSTEM_DEF(ping)
 	name = "Ping"
 	priority = FIRE_PRIORITY_PING
-	wait = 3 SECONDS
+	wait = 15 SECONDS
 	flags = SS_NO_INIT
-	runlevels = RUNLEVEL_LOBBY | RUNLEVEL_SETUP | RUNLEVEL_GAME | RUNLEVEL_POSTGAME
+	runlevels = RUNLEVEL_LOBBY|RUNLEVEL_SETUP|RUNLEVEL_GAME|RUNLEVEL_POSTGAME
 
 	var/list/currentrun = list()
 
 /datum/controller/subsystem/ping/stat_entry()
-	..("P:[GLOB.clients.len]")
+	..("P:[length(GLOB.clients)]")
 
 
-/datum/controller/subsystem/ping/fire(resumed = 0)
-	if (!resumed)
+/datum/controller/subsystem/ping/fire(resumed = FALSE)
+	if(!resumed)
 		src.currentrun = GLOB.clients.Copy()
 
 	//cache for sanic speed (lists are references anyways)
 	var/list/currentrun = src.currentrun
 
-	while (currentrun.len)
-		var/client/C = currentrun[currentrun.len]
+	while(length(currentrun))
+		var/client/C = currentrun[length(currentrun)]
 		currentrun.len--
 
-		if (!C || !C.chatOutput || !C.chatOutput.loaded)
-			if (MC_TICK_CHECK)
+		if(!C?.chatOutput?.loaded)
+			if(MC_TICK_CHECK)
 				return
 			continue
 
-		// softPang isn't handled anywhere but it'll always reset the opts.lastPang.
-		C.chatOutput.ehjax_send(data = C.is_afk(29) ? "softPang" : "pang")
-		if (MC_TICK_CHECK)
+		C.chatOutput.ehjax_send(data = "ping")
+		if(MC_TICK_CHECK)
 			return

--- a/goon/browserassets/css/browserOutput.css
+++ b/goon/browserassets/css/browserOutput.css
@@ -98,22 +98,6 @@ a.popt {text-decoration: none;}
 }
 #newMessages:hover {background: #ccc;}
 #newMessages i {vertical-align: middle; padding-left: 3px;}
-#ping {
-	position: fixed;
-	top: 0;
-	right: 80px;
-	width: 45px;
-	background: #ddd;
-	height: 30px;
-	padding: 8px 0 2px 0;
-}
-#ping i {display: block; text-align: center;}
-#ping .ms {
-	display: block;
-	text-align: center;
-	font-size: 8pt;
-	padding-top: 2px;
-}
 #userBar {
 	position: fixed;
 	top: 0;

--- a/goon/browserassets/html/browserOutput.html
+++ b/goon/browserassets/html/browserOutput.html
@@ -24,10 +24,6 @@
 
 	</div>
 	<div id="userBar" style="display: none;">
-		<div id="ping">
-			<i class="icon-circle" id="pingDot"></i>
-			<span class="ms" id="pingMs">--ms</span>
-		</div>
 		<div id="audio">
 			<a href="#" class="subCell toggle" id="toggleAudio" title="Audio"><i class="icon-volume-up"></i></a>
 		</div>
@@ -39,7 +35,6 @@
 			<a href="#" class="subCell increaseFont" id="increaseFont"><span>Increase font size</span> <i class="icon-font">+</i></a>
 			<a href="#" class="subCell decreaseLineHeight" id="decreaseLineHeight"><span>Decrease line height</span> <i class="icon-text-height">-</i></a>
 			<a href="#" class="subCell increaseLineHeight" id="increaseLineHeight"><span>Increase line height</span> <i class="icon-text-height">+</i></a>
-			<a href="#" class="subCell togglePing" id="togglePing"><span>Toggle ping display</span> <i class="icon-circle"></i></a>
 			<a href="#" class="subCell highlightTerm" id="highlightTerm"><span>Highlight string</span> <i class="icon-tag"></i></a>
 			<a href="#" class="subCell saveLog" id="saveLog"><span>Save chat log</span> <i class="icon-save"></i></a>
 			<a href="#" class="subCell toggleCombine" id="toggleCombine"><span>Toggle line combining</span> <i class="icon-filter"></i></a>

--- a/goon/browserassets/js/browserOutput.js
+++ b/goon/browserassets/js/browserOutput.js
@@ -41,13 +41,10 @@ var opts = {
 	'highlightTerms': [],
 	'highlightLimit': 5,
 	'highlightColor': '#FFFF00', //The color of the highlighted message
-	'pingDisabled': false, //Has the user disabled the ping counter
 
 	//Ping display
-	'lastPang': 0, //Timestamp of the last response from the server.
-	'pangLimit': 35000,
-	'pingTime': 0, //Timestamp of when ping sent
-	'pongTime': 0, //Timestamp of when ping received
+	'lastPinged': 0, //Timestamp of the last response from the server.
+	'pingedLimit': 35000,
 	'noResponse': false, //Tracks the state of the previous ping request
 	'noResponseCount': 0, //How many failed pings?
 
@@ -251,7 +248,7 @@ function output(message, flag) {
 	}
 
 	if (flag !== 'internal')
-		opts.lastPang = Date.now();
+		opts.lastPinged = Date.now();
 
 	message = byondDecode(message).trim();
 
@@ -483,25 +480,9 @@ function handleClientData(ckey, ip, compid) {
 //Server calls this on ehjax response
 //Or, y'know, whenever really
 function ehjaxCallback(data) {
-	opts.lastPang = Date.now();
-	if (data == 'softPang') {
+	opts.lastPinged = Date.now();
+	if (data == 'ping') {
 		return;
-	} else if (data == 'pang') {
-		opts.pingCounter = 0; //reset
-		opts.pingTime = Date.now();
-		runByond('?_src_=chat&proc=ping');
-
-	} else if (data == 'pong') {
-		if (opts.pingDisabled) {return;}
-		opts.pongTime = Date.now();
-		var pingDuration = Math.ceil((opts.pongTime - opts.pingTime) / 2);
-		$('#pingMs').text(pingDuration+'ms');
-		pingDuration = Math.min(pingDuration, 255);
-		var red = pingDuration;
-		var green = 255 - pingDuration;
-		var blue = 0;
-		var hex = rgbToHex(red, green, blue);
-		$('#pingDot').css('color', '#'+hex);
 
 	} else if (data == 'roundrestart') {
 		opts.restarting = true;
@@ -687,7 +668,7 @@ $(function() {
 
 	//Hey look it's a controller loop!
 	setInterval(function() {
-		if (opts.lastPang + opts.pangLimit < Date.now() && !opts.restarting) { //Every pingLimit
+		if (opts.lastPinged + opts.pingedLimit < Date.now() && !opts.restarting) { //Every pingLimit
 				if (!opts.noResponse) { //Only actually append a message if the previous ping didn't also fail (to prevent spam)
 					opts.noResponse = true;
 					opts.noResponseCount++;
@@ -708,7 +689,6 @@ $(function() {
 	var savedConfig = {
 		'sfontSize': getCookie('fontsize'),
 		'slineHeight': getCookie('lineheight'),
-		'spingDisabled': getCookie('pingdisabled'),
 		'shighlightTerms': getCookie('highlightterms'),
 		'shighlightColor': getCookie('highlightcolor'),
 		'smusicVolume': getCookie('musicVolume'),
@@ -722,13 +702,6 @@ $(function() {
 	if (savedConfig.slineHeight) {
 		$("body").css('line-height', savedConfig.slineHeight);
 		internalOutput('<span class="internal boldnshit">Loaded line height setting of: '+savedConfig.slineHeight+'</span>', 'internal');
-	}
-	if (savedConfig.spingDisabled) {
-		if (savedConfig.spingDisabled == 'true') {
-			opts.pingDisabled = true;
-			$('#ping').hide();
-		}
-		internalOutput('<span class="internal boldnshit">Loaded ping display of: '+(opts.pingDisabled ? 'hidden' : 'visible')+'</span>', 'internal');
 	}
 	if (savedConfig.shighlightTerms) {
 		var savedTerms = $.parseJSON(savedConfig.shighlightTerms);
@@ -984,17 +957,6 @@ $(function() {
 		$("body").css({'line-height': lineheightvar});
 		setCookie('lineheight', lineheightvar, 365);
 		internalOutput('<span class="internal boldnshit">Line height set to '+lineheightvar+'</span>', 'internal');
-	});
-
-	$('#togglePing').click(function(e) {
-		if (opts.pingDisabled) {
-			$('#ping').slideDown('fast');
-			opts.pingDisabled = false;
-		} else {
-			$('#ping').slideUp('fast');
-			opts.pingDisabled = true;
-		}
-		setCookie('pingdisabled', (opts.pingDisabled ? 'true' : 'false'), 365);
 	});
 
 	$('#saveLog').click(function(e) {

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -74,9 +74,6 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("tmp/iconCache.sav")) //Cache of ico
 		if("debug")
 			data = debug(arglist(params))
 
-		if("ping")
-			data = ping(arglist(params))
-
 		if("analyzeClientData")
 			data = analyzeClientData(arglist(params))
 
@@ -170,9 +167,6 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("tmp/iconCache.sav")) //Cache of ico
 
 	cookieSent = TRUE
 
-//Called by js client every 60 seconds
-/datum/chatOutput/proc/ping()
-	return "pong"
 
 //Called by js client on js error
 /datum/chatOutput/proc/debug(error)


### PR DESCRIPTION
1. more performance both client and server side due to having to perform less actions
2. the more accurate display is still enabled in the stats tab so people will no longer wonder which one is the real one (and having to explain what round-trip is over OOC each round is pretty exhausting)