### PR TITLE
Frenzy Reduction

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -282,6 +282,6 @@
 		return
 	frenzy_aura = new_aura
 	if(frenzy_aura)
-		add_movespeed_modifier(MOVESPEED_ID_FRENZY_AURA, TRUE, 0, NONE, TRUE, -frenzy_aura * 0.1)
+		add_movespeed_modifier(MOVESPEED_ID_FRENZY_AURA, TRUE, 0, NONE, TRUE, -frenzy_aura * 0.06)
 		return
 	remove_movespeed_modifier(MOVESPEED_ID_FRENZY_AURA)


### PR DESCRIPTION
## About The Pull Request

Reduces the speed bonus from frenzy. 

## Why It's Good For The Game

Xenos having good speeds without frenzy is just bad because, well, then frenzy pops that up a bit too much. So here's a frenzy nerf. 

## Changelog
:cl:
balance: Frenzy speed bonus reduced
/:cl:

