### PR TITLE
Slight SL and Engineer field engineering buff

### DIFF
--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -110,7 +110,7 @@
 
 /datum/skills/combat_engineer
 	name = "Combat Engineer"
-	engineer = SKILL_ENGINEER_ENGI
+	engineer = SKILL_ENGINEER_MASTER
 	construction = SKILL_CONSTRUCTION_ADVANCED
 	leadership = SKILL_LEAD_BEGINNER
 
@@ -270,7 +270,7 @@
 	name = SQUAD_LEADER
 	cqc = SKILL_CQC_TRAINED
 	construction = SKILL_CONSTRUCTION_PLASTEEL
-	engineer = SKILL_ENGINEER_PLASTEEL
+	engineer = SKILL_ENGINEER_ENGI
 	leadership = SKILL_LEAD_TRAINED
 	medical = SKILL_MEDICAL_NOVICE
 	surgery = SKILL_SURGERY_AMATEUR


### PR DESCRIPTION
## About The Pull Request

Title

## Why It's Good For The Game

Engis are always spread thin and SLs already are forced into Engineering roles due to excess of unga. Hopefully makes playing SL less frustrating as your only engineer charges into caves. Buffs squad engi to prevent redundancy.
## Changelog
:cl:
balance: Slightly buffed Engi and SL engineering skill
/:cl:

