### PR TITLE
Removes acid blood from all Xenos except boilers

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -452,6 +452,7 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define CASTE_HIDE_IN_STATUS		(1<<10)
 #define CASTE_QUICK_HEAL_STANDING (1<<11) // Xenomorphs heal standing same if they were resting.
 #define CASTE_CAN_HEAL_WIHOUT_QUEEN	(1<<12) // Xenomorphs can heal even without a queen on the same z level
+#define CASTE_ACID_BLOOD (1<<13) //The acid blood effect which damages humans near xenos that take damage
 
 //Charge-Crush
 #define CHARGE_OFF			0

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
@@ -32,7 +32,7 @@
 	deevolves_to = /mob/living/carbon/xenomorph/spitter
 
 	// *** Flags *** //
-	caste_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER
+	caste_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER|CASTE_ACID_BLOOD
 
 	// *** Defense *** //
 	armor = list("melee" = 30, "bullet" = 30, "laser" = 30, "energy" = 30, "bomb" = XENO_BOMB_RESIST_0, "bio" = 30, "rad" = 30, "fire" = 15, "acid" = 30)

--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -173,3 +173,25 @@
 		else
 			if(decal.random_icon_states && length(decal.random_icon_states) > 0) //If there's already one, just randomize it so it changes.
 				decal.icon_state = pick(decal.random_icon_states)
+
+		var/splash_chance = 40 //Base chance of getting splashed. Decreases with # of victims.
+		var/distance = 0 //Distance, decreases splash chance.
+		var/i = 0 //Tally up our victims.
+		
+		if(!(/mob/living/carbon/xenomorph.xeno_caste.caste_flags & CASTE_ACID_BLOOD))
+			return
+		else
+			for(var/mob/living/carbon/human/victim in range(radius,src)) //Loop through all nearby victims, including the tile.
+				distance = get_dist(src,victim)
+
+				splash_chance = 80 - (i * 5)
+				if(victim.loc == loc) splash_chance += 30 //Same tile? BURN
+				splash_chance += distance * -15
+
+				if(splash_chance > 0 && prob(splash_chance)) //Success!
+					i++
+					victim.visible_message("<span class='danger'>\The [victim] is scalded with hissing green blood!</span>", \
+					"<span class='danger'>You are splattered with sizzling blood! IT BURNS!</span>")
+					if(prob(60) && !victim.stat && !(victim.species.species_flags & NO_PAIN))
+						victim.emote("scream") //Topkek
+					victim.take_limb_damage(0, rand(10, 25)) //Sizzledam! This automagically burns a random existing body part.

--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -179,16 +179,16 @@
 		var/splash_chance = 40 //Base chance of getting splashed. Decreases with # of victims.
 		var/distance = 0 //Distance, decreases splash chance.
 		var/i = 0 //Tally up our victims.
-			for(var/mob/living/carbon/human/victim in range(radius,src)) //Loop through all nearby victims, including the tile.
-				distance = get_dist(src,victim)
+		for(var/mob/living/carbon/human/victim in range(radius,src)) //Loop through all nearby victims, including the tile.
+			distance = get_dist(src,victim)
 
-				splash_chance = 80 - (i * 5)
-				if(victim.loc == loc) 
-					splash_chance += 30 //Same tile? BURN
-				splash_chance += distance * -15
-				i++
-				victim.visible_message("<span class='danger'>\The [victim] is scalded with hissing green blood!</span>", \
-				"<span class='danger'>You are splattered with sizzling blood! IT BURNS!</span>")
-				if(victim.stat != CONSCIOUS && !(victim.species.species_flags & NO_PAIN) && prob(60)) 
-					victim.emote("scream") //Topkek
-				victim.take_limb_damage(0, rand(10, 25)) //Sizzledam! This automagically burns a random existing body part.
+			splash_chance = 80 - (i * 5)
+			if(victim.loc == loc) 
+				splash_chance += 30 //Same tile? BURN
+			splash_chance += distance * -15
+			i++
+			victim.visible_message("<span class='danger'>\The [victim] is scalded with hissing green blood!</span>", \
+			"<span class='danger'>You are splattered with sizzling blood! IT BURNS!</span>")
+			if(victim.stat != CONSCIOUS && !(victim.species.species_flags & NO_PAIN) && prob(60)) 
+				victim.emote("scream") //Topkek
+			victim.take_limb_damage(0, rand(10, 25)) //Sizzledam! This automagically burns a random existing body part.

--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -173,25 +173,22 @@
 		else
 			if(decal.random_icon_states && length(decal.random_icon_states) > 0) //If there's already one, just randomize it so it changes.
 				decal.icon_state = pick(decal.random_icon_states)
-
-		var/splash_chance = 40 //Base chance of getting splashed. Decreases with # of victims.
-		var/distance = 0 //Distance, decreases splash chance.
-		var/i = 0 //Tally up our victims.
 		
 		if(!(xeno_caste.caste_flags & CASTE_ACID_BLOOD))
 			return
-		else
+		var/splash_chance = 40 //Base chance of getting splashed. Decreases with # of victims.
+		var/distance = 0 //Distance, decreases splash chance.
+		var/i = 0 //Tally up our victims.
 			for(var/mob/living/carbon/human/victim in range(radius,src)) //Loop through all nearby victims, including the tile.
 				distance = get_dist(src,victim)
 
 				splash_chance = 80 - (i * 5)
-				if(victim.loc == loc) splash_chance += 30 //Same tile? BURN
+				if(victim.loc == loc) 
+					splash_chance += 30 //Same tile? BURN
 				splash_chance += distance * -15
-
-				if(splash_chance > 0 && prob(splash_chance)) //Success!
-					i++
-					victim.visible_message("<span class='danger'>\The [victim] is scalded with hissing green blood!</span>", \
-					"<span class='danger'>You are splattered with sizzling blood! IT BURNS!</span>")
-					if(prob(60) && !victim.stat && !(victim.species.species_flags & NO_PAIN))
-						victim.emote("scream") //Topkek
-					victim.take_limb_damage(0, rand(10, 25)) //Sizzledam! This automagically burns a random existing body part.
+				i++
+				victim.visible_message("<span class='danger'>\The [victim] is scalded with hissing green blood!</span>", \
+				"<span class='danger'>You are splattered with sizzling blood! IT BURNS!</span>")
+				if(victim.stat != CONSCIOUS && !(victim.species.species_flags & NO_PAIN) && prob(60)) 
+					victim.emote("scream") //Topkek
+				victim.take_limb_damage(0, rand(10, 25)) //Sizzledam! This automagically burns a random existing body part.

--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -173,22 +173,3 @@
 		else
 			if(decal.random_icon_states && length(decal.random_icon_states) > 0) //If there's already one, just randomize it so it changes.
 				decal.icon_state = pick(decal.random_icon_states)
-
-		var/splash_chance = 40 //Base chance of getting splashed. Decreases with # of victims.
-		var/distance = 0 //Distance, decreases splash chance.
-		var/i = 0 //Tally up our victims.
-
-		for(var/mob/living/carbon/human/victim in range(radius,src)) //Loop through all nearby victims, including the tile.
-			distance = get_dist(src,victim)
-
-			splash_chance = 80 - (i * 5)
-			if(victim.loc == loc) splash_chance += 30 //Same tile? BURN
-			splash_chance += distance * -15
-
-			if(splash_chance > 0 && prob(splash_chance)) //Success!
-				i++
-				victim.visible_message("<span class='danger'>\The [victim] is scalded with hissing green blood!</span>", \
-				"<span class='danger'>You are splattered with sizzling blood! IT BURNS!</span>")
-				if(prob(60) && !victim.stat && !(victim.species.species_flags & NO_PAIN))
-					victim.emote("scream") //Topkek
-				victim.take_limb_damage(0, rand(10, 25)) //Sizzledam! This automagically burns a random existing body part.

--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -178,7 +178,7 @@
 		var/distance = 0 //Distance, decreases splash chance.
 		var/i = 0 //Tally up our victims.
 		
-		if(!(/mob/living/carbon/xenomorph.xeno_caste.caste_flags & CASTE_ACID_BLOOD))
+		if(!(xeno_caste.caste_flags & CASTE_ACID_BLOOD))
 			return
 		else
 			for(var/mob/living/carbon/human/victim in range(radius,src)) //Loop through all nearby victims, including the tile.


### PR DESCRIPTION
## About The Pull Request

Removes acid blood, I was told Rohesie greenlighted this ages ago but that everyone was too lazy to do it themselves.

## Why It's Good For The Game

Getting punished for dealing damage is not cool

## Changelog
:cl:
balance: Removed acid blood damage from standing near xenos that take damage.
/:cl: