### PR TITLE
Deletion and bad client runtimes fixes

### DIFF
--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -122,7 +122,7 @@
 /datum/browser/proc/setup_onclose()
 	set waitfor = FALSE //winexists sleeps, so we don't need to.
 	for(var/i in 1 to 10)
-		if(user && winexists(user, window_id))
+		if(!QDELETED(user) && winexists(user, window_id))
 			onclose(user, window_id, ref)
 			break
 

--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -122,7 +122,9 @@
 /datum/browser/proc/setup_onclose()
 	set waitfor = FALSE //winexists sleeps, so we don't need to.
 	for(var/i in 1 to 10)
-		if(!QDELETED(user) && winexists(user, window_id))
+		if(QDELETED(user))
+			return
+		if(winexists(user, window_id))
 			onclose(user, window_id, ref)
 			break
 

--- a/code/game/objects/items/radio/headset.dm
+++ b/code/game/objects/items/radio/headset.dm
@@ -191,16 +191,17 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 
 
 /obj/item/radio/headset/mainship/Destroy()
-	if(wearer && headset_hud_on)
-		if(wearer.wear_ear == src)
+	if(wearer)
+		if(headset_hud_on && wearer.wear_ear == src)
 			squadhud.remove_hud_from(wearer)
 			wearer.SL_directional = null
 			if(wearer.assigned_squad)
 				SSdirection.stop_tracking(wearer.assigned_squad.tracking_id, wearer)
-			wearer = null
+		wearer = null
 	squadhud = null
 	headset_hud_on = FALSE
 	sl_direction = null
+	QDEL_NULL(camera)
 	return ..()
 
 

--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -37,6 +37,6 @@ GLOBAL_LIST_EMPTY(dummy_mob_list)
 	if(!slotnumber)
 		return
 	var/mob/living/carbon/human/dummy/D = GLOB.human_dummy_list[slotnumber]
-	if(istype(D))
+	if(!QDELETED(D))
 		D.wipe_state()
 		D.in_use = FALSE

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -547,6 +547,7 @@
 	max_integrity = 10 	//Health points 0-10
 	layer = DISPOSAL_PIPE_LAYER //Slightly lower than wires and other pipes
 	plane = FLOOR_PLANE
+	resistance_flags = RESIST_ALL
 	var/base_icon_state	//Initial icon state on map
 
 	//New pipe, set the icon_state as on map


### PR DESCRIPTION
* Fixes a runtime on a client that exists but is being destroyed:
```
[06:48:07] Runtime in browser.dm, line 125: bad client
proc name: setup onclose (/datum/browser/proc/setup_onclose)
src: /datum/browser/modal/alert (/datum/browser/modal/alert)
call stack:
/datum/browser/modal/alert (/datum/browser/modal/alert): setup onclose()
```

*Attempts to fix a runtime on a bad deletion, probably for uncleaned references, but fails:
```
[06:32:20] Runtime in garbage.dm, line 254: bad del
proc name: qdel (/proc/qdel)
usr: CKEY/(CKEY)
src: null
call stack:
qdel(null, 0)
the marine command radio heads... (/obj/item/radio/headset/mainship/mcom): Destroy(0)
the marine command radio heads... (/obj/item/radio/headset/mainship/mcom): Destroy(0)
the marine command radio heads... (/obj/item/radio/headset/mainship/mcom): Destroy(0)
qdel(the marine command radio heads... (/obj/item/radio/headset/mainship/mcom), 0)
Allie Bell (as Unknown) (/mob/living/carbon/human/dummy): delete equipment(0)
Allie Bell (as Unknown) (/mob/living/carbon/human/dummy): wipe state()
unset busy human dummy("dummy_preference_preview")
/datum/preferences (/datum/preferences): update preview icon()
/datum/preferences (/datum/preferences): ShowChoices(CKEY(/mob/new_player))
CKEY(/mob/new_player): Topic("src=\[mob_10];lobby_choice=sho...", /list (/list))
CKEY(/client): Topic("src=\[mob_10];lobby_choice=sho...", /list (/list), CKEY(/mob/new_player))
CKEY(/client): Topic("src=\[mob_10];lobby_choice=sho...", /list (/list), CKEY(/mob/new_player))
```
*Fixes disposal pipes being destructible with the object damage rework. They were not before, and that causes runtimes, besides that there's no gamplay reason to allow that behavior.