### PR TITLE
Fixes the stunbaton

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -101,8 +101,9 @@
 		if(!bcell)
 			return
 
+		bcell.loc = get_turf(src)
 		bcell.update_icon()
-		bcell.forceMove(loc)
+		bcell = null
 		to_chat(user, "<span class='notice'>You remove the cell from the [src].</span>")
 		status = 0
 

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -101,7 +101,7 @@
 		if(!bcell)
 			return
 
-		bcell.loc = get_turf(src)
+		bcell.forceMove(get_turf(src))
 		bcell.update_icon()
 		bcell = null
 		to_chat(user, "<span class='notice'>You remove the cell from the [src].</span>")


### PR DESCRIPTION
Fixes #3780

## About The Pull Request

#3780 gets fixed by this

## Why It's Good For The Game

no more battery rail guns.

## Changelog
:cl: Hughgent
fix: The stunbaton no longer acts like a battery based magnet railgun
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
