### PR TITLE
fix: restores skip_cleanup on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ jobs:
         - touch dmdoc/.nojekyll
       deploy:
         provider: pages
-        cleanup: false
+        skip_cleanup: true
         keep_history: true
         local_dir: dmdoc
         token: $DMDOC_GITHUB_TOKEN


### PR DESCRIPTION
This reverts the config back to skip_cleanup: true
https://docs.travis-ci.com/user/deployment/#uploading-files-and-skip_cleanup
