### PR TITLE
Specs are gone, reduced to ashes. Everyone can now use spec weapons effectively.

### DIFF
--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -15,7 +15,6 @@
 		/datum/job/terragov/squad/engineer = 8,
 		/datum/job/terragov/squad/corpsman = 8,
 		/datum/job/terragov/squad/smartgunner = 1,
-		/datum/job/terragov/squad/specialist = 1,
 		/datum/job/terragov/squad/leader = 1,
 		/datum/job/terragov/medical/professor = 1,
 		/datum/job/terragov/silicon/synthetic = 1,

--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -28,7 +28,6 @@
 		/datum/job/terragov/squad/engineer = 8,
 		/datum/job/terragov/squad/corpsman = 8,
 		/datum/job/terragov/squad/smartgunner = 1,
-		/datum/job/terragov/squad/specialist = 1,
 		/datum/job/terragov/squad/leader = 1,
 		/datum/job/terragov/squad/standard = -1,
 		/datum/job/survivor/rambo = 1,

--- a/code/datums/gamemodes/extended.dm
+++ b/code/datums/gamemodes/extended.dm
@@ -23,7 +23,6 @@
 		/datum/job/terragov/squad/engineer = 8,
 		/datum/job/terragov/squad/corpsman = 8,
 		/datum/job/terragov/squad/smartgunner = 4,
-		/datum/job/terragov/squad/specialist = 4,
 		/datum/job/terragov/squad/leader = 4,
 		/datum/job/terragov/squad/standard = -1
 	)

--- a/code/datums/gamemodes/infestation.dm
+++ b/code/datums/gamemodes/infestation.dm
@@ -7,5 +7,3 @@
 	var/datum/job/scaled_job = SSjob.GetJobType(/datum/job/terragov/squad/smartgunner)
 	scaled_job.job_points_needed  = 6
 
-	scaled_job = SSjob.GetJobType(/datum/job/terragov/squad/specialist)
-	scaled_job.job_points_needed  = 6

--- a/code/datums/jobs/job/marines.dm
+++ b/code/datums/jobs/job/marines.dm
@@ -137,8 +137,8 @@ You may not be a fully-fledged doctor, but you stand between life and death when
 	req_admin_notify = TRUE
 	paygrade = "E4"
 	comm_title = "Spec"
-	total_positions = 4
-	max_positions = 6
+	total_positions = 0
+	max_positions = 0
 	access = list(ACCESS_IFF_MARINE, ACCESS_MARINE_PREP, ACCESS_MARINE_SPECPREP)
 	minimal_access = list(ACCESS_IFF_MARINE, ACCESS_MARINE_PREP, ACCESS_MARINE_SPECPREP, ACCESS_MARINE_DROPSHIP)
 	skills_type = /datum/skills/specialist
@@ -146,7 +146,7 @@ You may not be a fully-fledged doctor, but you stand between life and death when
 	outfit = /datum/outfit/job/marine/specialist
 	exp_requirements = XP_REQ_INTERMEDIATE
 	exp_type = EXP_TYPE_REGULAR_ALL
-	job_flags = JOB_FLAG_LATEJOINABLE|JOB_FLAG_ROUNDSTARTJOINABLE|JOB_FLAG_ALLOWS_PREFS_GEAR|JOB_FLAG_PROVIDES_BANK_ACCOUNT|JOB_FLAG_ADDTOMANIFEST|JOB_FLAG_PROVIDES_SQUAD_HUD
+	job_flags = JOB_FLAG_ALLOWS_PREFS_GEAR|JOB_FLAG_PROVIDES_BANK_ACCOUNT|JOB_FLAG_ADDTOMANIFEST|JOB_FLAG_PROVIDES_SQUAD_HUD
 	jobworth = list(/datum/job/xenomorph = LARVA_POINTS_STRONG)
 	job_points_needed  = 10 //Redefined via config.
 

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -579,6 +579,13 @@ GLOBAL_LIST_INIT(marine_selector_cats, list(
 		/obj/item/clothing/mask/rebreather = list(CAT_MAS, "Rebreather", 0, "black"),
 	)
 
+/obj/machinery/marine_selector/clothes/specialist/Initialize()
+    . = ..()
+    new /obj/effect/decal/cleanable/cobweb(loc)
+    for(var/d in GLOB.alldirs)
+        var/turf/T = get_step(src, d)
+        if(!T.density)
+            new /obj/effect/decal/cleanable/cobweb(T)
 
 
 /obj/machinery/marine_selector/clothes/specialist/alpha
@@ -908,6 +915,13 @@ GLOBAL_LIST_INIT(available_specialist_sets, list("Scout Set", "Sniper Set", "Dem
 		/obj/item/attachable/stock/t19stock = list(CAT_ATT, "T-19 Submachinegun stock", 0, "black"),
 	)
 
+/obj/machinery/marine_selector/gear/spec/Initialize()
+    . = ..()
+    new /obj/effect/decal/cleanable/cobweb(loc)
+    for(var/d in GLOB.alldirs)
+        var/turf/T = get_step(src, d)
+        if(!T.density)
+            new /obj/effect/decal/cleanable/cobweb(T)
 
 
 

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -548,14 +548,6 @@ GLOBAL_LIST_INIT(marine_selector_cats, list(
 	req_access = list(ACCESS_MARINE_SPECPREP)
 	vendor_role = /datum/job/terragov/squad/specialist
 	gives_webbing = FALSE
-	
-/obj/machinery/marine_selector/clothes/spec/Initialize()
-    . = ..()
-    new /obj/effect/decal/cleanable/cobweb(loc)
-    for(var/d in GLOB.alldirs)
-        var/turf/T = get_step(src, d)
-        if(!T.density)
-            new /obj/effect/decal/cleanable/cobweb(T)
 
 
 	listed_products = list(
@@ -891,15 +883,6 @@ GLOBAL_LIST_INIT(available_specialist_sets, list("Scout Set", "Sniper Set", "Dem
 	vendor_role = /datum/job/terragov/squad/specialist
 	req_access = list(ACCESS_MARINE_SPECPREP)
 	
-/obj/machinery/marine_selector/gear/spec/Initialize()
-    . = ..()
-    new /obj/effect/decal/cleanable/cobweb(loc)
-    for(var/d in GLOB.alldirs)
-        var/turf/T = get_step(src, d)
-        if(!T.density)
-            new /obj/effect/decal/cleanable/cobweb(T)
-
-
 	listed_products = list(
 		/obj/item/storage/box/spec/scout = list(CAT_ESS, "Scout Set (Battle Rifle)", 0, "white"),
 		/obj/item/storage/box/spec/tracker = list(CAT_ESS, "Scout Set (Shotgun)", 0, "white"),

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -549,12 +549,14 @@ GLOBAL_LIST_INIT(marine_selector_cats, list(
 	vendor_role = /datum/job/terragov/squad/specialist
 	gives_webbing = FALSE
 	
-	    . = ..()
+/obj/machinery/marine_selector/clothes/spec/Initialize()
+    . = ..()
     new /obj/effect/decal/cleanable/cobweb(loc)
     for(var/d in GLOB.alldirs)
         var/turf/T = get_step(src, d)
         if(!T.density)
             new /obj/effect/decal/cleanable/cobweb(T)
+
 
 	listed_products = list(
 		/obj/effect/essentials_set/basic_specialist = list(CAT_STD, "Standard Kit", 0, "white"),
@@ -889,12 +891,14 @@ GLOBAL_LIST_INIT(available_specialist_sets, list("Scout Set", "Sniper Set", "Dem
 	vendor_role = /datum/job/terragov/squad/specialist
 	req_access = list(ACCESS_MARINE_SPECPREP)
 	
-	    . = ..()
+/obj/machinery/marine_selector/gear/spec/Initialize()
+    . = ..()
     new /obj/effect/decal/cleanable/cobweb(loc)
     for(var/d in GLOB.alldirs)
         var/turf/T = get_step(src, d)
         if(!T.density)
             new /obj/effect/decal/cleanable/cobweb(T)
+
 
 	listed_products = list(
 		/obj/item/storage/box/spec/scout = list(CAT_ESS, "Scout Set (Battle Rifle)", 0, "white"),

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -548,6 +548,13 @@ GLOBAL_LIST_INIT(marine_selector_cats, list(
 	req_access = list(ACCESS_MARINE_SPECPREP)
 	vendor_role = /datum/job/terragov/squad/specialist
 	gives_webbing = FALSE
+	
+	    . = ..()
+    new /obj/effect/decal/cleanable/cobweb(loc)
+    for(var/d in GLOB.alldirs)
+        var/turf/T = get_step(src, d)
+        if(!T.density)
+            new /obj/effect/decal/cleanable/cobweb(T)
 
 	listed_products = list(
 		/obj/effect/essentials_set/basic_specialist = list(CAT_STD, "Standard Kit", 0, "white"),
@@ -881,6 +888,13 @@ GLOBAL_LIST_INIT(available_specialist_sets, list("Scout Set", "Sniper Set", "Dem
 	icon_state = "specialist"
 	vendor_role = /datum/job/terragov/squad/specialist
 	req_access = list(ACCESS_MARINE_SPECPREP)
+	
+	    . = ..()
+    new /obj/effect/decal/cleanable/cobweb(loc)
+    for(var/d in GLOB.alldirs)
+        var/turf/T = get_step(src, d)
+        if(!T.density)
+            new /obj/effect/decal/cleanable/cobweb(T)
 
 	listed_products = list(
 		/obj/item/storage/box/spec/scout = list(CAT_ESS, "Scout Set (Battle Rifle)", 0, "white"),

--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -440,7 +440,7 @@
 		last_fired = world.time
 		last_use = world.time
 		return
-	if(user.skills.getRating("spec_weapons") < 0 && !do_after(user, 1 SECONDS, TRUE, src))
+	if(user.skills.getRating("firearms") < 0 && !do_after(user, 1 SECONDS, TRUE, src))
 		return
 	return ..()
 

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -6,7 +6,7 @@
 //Note that this means that snipers will have a slowdown of 3, due to the scope
 /obj/item/weapon/gun/rifle/sniper
 	aim_slowdown = 1
-	gun_skill_category = GUN_SKILL_SPEC
+	gun_skill_category = GUN_SKILL_RIFLE
 	wield_delay = 1 SECONDS
 
 //Pow! Headshot
@@ -317,7 +317,7 @@
 
 	flags_gun_features = GUN_AUTO_EJECTOR|GUN_WIELDED_FIRING_ONLY|GUN_AMMO_COUNTER
 	gun_firemode_list = list(GUN_FIREMODE_SEMIAUTO, GUN_FIREMODE_AUTOMATIC)
-	gun_skill_category = GUN_SKILL_SPEC
+	gun_skill_category = GUN_SKILL_FIREARMS
 	attachable_offset = list("muzzle_x" = 32, "muzzle_y" = 17,"rail_x" = 12, "rail_y" = 23, "under_x" = 23, "under_y" = 13, "stock_x" = 24, "stock_y" = 13)
 	starting_attachment_types = list(/obj/item/attachable/scope/mini/m4ra, /obj/item/attachable/stock/rifle/marksman)
 
@@ -482,7 +482,7 @@
 						/obj/item/attachable/scope/mini)
 
 	flags_gun_features = GUN_UNUSUAL_DESIGN|GUN_WIELDED_FIRING_ONLY|GUN_AMMO_COUNTER
-	gun_skill_category = GUN_SKILL_SPEC
+	gun_skill_category = GUN_SKILL_FIREARMS
 	var/datum/effect_system/smoke_spread/smoke
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 18,"rail_x" = 14, "rail_y" = 22, "under_x" = 19, "under_y" = 14, "stock_x" = 19, "stock_y" = 14)
 
@@ -526,7 +526,7 @@
 		return
 	if(gun_on_cooldown(user))
 		return
-	if(user.skills.getRating("spec_weapons") < 0 && !do_after(user, 0.8 SECONDS, TRUE, src))
+	if(user.skills.getRating("firearms") < 0 && !do_after(user, 0.8 SECONDS, TRUE, src))
 		return
 	if(get_dist(target,user) <= 2)
 		to_chat(user, "<span class='warning'>The grenade launcher beeps a warning noise. You are too close!</span>")
@@ -609,7 +609,7 @@
 	fire_sound = 'sound/weapons/armbomb.ogg'
 	cocked_sound = 'sound/weapons/guns/interact/m92_cocked.ogg'
 	aim_slowdown = 1
-	gun_skill_category = GUN_SKILL_SPEC
+	gun_skill_category = GUN_SKILL_FIREARMS
 	flags_gun_features = GUN_UNUSUAL_DESIGN|GUN_WIELDED_FIRING_ONLY|GUN_AMMO_COUNTER
 	attachable_allowed = list()
 	var/grenade
@@ -749,7 +749,7 @@
 						/obj/item/attachable/scope/mini)
 
 	flags_gun_features = GUN_WIELDED_FIRING_ONLY|GUN_AMMO_COUNTER
-	gun_skill_category = GUN_SKILL_SPEC
+	gun_skill_category = GUN_SKILL_FIREARMS
 	dry_fire_sound = 'sound/weapons/guns/fire/launcher_empty.ogg'
 	reload_sound = 'sound/weapons/guns/interact/launcher_reload.ogg'
 	unload_sound = 'sound/weapons/guns/interact/launcher_reload.ogg'
@@ -780,7 +780,7 @@
 	if(has_attachment(/obj/item/attachable/scope/mini))
 		delay += 0.2 SECONDS
 
-	if(user.skills.getRating("spec_weapons") < 0)
+	if(user.skills.getRating("firearms") < 0)
 		delay += 0.6 SECONDS
 
 	if(!do_after(user, delay, TRUE, src, BUSY_ICON_DANGER)) //slight wind up

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -6,7 +6,7 @@
 //Note that this means that snipers will have a slowdown of 3, due to the scope
 /obj/item/weapon/gun/rifle/sniper
 	aim_slowdown = 1
-	gun_skill_category = GUN_SKILL_RIFLE
+	gun_skill_category = GUN_SKILL_RIFLES
 	wield_delay = 1 SECONDS
 
 //Pow! Headshot

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -967,7 +967,7 @@
 	w_class = WEIGHT_CLASS_HUGE
 	force = 20
 	wield_delay = 15
-	gun_skill_category = GUN_SKILL_SPEC
+	gun_skill_category = GUN_SKILL_FIREARMS
 	aim_slowdown = 1.4
 	flags_gun_features = GUN_AUTO_EJECTOR|GUN_WIELDED_FIRING_ONLY|GUN_LOAD_INTO_CHAMBER|GUN_AMMO_COUNTER
 	gun_firemode_list = list(GUN_FIREMODE_BURSTFIRE, GUN_FIREMODE_AUTOMATIC, GUN_FIREMODE_AUTOBURST)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Specs are now disabled from being picked.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I'm curious to see how this pans out, removing specs and making their gear expensive power tools.
Specialists are bad for game design in a game that's centered around team based play, mostly because the entire team is dependant on 4 dudes, who if they die cripple the entire team. Balancing them is a chore as well.
If this makes marines lose literally every round I'm up for buffing PFCs rather than re-adding them personally.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Specs are gone. Anyone can use spec gear weapons now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
