### PR TITLE
Tools Pouch to 6 slots

### DIFF
--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -471,7 +471,7 @@
 /obj/item/storage/pouch/tools
 	name = "tools pouch"
 	desc = "It's designed to hold maintenance tools - screwdriver, wrench, cable coil, etc. It also has a hook for an entrenching tool."
-	storage_slots = 5
+	storage_slots = 6
 	max_w_class = 3
 	icon_state = "tools"
 	can_hold = list(


### PR DESCRIPTION
## About The Pull Request

Tools Pouch can now hold 6 items instead of 5.

## Why It's Good For The Game

The tools pouch held 5 tools, meaning that out of the 6 tools and engineer normally uses you would have 1 leave one of them out. This made it extremely awkward to use as you would constantly have to switch to your backpack whenever you would require that single tool.

This is mostly just QOL for engineers and balance wise it only makes using your tools a little quicker if you decide to use the belt slot for something other than a tool belt.

I don't think this will invalidate the tool belt, as an engineer you pretty much need a construction pouch, so if you take the tools pouch you cant take an explosives pouch full of claymores or such. You could just carry those in your backpack, but you could also just carry your tools in there as well.

## Changelog
:cl:
tweak: Tool pouch can hold 6 tools instead of 5
/:cl: