### PR TITLE
Immobile trait

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -80,10 +80,14 @@
 #define STASIS_BAG_TRAIT "stasis_bag"
 #define CRYOPOD_TRAIT "cryopod"
 #define TRAIT_XENO "xeno"
+#define FROZEN_TRAIT "frozen"
+#define STAT_TRAIT "stat"
+#define NECKGRAB_TRAIT "neckgrab"
 
 //mob traits
 #define TRAIT_KNOCKEDOUT		"knockedout" //Forces the user to stay unconscious.
 #define TRAIT_INCAPACITATED		"incapacitated"
+#define TRAIT_IMMOBILE			"immobile" //User is unable to move by its own volition.
 #define TRAIT_STUNIMMUNE		"stun_immunity"
 #define TRAIT_BATONIMMUNE		"baton_immunity"
 #define TRAIT_SLEEPIMMUNE		"sleep_immunity"

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -34,9 +34,11 @@
 	if(!.)
 		return
 	ADD_TRAIT(owner, TRAIT_INCAPACITATED, TRAIT_STATUS_EFFECT(id))
+	ADD_TRAIT(owner, TRAIT_IMMOBILE, TRAIT_STATUS_EFFECT(id))
 
 /datum/status_effect/incapacitating/stun/on_remove()
 	REMOVE_TRAIT(owner, TRAIT_INCAPACITATED, TRAIT_STATUS_EFFECT(id))
+	REMOVE_TRAIT(owner, TRAIT_IMMOBILE, TRAIT_STATUS_EFFECT(id))
 	return ..()
 
 //KNOCKDOWN
@@ -47,6 +49,16 @@
 /datum/status_effect/incapacitating/immobilized
 	id = "immobilized"
 
+/datum/status_effect/incapacitating/immobilized/on_apply()
+	. = ..()
+	if(!.)
+		return
+	ADD_TRAIT(owner, TRAIT_IMMOBILE, TRAIT_STATUS_EFFECT(id))
+
+/datum/status_effect/incapacitating/immobilized/on_remove()
+	REMOVE_TRAIT(owner, TRAIT_IMMOBILE, TRAIT_STATUS_EFFECT(id))
+	return ..()
+
 //PARALYZED
 /datum/status_effect/incapacitating/paralyzed
 	id = "paralyzed"
@@ -56,9 +68,11 @@
 	if(!.)
 		return
 	ADD_TRAIT(owner, TRAIT_INCAPACITATED, TRAIT_STATUS_EFFECT(id))
+	ADD_TRAIT(owner, TRAIT_IMMOBILE, TRAIT_STATUS_EFFECT(id))
 
 /datum/status_effect/incapacitating/paralyzed/on_remove()
 	REMOVE_TRAIT(owner, TRAIT_INCAPACITATED, TRAIT_STATUS_EFFECT(id))
+	REMOVE_TRAIT(owner, TRAIT_IMMOBILE, TRAIT_STATUS_EFFECT(id))
 	return ..()
 
 //UNCONSCIOUS

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -876,4 +876,7 @@
 
 
 /atom/movable/proc/setGrabState(newstate)
+	if(newstate == grab_state)
+		return
+	. = grab_state
 	grab_state = newstate

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -597,7 +597,7 @@ below 100 is not dizzy
 	else if(lying_angle)
 		set_lying_angle(0)
 
-	set_canmove(!(IsStun() || frozen || laid_down))
+	set_canmove(!(HAS_TRAIT(src, TRAIT_IMMOBILE) || laid_down))
 
 	if(lying_angle)
 		density = FALSE
@@ -785,3 +785,24 @@ below 100 is not dizzy
 	lying_angle = new_lying
 	update_transform()
 	lying_prev = lying_angle
+
+
+/mob/living/set_stat(new_stat)
+	. = ..()
+	if(isnull(.))
+		return
+	if(stat == CONSCIOUS) //From unconscious to conscious.
+		REMOVE_TRAIT(src, TRAIT_IMMOBILE, STAT_TRAIT)
+	else if(. == CONSCIOUS) //From conscious to unconscious.
+		ADD_TRAIT(src, TRAIT_IMMOBILE, STAT_TRAIT)
+
+
+/mob/living/setGrabState(newstate)
+	. = ..()
+	if(isnull(.))
+		return
+	if(grab_state >= GRAB_NECK)
+		if(. < GRAB_NECK) //Neckgrabbed.
+			ADD_TRAIT(pulling, TRAIT_IMMOBILE, NECKGRAB_TRAIT)
+	else if(. >= GRAB_NECK) //Released from neckgrab.
+		REMOVE_TRAIT(pulling, TRAIT_IMMOBILE, NECKGRAB_TRAIT)

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -366,9 +366,17 @@
 			priority_absorb_key["stuns_absorbed"] += amount
 		return TRUE
 
+
 /mob/living/proc/set_frozen(freeze = TRUE)
+	if(freeze == frozen)
+		return
+	. = frozen
 	frozen = freeze
-	return TRUE
+	if(frozen)
+		ADD_TRAIT(src, TRAIT_IMMOBILE, FROZEN_TRAIT)
+	else
+		REMOVE_TRAIT(src, TRAIT_IMMOBILE, FROZEN_TRAIT)
+
 
 /mob/living/proc/adjust_drugginess(amount)
 	return

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -844,10 +844,12 @@
 /// Updates the grab state of the mob and updates movespeed
 /mob/setGrabState(newstate)
 	. = ..()
+	if(isnull(.))
+		return
 	if(grab_state == GRAB_PASSIVE)
 		remove_movespeed_modifier(MOVESPEED_ID_MOB_GRAB_STATE)
-		return
-	add_movespeed_modifier(MOVESPEED_ID_MOB_GRAB_STATE, TRUE, 100, NONE, TRUE, grab_state * 3)
+	else if(. == GRAB_PASSIVE)
+		add_movespeed_modifier(MOVESPEED_ID_MOB_GRAB_STATE, TRUE, 100, NONE, TRUE, grab_state * 3)
 
 /mob/proc/set_stat(new_stat)
 	if(new_stat == stat)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -36,7 +36,7 @@
 
 
 /obj/item/grab/attack_self(mob/living/user)
-	if(!ismob(grabbed_thing) || user.action_busy)
+	if(!isliving(grabbed_thing) || user.action_busy)
 		return
 
 	if(!ishuman(user)) //only humans can reinforce a grab.
@@ -52,13 +52,16 @@
 	user.changeNext_move(CLICK_CD_GRABBING)
 	if(!do_mob(user, victim, 2 SECONDS, BUSY_ICON_HOSTILE, extra_checks = CALLBACK(user, /datum/.proc/Adjacent, victim)) || !user.pulling)
 		return
-	user.advance_grab_state(victim)
+	user.advance_grab_state()
 	if(user.grab_state == GRAB_NECK)
 		RegisterSignal(victim, COMSIG_LIVING_DO_RESIST, /atom/movable.proc/resisted_against)
 	victim.update_canmove()
 
 
-/mob/living/proc/advance_grab_state(mob/living/victim)
+/mob/living/proc/advance_grab_state()
+	if(!isliving(pulling))
+		CRASH("advance_grab_state() called without a living pulling victim")
+	var/mob/living/victim = pulling
 	playsound(loc, 'sound/weapons/thudswoosh.ogg', 25, TRUE, 7)
 	setGrabState(grab_state + 1)
 	switch(grab_state)


### PR DESCRIPTION
Adds an immobility trait. This should make it easier to respond to events.
One step closer to removing the need for `update_canmove()`
