### PR TITLE
fixes razorwire not working and nerfs it

### DIFF
--- a/code/game/objects/structures/razorwire.dm
+++ b/code/game/objects/structures/razorwire.dm
@@ -64,8 +64,7 @@
 
 
 /obj/structure/razorwire/proc/do_razorwire_tangle(mob/living/entangled)
-	to_chat(world, "Do razorwire_tangle called.")
-	entangled.set_canmove(FALSE)
+	ADD_TRAIT(entangled, TRAIT_IMMOBILE, type)
 	
 	ENABLE_BITFIELD(entangled.restrained_flags, RESTRAINED_RAZORWIRE)
 	LAZYADD(entangled_list, entangled) //Add the entangled person to the trapped list.
@@ -100,7 +99,7 @@
 	UnregisterSignal(entangled, list(COMSIG_PARENT_QDELETING, COMSIG_LIVING_DO_RESIST, COMSIG_MOVABLE_UNCROSS))
 	LAZYREMOVE(entangled_list, entangled)
 	DISABLE_BITFIELD(entangled.restrained_flags, RESTRAINED_RAZORWIRE)
-	entangled.set_canmove(TRUE)
+	REMOVE_TRAIT(entangled, TRAIT_IMMOBILE, type)
 
 
 /obj/structure/razorwire/proc/on_entangled_uncross(datum/source, atom/movable/uncrosser)

--- a/code/game/objects/structures/razorwire.dm
+++ b/code/game/objects/structures/razorwire.dm
@@ -60,12 +60,11 @@
 	COOLDOWN_START(entangled, COOLDOWN_ENTANGLE, duration)
 	entangled.visible_message("<span class='danger'>[entangled] gets entangled in the barbed wire!</span>",
 	"<span class='danger'>You got entangled in the barbed wire! Resist to untangle yourself after [duration * 0.1] seconds since you were entangled!</span>", null, null, 5)
-	do_razorwire_tangle()
+	do_razorwire_tangle(entangled)
 
 
 /obj/structure/razorwire/proc/do_razorwire_tangle(mob/living/entangled)
 	ADD_TRAIT(entangled, TRAIT_IMMOBILE, type)
-	
 	ENABLE_BITFIELD(entangled.restrained_flags, RESTRAINED_RAZORWIRE)
 	LAZYADD(entangled_list, entangled) //Add the entangled person to the trapped list.
 	RegisterSignal(entangled, COMSIG_LIVING_DO_RESIST, /atom/movable.proc/resisted_against)

--- a/code/game/objects/structures/razorwire.dm
+++ b/code/game/objects/structures/razorwire.dm
@@ -65,7 +65,8 @@
 
 /obj/structure/razorwire/proc/do_razorwire_tangle(mob/living/entangled)
 	to_chat(world, "Do razorwire_tangle called.")
-	ADD_TRAIT(entangled, TRAIT_IMMOBILE, type)
+	entangled.on_immobile_trait_gain()
+	
 	ENABLE_BITFIELD(entangled.restrained_flags, RESTRAINED_RAZORWIRE)
 	LAZYADD(entangled_list, entangled) //Add the entangled person to the trapped list.
 	RegisterSignal(entangled, COMSIG_LIVING_DO_RESIST, /atom/movable.proc/resisted_against)
@@ -99,7 +100,7 @@
 	UnregisterSignal(entangled, list(COMSIG_PARENT_QDELETING, COMSIG_LIVING_DO_RESIST, COMSIG_MOVABLE_UNCROSS))
 	LAZYREMOVE(entangled_list, entangled)
 	DISABLE_BITFIELD(entangled.restrained_flags, RESTRAINED_RAZORWIRE)
-	REMOVE_TRAIT(entangled, TRAIT_IMMOBILE, type)
+	entangled.on_immobile_trait_loss()
 
 
 /obj/structure/razorwire/proc/on_entangled_uncross(datum/source, atom/movable/uncrosser)

--- a/code/game/objects/structures/razorwire.dm
+++ b/code/game/objects/structures/razorwire.dm
@@ -16,7 +16,7 @@
 	var/table_prefix = "" //used in update_icon()
 	max_integrity = RAZORWIRE_MAX_HEALTH
 	var/soak = 5
-	flags_atom = ON_BORDER
+
 /obj/structure/razorwire/deconstruct(disassembled = TRUE)
 	if(disassembled)
 		if(obj_integrity > max_integrity * 0.5)

--- a/code/game/objects/structures/razorwire.dm
+++ b/code/game/objects/structures/razorwire.dm
@@ -88,7 +88,7 @@
 	playsound(src, 'sound/effects/barbed_wire_movement.ogg', 25, TRUE)
 	var/def_zone = ran_zone()
 	var/armor_block = entangled.run_armor_check(def_zone, "melee")
-	entangled.apply_damage(rand(RAZORWIRE_BASE_DAMAGE * 0.8, RAZORWIRE_BASE_DAMAGE * 1.2), BRUTE, def_zone, armor_block, TRUE) //Apply damage as we tear free
+	entangled.apply_damage(RAZORWIRE_BASE_DAMAGE * RAZORWIRE_MIN_DAMAGE_MULT_MED, BRUTE, def_zone, armor_block, TRUE) //Apply damage as we tear free
 	UPDATEHEALTH(entangled)
 	return TRUE
 

--- a/code/game/objects/structures/razorwire.dm
+++ b/code/game/objects/structures/razorwire.dm
@@ -16,7 +16,7 @@
 	var/table_prefix = "" //used in update_icon()
 	max_integrity = RAZORWIRE_MAX_HEALTH
 	var/soak = 5
-
+	flags_atom = ON_BORDER
 /obj/structure/razorwire/deconstruct(disassembled = TRUE)
 	if(disassembled)
 		if(obj_integrity > max_integrity * 0.5)

--- a/code/game/objects/structures/razorwire.dm
+++ b/code/game/objects/structures/razorwire.dm
@@ -64,6 +64,7 @@
 
 
 /obj/structure/razorwire/proc/do_razorwire_tangle(mob/living/entangled)
+	to_chat(world, "Do razorwire_tangle called.")
 	ADD_TRAIT(entangled, TRAIT_IMMOBILE, type)
 	ENABLE_BITFIELD(entangled.restrained_flags, RESTRAINED_RAZORWIRE)
 	LAZYADD(entangled_list, entangled) //Add the entangled person to the trapped list.

--- a/code/game/objects/structures/razorwire.dm
+++ b/code/game/objects/structures/razorwire.dm
@@ -65,7 +65,7 @@
 
 /obj/structure/razorwire/proc/do_razorwire_tangle(mob/living/entangled)
 	to_chat(world, "Do razorwire_tangle called.")
-	entangled.on_immobile_trait_gain()
+	entangled.set_canmove(FALSE)
 	
 	ENABLE_BITFIELD(entangled.restrained_flags, RESTRAINED_RAZORWIRE)
 	LAZYADD(entangled_list, entangled) //Add the entangled person to the trapped list.
@@ -100,7 +100,7 @@
 	UnregisterSignal(entangled, list(COMSIG_PARENT_QDELETING, COMSIG_LIVING_DO_RESIST, COMSIG_MOVABLE_UNCROSS))
 	LAZYREMOVE(entangled_list, entangled)
 	DISABLE_BITFIELD(entangled.restrained_flags, RESTRAINED_RAZORWIRE)
-	entangled.on_immobile_trait_loss()
+	entangled.set_canmove(TRUE)
 
 
 /obj/structure/razorwire/proc/on_entangled_uncross(datum/source, atom/movable/uncrosser)

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -128,7 +128,7 @@
 	. = ..()
 	if(!.)
 		return FALSE
-	if(X.is_charging == CHARGE_ON)
+	if(X.is_charging != CHARGE_OFF)
 		return FALSE
 	if(!X.hive.slashing_allowed && !(X.xeno_caste.caste_flags & CASTE_IS_INTELLIGENT))
 		to_chat(X, "<span class='warning'>Slashing is currently <b>forbidden</b> by the Queen. We refuse to slash [src].</span>")

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -128,7 +128,6 @@
 	. = ..()
 	if(!.)
 		return FALSE
-
 	if(!X.hive.slashing_allowed && !(X.xeno_caste.caste_flags & CASTE_IS_INTELLIGENT))
 		to_chat(X, "<span class='warning'>Slashing is currently <b>forbidden</b> by the Queen. We refuse to slash [src].</span>")
 		return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -128,6 +128,8 @@
 	. = ..()
 	if(!.)
 		return FALSE
+	if(X.is_charging == CHARGE_ON)
+		return FALSE
 	if(!X.hive.slashing_allowed && !(X.xeno_caste.caste_flags & CASTE_IS_INTELLIGENT))
 		to_chat(X, "<span class='warning'>Slashing is currently <b>forbidden</b> by the Queen. We refuse to slash [src].</span>")
 		return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -128,7 +128,7 @@
 	. = ..()
 	if(!.)
 		return FALSE
-	if(X.is_charging != CHARGE_OFF)
+	if(X.is_charging != CHARGE_OFF && get_charge_type() != CHARGE_BULL_GORE)
 		return FALSE
 	if(!X.hive.slashing_allowed && !(X.xeno_caste.caste_flags & CASTE_IS_INTELLIGENT))
 		to_chat(X, "<span class='warning'>Slashing is currently <b>forbidden</b> by the Queen. We refuse to slash [src].</span>")

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -128,8 +128,7 @@
 	. = ..()
 	if(!.)
 		return FALSE
-	if(X.is_charging != CHARGE_OFF && get_charge_type() != CHARGE_BULL_GORE)
-		return FALSE
+
 	if(!X.hive.slashing_allowed && !(X.xeno_caste.caste_flags & CASTE_IS_INTELLIGENT))
 		to_chat(X, "<span class='warning'>Slashing is currently <b>forbidden</b> by the Queen. We refuse to slash [src].</span>")
 		return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -478,7 +478,7 @@
 /obj/structure/razorwire/post_crush_act(mob/living/carbon/xenomorph/charger, datum/action/xeno_action/ready_charge/charge_datum)
 	if(!anchored)
 		return ..()
-	razorwire_tangle(charger, RAZORWIRE_ENTANGLE_DELAY * 0.25) //entangled for only 25% as long or 1.25 seconds
+	razorwire_tangle(charger, RAZORWIRE_ENTANGLE_DELAY * .20) //entangled for only 20% as long or 1 second
 	charger.visible_message("<span class='danger'>The barbed wire slices into [charger]!</span>",
 	"<span class='danger'>The barbed wire slices into you!</span>", null, 5)
 	charger.Paralyze(05)

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -481,7 +481,7 @@
 	razorwire_tangle(charger, RAZORWIRE_ENTANGLE_DELAY * 0.20) //entangled for only 20% as long or 1 second
 	charger.visible_message("<span class='danger'>The barbed wire slices into [charger]!</span>",
 	"<span class='danger'>The barbed wire slices into you!</span>", null, 5)
-	charger.Paralyze(05)
+	charger.Paralyze(0.5 SECONDS)
 	charger.apply_damage(RAZORWIRE_BASE_DAMAGE * RAZORWIRE_MIN_DAMAGE_MULT_MED, BRUTE, ran_zone(), 0, TRUE) //Armor is being ignored here.
 	UPDATEHEALTH(charger)
 	playsound(src, 'sound/effects/barbed_wire_movement.ogg', 25, 1)

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -478,7 +478,7 @@
 /obj/structure/razorwire/post_crush_act(mob/living/carbon/xenomorph/charger, datum/action/xeno_action/ready_charge/charge_datum)
 	if(!anchored)
 		return ..()
-	razorwire_tangle(charger, RAZORWIRE_ENTANGLE_DELAY * 0.5) //entangled for only half as long
+	razorwire_tangle(charger, RAZORWIRE_ENTANGLE_DELAY * 0.25) //entangled for only 25% as long or 1.25 seconds
 	charger.visible_message("<span class='danger'>The barbed wire slices into [charger]!</span>",
 	"<span class='danger'>The barbed wire slices into you!</span>", null, 5)
 	charger.Paralyze(05)

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -382,23 +382,23 @@
 		if(flags_atom & ON_BORDER)
 			if(dir == REVERSE_DIR(charger.dir))
 				. = (CHARGE_SPEED(charge_datum) * 80) //Damage to inflict.
-				to_chat(world, "It takes [.] amount of damage.")
+				to_chat(world, "It takes [.] amount of damage. First check 80")
 				charge_datum.speed_down(3)
 				return
 			else
 				. = (CHARGE_SPEED(charge_datum) * 160)
 				charge_datum.speed_down(1)
-				to_chat(world, "It takes [.] amount of damage.")
+				to_chat(world, "It takes [.] amount of damage. Second Check 160")
 				return
 		else
 			. = (CHARGE_SPEED(charge_datum) * 240)
 			charge_datum.speed_down(2)
-			to_chat(world, "It takes [.] amount of damage.")
+			to_chat(world, "It takes [.] amount of damage. Third Check 240")
 			return
 
 	for(var/m in buckled_mobs)
 		unbuckle_mob(m)
-	to_chat(world, "It takes [CHARGE_SPEED(charge_datum) * 20] amount of damage.")
+	to_chat(world, "It takes [CHARGE_SPEED(charge_datum) * 20] amount of damage. Fourth Check 20")
 	return (CHARGE_SPEED(charge_datum) * 20) //Damage to inflict.
 
 

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -572,8 +572,8 @@
 
 	charge_datum.do_stop_momentum(FALSE)
 	return PRECRUSH_STOPPED
-/mob/living/carbon/xenomorph/proc/get_charge_type(datum/action/xeno_action/ready_charge/charge_datum)
-	return charge_datum.charge_type
+/mob/living/carbon/xenomorph/proc/get_charge_type(datum/action/xeno_action/ready_charge/charge_datum/C)
+	return C.charge_type
 
 /mob/living/proc/emote_gored()
 	return

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -304,7 +304,7 @@
 				return COMPONENT_MOVABLE_PREBUMP_STOPPED
 			else
 				return COMPONENT_MOVABLE_PREBUMP_PLOWED
-
+		charger.visible_message("<span class='danger'>called crush object", null, 5)
 		return precrush2signal(crushed_obj.post_crush_act(charger, src))
 
 	if(isturf(crushed))
@@ -468,6 +468,7 @@
 
 /obj/structure/razorwire/post_crush_act(mob/living/carbon/xenomorph/charger, datum/action/xeno_action/ready_charge/charge_datum)
 	if(!anchored)
