### PR TITLE
Hyperzine rebalance

### DIFF
--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -117,10 +117,10 @@
 	volume = 25
 	icon_state = "autoinjector-1" //TEMP, god willing
 	list_reagents = list(/datum/reagent/medicine/hyperzine = 4, 
-						datum/reagent/mercury = 1, 
-						datum/reagent/medicine/dexalin = 8, 
-						datum/reagent/medicine/inaprovaline = 8, 
-						datum/reagent/toxin = 4)
+						/datum/reagent/mercury = 1, 
+						/datum/reagent/medicine/dexalin = 8, 
+						/datum/reagent/medicine/inaprovaline = 8, 
+						/datum/reagent/toxin = 4)
 
 /obj/item/reagent_container/hypospray/autoinjector/hyperzine
 	name = "expired hyperzine autoinjector"
@@ -129,5 +129,5 @@
 	volume = 25
 	icon_state = "autoinjector-1" //TEMP, god willing
 	list_reagents = list(/datum/reagent/medicine/hyperzine = 5, 
-						datum/reagent/medicine/dexalin = 10, 
-						datum/reagent/medicine/inaprovaline = 10)
+						/datum/reagent/medicine/dexalin = 10, 
+						/datum/reagent/medicine/inaprovaline = 10)

--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -109,3 +109,19 @@
 	volume = 3
 	icon_state = "autoinjector-8" //TEMP
 	list_reagents = list(/datum/reagent/medicine/hypervene = 3)
+
+/obj/item/reagent_container/hypospray/autoinjector/hyperzine_expired
+	name = "expired hyperzine autoinjector"
+	desc = "An auto-injector said to be loaded with a safe-to-use hyperzine mix, 3 months past it's expiration date."
+	amount_per_transfer_from_this = 25
+	volume = 25
+	icon_state = "autoinjector-1" //TEMP, god willing
+	list_reagents = list(/datum/reagent/medicine/hyperzine = 4, datum/reagent/mercury = 1, datum/reagent/medicine/dexalin = 8, datum/reagent/medicine/inaprovaline = 8, datum/reagent/toxin = 4)
+
+/obj/item/reagent_container/hypospray/autoinjector/hyperzine
+	name = "expired hyperzine autoinjector"
+	desc = "An auto-injector loaded with a safe-to-use hyperzine mix, 3 months past it's expiration date."
+	amount_per_transfer_from_this = 25
+	volume = 25
+	icon_state = "autoinjector-1" //TEMP, god willing
+	list_reagents = list(/datum/reagent/medicine/hyperzine = 5, datum/reagent/medicine/dexalin = 10, datum/reagent/medicine/inaprovaline = 10)

--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -116,7 +116,11 @@
 	amount_per_transfer_from_this = 25
 	volume = 25
 	icon_state = "autoinjector-1" //TEMP, god willing
-	list_reagents = list(/datum/reagent/medicine/hyperzine = 4, datum/reagent/mercury = 1, datum/reagent/medicine/dexalin = 8, datum/reagent/medicine/inaprovaline = 8, datum/reagent/toxin = 4)
+	list_reagents = list(/datum/reagent/medicine/hyperzine = 4, 
+						datum/reagent/mercury = 1, 
+						datum/reagent/medicine/dexalin = 8, 
+						datum/reagent/medicine/inaprovaline = 8, 
+						datum/reagent/toxin = 4)
 
 /obj/item/reagent_container/hypospray/autoinjector/hyperzine
 	name = "expired hyperzine autoinjector"
@@ -124,4 +128,6 @@
 	amount_per_transfer_from_this = 25
 	volume = 25
 	icon_state = "autoinjector-1" //TEMP, god willing
-	list_reagents = list(/datum/reagent/medicine/hyperzine = 5, datum/reagent/medicine/dexalin = 10, datum/reagent/medicine/inaprovaline = 10)
+	list_reagents = list(/datum/reagent/medicine/hyperzine = 5, 
+						datum/reagent/medicine/dexalin = 10, 
+						datum/reagent/medicine/inaprovaline = 10)

--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -120,7 +120,7 @@
 
 /obj/item/reagent_container/hypospray/autoinjector/hyperzine
 	name = "expired hyperzine autoinjector"
-	desc = "An auto-injector loaded with a safe-to-use hyperzine mix, 3 months past it's expiration date."
+	desc = "An auto-injector freshly loaded with a safe-to-use hyperzine mix."
 	amount_per_transfer_from_this = 25
 	volume = 25
 	icon_state = "autoinjector-1" //TEMP, god willing

--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -123,7 +123,7 @@
 						/datum/reagent/toxin = 4)
 
 /obj/item/reagent_container/hypospray/autoinjector/hyperzine
-	name = "expired hyperzine autoinjector"
+	name = "hyperzine autoinjector"
 	desc = "An auto-injector freshly loaded with a safe-to-use hyperzine mix."
 	amount_per_transfer_from_this = 25
 	volume = 25

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -371,7 +371,8 @@
 					/obj/item/reagent_container/hypospray/autoinjector/kelotane = 6,
 					/obj/item/reagent_container/hypospray/autoinjector/oxycodone = 4,
 					/obj/item/reagent_container/hypospray/autoinjector/tricordrazine = 8,
-					/obj/item/reagent_container/hypospray/autoinjector/hypervene = 4,
+					/obj/item/reagent_container/hypospray/autoinjector/hypervene = 4
+					/obj/item/reagent_container/hypospray/autoinjector/hyperzine = 0,
 					/obj/item/storage/pill_bottle/bicaridine = 3,
 					/obj/item/storage/pill_bottle/dexalin = 3,
 					/obj/item/storage/pill_bottle/dylovene = 3,

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -371,7 +371,7 @@
 					/obj/item/reagent_container/hypospray/autoinjector/kelotane = 6,
 					/obj/item/reagent_container/hypospray/autoinjector/oxycodone = 4,
 					/obj/item/reagent_container/hypospray/autoinjector/tricordrazine = 8,
-					/obj/item/reagent_container/hypospray/autoinjector/hypervene = 4
+					/obj/item/reagent_container/hypospray/autoinjector/hypervene = 4,
 					/obj/item/reagent_container/hypospray/autoinjector/hyperzine = 0,
 					/obj/item/storage/pill_bottle/bicaridine = 3,
 					/obj/item/storage/pill_bottle/dexalin = 3,

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -391,7 +391,8 @@
 					/obj/item/healthanalyzer = 3,
 					/obj/item/bodybag/cryobag = 2)
 
-	contraband = list(/obj/item/reagent_container/hypospray/autoinjector/sleeptoxin =3)
+	contraband = list(/obj/item/reagent_container/hypospray/autoinjector/sleeptoxin =3,
+					/obj/item/reagent_container/hypospray/autoinjector/hyperzine_expired =3)
 
 
 

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -783,6 +783,7 @@
 							list("Injector (Oxycodone)", 1, /obj/item/reagent_container/hypospray/autoinjector/oxycodone, null, "black"),
 							list("Injector (Tricord)", 1, /obj/item/reagent_container/hypospray/autoinjector/tricordrazine, null, "black"),
 							list("Injector (Hypervene)", 1, /obj/item/reagent_container/hypospray/autoinjector/hypervene, null, "black"),
+							list("Injector (Hyperzine)", 15, /obj/item/reagent_container/hypospray/autoinjector/hyperzine, null, "black"),
 							list("Advanced hypospray", 2, /obj/item/reagent_container/hypospray/advanced, null, "black"),
 							list("Health analyzer", 2, /obj/item/healthanalyzer, null, "black"),
 							list("Medical HUD glasses", 2, /obj/item/clothing/glasses/hud/health, null, "black"),

--- a/code/modules/reagents/chemistry_reagents/medical.dm
+++ b/code/modules/reagents/chemistry_reagents/medical.dm
@@ -600,7 +600,7 @@ datum/reagent/medicine/synaptizine/overdose_crit_process(mob/living/L, metabolis
 	trait_flags = TACHYCARDIC
 
 /datum/reagent/medicine/hyperzine/on_mob_delete(mob/living/L, metabolism)
-	var/amount = current_cycle * 4
+	var/amount = current_cycle * 2
 	L.adjustOxyLoss(amount)
 	L.adjustHalLoss(amount)
 	if(L.stat == DEAD)
@@ -625,11 +625,11 @@ datum/reagent/medicine/synaptizine/overdose_crit_process(mob/living/L, metabolis
 	return ..()
 
 /datum/reagent/medicine/hyperzine/on_mob_add(mob/living/L, metabolism)
-	purge_list.Add(/datum/reagent/medicine/dexalinplus, /datum/reagent/medicine/peridaxon) //Rapidly purges chems that would offset the downsides
+	purge_list.Add(/datum/reagent/medicine/peridaxon) //Rapidly purges chems that would offset the downsides
 	return ..()
 
 /datum/reagent/medicine/hyperzine/on_mob_life(mob/living/L, metabolism)
-	L.reagent_move_delay_modifier -= min(2.5, volume * 0.5)
+	L.reagent_move_delay_modifier -= min(2.0, volume * 0.5)
 	if(iscarbon(L))
 		var/mob/living/carbon/C = L
 		C.nutrition = max(C.nutrition-(3 * REM * volume), 0) //Body burns through energy fast (also can't go under 0 nutrition)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes hyperzine more usable in lower dosages.

## Why It's Good For The Game

As of now, hyperzine is unusable, both requiring a MD to make and being guaranteed to stun if you take more than 2u at once. This aims to make hyperzine more usable at or below 5u, while still maintaining the OD effects

## Changelog
:cl:
Halved the amount of oxy damage and halloss/u (down from 20 to 10)
Allowed dex+ to be used with hyperzine.
Slightly lowered maximum attainable speed.
/:cl:

Tested locally with a 5u hyperzine pill, and a 5u hyper, 10u dex+ pill, resulted in intended effect.
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
