### PR TITLE
reduces point to cooldown by 50%

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -639,7 +639,7 @@ below 100 is not dizzy
 	var/turf/our_tile = get_turf(src)
 	//Squad Leaders and above have reduced cooldown and get a bigger arrow
 	if(skills.getRating("leadership") < SKILL_LEAD_TRAINED)
-		COOLDOWN_START(src, COOLDOWN_POINT, 5 SECONDS)
+		COOLDOWN_START(src, COOLDOWN_POINT, 2.5 SECONDS)
 		var/obj/visual = new /obj/effect/overlay/temp/point(our_tile, invisibility)
 		animate(visual, pixel_x = (tile.x - our_tile.x) * world.icon_size + A.pixel_x, pixel_y = (tile.y - our_tile.y) * world.icon_size + A.pixel_y, time = 1.7, easing = EASE_OUT)
 	else


### PR DESCRIPTION

## About The Pull Request

This PR reduces point to cooldown by 50%
## Why It's Good For The Game

too hard to create understanding with pointing

## Changelog
:cl:

tweak: point to cooldown is now 2.5 seconds instead of 5

/:cl: