### PR TITLE
Reworks Queen (Including removing acid spit)

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -452,8 +452,8 @@
 	name = "Heal Xenomorph"
 	action_icon_state = "heal_xeno"
 	mechanics_text = "Heals a target Xenomorph"
-	plasma_cost = 600
-	cooldown_timer = 15 SECONDS
+	plasma_cost = 150
+	cooldown_timer = 8 SECONDS
 	keybind_signal = COMSIG_XENOABILITY_QUEEN_HEAL
 
 
@@ -486,8 +486,8 @@
 /datum/action/xeno_action/activable/queen_heal/use_ability(atom/target)
 	var/mob/living/carbon/xenomorph/patient = target
 	add_cooldown()
-	patient.adjustBruteLoss(-50)
-	patient.adjustFireLoss(-50)
+	patient.adjustBruteLoss(-100)
+	patient.adjustFireLoss(-100)
 	succeed_activate()
 	to_chat(owner, "<span class='xenonotice'>We channel our plasma to heal [target]'s wounds.</span>")
 	to_chat(patient, "<span class='xenonotice'>We feel our wounds heal. Bless the Queen!</span>")
@@ -500,8 +500,8 @@
 	name = "Give Plasma"
 	action_icon_state = "queen_give_plasma"
 	mechanics_text = "Give plasma to a target Xenomorph (you must be overwatching them.)"
-	plasma_cost = 600
-	cooldown_timer = 15 SECONDS
+	plasma_cost = 150
+	cooldown_timer = 8 SECONDS
 	keybind_signal = COMSIG_XENOABILITY_QUEEN_GIVE_PLASMA
 
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
@@ -9,20 +9,20 @@
 	wound_type = "queen" //used to match appropriate wound overlays
 
 	// *** Melee Attacks *** //
-	melee_damage = 45
+	melee_damage = 30
 
 	// *** Tackle *** //
-	tackle_damage = 45
+	tackle_damage = 35
 
 	// *** Speed *** //
-	speed = 0.6
+	speed = -0.2
 
 	// *** Plasma *** //
-	plasma_max = 700
-	plasma_gain = 30
+	plasma_max = 900
+	plasma_gain = 40
 
 	// *** Health *** //
-	max_health = 300
+	max_health = 200
 
 	// *** Evolution *** //
 	upgrade_threshold = 800
@@ -37,7 +37,7 @@
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.5 SECONDS
-	spit_types = list(/datum/ammo/xeno/sticky, /datum/ammo/xeno/acid/heavy)
+	spit_types = list(/datum/ammo/xeno/sticky)
 
 	// *** Pheromones *** //
 	aura_strength = 3 //The Queen's aura is strong and stays so, and gets devastating late game. Climbs by 1 to 5
@@ -53,6 +53,7 @@
 		/datum/action/xeno_action/choose_resin,
 		/datum/action/xeno_action/activable/secrete_resin,
 		/datum/action/xeno_action/lay_egg,
+		/datum/action/xeno_action/activable/larval_growth_sting,
 		/datum/action/xeno_action/call_of_the_burrowed,
 		/datum/action/xeno_action/activable/screech,
 		/datum/action/xeno_action/activable/corrosive_acid/strong,
@@ -79,20 +80,20 @@
 	upgrade = XENO_UPGRADE_ONE
 
 	// *** Melee Attacks *** //
-	melee_damage = 50
+	melee_damage = 35
 
 	// *** Tackle *** //
-	tackle_damage = 50
+	tackle_damage = 40
 
 	// *** Speed *** //
-	speed = 0.5
+	speed = -0.3
 
 	// *** Plasma *** //
-	plasma_max = 800
-	plasma_gain = 40
+	plasma_max = 1000
+	plasma_gain = 50
 
 	// *** Health *** //
-	max_health = 325
+	max_health = 225
 
 	// *** Evolution *** //
 	upgrade_threshold = 1600
@@ -115,20 +116,20 @@
 	upgrade = XENO_UPGRADE_TWO
 
 	// *** Melee Attacks *** //
-	melee_damage = 55
+	melee_damage = 40
 
 	// *** Tackle *** //
-	tackle_damage = 55
+	tackle_damage = 45
 
 	// *** Speed *** //
-	speed = 0.4
+	speed = -0.4
 
 	// *** Plasma *** //
-	plasma_max = 900
-	plasma_gain = 50
+	plasma_max = 1100
+	plasma_gain = 60
 
 	// *** Health *** //
-	max_health = 350
+	max_health = 250
 
 	// *** Evolution *** //
 	upgrade_threshold = 3200
@@ -151,20 +152,20 @@
 	upgrade = XENO_UPGRADE_THREE
 
 	// *** Melee Attacks *** //
-	melee_damage = 60
+	melee_damage = 45
 
 	// *** Tackle *** //
-	tackle_damage = 60
+	tackle_damage = 50
 
 	// *** Speed *** //
-	speed = 0.3
+	speed = -0.5
 
 	// *** Plasma *** //
-	plasma_max = 1000
-	plasma_gain = 50
+	plasma_max = 1200
+	plasma_gain = 70
 
 	// *** Health *** //
-	max_health = 375
+	max_health = 275
 
 	// *** Evolution *** //
 	upgrade_threshold = 3200


### PR DESCRIPTION
## About The Pull Request

Well I think its stupid game design that the queen, the leader of the xenos, is also one of the strongest fighting castes. In the current meta its pretty much necessary for her to fight on the front lines because without her the xenos loose a large, tanky xeno.

I think a queen that stays back and supports the hive with ranged support abilites, rarely running out to screech to assist the xenos is a better design.

I would also like to note I did test this stuff locally, most xenos have health in the hundreds. These abilities will be strong but I highly doubt they will be worse than what the queen was previous to this.

Queen Looses Acid Spit
Queen Heal Plasma Cost: 600 => 150
Queen Heal Cooldown: 15s => 8s
Queen Heal Amount: 50 => 100
Queen Give Plasma Cost: 600 => 150
Queen Give Plasma Cooldown: 15s => 8s
Queen Slash Damage: 45/50/55/60 => 30/35/40/45
Queen Tackle Damage: 45/50/55/60 => 35/40/45/50
Queen Speed: 0.6/0.5/0.4/0,3 => -0.2/-0.3/-0.4/-0.5 
Queen Max Health: 300/325/350/375 => 200/225/250/275
Queen Plasma Max: 700/800/900/1000 => 900/1000/1100/1200
Queen Plasma Gain: 30/40/50/60 => 40/50/60/70
Queen Gains Larva Grow Sting

## Why It's Good For The Game

Queen is no longer a big tanky caste that is required to be on the front lines to be useful but rather can command from the back line while using her abilities to help our fellow xenos.

## Changelog
:cl:
balance: Reworks Queen
/:cl: