### PR TITLE
4 Helmet Storage Slots

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -196,11 +196,13 @@
 						/obj/item/clothing/glasses/mgoggles/prescription = "goggles")
 
 /obj/item/storage/internal/marinehelmet
-	storage_slots = 2
+	storage_slots = 4
 	max_w_class = 1
 	bypass_w_limit = list(
 		/obj/item/clothing/glasses,
-		/obj/item/reagent_container/food/drinks/flask)
+		/obj/item/reagent_container/food/drinks/flask,
+		/obj/item/ammo_magazine/smg,
+		/obj/item/ammo_magazine/pistol)
 	cant_hold = list(
 		/obj/item/stack/)
 	max_storage_space = 4


### PR DESCRIPTION
### About the Pull Request
Gives the helmet 4 slots of storage space (max 4 storage space unchanged), allows it to hold pistol and smg mags.
### Why it's Good for the Game
Given that the helmet could hold a max weight of 4, expanded the number of helmet slots to match that. The helmet can store 4 tiny items, 2 small items, or 1 small item and 2 tiny items, for example. 
Also gives the helmet more functionality by being able to hold small magazines.
### Changelog
🆑 
Aurelien3189
:tweak: Increases marine helmet slots to 4 from 2, to match its maximum 4 storage space. Can store small pistol and smg magazines.
/🆑 