### PR TITLE
Nerfs Hunter Movementspeed

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
@@ -18,7 +18,7 @@
 	tackle_damage = 30
 
 	// *** Speed *** //
-	speed = -1.5
+	speed = -0.8
 
 	// *** Plasma *** //
 	plasma_max = 100
@@ -70,7 +70,7 @@
 	tackle_damage = 35
 
 	// *** Speed *** //
-	speed = -1.6
+	speed = -0.95
 
 	// *** Plasma *** //
 	plasma_max = 150
@@ -101,7 +101,7 @@
 	tackle_damage = 40
 
 	// *** Speed *** //
-	speed = -1.7
+	speed = -1.05
 
 	// *** Plasma *** //
 	plasma_max = 200
@@ -133,7 +133,7 @@
 	tackle_damage = 45
 
 	// *** Speed *** //
-	speed = -1.7
+	speed = -1.1
 
 	// *** Plasma *** //
 	plasma_max = 200


### PR DESCRIPTION

## About The Pull Request

Hunters now have the movement speed of sentinels.

## Why It's Good For The Game

Hunters have a lot of health, a lot of damage, and a lot of movespeed for what they can do. It's an absolute meme seeing them zip around players like a mouse on cocaine while bump slashing them into oblivion with sneak attack memes. This PR removes the amount of "dodge" they have by nerfing their movespeed to that of a sentinel.

## Changelog
:cl: BurgerBB
balance: Hunters are now slower; they move the same as a sentinel.
/:cl: