### PR TITLE
Reverts IS to old storage

### DIFF
--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -127,6 +127,7 @@
 	bypass_w_limit = list()
 	storage_slots = null
 	max_storage_space = 15 // Same as satchel
+	max_w_class = 3
 
 /obj/item/clothing/suit/storage/marine/M3E
 	name = "\improper M3-E pattern marine armor"

--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -124,13 +124,9 @@
 	pockets = /obj/item/storage/internal/suit/marine/M3IS
 
 /obj/item/storage/internal/suit/marine/M3IS
-	bypass_w_limit = list(/obj/item/weapon/gun/,
-						/obj/item/storage/large_holster/machete,
-						/obj/item/weapon/claymore/mercsword/machete)
-	cant_hold = list() //for if you want to not allow certain weapons.
-	storage_slots = 1
-	max_storage_space = 8 // Rifle, stock, extended barrel, grip/bipod.
-	max_w_class = 3 //Can fit larger items
+	bypass_w_limit = list()
+	storage_slots = null
+	max_storage_space = 15 // Same as satchel
 
 /obj/item/clothing/suit/storage/marine/M3E
 	name = "\improper M3-E pattern marine armor"

--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -118,7 +118,7 @@
 
 /obj/item/clothing/suit/storage/marine/M3IS
 	name = "\improper M3-IS pattern marine armor"
-	desc = "A standard Marine M3 Integrated Storage Pattern Chestplate. Increased encumbrance and weapon carrying capacity."
+	desc = "A standard Marine M3 Integrated Storage Pattern Chestplate. Increased encumbrance and storage capacity."
 	icon_state = "4"
 	slowdown = SLOWDOWN_ARMOR_HEAVY
 	pockets = /obj/item/storage/internal/suit/marine/M3IS


### PR DESCRIPTION
## About The Pull Request

Reverts Integrated storage from a weapon slot to old storage space

## Why It's Good For The Game

The weapon slot change was supposed to give IS a purpose but it only made IS even less used,so this is a revert to le old days where medics and engineers worldwide used it to store metal and ungajuice

## Changelog
:cl:
balance: Give Integrated storage armor old storage space back
/:cl:

