### PR TITLE
Synthetics no longer get head delimbed provided they're wearing a helmet

### DIFF
--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -207,7 +207,7 @@
 			owner.updatehealth()
 		return update_icon()
 	var/obj/item/clothing/worn_helmet = owner.head
-	if(body_part == HEAD && istype(worn_helmet, /obj/item/clothing/head/helmet) && !(owner.species.species_flags & IS_SYNTHETIC) ) //Early return if the body part is a head but target is wearing a helmet and is not a synth
+	if(body_part == HEAD && istype(worn_helmet, /obj/item/clothing/head/helmet)) //Early return if the body part is a head but target is wearing a helmet
 		if(updating_health)
 			owner.updatehealth()
 		return update_icon()
@@ -1106,10 +1106,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 	encased = "skull"
 	var/disfigured = 0 //whether the head is disfigured.
 	var/face_surgery_stage = 0
-
-/datum/limb/head/New()
-	..()
-	max_damage = owner.species.total_health
 
 /*
 /datum/limb/head/get_icon(icon/race_icon, icon/deform_icon)

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -665,7 +665,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			var/datum/wound/W
 			if(max_damage < 50)
 				W = new/datum/wound/lost_limb/small(max_damage * 0.25)
-			else 				
+			else
 				W = new/datum/wound/lost_limb(max_damage * 0.25)
 
 			parent.wounds += W
@@ -1106,6 +1106,10 @@ Note that amputating the affected organ does in fact remove the infection from t
 	encased = "skull"
 	var/disfigured = 0 //whether the head is disfigured.
 	var/face_surgery_stage = 0
+
+/datum/limb/head/New()
+	..()
+	max_damage = owner.species.total_health
 
 /*
 /datum/limb/head/get_icon(icon/race_icon, icon/deform_icon)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
As title says
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Synth buffs and some more overall sameness with humans
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: ma44
balance: Synths can't get head delimbed provided they wear a helmet
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
