### PR TITLE
Zoom and bipod fixes

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -141,6 +141,19 @@ GLOBAL_REAL_VAR(list/stack_trace_storage)
 	else if(. >= 360)
 		. -= 360
 
+// Adjusts the target if the user has their view offset and is firing onto a null location (deep darknes)
+proc/darkness_adjust(atom/target, mob/living/user)
+	var/newtargetX = target.x
+	var/newtargetY = target.y
+	var/newtarget
+	if (user.client.pixel_x != 0)
+		newtargetX = target.x + (user.client.pixel_x/32)
+	if (user.client.pixel_y != 0)
+		newtargetY = target.y + (user.client.pixel_y/32)
+
+	newtarget = locate(newtargetX,newtargetY,target.z)
+
+	return newtarget
 
 /proc/angle_to_dir(angle)
 	switch(angle)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -19,7 +19,7 @@
 /atom/Click(location, control, params)
 	if(flags_atom & INITIALIZED)
 		SEND_SIGNAL(src, COMSIG_CLICK, location, control, params, usr)
-		usr.ClickOn(src, params)
+		usr.ClickOn(src, params, location)
 
 
 /atom/DblClick(location, control, params)
@@ -45,7 +45,12 @@
 	* item/afterattack(atom, user, adjacent, params) - used both ranged and adjacent when not handled by attackby
 	* mob/RangedAttack(atom, params) - used only ranged, only used for tk and laser eyes but could be changed
 */
-/mob/proc/ClickOn(atom/A, params)
+/mob/proc/ClickOn(atom/A, params, location)
+
+	//Adjusts the target when shooting into darkness AND view is offset
+	if(isnull(location) && (src.client.pixel_x != 0 || src.client.pixel_y != 0))
+		A = darkness_adjust(A, src)
+
 	if(world.time <= next_click)
 		return
 	next_click = world.time + 1
@@ -69,7 +74,7 @@
 	if(modifiers["ctrl"] && modifiers["middle"])
 		CtrlMiddleClickOn(A)
 		return
-	if(modifiers["middle"] && MiddleClickOn(A))		
+	if(modifiers["middle"] && MiddleClickOn(A))
 		return
 	if(modifiers["shift"] && ShiftClickOn(A))
 		return
@@ -138,7 +143,7 @@
 			if(proximity && A.attackby(W, src, params))
 				attack = TRUE
 			if(!attack)
-				W.afterattack(A, src, proximity, params)
+				W.afterattack(A, src, proximity, params, location)
 		else
 			if(A.Adjacent(src))
 				A.attack_hand(src)

--- a/code/datums/components/full_auto_fire.dm
+++ b/code/datums/components/full_auto_fire.dm
@@ -281,7 +281,7 @@
 		if(-1 to 0)
 			target = get_step(shooter, shooter.dir) //Shoot in the direction faced if the mouse is on the same tile as we are.
 			target_loc = target
-		if(8 to INFINITY) //Can technically only go as far as 127 right now.
+		if(127 to INFINITY) //Can technically only go as far as 127 right now.
 			stop_autofiring() //Elvis has left the building.
 			return FALSE
 	shooter.face_atom(target)

--- a/code/datums/components/full_auto_fire.dm
+++ b/code/datums/components/full_auto_fire.dm
@@ -148,6 +148,8 @@
 		modifiers["icon-x"] = num2text(ABS_PIXEL_TO_REL(text2num(modifiers["icon-x"])))
 		modifiers["icon-y"] = num2text(ABS_PIXEL_TO_REL(text2num(modifiers["icon-y"])))
 		params = list2params(modifiers)
+		if(source.pixel_x != 0 || source.pixel_y != 0)
+			target = darkness_adjust(target, shooter)
 
 	if(SEND_SIGNAL(src, COMSIG_AUTOFIRE_ONMOUSEDOWN, source, target, location, control, params) & COMPONENT_AUTOFIRE_ONMOUSEDOWN_BYPASS)
 		return
@@ -257,6 +259,8 @@
 		modifiers["icon-y"] = num2text(ABS_PIXEL_TO_REL(text2num(modifiers["icon-y"])))
 		params = list2params(modifiers)
 		mouse_parameters = params
+		if(source.pixel_x != 0 || source.pixel_y != 0)
+			new_target = darkness_adjust(target, shooter)
 		if(!new_target)
 			if(QDELETED(target)) //No new target acquired, and old one was deleted, get us out of here.
 				stop_autofiring()

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1402,6 +1402,7 @@ Defined in conflicts.dm of the #defines folder.
 	if(bipod_deployed)
 		bipod_deployed = FALSE
 		to_chat(user, "<span class='notice'>You retract [src].</span>")
+		master_gun.aim_slowdown -= 1
 		master_gun.wield_delay -= 0.4 SECONDS
 		master_gun.accuracy_mult -= deployment_accuracy_mod
 		master_gun.recoil -= deployment_recoil_mod


### PR DESCRIPTION
## About The Pull Request

Fixes 3 bugs

- Bipods correctly reduce aim slowdown when being retracted
- Autofire has its range increased so it can be used while zoomed, keeping it consistent with regular fire
- Firing into darkness now finds the correct turf to target

## Why It's Good For The Game

fixes the bug with snipers turning 180° and FFing when firing into darkness

## Changelog
:cl:
fix: fixes a bipod and some zoom issues
/:cl:

