### PR TITLE
fixes the IS module to be like a satchel

### DIFF
--- a/code/modules/modular_armor/storage.dm
+++ b/code/modules/modular_armor/storage.dm
@@ -171,6 +171,7 @@
 	slowdown = 0.3
 
 /obj/item/storage/internal/modular/integrated
-	max_storage_space = 42
-	storage_slots = 7
-	max_w_class = WEIGHT_CLASS_SMALL
+	bypass_w_limit = list()
+	storage_slots = null
+	max_storage_space = 15
+	max_w_class = WEIGHT_CLASS_NORMAL


### PR DESCRIPTION

## About The Pull Request
This PR makes the IS module for Jaeger armor to be like normal IS armor storage
## Why It's Good For The Game
Its basically a redundant GP with slowdown yet the inability to store items
## Changelog
:cl:
tweak: made IS module act like IS armor storage
/:cl: