### PR TITLE
Changes Xeno Latespawns to be weighted depending on Human Jobs

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -97,3 +97,9 @@ GLOBAL_LIST_INIT(jobs_unassigned, list(SQUAD_MARINE))
 
 #define XP_REQ_INTERMEDIATE 60
 #define XP_REQ_EXPERIENCED 180
+
+// how much a job is going to contribute towards burrowed larva. see the respective game mode dm for how many points per larva
+#define LARVA_POINTS_SHIPSIDE 1
+#define LARVA_POINTS_SYNTH 2
+#define LARVA_POINTS_REGULAR 3
+#define LARVA_POINTS_STRONG 4.5

--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -98,8 +98,8 @@ GLOBAL_LIST_INIT(jobs_unassigned, list(SQUAD_MARINE))
 #define XP_REQ_INTERMEDIATE 60
 #define XP_REQ_EXPERIENCED 180
 
-// how much a job is going to contribute towards burrowed larva. see the respective game mode dm for how many points per larva
+// how much a job is going to contribute towards burrowed larva. see config for points required to larva. old balance was 1 larva per 3 humans.
 #define LARVA_POINTS_SHIPSIDE 1
-#define LARVA_POINTS_SYNTH 2
+#define LARVA_POINTS_SHIPSIDE_STRONG 2
 #define LARVA_POINTS_REGULAR 3
 #define LARVA_POINTS_STRONG 4.5

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -118,4 +118,3 @@
 /datum/config_entry/number/distress_larvapoints_required
 	config_entry_value = 8
 	min_val = 1
-	

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -111,6 +111,10 @@
 	config_entry_value = 15
 	min_val = 1
 
-/datum/config_entry/number/larvapoints_required
-	config_entry_value = 9
+/datum/config_entry/number/crash/larvapoints_required
+	config_entry_value = 10
+	min_val = 1
+
+/datum/config_entry/number/distress/larvapoints_required
+	config_entry_value = 8
 	min_val = 1

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -118,3 +118,4 @@
 /datum/config_entry/number/distress_larvapoints_required
 	config_entry_value = 8
 	min_val = 1
+

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -111,11 +111,6 @@
 	config_entry_value = 15
 	min_val = 1
 
-/datum/config_entry/number/latejoin_larva_required_num
-	integer = FALSE
-	min_val = 0
-	config_entry_value = 4
-
 /datum/config_entry/number/larvapoints_required
 	config_entry_value = 9
 	min_val = 1

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -112,7 +112,7 @@
 	min_val = 1
 
 /datum/config_entry/number/crash_larvapoints_required
-	config_entry_value = 10
+	config_entry_value = 9
 	min_val = 1
 
 /datum/config_entry/number/distress_larvapoints_required

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -115,3 +115,7 @@
 	integer = FALSE
 	min_val = 0
 	config_entry_value = 4
+
+/datum/config_entry/number/larvapoints_required
+	config_entry_value = 9
+	min_val = 1

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -111,11 +111,11 @@
 	config_entry_value = 15
 	min_val = 1
 
-/datum/config_entry/number/crash/larvapoints_required
-	config_entry_value = 9
+/datum/config_entry/number/crash_larvapoints_required
+	config_entry_value = 10
 	min_val = 1
 
-/datum/config_entry/number/distress/larvapoints_required
-	config_entry_value = 9
+/datum/config_entry/number/distress_larvapoints_required
+	config_entry_value = 8
 	min_val = 1
 	

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -112,9 +112,10 @@
 	min_val = 1
 
 /datum/config_entry/number/crash/larvapoints_required
-	config_entry_value = 10
+	config_entry_value = 9
 	min_val = 1
 
 /datum/config_entry/number/distress/larvapoints_required
-	config_entry_value = 8
+	config_entry_value = 9
 	min_val = 1
+	

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -152,10 +152,9 @@
 	if(world.time > larva_check_interval)
 		larva_check_interval = world.time + 1 MINUTES
 		var/datum/hive_status/normal/xeno_hive = GLOB.hive_datums[XENO_HIVE_NORMAL]
-		var/list/living_player_list = count_humans_and_xenos(count_flags = COUNT_IGNORE_HUMAN_SSD)
-		var/num_xenos = living_player_list[2] + xeno_hive.stored_larva
+		var/num_xenos = xeno_hive.get_total_xeno_number() - length(xeno_hive.get_ssd_xenos()) + xeno_hive.stored_larva
 		var/total_jobworth = get_total_joblarvaworth()
-		latejoin_larvapoints = total_jobworth / (max(1, num_xenos) * latejoin_larvapoints_required)
+		latejoin_larvapoints = (total_jobworth - (num_xenos * latejoin_larvapoints_required)) / latejoin_larvapoints_required)
 		if(!num_xenos)
 			if(!length(GLOB.xeno_resin_silos))
 				check_finished(TRUE)
@@ -164,9 +163,9 @@
 				return //No need for respawns nor to end the game. They can use their burrowed larvas.
 			xeno_hive.stored_larva += max(1, round(latejoin_larvapoints / latejoin_larvapoints_required)) //At least one
 			return 
-		if(latejoin_larvapoints < latejoin_larvapoints_required)
+		if(latejoin_larvapoints < 1)
 			return //Things are balanced, no burrowed needed
-		xeno_hive.stored_larva += (latejoin_larvapoints / latejoin_larvapoints_required) //however many burrowed they can afford to buy
+		xeno_hive.stored_larva += round(latejoin_larvapoints) //however many burrowed they can afford to buy, floored
 
 
 /datum/game_mode/crash/proc/crash_shuttle(obj/docking_port/stationary/target)

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -163,7 +163,7 @@
 				return //RIP benos.
 			if(xeno_hive.stored_larva)
 				return //No need for respawns nor to end the game. They can use their burrowed larvas.
-			xeno_hive.stored_larva += max(1, round(latejoin_larvapoints / latejoin_larvapoints_required)) //At least one
+			xeno_hive.stored_larva += max(1, round(latejoin_larvapoints) //At least one
 			return 
 		if(latejoin_larvapoints < 1)
 			return //Things are balanced, no burrowed needed

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -34,7 +34,7 @@
 	// Round start info
 	var/starting_squad = "Alpha"
 	var/latejoin_larvapoints		= 0
-	var/latejoin_larvapoints_required = 0
+	var/latejoin_larvapoints_required = 9 // to avoid division by zero if config doesn't deliver a value in :58 for some reason
 
 	var/larva_check_interval = 0
 
@@ -166,8 +166,7 @@
 			return 
 		if(latejoin_larvapoints < latejoin_larvapoints_required)
 			return //Things are balanced, no burrowed needed
-		if(latejoin_larvapoints >= latejoin_larvapoints_required)
-			xeno_hive.stored_larva += (latejoin_larvapoints / latejoin_larvapoints_required) //however many burrowed they can afford to buy
+		xeno_hive.stored_larva += (latejoin_larvapoints / latejoin_larvapoints_required) //however many burrowed they can afford to buy
 
 
 /datum/game_mode/crash/proc/crash_shuttle(obj/docking_port/stationary/target)

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -55,7 +55,7 @@
 	. = ..()
 	if(!.)
 		return
-	latejoin_larvapoints_required = CONFIG_GET(number/larvapoints_required)
+	latejoin_larvapoints_required = CONFIG_GET(number/crash/larvapoints_required)
 	xeno_starting_num = max(round(GLOB.ready_players / (CONFIG_GET(number/xeno_number) + CONFIG_GET(number/crash_coefficient) * GLOB.ready_players)), xeno_required_num)
 
 

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -153,7 +153,6 @@
 		larva_check_interval = world.time + 1 MINUTES
 		var/datum/hive_status/normal/xeno_hive = GLOB.hive_datums[XENO_HIVE_NORMAL]
 		var/list/living_player_list = count_humans_and_xenos(count_flags = COUNT_IGNORE_HUMAN_SSD)
-		var/num_humans = living_player_list[1]
 		var/num_xenos = living_player_list[2] + xeno_hive.stored_larva
 		var/total_jobworth = get_total_joblarvaworth()
 		latejoin_larvapoints = total_jobworth / (max(1, num_xenos) * latejoin_larvapoints_required)
@@ -163,18 +162,12 @@
 				return //RIP benos.
 			if(xeno_hive.stored_larva)
 				return //No need for respawns nor to end the game. They can use their burrowed larvas.
-			xeno_hive.stored_larva += max(1, round(num_humans * 0.2))
-			return
+			xeno_hive.stored_larva += max(1, round(latejoin_larvapoints / latejoin_larvapoints_required)) //At least one
+			return 
 		if(latejoin_larvapoints < latejoin_larvapoints_required)
-			return
-		if(latejoin_larvapoints >= 3 * latejoin_larvapoints_required)
-			xeno_hive.stored_larva += min(3, round(num_humans * 0.13)) //Three, unless there are less than 16 marines.
-			return
-		if(latejoin_larvapoints >= 2 * latejoin_larvapoints_required)
-			xeno_hive.stored_larva += min(2, round(num_humans * 0.25)) //Two, unless there are less than 8 marines.
-			return
+			return //Things are balanced, no burrowed needed
 		if(latejoin_larvapoints >= latejoin_larvapoints_required)
-			xeno_hive.stored_larva++
+			xeno_hive.stored_larva += (latejoin_larvapoints / latejoin_larvapoints_required) //however many burrowed they can afford to buy
 
 
 /datum/game_mode/crash/proc/crash_shuttle(obj/docking_port/stationary/target)

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -152,23 +152,6 @@
 	if(world.time > larva_check_interval)
 		balance_scales()
 
-	/*if(world.time > larva_check_interval)
-		larva_check_interval = world.time + 1 MINUTES
-		var/datum/hive_status/normal/xeno_hive = GLOB.hive_datums[XENO_HIVE_NORMAL]
-		var/num_xenos = xeno_hive.get_total_xeno_number() - length(xeno_hive.get_ssd_xenos()) + xeno_hive.stored_larva
-		latejoin_larvapoints = (get_total_joblarvaworth() - (num_xenos * latejoin_larvapoints_required)) / latejoin_larvapoints_required
-		if(!num_xenos)
-			if(!length(GLOB.xeno_resin_silos))
-				check_finished(TRUE)
-				return //RIP benos.
-			if(xeno_hive.stored_larva)
-				return //No need for respawns nor to end the game. They can use their burrowed larvas.
-			xeno_hive.stored_larva += max(1, round(latejoin_larvapoints) //At least one
-			return 
-		if(latejoin_larvapoints < 1)
-			return //Things are balanced, no burrowed needed
-		xeno_hive.stored_larva += round(latejoin_larvapoints) //however many burrowed they can afford to buy, floored
-*/
 
 /datum/game_mode/crash/proc/crash_shuttle(obj/docking_port/stationary/target)
 	shuttle_landed = TRUE

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -33,8 +33,8 @@
 
 	// Round start info
 	var/starting_squad = "Alpha"
-	var/latejoin_larvapoints		= 0
-	var/latejoin_larvapoints_required = 9 // to avoid division by zero if config doesn't deliver a value in :58 for some reason
+	latejoin_larvapoints		= 0
+	latejoin_larvapoints_required = 9 // to avoid division by zero if config doesn't deliver a value in :58 for some reason
 
 	var/larva_check_interval = 0
 
@@ -150,6 +150,9 @@
 		return
 
 	if(world.time > larva_check_interval)
+		balance_scales()
+
+	/*if(world.time > larva_check_interval)
 		larva_check_interval = world.time + 1 MINUTES
 		var/datum/hive_status/normal/xeno_hive = GLOB.hive_datums[XENO_HIVE_NORMAL]
 		var/num_xenos = xeno_hive.get_total_xeno_number() - length(xeno_hive.get_ssd_xenos()) + xeno_hive.stored_larva
@@ -165,7 +168,7 @@
 		if(latejoin_larvapoints < 1)
 			return //Things are balanced, no burrowed needed
 		xeno_hive.stored_larva += round(latejoin_larvapoints) //however many burrowed they can afford to buy, floored
-
+*/
 
 /datum/game_mode/crash/proc/crash_shuttle(obj/docking_port/stationary/target)
 	shuttle_landed = TRUE

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -153,8 +153,7 @@
 		larva_check_interval = world.time + 1 MINUTES
 		var/datum/hive_status/normal/xeno_hive = GLOB.hive_datums[XENO_HIVE_NORMAL]
 		var/num_xenos = xeno_hive.get_total_xeno_number() - length(xeno_hive.get_ssd_xenos()) + xeno_hive.stored_larva
-		var/total_jobworth = get_total_joblarvaworth()
-		latejoin_larvapoints = (total_jobworth - (num_xenos * latejoin_larvapoints_required)) / latejoin_larvapoints_required
+		latejoin_larvapoints = (get_total_joblarvaworth() - (num_xenos * latejoin_larvapoints_required)) / latejoin_larvapoints_required
 		if(!num_xenos)
 			if(!length(GLOB.xeno_resin_silos))
 				check_finished(TRUE)

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -55,7 +55,7 @@
 	. = ..()
 	if(!.)
 		return
-	latejoin_larvapoints_required = CONFIG_GET(number/crash/larvapoints_required)
+	latejoin_larvapoints_required = CONFIG_GET(number/crash_larvapoints_required)
 	xeno_starting_num = max(round(GLOB.ready_players / (CONFIG_GET(number/xeno_number) + CONFIG_GET(number/crash_coefficient) * GLOB.ready_players)), xeno_required_num)
 
 

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -154,7 +154,7 @@
 		var/datum/hive_status/normal/xeno_hive = GLOB.hive_datums[XENO_HIVE_NORMAL]
 		var/num_xenos = xeno_hive.get_total_xeno_number() - length(xeno_hive.get_ssd_xenos()) + xeno_hive.stored_larva
 		var/total_jobworth = get_total_joblarvaworth()
-		latejoin_larvapoints = (total_jobworth - (num_xenos * latejoin_larvapoints_required)) / latejoin_larvapoints_required)
+		latejoin_larvapoints = (total_jobworth - (num_xenos * latejoin_larvapoints_required)) / latejoin_larvapoints_required
 		if(!num_xenos)
 			if(!length(GLOB.xeno_resin_silos))
 				check_finished(TRUE)

--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -20,8 +20,8 @@
 	var/bioscan_current_interval = 45 MINUTES
 	var/bioscan_ongoing_interval = 20 MINUTES
 
-	var/latejoin_larvapoints		= 0
-	var/latejoin_larvapoints_required = 9 //in case config doesn't deliver a value in :198 for some reason
+	latejoin_larvapoints		= 0
+	latejoin_larvapoints_required = 9 //in case config doesn't deliver a value in :198 for some reason
 	var/orphan_hive_timer
 
 
@@ -62,6 +62,7 @@
 
 /datum/game_mode/distress/post_setup()
 	. = ..()
+	balance_scales()
 	addtimer(CALLBACK(src, .proc/announce_bioscans, FALSE, 1), rand(30 SECONDS, 1 MINUTES)) //First scan shows no location but more precise numbers.
 
 

--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -20,8 +20,8 @@
 	var/bioscan_current_interval = 45 MINUTES
 	var/bioscan_ongoing_interval = 20 MINUTES
 
-	var/latejoin_tally		= 0
-	var/latejoin_larva_drop = 0
+	var/latejoin_larvapoints		= 0
+	var/latejoin_larvapoints_required = 0
 	var/orphan_hive_timer
 
 
@@ -195,7 +195,7 @@
 	. = ..()
 	if(!.)
 		return
-	latejoin_larva_drop = CONFIG_GET(number/latejoin_larva_required_num)
+	latejoin_larvapoints_required = CONFIG_GET(number/larvapoints_required)
 	xeno_starting_num = max(round(GLOB.ready_players / (CONFIG_GET(number/xeno_number) + CONFIG_GET(number/xeno_coefficient) * GLOB.ready_players)), xeno_required_num)
 	surv_starting_num = CLAMP((round(GLOB.ready_players / CONFIG_GET(number/survivor_coefficient))), 0, 8)
 	marine_starting_num = GLOB.ready_players - xeno_starting_num - surv_starting_num
@@ -528,11 +528,14 @@
 		return "[(eta / 60) % 60]:[add_zero(num2text(eta % 60), 2)]"
 
 
-/datum/game_mode/distress/handle_late_spawn(mob/late_spawner)
-	latejoin_tally++
+/datum/game_mode/distress/handle_late_spawn(mob/living/late_spawner)
+	var/datum/job/job = SSjob.GetJob(late_spawner.job)
+	latejoin_larvapoints += job.larvaworth
+	to_chat(world, "[latejoin_larvapoints]")
 
-	if(latejoin_larva_drop && latejoin_tally >= latejoin_larva_drop)
-		latejoin_tally -= latejoin_larva_drop
+	if(latejoin_larvapoints >= latejoin_larvapoints_required)
+		latejoin_larvapoints -= latejoin_larvapoints_required
+		to_chat(world, "[latejoin_larvapoints]")
 		var/datum/hive_status/normal/HS = GLOB.hive_datums[XENO_HIVE_NORMAL]
 		HS.stored_larva++
 

--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -21,7 +21,7 @@
 	var/bioscan_ongoing_interval = 20 MINUTES
 
 	latejoin_larvapoints		= 0
-	latejoin_larvapoints_required = 9 //in case config doesn't deliver a value in :198 for some reason
+	latejoin_larvapoints_required = 9 //in case config doesn't deliver a value in initialize_scales() for some reason
 	var/orphan_hive_timer
 
 
@@ -65,8 +65,9 @@
 	balance_scales()
 	addtimer(CALLBACK(src, .proc/announce_bioscans, FALSE, 1), rand(30 SECONDS, 1 MINUTES)) //First scan shows no location but more precise numbers.
 
-/datum/game_mode/distress/proc/balance_scales()
+/datum/game_mode/distress/balance_scales()
 	. = ..()
+	latejoin_larvapoints -= round(latejoin_larvapoints)
 	latejoin_larvapoints *= latejoin_larvapoints_required //restores scaling for handle_late_spawn()
 
 /datum/game_mode/distress/proc/map_announce()
@@ -199,7 +200,7 @@
 	. = ..()
 	if(!.)
 		return
-	latejoin_larvapoints_required = CONFIG_GET(number/distress/larvapoints_required)
+	latejoin_larvapoints_required = CONFIG_GET(number/distress_larvapoints_required)
 	xeno_starting_num = max(round(GLOB.ready_players / (CONFIG_GET(number/xeno_number) + CONFIG_GET(number/xeno_coefficient) * GLOB.ready_players)), xeno_required_num)
 	surv_starting_num = CLAMP((round(GLOB.ready_players / CONFIG_GET(number/survivor_coefficient))), 0, 8)
 	marine_starting_num = GLOB.ready_players - xeno_starting_num - surv_starting_num

--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -63,6 +63,7 @@
 /datum/game_mode/distress/post_setup()
 	. = ..()
 	balance_scales()
+	latejoin_larvapoints *= latejoin_larvapoints_required
 	addtimer(CALLBACK(src, .proc/announce_bioscans, FALSE, 1), rand(30 SECONDS, 1 MINUTES)) //First scan shows no location but more precise numbers.
 
 
@@ -196,7 +197,7 @@
 	. = ..()
 	if(!.)
 		return
-	latejoin_larvapoints_required = CONFIG_GET(number/larvapoints_required)
+	latejoin_larvapoints_required = CONFIG_GET(number/distress/larvapoints_required)
 	xeno_starting_num = max(round(GLOB.ready_players / (CONFIG_GET(number/xeno_number) + CONFIG_GET(number/xeno_coefficient) * GLOB.ready_players)), xeno_required_num)
 	surv_starting_num = CLAMP((round(GLOB.ready_players / CONFIG_GET(number/survivor_coefficient))), 0, 8)
 	marine_starting_num = GLOB.ready_players - xeno_starting_num - surv_starting_num

--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -63,9 +63,11 @@
 /datum/game_mode/distress/post_setup()
 	. = ..()
 	balance_scales()
-	latejoin_larvapoints *= latejoin_larvapoints_required
 	addtimer(CALLBACK(src, .proc/announce_bioscans, FALSE, 1), rand(30 SECONDS, 1 MINUTES)) //First scan shows no location but more precise numbers.
 
+/datum/game_mode/distress/proc/balance_scales()
+	. = ..()
+	latejoin_larvapoints *= latejoin_larvapoints_required //restores scaling for handle_late_spawn()
 
 /datum/game_mode/distress/proc/map_announce()
 	if(!SSmapping.configs[GROUND_MAP].announce_text)

--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -21,7 +21,7 @@
 	var/bioscan_ongoing_interval = 20 MINUTES
 
 	var/latejoin_larvapoints		= 0
-	var/latejoin_larvapoints_required = 0
+	var/latejoin_larvapoints_required = 9 //in case config doesn't deliver a value in :198 for some reason
 	var/orphan_hive_timer
 
 

--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -531,11 +531,9 @@
 /datum/game_mode/distress/handle_late_spawn(mob/living/late_spawner)
 	var/datum/job/job = SSjob.GetJob(late_spawner.job)
 	latejoin_larvapoints += job.larvaworth
-	to_chat(world, "[latejoin_larvapoints]")
 
 	if(latejoin_larvapoints >= latejoin_larvapoints_required)
 		latejoin_larvapoints -= latejoin_larvapoints_required
-		to_chat(world, "[latejoin_larvapoints]")
 		var/datum/hive_status/normal/HS = GLOB.hive_datums[XENO_HIVE_NORMAL]
 		HS.stored_larva++
 

--- a/code/datums/gamemodes/game_mode.dm
+++ b/code/datums/gamemodes/game_mode.dm
@@ -722,8 +722,6 @@ Sensors indicate [numXenosShip ? "[numXenosShip]" : "no"] unknown lifeform signa
 			continue
 		. += job.larvaworth
 
-	return .
-
 
 /datum/game_mode/proc/is_xeno_in_forbidden_zone(mob/living/carbon/xenomorph/xeno)
 	return FALSE

--- a/code/datums/gamemodes/game_mode.dm
+++ b/code/datums/gamemodes/game_mode.dm
@@ -708,6 +708,22 @@ Sensors indicate [numXenosShip ? "[numXenosShip]" : "no"] unknown lifeform signa
 
 	return list(num_humans, num_xenos)
 
+/datum/game_mode/proc/get_total_joblarvaworth(list/z_levels = SSmapping.levels_by_any_trait(list(ZTRAIT_MARINE_MAIN_SHIP, ZTRAIT_GROUND, ZTRAIT_RESERVED)), count_flags)
+	var/total_worth = 0
+
+	for(var/i in GLOB.alive_human_list)
+		var/mob/living/carbon/human/H = i
+		var/datum/job/job = SSjob.GetJob(H.job)
+		if(count_flags & COUNT_IGNORE_HUMAN_SSD && !H.client)
+			continue
+		if(H.status_flags & XENO_HOST)
+			continue
+		if(!(H.z in z_levels) || isspaceturf(H.loc))
+			continue
+		total_worth += job.larvaworth
+
+	return total_worth
+
 
 /datum/game_mode/proc/is_xeno_in_forbidden_zone(mob/living/carbon/xenomorph/xeno)
 	return FALSE
@@ -822,7 +838,7 @@ Sensors indicate [numXenosShip ? "[numXenosShip]" : "no"] unknown lifeform signa
 	qdel(NP)
 
 
-/datum/game_mode/proc/handle_late_spawn(mob/late_spawner)
+/datum/game_mode/proc/handle_late_spawn(mob/living/late_spawner)
 	return
 
 

--- a/code/datums/gamemodes/game_mode.dm
+++ b/code/datums/gamemodes/game_mode.dm
@@ -709,7 +709,7 @@ Sensors indicate [numXenosShip ? "[numXenosShip]" : "no"] unknown lifeform signa
 	return list(num_humans, num_xenos)
 
 /datum/game_mode/proc/get_total_joblarvaworth(list/z_levels = SSmapping.levels_by_any_trait(list(ZTRAIT_MARINE_MAIN_SHIP, ZTRAIT_GROUND, ZTRAIT_RESERVED)), count_flags)
-	var/total_worth = 0
+	. = 0
 
 	for(var/i in GLOB.alive_human_list)
 		var/mob/living/carbon/human/H = i
@@ -720,9 +720,9 @@ Sensors indicate [numXenosShip ? "[numXenosShip]" : "no"] unknown lifeform signa
 			continue
 		if(!(H.z in z_levels) || isspaceturf(H.loc))
 			continue
-		total_worth += job.larvaworth
+		. += job.larvaworth
 
-	return total_worth
+	return .
 
 
 /datum/game_mode/proc/is_xeno_in_forbidden_zone(mob/living/carbon/xenomorph/xeno)

--- a/code/datums/gamemodes/game_mode.dm
+++ b/code/datums/gamemodes/game_mode.dm
@@ -740,7 +740,6 @@ Sensors indicate [numXenosShip ? "[numXenosShip]" : "no"] unknown lifeform signa
 		return //Things are balanced, no burrowed needed
 	xeno_hive.stored_larva += round(latejoin_larvapoints) //however many burrowed they can afford to buy, floored
 
-
 /datum/game_mode/proc/is_xeno_in_forbidden_zone(mob/living/carbon/xenomorph/xeno)
 	return FALSE
 

--- a/code/datums/gamemodes/game_mode.dm
+++ b/code/datums/gamemodes/game_mode.dm
@@ -728,17 +728,17 @@ Sensors indicate [numXenosShip ? "[numXenosShip]" : "no"] unknown lifeform signa
 	var/datum/hive_status/normal/xeno_hive = GLOB.hive_datums[XENO_HIVE_NORMAL]
 	var/num_xenos = xeno_hive.get_total_xeno_number() - length(xeno_hive.get_ssd_xenos()) + xeno_hive.stored_larva
 	latejoin_larvapoints = (get_total_joblarvaworth() - (num_xenos * latejoin_larvapoints_required)) / latejoin_larvapoints_required
-	if(!num_xenos)
-		if(!isdistress(SSticker?.mode) && !length(GLOB.xeno_resin_silos))
+	if(!num_xenos) //Distress ends here
+		if(!length(GLOB.xeno_resin_silos)) //Crash ends here
 			check_finished(TRUE)
 			return //RIP benos.
 		if(xeno_hive.stored_larva)
 			return //No need for respawns nor to end the game. They can use their burrowed larvas.
-		xeno_hive.stored_larva += max(1, round(latejoin_larvapoints / latejoin_larvapoints_required)) //At least one
+		xeno_hive.stored_larva += max(1, round(latejoin_larvapoints)) //At least one
 		return 
-		if(latejoin_larvapoints < 1)
-			return //Things are balanced, no burrowed needed
-		xeno_hive.stored_larva += round(latejoin_larvapoints) //however many burrowed they can afford to buy, floored
+	if(latejoin_larvapoints < 1)
+		return //Things are balanced, no burrowed needed
+	xeno_hive.stored_larva += round(latejoin_larvapoints) //however many burrowed they can afford to buy, floored
 
 
 /datum/game_mode/proc/is_xeno_in_forbidden_zone(mob/living/carbon/xenomorph/xeno)

--- a/code/datums/jobs/job/job.dm
+++ b/code/datums/jobs/job/job.dm
@@ -49,7 +49,8 @@ GLOBAL_PROTECT(exp_specialmap)
 
 	var/display_order = JOB_DISPLAY_ORDER_DEFAULT
 	var/job_flags = NONE
-
+	
+	var/larvaworth = 0
 
 /datum/job/proc/after_spawn(mob/living/L, mob/M, latejoin = FALSE) //do actions on L but send messages to M as the key may not have been transferred_yet
 	if(!ishuman(L))

--- a/code/datums/jobs/job/marines.dm
+++ b/code/datums/jobs/job/marines.dm
@@ -27,6 +27,7 @@ Make your way to the cafeteria for some post-cryosleep chow, and then get equipp
 	display_order = JOB_DISPLAY_ORDER_SQUAD_MARINE
 	outfit = /datum/outfit/job/marine/standard
 	total_positions = -1
+	var/larvaworth = LARVA_POINTS_REGULAR
 
 
 /datum/job/marine/standard/radio_help_message(mob/M)
@@ -54,6 +55,7 @@ What you lack alone, you gain standing shoulder to shoulder with the men and wom
 	skills_type = /datum/skills/combat_engineer
 	display_order = JOB_DISPLAY_ORDER_SUQAD_ENGINEER
 	outfit = /datum/outfit/job/marine/engineer
+	var/larvaworth = LARVA_POINTS_REGULAR
 
 
 /datum/job/marine/engineer/radio_help_message(mob/M)
@@ -81,6 +83,7 @@ Your squaddies will look to you when it comes to construction in the field of ba
 	skills_type = /datum/skills/combat_medic
 	display_order = JOB_DISPLAY_ORDER_SQUAD_CORPSMAN
 	outfit = /datum/outfit/job/marine/corpsman
+	var/larvaworth = LARVA_POINTS_REGULAR
 
 
 /datum/job/marine/corpsman/radio_help_message(mob/M)
@@ -108,6 +111,7 @@ You may not be a fully-fledged doctor, but you stand between life and death when
 	skills_type = /datum/skills/smartgunner
 	display_order = JOB_DISPLAY_ORDER_SQUAD_SMARTGUNNER
 	outfit = /datum/outfit/job/marine/smartgunner
+	var/larvaworth = LARVA_POINTS_REGULAR
 
 
 /datum/job/marine/smartgunner/radio_help_message(mob/M)
@@ -136,6 +140,7 @@ You may not be a fully-fledged doctor, but you stand between life and death when
 	outfit = /datum/outfit/job/marine/specialist
 	exp_requirements = XP_REQ_INTERMEDIATE
 	exp_type = EXP_TYPE_REGULAR_ALL
+	var/larvaworth = LARVA_POINTS_STRONG
 
 
 /datum/job/marine/specialist/radio_help_message(mob/M)
@@ -167,6 +172,7 @@ You can serve a variety of roles, so choose carefully."})
 	outfit = /datum/outfit/job/marine/leader
 	exp_requirements = XP_REQ_EXPERIENCED
 	exp_type = EXP_TYPE_REGULAR_ALL
+	var/larvaworth = LARVA_POINTS_REGULAR
 
 
 /datum/job/marine/leader/radio_help_message(mob/M)

--- a/code/datums/jobs/job/marines.dm
+++ b/code/datums/jobs/job/marines.dm
@@ -27,7 +27,7 @@ Make your way to the cafeteria for some post-cryosleep chow, and then get equipp
 	display_order = JOB_DISPLAY_ORDER_SQUAD_MARINE
 	outfit = /datum/outfit/job/marine/standard
 	total_positions = -1
-	var/larvaworth = LARVA_POINTS_REGULAR
+	larvaworth = LARVA_POINTS_REGULAR
 
 
 /datum/job/marine/standard/radio_help_message(mob/M)
@@ -55,7 +55,7 @@ What you lack alone, you gain standing shoulder to shoulder with the men and wom
 	skills_type = /datum/skills/combat_engineer
 	display_order = JOB_DISPLAY_ORDER_SUQAD_ENGINEER
 	outfit = /datum/outfit/job/marine/engineer
-	var/larvaworth = LARVA_POINTS_REGULAR
+	larvaworth = LARVA_POINTS_REGULAR
 
 
 /datum/job/marine/engineer/radio_help_message(mob/M)
@@ -83,7 +83,7 @@ Your squaddies will look to you when it comes to construction in the field of ba
 	skills_type = /datum/skills/combat_medic
 	display_order = JOB_DISPLAY_ORDER_SQUAD_CORPSMAN
 	outfit = /datum/outfit/job/marine/corpsman
-	var/larvaworth = LARVA_POINTS_REGULAR
+	larvaworth = LARVA_POINTS_REGULAR
 
 
 /datum/job/marine/corpsman/radio_help_message(mob/M)
@@ -111,7 +111,7 @@ You may not be a fully-fledged doctor, but you stand between life and death when
 	skills_type = /datum/skills/smartgunner
 	display_order = JOB_DISPLAY_ORDER_SQUAD_SMARTGUNNER
 	outfit = /datum/outfit/job/marine/smartgunner
-	var/larvaworth = LARVA_POINTS_REGULAR
+	larvaworth = LARVA_POINTS_REGULAR
 
 
 /datum/job/marine/smartgunner/radio_help_message(mob/M)
@@ -140,7 +140,7 @@ You may not be a fully-fledged doctor, but you stand between life and death when
 	outfit = /datum/outfit/job/marine/specialist
 	exp_requirements = XP_REQ_INTERMEDIATE
 	exp_type = EXP_TYPE_REGULAR_ALL
-	var/larvaworth = LARVA_POINTS_STRONG
+	larvaworth = LARVA_POINTS_STRONG
 
 
 /datum/job/marine/specialist/radio_help_message(mob/M)
@@ -172,7 +172,7 @@ You can serve a variety of roles, so choose carefully."})
 	outfit = /datum/outfit/job/marine/leader
 	exp_requirements = XP_REQ_EXPERIENCED
 	exp_type = EXP_TYPE_REGULAR_ALL
-	var/larvaworth = LARVA_POINTS_REGULAR
+	larvaworth = LARVA_POINTS_REGULAR
 
 
 /datum/job/marine/leader/radio_help_message(mob/M)

--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -20,7 +20,7 @@
 	outfit = /datum/outfit/job/command/captain
 	exp_requirements = XP_REQ_EXPERIENCED
 	exp_type = EXP_TYPE_REGULAR_ALL
-	var/larvaworth = LARVA_POINTS_SHIPSIDE
+	larvaworth = LARVA_POINTS_SHIPSIDE
 
 
 /datum/job/command/captain/radio_help_message(mob/M)
@@ -61,7 +61,7 @@ Godspeed, captain! And remember, you are not above the law."})
 	outfit = /datum/outfit/job/command/fieldcommander
 	exp_requirements = XP_REQ_EXPERIENCED
 	exp_type = EXP_TYPE_REGULAR_ALL
-	var/larvaworth = LARVA_POINTS_SHIPSIDE
+	larvaworth = LARVA_POINTS_REGULAR
 
 /datum/job/command/fieldcommander/after_spawn(mob/living/L, mob/M, latejoin)
 	. = ..()
@@ -107,7 +107,7 @@ Make the TGMC proud!"})
 	outfit = /datum/outfit/job/command/staffofficer
 	exp_requirements = XP_REQ_INTERMEDIATE
 	exp_type = EXP_TYPE_REGULAR_ALL
-	var/larvaworth = LARVA_POINTS_SHIPSIDE
+	larvaworth = LARVA_POINTS_SHIPSIDE
 
 
 /datum/job/command/staffofficer/radio_help_message(mob/M)
@@ -142,7 +142,7 @@ You are in charge of logistics and the overwatch system. You are also in line to
 	skills_type = /datum/skills/pilot
 	display_order = JOB_DISPLAY_ORDER_PILOT_OFFICER
 	outfit = /datum/outfit/job/command/pilot
-	var/larvaworth = LARVA_POINTS_SHIPSIDE
+	larvaworth = LARVA_POINTS_SHIPSIDE_STRONG
 
 
 /datum/job/command/pilot/radio_help_message(mob/M)
@@ -182,7 +182,7 @@ If you are not piloting, there is an autopilot fallback for command, but don't l
 	outfit = /datum/outfit/job/command/tank_crew
 	exp_requirements = XP_REQ_INTERMEDIATE
 	exp_type = EXP_TYPE_REGULAR_ALL
-	var/larvaworth = LARVA_POINTS_REGULAR
+	larvaworth = LARVA_POINTS_REGULAR
 
 
 /datum/job/command/tank_crew/radio_help_message(mob/M)
@@ -229,7 +229,7 @@ You could use MTs help to repair and replace hardpoints."})
 	skills_type = /datum/skills/MP
 	display_order = JOB_DISPLAY_ORDER_MILITARY_POLICE
 	outfit = /datum/outfit/job/police/officer
-	var/larvaworth = LARVA_POINTS_SHIPSIDE
+	larvaworth = LARVA_POINTS_SHIPSIDE
 
 
 /datum/job/police/officer/radio_help_message(mob/M)
@@ -271,7 +271,7 @@ In addition, you are tasked with the security of high-ranking personnel, includi
 	outfit = /datum/outfit/job/police/chief
 	exp_requirements = XP_REQ_INTERMEDIATE
 	exp_type = EXP_TYPE_REGULAR_ALL
-	var/larvaworth = LARVA_POINTS_SHIPSIDE
+	larvaworth = LARVA_POINTS_SHIPSIDE_STRONG
 
 
 /datum/job/police/chief/radio_help_message(mob/M)
@@ -321,7 +321,7 @@ In addition, you are tasked with the security of high-ranking personnel, includi
 	outfit = /datum/outfit/job/engineering/chief
 	exp_requirements = XP_REQ_INTERMEDIATE
 	exp_type = EXP_TYPE_REGULAR_ALL
-	var/larvaworth = LARVA_POINTS_SHIPSIDE
+	larvaworth = LARVA_POINTS_SHIPSIDE
 
 
 /datum/job/engineering/chief/radio_help_message(mob/M)
@@ -362,7 +362,7 @@ You are also next in the chain of command, should the bridge crew fall in the li
 	skills_type = /datum/skills/ST
 	display_order = JOB_DISPLAY_ORDER_SHIP_TECH
 	outfit = /datum/outfit/job/engineering/tech
-	var/larvaworth = LARVA_POINTS_SHIPSIDE
+	larvaworth = LARVA_POINTS_SHIPSIDE
 
 
 /datum/job/engineering/tech/radio_help_message(mob/M)
@@ -409,7 +409,7 @@ requisitions line and later on to be ready to send supplies for marines who are 
 	outfit = /datum/outfit/job/requisitions/officer
 	exp_requirements = XP_REQ_INTERMEDIATE
 	exp_type = EXP_TYPE_REGULAR_ALL
-	var/larvaworth = LARVA_POINTS_SHIPSIDE
+	larvaworth = LARVA_POINTS_SHIPSIDE
 
 
 /datum/job/requisitions/officer/radio_help_message(mob/M)
@@ -455,7 +455,7 @@ A happy ship is a well-functioning ship."})
 	outfit = /datum/outfit/job/medical/professor
 	exp_requirements = XP_REQ_INTERMEDIATE
 	exp_type = EXP_TYPE_REGULAR_ALL
-	var/larvaworth = LARVA_POINTS_SHIPSIDE
+	larvaworth = LARVA_POINTS_SHIPSIDE
 
 
 /datum/job/medical/professor/radio_help_message(mob/M)
@@ -498,7 +498,7 @@ Make sure that the doctors and nurses are doing their jobs and keeping the marin
 	skills_type = /datum/skills/doctor
 	display_order = JOB_DISPLAY_ORDER_DOCTOR
 	outfit = /datum/outfit/job/medical/medicalofficer
-	var/larvaworth = LARVA_POINTS_SHIPSIDE
+	larvaworth = LARVA_POINTS_SHIPSIDE
 
 /datum/job/medical/medicalofficer/radio_help_message(mob/M)
 	. = ..()
@@ -538,7 +538,7 @@ You are also an expert when it comes to medication and treatment. If you do not 
 	skills_type = /datum/skills/doctor
 	display_order = JOB_DISPLAY_ORDER_MEDIAL_RESEARCHER
 	outfit = /datum/outfit/job/medical/researcher
-	var/larvaworth = LARVA_POINTS_SHIPSIDE
+	larvaworth = LARVA_POINTS_SHIPSIDE
 
 
 /datum/job/medical/researcher/radio_help_message(mob/M)
@@ -585,7 +585,7 @@ While the Corporate Liaison is not your boss, it would be wise to consult them o
 	skills_type = /datum/skills/civilian
 	display_order = JOB_DISPLAY_ORDER_CORPORATE_LIAISON
 	outfit = /datum/outfit/job/civilian/liaison
-	var/larvaworth = LARVA_POINTS_SHIPSIDE
+	larvaworth = LARVA_POINTS_SHIPSIDE
 
 
 /datum/job/civilian/liaison/radio_help_message(mob/M)
@@ -621,7 +621,7 @@ Use your office fax machine to communicate with corporate headquarters or to acq
 	exp_requirements = XP_REQ_EXPERIENCED
 	exp_type = EXP_TYPE_REGULAR_ALL
 	job_flags = JOB_FLAG_SPECIALNAME
-	var/larvaworth = LARVA_POINTS_SYNTH
+	larvaworth = LARVA_POINTS_SHIPSIDE_STRONG
 
 
 /datum/job/civilian/synthetic/get_special_name(client/preference_source)
@@ -681,7 +681,7 @@ As a Synthetic you answer to the acting captain. Special circumstances may chang
 	exp_type_department = EXP_TYPE_SILICON
 	display_order = JOB_DISPLAY_ORDER_AI
 	job_flags = JOB_FLAG_SPECIALNAME
-	var/larvaworth = LARVA_POINTS_SHIPSIDE
+	larvaworth = LARVA_POINTS_SHIPSIDE
 
 
 /datum/job/ai/get_special_name(client/preference_source)

--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -20,6 +20,7 @@
 	outfit = /datum/outfit/job/command/captain
 	exp_requirements = XP_REQ_EXPERIENCED
 	exp_type = EXP_TYPE_REGULAR_ALL
+	var/larvaworth = LARVA_POINTS_SHIPSIDE
 
 
 /datum/job/command/captain/radio_help_message(mob/M)
@@ -60,6 +61,7 @@ Godspeed, captain! And remember, you are not above the law."})
 	outfit = /datum/outfit/job/command/fieldcommander
 	exp_requirements = XP_REQ_EXPERIENCED
 	exp_type = EXP_TYPE_REGULAR_ALL
+	var/larvaworth = LARVA_POINTS_SHIPSIDE
 
 /datum/job/command/fieldcommander/after_spawn(mob/living/L, mob/M, latejoin)
 	. = ..()
@@ -105,6 +107,7 @@ Make the TGMC proud!"})
 	outfit = /datum/outfit/job/command/staffofficer
 	exp_requirements = XP_REQ_INTERMEDIATE
 	exp_type = EXP_TYPE_REGULAR_ALL
+	var/larvaworth = LARVA_POINTS_SHIPSIDE
 
 
 /datum/job/command/staffofficer/radio_help_message(mob/M)
@@ -139,6 +142,7 @@ You are in charge of logistics and the overwatch system. You are also in line to
 	skills_type = /datum/skills/pilot
 	display_order = JOB_DISPLAY_ORDER_PILOT_OFFICER
 	outfit = /datum/outfit/job/command/pilot
+	var/larvaworth = LARVA_POINTS_SHIPSIDE
 
 
 /datum/job/command/pilot/radio_help_message(mob/M)
@@ -178,6 +182,7 @@ If you are not piloting, there is an autopilot fallback for command, but don't l
 	outfit = /datum/outfit/job/command/tank_crew
 	exp_requirements = XP_REQ_INTERMEDIATE
 	exp_type = EXP_TYPE_REGULAR_ALL
+	var/larvaworth = LARVA_POINTS_REGULAR
 
 
 /datum/job/command/tank_crew/radio_help_message(mob/M)
@@ -224,6 +229,7 @@ You could use MTs help to repair and replace hardpoints."})
 	skills_type = /datum/skills/MP
 	display_order = JOB_DISPLAY_ORDER_MILITARY_POLICE
 	outfit = /datum/outfit/job/police/officer
+	var/larvaworth = LARVA_POINTS_SHIPSIDE
 
 
 /datum/job/police/officer/radio_help_message(mob/M)
@@ -265,6 +271,7 @@ In addition, you are tasked with the security of high-ranking personnel, includi
 	outfit = /datum/outfit/job/police/chief
 	exp_requirements = XP_REQ_INTERMEDIATE
 	exp_type = EXP_TYPE_REGULAR_ALL
+	var/larvaworth = LARVA_POINTS_SHIPSIDE
 
 
 /datum/job/police/chief/radio_help_message(mob/M)
@@ -314,6 +321,7 @@ In addition, you are tasked with the security of high-ranking personnel, includi
 	outfit = /datum/outfit/job/engineering/chief
 	exp_requirements = XP_REQ_INTERMEDIATE
 	exp_type = EXP_TYPE_REGULAR_ALL
+	var/larvaworth = LARVA_POINTS_SHIPSIDE
 
 
 /datum/job/engineering/chief/radio_help_message(mob/M)
@@ -354,6 +362,7 @@ You are also next in the chain of command, should the bridge crew fall in the li
 	skills_type = /datum/skills/ST
 	display_order = JOB_DISPLAY_ORDER_SHIP_TECH
 	outfit = /datum/outfit/job/engineering/tech
+	var/larvaworth = LARVA_POINTS_SHIPSIDE
 
 
 /datum/job/engineering/tech/radio_help_message(mob/M)
@@ -400,6 +409,7 @@ requisitions line and later on to be ready to send supplies for marines who are 
 	outfit = /datum/outfit/job/requisitions/officer
 	exp_requirements = XP_REQ_INTERMEDIATE
 	exp_type = EXP_TYPE_REGULAR_ALL
+	var/larvaworth = LARVA_POINTS_SHIPSIDE
 
 
 /datum/job/requisitions/officer/radio_help_message(mob/M)
@@ -445,6 +455,7 @@ A happy ship is a well-functioning ship."})
 	outfit = /datum/outfit/job/medical/professor
 	exp_requirements = XP_REQ_INTERMEDIATE
 	exp_type = EXP_TYPE_REGULAR_ALL
+	var/larvaworth = LARVA_POINTS_SHIPSIDE
 
 
 /datum/job/medical/professor/radio_help_message(mob/M)
@@ -487,7 +498,7 @@ Make sure that the doctors and nurses are doing their jobs and keeping the marin
 	skills_type = /datum/skills/doctor
 	display_order = JOB_DISPLAY_ORDER_DOCTOR
 	outfit = /datum/outfit/job/medical/medicalofficer
-
+	var/larvaworth = LARVA_POINTS_SHIPSIDE
 
 /datum/job/medical/medicalofficer/radio_help_message(mob/M)
 	. = ..()
@@ -527,6 +538,7 @@ You are also an expert when it comes to medication and treatment. If you do not 
 	skills_type = /datum/skills/doctor
 	display_order = JOB_DISPLAY_ORDER_MEDIAL_RESEARCHER
 	outfit = /datum/outfit/job/medical/researcher
+	var/larvaworth = LARVA_POINTS_SHIPSIDE
 
 
 /datum/job/medical/researcher/radio_help_message(mob/M)
@@ -573,6 +585,7 @@ While the Corporate Liaison is not your boss, it would be wise to consult them o
 	skills_type = /datum/skills/civilian
 	display_order = JOB_DISPLAY_ORDER_CORPORATE_LIAISON
 	outfit = /datum/outfit/job/civilian/liaison
+	var/larvaworth = LARVA_POINTS_SHIPSIDE
 
 
 /datum/job/civilian/liaison/radio_help_message(mob/M)
@@ -608,6 +621,7 @@ Use your office fax machine to communicate with corporate headquarters or to acq
 	exp_requirements = XP_REQ_EXPERIENCED
 	exp_type = EXP_TYPE_REGULAR_ALL
 	job_flags = JOB_FLAG_SPECIALNAME
+	var/larvaworth = LARVA_POINTS_SYNTH
 
 
 /datum/job/civilian/synthetic/get_special_name(client/preference_source)
@@ -667,6 +681,7 @@ As a Synthetic you answer to the acting captain. Special circumstances may chang
 	exp_type_department = EXP_TYPE_SILICON
 	display_order = JOB_DISPLAY_ORDER_AI
 	job_flags = JOB_FLAG_SPECIALNAME
+	var/larvaworth = LARVA_POINTS_SHIPSIDE
 
 
 /datum/job/ai/get_special_name(client/preference_source)

--- a/code/datums/jobs/job/survivor.dm
+++ b/code/datums/jobs/job/survivor.dm
@@ -3,6 +3,7 @@
 	minimal_access = list(ACCESS_CIVILIAN_PUBLIC, ACCESS_CIVILIAN_RESEARCH, ACCESS_CIVILIAN_ENGINEERING, ACCESS_CIVILIAN_LOGISTICS)
 	skills_type = /datum/skills/civilian/survivor
 	faction = "Marine"
+	larvaworth = LARVA_POINTS_SHIPSIDE_STRONG
 
 
 //Assistant

--- a/code/game/objects/machinery/cryopod.dm
+++ b/code/game/objects/machinery/cryopod.dm
@@ -211,9 +211,6 @@
 			var/datum/game_mode/distress/D = SSticker.mode
 			var/datum/job/rank = SSjob.GetJob(job)
 			D.latejoin_larvapoints -= rank.larvaworth //Cryoing someone removes a player from the round, blocking further larva spawns until accounted for
-			if(D.latejoin_larvapoints < 0)
-				D.latejoin_larvapoints = 0
-			to_chat(world, "[D.latejoin_larvapoints]")
 		if(J.title in GLOB.jobs_police)
 			dept_console = CRYO_SEC
 		else if(J.title in GLOB.jobs_medical)

--- a/code/game/objects/machinery/cryopod.dm
+++ b/code/game/objects/machinery/cryopod.dm
@@ -209,7 +209,11 @@
 		J.current_positions--
 		if((J.title in GLOB.jobs_regular_all) && isdistress(SSticker?.mode))
 			var/datum/game_mode/distress/D = SSticker.mode
-			D.latejoin_tally-- //Cryoing someone removes a player from the round, blocking further larva spawns until accounted for
+			var/datum/job/rank = SSjob.GetJob(job)
+			D.latejoin_larvapoints -= rank.larvaworth //Cryoing someone removes a player from the round, blocking further larva spawns until accounted for
+			if(D.latejoin_larvapoints < 0)
+				D.latejoin_larvapoints = 0
+			to_chat(world, "[D.latejoin_larvapoints]")
 		if(J.title in GLOB.jobs_police)
 			dept_console = CRYO_SEC
 		else if(J.title in GLOB.jobs_medical)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
For reference: Currently, one xeno is spawned for every 3 humans alive (not SSD and in player-accessible z-levels)
With this change, Marines and the Survivor all have a 'job worth' now. This can easily be adjusted via defines. The number of points required for a larva to be spawned is a config option defaulting to 8 (distress) or 9 (crash) points now.
Most jobs add 3 points, preserving the old ratio. Most shipside roles add 1 point with stronger shipside roles being able to provide heavy support or lots of utility (like Synth) adding 2 and with specialists adding 4.5.
Effectively that means two specs will now cause a burrowed larva to be added, rather than the three you'd need before, with support roles doing light stuff or just RPing shipside not contributing too much to the problems the ground forces have to face.

## Why It's Good For The Game

Better finetuning in team balance.

## Changelog
:cl:
refactor: Made burrowed larva amount be dependant on a jobs estimated combat potential or support utility rather than bodycount
balance: Assigned combat worth/support utility to all common roles
config: Larva points required is a config option.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
