### PR TITLE
Support draw_mode for internal storage

### DIFF
--- a/code/game/objects/items/storage/internal.dm
+++ b/code/game/objects/items/storage/internal.dm
@@ -1,6 +1,7 @@
 //A storage item intended to be used by other items to provide storage functionality.
 //Types that use this should consider overriding emp_act() and hear_talk(), unless they shield their contents somehow.
 /obj/item/storage/internal
+	allow_drawing_method = FALSE /// Unable to set draw_mode ourselves
 	var/obj/item/master_item
 
 /obj/item/storage/internal/Initialize()
@@ -90,27 +91,31 @@
 /obj/item/storage/internal/proc/handle_attack_hand(mob/user as mob)
 
 	if(user.lying_angle)
-		return 0
+		return FALSE
 
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		if(H.l_store == master_item && !H.get_active_held_item())	//Prevents opening if it's in a pocket.
 			H.put_in_hands(master_item)
 			H.l_store = null
-			return 0
+			return FALSE
 		if(H.r_store == master_item && !H.get_active_held_item())
 			H.put_in_hands(master_item)
 			H.r_store = null
-			return 0
+			return FALSE
 
 	if(master_item.loc == user)
-		src.open(user)
-		return 0
+		if(draw_mode && ishuman(user) && contents.len)
+			var/obj/item/I = contents[contents.len]
+			I.attack_hand(user)
+		else
+			open(user)
+		return FALSE
 
 	for(var/mob/M in range(1, master_item.loc))
 		if(M.s_active == src)
-			src.close(M)
-	return 1
+			close(M)
+	return TRUE
 
 /obj/item/storage/internal/Adjacent(atom/neighbor)
 	return master_item.Adjacent(neighbor)


### PR DESCRIPTION
## About The Pull Request

This allows you to set draw_mode on internal storage where, when clicked it will remove the last item from the storage instead of opening the UI.

## Why It's Good For The Game

Adds the required support for the marine boot knife
