### PR TITLE
Fix xenos being able to drag and drop humans into machines

### DIFF
--- a/code/game/objects/machinery/Sleeper.dm
+++ b/code/game/objects/machinery/Sleeper.dm
@@ -471,7 +471,7 @@
 
 /obj/machinery/sleeper/MouseDrop_T(mob/M, mob/user)
 	if(!isliving(M) || !ishuman(user))
-		return 
+		return
 	move_inside_wrapper(M, user)
 
 /obj/machinery/sleeper/verb/move_inside()

--- a/code/game/objects/machinery/Sleeper.dm
+++ b/code/game/objects/machinery/Sleeper.dm
@@ -470,8 +470,8 @@
 		qdel(O)
 
 /obj/machinery/sleeper/MouseDrop_T(mob/M, mob/user)
-	if(!isliving(M))
-		return
+	if(!isliving(M) || !ishuman(user))
+		return 
 	move_inside_wrapper(M, user)
 
 /obj/machinery/sleeper/verb/move_inside()

--- a/code/game/objects/machinery/adv_med.dm
+++ b/code/game/objects/machinery/adv_med.dm
@@ -46,7 +46,7 @@
 		qdel(O)
 
 /obj/machinery/bodyscanner/MouseDrop_T(mob/M, mob/user)
-	if(!isliving(M))
+	if(!isliving(M) || !ishuman(user))
 		return
 	move_inside_wrapper(M, user)
 

--- a/code/game/objects/machinery/autodoc.dm
+++ b/code/game/objects/machinery/autodoc.dm
@@ -756,7 +756,7 @@
 			qdel(O)
 
 /obj/machinery/autodoc/MouseDrop_T(mob/M, mob/user)
-	if(!isliving(M))
+	if(!isliving(M) || !ishuman(user))
 		return
 	move_inside_wrapper(M, user)
 

--- a/code/game/objects/machinery/cryopod.dm
+++ b/code/game/objects/machinery/cryopod.dm
@@ -389,7 +389,7 @@
 	climb_in(M, user)
 
 /obj/machinery/cryopod/MouseDrop_T(mob/M, mob/user)
-	if(!isliving(M))
+	if(!isliving(M) || !ishuman(user))
 		return
 	move_inside_wrapper(M, user)
 


### PR DESCRIPTION
fixes #3638
Drag and drop requires the user to be human and can only drag living
