### PR TITLE
Removes custom CSS

### DIFF
--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -21,7 +21,6 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("tmp/iconCache.sav")) //Cache of ico
 	var/working      = TRUE
 	var/list/connectionHistory //Contains the connection history passed from chat cookie
 	var/adminMusicVolume = 10 //This is for the Play Global Sound verb
-	var/clientCSS = "" // This is a string var that stores client CSS.
 
 /datum/chatOutput/New(client/C)
 	owner = C

--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -118,7 +118,6 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("tmp/iconCache.sav")) //Cache of ico
 
 	messageQueue = null
 	sendClientData()
-	loadClientCSS()
 
 	//do not convert to to_chat()
 	SEND_TEXT(owner, "<span class=\"userdanger\">Failed to load fancy chat, reverting to old chat. Certain features won't work.</span>")
@@ -210,50 +209,6 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("tmp/iconCache.sav")) //Cache of ico
 //Called by js client on js error
 /datum/chatOutput/proc/debug(error)
 	log_world("\[[time2text(world.realtime, "YYYY-MM-DD hh:mm:ss")]\] Client: [(src.owner.key ? src.owner.key : src.owner)] triggered JS error: [error]")
-
-
-
-/mob/verb/update_client_css()
-	set category = "Preferences"
-	set name = "Update Custom CSS"
-
-	if(!client.chatOutput)
-		return
-	var/new_input = input(usr, "Enter custom CSS", "Client CSS", client.chatOutput.clientCSS) as message|null
-	if(isnull(new_input) || length(new_input) > UPLOAD_LIMIT)
-		return
-	to_chat(src, "<span class='notice'>Updating custom CSS.</span>")
-	client.chatOutput.clientCSS = new_input
-	client.chatOutput.saveClientCSS()
-	client.chatOutput.syncClientCSS()
-
-// Load the CSS into the user browser
-/datum/chatOutput/proc/syncClientCSS()
-	var/css_data = _replacetext(clientCSS, ";", "||") // ; is a reserved key so lets just replace it and replace it back in js
-	var/list/ajax_data = list("clientCSS" = css_data)
-	ehjax_send(data = ajax_data)
-
-// Save the CSS locally on the client
-/datum/chatOutput/proc/saveClientCSS()
-	var/savefile/F = new()
-	WRITE_FILE(F["CSS"], clientCSS)
-	owner.Export(F)
-	qdel(F)
-
-// Load the CSS from the local client
-/datum/chatOutput/proc/loadClientCSS()
-	var/last_savefile = owner.Import()
-	if(!last_savefile)
-		saveClientCSS("")
-		return
-	var/savefile/F = new(last_savefile)
-	READ_FILE(F["CSS"], clientCSS)
-
-	if(length(clientCSS) > UPLOAD_LIMIT)
-		clientCSS = ""
-	clientCSS = sanitize_text(clientCSS, "")
-
-	syncClientCSS(clientCSS)
 
 
 //Global chat procs

--- a/code/modules/goonchat/browserOutput.js
+++ b/code/modules/goonchat/browserOutput.js
@@ -539,13 +539,6 @@ function ehjaxCallback(data) {
 			var firebugEl = document.createElement('script');
 			firebugEl.src = 'https://getfirebug.com/firebug-lite-debug.js';
 			document.body.appendChild(firebugEl);
-		} else if (data.clientCSS) {
-			var css = data.clientCSS.replace(/\;/g, "").replace(/\|{2}/g, ";");
-			var $clientCSS = $('style#client-css');
-			if (!$clientCSS) {
-				return;
-			}
-			$clientCSS.text(css);
 		} else if (data.adminMusic) {
 			if (typeof data.adminMusic === 'string') {
 				var adminMusic = byondDecode(data.adminMusic);


### PR DESCRIPTION
Mainly due to being unmaintained and crashing the server. Lummox hasn't been able to diagnose the cause properly, but it happens every time certain client CSS files are read at different points of initialization in general.
This implementation is also problematic because this file is shared with every other SS13 server, which can lead to issues if they also use the same method, and easily corrupt the file.
Since we've had light and dark mode for quite a while, this is not really very much needed. Other skin or CSS options can be added if necessary.

## Changelog
:cl:
del: Removed custom CSS option.
/:cl: