### PR TITLE
Add a pregame gamemode vote

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -32,6 +32,8 @@ SUBSYSTEM_DEF(ticker)
 	var/list/round_start_events
 	var/list/round_end_events
 
+	var/gamemode_vote = FALSE
+
 	var/tipped = FALSE
 	var/selected_tip
 
@@ -74,6 +76,9 @@ SUBSYSTEM_DEF(ticker)
 				time_left = max(0, start_at - world.time)
 			if(start_immediately)
 				time_left = 0
+
+			if(time_left <= 90 SECONDS && time_left > 60 SECONDS && !gamemode_vote)
+				addtimer(CALLBACK(SSvote, /datum/controller/subsystem/vote.proc/initiate_vote, "gamemode", "SERVER"), 1 SECONDS)
 
 			if(time_left <= 300 && !tipped)
 				send_tip_of_the_round()


### PR DESCRIPTION
## About The Pull Request

Adds a gamemode vote at 90 seconds left on the round start timer

## Why It's Good For The Game

Allow admin-less gameplay between crash / distress.

## Changelog
:cl:
add: Added a new gamemode vote before round start.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
