### PR TITLE
CPR the dead

### DIFF
--- a/code/__DEFINES/cooldowns.dm
+++ b/code/__DEFINES/cooldowns.dm
@@ -20,6 +20,7 @@
 #define COOLDOWN_ARMOR_ACTION	"armor_action"
 #define COOLDOWN_FRIENDLY_FIRE_CAUSED	"friendly_fire_caused"
 #define COOLDOWN_FRIENDLY_FIRE_TAKEN	"friendly_fire_taken"
+#define COOLDOWN_CPR		"CPR"
 
 #define COOLDOWN_START(cd_source, cd_index, cd_time) LAZYSET(cd_source.cooldowns, cd_index, addtimer(CALLBACK(GLOBAL_PROC, /proc/end_cooldown, cd_source, cd_index), cd_time))
 

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -218,7 +218,7 @@
 	#define COMPONENT_PROJ_SCANTURF_TARGETFOUND (1<<1)
 
 // /mob signals
-#define COMSIG_MOB_DEATH "mob_death"							//from base of mob/death(): (gibbed)
+#define COMSIG_MOB_DEATH "mob_death"							//from base of mob/death(): (gibbing)
 #define COMSIG_MOB_REVIVE "mob_revive"							//from base of mob/on_revive(): ()
 #define COMSIG_MOB_MOUSEDOWN "mob_mousedown"					//from /client/MouseDown(): (atom/object, turf/location, control, params)
 #define COMSIG_MOB_MOUSEUP "mob_mouseup"						//from /client/MouseUp(): (atom/object, turf/location, control, params)

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -82,7 +82,7 @@
 #define UNCONSCIOUS	1
 #define DEAD		2
 
-#define check_tod(H) ((!H.undefibbable && world.time <= H.timeofdeath + CONFIG_GET(number/revive_grace_period)))
+#define check_tod(H) ((!H.undefibbable && world.time <= H.timeofdeath + CONFIG_GET(number/revive_grace_period) + H.revive_grace_time))
 
 //Damage things
 //Way to waste perfectly good damagetype names (BRUTE) on this... If you were really worried about case sensitivity, you could have just used lowertext(damagetype) in the proc...

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -244,10 +244,11 @@
 					status_hud.icon_state = "huddead"
 					return TRUE
 			var/stage = 1
-			if((world.time - timeofdeath) > (CONFIG_GET(number/revive_grace_period) * 0.4) && (world.time - timeofdeath) < (CONFIG_GET(number/revive_grace_period) * 0.8))
-				stage = 2
-			else if((world.time - timeofdeath) > (CONFIG_GET(number/revive_grace_period) * 0.8))
+			var/death_decay_time = world.time - timeofdeath - revive_grace_time
+			if(death_decay_time > (CONFIG_GET(number/revive_grace_period) * 0.8))
 				stage = 3
+			else if(death_decay_time > (CONFIG_GET(number/revive_grace_period) * 0.4))
+				stage = 2
 			status_hud.icon_state = "huddeaddefib[stage]"
 			return TRUE
 		if(UNCONSCIOUS)

--- a/code/game/objects/effects/landmarks/corpsespawner.dm
+++ b/code/game/objects/effects/landmarks/corpsespawner.dm
@@ -44,9 +44,9 @@
 	var/mob/living/carbon/human/M = new /mob/living/carbon/human (src.loc)
 	GLOB.round_statistics.total_humans_created-- //corpses don't count
 	SSblackbox.record_feedback("tally", "round_statistics", -1, "total_humans_created")
-	
+
 	M.real_name = name
-	M.death(1) //Kills the new mob
+	M.death(silent = TRUE) //Kills the new mob
 	M.timeofdeath = -CONFIG_GET(number/revive_grace_period)
 	if(corpseuniform)
 		M.equip_to_slot_or_del(new corpseuniform(M), SLOT_W_UNIFORM)

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -267,7 +267,7 @@
 		RegisterSignal(bodybag_occupant, list(COMSIG_MOB_DEATH, COMSIG_PARENT_PREQDELETED), .proc/on_bodybag_occupant_death)
 
 
-/obj/structure/closet/bodybag/cryobag/proc/on_bodybag_occupant_death(datum/source, gibbed)
+/obj/structure/closet/bodybag/cryobag/proc/on_bodybag_occupant_death(mob/source, gibbing)
 	if(!QDELETED(bodybag_occupant))
 		visible_message("<span class='notice'>\The [src] rejects the corpse.</span>")
 	open()

--- a/code/game/objects/items/defibrillator.dm
+++ b/code/game/objects/items/defibrillator.dm
@@ -207,8 +207,6 @@
 		return
 
 	user.visible_message("<span class='notice'>[icon2html(src, viewers(user))] \The [src] beeps: Defibrillation successful.</span>")
-	H.on_revive()
-	H.timeofdeath = 0
 	H.set_stat(UNCONSCIOUS)
 	H.emote("gasp")
 	H.regenerate_icons()

--- a/code/game/objects/items/marine_gear.dm
+++ b/code/game/objects/items/marine_gear.dm
@@ -73,7 +73,7 @@
 		RegisterSignal(bodybag_occupant, list(COMSIG_MOB_DEATH, COMSIG_PARENT_PREQDELETED), .proc/on_bodybag_occupant_death)
 
 
-/obj/structure/closet/bodybag/tarp/proc/on_bodybag_occupant_death(datum/source, gibbed)
+/obj/structure/closet/bodybag/tarp/proc/on_bodybag_occupant_death(mob/source, gibbing)
 	open()
 
 

--- a/code/game/objects/items/scanners.dm
+++ b/code/game/objects/items/scanners.dm
@@ -332,7 +332,7 @@ REAGENT SCANNER
 				//Check for whether there's an appropriate ghost
 				if(H.client)
 					//Calculate revival status/time left
-					var/revive_timer = round((H.timeofdeath + CONFIG_GET(number/revive_grace_period) - world.time) * 0.1)
+					var/revive_timer = round((H.timeofdeath + H.revive_grace_time + CONFIG_GET(number/revive_grace_period) - world.time) * 0.1)
 					if(revive_timer < 60) //Almost out of time; urgency required.
 						death_message = "<b>CRITICAL: Brain death imminent.</b> Reduce total injury value to sub-200 and administer defibrillator to unarmoured chest <b>immediately</b>."
 					else if(revive_timer < 120) //Running out of time; increase urgency of message.

--- a/code/game/objects/machinery/cryopod.dm
+++ b/code/game/objects/machinery/cryopod.dm
@@ -451,7 +451,7 @@
 	user.despawn(src)
 
 
-/obj/machinery/cryopod/proc/go_out()
+/obj/machinery/cryopod/proc/go_out(mob/source, gibbing)
 	if(QDELETED(occupant))
 		return
 

--- a/code/game/objects/machinery/cryopod.dm
+++ b/code/game/objects/machinery/cryopod.dm
@@ -451,7 +451,7 @@
 	user.despawn(src)
 
 
-/obj/machinery/cryopod/proc/go_out(mob/source, gibbing)
+/obj/machinery/cryopod/proc/go_out()
 	if(QDELETED(occupant))
 		return
 

--- a/code/game/objects/machinery/kitchen/gibber.dm
+++ b/code/game/objects/machinery/kitchen/gibber.dm
@@ -141,7 +141,7 @@
 
 		log_combat(user, src.occupant, "gibbed") //One shall not simply gib a mob unnoticed!
 
-		src.occupant.death(1)
+		occupant.death(silent = TRUE)
 		src.occupant.ghostize()
 
 	else if( istype(src.occupant, /mob/living/carbon/) || istype(src.occupant, /mob/living/simple_animal/ ) )
@@ -175,7 +175,7 @@
 		if(occupant.client) // Gibbed a cow with a client in it? log that shit
 			log_combat(occupant, user, "gibbed")
 
-		occupant.death(1)
+		occupant.death(silent = TRUE)
 		occupant.ghostize()
 
 	qdel(occupant)

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -26,8 +26,7 @@
 				meat = 5
 				meattype = 1
 				visible_message("<span class='warning'> [user] has forced [M] onto the spike, killing [M.p_them()] instantly!</span>")
-				M.death()
-				qdel(M)
+				M.death(TRUE)
 				G.grabbed_thing = null
 				qdel(G)
 

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -216,9 +216,7 @@
 						C.emote("scream")
 
 			log_combat(user, M, "creamated", src)
-			M.death(1)
-			M.ghostize()
-			qdel(M)
+			M.death(TRUE)
 
 		for(var/obj/O in contents)
 			if(istype(O, /obj/structure/morgue_tray)) continue

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -102,7 +102,7 @@
 		suiciding = 1
 		viewers(loc) << "<span class='danger'>[src]'s brain is growing dull and lifeless. It looks like it's lost the will to live.</span>"
 		spawn(50)
-			death(0)
+			death()
 			suiciding = 0
 
 /mob/living/carbon/monkey/verb/suicide()

--- a/code/modules/ai/ai_behaviors/carbon/carbon.dm
+++ b/code/modules/ai/ai_behaviors/carbon/carbon.dm
@@ -28,7 +28,7 @@
 
 //Signal wrappers; this can apply to both humans, xenos and other carbons that attack
 
-/datum/ai_behavior/carbon/proc/reason_target_killed()
+/datum/ai_behavior/carbon/proc/reason_target_killed(mob/source, gibbing)
 	change_state(REASON_TARGET_KILLED)
 
 //Processing; this is for abilities so we don't need to make endless xeno types to code specifically for what abilities they spawn with

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -35,6 +35,8 @@
 
 /mob/proc/death(gibbing, deathmessage = "seizes up and falls limp...", silent)
 	if(stat == DEAD)
+		if(gibbing)
+			qdel(src)
 		return
 
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_MOB_DEATH, src)

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -1,10 +1,9 @@
 //This is the proc for gibbing a mob. Cannot gib ghosts.
 //added different sort of gibs and animations. N
 /mob/proc/gib()
-	death(1)
 	gib_animation()
 	spawn_gibs()
-	qdel(src)
+	death(TRUE)
 
 
 /mob/proc/gib_animation()
@@ -21,10 +20,9 @@
 //Originally created for wizard disintegrate. I've removed the virus code since it's irrelevant here.
 //Dusting robots does not eject the MMI, so it's a bit more powerful than gib() /N
 /mob/proc/dust()
-	death(1)
 	dust_animation()
 	spawn_dust_remains()
-	qdel(src)
+	death(TRUE)
 
 
 /mob/proc/spawn_dust_remains()
@@ -35,18 +33,24 @@
 
 
 
-/mob/proc/death(gibbed, deathmessage = "seizes up and falls limp...")
-	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_MOB_LOGIN, src)
-	SEND_SIGNAL(src, COMSIG_MOB_DEATH, gibbed)
-	log_combat(src, src, "[deathmessage]")
+/mob/proc/death(gibbing, deathmessage = "seizes up and falls limp...", silent)
 	if(stat == DEAD)
-		return FALSE
+		return
 
-	if(!gibbed)
-		src.visible_message("<b>\The [src.name]</b> [deathmessage]")
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_MOB_DEATH, src)
+	SEND_SIGNAL(src, COMSIG_MOB_DEATH, gibbing)
+	log_combat(src, src, "[deathmessage]")
+
+	if(deathmessage && !silent && !gibbing)
+		visible_message("<b>\The [name]</b> [deathmessage]")
 
 	set_stat(DEAD)
 
+	if(!QDELETED(src) && gibbing)
+		qdel(src)
+
+
+/mob/proc/on_death()
 	client?.change_view(WORLD_VIEW) //just so we never get stuck with a large view somehow
 
 	hide_fullscreens()
@@ -73,5 +77,3 @@
 
 	if(SSticker.HasRoundStarted())
 		SSblackbox.ReportDeath(src)
-		
-	return TRUE

--- a/code/modules/mob/living/brain/death.dm
+++ b/code/modules/mob/living/brain/death.dm
@@ -1,7 +1,10 @@
-/mob/living/brain/death(gibbed)
-	if(!gibbed && istype(container, /obj/item/mmi)) //If not gibbed but in a container.
+/mob/living/brain/death(gibbing, deathmessage = "beeps shrilly as the MMI flatlines!", silent)
+	if(stat == DEAD)
+		return
+	if(!gibbing && istype(container, /obj/item/mmi)) //If not gibbing but in a container.
 		container.icon_state = "mmi_dead"
-	return ..(gibbed,"beeps shrilly as the MMI flatlines!")
+	return ..()
+
 
 /mob/living/brain/gib()
 	if(istype(container, /obj/item/mmi))

--- a/code/modules/mob/living/brain/death.dm
+++ b/code/modules/mob/living/brain/death.dm
@@ -1,6 +1,6 @@
 /mob/living/brain/death(gibbing, deathmessage = "beeps shrilly as the MMI flatlines!", silent)
 	if(stat == DEAD)
-		return
+		return ..()
 	if(!gibbing && istype(container, /obj/item/mmi)) //If not gibbing but in a container.
 		container.icon_state = "mmi_dead"
 	return ..()

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -45,7 +45,7 @@
 
 /mob/living/carbon/human/death(gibbing, deathmessage, silent)
 	if(stat == DEAD)
-		return
+		return ..()
 	if(!silent && species.death_sound)
 		playsound(loc, species.death_sound, 50, TRUE)
 	return ..()

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -43,21 +43,22 @@
 	new /obj/effect/overlay/temp/dust_animation(loc, src, "dust-h")
 
 
-/mob/living/carbon/human/death(gibbed)
+/mob/living/carbon/human/death(gibbing, deathmessage, silent)
 	if(stat == DEAD)
 		return
+	if(!silent && species.death_sound)
+		playsound(loc, species.death_sound, 50, TRUE)
+	return ..()
 
+
+/mob/living/carbon/human/on_death()
 	if(pulledby)
 		pulledby.stop_pulling()
 
 	//Handle species-specific deaths.
-	if(species)
-		species.handle_death(src, gibbed)
+	species.handle_death(src)
 
 	remove_typing_indicator()
-
-	if(!gibbed && species.death_sound)
-		playsound(loc, species.death_sound, 50, 1)
 
 	if(SSticker && SSticker.current_state == GAME_STATE_PLAYING) //game has started, to ignore the map placed corpses.
 		GLOB.round_statistics.total_human_deaths++
@@ -69,6 +70,7 @@
 	UnregisterSignal(src, COMSIG_MOVABLE_Z_CHANGED)
 
 	return ..()
+
 
 /mob/living/carbon/human/proc/makeSkeleton()
 	if(f_style)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -35,7 +35,7 @@
 				to_chat(H, "<span class='boldnotice'>Remove his mask!</span>")
 				return FALSE
 
-			if(!check_tod(src) || undefibbable)
+			if(stat == DEAD && !check_tod(src))
 				to_chat(H, "<span class='boldnotice'>Can't help this one. Body has gone cold.</span>")
 				return FALSE
 

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -30,31 +30,45 @@
 			if(health >= get_crit_threshold())
 				help_shake_act(H)
 				return 1
-//			if(H.health < -75)	return 0
+
+			if((head && (head.flags_inventory & COVERMOUTH)) || (wear_mask && (wear_mask.flags_inventory & COVERMOUTH)))
+				to_chat(H, "<span class='boldnotice'>Remove his mask!</span>")
+				return FALSE
+
+			if(!check_tod(src) || undefibbable)
+				to_chat(H, "<span class='boldnotice'>Can't help this one. Body has gone cold.</span>")
+				return FALSE
 
 			if((H.head && (H.head.flags_inventory & COVERMOUTH)) || (H.wear_mask && (H.wear_mask.flags_inventory & COVERMOUTH)))
 				to_chat(H, "<span class='boldnotice'>Remove your mask!</span>")
-				return 0
-			if((head && (head.flags_inventory & COVERMOUTH)) || (wear_mask && (wear_mask.flags_inventory & COVERMOUTH)))
-				to_chat(H, "<span class='boldnotice'>Remove his mask!</span>")
-				return 0
+				return FALSE
 
 			//CPR
 			if(H.action_busy)
-				return 1
+				return TRUE
+
 			H.visible_message("<span class='danger'>[H] is trying perform CPR on [src]!</span>", null, null, 4)
 
-			if(do_mob(H, src, HUMAN_STRIP_DELAY, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL))
-				if(health > get_death_threshold() && health < get_crit_threshold())
-					var/suff = min(getOxyLoss(), 5) //Pre-merge level, less healing, more prevention of dieing.
-					adjustOxyLoss(-suff)
-					updatehealth()
-					visible_message("<span class='warning'> [H] performs CPR on [src]!</span>", null, null, 3)
-					to_chat(src, "<span class='boldnotice'>You feel a breath of fresh air enter your lungs. It feels good.</span>")
-					to_chat(H, "<span class='warning'>Repeat at least every 7 seconds.</span>")
+			if(!do_mob(H, src, HUMAN_STRIP_DELAY, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL) || undefibbable)
+				return TRUE
 
+			if(health > get_death_threshold() && health < get_crit_threshold())
+				var/suff = min(getOxyLoss(), 5) //Pre-merge level, less healing, more prevention of dieing.
+				adjustOxyLoss(-suff)
+				updatehealth()
+				visible_message("<span class='warning'> [H] performs CPR on [src]!</span>",
+					"<span class='boldnotice'>You feel a breath of fresh air enter your lungs. It feels good.</span>",
+					vision_distance = 3)
+				to_chat(H, "<span class='warning'>Repeat at least every 7 seconds.</span>")
+			else if(stat == DEAD && check_tod(src) && !COOLDOWN_CHECK(src, COOLDOWN_CPR))
+				COOLDOWN_START(src, COOLDOWN_CPR, 7 SECONDS)
+				revive_grace_time += 5 SECONDS
+				visible_message("<span class='warning'> [H] performs CPR on [src]!</span>", vision_distance = 3)
+				to_chat(H, "<span class='warning'>The patient gains a little more time. Repeat every 7 seconds.</span>")
+			else
+				to_chat(H, "<span class='warning'>You fail to aid [src].</span>")
 
-			return 1
+			return TRUE
 
 		if(INTENT_GRAB)
 			if(H == src || anchored)

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -120,3 +120,6 @@
 	var/specset //Simple way to track which set has the player taken
 
 	var/static/list/can_ride_typecache = typecacheof(list(/mob/living/carbon/human, /mob/living/simple_animal/parrot))
+
+	///Amount of deciseconds gained from the braindeath timer, usually by CPR.
+	var/revive_grace_time = 0

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -34,9 +34,7 @@
 			if(!undefibbable && timeofdeath && life_tick > 5 && life_tick % 2 == 0)
 				if(timeofdeath < 5 || !check_tod(src) || !is_revivable())	//We are dead beyond revival, or we're junk mobs spawned like the clowns on the clown shuttle
 					set_undefibbable()
-				else if((world.time - timeofdeath) > (CONFIG_GET(number/revive_grace_period) * 0.4) && (world.time - timeofdeath) < (CONFIG_GET(number/revive_grace_period) * 0.8))
-					med_hud_set_status()
-				else if((world.time - timeofdeath) > (CONFIG_GET(number/revive_grace_period) * 0.8))
+				else
 					med_hud_set_status()
 
 	stabilize_body_temperature() //Body temperature adjusts itself (self-regulation) (even when dead)

--- a/code/modules/mob/living/carbon/monkey/death.dm
+++ b/code/modules/mob/living/carbon/monkey/death.dm
@@ -9,5 +9,5 @@
 
 /mob/living/carbon/monkey/death(gibbing, deathmessage = "lets out a faint chimper as it collapses and stops moving...", silent)
 	if(stat == DEAD)
-		return
+		return ..()
 	return ..() //Just a different standard deathmessage

--- a/code/modules/mob/living/carbon/monkey/death.dm
+++ b/code/modules/mob/living/carbon/monkey/death.dm
@@ -7,5 +7,7 @@
 	new /obj/effect/overlay/temp/dust_animation(loc, src, "dust-m")
 
 
-/mob/living/carbon/monkey/death(gibbed)
-	..(gibbed,"lets out a faint chimper as it collapses and stops moving...")
+/mob/living/carbon/monkey/death(gibbing, deathmessage = "lets out a faint chimper as it collapses and stops moving...", silent)
+	if(stat == DEAD)
+		return
+	return ..() //Just a different standard deathmessage

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/carrier.dm
@@ -22,9 +22,8 @@
 // ***************************************
 // *********** Death
 // ***************************************
-/mob/living/carbon/xenomorph/carrier/death(gibbed)
-	. = ..()
-	if(. && !gibbed && length(huggers))
+/mob/living/carbon/xenomorph/carrier/on_death()
+	if(length(huggers))
 		var/chance = 75
 		visible_message("<span class='xenowarning'>The chittering mass of tiny aliens is trying to escape [src]!</span>")
 		for(var/i in 1 to 3)
@@ -39,6 +38,9 @@
 				qdel(F)
 			chance -= 30
 		QDEL_LIST(huggers)
+
+	return ..()
+
 
 // ***************************************
 // *********** Life overrides

--- a/code/modules/mob/living/carbon/xenomorph/castes/larva/larva.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/larva/larva.dm
@@ -100,7 +100,7 @@
 // ***************************************
 // *********** Death
 // ***************************************
-/mob/living/carbon/xenomorph/larva/death(gibbed, deathmessage)
+/mob/living/carbon/xenomorph/larva/on_death()
 	log_game("[key_name(src)] died as a Larva at [AREACOORD(src)].")
 	message_admins("[ADMIN_TPMONTY(src)] died as a Larva.")
 	return ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -390,7 +390,7 @@
 	if(overwatch_active)
 		stop_overwatch()
 
-/datum/action/xeno_action/watch_xeno/proc/on_owner_death(datum/source, gibbed)
+/datum/action/xeno_action/watch_xeno/proc/on_owner_death(mob/source, gibbing)
 	if(overwatch_active)
 		stop_overwatch()
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
@@ -116,9 +116,6 @@
 // ***************************************
 // *********** Death
 // ***************************************
-/mob/living/carbon/xenomorph/queen/gib()
-	death(1) //we need the body to show the queen's name at round end.
-
 /mob/living/carbon/xenomorph/queen/death_cry()
 	playsound(loc, 'sound/voice/alien_queen_died.ogg', 75, 0)
 

--- a/code/modules/mob/living/carbon/xenomorph/death.dm
+++ b/code/modules/mob/living/carbon/xenomorph/death.dm
@@ -2,33 +2,35 @@
 /mob/living/carbon/xenomorph/proc/death_cry()
 	playsound(loc, prob(50) == 1 ? 'sound/voice/alien_death.ogg' : 'sound/voice/alien_death2.ogg', 25, 1)
 
-/mob/living/carbon/xenomorph/death(gibbed)
-	if(LAZYLEN(stomach_contents))
-		empty_gut()
-		visible_message("<span class='danger'>Something bursts out of [src]!</span>")
 
-	var/msg = "lets out a waning guttural screech, green blood bubbling from its maw."
-	. = ..(gibbed,msg)
-	if(!.) return //If they're already dead, it will return.
+/mob/living/carbon/xenomorph/death(gibbing, deathmessage = "lets out a waning guttural screech, green blood bubbling from its maw.", silent)
+	if(stat == DEAD)
+		return
+	return ..() //Just a different standard deathmessage
 
+
+/mob/living/carbon/xenomorph/on_death()
 	GLOB.alive_xeno_list -= src
 	GLOB.dead_xeno_list += src
 	hive?.on_xeno_death(src)
+
+	if(LAZYLEN(stomach_contents))
+		empty_gut()
+		visible_message("<span class='danger'>Something bursts out of [src]!</span>")
 
 	if(is_zoomed)
 		zoom_out()
 
 	set_light(0)
 
-	if(!gibbed)
-		if(hud_used)
-			if(hud_used.healths)
-				hud_used.healths.icon_state = "health_dead"
-			if(hud_used.staminas)
-				hud_used.staminas.icon_state = "staminaloss200"
-			if(hud_used.alien_plasma_display)
-				hud_used.alien_plasma_display.icon_state = "power_display_empty"
-		update_icons()
+	if(hud_used)
+		if(hud_used.healths)
+			hud_used.healths.icon_state = "health_dead"
+		if(hud_used.staminas)
+			hud_used.staminas.icon_state = "staminaloss200"
+		if(hud_used.alien_plasma_display)
+			hud_used.alien_plasma_display.icon_state = "power_display_empty"
+	update_icons()
 
 	death_cry()
 
@@ -36,12 +38,13 @@
 
 	hud_set_queen_overwatch() //updates the overwatch hud to remove the upgrade chevrons, gold star, etc
 
+	GLOB.round_statistics.total_xeno_deaths++
+	SSblackbox.record_feedback("tally", "round_statistics", 1, "total_xeno_deaths")
+
 	var/isAI = GetComponent(/datum/component/ai_controller)
 	if (isAI)
 		gib()
 
-	GLOB.round_statistics.total_xeno_deaths++
-	SSblackbox.record_feedback("tally", "round_statistics", 1, "total_xeno_deaths")
 
 /mob/living/carbon/xenomorph/proc/xeno_death_alert()
 	if(is_centcom_level(z))
@@ -61,7 +64,7 @@
 
 	check_blood_splash(35, BURN, 65, 2) //Some testing numbers. 35 burn, 65 chance.
 
-	..(1)
+	return ..()
 
 /mob/living/carbon/xenomorph/gib_animation()
 	new /obj/effect/overlay/temp/gib_animation/xeno(loc, src, xeno_caste.gib_flick, icon)

--- a/code/modules/mob/living/carbon/xenomorph/death.dm
+++ b/code/modules/mob/living/carbon/xenomorph/death.dm
@@ -5,7 +5,7 @@
 
 /mob/living/carbon/xenomorph/death(gibbing, deathmessage = "lets out a waning guttural screech, green blood bubbling from its maw.", silent)
 	if(stat == DEAD)
-		return
+		return ..()
 	return ..() //Just a different standard deathmessage
 
 

--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -205,7 +205,6 @@
 			H.internal_organs_by_name -= i
 			H.internal_organs -= O
 
-	victim.death() // Certain species were still surviving bursting, DEFINITELY kill them this time.
 	victim.chestburst = 2
 	victim.update_burst()
 	log_combat(src, null, "chestbursted as a larva.")
@@ -213,6 +212,9 @@
 
 	if((locate(/obj/structure/bed/nest) in loc) && hive.living_xeno_queen?.z == loc.z)
 		burrow()
+
+	victim.death()
+
 
 /mob/living/proc/emote_burstscream()
 	return

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -1,7 +1,4 @@
-/mob/living/death(gibbed, deathmessage = "seizes up and falls limp...")
-	if(stat == DEAD)
-		return FALSE
-
+/mob/living/on_death()
 	dizziness = 0
 	jitteriness = 0
 	reset_perspective(null)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -773,12 +773,18 @@ below 100 is not dizzy
 	. = ..()
 	if(isnull(.))
 		return
-	if(stat == CONSCIOUS) //From unconscious to conscious.
-		REMOVE_TRAIT(src, TRAIT_IMMOBILE, STAT_TRAIT)
-		REMOVE_TRAIT(src, TRAIT_FLOORED, STAT_TRAIT)
-	else if(. == CONSCIOUS) //From conscious to unconscious.
-		ADD_TRAIT(src, TRAIT_IMMOBILE, STAT_TRAIT)
-		ADD_TRAIT(src, TRAIT_FLOORED, STAT_TRAIT)
+	switch(.)
+		if(CONSCIOUS) //From conscious to unconscious.
+			ADD_TRAIT(src, TRAIT_IMMOBILE, STAT_TRAIT)
+			ADD_TRAIT(src, TRAIT_FLOORED, STAT_TRAIT)
+		if(DEAD)
+			on_revive()
+	switch(stat)
+		if(CONSCIOUS) //From unconscious to conscious.
+			REMOVE_TRAIT(src, TRAIT_IMMOBILE, STAT_TRAIT)
+			REMOVE_TRAIT(src, TRAIT_FLOORED, STAT_TRAIT)
+		if(DEAD)
+			on_death()
 
 
 /mob/living/setGrabState(newstate)

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -218,11 +218,13 @@ mob/living/proc/adjustHalLoss(amount) //This only makes sense for carbon.
 
 /mob/living/proc/on_revive()
 	SEND_SIGNAL(src, COMSIG_MOB_REVIVE)
+	timeofdeath = 0
 	GLOB.alive_living_list += src
 	GLOB.dead_mob_list -= src
 
 /mob/living/carbon/human/on_revive()
 	. = ..()
+	revive_grace_time = initial(revive_grace_time)
 	GLOB.alive_human_list += src
 	GLOB.dead_human_list -= src
 	LAZYADD(GLOB.humans_by_zlevel["[z]"], src)
@@ -271,11 +273,6 @@ mob/living/proc/adjustHalLoss(amount) //This only makes sense for carbon.
 	if(L)
 		qdel(L)
 	DISABLE_BITFIELD(status_flags, XENO_HOST)
-
-	// remove the character from the list of the dead
-	if(stat == DEAD)
-		on_revive()
-		timeofdeath = 0
 
 	// restore us to conciousness
 	set_stat(CONSCIOUS)

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -1,9 +1,4 @@
-/mob/living/silicon/ai/death(gibbed)
-	if(stat == DEAD)
-		return
-
-	. = ..()
-
+/mob/living/silicon/ai/on_death()
 	var/old_icon = icon_state
 	if("[icon_state]_dead" in icon_states(icon))
 		icon_state = "[icon_state]_dead"
@@ -15,3 +10,5 @@
 	if(eyeobj)
 		eyeobj.setLoc(get_turf(src))
 		set_eyeobj_visible(FALSE)
+
+	return ..()

--- a/code/modules/mob/living/silicon/decoy/decoy.dm
+++ b/code/modules/mob/living/silicon/decoy/decoy.dm
@@ -39,7 +39,7 @@
 
 /mob/living/silicon/decoy/death(gibbing, deathmessage = "sparks up and falls silent...", silent)
 	if(stat == DEAD)
-		return
+		return ..()
 	return ..()
 
 

--- a/code/modules/mob/living/silicon/decoy/decoy.dm
+++ b/code/modules/mob/living/silicon/decoy/decoy.dm
@@ -25,7 +25,7 @@
 		SSmobs.stop_processing(src)
 		return FALSE
 	if(health <= get_death_threshold() && stat != DEAD)
-		death(FALSE, "<b>\The [name]</b> sparks up and falls silent...")
+		death()
 
 /mob/living/silicon/decoy/updatehealth()
 	if(status_flags & GODMODE)
@@ -36,13 +36,24 @@
 
 	update_stat()
 
-/mob/living/silicon/decoy/death(gibbed, deathmessage)
-	set waitfor = 0
-	. = ..()
+
+/mob/living/silicon/decoy/death(gibbing, deathmessage = "sparks up and falls silent...", silent)
+	if(stat == DEAD)
+		return
+	return ..()
+
+
+/mob/living/silicon/decoy/on_death()
 	density = TRUE
 	icon_state = "hydra-off"
-	sleep(20)
-	explosion(loc, 0, 1, 9, 12)
+	addtimer(CALLBACK(src, .proc/post_mortem_explosion), 2 SECONDS)
+	return ..()
+
+
+/mob/living/silicon/decoy/proc/post_mortem_explosion()
+	if(isnull(loc))
+		return
+	explosion(get_turf(src), 0, 1, 9, 12)
 
 
 /mob/living/silicon/decoy/say(message, new_sound, datum/language/language) //General communication across the ship.

--- a/code/modules/mob/living/simple_animal/friendly/parrot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/parrot.dm
@@ -78,7 +78,7 @@
 
 /mob/living/simple_animal/parrot/death(gibbing, deathmessage, silent)
 	if(stat == DEAD)
-		return
+		return ..()
 	if(held_item)
 		held_item.forceMove(drop_location())
 		held_item = null

--- a/code/modules/mob/living/simple_animal/friendly/parrot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/parrot.dm
@@ -76,7 +76,9 @@
 	parrot_sleep_dur = parrot_sleep_max //In case someone decides to change the max without changing the duration var
 
 
-/mob/living/simple_animal/parrot/death(gibbed)
+/mob/living/simple_animal/parrot/death(gibbing, deathmessage, silent)
+	if(stat == DEAD)
+		return
 	if(held_item)
 		held_item.forceMove(drop_location())
 		held_item = null
@@ -564,7 +566,7 @@
 	return ..()
 
 
-/mob/living/simple_animal/parrot/Poly/death(gibbed)
+/mob/living/simple_animal/parrot/Poly/on_death()
 	if(!memory_saved)
 		Write_Memory(TRUE)
 	if(prob(0.666))

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -41,8 +41,9 @@
 	health = 200
 
 
-/mob/living/simple_animal/hostile/alien/death(gibbed, deathmessage = "lets out a waning guttural screech, green blood bubbling from its maw.")
-	. = ..()
-	if(!.)
+/mob/living/simple_animal/hostile/alien/death(gibbing, deathmessage = "lets out a waning guttural screech, green blood bubbling from its maw.", silent)
+	if(stat == DEAD)
 		return
-	playsound(src, 'sound/voice/alien_death.ogg', 50, 1)
+	if(!gibbing && !silent)
+		playsound(src, 'sound/voice/alien_death.ogg', 50, TRUE)
+	return ..()

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -43,7 +43,7 @@
 
 /mob/living/simple_animal/hostile/alien/death(gibbing, deathmessage = "lets out a waning guttural screech, green blood bubbling from its maw.", silent)
 	if(stat == DEAD)
-		return
+		return ..()
 	if(!gibbing && !silent)
 		playsound(src, 'sound/voice/alien_death.ogg', 50, TRUE)
 	return ..()

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -339,9 +339,9 @@
 	LoseAggro()
 
 
-/mob/living/simple_animal/hostile/death(gibbed)
+/mob/living/simple_animal/hostile/on_death()
 	LoseTarget()
-	return ..(gibbed)
+	return ..()
 
 
 /mob/living/simple_animal/hostile/proc/summon_backup(distance, exact_faction_match)

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -85,7 +85,7 @@
 	icon_state = initial(icon_state)
 
 
-/mob/living/simple_animal/hostile/mimic/crate/death()
+/mob/living/simple_animal/hostile/mimic/crate/on_death()
 	var/obj/structure/closet/crate/C = new(get_turf(src))
 	// Put loot in crate
 	for(var/obj/O in src)
@@ -122,9 +122,10 @@ GLOBAL_LIST_INIT(protected_objects, list(/obj/structure/table, /obj/structure/ca
 		death()
 
 
-/mob/living/simple_animal/hostile/mimic/copy/death()
-	for(var/atom/movable/M in src)
-		M.forceMove(get_turf(src))
+/mob/living/simple_animal/hostile/mimic/copy/on_death()
+	for(var/am in contents)
+		var/atom/movable/thing = am
+		thing.forceMove(get_turf(src))
 	return ..()
 
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -132,7 +132,7 @@
 
 /mob/living/simple_animal/death(gibbing, deathmessage, silent)
 	if(stat == DEAD)
-		return
+		return ..()
 	if(!silent && !gibbing && !del_on_death && !deathmessage && src.deathmessage)
 		emote("deathgasp")
 		silent = TRUE //No need to for the parent to deathmessage again.

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -130,22 +130,24 @@
 	return
 
 
-/mob/living/simple_animal/death(gibbed)
+/mob/living/simple_animal/death(gibbing, deathmessage, silent)
+	if(stat == DEAD)
+		return
+	if(!silent && !gibbing && !del_on_death && !deathmessage && src.deathmessage)
+		emote("deathgasp")
+		silent = TRUE //No need to for the parent to deathmessage again.
+	return ..()
+
+
+/mob/living/simple_animal/on_death()
+	health = 0
+	icon_state = icon_dead
+	density = FALSE
+
 	. = ..()
-	if(!gibbed)
-		if(deathmessage || !del_on_death)
-			emote("deathgasp")
-	if(del_on_death)
-		. = ..()
-		//Prevent infinite loops if the mob Destroy() is overridden in such
-		//a manner as to cause a call to death() again
-		del_on_death = FALSE
+
+	if(del_on_death && !QDELETED(src))
 		qdel(src)
-	else
-		health = 0
-		icon_state = icon_dead
-		density = FALSE
-		return ..()
 
 
 /mob/living/simple_animal/gib_animation()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

* Gives marines the ability to more quickly identify those long gone without tools, and help those still warm.
* Fixes an issue with the death balancing tool, sending the wrong global signal.
* Cleans up death code a bit, and makes the cleanup respond more properly to the event of the change of the `stat` value.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

* Making the medical game a bit more interesting. I'd increase the revive timer, personally, from 5 to 10 minutes or so. Didn't do so in this PR because I don't want to include big balance changes.

## Changelog
:cl:
add: Marines can CPR defibable bodies every 7 seconds, buying them some time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
