### PR TITLE
Move the xeno hive on icy caves

### DIFF
--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -12211,7 +12211,7 @@ bC
 aJ
 aJ
 aK
-aJ
+by
 cr
 aJ
 cR
@@ -12725,7 +12725,7 @@ cK
 bt
 bA
 aJ
-by
+aJ
 aJ
 aJ
 cR


### PR DESCRIPTION
This moves the hive over 2 tiles to the left, this will avoid it getting destroyed via grenandes.
