### PR TITLE
ZX is now an admin only weapon

### DIFF
--- a/_maps/map_files/generic/Admin_Level.dmm
+++ b/_maps/map_files/generic/Admin_Level.dmm
@@ -679,7 +679,6 @@
 /obj/item/storage/box/spec/heavy_gunner,
 /obj/item/storage/box/spec/pyro,
 /obj/item/storage/box/spec/scout,
-/obj/item/storage/box/spec/scoutshotgun,
 /obj/item/storage/box/spec/sniper,
 /turf/open/floor/mainship{
 	dir = 5;

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -251,17 +251,6 @@ WEAPONS
 	containername = "\improper MIC A7 Vindicator Minigun crate"
 	group = "Weapons"
 
-/datum/supply_packs/specshotgun
-	name = "ZX-76 Assault Shotgun crate (ZX-76 x1)"
-	contains = list(
-					/obj/item/weapon/gun/shotgun/merc/scout
-					)
-	cost = RO_PRICE_VERY_PRICY
-	containertype = /obj/structure/closet/crate/weapon
-	containername = "\improper ZX-76 Assault Shotgun crate"
-	group = "Weapons"
-
-
 /datum/supply_packs/flamethrower
 	name = "M240 Flamethrower crate (M240 x3)"
 	contains = list(

--- a/code/game/objects/items/storage/marine_boxes.dm
+++ b/code/game/objects/items/storage/marine_boxes.dm
@@ -399,37 +399,6 @@
 	new /obj/item/bodybag/tarp(src)
 
 
-/obj/item/storage/box/spec/scoutshotgun
-	name = "\improper Scout equipment"
-	desc = "A large case containing Scout equipment; this one features the ZX-76 assault shotgun. Drag this sprite into you to open it up!\nNOTE: You cannot put items back inside this case."
-	icon = 'icons/Marine/marine-weapons.dmi'
-	icon_state = "sniper_case"
-	w_class = WEIGHT_CLASS_HUGE
-	storage_slots = 21
-	slowdown = 1
-	can_hold = list() //Nada. Once you take the stuff out it doesn't fit back in.
-	foldable = null
-	spec_set = "scout shotgun"
-
-/obj/item/storage/box/spec/scoutshotgun/Initialize(mapload, ...)
-	. = ..()
-	new /obj/item/clothing/suit/storage/marine/M3S(src)
-	new /obj/item/clothing/head/helmet/marine/scout(src)
-	new /obj/item/clothing/glasses/night/M4RA(src)
-	new /obj/item/binoculars/tactical/scout(src)
-	new /obj/item/weapon/gun/pistol/vp70(src)
-	new /obj/item/ammo_magazine/pistol/vp70(src)
-	new /obj/item/ammo_magazine/pistol/vp70(src)
-	new /obj/item/weapon/gun/shotgun/merc/scout(src)
-	new /obj/item/ammo_magazine/shotgun/incendiary(src)
-	new /obj/item/ammo_magazine/shotgun/incendiary(src)
-	new /obj/item/storage/backpack/marine/satchel/scout_cloak/scout(src)
-	new /obj/item/motiondetector/scout(src)
-	new /obj/item/explosive/grenade/cloakbomb(src)
-	new /obj/item/explosive/grenade/cloakbomb(src)
-	new /obj/item/explosive/grenade/cloakbomb(src)
-
-
 /obj/item/storage/box/spec/pyro
 	name = "\improper Pyrotechnician equipment"
 	desc = "A large case containing Pyrotechnician equipment. Drag this sprite into you to open it up!\nNOTE: You cannot put items back inside this case."
@@ -521,7 +490,7 @@
 	icon_state = "deliverycrate"
 
 /obj/item/spec_kit/attack_self(mob/user as mob)
-	var/choice = input(user, "Please pick a specalist kit!","Selection") in list("Pyro","Heavy Armor (Grenadier)","Heavy Armor (Minigun)","Sniper","Scout (Battle Rifle)","Scout (Shotgun)","Demo")
+	var/choice = input(user, "Please pick a specalist kit!","Selection") in list("Pyro","Heavy Armor (Grenadier)","Heavy Armor (Minigun)","Sniper","Scout (Battle Rifle)","Demo")
 	var/obj/item/storage/box/spec/S = null
 	switch(choice)
 		if("Pyro")
@@ -534,8 +503,6 @@
 			S = /obj/item/storage/box/spec/sniper
 		if("Scout (Battle Rifle)")
 			S = /obj/item/storage/box/spec/scout
-		if("Scout (Shotgun)")
-			S = /obj/item/storage/box/spec/scoutshotgun
 		if("Demo")
 			S = /obj/item/storage/box/spec/demolitionist
 	new S(loc)

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -506,7 +506,6 @@
 					/obj/item/storage/box/spec/heavy_grenadier = 1,
 					/obj/item/storage/box/spec/sniper = 1,
 					/obj/item/storage/box/spec/scout = 1,
-					/obj/item/storage/box/spec/scoutshotgun = 1,
 					/obj/item/storage/box/spec/pyro = 1
 			)
 	prices = list()

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -922,7 +922,6 @@ GLOBAL_LIST_INIT(available_specialist_sets, list("Scout Set", "Sniper Set", "Dem
 	listed_products = list(
 							list("SPECIALIST SETS (Choose one)", 0, null, null, null),
 							list("Scout Set (Battle Rifle)", 0, /obj/item/storage/box/spec/scout, MARINE_CAN_BUY_ESSENTIALS, "white"),
-							list("Scout Set (Shotgun)", 0, /obj/item/storage/box/spec/scoutshotgun, MARINE_CAN_BUY_ESSENTIALS, "white"),
 							list("Sniper Set", 0, /obj/item/storage/box/spec/sniper, MARINE_CAN_BUY_ESSENTIALS, "white"),
 							list("Demolitionist Set", 0, /obj/item/storage/box/spec/demolitionist, MARINE_CAN_BUY_ESSENTIALS, "white"),
 							list("Heavy Armor Set (Grenadier)", 0, /obj/item/storage/box/spec/heavy_grenadier, MARINE_CAN_BUY_ESSENTIALS, "white"),


### PR DESCRIPTION
## About The Pull Request

The ZX now only exists in the code, and it's spec kit is gone, reduced to atoms along with any mention of it
## Why It's Good For The Game

It may be too much work to change it at this point, we can just give the scout another weapon that isn't the ZX
## Changelog
:cl: MetroidLover
del: Removed the ZX scout kit and the ZX crate
/:cl:
