### PR TITLE
Adds screwdriver sounds for opening and closing airlock panels.

### DIFF
--- a/code/game/objects/machinery/doors/airlock.dm
+++ b/code/game/objects/machinery/doors/airlock.dm
@@ -309,16 +309,6 @@
 								"<span class='notice'>You finish repairing the airlock.</span>")
 			update_icon()
 
-
-	else if(isscrewdriver(I))
-		if(no_panel)
-			to_chat(user, "<span class='warning'>\The [src] has no panel to open!</span>")
-			return
-
-		TOGGLE_BITFIELD(machine_stat, PANEL_OPEN)
-		to_chat(user, "<span class='notice'>You [CHECK_BITFIELD(machine_stat, PANEL_OPEN) ? "open" : "close"] [src]'s panel.</span>")
-		update_icon()
-
 	else if(iswirecutter(I))
 		return attack_hand(user)
 
@@ -408,6 +398,21 @@
 			close(1)
 
 	return TRUE
+
+/obj/machinery/door/airlock/screwdriver_act(mob/user, obj/item/I)
+	. = ..()
+	if(no_panel)
+		to_chat(user, "<span class='warning'>\The [src] has no panel to open!</span>")
+		return
+
+	machine_stat ^= PANEL_OPEN
+	if(machine_stat & PANEL_OPEN)
+		to_chat(user, "<span class='notice'>You open [src]'s panel.</span>")
+		playsound(loc, 'sound/items/screwdriver2.ogg', 25, 1)
+	else
+		to_chat(user, "<span class='notice'>You close [src]'s panel.</span>")
+		playsound(loc, 'sound/items/screwdriver.ogg', 25, 1)
+	update_icon()
 
 
 ///obj/machinery/door/airlock/phoron/attackby(C as obj, mob/user as mob)


### PR DESCRIPTION
## About The Pull Request

Coming from tg, I found the lack of these extremely jarring when I first encountered it.

## Why It's Good For The Game

Makes the game feel alive.

## Changelog
:cl:
soundadd: Added sounds for opening/closing the airlock panel with a screwdriver.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
