### PR TITLE
Fix the minigun belt making equip sounds every time it's picked up

### DIFF
--- a/code/game/objects/items/storage/marine_boxes.dm
+++ b/code/game/objects/items/storage/marine_boxes.dm
@@ -511,7 +511,8 @@
 	time_to_equip = 2 SECONDS
 
 /obj/item/minigun_harness/equipped(mob/living/carbon/human/user, slot)
-	playsound(src,'sound/machines/click.ogg', 15, FALSE, 1)
+	if(slot == SLOT_BELT)
+		playsound(src,'sound/machines/click.ogg', 15, FALSE, 1)
 
 
 /obj/item/spec_kit //For events/WO, allowing the user to choose a specalist kit


### PR DESCRIPTION

Oops.

## Changelog
:cl:
fix: The heavy duty harness no longer makes an equipping noise every time you pick it up.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
