### PR TITLE
fixes a bug with the box of 45 caliber mismatch

### DIFF
--- a/code/modules/projectiles/updated_projectiles/magazines/pistols.dm
+++ b/code/modules/projectiles/updated_projectiles/magazines/pistols.dm
@@ -49,7 +49,7 @@
 	name = "Box of .45 ACP"
 	icon_state = "box45" //With thanks to Eris
 	default_ammo = /datum/ammo/bullet/pistol/heavy
-	caliber = ".45"
+	caliber = ".45 ACP"
 	current_rounds = 50
 	max_rounds = 50
 


### PR DESCRIPTION
## About The Pull Request

bugfix

## Why It's Good For The Game

now the box of 45 ammo actually fits in 45 magazines.

## Changelog
:cl: Hughgent
fix: now the box of 45, ammo actually fits in 45 magazines.
/:cl:
