### PR TITLE
Tarp buffs

### DIFF
--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -2,6 +2,7 @@
 
 #define IN_USE					(1<<0) // If we have a user using us, this will be set on. We will check if the user has stopped using us, and thus stop updating and LAGGING EVERYTHING!
 #define CAN_BE_HIT				(1<<1) //can this be bludgeoned by items?
+#define PROJ_IGNORE_DENSITY 	(1<<2) // If non-dense structures can still get hit by projectiles
 
 //Fire and Acid stuff, for resistance_flags
 #define INDESTRUCTIBLE	(1<<0) //doesn't take damage

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -329,6 +329,9 @@
 /obj/item/proc/item_action_slot_check(mob/user, slot)
 	return TRUE
 
+// Anything unique the item can do, like pumping a shotgun, spin or whatever.
+/obj/item/proc/unique_action(mob/user)
+	return FALSE
 
 // The mob M is attempting to equip this item into the slot passed through as 'slot'. Return 1 if it can do this and 0 if it can't.
 // If you are making custom procs but would like to retain partial or complete functionality of this one, include a 'return ..()' to where you want this to happen.

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -62,6 +62,7 @@
 	storage_capacity = 3 //Just room enough for that stripped armor, gun and whatnot.
 	anchored = FALSE
 	drag_delay = 2 //slightly easier than to drag the body directly.
+	obj_flags = CAN_BE_HIT | PROJ_IGNORE_DENSITY
 	var/foldedbag_path = /obj/item/bodybag
 	var/obj/item/bodybag/foldedbag_instance = null
 	var/obj/structure/bed/roller/roller_buckled //the roller bed this bodybag is attached to.
@@ -156,18 +157,17 @@
 
 /obj/structure/closet/bodybag/MouseDrop(over_object, src_location, over_location)
 	. = ..()
-	if(over_object == usr && Adjacent(usr) && !roller_buckled)
-		if(!ishuman(usr))
-			return
-		if(opened)
-			return FALSE
-		if(length(contents))
-			return FALSE
-		visible_message("<span class='notice'>[usr] folds up [name].</span>")
-		if(QDELETED(foldedbag_instance))
-			foldedbag_instance = new foldedbag_path(loc, src)
-		usr.put_in_hands(foldedbag_instance)
-		moveToNullspace()
+	if(over_object != usr || !Adjacent(usr) || roller_buckled)
+		return
+	if(!ishuman(usr))
+		return
+	if(length(contents))
+		return FALSE
+	visible_message("<span class='notice'>[usr] folds up [name].</span>")
+	if(QDELETED(foldedbag_instance))
+		foldedbag_instance = new foldedbag_path(loc, src)
+	usr.put_in_hands(foldedbag_instance)
+	moveToNullspace()
 
 
 /obj/structure/closet/bodybag/Move(NewLoc, direct)
@@ -205,6 +205,10 @@
 		"<span class='danger'>We slash \the [src] open!</span>", null, 5)
 	return TRUE
 
+/obj/structure/closet/bodybag/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)
+	. = ..()
+	if(src != proj.original_target) //You miss unless you click directly on the bodybag
+		return FALSE
 
 /obj/item/storage/box/bodybags
 	name = "body bags"

--- a/code/game/objects/items/marine_gear.dm
+++ b/code/game/objects/items/marine_gear.dm
@@ -19,6 +19,9 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	unfoldedbag_path = /obj/structure/closet/bodybag/tarp
 
+/obj/item/bodybag/tarp/unique_action(mob/user)
+	deploy_bodybag(user, get_turf(user))
+	unfoldedbag_instance.close()
 
 /obj/item/bodybag/tarp/snow
 	icon = 'icons/obj/bodybag.dmi'
@@ -46,7 +49,7 @@
 	if(!opened && bodybag_occupant)
 		anchored = TRUE
 		playsound(loc,'sound/effects/cloak_scout_on.ogg', 15, 1) //stealth mode engaged!
-		animate(src, alpha = 13, time = 4 SECONDS) //Fade out gradually.
+		animate(src, alpha = 13, time = 3 SECONDS) //Fade out gradually.
 
 
 /obj/structure/closet/bodybag/tarp/open()

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -500,3 +500,16 @@ mob/proc/get_standard_bodytemperature()
   */
 /mob/proc/get_policy_keywords()
 	. = list("[type]")
+
+
+/// Try to perform a unique action on the current active held item.
+/mob/living/carbon/human/proc/do_unique_action()
+	. = COMSIG_KB_ACTIVATED //The return value must be a flag compatible with the signals triggering this.
+	if(incapacitated() || lying_angle)
+		return
+
+	var/obj/item/active_item = get_active_held_item()
+	if(!istype(active_item))
+		return
+
+	active_item.unique_action(src)

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -260,23 +260,6 @@ should be alright.
 				//						 \\
 				//						 \\
 //----------------------------------------------------------
-
-/obj/item/weapon/gun/proc/unique_action(mob/M) //Anything unique the gun can do, like pump or spin or whatever.
-	return FALSE
-
-
-/mob/living/carbon/human/proc/do_unique_action()
-	. = COMSIG_KB_ACTIVATED //The return value must be a flag compatible with the signals triggering this.
-	if(incapacitated() || lying_angle)
-		return
-
-	var/obj/item/weapon/gun/G = get_active_held_item()
-	if(!istype(G))
-		return
-
-	G.unique_action(src)
-
-
 /obj/item/weapon/gun/proc/check_inactive_hand(mob/user)
 	if(user)
 		var/obj/item/weapon/gun/in_hand = user.get_inactive_held_item()

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -552,7 +552,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 
 
 /obj/structure/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)
-	if(!density) //structure is passable
+	if(!density && !(obj_flags & PROJ_IGNORE_DENSITY)) //structure is passable
 		return FALSE
 	if(src == proj.original_target) //clicking on the structure itself hits the structure
 		return TRUE


### PR DESCRIPTION
## About The Pull Request

Buffs and improves tarps a little

- You can quick deploy and hide in tarps by press space while having them in your active hand.
- You can click and shoot directly on a tarp and hit the person inside.
- Tarps fade to their alpha in 3 seconds, instead of 4 

## Why It's Good For The Game
Tarp could be a little stronger as a utility item

## Changelog
:cl:
code: added support for unique actions on any object (triggered by pressing space)
/:cl:


https://streamable.com/vbnzpd
