### PR TITLE
Nerfs Boiler to no longer be an insane glob machine

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
@@ -42,9 +42,9 @@
 
 	// *** Boiler Abilities *** //
 	max_ammo = 4
-	bomb_strength = 1 //Multiplier to the effectiveness of the boiler glob. Improves by 0.5 per upgrade
+	bomb_strength = 1 //Multiplier to the effectiveness of the boiler glob. Improves by 0.1 per upgrade
 	acid_delay = 9 SECONDS //9 seconds delay on acid. Reduced by -1 per upgrade down to 5 seconds
-	bomb_delay = 10 SECONDS //20 seconds per glob at Young, -2.5 per upgrade down to 10 seconds
+	bomb_delay = 25 SECONDS //25 seconds per glob at every level but ancient, which has 20.
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
@@ -94,9 +94,9 @@
 
 	// *** Boiler Abilities *** //
 	max_ammo = 5
-	bomb_strength = 1.5
+	bomb_strength = 1.1
 	acid_delay = 9 SECONDS //9 seconds delay on acid. Reduced by -1 per upgrade down to 5 seconds
-	bomb_delay = 10 SECONDS //20 seconds per glob at Young, -2.5 per upgrade down to 10 seconds
+	bomb_delay = 25 SECONDS //25 seconds per glob at every level but ancient.
 
 /datum/xeno_caste/boiler/elder
 	upgrade_name = "Elder"
@@ -130,9 +130,9 @@
 
 	// *** Boiler Abilities *** //
 	max_ammo = 6
-	bomb_strength = 2
+	bomb_strength = 1.2
 	acid_delay = 9 SECONDS //9 seconds delay on acid. Reduced by -1 per upgrade down to 5 seconds
-	bomb_delay = 10 SECONDS //20 seconds per glob at Young, -2.5 per upgrade down to 10 seconds
+	bomb_delay = 25 SECONDS
 
 /datum/xeno_caste/boiler/ancient
 	upgrade_name = "Ancient"
@@ -164,6 +164,6 @@
 
 	// *** Boiler Abilities *** //
 	max_ammo = 7
-	bomb_strength = 2.5
+	bomb_strength = 1.3
 	acid_delay = 9 SECONDS //9 seconds delay on acid. Reduced by -1 per upgrade down to 5 seconds
-	bomb_delay = 10 SECONDS //20 seconds per glob at Young, -2.5 per upgrade down to 10 seconds
+	bomb_delay = 20 SECONDS //25 seconds per glob at Young, 20 at ancient

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
@@ -165,5 +165,5 @@
 	// *** Boiler Abilities *** //
 	max_ammo = 7
 	bomb_strength = 1.3
-	acid_delay = 9 SECONDS //9 seconds delay on acid. Reduced by -1 per upgrade down to 5 seconds
+	acid_delay = 9 SECONDS
 	bomb_delay = 20 SECONDS

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
@@ -43,7 +43,7 @@
 	// *** Boiler Abilities *** //
 	max_ammo = 4
 	bomb_strength = 1 //Multiplier to the effectiveness of the boiler glob.
-	acid_delay = 9 SECONDS //9 seconds delay on acid. Reduced by -1 per upgrade down to 5 seconds
+	acid_delay = 9 SECONDS
 	bomb_delay = 25 SECONDS
 
 	actions = list(

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
@@ -42,9 +42,9 @@
 
 	// *** Boiler Abilities *** //
 	max_ammo = 4
-	bomb_strength = 1 //Multiplier to the effectiveness of the boiler glob. Improves by 0.1 per upgrade
+	bomb_strength = 1 //Multiplier to the effectiveness of the boiler glob.
 	acid_delay = 9 SECONDS //9 seconds delay on acid. Reduced by -1 per upgrade down to 5 seconds
-	bomb_delay = 25 SECONDS //25 seconds per glob at every level but ancient, which has 20.
+	bomb_delay = 25 SECONDS
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
@@ -95,8 +95,8 @@
 	// *** Boiler Abilities *** //
 	max_ammo = 5
 	bomb_strength = 1.1
-	acid_delay = 9 SECONDS //9 seconds delay on acid. Reduced by -1 per upgrade down to 5 seconds
-	bomb_delay = 25 SECONDS //25 seconds per glob at every level but ancient.
+	acid_delay = 9 SECONDS
+	bomb_delay = 25 SECONDS
 
 /datum/xeno_caste/boiler/elder
 	upgrade_name = "Elder"
@@ -131,7 +131,7 @@
 	// *** Boiler Abilities *** //
 	max_ammo = 6
 	bomb_strength = 1.2
-	acid_delay = 9 SECONDS //9 seconds delay on acid. Reduced by -1 per upgrade down to 5 seconds
+	acid_delay = 9 SECONDS
 	bomb_delay = 25 SECONDS
 
 /datum/xeno_caste/boiler/ancient
@@ -166,4 +166,4 @@
 	max_ammo = 7
 	bomb_strength = 1.3
 	acid_delay = 9 SECONDS //9 seconds delay on acid. Reduced by -1 per upgrade down to 5 seconds
-	bomb_delay = 20 SECONDS //25 seconds per glob at Young, 20 at ancient
+	bomb_delay = 20 SECONDS

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1313,11 +1313,12 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	sound_hit 	 = "acid_hit"
 	sound_bounce	= "acid_bounce"
 	debilitate = list(1,1,0,0,1,1,0,0)
-	flags_ammo_behavior = AMMO_XENO|AMMO_SKIPS_ALIENS|AMMO_EXPLOSIVE|AMMO_IGNORE_ARMOR
+	flags_ammo_behavior = AMMO_XENO|AMMO_SKIPS_ALIENS|AMMO_EXPLOSIVE
 	armor_type = "acid"
 	danger_message = "<span class='danger'>A glob of acid lands with a splat and explodes into corrosive bile!</span>"
 	damage = 50
 	damage_type = BURN
+	penetration = 40
 
 /datum/ammo/xeno/boiler_gas/corrosive/on_shield_block(mob/victim, obj/projectile/proj)
 	airburst(victim, proj)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Nerfs boiler overall because constant globs at anything but lowpop could probably break the game

## Why It's Good For The Game

Boiler direct hits piercing all armor is dumb, They now penetrate a good chunk of armor instead.
Globs now take double the time overall.

## Changelog
/:cl:
balance: boiler nerfs

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
