### PR TITLE
Dropship Turret Nerf

### DIFF
--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -699,8 +699,8 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 
 /datum/ammo/bullet/turret/gauss
 	name = "gauss turret heavy slug"
-	damage = 50
-	penetration = 60
+	damage = 30
+	penetration = 30
 	accurate_range = 3
 
 /datum/ammo/bullet/turret/mini


### PR DESCRIPTION
## About The Pull Request

Hopefully this one works now.
Dropship Turret Damage 50 => 30
Dropship Turret Armor Piercing 60 => 30

## Why It's Good For The Game

Should no longer crit a queen with warding pheromones in a single second.

## Changelog
:cl:
balance: Nerfs DS turrets.
/:cl: