### PR TITLE
Fixes another hallucination runtime

### DIFF
--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -353,7 +353,7 @@ proc/check_panel(mob/M)
 	var/obj/effect/overlay/O = new/obj/effect/overlay(target.loc)
 	O.name = "blood"
 	var/image/I = image('icons/effects/blood.dmi',O,"floor[rand(1,7)]",O.dir,1)
-	to_chat(target, I)
+	SEND_IMAGE(target, I)
 	QDEL_IN(O, 30 SECONDS)
 
 GLOBAL_LIST_INIT(non_fakeattack_weapons, list(/obj/item/clothing/shoes/magboots, /obj/item/disk/nuclear,\


### PR DESCRIPTION
```
[22:28:47] Runtime in chat.dm, line 27: to_chat called with invalid input type: /image
proc name: queue (/datum/controller/subsystem/chat/proc/queue)
src: Chat (/datum/controller/subsystem/chat)
call stack:
Chat (/datum/controller/subsystem/chat): queue(William Westmoreland (/mob/living/carbon/human), , 1)
to chat(William Westmoreland (/mob/living/carbon/human), , 1)
fake blood(William Westmoreland (/mob/living/carbon/human))
David \'Snake\' Stormwell (/obj/effect/fake_attacker): attack loop()
David \'Snake\' Stormwell (/obj/effect/fake_attacker): New(the tool closet (/obj/structure/closet/toolcloset))
```