### PR TITLE
Rpg nerfs

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -910,7 +910,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage_falloff = 0
 	accurate_range = 15
 	penetration = 150
-	damage = 375
+	damage = 300
 
 /datum/ammo/rocket/ap/drop_nade(turf/T)
 	explosion(T, -1, -1, 2, 5)

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -910,10 +910,10 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage_falloff = 0
 	accurate_range = 15
 	penetration = 150
-	damage = 300
+	damage = 325
 
 /datum/ammo/rocket/ap/drop_nade(turf/T)
-	explosion(T, -1, -1, 2, 5)
+	explosion(T, -1, -1, -1, 1)
 
 /datum/ammo/rocket/ltb
 	name = "cannon round"


### PR DESCRIPTION


## About The Pull Request
oof

## Why It's Good For The Game

rpg nerfs
## Changelog
:cl:

balance: AP rockets now only have a light explosion, but have no smoke and deal less direct hit.
:cl:

