### PR TITLE
M240-T to use spec skill

### DIFF
--- a/code/modules/projectiles/updated_projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/flamer.dm
@@ -366,6 +366,7 @@
 	current_mag = /obj/item/ammo_magazine/flamer_tank/large
 	icon_state = "m240t"
 	item_state = "m240t"
+	gun_skill_category = GUN_SKILL_SPEC
 	flags_gun_features = GUN_UNUSUAL_DESIGN|GUN_WIELDED_FIRING_ONLY|GUN_AMMO_COUNTER
 	var/max_water = 200
 	var/last_use


### PR DESCRIPTION

## About The Pull Request

This makes the pyro flamer use specialist skill. 

## Why It's Good For The Game

It's a specialist weapon. It should use the specialist skill, instead of the heavy weapons skill like the regular flamer does. 

## Changelog
:cl:
tweak: M240-T now uses spec skill
/:cl:


