### PR TITLE
Fix resin walls leaving behind bad turfs

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -226,7 +226,9 @@
 	var/atom/new_resin
 
 	if(ispath(X.selected_resin, /turf)) // We should change turfs, not spawn them in directly
-		T.ChangeTurf(X.selected_resin)
+		var/baseturfs = islist(T.baseturfs) ? T.baseturfs : list(T.baseturfs)
+		baseturfs |= T.type
+		T.ChangeTurf(X.selected_resin, baseturfs)
 		new_resin = T
 	else
 		new_resin = new X.selected_resin(T)

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -226,7 +226,7 @@
 	var/atom/new_resin
 
 	if(ispath(X.selected_resin, /turf)) // We should change turfs, not spawn them in directly
-		var/baseturfs = islist(T.baseturfs) ? T.baseturfs : list(T.baseturfs)
+		var/list/baseturfs = islist(T.baseturfs) ? T.baseturfs : list(T.baseturfs)
 		baseturfs |= T.type
 		T.ChangeTurf(X.selected_resin, baseturfs)
 		new_resin = T


### PR DESCRIPTION
Currently when you destroy walls they goto the root turf type, which on lava outpost is lava.
This adds the current turf to the list to revert to.