### PR TITLE
Buffs Xenos upgrade/evolution times

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
@@ -25,8 +25,8 @@
 	max_health = 180
 
 	// *** Evolution *** //
-	evolution_threshold = 200
-	upgrade_threshold = 200
+	evolution_threshold = 100
+	upgrade_threshold = 100
 
 	evolves_to = list(/mob/living/carbon/xenomorph/crusher)
 	deevolves_to = /mob/living/carbon/xenomorph/runner
@@ -71,7 +71,7 @@
 	max_health = 200
 
 	// *** Evolution *** //
-	upgrade_threshold = 400
+	upgrade_threshold = 150
 
 	// *** Defense *** //
 	armor = list("melee" = 28, "bullet" = 28, "laser" = 28, "energy" = 28, "bomb" = XENO_BOMB_RESIST_0, "bio" = 28, "rad" = 28, "fire" = 18, "acid" = 28)
@@ -96,7 +96,7 @@
 	max_health = 220
 
 	// *** Evolution *** //
-	upgrade_threshold = 800
+	upgrade_threshold = 200
 
 	// *** Defense *** //
 	armor = list("melee" = 30, "bullet" = 30, "laser" = 30, "energy" = 30, "bomb" = XENO_BOMB_RESIST_0, "bio" = 30, "rad" = 30, "fire" = 20, "acid" = 30)
@@ -121,7 +121,7 @@
 	max_health = 240
 
 	// *** Evolution *** //
-	upgrade_threshold = 800
+	upgrade_threshold = 250
 
 	// *** Defense *** //
 	armor = list("melee" = 33, "bullet" = 33, "laser" = 33, "energy" = 33, "bomb" = XENO_BOMB_RESIST_0, "bio" = 33, "rad" = 33, "fire" = 25, "acid" = 33)

--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
@@ -25,8 +25,8 @@
 	max_health = 180
 
 	// *** Evolution *** //
-	evolution_threshold = 100
-	upgrade_threshold = 100
+	evolution_threshold = 150
+	upgrade_threshold = 150
 
 	evolves_to = list(/mob/living/carbon/xenomorph/crusher)
 	deevolves_to = /mob/living/carbon/xenomorph/runner
@@ -71,7 +71,7 @@
 	max_health = 200
 
 	// *** Evolution *** //
-	upgrade_threshold = 150
+	upgrade_threshold = 175
 
 	// *** Defense *** //
 	armor = list("melee" = 28, "bullet" = 28, "laser" = 28, "energy" = 28, "bomb" = XENO_BOMB_RESIST_0, "bio" = 28, "rad" = 28, "fire" = 18, "acid" = 28)

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/castedatum_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/castedatum_carrier.dm
@@ -27,8 +27,8 @@
 	max_health = 200
 
 	// *** Evolution *** //
-	evolution_threshold = 100
-	upgrade_threshold = 100
+	evolution_threshold = 150
+	upgrade_threshold = 150
 
 	deevolves_to = /mob/living/carbon/xenomorph/drone
 
@@ -89,7 +89,7 @@
 	max_health = 220
 
 	// *** Evolution *** //
-	upgrade_threshold = 150
+	upgrade_threshold = 175
 
 	// *** Defense *** //
 	armor = list("melee" = 5, "bullet" = 5, "laser" = 5, "energy" = 5, "bomb" = XENO_BOMB_RESIST_0, "bio" = 5, "rad" = 5, "fire" = 0, "acid" = 5)

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/castedatum_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/castedatum_carrier.dm
@@ -27,8 +27,8 @@
 	max_health = 200
 
 	// *** Evolution *** //
-	evolution_threshold = 200
-	upgrade_threshold = 200
+	evolution_threshold = 100
+	upgrade_threshold = 100
 
 	deevolves_to = /mob/living/carbon/xenomorph/drone
 
@@ -89,7 +89,7 @@
 	max_health = 220
 
 	// *** Evolution *** //
-	upgrade_threshold = 400
+	upgrade_threshold = 150
 
 	// *** Defense *** //
 	armor = list("melee" = 5, "bullet" = 5, "laser" = 5, "energy" = 5, "bomb" = XENO_BOMB_RESIST_0, "bio" = 5, "rad" = 5, "fire" = 0, "acid" = 5)
@@ -125,7 +125,7 @@
 	max_health = 230
 
 	// *** Evolution *** //
-	upgrade_threshold = 800
+	upgrade_threshold = 200
 
 	// *** Defense *** //
 	armor = list("melee" = 7, "bullet" = 7, "laser" = 7, "energy" = 7, "bomb" = XENO_BOMB_RESIST_0, "bio" = 7, "rad" = 7, "fire" = 0, "acid" = 7)
@@ -161,7 +161,7 @@
 	max_health = 240
 
 	// *** Evolution *** //
-	upgrade_threshold = 800
+	upgrade_threshold = 250
 
 	// *** Defense *** //
 	armor = list("melee" = 10, "bullet" = 10, "laser" = 10, "energy" = 10, "bomb" = XENO_BOMB_RESIST_0, "bio" = 10, "rad" = 10, "fire" = 0, "acid" = 10)

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -27,7 +27,7 @@
 	max_health = 300
 
 	// *** Evolution *** //
-	upgrade_threshold = 400
+	upgrade_threshold = 200
 
 	deevolves_to = /mob/living/carbon/xenomorph/bull
 
@@ -74,7 +74,7 @@
 	max_health = 325
 
 	// *** Evolution *** //
-	upgrade_threshold = 800
+	upgrade_threshold = 250
 
 	// *** Defense *** //
 	armor = list("melee" = 90, "bullet" = 45, "laser" = 45, "energy" = 90, "bomb" = XENO_BOMB_RESIST_3, "bio" = 90, "rad" = 90, "fire" = 0, "acid" = 90)
@@ -102,7 +102,7 @@
 	max_health = 340
 
 	// *** Evolution *** //
-	upgrade_threshold = 1600
+	upgrade_threshold = 300
 
 	// *** Defense *** //
 	armor = list("melee" = 95, "bullet" = 47, "laser" = 47, "energy" = 95, "bomb" = XENO_BOMB_RESIST_3, "bio" = 95, "rad" = 95, "fire" = 0, "acid" = 95)

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -27,7 +27,7 @@
 	max_health = 300
 
 	// *** Evolution *** //
-	upgrade_threshold = 200
+	upgrade_threshold = 250
 
 	deevolves_to = /mob/living/carbon/xenomorph/bull
 
@@ -74,7 +74,7 @@
 	max_health = 325
 
 	// *** Evolution *** //
-	upgrade_threshold = 250
+	upgrade_threshold = 300
 
 	// *** Defense *** //
 	armor = list("melee" = 90, "bullet" = 45, "laser" = 45, "energy" = 90, "bomb" = XENO_BOMB_RESIST_3, "bio" = 90, "rad" = 90, "fire" = 0, "acid" = 90)
@@ -102,7 +102,7 @@
 	max_health = 340
 
 	// *** Evolution *** //
-	upgrade_threshold = 300
+	upgrade_threshold = 350
 
 	// *** Defense *** //
 	armor = list("melee" = 95, "bullet" = 47, "laser" = 47, "energy" = 95, "bomb" = XENO_BOMB_RESIST_3, "bio" = 95, "rad" = 95, "fire" = 0, "acid" = 95)
@@ -125,6 +125,9 @@
 	// *** Plasma *** //
 	plasma_max = 400
 	plasma_gain = 30
+
+	// *** Evolution *** //
+	upgrade_threshold = 400
 
 	// *** Health *** //
 	max_health = 350

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
@@ -27,8 +27,8 @@
 	max_health = 250
 
 	// *** Evolution *** //
-	evolution_threshold = 50
-	upgrade_threshold = 50
+	evolution_threshold = 75
+	upgrade_threshold = 75
 
 	evolves_to = list(/mob/living/carbon/xenomorph/warrior)
 
@@ -81,7 +81,7 @@
 	max_health = 260
 
 	// *** Evolution *** //
-	upgrade_threshold = 75
+	upgrade_threshold = 100
 
 	// *** Defense *** //
 	armor = list("melee" = 33, "bullet" = 33, "laser" = 28, "energy" = 25, "bomb" = XENO_BOMB_RESIST_2, "bio" = 25, "rad" = 25, "fire" = 7, "acid" = 25)
@@ -112,7 +112,7 @@
 	max_health = 270
 
 	// *** Evolution *** //
-	upgrade_threshold = 100
+	upgrade_threshold = 125
 
 	// *** Defense *** //
 	armor = list("melee" = 35, "bullet" = 35, "laser" = 30, "energy" = 28, "bomb" = XENO_BOMB_RESIST_2, "bio" = 28, "rad" = 28, "fire" = 9, "acid" = 28)

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
@@ -27,8 +27,8 @@
 	max_health = 250
 
 	// *** Evolution *** //
-	evolution_threshold = 100
-	upgrade_threshold = 100
+	evolution_threshold = 50
+	upgrade_threshold = 50
 
 	evolves_to = list(/mob/living/carbon/xenomorph/warrior)
 
@@ -81,7 +81,7 @@
 	max_health = 260
 
 	// *** Evolution *** //
-	upgrade_threshold = 200
+	upgrade_threshold = 75
 
 	// *** Defense *** //
 	armor = list("melee" = 33, "bullet" = 33, "laser" = 28, "energy" = 25, "bomb" = XENO_BOMB_RESIST_2, "bio" = 25, "rad" = 25, "fire" = 7, "acid" = 25)
@@ -112,7 +112,7 @@
 	max_health = 270
 
 	// *** Evolution *** //
-	upgrade_threshold = 400
+	upgrade_threshold = 100
 
 	// *** Defense *** //
 	armor = list("melee" = 35, "bullet" = 35, "laser" = 30, "energy" = 28, "bomb" = XENO_BOMB_RESIST_2, "bio" = 28, "rad" = 28, "fire" = 9, "acid" = 28)
@@ -144,7 +144,7 @@
 	max_health = 280
 
 	// *** Evolution *** //
-	upgrade_threshold = 400
+	upgrade_threshold = 150
 
 	// *** Defense *** //
 	armor = list("melee" = 37, "bullet" = 37, "laser" = 32, "energy" = 30, "bomb" = XENO_BOMB_RESIST_2, "bio" = 30, "rad" = 30, "fire" = 10, "acid" = 30)

--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/castedatum_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/castedatum_defiler.dm
@@ -27,7 +27,7 @@
 	max_health = 280
 
 	// *** Evolution *** //
-	upgrade_threshold = 400
+	upgrade_threshold = 200
 
 	deevolves_to = /mob/living/carbon/xenomorph/carrier
 
@@ -78,7 +78,7 @@
 	max_health = 300
 
 	// *** Evolution *** //
-	upgrade_threshold = 800
+	upgrade_threshold = 250
 
 	// *** Defense *** //
 	armor = list("melee" = 35, "bullet" = 17, "laser" = 17, "energy" = 35, "bomb" = XENO_BOMB_RESIST_0, "bio" = 35, "rad" = 35, "fire" = 12, "acid" = 35)
@@ -109,7 +109,7 @@
 	max_health = 325
 
 	// *** Evolution *** //
-	upgrade_threshold = 1600
+	upgrade_threshold = 300
 
 	// *** Defense *** //
 	armor = list("melee" = 38, "bullet" = 19, "laser" = 19, "energy" = 38, "bomb" = XENO_BOMB_RESIST_0, "bio" = 38, "rad" = 38, "fire" = 14, "acid" = 38)
@@ -140,7 +140,7 @@
 	max_health = 340
 
 	// *** Evolution *** //
-	upgrade_threshold = 1600
+	upgrade_threshold = 350
 
 	// *** Defense *** //
 	armor = list("melee" = 40, "bullet" = 20, "laser" = 20, "energy" = 40, "bomb" = XENO_BOMB_RESIST_0, "bio" = 40, "rad" = 40, "fire" = 20, "acid" = 40)

--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/castedatum_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/castedatum_defiler.dm
@@ -27,7 +27,7 @@
 	max_health = 280
 
 	// *** Evolution *** //
-	upgrade_threshold = 200
+	upgrade_threshold = 250
 
 	deevolves_to = /mob/living/carbon/xenomorph/carrier
 
@@ -78,7 +78,7 @@
 	max_health = 300
 
 	// *** Evolution *** //
-	upgrade_threshold = 250
+	upgrade_threshold = 300
 
 	// *** Defense *** //
 	armor = list("melee" = 35, "bullet" = 17, "laser" = 17, "energy" = 35, "bomb" = XENO_BOMB_RESIST_0, "bio" = 35, "rad" = 35, "fire" = 12, "acid" = 35)
@@ -109,7 +109,7 @@
 	max_health = 325
 
 	// *** Evolution *** //
-	upgrade_threshold = 300
+	upgrade_threshold = 350
 
 	// *** Defense *** //
 	armor = list("melee" = 38, "bullet" = 19, "laser" = 19, "energy" = 38, "bomb" = XENO_BOMB_RESIST_0, "bio" = 38, "rad" = 38, "fire" = 14, "acid" = 38)
@@ -140,7 +140,7 @@
 	max_health = 340
 
 	// *** Evolution *** //
-	upgrade_threshold = 350
+	upgrade_threshold = 400
 
 	// *** Defense *** //
 	armor = list("melee" = 40, "bullet" = 20, "laser" = 20, "energy" = 40, "bomb" = XENO_BOMB_RESIST_0, "bio" = 40, "rad" = 40, "fire" = 20, "acid" = 40)

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
@@ -25,8 +25,8 @@
 	max_health = 120
 
 	// *** Evolution *** //
-	evolution_threshold = 50
-	upgrade_threshold = 50
+	evolution_threshold = 75
+	upgrade_threshold = 75
 
 	evolves_to = list(/mob/living/carbon/xenomorph/shrike, /mob/living/carbon/xenomorph/carrier, /mob/living/carbon/xenomorph/hivelord)
 
@@ -84,7 +84,7 @@
 	max_health = 150
 
 	// *** Evolution *** //
-	upgrade_threshold = 75
+	upgrade_threshold = 100
 
 	// *** Defense *** //
 	armor = list("melee" = 5, "bullet" = 3, "laser" = 3, "energy" = 5, "bomb" = XENO_BOMB_RESIST_0, "bio" = 5, "rad" = 5, "fire" = 5, "acid" = 5)
@@ -115,7 +115,7 @@
 	max_health = 170
 
 	// *** Evolution *** //
-	upgrade_threshold = 100
+	upgrade_threshold = 125
 
 	// *** Defense *** //
 	armor = list("melee" = 10, "bullet" = 5, "laser" = 5, "energy" = 10, "bomb" = XENO_BOMB_RESIST_0, "bio" = 10, "rad" = 10, "fire" = 10, "acid" = 10)

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
@@ -25,8 +25,8 @@
 	max_health = 120
 
 	// *** Evolution *** //
-	evolution_threshold = 100
-	upgrade_threshold = 100
+	evolution_threshold = 50
+	upgrade_threshold = 50
 
 	evolves_to = list(/mob/living/carbon/xenomorph/shrike, /mob/living/carbon/xenomorph/carrier, /mob/living/carbon/xenomorph/hivelord)
 
@@ -84,7 +84,7 @@
 	max_health = 150
 
 	// *** Evolution *** //
-	upgrade_threshold = 200
+	upgrade_threshold = 75
 
 	// *** Defense *** //
 	armor = list("melee" = 5, "bullet" = 3, "laser" = 3, "energy" = 5, "bomb" = XENO_BOMB_RESIST_0, "bio" = 5, "rad" = 5, "fire" = 5, "acid" = 5)
@@ -115,7 +115,7 @@
 	max_health = 170
 
 	// *** Evolution *** //
-	upgrade_threshold = 400
+	upgrade_threshold = 100
 
 	// *** Defense *** //
 	armor = list("melee" = 10, "bullet" = 5, "laser" = 5, "energy" = 10, "bomb" = XENO_BOMB_RESIST_0, "bio" = 10, "rad" = 10, "fire" = 10, "acid" = 10)
@@ -141,6 +141,9 @@
 	// *** Plasma *** //
 	plasma_max = 1000
 	plasma_gain = 40
+
+	// *** Evolution *** //
+	upgrade_threshold = 150
 
 	// *** Health *** //
 	max_health = 180

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/castedatum_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/castedatum_hivelord.dm
@@ -24,8 +24,8 @@
 	max_health = 250
 
 	// *** Evolution *** //
-	evolution_threshold = 100
-	upgrade_threshold = 100
+	evolution_threshold = 150
+	upgrade_threshold = 150
 
 	deevolves_to = /mob/living/carbon/xenomorph/drone
 
@@ -89,7 +89,7 @@
 	max_health = 275
 
 	// *** Evolution *** //
-	upgrade_threshold = 150
+	upgrade_threshold = 175
 
 	// *** Defense *** //
 	armor = list("melee" = 15, "bullet" = 7, "laser" = 7, "energy" = 15, "bomb" = XENO_BOMB_RESIST_0, "bio" = 15, "rad" = 15, "fire" = 15, "acid" = 15)

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/castedatum_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/castedatum_hivelord.dm
@@ -24,8 +24,8 @@
 	max_health = 250
 
 	// *** Evolution *** //
-	evolution_threshold = 200
-	upgrade_threshold = 200
+	evolution_threshold = 100
+	upgrade_threshold = 100
 
 	deevolves_to = /mob/living/carbon/xenomorph/drone
 
@@ -89,7 +89,7 @@
 	max_health = 275
 
 	// *** Evolution *** //
-	upgrade_threshold = 400
+	upgrade_threshold = 150
 
 	// *** Defense *** //
 	armor = list("melee" = 15, "bullet" = 7, "laser" = 7, "energy" = 15, "bomb" = XENO_BOMB_RESIST_0, "bio" = 15, "rad" = 15, "fire" = 15, "acid" = 15)
@@ -123,7 +123,7 @@
 	max_health = 290
 
 	// *** Evolution *** //
-	upgrade_threshold = 800
+	upgrade_threshold = 200
 
 	// *** Defense *** //
 	armor = list("melee" = 18, "bullet" = 9, "laser" = 9, "energy" = 18, "bomb" = XENO_BOMB_RESIST_0, "bio" = 18, "rad" = 18, "fire" = 18, "acid" = 18)
@@ -158,7 +158,7 @@
 	max_health = 300
 
 	// *** Evolution *** //
-	upgrade_threshold = 800
+	upgrade_threshold = 250
 
 	// *** Defense *** //
 	armor = list("melee" = 20, "bullet" = 10, "laser" = 10, "energy" = 20, "bomb" = XENO_BOMB_RESIST_0, "bio" = 20, "rad" = 20, "fire" = 20, "acid" = 20)

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
@@ -28,8 +28,8 @@
 	max_health = 150
 
 	// *** Evolution *** //
-	evolution_threshold = 200
-	upgrade_threshold = 200
+	evolution_threshold = 100
+	upgrade_threshold = 100
 
 	evolves_to = list(/mob/living/carbon/xenomorph/ravager)
 	deevolves_to = /mob/living/carbon/xenomorph/runner
@@ -80,7 +80,7 @@
 	max_health = 175
 
 	// *** Evolution *** //
-	upgrade_threshold = 400
+	upgrade_threshold = 150
 
 	// *** Defense *** //
 	armor = list("melee" = 13, "bullet" = 13, "laser" = 13, "energy" = 13, "bomb" = XENO_BOMB_RESIST_0, "bio" = 15, "rad" = 15, "fire" = 5, "acid" = 15)
@@ -111,7 +111,7 @@
 	max_health = 190
 
 	// *** Evolution *** //
-	upgrade_threshold = 800
+	upgrade_threshold = 200
 
 	// *** Defense *** //
 	armor = list("melee" = 15, "bullet" = 15, "laser" = 15, "energy" = 18, "bomb" = XENO_BOMB_RESIST_0, "bio" = 18, "rad" = 18, "fire" = 7, "acid" = 18)
@@ -143,7 +143,7 @@
 	max_health = 200
 
 	// *** Evolution *** //
-	upgrade_threshold = 800
+	upgrade_threshold = 250
 
 	// *** Defense *** //
 	armor = list("melee" = 18, "bullet" = 18, "laser" = 18, "energy" = 18, "bomb" = XENO_BOMB_RESIST_0, "bio" = 18, "rad" = 18, "fire" = 10, "acid" = 18)

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
@@ -28,8 +28,8 @@
 	max_health = 150
 
 	// *** Evolution *** //
-	evolution_threshold = 100
-	upgrade_threshold = 100
+	evolution_threshold = 150
+	upgrade_threshold = 150
 
 	evolves_to = list(/mob/living/carbon/xenomorph/ravager)
 	deevolves_to = /mob/living/carbon/xenomorph/runner
@@ -80,7 +80,7 @@
 	max_health = 175
 
 	// *** Evolution *** //
-	upgrade_threshold = 150
+	upgrade_threshold = 175
 
 	// *** Defense *** //
 	armor = list("melee" = 13, "bullet" = 13, "laser" = 13, "energy" = 13, "bomb" = XENO_BOMB_RESIST_0, "bio" = 15, "rad" = 15, "fire" = 5, "acid" = 15)

--- a/code/modules/mob/living/carbon/xenomorph/castes/larva/larva.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/larva/larva.dm
@@ -3,7 +3,7 @@
 	speak_emote = list("hisses")
 	icon_state = "Bloody Larva"
 	amount_grown = 0
-	max_grown = 100
+	max_grown = 10
 	maxHealth = 35
 	health = 35
 	see_in_dark = 8

--- a/code/modules/mob/living/carbon/xenomorph/castes/larva/larva.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/larva/larva.dm
@@ -56,9 +56,9 @@
 	var/progress = "" //Naming convention, three different names
 
 	switch(amount_grown)
-		if(0 to 49) //We're still bloody
+		if(0 to 5) //We're still bloody
 			progress = "Bloody "
-		if(100 to INFINITY)
+		if(6 to INFINITY)
 			progress = "Mature "
 
 	name = "\improper [hive.prefix][progress]Larva ([nicknumber])"

--- a/code/modules/mob/living/carbon/xenomorph/castes/larva/larva.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/larva/larva.dm
@@ -3,7 +3,7 @@
 	speak_emote = list("hisses")
 	icon_state = "Bloody Larva"
 	amount_grown = 0
-	max_grown = 10
+	max_grown = 25
 	maxHealth = 35
 	health = 35
 	see_in_dark = 8
@@ -56,9 +56,9 @@
 	var/progress = "" //Naming convention, three different names
 
 	switch(amount_grown)
-		if(0 to 5) //We're still bloody
+		if(0 to 15) //We're still bloody
 			progress = "Bloody "
-		if(6 to INFINITY)
+		if(16 to INFINITY)
 			progress = "Mature "
 
 	name = "\improper [hive.prefix][progress]Larva ([nicknumber])"
@@ -75,7 +75,7 @@
 	generate_name()
 
 	var/bloody = ""
-	if(amount_grown < 50)
+	if(amount_grown < 15)
 		bloody = "Bloody "
 
 	color = hive.color

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
@@ -25,7 +25,7 @@
 	max_health = 210
 
 	// *** Evolution *** //
-	upgrade_threshold = 400
+	upgrade_threshold = 200
 
 	deevolves_to = /mob/living/carbon/xenomorph/spitter
 
@@ -83,7 +83,7 @@
 	max_health = 250
 
 	// *** Evolution *** //
-	upgrade_threshold = 800
+	upgrade_threshold = 250
 
 	// *** Defense *** //
 	armor = list("melee" = 33, "bullet" = 33, "laser" = 33, "energy" = 33, "bomb" = XENO_BOMB_RESIST_0, "bio" = 33, "rad" = 33, "fire" = 13, "acid" = 33)
@@ -117,7 +117,7 @@
 	max_health = 270
 
 	// *** Evolution *** //
-	upgrade_threshold = 1600
+	upgrade_threshold = 300
 
 	// *** Defense *** //
 	armor = list("melee" = 35, "bullet" = 35, "laser" = 35, "energy" = 35, "bomb" = XENO_BOMB_RESIST_0, "bio" = 35, "rad" = 35, "fire" = 15, "acid" = 35)

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
@@ -25,7 +25,7 @@
 	max_health = 210
 
 	// *** Evolution *** //
-	upgrade_threshold = 200
+	upgrade_threshold = 250
 
 	deevolves_to = /mob/living/carbon/xenomorph/spitter
 
@@ -80,7 +80,7 @@
 	plasma_gain = 30
 
 	// *** Health *** //
-	max_health = 250
+	max_health = 300
 
 	// *** Evolution *** //
 	upgrade_threshold = 250
@@ -117,7 +117,7 @@
 	max_health = 270
 
 	// *** Evolution *** //
-	upgrade_threshold = 300
+	upgrade_threshold = 350
 
 	// *** Defense *** //
 	armor = list("melee" = 35, "bullet" = 35, "laser" = 35, "energy" = 35, "bomb" = XENO_BOMB_RESIST_0, "bio" = 35, "rad" = 35, "fire" = 15, "acid" = 35)
@@ -147,6 +147,9 @@
 	// *** Plasma *** //
 	plasma_max = 1000
 	plasma_gain = 50
+
+	// *** Evolution *** //
+	upgrade_threshold = 400
 
 	// *** Health *** //
 	max_health = 280

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
@@ -25,7 +25,7 @@
 	max_health = 200
 
 	// *** Evolution *** //
-	upgrade_threshold = 800
+	upgrade_threshold = 300
 
 	// *** Flags *** //
 	caste_flags = CASTE_IS_INTELLIGENT|CASTE_CAN_HOLD_FACEHUGGERS|CASTE_FIRE_IMMUNE|CASTE_HIDE_IN_STATUS
@@ -95,7 +95,7 @@
 	max_health = 225
 
 	// *** Evolution *** //
-	upgrade_threshold = 1600
+	upgrade_threshold = 400
 
 	// *** Defense *** //
 	armor = list("melee" = 35, "bullet" = 35, "laser" = 35, "energy" = 35, "bomb" = XENO_BOMB_RESIST_3, "bio" = 50, "rad" = 50, "fire" = 100, "acid" = 50)
@@ -131,7 +131,7 @@
 	max_health = 250
 
 	// *** Evolution *** //
-	upgrade_threshold = 3200
+	upgrade_threshold = 500
 
 	// *** Defense *** //
 	armor = list("melee" = 40, "bullet" = 40, "laser" = 40, "energy" = 40, "bomb" = XENO_BOMB_RESIST_3, "bio" = 55, "rad" = 55, "fire" = 100, "acid" = 55)
@@ -167,7 +167,7 @@
 	max_health = 275
 
 	// *** Evolution *** //
-	upgrade_threshold = 3200
+	upgrade_threshold = 600
 
 	// *** Defense *** //
 	armor = list("melee" = 45, "bullet" = 45, "laser" = 45, "energy" = 45, "bomb" = XENO_BOMB_RESIST_3, "bio" = 60, "rad" = 60, "fire" = 100, "acid" = 60)

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
@@ -25,7 +25,7 @@
 	max_health = 200
 
 	// *** Evolution *** //
-	upgrade_threshold = 300
+	upgrade_threshold = 500
 
 	// *** Flags *** //
 	caste_flags = CASTE_IS_INTELLIGENT|CASTE_CAN_HOLD_FACEHUGGERS|CASTE_FIRE_IMMUNE|CASTE_HIDE_IN_STATUS
@@ -95,7 +95,7 @@
 	max_health = 225
 
 	// *** Evolution *** //
-	upgrade_threshold = 400
+	upgrade_threshold = 600
 
 	// *** Defense *** //
 	armor = list("melee" = 35, "bullet" = 35, "laser" = 35, "energy" = 35, "bomb" = XENO_BOMB_RESIST_3, "bio" = 50, "rad" = 50, "fire" = 100, "acid" = 50)
@@ -131,7 +131,7 @@
 	max_health = 250
 
 	// *** Evolution *** //
-	upgrade_threshold = 500
+	upgrade_threshold = 700
 
 	// *** Defense *** //
 	armor = list("melee" = 40, "bullet" = 40, "laser" = 40, "energy" = 40, "bomb" = XENO_BOMB_RESIST_3, "bio" = 55, "rad" = 55, "fire" = 100, "acid" = 55)
@@ -167,7 +167,7 @@
 	max_health = 275
 
 	// *** Evolution *** //
-	upgrade_threshold = 600
+	upgrade_threshold = 800
 
 	// *** Defense *** //
 	armor = list("melee" = 45, "bullet" = 45, "laser" = 45, "energy" = 45, "bomb" = XENO_BOMB_RESIST_3, "bio" = 60, "rad" = 60, "fire" = 100, "acid" = 60)

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
@@ -26,7 +26,7 @@
 	max_health = 225
 
 	// *** Evolution *** //
-	upgrade_threshold = 200
+	upgrade_threshold = 250
 
 	deevolves_to = /mob/living/carbon/xenomorph/hunter
 
@@ -74,7 +74,7 @@
 	max_health = 265
 
 	// *** Evolution *** //
-	upgrade_threshold = 250
+	upgrade_threshold = 300
 
 	// *** Defense *** //
 	armor = list("melee" = 35, "bullet" = 35, "laser" = 35, "energy" = 35, "bomb" = XENO_BOMB_RESIST_1, "bio" = 35, "rad" = 35, "fire" = 20, "acid" = 35)
@@ -102,7 +102,7 @@
 	max_health = 290
 
 	// *** Evolution *** //
-	upgrade_threshold = 300
+	upgrade_threshold = 350
 
 	// *** Defense *** //
 	armor = list("melee" = 38, "bullet" = 38, "laser" = 38, "energy" = 38, "bomb" = XENO_BOMB_RESIST_1, "bio" = 38, "rad" = 38, "fire" = 25, "acid" = 38)
@@ -130,7 +130,7 @@
 	max_health = 300
 
 	// *** Evolution *** //
-	upgrade_threshold = 350
+	upgrade_threshold = 400
 
 	// *** Defense *** //
 	armor = list("melee" = 40, "bullet" = 40, "laser" = 40, "energy" = 40, "bomb" = XENO_BOMB_RESIST_1, "bio" = 40, "rad" = 40, "fire" = 28, "acid" = 40)

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
@@ -26,7 +26,7 @@
 	max_health = 225
 
 	// *** Evolution *** //
-	upgrade_threshold = 400
+	upgrade_threshold = 200
 
 	deevolves_to = /mob/living/carbon/xenomorph/hunter
 
@@ -74,7 +74,7 @@
 	max_health = 265
 
 	// *** Evolution *** //
-	upgrade_threshold = 800
+	upgrade_threshold = 250
 
 	// *** Defense *** //
 	armor = list("melee" = 35, "bullet" = 35, "laser" = 35, "energy" = 35, "bomb" = XENO_BOMB_RESIST_1, "bio" = 35, "rad" = 35, "fire" = 20, "acid" = 35)
@@ -102,7 +102,7 @@
 	max_health = 290
 
 	// *** Evolution *** //
-	upgrade_threshold = 1600
+	upgrade_threshold = 300
 
 	// *** Defense *** //
 	armor = list("melee" = 38, "bullet" = 38, "laser" = 38, "energy" = 38, "bomb" = XENO_BOMB_RESIST_1, "bio" = 38, "rad" = 38, "fire" = 25, "acid" = 38)
@@ -130,7 +130,7 @@
 	max_health = 300
 
 	// *** Evolution *** //
-	upgrade_threshold = 1600
+	upgrade_threshold = 350
 
 	// *** Defense *** //
 	armor = list("melee" = 40, "bullet" = 40, "laser" = 40, "energy" = 40, "bomb" = XENO_BOMB_RESIST_1, "bio" = 40, "rad" = 40, "fire" = 28, "acid" = 40)

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
@@ -31,8 +31,8 @@
 	max_health = 100
 
 	// *** Evolution *** //
-	evolution_threshold = 100
-	upgrade_threshold = 100
+	evolution_threshold = 50
+	upgrade_threshold = 50
 
 	evolves_to = list(/mob/living/carbon/xenomorph/hunter, /mob/living/carbon/xenomorph/bull)
 
@@ -85,7 +85,7 @@
 	max_health = 120
 
 	// *** Evolution *** //
-	upgrade_threshold = 200
+	upgrade_threshold = 75
 
 	// *** Defense *** //
 	armor = list("melee" = 3, "bullet" = 3, "laser" = 3, "energy" = 3, "bomb" = XENO_BOMB_RESIST_0, "bio" = 3, "rad" = 3, "fire" = 3, "acid" = 3)
@@ -118,7 +118,7 @@
 	max_health = 150
 
 	// *** Evolution *** //
-	upgrade_threshold = 400
+	upgrade_threshold = 100
 
 	// *** Defense *** //
 	armor = list("melee" = 5, "bullet" = 5, "laser" = 5, "energy" = 5, "bomb" = XENO_BOMB_RESIST_0, "bio" = 5, "rad" = 5, "fire" = 5, "acid" = 5)
@@ -152,7 +152,7 @@
 	max_health = 160
 
 	// *** Evolution *** //
-	upgrade_threshold = 400
+	upgrade_threshold = 150
 
 	// *** Defense *** //
 	armor = list("melee" = 7, "bullet" = 7, "laser" = 7, "energy" = 7, "bomb" = XENO_BOMB_RESIST_0, "bio" = 7, "rad" = 7, "fire" = 7, "acid" = 7)

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
@@ -31,8 +31,8 @@
 	max_health = 100
 
 	// *** Evolution *** //
-	evolution_threshold = 50
-	upgrade_threshold = 50
+	evolution_threshold = 75
+	upgrade_threshold = 75
 
 	evolves_to = list(/mob/living/carbon/xenomorph/hunter, /mob/living/carbon/xenomorph/bull)
 
@@ -85,7 +85,7 @@
 	max_health = 120
 
 	// *** Evolution *** //
-	upgrade_threshold = 75
+	upgrade_threshold = 100
 
 	// *** Defense *** //
 	armor = list("melee" = 3, "bullet" = 3, "laser" = 3, "energy" = 3, "bomb" = XENO_BOMB_RESIST_0, "bio" = 3, "rad" = 3, "fire" = 3, "acid" = 3)
@@ -118,7 +118,7 @@
 	max_health = 150
 
 	// *** Evolution *** //
-	upgrade_threshold = 100
+	upgrade_threshold = 125
 
 	// *** Defense *** //
 	armor = list("melee" = 5, "bullet" = 5, "laser" = 5, "energy" = 5, "bomb" = XENO_BOMB_RESIST_0, "bio" = 5, "rad" = 5, "fire" = 5, "acid" = 5)

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/castedatum_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/castedatum_sentinel.dm
@@ -24,8 +24,8 @@
 	max_health = 150
 
 	// *** Evolution *** //
-	evolution_threshold = 100
-	upgrade_threshold = 100
+	evolution_threshold = 50
+	upgrade_threshold = 50
 
 	evolves_to = list(/mob/living/carbon/xenomorph/spitter)
 
@@ -76,7 +76,7 @@
 	max_health = 180
 
 	// *** Evolution *** //
-	upgrade_threshold = 200
+	upgrade_threshold = 75
 
 	// *** Defense *** //
 	armor = list("melee" = 20, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = XENO_BOMB_RESIST_0, "bio" = 20, "rad" = 20, "fire" = 5, "acid" = 20)
@@ -108,7 +108,7 @@
 	max_health = 190
 
 	// *** Evolution *** //
-	upgrade_threshold = 400
+	upgrade_threshold = 100
 
 	// *** Defense *** //
 	armor = list("melee" = 23, "bullet" = 23, "laser" = 23, "energy" = 23, "bomb" = XENO_BOMB_RESIST_0, "bio" = 23, "rad" = 23, "fire" = 10, "acid" = 23)
@@ -140,7 +140,7 @@
 	max_health = 195
 
 	// *** Evolution *** //
-	upgrade_threshold = 400
+	upgrade_threshold = 150
 
 	// *** Defense *** //
 	armor = list("melee" = 25, "bullet" = 25, "laser" = 25, "energy" = 25, "bomb" = XENO_BOMB_RESIST_0, "bio" = 25, "rad" = 25, "fire" = 15, "acid" = 25)

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/castedatum_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/castedatum_sentinel.dm
@@ -24,8 +24,8 @@
 	max_health = 150
 
 	// *** Evolution *** //
-	evolution_threshold = 50
-	upgrade_threshold = 50
+	evolution_threshold = 75
+	upgrade_threshold = 75
 
 	evolves_to = list(/mob/living/carbon/xenomorph/spitter)
 
@@ -76,7 +76,7 @@
 	max_health = 180
 
 	// *** Evolution *** //
-	upgrade_threshold = 75
+	upgrade_threshold = 100
 
 	// *** Defense *** //
 	armor = list("melee" = 20, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = XENO_BOMB_RESIST_0, "bio" = 20, "rad" = 20, "fire" = 5, "acid" = 20)
@@ -108,7 +108,7 @@
 	max_health = 190
 
 	// *** Evolution *** //
-	upgrade_threshold = 100
+	upgrade_threshold = 125
 
 	// *** Defense *** //
 	armor = list("melee" = 23, "bullet" = 23, "laser" = 23, "energy" = 23, "bomb" = XENO_BOMB_RESIST_0, "bio" = 23, "rad" = 23, "fire" = 10, "acid" = 23)

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
@@ -26,8 +26,8 @@
 	max_health = 240
 
 	// *** Evolution *** //
-	evolution_threshold = 100
-	upgrade_threshold = 100
+	evolution_threshold = 250
+	upgrade_threshold = 250
 
 	evolves_to = list(/mob/living/carbon/xenomorph/queen)
 	deevolves_to = /mob/living/carbon/xenomorph/drone
@@ -90,7 +90,7 @@
 	max_health = 260
 
 	// *** Evolution *** //
-	upgrade_threshold = 200
+	upgrade_threshold = 300
 
 	// *** Defense *** //
 	armor = list("melee" = 15, "bullet" = 15, "laser" = 15, "energy" = 15, "bomb" = XENO_BOMB_RESIST_2, "bio" = 15, "rad" = 15, "fire" = 10, "acid" = 15)
@@ -121,7 +121,7 @@
 	max_health = 280
 
 	// *** Evolution *** //
-	upgrade_threshold = 300
+	upgrade_threshold = 350
 
 	// *** Defense *** //
 	armor = list("melee" = 18, "bullet" = 18, "laser" = 18, "energy" = 18, "bomb" = XENO_BOMB_RESIST_2, "bio" = 18, "rad" = 18, "fire" = 15, "acid" = 18)

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
@@ -26,8 +26,8 @@
 	max_health = 240
 
 	// *** Evolution *** //
-	evolution_threshold = 200
-	upgrade_threshold = 200
+	evolution_threshold = 100
+	upgrade_threshold = 100
 
 	evolves_to = list(/mob/living/carbon/xenomorph/queen)
 	deevolves_to = /mob/living/carbon/xenomorph/drone
@@ -90,7 +90,7 @@
 	max_health = 260
 
 	// *** Evolution *** //
-	upgrade_threshold = 400
+	upgrade_threshold = 200
 
 	// *** Defense *** //
 	armor = list("melee" = 15, "bullet" = 15, "laser" = 15, "energy" = 15, "bomb" = XENO_BOMB_RESIST_2, "bio" = 15, "rad" = 15, "fire" = 10, "acid" = 15)
@@ -121,7 +121,7 @@
 	max_health = 280
 
 	// *** Evolution *** //
-	upgrade_threshold = 800
+	upgrade_threshold = 300
 
 	// *** Defense *** //
 	armor = list("melee" = 18, "bullet" = 18, "laser" = 18, "energy" = 18, "bomb" = XENO_BOMB_RESIST_2, "bio" = 18, "rad" = 18, "fire" = 15, "acid" = 18)
@@ -152,7 +152,7 @@
 	max_health = 290
 
 	// *** Evolution *** //
-	upgrade_threshold = 1600
+	upgrade_threshold = 400
 
 	// *** Defense *** //
 	armor = list("melee" = 23, "bullet" = 23, "laser" = 23, "energy" = 23, "bomb" = XENO_BOMB_RESIST_2, "bio" = 23, "rad" = 23, "fire" = 18, "acid" = 20)

--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
@@ -24,8 +24,8 @@
 	max_health = 180
 
 	// *** Evolution *** //
-	evolution_threshold = 200
-	upgrade_threshold = 200
+	evolution_threshold = 100
+	upgrade_threshold = 100
 
 	evolves_to = list(/mob/living/carbon/xenomorph/boiler, /mob/living/carbon/xenomorph/praetorian)
 	deevolves_to = /mob/living/carbon/xenomorph/sentinel
@@ -79,7 +79,7 @@
 	max_health = 200
 
 	// *** Evolution *** //
-	upgrade_threshold = 400
+	upgrade_threshold = 150
 
 	// *** Defense *** //
 	armor = list("melee" = 15, "bullet" = 15, "laser" = 15, "energy" = 15, "bomb" = XENO_BOMB_RESIST_0, "bio" = 15, "rad" = 15, "fire" = 7, "acid" = 15)
@@ -112,7 +112,7 @@
 	max_health = 240
 
 	// *** Evolution *** //
-	upgrade_threshold = 800
+	upgrade_threshold = 200
 
 	// *** Defense *** //
 	armor = list("melee" = 18, "bullet" = 18, "laser" = 18, "energy" = 18, "bomb" = XENO_BOMB_RESIST_0, "bio" = 18, "rad" = 18, "fire" = 10, "acid" = 18)
@@ -145,7 +145,7 @@
 	max_health = 250
 
 	// *** Evolution *** //
-	upgrade_threshold = 800
+	upgrade_threshold = 250
 
 	// *** Defense *** //
 	armor = list("melee" = 20, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = XENO_BOMB_RESIST_0, "bio" = 20, "rad" = 20, "fire" = 15, "acid" = 20)

--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
@@ -24,8 +24,8 @@
 	max_health = 180
 
 	// *** Evolution *** //
-	evolution_threshold = 100
-	upgrade_threshold = 100
+	evolution_threshold = 150
+	upgrade_threshold = 150
 
 	evolves_to = list(/mob/living/carbon/xenomorph/boiler, /mob/living/carbon/xenomorph/praetorian)
 	deevolves_to = /mob/living/carbon/xenomorph/sentinel
@@ -79,7 +79,7 @@
 	max_health = 200
 
 	// *** Evolution *** //
-	upgrade_threshold = 150
+	upgrade_threshold = 175
 
 	// *** Defense *** //
 	armor = list("melee" = 15, "bullet" = 15, "laser" = 15, "energy" = 15, "bomb" = XENO_BOMB_RESIST_0, "bio" = 15, "rad" = 15, "fire" = 7, "acid" = 15)

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/castedatum_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/castedatum_warrior.dm
@@ -25,8 +25,8 @@
 	max_health = 220
 
 	// *** Evolution *** //
-	evolution_threshold = 200
-	upgrade_threshold = 200
+	evolution_threshold = 100
+	upgrade_threshold = 100
 
 	evolves_to = list(/mob/living/carbon/xenomorph/crusher)
 	deevolves_to = /mob/living/carbon/xenomorph/defender
@@ -77,7 +77,7 @@
 	max_health = 240
 
 	// *** Evolution *** //
-	upgrade_threshold = 400
+	upgrade_threshold = 150
 
 	// *** Defense *** //
 	armor = list("melee" = 36, "bullet" = 36, "laser" = 36, "energy" = 36, "bomb" = XENO_BOMB_RESIST_2, "bio" = 36, "rad" = 36, "fire" = 7, "acid" = 40)
@@ -107,7 +107,7 @@
 	max_health = 260
 
 	// *** Evolution *** //
-	upgrade_threshold = 800
+	upgrade_threshold = 200
 
 	// *** Defense *** //
 	armor = list("melee" = 39, "bullet" = 39, "laser" = 39, "energy" = 39, "bomb" = XENO_BOMB_RESIST_2, "bio" = 45, "rad" = 45, "fire" = 10, "acid" = 45)
@@ -138,7 +138,7 @@
 	max_health = 280
 
 	// *** Evolution *** //
-	upgrade_threshold = 800
+	upgrade_threshold = 250
 
 	// *** Defense *** //
 	armor = list("melee" = 43, "bullet" = 43, "laser" = 43, "energy" = 43, "bomb" = XENO_BOMB_RESIST_2, "bio" = 47, "rad" = 47, "fire" = 12, "acid" = 47)

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/castedatum_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/castedatum_warrior.dm
@@ -25,8 +25,8 @@
 	max_health = 220
 
 	// *** Evolution *** //
-	evolution_threshold = 100
-	upgrade_threshold = 100
+	evolution_threshold = 150
+	upgrade_threshold = 150
 
 	evolves_to = list(/mob/living/carbon/xenomorph/crusher)
 	deevolves_to = /mob/living/carbon/xenomorph/defender
@@ -77,7 +77,7 @@
 	max_health = 240
 
 	// *** Evolution *** //
-	upgrade_threshold = 150
+	upgrade_threshold = 175
 
 	// *** Defense *** //
 	armor = list("melee" = 36, "bullet" = 36, "laser" = 36, "energy" = 36, "bomb" = XENO_BOMB_RESIST_2, "bio" = 36, "rad" = 36, "fire" = 7, "acid" = 40)


### PR DESCRIPTION
## About The Pull Request

Reduces evolution and upgrade times for all xenos across the board

## Why It's Good For The Game

A buff for xenos so they hopefully have a better chance against marines,this reduces all the boring wait times and elevator gameplay that makes xeno so infuriating to play as,since my stat changes to xenos made maturities not crazy jumps in stats this will be balanced.
## Changelog
:cl:
Balance: Reduced all xeno evolution and upgrade timers across the board
/:cl:
