### PR TITLE
Makes rack health sensible

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -567,6 +567,7 @@
 	anchored = TRUE
 	throwpass = TRUE	//You can throw objects over this, despite it's density.
 	climbable = TRUE
+	max_integrity = 150
 	resistance_flags = XENO_DAMAGEABLE
 	var/parts = /obj/item/frame/rack
 


### PR DESCRIPTION
## About The Pull Request

Makes Rack health 150 instead of whatever insane amount it was before hand(I actually couldn't find where it was set)

## Why It's Good For The Game

Hand portable structures that take ages to break are a bad idea, and people are already starting to catch onto this fact.

## Changelog
:cl: MetroidLover
balance: Racks no longer have insane health
/:cl: