### PR TITLE
smg now does 5 round burst

### DIFF
--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -63,7 +63,6 @@
 						/obj/item/attachable/extended_barrel,
 						/obj/item/attachable/heavy_barrel,
 						/obj/item/attachable/scope/mini,
-						/obj/item/attachable/burstfire_assembly,
 						/obj/item/attachable/magnetic_harness,
 						/obj/item/attachable/gyro)
 
@@ -77,7 +76,7 @@
 	fire_delay = 0.2 SECONDS
 	scatter_unwielded = 30
 	aim_slowdown = 0.15
-	burst_amount = 2
+	burst_amount = 5
 
 
 //-------------------------------------------------------


### PR DESCRIPTION
## Why It's Good For The Game

0.2 is 5 bullets a second in theory. It also does no AP. This is so burst isn't garbo bad, removes BFA because I'd get screeched at otherwise

## Changelog
:cl:

balance: SMG now has 5 round burst, removed BFA

/:cl:

