### PR TITLE
Makes survivor armor have no slowdown and fixes a weird typo

### DIFF
--- a/code/datums/jobs/job/survivor.dm
+++ b/code/datums/jobs/job/survivor.dm
@@ -270,6 +270,6 @@
 	jobtype = /datum/job/survivor/rambo
 	w_uniform = /obj/item/clothing/under/color/grey
 	wear_suit = /obj/item/clothing/suit/armor/rugged
-	shoes = /obj/item/clothing/shoes/ruggetboot
+	shoes = /obj/item/clothing/shoes/ruggedboot
 	back = /obj/item/storage/backpack/satchel/rugged
 	gloves = /obj/item/clothing/gloves/ruggedgloves

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -24,8 +24,8 @@
 	flags_inventory = NOSLIPPING
 	siemens_coefficient = 0.6
 
-/obj/item/clothing/shoes/ruggetboot
-	name = "Rugget Boots"
+/obj/item/clothing/shoes/ruggedboot
+	name = "Rugged Boots"
 	desc = "A pair of boots used by workers in dangerous environments."
 	icon_state = "swat"
 	armor = list("melee" = 20, "bullet" = 20, "laser" = 20, "energy" = 25, "bomb" = 20, "bio" = 20, "rad" = 20, "fire" = 20, "acid" = 20)

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -203,7 +203,7 @@
 	item_state = "swatarmor"
 	var/obj/item/weapon/gun/holstered = null
 	flags_armor_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
-	slowdown = SLOWDOWN_ARMOR_LIGHT 
+	slowdown = 0
 	armor = list("melee" = 50, "bullet" = 40, "laser" = 40, "energy" = 40, "bomb" = 50, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 	siemens_coefficient = 0.7
 


### PR DESCRIPTION

## About The Pull Request

Rugged armor no longer has any slowdown

## Why It's Good For The Game
Survivors keep getting indirectly nerfed by a lot of balance changes. This is a nice buff.

## Changelog
:cl:
balance: rugged armor has 0 slowdown
:cl:

