### PR TITLE
Nerf surt by reducing suit light

### DIFF
--- a/code/modules/modular_armor/attachables.dm
+++ b/code/modules/modular_armor/attachables.dm
@@ -77,13 +77,17 @@
 	item_state = "mod_fire"
 	hard_armor = list("fire" = 200)
 	slowdown = 0.4
+	/// How much the suit light is modified by
+	var/light_mod = -2
 
 /obj/item/armor_module/attachable/fire_proof/do_attach(mob/living/user, obj/item/clothing/suit/modular/parent)
 	. = ..()
+	parent.light_strength += light_mod
 	parent.hard_armor = parent.hard_armor.attachArmor(hard_armor)
 	parent.max_heat_protection_temperature += FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 
 /obj/item/armor_module/attachable/fire_proof/do_detach(mob/living/user, obj/item/clothing/suit/modular/parent)
+	parent.light_strength -= light_mod
 	parent.hard_armor = parent.hard_armor.detachArmor(hard_armor)
 	parent.max_heat_protection_temperature -= FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	return ..()


### PR DESCRIPTION
## About The Pull Request

Nerfs the pyro module by reducing the suit light strength.
Generally this shouldn't impact much since flamers give their own light.

## Why It's Good For The Game
Balance

## Changelog
:cl:
balance: surt now reduces your suit light by 2 tiles
/:cl:
