### PR TITLE
Carrier Plasma Tweaks

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
@@ -133,7 +133,7 @@
 	name = "Place hugger trap"
 	action_icon_state = "place_trap"
 	mechanics_text = "Place a hole on weeds that can be filled with a hugger. Activates when a marine steps on it."
-	plasma_cost = 200
+	plasma_cost = 400
 	keybind_signal = COMSIG_XENOABILITY_PLACE_TRAP
 
 /datum/action/xeno_action/place_trap/can_use_action(silent = FALSE, override_flags)
@@ -174,7 +174,7 @@
 	name = "Spawn Facehugger"
 	action_icon_state = "spawn_hugger"
 	mechanics_text = "Spawn a facehugger that is stored on your body."
-	plasma_cost = 100
+	plasma_cost = 200
 	cooldown_timer = 10 SECONDS
 	keybind_signal = COMSIG_XENOABILITY_SPAWN_HUGGER
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/castedatum_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/castedatum_carrier.dm
@@ -20,8 +20,8 @@
 	speed = 0
 
 	// *** Plasma *** //
-	plasma_max = 250
-	plasma_gain = 8
+	plasma_max = 500
+	plasma_gain = 20
 
 	// *** Health *** //
 	max_health = 200
@@ -82,8 +82,8 @@
 	speed = -0.1
 
 	// *** Plasma *** //
-	plasma_max = 300
-	plasma_gain = 10
+	plasma_max = 600
+	plasma_gain = 25
 
 	// *** Health *** //
 	max_health = 220
@@ -118,8 +118,8 @@
 	speed = -0.2
 
 	// *** Plasma *** //
-	plasma_max = 350
-	plasma_gain = 12
+	plasma_max = 700
+	plasma_gain = 30
 
 	// *** Health *** //
 	max_health = 220
@@ -154,8 +154,8 @@
 	speed = -0.3
 
 	// *** Plasma *** //
-	plasma_max = 400
-	plasma_gain = 15
+	plasma_max = 800
+	plasma_gain = 38
 
 	// *** Health *** //
 	max_health = 250


### PR DESCRIPTION
## Carrier plasma tweaks

Carrier gets doubled Plasma storage and resin hole/Spawn Hugger costs twice as much. Plasma regen is +125% of what it was before.

## Why It's Good For The Game

Makes carrier more reliable on it's own and reduces trap spam from drones/queens feeding plasma to the carrier.

## Changelog
:cl:
balance: Carrier plasma regen, storage and costs increased
/:cl:
