### PR TITLE
Bump attack also targets foes on the ground when crossed

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -115,7 +115,8 @@
 // /atom/movable signals
 #define COMSIG_MOVABLE_PRE_MOVE "movable_pre_move"					//from base of atom/movable/Moved(): (/atom)
 #define COMSIG_MOVABLE_MOVED "movable_moved"					//from base of atom/movable/Moved(): (/atom, dir)
-#define COMSIG_MOVABLE_CROSSED "movable_crossed"                //from base of atom/movable/Crossed(): (/atom/movable)
+#define COMSIG_MOVABLE_CROSSED_BY "movable_crossed_by"			//from base of atom/movable/Crossed(): (/atom/movable, oldloc)
+#define COMSIG_MOVABLE_CROSSED "movable_crossed"				//from base of atom/movable/Crossed(): (/atom/movable, oldloc)
 #define COMSIG_MOVABLE_BUMP "movable_bump"						//from base of atom/movable/Bump(): (/atom)
 	#define COMPONENT_BUMP_RESOLVED (1<<0)
 #define COMSIG_MOVABLE_IMPACT "movable_impact"					//from base of atom/movable/throw_impact(): (/atom/hit_atom)

--- a/code/datums/components/bump_attack.dm
+++ b/code/datums/components/bump_attack.dm
@@ -1,6 +1,7 @@
 /datum/component/bump_attack
 	var/active = TRUE
 	var/bump_action_path
+	var/cross_action_path
 	var/datum/action/bump_attack_toggle/toggle_action
 
 
@@ -12,17 +13,20 @@
 	var/toggle_path
 	if(ishuman(parent))
 		bump_action_path = .proc/human_bump_action
+		cross_action_path = .proc/human_bump_action
 	else if(isxeno(parent))
 		bump_action_path = .proc/xeno_bump_action
+		cross_action_path = .proc/xeno_bump_action
 	else
 		bump_action_path = .proc/living_bump_action
+		cross_action_path = .proc/living_bump_action
 	toggle_path = .proc/living_activation_toggle
 	toggle_action.give_action(parent)
 	toggle_action.update_button_icon(active)
 	RegisterSignal(toggle_action, COMSIG_ACTION_TRIGGER, toggle_path)
 	if(active)
 		RegisterSignal(parent, COMSIG_MOVABLE_BUMP, bump_action_path)
-
+		RegisterSignal(parent, COMSIG_MOVABLE_CROSSED, cross_action_path)
 
 /datum/component/bump_attack/Destroy(force, silent)
 	QDEL_NULL(toggle_action)
@@ -35,8 +39,9 @@
 	to_chat(bumper, "<span class='notice'>You will now [active ? "attack" : "push"] enemies who are in your way.</span>")
 	if(active)
 		RegisterSignal(bumper, COMSIG_MOVABLE_BUMP, bump_action_path)
+		RegisterSignal(bumper, COMSIG_MOVABLE_CROSSED, cross_action_path)
 	else
-		UnregisterSignal(bumper, COMSIG_MOVABLE_BUMP)
+		UnregisterSignal(bumper, list(COMSIG_MOVABLE_BUMP, COMSIG_MOVABLE_CROSSED))
 	toggle_action.update_button_icon(active)
 
 

--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -18,7 +18,7 @@
 	RegisterSignal(parent, list(COMSIG_ATOM_ENTERED, COMSIG_PARENT_ATTACKBY), .proc/play_squeak)
 	if(ismovableatom(parent))
 		RegisterSignal(parent, list(COMSIG_MOVABLE_BUMP, COMSIG_MOVABLE_IMPACT), .proc/play_squeak)
-		RegisterSignal(parent, COMSIG_MOVABLE_CROSSED, .proc/play_squeak_crossed)
+		RegisterSignal(parent, COMSIG_MOVABLE_CROSSED_BY, .proc/play_squeak_crossed)
 		RegisterSignal(parent, COMSIG_MOVABLE_DISPOSING, .proc/disposing_react)
 		if(isitem(parent))
 			RegisterSignal(parent, COMSIG_ITEM_ATTACK, .proc/play_squeak)
@@ -60,7 +60,7 @@
 		steps++
 
 
-/datum/component/squeak/proc/play_squeak_crossed(datum/source, atom/movable/AM)
+/datum/component/squeak/proc/play_squeak_crossed(datum/source, atom/movable/AM, oldloc)
 	if(isitem(AM))
 		var/obj/item/I = AM
 		if(I.flags_item & ITEM_ABSTRACT)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -235,8 +235,11 @@
 
 
 //oldloc = old location on atom, inserted when forceMove is called and ONLY when forceMove is called!
-/atom/movable/Crossed(atom/movable/AM, oldloc)
-	SEND_SIGNAL(src, COMSIG_MOVABLE_CROSSED, AM)
+/atom/movable/Crossed(atom/movable/mover, oldloc)
+	SHOULD_CALL_PARENT(TRUE)
+	. = ..()
+	SEND_SIGNAL(src, COMSIG_MOVABLE_CROSSED_BY, mover, oldloc)
+	SEND_SIGNAL(mover, COMSIG_MOVABLE_CROSSED, src, oldloc)
 
 
 /atom/movable/Uncross(atom/movable/AM, atom/newloc)

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -55,8 +55,8 @@
 	STOP_PROCESSING(SSprocessing, src)
 	return ..()
 
-/obj/effect/xenomorph/spray/Crossed(AM as mob|obj)
-	..()
+/obj/effect/xenomorph/spray/Crossed(atom/movable/AM)
+	. = ..()
 	if(ishuman(AM))
 		var/mob/living/carbon/human/H = AM
 		var/armor_block

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -48,6 +48,7 @@
 	color = basecolor
 
 /obj/effect/decal/cleanable/blood/Crossed(mob/living/carbon/human/perp)
+	. = ..()
 	if (!istype(perp))
 		return
 	if(amount < 1)

--- a/code/game/objects/effects/effect_system/foam.dm
+++ b/code/game/objects/effects/effect_system/foam.dm
@@ -85,6 +85,7 @@
 
 
 /obj/effect/particle_effect/foam/Crossed(atom/movable/AM)
+	. = ..()
 	if(metal)
 		return
 	if (iscarbon(AM))

--- a/code/game/objects/effects/effect_system/particle_effects.dm
+++ b/code/game/objects/effects/effect_system/particle_effects.dm
@@ -40,7 +40,7 @@
 		S.fire_act()
 
 /obj/effect/particle_effect/fire/Crossed(mob/living/L)
-	..()
+	. = ..()
 	if(isliving(L))
 		L.fire_act()
 

--- a/code/game/objects/effects/proximity.dm
+++ b/code/game/objects/effects/proximity.dm
@@ -112,4 +112,5 @@
 
 /obj/effect/abstract/proximity_checker/Crossed(atom/movable/AM)
 	set waitfor = FALSE
+	. = ..()
 	monitor.hasprox_receiver.HasProximity(AM)

--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -9,8 +9,8 @@
 /obj/effect/step_trigger/proc/Trigger(atom/movable/A)
 	return 0
 
-/obj/effect/step_trigger/Crossed(H as mob|obj)
-	..()
+/obj/effect/step_trigger/Crossed(atom/movable/H)
+	. = ..()
 	if(!H)
 		return
 	if(isobserver(H) && !affect_ghosts)

--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -52,6 +52,7 @@
 		T.ceiling_desc(user)
 
 /obj/effect/alien/weeds/Crossed(atom/movable/AM)
+	. = ..()
 	if(ishuman(AM))
 		var/mob/living/carbon/human/H = AM
 		H.next_move_slowdown += 1

--- a/code/game/objects/items/explosives/grenades/chem_grenade.dm
+++ b/code/game/objects/items/explosives/grenades/chem_grenade.dm
@@ -167,6 +167,7 @@
 
 
 /obj/item/explosive/grenade/chem_grenade/Crossed(atom/movable/AM)
+	. = ..()
 	if(nadeassembly)
 		nadeassembly.Crossed(AM)
 

--- a/code/game/objects/items/legcuffs.dm
+++ b/code/game/objects/items/legcuffs.dm
@@ -54,4 +54,4 @@
 					armed = FALSE
 					var/mob/living/simple_animal/SA = AM
 					SA.health -= 20
-	..()
+	return ..()

--- a/code/game/objects/items/misc.dm
+++ b/code/game/objects/items/misc.dm
@@ -22,7 +22,8 @@
 	throw_speed = 4
 	throw_range = 20
 
-/obj/item/bananapeel/Crossed(AM as mob|obj)
+/obj/item/bananapeel/Crossed(AM)
+	. = ..()
 	if (iscarbon(AM))
 		var/mob/living/carbon/C = AM
 		C.slip(name, 4, 2)

--- a/code/game/objects/items/reagent_containers/food/snacks/grown.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks/grown.dm
@@ -407,7 +407,8 @@
 	qdel(src)
 	return
 
-/obj/item/reagent_containers/food/snacks/grown/bluetomato/Crossed(AM as mob|obj)
+/obj/item/reagent_containers/food/snacks/grown/bluetomato/Crossed(atom/movable/AM)
+	. = ..()
 	if (iscarbon(AM))
 		var/mob/living/carbon/C = AM
 		C.slip(name, 8, 5)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -297,6 +297,7 @@
 
 
 /obj/item/stack/Crossed(obj/item/stack/S)
+	. = ..()
 	if(istype(S, merge_type) && !S.throwing)
 		merge(S)
 	return ..()

--- a/code/game/objects/items/tools/cleaning_tools.dm
+++ b/code/game/objects/items/tools/cleaning_tools.dm
@@ -82,6 +82,7 @@
 	throw_range = 20
 
 /obj/item/tool/soap/Crossed(atom/movable/AM)
+	. = ..()
 	if (iscarbon(AM))
 		var/mob/living/carbon/C =AM
 		C.slip("soap", 3, 2)

--- a/code/game/objects/items/tools/policetape.dm
+++ b/code/game/objects/items/tools/policetape.dm
@@ -114,6 +114,7 @@
 		name = "crumpled [name]"
 
 /obj/item/tape/Crossed(atom/movable/AM)
+	. = ..()
 	if(!lifted && ismob(AM))
 		var/mob/M = AM
 		if(!allowed(M))	//only select few learn art of not crumpling the tape

--- a/code/game/objects/items/toys/toys.dm
+++ b/code/game/objects/items/toys/toys.dm
@@ -164,7 +164,8 @@
 		playsound(src, 'sound/effects/snap.ogg', 25, 1)
 		qdel(src)
 
-/obj/item/toy/snappop/Crossed(H as mob|obj)
+/obj/item/toy/snappop/Crossed(atom/movable/H)
+	. = ..()
 	if((ishuman(H))) //i guess carp and shit shouldn't set them off
 		var/mob/living/carbon/M = H
 		if(M.m_intent == MOVE_INTENT_RUN)

--- a/code/game/objects/structures/coathanger.dm
+++ b/code/game/objects/structures/coathanger.dm
@@ -30,7 +30,7 @@
 
 
 /obj/structure/coatrack/Crossed(atom/movable/AM)
-	..()
+	. = ..()
 	if(!coat)
 		for(var/T in allowed)
 			if(istype(AM,T))

--- a/code/game/objects/structures/plants.dm
+++ b/code/game/objects/structures/plants.dm
@@ -35,6 +35,7 @@
 
 
 /obj/structure/bush/Crossed(atom/movable/AM)
+	. = ..()
 	if(!stump)
 		if(isliving(AM))
 			var/mob/living/L = AM

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -53,7 +53,7 @@
 
 
 /obj/structure/table/Crossed(atom/movable/O)
-	..()
+	. = ..()
 	if(istype(O,/mob/living/carbon/xenomorph/ravager))
 		var/mob/living/carbon/xenomorph/M = O
 		if(!M.stat) //No dead xenos jumpin on the bed~
@@ -607,7 +607,7 @@
 
 
 /obj/structure/rack/Crossed(atom/movable/O)
-	..()
+	. = ..()
 	if(istype(O,/mob/living/carbon/xenomorph/ravager))
 		var/mob/living/carbon/xenomorph/M = O
 		if(!M.stat) //No dead xenos jumpin on the bed~

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -241,7 +241,7 @@
 				ismist = 0
 
 /obj/machinery/shower/Crossed(atom/movable/O)
-	..()
+	. = ..()
 	wash(O)
 	if(ismob(O))
 		mobpresent += 1

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -204,6 +204,7 @@
 
 
 /obj/effect/alien/resin/trap/Crossed(atom/A)
+	. = ..()
 	if(iscarbon(A))
 		HasProximity(A)
 
@@ -555,6 +556,7 @@
 
 
 /obj/effect/egg_trigger/Crossed(atom/A)
+	. = ..()
 	if(!linked_egg) //something went very wrong
 		qdel(src)
 	else if(get_dist(src, linked_egg) != 1 || !isturf(linked_egg.loc)) //something went wrong

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -69,6 +69,7 @@
 
 
 /obj/item/assembly_holder/Crossed(atom/movable/AM)
+	. = ..()
 	if(a_left)
 		a_left.Crossed(AM)
 	if(a_right)

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -258,6 +258,7 @@
 
 
 /obj/effect/beam/i_beam/Crossed(atom/movable/AM)
+	. = ..()
 	if(istype(AM, /obj/effect/beam))
 		return
 	if(isitem(AM))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -233,6 +233,7 @@
 // called when something steps onto a human
 // this handles mulebots and vehicles
 /mob/living/carbon/human/Crossed(atom/movable/AM)
+	. = ..()
 	if(istype(AM, /obj/machinery/bot/mulebot))
 		var/obj/machinery/bot/mulebot/MB = AM
 		MB.RunOver(src)

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -203,6 +203,7 @@
 	return TRUE
 
 /obj/item/clothing/mask/facehugger/Crossed(atom/target)
+	. = ..()
 	if(stat == CONSCIOUS)
 		HasProximity(target)
 

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -34,6 +34,7 @@
 
 
 /mob/living/simple_animal/mouse/Crossed(atom/movable/AM)
+	. = ..()
 	if(ishuman(AM) && stat == CONSCIOUS)
 		var/mob/living/carbon/human/H = AM
 		to_chat(H, "<span class='notice'>[icon2html(src, H)] Squeak!</span>")

--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -502,6 +502,7 @@
 	return ..()
 
 /obj/flamer_fire/Crossed(mob/living/M) //Only way to get it to reliable do it when you walk into it.
+	. = ..()
 	if(istype(M))
 		M.flamer_fire_crossed(burnlevel, firelevel)
 


### PR DESCRIPTION
Also refactors Crossed a bit, forcing it to call parent like on /tg/ and adding a signal for the thing doing the crossing.

## Changelog
:cl:
balance: Bump attack also targets foes on the ground when crossed.
/:cl: