### PR TITLE
Fixes bioscan dropship issue

### DIFF
--- a/code/datums/gamemodes/game_mode.dm
+++ b/code/datums/gamemodes/game_mode.dm
@@ -269,7 +269,7 @@
 			var/mob/M = i
 			SEND_SOUND(M, S)
 			to_chat(M, "<span class='xenoannounce'>The Queen Mother reaches into your mind from worlds away.</span>")
-			to_chat(M, "<span class='xenoannounce'>To my children and their Queen. I sense [numHostsShipr ? "approximately [numHostsShipr]":"no"] host[numHostsShipr > 1 ? "s":""] in the metal hive[show_locations && hostLocationS ? ", including one in [hostLocationS]":""] , [numHostsPlanet ? "[numHostsPlanet]":"none"] scattered elsewhere[show_locations && hostLocationP ? ", including one in [hostLocationP]":""] and [numHostsAlamor ? "approximately [numHostsAlamor]":"no"] host[numHostsAlamor > 1 ? "s":""] on the metal bird in transit.</span>")
+			to_chat(M, "<span class='xenoannounce'>To my children and their Queen. I sense [numHostsShipr ? "approximately [numHostsShipr]":"no"] host[numHostsShipr > 1 ? "s":""] in the metal hive[show_locations && hostLocationS ? ", including one in [hostLocationS]":""], [numHostsPlanet ? "[numHostsPlanet]":"none"] scattered elsewhere[show_locations && hostLocationP ? ", including one in [hostLocationP]":""] and [numHostsAlamor ? "approximately [numHostsAlamor]":"no"] host[numHostsAlamor > 1 ? "s":""] on the metal bird in transit.</span>")
 
 	var/xenoLocationP
 	var/xenoLocationS
@@ -283,7 +283,7 @@
 	var/name = "[MAIN_AI_SYSTEM] Bioscan Status"
 	var/input = {"Bioscan complete.
 
-Sensors indicate [numXenosShip ? "[numXenosShip]" : "no"] unknown lifeform signature[numXenosShip > 1 ? "s":""] present on the ship[show_locations && xenoLocationS ? " including one in [xenoLocationS]" : ""] , [numXenosPlanetr ? "approximately [numXenosPlanetr]":"no"] signature[numXenosPlanetr > 1 ? "s":""] located elsewhere[show_locations && xenoLocationP ? ", including one in [xenoLocationP]":""] and [numXenosAlamo ? "[numXenosAlamo]" : "no"] unknown lifeform signature[numXenosAlamo > 1 ? "s":""] on the Alamo in transit."}
+Sensors indicate [numXenosShip ? "[numXenosShip]" : "no"] unknown lifeform signature[numXenosShip > 1 ? "s":""] present on the ship[show_locations && xenoLocationS ? " including one in [xenoLocationS]" : ""], [numXenosPlanetr ? "approximately [numXenosPlanetr]":"no"] signature[numXenosPlanetr > 1 ? "s":""] located elsewhere[show_locations && xenoLocationP ? ", including one in [xenoLocationP]":""] and [numXenosAlamo ? "[numXenosAlamo]" : "no"] unknown lifeform signature[numXenosAlamo > 1 ? "s":""] on the Alamo in transit."}
 
 	if(announce_humans)
 		priority_announce(input, name, sound = 'sound/AI/bioscan.ogg')

--- a/code/datums/gamemodes/game_mode.dm
+++ b/code/datums/gamemodes/game_mode.dm
@@ -256,7 +256,7 @@
 	var/numXenosAlamor = max(0, numXenosAlamo + rand(-delta, delta))
 	var/hostLocationP
 	var/hostLocationS
-	var/hostLocationA
+
 	if(length(hostLocationsP))
 		hostLocationP = pick(hostLocationsP)
 
@@ -276,7 +276,7 @@
 
 	var/xenoLocationP
 	var/xenoLocationS
-	var/xenoLocationA
+	
 	if(length(xenoLocationsP))
 		xenoLocationP = pick(xenoLocationsP)
 

--- a/code/datums/gamemodes/game_mode.dm
+++ b/code/datums/gamemodes/game_mode.dm
@@ -308,7 +308,7 @@ Sensors indicate [numXenosShip ? "[numXenosShip]" : "no"] unknown lifeform signa
 [numHostsPlanet] human\s on the planet.
 [numHostsShip] human\s on the ship."
 [numHostsAlamo] human\s in transit on the Alamo.
-[numXenosAlamo] xeno\s in transit on the Alamo.</span>"})
+[numXenosAlamo] xeno\s in transit on the Alamo including [numLarvaAlamo] larva.</span>"})
 
 	message_admins("Bioscan - Humans: [numHostsPlanet] on the planet[hostLocationP ? ". Location:[hostLocationP]":""]. [numHostsShipr] on the ship.[hostLocationS ? " Location: [hostLocationS].":""]. [numHostsAlamor] in transit on the Alamo.")
 	message_admins("Bioscan - Xenos: [numXenosPlanetr] on the planet[numXenosPlanetr > 0 && xenoLocationP ? ". Location:[xenoLocationP]":""]. [numXenosShip] on the ship.[xenoLocationS ? " Location: [xenoLocationS].":""] [numXenosAlamor] in transit on the Alamo.")

--- a/code/datums/gamemodes/game_mode.dm
+++ b/code/datums/gamemodes/game_mode.dm
@@ -262,9 +262,6 @@
 
 	if(length(hostLocationsS))
 		hostLocationS = pick(hostLocationsS)
-
-	if(length(hostLocationsA))
-		hostLocationA = pick(hostLocationsA)
 	
 	var/sound/S = sound(get_sfx("queen"), channel = CHANNEL_ANNOUNCEMENTS, volume = 50)
 	if(announce_xenos)
@@ -276,15 +273,12 @@
 
 	var/xenoLocationP
 	var/xenoLocationS
-	
+
 	if(length(xenoLocationsP))
 		xenoLocationP = pick(xenoLocationsP)
 
 	if(length(xenoLocationsS))
 		xenoLocationS = pick(xenoLocationsS)
-
-	if(length(xenoLocationsA))
-		xenoLocationA = pick(xenoLocationsA)
 
 	var/name = "[MAIN_AI_SYSTEM] Bioscan Status"
 	var/input = {"Bioscan complete.


### PR DESCRIPTION
Closes https://github.com/tgstation/TerraGov-Marine-Corps/issues/4166

## About The Pull Request
this pr extends the bioscan message to include numbers about xenos and humans in transit on the dropship. Xenos do not get exact numbers of marines but marines do get exact numbers of xenos.
## Why It's Good For The Game
Monki asked me to fix it, and I am but a humble bug fixer
## Changelog
:cl:
fix: fixed the bioscan not showing humans or xenos in the dropship while in transit
/:cl:
