### PR TITLE
Cigarette tweaks

### DIFF
--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -18180,7 +18180,7 @@
 /area/mainship/shipboard/brig_cells)
 "aOl" = (
 /obj/structure/table/mainship,
-/obj/item/storage/fancy/cigarettes/lucky_strikes,
+/obj/item/storage/fancy/cigarettes/luckystarss,
 /obj/item/tool/lighter,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/brig_cells)
@@ -34577,7 +34577,7 @@
 	pixel_y = 3
 	},
 /obj/item/storage/box/tgmc_mre,
-/obj/item/storage/fancy/cigarettes/lucky_strikes,
+/obj/item/storage/fancy/cigarettes/luckystarss,
 /turf/open/floor/mainship{
 	dir = 4;
 	icon_state = "greencorner"

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -18180,7 +18180,7 @@
 /area/mainship/shipboard/brig_cells)
 "aOl" = (
 /obj/structure/table/mainship,
-/obj/item/storage/fancy/cigarettes/luckystarss,
+/obj/item/storage/fancy/cigarettes/luckystars,
 /obj/item/tool/lighter,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/brig_cells)
@@ -34577,7 +34577,7 @@
 	pixel_y = 3
 	},
 /obj/item/storage/box/tgmc_mre,
-/obj/item/storage/fancy/cigarettes/luckystarss,
+/obj/item/storage/fancy/cigarettes/luckystars,
 /turf/open/floor/mainship{
 	dir = 4;
 	icon_state = "greencorner"

--- a/_maps/map_files/Tyson_Station/Tyson_Station.dmm
+++ b/_maps/map_files/Tyson_Station/Tyson_Station.dmm
@@ -6475,7 +6475,7 @@
 /area/hallway/secondary/entry)
 "avs" = (
 /obj/structure/window/framed/colony,
-/obj/item/storage/fancy/cigarettes/luckystarss{
+/obj/item/storage/fancy/cigarettes/luckystars{
 	pixel_x = 31
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{

--- a/_maps/map_files/Tyson_Station/Tyson_Station.dmm
+++ b/_maps/map_files/Tyson_Station/Tyson_Station.dmm
@@ -6475,7 +6475,7 @@
 /area/hallway/secondary/entry)
 "avs" = (
 /obj/structure/window/framed/colony,
-/obj/item/storage/fancy/cigarettes/lucky_strikes{
+/obj/item/storage/fancy/cigarettes/luckystarss{
 	pixel_x = 31
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{

--- a/_maps/map_files/Whiskey_Outpost/Whiskey_Outpost_v2.dmm
+++ b/_maps/map_files/Whiskey_Outpost/Whiskey_Outpost_v2.dmm
@@ -1478,7 +1478,7 @@
 /area/whiskey_outpost)
 "eA" = (
 /obj/structure/table,
-/obj/item/storage/fancy/cigarettes/luckystarss,
+/obj/item/storage/fancy/cigarettes/luckystars,
 /turf/open/floor/tile/whiteyellow/full,
 /area/whiskey_outpost)
 "eC" = (
@@ -1954,7 +1954,7 @@
 /area/whiskey_outpost)
 "fK" = (
 /obj/structure/table,
-/obj/item/storage/fancy/cigarettes/luckystarss,
+/obj/item/storage/fancy/cigarettes/luckystars,
 /obj/item/tool/lighter/zippo,
 /turf/open/floor/tile/whiteyellow/full,
 /area/whiskey_outpost)

--- a/_maps/map_files/Whiskey_Outpost/Whiskey_Outpost_v2.dmm
+++ b/_maps/map_files/Whiskey_Outpost/Whiskey_Outpost_v2.dmm
@@ -1478,7 +1478,7 @@
 /area/whiskey_outpost)
 "eA" = (
 /obj/structure/table,
-/obj/item/storage/fancy/cigarettes/lucky_strikes,
+/obj/item/storage/fancy/cigarettes/luckystarss,
 /turf/open/floor/tile/whiteyellow/full,
 /area/whiskey_outpost)
 "eC" = (
@@ -1954,7 +1954,7 @@
 /area/whiskey_outpost)
 "fK" = (
 /obj/structure/table,
-/obj/item/storage/fancy/cigarettes/lucky_strikes,
+/obj/item/storage/fancy/cigarettes/luckystarss,
 /obj/item/tool/lighter/zippo,
 /turf/open/floor/tile/whiteyellow/full,
 /area/whiskey_outpost)

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -173,9 +173,9 @@
 	icon_state = "ntpacket"
 	item_state = "ntpacket"
 
-/obj/item/storage/fancy/cigarettes/lucky_strikes
-	name = "\improper Lucky Strikes packet"
-	desc = "Lucky Strikes Means Fine Tobacco! 9/10 doctors agree on Lucky Strikes...as the leading cause of marine lung cancer."
+/obj/item/storage/fancy/cigarettes/luckystars
+	name = "\improper Lucky Stars packet"
+	desc = "A mellow blend made from synthetic, pod-grown tobacco. The commercial jingle is guaranteed to get stuck in your head."
 	icon_state = "lspacket"
 	item_state = "lspacket"
 

--- a/code/game/objects/machinery/vending/vending_types.dm
+++ b/code/game/objects/machinery/vending/vending_types.dm
@@ -127,12 +127,23 @@
 
 /obj/machinery/vending/cigarette
 	name = "cigarette machine" //OCD had to be uppercase to look nice with the new formating
-	desc = "If you want to get cancer, might as well do it in style!"
-	product_slogans = "L.S./M.F.T.! Lucky Strikes Means Fine Tobacco.;For a classic style that lights up every time, there's always Zippo!;The FDA would like to remind you that tobacco products cause cancer and increased fatigue.;Real men smoke Lucky Strikes!;Serving the US Armed Forces for over two-hundred years!;Life's short, smoke a Lucky!;L.S./M.F.T.!;Lucky Strike is first again!;You just can't beat a Lucky Strike!;The preferred cigarette of Carlos Hathcock!;First again with tobacco-men!"
-	product_ads = "Real men smoke Lucky Strikes!;Serving the US Armed Forces for over two-hundred years!;Life's short, smoke a Lucky!;L.S./M.F.T.!;Lucky Strike is first again!;You just can't beat a Lucky Strike!;The preferred cigarette of Carlos Hathcock!;First again with tobacco-men!"
+	desc = "A specialized vending machine designed to contribute to your slow and uncomfortable death."
+	product_slogans = "There's no better time to start smokin'.;\
+		Smoke now, and win the adoration of your peers.;\
+		They beat cancer centuries ago, so smoke away.;\
+		If you're not smoking, you must be joking."
+	product_ads = "Probably not bad for you!;\
+		Don't believe the scientists!;\
+		It's good for you!;\
+		Don't quit, buy more!;\
+		Smoke!;\
+		Nicotine heaven.;\
+		Best cigarettes since 2150.;\
+		Don't be so hard on yourself, kid. Smoke a Lucky Star!;\
+		Professionals. Better cigarettes for better people. Yes, better people."
 	vend_delay = 14
 	icon_state = "cigs"
-	products = list(/obj/item/storage/fancy/cigarettes/lucky_strikes = 50,
+	products = list(/obj/item/storage/fancy/cigarettes/luckystars = 50,
 					/obj/item/storage/box/matches = 15,
 					/obj/item/tool/lighter/random = 25,
 					/obj/item/tool/lighter/zippo = 10)
@@ -140,7 +151,7 @@
 	contraband = list(/obj/item/clothing/mask/cigarette/cigar/havana = 5)
 
 	premium = list(/obj/item/storage/fancy/cigar = 25)
-	prices = list(/obj/item/storage/fancy/cigarettes/lucky_strikes = 15,
+	prices = list(/obj/item/storage/fancy/cigarettes/luckystars = 15,
 					/obj/item/storage/box/matches = 1,
 					/obj/item/tool/lighter/random = 2,
 					/obj/item/tool/lighter/zippo = 20,

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -198,7 +198,7 @@
 						/obj/item/storage/box/matches = "helmet_matches",
 						/obj/item/storage/fancy/cigarettes = "helmet_cig_kpack",
 						/obj/item/storage/fancy/cigarettes/kpack = "helmet_cig_kpack",
-						/obj/item/storage/fancy/cigarettes/lucky_strikes = "helmet_cig_ls",
+						/obj/item/storage/fancy/cigarettes/luckystars = "helmet_cig_ls",
 						/obj/item/storage/fancy/cigarettes/dromedaryco = "helmet_cig_kpack",
 						/obj/item/storage/fancy/cigarettes/lady_finger = "helmet_cig_lf",
 						/obj/item/toy/deck = "helmet_card_card",


### PR DESCRIPTION
Chiefly removes a real brand's name from the code and the reference to the US Armed Forces.
Copypasted the replacement from Bay.