### PR TITLE
Revert "Makes Helmets Smaller"

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -13,7 +13,7 @@
 	min_cold_protection_temperature = HELMET_MIN_COLD_PROTECTION_TEMPERATURE
 	max_heat_protection_temperature = HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0.7
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_BULKY
 
 
 
@@ -196,14 +196,16 @@
 						/obj/item/clothing/glasses/mgoggles/prescription = "goggles")
 
 /obj/item/storage/internal/marinehelmet
-	storage_slots = 2
+	storage_slots = 4
 	max_w_class = 1
 	bypass_w_limit = list(
 		/obj/item/clothing/glasses,
-		/obj/item/reagent_containers/food/drinks/flask)
+		/obj/item/reagent_containers/food/drinks/flask,
+		/obj/item/ammo_magazine/smg,
+		/obj/item/ammo_magazine/pistol)
 	cant_hold = list(
 		/obj/item/stack/)
-	max_storage_space = 2
+	max_storage_space = 4
 
 /obj/item/clothing/head/helmet/marine/Initialize()
 	. = ..()
@@ -575,4 +577,3 @@
 	icon_state = "som_helmet_leader"
 	item_state = "som_helmet_leader"
 	armor = list("melee" = 45, "bullet" = 38, "laser" = 48, "energy" = 30, "bomb" = 20, "bio" = 15, "rad" = 15, "fire" = 30, "acid" = 30)
-


### PR DESCRIPTION
# About The Pull Request
Reverts PR #3213 , reverting helmets back to bulky items with 4|4 storage space and slots

# Why It's Good For The Game
This PR essentially removed much of the helmet's functionality for a niche feature to allow it to fit in bags, something that wouldn't likely come into play. Stuff like goggles would take up the entire space among other items.

Changelog
🆑
tweak: Reverts small helmets PR (Bulky item size, 4 slot storage space)
/🆑