### PR TITLE
Add Player panel link for admins

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -67,8 +67,16 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	if(istype(D) && D.display_icon(src))
 		languageicon = "[D.get_icon()] "
 
-	return "[spanpart1][spanpart2][CMSG_FREQPART][languageicon][CMSG_JOBPART][namepart][endspanpart][messagepart]"
+	return "[spanpart1][spanpart2][CMSG_FREQPART][languageicon][CMSG_JOBPART][compose_name_href(namepart)][endspanpart][messagepart]"
 
+/**
+	Allows us to wrap the name for specific cases like AI tracking or observer tracking
+
+	Arguments
+	 - name {string} the name of the mob to modify.
+*/
+/atom/movable/proc/compose_name_href(name)
+	return name
 
 /atom/movable/proc/compose_freq(atom/movable/speaker, radio_freq)
 	var/job = speaker.GetJob()

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -73,7 +73,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	Allows us to wrap the name for specific cases like AI tracking or observer tracking
 
 	Arguments
-	 - name {string} the name of the mob to modify.
+	- name {string} the name of the mob to modify.
 */
 /atom/movable/proc/compose_name_href(name)
 	return name

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -83,17 +83,24 @@
 				display_colour = prefs.ooccolor
 
 	for(var/client/C in GLOB.clients)
-		if(C.prefs.toggles_chat & CHAT_OOC)
-			var/display_name = key
-			if(holder?.fakekey)
-				if(check_other_rights(C, R_ADMIN, FALSE))
-					display_name = "[holder.fakekey]/([key])"
-				else
-					display_name = holder.fakekey
-			if(display_colour)
-				to_chat(C, "<font color='[display_colour]'><span class='ooc'><span class='prefix'>OOC: [display_name]</span>: <span class='message linkify'>[msg]</span></span></font>")
+		if(!(C.prefs.toggles_chat & CHAT_OOC))
+			continue
+
+		var/display_name = key
+		if(holder?.fakekey)
+			if(check_other_rights(C, R_ADMIN, FALSE))
+				display_name = "[holder.fakekey]/([key])"
 			else
-				to_chat(C, "<span class='[display_class]'><span class='prefix'>OOC: [display_name]</span>: <span class='message linkify'>[msg]</span></span>")
+				display_name = holder.fakekey
+
+		// Admins open straight to player panel
+		if(check_other_rights(C, R_ADMIN, FALSE))
+			display_name = "<a href='?_src_=holder;[HrefToken(TRUE)];playerpanel=[REF(usr)]'>[display_name]</a>"
+
+		if(display_colour)
+			to_chat(C, "<font color='[display_colour]'><span class='ooc'><span class='prefix'>OOC: [display_name]</span>: <span class='message linkify'>[msg]</span></span></font>")
+		else
+			to_chat(C, "<span class='[display_class]'><span class='prefix'>OOC: [display_name]</span>: <span class='message linkify'>[msg]</span></span>")
 
 
 /client/verb/looc_wrapper()

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -30,6 +30,6 @@
 
 
 /mob/dead/observer/compose_name_href(name)
-	if(!check_rights(R_ADMIN, FALSE))
+	if(!check_other_rights(client, R_ADMIN, FALSE))
 		return name
 	return "<a href='?_src_=holder;[HrefToken(TRUE)];playerpanel=[REF(usr)]'>[name]</a>"

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -27,3 +27,9 @@
 	// Recompose the message, because it's scrambled by default
 	message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mode)
 	to_chat(src, "[link] [message]")
+
+
+/mob/dead/observer/compose_name_href(name)
+	if(!check_rights(R_ADMIN, FALSE))
+		return name
+	return "<a href='?_src_=holder;[HrefToken(TRUE)];playerpanel=[REF(usr)]'>[name]</a>"

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -35,8 +35,6 @@
 
 
 /mob/proc/say_dead(message)
-	var/name = real_name
-
 	if(!client)
 		return
 
@@ -55,17 +53,22 @@
 
 	log_talk(message, LOG_SAY, "ghost")
 
+	var/name = real_name
 	for(var/i in GLOB.player_list)
 		var/mob/M = i
 
 		if(isnewplayer(M))
 			continue
 
-		var/rendered = "[M != src ? FOLLOW_LINK(M, src) : ""] <span class='game deadsay'><span class='prefix'>DEAD:</span> <span class='name'>[name]</span> says, <span class='message'>\"[emoji_parse(message)]\"</span></span>"
-		if(M.client && M.stat == DEAD && (M.client.prefs.toggles_chat & CHAT_DEAD))
-			to_chat(M, rendered)
+		if(!(M.client.prefs.toggles_chat & CHAT_DEAD))
+			continue
 
-		else if(check_other_rights(M.client, R_ADMIN, FALSE) && (M.client.prefs.toggles_chat & CHAT_DEAD)) // Show the message to admins/mods with deadchat toggled on
+		// Admin links for name
+		if(check_other_rights(M.client, R_ADMIN, FALSE))
+			name = "<a href='?_src_=holder;[HrefToken(TRUE)];playerpanel=[REF(usr)]'>[name]</a>"
+
+		var/rendered = "[M != src ? FOLLOW_LINK(M, src) : ""] <span class='game deadsay'><span class='prefix'>DEAD:</span> <span class='name'>[name]</span> says, <span class='message'>\"[emoji_parse(message)]\"</span></span>"
+		if(M.client && (M.stat == DEAD || check_other_rights(M.client, R_ADMIN, FALSE)))
 			to_chat(M, rendered)
 
 

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -53,7 +53,6 @@
 
 	log_talk(message, LOG_SAY, "ghost")
 
-	var/name = real_name
 	for(var/i in GLOB.player_list)
 		var/mob/M = i
 
@@ -64,6 +63,7 @@
 			continue
 
 		// Admin links for name
+		var/name = real_name
 		if(check_other_rights(M.client, R_ADMIN, FALSE))
 			name = "<a href='?_src_=holder;[HrefToken(TRUE)];playerpanel=[REF(usr)]'>[name]</a>"
 


### PR DESCRIPTION
## About The Pull Request

This adds links to OOC, Dead chat, and Say chat (when ghosting) as admin

## Why It's Good For The Game

Makes it easier to administrate.


## Changelog
:cl:
admin: adds links to OOC, Dead chat, and Say chat (when ghosting) as admin
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
