### PR TITLE
Nerfed 88 Mod 4 (VP 70)

### DIFF
--- a/code/modules/projectiles/updated_projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/pistols.dm
@@ -370,7 +370,7 @@
 	burst_amount = 3
 	accuracy_mult = 1.05
 	accuracy_mult_unwielded = 0.95
-	damage_mult = 1.4
+	damage_mult = 1.2
 	recoil_unwielded = 2
 
 //-------------------------------------------------------


### PR DESCRIPTION
## About The Pull Request

88 Mod 4 (Called VP70) in the code is capable of critting a queen in 12 shots from the side. I nerfed its damage so now you need about 18 shots to crit a queen, a full mag, so you should actually need to reload to kill a queen with this pistol. Its still good just not completely broken.

## Why It's Good For The Game

This pistol is shit to play against as a tankier xeno as the guy with the pistol is faster than you and melts you very quickly. This change should make the pistol a bit more balanced.

## Changelog
:cl:
balance: 88 Mod 4 damage_mult = 1.4 => 1.2
/:cl: