### PR TITLE
heavy armor modular chest piece slowdown nerfed from .4 to .6

### DIFF
--- a/code/modules/modular_armor/armor_pieces.dm
+++ b/code/modules/modular_armor/armor_pieces.dm
@@ -99,7 +99,7 @@
 	icon_state = "heavy_chest_icon"
 	item_state = "heavy_chest"
 	soft_armor = list("melee" = 31, "bullet" = 31, "laser" = 31, "energy" = 31, "bomb" = 31, "bio" = 31, "rad" = 31, "fire" = 31, "acid" = 31)
-	slowdown = 0.4
+	slowdown = 0.6
 
 
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
title says all
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
because for some reason this totaled up to .8, rather than the old 1?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance:  heavy modular chestpiece slow is .6 rather than .4
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
