### PR TITLE
Fixes focus chat dropping input with high APM

### DIFF
--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -4,6 +4,13 @@
 	set instant = TRUE
 	set hidden = TRUE
 
+	//Due to performance reasons, Focus Chat needs this to return as early as possible.
+	//If this is triggered at all it's likely that the map has focus.
+	if(prefs.focus_chat && length(_key) == 1)
+		winset(src, null, "input.focus=true")
+		winset(src, null, "input.text=[url_encode(_key)]")
+		return
+
 	if(length(key) > 32)
 		log_admin("[key_name(src)] just attempted to send an invalid keypress with length over 32 characters, likely malicious.")
 		message_admins("[ADMIN_TPMONTY(mob)] just attempted to send an invalid keypress with length over 32 characters, likely malicious.")
@@ -13,19 +20,13 @@
 	keys_held[current_key_address + 1] = _key
 
 	keys_held[_key] = world.time
-	
+
 	current_key_address = ((current_key_address + 1) % 10)
 
 	var/movement = SSinput.movement_keys[_key]
 	if(!(next_move_dir_sub & movement) && !keys_held["Ctrl"])
 		next_move_dir_add |= movement
 
-	//Keys longer than 1 aren't printable, so we process them normally, regardless of Focus Chat.
-	//Otherwise, return focus to chat window if it isn't already, and relay the character.
-	if(prefs.focus_chat && !winget(src, null, "input.focus") && length(_key) == 1)
-		winset(src, null, "input.focus=true")
-		winset(src, null, "input.text=[url_encode(_key)]")
-		return
 
 	// Client-level keybindings are ones anyone should be able to do at any time
 	// Things like taking screenshots, hitting tab, and adminhelps.


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Moves the focus chat return point earlier in the input processing code.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's this or someone refactors the way keybindings are handled at a base level. Focus chat is inherently incompatible with the current way controls are handled. (`any` macro).

This is still undoubtedly going to have issues and be clunky.
