### PR TITLE
Gives Xeno Queen Call of the Burrowed

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
@@ -53,6 +53,7 @@
 		/datum/action/xeno_action/choose_resin,
 		/datum/action/xeno_action/activable/secrete_resin,
 		/datum/action/xeno_action/lay_egg,
+		/datum/action/xeno_action/call_of_the_burrowed,
 		/datum/action/xeno_action/activable/screech,
 		/datum/action/xeno_action/activable/corrosive_acid/strong,
 		/datum/action/xeno_action/psychic_whisper,


### PR DESCRIPTION

## About The Pull Request

Xeno Queen can now use call of the burrowed

## Why It's Good For The Game

Queen currently has no way of calling burrowed larva since Ovi was removed. Considering it is the queen, and evolution of the shrike, it should probably have such an important ability.

## Changelog
:cl:
add: Xeno Queen now has Call of the Burrowed
/:cl: