### PR TITLE
Fix xenos not dying correctly

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/larva/larva.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/larva/larva.dm
@@ -101,6 +101,6 @@
 // *********** Death
 // ***************************************
 /mob/living/carbon/xenomorph/larva/death(gibbed, deathmessage)
-	log_game("[key_name(src)] died as a Larva at [AREACOORD(src.loc)].")
+	log_game("[key_name(src)] died as a Larva at [AREACOORD(src)].")
 	message_admins("[ADMIN_TPMONTY(src)] died as a Larva.")
 	return ..()

--- a/code/modules/mob/living/carbon/xenomorph/xeno_helpers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_helpers.dm
@@ -19,4 +19,5 @@
 /mob/living/carbon/xenomorph/restrained(ignore_checks)
 	return FALSE
 
-
+/mob/living/carbon/xenomorph/get_death_threshold()
+	return xeno_caste.crit_health


### PR DESCRIPTION
Fixes https://github.com/tgstation/TerraGov-Marine-Corps/issues/3856

xenos were not using their xeno_caste.crit_health to calculate if they should die.
This made low hp xenos invincible (like larva)