### PR TITLE
Item storage runtime fix

### DIFF
--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -278,9 +278,9 @@
 	for(var/i = 1 to length(S.click_border_start))
 		if(S.click_border_start[i] > click_x || click_x > S.click_border_end[i])
 			continue
-		I = S.contents[i]
-		if(!I)
+		if(length(S.contents) < i)
 			continue
+		I = S.contents[i]
 		I.attack_hand(usr)
 		return
 


### PR DESCRIPTION
```
[18:27:12] Runtime in storage.dm, line 281: list index out of bounds
proc name: Click (/obj/screen/storage/Click)
usr: CKEY/(Andrew Johnes)
usr.loc: (Armory (103, 25, 2))
src: the storage (/obj/screen/storage)
src.loc: null
call stack:
the storage (/obj/screen/storage): Click(null, "mapwindow.map", "icon-x=6;icon-y=15;vis-x=31;vi...")
CKEY (/client): Click(the storage (/obj/screen/storage), null, "mapwindow.map", "icon-x=6;icon-y=15;vis-x=31;vi...")
```