### PR TITLE
Lower the minor version compile requirements

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -33,12 +33,12 @@
 
 //Update this whenever you need to take advantage of more recent byond features
 #define MIN_COMPILER_VERSION 513
-#define MIN_COMPILER_BUILD 1526
+#define MIN_COMPILER_BUILD 1523
 #ifndef SPACEMAN_DMM
 #if DM_VERSION < MIN_COMPILER_VERSION || DM_BUILD < MIN_COMPILER_BUILD
 //Don't forget to update this part
 #error Your version of BYOND is too out-of-date to compile this project. Go to https://secure.byond.com/download and update.
-#error You need version 513.1526 or higher
+#error You need version 513.1523 or higher
 #endif
 #endif
 


### PR DESCRIPTION
The server that generates the external rsc is on 513.1523 so our external rsc was no longer updated.
Lowering this requirement to allow that to continue to be generated.
