### PR TITLE
Crash xeno respawn fix

### DIFF
--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -210,7 +210,7 @@
 	var/datum/hive_status/normal/xeno_hive = GLOB.hive_datums[XENO_HIVE_NORMAL]
 	if(xeno_hive.stored_larva)
 		return TRUE //No need for respawns nor to end the game. They can use their burrowed larvas.
-	var/new_xeno_batch = min(1, round(num_humans * 0.2))
+	var/new_xeno_batch = max(1, round(num_humans * 0.2))
 	for(var/i in new_xeno_batch)
 		var/obj/structure/resin/silo/spawn_point = pick(GLOB.xeno_resin_silos)
 		var/mob/living/carbon/xenomorph/larva/new_xeno = new /mob/living/carbon/xenomorph/larva(spawn_point.loc)


### PR DESCRIPTION
Xenos weren't respawning properly upon being wiped out in Crash game mode.