### PR TITLE
Gives AK47 burst to carbine

### DIFF
--- a/code/modules/projectiles/updated_projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/rifles.dm
@@ -181,6 +181,7 @@
 	starting_attachment_types = list(/obj/item/attachable/stock/ak47)
 
 	accuracy_mult = 1.05
+	burst_amount = 0
 	fire_delay = 0.25 SECONDS
 
 
@@ -189,10 +190,11 @@
 	desc = "A cheap, reliable assault rifle chambered in 7.62x39mm. Commonly found in the hands of criminals or mercenaries. This is the carbine variant."
 	icon_state = "mar30"
 	item_state = "mar30"
-	gun_firemode_list = list(GUN_FIREMODE_SEMIAUTO, GUN_FIREMODE_AUTOMATIC)
+	gun_firemode_list = list(GUN_FIREMODE_SEMIAUTO, GUN_FIREMODE_AUTOMATIC, GUN_FIREMODE_BURSTFIRE, GUN_FIREMODE_AUTOBURST)
 	starting_attachment_types = null
 
 	fire_delay = 0.23 SECONDS
+	burst_amount = 3
 	accuracy_mult = 0.9
 	accuracy_mult_unwielded = 0.5
 


### PR DESCRIPTION
# about the pull request

Removes burst fire from AK47, gives it to the Carbine variant ("MAR-30") instead.

# Why it's good for the game

For some reason, even when it doesn't include GUN_FIREMODE_BURSTFIRE in its firemode list, it still had burst fire on the AK47. Instead a jury rig solution has been provided, Spyro accomplished this on the SX by making burst_amount = 0, and this will be my solution to the problem for now. 

I wanted the AK 47 to be a weapon with big bullets, restricted to single and autofire, while the M16 was restricted to single and burst fire. This should accomplish that. Also, note to self, replace the carbine with the AK74U with smaller rounds along with modern AK variants.