### PR TITLE
Only check larvasworth of a mob that has a job

### DIFF
--- a/code/datums/gamemodes/game_mode.dm
+++ b/code/datums/gamemodes/game_mode.dm
@@ -719,7 +719,7 @@ Sensors indicate [numXenosShip ? "[numXenosShip]" : "no"] unknown lifeform signa
 
 	for(var/i in GLOB.human_mob_list)
 		var/mob/living/carbon/human/H = i
-		var/datum/job/job = SSjob.GetJob(H.mind ? H.mind.assigned_role : H.job)
+		var/datum/job/job = SSjob.GetJob(H.job)
 		if(!istype(job))
 			continue
 		if(H.stat == DEAD && !H.is_revivable())

--- a/code/datums/gamemodes/game_mode.dm
+++ b/code/datums/gamemodes/game_mode.dm
@@ -720,7 +720,7 @@ Sensors indicate [numXenosShip ? "[numXenosShip]" : "no"] unknown lifeform signa
 	for(var/i in GLOB.human_mob_list)
 		var/mob/living/carbon/human/H = i
 		var/datum/job/job = SSjob.GetJob(H.job)
-		if(!istype(job))
+		if(!job)
 			continue
 		if(H.stat == DEAD && !H.is_revivable())
 			continue

--- a/code/datums/gamemodes/game_mode.dm
+++ b/code/datums/gamemodes/game_mode.dm
@@ -719,7 +719,9 @@ Sensors indicate [numXenosShip ? "[numXenosShip]" : "no"] unknown lifeform signa
 
 	for(var/i in GLOB.human_mob_list)
 		var/mob/living/carbon/human/H = i
-		var/datum/job/job = SSjob.GetJob(H.job)
+		var/datum/job/J = SSjob.GetJob(H.mind ? H.mind.assigned_role : H.job)
+		if(!istype(job))
+			continue
 		if(H.stat == DEAD && !H.is_revivable())
 			continue
 		if(count_flags & COUNT_IGNORE_HUMAN_SSD && !H.client)

--- a/code/datums/gamemodes/game_mode.dm
+++ b/code/datums/gamemodes/game_mode.dm
@@ -719,7 +719,7 @@ Sensors indicate [numXenosShip ? "[numXenosShip]" : "no"] unknown lifeform signa
 
 	for(var/i in GLOB.human_mob_list)
 		var/mob/living/carbon/human/H = i
-		var/datum/job/J = SSjob.GetJob(H.mind ? H.mind.assigned_role : H.job)
+		var/datum/job/job = SSjob.GetJob(H.mind ? H.mind.assigned_role : H.job)
 		if(!istype(job))
 			continue
 		if(H.stat == DEAD && !H.is_revivable())


### PR DESCRIPTION
```
Runtime in game_mode.dm, line 731: Cannot read null.larvaworth
proc name: get total joblarvaworth (/datum/game_mode/proc/get_total_joblarvaworth)
src: Crash (/datum/game_mode/crash)
call stack:
Crash (/datum/game_mode/crash): get total joblarvaworth(/list (/list), null)
Crash (/datum/game_mode/crash): balance scales()
Crash (/datum/game_mode/crash): process(2)
Ticker (/datum/controller/subsystem/ticker): fire(0)
Ticker (/datum/controller/subsystem/ticker): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop()
Master (/datum/controller/master): StartProcessing(0)
```