### PR TITLE
Fixes the spare vendor dispensing wrong camo helmet

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -691,7 +691,7 @@
 					/obj/item/clothing/suit/storage/marine/M3LB = 10,
 					/obj/item/clothing/suit/storage/marine/M3IS = 10,
 					/obj/item/clothing/suit/storage/marine/harness = 10,
-					/obj/item/clothing/head/helmet/marine = 20,
+					/obj/item/clothing/head/helmet/marine/standard = 20,
 					/obj/item/clothing/head/helmet/marine/heavy = 20,
 					/obj/item/clothing/glasses/mgoggles = 10,
 					/obj/item/clothing/glasses/mgoggles/prescription = 10,


### PR DESCRIPTION
## About The Pull Request

What the title says

## Why It's Good For The Game

Muh colored armor

## Changelog
:cl:
fix: Spare vendors no longer dispense wrong camo helmets.
/:cl:
