### PR TITLE
Nested hosts don't need to breath

### DIFF
--- a/code/modules/mob/living/carbon/carbon_helpers.dm
+++ b/code/modules/mob/living/carbon/carbon_helpers.dm
@@ -12,7 +12,7 @@
 
 
 /mob/living/carbon/proc/need_breathe()
-	if(reagents.has_reagent(/datum/reagent/toxin/lexorin) || HAS_TRAIT(src, TRAIT_STASIS))
+	if(reagents.has_reagent(/datum/reagent/toxin/lexorin) || HAS_TRAIT(src, TRAIT_STASIS) || isnestedhost(src))
 		return FALSE
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request
Buff to nested marines, they will no longer recover / loss breath while nested.

## Why It's Good For The Game
Increase the change that a xeno capture turns into a successful infection.

## Changelog
:cl:
add: Buff to nested marines, they will no longer recover / loss breath while nested
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
