### PR TITLE
Update flame turfs for incen grenades

### DIFF
--- a/code/__HELPERS/patterns.dm
+++ b/code/__HELPERS/patterns.dm
@@ -72,7 +72,8 @@
 				if (AdjT in results) // Ignore existing turfs
 					continue
 				if(AdjT.density || LinkBlocked(T, AdjT) || TurfBlockedNonWindow(AdjT))
-					results += AdjT
+					if(include_edge)
+						results += AdjT
 					continue
 
 				turfs_to_check += AdjT

--- a/code/__HELPERS/patterns.dm
+++ b/code/__HELPERS/patterns.dm
@@ -43,3 +43,38 @@
 			. += block(locate(x_0 - dy, y_0 - dx + 1, z_0), locate(x_0 - dy, y_0 + dx - 1, z_0))
 			dy--;
 	while(dy > dx)
+
+
+/proc/filled_turfs(atom/center, radius = 3, type = "circle", include_edge = TRUE)
+	var/turf/center_turf = get_turf(center)
+	if(radius < 0 || !center)
+		return
+	if(radius == 0)
+		return list(center_turf)
+
+	var/list/directions
+	switch(type)
+		if("square")
+			directions = GLOB.alldirs
+		if("circle")
+			directions = GLOB.cardinals
+
+	var/list/results = list()
+	var/list/turfs_to_check = list()
+	turfs_to_check += center_turf
+	var/node_size = radius
+	while (node_size > 0)
+		node_size--
+		for(var/X in turfs_to_check)
+			var/turf/T = X
+			for(var/direction in directions)
+				var/turf/AdjT = get_step(T, direction)
+				if (AdjT in results) // Ignore existing turfs
+					continue
+				if(AdjT.density || LinkBlocked(T, AdjT) || TurfBlockedNonWindow(AdjT))
+					results += AdjT
+					continue
+
+				turfs_to_check += AdjT
+				results += AdjT
+	return results

--- a/code/__HELPERS/patterns.dm
+++ b/code/__HELPERS/patterns.dm
@@ -62,9 +62,7 @@
 	var/list/results = list()
 	var/list/turfs_to_check = list()
 	turfs_to_check += center_turf
-	var/node_size = radius
-	while (node_size > 0)
-		node_size--
+	for(var/i = radius; i > 0; i--)
 		for(var/X in turfs_to_check)
 			var/turf/T = X
 			for(var/direction in directions)

--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -157,29 +157,6 @@
 	. = ..(mapload, src)
 
 	// Generate our full graph before adding to SSweeds
-	generate_weed_graph()
+	node_turfs = filled_turfs(src, node_range, "square")
 	SSweeds.add_node(src)
-
-/obj/effect/alien/weeds/node/proc/generate_weed_graph()
-	var/list/turfs_to_check = list()
-	turfs_to_check += get_turf(src)
-	var/node_size = node_range
-	while (node_size > 0)
-		node_size--
-		for(var/X in turfs_to_check)
-			var/turf/T = X
-			for(var/direction in GLOB.alldirs)
-				var/turf/AdjT = get_step(T, direction)
-				if (AdjT == src) // Ignore the node
-					continue
-				if (AdjT in node_turfs) // Ignore existing weeds
-					continue
-				if(AdjT.density || LinkBlocked(T, AdjT) || TurfBlockedNonWindow(AdjT))
-					// Finish here, but add it to expand weeds into
-					node_turfs += AdjT
-					continue
-
-				turfs_to_check += AdjT
-				node_turfs += AdjT
-
 #undef NODERANGE

--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -127,7 +127,7 @@
 	return
 
 
-proc/flame_radius(radius = 1, turf/T, burn_intensity = 25, burn_duration = 25, burn_damage = 25, fire_stacks = 15, int_var = 0.5, dur_var = 0.5, colour = "red") //~Art updated fire.
+/proc/flame_radius(radius = 1, turf/T, burn_intensity = 25, burn_duration = 25, burn_damage = 25, fire_stacks = 15, int_var = 0.5, dur_var = 0.5, colour = "red") //~Art updated fire.
 	if(!T || !isturf(T))
 		return
 	radius = CLAMP(radius, 1, 50) //Sanitize inputs
@@ -136,7 +136,7 @@ proc/flame_radius(radius = 1, turf/T, burn_intensity = 25, burn_duration = 25, b
 	fire_stacks = rand(burn_damage*(0.5-int_var),burn_damage*(0.5+int_var) ) + rand(burn_damage*(0.5-int_var),burn_damage*(0.5+int_var) )
 	burn_damage = rand(burn_damage*(0.5-int_var),burn_damage*(0.5+int_var) ) + rand(burn_damage*(0.5-int_var),burn_damage*(0.5+int_var) )
 
-	for(var/turf/IT in filled_circle_turfs(T,radius))
+	for(var/turf/IT in filled_turfs(T, radius, "circle"))
 		IT.ignite(rand(burn_intensity*(0.5-int_var), burn_intensity*(0.5+int_var)) + rand(burn_intensity*(0.5-int_var), burn_intensity*(0.5+int_var)), rand(burn_duration*(0.5-int_var), burn_duration*(0.5-int_var)) + rand(burn_duration*(0.5-int_var), burn_duration*(0.5-int_var)), colour, burn_damage, fire_stacks)
 
 


### PR DESCRIPTION
## About The Pull Request

Adds a new pattern taken from how we generate weed nodes.
Added a bit of customization to support circle and square sets.

This respects blocking tiles and wont continue if the tile is blocked / dense / whatever

## Why It's Good For The Game

Stops incens from destroying things on the other side of a barrier.

## Changelog
:cl:
tweak: how flame graphs are generated, they are now blocked by dense objects
/:cl:


As a note, this is kinda nerf to the grenades, so im thinking about increasing the radius by 1


video : https://streamable.com/0lc5k