### PR TITLE
Tier 1 xenos on crash start at ancient

### DIFF
--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -338,7 +338,7 @@
 /datum/game_mode/infestation/crash/proc/on_xeno_evolve(datum/source, mob/living/carbon/xenomorph/new_xeno)
 	switch(new_xeno.tier)
 		if(XENO_TIER_ONE)
-			new_xeno.upgrade_xeno(XENO_UPGRADE_ONE)
+			new_xeno.upgrade_xeno(XENO_UPGRADE_THREE)
 		if(XENO_TIER_TWO)
 			new_xeno.upgrade_xeno(XENO_UPGRADE_ONE)
 


### PR DESCRIPTION
## About The Pull Request

Buffs crash xenos
This removes the effect of dying but otherwise leaves the xenos unchanged.
This only affects tier 1 xenos.

## Why It's Good For The Game

Reduce the effect of dying for xenos on crash which allows the whole respawn gameplay to play out better for them

## Changelog
:cl:
balance: tier 1 crash xenos start at ancient
/:cl:
