### PR TITLE
Increases bull charge steps, lowers damage

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -329,7 +329,7 @@
 	speed_per_step = 0.1
 	steps_for_charge = 5
 	max_steps_buildup = 10
-	crush_living_damage = 30 // This is multiplied by speed, which in this case will range from 0.1 to 1.
+	crush_living_damage = 30
 
 
 /datum/action/xeno_action/ready_charge/bull_charge/give_action(mob/living/L)

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -327,9 +327,9 @@
 /datum/action/xeno_action/ready_charge/bull_charge
 	charge_type = CHARGE_BULL
 	speed_per_step = 0.1
-	steps_for_charge = 3
+	steps_for_charge = 5
 	max_steps_buildup = 10
-	crush_living_damage = 40 // This is multiplied by speed, which in this case will range from 0.1 to 1.
+	crush_living_damage = 30 // This is multiplied by speed, which in this case will range from 0.1 to 1.
 
 
 /datum/action/xeno_action/ready_charge/bull_charge/give_action(mob/living/L)


### PR DESCRIPTION

## About The Pull Request

Increases bull steps_for_charge from 3 to 5, 1 less than crusher's. This means it'll take 5 steps for a bull to enter charging phase. Also, lowers their damage from 40 to 30.

## Why It's Good For The Game

Crushers were nerfed from their throne of one-hit-killing every single marine that was in their path, so, naturally, bulls took up that position. This should prevent them from critting marines five seconds into the round.

## Changelog
:cl:
balance: Increased bull charge steps, lowered bull charge damage.
/:cl: