### PR TITLE
Nerfs burn damage pain,buffs acid spit

### DIFF
--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -46,7 +46,7 @@
 	traumatic_shock = 			\
 	0.75	* getOxyLoss() + 		\
 	0.75	* getToxLoss() + 		\
-	1.5		* getFireLoss() + 		\
+	1	* getFireLoss() + 		\
 	1		* getBruteLoss() + 		\
 	1		* getCloneLoss()
 

--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -1152,20 +1152,20 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	spit_cost = 75
 	flags_ammo_behavior = AMMO_XENO_ACID|AMMO_EXPLOSIVE
 	armor_type = "acid"
-	damage = 18
+	damage = 20
 
 /datum/ammo/xeno/acid/on_shield_block(mob/victim, obj/item/projectile/proj)
 	airburst(victim, proj)
 
 /datum/ammo/xeno/acid/medium
 	name = "acid spatter"
-	damage = 20
+	damage = 23
 
 /datum/ammo/xeno/acid/heavy
 	name = "acid splash"
 	added_spit_delay = 8
 	spit_cost = 75
-	damage = 23
+	damage = 28
 
 /datum/ammo/xeno/acid/heavy/on_hit_mob(mob/M,obj/item/projectile/P)
 	var/turf/T = get_turf(M)

--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -1152,20 +1152,20 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	spit_cost = 75
 	flags_ammo_behavior = AMMO_XENO_ACID|AMMO_EXPLOSIVE
 	armor_type = "acid"
-	damage = 20
+	damage = 25
 
 /datum/ammo/xeno/acid/on_shield_block(mob/victim, obj/item/projectile/proj)
 	airburst(victim, proj)
 
 /datum/ammo/xeno/acid/medium
 	name = "acid spatter"
-	damage = 23
+	damage = 28
 
 /datum/ammo/xeno/acid/heavy
 	name = "acid splash"
 	added_spit_delay = 8
 	spit_cost = 75
-	damage = 28
+	damage = 33
 
 /datum/ammo/xeno/acid/heavy/on_hit_mob(mob/M,obj/item/projectile/P)
 	var/turf/T = get_turf(M)


### PR DESCRIPTION
## About The Pull Request

Changes burn damage pain modifies from 1.5x to 1.0x and buffs acid spit damage

## Why It's Good For The Game

the pain damage on burns is absurd,lasguns and flames annihilate humans with pain damage,and acid spits deal more pain than damage themselves,this is a change to solve that issue

## Changelog
:cl:
balance: change pain damage modifier on burns and buff acid spit
/:cl: