### PR TITLE
Small full auto nerf

### DIFF
--- a/code/datums/components/full_auto_fire.dm
+++ b/code/datums/components/full_auto_fire.dm
@@ -315,7 +315,7 @@
 
 /obj/item/weapon/gun/proc/on_autofire_stop(shots_fired)
 	if(shots_fired > 1) //If it was a burst, apply the burst cooldown.
-		extra_delay = min(extra_delay+(burst_delay*2), fire_delay*3)
+		extra_delay += fire_delay * 2
 
 
 /obj/item/weapon/gun/proc/autofire_bypass_check(datum/source, client/clicker, atom/target, turf/location, control, params)

--- a/code/datums/components/full_auto_fire.dm
+++ b/code/datums/components/full_auto_fire.dm
@@ -315,7 +315,7 @@
 
 /obj/item/weapon/gun/proc/on_autofire_stop(shots_fired)
 	if(shots_fired > 1) //If it was a burst, apply the burst cooldown.
-		extra_delay += fire_delay * 2
+		extra_delay += fire_delay * 1.5
 
 
 /obj/item/weapon/gun/proc/autofire_bypass_check(datum/source, client/clicker, atom/target, turf/location, control, params)


### PR DESCRIPTION
People were reporting autoburst cooldown being too low. This should increase it a bit, we'll see how it goes.

## Changelog
:cl:
balance: Cooldown between autofire bursts increased a bit (to double the single fire cooldown).
/:cl: