### PR TITLE
Removes hit and run

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/runner.dm
@@ -31,34 +31,6 @@
 // ***************************************
 // *********** Life overrides
 // ***************************************
-/mob/living/carbon/xenomorph/runner/proc/hit_and_run_bonus(datum/source, mob/living/H, damage, list/damage_mod)
-	var/last_move = last_move_intent - 10
-	var/bonus
-	if(last_move && last_move < world.time - 5) //If we haven't moved in the last 500 ms, we lose our bonus
-		hit_and_run = 0
-		return
-	bonus = min(hit_and_run, 1)//Runner deals +5% damage per tile moved in rapid succession to a maximum of +100%. Damage bonus is lost on attacking.
-	switch(bonus)
-		if(1)
-			visible_message("<span class='danger'>\The [src] strikes with lethal speed!</span>", \
-			"<span class='danger'>We strike with lethal speed!</span>")
-		if(0.5 to 0.99)
-			visible_message("<span class='danger'>\The [src] strikes with deadly speed!</span>", \
-			"<span class='danger'>We strike with deadly speed!</span>")
-		if(0.25 to 0.45)
-			visible_message("<span class='danger'>\The [src] strikes with vicious speed!</span>", \
-			"<span class='danger'>We strike with vicious speed!</span>")
-
-	damage_mod += (damage * bonus)
-	hit_and_run = 0 //reset the hit and run bonus
-	return COMSIG_XENOMORPH_BONUS_APPLIED // dont stack our attack with bonus_dam
-
-/mob/living/carbon/xenomorph/runner/handle_status_effects()
-	if(hit_and_run)
-		var/last_move = last_move_intent - 10
-		if(last_move && last_move < world.time - 5) //If we haven't moved in the last 500 ms, we lose our bonus
-			hit_and_run = 0
-	return ..()
 
 /mob/living/carbon/xenomorph/runner/update_stat()
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/runner.dm
@@ -25,9 +25,7 @@
 	. = ..()
 	RegisterSignal(src, list(
 		COMSIG_XENOMORPH_DISARM_HUMAN,
-		COMSIG_XENOMORPH_ATTACK_LIVING),
-		.proc/hit_and_run_bonus)
-
+		COMSIG_XENOMORPH_ATTACK_LIVING)
 // ***************************************
 // *********** Life overrides
 // ***************************************

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -243,9 +243,6 @@
 	if(frenzy_aura)
 		. -= (frenzy_aura * 0.1)
 
-	if(hit_and_run) //We need to have the hit and run ability before we do anything
-		hit_and_run += 0.05 //increment the damage of our next attack by +5%
-
 //Stealth handling
 
 


### PR DESCRIPTION
## About The Pull Request

removes hit and run from runner

## Why It's Good For The Game

It was good when bump melee wasn't a thing,with bump melee you can always get 100% bonus damage by running around

## Changelog
:cl:
removal:removed hit and run
/:cl:
