### PR TITLE
Drone to Queen

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
@@ -28,7 +28,7 @@
 	evolution_threshold = 80
 	upgrade_threshold = 60
 
-	evolves_to = list(/mob/living/carbon/xenomorph/shrike, /mob/living/carbon/xenomorph/carrier, /mob/living/carbon/xenomorph/hivelord, /mob/living/carbon/xenomorph/hivemind)
+	evolves_to = list(/mob/living/carbon/xenomorph/shrike, /mob/living/carbon/xenomorph/queen, /mob/living/carbon/xenomorph/carrier, /mob/living/carbon/xenomorph/hivelord, /mob/living/carbon/xenomorph/hivemind)
 
 	// *** Flags *** //
 	caste_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_EVOLUTION_ALLOWED|CASTE_CAN_HOLD_FACEHUGGERS|CASTE_CAN_VENT_CRAWL|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER


### PR DESCRIPTION

## About The Pull Request

Drones can evolve to Queen again. 
## Why It's Good For The Game

Shrikes don't have to sacrifice their maturity to have a Queen in the hive anymore. 

## Changelog
:cl:
tweak: Drones can evolve to Queen 
/:cl:


