### PR TITLE
Moved signal

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -222,7 +222,6 @@
 #define COMSIG_LIVING_DO_RESIST			"living_do_resist"		//from the base of /mob/living/do_resist()
 #define COMSIG_LIVING_DO_MOVE_RESIST "living_do_move_resist"			//from the base of /client/Move()
 	#define COMSIG_LIVING_RESIST_SUCCESSFUL (1<<0)
-#define COMSIG_LIVING_DO_MOVE_TURFTOTURF	"living_do_move_turftoturf"	//from the base of /client/Move()
 #define COMSIG_LIVING_LEGCUFFED "living_legcuffed"	//from the base of /mob/living/carbon/proc/update_legcuffed(): (obj/item/restraints/legcuffs/restraints)
 #define COMSIG_LIVING_SET_CANMOVE "living_set_canmove"			//from base of /mob/living/set_canmove(): (canmove)
 

--- a/code/datums/components/stamina_behavior.dm
+++ b/code/datums/components/stamina_behavior.dm
@@ -24,7 +24,7 @@
 	if(stamina_state == STAMINA_STATE_ACTIVE)
 		return
 	stamina_state = STAMINA_STATE_ACTIVE
-	RegisterSignal(parent, COMSIG_LIVING_DO_MOVE_TURFTOTURF, .proc/on_move_run)
+	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, .proc/on_move_run)
 	RegisterSignal(parent, COMSIG_LIVING_SET_CANMOVE, .proc/on_canmove_change)
 
 
@@ -32,11 +32,15 @@
 	if(stamina_state == STAMINA_STATE_IDLE)
 		return
 	stamina_state = STAMINA_STATE_IDLE
-	UnregisterSignal(parent, list(COMSIG_LIVING_DO_MOVE_TURFTOTURF, COMSIG_LIVING_SET_CANMOVE))
+	UnregisterSignal(parent, list(COMSIG_MOVABLE_MOVED, COMSIG_LIVING_SET_CANMOVE))
 
 
-/datum/component/stamina_behavior/proc/on_move_run(datum/source, n, direct)
+/datum/component/stamina_behavior/proc/on_move_run(datum/source, atom/oldloc, direction, Forced)
+	if(Forced)
+		return
 	var/mob/living/stamina_holder = parent
+	if(oldloc == stamina_holder.loc)
+		return
 	stamina_holder.adjustStaminaLoss(1)
 	if(stamina_holder.staminaloss >= 0)
 		stamina_holder.toggle_move_intent(MOVE_INTENT_WALK)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -240,10 +240,8 @@
 
 /atom/movable/proc/Moved(atom/oldloc, direction, Forced = FALSE)
 	SEND_SIGNAL(src, COMSIG_MOVABLE_MOVED, oldloc, direction, Forced)
-	var/datum/light_source/L
-	var/thing
-	for(thing in light_sources) // Cycle through the light sources on this atom and tell them to update.
-		L = thing
+	for(var/thing in light_sources) // Cycle through the light sources on this atom and tell them to update.
+		var/datum/light_source/L = thing
 		L.source_atom.update_light()
 	return TRUE
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -240,6 +240,11 @@
 
 /atom/movable/proc/Moved(atom/oldloc, direction, Forced = FALSE)
 	SEND_SIGNAL(src, COMSIG_MOVABLE_MOVED, oldloc, direction, Forced)
+	var/datum/light_source/L
+	var/thing
+	for(thing in light_sources) // Cycle through the light sources on this atom and tell them to update.
+		L = thing
+		L.source_atom.update_light()
 	return TRUE
 
 

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -81,15 +81,6 @@
 			T.reconsider_lights()
 
 
-/atom/movable/Moved(atom/OldLoc, Dir)
-	. = ..()
-	var/datum/light_source/L
-	var/thing
-	for(thing in light_sources) // Cycle through the light sources on this atom and tell them to update.
-		L = thing
-		L.source_atom.update_light()
-
-
 /atom/vv_edit_var(var_name, var_value)
 	switch(var_name)
 		if("light_range")

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -125,8 +125,6 @@
 
 	L.last_move_intent = world.time + 1 SECONDS
 
-	SEND_SIGNAL(L, COMSIG_LIVING_DO_MOVE_TURFTOTURF, n, direct)
-
 	if(L.confused)
 		var/newdir = 0
 		if(L.confused > 40)


### PR DESCRIPTION
Removes a pre-move signal in favor of using the moved one to reduce quirky behavior such as stamina draining on failed move attempts.