### PR TITLE
Burrowed larva and larva now count towards xenomorph evolution tier and queen calculation

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -21,7 +21,7 @@
 	set name = "Regress"
 	set desc = "Regress into a lower form."
 	set category = "Alien"
-	
+
 	var/tiers_to_pick_from
 	switch(tier)
 		if(XENO_TIER_ZERO, XENO_TIER_FOUR)
@@ -153,7 +153,7 @@
 		if(is_banned_from(ckey, ROLE_XENO_QUEEN))
 			to_chat(src, "<span class='warning'>You are jobbanned from the Queen role.</span>")
 			return
-		
+
 		if(hive.living_xeno_queen)
 			to_chat(src, "<span class='warning'>There already is a living Queen.</span>")
 			return
@@ -188,14 +188,14 @@
 		if(length(hive.xenos_by_typepath[/mob/living/carbon/xenomorph/shrike]))
 			to_chat(src, "<span class='warning'>There already is a living Shrike. The hive cannot contain more than one psychic energy repository.</span>")
 			return
-		
+
 		if(mind)
 			mind.assigned_role = ROLE_XENO_QUEEN
 
 	else
 		var/potential_queens = length(hive.xenos_by_typepath[/mob/living/carbon/xenomorph/larva]) + length(hive.xenos_by_typepath[/mob/living/carbon/xenomorph/drone])
 
-		tierones = length(hive.xenos_by_tier[XENO_TIER_ONE])
+		tierones = length(hive.xenos_by_tier[XENO_TIER_ONE]) + length(hive.xenos_by_tier[XENO_TIER_ZERO]) + length(hive.stored_larva) //Includes larva and burrowed larva
 		tiertwos = length(hive.xenos_by_tier[XENO_TIER_TWO])
 		tierthrees = length(hive.xenos_by_tier[XENO_TIER_THREE])
 

--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -145,6 +145,7 @@
 		return
 
 	// used below
+	var/tierzeros //Larva and burrowed larva if it's a certain kinda hive
 	var/tierones
 	var/tiertwos
 	var/tierthrees
@@ -195,19 +196,17 @@
 	else
 		var/potential_queens = length(hive.xenos_by_typepath[/mob/living/carbon/xenomorph/larva]) + length(hive.xenos_by_typepath[/mob/living/carbon/xenomorph/drone])
 
-		tierones = length(hive.xenos_by_tier[XENO_TIER_ONE]) + length(hive.xenos_by_tier[XENO_TIER_ZERO])
-		if(istype(hive, /datum/hive_status/normal))
-			var/datum/hive_status/normal/normal_hive = hive
-			tierones += normal_hive.stored_larva
+		tierzeros = hive.get_total_tier_zeros()
+		tierones = length(hive.xenos_by_tier[XENO_TIER_ONE])
 		tiertwos = length(hive.xenos_by_tier[XENO_TIER_TWO])
 		tierthrees = length(hive.xenos_by_tier[XENO_TIER_THREE])
 
 		if(forced_caste_type)
 			//Nothing, go on as normal.
-		else if((tier == XENO_TIER_ONE && TO_XENO_TIER_2_FORMULA(tierones, tiertwos, tierthrees))
+		else if((tier == XENO_TIER_ONE && TO_XENO_TIER_2_FORMULA(tierzeros + tierones, tiertwos, tierthrees))
 			to_chat(src, "<span class='warning'>The hive cannot support another Tier 2, wait for either more aliens to be born or someone to die.</span>")
 			return
-		else if(tier == XENO_TIER_TWO && TO_XENO_TIER_3_FORMULA(tierones, tiertwos, tierthrees))
+		else if(tier == XENO_TIER_TWO && TO_XENO_TIER_3_FORMULA(tierzeros + tierones, tiertwos, tierthrees))
 			to_chat(src, "<span class='warning'>The hive cannot support another Tier 3, wait for either more aliens to be born or someone to die.</span>")
 			return
 		else if(isdistress(SSticker.mode) && !hive.living_xeno_ruler && potential_queens == 1)
@@ -233,6 +232,7 @@
 		to_chat(src, "<span class='warning'>We quiver, but nothing happens. We must hold still while evolving.</span>")
 		return
 
+	tierzeros = hive.get_total_tier_zeros()
 	tierones = length(hive.xenos_by_tier[XENO_TIER_ONE])
 	tiertwos = length(hive.xenos_by_tier[XENO_TIER_TWO])
 	tierthrees = length(hive.xenos_by_tier[XENO_TIER_THREE])
@@ -246,10 +246,10 @@
 			to_chat(src, "<span class='warning'>There already is a Shrike.</span>")
 			return
 	else if(!forced_caste_type) // these shouldnt be checked if trying to become a queen.
-		if((tier == XENO_TIER_ONE && TO_XENO_TIER_2_FORMULA(tierones, tiertwos, tierthrees))
+		if((tier == XENO_TIER_ONE && TO_XENO_TIER_2_FORMULA(tierzeros + tierones, tiertwos, tierthrees))
 			to_chat(src, "<span class='warning'>Another sister evolved meanwhile. The hive cannot support another Tier 2.</span>")
 			return
-		else if(tier == XENO_TIER_TWO && TO_XENO_TIER_3_FORMULA(tierones, tiertwos, tierthrees))
+		else if(tier == XENO_TIER_TWO && TO_XENO_TIER_3_FORMULA(tierzeros + tierones, tiertwos, tierthrees))
 			to_chat(src, "<span class='warning'>Another sister evolved meanwhile. The hive cannot support another Tier 3.</span>")
 			return
 

--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -195,11 +195,10 @@
 	else
 		var/potential_queens = length(hive.xenos_by_typepath[/mob/living/carbon/xenomorph/larva]) + length(hive.xenos_by_typepath[/mob/living/carbon/xenomorph/drone])
 
-		if(istype(hive, /datum/hive_status/normal)) //If it has burrowed larva let's include that
-			var/datum/hive_status/normal/hive2
-			tierones = length(hive2.xenos_by_tier[XENO_TIER_ONE]) + length(hive2.xenos_by_tier[XENO_TIER_ZERO]) + length(hive2.stored_larva) //Includes larva and burrowed larva
-		else
-			tierones = length(hive.xenos_by_tier[XENO_TIER_ONE]) + length(hive.xenos_by_tier[XENO_TIER_ZERO])
+		tierones = length(hive.xenos_by_tier[XENO_TIER_ONE]) + length(hive.xenos_by_tier[XENO_TIER_ZERO])
+		if(istype(hive, /datum/hive_status/normal))
+			var/datum/hive_status/normal/normal_hive = hive
+			tierones += normal_hive.stored_larva
 		tiertwos = length(hive.xenos_by_tier[XENO_TIER_TWO])
 		tierthrees = length(hive.xenos_by_tier[XENO_TIER_THREE])
 

--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -195,7 +195,11 @@
 	else
 		var/potential_queens = length(hive.xenos_by_typepath[/mob/living/carbon/xenomorph/larva]) + length(hive.xenos_by_typepath[/mob/living/carbon/xenomorph/drone])
 
-		tierones = length(hive.xenos_by_tier[XENO_TIER_ONE]) + length(hive.xenos_by_tier[XENO_TIER_ZERO]) + length(hive.stored_larva) //Includes larva and burrowed larva
+		if(istype(hive, /datum/hive_status/normal)) //If it has burrowed larva let's include that
+			var/datum/hive_status/normal/hive2
+			tierones = length(hive2.xenos_by_tier[XENO_TIER_ONE]) + length(hive2.xenos_by_tier[XENO_TIER_ZERO]) + length(hive2.stored_larva) //Includes larva and burrowed larva
+		else
+			tierones = length(hive.xenos_by_tier[XENO_TIER_ONE]) + length(hive.xenos_by_tier[XENO_TIER_ZERO])
 		tiertwos = length(hive.xenos_by_tier[XENO_TIER_TWO])
 		tierthrees = length(hive.xenos_by_tier[XENO_TIER_THREE])
 

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -67,10 +67,17 @@
 
 
 /datum/hive_status/proc/can_hive_have_a_queen()
-	return get_total_xeno_number() < xenos_per_queen
+	return (get_total_xeno_number() < xenos_per_queen)
 
 /datum/hive_status/normal/can_hive_have_a_queen()
-	return get_total_xeno_number() + stored_larva < xenos_per_queen
+	return ((get_total_xeno_number() + stored_larva) < xenos_per_queen)
+
+/datum/hive_status/proc/get_total_tier_zeros()
+	return length(xenos_by_tier[XENO_TIER_ZERO])
+
+/datum/hive_status/normal/get_total_tier_zeros()
+	. = ..()
+	. += stored_larva
 
 // ***************************************
 // *********** List getters

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -46,8 +46,8 @@
 	for(var/t in xenos_by_tier)
 		. += length(xenos_by_tier[t])
 
-//Ditto above but with burrowed larva
-/datum/hive_status/proc/get_total_xeno_number_and_burrowed()
+//Normal hive status includes burrowed
+/datum/hive_status/normal/get_total_xeno_number()
 	. = 0
 	for(var/t in xenos_by_tier)
 		. += length(xenos_by_tier[t])
@@ -74,7 +74,7 @@
 
 
 /datum/hive_status/proc/can_hive_have_a_queen()
-	return get_total_xeno_number_and_burrowed() < xenos_per_queen
+	return get_total_xeno_number() < xenos_per_queen
 
 
 // ***************************************

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -46,13 +46,6 @@
 	for(var/t in xenos_by_tier)
 		. += length(xenos_by_tier[t])
 
-//Normal hive status includes burrowed
-/datum/hive_status/normal/get_total_xeno_number()
-	. = 0
-	for(var/t in xenos_by_tier)
-		. += length(xenos_by_tier[t])
-	. += stored_larva
-
 /datum/hive_status/proc/post_add(mob/living/carbon/xenomorph/X)
 	X.color = color
 
@@ -76,6 +69,8 @@
 /datum/hive_status/proc/can_hive_have_a_queen()
 	return get_total_xeno_number() < xenos_per_queen
 
+/datum/hive_status/normal/can_hive_have_a_queen()
+	return get_total_xeno_number() + stored_larva < xenos_per_queen
 
 // ***************************************
 // *********** List getters

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -46,6 +46,13 @@
 	for(var/t in xenos_by_tier)
 		. += length(xenos_by_tier[t])
 
+//Ditto above but with burrowed larva
+/datum/hive_status/proc/get_total_xeno_number_and_burrowed()
+	. = 0
+	for(var/t in xenos_by_tier)
+		. += length(xenos_by_tier[t])
+	. += stored_larva
+
 /datum/hive_status/proc/post_add(mob/living/carbon/xenomorph/X)
 	X.color = color
 
@@ -67,7 +74,7 @@
 
 
 /datum/hive_status/proc/can_hive_have_a_queen()
-	return get_total_xeno_number() < xenos_per_queen
+	return get_total_xeno_number_and_burrowed() < xenos_per_queen
 
 
 // ***************************************


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Before burrowed larva and regular larva never counted towards the 8 xeno threshold for queen and for evolving into a tier 2 or 3 xeno; now it does

## Why It's Good For The Game
Prevents xenos getting screwed over from being able to evolve if theres

- No one willing to play burrowed larva
- SSD larvas that don't evolve

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Burrowed and regular larva will now count towards evolution equations, meaning xenomorphs can evolve as if burrowed and unburrowed larva were actual xenomorphs possessed by players
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
