### PR TITLE
Knockedout trait and init signals

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -82,6 +82,7 @@
 #define TRAIT_XENO "xeno"
 
 //mob traits
+#define TRAIT_KNOCKEDOUT		"knockedout" //Forces the user to stay unconscious.
 #define TRAIT_INCAPACITATED		"incapacitated"
 #define TRAIT_STUNIMMUNE		"stun_immunity"
 #define TRAIT_BATONIMMUNE		"baton_immunity"

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -70,10 +70,10 @@
 	. = ..()
 	if(!.)
 		return
-	ADD_TRAIT(owner, TRAIT_INCAPACITATED, TRAIT_STATUS_EFFECT(id))
+	ADD_TRAIT(owner, TRAIT_KNOCKEDOUT, TRAIT_STATUS_EFFECT(id))
 
 /datum/status_effect/incapacitating/unconscious/on_remove()
-	REMOVE_TRAIT(owner, TRAIT_INCAPACITATED, TRAIT_STATUS_EFFECT(id))
+	REMOVE_TRAIT(owner, TRAIT_KNOCKEDOUT, TRAIT_STATUS_EFFECT(id))
 	return ..()
 
 /datum/status_effect/incapacitating/unconscious/tick()
@@ -99,6 +99,16 @@
 /datum/status_effect/incapacitating/sleeping/Destroy()
 	carbon_owner = null
 	human_owner = null
+	return ..()
+
+/datum/status_effect/incapacitating/sleeping/on_apply()
+	. = ..()
+	if(!.)
+		return
+	ADD_TRAIT(owner, TRAIT_KNOCKEDOUT, TRAIT_STATUS_EFFECT(id))
+
+/datum/status_effect/incapacitating/sleeping/on_remove()
+	REMOVE_TRAIT(owner, TRAIT_KNOCKEDOUT, TRAIT_STATUS_EFFECT(id))
 	return ..()
 
 /datum/status_effect/incapacitating/sleeping/tick()
@@ -138,6 +148,16 @@
 	alert_type = /obj/screen/alert/status_effect/adminsleep
 	needs_update_stat = TRUE
 	duration = -1
+
+/datum/status_effect/incapacitating/adminsleep/on_apply()
+	. = ..()
+	if(!.)
+		return
+	ADD_TRAIT(owner, TRAIT_KNOCKEDOUT, TRAIT_STATUS_EFFECT(id))
+
+/datum/status_effect/incapacitating/adminsleep/on_remove()
+	REMOVE_TRAIT(owner, TRAIT_KNOCKEDOUT, TRAIT_STATUS_EFFECT(id))
+	return ..()
 
 /obj/screen/alert/status_effect/adminsleep
 	name = "Admin Slept"

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -62,13 +62,13 @@
 		death()
 		return
 
-	if(IsUnconscious() || IsSleeping() || IsAdminSleeping() || getOxyLoss() > CARBON_KO_OXYLOSS || health < get_crit_threshold())
+	if(HAS_TRAIT(src, TRAIT_KNOCKEDOUT) || getOxyLoss() > CARBON_KO_OXYLOSS || health < get_crit_threshold())
 		if(stat == UNCONSCIOUS)
 			return
 		set_stat(UNCONSCIOUS)
 	else if(stat == UNCONSCIOUS)
 		set_stat(CONSCIOUS)
-	update_canmove()
+
 
 /mob/living/carbon/handle_status_effects()
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -41,6 +41,18 @@
 	. = ..()
 	if(.)
 		return
+
+	if(HAS_TRAIT(src, TRAIT_KNOCKEDOUT) || health < get_crit_threshold())
+		if(stat != UNCONSCIOUS)
+			blind_eyes(1)
+		stat = UNCONSCIOUS
+		see_in_dark = 5
+	else if(stat == UNCONSCIOUS)
+		stat = CONSCIOUS
+		adjust_blindness(-1)
+		see_in_dark = 8
+	update_canmove()
+
 	//Deal with devoured things and people
 	if(LAZYLEN(stomach_contents) && world.time > devour_timer && !is_ventcrawling)
 		empty_gut()

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -42,17 +42,6 @@
 	if(.)
 		return
 
-	if(HAS_TRAIT(src, TRAIT_KNOCKEDOUT) || health < get_crit_threshold())
-		if(stat != UNCONSCIOUS)
-			blind_eyes(1)
-		stat = UNCONSCIOUS
-		see_in_dark = 5
-	else if(stat == UNCONSCIOUS)
-		stat = CONSCIOUS
-		adjust_blindness(-1)
-		see_in_dark = 8
-	update_canmove()
-
 	//Deal with devoured things and people
 	if(LAZYLEN(stomach_contents) && world.time > devour_timer && !is_ventcrawling)
 		empty_gut()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -71,6 +71,7 @@
 
 /mob/living/Initialize()
 	. = ..()
+	register_init_signals()
 	update_move_intent_effects()
 	GLOB.mob_living_list += src
 	if(stat != DEAD)
@@ -94,6 +95,21 @@
 	return ..()
 
 
+///Called on /mob/living/Initialize(), for the mob to register to relevant signals.
+/mob/living/proc/register_init_signals()
+	RegisterSignal(src, SIGNAL_ADDTRAIT(TRAIT_KNOCKEDOUT), .proc/on_knockedout_trait_gain)
+	RegisterSignal(src, SIGNAL_REMOVETRAIT(TRAIT_KNOCKEDOUT), .proc/on_knockedout_trait_loss)
+
+
+///Called when TRAIT_KNOCKEDOUT is added to the mob.
+/mob/living/proc/on_knockedout_trait_gain(datum/source)
+	if(stat < UNCONSCIOUS)
+		set_stat(UNCONSCIOUS)
+
+///Called when TRAIT_KNOCKEDOUT is removed from the mob.
+/mob/living/proc/on_knockedout_trait_loss(datum/source)
+	if(stat < DEAD)
+		update_stat()
 
 
 //This proc is used for mobs which are affected by pressure to calculate the amount of pressure that actually
@@ -571,7 +587,7 @@ below 100 is not dizzy
 
 /mob/living/update_canmove()
 
-	var/laid_down = (stat || IsParalyzed() || IsUnconscious() || !has_legs() || resting || (status_flags & FAKEDEATH) || (pulledby && pulledby.grab_state >= GRAB_NECK) || (buckled && buckled.buckle_lying != -1))
+	var/laid_down = (stat != CONSCIOUS || IsParalyzed() || !has_legs() || resting || (status_flags & FAKEDEATH) || (pulledby && pulledby.grab_state >= GRAB_NECK) || (buckled && buckled.buckle_lying != -1))
 
 	if(laid_down)
 		if(buckled && buckled.buckle_lying != -1)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -854,3 +854,4 @@
 		return
 	. = stat //old stat
 	stat = new_stat
+	update_canmove()


### PR DESCRIPTION
Turns the knockedout property into a trait so we can react to it, and it applies immediately.
Requires #3821 to compile properly and it will have conflicts with it that I'll fix once the other one is merged.
This is a purely backend refactor and shouldn't affect gameplay.