### PR TITLE
Attempted shuttle fix for cant

### DIFF
--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -24,6 +24,8 @@ All ShuttleMove procs go here
 	for(var/i in contents)
 		var/atom/movable/thing = i
 		SEND_SIGNAL(thing, COMSIG_MOVABLE_SHUTTLE_CRUSH, shuttle)
+		if(istype(thing, /obj/docking_port/stationary/transit))
+			continue
 		if(ismob(thing))
 			if(isliving(thing))
 				var/mob/living/M = thing


### PR DESCRIPTION
The runtime was that the transit was being qdel'd here.
So im excluding it.

The issue isn't happening locally so this is still a guess.


```
[2020-07-06 14:25:22.575] A transit dock was qdeled while it was assigned to TGS Canterbury.
[2020-07-06 14:25:22.678] runtime error: /obj/docking_port/stationary/transit destroy proc was called multiple times, likely due to a qdel loop in the Destroy logic
 - proc name: qdel (/proc/qdel)
 -   source file: garbage.dm,322
 -   usr: (src)
 -   src: null
 -   call stack:
 - qdel(Transit for 3/TGS Canterbury (/obj/docking_port/stationary/transit), 0)
 - space (63,27,4) (/turf/open/space): toShuttleMove(the catwalk (40,19,4) (/turf/open/floor/plating/plating_catwalk), 7, TGS Canterbury (/obj/docking_port/mobile/crashmode))
 - TGS Canterbury (/obj/docking_port/mobile/crashmode): preflight check(/list (/list), /list (/list), /list (/list), 0)
 - TGS Canterbury (/obj/docking_port/mobile/crashmode): initiate docking(Transit for 3/TGS Canterbury (/obj/docking_port/stationary/transit), 2, 0)
 - Shuttle (/datum/controller/subsystem/shuttle): action load(Canterbury (/datum/map_template/shuttle/tgs_canterbury), null)
 - Crash (/datum/game_mode/infestation/crash): pre setup()
 - Ticker (/datum/controller/subsystem/ticker): setup()
 - Ticker (/datum/controller/subsystem/ticker): fire(0)
 - Ticker (/datum/controller/subsystem/ticker): ignite(0)
 - 
[2020-07-06 14:25:24.465] Game start took 2.3s
```