### PR TITLE
[FIX] Corrects the get_alien proc so it is more random.

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -55,7 +55,7 @@
 		var/turf/speaker = get_turf(R)
 		if(!speaker)
 			continue
-			
+
 		for(var/turf/T in hear(R.canhear_range,speaker))
 			speaker_coverage[T] = T
 
@@ -82,7 +82,7 @@
 /proc/get_alien_candidate()
 	var/mob/dead/observer/picked
 
-	for(var/i in GLOB.observer_list)
+	for(var/i in shuffle(GLOB.observer_list))
 		var/mob/dead/observer/O = i
 		//Players without preferences or jobbaned players cannot be drafted.
 		if(!O.key || !O.mind || !O.client?.prefs || !(O.client.prefs.be_special & (BE_ALIEN|BE_ALIEN_UNREVIVABLE)) || is_banned_from(O.ckey, ROLE_XENOMORPH))

--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -148,7 +148,7 @@
 
 	var/list/valid_candidates = list()
 
-	for(var/i in shuffle(candidates))
+	for(var/i in candidates)
 		var/datum/mind/M = i
 		if(!istype(M)) // invalid
 			continue

--- a/code/datums/emergency_calls/emergency_call.dm
+++ b/code/datums/emergency_calls/emergency_call.dm
@@ -148,7 +148,7 @@
 
 	var/list/valid_candidates = list()
 
-	for(var/i in candidates)
+	for(var/i in shuffle(candidates))
 		var/datum/mind/M = i
 		if(!istype(M)) // invalid
 			continue


### PR DESCRIPTION
## Why It's Good For The Game

Aliens picking are now actually random instead of the first available in the observer list.

## Changelog
:cl:
fix: The first person on the observers list is no longer the next person to be a alien (If they want to be or get picked by a birthing larva maybe)
/:cl:

relevant PR and issue report to understand it.
https://github.com/tgstation/tgstation/pull/26099
https://github.com/tgstation/tgstation/issues/26098
This is likely a massive issue with poor RNG in places. (Because it might not be RNG at all)
