### PR TITLE
Fixes dense hiveminds PART 3

### DIFF
--- a/code/_onclick/xeno.dm
+++ b/code/_onclick/xeno.dm
@@ -27,9 +27,6 @@
 
 
 /mob/living/carbon/xenomorph/hivemind/UnarmedAttack(atom/A, proximity_flag)
-	if(lying_angle)
-		return FALSE
-
 	A.attack_hivemind(src)
 
 /atom/proc/attack_hivemind(mob/living/carbon/xenomorph/hivemind/attacker)

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
@@ -48,7 +48,7 @@
 
 	// Don't allow them over the timed_late doors
 	var/obj/machinery/door/poddoor/timed_late/door = locate() in NewLoc
-	if(door?.CanPass(src, NewLoc))
+	if(door && !door.CanPass(src, NewLoc))
 		return FALSE
 
 	// Hiveminds are scared of fire.
@@ -80,8 +80,12 @@
 /mob/living/carbon/xenomorph/hivemind/update_icons()
 	return FALSE
 
+/// Override hivemind can_move to stop hivemind being made dense again
+/mob/living/carbon/xenomorph/hivemind/update_canmove()
+	set_canmove(TRUE)
+	return canmove
 
-/* 
+/*
 These specifically override the default click actions for a hivemind
 If we want to be able to add other on click actions this would be where.
  */
@@ -90,6 +94,9 @@ If we want to be able to add other on click actions this would be where.
 		return
 
 	forceMove(get_turf(A))
+
+/mob/living/carbon/xenomorph/hivemind/CtrlClick(mob/user)
+	return FALSE
 
 /mob/living/carbon/xenomorph/hivemind/CtrlClickOn(atom/A)
 	return FALSE
@@ -117,7 +124,7 @@ If we want to be able to add other on click actions this would be where.
 /mob/living/carbon/xenomorph/hivemind/med_hud_set_status()
 	return
 
-	
+
 // =================
 // hivemind core
 /obj/effect/alien/hivemindcore


### PR DESCRIPTION
After being pulled hiveminds would become dense as part of the stop pulling proc
Additionally in the update_canmove proc we would send density based on lying angle (still trying to find out what makes us lie down).
This updates that proc to always return able to move.

Another quick fix to mean we don't care if lying when clicking something
