### PR TITLE
Fix ancient crest defense

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
@@ -150,5 +150,5 @@
 	armor = list("melee" = 37, "bullet" = 37, "laser" = 32, "energy" = 30, "bomb" = XENO_BOMB_RESIST_2, "bio" = 30, "rad" = 30, "fire" = 10, "acid" = 30)
 
 	// *** Defender Abilities *** //
-	crest_defense_armor = 25
-	fortify_armor = 50
+	crest_defense_armor = 40
+	fortify_armor = 70


### PR DESCRIPTION
## About The Pull Request

I don't know why this was so low until someone pointed it out, increased to be consistent with the values of the other evolutions.

## Why It's Good For The Game

Ancient defender no longer crippled.

## Changelog
:cl:
fix: Crest defense for ancient defenders no longer a downgrade
/:cl: