### PR TITLE
Fix mini sentry starting with less health

### DIFF
--- a/code/game/objects/machinery/sentries.dm
+++ b/code/game/objects/machinery/sentries.dm
@@ -1265,7 +1265,7 @@
 	icon_state = "minisentry_packed"
 	item_state = "minisentry_packed"
 	w_class = WEIGHT_CLASS_BULKY
-	max_integrity = 155 //We keep track of this when folding up the sentry.
+	max_integrity = 200 //We keep track of this when folding up the sentry.
 	flags_equip_slot = ITEM_SLOT_BACK
 
 /obj/item/marine_turret/mini/attack_self(mob/user) //click the sentry to deploy it.


### PR DESCRIPTION
## About The Pull Request

Title.

## Why It's Good For The Game

Bug fix.

## Changelog
:cl:
fix: Mini sentry started out with less health due to the folded state's max integrity not being raised. It now matches the deployed health.
/:cl: