### PR TITLE
Moves a crash marker on Sulaco so it isn't in space

### DIFF
--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -13590,14 +13590,6 @@
 	},
 /turf/open/floor,
 /area/sulaco/marine/alpha)
-"aOS" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4;
-	layer = 2
-	},
-/obj/docking_port/stationary/marine_dropship/crash_target,
-/turf/open/floor/tile/lightred/full,
-/area/sulaco/brig)
 "aOT" = (
 /obj/structure/ob_ammo/ob_fuel,
 /obj/structure/ob_ammo/ob_fuel,
@@ -17910,6 +17902,10 @@
 /obj/structure/largecrate/guns,
 /turf/open/floor/plating/plating_catwalk,
 /area/sulaco/cargo)
+"smG" = (
+/obj/docking_port/stationary/marine_dropship/crash_target,
+/turf/closed/wall/sulaco,
+/area/sulaco/bridge/quarters)
 "swp" = (
 /obj/structure/largecrate/supply/supplies/flares,
 /turf/open/floor/mainship/mono,
@@ -45313,7 +45309,7 @@ asQ
 atM
 ayt
 awS
-asQ
+smG
 azO
 aBf
 aoi
@@ -45323,7 +45319,7 @@ aFt
 aDt
 aHH
 aEx
-aOS
+aJH
 aEx
 aDG
 aEx


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed a crash spot on Sulaco that exposed the doors to space
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
