### PR TITLE
Bullet ping fix

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -962,7 +962,9 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 	if(prob(65))
 		if(P.ammo.sound_bounce) playsound(src, P.ammo.sound_bounce, 50, 1)
 		var/image/I = image('icons/obj/items/projectiles.dmi',src,P.ammo.ping,10)
-		var/angle = (P.firer && prob(60)) ? round(Get_Angle(P.starting_turf, src)) : round(rand(1,359))
+		var/angle = !isnull(P.dir_angle) ? P.dir_angle : round(Get_Angle(P.starting_turf, src), 1)
+		if(prob(60))
+			angle += rand(-angle, 360 - angle)
 		I.pixel_x += rand(-6,6)
 		I.pixel_y += rand(-6,6)
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -962,7 +962,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 	if(prob(65))
 		if(P.ammo.sound_bounce) playsound(src, P.ammo.sound_bounce, 50, 1)
 		var/image/I = image('icons/obj/items/projectiles.dmi',src,P.ammo.ping,10)
-		var/angle = (P.firer && prob(60)) ? round(Get_Angle(P.firer,src)) : round(rand(1,359))
+		var/angle = (P.firer && prob(60)) ? round(Get_Angle(P.starting_turf, src)) : round(rand(1,359))
 		I.pixel_x += rand(-6,6)
 		I.pixel_y += rand(-6,6)
 


### PR DESCRIPTION
This runtime makes no sense:
```
[00:06:36] Runtime in unsorted.dm, line 107: Cannot read null.loc
proc name: Get Angle (/proc/Get_Angle)
src: null
call stack:
Get Angle(null, the thin ice wall (4,13,2) (/turf/closed/ice/thin/single))
the thin ice wall (4,13,2) (/turf/closed/ice/thin/single): bullet ping(the small caliber autocannon b... (/obj/item/projectile))
the thin ice wall (4,13,2) (/turf/closed/ice/thin/single): bullet act(the small caliber autocannon b... (/obj/item/projectile))
the small caliber autocannon b... (/obj/item/projectile): scan a turf(the thin ice wall (4,13,2) (/turf/closed/ice/thin/single), 8)
the small caliber autocannon b... (/obj/item/projectile): projectile batch move(3)
the small caliber autocannon b... (/obj/item/projectile): process(2)
Projectiles (/datum/controller/subsystem/processing/projectiles): fire(1)
Projectiles (/datum/controller/subsystem/processing/projectiles): ignite(1)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop()
Master (/datum/controller/master): StartProcessing(0)
```