### PR TITLE
Marine Snow Slowdown reduced from +75% move speed penalty to +50% move speed penalty

### DIFF
--- a/code/game/turfs/snow.dm
+++ b/code/game/turfs/snow.dm
@@ -68,15 +68,15 @@
 	if(slayer > 0)
 		if(iscarbon(AM))
 			var/mob/living/carbon/C = AM
-			var/slow_amount = 0.75
+			var/slow_amount = 0.5
 			var/can_stuck = 1
 			if(isxeno(C))
 				slow_amount = 0.25
 				can_stuck = 0
 			C.next_move_slowdown += slow_amount * slayer
-			if(prob(2))
+			if(prob(1))
 				to_chat(C, "<span class='warning'>Moving through [src] slows you down.</span>")
-			else if(can_stuck && slayer == 3 && prob(2))
+			else if(can_stuck && slayer == 3 && prob(1))
 				to_chat(C, "<span class='warning'>You get stuck in [src] for a moment!</span>")
 				C.next_move_slowdown += 10
 	..()


### PR DESCRIPTION
## About The Pull Request
Reduces the move speed penalty for snow from +75% to 50%.
Reduced the chance of someone getting stuck from 2% to 1%.

## Why It's Good For The Game
Given the current xeno meta of "spit at people then run away", snow maps are absolutely terrible, especially on low pop. This PR makes snow maps slightly better by not almost doubling the move delay time.

## Changelog
:cl: BurgerBB
balance: Move delay from snow reduces from 75% to 50%. Chance to get stuck in snow reduced from 2% to 1%.
/:cl:
