### PR TITLE
mind references cleaning

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -44,6 +44,13 @@
 	src.key = key
 
 
+/datum/mind/Destroy(force, ...)
+	current = null
+	if(initial_account)
+		QDEL_NULL(initial_account)
+	return ..()
+
+
 /datum/mind/proc/transfer_to(mob/new_character, force_key_move = FALSE)
 	if(current)	// remove ourself from our old body's mind variable
 		current.mind = null

--- a/code/modules/mob/dead/observer/logout.dm
+++ b/code/modules/mob/dead/observer/logout.dm
@@ -14,4 +14,5 @@
 	if(QDELETED(src) || (key && !isaghost(src)))
 		return
 
+	mind = null //We no longer need a reference to this mind.
 	QDEL_IN(src, 2)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -12,7 +12,7 @@
 	ghostize()
 	clear_fullscreens()
 	if(mind)
-		stack_trace("Found a reference to an undeleted mind in mob/Destroy()")
+		stack_trace("Found a reference to an undeleted mind in mob/Destroy(). Mind name: [mind.name]. Mind mob: [mind.current]")
 		mind = null
 	if(hud_used)
 		QDEL_NULL(hud_used)

--- a/code/modules/mob/new_player/logout.dm
+++ b/code/modules/mob/new_player/logout.dm
@@ -5,4 +5,5 @@
 	. = ..()
 	if(!spawning)//Here so that if they are spawning and log out, the other procs can play out and they will have a mob to come back to.
 		key = null//We null their key before deleting the mob, so they are properly kicked out.
+		QDEL_NULL(mind)
 		qdel(src)


### PR DESCRIPTION
`new_player` mobs deleted themselves but not the mind or account if any when logging out.
Ghosts kept a reference to the old mind on deletion when the player respawned back to lobby.

In short the current behavior is that the `mind` datum will be preserved through disconnections unless the person is in the lobby, in which their association with a character is gone.