### PR TITLE
Small M39 Mags

### DIFF
--- a/code/modules/projectiles/updated_projectiles/magazines/smgs.dm
+++ b/code/modules/projectiles/updated_projectiles/magazines/smgs.dm
@@ -13,7 +13,7 @@
 	caliber = "10x20mm caseless"
 	icon_state = "m39"
 	max_rounds = 60
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_SMALL
 	gun_type = /obj/item/weapon/gun/smg/m39
 
 /obj/item/ammo_magazine/smg/m39/ap


### PR DESCRIPTION
### About the Pull Request 
Makes the M39 SMG mag a small item (2 slots) as opposed to a normal sized item (3 slots).

### Why it's Good for the Game
Aligns it with other SMG mags, which are tiny (1 slot) by default.

Should also align the M39 further with the "Concealed" gimmick
### Changelog
🆑 Aurelien3189
:tweak: Shrinks the m39 magazine item size to small (2 slots) from normal (3 slots), same size as a pistol magazine item.
/🆑 