### PR TITLE
HPR Rework

### DIFF
--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -23273,7 +23273,7 @@
 /obj/item/explosive/grenade/frag,
 /obj/item/explosive/grenade/frag,
 /obj/item/explosive/grenade/frag,
-/obj/item/ammo_magazine/rifle/lmg,
+/obj/item/ammo_magazine/lmg,
 /obj/item/weapon/gun/rifle/lmg,
 /turf/open/floor{
 	icon_state = "red";
@@ -24166,7 +24166,7 @@
 /obj/item/ammo_magazine/revolver/mateba,
 /obj/item/ammo_magazine/rifle/ap,
 /obj/item/ammo_magazine/rifle/incendiary,
-/obj/item/ammo_magazine/rifle/lmg,
+/obj/item/ammo_magazine/lmg,
 /obj/item/ammo_magazine/rifle/ak47,
 /obj/item/ammo_magazine/sniper/svd,
 /obj/item/ammo_magazine/rifle/m16,

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -15336,7 +15336,7 @@
 /area/mainship/shipboard/brig)
 "aHu" = (
 /obj/structure/rack,
-/obj/item/ammo_magazine/rifle/lmg,
+/obj/item/ammo_magazine/lmg,
 /obj/item/weapon/gun/rifle/lmg,
 /turf/open/floor/mainship{
 	icon_state = "redfull"

--- a/_maps/map_files/Whiskey_Outpost/Whiskey_Outpost_v2.dmm
+++ b/_maps/map_files/Whiskey_Outpost/Whiskey_Outpost_v2.dmm
@@ -2297,7 +2297,7 @@
 /area/whiskey_outpost/outside/east)
 "gn" = (
 /obj/structure/rack,
-/obj/item/ammo_magazine/rifle/lmg,
+/obj/item/ammo_magazine/lmg,
 /obj/item/weapon/gun/rifle/lmg,
 /turf/open/floor/tile/dark,
 /area/whiskey_outpost)

--- a/_maps/map_files/generic/Admin_Level.dmm
+++ b/_maps/map_files/generic/Admin_Level.dmm
@@ -618,8 +618,8 @@
 "bX" = (
 /obj/structure/closet/secure_closet/guncabinet,
 /obj/item/weapon/gun/rifle/lmg,
-/obj/item/ammo_magazine/rifle/lmg,
-/obj/item/ammo_magazine/rifle/lmg,
+/obj/item/ammo_magazine/lmg,
+/obj/item/ammo_magazine/lmg,
 /obj/item/weapon/gun/rifle/lmg,
 /turf/open/floor/mainship{
 	dir = 9;

--- a/code/datums/emergency_calls/supplies.dm
+++ b/code/datums/emergency_calls/supplies.dm
@@ -12,8 +12,8 @@
 							/obj/item/ammo_magazine/flamer_tank \
 							), \
 						list(/obj/item/weapon/gun/rifle/lmg, \
-							/obj/item/ammo_magazine/rifle/lmg, \
-							/obj/item/ammo_magazine/rifle/lmg, \
+							/obj/item/ammo_magazine/lmg, \
+							/obj/item/ammo_magazine/lmg, \
 							), \
 						list(/obj/item/weapon/gun/shotgun/combat, \
 							/obj/item/weapon/gun/shotgun/combat, \

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -384,7 +384,7 @@ WEAPONS
 /datum/supply_packs/gun/heavyrifle
 	contains = list(
 					/obj/item/weapon/gun/rifle/lmg,
-					/obj/item/ammo_magazine/rifle/lmg
+					/obj/item/ammo_magazine/lmg
 					)
 	name = "M41AE2 HPR crate (HPR x1, HPR ammo box x1)"
 	cost = RO_PRICE_VERY_CHEAP
@@ -399,11 +399,11 @@ WEAPONS
 					/obj/item/weapon/gun/rifle/lmg,
 					/obj/item/weapon/gun/rifle/lmg,
 					/obj/item/weapon/gun/rifle/lmg,
-					/obj/item/ammo_magazine/rifle/lmg,
-					/obj/item/ammo_magazine/rifle/lmg,
-					/obj/item/ammo_magazine/rifle/lmg,
-					/obj/item/ammo_magazine/rifle/lmg,
-					/obj/item/ammo_magazine/rifle/lmg
+					/obj/item/ammo_magazine/lmg,
+					/obj/item/ammo_magazine/lmg,
+					/obj/item/ammo_magazine/lmg,
+					/obj/item/ammo_magazine/lmg,
+					/obj/item/ammo_magazine/lmg
 					)
 	name = "M41AE2 HPR squad crate (HPR x5, HPR ammo box x5)"
 	cost = RO_PRICE_PRETTY_PRICY
@@ -1830,7 +1830,7 @@ AMMO
 					/obj/item/ammo_magazine/rifle/ap,
 					/obj/item/ammo_magazine/rifle/incendiary,
 					/obj/item/ammo_magazine/rifle/m41aMK1,
-					/obj/item/ammo_magazine/rifle/lmg,
+					/obj/item/ammo_magazine/lmg,
 					/obj/item/ammo_magazine/pistol,
 					/obj/item/ammo_magazine/pistol/extended,
 					/obj/item/ammo_magazine/pistol/ap,

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -414,6 +414,7 @@
 	desc= "A small, lightweight pouch that can be clipped onto Armat Systems M3 Pattern armor or your belt to provide additional storage."
 	storage_slots = 3
 	w_class = WEIGHT_CLASS_BULKY
+	cant_hold = list(/obj/item/ammo_magazine/lmg)
 	max_w_class = 3
 	icon_state= "sparepouch"
 	item_state= "sparepouch"

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -247,7 +247,7 @@
 	fill_number = 3
 
 /obj/item/storage/pouch/magazine/large/pmc_lmg
-	fill_type = /obj/item/ammo_magazine/rifle/lmg
+	fill_type = /obj/item/ammo_magazine/lmg
 	fill_number = 3
 
 /obj/item/storage/pouch/magazine/large/pmc_sniper

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -114,6 +114,7 @@
 					/obj/item/weapon/gun/revolver/m44 = 15,
 					/obj/item/weapon/gun/smg/m39 = 15,
 					/obj/item/weapon/gun/rifle/m41a = 20,
+					/obj/item/weapon/gun/rifle/lmg = 2,
 					/obj/item/weapon/gun/energy/lasgun/M43 = 10,
 					/obj/item/weapon/gun/shotgun/pump = 10,
 					/obj/item/explosive/mine = 2,

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -990,7 +990,7 @@ GLOBAL_LIST_INIT(available_specialist_sets, list("Scout Set", "Sniper Set", "Dem
 							list("M40 HEDP grenade", 3, /obj/item/explosive/grenade/frag, null, "black"),
 							list("M40 IMDP grenade", 3, /obj/item/explosive/grenade/impact, null, "black"),
 							list("M41AE2 heavy pulse rifle", 12, /obj/item/weapon/gun/rifle/lmg, null, "orange"),
-							list("M41AE2 magazine", 4, /obj/item/ammo_magazine/rifle/lmg, null, "black"),
+							list("M41AE2 magazine", 4, /obj/item/ammo_magazine/lmg, null, "black"),
 							list("Flamethrower", 12, /obj/item/weapon/gun/flamer, null, "orange"),
 							list("Flamethrower tank", 4, /obj/item/ammo_magazine/flamer_tank, null, "black"),
 							list("Whistle", 5, /obj/item/whistle, null, "black"),

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -245,7 +245,7 @@
 					/obj/item/weapon/gun/flamer = /obj/item/ammo_magazine/flamer_tank,
 					/obj/item/weapon/gun/pistol/m4a3/custom = /obj/item/ammo_magazine/pistol/incendiary,
 					/obj/item/weapon/gun/rifle/m41aMK1 = /obj/item/ammo_magazine/rifle/m41aMK1,
-					/obj/item/weapon/gun/rifle/lmg = /obj/item/ammo_magazine/rifle/lmg,
+					/obj/item/weapon/gun/rifle/lmg = /obj/item/ammo_magazine/lmg,
 					/obj/item/weapon/gun/launcher/m81 = /obj/item/explosive/grenade/phosphorus
 					)
 

--- a/code/modules/projectiles/updated_projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/rifles.dm
@@ -239,7 +239,7 @@
 	dry_fire_sound = 'sound/weapons/guns/fire/m41a_empty.ogg'
 	unload_sound = 'sound/weapons/guns/interact/m41a_unload.ogg'
 	reload_sound = 'sound/weapons/guns/interact/m41a_reload.ogg'
-	current_mag = /obj/item/ammo_magazine/rifle/lmg
+	current_mag = /obj/item/ammo_magazine/lmg
 	attachable_allowed = list(
 						/obj/item/attachable/extended_barrel,
 						/obj/item/attachable/reddot,

--- a/code/modules/projectiles/updated_projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/rifles.dm
@@ -257,7 +257,7 @@
 	gun_skill_category = GUN_SKILL_HEAVY_WEAPONS
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 19,"rail_x" = 10, "rail_y" = 23, "under_x" = 24, "under_y" = 12, "stock_x" = 24, "stock_y" = 14)
 
-	fire_delay = 0.4
+	fire_delay = 0.4 SECONDS
 	burst_amount = 5
 	burst_delay = 0.1 SECONDS
 	accuracy_mult_unwielded = 0.5

--- a/code/modules/projectiles/updated_projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/rifles.dm
@@ -233,7 +233,8 @@
 	item_state = "m41ae2"
 	caliber = "10x24mm caseless" //codex
 	max_shells = 300 //codex
-	wield_delay = 0.6 SECONDS + 0.2 SECONDS
+	aim_slowdown = 0.8
+	wield_delay = 2 SECONDS
 	fire_sound =  'sound/weapons/guns/fire/rifle.ogg'
 	dry_fire_sound = 'sound/weapons/guns/fire/m41a_empty.ogg'
 	unload_sound = 'sound/weapons/guns/interact/m41a_unload.ogg'
@@ -247,10 +248,7 @@
 						/obj/item/attachable/flashlight,
 						/obj/item/attachable/bipod,
 						/obj/item/attachable/stock/rifle,
-						/obj/item/attachable/heavy_barrel,
-						/obj/item/attachable/quickfire,
 						/obj/item/attachable/compensator,
-						/obj/item/attachable/burstfire_assembly,
 						/obj/item/attachable/magnetic_harness,
 						/obj/item/attachable/scope)
 
@@ -259,10 +257,11 @@
 	gun_skill_category = GUN_SKILL_HEAVY_WEAPONS
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 19,"rail_x" = 10, "rail_y" = 23, "under_x" = 24, "under_y" = 12, "stock_x" = 24, "stock_y" = 14)
 
-	fire_delay = 5
-	burst_amount = 3
+	fire_delay = 0.4
+	burst_amount = 5
 	burst_delay = 0.1 SECONDS
 	accuracy_mult_unwielded = 0.5
+	accuracy_mult = 1.05
 	scatter = 15
 	scatter_unwielded = 80
 	recoil_unwielded = 5

--- a/code/modules/projectiles/updated_projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/updated_projectiles/magazines/rifles.dm
@@ -87,6 +87,7 @@
 	desc = "A semi-rectangular box of rounds for the M41AE2 Heavy Pulse Rifle."
 	icon_state = "m41ae2"
 	caliber = "10x24mm caseless"
+	default_ammo = /datum/ammo/bullet/rifle
 	w_class = WEIGHT_CLASS_NORMAL
 	max_rounds = 200
 	gun_type = /obj/item/weapon/gun/rifle/lmg

--- a/code/modules/projectiles/updated_projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/updated_projectiles/magazines/rifles.dm
@@ -82,10 +82,11 @@
 //-------------------------------------------------------
 //M41AE2 HEAVY PULSE RIFLE
 
-/obj/item/ammo_magazine/rifle/lmg
+/obj/item/ammo_magazine/lmg
 	name = "\improper M41AE2 ammo box (10x24mm)"
 	desc = "A semi-rectangular box of rounds for the M41AE2 Heavy Pulse Rifle."
 	icon_state = "m41ae2"
+	caliber = "10x24mm caseless"
 	w_class = WEIGHT_CLASS_NORMAL
 	max_rounds = 200
 	gun_type = /obj/item/weapon/gun/rifle/lmg

--- a/code/modules/projectiles/updated_projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/updated_projectiles/magazines/rifles.dm
@@ -86,7 +86,8 @@
 	name = "\improper M41AE2 ammo box (10x24mm)"
 	desc = "A semi-rectangular box of rounds for the M41AE2 Heavy Pulse Rifle."
 	icon_state = "m41ae2"
-	max_rounds = 300
+	w_class = WEIGHT_CLASS_NORMAL
+	max_rounds = 200
 	gun_type = /obj/item/weapon/gun/rifle/lmg
 
 


### PR DESCRIPTION
## About The Pull Request

The HPR rework demanded to be made by MJP
Pros:

- Burst upped to 5. 
- The guns fire delay down to 0.4.
- Slight accuracy buff of +5% instead of 0%
- Added 1-2 into the Req vendor.

Cons:

- Unable to run a QFA, BFA, or BC
- Wield Delay upped to 2 seconds
- Mags now pretty much only fit in Backpacks and Satchels
- 0.8 slowdown
- 200 round magazines

## Why It's Good For The Game

From MJP: The HPR in its current state is basically an M41A1 with 300 rounds and worse scatter rather than it's intended "LMG" status. This rework aims to make the HPR more of it's intended LMG status by making you slower but giving you 5 round bursts. The ammo capacity was reduced from 300 to 200 since it was deemed like it was too much.

## Changelog
:cl: MJP & MetroidLover
balance: HPR rework
balance: Positive changes; Burst upped to 5, The guns fire delay down to 0.4, Slight accuracy buff of +5% instead of 0%, Added 1-2 into the Req vendor.
balance: Negative Changes; Unable to run a QFA, BFA, or BC, Wield Delay upped to 2 seconds, Mags now pretty much only fit in Backpacks and Satchels, 0.8 slowdown, 200 round magazines, 
/:cl: