### PR TITLE
Fix crusher exiting turfs

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -141,7 +141,6 @@
 	#define COMPONENT_MOVABLE_PREBUMP_PLOWED		(1<<1)
 	#define COMPONENT_MOVABLE_PREBUMP_ENTANGLED		(1<<2)
 #define COMSIG_MOVABLE_PREBUMP_EXIT_MOVABLE "movable_prebump_exit_movable" //from base of /turf/Exit(): (/atom/movable)
-	#define COMPONENT_MOVABLE_PREBUMP_EXIT_PLOWED	(1<<0)
 #define COMSIG_MOVABLE_UPDATE_GLIDE_SIZE "movable_glide_size"	//from base of /atom/movable/proc/set_glide_size(): (target)
 
 // /turf signals

--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -137,9 +137,11 @@
 #define COMSIG_MOVABLE_CLOSET_DUMPED "movable_closet_dumped"
 #define COMSIG_MOVABLE_PREBUMP_TURF "movable_prebump_turf"
 #define COMSIG_MOVABLE_PREBUMP_MOVABLE "movable_prebump_movable"
-	#define COMPONENT_MOVABLE_PREBUMP_STOPPED		-1
-	#define COMPONENT_MOVABLE_PREBUMP_PLOWED		-2
-	#define COMPONENT_MOVABLE_PREBUMP_ENTANGLED		-3
+	#define COMPONENT_MOVABLE_PREBUMP_STOPPED		(1<<0)
+	#define COMPONENT_MOVABLE_PREBUMP_PLOWED		(1<<1)
+	#define COMPONENT_MOVABLE_PREBUMP_ENTANGLED		(1<<2)
+#define COMSIG_MOVABLE_PREBUMP_EXIT_MOVABLE "movable_prebump_exit_movable" //from base of /turf/Exit(): (/atom/movable)
+	#define COMPONENT_MOVABLE_PREBUMP_EXIT_PLOWED	(1<<0)
 #define COMSIG_MOVABLE_UPDATE_GLIDE_SIZE "movable_glide_size"	//from base of /atom/movable/proc/set_glide_size(): (target)
 
 // /turf signals

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -156,6 +156,8 @@
 		var/atom/movable/thing = i
 		if(!thing.Uncross(mover, newloc))
 			if(thing.flags_atom & ON_BORDER)
+				if(SEND_SIGNAL(mover, COMSIG_MOVABLE_PREBUMP_EXIT_MOVABLE, thing) & COMPONENT_MOVABLE_PREBUMP_EXIT_PLOWED)
+					continue // no longer in the way
 				mover.Bump(thing)
 				return FALSE
 		if(QDELETED(mover))

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -127,13 +127,13 @@
 		var/atom/movable/thing = i
 		if(thing.Cross(mover))
 			continue
-		switch(SEND_SIGNAL(mover, COMSIG_MOVABLE_PREBUMP_MOVABLE, thing))
-			if(COMPONENT_MOVABLE_PREBUMP_STOPPED)
-				return FALSE //Stopped, bump no longer necessary.
-			if(COMPONENT_MOVABLE_PREBUMP_PLOWED)
-				continue //We've plowed through.
-			if(COMPONENT_MOVABLE_PREBUMP_ENTANGLED)
-				return TRUE //We've entered the tile and gotten entangled inside it.
+		var/signalreturn = SEND_SIGNAL(mover, COMSIG_MOVABLE_PREBUMP_MOVABLE, thing)
+		if(signalreturn & COMPONENT_MOVABLE_PREBUMP_STOPPED)
+			return FALSE //Stopped, bump no longer necessary.
+		if(signalreturn & COMPONENT_MOVABLE_PREBUMP_PLOWED)
+			continue //We've plowed through.
+		if(signalreturn & COMPONENT_MOVABLE_PREBUMP_ENTANGLED)
+			return TRUE //We've entered the tile and gotten entangled inside it.
 		if(QDELETED(mover)) //Mover deleted from Cross/CanPass, do not proceed.
 			return FALSE
 		else if(!firstbump || ((thing.layer > firstbump.layer || thing.flags_atom & ON_BORDER) && !(firstbump.flags_atom & ON_BORDER)))
@@ -156,7 +156,10 @@
 		var/atom/movable/thing = i
 		if(!thing.Uncross(mover, newloc))
 			if(thing.flags_atom & ON_BORDER)
-				if(SEND_SIGNAL(mover, COMSIG_MOVABLE_PREBUMP_EXIT_MOVABLE, thing) & COMPONENT_MOVABLE_PREBUMP_EXIT_PLOWED)
+				var/signalreturn = SEND_SIGNAL(mover, COMSIG_MOVABLE_PREBUMP_EXIT_MOVABLE, thing)
+				if(signalreturn & COMPONENT_MOVABLE_PREBUMP_STOPPED)
+					return FALSE
+				if(signalreturn & COMPONENT_MOVABLE_PREBUMP_PLOWED)
 					continue // no longer in the way
 				mover.Bump(thing)
 				return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -237,6 +237,17 @@
 #define PRECRUSH_PLOWED -2
 #define PRECRUSH_ENTANGLED -3
 
+/proc/precrush2signal(precrush)
+	switch(precrush)
+		if(PRECRUSH_STOPPED)
+			return COMPONENT_MOVABLE_PREBUMP_STOPPED
+		if(PRECRUSH_PLOWED)
+			return COMPONENT_MOVABLE_PREBUMP_PLOWED
+		if(PRECRUSH_ENTANGLED)
+			return COMPONENT_MOVABLE_PREBUMP_ENTANGLED
+		else
+			return NONE
+
 // Charge is divided into two acts: before and after the crushed thing taking damage, as that can cause it to be deleted.
 /datum/action/xeno_action/ready_charge/proc/do_crush(datum/source, atom/crushed)
 	var/mob/living/carbon/xenomorph/charger = owner
@@ -274,18 +285,9 @@
 			if(QDELETED(crushed_living))
 				charger.visible_message("<span class='danger'>[charger] anihilates [preserved_name]!</span>",
 				"<span class='xenodanger'>We anihilate [preserved_name]!</span>")
-				return COMPONENT_MOVABLE_PREBUMP_PLOWED|COMPONENT_MOVABLE_PREBUMP_EXIT_PLOWED
-
-		var/postcrush = crushed_living.post_crush_act(charger, src)
-		switch(postcrush)
-			if(PRECRUSH_STOPPED)
-				return COMPONENT_MOVABLE_PREBUMP_STOPPED
-			if(PRECRUSH_PLOWED)
 				return COMPONENT_MOVABLE_PREBUMP_PLOWED
-			if(PRECRUSH_ENTANGLED)
-				return COMPONENT_MOVABLE_PREBUMP_ENTANGLED
-			else
-				return NONE
+
+		return precrush2signal(crushed_living.post_crush_act(charger, src))
 
 	if(isobj(crushed))
 		var/obj/crushed_obj = crushed
@@ -298,9 +300,9 @@
 			if(crushed_behavior & STOP_CRUSHER_ON_DEL)
 				return COMPONENT_MOVABLE_PREBUMP_STOPPED
 			else
-				return COMPONENT_MOVABLE_PREBUMP_PLOWED|COMPONENT_MOVABLE_PREBUMP_EXIT_PLOWED
+				return COMPONENT_MOVABLE_PREBUMP_PLOWED
 
-		return crushed_obj.post_crush_act(charger, src)
+		return precrush2signal(crushed_obj.post_crush_act(charger, src))
 
 	if(isturf(crushed))
 		var/turf/crushed_turf = crushed

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -121,14 +121,14 @@
 
 /datum/action/xeno_action/ready_charge/proc/do_start_crushing()
 	var/mob/living/carbon/xenomorph/charger = owner
-	RegisterSignal(charger, list(COMSIG_MOVABLE_PREBUMP_TURF, COMSIG_MOVABLE_PREBUMP_MOVABLE), .proc/do_crush)
+	RegisterSignal(charger, list(COMSIG_MOVABLE_PREBUMP_TURF, COMSIG_MOVABLE_PREBUMP_MOVABLE, COMSIG_MOVABLE_PREBUMP_EXIT_MOVABLE), .proc/do_crush)
 	charger.is_charging = CHARGE_ON
 	charger.update_icons()
 
 
 /datum/action/xeno_action/ready_charge/proc/do_stop_crushing()
 	var/mob/living/carbon/xenomorph/charger = owner
-	UnregisterSignal(charger, list(COMSIG_MOVABLE_PREBUMP_TURF, COMSIG_MOVABLE_PREBUMP_MOVABLE))
+	UnregisterSignal(charger, list(COMSIG_MOVABLE_PREBUMP_TURF, COMSIG_MOVABLE_PREBUMP_MOVABLE, COMSIG_MOVABLE_PREBUMP_EXIT_MOVABLE))
 	if(valid_steps_taken > 0) //If this is false, then do_stop_momentum() should have it handled already.
 		charger.is_charging = CHARGE_BUILDINGUP
 		charger.update_icons()
@@ -233,6 +233,9 @@
 	else if(valid_steps_taken < steps_for_charge)
 		do_stop_crushing()
 
+#define PRECRUSH_STOPPED -1
+#define PRECRUSH_PLOWED -2
+#define PRECRUSH_ENTANGLED -3
 
 // Charge is divided into two acts: before and after the crushed thing taking damage, as that can cause it to be deleted.
 /datum/action/xeno_action/ready_charge/proc/do_crush(datum/source, atom/crushed)
@@ -244,12 +247,14 @@
 		do_stop_momentum()
 		return COMPONENT_MOVABLE_PREBUMP_STOPPED
 
-	. = crushed.pre_crush_act(charger, src) //Negative values are codes. Positive ones are damage to deal.
-	switch(.)
+	var/precrush = crushed.pre_crush_act(charger, src) //Negative values are codes. Positive ones are damage to deal.
+	switch(precrush)
 		if(null)
 			CRASH("[crushed] returned null from do_crush()")
-		if(COMPONENT_MOVABLE_PREBUMP_STOPPED, COMPONENT_MOVABLE_PREBUMP_PLOWED)
-			return //Already handled, no need to continue.
+		if(PRECRUSH_STOPPED)
+			return COMPONENT_MOVABLE_PREBUMP_STOPPED //Already handled, no need to continue.
+		if(PRECRUSH_PLOWED)
+			return COMPONENT_MOVABLE_PREBUMP_PLOWED
 
 	var/preserved_name = crushed.name
 
@@ -261,36 +266,45 @@
 			crushed_living.buckled.unbuckle()
 		animation_flash_color(crushed_living)
 
-		if(. > 0)
+		if(precrush > 0)
 			log_combat(charger, crushed_living, "xeno charged")
-			crushed_living.apply_damage(., BRUTE, "chest", updating_health = TRUE) //There is a chance to do enough damage here to gib certain mobs. Better update immediately.
+			crushed_living.apply_damage(precrush, BRUTE, "chest", updating_health = TRUE) //There is a chance to do enough damage here to gib certain mobs. Better update immediately.
 			if(QDELETED(crushed_living))
 				charger.visible_message("<span class='danger'>[charger] anihilates [preserved_name]!</span>",
 				"<span class='xenodanger'>We anihilate [preserved_name]!</span>")
-				return COMPONENT_MOVABLE_PREBUMP_PLOWED
+				return COMPONENT_MOVABLE_PREBUMP_PLOWED|COMPONENT_MOVABLE_PREBUMP_EXIT_PLOWED
 
-		return crushed_living.post_crush_act(charger, src)
+		var/postcrush = crushed_living.post_crush_act(charger, src)
+		switch(postcrush)
+			if(PRECRUSH_STOPPED)
+				return COMPONENT_MOVABLE_PREBUMP_STOPPED
+			if(PRECRUSH_PLOWED)
+				return COMPONENT_MOVABLE_PREBUMP_PLOWED
+			if(PRECRUSH_ENTANGLED)
+				return COMPONENT_MOVABLE_PREBUMP_ENTANGLED
+			else
+				return NONE
 
 	if(isobj(crushed))
 		var/obj/crushed_obj = crushed
 		playsound(crushed_obj.loc, "punch", 25, 1)
 		var/crushed_behavior = crushed_obj.crushed_special_behavior()
-		crushed_obj.take_damage(.)
+		crushed_obj.take_damage(precrush)
 		if(QDELETED(crushed_obj))
 			charger.visible_message("<span class='danger'>[charger] crushes [preserved_name]!</span>",
 			"<span class='xenodanger'>We crush [preserved_name]!</span>")
 			if(crushed_behavior & STOP_CRUSHER_ON_DEL)
 				return COMPONENT_MOVABLE_PREBUMP_STOPPED
 			else
-				return COMPONENT_MOVABLE_PREBUMP_PLOWED
+				return COMPONENT_MOVABLE_PREBUMP_PLOWED|COMPONENT_MOVABLE_PREBUMP_EXIT_PLOWED
 
 		return crushed_obj.post_crush_act(charger, src)
 
 	if(isturf(crushed))
 		var/turf/crushed_turf = crushed
-		switch(.)
+		switch(precrush)
 			if(1 to 3)
-				crushed_turf.ex_act(.)
+				crushed_turf.ex_act(precrush)
 
 		if(QDELETED(crushed_turf))
 			charger.visible_message("<span class='danger'>[charger] plows straight through [preserved_name]!</span>",
@@ -355,7 +369,7 @@
 /obj/pre_crush_act(mob/living/carbon/xenomorph/charger, datum/action/xeno_action/ready_charge/charge_datum)
 	if(CHECK_BITFIELD(resistance_flags, INDESTRUCTIBLE) || charger.is_charging < CHARGE_ON)
 		charge_datum.do_stop_momentum()
-		return COMPONENT_MOVABLE_PREBUMP_STOPPED
+		return PRECRUSH_STOPPED
 	if(anchored)
 		if(flags_atom & ON_BORDER)
 			if(dir == REVERSE_DIR(charger.dir))
@@ -391,12 +405,12 @@
 		charge_datum.do_stop_momentum(FALSE)
 		if(!anchored)
 			step(src, charger.dir)
-		return COMPONENT_MOVABLE_PREBUMP_STOPPED
+		return PRECRUSH_STOPPED
 
 	throw_at(get_step(loc, (charger.dir & (NORTH|SOUTH) ? pick(EAST, WEST) : pick(NORTH, SOUTH))), 1, 1, charger, (mob_size < charger.mob_size))
 
 	charge_datum.speed_down(1) //Lose one turf worth of speed.
-	return COMPONENT_MOVABLE_PREBUMP_PLOWED
+	return PRECRUSH_PLOWED
 
 
 /turf/pre_crush_act(mob/living/carbon/xenomorph/charger, datum/action/xeno_action/ready_charge/charge_datum)
@@ -410,7 +424,7 @@
 // ***************************************
 
 /atom/proc/post_crush_act(mob/living/carbon/xenomorph/charger, datum/action/xeno_action/ready_charge/charge_datum)
-	return COMPONENT_MOVABLE_PREBUMP_STOPPED //By default, if this happens then movement stops. But not necessarily.
+	return PRECRUSH_STOPPED //By default, if this happens then movement stops. But not necessarily.
 
 
 /obj/post_crush_act(mob/living/carbon/xenomorph/charger, datum/action/xeno_action/ready_charge/charge_datum)
@@ -419,14 +433,14 @@
 		"<span class='xenowarning'>We ram into [src] and skid to a halt!</span>")
 		if(charger.is_charging > CHARGE_OFF)
 			charge_datum.do_stop_momentum(FALSE)
-		return COMPONENT_MOVABLE_PREBUMP_STOPPED
+		return PRECRUSH_STOPPED
 	var/fling_dir = pick(GLOB.cardinals - ((charger.dir & (NORTH|SOUTH)) ? list(NORTH, SOUTH) : list(EAST, WEST))) //Fling them somewhere not behind nor ahead of the charger.
 	var/fling_dist = min(round(CHARGE_SPEED(charge_datum)) + 1, 3)
 	if(!step(src, fling_dir) && density)
 		charge_datum.do_stop_momentum(FALSE) //Failed to be tossed away and returned, more powerful than ever, to block the charger's path.
 		charger.visible_message("<span class='danger'>[charger] rams into [src] and skids to a halt!</span>",
 			"<span class='xenowarning'>We ram into [src] and skid to a halt!</span>")
-		return COMPONENT_MOVABLE_PREBUMP_STOPPED
+		return PRECRUSH_STOPPED
 	if(--fling_dist)
 		for(var/i in 1 to fling_dist)
 			if(!step(src, fling_dir))
@@ -434,7 +448,7 @@
 	charger.visible_message("<span class='warning'>[charger] knocks [src] aside.</span>!",
 	"<span class='xenowarning'>We knock [src] aside.</span>") //Canisters, crates etc. go flying.
 	charge_datum.speed_down(2) //Lose two turfs worth of speed.
-	return COMPONENT_MOVABLE_PREBUMP_PLOWED
+	return PRECRUSH_PLOWED
 
 
 /obj/structure/razorwire/post_crush_act(mob/living/carbon/xenomorph/charger, datum/action/xeno_action/ready_charge/charge_datum)
@@ -448,7 +462,7 @@
 	UPDATEHEALTH(charger)
 	playsound(src, 'sound/effects/barbed_wire_movement.ogg', 25, 1)
 	update_icon()
-	return COMPONENT_MOVABLE_PREBUMP_ENTANGLED //Let's return this so that the charger may enter the turf in where it's entangled, if it survived the wounds without gibbing.
+	return PRECRUSH_ENTANGLED //Let's return this so that the charger may enter the turf in where it's entangled, if it survived the wounds without gibbing.
 
 
 /obj/structure/mineral_door/post_crush_act(mob/living/carbon/xenomorph/charger, datum/action/xeno_action/ready_charge/charge_datum)
@@ -456,10 +470,10 @@
 		return ..()
 	TryToSwitchState(charger)
 	if(density)
-		return COMPONENT_MOVABLE_PREBUMP_STOPPED
+		return PRECRUSH_STOPPED
 	charger.visible_message("<span class='danger'>[charger] slams [src] open!</span>",
 	"<span class='xenowarning'>We slam [src] open!</span>")
-	return COMPONENT_MOVABLE_PREBUMP_PLOWED
+	return PRECRUSH_PLOWED
 
 
 /obj/machinery/vending/post_crush_act(mob/living/carbon/xenomorph/charger, datum/action/xeno_action/ready_charge/charge_datum)
@@ -467,10 +481,10 @@
 		return ..()
 	tip_over()
 	if(density)
-		return COMPONENT_MOVABLE_PREBUMP_STOPPED
+		return PRECRUSH_STOPPED
 	charger.visible_message("<span class='danger'>[charger] slams [src] into the ground!</span>",
 	"<span class='xenowarning'>We slam [src] into the ground!</span>")
-	return COMPONENT_MOVABLE_PREBUMP_PLOWED
+	return PRECRUSH_PLOWED
 
 
 /mob/living/post_crush_act(mob/living/carbon/xenomorph/charger, datum/action/xeno_action/ready_charge/charge_datum)
@@ -479,7 +493,7 @@
 		"<span class='xenowarning'>We ram into [src] and skid to a halt!</span>")
 		charge_datum.do_stop_momentum(FALSE)
 		step(src, charger.dir)
-		return COMPONENT_MOVABLE_PREBUMP_STOPPED
+		return PRECRUSH_STOPPED
 
 	switch(charge_datum.charge_type)
 		if(CHARGE_CRUSH)
@@ -491,7 +505,7 @@
 		charge_datum.do_stop_momentum(FALSE)
 		charger.visible_message("<span class='danger'>[charger] rams into [src] and skids to a halt!</span>",
 			"<span class='xenowarning'>We ram into [src] and skid to a halt!</span>")
-		return COMPONENT_MOVABLE_PREBUMP_STOPPED
+		return PRECRUSH_STOPPED
 
 	switch(charge_datum.charge_type)
 		if(CHARGE_CRUSH, CHARGE_BULL)
@@ -511,7 +525,7 @@
 			charger.visible_message("<span class='danger'>[charger] rams [src]!</span>",
 			"<span class='xenodanger'>We ram [src]!</span>")
 			charge_datum.speed_down(1) //Lose one turf worth of speed.
-			return COMPONENT_MOVABLE_PREBUMP_PLOWED
+			return PRECRUSH_PLOWED
 
 		if(CHARGE_BULL_GORE)
 			if(world.time > charge_datum.next_special_attack)
@@ -542,7 +556,7 @@
 				"<span class='xenowarning'>We ram into [src] and skid to a halt!</span>")
 
 	charge_datum.do_stop_momentum(FALSE)
-	return COMPONENT_MOVABLE_PREBUMP_STOPPED
+	return PRECRUSH_STOPPED
 
 
 /mob/living/proc/emote_gored()
@@ -573,3 +587,7 @@
 #undef CHARGE_MAX_SPEED
 
 #undef STOP_CRUSHER_ON_DEL
+
+#undef PRECRUSH_STOPPED
+#undef PRECRUSH_PLOWED
+#undef PRECRUSH_ENTANGLED

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -255,6 +255,8 @@
 			return COMPONENT_MOVABLE_PREBUMP_STOPPED //Already handled, no need to continue.
 		if(PRECRUSH_PLOWED)
 			return COMPONENT_MOVABLE_PREBUMP_PLOWED
+		if(PRECRUSH_ENTANGLED)
+			. = COMPONENT_MOVABLE_PREBUMP_ENTANGLED
 
 	var/preserved_name = crushed.name
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
turf/Exit() was always returning false on bumping on border atom/movable

Fixes #3443

## Changelog
:cl:
fix: crushers now properly hit barricades from behind
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
