### PR TITLE
SMG ammunition naming change 

### DIFF
--- a/code/modules/projectiles/updated_projectiles/magazines/smgs.dm
+++ b/code/modules/projectiles/updated_projectiles/magazines/smgs.dm
@@ -35,7 +35,7 @@
 	name = "\improper MP5 magazine (9mm)"
 	desc = "A 9mm magazine for the MP5."
 	default_ammo = /datum/ammo/bullet/smg
-	caliber = "9x19mm Parabellum"
+	caliber = "9x21mm IMI"
 	icon_state = "mp5"
 	gun_type = /obj/item/weapon/gun/smg/mp5
 	max_rounds = 30 //Also comes in 10 and 40.
@@ -91,7 +91,7 @@
 /obj/item/ammo_magazine/smg/uzi
 	name = "\improper GAL9 magazine (9mm)"
 	desc = "A magazine for the GAL9."
-	caliber = "9x19mm Parabellum"
+	caliber = "9x21mm IMI"
 	icon_state = "uzi"
 	max_rounds = 32
 	gun_type = /obj/item/weapon/gun/smg/uzi


### PR DESCRIPTION
## About The Pull Request
Differentiates SMG ammunition from pistol ammunition
## Why It's Good For The Game
Prevents possible mistakes with ammunition types and weapons
## Changelog
:cl:
tweak: Ammunition naming
/:cl: