### PR TITLE
Fixes a runtime with alien embryo

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -3,8 +3,8 @@
 	desc = "All slimy and yucky."
 	icon = 'icons/Xeno/1x1_Xenos.dmi'
 	icon_state = "Larva Dead"
-	reagents = /datum/reagent/consumable/larvajelly //good ol cookin
-	var/amount = 5
+	var/grinder_datum = /datum/reagent/consumable/larvajelly //good ol cookin
+	var/grinder_amount = 5
 	var/mob/living/affected_mob
 	var/stage = 0 //The stage of the bursts, with worsening effects.
 	var/counter = 0 //How developed the embryo is, if it ages up highly enough it has a chance to burst.

--- a/code/modules/reagents/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/machinery/reagentgrinder.dm
@@ -362,21 +362,17 @@
 				break
 		remove_object(O)
 
-	//special xeno grinding
+	//special xeno embryo grinding
 	for (var/obj/item/alien_embryo/O in holdingitems)
-		var/allowed = get_allowed_by_id(O)
 		if(beaker.reagents.total_volume >= beaker.reagents.maximum_volume)
 			break
-		for(var/i = 1; i <= round(O.amount, 1); i++)
-			for (var/r_id in allowed)
-				var/space = beaker.reagents.maximum_volume - beaker.reagents.total_volume
-				var/amount = allowed[r_id]
-				beaker.reagents.add_reagent(r_id,min(amount, space))
-				if(space < amount)
-					break
-			if(i == round(O.amount, 1))
-				remove_object(O)
-				break
+		var/space = beaker.reagents.maximum_volume - beaker.reagents.total_volume
+		var/amount = O.grinder_amount
+		beaker.reagents.add_reagent(O.grinder_datum,min(amount, space))
+		if(space < amount)
+			break
+		remove_object(O)
+		break
 
 	//Everything else - Transfers reagents from it into beaker
 	for(var/obj/item/reagent_containers/O in holdingitems)


### PR DESCRIPTION
## About The Pull Request

Turns out that treating alien embryo's like reagent containers is a bad idea.

## Why It's Good For The Game

no runtimes

## Changelog
:cl: Hughgent
fix: examining alien embryo's won't cause a runtime anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
