### PR TITLE
Psychic Cure Change + Queen Heal

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
@@ -48,7 +48,7 @@
 	if(owner.action_busy)
 		return FALSE
 
-	if(!do_mob(owner, target, 1 SECONDS, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL))
+	if(!do_mob(owner, target, heal_time, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL))
 		return FALSE
 
 	owner.visible_message("<span class='xenowarning'>\the [owner] vomits acid over [target]!</span>", \

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/abilities_hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/abilities_hivemind.dm
@@ -1,1 +1,8 @@
-// empty file for now
+/datum/action/xeno_action/activable/psychic_cure/hivemind
+	name = "Psychic Cure"
+	action_icon_state = "heal_xeno"
+	mechanics_text = "Heal and remove debuffs from a target."
+	cooldown_timer = 1 MINUTES
+	plasma_cost = 200
+	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_CURE
+	heal_time = 2 SECONDS

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/abilities_hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/abilities_hivemind.dm
@@ -1,8 +1,2 @@
 /datum/action/xeno_action/activable/psychic_cure/hivemind
-	name = "Psychic Cure"
-	action_icon_state = "heal_xeno"
-	mechanics_text = "Heal and remove debuffs from a target."
-	cooldown_timer = 1 MINUTES
-	plasma_cost = 200
-	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_CURE
 	heal_time = 2 SECONDS

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/castedatum_hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/castedatum_hivemind.dm
@@ -70,7 +70,7 @@
 	// *** Abilities *** //
 	actions = list(
 		/datum/action/xeno_action/plant_weeds/slow,
-		/datum/action/xeno_action/activable/psychic_cure,
+		/datum/action/xeno_action/activable/psychic_cure/hivemind,
 		)
 
 
@@ -79,7 +79,7 @@
 	upgrade = XENO_UPGRADE_TWO
 
 	// *** Plasma *** //
-	plasma_max = 250 
+	plasma_max = 250
 	plasma_gain = 60 // This is 4 weed every 10 secs.
 
 	// *** Health *** //
@@ -91,7 +91,7 @@
 	// *** Abilities *** //
 	actions = list(
 		/datum/action/xeno_action/plant_weeds/slow,
-		/datum/action/xeno_action/activable/psychic_cure,
+		/datum/action/xeno_action/activable/psychic_cure/hivemind,
 		/datum/action/xeno_action/toggle_pheromones,
 		)
 
@@ -101,7 +101,7 @@
 	upgrade = XENO_UPGRADE_THREE
 
 	// *** Plasma *** //
-	plasma_max = 300 
+	plasma_max = 300
 	plasma_gain = 75 // This is 5 weed every 10 secs.
 
 	// *** Health *** //
@@ -113,7 +113,7 @@
 	// *** Abilities *** //
 	actions = list(
 		/datum/action/xeno_action/plant_weeds/slow,
-		/datum/action/xeno_action/activable/psychic_cure,
+		/datum/action/xeno_action/activable/psychic_cure/hivemind,
 		/datum/action/xeno_action/choose_resin,
 		/datum/action/xeno_action/toggle_pheromones,
 		/datum/action/xeno_action/activable/secrete_resin/slow,

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -534,51 +534,15 @@
 // ***************************************
 // *********** Queen heal
 // ***************************************
-/datum/action/xeno_action/activable/queen_heal
-	name = "Heal Xenomorph"
+/datum/action/xeno_action/activable/psychic_cure/queen
+	name = "Psychic Cure"
 	action_icon_state = "heal_xeno"
-	mechanics_text = "Heals a target Xenomorph"
-	plasma_cost = 150
-	cooldown_timer = 16 SECONDS
+	mechanics_text = "Heal and remove debuffs from a target."
+	cooldown_timer = 1 MINUTES
+	plasma_cost = 200
 	keybind_signal = COMSIG_XENOABILITY_QUEEN_HEAL
-
-
-/datum/action/xeno_action/activable/queen_heal/can_use_ability(atom/target, silent = FALSE, override_flags)
-	. = ..()
-	if(!.)
-		return FALSE
-	if(!isxeno(target))
-		return FALSE
-	var/mob/living/carbon/xenomorph/patient = target
-	if(!CHECK_BITFIELD(use_state_flags|override_flags, XACT_IGNORE_DEAD_TARGET) && patient.stat == DEAD)
-		if(!silent)
-			to_chat(owner, "<span class='warning'>It's too late. This sister won't be coming back.</span>")
-		return FALSE
-	if(!(patient.xeno_caste.caste_flags & CASTE_CAN_BE_QUEEN_HEALED))
-		if(!silent)
-			to_chat(owner, "<span class='xenowarning'>We can't heal that caste.</span>")
-			return FALSE
-	var/mob/living/carbon/xenomorph/healer = owner
-	if(healer.z != patient.z)
-		if(!silent)
-			to_chat(healer, "<span class='xenowarning'>They are too far away to do this.</span>")
-		return FALSE
-	if(patient.health >= patient.maxHealth)
-		if(!silent)
-			to_chat(healer, "<span class='warning'>[patient] is at full health.</span>")
-		return FALSE
-
-
-/datum/action/xeno_action/activable/queen_heal/use_ability(atom/target)
-	var/mob/living/carbon/xenomorph/patient = target
-	add_cooldown()
-	patient.adjustBruteLoss(-100)
-	patient.adjustFireLoss(-100)
-	patient.adjust_sunder(-10)
-	succeed_activate()
-	to_chat(owner, "<span class='xenonotice'>We channel our plasma to heal [target]'s wounds.</span>")
-	to_chat(patient, "<span class='xenonotice'>We feel our wounds heal. Bless the Queen!</span>")
-
+	long_distance_heal = TRUE
+	heal_time = 2 SECONDS
 
 // ***************************************
 // *********** Queen plasma

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -535,13 +535,8 @@
 // *********** Queen heal
 // ***************************************
 /datum/action/xeno_action/activable/psychic_cure/queen
-	name = "Psychic Cure"
-	action_icon_state = "heal_xeno"
-	mechanics_text = "Heal and remove debuffs from a target."
-	cooldown_timer = 1 MINUTES
-	plasma_cost = 200
 	keybind_signal = COMSIG_XENOABILITY_QUEEN_HEAL
-	long_distance_heal = TRUE
+	ignore_distance_check = TRUE
 	heal_time = 2 SECONDS
 
 // ***************************************

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/castedatum_queen.dm
@@ -68,6 +68,7 @@
 		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/set_xeno_lead,
 		/datum/action/xeno_action/activable/queen_give_plasma,
+		/datum/action/xeno_action/activable/psychic_cure/queen,
 		/datum/action/xeno_action/queen_order,
 		/datum/action/xeno_action/deevolve
 		)

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -295,6 +295,8 @@
 	cooldown_timer = 1 MINUTES
 	plasma_cost = 200
 	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_CURE
+	var/long_distance_heal = FALSE
+	var/heal_time = 1 SECONDS
 
 
 /datum/action/xeno_action/activable/psychic_cure/on_cooldown_finish()
@@ -308,8 +310,9 @@
 		return FALSE
 	if(QDELETED(target))
 		return FALSE
-	if(!check_distance(target, silent))
-		return FALSE
+	if(!long_distance_heal)
+		if(!check_distance(target, silent))
+			return FALSE
 	if(!isxeno(target))
 		return FALSE
 	var/mob/living/carbon/xenomorph/patient = target
@@ -341,7 +344,7 @@
 	if(owner.action_busy)
 		return FALSE
 
-	if(!do_mob(owner, target, 1 SECONDS, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL))
+	if(!do_mob(owner, target, heal_time, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL))
 		return FALSE
 
 	GLOB.round_statistics.psychic_cures++

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -295,7 +295,7 @@
 	cooldown_timer = 1 MINUTES
 	plasma_cost = 200
 	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_CURE
-	var/long_distance_heal = FALSE
+	var/ignore_distance_check = FALSE
 	var/heal_time = 1 SECONDS
 
 
@@ -310,9 +310,8 @@
 		return FALSE
 	if(QDELETED(target))
 		return FALSE
-	if(!long_distance_heal)
-		if(!check_distance(target, silent))
-			return FALSE
+	if(!ignore_distance_check && !check_distance(target, silent))
+		return FALSE
 	if(!isxeno(target))
 		return FALSE
 	var/mob/living/carbon/xenomorph/patient = target


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds two variables to the psychic cure: long_distance_heal, and heal_time.
these two variables allow for some better balancing and more versatility.
long_distance_heal allows the heal to ignore distance, so this means the queen is now able to use the psychic cure on her overwatch.
heal_time is of course healing time. But, with this introduction, it allows for making certain heals take longer, which I have done. Drones and shrikes now have healing at the default (1 second), and hiveminds and queens now have 2 second healing.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Queens should have healing again. The original issue with the queens heal was that it was 16 seconds cooldown, and it was instant. Making it the psychic cure makes it a little better for counterplay, especially if it takes two seconds to heal and is a minute cooldown.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added new queen heal
del: Removed old queen heal
balance: hivemind heal is now 2 seconds to use
code: added two variables to psychic cure: long_distance_heal and heal_time
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
