### PR TITLE
bodyscanners, autodocs and sleepers now eject their occupants properly when destroyed

### DIFF
--- a/code/game/objects/machinery/Sleeper.dm
+++ b/code/game/objects/machinery/Sleeper.dm
@@ -179,6 +179,7 @@
 	//clean up; end stasis; remove from processing
 	if(occupant)
 		REMOVE_TRAIT(occupant, TRAIT_STASIS, SLEEPER_TRAIT)
+		go_out()
 	occupant = null
 	STOP_PROCESSING(SSobj, src)
 	stop_processing()

--- a/code/game/objects/machinery/adv_med.dm
+++ b/code/game/objects/machinery/adv_med.dm
@@ -57,6 +57,11 @@
 
 	move_inside_wrapper(usr, usr)
 
+/obj/machinery/bodyscanner/Destroy()
+	locked = FALSE
+	go_out()
+	return ..()
+
 /obj/machinery/bodyscanner/proc/go_out()
 	if (!occupant || locked)
 		return

--- a/code/game/objects/machinery/autodoc.dm
+++ b/code/game/objects/machinery/autodoc.dm
@@ -46,6 +46,7 @@
 	var/heal_toxin = 0
 	var/automaticmode = 0
 	var/event = 0
+	var/forceeject = FALSE
 
 	var/obj/machinery/autodoc_console/connected
 
@@ -674,6 +675,10 @@
 		playsound(loc,'sound/machines/buzz-two.ogg', 25, 1)
 		return
 	if(occupant)
+		if(forceeject)
+			visible_message("\The [src] malfunctions as it is destroyed mid-surgery, ejecting [occupant].")
+			occupant.take_limb_damage(rand(30,50),rand(30,50))
+			go_out()
 		if(isxeno(usr) && !surgery) // let xenos eject people hiding inside; a xeno ejecting someone during surgery does so like someone untrained
 			go_out(AUTODOC_NOTICE_XENO_FUCKERY)
 			return
@@ -867,6 +872,11 @@
 	var/mob/living/carbon/human/H = occupant
 	med_scan(H, null, implants, TRUE)
 	start_processing()
+
+obj/machinery/autodoc/Destroy()
+	forceeject = TRUE
+	eject()
+	return ..()
 
 /////////////////////////////////////////////////////////////
 

--- a/code/game/objects/machinery/autodoc.dm
+++ b/code/game/objects/machinery/autodoc.dm
@@ -681,9 +681,11 @@
 				visible_message("\The [src] is destroyed, ejecting [occupant] and showering them in debris.")
 				occupant.take_limb_damage(rand(10,20),rand(10,20))
 				go_out(AUTODOC_NOTICE_FORCE_EJECT)
+				return
 			visible_message("\The [src] malfunctions as it is destroyed mid-surgery, ejecting [occupant] with surgical wounds and showering them in debris.")
 			occupant.take_limb_damage(rand(30,50),rand(30,50))
 			go_out(AUTODOC_NOTICE_FORCE_EJECT)
+			return
 		if(isxeno(usr) && !surgery) // let xenos eject people hiding inside; a xeno ejecting someone during surgery does so like someone untrained
 			go_out(AUTODOC_NOTICE_XENO_FUCKERY)
 			return

--- a/code/game/objects/machinery/autodoc.dm
+++ b/code/game/objects/machinery/autodoc.dm
@@ -4,6 +4,7 @@
 #define AUTODOC_NOTICE_NO_POWER 4
 #define AUTODOC_NOTICE_XENO_FUCKERY 5
 #define AUTODOC_NOTICE_IDIOT_EJECT 6
+#define AUTODOC_NOTICE_FORCE_EJECT 7
 
 #define ADSURGERY_INTERNAL 1
 #define ADSURGERY_GERMS 2
@@ -678,7 +679,7 @@
 		if(forceeject)
 			visible_message("\The [src] malfunctions as it is destroyed mid-surgery, ejecting [occupant].")
 			occupant.take_limb_damage(rand(30,50),rand(30,50))
-			go_out()
+			go_out(AUTODOC_NOTICE_FORCE_EJECT)
 		if(isxeno(usr) && !surgery) // let xenos eject people hiding inside; a xeno ejecting someone during surgery does so like someone untrained
 			go_out(AUTODOC_NOTICE_XENO_FUCKERY)
 			return
@@ -779,6 +780,9 @@
 			if(AUTODOC_NOTICE_IDIOT_EJECT)
 				playsound(src.loc, 'sound/machines/warning-buzzer.ogg', 50, FALSE)
 				reason = "Reason for discharge: Unauthorized manual release during surgery. Alerting security advised."
+			if(AUTODOC_NOTICE_FORCE_EJECT)
+				playsound(src.loc, 'sound/machines/warning-buzzer.ogg', 50, FALSE)
+				reason = "Reason for discharge: Destruction of linked Autodoc Medical System. Alerting security advised."
 		connected.radio.talk_into(src, "<b>Patient: [occupant] has been released from [src] at: [get_area(src)]. [reason]</b>", RADIO_CHANNEL_MEDICAL)
 	occupant = null
 	surgery_todo_list = list()

--- a/code/game/objects/machinery/autodoc.dm
+++ b/code/game/objects/machinery/autodoc.dm
@@ -677,7 +677,11 @@
 		return
 	if(occupant)
 		if(forceeject)
-			visible_message("\The [src] malfunctions as it is destroyed mid-surgery, ejecting [occupant].")
+			if(!surgery)
+				visible_message("\The [src] is destroyed, ejecting [occupant] and showering them in debris.")
+				occupant.take_limb_damage(rand(10,20),rand(10,20))
+				go_out(AUTODOC_NOTICE_FORCE_EJECT)
+			visible_message("\The [src] malfunctions as it is destroyed mid-surgery, ejecting [occupant] with surgical wounds and showering them in debris.")
 			occupant.take_limb_damage(rand(30,50),rand(30,50))
 			go_out(AUTODOC_NOTICE_FORCE_EJECT)
 		if(isxeno(usr) && !surgery) // let xenos eject people hiding inside; a xeno ejecting someone during surgery does so like someone untrained


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #3368 

adds existing go_out or similar procs to the machines' destroy()
adds a forceeject var and related code to the autodoc and adds it to its destroy()

## Why It's Good For The Game

no more yeetus deleetus

## Changelog
:cl:
fix: Fixes Autodoc sending you into the Shadowrealm when destroyed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
