### PR TITLE
Buff Synthetic burn resistances 

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -590,7 +590,7 @@
 	total_health = 150 //more health than regular humans
 
 	brute_mod = 0.75
-	burn_mod = 1.1
+	burn_mod = 0.90 //Synthetics should not be instantly melted by acid compared to humans - This is a test to hopefully fix very glaring issues involving synthetics taking 2.6 trillion damage when so much as touching acid
 
 	cold_level_1 = -1
 	cold_level_2 = -1
@@ -642,8 +642,8 @@
 	slowdown = 1.3 //Slower than later synths
 	total_health = 200 //But more durable
 	insulated = 1
-	brute_mod = 0.75
-	burn_mod = 1.1
+	brute_mod = 0.60 //but more durable
+	burn_mod = 0.90 //previous comment
 
 	cold_level_1 = -1
 	cold_level_2 = -1


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Buffs synthetics to have acid resistance rather than vulnerability - ill cover why below
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Currently, synths can be instantly stunlocked and killed (nearly full to 0hp) upon so much as touching an acid tile or acid smoke
https://cdn.discordapp.com/attachments/500801682058379265/692526872940118036/unknown.png
https://cdn.discordapp.com/attachments/500801682058379265/692499935983173672/unknown.png
both of these screenshots happened in less than two seconds respectively.
Furthermore, even with heavy armor this occurs (second one occurred with, the first one with medium)

Basically, with the amount of trash synths have piled ontop of their gameplay, this would be a nice change of pace.

Peoples argument for 'more health and brute resist' being the tradeoff for not being able to use guns, heavy armaments (such as dropship weapons + tank + mortar) is a terrible excuse for making a role utterly useless when faced with burn damage in general
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: synth and old synth now have 0.9* the normal burn damage.
tweak: old synths now have extra brute armor to accompany the slowdown and extra HP compared to new synths
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
