### PR TITLE
Makes the Machete destroy weed nodes in one hit.

### DIFF
--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -167,4 +167,9 @@
 				turfs_to_check += AdjT
 				node_turfs += AdjT
 
+/obj/effect/alien/weeds/node/attacked_by(obj/item/weapon/claymore/mercsword/machete/I, mob/living/user)
+	I.force = 100
+	. = ..()
+	I.force = 40
+
 #undef NODERANGE

--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -168,8 +168,8 @@
 				node_turfs += AdjT
 
 /obj/effect/alien/weeds/node/attacked_by(obj/item/weapon/claymore/mercsword/machete/I, mob/living/user)
-	I.force = 100
+	I.force = 100 //To make it remove all the nodes health in one hit.
 	. = ..()
-	I.force = 40
+	I.force = 40 //To return it to normal amounts of damage.
 
 #undef NODERANGE


### PR DESCRIPTION

## About The Pull Request

Shitcode

## Why It's Good For The Game

Makes the machete a one hit weed node removal tool. as before it was a three hit tool.
When compared to the faster hitting knife (4 hits) it was the sub optimal choice for removing weed nodes.

## Changelog
:cl: Hughgent
tweak: Machete's now remove nodes in one hit.
/:cl:
