### PR TITLE
A major marine victory in crash only requires one authentication disk to be loaded into the nuke.

### DIFF
--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -147,8 +147,8 @@
 	for(var/i in GLOB.xeno_resin_silo_turfs)
 		new /obj/structure/resin/silo(i)
 
-	for(var/i in GLOB.nuke_spawn_locs)
-		new /obj/machinery/nuclearbomb(i)
+	var/obj/machinery/nuclearbomb/NB = new(pick(GLOB.nuke_spawn_locs))
+	NB.require_one_auth = TRUE
 
 	for(var/i in GLOB.shuttle_controls_list)
 		var/obj/machinery/computer/shuttle/shuttle_control/computer_to_disable = i
@@ -179,9 +179,8 @@
 
 /datum/game_mode/crash/announce()
 	to_chat(world, "<span class='round_header'>The current map is - [SSmapping.configs[GROUND_MAP].map_name]!</span>")
-	priority_announce("Scheduled for landing in T-10 Minutes. Prepare for landing. Known hostiles near LZ. Detonation Protocol Active, planet disposable. Marines disposable.", type = ANNOUNCEMENT_PRIORITY)
+	priority_announce("Scheduled for landing in T-10 Minutes. Prepare for landing. Known hostiles near LZ. Detonation Protocol Active, planet disposable. Marines disposable.<br><br>Your objective is the following:<br>1.Locate and obtain a nuclear authentication disk from one of the three terminals located in this area.<br>2. Defend the nuclear authentication terminal as it generates an aunthentication generation program.<br>3. Locate and activate the plantary destruction device.<br>4. Defend the plantary destruction device as it detonates.<br>(Optional) 5. Flee the planet.", type = ANNOUNCEMENT_PRIORITY)
 	playsound(shuttle, 'sound/machines/warning-buzzer.ogg', 75, 0, 30)
-
 
 /datum/game_mode/crash/proc/add_larva()
 	var/datum/hive_status/normal/HS = GLOB.hive_datums[XENO_HIVE_NORMAL]
@@ -410,7 +409,11 @@
 /datum/game_mode/crash/proc/on_nuke_started(obj/machinery/nuclearbomb/nuke)
 	var/datum/hive_status/normal/HS = GLOB.hive_datums[XENO_HIVE_NORMAL]
 	var/area_name = get_area_name(nuke)
+	priority_announce("WARNING. WARNING. Planetary Nuke activated. WARNING. WARNING. Evacuate planet immediately. WARNING. WARNING.", "Priority Alert")
 	HS.xeno_message("An overwhelming wave of dread ripples throughout the hive... A nuke has been activated[area_name ? " in [area_name]":""]!")
+
+	var/sound/S = sound('sound/machines/alarm.ogg',channel = CHANNEL_CINEMATIC)
+	SEND_SOUND(world, S)
 
 /datum/game_mode/crash/proc/play_cinematic(z_level)
 	GLOB.enter_allowed = FALSE

--- a/code/game/objects/machinery/nuclearbomb.dm
+++ b/code/game/objects/machinery/nuclearbomb.dm
@@ -29,6 +29,8 @@
 	var/obj/item/disk/nuclear/green/g_auth
 	var/obj/item/disk/nuclear/blue/b_auth
 
+	var/require_one_auth = FALSE
+
 
 /obj/machinery/nuclearbomb/Initialize()
 	. = ..()
@@ -102,11 +104,10 @@
 			g_auth = I
 		if(/obj/item/disk/nuclear/blue)
 			b_auth = I
-	if(r_auth && g_auth && b_auth)
+	if( (r_auth && g_auth && b_auth) || (require_one_auth && (b_auth || g_auth || b_auth)) )
 		has_auth = TRUE
 
 	updateUsrDialog()
-
 
 /obj/machinery/nuclearbomb/attack_alien(mob/living/carbon/xenomorph/X)
 	if(!(X.xeno_caste.caste_flags & CASTE_IS_INTELLIGENT))


### PR DESCRIPTION

## About The Pull Request

Changes the gamemode so only one disk, and of course the nuke, is needed to blow the planet up.
Marines are notified of their objectives on round start via announcement system.

## Why It's Good For The Game

According to statistics from the World Health Organization, the average marine intelligence is roughly around 10 (Margin of error: 20). Given the local wildlife on most crash scenarios, completing difficult tasks such as defending 3 computer terminals from an near infinite onslaught of xenos (one is literally born every minute) is almost impossible. This PR fixes that so marines don't have to go through a sea of bullshit (See: Spitters, Runners) to take even a single step outside the Canterbury Cream Egg.


## Changelog
:cl: BurgerBB
balance: Reworked crash so you only need one authentication disk to activate the nuclear device.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
