### PR TITLE
Components cleanup fix

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -32,6 +32,8 @@
 #define COMSIG_COMPONENT_REMOVING "component_removing"
 /// before a datum's Destroy() is called: (force), returning a nonzero value will cancel the qdel operation
 #define COMSIG_PARENT_PREQDELETED "parent_preqdeleted"
+/// just before a datum's Destroy() is called: (force), at this point none of the other components chose to interrupt qdel and Destroy will be called
+#define COMSIG_PARENT_QDELETING "parent_qdeleting"
 /// generic topic handler (usr, href_list)
 #define COMSIG_TOPIC "handle_topic"
 

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -98,7 +98,7 @@ SUBSYSTEM_DEF(garbage)
 					state = SS_RUNNING
 				break
 
-	
+
 
 
 /datum/controller/subsystem/garbage/proc/HandleQueue(level = GC_QUEUE_CHECK)

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -1,9 +1,27 @@
+/**
+  * The absolute base class for everything
+  *
+  * A datum instantiated has no physical world prescence, use an atom if you want something
+  * that actually lives in the world
+  *
+  * Be very mindful about adding variables to this class, they are inherited by every single
+  * thing in the entire game, and so you can easily cause memory usage to rise a lot with careless
+  * use of variables at this level
+  */
 /datum
-	var/gc_destroyed //Time when this object was destroyed.
-	var/list/active_timers  //for SStimer
+	/**
+	  * Tick count time when this object was destroyed.
+	  *
+	  * If this is non zero then the object has been garbage collected and is awaiting either
+	  * a hard del by the GC subsystme, or to be autocollected (if it has no references)
+	  */
+	var/gc_destroyed
+
+	/// Active timers with this datum as the target
+	var/list/active_timers
+	/// Status traits attached to this datum
 	var/list/status_traits
-	var/datum_flags = NONE
-	var/datum/weakref/weak_reference
+	
 	var/hidden_from_codex = FALSE //set to TRUE if you want something to be hidden.
 	var/interaction_flags = NONE //Defined at the datum level since some can be interacted with.
 
@@ -28,6 +46,12 @@
 	  */
 	var/signal_enabled = FALSE
 
+	/// Datum level flags
+	var/datum_flags = NONE
+
+	/// A weak reference to another datum
+	var/datum/weakref/weak_reference
+
 #ifdef TESTING
 	var/running_find_references
 	var/last_find_references = 0
@@ -37,9 +61,23 @@
 	var/list/cached_vars
 #endif
 
-// Default implementation of clean-up code.
-// This should be overridden to remove all references pointing to the object being destroyed.
-// Return the appropriate QDEL_HINT; in most cases this is QDEL_HINT_QUEUE.
+
+/**
+  * Default implementation of clean-up code.
+  *
+  * This should be overridden to remove all references pointing to the object being destroyed, if
+  * you do override it, make sure to call the parent and return it's return value by default
+  *
+  * Return an appropriate [QDEL_HINT][QDEL_HINT_QUEUE] to modify handling of your deletion;
+  * in most cases this is [QDEL_HINT_QUEUE].
+  *
+  * The base case is responsible for doing the following
+  * * Erasing timers pointing to this datum
+  * * Erasing compenents on this datum
+  * * Notifying datums listening to signals from this datum that we are going away
+  *
+  * Returns [QDEL_HINT_QUEUE]
+  */
 /datum/proc/Destroy(force=FALSE, ...)
 	SHOULD_CALL_PARENT(TRUE)
 	tag = null
@@ -53,6 +91,38 @@
 		if (timer.spent)
 			continue
 		qdel(timer)
+
+	//BEGIN: ECS SHIT
+	signal_enabled = FALSE
+
+	var/list/dc = datum_components
+	if(dc)
+		var/all_components = dc[/datum/component]
+		if(length(all_components))
+			for(var/I in all_components)
+				var/datum/component/C = I
+				qdel(C, FALSE, TRUE)
+		else
+			var/datum/component/C = all_components
+			qdel(C, FALSE, TRUE)
+		dc.Cut()
+
+	var/list/lookup = comp_lookup
+	if(lookup)
+		for(var/sig in lookup)
+			var/list/comps = lookup[sig]
+			if(length(comps))
+				for(var/i in comps)
+					var/datum/component/comp = i
+					comp.UnregisterSignal(src, sig)
+			else
+				var/datum/component/comp = comps
+				comp.UnregisterSignal(src, sig)
+		comp_lookup = lookup = null
+
+	for(var/target in signal_procs)
+		UnregisterSignal(target, signal_procs[target])
+	//END: ECS SHIT
 
 	return QDEL_HINT_QUEUE
 
@@ -83,15 +153,15 @@
 	to_chat(target, txt_changed_vars())
 #endif
 
-//Return a LIST for serialize_datum to encode! Not the actual json!
+///Return a LIST for serialize_datum to encode! Not the actual json!
 /datum/proc/serialize_list(list/options)
 	CRASH("Attempted to serialize datum [src] of type [type] without serialize_list being implemented!")
 
-//Accepts a LIST from deserialize_datum. Should return src or another datum.
+///Accepts a LIST from deserialize_datum. Should return src or another datum.
 /datum/proc/deserialize_list(json, list/options)
 	CRASH("Attempted to deserialize datum [src] of type [type] without deserialize_list being implemented!")
 
-//Serializes into JSON. Does not encode type.
+///Serializes into JSON. Does not encode type.
 /datum/proc/serialize_json(list/options)
 	. = serialize_list(options)
 	if(!islist(.))
@@ -99,13 +169,14 @@
 	else
 		. = json_encode(.)
 
-//Deserializes from JSON. Does not parse type.
+///Deserializes from JSON. Does not parse type.
 /datum/proc/deserialize_json(list/input, list/options)
 	var/list/jsonlist = json_decode(input)
 	. = deserialize_list(jsonlist)
 	if(!istype(., /datum))
 		. = null
 
+///Convert a datum into a json blob
 /proc/json_serialize_datum(datum/D, list/options)
 	if(!istype(D))
 		return
@@ -114,6 +185,7 @@
 		jsonlist["DATUM_TYPE"] = D.type
 	return json_encode(jsonlist)
 
+/// Convert a list of json to datum
 /proc/json_deserialize_datum(list/jsonlist, list/options, target_type, strict_target_type = FALSE)
 	if(!islist(jsonlist))
 		if(!istext(jsonlist))
@@ -146,6 +218,11 @@
 		return returned
 
 
+/**
+  * Called when a href for this datum is clicked
+  *
+  * Sends a [COMSIG_TOPIC] signal
+  */
 /datum/Topic(href, list/href_list)
 	. = ..()
 	if(.)


### PR DESCRIPTION
Components were not being correctly removed.

This adds latest /tg/ code, plus a few useful procs for debugging deletion and finding uncleared references.