### PR TITLE
Fix being able to move an active bomb

### DIFF
--- a/code/game/objects/machinery/nuclearbomb.dm
+++ b/code/game/objects/machinery/nuclearbomb.dm
@@ -68,6 +68,7 @@
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_NUKE_STOP, src)
 	countdown.stop()
 	GLOB.active_nuke_list -= src
+	timeleft = initial(timeleft)
 	return ..()
 
 

--- a/code/game/objects/machinery/nuclearbomb.dm
+++ b/code/game/objects/machinery/nuclearbomb.dm
@@ -273,6 +273,9 @@
 			if(safety)
 				to_chat(usr, "<span class='warning'>The safety is still on.</span>")
 				return
+			if(!anchored)
+				to_chat(usr, "<span class='warning'>The anchors are not set.</span>")
+				return
 			timer_enabled = !timer_enabled
 			if(timer_enabled)
 				start_processing()
@@ -297,6 +300,8 @@
 				visible_message("<span class='warning'>With a steely snap, bolts slide out of [src] and anchor it to the flooring.</span>")
 			else
 				visible_message("<span class='warning'>The anchoring bolts slide back into the depths of [src].</span>")
+				timer_enabled = FALSE
+				stop_processing()
 
 	updateUsrDialog()
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so that for the timer to be active you must have disabled the saftey and anchored the nuke

## Why It's Good For The Game

Dragging the nuke while its active leaves no counter play for xenos.

## Changelog
:cl:
tweak: Nuke must be anchored for the timer to be active, disabling the nuke resets the timer
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
