### PR TITLE
Buffs base marine glove melee protection.

### DIFF
--- a/code/modules/clothing/gloves/marine_gloves.dm
+++ b/code/modules/clothing/gloves/marine_gloves.dm
@@ -15,7 +15,7 @@
 	min_cold_protection_temperature = GLOVES_MIN_COLD_PROTECTION_TEMPERATURE
 	max_heat_protection_temperature = GLOVES_MAX_HEAT_PROTECTION_TEMPERATURE
 	flags_armor_protection = HANDS
-	armor = list("melee" = 60, "bullet" = 40, "laser" = 30, "energy" = 20, "bomb" = 30, "bio" = 10, "rad" = 10, "fire" = 20, "acid" = 20)
+	armor = list("melee" = 80, "bullet" = 40, "laser" = 30, "energy" = 20, "bomb" = 30, "bio" = 10, "rad" = 10, "fire" = 20, "acid" = 20)
 
 
 /obj/item/clothing/gloves/marine/Initialize(mapload, squad, rank)
@@ -106,7 +106,7 @@
 	desc = "A pair of heavily armored gloves."
 	icon_state = "armored"
 	item_state = "bgloves"
-	armor = list("melee" = 80, "bullet" = 95, "laser" = 80, "energy" = 80, "bomb" = 80, "bio" = 20, "rad" = 20, "fire" = 80, "acid" = 80)
+	armor = list("melee" = 95, "bullet" = 95, "laser" = 80, "energy" = 80, "bomb" = 80, "bio" = 20, "rad" = 20, "fire" = 80, "acid" = 80)
 	resistance_flags = UNACIDABLE
 
 /obj/item/clothing/gloves/marine/veteran/PMC


### PR DESCRIPTION

## About The Pull Request

Makes Base Marine gloves go from 60->80 and B18 from 80->95

## Why It's Good For The Game

Makes delimbs harder for non dedicated melee castes and makes going for that epic delimb a bigger risk in general.
## Changelog
:cl:Buffed marine glove melee defense.
/🆑



