### PR TITLE
Reduce resin door opening relay

### DIFF
--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -290,7 +290,7 @@
 	isSwitchingStates = TRUE
 	playsound(loc, "alien_resin_move", 25)
 	flick("[mineralType]opening",src)
-	sleep(10)
+	sleep(7)
 	density = FALSE
 	opacity = FALSE
 	state = 1

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -290,7 +290,7 @@
 	isSwitchingStates = TRUE
 	playsound(loc, "alien_resin_move", 25)
 	flick("[mineralType]opening",src)
-	sleep(7)
+	sleep(0.7 SECONDS)
 	density = FALSE
 	opacity = FALSE
 	state = 1


### PR DESCRIPTION
Reduces the sleep between initiating the opening and the actual opening from 10 to 7

<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reduces the sleep between initiating the opening and the actual opening from 10 to 7.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Resin doors are rarely used as they slow xenos as much as they slow marines.
This should reduce the xeno slowdown a little bit.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Decreases resin door opening delay from 10 to 7 frames.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
