### PR TITLE
Removes unused attachments from distress, adds the T-19 stock to distres.

### DIFF
--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -258,7 +258,7 @@
 					/obj/item/attachable/burstfire_assembly = round(scale * 4),
 
 					/obj/item/attachable/stock/t35stock = round(scale * 4),
-					/obj/item/attachable/stock/t19stock = round(scale * 4) ,
+					/obj/item/attachable/stock/t19stock = round(scale * 4),
 					/obj/item/attachable/stock/tactical = round(scale * 3),
 
 					/obj/item/attachable/attached_gun/grenade = round(scale * 10),

--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -258,8 +258,7 @@
 					/obj/item/attachable/burstfire_assembly = round(scale * 4),
 
 					/obj/item/attachable/stock/t35stock = round(scale * 4),
-					/obj/item/attachable/stock/revolver = round(scale * 4),
-					/obj/item/attachable/stock/smg = round(scale * 4) ,
+					/obj/item/attachable/stock/t19stock = round(scale * 4) ,
 					/obj/item/attachable/stock/tactical = round(scale * 3),
 
 					/obj/item/attachable/attached_gun/grenade = round(scale * 10),


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds t-19 stock, removes deprecated m39 stock.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's old stuff Kuro was too lazy to remove. Also adds the stock, people were complaning
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:

fix: old M39 SMG stock replaced with the one for the current SMG, removed deprecated revolver stock that's unused.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
