### PR TITLE
mob reference cleanup

### DIFF
--- a/code/controllers/subsystem/direction.dm
+++ b/code/controllers/subsystem/direction.dm
@@ -89,7 +89,7 @@ SUBSYSTEM_DEF(direction)
 	if(!mobs_in_processing[C])
 		return TRUE // already removed
 	var/tracking_id = mobs_in_processing[C]
-	mobs_in_processing[C] = FALSE
+	mobs_in_processing -= C
 
 	if(tracking_id != squad_id)
 		if(!force)

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -293,11 +293,13 @@ SUBSYSTEM_DEF(job)
 		JobDebug("Player already assigned a role :[player]")
 		unassigned -= player
 		player.ready = FALSE
+		GLOB.ready_players -= player
 		return
 	JobDebug("Player rejected :[player]")
 	to_chat(player, "<b>You have failed to qualify for any job you desired.</b>")
 	unassigned -= player
 	player.ready = FALSE
+	GLOB.ready_players -= player
 
 
 /datum/controller/subsystem/job/Recover()

--- a/code/datums/atom_hud.dm
+++ b/code/datums/atom_hud.dm
@@ -21,7 +21,7 @@ GLOBAL_LIST_INIT(huds, list(
 
 /datum/atom_hud
 	var/list/atom/hudatoms = list() //list of all atoms which display this hud
-	var/list/hudusers = list() //list with all mobs who can see the hud
+	var/list/mob/hudusers = list() //list with all mobs who can see the hud
 	var/list/hud_icons = list() //these will be the indexes for the atom's hud_list
 
 	var/list/next_time_allowed = list() //mobs associated with the next time this hud can be added to them
@@ -37,6 +37,7 @@ GLOBAL_LIST_INIT(huds, list(
 		remove_hud_from(v)
 	for(var/v in hudatoms)
 		remove_from_hud(v)
+	next_time_allowed.Cut()
 	GLOB.all_huds -= src
 	return ..()
 
@@ -44,19 +45,20 @@ GLOBAL_LIST_INIT(huds, list(
 /datum/atom_hud/proc/remove_hud_from(mob/M)
 	if(!M || !hudusers[M])
 		return
-	if(!--hudusers[M])
-		hudusers -= M
-		if(queued_to_see[M])
-			queued_to_see -= M
-		else
-			for(var/atom/A in hudatoms)
-				remove_from_single_hud(M, A)
+	hudusers -= M
+	if(queued_to_see[M])
+		queued_to_see -= M
+		return
+	for(var/h in hudatoms)
+		var/atom/A = h
+		remove_from_single_hud(M, A)
 
 
 /datum/atom_hud/proc/remove_from_hud(atom/A)
 	if(!A)
 		return FALSE
-	for(var/mob/M in hudusers)
+	for(var/u in hudusers)
+		var/mob/M = u
 		remove_from_single_hud(M, A)
 	hudatoms -= A
 	return TRUE
@@ -70,35 +72,36 @@ GLOBAL_LIST_INIT(huds, list(
 
 
 /datum/atom_hud/proc/add_hud_to(mob/M)
-	if(!M)
+	if(!M || hudusers[M])
 		return
-	if(!hudusers[M])
-		hudusers[M] = 1
-		if(next_time_allowed[M] > world.time)
-			if(!queued_to_see[M])
-				addtimer(CALLBACK(src, .proc/show_hud_images_after_cooldown, M), next_time_allowed[M] - world.time)
-				queued_to_see[M] = TRUE
-		else
-			next_time_allowed[M] = world.time + ADD_HUD_TO_COOLDOWN
-			for(var/atom/A in hudatoms)
-				add_to_single_hud(M, A)
+	hudusers[M] = TRUE
+	if(next_time_allowed[M] > world.time)
+		if(!queued_to_see[M])
+			addtimer(CALLBACK(src, .proc/show_hud_images_after_cooldown, M), next_time_allowed[M] - world.time)
+			queued_to_see[M] = TRUE
 	else
-		hudusers[M]++
+		if(!next_time_allowed[M])
+			RegisterSignal(M, COMSIG_PARENT_QDELETING, .proc/clean_mob_refs)
+		next_time_allowed[M] = world.time + ADD_HUD_TO_COOLDOWN
+		for(var/atom/A in hudatoms)
+			add_to_single_hud(M, A)
 
 
 /datum/atom_hud/proc/show_hud_images_after_cooldown(M)
 	if(queued_to_see[M])
 		queued_to_see -= M
 		next_time_allowed[M] = world.time + ADD_HUD_TO_COOLDOWN
-		for(var/atom/A in hudatoms)
-			add_to_single_hud(M, A)
+		for(var/h in hudatoms)
+			var/atom/hud_atom = h
+			add_to_single_hud(M, hud_atom)
 
 
 /datum/atom_hud/proc/add_to_hud(atom/A)
-	if(!A)
+	if(!A || (A in hudatoms))
 		return FALSE
 	hudatoms |= A
-	for(var/mob/M in hudusers)
+	for(var/u in hudusers)
+		var/mob/M = u
 		if(!queued_to_see[M])
 			add_to_single_hud(M, A)
 	return TRUE
@@ -111,6 +114,11 @@ GLOBAL_LIST_INIT(huds, list(
 		if(A.hud_list[i])
 			M.client.images |= A.hud_list[i]
 
+
+/datum/atom_hud/proc/clean_mob_refs(datum/source, force)
+	remove_hud_from(source)
+	remove_from_hud(source)
+	next_time_allowed -= source
 
 
 /mob/proc/reload_huds()

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -12,21 +12,24 @@
 
 
 /mob/living/carbon/human/add_to_all_mob_huds()
-	for(var/datum/atom_hud/hud in GLOB.huds)
-		if(istype(hud, /datum/atom_hud/xeno)) //this one is xeno only
+	for(var/h in GLOB.huds)
+		if(istype(h, /datum/atom_hud/xeno)) //this one is xeno only
 			continue
+		var/datum/atom_hud/hud = h
 		hud.add_to_hud(src)
 
 
 /mob/living/carbon/monkey/add_to_all_mob_huds()
-	for(var/datum/atom_hud/hud in GLOB.huds)
+	for(var/h in GLOB.huds)
+		var/datum/atom_hud/hud = h
 		hud.add_to_hud(src)
 
 
 /mob/living/carbon/xenomorph/add_to_all_mob_huds()
-	for(var/datum/atom_hud/hud in GLOB.huds)
-		if(!istype(hud, /datum/atom_hud/xeno))
+	for(var/h in GLOB.huds)
+		if(!istype(h, /datum/atom_hud/xeno))
 			continue
+		var/datum/atom_hud/hud = h
 		hud.add_to_hud(src)
 
 
@@ -35,21 +38,24 @@
 
 
 /mob/living/carbon/human/remove_from_all_mob_huds()
-	for(var/datum/atom_hud/hud in GLOB.huds)
-		if(istype(hud, /datum/atom_hud/xeno))
+	for(var/h in GLOB.huds)
+		if(istype(h, /datum/atom_hud/xeno))
 			continue
+		var/datum/atom_hud/hud = h
 		hud.remove_from_hud(src)
 
 
 /mob/living/carbon/monkey/remove_from_all_mob_huds()
-	for(var/datum/atom_hud/hud in GLOB.huds)
+	for(var/h in GLOB.huds)
+		var/datum/atom_hud/hud = h
 		hud.add_to_hud(src)
 
 
 /mob/living/carbon/xenomorph/remove_from_all_mob_huds()
-	for(var/datum/atom_hud/hud in GLOB.huds)
-		if(!istype(hud, /datum/atom_hud/xeno))
+	for(var/h in GLOB.huds)
+		if(!istype(h, /datum/atom_hud/xeno))
 			continue
+		var/datum/atom_hud/hud = h
 		hud.remove_from_hud(src)
 
 

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -258,6 +258,8 @@
 	if(queen_chosen_lead || (src in hive.xeno_leader_list))
 		hive.remove_leader(src)
 
+	SSdirection.stop_tracking(hive.hivenumber, src)
+
 	hive = null
 	hivenumber = XENO_HIVE_NONE // failsafe value
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -11,6 +11,14 @@
 			D.reset_perspective(null)
 	ghostize()
 	clear_fullscreens()
+	if(mind)
+		stack_trace("Found a reference to an undeleted mind in mob/Destroy()")
+		mind = null
+	if(hud_used)
+		QDEL_NULL(hud_used)
+	for(var/a in actions)
+		var/datum/action/action_to_remove = a
+		action_to_remove.remove_action(src)
 	return ..()
 
 /mob/Initialize()

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -463,8 +463,7 @@
 /mob/new_player/proc/transfer_character()
 	. = new_character
 	if(.)
-		new_character.key = key		//Manually transfer the key to log them in
-		new_character = null
+		mind.transfer_to(new_character, TRUE) //Manually transfer the key to log them in
 		qdel(src)
 
 


### PR DESCRIPTION
Clears up mob references from lists so that they may not require being hard-deleted.
Requires #3768 to compile correctly.