### PR TITLE
lying_angle mass-rename and set_lying_angle proc

### DIFF
--- a/code/_onclick/human.dm
+++ b/code/_onclick/human.dm
@@ -40,7 +40,7 @@
 
 
 /mob/living/carbon/human/UnarmedAttack(atom/A, proximity)
-	if(lying) //No attacks while laying down
+	if(lying_angle) //No attacks while laying down
 		return FALSE
 
 	var/obj/item/clothing/gloves/G = gloves // not typecast specifically enough in defines

--- a/code/_onclick/xeno.dm
+++ b/code/_onclick/xeno.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/xenomorph/UnarmedAttack(atom/A, proximity_flag)
-	if(lying)
+	if(lying_angle)
 		return FALSE
 
 	if(xeno_caste)
@@ -16,7 +16,7 @@
 
 
 /mob/living/carbon/xenomorph/larva/UnarmedAttack(atom/A, proximity_flag)
-	if(lying)
+	if(lying_angle)
 		return FALSE
 
 	A.attack_larva(src)
@@ -27,7 +27,7 @@
 
 
 /mob/living/carbon/xenomorph/hivemind/UnarmedAttack(atom/A, proximity_flag)
-	if(lying)
+	if(lying_angle)
 		return FALSE
 
 	A.attack_hivemind(src)

--- a/code/datums/actions/item_action.dm
+++ b/code/datums/actions/item_action.dm
@@ -24,7 +24,7 @@
 		I.ui_action_click(owner, src, holder_item)
 
 /datum/action/item_action/can_use_action()
-	if(QDELETED(owner) || owner.incapacitated() || owner.lying)
+	if(QDELETED(owner) || owner.incapacitated() || owner.lying_angle)
 		return FALSE
 	return TRUE
 

--- a/code/datums/actions/xeno_action.dm
+++ b/code/datums/actions/xeno_action.dm
@@ -58,7 +58,7 @@
 			to_chat(owner, "<span class='warning'>We can't do this while incapacitated!</span>")
 		return FALSE
 
-	if(!CHECK_BITFIELD(flags_to_check, XACT_USE_LYING) && X.lying)
+	if(!CHECK_BITFIELD(flags_to_check, XACT_USE_LYING) && X.lying_angle)
 		if(!silent)
 			to_chat(owner, "<span class='warning'>We can't do this while lying down!</span>")
 		return FALSE

--- a/code/datums/components/footstep.dm
+++ b/code/datums/components/footstep.dm
@@ -40,7 +40,7 @@
 		return
 
 	var/mob/living/LM = parent
-	if(LM.buckled || LM.lying || LM.throwing || LM.is_ventcrawling)
+	if(LM.buckled || LM.lying_angle || LM.throwing || LM.is_ventcrawling)
 		return
 
 	steps++

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -32,7 +32,7 @@
 	var/list/mob/living/buckled_mobs // mobs buckled to this mob
 	var/buckle_flags = NONE
 	var/max_buckled_mobs = 1
-	var/buckle_lying = -1 //bed-like behaviour, forces mob.lying = buckle_lying if != -1
+	var/buckle_lying = -1 //bed-like behaviour, forces mob.lying_angle = buckle_lying if != -1
 
 	var/datum/component/orbiter/orbiting
 
@@ -355,7 +355,7 @@
 			continue
 		if(isliving(A))
 			var/mob/living/L = A
-			if(L.lying)
+			if(L.lying_angle)
 				continue
 			throw_impact(A, speed)
 		if(isobj(A) && A.density && !(A.flags_atom & ON_BORDER) && (!A.throwpass || iscarbon(src)))

--- a/code/game/objects/effects/acid_hole.dm
+++ b/code/game/objects/effects/acid_hole.dm
@@ -51,17 +51,17 @@
 		use_wall_hole(user)
 
 /obj/effect/acid_hole/proc/expand_hole(mob/living/carbon/xenomorph/user)
-	if(user.action_busy || user.lying)
+	if(user.action_busy || user.lying_angle)
 		return
 
 	playsound(src, 'sound/effects/metal_creaking.ogg', 25, 1)
-	if(do_after(user,60, FALSE, holed_wall, BUSY_ICON_HOSTILE) && !QDELETED(src) && !user.lying)
+	if(do_after(user,60, FALSE, holed_wall, BUSY_ICON_HOSTILE) && !QDELETED(src) && !user.lying_angle)
 		holed_wall.take_damage(rand(2000,3500))
 		user.emote("roar")
 
 /obj/effect/acid_hole/proc/use_wall_hole(mob/user)
 
-	if(user.mob_size == MOB_SIZE_BIG || user.incapacitated() || user.lying || user.buckled || user.anchored)
+	if(user.mob_size == MOB_SIZE_BIG || user.incapacitated() || user.lying_angle || user.buckled || user.anchored)
 		return
 
 	var/mob_dir = get_dir(user, src)
@@ -94,7 +94,7 @@
 
 	to_chat(user, "<span class='notice'>You start crawling through the hole.</span>")
 
-	if(do_after(user, 15, FALSE, src, BUSY_ICON_HOSTILE) && !T.density && !user.lying && !user.buckled)
+	if(do_after(user, 15, FALSE, src, BUSY_ICON_HOSTILE) && !T.density && !user.lying_angle && !user.buckled)
 		for(var/obj/O in T)
 			if(!O.CanPass(user, user.loc))
 				return

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -63,7 +63,7 @@
 		if(H.cooldowns[COOLDOWN_ACID])
 			return
 		H.cooldowns[COOLDOWN_ACID] = addtimer(VARSET_LIST_CALLBACK(H.cooldowns, COOLDOWN_ACID, null), 1 SECONDS)
-		if(!H.lying)
+		if(!H.lying_angle)
 			to_chat(H, "<span class='danger'>Your feet scald and burn! Argh!</span>")
 			if(!(H.species.species_flags & NO_PAIN))
 				H.emote("pain")

--- a/code/game/objects/items/explosives/mine.dm
+++ b/code/game/objects/items/explosives/mine.dm
@@ -100,7 +100,7 @@
 	. = ..()
 	if(isliving(A))
 		var/mob/living/L = A
-		if(!L.lying)//so dragged corpses don't trigger mines.
+		if(!L.lying_angle)//so dragged corpses don't trigger mines.
 			Bumped(A)
 
 /obj/item/explosive/mine/Bumped(mob/living/L)

--- a/code/game/objects/items/storage/internal.dm
+++ b/code/game/objects/items/storage/internal.dm
@@ -35,7 +35,7 @@
 /obj/item/storage/internal/proc/handle_mousedrop(mob/user as mob, obj/over_object as obj)
 	if(ishuman(user) || ismonkey(user)) //so monkeys can take off their backpacks -- Urist
 
-		if(user.lying) //Can't use your inventory when lying
+		if(user.lying_angle) //Can't use your inventory when lying
 			return
 
 		if(istype(user.loc, /obj/vehicle/multitile/root/cm_armored)) //Stops inventory actions in a mech/tank
@@ -89,7 +89,7 @@
 //It's strange, but no other way of doing it without the ability to call another proc's parent, really.
 /obj/item/storage/internal/proc/handle_attack_hand(mob/user as mob)
 
-	if(user.lying)
+	if(user.lying_angle)
 		return 0
 
 	if(ishuman(user))

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -41,7 +41,7 @@
 /obj/item/storage/MouseDrop(obj/over_object as obj)
 	if(ishuman(usr) || ismonkey(usr)) //so monkeys can take off their backpacks -- Urist
 
-		if(usr.lying)
+		if(usr.lying_angle)
 			return
 
 		if(istype(usr.loc, /obj/vehicle/multitile/root/cm_armored)) // stops inventory actions in a mech/tank

--- a/code/game/objects/items/toys/toy_weapons.dm
+++ b/code/game/objects/items/toys/toy_weapons.dm
@@ -152,14 +152,14 @@
 
 // ******* Check
 
-		if (src.bullets > 0 && M.lying)
+		if (bullets > 0 && M.lying_angle)
 			visible_message("<span class='danger'>[user] casually lines up a shot with [M]'s head and pulls the trigger!</span>", null, "<span class='warning'>You hear the sound of foam against skull</span>")
 			visible_message("<span class='warning'>[M] was hit in the head by the foam dart!</span>")
 
 			playsound(user.loc, 'sound/items/syringeproj.ogg', 15, 1)
 			new /obj/item/toy/crossbow_ammo(M.loc)
 			src.bullets--
-		else if(M.lying && !bullets && isliving(M))
+		else if(M.lying_angle && !bullets && isliving(M))
 			var/mob/living/L = M
 			L.visible_message("<span class='danger'>[user] casually lines up a shot with [L]'s head, pulls the trigger, then realizes they are out of ammo and drops to the floor in search of some!</span>")
 			L.Paralyze(10 SECONDS)

--- a/code/game/objects/machinery/OpTable.dm
+++ b/code/game/objects/machinery/OpTable.dm
@@ -151,7 +151,7 @@
 /obj/machinery/optable/proc/check_victim()
 	if(locate(/mob/living/carbon/human, loc))
 		var/mob/living/carbon/human/M = locate(/mob/living/carbon/human, loc)
-		if(M.lying)
+		if(M.lying_angle)
 			victim = M
 			icon_state = M.handle_pulse() ? "table2-active" : "table2-idle"
 			return 1

--- a/code/game/objects/machinery/bots/mulebot.dm
+++ b/code/game/objects/machinery/bots/mulebot.dm
@@ -639,9 +639,7 @@
 	var/mob/living/L = A
 	visible_message("<span class='warning'>[src] knocks over [L]!</span>")
 	L.stop_pulling()
-	L.Stun(16 SECONDS)
 	L.Paralyze(10 SECONDS)
-	L.lying = TRUE
 
 
 // called from mob/living/carbon/human/Crossed()

--- a/code/game/objects/machinery/computer/card.dm
+++ b/code/game/objects/machinery/computer/card.dm
@@ -31,7 +31,8 @@
 	set name = "Eject ID Card"
 	set src in oview(1)
 
-	if(!usr || usr.stat || usr.lying)	return
+	if(!usr || usr.stat || usr.lying_angle)
+		return
 
 	if(scan)
 		to_chat(usr, "You remove \the [scan] from \the [src].")

--- a/code/game/objects/machinery/computer/medical.dm
+++ b/code/game/objects/machinery/computer/medical.dm
@@ -19,7 +19,8 @@
 	set name = "Eject ID Card"
 	set src in oview(1)
 
-	if(!usr || usr.stat || usr.lying)	return
+	if(!usr || usr.stat || usr.lying_angle)
+		return
 
 	if(scan)
 		to_chat(usr, "You remove \the [scan] from \the [src].")

--- a/code/game/objects/machinery/computer/security.dm
+++ b/code/game/objects/machinery/computer/security.dm
@@ -25,7 +25,8 @@
 	set name = "Eject ID Card"
 	set src in oview(1)
 
-	if(!usr || usr.stat || usr.lying)	return
+	if(!usr || usr.stat || usr.lying_angle)
+		return
 
 	if(scan)
 		to_chat(usr, "You remove \the [scan] from \the [src].")

--- a/code/game/objects/machinery/doors/airlock.dm
+++ b/code/game/objects/machinery/doors/airlock.dm
@@ -225,7 +225,7 @@
 	M.visible_message("<span class='warning'>\The [M] digs into \the [src] and begins to pry it open.</span>", \
 	"<span class='warning'>We dig into \the [src] and begin to pry it open.</span>", null, 5)
 
-	if(do_after(M, 40, FALSE, src, BUSY_ICON_HOSTILE) && !M.lying)
+	if(do_after(M, 40, FALSE, src, BUSY_ICON_HOSTILE) && !M.lying_angle)
 		if(locked)
 			to_chat(M, "<span class='warning'>\The [src] is bolted down tight.</span>")
 			return FALSE

--- a/code/game/objects/machinery/iv_drip.dm
+++ b/code/game/objects/machinery/iv_drip.dm
@@ -40,7 +40,7 @@
 
 	if(ishuman(usr))
 		var/mob/living/carbon/human/H = usr
-		if(H.stat || get_dist(H, src) > 1 || is_blind(H) || H.lying)
+		if(H.stat || get_dist(H, src) > 1 || is_blind(H) || H.lying_angle)
 			return
 
 		if(attached)
@@ -154,7 +154,7 @@
 	if(!isliving(usr))
 		return
 
-	if(usr.stat || usr.lying)
+	if(usr.stat || usr.lying_angle)
 		return
 
 	mode = !mode

--- a/code/game/objects/machinery/sentries.dm
+++ b/code/game/objects/machinery/sentries.dm
@@ -514,7 +514,7 @@
 		DISABLE_BITFIELD(turret_flags, TURRET_MANUAL)
 
 /obj/machinery/marine_turret/check_eye(mob/user)
-	if(user.incapacitated() || get_dist(user, src) > 1 || is_blind(user) || user.lying || !user.client)
+	if(user.incapacitated() || get_dist(user, src) > 1 || is_blind(user) || user.lying_angle || !user.client)
 		user.unset_interaction()
 
 /obj/machinery/marine_turret/attackby(obj/item/I, mob/user, params)

--- a/code/game/objects/machinery/smartgun_mount.dm
+++ b/code/game/objects/machinery/smartgun_mount.dm
@@ -509,7 +509,7 @@
 /obj/machinery/m56d_hmg/InterceptClickOn(mob/user, params, atom/object)
 	if(is_bursting)
 		return TRUE
-	if(user.lying || !Adjacent(user) || user.incapacitated())
+	if(user.lying_angle || !Adjacent(user) || user.incapacitated())
 		user.unset_interaction()
 		return FALSE
 	if(user.get_active_held_item())
@@ -575,7 +575,7 @@
 	user.verbs -= /mob/living/proc/toogle_mg_burst_fire
 
 /obj/machinery/m56d_hmg/check_eye(mob/user)
-	if(user.lying || !Adjacent(user) || user.incapacitated() || !user.client)
+	if(user.lying_angle || !Adjacent(user) || user.incapacitated() || !user.client)
 		user.unset_interaction()
 
 /mob/living/proc/toogle_mg_burst_fire(obj/machinery/m56d_hmg/MG in list(interactee))

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -273,7 +273,7 @@
 	if(machine_stat & (BROKEN|NOPOWER))
 		return
 
-	if(user.stat || user.restrained() || user.lying)
+	if(user.stat || user.restrained() || user.lying_angle)
 		return
 
 	if(get_dist(user, src) > 1 || get_dist(src, A) > 1)

--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -540,7 +540,7 @@ GLOBAL_LIST_INIT(vending_white_items, typecacheof(list(
 	if(machine_stat & (BROKEN|NOPOWER))
 		return
 
-	if(user.stat || user.restrained() || user.lying)
+	if(user.stat || user.restrained() || user.lying_angle)
 		return
 
 	if(get_dist(user, src) > 1 || get_dist(src, A) > 1)

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -153,7 +153,7 @@
 
 	for(var/mob/living/M in get_turf(src))
 
-		if(M.lying)
+		if(M.lying_angle)
 			return //No spamming this on people.
 
 		M.Paralyze(10 SECONDS)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -470,7 +470,7 @@
 
 /mob/living/proc/on_closet_dump(datum/source, obj/structure/closet/origin)
 	SetStun(origin.closet_stun_delay)//Action delay when going out of a closet
-	if(!lying && IsStun())
+	if(!lying_angle && IsStun())
 		visible_message("<span class='warning'>[src] suddenly gets out of [origin]!</span>",
 		"<span class='warning'>You get out of [origin] and get your bearings!</span>")
 	origin.UnregisterSignal(src, COMSIG_LIVING_DO_RESIST)

--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -78,7 +78,7 @@
 	. = ..()
 	if(.)
 		return
-	if(user.incapacitated() || !Adjacent(user) || user.lying || user.buckled || user.anchored)
+	if(user.incapacitated() || !Adjacent(user) || user.lying_angle || user.buckled || user.anchored)
 		return
 	var/ladder_dir_name
 	var/obj/structure/ladder/ladder_dest
@@ -100,7 +100,7 @@
 	step(user, get_dir(user, src))
 	user.visible_message("<span class='notice'>[user] starts climbing [ladder_dir_name] [src].</span>",
 	"<span class='notice'>You start climbing [ladder_dir_name] [src].</span>")
-	if(!do_after(user, 20, FALSE, src, BUSY_ICON_GENERIC) || user.lying || user.anchored)
+	if(!do_after(user, 20, FALSE, src, BUSY_ICON_GENERIC) || user.lying_angle || user.anchored)
 		return
 	user.trainteleport(ladder_dest.loc)
 	visible_message("<span class='notice'>[user] climbs [ladder_dir_name] [src].</span>") //Hack to give a visible message to the people here without duplicating user message
@@ -133,7 +133,7 @@
 
 /obj/structure/ladder/check_eye(mob/user)
 	//Are we capable of looking?
-	if(user.incapacitated() || get_dist(user, src) > 1 || is_blind(user) || user.lying || !user.client)
+	if(user.incapacitated() || get_dist(user, src) > 1 || is_blind(user) || user.lying_angle || !user.client)
 		user.unset_interaction()
 
 	//Are ladder cameras ok?
@@ -168,7 +168,7 @@
 //Peeking up/down
 /obj/structure/ladder/MouseDrop(over_object, src_location, over_location)
 	if((over_object == usr && (in_range(src, usr))))
-		if(isxenolarva(usr) || isobserver(usr) || usr.incapacitated() || is_blind(usr) || usr.lying)
+		if(isxenolarva(usr) || isobserver(usr) || usr.incapacitated() || is_blind(usr) || usr.lying_angle)
 			to_chat(usr, "You can't do that in your current state.")
 			return
 		if(is_watching)

--- a/code/game/objects/structures/misc.dm
+++ b/code/game/objects/structures/misc.dm
@@ -169,7 +169,7 @@ obj/item/alienjar
 
 	if(isliving(A)) // You Shall Not Pass!
 		var/mob/living/M = A
-		if(!M.lying && !ismonkey(M) && !istype(M, /mob/living/simple_animal/mouse))  //If your not laying down, or a small creature, no pass.
+		if(!M.lying_angle && !ismonkey(M) && !istype(M, /mob/living/simple_animal/mouse))  //If your not laying down, or a small creature, no pass.
 			return 0
 	return ..()
 

--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -13,7 +13,7 @@
 	if(world.time <= last_move_time + move_delay)
 		return
 	// Redundant check?
-	if(user.incapacitated() || user.lying)
+	if(user.incapacitated() || user.lying_angle)
 		return
 
 	if(propelled) //can't manually move it mid-propelling.

--- a/code/game/objects/structures/stool_bed_chair_nest/xeno_nest.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/xeno_nest.dm
@@ -53,7 +53,7 @@
 		if(H.cooldowns[COOLDOWN_NEST])
 			to_chat(user, "<span class='warning'>[H] was recently unbuckled. Wait a bit.</span>")
 			return FALSE
-		if(!H.lying)
+		if(!H.lying_angle)
 			to_chat(user, "<span class='warning'>[H] is resisting, ground [H.p_them()].</span>")
 			return FALSE
 
@@ -67,7 +67,7 @@
 	if(LAZYLEN(buckled_mobs))
 		to_chat(user, "<span class='warning'>There's already someone in [src].</span>")
 		return FALSE
-	if(ishuman(buckling_mob) && !buckling_mob.lying) //Improperly stunned Marines won't be nested
+	if(ishuman(buckling_mob) && !buckling_mob.lying_angle) //Improperly stunned Marines won't be nested
 		to_chat(user, "<span class='warning'>[buckling_mob] is resisting, ground [buckling_mob.p_them()].</span>")
 		return FALSE
 

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -86,7 +86,7 @@
 
 	var/mob/living/carbon/human/H = AM
 
-	if(H.lying)
+	if(H.lying_angle)
 		return
 
 	H.next_move_slowdown += slow_amt
@@ -639,7 +639,7 @@ TUNNEL
 	attack_alien(user)
 
 /obj/structure/tunnel/attack_alien(mob/living/carbon/xenomorph/M)
-	if(!istype(M) || M.stat || M.lying)
+	if(!istype(M) || M.stat || M.lying_angle)
 		return
 
 	if(M.a_intent == INTENT_HARM && M == creator)

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -14,7 +14,7 @@
 /turf/open/Entered(atom/A, atom/OL)
 	if(iscarbon(A))
 		var/mob/living/carbon/C = A
-		if(!C.lying && !(C.buckled && istype(C.buckled,/obj/structure/bed/chair)))
+		if(!C.lying_angle && !(C.buckled && istype(C.buckled,/obj/structure/bed/chair)))
 			if(ishuman(C))
 				var/mob/living/carbon/human/H = C
 

--- a/code/modules/clothing/under/ties.dm
+++ b/code/modules/clothing/under/ties.dm
@@ -361,7 +361,7 @@
 /mob/living/carbon/human/proc/do_holster()
 	. = COMSIG_KB_ACTIVATED //The return value must be a flag compatible with the signals triggering this.
 
-	if(incapacitated() || lying)
+	if(incapacitated() || lying_angle)
 		return
 
 	if(!istype(w_uniform, /obj/item/clothing/under))

--- a/code/modules/clothing/under/under.dm
+++ b/code/modules/clothing/under/under.dm
@@ -85,7 +85,7 @@
 		if ((flags_item & NODROP) || loc != usr)
 			return
 
-		if (!usr.incapacitated() && !(usr.buckled && usr.lying))
+		if (!usr.incapacitated() && !(usr.buckled && usr.lying_angle))
 			if(over_object)
 				switch(over_object.name)
 					if("r_hand")

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -15,7 +15,7 @@
 
 //Puts the item into your l_hand if possible and calls all necessary triggers/updates. returns 1 on success.
 /mob/proc/put_in_l_hand(obj/item/W)
-	if(lying)
+	if(lying_angle)
 		return FALSE
 	if(!istype(W))
 		return FALSE
@@ -31,7 +31,7 @@
 
 //Puts the item into your r_hand if possible and calls all necessary triggers/updates. returns 1 on success.
 /mob/proc/put_in_r_hand(obj/item/W)
-	if(lying)
+	if(lying_angle)
 		return FALSE
 	if(!istype(W))
 		return FALSE

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -150,7 +150,7 @@
 		to_chat(shaker, "<span class='highdanger'>This player has been admin slept, do not interfere with them.</span>")
 		return
 
-	if(lying || IsSleeping())
+	if(lying_angle || IsSleeping())
 		if(client)
 			AdjustSleeping(-10 SECONDS)
 		if(!IsSleeping())
@@ -322,19 +322,20 @@
 	set waitfor = 0
 	if(buckled) return FALSE //can't slip while buckled
 	if(run_only && (m_intent != MOVE_INTENT_RUN)) return FALSE
-	if(lying) return FALSE //can't slip if already lying down.
+	if(lying_angle)
+		return FALSE //can't slip if already lying down.
 	stop_pulling()
 	to_chat(src, "<span class='warning'>You slipped on \the [slip_source_name? slip_source_name : "floor"]!</span>")
 	playsound(src.loc, 'sound/misc/slip.ogg', 25, 1)
 	Stun(stun_level)
 	Paralyze(weaken_level)
 	. = TRUE
-	if(slide_steps && lying)//lying check to make sure we downed the mob
+	if(slide_steps && lying_angle)//lying check to make sure we downed the mob
 		var/slide_dir = dir
 		for(var/i=1, i<=slide_steps, i++)
 			step(src, slide_dir)
 			sleep(2)
-			if(!lying)
+			if(!lying_angle)
 				break
 
 

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -1,7 +1,7 @@
 /mob/living/carbon/human/proc/do_quick_equip()
 	. = COMSIG_KB_ACTIVATED //The return value must be a flag compatible with the signals triggering this.
 
-	if(incapacitated() || lying || istype(loc, /obj/vehicle/multitile/root/cm_armored))
+	if(incapacitated() || lying_angle || istype(loc, /obj/vehicle/multitile/root/cm_armored))
 		return
 
 	var/obj/item/I = get_active_held_item()

--- a/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
@@ -16,7 +16,7 @@
 				to_chat(src, "<span class='danger'>Your hand won't respond properly, you drop what you're holding.</span>")
 				drop_held_item()
 		if(10 to 12)
-			if(!lying && getBrainLoss())
+			if(!lying_angle && getBrainLoss())
 				to_chat(src, "<span class='danger'>Your legs won't respond properly, you fall down.</span>")
 				set_resting(TRUE)
 

--- a/code/modules/mob/living/carbon/human/life/handle_mutations_and_radiation.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_mutations_and_radiation.dm
@@ -23,7 +23,7 @@
 			radiation -= 5 * RADIATION_SPEED_COEFFICIENT
 			to_chat(src, "<span class='warning'>You feel weak.</span>")
 			Paralyze(60)
-			if(!lying)
+			if(!lying_angle)
 				emote("collapse")
 		if(prob(5) && prob(100 * RADIATION_SPEED_COEFFICIENT) && ishumanbasic(src)) //Apes go bald
 			if((h_style != "Bald" || f_style != "Shaved"))

--- a/code/modules/mob/living/carbon/human/life/handle_organs.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_organs.dm
@@ -36,7 +36,7 @@
 
 		E.process()
 
-		if(!lying && world.time - last_move_time < 15 && m_intent != MOVE_INTENT_WALK || pulledby)
+		if(!lying_angle && world.time - last_move_time < 15 && m_intent != MOVE_INTENT_WALK || pulledby)
 			if(E.is_broken() && E.internal_organs && prob(15))
 				var/datum/internal_organ/I = pick(E.internal_organs)
 				custom_pain("You feel broken bones moving in your [E.display_name]!", 1)
@@ -49,12 +49,12 @@
 					continue
 				W.germ_level += 1
 
-		if(E.name in list("l_leg", "l_foot", "r_leg", "r_foot") && !lying)
+		if(E.name in list("l_leg", "l_foot", "r_leg", "r_foot") && !lying_angle)
 			if(!E.is_usable() || E.is_malfunctioning() || ( E.is_broken() && !(E.limb_status & LIMB_SPLINTED) && !(E.limb_status & LIMB_STABILIZED) ) )
 				leg_tally--			//let it fail even if just foot&leg
 
 	//standing is poor
-	if(leg_tally <= 0 && !IsUnconscious() && !lying && prob(5))
+	if(leg_tally <= 0 && !IsUnconscious() && !lying_angle && prob(5))
 		if(!(species.species_flags & NO_PAIN))
 			emote("pain")
 		emote("collapse")

--- a/code/modules/mob/living/carbon/human/life/handle_shock.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_shock.dm
@@ -41,12 +41,12 @@
 			blur_eyes(2)
 			stuttering = max(stuttering, 5)
 		if(60 to 79)
-			if(!lying && prob(20))
+			if(!lying_angle && prob(20))
 				emote("me", 1, " is having trouble standing.")
 			blur_eyes(2)
 			stuttering = max(stuttering, 5)
 			if(prob(2))
-				if(!lying)
+				if(!lying_angle)
 					emote("me", 1, " is having trouble standing.")
 				to_chat(src, "<span class='danger'>[pick("The pain is excruciating", "Please, just end the pain", "Your whole body is going numb")]!</span>")
 				Paralyze(10 SECONDS)
@@ -54,7 +54,7 @@
 			blur_eyes(2)
 			stuttering = max(stuttering, 5)
 			if(prob(7))
-				if(!lying)
+				if(!lying_angle)
 					emote("me", 1, " is having trouble standing.")
 				to_chat(src, "<span class='danger'>[pick("The pain is excruciating", "Please, just end the pain", "Your whole body is going numb")]!</span>")
 				Paralyze(10 SECONDS)
@@ -62,7 +62,7 @@
 			blur_eyes(2)
 			stuttering = max(stuttering, 5)
 			if(prob(7))
-				if(!lying)
+				if(!lying_angle)
 					emote("me", 1, " is having trouble standing.")
 				to_chat(src, "<span class='danger'>[pick("The pain is excruciating", "Please, just end the pain", "Your whole body is going numb")]!</span>")
 				Paralyze(10 SECONDS)
@@ -70,7 +70,7 @@
 				to_chat(src, "<span class='danger'>[pick("You black out", "You feel like you could die any moment now", "You're about to lose consciousness")]!</span>")
 				Unconscious(10 SECONDS)
 		if(150 to INFINITY)
-			if(shock_stage == 150 && !lying) emote("me", 1, "can no longer stand, collapsing!")
+			if(shock_stage == 150 && !lying_angle) emote("me", 1, "can no longer stand, collapsing!")
 			blur_eyes(2)
 			stuttering = max(stuttering, 5)
 			if(prob(7))
@@ -87,7 +87,7 @@
 		return
 	var/rate = BASE_HALLOSS_RECOVERY_RATE
 
-	if(lying || last_move_intent < world.time - 20) //If we're standing still or knocked down we benefit from the downed halloss rate
+	if(lying_angle || last_move_intent < world.time - 20) //If we're standing still or knocked down we benefit from the downed halloss rate
 		if(resting || IsSleeping()) //we're deliberately resting, comfortably taking a breather
 			rate = REST_HALLOSS_RECOVERY_RATE
 		else

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -39,7 +39,7 @@
 		if (radiation > 100)
 			radiation = 100
 			Paralyze(20 SECONDS)
-			if(!lying)
+			if(!lying_angle)
 				to_chat(src, "<span class='warning'>You feel weak.</span>")
 				emote("collapse")
 
@@ -55,7 +55,7 @@
 				if(prob(5))
 					radiation -= 5
 					Paralyze(60)
-					if(!lying)
+					if(!lying_angle)
 						to_chat(src, "<span class='warning'>You feel weak.</span>")
 						emote("collapse")
 

--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -122,7 +122,7 @@
 		return
 	var/rate = BASE_HALLOSS_RECOVERY_RATE
 
-	if(lying || last_move_intent < world.time - 20) //If we're standing still or knocked down we benefit from the downed halloss rate
+	if(lying_angle || last_move_intent < world.time - 20) //If we're standing still or knocked down we benefit from the downed halloss rate
 		if(resting || IsSleeping()) //we're deliberately resting, comfortably taking a breather
 			rate = REST_HALLOSS_RECOVERY_RATE
 		else

--- a/code/modules/mob/living/carbon/update_icons.dm
+++ b/code/modules/mob/living/carbon/update_icons.dm
@@ -21,15 +21,15 @@
 	var/final_pixel_y = pixel_y
 	var/final_dir = dir
 	var/changed = 0
-	if(lying != lying_prev && rotate_on_lying)
+	if(lying_angle != lying_prev && rotate_on_lying)
 		changed++
-		ntransform.TurnTo(lying_prev, lying)
-		if(lying == 0) //Lying to standing
-			final_pixel_y = lying ? -6 : initial(pixel_y)
-		else //if(lying != 0)
-			if(lying_prev == 0) //Standing to lying
-				pixel_y = lying ? -6 : initial(pixel_y)
-				final_pixel_y = lying ? -6 : initial(pixel_y)
+		ntransform.TurnTo(lying_prev, lying_angle)
+		if(!lying_angle) //Lying to standing
+			final_pixel_y = lying_angle ? -6 : initial(pixel_y)
+		else //if(lying_angle != 0)
+			if(lying_prev == 0) //Standing to lying down
+				pixel_y = lying_angle ? -6 : initial(pixel_y)
+				final_pixel_y = lying_angle ? -6 : initial(pixel_y)
 				if(dir & (EAST|WEST)) //Facing east or west
 					final_dir = pick(NORTH, SOUTH) //So you fall on your side rather than your face or ass
 
@@ -39,4 +39,4 @@
 		resize = RESIZE_DEFAULT_SIZE
 
 	if(changed)
-		animate(src, transform = ntransform, time = (lying_prev == 0 || !lying) ? 0.2 SECONDS : 0, pixel_y = final_pixel_y, dir = final_dir, easing = (EASE_IN|EASE_OUT))
+		animate(src, transform = ntransform, time = (lying_prev == 0 || lying_angle == 0) ? 0.2 SECONDS : 0, pixel_y = final_pixel_y, dir = final_dir, easing = (EASE_IN|EASE_OUT))

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/hunter.dm
@@ -75,7 +75,7 @@
 /mob/living/carbon/xenomorph/hunter/proc/handle_stealth()
 	if(!stealth_router(HANDLE_STEALTH_CHECK))
 		return
-	if(stat != CONSCIOUS || stealth == FALSE || lying || resting) //Can't stealth while unconscious/resting
+	if(stat != CONSCIOUS || stealth == FALSE || lying_angle || resting) //Can't stealth while unconscious/resting
 		cancel_stealth()
 		return
 	//Initial stealth

--- a/code/modules/mob/living/carbon/xenomorph/castes/larva/larva.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/larva/larva.dm
@@ -89,7 +89,7 @@
 	else if(handcuffed || legcuffed)
 		icon_state = "[bloody][base_icon_state] Cuff"
 
-	else if(lying)
+	else if(lying_angle)
 		if((resting || IsSleeping()) && (!IsParalyzed() && !IsUnconscious() && health > 0))
 			icon_state = "[bloody][base_icon_state] Sleeping"
 		else

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -213,7 +213,7 @@
 						continue
 					if(victim.client)
 						shake_camera(victim, 1, 1)
-					if(victim.loc != charger.loc || !victim.lying || isnestedhost(victim))
+					if(victim.loc != charger.loc || !victim.lying_angle || isnestedhost(victim))
 						continue
 					charger.visible_message("<span class='danger'>[charger] runs [victim] over!</span>",
 						"<span class='danger'>We run [victim] over!</span>", null, 5)

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -23,7 +23,7 @@
 			zoom_out()
 	else
 		if(is_zoomed)
-			if(loc != zoom_turf || lying)
+			if(loc != zoom_turf || lying_angle)
 				zoom_out()
 		update_progression()
 		update_evolving()
@@ -81,7 +81,7 @@
 		ruler_healing_penalty = 1
 
 	if(locate(/obj/effect/alien/weeds) in T || xeno_caste.caste_flags & CASTE_INNATE_HEALING) //We regenerate on weeds or can on our own.
-		if(lying || resting || xeno_caste.caste_flags & CASTE_QUICK_HEAL_STANDING)
+		if(lying_angle || resting || xeno_caste.caste_flags & CASTE_QUICK_HEAL_STANDING)
 			heal_wounds(XENO_RESTING_HEAL * ruler_healing_penalty)
 		else
 			heal_wounds(XENO_STANDING_HEAL * ruler_healing_penalty) //Major healing nerf if standing.
@@ -118,7 +118,7 @@
 			use_plasma(5)
 
 	if((locate(/obj/effect/alien/weeds) in T) || (xeno_caste.caste_flags & CASTE_INNATE_PLASMA_REGEN))
-		if(lying || resting)
+		if(lying_angle || resting)
 			gain_plasma((xeno_caste.plasma_gain + round(xeno_caste.plasma_gain * recovery_aura * 0.25)) * 2) // Empty recovery aura will always equal 0
 		else
 			gain_plasma(max(((xeno_caste.plasma_gain + round(xeno_caste.plasma_gain * recovery_aura * 0.25)) * 0.5), 1))

--- a/code/modules/mob/living/carbon/xenomorph/update_icons.dm
+++ b/code/modules/mob/living/carbon/xenomorph/update_icons.dm
@@ -18,7 +18,7 @@
 /mob/living/carbon/xenomorph/update_icons()
 	if(stat == DEAD)
 		icon_state = "[xeno_caste.caste_name] Dead"
-	else if(lying)
+	else if(lying_angle)
 		if((resting || IsSleeping()) && (!IsParalyzed() && !IsUnconscious() && health > 0))
 			icon_state = "[xeno_caste.caste_name] Sleeping"
 		else
@@ -97,7 +97,7 @@
 	if(on_fire)
 		var/image/I
 		if(mob_size == MOB_SIZE_BIG)
-			if((!initial(pixel_y) || lying) && !resting && !IsSleeping())
+			if((!initial(pixel_y) || lying_angle) && !resting && !IsSleeping())
 				I = image("icon"='icons/Xeno/2x2_Xenos.dmi', "icon_state"="alien_fire", "layer"=-X_FIRE_LAYER)
 			else
 				I = image("icon"='icons/Xeno/2x2_Xenos.dmi', "icon_state"="alien_fire_lying", "layer"=-X_FIRE_LAYER)
@@ -114,7 +114,7 @@
 	remove_overlay(X_WOUND_LAYER)
 	if(health < maxHealth * 0.5) //Injuries appear at less than 50% health
 		var/image/I
-		if(lying)
+		if(lying_angle)
 			if((resting || IsSleeping()) && (!IsParalyzed() && !IsUnconscious() && health > 0))
 				I = image("icon"='icons/Xeno/wound_overlays.dmi', "icon_state"="[xeno_caste.wound_type]_wounded_resting", "layer"=-X_WOUND_LAYER)
 			else

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -195,7 +195,7 @@
 
 //A simple handler for checking your state. Used in pretty much all the procs.
 /mob/living/carbon/xenomorph/proc/check_state()
-	if(incapacitated() || lying || buckled)
+	if(incapacitated() || lying_angle || buckled)
 		to_chat(src, "<span class='warning'>We cannot do this in our current state.</span>")
 		return 0
 	return 1

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -186,13 +186,11 @@
 				return buckled.Move(newloc, direct)
 			else
 				return FALSE
-	else if(lying)
+	else if(lying_angle)
 		if(direct & EAST)
-			lying = 90
+			set_lying_angle(90)
 		else if(direct & WEST)
-			lying = 270
-		update_transform()
-		lying_prev = lying
+			set_lying_angle(270)
 
 	. = ..()
 
@@ -591,25 +589,21 @@ below 100 is not dizzy
 
 	if(laid_down)
 		if(buckled && buckled.buckle_lying != -1)
-			lying = buckled.buckle_lying //Might not actually be laying down, like with chairs, but the rest of the logic applies.
-		else if(!lying)
-			lying = pick(90, 270)
-	else if(lying)
-		lying = 0
+			set_lying_angle(buckled.buckle_lying) //Might not actually be laying down, like with chairs, but the rest of the logic applies.
+		else if(!lying_angle)
+			set_lying_angle(pick(90, 270))
+	else if(lying_angle)
+		set_lying_angle(0)
 
 	set_canmove(!(IsStun() || frozen || laid_down))
 
-	if(lying)
+	if(lying_angle)
 		density = FALSE
 		drop_all_held_items()
 	else
 		density = TRUE
 
-	if(lying_prev != lying)
-		update_transform()
-		lying_prev = lying
-
-	if(lying)
+	if(lying_angle)
 		if(layer == initial(layer)) //to avoid things like hiding larvas.
 			layer = LYING_MOB_LAYER //so mob lying always appear behind standing mobs
 	else
@@ -719,16 +713,12 @@ below 100 is not dizzy
 		if(SOUTH)
 			animate(pulled_mob, pixel_x = 0, pixel_y = -offset, 0.3 SECONDS)
 		if(EAST)
-			if(pulled_mob.lying == 270) //update the dragged dude's direction if we've turned
-				pulled_mob.lying = 90
-				pulled_mob.update_transform() //force a transformation update, otherwise it'll take a few ticks for update_mobility() to do so
-				pulled_mob.lying_prev = pulled_mob.lying
+			if(pulled_mob.lying_angle == 270) //update the dragged dude's direction if we've turned
+				pulled_mob.set_lying_angle(90)
 			animate(pulled_mob, pixel_x = offset, pixel_y = 0, 0.3 SECONDS)
 		if(WEST)
-			if(pulled_mob.lying == 90)
-				pulled_mob.lying = 270
-				pulled_mob.update_transform()
-				pulled_mob.lying_prev = pulled_mob.lying
+			if(pulled_mob.lying_angle == 90)
+				pulled_mob.set_lying_angle(270)
 			animate(pulled_mob, pixel_x = -offset, pixel_y = 0, 0.3 SECONDS)
 
 /mob/living/proc/reset_pull_offsets(mob/living/pulled_mob, override)
@@ -777,3 +767,19 @@ below 100 is not dizzy
 
 /mob/living/can_interact_with(datum/D)
 	return D.Adjacent(src)
+
+/**
+  * Changes the inclination angle of a mob, used by humans and others to differentiate between standing up and prone positions.
+  *
+  * In BYOND-angles 0 is NORTH, 90 is EAST, 180 is SOUTH and 270 is WEST.
+  * This usually means that 0 is standing up, 90 and 270 are horizontal positions to right and left respectively, and 180 is upside-down.
+  * Mobs that do now follow these conventions due to unusual sprites should require a special handling or redefinition of this proc, due to the density and layer changes.
+  * The return of this proc is the previous value of the modified lying_angle if a change was successful (might include zero), or null if no change was made.
+  */
+/mob/living/proc/set_lying_angle(new_lying)
+	if(new_lying == lying_angle)
+		return
+	. = lying_angle
+	lying_angle = new_lying
+	update_transform()
+	lying_prev = lying_angle

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -43,7 +43,8 @@
 	var/inertia_dir = 0
 	var/move_on_shuttle = TRUE // Can move on the shuttle.
 	var/canmove = TRUE
-	var/lying = 0
+	///Mob's angle in BYOND degrees. 0 is north (up/standing for humans), 90 and 270 are east and west respectively (lying horizontally), and 90 is south (upside-down).
+	VAR_PROTECTED/lying_angle = 0
 	var/lying_prev = 0
 
 	//Security

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -44,7 +44,7 @@
 	var/move_on_shuttle = TRUE // Can move on the shuttle.
 	var/canmove = TRUE
 	///Mob's angle in BYOND degrees. 0 is north (up/standing for humans), 90 and 270 are east and west respectively (lying horizontally), and 90 is south (upside-down).
-	VAR_PROTECTED/lying_angle = 0
+	var/lying_angle = 0
 	var/lying_prev = 0
 
 	//Security

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -114,7 +114,7 @@ GLOBAL_LIST_INIT(organ_rel_size, list(
 	zone = check_zone(zone)
 
 	// you can only miss if your target is standing and not restrained
-	if(!target.buckled && !target.lying)
+	if(!target.buckled && !target.lying_angle)
 		var/miss_chance = 10
 		if (zone in GLOB.base_miss_chance)
 			miss_chance = GLOB.base_miss_chance[zone]
@@ -371,7 +371,8 @@ GLOBAL_LIST_INIT(organ_rel_size, list(
 
 //check if mob is lying down on something we can operate him on.
 /mob/living/carbon/can_be_operated_on()
-	if(!lying) return FALSE
+	if(!lying_angle)
+		return FALSE
 	if(locate(/obj/machinery/optable, loc) || locate(/obj/structure/bed/roller, loc))
 		return TRUE
 	var/obj/structure/table/T = locate(/obj/structure/table, loc)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -3,7 +3,7 @@
 		return TRUE
 	if(ismob(mover) && CHECK_BITFIELD(mover.flags_pass, PASSMOB))
 		return TRUE
-	return (!mover.density || !density || lying)
+	return (!mover.density || !density || lying_angle)
 
 
 /client/verb/swap_hand()

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -56,7 +56,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 /datum/ammo/proc/knockback(mob/victim, obj/projectile/proj, max_range = 2)
 	if(!victim || victim == proj.firer)
 		CRASH("knockback called [victim ? "without a mob target" : "while the mob target was the firer"]")
-	if(proj.distance_travelled > max_range || victim.lying) shake_camera(victim, 2, 1) //Three tiles away or more, basically.
+	if(proj.distance_travelled > max_range || victim.lying_angle) shake_camera(victim, 2, 1) //Three tiles away or more, basically.
 
 	else //Two tiles away or less.
 		shake_camera(victim, 3, 4)
@@ -78,7 +78,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 		CRASH("staggerstun called [victim ? "without a mob target" : "while the mob target was the firer"]")
 	if(!isliving(victim))
 		return
-	if(shake && (proj.distance_travelled > max_range || victim.lying))
+	if(shake && (proj.distance_travelled > max_range || victim.lying_angle))
 		shake_camera(victim, shake + 1, shake)
 		return
 	var/impact_message = ""

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -267,7 +267,7 @@ should be alright.
 
 /mob/living/carbon/human/proc/do_unique_action()
 	. = COMSIG_KB_ACTIVATED //The return value must be a flag compatible with the signals triggering this.
-	if(incapacitated() || lying)
+	if(incapacitated() || lying_angle)
 		return
 
 	var/obj/item/weapon/gun/G = get_active_held_item()

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -243,7 +243,7 @@
 	. = ..()
 	if(.)
 		var/mob/living/carbon/human/PMC_sniper = user
-		if(PMC_sniper.lying == 0 && !istype(PMC_sniper.wear_suit,/obj/item/clothing/suit/storage/marine/smartgunner/veteran/PMC) && !istype(PMC_sniper.wear_suit,/obj/item/clothing/suit/storage/marine/veteran))
+		if(PMC_sniper.lying_angle == 0 && !istype(PMC_sniper.wear_suit,/obj/item/clothing/suit/storage/marine/smartgunner/veteran/PMC) && !istype(PMC_sniper.wear_suit,/obj/item/clothing/suit/storage/marine/veteran))
 			PMC_sniper.visible_message("<span class='warning'>[PMC_sniper] is blown backwards from the recoil of the [src]!</span>","<span class='highdanger'>You are knocked prone by the blowback!</span>")
 			step(PMC_sniper,turn(PMC_sniper.dir,180))
 			PMC_sniper.Paralyze(10 SECONDS)
@@ -867,7 +867,7 @@
 	smoke.set_up(0, backblast_loc)
 	smoke.start()
 	for(var/mob/living/carbon/victim in backblast_loc)
-		if(victim.lying || victim.stat == DEAD) //Have to be standing up to get the fun stuff
+		if(victim.lying_angle || victim.stat == DEAD) //Have to be standing up to get the fun stuff
 			continue
 		victim.adjustBruteLoss(15) //The shockwave hurts, quite a bit. It can knock unarmored targets unconscious in real life
 		victim.Paralyze(60) //For good measure

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -599,7 +599,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 
 
 /mob/living/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)
-	if(lying && src != proj.original_target)
+	if(lying_angle && src != proj.original_target)
 		return FALSE
 	if((proj.ammo.flags_ammo_behavior & AMMO_XENO) && (isnestedhost(src) || stat == DEAD))
 		return FALSE
@@ -621,7 +621,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 	#endif
 
 	. = max(5, .) //default hit chance is at least 5%.
-	if(lying && stat != CONSCIOUS)
+	if(lying_angle && stat != CONSCIOUS)
 		. += 15 //Bonus hit against unconscious people.
 
 	if(isliving(proj.firer))
@@ -658,7 +658,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 			proj.def_zone = new_def_zone
 			return TRUE
 
-	if(!lying) //Narrow miss!
+	if(!lying_angle) //Narrow miss!
 		animatation_displace_reset(src)
 		if(proj.ammo.sound_miss)
 			playsound_local(get_turf(src), proj.ammo.sound_miss, 75, 1)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -171,7 +171,7 @@
 	if(isliving(user))
 		var/mob/living/L = user
 		L.Stun(40)
-	if(!user.lying)
+	if(!user.lying_angle)
 		user.visible_message("<span class='warning'>[user] suddenly climbs out of [src]!",
 		"<span class='warning'>You climb out of [src] and get your bearings!")
 		update()
@@ -253,7 +253,7 @@
 		if(isliving(AM))
 			var/mob/M = AM
 			M.update_canmove() //Force the delay to go in action immediately
-			if(!M.lying)
+			if(!M.lying_angle)
 				M.visible_message("<span class='warning'>[M] is suddenly pushed out of [src]!",
 				"<span class='warning'>You get pushed out of [src] and get your bearings!")
 			if(isliving(M))

--- a/code/modules/tgui/states/not_incapacitated.dm
+++ b/code/modules/tgui/states/not_incapacitated.dm
@@ -28,6 +28,6 @@ GLOBAL_DATUM_INIT(not_incapacitated_turf_state, /datum/ui_state/not_incapacitate
 		return UI_DISABLED
 	if(isliving(user))
 		var/mob/living/L = user
-		if(L.resting || L.lying)
+		if(L.resting || L.lying_angle)
 			return UI_DISABLED
 	return UI_INTERACTIVE

--- a/code/modules/vehicles/multitile/cm_armored.dm
+++ b/code/modules/vehicles/multitile/cm_armored.dm
@@ -352,7 +352,7 @@ GLOBAL_LIST_INIT(armorvic_dmg_distributions, list(
 		throw_at(T, 3, 2, C, 1)
 		apply_damage(rand(5, 7.5), BRUTE)
 		return
-	if(!lying)
+	if(!lying_angle)
 		temp = get_step(T, facing)
 		T = temp
 		T = get_step(T, pick(GLOB.cardinals))
@@ -370,7 +370,7 @@ GLOBAL_LIST_INIT(armorvic_dmg_distributions, list(
 		H?.livingmob_interact(src)
 
 /mob/living/carbon/xenomorph/queen/tank_collision(obj/vehicle/multitile/hitbox/cm_armored/C, facing, turf/T, turf/temp)
-	if(lying || loc == C.loc)
+	if(lying_angle || loc == C.loc)
 		return ..()
 	temp = get_step(T, facing)
 	T = temp
@@ -379,7 +379,7 @@ GLOBAL_LIST_INIT(armorvic_dmg_distributions, list(
 	visible_message("<span class='danger'>[C] bumps into [src], pushing [p_them()] away!</span>", "<span class='danger'>[C] bumps into you!</span>")
 
 /mob/living/carbon/xenomorph/crusher/tank_collision(obj/vehicle/multitile/hitbox/cm_armored/C, facing, turf/T, turf/temp)
-	if(lying || loc == C.loc)
+	if(lying_angle || loc == C.loc)
 		return ..()
 	temp = get_step(T, facing)
 	T = temp


### PR DESCRIPTION
* Mass-renames the `lying` var to `lying_angle` (it used to be a boolean but it got changed to represent angles instead).
* Moves all of its assignments to a `set_lying_angle` proc.
* Moves `update_transform()` and `lying_prev = lying_angle` into the proc.

This changes nothing in functionality, it just cleans up code a little and sets it up for further changes.