### PR TITLE
Makes marines no longer require tramadol to walk out of fob

### DIFF
--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -71,7 +71,7 @@
 	traumatic_shock = 			\
 	0.75	* getOxyLoss() + 		\
 	0.75	* getToxLoss() + 		\
-	1.05		* getFireLoss() + 		\
+	1.20		* getFireLoss() + 		\
 	1		* getBruteLoss() + 		\
 	1		* getCloneLoss()
 

--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -71,7 +71,7 @@
 	traumatic_shock = 			\
 	0.75	* getOxyLoss() + 		\
 	0.75	* getToxLoss() + 		\
-	1.5		* getFireLoss() + 		\
+	1.05		* getFireLoss() + 		\
 	1		* getBruteLoss() + 		\
 	1		* getCloneLoss()
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This is technically a premed nerf and xeno nerf combined into one. Also technically a marine buff.
This just makes it so you dont take 1.5X pain from burn sources
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
uhh yeah chief taking 1.5x pain is fucking stupid and whoever designed it should be shot behind a barn, its an excuse for every marine to instantly premed themselves with kelo + oxytrama as soon as they see even a tail of a xeno.
Also its dumb going into paincrit because i got booped with 20 burn damage
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Bumps the 1.5X burn pain modifier down to 1.2X
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
