### PR TITLE
hivemind throw fix

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -360,7 +360,7 @@
 			continue
 		if(isliving(A))
 			var/mob/living/L = A
-			if(L.lying_angle)
+			if(!L.density || L.throwpass)
 				continue
 			throw_impact(A, speed)
 		if(isobj(A) && A.density && !(A.flags_atom & ON_BORDER) && (!A.throwpass || iscarbon(src)))


### PR DESCRIPTION
Hiveminds are blocking thrown grenades, sneaky creatures (or anything thrown really). They have `throwpass = TRUE` but that currently does nothing.

`density` is already turned on when `lying_angle` is set to a positive value, and off when to zero, so this kills two birds with one stone.