### PR TITLE
Reduce amount of extra SG slots

### DIFF
--- a/code/datums/gamemodes/infestation.dm
+++ b/code/datums/gamemodes/infestation.dm
@@ -5,5 +5,4 @@
 	if(!.)
 		return
 	var/datum/job/scaled_job = SSjob.GetJobType(/datum/job/terragov/squad/smartgunner)
-	scaled_job.job_points_needed  = 6
-
+	scaled_job.job_points_needed  = 20 //For every 10 marine late joins, 1 extra SG


### PR DESCRIPTION
## About The Pull Request

Drastically increases the amount of job points required for extra SG roles to open up. From 6 points (3 marines) to 20 (10 marines) required.

## Why It's Good For The Game

A horde of SGs is absolutely horrible for benos to fight against. This should be a more reasonable scaling, depending on how tests go.

## Changelog
:cl:
balance: Extra SG slot per 10 marines instead of 3.
/:cl: