### PR TITLE
Reduce hunter knockdown from max of 6 secs to 0.5

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -89,7 +89,7 @@
 				staggerslow_stacks *= 2
 				X.visible_message("<span class='danger'>\The [X] strikes [src] with deadly precision!</span>", \
 				"<span class='danger'>We strike [src] with deadly precision!</span>")
-			KnockdownNoChain(0.5 SECONDS) //...And we knock
+			KnockdownNoChain(1.5 SECONDS) //...And we knock
 			adjust_stagger(staggerslow_stacks)
 			add_slowdown(staggerslow_stacks)
 

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -89,6 +89,7 @@
 				staggerslow_stacks *= 2
 				X.visible_message("<span class='danger'>\The [X] strikes [src] with deadly precision!</span>", \
 				"<span class='danger'>We strike [src] with deadly precision!</span>")
+			KnockdownNoChain(0.5 SECONDS) //...And we knock
 			adjust_stagger(staggerslow_stacks)
 			add_slowdown(staggerslow_stacks)
 
@@ -218,7 +219,6 @@
 				staggerslow_stacks *= 2
 				X.visible_message("<span class='danger'>\The [X] strikes [src] with deadly precision!</span>", \
 				"<span class='danger'>We strike [src] with deadly precision!</span>")
-			Unconscious(0.5 SECONDS) //...And we knock
 			adjust_stagger(staggerslow_stacks)
 			add_slowdown(staggerslow_stacks)
 

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -209,7 +209,6 @@
 			to_chat(world, "DEBUG_ALIEN_ATTACK SNEAK ATTACK: target: [src] last_move_intent: [M.last_move_intent] world.time minus run delay: [world.time - HUNTER_SNEAK_ATTACK_RUN_DELAY]")
 			#endif
 			var/staggerslow_stacks = 2
-			var/knockout_stacks = 1
 			if(m_intent == MOVE_INTENT_RUN && ( X.last_move_intent > (world.time - HUNTER_SNEAK_ATTACK_RUN_DELAY) ) ) //Allows us to slash while running... but only if we've been stationary for awhile
 			//...And we knock them out
 				X.visible_message("<span class='danger'>\The [X] strikes [src] with vicious precision!</span>", \
@@ -217,10 +216,9 @@
 			else
 				armor_block *= HUNTER_SNEAK_SLASH_ARMOR_PEN //20% armor penetration
 				staggerslow_stacks *= 2
-				knockout_stacks *= 2
 				X.visible_message("<span class='danger'>\The [X] strikes [src] with deadly precision!</span>", \
 				"<span class='danger'>We strike [src] with deadly precision!</span>")
-			Unconscious(knockout_stacks * 20) //...And we knock
+			Unconscious(0.5 SECONDS) //...And we knock
 			adjust_stagger(staggerslow_stacks)
 			add_slowdown(staggerslow_stacks)
 


### PR DESCRIPTION
## About The Pull Request

Hunter could knock someone unconcious for up to 6 secs, 2 if running.
This replaces that with a flat 0.5 sec knockdown but only when disarming instead of on harm.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Xeno balance
## Changelog
:cl:
balance: hunter stealth attack changed to flat 0.5 seconds, and only applied on disarm.
/:cl:
