### PR TITLE
Legacy chat support re-enabled

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -60,6 +60,7 @@ GLOBAL_VAR_INIT(global_unique_id, 1)
 #define DUMMY_HUMAN_SLOT_ADMIN "admintools"
 #define DUMMY_HUMAN_SLOT_MANIFEST "dummy_manifest_generation"
 
+#define CLIENT_FROM_VAR(I) (ismob(I) ? I:client : (istype(I, /client) ? I : (istype(I, /datum/mind) ? I:current?:client : null)))
 
 #define AREASELECT_CORNERA "corner A"
 #define AREASELECT_CORNERB "corner B"
@@ -98,3 +99,6 @@ GLOBAL_VAR_INIT(global_unique_id, 1)
 #else
 #define CHECK_NULL_CLIENT(X) X
 #endif
+
+//Misc text define. Does 4 spaces. Used as a makeshift tabulator.
+#define FOURSPACES "&nbsp;&nbsp;&nbsp;&nbsp;"

--- a/code/controllers/subsystem/chat.dm
+++ b/code/controllers/subsystem/chat.dm
@@ -34,7 +34,7 @@ SUBSYSTEM_DEF(chat)
 	message = replacetext(message, "\proper", "")
 	if(handle_whitespace)
 		message = replacetext(message, "\n", "<br>")
-		message = replacetext(message, "\t", "[GLOB.TAB][GLOB.TAB]")
+		message = replacetext(message, "\t", "[FOURSPACES][FOURSPACES]")
 	message += "<br>"
 
 
@@ -44,28 +44,40 @@ SUBSYSTEM_DEF(chat)
 
 	if(islist(target))
 		for(var/I in target)
-			var/mob/M = I
-			var/client/C = istype(M) ? M.client : I
+			var/client/C = CLIENT_FROM_VAR(I)
 
-			if(!C?.chatOutput?.working || (!C.chatOutput.loaded && length(C.chatOutput.messageQueue) > 25)) //A player who hasn't updated his skin file.
-				SEND_TEXT(C, original_message)
+			if(!C)
+				return
+
+			//Send it to the old style output window.
+			SEND_TEXT(C, original_message)
+
+			if(!C.chatOutput?.working) //A player who hasn't updated his skin file.
 				continue
 
 			if(!C.chatOutput.loaded) //Client still loading, put their messages in a queue
+				if(length(C.chatOutput.messageQueue) > 25)
+					continue
 				C.chatOutput.messageQueue += message
 				continue
 
 			payload[C] += twiceEncoded
 
 	else
-		var/mob/M = target
-		var/client/C = istype(M) ? M.client : target
+		var/client/C = CLIENT_FROM_VAR(target)
 
-		if(!C?.chatOutput?.working || (!C.chatOutput.loaded && length(C.chatOutput.messageQueue) > 25)) //A player who hasn't updated his skin file.
-			SEND_TEXT(C, original_message)
+		if(!C)
+			return
+
+		//Send it to the old style output window.
+		SEND_TEXT(C, original_message)
+
+		if(!C?.chatOutput?.working) //A player who hasn't updated his skin file.
 			return
 
 		if(!C.chatOutput.loaded) //Client still loading, put their messages in a queue
+			if(length(C.chatOutput.messageQueue) > 25)
+				return
 			C.chatOutput.messageQueue += message
 			return
 

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -95,7 +95,7 @@ SUBSYSTEM_DEF(vote)
 			if(length(winners) > 1)
 				text = "<br><b>Vote Tied Between:</b>"
 				for(var/option in winners)
-					text += "<br>[GLOB.TAB][option]"
+					text += "<br>[FOURSPACES][option]"
 			. = pick(winners)
 			text += "<br><b>Vote Result: [.]</b>"
 		else
@@ -263,7 +263,7 @@ SUBSYSTEM_DEF(vote)
 		else
 			. += "<font color='grey'>Restart (Disallowed)</font>"
 		if(admin)
-			. += "[GLOB.TAB](<a href='?_src_=vote;vote=toggle_restart'>[avr ? "Allowed" : "Disallowed"]</a>)"
+			. += "[FOURSPACES](<a href='?_src_=vote;vote=toggle_restart'>[avr ? "Allowed" : "Disallowed"]</a>)"
 		. += "</li><li>"
 
 		var/avm = CONFIG_GET(flag/allow_vote_mode)
@@ -273,7 +273,7 @@ SUBSYSTEM_DEF(vote)
 			. += "<font color='grey'>GameMode (Disallowed)</font>"
 
 		if(admin)
-			. += "[GLOB.TAB](<a href='?_src_=vote;vote=toggle_gamemode'>[avm ? "Allowed" : "Disallowed"]</a>)"
+			. += "[FOURSPACES](<a href='?_src_=vote;vote=toggle_gamemode'>[avm ? "Allowed" : "Disallowed"]</a>)"
 
 		. += "</li><hr>"
 

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -270,83 +270,94 @@
 /client/verb/fix_chat()
 	set name = "Fix chat"
 	set category = "OOC"
-	if (!chatOutput || !istype(chatOutput))
-		var/action = alert(src, "Invalid Chat Output data found!\nRecreate data?", "Wot?", "Recreate Chat Output data", "Cancel")
-		if (action != "Recreate Chat Output data")
+
+	var/action = alert(src, "Select desired action", "Options", "Troubleshoot Goonchat", "Revert to old chat", "Cancel")
+	switch(action)
+		if("Revert to old chat")
+			winset(src, "output", "is-visible=true;is-disabled=false")
+			winset(src, "browseroutput", "is-visible=false")
+			return
+		if("Cancel")
+			return
+
+	if(!istype(chatOutput))
+		action = alert(src, "Invalid Chat Output data found!\nRecreate data?", "Recreate Chat Output data", "Yes", "Cancel")
+		if(action != "Yes")
 			return
 		chatOutput = new /datum/chatOutput(src)
 		chatOutput.start()
-		action = alert(src, "Goon chat reloading, wait a bit and tell me if it's fixed", "", "Fixed", "Nope")
-		if (action == "Fixed")
+		action = alert(src, "Goon chat reloading, wait a bit and state if it's fixed", "Fixed", "Yes", "No")
+		if(action == "Yes")
 			log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by re-creating the chatOutput datum")
-		else
-			chatOutput.load()
-			action = alert(src, "How about now? (give it a moment (it may also try to load twice))", "", "Yes", "No")
-			if (action == "Yes")
-				log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by re-creating the chatOutput datum and forcing a load()")
-			else
-				action = alert(src, "Welp, I'm all out of ideas. Try closing byond and reconnecting.\nWe could also disable fancy chat and re-enable oldchat", "", "Thanks anyways", "Switch to old chat")
-				if (action == "Switch to old chat")
-					winset(src, "output", "is-visible=true;is-disabled=false")
-					winset(src, "browseroutput", "is-visible=false")
-				log_game("GOONCHAT: [key_name(src)] Failed to fix their goonchat window after recreating the chatOutput and forcing a load()")
-
-	else if (chatOutput.loaded)
-		var/action = alert(src, "ChatOutput seems to be loaded\nDo you want me to force a reload, wiping the chat log or just refresh the chat window because it broke/went away?", "Hmmm", "Force Reload", "Refresh", "Cancel")
-		switch (action)
-			if ("Force Reload")
-				chatOutput.loaded = FALSE
-				chatOutput.start() //this is likely to fail since it asks , but we should try it anyways so we know.
-				action = alert(src, "Goon chat reloading, wait a bit and tell me if it's fixed", "", "Fixed", "Nope")
-				if (action == "Fixed")
-					log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by forcing a start()")
-				else
-					chatOutput.load()
-					action = alert(src, "How about now? (give it a moment (it may also try to load twice))", "", "Yes", "No")
-					if (action == "Yes")
-						log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by forcing a load()")
-					else
-						action = alert(src, "Welp, I'm all out of ideas. Try closing byond and reconnecting.\nWe could also disable fancy chat and re-enable oldchat", "", "Thanks anyways", "Switch to old chat")
-						if (action == "Switch to old chat")
-							winset(src, "output", "is-visible=true;is-disabled=false")
-							winset(src, "browseroutput", "is-visible=false")
-						log_game("GOONCHAT: [key_name(src)] Failed to fix their goonchat window forcing a start() and forcing a load()")
-
-			if ("Refresh")
-				chatOutput.showChat()
-				action = alert(src, "Goon chat refreshing, wait a bit and tell me if it's fixed", "", "Fixed", "Nope, force a reload")
-				if (action == "Fixed")
-					log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by forcing a show()")
-				else
-					chatOutput.loaded = FALSE
-					chatOutput.load()
-					action = alert(src, "How about now? (give it a moment)", "", "Yes", "No")
-					if (action == "Yes")
-						log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by forcing a load()")
-					else
-						action = alert(src, "Welp, I'm all out of ideas. Try closing byond and reconnecting.\nWe could also disable fancy chat and re-enable oldchat", "", "Thanks anyways", "Switch to old chat")
-						if (action == "Switch to old chat")
-							winset(src, "output", "is-visible=true;is-disabled=false")
-							winset(src, "browseroutput", "is-visible=false")
-						log_game("GOONCHAT: [key_name(src)] Failed to fix their goonchat window forcing a show() and forcing a load()")
+			return
+		chatOutput.load()
+		action = alert(src, "How about now? (give it a moment (it may also try to load twice))", "Loaded", "Yes", "No")
+		if(action == "Yes")
+			log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by re-creating the chatOutput datum and forcing a load()")
+			return
+		action = alert(src, "Reloading failed. Try closing the game, clearing the Internet Explorer and BYOND caches, and reconnecting.\nWe could also disable fancy chat and re-enable oldchat", "Close or Switch", "Close", "Switch to old chat")
+		if(action == "Switch to old chat")
+			winset(src, "output", "is-visible=true ; is-disabled=false")
+			winset(src, "browseroutput", "is-visible=false")
+		log_game("GOONCHAT: [key_name(src)] Failed to fix their goonchat window after recreating the chatOutput and forcing a load()")
 		return
 
-	else
-		chatOutput.start()
-		var/action = alert(src, "Manually loading Chat, wait a bit and tell me if it's fixed", "", "Fixed", "Nope")
-		if (action == "Fixed")
-			log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by manually calling start()")
-		else
-			chatOutput.load()
-			alert(src, "How about now? (give it a moment (it may also try to load twice))", "", "Yes", "No")
-			if (action == "Yes")
-				log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by manually calling start() and forcing a load()")
-			else
-				action = alert(src, "Welp, I'm all out of ideas. Try closing byond and reconnecting.\nWe could also disable fancy chat and re-enable oldchat", "", "Thanks anyways", "Switch to old chat")
-				if (action == "Switch to old chat")
-					winset(src, "output", list2params(list("on-show" = "", "is-disabled" = "false", "is-visible" = "true")))
-					winset(src, "browseroutput", "is-disabled=true;is-visible=false")
-				log_game("GOONCHAT: [key_name(src)] Failed to fix their goonchat window after manually calling start() and forcing a load()")
+	if(chatOutput.loaded)
+		action = alert(src, "ChatOutput seems to be loaded\nForce a reload, wiping the chat log, or just refresh the chat window because it broke/went away?", "Reload or Refresh", "Force Reload", "Refresh", "Cancel")
+		switch(action)
+			if("Force Reload")
+				chatOutput.loaded = FALSE
+				chatOutput.start() //this is likely to fail since it asks , but we should try it anyways so we know.
+				action = alert(src, "Goon chat reloading, wait a bit and state if it's fixed", "Fixed", "Yes", "No")
+				if(action == "Yes")
+					log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by forcing a start()")
+					return
+				chatOutput.load()
+				action = alert(src, "How about now? (give it a moment (it may also try to load twice))", "Loaded", "Yes", "No")
+				if(action == "Yes")
+					log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by forcing a load()")
+					return
+				action = alert(src, "Reloading failed. Try closing the game, clearing the Internet Explorer and BYOND caches, and reconnecting.\nWe could also disable fancy chat and re-enable oldchat", "Close or Switch", "Close", "Switch to old chat")
+				if(action == "Switch to old chat")
+					winset(src, "output", "is-visible=true ; is-disabled=false")
+					winset(src, "browseroutput", "is-visible=false")
+				log_game("GOONCHAT: [key_name(src)] Failed to fix their goonchat window forcing a start() and forcing a load()")
+				return
+
+			if("Refresh")
+				chatOutput.showChat()
+				action = alert(src, "Goon chat refreshing, wait a bit and state if it's fixed", "Fixed", "Yes", "No, force a reload")
+				if(action == "Yes")
+					log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by forcing a show()")
+					return
+				chatOutput.loaded = FALSE
+				chatOutput.load()
+				action = alert(src, "How about now? (give it a moment)", "Loaded", "Yes", "No")
+				if(action == "Yes")
+					log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by forcing a load()")
+					return
+				action = alert(src, "Reloading failed. Try closing the game, clearing the Internet Explorer and BYOND caches, and reconnecting.\nWe could also disable fancy chat and re-enable oldchat", "Close or Switch", "Close", "Switch to old chat")
+				if(action == "Switch to old chat")
+					winset(src, "output", "is-visible=true;is-disabled=false")
+					winset(src, "browseroutput", "is-visible=false")
+				log_game("GOONCHAT: [key_name(src)] Failed to fix their goonchat window forcing a show() and forcing a load()")
+		return
+
+	chatOutput.start()
+	action = alert(src, "Manually loading Chat, wait a bit and state if it's fixed", "Fixed", "Yes", "No")
+	if(action == "Yes")
+		log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by manually calling start()")
+		return
+	chatOutput.load()
+	action = alert(src, "How about now? (give it a moment)", "Loaded", "Yes", "No")
+	if(action == "Yes")
+		log_game("GOONCHAT: [key_name(src)] Had to fix their goonchat by manually calling start() and forcing a load()")
+		return
+	action = alert(src, "Reloading failed. Try closing the game, clearing the Internet Explorer and BYOND caches, and reconnecting.\nWe could also disable fancy chat and re-enable oldchat", "Close or Switch", "Close", "Switch to old chat")
+	if(action == "Switch to old chat")
+		winset(src, "output", list2params(list("on-show" = "", "is-disabled" = "false", "is-visible" = "true")))
+		winset(src, "browseroutput", "is-disabled=true;is-visible=false")
+	log_game("GOONCHAT: [key_name(src)] Failed to fix their goonchat window after manually calling start() and forcing a load()")
 
 
 /client/verb/update_ping(time as num)


### PR DESCRIPTION
In line with this: https://github.com/tgstation/tgstation/pull/47709

## Changelog
:cl:
add: Legacy chat support re-enabled. It can be set with the Fix Chat verb in the OOC tab. It offers higher performance for low spec computers, at the cost of many features.
/:cl: