### PR TITLE
Properly Buffs/Nerfs the LMG

### DIFF
--- a/code/modules/projectiles/updated_projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_attachables.dm
@@ -1259,7 +1259,7 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/bipod
 	name = "bipod"
-	desc = "A simple set of telescopic poles to keep a weapon stabilized during firing. \nGreatly increases accuracy and reduces recoil when properly placed, but also increases weapon size and slows firing speed."
+	desc = "A simple set of telescopic poles to keep a weapon stabilized during firing. \nGreatly increases accuracy and reduces recoil when properly placed, but also increases weapon size."
 	icon_state = "bipod"
 	attach_icon = "bipod_a"
 	slot = "under"
@@ -1279,7 +1279,6 @@ Defined in conflicts.dm of the #defines folder.
 	if(bipod_deployed)
 		bipod_deployed = FALSE
 		to_chat(user, "<span class='notice'>You retract [src].</span>")
-		master_gun.aim_slowdown -= 1
 		master_gun.wield_delay -= 0.4 SECONDS
 		master_gun.accuracy_mult -= deployment_accuracy_mod
 		master_gun.recoil -= deployment_recoil_mod

--- a/code/modules/projectiles/updated_projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/rifles.dm
@@ -378,7 +378,7 @@
 	starting_attachment_types = list(/obj/item/attachable/stock/dmr, /obj/item/attachable/t42barrel,/obj/item/attachable/bipod)
 	gun_skill_category = GUN_SKILL_HEAVY_WEAPONS
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 17,"rail_x" = 10, "rail_y" = 20, "under_x" = 24, "under_y" = 13, "stock_x" = 12, "stock_y" = 12)
-	fire_delay = 0.35 SECONDS
+	fire_delay = 0.3 SECONDS
 	burst_amount = 0
 	accuracy_mult_unwielded = 0.5
 	accuracy_mult = 0.75

--- a/code/modules/projectiles/updated_projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/rifles.dm
@@ -356,7 +356,7 @@
 	max_shells = 120 //codex
 	force = 30
 	slowdown = 0.9
-	aim_slowdown = 0.8
+	aim_slowdown = 0.85
 	wield_delay = 1.4 SECONDS
 	fire_sound =  'sound/weapons/guns/fire/rifle.ogg'
 	dry_fire_sound = 'sound/weapons/guns/fire/m41a_empty.ogg'
@@ -378,7 +378,7 @@
 	starting_attachment_types = list(/obj/item/attachable/stock/dmr, /obj/item/attachable/t42barrel,/obj/item/attachable/bipod)
 	gun_skill_category = GUN_SKILL_HEAVY_WEAPONS
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 17,"rail_x" = 10, "rail_y" = 20, "under_x" = 24, "under_y" = 13, "stock_x" = 12, "stock_y" = 12)
-	fire_delay = 0.3 SECONDS
+	fire_delay = 0.25 SECONDS
 	burst_amount = 0
 	accuracy_mult_unwielded = 0.5
 	accuracy_mult = 0.75

--- a/code/modules/projectiles/updated_projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/rifles.dm
@@ -355,8 +355,8 @@
 	caliber = "10x24mm caseless" //codex
 	max_shells = 120 //codex
 	force = 30
-	slowdown = 0.9
-	aim_slowdown = 0.85
+	slowdown = 0.25
+	aim_slowdown = 0.2
 	wield_delay = 1.4 SECONDS
 	fire_sound =  'sound/weapons/guns/fire/rifle.ogg'
 	dry_fire_sound = 'sound/weapons/guns/fire/m41a_empty.ogg'
@@ -382,7 +382,7 @@
 	burst_amount = 0
 	accuracy_mult_unwielded = 0.5
 	accuracy_mult = 0.75
-	scatter = 35
+	scatter = 25
 	scatter_unwielded = 80
 
 //-------------------------------------------------------

--- a/code/modules/projectiles/updated_projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/rifles.dm
@@ -202,7 +202,7 @@
 	burst_delay = 0.2 SECONDS
 	accuracy_mult = 1.5
 	damage_mult = 1.5
-	scatter = -10	
+	scatter = -10
 
 
 //-------------------------------------------------------
@@ -355,7 +355,8 @@
 	caliber = "10x24mm caseless" //codex
 	max_shells = 120 //codex
 	force = 30
-	aim_slowdown = 0.9
+	slowdown = 0.9
+	aim_slowdown = 0.8
 	wield_delay = 1.4 SECONDS
 	fire_sound =  'sound/weapons/guns/fire/rifle.ogg'
 	dry_fire_sound = 'sound/weapons/guns/fire/m41a_empty.ogg'
@@ -374,18 +375,15 @@
 
 	flags_gun_features = GUN_AUTO_EJECTOR|GUN_AMMO_COUNTER|GUN_LOAD_INTO_CHAMBER
 	gun_firemode_list = list(GUN_FIREMODE_SEMIAUTO, GUN_FIREMODE_AUTOMATIC)
-	starting_attachment_types = list(/obj/item/attachable/stock/dmr, /obj/item/attachable/t42barrel)
+	starting_attachment_types = list(/obj/item/attachable/stock/dmr, /obj/item/attachable/t42barrel,/obj/item/attachable/bipod)
 	gun_skill_category = GUN_SKILL_HEAVY_WEAPONS
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 17,"rail_x" = 10, "rail_y" = 20, "under_x" = 24, "under_y" = 13, "stock_x" = 12, "stock_y" = 12)
-	fire_delay = 0.2 SECONDS
+	fire_delay = 0.35 SECONDS
 	burst_amount = 0
 	accuracy_mult_unwielded = 0.5
-	accuracy_mult = 1.05
-	scatter = 15
+	accuracy_mult = 0.75
+	scatter = 35
 	scatter_unwielded = 80
-	recoil_unwielded = 5
-	damage_mult = 0.85
-
 
 //-------------------------------------------------------
 //M41AE2 Heavy Pulse Rifle
@@ -415,12 +413,12 @@
                         /obj/item/attachable/compensator,
                         /obj/item/attachable/magnetic_harness,
                         /obj/item/attachable/scope)
- 
+
     flags_gun_features = GUN_AUTO_EJECTOR|GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER|GUN_WIELDED_FIRING_ONLY|GUN_LOAD_INTO_CHAMBER
     gun_firemode_list = list(GUN_FIREMODE_SEMIAUTO, GUN_FIREMODE_BURSTFIRE, GUN_FIREMODE_AUTOMATIC, GUN_FIREMODE_AUTOBURST)
     gun_skill_category = GUN_SKILL_HEAVY_WEAPONS
     attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 19,"rail_x" = 10, "rail_y" = 23, "under_x" = 24, "under_y" = 12, "stock_x" = 24, "stock_y" = 14)
- 
+
     fire_delay = 0.4 SECONDS
     burst_amount = 5
     burst_delay = 0.1 SECONDS


### PR DESCRIPTION
## About The Pull Request


(-) LMG fire delay increased from 0.2 seconds to 0.25 seconds.
(-) LMG now slows you by 10% when not aiming.
(-) LMG increased aiming slowdown from 10% to 15%.
(-) LMG accuracy reduced from 1.05 to 0.75.
(-) LMG scatter increased from 15 to 35.
(+) LMG now gets a stock bipod.
(+) LMG damage multiplier increased from 0.85 to 1.
(+) LMG unwelded recoil reduced from 5 to 4.

(+) Removed slowdown from bipod.

## Why It's Good For The Game

The LMG is bad in several ways. Even after the pre-merge nerf, it's just an awfully balance gun for what it is. A damage malus doesn't make any sense at all, and there are other values you can touch that can make it a balanced gun, which is what this PR basically does. My philosophy is that the PFC standard-issue guns should all be pretty much the same in power but exceed in different areas and fail in others. Guns shouldn't be direct upgrades of eachother. The goal here is to make the LMG better than an assault rifle when deployed with a bipod, but weaker when it isn't.

## Changelog
:cl: BurgerBB
balance: Reworks the LMG again.
balance: Removes slowdown from LMG.
/:cl: