### PR TITLE
stat change refactor

### DIFF
--- a/code/game/objects/items/defibrillator.dm
+++ b/code/game/objects/items/defibrillator.dm
@@ -209,7 +209,7 @@
 	user.visible_message("<span class='notice'>[icon2html(src, viewers(user))] \The [src] beeps: Defibrillation successful.</span>")
 	H.on_revive()
 	H.timeofdeath = 0
-	H.stat = UNCONSCIOUS
+	H.set_stat(UNCONSCIOUS)
 	H.emote("gasp")
 	H.regenerate_icons()
 	H.reload_fullscreens()

--- a/code/game/objects/items/storage/briefcase.dm
+++ b/code/game/objects/items/storage/briefcase.dm
@@ -4,34 +4,9 @@
 	icon_state = "briefcase"
 	item_state = "briefcase"
 	flags_atom = CONDUCT
-	force = 8.0
+	force = 8
 	throw_speed = 1
 	throw_range = 4
 	w_class = WEIGHT_CLASS_BULKY
 	max_w_class = 3
 	max_storage_space = 16
-
-/obj/item/storage/briefcase/attack(mob/living/M as mob, mob/living/user as mob)
-	//..()
-
-	log_combat(user, M, "attack", src)
-
-	if (M.stat < 2 && M.health < 50 && prob(90))
-		if(ishuman(M))
-			var/mob/living/carbon/human/H = M
-			var/obj/item/P = H.head
-			if(istype(P) && P.flags_inventory & BLOCKSHARPOBJ && prob(80))
-				to_chat(M, "<span class='warning'>The helmet protects you from being hit hard in the head!</span>")
-				return
-		var/time = rand(40, 80)
-		if (prob(75))
-			M.Unconscious(time)
-		else
-			M.Stun(time)
-		if(M.stat != 2)	M.stat = 1
-		visible_message("span class='danger'>[M] has been knocked unconscious!</span>", null, "<span class='warning'> You hear someone fall.</span>")
-	else
-		to_chat(M, text("<span class='warning'> [] tried to knock you unconcious!</span>",user))
-		M.adjust_blurriness(3)
-
-	return

--- a/code/game/objects/items/tools/kitchen_tools.dm
+++ b/code/game/objects/items/tools/kitchen_tools.dm
@@ -169,38 +169,13 @@
 	name = "rolling pin"
 	desc = "Used to knock out the Bartender."
 	icon_state = "rolling_pin"
-	force = 8.0
-	throwforce = 10.0
+	force = 8
+	throwforce = 10
 	throw_speed = 2
 	throw_range = 7
 	w_class = WEIGHT_CLASS_NORMAL
-	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "whacked") //I think the rollingpin attackby will end up ignoring this anyway.
+	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "whacked")
 
-/obj/item/tool/kitchen/rollingpin/attack(mob/living/M as mob, mob/living/user as mob)
-	log_combat(user, M, "attacked", src)
-
-	var/t = user:zone_selected
-	if (t == "head")
-		if(ishuman(M))
-			var/mob/living/carbon/human/H = M
-			var/obj/item/head_protection = H.head
-			if (H.stat < 2 && H.health < 50 && prob(90))
-				// ******* Check
-				if (istype(head_protection) && head_protection.flags_inventory & BLOCKSHARPOBJ  && prob(80))
-					to_chat(H, "<span class='warning'>The helmet protects you from being hit hard in the head!</span>")
-					return
-				var/time = rand(4 SECONDS, 12 SECONDS)
-				if (prob(75))
-					H.Unconscious(time)
-				else
-					H.Stun(time)
-				if(H.stat != 2)	H.stat = 1
-				user.visible_message("<span class='danger'>[H] has been knocked unconscious!</span>", "<span class='danger'>You knock [H] unconscious!</span>")
-				return
-			else
-				H.visible_message("<span class='warning'> [user] tried to knock [H] unconscious!</span>", "<span class='warning'> [user] tried to knock you unconscious!</span>")
-				H.blur_eyes(3)
-	return ..()
 
 /*
 * Trays - Agouri

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -58,7 +58,7 @@
 			go_out(TRUE)
 			return
 		occupant.bodytemperature = 100 //Temp fix for broken atmos
-		occupant.stat = 1
+		occupant.set_stat(UNCONSCIOUS)
 		if(occupant.bodytemperature < T0C)
 			occupant.Knockdown(20 SECONDS)
 			if(occupant.getOxyLoss())

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -45,7 +45,7 @@
 	if(!gibbed)
 		src.visible_message("<b>\The [src.name]</b> [deathmessage]")
 
-	stat = DEAD
+	set_stat(DEAD)
 
 	update_canmove()
 

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -32,7 +32,7 @@
 			O:brainmob = null
 			brainmob.loc = src
 			brainmob.container = src
-			brainmob.stat = 0
+			brainmob.set_stat(CONSCIOUS)
 			GLOB.dead_mob_list -= brainmob//Update dem lists
 			GLOB.alive_living_list += brainmob
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -481,3 +481,14 @@
 		to_chat(src, "<span class='notice'>The selected special ability will now be activated with shift clicking.</span>")
 	else
 		to_chat(src, "<span class='notice'>The selected special ability will now be activated with middle mouse clicking.</span>")
+
+/mob/living/carbon/set_stat(new_stat)
+	. = ..()
+	if(isnull(.))
+		return
+	if(stat == UNCONSCIOUS)
+		blind_eyes(1)
+		disabilities |= DEAF
+	else if(. == UNCONSCIOUS)
+		adjust_blindness(-1)
+		disabilities &= ~DEAF

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -51,3 +51,6 @@
 	// halucination vars
 	var/hal_screwyhud = SCREWYHUD_NONE
 	var/next_hallucination = 0
+
+	/// % Chance of exploding on death, incremented by total damage taken if not initially zero.
+	var/gib_chance = 0

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -3,7 +3,7 @@
 
 	if(status_flags & GODMODE)
 		health = species.total_health
-		stat = CONSCIOUS
+		set_stat(CONSCIOUS)
 		return
 	var/total_burn	= 0
 	var/total_brute	= 0

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -46,6 +46,9 @@
 
 /mob/living/carbon/update_stat()
 	. = ..()
+	if(.)
+		return
+
 	if(status_flags & GODMODE)
 		return
 
@@ -53,18 +56,18 @@
 		return
 
 	if(health <= get_death_threshold())
+		if(gib_chance && prob(gib_chance + 0.5 * (get_death_threshold() - health)))
+			gib()
+			return TRUE
 		death()
 		return
 
 	if(IsUnconscious() || IsSleeping() || IsAdminSleeping() || getOxyLoss() > CARBON_KO_OXYLOSS || health < get_crit_threshold())
-		if(stat != UNCONSCIOUS)
-			blind_eyes(1)
-			disabilities |= DEAF
-		stat = UNCONSCIOUS
+		if(stat == UNCONSCIOUS)
+			return
+		set_stat(UNCONSCIOUS)
 	else if(stat == UNCONSCIOUS)
-		stat = CONSCIOUS
-		adjust_blindness(-1)
-		disabilities &= ~DEAF
+		set_stat(CONSCIOUS)
 	update_canmove()
 
 /mob/living/carbon/handle_status_effects()

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/boiler.dm
@@ -27,18 +27,9 @@
 	. = ..()
 	set_light(BOILER_LUMINOSITY)
 	smoke = new /datum/effect_system/smoke_spread/xeno/acid(src)
-	see_in_dark = 20
 	ammo = GLOB.ammo_list[/datum/ammo/xeno/boiler_gas]
 	RegisterSignal(src, COMSIG_XENOMORPH_GIBBING, .proc/gib_explode)
 
-
-// ***************************************
-// *********** Life overrides
-// ***************************************
-/mob/living/carbon/xenomorph/boiler/update_stat()
-	. = ..()
-	if(stat == CONSCIOUS)
-		see_in_dark = 20
 
 // ***************************************
 // *********** Gibbing behaviour

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
@@ -31,6 +31,9 @@
 
 	deevolves_to = /mob/living/carbon/xenomorph/spitter
 
+	// *** Darksight *** ///
+	conscious_see_in_dark = 20
+
 	// *** Flags *** //
 	caste_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER|CASTE_ACID_BLOOD
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/defender.dm
@@ -36,9 +36,11 @@
 // ***************************************
 // *********** Life overrides
 // ***************************************
-/mob/living/carbon/xenomorph/defender/update_stat()
+/mob/living/carbon/xenomorph/defender/set_stat()
 	. = ..()
-	if(stat && fortify)
+	if(isnull(.))
+		return
+	if(. == CONSCIOUS && fortify) //No longer conscious.
 		set_fortify(FALSE) //Fortify prevents dragging due to the anchor component.
 
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/runner.dm
@@ -16,7 +16,9 @@
 		/mob/living/carbon/xenomorph/proc/vent_crawl,
 		)
 
-/mob/living/carbon/xenomorph/runner/update_stat()
+/mob/living/carbon/xenomorph/runner/set_stat()
 	. = ..()
-	if(stat != CONSCIOUS && layer != initial(layer))
+	if(isnull(.))
+		return
+	if(. == CONSCIOUS && layer != initial(layer))
 		layer = MOB_LAYER

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -38,39 +38,12 @@
 
 
 /mob/living/carbon/xenomorph/update_stat()
-
-	update_cloak()
-
-	if(status_flags & GODMODE)
+	. = ..()
+	if(.)
 		return
-
-	if(stat == DEAD)
-		return
-
-	if(health <= xeno_caste.crit_health)
-		if(prob(gib_chance + 0.5*(xeno_caste.crit_health - health)))
-			gib()
-		else
-			death()
-		return
-
-	if(IsUnconscious() || IsSleeping() || IsAdminSleeping() || health < get_crit_threshold())
-		if(stat != UNCONSCIOUS)
-			blind_eyes(1)
-		stat = UNCONSCIOUS
-		see_in_dark = 5
-	else if(stat == UNCONSCIOUS)
-		stat = CONSCIOUS
-		adjust_blindness(-1)
-		see_in_dark = 8
-	update_canmove()
-
 	//Deal with devoured things and people
 	if(LAZYLEN(stomach_contents) && world.time > devour_timer && !is_ventcrawling)
 		empty_gut()
-
-	return TRUE
-
 
 
 /mob/living/carbon/xenomorph/handle_status_effects()

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -49,6 +49,11 @@
 	var/list/evolves_to = list() //type paths to the castes that can be evolved to
 	var/deevolves_to // type path to the caste to deevolve to
 
+	///see_in_dark value while consicious
+	var/conscious_see_in_dark = 8
+	///see_in_dark value while unconscious
+	var/unconscious_see_in_dark = 5
+
 	// *** Flags *** //
 	var/caste_flags = CASTE_EVOLUTION_ALLOWED|CASTE_CAN_VENT_CRAWL|CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_LEADER
 
@@ -123,6 +128,9 @@
 	hud_possible = list(HEALTH_HUD_XENO, PLASMA_HUD, PHEROMONE_HUD, QUEEN_OVERWATCH_HUD, ARMOR_SUNDER_HUD)
 	buckle_flags = NONE
 	faction = "Xeno"
+	initial_language_holder = /datum/language_holder/xeno
+	gib_chance = 5
+
 	var/hivenumber = XENO_HIVE_NORMAL
 
 	var/datum/hive_status/hive
@@ -147,7 +155,6 @@
 
 	var/upgrade_stored = 0 //How much upgrade points they have stored.
 	var/upgrade = XENO_UPGRADE_INVALID  //This will track their upgrade level.
-	var/gib_chance = 5 // % chance of them exploding when taking damage. Goes up with damage inflicted.
 
 	var/datum/armor/armor
 	var/armor_bonus = 0
@@ -186,8 +193,6 @@
 	//If they're not a xeno subtype it might crash or do weird things, like using human verb procs
 	//It should add them properly on New() and should reset/readd them on evolves
 	var/list/inherent_verbs = list()
-
-	initial_language_holder = /datum/language_holder/xeno
 
 	//Lord forgive me for this horror, but Life code is awful
 	//These are tally vars, yep. Because resetting the aura value directly leads to fuckups

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -16,7 +16,16 @@
 	create_reagents(1000)
 	gender = NEUTER
 
-	GLOB.alive_xeno_list += src
+	switch(stat)
+		if(CONSCIOUS)
+			GLOB.alive_xeno_list += src
+			see_in_dark = xeno_caste.conscious_see_in_dark
+		if(UNCONSCIOUS)
+			GLOB.alive_xeno_list += src
+			see_in_dark = xeno_caste.unconscious_see_in_dark
+		if(DEAD)
+			see_in_dark = xeno_caste.unconscious_see_in_dark
+
 	GLOB.xeno_mob_list += src
 	GLOB.round_statistics.total_xenos_created++
 	SSblackbox.record_feedback("tally", "round_statistics", 1, "total_xenos_created")
@@ -309,3 +318,14 @@
 	if(!. || can_reenter_corpse)
 		return
 	set_afk_status(MOB_RECENTLY_DISCONNECTED, 5 SECONDS)
+
+/mob/living/carbon/xenomorph/set_stat(new_stat)
+	. = ..()
+	if(isnull(.))
+		return
+	switch(stat)
+		if(UNCONSCIOUS)
+			see_in_dark = xeno_caste.unconscious_see_in_dark
+		if(DEAD, CONSCIOUS)
+			if(. == UNCONSCIOUS)
+				see_in_dark = xeno_caste.conscious_see_in_dark

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -66,6 +66,7 @@
 	update_stat()
 
 /mob/living/update_stat()
+	. = ..()
 	update_cloak()
 
 /mob/living/Initialize()

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -276,7 +276,7 @@ mob/living/proc/adjustHalLoss(amount) //This only makes sense for carbon.
 		timeofdeath = 0
 
 	// restore us to conciousness
-	stat = CONSCIOUS
+	set_stat(CONSCIOUS)
 	updatehealth()
 
 	// make the icons look correct

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -18,7 +18,7 @@
 		if(health <= get_death_threshold())
 			death()
 		else if(stat == UNCONSCIOUS)
-			stat = CONSCIOUS
+			set_stat(CONSCIOUS)
 
 
 /mob/living/silicon/ai/updatehealth()

--- a/code/modules/mob/living/silicon/decoy/decoy.dm
+++ b/code/modules/mob/living/silicon/decoy/decoy.dm
@@ -30,7 +30,7 @@
 /mob/living/silicon/decoy/updatehealth()
 	if(status_flags & GODMODE)
 		health = 100
-		stat = CONSCIOUS
+		set_stat(CONSCIOUS)
 	else
 		health = 100 - getOxyLoss() - getToxLoss() - getFireLoss() - getBruteLoss()
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -94,7 +94,7 @@
 		if(health <= 0)
 			death()
 		else
-			stat = CONSCIOUS
+			set_stat(CONSCIOUS)
 	med_hud_set_status()
 
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -581,7 +581,7 @@
 	overlay_fullscreen("pain", /obj/screen/fullscreen/pain, 1)
 	clear_fullscreen("pain")
 
-///Called to update the stat var, returns a boolean to indicate if it needs further handling.
+///Called to update the stat var, returns a boolean to indicate if it has been handled.
 /mob/proc/update_stat()
 	return FALSE
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -581,9 +581,9 @@
 	overlay_fullscreen("pain", /obj/screen/fullscreen/pain, 1)
 	clear_fullscreen("pain")
 
-
+///Called to update the stat var, returns a boolean to indicate if it needs further handling.
 /mob/proc/update_stat()
-	return
+	return FALSE
 
 /mob/proc/can_inject()
 	return reagents
@@ -848,3 +848,9 @@
 		remove_movespeed_modifier(MOVESPEED_ID_MOB_GRAB_STATE)
 		return
 	add_movespeed_modifier(MOVESPEED_ID_MOB_GRAB_STATE, TRUE, 100, NONE, TRUE, grab_state * 3)
+
+/mob/proc/set_stat(new_stat)
+	if(new_stat == stat)
+		return
+	. = stat //old stat
+	stat = new_stat

--- a/code/modules/organs/limb_objects.dm
+++ b/code/modules/organs/limb_objects.dm
@@ -107,7 +107,6 @@ obj/item/limb/New(loc, mob/living/carbon/human/H)
 	H.regenerate_icons()
 
 	if(braindeath_on_decap)
-		brainmob.stat = DEAD
 		brainmob.death()
 
 	GLOB.head_list += src


### PR DESCRIPTION
* `stat` is set through a proc so we can react to changes
* Removed legacy balance-concerning object interactions that would knock people unconscious.
* Moved `gib_chance` from xeno to carbon and reduced repeated code.
* Moved code away from `life()` and into the stat change procs.
* Added xeno caste vars to determine `see_in_dark` range values.