### PR TITLE
Pheromone Mini-Rework

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -392,8 +392,6 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 
 //Xeno Defines
 
-#define FRENZY_DAMAGE_BONUS(Xenomorph) ((Xenomorph.frenzy_aura * 2))
-
 #define XENO_SLOWDOWN_REGEN 0.4
 #define XENO_HALOSS_REGEN 3
 #define QUEEN_DEATH_TIMER 300 // 5 minutes

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -58,8 +58,6 @@
 	playsound(loc, 'sound/weapons/alien_knockdown.ogg', 25, 1)
 
 	var/tackle_pain = X.xeno_caste.tackle_damage
-	if(X.frenzy_aura)
-		tackle_pain = tackle_pain * (1 + (0.05 * X.frenzy_aura))  //Halloss damage increased by 5% per rank of frenzy aura
 	if(protection_aura)
 		tackle_pain = tackle_pain * (1 - (0.10 + 0.05 * protection_aura))  //Halloss damage decreased by 10% + 5% per rank of protection aura
 	if(X.stealth_router(HANDLE_STEALTH_CHECK))

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -58,6 +58,10 @@
 	playsound(loc, 'sound/weapons/alien_knockdown.ogg', 25, 1)
 
 	var/tackle_pain = X.xeno_caste.tackle_damage
+	if(X.frenzy_aura)
+		tackle_pain = tackle_pain * (1 + (0.05 * X.frenzy_aura))  //Halloss damage increased by 5% per rank of frenzy aura
+	if(protection_aura)
+		tackle_pain = tackle_pain * (1 - (0.10 + 0.05 * protection_aura))  //Halloss damage decreased by 10% + 5% per rank of protection aura
 	if(X.stealth_router(HANDLE_STEALTH_CHECK))
 		if(X.stealth_router(HANDLE_SNEAK_ATTACK_CHECK))
 			#ifdef DEBUG_ATTACK_ALIEN

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -58,10 +58,6 @@
 	playsound(loc, 'sound/weapons/alien_knockdown.ogg', 25, 1)
 
 	var/tackle_pain = X.xeno_caste.tackle_damage
-	if(X.frenzy_aura)
-		tackle_pain = tackle_pain * (1 + (0.05 * X.frenzy_aura))  //Halloss damage increased by 5% per rank of frenzy aura
-	if(protection_aura)
-		tackle_pain = tackle_pain * (1 - (0.10 + 0.05 * protection_aura))  //Halloss damage decreased by 10% + 5% per rank of protection aura
 	if(X.stealth_router(HANDLE_STEALTH_CHECK))
 		if(X.stealth_router(HANDLE_SNEAK_ATTACK_CHECK))
 			#ifdef DEBUG_ATTACK_ALIEN
@@ -163,7 +159,7 @@
 
 	// copypasted from attack_alien.dm
 	//From this point, we are certain a full attack will go out. Calculate damage and modifiers
-	var/damage = X.xeno_caste.melee_damage + FRENZY_DAMAGE_BONUS(X)
+	var/damage = X.xeno_caste.melee_damage
 
 	X.do_attack_animation(src)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
@@ -28,7 +28,6 @@
 			continue
 		var/distance = get_dist(M, X)
 		var/damage = (rand(CRUSHER_STOMP_LOWER_DMG, CRUSHER_STOMP_UPPER_DMG) * CRUSHER_STOMP_UPGRADE_BONUS(X)) / max(1,distance + 1)
-		damage += FRENZY_DAMAGE_BONUS(X)
 		if(distance == 0) //If we're on top of our victim, give him the full impact
 			GLOB.round_statistics.crusher_stomp_victims++
 			var/armor_block = M.run_armor_check("chest", "melee") * 0.5 //Only 50% armor applies vs stomp brute damage
@@ -129,7 +128,6 @@
 	//Handle the damage
 	if(!X.issamexenohive(L)) //Friendly xenos don't take damage.
 		var/damage = toss_distance * 5
-		damage += FRENZY_DAMAGE_BONUS(X)
 		var/armor_block = L.run_armor_check("chest", "melee")
 		if(ishuman(L))
 			var/mob/living/carbon/human/H = L

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -63,7 +63,7 @@
 
 	X.face_atom(H) //Face towards the target so we don't look silly
 
-	var/damage = X.xeno_caste.melee_damage + FRENZY_DAMAGE_BONUS(X)
+	var/damage = X.xeno_caste.melee_damage
 	damage *= (1 + distance * 0.25) //More distance = more momentum = stronger Headbutt.
 	var/affecting = H.get_limb(ran_zone(null, 0))
 	if(!affecting) //Still nothing??
@@ -132,7 +132,7 @@
 	for (var/mob/living/carbon/human/H in L)
 		step_away(H, src, sweep_range, 2)
 		if(H.stat != DEAD && !isnestedhost(H) ) //No bully
-			var/damage = X.xeno_caste.melee_damage + FRENZY_DAMAGE_BONUS(X)
+			var/damage = X.xeno_caste.melee_damage
 			var/affecting = H.get_limb(ran_zone(null, 0))
 			if(!affecting) //Still nothing??
 				affecting = H.get_limb("chest") //Gotta have a torso?!
@@ -280,7 +280,7 @@
 		X.set_crest_defense(FALSE, TRUE)
 		CD.add_cooldown()
 		to_chat(X, "<span class='xenowarning'>We tuck our lowered crest into ourselves.</span>")
-	
+
 	X.set_fortify(TRUE, was_crested)
 	add_cooldown()
 	return succeed_activate()

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -149,7 +149,7 @@
 			use_plasma(5)
 
 	if(locate(/obj/effect/alien/weeds) in T)
