### PR TITLE
Headset camera runtime fix

### DIFF
--- a/code/game/objects/items/radio/headset.dm
+++ b/code/game/objects/items/radio/headset.dm
@@ -164,6 +164,10 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 
 /obj/item/radio/headset/mainship/Initialize()
 	. = ..()
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/item/radio/headset/mainship/LateInitialize(mapload)
+	. = ..()
 	camera = new /obj/machinery/camera/headset(src)
 
 


### PR DESCRIPTION
Trying to guarantee here that the camera exists.

```
[22:15:46] Runtime in facehuggers.dm, line 411: Cannot read null.status
proc name: Attach (/obj/item/clothing/mask/facehugger/proc/Attach)
usr: CKEY/(Ancient Carrier (738))
usr.loc: (Space Port (41, 179, 2))
src: the alien (/obj/item/clothing/mask/facehugger/stasis)
src.loc: the plating (39,179,2) (/turf/open/floor/plating)
call stack:
the alien (/obj/item/clothing/mask/facehugger/stasis): Attach(Maddox Polson (/mob/living/carbon/human))
the alien (/obj/item/clothing/mask/facehugger/stasis): throw impact(Maddox Polson (/mob/living/carbon/human), 1)
the alien (/obj/item/clothing/mask/facehugger/stasis): hit check(1)
(...)
```