### PR TITLE
Stops resin sacs and resin holes being placed on the same turf

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -49,6 +49,13 @@
 	mechanics_text = "Plant a weed node (purple sac) on your tile."
 	keybind_signal = COMSIG_XENOABILITY_DROP_WEEDS
 
+/datum/action/xeno_action/plant_weeds/can_use_action(silent, override_flags)
+	. = ..()
+	if(locate(/obj/effect/alien/resin/trap) in get_turf(owner))
+		if(!silent)
+			to_chat(owner, "<span class='warning'>There is a resin trap in the way!</span>")
+		return FALSE
+
 /datum/action/xeno_action/plant_weeds/action_activate()
 	var/turf/T = get_turf(owner)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
@@ -152,6 +152,11 @@
 	if(!T.check_alien_construction(owner, silent))
 		return FALSE
 
+	if(locate(/obj/effect/alien/weeds/node) in T)
+		if(!silent)
+			to_chat(owner, "<span class='warning'>There is a resin node in the way!</span>")
+		return FALSE
+
 /datum/action/xeno_action/place_trap/action_activate()
 	var/turf/T = get_turf(owner)
 


### PR DESCRIPTION

## Changelog
:cl:
balance: resin holes and resin sacs can no longer be placed on the same spot
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
