### PR TITLE
Small fixes to LV624

### DIFF
--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -19915,18 +19915,6 @@
 	dir = 9
 	},
 /area/lv624/lazarus/comms)
-"eyk" = (
-/obj/structure/table,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/tile/purple/taupepurple{
-	dir = 9
-	},
-/area/lv624/lazarus/sleep_female)
 "eJQ" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral,
@@ -20018,6 +20006,14 @@
 	dir = 5
 	},
 /area/lv624/lazarus/research)
+"gvS" = (
+/obj/machinery/door/airlock/mainship/security{
+	locked = 1;
+	name = "\improper Nexus Dome Marshal Office";
+	req_access_txt = "0"
+	},
+/turf/open/floor,
+/area/lv624/lazarus/security)
 "gwG" = (
 /obj/structure/jungle/vines,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -20299,6 +20295,18 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating,
 /area/lv624/lazarus/robotics)
+"pPg" = (
+/obj/structure/table,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
 "qQj" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/wall,
@@ -20432,14 +20440,6 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/ground/river,
 /area/lv624/ground/river1)
-"uTP" = (
-/obj/machinery/door/airlock/mainship/security{
-	locked = 1;
-	name = "\improper Nexus Dome Marshal Office";
-	req_access_txt = "0"
-	},
-/turf/open/floor,
-/area/lv624/lazarus/security)
 "uVd" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -48280,7 +48280,7 @@ bbX
 bbX
 bbX
 bbX
-uTP
+gvS
 bbW
 bhs
 biq
@@ -53398,7 +53398,7 @@ aNG
 aMH
 aPs
 aQs
-eyk
+pPg
 aPr
 aSt
 aTh

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -2413,16 +2413,6 @@
 	icon_state = "red"
 	},
 /area/lv624/lazarus/security)
-"aiP" = (
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	dir = 1
-	},
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/armory)
 "aiQ" = (
 /obj/machinery/power/apc,
 /obj/structure/cable/yellow{
@@ -6175,11 +6165,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /turf/open/floor/tile/red/redtaupecorner{
 	dir = 8
 	},
@@ -6271,22 +6256,6 @@
 	dir = 1
 	},
 /area/lv624/lazarus/hydroponics)
-"axJ" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/open/floor/tile/red/full,
-/area/lv624/lazarus/security)
-"axK" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/tile/red/full,
-/area/lv624/lazarus/security)
 "axL" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/dirtgrassborder2/corner{
@@ -6374,11 +6343,6 @@
 /turf/open/floor/plating,
 /area/lv624/lazarus/medbay)
 "axY" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/open/floor/tile/red/redtaupe{
 	dir = 8
 	},
@@ -6576,32 +6540,7 @@
 	name = "\improper Nexus Dome Armory";
 	req_access_txt = "0"
 	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/open/floor/plating,
-/area/lv624/lazarus/armory)
-"ayD" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/tile/red/redtaupe{
-	dir = 5
-	},
-/area/lv624/lazarus/security)
-"ayE" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/tile/red/redtaupe{
-	dir = 9
-	},
 /area/lv624/lazarus/security)
 "ayF" = (
 /obj/structure/cable/yellow{
@@ -6693,32 +6632,17 @@
 	},
 /area/lv624/ground/jungle5)
 "ayU" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/open/floor/tile/red/redtaupecorner{
 	dir = 4
 	},
 /area/lv624/lazarus/security)
 "ayV" = (
 /obj/machinery/light/small,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/open/floor/tile/red/redtaupe{
 	dir = 1
 	},
 /area/lv624/lazarus/security)
 "ayW" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/open/floor/tile/red/redtaupe{
 	dir = 1
 	},
@@ -14846,9 +14770,6 @@
 	icon_state = "whiteyellowcorner"
 	},
 /area/lv624/lazarus/main_hall)
-"bbV" = (
-/turf/closed/wall/r_wall,
-/area/lv624/lazarus/armory)
 "bbW" = (
 /turf/closed/wall/r_wall,
 /area/lv624/lazarus/security)
@@ -15085,7 +15006,7 @@
 /obj/item/ammo_magazine/shotgun,
 /obj/item/weapon/gun/shotgun/pump/cmb,
 /turf/open/floor/tile/dark,
