### PR TITLE
fixes boiler lights going out after an aheal

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -165,6 +165,10 @@
 	. = ..()
 	set_light(0) //Reset lighting
 
+/mob/living/carbon/xenomorph/caste/boiler/ExtinguishMob()
+	. = ..()
+	set_light(BOILER_LUMINOSITY)
+
 /mob/living/proc/update_fire()
 	return
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -165,7 +165,7 @@
 	. = ..()
 	set_light(0) //Reset lighting
 
-/mob/living/carbon/xenomorph/caste/boiler/ExtinguishMob()
+/mob/living/carbon/xenomorph/boiler/ExtinguishMob()
 	. = ..()
 	set_light(BOILER_LUMINOSITY)
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #3333 without interfering with #3329 

## Why It's Good For The Game

bugfix good

## Changelog
:cl:Terranaut
fix: boilers keep on shining bright after aheal
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
