### PR TITLE
removes ammo box magic tricks

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -425,6 +425,10 @@ Turn() or Shift() as there is virtually no overhead. ~N
 	if(MG.default_ammo != ammo_type)
 		to_chat(user, "<span class='warning'>That's not the right kind of ammo.</span>")
 		return
+		
+	if(!(MG.type == magazine_type))
+		to_chat(user,"<span class='warning'>That's not the right kind of magazine.</span>")
+		return
 
 	if(MG.current_rounds != MG.max_rounds)
 		to_chat(user, "<span class='warning'>The magazine is not full!</span>")

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -426,7 +426,7 @@ Turn() or Shift() as there is virtually no overhead. ~N
 		to_chat(user, "<span class='warning'>That's not the right kind of ammo.</span>")
 		return
 		
-	if(!(MG.type == magazine_type))
+	if(MG.type != magazine_type)
 		to_chat(user,"<span class='warning'>That's not the right kind of magazine.</span>")
 		return
 


### PR DESCRIPTION
:cl:
fix: you can no longer transmute normal magazines into extended ones with ammo boxes
/:cl:
fixes #3575 