### PR TITLE
FIx slow shuttle spawning issues

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -1,4 +1,5 @@
 #define MAX_TRANSIT_REQUEST_RETRIES 10
+#define SHUTTLE_SPAWN_BUFFER 100 /// Give a shuttle 10 seconds to spawn before it can be cleaned up.
 
 SUBSYSTEM_DEF(shuttle)
 	name = "Shuttle"
@@ -68,7 +69,7 @@ SUBSYSTEM_DEF(shuttle)
 		// immediately being used. This will mean that the zone creation
 		// code will be running a lot.
 		var/obj/docking_port/mobile/owner = T.owner
-		if(owner)
+		if(owner && (world.time > T.spawn_time + SHUTTLE_SPAWN_BUFFER))
 			var/idle = owner.mode == SHUTTLE_IDLE
 			var/not_centcom_evac = owner.launch_status == NOLAUNCH
 			var/not_in_use = (!T.get_docked())
@@ -618,3 +619,6 @@ SUBSYSTEM_DEF(shuttle)
 					message_admins("[key_name_admin(usr)] loaded [mdp] with the shuttle manipulator.")
 					log_admin("[key_name(usr)] loaded [mdp] with the shuttle manipulator.</span>")
 					SSblackbox.record_feedback("text", "shuttle_manipulator", 1, "[mdp.name]")
+
+
+#undef SHUTTLE_SPAWN_BUFFER

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -1,5 +1,5 @@
 #define MAX_TRANSIT_REQUEST_RETRIES 10
-#define SHUTTLE_SPAWN_BUFFER 100 /// Give a shuttle 10 seconds to spawn before it can be cleaned up.
+#define SHUTTLE_SPAWN_BUFFER SSshuttle.wait * 10 /// Give a shuttle 10 "fires" (~10 seconds) to spawn before it can be cleaned up.
 
 SUBSYSTEM_DEF(shuttle)
 	name = "Shuttle"

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -38,6 +38,10 @@
 	var/bioscan_interval = INFINITY
 
 
+/client/verb/spawn_shuttle()
+	var/datum/map_template/shuttle/ST = SSmapping.shuttle_templates["tgs_canterbury"]
+	SSshuttle.load_template_to_transit(ST)
+
 /datum/game_mode/infestation/crash/scale_roles()
 	. = ..()
 	if(!.)
@@ -51,15 +55,11 @@
 
 	// Spawn the ship
 	if(!SSmapping.shuttle_templates[shuttle_id])
+		message_admins("Gamemode: couldn't find a valid shuttle template for [shuttle_id]")
 		CRASH("Shuttle [shuttle_id] wasn't found and can't be loaded")
 
 	var/datum/map_template/shuttle/ST = SSmapping.shuttle_templates[shuttle_id]
-
-	shuttle = SSshuttle.action_load(ST)
-
-	var/obj/docking_port/stationary/L = SSshuttle.generate_transit_dock(shuttle)
-
-	shuttle.initiate_docking(L)
+	shuttle = SSshuttle.load_template_to_transit(ST)
 
 	// Redefine the relevant spawnpoints after spawning the ship.
 	for(var/job_type in shuttle.spawns_by_job)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -227,9 +227,12 @@
 	var/area/shuttle/transit/assigned_area
 	var/obj/docking_port/mobile/owner
 
+	var/spawn_time
+
 /obj/docking_port/stationary/transit/Initialize()
 	. = ..()
 	SSshuttle.transit += src
+	spawn_time = world.time
 
 /obj/docking_port/stationary/transit/Destroy(force=FALSE)
 	if(force)


### PR DESCRIPTION
Delay deleting the transit shuttle if for some reason the shuttle hasn't finished loading by the time the tick fires.
This gives shuttles 10* the shuttle subsystem wait period.