### PR TITLE
Acid damage no longer triggers fuel tank explosions

### DIFF
--- a/code/game/objects/structures/reagent_dispensers.dm
+++ b/code/game/objects/structures/reagent_dispensers.dm
@@ -146,12 +146,13 @@
 
 
 /obj/structure/reagent_dispensers/fueltank/bullet_act(obj/item/projectile/Proj)
+
 	if(exploding)
 		return FALSE
 
 	. = ..()
 
-	if(Proj.damage > 10 && prob(60) && (Proj.ammo.damage_type in list(BRUTE, BURN)))
+	if(Proj.damage > 10 && prob(60) && (Proj.ammo.damage_type in list(BRUTE, BURN)) && Proj.ammo.armor_type != "acid")
 		explode()
 
 /obj/structure/reagent_dispensers/fueltank/ex_act()


### PR DESCRIPTION

## About The Pull Request

Acid damage no longer triggers fuel tank explosions.

## Why It's Good For The Game

Fuel tanks are triggered to explode if a brute dealing bullet or a burn dealing bullet hits it. This assume that both sources of the bullet have a high enough heat to combust the fueltank, which is true in 99% of cases. The code thinks that since xeno acid spit deals burn damage, it must be a laser or something hot.

Xenos have been exploiting this recently and bringing fuel tanks to the LZ to destroy barricades and kill marines before the shutters have even opened. It's hilarious but once you consider the situation it's some pretty awful bullshit. This effectively makes this behavior impossible until coders make some sort of flamethrower caste or something idk.

## Changelog
:cl: BurgerBB
fix: Acid dealing projectiles no longer trigger fueltank explosions.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
