### PR TITLE
Changes the Integrated Storage to hold a gun.

### DIFF
--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -116,8 +116,9 @@
 
 /obj/item/storage/internal/suit/marine/M3IS
 	bypass_w_limit = list(/obj/item/weapon/gun/,
-						/obj/item/storage/large_holster/machete)
-	cant_hold = list()
+						/obj/item/storage/large_holster/machete,
+						/obj/item/weapon/claymore/mercsword/machete)
+	cant_hold = list() //for if you want to not allow certain weapons.
 	storage_slots = 1
 	max_storage_space = 8 // Rifle, stock, extended barrel, grip/bipod.
 	max_w_class = 3 //Can fit larger items

--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -109,15 +109,16 @@
 
 /obj/item/clothing/suit/storage/marine/M3IS
 	name = "\improper M3-IS pattern marine armor"
-	desc = "A standard Marine M3 Integrated Storage Pattern Chestplate. Increased encumbrance and carrying capacity."
+	desc = "A standard Marine M3 Integrated Storage Pattern Chestplate. Increased encumbrance and weapon carrying capacity."
 	icon_state = "4"
 	slowdown = SLOWDOWN_ARMOR_HEAVY
 	pockets = /obj/item/storage/internal/suit/marine/M3IS
 
 /obj/item/storage/internal/suit/marine/M3IS
-	bypass_w_limit = list()
-	storage_slots = null
-	max_storage_space = 15 // Same as satchel
+	bypass_w_limit = list(/obj/item/weapon/gun/,
+						/obj/item/storage/large_holster/machete)
+	storage_slots = 1
+	max_storage_space = 6 // Rifle, stock, extended barrel.
 	max_w_class = 3 //Can fit larger items
 
 /obj/item/clothing/suit/storage/marine/M3E

--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -117,8 +117,9 @@
 /obj/item/storage/internal/suit/marine/M3IS
 	bypass_w_limit = list(/obj/item/weapon/gun/,
 						/obj/item/storage/large_holster/machete)
+	cant_hold = list()
 	storage_slots = 1
-	max_storage_space = 6 // Rifle, stock, extended barrel.
+	max_storage_space = 8 // Rifle, stock, extended barrel, grip/bipod.
 	max_w_class = 3 //Can fit larger items
 
 /obj/item/clothing/suit/storage/marine/M3E


### PR DESCRIPTION
## About The Pull Request

Talked about how the Integrated Storage armor wasn't being picked. So this is a potential replacement to it's limited usefulness.

## Why It's Good For The Game

makes the Integrated Storage armor set a bit more competitive.

## Changelog
:cl: Hughgent
balance: The Integrated Storage armor no longer is a satchel in your armor. It is now a single slot for carrying a fully kitted weapon or machete.
/:cl:

![image](https://user-images.githubusercontent.com/45076386/64140998-1f14f380-cdcc-11e9-90ed-922eb53b3aed.png)
