### PR TITLE
Lower wield delay, higher fire delay for spec grenade launcher

### DIFF
--- a/code/modules/projectiles/updated_projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/specialist.dm
@@ -470,7 +470,7 @@
 	throw_speed = 2
 	throw_range = 10
 	force = 5.0
-	wield_delay = 6
+	wield_delay = 0.6 SECONDS
 	fire_sound = 'sound/weapons/guns/fire/m92_attachable.ogg'
 	cocked_sound = 'sound/weapons/guns/interact/m92_cocked.ogg'
 	var/list/grenades = list()

--- a/code/modules/projectiles/updated_projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/specialist.dm
@@ -470,7 +470,7 @@
 	throw_speed = 2
 	throw_range = 10
 	force = 5.0
-	wield_delay = 8
+	wield_delay = 6
 	fire_sound = 'sound/weapons/guns/fire/m92_attachable.ogg'
 	cocked_sound = 'sound/weapons/guns/interact/m92_cocked.ogg'
 	var/list/grenades = list()
@@ -485,7 +485,7 @@
 	var/datum/effect_system/smoke_spread/smoke
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 18,"rail_x" = 14, "rail_y" = 22, "under_x" = 19, "under_y" = 14, "stock_x" = 19, "stock_y" = 14)
 
-	fire_delay = 2 SECONDS
+	fire_delay = 2.3 SECONDS
 
 
 /obj/item/weapon/gun/launcher/m92/Initialize()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

you cant chainstun as easily with the grenadelauncher now
in return you can wield it a quarter faster

## Why It's Good For The Game

I was admin observing and saw a grenadier spec kill an elder ravager with warding pheros and a queen heal alone with grenade spam and I thought that's pretty dumb and bad game design

## Changelog
:cl:
balance: grenade launcher cant chainstun as easy now, wields faster
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
