### PR TITLE
Removes the Spatial Agent glasses tint

### DIFF
--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -274,7 +274,7 @@
 
 /obj/item/clothing/glasses/sunglasses/sa/Initialize()
 	. = ..()
-	AddComponent(/datum/component/clothing_tint, TINT_NONE
+	AddComponent(/datum/component/clothing_tint, TINT_NONE)
 
 /obj/item/clothing/glasses/sunglasses/sechud
 	name = "HUDSunglasses"

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -272,6 +272,10 @@
 	vision_flags = SEE_TURFS|SEE_MOBS|SEE_OBJS
 	lighting_alpha = LIGHTING_PLANE_ALPHA_INVISIBLE
 
+/obj/item/clothing/glasses/sunglasses/sa/Initialize()
+	. = ..()
+	AddComponent(/datum/component/clothing_tint, TINT_NONE
+
 /obj/item/clothing/glasses/sunglasses/sechud
 	name = "HUDSunglasses"
 	desc = "Sunglasses with a HUD."


### PR DESCRIPTION
## About The Pull Request

title
## Why It's Good For The Game

It's annoying

## Changelog
:cl:
tweak: Spatial agent glasses now have no tint
/:cl: