### PR TITLE
adds the dab emote for xenomorphs

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/emote.dm
+++ b/code/modules/mob/living/carbon/xenomorph/emote.dm
@@ -132,3 +132,8 @@
 		playsound(user.loc, "alien_roar_larva", 15)
 	else
 		return ..()
+
+/datum/emote/living/carbon/xenomorph/dab
+	key = "dab"
+	key_third_person = "dabs"
+	message = "hits a nasty dab!"


### PR DESCRIPTION
## About The Pull Request

adds the dab emote under *dab for xenomorphs

## Why It's Good For The Game

lets fun new rp oppurtunities arrive where xenos can emphrase their emotions with dance moves!

## Changelog
:cl:
add: Xenomorphs can now *dab
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
