### PR TITLE
Crusher charge damage nerf

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -27,7 +27,7 @@
 	var/speed_per_step = 0.15
 	var/steps_for_charge = 7
 	var/max_steps_buildup = 14
-	var/crush_living_damage = 30
+	var/crush_living_damage = 10
 	var/next_special_attack = 0 //Little var to keep track on special attack timers.
 
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reduces the amount of base damage charge does from 30 to 10 (charge speed seems to max out at 3, so the charge does 30 damage max, unlike now where it does like 90 or something)
## Why It's Good For The Game
Crusher needs a nerf, I can up it to 15 or something if it's too bad at this level, though I think it'll still be good due to the level of safety the charge has

## Changelog
:cl:

balance: Crusher base ram damage nerfed from 30 to 10

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