+		charger.visible_message("<span class='danger'>Uh oh it broke", null, 5)
 		return ..()
 	razorwire_tangle(charger, RAZORWIRE_ENTANGLE_DELAY * 0.5) //entangled for only half as long
 	charger.visible_message("<span class='danger'>The barbed wire slices into [charger]!</span>",

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -297,6 +297,7 @@
 		playsound(crushed_obj.loc, "punch", 25, 1)
 		var/crushed_behavior = crushed_obj.crushed_special_behavior()
 		crushed_obj.take_damage(precrush)
+		to_chat(world, "It takes [precrush] amount of damage.")
 		if(QDELETED(crushed_obj))
 			charger.visible_message("<span class='danger'>[charger] crushes [preserved_name]!</span>",
 			"<span class='xenodanger'>We crush [preserved_name]!</span>")

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -304,7 +304,7 @@
 				return COMPONENT_MOVABLE_PREBUMP_STOPPED
 			else
 				return COMPONENT_MOVABLE_PREBUMP_PLOWED
-		charger.visible_message("<span class='danger'>called crush object", null, 5)
+		charger.visible_message("<span class='danger'>called crush object", "<span class='xenodanger'>We crush [preserved_name]!</span>", 5)
 		return precrush2signal(crushed_obj.post_crush_act(charger, src))
 
 	if(isturf(crushed))
@@ -468,7 +468,7 @@
 
 /obj/structure/razorwire/post_crush_act(mob/living/carbon/xenomorph/charger, datum/action/xeno_action/ready_charge/charge_datum)
 	if(!anchored)
-		charger.visible_message("<span class='danger'>Uh oh it broke", null, 5)
+		charger.visible_message("<span class='danger'>Uh oh it broke","<span class='danger'>Uh oh it broke" , 5)
 		return ..()
 	razorwire_tangle(charger, RAZORWIRE_ENTANGLE_DELAY * 0.5) //entangled for only half as long
 	charger.visible_message("<span class='danger'>The barbed wire slices into [charger]!</span>",

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -482,7 +482,7 @@
 	charger.visible_message("<span class='danger'>The barbed wire slices into [charger]!</span>",
 	"<span class='danger'>The barbed wire slices into you!</span>", null, 5)
 	charger.Paralyze(05)
-	charger.apply_damage(rand(RAZORWIRE_BASE_DAMAGE * RAZORWIRE_MIN_DAMAGE_MULT_MED, RAZORWIRE_BASE_DAMAGE * RAZORWIRE_MAX_DAMAGE_MULT_MED), BRUTE, ran_zone(), 0, TRUE) //Armor is being ignored here.
+	charger.apply_damage(RAZORWIRE_BASE_DAMAGE * RAZORWIRE_MIN_DAMAGE_MULT_MED, BRUTE, ran_zone(), 0, TRUE) //Armor is being ignored here.
 	UPDATEHEALTH(charger)
 	playsound(src, 'sound/effects/barbed_wire_movement.ogg', 25, 1)
 	update_icon()

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -401,7 +401,7 @@
 		charge_datum.do_stop_momentum()
 		return PRECRUSH_STOPPED
 	if(anchored)
-		. = (CHARGE_SPEED(charge_datum) * 80) //Damage to inflict.
+		. = (CHARGE_SPEED(charge_datum) * 50) //Damage to inflict. 3 rams, 2 times taking damage.
 		charge_datum.speed_down(3)
 		return
 	return (CHARGE_SPEED(charge_datum) * 20) //Damage to inflict.
@@ -481,7 +481,7 @@
 	razorwire_tangle(charger, RAZORWIRE_ENTANGLE_DELAY * 0.5) //entangled for only half as long
 	charger.visible_message("<span class='danger'>The barbed wire slices into [charger]!</span>",
 	"<span class='danger'>The barbed wire slices into you!</span>", null, 5)
-	charger.Paralyze(20)
+	charger.Paralyze(05)
 	charger.apply_damage(rand(RAZORWIRE_BASE_DAMAGE * RAZORWIRE_MIN_DAMAGE_MULT_MED, RAZORWIRE_BASE_DAMAGE * RAZORWIRE_MAX_DAMAGE_MULT_MED), BRUTE, ran_zone(), 0, TRUE) //Armor is being ignored here.
 	UPDATEHEALTH(charger)
 	playsound(src, 'sound/effects/barbed_wire_movement.ogg', 25, 1)

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -297,7 +297,6 @@
 		playsound(crushed_obj.loc, "punch", 25, 1)
 		var/crushed_behavior = crushed_obj.crushed_special_behavior()
 		crushed_obj.take_damage(precrush)
-		to_chat(world, "It takes [precrush] amount of damage.")
 		if(QDELETED(crushed_obj))
 			charger.visible_message("<span class='danger'>[charger] crushes [preserved_name]!</span>",
 			"<span class='xenodanger'>We crush [preserved_name]!</span>")

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -572,7 +572,8 @@
 
 	charge_datum.do_stop_momentum(FALSE)
 	return PRECRUSH_STOPPED
-
+/mob/living/carbon/xenomorph/proc/get_charge_type(datum/action/xeno_action/ready_charge/charge_datum)
+	return charge_datum.charge_type
 
 /mob/living/proc/emote_gored()
 	return

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -382,19 +382,23 @@
 		if(flags_atom & ON_BORDER)
 			if(dir == REVERSE_DIR(charger.dir))
 				. = (CHARGE_SPEED(charge_datum) * 80) //Damage to inflict.
+				to_chat(world, "It takes [.] amount of damage.")
 				charge_datum.speed_down(3)
 				return
 			else
 				. = (CHARGE_SPEED(charge_datum) * 160)
 				charge_datum.speed_down(1)
+				to_chat(world, "It takes [.] amount of damage.")
 				return
 		else
 			. = (CHARGE_SPEED(charge_datum) * 240)
 			charge_datum.speed_down(2)
+			to_chat(world, "It takes [.] amount of damage.")
 			return
 
 	for(var/m in buckled_mobs)
 		unbuckle_mob(m)
+	to_chat(world, "It takes [CHARGE_SPEED(charge_datum) * 20] amount of damage.")
 	return (CHARGE_SPEED(charge_datum) * 20) //Damage to inflict.
 
 

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -478,7 +478,7 @@
 /obj/structure/razorwire/post_crush_act(mob/living/carbon/xenomorph/charger, datum/action/xeno_action/ready_charge/charge_datum)
 	if(!anchored)
 		return ..()
-	razorwire_tangle(charger, RAZORWIRE_ENTANGLE_DELAY * .20) //entangled for only 20% as long or 1 second
+	razorwire_tangle(charger, RAZORWIRE_ENTANGLE_DELAY * 0.20) //entangled for only 20% as long or 1 second
 	charger.visible_message("<span class='danger'>The barbed wire slices into [charger]!</span>",
 	"<span class='danger'>The barbed wire slices into you!</span>", null, 5)
 	charger.Paralyze(05)

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -572,8 +572,7 @@
 
 	charge_datum.do_stop_momentum(FALSE)
 	return PRECRUSH_STOPPED
-/mob/living/carbon/xenomorph/proc/get_charge_type(datum/action/xeno_action/ready_charge/C)
-	return C.charge_type
+
 
 /mob/living/proc/emote_gored()
 	return

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -304,7 +304,7 @@
 				return COMPONENT_MOVABLE_PREBUMP_STOPPED
 			else
 				return COMPONENT_MOVABLE_PREBUMP_PLOWED
-		charger.visible_message("<span class='danger'>called crush object", "<span class='xenodanger'>We crush [preserved_name]!</span>", 5)
+
 		return precrush2signal(crushed_obj.post_crush_act(charger, src))
 
 	if(isturf(crushed))
@@ -468,7 +468,6 @@
 
 /obj/structure/razorwire/post_crush_act(mob/living/carbon/xenomorph/charger, datum/action/xeno_action/ready_charge/charge_datum)
 	if(!anchored)
-		charger.visible_message("<span class='danger'>Uh oh it broke","<span class='danger'>Uh oh it broke" , 5)
 		return ..()
 	razorwire_tangle(charger, RAZORWIRE_ENTANGLE_DELAY * 0.5) //entangled for only half as long
 	charger.visible_message("<span class='danger'>The barbed wire slices into [charger]!</span>",

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -572,7 +572,7 @@
 
 	charge_datum.do_stop_momentum(FALSE)
 	return PRECRUSH_STOPPED
-/mob/living/carbon/xenomorph/proc/get_charge_type(datum/action/xeno_action/ready_charge/charge_datum/C)
+/mob/living/carbon/xenomorph/proc/get_charge_type(datum/action/xeno_action/ready_charge/C)
 	return C.charge_type
 
 /mob/living/proc/emote_gored()

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -382,25 +382,30 @@
 		if(flags_atom & ON_BORDER)
 			if(dir == REVERSE_DIR(charger.dir))
 				. = (CHARGE_SPEED(charge_datum) * 80) //Damage to inflict.
-				to_chat(world, "It takes [.] amount of damage. First check 80")
 				charge_datum.speed_down(3)
 				return
 			else
 				. = (CHARGE_SPEED(charge_datum) * 160)
 				charge_datum.speed_down(1)
-				to_chat(world, "It takes [.] amount of damage. Second Check 160")
 				return
 		else
 			. = (CHARGE_SPEED(charge_datum) * 240)
 			charge_datum.speed_down(2)
-			to_chat(world, "It takes [.] amount of damage. Third Check 240")
 			return
-
+		
 	for(var/m in buckled_mobs)
 		unbuckle_mob(m)
-	to_chat(world, "It takes [CHARGE_SPEED(charge_datum) * 20] amount of damage. Fourth Check 20")
 	return (CHARGE_SPEED(charge_datum) * 20) //Damage to inflict.
 
+/obj/structure/razorwire/pre_crush_act(mob/living/carbon/xenomorph/charger, datum/action/xeno_action/ready_charge/charge_datum)
+	if(CHECK_BITFIELD(resistance_flags, INDESTRUCTIBLE) || charger.is_charging < CHARGE_ON)
+		charge_datum.do_stop_momentum()
+		return PRECRUSH_STOPPED
+	if(anchored)
+		. = (CHARGE_SPEED(charge_datum) * 80) //Damage to inflict.
+		charge_datum.speed_down(3)
+		return
+	return (CHARGE_SPEED(charge_datum) * 20) //Damage to inflict.
 
 /obj/structure/bed/pre_crush_act(mob/living/carbon/xenomorph/charger, datum/action/xeno_action/ready_charge/charge_datum)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

This PR fixes razorwire and makes it into its intended state, albeit less powerful than was originally in there. It entangles crushers for 1 second, and takes 3 RAMS to destroy, the crusher takes damage the 2 first times when ramming.
## Why It's Good For The Game

fixes are good, but this is content and complexity that was never in the game before. I believe this will strengthen fob defense while also forcing xenos to work around the razorwire, like through gas shelling and vomiting acid onto the wire or spitters using their acid spray to remove it in 2 hits. It adds more tools for engineers, while making sure crushers arent instantly breaching the FOB

## Changelog
:cl:
balance: reduced the stun on the razorwire for charging crushers from 2 seconds to half a second, this is to make sure they actually stop moving.
balance: based on input by xeno people, and testing, I have turned the damage into a flat 32 for getting entangled and unentangled. Try and use spitter acid spray or gas clouds and vomiting acid.
balance: made the entanglement last 1 second instead of 2.5 seconds.
fix: fixed razorwire being instantly destroyed by crushers.
fix: fixed razorwire not correctly entangling.
/:cl: