### PR TITLE
Machine pistol now pistol sized, less ammo in mags, better accuracy

### DIFF
--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -183,7 +183,8 @@
 	max_w_class = 3
 	can_hold = list(
 		/obj/item/weapon/gun/pistol,
-		/obj/item/weapon/gun/revolver)
+		/obj/item/weapon/gun/revolver,
+		/obj/item/weapon/gun/smg/standard_machinepistol)
 	draw_mode = 1
 
 
@@ -222,7 +223,8 @@
 
 	can_hold = list(
 		/obj/item/ammo_magazine/pistol,
-		/obj/item/ammo_magazine/revolver)
+		/obj/item/ammo_magazine/revolver,
+		/obj/item/ammo_magazine/smg/standard_machinepistol)
 
 /obj/item/storage/pouch/magazine/pistol/large
 	name = "large pistol magazine pouch"
@@ -567,7 +569,7 @@
 /obj/item/storage/pouch/shotgun/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/ammo_magazine))
 		var/obj/item/ammo_magazine/M = I
-	
+
 		if(M.flags_magazine & AMMUNITION_REFILLABLE)
 			if(!M.current_rounds)
 				to_chat(user, "<span class='warning'>[M] is empty.</span>")

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -49,7 +49,7 @@
 	icon_state = "t19"
 	item_state = "t19"
 	caliber = "10x20mm caseless" //codex
-	max_shells = 25 //codex
+	max_shells = 30 //codex
 	flags_equip_slot = ITEM_SLOT_BACK|ITEM_SLOT_BELT
 	current_mag = /obj/item/ammo_magazine/smg/standard_machinepistol
 	type_of_casings = null

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -72,7 +72,7 @@
 	gun_firemode_list = list(GUN_FIREMODE_SEMIAUTO, GUN_FIREMODE_BURSTFIRE, GUN_FIREMODE_AUTOMATIC, GUN_FIREMODE_AUTOBURST)
 	attachable_offset = list("muzzle_x" = 27, "muzzle_y" = 17,"rail_x" = 9, "rail_y" = 20, "under_x" = 21, "under_y" = 12, "stock_x" = 24, "stock_y" = 10)
 
-	accuracy_mult = 1.15
+	accuracy_mult = 1.5
 	accuracy_mult_unwielded = 0.85
 	recoil_unwielded = 0
 	scatter = 15

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -49,10 +49,11 @@
 	icon_state = "t19"
 	item_state = "t19"
 	caliber = "10x20mm caseless" //codex
-	max_shells = 40 //codex
+	max_shells = 25 //codex
 	flags_equip_slot = ITEM_SLOT_BACK|ITEM_SLOT_BELT
 	current_mag = /obj/item/ammo_magazine/smg/standard_machinepistol
 	type_of_casings = null
+	w_class = WEIGHT_CLASS_NORMAL
 	attachable_allowed = list(
 						/obj/item/attachable/suppressor,
 						/obj/item/attachable/reddot,

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -72,14 +72,15 @@
 	gun_firemode_list = list(GUN_FIREMODE_SEMIAUTO, GUN_FIREMODE_BURSTFIRE, GUN_FIREMODE_AUTOMATIC, GUN_FIREMODE_AUTOBURST)
 	attachable_offset = list("muzzle_x" = 27, "muzzle_y" = 17,"rail_x" = 9, "rail_y" = 20, "under_x" = 21, "under_y" = 12, "stock_x" = 24, "stock_y" = 10)
 
-	accuracy_mult = 0.95
+	accuracy_mult = 1.15
 	accuracy_mult_unwielded = 0.85
 	recoil_unwielded = 0
 	scatter = 15
 	fire_delay = 0.15 SECONDS
-	scatter_unwielded = 15 //Made to be used one handed.
+	scatter_unwielded = 0 //Made to be used one handed.
 	aim_slowdown = 0.15
 	burst_amount = 5
+	movement_acc_penalty_mult = 0
 
 //-------------------------------------------------------
 // War is hell. Not glorious.

--- a/code/modules/projectiles/magazines/smgs.dm
+++ b/code/modules/projectiles/magazines/smgs.dm
@@ -35,7 +35,7 @@
 	desc = "A 10x20mm caseless Submachine Gun magazine."
 	caliber = "10x20mm caseless"
 	icon_state = "t19"
-	max_rounds = 40
+	max_rounds = 25
 	w_class = WEIGHT_CLASS_SMALL
 	gun_type = /obj/item/weapon/gun/smg/standard_machinepistol
 

--- a/code/modules/projectiles/magazines/smgs.dm
+++ b/code/modules/projectiles/magazines/smgs.dm
@@ -35,7 +35,7 @@
 	desc = "A 10x20mm caseless Submachine Gun magazine."
 	caliber = "10x20mm caseless"
 	icon_state = "t19"
-	max_rounds = 25
+	max_rounds = 30
 	w_class = WEIGHT_CLASS_SMALL
 	gun_type = /obj/item/weapon/gun/smg/standard_machinepistol
 


### PR DESCRIPTION
## About The Pull Request

Poor machine pistol was hastily converted into a weird, less useful SMG. Now it can fit in shoulder holsters, sidearm pouches, and backpacks. The magazines can be put inside pistol pouches as well. Lowered the magazine capacity from 40 to 25 due to this.

Buffed accuracy and scatter to compensate. Scatter for one handed seems to be either bugged or just not working how it is intended to. Reduced scatter and movement accuracy penalty to 0 to prevent the pistol from turning into a shotgun the moment you start moving while firing. There is no in between. Accuracy multiplier penalty remains the same as it scales perfectly by distance. Benos at the edge of the screen will dodge a lot of shots when shooting one handed, while up close it will be much less. Wielded mode still has a bit of scatter as it works fine, but lowered it from the original values so it does not shoot like a shotgun either. Accuracy was increased so barely any shots will miss minus the ones that scatter off. At the moment a full clip can crit an ancient runner. Barely any will miss if wielded. Dual wielding scattering remains the same and is not affected. These are all tested without attachments.

## Why It's Good For The Game

Machine pistol joins the pistol club. Viable sidearm. Arguably a nerf for people who use it as a primary, but still viable for that.

## Changelog
:cl:
balance: Machine pistol now pistol sized. Gun and mags fit in appropriate pistol pouches. Halved ammo capacity. Way better accuracy.
/:cl: