### PR TITLE
Queen Acid Spit Removed

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
@@ -37,7 +37,7 @@
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.5 SECONDS
-	spit_types = list(/datum/ammo/xeno/sticky, /datum/ammo/xeno/acid/heavy)
+	spit_types = list(/datum/ammo/xeno/sticky)
 
 	// *** Pheromones *** //
 	aura_strength = 3 //The Queen's aura is strong and stays so, and gets devastating late game. Climbs by 1 to 5


### PR DESCRIPTION

## About The Pull Request

Removes Queen Acid Spit. Her toolbox was too big and this was a very strong thing. MJP wants it gone but won't do their own PRs so here I am I guess. 

## Why It's Good For The Game

Less acid spam. Yay for less face melting. 

## Changelog
:cl:
balance: Queen loses acid spit
/:cl:

