### PR TITLE
Increases medical skill for Squad Leaders, Corpsman, and CMOs by one.

### DIFF
--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -107,7 +107,7 @@
 /datum/skills/combat_medic
 	name = "Combat Medic"
 	leadership = SKILL_LEAD_BEGINNER
-	medical = SKILL_MEDICAL_PRACTICED
+	medical = SKILL_MEDICAL_COMPETENT
 	surgery = SKILL_SURGERY_TRAINED
 
 /datum/skills/combat_medic/crafty
@@ -128,7 +128,7 @@
 	cqc = SKILL_CQC_WEAK
 	firearms = SKILL_FIREARMS_UNTRAINED
 	leadership = SKILL_LEAD_TRAINED
-	medical = SKILL_MEDICAL_EXPERT
+	medical = SKILL_MEDICAL_MASTER
 	surgery = SKILL_SURGERY_EXPERT
 	melee_weapons = SKILL_MELEE_WEAK
 	police = SKILL_POLICE_FLASH
@@ -253,19 +253,14 @@
 	construction = SKILL_CONSTRUCTION_METAL
 	engineer = SKILL_ENGINEER_METAL
 
-
-
-
 /datum/skills/SL
 	name = SQUAD_LEADER
 	cqc = SKILL_CQC_TRAINED
 	construction = SKILL_CONSTRUCTION_PLASTEEL
 	engineer = SKILL_ENGINEER_PLASTEEL
 	leadership = SKILL_LEAD_TRAINED
-	medical = SKILL_MEDICAL_NOVICE
+	medical = SKILL_MEDICAL_PRACTICED
 	surgery = SKILL_SURGERY_AMATEUR
-
-
 
 /datum/skills/SL/upp
 	name = "UPP Leader"


### PR DESCRIPTION

## About The Pull Request

Increased Squad Leader's medical skill.
Increased Corpsman's medical skill.
Increased CMO's medical skill.

Medical Skill Affects:
- Apply Splint Speed
- Injecting Syringe Speed
- Forcefeeding Pill Speed
- Defib "Heal" amount.

It does NOT affect surgery.

## Why It's Good For The Game

SLs should be able to heal people faster as their rank should indicate that they're good at keeping people alive. Corpsman should be slightly stronger in their speed of doing actions given that they're a corpsman, and should be better than an SL at medical. The speed buff to medical healing should be on par with an unga's desire to go back in and fight. CMOs should also be pretty fucking good at medical and be better than any doctor below them.


## Changelog
:cl: BurgerBB
balance: Increases the medical skil by 1 for Squad Leaders, Corpsman, and CMOs.
/:cl:
