### PR TITLE
Shrike Unrelenting Force now uses plasma

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -145,6 +145,7 @@
 
 
 /datum/action/xeno_action/activable/unrelenting_force/use_ability(atom/target)
+	succeed_activate()
 	add_cooldown()
 	addtimer(CALLBACK(owner, /mob.proc/update_icons), 1 SECONDS)
 	owner.icon_state = "Shrike Screeching"


### PR DESCRIPTION
## About The Pull Request

Fixes #3230

## Why It's Good For The Game


## Changelog
:cl: Hughgent
fix: Shrike Unrelenting Force now uses plasma properly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
