### PR TITLE
Buckle runtime fix

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -139,26 +139,27 @@
 
 
 /obj/proc/unbuckle(mob/user, silent = TRUE)
-	buckled_mob.buckled = null
-	buckled_mob.anchored = initial(buckled_mob.anchored)
-	buckled_mob.update_canmove()
+	var/mob/buckled_mob_backup = buckled_mob
+	buckled_mob = null
+	buckled_mob_backup.buckled = null
+	buckled_mob_backup.anchored = initial(buckled_mob_backup.anchored)
+	buckled_mob_backup.update_canmove()
 
 	if(!silent)
-		if(buckled_mob == user)
-			buckled_mob.visible_message(
-			"<span class='notice'>[buckled_mob] unbuckled [buckled_mob.p_them()]self!</span>",
+		if(buckled_mob_backup == user)
+			buckled_mob_backup.visible_message(
+			"<span class='notice'>[buckled_mob_backup] unbuckled [buckled_mob_backup.p_them()]self!</span>",
 			"<span class='notice'>You unbuckle yourself from [src].</span>",
 			"<span class='notice'>You hear metal clanking</span>"
 			)
 		else
-			buckled_mob.visible_message(
-			"<span class='notice'>[buckled_mob] was unbuckled by [user]!</span>",
-			"<span class='notice'>You were unbuckled from [src] by [user].</span>",
+			var/by_user = user ? " by [user]" : ""
+			buckled_mob_backup.visible_message(
+			"<span class='notice'>[buckled_mob_backup] was unbuckled[by_user]!</span>",
+			"<span class='notice'>You were unbuckled from [src][by_user]].</span>",
 			"<span class='notice'>You hear metal clanking.</span>"
 			)
 
-	var/buckled_mob_backup = buckled_mob
-	buckled_mob = null
 	UnregisterSignal(buckled_mob_backup, COMSIG_LIVING_DO_RESIST)
 	afterbuckle(buckled_mob_backup)
 


### PR DESCRIPTION
1) The powerloader is destroyed.
2) Unbuckle of the driver is called.
3) `update_canmove()` is called
4) The user falls to the ground and drops the clamp items.
5) The clamp items on drop try to call unbuckle again, as `buckled_mob` hasn't been nulled.
6) Runtime.