### PR TITLE
Ert changes

### DIFF
--- a/code/datums/emergency_calls/deathsquad.dm
+++ b/code/datums/emergency_calls/deathsquad.dm
@@ -1,6 +1,6 @@
 /datum/emergency_call/deathsquad
 	name = "Deathsquad"
-	probability = 0
+	probability = 5
 	shuttle_id = "distress_pmc"
 
 

--- a/code/datums/emergency_calls/freelancers.dm
+++ b/code/datums/emergency_calls/freelancers.dm
@@ -1,6 +1,6 @@
 /datum/emergency_call/freelancers
 	name = "Freelancers"
-	probability = 25
+	probability = 30
 
 
 /datum/emergency_call/freelancers/print_backstory(mob/living/carbon/human/H)

--- a/code/datums/emergency_calls/pizza.dm
+++ b/code/datums/emergency_calls/pizza.dm
@@ -1,7 +1,7 @@
 /datum/emergency_call/pizza
 	name = "Pizza Delivery"
 	mob_max = 3
-	probability = 0
+	probability = 5
 
 /datum/emergency_call/pizza/print_backstory(mob/living/carbon/human/H)
 	to_chat(H, "<B>You are a pizza deliverer who's employed by the Zippy Pizza Corporation.</b>")

--- a/code/datums/emergency_calls/pmc.dm
+++ b/code/datums/emergency_calls/pmc.dm
@@ -1,6 +1,6 @@
 /datum/emergency_call/pmc
 	name = "PMC"
-	probability = 25
+	probability = 15
 	shuttle_id = "distress_pmc"
 
 
@@ -41,7 +41,7 @@
 		to_chat(H, "<span class='notice'>You are the leader of this Nanotrasen contractor team in responding to the TGMC distress signal sent out nearby. Address the situation and get your team to safety!</span>")
 		return
 
-	if(prob(50))
+	if(prob(30))
 		var/datum/job/J = SSjob.GetJobType(/datum/job/pmc/gunner)
 		SSjob.AssignRole(H, J.title)
 		J.assign_equip(H)

--- a/code/datums/emergency_calls/sonsofmars.dm
+++ b/code/datums/emergency_calls/sonsofmars.dm
@@ -1,7 +1,7 @@
 //Sons of Mars
 /datum/emergency_call/som
 	name = "SOM"
-	probability = 20
+	probability = 15
 
 
 /datum/emergency_call/som/print_backstory(mob/living/carbon/human/H)

--- a/code/datums/emergency_calls/upp.dm
+++ b/code/datums/emergency_calls/upp.dm
@@ -1,6 +1,6 @@
 /datum/emergency_call/upp
 	name = "UPP"
-	probability = 10
+	probability = 15
 	shuttle_id = "distress_upp"
 
 

--- a/code/datums/emergency_calls/xeno.dm
+++ b/code/datums/emergency_calls/xeno.dm
@@ -1,6 +1,6 @@
 /datum/emergency_call/xenomorphs
 	name = "Xenomorphs"
-	probability = 10
+	probability = 15
 	auto_shuttle_launch = TRUE
 	spawn_type = /mob/living/carbon/xenomorph
 

--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -77,10 +77,10 @@
 	if(CHECK_BITFIELD(affected_mob.restrained_flags, RESTRAINED_XENO_NEST)) //Hosts who are nested in resin nests provide an ideal setting, larva grows faster.
 		counter += 1 + max(0, (0.03 * affected_mob.health)) //Up to +300% faster, depending on the health of the host.
 	else if(stage <= 4)
-		counter++
+		counter += 2 //Doubled growth overall, lowering free burst time to ~10 min.
 
 	if(affected_mob.reagents.get_reagent_amount(/datum/reagent/toxin/xeno_growthtoxin))
-		counter += 4 //Dramatically accelerates larval growth. You don't want this stuff in your body. Larva hits Stage 5 in just over 3 minutes, assuming the victim has growth toxin for the full duration.
+		counter += 2 //Accelerates larval growth somewhat. You don't want this stuff in your body. Larva hits Stage 5 in just over 3 minutes, assuming the victim has growth toxin for the full duration.
 
 	if(stage < 5 && counter >= 120)
 		counter = 0

--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -80,7 +80,7 @@
 		counter += 2 //Free burst time in ~10 min.
 
 	if(affected_mob.reagents.get_reagent_amount(/datum/reagent/toxin/xeno_growthtoxin))
-		counter += 2 //Accelerates larval growth somewhat. You don't want this stuff in your body. Larva hits Stage 5 in exactly 5 minutes, assuming the victim has growth toxin for the full duration.
+		counter += 2 //Accelerates larval growth somewhat. You don't want this stuff in your body. Larva hits Stage 5 in exactly 5 minutes (lower if healthy and nested), assuming the victim has growth toxin for the full duration.
 
 	if(stage < 5 && counter >= 120)
 		counter = 0

--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -77,7 +77,7 @@
 	if(CHECK_BITFIELD(affected_mob.restrained_flags, RESTRAINED_XENO_NEST)) //Hosts who are nested in resin nests provide an ideal setting, larva grows faster.
 		counter += 1 + max(0, (0.03 * affected_mob.health)) //Up to +300% faster, depending on the health of the host.
 	else if(stage <= 4)
-		counter += 2 //Doubled growth overall, lowering free burst time to ~10 min.
+		counter += 2 //Free burst time in ~10 min.
 
 	if(affected_mob.reagents.get_reagent_amount(/datum/reagent/toxin/xeno_growthtoxin))
 		counter += 2 //Accelerates larval growth somewhat. You don't want this stuff in your body. Larva hits Stage 5 in exactly 5 minutes, assuming the victim has growth toxin for the full duration.

--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -80,7 +80,7 @@
 		counter += 2 //Doubled growth overall, lowering free burst time to ~10 min.
 
 	if(affected_mob.reagents.get_reagent_amount(/datum/reagent/toxin/xeno_growthtoxin))
-		counter += 2 //Accelerates larval growth somewhat. You don't want this stuff in your body. Larva hits Stage 5 in just over 3 minutes, assuming the victim has growth toxin for the full duration.
+		counter += 2 //Accelerates larval growth somewhat. You don't want this stuff in your body. Larva hits Stage 5 in exactly 5 minutes, assuming the victim has growth toxin for the full duration.
 
 	if(stage < 5 && counter >= 120)
 		counter = 0

--- a/code/modules/reagents/chemistry_reagents/toxin.dm
+++ b/code/modules/reagents/chemistry_reagents/toxin.dm
@@ -492,8 +492,6 @@
 	scannable = TRUE
 
 /datum/reagent/toxin/xeno_growthtoxin/on_mob_life(mob/living/L)
-	if(L.getOxyLoss())
-		L.adjustOxyLoss(-REM)
 	if(L.getBruteLoss() || L.getFireLoss())
 		L.heal_limb_damage(REM, REM)
 	if(L.getToxLoss())


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

ERT changes

## Why It's Good For The Game

Rebalances ERT chances to discourage calling before xenomorphs are going to board.

Of the 90% "normal" ERT percentage, half are default friendly (15% PMC, 30% freelancers), while half are hostile (15% ayy, 15% SoM, 15% UPP). However, 83% are human and will thus fight ayys.

60% are a minor boost to the round (freelancer, SoM, UPP)
30% are a major boost to the round (ayy, PMC)
10% are the "joker" ERTs (5% pizza, 5% DS) which either do near-nothing, or will end the round preety fast.

Additionally the PMC SG chance was lowered from 50% to 30%, because 5 SG's spawning in an ERT guaranteed to be friendly to marines is very stronk.

## Changelog
:cl:
balance: Altered ERT spawn chances, lowered PMC S/G spawn chance.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
