### PR TITLE
Nerf T1 Xenos on crash

### DIFF
--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -340,7 +340,7 @@
 /datum/game_mode/infestation/crash/proc/on_xeno_evolve(datum/source, mob/living/carbon/xenomorph/new_xeno)
 	switch(new_xeno.tier)
 		if(XENO_TIER_ONE)
-			new_xeno.upgrade_xeno(XENO_UPGRADE_THREE)
+			new_xeno.upgrade_xeno(XENO_UPGRADE_TWO)
 		if(XENO_TIER_TWO)
 			new_xeno.upgrade_xeno(XENO_UPGRADE_ONE)
 


### PR DESCRIPTION
## About The Pull Request

T1 Xenos do not get ancient straight away.

## Why It's Good For The Game

Xenos win too much

## Changelog
:cl:
balance: on crash t1 xenos are no longer ancient on spawn, they are now elder.
/:cl:
