### PR TITLE
Temporary Fog

### DIFF
--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -147,10 +147,7 @@
 
 /obj/effect/forcefield/fog/passable_fog/update_icon()
 	. = ..()
-	if(invisible)
-		icon_state = NONE
-	else
-		icon_state = "smoke"
+	alpha = invisible ? 0 : initial(alpha)
 
 //used to control opacity of multitiles doors
 /obj/effect/opacifier

--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -124,7 +124,6 @@
 	desc = "It looks dangerous to traverse."
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "smoke"
-	opacity = TRUE
 	density = FALSE
 
 /obj/effect/forcefield/fog/passable_fog/CanPass(atom/movable/mover, turf/target)
@@ -136,7 +135,7 @@
 		return
 	set_opacity(FALSE)
 	alpha = 0
-	addtimer(CALLBACK(src, .proc/reset), 30 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE)
+	addtimer(CALLBACK(src, .proc/reset), 30 SECONDS)
 
 /obj/effect/forcefield/fog/passable_fog/proc/reset()
 	alpha = initial(alpha)

--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -126,27 +126,18 @@
 	icon_state = "smoke"
 	opacity = TRUE
 	density = FALSE
-	var/invisible = FALSE
 
 /obj/effect/forcefield/fog/passable_fog/CanPass(atom/movable/mover, turf/target)
 	return TRUE
 
 /obj/effect/forcefield/fog/passable_fog/Crossed(atom/movable/mover, oldloc)
 	. = ..()
-	invisible = TRUE
-	opacity = FALSE
-	update_icon()
-	addtimer(CALLBACK(src, .proc/icon_update_check), 30 SECONDS)
+	set_opacity(FALSE)
+	addtimer(CALLBACK(src, .proc/go_invisible), 30 SECONDS, TIMER_OVERRIDE|TIMER_UNIQUE)
 
-/obj/effect/forcefield/fog/passable_fog/proc/icon_update_check()
-	invisible = FALSE
-	opacity = TRUE
-	update_icon()
-
-/obj/effect/forcefield/fog/passable_fog/update_icon()
-	. = ..()
-	alpha = invisible ? 0 : initial(alpha)
-	set_opacity(opacity)
+/obj/effect/forcefield/fog/passable_fog/proc/go_invisible()
+	alpha = opacity ? initial(alpha) : 0
+	set_opacity(TRUE)
 
 //used to control opacity of multitiles doors
 /obj/effect/opacifier

--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -126,18 +126,27 @@
 	icon_state = "smoke"
 	opacity = TRUE
 	density = FALSE
+	var/invisible = FALSE
 
 /obj/effect/forcefield/fog/passable_fog/CanPass(atom/movable/mover, turf/target)
 	return TRUE
 
 /obj/effect/forcefield/fog/passable_fog/Crossed(atom/movable/mover, oldloc)
 	. = ..()
-	set_opacity(FALSE)
-	addtimer(CALLBACK(src, .proc/go_invisible), 30 SECONDS, TIMER_OVERRIDE|TIMER_UNIQUE)
+	invisible = TRUE
+	opacity = FALSE
+	update_icon()
+	addtimer(CALLBACK(src, .proc/icon_update_check), 30 SECONDS)
 
-/obj/effect/forcefield/fog/passable_fog/proc/go_invisible()
-	alpha = opacity ? initial(alpha) : 0
-	set_opacity(TRUE)
+/obj/effect/forcefield/fog/passable_fog/proc/icon_update_check()
+	invisible = FALSE
+	opacity = TRUE
+	update_icon()
+
+/obj/effect/forcefield/fog/passable_fog/update_icon()
+	. = ..()
+	alpha = invisible ? 0 : initial(alpha)
+	set_opacity(opacity)
 
 //used to control opacity of multitiles doors
 /obj/effect/opacifier

--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -119,6 +119,38 @@
 		return TRUE
 	return FALSE
 
+/obj/effect/forcefield/fog/passable_fog
+	name = "fog"
+	desc = "It looks dangerous to traverse."
+	icon = 'icons/effects/effects.dmi'
+	icon_state = "smoke"
+	opacity = TRUE
+	density = FALSE
+	var/invisible = FALSE
+
+/obj/effect/forcefield/fog/passable_fog/CanPass(atom/movable/mover, turf/target)
+	return TRUE
+
+/obj/effect/forcefield/fog/passable_fog/Crossed(atom/movable/mover, oldloc)
+	. = ..()
+	invisible = TRUE
+	opacity = FALSE
+	set_opacity(opacity)
+	update_icon()
+	addtimer(CALLBACK(src, .proc/icon_update_check), 30 SECONDS)
+
+/obj/effect/forcefield/fog/passable_fog/proc/icon_update_check()
+	invisible = FALSE
+	opacity = TRUE
+	set_opacity(opacity)
+	update_icon()
+
+/obj/effect/forcefield/fog/passable_fog/update_icon()
+	. = ..()
+	if(invisible)
+		icon_state = NONE
+	else
+		icon_state = "smoke"
 
 //used to control opacity of multitiles doors
 /obj/effect/opacifier

--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -126,27 +126,21 @@
 	icon_state = "smoke"
 	opacity = TRUE
 	density = FALSE
-	var/invisible = FALSE
 
 /obj/effect/forcefield/fog/passable_fog/CanPass(atom/movable/mover, turf/target)
 	return TRUE
 
 /obj/effect/forcefield/fog/passable_fog/Crossed(atom/movable/mover, oldloc)
 	. = ..()
-	invisible = TRUE
-	opacity = FALSE
-	update_icon()
-	addtimer(CALLBACK(src, .proc/icon_update_check), 30 SECONDS)
+	if(!opacity)
+		return
+	set_opacity(FALSE)
+	alpha = 0
+	addtimer(CALLBACK(src, .proc/reset), 30 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE)
 
-/obj/effect/forcefield/fog/passable_fog/proc/icon_update_check()
-	invisible = FALSE
-	opacity = TRUE
-	update_icon()
-
-/obj/effect/forcefield/fog/passable_fog/update_icon()
-	. = ..()
-	alpha = invisible ? 0 : initial(alpha)
-	set_opacity(opacity)
+/obj/effect/forcefield/fog/passable_fog/proc/reset()
+	alpha = initial(alpha)
+	set_opacity(TRUE)
 
 //used to control opacity of multitiles doors
 /obj/effect/opacifier

--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -135,19 +135,18 @@
 	. = ..()
 	invisible = TRUE
 	opacity = FALSE
-	set_opacity(opacity)
 	update_icon()
 	addtimer(CALLBACK(src, .proc/icon_update_check), 30 SECONDS)
 
 /obj/effect/forcefield/fog/passable_fog/proc/icon_update_check()
 	invisible = FALSE
 	opacity = TRUE
-	set_opacity(opacity)
 	update_icon()
 
 /obj/effect/forcefield/fog/passable_fog/update_icon()
 	. = ..()
 	alpha = invisible ? 0 : initial(alpha)
+	set_opacity(opacity)
 
 //used to control opacity of multitiles doors
 /obj/effect/opacifier


### PR DESCRIPTION
## About The Pull Request

This makes temporary opaque fog to block vision and create ambiance for mapping.

## Why It's Good For The Game

No longer shall fog be only for blocking of areas. Now it can be used to make places just dark and scary to walk through as you can't see anything beyond your hand. 

This is true london pea soup fog.

Once anything steps through it, the fog disappears for X(30) seconds. They also disappear with the rest of the regular blocking fog.

## Changelog
:cl: Hughgent
add: Fog that is actually fog like, and not wall like.
/:cl:

