### PR TITLE
Game tab

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -271,7 +271,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 /mob/dead/observer/Stat()
 	. = ..()
 
-	if(statpanel("Stats"))
+	if(statpanel("Game"))
 		if(SSticker.current_state == GAME_STATE_PREGAME)
 			stat("Time To Start:", "[SSticker.time_left > 0 ? SSticker.GetTimeLeft() : "(DELAYED)"]")
 			stat("Players: [length(GLOB.player_list)]", "Players Ready: [GLOB.ready_players]")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -70,7 +70,7 @@
 /mob/living/carbon/human/Stat()
 	. = ..()
 
-	if(statpanel("Stats"))
+	if(statpanel("Game"))
 		var/eta_status = SSevacuation?.get_status_panel_eta()
 		if(eta_status)
 			stat("Evacuation in:", eta_status)

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -262,7 +262,7 @@
 /mob/living/carbon/monkey/Stat()
 	. = ..()
 
-	if(statpanel("Stats"))
+	if(statpanel("Game"))
 		stat(null, text("Intent: []", a_intent))
 		stat(null, text("Move Mode: []", m_intent))
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/carrier.dm
@@ -47,6 +47,6 @@
 /mob/living/carbon/xenomorph/carrier/Stat()
 	. = ..()
 
-	if(statpanel("Stats"))
+	if(statpanel("Game"))
 		stat(null, "Stored Huggers: [huggers.len] / [xeno_caste.huggers_max]")
 		stat(null, "Stored Eggs: [eggs_cur] / [xeno_caste.eggs_max]")

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/hivelord.dm
@@ -48,5 +48,5 @@
 /mob/living/carbon/xenomorph/hivelord/Stat()
 	. = ..()
 
-	if(statpanel("Stats"))
+	if(statpanel("Game"))
 		stat(null, "Active Tunnel Sets: [tunnels.len * 0.5] / [HIVELORD_TUNNEL_SET_LIMIT]")

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/hunter.dm
@@ -51,7 +51,7 @@
 /mob/living/carbon/xenomorph/hunter/Stat()
 	. = ..()
 
-	if(statpanel("Stats"))
+	if(statpanel("Game"))
 		stat(null, "Sneak Attack Multiplier: [sneak_bonus] / [HUNTER_SNEAKATTACK_MAX_MULTIPLIER]")
 
 // ***************************************

--- a/code/modules/mob/living/carbon/xenomorph/castes/larva/larva.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/larva/larva.dm
@@ -37,7 +37,7 @@
 /mob/living/carbon/xenomorph/larva/Stat()
 	. = ..()
 
-	if(statpanel("Stats"))
+	if(statpanel("Game"))
 		stat(null, "Progress: [amount_grown]/[max_grown]")
 
 

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -110,7 +110,7 @@
 /mob/living/carbon/xenomorph/Stat()
 	. = ..()
 
-	if(!statpanel("Stats"))
+	if(!statpanel("Game"))
 		return
 
 	if(!(xeno_caste.caste_flags & CASTE_EVOLUTION_ALLOWED))

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -227,7 +227,7 @@
 /mob/living/silicon/ai/Stat()
 	. = ..()
 
-	if(statpanel("Stats"))
+	if(statpanel("Game"))
 
 		if(stat != CONSCIOUS)
 			stat(null, text("Systems nonfunctional"))

--- a/code/modules/mob/living/simple_animal/friendly/parrot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/parrot.dm
@@ -90,7 +90,7 @@
 
 /mob/living/simple_animal/parrot/Stat()
 	. = ..()
-	if(statpanel("Status"))
+	if(statpanel("Game"))
 		stat("Held Item", held_item)
 
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -223,7 +223,7 @@
 /mob/living/simple_animal/Stat()
 	. = ..()
 
-	if(statpanel("Stats"))
+	if(statpanel("Game"))
 		stat(null, "Health: [round((health / maxHealth) * 100)]%")
 
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -22,17 +22,17 @@
 
 /mob/Stat()
 	. = ..()
-
-	if(statpanel("Stats"))
+	if(statpanel("Status"))
 		if(client)
 			stat(null, "Ping: [round(client.lastping, 1)]ms (Average: [round(client.avgping, 1)]ms)")
+
+	if(statpanel("Game"))
 		if(GLOB.round_id)
 			stat("Round ID: [GLOB.round_id]")
 		stat("Operation Time: [worldtime2text()]")
 		stat("Current Map: [length(SSmapping.configs) ? SSmapping.configs[GROUND_MAP].map_name : "Loading..."]")
 		stat("Current Ship: [length(SSmapping.configs) ? SSmapping.configs[SHIP_MAP].map_name : "Loading..."]")
 		stat("Time Dilation: [round(SStime_track.time_dilation_current,1)]% AVG:([round(SStime_track.time_dilation_avg_fast,1)]%, [round(SStime_track.time_dilation_avg,1)]%, [round(SStime_track.time_dilation_avg_slow,1)]%)")
-
 
 	if(client?.holder?.rank?.rights)
 		if(client.holder.rank.rights & (R_ADMIN|R_DEBUG))
@@ -65,7 +65,6 @@
 				for(var/i in GLOB.sdql2_queries)
 					var/datum/SDQL2_query/Q = i
 					Q.generate_stat()
-
 
 	if(listed_turf && client)
 		if(!TurfAdjacent(listed_turf))

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -84,7 +84,7 @@
 	if(!SSticker)
 		return
 
-	if(statpanel("Stats"))
+	if(statpanel("Game"))
 		stat("Game Mode:", "[GLOB.master_mode]")
 
 		if(SSticker.current_state == GAME_STATE_PREGAME)


### PR DESCRIPTION
Moves everything but the ping from the "Stat" tab into a "Game" tab, and renames the former to "Status" like /tg/'s
This is because the first tab is the default one, and causes lag for players with a poor connection. They can still access the information but need to opt for it.