### PR TITLE
Fixes pacman generators not working and adjusts them

### DIFF
--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -90,9 +90,9 @@
 	var/sheet_name = ""
 	var/sheet_path = /obj/item/stack/sheet/mineral/phoron
 	var/sheet_left = 0 // How much is left of the sheet
-	var/time_per_sheet = 260
+	var/time_per_sheet = 580
 	var/current_heat = 0
-
+	power_gen = 15000
 /obj/machinery/power/port_gen/pacman/Initialize()
 	. = ..()
 	if(anchored)

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -93,6 +93,7 @@
 	var/time_per_sheet = 580
 	var/current_heat = 0
 	power_gen = 15000
+
 /obj/machinery/power/port_gen/pacman/Initialize()
 	. = ..()
 	if(anchored)

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -97,6 +97,12 @@
 	. = ..()
 	if(anchored)
 		connect_to_network()
+	component_parts = list()
+	component_parts += new /obj/item/stock_parts/matter_bin(src)
+	component_parts += new /obj/item/stock_parts/micro_laser(src)
+	component_parts += new /obj/item/stack/cable_coil(src)
+	component_parts += new /obj/item/stack/cable_coil(src)
+	component_parts += new /obj/item/stock_parts/capacitor(src)
 	RefreshParts()
 
 /obj/machinery/power/port_gen/pacman/Initialize()

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -17,8 +17,6 @@
 	var/base_icon = "portgen0"
 	var/datum/looping_sound/generator/soundloop
 
-	interaction_flags = INTERACT_MACHINE_TGUI
-
 /obj/machinery/power/port_gen/Initialize()
 	. = ..()
 	soundloop = new(list(src), active)
@@ -93,6 +91,7 @@
 	var/time_per_sheet = 580
 	var/current_heat = 0
 	power_gen = 15000
+	interaction_flags = INTERACT_MACHINE_TGUI
 
 /obj/machinery/power/port_gen/pacman/Initialize()
 	. = ..()

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -97,6 +97,7 @@
 	. = ..()
 	if(anchored)
 		connect_to_network()
+	RefreshParts()
 
 /obj/machinery/power/port_gen/pacman/Initialize()
 	. = ..()

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -17,7 +17,7 @@
 	var/base_icon = "portgen0"
 	var/datum/looping_sound/generator/soundloop
 
-	interaction_flags_atom = INTERACT_ATOM_ATTACK_HAND | INTERACT_ATOM_UI_INTERACT | INTERACT_ATOM_REQUIRES_ANCHORED
+	interaction_flags = INTERACT_MACHINE_TGUI
 
 /obj/machinery/power/port_gen/Initialize()
 	. = ..()

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -17,7 +17,7 @@
 	var/base_icon = "portgen0"
 	var/datum/looping_sound/generator/soundloop
 
-	//interaction_flags_atom = INTERACT_ATOM_ATTACK_HAND | INTERACT_ATOM_UI_INTERACT | INTERACT_ATOM_REQUIRES_ANCHORED
+	interaction_flags_atom = INTERACT_ATOM_ATTACK_HAND | INTERACT_ATOM_UI_INTERACT | INTERACT_ATOM_REQUIRES_ANCHORED
 
 /obj/machinery/power/port_gen/Initialize()
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

This PR fixes Pacmans and makes the UI actually work along with the power usage and stuff.
## Why It's Good For The Game

This should have been fixed a long time ago, as it is not intended behavior and its a feature that was ignored. 
## Changelog
:cl:
fix: made the pacman's UI usable
fix: made the pacman actually eat away at the sheets.
balance: adjusted the pacman to be longer lasting and have more power for use
/:cl: