### PR TITLE
Fixes facehuggers not having their thrown sprite appear

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -60,7 +60,7 @@
 		var/fertility = sterile ? "impregnated" : "dead"
 		icon_state = "[initial(icon_state)]_[fertility]"
 	else if(throwing)
-		icon_state = "[initial(icon_state)]_throwing"
+		icon_state = "[initial(icon_state)]_thrown"
 	else if(stat == UNCONSCIOUS && !attached)
 		icon_state = "[initial(icon_state)]_inactive"
 	else


### PR DESCRIPTION
## About The Pull Request

Thrown facehuggers were invisible because of a spelling error in facehuggers.dm

## Changelog
:cl:
fix: Facehuggers aren't invisible when being thrown anymore.
/:cl: