### PR TITLE
makes explosions not explode things 4 times

### DIFF
--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -110,7 +110,7 @@
 					continue
 				A.ex_act(dist)
 
-		if(dist > 0)
+		else if(dist > 0)
 			T.ex_act(dist)
 			for(var/i in T)
 				var/atom/movable/AM = i

--- a/code/modules/projectiles/updated_projectiles/projectile.dm
+++ b/code/modules/projectiles/updated_projectiles/projectile.dm
@@ -502,9 +502,6 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 		if(!thing_to_hit.projectile_hit(src, cardinal_move)) //Calculated from combination of both ammo accuracy and gun accuracy.
 			continue
 
-		if(ammo.flags_ammo_behavior & AMMO_EXPLOSIVE)
-			ammo.on_hit_turf(turf_to_scan, src)
-
 		thing_to_hit.do_projectile_hit(src)
 		return TRUE
 


### PR DESCRIPTION
:cl:
fix: explosions no longer hit things on their centre tile multiple times, and rockets no longer explode twice. Xenos should be pulped less by explosions now.
/:cl:
fixes the xeno squish
HE rockets should no longer do ~400 damage to queens instantly. They now do somewhere in the area of 100.