### PR TITLE
Buffs machete,nerfs weed nodes

### DIFF
--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -119,7 +119,7 @@
 	desc = "A weird, pulsating node."
 	icon_state = "weednode"
 	var/node_range = NODERANGE
-	max_integrity = 100
+	max_integrity = 60
 
 	var/node_turfs = list() // list of all potential turfs that we can expand to
 

--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -35,8 +35,8 @@
 	name = "\improper M2132 machete"
 	desc = "Latest issue of the TGMC Machete. Great for clearing out jungle or brush on outlying colonies. Found commonly in the hands of scouts and trackers, but difficult to carry with the usual kit."
 	icon_state = "machete"
-	force = 40
-	attack_speed = 9
+	force = 60
+	attack_speed = 12
 	w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/weapon/claymore/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)


### PR DESCRIPTION
## About The Pull Request

Makes machete one shot weeds by reducing weeds health and increasing machete damage and attack delay

## Why It's Good For The Game

Machete is quite useless,you need to sacrifice back or belt slot for it,using it against xenos kills you because of acid blood and it needs 3 hits to kill weed nodes,this makes it kill weeds in one hit but it has increased attack delay

~~also makes mjp stop screeching in the discord~~

## Changelog
:cl:
balance: Buffs machete,nerfs weed nodes
/:cl:

