### PR TITLE
Adds ACCESS_CIVILIAN_ENGINEERING to Ship Techs and changes circuit weights to TINY.

### DIFF
--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -349,8 +349,8 @@ You are also next in the chain of command, should the bridge crew fall in the li
 	total_positions = 5
 	supervisors = "the chief ship engineer and the requisitions officer"
 	selection_color = "#fff5cc"
-	access = list(ACCESS_IFF_MARINE, ACCESS_MARINE_ENGINEERING, ACCESS_MARINE_PREP, ACCESS_MARINE_MEDBAY, ACCESS_MARINE_CARGO)
-	minimal_access = list(ACCESS_IFF_MARINE, ACCESS_MARINE_ENGINEERING, ACCESS_MARINE_PREP, ACCESS_MARINE_MEDBAY, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_CARGO)
+	access = list(ACCESS_IFF_MARINE, ACCESS_MARINE_ENGINEERING, ACCESS_MARINE_PREP, ACCESS_MARINE_MEDBAY, ACCESS_MARINE_CARGO, ACCESS_CIVILIAN_ENGINEERING)
+	minimal_access = list(ACCESS_IFF_MARINE, ACCESS_MARINE_ENGINEERING, ACCESS_MARINE_PREP, ACCESS_MARINE_MEDBAY, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_CARGO, ACCESS_CIVILIAN_ENGINEERING)
 	skills_type = /datum/skills/ST
 	display_order = JOB_DISPLAY_ORDER_SHIP_TECH
 	outfit = /datum/outfit/job/engineering/tech

--- a/code/game/objects/items/circuitboards/circuitboard.dm
+++ b/code/game/objects/items/circuitboards/circuitboard.dm
@@ -1,5 +1,5 @@
 /obj/item/circuitboard
-	w_class = WEIGHT_CLASS_SMALL
+	w_class = WEIGHT_CLASS_TINY
 	name = "Circuit board"
 	icon = 'icons/obj/items/circuitboards.dmi'
 	icon_state = "id_mod"
@@ -83,7 +83,6 @@
 /obj/item/circuitboard/airlock
 	name = "airlock electronics"
 	icon_state = "door_electronics"
-	w_class = WEIGHT_CLASS_SMALL //It should be tiny! -Agouri
 	req_access = list(ACCESS_CIVILIAN_ENGINEERING)
 	var/list/conf_access = null
 	var/one_access = 0 //if set to 1, door would receive req_one_access instead of req_access


### PR DESCRIPTION
## About The Pull Request

These 2 were pretty small changes and semi-related but I can separate them if needed.

First part just adds the ACCESS_CIVILIAN_ENGINEERING to Ship Techs because map APCs and airlock circuits require them. Chief Engineer and Combat Engineers get this access already, but STs do not. Without it you just have to take an extra to 10 seconds to hack an APC whenever you want to change something and airlock circuits cannot be configured, so new airlocks with access can't be built shipside or planetside.

The second part changes the circuitboard weight to tiny instead of small. Found a comment that circuits should be tiny instead of small while doing the first part of this PR, and it makes sense. According to the defines, tiny items are hand sized or smaller. Circuitboards are that.

## Why It's Good For The Game

ACCESS_CIVILIAN_ENGINEERING saves a lot of hassle when doing certain engineering stuff and it is consistent with the other engineering roles. Circuitboards are tiny, not small.

## Changelog
:cl:
tweak: Ship Techs get can unlock colony APCs and set airlock accesses.
tweak: Circuitboards are tiny sized instead of small.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
