### PR TITLE
defiler gas cancel now results in nothing

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
@@ -74,10 +74,7 @@
 
 	if(!do_after(X, DEFILER_GAS_CHANNEL_TIME, TRUE, null, BUSY_ICON_HOSTILE))
 		if(!QDELETED(src))
-			var/datum/effect_system/smoke_spread/xeno/neuro/NS = new(X)
-			NS.set_up(1, get_turf(src))
-			NS.start()
-			to_chat(X, "<span class='xenodanger'>We abort emitting neurogas, our expended plasma resulting in only a feeble wisp.</span>")
+			to_chat(X, "<span class='xenodanger'>We abort emitting neurogas, our expended plasma resulting in nothing.</span>")
 			X.emitting_gas = FALSE
 			X.icon_state = "Defiler Running"
 			return fail_activate()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Cancelling defiler gas resulted in a very small 2x2 cloud. Now it does exactly nothing.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Canceling the cloud in combat was more effective than doing the move itself with the full cast. Which made no sense. So why should canceling cause a cloud? The cast itself is also 0.5 seconds, you should be forced to stand still for the bonus that you're closer to marines.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: defiler can no longer cancel his cast to make a small cloud. It now results in nothing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
