### PR TITLE
Lowers crusher charge knockdown/stun

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -512,7 +512,7 @@
 
 	switch(charge_datum.charge_type)
 		if(CHARGE_CRUSH)
-			Knockdown(CHARGE_SPEED(charge_datum) * 80)
+			Knockdown(CHARGE_SPEED(charge_datum) * 20)
 		if(CHARGE_BULL_HEADBUTT)
 			Knockdown(CHARGE_SPEED(charge_datum) * 60)
 


### PR DESCRIPTION

## About The Pull Request

Brings down the ludicrous 80 knockdown to 20 knockdown. Marines get up quicker from being rammed by charges.

## Why It's Good For The Game

Not only did 80 knockdown allow crushers to single-handedly kill squads with impunity, it made crusher pairs easily capable of winning rounds through charge spam. 

## Changelog
:cl:
balance: Lowered crusher charge knockdown to 20. Ungas get up quicker from rams.
/:cl: