### PR TITLE
allows marines to build on grass and wet grass

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -11,6 +11,8 @@
 
 #define isopenturf(A) (istype(A, /turf/open))
 
+#define isopengroundturf(A) (istype(A, /turf/open/ground/jungle) || istype(A,/turf/open/ground/grass))
+
 #define isspaceturf(A) (istype(A, /turf/open/space))
 
 #define islava(A) (istype(A, /turf/open/lavaland/lava))

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -11,7 +11,7 @@
 
 #define isopenturf(A) (istype(A, /turf/open))
 
-#define isopengroundturf(A) (istype(A, /turf/open/ground/jungle) || istype(A,/turf/open/ground/grass))
+#define isopengroundturf(A) (istype(A, /turf/open/ground/jungle) || istype(A, /turf/open/ground/grass))
 
 #define isspaceturf(A) (istype(A, /turf/open/space))
 

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -224,7 +224,7 @@
 				to_chat(usr, "<span class='warning'>You can't build \the [R.title] on top of another!</span>")
 				return FALSE
 	if(R.on_floor)
-		if(!isfloorturf(T) && !isbasalt(T) && !islavacatwalk(T))
+		if(!isfloorturf(T) && !isbasalt(T) && !islavacatwalk(T) && !isopengroundturf(T))
 			to_chat(usr, "<span class='warning'>\The [R.title] must be constructed on the floor!</span>")
 			return FALSE
 		for(var/obj/AM in T)


### PR DESCRIPTION
## About The Pull Request

this PR allows marines to build structures on grass and wet grass
Closes #3838
## Why It's Good For The Game

I was told to fix this by highly experienced players and I believe this is a fix which will reduce headaches for whiskey outpost. 

## Changelog
:cl:
fix: fixed marines being unable to build on grass and wet grass (most useful on Whiskey Outpost, but also elsewhere)
/:cl:
