### PR TITLE
Removes ice colony from rotation

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -19,9 +19,6 @@ endmap
 map bigred_v2
 endmap
 
-map ice_colony_v2
-endmap
-
 map prison_station_fop
 endmap
 


### PR DESCRIPTION
## About The Pull Request

Removes Ice Colony v2 from map rotation.

## Why It's Good For The Game

I used ice colony as a base map, as it was a map created DIRECTLY for TGMC, as an example for Desert Outpost. Funny enough, literally all the criticisms of Desert Outpost apply to Ice Colony, but worse. Doesn't make sense that we don't have consistent mapping standards but here we are.

![image](https://user-images.githubusercontent.com/8602857/68989776-3a56a300-0800-11ea-8d4f-1ffc1eabff4e.png)
![image](https://user-images.githubusercontent.com/8602857/68989777-404c8400-0800-11ea-8b9a-b02c763baa7a.png)
![image](https://user-images.githubusercontent.com/8602857/68989780-47739200-0800-11ea-861a-a7d63f549dbd.png)

Ice Colony is considered a bad map on CM and it's considered a bad map on here. Ice Colony absolutely does not work on a coderbase where the average number of marines playing is 20. This map was clearly designed for 60 or so marines because of its massive size and massive amount of ground to cover. This map is absolutely not new player friendly and even though I've played several rounds of the map and looked at the map file several times, I still get lost moreso than any other map in rotation. Most maps clearly have a marine or xeno bias, but this map's bias is unironically against the player.

if Ice Colony was implemented today in its current state in a PR then there would be at least 100 comments of discussion, requested changes, feedback, and tweaks to get it working to a playable map.

## Changelog
:cl: BurgerBB
del: Removes Ice Colony v2 from rotation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
