### PR TITLE
Xeno ability destroy fix

### DIFF
--- a/code/datums/actions/xeno_action.dm
+++ b/code/datums/actions/xeno_action.dm
@@ -162,6 +162,14 @@
 /datum/action/xeno_action/activable/New()
 	. = ..()
 
+
+/datum/action/xeno_action/activable/Destroy()
+	var/mob/living/carbon/xenomorph/X = owner
+	if(X.selected_ability == src)
+		deselect()
+	return ..()
+
+
 /datum/action/xeno_action/activable/keybind_activation()
 	. = COMSIG_KB_ACTIVATED
 	if(CHECK_BITFIELD(keybind_flags, XACT_KEYBIND_USE_ABILITY))


### PR DESCRIPTION
There was no provision for a selected ability being deleted, because it didn't happen before, unlike now:
```
[18:46:25] Runtime in xeno_action.dm, line 220: Cannot read null.selected_ability
proc name: can use ability (/datum/action/xeno_action/activable/proc/can_use_ability)
usr: CKEY/(Ancient Shrike)
usr.loc: (Nanotrasen Research Lab (103, 56, 2))
src: Corrosive Acid (100) (/datum/action/xeno_action/activable/corrosive_acid)
call stack:
Corrosive Acid (100) (/datum/action/xeno_action/activable/corrosive_acid): can use ability(the table (/obj/structure/table), 1, null)
Corrosive Acid (100) (/datum/action/xeno_action/activable/corrosive_acid): can use ability(the table (/obj/structure/table), 1)
Corrosive Acid (100) (/datum/action/xeno_action/activable/corrosive_acid): use ability(the table (/obj/structure/table))
Ancient Shrike (/mob/living/carbon/xenomorph/shrike): MiddleClickOn(the table (/obj/structure/table))
Ancient Shrike (/mob/living/carbon/xenomorph/shrike): ClickOn(the table (/obj/structure/table), "icon-x=9;icon-y=21;middle=1;sc...")
the table (/obj/structure/table): Click(the floor (104,56,2) (/turf/open/floor/tile/dark), "mapwindow.map", "icon-x=9;icon-y=21;middle=1;sc...")
```