### PR TITLE
Revert "increase head max damage to 150 (#4036)"

### DIFF
--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -1204,7 +1204,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "head"
 	icon_name = "head"
 	display_name = "head"
-	max_damage = 150
+	max_damage = 100
 	min_broken_damage = 40
 	body_part = HEAD
 	vital = TRUE


### PR DESCRIPTION
This reverts commit f32865982b37a431ee5ef5ab94bbcb2faa482675.

<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Decreases max hp for heads back down to 100
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I don't get why this was merged in the first place other than the fact that people believe that non-helmet shouldn't cause death?
Also a large majority of people disagreed with the change anyway, and it was pushed through anyhow.
100 head HP is around 4 slashes from a normal bean if you're wearing one of the berets or caps anyway. I don't see the need for this.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: people no longer have 150 head hp. Have 100 again.
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
