### PR TITLE
Tarp Uncovering

### DIFF
--- a/code/game/objects/items/marine_gear.dm
+++ b/code/game/objects/items/marine_gear.dm
@@ -38,6 +38,7 @@
 	close_sound = 'sound/effects/vegetation_walk_2.ogg'
 	foldedbag_path = /obj/item/bodybag/tarp
 	closet_stun_delay = 0
+	var/list/tarp_triggers = list()
 
 
 /obj/structure/closet/bodybag/tarp/close()
@@ -56,6 +57,7 @@
 		animate(src) //Cancel the fade out if still ongoing.
 	if(bodybag_occupant)
 		UnregisterSignal(bodybag_occupant, list(COMSIG_MOB_DEATH, COMSIG_PARENT_PREQDELETED))
+	QDEL_LIST(tarp_triggers)
 	return ..()
 
 
@@ -71,7 +73,7 @@
 	. = ..()
 	if(bodybag_occupant)
 		RegisterSignal(bodybag_occupant, list(COMSIG_MOB_DEATH, COMSIG_PARENT_PREQDELETED), .proc/on_bodybag_occupant_death)
-
+		deploy_triggers()
 
 /obj/structure/closet/bodybag/tarp/proc/on_bodybag_occupant_death(datum/source, gibbed)
 	open()
@@ -108,6 +110,36 @@
 	if(!opened && M)
 		M.bullet_act(Proj) //tarp isn't bullet proof; concealment, not cover; pass it on to the occupant.
 
+/obj/structure/closet/bodybag/tarp/proc/trigger_open()
+	if(locate(/mob/living/carbon/xenomorph) in viewers(2,get_turf(src)))
+		open()
+
+/obj/structure/closet/bodybag/tarp/proc/deploy_triggers()
+	QDEL_LIST(tarp_triggers)
+	var/list/turf/target_locations = filled_turfs(src, 2, "circle", FALSE)
+	for(var/turf/trigger_location in target_locations)
+		var/obj/effect/tarp_trigger/TT = new /obj/effect/tarp_trigger(trigger_location, src)
+		TT.linked_tarp = src
+		tarp_triggers += TT
+
+/obj/effect/tarp_trigger
+	name = "tarp trigger"
+	icon = 'icons/effects/effects.dmi'
+	anchored = TRUE
+	mouse_opacity = 0
+	invisibility = INVISIBILITY_MAXIMUM
+	var/obj/structure/closet/bodybag/tarp/linked_tarp
+
+/obj/effect/tarp_trigger/Initialize(mapload, obj/structure/closet/bodybag/tarp/source_tarp)
+	. = ..()
+	linked_tarp = source_tarp
+
+/obj/effect/tarp_trigger/Crossed(atom/A)
+	. = ..()
+	if(!linked_tarp) //something went very wrong
+		qdel(src)
+	else if(isxeno(A))
+		addtimer(CALLBACK(linked_tarp, /obj/structure/closet/bodybag/tarp.proc/trigger_open), 5 SECONDS)
 
 /obj/structure/closet/bodybag/tarp/snow
 	icon_state = "snowtarp_closed"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes tarps get uncovered if a xeno gets too close and stays too close for too long.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
adds some counterplay to tarps.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: tarps will uncover if a xeno stands too close for too long
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
