### PR TITLE
Add sound alert for command replies

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -461,6 +461,8 @@ Status: [status ? status : "Unknown"] | Damage: [health ? health : "None"]
 			return
 
 		to_chat(H, "<span class='boldnotice'>Please stand by for a message from TGMC:<br/>[input]</span>")
+		var/sound/S = sound('sound/effects/sos-morse-code.ogg', channel = CHANNEL_ADMIN)
+		SEND_SOUND(H, S)
 
 		log_admin("[key_name(usr)] replied to [ADMIN_TPMONTY(H)]'s TGMC message with: [input].")
 		message_admins("[ADMIN_TPMONTY(usr)] replied to [ADMIN_TPMONTY(H)]'s' TGMC message with: [input]")


### PR DESCRIPTION
So the admin reply messages don't get lost.
Though we could deprecate this fulltime for Faxes instead.
