### PR TITLE
Buff light armor and harness, slightly nerf heavy

### DIFF
--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -98,14 +98,14 @@
 	name = "\improper M3-H pattern marine armor"
 	desc = "A standard Marine M3 Heavy Build Pattern Chestplate. Increased protection at the cost of slowdown."
 	icon_state = "1"
-	armor = list("melee" = 65, "bullet" = 70, "laser" = 60, "energy" = 30, "bomb" = 60, "bio" = 50, "rad" = 20, "fire" = 50, "acid" = 50)
+	armor = list("melee" = 65, "bullet" = 70, "laser" = 60, "energy" = 30, "bomb" = 60, "bio" = 30, "rad" = 20, "fire" = 50, "acid" = 30)
 	slowdown = SLOWDOWN_ARMOR_HEAVY
 
 /obj/item/clothing/suit/storage/marine/M3LB
 	name = "\improper M3-LB pattern marine armor"
-	desc = "A standard Marine M3 Light Build Pattern Chestplate. Lesser encumbrance and protection."
+	desc = "A standard Marine M3 Light Build Pattern Chestplate. Fitted with lightweight, toxin-resistant plating. Lesser encumbrance and protection."
 	icon_state = "2"
-	armor = list("melee" = 30, "bullet" = 20, "laser" = 25, "energy" = 10, "bomb" = 15, "bio" = 10, "rad" = 0, "fire" = 10, "acid" = 10)
+	armor = list("melee" = 30, "bullet" = 20, "laser" = 25, "energy" = 10, "bomb" = 15, "bio" = 60, "rad" = 0, "fire" = 10, "acid" = 60)
 	slowdown = SLOWDOWN_ARMOR_LIGHT
 
 /obj/item/clothing/suit/storage/marine/harness
@@ -115,12 +115,14 @@
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	slowdown = 0
 	flags_atom = NONE
+	time_to_unequip = 0
+	time_to_equip = 0
 
 /obj/item/clothing/suit/storage/marine/M3IS
 	name = "\improper M3-IS pattern marine armor"
 	desc = "A standard Marine M3 Integrated Storage Pattern Chestplate. Increased encumbrance and storage capacity."
 	icon_state = "4"
-	armor = list("melee" = 60, "bullet" = 60, "laser" = 40, "energy" = 20, "bomb" = 50, "bio" = 40, "rad" = 10, "fire" = 35, "acid" = 45)
+	armor = list("melee" = 60, "bullet" = 60, "laser" = 40, "energy" = 20, "bomb" = 50, "bio" = 20, "rad" = 10, "fire" = 35, "acid" = 25)
 	slowdown = SLOWDOWN_ARMOR_HEAVY
 	pockets = /obj/item/storage/internal/suit/marine/M3IS
 


### PR DESCRIPTION
## About The Pull Request

Light armor has become useless because all other armors provide better protection while still being slower than harness. Perhaps it will do better if it had a specialization. Bio and acid protections were increased to be more sturdy against neurotoxin and acid. No other armor serves that kind of role yet, and it makes sense for light armor to serve that role. Neurotoxin is a death sentence for speed-oriented marines as it affects stamina. Spitter acid can quickly build up burn damage and considerably slow down an unarmored marine over time from burns. A player will not be expected to 1v1 a crusher or ravager with light armor, but they will not be severely hampered by neurotoxin or acid burn like other armors. Lowered heavy and integrated storage bio and acid armor values to allow light armor to shine in that role, since they already provide high melee and bullet armor. With them being slow, it is also not as bad if they take stamina damage (until the player falls over).

Also removed the equip delay for harnesses because they are pitiful as armor and have no slowdown, so there is no reason to quick un/equip in order to move faster.

## Why It's Good For The Game

Light armor is a meme because it is not very good at being armor compared to the others. Instead of raising melee armor, which would result in powercreep, better to give it bio and acid resistances so that it won't be crippled by ranged castes. Not as fast as harness, but will keep you running for longer when attacked by toxin/acid.

## Changelog
:cl:
balance: Light armor becomes anti-acid/toxin. Heavy and IS have less resistance.
tweak: Harness no longer has an un/equip delay.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
