### PR TITLE
should fix shuttle explosions

### DIFF
--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -290,7 +290,7 @@ This way we'll be able to draw the explosion's expansion path without having to 
 
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_EXPLOSION, epicenter, devastation_range, heavy_impact_range, light_impact_range, (REALTIMEOFDAY - started_at) * 0.1)
 
-/datum/controller/subsystem/explosions/proc/wipe_turf(var/turf/T)
+/datum/controller/subsystem/explosions/proc/wipe_turf(turf/T)
 	highTurf -= T
 	medTurf -= T
 	lowTurf -= T

--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -290,6 +290,12 @@ This way we'll be able to draw the explosion's expansion path without having to 
 
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_EXPLOSION, epicenter, devastation_range, heavy_impact_range, light_impact_range, (REALTIMEOFDAY - started_at) * 0.1)
 
+/datum/controller/subsystem/explosions/proc/wipe_turf(var/turf/T)
+	highTurf -= T
+	medTurf -= T
+	lowTurf -= T
+	flameturf -= T
+	throwTurf -= T
 
 /datum/controller/subsystem/explosions/fire(resumed = FALSE)
 	if(!(length(lowTurf) || length(medTurf) || length(highTurf) || length(flameturf) || length(throwTurf) || length(lowMovAtom) || length(medMovAtom) || length(highMovAtom)))

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -68,7 +68,9 @@ All ShuttleMove procs go here
 // Called on the new turf after everything has been moved
 /turf/proc/afterShuttleMove(turf/oldT, rotation)
 	//Dealing with the turf we left behind
-//	oldT.TransferComponents(src)
+	oldT.TransferComponents(src)
+	SSexplosions.wipe_turf(src)
+
 	var/shuttle_boundary = baseturfs.Find(/turf/baseturf_skipover/shuttle)
 	if(shuttle_boundary)
 		oldT.ScrapeAway(baseturfs.len - shuttle_boundary + 1)
@@ -112,8 +114,8 @@ All ShuttleMove procs go here
 	if (newT.z != oldT.z)
 		onTransitZ(oldT.z, newT.z)
 
-//	if(light)
-//		update_light()
+	if(light)
+		update_light()
 	if(rotation)
 		shuttleRotate(rotation)
 
@@ -149,7 +151,7 @@ All ShuttleMove procs go here
 
 	contents -= oldT
 	underlying_old_area.contents += oldT
-//	oldT.change_area(src, underlying_old_area) //lighting
+	oldT.change_area(src, underlying_old_area) //lighting
 	//The old turf has now been given back to the area that turf originaly belonged to
 
 	var/area/old_dest_area = newT.loc
@@ -157,7 +159,7 @@ All ShuttleMove procs go here
 
 	old_dest_area.contents -= newT
 	contents += newT
-//	newT.change_area(old_dest_area, src) //lighting
+	newT.change_area(old_dest_area, src) //lighting
 	return TRUE
 
 // Called on areas after everything has been moved


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This should fix the issue of explosions happening to shuttle turfs for explosions that started before it moved.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: explosions no longer happen on shuttles after they move to an exploding turf
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
