### PR TITLE
Fixes explosions happening at the same time as crash

### DIFF
--- a/code/__DEFINES/shuttles.dm
+++ b/code/__DEFINES/shuttles.dm
@@ -10,6 +10,11 @@
 #define SHUTTLE_RECHARGING	"recharging"
 #define SHUTTLE_PREARRIVAL	"pre-arrival"
 
+///Whether specific shuttle effects happen on arrivals or not.
+#define NO_ARRIVALS_INTERACTION 0
+#define SHUTTLE_ARRIVING 1
+#define SHUTTLE_ARRIVED 2
+
 #define EMERGENCY_IDLE_OR_RECALLED (SSshuttle.emergency && ((SSshuttle.emergency.mode == SHUTTLE_IDLE) || (SSshuttle.emergency.mode == SHUTTLE_RECALL)))
 #define EMERGENCY_ESCAPED_OR_ENDGAMED (SSshuttle.emergency && ((SSshuttle.emergency.mode == SHUTTLE_ESCAPE) || (SSshuttle.emergency.mode == SHUTTLE_ENDGAME)))
 #define EMERGENCY_AT_LEAST_DOCKED (SSshuttle.emergency && SSshuttle.emergency.mode != SHUTTLE_IDLE && SSshuttle.emergency.mode != SHUTTLE_RECALL && SSshuttle.emergency.mode != SHUTTLE_CALL)
@@ -31,8 +36,9 @@
 #define EARLY_LAUNCHED 2
 #define ENDGAME_TRANSIT 3
 
-// Ripples, effects that signal a shuttle's arrival
-#define SHUTTLE_RIPPLE_TIME 100
+//How long before arrival the effects take place.
+#define SHUTTLE_RIPPLE_TIME 10 SECONDS
+#define SHUTTLE_PRE_CRASH_TIME 1 SECONDS
 
 #define TRANSIT_REQUEST 1
 #define TRANSIT_READY 2

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -78,6 +78,7 @@
 	var/obj/docking_port/stationary/crashmode/actual_crash_site = pick(valid_docks)
 
 	shuttle.crashing = TRUE
+	shuttle.pre_crash_status = SHUTTLE_ARRIVING
 	SSshuttle.moveShuttleToDock(shuttle.id, actual_crash_site, TRUE) // FALSE = instant arrival
 	addtimer(CALLBACK(src, .proc/crash_shuttle, actual_crash_site), 10 MINUTES)
 
@@ -137,6 +138,7 @@
 /datum/game_mode/infestation/crash/proc/crash_shuttle(obj/docking_port/stationary/target)
 	shuttle_landed = TRUE
 	shuttle.crashing = FALSE
+	shuttle.pre_crash_status = initial(shuttle.pre_crash_status)
 
 	// We delay this a little because the shuttle takes some time to land, and we want to the xenos to know the position of the marines.
 	bioscan_interval = world.time + 30 SECONDS

--- a/code/modules/admin/fun_verbs.dm
+++ b/code/modules/admin/fun_verbs.dm
@@ -1044,6 +1044,7 @@
 /datum/admins/proc/force_dropship()
 	set category = "Fun"
 	set name = "Force Dropship"
+	set waitfor = FALSE
 
 	if(!check_rights(R_FUN))
 		return
@@ -1096,9 +1097,28 @@
 		to_chat(usr, "<span class='warning'>No valid dock found!</span>")
 		return
 
+	var/crashing = FALSE
+	switch(alert("Do you want to crash [D.name] on arrivals?", "Force Dropship", "Yes", "No", "Cancel"))
+		if("Yes")
+			crashing = TRUE
+		if("Cancel")
+			return
+
 	var/instant = FALSE
-	if(alert("Do you want to move the [D.name] instantly?", "Force Dropship", "Yes", "No") == "Yes")
-		instant = TRUE
+	switch(alert("Do you want to move the [D.name] instantly?", "Force Dropship", "Yes", "No", "Cancel"))
+		if("Yes")
+			instant = TRUE
+		if("Cancel")
+			return
+
+	if(crashing)
+		D.crashing = TRUE
+		D.pre_crash_status = SHUTTLE_ARRIVING
+		if(instant) //Give it a second to process the crashing.
+			target.pre_crash_impact()
+			D.pre_crash_impact()
+			D.pre_crash_status = initial(D.pre_crash_status)
+			sleep(SHUTTLE_PRE_CRASH_TIME)
 
 	var/success = SSshuttle.moveShuttleToDock(D.id, target, !instant)
 	switch(success)

--- a/code/modules/shuttle/gamemodes/crash.dm
+++ b/code/modules/shuttle/gamemodes/crash.dm
@@ -10,6 +10,9 @@
 
 
 /obj/docking_port/stationary/crashmode/on_crash()
+	return
+
+/obj/docking_port/stationary/crashmode/pre_crash_impact()
 	//clear areas around the shuttle with explosions
 	var/turf/C = return_center_turf()
 
@@ -56,7 +59,7 @@
 	id = "canterbury_loadingdock"
 	name = "Low Orbit"
 
-/obj/docking_port/stationary/crashmode/loading/on_crash()
+/obj/docking_port/stationary/crashmode/loading/pre_crash_impact()
 	return // No explosions please and thank you.
 
 // -- Shuttles

--- a/code/modules/shuttle/gamemodes/crash.dm
+++ b/code/modules/shuttle/gamemodes/crash.dm
@@ -73,7 +73,7 @@
 
 	callTime = 10 MINUTES
 	ignitionTime = 5 SECONDS
-	prearrivalTime = 12 SECONDS
+	prearrivalTime = 2 SECONDS //We only need time for the arrival sound here.
 
 	var/list/spawnpoints = list()
 	var/list/latejoins = list()

--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -43,6 +43,8 @@
 
 	GLOB.enter_allowed = FALSE //No joining after dropship crash
 
+
+/obj/docking_port/stationary/marine_dropship/pre_crash_impact()
 	//clear areas around the shuttle with explosions
 	var/turf/C = return_center_turf()
 
@@ -625,6 +627,7 @@
 	crashing_dropship.set_hijack_state(HIJACK_STATE_CRASHING)
 	crashing_dropship.callTime = 2 MINUTES
 	crashing_dropship.crashing = TRUE
+	crashing_dropship.pre_crash_status = SHUTTLE_ARRIVING
 	crashing_dropship.unlock_all()
 	priority_announce("Unscheduled dropship departure detected from operational area. Hijack likely. Shutting down autopilot.", "Dropship Alert", sound = 'sound/AI/hijack.ogg')
 	to_chat(user, "<span class='danger'>A loud alarm erupts from [src]! The fleshy hosts must know that you can access it!</span>")

--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -626,6 +626,7 @@
 /obj/machinery/computer/shuttle/marine_dropship/proc/do_hijack(obj/docking_port/mobile/marine_dropship/crashing_dropship, obj/docking_port/stationary/marine_dropship/crash_target/crash_target, mob/living/carbon/xenomorph/user)
 	crashing_dropship.set_hijack_state(HIJACK_STATE_CRASHING)
 	crashing_dropship.callTime = 2 MINUTES
+	crashing_dropship.prearrivalTime = 2 SECONDS
 	crashing_dropship.crashing = TRUE
 	crashing_dropship.pre_crash_status = SHUTTLE_ARRIVING
 	crashing_dropship.unlock_all()

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -641,6 +641,7 @@
 			if(time_left <= SHUTTLE_RIPPLE_TIME && use_ripples == SHUTTLE_ARRIVING)
 				create_ripples(destination, time_left)
 
+		if(SHUTTLE_PREARRIVAL)
 			if(time_left <= SHUTTLE_PRE_CRASH_TIME && crashing && pre_crash_status == SHUTTLE_ARRIVING && !istype(destination, /obj/docking_port/stationary/transit))
 				destination.pre_crash_impact()
 				pre_crash_impact()

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -636,13 +636,15 @@
 	set_idle()
 
 /obj/docking_port/mobile/proc/check_effects(time_left)
-	if(time_left <= SHUTTLE_RIPPLE_TIME && use_ripples == SHUTTLE_ARRIVING && ((mode == SHUTTLE_CALL) || (mode == SHUTTLE_RECALL)))
-		create_ripples(destination, time_left)
+	switch(mode)
+		if(SHUTTLE_CALL, SHUTTLE_RECALL)
+			if(time_left <= SHUTTLE_RIPPLE_TIME && use_ripples == SHUTTLE_ARRIVING)
+				create_ripples(destination, time_left)
 
-	if(time_left <= SHUTTLE_PRE_CRASH_TIME && crashing && pre_crash_status == SHUTTLE_ARRIVING && !istype(destination, /obj/docking_port/stationary/transit))
-		destination.pre_crash_impact()
-		pre_crash_impact()
-		pre_crash_status = initial(pre_crash_status)
+			if(time_left <= SHUTTLE_PRE_CRASH_TIME && crashing && pre_crash_status == SHUTTLE_ARRIVING && !istype(destination, /obj/docking_port/stationary/transit))
+				destination.pre_crash_impact()
+				pre_crash_impact()
+				pre_crash_status = initial(pre_crash_status)
 
 	//var/obj/docking_port/stationary/S0 = get_docked()
 	//if(istype(S0, /obj/docking_port/stationary/transit) && timeLeft(1) <= PARALLAX_LOOP_TIME)


### PR DESCRIPTION
* Adds a pre-crash proc for both the shuttle and destination to happen one second before crashing.
* It allows for other pre-arrival interactions.
* Does PsyKzz's request of allowing the admins to do instant shuttle crashes without sacrificing the explosions.