### PR TITLE
Set default larvaworth for base job

### DIFF
--- a/code/datums/jobs/job/job.dm
+++ b/code/datums/jobs/job/job.dm
@@ -50,7 +50,7 @@ GLOBAL_PROTECT(exp_specialmap)
 	var/display_order = JOB_DISPLAY_ORDER_DEFAULT
 	var/job_flags = NONE
 	
-	var/larvaworth = 0
+	var/larvaworth = LARVA_POINTS_REGULAR
 
 /datum/job/proc/after_spawn(mob/living/L, mob/M, latejoin = FALSE) //do actions on L but send messages to M as the key may not have been transferred_yet
 	if(!ishuman(L))


### PR DESCRIPTION
Fixes issue with admin spawned mobs not contributing to total larvaworth.
