### PR TITLE
Xeno Bump Attack toggled on by Default

### DIFF
--- a/code/datums/components/bump_attack.dm
+++ b/code/datums/components/bump_attack.dm
@@ -1,5 +1,5 @@
 /datum/component/bump_attack
-	var/active = FALSE
+	var/active = TRUE
 	var/bump_action_path
 	var/datum/action/bump_attack_toggle/toggle_action
 
@@ -20,6 +20,7 @@
 	toggle_action.give_action(parent)
 	toggle_action.update_button_icon(active)
 	RegisterSignal(toggle_action, COMSIG_ACTION_TRIGGER, toggle_path)
+	RegisterSignal(parent, COMSIG_MOVABLE_BUMP, bump_action_path)
 
 
 /datum/component/bump_attack/Destroy(force, silent)

--- a/code/datums/components/bump_attack.dm
+++ b/code/datums/components/bump_attack.dm
@@ -20,7 +20,8 @@
 	toggle_action.give_action(parent)
 	toggle_action.update_button_icon(active)
 	RegisterSignal(toggle_action, COMSIG_ACTION_TRIGGER, toggle_path)
-	RegisterSignal(parent, COMSIG_MOVABLE_BUMP, bump_action_path)
+	if(active)
+		RegisterSignal(parent, COMSIG_MOVABLE_BUMP, bump_action_path)
 
 
 /datum/component/bump_attack/Destroy(force, silent)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Xenos (and everyone else, I suppose) begins with bump attack on by default.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It was on rohesie's simple additions

Don't yell at me, most aliens immediately turn it on anyway.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: xeno bump attack is on by default
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
