### PR TITLE
Removes shitty flamer rng

### DIFF
--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -510,8 +510,7 @@
 // override this proc to give different walking-over-fire effects
 /mob/living/proc/flamer_fire_crossed(burnlevel, firelevel, fire_mod = 1)
 	adjust_fire_stacks(burnlevel) //Make it possible to light them on fire later.
-	if (prob(firelevel + 2*fire_stacks)) //the more soaked in fire you are, the likelier to be ignited
-		IgniteMob()
+	IgniteMob()
 	var/armor_block = run_armor_check(null, "fire")
 	if(apply_damage(round(burnlevel*0.5)* fire_mod, BURN, null, armor_block))
 		UPDATEHEALTH(src)
@@ -593,8 +592,7 @@
 		adjustFireLoss(rand(0, burnlevel * 0.25)) //Does small burn damage to a person wearing one of the suits.
 		return
 	adjust_fire_stacks(burnlevel) //If i stand in the fire i deserve all of this. Also Napalm stacks quickly.
-	if(prob(firelevel))
-		IgniteMob()
+	IgniteMob()
 	adjustFireLoss(rand(10 , burnlevel)) //Including the fire should be way stronger.
 	to_chat(src, "<span class='warning'>You are burned!</span>")
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Why did Cm think this was a good idea
Hmm yes you get to roll to decide to just ignore fire
genius

## Why It's Good For The Game

Tweaks can be done after as necessary

## Changelog
:cl:
balance: Removed flamer RNG, making lighting mobs on fire more reliable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
