### PR TITLE
Removes recoil from all weapons

### DIFF
--- a/code/datums/components/full_auto_fire.dm
+++ b/code/datums/components/full_auto_fire.dm
@@ -359,7 +359,6 @@
 		projectile_to_fire.p_x = text2num(mouse_control["icon-x"])
 	if(mouse_control["icon-y"])
 		projectile_to_fire.p_y = text2num(mouse_control["icon-y"])
-	simulate_recoil(0 , shooter)
 	play_fire_sound(shooter)
 	var/firing_angle = get_angle_with_scatter(shooter, target, get_scatter(projectile_to_fire.scatter, shooter), projectile_to_fire.p_x, projectile_to_fire.p_y)
 	muzzle_flash(firing_angle, shooter)

--- a/code/modules/codex/entries/guns_codex.dm
+++ b/code/modules/codex/entries/guns_codex.dm
@@ -73,8 +73,6 @@
 		traits += "Damage modifier: [((damage_mult - 1) * 100) > 0 ? "+[(damage_mult - 1) * 100]" : "[(damage_mult - 1) * 100]"]%"
 	if(damage_falloff_mult)
 		traits += "Damage falloff: -[damage_falloff_mult] per tile travelled."
-	if(recoil)
-		traits += "Recoil: [recoil]"
 	if(scatter)
 		traits += "Scatter chance modifier: [scatter]%"
 	if(burst_scatter_mult)
@@ -83,8 +81,6 @@
 		traits += "Accuracy modifier: [accuracy_mod * 100]%"
 	if(accuracy_mult_unwielded)
 		traits += "Accuracy unwielded modifier: [((accuracy_mult_unwielded - 1) * 100) > 0 ? "+[(accuracy_mult_unwielded - 1) * 100]" : "[(accuracy_mult_unwielded - 1) * 100]"]%"
-	if(recoil_unwielded)
-		traits += "Recoil Unwielded: [recoil_unwielded]"
 	if(scatter_unwielded)
 		traits += "Unwielded Scatter chance modifier: [scatter_unwielded > 0 ? "+[scatter_unwielded]" : "[scatter_unwielded]"]%"
 	if(movement_acc_penalty_mult)

--- a/code/modules/projectiles/updated_projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_attachables.dm
@@ -153,8 +153,6 @@ Defined in conflicts.dm of the #defines folder.
 		master_gun.modify_burst_delay(burst_delay_mod)
 	if(burst_mod)
 		master_gun.modify_burst_amount(burst_mod, user)
-	master_gun.recoil						+= recoil_mod
-	master_gun.recoil_unwielded				+= recoil_unwielded_mod
 	master_gun.force						+= melee_mod
 	master_gun.aim_slowdown					+= aim_speed_mod
 	master_gun.wield_delay					+= wield_delay_mod
@@ -214,8 +212,6 @@ Defined in conflicts.dm of the #defines folder.
 		master_gun.modify_burst_delay(-burst_delay_mod)
 	if(burst_mod)
 		master_gun.modify_burst_amount(-burst_mod, user)
-	master_gun.recoil						-= recoil_mod
-	master_gun.recoil_unwielded				-= recoil_unwielded_mod
 	master_gun.force						-= melee_mod
 	master_gun.aim_slowdown					-= aim_speed_mod
 	master_gun.wield_delay					-= wield_delay_mod
@@ -1269,8 +1265,7 @@ Defined in conflicts.dm of the #defines folder.
 	flags_attach_features = ATTACH_REMOVABLE|ATTACH_ACTIVATION
 	attachment_action_type = /datum/action/item_action/toggle
 	var/mob/living/master_user
-	var/deployment_accuracy_mod = 0.30
-	var/deployment_recoil_mod = -2
+	var/deployment_accuracy_mod = 0.40
 	var/deployment_scatter_mod = -20
 	var/deployment_burst_scatter_mod = -3
 
@@ -1282,7 +1277,6 @@ Defined in conflicts.dm of the #defines folder.
 		master_gun.aim_slowdown -= 1
 		master_gun.wield_delay -= 0.4 SECONDS
 		master_gun.accuracy_mult -= deployment_accuracy_mod
-		master_gun.recoil -= deployment_recoil_mod
 		master_gun.scatter -= deployment_scatter_mod
 		master_gun.burst_scatter_mult -= deployment_burst_scatter_mod
 		icon_state = "bipod"
@@ -1307,7 +1301,6 @@ Defined in conflicts.dm of the #defines folder.
 		master_gun.aim_slowdown += 1
 		master_gun.wield_delay += 0.4 SECONDS
 		master_gun.accuracy_mult += deployment_accuracy_mod
-		master_gun.recoil += deployment_recoil_mod
 		master_gun.scatter += deployment_scatter_mod
 		master_gun.burst_scatter_mult += deployment_burst_scatter_mod
 		icon_state = "bipod-on"

--- a/code/modules/projectiles/updated_projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/pistols.dm
@@ -99,7 +99,6 @@
 	accuracy_mult = 1.15
 	accuracy_mult_unwielded = 0.85
 	damage_mult = 1.15
-	recoil_unwielded = 2
 
 /obj/item/weapon/gun/pistol/m1911/custom
 	name = "\improper M1911A1 custom pistol"
@@ -211,8 +210,6 @@
 	fire_delay = 0.7 SECONDS
 	scatter_unwielded = 25
 	damage_mult = 1.2
-	recoil = 2
-	recoil_unwielded = 4
 
 /obj/item/weapon/gun/pistol/heavy/gold
 	icon_state = "g_deagle"
@@ -284,8 +281,6 @@
 	attachable_offset = list("muzzle_x" = 32, "muzzle_y" = 20,"rail_x" = 8, "rail_y" = 22, "under_x" = 22, "under_y" = 17, "stock_x" = 22, "stock_y" = 17)
 
 	fire_delay = 1 SECONDS
-	recoil = 2
-	recoil_unwielded = 3
 	accuracy_mult = 1.4
 
 //-------------------------------------------------------
@@ -336,8 +331,6 @@
 
 	fire_delay = 1 SECONDS
 	damage_mult = 1.5
-	recoil = 2
-	recoil_unwielded = 3
 	accuracy_mult = 1.5
 	scatter = 10
 
@@ -376,7 +369,6 @@
 	accuracy_mult = 1.05
 	accuracy_mult_unwielded = 0.95
 	damage_mult = 1.2
-	recoil_unwielded = 2
 
 //-------------------------------------------------------
 //VP78
@@ -402,8 +394,6 @@
 	burst_delay = 0.3 SECONDS
 	accuracy_mult = 1.15
 	accuracy_mult_unwielded = 0.85
-	recoil = 2
-	recoil_unwielded = 3
 
 //-------------------------------------------------------
 /*
@@ -425,8 +415,6 @@ It is a modified Beretta 93R, and can fire three round burst or single fire. Whe
 
 	fire_delay = 0.4 SECONDS
 	burst_amount = 3
-	recoil = 2
-	recoil_unwielded = 3
 
 //-------------------------------------------------------
 //The first rule of monkey pistol is we don't talk about monkey pistol.

--- a/code/modules/projectiles/updated_projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/revolvers.dm
@@ -26,9 +26,6 @@
 	fire_delay = 2
 	accuracy_mult_unwielded = 0.85
 	scatter_unwielded = 25
-	recoil = 2
-	recoil_unwielded = 3
-
 
 /obj/item/weapon/gun/revolver/Initialize()
 	. = ..()
@@ -341,9 +338,6 @@
 	attachable_offset = list("muzzle_x" = 28, "muzzle_y" = 21,"rail_x" = 14, "rail_y" = 23, "under_x" = 24, "under_y" = 19, "stock_x" = 24, "stock_y" = 19)
 
 	damage_mult = 1.05
-	recoil = 0
-	recoil_unwielded = 0
-
 
 //-------------------------------------------------------
 //357 REVOLVER //Based on the generic S&W 357.
@@ -369,8 +363,6 @@
 	attachable_offset = list("muzzle_x" = 30, "muzzle_y" = 19,"rail_x" = 12, "rail_y" = 21, "under_x" = 20, "under_y" = 15, "stock_x" = 20, "stock_y" = 15)
 
 	scatter_unwielded = 20
-	recoil = 0
-	recoil_unwielded = 0
 
 /obj/item/weapon/gun/revolver/small/unique_action(mob/user)
 	return revolver_trick(user)

--- a/code/modules/projectiles/updated_projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/rifles.dm
@@ -16,7 +16,6 @@
 	burst_delay = 0.2 SECONDS
 	accuracy_mult_unwielded = 0.6
 	scatter_unwielded = 40
-	recoil_unwielded = 4
 	damage_falloff_mult = 0.5
 
 
@@ -202,7 +201,7 @@
 	burst_delay = 0.2 SECONDS
 	accuracy_mult = 1.5
 	damage_mult = 1.5
-	scatter = -10	
+	scatter = -10
 
 
 //-------------------------------------------------------
@@ -383,7 +382,6 @@
 	accuracy_mult = 1.05
 	scatter = 15
 	scatter_unwielded = 80
-	recoil_unwielded = 5
 	damage_mult = 0.85
 
 
@@ -415,12 +413,12 @@
                         /obj/item/attachable/compensator,
                         /obj/item/attachable/magnetic_harness,
                         /obj/item/attachable/scope)
- 
+
     flags_gun_features = GUN_AUTO_EJECTOR|GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER|GUN_WIELDED_FIRING_ONLY|GUN_LOAD_INTO_CHAMBER
     gun_firemode_list = list(GUN_FIREMODE_SEMIAUTO, GUN_FIREMODE_BURSTFIRE, GUN_FIREMODE_AUTOMATIC, GUN_FIREMODE_AUTOBURST)
     gun_skill_category = GUN_SKILL_HEAVY_WEAPONS
     attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 19,"rail_x" = 10, "rail_y" = 23, "under_x" = 24, "under_y" = 12, "stock_x" = 24, "stock_y" = 14)
- 
+
     fire_delay = 0.4 SECONDS
     burst_amount = 5
     burst_delay = 0.1 SECONDS
@@ -428,7 +426,6 @@
     accuracy_mult = 1.05
     scatter = 15
     scatter_unwielded = 80
-    recoil_unwielded = 5
 
 
 //-------------------------------------------------------

--- a/code/modules/projectiles/updated_projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/shotguns.dm
@@ -30,9 +30,6 @@ can cause issues with ammo types getting mixed up during the burst.
 	accuracy_mult_unwielded = 0.85
 	scatter = 20
 	scatter_unwielded = 40
-	recoil = 2
-	recoil_unwielded = 4
-
 
 /obj/item/weapon/gun/shotgun/Initialize()
 	. = ..()
@@ -202,9 +199,6 @@ can cause issues with ammo types getting mixed up during the burst.
 	accuracy_mult_unwielded = 0.5
 	scatter = 20
 	scatter_unwielded = 40
-	recoil = 2
-	recoil_unwielded = 4
-
 
 /obj/item/weapon/gun/shotgun/merc/examine_ammo_count(mob/user)
 	if(in_chamber)
@@ -239,9 +233,6 @@ can cause issues with ammo types getting mixed up during the burst.
 	scatter = 20
 	scatter_unwielded = 40
 	damage_mult = 0.75  //normalizing gun for vendors; damage reduced by 25% to compensate for faster fire rate; still higher DPS than M37.
-	recoil = 2
-	recoil_unwielded = 4
-
 
 /obj/item/weapon/gun/shotgun/combat/examine_ammo_count(mob/user)
 	if(in_chamber)
@@ -278,8 +269,6 @@ can cause issues with ammo types getting mixed up during the burst.
 	accuracy_mult_unwielded = 0.85
 	scatter = 20
 	scatter_unwielded = 40
-	recoil = 2
-	recoil_unwielded = 4
 
 /obj/item/weapon/gun/shotgun/double/examine_ammo_count(mob/user)
 	if(current_mag.chamber_closed)
@@ -372,9 +361,6 @@ can cause issues with ammo types getting mixed up during the burst.
 	scatter = 20
 	scatter_unwielded = 40
 	damage_mult = 1.4
-	recoil = 3
-	recoil_unwielded = 5
-
 
 //-------------------------------------------------------
 //PUMP SHOTGUN
@@ -417,8 +403,6 @@ can cause issues with ammo types getting mixed up during the burst.
 	accuracy_mult_unwielded = 0.85
 	scatter = 20
 	scatter_unwielded = 40
-	recoil = 2
-	recoil_unwielded = 4
 	pump_delay = 14
 
 
@@ -522,8 +506,6 @@ can cause issues with ammo types getting mixed up during the burst.
 	accuracy_mult_unwielded = 0.7
 	scatter = 15
 	scatter_unwielded = 40
-	recoil = 2
-	recoil_unwielded = 4
 	pump_delay = 12
 
 //-------------------------------------------------------
@@ -556,8 +538,6 @@ can cause issues with ammo types getting mixed up during the burst.
 	accuracy_mult_unwielded = 1
 	scatter = 15
 	scatter_unwielded = 40
-	recoil = 2
-	recoil_unwielded = 4
 	pump_delay = 12
 
 //------------------------------------------------------
@@ -594,8 +574,6 @@ can cause issues with ammo types getting mixed up during the burst.
 	accuracy_mult_unwielded = 0.7
 	scatter = 15
 	scatter_unwielded = 40
-	recoil = 2
-	recoil_unwielded = 4
 	pump_delay = 12
 	aim_slowdown = 0.5
 
@@ -640,8 +618,6 @@ can cause issues with ammo types getting mixed up during the burst.
 	accuracy_mult_unwielded = 0.7
 	scatter = 15
 	scatter_unwielded = 40
-	recoil = 2
-	recoil_unwielded = 4
 	pump_delay = 6
 
 /obj/item/weapon/gun/shotgun/pump/lever/unique_action(mob/user)

--- a/code/modules/projectiles/updated_projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/smgs.dm
@@ -21,7 +21,6 @@
 
 	fire_delay = 0.3 SECONDS
 	burst_amount = 3
-	recoil_unwielded = 0.5
 
 
 /obj/item/weapon/gun/smg/unique_action(mob/user)

--- a/code/modules/projectiles/updated_projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/specialist.dm
@@ -44,7 +44,6 @@
 	fire_delay = 2.5 SECONDS
 	burst_amount = 1
 	accuracy_mult = 1.50
-	recoil = 2
 
 
 /obj/item/weapon/gun/rifle/sniper/M42A/Initialize()
@@ -236,17 +235,6 @@
 	fire_delay = 2.5 SECONDS
 	accuracy_mult = 1.50
 	scatter = 15
-	recoil = 5
-
-
-/obj/item/weapon/gun/rifle/sniper/elite/simulate_recoil(total_recoil = 0, mob/user)
-	. = ..()
-	if(.)
-		var/mob/living/carbon/human/PMC_sniper = user
-		if(PMC_sniper.lying == 0 && !istype(PMC_sniper.wear_suit,/obj/item/clothing/suit/storage/marine/smartgunner/veteran/PMC) && !istype(PMC_sniper.wear_suit,/obj/item/clothing/suit/storage/marine/veteran))
-			PMC_sniper.visible_message("<span class='warning'>[PMC_sniper] is blown backwards from the recoil of the [src]!</span>","<span class='highdanger'>You are knocked prone by the blowback!</span>")
-			step(PMC_sniper,turn(PMC_sniper.dir,180))
-			PMC_sniper.knock_down(5)
 
 //SVD //Based on the Dragunov sniper rifle.
 
@@ -281,7 +269,6 @@
 	burst_amount = 2
 	accuracy_mult = 0.85
 	scatter = 15
-	recoil = 2
 
 
 
@@ -324,7 +311,6 @@
 	burst_delay = 0.1 SECONDS
 	accuracy_mult = 1.05
 	scatter = 15
-	recoil = 2
 
 //-------------------------------------------------------
 //SMARTGUN
@@ -753,8 +739,6 @@
 	var/datum/effect_system/smoke_spread/smoke
 
 	fire_delay = 1 SECONDS
-	recoil = 3
-
 
 /obj/item/weapon/gun/launcher/rocket/Initialize(mapload, spawn_empty)
 	. = ..()
@@ -971,8 +955,6 @@
 
 	fire_delay = 2
 	burst_amount = 7
-	recoil = 2
-	recoil_unwielded = 4
 	damage_falloff_mult = 0.5
 
 


### PR DESCRIPTION
## About The Pull Request

Recoil doesn't exist anymore. Your screen will no longer shake like a shakeweight:tm: when firing any gun.

## Why It's Good For The Game

Recoil is shit in a 2D spessmans game. This isn't a third person shooter; it's a top down shooter where the recoil system makes absolutely no sense. Recoil shaking should be used in special circumstances only, such as getting hit with something, explosions, or taking damage; not firing a gun.

Also recoil has 0 effect on the performance/damage/accuracy of the gun: it's literally just a cosmetic effect.

## Changelog
:cl: BurgerBB
del: Removes recoil from the game, aka that shitty screenshake you get when you fire a weapon sometimes.
fix: Fixes any and all past, present, and future recoil bugs.
/:cl: