### PR TITLE
Distress resin silos

### DIFF
--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -62,6 +62,8 @@
 
 /datum/game_mode/distress/post_setup()
 	. = ..()
+	for(var/i in GLOB.xeno_resin_silo_turfs)
+		new /obj/structure/resin/silo(i)
 	balance_scales()
 	addtimer(CALLBACK(src, .proc/announce_bioscans, FALSE, 1), rand(30 SECONDS, 1 MINUTES)) //First scan shows no location but more precise numbers.
 

--- a/code/datums/gamemodes/game_mode.dm
+++ b/code/datums/gamemodes/game_mode.dm
@@ -728,8 +728,8 @@ Sensors indicate [numXenosShip ? "[numXenosShip]" : "no"] unknown lifeform signa
 	var/datum/hive_status/normal/xeno_hive = GLOB.hive_datums[XENO_HIVE_NORMAL]
 	var/num_xenos = xeno_hive.get_total_xeno_number() - length(xeno_hive.get_ssd_xenos()) + xeno_hive.stored_larva
 	latejoin_larvapoints = (get_total_joblarvaworth() - (num_xenos * latejoin_larvapoints_required)) / latejoin_larvapoints_required
-	if(!num_xenos) //Distress ends here
-		if(!length(GLOB.xeno_resin_silos)) //Crash ends here
+	if(!num_xenos)
+		if(!length(GLOB.xeno_resin_silos))
 			check_finished(TRUE)
 			return //RIP benos.
 		if(xeno_hive.stored_larva)

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -689,6 +689,8 @@ to_chat will check for valid clients itself already so no need to double check f
 		boarder.gib()
 		stored_larva++
 		left_behind++
+	for(var/i in GLOB.xeno_resin_silos)
+		qdel(i)
 	if(left_behind)
 		xeno_message("[left_behind > 1 ? "[left_behind] sisters" : "One sister"] perished due to being too slow to board the bird. The freeing of their psychic link allows us to call borrowed, at least.")
 


### PR DESCRIPTION
## Changelog
:cl:
add: Resin silos added to Distress game mode. They are unprotected by fog and get automatically destroyed on xeno shuttle hijack.
/:cl: