### PR TITLE
XenoSpit to 8

### DIFF
--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -917,7 +917,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	shell_speed = 1
 	accuracy = 40
 	accurate_range = 15
-	max_range = 15
+	max_range = 8
 	accuracy_var_low = 3
 	accuracy_var_high = 3
 
@@ -931,7 +931,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	armor_type = "bio"
 	accuracy = 40
 	accurate_range = 5
-	max_range = 10
+	max_range = 8
 	accuracy_var_low = 3
 	accuracy_var_high = 3
 	damage = 15
@@ -1055,7 +1055,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage_type = BURN
 	added_spit_delay = 5
 	spit_cost = 75
-	flags_ammo_behavior = AMMO_XENO_ACID|AMMO_EXPLOSIVE
+	flags_ammo_behavior = AMMO_XENO_ACID
 	armor_type = "acid"
 	damage = 20
 


### PR DESCRIPTION

## About The Pull Request

EOL changes are evil.

## Why It's Good For The Game
Xenos don't need to be perfectly on tile accurate, they can just click in line with their target.

## Changelog
:cl:
tweak: Xeno Spit is range based now. you can click in line with your target.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