-		gain_plasma(xeno_caste.plasma_gain + round(xeno_caste.plasma_gain * 0.5 * ( recovery_aura * 0.5 ))) // Empty recovery aura will always equal 0
+		gain_plasma(xeno_caste.plasma_gain + round(xeno_caste.plasma_gain * recovery_aura * 0.25)) // Empty recovery aura will always equal 0
 	else
 		gain_plasma(1)
 

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -126,9 +126,9 @@
 		adjustBruteLoss(XENO_CRIT_DAMAGE - warding_aura) //Warding can heavily lower the impact of bleedout. Halved at 2.5 phero, stopped at 5 phero
 
 /mob/living/carbon/xenomorph/proc/heal_wounds(multiplier = XENO_RESTING_HEAL)
-	var/amount = (1 + (maxHealth * 0.02) ) // 1 damage + 2% max health
+	var/amount = (1 + (maxHealth * 0.03) ) // 1 damage + 3% max health
 	if(recovery_aura)
-		amount += recovery_aura * maxHealth * 0.01 // +1% max health per recovery level, up to +5%
+		amount += recovery_aura * maxHealth * 0.008 // +08% max health per recovery level, up to +4%
 	amount *= multiplier
 	adjustBruteLoss(-amount)
 	adjustFireLoss(-amount)
@@ -149,7 +149,7 @@
 			use_plasma(5)
 
 	if(locate(/obj/effect/alien/weeds) in T)
-		gain_plasma(xeno_caste.plasma_gain + round(xeno_caste.plasma_gain * recovery_aura * 0.25)) // Empty recovery aura will always equal 0
+		gain_plasma(xeno_caste.plasma_gain + round(xeno_caste.plasma_gain * 0.5 * ( recovery_aura * 0.5 ))) // Empty recovery aura will always equal 0
 	else
 		gain_plasma(1)
 

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -128,7 +128,7 @@
 /mob/living/carbon/xenomorph/proc/heal_wounds(multiplier = XENO_RESTING_HEAL)
 	var/amount = (1 + (maxHealth * 0.03) ) // 1 damage + 3% max health
 	if(recovery_aura)
-		amount += recovery_aura * maxHealth * 0.008 // +08% max health per recovery level, up to +4%
+		amount += recovery_aura * maxHealth * 0.008 // +0.8% max health per recovery level, up to +4%
 	amount *= multiplier
 	adjustBruteLoss(-amount)
 	adjustFireLoss(-amount)

--- a/code/modules/mob/living/carbon/xenomorph/xenoattacks.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoattacks.dm
@@ -133,7 +133,7 @@
 				else
 					// copypasted from attack_alien.dm
 					//From this point, we are certain a full attack will go out. Calculate damage and modifiers
-					var/damage = M.xeno_caste.melee_damage + FRENZY_DAMAGE_BONUS(M)
+					var/damage = M.xeno_caste.melee_damage
 
 					//Somehow we will deal no damage on this attack
 					if(!damage)

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -224,7 +224,7 @@
 	. += speed + slowdown + speed_modifier
 
 	if(frenzy_aura)
-		. -= (frenzy_aura * 0.12)
+		. -= (frenzy_aura * 0.10)
 
 	if(hit_and_run) //We need to have the hit and run ability before we do anything
 		hit_and_run += 0.05 //increment the damage of our next attack by +5%

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -224,7 +224,7 @@
 	. += speed + slowdown + speed_modifier
 
 	if(frenzy_aura)
-		. -= (frenzy_aura * 0.10)
+		. -= (frenzy_aura * 0.1)
 
 	if(hit_and_run) //We need to have the hit and run ability before we do anything
 		hit_and_run += 0.05 //increment the damage of our next attack by +5%

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -224,7 +224,7 @@
 	. += speed + slowdown + speed_modifier
 
 	if(frenzy_aura)
-		. -= (frenzy_aura * 0.05)
+		. -= (frenzy_aura * 0.12)
 
 	if(hit_and_run) //We need to have the hit and run ability before we do anything
 		hit_and_run += 0.05 //increment the damage of our next attack by +5%

--- a/code/modules/vehicles/multitile/cm_armored.dm
+++ b/code/modules/vehicles/multitile/cm_armored.dm
@@ -555,7 +555,7 @@ GLOBAL_LIST_INIT(armorvic_dmg_distributions, list(
 		handle_player_entrance(M) //will call the get out of tank proc on its own
 		return
 
-	var/damage = M.xeno_caste.melee_damage + dam_bonus + FRENZY_DAMAGE_BONUS(M)
+	var/damage = M.xeno_caste.melee_damage + dam_bonus
 
 	M.do_attack_animation(src)
 


### PR DESCRIPTION
##About The Pull Request

This removes all damage bonuses from Frenzy, makes it not take 5 years to heal while resting on resin without pheros, adjusts regenerative pheromones so they don't become god like, and makes Frenzy increase movespeed by 0.12 per strength (Up to 0.6 at very strong)

## Why It's Good For The Game

Nobody likes frenzy pheromones, and they mess with balance. There is an over-reliance on regenerative pheromones since you heal like molasses otherwise. This should hopefully ensure every pheromone is helpful without being godlike, since most players disliked the dependency.

## Changelog
:cl:
balance: Buffs base health regeneration, slightly nerfs regenerative pheromone buff
balance: Frenzy now increased movespeed significantly more than it previously did. Completely removes all Frenzy Damage buffs from the game.
/:cl:

