### PR TITLE
Add Testmerge information to feedback

### DIFF
--- a/code/controllers/subsystem/blackbox.dm
+++ b/code/controllers/subsystem/blackbox.dm
@@ -37,10 +37,8 @@ SUBSYSTEM_DEF(blackbox)
 		SSdbcore.SetRoundID()
 
 
-	if(!CONFIG_GET(flag/use_exp_tracking))
-		return
-
-	update_exp(10, FALSE)
+	if(CONFIG_GET(flag/use_exp_tracking))
+		update_exp(10, FALSE)
 
 
 /datum/controller/subsystem/blackbox/vv_get_var(var_name)

--- a/code/datums/helper_datums/getrev.dm
+++ b/code/datums/helper_datums/getrev.dm
@@ -28,7 +28,7 @@
 	for(var/line in testmerge)
 		var/datum/tgs_revision_information/test_merge/tm = line
 		msg += "Test merge active of PR #[tm.number] commit [tm.commit]"
-		//SSblackbox.record_feedback("associative", "testmerged_prs", 1, list("number" = "[tm.number]", "commit" = "[tm.commit]", "title" = "[tm.title]", "author" = "[tm.author]"))
+		SSblackbox.record_feedback("associative", "testmerged_prs", 1, list("number" = "[tm.number]", "commit" = "[tm.commit]", "title" = "[tm.title]", "author" = "[tm.author]"))
 
 	if(commit && commit != originmastercommit)
 		msg += "HEAD: [commit]"


### PR DESCRIPTION
This was already there just needed to be enabled.
Also the check for exp_tracking doesn't make sense if we want to add more things so the early return was removed