### PR TITLE
fixes bodybags and stasis bags not working with the medevac stretcher 

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -86,6 +86,7 @@ obj/structure/bed/Destroy()
 	buckled_bodybag.roller_buckled = null
 	buckled_bodybag.glide_modifier_flags &= ~GLIDE_MOD_BUCKLED
 	buckled_bodybag.reset_glide_size()
+	buckled_bodybag = null
 	density = FALSE
 	update_icon()
 

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -454,9 +454,9 @@ GLOBAL_LIST_EMPTY(activated_medevac_stretchers)
 
 	visible_message("<span class='notice'><b>[M] vanishes in a flash of sparks as [src]'s bluespace engine generates its displacement field.</b></span>")
 	if(buckled_bodybag)
+		var/obj/structure/closet/bodybag/teleported_bodybag = buckled_bodybag
 		unbuckle_bodybag()
-		buckled_bodybag.forceMove(get_turf(linked_beacon))
-		buckled_bodybag = null
+		teleported_bodybag.forceMove(get_turf(linked_beacon))
 	else
 		unbuckle_mob(M)
 		M.forceMove(get_turf(linked_beacon))

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -86,7 +86,6 @@ obj/structure/bed/Destroy()
 	buckled_bodybag.roller_buckled = null
 	buckled_bodybag.glide_modifier_flags &= ~GLIDE_MOD_BUCKLED
 	buckled_bodybag.reset_glide_size()
-	buckled_bodybag = null
 	density = FALSE
 	update_icon()
 
@@ -457,6 +456,7 @@ GLOBAL_LIST_EMPTY(activated_medevac_stretchers)
 	if(buckled_bodybag)
 		unbuckle_bodybag()
 		buckled_bodybag.forceMove(get_turf(linked_beacon))
+		buckled_bodybag = null
 	else
 		unbuckle_mob(M)
 		M.forceMove(get_turf(linked_beacon))


### PR DESCRIPTION
## About The Pull Request

This PR fixes the bug in which stasis bags do not work with the medevac stretcher 
Closes #4329 
## Why It's Good For The Game

Fixes good bugs bad

## Changelog
:cl:

fix: Corpsmen can now use stasis bags again with medevac stretchers 

/:cl: