### PR TITLE
Revolver runtime fix

### DIFF
--- a/code/modules/projectiles/updated_projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/revolvers.dm
@@ -36,7 +36,9 @@
 
 
 /obj/item/weapon/gun/revolver/examine_ammo_count(mob/user)
-	to_chat(user, "[current_mag?.chamber_closed? "It's closed.": "It's open with [current_mag.current_rounds] round\s loaded."]")
+	if(!current_mag)
+		return
+	to_chat(user, "[current_mag.chamber_closed ? "It's closed." : "It's open with [current_mag.current_rounds] round\s loaded."]")
 
 /obj/item/weapon/gun/revolver/update_icon() //Special snowflake update icon.
 	icon_state = current_mag.chamber_closed ? initial(icon_state) : initial(icon_state) + "_o"


### PR DESCRIPTION
```
[18:29:03] Runtime in revolvers.dm, line 39: Cannot read null.current_rounds
proc name: examine ammo count (/obj/item/weapon/gun/revolver/examine_ammo_count)
usr: CKEY/(Leon Kennedy)
usr.loc: (General Offices (141, 164, 2))
src: the N-Y 7.62mm revolver (/obj/item/weapon/gun/revolver/upp)
src.loc: null
call stack:
the N-Y 7.62mm revolver (/obj/item/weapon/gun/revolver/upp): examine ammo count(Leon Kennedy (/mob/dead/observer))
the N-Y 7.62mm revolver (/obj/item/weapon/gun/revolver/upp): examine(Leon Kennedy (/mob/dead/observer))
Leon Kennedy (/mob/dead/observer): Examine(the N-Y 7.62mm revolver (/obj/item/weapon/gun/revolver/upp))
the N-Y 7.62mm revolver (/obj/item/weapon/gun/revolver/upp): ShiftClick(Leon Kennedy (/mob/dead/observer))
Leon Kennedy (/mob/dead/observer): ShiftClickOn(the N-Y 7.62mm revolver (/obj/item/weapon/gun/revolver/upp))
Leon Kennedy (/mob/dead/observer): ClickOn(the N-Y 7.62mm revolver (/obj/item/weapon/gun/revolver/upp), "icon-x=21;icon-y=15;left=1;shi...")
the N-Y 7.62mm revolver (/obj/item/weapon/gun/revolver/upp): Click(the floor (138,166,2) (/turf/open/floor/tile/dark), "mapwindow.map", "icon-x=21;icon-y=15;left=1;shi...")
MetroidLover (/client): Click(the N-Y 7.62mm revolver (/obj/item/weapon/gun/revolver/upp), the floor (138,166,2) (/turf/open/floor/tile/dark), "mapwindow.map", "icon-x=21;icon-y=15;left=1;shi...")
```