### PR TITLE
Xenomorphs no longer get 1.25x or 1.5x critical hits

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -6,9 +6,6 @@
 
 //#define DEBUG_ATTACK_ALIEN
 
-/mob/living/carbon/xenomorph/proc/reset_critical_hit()
-	critical_proc = FALSE
-
 /mob/living/proc/attack_alien_grab(mob/living/carbon/xenomorph/X)
 	if(X == src || anchored || buckled)
 		return FALSE
@@ -172,26 +169,6 @@
 	var/attack_message1 = "<span class='danger'>\The [X] slashes [src]!</span>"
 	var/attack_message2 = "<span class='danger'>We slash [src]!</span>"
 	var/log = "slashed"
-	//Check for a special bite attack
-	if(prob(X.xeno_caste.bite_chance) && !X.critical_proc && !no_crit && !X.stealth_router(HANDLE_STEALTH_CHECK)) //Can't crit if we already crit in the past 3 seconds; stealthed ironically can't crit because weeoo das a lotta damage
-		damage *= 1.5
-		attack_sound = "alien_bite"
-		attack_message1 = "<span class='danger'>\The [src] is viciously shredded by \the [X]'s sharp teeth!</span>"
-		attack_message2 = "<span class='danger'>We viciously rend \the [src] with our teeth!</span>"
-		log = "bit"
-		X.critical_proc = TRUE
-		addtimer(CALLBACK(X, /mob/living/carbon/xenomorph/proc/reset_critical_hit), X.xeno_caste.rng_min_interval)
-
-	//Check for a special bite attack
-	if(prob(X.xeno_caste.tail_chance) && !X.critical_proc && !no_crit && !X.stealth_router(HANDLE_STEALTH_CHECK)) //Can't crit if we already crit in the past 3 seconds; stealthed ironically can't crit because weeoo das a lotta damage
-		damage *= 1.25
-		attack_flick = "tail"
-		attack_sound = 'sound/weapons/alien_tail_attack.ogg'
-		attack_message1 = "<span class='danger'>\The [src] is suddenly impaled by \the [X]'s sharp tail!</span>"
-		attack_message2 = "<span class='danger'>We violently impale \the [src] with our tail!</span>"
-		log = "tail-stabbed"
-		X.critical_proc = TRUE
-		addtimer(CALLBACK(X, /mob/living/carbon/xenomorph/proc/reset_critical_hit), X.xeno_caste.rng_min_interval)
 
 	//Somehow we will deal no damage on this attack
 	if(!damage)

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -16,9 +16,6 @@
 	// *** Tackle *** //
 	tackle_damage = 55
 
-	// *** RNG Attacks *** //
-	tail_chance = 0 //Inherited from old code. Tail's too big
-
 	// *** Speed *** //
 	speed = 0.1
 
@@ -134,4 +131,4 @@
 
 	// *** Defense *** //
 	armor = list("melee" = 100, "bullet" = 50, "laser" = 50, "energy" = 100, "bomb" = XENO_BOMB_RESIST_3, "bio" = 100, "rad" = 100, "fire" = 15, "acid" = 100)
-	
+

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -28,11 +28,6 @@
 	var/tackle_chance = 100
 	var/tackle_damage = 20 //How much HALLOSS damage a xeno deals when tackling
 
-	// *** RNG Attacks *** //
-	var/bite_chance = 5 //Chance of doing a special bite attack in place of a claw. Set to 0 to disable.
-	var/tail_chance = 10 //Chance of doing a special tail attack in place of a claw. Set to 0 to disable.
-	var/rng_min_interval = 3 SECONDS //Prevents further critical hits until this much time elapses
-
 	// *** Speed *** //
 	var/speed = 1
 
@@ -148,8 +143,6 @@
 	var/upgrade_stored = 0 //How much upgrade points they have stored.
 	var/upgrade = XENO_UPGRADE_INVALID  //This will track their upgrade level.
 	var/gib_chance = 5 // % chance of them exploding when taking damage. Goes up with damage inflicted.
-	var/critical_proc = 0
-	var/critical_delay = 25
 
 	var/middle_mouse_toggle = TRUE //This toggles whether selected ability uses middle mouse clicking or shift clicking
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Xenomorphs no longer have a 10% or a 5% chance to get a 1.25x damage slash or a 1.5x damage slash respectively

## Why It's Good For The Game
Removes rng from game, consistent damage now
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Xenomorphs no longer get critical hits
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
