### PR TITLE
Changed queen heal into shrike heal

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -500,7 +500,7 @@
 	new /obj/effect/temp_visual/telekinesis(get_turf(target))
 	var/mob/living/carbon/xenomorph/patient = target
 	patient.heal_wounds(SHRIKE_CURE_HEAL_MULTIPLIER)
-		if(patient.health > 0) //If they are not in crit after the heal, let's remove evil debuffs.
+	if(patient.health > 0) //If they are not in crit after the heal, let's remove evil debuffs.
 		patient.set_knocked_out(0)
 		patient.set_stunned(0)
 		patient.set_knocked_down(0)


### PR DESCRIPTION
## About The Pull Request

Changes queen heal into shrike heal

## Why It's Good For The Game

Makes the heal more functional,now it has a cast time/sound and special effects to show a xeno is being healed,it heals any negative effects on xenos (like fire),it heals all the damage at the same time (no more outheal memes) and you can heal any xeno you can see even in overwatch (no more only being able to heal the xeno you're observing)

## Changelog
:cl:
tweak:changed queen heal into a shrike heal
/:cl:
