### PR TITLE
Signals cleanup

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -168,8 +168,11 @@
 #define COMSIG_MOB_CLICKON "mob_clickon"						//from base of mob/clickon(): (atom/A, params)
 	#define COMSIG_MOB_CANCEL_CLICKON 1
 #define COMSIG_MOB_ATTACK_RANGED "mob_attack_ranged"			//from base of mob/RangedAttack(): (atom/A, params)
+#define COMSIG_MOB_THROW "mob_throw"							//from base of /mob/throw_item(): (atom/target)
 #define COMSIG_MOB_UPDATE_SIGHT "mob_update_sight"				//from base of /mob/update_sight(): ()
 #define COMSIG_MOB_HUD_CREATED "mob_hud_created"				//from base of mob/create_mob_hud(): ()
+#define COMSIG_MOB_ITEM_ATTACK "mob_item_attack"				//from base of /obj/item/attack(): (mob/M, mob/user)
+	#define COMPONENT_ITEM_NO_ATTACK (1<<0)
 #define COMSIG_MOB_ITEM_AFTERATTACK "mob_item_afterattack"		//from base of obj/item/afterattack(): (atom/target, mob/user, proximity_flag, click_parameters)
 #define COMSIG_MOB_SAY "mob_say" 								// from /mob/living/say(): (proc args list)
 #define COMSIG_MOB_LOGOUT "mob_logout"							//from /mob/Logout(): ()
@@ -341,8 +344,6 @@
 #define COMSIG_HUMAN_GUN_FIRED "human_gun_fired"				//from gun system: (atom/target,obj/item/weapon/gun/gun, mob/living/user)
 #define COMSIG_HUMAN_GUN_AUTOFIRED "human_gun_autofired"
 #define COMSIG_HUMAN_ATTACHMENT_FIRED "human_attachment_fired"
-#define COMSIG_HUMAN_ITEM_ATTACK "human_item_attack"			//from base of obj/item/attack(): (/mob/living/target, obj/item/I, /mob/living/carbon/human/user)
-#define COMSIG_HUMAN_ITEM_THROW "human_item_throw"
 
 // /datum/action signals
 #define COMSIG_ACTION_TRIGGER "action_trigger"                        //from base of datum/action/proc/Trigger(): (datum/action)

--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -171,7 +171,7 @@
 #define COMSIG_MOB_THROW "mob_throw"							//from base of /mob/throw_item(): (atom/target)
 #define COMSIG_MOB_UPDATE_SIGHT "mob_update_sight"				//from base of /mob/update_sight(): ()
 #define COMSIG_MOB_HUD_CREATED "mob_hud_created"				//from base of mob/create_mob_hud(): ()
-#define COMSIG_MOB_ITEM_ATTACK "mob_item_attack"				//from base of /obj/item/attack(): (mob/M, mob/user)
+#define COMSIG_MOB_ITEM_ATTACK "mob_item_attack"				//from base of /obj/item/attack(): (mob/target, /obj/item/attacking_item)
 	#define COMPONENT_ITEM_NO_ATTACK (1<<0)
 #define COMSIG_MOB_ITEM_AFTERATTACK "mob_item_afterattack"		//from base of obj/item/afterattack(): (atom/target, mob/user, proximity_flag, click_parameters)
 #define COMSIG_MOB_SAY "mob_say" 								// from /mob/living/say(): (proc args list)

--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -176,6 +176,9 @@
 #define COMSIG_MOB_ITEM_AFTERATTACK "mob_item_afterattack"		//from base of obj/item/afterattack(): (atom/target, mob/user, proximity_flag, click_parameters)
 #define COMSIG_MOB_SAY "mob_say" 								// from /mob/living/say(): (proc args list)
 #define COMSIG_MOB_LOGOUT "mob_logout"							//from /mob/Logout(): ()
+#define COMSIG_MOB_GUN_FIRED "mob_gun_fired"					//from gun system: (atom/target,obj/item/weapon/gun/gun, mob/living/user)
+#define COMSIG_MOB_GUN_AUTOFIRED "mob_gun_autofired"
+#define COMSIG_MOB_ATTACHMENT_FIRED "mob_attachment_fired"
 
 //mob/living signals
 #define COMSIG_LIVING_DO_RESIST			"living_do_resist"		//from the base of /mob/living/do_resist()
@@ -340,10 +343,6 @@
 #define REDIRECT_TRANSFER_WITH_TURF 1
 
 #define COMSIG_HUMAN_DAMAGE_TAKEN "human_damage_taken"			//from human damage receiving procs: (mob/living/carbon/human/wearer, damage)
-
-#define COMSIG_HUMAN_GUN_FIRED "human_gun_fired"				//from gun system: (atom/target,obj/item/weapon/gun/gun, mob/living/user)
-#define COMSIG_HUMAN_GUN_AUTOFIRED "human_gun_autofired"
-#define COMSIG_HUMAN_ATTACHMENT_FIRED "human_attachment_fired"
 
 // /datum/action signals
 #define COMSIG_ACTION_TRIGGER "action_trigger"                        //from base of datum/action/proc/Trigger(): (datum/action)

--- a/code/__DEFINES/equipment.dm
+++ b/code/__DEFINES/equipment.dm
@@ -216,9 +216,6 @@
 #define FULL_BODY		(~0)
 //=================================================
 
-//defense zones for selecting them via the hud.
-#define DEFENSE_ZONES_LIVING list("head","chest","mouth","eyes","groin","l_leg","l_foot","r_leg","r_foot","l_arm","l_hand","r_arm","r_hand")
-
 // bitflags for the percentual amount of protection a piece of clothing which covers the body part offers.
 // Used with human/proc/get_flags_heat_protection() and human/proc/get_flags_cold_protection()
 // The values here should add up to 1.

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -89,7 +89,10 @@
 
 
 /obj/item/proc/attack(mob/living/M, mob/living/user)
-	SEND_SIGNAL(src, COMSIG_ITEM_ATTACK, M, user)
+	if(SEND_SIGNAL(src, COMSIG_ITEM_ATTACK, M, user) & COMPONENT_ITEM_NO_ATTACK)
+		return
+	if(SEND_SIGNAL(user, COMSIG_MOB_ITEM_ATTACK, M, src) & COMPONENT_ITEM_NO_ATTACK)
+		return
 
 	if(flags_item & NOBLUDGEON)
 		return
@@ -111,8 +114,6 @@
 
 	if(user.mind && user.mind.cm_skills)
 		power = round(power * (1 + 0.3*user.mind.cm_skills.melee_weapons)) //30% bonus per melee level
-
-	SEND_SIGNAL(user, COMSIG_HUMAN_ITEM_ATTACK, M, src, user)
 
 	if(!ishuman(M))
 		var/showname = "."

--- a/code/datums/components/full_auto_fire.dm
+++ b/code/datums/components/full_auto_fire.dm
@@ -366,7 +366,7 @@
 	if(!reload_into_chamber(shooter))
 		click_empty(shooter)
 		return NONE
-	SEND_SIGNAL(shooter, COMSIG_HUMAN_GUN_AUTOFIRED, target, src)
+	SEND_SIGNAL(shooter, COMSIG_MOB_GUN_AUTOFIRED, target, src)
 	var/obj/screen/ammo/A = shooter.hud_used.ammo
 	A.update_hud(shooter) //Ammo HUD.
 	return COMPONENT_AUTOFIRE_SHOT_SUCCESS //All is well, we can continue shooting.

--- a/code/datums/components/full_auto_fire.dm
+++ b/code/datums/components/full_auto_fire.dm
@@ -366,7 +366,7 @@
 	if(!reload_into_chamber(shooter))
 		click_empty(shooter)
 		return NONE
-	SEND_SIGNAL(shooter, COMSIG_HUMAN_GUN_AUTOFIRED, target, src, shooter)
+	SEND_SIGNAL(shooter, COMSIG_HUMAN_GUN_AUTOFIRED, target, src)
 	var/obj/screen/ammo/A = shooter.hud_used.ammo
 	A.update_hud(shooter) //Ammo HUD.
 	return COMPONENT_AUTOFIRE_SHOT_SUCCESS //All is well, we can continue shooting.

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -500,15 +500,13 @@
 
 	addtimer(CALLBACK(src, .proc/on_cloak), 1)
 	RegisterSignal(M, COMSIG_HUMAN_DAMAGE_TAKEN, .proc/damage_taken)
-	RegisterSignal(M, list(COMSIG_MOB_GUN_FIRED, COMSIG_MOB_GUN_AUTOFIRED), .proc/on_gun_firing)
-	RegisterSignal(M, COMSIG_MOB_ATTACHMENT_FIRED, .proc/on_gun_attachment_firing)
-	RegisterSignal(M, COMSIG_MOB_THROW, .proc/on_throw)
-	RegisterSignal(M, COMSIG_MOB_ITEM_ATTACK, .proc/on_attack)
+	RegisterSignal(M, list(COMSIG_MOB_GUN_FIRED, COMSIG_MOB_GUN_AUTOFIRED, COMSIG_MOB_ATTACHMENT_FIRED, COMSIG_MOB_THROW, COMSIG_MOB_ITEM_ATTACK), .proc/action_taken)
 
 	START_PROCESSING(SSprocessing, src)
 	wearer.cloaking = TRUE
 
 	return TRUE
+
 
 /obj/item/storage/backpack/marine/satchel/scout_cloak/proc/on_cloak()
 	if(wearer)
@@ -609,19 +607,7 @@
 		to_chat(wearer, "<span class='danger'>Your cloak shimmers from the damage!</span>")
 		apply_shimmer()
 
-/obj/item/storage/backpack/marine/satchel/scout_cloak/proc/on_gun_firing(datum/source, atom/target, obj/item/weapon/gun/firing_gun)
-	action_taken()
-
-/obj/item/storage/backpack/marine/satchel/scout_cloak/proc/on_gun_attachment_firing(datum/source, atom/target, obj/item/attachable/firing_attachment, obj/item/weapon/gun/master_gun)
-	action_taken()
-
-/obj/item/storage/backpack/marine/satchel/scout_cloak/proc/on_throw(datum/source, atom/target)
-	action_taken()
-
-/obj/item/storage/backpack/marine/satchel/scout_cloak/proc/on_attack(datum/source, mob/living/target, obj/item/used_item)
-	action_taken()
-
-/obj/item/storage/backpack/marine/satchel/scout_cloak/proc/action_taken()
+/obj/item/storage/backpack/marine/satchel/scout_cloak/proc/action_taken() //This is used by multiple signals passing different parameters.
 	to_chat(wearer, "<span class='danger'>Your cloak shimmers from your actions!</span>")
 	apply_shimmer()
 

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -500,7 +500,12 @@
 
 	addtimer(CALLBACK(src, .proc/on_cloak), 1)
 	RegisterSignal(M, COMSIG_HUMAN_DAMAGE_TAKEN, .proc/damage_taken)
-	RegisterSignal(M, list(COMSIG_MOB_GUN_FIRED, COMSIG_MOB_GUN_AUTOFIRED, COMSIG_MOB_ATTACHMENT_FIRED, COMSIG_MOB_THROW, COMSIG_MOB_ITEM_ATTACK), .proc/action_taken)
+	RegisterSignal(M, list(
+		COMSIG_MOB_GUN_FIRED,
+		COMSIG_MOB_GUN_AUTOFIRED,
+		COMSIG_MOB_ATTACHMENT_FIRED,
+		COMSIG_MOB_THROW,
+		COMSIG_MOB_ITEM_ATTACK), .proc/action_taken)
 
 	START_PROCESSING(SSprocessing, src)
 	wearer.cloaking = TRUE

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -500,8 +500,8 @@
 
 	addtimer(CALLBACK(src, .proc/on_cloak), 1)
 	RegisterSignal(M, COMSIG_HUMAN_DAMAGE_TAKEN, .proc/damage_taken)
-	RegisterSignal(M, list(COMSIG_HUMAN_GUN_FIRED, COMSIG_HUMAN_GUN_AUTOFIRED), .proc/on_gun_firing)
-	RegisterSignal(M, COMSIG_HUMAN_ATTACHMENT_FIRED, .proc/on_gun_attachment_firing)
+	RegisterSignal(M, list(COMSIG_MOB_GUN_FIRED, COMSIG_MOB_GUN_AUTOFIRED), .proc/on_gun_firing)
+	RegisterSignal(M, COMSIG_MOB_ATTACHMENT_FIRED, .proc/on_gun_attachment_firing)
 	RegisterSignal(M, COMSIG_MOB_THROW, .proc/on_throw)
 	RegisterSignal(M, COMSIG_MOB_ITEM_ATTACK, .proc/on_attack)
 
@@ -551,8 +551,8 @@
 
 	UnregisterSignal(user, list(
 		COMSIG_HUMAN_DAMAGE_TAKEN,
-		COMSIG_HUMAN_GUN_FIRED,
-		COMSIG_HUMAN_ATTACHMENT_FIRED,
+		COMSIG_MOB_GUN_FIRED,
+		COMSIG_MOB_ATTACHMENT_FIRED,
 		COMSIG_MOB_THROW,
 		COMSIG_MOB_ITEM_ATTACK))
 	STOP_PROCESSING(SSprocessing, src)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -500,11 +500,10 @@
 
 	addtimer(CALLBACK(src, .proc/on_cloak), 1)
 	RegisterSignal(M, COMSIG_HUMAN_DAMAGE_TAKEN, .proc/damage_taken)
-	RegisterSignal(M, list(
-		COMSIG_HUMAN_GUN_FIRED,
-		COMSIG_HUMAN_ATTACHMENT_FIRED,
-		COMSIG_HUMAN_ITEM_THROW,
-		COMSIG_HUMAN_ITEM_ATTACK), .proc/action_taken)
+	RegisterSignal(M, list(COMSIG_HUMAN_GUN_FIRED, COMSIG_HUMAN_GUN_AUTOFIRED), .proc/on_gun_firing)
+	RegisterSignal(M, COMSIG_HUMAN_ATTACHMENT_FIRED, .proc/on_gun_attachment_firing)
+	RegisterSignal(M, COMSIG_MOB_THROW, .proc/on_throw)
+	RegisterSignal(M, COMSIG_MOB_ITEM_ATTACK, .proc/on_attack)
 
 	START_PROCESSING(SSprocessing, src)
 	wearer.cloaking = TRUE
@@ -554,8 +553,8 @@
 		COMSIG_HUMAN_DAMAGE_TAKEN,
 		COMSIG_HUMAN_GUN_FIRED,
 		COMSIG_HUMAN_ATTACHMENT_FIRED,
-		COMSIG_HUMAN_ITEM_THROW,
-		COMSIG_HUMAN_ITEM_ATTACK))
+		COMSIG_MOB_THROW,
+		COMSIG_MOB_ITEM_ATTACK))
 	STOP_PROCESSING(SSprocessing, src)
 	wearer.cloaking = FALSE
 
@@ -610,7 +609,19 @@
 		to_chat(wearer, "<span class='danger'>Your cloak shimmers from the damage!</span>")
 		apply_shimmer()
 
-/obj/item/storage/backpack/marine/satchel/scout_cloak/proc/action_taken(datum/source, atom/target, obj/item/I, mob/living/wearer)
+/obj/item/storage/backpack/marine/satchel/scout_cloak/proc/on_gun_firing(datum/source, atom/target, obj/item/weapon/gun/firing_gun)
+	action_taken()
+
+/obj/item/storage/backpack/marine/satchel/scout_cloak/proc/on_gun_attachment_firing(datum/source, atom/target, obj/item/attachable/firing_attachment, obj/item/weapon/gun/master_gun)
+	action_taken()
+
+/obj/item/storage/backpack/marine/satchel/scout_cloak/proc/on_throw(datum/source, atom/target)
+	action_taken()
+
+/obj/item/storage/backpack/marine/satchel/scout_cloak/proc/on_attack(datum/source, mob/living/target, obj/item/used_item)
+	action_taken()
+
+/obj/item/storage/backpack/marine/satchel/scout_cloak/proc/action_taken()
 	to_chat(wearer, "<span class='danger'>Your cloak shimmers from your actions!</span>")
 	apply_shimmer()
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -199,9 +199,12 @@
 		hud_used.throw_icon.icon_state = "act_throw_on"
 
 /mob/proc/throw_item(atom/target)
-	return
+	SHOULD_CALL_PARENT(1)
+	SEND_SIGNAL(src, COMSIG_MOB_THROW, target)
+
 
 /mob/living/carbon/throw_item(atom/target)
+	. = ..()
 	src.throw_mode_off()
 	if(is_ventcrawling) //NOPE
 		return

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -236,7 +236,3 @@
 
 mob/living/carbon/human/get_standard_bodytemperature()
 	return species.body_temperature
-
-/mob/living/carbon/human/throw_item(atom/target)
-	. = ..()
-	SEND_SIGNAL(src, COMSIG_HUMAN_ITEM_THROW, target, null, src)

--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/defiler.dm
@@ -16,19 +16,3 @@
 	inherent_verbs = list(
 		/mob/living/carbon/xenomorph/proc/vent_crawl
 		)
-
-// ***************************************
-// *********** Mob overrides
-// ***************************************
-/mob/living/carbon/xenomorph/Defiler/throw_item(atom/target)
-	throw_mode_off()
-
-/mob/living/carbon/xenomorph/Defiler/hitby(atom/movable/AM as mob|obj,speed = 5)
-	if(ishuman(AM))
-		return
-	return ..()
-
-/mob/living/carbon/xenomorph/Defiler/Bumped(atom/movable/AM as mob|obj)
-	if(emitting_gas) //We don't get bumped around
-		return
-	return ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/warrior.dm
@@ -30,9 +30,6 @@
 // ***************************************
 // *********** Mob overrides
 // ***************************************
-/mob/living/carbon/xenomorph/warrior/throw_item(atom/target)
-	throw_mode_off()
-
 /mob/living/carbon/xenomorph/warrior/stop_pulling()
 	if(isliving(pulling) && !isxeno(pulling))
 		var/mob/living/L = pulling

--- a/code/modules/projectiles/updated_projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_attachables.dm
@@ -268,7 +268,7 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/proc/fire_attachment(atom/target,obj/item/weapon/gun/gun, mob/user) //For actually shooting those guns.
 	SHOULD_CALL_PARENT(1)
-	SEND_SIGNAL(user, COMSIG_HUMAN_ATTACHMENT_FIRED, target, src, gun)
+	SEND_SIGNAL(user, COMSIG_MOB_ATTACHMENT_FIRED, target, src, gun)
 
 
 /////////// Muzzle Attachments /////////////////////////////////

--- a/code/modules/projectiles/updated_projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_attachables.dm
@@ -267,7 +267,8 @@ Defined in conflicts.dm of the #defines folder.
 	return
 
 /obj/item/attachable/proc/fire_attachment(atom/target,obj/item/weapon/gun/gun, mob/user) //For actually shooting those guns.
-	return
+	SHOULD_CALL_PARENT(1)
+	SEND_SIGNAL(user, COMSIG_HUMAN_ATTACHMENT_FIRED, target, src, gun)
 
 
 /////////// Muzzle Attachments /////////////////////////////////
@@ -963,6 +964,7 @@ Defined in conflicts.dm of the #defines folder.
 			qdel(G)
 
 /obj/item/attachable/attached_gun/grenade/fire_attachment(atom/target,obj/item/weapon/gun/gun,mob/living/user)
+	. = ..()
 	if(get_dist(user,target) > max_range)
 		to_chat(user, "<span class='warning'>Too far to fire the attachment!</span>")
 		return
@@ -1067,6 +1069,7 @@ Defined in conflicts.dm of the #defines folder.
 		to_chat(user, "<span class='warning'>[src] can be refilled only with welding fuel.</span>")
 
 /obj/item/attachable/attached_gun/flamer/fire_attachment(atom/target, obj/item/weapon/gun/gun, mob/living/user)
+	. = ..()
 	if(get_dist(user,target) > max_range+3)
 		to_chat(user, "<span class='warning'>Too far to fire the attachment!</span>")
 		return

--- a/code/modules/projectiles/updated_projectiles/gun_system.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_system.dm
@@ -681,7 +681,7 @@ and you're good to go.
 			extra_delay = min(extra_delay+(burst_delay*2), fire_delay*3) // The more bullets you shoot, the more delay there is, but no more than thrice the regular delay.
 			sleep(burst_delay)
 
-		SEND_SIGNAL(user, COMSIG_HUMAN_GUN_FIRED, target, src, user)
+		SEND_SIGNAL(user, COMSIG_HUMAN_GUN_FIRED, target, src)
 
 	flags_gun_features &= ~GUN_BURST_FIRING // We always want to turn off bursting when we're done.
 
@@ -1167,5 +1167,4 @@ and you're good to go.
 		to_chat(user, "<span class='warning'>[active_attachable] is not ready to fire!</span>")
 		return
 	active_attachable.fire_attachment(target, src, user) //Fire it.
-	SEND_SIGNAL(user, COMSIG_HUMAN_ATTACHMENT_FIRED, target, active_attachable, user)
 	last_fired = world.time

--- a/code/modules/projectiles/updated_projectiles/gun_system.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_system.dm
@@ -681,7 +681,7 @@ and you're good to go.
 			extra_delay = min(extra_delay+(burst_delay*2), fire_delay*3) // The more bullets you shoot, the more delay there is, but no more than thrice the regular delay.
 			sleep(burst_delay)
 
-		SEND_SIGNAL(user, COMSIG_HUMAN_GUN_FIRED, target, src)
+		SEND_SIGNAL(user, COMSIG_MOB_GUN_FIRED, target, src)
 
 	flags_gun_features &= ~GUN_BURST_FIRING // We always want to turn off bursting when we're done.
 


### PR DESCRIPTION
* Moves signals to the base of the procs and adds a requirement to call the parent.
* Adds item attack signals and cleans up other existing ones.
* Cleans up scout cloak code.
* Removes procs that don't do anything.
* Deletes an unused define.