### PR TITLE
Remove spec skill requirements from guns

### DIFF
--- a/code/__DEFINES/skills.dm
+++ b/code/__DEFINES/skills.dm
@@ -153,8 +153,6 @@
 #define GUN_SKILL_RIFLES		"rifles"
 #define GUN_SKILL_HEAVY_WEAPONS	"heavy_weapons"
 #define GUN_SKILL_SMARTGUN		"smartgun"
-#define GUN_SKILL_SPEC			"spec_weapons"
-
 
 //multitile vehicle skills
 #define SKILL_LARGE_VEHICLE_DEFAULT 0

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -808,7 +808,7 @@ and you're good to go.
 				if(GUN_SKILL_HEAVY_WEAPONS)
 					if(fire_delay > 1 SECONDS) //long delay to fire
 						added_delay = max(fire_delay - 3 * user.skills.getRating(gun_skill_category), 6)
-				if(GUN_SKILL_SMARTGUN, GUN_SKILL_SPEC)
+				if(GUN_SKILL_SMARTGUN)
 					if(user.skills.getRating(gun_skill_category) < 0)
 						added_delay -= 2 * user.skills.getRating(gun_skill_category)
 

--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -367,7 +367,6 @@
 	current_mag = /obj/item/ammo_magazine/flamer_tank/large
 	icon_state = "m240t"
 	item_state = "m240t"
-	gun_skill_category = GUN_SKILL_SPEC
 	flags_gun_features = GUN_UNUSUAL_DESIGN|GUN_WIELDED_FIRING_ONLY|GUN_AMMO_COUNTER
 	var/max_water = 200
 	var/last_use

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -744,7 +744,7 @@ can cause issues with ammo types getting mixed up during the burst.
 	load_method = SINGLE_CASING
 	max_shells = 10
 	current_mag = /obj/item/ammo_magazine/internal/shotgun/pump/lever/mbx900
-	gun_skill_category = GUN_SKILL_SPEC
+	gun_skill_category = GUN_SKILL_SHOTGUNS
 	type_of_casings = "cartridge"
 	pump_sound = 'sound/weapons/guns/interact/ak47_cocked.ogg'
 

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -923,7 +923,7 @@
 	load_method = SINGLE_CASING //codex
 	fire_sound = 'sound/weapons/guns/fire/shotgun_light.ogg'
 	current_mag = /obj/item/ammo_magazine/internal/shotgun/scout
-	gun_skill_category = GUN_SKILL_SPEC
+	gun_skill_category = GUN_SKILL_SHOTGUNS
 	aim_slowdown = 0.75
 	attachable_allowed = list(
 						/obj/item/attachable/bayonet,


### PR DESCRIPTION
## About The Pull Request

Local MJP man doesn't know how to search for gun_skill_spec. Spec shotguns use the shotgun skill now, the spec flamer inherits the heavy weapons skill requirement from normal flamer.

## Why It's Good For The Game

No more gimped guns.

## Changelog
:cl:
fix: Removed spec skill requirements from a few guns that still had it.
/:cl: