### PR TITLE
Pyro Backpack Change

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -732,6 +732,7 @@
 	name = "\improper TGMC Pyrotechnician fueltank"
 	desc = "A specialized fueltank worn by TGMC Pyrotechnicians for use with the M240-T incinerator unit. A small general storage compartment is installed."
 	icon_state = "flamethrower_tank"
+	worn_accessible = true
 	max_fuel = 500
 
 

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -732,7 +732,7 @@
 	name = "\improper TGMC Pyrotechnician fueltank"
 	desc = "A specialized fueltank worn by TGMC Pyrotechnicians for use with the M240-T incinerator unit. A small general storage compartment is installed."
 	icon_state = "flamethrower_tank"
-	worn_accessible = true
+	worn_accessible = TRUE
 	max_fuel = 500
 
 


### PR DESCRIPTION

## About The Pull Request

The pyro fuel pack will become satchel access requirements to match its satchel access space. That's it basically. 
## Why It's Good For The Game

Makes it less of a juggle for a pyro to change tanks.
## Changelog
:cl:
tweak: Pyro Fuel Pack is a satchel now
/:cl:

