### PR TITLE
Rogue shots fixes

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -64,4 +64,5 @@
 		return TRUE
 	if(user.inquisitive_ghost)
 		user.examinate(src)
+		return TRUE
 	return FALSE

--- a/code/game/objects/machinery.dm
+++ b/code/game/objects/machinery.dm
@@ -172,6 +172,10 @@
 
 
 /obj/machinery/attack_ghost(mob/dead/observer/user)
+	. = ..()
+	if(.)
+		return //Already handled.
+
 	if(CHECK_BITFIELD(machine_stat, PANEL_OPEN) && wires && wires.interact(user))
 		return TRUE
 

--- a/code/game/objects/machinery/sentries.dm
+++ b/code/game/objects/machinery/sentries.dm
@@ -834,8 +834,10 @@
 
 	DISABLE_BITFIELD(turret_flags, TURRET_MANUAL)
 	target = get_target()
+	if(QDELETED(target))
+		return
 	process_shot()
-	return
+
 
 /obj/machinery/marine_turret/proc/load_into_chamber()
 	if(in_chamber)

--- a/code/game/objects/machinery/smartgun_mount.dm
+++ b/code/game/objects/machinery/smartgun_mount.dm
@@ -432,6 +432,39 @@
 		I.transform = rotate
 		flick_overlay_view(I, src, 3)
 
+
+/obj/machinery/m56d_hmg/interact(mob/user)
+	if(!ishuman(user))
+		return TRUE
+	var/mob/living/carbon/human/human_user = user
+	if(user.interactee == src)
+		user.unset_interaction()
+		visible_message("[icon2html(src, viewers(src))] <span class='notice'>[user] decided to let someone else have a go </span>",
+			"<span class='notice'>You decided to let someone else have a go on the MG </span>")
+		return TRUE
+	if(get_step(src, REVERSE_DIR(dir)) != user.loc)
+		to_chat(user, "<span class='warning'>You should be behind [src] to man it!</span>")
+		return TRUE
+	if(operator) //If there is already a operator then they're manning it.
+		if(!operator.interactee)
+			stack_trace("/obj/machinery/m56d_hmg/interact called by user [user] with an operator with a null interactee: [operator].")
+			operator = null //this shouldn't happen, but just in case
+		else
+			to_chat(user, "<span class='warning'>Someone's already controlling it.</span>")
+			return TRUE
+	if(user.interactee) //Make sure we're not manning two guns at once, tentacle arms.
+		to_chat(user, "<span class='warning'>You're already busy!</span>")
+		return TRUE
+	if(issynth(human_user) && !CONFIG_GET(flag/allow_synthetic_gun_use))
+		to_chat(user, "<span class='warning'>Your programming restricts operating heavy weaponry.</span>")
+		return TRUE
+
+	visible_message("[icon2html(src, viewers(src))] <span class='notice'>[user] mans the M56D!</span>",
+		"<span class='notice'>You man the gun!</span>")
+
+	return ..()
+
+
 /obj/machinery/m56d_hmg/MouseDrop(over_object, src_location, over_location) //Drag the MG to us to man it.
 	if(!ishuman(usr))
 		return

--- a/code/game/objects/machinery/smartgun_mount.dm
+++ b/code/game/objects/machinery/smartgun_mount.dm
@@ -483,6 +483,8 @@
 	target = object
 	if(!istype(target))
 		return FALSE
+	if(user != operator)
+		CRASH("InterceptClickOn called by user ([user]) different from operator ([operator]).")
 	if(isnull(operator.loc) || isnull(loc) || !z || !target?.z == z)
 		return FALSE
 	if(get_dist(target, loc) > 15)

--- a/code/modules/admin/holder.dm
+++ b/code/modules/admin/holder.dm
@@ -638,11 +638,9 @@ GLOBAL_PROTECT(admin_verbs_spawn)
 
 
 /proc/IsAdminGhost(mob/user)
-	if(!istype(user))
+	if(!isobserver(user))
 		return FALSE
 	if(!user.client)
-		return FALSE
-	if(!isobserver(user))
 		return FALSE
 	if(!check_other_rights(user.client, R_ADMIN, FALSE)) // Are they allowed?
 		return FALSE


### PR DESCRIPTION
* Fixed ghosts being able to interact with M56Ds and use them to shoot, a side-effect of the interaction rework:
```
[19:13:59] Runtime in smartgun_mount.dm, line 486: Cannot read null.loc
proc name: InterceptClickOn (/obj/machinery/m56d_hmg/InterceptClickOn)
usr: CKEY/(Andrew Johnes)
usr.loc: (Self-Destruct Core Room (226, 189, 3))
src: the M56D mounted smartgun (/obj/machinery/m56d_hmg)
src.loc: the floor (225,189,3) (/turf/open/shuttle/escapepod)
call stack:
the M56D mounted smartgun (/obj/machinery/m56d_hmg): InterceptClickOn(Andrew Johnes (/mob/living/carbon/human), "icon-x=31;icon-y=19;left=1;scr...", Ancient Shrike (/mob/living/carbon/xenomorph/shrike))
Andrew Johnes (/mob/living/carbon/human): check click intercept("icon-x=31;icon-y=19;left=1;scr...", Ancient Shrike (/mob/living/carbon/xenomorph/shrike))
Andrew Johnes (/mob/living/carbon/human): ClickOn(Ancient Shrike (/mob/living/carbon/xenomorph/shrike), "icon-x=31;icon-y=19;left=1;scr...")
Ancient Shrike (/mob/living/carbon/xenomorph/shrike): Click(the floor (217,189,3) (/turf/open/floor/mainship), "mapwindow.map", "icon-x=31;icon-y=19;left=1;scr...")
Pirao (/client): Click(Ancient Shrike (/mob/living/carbon/xenomorph/shrike), the floor (217,189,3) (/turf/open/floor/mainship), "mapwindow.map", "icon-x=31;icon-y=19;left=1;scr...")
```

* Fixed:
```
[21:40:24] Runtime in unsorted.dm, line 37: fire_at called on a QDELETED target (Elder Hunter (644)) with no original_target_turf and a null angle.
proc name: stack trace (/datum/proc/stack_trace)
src: the gauss turret heavy slug (/obj/item/projectile)
src.loc: UA-577 Gauss Dropship Turret (/obj/machinery/marine_turret/premade/dropship)
call stack:
the gauss turret heavy slug (/obj/item/projectile): stack trace("fire_at called on a QDELETED t...")
the gauss turret heavy slug (/obj/item/projectile): fire at(Elder Hunter (644) (/mob/living/carbon/xenomorph/hunter), UA-577 Gauss Dropship Turret (/obj/machinery/marine_turret/premade/dropship), null, 20, 3, null, null)
UA-577 Gauss Dropship Turret (/obj/machinery/marine_turret/premade/dropship): fire shot()
UA-577 Gauss Dropship Turret (/obj/machinery/marine_turret/premade/dropship): process shot()
```