### PR TITLE
Readds code for setting playercount limits on map voting

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -185,7 +185,14 @@ SUBSYSTEM_DEF(vote)
 					var/datum/map_config/VM = config.maplist[GROUND_MAP][i]
 					if(!VM.voteweight)
 						continue
+					if(VM.config_max_users || VM.config_min_users)
+						var/players = length(GLOB.clients)
+						if(players > VM.config_max_users)
+							continue
+						if(players < VM.config_min_users)
+							continue
 					maps += i
+
 				choices.Add(maps)
 				if(length(choices) < 2)
 					return FALSE
@@ -195,6 +202,12 @@ SUBSYSTEM_DEF(vote)
 					var/datum/map_config/VM = config.maplist[SHIP_MAP][i]
 					if(!VM.voteweight)
 						continue
+					if(VM.config_max_users || VM.config_min_users)
+						var/players = length(GLOB.clients)
+						if(players > VM.config_max_users)
+							continue
+						if(players < VM.config_min_users)
+							continue
 					maps += i
 				choices.Add(maps)
 				if(length(choices) < 2)

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -14,15 +14,20 @@ endmap
 
 map lv624
 	default
+	minplayers 25
 endmap
 
 map bigred_v2
+	minplayers 25
 endmap
 
 map ice_colony_v2
+	minplayers 40
 endmap
 
 map prison_station_fop
+	minplayers 20
+	maxplayers 60
 endmap
 
 map tyson_station
@@ -32,15 +37,18 @@ map vapor_processing
 endmap
 
 map icy_caves
+	maxplayers 50
 endmap
 
 map desert
 endmap
 
 map research_outpost
+	maxplayers 40
 endmap
 
 map lava_outpost
+	maxplayers 40
 endmap
 
 map whiskey_outpost_v2


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Provisional config values added from player consultation, final values up to keyholders but I feel these suggested numbers are fairly generous.
Admins can still force maps without restriction.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Stops players voting for maps that don't work well with the wrong number of players
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
config: per-map player limits re-added for end of round map voting
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
