### PR TITLE
"Reworks" the RPG + RPG Ammo

### DIFF
--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -801,12 +801,12 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	shell_speed = 2
 	accuracy = 40
 	accurate_range = 20
-	max_range = 30
+	max_range = 40
 	damage = 50
 	penetration = 80
 
 /datum/ammo/rocket/drop_nade(turf/T)
-	explosion(T, -1, 3, 5, 5)
+	explosion(T, 1, 3, 5, 5)
 
 /datum/ammo/rocket/on_hit_mob(mob/M, obj/item/projectile/P)
 	drop_nade(get_turf(M))
@@ -825,8 +825,9 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	hud_state = "rocket_ap"
 	damage_falloff = 0
 	accurate_range = 15
-	penetration = 150
-	damage = 275
+	penetration = 1000 //IGNORE ALL THE ARMOR
+	damage = 195
+	max_range = 300
 
 /datum/ammo/rocket/ap/drop_nade(turf/T)
 	explosion(T, -1, -1, 2, 5)
@@ -853,12 +854,13 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	accuracy_var_low = 7
 	accurate_range = 15
 	damage = 150
-	max_range = 20
+	max_range = 40
 
 /datum/ammo/rocket/wp/drop_nade(turf/T, radius = 3)
 	if(!T || !isturf(T))
 		return
 	playsound(T, 'sound/weapons/guns/fire/flamethrower2.ogg', 50, 1, 4)
+	explosion(T, -1, 1, 1, 1)
 	flame_radius(radius, T, 27, 27, 27, 17)
 
 /datum/ammo/rocket/wp/quad
@@ -866,7 +868,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	hud_state = "rocket_thermobaric"
 	flags_ammo_behavior = AMMO_ROCKET
 	damage = 200
-	max_range = 30
+	max_range = 50
 
 /datum/ammo/rocket/wp/quad/drop_nade(turf/T, radius = 3)
 	. = ..()

--- a/code/modules/projectiles/updated_projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/specialist.dm
@@ -759,6 +759,8 @@
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 18,"rail_x" = 6, "rail_y" = 19, "under_x" = 19, "under_y" = 14, "stock_x" = 19, "stock_y" = 14)
 	var/datum/effect_system/smoke_spread/smoke
 
+	fire_delay = 1 SECOND
+
 	recoil = 3
 
 

--- a/code/modules/projectiles/updated_projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/specialist.dm
@@ -759,7 +759,7 @@
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 18,"rail_x" = 6, "rail_y" = 19, "under_x" = 19, "under_y" = 14, "stock_x" = 19, "stock_y" = 14)
 	var/datum/effect_system/smoke_spread/smoke
 
-	fire_delay = 1 SECOND
+	fire_delay = 1 SECONDS
 
 	recoil = 3
 

--- a/code/modules/projectiles/updated_projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/specialist.dm
@@ -741,8 +741,15 @@
 	wield_penalty = 1.6 SECONDS
 	aim_slowdown = 1.75
 	attachable_allowed = list(
-						/obj/item/attachable/magnetic_harness,
-						/obj/item/attachable/scope/mini)
+		/obj/item/attachable/angledgrip,
+		/obj/item/attachable/bipod,
+		/obj/item/attachable/flashlight,
+		/obj/item/attachable/scope,
+		/obj/item/attachable/scope/mini,
+		/obj/item/attachable/lasersight,
+		/obj/item/attachable/magnetic_harness,
+		/obj/item/attachable/verticalgrip
+	)
 
 	flags_gun_features = GUN_WIELDED_FIRING_ONLY|GUN_AMMO_COUNTER
 	gun_skill_category = GUN_SKILL_SPEC
@@ -752,7 +759,6 @@
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 18,"rail_x" = 6, "rail_y" = 19, "under_x" = 19, "under_y" = 14, "stock_x" = 19, "stock_y" = 14)
 	var/datum/effect_system/smoke_spread/smoke
 
-	fire_delay = 1 SECONDS
 	recoil = 3
 
 
@@ -771,21 +777,22 @@
 	if(gun_on_cooldown(user))
 		return
 
-	var/delay = 3
+	var/delay = 0
+
 	if(has_attachment(/obj/item/attachable/scope/mini))
 		delay += 3
+
+	else if(has_attachment(/obj/item/attachable/scope))
+		delay += 10
 
 	if(user.mind?.cm_skills && user.mind.cm_skills.spec_weapons < 0)
 		delay += 6
 
-	if(!do_after(user, delay, TRUE, src, BUSY_ICON_DANGER)) //slight wind up
+	if(delay && !do_after(user, delay, TRUE, src, BUSY_ICON_DANGER)) //slight wind up
 		return
 
 	playsound(loc,'sound/weapons/guns/fire/launcher.ogg', 50, 1)
 	. = ..()
-
-
-	//loaded_rocket.current_rounds = max(loaded_rocket.current_rounds - 1, 0)
 
 	if(current_mag && !current_mag.current_rounds)
 		current_mag.loc = get_turf(src)

--- a/code/modules/projectiles/updated_projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/specialist.dm
@@ -741,7 +741,6 @@
 	wield_penalty = 1.6 SECONDS
 	aim_slowdown = 1.75
 	attachable_allowed = list(
-		/obj/item/attachable/angledgrip,
 		/obj/item/attachable/bipod,
 		/obj/item/attachable/flashlight,
 		/obj/item/attachable/scope,


### PR DESCRIPTION

## About The Pull Request
HE Rocket Range increased from 30 to 40.
HE Rockets now have 1 range of "total devastation" which means objects will be destroyed when hit.

AP Rocket armor penetration increased from 150 to 1000.
AP Rocket damage reduced from 275 to 195.
AP Rocket maximum range increased from 30 to 300.

Incin Rockets range increased from 20 to 40.
Incin Rockets create a very small explosion from the impact zone.

Quad Rocket ranged increased from 30 to 50.

Spec RPG base delay reduces from 3 deciseconds to 0 deciseconds.
Spec RPG with a miniscope has a 3 decisecond delay from firing.
Spec RPG with a full scope has a 10 decisecond delay from firing.

Spec RPG can now accept the following attachments:
- Angled Grip
- Bipod
- Flashlight
- Rail Scope
- Mini Rail Scope
- Laser Sight
- Magnetic Harness
- Vertical Grip

## Why It's Good For The Game

Rocket Spec was always a last pick for most specialists. No one likes playing it except for people who tend to try hard with it and only use AP rounds to oneshot the queen, which most players believe is unfair. 90% of maps and situations, the RPG isn't very good. This changes that by effectively expanding the utility and usefulness of the RPG overall, while reducing it's maximum effectiveness.

## Changelog
:cl: BurgerBB
balance: Buffed the RPG. Nerfed AP rockets so it doesn't insta kill queens from full HP.
/:cl: