### PR TITLE
Runner adjustments and a new "tail slash" ability.

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -319,6 +319,7 @@
 
 #define COMSIG_XENOABILITY_TOGGLE_SAVAGE "xenoability_toggle_savage"
 #define COMSIG_XENOABILITY_POUNCE "xenoability_pounce"
+#define COMSIG_XENOABILITY_TAIL_SLASH "tail_slash"
 
 #define COMSIG_XENOABILITY_TOGGLE_AGILITY "xenoability_toggle_agility"
 #define COMSIG_XENOABILITY_LUNGE "xenoability_lunge"

--- a/code/datums/keybinding/xeno.dm
+++ b/code/datums/keybinding/xeno.dm
@@ -426,6 +426,13 @@
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_POUNCE
 
+/datum/keybinding/xeno/tail_slash
+	key = "Unbound"
+	name = "tail_slash"
+	full_name = "Runner: Tail Slash"
+	description = ""
+	keybind_signal = COMSIG_XENOABILITY_TAIL_SLASH
+
 /datum/keybinding/xeno/toggle_agility
 	key = "Unbound"
 	name = "toggle_agility"

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
@@ -51,6 +51,7 @@
 		/datum/action/xeno_action/xeno_resting,
 		/datum/action/xeno_action/regurgitate,
 		/datum/action/xeno_action/xenohide,
+		/datum/action/xeno_action/activable/tail_slash,
 		/datum/action/xeno_action/activable/pounce,
 		/datum/action/xeno_action/toggle_savage,
 		)


### PR DESCRIPTION
## About The Pull Request

This PR adds a new 1 tile AOE attack in the form of tail slash, which is effective for hit and runs and has a 10 second cd. With this new addition, Savage has been nerfed to only do 30 bonus damage instead of 40 at max plasma, and no longer eats your entire plasma pool.

Subject to balance changes, tail slash might need a longer cooldown/plasma cost.

## Why It's Good For The Game

Adding more tools and abilities for xenos to play around with should make the caste a bit more fun to play, especially with the risk reward of running between marines to slash as many of them as possible. Ravage is frustrating to play against, and forces runners to rest for a long ass time waiting for plasma stores to refuel, so these adjustments should make it a bit less frustrating overall.

## Changelog
:cl:
add: New AOE ability for runner: Tail slash
balance: Ravage now does less damage overall, but drains less plasma upon use.
/:cl:
