### PR TITLE
brings the construction skill in line with other time reducing skills

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -162,6 +162,8 @@
 		var/building_time = R.time
 		if(R.skill_req && usr.skills.getRating("construction") < R.skill_req)
 			building_time += R.time * ( R.skill_req - usr.skills.getRating("construction") ) * 0.5 // +50% time each skill point lacking.
+		if(R.skill_req && usr.skills.getRating("construction") > R.skill_req)
+			building_time -= R.time * ( usr.skills.getRating("construction") - R.skill_req ) * 0.1 // -10% time each extra skill point
 		if(building_time)
 			if(building_time > R.time)
 				usr.visible_message("<span class='notice'>[usr] fumbles around figuring out how to build \a [R.title].</span>",


### PR DESCRIPTION

## About The Pull Request
This PR brings the construction skill in line with other time reducing skills by making extra skill reduce construction time
## Why It's Good For The Game

The construction skill was essentially static compared, with it only being used as requirements, like other skills, but not as time reduction, like many many other skills. This changes that so the CE is better than an average engineer, and so are ship technicians. Should provide an extra reason to play them and create an interesting dynamic.

## Changelog
:cl:
tweak: tweaked the construction skill to it so if you have more skill than needed to construct an object, it constructs 10% faster for each extra skill point
:cl: