### PR TITLE
Allows the heavy armor to have variant sprite

### DIFF
--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -101,6 +101,10 @@
 	armor = list("melee" = 65, "bullet" = 70, "laser" = 60, "energy" = 30, "bomb" = 60, "bio" = 50, "rad" = 20, "fire" = 50, "acid" = 50)
 	slowdown = SLOWDOWN_ARMOR_HEAVY
 
+/obj/item/clothing/suit/storage/marine/M3HB/Initialize()
+	icon_state = pick("1","5")
+	. = ..()
+
 /obj/item/clothing/suit/storage/marine/M3LB
 	name = "\improper M3-LB pattern marine armor"
 	desc = "A standard Marine M3 Light Build Pattern Chestplate. Lesser encumbrance and protection."


### PR DESCRIPTION


## About The Pull Request

@Kuro-ai wanted his 'edge' sprite to be used. So I'm making the heavy armor have RNG sprites.
the "5" sprite is currently not in use.

## Why It's Good For The Game

slightly more variety 

## Changelog
:cl: Kuro, Hughgent
tweak: Heavy armor can look different sometimes
/:cl:

