### PR TITLE
you can refill mags with other mags

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -69,14 +69,11 @@ They're all essentially identical when it comes to getting the job done.
 	. = ..()
 
 	if(istype(I, /obj/item/ammo_magazine))
-		var/obj/item/ammo_magazine/MG = I
-		if(!(MG.flags_magazine & AMMUNITION_HANDFUL)) //got a handful of bullets
-			return
 
 		if(!(flags_magazine & AMMUNITION_REFILLABLE)) //and a refillable magazine
 			return
 
-		var/obj/item/ammo_magazine/handful/H = I
+		var/obj/item/ammo_magazine/H = I
 		if(src != user.get_inactive_held_item()) //It has to be held.
 			to_chat(user, "Try holding [src] before you attempt to restock it.")
 			return
@@ -87,7 +84,6 @@ They're all essentially identical when it comes to getting the job done.
 
 		transfer_ammo(H, user, H.current_rounds) // This takes care of the rest.
 
-
 //Generic proc to transfer ammo between ammo mags. Can work for anything, mags, handfuls, etc.
 /obj/item/ammo_magazine/proc/transfer_ammo(obj/item/ammo_magazine/source, mob/user, transfer_amount = 1)
 	if(current_rounds == max_rounds) //Does the mag actually need reloading?
@@ -97,6 +93,17 @@ They're all essentially identical when it comes to getting the job done.
 	if(source.caliber != caliber) //Are they the same caliber?
 		to_chat(user, "The rounds don't match up. Better not mix them up.")
 		return
+
+	if(!source.current_rounds)
+		to_chat(user, "[source] is empty.")
+		return
+
+	if(!istype(source, /obj/item/ammo_magazine/handful)) //if it isn't a handful, give a delay.
+		to_chat(user, "<span class='notice'>You start refilling [src] with [source].</span>")
+		if(!do_after(user, 15, TRUE, src, BUSY_ICON_GENERIC))
+			return
+
+	to_chat(user, "<span class='notice'>You refill [src] with [source].</span>")
 
 	var/S = min(transfer_amount, max_rounds - current_rounds)
 	source.current_rounds -= S

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -100,7 +100,7 @@ They're all essentially identical when it comes to getting the job done.
 
 	if(!istype(source, /obj/item/ammo_magazine/handful)) //if it isn't a handful, give a delay.
 		to_chat(user, "<span class='notice'>You start refilling [src] with [source].</span>")
-		if(!do_after(user, 15, TRUE, src, BUSY_ICON_GENERIC))
+		if(!do_after(user, 1.5 SECONDS, TRUE, src, BUSY_ICON_GENERIC))
 			return
 
 	to_chat(user, "<span class='notice'>You refill [src] with [source].</span>")

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -95,7 +95,7 @@ They're all essentially identical when it comes to getting the job done.
 		return
 
 	if(!source.current_rounds)
-		to_chat(user, "[source] is empty.")
+		to_chat(user, "<span class='warning'>\The [source] is empty.</span>")
 		return
 
 	if(!istype(source, /obj/item/ammo_magazine/handful)) //if it isn't a handful, give a delay.

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -97,8 +97,8 @@ They're all essentially identical when it comes to getting the job done.
 	if(!source.current_rounds)
 		to_chat(user, "<span class='warning'>\The [source] is empty.</span>")
 		return
-
-	if(!istype(source, /obj/item/ammo_magazine/handful)) //if it isn't a handful, give a delay.
+//using handfuls; and filling internal mags has no delay.
+	if(!istype(source, /obj/item/ammo_magazine/handful) && !istype(src, /obj/item/ammo_magazine/internal) ) 
 		to_chat(user, "<span class='notice'>You start refilling [src] with [source].</span>")
 		if(!do_after(user, 1.5 SECONDS, TRUE, src, BUSY_ICON_GENERIC))
 			return


### PR DESCRIPTION
## About The Pull Request

Removes handful requirement from mag refilling.
Adds delay if it is not a handful.

## Why It's Good For The Game

While it is "realistic" that you'd have to juggle around ammo and handfuls and mags, it simply isn't conducive to simulate that in the game environment. This makes refilling mags less of a pain.

## Changelog
:cl:
add: You can refill mags with other mags, now.
/:cl: