### PR TITLE
FOB Drone Construction Speed

### DIFF
--- a/code/modules/mining/remote_fob/remote_fob_actions_misc.dm
+++ b/code/modules/mining/remote_fob/remote_fob_actions_misc.dm
@@ -58,7 +58,7 @@
 			continue
 		to_chat(owner, "<span class='warning'>No space here for a barricade.</span>")
 		return
-	if(!do_after(fobdrone, 3 SECONDS, FALSE, buildplace, BUSY_ICON_BUILD))
+	if(!do_after(fobdrone, 1.5 SECONDS, FALSE, buildplace, BUSY_ICON_BUILD))
 		return
 	console.metal_remaining -= 4
 	cade = new /obj/structure/barricade/metal(buildplace)
@@ -99,7 +99,7 @@
 			continue
 		to_chat(owner, "<span class='warning'>No space here for a barricade.</span>")
 		return
-	if(!do_after(fobdrone, 3 SECONDS, FALSE, buildplace, BUSY_ICON_BUILD))
+	if(!do_after(fobdrone, 1.5 SECONDS, FALSE, buildplace, BUSY_ICON_BUILD))
 		return
 	console.plasteel_remaining -= 5
 	cade = new /obj/structure/barricade/plasteel(buildplace)
@@ -151,7 +151,7 @@
 			else
 				to_chat(owner, "<span class='warning'>No space here for a sentry.</span>")
 				return
-	if(!do_after(fobdrone, 6 SECONDS, FALSE, buildplace, BUSY_ICON_BUILD))
+	if(!do_after(fobdrone, 3 SECONDS, FALSE, buildplace, BUSY_ICON_BUILD))
 		return
 	console.sentry_remaining -= 1
 	turret = new /obj/machinery/marine_turret(buildplace)


### PR DESCRIPTION

## About The Pull Request

Basically this makes the FOB Drone build barricades, plasteel barricades, and sentries faster. Does not change material cost of either cade types. 

## Why It's Good For The Game

Less rush for whoever is manning the FOB drone, while the ungas all shout about how they want to deploy. 

## Changelog
:cl:
balance: FOB Drone Builds Faster
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