-/area/lv624/lazarus/armory)
+/area/lv624/lazarus/security)
 "bcM" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/item/reagent_containers/hypospray/autoinjector/tricordrazine,
@@ -15100,7 +15021,7 @@
 	},
 /obj/item/reagent_containers/hypospray/autoinjector/tricordrazine,
 /turf/open/floor/tile/dark,
-/area/lv624/lazarus/armory)
+/area/lv624/lazarus/security)
 "bcN" = (
 /obj/item/target/syndicate,
 /obj/structure/target_stake,
@@ -15402,7 +15323,7 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/computer/nuke_disk_generator/green,
 /turf/open/floor/tile/dark,
-/area/lv624/lazarus/armory)
+/area/lv624/lazarus/security)
 "bdL" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -15415,10 +15336,10 @@
 /obj/item/ammo_magazine/pistol/b92fs,
 /obj/item/ammo_magazine/pistol/b92fs,
 /turf/open/floor/tile/dark,
-/area/lv624/lazarus/armory)
+/area/lv624/lazarus/security)
 "bdM" = (
 /turf/open/floor/tile/dark,
-/area/lv624/lazarus/armory)
+/area/lv624/lazarus/security)
 "bdN" = (
 /obj/item/explosive/plastique{
 	pixel_x = 3;
@@ -15622,7 +15543,7 @@
 "beu" = (
 /obj/machinery/deployable/barrier,
 /turf/open/floor/tile/dark,
-/area/lv624/lazarus/armory)
+/area/lv624/lazarus/security)
 "bev" = (
 /obj/structure/rack,
 /obj/item/weapon/gun/smg/mp5,
@@ -15632,7 +15553,7 @@
 /obj/item/ammo_magazine/smg/mp5,
 /obj/item/ammo_magazine/smg/mp5,
 /turf/open/floor/tile/dark,
-/area/lv624/lazarus/armory)
+/area/lv624/lazarus/security)
 "bew" = (
 /turf/open/floor/tile/red/redtaupe{
 	dir = 5
@@ -15914,7 +15835,7 @@
 /obj/item/storage/toolbox/syndicate,
 /obj/structure/rack,
 /turf/open/floor/tile/dark,
-/area/lv624/lazarus/armory)
+/area/lv624/lazarus/security)
 "bfp" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -16135,7 +16056,7 @@
 "bge" = (
 /obj/structure/jungle/vines,
 /turf/closed/wall/r_wall,
-/area/lv624/lazarus/armory)
+/area/lv624/lazarus/security)
 "bgl" = (
 /obj/structure/closet/lawcloset,
 /turf/open/floor/tile/red/redtaupe{
@@ -19994,6 +19915,18 @@
 	dir = 9
 	},
 /area/lv624/lazarus/comms)
+"eyk" = (
+/obj/structure/table,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
 "eJQ" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral,
@@ -20482,13 +20415,6 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/dirtgrassborder/corner,
 /area/lv624/ground/jungle3)
-"uqX" = (
-/obj/structure/bed/chair/wood/wings,
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/tile/purple/taupepurple{
-	dir = 9
-	},
-/area/lv624/lazarus/sleep_female)
 "usu" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -20506,6 +20432,14 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/ground/river,
 /area/lv624/ground/river1)
+"uTP" = (
+/obj/machinery/door/airlock/mainship/security{
+	locked = 1;
+	name = "\improper Nexus Dome Marshal Office";
+	req_access_txt = "0"
+	},
+/turf/open/floor,
+/area/lv624/lazarus/security)
 "uVd" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -46286,10 +46220,10 @@ bah
 aNB
 aNB
 aNB
-bbV
-bbV
-bbV
-bbV
+bbW
+bbW
+bbW
+bbW
 bet
 aFB
 aFB
@@ -46543,12 +46477,12 @@ aRd
 aNC
 aNz
 aNz
-bbV
+bbW
 bdK
 bdM
-bbV
+bbW
 bge
-bbV
+bbW
 aFB
 aFB
 aFB
@@ -46799,13 +46733,13 @@ aNB
 aRd
 aNB
 bbw
-bbV
-bbV
+bbW
+bbW
 bdL
 bdM
 beu
 beu
-bbV
+bbW
 bhs
 bhs
 aFB
@@ -47056,13 +46990,13 @@ aNz
 aRd
 aNz
 aNz
-bbV
+bbW
 bcL
 bdM
 bdM
 bdM
 bdM
-bbV
+bbW
 bht
 bhs
 bjc
@@ -47313,13 +47247,13 @@ aNz
 aRd
 aNz
 aNz
-bbV
+bbW
 bcM
 bdN
 bev
 bfo
-aiP
-bbV
+bdM
+bbW
 bhu
 bim
 bhs
@@ -47570,13 +47504,13 @@ aZz
 bai
 baZ
 aNz
-bbV
-bbV
-bbV
-bbV
-bbV
+bbW
+bbW
+bbW
+bbW
+bbW
 ayC
-bbV
+bbW
 azh
 bin
 aiS
@@ -47832,7 +47766,7 @@ bcN
 bdO
 bew
 bfp
-ayD
+bew
 bbW
 bhw
 bio
@@ -48089,7 +48023,7 @@ bcO
 bdP
 bdP
 bfq
-ayE
+bdP
 bbW
 bhx
 bip
@@ -48346,7 +48280,7 @@ bbX
 bbX
 bbX
 bbX
-beC
+uTP
 bbW
 bhs
 biq
@@ -49116,7 +49050,7 @@ bbX
 bfs
 bdS
 bey
-axJ
+bdR
 ayW
 bbW
 bhA
@@ -49373,7 +49307,7 @@ bbX
 bcS
 bdT
 bez
-axK
+bdR
 bgl
 bbW
 bhB
@@ -49630,7 +49564,7 @@ bbW
 bbX
 bbW
 aiO
-axK
+bdR
 bgM
 bbW
 bhC
@@ -53463,8 +53397,8 @@ aJF
 aNG
 aMH
 aPs
-uqX
-aRi
+aQs
+eyk
 aPr
 aSt
 aTh

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -16333,6 +16333,11 @@
 	},
 /area/lv624/lazarus/atmos)
 "bhn" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/open/ground/grass/beach/corner{
 	dir = 1
 	},
@@ -20006,14 +20011,6 @@
 	dir = 5
 	},
 /area/lv624/lazarus/research)
-"gvS" = (
-/obj/machinery/door/airlock/mainship/security{
-	locked = 1;
-	name = "\improper Nexus Dome Marshal Office";
-	req_access_txt = "0"
-	},
-/turf/open/floor,
-/area/lv624/lazarus/security)
 "gwG" = (
 /obj/structure/jungle/vines,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -20104,6 +20101,18 @@
 	},
 /turf/open/floor,
 /area/lv624/ground/compound/n)
+"jGu" = (
+/obj/structure/table,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
 "jOz" = (
 /obj/structure/jungle/vines,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
@@ -20208,6 +20217,14 @@
 	},
 /turf/closed/wall/r_wall,
 /area/shuttle/drop1/lz1)
+"mGh" = (
+/obj/machinery/door/airlock/mainship/security{
+	locked = 1;
+	name = "\improper Nexus Dome Marshal Office";
+	req_access_txt = "0"
+	},
+/turf/open/floor,
+/area/lv624/lazarus/security)
 "mWY" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral,
@@ -20295,18 +20312,6 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating,
 /area/lv624/lazarus/robotics)
-"pPg" = (
-/obj/structure/table,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/tile/purple/taupepurple{
-	dir = 9
-	},
-/area/lv624/lazarus/sleep_female)
 "qQj" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/wall,
@@ -48280,7 +48285,7 @@ bbX
 bbX
 bbX
 bbX
-gvS
+mGh
 bbW
 bhs
 biq
@@ -53398,7 +53403,7 @@ aNG
 aMH
 aPs
 aQs
-pPg
+jGu
 aPr
 aSt
 aTh


### PR DESCRIPTION
## About The Pull Request
Moves a crash site lower to avoid having a free wall
Joins the security area into a single area supported by a single APC.

## Why It's Good For The Game

Marines got a free wall on one of the crash sites,
Makes assault the security (green disk) easier

## Changelog
:cl:
balance: updated the lv624 map a little
/:cl:



![image](https://user-images.githubusercontent.com/1134201/79640783-600b1e00-818b-11ea-9045-e2fc0cc694e4.png)
