### PR TITLE
[Fix] LO Catwalk, Basalt Barricades. Buttons

### DIFF
--- a/_maps/map_files/Lava_Outpost/LavaOutpost.dmm
+++ b/_maps/map_files/Lava_Outpost/LavaOutpost.dmm
@@ -201,7 +201,7 @@
 "cx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/machinery/door_control{
+/obj/machinery/door_control/directional{
 	dir = 8;
 	id = "secure_blast1";
 	name = "Vault Access"
@@ -936,7 +936,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/door_control{
+/obj/machinery/door_control/directional{
 	dir = 8;
 	id = "secure_blast2";
 	name = "Vault Access"
@@ -1883,11 +1883,10 @@
 /turf/open/floor/tile/white,
 /area/lavaland/security)
 "wX" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/directional/unmeltable{
 	dir = 8;
 	id = "secure_blast4";
-	name = "Vault Access";
-	resistance_flags = 3
+	name = "Vault Access"
 	},
 /turf/open/lavaland/lava,
 /area/lavaland/engie/engine)
@@ -2029,7 +2028,7 @@
 /turf/open/floor/plating/asteroidfloor,
 /area/lavaland/engie/engine)
 "yq" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/directional{
 	dir = 8;
 	id = "cargobay";
 	name = "Cargo Bay"
@@ -2051,7 +2050,7 @@
 /turf/open/floor/tile/dark,
 /area/lavaland/security/nuke)
 "yw" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/directional{
 	dir = 4;
 	id = "cargobay";
 	name = "Cargo Bay"
@@ -2264,9 +2263,9 @@
 "AX" = (
 /obj/structure/table,
 /obj/item/tank/anesthetic,
-/obj/machinery/door_control{
+/obj/machinery/door_control/directional{
 	id = "OR2";
-	name = "OR2 Shutters"
+	name = "OR Shutters"
 	},
 /turf/open/floor/tile/white,
 /area/lavaland/medical)
@@ -3224,7 +3223,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/door_control{
+/obj/machinery/door_control/directional{
 	dir = 8;
 	id = "secure_blast3";
 	name = "Vault Access"
@@ -3291,10 +3290,9 @@
 /turf/open/lavaland/basalt,
 /area/lavaland/engie/two)
 "MI" = (
-/obj/machinery/door_control{
+/obj/machinery/door_control/directional/unmeltable{
 	id = "secure_blast5";
-	name = "Vault Access";
-	resistance_flags = 3
+	name = "Vault Access"
 	},
 /turf/open/lavaland/basalt,
 /area/lavaland/engie/engine)

--- a/_maps/map_files/Lava_Outpost/LavaOutpost.dmm
+++ b/_maps/map_files/Lava_Outpost/LavaOutpost.dmm
@@ -294,6 +294,13 @@
 	dir = 4
 	},
 /area/lavaland)
+"ev" = (
+/obj/structure/closet/secure_closet/engineering_welding,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark2,
+/area/lavaland/engie/engine)
 "ew" = (
 /obj/machinery/light{
 	dir = 8
@@ -348,6 +355,12 @@
 	},
 /turf/open/floor/tile/white,
 /area/lavaland/medical)
+"fB" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/tile/dark2,
+/area/lavaland/engie/engine)
 "fE" = (
 /obj/structure/closet/secure_closet/engineering_welding,
 /turf/open/floor/tile/dark2,
@@ -651,6 +664,12 @@
 	},
 /turf/open/floor/tile/bar,
 /area/lavaland/civilian/cook)
+"iS" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/tile/dark2,
+/area/lavaland/engie/engine)
 "iU" = (
 /obj/structure/cable,
 /turf/open/floor/tile/bar,
@@ -1238,6 +1257,12 @@
 	},
 /turf/open/floor/tile/dark2,
 /area/lavaland/civilian/cargo)
+"oZ" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/lavaland/basalt,
+/area/lavaland/engie/engine)
 "pa" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/technology_scanner,
@@ -1361,6 +1386,12 @@
 	dir = 4
 	},
 /area/lavaland)
+"qz" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark2,
+/area/lavaland/engie/engine)
 "qB" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/tile/dark2,
@@ -1560,6 +1591,13 @@
 	},
 /turf/open/floor/plating/asteroidfloor,
 /area/shuttle/drop1/lz1)
+"sN" = (
+/obj/structure/closet/secure_closet/engineering_welding,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/tile/dark2,
+/area/lavaland/engie/engine)
 "sQ" = (
 /obj/machinery/floodlight/outpost,
 /turf/open/lavaland/basalt,
@@ -1635,6 +1673,11 @@
 /obj/docking_port/stationary/crashmode,
 /turf/closed/brock,
 /area/lavaland/cave/southeast)
+"tY" = (
+/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/machinery/light,
+/turf/open/floor/tile/dark2,
+/area/lavaland/engie/engine)
 "ua" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/cable,
@@ -1882,6 +1925,10 @@
 	},
 /turf/open/floor/tile/white,
 /area/lavaland/security)
+"wT" = (
+/obj/machinery/light,
+/turf/open/floor/tile/dark2,
+/area/lavaland/engie/engine)
 "wX" = (
 /obj/machinery/door_control/directional/unmeltable{
 	dir = 8;
@@ -2204,6 +2251,13 @@
 /obj/structure/fence,
 /turf/open/lavaland/basalt,
 /area/lavaland/cave/northwest)
+"AC" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/tile/dark2,
+/area/lavaland/engie/engine)
 "AD" = (
 /obj/structure/cable,
 /obj/machinery/light{
@@ -3120,6 +3174,13 @@
 /obj/structure/closet/secure_closet/engineering_personal,
 /turf/open/floor/tile/dark2,
 /area/lavaland/engie/engine)
+"KF" = (
+/obj/structure/closet/secure_closet/atmos_personal,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark2,
+/area/lavaland/engie/engine)
 "KJ" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood,
@@ -3440,6 +3501,11 @@
 	},
 /turf/open/floor/tile/dark,
 /area/lavaland/security/nuke)
+"OP" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/machinery/light,
+/turf/open/floor/tile/dark2,
+/area/lavaland/engie/engine)
 "OR" = (
 /turf/open/lavaland/catwalk,
 /area/lavaland/cave/south)
@@ -3547,6 +3613,17 @@
 	},
 /turf/open/floor/plating,
 /area/lavaland/engie/two)
+"Qn" = (
+/obj/structure/closet/secure_closet/atmos_personal,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/tile/dark2,
+/area/lavaland/engie/engine)
+"Qs" = (
+/obj/machinery/light/small,
+/turf/open/lavaland/basalt,
+/area/lavaland/engie/engine)
 "Qt" = (
 /obj/machinery/light{
 	dir = 1
@@ -4017,6 +4094,13 @@
 "Vf" = (
 /turf/open/lavaland/lava,
 /area/lavaland/cave/east)
+"Vg" = (
+/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/tile/dark2,
+/area/lavaland/engie/engine)
 "Vh" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -4150,6 +4234,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/lavaland/medical)
+"Xb" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/lavaland/lava,
+/area/lavaland/engie/engine)
 "Xg" = (
 /turf/open/lavaland/lava/side,
 /area/lavaland/cave/east)
@@ -18156,8 +18246,8 @@ RY
 RY
 RY
 yH
-ZW
-ZW
+oZ
+ZN
 ZW
 ZN
 ZN
@@ -26024,7 +26114,7 @@ al
 fw
 fw
 fE
-fE
+sN
 fE
 fw
 gq
@@ -26034,7 +26124,7 @@ aY
 gq
 fw
 KA
-KA
+AC
 KA
 fw
 fw
@@ -26536,21 +26626,21 @@ al
 al
 al
 fw
-fE
+ev
 aY
 aY
 ds
 fw
-aY
+qz
 dq
 gF
 aY
-aY
+wT
 fw
 WU
 aY
 aY
-KA
+OP
 fw
 al
 al
@@ -26562,8 +26652,8 @@ al
 al
 al
 al
-al
-aZ
+cd
+oZ
 aZ
 aZ
 aZ
@@ -27309,7 +27399,7 @@ al
 fw
 aY
 aY
-aY
+fB
 ks
 ks
 ks
@@ -27319,15 +27409,15 @@ aY
 ks
 ks
 ks
-aY
+fB
 aY
 aY
 nO
+fB
 aY
 aY
 aY
-aY
-aY
+fB
 nO
 aZ
 aZ
@@ -27855,8 +27945,8 @@ aZ
 aZ
 aZ
 aZ
-aZ
-al
+Qs
+cd
 al
 al
 al
@@ -28337,7 +28427,7 @@ al
 fw
 aY
 aY
-aY
+iS
 ks
 ks
 ks
@@ -28347,15 +28437,15 @@ dq
 ks
 ks
 ks
-aY
+iS
 gF
 aY
 nO
+iS
 aY
 aY
 aY
-aY
-aY
+iS
 nO
 aZ
 aZ
@@ -29106,21 +29196,21 @@ al
 al
 al
 fw
-bo
+KF
 aY
 aY
 WU
 fw
-aY
+qz
 aY
 BC
 aY
-aY
+wT
 fw
 eQ
 aY
 gF
-Cb
+tY
 fw
 al
 al
@@ -29622,7 +29712,7 @@ al
 fw
 fw
 bo
-bo
+Qn
 bo
 fw
 gq
@@ -29632,7 +29722,7 @@ aY
 gq
 fw
 Cb
-Cb
+Vg
 Cb
 fw
 fw
@@ -30687,8 +30777,8 @@ al
 al
 al
 al
-al
-aZ
+cd
+oZ
 aZ
 aZ
 aZ
@@ -31706,8 +31796,8 @@ al
 al
 al
 al
-al
-aZ
+cd
+oZ
 aZ
 aZ
 aZ
@@ -50248,7 +50338,7 @@ wX
 EK
 EK
 EK
-TO
+Xb
 TO
 TO
 TO

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -23,6 +23,10 @@
 
 #define islava(A) (istype(A, /turf/open/lavaland/lava))
 
+#define isbasalt(A) (istype(A, /turf/open/lavaland/basalt))
+
+#define islavacatwalk(A) (istype(A, /turf/open/lavaland/catwalk))
+
 #define isfloorturf(A) (istype(A, /turf/open/floor))
 
 #define isclosedturf(A) (istype(A, /turf/closed))

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -224,7 +224,7 @@
 				to_chat(usr, "<span class='warning'>You can't build \the [R.title] on top of another!</span>")
 				return FALSE
 	if(R.on_floor)
-		if(!isfloorturf(T))
+		if(!isfloorturf(T) && !isbasalt(T) && !islavacatwalk(T))
 			to_chat(usr, "<span class='warning'>\The [R.title] must be constructed on the floor!</span>")
 			return FALSE
 		for(var/obj/AM in T)

--- a/code/game/objects/machinery/door_control.dm
+++ b/code/game/objects/machinery/door_control.dm
@@ -173,10 +173,10 @@
 
 /obj/machinery/door_control/mainship/fuel
 	name = "Solid Fuel Storage"
-	id = "solid_fuel"	
+	id = "solid_fuel"
 
 /obj/machinery/door_control/mainship/hangar
-	name = "Hangar Shutters"	
+	name = "Hangar Shutters"
 	id = "hangar_shutters"
 
 /obj/machinery/door_control/mainship/research
@@ -186,10 +186,10 @@
 
 /obj/machinery/door_control/mainship/research/lockdown
 	name = "Research Lockdown"
-	id = "researchlockdownext"	
+	id = "researchlockdownext"
 
 /obj/machinery/door_control/mainship/brigarmory
-	name = "Brig Armory"	
+	name = "Brig Armory"
 	id = "brig_armory"
 	req_access = list(ACCESS_MARINE_BRIG)
 
@@ -206,35 +206,53 @@
 /obj/machinery/door_control/mainship/cic
 	name = "CIC Lockdown"
 	id = "cic_lockdown"
-	req_one_access = list(ACCESS_MARINE_BRIDGE)	
+	req_one_access = list(ACCESS_MARINE_BRIDGE)
 
 /obj/machinery/door_control/mainship/cic/armory
-	name = "Armory Lockdown"	
+	name = "Armory Lockdown"
 	id = "cic_armory"
 
 /obj/machinery/door_control/mainship/cic/hangar
 	name = "Hangar Lockdown"
-	id = "hangar_lockdown"	
+	id = "hangar_lockdown"
 
 /obj/machinery/door_control/mainship/tcomms
 	name = "Telecommunications Entrance"
 	id = "tcomms"
-	req_one_access = list(ACCESS_MARINE_ENGINEERING, ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_BRIDGE)	
+	req_one_access = list(ACCESS_MARINE_ENGINEERING, ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_BRIDGE)
 
 /obj/machinery/door_control/mainship/corporate
 	name = "Privacy Shutters"
 	id = "cl_shutters"
-	req_access = list(ACCESS_NT_CORPORATE)	
+	req_access = list(ACCESS_NT_CORPORATE)
 
-/obj/machinery/door_control/mainship/req	
+/obj/machinery/door_control/mainship/req
 	name = "RO Line Shutters"
 	id = "ROlobby"
 	req_one_access = list(ACCESS_MARINE_CARGO)
 
-/obj/machinery/door_control/mainship/req/ro1	
+/obj/machinery/door_control/mainship/req/ro1
 	name = "RO Line 1 Shutters"
 	id = "ROlobby1"
 
-/obj/machinery/door_control/mainship/req/ro2	
+/obj/machinery/door_control/mainship/req/ro2
 	name = "RO Line 2 Shutters"
 	id = "ROlobby2"
+
+/obj/machinery/door_control/directional
+	name = "autodirection door control"
+
+/obj/machinery/door_control/directional/Initialize(mapload)
+	. = ..()
+	switch(dir)
+		if(NORTH)
+			pixel_y = -28
+		if(SOUTH)
+			pixel_y = 28
+		if(EAST)
+			pixel_x = -28
+		if(WEST)
+			pixel_x = 28
+
+/obj/machinery/door_control/directional/unmeltable
+	resistance_flags = RESIST_ALL


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You can build barricades on basalt and lava catwalks with this PR.
Fixes the buttons.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Barricades were intended to be built on basalt and catwalks.
Pixel_x/y edits are not good in the map, so made it in code. Didnt originally add it to LO PR, so this is the fix for that.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed barricades being unable to be built on basalt and lava catwalks
fix: fixed buttons that are on the floor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
