### PR TITLE
boiler light gets reset properly on being ahealed

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/boiler.dm
@@ -35,6 +35,7 @@
 // ***************************************
 /mob/living/carbon/xenomorph/boiler/update_stat()
 	. = ..()
+	set_light(BOILER_LUMINOSITY)
 	if(stat == CONSCIOUS)
 		see_in_dark = 20
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -165,6 +165,10 @@
 	. = ..()
 	set_light(0) //Reset lighting
 
+/mob/living/carbon/xenomorph/caste/boiler/ExtinguishMob()
+	. = ..()
+	set_light(BOILER_LUMINOSITY)
+
 /mob/living/proc/update_fire()
 	return
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #3333 

## Why It's Good For The Game

bugs bad

## Changelog
:cl:Terranaut
fix: fixed boilers going dark when ahealed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
