### PR TITLE
Fixes Carrier being able to drop 10 huggers in a group of marines in about a second

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
@@ -7,6 +7,7 @@
 	mechanics_text = "Click once to bring a facehugger into your hand. Click again to ready that facehugger for throwing at a target or tile."
 	ability_name = "throw facehugger"
 	keybind_signal = COMSIG_XENOABILITY_THROW_HUGGER
+	cooldown_timer = 3 SECONDS
 
 /datum/action/xeno_action/activable/throw_hugger/get_cooldown()
 	var/mob/living/carbon/xenomorph/carrier/X = owner

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
@@ -9,6 +9,10 @@
 	keybind_signal = COMSIG_XENOABILITY_THROW_HUGGER
 	cooldown_timer = 3 SECONDS
 
+/datum/action/xeno_action/activable/throw_hugger/get_cooldown()	
+	var/mob/living/carbon/xenomorph/carrier/X = owner	
+	return X.xeno_caste.hugger_delay
+
 /datum/action/xeno_action/activable/throw_hugger/can_use_ability(atom/A, silent = FALSE, override_flags) // true
 	. = ..()
 	if(!.)
@@ -52,7 +56,6 @@
 		F.throw_at(A, CARRIER_HUGGER_THROW_DISTANCE, CARRIER_HUGGER_THROW_SPEED)
 		X.visible_message("<span class='xenowarning'>\The [X] throws something towards \the [A]!</span>", \
 		"<span class='xenowarning'>We throw a facehugger towards \the [A]!</span>")
-		add_cooldown()
 
 /mob/living/carbon/xenomorph/carrier/proc/store_hugger(obj/item/clothing/mask/facehugger/F, message = TRUE, forced = FALSE)
 	if(huggers.len < xeno_caste.huggers_max)

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
@@ -9,7 +9,7 @@
 	keybind_signal = COMSIG_XENOABILITY_THROW_HUGGER
 	cooldown_timer = 3 SECONDS
 
-/datum/action/xeno_action/activable/throw_hugger/can_use_ability(atom/A, silent = FALSE) // true
+/datum/action/xeno_action/activable/throw_hugger/can_use_ability(atom/A, silent = FALSE, override_flags) // true
 	. = ..()
 	if(!.)
 		return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
@@ -9,8 +9,8 @@
 	keybind_signal = COMSIG_XENOABILITY_THROW_HUGGER
 	cooldown_timer = 3 SECONDS
 
-/datum/action/xeno_action/activable/throw_hugger/get_cooldown()	
-	var/mob/living/carbon/xenomorph/carrier/X = owner	
+/datum/action/xeno_action/activable/throw_hugger/get_cooldown()
+	var/mob/living/carbon/xenomorph/carrier/X = owner
 	return X.xeno_caste.hugger_delay
 
 /datum/action/xeno_action/activable/throw_hugger/can_use_ability(atom/A, silent = FALSE, override_flags) // true

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
@@ -9,11 +9,7 @@
 	keybind_signal = COMSIG_XENOABILITY_THROW_HUGGER
 	cooldown_timer = 3 SECONDS
 
-/datum/action/xeno_action/activable/throw_hugger/get_cooldown()
-	var/mob/living/carbon/xenomorph/carrier/X = owner
-	return X.xeno_caste.hugger_delay
-
-/datum/action/xeno_action/activable/throw_hugger/can_use_ability(atom/A, silent = FALSE, override_flags = XACT_IGNORE_COOLDOWN) // true
+/datum/action/xeno_action/activable/throw_hugger/can_use_ability(atom/A, silent = FALSE) // true
 	. = ..()
 	if(!.)
 		return FALSE
@@ -43,6 +39,7 @@
 		X.put_in_active_hand(F)
 		F.GoActive(TRUE)
 		to_chat(X, "<span class='xenonotice'>We grab one of the facehugger in our storage. Now sheltering: [X.huggers.len] / [X.xeno_caste.huggers_max].</span>")
+		add_cooldown()
 		return succeed_activate()
 
 	if(!istype(F)) //something else in our hand


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

3 second cooldown for carriers to pull huggers out of their storage

## Why It's Good For The Game

you know if you've seen it

## Changelog
:cl:Terranaut
balance: 3 Second Cooldown for Carriers taking a Hugger out of storage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
