### PR TITLE
[Map Edit] Sulaco Walls/Hulls Change

### DIFF
--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -8005,7 +8005,7 @@
 /area/sulaco/hallway/central_hall)
 "axC" = (
 /obj/structure/cable,
-/turf/closed/wall/sulaco,
+/turf/closed/wall/sulaco/hull,
 /area/sulaco/cap_office)
 "axE" = (
 /obj/structure/bed/chair{
@@ -9362,12 +9362,8 @@
 /turf/closed/wall/sulaco,
 /area/sulaco/brig)
 "aBG" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4;
-	layer = 2
-	},
 /turf/closed/wall/sulaco/hull,
-/area/sulaco/brig)
+/area/space)
 "aBH" = (
 /obj/machinery/door/poddoor/open/isolation{
 	dir = 4
@@ -9379,7 +9375,7 @@
 /area/sulaco/brig)
 "aBI" = (
 /turf/closed/wall/sulaco/hull,
-/area/sulaco/brig)
+/area/sulaco/bridge)
 "aBJ" = (
 /obj/machinery/door/airlock/mainship/marine/alpha/medic{
 	dir = 4
@@ -17953,6 +17949,9 @@
 /obj/structure/largecrate/supply/supplies/water,
 /turf/open/floor/mainship/mono,
 /area/sulaco/cargo)
+"vvh" = (
+/turf/closed/wall/sulaco/hull,
+/area/sulaco/bridge/office)
 "whS" = (
 /obj/machinery/door_control/mainship/req{
 	id = "qm_warehouse";
@@ -36555,7 +36554,7 @@ aas
 aaa
 aaa
 aas
-aaf
+aBG
 apn
 aqJ
 asc
@@ -36565,7 +36564,7 @@ awp
 awT
 ays
 aAN
-aaf
+aBG
 aas
 aaa
 aaa
@@ -36812,7 +36811,7 @@ aas
 aaa
 aaa
 aas
-anV
+aBI
 apo
 aqM
 asd
@@ -36822,7 +36821,7 @@ ayF
 awX
 ayC
 azA
-anV
+aBI
 aas
 aaa
 aaa
@@ -37069,7 +37068,7 @@ aas
 aaa
 aaa
 aas
-anV
+aBI
 app
 aqN
 ase
@@ -37326,7 +37325,7 @@ aas
 aaa
 aaa
 aas
-anV
+aBI
 aoF
 aqN
 ase
@@ -37583,7 +37582,7 @@ aas
 aaa
 aaa
 aas
-anV
+aBI
 apr
 aqN
 asf
@@ -37593,7 +37592,7 @@ ayS
 asf
 ayE
 azA
-anV
+aBI
 aas
 aaa
 aaa
@@ -37840,7 +37839,7 @@ aas
 aaa
 aaa
 aas
-anV
+aBI
 aoO
 apq
 asg
@@ -37850,7 +37849,7 @@ auF
 axc
 awn
 avv
-anV
+aBI
 aas
 aaa
 aaa
@@ -38107,7 +38106,7 @@ awv
 axf
 ayH
 aDd
-anV
+aBI
 aas
 aaa
 aaa
@@ -39639,14 +39638,14 @@ ahd
 alH
 alH
 alH
-akt
-akt
+vvh
+vvh
 aqR
-akt
+vvh
 auu
-anV
+aBI
 awM
-anV
+aBI
 azs
 axC
 axC
@@ -47114,12 +47113,12 @@ aHM
 azq
 bbd
 abN
-aBG
-aBI
-aBI
-aBI
-aBI
-aBI
+aAL
+aEw
+aEw
+aEw
+aEw
+aEw
 aOU
 aZb
 aaa

--- a/code/game/turfs/walls/wall_types.dm
+++ b/code/game/turfs/walls/wall_types.dm
@@ -161,11 +161,10 @@
 
 //Sulaco walls.
 /turf/closed/wall/sulaco
-	name = "spaceship hull"
+	name = "hull"
 	desc = "A huge chunk of metal used to separate rooms on spaceships from the cold void of space."
 	icon = 'icons/turf/walls.dmi'
 	icon_state = "sulaco0"
-	resistance_flags = RESIST_ALL
 
 	max_integrity = 3000
 	max_temperature = 28000 //K, walls will take damage if they're next to a fire hotter than this
@@ -189,7 +188,7 @@
 	name = "outer hull"
 	desc = "A reinforced outer hull, probably to prevent breaches"
 	walltype = "sulaco"
-
+	resistance_flags = RESIST_ALL
 
 /turf/closed/wall/sulaco/unmeltable
 	resistance_flags = RESIST_ALL


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
modifies the resistance tags of normal hulls on sulaco hulls.
changes some outer hulls to normal hulls, as they were not guarding something important.
changes some normal hulls to outer hulls, as they were guarding something important.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Inner walls on ship-side should be mostly destroy-able. However, Sulaco had a resistance flag on the base hull turf, which means that the inner walls were acting similar to the outer walls.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed inner hull on Sulaco to not have RESIST_ALL
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
