### PR TITLE
Delimbs now work off of thresholds instead of rng

### DIFF
--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -9,7 +9,7 @@
 	var/damage_state = "00"
 	var/brute_dam = 0
 	var/burn_dam = 0
-	var/max_damage = 0
+	var/max_damage = 0 //The threshold before that limb gets destroyed
 	var/max_size = 0
 	var/last_dam = -1
 	var/supported = FALSE
@@ -213,10 +213,8 @@
 		owner.updatehealth()
 		return update_icon()
 	if(CONFIG_GET(flag/limbs_can_break) && brute_dam >= max_damage * CONFIG_GET(number/organ_health_multiplier))
-		var/cut_prob = brute/max_damage * 10
-		if(prob(cut_prob))
-			droplimb()
-			return
+		droplimb() //Reached max damage threshold through brute damage, that limb is going bye bye
+		return
 
 	owner.updatehealth()
 
@@ -662,8 +660,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 		wounds.Cut()
 		if(parent && !amputation)
 			var/datum/wound/W
-			if(max_damage < 50) W = new/datum/wound/lost_limb/small(max_damage)
-			else 				W = new/datum/wound/lost_limb(max_damage)
+			if(max_damage < 50) W = new/datum/wound/lost_limb/small(max_damage / 4)
+			else 				W = new/datum/wound/lost_limb(max_damage / 4)
 
 			parent.wounds += W
 			parent.update_damages()
@@ -994,7 +992,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	icon_name = "torso"
 	display_name = "chest"
 	max_damage = 200
-	min_broken_damage = 40
+	min_broken_damage = 60
 	body_part = CHEST
 	vital = 1
 	encased = "ribcage"
@@ -1004,7 +1002,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	icon_name = "groin"
 	display_name = "groin"
 	max_damage = 200
-	min_broken_damage = 40
+	min_broken_damage = 60
 	body_part = GROIN
 	vital = 1
 
@@ -1012,8 +1010,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "l_arm"
 	display_name = "left arm"
 	icon_name = "l_arm"
-	max_damage = 35
-	min_broken_damage = 30
+	max_damage = 100
+	min_broken_damage = 50
 	body_part = ARM_LEFT
 
 	process()
@@ -1024,8 +1022,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "l_leg"
 	display_name = "left leg"
 	icon_name = "l_leg"
-	max_damage = 35
-	min_broken_damage = 30
+	max_damage = 100
+	min_broken_damage = 50
 	body_part = LEG_LEFT
 	icon_position = LEFT
 
@@ -1033,8 +1031,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "r_arm"
 	display_name = "right arm"
 	icon_name = "r_arm"
-	max_damage = 35
-	min_broken_damage = 30
+	max_damage = 100
+	min_broken_damage = 50
 	body_part = ARM_RIGHT
 
 	process()
@@ -1045,8 +1043,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "r_leg"
 	display_name = "right leg"
 	icon_name = "r_leg"
-	max_damage = 35
-	min_broken_damage = 30
+	max_damage = 100
+	min_broken_damage = 50
 	body_part = LEG_RIGHT
 	icon_position = RIGHT
 
@@ -1054,8 +1052,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "l_foot"
 	display_name = "left foot"
 	icon_name = "l_foot"
-	max_damage = 30
-	min_broken_damage = 25
+	max_damage = 75
+	min_broken_damage = 37
 	body_part = FOOT_LEFT
 	icon_position = LEFT
 
@@ -1063,8 +1061,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "r_foot"
 	display_name = "right foot"
 	icon_name = "r_foot"
-	max_damage = 30
-	min_broken_damage = 25
+	max_damage = 75
+	min_broken_damage = 37
 	body_part = FOOT_RIGHT
 	icon_position = RIGHT
 
@@ -1072,8 +1070,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "r_hand"
 	display_name = "right hand"
 	icon_name = "r_hand"
-	max_damage = 30
-	min_broken_damage = 25
+	max_damage = 75
+	min_broken_damage = 37
 	body_part = HAND_RIGHT
 
 	process()
@@ -1084,8 +1082,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "l_hand"
 	display_name = "left hand"
 	icon_name = "l_hand"
-	max_damage = 30
-	min_broken_damage = 25
+	max_damage = 75
+	min_broken_damage = 37
 	body_part = HAND_LEFT
 
 	process()
@@ -1096,7 +1094,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "head"
 	icon_name = "head"
 	display_name = "head"
-	max_damage = 60
+	max_damage = 100
 	min_broken_damage = 40
 	body_part = HEAD
 	vital = 1

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -660,8 +660,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 		wounds.Cut()
 		if(parent && !amputation)
 			var/datum/wound/W
-			if(max_damage < 50) W = new/datum/wound/lost_limb/small(max_damage / 4)
-			else 				W = new/datum/wound/lost_limb(max_damage / 4)
+			if(max_damage < 50) W = new/datum/wound/lost_limb/small(max_damage * 0.25)
+			else 				W = new/datum/wound/lost_limb(max_damage * 0.25)
 
 			parent.wounds += W
 			parent.update_damages()

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -654,14 +654,17 @@ Note that amputating the affected organ does in fact remove the infection from t
 			hidden = null
 
 		// If any organs are attached to this, destroy them
-		for(var/datum/limb/O in children) O.droplimb(amputation, delete_limb)
+		for(var/datum/limb/O in children)
+			O.droplimb(amputation, delete_limb)
 
 		//Replace all wounds on that arm with one wound on parent organ.
 		wounds.Cut()
 		if(parent && !amputation)
 			var/datum/wound/W
-			if(max_damage < 50) W = new/datum/wound/lost_limb/small(max_damage * 0.25)
-			else 				W = new/datum/wound/lost_limb(max_damage * 0.25)
+			if(max_damage < 50)
+				W = new/datum/wound/lost_limb/small(max_damage * 0.25)
+			else 				
+				W = new/datum/wound/lost_limb(max_damage * 0.25)
 
 			parent.wounds += W
 			parent.update_damages()
@@ -674,9 +677,9 @@ Note that amputating the affected organ does in fact remove the infection from t
 		switch(body_part)
 			if(HEAD)
 				if(owner.species.species_flags & IS_SYNTHETIC) //special head for synth to allow brainmob to talk without an MMI
-					organ= new /obj/item/limb/head/synth(owner.loc, owner)
+					organ = new /obj/item/limb/head/synth(owner.loc, owner)
 				else
-					organ= new /obj/item/limb/head(owner.loc, owner)
+					organ = new /obj/item/limb/head(owner.loc, owner)
 				owner.dropItemToGround(owner.glasses, null, TRUE)
 				owner.dropItemToGround(owner.head, null, TRUE)
 				owner.dropItemToGround(owner.wear_ear, null, TRUE)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes delimbing only happen once the limb goes above the max_damage threshold; threshold has been increased according

Upon delimbing, 25% of the max_damage is transferred to it's parent instead of 100% (hand => arm, arm => chest etc)

Bone breaking threshold is also increased to max_damage / 2 rounded up
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Removes rng from delimbs and makes it threshold based, this stops people from complaining of getting their hand yeeted by some young runner (420) and instead has to occur from a drawn out fight or a significant pile on
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: ma44
balance: Delimbs now occur based on thresholds instead of rng, see below for details
balance: Delimbs occur when the limb has 75 or 100 brute damage occurred to it if it's a hand/foot or arm/leg respectively
balance: When a limb is delimbed, only 25% of it's damage is transferred to it's "parent" (hand to arm to chest for example)
balance: Bone breaks now only occur at 37 and 50 damage for hands/feet and arms/legs respectively
balance: FOR XENOS: This means if you want to kill a marine as fast as possible, you target their chest, otherwise you can target a limb to disable a limb but expect a longer fight due to a decreased damage transfer upon limb dismembering
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
