### PR TITLE
Ravagers now gain rage on slashing humans; no more rage gained from taking damage

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/ravager.dm
@@ -24,10 +24,7 @@
 // ***************************************
 /mob/living/carbon/xenomorph/ravager/Initialize(mapload, can_spawn_in_centcomm)
 	. = ..()
-	RegisterSignal(src, list(
-		COMSIG_XENOMORPH_BRUTE_DAMAGE,
-		COMSIG_XENOMORPH_BURN_DAMAGE), 
-		.proc/process_rage_damage)
+	RegisterSignal(src, COMSIG_XENOMORPH_ATTACK_HUMAN, .proc/process_rage_attack)
 
 // ***************************************
 // *********** Mob overrides
@@ -72,12 +69,5 @@
 	if(statpanel("Stats"))
 		stat(null, "Rage: [rage] / [RAVAGER_MAX_RAGE]")
 
-// ***************************************
-// *********** Rage
-// ***************************************
-/mob/living/carbon/xenomorph/ravager/proc/process_rage_damage(datum/source, damage, list/damage_mod)
-	if(damage < 1 || cooldowns[COOLDOWN_RAV_NEXT_DAMAGE])
-		return
-	rage += round(damage * RAV_DAMAGE_RAGE_MULITPLIER)
-	
-	cooldowns[COOLDOWN_RAV_NEXT_DAMAGE] = addtimer(VARSET_LIST_CALLBACK(cooldowns, COOLDOWN_RAV_NEXT_DAMAGE, null), 0.2 SECONDS)  // Limit how often this proc can trigger; once per 0.2 seconds
+/mob/living/carbon/xenomorph/ravager/proc/process_rage_attack()
+	rage += RAV_RAGE_ON_HIT


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Removes the component that makes ravagers gain rage upon taking damage and reintroduces the mechanic of ravagers gaining rage when slashing humans

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Ravagers should be rewarded more for actually slashing humans instead of tanking damage, healing then deciding their finally going to use abilities; even in a best case scenario of a ravager hitting 3 dudes with their 1 tile ravage and getting 30 rage, they still need to take about 80-100 damage to actually get full rage and keep it there
## Changelog
:cl:
tweak: Ravagers now gain rage upon slashing humans; reward for actually getting into combat and slashing things
tweak: Ravagers no longer gain rage upon taking damage

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
