### PR TITLE
Removes stored larva loss on queen death

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -406,8 +406,6 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define SPRAY_STRUCTURE_UPGRADE_BONUS(Xenomorph) (( Xenomorph.upgrade_as_number() * 8 ))
 #define SPRAY_MOB_UPGRADE_BONUS(Xenomorph) (( Xenomorph.upgrade_as_number() * 4 ))
 
-#define QUEEN_DEATH_LARVA_MULTIPLIER(Xenomorph) ((Xenomorph.upgrade_as_number() + 1) * 0.17) // 85/68/51/34 for ancient/elder emp/elder queen/queen
-
 #define PLASMA_TRANSFER_AMOUNT 50
 #define PLASMA_SALVAGE_AMOUNT 40
 #define PLASMA_SALVAGE_MULTIPLIER 0.5 // I'd not reccomend setting this higher than one.

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -476,8 +476,6 @@ to_chat will check for valid clients itself already so no need to double check f
 	if(!stored_larva) // no larva to deal with
 		return ..()
 
-	stored_larva = round(stored_larva * QUEEN_DEATH_LARVA_MULTIPLIER(Q))
-
 	if(isdistress(SSticker?.mode))
 		INVOKE_ASYNC(src, .proc/unbury_all_larva) // this is potentially a lot of calls so do it async
 


### PR DESCRIPTION
CM designed the Queen to be the final boss, so it made it extra punishing when the hive lost one. Our Queens are more like chess Kings. This concept doesn't fit our idea.

## Changelog
:cl:
balance: Xenos no longer lose stored larvas on a Queen death.
/:cl: