### PR TITLE
[s] Updates pillow  minimum required version

### DIFF
--- a/tools/mapmerge2/requirements.txt
+++ b/tools/mapmerge2/requirements.txt
@@ -1,3 +1,3 @@
 pygit2==0.27.2
 bidict==0.13.1
-Pillow==5.1.0
+Pillow==6.2.0


### PR DESCRIPTION
Lower versions have known vulnerabilities.
/tg/ uses this one as well.