### PR TITLE
Fixes razorwire runtime and cleans up code

### DIFF
--- a/code/game/objects/structures/razorwire.dm
+++ b/code/game/objects/structures/razorwire.dm
@@ -65,10 +65,10 @@
 /obj/structure/razorwire/proc/do_razorwire_tangle(mob/living/entangled)
 	ADD_TRAIT(entangled, TRAIT_IMMOBILE, type)
 	ENABLE_BITFIELD(entangled.restrained_flags, RESTRAINED_RAZORWIRE)
-	entangled.entangled_by = src
 	LAZYADD(entangled_list, entangled) //Add the entangled person to the trapped list.
 	RegisterSignal(entangled, COMSIG_LIVING_DO_RESIST, /atom/movable.proc/resisted_against)
 	RegisterSignal(entangled, COMSIG_PARENT_QDELETING, .proc/do_razorwire_untangle)
+	RegisterSignal(entangled, COMSIG_MOVABLE_UNCROSS, .proc/on_entangled_uncross)
 
 
 /obj/structure/razorwire/resisted_against(datum/source)
@@ -92,20 +92,16 @@
 	return TRUE
 
 
+///This proc is used for signals, so if you plan on adding a second argument, or making it return a value, then change those RegisterSignal's referncing it first.
 /obj/structure/razorwire/proc/do_razorwire_untangle(mob/living/entangled)
-	UnregisterSignal(entangled, list(COMSIG_PARENT_QDELETING, COMSIG_LIVING_DO_RESIST))
+	UnregisterSignal(entangled, list(COMSIG_PARENT_QDELETING, COMSIG_LIVING_DO_RESIST, COMSIG_MOVABLE_UNCROSS))
 	LAZYREMOVE(entangled_list, entangled)
-	entangled.entangled_by = null
 	DISABLE_BITFIELD(entangled.restrained_flags, RESTRAINED_RAZORWIRE)
 	REMOVE_TRAIT(entangled, TRAIT_IMMOBILE, type)
 
 
-/obj/structure/razorwire/CheckExit(atom/movable/O as mob|obj, target as turf)
-	if(isliving(O))
-		var/mob/living/M = O
-		if(M.entangled_by)
-			razorwire_untangle(M)
-	return ..()
+/obj/structure/razorwire/proc/on_entangled_uncross(datum/source, atom/movable/uncrosser)
+	razorwire_untangle(uncrosser)
 
 
 /obj/structure/razorwire/Destroy()

--- a/code/game/objects/structures/razorwire.dm
+++ b/code/game/objects/structures/razorwire.dm
@@ -10,7 +10,7 @@
 	throwpass = TRUE	//You can throw objects over this
 	climbable = TRUE
 	resistance_flags = XENO_DAMAGEABLE
-	var/list/entangled_list = list()
+	var/list/entangled_list
 	var/sheet_type = /obj/item/stack/barbed_wire
 	var/sheet_type2 = /obj/item/stack/rods
 	var/table_prefix = "" //used in update_icon()
@@ -52,17 +52,23 @@
 	UPDATEHEALTH(M)
 	razorwire_tangle(M)
 
-/obj/structure/razorwire/proc/razorwire_tangle(mob/living/M, duration = RAZORWIRE_ENTANGLE_DELAY)
+
+/obj/structure/razorwire/proc/razorwire_tangle(mob/living/entangled, duration = RAZORWIRE_ENTANGLE_DELAY)
 	if(QDELETED(src)) //Sanity check so that you can't get entangled if the razorwire is destroyed; this happens apparently.
-		return
-	COOLDOWN_START(M, COOLDOWN_ENTANGLE, duration)
-	M.visible_message("<span class='danger'>[M] gets entangled in the barbed wire!</span>",
+		CRASH("QDELETED razorwire called razorwire_tangle()")
+	COOLDOWN_START(entangled, COOLDOWN_ENTANGLE, duration)
+	entangled.visible_message("<span class='danger'>[entangled] gets entangled in the barbed wire!</span>",
 	"<span class='danger'>You got entangled in the barbed wire! Resist to untangle yourself after [duration * 0.1] seconds since you were entangled!</span>", null, null, 5)
-	M.set_frozen(TRUE)
-	entangled_list += M //Add the entangled person to the trapped list.
-	M.entangled_by = src
-	ENABLE_BITFIELD(M.restrained_flags, RESTRAINED_RAZORWIRE)
-	RegisterSignal(M, COMSIG_LIVING_DO_RESIST, /atom/movable.proc/resisted_against)
+	do_razorwire_tangle()
+
+
+/obj/structure/razorwire/proc/do_razorwire_tangle(mob/living/entangled)
+	entangled.set_frozen(TRUE)
+	ENABLE_BITFIELD(entangled.restrained_flags, RESTRAINED_RAZORWIRE)
+	entangled.entangled_by = src
+	LAZYADD(entangled_list, entangled) //Add the entangled person to the trapped list.
+	RegisterSignal(entangled, COMSIG_LIVING_DO_RESIST, /atom/movable.proc/resisted_against)
+	RegisterSignal(entangled, COMSIG_PARENT_QDELETING, .proc/do_razorwire_untangle)
 
 
 /obj/structure/razorwire/resisted_against(datum/source)
@@ -74,21 +80,24 @@
 	return razorwire_untangle(entangled)
 
 
-/obj/structure/razorwire/proc/razorwire_untangle(mob/living/M)
-	var/armor_block = null
+/obj/structure/razorwire/proc/razorwire_untangle(mob/living/entangled)
+	entangled.next_move_slowdown += RAZORWIRE_SLOWDOWN //big slowdown
+	do_razorwire_untangle(entangled)
+	visible_message("<span class='danger'>[entangled] disentangles from [src]!</span>")
+	playsound(src, 'sound/effects/barbed_wire_movement.ogg', 25, TRUE)
 	var/def_zone = ran_zone()
-	armor_block = M.run_armor_check(def_zone, "melee")
-	visible_message("<span class='danger'>[M] disentangles from [src]!</span>")
-	playsound(src, 'sound/effects/barbed_wire_movement.ogg', 25, 1)
-	entangled_list -= M
-	M.entangled_by = null
-	M.set_frozen(FALSE)
-	M.apply_damage(rand(RAZORWIRE_BASE_DAMAGE * 0.8, RAZORWIRE_BASE_DAMAGE * 1.2), BRUTE, def_zone, armor_block, TRUE) //Apply damage as we tear free
-	UPDATEHEALTH(M)
-	M.next_move_slowdown += RAZORWIRE_SLOWDOWN //big slowdown
-	DISABLE_BITFIELD(M.restrained_flags, RESTRAINED_RAZORWIRE)
-	UnregisterSignal(M, COMSIG_LIVING_DO_RESIST)
+	var/armor_block = entangled.run_armor_check(def_zone, "melee")
+	entangled.apply_damage(rand(RAZORWIRE_BASE_DAMAGE * 0.8, RAZORWIRE_BASE_DAMAGE * 1.2), BRUTE, def_zone, armor_block, TRUE) //Apply damage as we tear free
+	UPDATEHEALTH(entangled)
 	return TRUE
+
+
+/obj/structure/razorwire/proc/do_razorwire_untangle(mob/living/entangled)
+	UnregisterSignal(entangled, list(COMSIG_PARENT_QDELETING, COMSIG_LIVING_DO_RESIST))
+	LAZYREMOVE(entangled_list, entangled)
+	entangled.entangled_by = null
+	DISABLE_BITFIELD(entangled.restrained_flags, RESTRAINED_RAZORWIRE)
+	entangled.set_frozen(FALSE)
 
 
 /obj/structure/razorwire/CheckExit(atom/movable/O as mob|obj, target as turf)
@@ -98,14 +107,12 @@
 			razorwire_untangle(M)
 	return ..()
 
+
 /obj/structure/razorwire/Destroy()
 	for(var/i in entangled_list)
-		var/mob/living/L = i
-		L.set_frozen(FALSE)
-		if(L.entangled_by == src)
-			L.entangled_by = null
-	entangled_list.Cut()
+		do_razorwire_untangle(i)
 	return ..()
+
 
 /obj/structure/razorwire/attackby(obj/item/I, mob/user, params)
 	. = ..()

--- a/code/game/objects/structures/razorwire.dm
+++ b/code/game/objects/structures/razorwire.dm
@@ -63,7 +63,7 @@
 
 
 /obj/structure/razorwire/proc/do_razorwire_tangle(mob/living/entangled)
-	entangled.set_frozen(TRUE)
+	ADD_TRAIT(entangled, TRAIT_IMMOBILE, type)
 	ENABLE_BITFIELD(entangled.restrained_flags, RESTRAINED_RAZORWIRE)
 	entangled.entangled_by = src
 	LAZYADD(entangled_list, entangled) //Add the entangled person to the trapped list.
@@ -97,7 +97,7 @@
 	LAZYREMOVE(entangled_list, entangled)
 	entangled.entangled_by = null
 	DISABLE_BITFIELD(entangled.restrained_flags, RESTRAINED_RAZORWIRE)
-	entangled.set_frozen(FALSE)
+	REMOVE_TRAIT(entangled, TRAIT_IMMOBILE, type)
 
 
 /obj/structure/razorwire/CheckExit(atom/movable/O as mob|obj, target as turf)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -102,8 +102,6 @@
 
 	var/fire_resist = 1 //0 to 1; lower is better as it is a multiplier.
 
-	var/entangled_by
-
 	var/ventcrawl_layer = PIPING_LAYER_DEFAULT
 
 	var/grab_resist_level = 0 //Every time we try to resist a grab, we increment this by 1 until it exceeds the grab level, thereby breaking the grab.


### PR DESCRIPTION
* Turns `entangled_list` into a lazy list.
* Turns the set_frozen into a proper trait for source tracing.

It seems things were getting deleted but not cleared up from `entangled_list`