### PR TITLE
Lever Action Rifle sprite fix

### DIFF
--- a/code/modules/projectiles/updated_projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/shotguns.dm
@@ -640,6 +640,7 @@ can cause issues with ammo types getting mixed up during the burst.
 	gun_skill_category = GUN_SKILL_RIFLES
 	type_of_casings = "cartridge"
 	pump_sound = 'sound/weapons/guns/interact/ak47_cocked.ogg'//good enough for now.
+	flags_item_map_variant = NONE
 	attachable_allowed = list(
 						/obj/item/attachable/reddot,
 						/obj/item/attachable/scope/mini,


### PR DESCRIPTION


## About The Pull Request

Fixes #3492
Lever action doesn't have any map variants.

## Why It's Good For The Game

bugfix

## Changelog
:cl: Hughgent
fix: Lever action rifle sprite fix
/:cl:
