### PR TITLE
Fixes a modular armor exploit

### DIFF
--- a/code/modules/modular_armor/modular.dm
+++ b/code/modules/modular_armor/modular.dm
@@ -442,6 +442,9 @@
 			to_chat(user,"<span class='warning'>There is already an installed module.</span>")
 		return FALSE
 
+	if(user.action_busy)
+		return FALSE
+
 	if(!do_after(user, equip_delay, TRUE, user, BUSY_ICON_GENERIC))
 		return FALSE
 


### PR DESCRIPTION
Fixes #4351

You should always add this kind of check before `do_after` procs.