### PR TITLE
tweak cant to be less xeno rush friendly

### DIFF
--- a/_maps/shuttles/tgs_canterbury.dmm
+++ b/_maps/shuttles/tgs_canterbury.dmm
@@ -200,7 +200,9 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury/cic)
 "aw" = (
-/obj/machinery/marine_turret/premade/canterbury,
+/obj/machinery/marine_turret/premade/canterbury{
+	dir = 8
+	},
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -443,11 +445,10 @@
 	},
 /area/shuttle/canterbury/general)
 "aV" = (
-/obj/machinery/marine_turret/premade/canterbury{
-	icon_state = "sentry_base";
-	dir = 1
-	},
 /obj/machinery/light/small,
+/obj/machinery/marine_turret/premade/canterbury{
+	dir = 8
+	},
 /turf/open/floor/mainship{
 	icon_state = "test_floor4"
 	},
@@ -1399,10 +1400,6 @@
 	icon_state = "0-4";
 	d2 = 4
 	},
-/obj/machinery/door_control{
-	id = "storage_podlock";
-	pixel_x = -32
-	},
 /turf/open/floor/mainship,
 /area/shuttle/canterbury/general)
 "cK" = (
@@ -1561,15 +1558,6 @@
 	icon_state = "cargo"
 	},
 /area/shuttle/canterbury/general)
-"cZ" = (
-/obj/machinery/door_control{
-	id = "starboard_engine_podlock";
-	pixel_y = 32
-	},
-/turf/open/floor/mainship{
-	icon_state = "cargo"
-	},
-/area/shuttle/canterbury/general)
 "da" = (
 /obj/machinery/light{
 	dir = 4
@@ -1610,6 +1598,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/marine_turret/premade/canterbury,
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury/general)
 "dd" = (
@@ -1701,23 +1690,6 @@
 	},
 /turf/closed/wall/mainship/outer,
 /area/shuttle/canterbury/medical)
-"do" = (
-/obj/machinery/door_control{
-	id = "port_engine_podlock"
-	},
-/turf/closed/wall/mainship/outer,
-/area/shuttle/canterbury/medical)
-"dp" = (
-/obj/machinery/door/poddoor/mainship{
-	dir = 8;
-	icon_state = "pdoor1";
-	id = "storage_podlock"
-	},
-/obj/machinery/door/poddoor/shutters/transit,
-/turf/open/floor/mainship{
-	icon_state = "test_floor4"
-	},
-/area/shuttle/canterbury/general)
 "ds" = (
 /obj/machinery/door/poddoor/mainship{
 	id = "starboard_umbilical_inner";
@@ -1746,46 +1718,6 @@
 	icon_state = "cargo_arrow"
 	},
 /area/shuttle/canterbury/general)
-"dA" = (
-/obj/machinery/door/poddoor/mainship{
-	dir = 8;
-	icon_state = "pdoor1";
-	id = "port_engine_podlock"
-	},
-/obj/machinery/door/poddoor/shutters/transit,
-/turf/open/floor/plating,
-/area/shuttle/canterbury/general)
-"dB" = (
-/obj/machinery/door/poddoor/mainship{
-	dir = 8;
-	icon_state = "pdoor1";
-	id = "starboard_engine_podlock"
-	},
-/obj/machinery/door/poddoor/shutters/transit,
-/turf/open/floor/plating,
-/area/shuttle/canterbury/general)
-"dC" = (
-/obj/machinery/door/poddoor/mainship{
-	dir = 1;
-	icon_state = "pdoor1";
-	id = "port_engine_podlock"
-	},
-/obj/machinery/door/poddoor/shutters/transit{
-	dir = 2
-	},
-/turf/open/floor/plating,
-/area/shuttle/canterbury/general)
-"dD" = (
-/obj/machinery/door/poddoor/mainship{
-	dir = 1;
-	icon_state = "pdoor1";
-	id = "starboard_engine_podlock"
-	},
-/obj/machinery/door/poddoor/shutters/transit{
-	dir = 2
-	},
-/turf/open/floor/plating,
-/area/shuttle/canterbury/general)
 "dE" = (
 /obj/machinery/door/poddoor/mainship{
 	dir = 1;
@@ -1808,6 +1740,26 @@
 	},
 /obj/machinery/door/poddoor/shutters/transit,
 /turf/open/floor/mainship/mono,
+/area/shuttle/canterbury/general)
+"jQ" = (
+/obj/machinery/light/small,
+/obj/machinery/marine_turret/premade/canterbury{
+	dir = 4
+	},
+/turf/open/floor/mainship{
+	icon_state = "test_floor4"
+	},
+/area/shuttle/canterbury/general)
+"AO" = (
+/obj/machinery/marine_turret/premade/canterbury{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/mainship{
+	icon_state = "test_floor4"
+	},
 /area/shuttle/canterbury/general)
 "Oh" = (
 /obj/effect/landmark/start/marine/crash/synthetic,
@@ -1863,10 +1815,10 @@ aa
 aa
 aa
 as
-as
+aG
 aG
 VH
-as
+aG
 as
 aZ
 bi
@@ -1905,7 +1857,7 @@ cs
 cE
 cQ
 ch
-dA
+as
 as
 aa
 "}
@@ -1932,7 +1884,7 @@ cF
 ct
 ch
 de
-dC
+as
 aa
 "}
 (5,1,1) = {"
@@ -1956,9 +1908,9 @@ cj
 cu
 cG
 cR
-do
+ch
 df
-dC
+as
 aa
 "}
 (6,1,1) = {"
@@ -2113,8 +2065,8 @@ cz
 cL
 cW
 as
-cZ
-dD
+df
+as
 aa
 "}
 (12,1,1) = {"
@@ -2140,7 +2092,7 @@ cM
 cW
 as
 de
-dD
+as
 aa
 "}
 (13,1,1) = {"
@@ -2149,10 +2101,10 @@ aa
 aa
 aa
 as
-aw
+AO
 aM
 aU
-aV
+jQ
 as
 bg
 bs
@@ -2165,7 +2117,7 @@ cB
 cN
 cX
 as
-dB
+as
 as
 aa
 "}
@@ -2175,10 +2127,10 @@ aa
 aa
 aa
 as
-as
+bS
 bS
 eA
-as
+bS
 as
 bh
 bt
@@ -2213,9 +2165,9 @@ as
 as
 as
 as
-dp
-dp
-dp
+as
+as
+as
 as
 aa
 aa

--- a/_maps/shuttles/tgs_canterbury.dmm
+++ b/_maps/shuttles/tgs_canterbury.dmm
@@ -1656,12 +1656,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury/general)
-"dm" = (
-/obj/machinery/door_control{
-	id = "aft_engine_podlock"
-	},
-/turf/closed/wall/mainship/outer,
-/area/shuttle/canterbury/medical)
 "dy" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -1687,72 +1681,7 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/canterbury/general)
-"eW" = (
-/obj/machinery/marine_turret/premade/canterbury{
-	dir = 8
-	},
-/obj/structure/barricade/metal{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/turf/open/floor/mainship{
-	icon_state = "test_floor5"
-	},
-/area/shuttle/canterbury/general)
-"gV" = (
-/obj/machinery/marine_turret/premade/canterbury{
-	dir = 8
-	},
-/obj/structure/barricade/metal{
-	dir = 8
-	},
-/turf/open/floor/mainship{
-	icon_state = "test_floor5"
-	},
-/area/shuttle/canterbury/general)
-"ru" = (
-/obj/machinery/marine_turret/premade/canterbury{
-	dir = 4
-	},
-/obj/structure/barricade/metal{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/turf/open/floor/mainship{
-	icon_state = "test_floor5"
-	},
-/area/shuttle/canterbury/general)
-"rN" = (
-/obj/machinery/door_control{
-	id = "aft_engine_podlock"
-	},
-/turf/closed/wall/mainship/outer,
-/area/shuttle/canterbury/general)
-"tl" = (
-/obj/machinery/marine_turret/premade/canterbury{
-	dir = 4
-	},
-/obj/structure/barricade/metal{
-	dir = 4
-	},
-/turf/open/floor/mainship{
-	icon_state = "test_floor5"
-	},
-/area/shuttle/canterbury/general)
-"uL" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/closet/crate/trashcart,
-/turf/open/floor/mainship{
-	icon_state = "cargo"
-	},
-/area/shuttle/canterbury/general)
-"uM" = (
+"gf" = (
 /obj/machinery/door/poddoor/mainship{
 	id = "starboard_umbilical_outer";
 	name = "\improper Umbillical Airlock"
@@ -1765,13 +1694,30 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury/general)
-"Oh" = (
-/obj/effect/landmark/start/marine/crash/synthetic,
+"iW" = (
+/obj/machinery/marine_turret/premade/canterbury{
+	dir = 4
+	},
+/obj/structure/barricade/metal{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
 /turf/open/floor/mainship{
-	icon_state = "orangefull"
+	icon_state = "test_floor5"
 	},
 /area/shuttle/canterbury/general)
-"Vd" = (
+"nF" = (
+/obj/machinery/door_control{
+	id = "aft_engine_podlock";
+	pixel_x = 32
+	},
+/turf/open/floor/mainship{
+	icon_state = "cargo"
+	},
+/area/shuttle/canterbury/general)
+"oc" = (
 /obj/machinery/door/poddoor/mainship{
 	id = "port_umbilical_outer";
 	name = "\improper Umbillical Airlock"
@@ -1785,7 +1731,38 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury/general)
-"Ve" = (
+"vS" = (
+/obj/machinery/marine_turret/premade/canterbury{
+	dir = 8
+	},
+/obj/structure/barricade/metal{
+	dir = 8
+	},
+/turf/open/floor/mainship{
+	icon_state = "test_floor5"
+	},
+/area/shuttle/canterbury/general)
+"yR" = (
+/obj/machinery/door_control{
+	id = "aft_engine_podlock"
+	},
+/turf/closed/wall/mainship/outer,
+/area/shuttle/canterbury/general)
+"zN" = (
+/obj/machinery/marine_turret/premade/canterbury{
+	dir = 8
+	},
+/obj/structure/barricade/metal{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor/mainship{
+	icon_state = "test_floor5"
+	},
+/area/shuttle/canterbury/general)
+"LO" = (
 /obj/structure/bed/chair/dropship/passenger{
 	icon_state = "shuttle_chair";
 	dir = 1
@@ -1796,10 +1773,36 @@
 	},
 /turf/open/floor/plating/mainship,
 /area/shuttle/canterbury/general)
+"Oh" = (
+/obj/effect/landmark/start/marine/crash/synthetic,
+/turf/open/floor/mainship{
+	icon_state = "orangefull"
+	},
+/area/shuttle/canterbury/general)
+"Ql" = (
+/obj/machinery/marine_turret/premade/canterbury{
+	dir = 4
+	},
+/obj/structure/barricade/metal{
+	dir = 4
+	},
+/turf/open/floor/mainship{
+	icon_state = "test_floor5"
+	},
+/area/shuttle/canterbury/general)
+"Rl" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/closet/crate/trashcart,
+/turf/open/floor/mainship{
+	icon_state = "cargo"
+	},
+/area/shuttle/canterbury/general)
 "Wo" = (
 /turf/closed/wall/mainship,
 /area/shuttle/canterbury/medical)
-"XA" = (
+"WM" = (
 /obj/structure/bed/chair/dropship/passenger{
 	icon_state = "shuttle_chair";
 	dir = 1
@@ -1843,7 +1846,7 @@ aa
 aa
 aa
 as
-Vd
+oc
 aG
 aG
 aG
@@ -1895,10 +1898,10 @@ aa
 aa
 aa
 as
-gV
+vS
 aO
 aE
-eW
+zN
 as
 bw
 bk
@@ -1925,7 +1928,7 @@ ax
 aH
 aP
 cD
-XA
+WM
 bl
 dl
 bx
@@ -2014,7 +2017,7 @@ Wo
 Wo
 Wo
 Wo
-dm
+ch
 dc
 df
 dE
@@ -2042,7 +2045,7 @@ cJ
 cU
 as
 dj
-df
+nF
 dE
 "}
 (10,1,1) = {"
@@ -2069,7 +2072,7 @@ cV
 cm
 dg
 as
-rN
+yR
 "}
 (11,1,1) = {"
 ab
@@ -2081,7 +2084,7 @@ aD
 aL
 aT
 da
-Ve
+LO
 be
 bq
 bC
@@ -2103,10 +2106,10 @@ aa
 aa
 aa
 as
-tl
+Ql
 aO
 aY
-ru
+iW
 as
 bf
 br
@@ -2119,7 +2122,7 @@ cA
 cM
 cW
 as
-uL
+Rl
 as
 aa
 "}
@@ -2155,7 +2158,7 @@ aa
 aa
 aa
 as
-uM
+gf
 bS
 bS
 bS

--- a/_maps/shuttles/tgs_canterbury.dmm
+++ b/_maps/shuttles/tgs_canterbury.dmm
@@ -206,6 +206,9 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/barricade/metal{
+	dir = 8
+	},
 /turf/open/floor/mainship{
 	icon_state = "test_floor4"
 	},
@@ -378,7 +381,14 @@
 	},
 /obj/machinery/door_control{
 	id = "port_umbilical_inner";
-	pixel_y = 32
+	name = "inner door-control";
+	pixel_y = 35
+	},
+/obj/machinery/door_control{
+	dir = 2;
+	id = "port_umbilical_outer";
+	name = "outer door-control";
+	pixel_y = 28
 	},
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury/general)
@@ -447,6 +457,9 @@
 "aV" = (
 /obj/machinery/light/small,
 /obj/machinery/marine_turret/premade/canterbury{
+	dir = 8
+	},
+/obj/structure/barricade/metal{
 	dir = 8
 	},
 /turf/open/floor/mainship{
@@ -1521,7 +1534,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/closet/crate/trashcart,
 /turf/open/floor/mainship{
 	icon_state = "cargo"
 	},
@@ -1700,7 +1712,13 @@
 	},
 /obj/machinery/door_control{
 	id = "starboard_umbilical_inner";
-	pixel_y = 32
+	name = "inner door-control";
+	pixel_y = 35
+	},
+/obj/machinery/door_control{
+	id = "starboard_umbilical_outer";
+	name = "outer door-control";
+	pixel_y = 28
 	},
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury/general)
@@ -1729,33 +1747,36 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/canterbury/general)
-"eA" = (
-/obj/machinery/door/poddoor/mainship{
-	id = "starboard_umbilical_outer";
-	name = "\improper Umbillical Airlock"
+"eO" = (
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/machinery/door_control{
-	id = "starboard_umbilical_outer";
-	pixel_y = -32
+/obj/structure/closet/crate/trashcart,
+/turf/open/floor/mainship{
+	icon_state = "cargo"
 	},
-/obj/machinery/door/poddoor/shutters/transit,
-/turf/open/floor/mainship/mono,
 /area/shuttle/canterbury/general)
-"jQ" = (
-/obj/machinery/light/small,
+"Bt" = (
 /obj/machinery/marine_turret/premade/canterbury{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/barricade/metal{
 	dir = 4
 	},
 /turf/open/floor/mainship{
 	icon_state = "test_floor4"
 	},
 /area/shuttle/canterbury/general)
-"AO" = (
+"CO" = (
+/obj/machinery/light/small,
 /obj/machinery/marine_turret/premade/canterbury{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/barricade/metal{
+	dir = 4
 	},
 /turf/open/floor/mainship{
 	icon_state = "test_floor4"
@@ -1766,18 +1787,6 @@
 /turf/open/floor/mainship{
 	icon_state = "orangefull"
 	},
-/area/shuttle/canterbury/general)
-"VH" = (
-/obj/machinery/door/poddoor/mainship{
-	id = "port_umbilical_outer";
-	name = "\improper Umbillical Airlock"
-	},
-/obj/machinery/door_control{
-	id = "port_umbilical_outer";
-	pixel_y = -32
-	},
-/obj/machinery/door/poddoor/shutters/transit,
-/turf/open/floor/mainship/mono,
 /area/shuttle/canterbury/general)
 "Wo" = (
 /turf/closed/wall/mainship,
@@ -1817,7 +1826,7 @@ aa
 as
 aG
 aG
-VH
+aG
 aG
 as
 aZ
@@ -2091,7 +2100,7 @@ cA
 cM
 cW
 as
-de
+eO
 as
 aa
 "}
@@ -2101,10 +2110,10 @@ aa
 aa
 aa
 as
-AO
+Bt
 aM
 aU
-jQ
+CO
 as
 bg
 bs
@@ -2129,7 +2138,7 @@ aa
 as
 bS
 bS
-eA
+bS
 bS
 as
 bh

--- a/_maps/shuttles/tgs_canterbury.dmm
+++ b/_maps/shuttles/tgs_canterbury.dmm
@@ -203,12 +203,6 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/door_control{
-	dir = 2;
-	id = "port_umbilical_outer";
-	name = "outer door-control";
-	pixel_y = 32
-	},
 /turf/open/floor/mainship{
 	icon_state = "test_floor4"
 	},
@@ -1693,7 +1687,32 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/canterbury/general)
-"fw" = (
+"eW" = (
+/obj/machinery/marine_turret/premade/canterbury{
+	dir = 8
+	},
+/obj/structure/barricade/metal{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor/mainship{
+	icon_state = "test_floor5"
+	},
+/area/shuttle/canterbury/general)
+"gV" = (
+/obj/machinery/marine_turret/premade/canterbury{
+	dir = 8
+	},
+/obj/structure/barricade/metal{
+	dir = 8
+	},
+/turf/open/floor/mainship{
+	icon_state = "test_floor5"
+	},
+/area/shuttle/canterbury/general)
+"ru" = (
 /obj/machinery/marine_turret/premade/canterbury{
 	dir = 4
 	},
@@ -1707,7 +1726,24 @@
 	icon_state = "test_floor5"
 	},
 /area/shuttle/canterbury/general)
-"mb" = (
+"rN" = (
+/obj/machinery/door_control{
+	id = "aft_engine_podlock"
+	},
+/turf/closed/wall/mainship/outer,
+/area/shuttle/canterbury/general)
+"tl" = (
+/obj/machinery/marine_turret/premade/canterbury{
+	dir = 4
+	},
+/obj/structure/barricade/metal{
+	dir = 4
+	},
+/turf/open/floor/mainship{
+	icon_state = "test_floor5"
+	},
+/area/shuttle/canterbury/general)
+"uL" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -1716,65 +1752,18 @@
 	icon_state = "cargo"
 	},
 /area/shuttle/canterbury/general)
-"mZ" = (
-/obj/machinery/light/small{
-	dir = 1
+"uM" = (
+/obj/machinery/door/poddoor/mainship{
+	id = "starboard_umbilical_outer";
+	name = "\improper Umbillical Airlock"
 	},
+/obj/machinery/door/poddoor/shutters/transit,
 /obj/machinery/door_control{
 	id = "starboard_umbilical_outer";
 	name = "outer door-control";
 	pixel_y = 32
 	},
-/turf/open/floor/mainship{
-	icon_state = "test_floor4"
-	},
-/area/shuttle/canterbury/general)
-"nJ" = (
-/obj/machinery/marine_turret/premade/canterbury{
-	dir = 4
-	},
-/obj/structure/barricade/metal{
-	dir = 4
-	},
-/turf/open/floor/mainship{
-	icon_state = "test_floor5"
-	},
-/area/shuttle/canterbury/general)
-"nT" = (
-/obj/machinery/marine_turret/premade/canterbury{
-	dir = 8
-	},
-/obj/structure/barricade/metal{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/turf/open/floor/mainship{
-	icon_state = "test_floor5"
-	},
-/area/shuttle/canterbury/general)
-"st" = (
-/obj/machinery/marine_turret/premade/canterbury{
-	dir = 8
-	},
-/obj/structure/barricade/metal{
-	dir = 8
-	},
-/turf/open/floor/mainship{
-	icon_state = "test_floor5"
-	},
-/area/shuttle/canterbury/general)
-"CR" = (
-/obj/structure/bed/chair/dropship/passenger{
-	icon_state = "shuttle_chair";
-	dir = 1
-	},
-/obj/effect/landmark/start/latejoin/crash,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plating/mainship,
+/turf/open/floor/mainship/mono,
 /area/shuttle/canterbury/general)
 "Oh" = (
 /obj/effect/landmark/start/marine/crash/synthetic,
@@ -1782,7 +1771,35 @@
 	icon_state = "orangefull"
 	},
 /area/shuttle/canterbury/general)
-"Tz" = (
+"Vd" = (
+/obj/machinery/door/poddoor/mainship{
+	id = "port_umbilical_outer";
+	name = "\improper Umbillical Airlock"
+	},
+/obj/machinery/door/poddoor/shutters/transit,
+/obj/machinery/door_control{
+	dir = 2;
+	id = "port_umbilical_outer";
+	name = "outer door-control";
+	pixel_y = 32
+	},
+/turf/open/floor/mainship/mono,
+/area/shuttle/canterbury/general)
+"Ve" = (
+/obj/structure/bed/chair/dropship/passenger{
+	icon_state = "shuttle_chair";
+	dir = 1
+	},
+/obj/effect/landmark/start/latejoin/crash,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/mainship,
+/area/shuttle/canterbury/general)
+"Wo" = (
+/turf/closed/wall/mainship,
+/area/shuttle/canterbury/medical)
+"XA" = (
 /obj/structure/bed/chair/dropship/passenger{
 	icon_state = "shuttle_chair";
 	dir = 1
@@ -1793,9 +1810,6 @@
 	},
 /turf/open/floor/plating/mainship,
 /area/shuttle/canterbury/general)
-"Wo" = (
-/turf/closed/wall/mainship,
-/area/shuttle/canterbury/medical)
 
 (1,1,1) = {"
 aa
@@ -1829,7 +1843,7 @@ aa
 aa
 aa
 as
-aG
+Vd
 aG
 aG
 aG
@@ -1881,10 +1895,10 @@ aa
 aa
 aa
 as
-st
+gV
 aO
 aE
-nT
+eW
 as
 bw
 bk
@@ -1911,7 +1925,7 @@ ax
 aH
 aP
 cD
-Tz
+XA
 bl
 dl
 bx
@@ -2055,7 +2069,7 @@ cV
 cm
 dg
 as
-as
+rN
 "}
 (11,1,1) = {"
 ab
@@ -2067,7 +2081,7 @@ aD
 aL
 aT
 da
-CR
+Ve
 be
 bq
 bC
@@ -2089,10 +2103,10 @@ aa
 aa
 aa
 as
-nJ
+tl
 aO
 aY
-fw
+ru
 as
 bf
 br
@@ -2105,7 +2119,7 @@ cA
 cM
 cW
 as
-mb
+uL
 as
 aa
 "}
@@ -2115,7 +2129,7 @@ aa
 aa
 aa
 as
-mZ
+aw
 aM
 aU
 aV
@@ -2141,7 +2155,7 @@ aa
 aa
 aa
 as
-bS
+uM
 bS
 bS
 bS

--- a/_maps/shuttles/tgs_canterbury.dmm
+++ b/_maps/shuttles/tgs_canterbury.dmm
@@ -200,14 +200,14 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury/cic)
 "aw" = (
-/obj/machinery/marine_turret/premade/canterbury{
-	dir = 8
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/barricade/metal{
-	dir = 8
+/obj/machinery/door_control{
+	dir = 2;
+	id = "port_umbilical_outer";
+	name = "outer door-control";
+	pixel_y = 32
 	},
 /turf/open/floor/mainship{
 	icon_state = "test_floor4"
@@ -218,6 +218,9 @@
 	dir = 4
 	},
 /obj/structure/closet/firecloset,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury/general)
 "ay" = (
@@ -267,19 +270,18 @@
 	},
 /obj/structure/closet/emcloset,
 /obj/machinery/light{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury/general)
 "aE" = (
-/obj/machinery/door/poddoor/mainship{
-	id = "port_umbilical_inner";
-	name = "\improper Umbillical Airlock"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
+	},
+/turf/open/floor/plating/plating_catwalk,
 /area/shuttle/canterbury/general)
 "aF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -305,9 +307,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/mainship{
-	icon_state = "test_floor5"
-	},
+/turf/open/floor/mainship,
 /area/shuttle/canterbury/general)
 "aI" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -350,9 +350,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/mainship{
-	icon_state = "test_floor5"
-	},
+/turf/open/floor/mainship,
 /area/shuttle/canterbury/general)
 "aM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -372,25 +370,10 @@
 	},
 /area/shuttle/canterbury/general)
 "aO" = (
-/obj/machinery/door/poddoor/mainship{
-	id = "port_umbilical_inner";
-	name = "\improper Umbillical Airlock"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/door_control{
-	id = "port_umbilical_inner";
-	name = "inner door-control";
-	pixel_y = 35
-	},
-/obj/machinery/door_control{
-	dir = 2;
-	id = "port_umbilical_outer";
-	name = "outer door-control";
-	pixel_y = 28
-	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/plating/plating_catwalk,
 /area/shuttle/canterbury/general)
 "aP" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -400,9 +383,7 @@
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/thin,
-/turf/open/floor/mainship{
-	icon_state = "test_floor5"
-	},
+/turf/open/floor/mainship,
 /area/shuttle/canterbury/general)
 "aQ" = (
 /obj/effect/decal/warning_stripes/thin,
@@ -442,9 +423,7 @@
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/thin,
-/turf/open/floor/mainship{
-	icon_state = "test_floor5"
-	},
+/turf/open/floor/mainship,
 /area/shuttle/canterbury/general)
 "aU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -456,12 +435,6 @@
 /area/shuttle/canterbury/general)
 "aV" = (
 /obj/machinery/light/small,
-/obj/machinery/marine_turret/premade/canterbury{
-	dir = 8
-	},
-/obj/structure/barricade/metal{
-	dir = 8
-	},
 /turf/open/floor/mainship{
 	icon_state = "test_floor4"
 	},
@@ -479,14 +452,13 @@
 /turf/open/floor/plating/mainship,
 /area/shuttle/canterbury/general)
 "aY" = (
-/obj/machinery/door/poddoor/mainship{
-	id = "starboard_umbilical_inner";
-	name = "\improper Umbillical Airlock"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 10
+	},
+/turf/open/floor/plating/plating_catwalk,
 /area/shuttle/canterbury/general)
 "aZ" = (
 /obj/machinery/power/fusion_engine/random,
@@ -1329,9 +1301,6 @@
 	},
 /area/shuttle/canterbury/general)
 "cD" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/structure/bed/chair/dropship/passenger{
 	icon_state = "shuttle_chair";
 	dir = 1
@@ -1571,9 +1540,6 @@
 	},
 /area/shuttle/canterbury/general)
 "da" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/bed/chair/dropship/passenger{
 	icon_state = "shuttle_chair";
 	dir = 1
@@ -1702,26 +1668,6 @@
 	},
 /turf/closed/wall/mainship/outer,
 /area/shuttle/canterbury/medical)
-"ds" = (
-/obj/machinery/door/poddoor/mainship{
-	id = "starboard_umbilical_inner";
-	name = "\improper Umbillical Airlock"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/door_control{
-	id = "starboard_umbilical_inner";
-	name = "inner door-control";
-	pixel_y = 35
-	},
-/obj/machinery/door_control{
-	id = "starboard_umbilical_outer";
-	name = "outer door-control";
-	pixel_y = 28
-	},
-/turf/open/floor/mainship/mono,
-/area/shuttle/canterbury/general)
 "dy" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -1747,7 +1693,21 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/canterbury/general)
-"eO" = (
+"fw" = (
+/obj/machinery/marine_turret/premade/canterbury{
+	dir = 4
+	},
+/obj/structure/barricade/metal{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor/mainship{
+	icon_state = "test_floor5"
+	},
+/area/shuttle/canterbury/general)
+"mb" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -1756,22 +1716,20 @@
 	icon_state = "cargo"
 	},
 /area/shuttle/canterbury/general)
-"Bt" = (
-/obj/machinery/marine_turret/premade/canterbury{
-	dir = 4
-	},
+"mZ" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/barricade/metal{
-	dir = 4
+/obj/machinery/door_control{
+	id = "starboard_umbilical_outer";
+	name = "outer door-control";
+	pixel_y = 32
 	},
 /turf/open/floor/mainship{
 	icon_state = "test_floor4"
 	},
 /area/shuttle/canterbury/general)
-"CO" = (
-/obj/machinery/light/small,
+"nJ" = (
 /obj/machinery/marine_turret/premade/canterbury{
 	dir = 4
 	},
@@ -1779,14 +1737,61 @@
 	dir = 4
 	},
 /turf/open/floor/mainship{
-	icon_state = "test_floor4"
+	icon_state = "test_floor5"
 	},
+/area/shuttle/canterbury/general)
+"nT" = (
+/obj/machinery/marine_turret/premade/canterbury{
+	dir = 8
+	},
+/obj/structure/barricade/metal{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor/mainship{
+	icon_state = "test_floor5"
+	},
+/area/shuttle/canterbury/general)
+"st" = (
+/obj/machinery/marine_turret/premade/canterbury{
+	dir = 8
+	},
+/obj/structure/barricade/metal{
+	dir = 8
+	},
+/turf/open/floor/mainship{
+	icon_state = "test_floor5"
+	},
+/area/shuttle/canterbury/general)
+"CR" = (
+/obj/structure/bed/chair/dropship/passenger{
+	icon_state = "shuttle_chair";
+	dir = 1
+	},
+/obj/effect/landmark/start/latejoin/crash,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/mainship,
 /area/shuttle/canterbury/general)
 "Oh" = (
 /obj/effect/landmark/start/marine/crash/synthetic,
 /turf/open/floor/mainship{
 	icon_state = "orangefull"
 	},
+/area/shuttle/canterbury/general)
+"Tz" = (
+/obj/structure/bed/chair/dropship/passenger{
+	icon_state = "shuttle_chair";
+	dir = 1
+	},
+/obj/effect/landmark/start/latejoin/crash,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/mainship,
 /area/shuttle/canterbury/general)
 "Wo" = (
 /turf/closed/wall/mainship,
@@ -1876,10 +1881,10 @@ aa
 aa
 aa
 as
-as
+st
 aO
 aE
-as
+nT
 as
 bw
 bk
@@ -1906,7 +1911,7 @@ ax
 aH
 aP
 cD
-aX
+Tz
 bl
 dl
 bx
@@ -2062,7 +2067,7 @@ aD
 aL
 aT
 da
-aX
+CR
 be
 bq
 bC
@@ -2084,10 +2089,10 @@ aa
 aa
 aa
 as
-as
-ds
+nJ
+aO
 aY
-as
+fw
 as
 bf
 br
@@ -2100,7 +2105,7 @@ cA
 cM
 cW
 as
-eO
+mb
 as
 aa
 "}
@@ -2110,10 +2115,10 @@ aa
 aa
 aa
 as
-Bt
+mZ
 aM
 aU
-CO
+aV
 as
 bg
 bs


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
removes some entrances and makes turrets face a better direction
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->



## Changelog
:cl:
balance: removed some entrances from the canterbury and made turrets face outwards
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
