### PR TITLE
Shrike Gets Larva Growth Acceleration Sting

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
@@ -50,6 +50,7 @@
 		/datum/action/xeno_action/regurgitate,
 		/datum/action/xeno_action/plant_weeds,
 		/datum/action/xeno_action/lay_egg,
+		/datum/action/xeno_action/activable/larval_growth_sting,
 		/datum/action/xeno_action/call_of_the_burrowed,
 		/datum/action/xeno_action/choose_resin,
 		/datum/action/xeno_action/activable/secrete_resin,


### PR DESCRIPTION
## About The Pull Request

Shrike Gets Larva Growth Acceleration Sting

## Why It's Good For The Game

One of the worst things about xenos is that if you want captures you pretty much need a drone or defiler. I think many xeno players can agree that being forced to play drone is one of the most boring things about xenos. This should prevent that from being necessary.

In my Queen rework PR I gave Queen the larva sting too.

## Changelog
:cl:
tweak: Shrike Gets Larva Growth Acceleration Sting
/:cl: