### PR TITLE
SpecialClick Framework added, Vaulting and holecrawling changed to fit into it

### DIFF
--- a/code/datums/keybinding/carbon.dm
+++ b/code/datums/keybinding/carbon.dm
@@ -88,24 +88,24 @@
 	user.mob?.a_intent_change(INTENT_HARM)
 	return TRUE
 
-/datum/keybinding/mob/specialclick
+/datum/keybinding/carbon/specialclick
 	key = "Control"
 	name = "specialclick"
 	full_name = "Special Click"
 	description = "Hold this key and click to trigger special object interactions."
 
 
-/datum/keybinding/mob/specialclick/down(client/user)
+/datum/keybinding/carbon/specialclick/down(client/user)
 	RegisterSignal(user.mob, list(COMSIG_MOB_CLICKON), .proc/specialclicky)
-	RegisterSignal(user.mob, list(COMSIG_MOB_MOUSEDOWN, COMSIG_MOB_MOUSEUP), .proc/intercept_mouse_special)
+	RegisterSignal(user.mob, list(COMSIG_MOB_MOUSEDOWN, COMSIG_MOB_MOUSEUP), /datum/keybinding/mob/examine/proc/intercept_mouse_special)
 	return TRUE
 
 
-/datum/keybinding/mob/specialclick/up(client/user)
+/datum/keybinding/carbon/specialclick/up(client/user)
 	UnregisterSignal(user.mob, list(COMSIG_MOB_MOUSEDOWN, COMSIG_MOB_MOUSEUP, COMSIG_MOB_CLICKON))
 	return TRUE
 
-/datum/keybinding/mob/specialclick/proc/specialclicky(datum/source, atom/A, params)
+/datum/keybinding/carbon/specialclick/proc/specialclicky(datum/source, atom/A, params)
 	var/mob/living/carbon/user = source
 	if(!user.client || !(user.client.eye == user || user.client.eye == user.loc))
 		UnregisterSignal(user, (COMSIG_MOB_CLICKON))

--- a/code/datums/keybinding/carbon.dm
+++ b/code/datums/keybinding/carbon.dm
@@ -87,3 +87,27 @@
 /datum/keybinding/carbon/select_harm_intent/down(client/user)
 	user.mob?.a_intent_change(INTENT_HARM)
 	return TRUE
+
+/datum/keybinding/mob/specialclick
+	key = "Control"
+	name = "specialclick"
+	full_name = "Special Click"
+	description = "Hold this key and click to trigger special object interactions."
+
+
+/datum/keybinding/mob/specialclick/down(client/user)
+	RegisterSignal(user.mob, list(COMSIG_MOB_CLICKON), .proc/specialclicky)
+	RegisterSignal(user.mob, list(COMSIG_MOB_MOUSEDOWN, COMSIG_MOB_MOUSEUP), .proc/intercept_mouse_special)
+	return TRUE
+
+
+/datum/keybinding/mob/specialclick/up(client/user)
+	UnregisterSignal(user.mob, list(COMSIG_MOB_MOUSEDOWN, COMSIG_MOB_MOUSEUP, COMSIG_MOB_CLICKON))
+	return TRUE
+
+/datum/keybinding/mob/specialclick/proc/specialclicky(datum/source, atom/A, params)
+	var/mob/living/carbon/user = source
+	if(!user.client || !(user.client.eye == user || user.client.eye == user.loc))
+		UnregisterSignal(user, (COMSIG_MOB_CLICKON))
+		return
+	A.specialclick(user)

--- a/code/datums/keybinding/carbon.dm
+++ b/code/datums/keybinding/carbon.dm
@@ -89,7 +89,7 @@
 	return TRUE
 
 /datum/keybinding/carbon/specialclick
-	key = "Control"
+	key = "ctrl"
 	name = "specialclick"
 	full_name = "Special Click"
 	description = "Hold this key and click to trigger special object interactions."
@@ -97,7 +97,7 @@
 
 /datum/keybinding/carbon/specialclick/down(client/user)
 	RegisterSignal(user.mob, list(COMSIG_MOB_CLICKON), .proc/specialclicky)
-	RegisterSignal(user.mob, list(COMSIG_MOB_MOUSEDOWN, COMSIG_MOB_MOUSEUP), /datum/keybinding/mob/examine/proc/intercept_mouse_special)
+	RegisterSignal(user.mob, list(COMSIG_MOB_MOUSEDOWN, COMSIG_MOB_MOUSEUP), .keybinding/proc/intercept_mouse_special)
 	return TRUE
 
 

--- a/code/datums/keybinding/keybinding.dm
+++ b/code/datums/keybinding/keybinding.dm
@@ -25,3 +25,4 @@
 
 /datum/keybinding/proc/intercept_mouse_special(datum/source)
 	return COMSIG_MOB_CLICK_CANCELED
+	

--- a/code/datums/keybinding/keybinding.dm
+++ b/code/datums/keybinding/keybinding.dm
@@ -25,7 +25,3 @@
 
 /datum/keybinding/proc/intercept_mouse_special(datum/source)
 	return COMSIG_MOB_CLICK_CANCELED
-
-
-
-	

--- a/code/datums/keybinding/keybinding.dm
+++ b/code/datums/keybinding/keybinding.dm
@@ -22,3 +22,6 @@
 
 /datum/keybinding/proc/up(client/user)
 	return FALSE
+
+/datum/keybinding/proc/intercept_mouse_special(datum/source)
+	return COMSIG_MOB_CLICK_CANCELED

--- a/code/datums/keybinding/keybinding.dm
+++ b/code/datums/keybinding/keybinding.dm
@@ -25,4 +25,5 @@
 
 /datum/keybinding/proc/intercept_mouse_special(datum/source)
 	return COMSIG_MOB_CLICK_CANCELED
+
 	

--- a/code/datums/keybinding/keybinding.dm
+++ b/code/datums/keybinding/keybinding.dm
@@ -26,4 +26,6 @@
 /datum/keybinding/proc/intercept_mouse_special(datum/source)
 	return COMSIG_MOB_CLICK_CANCELED
 
+
+
 	

--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -156,7 +156,7 @@
 
 /datum/keybinding/mob/examine/down(client/user)
 	RegisterSignal(user.mob, list(COMSIG_MOB_CLICKON, COMSIG_OBSERVER_CLICKON), .proc/examinate)
-	RegisterSignal(user.mob, list(COMSIG_MOB_MOUSEDOWN, COMSIG_MOB_MOUSEUP), .proc/intercept_mouse_special)
+	RegisterSignal(user.mob, list(COMSIG_MOB_MOUSEDOWN, COMSIG_MOB_MOUSEUP), .keybinding/proc/intercept_mouse_special)
 	return TRUE
 
 
@@ -172,11 +172,6 @@
 		return
 	user.examinate(A)
 	return COMSIG_MOB_CLICK_HANDLED
-
-
-/datum/keybinding/mob/examine/proc/intercept_mouse_special(datum/source)
-	return COMSIG_MOB_CLICK_CANCELED
-
 
 /datum/keybinding/mob/toggle_move_intent
 	key = "5"

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -675,3 +675,8 @@ Proc for attack log creation, because really why not
 		return FALSE
 
 	return TRUE
+
+
+// For special click interactions (take first item out of container, quick-climb, etc.)
+/atom/proc/specialclick(mob/living/carbon/user)
+	return

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -680,4 +680,3 @@ Proc for attack log creation, because really why not
 // For special click interactions (take first item out of container, quick-climb, etc.)
 /atom/proc/specialclick(mob/living/carbon/user)
 	return
-	

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -680,3 +680,4 @@ Proc for attack log creation, because really why not
 // For special click interactions (take first item out of container, quick-climb, etc.)
 /atom/proc/specialclick(mob/living/carbon/user)
 	return
+	

--- a/code/game/objects/effects/acid_hole.dm
+++ b/code/game/objects/effects/acid_hole.dm
@@ -42,11 +42,12 @@
 
 
 /obj/effect/acid_hole/specialclick(mob/living/carbon/xenomorph/user)
-	if(holed_wall)
-		if(user.mob_size == MOB_SIZE_BIG)
-			expand_hole(user)
-			return
-		use_wall_hole(user)
+	if(isxeno(user))	
+		if(holed_wall)
+			if(user.mob_size == MOB_SIZE_BIG)
+				expand_hole(user)
+				return
+			use_wall_hole(user)
 
 /obj/effect/acid_hole/proc/expand_hole(mob/living/carbon/xenomorph/user)
 	if(user.action_busy || user.lying)

--- a/code/game/objects/effects/acid_hole.dm
+++ b/code/game/objects/effects/acid_hole.dm
@@ -1,6 +1,6 @@
 /obj/effect/acid_hole
 	name = "hole"
-	desc = "What could have done this?"
+	desc = "What could have done this? Something agile enough could probably climb through."
 	icon = 'icons/effects/new_acid.dmi'
 	icon_state = "hole_0"
 	anchored = TRUE
@@ -45,6 +45,8 @@
 	if(holed_wall)
 		if(user.mob_size == MOB_SIZE_BIG)
 			expand_hole(user)
+			return
+		use_wall_hole(user)
 
 /obj/effect/acid_hole/proc/expand_hole(mob/living/carbon/xenomorph/user)
 	if(user.action_busy || user.lying)

--- a/code/game/objects/effects/acid_hole.dm
+++ b/code/game/objects/effects/acid_hole.dm
@@ -41,7 +41,7 @@
 		use_wall_hole(user)
 
 
-/obj/effect/acid_hole/attack_alien(mob/living/carbon/xenomorph/user)
+/obj/effect/acid_hole/specialclick(mob/living/carbon/xenomorph/user)
 	if(holed_wall)
 		if(user.mob_size == MOB_SIZE_BIG)
 			expand_hole(user)

--- a/code/game/objects/effects/acid_hole.dm
+++ b/code/game/objects/effects/acid_hole.dm
@@ -41,13 +41,14 @@
 		use_wall_hole(user)
 
 
-/obj/effect/acid_hole/specialclick(mob/living/carbon/xenomorph/user)
-	if(isxeno(user))	
-		if(holed_wall)
-			if(user.mob_size == MOB_SIZE_BIG)
-				expand_hole(user)
-				return
-			use_wall_hole(user)
+/obj/effect/acid_hole/specialclick(mob/living/carbon/user)
+	if(!isxeno(user))
+		return	
+	if(holed_wall)
+		if(user.mob_size == MOB_SIZE_BIG)
+			expand_hole(user)
+			return
+		use_wall_hole(user)
 
 /obj/effect/acid_hole/proc/expand_hole(mob/living/carbon/xenomorph/user)
 	if(user.action_busy || user.lying)

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -41,6 +41,14 @@
 
 	do_climb(usr)
 
+/obj/structure/attack_alien(mob/living/carbon/xenomorph/user)
+	. = ..()
+	do_climb(usr)
+
+/obj/structure/attack_hand(mob/living/carbon/human/user)
+	. = ..()
+	do_climb(usr)
+
 /obj/structure/MouseDrop_T(mob/target, mob/user)
 	. = ..()
 	var/mob/living/H = user

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -41,13 +41,9 @@
 
 	do_climb(usr)
 
-/obj/structure/attack_alien(mob/living/carbon/xenomorph/user)
+/obj/structure/specialclick(mob/living/carbon/user)
 	. = ..()
-	do_climb(usr)
-
-/obj/structure/attack_hand(mob/living/carbon/human/user)
-	. = ..()
-	do_climb(usr)
+	do_climb(user)
 
 /obj/structure/MouseDrop_T(mob/target, mob/user)
 	. = ..()

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -633,6 +633,7 @@
 	density = FALSE
 	closed = TRUE
 	can_wire = TRUE
+	climbable = TRUE
 
 	var/build_state = 2 //2 is fully secured, 1 is after screw, 0 is after wrench. Crowbar disassembles
 	var/tool_cooldown = 0 //Delay to apply tools to prevent spamming

--- a/strings/tips/marine.txt
+++ b/strings/tips/marine.txt
@@ -18,4 +18,4 @@ Stop, Drop, and Roll, if you are on fire to put yourself out.
 A fit marine can carry many weapons: in their armor, belt, even hanging from their back.
 Requisitions have many supplies to enhance the combat power of marine units. Attachments, ammunition, and other toys, ask their crew what's on store and you may be pleasantly surprised. DISCLAIMER: Extra gear's availability dependent on supply.
 As a Marine or Cargo, don't let garbage crates like SL Armor be ordered. You need those points for other stuff. 
-As a Human, you can climb over waist-high obstacles like sandbags, window frames or tables by clicking on them or drag-clicking yourself on them.
+As a Human, you can climb over waist-high obstacles like sandbags, window frames or tables by SpecialClicking (Default: CTRL) on them or drag-clicking yourself on them.

--- a/strings/tips/marine.txt
+++ b/strings/tips/marine.txt
@@ -18,3 +18,4 @@ Stop, Drop, and Roll, if you are on fire to put yourself out.
 A fit marine can carry many weapons: in their armor, belt, even hanging from their back.
 Requisitions have many supplies to enhance the combat power of marine units. Attachments, ammunition, and other toys, ask their crew what's on store and you may be pleasantly surprised. DISCLAIMER: Extra gear's availability dependent on supply.
 As a Marine or Cargo, don't let garbage crates like SL Armor be ordered. You need those points for other stuff. 
+As a Human, you can climb over waist-high obstacles like sandbags, window frames or tables by clicking on them or drag-clicking yourself on them.

--- a/strings/tips/xeno.txt
+++ b/strings/tips/xeno.txt
@@ -30,5 +30,5 @@ As a xeno, it's not a good idea to kill hosts during the crash phase if they can
 As a xeno, don't take too long attacking during the crash phase. The ship can be rigged to explode in twenty minutes, ending the round in a tie.
 As a xeno, remember that neurotox injected by defilers, sentinels, praetorian, and queen can overdose, killing a marine quickly. Try to avoid this when capturing, if they scream in pain they've probably had enough.
 As a xeno, you can use the crawl through vent verb found in the xeno tab to quickly find and use vents in the floor without having to alt-click them. 
-As a xeno, you can crawl through holes in walls made by acid by clicking on them or click-dragging yourself on them. If you're too big to pass through, you'll damage the wall instead.
-As a xeno, you can climb over window frames by clicking on them or click-dragging yourself on them.
+As a xeno, you can crawl through holes in walls made by acid by SpecialClicking (Default: CTRL) on them or click-dragging yourself on them. If you're too big to pass through, you'll damage the wall instead.
+As a xeno, you can climb over window frames by SpecialClicking (Default: CTRL) on them or click-dragging yourself on them.

--- a/strings/tips/xeno.txt
+++ b/strings/tips/xeno.txt
@@ -30,3 +30,5 @@ As a xeno, it's not a good idea to kill hosts during the crash phase if they can
 As a xeno, don't take too long attacking during the crash phase. The ship can be rigged to explode in twenty minutes, ending the round in a tie.
 As a xeno, remember that neurotox injected by defilers, sentinels, praetorian, and queen can overdose, killing a marine quickly. Try to avoid this when capturing, if they scream in pain they've probably had enough.
 As a xeno, you can use the crawl through vent verb found in the xeno tab to quickly find and use vents in the floor without having to alt-click them. 
+As a xeno, you can crawl through holes in walls made by acid by clicking on them or click-dragging yourself on them. If you're too big to pass through, you'll damage the wall instead.
+As a xeno, you can climb over window frames by clicking on them or click-dragging yourself on them.


### PR DESCRIPTION
## About The Pull Request

Adds an extra proc simply named Special Click, by default bound to Ctrl, that overrides regular click procs. You can use it for any special item interactions you want without writing your own proc. I was initially going to make it easier to climb over barricades, tables, frames and through acid holes because I think the drag-dropping yourself on them is really fucking annoying and sometimes difficult especially in hectic situations or when the sprite is blocked. Adding this functionality is included. Things like grab-pulling can be reworked to call this and if I'm less lazy in the future maybe I'll put container opening (what happens when you alt-click a container on /tg/ and downstreams) to this or someone else can.

## Why It's Good For The Game

Click-dragging yourself is also clunky, slow and fails half the time especially if there's weeds grown over the frame because the weed sprite takes up most of it.
Framework for future stuff I guess.

## Changelog
:cl:Terranaut
add: Specialclick framework added
tweak: You can now specialclick (default: ctrl) to get over/through waist-high obstacles and through acid holes, or to rip them open.
/:cl:

