### PR TITLE
Plasma gain while standing is nerfed; buffed when resting

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -143,7 +143,10 @@
 			use_plasma(5)
 
 	if(locate(/obj/effect/alien/weeds) in T)
-		gain_plasma(xeno_caste.plasma_gain + round(xeno_caste.plasma_gain * recovery_aura * 0.25)) // Empty recovery aura will always equal 0
+		if(lying || resting) //If we lie down or rest we get four times the amount of plasma gain compared to just standing
+			gain_plasma((xeno_caste.plasma_gain + round(xeno_caste.plasma_gain * recovery_aura * 0.25)) * 4) // Empty recovery aura will always equal 0
+		else
+			gain_plasma(max(0, (xeno_caste.plasma_gain + round(xeno_caste.plasma_gain * recovery_aura * 0.25)) / 4))
 	else
 		gain_plasma(1)
 

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -144,7 +144,7 @@
 
 	if(locate(/obj/effect/alien/weeds) in T)
 		if(lying || resting)
-			gain_plasma((xeno_caste.plasma_gain + round(xeno_caste.plasma_gain * recovery_aura * 0.25)) * 4) // Empty recovery aura will always equal 0
+			gain_plasma((xeno_caste.plasma_gain + round(xeno_caste.plasma_gain * recovery_aura * 0.25)) * 2) // Empty recovery aura will always equal 0
 		else
 			gain_plasma(max((xeno_caste.plasma_gain + round(xeno_caste.plasma_gain * recovery_aura * 0.25)) * 0.5), 1))
 	else

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -146,7 +146,7 @@
 		if(lying || resting)
 			gain_plasma((xeno_caste.plasma_gain + round(xeno_caste.plasma_gain * recovery_aura * 0.25)) * 2) // Empty recovery aura will always equal 0
 		else
-			gain_plasma(max((xeno_caste.plasma_gain + round(xeno_caste.plasma_gain * recovery_aura * 0.25)) * 0.5), 1))
+			gain_plasma(max(((xeno_caste.plasma_gain + round(xeno_caste.plasma_gain * recovery_aura * 0.25)) * 0.5), 1))
 	else
 		gain_plasma(1)
 

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -143,7 +143,7 @@
 			use_plasma(5)
 
 	if(locate(/obj/effect/alien/weeds) in T)
-		if(lying || resting) //When laying down we regen 4x the base plasma regen; likewise standing is 1/4th of the base plasma regen
+		if(lying || resting)
 			gain_plasma((xeno_caste.plasma_gain + round(xeno_caste.plasma_gain * recovery_aura * 0.25)) * 4) // Empty recovery aura will always equal 0
 		else
 			gain_plasma(max((xeno_caste.plasma_gain + round(xeno_caste.plasma_gain * recovery_aura * 0.25)) * 0.25), 1))

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -146,7 +146,7 @@
 		if(lying || resting)
 			gain_plasma((xeno_caste.plasma_gain + round(xeno_caste.plasma_gain * recovery_aura * 0.25)) * 4) // Empty recovery aura will always equal 0
 		else
-			gain_plasma(max((xeno_caste.plasma_gain + round(xeno_caste.plasma_gain * recovery_aura * 0.25)) * 0.25), 1))
+			gain_plasma(max((xeno_caste.plasma_gain + round(xeno_caste.plasma_gain * recovery_aura * 0.25)) * 0.5), 1))
 	else
 		gain_plasma(1)
 

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -146,7 +146,7 @@
 		if(lying || resting) //When laying down we regen 4x the base plasma regen; likewise standing is 1/4th of the base plasma regen
 			gain_plasma((xeno_caste.plasma_gain + round(xeno_caste.plasma_gain * recovery_aura * 0.25)) * 4) // Empty recovery aura will always equal 0
 		else
-			gain_plasma((xeno_caste.plasma_gain + round(xeno_caste.plasma_gain * recovery_aura * 0.25)) / 4)
+			gain_plasma(max((xeno_caste.plasma_gain + round(xeno_caste.plasma_gain * recovery_aura * 0.25)) * 0.25), 1))
 	else
 		gain_plasma(1)
 

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -143,10 +143,10 @@
 			use_plasma(5)
 
 	if(locate(/obj/effect/alien/weeds) in T)
-		if(lying || resting) //If we lie down or rest we get four times the amount of plasma gain compared to just standing
+		if(lying || resting) //When laying down we regen 4x the base plasma regen; likewise standing is 1/4th of the base plasma regen
 			gain_plasma((xeno_caste.plasma_gain + round(xeno_caste.plasma_gain * recovery_aura * 0.25)) * 4) // Empty recovery aura will always equal 0
 		else
-			gain_plasma(max(0, (xeno_caste.plasma_gain + round(xeno_caste.plasma_gain * recovery_aura * 0.25)) / 4))
+			gain_plasma((xeno_caste.plasma_gain + round(xeno_caste.plasma_gain * recovery_aura * 0.25)) / 4)
 	else
 		gain_plasma(1)
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Plasma regeneration on weeds when standing is now reduced by 1/4th
Plasma regeneration on weeds while resting is now multiplied by 4x

## Why It's Good For The Game
Essentially makes xenos much more of hit and runners as plasma regen when in combat and on weeds is heavily nerfed, although it's easily recharged while resting. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Base plasma regen is now 1/4th when standing on weeds and 4x while resting on weeds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
