### PR TITLE
Fixes a crate runtime

### DIFF
--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -21,21 +21,26 @@
 	. = ..()
 	to_chat(user, "<span class='notice'>You need a crowbar to pry this open!</span>")
 
+
 /obj/structure/largecrate/attackby(obj/item/I, mob/user, params)
 	. = ..()
-
-	if(iscrowbar(I))
-		user.visible_message("<span class='notice'>[user] pries \the [src] open.</span>", \
-							"<span class='notice'>You pry open \the [src].</span>", \
-							"<span class='notice'>You hear splitting wood.</span>")
-		new /obj/item/stack/sheet/wood(src)
-		deconstruct(TRUE)
-		return
+	if(.)
+		return TRUE
 	
 	if(istype(I, /obj/item/powerloader_clamp))
 		return
 	
 	return attack_hand(user)
+
+
+/obj/structure/largecrate/crowbar_act(mob/living/user, obj/item/I)
+	. = ..()
+	user.visible_message("<span class='notice'>[user] pries \the [src] open.</span>",
+		"<span class='notice'>You pry open \the [src].</span>",
+		"<span class='notice'>You hear splitting wood.</span>")
+	new /obj/item/stack/sheet/wood(loc)
+	deconstruct(TRUE)
+	return TRUE
 
 
 /obj/structure/largecrate/proc/spawn_stuff()
@@ -197,24 +202,24 @@
 	icon_state = "secure_crate_strapped"
 	var/strapped = 1
 
-/obj/structure/largecrate/random/secure/attackby(obj/item/I, mob/user, params)
+
+/obj/structure/largecrate/random/secure/crowbar_act(mob/living/user, obj/item/I)
+	if(strapped)
+		return FALSE
+	return ..()
+
+
+/obj/structure/largecrate/random/secure/wirecutter_act(mob/living/user, obj/item/I)
 	. = ..()
-
-	if(!strapped)
-		return
-
-	else if(!I.sharp)
-		return attack_hand(user)
-
 	to_chat(user, "<span class='notice'>You begin to cut the straps off \the [src]...</span>")
-
-	if(!do_after(user, 15, TRUE, src, BUSY_ICON_GENERIC))
-		return
-
+	if(!do_after(user, 1.5 SECONDS, TRUE, src, BUSY_ICON_GENERIC))
+		return TRUE
 	playsound(loc, 'sound/items/wirecutter.ogg', 25, 1)
 	to_chat(user, "<span class='notice'>You cut the straps away.</span>")
 	icon_state = "secure_crate"
 	strapped = FALSE
+	return TRUE
+
 
 /obj/structure/largecrate/random/barrel/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
```
[03:43:32] Runtime in human.dm, line 67: attack_hand on a qdeleted atom
proc name: attack hand (/atom/proc/attack_hand)
usr: CKEY/(Katlyn Rhinehart)
usr.loc: (Hangar (81, 74, 3))
src: the secure supply crate (/obj/structure/largecrate/random/secure)
src.loc: null
call stack:
the secure supply crate (/obj/structure/largecrate/random/secure): attack hand(Katlyn Rhinehart (/mob/living/carbon/human))
the secure supply crate (/obj/structure/largecrate/random/secure): attack hand(Katlyn Rhinehart (/mob/living/carbon/human))
the secure supply crate (/obj/structure/largecrate/random/secure): attack hand(Katlyn Rhinehart (/mob/living/carbon/human))
the secure supply crate (/obj/structure/largecrate/random/secure): attackby(the crowbar (/obj/item/tool/crowbar), Katlyn Rhinehart (/mob/living/carbon/human), "icon-x=17;icon-y=21;left=1;scr...")
the crowbar (/obj/item/tool/crowbar): melee attack chain(Katlyn Rhinehart (/mob/living/carbon/human), the secure supply crate (/obj/structure/largecrate/random/secure), "icon-x=17;icon-y=21;left=1;scr...")
Katlyn Rhinehart (/mob/living/carbon/human): ClickOn(the secure supply crate (/obj/structure/largecrate/random/secure), "icon-x=17;icon-y=21;left=1;scr...")
the secure supply crate (/obj/structure/largecrate/random/secure): Click(the floor (81,75,3) (/turf/open/floor/mainship/mono), "mapwindow.map", "icon-x=17;icon-y=21;left=1;scr...")
CKEY (/client): Click(the secure supply crate (/obj/structure/largecrate/random/secure), the floor (81,75,3) (/turf/open/floor/mainship/mono), "mapwindow.map", "icon-x=17;icon-y=21;left=1;scr...")
```