### PR TITLE
Detpack buff (Maybe)

### DIFF
--- a/code/game/objects/items/radio/detpack.dm
+++ b/code/game/objects/items/radio/detpack.dm
@@ -7,7 +7,7 @@
 	item_state = "plasticx"
 	flags_item = NOBLUDGEON
 	w_class = WEIGHT_CLASS_SMALL
-	layer = MOB_LAYER - 0.1
+	layer = MOB_LAYER - 2
 	var/frequency = 1457
 	var/on = FALSE
 	var/armed = FALSE


### PR DESCRIPTION
Testing this

<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Literally just changes the det pack layer value from .1 to 2 so it can be hidden below things to allow marines to make traps

## Why It's Good For The Game

Adds balance in the forms of traps for marines, similar to resin holes

## Changelog
:cl:
balance: Marines can now make traps using det packs and creativity! Yay!
code: Changed the detpacks layer value from .1 to 2
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
