### PR TITLE
Acid sprays now extinguish fires and ignited mobs

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -479,6 +479,7 @@
 	return TRUE
 
 /mob/living/carbon/acid_spray_act(mob/living/carbon/xenomorph/X)
+	ExtinguishMob()
 	if(isnestedhost(src))
 		return
 
@@ -506,8 +507,10 @@
 	Paralyze(20)
 
 /mob/living/carbon/xenomorph/acid_spray_act(mob/living/carbon/xenomorph/X)
-	return
+	ExtinguishMob()
 
+/obj/flamer_fire/acid_spray_act(mob/living/carbon/xenomorph/X)
+	Destroy()
 
 // Vent Crawl
 /mob/living/carbon/xenomorph/proc/vent_crawl()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This is a minor code change that allows xenomorphs to use their spray acid abilities (spitter/boiler/praetorian) to extinguish
fires and ignited mobs.

## Why It's Good For The Game

It makes the game **more interesting** by enabling xenos to (somewhat) counter the effects of fire in an **active** manner.

## Changelog
:cl:
add: added fire extinguishing effect to xeno acid sprays
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
