### PR TITLE
Tweaks facehugger stun

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -431,8 +431,9 @@
 	if(!sterile && !issynth(user) && !isIPC(user))
 		if(user.disable_lights(sparks = TRUE, silent = TRUE)) //Knock out the lights so the victim can't be cam tracked/spotted as easily
 			user.visible_message("<span class='danger'>[user]'s lights flicker and short out in a struggle!</span>", "<span class='danger'>Your equipment's lights flicker and short out in a struggle!</span>")
-		user.apply_damage(250, STAMINA)
-		user.Unconscious(6 SECONDS)
+		var/stamina_dmg = user.maxHealth * 2 + user.max_stamina_buffer
+		user.apply_damage(stamina_dmg, STAMINA) // complete winds the target
+		user.Unconscious(6 SECONDS) //THIS MIGHT NEED TWEAKS // still might! // tweaked it
 	flags_item |= NODROP
 	attached = TRUE
 	GoIdle(FALSE, TRUE)

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -1,5 +1,5 @@
 #define FACEHUGGER_LIFECYCLE 12 SECONDS
-#define FACEHUGGER_KNOCKOUT 10
+#define FACEHUGGER_KNOCKOUT 6 SECONDS
 
 #define MIN_IMPREGNATION_TIME 10 SECONDS //Time it takes to impregnate someone
 #define MAX_IMPREGNATION_TIME 15 SECONDS
@@ -431,7 +431,8 @@
 	if(!sterile && !issynth(user) && !isIPC(user))
 		if(user.disable_lights(sparks = TRUE, silent = TRUE)) //Knock out the lights so the victim can't be cam tracked/spotted as easily
 			user.visible_message("<span class='danger'>[user]'s lights flicker and short out in a struggle!</span>", "<span class='danger'>Your equipment's lights flicker and short out in a struggle!</span>")
-		user.Unconscious(FACEHUGGER_KNOCKOUT * 20) //THIS MIGHT NEED TWEAKS // still might!
+		user.apply_damage(250, STAMINA)
+		user.Unconscious(6 SECONDS)
 	flags_item |= NODROP
 	attached = TRUE
 	GoIdle(FALSE, TRUE)


### PR DESCRIPTION
## About The Pull Request

This moves most of the stun to stamina damage instead of 20 secs of unconscious.
I kept 6 secs of unconscious, since the player might be jacked up on coffee and i want make sure xenos have enough time to react.

## Why It's Good For The Game
Balances facehuggers, while keeping the majority of their strengths of securing a capture

## Changelog
:cl:
balance: facehuggers strip stamina instead of 20sec of unconciousness on hit
/:cl:
