### PR TITLE
Topic filtering whitelist

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -368,3 +368,11 @@ The default value assumes youtube-dl is in your system PATH
 
 /datum/config_entry/string/default_view_square
 	config_entry_value = "15x15"
+
+/*
+ This maintains a list of ip addresses that are able to bypass topic filtering.
+*/
+/datum/config_entry/keyed_list/topic_filtering_whitelist
+	key_mode = KEY_MODE_TEXT
+	value_mode = VALUE_MODE_FLAG
+	protection = CONFIG_ENTRY_LOCKED

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -370,7 +370,7 @@ The default value assumes youtube-dl is in your system PATH
 	config_entry_value = "15x15"
 
 /*
- This maintains a list of ip addresses that are able to bypass topic filtering.
+This maintains a list of ip addresses that are able to bypass topic filtering.
 */
 /datum/config_entry/keyed_list/topic_filtering_whitelist
 	key_mode = KEY_MODE_TEXT

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -133,19 +133,22 @@ GLOBAL_VAR(restart_counter)
 	if (bannedsourceaddrs[addr])
 		return
 
-	if(length(T) >= MAX_TOPIC_LEN)
-		log_admin_private("[addr] banned from topic calls for a round for too long status message")
-		bannedsourceaddrs[addr] = TOPIC_BANNED
-		return
-
-	if(lasttimeaddr[addr])
-		var/lasttime = lasttimeaddr[addr]
-		if(world.time < (lasttime + 2 SECONDS))
-			log_admin_private("[addr] banned from topic calls for a round for too frequent messages")
+	var/list/filtering_whitelist = CONFIG_GET(keyed_list/topic_filtering_whitelist)
+	var/host = splittext_char(addr, ":")
+	if(!filtering_whitelist[host[1]]) // We only ever check the host, not the port (if provided)
+		if(length(T) >= MAX_TOPIC_LEN)
+			log_admin_private("[addr] banned from topic calls for a round for too long status message")
 			bannedsourceaddrs[addr] = TOPIC_BANNED
 			return
 
-	lasttimeaddr[addr] = world.time
+		if(lasttimeaddr[addr])
+			var/lasttime = lasttimeaddr[addr]
+			if(world.time < lasttime)
+				log_admin_private("[addr] banned from topic calls for a round for too frequent messages")
+				bannedsourceaddrs[addr] = TOPIC_BANNED
+				return
+
+		lasttimeaddr[addr] = world.time + 2 SECONDS
 
 
 	TGS_TOPIC	//redirect to server tools if necessary

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -134,7 +134,7 @@ GLOBAL_VAR(restart_counter)
 		return
 
 	var/list/filtering_whitelist = CONFIG_GET(keyed_list/topic_filtering_whitelist)
-	var/host = splittext_char(addr, ":")
+	var/host = splittext(addr, ":")
 	if(!filtering_whitelist[host[1]]) // We only ever check the host, not the port (if provided)
 		if(length(T) >= MAX_TOPIC_LEN)
 			log_admin_private("[addr] banned from topic calls for a round for too long status message")

--- a/config/config.txt
+++ b/config/config.txt
@@ -90,4 +90,4 @@ LIMBS_CAN_BREAK
 
 # Topic filtering whitelist
 # Addressed listed below are except from any incoming topic filering
-TOPIC_FILTERING_WHITELIST 127.0.0.1
+# TOPIC_FILTERING_WHITELIST 127.0.0.1

--- a/config/config.txt
+++ b/config/config.txt
@@ -86,3 +86,8 @@ LOOC_ENABLED
 
 BONES_CAN_BREAK
 LIMBS_CAN_BREAK
+
+
+# Topic filtering whitelist
+# Addressed listed below are except from any incoming topic filering
+TOPIC_FILTERING_WHITELIST 127.0.0.1


### PR DESCRIPTION
closes #3779 
This adds a whitelist controlled by config.txt
These are not banned when they go over length or request per second limits.