### PR TITLE
Tweak for pump action shotgun ammo hud

### DIFF
--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -173,6 +173,8 @@ can cause issues with ammo types getting mixed up during the burst.
 	return TRUE
 
 /obj/item/weapon/gun/shotgun/get_ammo_type()
+	if(in_chamber)
+		return(list(in_chamber.ammo.hud_state, in_chamber.ammo.hud_state_empty))
 	if(!ammo)
 		return list("unknown", "unknown")
 	else
@@ -473,6 +475,8 @@ can cause issues with ammo types getting mixed up during the burst.
 	recent_pump = world.time
 	if(in_chamber) //Lock only if we have ammo loaded.
 		pump_lock = TRUE
+		var/obj/screen/ammo/A = user.hud_used.ammo
+		A.update_hud(user)
 
 	return TRUE
 

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -174,7 +174,7 @@ can cause issues with ammo types getting mixed up during the burst.
 
 /obj/item/weapon/gun/shotgun/get_ammo_type()
 	if(in_chamber)
-		return(list(in_chamber.ammo.hud_state, in_chamber.ammo.hud_state_empty))
+		return list(in_chamber.ammo.hud_state, in_chamber.ammo.hud_state_empty)
 	if(!ammo)
 		return list("unknown", "unknown")
 	else


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

'fixes' or more accurately 'tweaks to the preference of' #3587

## Why It's Good For The Game

Ammo hud for pump action shotguns/rifles will now show what is actually loaded into the chamber for firing.

## Changelog
:cl:
tweak: Shotgun Ammo Hud updates upon pump_action
/:cl:

