### PR TITLE
Spitting anything (acid spit, slowdown spit, boiler spit) as a Xeno slows you down for a short time.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -681,7 +681,7 @@
 
 	newspit.fire_at(A, X, null, X.ammo.max_range, X.ammo.shell_speed)
 
-	X.add_slowdown(4) //This can stack.
+	X.add_slowdown(2)
 
 	add_cooldown()
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -681,6 +681,8 @@
 
 	newspit.fire_at(A, X, null, X.ammo.max_range, X.ammo.shell_speed)
 
+	X.add_slowdown(4) //This can stack.
+
 	add_cooldown()
 
 	return succeed_activate()


### PR DESCRIPTION
## About The Pull Request

Spitting anything as a xeno will slow you down for about 2 seconds. The slow effect is based on the game's slow effect, and you will progressively increase in speed as the effect reduces.

## Why It's Good For The Game

Honestly one of the worst things about TGMC right now is the 2 hour rounds that are only 2 hours long because the last few xenos consist of a shrike and two spitters/sentinels. The marines proceed to chase these 3 xenos through the winding ice caves, almost killing one each time, but only to get healed or get away at 25% health because the xenos just spam their short cooldown spit abilities.

The second worst thing about TGMC is those lone sentinels/spitters who repeatedly hide behind a corner, spit at a turret, then go back behind that corner and/or run off into the distance to repeat the process a thousand times over. They don't bother to evolve to boiler because that means they're too weak and important to be alone, which means that they, god forbid, have to work with other xenos.

This is not good gameplay. It's getting extremely stale, especially on crash rounds. Even playing spitter/sentinel doing this, it just feels wrong. Hopefully this PR will be the first of many reworks/buffs/nerfs that prevent the sort of hit and run gameplay that should only be reserved to the hunter/runner/pred castes. 

## Changelog
:cl: BurgerBB
balance: Spitting as xeno slows you down for 2 seconds. The slow's magnitude is reduced when the duration is depleted.
/:cl: