### PR TITLE
Assembly runtime fix

### DIFF
--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -103,9 +103,9 @@
 	if(.)
 		return
 	if(a_left)
-		a_left.attack_hand()
+		a_left.attack_hand(user)
 	if(a_right)
-		a_right.attack_hand()
+		a_right.attack_hand(user)
 
 
 /obj/item/assembly_holder/screwdriver_act(mob/user, obj/item/tool)


### PR DESCRIPTION
```
[16:19:59] Runtime in atoms.dm, line 623: Cannot read null.type
proc name: add fingerprint (/atom/proc/add_fingerprint)
usr: CKEY/(Andrew Johnes)
usr.loc: (Research Lab (77, 50, 2))
src: the timer (/obj/item/assembly/timer)
src.loc: the igniter-timer assembly (/obj/item/assembly_holder)
call stack:
the timer (/obj/item/assembly/timer): add fingerprint(null, "attack_hand", null)
the timer (/obj/item/assembly/timer): attack hand(null)
the timer (/obj/item/assembly/timer): attack hand(null)
the timer (/obj/item/assembly/timer): attack hand(null)
the igniter-timer assembly (/obj/item/assembly_holder): attack hand(Andrew Johnes (/mob/living/carbon/human))
Andrew Johnes (/mob/living/carbon/human): UnarmedAttack(the igniter-timer assembly (/obj/item/assembly_holder), 1)
Andrew Johnes (/mob/living/carbon/human): ClickOn(the igniter-timer assembly (/obj/item/assembly_holder), "icon-x=16;icon-y=16;left=1;scr...")
the igniter-timer assembly (/obj/item/assembly_holder): Click(the floor (77,51,2) (/turf/open/floor/tile/white), "mapwindow.map", "icon-x=16;icon-y=16;left=1;scr...")
CKEY (/client): Click(the igniter-timer assembly (/obj/item/assembly_holder), the floor (77,51,2) (/turf/open/floor/tile/white), "mapwindow.map", "icon-x=16;icon-y=16;left=1;scr...")
```