### PR TITLE
Fixes unintentional doubleclicks on the item action ui

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -637,7 +637,6 @@
 //The default action is attack_self().
 //Checks before we get to here are: mob is alive, mob is not restrained, paralyzed, asleep, resting, laying, item is on the mob.
 /obj/item/proc/ui_action_click(mob/user, datum/action/item_action/action)
-	toggle_item_state(user)
 	attack_self(user)
 
 /obj/item/proc/toggle_item_state(mob/user)


### PR DESCRIPTION
`attack_self` calls for `toggle_item_state`