### PR TITLE
alters beaker possible_transfer_amounts

### DIFF
--- a/code/game/objects/items/reagent_containers/glass.dm
+++ b/code/game/objects/items/reagent_containers/glass.dm
@@ -181,7 +181,7 @@
 	materials = list(/datum/material/glass = 5000)
 	volume = 120
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list(5,10,20,30,40,120)
+	possible_transfer_amounts = list(5,10,15,20,30,40,60,120)
 
 /obj/item/reagent_containers/glass/beaker/noreact
 	name = "cryostasis beaker"
@@ -199,8 +199,7 @@
 	materials = list(/datum/material/glass = 5000)
 	volume = 300
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list(5,10,20,40,80,120,300)
-
+	possible_transfer_amounts = list(5,10,15,20,30,40,60,120,300)
 
 /obj/item/reagent_containers/glass/beaker/vial
 	name = "vial"


### PR DESCRIPTION
A significant number of the recipes use equal numbers of 3 different things, so 15/30/60u are useful amounts (eg alky: 10u of nitro/potas/silicon makes 30u, so completing the recipe uses 30u of nitrogen and chlorine)

80u is dumb

:cl:
tweak: beakers can use 15/30/60u transfer amounts
/:cl: