### PR TITLE
Access rework

### DIFF
--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -261,10 +261,9 @@
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/space_port)
 "aaY" = (
-/obj/machinery/door/airlock/mainship/research/glass{
+/obj/machinery/door/airlock/mainship/research/glass/free_access{
 	dir = 4;
-	name = "\improper Eta Lab Secure Storage";
-	req_access_txt = "0"
+	name = "\improper Eta Lab Secure Storage"
 	},
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/nanotrasen_lab/inside)
@@ -918,10 +917,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Telecommunications";
-	req_one_access_txt = "0"
+	name = "\improper Telecommunications"
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/telecomm)
@@ -1261,9 +1259,7 @@
 /turf/closed/wall/r_wall,
 /area/bigredv2/caves/lambda_lab)
 "aea" = (
-/obj/machinery/computer/telecomms/monitor{
-	req_one_access_txt = "19;200"
-	},
+/obj/machinery/computer/telecomms/monitor,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/telecomm)
 "aeb" = (
@@ -1326,19 +1322,17 @@
 	},
 /area/bigredv2/outside/space_port)
 "aem" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 1;
-	name = "\improper Marshal Office Prison";
-	req_one_access_txt = "0"
+	name = "\improper Marshal Office Prison"
 	},
 /turf/open/floor/tile/green/whitegreenfull,
 /area/bigredv2/outside/marshal_office)
 "aen" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 1;
-	name = "\improper Marshal Office Prison";
-	req_one_access_txt = "0"
+	name = "\improper Marshal Office Prison"
 	},
 /turf/open/floor/tile/green/whitegreenfull,
 /area/bigredv2/outside/marshal_office)
@@ -1418,10 +1412,7 @@
 	},
 /area/bigredv2/caves/lambda_lab)
 "aeB" = (
-/obj/machinery/computer/telecomms/server{
-	req_access = null;
-	req_one_access_txt = "19;200"
-	},
+/obj/machinery/computer/telecomms/server,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/telecomm)
 "aeC" = (
@@ -1829,23 +1820,17 @@
 /turf/open/floor/marking/delivery,
 /area/bigredv2/outside/marshal_office)
 "afP" = (
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 1;
-	icon_state = "door_locked";
-	locked = 1;
-	name = "\improper Marshal Office Prison";
-	req_access_txt = "0"
+	name = "\improper Marshal Office Prison"
 	},
 /turf/open/floor/tile/green/whitegreenfull,
 /area/bigredv2/outside/marshal_office)
 "afQ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 1;
-	icon_state = "door_locked";
-	locked = 1;
-	name = "\improper Marshal Office Prison";
-	req_access_txt = "0"
+	name = "\improper Marshal Office Prison"
 	},
 /turf/open/floor/tile/green/whitegreenfull,
 /area/bigredv2/outside/marshal_office)
@@ -1914,10 +1899,9 @@
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/lambda_lab)
 "age" = (
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 1;
-	name = "\improper Lambda Lab Storage";
-	req_one_access_txt = "0"
+	name = "\improper Lambda Lab Storage"
 	},
 /turf/open/floor/plating,
 /area/bigredv2/caves/lambda_lab)
@@ -1941,10 +1925,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/mainship/research/glass{
+/obj/machinery/door/airlock/mainship/research/glass/free_access{
 	dir = 1;
-	name = "\improper Lambda Lab Chemistry Lab";
-	req_access_txt = "0"
+	name = "\improper Lambda Lab Chemistry Lab"
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/lambda_lab)
@@ -2128,10 +2111,9 @@
 	},
 /area/bigredv2/outside/marshal_office)
 "agJ" = (
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 1;
-	name = "\improper Marshall Head Office";
-	req_access_txt = "0"
+	name = "\improper Marshall Head Office"
 	},
 /turf/open/floor/wood,
 /area/bigredv2/outside/marshal_office)
@@ -2148,9 +2130,8 @@
 /turf/open/floor/freezer,
 /area/bigredv2/caves/lambda_lab)
 "agM" = (
-/obj/machinery/door/airlock/mainship/research/glass{
-	name = "\improper Lambda Lab Surgery";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/research/glass/free_access{
+	name = "\improper Lambda Lab Surgery"
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/lambda_lab)
@@ -2438,8 +2419,7 @@
 "ahB" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	dir = 1;
-	name = "\improper Lambda Lab Surgery";
-	req_one_access_txt = "0"
+	name = "\improper Lambda Lab Surgery"
 	},
 /turf/open/floor/tile/dark/purple2{
 	dir = 2
@@ -2524,7 +2504,7 @@
 	},
 /area/bigredv2/caves/lambda_lab)
 "ahM" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 1;
 	name = "\improper Lambda Lab Cell"
 	},
@@ -2631,20 +2611,16 @@
 /area/bigredv2/outside/marshal_office)
 "aih" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 1;
-	icon_state = "door_locked";
-	locked = 1;
-	name = "\improper Marshal Office Armory";
-	req_access_txt = "0"
+	name = "\improper Marshal Office Armory"
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/marshal_office)
 "aii" = (
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 1;
-	name = "\improper Marshal Office Equipment";
-	req_access_txt = "0"
+	name = "\improper Marshal Office Equipment"
 	},
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
@@ -2672,10 +2648,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 1;
-	name = "\improper Lambda Lab Maintenance";
-	req_one_access_txt = "0"
+	name = "\improper Lambda Lab Maintenance"
 	},
 /turf/open/floor/plating,
 /area/bigredv2/caves/lambda_lab)
@@ -2948,10 +2923,9 @@
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "ajk" = (
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 1;
-	name = "\improper Lambda Lab Maintenance";
-	req_one_access_txt = "0"
+	name = "\improper Lambda Lab Maintenance"
 	},
 /turf/open/floor/plating,
 /area/bigredv2/caves/lambda_lab)
@@ -3020,8 +2994,7 @@
 "ajr" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	dir = 1;
-	name = "\improper Lambda Lab Prisoner Room";
-	req_one_access_txt = "0"
+	name = "\improper Lambda Lab Prisoner Room"
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/lambda_lab)
@@ -3118,12 +3091,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 4;
-	icon_state = "door_locked";
-	locked = 1;
-	name = "\improper Marshal Office Armory";
-	req_access_txt = "0"
+	name = "\improper Marshal Office Armory"
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/marshal_office)
@@ -3198,8 +3168,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
-	name = "\improper Lambda Lab Break Room";
-	req_one_access_txt = "0"
+	name = "\improper Lambda Lab Break Room"
 	},
 /turf/open/floor/marking/delivery,
 /area/bigredv2/caves/lambda_lab)
@@ -3308,10 +3277,9 @@
 /turf/open/floor/tile/darkish,
 /area/bigredv2/outside/marshal_office)
 "akh" = (
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 4;
-	name = "\improper Marshal Office Interrogation";
-	req_access_txt = "0"
+	name = "\improper Marshal Office Interrogation"
 	},
 /turf/open/floor/tile/darkish,
 /area/bigredv2/outside/marshal_office)
@@ -3386,10 +3354,9 @@
 /turf/open/floor/plating,
 /area/bigredv2/outside/marshal_office)
 "akv" = (
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 1;
-	name = "\improper Marshal Office";
-	req_access_txt = "0"
+	name = "\improper Marshal Office"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor,
@@ -3550,10 +3517,9 @@
 	},
 /area/bigredv2/outside/marshal_office)
 "akR" = (
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 1;
-	name = "\improper Marshal Office";
-	req_access_txt = "0"
+	name = "\improper Marshal Office"
 	},
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
@@ -3691,10 +3657,9 @@
 /turf/open/floor/plating,
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "alp" = (
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 1;
-	name = "\improper Marshal Office Evidence Room";
-	req_access_txt = "0"
+	name = "\improper Marshal Office Evidence Room"
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/marshal_office)
@@ -4098,9 +4063,8 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/security/glass{
-	name = "\improper Marshal Office Courtroom";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	name = "\improper Marshal Office Courtroom"
 	},
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
@@ -4224,9 +4188,8 @@
 	},
 /area/bigredv2/caves/lambda_lab)
 "amP" = (
-/obj/machinery/door/airlock/mainship/research/glass{
-	name = "\improper Lambda Lab Xenobiology";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/research/glass/free_access{
+	name = "\improper Lambda Lab Xenobiology"
 	},
 /turf/open/floor/marking/delivery,
 /area/bigredv2/caves/lambda_lab)
@@ -4242,9 +4205,8 @@
 	},
 /area/bigredv2/caves/lambda_lab)
 "amR" = (
-/obj/machinery/door/airlock/mainship/research/glass{
-	name = "\improper Lambda Lab Hydroponics";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/research/glass/free_access{
+	name = "\improper Lambda Lab Hydroponics"
 	},
 /turf/open/floor/marking/delivery,
 /area/bigredv2/caves/lambda_lab)
@@ -4407,10 +4369,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 4;
-	name = "\improper Lambda Lab Maintenance Storage";
-	req_one_access_txt = "0"
+	name = "\improper Lambda Lab Maintenance Storage"
 	},
 /turf/open/floor/plating,
 /area/bigredv2/caves/lambda_lab)
@@ -4494,20 +4455,16 @@
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/nw)
 "anx" = (
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 1;
-	icon_state = "door_locked";
-	locked = 1;
-	name = "\improper Marshal Office Holding Cell";
-	req_access_txt = "0"
+	name = "\improper Marshal Office Holding Cell"
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/marshal_office)
 "any" = (
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 1;
-	name = "\improper Marshal Office Checkpoint";
-	req_access_txt = "0"
+	name = "\improper Marshal Office Checkpoint"
 	},
 /turf/open/floor/tile/red/full,
 /area/bigredv2/outside/marshal_office)
@@ -4526,12 +4483,8 @@
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "anA" = (
-/obj/machinery/door/airlock/glass_security{
-	icon_state = "door_locked";
-	id_tag = "marshal_cell";
-	locked = 1;
-	name = "Cell";
-	req_access_txt = "101"
+/obj/machinery/door/airlock/glass_security/locked{
+	name = "Cell"
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/marshal_office)
@@ -4685,9 +4638,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/research/glass{
-	name = "\improper Lambda Lab Xenobiology";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/research/glass/free_access{
+	name = "\improper Lambda Lab Xenobiology"
 	},
 /turf/open/floor/marking/delivery,
 /area/bigredv2/caves/lambda_lab)
@@ -4733,9 +4685,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/research/glass{
-	name = "\improper Lambda Lab Hydroponics";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/research/glass/free_access{
+	name = "\improper Lambda Lab Hydroponics"
 	},
 /turf/open/floor/marking/delivery,
 /area/bigredv2/caves/lambda_lab)
@@ -5017,10 +4968,7 @@
 /obj/machinery/door_control{
 	id = "viro_q";
 	name = "Qurantine Lockdown";
-	normaldoorcontrol = 1;
-	pixel_x = -25;
-	req_access_txt = "7";
-	specialfunctions = 4
+	pixel_x = -25
 	},
 /obj/structure/sign/biohazard{
 	dir = 2
@@ -5114,9 +5062,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	name = "\improper Dormitories EVA Maintenance";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "\improper Dormitories EVA Maintenance"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -5144,10 +5091,9 @@
 	},
 /area/bigredv2/caves/lambda_lab)
 "apm" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 4;
-	name = "\improper Dormitories EVA";
-	req_one_access_txt = "0"
+	name = "\improper Dormitories EVA"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -5256,8 +5202,7 @@
 "apE" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
-	name = "\improper Medical Clinic";
-	req_one_access_txt = "0"
+	name = "\improper Medical Clinic"
 	},
 /turf/open/floor/tile/white/warningstripe{
 	dir = 1
@@ -5316,7 +5261,7 @@
 /turf/open/floor,
 /area/bigredv2/outside/general_offices)
 "apM" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 4;
 	name = "\improper Dormitories Lavatory"
 	},
@@ -5973,8 +5918,7 @@
 /area/bigredv2/caves/lambda_lab)
 "arJ" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
-	name = "\improper Lambda Lab Biology Wing";
-	req_one_access_txt = "0"
+	name = "\improper Lambda Lab Biology Wing"
 	},
 /turf/open/floor/marking/delivery,
 /area/bigredv2/caves/lambda_lab)
@@ -6146,10 +6090,9 @@
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/n)
 "asi" = (
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 1;
-	name = "\improper Dormitories Tool Storage Maintenance";
-	req_one_access_txt = "0"
+	name = "\improper Dormitories Tool Storage Maintenance"
 	},
 /turf/open/floor/plating,
 /area/bigredv2/outside/general_offices)
@@ -6158,10 +6101,9 @@
 /turf/open/floor/plating,
 /area/bigredv2/outside/general_offices)
 "ask" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Dormitories EVA";
-	req_one_access_txt = "0"
+	name = "\improper Dormitories EVA"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable{
@@ -6605,13 +6547,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/locked/free_access{
 	dir = 1;
-	icon_state = "door_locked";
 	id = "safe_room";
-	locked = 1;
-	name = "\improper Lambda Lab Secure Storage";
-	req_access_txt = "0"
+	name = "\improper Lambda Lab Secure Storage"
 	},
 /turf/open/floor/elevatorshaft,
 /area/bigredv2/caves/lambda_lab)
@@ -6619,18 +6558,14 @@
 /obj/machinery/door_control{
 	id = "safe_room";
 	name = "Door Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_y = -5;
-	req_access_txt = "7";
-	specialfunctions = 4
+	pixel_y = -5
 	},
 /turf/closed/wall/r_wall,
 /area/bigredv2/caves/lambda_lab)
 "atK" = (
-/obj/machinery/door/airlock/mainship/research/glass{
+/obj/machinery/door/airlock/mainship/research/glass/free_access{
 	dir = 1;
-	name = "\improper Lambda Lab Administration Office";
-	req_access_txt = "0"
+	name = "\improper Lambda Lab Administration Office"
 	},
 /turf/open/floor/wood,
 /area/bigredv2/caves/lambda_lab)
@@ -6716,28 +6651,25 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 1;
-	name = "\improper Medical Clinic";
-	req_one_access_txt = "0"
+	name = "\improper Medical Clinic"
 	},
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/medical)
 "atV" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 1;
-	name = "\improper Medical Clinic CMO's Office";
-	req_one_access_txt = "0"
+	name = "\improper Medical Clinic CMO's Office"
 	},
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/medical)
 "atW" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/medical{
+/obj/machinery/door/airlock/mainship/medical/free_access{
 	dir = 1;
-	name = "\improper Medical Clinic Morgue";
-	req_one_access_txt = "0"
+	name = "\improper Medical Clinic Morgue"
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/medical)
@@ -6805,9 +6737,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/research/glass{
-	name = "\improper Lambda Lab Administration Office";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/research/glass/free_access{
+	name = "\improper Lambda Lab Administration Office"
 	},
 /turf/open/floor/wood,
 /area/bigredv2/caves/lambda_lab)
@@ -7114,8 +7045,7 @@
 	},
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	dir = 1;
-	name = "\improper Lambda Lab Administration Wing";
-	req_one_access_txt = "0"
+	name = "\improper Lambda Lab Administration Wing"
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/lambda_lab)
@@ -7193,8 +7123,7 @@
 "avl" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	dir = 1;
-	name = "\improper Lambda Lab Break Room";
-	req_one_access_txt = "0"
+	name = "\improper Lambda Lab Break Room"
 	},
 /turf/open/floor/marking/delivery,
 /area/bigredv2/caves/lambda_lab)
@@ -7249,10 +7178,9 @@
 	},
 /area/bigredv2/outside/nw)
 "avu" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 1;
-	name = "\improper Medical Clinic Chemistry";
-	req_one_access_txt = "0"
+	name = "\improper Medical Clinic Chemistry"
 	},
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/medical)
@@ -7345,8 +7273,7 @@
 /area/bigredv2/caves/lambda_lab)
 "avO" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
-	name = "\improper Lambda Lab Relaxation Room";
-	req_one_access_txt = "0"
+	name = "\improper Lambda Lab Relaxation Room"
 	},
 /turf/open/floor/wood,
 /area/bigredv2/caves/lambda_lab)
@@ -7558,9 +7485,8 @@
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/medical)
 "awj" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
-	name = "\improper Medical Clinic Scanner Room";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	name = "\improper Medical Clinic Scanner Room"
 	},
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/medical)
@@ -7898,8 +7824,7 @@
 "axy" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
-	name = "\improper Medical Clinic Treatment";
-	req_one_access_txt = "0"
+	name = "\improper Medical Clinic Treatment"
 	},
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/medical)
@@ -8099,8 +8024,7 @@
 	},
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	dir = 1;
-	name = "\improper Medical Clinic";
-	req_one_access_txt = "0"
+	name = "\improper Medical Clinic"
 	},
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/medical)
@@ -8475,8 +8399,7 @@
 	},
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	dir = 1;
-	name = "\improper Medical Clinic Treatment";
-	req_one_access_txt = "0"
+	name = "\improper Medical Clinic Treatment"
 	},
 /turf/open/floor/tile/white/warningstripe{
 	dir = 4
@@ -8564,9 +8487,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	name = "\improper Medical Clinic Power Station";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "\improper Medical Clinic Power Station"
 	},
 /turf/open/floor/plating/warning{
 	dir = 8
@@ -8782,9 +8704,8 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	name = "\improper Bar Maintenance";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "\improper Bar Maintenance"
 	},
 /turf/open/floor/plating,
 /area/bigredv2/outside/dorms)
@@ -8930,7 +8851,7 @@
 /turf/open/floor/freezer,
 /area/bigredv2/outside/dorms)
 "aAE" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 1;
 	name = "\improper Recreation"
 	},
@@ -8975,9 +8896,8 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	name = "\improper Bar Maintenance";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "\improper Bar Maintenance"
 	},
 /turf/open/floor/plating,
 /area/bigredv2/outside/bar)
@@ -9111,10 +9031,9 @@
 /area/bigredv2/outside/medical)
 "aBe" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 1;
-	name = "\improper Medical Clinic";
-	req_one_access_txt = "0"
+	name = "\improper Medical Clinic"
 	},
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/medical)
@@ -9236,10 +9155,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 1;
-	name = "\improper Greenhouse";
-	req_one_access_txt = "0"
+	name = "\improper Greenhouse"
 	},
 /turf/open/floor,
 /area/bigredv2/outside/hydroponics)
@@ -9543,8 +9461,7 @@
 "aCv" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	dir = 1;
-	name = "\improper Lambda Lab Technical Lab";
-	req_one_access_txt = "0"
+	name = "\improper Lambda Lab Technical Lab"
 	},
 /turf/open/floor/marking/delivery,
 /area/bigredv2/caves/lambda_lab)
@@ -9560,10 +9477,9 @@
 	},
 /area/bigredv2/caves/lambda_lab)
 "aCy" = (
-/obj/machinery/door/airlock/mainship/research/glass{
+/obj/machinery/door/airlock/mainship/research/glass/free_access{
 	dir = 1;
-	name = "\improper Lambda Lab Anomaly Chamber";
-	req_access_txt = "0"
+	name = "\improper Lambda Lab Anomaly Chamber"
 	},
 /turf/open/floor/podhatch/floor,
 /area/bigredv2/caves/lambda_lab)
@@ -9601,9 +9517,8 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/medical/glass{
-	name = "\improper Medical Clinic Storage";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	name = "\improper Medical Clinic Storage"
 	},
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/medical)
@@ -9625,9 +9540,8 @@
 	},
 /area/bigredv2/outside/medical)
 "aCG" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
-	name = "\improper Medical Clinic Storage";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	name = "\improper Medical Clinic Storage"
 	},
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/medical)
@@ -9698,10 +9612,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 1;
-	name = "\improper Bar Maintenance";
-	req_one_access_txt = "0"
+	name = "\improper Bar Maintenance"
 	},
 /turf/open/floor/plating,
 /area/bigredv2/outside/bar)
@@ -10578,9 +10491,8 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/medical/glass{
-	name = "\improper Medical Clinic Operating Theatre";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	name = "\improper Medical Clinic Operating Theatre"
 	},
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/medical)
@@ -10646,9 +10558,7 @@
 "aFK" = (
 /obj/machinery/door/airlock/glass_medical{
 	id_tag = "mbayexit";
-	name = "Medbay Reception";
-	req_access_txt = "0";
-	req_one_access_txt = "2;8;19"
+	name = "Medbay Reception"
 	},
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/medical)
@@ -10787,7 +10697,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 4;
 	name = "\improper Greenhouse Storage"
 	},
@@ -11320,8 +11230,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
-	name = "\improper Lambda Lab Anomaly Lab";
-	req_one_access_txt = "0"
+	name = "\improper Lambda Lab Anomaly Lab"
 	},
 /turf/open/floor/marking/delivery,
 /area/bigredv2/caves/lambda_lab)
@@ -11831,8 +11740,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
-	name = "\improper Medical Clinic";
-	req_one_access_txt = "0"
+	name = "\improper Medical Clinic"
 	},
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/medical)
@@ -12200,8 +12108,7 @@
 	},
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	dir = 1;
-	name = "\improper Lambda Lab Virology Wing";
-	req_one_access_txt = "0"
+	name = "\improper Lambda Lab Virology Wing"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -12265,8 +12172,7 @@
 	},
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	dir = 1;
-	name = "\improper Lambda Lab Virology Wing";
-	req_one_access_txt = "0"
+	name = "\improper Lambda Lab Virology Wing"
 	},
 /turf/open/floor/marking/delivery,
 /area/bigredv2/caves/lambda_lab)
@@ -12628,7 +12534,7 @@
 	},
 /area/bigredv2/outside/c)
 "aLe" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	name = "\improper Medical Command Complex"
 	},
 /turf/open/floor/tile/white,
@@ -12661,7 +12567,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	name = "\improper Medical Command Complex"
 	},
 /turf/open/floor/tile/white,
@@ -12845,8 +12751,7 @@
 	},
 /obj/machinery/door/window{
 	dir = 1;
-	icon_state = "left";
-	opacity = 1
+	icon_state = "left"
 	},
 /turf/open/floor/tile/white/warningstripe{
 	dir = 2
@@ -13028,8 +12933,7 @@
 /area/bigredv2/outside/hydroponics)
 "aMq" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
-	name = "\improper Lambda Lab";
-	req_one_access_txt = "0"
+	name = "\improper Lambda Lab"
 	},
 /turf/open/floor/tile/dark/purple2{
 	dir = 8
@@ -13087,10 +12991,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/research{
+/obj/machinery/door/airlock/mainship/research/free_access{
 	dir = 1;
-	name = "\improper Virology Lab Decontamination";
-	req_access_txt = "0"
+	name = "\improper Virology Lab Decontamination"
 	},
 /turf/open/floor/tile/white/warningstripe{
 	dir = 1
@@ -13104,7 +13007,7 @@
 /turf/open/floor/plating,
 /area/bigredv2/outside/general_store)
 "aME" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 1;
 	name = "\improper General Store"
 	},
@@ -13117,9 +13020,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/multi_tile/mainship/comdoor{
-	name = "\improper Operations";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/multi_tile/mainship/comdoor/free_access{
+	name = "\improper Operations"
 	},
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/admin_building)
@@ -13201,8 +13103,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	dir = 4;
-	name = "\improper Lambda Lab Virology Quarantine";
-	req_one_access_txt = "0"
+	name = "\improper Lambda Lab Virology Quarantine"
 	},
 /turf/open/floor/marking/delivery,
 /area/bigredv2/caves/lambda_lab)
@@ -13282,7 +13183,7 @@
 /turf/open/floor,
 /area/bigredv2/outside/general_store)
 "aNp" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 4;
 	name = "\improper General Store"
 	},
@@ -13363,10 +13264,7 @@
 /area/bigredv2/outside/admin_building)
 "aND" = (
 /obj/structure/table,
-/obj/machinery/faxmachine{
-	density = 0;
-	req_one_access_txt = "200"
-	},
+/obj/machinery/faxmachine,
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/admin_building)
 "aNE" = (
@@ -13683,7 +13581,7 @@
 /turf/open/floor/wood,
 /area/bigredv2/outside/bar)
 "aOU" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 1;
 	name = "\improper Crew Habitation Complex"
 	},
@@ -13766,10 +13664,9 @@
 /turf/open/floor/carpet,
 /area/bigredv2/outside/library)
 "aPq" = (
-/obj/machinery/door/airlock/mainship/research/glass{
+/obj/machinery/door/airlock/mainship/research/glass/free_access{
 	dir = 1;
-	name = "\improper Lambda Lab Anomaly Chamber";
-	req_access_txt = "0"
+	name = "\improper Lambda Lab Anomaly Chamber"
 	},
 /turf/open/floor/marking/delivery,
 /area/bigredv2/caves/lambda_lab)
@@ -13795,10 +13692,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/research{
+/obj/machinery/door/airlock/mainship/research/free_access{
 	dir = 1;
-	name = "\improper Virology Lab Decontamination";
-	req_access_txt = "0"
+	name = "\improper Virology Lab Decontamination"
 	},
 /turf/open/floor/tile/white/warningstripe{
 	dir = 2
@@ -14066,8 +13962,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	dir = 4;
-	name = "\improper Lambda Lab Virology Quarantine";
-	req_one_access_txt = "0"
+	name = "\improper Lambda Lab Virology Quarantine"
 	},
 /turf/open/floor/marking/delivery,
 /area/bigredv2/caves/lambda_lab)
@@ -14264,10 +14159,9 @@
 	},
 /area/bigredv2/outside/admin_building)
 "aRe" = (
-/obj/machinery/door/airlock/multi_tile/mainship/comdoor{
+/obj/machinery/door/airlock/multi_tile/mainship/comdoor/free_access{
 	dir = 1;
-	name = "\improper Operations";
-	req_access_txt = "0"
+	name = "\improper Operations"
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/admin_building)
@@ -14536,10 +14430,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/mainship/command{
+/obj/machinery/door/airlock/mainship/command/free_access{
 	dir = 1;
-	name = "\improper Operations Maintenance";
-	req_access_txt = "0"
+	name = "\improper Operations Maintenance"
 	},
 /turf/open/floor/plating,
 /area/bigredv2/outside/admin_building)
@@ -14677,10 +14570,9 @@
 /turf/open/floor/plating,
 /area/bigredv2/outside/virology)
 "aSA" = (
-/obj/machinery/door/airlock/mainship/research/glass{
+/obj/machinery/door/airlock/mainship/research/glass/free_access{
 	dir = 1;
-	name = "\improper Virology Lab Cell";
-	req_access_txt = "0"
+	name = "\improper Virology Lab Cell"
 	},
 /turf/open/floor/freezer,
 /area/bigredv2/outside/virology)
@@ -14755,10 +14647,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/mainship/command{
+/obj/machinery/door/airlock/mainship/command/free_access{
 	dir = 1;
-	name = "\improper Operations";
-	req_access_txt = "0"
+	name = "\improper Operations"
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/admin_building)
@@ -15662,7 +15553,7 @@
 	},
 /area/bigredv2/outside/w)
 "aVJ" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 4;
 	name = "\improper General Store"
 	},
@@ -15820,7 +15711,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 4;
 	name = "\improper General Store"
 	},
@@ -15902,10 +15793,9 @@
 /area/bigredv2/outside/general_store)
 "aWC" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 1;
-	name = "\improper Operations Armory";
-	req_access_txt = "0"
+	name = "\improper Operations Armory"
 	},
 /turf/open/floor,
 /area/bigredv2/outside/admin_building)
@@ -15963,10 +15853,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/research/glass{
+/obj/machinery/door/airlock/mainship/research/glass/free_access{
 	dir = 4;
-	name = "\improper Virology Lab Chemistry";
-	req_access_txt = "0"
+	name = "\improper Virology Lab Chemistry"
 	},
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/virology)
@@ -16156,10 +16045,9 @@
 	},
 /area/bigredv2/outside/virology)
 "aXx" = (
-/obj/machinery/door/airlock/mainship/research/glass{
+/obj/machinery/door/airlock/mainship/research/glass/free_access{
 	dir = 4;
-	name = "\improper Virology Lab Cell";
-	req_access_txt = "0"
+	name = "\improper Virology Lab Cell"
 	},
 /turf/open/floor/freezer,
 /area/bigredv2/outside/virology)
@@ -16238,10 +16126,9 @@
 /turf/open/floor/plating,
 /area/bigredv2/outside/cargo)
 "aXJ" = (
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 4;
-	name = "\improper General Store Storage";
-	req_one_access_txt = "0"
+	name = "\improper General Store Storage"
 	},
 /turf/open/floor/plating,
 /area/bigredv2/outside/cargo)
@@ -16266,10 +16153,7 @@
 /area/bigredv2/outside/admin_building)
 "aXN" = (
 /obj/structure/table,
-/obj/machinery/faxmachine{
-	density = 0;
-	req_one_access_txt = "200"
-	},
+/obj/machinery/faxmachine,
 /turf/open/floor/tile/dark/blue2{
 	dir = 10
 	},
@@ -16343,10 +16227,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 1;
-	name = "\improper General Store Maintenance";
-	req_one_access_txt = "0"
+	name = "\improper General Store Maintenance"
 	},
 /turf/open/floor,
 /area/bigredv2/outside/general_store)
@@ -16429,10 +16312,9 @@
 	},
 /area/bigredv2/outside/admin_building)
 "aYm" = (
-/obj/machinery/door/airlock/mainship/command{
+/obj/machinery/door/airlock/mainship/command/free_access{
 	dir = 1;
-	name = "\improper Operations Office";
-	req_access_txt = "0"
+	name = "\improper Operations Office"
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/admin_building)
@@ -16706,9 +16588,8 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/research{
-	name = "\improper Virology Lab Decontamination";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/research/free_access{
+	name = "\improper Virology Lab Decontamination"
 	},
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/virology)
@@ -16834,10 +16715,9 @@
 /area/bigredv2/outside/chapel)
 "aZL" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 1;
-	name = "\improper General Store Maintenance";
-	req_one_access_txt = "0"
+	name = "\improper General Store Maintenance"
 	},
 /turf/open/floor/plating,
 /area/bigredv2/outside/cargo)
@@ -17090,9 +16970,8 @@
 /turf/open/floor/carpet,
 /area/bigredv2/outside/admin_building)
 "baI" = (
-/obj/machinery/door/airlock/multi_tile/mainship/comdoor{
-	name = "\improper Operations";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/multi_tile/mainship/comdoor/free_access{
+	name = "\improper Operations"
 	},
 /turf/open/floor,
 /area/bigredv2/outside/admin_building)
@@ -17579,9 +17458,8 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/command{
-	name = "\improper Operations Office";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/command/free_access{
+	name = "\improper Operations Office"
 	},
 /turf/open/floor/wood,
 /area/bigredv2/outside/admin_building)
@@ -17609,10 +17487,7 @@
 /area/bigredv2/outside/admin_building)
 "bcP" = (
 /obj/structure/table,
-/obj/machinery/faxmachine{
-	density = 0;
-	req_one_access_txt = "200"
-	},
+/obj/machinery/faxmachine,
 /turf/open/floor/wood,
 /area/bigredv2/outside/admin_building)
 "bcQ" = (
@@ -17707,10 +17582,9 @@
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
 "bdj" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Cargo Bay Offices";
-	req_one_access_txt = "0"
+	name = "\improper Cargo Bay Offices"
 	},
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
@@ -17724,9 +17598,8 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/command{
-	name = "\improper Operations Meeting Room";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/command/free_access{
+	name = "\improper Operations Meeting Room"
 	},
 /turf/open/floor,
 /area/bigredv2/outside/admin_building)
@@ -17984,9 +17857,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/multi_tile/mainship/comdoor{
-	name = "\improper Operations";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/multi_tile/mainship/comdoor/free_access{
+	name = "\improper Operations"
 	},
 /turf/open/floor,
 /area/bigredv2/outside/admin_building)
@@ -18526,9 +18398,8 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/security/glass{
-	name = "\improper Cargo Bay Security";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	name = "\improper Cargo Bay Security"
 	},
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
@@ -18945,11 +18816,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/secure{
-	icon_state = "door_locked";
-	locked = 1;
-	name = "\improper Emergency Vault";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/secure/locked/free_access{
+	name = "\improper Emergency Vault"
 	},
 /turf/open/floor,
 /area/bigredv2/outside/storage)
@@ -19467,10 +19335,9 @@
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
 "bju" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 4;
-	name = "\improper Cargo Bay Storage";
-	req_one_access_txt = "0"
+	name = "\improper Cargo Bay Storage"
 	},
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
@@ -19629,10 +19496,9 @@
 /area/bigredv2/outside/cargo)
 "bjR" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Cargo Bay Quartermaster";
-	req_one_access_txt = "0"
+	name = "\improper Cargo Bay Quartermaster"
 	},
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
@@ -19715,10 +19581,9 @@
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
 "bko" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Cargo Bay Storage";
-	req_one_access_txt = "0"
+	name = "\improper Cargo Bay Storage"
 	},
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
@@ -19742,10 +19607,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Atmospherics Condenser";
-	req_one_access_txt = "0"
+	name = "\improper Atmospherics Condenser"
 	},
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
@@ -19753,10 +19617,9 @@
 /turf/closed/wall/r_wall/unmeltable,
 /area/bigredv2/outside/filtration_plant)
 "bkw" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Atmospherics Condenser";
-	req_one_access_txt = "0"
+	name = "\improper Atmospherics Condenser"
 	},
 /turf/open/floor/plating,
 /area/bigredv2/outside/filtration_plant)
@@ -19767,10 +19630,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Atmospherics Condenser";
-	req_one_access_txt = "0"
+	name = "\improper Atmospherics Condenser"
 	},
 /turf/open/floor/plating,
 /area/bigredv2/outside/filtration_plant)
@@ -19780,10 +19642,9 @@
 	},
 /area/bigredv2/outside/se)
 "bkz" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 4;
-	name = "\improper Cargo Bay Quartermaster";
-	req_one_access_txt = "0"
+	name = "\improper Cargo Bay Quartermaster"
 	},
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
@@ -19868,10 +19729,9 @@
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
 "bkP" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 4;
-	name = "\improper Atmospherics Condenser Storage";
-	req_one_access_txt = "0"
+	name = "\improper Atmospherics Condenser Storage"
 	},
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
@@ -20061,10 +19921,9 @@
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
 "blF" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 4;
-	name = "\improper Atmospherics Condenser Air Filtration";
-	req_one_access_txt = "0"
+	name = "\improper Atmospherics Condenser Air Filtration"
 	},
 /turf/open/floor/plating,
 /area/bigredv2/outside/filtration_plant)
@@ -20421,10 +20280,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 4;
-	name = "\improper Atmospherics Condenser Storage";
-	req_one_access_txt = "0"
+	name = "\improper Atmospherics Condenser Storage"
 	},
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
@@ -20543,10 +20401,9 @@
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
 "bnA" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 4;
-	name = "\improper Atmospherics Condenser";
-	req_one_access_txt = "0"
+	name = "\improper Atmospherics Condenser"
 	},
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
@@ -20710,10 +20567,9 @@
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
 "bol" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Engineering SMES";
-	req_one_access_txt = "0"
+	name = "\improper Engineering SMES"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -20757,10 +20613,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Atmospherics Condenser";
-	req_one_access_txt = "0"
+	name = "\improper Atmospherics Condenser"
 	},
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
@@ -20891,9 +20746,8 @@
 /area/bigredv2/outside/engineering)
 "boM" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/mainship/secure{
-	name = "\improper Engineering Secure Storage";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/secure/free_access{
+	name = "\improper Engineering Secure Storage"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -20931,10 +20785,9 @@
 /area/bigredv2/outside/engineering)
 "boU" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Chief Engineer's Office";
-	req_one_access_txt = "0"
+	name = "\improper Chief Engineer's Office"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -21022,10 +20875,9 @@
 /area/bigredv2/outside/engineering)
 "bpk" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Engineering Tool Storage";
-	req_one_access_txt = "0"
+	name = "\improper Engineering Tool Storage"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -21125,19 +20977,17 @@
 	},
 /area/bigredv2/outside/sw)
 "bpz" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Engineering Lockers";
-	req_one_access_txt = "0"
+	name = "\improper Engineering Lockers"
 	},
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
 "bpA" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Engineering Lockers";
-	req_one_access_txt = "0"
+	name = "\improper Engineering Lockers"
 	},
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
@@ -21249,10 +21099,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 4;
-	name = "\improper Atmospherics Condenser Water Filtration";
-	req_one_access_txt = "0"
+	name = "\improper Atmospherics Condenser Water Filtration"
 	},
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
@@ -21303,10 +21152,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Engineering Break Room";
-	req_one_access_txt = "0"
+	name = "\improper Engineering Break Room"
 	},
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
@@ -21401,10 +21249,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 4;
-	name = "\improper Atmospherics Condenser Water Filtration";
-	req_one_access_txt = "0"
+	name = "\improper Atmospherics Condenser Water Filtration"
 	},
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
@@ -21539,10 +21386,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 4;
-	name = "\improper Engineering Workshop";
-	req_one_access_txt = "0"
+	name = "\improper Engineering Workshop"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -21573,10 +21419,9 @@
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
 "bqP" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Engine Reactor Control";
-	req_one_access_txt = "0"
+	name = "\improper Engine Reactor Control"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -21668,10 +21513,9 @@
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
 "brf" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 4;
-	name = "\improper Engineering Workshop";
-	req_one_access_txt = "0"
+	name = "\improper Engineering Workshop"
 	},
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
@@ -21952,8 +21796,7 @@
 	desc = "A remote control-switch for opening the engines blast doors.";
 	id = "rad_door";
 	name = "Reactor Radiation Shielding control";
-	pixel_x = 30;
-	req_access_txt = "7"
+	pixel_x = 30
 	},
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
@@ -22045,10 +21888,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/free_access{
 	dir = 1;
-	name = "\improper Engine Reactor";
-	req_access_txt = "0"
+	name = "\improper Engine Reactor"
 	},
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
@@ -22073,10 +21915,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 4;
-	name = "\improper Engine Reactor Control";
-	req_one_access_txt = "0"
+	name = "\improper Engine Reactor Control"
 	},
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
@@ -22574,10 +22415,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Power Substation";
-	req_one_access_txt = "0"
+	name = "\improper Power Substation"
 	},
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
@@ -22657,10 +22497,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Power Substation";
-	req_one_access_txt = "0"
+	name = "\improper Power Substation"
 	},
 /turf/open/floor/plating,
 /area/bigredv2/outside/engineering)
@@ -22742,8 +22581,7 @@
 "bwG" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
-	name = "\improper Eta Lab Storage Bay";
-	req_one_access_txt = "0"
+	name = "\improper Eta Lab Storage Bay"
 	},
 /turf/open/floor/marking/loadingarea{
 	dir = 2
@@ -22760,10 +22598,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/mainship/research{
+/obj/machinery/door/airlock/mainship/research/free_access{
 	dir = 1;
-	name = "\improper Eta Lab Decontamination";
-	req_access_txt = "0"
+	name = "\improper Eta Lab Decontamination"
 	},
 /turf/open/floor/freezer,
 /area/bigredv2/outside/nanotrasen_lab/inside)
@@ -22924,10 +22761,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/research/glass{
+/obj/machinery/door/airlock/mainship/research/glass/free_access{
 	dir = 4;
-	name = "\improper Eta Lab Robotics";
-	req_access_txt = "0"
+	name = "\improper Eta Lab Robotics"
 	},
 /turf/open/floor,
 /area/bigredv2/outside/nanotrasen_lab/inside)
@@ -23226,10 +23062,9 @@
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "byE" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/research/glass{
+/obj/machinery/door/airlock/mainship/research/glass/free_access{
 	dir = 1;
-	name = "\improper Eta Lab Technical Storage";
-	req_access_txt = "0"
+	name = "\improper Eta Lab Technical Storage"
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
@@ -23317,10 +23152,9 @@
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "byZ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/research/glass{
+/obj/machinery/door/airlock/mainship/research/glass/free_access{
 	dir = 1;
-	name = "\improper Eta Lab Robotics";
-	req_access_txt = "0"
+	name = "\improper Eta Lab Robotics"
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
@@ -23424,10 +23258,9 @@
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "bzs" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/research/glass/free_access{
 	dir = 1;
-	name = "\improper Eta Lab Armory";
-	req_access_txt = "0"
+	name = "\improper Eta Lab Armory"
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
@@ -23558,19 +23391,17 @@
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "bzQ" = (
-/obj/machinery/door/airlock/mainship/research/glass{
+/obj/machinery/door/airlock/mainship/research/glass/free_access{
 	dir = 1;
-	name = "\improper Eta Lab Server";
-	req_access_txt = "0"
+	name = "\improper Eta Lab Server"
 	},
 /turf/open/floor/tile/darkish,
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "bzR" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 1;
-	name = "\improper Eta Lab Security Office";
-	req_access_txt = "0"
+	name = "\improper Eta Lab Security Office"
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
@@ -23701,10 +23532,9 @@
 /turf/open/floor/tile/darkish,
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "bAw" = (
-/obj/machinery/door/airlock/mainship/research/glass{
+/obj/machinery/door/airlock/mainship/research/glass/free_access{
 	dir = 4;
-	name = "\improper Eta Lab Server";
-	req_access_txt = "0"
+	name = "\improper Eta Lab Server"
 	},
 /turf/open/floor/tile/darkish,
 /area/bigredv2/outside/nanotrasen_lab/inside)
@@ -23752,10 +23582,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/research/glass{
+/obj/machinery/door/airlock/mainship/research/glass/free_access{
 	dir = 4;
-	name = "\improper Eta Lab Director's Office";
-	req_access_txt = "0"
+	name = "\improper Eta Lab Director's Office"
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
@@ -23999,9 +23828,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	name = "\improper Eta Lab Maintenance Storage";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "\improper Eta Lab Maintenance Storage"
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
@@ -24045,18 +23873,16 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/research/glass{
+/obj/machinery/door/airlock/mainship/research/glass/free_access{
 	dir = 4;
-	name = "\improper Eta Lab Biology Laboratory";
-	req_access_txt = "0"
+	name = "\improper Eta Lab Biology Laboratory"
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "bBH" = (
-/obj/machinery/door/airlock/mainship/research/glass{
+/obj/machinery/door/airlock/mainship/research/glass/free_access{
 	dir = 4;
-	name = "\improper Eta Lab Cell";
-	req_access_txt = "0"
+	name = "\improper Eta Lab Cell"
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
@@ -24102,10 +23928,9 @@
 	},
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "bBS" = (
-/obj/machinery/door/airlock/mainship/research/glass{
+/obj/machinery/door/airlock/mainship/research/glass/free_access{
 	dir = 1;
-	name = "\improper Eta Lab Cell";
-	req_access_txt = "0"
+	name = "\improper Eta Lab Cell"
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
@@ -24294,10 +24119,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/research/glass{
+/obj/machinery/door/airlock/mainship/research/glass/free_access{
 	dir = 4;
-	name = "\improper Eta Lab Xenobiology Lab";
-	req_access_txt = "0"
+	name = "\improper Eta Lab Xenobiology Lab"
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
@@ -24400,8 +24224,7 @@
 "bCR" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
-	name = "\improper Eta Lab";
-	req_one_access_txt = "0"
+	name = "\improper Eta Lab"
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
@@ -24638,18 +24461,16 @@
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "bDO" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/research/glass{
+/obj/machinery/door/airlock/mainship/research/glass/free_access{
 	dir = 1;
-	name = "\improper Eta Lab Research Office";
-	req_access_txt = "0"
+	name = "\improper Eta Lab Research Office"
 	},
 /turf/open/floor/wood,
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "bDP" = (
-/obj/machinery/door/airlock/mainship/research/glass{
+/obj/machinery/door/airlock/mainship/research/glass/free_access{
 	dir = 1;
-	name = "\improper Eta Lab Canteen";
-	req_access_txt = "0"
+	name = "\improper Eta Lab Canteen"
 	},
 /turf/open/floor,
 /area/bigredv2/outside/nanotrasen_lab/inside)
@@ -24853,10 +24674,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/research/glass{
+/obj/machinery/door/airlock/mainship/research/glass/free_access{
 	dir = 4;
-	name = "\improper Eta Lab Relaxation";
-	req_access_txt = "0"
+	name = "\improper Eta Lab Relaxation"
 	},
 /turf/open/floor,
 /area/bigredv2/outside/nanotrasen_lab/inside)
@@ -25004,9 +24824,8 @@
 /turf/closed/wall/r_wall/unmeltable,
 /area/bigredv2/outside/se)
 "dcO" = (
-/obj/machinery/door/airlock/mainship/research{
-	name = "\improper Virology Lab Administration";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/research/free_access{
+	name = "\improper Virology Lab Administration"
 	},
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/virology)
@@ -25018,7 +24837,7 @@
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "dlo" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 1;
 	name = "\improper General Store"
 	},
@@ -25285,10 +25104,9 @@
 /turf/open/floor/plating,
 /area/bigredv2/outside/space_port)
 "ggV" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 4;
-	name = "\improper Chief Engineer's Office";
-	req_one_access_txt = "0"
+	name = "\improper Chief Engineer's Office"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -25345,10 +25163,9 @@
 /turf/closed/mineral/bigred,
 /area/bigredv2/outside/nw)
 "gQc" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 4;
-	name = "\improper Engineering Workshop";
-	req_one_access_txt = "0"
+	name = "\improper Engineering Workshop"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -25369,10 +25186,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 4;
-	name = "\improper Engineering SMES";
-	req_one_access_txt = "0"
+	name = "\improper Engineering SMES"
 	},
 /turf/open/floor/plating,
 /area/bigredv2/outside/engineering)
@@ -34798,7 +34614,6 @@ aac
 aac
 aac
 aab
-aaa
 aaa
 aaa
 aaa

--- a/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -778,10 +778,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Colony Engineering Electric Storage";
-	req_access_txt = "100"
+	name = "\improper Colony Engineering Electric Storage"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/engineering/electric)
@@ -916,12 +915,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/locked/free_access{
 	dir = 4;
-	icon_state = "door_locked";
-	locked = 1;
-	name = "Colony Requesitions Storage Pod";
-	req_access_txt = "100"
+	name = "\improper Colony Requesitions Storage Pod"
 	},
 /turf/open/floor/plating/icefloor,
 /area/ice_colony/surface/requesitions)
@@ -1427,9 +1423,8 @@
 /turf/open/floor/plating,
 /area/ice_colony/surface/engineering)
 "aeL" = (
-/obj/machinery/door/airlock/mainship/engineering{
-	name = "\improper Colony Engineering Generator Room";
-	req_access_txt = "100"
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Colony Engineering Generator Room"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/engineering/generator)
@@ -1490,10 +1485,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Colony Engineering Tool Storage";
-	req_access_txt = "100"
+	name = "\improper Colony Engineering Tool Storage"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/engineering/tool)
@@ -1655,10 +1649,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 4;
-	name = "\improper Colony Engineering Material Storage";
-	req_access_txt = "100"
+	name = "\improper Colony Engineering Material Storage"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/engineering)
@@ -2151,9 +2144,8 @@
 	},
 /area/ice_colony/exterior/surface/valley/northwest)
 "agD" = (
-/obj/machinery/door/airlock/mainship/engineering{
-	name = "\improper Colony Engineering Generator Room";
-	req_access_txt = "100"
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Colony Engineering Generator Room"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -2329,17 +2321,13 @@
 /turf/closed/ice_rock/southWall,
 /area/ice_colony/exterior/surface/valley/north)
 "agY" = (
-/obj/machinery/vending/tool{
-	req_access_txt = "102"
-	},
+/obj/machinery/vending/tool,
 /turf/open/floor/tile/dark/yellow2{
 	dir = 1
 	},
 /area/ice_colony/surface/substation/smes)
 "agZ" = (
-/obj/machinery/vending/engivend{
-	req_access_txt = "102"
-	},
+/obj/machinery/vending/engivend,
 /turf/open/floor/tile/dark/yellow2{
 	dir = 1
 	},
@@ -2455,10 +2443,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 4;
-	name = "\improper Colony Engineering Locker Room";
-	req_access_txt = "100"
+	name = "\improper Colony Engineering Locker Room"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/engineering)
@@ -2941,10 +2928,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Colony Engineering";
-	req_access_txt = "100"
+	name = "\improper Colony Engineering"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/engineering)
@@ -2958,10 +2944,9 @@
 /area/ice_colony/surface/engineering)
 "aiA" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Colony Engineering Backup Power Storage";
-	req_access_txt = "100"
+	name = "\improper Colony Engineering Backup Power Storage"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/engineering)
@@ -3073,11 +3058,9 @@
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/hydroponics/north)
 "aiP" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 4;
-	name = "\improper Hydroponics North Wing Dome";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Hydroponics North Wing Dome"
 	},
 /turf/open/floor/tile/darkgreen/darkgreen2{
 	dir = 8
@@ -3303,12 +3286,9 @@
 /turf/open/floor/tile/dark,
 /area/ice_colony/exterior/surface/landing_pad2)
 "ajq" = (
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/locked/free_access{
 	dir = 4;
-	icon_state = "door_locked";
-	locked = 1;
-	name = "Colony Requesitions Storage Pod";
-	req_access_txt = "100"
+	name = "\improper Colony Requesitions Storage Pod"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -3466,10 +3446,9 @@
 /area/ice_colony/surface/engineering)
 "ajE" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Colony Power Substation SMES";
-	req_access_txt = "100"
+	name = "\improper Colony Power Substation SMES"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/substation/smes)
@@ -4035,10 +4014,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Colony Power Substation";
-	req_access_txt = "100"
+	name = "\improper Colony Power Substation"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/substation/smes)
@@ -4049,8 +4027,7 @@
 /area/ice_colony/underground/hangar)
 "alf" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	name = "\improper Hydroponics Dome South Wing";
-	req_access_txt = "100"
+	name = "\improper Hydroponics Dome South Wing"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark2,
@@ -4744,11 +4721,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 4;
-	name = "\improper Hydroponics North Wing Technical Storage";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Hydroponics North Wing Technical Storage"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/hydroponics/north)
@@ -4977,15 +4952,11 @@
 /turf/open/floor/tile/dark/yellow2,
 /area/ice_colony/surface/substation)
 "anQ" = (
-/obj/machinery/vending/assist{
-	req_access_txt = "102"
-	},
+/obj/machinery/vending/assist,
 /turf/open/floor/tile/dark/yellow2,
 /area/ice_colony/surface/substation)
 "anR" = (
-/obj/machinery/vending/assist{
-	req_access_txt = "102"
-	},
+/obj/machinery/vending/assist,
 /turf/open/floor/tile/dark/yellow2{
 	dir = 6
 	},
@@ -5035,9 +5006,7 @@
 "anY" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 4;
-	name = "\improper Toilet Unit";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Toilet Unit"
 	},
 /turf/open/floor/freezer,
 /area/ice_colony/surface/dorms/restroom_w)
@@ -5143,9 +5112,7 @@
 "aom" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 4;
-	name = "\improper Toilet Unit";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Toilet Unit"
 	},
 /turf/open/floor/freezer,
 /area/ice_colony/surface/dorms/restroom_e)
@@ -5171,10 +5138,9 @@
 "aop" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Colony Power Substation";
-	req_access_txt = "100"
+	name = "\improper Colony Power Substation"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -5453,9 +5419,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/engineering{
-	name = "\improper Colony Mining Station";
-	req_access_txt = "100"
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Colony Mining Station"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/surface/mining)
@@ -5514,11 +5479,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 4;
-	name = "\improper Aurora Medical Clinic Recovery Room";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Aurora Medical Clinic Recovery Room"
 	},
 /turf/open/floor/tile/white,
 /area/ice_colony/surface/clinic/treatment)
@@ -5599,11 +5562,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 4;
-	name = "\improper Aurora Medical Clinic Scanning Unit";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Aurora Medical Clinic Scanning Unit"
 	},
 /turf/open/floor/tile/white,
 /area/ice_colony/surface/clinic/treatment)
@@ -6142,11 +6103,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 4;
-	name = "\improper Aurora Medical Clinic Storage";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Aurora Medical Clinic Storage"
 	},
 /turf/open/floor/tile/white,
 /area/ice_colony/surface/clinic/storage)
@@ -6210,9 +6169,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
-	name = "\improper Dormitories Men's Restroom";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Dormitories Men's Restroom"
 	},
 /turf/open/floor/freezer,
 /area/ice_colony/surface/dorms/restroom_w)
@@ -6236,9 +6193,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
-	name = "\improper Dormitories Women's Restroom";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Dormitories Women's Restroom"
 	},
 /turf/open/floor/freezer,
 /area/ice_colony/surface/dorms/restroom_e)
@@ -6575,8 +6530,7 @@
 "arx" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
-	name = "\improper Colony Dormitories";
-	req_access_txt = "100"
+	name = "\improper Colony Dormitories"
 	},
 /turf/open/floor/tile/darkgreen/darkgreen2{
 	dir = 6
@@ -6617,9 +6571,7 @@
 "arF" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
-	name = "\improper Colony Dormitory Unit";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Colony Dormitory Unit"
 	},
 /turf/open/floor/wood,
 /area/ice_colony/surface/dorms)
@@ -6649,9 +6601,7 @@
 "arK" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
-	name = "\improper Colony Dormitory Custodial Closet";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Colony Dormitory Custodial Closet"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/surface/dorms)
@@ -6667,8 +6617,7 @@
 	},
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
-	name = "\improper Colony Dormitories";
-	req_access_txt = "100"
+	name = "\improper Colony Dormitories"
 	},
 /turf/open/floor/tile/darkgreen/darkgreen2{
 	dir = 10
@@ -6981,8 +6930,7 @@
 "asE" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	dir = 4;
-	name = "\improper Aurora Medical Clinic Treatment";
-	req_access_txt = "100"
+	name = "\improper Aurora Medical Clinic Treatment"
 	},
 /turf/open/floor/tile/red/whitered{
 	dir = 8
@@ -7001,11 +6949,9 @@
 	},
 /area/ice_colony/surface/clinic/treatment)
 "asG" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 1;
-	name = "\improper Aurora Medical Clinic Storage";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Aurora Medical Clinic Storage"
 	},
 /turf/open/floor{
 	icon_state = "cafeteria";
@@ -7741,8 +7687,7 @@
 	},
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	dir = 1;
-	name = "\improper Aurora Medical Clinic";
-	req_access_txt = "100"
+	name = "\improper Aurora Medical Clinic"
 	},
 /turf/open/floor/tile/red/whiteredfull,
 /area/ice_colony/surface/clinic/lobby)
@@ -8309,8 +8254,7 @@
 	},
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
-	name = "\improper Hydroponics Dome";
-	req_access_txt = "100"
+	name = "\improper Hydroponics Dome"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/hydroponics/lobby)
@@ -8383,8 +8327,7 @@
 	},
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
-	name = "\improper Colony Dormitories";
-	req_access_txt = "100"
+	name = "\improper Colony Dormitories"
 	},
 /turf/open/floor/tile/darkgreen/darkgreen2{
 	dir = 6
@@ -8490,8 +8433,7 @@
 "awo" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
-	name = "\improper Hydroponics Zoo Dome";
-	req_access_txt = "100"
+	name = "\improper Hydroponics Zoo Dome"
 	},
 /turf/open/floor/tile/darkgreen/darkgreen2,
 /area/ice_colony/surface/hydroponics/lobby)
@@ -8522,8 +8464,7 @@
 	},
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
-	name = "\improper Hydroponics Dome";
-	req_access_txt = "100"
+	name = "\improper Hydroponics Dome"
 	},
 /turf/open/floor/tile/darkgreen/darkgreen2,
 /area/ice_colony/surface/hydroponics/lobby)
@@ -8653,8 +8594,7 @@
 	},
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
-	name = "\improper Colony Dormitories";
-	req_access_txt = "100"
+	name = "\improper Colony Dormitories"
 	},
 /turf/open/floor/tile/darkgreen/darkgreen2{
 	dir = 10
@@ -9436,8 +9376,7 @@
 "ayS" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
-	name = "\improper Underground Power Substation";
-	req_access_txt = "100"
+	name = "\improper Underground Power Substation"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -9697,9 +9636,8 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/engineering{
-	name = "\improper Colony Disposals";
-	req_access_txt = "100"
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Colony Disposals"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/disposals)
@@ -9953,8 +9891,7 @@
 "aAp" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	name = "\improper Colony Dormitories Lavatory";
-	req_access_txt = "100"
+	name = "\improper Colony Dormitories Lavatory"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/dorms/lavatory)
@@ -10006,8 +9943,7 @@
 "aAw" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	name = "\improper Colony Dormitories Canteen";
-	req_access_txt = "100"
+	name = "\improper Colony Dormitories Canteen"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/dorms/canteen)
@@ -10215,11 +10151,9 @@
 	},
 /area/ice_colony/surface/disposals)
 "aBf" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 4;
-	name = "\improper Hydroponics South Wing Dome";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Hydroponics South Wing Dome"
 	},
 /turf/open/floor/tile/darkgreen/darkgreen2{
 	dir = 8
@@ -10466,8 +10400,7 @@
 	},
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
-	name = "\improper Colony Dormitories";
-	req_access_txt = "100"
+	name = "\improper Colony Dormitories"
 	},
 /turf/open/floor/tile/dark/blue2{
 	dir = 6
@@ -10690,9 +10623,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/multi_tile/mainship/comdoor{
-	name = "\improper Colony Administration";
-	req_access_txt = "100"
+/obj/machinery/door/airlock/multi_tile/mainship/comdoor/free_access{
+	name = "\improper Colony Administration"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/command/checkpoint)
@@ -11061,10 +10993,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 4;
-	name = "\improper Colony Security Checkpoint";
-	req_access_txt = "100"
+	name = "\improper Colony Security Checkpoint"
 	},
 /turf/open/floor/tile/dark/red2{
 	dir = 8
@@ -11213,9 +11144,7 @@
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
-	name = "\improper Colony Dormitory Unit";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Colony Dormitory Unit"
 	},
 /turf/open/floor/wood,
 /area/ice_colony/surface/dorms)
@@ -11426,10 +11355,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/free_access{
 	dir = 4;
-	name = "Colony Garage";
-	req_access_txt = "100"
+	name = "\improper Colony Garage"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/garage/one)
@@ -11553,8 +11481,7 @@
 "aEo" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
-	name = "\improper Colony Garage";
-	req_access_txt = "100"
+	name = "\improper Colony Garage"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/garage/repair)
@@ -11883,11 +11810,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 4;
-	name = "\improper Hydroponics South Wing Technical Storage";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Hydroponics South Wing Technical Storage"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -12087,9 +12012,8 @@
 	id = "colony_admin_top";
 	name = "\improper Colony Administration Blast Door"
 	},
-/obj/machinery/door/airlock/multi_tile/mainship/comdoor{
-	name = "\improper Colony Offices";
-	req_access_txt = "100"
+/obj/machinery/door/airlock/multi_tile/mainship/comdoor/free_access{
+	name = "\improper Colony Offices"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/command/control/office)
@@ -12219,10 +12143,9 @@
 /area/ice_colony/surface/garage/repair)
 "aFY" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Colony Garage Repair Station";
-	req_access_txt = "100"
+	name = "\improper Colony Garage Repair Station"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/garage/repair)
@@ -12563,10 +12486,9 @@
 	id = "colony_admin_top";
 	name = "\improper Colony Administration Blast Door"
 	},
-/obj/machinery/door/airlock/multi_tile/mainship/comdoor{
+/obj/machinery/door/airlock/multi_tile/mainship/comdoor/free_access{
 	dir = 1;
-	name = "\improper Colony Control Center";
-	req_access_txt = "100"
+	name = "\improper Colony Control Center"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/command/control)
@@ -12674,10 +12596,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/free_access{
 	dir = 2;
-	name = "Colony Garage";
-	req_access_txt = "100"
+	name = "\improper Colony Garage"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/garage/one)
@@ -12727,10 +12648,9 @@
 	},
 /area/ice_colony/surface/garage/one)
 "aHc" = (
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/free_access{
 	dir = 2;
-	name = "Colony Garage";
-	req_access_txt = "100"
+	name = "\improper Colony Garage"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/garage/two)
@@ -12992,9 +12912,8 @@
 	name = "\improper Forced Blast Door";
 	opacity = 0
 	},
-/obj/machinery/door/airlock/multi_tile/mainship/comdoor{
-	name = "\improper Colony Crisis Room";
-	req_access_txt = "100"
+/obj/machinery/door/airlock/multi_tile/mainship/comdoor/free_access{
+	name = "\improper Colony Crisis Room"
 	},
 /turf/open/floor/wood,
 /area/ice_colony/surface/command/crisis)
@@ -13017,10 +12936,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/mainship/command{
+/obj/machinery/door/airlock/mainship/command/free_access{
 	dir = 1;
-	name = "\improper Colony Administration Office";
-	req_access_txt = "100"
+	name = "\improper Colony Administration Office"
 	},
 /turf/open/floor/wood,
 /area/ice_colony/surface/command/control/pv1)
@@ -13035,10 +12953,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/command{
+/obj/machinery/door/airlock/mainship/command/free_access{
 	dir = 1;
-	name = "\improper Colony Administration Office";
-	req_access_txt = "100"
+	name = "\improper Colony Administration Office"
 	},
 /turf/open/floor/wood,
 /area/ice_colony/surface/command/control/pv2)
@@ -13073,10 +12990,7 @@
 /obj/machinery/door_control{
 	id = "st_17";
 	name = "Storage Unit Lock";
-	normaldoorcontrol = 1;
-	pixel_x = 24;
-	req_access_txt = "100";
-	specialfunctions = 4
+	pixel_x = 24
 	},
 /turf/open/floor/tile/vault{
 	dir = 8
@@ -13086,10 +13000,7 @@
 /obj/machinery/door_control{
 	id = "st_17";
 	name = "Storage Unit Lock";
-	normaldoorcontrol = 1;
-	pixel_x = -24;
-	req_access_txt = "100";
-	specialfunctions = 4
+	pixel_x = -24
 	},
 /turf/open/floor/plating/ground/snow/layer2,
 /area/ice_colony/surface/storage_unit/power)
@@ -13397,8 +13308,7 @@
 /area/ice_colony/exterior/surface/valley/southeast)
 "aIT" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	name = "\improper Hydroponics Dome South Wing";
-	req_access_txt = "100"
+	name = "\improper Hydroponics Dome South Wing"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark2,
@@ -13479,8 +13389,7 @@
 "aJf" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
-	name = "\improper Colony Dormitories";
-	req_access_txt = "100"
+	name = "\improper Colony Dormitories"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -13977,8 +13886,7 @@
 /area/ice_colony/exterior/surface/clearing/north)
 "aKM" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	name = "\improper Hydroponics Dome North Wing";
-	req_access_txt = "100"
+	name = "\improper Hydroponics Dome North Wing"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/hydroponics/north)
@@ -14021,13 +13929,8 @@
 /turf/open/floor/plating,
 /area/ice_colony/underground/maintenance/north)
 "aKT" = (
-/obj/machinery/door/airlock/mainship/maint{
-	icon_state = "door_locked";
-	id = "undergroundhangarwest";
-	locked = 1;
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "\improper Underground Maintenance"
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -14423,8 +14326,7 @@
 	},
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
-	name = "\improper Anti-Freeze Canteen";
-	req_access_txt = "100"
+	name = "\improper Anti-Freeze Canteen"
 	},
 /turf/open/floor/wood,
 /area/ice_colony/surface/bar/canteen)
@@ -14594,8 +14496,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	name = "\improper Hydroponics Dome North Wing";
-	req_access_txt = "100"
+	name = "\improper Hydroponics Dome North Wing"
 	},
 /turf/open/floor/tile/dark,
 /area/ice_colony/surface/hydroponics/north)
@@ -14677,10 +14578,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 4;
-	name = "\improper Colony Security Checkpoint";
-	req_access_txt = "100"
+	name = "\improper Colony Security Checkpoint"
 	},
 /turf/open/floor/tile/dark/red2{
 	dir = 8
@@ -15041,13 +14941,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/locked/free_access{
 	dir = 2;
-	icon_state = "door_locked";
 	id = "st_18";
-	locked = 1;
-	name = "Disposals Storage Unit";
-	req_access_txt = "100"
+	name = "\improper Disposals Storage Unit"
 	},
 /turf/open/floor/tile/vault{
 	dir = 8
@@ -15252,10 +15149,7 @@
 /obj/machinery/door_control{
 	id = "st_18";
 	name = "Storage Unit Lock";
-	normaldoorcontrol = 1;
-	pixel_y = 24;
-	req_access_txt = "100";
-	specialfunctions = 4
+	pixel_y = 24
 	},
 /turf/open/floor/tile/vault{
 	dir = 8
@@ -15287,10 +15181,9 @@
 /turf/closed/wall,
 /area/ice_colony/surface/research)
 "aOp" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Omicron Custodial Storage";
-	req_access_txt = "100"
+	name = "\improper Omicron Custodial Storage"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/surface/research)
@@ -15336,10 +15229,7 @@
 /obj/machinery/door_control{
 	id = "st_19";
 	name = "Storage Unit Lock";
-	normaldoorcontrol = 1;
-	pixel_y = -24;
-	req_access_txt = "103";
-	specialfunctions = 4
+	pixel_y = -24
 	},
 /turf/open/floor/tile/vault{
 	dir = 8
@@ -15658,10 +15548,7 @@
 /obj/machinery/door_control{
 	id = "research_entrance";
 	name = "Research Entrance Lock";
-	normaldoorcontrol = 1;
-	pixel_x = 24;
-	req_access_txt = "103";
-	specialfunctions = 4
+	pixel_x = 24
 	},
 /turf/open/floor/tile/dark/brown2{
 	dir = 5
@@ -15701,8 +15588,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	name = "\improper Hydroponics Dome South Wing";
-	req_access_txt = "100"
+	name = "\improper Hydroponics Dome South Wing"
 	},
 /turf/open/floor/tile/dark,
 /area/ice_colony/surface/hydroponics/south)
@@ -15723,13 +15609,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/locked/free_access{
 	dir = 2;
-	icon_state = "door_locked";
 	id = "st_19";
-	locked = 1;
-	name = "Research Storage Unit";
-	req_access_txt = "100"
+	name = "\improper Research Storage Unit";
+	
 	},
 /turf/open/floor/tile/vault{
 	dir = 8
@@ -15782,8 +15666,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	name = "\improper Security Checkpoint";
-	req_access_txt = "100"
+	name = "\improper Security Checkpoint"
 	},
 /turf/open/floor/tile/dark/brown2{
 	dir = 9
@@ -16024,13 +15907,11 @@
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/research)
 "aQm" = (
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/locked/free_access{
 	dir = 4;
-	icon_state = "door_locked";
 	id = "research_entrance";
-	locked = 1;
-	name = "Omicron Research Dome";
-	req_access_txt = "100"
+	name = "\improper Omicron Research Dome";
+	
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -16204,9 +16085,8 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/engineering{
-	name = "\improper Aerodrome Hangar Alpha";
-	req_access_txt = "100"
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Aerodrome Hangar Alpha"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/hangar/alpha)
@@ -16643,11 +16523,9 @@
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/research/field_gear)
 "aRK" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	name = "\improper Omicron Field Gear Storage";
-	icon_state = "door_closed";
-	dir = 8;
-	req_access_txt = "100"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -16815,9 +16693,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
-	name = "\improper Anti-Freeze Canteen Freezer";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Anti-Freeze Canteen Freezer"
 	},
 /turf/open/floor/freezer,
 /area/ice_colony/surface/bar/canteen)
@@ -18075,10 +17951,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 4;
-	name = "\improper Omicron Temporary Sample Storage";
-	req_access_txt = "100"
+	name = "\improper Omicron Temporary Sample Storage"
 	},
 /turf/open/floor/tile/dark/yellow2{
 	dir = 4
@@ -18572,9 +18447,8 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/engineering{
-	name = "\improper Aerodrome Hangar Beta";
-	req_access_txt = "100"
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Aerodrome Hangar Beta"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/hangar/beta)
@@ -18686,10 +18560,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Omicron Technical Storage";
-	req_access_txt = "100"
+	name = "\improper Omicron Technical Storage"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -19811,8 +19684,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	name = "\improper Aerodrome Hangar";
-	req_access_txt = "100"
+	name = "\improper Aerodrome Hangar"
 	},
 /turf/open/floor/tile/dark/brown2{
 	dir = 10
@@ -20595,8 +20467,7 @@
 "bcj" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	dir = 4;
-	name = "\improper Colony Xenoarcheology Outpost";
-	req_access_txt = "100"
+	name = "\improper Colony Xenoarcheology Outpost"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/excavation)
@@ -20790,10 +20661,8 @@
 	d1 = 4;
 	d2 = 8
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/tile/dark,
 /area/ice_colony/underground/westroadtunnel)
@@ -20826,10 +20695,8 @@
 /turf/open/floor/tile/dark,
 /area/ice_colony/underground/westroadtunnel)
 "bcV" = (
-/obj/machinery/door/airlock/mainship/maint{
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/tile/dark,
 /area/ice_colony/underground/westroadtunnel)
@@ -20961,13 +20828,8 @@
 	},
 /area/ice_colony/surface/excavation)
 "bdp" = (
-/obj/machinery/door/airlock/mainship/maint{
-	icon_state = "door_locked";
-	id = "Colony_PMC_Hangar";
-	locked = 1;
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "\improper Underground Maintenance"
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -21106,9 +20968,8 @@
 	},
 /area/ice_colony/underground/responsehangar)
 "bdI" = (
-/obj/machinery/door/airlock/mainship/security/glass{
-	name = "\improper Security Prep";
-	req_access_txt = "100"
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	name = "\improper Security Prep"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -21345,8 +21206,7 @@
 "ben" = (
 /obj/effect/decal/cleanable/blood/xtracks,
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	name = "\improper Anti-Freeze Bar";
-	req_access_txt = "100"
+	name = "\improper Anti-Freeze Bar"
 	},
 /turf/open/floor/wood,
 /area/ice_colony/surface/bar/bar)
@@ -21491,13 +21351,8 @@
 /turf/open/floor/plating,
 /area/ice_colony/underground/maintenance/north)
 "beJ" = (
-/obj/machinery/door/airlock/mainship/maint{
-	icon_state = "door_locked";
-	id = "undergroundhangarwest";
-	locked = 1;
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/hangar)
@@ -21740,11 +21595,9 @@
 /turf/open/floor/plating,
 /area/ice_colony/underground/maintenance/north)
 "bfv" = (
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 1;
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/maintenance/north)
@@ -21777,10 +21630,7 @@
 /obj/machinery/door_control{
 	id = "st_19";
 	name = "Storage Unit Lock";
-	normaldoorcontrol = 1;
-	pixel_y = 24;
-	req_access_txt = "103";
-	specialfunctions = 4
+	pixel_y = 24
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/ice_colony/exterior/surface/valley/southwest)
@@ -21796,11 +21646,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 1;
-	name = "\improper Underground Requesitions Office";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Underground Requesitions Office"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/requesition/lobby)
@@ -22097,11 +21945,9 @@
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/excavation)
 "bgt" = (
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 1;
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/requesition)
@@ -22238,9 +22084,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
-	name = "\improper Anti-Freeze Bar Freezer";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Anti-Freeze Bar Freezer"
 	},
 /turf/open/floor/freezer,
 /area/ice_colony/surface/bar/bar)
@@ -22426,10 +22270,9 @@
 	},
 /area/ice_colony/underground/requesition)
 "bhp" = (
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/free_access{
 	dir = 2;
-	name = "Underground Hangar Power Substation";
-	req_access_txt = "100"
+	name = "\improper Underground Hangar Power Substation"
 	},
 /turf/open/floor/plating/icefloor,
 /area/ice_colony/underground/hangar)
@@ -22651,10 +22494,7 @@
 /obj/machinery/door_control{
 	id = "req_sec_storage";
 	name = "Requesition Secure Storage";
-	normaldoorcontrol = 1;
-	pixel_y = -24;
-	req_access_txt = "100";
-	specialfunctions = 4
+	pixel_y = -24
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -22780,8 +22620,7 @@
 "bio" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	name = "\improper Underground Requesitions Bay";
-	req_access_txt = "100"
+	name = "\improper Underground Requesitions Bay"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/requesition)
@@ -22792,14 +22631,10 @@
 /obj/structure/table/woodentable{
 	icon_state = "reinf_table"
 	},
-/obj/machinery/door/window/brigdoor/westleft{
-	dir = 1;
-	icon_state = "leftsecure";
-	id = null;
+/obj/machinery/door/window/brigdoor/southleft{
 	name = "Requesitions Desk"
 	},
-/obj/machinery/door/window/northright{
-	dir = 2;
+/obj/machinery/door/window/southright{
 	name = "Requesitions Desk"
 	},
 /obj/item/tool/pen/blue{
@@ -22859,8 +22694,7 @@
 "bix" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
-	name = "\improper Underground Power Substation";
-	req_access_txt = "100"
+	name = "\improper Underground Power Substation"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -22972,10 +22806,7 @@
 /obj/machinery/door_control{
 	id = "req_sec_storage";
 	name = "Requesition Secure Storage";
-	normaldoorcontrol = 1;
-	pixel_y = 24;
-	req_access_txt = "100";
-	specialfunctions = 4
+	pixel_y = 24
 	},
 /turf/open/floor/tile/dark/brown2{
 	dir = 1
@@ -23238,10 +23069,8 @@
 	},
 /area/ice_colony/underground/requesition/lobby)
 "bju" = (
-/obj/machinery/door/airlock/mainship/maint{
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "\improper Underground Maintenance"
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -23259,14 +23088,9 @@
 /turf/open/floor/plating,
 /area/ice_colony/underground/maintenance/north)
 "bjw" = (
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 1;
-	icon_state = "door_locked";
-	id = "undergroundhangarpower";
-	locked = 1;
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/hangar)
@@ -23604,11 +23428,9 @@
 /turf/closed/wall/r_wall,
 /area/ice_colony/underground/crew/chapel)
 "bkD" = (
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 1;
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/crew/chapel)
@@ -23635,14 +23457,6 @@
 "bkJ" = (
 /turf/closed/wall/r_wall,
 /area/ice_colony/underground/maintenance/research)
-"bkK" = (
-/obj/machinery/door/airlock/mainship/maint{
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
-	},
-/turf/open/floor/plating,
-/area/ice_colony/underground/hallway/north_west)
 "bkL" = (
 /obj/machinery/light{
 	dir = 4
@@ -23697,8 +23511,7 @@
 /area/ice_colony/underground/crew/chapel)
 "bkS" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	name = "\improper Underground Requesitions Lobby";
-	req_access_txt = "100"
+	name = "\improper Underground Requesitions Lobby"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/hallway/north_west)
@@ -23721,11 +23534,9 @@
 /turf/closed/wall/r_wall/unmeltable,
 /area/ice_colony/underground/hallway/north_west)
 "bkX" = (
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 1;
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/crew/morgue)
@@ -23794,13 +23605,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/locked/free_access{
 	dir = 4;
-	icon_state = "door_locked";
 	id = "st_17";
-	locked = 1;
-	name = "Power Storage Unit";
-	req_access_txt = "100"
+	name = "\improper Power Storage Unit"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -23810,11 +23618,9 @@
 	},
 /area/ice_colony/surface/storage_unit/power)
 "blh" = (
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 1;
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/requesition/sec_storage)
@@ -24253,10 +24059,8 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/hallway/north_west)
@@ -24629,11 +24433,9 @@
 	},
 /area/ice_colony/underground/hallway/north_west)
 "bnA" = (
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 1;
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/hallway/north_west)
@@ -25086,10 +24888,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/free_access{
 	dir = 4;
-	name = "Underground Morgue";
-	req_access_txt = "100"
+	name = "\improper Underground Morgue"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/crew/morgue)
@@ -25389,9 +25190,7 @@
 	},
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 4;
-	name = "\improper Underground Requesitions Freezer";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Underground Requesitions Freezer"
 	},
 /turf/open/floor/freezer,
 /area/ice_colony/underground/requesition/storage)
@@ -25526,9 +25325,8 @@
 /area/ice_colony/underground/hallway/south_east)
 "bpY" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor/westleft{
+/obj/machinery/door/window/brigdoor/eastleft{
 	icon_state = "leftsecure";
-	dir = 4;
 	id = "brg"
 	},
 /obj/machinery/door/window/brigdoor/westleft{
@@ -25694,10 +25492,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/free_access{
 	dir = 2;
-	name = "Underground Morgue";
-	req_access_txt = "100"
+	name = "\improper Underground Morgue"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/crew/morgue)
@@ -25708,11 +25505,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 1;
-	name = "\improper Underground Library";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Underground Library"
 	},
 /turf/open/floor/wood,
 /area/ice_colony/underground/crew/library)
@@ -25972,8 +25767,7 @@
 /area/ice_colony/underground/hallway/north_west)
 "brm" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	name = "\improper Underground Sports Center";
-	req_access_txt = "100"
+	name = "\improper Underground Sports Center"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/crew/bball)
@@ -26026,10 +25820,8 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/engineering)
@@ -26301,8 +26093,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	dir = 4;
-	name = "\improper Underground Medical Laboratory";
-	req_access_txt = "100"
+	name = "\improper Underground Medical Laboratory"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/medical/lobby)
@@ -26359,8 +26150,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	name = "\improper Underground Sports Center";
-	req_access_txt = "100"
+	name = "\improper Underground Sports Center"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/crew/bball)
@@ -26523,11 +26313,9 @@
 /area/ice_colony/underground/medical/treatment)
 "bsP" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 1;
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/hallway/north_west)
@@ -26537,8 +26325,7 @@
 "bsR" = (
 /obj/structure/table/reinforced,
 /obj/structure/paper_bin,
-/obj/machinery/door/window/brigdoor/westleft{
-	dir = 2;
+/obj/machinery/door/window/brigdoor/southleft{
 	icon_state = "leftsecure";
 	id = "brg";
 	name = "Security Desk"
@@ -26559,10 +26346,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 1;
-	name = "\improper Underground Security Checkpoint";
-	req_access_txt = "100"
+	name = "\improper Underground Security Checkpoint"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/reception/checkpoint_north)
@@ -26623,8 +26409,7 @@
 	},
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	dir = 1;
-	name = "\improper Underground Medical Laboratory";
-	req_access_txt = "100"
+	name = "\improper Underground Medical Laboratory"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/medical/lobby)
@@ -27111,10 +26896,8 @@
 /turf/open/floor/wood,
 /area/ice_colony/underground/security/marshal)
 "bus" = (
-/obj/machinery/door/airlock/mainship/maint{
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/reception/checkpoint_north)
@@ -27250,8 +27033,7 @@
 "buI" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	dir = 1;
-	name = "\improper Underground Medical Laboratory";
-	req_access_txt = "100"
+	name = "\improper Underground Medical Laboratory"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/medical/lobby)
@@ -27349,11 +27131,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 4;
-	name = "\improper Underground Sports Center";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Underground Sports Center"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/crew/bball)
@@ -27562,8 +27342,7 @@
 	},
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
-	name = "\improper Underground Chapel";
-	req_access_txt = "100"
+	name = "\improper Underground Chapel"
 	},
 /turf/open/floor/wood,
 /area/ice_colony/underground/crew/chapel)
@@ -27689,10 +27468,8 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/medical/or)
@@ -27896,11 +27673,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 4;
-	name = "\improper Underground Medical Laboratory Lobby";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Underground Medical Laboratory Lobby"
 	},
 /turf/open/floor/tile/white,
 /area/ice_colony/underground/medical/lobby)
@@ -28089,11 +27864,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/mainship/medical{
-	dir = 1;
-	name = "Underground Medical Laboratory Operating Theatre";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/medical/or/free_access{
+	name = "\improper Underground Medical Laboratory Operating Theatre";
+	dir = 1
 	},
 /turf/open/floor/tile/white,
 /area/ice_colony/underground/medical/or)
@@ -28137,10 +27910,8 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/medical/treatment)
@@ -28311,11 +28082,9 @@
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/crew/morgue)
 "bxn" = (
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 1;
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/maintenance/central/construction)
@@ -28508,11 +28277,9 @@
 /turf/open/floor/plating,
 /area/ice_colony/underground/maintenance/central)
 "bxQ" = (
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 1;
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/crew/bball)
@@ -28573,11 +28340,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 1;
-	name = "\improper Underground Medical Laboratory";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Underground Medical Laboratory"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/medical/lobby)
@@ -28595,8 +28360,7 @@
 	},
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
-	name = "\improper Underground Power Substation";
-	req_access_txt = "100"
+	name = "\improper Underground Power Substation"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/engineering)
@@ -28829,8 +28593,7 @@
 	},
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
-	name = "\improper Underground Power Substation";
-	req_access_txt = "100"
+	name = "\improper Underground Power Substation"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/engineering)
@@ -29223,11 +28986,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 1;
-	name = "\improper Underground Medical Laboratory Storage";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Underground Medical Laboratory Storage"
 	},
 /turf/open/floor/tile/white,
 /area/ice_colony/underground/medical/storage)
@@ -29409,11 +29170,9 @@
 /area/ice_colony/underground/medical/storage)
 "bAb" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 1;
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/command/center)
@@ -29479,11 +29238,9 @@
 /area/ice_colony/underground/security/marshal)
 "bAn" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 1;
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/maintenance/engineering)
@@ -29633,10 +29390,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 1;
-	name = "\improper Underground Security Detective's Office";
-	req_access_txt = "100"
+	name = "\improper Underground Security Detective's Office"
 	},
 /turf/open/floor/wood,
 /area/ice_colony/underground/security/detective)
@@ -29647,10 +29403,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 1;
-	name = "\improper Underground Security Marshal's Office";
-	req_access_txt = "100"
+	name = "\improper Underground Security Marshal's Office"
 	},
 /turf/open/floor/wood,
 /area/ice_colony/underground/security/marshal)
@@ -29758,8 +29513,7 @@
 "bBe" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
-	name = "\improper Underground Staff Canteen";
-	req_access_txt = "100"
+	name = "\improper Underground Staff Canteen"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/crew/canteen)
@@ -29791,9 +29545,8 @@
 	},
 /area/ice_colony/underground/hallway/south_east)
 "bBi" = (
-/obj/machinery/door/airlock/mainship/security/glass{
-	name = "\improper Underground Security";
-	req_access_txt = "100"
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	name = "\improper Underground Security"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -29851,11 +29604,9 @@
 /area/ice_colony/underground/hallway/north_west)
 "bBq" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 1;
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/medical/storage)
@@ -29898,10 +29649,8 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/crew/canteen)
@@ -30055,8 +29804,7 @@
 	},
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
-	name = "\improper Underground Main Hallway";
-	req_access_txt = "100"
+	name = "\improper Underground Main Hallway"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/hallway/north_west)
@@ -30106,10 +29854,8 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/security/hallway)
@@ -30138,10 +29884,8 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/hallway/north_west)
@@ -30279,9 +30023,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/machinery/door/airlock/mainship/security/glass{
-	name = "\improper Underground Security";
-	req_access_txt = "100"
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	name = "\improper Underground Security"
 	},
 /turf/open/floor/tile/dark/red2{
 	dir = 10
@@ -30875,10 +30618,9 @@
 /turf/open/floor/plating,
 /area/ice_colony/underground/command/center)
 "bDI" = (
-/obj/machinery/door/airlock/mainship/command{
+/obj/machinery/door/airlock/mainship/command/free_access{
 	dir = 1;
-	name = "\improper Underground Command Center";
-	req_access_txt = "100"
+	name = "\improper Underground Command Center"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/command/center)
@@ -31141,20 +30883,16 @@
 	},
 /area/ice_colony/underground/command/center)
 "bEr" = (
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 1;
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/command/pv1)
 "bEs" = (
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 1;
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/command/pv2)
@@ -31410,8 +31148,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	name = "\improper Underground Security Checkpoint";
-	req_access_txt = "100"
+	name = "\improper Underground Security Checkpoint"
 	},
 /turf/open/floor/tile/dark/red2{
 	dir = 8
@@ -31651,20 +31388,16 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/locked/free_access{
 	dir = 2;
-	icon_state = "door_locked";
-	locked = 1;
-	name = "Underground Secure Technical Storage";
-	req_access_txt = "100"
+	name = "\improper Underground Secure Technical Storage"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/storage/highsec)
 "bFP" = (
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 1;
-	name = "\improper Underground Security Checkpoint";
-	req_access_txt = "100"
+	name = "\improper Underground Security Checkpoint"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/command/checkpoint)
@@ -31810,9 +31543,7 @@
 /area/ice_colony/underground/security/hallway)
 "bGg" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor/westleft{
-	icon_state = "leftsecure";
-	dir = 4;
+/obj/machinery/door/window/brigdoor/eastleft{
 	id = "brg"
 	},
 /obj/machinery/door/window/brigdoor/westleft{
@@ -32096,10 +31827,8 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/hallway/south_east)
@@ -32263,10 +31992,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/mainship/command{
+/obj/machinery/door/airlock/mainship/command/free_access{
 	dir = 1;
-	name = "\improper Underground Administration Office";
-	req_access_txt = "100"
+	name = "\improper Underground Administration Office"
 	},
 /turf/open/floor/wood,
 /area/ice_colony/underground/command/pv1)
@@ -32278,10 +32006,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/mainship/command{
+/obj/machinery/door/airlock/mainship/command/free_access{
 	dir = 1;
-	name = "\improper Underground Administration Office";
-	req_access_txt = "100"
+	name = "\improper Underground Administration Office"
 	},
 /turf/open/floor/wood,
 /area/ice_colony/underground/command/pv2)
@@ -32500,10 +32227,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/mainship/security{
+/obj/machinery/door/airlock/mainship/security/free_access{
 	dir = 1;
-	name = "\improper Underground Security Interrogation Observation";
-	req_access_txt = "100"
+	name = "\improper Underground Security Interrogation Observation"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/security/backroom)
@@ -32519,11 +32245,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 4;
-	name = "\improper Underground Medical Laboratory Treatment";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Underground Medical Laboratory Treatment"
 	},
 /turf/open/floor/tile/white,
 /area/ice_colony/underground/medical/treatment)
@@ -32534,8 +32258,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	name = "\improper Underground Security Checkpoint";
-	req_access_txt = "100"
+	name = "\improper Underground Security Checkpoint"
 	},
 /turf/open/floor/tile/dark/red2{
 	dir = 8
@@ -32555,10 +32278,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 1;
-	name = "\improper Underground Security Lobby";
-	req_access_txt = "100"
+	name = "\improper Underground Security Lobby"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/security)
@@ -32810,10 +32532,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/hallway/south_east)
@@ -32843,9 +32563,7 @@
 /turf/open/floor/tile/dark/yellow2,
 /area/ice_colony/underground/storage)
 "bIG" = (
-/obj/machinery/vending/assist{
-	req_access_txt = "102"
-	},
+/obj/machinery/vending/assist,
 /turf/open/floor/tile/dark/yellow2{
 	dir = 6
 	},
@@ -32872,10 +32590,8 @@
 	},
 /area/ice_colony/underground/command/checkpoint)
 "bIL" = (
-/obj/machinery/door/airlock/mainship/maint{
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/storage)
@@ -32992,10 +32708,9 @@
 	},
 /area/ice_colony/underground/command/checkpoint)
 "bJa" = (
-/obj/machinery/door/airlock/multi_tile/mainship/comdoor{
+/obj/machinery/door/airlock/multi_tile/mainship/comdoor/free_access{
 	dir = 1;
-	name = "\improper Colony Offices";
-	req_access_txt = "100"
+	name = "\improper Colony Offices"
 	},
 /turf/open/floor/tile/dark/blue2{
 	dir = 2
@@ -33250,10 +32965,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/hallway/north_west)
@@ -33287,10 +33000,9 @@
 	},
 /area/ice_colony/underground/command/checkpoint)
 "bJG" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Underground Technical Storage";
-	req_access_txt = "100"
+	name = "\improper Underground Technical Storage"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/storage)
@@ -33306,10 +33018,9 @@
 /area/ice_colony/underground/storage)
 "bJI" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Underground Technical Storage";
-	req_access_txt = "100"
+	name = "\improper Underground Technical Storage"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/storage)
@@ -33331,9 +33042,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
-	name = "\improper Underground Men's Barracks";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Underground Men's Barracks"
 	},
 /turf/open/floor/wood,
 /area/ice_colony/underground/crew/dorm_l)
@@ -33346,9 +33055,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
-	name = "\improper Underground Women's Barracks";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Underground Women's Barracks"
 	},
 /turf/open/floor/wood,
 /area/ice_colony/underground/crew/dorm_r)
@@ -33681,17 +33388,15 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 1;
-	name = "\improper Underground Security Armory";
-	req_access_txt = "100"
+	name = "\improper Underground Security Armory"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/security/armory)
 "bKA" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	name = "\improper Underground Security Brig";
-	req_access_txt = "100"
+	name = "\improper Underground Security Brig"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/security/brig)
@@ -33713,8 +33418,7 @@
 "bKD" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
-	name = "\improper Underground Main Hallway";
-	req_access_txt = "100"
+	name = "\improper Underground Main Hallway"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/hallway/north_west)
@@ -33939,10 +33643,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Underground Disposals";
-	req_access_txt = "100"
+	name = "\improper Underground Disposals"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/crew/disposals)
@@ -33956,9 +33659,7 @@
 	},
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
-	name = "\improper Underground Lavatory";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Underground Lavatory"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/crew/lavatory)
@@ -34406,11 +34107,9 @@
 /area/ice_colony/underground/crew/lavatory)
 "bMw" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 1;
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/security)
@@ -34694,10 +34393,8 @@
 /turf/open/floor/carpet,
 /area/ice_colony/underground/crew/leisure)
 "bNn" = (
-/obj/machinery/door/airlock/mainship/maint{
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/reception)
@@ -34784,11 +34481,9 @@
 /area/ice_colony/underground/security/armory)
 "bNx" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 1;
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/hallway/south_east)
@@ -34964,11 +34659,9 @@
 	},
 /area/ice_colony/underground/responsehangar)
 "bNZ" = (
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 1;
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/reception)
@@ -35296,10 +34989,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 1;
-	name = "\improper PMC Hangar Checkpoint";
-	req_access_txt = "100"
+	name = "\improper PMC Hangar Checkpoint"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/responsehangar)
@@ -35599,11 +35291,9 @@
 /area/ice_colony/underground/crew/lavatory)
 "bPT" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 1;
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/crew/leisure)
@@ -35637,28 +35327,22 @@
 /area/ice_colony/underground/security/armory)
 "bPZ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 1;
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/crew/disposals)
 "bQa" = (
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 1;
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/crew/lavatory)
 "bQb" = (
-/obj/machinery/door/airlock/mainship/maint{
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/hallway/south_east)
@@ -35676,9 +35360,8 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/security{
-	name = "\improper Underground Security Showers";
-	req_access_txt = "100"
+/obj/machinery/door/airlock/mainship/security/free_access{
+	name = "\improper Underground Security Showers"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/security/brig)
@@ -35970,12 +35653,9 @@
 	},
 /area/ice_colony/underground/responsehangar)
 "bQZ" = (
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 1;
-	icon_state = "door_locked";
-	locked = 1;
-	name = "\improper Hangar Armoury";
-	req_access_txt = "0"
+	name = "\improper Hangar Armoury"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/hangar/checkpoint)
@@ -36013,8 +35693,7 @@
 	},
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
-	name = "\improper Underground Staff Canteen";
-	req_access_txt = "100"
+	name = "\improper Underground Staff Canteen"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/crew/canteen)
@@ -36085,13 +35764,8 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/ice_colony/exterior/surface/valley/southwest)
 "bRo" = (
-/obj/machinery/door/airlock/mainship/maint{
-	icon_state = "door_locked";
-	id = "undergroundhangarsouth";
-	locked = 1;
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/hallway/north_west)
@@ -36260,9 +35934,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/security{
-	name = "\improper Underground Security Evidence Storage";
-	req_access_txt = "100"
+/obj/machinery/door/airlock/mainship/security/free_access{
+	name = "\improper Underground Security Evidence Storage"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/security/interrogation)
@@ -36340,9 +36013,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/security/glass{
-	name = "\improper Underground Security Interrogation";
-	req_access_txt = "100"
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	name = "\improper Underground Security Interrogation"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/security/interrogation)
@@ -36570,10 +36242,8 @@
 	},
 /area/ice_colony/exterior/underground/caves)
 "bSC" = (
-/obj/machinery/door/airlock/mainship/maint{
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/maintenance/north)
@@ -36611,9 +36281,7 @@
 "bSK" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
-	name = "\improper Toilet Unit";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Toilet Unit"
 	},
 /turf/open/floor/tile/white,
 /area/ice_colony/underground/hallway/north_west)
@@ -36838,12 +36506,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/locked/free_access{
 	dir = 2;
-	icon_state = "door_locked";
-	locked = 1;
-	name = "Underground Secure Technical Storage";
-	req_access_txt = "100"
+	name = "\improper Underground Secure Technical Storage"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/engineering/substation)
@@ -36860,9 +36525,7 @@
 "bTm" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 4;
-	name = "\improper Underground Lavatory";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Underground Lavatory"
 	},
 /turf/open/floor/tile/white,
 /area/ice_colony/underground/hallway/north_west)
@@ -37391,8 +37054,7 @@
 /area/ice_colony/surface/hydroponics/south)
 "bUV" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	name = "\improper Hydroponics Dome South Wing";
-	req_access_txt = "100"
+	name = "\improper Hydroponics Dome South Wing"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/hydroponics/south)
@@ -38702,10 +38364,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/security/backroom)
@@ -38809,10 +38469,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/free_access{
 	dir = 2;
-	name = "Underground Power Substation";
-	req_access_txt = "100"
+	name = "\improper Underground Power Substation"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/engineering/substation)
@@ -38853,7 +38512,9 @@
 /turf/open/floor/plating,
 /area/ice_colony/underground/engineering/substation)
 "bYM" = (
-/obj/machinery/door/airlock/mainship/maint,
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "\improper Underground Maintenance"
+	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/engineering/substation)
 "bYN" = (
@@ -38899,9 +38560,7 @@
 "bYR" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
-	name = "\improper Underground Lavatory";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Underground Lavatory"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/white,
@@ -38992,9 +38651,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/security{
-	name = "\improper Underground Security Custodial Closet";
-	req_access_txt = "100"
+/obj/machinery/door/airlock/mainship/security/free_access{
+	name = "\improper Underground Security Custodial Closet"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/security/backroom)
@@ -39094,16 +38752,14 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	name = "\improper Underground Excavation Prep";
-	req_access_txt = "100"
+	name = "\improper Underground Excavation Prep"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/hallway/south_east)
 "bZo" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Underground Engineering Locker Room";
-	req_access_txt = "100"
+	name = "\improper Underground Engineering Locker Room"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/engineering)
@@ -39140,10 +38796,9 @@
 /turf/open/floor/plating/icefloor,
 /area/ice_colony/underground/hangar)
 "bZt" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 4;
-	name = "\improper Underground Engineering Locker Room";
-	req_access_txt = "100"
+	name = "\improper Underground Engineering Locker Room"
 	},
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/engineering)
@@ -39173,11 +38828,9 @@
 	},
 /area/ice_colony/exterior/surface/landing_pad)
 "bZx" = (
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 1;
-	name = "\improper Underground Maintenance";
-	req_access_txt = "100";
-	req_one_access_txt = "0"
+	name = "\improper Underground Maintenance"
 	},
 /turf/open/floor/plating,
 /area/ice_colony/underground/maintenance/engineering)
@@ -39289,7 +38942,7 @@
 /area/ice_colony/underground/maintenance/engineering)
 "bZJ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 2;
 	name = "Maintenance Hatch"
 	},
@@ -39694,9 +39347,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/multi_tile/mainship/comdoor{
-	name = "\improper Colony Administration";
-	req_access_txt = "100"
+/obj/machinery/door/airlock/multi_tile/mainship/comdoor/free_access{
+	name = "\improper Colony Administration"
 	},
 /obj/effect/decal/cleanable/blood/xtracks,
 /turf/open/floor/tile/dark2,
@@ -39822,9 +39474,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/multi_tile/mainship/comdoor{
-	name = "\improper Colony Administration";
-	req_access_txt = "100"
+/obj/machinery/door/airlock/multi_tile/mainship/comdoor/free_access{
+	name = "\improper Colony Administration"
 	},
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/tile/dark2,
@@ -56748,7 +56399,7 @@ bRo
 bkt
 bkt
 bkt
-bkK
+bRo
 bkt
 bkt
 bkt

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -933,12 +933,9 @@
 /turf/open/floor/tile/dark,
 /area/lv624/ground/caves/central1)
 "adk" = (
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/locked/free_access{
 	dir = 4;
-	icon_state = "door_locked";
-	locked = 1;
-	name = "Mining Storage";
-	req_access_txt = "0"
+	name = "\improper Mining Storage"
 	},
 /turf/open/floor/tile/dark,
 /area/lv624/ground/caves/central1)
@@ -3574,10 +3571,9 @@
 /turf/open/floor,
 /area/lv624/ground/sand8)
 "ana" = (
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/free_access{
 	dir = 4;
-	name = "Water Filtration Plant";
-	req_access_txt = "0"
+	name = "\improper Water Filtration Plant"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -3617,10 +3613,9 @@
 	},
 /area/lv624/ground/sand8)
 "anf" = (
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/free_access{
 	dir = 4;
-	name = "Water Filtration Plant";
-	req_access_txt = "0"
+	name = "\improper Water Filtration Plant"
 	},
 /turf/open/floor/plating/platebot,
 /area/lv624/ground/sand8)
@@ -6173,8 +6168,7 @@
 /obj/machinery/door_control{
 	id = "secure_blast";
 	name = "Vault Access";
-	pixel_x = -25;
-	req_access_txt = "0"
+	pixel_x = -25
 	},
 /turf/open/floor/wood,
 /area/lv624/lazarus/internal_affairs)
@@ -6535,10 +6529,9 @@
 	},
 /area/lv624/lazarus/medbay)
 "ayC" = (
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/free_access{
 	locked = 1;
-	name = "\improper Nexus Dome Armory";
-	req_access_txt = "0"
+	name = "\improper Nexus Dome Armory"
 	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/security)
@@ -6590,11 +6583,9 @@
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/quartstorage)
 "ayL" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 4;
-	name = "\improper Hydroponics Dome";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+	name = "\improper Hydroponics Dome"
 	},
 /turf/open/floor/tile/green/greentaupe{
 	dir = 1
@@ -6691,9 +6682,7 @@
 "azf" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	dir = 1;
-	name = "\improper Medical Dome";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+	name = "\improper Medical Dome"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -6718,8 +6707,7 @@
 "azj" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
-	name = "\improper Hydroponics Dome";
-	req_access_txt = "0"
+	name = "\improper Hydroponics Dome"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -6854,8 +6842,7 @@
 /obj/machinery/door_control{
 	id = "secure_blast";
 	name = "Vault Access";
-	pixel_x = 25;
-	req_access_txt = "0"
+	pixel_x = 25
 	},
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -7542,11 +7529,9 @@
 /turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/ground/compound/n)
 "aCB" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 1;
-	name = "\improper Hydroponics Dome";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+	name = "\improper Hydroponics Dome"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/tile/green/greentaupe{
@@ -7610,11 +7595,9 @@
 	},
 /area/lv624/ground/jungle6)
 "aCY" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 1;
-	name = "\improper Medical Dome";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+	name = "\improper Medical Dome"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/tile/blue/whitebluecorner{
@@ -7795,13 +7778,9 @@
 /turf/open/floor/plating,
 /area/lv624/lazarus/quartstorage)
 "aDN" = (
-/obj/machinery/door/airlock/mainship/engineering{
-	density = 0;
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	icon_state = "door_open";
-	name = "\improper Storage Dome";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+	name = "\improper Storage Dome"
 	},
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/quartstorage)
@@ -7930,11 +7909,9 @@
 	id = "science_blast";
 	name = "\improper Science Wing Blast Door"
 	},
-/obj/machinery/door/airlock/mainship/research{
+/obj/machinery/door/airlock/mainship/research/locked/free_access{
 	dir = 1;
-	locked = 1;
-	name = "\improper Research Dome";
-	req_access_txt = "0"
+	name = "\improper Research Dome"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/tile/white,
@@ -8058,11 +8035,9 @@
 /turf/open/floor/plating,
 /area/lv624/lazarus/fitness)
 "aFy" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 1;
-	name = "\improper Leisure Dome";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+	name = "\improper Leisure Dome"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -8314,11 +8289,9 @@
 	},
 /area/lv624/lazarus/research)
 "aGy" = (
-/obj/machinery/door/airlock/mainship/research{
+/obj/machinery/door/airlock/mainship/research/locked/free_access{
 	dir = 4;
-	locked = 1;
-	name = "\improper Research Dome";
-	req_access_txt = "0"
+	name = "\improper Research Dome"
 	},
 /turf/open/floor/tile/purple/whitepurple{
 	dir = 5
@@ -8580,13 +8553,9 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/quartstorage/outdoors)
 "aHx" = (
-/obj/machinery/door/airlock/mainship/engineering{
-	density = 1;
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 4;
-	icon_state = "door_closed";
-	name = "\improper Storage Dome";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+	name = "\improper Storage Dome"
 	},
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/quartstorage)
@@ -8650,35 +8619,25 @@
 /turf/open/floor/plating,
 /area/lv624/lazarus/robotics)
 "aHK" = (
-/obj/machinery/door/airlock/mainship/engineering{
-	density = 0;
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	icon_state = "door_open";
-	name = "\improper Robotics Dome";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+	name = "\improper Robotics Dome"
 	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/robotics)
 "aHM" = (
-/obj/machinery/door/airlock/mainship/research{
+/obj/machinery/door/airlock/mainship/research/locked/free_access{
 	dir = 1;
-	locked = 1;
-	name = "\improper Research Dome";
-	req_access_txt = "0"
+	name = "\improper Research Dome"
 	},
 /turf/open/floor/tile/purple/whitepurple{
 	dir = 5
 	},
 /area/lv624/lazarus/research)
 "aHN" = (
-/obj/machinery/door/airlock/mainship/research{
-	density = 0;
+/obj/machinery/door/airlock/mainship/research/open/free_access{
 	dir = 1;
-	icon_state = "door_open";
-	name = "\improper Research Dome";
-	opacity = 0;
-	req_access_txt = "0"
+	name = "\improper Research Dome"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/tile/white,
@@ -8997,11 +8956,9 @@
 	id = "science_blast";
 	name = "\improper Science Wing Blast Door"
 	},
-/obj/machinery/door/airlock/mainship/research{
+/obj/machinery/door/airlock/mainship/research/locked/free_access{
 	dir = 4;
-	locked = 1;
-	name = "\improper Research Dome";
-	req_access_txt = "0"
+	name = "\improper Research Dome"
 	},
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/research)
@@ -9020,12 +8977,8 @@
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/research)
 "aJn" = (
-/obj/machinery/door/airlock/mainship/research{
-	density = 0;
-	icon_state = "door_open";
-	name = "\improper Research Dome";
-	opacity = 0;
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/research/open/free_access{
+	name = "\improper Research Dome"
 	},
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/research)
@@ -9057,9 +9010,8 @@
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/research)
 "aJr" = (
-/obj/machinery/door/airlock/mainship/research{
-	name = "\improper Research Dome";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/research/free_access{
+	name = "\improper Research Dome"
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -9096,12 +9048,8 @@
 	name = "\improper Forced Blast Door";
 	opacity = 0
 	},
-/obj/machinery/door/airlock/mainship/research{
-	density = 0;
-	icon_state = "door_open";
-	name = "\improper Research Dome";
-	opacity = 0;
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/research/open/free_access{
+	name = "\improper Research Dome"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -9244,10 +9192,8 @@
 /turf/open/floor/plating/platebot,
 /area/lv624/lazarus/robotics)
 "aJX" = (
-/obj/machinery/door/airlock/mainship/engineering{
-	name = "\improper Robotics Dome";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Robotics Dome"
 	},
 /turf/open/floor/tile/vault{
 	dir = 8
@@ -9302,12 +9248,8 @@
 	name = "\improper Forced Blast Door";
 	opacity = 0
 	},
-/obj/machinery/door/airlock/mainship/research{
-	density = 0;
-	icon_state = "door_open";
-	name = "\improper Research Dome";
-	opacity = 0;
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/research/open/free_access{
+	name = "\improper Research Dome"
 	},
 /turf/open/floor/tile/purple/whitepurple{
 	dir = 5
@@ -9320,8 +9262,7 @@
 "aKj" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
-	name = "\improper Leisure Dome";
-	req_access_txt = "0"
+	name = "\improper Leisure Dome"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -9396,11 +9337,9 @@
 	},
 /area/lv624/lazarus/fitness)
 "aKq" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 4;
-	name = "\improper Leisure Dome";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+	name = "\improper Leisure Dome"
 	},
 /turf/open/floor/tile/purple/whitepurple{
 	dir = 5
@@ -9444,13 +9383,9 @@
 /turf/open/ground/grass,
 /area/lv624/ground/compound/ne)
 "aKy" = (
-/obj/machinery/door/airlock/mainship/engineering{
-	density = 1;
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	icon_state = "door_closed";
-	name = "\improper Storage Dome";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+	name = "\improper Storage Dome"
 	},
 /turf/open/floor/vault,
 /area/lv624/lazarus/quartstorage)
@@ -9540,13 +9475,9 @@
 /turf/open/ground/grass,
 /area/lv624/ground/jungle6)
 "aKT" = (
-/obj/machinery/door/airlock/mainship/research{
-	density = 0;
+/obj/machinery/door/airlock/mainship/research/open/free_access{
 	dir = 1;
-	icon_state = "door_open";
-	name = "\improper Research Dome";
-	opacity = 0;
-	req_access_txt = "0"
+	name = "\improper Research Dome"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable/yellow{
@@ -9637,11 +9568,9 @@
 /turf/open/ground/grass,
 /area/lv624/ground/jungle6)
 "aLq" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Robotics Dome";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+	name = "\improper Robotics Dome"
 	},
 /turf/open/floor/plating/platebot,
 /area/lv624/lazarus/robotics)
@@ -9759,8 +9688,7 @@
 /area/lv624/lazarus/main_hall)
 "aLM" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	name = "\improper Nexus Dome";
-	req_access_txt = "0"
+	name = "\improper Nexus Dome"
 	},
 /obj/machinery/door/poddoor/mainship{
 	density = 0;
@@ -9944,9 +9872,8 @@
 /turf/open/floor/freezer,
 /area/lv624/lazarus/research)
 "aMr" = (
-/obj/machinery/door/airlock/mainship/research{
-	name = "\improper Research Dome";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/research/free_access{
+	name = "\improper Research Dome"
 	},
 /turf/open/floor/tile/purple/whitepurple{
 	dir = 5
@@ -10126,12 +10053,8 @@
 /turf/open/ground/river,
 /area/lv624/ground/jungle6)
 "aNa" = (
-/obj/machinery/door/airlock/mainship/engineering{
-	density = 0;
-	icon_state = "door_open";
-	name = "\improper Robotics Dome";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Robotics Dome"
 	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/robotics)
@@ -10211,12 +10134,8 @@
 	},
 /area/lv624/lazarus/robotics)
 "aNj" = (
-/obj/machinery/door/airlock/mainship/engineering{
-	density = 0;
-	icon_state = "door_open";
-	name = "\improper Robotics Dome";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Robotics Dome"
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -11126,13 +11045,9 @@
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/quartstorage)
 "aQx" = (
-/obj/machinery/door/airlock/mainship/engineering{
-	density = 1;
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 4;
-	icon_state = "door_closed";
-	name = "\improper Storage Dome";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+	name = "\improper Storage Dome"
 	},
 /turf/open/floor/vault,
 /area/lv624/lazarus/quartstorage)
@@ -11209,18 +11124,6 @@
 /obj/structure/largecrate,
 /obj/item/mecha_parts/part/gygax_armour,
 /turf/open/floor/plating/platebot,
-/area/lv624/lazarus/robotics)
-"aQO" = (
-/obj/machinery/door/airlock/mainship/engineering{
-	density = 0;
-	icon_state = "door_open";
-	name = "\improper Robotics Dome";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
-	},
-/turf/open/floor/tile/vault{
-	dir = 8
-	},
 /area/lv624/lazarus/robotics)
 "aQP" = (
 /obj/structure/cable/yellow{
@@ -11326,8 +11229,7 @@
 "aRb" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
-	name = "\improper Nexus Dome Male Dormitories";
-	req_access_txt = "0"
+	name = "\improper Nexus Dome Male Dormitories"
 	},
 /turf/open/floor/tile/blue/taupebluecorner{
 	dir = 2
@@ -11362,8 +11264,7 @@
 "aRe" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
-	name = "\improper Nexus Dome Female Dormitories";
-	req_access_txt = "0"
+	name = "\improper Nexus Dome Female Dormitories"
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -11916,13 +11817,9 @@
 /turf/open/ground/grass,
 /area/lv624/ground/jungle9)
 "aSN" = (
-/obj/machinery/door/airlock/mainship/engineering{
-	density = 0;
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	icon_state = "door_open";
-	name = "\improper Robotics Dome";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+	name = "\improper Robotics Dome"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
@@ -12235,13 +12132,9 @@
 /turf/open/floor/plating,
 /area/lv624/lazarus/quart)
 "aTN" = (
-/obj/machinery/door/airlock/mainship/engineering{
-	density = 1;
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	icon_state = "door_closed";
-	name = "\improper Storage Dome";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+	name = "\improper Storage Dome"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -12572,12 +12465,8 @@
 /turf/open/floor/plating/platebotc,
 /area/lv624/lazarus/chapel)
 "aUW" = (
-/obj/machinery/door/airlock/mainship/engineering{
-	density = 0;
-	icon_state = "door_open";
-	name = "\improper Nexus Cargo Storage";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Nexus Cargo Storage"
 	},
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/lazarus/quart)
@@ -12637,13 +12526,9 @@
 /area/lv624/lazarus/quartstorage)
 "aVg" = (
 /obj/effect/decal/cleanable/blood/oil,
-/obj/machinery/door/airlock/mainship/engineering{
-	density = 0;
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	icon_state = "door_open";
-	name = "\improper Storage Dome";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+	name = "\improper Storage Dome"
 	},
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 1
@@ -12793,13 +12678,9 @@
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/lazarus/quart)
 "aVI" = (
-/obj/machinery/door/airlock/mainship/engineering{
-	density = 1;
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 4;
-	icon_state = "door_closed";
-	name = "\improper Storage Dome";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+	name = "\improper Storage Dome"
 	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/quart)
@@ -13125,24 +13006,16 @@
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/lazarus/quart)
 "aWS" = (
-/obj/machinery/door/airlock/mainship/engineering{
-	density = 0;
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	icon_state = "door_open";
-	name = "\improper Storage Dome";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+	name = "\improper Storage Dome"
 	},
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/quartstorage)
 "aWT" = (
-/obj/machinery/door/airlock/mainship/engineering{
-	density = 0;
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	icon_state = "door_open";
-	name = "\improper Storage Dome";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+	name = "\improper Storage Dome"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -13438,8 +13311,7 @@
 "aXW" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
-	name = "\improper Nexus Dome Bathroom";
-	req_access_txt = "0"
+	name = "\improper Nexus Dome Bathroom"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -13451,8 +13323,7 @@
 /area/lv624/lazarus/toilet)
 "aXX" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	name = "\improper Nexus Dome Chapel";
-	req_access_txt = "0"
+	name = "\improper Nexus Dome Chapel"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -13586,8 +13457,7 @@
 "aYz" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
-	name = "\improper Nexus Dome";
-	req_access_txt = "0"
+	name = "\improper Nexus Dome"
 	},
 /obj/machinery/door/poddoor/mainship{
 	density = 0;
@@ -13726,8 +13596,7 @@
 "aYS" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
-	name = "\improper Nexus Dome";
-	req_access_txt = "0"
+	name = "\improper Nexus Dome"
 	},
 /obj/machinery/door/poddoor/mainship{
 	density = 0;
@@ -14017,11 +13886,8 @@
 /area/lv624/lazarus/internal_affairs)
 "aZQ" = (
 /obj/machinery/door/airlock/mainship/generic/corporate{
-	density = 0;
 	dir = 4;
-	icon_state = "door_open";
-	name = "Corporate Dome";
-	opacity = 0
+	name = "Corporate Dome"
 	},
 /turf/open/floor/wood,
 /area/lv624/lazarus/internal_affairs)
@@ -14577,16 +14443,6 @@
 /obj/structure/jungle/vines,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle9)
-"bbm" = (
-/obj/machinery/door/airlock/mainship/generic/corporate{
-	density = 0;
-	dir = 1;
-	icon_state = "door_open";
-	name = "Corporate Dome";
-	opacity = 0
-	},
-/turf/open/floor/wood,
-/area/lv624/lazarus/internal_affairs)
 "bbn" = (
 /obj/machinery/door/airlock/mainship/generic/corporate{
 	dir = 1;
@@ -14754,8 +14610,7 @@
 "bbU" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
-	name = "\improper Nexus Dome";
-	req_access_txt = "0"
+	name = "\improper Nexus Dome"
 	},
 /obj/machinery/door/poddoor/mainship{
 	density = 0;
@@ -14812,8 +14667,7 @@
 /area/lv624/lazarus/canteen)
 "bce" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	name = "\improper Nexus Dome Canteen";
-	req_access_txt = "0"
+	name = "\improper Nexus Dome Canteen"
 	},
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/canteen)
@@ -15457,11 +15311,9 @@
 /turf/open/floor/tile/bar,
 /area/lv624/lazarus/canteen)
 "beb" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 1;
-	name = "\improper Nexus Dome Canteen";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+	name = "\improper Nexus Dome Canteen"
 	},
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/canteen)
@@ -15575,10 +15427,8 @@
 	},
 /area/lv624/lazarus/security)
 "beC" = (
-/obj/machinery/door/airlock/mainship/security{
-	locked = 1;
-	name = "\improper Nexus Dome Marshal Office";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/security/locked/free_access{
+	name = "\improper Nexus Dome Marshal Office"
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -15893,10 +15743,8 @@
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/main_hall)
 "bfx" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
-	name = "\improper Nexus Dome Canteen";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	name = "\improper Nexus Dome Canteen"
 	},
 /turf/open/floor/tile/barber,
 /area/lv624/lazarus/kitchen)
@@ -16189,11 +16037,9 @@
 /turf/open/floor/plating,
 /area/lv624/lazarus/comms)
 "bgK" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Communications Dome";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+	name = "\improper Communications Dome"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -16615,10 +16461,8 @@
 /turf/open/floor/grimy,
 /area/lv624/lazarus/captain)
 "biq" = (
-/obj/machinery/door/airlock/mainship/command{
-	locked = 1;
-	name = "\improper Nexus Dome Marshal's Quarter";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/command/locked/free_access{
+	name = "\improper Nexus Dome Marshal's Quarter"
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -17015,11 +16859,9 @@
 /area/lv624/lazarus/engineering)
 "bjI" = (
 /obj/structure/foamedmetal,
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Engineering Dome";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+	name = "\improper Engineering Dome"
 	},
 /obj/structure/jungle/vines/heavy,
 /obj/structure/cable/yellow{
@@ -17081,9 +16923,8 @@
 /turf/open/floor/wood,
 /area/lv624/lazarus/hop)
 "bjQ" = (
-/obj/machinery/door/airlock/mainship/command{
-	name = "\improper Nexus Dome Command Quarter";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/command/free_access{
+	name = "\improper Nexus Dome Command Quarter"
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -17407,8 +17248,7 @@
 "bkP" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
-	name = "\improper Nexus Dome Freezer";
-	req_access_txt = "0"
+	name = "\improper Nexus Dome Freezer"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -17541,10 +17381,8 @@
 /turf/open/floor/plating,
 /area/lv624/lazarus/engineering)
 "blk" = (
-/obj/machinery/door/airlock/mainship/engineering{
-	name = "\improper Engineering Dome";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Engineering Dome"
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -17614,11 +17452,9 @@
 /turf/open/floor/grimy,
 /area/lv624/lazarus/hop)
 "bls" = (
-/obj/machinery/door/airlock/mainship/command{
+/obj/machinery/door/airlock/mainship/command/locked/free_access{
 	dir = 1;
-	locked = 1;
-	name = "\improper Nexus Dome Director's Quarter";
-	req_access_txt = "0"
+	name = "\improper Nexus Dome Director's Quarter"
 	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/hop)
@@ -17727,10 +17563,8 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/sw)
 "blJ" = (
-/obj/machinery/door/airlock/mainship/engineering{
-	name = "\improper Communications Dome";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Communications Dome"
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -18515,10 +18349,8 @@
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/engineering)
 "bnW" = (
-/obj/machinery/door/airlock/mainship/engineering{
-	name = "\improper Engineering Dome";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Engineering Dome"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -18723,10 +18555,8 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/atmos/outside)
 "boC" = (
-/obj/machinery/door/airlock/mainship/engineering{
-	name = "\improper Engineering Dome";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Engineering Dome"
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -19124,11 +18954,9 @@
 	},
 /area/lv624/lazarus/engineering)
 "bpM" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Engineering Dome";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+	name = "\improper Engineering Dome"
 	},
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/engineering)
@@ -19376,11 +19204,9 @@
 /turf/open/ground/grass,
 /area/lv624/ground/jungle2)
 "bqP" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Communications Dome";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+	name = "\improper Communications Dome"
 	},
 /turf/open/floor/tile/brown{
 	dir = 9
@@ -19925,13 +19751,9 @@
 /turf/closed/mineral,
 /area/lv624/ground/sand4)
 "eLi" = (
-/obj/machinery/door/airlock/mainship/engineering{
-	density = 1;
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	icon_state = "door_closed";
-	name = "\improper Storage Dome";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+	name = "\improper Storage Dome"
 	},
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 1
@@ -20226,10 +20048,8 @@
 /turf/closed/wall/r_wall,
 /area/shuttle/drop1/lz1)
 "mGh" = (
-/obj/machinery/door/airlock/mainship/security{
-	locked = 1;
-	name = "\improper Nexus Dome Marshal Office";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/security/locked/free_access{
+	name = "\improper Nexus Dome Marshal Office"
 	},
 /turf/open/floor,
 /area/lv624/lazarus/security)
@@ -33128,7 +32948,7 @@ qYr
 aZc
 aZP
 baE
-bbm
+bbn
 bbG
 bct
 aZR
@@ -34397,7 +34217,7 @@ aNg
 aJY
 aHI
 aHI
-aQO
+aJX
 aHI
 aHI
 aHI
@@ -54231,7 +54051,6 @@ bdk
 bdk
 bdk
 bdk
-aab
 "}
 (132,1,1) = {"
 aaa

--- a/_maps/map_files/MarineHQ/MarineHQ.dmm
+++ b/_maps/map_files/MarineHQ/MarineHQ.dmm
@@ -5944,7 +5944,6 @@
 /area/mainship/hallways/hangar)
 "pm" = (
 /obj/machinery/door/airlock/mainship/medical/glass/free_access{
-	icon_state = "door_closed";
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,

--- a/_maps/map_files/MarineHQ/MarineHQ.dmm
+++ b/_maps/map_files/MarineHQ/MarineHQ.dmm
@@ -1899,7 +1899,8 @@
 /area/mainship/living/numbertwobunks)
 "fq" = (
 /obj/machinery/door/airlock/mainship/generic{
-	dir = 1name = "\improper Kitchen"
+	dir = 1;
+	name = "\improper Kitchen"
 	},
 /turf/open/floor/mainship{
 	icon_state = "plate";

--- a/_maps/map_files/MarineHQ/MarineHQ.dmm
+++ b/_maps/map_files/MarineHQ/MarineHQ.dmm
@@ -403,7 +403,6 @@
 "bp" = (
 /obj/machinery/door/airlock/mainship/research/glass{
 	id = "Containment Cell 3";
-	locked = 1;
 	name = "\improper Containment Cell 3"
 	},
 /obj/machinery/door/poddoor/shutters/mainship{
@@ -612,8 +611,7 @@
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
 	id = 5;
-	name = "\improper Quarters 5";
-	req_access_txt = "0"
+	name = "\improper Quarters 5"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -879,7 +877,7 @@
 "cL" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 4;
-	name = "Toilet"
+	name = "\improper Toilet"
 	},
 /turf/open/floor/mainship{
 	icon_state = "dark_sterile"
@@ -935,9 +933,8 @@
 	},
 /area/mainship/hallways/hangar)
 "cV" = (
-/obj/machinery/door/airlock/mainship/secure{
-	name = "Telecommunications";
-	req_access_txt = "6"
+/obj/machinery/door/airlock/mainship/secure/tcomms{
+	name = "\improper Telecommunications"
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
@@ -1011,11 +1008,9 @@
 	},
 /area/mainship/medical/medical_science)
 "dh" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 1;
-	name = "Animal Control Closet";
-	req_access_txt = "14";
-	req_one_access_txt = "0"
+	name = "Animal Control Closet"
 	},
 /turf/open/floor/mainship{
 	icon_state = "dark_sterile"
@@ -1143,9 +1138,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/mainship/research{
-	dir = 2;
-	req_access_txt = "20"
+/obj/machinery/door/airlock/mainship/research/chemistry{
+	dir = 2
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/medical/medical_science)
@@ -1268,9 +1262,8 @@
 	},
 /area/mainship/medical/medical_science)
 "dH" = (
-/obj/machinery/door/airlock/mainship/research{
-	dir = 2;
-	req_access_txt = "20"
+/obj/machinery/door/airlock/mainship/research/chemistry{
+	dir = 2
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -1336,8 +1329,7 @@
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
 	id = 6;
-	name = "\improper Quarters 6";
-	req_access_txt = "0"
+	name = "\improper Quarters 6"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -1517,7 +1509,7 @@
 "es" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 4;
-	name = "Freezer"
+	name = "\improper Freezer"
 	},
 /turf/open/floor/mainship,
 /area/mainship/living/captain_mess)
@@ -1647,7 +1639,7 @@
 "eH" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
-	name = "Bathroom"
+	name = "\improper Bathroom"
 	},
 /turf/open/floor/mainship{
 	icon_state = "dark_sterile"
@@ -1656,8 +1648,7 @@
 "eI" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
-	icon_state = "door_closed";
-	name = "Kitchen"
+	name = "\improper Kitchen"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -1674,16 +1665,14 @@
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
 	id = 1;
-	id_tag = 1;
-	name = "\improper Quarters 1";
-	req_access_txt = "0"
+	name = "\improper Quarters 1"
 	},
 /turf/open/floor/wood,
 /area/mainship/living/bridgebunks)
 "eK" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
-	name = "Bathroom"
+	name = "\improper Bathroom"
 	},
 /turf/open/floor/mainship{
 	icon_state = "dark_sterile"
@@ -1693,8 +1682,7 @@
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
 	id = 2;
-	name = "\improper Quarters 2";
-	req_access_txt = "0"
+	name = "\improper Quarters 2"
 	},
 /turf/open/floor/wood,
 /area/mainship/squads/alpha)
@@ -1779,7 +1767,7 @@
 "eW" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
-	name = "Bathroom"
+	name = "\improper Bathroom"
 	},
 /turf/open/floor/mainship{
 	icon_state = "dark_sterile"
@@ -1789,15 +1777,14 @@
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
 	id = 3;
-	name = "\improper Quarters 3";
-	req_access_txt = "0"
+	name = "\improper Quarters 3"
 	},
 /turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "eY" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
-	name = "Bathroom"
+	name = "\improper Bathroom"
 	},
 /turf/open/floor/mainship{
 	icon_state = "dark_sterile"
@@ -1807,8 +1794,7 @@
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
 	id = 4;
-	name = "\improper Quarters 4";
-	req_access_txt = "0"
+	name = "\improper Quarters 4"
 	},
 /turf/open/floor/wood,
 /area/mainship/squads/bravo)
@@ -1913,9 +1899,7 @@
 /area/mainship/living/numbertwobunks)
 "fq" = (
 /obj/machinery/door/airlock/mainship/generic{
-	dir = 1;
-	icon_state = "door_closed";
-	name = "Kitchen"
+	dir = 1name = "\improper Kitchen"
 	},
 /turf/open/floor/mainship{
 	icon_state = "plate";
@@ -2054,9 +2038,8 @@
 /turf/open/floor/wood,
 /area/mainship/squads/req)
 "fK" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
-	name = "\improper Unform Airlock";
-	req_one_access = 0
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	name = "\improper Unform Airlock"
 	},
 /turf/open/floor/wood,
 /area/mainship/squads/req)
@@ -2311,9 +2294,7 @@
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
 	id = 998;
-	id_tag = 999;
-	name = "\improper Quarters 1";
-	req_access_txt = "0"
+	name = "\improper Quarters 1"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -2374,8 +2355,7 @@
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
 	id = 2;
-	name = "\improper Quarters 2";
-	req_access_txt = "0"
+	name = "\improper Quarters 2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -2397,8 +2377,7 @@
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
 	id = 3;
-	name = "\improper Quarters 3";
-	req_access_txt = "0"
+	name = "\improper Quarters 3"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -2431,8 +2410,7 @@
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
 	id = 4;
-	name = "\improper Quarters 4";
-	req_access_txt = "0"
+	name = "\improper Quarters 4"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -2734,8 +2712,7 @@
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
 	id = 7;
-	name = "\improper Quarters 7";
-	req_access_txt = "0"
+	name = "\improper Quarters 7"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -2827,8 +2804,7 @@
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
 	id = 8;
-	name = "\improper Quarters 8";
-	req_access_txt = "0"
+	name = "\improper Quarters 8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -3057,7 +3033,7 @@
 "ig" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
-	name = "Bathroom"
+	name = "\improper Bathroom"
 	},
 /turf/open/floor/wood,
 /area/mainship/living/grunt_rnr)
@@ -3303,7 +3279,6 @@
 "iU" = (
 /obj/machinery/door/airlock/mainship/generic{
 	name = "\improper Extended Operations Bunks";
-	icon_state = "door_closed";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -3342,7 +3317,6 @@
 "ja" = (
 /obj/machinery/door/airlock/mainship/generic{
 	name = "\improper Extended Operations Bunks";
-	icon_state = "door_closed";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -4171,7 +4145,6 @@
 "ls" = (
 /obj/machinery/door/airlock/mainship/generic{
 	name = "\improper Extended Operations Bunks";
-	icon_state = "door_closed";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -4264,8 +4237,7 @@
 "lE" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
-	name = "\improper Leisure Dome";
-	req_access_txt = "0"
+	name = "\improper Leisure Dome"
 	},
 /obj/structure/cable{
 	icon_state = "4-8";
@@ -4434,12 +4406,10 @@
 	},
 /area/mainship/shipboard/sensors)
 "lZ" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "hangarentrancenorth";
 	name = "North Hangar Shutters";
-	pixel_x = -30;
-	req_one_access_txt = "2;3;12;19";
-	throw_range = 15
+	pixel_x = -30
 	},
 /turf/open/floor/mainship{
 	dir = 8;
@@ -4522,9 +4492,8 @@
 	},
 /area/mainship/shipboard/sensors)
 "mh" = (
-/obj/machinery/door/airlock/mainship/security/glass{
-	dir = 2;
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	dir = 2
 	},
 /turf/open/floor/mainship{
 	dir = 8;
@@ -5099,9 +5068,7 @@
 "nr" = (
 /obj/machinery/door/airlock/mainship/command{
 	dir = 1;
-	icon_state = "door_closed";
-	name = "\improper Combat Information Center";
-	req_access = null
+	name = "\improper Combat Information Center"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -5385,9 +5352,7 @@
 	},
 /area/mainship/hallways/hangar)
 "oa" = (
-/obj/machinery/vending/attachments{
-	req_access = null
-	},
+/obj/machinery/vending/attachments,
 /turf/open/floor/mainship{
 	icon_state = "cargo"
 	},
@@ -5509,9 +5474,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "oq" = (
-/obj/machinery/door/airlock/mainship/engineering{
-	req_one_access = null
-	},
+/obj/machinery/door/airlock/mainship/engineering/free_access,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -5980,10 +5943,9 @@
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "pm" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	icon_state = "door_closed";
-	dir = 2;
-	req_one_access = null
+	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -6016,10 +5978,7 @@
 /area/mainship/hallways/hangar)
 "pq" = (
 /obj/machinery/door/airlock/mainship/marine{
-	icon_state = "door_closed";
-	dir = 8;
-	req_access = list();
-	req_one_access = list()
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -6267,7 +6226,7 @@
 "pW" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
-	name = "Bathroom"
+	name = "\improper Bathroom"
 	},
 /obj/structure/disposalpipe/segment{
 	icon_state = "pipe-s";
@@ -6619,12 +6578,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
 "rQ" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 4;
-	name = "Killhouse";
-	req_access_txt = "0";
-	req_one_access = 0;
-	req_one_access_txt = "0"
+	name = "Killhouse"
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/firing_range)
@@ -6639,12 +6595,9 @@
 	},
 /area/mainship/shipboard/firing_range)
 "rS" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 1;
-	name = "Killhouse";
-	req_access_txt = "0";
-	req_one_access = 0;
-	req_one_access_txt = "0"
+	name = "Killhouse"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -6842,9 +6795,7 @@
 	},
 /area/mainship/command/cic)
 "sR" = (
-/obj/structure/closet/secure_closet/personal/cabinet{
-	req_access = null
-	},
+/obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/carpet{
 	icon_state = "carpetside";
 	dir = 5
@@ -7214,12 +7165,9 @@
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
 "vU" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 4;
-	name = "Killhouse";
-	req_access_txt = "0";
-	req_one_access = 0;
-	req_one_access_txt = "0"
+	name = "Killhouse"
 	},
 /turf/open/floor/mainship,
 /area/mainship/shipboard/firing_range)
@@ -7376,12 +7324,9 @@
 	},
 /area/mainship/shipboard/firing_range)
 "xz" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 1;
-	name = "Killhouse";
-	req_access_txt = "0";
-	req_one_access = 0;
-	req_one_access_txt = "0"
+	name = "Killhouse"
 	},
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
@@ -7423,9 +7368,7 @@
 /area/mainship/living/commandbunks)
 "xQ" = (
 /obj/machinery/door_control{
-	id = 1006;
-	pixel_w = 0;
-	pixel_z = -7
+	id = 1006
 	},
 /turf/closed/wall,
 /area/mainship/medical/medical_science)
@@ -7510,9 +7453,7 @@
 /area/mainship/medical/medical_science)
 "yJ" = (
 /obj/machinery/door_control{
-	id = 1002;
-	pixel_w = 0;
-	pixel_z = -7
+	id = 1002
 	},
 /turf/closed/wall,
 /area/mainship/living/tankerbunks)
@@ -7748,7 +7689,6 @@
 "Ap" = (
 /obj/machinery/door/airlock/mainship/generic{
 	name = "\improper Extended Operations Bunks";
-	icon_state = "door_closed";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -8000,10 +7940,9 @@
 /turf/open/floor/grass,
 /area/lv624/ground/compound/se)
 "Bh" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "northcheckpoint";
-	name = "North Checkpoint Shutters";
-	req_one_access_txt = "0"
+	name = "North Checkpoint Shutters"
 	},
 /turf/closed/wall,
 /area/mainship/living/starboard_emb)
@@ -8170,10 +8109,9 @@
 /area/mainship/shipboard/sensors)
 "BL" = (
 /obj/structure/table/mainship,
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "northcheckpoint";
-	name = "North Checkpoint Shutters";
-	req_one_access_txt = "0"
+	name = "North Checkpoint Shutters"
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/sensors)
@@ -8353,9 +8291,7 @@
 /area/mainship/squads/charlie)
 "Cy" = (
 /obj/machinery/door_control{
-	id = 1003;
-	pixel_w = 0;
-	pixel_z = -7
+	id = 1003
 	},
 /turf/closed/wall,
 /area/mainship/squads/charlie)
@@ -8467,7 +8403,7 @@
 "CT" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
-	name = "Bathroom"
+	name = "\improper Bathroom"
 	},
 /turf/open/floor/mainship{
 	icon_state = "dark_sterile"
@@ -8477,15 +8413,14 @@
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
 	id = 5;
-	name = "\improper Quarters 5";
-	req_access_txt = "0"
+	name = "\improper Quarters 5"
 	},
 /turf/open/floor/wood,
 /area/mainship/living/tankerbunks)
 "CV" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
-	name = "Bathroom"
+	name = "\improper Bathroom"
 	},
 /turf/open/floor/mainship{
 	icon_state = "dark_sterile"
@@ -8495,15 +8430,14 @@
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
 	id = 6;
-	name = "\improper Quarters 6";
-	req_access_txt = "0"
+	name = "\improper Quarters 6"
 	},
 /turf/open/floor/wood,
 /area/mainship/squads/charlie)
 "CX" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
-	name = "Bathroom"
+	name = "\improper Bathroom"
 	},
 /turf/open/floor/mainship{
 	icon_state = "dark_sterile"
@@ -8513,15 +8447,14 @@
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
 	id = 7;
-	name = "\improper Quarters 7";
-	req_access_txt = "0"
+	name = "\improper Quarters 7"
 	},
 /turf/open/floor/wood,
 /area/mainship/living/pilotbunks)
 "CZ" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
-	name = "Bathroom"
+	name = "\improper Bathroom"
 	},
 /turf/open/floor/mainship{
 	icon_state = "dark_sterile"
@@ -8531,8 +8464,7 @@
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
 	id = 8;
-	name = "\improper Quarters 8";
-	req_access_txt = "0"
+	name = "\improper Quarters 8"
 	},
 /turf/open/floor/wood,
 /area/mainship/squads/delta)
@@ -9164,9 +9096,7 @@
 /area/mainship/engineering/engine_core)
 "Fl" = (
 /obj/machinery/door/airlock/mainship/maint{
-	dir = 2;
-	req_access_txt = "0";
-	req_one_access_txt = "2;7"
+	dir = 2
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -9372,9 +9302,7 @@
 /area/mainship/engineering/engine_core)
 "FJ" = (
 /obj/machinery/door/airlock/mainship/security{
-	locked = 1;
-	name = "\improper Nexus Dome Marshal Office";
-	req_access_txt = "0"
+	name = "\improper Nexus Dome Marshal Office"
 	},
 /turf/open/floor/mainship/mono,
 /area/lv624/lazarus/security)
@@ -9600,8 +9528,7 @@
 "Gn" = (
 /obj/machinery/door/airlock/mainship/security{
 	dir = 2;
-	name = "\improper Security Checkpoint";
-	req_access = 0
+	name = "\improper Security Checkpoint"
 	},
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
@@ -9905,9 +9832,7 @@
 "Hw" = (
 /obj/machinery/door/airlock/mainship/security{
 	dir = 1;
-	locked = 1;
-	name = "\improper Nexus Dome Marshal Office";
-	req_access_txt = "0"
+	name = "\improper Nexus Dome Marshal Office"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -10327,7 +10252,7 @@
 "IF" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 4;
-	name = "Toilet"
+	name = "\improper Toilet"
 	},
 /turf/open/floor/mainship{
 	icon_state = "dark_sterile"
@@ -10343,8 +10268,7 @@
 /area/lv624/lazarus/armory)
 "IH" = (
 /obj/machinery/door_control{
-	id = 1000;
-	pixel_z = 8
+	id = 1000
 	},
 /turf/closed/wall,
 /area/mainship/living/numbertwobunks)
@@ -10355,7 +10279,7 @@
 "IL" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
-	name = "Toilet"
+	name = "\improper Toilet"
 	},
 /turf/open/floor/mainship{
 	icon_state = "dark_sterile"
@@ -10383,7 +10307,7 @@
 "IR" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
-	name = "Bathroom"
+	name = "\improper Bathroom"
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/starboard_emb)
@@ -10644,7 +10568,7 @@
 "Ju" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1;
-	name = "Bathroom"
+	name = "\improper Bathroom"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -10699,9 +10623,7 @@
 "Jz" = (
 /obj/machinery/door/airlock/mainship/security{
 	dir = 1;
-	locked = 1;
-	name = "\improper Nexus Dome Marshal Office";
-	req_access_txt = "0"
+	name = "\improper Nexus Dome Marshal Office"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -11178,10 +11100,9 @@
 	},
 /area/mainship/shipboard/firing_range)
 "Ly" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "northcheckpoint";
-	name = "North Checkpoint Shutters";
-	req_one_access_txt = "0"
+	name = "North Checkpoint Shutters"
 	},
 /turf/closed/wall,
 /area/mainship/living/commandbunks)
@@ -11200,12 +11121,9 @@
 	},
 /area/mainship/shipboard/weapon_room)
 "LJ" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 1;
-	name = "Killhouse";
-	req_access_txt = "0";
-	req_one_access = 0;
-	req_one_access_txt = "0"
+	name = "Killhouse"
 	},
 /turf/open/floor/mainship,
 /area/mainship/shipboard/firing_range)
@@ -11945,9 +11863,7 @@
 /area/mainship/shipboard/firing_range)
 "Sv" = (
 /obj/machinery/door_control{
-	id = 1005;
-	pixel_w = 0;
-	pixel_z = -7
+	id = 1005
 	},
 /turf/closed/wall,
 /area/mainship/squads/delta)
@@ -12131,9 +12047,7 @@
 /area/mainship/shipboard/firing_range)
 "UV" = (
 /obj/machinery/door_control{
-	id = 1004;
-	pixel_w = 0;
-	pixel_z = -7
+	id = 1004
 	},
 /turf/closed/wall,
 /area/mainship/living/pilotbunks)
@@ -12489,8 +12403,7 @@
 /area/mainship/shipboard/firing_range)
 "YU" = (
 /obj/machinery/door_control{
-	id = 1001;
-	pixel_z = 8
+	id = 1001
 	},
 /turf/closed/wall,
 /area/mainship/squads/bravo)

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -286,8 +286,7 @@
 /area/mainship/hallways/hangar)
 "aU" = (
 /obj/machinery/door/firedoor/mainship{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /turf/open/floor/stairs/rampbottom{
 	dir = 1
@@ -715,8 +714,7 @@
 /area/mainship/medical/chemistry)
 "bQ" = (
 /obj/machinery/door/firedoor/mainship{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/light{
 	dir = 8
@@ -870,8 +868,7 @@
 "cf" = (
 /obj/structure/window/framed/mainship/white,
 /obj/machinery/door/firedoor/mainship{
-	dir = 2;
-	icon_state = "door_open"
+	dir = 2
 	},
 /turf/open/floor/mainship{
 	icon_state = "dark_sterile"
@@ -889,8 +886,7 @@
 /area/mainship/hallways/hangar)
 "ch" = (
 /obj/machinery/door/firedoor/mainship{
-	dir = 2;
-	icon_state = "door_open"
+	dir = 2
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -958,8 +954,7 @@
 	dir = 2
 	},
 /obj/machinery/door/firedoor/mainship{
-	dir = 2;
-	icon_state = "door_open"
+	dir = 2
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -1024,8 +1019,7 @@
 	throw_range = 15
 	},
 /obj/machinery/door/firedoor/mainship{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 1
@@ -1377,8 +1371,7 @@
 /area/mainship/hallways/stern_hallway)
 "dr" = (
 /obj/machinery/door/firedoor/mainship{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 1
@@ -1403,8 +1396,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /turf/open/floor/mainship{
 	icon_state = "dark_sterile"
@@ -1525,8 +1517,7 @@
 "dX" = (
 /obj/structure/window/framed/mainship/white,
 /obj/machinery/door/firedoor/mainship{
-	dir = 2;
-	icon_state = "door_open"
+	dir = 2
 	},
 /turf/open/floor/mainship{
 	icon_state = "dark_sterile"
@@ -1698,8 +1689,7 @@
 	icon_state = "pdoor0"
 	},
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
@@ -1805,8 +1795,7 @@
 "eN" = (
 /obj/structure/window/framed/mainship,
 /obj/machinery/door/firedoor/mainship{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
@@ -2011,8 +2000,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/mainship{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 1
@@ -2246,8 +2234,7 @@
 	dir = 2
 	},
 /obj/machinery/door/firedoor/mainship{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /turf/open/floor/mainship,
 /area/mainship/living/port_emb)
@@ -2435,8 +2422,7 @@
 "hy" = (
 /obj/structure/window/framed/mainship/white,
 /obj/machinery/door/firedoor/mainship{
-	dir = 2;
-	icon_state = "door_open"
+	dir = 2
 	},
 /turf/open/floor/mainship{
 	icon_state = "dark_sterile"
@@ -2510,8 +2496,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/mainship{
-	dir = 2;
-	icon_state = "door_open"
+	dir = 2
 	},
 /turf/open/floor/mainship{
 	icon_state = "dark_sterile"
@@ -2606,8 +2591,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/mainship{
-	dir = 2;
-	icon_state = "door_open"
+	dir = 2
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
@@ -2616,8 +2600,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/mainship{
-	dir = 2;
-	icon_state = "door_open"
+	dir = 2
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -3246,8 +3229,7 @@
 /area/mainship/medical/medical_science)
 "jQ" = (
 /obj/machinery/door/firedoor/mainship{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/airlock/mainship/marine/general/corps{
 	dir = 2
@@ -3256,8 +3238,7 @@
 /area/mainship/squads/general)
 "jR" = (
 /obj/machinery/door/firedoor/mainship{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/airlock/mainship/marine/general/engi{
 	dir = 2
@@ -3379,8 +3360,7 @@
 	dir = 2
 	},
 /obj/machinery/door/firedoor/multi_tile{
-	dir = 2;
-	icon_state = "door_open"
+	dir = 2
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3505,8 +3485,7 @@
 /area/mainship/living/port_garden)
 "kz" = (
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /turf/open/floor/mainship{
 	icon_state = "test_floor4"
@@ -4517,8 +4496,7 @@
 	icon_state = "left"
 	},
 /obj/machinery/door/firedoor/mainship{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/poddoor/shutters/mainship/req/ro{
 	dir = 2
@@ -4825,8 +4803,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/multi_tile{
-	dir = 2;
-	icon_state = "door_open"
+	dir = 2
 	},
 /turf/open/floor/mainship{
 	icon_state = "dark_sterile"
@@ -5399,8 +5376,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/mainship{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -6166,8 +6142,7 @@
 "rH" = (
 /obj/structure/window/framed/mainship,
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /turf/open/floor/plating/mainship,
 /area/mainship/living/port_garden)
@@ -6245,8 +6220,7 @@
 "rS" = (
 /obj/structure/window/framed/mainship,
 /obj/machinery/door/firedoor/mainship{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /turf/open/floor/mainship{
 	icon_plating = "tcomms";
@@ -6259,8 +6233,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -6574,8 +6547,7 @@
 	dir = 2
 	},
 /obj/machinery/door/firedoor/mainship{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/bridgebunks)
@@ -6739,8 +6711,7 @@
 	pixel_y = 5
 	},
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/item/tool/pen,
 /turf/open/floor/mainship/mono,
@@ -6947,8 +6918,7 @@
 /obj/item/folder/red,
 /obj/item/tool/pen,
 /obj/machinery/door/firedoor/mainship{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_umbilical)
@@ -7336,8 +7306,7 @@
 "uz" = (
 /obj/structure/window/framed/mainship/toughened,
 /obj/machinery/door/firedoor/mainship{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_umbilical)
@@ -7524,8 +7493,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /turf/open/floor/mainship{
 	icon_state = "redfull"
@@ -7686,8 +7654,7 @@
 /area/mainship/command/airoom)
 "vx" = (
 /obj/machinery/door/firedoor/mainship{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /turf/open/floor/mainship{
 	icon_state = "test_floor4"
@@ -7782,8 +7749,7 @@
 	dir = 2
 	},
 /obj/machinery/door/firedoor/mainship{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/upper_engineering)
@@ -8193,8 +8159,7 @@
 "wM" = (
 /obj/machinery/door/airlock/mainship/marine/requisitions,
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -8675,8 +8640,7 @@
 "ya" = (
 /obj/structure/window/framed/mainship,
 /obj/machinery/door/firedoor/mainship{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /turf/open/floor/plating/mainship,
 /area/mainship/engineering/upper_engineering)
@@ -8685,8 +8649,7 @@
 /obj/machinery/door/window/northleft/brig,
 /obj/machinery/door/window/southleft/brig,
 /obj/machinery/door/firedoor/mainship{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/lower_engineering)
@@ -9036,8 +8999,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /turf/open/floor/mainship{
 	icon_state = "test_floor4"
@@ -9228,8 +9190,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /turf/open/floor/plating/mainship,
 /area/mainship/engineering/engineering_workshop)
@@ -9340,8 +9301,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /turf/open/floor/plating/mainship,
 /area/mainship/engineering/engineering_workshop)
@@ -9543,8 +9503,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/multi_tile{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /turf/open/floor/mainship,
 /area/mainship/living/cryo_cells)
@@ -9712,8 +9671,7 @@
 /area/mainship/living/port_emb)
 "AB" = (
 /obj/machinery/door/firedoor/mainship{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /turf/open/floor/mainship{
 	icon_state = "test_floor4"
@@ -9793,8 +9751,7 @@
 /area/mainship/command/self_destruct)
 "AM" = (
 /obj/machinery/door/firedoor/mainship{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /turf/open/floor/mainship{
 	icon_state = "test_floor4"
@@ -9821,8 +9778,7 @@
 /area/mainship/hallways/port_hallway)
 "AP" = (
 /obj/machinery/door/firedoor/mainship{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /turf/open/floor/mainship{
 	icon_state = "test_floor4"
@@ -9940,8 +9896,7 @@
 /area/shuttle/distress/arrive_s_hangar)
 "Be" = (
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /turf/open/floor/mainship{
 	icon_state = "test_floor4"
@@ -9949,8 +9904,7 @@
 /area/mainship/hallways/starboard_umbilical)
 "Bf" = (
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /turf/open/floor/mainship{
 	icon_state = "test_floor4"
@@ -10564,8 +10518,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -10890,8 +10843,7 @@
 /area/mainship/hallways/port_hallway)
 "Dh" = (
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/poddoor/mainship/open/cic{
 	dir = 4;
@@ -11039,8 +10991,7 @@
 /area/mainship/command/cic)
 "Dw" = (
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/poddoor/mainship/open/cic{
 	dir = 4;
@@ -11144,8 +11095,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -11687,8 +11637,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/mainship{
-	dir = 2;
-	icon_state = "door_open"
+	dir = 2
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -12352,8 +12301,7 @@
 /area/mainship/command/telecomms)
 "Gy" = (
 /obj/machinery/door/firedoor/mainship{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
@@ -12474,8 +12422,7 @@
 /area/mainship/hallways/hangar)
 "GL" = (
 /obj/machinery/door/firedoor/mainship{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 1
@@ -12579,8 +12526,7 @@
 "GU" = (
 /obj/structure/window/framed/mainship,
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/poddoor/shutters/mainship/corporate{
 	dir = 4;
@@ -12604,8 +12550,7 @@
 "GW" = (
 /obj/structure/window/framed/mainship,
 /obj/machinery/door/firedoor/mainship{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /turf/open/floor/plating/mainship,
 /area/mainship/hallways/hangar)
@@ -12708,8 +12653,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -13014,8 +12958,7 @@
 "HF" = (
 /obj/machinery/door/airlock/mainship/maint/core,
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -13179,8 +13122,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -13408,8 +13350,7 @@
 /area/mainship/hallways/starboard_umbilical)
 "Io" = (
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -13813,8 +13754,7 @@
 "Jj" = (
 /obj/machinery/door/airlock/mainship/command/FCDRoffice,
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -13970,8 +13910,7 @@
 	dir = 2
 	},
 /obj/machinery/door/firedoor/mainship{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -14190,8 +14129,7 @@
 /area/mainship/squads/req)
 "JO" = (
 /obj/machinery/door/firedoor/mainship{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
@@ -14601,8 +14539,7 @@
 /area/mainship/hallways/stern_hallway)
 "Kw" = (
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -14719,8 +14656,7 @@
 "KC" = (
 /obj/machinery/door/airlock/mainship/command,
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -14849,8 +14785,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/multi_tile{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -15544,8 +15479,7 @@
 /area/mainship/engineering/engineering_workshop)
 "Mt" = (
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /turf/open/floor/mainship{
 	icon_state = "test_floor4"
@@ -16026,8 +15960,7 @@
 /area/mainship/hallways/aft_hallway)
 "Nu" = (
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 1
@@ -16109,8 +16042,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/airlock/mainship/engineering/disposals{
 	dir = 4
@@ -16119,8 +16051,7 @@
 /area/mainship/hull/lower_hull)
 "NC" = (
 /obj/machinery/door/firedoor/mainship{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/airlock/mainship/engineering/workshop{
 	dir = 2
@@ -16129,8 +16060,7 @@
 /area/mainship/engineering/upper_engineering)
 "ND" = (
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -16236,8 +16166,7 @@
 /area/mainship/squads/general)
 "NN" = (
 /obj/machinery/door/firedoor/mainship{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -16329,8 +16258,7 @@
 "Ot" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -16920,8 +16848,7 @@
 	name = "\improper Rest and Relaxation Area"
 	},
 /obj/machinery/door/firedoor/multi_tile{
-	dir = 2;
-	icon_state = "door_open"
+	dir = 2
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -18089,8 +18016,7 @@
 "YX" = (
 /obj/machinery/door/airlock/mainship/marine/requisitions,
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -3250,8 +3250,7 @@
 	icon_state = "door_open"
 	},
 /obj/machinery/door/airlock/mainship/marine/general/corps{
-	dir = 2;
-	icon_state = "door_closed"
+	dir = 2
 	},
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
@@ -3261,8 +3260,7 @@
 	icon_state = "door_open"
 	},
 /obj/machinery/door/airlock/mainship/marine/general/engi{
-	dir = 2;
-	icon_state = "door_closed"
+	dir = 2
 	},
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
@@ -9542,8 +9540,7 @@
 /area/mainship/engineering/engineering_workshop)
 "Ah" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic/cryo{
-	dir = 8;
-	icon_state = "door_closed"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 8;

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -219,10 +219,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "aL" = (
-/obj/machinery/door/airlock/mainship/maint{
-	no_panel = 1;
-	not_weldable = 1
-	},
+/obj/machinery/door/airlock/mainship/maint,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -1473,8 +1470,7 @@
 "dO" = (
 /obj/machinery/door/airlock/mainship/medical/glass,
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /turf/open/floor/mainship{
 	icon_state = "dark_sterile"
@@ -1485,8 +1481,7 @@
 	dir = 2
 	},
 /obj/machinery/door/firedoor/mainship{
-	dir = 2;
-	icon_state = "door_open"
+	dir = 2
 	},
 /turf/open/floor/mainship{
 	icon_state = "dark_sterile"
@@ -2219,10 +2214,7 @@
 /turf/open/floor/mainship,
 /area/mainship/hallways/aft_hallway)
 "gJ" = (
-/obj/machinery/door/airlock/mainship/maint{
-	no_panel = 1;
-	not_weldable = 1
-	},
+/obj/machinery/door/airlock/mainship/maint,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -2481,8 +2473,7 @@
 	dir = 2
 	},
 /obj/machinery/door/firedoor/mainship{
-	dir = 2;
-	icon_state = "door_open"
+	dir = 2
 	},
 /turf/open/floor/mainship{
 	icon_state = "dark_sterile"
@@ -2599,8 +2590,7 @@
 "hP" = (
 /obj/machinery/door/airlock/mainship/research/pen,
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -3431,8 +3421,7 @@
 "kr" = (
 /obj/machinery/door/airlock/mainship/research/pen,
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -3465,10 +3454,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/stern_hallway)
 "ku" = (
-/obj/machinery/door/airlock/mainship/maint{
-	req_access_txt = "7";
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/mainship/maint,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -3506,10 +3492,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/port_garden)
 "kx" = (
-/obj/machinery/door/airlock/mainship/maint{
-	req_access_txt = "7";
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/mainship/maint,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -3558,11 +3541,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/port_missiles)
 "kD" = (
-/obj/machinery/door/airlock/mainship/maint{
-	req_access_txt = "200";
-	req_one_access = null;
-	req_one_access_txt = null
-	},
+/obj/machinery/door/airlock/mainship/maint,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "kE" = (
@@ -4126,10 +4105,7 @@
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "lZ" = (
-/obj/machinery/door/airlock/mainship/maint{
-	req_access_txt = "7";
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/mainship/maint,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -4561,8 +4537,7 @@
 "nj" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor/medbay,
 /obj/machinery/door/firedoor/multi_tile{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /turf/open/floor/mainship{
 	icon_state = "dark_sterile"
@@ -5398,7 +5373,9 @@
 	},
 /area/mainship/command/cic)
 "pC" = (
-/obj/machinery/door/airlock/mainship/medical/glass/animalcontrol,
+/obj/machinery/door/airlock/mainship/medical/glass/research{
+	name = "\improper Animal Control Closet"
+	},
 /turf/open/floor/mainship{
 	icon_state = "dark_sterile"
 	},
@@ -5665,10 +5642,7 @@
 /area/mainship/command/corporateliaison)
 "qi" = (
 /obj/structure/table/woodentable,
-/obj/machinery/computer/skills{
-	density = 0;
-	req_one_access = list(200)
-	},
+/obj/machinery/computer/skills,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "qj" = (
@@ -6040,11 +6014,7 @@
 /turf/open/floor/mainship,
 /area/mainship/living/cafeteria_starboard)
 "rj" = (
-/obj/machinery/door/airlock/mainship/maint{
-	req_access_txt = "1";
-	req_one_access = null;
-	req_one_access_txt = null
-	},
+/obj/machinery/door/airlock/mainship/maint,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "rk" = (
@@ -6613,8 +6583,7 @@
 /area/mainship/living/bridgebunks)
 "sJ" = (
 /obj/machinery/door/airlock/mainship/maint{
-	dir = 2;
-	req_one_access_txt = "2;7;200"
+	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
@@ -6766,13 +6735,8 @@
 /area/mainship/hull/lower_hull)
 "te" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/eastleft{
-	req_one_access_txt = "2;21"
-	},
-/obj/machinery/door/window/eastleft{
-	dir = 8;
-	icon_state = "left"
-	},
+/obj/machinery/door/window/eastleft/req,
+/obj/machinery/door/window/westleft,
 /obj/structure/paper_bin{
 	pixel_y = 5
 	},
@@ -6802,10 +6766,7 @@
 /turf/closed/wall/mainship,
 /area/mainship/command/airoom)
 "tk" = (
-/obj/machinery/door/airlock/mainship/maint{
-	req_access_txt = "7";
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/mainship/maint,
 /turf/open/floor/plating,
 /area/mainship/hull/lower_hull)
 "tl" = (
@@ -6979,18 +6940,8 @@
 /area/mainship/hull/lower_hull)
 "tF" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/eastleft{
-	dir = 2;
-	icon_state = "left";
-	req_access = null;
-	req_access_txt = "3"
-	},
-/obj/machinery/door/window/eastleft{
-	dir = 1;
-	icon_state = "left";
-	req_access = null;
-	req_access_txt = "3"
-	},
+/obj/machinery/door/window/northleft/brig,
+/obj/machinery/door/window/southleft/brig,
 /obj/structure/paper_bin{
 	pixel_x = -4;
 	pixel_y = 5
@@ -7612,9 +7563,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/port_missiles)
 "vh" = (
-/obj/structure/closet/secure_closet/personal/cabinet{
-	req_access = null
-	},
+/obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/carpet{
 	dir = 10;
 	icon_state = "carpetside"
@@ -8735,18 +8684,8 @@
 /area/mainship/engineering/upper_engineering)
 "yb" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/eastleft{
-	dir = 1;
-	icon_state = "left";
-	req_access = null;
-	req_access_txt = "3"
-	},
-/obj/machinery/door/window/eastleft{
-	dir = 2;
-	icon_state = "left";
-	req_access = null;
-	req_access_txt = "3"
-	},
+/obj/machinery/door/window/northleft/brig,
+/obj/machinery/door/window/southleft/brig,
 /obj/machinery/door/firedoor/mainship{
 	dir = 1;
 	icon_state = "door_open"
@@ -9282,8 +9221,7 @@
 /area/mainship/hallways/hangar)
 "zr" = (
 /obj/machinery/door/airlock/mainship/engineering/storage{
-	dir = 8;
-	icon_state = "door_closed"
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -9398,8 +9336,7 @@
 /area/mainship/engineering/lower_engine_monitoring)
 "zH" = (
 /obj/machinery/door/airlock/mainship/engineering/storage{
-	dir = 8;
-	icon_state = "door_closed"
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -9936,10 +9873,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "AU" = (
-/obj/machinery/door/airlock/mainship/maint{
-	req_access_txt = "7";
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/mainship/maint,
 /turf/open/floor/plating/mainship,
 /area/mainship/engineering/lower_engine_monitoring)
 "AV" = (
@@ -9948,10 +9882,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	req_access_txt = "7";
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/mainship/maint,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "AW" = (
@@ -9972,18 +9903,8 @@
 /area/mainship/shipboard/starboard_missiles)
 "AZ" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/eastleft{
-	dir = 1;
-	icon_state = "left";
-	req_access = null;
-	req_access_txt = "3"
-	},
-/obj/machinery/door/window/eastleft{
-	dir = 2;
-	icon_state = "left";
-	req_access = null;
-	req_access_txt = "3"
-	},
+/obj/machinery/door/window/northleft/brig,
+/obj/machinery/door/window/eastleft/brig,
 /obj/structure/paper_bin{
 	pixel_y = 5
 	},
@@ -10049,18 +9970,8 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
-"Bh" = (
-/obj/machinery/door/airlock/mainship/maint{
-	req_access_txt = "7";
-	req_one_access_txt = "0"
-	},
-/turf/open/floor/plating/mainship,
-/area/mainship/medical/lower_medical)
 "Bi" = (
-/obj/machinery/door/airlock/mainship/maint{
-	req_access_txt = "7";
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/mainship/maint,
 /turf/open/floor/plating/mainship,
 /area/mainship/hull/lower_hull)
 "Bj" = (
@@ -10380,8 +10291,7 @@
 "BM" = (
 /obj/machinery/door/airlock/mainship/generic/corporate/quarters,
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -10760,10 +10670,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "CN" = (
-/obj/machinery/door/airlock/mainship/maint{
-	req_access_txt = "7";
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/mainship/maint,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -10802,10 +10709,7 @@
 	},
 /area/mainship/hull/lower_hull)
 "CR" = (
-/obj/machinery/door/airlock/mainship/maint{
-	no_panel = 1;
-	not_weldable = 1
-	},
+/obj/machinery/door/airlock/mainship/maint,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -10872,10 +10776,7 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
 "CX" = (
-/obj/machinery/door/airlock/mainship/maint{
-	req_access_txt = "7";
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/mainship/maint,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -11337,10 +11238,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_umbilical)
 "DJ" = (
-/obj/machinery/door/airlock/mainship/maint{
-	no_panel = 1;
-	not_weldable = 1
-	},
+/obj/machinery/door/airlock/mainship/maint,
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-s"
@@ -11471,10 +11369,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "DW" = (
-/obj/machinery/door/airlock/mainship/maint{
-	no_panel = 1;
-	not_weldable = 1
-	},
+/obj/machinery/door/airlock/mainship/maint,
 /turf/open/floor/plating/mainship,
 /area/mainship/medical/lower_medical)
 "DZ" = (
@@ -12436,8 +12331,7 @@
 	dir = 1
 	},
 /obj/machinery/door_control/mainship/ammo{
-	pixel_x = 30;
-	throw_range = 15
+	pixel_x = 30
 	},
 /turf/open/floor/mainship{
 	icon_state = "test_floor4"
@@ -14453,10 +14347,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	no_panel = 1;
-	not_weldable = 1
-	},
+/obj/machinery/door/airlock/mainship/maint,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -14675,8 +14566,7 @@
 "Ku" = (
 /obj/machinery/door/airlock/mainship/generic/bathroom,
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -14867,18 +14757,6 @@
 "KE" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/briefing)
-"KF" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2;
-	req_one_access_txt = "2;7;200"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
 "KH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 1
@@ -15148,8 +15026,7 @@
 "Li" = (
 /obj/machinery/door/airlock/mainship/engineering/CSEoffice,
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -15367,18 +15244,6 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
-"LC" = (
-/obj/machinery/door/airlock/mainship/maint{
-	req_access_txt = "7";
-	req_one_access_txt = "0"
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
@@ -15926,8 +15791,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/mainship{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -15952,10 +15816,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	no_panel = 1;
-	not_weldable = 1
-	},
+/obj/machinery/door/airlock/mainship/maint,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -16486,8 +16347,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/mainship/engineering/atmos{
-	dir = 8;
-	icon_state = "door_closed"
+	dir = 8
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/port_atmos)
@@ -17417,8 +17277,7 @@
 /area/mainship/hallways/hangar)
 "Sp" = (
 /obj/machinery/door/airlock/mainship/command/FCDRquarters{
-	dir = 2;
-	icon_state = "door_closed"
+	dir = 2
 	},
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
@@ -17575,10 +17434,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	req_access_txt = "7";
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/mainship/maint,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "TH" = (
@@ -17640,11 +17496,7 @@
 /turf/open/floor/mainship,
 /area/mainship/living/cafeteria_starboard)
 "Uk" = (
-/obj/machinery/door/airlock/mainship/maint{
-	req_access_txt = "1";
-	req_one_access = null;
-	req_one_access_txt = null
-	},
+/obj/machinery/door/airlock/mainship/maint,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "Up" = (
@@ -18076,10 +17928,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "Xt" = (
-/obj/machinery/door/airlock/mainship/maint{
-	no_panel = 1;
-	not_weldable = 1
-	},
+/obj/machinery/door/airlock/mainship/maint,
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-s"
@@ -41123,7 +40972,7 @@ tH
 ad
 ad
 ad
-LC
+aL
 Mb
 Mb
 Mb
@@ -41137,7 +40986,7 @@ Mb
 Mb
 Mb
 Mb
-LC
+aL
 OB
 tp
 tp
@@ -42645,7 +42494,7 @@ nH
 nN
 bd
 bd
-Bh
+DW
 bd
 bd
 bd
@@ -43980,7 +43829,7 @@ Mb
 uX
 JD
 ew
-KF
+JF
 ew
 ew
 ew
@@ -44247,7 +44096,7 @@ zC
 zC
 zC
 zC
-LC
+aL
 ad
 aa
 aa
@@ -48359,7 +48208,7 @@ Lf
 Ln
 Lt
 Ly
-LC
+aL
 ad
 aa
 aa
@@ -52728,7 +52577,7 @@ Mb
 Mb
 Mb
 Mb
-LC
+aL
 ad
 aa
 aa
@@ -55772,7 +55621,7 @@ Ee
 ad
 ad
 ad
-LC
+aL
 Mb
 Mb
 Mb
@@ -55786,7 +55635,7 @@ Mb
 Mb
 Mb
 Mb
-LC
+aL
 Mb
 aO
 Mb

--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -1378,11 +1378,7 @@
 /turf/open/floor/prison/marked,
 /area/prison/research/secret/bioengineering)
 "agn" = (
-/obj/machinery/door/airlock/prison{
-	density = 0;
-	icon_state = "door_open";
-	opacity = 0
-	},
+/obj/machinery/door/airlock/prison/open,
 /turf/open/floor/prison/cellstripe{
 	dir = 4
 	},
@@ -4044,11 +4040,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/prison{
-	density = 0;
-	icon_state = "door_open";
-	opacity = 0
-	},
+/obj/machinery/door/airlock/prison/open,
 /turf/open/floor/prison,
 /area/prison/cellblock/maxsec/south)
 "anc" = (
@@ -4091,11 +4083,7 @@
 	},
 /area/prison/cellblock/maxsec/south)
 "anh" = (
-/obj/machinery/door/airlock/prison{
-	density = 0;
-	icon_state = "door_open";
-	opacity = 0
-	},
+/obj/machinery/door/airlock/prison/open,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -5000,11 +4988,7 @@
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/access/north)
 "apj" = (
-/obj/machinery/door/airlock/prison{
-	density = 0;
-	icon_state = "door_open";
-	opacity = 0
-	},
+/obj/machinery/door/airlock/prison/open,
 /turf/open/floor/prison/red/full,
 /area/prison/cellblock/highsec/north/north)
 "apk" = (
@@ -7731,11 +7715,7 @@
 /turf/open/floor/wood,
 /area/prison/residential/north)
 "avU" = (
-/obj/machinery/door/airlock/prison/horizontal{
-	density = 0;
-	icon_state = "door_open";
-	opacity = 0
-	},
+/obj/machinery/door/airlock/prison/horizontal/open,
 /turf/open/floor/prison/red/full,
 /area/prison/cellblock/highsec/north/north)
 "avV" = (
@@ -12847,11 +12827,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/north)
 "aIs" = (
-/obj/machinery/door/airlock/prison{
-	density = 0;
-	icon_state = "door_open";
-	opacity = 0
-	},
+/obj/machinery/door/airlock/prison/open,
 /turf/open/floor/prison/red/full,
 /area/prison/cellblock/highsec/north/south)
 "aIt" = (
@@ -17590,11 +17566,7 @@
 /turf/open/floor/prison,
 /area/prison/canteen)
 "aTH" = (
-/obj/machinery/door/airlock/prison/horizontal{
-	density = 0;
-	icon_state = "door_open";
-	opacity = 0
-	},
+/obj/machinery/door/airlock/prison/horizontal/open,
 /turf/open/floor/prison/green/full,
 /area/prison/cellblock/lowsec/nw)
 "aTI" = (
@@ -17674,11 +17646,7 @@
 	},
 /area/prison/yard)
 "aTS" = (
-/obj/machinery/door/airlock/prison/horizontal{
-	density = 0;
-	icon_state = "door_open";
-	opacity = 0
-	},
+/obj/machinery/door/airlock/prison/horizontal/open,
 /turf/open/floor/prison/green/full,
 /area/prison/cellblock/lowsec/ne)
 "aTT" = (
@@ -18911,11 +18879,7 @@
 /turf/closed/wall/r_wall/prison_unmeltable,
 /area/prison/security/monitoring/highsec)
 "aWA" = (
-/obj/machinery/door/airlock/prison/horizontal{
-	density = 0;
-	icon_state = "door_open";
-	opacity = 0
-	},
+/obj/machinery/door/airlock/prison/horizontal/open,
 /turf/open/floor/prison/red/full,
 /area/prison/cellblock/highsec/north/south)
 "aWB" = (
@@ -19543,11 +19507,7 @@
 	},
 /area/prison/cellblock/lowsec/ne)
 "aYp" = (
-/obj/machinery/door/airlock/prison{
-	density = 0;
-	icon_state = "door_open";
-	opacity = 0
-	},
+/obj/machinery/door/airlock/prison/open,
 /turf/open/floor/prison/green/full,
 /area/prison/cellblock/lowsec/ne)
 "aYq" = (
@@ -20679,11 +20639,7 @@
 	},
 /area/prison/cellblock/lowsec/nw)
 "bbm" = (
-/obj/machinery/door/airlock/prison{
-	density = 0;
-	icon_state = "door_open";
-	opacity = 0
-	},
+/obj/machinery/door/airlock/prison/open,
 /turf/open/floor/prison/green/full,
 /area/prison/cellblock/lowsec/nw)
 "bbn" = (
@@ -28226,11 +28182,7 @@
 	},
 /area/prison/cellblock/lowsec/se)
 "bsM" = (
-/obj/machinery/door/airlock/prison/horizontal{
-	density = 0;
-	icon_state = "door_open";
-	opacity = 0
-	},
+/obj/machinery/door/airlock/prison/horizontal/open,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison/blue/full,
@@ -30372,11 +30324,7 @@
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/se)
 "byq" = (
-/obj/machinery/door/airlock/prison{
-	density = 0;
-	icon_state = "door_open";
-	opacity = 0
-	},
+/obj/machinery/door/airlock/prison/open,
 /turf/open/floor/prison/green/full,
 /area/prison/cellblock/lowsec/sw)
 "byr" = (
@@ -30779,11 +30727,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/central)
 "bzs" = (
-/obj/machinery/door/airlock/prison{
-	density = 0;
-	icon_state = "door_open";
-	opacity = 0
-	},
+/obj/machinery/door/airlock/prison/open,
 /turf/open/floor/prison/green/full,
 /area/prison/cellblock/lowsec/se)
 "bzt" = (
@@ -32030,11 +31974,7 @@
 	},
 /area/prison/hallway/central)
 "bCA" = (
-/obj/machinery/door/airlock/prison/horizontal{
-	density = 0;
-	icon_state = "door_open";
-	opacity = 0
-	},
+/obj/machinery/door/airlock/prison/horizontal/open,
 /turf/open/floor/prison/red/full,
 /area/prison/cellblock/highsec/south/north)
 "bCB" = (
@@ -34963,11 +34903,7 @@
 	},
 /area/prison/holding/holding2)
 "bJb" = (
-/obj/machinery/door/airlock/prison/horizontal{
-	density = 0;
-	icon_state = "door_open";
-	opacity = 0
-	},
+/obj/machinery/door/airlock/prison/horizontal/open,
 /turf/open/floor/prison/green/full,
 /area/prison/cellblock/lowsec/sw)
 "bJc" = (
@@ -35141,11 +35077,7 @@
 /turf/open/floor/wood,
 /area/prison/residential/south)
 "bJC" = (
-/obj/machinery/door/airlock/prison/horizontal{
-	density = 0;
-	icon_state = "door_open";
-	opacity = 0
-	},
+/obj/machinery/door/airlock/prison/horizontal/open,
 /turf/open/floor/prison/green/full,
 /area/prison/cellblock/lowsec/se)
 "bJE" = (
@@ -37430,11 +37362,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/south)
 "bPg" = (
-/obj/machinery/door/airlock/prison{
-	density = 0;
-	icon_state = "door_open";
-	opacity = 0
-	},
+/obj/machinery/door/airlock/prison/open,
 /turf/open/floor/prison/red/full,
 /area/prison/cellblock/highsec/south/north)
 "bPh" = (
@@ -46542,11 +46470,7 @@
 /turf/open/floor/plating,
 /area/prison/cellblock/protective)
 "cmy" = (
-/obj/machinery/door/airlock/prison/horizontal{
-	density = 0;
-	icon_state = "door_open";
-	opacity = 0
-	},
+/obj/machinery/door/airlock/prison/horizontal/open,
 /turf/open/floor/plating,
 /area/prison/cellblock/highsec/south/south)
 "cmz" = (
@@ -47054,11 +46978,7 @@
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/highsec/south/south)
 "cnO" = (
-/obj/machinery/door/airlock/prison/horizontal{
-	density = 0;
-	icon_state = "door_open";
-	opacity = 0
-	},
+/obj/machinery/door/airlock/prison/horizontal/open,
 /turf/open/floor/prison/red/full,
 /area/prison/cellblock/highsec/south/south)
 "cnQ" = (
@@ -48119,11 +48039,7 @@
 	},
 /area/prison/cellblock/mediumsec/east)
 "cqS" = (
-/obj/machinery/door/airlock/prison/horizontal{
-	density = 0;
-	icon_state = "door_open";
-	opacity = 0
-	},
+/obj/machinery/door/airlock/prison/horizontal/open,
 /turf/open/floor/prison/blue/full,
 /area/prison/cellblock/protective)
 "cqT" = (
@@ -48651,11 +48567,7 @@
 /turf/open/floor/plating,
 /area/prison/cellblock/mediumsec/west)
 "csA" = (
-/obj/machinery/door/airlock/prison/horizontal{
-	density = 0;
-	icon_state = "door_open";
-	opacity = 0
-	},
+/obj/machinery/door/airlock/prison/horizontal/open,
 /turf/open/floor/prison/yellow/full,
 /area/prison/cellblock/mediumsec/west)
 "csB" = (
@@ -48736,11 +48648,7 @@
 	},
 /area/prison/cellblock/mediumsec/north)
 "csK" = (
-/obj/machinery/door/airlock/prison/horizontal{
-	density = 0;
-	icon_state = "door_open";
-	opacity = 0
-	},
+/obj/machinery/door/airlock/prison/horizontal/open,
 /turf/open/floor/prison/yellow/full,
 /area/prison/cellblock/mediumsec/east)
 "csL" = (
@@ -49446,11 +49354,7 @@
 	},
 /area/prison/cellblock/mediumsec/east)
 "cuy" = (
-/obj/machinery/door/airlock/prison{
-	density = 0;
-	icon_state = "door_open";
-	opacity = 0
-	},
+/obj/machinery/door/airlock/prison/open,
 /turf/open/floor/prison/yellow/full,
 /area/prison/cellblock/mediumsec/north)
 "cuz" = (
@@ -49497,11 +49401,7 @@
 	},
 /area/prison/cellblock/mediumsec/west)
 "cuI" = (
-/obj/machinery/door/airlock/prison{
-	density = 0;
-	icon_state = "door_open";
-	opacity = 0
-	},
+/obj/machinery/door/airlock/prison/open,
 /turf/open/floor/prison/red/full,
 /area/prison/cellblock/highsec/south/south)
 "cuJ" = (
@@ -49531,11 +49431,7 @@
 	},
 /area/prison/cellblock/mediumsec/south)
 "cuO" = (
-/obj/machinery/door/airlock/prison{
-	density = 0;
-	icon_state = "door_open";
-	opacity = 0
-	},
+/obj/machinery/door/airlock/prison/open,
 /turf/open/floor/prison/yellow/full,
 /area/prison/cellblock/mediumsec/east)
 "cuP" = (
@@ -50060,11 +49956,7 @@
 	},
 /area/prison/security/monitoring/medsec/central)
 "cwk" = (
-/obj/machinery/door/airlock/prison{
-	density = 0;
-	icon_state = "door_open";
-	opacity = 0
-	},
+/obj/machinery/door/airlock/prison/open,
 /turf/open/floor/prison/yellow/full,
 /area/prison/cellblock/mediumsec/south)
 "cwl" = (
@@ -50197,11 +50089,7 @@
 	},
 /area/prison/security/monitoring/medsec/central)
 "cwC" = (
-/obj/machinery/door/airlock/prison{
-	density = 0;
-	icon_state = "door_open";
-	opacity = 0
-	},
+/obj/machinery/door/airlock/prison/open,
 /turf/open/floor/plating,
 /area/prison/cellblock/mediumsec/west)
 "cwE" = (
@@ -50224,11 +50112,7 @@
 /turf/open/floor/plating,
 /area/prison/pirate)
 "cwG" = (
-/obj/machinery/door/airlock/prison{
-	density = 0;
-	icon_state = "door_open";
-	opacity = 0
-	},
+/obj/machinery/door/airlock/prison/open,
 /turf/open/floor/prison/yellow/full,
 /area/prison/cellblock/mediumsec/west)
 "cwH" = (
@@ -50831,11 +50715,7 @@
 	},
 /area/prison/cellblock/mediumsec/south)
 "czk" = (
-/obj/machinery/door/airlock/prison/horizontal{
-	density = 0;
-	icon_state = "door_open";
-	opacity = 0
-	},
+/obj/machinery/door/airlock/prison/horizontal/open,
 /turf/open/floor/prison/yellow/full,
 /area/prison/cellblock/mediumsec/south)
 "czl" = (

--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -238,10 +238,9 @@
 /turf/open/floor/plating,
 /area/prison/cellblock/maxsec/north)
 "adf" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 2;
-	name = "Storage";
-	req_one_access_txt = "0"
+	name = "Storage"
 	},
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/access/north)
@@ -390,9 +389,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/security/glass{
-	name = "Maximum-Security Panopticon";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	name = "Maximum-Security Panopticon"
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/maxsec/north)
@@ -518,12 +516,8 @@
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/maxsec/north)
 "adR" = (
-/obj/machinery/door/airlock/mainship/secure{
-	density = 0;
-	icon_state = "door_open";
-	name = "Cell";
-	opacity = 0;
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/secure/open/free_access{
+	name = "Cell"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -531,9 +525,8 @@
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/maxsec/north)
 "adS" = (
-/obj/machinery/door/airlock/mainship/security/glass{
-	name = "Maximum-Security Panopticon";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	name = "Maximum-Security Panopticon"
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/maxsec/north)
@@ -678,12 +671,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/secure{
-	density = 0;
-	icon_state = "door_open";
-	name = "Cell";
-	opacity = 0;
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/secure/open/free_access{
+	name = "Cell"
 	},
 /turf/open/floor/prison/cellstripe{
 	dir = 8
@@ -723,11 +712,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/security/glass{
-	density = 0;
-	icon_state = "door_open";
-	name = "Cell Access";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	name = "Cell Access"
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/maxsec/north)
@@ -1106,12 +1092,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/secure{
-	density = 0;
-	icon_state = "door_open";
-	name = "Cell";
-	opacity = 0;
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/secure/open/free_access{
+	name = "Cell"
 	},
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/maxsec/north)
@@ -1139,11 +1121,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/security/glass{
-	density = 0;
-	icon_state = "door_open";
-	name = "Cell Access";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	name = "Cell Access"
 	},
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/maxsec/north)
@@ -1444,9 +1423,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/airlock/multi_tile/mainship/comdoor{
-	name = "Biological Testing";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/multi_tile/mainship/comdoor/free_access{
+	name = "Biological Testing"
 	},
 /turf/open/floor/prison/whitepurple/full,
 /area/prison/research/secret/testing)
@@ -1503,9 +1481,7 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/mainship/maint/free_access,
 /turf/open/floor/plating,
 /area/prison/research/secret/containment)
 "agH" = (
@@ -1683,17 +1659,15 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2;
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	dir = 2
 	},
 /turf/open/floor/plating,
 /area/prison/research/secret/containment)
 "ahj" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 2;
-	name = "Human Containment Pen";
-	req_one_access_txt = "0"
+	name = "Human Containment Pen"
 	},
 /turf/open/floor/prison/whitepurple/full,
 /area/prison/research/secret/containment)
@@ -2055,9 +2029,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/mainship/maint/free_access,
 /turf/open/floor/prison/whitepurple/full,
 /area/prison/research/secret/containment)
 "aib" = (
@@ -2460,9 +2432,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/medical/glass{
-	name = "Research Suit Storage";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	name = "Research Suit Storage"
 	},
 /turf/open/floor/prison,
 /area/prison/research/secret)
@@ -2527,10 +2498,9 @@
 /turf/open/floor/prison/whitepurple/full,
 /area/prison/research/secret/containment)
 "aji" = (
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 2;
-	name = "Panopticon Monitoring";
-	req_access_txt = "0"
+	name = "Panopticon Monitoring"
 	},
 /turf/open/floor/prison/plate,
 /area/prison/security/monitoring/maxsec/panopticon)
@@ -2542,10 +2512,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 2;
-	name = "Panopticon Monitoring";
-	req_access_txt = "0"
+	name = "Panopticon Monitoring"
 	},
 /turf/open/floor/prison/plate,
 /area/prison/security/monitoring/maxsec/panopticon)
@@ -2822,9 +2791,8 @@
 /turf/open/floor/prison,
 /area/prison/research/secret/containment)
 "ajV" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
-	name = "Simian Containment Pen";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	name = "Simian Containment Pen"
 	},
 /turf/open/floor/prison/whitepurple/full,
 /area/prison/research/secret/containment)
@@ -3049,10 +3017,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/door/airlock/multi_tile/mainship/comdoor{
+/obj/machinery/door/airlock/multi_tile/mainship/comdoor/free_access{
 	dir = 2;
-	name = "Test Subject Containment";
-	req_access_txt = "0"
+	name = "Test Subject Containment"
 	},
 /turf/open/floor/prison/whitepurple/full,
 /area/prison/research/secret/containment)
@@ -3098,10 +3065,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/door/airlock/multi_tile/mainship/comdoor{
+/obj/machinery/door/airlock/multi_tile/mainship/comdoor/free_access{
 	dir = 2;
-	name = "Test Subject Containment";
-	req_access_txt = "0"
+	name = "Test Subject Containment"
 	},
 /turf/open/floor/prison/whitepurple/full,
 /area/prison/research/secret)
@@ -3169,9 +3135,8 @@
 /turf/closed/wall/r_wall/prison_unmeltable,
 /area/prison/cellblock/maxsec/south)
 "akG" = (
-/obj/machinery/door/airlock/mainship/security/glass{
-	name = "Maximum-Security Panopticon";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	name = "Maximum-Security Panopticon"
 	},
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/maxsec/north)
@@ -3320,9 +3285,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/security/glass{
-	name = "Maximum-Security Panopticon";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	name = "Maximum-Security Panopticon"
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/maxsec/south)
@@ -3333,9 +3297,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/security/glass{
-	name = "Maximum-Security Panopticon";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	name = "Maximum-Security Panopticon"
 	},
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/maxsec/north)
@@ -3376,10 +3339,9 @@
 /turf/open/floor/plating,
 /area/prison/cellblock/maxsec/south)
 "ale" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 2;
-	name = "Simian Containment Pen";
-	req_one_access_txt = "0"
+	name = "Simian Containment Pen"
 	},
 /turf/open/floor/prison/whitepurple/full,
 /area/prison/research/secret/containment)
@@ -3432,9 +3394,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/secure{
-	name = "Research Armory";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/secure/free_access{
+	name = "Research Armory"
 	},
 /turf/open/floor/prison,
 /area/prison/research/secret)
@@ -3628,8 +3589,7 @@
 /obj/machinery/crema_switch{
 	id = "crema";
 	pixel_x = 28;
-	pixel_y = 28;
-	req_one_access_txt = "2;8;19"
+	pixel_y = 28
 	},
 /turf/open/floor/prison,
 /area/prison/research/secret/dissection)
@@ -3681,10 +3641,9 @@
 /turf/open/floor/prison,
 /area/prison/research/secret)
 "alV" = (
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 2;
-	name = "Maximum-Security Panopticon";
-	req_access_txt = "0"
+	name = "Maximum-Security Panopticon"
 	},
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/maxsec/north)
@@ -3696,10 +3655,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 2;
-	name = "Maximum-Security Panopticon";
-	req_access_txt = "0"
+	name = "Maximum-Security Panopticon"
 	},
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/maxsec/north)
@@ -3710,9 +3668,8 @@
 /turf/open/floor/prison,
 /area/prison/research/secret/containment)
 "alY" = (
-/obj/machinery/door/airlock/mainship/medical{
-	name = "Dissection";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/medical/free_access{
+	name = "Dissection"
 	},
 /turf/open/floor/prison,
 /area/prison/research/secret/dissection)
@@ -3838,10 +3795,9 @@
 	},
 /area/prison/research/secret/chemistry)
 "ams" = (
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 2;
-	name = "Medium-Security Monitoring";
-	req_access_txt = "0"
+	name = "Medium-Security Monitoring"
 	},
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/prison/darkred/full,
@@ -4008,9 +3964,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/medical/glass{
-	name = "Chemistry";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	name = "Chemistry"
 	},
 /turf/open/floor/tile/white,
 /area/prison/research/secret/chemistry)
@@ -4029,11 +3984,9 @@
 /turf/open/floor/plating,
 /area/prison/cellblock/maxsec/south)
 "amU" = (
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	density = 0;
-	icon_state = "door_open";
-	name = "Cell Access";
-	req_access_txt = "0"
+	name = "Cell Access"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -4050,11 +4003,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	density = 0;
-	icon_state = "door_open";
-	name = "Cell Access";
-	req_access_txt = "0"
+	name = "Cell Access"
 	},
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/maxsec/south)
@@ -4228,11 +4179,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	density = 0;
-	icon_state = "door_open";
-	name = "Cell Access";
-	req_access_txt = "0"
+	name = "Cell Access"
 	},
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/maxsec/south)
@@ -4317,9 +4266,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	name = "Research-Infirmary Maintenance";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "Research-Infirmary Maintenance"
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/maxsec/south)
@@ -4568,9 +4516,8 @@
 "aoi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2;
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	dir = 2
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -4832,9 +4779,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	name = "Research-Infirmary Maintenance";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "Research-Infirmary Maintenance"
 	},
 /turf/open/floor/plating,
 /area/prison/maintenance/research_medbay)
@@ -4922,9 +4868,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/medical{
-	name = "Dissection";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/medical/free_access{
+	name = "Dissection"
 	},
 /turf/open/floor/prison,
 /area/prison/research/secret/dissection)
@@ -4956,9 +4901,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/mainship/maint/free_access,
 /turf/open/floor/plating,
 /area/prison/cellblock/maxsec/south)
 "aoW" = (
@@ -5121,10 +5064,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 2;
-	name = "Research-Infirmary Maintenance";
-	req_one_access_txt = "0"
+	name = "Research-Infirmary Maintenance"
 	},
 /turf/open/floor/plating,
 /area/prison/medbay)
@@ -5442,13 +5384,9 @@
 /turf/closed/wall/r_wall/prison_unmeltable,
 /area/prison/security/checkpoint/maxsec_highsec)
 "aqr" = (
-/obj/machinery/door/airlock/mainship/secure{
-	density = 0;
+/obj/machinery/door/airlock/mainship/secure/open/free_access{
 	dir = 2;
-	icon_state = "door_open";
-	name = "Solitary Confinement";
-	opacity = 0;
-	req_access_txt = "0"
+	name = "Solitary Confinement"
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/highsec/north/north)
@@ -5467,9 +5405,8 @@
 /turf/open/floor/prison/sterilewhite,
 /area/prison/medbay)
 "aqu" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
-	name = "Medical Cell";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	name = "Medical Cell"
 	},
 /turf/open/floor/prison/whitegreen/full,
 /area/prison/medbay)
@@ -5615,9 +5552,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/medical{
-	name = "Operating Theatre"
-	},
+/obj/machinery/door/airlock/mainship/medical/or/free_access,
 /turf/open/floor/prison/whitegreen/full,
 /area/prison/medbay/surgery)
 "aqQ" = (
@@ -5810,9 +5745,8 @@
 /turf/open/floor/prison/sterilewhite,
 /area/prison/research/RD)
 "ars" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2;
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -5992,9 +5926,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/security/glass{
-	name = "Security Booth";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	name = "Security Booth"
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/checkpoint/maxsec_highsec)
@@ -6188,9 +6121,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/security/glass{
-	name = "Security Booth";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	name = "Security Booth"
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/checkpoint/maxsec_highsec)
@@ -6493,7 +6425,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/command,
+/obj/machinery/door/airlock/mainship/command/free_access,
 /turf/open/floor,
 /area/prison/research/RD)
 "asS" = (
@@ -6616,10 +6548,8 @@
 /obj/machinery/holosign/surgery{
 	id = "otice"
 	},
-/obj/machinery/door/airlock/mainship/medical{
-	dir = 2;
-	name = "Operating Theatre";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/medical/or/free_access{
+	dir = 2
 	},
 /turf/open/floor/prison/whitegreen/full,
 /area/prison/medbay/surgery)
@@ -7105,9 +7035,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/medical{
-	name = "Morgue";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/medical/free_access{
+	name = "Morgue"
 	},
 /turf/open/floor/prison,
 /area/prison/medbay/morgue)
@@ -7140,8 +7069,7 @@
 /obj/machinery/crema_switch{
 	id = "crema";
 	pixel_x = 28;
-	pixel_y = 28;
-	req_one_access_txt = "2;8;19"
+	pixel_y = 28
 	},
 /turf/open/floor/prison,
 /area/prison/medbay/morgue)
@@ -7159,9 +7087,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/secure{
-	name = "Morgue";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/secure/free_access{
+	name = "Morgue"
 	},
 /turf/open/floor/prison,
 /area/prison/medbay/morgue)
@@ -7820,10 +7747,9 @@
 /turf/open/floor/prison,
 /area/prison/hangar_storage/research)
 "avW" = (
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 2;
-	name = "Maximum-Security Suspended Cellblock";
-	req_access_txt = "0"
+	name = "Maximum-Security Suspended Cellblock"
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/cellblock/maxsec/south)
@@ -7835,10 +7761,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 2;
-	name = "Maximum-Security Suspended Cellblock";
-	req_access_txt = "0"
+	name = "Maximum-Security Suspended Cellblock"
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/cellblock/maxsec/south)
@@ -8242,11 +8167,8 @@
 /area/prison/residential/north)
 "axc" = (
 /obj/machinery/door/airlock/mainship/generic{
-	density = 0;
 	dir = 2;
-	icon_state = "door_open";
-	name = "Toilet";
-	opacity = 0
+	name = "Toilet"
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/north)
@@ -8295,11 +8217,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/security/glass{
-	density = 0;
-	icon_state = "door_open";
-	name = "Cell Access";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	name = "Cell Access"
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/cellblock/maxsec/south)
@@ -8314,9 +8233,8 @@
 /turf/open/floor/plating,
 /area/prison/cellblock/maxsec/south)
 "axi" = (
-/obj/machinery/door/airlock/mainship/security/glass{
-	name = "Maximum-Security Suspended Cellblock";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	name = "Maximum-Security Suspended Cellblock"
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/cellblock/maxsec/south)
@@ -8763,9 +8681,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/medical/glass{
-	name = "Infirmary Storage";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	name = "Infirmary Storage"
 	},
 /turf/open/floor/prison/whitegreen/full,
 /area/prison/medbay)
@@ -8779,7 +8696,7 @@
 /turf/open/floor/prison,
 /area/prison/hangar/civilian)
 "ayt" = (
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	name = "Security Booth"
 	},
 /turf/open/floor/prison/darkred/full,
@@ -8901,9 +8818,7 @@
 	},
 /area/prison/chapel)
 "ayL" = (
-/obj/machinery/door/airlock/mainship/maint{
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/mainship/maint/free_access,
 /turf/open/floor/prison/darkred/full,
 /area/prison/chapel)
 "ayM" = (
@@ -8995,10 +8910,9 @@
 /turf/open/floor/prison/sterilewhite,
 /area/prison/medbay)
 "ayW" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 2;
-	name = "Infirmary Storage";
-	req_one_access_txt = "0"
+	name = "Infirmary Storage"
 	},
 /turf/open/floor/prison/whitegreen/full,
 /area/prison/medbay)
@@ -9430,10 +9344,9 @@
 	},
 /area/prison/research)
 "azU" = (
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 2;
-	name = "Staff-Research Maintenance";
-	req_one_access_txt = "0"
+	name = "Staff-Research Maintenance"
 	},
 /turf/open/floor/prison,
 /area/prison/hangar_storage/research)
@@ -9882,7 +9795,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	name = "North Civilian Residences Access"
 	},
 /turf/open/floor/plating,
@@ -10042,9 +9955,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/medical/glass{
-	name = "Doctor's Office";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	name = "Doctor's Office"
 	},
 /turf/open/floor/prison/whitegreen/full,
 /area/prison/medbay)
@@ -10099,9 +10011,8 @@
 /turf/open/floor/prison/sterilewhite,
 /area/prison/medbay)
 "aBA" = (
-/obj/machinery/door/airlock/mainship/security/glass{
-	name = "Security Booth";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	name = "Security Booth"
 	},
 /turf/open/floor/prison,
 /area/prison/medbay)
@@ -10152,9 +10063,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/secure{
-	name = "Security Booth";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/secure/free_access{
+	name = "Security Booth"
 	},
 /turf/open/floor/prison,
 /area/prison/research)
@@ -10260,9 +10170,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	name = "Staff-Research Maintenance";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "Staff-Research Maintenance"
 	},
 /turf/open/floor/plating,
 /area/prison/maintenance/staff_research)
@@ -10405,7 +10314,7 @@
 	},
 /area/prison/hallway/central)
 "aCf" = (
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	name = "North Civilian Residences Access"
 	},
 /turf/open/floor/plating,
@@ -10610,8 +10519,7 @@
 "aCI" = (
 /obj/machinery/door/morgue{
 	dir = 2;
-	name = "Confession Booth (Chaplain)";
-	req_access = list(22)
+	name = "Confession Booth (Chaplain)"
 	},
 /turf/open/floor/wood,
 /area/prison/chapel)
@@ -11053,7 +10961,7 @@
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/nw)
 "aDF" = (
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	name = "Custodial Closet"
 	},
 /turf/open/floor/prison/sterilewhite,
@@ -11065,11 +10973,8 @@
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/central)
 "aDH" = (
-/obj/machinery/door/airlock/mainship/security/glass{
-	density = 0;
-	icon_state = "door_open";
-	name = "Cell Access";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	name = "Cell Access"
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/cellblock/maxsec/south)
@@ -11135,7 +11040,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	name = "North Civilian Residences Access"
 	},
 /obj/structure/cable{
@@ -11219,10 +11124,9 @@
 	},
 /area/prison/recreation/highsec/n)
 "aDZ" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 2;
-	name = "Toilet";
-	req_one_access_txt = "0"
+	name = "Toilet"
 	},
 /turf/open/floor/prison{
 	icon_state = "kitchen"
@@ -11279,10 +11183,9 @@
 "aEh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 2;
-	name = "Security Booth";
-	req_access_txt = "0"
+	name = "Security Booth"
 	},
 /turf/open/floor/prison,
 /area/prison/security/checkpoint/maxsec)
@@ -11291,9 +11194,8 @@
 /turf/open/floor/plating,
 /area/prison/security/checkpoint/maxsec)
 "aEj" = (
-/obj/machinery/door/airlock/multi_tile/mainship/comdoor{
-	name = "Maximum-Security Wing";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/multi_tile/mainship/comdoor/free_access{
+	name = "Maximum-Security Wing"
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/checkpoint/maxsec)
@@ -11311,17 +11213,15 @@
 "aEm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock/mainship/medical{
+/obj/machinery/door/airlock/mainship/medical/free_access{
 	dir = 2;
-	name = "Infirmary Reception";
-	req_one_access_txt = "0"
+	name = "Infirmary Reception"
 	},
 /turf/open/floor/prison/whitegreen/full,
 /area/prison/medbay)
 "aEn" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
-	name = "Infirmary";
-	req_one_access_txt = "0"
+	name = "Infirmary"
 	},
 /turf/open/floor/prison/whitegreen/full,
 /area/prison/medbay)
@@ -11337,10 +11237,9 @@
 /turf/open/floor/prison/whitegreen/full,
 /area/prison/medbay)
 "aEq" = (
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 2;
-	name = "Security Booth";
-	req_access_txt = "0"
+	name = "Security Booth"
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/medbay/foyer)
@@ -12129,7 +12028,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/security{
+/obj/machinery/door/airlock/mainship/security/free_access{
 	name = "Security Office"
 	},
 /turf/open/floor/prison,
@@ -12789,9 +12688,7 @@
 	},
 /area/prison/security/checkpoint/maxsec)
 "aHV" = (
-/obj/machinery/door/airlock/mainship/maint{
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/mainship/maint/free_access,
 /turf/open/floor/plating,
 /area/prison/medbay)
 "aHW" = (
@@ -12826,8 +12723,7 @@
 "aIa" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	dir = 2;
-	name = "Infirmary Foyer";
-	req_one_access_txt = "0"
+	name = "Infirmary Foyer"
 	},
 /turf/open/floor/prison{
 	icon_state = "bright_clean";
@@ -12855,10 +12751,9 @@
 	},
 /area/prison/medbay/foyer)
 "aId" = (
-/obj/machinery/door/airlock/multi_tile/mainship/comdoor{
+/obj/machinery/door/airlock/multi_tile/mainship/comdoor/free_access{
 	dir = 2;
-	name = "Biological Research Department";
-	req_access_txt = "0"
+	name = "Biological Research Department"
 	},
 /turf/open/floor/prison/darkpurple/full,
 /area/prison/research)
@@ -12870,10 +12765,9 @@
 /turf/open/floor/prison/sterilewhite,
 /area/prison/research)
 "aIf" = (
-/obj/machinery/door/airlock/multi_tile/mainship/comdoor{
+/obj/machinery/door/airlock/multi_tile/mainship/comdoor/free_access{
 	dir = 2;
-	name = "Research Common Room";
-	req_access_txt = "0"
+	name = "Research Common Room"
 	},
 /turf/open/floor/prison/darkpurple/full,
 /area/prison/research)
@@ -12898,10 +12792,7 @@
 /area/prison/hangar_storage/main)
 "aIj" = (
 /obj/machinery/door/airlock/mainship/generic{
-	density = 0;
-	icon_state = "door_open";
-	name = "Toilet";
-	opacity = 0
+	name = "Toilet"
 	},
 /turf/open/floor/prison/whitegreen/full,
 /area/prison/medbay)
@@ -13333,9 +13224,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/medical/glass{
-	name = "Research Dorms";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	name = "Research Dorms"
 	},
 /turf/open/floor,
 /area/prison/quarters/research)
@@ -13687,9 +13577,8 @@
 "aJS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2;
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	dir = 2
 	},
 /turf/open/floor/wood,
 /area/prison/storage/highsec/n)
@@ -13708,9 +13597,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	name = "Staff-Research Maintenance";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "Staff-Research Maintenance"
 	},
 /turf/open/floor/plating,
 /area/prison/quarters/research)
@@ -13796,9 +13684,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/security/glass{
-	name = "Security Booth";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	name = "Security Booth"
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/checkpoint/highsec/n)
@@ -13976,10 +13863,7 @@
 /area/prison/cellblock/highsec/north/south)
 "aKy" = (
 /obj/machinery/door/airlock/mainship/generic{
-	density = 0;
-	icon_state = "door_open";
-	name = "Toilet";
-	opacity = 0
+	name = "Toilet"
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/prison/toilet/research)
@@ -14976,10 +14860,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 2;
-	name = "North High-Security Storage";
-	req_one_access_txt = "0"
+	name = "North High-Security Storage"
 	},
 /turf/open/floor/prison,
 /area/prison/storage/highsec/n)
@@ -15059,10 +14942,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 2;
-	name = "Staff-Research Maintenance";
-	req_one_access_txt = "0"
+	name = "Staff-Research Maintenance"
 	},
 /turf/open/floor/plating,
 /area/prison/maintenance/staff_research)
@@ -15629,9 +15511,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/medical/glass{
-	name = "Staff Quarters";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	name = "Staff Quarters"
 	},
 /turf/open/floor/prison/green/full,
 /area/prison/quarters/staff)
@@ -16386,7 +16267,7 @@
 /turf/open/floor/prison,
 /area/prison/cleaning)
 "aPV" = (
-/obj/machinery/door/airlock/mainship/maint,
+/obj/machinery/door/airlock/mainship/maint/free_access,
 /turf/open/floor/prison,
 /area/prison/quarters/staff)
 "aPW" = (
@@ -16772,10 +16653,9 @@
 	},
 /area/prison/cellblock/lowsec/nw)
 "aQU" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 2;
-	name = "Toilet";
-	req_one_access_txt = "0"
+	name = "Toilet"
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/prison/cellblock/lowsec/nw)
@@ -17044,9 +16924,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/command{
-	name = "Warden's Office";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/command/free_access{
+	name = "Warden's Office"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -17190,9 +17069,7 @@
 /turf/open/floor/prison/red/full,
 /area/prison/security/checkpoint/highsec/n)
 "aSc" = (
-/obj/machinery/door/airlock/mainship/maint{
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/mainship/maint/free_access,
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
 /area/prison/cellblock/lowsec/nw)
@@ -17250,12 +17127,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/airlock/mainship/medical/glass{
-	density = 0;
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 2;
-	icon_state = "door_open";
-	name = "Research Restrooms";
-	req_one_access_txt = "0"
+	name = "Research Restrooms"
 	},
 /turf/open/floor/freezer,
 /area/prison/toilet/research)
@@ -17490,13 +17364,9 @@
 "aSW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/airlock/mainship/command{
-	density = 0;
+/obj/machinery/door/airlock/mainship/command/open/free_access{
 	dir = 2;
-	icon_state = "door_open";
-	name = "Research Director's Quarters";
-	opacity = 0;
-	req_access_txt = "0"
+	name = "Research Director's Quarters"
 	},
 /turf/open/floor/wood,
 /area/prison/quarters/research)
@@ -17676,10 +17546,9 @@
 "aTB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 2;
-	name = "Northeast Low-Security Monitoring";
-	req_access_txt = "0"
+	name = "Northeast Low-Security Monitoring"
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/monitoring/lowsec/ne)
@@ -17715,9 +17584,8 @@
 "aTG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2;
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	dir = 2
 	},
 /turf/open/floor/prison,
 /area/prison/canteen)
@@ -17828,10 +17696,7 @@
 /area/prison/cellblock/highsec/north/south)
 "aTU" = (
 /obj/machinery/door/airlock/mainship/generic{
-	density = 0;
-	icon_state = "door_open";
-	name = "Toilet";
-	opacity = 0
+	name = "Toilet"
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/north)
@@ -17862,7 +17727,7 @@
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/nw)
 "aTX" = (
-/obj/machinery/door/airlock/mainship/maint,
+/obj/machinery/door/airlock/mainship/maint/free_access,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -17877,10 +17742,9 @@
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/nw)
 "aTY" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 2;
-	name = "Garden";
-	req_one_access_txt = "0"
+	name = "Garden"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/ground/dirtgrassborder,
@@ -17898,7 +17762,7 @@
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/nw)
 "aUa" = (
-/obj/machinery/door/airlock/mainship/maint,
+/obj/machinery/door/airlock/mainship/maint/free_access,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -17913,10 +17777,9 @@
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/ne)
 "aUb" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 2;
-	name = "Garden";
-	req_one_access_txt = "0"
+	name = "Garden"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/ground/dirtgrassborder,
@@ -18405,9 +18268,7 @@
 	},
 /area/prison/security/monitoring/highsec)
 "aUU" = (
-/obj/machinery/door/airlock/mainship/maint{
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/mainship/maint/free_access,
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
 /area/prison/security/monitoring/lowsec/ne)
@@ -18434,12 +18295,8 @@
 	},
 /area/prison/security/monitoring/lowsec/ne)
 "aUY" = (
-/obj/machinery/door/airlock/mainship/secure{
-	density = 0;
-	icon_state = "door_open";
-	name = "Solitary Confinement";
-	opacity = 0;
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/secure/open/free_access{
+	name = "Solitary Confinement"
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/highsec/north/south)
@@ -18893,9 +18750,8 @@
 /turf/open/floor/wood,
 /area/prison/recreation/staff)
 "aWf" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
-	name = "Staff Recreation";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	name = "Staff Recreation"
 	},
 /turf/open/floor/wood,
 /area/prison/recreation/staff)
@@ -19080,11 +18936,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/medical/glass{
-	density = 0;
-	icon_state = "door_open";
-	name = "Staff Restrooms";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	name = "Staff Restrooms"
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/prison/toilet/staff)
@@ -19095,9 +18948,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/security/glass{
-	name = "Security Booth";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	name = "Security Booth"
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/checkpoint/highsec/n)
@@ -19151,10 +19003,9 @@
 	},
 /area/prison/hallway/central)
 "aWK" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 2;
-	name = "Phone Booth";
-	req_one_access_txt = "0"
+	name = "Phone Booth"
 	},
 /turf/open/floor/prison/green/full,
 /area/prison/cellblock/lowsec/nw)
@@ -19233,10 +19084,7 @@
 /area/prison/cellblock/lowsec/ne)
 "aWX" = (
 /obj/machinery/door/airlock/mainship/generic{
-	density = 0;
-	icon_state = "door_open";
-	name = "Toilet";
-	opacity = 0
+	name = "Toilet"
 	},
 /turf/open/floor/prison{
 	icon_state = "kitchen"
@@ -19365,9 +19213,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/medical/glass{
-	name = "Staff Recreation";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	name = "Staff Recreation"
 	},
 /turf/open/floor/wood,
 /area/prison/recreation/staff)
@@ -19390,10 +19237,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/mainship/command{
+/obj/machinery/door/airlock/mainship/command/free_access{
 	dir = 2;
-	name = "Warden's Secretary's Office";
-	req_access_txt = "0"
+	name = "Warden's Secretary's Office"
 	},
 /turf/open/floor/prison/plate,
 /area/prison/command/secretary_office)
@@ -19407,10 +19253,9 @@
 "aXq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock/mainship/command{
+/obj/machinery/door/airlock/mainship/command/free_access{
 	dir = 2;
-	name = "Warden's Quarters";
-	req_access_txt = "0"
+	name = "Warden's Quarters"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -19916,12 +19761,8 @@
 /turf/open/floor/wood,
 /area/prison/residential/central)
 "aYS" = (
-/obj/machinery/door/airlock/mainship/secure{
-	density = 0;
-	icon_state = "door_open";
-	name = "Solitary Confinement";
-	opacity = 0;
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/secure/open/free_access{
+	name = "Solitary Confinement"
 	},
 /turf/open/floor/prison/red/full,
 /area/prison/cellblock/highsec/north/south)
@@ -19996,7 +19837,7 @@
 "aZg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock/mainship/security{
+/obj/machinery/door/airlock/mainship/security/free_access{
 	dir = 2;
 	name = "Security Records"
 	},
@@ -20174,9 +20015,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/medical/glass{
-	name = "Staff Recreation";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	name = "Staff Recreation"
 	},
 /turf/open/floor/wood,
 /area/prison/recreation/staff)
@@ -20304,11 +20144,8 @@
 /area/prison/command/quarters)
 "aZM" = (
 /obj/machinery/door/airlock/mainship/generic{
-	density = 0;
 	dir = 2;
-	icon_state = "door_open";
-	name = "Toilet";
-	opacity = 0
+	name = "Toilet"
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/prison/toilet/staff)
@@ -20909,10 +20746,7 @@
 /area/prison/hallway/staff)
 "bbw" = (
 /obj/machinery/door/airlock/mainship/generic{
-	density = 0;
-	icon_state = "door_open";
-	name = "Staff Custodial Closet";
-	opacity = 0
+	name = "Staff Custodial Closet"
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/prison/hallway/staff)
@@ -21059,9 +20893,8 @@
 /turf/open/floor/carpet,
 /area/prison/residential/central)
 "bbP" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2;
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	dir = 2
 	},
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/ne)
@@ -21418,7 +21251,7 @@
 "bcW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock/mainship/security{
+/obj/machinery/door/airlock/mainship/security/free_access{
 	dir = 2;
 	name = "High-Security Monitoring Storage"
 	},
@@ -21644,10 +21477,9 @@
 /area/prison/residential/central)
 "bdy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 2;
-	name = "Medium-Security Monitoring";
-	req_access_txt = "0"
+	name = "Medium-Security Monitoring"
 	},
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/prison/darkred/full,
@@ -21788,9 +21620,8 @@
 /turf/closed/wall/r_wall/prison,
 /area/prison/security/checkpoint/vip)
 "bdP" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2;
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	dir = 2
 	},
 /turf/open/floor/prison/kitchen,
 /area/prison/security/checkpoint/vip)
@@ -22076,7 +21907,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/entrance)
 "bes" = (
-/obj/machinery/door/airlock/mainship/security,
+/obj/machinery/door/airlock/mainship/security/free_access,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -22361,10 +22192,9 @@
 	},
 /area/prison/security/monitoring/highsec)
 "beW" = (
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 2;
-	name = "High-Security Monitoring";
-	req_access_txt = "0"
+	name = "High-Security Monitoring"
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/monitoring/highsec)
@@ -22376,10 +22206,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 2;
-	name = "High-Security Monitoring";
-	req_access_txt = "0"
+	name = "High-Security Monitoring"
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/monitoring/highsec)
@@ -22682,10 +22511,9 @@
 	},
 /area/prison/kitchen)
 "bfL" = (
-/obj/machinery/door/airlock/mainship/command{
+/obj/machinery/door/airlock/mainship/command/free_access{
 	dir = 4;
-	name = "Civilian Residences Admin";
-	req_access_txt = "0"
+	name = "Civilian Residences Admin"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -22894,9 +22722,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/security/glass{
-	name = "Security Booth";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	name = "Security Booth"
 	},
 /turf/open/floor/prison,
 /area/prison/security/checkpoint/vip)
@@ -23329,9 +23156,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/security/glass{
-	name = "Security Booth";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	name = "Security Booth"
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/monitoring/highsec)
@@ -24183,10 +24009,9 @@
 	},
 /area/prison/hangar/main)
 "biK" = (
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 2;
-	name = "Panopticon Monitoring";
-	req_access_txt = "0"
+	name = "Panopticon Monitoring"
 	},
 /turf/open/floor/prison,
 /area/prison/security/monitoring/maxsec/panopticon)
@@ -24247,10 +24072,9 @@
 /turf/open/floor/prison,
 /area/prison/residential/central)
 "biR" = (
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 2;
-	name = "High-Security Monitoring";
-	req_access_txt = "0"
+	name = "High-Security Monitoring"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -25004,10 +24828,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 2;
-	name = "Security Booth";
-	req_access_txt = "0"
+	name = "Security Booth"
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/hangar/main)
@@ -25062,12 +24885,8 @@
 /turf/open/floor/prison/plate,
 /area/prison/toilet/canteen)
 "bkO" = (
-/obj/machinery/door/airlock/mainship/secure{
-	density = 0;
-	icon_state = "door_open";
-	name = "Solitary Confinement";
-	opacity = 0;
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/secure/open/free_access{
+	name = "Solitary Confinement"
 	},
 /turf/open/floor/plating,
 /area/prison/hallway/central)
@@ -25079,10 +24898,9 @@
 	},
 /area/prison/residential/central)
 "bkR" = (
-/obj/machinery/door/airlock/mainship/command{
+/obj/machinery/door/airlock/mainship/command/free_access{
 	dir = 2;
-	name = "Civilian Residences Admin";
-	req_access_txt = "0"
+	name = "Civilian Residences Admin"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -25105,32 +24923,22 @@
 	},
 /area/prison/security/monitoring/highsec)
 "bkT" = (
-/obj/machinery/door/airlock/mainship/secure{
-	density = 0;
+/obj/machinery/door/airlock/mainship/secure/open/free_access{
 	dir = 2;
-	icon_state = "door_open";
-	name = "Solitary Confinement";
-	opacity = 0;
-	req_access_txt = "0"
+	name = "Solitary Confinement"
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/lowsec/ne)
 "bkU" = (
 /obj/machinery/door/airlock/mainship/generic{
-	density = 0;
 	dir = 2;
-	icon_state = "door_open";
-	name = "Toilet";
-	opacity = 0
+	name = "Toilet"
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/central)
 "bkV" = (
 /obj/machinery/door/airlock/mainship/generic{
-	density = 0;
-	icon_state = "door_open";
-	name = "Toilet";
-	opacity = 0
+	name = "Toilet"
 	},
 /turf/open/floor/freezer,
 /area/prison/command/quarters)
@@ -25170,10 +24978,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 2;
-	name = "Security Booth";
-	req_access_txt = "0"
+	name = "Security Booth"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -25223,10 +25030,9 @@
 "bld" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 2;
-	name = "Storage";
-	req_one_access_txt = "0"
+	name = "Storage"
 	},
 /turf/open/floor/prison,
 /area/prison/storage/vip)
@@ -25478,11 +25284,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/door/airlock/mainship/generic{
-	density = 0;
 	dir = 2;
-	icon_state = "door_open";
-	name = "Dorm Room";
-	opacity = 0
+	name = "Dorm Room"
 	},
 /turf/open/floor/wood,
 /area/prison/quarters/research)
@@ -25602,10 +25405,9 @@
 	},
 /area/prison/cellblock/highsec/north/south)
 "blX" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 2;
-	name = "Storage";
-	req_one_access_txt = "0"
+	name = "Storage"
 	},
 /turf/open/floor/plating,
 /area/prison/security/monitoring/highsec)
@@ -25885,9 +25687,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/security/glass{
-	name = "High-Security Monitoring";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	name = "High-Security Monitoring"
 	},
 /turf/open/floor/prison,
 /area/prison/security/monitoring/highsec)
@@ -26047,16 +25848,14 @@
 /turf/open/floor/plating,
 /area/prison/security/monitoring/highsec)
 "bni" = (
-/obj/machinery/door/airlock/mainship/security/glass{
-	name = "High-Security Monitoring";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	name = "High-Security Monitoring"
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/monitoring/highsec)
 "bnj" = (
-/obj/machinery/door/airlock/mainship/security/glass{
-	name = "High-Security Monitoring";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	name = "High-Security Monitoring"
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/cellblock/vip)
@@ -26185,7 +25984,7 @@
 	},
 /area/prison/hallway/central)
 "bnF" = (
-/obj/machinery/door/airlock/mainship/maint,
+/obj/machinery/door/airlock/mainship/maint/free_access,
 /turf/open/floor/plating,
 /area/prison/hallway/central)
 "bnG" = (
@@ -26322,9 +26121,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/security/glass{
-	name = "High-Security Monitoring";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	name = "High-Security Monitoring"
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/cellblock/vip)
@@ -26533,10 +26331,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/multi_tile/mainship/comdoor{
+/obj/machinery/door/airlock/multi_tile/mainship/comdoor/free_access{
 	dir = 2;
-	name = "VIP Cellblock / Civilian Residences Access";
-	req_access_txt = "0"
+	name = "VIP Cellblock / Civilian Residences Access"
 	},
 /turf/open/floor/prison/blue/full,
 /area/prison/security/checkpoint/vip)
@@ -27443,10 +27240,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 2;
-	name = "Security Booth";
-	req_access_txt = "0"
+	name = "Security Booth"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -27571,9 +27367,8 @@
 /turf/open/floor/prison/plate,
 /area/prison/toilet/canteen)
 "bqA" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2;
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	dir = 2
 	},
 /turf/open/floor/plating,
 /area/prison/hallway/central)
@@ -28497,10 +28292,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 2;
-	name = "Security Booth";
-	req_access_txt = "0"
+	name = "Security Booth"
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/hangar/main)
@@ -28667,9 +28461,8 @@
 	},
 /area/prison/cellblock/lowsec/se)
 "bts" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2;
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	dir = 2
 	},
 /turf/open/floor/plating,
 /area/prison/canteen)
@@ -30046,10 +29839,9 @@
 /turf/closed/wall/prison,
 /area/prison/visitation)
 "bwY" = (
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 2;
-	name = "Security Booth";
-	req_access_txt = "0"
+	name = "Security Booth"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -30133,11 +29925,8 @@
 /area/prison/cellblock/highsec/south/north)
 "bxl" = (
 /obj/machinery/door/airlock/mainship/generic{
-	density = 0;
 	dir = 2;
-	icon_state = "door_open";
-	name = "Toilet";
-	opacity = 0
+	name = "Toilet"
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/prison/toilet/canteen)
@@ -30386,7 +30175,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/lowsec/sw)
 "bxQ" = (
-/obj/machinery/door/airlock/mainship/maint,
+/obj/machinery/door/airlock/mainship/maint/free_access,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -30631,7 +30420,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/security{
+/obj/machinery/door/airlock/mainship/security/free_access{
 	name = "Main Hangar Traffic Control"
 	},
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
@@ -30711,7 +30500,7 @@
 "byH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock/mainship/security{
+/obj/machinery/door/airlock/mainship/security/free_access{
 	dir = 2;
 	name = "Security Records"
 	},
@@ -30841,9 +30630,8 @@
 	},
 /area/prison/store)
 "byX" = (
-/obj/machinery/door/airlock/mainship/security/glass{
-	name = "Security Booth";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	name = "Security Booth"
 	},
 /turf/open/floor/prison{
 	icon_state = "bright_clean";
@@ -30923,10 +30711,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 2;
-	name = "Hangar-Barracks Maintenance";
-	req_one_access_txt = "0"
+	name = "Hangar-Barracks Maintenance"
 	},
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -30937,10 +30724,9 @@
 /turf/closed/wall/r_wall/prison,
 /area/prison/security/checkpoint/hangar)
 "bzj" = (
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 2;
-	name = "Main Hangar Traffic Control";
-	req_access_txt = "0"
+	name = "Main Hangar Traffic Control"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -31325,9 +31111,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/security/glass{
-	name = "Security Booth";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	name = "Security Booth"
 	},
 /turf/open/floor/prison,
 /area/prison/security/checkpoint/highsec/s)
@@ -31914,7 +31699,7 @@
 	},
 /area/prison/hallway/east)
 "bBL" = (
-/obj/machinery/door/airlock/mainship/maint,
+/obj/machinery/door/airlock/mainship/maint/free_access,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -32041,7 +31826,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/south)
 "bCd" = (
-/obj/machinery/door/airlock/mainship/maint,
+/obj/machinery/door/airlock/mainship/maint/free_access,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -33500,10 +33285,9 @@
 "bFj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 2;
-	name = "Southwest Low-Security Monitoring";
-	req_access_txt = "0"
+	name = "Southwest Low-Security Monitoring"
 	},
 /turf/open/floor/prison,
 /area/prison/security/monitoring/lowsec/sw)
@@ -33695,7 +33479,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/security{
+/obj/machinery/door/airlock/mainship/security/free_access{
 	name = "Security Barracks"
 	},
 /turf/open/floor/prison{
@@ -33732,9 +33516,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/secure{
-	name = "Telecommunications";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/secure/free_access{
+	name = "Telecommunications"
 	},
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/prison,
@@ -34003,9 +33786,7 @@
 /turf/open/floor/prison/darkred/full,
 /area/prison/monorail/east)
 "bGm" = (
-/obj/machinery/door/airlock/mainship/maint{
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/mainship/maint/free_access,
 /turf/open/floor/plating,
 /area/prison/laundry)
 "bGp" = (
@@ -34056,9 +33837,7 @@
 /turf/open/floor/prison/kitchen,
 /area/prison/cellblock/lowsec/se)
 "bGx" = (
-/obj/machinery/door/airlock/mainship/maint{
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/mainship/maint/free_access,
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
 /area/prison/cellblock/lowsec/se)
@@ -34643,9 +34422,7 @@
 /turf/open/floor/wood,
 /area/prison/residential/south)
 "bIg" = (
-/obj/machinery/door/airlock/mainship/maint{
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/mainship/maint/free_access,
 /turf/open/floor/prison,
 /area/prison/storage/medsec)
 "bIh" = (
@@ -34975,9 +34752,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	name = "Hangar-Barracks Maintenance";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "Hangar-Barracks Maintenance"
 	},
 /turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
@@ -35570,9 +35346,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/security/glass{
-	name = "Security Booth";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	name = "Security Booth"
 	},
 /turf/open/floor/prison,
 /area/prison/security/checkpoint/highsec/s)
@@ -35849,7 +35624,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/airlock/mainship/security{
+/obj/machinery/door/airlock/mainship/security/free_access{
 	dir = 2;
 	name = "Security Barracks"
 	},
@@ -36016,10 +35791,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 2;
-	name = "South High-Security Storage";
-	req_one_access_txt = "0"
+	name = "South High-Security Storage"
 	},
 /turf/open/floor/prison,
 /area/prison/storage/highsec/s)
@@ -37073,10 +36847,7 @@
 /area/prison/security)
 "bNT" = (
 /obj/machinery/door/airlock/mainship/generic{
-	density = 0;
-	icon_state = "door_open";
-	name = "Toilet";
-	opacity = 0
+	name = "Toilet"
 	},
 /turf/open/floor/prison{
 	icon_state = "bright_clean2";
@@ -37163,11 +36934,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/medical/glass{
-	density = 0;
-	icon_state = "door_open";
-	name = "Security Restrooms";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	name = "Security Restrooms"
 	},
 /turf/open/floor/prison{
 	icon_state = "bright_clean2";
@@ -37317,9 +37085,8 @@
 "bOr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2;
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	dir = 2
 	},
 /turf/open/floor/plating,
 /area/prison/laundry)
@@ -37568,12 +37335,8 @@
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/south)
 "bOW" = (
-/obj/machinery/door/airlock/mainship/secure{
-	density = 0;
-	icon_state = "door_open";
-	name = "Solitary Confinement";
-	opacity = 0;
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/secure/open/free_access{
+	name = "Solitary Confinement"
 	},
 /turf/open/floor/prison/red/full,
 /area/prison/cellblock/highsec/south/north)
@@ -38169,9 +37932,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/engineering{
-	name = "Medium-Security Storage";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "Medium-Security Storage"
 	},
 /turf/open/floor/prison/darkyellow/full,
 /area/prison/storage/medsec)
@@ -38324,10 +38086,9 @@
 	},
 /area/prison/recreation/highsec/s)
 "bQU" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 2;
-	name = "Toilet";
-	req_one_access_txt = "0"
+	name = "Toilet"
 	},
 /turf/open/floor/prison/kitchen,
 /area/prison/recreation/highsec/s)
@@ -38741,10 +38502,9 @@
 /turf/open/floor/plating,
 /area/prison/residential/south)
 "bSh" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 2;
-	name = "Garden";
-	req_one_access_txt = "0"
+	name = "Garden"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison{
@@ -38753,10 +38513,9 @@
 	},
 /area/prison/residential/south)
 "bSi" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 2;
-	name = "Garden";
-	req_one_access_txt = "0"
+	name = "Garden"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison{
@@ -39133,7 +38892,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	name = "South Civilian Residences Access"
 	},
 /obj/structure/cable{
@@ -39423,7 +39182,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/south)
 "bTK" = (
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	name = "South Civilian Residences Access"
 	},
 /turf/open/floor/plating,
@@ -39997,7 +39756,7 @@
 /turf/open/beach/sand,
 /area/prison/residential/south)
 "bVn" = (
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	name = "Custodial Closet"
 	},
 /turf/open/floor/prison/sterilewhite,
@@ -40020,22 +39779,15 @@
 /turf/open/beach/sand,
 /area/prison/residential/south)
 "bVq" = (
-/obj/machinery/door/airlock/mainship/secure{
-	density = 0;
+/obj/machinery/door/airlock/mainship/secure/open/free_access{
 	dir = 2;
-	icon_state = "door_open";
-	name = "Solitary Confinement";
-	opacity = 0;
-	req_access_txt = "0"
+	name = "Solitary Confinement"
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/lowsec/sw)
 "bVr" = (
 /obj/machinery/door/airlock/mainship/generic{
-	density = 0;
-	icon_state = "door_open";
-	name = "Toilet";
-	opacity = 0
+	name = "Toilet"
 	},
 /turf/open/floor/prison{
 	icon_state = "bright_clean2";
@@ -40044,21 +39796,15 @@
 /area/prison/holding/holding2)
 "bVs" = (
 /obj/machinery/door/airlock/mainship/generic{
-	density = 0;
 	dir = 2;
-	icon_state = "door_open";
-	name = "Toilet";
-	opacity = 0
+	name = "Toilet"
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/south)
 "bVt" = (
 /obj/machinery/door/airlock/mainship/generic{
-	density = 0;
 	dir = 2;
-	icon_state = "door_open";
-	name = "Toilet";
-	opacity = 0
+	name = "Toilet"
 	},
 /turf/open/floor/prison{
 	icon_state = "bright_clean2";
@@ -40067,10 +39813,7 @@
 /area/prison/toilet/security)
 "bVu" = (
 /obj/machinery/door/airlock/mainship/generic{
-	density = 0;
-	icon_state = "door_open";
-	name = "Toilet";
-	opacity = 0
+	name = "Toilet"
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/south)
@@ -40090,12 +39833,8 @@
 	},
 /area/prison/cellblock/highsec/south/north)
 "bVw" = (
-/obj/machinery/door/airlock/mainship/secure{
-	density = 0;
-	icon_state = "door_open";
-	name = "Solitary Confinement";
-	opacity = 0;
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/secure/open/free_access{
+	name = "Solitary Confinement"
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/highsec/south/north)
@@ -40178,10 +39917,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 2;
-	name = "Security Booth";
-	req_access_txt = "0"
+	name = "Security Booth"
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/checkpoint/medsec)
@@ -40215,10 +39953,9 @@
 "bVN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 2;
-	name = "Security Booth";
-	req_access_txt = "0"
+	name = "Security Booth"
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/checkpoint/medsec)
@@ -40742,9 +40479,7 @@
 	},
 /area/prison/storage/medsec)
 "bXt" = (
-/obj/machinery/door/airlock/mainship/maint{
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/mainship/maint/free_access,
 /turf/open/floor/plating,
 /area/prison/storage/medsec)
 "bXu" = (
@@ -40787,10 +40522,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 2;
-	name = "SMES";
-	req_one_access_txt = "0"
+	name = "SMES"
 	},
 /turf/open/floor/plating,
 /area/prison/engineering)
@@ -41024,7 +40758,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	name = "South Civilian Residences Access"
 	},
 /turf/open/floor/plating,
@@ -41234,9 +40968,8 @@
 /turf/closed/wall/prison,
 /area/prison/cellblock/highsec/south/south)
 "bYD" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2;
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -41281,10 +41014,9 @@
 	},
 /area/prison/cellblock/highsec/south/south)
 "bYI" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 2;
-	name = "Medium-Security Storage";
-	req_one_access_txt = "0"
+	name = "Medium-Security Storage"
 	},
 /turf/open/floor/prison/darkyellow/full,
 /area/prison/storage/medsec)
@@ -41296,10 +41028,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 2;
-	name = "Medium-Security Storage";
-	req_one_access_txt = "0"
+	name = "Medium-Security Storage"
 	},
 /turf/open/floor/prison/darkyellow/full,
 /area/prison/storage/medsec)
@@ -41409,9 +41140,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/engineering{
-	name = "Atmospherics";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "Atmospherics"
 	},
 /turf/open/floor/prison/darkyellow/full,
 /area/prison/engineering)
@@ -41756,9 +41486,8 @@
 	},
 /area/prison/cellblock/mediumsec/north)
 "cah" = (
-/obj/machinery/door/airlock/mainship/security/glass{
-	name = "Security Booth";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	name = "Security Booth"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -41915,18 +41644,16 @@
 /turf/open/floor/plating,
 /area/prison/engineering/atmos)
 "caD" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 2;
-	name = "Atmospherics";
-	req_one_access_txt = "0"
+	name = "Atmospherics"
 	},
 /turf/open/floor/prison,
 /area/prison/engineering/atmos)
 "caE" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 2;
-	name = "Atmospherics";
-	req_one_access_txt = "0"
+	name = "Atmospherics"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -42321,9 +42048,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/mediumsec/west)
 "cbC" = (
-/obj/machinery/door/airlock/mainship/maint{
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/mainship/maint/free_access,
 /turf/open/floor/plating,
 /area/prison/library)
 "cbD" = (
@@ -42697,9 +42422,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/engineering{
-	name = "Engineering";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "Engineering"
 	},
 /turf/open/floor/prison,
 /area/prison/engineering)
@@ -42818,7 +42542,7 @@
 	},
 /area/prison/pirate)
 "ccD" = (
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	name = "Security Booth"
 	},
 /turf/open/floor/prison,
@@ -42921,10 +42645,9 @@
 /turf/open/floor/prison,
 /area/prison/recreation/medsec)
 "ccS" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 2;
-	name = "Toilet";
-	req_one_access_txt = "0"
+	name = "Toilet"
 	},
 /turf/open/floor/prison,
 /area/prison/recreation/medsec)
@@ -43172,9 +42895,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/engineering{
-	name = "Engineering Hallway";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "Engineering Hallway"
 	},
 /turf/open/floor/prison{
 	icon_state = "darkbrownfull2"
@@ -43301,9 +43023,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/command{
-	name = "Head of Security's Office";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/command/free_access{
+	name = "Head of Security's Office"
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/head)
@@ -43648,9 +43369,8 @@
 /turf/open/floor/plating,
 /area/prison/engineering)
 "cek" = (
-/obj/machinery/door/airlock/mainship/engineering{
-	name = "Engineering";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "Engineering"
 	},
 /turf/open/floor/prison,
 /area/prison/engineering)
@@ -43691,9 +43411,8 @@
 /turf/open/floor/prison,
 /area/prison/hallway/engineering)
 "cer" = (
-/obj/machinery/door/airlock/mainship/engineering{
-	name = "Engineering Hallway";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "Engineering Hallway"
 	},
 /turf/open/floor/prison{
 	icon_state = "darkbrownfull2"
@@ -44051,9 +43770,7 @@
 	},
 /area/prison/cellblock/highsec/south/south)
 "cfe" = (
-/obj/machinery/door/airlock/mainship/maint{
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/mainship/maint/free_access,
 /turf/open/floor/plating,
 /area/prison/cellblock/highsec/south/south)
 "cff" = (
@@ -44077,9 +43794,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/command{
-	name = "Chief Engineer's Quarters";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/command/free_access{
+	name = "Chief Engineer's Quarters"
 	},
 /turf/open/floor/plating,
 /area/prison/engineering)
@@ -44420,10 +44136,9 @@
 /turf/open/floor/prison/plate,
 /area/prison/recreation/medsec)
 "cgt" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 2;
-	name = "Phone Booth";
-	req_one_access_txt = "0"
+	name = "Phone Booth"
 	},
 /turf/open/floor/prison,
 /area/prison/recreation/medsec)
@@ -44531,10 +44246,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/mainship/maint{
+/obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 2;
-	name = "Disposals";
-	req_one_access_txt = "0"
+	name = "Disposals"
 	},
 /turf/open/floor/plating,
 /area/prison/disposal)
@@ -44553,10 +44267,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/free_access{
 	dir = 2;
-	name = "Execution";
-	req_access_txt = "0"
+	name = "Execution"
 	},
 /turf/open/floor/prison,
 /area/prison/execution)
@@ -44564,10 +44277,9 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
 	},
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/free_access{
 	dir = 2;
-	name = "Execution";
-	req_access_txt = "0"
+	name = "Execution"
 	},
 /turf/open/floor/prison,
 /area/prison/execution)
@@ -44611,10 +44323,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/free_access{
 	dir = 2;
-	name = "Riot Armory";
-	req_access_txt = "0"
+	name = "Riot Armory"
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/armory/riot)
@@ -44649,10 +44360,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/free_access{
 	dir = 2;
-	name = "Lethal Armory";
-	req_access_txt = "0"
+	name = "Lethal Armory"
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/armory/lethal)
@@ -44665,10 +44375,9 @@
 "chb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock/mainship/command{
+/obj/machinery/door/airlock/mainship/command/free_access{
 	dir = 2;
-	name = "Head of Security's Quarters";
-	req_access_txt = "0"
+	name = "Head of Security's Quarters"
 	},
 /turf/open/floor/prison,
 /area/prison/security/head)
@@ -46486,9 +46195,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/security/glass{
-	name = "Protective Custody Monitoring";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	name = "Protective Custody Monitoring"
 	},
 /turf/open/floor/prison/plate,
 /area/prison/security/monitoring/protective)
@@ -46529,9 +46237,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/security/glass{
-	name = "Security Booth";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	name = "Security Booth"
 	},
 /turf/open/floor/prison,
 /area/prison/security/checkpoint/highsec_medsec)
@@ -47501,9 +47208,8 @@
 /turf/open/floor/wood,
 /area/prison/parole/protective_custody)
 "coi" = (
-/obj/machinery/door/airlock/mainship/maint{
-	name = "Disposals";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "Disposals"
 	},
 /turf/open/floor/plating,
 /area/prison/disposal)
@@ -47735,19 +47441,17 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/free_access{
 	dir = 2;
-	name = "Execution Chamber";
-	req_access_txt = "0"
+	name = "Execution Chamber"
 	},
 /turf/open/floor/prison,
 /area/prison/execution)
 "coR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/free_access{
 	dir = 2;
-	name = "Execution Chamber";
-	req_access_txt = "0"
+	name = "Execution Chamber"
 	},
 /turf/open/floor/prison,
 /area/prison/execution)
@@ -47890,9 +47594,8 @@
 	},
 /area/prison/cellblock/mediumsec/north)
 "cpn" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2;
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	dir = 2
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/protective)
@@ -47904,9 +47607,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2;
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	dir = 2
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/protective)
@@ -48129,16 +47831,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2;
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	dir = 2
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/highsec/south/south)
 "cpT" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2;
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	dir = 2
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/highsec/south/south)
@@ -48453,9 +48153,8 @@
 /turf/open/floor/plating,
 /area/prison/disposal)
 "cqY" = (
-/obj/machinery/door/airlock/mainship/security/glass{
-	name = "Security Booth";
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	name = "Security Booth"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -48971,16 +48670,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2;
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	dir = 2
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/mediumsec/west)
 "csD" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2;
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	dir = 2
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/mediumsec/west)
@@ -49047,9 +48744,8 @@
 /turf/open/floor/prison/yellow/full,
 /area/prison/cellblock/mediumsec/east)
 "csL" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2;
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	dir = 2
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/mediumsec/east)
@@ -49061,9 +48757,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2;
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	dir = 2
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/mediumsec/east)
@@ -49144,9 +48839,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/mainship/maint/free_access,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating,
 /area/prison/cellblock/mediumsec/south)
@@ -49230,9 +48923,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/mainship/maint/free_access,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating,
 /area/prison/cellblock/mediumsec/south)
@@ -49419,9 +49110,8 @@
 "ctx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2;
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	dir = 2
 	},
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -49622,13 +49312,9 @@
 /turf/open/floor/carpet,
 /area/prison/pirate)
 "cuk" = (
-/obj/machinery/door/airlock/mainship/secure{
-	density = 0;
+/obj/machinery/door/airlock/mainship/secure/open/free_access{
 	dir = 2;
-	icon_state = "door_open";
-	name = "Solitary Confinement";
-	opacity = 0;
-	req_access_txt = "0"
+	name = "Solitary Confinement"
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/mediumsec/west)
@@ -49968,12 +49654,8 @@
 	},
 /area/prison/cellblock/mediumsec/east)
 "cvh" = (
-/obj/machinery/door/airlock/mainship/secure{
-	density = 0;
-	icon_state = "door_open";
-	name = "Solitary Confinement";
-	opacity = 0;
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/secure/open/free_access{
+	name = "Solitary Confinement"
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/mediumsec/north)
@@ -50296,34 +49978,23 @@
 	},
 /area/prison/cellblock/mediumsec/south)
 "cvX" = (
-/obj/machinery/door/airlock/mainship/secure{
-	density = 0;
+/obj/machinery/door/airlock/mainship/secure/open/free_access{
 	dir = 2;
-	icon_state = "door_open";
-	name = "Solitary Confinement";
-	opacity = 0;
-	req_access_txt = "0"
+	name = "Solitary Confinement"
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/protective)
 "cvY" = (
 /obj/machinery/door/airlock/mainship/generic{
-	density = 0;
 	dir = 2;
-	icon_state = "door_open";
-	name = "Toilet";
-	opacity = 0
+	name = "Toilet"
 	},
 /turf/open/floor/freezer,
 /area/prison/security/head)
 "cvZ" = (
-/obj/machinery/door/airlock/mainship/secure{
-	density = 0;
+/obj/machinery/door/airlock/mainship/secure/open/free_access{
 	dir = 2;
-	icon_state = "door_open";
-	name = "Solitary Confinement";
-	opacity = 0;
-	req_access_txt = "0"
+	name = "Solitary Confinement"
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/highsec/south/south)
@@ -50352,13 +50023,9 @@
 /turf/open/floor/plating,
 /area/prison/pirate)
 "cwc" = (
-/obj/machinery/door/airlock/mainship/secure{
-	density = 0;
+/obj/machinery/door/airlock/mainship/secure/open/free_access{
 	dir = 2;
-	icon_state = "door_open";
-	name = "Solitary Confinement";
-	opacity = 0;
-	req_access_txt = "0"
+	name = "Solitary Confinement"
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/mediumsec/east)
@@ -50503,12 +50170,8 @@
 	},
 /area/prison/cellblock/mediumsec/west)
 "cww" = (
-/obj/machinery/door/airlock/mainship/secure{
-	density = 0;
-	icon_state = "door_open";
-	name = "Solitary Confinement";
-	opacity = 0;
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/secure/open/free_access{
+	name = "Solitary Confinement"
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/mediumsec/east)
@@ -50946,12 +50609,8 @@
 /turf/open/floor/plating,
 /area/prison/cellblock/mediumsec/south)
 "cyz" = (
-/obj/machinery/door/airlock/mainship/secure{
-	density = 0;
-	icon_state = "door_open";
-	name = "Solitary Confinement";
-	opacity = 0;
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/secure/open/free_access{
+	name = "Solitary Confinement"
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/mediumsec/south)
@@ -51189,10 +50848,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 2;
-	name = "Medium-Security Monitoring";
-	req_access_txt = "0"
+	name = "Medium-Security Monitoring"
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/monitoring/medsec/south)
@@ -51202,10 +50860,9 @@
 /area/prison/security/monitoring/medsec/south)
 "czo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 2;
-	name = "Medium-Security Monitoring";
-	req_access_txt = "0"
+	name = "Medium-Security Monitoring"
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/monitoring/medsec/south)
@@ -51537,9 +51194,8 @@
 	},
 /area/prison/residential/south)
 "dPR" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2;
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	dir = 2
 	},
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating,
@@ -51850,9 +51506,8 @@
 	},
 /area/prison/residential/north)
 "kja" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2;
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	dir = 2
 	},
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating,
@@ -52192,12 +51847,8 @@
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/mediumsec/south)
 "swP" = (
-/obj/machinery/door/airlock/mainship/secure{
-	density = 0;
-	icon_state = "door_open";
-	name = "Solitary Confinement";
-	opacity = 0;
-	req_access_txt = "0"
+/obj/machinery/door/airlock/mainship/secure/open/free_access{
+	name = "Solitary Confinement"
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/mediumsec/west)
@@ -52375,9 +52026,7 @@
 	},
 /area/prison/hallway/central)
 "woW" = (
-/obj/machinery/door/airlock/mainship/maint{
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/mainship/maint/free_access,
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
 /area/prison/security/monitoring/lowsec/sw)

--- a/_maps/map_files/Research_Outpost/Research_Outpost.dmm
+++ b/_maps/map_files/Research_Outpost/Research_Outpost.dmm
@@ -581,7 +581,7 @@
 /turf/open/floor/tile/dark,
 /area/outpost/engineering/security)
 "cR" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 2
 	},
 /obj/structure/cable{
@@ -663,12 +663,9 @@
 /turf/open/floor/plating,
 /area/outpost/engineering/engine)
 "dm" = (
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 1;
-	icon_state = "door_locked";
-	locked = 1;
-	name = "\improper Marshal Office Armory";
-	req_access_txt = "0"
+	name = "\improper Marshal Office Armory"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -806,7 +803,7 @@
 /turf/closed/wall/r_wall,
 /area/outpost/brig/wardens_office)
 "eg" = (
-/obj/machinery/door/airlock/mainship/research/glass{
+/obj/machinery/door/airlock/mainship/research/glass/free_access{
 	dir = 8
 	},
 /obj/structure/cable{
@@ -904,7 +901,7 @@
 	},
 /area/outpost/hallway/east)
 "ez" = (
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -1269,7 +1266,7 @@
 	},
 /area/outpost/medbay/surgery)
 "fZ" = (
-/obj/machinery/door/airlock/mainship/medical{
+/obj/machinery/door/airlock/mainship/medical/free_access{
 	dir = 2
 	},
 /obj/structure/cable{
@@ -1366,7 +1363,7 @@
 	},
 /area/outpost/brig/armoury)
 "gr" = (
-/obj/machinery/door/airlock/mainship/medical,
+/obj/machinery/door/airlock/mainship/medical/free_access,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -1515,12 +1512,9 @@
 /turf/open/floor/tile/dark,
 /area/outpost/brig/armoury)
 "hd" = (
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 4;
-	icon_state = "door_locked";
-	locked = 1;
-	name = "\improper Marshal Office Armory";
-	req_access_txt = "0"
+	name = "\improper Marshal Office Armory"
 	},
 /turf/open/floor/tile/dark,
 /area/outpost/brig/wardens_office)
@@ -1699,7 +1693,7 @@
 	},
 /area/outpost/cargo)
 "ib" = (
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 2
 	},
 /obj/structure/cable{
@@ -1837,12 +1831,9 @@
 /turf/open/floor/tile/dark/blue2,
 /area/outpost/medbay/storage)
 "iC" = (
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 1;
-	icon_state = "door_locked";
-	locked = 1;
-	name = "\improper Marshal Office Armory";
-	req_access_txt = "0"
+	name = "\improper Marshal Office Armory"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -2448,7 +2439,7 @@
 /turf/open/floor/tile/dark,
 /area/outpost/medbay/storage)
 "lk" = (
-/obj/machinery/door/airlock/mainship/research/glass{
+/obj/machinery/door/airlock/mainship/research/glass/free_access{
 	dir = 1
 	},
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -2936,7 +2927,7 @@
 /turf/open/floor/tile/dark/brown2,
 /area/outpost/hallway/northern)
 "nM" = (
-/obj/machinery/door/airlock/mainship/medical{
+/obj/machinery/door/airlock/mainship/medical/free_access{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -3230,7 +3221,7 @@
 	},
 /area/outpost/cargo)
 "pg" = (
-/obj/machinery/door/airlock/mainship/engineering,
+/obj/machinery/door/airlock/mainship/engineering/free_access,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -3659,12 +3650,9 @@
 	},
 /area/outpost/science/rd_office)
 "re" = (
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 1;
-	icon_state = "door_locked";
-	locked = 1;
-	name = "\improper Marshal Office Holding Cell";
-	req_access_txt = "0"
+	name = "\improper Marshal Office Holding Cell"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
@@ -4275,7 +4263,7 @@
 	},
 /area/outpost/hallway/south_east)
 "tS" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 8
 	},
 /obj/structure/cable{
@@ -4446,7 +4434,7 @@
 	},
 /area/outpost/yard/east)
 "vc" = (
-/obj/machinery/door/airlock/multi_tile/mainship/medidoor/medbay,
+/obj/machinery/door/airlock/multi_tile/mainship/medidoor,
 /turf/open/floor/tile/dark,
 /area/outpost/medbay)
 "vd" = (
@@ -4672,7 +4660,7 @@
 	},
 /area/outpost/yard/south)
 "wm" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 2
 	},
 /obj/structure/cable{
@@ -7346,7 +7334,7 @@
 	},
 /area/outpost/lz1)
 "JG" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -7366,7 +7354,7 @@
 	},
 /area/outpost/medbay/surgery)
 "JK" = (
-/obj/machinery/door/airlock/multi_tile/mainship/medidoor/medbay{
+/obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	dir = 2
 	},
 /obj/structure/cable{
@@ -7701,7 +7689,7 @@
 /turf/open/floor/tile/dark,
 /area/outpost/medbay)
 "KP" = (
-/obj/machinery/door/airlock/mainship/research/glass{
+/obj/machinery/door/airlock/mainship/research/glass/free_access{
 	dir = 8
 	},
 /obj/structure/cable{
@@ -8715,10 +8703,9 @@
 	},
 /area/outpost/medbay)
 "Py" = (
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 1;
-	name = "\improper Marshal Office";
-	req_access_txt = "0"
+	name = "\improper Marshal Office"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -9631,7 +9618,7 @@
 	},
 /area/outpost/cargo)
 "Tx" = (
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -9939,7 +9926,7 @@
 /turf/open/floor/tile/dark,
 /area/outpost/hallway/east)
 "UZ" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -10817,7 +10804,7 @@
 	},
 /area/outpost/lz2)
 "Zn" = (
-/obj/machinery/door/airlock/mainship/research/glass{
+/obj/machinery/door/airlock/mainship/research/glass/free_access{
 	dir = 8
 	},
 /obj/structure/cable{
@@ -11015,7 +11002,7 @@
 	},
 /area/outpost/caves/east)
 "ZR" = (
-/obj/machinery/door/airlock/mainship/medical{
+/obj/machinery/door/airlock/mainship/medical/free_access{
 	dir = 1
 	},
 /obj/structure/cable{

--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -2667,7 +2667,8 @@
 	},
 /obj/machinery/door_control{
 	id = "mbayexit";
-	name = "medbay exit"pixel_y = -32
+	name = "medbay exit";
+	pixel_y = -32
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;

--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -963,7 +963,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/door/airlock/mainship/marine/requisitions{
-	icon_state = "door_closed";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -3603,7 +3602,6 @@
 "aiv" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/mainship/marine/requisitions{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /turf/open/floor{
@@ -4227,7 +4225,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/mainship/marine/requisitions{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /turf/open/floor{
@@ -13069,7 +13066,6 @@
 /area/sulaco/bridge)
 "aAO" = (
 /obj/machinery/door/airlock/mainship/security{
-	icon_state = "door_closed";
 	dir = 2
 	},
 /turf/open/floor{
@@ -13556,7 +13552,6 @@
 /area/sulaco/brig)
 "aBJ" = (
 /obj/machinery/door/airlock/mainship/marine/alpha/medic{
-	icon_state = "door_closed";
 	dir = 4
 	},
 /turf/open/floor{
@@ -13633,7 +13628,6 @@
 /area/sulaco/hallway/central_hall3)
 "aBV" = (
 /obj/machinery/door/airlock/mainship/marine/alpha/sl{
-	icon_state = "door_closed";
 	dir = 4
 	},
 /turf/open/floor{
@@ -13816,7 +13810,6 @@
 /area/sulaco/marine/delta)
 "aCm" = (
 /obj/machinery/door/airlock/mainship/marine/alpha/engineer{
-	icon_state = "door_closed";
 	dir = 4
 	},
 /turf/open/floor{
@@ -14078,14 +14071,12 @@
 /area/sulaco/marine/delta)
 "aCO" = (
 /obj/machinery/door/airlock/mainship/marine/delta/smart{
-	icon_state = "door_closed";
 	dir = 4
 	},
 /turf/open/floor,
 /area/sulaco/marine/delta)
 "aCP" = (
 /obj/machinery/door/airlock/mainship/marine/alpha/smart{
-	icon_state = "door_closed";
 	dir = 4
 	},
 /turf/open/floor,
@@ -15866,7 +15857,6 @@
 /area/sulaco/marine/delta)
 "aGT" = (
 /obj/machinery/door/airlock/mainship/marine/delta/medic{
-	icon_state = "door_closed";
 	dir = 4
 	},
 /turf/open/floor{
@@ -17157,7 +17147,6 @@
 /area/mainship/shipboard/weapon_room)
 "aJN" = (
 /obj/machinery/door/airlock/mainship/marine/delta/sl{
-	icon_state = "door_closed";
 	dir = 4
 	},
 /turf/open/floor{
@@ -17644,7 +17633,6 @@
 /area/sulaco/hangar/two)
 "aKW" = (
 /obj/machinery/door/airlock/mainship/marine/charlie/medic{
-	icon_state = "door_closed";
 	dir = 4
 	},
 /turf/open/floor{
@@ -17653,7 +17641,6 @@
 /area/sulaco/marine/charlie)
 "aKX" = (
 /obj/machinery/door/airlock/mainship/marine/bravo/medic{
-	icon_state = "door_closed";
 	dir = 8
 	},
 /turf/open/floor{
@@ -17668,7 +17655,6 @@
 /area/sulaco/marine/delta)
 "aKZ" = (
 /obj/machinery/door/airlock/mainship/marine/delta/engineer{
-	icon_state = "door_closed";
 	dir = 4
 	},
 /turf/open/floor{
@@ -17739,7 +17725,6 @@
 /area/sulaco/brig)
 "aLk" = (
 /obj/machinery/door/airlock/mainship/marine/charlie/sl{
-	icon_state = "door_closed";
 	dir = 8
 	},
 /turf/open/floor{
@@ -17748,7 +17733,6 @@
 /area/sulaco/marine/charlie)
 "aLl" = (
 /obj/machinery/door/airlock/mainship/marine/bravo/sl{
-	icon_state = "door_closed";
 	dir = 4
 	},
 /turf/open/floor{
@@ -18044,7 +18028,6 @@
 /area/sulaco/brig)
 "aLX" = (
 /obj/machinery/door/airlock/mainship/marine/charlie/engineer{
-	icon_state = "door_closed";
 	dir = 8
 	},
 /turf/open/floor{
@@ -18067,7 +18050,6 @@
 /area/sulaco/marine/bravo)
 "aMa" = (
 /obj/machinery/door/airlock/mainship/marine/bravo/engineer{
-	icon_state = "door_closed";
 	dir = 8
 	},
 /turf/open/floor{
@@ -18188,7 +18170,6 @@
 /area/sulaco/hallway/central_hall3)
 "aMo" = (
 /obj/machinery/door/airlock/mainship/marine/charlie/smart{
-	icon_state = "door_closed";
 	dir = 4
 	},
 /turf/open/floor,
@@ -18255,7 +18236,6 @@
 /area/sulaco/command/eva)
 "aMz" = (
 /obj/machinery/door/airlock/mainship/marine/bravo/smart{
-	icon_state = "door_closed";
 	dir = 4
 	},
 /turf/open/floor,
@@ -19971,7 +19951,6 @@
 /area/sulaco/morgue)
 "aQR" = (
 /obj/machinery/door/airlock/mainship/marine/requisitions{
-	icon_state = "door_closed";
 	dir = 8
 	},
 /turf/open/floor/mainship{

--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -648,12 +648,10 @@
 /area/sulaco/disposal)
 "abX" = (
 /obj/item/stool,
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/engineering{
 	id = "Disposal Exit";
 	name = "Disposal Vent Control";
-	pixel_y = 36;
-	req_access_txt = "0";
-	req_one_access_txt = "7;21"
+	pixel_y = 36
 	},
 /obj/machinery/camera/autoname,
 /obj/machinery/driver_button{
@@ -1117,9 +1115,7 @@
 	},
 /area/sulaco/medbay/storage)
 "adc" = (
-/obj/structure/closet/secure_closet/chemical{
-	req_access = null
-	},
+/obj/structure/closet/secure_closet/chemical,
 /turf/open/floor{
 	icon_state = "white"
 	},
@@ -1407,7 +1403,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/mainship/medical{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /turf/open/floor{
@@ -1486,7 +1481,6 @@
 /area/sulaco/maintenance/north_solar_maint)
 "adV" = (
 /obj/machinery/door/airlock/mainship/engineering/CSEoffice{
-	icon_state = "door_closed";
 	dir = 2
 	},
 /obj/structure/cable/yellow{
@@ -2674,9 +2668,7 @@
 	},
 /obj/machinery/door_control{
 	id = "mbayexit";
-	name = "medbay exit";
-	normaldoorcontrol = 1;
-	pixel_y = -32
+	name = "medbay exit"pixel_y = -32
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -2789,7 +2781,6 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/mainship/medical/glass/CMO{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /turf/open/floor{
@@ -3231,11 +3222,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/closet/walllocker/hydrant,
 /obj/structure/table,
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/medbay{
 	id = "Medbay";
 	name = "Medbay Lockdown";
-	pixel_x = -4;
-	req_one_access_txt = "5"
+	pixel_x = -4
 	},
 /turf/open/floor{
 	icon_state = "white"
@@ -3429,7 +3419,6 @@
 "aib" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/machinery/door/airlock/mainship/engineering/CSEoffice{
-	icon_state = "door_closed";
 	dir = 2
 	},
 /turf/open/floor{
@@ -3439,7 +3428,6 @@
 /area/sulaco/engineering/ce)
 "aic" = (
 /obj/machinery/door/airlock/mainship/engineering/CSEoffice{
-	icon_state = "door_closed";
 	dir = 2
 	},
 /obj/structure/cable/yellow{
@@ -3906,11 +3894,10 @@
 /area/sulaco/medbay)
 "aja" = (
 /obj/structure/bed/chair/office/dark,
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/req{
 	id = "ROlobby1";
 	name = "RO Line 1 Shutters";
-	pixel_x = -30;
-	req_one_access_txt = "1;21"
+	pixel_x = -30
 	},
 /obj/machinery/flasher_button{
 	id = "req";
@@ -3927,13 +3914,11 @@
 /area/sulaco/cargo)
 "ajc" = (
 /obj/structure/bed/chair/office/dark,
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/req{
 	id = "ROlobby2";
 	name = "RO Line 2 Shutters";
 	pixel_x = 30;
-	pixel_y = -30;
-	pixel_z = 0;
-	req_one_access_txt = "1;21"
+	pixel_y = -30
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /obj/machinery/flasher_button{
@@ -4484,14 +4469,6 @@
 	icon_state = "platebotc"
 	},
 /area/sulaco/medbay)
-"akg" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 1;
-	icon_state = "door_closed";
-	req_one_access = "2;8;19"
-	},
-/turf/open/floor/plating,
-/area/sulaco/maintenance/north_solar_maint)
 "akh" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -5248,7 +5225,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/mainship/command/FCDRquarters{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -5523,11 +5499,10 @@
 	},
 /area/sulaco/cryosleep)
 "amo" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/req{
 	id = "qm_warehouse";
 	name = "RO Warehouse Shutters";
-	pixel_x = -30;
-	req_one_access_txt = "1;21"
+	pixel_x = -30
 	},
 /obj/machinery/vending/lasgun,
 /turf/open/floor/mainship/mono,
@@ -5900,11 +5875,10 @@
 /area/sulaco/cargo/office)
 "amV" = (
 /obj/machinery/light,
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/req{
 	id = "qm_warehouse";
 	name = "RO Warehouse Shutters";
-	pixel_y = -30;
-	req_one_access_txt = "2;21"
+	pixel_y = -30
 	},
 /obj/machinery/vending/uniform_supply,
 /turf/open/floor/mainship/mono,
@@ -5991,7 +5965,6 @@
 /area/sulaco/cafeteria)
 "anh" = (
 /obj/machinery/door/airlock/mainship/maint{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -6190,10 +6163,9 @@
 /area/sulaco/cargo/office)
 "anG" = (
 /obj/structure/table,
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/req{
 	id = "ROoffice";
-	name = "RO Office Shutters";
-	req_one_access_txt = "1;21"
+	name = "RO Office Shutters"
 	},
 /obj/item/tool/stamp{
 	pixel_x = -3;
@@ -6408,7 +6380,6 @@
 /area/sulaco/bridge)
 "anZ" = (
 /obj/machinery/door/airlock/mainship/maint{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -6440,7 +6411,6 @@
 "aoc" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/machinery/door/airlock/mainship/engineering/workshop{
-	icon_state = "door_closed";
 	dir = 2
 	},
 /turf/open/floor{
@@ -6451,7 +6421,6 @@
 "aod" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/machinery/door/airlock/mainship/maint{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -6507,7 +6476,6 @@
 	opacity = 0
 	},
 /obj/machinery/door/airlock/mainship/command/cic{
-	icon_state = "door_closed";
 	dir = 8
 	},
 /obj/structure/sign/prop3,
@@ -6525,7 +6493,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/mainship/engineering/atmos{
-	icon_state = "door_closed";
 	dir = 2
 	},
 /obj/structure/cable/yellow{
@@ -6554,14 +6521,8 @@
 /turf/closed/wall/sulaco/unmeltable,
 /area/space)
 "aoq" = (
-/obj/machinery/door/window/westleft{
-	layer = 3.1;
-	req_access_txt = "0";
-	req_one_access_txt = "2"
-	},
-/obj/machinery/door/window/eastleft{
-	layer = 3.1
-	},
+/obj/machinery/door/window/westleft,
+/obj/machinery/door/window/eastleft,
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -6752,10 +6713,8 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/door/window{
-	name = "interior door";
-	req_access_txt = "19";
-	req_one_access_txt = "0"
+/obj/machinery/door/window/mainship/bridge{
+	name = "interior door"
 	},
 /turf/open/floor/stairs/rampbottom{
 	icon_state = "rampbottom";
@@ -6981,10 +6940,7 @@
 	},
 /area/sulaco/bridge)
 "apq" = (
-/obj/machinery/door/window/eastright{
-	req_access = null;
-	req_access_txt = "19"
-	},
+/obj/machinery/door/window/eastright/bridge,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -7686,7 +7642,6 @@
 	opacity = 0
 	},
 /obj/machinery/door/airlock/mainship/command/FCDRquarters{
-	icon_state = "door_closed";
 	dir = 8
 	},
 /turf/open/floor/carpet,
@@ -7872,12 +7827,10 @@
 /turf/closed/wall/sulaco,
 /area/sulaco/hallway/central_hall2)
 "arm" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "bar";
 	name = "Briefing Shutters";
-	pixel_x = -30;
-	req_one_access_txt = "2;3;12;19";
-	throw_range = 15
+	pixel_x = -30
 	},
 /turf/open/floor,
 /area/sulaco/briefing)
@@ -7965,17 +7918,15 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/medbay{
 	id = "Medbay";
 	name = "Medbay Lockdown";
-	pixel_y = -3;
-	req_one_access_txt = "5"
+	pixel_y = -3
 	},
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/cic{
 	id = "sb blast";
 	name = "Fore Lockdown";
-	pixel_y = 6;
-	req_access_txt = "19"
+	pixel_y = 6
 	},
 /obj/structure/table/reinforced,
 /turf/open/floor/prison,
@@ -8124,7 +8075,6 @@
 /area/sulaco/engineering)
 "arO" = (
 /obj/machinery/door/airlock/mainship/engineering/workshop{
-	icon_state = "door_closed";
 	dir = 2
 	},
 /obj/structure/cable/yellow{
@@ -8150,12 +8100,8 @@
 /area/sulaco/engineering)
 "arQ" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/obj/machinery/door/airlock/hatch{
-	icon_state = "door_locked";
-	id_tag = "engine_electrical_maintenance";
-	locked = 1;
-	name = "Engine Electrical Maintenance";
-	req_access_txt = "7"
+/obj/machinery/door/airlock/hatch/engineering{
+	name = "Engine Electrical Maintenance"
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -8332,8 +8278,7 @@
 /area/sulaco/engineering)
 "ask" = (
 /obj/machinery/door/airlock/glass{
-	name = "Stern Tool Storage";
-	req_access_txt = "7"
+	name = "Stern Tool Storage"
 	},
 /turf/open/floor,
 /area/sulaco/cargo/office)
@@ -8351,19 +8296,17 @@
 /obj/structure/bed/chair/comfy/black{
 	dir = 8
 	},
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/cic{
 	id = "port blast";
 	name = "Aft Lockdown";
 	pixel_x = -1;
-	pixel_y = -32;
-	req_access_txt = "19"
+	pixel_y = -32
 	},
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/cic{
 	id = "bridge blast";
 	name = "Bridge Blast Door Control";
 	pixel_x = -1;
-	pixel_y = -24;
-	req_access_txt = "19"
+	pixel_y = -24
 	},
 /turf/open/floor/prison,
 /area/sulaco/bridge)
@@ -8410,10 +8353,8 @@
 	},
 /area/sulaco/hallway/central_hall)
 "ast" = (
-/obj/machinery/door/window{
-	name = "Commander's Deck";
-	req_access_txt = "19";
-	req_one_access_txt = "0"
+/obj/machinery/door/window/mainship/bridge{
+	name = "Commander's Deck"
 	},
 /turf/open/floor/stairs/rampbottom{
 	icon_state = "rampbottom";
@@ -8432,7 +8373,6 @@
 /area/sulaco/cargo/office)
 "asv" = (
 /obj/machinery/door/airlock/mainship/maint{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -8546,12 +8486,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "bar";
 	name = "Briefing Shutters";
-	pixel_y = 30;
-	req_one_access_txt = "2;3;12;19";
-	throw_range = 15
+	pixel_y = 30
 	},
 /obj/structure/ladder{
 	height = 2;
@@ -8563,7 +8501,6 @@
 "asI" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/machinery/door/airlock/mainship/engineering{
-	icon_state = "door_closed";
 	dir = 2
 	},
 /turf/open/floor{
@@ -8700,13 +8637,10 @@
 /turf/closed/wall/sulaco,
 /area/sulaco/engineering)
 "asX" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/engineering{
 	id = "engine_electrical_maintenance";
 	name = "Door Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 30;
-	req_access_txt = "7";
-	specialfunctions = 4
+	pixel_x = 30
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/plating,
@@ -8997,9 +8931,8 @@
 	icon_state = "table";
 	layer = 2.1
 	},
-/obj/machinery/door/window/westleft{
-	dir = 4;
-	req_one_access_txt = "7"
+/obj/machinery/door/window/westleft/engineering{
+	dir = 4
 	},
 /obj/machinery/door/window/westleft{
 	base_state = "right";
@@ -9458,7 +9391,6 @@
 /area/sulaco/briefing)
 "aun" = (
 /obj/machinery/door/airlock/mainship/maint{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -9586,7 +9518,6 @@
 	layer = 2
 	},
 /obj/machinery/door/airlock/mainship/command/cic{
-	icon_state = "door_closed";
 	dir = 8
 	},
 /turf/open/floor{
@@ -9755,7 +9686,6 @@
 /area/sulaco/engineering/smes)
 "auJ" = (
 /obj/machinery/door/airlock/mainship/engineering{
-	icon_state = "door_closed";
 	dir = 2
 	},
 /obj/structure/cable/yellow{
@@ -10112,7 +10042,6 @@
 /area/sulaco/hallway/central_hall2)
 "avr" = (
 /obj/machinery/door/airlock/mainship/command/cic{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -10151,10 +10080,7 @@
 /area/sulaco/briefing)
 "avv" = (
 /obj/structure/window/reinforced,
-/obj/machinery/door/window/eastright{
-	req_access = null;
-	req_access_txt = "19"
-	},
+/obj/machinery/door/window/eastright/bridge,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -10497,7 +10423,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/mainship/engineering{
-	icon_state = "door_closed";
 	dir = 2
 	},
 /turf/open/floor{
@@ -10567,12 +10492,11 @@
 	dir = 5
 	},
 /obj/structure/table/reinforced,
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/engineering{
 	desc = "A remote control-switch for the engine control room blast doors.";
 	id = "EngineBlast";
 	name = "Engine Room Blast Doors";
-	pixel_y = -3;
-	req_access_txt = "7"
+	pixel_y = -3
 	},
 /obj/structure/cable{
 	icon_state = "4-8";
@@ -10638,10 +10562,8 @@
 /turf/open/floor/plating/mainship,
 /area/sulaco/engineering/engine)
 "awn" = (
-/obj/machinery/door/window{
-	name = "interior door";
-	req_access_txt = "19";
-	req_one_access_txt = "0"
+/obj/machinery/door/window/mainship/bridge{
+	name = "interior door"
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
@@ -10883,7 +10805,6 @@
 	opacity = 0
 	},
 /obj/machinery/door/airlock/mainship/command/cic{
-	icon_state = "door_closed";
 	dir = 8
 	},
 /turf/open/floor{
@@ -11263,7 +11184,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/mainship/engineering{
-	icon_state = "door_closed";
 	dir = 2
 	},
 /obj/structure/cable/yellow{
@@ -11651,7 +11571,6 @@
 /area/sulaco/hallway/central_hall3)
 "axR" = (
 /obj/machinery/door/airlock/mainship/engineering{
-	icon_state = "door_closed";
 	dir = 2
 	},
 /obj/structure/cable/yellow{
@@ -11865,11 +11784,10 @@
 "ayj" = (
 /obj/machinery/computer/secure_data,
 /obj/structure/table/reinforced,
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/brigarmory{
 	id = "Secure Gate";
 	name = "Security Lockdown";
-	pixel_x = 30;
-	req_access_txt = "3"
+	pixel_x = 30
 	},
 /turf/open/floor{
 	icon_state = "floor4"
@@ -11983,7 +11901,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/mainship/maint{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -12236,7 +12153,6 @@
 "ayY" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/mainship/maint{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -12307,12 +12223,8 @@
 /turf/closed/wall/sulaco,
 /area/sulaco/engineering/storage)
 "azj" = (
-/obj/machinery/door/airlock/hatch{
-	icon_state = "door_locked";
-	id_tag = "engine_electrical_maintenance";
-	locked = 1;
-	name = "Engine Electrical Maintenance";
-	req_access_txt = "7"
+/obj/machinery/door/airlock/hatch/engineering{
+	name = "Engine Electrical Maintenance"
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -12426,7 +12338,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/mainship/command/CPToffice{
-	icon_state = "door_closed";
 	dir = 2
 	},
 /turf/open/floor/wood,
@@ -12453,7 +12364,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/mainship/security/glass{
-	icon_state = "door_closed";
 	dir = 2
 	},
 /turf/open/floor{
@@ -12549,13 +12459,8 @@
 	},
 /area/sulaco/bridge)
 "azG" = (
-/obj/machinery/door/window/westleft{
-	layer = 3.1;
-	req_access_txt = "1"
-	},
-/obj/machinery/door/window/eastleft{
-	layer = 3.1
-	},
+/obj/machinery/door/window/westleft/bridge,
+/obj/machinery/door/window/eastleft,
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -12618,7 +12523,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/door/airlock/mainship/maint{
-	icon_state = "door_closed";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -12720,7 +12624,6 @@
 "azZ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/machinery/door/airlock/mainship/command{
-	icon_state = "door_closed";
 	dir = 8
 	},
 /turf/open/floor,
@@ -12735,7 +12638,6 @@
 /area/sulaco/briefing)
 "aAc" = (
 /obj/machinery/door/airlock/mainship/engineering/atmos{
-	icon_state = "door_closed";
 	dir = 2
 	},
 /turf/open/floor{
@@ -12744,7 +12646,6 @@
 /area/sulaco/engineering/smes)
 "aAd" = (
 /obj/machinery/door/airlock/mainship/engineering{
-	icon_state = "door_closed";
 	dir = 2
 	},
 /turf/open/floor/tile,
@@ -12763,10 +12664,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/machinery/door/window/northleft{
-	layer = 2.9;
-	req_one_access_txt = "2"
-	},
+/obj/machinery/door/window/northleft/req,
 /turf/open/floor,
 /area/sulaco/briefing)
 "aAg" = (
@@ -12814,7 +12712,6 @@
 /area/sulaco/brig)
 "aAl" = (
 /obj/machinery/door/airlock/mainship/security/glass{
-	icon_state = "door_closed";
 	dir = 2
 	},
 /turf/open/floor{
@@ -12951,12 +12848,8 @@
 	},
 /area/sulaco/engineering)
 "aAx" = (
-/obj/machinery/door/airlock/hatch{
-	icon_state = "door_locked";
-	id_tag = "engine_electrical_maintenance";
-	locked = 1;
-	name = "Engine Electrical Maintenance";
-	req_access_txt = "7"
+/obj/machinery/door/airlock/hatch/engineering{
+	name = "Engine Electrical Maintenance"
 	},
 /turf/open/floor/plating/mainship,
 /area/sulaco/engineering/engine)
@@ -13003,7 +12896,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/mainship/security/glass/cells{
-	icon_state = "door_closed";
 	dir = 8
 	},
 /turf/open/floor{
@@ -13097,7 +12989,6 @@
 /area/sulaco/engineering)
 "aAH" = (
 /obj/machinery/door/airlock/mainship/security/glass{
-	icon_state = "door_closed";
 	dir = 8
 	},
 /turf/open/floor{
@@ -13133,7 +13024,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/mainship/security/glass/cells{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /turf/open/floor{
@@ -13336,7 +13226,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/mainship/maint{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -13479,7 +13368,6 @@
 /area/sulaco/hallway/central_hall)
 "aBo" = (
 /obj/machinery/door/airlock/mainship/engineering{
-	icon_state = "door_closed";
 	dir = 2
 	},
 /obj/structure/cable/yellow{
@@ -13537,7 +13425,6 @@
 /area/sulaco/maintenance/south_solar_maint)
 "aBt" = (
 /obj/machinery/door/airlock/mainship/maint{
-	icon_state = "door_closed";
 	dir = 8
 	},
 /turf/open/floor,
@@ -13569,12 +13456,10 @@
 	},
 /area/sulaco/brig)
 "aBx" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "bar";
 	name = "Briefing Shutters";
-	pixel_y = 30;
-	req_one_access_txt = "2;3;12;19";
-	throw_range = 15
+	pixel_y = 30
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -13660,7 +13545,6 @@
 	opacity = 0
 	},
 /obj/machinery/door/airlock/mainship/security/glass{
-	icon_state = "door_closed";
 	dir = 8
 	},
 /turf/open/floor{
@@ -14078,7 +13962,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/mainship/security/glass{
-	icon_state = "door_closed";
 	dir = 2
 	},
 /obj/structure/cable/yellow{
@@ -14175,9 +14058,7 @@
 /turf/open/floor,
 /area/sulaco/maintenance/south_solar_maint)
 "aCK" = (
-/obj/machinery/door/window/westleft{
-	req_one_access_txt = "2"
-	},
+/obj/machinery/door/window/westleft/req,
 /turf/open/floor,
 /area/sulaco/briefing)
 "aCL" = (
@@ -14343,13 +14224,10 @@
 	},
 /area/sulaco/cryosleep)
 "aDf" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/engineering{
 	id = "engine_electrical_maintenance";
 	name = "Door Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_y = -30;
-	req_access_txt = "7";
-	specialfunctions = 4
+	pixel_y = -30
 	},
 /turf/open/floor{
 	icon_state = "yellowfull"
@@ -14395,7 +14273,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/mainship/security/glass/cells{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /turf/open/floor{
@@ -14844,16 +14721,12 @@
 /area/sulaco/brig)
 "aEy" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/eastleft{
-	req_access = null;
-	req_access_txt = "3"
-	},
+/obj/machinery/door/window/eastleft/brig,
 /obj/machinery/door/window/westleft,
 /obj/structure/paper_bin,
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/brigarmory{
 	id = "Secure Gate";
-	name = "Security Lockdown";
-	req_access_txt = "3"
+	name = "Security Lockdown"
 	},
 /turf/open/floor{
 	icon_state = "floor4"
@@ -15382,10 +15255,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westright,
 /obj/item/folder/red,
-/obj/machinery/door/window/eastright{
-	req_access = null;
-	req_access_txt = "3"
-	},
+/obj/machinery/door/window/eastright/briefing,
 /turf/open/floor{
 	icon_state = "floor4"
 	},
@@ -15426,11 +15296,10 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/brigarmory{
 	id = "Secure Gate";
 	name = "Security Lockdown";
-	pixel_x = 30;
-	req_access_txt = "3"
+	pixel_x = 30
 	},
 /turf/open/floor{
 	icon_state = "floor4"
@@ -15504,7 +15373,6 @@
 /area/sulaco/hallway/central_hall3)
 "aFW" = (
 /obj/machinery/door/airlock/mainship/research/pen{
-	icon_state = "door_closed";
 	dir = 8
 	},
 /turf/open/floor{
@@ -16183,7 +16051,6 @@
 /area/sulaco/cap_office)
 "aHq" = (
 /obj/machinery/door/airlock/mainship/maint{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /turf/open/floor/plating/mainship,
@@ -16294,7 +16161,6 @@
 /area/sulaco/brig)
 "aHD" = (
 /obj/machinery/door/airlock/mainship/security/glass{
-	icon_state = "door_closed";
 	dir = 2
 	},
 /obj/structure/cable/yellow{
@@ -16381,10 +16247,8 @@
 	},
 /area/sulaco/brig)
 "aHL" = (
-/obj/machinery/door/airlock/hatch{
-	name = "EVA";
-	req_access_txt = "0";
-	req_one_access_txt = "1;6"
+/obj/machinery/door/airlock/hatch/engineering{
+	name = "EVA"
 	},
 /turf/open/floor,
 /area/sulaco/command/eva)
@@ -16397,7 +16261,6 @@
 /area/shuttle/distress/arrive_1)
 "aHO" = (
 /obj/machinery/door/airlock/mainship/engineering{
-	icon_state = "door_closed";
 	dir = 2
 	},
 /turf/open/floor/plating,
@@ -16812,9 +16675,7 @@
 /area/space)
 "aIP" = (
 /obj/machinery/door/airlock/mainship/maint{
-	dir = 2;
-	req_access_txt = "1";
-	req_one_access_txt = ""
+	dir = 2
 	},
 /turf/open/floor/plating,
 /area/sulaco/cap_office)
@@ -17492,7 +17353,6 @@
 /area/sulaco/command/eva)
 "aKn" = (
 /obj/machinery/door/airlock/mainship/command/CPToffice{
-	icon_state = "door_closed";
 	dir = 2
 	},
 /turf/open/floor{
@@ -17995,9 +17855,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/external{
-	name = "Execution Chamber";
-	req_access_txt = "3"
+/obj/machinery/door/airlock/external/brig{
+	name = "Execution Chamber"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor{
@@ -18403,9 +18262,7 @@
 /area/sulaco/marine/bravo)
 "aMA" = (
 /obj/structure/window/reinforced,
-/obj/structure/closet/secure_closet/injection{
-	req_access_txt = "1"
-	},
+/obj/structure/closet/secure_closet/injection,
 /obj/item/storage/bible{
 	desc = "As the legendary US Army chaplain once said, 'There are no Athiests in fancy offices'.";
 	name = "Holy Bible"
@@ -18609,7 +18466,6 @@
 /area/sulaco/marine/alpha)
 "aNe" = (
 /obj/machinery/door/airlock/mainship/medical/morgue{
-	icon_state = "door_closed";
 	dir = 8
 	},
 /turf/open/floor{
@@ -18653,7 +18509,6 @@
 /area/sulaco/maintenance/lower_maint)
 "aNi" = (
 /obj/machinery/door/airlock/mainship/medical/morgue{
-	icon_state = "door_closed";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -18809,7 +18664,6 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mainship/engineering/atmos{
-	icon_state = "door_closed";
 	dir = 2
 	},
 /turf/open/floor{
@@ -19013,9 +18867,7 @@
 	},
 /area/sulaco/hangar/two)
 "aNU" = (
-/obj/machinery/door/window/brigdoor/southright{
-	req_access_txt = "3"
-	},
+/obj/machinery/door/window/brigdoor/southright,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor{
 	icon_state = "floorgrimecaution";
@@ -19024,12 +18876,11 @@
 /area/sulaco/brig)
 "aNV" = (
 /obj/structure/window/reinforced,
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/engineering{
 	id = "ex_chamber";
 	name = "Vacuum Switch";
 	pixel_x = 26;
-	pixel_y = 5;
-	req_access_txt = "1"
+	pixel_y = 5
 	},
 /turf/open/floor{
 	icon_state = "floorgrimecaution";
@@ -19565,7 +19416,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
-	icon_state = "door_closed";
 	dir = 2
 	},
 /turf/open/floor{
@@ -19575,7 +19425,6 @@
 "aPr" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
-	icon_state = "door_closed";
 	dir = 2
 	},
 /turf/open/floor{
@@ -20002,7 +19851,6 @@
 /area/sulaco/hangar)
 "aQD" = (
 /obj/machinery/door/airlock/mainship/maint{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -20104,8 +19952,7 @@
 /obj/machinery/crema_switch{
 	id = "crema";
 	pixel_x = 28;
-	pixel_y = 28;
-	req_one_access_txt = "2;8;19"
+	pixel_y = 28
 	},
 /turf/open/floor{
 	icon_state = "cult";
@@ -20150,7 +19997,6 @@
 "aQT" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /obj/machinery/door/airlock/mainship/secure/tcomms{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /turf/open/floor{
@@ -20234,7 +20080,6 @@
 /area/sulaco/medbay/hangar)
 "aRe" = (
 /obj/machinery/door/airlock/mainship/generic/corporate{
-	icon_state = "door_closed";
 	dir = 2
 	},
 /turf/open/floor/wood,
@@ -20309,10 +20154,7 @@
 /area/sulaco/morgue)
 "aRo" = (
 /obj/structure/table/woodentable,
-/obj/machinery/faxmachine{
-	density = 0;
-	req_one_access_txt = "200"
-	},
+/obj/machinery/faxmachine,
 /turf/open/floor/carpet,
 /area/sulaco/liaison/quarters)
 "aRp" = (
@@ -20325,7 +20167,6 @@
 /area/sulaco/maintenance/lower_maint2)
 "aRq" = (
 /obj/machinery/door/airlock/mainship/secure/tcomms{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -20553,7 +20394,6 @@
 /area/sulaco/hangar)
 "aRS" = (
 /obj/machinery/door/airlock/mainship/generic/pilot/bunk{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -20581,7 +20421,6 @@
 /area/sulaco/hangar)
 "aRV" = (
 /obj/machinery/door/airlock/mainship/research/glass/cell/cell1{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /obj/machinery/door/poddoor/shutters/mainship/cell/cell1{
@@ -20824,7 +20663,6 @@
 /area/sulaco/research)
 "aSy" = (
 /obj/machinery/door/airlock/mainship/medical/morgue{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -20888,7 +20726,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/machinery/door/airlock/mainship/research{
-	icon_state = "door_closed";
 	dir = 2
 	},
 /turf/open/floor{
@@ -21178,7 +21015,6 @@
 /area/sulaco/medbay/hangar)
 "aTl" = (
 /obj/machinery/door/airlock/mainship/maint{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -21409,7 +21245,6 @@
 	name = "Blast Door"
 	},
 /obj/machinery/door/airlock/mainship/secure/tcomms{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -21429,7 +21264,6 @@
 /area/sulaco/telecomms/office)
 "aTO" = (
 /obj/machinery/door/airlock/mainship/secure/tcomms{
-	icon_state = "door_closed";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -21794,7 +21628,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	icon_state = "door_closed";
 	dir = 2
 	},
 /turf/open/floor{
@@ -21808,7 +21641,6 @@
 /area/sulaco/hangar/one)
 "aUP" = (
 /obj/machinery/door/airlock/mainship/medical/morgue{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /turf/open/floor{
@@ -22066,7 +21898,6 @@
 	layer = 2
 	},
 /obj/machinery/door/airlock/mainship/maint{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /turf/open/floor/mainship/mono,
@@ -22233,7 +22064,6 @@
 /area/sulaco/hallway/lower_main_hall)
 "aVT" = (
 /obj/machinery/door/airlock/mainship/maint{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -22360,7 +22190,6 @@
 /area/sulaco/maintenance/lower_maint)
 "aWg" = (
 /obj/machinery/door/airlock/mainship/maint{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -22440,7 +22269,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mainship/secure/tcomms{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -22981,7 +22809,6 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mainship/generic/corporate{
-	icon_state = "door_closed";
 	dir = 2
 	},
 /obj/structure/cable{
@@ -22995,7 +22822,6 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	icon_state = "door_closed";
 	dir = 2
 	},
 /turf/open/floor{
@@ -23031,7 +22857,6 @@
 /area/sulaco/maintenance/lower_maint)
 "aXu" = (
 /obj/machinery/door/airlock/mainship/secure/tcomms{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -23141,7 +22966,6 @@
 "aXI" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mainship/engineering/atmos{
-	icon_state = "door_closed";
 	dir = 2
 	},
 /obj/structure/cable{
@@ -23886,9 +23710,7 @@
 	},
 /area/sulaco/hallway/lower_main_hall)
 "aZi" = (
-/obj/structure/closet/secure_closet/guncabinet{
-	req_access_txt = "3"
-	},
+/obj/structure/closet/secure_closet/guncabinet/mp_armory,
 /obj/item/weapon/gun/pistol/m4a3,
 /obj/item/ammo_magazine/pistol,
 /obj/item/ammo_magazine/shotgun/buckshot,
@@ -24518,7 +24340,7 @@
 /obj/item/tool/stamp/internalaffairs{
 	pixel_y = 6
 	},
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/corporate{
 	id = "wyoffice";
 	name = "Window Shutters";
 	pixel_y = -5
@@ -24940,10 +24762,7 @@
 /area/sulaco/liaison)
 "bbH" = (
 /obj/structure/table/woodentable,
-/obj/machinery/computer/skills{
-	density = 0;
-	req_one_access = list(200)
-	},
+/obj/machinery/computer/skills,
 /turf/open/floor/wood,
 /area/sulaco/liaison)
 "bbI" = (
@@ -24971,9 +24790,7 @@
 /turf/open/floor/engine/vacuum,
 /area/sulaco/telecomms)
 "bbX" = (
-/obj/machinery/computer/telecomms/monitor{
-	req_one_access_txt = "19;200"
-	},
+/obj/machinery/computer/telecomms/monitor,
 /turf/open/floor{
 	icon_state = "dark"
 	},
@@ -25129,10 +24946,7 @@
 /turf/open/floor/engine/vacuum,
 /area/sulaco/telecomms)
 "bdf" = (
-/obj/machinery/computer/telecomms/server{
-	req_access = null;
-	req_one_access_txt = "19;200"
-	},
+/obj/machinery/computer/telecomms/server,
 /turf/open/floor{
 	icon_state = "dark"
 	},
@@ -25145,7 +24959,7 @@
 /area/sulaco/telecomms/office)
 "bdh" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/tcomms{
 	id = "tcomwind";
 	name = "Telecomms Window Control"
 	},
@@ -25223,10 +25037,9 @@
 /area/sulaco/telecomms/office)
 "bdC" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/tcomms{
 	id = "tcomdoor";
-	name = "Telecomms Door Control";
-	req_one_access_txt = "6"
+	name = "Telecomms Door Control"
 	},
 /turf/open/floor{
 	icon_state = "dark"
@@ -25275,9 +25088,7 @@
 /turf/open/floor/plating,
 /area/sulaco/hallway/lower_main_hall)
 "bdY" = (
-/obj/machinery/computer/crew{
-	req_access_txt = "200"
-	},
+/obj/machinery/computer/crew,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -55537,7 +55348,7 @@ agD
 afX
 afX
 ajS
-akg
+anZ
 aaW
 aaw
 ank

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -1869,9 +1869,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/upper_hull)
 "aeT" = (
-/obj/machinery/door/airlock/mainship/maint{
-	req_access_txt = "19"
-	},
+/obj/machinery/door/airlock/mainship/maint,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -2388,23 +2386,19 @@
 /obj/structure/table/mainship,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/reagent_containers/spray/cleaner,
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/research{
 	dir = 1;
 	id = "researchdoorext";
 	name = "Exterior Doors";
-	normaldoorcontrol = 1;
 	pixel_x = -10;
-	pixel_y = 8;
-	req_access_txt = "14"
+	pixel_y = 8
 	},
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/research{
 	dir = 1;
 	id = "researchdoorint";
 	name = "Interior Doors";
-	normaldoorcontrol = 1;
 	pixel_x = -10;
-	pixel_y = -4;
-	req_access_txt = "14"
+	pixel_y = -4
 	},
 /obj/machinery/firealarm{
 	dir = 4
@@ -3499,9 +3493,7 @@
 	},
 /area/mainship/command/corporateliaison)
 "aiQ" = (
-/obj/structure/closet/secure_closet/personal/cabinet{
-	req_access = null
-	},
+/obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/carpet{
 	dir = 4;
 	icon_state = "carpetside"
@@ -3756,8 +3748,7 @@
 "ajz" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 1;
-	name = "\improper Emergency Air Storage";
-	req_one_access_txt = "2;7"
+	name = "\improper Emergency Air Storage"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -4410,13 +4401,6 @@
 	icon_state = "cargo"
 	},
 /area/mainship/squads/bravo)
-"akR" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2;
-	req_one_access_txt = "2;7"
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/upper_hull)
 "akS" = (
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/brig)
@@ -4598,11 +4582,10 @@
 "alp" = (
 /obj/structure/table/mainship,
 /obj/item/portable_vendor/corporate,
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/corporate{
 	id = "quarters_shutters";
 	name = "Quarters Shutters";
-	pixel_x = -25;
-	req_access_txt = "200"
+	pixel_x = -25
 	},
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
@@ -5534,8 +5517,7 @@
 /area/mainship/command/cic)
 "amO" = (
 /obj/machinery/door/airlock/mainship/generic{
-	name = "\improper Quarters";
-	req_access_txt = "200"
+	name = "\improper Quarters"
 	},
 /obj/machinery/door/poddoor/shutters/mainship{
 	id = "quarters_shutters";
@@ -5581,9 +5563,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/medical/upper_medical)
 "amW" = (
-/obj/machinery/door/airlock/mainship/medical{
-	name = "Morgue";
-	req_access_txt = "20"
+/obj/machinery/door/airlock/mainship/medical/morgue{
+	name = "Morgue"
 	},
 /turf/open/floor/plating/mainship,
 /area/mainship/medical/upper_medical)
@@ -6098,10 +6079,7 @@
 /area/mainship/command/cic)
 "aoj" = (
 /obj/structure/table/woodentable,
-/obj/machinery/computer/skills{
-	density = 0;
-	req_one_access = list(200)
-	},
+/obj/machinery/computer/skills,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
 "aok" = (
@@ -6174,10 +6152,9 @@
 	},
 /area/mainship/medical/upper_medical)
 "aov" = (
-/obj/machinery/door/airlock/multi_tile/mainship/medidoor{
+/obj/machinery/door/airlock/multi_tile/mainship/research{
 	dir = 2;
-	name = "Research Botanical Lab";
-	req_access_txt = "20"
+	name = "Research Botanical Lab"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6587,10 +6564,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/corporate{
 	id = "cl_shutters";
-	name = "Privacy Shutters";
-	req_access_txt = "200"
+	name = "Privacy Shutters"
 	},
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
@@ -7764,8 +7740,7 @@
 /area/mainship/engineering/ce_room)
 "asu" = (
 /obj/machinery/door/airlock/mainship/maint{
-	dir = 2;
-	req_one_access_txt = "2;7"
+	dir = 2
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -8298,7 +8273,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/tcomms{
 	id = "tcomms_apc";
 	name = "Telecommuncation Power";
 	pixel_x = -25
@@ -8306,10 +8281,9 @@
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
 	},
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/tcomms{
 	dir = 2;
-	name = "Telecommunications";
-	req_access_txt = "6"
+	name = "Telecommunications"
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
@@ -8753,9 +8727,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "auG" = (
-/obj/structure/closet/secure_closet{
-	name = "secure evidence locker";
-	req_access_txt = "3"
+/obj/structure/closet/secure_closet/evidence{
+	name = "secure evidence locker"
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -8911,11 +8884,10 @@
 /obj/structure/table/mainship,
 /obj/structure/paper_bin,
 /obj/item/tool/pen,
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/cic{
 	id = "CIC Checkpoint Shutters";
 	name = "CIC Checkpoint Shutters";
-	pixel_x = 25;
-	req_access_txt = "1"
+	pixel_x = 25
 	},
 /obj/item/tool/pen,
 /turf/open/floor/mainship{
@@ -9125,9 +9097,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/research{
-	name = "\improper Experimental Operating Theatre"
-	},
+/obj/machinery/door/airlock/mainship/research/or,
 /turf/open/floor/mainship{
 	icon_state = "dark_sterile"
 	},
@@ -10169,13 +10139,8 @@
 	name = "\improper CIC Checkpoint Shutters"
 	},
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor/westleft{
-	req_access = null;
-	req_access_txt = "13"
-	},
-/obj/machinery/door/window/brigdoor/eastleft{
-	req_access = null
-	},
+/obj/machinery/door/window/brigdoor/westleft,
+/obj/machinery/door/window/eastleft,
 /turf/open/floor/mainship,
 /area/mainship/command/cic)
 "axV" = (
@@ -10297,11 +10262,10 @@
 /turf/open/floor/mainship,
 /area/mainship/hallways/aft_hallway)
 "ayh" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/corporate{
 	id = "cl_shutters";
 	name = "Privacy Shutters";
-	pixel_y = 30;
-	req_access_txt = "200"
+	pixel_y = 30
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -10898,11 +10862,10 @@
 /turf/open/floor/plating,
 /area/mainship/command/cic)
 "azs" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/brigarmory{
 	id = "Brig Armoury";
 	name = "Brig Armoury";
-	pixel_y = 30;
-	req_access_txt = "3"
+	pixel_y = 30
 	},
 /turf/open/floor/mainship{
 	dir = 1;
@@ -10939,13 +10902,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/window/brigdoor/westleft{
-	req_access = null;
-	req_access_txt = "3"
-	},
-/obj/machinery/door/window/brigdoor/eastleft{
-	req_access = null
-	},
+/obj/machinery/door/window/brigdoor/westleft,
+/obj/machinery/door/window/eastleft,
 /turf/open/floor/plating,
 /area/mainship/shipboard/brig)
 "azx" = (
@@ -11241,10 +11199,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "azY" = (
-/obj/machinery/door/airlock/mainship/medical{
+/obj/machinery/door/airlock/mainship/medical/morgue{
 	dir = 2;
-	name = "Morgue";
-	req_access_txt = "20"
+	name = "Morgue"
 	},
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
@@ -11295,7 +11252,6 @@
 	dir = 1;
 	id = "Surgery Hallway 2";
 	name = "Door Release";
-	normaldoorcontrol = 1;
 	pixel_x = -23
 	},
 /turf/open/floor/mainship{
@@ -11345,9 +11301,8 @@
 	},
 /area/mainship/medical/medical_science)
 "aAj" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
-	name = "Animal Control Closet";
-	req_access_txt = "14"
+/obj/machinery/door/airlock/mainship/medical/glass/research{
+	name = "\improper Animal Control Closet"
 	},
 /turf/open/floor/mainship{
 	icon_state = "dark_sterile"
@@ -11494,9 +11449,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/secure{
-	name = "Telecommunications";
-	req_access_txt = "6"
+/obj/machinery/door/airlock/mainship/secure/tcomms{
+	name = "Telecommunications"
 	},
 /obj/machinery/door/firedoor/mainship{
 	dir = 8
@@ -11976,10 +11930,7 @@
 	},
 /area/mainship/shipboard/chief_mp_office)
 "aBn" = (
-/obj/structure/closet/secure_closet{
-	name = "secure evidence locker";
-	req_access_txt = "3"
-	},
+/obj/structure/closet/secure_closet/evidence,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -12261,10 +12212,9 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/mainship,
-/obj/machinery/door/airlock/multi_tile/mainship/medidoor{
+/obj/machinery/door/airlock/multi_tile/mainship/research{
 	dir = 2;
-	name = "Research Wing";
-	req_access_txt = "20"
+	name = "Research Wing"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -12975,8 +12925,7 @@
 "aDj" = (
 /obj/machinery/door/airlock/mainship/security{
 	dir = 2;
-	name = "\improper CIC Security Checkpoint";
-	req_one_access_txt = "3;22"
+	name = "\improper CIC Security Checkpoint"
 	},
 /turf/open/floor/mainship,
 /area/mainship/hallways/aft_hallway)
@@ -13133,11 +13082,10 @@
 	},
 /area/mainship/medical/medical_science)
 "aDC" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/research{
 	id = "containmentlockdown";
 	name = "Containment Lockdown";
-	pixel_x = 25;
-	req_one_access_txt = "19"
+	pixel_x = 25
 	},
 /turf/open/floor/mainship{
 	dir = 4;
@@ -13794,7 +13742,7 @@
 /turf/open/floor/wood,
 /area/mainship/medical/upper_medical)
 "aEU" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/research{
 	name = "\improper Medical Research Lounge"
 	},
 /obj/machinery/door/firedoor/mainship,
@@ -14437,10 +14385,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	no_panel = 1;
-	not_weldable = 1
-	},
+/obj/machinery/door/airlock/mainship/maint,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/upper_hull)
 "aGm" = (
@@ -14466,10 +14411,7 @@
 	},
 /area/mainship/squads/delta)
 "aGo" = (
-/obj/structure/closet/secure_closet{
-	name = "secure evidence locker";
-	req_access_txt = "3"
-	},
+/obj/structure/closet/secure_closet/evidence,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -14483,10 +14425,7 @@
 	},
 /area/mainship/shipboard/brig)
 "aGp" = (
-/obj/structure/closet/secure_closet{
-	name = "secure evidence locker";
-	req_access_txt = "3"
-	},
+/obj/structure/closet/secure_closet/evidence,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -14505,10 +14444,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/captain_mess)
 "aGt" = (
-/obj/machinery/door/airlock/mainship/medical{
+/obj/machinery/door/airlock/mainship/medical/morgue{
 	dir = 2;
-	name = "Morgue Processing";
-	req_access_txt = "20"
+	name = "Morgue Processing"
 	},
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
@@ -14689,10 +14627,9 @@
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
 	},
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/tcomms{
 	dir = 2;
-	name = "Telecommunications";
-	req_access_txt = "6"
+	name = "Telecommunications"
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
@@ -15115,10 +15052,8 @@
 /turf/open/floor/plating,
 /area/mainship/medical/lower_medical)
 "aHM" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
-	dir = 2;
-	name = "\improper CMO's Office";
-	req_access_txt = "5"
+/obj/machinery/door/airlock/mainship/medical/glass/CMO{
+	dir = 2
 	},
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
@@ -15172,12 +15107,11 @@
 /turf/open/floor/wood,
 /area/mainship/medical/upper_medical)
 "aHT" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/research{
 	dir = 1;
 	id = "researchlockdownext";
 	name = "Research Lockdown";
-	pixel_x = -27;
-	req_access_txt = "14"
+	pixel_x = -27
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship{
@@ -15277,7 +15211,7 @@
 	},
 /area/mainship/command/airoom)
 "aIe" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/tcomms{
 	id = "tcomms";
 	name = "Telecommunications Entrance";
 	pixel_y = 25
@@ -16405,10 +16339,9 @@
 	id = "researchlockdownext";
 	name = "\improper Research Lockdown"
 	},
-/obj/machinery/door/airlock/multi_tile/mainship/medidoor{
+/obj/machinery/door/airlock/multi_tile/mainship/research{
 	dir = 2;
-	name = "Research Wing";
-	req_access_txt = "20"
+	name = "Research Wing"
 	},
 /turf/open/floor/mainship{
 	icon_state = "sterile_green_side"
@@ -16501,10 +16434,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/multi_tile/mainship/medidoor{
+/obj/machinery/door/airlock/multi_tile/mainship/research{
 	dir = 2;
-	name = "Research Chemical Lab";
-	req_access_txt = "20"
+	name = "Research Chemical Lab"
 	},
 /turf/open/floor/mainship{
 	icon_state = "sterile_green_side"
@@ -17444,7 +17376,7 @@
 "aMS" = (
 /obj/machinery/door/airlock/mainship/medical/glass{
 	dir = 2;
-	name = "Morgue Waiting Room"
+	name = "\improper Morgue Waiting Room"
 	},
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
@@ -19549,9 +19481,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/starboard_point_defense)
 "aRA" = (
-/obj/machinery/door/airlock/mainship/secure{
-	name = "Telecommunications";
-	req_access_txt = "6"
+/obj/machinery/door/airlock/mainship/secure/tcomms{
+	name = "Telecommunications"
 	},
 /turf/open/floor/mainship{
 	icon_state = "ai_floors"
@@ -19773,9 +19704,7 @@
 /turf/open/floor/wood,
 /area/mainship/living/bridgebunks)
 "aSc" = (
-/obj/structure/closet/secure_closet/personal/cabinet{
-	req_access = null
-	},
+/obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/wood,
 /area/mainship/living/bridgebunks)
 "aSd" = (
@@ -20018,9 +19947,8 @@
 /turf/open/floor/plating/mainship,
 /area/mainship/hallways/aft_hallway)
 "aSL" = (
-/obj/machinery/door/airlock/mainship/secure{
-	name = "Telecommunications";
-	req_access_txt = "6"
+/obj/machinery/door/airlock/mainship/secure/tcomms{
+	name = "Telecommunications"
 	},
 /turf/open/floor/mainship{
 	icon_plating = "tcomms";
@@ -20163,12 +20091,10 @@
 /turf/open/floor/mainship,
 /area/mainship/powered)
 "aTc" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "garage1";
 	name = "Vehicle Garage 1";
-	pixel_x = 30;
-	req_one_access_txt = "2;3;7;12;19;22";
-	throw_range = 15
+	pixel_x = 30
 	},
 /obj/machinery/door/poddoor/mainship{
 	dir = 2;
@@ -20293,12 +20219,10 @@
 	},
 /area/mainship/living/captain_mess)
 "aTr" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "garage2";
 	name = "Vehicle Garage 2";
-	pixel_x = 30;
-	req_one_access_txt = "2;3;7;12;19;22";
-	throw_range = 15
+	pixel_x = 30
 	},
 /obj/machinery/door/poddoor/mainship{
 	dir = 2;
@@ -20367,12 +20291,10 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "hangarentrancesouth";
 	name = "South Hangar Shutters";
-	pixel_y = 30;
-	req_one_access_txt = "2;3;12;19;22";
-	throw_range = 15
+	pixel_y = 30
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
@@ -20380,12 +20302,10 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "hangarentrancenorth";
 	name = "North Hangar Shutters";
-	pixel_y = 30;
-	req_one_access_txt = "2;3;12;19;22";
-	throw_range = 15
+	pixel_y = 30
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
@@ -20393,12 +20313,10 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "hangarentrancenorth";
 	name = "North Hangar Shutters";
-	pixel_y = 30;
-	req_one_access_txt = "2;3;12;19;22";
-	throw_range = 15
+	pixel_y = 30
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
@@ -20406,12 +20324,10 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "hangarentrancesouth";
 	name = "South Hangar Shutters";
-	pixel_y = 30;
-	req_one_access_txt = "2;3;12;19;22";
-	throw_range = 15
+	pixel_y = 30
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
@@ -20999,22 +20915,18 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/starboard_point_defense)
 "aWx" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "laddernortheast";
 	name = "North East Ladders Shutters";
-	pixel_x = 25;
-	req_one_access_txt = "2;3;12;19";
-	throw_range = 15
+	pixel_x = 25
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "aWy" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "laddernortheast";
 	name = "North East Ladders Shutters";
-	pixel_x = -25;
-	req_one_access_txt = "2;3;12;19";
-	throw_range = 15
+	pixel_x = -25
 	},
 /turf/open/floor/mainship{
 	dir = 1;
@@ -21022,12 +20934,10 @@
 	},
 /area/mainship/hallways/starboard_hallway)
 "aWz" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "laddernortheast";
 	name = "North East Ladders Shutters";
-	pixel_x = 25;
-	req_one_access_txt = "2;3;12;19";
-	throw_range = 15
+	pixel_x = 25
 	},
 /obj/effect/decal/warning_stripes/thin{
 	dir = 5
@@ -21197,12 +21107,10 @@
 /turf/open/floor/mainship,
 /area/mainship/hallways/starboard_hallway)
 "aWZ" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "laddernortheast";
 	name = "North East Ladders Shutters";
-	pixel_x = 25;
-	req_one_access_txt = "2;3;12;19";
-	throw_range = 15
+	pixel_x = 25
 	},
 /turf/open/floor/mainship{
 	dir = 4;
@@ -23343,12 +23251,10 @@
 /area/mainship/shipboard/firing_range)
 "bcZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "laddernorthwest";
 	name = "North West Ladders Shutters";
-	pixel_x = -25;
-	req_one_access_txt = "2;3;12;19";
-	throw_range = 15
+	pixel_x = -25
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship{
@@ -24015,12 +23921,10 @@
 	height = 1;
 	id = "l1"
 	},
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "laddernorthwest";
 	name = "North West Ladders Shutters";
-	pixel_y = 30;
-	req_one_access_txt = "2;3;12;19";
-	throw_range = 15
+	pixel_y = 30
 	},
 /turf/open/floor/plating/mainship,
 /area/mainship/hallways/starboard_hallway)
@@ -24383,12 +24287,10 @@
 	},
 /area/mainship/hallways/hangar)
 "bgd" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "ammo2";
 	name = "Ammo Storage";
-	pixel_x = 30;
-	req_one_access_txt = "2;3;7;12;19;22";
-	throw_range = 15
+	pixel_x = 30
 	},
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -24880,12 +24782,10 @@
 	height = 1;
 	id = "l6"
 	},
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "laddernorthwest";
 	name = "North West Ladders Shutters";
-	pixel_y = -25;
-	req_one_access_txt = "2;3;12;19";
-	throw_range = 15
+	pixel_y = -25
 	},
 /turf/open/floor/plating/mainship,
 /area/mainship/hallways/starboard_hallway)
@@ -25166,12 +25066,10 @@
 	},
 /area/mainship/hallways/hangar)
 "bie" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "ammo2";
 	name = "Ammo Storage";
-	pixel_x = 30;
-	req_one_access_txt = "2;3;7;12;19;22";
-	throw_range = 15
+	pixel_x = 30
 	},
 /turf/open/floor/mainship{
 	icon_state = "test_floor4"
@@ -25509,12 +25407,10 @@
 /turf/open/floor/mainship,
 /area/mainship/hallways/starboard_hallway)
 "bjf" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "laddernorthwest";
 	name = "North West Ladders Shutters";
-	pixel_y = 30;
-	req_one_access_txt = "2;3;12;19";
-	throw_range = 15
+	pixel_y = 30
 	},
 /turf/open/floor/mainship,
 /area/mainship/hallways/starboard_hallway)
@@ -25642,10 +25538,9 @@
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
 	},
-/obj/machinery/door/airlock/mainship/generic{
+/obj/machinery/door/airlock/mainship/generic/corporate{
 	dir = 2;
-	name = "\improper Corporate Liason Office";
-	req_access_txt = "200"
+	name = "\improper Corporate Liason Office"
 	},
 /obj/machinery/door/poddoor/shutters/mainship{
 	dir = 1;
@@ -27242,10 +27137,9 @@
 /area/mainship/hull/lower_hull)
 "bnt" = (
 /obj/structure/table/mainship,
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "northcheckpoint";
-	name = "North Checkpoint Shutters";
-	req_one_access_txt = "2;3;12;19"
+	name = "North Checkpoint Shutters"
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
@@ -27763,12 +27657,10 @@
 	},
 /area/mainship/medical/operating_room_one)
 "boV" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "hangarentrancenorth";
 	name = "North Hangar Shutters";
-	pixel_x = -30;
-	req_one_access_txt = "2;3;12;19";
-	throw_range = 15
+	pixel_x = -30
 	},
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -28280,7 +28172,7 @@
 /area/mainship/medical/lower_medical)
 "bqC" = (
 /obj/machinery/door/airlock/mainship/medical/glass{
-	name = "break room"
+	name = "\improper Break Room"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28400,9 +28292,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/mainship,
-/obj/machinery/door/airlock/mainship/medical{
-	name = "Operating Theatre 1"
-	},
+/obj/machinery/door/airlock/mainship/medical/or/or1,
 /obj/machinery/holosign/surgery{
 	id = "or1sign"
 	},
@@ -29502,10 +29392,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/mainship/medical/glass{
-	dir = 2;
-	name = "\improper Chemistry Laboratory";
-	req_access_txt = "20"
+/obj/machinery/door/airlock/mainship/medical/glass/chemistry{
+	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship{
@@ -29538,10 +29426,8 @@
 /turf/open/floor/wood,
 /area/mainship/medical/lower_medical)
 "bux" = (
-/obj/machinery/door/airlock/multi_tile/mainship/medidoor{
+/obj/machinery/door/airlock/multi_tile/mainship/medidoor/medbay{
 	dir = 2;
-	id = "Surgery Hallway 1";
-	id_tag = "Surgery Hallway 1";
 	name = "Surgery Hallway 1"
 	},
 /obj/machinery/door/firedoor/mainship,
@@ -29588,8 +29474,7 @@
 "buF" = (
 /obj/machinery/door/airlock/mainship/marine/requisitions{
 	dir = 2;
-	name = "\improper Requisition's Office";
-	req_one_access_txt = "1;26"
+	name = "\improper Requisition's Office"
 	},
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
@@ -30016,12 +29901,11 @@
 	},
 /area/mainship/hull/lower_hull)
 "bvV" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/research{
 	dir = 1;
 	id = "Research Armory";
 	name = "Research Armory";
-	pixel_x = -27;
-	req_access_txt = "14"
+	pixel_x = -27
 	},
 /turf/open/floor/mainship{
 	dir = 8;
@@ -30468,7 +30352,6 @@
 /obj/machinery/door_control{
 	id = "Surgery Hallway 1";
 	name = "Door Release";
-	normaldoorcontrol = 1;
 	pixel_x = -23
 	},
 /turf/open/floor/mainship{
@@ -30989,11 +30872,10 @@
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
 "byR" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	dir = 8;
 	id = "medicalemergency";
-	name = "Medical Emergency Shutters";
-	req_one_access_txt = "2;3;8;12;19"
+	name = "Medical Emergency Shutters"
 	},
 /turf/closed/wall/mainship/white,
 /area/mainship/medical/lower_medical)
@@ -31121,9 +31003,7 @@
 /obj/machinery/holosign/surgery{
 	id = "or2sign"
 	},
-/obj/machinery/door/airlock/mainship/medical{
-	name = "Operating Theatre 2"
-	},
+/obj/machinery/door/airlock/mainship/medical/or/or2,
 /turf/open/floor/mainship{
 	icon_state = "dark_sterile"
 	},
@@ -31502,12 +31382,10 @@
 	name = "\improper Hangar Lockdown Blast Door";
 	opacity = 0
 	},
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "medicalemergency";
 	name = "Medical Emergency Shutters";
-	pixel_y = 30;
-	req_one_access_txt = "2;3;8;12;19";
-	throw_range = 15
+	pixel_y = 30
 	},
 /turf/open/floor/mainship{
 	icon_state = "test_floor4"
@@ -31730,9 +31608,7 @@
 /area/mainship/squads/req)
 "bAH" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/eastleft{
-	req_one_access_txt = "2;21"
-	},
+/obj/machinery/door/window/eastleft/req,
 /obj/machinery/door/window/westright,
 /obj/machinery/door/poddoor/shutters/mainship{
 	id = "ROlobby1";
@@ -31750,11 +31626,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
 "bAJ" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/req{
 	id = "ROlobby1";
 	name = "RO Line 1 Shutters";
-	pixel_y = -25;
-	req_one_access_txt = "1;21"
+	pixel_y = -25
 	},
 /turf/open/floor/mainship{
 	dir = 10;
@@ -32057,8 +31932,7 @@
 	id = "briefing_flash";
 	name = "Briefing Flasher";
 	pixel_x = 32;
-	pixel_y = 27;
-	req_access_txt = "19"
+	pixel_y = 27
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -32097,14 +31971,12 @@
 /obj/machinery/line_nexter_control{
 	id = "line2";
 	pixel_x = -20;
-	pixel_y = -4;
-	req_one_access_txt = "1;21"
+	pixel_y = -4
 	},
 /obj/machinery/line_nexter_control{
 	id = "line1";
 	pixel_x = -20;
-	pixel_y = 8;
-	req_one_access_txt = "1;21"
+	pixel_y = 8
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
@@ -32142,13 +32014,6 @@
 	icon_state = "cargo_arrow"
 	},
 /area/mainship/squads/req)
-"bBZ" = (
-/obj/machinery/door/airlock/mainship/maint{
-	no_panel = 1;
-	not_weldable = 1
-	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/lower_hull)
 "bCa" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/living/cryo_cells)
@@ -32723,9 +32588,7 @@
 /area/mainship/squads/req)
 "bDC" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/eastleft{
-	req_one_access_txt = "2;21"
-	},
+/obj/machinery/door/window/eastleft/req,
 /obj/machinery/door/window/westright,
 /obj/machinery/door/poddoor/shutters/mainship{
 	id = "ROlobby2";
@@ -32737,11 +32600,10 @@
 	},
 /area/mainship/squads/req)
 "bDD" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/req{
 	id = "ROlobby2";
 	name = "RO Line 2 Shutters";
-	pixel_y = 27;
-	req_one_access_txt = "1;21"
+	pixel_y = 27
 	},
 /turf/open/floor/mainship{
 	dir = 9;
@@ -33434,9 +33296,7 @@
 	},
 /area/mainship/medical/surgery_hallway)
 "bFW" = (
-/obj/machinery/door/airlock/mainship/medical{
-	name = "Operating Theatre 3"
-	},
+/obj/machinery/door/airlock/mainship/medical/or/or3,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -33720,11 +33580,10 @@
 	},
 /area/mainship/shipboard/weapon_room)
 "bGQ" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/corporate{
 	id = "quarters_shutters";
 	name = "Quarters Shutters";
-	pixel_x = 25;
-	req_access_txt = "200"
+	pixel_x = 25
 	},
 /turf/open/floor/mainship{
 	dir = 5;
@@ -35584,9 +35443,7 @@
 	},
 /area/mainship/medical/surgery_hallway)
 "bMj" = (
-/obj/machinery/door/airlock/mainship/medical{
-	name = "Operating Theatre 4"
-	},
+/obj/machinery/door/airlock/mainship/medical/or/or4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -35644,12 +35501,10 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
 "bMo" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "hangarentrancesouth";
 	name = "South Hangar Shutters";
-	pixel_x = -30;
-	req_one_access_txt = "2;3;12;19";
-	throw_range = 15
+	pixel_x = -30
 	},
 /obj/effect/decal/warning_stripes/thin{
 	dir = 5
@@ -36170,10 +36025,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
 "bNK" = (
-/obj/machinery/door/airlock/multi_tile/mainship/medidoor{
+/obj/machinery/door/airlock/multi_tile/mainship/medidoor/medbay{
 	dir = 2;
-	id = "Surgery Hallway 2";
-	id_tag = "Surgery Hallway 2";
 	name = "Surgery Hallway 2"
 	},
 /obj/machinery/door/firedoor/mainship,
@@ -36218,10 +36071,9 @@
 /area/mainship/hull/lower_hull)
 "bNQ" = (
 /obj/structure/table/mainship,
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "southcheckpoint";
-	name = "South Checkpoint Shutters";
-	req_one_access_txt = "2;3;12;19"
+	name = "South Checkpoint Shutters"
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
@@ -37511,12 +37363,10 @@
 /turf/open/floor/mainship,
 /area/mainship/hallways/port_hallway)
 "bRc" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "laddersouthwest";
 	name = "South West Ladders Shutters";
-	pixel_y = -25;
-	req_one_access_txt = "2;3;12;19";
-	throw_range = 15
+	pixel_y = -25
 	},
 /obj/machinery/light,
 /turf/open/floor/mainship,
@@ -38055,12 +37905,10 @@
 	height = 1;
 	id = "l10"
 	},
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "laddersouthwest";
 	name = "South West Ladders Shutters";
-	pixel_y = 30;
-	req_one_access_txt = "2;3;12;19";
-	throw_range = 15
+	pixel_y = 30
 	},
 /turf/open/floor/plating/mainship,
 /area/mainship/hallways/port_hallway)
@@ -38380,8 +38228,7 @@
 /area/mainship/living/tankerbunks)
 "bTy" = (
 /obj/machinery/door/airlock/mainship/generic{
-	name = "\improper Tanker Quarters";
-	req_one_access_txt = "22;2;7"
+	name = "\improper Tanker Quarters"
 	},
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/mainship/mono,
@@ -38397,9 +38244,8 @@
 /area/mainship/hallways/hangar)
 "bTA" = (
 /obj/machinery/door/firedoor/mainship,
-/obj/machinery/door/airlock/mainship/generic{
-	name = "\improper Pilot's Quarters";
-	req_one_access_txt = "22"
+/obj/machinery/door/airlock/mainship/generic/pilot{
+	name = "\improper Pilot's Quarters"
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/pilotbunks)
@@ -38839,8 +38685,7 @@
 	},
 /obj/machinery/door/firedoor/mainship,
 /obj/machinery/door/airlock/mainship/generic{
-	name = "\improper Tanker Quarters";
-	req_one_access_txt = "22;2;7"
+	name = "\improper Tanker Quarters"
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/tankerbunks)
@@ -38905,9 +38750,8 @@
 /area/mainship/hallways/hangar)
 "bVf" = (
 /obj/machinery/door/firedoor/mainship,
-/obj/machinery/door/airlock/mainship/generic{
-	name = "\improper Pilot's Quarters";
-	req_one_access_txt = "22"
+/obj/machinery/door/airlock/mainship/generic/pilot{
+	name = "\improper Pilot's Quarters"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -39068,12 +38912,10 @@
 	height = 1;
 	id = "l12"
 	},
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "laddersouthwest";
 	name = "South West Ladders Shutters";
-	pixel_y = -25;
-	req_one_access_txt = "2;3;12;19";
-	throw_range = 15
+	pixel_y = -25
 	},
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
@@ -39467,12 +39309,10 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "pilotentrance";
 	name = "Pilot Workshop Shutters";
-	pixel_y = 30;
-	req_one_access_txt = "2;3;12;19;22";
-	throw_range = 15
+	pixel_y = 30
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/repair_bay)
@@ -39490,12 +39330,10 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "pilotentrance";
 	name = "Pilot Workshop Shutters";
-	pixel_y = 30;
-	req_one_access_txt = "2;3;12;19;22";
-	throw_range = 15
+	pixel_y = 30
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/repair_bay)
@@ -39834,12 +39672,10 @@
 	},
 /area/mainship/hallways/port_hallway)
 "bXE" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "laddersouthwest";
 	name = "South West Ladders Shutters";
-	pixel_x = 25;
-	req_one_access_txt = "2;3;12;19";
-	throw_range = 15
+	pixel_x = 25
 	},
 /turf/open/floor/mainship{
 	dir = 8;
@@ -40248,10 +40084,9 @@
 /obj/machinery/door/firedoor/mainship{
 	dir = 2
 	},
-/obj/machinery/door/airlock/mainship/generic{
+/obj/machinery/door/airlock/mainship/generic/pilot{
 	dir = 2;
-	name = "\improper Pilot's Office";
-	req_one_access_txt = "22"
+	name = "\improper Pilot's Office"
 	},
 /turf/open/floor/mainship,
 /area/mainship/living/pilotbunks)
@@ -40613,9 +40448,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/mainship,
-/obj/machinery/door/airlock/mainship/generic{
-	name = "\improper Pilot's Office";
-	req_one_access_txt = "22"
+/obj/machinery/door/airlock/mainship/generic/pilot{
+	name = "\improper Pilot's Office"
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/pilotbunks)
@@ -40883,9 +40717,8 @@
 /area/mainship/living/pilotbunks)
 "cat" = (
 /obj/machinery/door/firedoor/mainship,
-/obj/machinery/door/airlock/mainship/generic{
-	name = "\improper Pilot's Office";
-	req_one_access_txt = "22"
+/obj/machinery/door/airlock/mainship/generic/pilot{
+	name = "\improper Pilot's Office"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -41955,12 +41788,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "cdL" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "laddersoutheast";
 	name = "South East Ladders Shutters";
-	pixel_x = 25;
-	req_one_access_txt = "2;3;12;19";
-	throw_range = 15
+	pixel_x = 25
 	},
 /turf/open/floor/mainship{
 	dir = 4;
@@ -42179,22 +42010,18 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/delta)
 "ceo" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "laddersoutheast";
 	name = "South East Ladders Shutters";
-	pixel_x = 25;
-	req_one_access_txt = "2;3;12;19";
-	throw_range = 15
+	pixel_x = 25
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "cep" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "laddersoutheast";
 	name = "South East Ladders Shutters";
-	pixel_x = -25;
-	req_one_access_txt = "2;3;12;19";
-	throw_range = 15
+	pixel_x = -25
 	},
 /turf/open/floor/mainship{
 	dir = 8;
@@ -42202,12 +42029,10 @@
 	},
 /area/mainship/hallways/port_hallway)
 "ceq" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/checkpoint{
 	id = "laddersoutheast";
 	name = "South East Ladders Shutters";
-	pixel_x = 25;
-	req_one_access_txt = "2;3;12;19";
-	throw_range = 15
+	pixel_x = 25
 	},
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -42967,7 +42792,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/brig_cells)
 "cgL" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/brigarmory{
 	id = "CMP Office Shutters";
 	name = "CMP Office Shutters";
 	pixel_y = -20
@@ -42984,16 +42809,15 @@
 	pixel_x = -10;
 	pixel_y = -30
 	},
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/brigarmory{
 	id = "Brig Lockdown";
 	name = "Brig Lockdown";
 	pixel_y = -30
 	},
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/brigarmory{
 	id = "Brig Armoury";
 	name = "Brig Armoury";
-	pixel_y = -40;
-	req_access_txt = "3"
+	pixel_y = -40
 	},
 /turf/open/floor/mainship{
 	icon_state = "red"
@@ -44597,9 +44421,7 @@
 /area/mainship/command/cic)
 "cSa" = (
 /obj/machinery/door/airlock/mainship/maint{
-	dir = 2;
-	req_access_txt = "200";
-	req_one_access_txt = ""
+	dir = 2
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
@@ -44913,11 +44735,10 @@
 /area/mainship/hull/upper_hull)
 "eGx" = (
 /obj/structure/table/mainship,
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/research{
 	id = "researchlockdownext";
 	name = "Research Lockdown";
-	pixel_x = -7;
-	req_access_txt = "5"
+	pixel_x = -7
 	},
 /turf/open/floor/mainship{
 	dir = 1;
@@ -45859,19 +45680,17 @@
 	pixel_x = -7;
 	pixel_y = 2
 	},
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/cic{
 	id = "CIC Lockdown";
 	name = "CIC Lockdown";
 	pixel_x = -7;
-	pixel_y = 9;
-	req_access_txt = "1"
+	pixel_y = 9
 	},
-/obj/machinery/door_control{
+/obj/machinery/door_control/mainship/cic{
 	id = "bot_armory";
 	name = "Armory Lockdown";
 	pixel_x = -7;
-	pixel_y = -5;
-	req_access_txt = "1"
+	pixel_y = -5
 	},
 /obj/structure/window/reinforced/toughened{
 	dir = 4
@@ -46875,9 +46694,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/shipboard/weapon_room)
 "oLS" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
-	name = "\improper CMO's Bunks";
-	req_access_txt = "5"
+/obj/machinery/door/airlock/mainship/medical/glass/CMO{
+	name = "\improper CMO's Bunks"
 	},
 /turf/open/floor/mainship{
 	icon_state = "dark_sterile"
@@ -47377,8 +47195,7 @@
 /area/mainship/living/numbertwobunks)
 "qOH" = (
 /obj/machinery/door/airlock/mainship/maint{
-	dir = 2;
-	req_one_access_txt = "2;7;200"
+	dir = 2
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -47568,9 +47385,8 @@
 	},
 /area/mainship/command/self_destruct)
 "swd" = (
-/obj/machinery/door/airlock/mainship/research{
-	dir = 2;
-	req_access_txt = "20"
+/obj/machinery/door/airlock/mainship/research/chemistry{
+	dir = 2
 	},
 /turf/open/floor/mainship{
 	icon_state = "dark_sterile"
@@ -47921,9 +47737,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	req_access_txt = "19"
-	},
+/obj/machinery/door/airlock/mainship/maint,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/upper_hull)
 "unT" = (
@@ -93395,7 +93209,7 @@ aVs
 aVs
 aVs
 aVs
-bBZ
+brq
 aVs
 aVs
 aVs
@@ -95335,7 +95149,7 @@ aJt
 aLa
 akP
 aTX
-akR
+aaq
 aam
 aai
 aai
@@ -95829,7 +95643,7 @@ aag
 aag
 aai
 aal
-akR
+aaq
 amo
 ant
 aoM
@@ -97391,7 +97205,7 @@ aJz
 aoM
 akL
 aMj
-akR
+aaq
 aUZ
 aai
 aag

--- a/_maps/map_files/Tyson_Station/Tyson_Station.dmm
+++ b/_maps/map_files/Tyson_Station/Tyson_Station.dmm
@@ -7399,8 +7399,7 @@
 /obj/machinery/door_control{
 	id = "areslockdowninterior";
 	name = "ARES Lockdown";
-	pixel_x = -25;
-	req_one_access_txt = "19"
+	pixel_x = -25
 	},
 /mob/living/silicon/decoy/ship_ai,
 /turf/open/floor/tile/dark/brown2/corner,
@@ -11144,8 +11143,7 @@
 	},
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	dir = 1;
-	name = "\improper Medical Clinic Treatment";
-	req_one_access_txt = "0"
+	name = "\improper Medical Clinic Treatment"
 	},
 /turf/open/floor/tile/white/warningstripe{
 	dir = 4
@@ -11695,8 +11693,7 @@
 	},
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	dir = 1;
-	name = "\improper Medical Clinic Treatment";
-	req_one_access_txt = "0"
+	name = "\improper Medical Clinic Treatment"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -11820,8 +11817,7 @@
 /area/medical/biostorage)
 "aMP" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
-	name = "\improper Medical Clinic Treatment";
-	req_one_access_txt = "0"
+	name = "\improper Medical Clinic Treatment"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -11923,8 +11919,7 @@
 	},
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	dir = 1;
-	name = "\improper Medical Clinic Treatment";
-	req_one_access_txt = "0"
+	name = "\improper Medical Clinic Treatment"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/tile/white/warningstripe{
@@ -12050,8 +12045,7 @@
 /area/maintenance/substation)
 "aND" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
-	name = "\improper Medical Clinic Treatment";
-	req_one_access_txt = "0"
+	name = "\improper Medical Clinic Treatment"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -12240,10 +12234,9 @@
 /area/medical/reception)
 "aOh" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door/airlock/mainship/medical/glass{
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	dir = 1;
-	name = "\improper Medical Clinic";
-	req_one_access_txt = "0"
+	name = "\improper Medical Clinic"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -19522,8 +19515,7 @@
 /area/hallway/primary/starboard)
 "bhJ" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
-	name = "\improper Medical Clinic Treatment";
-	req_one_access_txt = "0"
+	name = "\improper Medical Clinic Treatment"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/tile/white,

--- a/_maps/map_files/Vapor_Processing/Vapor_Processing.dmm
+++ b/_maps/map_files/Vapor_Processing/Vapor_Processing.dmm
@@ -380,8 +380,7 @@
 "bj" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
-	name = "\improper Airlock";
-	req_access_txt = "0"
+	name = "\improper Airlock"
 	},
 /turf/open/floor/plating,
 /area/maintenance/apmaint)
@@ -3885,8 +3884,7 @@
 "lK" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
-	name = "\improper Airlock";
-	req_access_txt = "0"
+	name = "\improper Airlock"
 	},
 /turf/open/floor/plating,
 /area/vapor_processing/cargo_maint_s)
@@ -5673,8 +5671,7 @@
 /obj/machinery/door_control{
 	id = "secure_blast";
 	name = "Vault Access";
-	pixel_x = 25;
-	req_access_txt = "0"
+	pixel_x = 25
 	},
 /turf/open/floor,
 /area/lv624/lazarus/research)
@@ -6640,8 +6637,7 @@
 /obj/machinery/door_control{
 	id = "secure_blast";
 	name = "Vault Access";
-	pixel_x = 25;
-	req_access_txt = "0"
+	pixel_x = 25
 	},
 /turf/open/floor/plating/dmg3,
 /area/lv624/lazarus/research)

--- a/_maps/map_files/Whiskey_Outpost/Whiskey_Outpost_v2.dmm
+++ b/_maps/map_files/Whiskey_Outpost/Whiskey_Outpost_v2.dmm
@@ -516,11 +516,7 @@
 /area/whiskey_outpost)
 "bE" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/eastleft{
-	icon_state = "left";
-	dir = 1;
-	req_one_access_txt = "2;21"
-	},
+/obj/machinery/door/window/northleft,
 /obj/machinery/door/window/westright{
 	icon_state = "right";
 	dir = 2
@@ -597,10 +593,7 @@
 	},
 /area/whiskey_outpost)
 "bQ" = (
-/obj/machinery/door/airlock/mainship/medical{
-	dir = 1;
-	name = "Operating Theatre 1"
-	},
+/obj/machinery/door/airlock/mainship/medical/or/or1,
 /turf/open/floor/mainship{
 	icon_state = "dark_sterile"
 	},
@@ -2221,9 +2214,8 @@
 /turf/open/ground/grass,
 /area/whiskey_outpost/outside/north)
 "gK" = (
-/obj/machinery/door/airlock/mainship/medical{
-	dir = 1;
-	name = "Operating Theatre 2"
+/obj/machinery/door/airlock/mainship/medical/or/or2{
+	dir = 1
 	},
 /turf/open/floor/mainship{
 	icon_state = "dark_sterile"
@@ -4630,11 +4622,8 @@
 /turf/open/floor/plating,
 /area/whiskey_outpost)
 "qa" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
-	dir = 2;
-	name = "\improper Chemistry Laboratory";
-	req_access_txt = "20";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/medical/glass/chemistry{
+	dir = 2
 	},
 /turf/open/floor/plating,
 /area/whiskey_outpost)

--- a/_maps/map_files/debugdalus/tgs_debugdalus.dmm
+++ b/_maps/map_files/debugdalus/tgs_debugdalus.dmm
@@ -1216,8 +1216,7 @@
 /area/mainship/hallways/starboard_hallway)
 "acO" = (
 /obj/machinery/door/airlock/mainship/maint{
-	name = "\improper Shuttle Hanger";
-	req_one_access_txt = "0"
+	name = "\improper Shuttle Hanger"
 	},
 /turf/open/floor/mainship{
 	pixel_z = -1
@@ -1319,8 +1318,7 @@
 /area/mainship/hallways/starboard_hallway)
 "acX" = (
 /obj/machinery/door/airlock/mainship/maint{
-	name = "\improper Shuttle Hanger";
-	req_one_access_txt = "0"
+	name = "\improper Shuttle Hanger"
 	},
 /obj/structure/cable{
 	icon_state = "4-8";
@@ -1961,9 +1959,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/medical{
-	name = "Operating Theatre 1"
-	},
+/obj/machinery/door/airlock/mainship/medical/or/or1,
 /turf/open/floor/mainship{
 	pixel_z = -1
 	},
@@ -2705,9 +2701,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/medical{
-	name = "Operating Theatre 2"
-	},
+/obj/machinery/door/airlock/mainship/medical/or/or2,
 /turf/open/floor/mainship{
 	pixel_z = -1
 	},
@@ -2855,9 +2849,7 @@
 /area/space)
 "agC" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/eastleft{
-	req_one_access_txt = "2;21"
-	},
+/obj/machinery/door/window/eastleft/req,
 /obj/machinery/door/window/westright,
 /turf/open/floor/mainship{
 	pixel_z = -1
@@ -2903,9 +2895,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/mainship/secure{
-	name = "Telecommunications";
-	req_access_txt = "6"
+/obj/machinery/door/airlock/mainship/secure/tcomms{
+	name = "Telecommunications"
 	},
 /turf/open/floor/mainship{
 	pixel_z = -1
@@ -3052,14 +3043,12 @@
 /obj/machinery/line_nexter_control{
 	id = "line2";
 	pixel_x = -20;
-	pixel_y = -4;
-	req_one_access_txt = "1;21"
+	pixel_y = -4
 	},
 /obj/machinery/line_nexter_control{
 	id = "line1";
 	pixel_x = -20;
-	pixel_y = 8;
-	req_one_access_txt = "1;21"
+	pixel_y = 8
 	},
 /turf/open/floor/mainship{
 	pixel_z = -1
@@ -3377,9 +3366,7 @@
 	},
 /area/mainship/medical/surgery_hallway)
 "ahP" = (
-/obj/machinery/door/airlock/mainship/medical{
-	name = "Operating Theatre 3"
-	},
+/obj/machinery/door/airlock/mainship/medical/or/or3,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -3448,10 +3435,9 @@
 	},
 /area/mainship/living/cryo_cells)
 "ahW" = (
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/tcomms{
 	dir = 2;
-	name = "Telecommunications";
-	req_access_txt = "6"
+	name = "Telecommunications"
 	},
 /turf/open/floor/mainship{
 	pixel_z = -1
@@ -3540,7 +3526,7 @@
 	},
 /area/mainship/command/telecomms)
 "aij" = (
-/obj/machinery/door/airlock/mainship/secure,
+/obj/machinery/door/airlock/mainship/secure/tcomms,
 /turf/open/floor/mainship{
 	pixel_z = -1
 	},
@@ -3793,9 +3779,7 @@
 	},
 /area/mainship/medical/surgery_hallway)
 "aiN" = (
-/obj/machinery/door/airlock/mainship/medical{
-	name = "Operating Theatre 4"
-	},
+/obj/machinery/door/airlock/mainship/medical/or/or4,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -4126,8 +4110,7 @@
 /area/mainship/hallways/port_hallway)
 "ajB" = (
 /obj/machinery/door/airlock/mainship/maint{
-	name = "\improper Shuttle Hanger";
-	req_one_access_txt = "0"
+	name = "\improper Shuttle Hanger"
 	},
 /turf/open/floor/mainship{
 	pixel_z = -1
@@ -4204,10 +4187,9 @@
 	},
 /area/mainship/shipboard/port_point_defense)
 "ajL" = (
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/free_access{
 	dir = 2;
-	name = "\improper Evacuation Airlock";
-	req_access_txt = "0"
+	name = "\improper Evacuation Airlock"
 	},
 /turf/open/floor/mainship{
 	pixel_z = -1
@@ -5102,10 +5084,9 @@
 /turf/closed/wall/mainship,
 /area/mainship/hallways/starboard_hallway)
 "aWg" = (
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/free_access{
 	dir = 2;
-	name = "\improper Evacuation Airlock";
-	req_access_txt = "0"
+	name = "\improper Evacuation Airlock"
 	},
 /turf/open/floor/plating,
 /area/mainship/powered)

--- a/_maps/map_files/desert/desert.dmm
+++ b/_maps/map_files/desert/desert.dmm
@@ -1502,8 +1502,7 @@
 	icon_state = "pipe11-2";
 	dir = 1
 	},
-/obj/machinery/door/airlock/mainship/command/CPToffice{
-	icon_state = "door_closed";
+/obj/machinery/door/airlock/mainship/command/free_access{
 	dir = 2
 	},
 /obj/structure/cable/yellow{
@@ -1810,8 +1809,7 @@
 /area/desert/interior/toilet)
 "ft" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/airlock/mainship/medical{
-	icon_state = "door_closed";
+/obj/machinery/door/airlock/mainship/medical/free_access{
 	dir = 1
 	},
 /obj/structure/cable/yellow{
@@ -1833,8 +1831,7 @@
 /area/desert/interior/science)
 "fw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/airlock/mainship/research{
-	icon_state = "door_closed";
+/obj/machinery/door/airlock/mainship/research/free_access{
 	dir = 2
 	},
 /obj/structure/cable/yellow{
@@ -2221,8 +2218,7 @@
 /turf/open/floor/tile/white,
 /area/desert/interior/medbay)
 "gD" = (
-/obj/machinery/door/airlock/mainship/research{
-	icon_state = "door_closed";
+/obj/machinery/door/airlock/mainship/research/free_access{
 	dir = 2
 	},
 /turf/open/floor/tile/white,

--- a/_maps/map_files/desert/desert.dmm
+++ b/_maps/map_files/desert/desert.dmm
@@ -388,7 +388,6 @@
 "bq" = (
 /obj/machinery/door/airlock/colony/engineering{
 	name = "\improper Maintenance Airlock";
-	icon_state = "door_closed";
 	dir = 1
 	},
 /obj/structure/cable/yellow{
@@ -701,7 +700,6 @@
 "cp" = (
 /obj/machinery/door/airlock/colony/engineering{
 	name = "\improper Maintenance Airlock";
-	icon_state = "door_closed";
 	dir = 1
 	},
 /turf/open/floor/tile/dark,
@@ -752,7 +750,6 @@
 /area/shuttle/drop1/lz1)
 "cw" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	icon_state = "door_closed";
 	dir = 2
 	},
 /turf/open/floor/tile/white,
@@ -1088,7 +1085,6 @@
 "dt" = (
 /obj/machinery/door/airlock/colony/engineering{
 	name = "\improper Maintenance Airlock";
-	icon_state = "door_closed";
 	dir = 1
 	},
 /obj/structure/cable/yellow{
@@ -1535,7 +1531,6 @@
 	},
 /obj/machinery/door/airlock/colony/engineering{
 	name = "\improper Storage";
-	icon_state = "door_closed";
 	dir = 2
 	},
 /turf/open/floor/plating,
@@ -2375,7 +2370,6 @@
 "hc" = (
 /obj/machinery/door/airlock/colony/engineering{
 	name = "\improper Maintenance Airlock";
-	icon_state = "door_closed";
 	dir = 1
 	},
 /obj/structure/cable/yellow{
@@ -2783,7 +2777,6 @@
 "ie" = (
 /obj/machinery/door/airlock/colony/engineering{
 	name = "\improper Maintenance Airlock";
-	icon_state = "door_closed";
 	dir = 1
 	},
 /obj/structure/cable/yellow{
@@ -3206,7 +3199,6 @@
 "jh" = (
 /obj/machinery/door/airlock/colony/engineering{
 	name = "\improper Maintenance Airlock";
-	icon_state = "door_closed";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -3604,7 +3596,6 @@
 /area/desert/outside/sw)
 "kq" = (
 /obj/machinery/door/airlock/multi_tile/secure2_glass{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
@@ -3632,7 +3623,6 @@
 /area/desert/outside/sw)
 "ku" = (
 /obj/machinery/door/airlock/multi_tile/secure2_glass{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /turf/open/floor/tile/dark,
@@ -3771,7 +3761,6 @@
 "kQ" = (
 /obj/machinery/door/airlock/colony/engineering{
 	name = "\improper Maintenance Airlock";
-	icon_state = "door_closed";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -3924,7 +3913,6 @@
 /area/desert/interior/shipping/south)
 "lt" = (
 /obj/machinery/door/airlock/multi_tile/secure2_glass{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
@@ -3932,7 +3920,6 @@
 /area/desert/interior/shipping/south)
 "lu" = (
 /obj/machinery/door/airlock/multi_tile/secure2_glass{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /turf/open/floor/tile/dark,
@@ -4103,7 +4090,6 @@
 "Bv" = (
 /obj/machinery/door/airlock/colony/engineering{
 	name = "\improper Storage";
-	icon_state = "door_closed";
 	dir = 8
 	},
 /turf/open/floor/plating,

--- a/_maps/map_files/generic/Admin_Level.dmm
+++ b/_maps/map_files/generic/Admin_Level.dmm
@@ -249,8 +249,7 @@
 "aN" = (
 /obj/machinery/door/airlock/multi_tile/mainship/secdoor{
 	dir = 2;
-	name = "\improper Centcomm Security";
-	req_access = list(200)
+	name = "\improper Centcomm Security"
 	},
 /turf/open/floor/mainship{
 	dir = 8;
@@ -387,11 +386,7 @@
 	},
 /area/centcom)
 "bk" = (
-/obj/machinery/door/airlock/command{
-	name = "Thunderdome Administration";
-	req_access = null;
-	req_access_txt = "102"
-	},
+/obj/machinery/door/airlock/command/thunderdome,
 /turf/open/floor,
 /area/tdome)
 "bl" = (
@@ -694,8 +689,7 @@
 "ci" = (
 /obj/machinery/door/airlock/multi_tile/mainship/secdoor{
 	dir = 2;
-	name = "\improper Centcomm Security";
-	req_access = list(200)
+	name = "\improper Centcomm Security"
 	},
 /turf/open/floor/mainship{
 	dir = 4;
@@ -705,8 +699,7 @@
 /area/centcom)
 "cj" = (
 /obj/machinery/door/airlock/multi_tile/mainship/secdoor{
-	dir = 2;
-	req_access = null
+	dir = 2
 	},
 /turf/open/floor/mainship{
 	dir = 4;
@@ -761,24 +754,12 @@
 	icon_state = "cargo"
 	},
 /area/centcom/supplypod/loading/ert)
-"cs" = (
-/obj/machinery/door/airlock/multi_tile/mainship/comdoor{
-	name = "\improper Cargo Pads";
-	req_access_txt = 200
-	},
-/turf/open/floor/mainship,
-/area/centcom)
 "ct" = (
-/obj/machinery/door/airlock/multi_tile/mainship/comdoor{
-	name = "\improper Cargo Pads";
-	req_access_txt = null
-	},
+/obj/machinery/door/airlock/multi_tile/mainship/comdoor/cargopads,
 /turf/open/floor/mainship,
 /area/centcom)
 "cu" = (
-/obj/machinery/door/airlock/multi_tile/mainship/secdoor{
-	req_access = null
-	},
+/obj/machinery/door/airlock/multi_tile/mainship/secdoor,
 /turf/open/floor/mainship,
 /area/centcom)
 "cv" = (
@@ -910,10 +891,8 @@
 	},
 /area/centcom/control)
 "ff" = (
-/obj/machinery/door/airlock/mainship/engineering{
-	dir = 1;
-	name = "\improper Server Room";
-	req_one_access_txt = null
+/obj/machinery/door/airlock/mainship/engineering/server_room{
+	dir = 1
 	},
 /turf/open/floor/mainship,
 /area/centcom/control)
@@ -989,10 +968,8 @@
 	},
 /area/centcom/supply)
 "gg" = (
-/obj/machinery/door/airlock/mainship/marine/requisitions{
-	dir = 1;
-	name = "\improper ASRS Lift";
-	req_one_access_txt = null
+/obj/machinery/door/airlock/mainship/marine/requisitions/lift{
+	dir = 1
 	},
 /turf/open/floor/mainship,
 /area/centcom/supply)
@@ -1229,10 +1206,7 @@
 	},
 /area/shuttle/distress/start_big)
 "kL" = (
-/obj/machinery/door/airlock/mainship/medical{
-	name = "Operating Theatre";
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/mainship/medical/or,
 /turf/open/floor/mainship{
 	icon_state = "plate"
 	},
@@ -1365,10 +1339,8 @@
 	},
 /area/shuttle/distress/start_big)
 "lc" = (
-/obj/machinery/door/airlock/mainship/medical{
-	dir = 2;
-	name = "Operating Theatre";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/medical/or{
+	dir = 2
 	},
 /turf/open/floor/mainship{
 	icon_state = "plate"
@@ -11795,7 +11767,7 @@ eo
 eo
 eo
 Xu
-cs
+ct
 eo
 eo
 yW

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -5087,7 +5087,6 @@
 /area/icy_caves/outpost/research)
 "qI" = (
 /obj/machinery/door/airlock/colony/research{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /turf/open/floor/tile/dark2,
@@ -5147,7 +5146,6 @@
 /area/icy_caves/outpost/research)
 "qP" = (
 /obj/machinery/door/airlock/colony/research{
-	icon_state = "door_closed";
 	dir = 1
 	},
 /obj/structure/cable/yellow{

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -1191,12 +1191,9 @@
 /turf/open/floor/tile/dark2,
 /area/icy_caves/caves/west)
 "eF" = (
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/locked/free_access{
 	dir = 4;
-	icon_state = "door_locked";
-	locked = 1;
-	name = "Mining Storage";
-	req_access_txt = "0"
+	name = "\improper Mining Storage"
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -2321,7 +2318,7 @@
 	},
 /area/icy_caves/caves/west)
 "ip" = (
-/obj/machinery/door/airlock/mainship/engineering,
+/obj/machinery/door/airlock/mainship/engineering/free_access,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -2356,7 +2353,7 @@
 /turf/open/floor/tile/dark2,
 /area/icy_caves/outpost/engineering)
 "is" = (
-/obj/machinery/door/airlock/mainship/engineering,
+/obj/machinery/door/airlock/mainship/engineering/free_access,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -2652,10 +2649,9 @@
 /turf/closed/wall,
 /area/icy_caves/outpost/engineering)
 "jj" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
-	name = "\improper Colony Power Substation";
-	req_access_txt = "100"
+	name = "\improper Colony Power Substation"
 	},
 /turf/open/floor/tile/dark2,
 /area/icy_caves/outpost/engineering)
@@ -2943,7 +2939,7 @@
 /turf/open/floor/tile/dark2,
 /area/icy_caves/outpost/medbay)
 "jZ" = (
-/obj/machinery/door/airlock/mainship/medical,
+/obj/machinery/door/airlock/mainship/medical/free_access,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
@@ -3507,8 +3503,7 @@
 "lS" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	dir = 1;
-	name = "\improper Medical Clinic";
-	req_one_access_txt = "0"
+	name = "\improper Medical Clinic"
 	},
 /turf/open/floor/tile/dark2,
 /area/icy_caves/outpost/medbay)
@@ -3840,8 +3835,7 @@
 /area/icy_caves/outpost/dorms)
 "mU" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
-	name = "\improper Colony Dormitories Canteen";
-	req_access_txt = "100"
+	name = "\improper Colony Dormitories Canteen"
 	},
 /turf/open/floor/tile/dark2,
 /area/icy_caves/outpost/dorms)
@@ -4372,7 +4366,7 @@
 /turf/open/floor/tile/dark2,
 /area/icy_caves/outpost/dorms)
 "oL" = (
-/obj/machinery/door/airlock/mainship/security,
+/obj/machinery/door/airlock/mainship/security/free_access,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -4404,8 +4398,7 @@
 "oO" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
-	name = "\improper Colony Dormitories";
-	req_access_txt = "100"
+	name = "\improper Colony Dormitories"
 	},
 /turf/open/floor/tile/dark2,
 /area/icy_caves/outpost/dorms)
@@ -4909,10 +4902,9 @@
 /turf/open/floor/tile/dark2,
 /area/icy_caves/outpost/security)
 "ql" = (
-/obj/machinery/door/airlock/mainship/security/glass{
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 1;
-	name = "\improper Underground Security Armory";
-	req_access_txt = "100"
+	name = "\improper Underground Security Armory"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;

--- a/_maps/shuttles/big_ert.dmm
+++ b/_maps/shuttles/big_ert.dmm
@@ -170,10 +170,7 @@
 	},
 /area/shuttle/big_ert)
 "az" = (
-/obj/machinery/door/airlock/mainship/medical{
-	name = "Operating Theatre";
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/mainship/medical/or/free_access,
 /turf/open/floor/mainship{
 	icon_state = "plate"
 	},
@@ -306,10 +303,8 @@
 	},
 /area/shuttle/big_ert)
 "aQ" = (
-/obj/machinery/door/airlock/mainship/medical{
-	dir = 2;
-	name = "Operating Theatre";
-	req_one_access_txt = "0"
+/obj/machinery/door/airlock/mainship/medical/or/free_access{
+	dir = 2
 	},
 /turf/open/floor/mainship{
 	icon_state = "plate"
@@ -538,7 +533,7 @@
 "bs" = (
 /obj/machinery/door/airlock/mainship/command{
 	dir = 1;
-	name = "Captain's Quarters"
+	name = "\improper Captain's Quarters"
 	},
 /turf/open/floor/plating/mainship,
 /area/shuttle/big_ert)
@@ -613,7 +608,7 @@
 "bC" = (
 /obj/machinery/door/airlock/mainship/command{
 	dir = 4;
-	name = "Bridge"
+	name = "\improper Bridge"
 	},
 /turf/open/floor/plating/mainship,
 /area/shuttle/big_ert)
@@ -783,7 +778,7 @@
 "bQ" = (
 /obj/machinery/door/airlock/mainship/command{
 	dir = 1;
-	name = "Captain's Storage"
+	name = "\improper Captain's Storage"
 	},
 /turf/open/floor/plating/mainship,
 /area/shuttle/big_ert)

--- a/_maps/shuttles/tgs_canterbury.dmm
+++ b/_maps/shuttles/tgs_canterbury.dmm
@@ -220,9 +220,7 @@
 "aw" = (
 /obj/machinery/door/airlock/mainship/command{
 	dir = 1;
-	icon_state = "door_closed";
-	name = "\improper Combat Information Center";
-	req_access = null
+	name = "\improper Combat Information Center"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -391,17 +389,13 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "aN" = (
-/obj/machinery/vending/marine/cargo_guns{
-	req_one_access = null
-	},
+/obj/machinery/vending/marine/cargo_guns,
 /turf/open/floor/mainship{
 	icon_state = "cargo"
 	},
 /area/shuttle/canterbury)
 "aO" = (
-/obj/machinery/vending/attachments{
-	req_access = null
-	},
+/obj/machinery/vending/attachments,
 /turf/open/floor/mainship{
 	icon_state = "cargo"
 	},
@@ -458,9 +452,7 @@
 	icon_state = "rwindow";
 	dir = 4
 	},
-/obj/machinery/vending/marine/cargo_guns{
-	req_one_access = null
-	},
+/obj/machinery/vending/marine/cargo_guns,
 /turf/open/floor/mainship{
 	icon_state = "cargo"
 	},
@@ -520,9 +512,7 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "bb" = (
-/obj/machinery/door/airlock/mainship/engineering{
-	req_one_access = null
-	},
+/obj/machinery/door/airlock/mainship/engineering/free_access,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -1171,10 +1161,8 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/shuttle/canterbury)
 "cs" = (
-/obj/machinery/door/airlock/mainship/medical/glass{
-	icon_state = "door_closed";
-	dir = 2;
-	req_one_access = null
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -1316,10 +1304,7 @@
 /area/shuttle/canterbury)
 "cG" = (
 /obj/machinery/door/airlock/mainship/marine{
-	icon_state = "door_closed";
-	dir = 8;
-	req_access = list();
-	req_one_access = list()
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4

--- a/code/__DEFINES/access.dm
+++ b/code/__DEFINES/access.dm
@@ -1,58 +1,60 @@
+///Dictionary of all req_access lists.
+GLOBAL_LIST_EMPTY(all_req_access)
+///Dictionary of all one_req_access lists.
+GLOBAL_LIST_EMPTY(all_req_one_access)
 
-/*Access levels. Changed into defines, since that's what they should be.
-It's best not to mess with the numbers of the regular access levels because
-most of them are tied into map-placed objects. This should be reworked in the future.*/
-//WE NEED TO REWORK THIS ONE DAY.  Access levels make me cry - Apophis
-#define ACCESS_MARINE_CAPTAIN 	1
-#define ACCESS_MARINE_LOGISTICS 	2
-#define ACCESS_MARINE_BRIG 			3
-#define ACCESS_MARINE_ARMORY 		4
-#define ACCESS_MARINE_CMO 			5
-#define ACCESS_MARINE_CE 			6
-#define ACCESS_MARINE_ENGINEERING 	7
-#define ACCESS_MARINE_MEDBAY 		8
-#define ACCESS_MARINE_PREP 			9
-#define ACCESS_MARINE_MEDPREP 		10
-#define ACCESS_MARINE_ENGPREP 		11
-#define ACCESS_MARINE_LEADER 		12
-#define ACCESS_MARINE_SPECPREP 		13
-#define ACCESS_MARINE_RESEARCH 		14
-#define ACCESS_MARINE_SMARTPREP		25
-#define ACCESS_MARINE_REMOTEBUILD   28
 
-#define ACCESS_MARINE_ALPHA 		15
-#define ACCESS_MARINE_BRAVO 		16
-#define ACCESS_MARINE_CHARLIE 		17
-#define ACCESS_MARINE_DELTA 		18
+#define ACCESS_MARINE_CAPTAIN		1
+#define ACCESS_MARINE_LOGISTICS		2
+#define ACCESS_MARINE_BRIG			3
+#define ACCESS_MARINE_ARMORY		4
+#define ACCESS_MARINE_CMO			5
+#define ACCESS_MARINE_CE			6
+#define ACCESS_MARINE_ENGINEERING	7
+#define ACCESS_MARINE_MEDBAY		8
+#define ACCESS_MARINE_PREP			9
+#define ACCESS_MARINE_MEDPREP		10
+#define ACCESS_MARINE_ENGPREP		11
+#define ACCESS_MARINE_LEADER		12
+#define ACCESS_MARINE_SPECPREP		13
+#define ACCESS_MARINE_RESEARCH		14
+#define ACCESS_MARINE_SMARTPREP		15
 
-#define ACCESS_MARINE_BRIDGE 		19
-#define ACCESS_MARINE_CHEMISTRY 	20
-#define ACCESS_MARINE_CARGO 		21
-#define ACCESS_MARINE_DROPSHIP 		22
-#define ACCESS_MARINE_PILOT 		23
-#define ACCESS_MARINE_WO			24
-#define ACCESS_MARINE_RO			26
-#define ACCESS_MARINE_TANK			27
+#define ACCESS_MARINE_BRIDGE		40
+#define ACCESS_MARINE_CHEMISTRY		41
+#define ACCESS_MARINE_CARGO			42
+#define ACCESS_MARINE_DROPSHIP		43
+#define ACCESS_MARINE_PILOT			44
+#define ACCESS_MARINE_WO			45
+#define ACCESS_MARINE_RO			46
+#define ACCESS_MARINE_TANK			47
+
+#define ACCESS_MARINE_REMOTEBUILD	60
+
+#define ACCESS_MARINE_ALPHA			80
+#define ACCESS_MARINE_BRAVO			81
+#define ACCESS_MARINE_CHARLIE		82
+#define ACCESS_MARINE_DELTA			83
 
 //Surface access levels
-#define ACCESS_CIVILIAN_PUBLIC 		100
-#define ACCESS_CIVILIAN_LOGISTICS 	101
-#define ACCESS_CIVILIAN_ENGINEERING 102
+#define ACCESS_CIVILIAN_PUBLIC		100
+#define ACCESS_CIVILIAN_LOGISTICS	101
+#define ACCESS_CIVILIAN_ENGINEERING	102
 #define ACCESS_CIVILIAN_RESEARCH	103
 #define ACCESS_CIVILIAN_MEDICAL		104
 
 //Special access levels. Should be alright to modify these.
-#define ACCESS_NT_PMC_GREEN 		180
-#define ACCESS_NT_PMC_ORANGE	 	181
+#define ACCESS_NT_PMC_GREEN			180
+#define ACCESS_NT_PMC_ORANGE		181
 #define ACCESS_NT_PMC_RED			182
 #define ACCESS_NT_PMC_BLACK			183
 #define ACCESS_NT_PMC_WHITE			184
-#define ACCESS_NT_CORPORATE 		200
-#define ACCESS_ILLEGAL_PIRATE 		201
+#define ACCESS_NT_CORPORATE			200
+#define ACCESS_ILLEGAL_PIRATE		201
 
 //Temporary until I turn these into defines/bitflags and develop proper IF tagging.
-#define ACCESS_IFF_MARINE 			998
-#define ACCESS_IFF_PMC 				999
+#define ACCESS_IFF_MARINE			998
+#define ACCESS_IFF_PMC				999
 //=================================================
 
 #define PAYGRADES_MARINE list("C","CMN","E1","E2","E3","E4","E5","E6","E7","E8","E8E","E9","E9E","O1","O2","O3","O4","O5","O6","WO","CWO","PO","CPO","MAJ")

--- a/code/datums/jobs/access.dm
+++ b/code/datums/jobs/access.dm
@@ -15,42 +15,18 @@
 
 
 /obj/proc/check_access(obj/item/card/id/ID)
-	//These generations have been moved out of /obj/New() because they were slowing down the creation of objects that never even used the access system.
-	var/i
-	if(!req_access)
-		req_access = list()
-		if(req_access_txt)
-			var/list/req_access_str = text2list(req_access_txt, ";")
-			var/n
-			for(i in req_access_str)
-				n = text2num(i)
-				if(!n)
-					continue
-				req_access += n
-
-	if(!req_one_access)
-		req_one_access = list()
-		if(req_one_access_txt)
-			var/list/req_one_access_str = text2list(req_one_access_txt, ";")
-			var/n
-			for(i in req_one_access_str)
-				n = text2num(i)
-				if(!n)
-					continue
-				req_one_access += n
-
-	if(!length(req_access) && !length(req_one_access))
+	if(!LAZYLEN(req_access) && !LAZYLEN(req_one_access))
 		return TRUE
 
 	if(!istype(ID))
 		return FALSE
 
-	for(i in req_access)
+	for(var/i in req_access)
 		if(!(i in ID.access))
 			return FALSE
 
-	if(length(req_one_access))
-		for(i in req_one_access)
+	if(LAZYLEN(req_one_access))
+		for(var/i in req_one_access)
 			if(!(i in ID.access))
 				continue
 			return TRUE

--- a/code/game/objects/items/portable_vendor.dm
+++ b/code/game/objects/items/portable_vendor.dm
@@ -200,7 +200,7 @@
 	name = "\improper Nanotrasen Automated Storage Briefcase"
 	desc = "A suitcase-sized automated storage and retrieval system. Designed to efficiently store and selectively dispense small items. This one has the Nanotrasen logo stamped on its side."
 
-	req_access_txt = "200"
+	req_access = list(ACCESS_NT_CORPORATE)
 	req_role = /datum/job/terragov/civilian/liaison
 	listed_products = list(
 							list("INCENTIVES", 0, null, null, null),

--- a/code/game/objects/machinery/door_control.dm
+++ b/code/game/objects/machinery/door_control.dm
@@ -165,6 +165,12 @@
 	id = "ammo2"
 	req_one_access = list(ACCESS_MARINE_BRIG, ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_ENGINEERING, ACCESS_MARINE_LEADER, ACCESS_MARINE_BRIDGE, ACCESS_MARINE_DROPSHIP)
 
+/obj/machinery/door_control/mainship/engineering
+	req_access = list(ACCESS_MARINE_ENGINEERING)
+
+/obj/machinery/door_control/mainship/medbay
+	req_access = list(ACCESS_MARINE_MEDBAY)
+
 /obj/machinery/door_control/mainship/fuel
 	name = "Solid Fuel Storage"
 	id = "solid_fuel"	
@@ -176,7 +182,7 @@
 /obj/machinery/door_control/mainship/research
 	name = "Medical Research Wing"
 	id = "researchdoorext"
-	req_access = list(ACCESS_MARINE_CMO)
+	req_access = list(ACCESS_MARINE_RESEARCH)
 
 /obj/machinery/door_control/mainship/research/lockdown
 	name = "Research Lockdown"
@@ -189,7 +195,7 @@
 
 /obj/machinery/door_control/mainship/checkpoint
 	name = "Checkpoint Shutters"
-	req_one_access = list(ACCESS_MARINE_BRIDGE, ACCESS_MARINE_BRIG, ACCESS_MARINE_LEADER, ACCESS_MARINE_LOGISTICS)
+	req_one_access = list(ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_BRIG, ACCESS_MARINE_LEADER, ACCESS_MARINE_BRIDGE)
 
 /obj/machinery/door_control/mainship/checkpoint/north
 	id = "northcheckpoint"
@@ -200,7 +206,7 @@
 /obj/machinery/door_control/mainship/cic
 	name = "CIC Lockdown"
 	id = "cic_lockdown"
-	req_one_access = list(ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_CAPTAIN)	
+	req_one_access = list(ACCESS_MARINE_BRIDGE)	
 
 /obj/machinery/door_control/mainship/cic/armory
 	name = "Armory Lockdown"	
@@ -223,7 +229,7 @@
 /obj/machinery/door_control/mainship/req	
 	name = "RO Line Shutters"
 	id = "ROlobby"
-	req_one_access = list(ACCESS_MARINE_CARGO, ACCESS_MARINE_CAPTAIN)
+	req_one_access = list(ACCESS_MARINE_CARGO)
 
 /obj/machinery/door_control/mainship/req/ro1	
 	name = "RO Line 1 Shutters"

--- a/code/game/objects/machinery/doors/airlock_types.dm
+++ b/code/game/objects/machinery/doors/airlock_types.dm
@@ -10,6 +10,10 @@
 	icon = 'icons/obj/doors/Doorcom.dmi'
 	assembly_type = /obj/structure/door_assembly/door_assembly_com
 
+/obj/machinery/door/airlock/command/thunderdome
+	name = "\improper Thunderdome Administration"
+	req_access = list(ACCESS_CIVILIAN_ENGINEERING)
+
 /obj/machinery/door/airlock/security
 	name = "\improper Security Airlock"
 	icon = 'icons/obj/doors/Doorsec.dmi'
@@ -34,6 +38,9 @@
 	name = "\improper External Airlock"
 	icon = 'icons/obj/doors/Doorext.dmi'
 	assembly_type = /obj/structure/door_assembly/door_assembly_ext
+
+/obj/machinery/door/airlock/external/brig
+	req_access = list(ACCESS_MARINE_BRIG)
 
 /obj/machinery/door/airlock/glass
 	name = "\improper Glass Airlock"
@@ -64,6 +71,9 @@
 	opacity = TRUE
 	assembly_type = /obj/structure/door_assembly/door_assembly_hatch
 
+/obj/machinery/door/airlock/hatch/engineering
+	req_access = list(ACCESS_CIVILIAN_ENGINEERING)
+
 /obj/machinery/door/airlock/maintenance_hatch
 	name = "\improper Maintenance Hatch"
 	icon = 'icons/obj/doors/Doorhatchmaint2.dmi'
@@ -90,6 +100,10 @@
 	opacity = FALSE
 	assembly_type = /obj/structure/door_assembly/door_assembly_sec
 	glass = TRUE
+
+/obj/machinery/door/airlock/glass_security/locked
+	icon_state = "door_locked"
+	locked = TRUE
 
 /obj/machinery/door/airlock/glass_medical
 	name = "\improper Medical Airlock"
@@ -224,6 +238,16 @@
 	icon = 'icons/obj/doors/mainship/secdoor.dmi'
 	req_access = list(ACCESS_MARINE_BRIG)
 
+/obj/machinery/door/airlock/mainship/security/free_access
+	req_access = null
+
+/obj/machinery/door/airlock/mainship/security/locked
+	icon_state = "door_locked"
+	locked = TRUE
+
+/obj/machinery/door/airlock/mainship/security/locked/free_access
+	req_access = null
+
 /obj/machinery/door/airlock/mainship/security/checkpoint
 	name = "\improper Security Checkpoint"	
 
@@ -235,6 +259,9 @@
 	icon = 'icons/obj/doors/mainship/secdoor_glass.dmi'
 	opacity = FALSE
 	glass = TRUE
+
+/obj/machinery/door/airlock/mainship/security/glass/free_access
+	req_access = null
 
 /obj/machinery/door/airlock/mainship/security/glass/office
 	name = "\improper Security Office"	
@@ -249,6 +276,24 @@
 	name = "\improper Command Airlock"
 	icon = 'icons/obj/doors/mainship/comdoor.dmi'
 	req_access = list(ACCESS_MARINE_BRIDGE)
+
+/obj/machinery/door/airlock/mainship/command/free_access
+	req_access = null
+
+/obj/machinery/door/airlock/mainship/command/locked
+	icon_state = "door_locked"
+	locked = TRUE
+
+/obj/machinery/door/airlock/mainship/command/locked/free_access
+	req_access = null
+
+/obj/machinery/door/airlock/mainship/command/open
+	icon_state = "door_open"
+	density = FALSE
+	opacity = FALSE
+
+/obj/machinery/door/airlock/mainship/command/open/free_access
+	req_access = null
 
 /obj/machinery/door/airlock/mainship/command/cic
 	name = "\improper Combat Information Center"	
@@ -273,18 +318,36 @@
 	name = "\improper FCDR's Quarters"
 
 /obj/machinery/door/airlock/mainship/command/officer
-	name = "\improper Officer's Quarters"	
+	name = "\improper Officer's Quarters"
 
 /obj/machinery/door/airlock/mainship/secure
 	name = "\improper Secure Airlock"
 	icon = 'icons/obj/doors/mainship/securedoor.dmi'
 	req_access = list(ACCESS_MARINE_BRIDGE)
 
+/obj/machinery/door/airlock/mainship/secure/free_access
+	req_access = null
+
+/obj/machinery/door/airlock/mainship/secure/locked
+	icon_state = "door_locked"
+	locked = TRUE
+
+/obj/machinery/door/airlock/mainship/secure/locked/free_access
+	req_access = null
+
+/obj/machinery/door/airlock/mainship/secure/open
+	icon_state = "door_open"
+	density = FALSE
+	opacity = FALSE
+
+/obj/machinery/door/airlock/mainship/secure/open/free_access
+	req_access = null
+
 /obj/machinery/door/airlock/mainship/secure/tcomms
-	name = "\improper Telecommunications"	
+	name = "\improper Telecommunications"
 
 /obj/machinery/door/airlock/mainship/secure/evac
-	name = "\improper Evacuation Airlock"	
+	name = "\improper Evacuation Airlock"
 
 /obj/machinery/door/airlock/mainship/ai
 	name = "\improper AI Core"
@@ -309,6 +372,8 @@
 	icon = 'icons/obj/doors/mainship/maintdoor.dmi'
 	req_one_access = list(ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_ENGINEERING)
 
+/obj/machinery/door/airlock/mainship/maint/free_access
+
 /obj/machinery/door/airlock/mainship/maint/core
 	name = "\improper Core Hatch"	
 
@@ -322,6 +387,9 @@
 	opacity = FALSE
 	glass = TRUE
 	req_one_access = list(ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_ENGINEERING)
+
+/obj/machinery/door/airlock/mainship/engineering/free_access
+	req_one_access = null
 
 /obj/machinery/door/airlock/mainship/engineering/storage
 	name = "\improper Engineering Storage"
@@ -343,10 +411,16 @@
 	name = "\improper Chief Ship Engineer's Office"
 	req_access = list(ACCESS_MARINE_CE)
 
+/obj/machinery/door/airlock/mainship/engineering/server_room
+	name = "\improper Server Room"
+	req_one_access = null
+
 /obj/machinery/door/airlock/mainship/medical
 	name = "\improper Medical Airlock"
 	icon = 'icons/obj/doors/mainship/medidoor.dmi'
 	req_one_access = list(ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_MEDBAY, ACCESS_MARINE_BRIDGE)
+
+/obj/machinery/door/airlock/mainship/medical/free_access
 
 /obj/machinery/door/airlock/mainship/medical/morgue
 	name = "\improper Morgue"
@@ -367,6 +441,9 @@
 /obj/machinery/door/airlock/mainship/medical/or/or4
 	name = "\improper Operating Theatre 4"	
 
+/obj/machinery/door/airlock/mainship/medical/or/free_access
+	req_one_access = null
+
 /obj/machinery/door/airlock/mainship/medical/glass
 	name = "\improper Medical Airlock"
 	icon = 'icons/obj/doors/mainship/medidoor_glass.dmi'
@@ -374,22 +451,49 @@
 	glass = TRUE
 	req_one_access = list(ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_MEDBAY, ACCESS_MARINE_BRIDGE)
 
+/obj/machinery/door/airlock/mainship/medical/glass/free_access
+	req_one_access = null
+
 /obj/machinery/door/airlock/mainship/medical/glass/CMO
 	name = "\improper CMO's Office"
 	req_access = list(ACCESS_MARINE_CMO)
 
 /obj/machinery/door/airlock/mainship/medical/glass/chemistry
 	name = "\improper Chemistry Laboratory"
-	req_access = list(ACCESS_MARINE_CHEMISTRY)	
+	req_access = list(ACCESS_MARINE_CHEMISTRY)
 
-/obj/machinery/door/airlock/mainship/medical/glass/animalcontrol
-	name = "\improper Animal Control Closet"	
+/obj/machinery/door/airlock/mainship/medical/glass/research
 	req_access = list(ACCESS_MARINE_RESEARCH)
 
 /obj/machinery/door/airlock/mainship/research
 	name = "\improper Research Airlock"
 	icon = 'icons/obj/doors/mainship/medidoor.dmi'
 	req_access = list(ACCESS_MARINE_RESEARCH)
+
+/obj/machinery/door/airlock/mainship/research/free_access
+	req_access = null
+
+/obj/machinery/door/airlock/mainship/research/open
+	icon_state = "door_open"
+	density = FALSE
+	opacity = FALSE
+
+/obj/machinery/door/airlock/mainship/research/open/free_access
+	req_one_access = null
+
+/obj/machinery/door/airlock/mainship/research/locked
+	icon_state = "door_locked"
+	locked = TRUE
+
+/obj/machinery/door/airlock/mainship/research/locked/free_access
+	req_one_access = null
+
+/obj/machinery/door/airlock/mainship/research/chemistry
+	name = "\improper Chemistry Laboratory"
+	req_access = list(ACCESS_MARINE_CHEMISTRY)
+
+/obj/machinery/door/airlock/mainship/research/or
+	name = "\improper Experimental Operating Theatre"
 
 /obj/machinery/door/airlock/mainship/research/pen
 	name = "\improper Research Pens"
@@ -406,6 +510,7 @@
 /obj/machinery/door/airlock/mainship/research/glass/cell
 	name = "\improper Containment Cell"
 	id = "Containment Cell"
+	icon_state = "door_locked"
 	locked = TRUE
 
 /obj/machinery/door/airlock/mainship/research/glass/cell/cell1
@@ -415,6 +520,9 @@
 /obj/machinery/door/airlock/mainship/research/glass/cell/cell2
 	name = "\improper Containment Cell 2"
 	id = "Containment Cell 2"
+
+/obj/machinery/door/airlock/mainship/research/glass/free_access
+	req_access = null
 
 /obj/machinery/door/airlock/mainship/generic
 	name = "\improper Airlock"
@@ -492,6 +600,10 @@
 	opacity = FALSE
 	glass = TRUE
 
+/obj/machinery/door/airlock/mainship/marine/requisitions/lift
+	name = "\improper ASRS Lift"
+	req_one_access = null
+
 /obj/machinery/door/airlock/mainship/marine/alpha
 	name = "\improper Alpha Squad Preparations"
 	icon = 'icons/obj/doors/mainship/prepdoor_alpha.dmi'
@@ -552,7 +664,7 @@
 
 /obj/machinery/door/airlock/mainship/marine/bravo/medic
 	name = "\improper Bravo Squad Medic Preparations"
-	req_access_txt = list(ACCESS_MARINE_MEDPREP, ACCESS_MARINE_BRAVO)
+	req_access = list(ACCESS_MARINE_MEDPREP, ACCESS_MARINE_BRAVO)
 	req_one_access = null
 
 /obj/machinery/door/airlock/mainship/marine/bravo/smart
@@ -708,6 +820,7 @@
 /obj/machinery/door/airlock/colony/engineering/nexusstorage/open
 	icon_state = "door_open"
 	density = FALSE
+	opacity = FALSE
 
 
 /obj/machinery/door/airlock/colony/medical
@@ -736,4 +849,5 @@
 
 /obj/machinery/door/airlock/colony/research/dome
 	name = "\improper Research Dome"
+	icon_state = "door_locked"
 	locked = TRUE

--- a/code/game/objects/machinery/doors/airlock_types.dm
+++ b/code/game/objects/machinery/doors/airlock_types.dm
@@ -792,13 +792,23 @@
 	icon = 'icons/obj/doors/mainship/dropship2_pilot.dmi'
 
 //PRISON AIRLOCKS
-/obj/machinery/door/airlock/prison/
+/obj/machinery/door/airlock/prison
 	name = "\improper Cell Door"
 	icon = 'icons/obj/doors/prison/celldoor.dmi'
 	glass = FALSE
 
+/obj/machinery/door/airlock/prison/open
+	icon_state = "door_open"
+	density = FALSE
+	opacity = FALSE
+
 /obj/machinery/door/airlock/prison/horizontal
 	dir = SOUTH
+
+/obj/machinery/door/airlock/prison/horizontal/open
+	icon_state = "door_open"
+	density = FALSE
+	opacity = FALSE
 
 
 //Colony Mapped Doors

--- a/code/game/objects/machinery/doors/multi_tile.dm
+++ b/code/game/objects/machinery/doors/multi_tile.dm
@@ -105,7 +105,8 @@
 	glass = TRUE
 
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor/medbay
-	name = "\improper Medical Bay"	
+	name = "\improper Medical Bay"
+	req_access = list(ACCESS_MARINE_MEDBAY)
 
 /obj/machinery/door/airlock/multi_tile/mainship/research
 	name = "\improper Research Airlock"
@@ -119,7 +120,14 @@
 	icon = 'icons/obj/doors/mainship/2x1comdoor.dmi'
 	opacity = FALSE
 	glass = TRUE
-	req_access_txt = "19"
+	req_access = list(ACCESS_MARINE_BRIDGE)
+
+/obj/machinery/door/airlock/multi_tile/mainship/comdoor/free_access
+	req_access = null
+
+/obj/machinery/door/airlock/multi_tile/mainship/comdoor/cargopads
+	name = "\improper Cargo Pads"
+	req_access = list(ACCESS_NT_CORPORATE)
 
 /obj/machinery/door/airlock/multi_tile/mainship/secdoor
 	name = "\improper Security Airlock"

--- a/code/game/objects/machinery/doors/windowdoor.dm
+++ b/code/game/objects/machinery/doors/windowdoor.dm
@@ -238,14 +238,39 @@
 /obj/machinery/door/window/northleft
 	dir = NORTH
 
+/obj/machinery/door/window/northleft/brig
+	req_access = list(ACCESS_MARINE_BRIG)
+
+/obj/machinery/door/window/northleft/req
+	req_one_access = list(ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_CARGO)
+
 /obj/machinery/door/window/eastleft
 	dir = EAST
+
+/obj/machinery/door/window/eastleft/req
+	req_one_access = list(ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_CARGO)
+
+/obj/machinery/door/window/eastleft/brig
+	req_access = list(ACCESS_MARINE_BRIG)
 
 /obj/machinery/door/window/westleft
 	dir = WEST
 
+/obj/machinery/door/window/westleft/bridge
+	req_access = list(ACCESS_MARINE_BRIDGE)
+
+/obj/machinery/door/window/westleft/engineering
+	req_access = list(ACCESS_MARINE_ENGINEERING)
+
+/obj/machinery/door/window/westleft/req
+	req_one_access = list(ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_CARGO)
+
+
 /obj/machinery/door/window/southleft
 	dir = SOUTH
+
+/obj/machinery/door/window/southleft/brig
+	req_access = list(ACCESS_MARINE_BRIG)
 
 /obj/machinery/door/window/southleft/briefing
 	req_access = list(ACCESS_MARINE_BRIG)
@@ -265,6 +290,9 @@
 
 /obj/machinery/door/window/eastright/briefing
 	req_access = list(ACCESS_MARINE_BRIG)
+
+/obj/machinery/door/window/eastright/bridge
+	req_access = list(ACCESS_MARINE_BRIDGE)
 
 /obj/machinery/door/window/westright
 	dir = WEST
@@ -307,3 +335,6 @@
 	dir = SOUTH
 	icon_state = "rightsecure"
 	base_state = "rightsecure"
+
+/obj/machinery/door/window/mainship/bridge
+	req_access = list(ACCESS_MARINE_BRIDGE)

--- a/code/game/objects/machinery/kitchen/smartfridge.dm
+++ b/code/game/objects/machinery/kitchen/smartfridge.dm
@@ -252,7 +252,8 @@
 	icon_on = "smartfridge"
 	icon_off = "smartfridge-off"
 	is_secure_fridge = TRUE
-	req_one_access_txt = "5;33"
+	req_one_access = list(ACCESS_MARINE_CMO, ACCESS_CIVILIAN_MEDICAL)
+
 
 /obj/machinery/smartfridge/secure/medbay/accept_check(obj/item/O as obj)
 	if(istype(O,/obj/item/reagent_containers/glass/))
@@ -268,7 +269,7 @@
 	name = "\improper Refrigerated Virus Storage"
 	desc = "A refrigerated storage unit for storing viral material."
 	is_secure_fridge = TRUE
-	req_access_txt = "39"
+	req_access = list(ACCESS_CIVILIAN_MEDICAL)
 	icon_state = "smartfridge"
 	icon_on = "smartfridge"
 	icon_off = "smartfridge-off"

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -346,7 +346,6 @@
 	vend_delay = 15
 	//product_slogans = "Standard Issue Marine food!;It's good for you, and not the worst thing in the world.;Just fucking eat it.;"
 	product_ads = "Try the cornbread.;Try the pizza.;Try the pasta.;Try the tofu, wimp.;Try the pork."
-	req_access_txt = ""
 
 
 /obj/machinery/vending/MarineMed

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -73,9 +73,7 @@ GLOBAL_LIST_INIT(marine_selector_cats, list(
 	anchored = TRUE
 	layer = BELOW_OBJ_LAYER
 	req_access = null
-	req_access_txt = "0"
 	req_one_access = null
-	req_one_access_txt = "0"
 	interaction_flags = INTERACT_MACHINE_NANO
 
 	idle_power_usage = 60

--- a/code/game/objects/machinery/vending/vending_types.dm
+++ b/code/game/objects/machinery/vending/vending_types.dm
@@ -248,7 +248,7 @@
 	product_ads = "Crack capitalist skulls!;Beat some heads in!;Don't forget - harm is good!;Your weapons are right here.;Handcuffs!;Freeze, scumbag!;Don't tase me bro!;Tase them, bro.;Why not have a donut?"
 	icon_state = "sec"
 	icon_deny = "sec-deny"
-	req_access_txt = "3"
+	req_access = list(ACCESS_MARINE_BRIG)
 	products = list(/obj/item/restraints/handcuffs = 8,
 					/obj/item/restraints/handcuffs/zip = 10,
 					/obj/item/explosive/grenade/flashbang = 4,
@@ -321,7 +321,6 @@
 	desc = "Tools for tools."
 	icon_state = "tool"
 	icon_deny = "tool-deny"
-	//req_access_txt = "12" //Maintenance access
 	products = list(/obj/item/stack/cable_coil/random = 10,/obj/item/tool/crowbar = 5,/obj/item/tool/weldingtool = 3,/obj/item/tool/wirecutters = 5,
 					/obj/item/tool/wrench = 5,/obj/item/analyzer = 5,/obj/item/t_scanner = 5,/obj/item/tool/screwdriver = 5)
 	contraband = list(/obj/item/tool/weldingtool/hugetank = 2,/obj/item/clothing/gloves/fyellow = 2)
@@ -332,7 +331,7 @@
 	desc = "Spare electronics vending. What? Did you expect some witty description?"
 	icon_state = "engivend"
 	icon_deny = "engivend-deny"
-	req_access_txt = "7" //Engineering Equipment access
+	req_access = list(ACCESS_MARINE_ENGINEERING)
 	products = list(/obj/item/clothing/glasses/meson = 2,/obj/item/multitool = 4,/obj/item/circuitboard/airlock = 10,/obj/item/circuitboard/apc = 10,/obj/item/circuitboard/airalarm = 10, /obj/item/circuitboard/general = 20, /obj/item/cell/high = 10)
 	contraband = list(/obj/item/cell/potato = 3)
 	premium = list(/obj/item/storage/belt/utility = 3)
@@ -343,7 +342,7 @@
 	desc = "A large storage machine containing various tools and devices for general repair."
 	icon_state = "engi"
 	icon_deny = "engi-deny"
-	req_access_txt = "7"
+	req_access = list(ACCESS_MARINE_ENGINEERING)
 	products = list(/obj/item/clothing/head/hardhat = 4,/obj/item/storage/belt/utility = 4,/obj/item/clothing/glasses/meson = 4,/obj/item/clothing/gloves/yellow = 4,
 					/obj/item/tool/screwdriver = 12,/obj/item/tool/crowbar = 12,/obj/item/tool/wirecutters = 12,/obj/item/multitool = 12,/obj/item/tool/wrench = 12,
 					/obj/item/t_scanner = 12, /obj/item/cell = 8, /obj/item/tool/weldingtool = 8,/obj/item/clothing/head/welding = 8,
@@ -356,7 +355,7 @@
 	desc = "All the tools you need to create your own robot army."
 	icon_state = "robotics"
 	icon_deny = "robotics-deny"
-	req_access_txt = "14"
+	req_access = list(ACCESS_MARINE_RESEARCH)
 	products = list(/obj/item/clothing/suit/storage/labcoat = 4,/obj/item/clothing/under/rank/roboticist = 4,/obj/item/stack/cable_coil = 4,/obj/item/flash = 4,
 					/obj/item/cell/high = 12, /obj/item/assembly/prox_sensor = 3,/obj/item/assembly/signaler = 3,/obj/item/healthanalyzer = 3,
 					/obj/item/tool/surgery/scalpel = 2,/obj/item/tool/surgery/circular_saw = 2,/obj/item/tank/anesthetic = 2,/obj/item/clothing/mask/breath/medical = 5,

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -26,9 +26,6 @@
 	var/list/req_access = null
 	var/list/req_one_access = null
 
-	//Don't directly use these two, please. No: magic numbers, Yes: defines.
-	var/req_one_access_txt = "0"
-	var/req_access_txt = "0"
 
 /obj/Initialize()
 	. = ..()
@@ -41,6 +38,21 @@
 
 	if(obj_integrity == null)
 		obj_integrity = max_integrity
+
+	if(LAZYLEN(req_access))
+		var/txt_access = req_access.Join("-")
+		if(!GLOB.all_req_access[txt_access])
+			GLOB.all_req_access[txt_access] = req_access
+		else
+			req_access = GLOB.all_req_access[txt_access]
+
+	if(LAZYLEN(req_one_access))
+		var/txt_access = req_one_access.Join("-")
+		if(!GLOB.all_req_one_access[txt_access])
+			GLOB.all_req_one_access[txt_access] = req_one_access
+		else
+			req_one_access = GLOB.all_req_one_access[txt_access]
+
 
 /obj/proc/setAnchored(anchorvalue)
 	SEND_SIGNAL(src, COMSIG_OBJ_SETANCHORED, anchorvalue)

--- a/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
@@ -1,6 +1,5 @@
 /obj/structure/closet/secure_closet/guncabinet
 	name = "gun cabinet"
-	req_access_txt = "0"
 	icon = 'icons/obj/structures/misc.dmi'
 	icon_state = "base"
 	icon_off ="base"

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -237,6 +237,11 @@
 	density = FALSE
 
 
+/obj/structure/closet/secure_closet/evidence
+	name = "Secure Evidence Locker"
+	req_access = list(ACCESS_MARINE_BRIG)
+
+
 /obj/structure/closet/secure_closet/detective
 	name = "Detective's Cabinet"
 	req_access = list(ACCESS_MARINE_BRIG)


### PR DESCRIPTION
* Removed `req_access_txt` and `req_one_access_txt`, we use lists and defines now.

* Refactored the way the lists are stored, so we make use of dictionaries for unique combinations. After the huge var-edit cleanup we'd still have 1014 unique access lists on Pillar + Prison. This system reduces this to just 2 directory lists, plus 25  unique `req_access` and 19 `req_one_access` lists. Not a huge gain, but it's something.

* Since I really don't love myself, removed a ton of var-edits, cleaning up the maps quite a bit.

* Ice Colony and to a lesser degree Prison Station had several access locks. Both were removed, following the standard of other patterns, to avoid having the station be powered be against the marines.