### PR TITLE
Grenade launcher and similar shoot through MMB or shift+click, instead of ctrl+click

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -159,6 +159,7 @@
 	#define COMPONENT_NO_ATTACK_OBJ 1
 
 #define COMSIG_ITEM_MIDDLECLICKON "item_middleclickon"					//from base of mob/MiddleClickOn(): (/atom, /mob)
+#define COMSIG_ITEM_SHIFTCLICKON "item_shiftclickon"					//from base of mob/ShiftClickOn(): (/atom, /mob)
 	#define COMPONENT_ITEM_CLICKON_BYPASS (1<<0)
 
 // /obj/item/weapon/gun signals

--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -158,8 +158,8 @@
 #define COMSIG_ITEM_ATTACK_OBJ "item_attack_obj"				//from base of obj/item/attack_obj(): (/obj, /mob)
 	#define COMPONENT_NO_ATTACK_OBJ 1
 
-#define COMSIG_ITEM_CLICKCTRLON "item_ctrlclickon"					//from base of mob/CtrlClickOn(): (/atom, /mob)
-	#define COMPONENT_ITEM_CLICKCTRLON_INTERCEPTED (1<<0)				//from base of mob/CtrlClickOn(): (/atom, /mob)
+#define COMSIG_ITEM_MIDDLECLICKON "item_middleclickon"					//from base of mob/MiddleClickOn(): (/atom, /mob)
+	#define COMPONENT_ITEM_CLICKON_BYPASS (1<<0)
 
 // /obj/item/weapon/gun signals
 #define COMSIG_GUN_FIRE "gun_fire"

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -128,8 +128,7 @@
 	if(modifiers["ctrl"] && modifiers["middle"])
 		CtrlMiddleClickOn(A)
 		return
-	if(modifiers["middle"])
-		MiddleClickOn(A)
+	if(modifiers["middle"] && MiddleClickOn(A))		
 		return
 	if(modifiers["shift"] && ShiftClickOn(A))
 		return
@@ -339,7 +338,10 @@
 	Only used for swapping hands
 */
 /mob/proc/MiddleClickOn(atom/A)
-	return
+	var/obj/item/held_thing = get_active_held_item()
+	if(held_thing && SEND_SIGNAL(held_thing, COMSIG_ITEM_MIDDLECLICKON, A, src) & COMPONENT_ITEM_CLICKON_BYPASS)
+		return FALSE
+	return TRUE
 
 
 
@@ -366,9 +368,6 @@
 	For most objects, pull
 */
 /mob/proc/CtrlClickOn(atom/A)
-	var/obj/item/held_thing = get_active_held_item()
-	if(held_thing && SEND_SIGNAL(held_thing, COMSIG_ITEM_CLICKCTRLON, A, src) & COMPONENT_ITEM_CLICKCTRLON_INTERCEPTED)
-		return
 	A.CtrlClick(src)
 
 

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -338,12 +338,24 @@
 	Only used for swapping hands
 */
 /mob/proc/MiddleClickOn(atom/A)
-	var/obj/item/held_thing = get_active_held_item()
-	if(held_thing && SEND_SIGNAL(held_thing, COMSIG_ITEM_MIDDLECLICKON, A, src) & COMPONENT_ITEM_CLICKON_BYPASS)
-		return FALSE
 	return TRUE
 
 
+/mob/living/carbon/human/MiddleClickOn(atom/A)
+	. = ..()
+	if(!middle_mouse_toggle)
+		return
+	var/obj/item/held_thing = get_active_held_item()
+	if(held_thing && SEND_SIGNAL(held_thing, COMSIG_ITEM_MIDDLECLICKON, A, src) & COMPONENT_ITEM_CLICKON_BYPASS)
+		return FALSE
+
+
+/mob/living/carbon/xenomorph/MiddleClickOn(atom/A)
+	. = ..()
+	if(!middle_mouse_toggle || !selected_ability)
+		return
+	if(selected_ability.can_use_ability(A))
+		selected_ability.use_ability(A)
 
 /*
 	Shift click
@@ -357,6 +369,24 @@
 		if(COMSIG_MOB_CLICK_HANDLED)
 			return TRUE
 	return A.ShiftClick(src)
+
+
+/mob/living/carbon/human/ShiftClickOn(atom/A)
+	if(middle_mouse_toggle)
+		return ..()
+	var/obj/item/held_thing = get_active_held_item()
+
+	if(held_thing && SEND_SIGNAL(held_thing, COMSIG_ITEM_SHIFTCLICKON, A, src) & COMPONENT_ITEM_CLICKON_BYPASS)
+		return FALSE
+	return ..()
+
+
+/mob/living/carbon/xenomorph/ShiftClickOn(atom/A)
+	if(!selected_ability || middle_mouse_toggle)
+		return ..()
+	if(selected_ability.can_use_ability(A))
+		selected_ability.use_ability(A)
+	return TRUE
 
 
 /atom/proc/ShiftClick(mob/user)

--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -30,8 +30,7 @@
 	if(modifiers["shift"] && modifiers["ctrl"])
 		CtrlShiftClickOn(A)
 		return
-	if(modifiers["middle"])
-		MiddleClickOn(A)
+	if(modifiers["middle"] && MiddleClickOn(A))
 		return
 	if(modifiers["shift"] && ShiftClickOn(A))
 		return

--- a/code/_onclick/xeno.dm
+++ b/code/_onclick/xeno.dm
@@ -24,19 +24,3 @@
 
 /atom/proc/attack_larva(mob/living/carbon/xenomorph/larva/L)
 	return
-
-
-/mob/living/carbon/xenomorph/MiddleClickOn(atom/A)
-	. = ..()
-	if(!middle_mouse_toggle || !selected_ability)
-		return
-	if(selected_ability.can_use_ability(A))
-		selected_ability.use_ability(A)
-
-
-/mob/living/carbon/xenomorph/ShiftClickOn(atom/A)
-	if(!selected_ability || middle_mouse_toggle)
-		return ..()
-	if(selected_ability.can_use_ability(A))
-		selected_ability.use_ability(A)
-	return TRUE

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -465,7 +465,7 @@
 
 /mob/living/carbon/verb/middle_mousetoggle()
 	set name = "Toggle Middle/Shift Clicking"
-	set desc = "Toggles between using middle mouse click and shift click for selected abilitiy use."
+	set desc = "Toggles between using middle mouse click and shift click for selected ability use."
 	set category = "IC"
 
 	middle_mouse_toggle = !middle_mouse_toggle

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -461,3 +461,15 @@
 
 	to_chat(src, "<span class='xenoannounce'>We are an old xenomorph re-awakened from slumber!</span>")
 	playsound_local(get_turf(src), 'sound/effects/xeno_newlarva.ogg')
+
+
+/mob/living/carbon/verb/middle_mousetoggle()
+	set name = "Toggle Middle/Shift Clicking"
+	set desc = "Toggles between using middle mouse click and shift click for selected abilitiy use."
+	set category = "IC"
+
+	middle_mouse_toggle = !middle_mouse_toggle
+	if(!middle_mouse_toggle)
+		to_chat(src, "<span class='notice'>The selected special ability will now be activated with shift clicking.</span>")
+	else
+		to_chat(src, "<span class='notice'>The selected special ability will now be activated with middle mouse clicking.</span>")

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -44,3 +44,5 @@
 
 	var/afk_timer_id
 	var/afk_status = MOB_DISCONNECTED
+
+	var/middle_mouse_toggle = TRUE //This toggles whether special clicks use middle mouse clicking or shift clicking

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -145,8 +145,6 @@
 	var/upgrade = XENO_UPGRADE_INVALID  //This will track their upgrade level.
 	var/gib_chance = 5 // % chance of them exploding when taking damage. Goes up with damage inflicted.
 
-	var/middle_mouse_toggle = TRUE //This toggles whether selected ability uses middle mouse clicking or shift clicking
-
 	var/datum/armor/armor
 	var/armor_bonus = 0
 	var/armor_pheromone_bonus = 0

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -628,18 +628,6 @@
 	to_chat(src, "<span class='notice'>You have [xeno_mobhud ? "enabled" : "disabled"] the Xeno Status HUD.</span>")
 
 
-/mob/living/carbon/xenomorph/verb/middle_mousetoggle()
-	set name = "Toggle Middle/Shift Clicking"
-	set desc = "Toggles between using middle mouse click and shift click for selected abilitiy use."
-	set category = "Alien"
-
-	middle_mouse_toggle = !middle_mouse_toggle
-	if(!middle_mouse_toggle)
-		to_chat(src, "<span class='notice'>The selected xeno ability will now be activated with shift clicking.</span>")
-	else
-		to_chat(src, "<span class='notice'>The selected xeno ability will now be activated with middle mouse clicking.</span>")
-
-
 /mob/living/carbon/xenomorph/proc/recurring_injection(mob/living/carbon/C, toxin = /datum/reagent/toxin/xeno_neurotoxin, channel_time = XENO_NEURO_CHANNEL_TIME, transfer_amount = XENO_NEURO_AMOUNT_RECURRING, count = 3)
 	if(!C?.can_sting() || !toxin)
 		return FALSE

--- a/code/modules/projectiles/updated_projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_attachables.dm
@@ -263,7 +263,7 @@ Defined in conflicts.dm of the #defines folder.
 /obj/item/attachable/proc/activate_attachment(mob/user, turn_off) //This is for activating stuff like flamethrowers, or switching weapon modes.
 	return
 
-/obj/item/attachable/proc/reload_attachment(obj/item/I, mob/user)
+/obj/item/attachable/proc/reload_attachment(obj/item/I, mob/user, silent)
 	return
 
 /obj/item/attachable/proc/fire_attachment(atom/target,obj/item/weapon/gun/gun, mob/user) //For actually shooting those guns.
@@ -988,26 +988,30 @@ Defined in conflicts.dm of the #defines folder.
 		to_chat(user, "It's empty.")
 
 
-
-
-
-/obj/item/attachable/attached_gun/grenade/reload_attachment(obj/item/explosive/grenade/G, mob/user)
+/obj/item/attachable/attached_gun/grenade/reload_attachment(obj/item/explosive/grenade/G, mob/user, silent)
 	if(!istype(G))
-		to_chat(user, "<span class='warning'>[src] doesn't accept that type of grenade.</span>")
-		return
-	if(!G.active) //can't load live grenades
-		if(!G.underslug_launchable)
+		if(!silent)
 			to_chat(user, "<span class='warning'>[src] doesn't accept that type of grenade.</span>")
-			return
-		if(current_rounds >= max_rounds)
+		return FALSE
+	if(G.active) //can't load live grenades
+		return FALSE
+	if(!G.underslug_launchable)
+		if(!silent)
+			to_chat(user, "<span class='warning'>[src] doesn't accept that type of grenade.</span>")
+		return FALSE
+	if(current_rounds >= max_rounds)
+		if(!silent)
 			to_chat(user, "<span class='warning'>[src] is full.</span>")
-		else
-			playsound(user, 'sound/weapons/guns/interact/shotgun_shell_insert.ogg', 25, 1)
-			current_rounds++
-			loaded_grenades += G.type
-			to_chat(user, "<span class='notice'>You load [G] in [src].</span>")
-			user.temporarilyRemoveItemFromInventory(G)
-			qdel(G)
+		return FALSE
+	playsound(user, 'sound/weapons/guns/interact/shotgun_shell_insert.ogg', 25, 1)
+	current_rounds++
+	loaded_grenades += G.type
+	if(!silent)
+		to_chat(user, "<span class='notice'>You load [G] in [src].</span>")
+	user.temporarilyRemoveItemFromInventory(G)
+	qdel(G)
+	return TRUE
+
 
 /obj/item/attachable/attached_gun/grenade/fire_attachment(atom/target,obj/item/weapon/gun/gun,mob/living/user)
 	. = ..()
@@ -1062,56 +1066,68 @@ Defined in conflicts.dm of the #defines folder.
 	else
 		to_chat(user, "It's empty.")
 
-/obj/item/attachable/attached_gun/flamer/reload_attachment(object, mob/user)
+/obj/item/attachable/attached_gun/flamer/reload_attachment(object, mob/user, silent)
 	if(istype(object, /obj/item/ammo_magazine/flamer_tank))
 		var/obj/item/ammo_magazine/flamer_tank/I = object
 		if(current_rounds >= max_rounds)
-			to_chat(user, "<span class='warning'>[src] is full.</span>")
+			if(!silent)
+				to_chat(user, "<span class='warning'>[src] is full.</span>")
 		else if(I.current_rounds <= 0)
-			to_chat(user, "<span class='warning'>[I] is empty!</span>")
+			if(!silent)
+				to_chat(user, "<span class='warning'>[I] is empty!</span>")
 		else
 			var/transfered_rounds = min(max_rounds - current_rounds, I.current_rounds)
 			current_rounds += transfered_rounds
 			I.current_rounds -= transfered_rounds
 			playsound(user, 'sound/effects/refill.ogg', 25, 1, 3)
-			to_chat(user, "<span class='notice'>You refill [src] with [I].</span>")
+			if(!silent)
+				to_chat(user, "<span class='notice'>You refill [src] with [I].</span>")
 	else if(istype(object, /obj/item/tool/weldpack))
 		var/obj/item/tool/weldpack/FT = object
 		if(current_rounds >= max_rounds)
-			to_chat(user, "<span class='warning'>[src] is full.</span>")
+			if(!silent)
+				to_chat(user, "<span class='warning'>[src] is full.</span>")
 		else if(!FT.reagents.get_reagent_amount(/datum/reagent/fuel))
-			to_chat(user, "<span class='warning'>The [FT] doesn't have any welding fuel!</span>")
+			if(!silent)
+				to_chat(user, "<span class='warning'>The [FT] doesn't have any welding fuel!</span>")
 		else
 			var/transfered_rounds = min(max_rounds - current_rounds, FT.reagents.get_reagent_amount(/datum/reagent/fuel))
 			current_rounds += transfered_rounds
 			FT.reagents.remove_reagent(/datum/reagent/fuel, transfered_rounds)
-			to_chat(user, "<span class='notice'>You refill [src] with [FT].</span>")
+			if(!silent)
+				to_chat(user, "<span class='notice'>You refill [src] with [FT].</span>")
 			playsound(user, 'sound/effects/refill.ogg', 25, 1, 3)
 	else if(istype(object, /obj/item/storage/backpack/marine/engineerpack))
 		var/obj/item/storage/backpack/marine/engineerpack/FT = object
 		if(current_rounds >= max_rounds)
-			to_chat(user, "<span class='warning'>[src] is full.</span>")
+			if(!silent)
+				to_chat(user, "<span class='warning'>[src] is full.</span>")
 		else if(!FT.reagents.get_reagent_amount(/datum/reagent/fuel))
-			to_chat(user, "<span class='warning'>The [FT] doesn't have any welding fuel!</span>")
+			if(!silent)
+				to_chat(user, "<span class='warning'>The [FT] doesn't have any welding fuel!</span>")
 		else
 			var/transfered_rounds = min(max_rounds - current_rounds, FT.reagents.get_reagent_amount(/datum/reagent/fuel))
 			current_rounds += transfered_rounds
 			FT.reagents.remove_reagent(/datum/reagent/fuel, transfered_rounds)
-			to_chat(user, "<span class='notice'>You refill [src] with [FT].</span>")
+			if(!silent)
+				to_chat(user, "<span class='notice'>You refill [src] with [FT].</span>")
 			playsound(user, 'sound/effects/refill.ogg', 25, 1, 3)
 	else if(istype(object, /obj/item/reagent_containers))
 		var/obj/item/reagent_containers/FT = object
 		if(current_rounds >= max_rounds)
-			to_chat(user, "<span class='warning'>[src] is full.</span>")
+			if(!silent)
+				to_chat(user, "<span class='warning'>[src] is full.</span>")
 		else if(!FT.reagents.get_reagent_amount(/datum/reagent/fuel))
-			to_chat(user, "<span class='warning'>The [FT] doesn't have any welding fuel!</span>")
+			if(!silent)
+				to_chat(user, "<span class='warning'>The [FT] doesn't have any welding fuel!</span>")
 		else
 			var/transfered_rounds = min(max_rounds - current_rounds, FT.reagents.get_reagent_amount(/datum/reagent/fuel))
 			current_rounds += transfered_rounds
 			FT.reagents.remove_reagent(/datum/reagent/fuel, transfered_rounds)
-			to_chat(user, "<span class='notice'>You refill [src] with [FT].</span>")
+			if(!silent)
+				to_chat(user, "<span class='notice'>You refill [src] with [FT].</span>")
 			playsound(user, 'sound/effects/refill.ogg', 25, 1, 3)
-	else
+	else if(!silent)
 		to_chat(user, "<span class='warning'>[src] can be refilled only with welding fuel.</span>")
 
 /obj/item/attachable/attached_gun/flamer/fire_attachment(atom/target, obj/item/weapon/gun/gun, mob/living/user)
@@ -1204,23 +1220,25 @@ Defined in conflicts.dm of the #defines folder.
 	else
 		to_chat(user, "It's empty.")
 
-/obj/item/attachable/attached_gun/shotgun/reload_attachment(obj/item/ammo_magazine/handful/mag, mob/user)
+/obj/item/attachable/attached_gun/shotgun/reload_attachment(obj/item/ammo_magazine/handful/mag, mob/user, silent)
 	if(istype(mag) && mag.flags_magazine & AMMUNITION_HANDFUL)
 		if(mag.default_ammo == /datum/ammo/bullet/shotgun/buckshot)
 			if(current_rounds >= max_rounds)
-				to_chat(user, "<span class='warning'>[src] is full.</span>")
+				if(!silent)
+					to_chat(user, "<span class='warning'>[src] is full.</span>")
 			else
 				current_rounds++
 				mag.current_rounds--
 				mag.update_icon()
-				to_chat(user, "<span class='notice'>You load one shotgun shell in [src].</span>")
+				if(!silent)
+					to_chat(user, "<span class='notice'>You load one shotgun shell in [src].</span>")
 				playsound(user, 'sound/weapons/guns/interact/shotgun_shell_insert.ogg', 25, 1)
 				if(mag.current_rounds <= 0)
 					user.temporarilyRemoveItemFromInventory(mag)
 					qdel(mag)
 			return
-	to_chat(user, "<span class='warning'>[src] only accepts shotgun buckshot.</span>")
-
+	if(!silent)
+		to_chat(user, "<span class='warning'>[src] only accepts shotgun buckshot.</span>")
 
 
 /obj/item/attachable/verticalgrip

--- a/code/modules/projectiles/updated_projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_helpers.dm
@@ -206,22 +206,23 @@ should be alright.
 //Attachables & Reloading
 /obj/item/weapon/gun/attackby(obj/item/I, mob/user, params)
 	. = ..()
-	if(flags_gun_features & GUN_BURST_FIRING)
+	if(.)
 		return
 
-	. = ..()
+	if(flags_gun_features & GUN_BURST_FIRING)
+		return
 
 	if(istype(I,/obj/item/attachable) && check_inactive_hand(user))
 		attach_to_gun(user, I)
 		return
 
 	//the active attachment is reloadable
-	if(active_attachable?.flags_attach_features & ATTACH_RELOADABLE && check_inactive_hand(user))
-		active_attachable.reload_attachment(I, user)
+	if(active_attachable?.flags_attach_features & ATTACH_RELOADABLE && check_inactive_hand(user) && active_attachable.reload_attachment(I, user, TRUE))
 		return
 
 	if((istype(I, /obj/item/ammo_magazine) || istype(I, /obj/item/cell/lasgun)) && check_inactive_hand(user))
 		reload(user, I)
+		return
 
 
 //tactical reloads

--- a/code/modules/projectiles/updated_projectiles/gun_system.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_system.dm
@@ -1151,12 +1151,12 @@ and you're good to go.
 		return
 	if(attaching.flags_attach_features & ATTACH_PROJECTILE)
 		return //These are handled through regular Fire() for now.
-	RegisterSignal(src, COMSIG_ITEM_MIDDLECLICKON, .proc/do_fire_attachment) //For weapons with special projectiles not handled via Fire()
+	RegisterSignal(src, list(COMSIG_ITEM_MIDDLECLICKON, COMSIG_ITEM_SHIFTCLICKON), .proc/do_fire_attachment) //For weapons with special projectiles not handled via Fire()
 
 
 /obj/item/weapon/gun/proc/on_gun_attachment_detach(obj/item/attachable/attached_gun/detaching)
 	active_attachable = null
-	UnregisterSignal(src, COMSIG_ITEM_MIDDLECLICKON)
+	UnregisterSignal(src, list(COMSIG_ITEM_MIDDLECLICKON, COMSIG_ITEM_SHIFTCLICKON))
 
 
 /obj/item/weapon/gun/proc/do_fire_attachment(datum/source, atom/target, mob/user)

--- a/code/modules/projectiles/updated_projectiles/gun_system.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_system.dm
@@ -1151,21 +1151,21 @@ and you're good to go.
 		return
 	if(attaching.flags_attach_features & ATTACH_PROJECTILE)
 		return //These are handled through regular Fire() for now.
-	RegisterSignal(src, COMSIG_ITEM_CLICKCTRLON, .proc/do_fire_attachment) //For weapons with special projectiles not handled via Fire()
+	RegisterSignal(src, COMSIG_ITEM_MIDDLECLICKON, .proc/do_fire_attachment) //For weapons with special projectiles not handled via Fire()
 
 
 /obj/item/weapon/gun/proc/on_gun_attachment_detach(obj/item/attachable/attached_gun/detaching)
 	active_attachable = null
-	UnregisterSignal(src, COMSIG_ITEM_CLICKCTRLON)
+	UnregisterSignal(src, COMSIG_ITEM_MIDDLECLICKON)
 
 
 /obj/item/weapon/gun/proc/do_fire_attachment(datum/source, atom/target, mob/user)
-	if(!CHECK_BITFIELD(flags_item, WIELDED))
-		return NONE //By default, let people CTRL+grab others if they are one-handing the weapon.
-	. = COMPONENT_ITEM_CLICKCTRLON_INTERCEPTED
 	if(!able_to_fire(user))
 		return
 	if(gun_on_cooldown(user))
+		return
+	if(!CHECK_BITFIELD(flags_item, WIELDED))
+		to_chat(user, "<span class='warning'>[active_attachable] must be wielded to fire!</span>")
 		return
 	if(active_attachable.current_rounds <= 0)
 		click_empty(user) //If it's empty, let them know.


### PR DESCRIPTION
This is not good code, but I need to do a big gun refactor to do it like I want to, properly.
People were complaining a lot about ctrl+click, so hopefully this is better.

## Changelog
:cl:
tweak: UGLs and similar are now shot once active via middle mouse button or shift click, like xeno abilities, instead of ctrl+click. You can also load and unload rifle magazines while it's active. You can find the option to toggle this in the IC tab instead of the Alien one.
/:cl: