### PR TITLE
Fixes a barrel runtime

### DIFF
--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -144,21 +144,20 @@
 	return ..()
 
 
-/obj/structure/largecrate/random/barrel/attackby(obj/item/I, mob/user, params)
-	. = ..()
+/obj/structure/largecrate/random/barrel/welder_act(mob/living/user, obj/item/tool/weldingtool/welder)
+	if(!welder.isOn())
+		return FALSE
+	if(!do_after(user, 5 SECONDS, TRUE, src, BUSY_ICON_BUILD))
+		return TRUE
+	if(!welder.remove_fuel(1, user))
+		return TRUE
+	user.visible_message("<span class='notice'>[user] welds \the [src] open.</span>",
+		"<span class='notice'>You weld open \the [src].</span>",
+		"<span class='notice'>You hear loud hissing and the sound of metal falling over.</span>")
+	playsound(loc, 'sound/items/welder2.ogg', 25, TRUE)
+	deconstruct(TRUE)
+	return TRUE
 
-	if(iswelder(I))
-		var/obj/item/tool/weldingtool/WT = I
-		if(!do_after(user, 50, TRUE, src, BUSY_ICON_BUILD))
-			return
-		WT.remove_fuel(1, user)
-		user.visible_message("<span class='notice'>[user] welds \the [src] open.</span>", \
-							"<span class='notice'>You weld open \the [src].</span>", \
-							"<span class='notice'>You hear loud hissing and the sound of metal falling over.</span>")
-		playsound(loc, 'sound/items/welder2.ogg', 25, 1)
-		deconstruct(TRUE)
-	else
-		return attack_hand(user)
 
 /obj/structure/largecrate/random/barrel/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
```
[23:16:58] Runtime in human.dm, line 67: attack_hand on a qdeleted atom
proc name: attack hand (/atom/proc/attack_hand)
usr: CKEY/(Rylie Poehler)
usr.loc: (Alamo Landing Zone (141, 24, 2))
src: the blue barrel (/obj/structure/largecrate/random/barrel)
src.loc: null
call stack:
the blue barrel (/obj/structure/largecrate/random/barrel): attack hand(Rylie Poehler (/mob/living/carbon/human))
the blue barrel (/obj/structure/largecrate/random/barrel): attack hand(Rylie Poehler (/mob/living/carbon/human))
the blue barrel (/obj/structure/largecrate/random/barrel): attack hand(Rylie Poehler (/mob/living/carbon/human))
the blue barrel (/obj/structure/largecrate/random/barrel): attackby(the M41A1 pulse rifle (/obj/item/weapon/gun/rifle/m41a), Rylie Poehler (/mob/living/carbon/human), "icon-x=14;icon-y=13;left=1;scr...")
the M41A1 pulse rifle (/obj/item/weapon/gun/rifle/m41a): melee attack chain(Rylie Poehler (/mob/living/carbon/human), the blue barrel (/obj/structure/largecrate/random/barrel), "icon-x=14;icon-y=13;left=1;scr...")
Rylie Poehler (/mob/living/carbon/human): ClickOn(the blue barrel (/obj/structure/largecrate/random/barrel), "icon-x=14;icon-y=13;left=1;scr...")
the blue barrel (/obj/structure/largecrate/random/barrel): Click(the floor (141,23,2) (/turf/open/floor), "mapwindow.map", "icon-x=14;icon-y=13;left=1;scr...")
CKEY (/client): Click(the blue barrel (/obj/structure/largecrate/random/barrel), the floor (141,23,2) (/turf/open/floor), "mapwindow.map", "icon-x=14;icon-y=13;left=1;scr...")
```
