### PR TITLE
Removed intentional "cooldowns" for interacting with storage and items

### DIFF
--- a/code/_onclick/human.dm
+++ b/code/_onclick/human.dm
@@ -56,7 +56,6 @@
 		to_chat(src, "<span class='notice'>You try to move your [temp.display_name], but cannot!")
 		return
 
-	changeNext_move(CLICK_CD_MELEE)
 	SEND_SIGNAL(src, COMSIG_HUMAN_MELEE_UNARMED_ATTACK, A)
 	A.attack_hand(src)
 

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -66,12 +66,6 @@
 		. = TRUE
 	take_damage(I.force, I.damtype, "melee")
 
-
-/obj/item/storage/attackby(obj/item/I, mob/user, params)
-	. = ..()
-	user.changeNext_move(CLICK_CD_FASTEST)
-
-
 /mob/living/attackby(obj/item/I, mob/living/user, params)
 	. = ..()
 	if(.)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -161,8 +161,6 @@
 	if(loc == user && !user.temporarilyRemoveItemFromInventory(src))
 		return
 
-	user.changeNext_move(CLICK_CD_RAPID)
-
 	if(QDELETED(src))
 		return
 
@@ -255,7 +253,6 @@
 		UPDATEHEALTH(H)
 		qdel(current_acid)
 		current_acid = null
-	user.changeNext_move(CLICK_CD_RAPID)
 	return
 
 


### PR DESCRIPTION

## About The Pull Request

You were given a cooldown every time you interacted with an item or opened your inventory.  This removes this.
## Why It's Good For The Game

This is really fucking bad game design because it eats your fucking inputs intentionally in the name of """"balance""""

## Changelog
:cl: BurgerBB
balance: Removes click delay for interacting with storage and generic items.
/:cl:
