### PR TITLE
Hijacks /client/click() to return focus to the input bar, Fixes FC dropping input.

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -49,7 +49,7 @@
 
 	if(object && object == middragatom && L["left"])
 		ab = max(0, 5 SECONDS - (world.time - middragtime) * 0.1)
-		
+
 	var/mcl = CONFIG_GET(number/minute_click_limit)
 	if(mcl && !check_rights(R_ADMIN, FALSE))
 		var/minute = round(world.time, 600)
@@ -83,6 +83,10 @@
 		if(clicklimiter[2] > scl)
 			to_chat(src, "<span class='danger'>Your previous click was ignored because you've done too many in a second</span>")
 			return
+
+//Hijack for FC.
+	if(prefs.focus_chat)
+		winset(src, null, "input.focus=true")
 
 	return ..()
 
@@ -431,7 +435,7 @@
 
 /mob/living/ShiftMiddleClickOn(atom/A)
 	point_to(A)
-		
+
 
 /atom/proc/CtrlShiftClick(mob/user)
 	SEND_SIGNAL(src, COMSIG_CLICK_CTRL_SHIFT)

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -4,19 +4,17 @@
 	set instant = TRUE
 	set hidden = TRUE
 
-	//Keys longer than 1 aren't printable, so we process them normally, regardless of Focus Chat.
-	//Otherwise, return focus to chat window if it isn't already, and relay the character.
-	//This needs to be processed as soon as possible for timing reasons, including making assumptions.
-	//This shouldn't fire if things go right anyways.
-	if(prefs.focus_chat && length(_key) == 1)
-		winset(src, null, "input.focus=true")
-		winset(src, null, "input.text=[url_encode(_key)]")
-		return
-
 	if(length(key) > 32)
 		log_admin("[key_name(src)] just attempted to send an invalid keypress with length over 32 characters, likely malicious.")
 		message_admins("[ADMIN_TPMONTY(mob)] just attempted to send an invalid keypress with length over 32 characters, likely malicious.")
 		QDEL_IN(src, 1)
+		return
+
+
+//Focus Chat failsafe. Overrides movement checks to prevent WASD.
+	if(prefs.focus_chat && length(_key) == 1)
+		winset(src, null, "input.focus=true")
+		winset(src, null, "input.text=[url_encode(_key)]")
 		return
 
 	keys_held[current_key_address + 1] = _key

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -4,6 +4,15 @@
 	set instant = TRUE
 	set hidden = TRUE
 
+	//Keys longer than 1 aren't printable, so we process them normally, regardless of Focus Chat.
+	//Otherwise, return focus to chat window if it isn't already, and relay the character.
+	//This needs to be processed as soon as possible for timing reasons, including making assumptions.
+	//This shouldn't fire if things go right anyways.
+	if(prefs.focus_chat && length(_key) == 1)
+		winset(src, null, "input.focus=true")
+		winset(src, null, "input.text=[url_encode(_key)]")
+		return
+
 	if(length(key) > 32)
 		log_admin("[key_name(src)] just attempted to send an invalid keypress with length over 32 characters, likely malicious.")
 		message_admins("[ADMIN_TPMONTY(mob)] just attempted to send an invalid keypress with length over 32 characters, likely malicious.")
@@ -13,19 +22,14 @@
 	keys_held[current_key_address + 1] = _key
 
 	keys_held[_key] = world.time
-	
+
 	current_key_address = ((current_key_address + 1) % 10)
 
 	var/movement = SSinput.movement_keys[_key]
 	if(!(next_move_dir_sub & movement) && !keys_held["Ctrl"])
 		next_move_dir_add |= movement
 
-	//Keys longer than 1 aren't printable, so we process them normally, regardless of Focus Chat.
-	//Otherwise, return focus to chat window if it isn't already, and relay the character.
-	if(prefs.focus_chat && !winget(src, null, "input.focus") && length(_key) == 1)
-		winset(src, null, "input.focus=true")
-		winset(src, null, "input.text=[url_encode(_key)]")
-		return
+
 
 	// Client-level keybindings are ones anyone should be able to do at any time
 	// Things like taking screenshots, hitting tab, and adminhelps.


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Why can't we treat the text box as a variable.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Focus Chat should work fine now.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Francinum
refactor: Focus Chat should now operate roughly in line with expected behavior.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
