### PR TITLE
Fixes Lasgun Charger double stocking.

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -288,7 +288,14 @@
 
 
 /obj/machinery/vending/lasgun/MouseDrop_T(atom/movable/A, mob/user)
-	. = ..()
+	if(machine_stat & (BROKEN|NOPOWER))
+		return
+
+	if(user.stat || user.restrained() || user.lying)
+		return
+
+	if(get_dist(user, src) > 1 || get_dist(src, A) > 1)
+		return
 
 	var/obj/item/I = A
 	if(istype(I, /obj/item/cell/lasgun))


### PR DESCRIPTION

## About The Pull Request

Fixes #3417 
Unfortunately, `. = ..()` was calling `stock()` the first time and the override was calling it a second time (with special recharge parameters). Both were working just fine, which was the issue.

## Why It's Good For The Game

no more infinite lasers.

## Changelog
:cl: Hughgent
fix: You can no longer get infinite lasgun cells from the lasgun charger.
/:cl:

