### PR TITLE
Nerfs permastun memes

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
@@ -54,7 +54,7 @@
 	mechanics_text = "Fling an adjacent target over and behind you. Also works over barricades."
 	ability_name = "crest toss"
 	plasma_cost = 40
-	cooldown_timer = 6 SECONDS
+	cooldown_timer = 18 SECONDS
 	keybind_signal = COMSIG_XENOABILITY_CRESTTOSS
 
 /datum/action/xeno_action/activable/cresttoss/on_cooldown_finish()


### PR DESCRIPTION
## About The Pull Request

Increases crusher crest toss cooldown from 6 seconds to 18 seconds

## Why It's Good For The Game

Do I need to explain why a stun with 6 seconds cooldown is bad

## Changelog
:cl:
balance: Increased crest toss cooldown
/:cl:
