### PR TITLE
Welderpacks can be opened while worn

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -672,6 +672,7 @@
 	var/max_fuel = 260
 	storage_slots = null
 	max_storage_space = 15
+	worn_accessible = TRUE
 
 /obj/item/storage/backpack/marine/engineerpack/Initialize(mapload, ...)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Allows for engineers/ship techs to open welderpacks when they are on their back.

## Why It's Good For The Game

The only benefit a welderpack has is a small fuel tank. Other than that it is only a satchel, but without being able to be opened like one. Welderpack being the niche storage option that it is, it should not punish you for trying to take advantage of its one purpose.

## Changelog
:cl:
balance: Welderpack can be opened while worn.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
