### PR TITLE
Fixes Pillar maint id access

### DIFF
--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -3561,7 +3561,7 @@
 /area/mainship/hallways/stern_hallway)
 "ku" = (
 /obj/machinery/door/airlock/mainship/maint{
-	req_access_txt = "19";
+	req_access_txt = "7";
 	req_one_access_txt = "0"
 	},
 /obj/structure/disposalpipe/segment{
@@ -3602,7 +3602,7 @@
 /area/mainship/living/port_garden)
 "kx" = (
 /obj/machinery/door/airlock/mainship/maint{
-	req_access_txt = "19";
+	req_access_txt = "7";
 	req_one_access_txt = "0"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -3654,8 +3654,9 @@
 /area/mainship/shipboard/port_missiles)
 "kD" = (
 /obj/machinery/door/airlock/mainship/maint{
-	req_access_txt = "19";
-	req_one_access_txt = "0"
+	req_access_txt = "200";
+	req_one_access = null;
+	req_one_access_txt = null
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
@@ -4221,7 +4222,7 @@
 /area/mainship/squads/general)
 "lZ" = (
 /obj/machinery/door/airlock/mainship/maint{
-	req_access_txt = "19";
+	req_access_txt = "7";
 	req_one_access_txt = "0"
 	},
 /obj/structure/cable/yellow{
@@ -6147,8 +6148,9 @@
 /area/mainship/living/cafeteria_starboard)
 "rj" = (
 /obj/machinery/door/airlock/mainship/maint{
-	req_access_txt = "19";
-	req_one_access_txt = "0"
+	req_access_txt = "1";
+	req_one_access = null;
+	req_one_access_txt = null
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
@@ -6912,7 +6914,7 @@
 /area/mainship/command/airoom)
 "tk" = (
 /obj/machinery/door/airlock/mainship/maint{
-	req_access_txt = "19";
+	req_access_txt = "7";
 	req_one_access_txt = "0"
 	},
 /turf/open/floor/plating,
@@ -10048,7 +10050,7 @@
 /area/mainship/hull/lower_hull)
 "AU" = (
 /obj/machinery/door/airlock/mainship/maint{
-	req_access_txt = "19";
+	req_access_txt = "7";
 	req_one_access_txt = "0"
 	},
 /turf/open/floor/plating/mainship,
@@ -10060,7 +10062,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/mainship/maint{
-	req_access_txt = "19";
+	req_access_txt = "7";
 	req_one_access_txt = "0"
 	},
 /turf/open/floor/plating/plating_catwalk,
@@ -10162,14 +10164,14 @@
 /area/mainship/hallways/port_hallway)
 "Bh" = (
 /obj/machinery/door/airlock/mainship/maint{
-	req_access_txt = "19";
+	req_access_txt = "7";
 	req_one_access_txt = "0"
 	},
 /turf/open/floor/plating/mainship,
 /area/mainship/medical/lower_medical)
 "Bi" = (
 /obj/machinery/door/airlock/mainship/maint{
-	req_access_txt = "19";
+	req_access_txt = "7";
 	req_one_access_txt = "0"
 	},
 /turf/open/floor/plating/mainship,
@@ -10892,7 +10894,7 @@
 /area/mainship/hull/lower_hull)
 "CN" = (
 /obj/machinery/door/airlock/mainship/maint{
-	req_access_txt = "19";
+	req_access_txt = "7";
 	req_one_access_txt = "0"
 	},
 /obj/structure/cable/yellow{
@@ -11000,7 +11002,7 @@
 /area/mainship/hull/lower_hull)
 "CX" = (
 /obj/machinery/door/airlock/mainship/maint{
-	req_access_txt = "19";
+	req_access_txt = "7";
 	req_one_access_txt = "0"
 	},
 /obj/structure/cable/yellow{
@@ -15498,7 +15500,7 @@
 /area/mainship/hull/lower_hull)
 "LC" = (
 /obj/machinery/door/airlock/mainship/maint{
-	req_access_txt = "19";
+	req_access_txt = "7";
 	req_one_access_txt = "0"
 	},
 /obj/structure/cable/yellow{
@@ -17615,7 +17617,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/mainship/maint{
-	req_access_txt = "19";
+	req_access_txt = "7";
 	req_one_access_txt = "0"
 	},
 /turf/open/floor/mainship/mono,
@@ -17668,8 +17670,9 @@
 /area/mainship/living/cafeteria_starboard)
 "Uk" = (
 /obj/machinery/door/airlock/mainship/maint{
-	req_access_txt = "19";
-	req_one_access_txt = "0"
+	req_access_txt = "1";
+	req_one_access = null;
+	req_one_access_txt = null
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Something I never noticed when I published the Pillar was that for some unknown reason (cough cough KWIN) most maintenance doors were set to only open with bridge access.
This PR changes the perms so that anyone with at least Ship Tech access can use the maintenance airlocks. Only exceptions are maintenance airlocks leading into private rooms i.e. FC, CO, and CL quarters.

## Why It's Good For The Game

Ship Techs can use maintenance tunnels.

## Changelog
:cl:
fix: Ship Techs should now be able to properly access most maintenance airlocks on the Pillar
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
