### PR TITLE
Adds different light colors to flamer fire

### DIFF
--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -344,7 +344,7 @@ proc/flame_radius(radius = 1, turf/T, burn_intensity = 25, burn_duration = 25, b
 /obj/item/explosive/grenade/flare/proc/update_brightness()
 	if(active && fuel > 0)
 		icon_state = "[initial(icon_state)]_active"
-		set_light(5)
+		set_light(5, l_color = LIGHT_COLOR_FLARE)
 	else
 		icon_state = initial(icon_state)
 		set_light(0)

--- a/code/modules/projectiles/updated_projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/flamer.dm
@@ -546,19 +546,26 @@
 	updatehealth()
 
 /obj/flamer_fire/proc/updateicon()
-	if(burnlevel < 15)
-		color = "#c1c1c1" //make it darker to make show its weaker.
+	var/light_color = "red"
+	var/light_intensity = 3
+	switch(flame_color)
+		if("red")
+			light_color = LIGHT_COLOR_LAVA
+		if("blue")
+			light_color = LIGHT_COLOR_CYAN
+		if("green")
+			light_color = LIGHT_COLOR_GREEN
 	switch(firelevel)
 		if(1 to 9)
 			icon_state = "[flame_color]_1"
-			set_light(2)
+			light_intensity = 2
 		if(10 to 25)
 			icon_state = "[flame_color]_2"
-			set_light(4)
+			light_intensity = 4
 		if(25 to INFINITY) //Change the icons and luminosity based on the fire's intensity
 			icon_state = "[flame_color]_3"
-			set_light(6)
-
+			light_intensity = 6
+	set_light(light_intensity, null, light_color)
 
 /obj/flamer_fire/process()
 	var/turf/T = loc

--- a/code/modules/projectiles/updated_projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/flamer.dm
@@ -546,7 +546,7 @@
 	updatehealth()
 
 /obj/flamer_fire/proc/updateicon()
-	var/light_color = "red"
+	var/light_color = "LIGHT_COLOR_LAVA"
 	var/light_intensity = 3
 	switch(flame_color)
 		if("red")


### PR DESCRIPTION
## About The Pull Request
This makes fire have different colored light with an intensity based on how strong the fire is.
It also makes light from flares colored.

Normal fire:
![firered](https://user-images.githubusercontent.com/35285914/65381789-f8a8f080-dcc5-11e9-9eff-289feee92bd4.PNG)

Blue fire
![fireblue](https://user-images.githubusercontent.com/35285914/65381795-078fa300-dcc6-11e9-9ee3-a830d7fe0566.PNG)

Green fire
![firegreen](https://user-images.githubusercontent.com/35285914/65381797-0c545700-dcc6-11e9-9504-487bbf0299f0.PNG)

![flarelight](https://user-images.githubusercontent.com/35285914/65395484-55111c00-dd69-11e9-9b62-3b443b2a4ce2.PNG)


## Why It's Good For The Game

It looks nice, and makes good use of dynamic lighting.

## Changelog
:cl:
add: Fire will now make colored light, based on the color of the fire.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
