### PR TITLE
Make tackle damage respect 80% of armor value

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -436,7 +436,7 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define CASTE_QUICK_HEAL_STANDING (1<<11) // Xenomorphs heal standing same if they were resting.
 #define CASTE_CAN_HEAL_WIHOUT_QUEEN	(1<<12) // Xenomorphs can heal even without a queen on the same z level
 
-#define XENO_TACKLE_ARMOR_PEN	0.4 //Actual armor pen is 1 - this value.
+#define XENO_TACKLE_ARMOR_PEN	0.8 //Actual armor pen is 1 - this value.
 
 //Charge-Crush
 #define CHARGE_OFF			0


### PR DESCRIPTION

About The Pull Request

Makes tackle respect 80% of armor value instad of 40%

 Why It's Good For The Game

as it is right now a few xeno tackles can perma stun just about anyone,with this change light/medium armor users will still get perma stunned by any xeno with little effort but heavier armor sets will need a lot more work,b18 can only be permastunned by tackles if there is 2 xenos tackling it

## Changelog
:cl:
changes xeno tackle pen from 0.4 to 0.8
/:cl:
