### PR TITLE
Move delay from wearing B18 armor increased from +100% to +115%

### DIFF
--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -235,7 +235,7 @@
 	flags_armor_protection = CHEST|GROIN|ARMS|LEGS|FEET|HANDS
 	flags_cold_protection = CHEST|GROIN|ARMS|LEGS|FEET|HANDS
 	flags_heat_protection = CHEST|GROIN|ARMS|LEGS|FEET|HANDS
-	slowdown = SLOWDOWN_ARMOR_HEAVY
+	slowdown = SLOWDOWN_ARMOR_VERY_HEAVY
 	var/mob/living/carbon/human/wearer = null
 	var/B18_burn_cooldown = null
 	var/B18_oxy_cooldown = null


### PR DESCRIPTION
##  About The Pull Request

Move delay from wearing B18 armor increased from +100% to +115%

## Why It's Good For The Game

B18 Armor makes you a living god. You have a shitload of damage resist and an autodoc system that makes you super tanky. The B18 Armor is my favorite thing in the world but honestly as someone who mains it, I find it absolutely ridiculously overpowered. While it pains me to give it this nerf because I'm always left behind in my armor, I think it's needed to match the sheer protection it gives.

## Changelog
:cl: BurgerBB
balance: Move delay from wearing B18 armor increased from +100% to +115%
/:cl: