### PR TITLE
The SMG and Shotgun now have irremoveable stocks. And have a minor gun stat rebalance.

### DIFF
--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -252,8 +252,6 @@
 					/obj/item/attachable/bipod = round(scale * 8),
 					/obj/item/attachable/burstfire_assembly = round(scale * 4),
 
-					/obj/item/attachable/stock/t35stock = round(scale * 4),
-					/obj/item/attachable/stock/t19stock = round(scale * 4),
 					/obj/item/attachable/stock/tactical = round(scale * 3),
 
 					/obj/item/attachable/attached_gun/grenade = round(scale * 10),
@@ -321,7 +319,6 @@
 						/obj/item/storage/belt/grenade = round(scale * 5),
 						/obj/item/storage/belt/gun/pistol/standard_pistol = round(scale * 10),
 						/obj/item/storage/belt/gun/revolver/standard_revolver = round(scale * 5),
-						/obj/item/storage/large_holster/t19 = round(scale * 5),
 						/obj/item/clothing/tie/storage/webbing = round(scale * 5),
 						/obj/item/clothing/tie/storage/brown_vest = round(scale * 5),
 						/obj/item/clothing/tie/storage/white_vest/medic = round(scale * 5),

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -86,7 +86,6 @@
 					/obj/item/storage/belt/grenade = 5,
 					/obj/item/storage/belt/gun/pistol/standard_pistol = 10,
 					/obj/item/storage/belt/gun/revolver/standard_revolver = 5,
-					/obj/item/storage/large_holster/t19 = 5,
 					/obj/item/clothing/tie/storage/webbing = 5,
 					/obj/item/clothing/tie/storage/brown_vest = 5,
 					/obj/item/clothing/tie/storage/white_vest/medic = 5,
@@ -636,9 +635,7 @@
 						/obj/item/attachable/lasersight = 10,
 						/obj/item/attachable/verticalgrip = 10,
 
-						/obj/item/attachable/stock/t19stock = 3,
 						/obj/item/attachable/stock/revolver = 3,
-						/obj/item/attachable/stock/t35stock = 3,
 						/obj/item/attachable/stock/tactical = 3,
 
 						/obj/item/attachable/attached_gun/flamer = 3,
@@ -698,7 +695,6 @@
 					/obj/item/storage/belt/sparepouch = 10,
 					/obj/item/storage/belt/gun/pistol/standard_pistol = 10,
 					/obj/item/storage/belt/gun/revolver/standard_revolver = 10,
-					/obj/item/storage/large_holster/t19 = 10,
 					/obj/item/storage/pouch/pistol = 10,
 					/obj/item/storage/pouch/magazine = 10,
 					/obj/item/storage/pouch/magazine/pistol = 10,

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -497,7 +497,6 @@ GLOBAL_LIST_INIT(marine_selector_cats, list(
 		/obj/item/clothing/tie/storage/black_vest = list(CAT_WEB, "Tactical Black Vest", 0, "orange"),
 		/obj/item/clothing/tie/storage/webbing = list(CAT_WEB, "Tactical Webbing", 0, "black"),
 		/obj/item/clothing/tie/holster = list(CAT_WEB, "Shoulder Handgun Holster", 0, "black"),
-		/obj/item/storage/large_holster/t19 = list(CAT_BEL, "T-19 holster belt", 0, "orange"),
 		/obj/item/storage/belt/marine = list(CAT_BEL, "Standard ammo belt", 0, "black"),
 		/obj/item/storage/belt/shotgun = list(CAT_BEL, "Shotgun ammo belt", 0, "black"),
 		/obj/item/storage/belt/knifepouch = list(CAT_BEL, "Knives belt", 0, "black"),
@@ -551,7 +550,6 @@ GLOBAL_LIST_INIT(marine_selector_cats, list(
 		/obj/item/clothing/tie/storage/black_vest = list(CAT_WEB, "Tactical Black Vest", 0, "black"),
 		/obj/item/clothing/tie/storage/webbing = list(CAT_WEB, "Tactical Webbing", 0, "black"),
 		/obj/item/clothing/tie/holster = list(CAT_WEB, "Shoulder Handgun Holster", 0, "black"),
-		/obj/item/storage/large_holster/t19 = list(CAT_BEL, "T-19 holster belt", 0, "black"),
 		/obj/item/storage/belt/marine = list(CAT_BEL, "Standard ammo belt", 0, "black"),
 		/obj/item/storage/belt/shotgun = list(CAT_BEL, "Shotgun ammo belt", 0, "black"),
 		/obj/item/storage/belt/knifepouch = list(CAT_BEL, "Knives belt", 0, "black"),
@@ -610,7 +608,6 @@ GLOBAL_LIST_INIT(marine_selector_cats, list(
 		/obj/item/clothing/tie/holster = list(CAT_WEB, "Shoulder Handgun Holster", 0, "black"),
 		/obj/item/storage/belt/marine = list(CAT_BEL, "Standard ammo belt", 0, "black"),
 		/obj/item/storage/belt/shotgun = list(CAT_BEL, "Shotgun ammo belt", 0, "black"),
-		/obj/item/storage/large_holster/t19 = list(CAT_BEL, "T-19 holster belt", 0, "black"),
 		/obj/item/storage/belt/knifepouch = list(CAT_BEL, "Knives belt", 0, "black"),
 		/obj/item/storage/belt/gun/pistol/standard_pistol = list(CAT_BEL, "Pistol belt", 0, "black"),
 		/obj/item/storage/belt/gun/revolver/standard_revolver = list(CAT_BEL, "Revolver belt", 0, "black"),
@@ -792,8 +789,6 @@ GLOBAL_LIST_INIT(marine_selector_cats, list(
 		/obj/item/attachable/lasersight = list(CAT_ATT, "Laser sight", 0, "black"),
 		/obj/item/attachable/verticalgrip = list(CAT_ATT, "Vertical grip", 0, "black"),
 		/obj/item/attachable/angledgrip = list(CAT_ATT, "Angled grip", 0, "orange"),
-		/obj/item/attachable/stock/t35stock = list(CAT_ATT, "T-35 stock", 0, "black"),
-		/obj/item/attachable/stock/t19stock = list(CAT_ATT, "T-19 Submachinegun stock", 0, "black"),
 	)
 
 
@@ -835,8 +830,6 @@ GLOBAL_LIST_INIT(marine_selector_cats, list(
 		/obj/item/attachable/scope/mini = list(CAT_ATT, "Mini-Scope", 0,"black"),
 		/obj/item/attachable/verticalgrip = list(CAT_ATT, "Vertical grip", 0, "black"),
 		/obj/item/attachable/angledgrip = list(CAT_ATT, "Angled grip", 0, "orange"),
-		/obj/item/attachable/stock/t35stock = list(CAT_ATT, "T-35 stock", 0, "black"),
-		/obj/item/attachable/stock/t19stock = list(CAT_ATT, "T-19 Submachinegun stock", 0, "black"),
 	)
 
 
@@ -862,8 +855,6 @@ GLOBAL_LIST_INIT(marine_selector_cats, list(
 		/obj/item/attachable/lasersight = list(CAT_ATT, "Laser sight", 0, "black"),
 		/obj/item/attachable/verticalgrip = list(CAT_ATT, "Vertical grip", 0, "black"),
 		/obj/item/attachable/angledgrip = list(CAT_ATT, "Angled grip", 0, "orange"),
-		/obj/item/attachable/stock/t35stock = list(CAT_ATT, "T-35 stock", 0, "black"),
-		/obj/item/attachable/stock/t19stock = list(CAT_ATT, "T-19 Submachinegun stock", 0, "black"),
 	)
 
 
@@ -949,8 +940,6 @@ GLOBAL_LIST_INIT(available_specialist_sets, list("Scout Set", "Sniper Set", "Dem
 		/obj/item/attachable/scope/mini = list(CAT_ATT, "Mini-Scope", 0,"black"),
 		/obj/item/attachable/verticalgrip = list(CAT_ATT, "Vertical grip", 0, "black"),
 		/obj/item/attachable/angledgrip = list(CAT_ATT, "Angled grip", 0, "orange"),
-		/obj/item/attachable/stock/t35stock = list(CAT_ATT, "T-35 stock", 0, "black"),
-		/obj/item/attachable/stock/t19stock = list(CAT_ATT, "T-19 Submachine Gun stock", 0, "black"),
 	)
 
 

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -891,8 +891,6 @@ GLOBAL_LIST_INIT(available_specialist_sets, list("Scout Set", "Sniper Set", "Dem
 		/obj/item/attachable/verticalgrip = list(CAT_ATT, "Vertical grip", 0, "black"),
 		/obj/item/attachable/scope/mini = list(CAT_ATT, "Mini-Scope", 0,"black"),
 		/obj/item/attachable/angledgrip = list(CAT_ATT, "Angled grip", 0, "orange"),
-		/obj/item/attachable/stock/t35stock = list(CAT_ATT, "T-35 stock", 0, "black"),
-		/obj/item/attachable/stock/t19stock = list(CAT_ATT, "T-19 Submachinegun stock", 0, "black"),
 	)
 
 

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -341,8 +341,6 @@ GLOBAL_LIST_INIT(marine_selector_cats, list(
 		/obj/item/attachable/verticalgrip = list(CAT_ATT, "Vertical grip", 0,"black"),
 		/obj/item/attachable/scope/mini = list(CAT_ATT, "Mini-Scope", 0,"black"),
 		/obj/item/attachable/angledgrip = list(CAT_ATT, "Angled grip", 0,"orange"),
-		/obj/item/attachable/stock/t35stock = list(CAT_ATT, "T-35 stock", 0,"black"),
-		/obj/item/attachable/stock/t19stock = list(CAT_ATT, "T-19 Submachinegun stock", 0,"black"),
 	)
 
 

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1018,27 +1018,28 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/stock/t19stock
 	name = "T-19 Submachine Gun stock"
-	desc = "A rare stock distributed in small numbers to TGMC forces. Compatible with the T-19, this stock reduces recoil and improves accuracy, but at a reduction to handling and agility. Seemingly a bit more effective in a brawl."
-	slot = "stock"
-	wield_delay_mod = 0.3 SECONDS
-	melee_mod = 5
-	size_mod = 1
+	desc = "A  stock distributed  to TGMC forces. Compatible with the T-19. Irremoveable in most circumstances."
 	icon_state = "t19stock"
 	pixel_shift_x = 39
 	pixel_shift_y = 11
-	accuracy_mod = 0.1
-	recoil_mod = -2
-	scatter_mod = -10
+	flags_attach_features = NONE
+	accuracy_mod = 0
+	recoil_mod = 0
+	melee_mod = 0
+	scatter_mod = 0
+	movement_acc_penalty_mod = 0
 
 /obj/item/attachable/stock/t35stock
 	name = "\improper T-35 stock"
 	desc = "A non-standard heavy stock for the T-35 Shotgun. Less quick and more cumbersome than the standard issue stakeout, but reduces recoil and improves accuracy. Allegedly makes a pretty good club in a fight too."
 	slot = "stock"
-	wield_delay_mod = 0.4 SECONDS
 	icon_state = "t35stock"
-	accuracy_mod = 0.15
-	recoil_mod = -3
-	scatter_mod = -20
+	flags_attach_features = NONE
+	accuracy_mod = 0
+	recoil_mod = 0
+	melee_mod = 0
+	scatter_mod = 0
+	movement_acc_penalty_mod = 0
 
 ////////////// Underbarrel Attachments ////////////////////////////////////
 

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1018,7 +1018,7 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/stock/t19stock
 	name = "T-19 Submachine Gun stock"
-	desc = "A  stock distributed  to TGMC forces. Compatible with the T-19. Irremoveable in most circumstances."
+	desc = "A stock distributed to TGMC forces. Compatible with the T-19. Irremovable in most circumstances."
 	icon_state = "t19stock"
 	pixel_shift_x = 39
 	pixel_shift_y = 11

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -758,9 +758,10 @@ can cause issues with ammo types getting mixed up during the burst.
 						/obj/item/attachable/stock/t35stock)
 
 	attachable_offset = list("muzzle_x" = 31, "muzzle_y" = 18,"rail_x" = 10, "rail_y" = 20, "under_x" = 21, "under_y" = 12, "stock_x" = 20, "stock_y" = 16)
-
+	starting_attachment_types = list(/obj/item/attachable/stock/t35stock)
 	flags_item_map_variant = NONE
 
+	wield_delay = 0.8 SECONDS
 	fire_delay = 20
 	accuracy_mult = 1.15
 	accuracy_mult_unwielded = 0.85

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -764,10 +764,10 @@ can cause issues with ammo types getting mixed up during the burst.
 
 	wield_delay = 0.9 SECONDS
 	fire_delay = 20
-	accuracy_mult = 1.15
+	accuracy_mult = 1.25
 	accuracy_mult_unwielded = 0.85
-	scatter = 20
-	scatter_unwielded = 40
+	scatter = 5
+	scatter_unwielded = 35
 	recoil = 0 // The gun has the stock already.
 	recoil_unwielded = 4
 	pump_delay = 14

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -762,11 +762,11 @@ can cause issues with ammo types getting mixed up during the burst.
 	starting_attachment_types = list(/obj/item/attachable/stock/t35stock)
 	flags_item_map_variant = NONE
 
-	wield_delay = 0.9 SECONDS
+	wield_delay = 0.8 SECONDS
 	fire_delay = 20
-	accuracy_mult = 1.25
+	accuracy_mult = 1.20
 	accuracy_mult_unwielded = 0.85
-	scatter = -5
+	scatter = 0
 	scatter_unwielded = 35
 	recoil = 0 // The gun has the stock already.
 	recoil_unwielded = 4

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -738,6 +738,7 @@ can cause issues with ammo types getting mixed up during the burst.
 	flags_equip_slot = ITEM_SLOT_BACK
 	icon_state = "t35"
 	item_state = "t35"
+	force = 19.0
 	current_mag = /obj/item/ammo_magazine/internal/shotgun/pump
 	fire_sound = 'sound/weapons/guns/fire/t35.ogg'
 	max_shells = 9
@@ -761,7 +762,7 @@ can cause issues with ammo types getting mixed up during the burst.
 	starting_attachment_types = list(/obj/item/attachable/stock/t35stock)
 	flags_item_map_variant = NONE
 
-	wield_delay = 0.8 SECONDS
+	wield_delay = 0.9 SECONDS
 	fire_delay = 20
 	accuracy_mult = 1.15
 	accuracy_mult_unwielded = 0.85

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -766,7 +766,7 @@ can cause issues with ammo types getting mixed up during the burst.
 	fire_delay = 20
 	accuracy_mult = 1.25
 	accuracy_mult_unwielded = 0.85
-	scatter = 5
+	scatter = -5
 	scatter_unwielded = 35
 	recoil = 0 // The gun has the stock already.
 	recoil_unwielded = 4

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -768,6 +768,6 @@ can cause issues with ammo types getting mixed up during the burst.
 	accuracy_mult_unwielded = 0.85
 	scatter = 20
 	scatter_unwielded = 40
-	recoil = 2
+	recoil = 0 // The gun has the stock already.
 	recoil_unwielded = 4
 	pump_delay = 14

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -49,7 +49,8 @@
 	item_state = "t19"
 	caliber = "10x20mm caseless" //codex
 	max_shells = 60 //codex
-	flags_equip_slot = ITEM_SLOT_BACK
+	force = 13
+	flags_equip_slot = ITEM_SLOT_BACK|ITEM_SLOT_BELT
 	current_mag = /obj/item/ammo_magazine/smg/standard_smg
 	type_of_casings = null
 	attachable_allowed = list(
@@ -67,12 +68,14 @@
 						/obj/item/attachable/gyro)
 
 	flags_gun_features = GUN_AUTO_EJECTOR|GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER|GUN_LOAD_INTO_CHAMBER
+	starting_attachment_types = list(/obj/item/attachable/stock/t19stock)
 	gun_firemode_list = list(GUN_FIREMODE_SEMIAUTO, GUN_FIREMODE_BURSTFIRE, GUN_FIREMODE_AUTOMATIC, GUN_FIREMODE_AUTOBURST)
 	attachable_offset = list("muzzle_x" = 27, "muzzle_y" = 17,"rail_x" = 9, "rail_y" = 20, "under_x" = 21, "under_y" = 12, "stock_x" = 24, "stock_y" = 10)
 
-	accuracy_mult = 0.95
+	wield_delay = 0.5 SECONDS
+	accuracy_mult = 1
 	accuracy_mult_unwielded = 0.9
-	scatter = 20
+	scatter = 10
 	fire_delay = 0.15 SECONDS
 	scatter_unwielded = 30
 	aim_slowdown = 0.15

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -73,9 +73,9 @@
 	attachable_offset = list("muzzle_x" = 27, "muzzle_y" = 17,"rail_x" = 9, "rail_y" = 20, "under_x" = 21, "under_y" = 12, "stock_x" = 24, "stock_y" = 10)
 
 	wield_delay = 0.5 SECONDS
-	accuracy_mult = 1
+	accuracy_mult = 1.05
 	accuracy_mult_unwielded = 0.9
-	scatter = 10
+	scatter = 5
 	fire_delay = 0.15 SECONDS
 	scatter_unwielded = 30
 	aim_slowdown = 0.15


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Almost all people use the stock on these guns already. And the SMG basically needs it to be viable. I feel like this is a decent change. ~~also they clearly were made with them in mind and both look awful without the stock dear gosh~~
SMG/Shotgun now have irremoveable stocks.
The shotgun has slightly more scatter at peak now and less accuracy overall. I might need to make it worse but the wield delay is more now so we'll see.
The stocks no longer spawn in vendors. Nor can you pick them.
T19 now fits on belt naturally. I felt the belt holster was practically useless. As the gun without the stock felt awful to use no matter the loadout. Though I didn't give it as much wield delay as with stock as it has no angled grip and it'd make it slower than most guns in the game to wield.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Stocks are kind of dumb. From an immersion or realism standpoint and a balance standpoint being forced to use attachments to make a gun useable is bad and guns being stockless outside of pistols or machine pistols is extra weird. I feel like they should either have a stock or no stock unless they're a pistol.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: T19 stock is gone outside of adminbus. There's no use for it anymore
balance: T19 and shotgun now have the stocks and assorted stats naturally. T19 now naturally fits on belts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
