### PR TITLE
M4RA changes

### DIFF
--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -4851,7 +4851,6 @@
 /obj/item/attachable/burstfire_assembly,
 /obj/item/attachable/suppressor,
 /obj/item/attachable/suppressor,
-/obj/item/attachable/scope/m4ra,
 /obj/machinery/light/small{
 	dir = 1
 	},

--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -427,7 +427,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage_falloff = 0
 	flags_ammo_behavior = AMMO_BALLISTIC
 	accurate_range_min = 6
-	damage = 55
+	damage = 50
 	scatter = -15
 	penetration = 30
 
@@ -443,9 +443,9 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	name = "A19 high velocity impact bullet"
 	hud_state = "hivelo_impact"
 	flags_ammo_behavior = AMMO_BALLISTIC
-	damage = 50
+	damage = 35
 	accuracy = -10
-	penetration = 20
+	penetration = 25
 
 /datum/ammo/bullet/rifle/m4ra/impact/on_hit_mob(mob/M, obj/item/projectile/P)
 	staggerstun(M, P, max_range = 40, weaken = 1, stagger = 1, knockback = 1)
@@ -456,7 +456,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	iff_signal = ACCESS_IFF_MARINE
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SKIPS_HUMANS
 	damage = 30
-	penetration = 50
+	penetration = 30
 
 /datum/ammo/bullet/rifle/ak47
 	name = "heavy rifle bullet"

--- a/code/modules/projectiles/updated_projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_attachables.dm
@@ -625,6 +625,7 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/scope/mini/m4ra
 	name = "M4RA rail scope"
+	aim_speed_mod = 0
 	attach_icon = "none"
 	desc = "A rail mounted zoom sight scope specialized for the M4RA Battle Rifle . Allows zoom by activating the attachment. Use F12 if your HUD doesn't come back."
 	flags_attach_features = ATTACH_ACTIVATION

--- a/code/modules/projectiles/updated_projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_attachables.dm
@@ -623,15 +623,11 @@ Defined in conflicts.dm of the #defines folder.
 	scope_zoom_mod = TRUE
 	movement_acc_penalty_mod = 0.1
 
-/obj/item/attachable/scope/m4ra
+/obj/item/attachable/scope/mini/m4ra
 	name = "M4RA rail scope"
 	attach_icon = "none"
 	desc = "A rail mounted zoom sight scope specialized for the M4RA Battle Rifle . Allows zoom by activating the attachment. Use F12 if your HUD doesn't come back."
-	zoom_offset = 5
-	zoom_viewsize = 7
-	zoom_accuracy = SCOPE_RAIL_MINI
 	flags_attach_features = ATTACH_ACTIVATION
-
 
 /obj/item/attachable/scope/m42a
 	name = "m42a rail scope"

--- a/code/modules/projectiles/updated_projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/specialist.dm
@@ -323,7 +323,6 @@
 	fire_delay = 0.4 SECONDS
 	burst_amount = 2
 	burst_delay = 0.1 SECONDS
-	burst_accuracy_mult = 0.9
 	accuracy_mult = 1.05
 	scatter = 15
 	recoil = 2

--- a/code/modules/projectiles/updated_projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/specialist.dm
@@ -292,7 +292,7 @@
 	desc = "The M4RA battle rifle is a designated marksman rifle in service with the TGMC. Only fielded in small numbers, and sporting a bullpup configuration, the M4RA battle rifle is perfect for reconnaissance and fire support teams.\nIt is equipped with rail scope and takes 10x24mm A19 high velocity magazines."
 	icon_state = "m4ra"
 	item_state = "m4ra"
-	max_shells = 15 //codex
+	max_shells = 20 //codex
 	caliber = "10x24mm caseless" //codex
 	fire_sound = 'sound/weapons/guns/fire/m4ra.ogg'
 	unload_sound = 'sound/weapons/guns/interact/m4ra_unload.ogg'
@@ -300,6 +300,7 @@
 	cocked_sound = 'sound/weapons/guns/interact/m4ra_cocked.ogg'
 	current_mag = /obj/item/ammo_magazine/rifle/m4ra
 	force = 16
+	aim_slowdown = 0.5
 	attachable_allowed = list(
 						/obj/item/attachable/suppressor,
 						/obj/item/attachable/extended_barrel,
@@ -314,9 +315,10 @@
 						)
 
 	flags_gun_features = GUN_AUTO_EJECTOR|GUN_WIELDED_FIRING_ONLY|GUN_AMMO_COUNTER
+	gun_firemode_list = list(GUN_FIREMODE_SEMIAUTO, GUN_FIREMODE_BURSTFIRE, GUN_FIREMODE_AUTOMATIC)
 	gun_skill_category = GUN_SKILL_SPEC
 	attachable_offset = list("muzzle_x" = 32, "muzzle_y" = 17,"rail_x" = 12, "rail_y" = 23, "under_x" = 23, "under_y" = 13, "stock_x" = 24, "stock_y" = 13)
-	starting_attachment_types = list(/obj/item/attachable/scope/m4ra, /obj/item/attachable/stock/rifle/marksman)
+	starting_attachment_types = list(/obj/item/attachable/scope/mini/m4ra, /obj/item/attachable/stock/rifle/marksman)
 
 	fire_delay = 0.4 SECONDS
 	burst_amount = 2

--- a/code/modules/projectiles/updated_projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/updated_projectiles/magazines/specialist.dm
@@ -56,7 +56,7 @@
 	desc = "A magazine of A19 high velocity rounds for use in the M4RA battle rifle. The M4RA battle rifle is the only gun that can chamber these rounds."
 	icon_state = "m4ra"
 	default_ammo = /datum/ammo/bullet/rifle/m4ra
-	max_rounds = 15
+	max_rounds = 20
 	gun_type = /obj/item/weapon/gun/rifle/m4ra
 
 /obj/item/ammo_magazine/rifle/m4ra/incendiary
@@ -64,7 +64,7 @@
 	desc = "A magazine of A19 high velocity incendiary rounds for use in the M4RA battle rifle. The M4RA battle rifle is the only gun that can chamber these rounds."
 	icon_state = "m4ra_incendiary"
 	default_ammo = /datum/ammo/bullet/rifle/m4ra/incendiary
-	max_rounds = 15
+	max_rounds = 20
 	gun_type = /obj/item/weapon/gun/rifle/m4ra
 
 /obj/item/ammo_magazine/rifle/m4ra/impact
@@ -72,7 +72,7 @@
 	desc = "A magazine of A19 high velocity impact rounds for use in the M4RA battle rifle. The M4RA battle rifle is the only gun that can chamber these rounds."
 	icon_state = "m4ra_impact"
 	default_ammo = /datum/ammo/bullet/rifle/m4ra/impact
-	max_rounds = 15
+	max_rounds = 20
 	gun_type = /obj/item/weapon/gun/rifle/m4ra
 
 obj/item/ammo_magazine/rifle/m4ra/smart


### PR DESCRIPTION
## About The Pull Request

This makes changes to the M4RA as outlined by MJP. The only changes I haven't made in this PR is their requested attachments, because of the deal with the M4RA scope being a part of the gun's default sprite. 
## Why It's Good For The Game

Well, it's a bit of a rework of the M4RA. The scope had gotten mini scope level zoom and mini scope level accuracy benefits, but kept the negatives of a big scope, mainly a +1 to wield slowdown and a +0.6 to wield delay. This fixes that but also reduces the damage, and gives it automatic fire (but not autoburst) for QOL purposes. 

## Changelog
:cl:
Balance-Makes the BR Scope penalties into miniscope penalties
Balance-Some nerfs to BR ammo damage overall
Balance-BR becomes 0.5 slowdown (before was 1.35 due to miniscope.)
/:cl:

