### PR TITLE
Deprecated shuttle proc

### DIFF
--- a/code/__DEFINES/shuttles.dm
+++ b/code/__DEFINES/shuttles.dm
@@ -1,8 +1,8 @@
 //shuttle mode defines
 #define SHUTTLE_IDLE		"idle"
 #define SHUTTLE_IGNITING	"igniting"
-#define SHUTTLE_RECALL		"recall"
-#define SHUTTLE_CALL		"call"
+#define SHUTTLE_RECALL		"recalled"
+#define SHUTTLE_CALL		"called"
 #define SHUTTLE_DOCKED		"docked"
 #define SHUTTLE_STRANDED	"stranded"
 #define SHUTTLE_ESCAPE		"escape"

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -459,27 +459,6 @@ SUBSYSTEM_DEF(shuttle)
 		ui = new(user, src, ui_key, "shuttle_manipulator", name, 800, 600, master_ui, state)
 		ui.open()
 
-/proc/shuttlemode2str(mode)
-	switch(mode)
-		if(SHUTTLE_IDLE)
-			. = "idle"
-		if(SHUTTLE_IGNITING)
-			. = "engines charging"
-		if(SHUTTLE_RECALL)
-			. = "recalled"
-		if(SHUTTLE_CALL)
-			. = "called"
-		if(SHUTTLE_DOCKED)
-			. = "docked"
-		if(SHUTTLE_STRANDED)
-			. = "stranded"
-		if(SHUTTLE_ESCAPE)
-			. = "escape"
-		if(SHUTTLE_ENDGAME)
-			. = "endgame"
-	if(!.)
-		CRASH("shuttlemode2str(): invalid mode [mode]")
-
 
 /datum/controller/subsystem/shuttle/ui_data(mob/user)
 	var/list/data = list()
@@ -532,7 +511,7 @@ SUBSYSTEM_DEF(shuttle)
 		if(!M.destination)
 			L["can_fast_travel"] = FALSE
 		if (M.mode != SHUTTLE_IDLE)
-			L["mode"] = capitalize(shuttlemode2str(M.mode))
+			L["mode"] = capitalize(M.mode)
 		L["status"] = M.getDbgStatusText()
 		if(M == existing_shuttle)
 			data["existing_shuttle"] = L


### PR DESCRIPTION
Removes a runtiming deprecated shuttle proc, likely from when the shuttle defines were numbers instead of strings:
```
[17:10:03] Runtime in shuttle.dm, line 481: shuttlemode2str(): invalid mode recharging
proc name: shuttlemode2str (/proc/shuttlemode2str)
usr: CKEY/(Cecille Damont)
usr.loc: (Dropship Alamo (83, 31, 1))
src: null
call stack:
shuttlemode2str("recharging")
Shuttle (/datum/controller/subsystem/shuttle): ui data(Cecille Damont (/mob/dead/observer))
/datum/tgui (/datum/tgui): open()
Shuttle (/datum/controller/subsystem/shuttle): ui interact(Cecille Damont (/mob/dead/observer), "main", /datum/tgui (/datum/tgui), 0, null, /datum/ui_state/admin_state (/datum/ui_state/admin_state))
CKEY (/client): Shuttle Manipulator()
```
