### PR TITLE
remove br memes

### DIFF
--- a/code/modules/projectiles/updated_projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/specialist.dm
@@ -310,7 +310,6 @@
 						/obj/item/attachable/bipod,
 						/obj/item/attachable/lasersight,
 						/obj/item/attachable/attached_gun/flamer,
-						/obj/item/attachable/attached_gun/shotgun,
 						/obj/item/attachable/attached_gun/grenade
 						)
 


### PR DESCRIPTION
## About The Pull Request

remove the masterkey from the m4ra

## Why It's Good For The Game

the m4ra has a strange interaction where it's burst makes the masterkey burst making it ZX 2.0,no other gun does this so it's losing the masterkey

## Changelog
:cl:
tweak: removes masterkey from the m4ra
/:cl:

