### PR TITLE
Move the LZ1 lockdown button on prison

### DIFF
--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -27288,18 +27288,6 @@
 /area/prison/console)
 "bEP" = (
 /obj/structure/table/reinforced,
-/obj/machinery/button/door/open_only/landing_zone{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/checkpoint/hangar)
 "bEQ" = (
@@ -42377,6 +42365,21 @@
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating,
 /area/prison/cellblock/mediumsec/south)
+"gSk" = (
+/obj/machinery/button/door/open_only/landing_zone{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/prison,
+/area/prison/hangar/main)
 "gWy" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/prison,
@@ -103065,7 +103068,7 @@ aYM
 bwq
 bnQ
 byi
-bnQ
+gSk
 bzi
 bAN
 bBQ


### PR DESCRIPTION
Move the LZ1 lockdown button on prison
It was previously hidden under containment shutters