### PR TITLE
Add a flag to disable distress beacons

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -102,3 +102,6 @@
 /datum/config_entry/keyed_list/lobby_music
 	key_mode = KEY_MODE_TEXT
 	value_mode = VALUE_MODE_TEXT
+
+/datum/config_entry/flag/distress_ert_allowed
+	config_entry_value = TRUE

--- a/code/game/objects/machinery/computer/communications.dm
+++ b/code/game/objects/machinery/computer/communications.dm
@@ -357,8 +357,9 @@
 		if(STATE_EVACUATION_CANCEL)
 			dat += "Are you sure you want to cancel the evacuation of the [SSmapping.configs[SHIP_MAP].map_name]? \[ <A HREF='?src=\ref[src];operation=evacuation_cancel'>Confirm</A>\]"
 
-		if(STATE_DISTRESS && CONFIG_GET(flag/distress_ert_allowed))
-			dat += "Are you sure you want to trigger a distress signal? The signal can be picked up by anyone listening, friendly or not. \[ <A HREF='?src=\ref[src];operation=distress'>Confirm</A>\]"
+		if(STATE_DISTRESS)
+			if(CONFIG_GET(flag/distress_ert_allowed))
+				dat += "Are you sure you want to trigger a distress signal? The signal can be picked up by anyone listening, friendly or not. \[ <A HREF='?src=\ref[src];operation=distress'>Confirm</A>\]"
 
 		if(STATE_MESSAGELIST)
 			dat += "Messages:"

--- a/code/game/objects/machinery/computer/communications.dm
+++ b/code/game/objects/machinery/computer/communications.dm
@@ -171,6 +171,10 @@
 
 		if("distress")
 			if(state == STATE_DISTRESS)
+				if(!CONFIG_GET(flag/distress_ert_allowed))
+					to_chat(usr, "<span class='warning'>The distress beacon doesn't seem to be working.</span>")
+					return FALSE
+					
 				if(world.time < DISTRESS_TIME_LOCK)
 					to_chat(usr, "<span class='warning'>The distress beacon cannot be launched this early in the operation. Please wait another [round((DISTRESS_TIME_LOCK-world.time)/600)] minutes before trying again.</span>")
 					return FALSE

--- a/code/game/objects/machinery/computer/communications.dm
+++ b/code/game/objects/machinery/computer/communications.dm
@@ -172,7 +172,8 @@
 		if("distress")
 			if(state == STATE_DISTRESS)
 				if(!CONFIG_GET(flag/distress_ert_allowed))
-					to_chat(usr, "<span class='warning'>The distress beacon doesn't seem to be working.</span>")
+					log_admin_private("[key_name(usr)] may have attempted a href exploit on a [src]. [AREACOORD(usr)].")
+					message_admins("[ADMIN_TPMONTY(usr)] may be attempting a href exploit on a [src]. [ADMIN_VERBOSEJMP(usr)].")
 					return FALSE
 					
 				if(world.time < DISTRESS_TIME_LOCK)
@@ -341,7 +342,8 @@
 					dat += "<BR>\[ <A HREF='?src=\ref[src];operation=announce'>Make an announcement</A> \]"
 					dat += length(GLOB.admins) > 0 ? "<BR>\[ <A HREF='?src=\ref[src];operation=messageTGMC'>Send a message to TGMC</A> \]" : "<BR>\[ TGMC communication offline \]"
 					dat += "<BR>\[ <A HREF='?src=\ref[src];operation=award'>Award a medal</A> \]"
-					dat += "<BR>\[ <A HREF='?src=\ref[src];operation=distress'>Send Distress Beacon</A> \]"
+					if(CONFIG_GET(flag/distress_ert_allowed)) // We only add the UI if the flag is allowed
+						dat += "<BR>\[ <A HREF='?src=\ref[src];operation=distress'>Send Distress Beacon</A> \]"
 					switch(SSevacuation.evac_status)
 						if(EVACUATION_STATUS_STANDING_BY) dat += "<BR>\[ <A HREF='?src=\ref[src];operation=evacuation_start'>Initiate emergency evacuation</A> \]"
 						if(EVACUATION_STATUS_INITIATING) dat += "<BR>\[ <A HREF='?src=\ref[src];operation=evacuation_cancel'>Cancel emergency evacuation</A> \]"
@@ -355,7 +357,7 @@
 		if(STATE_EVACUATION_CANCEL)
 			dat += "Are you sure you want to cancel the evacuation of the [SSmapping.configs[SHIP_MAP].map_name]? \[ <A HREF='?src=\ref[src];operation=evacuation_cancel'>Confirm</A>\]"
 
-		if(STATE_DISTRESS)
+		if(STATE_DISTRESS && CONFIG_GET(flag/distress_ert_allowed))
 			dat += "Are you sure you want to trigger a distress signal? The signal can be picked up by anyone listening, friendly or not. \[ <A HREF='?src=\ref[src];operation=distress'>Confirm</A>\]"
 
 		if(STATE_MESSAGELIST)


### PR DESCRIPTION
## About The Pull Request

Add an admin flag to be able to disable the distress beacon

## Changelog
:cl:
admin: added a flag to disable ert on distress
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
