### PR TITLE
Fixes a runtime with tier spawning

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -148,7 +148,7 @@
 	load_method = CELL //codex stuff
 	ammo = /datum/ammo/energy/lasgun/M43
 	ammo_diff = null
-	cell_type = null
+	cell_type = /obj/item/cell/lasgun/M43
 	charge_cost = ENERGY_STANDARD_AMMO_COST
 	attachable_allowed = list(
 						/obj/item/attachable/bayonet,
@@ -423,7 +423,7 @@
 	load_method = CELL //codex stuff
 	ammo = /datum/ammo/energy/lasgun/M43
 	ammo_diff = null
-	cell_type = null
+	cell_type = /obj/item/cell/lasgun/lasrifle
 	charge_cost = 20
 	attachable_allowed = list(
 						/obj/item/attachable/bayonet,


### PR DESCRIPTION
## About The Pull Request

The two energy weapons didn't have a `cell_type` set in their object. This would cause a runtime at map loading.

## Why It's Good For The Game

less runtimes

## Changelog
:cl: Hughgent
fix: runtime with tier spawning associated with energy weapons.
/:cl:

