### PR TITLE
Buffs barricades 

### DIFF
--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -383,7 +383,7 @@
 	icon_state = "metal_0"
 	max_integrity = 200
 	soft_armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 0, "fire" = 80, "acid" = 40)
-	coverage = 20
+	coverage = 100
 	crusher_resistant = TRUE
 	barricade_resistance = 10
 	stack_type = /obj/item/stack/sheet/metal
@@ -629,7 +629,7 @@
 	icon_state = "plasteel_closed_0"
 	max_integrity = 600
 	soft_armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 0, "fire" = 80, "acid" = 40)
-	coverage = 20
+	coverage = 100
 	crusher_resistant = TRUE
 	barricade_resistance = 20
 	stack_type = /obj/item/stack/sheet/plasteel
@@ -882,7 +882,7 @@
 	barricade_resistance = 15
 	max_integrity = 400
 	soft_armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 0, "fire" = 80, "acid" = 40)
-	coverage = 20
+	coverage = 100
 	stack_type = /obj/item/stack/sandbags
 	hit_sound = "sound/weapons/genhit.ogg"
 	barricade_type = "sandbag"

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -383,7 +383,7 @@
 	icon_state = "metal_0"
 	max_integrity = 200
 	soft_armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 0, "fire" = 80, "acid" = 40)
-	coverage = 100
+	coverage = 128
 	crusher_resistant = TRUE
 	barricade_resistance = 10
 	stack_type = /obj/item/stack/sheet/metal
@@ -629,7 +629,7 @@
 	icon_state = "plasteel_closed_0"
 	max_integrity = 600
 	soft_armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 0, "fire" = 80, "acid" = 40)
-	coverage = 100
+	coverage = 128
 	crusher_resistant = TRUE
 	barricade_resistance = 20
 	stack_type = /obj/item/stack/sheet/plasteel
@@ -882,7 +882,7 @@
 	barricade_resistance = 15
 	max_integrity = 400
 	soft_armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 0, "fire" = 80, "acid" = 40)
-	coverage = 100
+	coverage = 128
 	stack_type = /obj/item/stack/sandbags
 	hit_sound = "sound/weapons/genhit.ogg"
 	barricade_type = "sandbag"

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -383,7 +383,7 @@
 	icon_state = "metal_0"
 	max_integrity = 200
 	soft_armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 0, "fire" = 80, "acid" = 40)
-	coverage = 80
+	coverage = 20
 	crusher_resistant = TRUE
 	barricade_resistance = 10
 	stack_type = /obj/item/stack/sheet/metal
@@ -629,7 +629,7 @@
 	icon_state = "plasteel_closed_0"
 	max_integrity = 600
 	soft_armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 0, "fire" = 80, "acid" = 40)
-	coverage = 80
+	coverage = 20
 	crusher_resistant = TRUE
 	barricade_resistance = 20
 	stack_type = /obj/item/stack/sheet/plasteel
@@ -882,7 +882,7 @@
 	barricade_resistance = 15
 	max_integrity = 400
 	soft_armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 0, "fire" = 80, "acid" = 40)
-	coverage = 80
+	coverage = 20
 	stack_type = /obj/item/stack/sandbags
 	hit_sound = "sound/weapons/genhit.ogg"
 	barricade_type = "sandbag"

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -382,6 +382,8 @@
 	desc = "A sturdy and easily assembled barricade made of metal plates, often used for quick fortifications. Use a blowtorch to repair."
 	icon_state = "metal_0"
 	max_integrity = 200
+	soft_armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 0, "fire" = 80, "acid" = 40)
+	coverage = 80
 	crusher_resistant = TRUE
 	barricade_resistance = 10
 	stack_type = /obj/item/stack/sheet/metal
@@ -626,6 +628,8 @@
 	desc = "A very sturdy barricade made out of plasteel panels, the pinnacle of strongpoints. Use a blowtorch to repair. Can be flipped down to create a path."
 	icon_state = "plasteel_closed_0"
 	max_integrity = 600
+	soft_armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 0, "fire" = 80, "acid" = 40)
+	coverage = 80
 	crusher_resistant = TRUE
 	barricade_resistance = 20
 	stack_type = /obj/item/stack/sheet/plasteel
@@ -877,6 +881,8 @@
 	icon_state = "sandbag_0"
 	barricade_resistance = 15
 	max_integrity = 400
+	soft_armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 0, "fire" = 80, "acid" = 40)
+	coverage = 80
 	stack_type = /obj/item/stack/sandbags
 	hit_sound = "sound/weapons/genhit.ogg"
 	barricade_type = "sandbag"

--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/abilities_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/abilities_spitter.dm
@@ -57,6 +57,8 @@
 
 		var/blocked = FALSE
 		for(var/obj/O in T)
+			if(is_type_in_typecache(O, GLOB.acid_spray_hit) && O.acid_spray_act(owner))
+				return // returned true if normal density applies
 			if(O.density && !O.throwpass && !(O.flags_atom & ON_BORDER))
 				blocked = TRUE
 				break

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -466,7 +466,7 @@
 /obj/structure/acid_spray_act(mob/living/carbon/xenomorph/X)
 	if(!is_type_in_typecache(src, GLOB.acid_spray_hit))
 		return TRUE // normal density flag
-	take_damage(rand(40,60) + SPRAY_STRUCTURE_UPGRADE_BONUS(X))
+	take_damage_type(45 + SPRAY_STRUCTURE_UPGRADE_BONUS(X), "acid", src)
 	return TRUE // normal density flag
 
 /obj/structure/razorwire/acid_spray_act(mob/living/carbon/xenomorph/X)
@@ -474,7 +474,7 @@
 	return FALSE // not normal density flag
 
 /obj/vehicle/multitile/root/cm_armored/acid_spray_act(mob/living/carbon/xenomorph/X)
-	take_damage_type(rand(40,60) + SPRAY_STRUCTURE_UPGRADE_BONUS(X), "acid", src)
+	take_damage_type(45 + SPRAY_STRUCTURE_UPGRADE_BONUS(X), "acid", src)
 	healthcheck()
 	return TRUE
 

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -466,7 +466,7 @@
 /obj/structure/acid_spray_act(mob/living/carbon/xenomorph/X)
 	if(!is_type_in_typecache(src, GLOB.acid_spray_hit))
 		return TRUE // normal density flag
-	take_damage_type(45 + SPRAY_STRUCTURE_UPGRADE_BONUS(X), "acid", src)
+	take_damage(45 + SPRAY_STRUCTURE_UPGRADE_BONUS(X), "acid", "acid")
 	return TRUE // normal density flag
 
 /obj/structure/razorwire/acid_spray_act(mob/living/carbon/xenomorph/X)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -573,6 +573,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 	. -= (proj.accuracy - (proj.accuracy * ( (proj.distance_travelled/proj.ammo.accurate_range)*(proj.distance_travelled/proj.ammo.accurate_range) ) ))
 	if(!anchored)
 		. *= 0.5 //Half the protection from unaffixed structures.
+	visible_message("<span> Coverage = [coverage].</span>")
 	return prob(.)
 
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -573,7 +573,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 	. -= (proj.accuracy - (proj.accuracy * ( (proj.distance_travelled/proj.ammo.accurate_range)*(proj.distance_travelled/proj.ammo.accurate_range) ) ))
 	if(!anchored)
 		. *= 0.5 //Half the protection from unaffixed structures.
-	visible_message("<span> Coverage = [coverage].</span>")
+	visible_message("<span> Coverage = [.].</span>")
 	return prob(.)
 
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -570,14 +570,9 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 			return FALSE //No effect now, but we save the reference to check on exiting the tile.
 		. *= uncrossing ? 0.5 : 1.5 //Higher hitchance when shooting in the barricade's direction.
 	//Bypass chance calculation. Accuracy over 100 increases the chance of squeezing the bullet past the structure's uncovered areas.
-	visible_message("<span> before coverage = [.].</span>")
-	visible_message("<span> accuracy = [proj.accuracy].</span>")
-	visible_message("<span> distance traveled = [proj.distance_travelled].</span>")
-	visible_message("<span> accurate range = [proj.ammo.accurate_range].</span>")
 	. -= (proj.accuracy - (proj.accuracy * ( (proj.distance_travelled/proj.ammo.accurate_range)*(proj.distance_travelled/proj.ammo.accurate_range) ) ))
 	if(!anchored)
 		. *= 0.5 //Half the protection from unaffixed structures.
-	visible_message("<span> after coverage = [.].</span>")
 	return prob(.)
 
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -570,10 +570,14 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 			return FALSE //No effect now, but we save the reference to check on exiting the tile.
 		. *= uncrossing ? 0.5 : 1.5 //Higher hitchance when shooting in the barricade's direction.
 	//Bypass chance calculation. Accuracy over 100 increases the chance of squeezing the bullet past the structure's uncovered areas.
+	visible_message("<span> before coverage = [.].</span>")
+	visible_message("<span> accuracy = [proj.accuracy].</span>")
+	visible_message("<span> distance traveled = [proj.distance_travelled].</span>")
+	visible_message("<span> accurate range = [proj.ammo.accurate_range].</span>")
 	. -= (proj.accuracy - (proj.accuracy * ( (proj.distance_travelled/proj.ammo.accurate_range)*(proj.distance_travelled/proj.ammo.accurate_range) ) ))
 	if(!anchored)
 		. *= 0.5 //Half the protection from unaffixed structures.
-	visible_message("<span> Coverage = [.].</span>")
+	visible_message("<span> after coverage = [.].</span>")
 	return prob(.)
 
 


### PR DESCRIPTION
## About The Pull Request
This PR buffs barricades based on suggestions by others and my own inputs. 
## Why It's Good For The Game
Its not exactly balanced to have an ancient spitter or elder praetorian run up to the cades, stun marines and half health and entire column of cades. This will stop spitters from peeking a corner and just firing off a spit on the cades constantly. Stop being cheese. 
## Changelog
:cl:
add: Added new things
balance: gave barricades 128 coverage which at minimum equates to around a 20% chance to spit beyond the barricade. 
balance: gave metal barricades 40 acid armor, it takes 10 acid spits to take them down with barbed wire (all other barricades have 40 acid armor too, but I didnt calculate them)
balance: made acid sprays stop at barricades and not go through them.
/:cl:
