### PR TITLE
soft/hard armor

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -105,9 +105,9 @@
 
 	switch(I.damtype)
 		if(BRUTE)
-			apply_damage(power, BRUTE, user.zone_selected, get_living_armor("melee", user.zone_selected))
+			apply_damage(power, BRUTE, user.zone_selected, get_soft_armor("melee", user.zone_selected))
 		if(BURN)
-			if(apply_damage(power, BURN, user.zone_selected, get_living_armor("fire", user.zone_selected)))
+			if(apply_damage(power, BURN, user.zone_selected, get_soft_armor("fire", user.zone_selected)))
 				attack_message_local = "[attack_message_local] It burns!"
 
 	visible_message("<span class='danger'>[attack_message]</span>",

--- a/code/datums/armor.dm
+++ b/code/datums/armor.dm
@@ -37,7 +37,9 @@
 /datum/armor/proc/modifyAllRatings(modifier = 0)
 	return getArmor(melee+modifier, bullet+modifier, laser+modifier, energy+modifier, bomb+modifier, bio+modifier, rad+modifier, fire+modifier, acid+modifier, magic+modifier)
 
-/datum/armor/proc/scaleAllRatings(modifier = 1)
+/datum/armor/proc/scaleAllRatings(modifier = 1, round_to = 0)
+	if(round_to >= 1)
+		return getArmor(round(melee*modifier,round_to), round(bullet*modifier,round_to), round(laser*modifier,round_to), round(energy*modifier,round_to), round(bomb*modifier,round_to), round(bio*modifier,round_to), round(rad*modifier,round_to), round(fire*modifier,round_to), round(acid*modifier,round_to), round(magic*modifier,round_to))
 	return getArmor(melee*modifier, bullet*modifier, laser*modifier, energy*modifier, bomb*modifier, bio*modifier, rad*modifier, fire*modifier, acid*modifier, magic*modifier)
 
 /datum/armor/proc/setRating(melee, bullet, laser, energy, bomb, bio, rad, fire, acid, magic)

--- a/code/datums/armor.dm
+++ b/code/datums/armor.dm
@@ -37,6 +37,9 @@
 /datum/armor/proc/modifyAllRatings(modifier = 0)
 	return getArmor(melee+modifier, bullet+modifier, laser+modifier, energy+modifier, bomb+modifier, bio+modifier, rad+modifier, fire+modifier, acid+modifier, magic+modifier)
 
+/datum/armor/proc/scaleAllRatings(modifier = 1)
+	return getArmor(melee*modifier, bullet*modifier, laser*modifier, energy*modifier, bomb*modifier, bio*modifier, rad*modifier, fire*modifier, acid*modifier, magic*modifier)
+
 /datum/armor/proc/setRating(melee, bullet, laser, energy, bomb, bio, rad, fire, acid, magic)
 	return getArmor((isnull(melee) ? src.melee : melee),\
 					(isnull(bullet) ? src.bullet : bullet),\

--- a/code/modules/codex/entries/mobs_codex.dm
+++ b/code/modules/codex/entries/mobs_codex.dm
@@ -30,7 +30,7 @@
 			xeno_strings += "Can smash walls: No"
 	xeno_strings += "Max health: [xeno_caste.max_health]"
 	for(var/armor_type in GLOB.armour_to_descriptive_term)
-		switch(armor.getRating(armor_type))
+		switch(soft_armor.getRating(armor_type))
 			if(0)
 				xeno_strings += "Has no protection against [GLOB.armour_to_descriptive_term[armor_type]]."
 			if(1 to 20)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -75,7 +75,7 @@ Contains most of the procs that are called when a mob is attacked by something
 		var/datum/limb/limb_to_check = i
 		if(!(limb_to_check.body_part & armor_item.flags_armor_protection))
 			continue
-		limb_to_check.armor = limb_to_check.armor.attachArmor(armor_item.armor)
+		limb_to_check.add_limb_soft_armor(armor_item.armor)
 
 
 /mob/living/carbon/human/dummy/add_limb_armor(obj/item/armor_item)
@@ -87,16 +87,16 @@ Contains most of the procs that are called when a mob is attacked by something
 		var/datum/limb/limb_to_check = i
 		if(!(limb_to_check.body_part & armor_item.flags_armor_protection))
 			continue
-		limb_to_check.armor = limb_to_check.armor.detachArmor(armor_item.armor)
+		limb_to_check.remove_limb_soft_armor(armor_item.armor)
 
 
 /mob/living/carbon/human/dummy/remove_limb_armor(obj/item/armor_item)
 	return
 
 
-//this proc returns the armour value for a particular external organ.
+///This proc returns the armour value for a particular external organ.
 /mob/living/carbon/human/proc/getarmor_organ(datum/limb/affected_limb, type)
-	return affected_limb.armor.getRating(type)
+	return affected_limb.soft_armor.getRating(type)
 
 
 /mob/living/carbon/human/proc/check_head_coverage()

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
@@ -38,7 +38,7 @@
 	caste_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER|CASTE_ACID_BLOOD
 
 	// *** Defense *** //
-	armor = list("melee" = 40, "bullet" = 40, "laser" = 40, "energy" = 40, "bomb" = XENO_BOMB_RESIST_0, "bio" = 30, "rad" = 30, "fire" = 15, "acid" = 30)
+	soft_armor = list("melee" = 40, "bullet" = 40, "laser" = 40, "energy" = 40, "bomb" = XENO_BOMB_RESIST_0, "bio" = 30, "rad" = 30, "fire" = 15, "acid" = 30)
 
 	// *** Ranged Attack *** //
 	spit_delay = 4 SECONDS
@@ -90,7 +90,7 @@
 	upgrade_threshold = 500
 
 	// *** Defense *** //
-	armor = list("melee" = 45, "bullet" = 45, "laser" = 45, "energy" = 45, "bomb" = XENO_BOMB_RESIST_0, "bio" = 33, "rad" = 33, "fire" = 20, "acid" = 33)
+	soft_armor = list("melee" = 45, "bullet" = 45, "laser" = 45, "energy" = 45, "bomb" = XENO_BOMB_RESIST_0, "bio" = 33, "rad" = 33, "fire" = 20, "acid" = 33)
 
 	// *** Ranged Attack *** //
 	spit_delay = 3 SECONDS
@@ -126,7 +126,7 @@
 	upgrade_threshold = 1000
 
 	// *** Defense *** //
-	armor = list("melee" = 45, "bullet" = 45, "laser" = 45 , "energy" = 45, "bomb" = XENO_BOMB_RESIST_0, "bio" = 35, "rad" = 35, "fire" = 22, "acid" = 35)
+	soft_armor = list("melee" = 45, "bullet" = 45, "laser" = 45 , "energy" = 45, "bomb" = XENO_BOMB_RESIST_0, "bio" = 35, "rad" = 35, "fire" = 22, "acid" = 35)
 
 	// *** Ranged Attack *** //
 	spit_delay = 2 SECONDS
@@ -160,7 +160,7 @@
 	max_health = 275
 
 	// *** Defense *** //
-	armor = list("melee" = 45, "bullet" = 45, "laser" = 45, "energy" = 45, "bomb" = XENO_BOMB_RESIST_0, "bio" = 37, "rad" = 37, "fire" = 25, "acid" = 37)
+	soft_armor = list("melee" = 45, "bullet" = 45, "laser" = 45, "energy" = 45, "bomb" = XENO_BOMB_RESIST_0, "bio" = 37, "rad" = 37, "fire" = 25, "acid" = 37)
 
 	// *** Ranged Attack *** //
 	spit_delay = 1 SECONDS

--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
@@ -35,7 +35,7 @@
 	caste_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_EVOLUTION_ALLOWED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER
 
 	// *** Defense *** //
-	armor = list("melee" = 25, "bullet" = 35, "laser" = 25, "energy" = 25, "bomb" = XENO_BOMB_RESIST_0, "bio" = 25, "rad" = 25, "fire" = 15, "acid" = 25)
+	soft_armor = list("melee" = 25, "bullet" = 35, "laser" = 25, "energy" = 25, "bomb" = XENO_BOMB_RESIST_0, "bio" = 25, "rad" = 25, "fire" = 15, "acid" = 25)
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
@@ -77,7 +77,7 @@
 	upgrade_threshold = 260
 
 	// *** Defense *** //
-	armor = list("melee" = 30, "bullet" = 40, "laser" = 30, "energy" = 30, "bomb" = XENO_BOMB_RESIST_0, "bio" = 28, "rad" = 28, "fire" = 18, "acid" = 28)
+	soft_armor = list("melee" = 30, "bullet" = 40, "laser" = 30, "energy" = 30, "bomb" = XENO_BOMB_RESIST_0, "bio" = 28, "rad" = 28, "fire" = 18, "acid" = 28)
 
 /datum/xeno_caste/bull/elder
 	upgrade_name = "Elder"
@@ -105,7 +105,7 @@
 	upgrade_threshold = 480
 
 	// *** Defense *** //
-	armor = list("melee" = 35, "bullet" = 45, "laser" = 35, "energy" = 35, "bomb" = XENO_BOMB_RESIST_0, "bio" = 30, "rad" = 30, "fire" = 20, "acid" = 30)
+	soft_armor = list("melee" = 35, "bullet" = 45, "laser" = 35, "energy" = 35, "bomb" = XENO_BOMB_RESIST_0, "bio" = 30, "rad" = 30, "fire" = 20, "acid" = 30)
 
 /datum/xeno_caste/bull/ancient
 	upgrade_name = "Ancient"
@@ -133,4 +133,4 @@
 	upgrade_threshold = 480
 
 	// *** Defense *** //
-	armor = list("melee" = 40, "bullet" = 50, "laser" = 40, "energy" = 40, "bomb" = XENO_BOMB_RESIST_0, "bio" = 33, "rad" = 33, "fire" = 25, "acid" = 33)
+	soft_armor = list("melee" = 40, "bullet" = 50, "laser" = 40, "energy" = 40, "bomb" = XENO_BOMB_RESIST_0, "bio" = 33, "rad" = 33, "fire" = 25, "acid" = 33)

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/castedatum_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/castedatum_carrier.dm
@@ -39,7 +39,7 @@
 	can_hold_eggs = CAN_HOLD_ONE_HAND
 
 	// *** Defense *** //
-	armor = list("melee" = 15, "bullet" = 15, "laser" = 15, "energy" = 15, "bomb" = XENO_BOMB_RESIST_0, "bio" = 5, "rad" = 5, "fire" = 0, "acid" = 5)
+	soft_armor = list("melee" = 15, "bullet" = 15, "laser" = 15, "energy" = 15, "bomb" = XENO_BOMB_RESIST_0, "bio" = 5, "rad" = 5, "fire" = 0, "acid" = 5)
 
 	// *** Pheromones *** //
 	aura_strength = 1.5
@@ -92,7 +92,7 @@
 	upgrade_threshold = 240
 
 	// *** Defense *** //
-	armor = list("melee" = 20, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = XENO_BOMB_RESIST_0, "bio" = 5, "rad" = 5, "fire" = 0, "acid" = 5)
+	soft_armor = list("melee" = 20, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = XENO_BOMB_RESIST_0, "bio" = 5, "rad" = 5, "fire" = 0, "acid" = 5)
 
 	// *** Pheromones *** //
 	aura_strength = 2
@@ -128,7 +128,7 @@
 	upgrade_threshold = 480
 
 	// *** Defense *** //
-	armor = list("melee" = 25, "bullet" = 25, "laser" = 25, "energy" = 25, "bomb" = XENO_BOMB_RESIST_0, "bio" = 7, "rad" = 7, "fire" = 0, "acid" = 7)
+	soft_armor = list("melee" = 25, "bullet" = 25, "laser" = 25, "energy" = 25, "bomb" = XENO_BOMB_RESIST_0, "bio" = 7, "rad" = 7, "fire" = 0, "acid" = 7)
 
 	// *** Pheromones *** //
 	aura_strength = 2.3
@@ -164,7 +164,7 @@
 	upgrade_threshold = 480
 
 	// *** Defense *** //
-	armor = list("melee" = 30, "bullet" = 30, "laser" = 30, "energy" = 30, "bomb" = XENO_BOMB_RESIST_0, "bio" = 10, "rad" = 10, "fire" = 0, "acid" = 10)
+	soft_armor = list("melee" = 30, "bullet" = 30, "laser" = 30, "energy" = 30, "bomb" = XENO_BOMB_RESIST_0, "bio" = 10, "rad" = 10, "fire" = 0, "acid" = 10)
 
 	// *** Pheromones *** //
 	aura_strength = 2.5

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -35,7 +35,7 @@
 	caste_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER
 
 	// *** Defense *** //
-	armor = list("melee" = 70, "bullet" = 60, "laser" = 60, "energy" = 60, "bomb" = XENO_BOMB_RESIST_3, "bio" = 80, "rad" = 80, "fire" = 0, "acid" = 80)
+	soft_armor = list("melee" = 70, "bullet" = 60, "laser" = 60, "energy" = 60, "bomb" = XENO_BOMB_RESIST_3, "bio" = 80, "rad" = 80, "fire" = 0, "acid" = 80)
 
 	// *** Crusher Abilities *** //
 	actions = list(
@@ -77,7 +77,7 @@
 	upgrade_threshold = 500
 
 	// *** Defense *** //
-	armor = list("melee" = 75, "bullet" = 65, "laser" = 65, "energy" = 65, "bomb" = XENO_BOMB_RESIST_3, "bio" = 90, "rad" = 90, "fire" = 0, "acid" = 90)
+	soft_armor = list("melee" = 75, "bullet" = 65, "laser" = 65, "energy" = 65, "bomb" = XENO_BOMB_RESIST_3, "bio" = 90, "rad" = 90, "fire" = 0, "acid" = 90)
 
 /datum/xeno_caste/crusher/elder
 	upgrade_name = "Elder"
@@ -105,7 +105,7 @@
 	upgrade_threshold = 1000
 
 	// *** Defense *** //
-	armor = list("melee" = 80, "bullet" = 70, "laser" = 70, "energy" = 70, "bomb" = XENO_BOMB_RESIST_3, "bio" = 95, "rad" = 95, "fire" = 0, "acid" = 95)
+	soft_armor = list("melee" = 80, "bullet" = 70, "laser" = 70, "energy" = 70, "bomb" = XENO_BOMB_RESIST_3, "bio" = 95, "rad" = 95, "fire" = 0, "acid" = 95)
 
 /datum/xeno_caste/crusher/ancient
 	upgrade_name = "Ancient"
@@ -130,4 +130,4 @@
 	max_health = 350
 
 	// *** Defense *** //
-	armor = list("melee" = 90, "bullet" = 75, "laser" = 75, "energy" = 75, "bomb" = XENO_BOMB_RESIST_3, "bio" = 100, "rad" = 100, "fire" = 0, "acid" = 100)
+	soft_armor = list("melee" = 90, "bullet" = 75, "laser" = 75, "energy" = 75, "bomb" = XENO_BOMB_RESIST_3, "bio" = 100, "rad" = 100, "fire" = 0, "acid" = 100)

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -277,7 +277,7 @@
 			to_chat(src, "<span class='xenowarning'>We tuck ourselves into a defensive stance.</span>")
 		GLOB.round_statistics.defender_crest_lowerings++
 		SSblackbox.record_feedback("tally", "round_statistics", 1, "defender_crest_lowerings")
-		armor = armor.setRating(bomb = XENO_BOMB_RESIST_2)
+		soft_armor = soft_armor.setRating(bomb = XENO_BOMB_RESIST_2)
 		armor_bonus += xeno_caste.crest_defense_armor
 		add_movespeed_modifier(MOVESPEED_ID_CRESTDEFENSE, TRUE, 0, NONE, TRUE, DEFENDER_CRESTDEFENSE_SLOWDOWN)
 	else
@@ -285,7 +285,7 @@
 			to_chat(src, "<span class='xenowarning'>We raise our crest.</span>")
 		GLOB.round_statistics.defender_crest_raises++
 		SSblackbox.record_feedback("tally", "round_statistics", 1, "defender_crest_raises")
-		armor = armor.setRating(bomb = XENO_BOMB_RESIST_0)
+		soft_armor = soft_armor.setRating(bomb = XENO_BOMB_RESIST_0)
 		armor_bonus -= xeno_caste.crest_defense_armor
 		remove_movespeed_modifier(MOVESPEED_ID_CRESTDEFENSE)
 	update_icons()
@@ -336,12 +336,12 @@
 		if(!silent)
 			to_chat(src, "<span class='xenowarning'>We tuck ourselves into a defensive stance.</span>")
 		armor_bonus += xeno_caste.fortify_armor
-		armor = armor.setRating(bomb = XENO_BOMB_RESIST_3)
+		soft_armor = soft_armor.setRating(bomb = XENO_BOMB_RESIST_3)
 	else
 		if(!silent)
 			to_chat(src, "<span class='xenowarning'>We resume our normal stance.</span>")
 		armor_bonus -= xeno_caste.fortify_armor
-		armor = armor.setRating(bomb = XENO_BOMB_RESIST_0)
+		soft_armor = soft_armor.setRating(bomb = XENO_BOMB_RESIST_0)
 	fortify = on
 	set_frozen(on)
 	anchored = on

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
@@ -36,7 +36,7 @@
 	caste_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_EVOLUTION_ALLOWED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER
 
 	// *** Defense *** //
-	armor = list("melee" = 30, "bullet" = 30, "laser" = 25, "energy" = 20, "bomb" = XENO_BOMB_RESIST_2, "bio" = 20, "rad" = 20, "fire" = 5, "acid" = 20)
+	soft_armor = list("melee" = 30, "bullet" = 30, "laser" = 25, "energy" = 20, "bomb" = XENO_BOMB_RESIST_2, "bio" = 20, "rad" = 20, "fire" = 5, "acid" = 20)
 
 	// *** Ranged Attack *** //
 	charge_type = CHARGE_TYPE_LARGE
@@ -84,7 +84,7 @@
 	upgrade_threshold = 120
 
 	// *** Defense *** //
-	armor = list("melee" = 33, "bullet" = 33, "laser" = 28, "energy" = 25, "bomb" = XENO_BOMB_RESIST_2, "bio" = 25, "rad" = 25, "fire" = 7, "acid" = 25)
+	soft_armor = list("melee" = 33, "bullet" = 33, "laser" = 28, "energy" = 25, "bomb" = XENO_BOMB_RESIST_2, "bio" = 25, "rad" = 25, "fire" = 7, "acid" = 25)
 
 	// *** Defender Abilities *** //
 	crest_defense_armor = 26
@@ -115,7 +115,7 @@
 	upgrade_threshold = 240
 
 	// *** Defense *** //
-	armor = list("melee" = 35, "bullet" = 35, "laser" = 30, "energy" = 28, "bomb" = XENO_BOMB_RESIST_2, "bio" = 28, "rad" = 28, "fire" = 9, "acid" = 28)
+	soft_armor = list("melee" = 35, "bullet" = 35, "laser" = 30, "energy" = 28, "bomb" = XENO_BOMB_RESIST_2, "bio" = 28, "rad" = 28, "fire" = 9, "acid" = 28)
 
 	// *** Defender Abilities *** //
 	crest_defense_armor = 30
@@ -147,7 +147,7 @@
 	upgrade_threshold = 240
 
 	// *** Defense *** //
-	armor = list("melee" = 40, "bullet" = 40, "laser" = 40, "energy" = 40, "bomb" = XENO_BOMB_RESIST_2, "bio" = 30, "rad" = 30, "fire" = 10, "acid" = 30)
+	soft_armor = list("melee" = 40, "bullet" = 40, "laser" = 40, "energy" = 40, "bomb" = XENO_BOMB_RESIST_2, "bio" = 30, "rad" = 30, "fire" = 10, "acid" = 30)
 
 	// *** Defender Abilities *** //
 	crest_defense_armor = 30

--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/castedatum_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/castedatum_defiler.dm
@@ -35,7 +35,7 @@
 	caste_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_EVOLUTION_ALLOWED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER|CASTE_CAN_VENT_CRAWL
 
 	// *** Defense *** //
-	armor = list("melee" = 30, "bullet" = 25, "laser" = 15, "energy" = 30, "bomb" = XENO_BOMB_RESIST_0, "bio" = 30, "rad" = 30, "fire" = 10, "acid" = 30)
+	soft_armor = list("melee" = 30, "bullet" = 25, "laser" = 15, "energy" = 30, "bomb" = XENO_BOMB_RESIST_0, "bio" = 30, "rad" = 30, "fire" = 10, "acid" = 30)
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
@@ -82,7 +82,7 @@
 	upgrade_threshold = 500
 
 	// *** Defense *** //
-	armor = list("melee" = 35, "bullet" = 30, "laser" = 30, "energy" = 30, "bomb" = XENO_BOMB_RESIST_0, "bio" = 35, "rad" = 35, "fire" = 12, "acid" = 35)
+	soft_armor = list("melee" = 35, "bullet" = 30, "laser" = 30, "energy" = 30, "bomb" = XENO_BOMB_RESIST_0, "bio" = 35, "rad" = 35, "fire" = 12, "acid" = 35)
 
 	// *** Pheromones *** //
 	aura_strength = 2 //Defilers aura begins at 1.7 and ends at 2.6. It's .1 better than a carrier at ancient.
@@ -113,7 +113,7 @@
 	upgrade_threshold = 1000
 
 	// *** Defense *** //
-	armor = list("melee" = 38, "bullet" = 35, "laser" = 35, "energy" = 35, "bomb" = XENO_BOMB_RESIST_0, "bio" = 38, "rad" = 38, "fire" = 14, "acid" = 38)
+	soft_armor = list("melee" = 38, "bullet" = 35, "laser" = 35, "energy" = 35, "bomb" = XENO_BOMB_RESIST_0, "bio" = 38, "rad" = 38, "fire" = 14, "acid" = 38)
 
 		// *** Pheromones *** //
 	aura_strength = 2.1 //Defilers aura begins at 1.7 and ends at 2.6. It's .1 better than a carrier at ancient.
@@ -144,7 +144,7 @@
 	upgrade_threshold = 1000
 
 	// *** Defense *** //
-	armor = list("melee" = 40, "bullet" = 40, "laser" = 40, "energy" = 40, "bomb" = XENO_BOMB_RESIST_0, "bio" = 40, "rad" = 40, "fire" = 20, "acid" = 40)
+	soft_armor = list("melee" = 40, "bullet" = 40, "laser" = 40, "energy" = 40, "bomb" = XENO_BOMB_RESIST_0, "bio" = 40, "rad" = 40, "fire" = 20, "acid" = 40)
 
 	// *** Pheromones *** //
 	aura_strength = 2.6 //Defilers aura begins at 1.7 and ends at 2.6. It's .1 better than a carrier at ancient.

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
@@ -36,7 +36,7 @@
 	can_hold_eggs = CAN_HOLD_TWO_HANDS
 
 	// *** Defense *** //
-	armor = list("melee" = 10, "bullet" = 10, "laser" = 10, "energy" = 10, "bomb" = XENO_BOMB_RESIST_0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+	soft_armor = list("melee" = 10, "bullet" = 10, "laser" = 10, "energy" = 10, "bomb" = XENO_BOMB_RESIST_0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 
 	// *** Pheromones *** //
 	aura_strength = 1 //Drone's aura is the weakest. At the top of their evolution, it's equivalent to a Young Queen Climbs by 0.5 to 2
@@ -88,7 +88,7 @@
 	upgrade_threshold = 120
 
 	// *** Defense *** //
-	armor = list("melee" = 17, "bullet" = 17, "laser" = 17, "energy" = 17, "bomb" = XENO_BOMB_RESIST_0, "bio" = 5, "rad" = 5, "fire" = 5, "acid" = 5)
+	soft_armor = list("melee" = 17, "bullet" = 17, "laser" = 17, "energy" = 17, "bomb" = XENO_BOMB_RESIST_0, "bio" = 5, "rad" = 5, "fire" = 5, "acid" = 5)
 
 	// *** Pheromones *** //
 	aura_strength = 1.5
@@ -119,7 +119,7 @@
 	upgrade_threshold = 240
 
 	// *** Defense *** //
-	armor = list("melee" = 24, "bullet" = 24, "laser" = 24, "energy" = 24, "bomb" = XENO_BOMB_RESIST_0, "bio" = 10, "rad" = 10, "fire" = 10, "acid" = 10)
+	soft_armor = list("melee" = 24, "bullet" = 24, "laser" = 24, "energy" = 24, "bomb" = XENO_BOMB_RESIST_0, "bio" = 10, "rad" = 10, "fire" = 10, "acid" = 10)
 
 	// *** Pheromones *** //
 	aura_strength = 1.8
@@ -147,7 +147,7 @@
 	max_health = 250
 
 	// *** Defense *** //
-	armor = list("melee" = 31, "bullet" = 31, "laser" = 31, "energy" = 31, "bomb" = XENO_BOMB_RESIST_0, "bio" = 15, "rad" = 15, "fire" = 15, "acid" = 15)
+	soft_armor = list("melee" = 31, "bullet" = 31, "laser" = 31, "energy" = 31, "bomb" = XENO_BOMB_RESIST_0, "bio" = 15, "rad" = 15, "fire" = 15, "acid" = 15)
 
 	// *** Pheromones *** //
 	aura_strength = 2

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/castedatum_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/castedatum_hivelord.dm
@@ -37,7 +37,7 @@
 	can_hold_eggs = CAN_HOLD_TWO_HANDS
 
 	// *** Defense *** //
-	armor = list("melee" = 15, "bullet" = 15, "laser" = 15, "energy" = 15, "bomb" = XENO_BOMB_RESIST_0, "bio" = 10, "rad" = 10, "fire" = 10, "acid" = 10)
+	soft_armor = list("melee" = 15, "bullet" = 15, "laser" = 15, "energy" = 15, "bomb" = XENO_BOMB_RESIST_0, "bio" = 10, "rad" = 10, "fire" = 10, "acid" = 10)
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.3 SECONDS
@@ -92,7 +92,7 @@
 	upgrade_threshold = 240
 
 	// *** Defense *** //
-	armor = list("melee" = 20, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = XENO_BOMB_RESIST_0, "bio" = 15, "rad" = 15, "fire" = 15, "acid" = 15)
+	soft_armor = list("melee" = 20, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = XENO_BOMB_RESIST_0, "bio" = 15, "rad" = 15, "fire" = 15, "acid" = 15)
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.3 SECONDS
@@ -126,7 +126,7 @@
 	upgrade_threshold = 480
 
 	// *** Defense *** //
-	armor = list("melee" = 25, "bullet" = 25, "laser" = 25, "energy" = 25, "bomb" = XENO_BOMB_RESIST_0, "bio" = 18, "rad" = 18, "fire" = 18, "acid" = 18)
+	soft_armor = list("melee" = 25, "bullet" = 25, "laser" = 25, "energy" = 25, "bomb" = XENO_BOMB_RESIST_0, "bio" = 18, "rad" = 18, "fire" = 18, "acid" = 18)
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.3 SECONDS
@@ -161,7 +161,7 @@
 	upgrade_threshold = 480
 
 	// *** Defense *** //
-	armor = list("melee" = 30, "bullet" = 30, "laser" = 30, "energy" = 30, "bomb" = XENO_BOMB_RESIST_0, "bio" = 20, "rad" = 20, "fire" = 20, "acid" = 20)
+	soft_armor = list("melee" = 30, "bullet" = 30, "laser" = 30, "energy" = 30, "bomb" = XENO_BOMB_RESIST_0, "bio" = 20, "rad" = 20, "fire" = 20, "acid" = 20)
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.3 SECONDS

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/castedatum_hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/castedatum_hivemind.dm
@@ -36,7 +36,7 @@
 	can_hold_eggs = CANNOT_HOLD_EGGS
 
 	// *** Defense *** //
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = XENO_BOMB_RESIST_0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+	soft_armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = XENO_BOMB_RESIST_0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 
 	// *** Ranged Attack *** //
 	spit_delay = 0 SECONDS

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
@@ -38,7 +38,7 @@
 	caste_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_EVOLUTION_ALLOWED|CASTE_CAN_VENT_CRAWL|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER
 
 	// *** Defense *** //
-	armor = list("melee" = 15, "bullet" = 15, "laser" = 15, "energy" = 15, "bomb" = XENO_BOMB_RESIST_0, "bio" = 10, "rad" = 10, "fire" = 0, "acid" = 10)
+	soft_armor = list("melee" = 15, "bullet" = 15, "laser" = 15, "energy" = 15, "bomb" = XENO_BOMB_RESIST_0, "bio" = 10, "rad" = 10, "fire" = 0, "acid" = 10)
 
 	// *** Ranged Attack *** //
 	charge_type = CHARGE_TYPE_MEDIUM
@@ -83,7 +83,7 @@
 	upgrade_threshold = 240
 
 	// *** Defense *** //
-	armor = list("melee" = 20, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = XENO_BOMB_RESIST_0, "bio" = 15, "rad" = 15, "fire" = 5, "acid" = 15)
+	soft_armor = list("melee" = 20, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = XENO_BOMB_RESIST_0, "bio" = 15, "rad" = 15, "fire" = 5, "acid" = 15)
 
 	// *** Ranged Attack *** //
 	pounce_delay = 12.5 SECONDS
@@ -114,7 +114,7 @@
 	upgrade_threshold = 480
 
 	// *** Defense *** //
-	armor = list("melee" = 25, "bullet" = 25, "laser" = 25, "energy" = 25, "bomb" = XENO_BOMB_RESIST_0, "bio" = 18, "rad" = 18, "fire" = 7, "acid" = 18)
+	soft_armor = list("melee" = 25, "bullet" = 25, "laser" = 25, "energy" = 25, "bomb" = XENO_BOMB_RESIST_0, "bio" = 18, "rad" = 18, "fire" = 7, "acid" = 18)
 
 	// *** Ranged Attack *** //
 	pounce_delay = 11.0 SECONDS
@@ -146,7 +146,7 @@
 	upgrade_threshold = 480
 
 	// *** Defense *** //
-	armor = list("melee" = 30, "bullet" = 30, "laser" = 30, "energy" = 30, "bomb" = XENO_BOMB_RESIST_0, "bio" = 18, "rad" = 18, "fire" = 10, "acid" = 18)
+	soft_armor = list("melee" = 30, "bullet" = 30, "laser" = 30, "energy" = 30, "bomb" = XENO_BOMB_RESIST_0, "bio" = 18, "rad" = 18, "fire" = 10, "acid" = 18)
 
 	// *** Ranged Attack *** //
 	pounce_delay = 10.0 SECONDS

--- a/code/modules/mob/living/carbon/xenomorph/castes/larva/castedatum_larva.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/larva/castedatum_larva.dm
@@ -31,7 +31,7 @@
 	caste_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_EVOLUTION_ALLOWED|CASTE_CAN_VENT_CRAWL|CASTE_INNATE_HEALING|CASTE_DECAY_PROOF
 
 	// *** Defense *** //
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = XENO_BOMB_RESIST_0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+	soft_armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = XENO_BOMB_RESIST_0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 
 	// *** Abilities *** //
 	actions = list(

--- a/code/modules/mob/living/carbon/xenomorph/castes/panther/castedatum_panther.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/panther/castedatum_panther.dm
@@ -39,7 +39,7 @@
 	caste_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_EVOLUTION_ALLOWED|CASTE_CAN_VENT_CRAWL|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER
 
 	// *** Defense *** //
-	armor = list("melee" = 10, "bullet" = 10, "laser" = 10, "energy" = 5, "bomb" = XENO_BOMB_RESIST_0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+	soft_armor = list("melee" = 10, "bullet" = 10, "laser" = 10, "energy" = 5, "bomb" = XENO_BOMB_RESIST_0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 
 	// *** Ranged Attack *** //
 	charge_type = CHARGE_TYPE_PANTHER
@@ -85,7 +85,7 @@
 	upgrade_threshold = 100
 
 	// *** Defense *** //
-	armor = list("melee" = 15, "bullet" = 15, "laser" = 15, "energy" = 15, "bomb" = XENO_BOMB_RESIST_0, "bio" = 3, "rad" = 3, "fire" = 3, "acid" = 3)
+	soft_armor = list("melee" = 15, "bullet" = 15, "laser" = 15, "energy" = 15, "bomb" = XENO_BOMB_RESIST_0, "bio" = 3, "rad" = 3, "fire" = 3, "acid" = 3)
 
 	// *** Ranged Attack *** //
 	pounce_delay = 35.0 SECONDS
@@ -117,7 +117,7 @@
 	upgrade_threshold = 200
 
 	// *** Defense *** //
-	armor = list("melee" = 20, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = XENO_BOMB_RESIST_0, "bio" = 5, "rad" = 5, "fire" = 5, "acid" = 5)
+	soft_armor = list("melee" = 20, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = XENO_BOMB_RESIST_0, "bio" = 5, "rad" = 5, "fire" = 5, "acid" = 5)
 
 	// *** Ranged Attack *** //
 	pounce_delay = 45.0 SECONDS
@@ -150,7 +150,7 @@
 	upgrade_threshold = 200
 
 	// *** Defense *** //
-	armor = list("melee" = 24, "bullet" = 24, "laser" = 24, "energy" = 124, "bomb" = XENO_BOMB_RESIST_0, "bio" = 7, "rad" = 7, "fire" = 7, "acid" = 7)
+	soft_armor = list("melee" = 24, "bullet" = 24, "laser" = 24, "energy" = 124, "bomb" = XENO_BOMB_RESIST_0, "bio" = 7, "rad" = 7, "fire" = 7, "acid" = 7)
 
 	// *** Ranged Attack *** //
 	pounce_delay = 35.0 SECONDS

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
@@ -33,7 +33,7 @@
 	caste_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER
 
 	// *** Defense *** //
-	armor = list("melee" = 30, "bullet" = 35, "laser" = 35, "energy" = 35, "bomb" = XENO_BOMB_RESIST_0, "bio" = 28, "rad" = 28, "fire" = 10, "acid" = 28)
+	soft_armor = list("melee" = 30, "bullet" = 35, "laser" = 35, "energy" = 35, "bomb" = XENO_BOMB_RESIST_0, "bio" = 28, "rad" = 28, "fire" = 10, "acid" = 28)
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.5 SECONDS
@@ -86,7 +86,7 @@
 	upgrade_threshold = 500
 
 	// *** Defense *** //
-	armor = list("melee" = 35, "bullet" = 40, "laser" = 40, "energy" = 40, "bomb" = XENO_BOMB_RESIST_0, "bio" = 33, "rad" = 33, "fire" = 13, "acid" = 33)
+	soft_armor = list("melee" = 35, "bullet" = 40, "laser" = 40, "energy" = 40, "bomb" = XENO_BOMB_RESIST_0, "bio" = 33, "rad" = 33, "fire" = 13, "acid" = 33)
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.5 SECONDS
@@ -120,7 +120,7 @@
 	upgrade_threshold = 1000
 
 	// *** Defense *** //
-	armor = list("melee" = 40, "bullet" = 45, "laser" = 45, "energy" = 45, "bomb" = XENO_BOMB_RESIST_0, "bio" = 35, "rad" = 35, "fire" = 15, "acid" = 35)
+	soft_armor = list("melee" = 40, "bullet" = 45, "laser" = 45, "energy" = 45, "bomb" = XENO_BOMB_RESIST_0, "bio" = 35, "rad" = 35, "fire" = 15, "acid" = 35)
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.5 SECONDS
@@ -152,7 +152,7 @@
 	max_health = 310
 
 	// *** Defense *** //
-	armor = list("melee" = 45, "bullet" = 50, "laser" = 50, "energy" = 50, "bomb" = XENO_BOMB_RESIST_0, "bio" = 38, "rad" = 38, "fire" = 18, "acid" = 38)
+	soft_armor = list("melee" = 45, "bullet" = 50, "laser" = 50, "energy" = 50, "bomb" = XENO_BOMB_RESIST_0, "bio" = 38, "rad" = 38, "fire" = 18, "acid" = 38)
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.5 SECONDS

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
@@ -34,7 +34,7 @@
 	can_hold_eggs = CAN_HOLD_TWO_HANDS
 
 	// *** Defense *** //
-	armor = list("melee" = 50, "bullet" = 50, "laser" = 40, "energy" = 40, "bomb" = XENO_BOMB_RESIST_3, "bio" = 45, "rad" = 45, "fire" = 100, "acid" = 45)
+	soft_armor = list("melee" = 50, "bullet" = 50, "laser" = 40, "energy" = 40, "bomb" = XENO_BOMB_RESIST_3, "bio" = 45, "rad" = 45, "fire" = 100, "acid" = 45)
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.5 SECONDS
@@ -99,7 +99,7 @@
 	upgrade_threshold = 960
 
 	// *** Defense *** //
-	armor = list("melee" = 55, "bullet" = 55, "laser" = 40, "energy" = 40, "bomb" = XENO_BOMB_RESIST_3, "bio" = 50, "rad" = 50, "fire" = 100, "acid" = 50)
+	soft_armor = list("melee" = 55, "bullet" = 55, "laser" = 40, "energy" = 40, "bomb" = XENO_BOMB_RESIST_3, "bio" = 50, "rad" = 50, "fire" = 100, "acid" = 50)
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.3 SECONDS
@@ -135,7 +135,7 @@
 	upgrade_threshold = 1920
 
 	// *** Defense *** //
-	armor = list("melee" = 60, "bullet" = 60, "laser" = 45, "energy" = 45, "bomb" = XENO_BOMB_RESIST_3, "bio" = 55, "rad" = 55, "fire" = 100, "acid" = 55)
+	soft_armor = list("melee" = 60, "bullet" = 60, "laser" = 45, "energy" = 45, "bomb" = XENO_BOMB_RESIST_3, "bio" = 55, "rad" = 55, "fire" = 100, "acid" = 55)
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.3 SECONDS
@@ -171,7 +171,7 @@
 	upgrade_threshold = 1920
 
 	// *** Defense *** //
-	armor = list("melee" = 65, "bullet" = 65, "laser" = 50, "energy" = 50, "bomb" = XENO_BOMB_RESIST_3, "bio" = 60, "rad" = 60, "fire" = 100, "acid" = 60)
+	soft_armor = list("melee" = 65, "bullet" = 65, "laser" = 50, "energy" = 50, "bomb" = XENO_BOMB_RESIST_3, "bio" = 60, "rad" = 60, "fire" = 100, "acid" = 60)
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.3 SECONDS

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
@@ -34,7 +34,7 @@
 	caste_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER
 
 	// *** Defense *** //
-	armor = list("melee" = 35, "bullet" = 40, "laser" = 30, "energy" = 30, "bomb" = XENO_BOMB_RESIST_1, "bio" = 30, "rad" = 30, "fire" = 15, "acid" = 30)
+	soft_armor = list("melee" = 35, "bullet" = 40, "laser" = 30, "energy" = 30, "bomb" = XENO_BOMB_RESIST_1, "bio" = 30, "rad" = 30, "fire" = 15, "acid" = 30)
 
 	// *** Ranged Attack *** //
 	charge_type = CHARGE_TYPE_LARGE
@@ -78,7 +78,7 @@
 	upgrade_threshold = 500
 
 	// *** Defense *** //
-	armor = list("melee" = 40, "bullet" = 45, "laser" = 40, "energy" = 40, "bomb" = XENO_BOMB_RESIST_1, "bio" = 35, "rad" = 35, "fire" = 20, "acid" = 35)
+	soft_armor = list("melee" = 40, "bullet" = 45, "laser" = 40, "energy" = 40, "bomb" = XENO_BOMB_RESIST_1, "bio" = 35, "rad" = 35, "fire" = 20, "acid" = 35)
 
 /datum/xeno_caste/ravager/elder
 	upgrade_name = "Elder"
@@ -106,7 +106,7 @@
 	upgrade_threshold = 1000
 
 	// *** Defense *** //
-	armor = list("melee" = 45, "bullet" = 50, "laser" = 45, "energy" = 45, "bomb" = XENO_BOMB_RESIST_1, "bio" = 38, "rad" = 38, "fire" = 25, "acid" = 38)
+	soft_armor = list("melee" = 45, "bullet" = 50, "laser" = 45, "energy" = 45, "bomb" = XENO_BOMB_RESIST_1, "bio" = 38, "rad" = 38, "fire" = 25, "acid" = 38)
 
 /datum/xeno_caste/ravager/ancient
 	upgrade_name = "Ancient"
@@ -134,4 +134,4 @@
 	upgrade_threshold = 1000
 
 	// *** Defense *** //
-	armor = list("melee" = 50, "bullet" = 55, "laser" = 50, "energy" = 50, "bomb" = XENO_BOMB_RESIST_1, "bio" = 40, "rad" = 40, "fire" = 30, "acid" = 40)
+	soft_armor = list("melee" = 50, "bullet" = 55, "laser" = 50, "energy" = 50, "bomb" = XENO_BOMB_RESIST_1, "bio" = 40, "rad" = 40, "fire" = 30, "acid" = 40)

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravenger/ravenger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravenger/ravenger.dm
@@ -29,7 +29,7 @@
 	caste_flags = CASTE_IS_INTELLIGENT|CASTE_HIDE_IN_STATUS
 
 	// *** Defense *** //
-	armor = list("melee" = 20, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = 20, "bio" = 20, "rad" = 20, "fire" = 20, "acid" = 20)
+	soft_armor = list("melee" = 20, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = 20, "bio" = 20, "rad" = 20, "fire" = 20, "acid" = 20)
 
 	fire_resist = 0.5 //0 to 1; lower is better as it is a multiplier.
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
@@ -40,7 +40,7 @@
 	caste_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_EVOLUTION_ALLOWED|CASTE_CAN_VENT_CRAWL|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER
 
 	// *** Defense *** //
-	armor = list("melee" = 5, "bullet" = 5, "laser" = 5, "energy" = 0, "bomb" = XENO_BOMB_RESIST_0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+	soft_armor = list("melee" = 5, "bullet" = 5, "laser" = 5, "energy" = 0, "bomb" = XENO_BOMB_RESIST_0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 
 	// *** Ranged Attack *** //
 	charge_type = CHARGE_TYPE_SMALL
@@ -88,7 +88,7 @@
 	upgrade_threshold = 120
 
 	// *** Defense *** //
-	armor = list("melee" = 10, "bullet" = 10, "laser" = 10, "energy" = 10, "bomb" = XENO_BOMB_RESIST_0, "bio" = 3, "rad" = 3, "fire" = 3, "acid" = 3)
+	soft_armor = list("melee" = 10, "bullet" = 10, "laser" = 10, "energy" = 10, "bomb" = XENO_BOMB_RESIST_0, "bio" = 3, "rad" = 3, "fire" = 3, "acid" = 3)
 
 	// *** Ranged Attack *** //
 	pounce_delay = 6.0 SECONDS
@@ -121,7 +121,7 @@
 	upgrade_threshold = 240
 
 	// *** Defense *** //
-	armor = list("melee" = 15, "bullet" = 15, "laser" = 15, "energy" = 15, "bomb" = XENO_BOMB_RESIST_0, "bio" = 5, "rad" = 5, "fire" = 5, "acid" = 5)
+	soft_armor = list("melee" = 15, "bullet" = 15, "laser" = 15, "energy" = 15, "bomb" = XENO_BOMB_RESIST_0, "bio" = 5, "rad" = 5, "fire" = 5, "acid" = 5)
 
 	// *** Ranged Attack *** //
 	pounce_delay = 6.0 SECONDS
@@ -155,7 +155,7 @@
 	upgrade_threshold = 240
 
 	// *** Defense *** //
-	armor = list("melee" = 19, "bullet" = 19, "laser" = 19, "energy" = 19, "bomb" = XENO_BOMB_RESIST_0, "bio" = 7, "rad" = 7, "fire" = 7, "acid" = 7)
+	soft_armor = list("melee" = 19, "bullet" = 19, "laser" = 19, "energy" = 19, "bomb" = XENO_BOMB_RESIST_0, "bio" = 7, "rad" = 7, "fire" = 7, "acid" = 7)
 
 	// *** Ranged Attack *** //
 	pounce_delay = 6.0 SECONDS

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/castedatum_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/castedatum_sentinel.dm
@@ -33,7 +33,7 @@
 	caste_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_EVOLUTION_ALLOWED|CASTE_CAN_VENT_CRAWL|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER
 
 	// *** Defense *** //
-	armor = list("melee" = 15, "bullet" = 15, "laser" = 15, "energy" = 15, "bomb" = XENO_BOMB_RESIST_0, "bio" = 15, "rad" = 15, "fire" = 0, "acid" = 15)
+	soft_armor = list("melee" = 15, "bullet" = 15, "laser" = 15, "energy" = 15, "bomb" = XENO_BOMB_RESIST_0, "bio" = 15, "rad" = 15, "fire" = 0, "acid" = 15)
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.3 SECONDS
@@ -79,7 +79,7 @@
 	upgrade_threshold = 120
 
 	// *** Defense *** //
-	armor = list("melee" = 20, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = XENO_BOMB_RESIST_0, "bio" = 20, "rad" = 20, "fire" = 5, "acid" = 20)
+	soft_armor = list("melee" = 20, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = XENO_BOMB_RESIST_0, "bio" = 20, "rad" = 20, "fire" = 5, "acid" = 20)
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.3 SECONDS
@@ -111,7 +111,7 @@
 	upgrade_threshold = 240
 
 	// *** Defense *** //
-	armor = list("melee" = 23, "bullet" = 23, "laser" = 23, "energy" = 23, "bomb" = XENO_BOMB_RESIST_0, "bio" = 23, "rad" = 23, "fire" = 10, "acid" = 23)
+	soft_armor = list("melee" = 23, "bullet" = 23, "laser" = 23, "energy" = 23, "bomb" = XENO_BOMB_RESIST_0, "bio" = 23, "rad" = 23, "fire" = 10, "acid" = 23)
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.3 SECONDS
@@ -143,7 +143,7 @@
 	upgrade_threshold = 240
 
 	// *** Defense *** //
-	armor = list("melee" = 26, "bullet" = 26, "laser" = 26, "energy" = 26, "bomb" = XENO_BOMB_RESIST_0, "bio" = 25, "rad" = 25, "fire" = 15, "acid" = 25)
+	soft_armor = list("melee" = 26, "bullet" = 26, "laser" = 26, "energy" = 26, "bomb" = XENO_BOMB_RESIST_0, "bio" = 25, "rad" = 25, "fire" = 15, "acid" = 25)
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.3 SECONDS

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/castedatum_shrike.dm
@@ -39,7 +39,7 @@
 	can_hold_eggs = CAN_HOLD_TWO_HANDS
 
 	// *** Defense *** //
-	armor = list("melee" = 30, "bullet" = 30, "laser" = 30, "energy" = 30, "bomb" = XENO_BOMB_RESIST_2, "bio" = 10, "rad" = 10, "fire" = 5, "acid" = 10)
+	soft_armor = list("melee" = 30, "bullet" = 30, "laser" = 30, "energy" = 30, "bomb" = XENO_BOMB_RESIST_2, "bio" = 10, "rad" = 10, "fire" = 5, "acid" = 10)
 
 	// *** Pheromones *** //
 	aura_strength = 2 //The Shrike's aura is decent.
@@ -94,7 +94,7 @@
 	upgrade_threshold = 240
 
 	// *** Defense *** //
-	armor = list("melee" = 35, "bullet" = 35, "laser" = 35, "energy" = 35, "bomb" = XENO_BOMB_RESIST_2, "bio" = 15, "rad" = 15, "fire" = 10, "acid" = 15)
+	soft_armor = list("melee" = 35, "bullet" = 35, "laser" = 35, "energy" = 35, "bomb" = XENO_BOMB_RESIST_2, "bio" = 15, "rad" = 15, "fire" = 10, "acid" = 15)
 
 	// *** Pheromones *** //
 	aura_strength = 2.5
@@ -125,7 +125,7 @@
 	upgrade_threshold = 480
 
 	// *** Defense *** //
-	armor = list("melee" = 40, "bullet" = 40, "laser" = 40, "energy" = 40, "bomb" = XENO_BOMB_RESIST_2, "bio" = 18, "rad" = 18, "fire" = 15, "acid" = 18)
+	soft_armor = list("melee" = 40, "bullet" = 40, "laser" = 40, "energy" = 40, "bomb" = XENO_BOMB_RESIST_2, "bio" = 18, "rad" = 18, "fire" = 15, "acid" = 18)
 
 	// *** Pheromones *** //
 	aura_strength = 2.8
@@ -156,7 +156,7 @@
 	upgrade_threshold = 480
 
 	// *** Defense *** //
-	armor = list("melee" = 45, "bullet" = 45, "laser" = 45, "energy" = 45, "bomb" = XENO_BOMB_RESIST_2, "bio" = 23, "rad" = 23, "fire" = 18, "acid" = 20)
+	soft_armor = list("melee" = 45, "bullet" = 45, "laser" = 45, "energy" = 45, "bomb" = XENO_BOMB_RESIST_2, "bio" = 23, "rad" = 23, "fire" = 18, "acid" = 20)
 
 	// *** Pheromones *** //
 	aura_strength = 3

--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
@@ -34,7 +34,7 @@
 	caste_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_EVOLUTION_ALLOWED|CASTE_CAN_VENT_CRAWL|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER
 
 	// *** Defense *** //
-	armor = list("melee" = 10, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = XENO_BOMB_RESIST_0, "bio" = 10, "rad" = 10, "fire" = 5, "acid" = 10)
+	soft_armor = list("melee" = 10, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = XENO_BOMB_RESIST_0, "bio" = 10, "rad" = 10, "fire" = 5, "acid" = 10)
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.5 SECONDS
@@ -82,7 +82,7 @@
 	upgrade_threshold = 240
 
 	// *** Defense *** //
-	armor = list("melee" = 15, "bullet" = 25, "laser" = 25, "energy" = 25, "bomb" = XENO_BOMB_RESIST_0, "bio" = 15, "rad" = 15, "fire" = 7, "acid" = 15)
+	soft_armor = list("melee" = 15, "bullet" = 25, "laser" = 25, "energy" = 25, "bomb" = XENO_BOMB_RESIST_0, "bio" = 15, "rad" = 15, "fire" = 7, "acid" = 15)
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.5 SECONDS
@@ -115,7 +115,7 @@
 	upgrade_threshold = 480
 
 	// *** Defense *** //
-	armor = list("melee" = 20, "bullet" = 30, "laser" = 30, "energy" = 30, "bomb" = XENO_BOMB_RESIST_0, "bio" = 18, "rad" = 18, "fire" = 10, "acid" = 18)
+	soft_armor = list("melee" = 20, "bullet" = 30, "laser" = 30, "energy" = 30, "bomb" = XENO_BOMB_RESIST_0, "bio" = 18, "rad" = 18, "fire" = 10, "acid" = 18)
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.5 SECONDS
@@ -148,7 +148,7 @@
 	upgrade_threshold = 480
 
 	// *** Defense *** //
-	armor = list("melee" = 25, "bullet" = 35, "laser" = 35, "energy" = 35, "bomb" = XENO_BOMB_RESIST_0, "bio" = 20, "rad" = 20, "fire" = 15, "acid" = 20)
+	soft_armor = list("melee" = 25, "bullet" = 35, "laser" = 35, "energy" = 35, "bomb" = XENO_BOMB_RESIST_0, "bio" = 20, "rad" = 20, "fire" = 15, "acid" = 20)
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.5 SECONDS

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/castedatum_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/castedatum_warrior.dm
@@ -35,7 +35,7 @@
 	caste_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_EVOLUTION_ALLOWED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER
 
 	// *** Defense *** //
-	armor = list("melee" = 30, "bullet" = 40, "laser" = 40, "energy" = 30, "bomb" = XENO_BOMB_RESIST_2, "bio" = 36, "rad" = 36, "fire" = 0, "acid" = 36)
+	soft_armor = list("melee" = 30, "bullet" = 40, "laser" = 40, "energy" = 30, "bomb" = XENO_BOMB_RESIST_2, "bio" = 36, "rad" = 36, "fire" = 0, "acid" = 36)
 
 	// *** Warrior Abilities *** //
 	agility_speed_increase = 0
@@ -80,7 +80,7 @@
 	upgrade_threshold = 240
 
 	// *** Defense *** //
-	armor = list("melee" = 34, "bullet" = 45, "laser" = 45, "energy" = 34, "bomb" = XENO_BOMB_RESIST_2, "bio" = 36, "rad" = 36, "fire" = 0, "acid" = 36)
+	soft_armor = list("melee" = 34, "bullet" = 45, "laser" = 45, "energy" = 34, "bomb" = XENO_BOMB_RESIST_2, "bio" = 36, "rad" = 36, "fire" = 0, "acid" = 36)
 
 	// *** Warrior Abilities *** //
 
@@ -110,7 +110,7 @@
 	upgrade_threshold = 480
 
 	// *** Defense *** //
-	armor = list("melee" = 38, "bullet" = 50, "laser" = 50, "energy" = 38, "bomb" = XENO_BOMB_RESIST_2, "bio" = 40, "rad" = 40, "fire" = 0, "acid" = 40)
+	soft_armor = list("melee" = 38, "bullet" = 50, "laser" = 50, "energy" = 38, "bomb" = XENO_BOMB_RESIST_2, "bio" = 40, "rad" = 40, "fire" = 0, "acid" = 40)
 
 	// *** Warrior Abilities *** //
 	agility_speed_increase = 0
@@ -141,7 +141,7 @@
 	upgrade_threshold = 480
 
 	// *** Defense *** //
-	armor = list("melee" = 42, "bullet" = 55, "laser" = 55, "energy" = 42, "bomb" = XENO_BOMB_RESIST_2, "bio" = 50, "rad" = 50, "fire" = 0, "acid" = 50)
+	soft_armor = list("melee" = 42, "bullet" = 55, "laser" = 55, "energy" = 42, "bomb" = XENO_BOMB_RESIST_2, "bio" = 50, "rad" = 50, "fire" = 0, "acid" = 50)
 
 	// *** Warrior Abilities *** //
 	agility_speed_increase = 0

--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -13,7 +13,7 @@
 		for(var/i in stomach_contents)
 			var/mob/living/carbon/prey = i
 			prey.ex_act(severity + 1)
-	var/bomb_armor = armor.getRating("bomb")
+	var/bomb_armor = soft_armor.getRating("bomb")
 	var/b_loss = 0
 	var/f_loss = 0
 	switch(severity)

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -60,7 +60,8 @@
 	var/can_hold_eggs = CANNOT_HOLD_EGGS
 
 	// *** Defense *** //
-	var/list/armor
+	var/list/soft_armor
+	var/list/hard_armor
 
 	var/fire_resist = 1 //0 to 1; lower is better as it is a multiplier.
 

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -157,7 +157,6 @@
 	var/upgrade_stored = 0 //How much upgrade points they have stored.
 	var/upgrade = XENO_UPGRADE_INVALID  //This will track their upgrade level.
 
-	var/datum/armor/armor
 	var/armor_bonus = 0
 	var/armor_pheromone_bonus = 0
 	var/sunder = 0 // sunder affects armour values and does a % removal before dmg is applied. 50 sunder == 50% effective armour values

--- a/code/modules/mob/living/carbon/xenomorph/xenoattacks.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoattacks.dm
@@ -81,7 +81,7 @@
 			H.do_attack_animation(src, ATTACK_EFFECT_YELLOWPUNCH)
 			playsound(loc, attack.attack_sound, 25, TRUE)
 			visible_message("<span class='danger'>[H] [pick(attack.attack_verb)]ed [src]!</span>", null, null, 5)
-			apply_damage(melee_damage + attack.damage, BRUTE, "chest", armor.getRating("melee") + armor_bonus + armor_pheromone_bonus)
+			apply_damage(melee_damage + attack.damage, BRUTE, "chest", soft_armor.getRating("melee") + armor_bonus + armor_pheromone_bonus)
 			UPDATEHEALTH(src)
 
 

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -77,7 +77,12 @@
 	maxHealth = xeno_caste.max_health
 	health = maxHealth
 	setXenoCasteSpeed(xeno_caste.speed)
-	armor = getArmor(arglist(xeno_caste.armor))
+	soft_armor = getArmor(arglist(xeno_caste.soft_armor))
+	hard_armor = getArmor(arglist(xeno_caste.hard_armor))
+
+
+/mob/living/carbon/xenomorph/set_armor_datum()
+	return //Handled in set_datum()
 
 
 /mob/living/carbon/xenomorph/proc/generate_nicknumber()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -80,6 +80,8 @@
 		GLOB.alive_living_list += src
 	START_PROCESSING(SSmobs, src)
 
+	set_armor_datum()
+
 /mob/living/Destroy()
 	for(var/i in embedded_objects)
 		var/obj/item/embedded = i
@@ -149,6 +151,22 @@
 		if(O.type == A)
 			return TRUE
 	return FALSE
+
+
+/mob/living/proc/set_armor_datum()
+	if(islist(soft_armor))
+		soft_armor = getArmor(arglist(soft_armor))
+	else if (!soft_armor)
+		soft_armor = getArmor()
+	else if (!istype(soft_armor, /datum/armor))
+		stack_trace("Invalid type [soft_armor.type] found in .soft_armor during [type] Initialize()")
+
+	if(islist(hard_armor))
+		hard_armor = getArmor(arglist(hard_armor))
+	else if (!hard_armor)
+		hard_armor = getArmor()
+	else if (!istype(hard_armor, /datum/armor))
+		stack_trace("Invalid type [hard_armor.type] found in .hard_armor during [type] Initialize()")
 
 
 /mob/living/proc/get_limbzone_target()

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -15,6 +15,11 @@
 	/// Health at which a mob goes into crit
 	var/health_threshold_crit = 0
 
+	/// %-reduction-based armor.
+	var/datum/armor/soft_armor
+	/// Flat-damage-reduction-based armor.
+	var/datum/armor/hard_armor
+
 	/* Damage related vars, NOTE: THESE SHOULD ONLY BE MODIFIED BY PROCS */
 	/// Brutal damage caused by brute force (punching, being clubbed by a toolbox ect... this also accounts for pressure damage)
 	var/bruteloss = 0

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -1073,13 +1073,13 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 /datum/limb/proc/add_limb_soft_armor(datum/armor/added_armor)
 	soft_armor = soft_armor.attachArmor(added_armor)
-	var/datum/armor/scaled_armor = added_armor.scaleAllRatings(cover_index * 0.01)
+	var/datum/armor/scaled_armor = added_armor.scaleAllRatings(cover_index * 0.01, 1)
 	owner.soft_armor = owner.soft_armor.attachArmor(scaled_armor)
 
 
 /datum/limb/proc/remove_limb_soft_armor(datum/armor/removed_armor)
 	soft_armor = soft_armor.detachArmor(removed_armor)
-	var/datum/armor/scaled_armor = removed_armor.scaleAllRatings(cover_index * 0.01)
+	var/datum/armor/scaled_armor = removed_armor.scaleAllRatings(cover_index * 0.01, 1)
 	owner.soft_armor = owner.soft_armor.detachArmor(scaled_armor)
 
 

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -14,7 +14,8 @@
 	var/last_dam = -1
 	var/supported = FALSE
 
-	var/datum/armor/armor
+	var/datum/armor/soft_armor
+	var/datum/armor/hard_armor
 
 	var/display_name
 	var/list/wounds = list()
@@ -55,6 +56,9 @@
 	var/vital //Lose a vital limb, die immediately.
 	var/germ_level = 0		// INTERNAL germs inside the organ, this is BAD if it's greater than INFECTION_LEVEL_ONE
 
+	///What % of the body does this limb cover.
+	var/cover_index = 0
+
 
 /datum/limb/New(datum/limb/P, mob/mob_owner)
 	if(P)
@@ -64,7 +68,8 @@
 		parent.children.Add(src)
 	if(mob_owner)
 		owner = mob_owner
-	armor = getArmor()
+	soft_armor = getArmor()
+	hard_armor = getArmor()
 	return ..()
 
 /*
@@ -1066,6 +1071,16 @@ Note that amputating the affected organ does in fact remove the infection from t
 	cavity = 0
 
 
+/datum/limb/proc/add_limb_soft_armor(datum/armor/added_armor)
+	soft_armor = soft_armor.attachArmor(added_armor)
+	var/datum/armor/scaled_armor = added_armor.scaleAllRatings(cover_index * 0.01)
+	owner.soft_armor = owner.soft_armor.attachArmor(scaled_armor)
+
+
+/datum/limb/proc/remove_limb_soft_armor(datum/armor/removed_armor)
+	soft_armor = soft_armor.detachArmor(removed_armor)
+	var/datum/armor/scaled_armor = removed_armor.scaleAllRatings(cover_index * 0.01)
+	owner.soft_armor = owner.soft_armor.detachArmor(scaled_armor)
 
 
 /****************************************************
@@ -1079,7 +1094,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 	max_damage = 200
 	min_broken_damage = 60
 	body_part = CHEST
-	vital = 1
+	vital = TRUE
+	cover_index = 27
 	encased = "ribcage"
 
 /datum/limb/groin
@@ -1089,7 +1105,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 	max_damage = 200
 	min_broken_damage = 60
 	body_part = GROIN
-	vital = 1
+	vital = TRUE
+	cover_index = 9
 
 /datum/limb/l_arm
 	name = "l_arm"
@@ -1098,6 +1115,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	max_damage = 100
 	min_broken_damage = 50
 	body_part = ARM_LEFT
+	cover_index = 7
 
 	process()
 		..()
@@ -1110,6 +1128,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	max_damage = 100
 	min_broken_damage = 50
 	body_part = LEG_LEFT
+	cover_index = 14
 	icon_position = LEFT
 
 /datum/limb/r_arm
@@ -1119,6 +1138,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	max_damage = 100
 	min_broken_damage = 50
 	body_part = ARM_RIGHT
+	cover_index = 7
 
 	process()
 		..()
@@ -1131,6 +1151,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	max_damage = 100
 	min_broken_damage = 50
 	body_part = LEG_RIGHT
+	cover_index = 14
 	icon_position = RIGHT
 
 /datum/limb/foot/l_foot
@@ -1140,6 +1161,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	max_damage = 75
 	min_broken_damage = 37
 	body_part = FOOT_LEFT
+	cover_index = 4
 	icon_position = LEFT
 
 /datum/limb/foot/r_foot
@@ -1149,6 +1171,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	max_damage = 75
 	min_broken_damage = 37
 	body_part = FOOT_RIGHT
+	cover_index = 4
 	icon_position = RIGHT
 
 /datum/limb/hand/r_hand
@@ -1158,6 +1181,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	max_damage = 75
 	min_broken_damage = 37
 	body_part = HAND_RIGHT
+	cover_index = 2
 
 	process()
 		..()
@@ -1170,6 +1194,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	max_damage = 75
 	min_broken_damage = 37
 	body_part = HAND_LEFT
+	cover_index = 2
 
 	process()
 		..()
@@ -1182,7 +1207,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 	max_damage = 100
 	min_broken_damage = 40
 	body_part = HEAD
-	vital = 1
+	vital = TRUE
+	cover_index = 10
 	encased = "skull"
 	var/disfigured = 0 //whether the head is disfigured.
 	var/face_surgery_stage = 0

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -56,7 +56,7 @@
 	var/vital //Lose a vital limb, die immediately.
 	var/germ_level = 0		// INTERNAL germs inside the organ, this is BAD if it's greater than INFECTION_LEVEL_ONE
 
-	///What % of the body does this limb cover.
+	///What % of the body does this limb cover. Make sure that the sum is always 100.
 	var/cover_index = 0
 
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -858,7 +858,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 
 /mob/living/carbon/human/get_hard_armor(armor_type, proj_def_zone, proj_dir)
 	var/datum/limb/affected_limb = get_limb(check_zone(proj_def_zone))
-	return affected_limb.hard_armor.getRating(type)
+	return affected_limb.hard_armor.getRating(armor_type)
 
 /mob/living/carbon/xenomorph/get_hard_armor(armor_type, proj_def_zone, proj_dir)
 	return ..() * get_sunder()

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1012,32 +1012,32 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 
 /mob/living/carbon/xenomorph/bullet_message(obj/projectile/proj, feedback_flags)
 	. = ..()
-	var/onlooker_feedback = "[src] is hit by the [proj] in the [parse_zone(proj.def_zone)]!"
+	var/list/onlooker_feedback = list("[src] is hit by the [proj] in the [parse_zone(proj.def_zone)]!")
 
-	var/victim_feedback
+	var/list/victim_feedback
 	if(proj.ammo.flags_ammo_behavior & AMMO_IS_SILENCED)
-		victim_feedback = "We've been shot in the [parse_zone(proj.def_zone)] by [proj]!"
+		victim_feedback = list("We've been shot in the [parse_zone(proj.def_zone)] by [proj]!")
 	else
-		victim_feedback = "We are hit by the [proj] in the [parse_zone(proj.def_zone)]!"
+		victim_feedback = list("We are hit by the [proj] in the [parse_zone(proj.def_zone)]!")
 
 	if(feedback_flags & BULLET_FEEDBACK_IMMUNE)
-		victim_feedback += " Our exoskeleton deflects it!"
-		onlooker_feedback += " [p_their(TRUE)] thick exoskeleton deflects it!"
+		victim_feedback += "Our exoskeleton deflects it!"
+		onlooker_feedback += "[p_their(TRUE)] thick exoskeleton deflects it!"
 	else if(feedback_flags & BULLET_FEEDBACK_SOAK)
-		victim_feedback += " Our exoskeleton absorbs it!"
-		onlooker_feedback += " [p_their(TRUE)] thick exoskeleton absorbs it!"
+		victim_feedback += "Our exoskeleton absorbs it!"
+		onlooker_feedback += "[p_their(TRUE)] thick exoskeleton absorbs it!"
 	else if(feedback_flags & BULLET_FEEDBACK_PEN)
-		victim_feedback += " Our exoskeleton was penetrated!"
+		victim_feedback += "Our exoskeleton was penetrated!"
 
 	if(feedback_flags & BULLET_FEEDBACK_FIRE)
-		victim_feedback += " We burst into flames!! Auuugh! Resist to put out the flames!"
+		victim_feedback += "We burst into flames!! Auuugh! Resist to put out the flames!"
 		onlooker_feedback += "[p_they(TRUE)] burst into flames!"
 
 	if(feedback_flags & BULLET_FEEDBACK_SCREAM && stat == CONSCIOUS)
 		emote(prob(70) ? "hiss" : "roar")
 
-	visible_message("<span class='danger'>[onlooker_feedback]</span>",
-	"<span class='xenodanger'>[victim_feedback]", null, 4)
+	visible_message("<span class='danger'>[onlooker_feedback.Join(" ")]</span>",
+	"<span class='xenodanger'>[victim_feedback.Join(" ")]", null, 4)
 
 // Sundering procs
 /mob/living/proc/adjust_sunder(adjustment)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -745,35 +745,40 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 
 	var/feedback_flags = NONE
 
-	var/living_armor = (proj.ammo.flags_ammo_behavior & AMMO_IGNORE_ARMOR) ? 0 : get_living_armor(proj.armor_type, proj.def_zone, proj.dir)
-	if(living_armor)
+	var/hard_armor = (proj.ammo.flags_ammo_behavior & AMMO_IGNORE_ARMOR) ? 0 : get_hard_armor(proj.armor_type, proj.def_zone, proj.dir)
+	var/soft_armor = (proj.ammo.flags_ammo_behavior & AMMO_IGNORE_ARMOR) ? 0 : get_soft_armor(proj.armor_type, proj.def_zone, proj.dir)
+	if(hard_armor || soft_armor)
 		var/penetration = proj.ammo.penetration
 		if(penetration > 0)
 			if(proj.shot_from && src == proj.shot_from.sniper_target(src))
 				damage *= SNIPER_LASER_DAMAGE_MULTIPLIER
 				penetration *= SNIPER_LASER_ARMOR_MULTIPLIER
 				add_slowdown(SNIPER_LASER_SLOWDOWN_STACKS)
-			living_armor -= penetration
-		switch(living_armor)
-			if(-INFINITY to 0) //Armor fully penetrated.
-				feedback_flags |= BULLET_FEEDBACK_PEN
-			if(100 to INFINITY) //Damage invulnerability.
+			if(hard_armor)
+				hard_armor = max(0, hard_armor - (hard_armor * penetration * 0.01)) //AP reduces a % of hard armor.
+			if(soft_armor)
+				soft_armor = max(0, soft_armor - penetration) //Flat removal.
+
+		if(!hard_armor && !soft_armor) //Armor fully penetrated.
+			feedback_flags |= BULLET_FEEDBACK_PEN
+		else
+			if(hard_armor)
+				damage = max(0, damage - hard_armor) //Damage soak.
+			if(!damage) //Damage fully soaked.
+				bullet_soak_effect(proj)
+				feedback_flags |= BULLET_FEEDBACK_IMMUNE
+			else if(soft_armor >= 100) //Damage invulnerability.
 				damage = 0
 				bullet_soak_effect(proj)
 				feedback_flags |= BULLET_FEEDBACK_IMMUNE
-			else
-				damage = max(0, damage - (living_armor * 0.1)) //Hard armor, damage soak. 10% of the armor's value.
-				if(!damage) //Damage fully soaked.
-					bullet_soak_effect(proj)
-					feedback_flags |= BULLET_FEEDBACK_SOAK
-				else
-					living_armor *= 0.9 //Remove the 10% that was used to soak damage.
-					damage -= damage * living_armor * 0.01 //Soft armor/padding, damage reduction.
+			else if(soft_armor) //Soft armor/padding, damage reduction.
+				feedback_flags |= BULLET_FEEDBACK_SOAK
+				damage -= damage * soft_armor * 0.01
 
 	if(proj.ammo.flags_ammo_behavior & AMMO_INCENDIARY)
-		living_armor = get_living_armor("fire", proj.def_zone) //This value could potentially be negative, indicating fire weakness.
-		if(living_armor < 100) //If armor is 100 or over the mob is fireproof.
-			adjust_fire_stacks(CEILING(10 - (10 * (living_armor / 100)), 1)) //We could add an ammo fire strength in time, as a variable.
+		soft_armor = get_soft_armor("fire", proj.def_zone) //This value could potentially be negative, indicating fire weakness.
+		if(soft_armor < 100) //If armor is 100 or over the mob is fireproof.
+			adjust_fire_stacks(CEILING(10 - (soft_armor * 0.1), 1)) //We could add an ammo fire strength in time, as a variable.
 			IgniteMob()
 			feedback_flags |= (BULLET_FEEDBACK_FIRE|BULLET_FEEDBACK_SCREAM)
 
@@ -835,16 +840,26 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 	return ..()
 
 
-/mob/living/proc/get_living_armor(armor_type, proj_def_zone, proj_dir)
-	return 0
+/mob/living/proc/get_soft_armor(armor_type, proj_def_zone, proj_dir)
+	return soft_armor.getRating(armor_type)
+
+/mob/living/carbon/human/get_soft_armor(armor_type, proj_def_zone, proj_dir)
+	var/datum/limb/affected_limb = get_limb(check_zone(proj_def_zone))
+	return affected_limb.soft_armor.getRating(type)
+
+/mob/living/carbon/xenomorph/get_soft_armor(armor_type, proj_def_zone, proj_dir)
+	return ..() * get_sunder()
 
 
-/mob/living/carbon/human/get_living_armor(armor_type, proj_def_zone, proj_dir)
-	return getarmor_organ(get_limb(check_zone(proj_def_zone)), armor_type) //Should always have a type; this defaults to bullet if nothing else.
+/mob/living/proc/get_hard_armor(armor_type, proj_def_zone, proj_dir)
+	return hard_armor.getRating(armor_type)
 
+/mob/living/carbon/human/get_hard_armor(armor_type, proj_def_zone, proj_dir)
+	var/datum/limb/affected_limb = get_limb(check_zone(proj_def_zone))
+	return affected_limb.hard_armor.getRating(type)
 
-/mob/living/carbon/xenomorph/get_living_armor(armor_type, proj_def_zone, proj_dir)
-	. = (armor.getRating(armor_type) + armor_bonus + armor_pheromone_bonus) * get_sunder()
+/mob/living/carbon/xenomorph/get_hard_armor(armor_type, proj_def_zone, proj_dir)
+	return ..() * get_sunder()
 
 
 /mob/living/proc/bullet_soak_effect(obj/projectile/proj)


### PR DESCRIPTION
* Introduces the concept of hard and soft armor and generalizes it for all `living`. Sur wanted to add a soak variable before, and this can play the part. Soft armor is our regular armor, it reduces incoming damage by its value read as a %. Hard armor is what the soak was, it reduces damage by a flat value.

* Removed the 10% of the armor value being soak by default. This balance change can be reverted by adding actual hard armor to specific things as necessary. Personally I'd recommend against using it much, as it promotes spiky balance, making tanky castes tankier instead of the linear scaling soft armor offers. But in the future it might be useful for actual tanks / armored vehicles and whatnot. For now it only works, as before, for projectile damage.

* Since all `living` have armor(s) datums now, and humans already have armor datums on the limbs, added the concept of a human global armor that is made by the sum of all limb armor values scaled to the limb size by approximate body surface (represented by the % `cover_index` limb var, the sum of them reaching 100). This could be used environment damage and the likes.

## Changelog
:cl:
balance: Projectile damage soak zeroed. This means armors scale linearly against bullets, instead of high armors negating exponetially more damage against low values. In other words, high-armor nerf against bullets (and xeno spits).
/:cl: