### PR TITLE
Fixes dropship attachment acid removal exploit and an error message

### DIFF
--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -225,7 +225,7 @@
 						linked_console.selected_equipment = null
 			update_equipment()
 			return TRUE //removed or uninstalled equipment
-		to_chat(user, "<span class='notice'>You cannot touch [src] with the [PC] due to the acid on the [src].</span>")
+		to_chat(user, "<span class='notice'>You cannot touch [src] with the [PC] due to the acid on [src].</span>")
 
 /obj/structure/dropship_equipment/update_icon()
 	return

--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -226,7 +226,7 @@
 			update_equipment()
 			return TRUE //removed or uninstalled equipment
 		to_chat(user, "<span class='notice'>You cannot touch [src] with the [PC] due to the acid on [src].</span>")
-
+		return TRUE
 /obj/structure/dropship_equipment/update_icon()
 	return
 

--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -203,7 +203,7 @@
 			ammo_equipped = null
 			update_icon()
 			return TRUE //emptied or removed dropship ammo
-		else
+		else if(!current_acid)
 			playsound(loc, 'sound/machines/hydraulics_2.ogg', 40, 1)
 			var/duration_time = ship_base ? 70 : 10 //uninstalling equipment takes more time
 			if(!do_after(user, duration_time, FALSE, src, BUSY_ICON_BUILD))
@@ -225,7 +225,7 @@
 						linked_console.selected_equipment = null
 			update_equipment()
 			return TRUE //removed or uninstalled equipment
-
+		to_chat(user, "<span class='notice'>You cannot touch [src] with the [PC] due to the acid on the [src].</span>")
 
 /obj/structure/dropship_equipment/update_icon()
 	return

--- a/code/modules/vehicles/powerloader.dm
+++ b/code/modules/vehicles/powerloader.dm
@@ -289,7 +289,10 @@
 		update_icon()
 		user.visible_message("<span class='notice'>[user] grabs [loaded] with [src].</span>",
 		"<span class='notice'>You grab [loaded] with [src].</span>")
-
+	
+	else if(istype(target, /obj/structure/dropship_equipment))
+		return 
+	
 	else if(istype(target, /obj))
 		to_chat(user, "<span class='warning'>The powerloader is not capable of carrying this!</span>")
 		return

--- a/code/modules/vehicles/powerloader.dm
+++ b/code/modules/vehicles/powerloader.dm
@@ -289,10 +289,7 @@
 		update_icon()
 		user.visible_message("<span class='notice'>[user] grabs [loaded] with [src].</span>",
 		"<span class='notice'>You grab [loaded] with [src].</span>")
-	
-	else if(istype(target, /obj/structure/dropship_equipment))
-		return 
-	
+
 	else if(istype(target, /obj))
 		to_chat(user, "<span class='warning'>The powerloader is not capable of carrying this!</span>")
 		return


### PR DESCRIPTION
## About The Pull Request
Fixes #4178
fixes wonky error message when you stop adding an attachment to the alamo or stop removing an attachment and also stops you from removing attachments from the alamo if its been acided.
## Why It's Good For The Game
nice exploit kiddo, it would be a shame if someone fixed it
## Changelog
:cl:
fix: fixed an exploit which allowed people to remove attachments off the attachment points of the alamo to remove acid from them and instantly put them back on.
fix: fixed a wrong error message that would come up whenever you tried to interact with dropship attachments and then stopped. 
/:cl: