### PR TITLE
Boiler Gas Message Fix

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
@@ -36,11 +36,12 @@
 
 /datum/action/xeno_action/toggle_bomb/action_activate()
 	var/mob/living/carbon/xenomorph/boiler/X = owner
-	to_chat(X, "<span class='notice'>We will now fire [X.ammo.type == /datum/ammo/xeno/boiler_gas/corrosive ? "corrosive acid. This is lethal!" : "neurotoxic gas. This is nonlethal."]</span>")
 	if(X.ammo.type == /datum/ammo/xeno/boiler_gas)
 		X.ammo = GLOB.ammo_list[/datum/ammo/xeno/boiler_gas/corrosive]
+		to_chat(X, "<span class='notice'>We will now fire corrosive acid. This is lethal!</span>")
 	else
 		X.ammo = GLOB.ammo_list[/datum/ammo/xeno/boiler_gas]
+		to_chat(X, "<span class='notice'>We will now fire neurotoxic gas. This is nonlethal.</span>")
 	update_button_icon()
 
 /datum/action/xeno_action/toggle_bomb/update_button_icon()


### PR DESCRIPTION
## About The Pull Request

Ensures that the text stating which type of gas you have switched to as boiler is actually correct.

## Why It's Good For The Game

Reduces player confusion.

## Changelog
:cl:
fix: Fixes the text telling Boilers which gas type they have selected. 
/:cl:

Fixes #3073