### PR TITLE
fixes the megaphone as a xeno translation device.

### DIFF
--- a/code/game/objects/items/megaphone.dm
+++ b/code/game/objects/items/megaphone.dm
@@ -29,7 +29,7 @@
 	message = capitalize(message)
 	user.log_talk(message, LOG_SAY, "(megaphone)")
 	if ((src.loc == user && usr.stat == 0))
-		audible_message("<B>[user]</B> broadcasts, <FONT size=3>\"[message]\"</FONT>")
+		user.send_speech("<FONT size=4>[message]</FONT>", message_language = user.get_default_language())
 
 		spamcheck = TRUE
 		addtimer(VARSET_CALLBACK(src, spamcheck, FALSE), 2 SECONDS)


### PR DESCRIPTION

## About The Pull Request

fixes #3384 
To note, I did not use `say()` because that sanitizes the text and we need the font to be 'big'.

## Why It's Good For The Game

small adjustment and bugfix for the megaphone.

## Changelog
:cl: Hughgent
fix: The megaphone no longer acts as a one way translation device.
/:cl:

![image](https://user-images.githubusercontent.com/45076386/69016450-072d2480-0964-11ea-8cca-ba0ae116137a.png)
