### PR TITLE
Minigun Buff

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -98,7 +98,7 @@
 	return ..()
 
 
-/proc/do_after(mob/user, delay, needhand = TRUE, atom/target, user_display, target_display, prog_bar = PROGRESS_GENERIC, datum/callback/extra_checks)
+/proc/do_after(mob/user, delay, needhand = TRUE, atom/target, user_display, target_display, prog_bar = PROGRESS_GENERIC, datum/callback/extra_checks, ignore_turf_checks = FALSE)
 	if(!user)
 		return FALSE
 
@@ -124,12 +124,12 @@
 		stoplag(1)
 		P?.update(world.time - starttime)
 
-		if(QDELETED(user) || user.incapacitated(TRUE) || user.loc != Uloc || (extra_checks && !extra_checks.Invoke()))
+		if(QDELETED(user) || user.incapacitated(TRUE) || (!ignore_turf_checks && user.loc != Uloc) || (extra_checks && !extra_checks.Invoke()))
 			. = FALSE
 			break
 
 		if(!QDELETED(Tloc) && (QDELETED(target) || Tloc != target.loc))
-			if(Uloc != Tloc || Tloc != user)
+			if((!ignore_turf_checks && Uloc != Tloc) || Tloc != user)
 				. = FALSE
 				break
 

--- a/code/datums/components/full_auto_fire.dm
+++ b/code/datums/components/full_auto_fire.dm
@@ -379,7 +379,7 @@
 	if(shooter.action_busy)
 		return FALSE
 	playsound(get_turf(src), 'sound/weapons/guns/fire/tank_minigun_start.ogg', 30)
-	if(!do_after(shooter, 0.4 SECONDS, TRUE, src, BUSY_ICON_DANGER, BUSY_ICON_DANGER,ignore_turf_checks = TRUE))
+	if(!do_after(shooter, 0.4 SECONDS, TRUE, src, BUSY_ICON_DANGER, BUSY_ICON_DANGER, ignore_turf_checks = TRUE))
 		return FALSE
 
 #undef AUTOFIRE_MOUSEUP

--- a/code/datums/components/full_auto_fire.dm
+++ b/code/datums/components/full_auto_fire.dm
@@ -80,7 +80,7 @@
 	autofire_off()
 
 	UnregisterSignal(parent, list(COMSIG_PARENT_QDELETING, COMSIG_ITEM_EQUIPPED))
-	
+
 	autofire_stat = AUTOFIRE_STAT_SLEEPING
 
 
@@ -379,7 +379,7 @@
 	if(shooter.action_busy)
 		return FALSE
 	playsound(get_turf(src), 'sound/weapons/guns/fire/tank_minigun_start.ogg', 30)
-	if(!do_after(shooter, 0.5 SECONDS, TRUE, src, BUSY_ICON_DANGER))
+	if(!do_after(shooter, 0.4 SECONDS, TRUE, src, BUSY_ICON_DANGER, BUSY_ICON_DANGER,ignore_turf_checks = TRUE))
 		return FALSE
 
 #undef AUTOFIRE_MOUSEUP

--- a/code/modules/projectiles/updated_projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/specialist.dm
@@ -970,7 +970,7 @@
 						/obj/item/attachable/flashlight)
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 19,"rail_x" = 10, "rail_y" = 21, "under_x" = 24, "under_y" = 14, "stock_x" = 24, "stock_y" = 12)
 
-	fire_delay = 3
+	fire_delay = 2
 	burst_amount = 7
 	recoil = 2
 	recoil_unwielded = 4
@@ -982,7 +982,7 @@ obj/item/weapon/gun/minigun/Fire(atom/target, mob/living/user, params, reflex = 
 		if(user.action_busy)
 			return
 		playsound(get_turf(src), 'sound/weapons/guns/fire/tank_minigun_start.ogg', 30)
-		if(!do_after(user, 0.5 SECONDS, TRUE, src, BUSY_ICON_DANGER))
+		if(!do_after(user, 0.4 SECONDS, TRUE, src, BUSY_ICON_DANGER, BUSY_ICON_DANGER, ignore_turf_checks = TRUE))
 			return
 	return ..()
 


### PR DESCRIPTION
##  About The Pull Request
The minigun can now be spooled up while moving. (Also added a variable for do_after to extend this to other actions too if coder want.) 
Decreased fire delay of the minigun from 0.3 seconds to 0.2 seconds.
Decreased wind up time of the minigun from 0.5 seconds to 0.4 seconds.
Everyone (marines and xenos) gets a visual notification (Danger Icon) when the minigun winds up.

## Why It's Good For The Game
The minigun class was such a massive meme. In nearly every round I've seen specialists pick it, they pick it because of the armor, and immediately throw out the minigun. The even bigger meme of this case is that Pvts don't even pick it up. My changes should make the minigun more viable and less annoying to use, but still balanced because of how slow it is still.

## Changelog
:cl: BurgerBB
balance: The minigun can now be spooled up while moving. Decreased fire delay of the minigun from 0.3 seconds to 0.2 seconds. Decreased wind up time of the minigun from 0.5 seconds to 0.4 seconds. Everyone (marines and xenos) gets a visual notification (Danger Icon) when the minigun winds up.
/:cl:
