### PR TITLE
Removes the Melee malus on revolver stock

### DIFF
--- a/code/modules/projectiles/updated_projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_attachables.dm
@@ -764,10 +764,9 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/stock/revolver
 	name = "\improper M44 magnum sharpshooter stock"
-	desc = "A wooden stock modified for use on a 44-magnum. Increases accuracy and reduces recoil at the expense of handling and agility. Less effective in melee as well"
+	desc = "A wooden stock modified for use on a 44-magnum. Increases accuracy and reduces recoil at the expense of handling and agility."
 	slot = "stock"
 	wield_delay_mod = 0.2 SECONDS
-	melee_mod = -5
 	size_mod = 2
 	icon_state = "44stock"
 	pixel_shift_x = 35


### PR DESCRIPTION
## About The Pull Request

Removes revolver stock's melee damage reduction

## Why It's Good For The Game

You already have to do so much for the revolver to mean anything, and why does THIS PARTICULAR STOCK go against EVERY OTHER STOCK and decrease melee damage

## Changelog
:cl: MetroidLover
balance: Revolver Stocks no longer reduce melee damage
/:cl:
