### PR TITLE
makes AI not go to EORDM

### DIFF
--- a/code/datums/gamemodes/game_mode.dm
+++ b/code/datums/gamemodes/game_mode.dm
@@ -483,7 +483,7 @@ Sensors indicate [numXenosShip ? "[numXenosShip]" : "no"] unknown lifeform signa
 			continue
 
 		var/mob/living/L
-		if(!isliving(M))
+		if(!isliving(M)|isAI(M))
 			L = new /mob/living/carbon/human(picked)
 			M.mind.transfer_to(L, TRUE)
 		else

--- a/code/datums/gamemodes/game_mode.dm
+++ b/code/datums/gamemodes/game_mode.dm
@@ -483,7 +483,7 @@ Sensors indicate [numXenosShip ? "[numXenosShip]" : "no"] unknown lifeform signa
 			continue
 
 		var/mob/living/L
-		if(!isliving(M)|isAI(M))
+		if(!isliving(M) || isAI(M))
 			L = new /mob/living/carbon/human(picked)
 			M.mind.transfer_to(L, TRUE)
 		else


### PR DESCRIPTION
:cl:
fix: AI no longer goes to the end-of-round deathmatch.
/:cl:
they should be treated as ghosts are, meaning they spawn as ERT people in the arena.
Fixes: #2982 