### PR TITLE
Projectile reference fix and cleanup

### DIFF
--- a/code/datums/components/full_auto_fire.dm
+++ b/code/datums/components/full_auto_fire.dm
@@ -344,6 +344,7 @@
 /obj/item/weapon/gun/proc/do_autofire(datum/source, atom/target, mob/living/shooter, params, shots_fired)
 	SEND_SIGNAL(src, COMSIG_GUN_AUTOFIRE, target, shooter)
 	var/obj/projectile/projectile_to_fire = load_into_chamber(shooter)
+	in_chamber = null //Projectiles live and die fast. It's better to null the reference early so the GC can handle it immediately.
 	if(!projectile_to_fire)
 		click_empty(shooter)
 		return NONE

--- a/code/game/objects/machinery/smartgun_mount.dm
+++ b/code/game/objects/machinery/smartgun_mount.dm
@@ -400,22 +400,24 @@
 		U = locate(U.x + rand(-1,1),U.y + rand(-1,1),U.z)
 
 
-	if(load_into_chamber() == 1)
-		if(istype(in_chamber,/obj/projectile))
-			in_chamber.original_target = target
-			in_chamber.setDir(dir)
-			in_chamber.def_zone = pick("chest","chest","chest","head")
-			playsound(src.loc, 'sound/weapons/guns/fire/hmg.ogg', 75, 1)
-			if(!QDELETED(target))
-				var/angle = round(Get_Angle(src,target))
-				muzzle_flash(angle)
-			in_chamber.fire_at(U, user, src, ammo.max_range, ammo.shell_speed)
-			in_chamber = null
-			rounds--
-			if(!rounds)
-				visible_message("<span class='notice'> [icon2html(src, viewers(src))] \The M56D beeps steadily and its ammo light blinks red.</span>")
-				playsound(src.loc, 'sound/weapons/guns/misc/smg_empty_alarm.ogg', 25, 1)
-				update_icon() //final safeguard.
+	if(!load_into_chamber())
+		return
+
+	var/obj/projectile/proj_to_fire = in_chamber
+	in_chamber = null //Projectiles live and die fast. It's better to null the reference early so the GC can handle it immediately.
+	proj_to_fire.original_target = target
+	proj_to_fire.setDir(dir)
+	proj_to_fire.def_zone = pick("chest","chest","chest","head")
+	playsound(loc, 'sound/weapons/guns/fire/hmg.ogg', 75, TRUE)
+	if(!QDELETED(target))
+		var/angle = round(Get_Angle(src,target))
+		muzzle_flash(angle)
+	proj_to_fire.fire_at(U, user, src, ammo.max_range, ammo.shell_speed)
+	rounds--
+	if(!rounds)
+		visible_message("<span class='notice'> [icon2html(src, viewers(src))] \The M56D beeps steadily and its ammo light blinks red.</span>")
+		playsound(loc, 'sound/weapons/guns/misc/smg_empty_alarm.ogg', 25, TRUE)
+		update_icon() //final safeguard.
 
 
 /obj/machinery/m56d_hmg/proc/muzzle_flash(angle) // Might as well keep this too.

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -44,8 +44,8 @@
 	Also where the gun will do final attachment calculations if the gun fired an attachment bullet.
 	This must return positive to continue burst firing or so that you don't hear *click*.
 
-	delete_bullet() //Important for point blanking and and jams, but can be called on for other reasons (that are
-	not currently used). If the gun makes a bullet but doesn't fire it, this will be called on through clear_jam().
+	delete_bullet() //Important for point blanking, but can be called on for other reasons (that are
+	not currently used).
 	This is also used to delete the bullet when you directly fire a bullet without going through the Fire() process,
 	like with the mentioned point blanking/suicide.
 

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -416,7 +416,7 @@ User can be passed as null, (a gun reloading itself for instance), so we need to
 			user.put_in_hands(H)
 
 		H.update_icon()
-		in_chamber = null
+		QDEL_NULL(in_chamber)
 	else
 		user.visible_message("<span class='notice'>[user] cocks [src].</span>",
 		"<span class='notice'>You cock [src].</span>", null, 4)
@@ -461,7 +461,7 @@ User can be passed as null, (a gun reloading itself for instance), so we need to
 		Fire(A, user, params) //Otherwise, fire normally.
 
 /*
-load_into_chamber(), reload_into_chamber(), and clear_jam() do all of the heavy lifting.
+load_into_chamber() and reload_into_chamber() do all of the heavy lifting.
 If you need to change up how a gun fires, just change these procs for that subtype
 and you're good to go.
 */
@@ -512,7 +512,8 @@ and you're good to go.
 		return in_chamber
 
 	make_casing(type_of_casings) // Drop a casing if needed.
-	in_chamber = null //If we didn't fire from attachable, let's set this so the next pass doesn't think it still exists.
+	if(in_chamber)
+		QDEL_NULL(in_chamber) //If we didn't fire from attachable, let's set this so the next pass doesn't think it still exists.
 
 	if(current_mag) //If there is no mag, we can't reload.
 		ready_in_chamber(user)
@@ -530,13 +531,6 @@ and you're good to go.
 			active_attachable.current_rounds += ammo_per_shot //Refund the bullet.
 		return TRUE
 
-
-/obj/item/weapon/gun/proc/clear_jam(obj/projectile/projectile_to_fire, mob/user) //Guns jamming, great.
-	flags_gun_features &= ~GUN_BURST_FIRING // Also want to turn off bursting, in case that was on. It probably was.
-	delete_bullet(projectile_to_fire, TRUE) //We're going to clear up anything inside if we need to.
-	//If it's a regular bullet, we're just going to keep it chambered.
-	extra_delay = 0.2 SECONDS + ((burst_delay + extra_delay) * 2) // Some extra delay before firing again.
-	to_chat(user, "<span class='warning'>[src] jammed! You'll need a second to get it fixed!</span>")
 
 //----------------------------------------------------------
 		//									   \\
@@ -581,6 +575,7 @@ and you're good to go.
 
 		//The gun should return the bullet that it already loaded from the end cycle of the last Fire().
 		var/obj/projectile/projectile_to_fire = load_into_chamber(user) //Load a bullet in or check for existing one.
+		in_chamber = null //Projectiles live and die fast. It's better to null the reference early so the GC can handle it immediately.
 		if(!projectile_to_fire) //If there is nothing to fire, click.
 			click_empty(user)
 			break
@@ -672,6 +667,7 @@ and you're good to go.
 		if(active_attachable && !CHECK_BITFIELD(active_attachable.flags_attach_features, ATTACH_PROJECTILE))
 			active_attachable.activate_attachment(null, TRUE)//No way.
 		var/obj/projectile/projectile_to_fire = load_into_chamber(user)
+		in_chamber = null //Projectiles live and die fast. It's better to null the reference early so the GC can handle it immediately.
 		if(!projectile_to_fire) //We actually have a projectile, let's move on. We're going to simulate the fire cycle.
 			return // no ..(), already invoked above
 
@@ -722,6 +718,7 @@ and you're good to go.
 	if(active_attachable && !CHECK_BITFIELD(active_attachable.flags_attach_features, ATTACH_PROJECTILE))
 		active_attachable.activate_attachment(null, TRUE)//We're not firing off a nade into our mouth.
 	var/obj/projectile/projectile_to_fire = load_into_chamber(user)
+	in_chamber = null //Projectiles live and die fast. It's better to null the reference early so the GC can handle it immediately.
 
 	if(!projectile_to_fire) //We actually have a projectile, let's move on.
 		click_empty(user)//If there's no projectile, we can't do much.

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -72,7 +72,7 @@ can cause issues with ammo types getting mixed up during the burst.
 	if(!in_chamber)
 		to_chat(user, "<span class='warning'>[src] is already empty.</span>")
 		return TRUE
-	in_chamber = null
+	QDEL_NULL(in_chamber)
 	var/obj/item/ammo_magazine/handful/new_handful = retrieve_shell(ammo.type)
 	playsound(user, reload_sound, 25, 1)
 	new_handful.forceMove(get_turf(src))
@@ -163,7 +163,8 @@ can cause issues with ammo types getting mixed up during the burst.
 		make_casing(active_attachable.type_of_casings)
 	else
 		make_casing(type_of_casings)
-		in_chamber = null
+		if(in_chamber)
+			QDEL_NULL(in_chamber)
 
 		//Time to move the tube position.
 		ready_in_chamber() //We're going to try and reload. If we don't get anything, icon change.
@@ -358,7 +359,8 @@ can cause issues with ammo types getting mixed up during the burst.
 	return TRUE
 
 /obj/item/weapon/gun/shotgun/double/reload_into_chamber(mob/user)
-	in_chamber = null
+	if(in_chamber)
+		QDEL_NULL(in_chamber)
 	current_mag.chamber_contents[current_mag.chamber_position] = "empty"
 	current_mag.chamber_position--
 	current_mag.used_casings++
@@ -459,7 +461,7 @@ can cause issues with ammo types getting mixed up during the burst.
 		return TRUE
 
 	if(in_chamber) //eject the chambered round
-		in_chamber = null
+		QDEL_NULL(in_chamber)
 		var/obj/item/ammo_magazine/handful/new_handful = retrieve_shell(ammo.type)
 		new_handful.forceMove(get_turf(src))
 
@@ -494,9 +496,10 @@ can cause issues with ammo types getting mixed up during the burst.
 	else
 		pump_lock = FALSE //fired successfully; unlock the pump
 		current_mag.used_casings++ //The shell was fired successfully. Add it to used.
-		in_chamber = null
+		if(in_chamber)
+			QDEL_NULL(in_chamber)
 		//Time to move the tube position.
-		if(!current_mag.current_rounds && !in_chamber)
+		if(!current_mag.current_rounds)
 			update_icon()//No rounds, nothing chambered.
 
 	return TRUE


### PR DESCRIPTION
Several projectiles were still referenced on `in_chamber` on deletion, causing a hard del.

Also removed the legacy `clear_jam` proc.