### PR TITLE
New Crash landing spots

### DIFF
--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -24933,14 +24933,18 @@
 	dir = 1
 	},
 /area/bigredv2/outside/nw)
+"bZF" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves)
 "cca" = (
 /obj/effect/landmark/monkey_spawn,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/lambda_lab)
-"cem" = (
+"ccP" = (
 /obj/docking_port/stationary/crashmode,
-/turf/open/floor/asteroidfloor,
-/area/bigredv2/outside/nw)
+/turf/closed/wall,
+/area/bigredv2/outside/office_complex)
 "chz" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/floor/wood,
@@ -24980,10 +24984,10 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor,
 /area/bigredv2/outside/hydroponics)
-"cOd" = (
-/obj/machinery/computer/nuke_disk_generator/blue,
-/turf/open/floor/tile/dark,
-/area/bigredv2/outside/nanotrasen_lab/inside)
+"cTr" = (
+/obj/docking_port/stationary/crashmode,
+/turf/closed/wall/r_wall,
+/area/bigredv2/outside/se)
 "cWF" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral/bigred,
@@ -25013,11 +25017,14 @@
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
-"dlx" = (
-/obj/structure/window/framed/colony/reinforced/hull,
+"dlo" = (
+/obj/machinery/door/airlock/mainship/medical/glass{
+	dir = 1;
+	name = "\improper General Store"
+	},
 /obj/docking_port/stationary/crashmode,
-/turf/open/floor/plating,
-/area/bigredv2/outside/se)
+/turf/open/floor,
+/area/bigredv2/outside/general_store)
 "dmd" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /turf/open/floor,
@@ -25088,10 +25095,6 @@
 	dir = 8
 	},
 /area/bigredv2/outside/nanotrasen_lab/inside)
-"ecJ" = (
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/bigredv2/outside/se)
 "edO" = (
 /turf/open/floor/carpet,
 /area/bigredv2/outside/bar)
@@ -25130,6 +25133,10 @@
 	dir = 4
 	},
 /area/bigredv2/caves/lambda_lab)
+"eIX" = (
+/obj/machinery/computer/nuke_disk_generator/blue,
+/turf/open/floor/tile/dark,
+/area/bigredv2/outside/nanotrasen_lab/inside)
 "eQO" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor,
@@ -25186,10 +25193,6 @@
 	},
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/virology)
-"fnZ" = (
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/bigredv2/caves)
 "fra" = (
 /obj/effect/landmark/start/xeno_spawn,
 /turf/open/floor/tile/white,
@@ -25221,6 +25224,10 @@
 /obj/item/tool/warning_cone,
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/se)
+"fLz" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating,
+/area/bigredv2/outside/nw)
 "fMu" = (
 /obj/effect/landmark/start/xeno_spawn,
 /turf/open/floor/tile/dark/purple2{
@@ -25301,15 +25308,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/general_offices)
-"glL" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/plating,
-/area/bigredv2/outside/cargo)
 "gnu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -25425,16 +25423,33 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"hvV" = (
+/obj/docking_port/stationary/crashmode,
+/turf/closed/wall,
+/area/bigredv2/outside/cargo)
 "hzx" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves)
+"hEq" = (
+/obj/docking_port/stationary/crashmode,
+/turf/closed/wall/r_wall,
+/area/bigredv2/outside/engineering)
 "hHN" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/tile/dark/yellow2/corner{
 	dir = 8
 	},
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"hIr" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating,
+/area/bigredv2/outside/cargo)
 "hKr" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
@@ -25460,12 +25475,10 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/general_offices)
-"iaz" = (
+"hVF" = (
 /obj/docking_port/stationary/crashmode,
-/turf/open/floor/engine/cult{
-	dir = 2
-	},
-/area/bigredv2/outside/chapel)
+/turf/closed/wall,
+/area/bigredv2/outside/admin_building)
 "iiY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
@@ -25486,6 +25499,11 @@
 	},
 /turf/closed/mineral/bigred,
 /area/bigredv2/outside/virology)
+"iCt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor,
+/area/bigredv2/outside/office_complex)
 "iKn" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -25524,14 +25542,6 @@
 	dir = 8
 	},
 /area/bigredv2/outside/chapel)
-"jyI" = (
-/obj/docking_port/stationary/crashmode,
-/turf/closed/wall/r_wall,
-/area/bigredv2/outside/engineering)
-"jEI" = (
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/bigredv2/outside/nw)
 "jHL" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/mineral/bigred,
@@ -25542,10 +25552,6 @@
 	dir = 4
 	},
 /area/bigredv2/caves/lambda_lab)
-"jMY" = (
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor,
-/area/bigredv2/outside/general_offices)
 "jQL" = (
 /obj/effect/alien/weeds/node,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -25563,10 +25569,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/general_offices)
-"jTl" = (
-/obj/docking_port/stationary/crashmode,
-/turf/closed/wall/r_wall,
-/area/bigredv2/outside/se)
 "jTB" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -25602,10 +25604,10 @@
 /obj/item/tool/pen/red,
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/virology)
-"kmX" = (
+"khG" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor,
-/area/bigredv2/outside/dorms)
+/area/bigredv2/outside/general_offices)
 "knF" = (
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/outside/engineering)
@@ -25632,6 +25634,10 @@
 	dir = 4
 	},
 /area/bigredv2/outside/virology)
+"kEl" = (
+/obj/structure/largecrate/random,
+/turf/open/floor/marking/bot,
+/area/bigredv2/outside/nanotrasen_lab/inside)
 "kEZ" = (
 /turf/open/floor/plating,
 /area/bigredv2/outside/engineering)
@@ -25669,6 +25675,16 @@
 	},
 /turf/closed/wall,
 /area/bigredv2/outside/cargo)
+"lji" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/outside/se)
+"loj" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/engine/cult{
+	dir = 2
+	},
+/area/bigredv2/outside/chapel)
 "loF" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -25722,16 +25738,6 @@
 /obj/structure/sign/prop1,
 /turf/open/floor,
 /area/bigredv2/outside/office_complex)
-"lIJ" = (
-/obj/structure/window/framed/colony/reinforced,
-/obj/machinery/door/poddoor/shutters/mainship{
-	dir = 2;
-	id = "Engineering";
-	name = "\improper Engineering Shutters"
-	},
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
 "lLO" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/tile/dark/purple2{
@@ -25745,10 +25751,6 @@
 	},
 /turf/open/floor/tile/blue/whitebluefull,
 /area/bigredv2/outside/general_store)
-"lNq" = (
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/bigredv2/outside/c)
 "mbT" = (
 /obj/item/trash/sosjerky,
 /turf/open/floor/plating,
@@ -25883,14 +25885,6 @@
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
-"nVI" = (
-/obj/docking_port/stationary/crashmode,
-/turf/closed/wall,
-/area/bigredv2/outside/cargo)
-"ock" = (
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/bigredv2/outside/se)
 "onZ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -26008,6 +26002,16 @@
 "oWn" = (
 /turf/open/floor/tile/green/whitegreenfull,
 /area/bigredv2/caves/lambda_lab)
+"pbv" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/machinery/door/poddoor/shutters/mainship{
+	dir = 2;
+	id = "Engineering";
+	name = "\improper Engineering Shutters"
+	},
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating,
+/area/bigredv2/outside/engineering)
 "pbI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -26068,6 +26072,10 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/marshal_office)
+"pRv" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/outside/c)
 "pRU" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/machinery/door/poddoor/shutters/mainship{
@@ -26190,6 +26198,10 @@
 /obj/effect/landmark/monkey_spawn,
 /turf/open/floor/tile/darkish,
 /area/bigredv2/caves/lambda_lab)
+"qKE" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/outside/se)
 "qNm" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -26198,10 +26210,6 @@
 	dir = 4
 	},
 /area/bigredv2/outside/w)
-"qOQ" = (
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/plating,
-/area/bigredv2/outside/nw)
 "qQd" = (
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/tile/dark/purple2/corner{
@@ -26253,10 +26261,6 @@
 	dir = 8
 	},
 /area/bigredv2/outside/virology)
-"rrO" = (
-/obj/docking_port/stationary/crashmode,
-/turf/closed/mineral/bigred,
-/area/bigredv2/caves)
 "rvh" = (
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/lambda_lab)
@@ -26271,10 +26275,6 @@
 	dir = 1
 	},
 /area/bigredv2/outside/chapel)
-"rDJ" = (
-/obj/docking_port/stationary/crashmode,
-/turf/closed/wall,
-/area/bigredv2/outside/admin_building)
 "rMV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -26362,6 +26362,10 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
+"sZi" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor,
+/area/bigredv2/outside/dorms)
 "tco" = (
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/s)
@@ -26407,11 +26411,6 @@
 	dir = 6
 	},
 /area/bigredv2/outside/ne)
-"tGa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor,
-/area/bigredv2/outside/office_complex)
 "tIX" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -26488,6 +26487,11 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
+"uja" = (
+/obj/structure/window/framed/colony/reinforced/hull,
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating,
+/area/bigredv2/outside/se)
 "ujn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
@@ -26497,10 +26501,6 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral/bigred,
 /area/bigredv2/outside/s)
-"uvM" = (
-/obj/structure/largecrate/random,
-/turf/open/floor/marking/bot,
-/area/bigredv2/outside/nanotrasen_lab/inside)
 "uwp" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -26540,16 +26540,16 @@
 	},
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/virology)
-"uPW" = (
-/obj/docking_port/stationary/crashmode,
-/turf/closed/wall,
-/area/bigredv2/outside/dorms)
 "uTl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	on = 1
 	},
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
+"uUn" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/outside/nw)
 "uWN" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -26569,6 +26569,10 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/c)
+"vAP" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/asteroidfloor,
+/area/bigredv2/outside/nw)
 "vDI" = (
 /turf/closed/mineral/bigred,
 /area/bigredv2/outside/w)
@@ -26578,10 +26582,6 @@
 	},
 /turf/open/floor/wood,
 /area/bigredv2/caves/lambda_lab)
-"vKu" = (
-/obj/docking_port/stationary/crashmode,
-/turf/closed/wall,
-/area/bigredv2/outside/office_complex)
 "vTU" = (
 /obj/effect/alien/weeds/node,
 /turf/open/ground/jungle/clear,
@@ -26689,6 +26689,10 @@
 /obj/effect/spawner/random/tool,
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
+"xnD" = (
+/obj/docking_port/stationary/crashmode,
+/turf/closed/wall,
+/area/bigredv2/outside/dorms)
 "xqo" = (
 /obj/machinery/door_control{
 	id = "Kitchen";
@@ -26739,6 +26743,10 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/sw)
+"xHV" = (
+/obj/docking_port/stationary/crashmode,
+/turf/closed/mineral/bigred,
+/area/bigredv2/caves)
 "xRR" = (
 /obj/machinery/light{
 	dir = 1
@@ -26772,14 +26780,6 @@
 	dir = 4
 	},
 /area/bigredv2/outside/space_port)
-"ycR" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
-	dir = 1;
-	name = "\improper General Store"
-	},
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor,
-/area/bigredv2/outside/general_store)
 "yek" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -33570,7 +33570,7 @@ aac
 aac
 aac
 aac
-rrO
+xHV
 aac
 aac
 aac
@@ -36823,7 +36823,7 @@ ahX
 aiA
 ajy
 mLR
-cem
+vAP
 ajx
 ajx
 ajx
@@ -37278,7 +37278,7 @@ avT
 avT
 ayc
 avT
-qOQ
+fLz
 avT
 avT
 avr
@@ -37327,7 +37327,7 @@ aXK
 aXK
 bil
 bbg
-nVI
+hvV
 aXK
 aXK
 aXK
@@ -37741,7 +37741,7 @@ aNm
 aMB
 aXH
 aYa
-glL
+hIr
 aXH
 aXK
 baz
@@ -38156,7 +38156,7 @@ aeI
 aeI
 aeI
 aHn
-jEI
+uUn
 aeI
 aeI
 aeI
@@ -38573,7 +38573,7 @@ aeI
 aeI
 aeI
 aeI
-jEI
+uUn
 aeI
 aeI
 apC
@@ -38650,7 +38650,7 @@ gQc
 fOE
 brf
 blJ
-jyI
+hEq
 bme
 bme
 bmd
@@ -38980,7 +38980,7 @@ aac
 aac
 aac
 aad
-fnZ
+bZF
 aad
 aac
 hzx
@@ -39953,7 +39953,7 @@ bop
 gBV
 feK
 bta
-lIJ
+pbv
 bme
 bme
 bme
@@ -40331,7 +40331,7 @@ aHD
 aBR
 aBR
 aMc
-ycR
+dlo
 aNq
 aNo
 aPH
@@ -42324,7 +42324,7 @@ aHD
 aWJ
 aBR
 aBR
-jyI
+hEq
 bmo
 boE
 bmg
@@ -46613,7 +46613,7 @@ acP
 azK
 acP
 aBR
-lNq
+pRv
 aBR
 aBR
 aBR
@@ -46922,7 +46922,7 @@ bwG
 bwL
 bxc
 bxd
-uvM
+kEl
 bxc
 bxU
 bxc
@@ -47356,7 +47356,7 @@ bwF
 bwN
 byh
 bxd
-uvM
+kEl
 bww
 bxV
 bxc
@@ -48000,7 +48000,7 @@ bjy
 abi
 bjw
 bwF
-uvM
+kEl
 bxc
 bxc
 bAg
@@ -48217,7 +48217,7 @@ bjy
 abi
 bjw
 bwF
-uvM
+kEl
 bxc
 bwK
 abX
@@ -48434,7 +48434,7 @@ blv
 abi
 bwb
 bwF
-uvM
+kEl
 bxc
 bxc
 bAg
@@ -48594,7 +48594,7 @@ aYp
 aKn
 aNL
 aUb
-rDJ
+hVF
 bbq
 bcd
 bcU
@@ -48651,7 +48651,7 @@ bjy
 abi
 bjw
 bwF
-uvM
+kEl
 bwK
 bxc
 bAg
@@ -48887,7 +48887,7 @@ bzA
 bxN
 bxg
 bxA
-cOd
+eIX
 bxN
 bBg
 bBu
@@ -48997,7 +48997,7 @@ axI
 ayp
 asJ
 azS
-uPW
+xnD
 asH
 asH
 aCQ
@@ -49481,7 +49481,7 @@ aBR
 aBR
 aBR
 aBR
-lNq
+pRv
 bkv
 bkv
 bkv
@@ -49879,7 +49879,7 @@ aBR
 aBR
 aBR
 aBR
-lNq
+pRv
 aBR
 aBR
 aBR
@@ -50514,7 +50514,7 @@ asJ
 asJ
 asJ
 asJ
-kmX
+sZi
 azY
 aAD
 aBp
@@ -52733,7 +52733,7 @@ aXp
 aXp
 bhV
 aXp
-vKu
+ccP
 aXp
 bjL
 bgx
@@ -54198,7 +54198,7 @@ asP
 apc
 apc
 auV
-jMY
+khG
 aop
 apc
 axR
@@ -54269,7 +54269,7 @@ bqa
 cXu
 oGC
 oGC
-dlx
+uja
 oGC
 cXu
 bqa
@@ -55103,7 +55103,7 @@ aTr
 aTq
 aTq
 aXp
-vKu
+ccP
 aXp
 aXp
 aXp
@@ -55759,7 +55759,7 @@ aXp
 aXp
 aXp
 aXr
-tGa
+iCt
 bdW
 aXp
 beI
@@ -55774,7 +55774,7 @@ aXp
 bjb
 mpz
 bes
-ecJ
+qKE
 bes
 bes
 bes
@@ -56023,7 +56023,7 @@ bux
 bux
 bux
 bux
-ock
+lji
 buM
 aac
 aac
@@ -57093,7 +57093,7 @@ bqa
 bqZ
 bqZ
 bqZ
-jTl
+cTr
 brD
 bqZ
 bqZ
@@ -57566,7 +57566,7 @@ aad
 aad
 aad
 aad
-fnZ
+bZF
 aad
 aad
 aac
@@ -58829,7 +58829,7 @@ aad
 aad
 aad
 abq
-rrO
+xHV
 aac
 aac
 aac
@@ -59443,7 +59443,7 @@ aKP
 aTr
 aZf
 aZH
-iaz
+loj
 bal
 bal
 bal
@@ -61269,7 +61269,7 @@ aad
 aad
 aac
 aac
-rrO
+xHV
 aac
 aac
 aac
@@ -62533,7 +62533,7 @@ aad
 aad
 abq
 aac
-rrO
+xHV
 aac
 aac
 aac
@@ -63600,7 +63600,7 @@ aac
 aac
 aac
 aac
-rrO
+xHV
 aac
 aac
 aac
@@ -67272,7 +67272,7 @@ aad
 afZ
 aad
 aad
-fnZ
+bZF
 abq
 aad
 aad

--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -45,10 +45,6 @@
 	dir = 4
 	},
 /area/bigredv2/outside/space_port)
-"aan" = (
-/obj/effect/landmark/nuke_spawn,
-/turf/open/floor/podhatch/floor,
-/area/bigredv2/outside/admin_building)
 "aao" = (
 /turf/open/floor/plating,
 /area/shuttle/drop1/lz1)
@@ -109,10 +105,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/space_port)
-"aaz" = (
-/obj/machinery/computer/nuke_disk_generator/blue,
-/turf/open/floor,
-/area/bigredv2/outside/nanotrasen_lab/inside)
 "aaA" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/tile/dark,
@@ -7226,6 +7218,7 @@
 /area/bigredv2/caves/lambda_lab)
 "avp" = (
 /obj/machinery/light,
+/obj/effect/landmark/nuke_spawn,
 /turf/open/floor/tile/dark/purple2/corner{
 	dir = 4
 	},
@@ -8458,6 +8451,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
+/obj/docking_port/stationary/crashmode,
 /turf/open/floor/tile/white/warningstripe{
 	dir = 8
 	},
@@ -14373,6 +14367,7 @@
 /area/bigredv2/outside/hydroponics)
 "aRs" = (
 /obj/machinery/light,
+/obj/docking_port/stationary/crashmode,
 /turf/open/floor/tile/yellow/full,
 /area/bigredv2/outside/hydroponics)
 "aRu" = (
@@ -14752,11 +14747,6 @@
 /area/bigredv2/outside/general_store)
 "aSP" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/security/glass{
-	dir = 1;
-	name = "\improper General Store Security";
-	req_access_txt = "0"
-	},
 /turf/open/floor/tile/yellow/full,
 /area/bigredv2/outside/general_store)
 "aSQ" = (
@@ -22993,11 +22983,6 @@
 /obj/effect/alien/weeds/node,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
-"bxB" = (
-/obj/structure/largecrate/guns,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/marking/bot,
-/area/bigredv2/outside/nanotrasen_lab/inside)
 "bxC" = (
 /obj/structure/largecrate/guns,
 /turf/open/floor/marking/bot,
@@ -24952,6 +24937,10 @@
 /obj/effect/landmark/monkey_spawn,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/lambda_lab)
+"cem" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/asteroidfloor,
+/area/bigredv2/outside/nw)
 "chz" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/floor/wood,
@@ -24991,6 +24980,10 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor,
 /area/bigredv2/outside/hydroponics)
+"cOd" = (
+/obj/machinery/computer/nuke_disk_generator/blue,
+/turf/open/floor/tile/dark,
+/area/bigredv2/outside/nanotrasen_lab/inside)
 "cWF" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral/bigred,
@@ -25020,6 +25013,11 @@
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"dlx" = (
+/obj/structure/window/framed/colony/reinforced/hull,
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating,
+/area/bigredv2/outside/se)
 "dmd" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /turf/open/floor,
@@ -25090,6 +25088,10 @@
 	dir = 8
 	},
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"ecJ" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/outside/se)
 "edO" = (
 /turf/open/floor/carpet,
 /area/bigredv2/outside/bar)
@@ -25184,6 +25186,10 @@
 	},
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/virology)
+"fnZ" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves)
 "fra" = (
 /obj/effect/landmark/start/xeno_spawn,
 /turf/open/floor/tile/white,
@@ -25295,6 +25301,15 @@
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/general_offices)
+"glL" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating,
+/area/bigredv2/outside/cargo)
 "gnu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -25445,6 +25460,12 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/general_offices)
+"iaz" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/engine/cult{
+	dir = 2
+	},
+/area/bigredv2/outside/chapel)
 "iiY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
@@ -25503,6 +25524,14 @@
 	dir = 8
 	},
 /area/bigredv2/outside/chapel)
+"jyI" = (
+/obj/docking_port/stationary/crashmode,
+/turf/closed/wall/r_wall,
+/area/bigredv2/outside/engineering)
+"jEI" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/outside/nw)
 "jHL" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/mineral/bigred,
@@ -25513,6 +25542,10 @@
 	dir = 4
 	},
 /area/bigredv2/caves/lambda_lab)
+"jMY" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor,
+/area/bigredv2/outside/general_offices)
 "jQL" = (
 /obj/effect/alien/weeds/node,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -25530,6 +25563,10 @@
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/general_offices)
+"jTl" = (
+/obj/docking_port/stationary/crashmode,
+/turf/closed/wall/r_wall,
+/area/bigredv2/outside/se)
 "jTB" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -25565,6 +25602,10 @@
 /obj/item/tool/pen/red,
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/virology)
+"kmX" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor,
+/area/bigredv2/outside/dorms)
 "knF" = (
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/outside/engineering)
@@ -25681,6 +25722,16 @@
 /obj/structure/sign/prop1,
 /turf/open/floor,
 /area/bigredv2/outside/office_complex)
+"lIJ" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/machinery/door/poddoor/shutters/mainship{
+	dir = 2;
+	id = "Engineering";
+	name = "\improper Engineering Shutters"
+	},
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating,
+/area/bigredv2/outside/engineering)
 "lLO" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/tile/dark/purple2{
@@ -25694,6 +25745,10 @@
 	},
 /turf/open/floor/tile/blue/whitebluefull,
 /area/bigredv2/outside/general_store)
+"lNq" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/outside/c)
 "mbT" = (
 /obj/item/trash/sosjerky,
 /turf/open/floor/plating,
@@ -25828,6 +25883,14 @@
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
+"nVI" = (
+/obj/docking_port/stationary/crashmode,
+/turf/closed/wall,
+/area/bigredv2/outside/cargo)
+"ock" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/outside/se)
 "onZ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -26135,6 +26198,10 @@
 	dir = 4
 	},
 /area/bigredv2/outside/w)
+"qOQ" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating,
+/area/bigredv2/outside/nw)
 "qQd" = (
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/tile/dark/purple2/corner{
@@ -26186,6 +26253,10 @@
 	dir = 8
 	},
 /area/bigredv2/outside/virology)
+"rrO" = (
+/obj/docking_port/stationary/crashmode,
+/turf/closed/mineral/bigred,
+/area/bigredv2/caves)
 "rvh" = (
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/lambda_lab)
@@ -26200,6 +26271,10 @@
 	dir = 1
 	},
 /area/bigredv2/outside/chapel)
+"rDJ" = (
+/obj/docking_port/stationary/crashmode,
+/turf/closed/wall,
+/area/bigredv2/outside/admin_building)
 "rMV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -26332,6 +26407,11 @@
 	dir = 6
 	},
 /area/bigredv2/outside/ne)
+"tGa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor,
+/area/bigredv2/outside/office_complex)
 "tIX" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -26417,6 +26497,10 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral/bigred,
 /area/bigredv2/outside/s)
+"uvM" = (
+/obj/structure/largecrate/random,
+/turf/open/floor/marking/bot,
+/area/bigredv2/outside/nanotrasen_lab/inside)
 "uwp" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -26456,6 +26540,10 @@
 	},
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/virology)
+"uPW" = (
+/obj/docking_port/stationary/crashmode,
+/turf/closed/wall,
+/area/bigredv2/outside/dorms)
 "uTl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	on = 1
@@ -26490,6 +26578,10 @@
 	},
 /turf/open/floor/wood,
 /area/bigredv2/caves/lambda_lab)
+"vKu" = (
+/obj/docking_port/stationary/crashmode,
+/turf/closed/wall,
+/area/bigredv2/outside/office_complex)
 "vTU" = (
 /obj/effect/alien/weeds/node,
 /turf/open/ground/jungle/clear,
@@ -26680,6 +26772,14 @@
 	dir = 4
 	},
 /area/bigredv2/outside/space_port)
+"ycR" = (
+/obj/machinery/door/airlock/mainship/medical/glass{
+	dir = 1;
+	name = "\improper General Store"
+	},
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor,
+/area/bigredv2/outside/general_store)
 "yek" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -33470,7 +33570,7 @@ aac
 aac
 aac
 aac
-aac
+rrO
 aac
 aac
 aac
@@ -36723,7 +36823,7 @@ ahX
 aiA
 ajy
 mLR
-ajx
+cem
 ajx
 ajx
 ajx
@@ -37178,7 +37278,7 @@ avT
 avT
 ayc
 avT
-avT
+qOQ
 avT
 avT
 avr
@@ -37227,7 +37327,7 @@ aXK
 aXK
 bil
 bbg
-aXK
+nVI
 aXK
 aXK
 aXK
@@ -37641,7 +37741,7 @@ aNm
 aMB
 aXH
 aYa
-aYd
+glL
 aXH
 aXK
 baz
@@ -38056,7 +38156,7 @@ aeI
 aeI
 aeI
 aHn
-aeI
+jEI
 aeI
 aeI
 aeI
@@ -38473,7 +38573,7 @@ aeI
 aeI
 aeI
 aeI
-aeI
+jEI
 aeI
 aeI
 apC
@@ -38550,7 +38650,7 @@ gQc
 fOE
 brf
 blJ
-blJ
+jyI
 bme
 bme
 bmd
@@ -38880,7 +38980,7 @@ aac
 aac
 aac
 aad
-aad
+fnZ
 aad
 aac
 hzx
@@ -39853,7 +39953,7 @@ bop
 gBV
 feK
 bta
-asT
+lIJ
 bme
 bme
 bme
@@ -40231,7 +40331,7 @@ aHD
 aBR
 aBR
 aMc
-aME
+ycR
 aNq
 aNo
 aPH
@@ -41321,7 +41421,7 @@ aNt
 aOB
 aNo
 aNo
-aRR
+aQS
 aMB
 aPH
 aPH
@@ -41538,8 +41638,8 @@ aNu
 aNo
 aNo
 aNo
-aRR
-aPH
+aQS
+aXc
 aTT
 aVh
 aQS
@@ -42224,7 +42324,7 @@ aHD
 aWJ
 aBR
 aBR
-blJ
+jyI
 bmo
 boE
 bmg
@@ -43276,7 +43376,7 @@ aPK
 aQV
 aRT
 aKn
-aan
+aVR
 aNF
 aVQ
 aKn
@@ -46513,7 +46613,7 @@ acP
 azK
 acP
 aBR
-aBR
+lNq
 aBR
 aBR
 aBR
@@ -46822,7 +46922,7 @@ bwG
 bwL
 bxc
 bxd
-bxB
+uvM
 bxc
 bxU
 bxc
@@ -47256,7 +47356,7 @@ bwF
 bwN
 byh
 bxd
-bxB
+uvM
 bww
 bxV
 bxc
@@ -47900,7 +48000,7 @@ bjy
 abi
 bjw
 bwF
-bxC
+uvM
 bxc
 bxc
 bAg
@@ -48117,7 +48217,7 @@ bjy
 abi
 bjw
 bwF
-bxC
+uvM
 bxc
 bwK
 abX
@@ -48334,7 +48434,7 @@ blv
 abi
 bwb
 bwF
-bxC
+uvM
 bxc
 bxc
 bAg
@@ -48494,7 +48594,7 @@ aYp
 aKn
 aNL
 aUb
-aKn
+rDJ
 bbq
 bcd
 bcU
@@ -48551,7 +48651,7 @@ bjy
 abi
 bjw
 bwF
-bxC
+uvM
 bwK
 bxc
 bAg
@@ -48787,7 +48887,7 @@ bzA
 bxN
 bxg
 bxA
-bxo
+cOd
 bxN
 bBg
 bBu
@@ -48897,7 +48997,7 @@ axI
 ayp
 asJ
 azS
-asH
+uPW
 asH
 asH
 aCQ
@@ -49202,7 +49302,7 @@ bjy
 abi
 bjw
 bwF
-aaz
+bxc
 bwK
 bxc
 bAg
@@ -49381,7 +49481,7 @@ aBR
 aBR
 aBR
 aBR
-aBR
+lNq
 bkv
 bkv
 bkv
@@ -49779,7 +49879,7 @@ aBR
 aBR
 aBR
 aBR
-aBR
+lNq
 aBR
 aBR
 aBR
@@ -50414,7 +50514,7 @@ asJ
 asJ
 asJ
 asJ
-asJ
+kmX
 azY
 aAD
 aBp
@@ -50440,7 +50540,7 @@ aBR
 aBR
 aBR
 aMc
-aHD
+vsq
 aIn
 aIn
 aIn
@@ -52633,7 +52733,7 @@ aXp
 aXp
 bhV
 aXp
-aXp
+vKu
 aXp
 bjL
 bgx
@@ -54098,7 +54198,7 @@ asP
 apc
 apc
 auV
-apc
+jMY
 aop
 apc
 axR
@@ -54169,7 +54269,7 @@ bqa
 cXu
 oGC
 oGC
-oGC
+dlx
 oGC
 cXu
 bqa
@@ -55003,7 +55103,7 @@ aTr
 aTq
 aTq
 aXp
-aXp
+vKu
 aXp
 aXp
 aXp
@@ -55659,7 +55759,7 @@ aXp
 aXp
 aXp
 aXr
-aXU
+tGa
 bdW
 aXp
 beI
@@ -55674,7 +55774,7 @@ aXp
 bjb
 mpz
 bes
-bes
+ecJ
 bes
 bes
 bes
@@ -55923,7 +56023,7 @@ bux
 bux
 bux
 bux
-bux
+ock
 buM
 aac
 aac
@@ -56993,7 +57093,7 @@ bqa
 bqZ
 bqZ
 bqZ
-bqZ
+jTl
 brD
 bqZ
 bqZ
@@ -57466,7 +57566,7 @@ aad
 aad
 aad
 aad
-aad
+fnZ
 aad
 aad
 aac
@@ -58729,7 +58829,7 @@ aad
 aad
 aad
 abq
-aac
+rrO
 aac
 aac
 aac
@@ -59343,7 +59443,7 @@ aKP
 aTr
 aZf
 aZH
-bal
+iaz
 bal
 bal
 bal
@@ -61169,7 +61269,7 @@ aad
 aad
 aac
 aac
-aac
+rrO
 aac
 aac
 aac
@@ -62433,7 +62533,7 @@ aad
 aad
 abq
 aac
-aac
+rrO
 aac
 aac
 aac
@@ -63500,7 +63600,7 @@ aac
 aac
 aac
 aac
-aac
+rrO
 aac
 aac
 aac
@@ -67172,7 +67272,7 @@ aad
 afZ
 aad
 aad
-aad
+fnZ
 abq
 aad
 aad

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -19888,6 +19888,10 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
 /area/lv624/ground/sand5)
+"bOR" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor,
+/area/lv624/ground/river2)
 "bVE" = (
 /obj/structure/fence,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
@@ -19897,6 +19901,10 @@
 	dir = 8
 	},
 /area/shuttle/drop2/lz2)
+"cat" = (
+/obj/docking_port/stationary/crashmode,
+/turf/closed/gm/dense,
+/area/lv624/ground/jungle7)
 "ciV" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -19932,10 +19940,6 @@
 	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/quartstorage)
-"cTS" = (
-/obj/docking_port/stationary/crashmode,
-/turf/closed/gm/dense,
-/area/lv624/ground/jungle6)
 "cTX" = (
 /obj/structure/jungle/vines/heavy,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -19966,10 +19970,14 @@
 	dir = 4
 	},
 /area/shuttle/drop2/lz2)
-"eil" = (
+"dRM" = (
+/obj/docking_port/stationary/crashmode,
+/turf/closed/gm/dense,
+/area/lv624/ground/jungle9)
+"epV" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/caves/west1)
+/area/lv624/ground/sand2)
 "evP" = (
 /obj/structure/sign/atmosplaque{
 	dir = 1
@@ -20096,6 +20104,10 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/cult,
 /area/lv624/ground/caves/west1)
+"hDA" = (
+/obj/docking_port/stationary/crashmode,
+/turf/closed/wall,
+/area/lv624/ground/river2)
 "hVU" = (
 /obj/structure/window/framed/colony,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
@@ -20108,16 +20120,28 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/west1)
+"iEQ" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/marking/bot,
+/area/shuttle/drop1/lz1)
 "iLV" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/cult,
 /area/lv624/ground/sand4)
+"jeZ" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand3)
 "jgW" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 8
 	},
 /turf/closed/wall,
 /area/lv624/lazarus/main_hall)
+"jzY" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand4)
 "jAh" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral,
@@ -20154,10 +20178,14 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral,
 /area/lv624/ground/caves/west1)
-"ksR" = (
+"jVV" = (
 /obj/docking_port/stationary/crashmode,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/sand3)
+/turf/open/ground/river,
+/area/lv624/ground/river2)
+"kir" = (
+/obj/docking_port/stationary/crashmode,
+/turf/closed/gm/dense,
+/area/lv624/ground/jungle6)
 "ktj" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral,
@@ -20174,6 +20202,10 @@
 	dir = 8
 	},
 /area/lv624/ground/jungle6)
+"kPi" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand5)
 "lda" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral,
@@ -20224,10 +20256,14 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/n)
-"mDm" = (
+"mrh" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor,
 /area/lv624/ground/sand2)
+"mvX" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle7)
 "mGd" = (
 /obj/structure/jungle/vines,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
@@ -20259,10 +20295,6 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/n)
-"nIT" = (
-/obj/docking_port/stationary/crashmode,
-/turf/closed/wall,
-/area/lv624/ground/river3)
 "nUa" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/dirt,
@@ -20275,10 +20307,6 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand5)
-"owm" = (
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor,
-/area/lv624/ground/river2)
 "oFi" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/dirt,
@@ -20320,23 +20348,16 @@
 	dir = 1
 	},
 /area/shuttle/drop2/lz2)
+"puV" = (
+/obj/structure/window/framed/colony,
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
 "pNb" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating,
 /area/lv624/lazarus/robotics)
-"pSM" = (
-/obj/structure/jungle/vines,
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 4
-	},
-/area/shuttle/drop1/lz1)
-"qPR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor,
-/area/lv624/ground/sand8)
 "qQj" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/wall,
@@ -20354,13 +20375,6 @@
 	dir = 5
 	},
 /area/shuttle/drop1/lz1)
-"qVd" = (
-/obj/structure/bed/chair/wood/wings,
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/tile/purple/taupepurple{
-	dir = 9
-	},
-/area/lv624/lazarus/sleep_female)
 "qYr" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/machinery/door/poddoor/mainship{
@@ -20400,23 +20414,14 @@
 	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/internal_affairs)
+"rDw" = (
+/obj/docking_port/stationary/crashmode,
+/turf/closed/wall,
+/area/lv624/ground/river3)
 "rOf" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/platebotc,
 /area/lv624/lazarus/quartstorage/outdoors)
-"rTs" = (
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/sand4)
-"scX" = (
-/obj/structure/jungle/plantbot1/alien,
-/obj/docking_port/stationary/crashmode,
-/turf/open/ground/river,
-/area/lv624/ground/river1)
-"smy" = (
-/obj/docking_port/stationary/crashmode,
-/turf/open/ground/grass,
-/area/lv624/ground/jungle7)
 "sGt" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 8
@@ -20446,15 +20451,6 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/east2)
-"tnn" = (
-/obj/structure/window/framed/colony,
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/plating,
-/area/lv624/lazarus/quartstorage)
-"ttu" = (
-/obj/docking_port/stationary/crashmode,
-/turf/open/ground/river,
-/area/lv624/ground/river2)
 "tAN" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/dirt,
@@ -20464,6 +20460,10 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral,
 /area/lv624/ground/caves/east1)
+"tUO" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/west1)
 "tWO" = (
 /obj/structure/mineral_door/resin,
 /obj/effect/alien/weeds/node,
@@ -20474,10 +20474,13 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/dirtgrassborder/corner,
 /area/lv624/ground/jungle3)
-"ugT" = (
+"uqX" = (
+/obj/structure/bed/chair/wood/wings,
 /obj/docking_port/stationary/crashmode,
-/turf/closed/gm/dense,
-/area/lv624/ground/jungle7)
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
 "usu" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -20490,6 +20493,11 @@
 	},
 /turf/closed/wall,
 /area/lv624/lazarus/quartstorage)
+"uNG" = (
+/obj/structure/jungle/plantbot1/alien,
+/obj/docking_port/stationary/crashmode,
+/turf/open/ground/river,
+/area/lv624/ground/river1)
 "uVd" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -20516,6 +20524,13 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand4)
+"vuY" = (
+/obj/structure/jungle/vines,
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 4
+	},
+/area/shuttle/drop1/lz1)
 "vzU" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -20528,10 +20543,11 @@
 	},
 /turf/closed/wall/r_wall,
 /area/lv624/lazarus/internal_affairs)
-"vJc" = (
+"vJf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/docking_port/stationary/crashmode,
-/turf/closed/gm/dense,
-/area/lv624/ground/jungle9)
+/turf/open/floor,
+/area/lv624/ground/sand8)
 "vLs" = (
 /obj/structure/mineral_door/resin,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -20544,22 +20560,6 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle7)
-"vYA" = (
-/obj/docking_port/stationary/crashmode,
-/turf/closed/wall,
-/area/lv624/ground/river2)
-"web" = (
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/sand2)
-"wuX" = (
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/sand5)
-"wwM" = (
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/marking/bot,
-/area/shuttle/drop1/lz1)
 "wDI" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/engine/cult{
@@ -27485,7 +27485,7 @@ avO
 auH
 avd
 auJ
-cTS
+kir
 axQ
 axQ
 axQ
@@ -31088,7 +31088,7 @@ axQ
 axQ
 axQ
 axQ
-cTS
+kir
 axQ
 axQ
 auJ
@@ -33586,7 +33586,7 @@ abc
 abc
 abc
 abc
-eil
+tUO
 abc
 abc
 abc
@@ -33889,7 +33889,7 @@ aqD
 aqD
 aqD
 auZ
-scX
+uNG
 are
 are
 atz
@@ -34121,7 +34121,7 @@ abc
 iuG
 aht
 ahu
-rTs
+jzY
 aht
 aht
 aht
@@ -38500,7 +38500,7 @@ amT
 alm
 alm
 ajj
-owm
+bOR
 ajS
 apQ
 amw
@@ -41085,7 +41085,7 @@ arW
 atI
 auK
 arW
-smy
+mvX
 avV
 awn
 awn
@@ -41562,7 +41562,7 @@ afR
 aen
 agv
 agv
-web
+epV
 agv
 agv
 agv
@@ -43638,7 +43638,7 @@ akH
 aln
 amX
 anw
-qPR
+vJf
 aoF
 apg
 apC
@@ -47238,7 +47238,7 @@ amU
 ajR
 akq
 aoz
-ttu
+jVV
 amw
 ajz
 ajz
@@ -48560,7 +48560,7 @@ aEy
 aEW
 aFG
 aGn
-vJc
+dRM
 aFB
 aFB
 aGo
@@ -49014,7 +49014,7 @@ adR
 adR
 adR
 agy
-mDm
+mrh
 agy
 agy
 aho
@@ -50031,7 +50031,7 @@ aen
 aen
 aen
 aen
-wuX
+kPi
 aen
 afu
 aen
@@ -51876,7 +51876,7 @@ arW
 asW
 arW
 atl
-ugT
+cat
 atl
 atl
 auL
@@ -52890,7 +52890,7 @@ amg
 amH
 ane
 aei
-vYA
+hDA
 ajz
 akp
 ajz
@@ -53455,7 +53455,7 @@ aJF
 aNG
 aMH
 aPs
-qVd
+uqX
 aRi
 aPr
 aSt
@@ -56049,7 +56049,7 @@ eNq
 beQ
 mGd
 bgw
-pSM
+vuY
 bgw
 biF
 bju
@@ -57003,7 +57003,7 @@ amK
 ani
 anQ
 aol
-nIT
+rDw
 aoS
 aoS
 aoS
@@ -57757,7 +57757,7 @@ aft
 afA
 ahh
 ahh
-ksR
+jeZ
 ahh
 ahh
 ahf
@@ -57842,7 +57842,7 @@ aYi
 aWs
 aYi
 aWs
-wwM
+iEQ
 aWs
 aSB
 aWs
@@ -58588,7 +58588,7 @@ aEk
 aEk
 aDL
 aEj
-tnn
+puV
 aEj
 aDL
 aAn

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -2498,6 +2498,7 @@
 	dir = 4
 	},
 /obj/item/explosive/grenade/incendiary,
+/obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating,
 /area/lv624/ground/sand2)
 "ajc" = (
@@ -6724,6 +6725,7 @@
 /area/lv624/lazarus/security)
 "ayX" = (
 /obj/structure/flora/ausbushes/sparsegrass,
+/obj/docking_port/stationary/crashmode,
 /turf/open/ground/river,
 /area/lv624/ground/river1)
 "ayY" = (
@@ -14386,6 +14388,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/docking_port/stationary/crashmode,
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/main_hall)
 "bax" = (
@@ -19894,12 +19897,6 @@
 	dir = 8
 	},
 /area/shuttle/drop2/lz2)
-"bXW" = (
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/tile/vault{
-	dir = 8
-	},
-/area/lv624/lazarus/robotics)
 "ciV" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -19935,6 +19932,10 @@
 	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/quartstorage)
+"cTS" = (
+/obj/docking_port/stationary/crashmode,
+/turf/closed/gm/dense,
+/area/lv624/ground/jungle6)
 "cTX" = (
 /obj/structure/jungle/vines/heavy,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -19965,6 +19966,10 @@
 	dir = 4
 	},
 /area/shuttle/drop2/lz2)
+"eil" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/west1)
 "evP" = (
 /obj/structure/sign/atmosplaque{
 	dir = 1
@@ -20149,6 +20154,10 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral,
 /area/lv624/ground/caves/west1)
+"ksR" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand3)
 "ktj" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral,
@@ -20215,6 +20224,10 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/n)
+"mDm" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor,
+/area/lv624/ground/sand2)
 "mGd" = (
 /obj/structure/jungle/vines,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
@@ -20222,10 +20235,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/drop1/lz1)
-"mOk" = (
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/compound/sw)
 "mWY" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral,
@@ -20250,6 +20259,10 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/n)
+"nIT" = (
+/obj/docking_port/stationary/crashmode,
+/turf/closed/wall,
+/area/lv624/ground/river3)
 "nUa" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/dirt,
@@ -20262,6 +20275,10 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand5)
+"owm" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor,
+/area/lv624/ground/river2)
 "oFi" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/dirt,
@@ -20308,6 +20325,18 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating,
 /area/lv624/lazarus/robotics)
+"pSM" = (
+/obj/structure/jungle/vines,
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 4
+	},
+/area/shuttle/drop1/lz1)
+"qPR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor,
+/area/lv624/ground/sand8)
 "qQj" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/wall,
@@ -20325,6 +20354,13 @@
 	dir = 5
 	},
 /area/shuttle/drop1/lz1)
+"qVd" = (
+/obj/structure/bed/chair/wood/wings,
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
 "qYr" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/machinery/door/poddoor/mainship{
@@ -20368,6 +20404,19 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/platebotc,
 /area/lv624/lazarus/quartstorage/outdoors)
+"rTs" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand4)
+"scX" = (
+/obj/structure/jungle/plantbot1/alien,
+/obj/docking_port/stationary/crashmode,
+/turf/open/ground/river,
+/area/lv624/ground/river1)
+"smy" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle7)
 "sGt" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 8
@@ -20397,6 +20446,15 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/east2)
+"tnn" = (
+/obj/structure/window/framed/colony,
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"ttu" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/ground/river,
+/area/lv624/ground/river2)
 "tAN" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/dirt,
@@ -20416,6 +20474,10 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/dirtgrassborder/corner,
 /area/lv624/ground/jungle3)
+"ugT" = (
+/obj/docking_port/stationary/crashmode,
+/turf/closed/gm/dense,
+/area/lv624/ground/jungle7)
 "usu" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -20428,16 +20490,6 @@
 	},
 /turf/closed/wall,
 /area/lv624/lazarus/quartstorage)
-"uCp" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/tile/barber,
-/area/lv624/lazarus/fitness)
 "uVd" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -20476,6 +20528,10 @@
 	},
 /turf/closed/wall/r_wall,
 /area/lv624/lazarus/internal_affairs)
+"vJc" = (
+/obj/docking_port/stationary/crashmode,
+/turf/closed/gm/dense,
+/area/lv624/ground/jungle9)
 "vLs" = (
 /obj/structure/mineral_door/resin,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -20488,6 +20544,22 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle7)
+"vYA" = (
+/obj/docking_port/stationary/crashmode,
+/turf/closed/wall,
+/area/lv624/ground/river2)
+"web" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand2)
+"wuX" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand5)
+"wwM" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/marking/bot,
+/area/shuttle/drop1/lz1)
 "wDI" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/engine/cult{
@@ -27413,7 +27485,7 @@ avO
 auH
 avd
 auJ
-axQ
+cTS
 axQ
 axQ
 axQ
@@ -31016,7 +31088,7 @@ axQ
 axQ
 axQ
 axQ
-axQ
+cTS
 axQ
 axQ
 auJ
@@ -33514,7 +33586,7 @@ abc
 abc
 abc
 abc
-abc
+eil
 abc
 abc
 abc
@@ -33817,7 +33889,7 @@ aqD
 aqD
 aqD
 auZ
-atA
+scX
 are
 are
 atz
@@ -33844,7 +33916,7 @@ avd
 aHK
 aIq
 aJe
-bXW
+aJe
 aJe
 aJe
 aJe
@@ -34049,7 +34121,7 @@ abc
 iuG
 aht
 ahu
-aht
+rTs
 aht
 aht
 aht
@@ -38428,7 +38500,7 @@ amT
 alm
 alm
 ajj
-ajj
+owm
 ajS
 apQ
 amw
@@ -39785,7 +39857,7 @@ aZl
 aZl
 aZl
 aZl
-mOk
+aZl
 bgJ
 bnN
 bnN
@@ -41013,7 +41085,7 @@ arW
 atI
 auK
 arW
-arW
+smy
 avV
 awn
 awn
@@ -41490,7 +41562,7 @@ afR
 aen
 agv
 agv
-agv
+web
 agv
 agv
 agv
@@ -43566,7 +43638,7 @@ akH
 aln
 amX
 anw
-anw
+qPR
 aoF
 apg
 apC
@@ -44634,7 +44706,7 @@ aAc
 aFy
 aGi
 aGJ
-uCp
+aGJ
 aGJ
 aGJ
 aGJ
@@ -47166,7 +47238,7 @@ amU
 ajR
 akq
 aoz
-ajz
+ttu
 amw
 ajz
 ajz
@@ -48488,7 +48560,7 @@ aEy
 aEW
 aFG
 aGn
-aFB
+vJc
 aFB
 aFB
 aGo
@@ -48942,7 +49014,7 @@ adR
 adR
 adR
 agy
-agy
+mDm
 agy
 agy
 aho
@@ -49959,7 +50031,7 @@ aen
 aen
 aen
 aen
-aen
+wuX
 aen
 afu
 aen
@@ -51804,7 +51876,7 @@ arW
 asW
 arW
 atl
-atl
+ugT
 atl
 atl
 auL
@@ -52818,7 +52890,7 @@ amg
 amH
 ane
 aei
-alS
+vYA
 ajz
 akp
 ajz
@@ -53383,7 +53455,7 @@ aJF
 aNG
 aMH
 aPs
-aQs
+qVd
 aRi
 aPr
 aSt
@@ -55977,7 +56049,7 @@ eNq
 beQ
 mGd
 bgw
-bgw
+pSM
 bgw
 biF
 bju
@@ -56931,7 +57003,7 @@ amK
 ani
 anQ
 aol
-aoS
+nIT
 aoS
 aoS
 aoS
@@ -57685,7 +57757,7 @@ aft
 afA
 ahh
 ahh
-ahh
+ksR
 ahh
 ahh
 ahf
@@ -57770,7 +57842,7 @@ aYi
 aWs
 aYi
 aWs
-aYi
+wwM
 aWs
 aSB
 aWs
@@ -58516,7 +58588,7 @@ aEk
 aEk
 aDL
 aEj
-aEj
+tnn
 aEj
 aDL
 aAn

--- a/_maps/map_files/desert/desert.dmm
+++ b/_maps/map_files/desert/desert.dmm
@@ -4096,6 +4096,14 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating/ground,
 /area/desert/outside)
+"zQ" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	icon_state = "pdoor1";
+	dir = 1
+	},
+/obj/docking_port/stationary/crashmode,
+/turf/closed/wall/r_wall,
+/area/desert/interior/shipping/north)
 "Bv" = (
 /obj/machinery/door/airlock/colony/engineering{
 	name = "\improper Storage";
@@ -4104,24 +4112,16 @@
 	},
 /turf/open/floor/plating,
 /area/desert/interior/security)
-"Lj" = (
-/obj/effect/alien/weeds/node/strong,
+"EQ" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground,
 /area/desert/outside)
-"Oq" = (
+"EV" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/plating_catwalk,
 /area/desert/interior/shipping/south)
-"Wc" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	icon_state = "pdoor1";
-	dir = 1
-	},
-/obj/docking_port/stationary/crashmode,
-/turf/closed/wall/r_wall,
-/area/desert/interior/shipping/north)
-"Wd" = (
+"OJ" = (
+/obj/effect/alien/weeds/node/strong,
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground,
 /area/desert/outside)
@@ -18914,7 +18914,7 @@ aU
 bA
 bA
 bA
-Lj
+OJ
 bA
 bA
 bA
@@ -22016,7 +22016,7 @@ bS
 kX
 bA
 bA
-Wd
+EQ
 bA
 aC
 aC
@@ -32032,7 +32032,7 @@ ll
 ll
 ll
 ll
-Oq
+EV
 la
 ly
 lD
@@ -33525,7 +33525,7 @@ bA
 bA
 jF
 kY
-Wc
+zQ
 bI
 fa
 fa

--- a/_maps/map_files/desert/desert.dmm
+++ b/_maps/map_files/desert/desert.dmm
@@ -4104,6 +4104,27 @@
 	},
 /turf/open/floor/plating,
 /area/desert/interior/security)
+"Lj" = (
+/obj/effect/alien/weeds/node/strong,
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground,
+/area/desert/outside)
+"Oq" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/plating_catwalk,
+/area/desert/interior/shipping/south)
+"Wc" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	icon_state = "pdoor1";
+	dir = 1
+	},
+/obj/docking_port/stationary/crashmode,
+/turf/closed/wall/r_wall,
+/area/desert/interior/shipping/north)
+"Wd" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground,
+/area/desert/outside)
 
 (1,1,1) = {"
 au
@@ -18893,7 +18914,7 @@ aU
 bA
 bA
 bA
-bK
+Lj
 bA
 bA
 bA
@@ -21995,7 +22016,7 @@ bS
 kX
 bA
 bA
-bA
+Wd
 bA
 aC
 aC
@@ -32011,7 +32032,7 @@ ll
 ll
 ll
 ll
-li
+Oq
 la
 ly
 lD
@@ -33504,7 +33525,7 @@ bA
 bA
 jF
 kY
-aO
+Wc
 bI
 fa
 fa

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -4606,10 +4606,6 @@
 /obj/item/explosive/plastique,
 /turf/open/floor/tile/dark2,
 /area/icy_caves/outpost/refinery)
-"ps" = (
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/plating/icefloor,
-/area/icy_caves/outpost/LZ1)
 "pt" = (
 /obj/docking_port/stationary/marine_dropship/lz1,
 /turf/open/floor/plating,
@@ -5272,6 +5268,10 @@
 /obj/effect/landmark/corpsespawner/pmc,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
+"sf" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground/ice,
+/area/icy_caves/caves/east)
 "tm" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -5311,10 +5311,28 @@
 	},
 /turf/open/floor/tile/dark2,
 /area/icy_caves/outpost/research)
+"yE" = (
+/obj/docking_port/stationary/crashmode,
+/turf/closed/ice/thin/intersection,
+/area/icy_caves/caves/south)
 "zl" = (
 /obj/effect/landmark/start/surv_spawn,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
+"zn" = (
+/obj/docking_port/stationary/crashmode,
+/turf/closed/wall/r_wall,
+/area/icy_caves/outpost/dorms)
+"zV" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground/snow,
+/area/icy_caves/outpost/outside)
 "Br" = (
 /obj/structure/cable/yellow{
 	d2 = 4;
@@ -5322,6 +5340,10 @@
 	},
 /turf/open/floor/tile/dark2,
 /area/icy_caves/outpost/research)
+"Fa" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground/ice,
+/area/icy_caves/caves/west)
 "GZ" = (
 /obj/structure/bed,
 /obj/effect/landmark/start/surv_spawn,
@@ -5382,6 +5404,10 @@
 "NU" = (
 /turf/closed/ice_rock/fourway,
 /area/icy_caves/outpost/outside)
+"Ou" = (
+/obj/docking_port/stationary/crashmode,
+/turf/closed/ice_rock/single,
+/area/icy_caves/caves/west)
 "PB" = (
 /obj/machinery/door/airlock/colony/research,
 /turf/open/floor/tile/dark2,
@@ -5406,6 +5432,12 @@
 "Ry" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/caves/OOB)
+"RJ" = (
+/obj/docking_port/stationary/crashmode,
+/turf/closed/ice/thin/junction{
+	dir = 1
+	},
+/area/icy_caves/caves/south)
 "RN" = (
 /obj/effect/landmark/start/surv_spawn,
 /turf/open/floor/tile/dark2,
@@ -5464,6 +5496,13 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/outside)
+"Xf" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/obj/docking_port/stationary/crashmode,
+/turf/closed/wall/r_wall,
+/area/icy_caves/outpost/refinery)
 "XH" = (
 /obj/structure/table,
 /obj/structure/cable/yellow{
@@ -9058,7 +9097,7 @@ la
 la
 la
 la
-ps
+fE
 la
 la
 la
@@ -12394,7 +12433,7 @@ aU
 aU
 aU
 gw
-go
+Xf
 jV
 jU
 jU
@@ -13118,7 +13157,7 @@ eb
 hs
 dc
 dc
-dc
+Fa
 dc
 dc
 dc
@@ -15976,7 +16015,7 @@ gv
 mO
 bP
 bP
-bP
+zV
 bP
 bP
 bP
@@ -18530,7 +18569,7 @@ eg
 dD
 dD
 ef
-ef
+Ou
 ef
 gv
 gw
@@ -21387,7 +21426,7 @@ aU
 mL
 aU
 gw
-mT
+zn
 mY
 nb
 nd
@@ -25720,7 +25759,7 @@ dm
 dm
 fz
 iK
-iK
+yE
 dl
 dM
 dM
@@ -28512,7 +28551,7 @@ dm
 dm
 ej
 fz
-gL
+RJ
 ha
 gJ
 dL
@@ -28787,7 +28826,7 @@ dm
 dm
 fC
 iK
-iK
+yE
 dj
 gZ
 hV
@@ -33950,7 +33989,7 @@ ds
 ds
 ds
 jp
-ds
+sf
 ds
 ds
 ds

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -5268,10 +5268,10 @@
 /obj/effect/landmark/corpsespawner/pmc,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
-"sf" = (
+"rt" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/east)
+/area/icy_caves/caves/west)
 "tm" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -5311,19 +5311,22 @@
 	},
 /turf/open/floor/tile/dark2,
 /area/icy_caves/outpost/research)
-"yE" = (
+"yl" = (
 /obj/docking_port/stationary/crashmode,
-/turf/closed/ice/thin/intersection,
-/area/icy_caves/caves/south)
+/turf/closed/wall/r_wall,
+/area/icy_caves/outpost/dorms)
 "zl" = (
 /obj/effect/landmark/start/surv_spawn,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
-"zn" = (
-/obj/docking_port/stationary/crashmode,
-/turf/closed/wall/r_wall,
-/area/icy_caves/outpost/dorms)
-"zV" = (
+"Br" = (
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/open/floor/tile/dark2,
+/area/icy_caves/outpost/research)
+"Bs" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -5333,17 +5336,6 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/snow,
 /area/icy_caves/outpost/outside)
-"Br" = (
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/open/floor/tile/dark2,
-/area/icy_caves/outpost/research)
-"Fa" = (
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/west)
 "GZ" = (
 /obj/structure/bed,
 /obj/effect/landmark/start/surv_spawn,
@@ -5391,9 +5383,17 @@
 /obj/structure/dispenser,
 /turf/open/floor/tile/dark2,
 /area/icy_caves/outpost/research)
+"LI" = (
+/obj/docking_port/stationary/crashmode,
+/turf/closed/ice_rock/single,
+/area/icy_caves/caves/west)
 "MQ" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/caves/northern)
+"Nf" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground/ice,
+/area/icy_caves/caves/east)
 "NE" = (
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/OOB)
@@ -5404,10 +5404,6 @@
 "NU" = (
 /turf/closed/ice_rock/fourway,
 /area/icy_caves/outpost/outside)
-"Ou" = (
-/obj/docking_port/stationary/crashmode,
-/turf/closed/ice_rock/single,
-/area/icy_caves/caves/west)
 "PB" = (
 /obj/machinery/door/airlock/colony/research,
 /turf/open/floor/tile/dark2,
@@ -5421,6 +5417,13 @@
 "Ql" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area)
+"QK" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/obj/docking_port/stationary/crashmode,
+/turf/closed/wall/r_wall,
+/area/icy_caves/outpost/refinery)
 "Rh" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -5432,12 +5435,6 @@
 "Ry" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/caves/OOB)
-"RJ" = (
-/obj/docking_port/stationary/crashmode,
-/turf/closed/ice/thin/junction{
-	dir = 1
-	},
-/area/icy_caves/caves/south)
 "RN" = (
 /obj/effect/landmark/start/surv_spawn,
 /turf/open/floor/tile/dark2,
@@ -5459,6 +5456,10 @@
 	},
 /turf/open/floor/tile/dark2,
 /area/icy_caves/outpost/research)
+"ST" = (
+/obj/docking_port/stationary/crashmode,
+/turf/closed/ice/thin/intersection,
+/area/icy_caves/caves/south)
 "Tb" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 6
@@ -5476,6 +5477,12 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/dark2,
 /area/icy_caves/outpost/research)
+"Uk" = (
+/obj/docking_port/stationary/crashmode,
+/turf/closed/ice/thin/junction{
+	dir = 1
+	},
+/area/icy_caves/caves/south)
 "UM" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/research)
@@ -5496,13 +5503,6 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/outside)
-"Xf" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
-/obj/docking_port/stationary/crashmode,
-/turf/closed/wall/r_wall,
-/area/icy_caves/outpost/refinery)
 "XH" = (
 /obj/structure/table,
 /obj/structure/cable/yellow{
@@ -12433,7 +12433,7 @@ aU
 aU
 aU
 gw
-Xf
+QK
 jV
 jU
 jU
@@ -13157,7 +13157,7 @@ eb
 hs
 dc
 dc
-Fa
+rt
 dc
 dc
 dc
@@ -16015,7 +16015,7 @@ gv
 mO
 bP
 bP
-zV
+Bs
 bP
 bP
 bP
@@ -18569,7 +18569,7 @@ eg
 dD
 dD
 ef
-Ou
+LI
 ef
 gv
 gw
@@ -21426,7 +21426,7 @@ aU
 mL
 aU
 gw
-zn
+yl
 mY
 nb
 nd
@@ -25759,7 +25759,7 @@ dm
 dm
 fz
 iK
-yE
+ST
 dl
 dM
 dM
@@ -28551,7 +28551,7 @@ dm
 dm
 ej
 fz
-RJ
+Uk
 ha
 gJ
 dL
@@ -28826,7 +28826,7 @@ dm
 dm
 fC
 iK
-yE
+ST
 dj
 gZ
 hV
@@ -33989,7 +33989,7 @@ ds
 ds
 ds
 jp
-sf
+Nf
 ds
 ds
 ds


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Big Red:
- New crash landing spots (39 landing spots total).
- Moved blue disk gen to another part of Eta lab.
- Moved the nuke to Lambda lab.
- Replaced the Firearm crates in Eta with regular randomized crates.

Icy Caves:
- New crash landing spots (9 landing spots total).

LV624:
- New crash landing spots (25 landing spots total).

Desert Outpost:
- New crash landing spots (7 landing spots total).

## Why It's Good For The Game

Adds more variety to crash, as most maps only had 1-3 landing spots.
Also lets Lambda lab see some use in crash.
Moved the disk generator in Eta out of the room with 1 entrance and reinforced walls to a larger room closer to the APC.
Replaced the firearm crates in Eta, because there's no real reason for them to be there. It's not an armory.

## Changelog
:cl:
add: New Crash landing spots in Desert, Big Red, LV624, and Icy Caves.
add: Replaced firearm crates in Big Red's Eta Lab with regular crates.
del: Removed the firearm crates in Big Red's Eta Lab.
tweak: Moved the nuke in Big Red to Lambda lab.
tweak: Moved the disk generator in Eta Lab closer to the APC.
balance: rebalanced something
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
