### PR TITLE
Buffs LMG and removes starting bipod from it

### DIFF
--- a/code/modules/projectiles/updated_projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/rifles.dm
@@ -421,14 +421,14 @@
 
 	flags_gun_features = GUN_AUTO_EJECTOR|GUN_AMMO_COUNTER|GUN_LOAD_INTO_CHAMBER
 	gun_firemode_list = list(GUN_FIREMODE_SEMIAUTO, GUN_FIREMODE_AUTOMATIC)
-	starting_attachment_types = list(/obj/item/attachable/stock/dmr, /obj/item/attachable/t42barrel,/obj/item/attachable/bipod)
+	starting_attachment_types = list(/obj/item/attachable/stock/dmr, /obj/item/attachable/t42barrel)
 	gun_skill_category = GUN_SKILL_HEAVY_WEAPONS
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 17,"rail_x" = 10, "rail_y" = 20, "under_x" = 24, "under_y" = 13, "stock_x" = 12, "stock_y" = 12)
 	fire_delay = 0.25 SECONDS
 	burst_amount = 0
 	accuracy_mult_unwielded = 0.5
-	accuracy_mult = 0.75
-	scatter = 25
+	accuracy_mult = 0.9
+	scatter = 20
 	scatter_unwielded = 80
 
 //-------------------------------------------------------


### PR DESCRIPTION
## About The Pull Request

reduces scatter from 25 to 20, ups base accuracy from 0.75 to 0.9 and removes the starting bipod

## Why It's Good For The Game

The LMG when it arrived was strong as fuck,but after a round of nerfs it became kind of meh,the bipod is actively bad on it and causes new players to suffer more with it because they don't know of it,also the base scatter and accuracy being worse than any other gun for no reason doesn't sit well with me when the whole point of the new guns was them not needing attachments to be usable,so this is an attempt to fix that,no it won't be like when it first arrived,it doesn't have the same fire delay or accuracy/scatter

## Changelog
:cl:
balance: Buffed LMG base accuracy and scatter and removed its starting bipod.
/:cl:

