### PR TITLE
you are no longer shot by specifically a military laser bolt

### DIFF
--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -916,7 +916,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 
 
 /datum/ammo/energy/lasgun
-	name = "civilian laser bolt"
+	name = "laser bolt"
 	icon_state = "laser"
 	hud_state = "laser"
 	armor_type = "laser"
@@ -929,11 +929,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	accuracy_var_high = 3
 
 /datum/ammo/energy/lasgun/M43
-	name = "military laser bolt"
 	icon_state = "laser2"
-	hud_state = "laser"
-	damage = 25
-	penetration = 10
 
 /datum/ammo/energy/lasgun/M43/overcharge
 	name = "overcharged laser bolt"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
renames military/civilian laser bolts to just laser bolt and removes the useless vars on military lasers

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
it sounds really dumb that when you get shot its specifically called a military laser bolt

## Changelog
:cl:
spellcheck: military/civilian laser bolts are now just simply laser bolts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
