### PR TITLE
Unlock airlocks on hijack

### DIFF
--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -224,6 +224,7 @@
 /obj/docking_port/mobile/marine_dropship/proc/summon_dropship_to(obj/docking_port/stationary/S)
 	if(hijack_state != HIJACK_STATE_NORMAL)
 		return
+	unlock_all()
 	switch(mode)
 		if(SHUTTLE_IDLE)
 			set_hijack_state(HIJACK_STATE_CALLED_DOWN)


### PR DESCRIPTION
## Changelog
:cl:
fix: Dropship airlocks get unlocked on shuttle hijack, in case a pilot locked them before transit, not to trap the marines inside.
/:cl: