### PR TITLE
Gives Hivelord Larva Sting

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/castedatum_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/castedatum_hivelord.dm
@@ -56,6 +56,7 @@
 		/datum/action/xeno_action/activable/secrete_resin/hivelord,
 		/datum/action/xeno_action/activable/transfer_plasma/improved,
 		/datum/action/xeno_action/activable/corrosive_acid,
+		/datum/action/xeno_action/activable/larval_growth_sting,
 		/datum/action/xeno_action/build_tunnel,
 		/datum/action/xeno_action/toggle_speed,
 		/datum/action/xeno_action/toggle_pheromones,


### PR DESCRIPTION
## About The Pull Request

Gives Hivelord Larva Growth Acceleration Sting

## Why It's Good For The Game

Drone is more useful than Hivelord because Hivelord lacks larva growth sting, this fixes that so Hivelord is more of a T2.

## Changelog
:cl:
add: Hivelord Gets Larva Growth Sting.
/:cl: