### PR TITLE
Fixes respawn timer

### DIFF
--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -116,5 +116,5 @@
 
 #define XENO_AFK_TIMER			5 MINUTES
 
-#define DEATHTIME_CHECK(M) ((world.time - M.timeofdeath) > GLOB.respawntime) && check_other_rights(M.client, R_ADMIN, FALSE)
+#define DEATHTIME_CHECK(M) (((world.time - M.timeofdeath) > GLOB.respawntime) && !check_other_rights(M.client, R_ADMIN, FALSE))
 #define DEATHTIME_MESSAGE(M) to_chat(M, "<span class='warning'>You have been dead for [(world.time - M.timeofdeath) * 0.1] second\s.</span><br><span class='warning'>You must wait [GLOB.respawntime * 0.1] seconds before rejoining the game!</span>")

--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -116,5 +116,5 @@
 
 #define XENO_AFK_TIMER			5 MINUTES
 
-#define DEATHTIME_CHECK(M) (((world.time - M.timeofdeath) > GLOB.respawntime) && !check_other_rights(M.client, R_ADMIN, FALSE))
+#define DEATHTIME_CHECK(M) (((world.time - M.timeofdeath) < GLOB.respawntime) && !check_other_rights(M.client, R_ADMIN, FALSE))
 #define DEATHTIME_MESSAGE(M) to_chat(M, "<span class='warning'>You have been dead for [(world.time - M.timeofdeath) * 0.1] second\s.</span><br><span class='warning'>You must wait [GLOB.respawntime * 0.1] seconds before rejoining the game!</span>")

--- a/code/_globalvars/admin.dm
+++ b/code/_globalvars/admin.dm
@@ -4,7 +4,7 @@ GLOBAL_VAR_INIT(dsay_allowed, TRUE)
 GLOBAL_VAR_INIT(enter_allowed, TRUE)
 GLOBAL_VAR_INIT(respawn_allowed, FALSE)
 
-GLOBAL_VAR_INIT(respawntime, 5 MINUTES)
+GLOBAL_VAR_INIT(respawntime, 2 MINUTES)
 GLOBAL_VAR_INIT(fileaccess_timer, 0)
 
 GLOBAL_VAR_INIT(custom_info, "")

--- a/code/datums/gamemodes/game_mode.dm
+++ b/code/datums/gamemodes/game_mode.dm
@@ -835,7 +835,7 @@ Sensors indicate [numXenosShip ? "[numXenosShip]" : "no"] unknown lifeform signa
 		to_chat(xeno_candidate, "<span class='warning'>That xenomorph has been occupied.</span>")
 		return FALSE
 
-	if(!DEATHTIME_CHECK(xeno_candidate))
+	if(DEATHTIME_CHECK(xeno_candidate))
 		DEATHTIME_MESSAGE(xeno_candidate)
 		return FALSE
 

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -549,7 +549,7 @@ to_chat will check for valid clients itself already so no need to double check f
 	if(QDELETED(chosen_mother) || !xeno_candidate?.client)
 		return FALSE
 
-	if(!isnewplayer(xeno_candidate) && !DEATHTIME_CHECK(xeno_candidate))
+	if(!isnewplayer(xeno_candidate) && DEATHTIME_CHECK(xeno_candidate))
 		DEATHTIME_MESSAGE(xeno_candidate)
 		return FALSE
 
@@ -566,7 +566,7 @@ to_chat will check for valid clients itself already so no need to double check f
 	if(QDELETED(chosen_silo) || !xeno_candidate?.client)
 		return FALSE
 
-	if(!isnewplayer(xeno_candidate) && !DEATHTIME_CHECK(xeno_candidate))
+	if(!isnewplayer(xeno_candidate) && DEATHTIME_CHECK(xeno_candidate))
 		DEATHTIME_MESSAGE(xeno_candidate)
 		return FALSE
 


### PR DESCRIPTION
## Changelog
:cl:
fix: Fixed a bug in where only admins would suffer a 5 minutes cooldown before they could rejoin as xeno, or anything. In compensation, reduced the time to only 2 minutes, where before it was zero for everyone else.
/:cl: