### PR TITLE
Fixes typo in ancient boiler caste desc

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
@@ -136,7 +136,7 @@
 
 /datum/xeno_caste/boiler/ancient
 	upgrade_name = "Ancient"
-	caste_desc = "A devestating piece of alien artillery."
+	caste_desc = "A devastating piece of alien artillery."
 	upgrade = XENO_UPGRADE_THREE
 	ancient_message = "We are the master of ranged artillery. Let's bring death from above."
 


### PR DESCRIPTION

## About The Pull Request

Fixes a single letter in ancient boiler caste desc; from "devestating" to "devastating". Riveting, I know.

## Why It's Good For The Game

Muh grammur.

## Changelog
:cl:
spellcheck: Fixed ancient boiler caste description.
/:cl:
