### PR TITLE
Buffs the Range Finder

### DIFF
--- a/code/game/objects/items/binoculars.dm
+++ b/code/game/objects/items/binoculars.dm
@@ -147,7 +147,6 @@
 
 
 	var/turf/TU = get_turf(A)
-	var/area/targ_area = get_area(A)
 	if(!istype(TU))
 		return
 	if(user.action_busy)

--- a/code/game/objects/items/binoculars.dm
+++ b/code/game/objects/items/binoculars.dm
@@ -33,8 +33,7 @@
 
 /obj/item/binoculars/tactical/examine()
 	..()
-	to_chat(usr, "<span class='notice'>They are currently set to [mode ? "range finder" : "CAS marking"] mode.</span>")
-	to_chat(usr, "<span class='notice'>The internal GPS reads: [src.x][src.y].</span>")
+	to_chat(usr, "<span class='notice'>They are currently set to [mode ? "range finder" : "CAS marking"] mode.<br>The internal GPS reads: [src.x][src.y].</span>")
 
 /obj/item/binoculars/tactical/Destroy()
 	if(laser)

--- a/code/game/objects/items/binoculars.dm
+++ b/code/game/objects/items/binoculars.dm
@@ -135,7 +135,7 @@
 
 	var/acquisition_time = target_acquisition_delay
 	if(user.mind.cm_skills)
-		acquisition_time = max(5, acquisition_time - 15*user.mind.cm_skills.leadership)
+		acquisition_time = max(0.5 SECONDS, acquisition_time - 1.5 SECONDS * user.mind.cm_skills.leadership)
 
 	var/datum/squad/S = user.assigned_squad
 

--- a/code/game/objects/items/binoculars.dm
+++ b/code/game/objects/items/binoculars.dm
@@ -150,13 +150,6 @@
 	var/area/targ_area = get_area(A)
 	if(!istype(TU))
 		return
-	var/is_outside = FALSE
-	if(is_ground_level(TU.z))
-		switch(targ_area.ceiling)
-			if(CEILING_NONE)
-				is_outside = TRUE
-			if(CEILING_GLASS)
-				is_outside = TRUE
 	if(user.action_busy)
 		return
 	playsound(src, 'sound/effects/nightvision.ogg', 35)

--- a/code/game/objects/items/binoculars.dm
+++ b/code/game/objects/items/binoculars.dm
@@ -34,6 +34,7 @@
 /obj/item/binoculars/tactical/examine()
 	..()
 	to_chat(usr, "<span class='notice'>They are currently set to [mode ? "range finder" : "CAS marking"] mode.</span>")
+	to_chat(usr, "<span class='notice'>The internal GPS reads: [src.x][src.y].</span>")
 
 /obj/item/binoculars/tactical/Destroy()
 	if(laser)
@@ -134,7 +135,7 @@
 
 	var/acquisition_time = target_acquisition_delay
 	if(user.mind.cm_skills)
-		acquisition_time = max(15, acquisition_time - 25*user.mind.cm_skills.leadership)
+		acquisition_time = max(5, acquisition_time - 15*user.mind.cm_skills.leadership)
 
 	var/datum/squad/S = user.assigned_squad
 
@@ -156,9 +157,6 @@
 				is_outside = TRUE
 			if(CEILING_GLASS)
 				is_outside = TRUE
-	if(!is_outside)
-		to_chat(user, "<span class='warning'>INVALID TARGET: target must be visible from high altitude.</span>")
-		return
 	if(user.action_busy)
 		return
 	playsound(src, 'sound/effects/nightvision.ogg', 35)


### PR DESCRIPTION
## About The Pull Request

The tactical binoculars now has an internal GPS that can be read by examining it.
The tactical binocular acquisition time is now reduced by a second.
The tactical binoculars can now work indoors.


## Why It's Good For The Game

Tactical binoculars were shit. This makes them not shit by buffing how easy it is to get coords now because there is nothing stopping another person from getting the cords another way, such as suit sensors or literally opening the map in the map viewer/editor or preemptively writing down good mortar coordinates.

## Changelog
:cl:
balance: The tactical binoculars now has an internal GPS that can be read via examine, it can now work indoors, and it has a faster acquisition time.
/:cl: