### PR TITLE
B18 armor no longer autoheals, is now not heavy

### DIFF
--- a/code/__DEFINES/objects.dm
+++ b/code/__DEFINES/objects.dm
@@ -131,18 +131,6 @@ GLOBAL_LIST_INIT(restricted_camera_networks, list( //Those networks can only be 
 #define SCOUT_CLOAK_MAX_ENERGY 100
 #define SCOUT_CLOAK_OFF_DAMAGE (1 << 0)
 #define SCOUT_CLOAK_OFF_ATTACK (1 << 1)
-//B18 DEFINES
-#define B18_CHEM_COOLDOWN				2.5 MINUTES
-#define B18_CHEM_MOD					0.5
-#define B18_BRUTE_CODE					1
-#define B18_BURN_CODE					2
-#define B18_OXY_CODE					3
-#define B18_TOX_CODE					4
-#define B18_PAIN_CODE					5
-#define B18_DAMAGE_MIN					50
-#define B18_DAMAGE_MAX					150
-#define B18_PAIN_MIN					50
-#define B18_PAIN_MAX					150
 
 
 //Razor wire

--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -235,6 +235,7 @@
 	flags_cold_protection = CHEST|GROIN|ARMS|LEGS|FEET
 	flags_heat_protection = CHEST|GROIN|ARMS|LEGS|FEET
 	var/obj/item/healthanalyzer/integrated/B18_analyzer = null
+	var/mob/living/carbon/human/wearer = null
 	supporting_limbs = list(CHEST, GROIN, ARM_LEFT, ARM_RIGHT, HAND_LEFT, HAND_RIGHT, LEG_LEFT, LEG_RIGHT, FOOT_LEFT, FOOT_RIGHT) //B18 effectively stabilizes these.
 	resistance_flags = UNACIDABLE
 
@@ -243,8 +244,18 @@
 	B18_analyzer = new /obj/item/healthanalyzer/integrated
 
 /obj/item/clothing/suit/storage/marine/specialist/Destroy()
+	wearer = null
 	qdel(B18_analyzer)
 	. = ..()
+
+/obj/item/clothing/suit/storage/marine/specialist/dropped(mob/user)
+	. = ..()
+	wearer = null
+
+/obj/item/clothing/suit/storage/marine/specialist/equipped(mob/living/carbon/human/user, slot)
+	. = ..()
+	if(slot == SLOT_WEAR_SUIT)
+		wearer = user
 
 /obj/item/clothing/suit/storage/marine/specialist/verb/b18_automedic_scan()
 	set name = "B18 Automedic User Scan"

--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -228,7 +228,7 @@
 
 /obj/item/clothing/suit/storage/marine/specialist
 	name = "\improper B18 defensive armor"
-	desc = "A rugged set of armor plates for when you really, really need to not die horribly. Slows you down though.\nHas an automated diagnostics system for checking it's wearer's health on the spot."
+	desc = "A rugged set of armor plates for when you really, really need to not die horribly. Slows you down though.\nHas an automated diagnostics system for checking its wearer's health on the spot."
 	icon_state = "xarmor"
 	armor = list("melee" = 80, "bullet" = 110, "laser" = 80, "energy" = 80, "bomb" = 80, "bio" = 20, "rad" = 20, "fire" = 80, "acid" = 80)
 	flags_armor_protection = CHEST|GROIN|ARMS|LEGS|FEET

--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -228,22 +228,12 @@
 
 /obj/item/clothing/suit/storage/marine/specialist
 	name = "\improper B18 defensive armor"
-	desc = "A heavy, rugged set of armor plates for when you really, really need to not die horribly. Slows you down though.\nHas an automated diagnostics and medical system for keeping its wearer alive."
+	desc = "A rugged set of armor plates for when you really, really need to not die horribly. Slows you down though.\nHas an automated diagnostics system for checking it's wearer's health on the spot."
 	icon_state = "xarmor"
 	armor = list("melee" = 80, "bullet" = 110, "laser" = 80, "energy" = 80, "bomb" = 80, "bio" = 20, "rad" = 20, "fire" = 80, "acid" = 80)
 	flags_armor_protection = CHEST|GROIN|ARMS|LEGS|FEET
 	flags_cold_protection = CHEST|GROIN|ARMS|LEGS|FEET
 	flags_heat_protection = CHEST|GROIN|ARMS|LEGS|FEET
-	slowdown = SLOWDOWN_ARMOR_HEAVY
-	var/mob/living/carbon/human/wearer = null
-	var/B18_burn_cooldown = null
-	var/B18_oxy_cooldown = null
-	var/B18_brute_cooldown = null
-	var/B18_tox_cooldown = null
-	var/B18_pain_cooldown = null
-	var/B18_automed_on = TRUE
-	var/B18_automed_damage = 50
-	var/B18_automed_pain = 70
 	var/obj/item/healthanalyzer/integrated/B18_analyzer = null
 	supporting_limbs = list(CHEST, GROIN, ARM_LEFT, ARM_RIGHT, HAND_LEFT, HAND_RIGHT, LEG_LEFT, LEG_RIGHT, FOOT_LEFT, FOOT_RIGHT) //B18 effectively stabilizes these.
 	resistance_flags = UNACIDABLE
@@ -252,242 +242,28 @@
 	. = ..()
 	B18_analyzer = new /obj/item/healthanalyzer/integrated
 
-/obj/item/clothing/suit/storage/marine/specialist/examine(mob/user)
-	. = ..()
-	if(user != wearer) //Only the wearer can see these details.
-		return
-	var/list/details = list()
-	if(B18_burn_cooldown)
-		details +=("Its burn treatment injector is currently refilling. It will resupply in [(B18_burn_cooldown - world.time) * 0.1] seconds.</br>")
-
-	if(B18_brute_cooldown)
-		details +=("Its trauma treatment injector is currently refilling. It will resupply in [(B18_brute_cooldown - world.time) * 0.1] seconds.</br>")
-
-	if(B18_oxy_cooldown)
-		details +=("Its oxygenating injector is currently refilling. It will resupply in [(B18_oxy_cooldown - world.time) * 0.1] seconds.</br>")
-
-	if(B18_tox_cooldown)
-		details +=("Its anti-toxin injector is currently refilling. It will resupply in [(B18_tox_cooldown - world.time) * 0.1] seconds.</br>")
-
-	if(B18_pain_cooldown)
-		details +=("Its painkiller injector is currently refilling. It will resupply in [(B18_pain_cooldown - world.time) * 0.1] seconds.</br>")
-
-	to_chat(user, "<span class='danger'>[details.Join(" ")]</span>")
-
 /obj/item/clothing/suit/storage/marine/specialist/Destroy()
-	b18automed_turn_off(wearer, TRUE)
-	wearer = null
 	qdel(B18_analyzer)
 	. = ..()
-
-/obj/item/clothing/suit/storage/marine/specialist/dropped(mob/user)
-	. = ..()
-	b18automed_turn_off(wearer, TRUE)
-	wearer = null
-
-/obj/item/clothing/suit/storage/marine/specialist/equipped(mob/living/carbon/human/user, slot)
-	. = ..()
-	if(slot == SLOT_WEAR_SUIT)
-		wearer = user
-		b18automed_turn_on(user)
-
-/obj/item/clothing/suit/storage/marine/specialist/proc/b18automed_turn_off(mob/living/carbon/human/user, silent = FALSE)
-	B18_automed_on = FALSE
-	STOP_PROCESSING(SSobj, src)
-	if(!silent)
-		to_chat(user, "<span class='warning'>[src] lets out a beep as its automedical suite deactivates.</span>")
-		playsound(src,'sound/machines/click.ogg', 15, 0, 1)
-
-/obj/item/clothing/suit/storage/marine/specialist/proc/b18automed_turn_on(mob/living/carbon/human/user, silent = FALSE)
-	B18_automed_on = TRUE
-	START_PROCESSING(SSobj, src)
-	if(!silent)
-		to_chat(user, "<span class='notice'>[src] lets out a hum as its automedical suite activates.</span>")
-		playsound(src,'sound/voice/b18_activate.ogg', 15, 0, 1)
-
-/obj/item/clothing/suit/storage/marine/specialist/process()
-	if(!B18_automed_on)
-		STOP_PROCESSING(SSobj, src)
-		return
-	if(!wearer)
-		STOP_PROCESSING(SSobj, src)
-		return
-
-	var/list/details = list()
-	var/dose_administered = null
-
-	if(wearer.getFireLoss() > B18_automed_damage && !B18_burn_cooldown)
-		var/kelotane = CLAMP(REAGENTS_OVERDOSE - (wearer.reagents.get_reagent_amount(/datum/reagent/medicine/kelotane) + 0.5),0,REAGENTS_OVERDOSE * B18_CHEM_MOD)
-		var/tricordrazine = CLAMP(REAGENTS_OVERDOSE - (wearer.reagents.get_reagent_amount(/datum/reagent/medicine/tricordrazine) + 0.5),0,REAGENTS_OVERDOSE * B18_CHEM_MOD)
-		if(kelotane)
-			wearer.reagents.add_reagent(/datum/reagent/medicine/kelotane,kelotane)
-		if(tricordrazine)
-			wearer.reagents.add_reagent(/datum/reagent/medicine/tricordrazine,tricordrazine)
-		if(kelotane || tricordrazine) //Only report if we actually administer something
-			details +=("Significant tissue burns detected. Restorative injection administered. <b>Dosage:[kelotane ? " Kelotane: [kelotane]U |" : ""][tricordrazine ? " Tricordrazine: [tricordrazine]U" : ""]</b></br>")
-			B18_burn_cooldown = world.time + B18_CHEM_COOLDOWN
-			handle_chem_cooldown(B18_BURN_CODE)
-			dose_administered = TRUE
-
-	if(wearer.getBruteLoss() > B18_automed_damage && !B18_brute_cooldown)
-		var/bicaridine = CLAMP(REAGENTS_OVERDOSE - (wearer.reagents.get_reagent_amount(/datum/reagent/medicine/bicaridine) + 0.5),0,REAGENTS_OVERDOSE * B18_CHEM_MOD)
-		var/quickclot = CLAMP(REAGENTS_OVERDOSE * 0.5 - (wearer.reagents.get_reagent_amount(/datum/reagent/medicine/quickclot) + 0.5),0,REAGENTS_OVERDOSE * 0.5 * B18_CHEM_MOD)
-		var/tricordrazine = CLAMP(REAGENTS_OVERDOSE - (wearer.reagents.get_reagent_amount(/datum/reagent/medicine/tricordrazine) + 0.5),0,REAGENTS_OVERDOSE * B18_CHEM_MOD)
-		if(quickclot)
-			wearer.reagents.add_reagent(/datum/reagent/medicine/quickclot,quickclot)
-		if(bicaridine)
-			wearer.reagents.add_reagent(/datum/reagent/medicine/bicaridine,bicaridine)
-		if(tricordrazine)
-			wearer.reagents.add_reagent(/datum/reagent/medicine/tricordrazine,tricordrazine)
-		if(quickclot || bicaridine || tricordrazine) //Only report if we actually administer something
-			details +=("Significant physical trauma detected. Regenerative formula administered. <b>Dosage:[bicaridine ? " Bicaridine: [bicaridine]U |" : ""][quickclot ? " Quickclot: [quickclot]U |" : ""][tricordrazine ? " Tricordrazine: [tricordrazine]U" : ""]</b></br>")
-			B18_brute_cooldown = world.time + B18_CHEM_COOLDOWN
-			handle_chem_cooldown(B18_BRUTE_CODE)
-			playsound(src,'sound/voice/b18_brute.ogg', 15, 0, 1)
-			dose_administered = TRUE
-
-	if(wearer.getOxyLoss() > B18_automed_damage && !B18_oxy_cooldown)
-		var/dexalinplus = CLAMP(REAGENTS_OVERDOSE * 0.5 - (wearer.reagents.get_reagent_amount(/datum/reagent/medicine/dexalinplus) + 0.5),0,REAGENTS_OVERDOSE * 0.5 * B18_CHEM_MOD)
-		var/inaprovaline = CLAMP(REAGENTS_OVERDOSE * 2 - (wearer.reagents.get_reagent_amount(/datum/reagent/medicine/inaprovaline) + 0.5),0,REAGENTS_OVERDOSE * 2 * B18_CHEM_MOD)
-		var/tricordrazine = CLAMP(REAGENTS_OVERDOSE - (wearer.reagents.get_reagent_amount(/datum/reagent/medicine/tricordrazine) + 0.5),0,REAGENTS_OVERDOSE * B18_CHEM_MOD)
-		if(dexalinplus)
-			wearer.reagents.add_reagent(/datum/reagent/medicine/dexalinplus,dexalinplus)
-		if(inaprovaline)
-			wearer.reagents.add_reagent(/datum/reagent/medicine/inaprovaline,inaprovaline)
-		if(tricordrazine)
-			wearer.reagents.add_reagent(/datum/reagent/medicine/tricordrazine,tricordrazine)
-		if(dexalinplus || inaprovaline || tricordrazine) //Only report if we actually administer something
-			details +=("Low blood oxygen detected. Reoxygenating preparation administered. <b>Dosage:[dexalinplus ? " Dexalin Plus: [dexalinplus]U |" : ""][inaprovaline ? " Inaprovaline: [inaprovaline]U |" : ""][tricordrazine ? " Tricordrazine: [tricordrazine]U" : ""]</b></br>")
-			B18_oxy_cooldown = world.time + B18_CHEM_COOLDOWN
-			handle_chem_cooldown(B18_OXY_CODE)
-			dose_administered = TRUE
-
-	if(wearer.getToxLoss() > B18_automed_damage && !B18_tox_cooldown)
-		var/dylovene = CLAMP(REAGENTS_OVERDOSE - (wearer.reagents.get_reagent_amount(/datum/reagent/medicine/dylovene) + 0.5),0,REAGENTS_OVERDOSE * B18_CHEM_MOD)
-		var/spaceacillin = CLAMP(REAGENTS_OVERDOSE - (wearer.reagents.get_reagent_amount(/datum/reagent/medicine/spaceacillin) + 0.5),0,REAGENTS_OVERDOSE * B18_CHEM_MOD)
-		var/tricordrazine = CLAMP(REAGENTS_OVERDOSE - (wearer.reagents.get_reagent_amount(/datum/reagent/medicine/tricordrazine) + 0.5),0,REAGENTS_OVERDOSE * B18_CHEM_MOD)
-		if(dylovene)
-			wearer.reagents.add_reagent(/datum/reagent/medicine/dylovene,dylovene)
-		if(spaceacillin)
-			wearer.reagents.add_reagent(/datum/reagent/medicine/spaceacillin,spaceacillin)
-		if(tricordrazine)
-			wearer.reagents.add_reagent(/datum/reagent/medicine/tricordrazine,tricordrazine)
-		if(dylovene || spaceacillin || tricordrazine) //Only report if we actually administer something
-			details +=("Significant blood toxicity detected. Chelating agents and curatives administered. <b>Dosage:[dylovene ? " Dylovene: [dylovene]U |" : ""][spaceacillin ? " Spaceacillin: [spaceacillin]U |" : ""][tricordrazine ? " Tricordrazine: [tricordrazine]U" : ""]</b></br>")
-			B18_tox_cooldown = world.time + B18_CHEM_COOLDOWN
-			playsound(src,pick('sound/voice/b18_antitoxin.ogg','sound/voice/b18_antitoxin2.ogg'), 15, 0, 1)
-			handle_chem_cooldown(B18_TOX_CODE)
-			dose_administered = TRUE
-
-	if(wearer.traumatic_shock > B18_automed_pain && !B18_pain_cooldown)
-		var/oxycodone = CLAMP(REAGENTS_OVERDOSE * 0.66 - (wearer.reagents.get_reagent_amount(/datum/reagent/medicine/oxycodone) + 0.5),0,REAGENTS_OVERDOSE * 0.66 * B18_CHEM_MOD)
-		var/tramadol = CLAMP(REAGENTS_OVERDOSE - (wearer.reagents.get_reagent_amount(/datum/reagent/medicine/tramadol) + 0.5),0,REAGENTS_OVERDOSE * B18_CHEM_MOD)
-		if(oxycodone)
-			wearer.reagents.add_reagent(/datum/reagent/medicine/oxycodone,oxycodone)
-		if(tramadol)
-			wearer.reagents.add_reagent(/datum/reagent/medicine/tramadol,tramadol)
-		if(oxycodone || tramadol) //Only report if we actually administer something
-			details +=("User pain at performance impeding levels. Painkillers administered. <b>Dosage:[oxycodone ? " Oxycodone: [oxycodone]U |" : ""][tramadol ? " Tramadol: [tramadol]U" : ""]</b></br>")
-			B18_pain_cooldown = world.time + B18_CHEM_COOLDOWN
-			handle_chem_cooldown(B18_PAIN_CODE)
-			playsound(src,'sound/voice/b18_pain_suppress.ogg', 15, 0, 1)
-			dose_administered = TRUE
-
-	if(dose_administered)
-		playsound(src,'sound/items/hypospray.ogg', 25, 0, 1)
-		details +=("Estimated [B18_CHEM_COOLDOWN/600] minute replenishment time for each dosage.")
-		to_chat(wearer, "<span class='notice'>[icon2html(src, wearer)] beeps:</br> [details.Join(" ")]</span>")
-
-/obj/item/clothing/suit/storage/marine/specialist/proc/handle_chem_cooldown(code = B18_BRUTE_CODE, silent = FALSE)
-	if(code)
-		spawn(B18_CHEM_COOLDOWN)
-			switch(code)
-				if(B18_BRUTE_CODE)
-					if(B18_brute_cooldown)
-						B18_brute_cooldown = null
-				if(B18_BURN_CODE)
-					if(B18_burn_cooldown)
-						B18_burn_cooldown = null
-				if(B18_OXY_CODE)
-					if(B18_oxy_cooldown)
-						B18_oxy_cooldown = null
-				if(B18_TOX_CODE)
-					if(B18_tox_cooldown)
-						B18_tox_cooldown = null
-				if(B18_PAIN_CODE)
-					if(B18_pain_cooldown)
-						B18_pain_cooldown = null
-			if(!silent)
-				to_chat(wearer, "<span class='notice'>[src] beeps: [code == B18_BRUTE_CODE ? "Trauma treatment" : code == B18_BURN_CODE ? "Burn treatment" : code == B18_OXY_CODE ? "Oxygenation treatment" : code == B18_TOX_CODE ? "Toxicity treatment" : "Painkiller"] reservoir replenished.</span>")
-			playsound(src,'sound/effects/refill.ogg', 25, 0, 1)
-
-/obj/item/clothing/suit/storage/marine/specialist/verb/b18_automedic_toggle()
-	set name = "Toggle B18 Automedic"
-	set category = "B18 Armor"
-	set src in usr
-
-	if(usr.incapacitated() || usr != wearer )
-		return 0
-
-	if(B18_automed_on)
-		b18automed_turn_off(usr)
-	else
-		b18automed_turn_on(usr)
-
 
 /obj/item/clothing/suit/storage/marine/specialist/verb/b18_automedic_scan()
 	set name = "B18 Automedic User Scan"
 	set category = "B18 Armor"
 	set src in usr
-
 	if(usr.incapacitated() || usr != wearer )
 		return 0
-
 	B18_analyzer.attack(usr, usr, TRUE)
-
-/obj/item/clothing/suit/storage/marine/specialist/verb/configure_automedic()
-	set name = "Configure B18 Automedic"
-	set category = "B18 Armor"
-	set src in usr
-
-	if(!can_interact(usr))
-		return FALSE
-
-	interact(usr)
 
 
 /obj/item/clothing/suit/storage/marine/specialist/interact(mob/user)
 	. = ..()
 	if(.)
 		return
-
 	var/dat = {"
-	<A href='?src=\ref[src];B18_automed_on=1'>Turn Automed System: [B18_automed_on ? "Off" : "On"]</A><BR>
-	<BR>
 	<B>Integrated Health Analyzer:</B><BR>
 	<A href='byond://?src=\ref[src];B18_analyzer=1'>Scan Wearer</A><BR>
-	<A href='byond://?src=\ref[src];B18_toggle_mode=1'>Turn Scanner HUD Mode: [B18_analyzer.hud_mode ? "Off" : "On"]</A><BR>
-	<BR>
-	<B>Damage Trigger Threshold (Max 150, Min 50):</B><BR>
-	<A href='byond://?src=\ref[src];B18_automed_damage=-50'>-50</A>
-	<A href='byond://?src=\ref[src];B18_automed_damage=-10'>-10</A>
-	<A href='byond://?src=\ref[src];B18_automed_damage=-5'>-5</A>
-	<A href='byond://?src=\ref[src];B18_automed_damage=-1'>-1</A> [B18_automed_damage]
-	<A href='byond://?src=\ref[src];B18_automed_damage=1'>+1</A>
-	<A href='byond://?src=\ref[src];B18_automed_damage=5'>+5</A>
-	<A href='byond://?src=\ref[src];B18_automed_damage=10'>+10</A>
-	<A href='byond://?src=\ref[src];B18_automed_damage=50'>+50</A><BR>
-	<BR>
-	<B>Pain Trigger Threshold (Max 150, Min 50):</B><BR>
-	<A href='byond://?src=\ref[src];B18_automed_pain=-50'>-50</A>
-	<A href='byond://?src=\ref[src];B18_automed_pain=-10'>-10</A>
-	<A href='byond://?src=\ref[src];B18_automed_pain=-5'>-5</A>
-	<A href='byond://?src=\ref[src];B18_automed_pain=-1'>-1</A> [B18_automed_pain]
-	<A href='byond://?src=\ref[src];B18_automed_pain=1'>+1</A>
-	<A href='byond://?src=\ref[src];B18_automed_pain=5'>+5</A>
-	<A href='byond://?src=\ref[src];B18_automed_pain=10'>+10</A>
-	<A href='byond://?src=\ref[src];B18_automed_pain=50'>+50</A><BR>"}
-
+	<A href='byond://?src=\ref[src];B18_toggle_mode=1'>Turn Scanner Mode: [B18_analyzer.hud_mode ? "Off" : "On"]</A><BR>
+	<BR>"}
 	var/datum/browser/popup = new(user, "b18")
 	popup.set_content(dat)
 	popup.open()
@@ -498,16 +274,8 @@
 	. = ..()
 	if(.)
 		return
-
-	if(href_list["B18_automed_on"])
-		if(B18_automed_on)
-			b18automed_turn_off(usr)
-		else
-			b18automed_turn_on(usr)
-
 	else if(href_list["B18_analyzer"] && B18_analyzer && usr == wearer) //Integrated scanner
 		B18_analyzer.attack(usr, usr, TRUE)
-
 	else if(href_list["B18_toggle_mode"] && B18_analyzer && usr == wearer) //Integrated scanner
 		B18_analyzer.hud_mode = !B18_analyzer.hud_mode
 		switch (B18_analyzer.hud_mode)
@@ -515,16 +283,6 @@
 				to_chat(usr, "<span class='notice'>The scanner now shows results on the hud.</span>")
 			if(FALSE)
 				to_chat(usr, "<span class='notice'>The scanner no longer shows results on the hud.</span>")
-
-	else if(href_list["B18_automed_damage"])
-		B18_automed_damage += text2num(href_list["B18_automed_damage"])
-		B18_automed_damage = round(B18_automed_damage)
-		B18_automed_damage = CLAMP(B18_automed_damage,B18_DAMAGE_MIN,B18_DAMAGE_MAX)
-	else if(href_list["B18_automed_pain"])
-		B18_automed_pain += text2num(href_list["B18_automed_pain"])
-		B18_automed_pain = round(B18_automed_pain)
-		B18_automed_pain = CLAMP(B18_automed_pain,B18_PAIN_MIN,B18_PAIN_MAX)
-
 	updateUsrDialog()
 
 

--- a/strings/tips/meta.txt
+++ b/strings/tips/meta.txt
@@ -31,7 +31,7 @@ As a corpsman, scan before you treat and you can't be beat.
 As a corpsman or doctor, remember that your HUD will tell you how much time is left to defibrillate a patient.
 As a corpsman, remember to bring extra kelotane or dermaline to heal burn damage. Xenos love acid and burning marines.
 As a corpsman, hypervene is useful. Use it to purge deadly neurotoxins and larva boosting growth hormones.
-As a B18 specialist, your armor has a built in medical system.
+As a B18 specialist, your armor has a built in analyzing system.
 As a scout specialist, you can take your battle rifle or your custom shotgun.
 As a sniper specialist, you've got a tarp that can make you stealth so long as you don't move.
 As a pyro specialist, your flamethrower has an extinguisher built into it.


### PR DESCRIPTION
## About The Pull Request

the b18 armor no longer autoheals, it still has a health analyzer mode
now slows down the same as regular armor

## Why It's Good For The Game

b18 armor is pretty much unfair, autoheal with 80 protection against everything, now they have to rely on another person (a medic) instead of being able to go solo against any xeno and win and then return with full health

## Changelog
:cl:
balance: b18 armor no longer autoheals, but it now slows down less
/:cl:
