### PR TITLE
Supply shuttle runtime fixes

### DIFF
--- a/code/game/objects/machinery/doors/railing.dm
+++ b/code/game/objects/machinery/doors/railing.dm
@@ -10,6 +10,8 @@
 	open_layer = CATWALK_LAYER
 	closed_layer = WINDOW_LAYER
 
+	var/obj/docking_port/mobile/supply/linked_pad
+
 
 /obj/machinery/door/poddoor/railing/opened
 	icon_state = "railing0"
@@ -21,6 +23,14 @@
 	if(dir == SOUTH)
 		closed_layer = ABOVE_MOB_LAYER
 	layer = closed_layer
+
+
+/obj/machinery/door/poddoor/railing/Destroy()
+	if(linked_pad)
+		linked_pad.railings -= src
+		linked_pad = null
+	return ..()
+
 
 /obj/machinery/door/poddoor/railing/CheckExit(atom/movable/O, turf/target)
 	if(!density)

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -51,7 +51,16 @@ GLOBAL_LIST_EMPTY(exports_types)
 	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0)
 	use_ripples = FALSE
 	var/list/gears = list()
-	var/list/railings = list()
+	var/list/obj/machinery/door/poddoor/railing/railings = list()
+
+
+/obj/docking_port/mobile/supply/Destroy(force)
+	for(var/i in railings)
+		var/obj/machinery/door/poddoor/railing/railing = i
+		railing.linked_pad = null
+	railings.Cut()
+	return ..()
+
 
 	//Export categories for this run, this is set by console sending the shuttle.
 //	var/export_categories = EXPORT_CARGO
@@ -91,6 +100,7 @@ GLOBAL_LIST_EMPTY(exports_types)
 	for(var/obj/machinery/door/poddoor/railing/R in GLOB.machines)
 		if(R.id == "supply_elevator_railing")
 			railings += R
+			R.linked_pad = src
 			R.open()
 
 /obj/docking_port/mobile/supply/canMove()


### PR DESCRIPTION
When an explosion deletes railings the port needs to clear up its railings list.