### PR TITLE
Resin Traps, Goo, and Eggs are destroyed if the resin tile below them is also destroyed.

### DIFF
--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -10,7 +10,7 @@
 	layer = TURF_LAYER
 	plane = FLOOR_PLANE
 	var/parent_node
-	max_integrity = 4
+	max_integrity = 36
 
 /obj/effect/alien/weeds/deconstruct(disassembled = TRUE)
 	GLOB.round_statistics.weeds_destroyed++
@@ -31,7 +31,9 @@
 		SSweeds.add_weed(src)
 
 	if(loc)
-		for(var/obj/effect/alien/resin/R in loc.contents)
+		for(var/obj/effect/alien/R in loc.contents)
+			if(R == src)
+				continue
 			qdel(R)
 
 	var/oldloc = loc

--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -31,7 +31,7 @@
 		SSweeds.add_weed(src)
 
 	for(var/obj/effect/alien/A in loc.contents)
-		if(A == src || A.gc_destroyed || A.ignore_weed_destruction)
+		if(QDELETED(A) || A == src || A.ignore_weed_destruction)
 			continue
 		A.obj_destruction("melee")
 

--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -26,8 +26,13 @@
 
 
 /obj/effect/alien/weeds/Destroy()
+
 	if(parent_node)
 		SSweeds.add_weed(src)
+
+	if(loc)
+		for(var/obj/effect/alien/resin/R in loc.contents)
+			qdel(R)
 
 	var/oldloc = loc
 	. = ..()

--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -30,11 +30,10 @@
 	if(parent_node)
 		SSweeds.add_weed(src)
 
-	if(loc)
-		for(var/obj/effect/alien/A in loc.contents)
-			if(A == src)
-				continue
-			qdel(A)
+	for(var/obj/effect/alien/A in loc.contents)
+		if(A == src)
+			continue
+		A.obj_destruction("melee")
 
 	var/oldloc = loc
 	. = ..()

--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -10,7 +10,7 @@
 	layer = TURF_LAYER
 	plane = FLOOR_PLANE
 	var/parent_node
-	max_integrity = 36
+	max_integrity = 25
 
 /obj/effect/alien/weeds/deconstruct(disassembled = TRUE)
 	GLOB.round_statistics.weeds_destroyed++
@@ -31,10 +31,10 @@
 		SSweeds.add_weed(src)
 
 	if(loc)
-		for(var/obj/effect/alien/R in loc.contents)
-			if(R == src)
+		for(var/obj/effect/alien/A in loc.contents)
+			if(A == src)
 				continue
-			qdel(R)
+			qdel(A)
 
 	var/oldloc = loc
 	. = ..()

--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -31,7 +31,7 @@
 		SSweeds.add_weed(src)
 
 	for(var/obj/effect/alien/A in loc.contents)
-		if(A == src)
+		if(A == src || A.gc_destroyed || A.ignore_weed_destruction)
 			continue
 		A.obj_destruction("melee")
 
@@ -128,6 +128,8 @@
 	max_integrity = 100
 
 	var/node_turfs = list() // list of all potential turfs that we can expand to
+
+	ignore_weed_destruction = TRUE
 
 /obj/effect/alien/weeds/node/Destroy()
 	. = ..()

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -12,6 +12,7 @@
 	resistance_flags = UNACIDABLE
 	obj_flags = CAN_BE_HIT
 	var/on_fire = FALSE
+	var/ignore_weed_destruction = FALSE //Set this to true if this object isn't destroyed when the weeds under it is.
 
 
 /obj/effect/alien/attackby(obj/item/I, mob/user, params)
@@ -75,6 +76,8 @@
 	hit_sound = "alien_resin_move"
 	var/slow_amt = 8
 
+	ignore_weed_destruction = TRUE
+
 
 /obj/effect/alien/resin/sticky/Crossed(atom/movable/AM)
 	. = ..()
@@ -95,6 +98,8 @@
 	desc = "A thin layer of disgusting sticky slime."
 	max_integrity = 6
 	slow_amt = 4
+
+	ignore_weed_destruction = FALSE
 
 
 //Carrier trap


### PR DESCRIPTION
## About The Pull Request 

If you destroy a resin tile, any resin structures, except strong sticky goo, doors, beds, and walls, will be removed as well.

Individual resin health increased from 8 to 25 (Knives do 25 damage).

## Why It's Good For The Game

Just makes sense logically. Why would a resin trap continue to exist when the resin itself on the tile is destroyed? Why would goo, which cannot be placed on non-resin tiles, continue to exist despite the resin tile removed?

Also in the name of xeno balance, the overall health of resin floor tiles was increased so marines can't just somehow magically remove it with the butt of their gun. They're going to need a machete or knife to remove it. Annoying, yes, but most people just attack the node anyways, which has 100 health.

## Changelog
:cl: BurgerBB
balance: If you destroy a resin tile, any resin structures, except doors, walls, and strong sticky good, will be removed as well.
balance: Individual resin health increased from 8 to 25 (Knives do 25 damage).
/:cl: