### PR TITLE
Changes the range of XenoSpit

### DIFF
--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -917,7 +917,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	shell_speed = 1
 	accuracy = 40
 	accurate_range = 15
-	max_range = 7
+	max_range = 15
 	accuracy_var_low = 3
 	accuracy_var_high = 3
 
@@ -931,7 +931,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	armor_type = "bio"
 	accuracy = 40
 	accurate_range = 5
-	max_range = 7
+	max_range = 10
 	accuracy_var_low = 3
 	accuracy_var_high = 3
 	damage = 15
@@ -1055,7 +1055,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage_type = BURN
 	added_spit_delay = 5
 	spit_cost = 75
-	flags_ammo_behavior = AMMO_XENO_ACID
+	flags_ammo_behavior = AMMO_XENO_ACID|AMMO_EXPLOSIVE
 	armor_type = "acid"
 	damage = 20
 

--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -917,7 +917,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	shell_speed = 1
 	accuracy = 40
 	accurate_range = 15
-	max_range = 15
+	max_range = 7
 	accuracy_var_low = 3
 	accuracy_var_high = 3
 
@@ -931,7 +931,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	armor_type = "bio"
 	accuracy = 40
 	accurate_range = 5
-	max_range = 10
+	max_range = 7
 	accuracy_var_low = 3
 	accuracy_var_high = 3
 	damage = 15
@@ -1055,7 +1055,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage_type = BURN
 	added_spit_delay = 5
 	spit_cost = 75
-	flags_ammo_behavior = AMMO_XENO_ACID|AMMO_EXPLOSIVE
+	flags_ammo_behavior = AMMO_XENO_ACID
 	armor_type = "acid"
 	damage = 20
 

--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -917,7 +917,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	shell_speed = 1
 	accuracy = 40
 	accurate_range = 15
-	max_range = 15
+	max_range = 8
 	accuracy_var_low = 3
 	accuracy_var_high = 3
 
@@ -931,7 +931,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	armor_type = "bio"
 	accuracy = 40
 	accurate_range = 5
-	max_range = 10
+	max_range = 8
 	accuracy_var_low = 3
 	accuracy_var_high = 3
 	damage = 15
@@ -1055,7 +1055,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage_type = BURN
 	added_spit_delay = 5
 	spit_cost = 75
-	flags_ammo_behavior = AMMO_XENO_ACID|AMMO_EXPLOSIVE
+	flags_ammo_behavior = AMMO_XENO_ACID
 	armor_type = "acid"
 	damage = 20
 


### PR DESCRIPTION
## About The Pull Request

Just starting

## Why It's Good For The Game

I heard that xeno spit doesn't affect turrets because of the ammo_explosive thing.

So to keep things mostly the same (barring losing a few tiles at the corner). I changed the max_range of xeno spit.

## Changelog
:cl: Hughgent
tweak: Xeno Spit is now range based.
fix: Xeno Spit now affects turrets again.
/:cl:
