### PR TITLE
LZ shutters now require access to open

### DIFF
--- a/code/game/objects/machinery/buttons.dm
+++ b/code/game/objects/machinery/buttons.dm
@@ -99,6 +99,8 @@
 	id = "landing_zone"
 	use_power = NO_POWER_USE
 	resistance_flags = RESIST_ALL
+	req_access = ACCESS_MARINE_DROPSHIP
+
 
 
 /obj/machinery/button/door/open_only/landing_zone/lz2

--- a/code/game/objects/machinery/buttons.dm
+++ b/code/game/objects/machinery/buttons.dm
@@ -99,7 +99,7 @@
 	id = "landing_zone"
 	use_power = NO_POWER_USE
 	resistance_flags = RESIST_ALL
-	req_access = ACCESS_MARINE_DROPSHIP
+	req_access = list(ACCESS_MARINE_DROPSHIP)
 
 
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Specifically, if you can operate the dropship, you can open the shutters. This means (acting) Squad Lead or any Command Role.

## Why It's Good For The Game

gonna have to bwoink less people for being dentheads

## Changelog
:cl:
add: LZ shutters now require (acting) Squad Leader or higher rank access
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
