### PR TITLE
Reset clothing's bio armor

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -1,5 +1,9 @@
 /obj/item/clothing
 	name = "clothing"
+
+	/// Resets the armor on clothing since by default /objs get 100 bio armor
+	soft_armor = list()
+	
 	var/eye_protection = 0 //used for headgear, masks, and glasses, to see how much they protect eyes from bright lights.
 	var/accuracy_mod = 0
 


### PR DESCRIPTION
Previously items had 100 bio, this was on every item that didn't have default armor.
Since the soft/hard changes were added to objs we previously broke that, so i added a fix.

That fix had the sideeffect of giving armorless cloths 100 bio armor.

This is resetting that back to 0 armor values.