### PR TITLE
Removes quick fire assembly from the pulse rifles

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -261,7 +261,6 @@
 	max_shells = 40 //codex
 	current_mag = /obj/item/ammo_magazine/rifle
 	attachable_allowed = list(
-						/obj/item/attachable/quickfire,
 						/obj/item/attachable/suppressor,
 						/obj/item/attachable/bayonet,
 						/obj/item/attachable/bayonetknife,
@@ -346,7 +345,6 @@
 						/obj/item/attachable/extended_barrel,
 						/obj/item/attachable/heavy_barrel,
 						/obj/item/attachable/scope/mini,
-						/obj/item/attachable/quickfire,
 						/obj/item/attachable/gyro,
 						/obj/item/attachable/flashlight,
 						/obj/item/attachable/scope)


### PR DESCRIPTION
## About The Pull Request

QFA makes the pulse rifles brrrrt machines.

## Why It's Good For The Game

Broken attachment for pulse rifles.

## Changelog
:cl:
balance: Prevent pulse rifles from accepting quick fire adapters.
/:cl: