### PR TITLE
Fixes T19 Mag name on vendors

### DIFF
--- a/code/modules/projectiles/updated_projectiles/magazines/smgs.dm
+++ b/code/modules/projectiles/updated_projectiles/magazines/smgs.dm
@@ -31,7 +31,7 @@
 //T-19 SMG ammo
 
 /obj/item/ammo_magazine/smg/standard_smg
-	name = "\improper T-19 Submachine Gun magazine (10x20mm)"
+	name = "\improper T-19 submachine gun magazine (10x20mm)"
 	desc = "A 10x20mm caseless Submachine Gun magazine."
 	caliber = "10x20mm caseless"
 	icon_state = "t19"

--- a/code/modules/projectiles/updated_projectiles/magazines/smgs.dm
+++ b/code/modules/projectiles/updated_projectiles/magazines/smgs.dm
@@ -31,7 +31,7 @@
 //T-19 SMG ammo
 
 /obj/item/ammo_magazine/smg/standard_smg
-	name = "\improper T-19 magazine (10x20mm)"
+	name = "\improper T-19 Submachine Gun magazine (10x20mm)"
 	desc = "A 10x20mm caseless Submachine Gun magazine."
 	caliber = "10x20mm caseless"
 	icon_state = "t19"


### PR DESCRIPTION
## About The Pull Request

Changes the name of the T19 mag

## Why It's Good For The Game

More clarity on the vendors and keeps in line with the other weapons,it was supposed to be like that but it was merged before it could be changed

## Changelog
:cl:
fix: fixes t19 mag name being incorrect
/:cl:

