### PR TITLE
Flame radius didn't include center turf

### DIFF
--- a/code/__HELPERS/patterns.dm
+++ b/code/__HELPERS/patterns.dm
@@ -59,7 +59,7 @@
 		if("circle")
 			directions = GLOB.cardinals
 
-	var/list/results = list()
+	var/list/results = list(center_turf)
 	var/list/turfs_to_check = list()
 	turfs_to_check += center_turf
 	for(var/i = radius; i > 0; i--)


### PR DESCRIPTION
When all directions are blocked we'd never get a chance to check the center tile.
This includes it by default
