### PR TITLE
Disables ship explosions during crashes [TEST MERGE]

### DIFF
--- a/code/modules/shuttle/gamemodes/crash.dm
+++ b/code/modules/shuttle/gamemodes/crash.dm
@@ -41,15 +41,15 @@
 
 
 	// Big explosions
-	explosion(front, 3, 4, 7, 0)
-	explosion(rear, 3, 4, 7, 0)
-	explosion(left, 3, 4, 7, 0)
-	explosion(right, 3, 4, 7, 0)
+	// explosion(front, 3, 4, 7, 0)
+	// explosion(rear, 3, 4, 7, 0)
+	// explosion(left, 3, 4, 7, 0)
+	// explosion(right, 3, 4, 7, 0)
 
-	explosion(front_right, 4, 6, 10, 0)
-	explosion(front_left, 4, 6, 10, 0)
-	explosion(rear_right, 4, 6, 10, 0)
-	explosion(rear_left, 3, 4, 7, 0)
+	// explosion(front_right, 4, 6, 10, 0)
+	// explosion(front_left, 4, 6, 10, 0)
+	// explosion(rear_right, 4, 6, 10, 0)
+	// explosion(rear_left, 3, 4, 7, 0)
 
 
 /obj/docking_port/stationary/crashmode/loading

--- a/code/modules/shuttle/gamemodes/crash.dm
+++ b/code/modules/shuttle/gamemodes/crash.dm
@@ -9,49 +9,6 @@
 	dheight = 12
 
 
-/obj/docking_port/stationary/crashmode/on_crash()
-	//clear areas around the shuttle with explosions
-	var/turf/C = return_center_turf()
-
-	var/cos = 1
-	var/sin = 0
-	switch(dir)
-		if(WEST)
-			cos = 0
-			sin = 1
-		if(SOUTH)
-			cos = -1
-			sin = 0
-		if(EAST)
-			cos = 0
-			sin = -1
-
-	var/updown = (round(width/2))*sin + (round(height/2))*cos
-	var/leftright = (round(width/2))*cos - (round(height/2))*sin
-
-	var/turf/front = locate(C.x, C.y - updown, C.z)
-	var/turf/rear = locate(C.x, C.y + updown, C.z)
-	var/turf/left = locate(C.x - leftright, C.y, C.z)
-	var/turf/right = locate(C.x + leftright, C.y, C.z)
-
-	var/turf/front_right = locate(C.x - round(leftright/2), C.y - round(updown/2), C.z)
-	var/turf/front_left = locate(C.x + round(leftright/2), C.y - round(updown/2), C.z)
-	var/turf/rear_right = locate(C.x - round(leftright/2), C.y + round(updown/2), C.z)
-	var/turf/rear_left = locate(C.x + round(leftright/2), C.y + round(updown/2), C.z)
-
-
-	// Big explosions
-	// explosion(front, 3, 4, 7, 0)
-	// explosion(rear, 3, 4, 7, 0)
-	// explosion(left, 3, 4, 7, 0)
-	// explosion(right, 3, 4, 7, 0)
-
-	// explosion(front_right, 4, 6, 10, 0)
-	// explosion(front_left, 4, 6, 10, 0)
-	// explosion(rear_right, 4, 6, 10, 0)
-	// explosion(rear_left, 3, 4, 7, 0)
-
-
 /obj/docking_port/stationary/crashmode/loading
 	id = "canterbury_loadingdock"
 	name = "Low Orbit"

--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -43,34 +43,6 @@
 
 	GLOB.enter_allowed = FALSE //No joining after dropship crash
 
-	//clear areas around the shuttle with explosions
-	var/turf/C = return_center_turf()
-
-	var/cos = 1
-	var/sin = 0
-	switch(dir)
-		if(WEST)
-			cos = 0
-			sin = 1
-		if(SOUTH)
-			cos = -1
-			sin = 0
-		if(EAST)
-			cos = 0
-			sin = -1
-
-	var/updown = (round(width/2))*sin + (round(height/2))*cos
-	var/leftright = (round(width/2))*cos - (round(height/2))*sin
-
-	var/turf/front = locate(C.x, C.y - updown, C.z)
-	var/turf/rear = locate(C.x, C.y + updown, C.z)
-	var/turf/left = locate(C.x - leftright, C.y, C.z)
-	var/turf/right = locate(C.x + leftright, C.y, C.z)
-
-	// explosion(front, 2, 4, 7, 0)
-	// explosion(rear, 3, 5, 8, 0)
-	// explosion(left, 3, 5, 8, 0)
-	// explosion(right, 3, 5, 8, 0)
 
 /obj/docking_port/stationary/marine_dropship/crash_target
 	name = "dropshipcrash"

--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -67,10 +67,10 @@
 	var/turf/left = locate(C.x - leftright, C.y, C.z)
 	var/turf/right = locate(C.x + leftright, C.y, C.z)
 
-	explosion(front, 2, 4, 7, 0)
-	explosion(rear, 3, 5, 8, 0)
-	explosion(left, 3, 5, 8, 0)
-	explosion(right, 3, 5, 8, 0)
+	// explosion(front, 2, 4, 7, 0)
+	// explosion(rear, 3, 5, 8, 0)
+	// explosion(left, 3, 5, 8, 0)
+	// explosion(right, 3, 5, 8, 0)
 
 /obj/docking_port/stationary/marine_dropship/crash_target
 	name = "dropshipcrash"


### PR DESCRIPTION
Explosions are currently killing marines when they land, this disables that for the time being.