### PR TITLE
Powerloader skill increases to RO, CE, Combat Engineers, and early model synths; RO can now flash marines

### DIFF
--- a/code/__DEFINES/skills.dm
+++ b/code/__DEFINES/skills.dm
@@ -115,10 +115,10 @@
 //hidden
 //proficiency with powerloader, changes powerloader speed.
 #define SKILL_POWERLOADER_DEFAULT	0
-#define SKILL_POWERLOADER_DABBLING	1 //Pilot
-#define SKILL_POWERLOADER_TRAINED	2 //Req
-#define SKILL_POWERLOADER_PRO		3 //ST
-#define SKILL_POWERLOADER_MASTER	4 //CE
+#define SKILL_POWERLOADER_DABBLING	1 //Combat Engineer
+#define SKILL_POWERLOADER_TRAINED	2 //Captain, FC
+#define SKILL_POWERLOADER_PRO		3 //Pilot
+#define SKILL_POWERLOADER_MASTER	4 //CE, RO, ST
 
 
 //leadership skill

--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -262,6 +262,7 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	engineer = SKILL_ENGINEER_ENGI
 	construction = SKILL_CONSTRUCTION_ADVANCED
 	leadership = SKILL_LEAD_BEGINNER
+	powerloader = SKILL_POWERLOADER_DABBLING
 
 /datum/skills/combat_medic
 	name = "Combat Medic"
@@ -318,7 +319,7 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	melee_weapons = SKILL_MELEE_SUPER
 	pilot = SKILL_PILOT_TRAINED
 	police = SKILL_POLICE_MP
-	powerloader = SKILL_POWERLOADER_TRAINED
+	powerloader = SKILL_POWERLOADER_MASTER
 	large_vehicle = SKILL_LARGE_VEHICLE_TRAINED
 
 /datum/skills/captain

--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -208,7 +208,7 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	construction = SKILL_CONSTRUCTION_MASTER
 	engineer = SKILL_ENGINEER_MASTER
 	powerloader = SKILL_POWERLOADER_MASTER
-	police = SKILL_POLICE_FLASH 
+	police = SKILL_POLICE_FLASH
 
 /datum/skills/civilian/survivor/doctor
 	name = "Survivor Doctor"
@@ -377,13 +377,13 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	construction = SKILL_CONSTRUCTION_MASTER
 	leadership = SKILL_LEAD_MASTER
 	police = SKILL_POLICE_FLASH
-	powerloader = SKILL_POWERLOADER_TRAINED
+	powerloader = SKILL_POWERLOADER_MASTER
 
 /datum/skills/RO
 	name = "Requisition Officer"
 	construction = SKILL_CONSTRUCTION_PLASTEEL
 	leadership = SKILL_LEAD_TRAINED
-	powerloader = SKILL_POWERLOADER_TRAINED
+	powerloader = SKILL_POWERLOADER_MASTER
 
 /datum/skills/ST
 	name = SHIP_TECH
@@ -647,4 +647,3 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 
 	medical = SKILL_MEDICAL_EXPERT
 	surgery = SKILL_SURGERY_EXPERT
-

--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -385,6 +385,7 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	construction = SKILL_CONSTRUCTION_PLASTEEL
 	leadership = SKILL_LEAD_TRAINED
 	powerloader = SKILL_POWERLOADER_MASTER
+	police = SKILL_POLICE_FLASH
 
 /datum/skills/ST
 	name = SHIP_TECH

--- a/code/game/objects/structures/crates_lockers/closets/secure/cm_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cm_closets.dm
@@ -488,6 +488,7 @@
 	new /obj/item/clothing/gloves/white(src)
 	new /obj/item/clothing/under/whites(src)
 	new /obj/item/clothing/head/white_dress(src)
+	new /obj/item/flash(src)
 
 /obj/structure/closet/secure_closet/shiptech
 	name = "Requisitions' Locker"


### PR DESCRIPTION
## About The Pull Request

RO, CE, and early gen synths now have level 4 mech skills, on par with STs. Combat engineer gets level 1. RO gains level 1 police skill and a flash spawns in the RO locker.

## Why It's Good For The Game

RO and CE were outclassed by the ST in using the Ripley. Why? I don't know, but now they are just as good so they can do quicker deliveries. Also raised the skill of early synths because synths are one of the primary mech users so leaving it at level 2 is a hindrance and does not make sense.

Combat engineer gets it at level 1 since it seems reasonable for them to be able to use it slightly faster than a regular marine.

RO is an officer so they should have had flash access regardless. They are also the ones who need it the most besides MPs to subdue marines who break into the department and not have to resort to a gun or a fist fight.

## Changelog
:cl:
tweak: RO lockers spawn a flash, which the RO can now use
balance: RO, CE, and early gen synths have level 4 powerloader skill
balance: Combet engis gain level 1 powerloader skill
/:cl: