### PR TITLE
Xenos can increase the chances generators fail

### DIFF
--- a/code/modules/power/groundmap_geothermal.dm
+++ b/code/modules/power/groundmap_geothermal.dm
@@ -101,6 +101,9 @@
 
 /obj/machinery/power/geothermal/attack_alien(mob/living/carbon/xenomorph/X)
 	. = ..()
+	// Can't damage a broken generator
+	if(buildstate)
+		return
 	X.do_attack_animation(src, ATTACK_EFFECT_CLAW)
 	play_attack_sound(1)
 	X.visible_message("<span class='danger'>\The [X] slashes at \the [src], tearing at it's components!</span>",

--- a/code/modules/power/groundmap_geothermal.dm
+++ b/code/modules/power/groundmap_geothermal.dm
@@ -15,7 +15,7 @@
 	var/power_generation_max = 100000 //Full capacity
 	var/buildstate = GEOTHERMAL_HEAVY_DAMAGE //What state of building it are we on, 0-3, 1 is "broken", the default
 	var/is_on = FALSE  //Is this damn thing on or what?
-	var/fail_rate = 10 //% chance of failure each fail_tick check
+	var/fail_rate = 0 //% chance of failure each fail_tick check
 	var/fail_check_ticks = 100 //Check for failure every this many ticks
 	var/cur_tick = 0 //Tick updater
 
@@ -87,6 +87,10 @@
 			visible_message("[icon2html(src, viewers(src))] <span class='notice'><b>[src]</b> beeps wildly and sprays random pieces everywhere! Use a wrench to repair it.")
 			buildstate = GEOTHERMAL_LIGHT_DAMAGE
 			icon_state = "wrench"
+
+		//Resets the fail_rate incase the xenos have been fucking with it.
+		fail_rate = initial(fail_rate)
+
 		is_on = FALSE
 		power_gen_percent = 0
 		update_icon()
@@ -94,6 +98,15 @@
 		stop_processing()
 		return TRUE
 	return FALSE //Nope, all fine
+
+/obj/machinery/power/geothermal/attack_alien(mob/living/carbon/xenomorph/X)
+	. = ..()
+	X.do_attack_animation(src, ATTACK_EFFECT_CLAW)
+	play_attack_sound(1)
+	X.visible_message("<span class='danger'>\The [X] slashes at \the [src], tearing at it's components!</span>",
+		"<span class='danger'>We start slashing at \the [src], tearing at it's components!</span>")
+	fail_rate += 5 // 5% fail rate every attack
+
 
 /obj/machinery/power/geothermal/attack_hand(mob/living/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Everytime a xeno hits a generator, it can increase its chance of failing
Generators also don't fail on their own anymore.

## Why It's Good For The Game
Xenos can counter power mechanics


## Changelog
:cl:
add: Xenos can attack generators to increase the chance they will fail naturally
/:cl:

