### PR TITLE
Buffs Shotgun Buckshot and Flechette + New Attachments

### DIFF
--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -534,7 +534,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	max_range = 15
 	damage = 20
 	damage_falloff = 0.5
-	penetration = 40
+	penetration = 75
 
 /datum/ammo/bullet/shotgun/flechette_spread
 	name = "additional flechette"
@@ -544,7 +544,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	max_range = 15
 	damage = 20
 	damage_falloff = 0.5
-	penetration = 20
+	penetration = 75
 
 /datum/ammo/bullet/shotgun/buckshot
 	name = "shotgun buckshot shell"
@@ -557,7 +557,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	accuracy_var_high = 9
 	accurate_range = 3
 	max_range = 10
-	damage = 30
+	damage = 40
 	damage_falloff = 4
 	penetration = 10
 
@@ -573,7 +573,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	accuracy_var_high = 9
 	accurate_range = 3
 	max_range = 10
-	damage = 30
+	damage = 40
 	damage_falloff = 4
 	penetration = 0
 
@@ -619,7 +619,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	max_range = 15
 	damage = 15
 	damage_falloff = 0.5
-	penetration = 15
+	penetration = 60
 
 /datum/ammo/bullet/shotgun/sx16_flechette/spread
 	name = "additional flechette"
@@ -629,7 +629,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	max_range = 15
 	damage = 15
 	damage_falloff = 0.5
-	penetration = 15
+	penetration = 60
 
 /datum/ammo/bullet/shotgun/sx16_slug
 	name = "shotgun slug"

--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -527,14 +527,14 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	icon_state = "flechette"
 	hud_state = "shotgun_flechette"
 	bonus_projectiles_type = /datum/ammo/bullet/shotgun/flechette_spread
-	bonus_projectiles_amount = 4
+	bonus_projectiles_amount = 5
 	bonus_projectiles_scatter = 8
 	accuracy_var_low = 7
 	accuracy_var_high = 7
 	max_range = 15
 	damage = 20
 	damage_falloff = 0.5
-	penetration = 20
+	penetration = 40
 
 /datum/ammo/bullet/shotgun/flechette_spread
 	name = "additional flechette"
@@ -551,7 +551,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	icon_state = "buckshot"
 	hud_state = "shotgun_buckshot"
 	bonus_projectiles_type = /datum/ammo/bullet/shotgun/spread
-	bonus_projectiles_amount = 4
+	bonus_projectiles_amount = 7
 	bonus_projectiles_scatter = 10
 	accuracy_var_low = 9
 	accuracy_var_high = 9
@@ -559,7 +559,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	max_range = 10
 	damage = 30
 	damage_falloff = 4
-	penetration = 0
+	penetration = 10
 
 
 /datum/ammo/bullet/shotgun/buckshot/on_hit_mob(mob/M,obj/item/projectile/P)

--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -551,7 +551,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	icon_state = "buckshot"
 	hud_state = "shotgun_buckshot"
 	bonus_projectiles_type = /datum/ammo/bullet/shotgun/spread
-	bonus_projectiles_amount = 7
+	bonus_projectiles_amount = 6
 	bonus_projectiles_scatter = 10
 	accuracy_var_low = 9
 	accuracy_var_high = 9
@@ -654,6 +654,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	accuracy_var_high = 10
 	max_range = 10
 	damage = 40
+	penetration = 10
 	damage_falloff = 2
 
 /datum/ammo/bullet/shotgun/mbx900_buckshot/spread
@@ -662,7 +663,8 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	accuracy_var_low = 7
 	accuracy_var_high = 7
 	max_range = 10
-	damage = 30
+	damage = 40
+	penetration = 10
 	damage_falloff = 2
 
 /datum/ammo/bullet/shotgun/mbx900_sabot
@@ -672,7 +674,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	shell_speed = 5
 	max_range = 30
 	damage = 35
-	penetration = 40
+	penetration = 50
 
 /datum/ammo/bullet/shotgun/mbx900_tracker
 	name = ".410 tracker"

--- a/code/modules/projectiles/updated_projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/shotguns.dm
@@ -401,19 +401,21 @@ can cause issues with ammo types getting mixed up during the burst.
 	var/recent_notice //world.time to see when they last got a notice.
 	var/pump_lock = FALSE //Modern shotguns normally lock after being pumped; this lock is undone by pumping or operating the slide release i.e. unloading a shell manually.
 	attachable_allowed = list(
-						/obj/item/attachable/bayonet,
-						/obj/item/attachable/reddot,
-						/obj/item/attachable/verticalgrip,
-						/obj/item/attachable/angledgrip,
-						/obj/item/attachable/gyro,
-						/obj/item/attachable/flashlight,
-						/obj/item/attachable/extended_barrel,
-						/obj/item/attachable/heavy_barrel,
-						/obj/item/attachable/compensator,
-						/obj/item/attachable/magnetic_harness,
-						/obj/item/attachable/attached_gun/flamer,
-						/obj/item/attachable/attached_gun/shotgun,
-						/obj/item/attachable/stock/shotgun)
+		/obj/item/attachable/angledgrip,
+		/obj/item/attachable/attached_gun/flamer,
+		/obj/item/attachable/bayonet,
+		/obj/item/attachable/compensator,
+		/obj/item/attachable/extended_barrel,
+		/obj/item/attachable/flashlight,
+		/obj/item/attachable/gyro,
+		/obj/item/attachable/heavy_barrel,
+		/obj/item/attachable/lasersight,
+		/obj/item/attachable/magnetic_harness,
+		/obj/item/attachable/quickfire,
+		/obj/item/attachable/reddot,
+		/obj/item/attachable/stock/shotgun,
+		/obj/item/attachable/verticalgrip
+	)
 
 	flags_item_map_variant = (ITEM_JUNGLE_VARIANT|ITEM_ICE_VARIANT)
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 18,"rail_x" = 10, "rail_y" = 21, "under_x" = 20, "under_y" = 14, "stock_x" = 20, "stock_y" = 14)


### PR DESCRIPTION

## About The Pull Request

Adds new attachments to the 12 gauge shotgun.
Increases 12 gauge buckshot damage from 30/0(x4) to 40/10(x6) (120 to 240).
Increases 12 gauge flechette damage from 20/20(x4) to 20/70(x5). (80 to 100).
Increased 16 gauge flechette damage from 15/15(x4) to 15/60(x4).
Increases .410 buckshot damage from 30/0(x3) to 40/10(x4).
Increased .410 sabot damage from 35/40 to 35/50.


## Why It's Good For The Game

Non-slug shotguns are trash. The automatic shotgun was out-performing the higher gauge shotgun in tests in terms of DPS. No one uses the shotgun for the stun, so its time to fix that.

Please done that with the increase in extra buckshot bullets, it means that the shotgun has more spread. This means that more things will be hit, but at most ranges, the thing you're shooting at will be hit the same amount as before.

## Changelog
:cl: BurgerBB
add: Adds new attachments to the 12 gauge shotgun.
balance: Increases 12 gauge buckshot damage from 30/0(x4) to 40/10(x6). Increases 12 gauge flechette damage from 20/20(x4) to 20/70(x5). Increased 16 gauge flechette damage from 15/15(x4) to 15/60(x4). Increases .410 buckshot damage from 30/0(x3) to 40/10(x4). Increased .410 sabot damage from 35/40 to 35/50.
/:cl: