### PR TITLE
Fixes pistol rig not holding other pistols

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -578,23 +578,19 @@
 		)
 
 /obj/item/storage/belt/gun/pistol/standard_pistol
-	name = "\improper T457 pattern TP-14 holster rig"
+	name = "\improper T457 pattern pistol holster rig"
 	desc = "The T457 is the standard load-bearing equipment of the TGMC. It consists of a modular belt with various clips. This version is for the TP-14 Pistol."
 	icon_state = "tp14_holster"
 	item_state = "tp14_holster"
-	can_hold = list(
-		/obj/item/weapon/gun/pistol/standard_pistol,
-		/obj/item/ammo_magazine/pistol/standard_pistol
-		)
 
 /obj/item/storage/belt/gun/revolver/standard_revolver
-	name = "\improper T457 pattern TP-44 holster rig"
+	name = "\improper T457 pattern revolver holster rig"
 	desc = "The T457 is the standard load-bearing equipment of the TGMC. It consists of a modular belt with various clips. This version is for the TP-44 Revolver."
 	icon_state = "tp44_holster"
 	item_state = "tp44_holster"
 	can_hold = list(
-		/obj/item/weapon/gun/revolver/standard_revolver,
-		/obj/item/ammo_magazine/revolver/standard_revolver
+		/obj/item/weapon/gun/revolver,
+		/obj/item/ammo_magazine/revolver
 		)
 
 /obj/item/storage/belt/gun/m44

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -579,7 +579,7 @@
 
 /obj/item/storage/belt/gun/pistol/standard_pistol
 	name = "\improper T457 pattern pistol holster rig"
-	desc = "The T457 is the standard load-bearing equipment of the TGMC. It consists of a modular belt with various clips. This version is for the TP-14 Pistol."
+	desc = "The T457 is the standard load-bearing equipment of the TGMC. It consists of a modular belt with various clips."
 	icon_state = "tp14_holster"
 	item_state = "tp14_holster"
 

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -585,7 +585,7 @@
 
 /obj/item/storage/belt/gun/revolver/standard_revolver
 	name = "\improper T457 pattern revolver holster rig"
-	desc = "The T457 is the standard load-bearing equipment of the TGMC. It consists of a modular belt with various clips. This version is for the TP-44 Revolver."
+	desc = "The T457 is the standard load-bearing equipment of the TGMC. It consists of a modular belt with various clips."
 	icon_state = "tp44_holster"
 	item_state = "tp44_holster"
 	can_hold = list(


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes the TP-14 holster not being able to hold other pistols, like the Mod88. Also renamed the rig to reflect it's standard use.

## Why It's Good For The Game

If it's the standard pistol rig in all the vendors and req, it should hold all pistols available to marines.

## Changelog
:cl:
fix: The pistol rig now properly holds pistols other than the TP-14
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
