### PR TITLE
Shards have a chance to be destroyed when stepped on

### DIFF
--- a/code/game/objects/items/shards.dm
+++ b/code/game/objects/items/shards.dm
@@ -77,11 +77,11 @@
 	if(M.status_flags & INCORPOREAL)
 		return ..()
 	
+	playsound(loc, 'sound/effects/glass_step.ogg', 25, TRUE)
 	if(prob(20))
-		playsound(src.loc, 'sound/weapons/genhit.ogg', 25, TRUE)
+	    to_chat(M, "<span class='danger'>[isxeno(M) ? "We" : "You"] step on \the [src], shattering it!</span>")
 		qdel(src)
-	else
-		playsound(src.loc, 'sound/effects/glass_step.ogg', 25, TRUE) // not sure how to handle metal shards with sounds
+		return 
 	
 	if(!M.buckled)
 		to_chat(M, "<span class='danger'>[isxeno(M) ? "We" : "You"] step on \the [src]!</span>")

--- a/code/game/objects/items/shards.dm
+++ b/code/game/objects/items/shards.dm
@@ -81,7 +81,7 @@
 	if(prob(20))
 		to_chat(M, "<span class='danger'>[isxeno(M) ? "We" : "You"] step on \the [src], shattering it!</span>")
 		qdel(src)
-		return ..()
+		return
 	
 	if(!M.buckled)
 		to_chat(M, "<span class='danger'>[isxeno(M) ? "We" : "You"] step on \the [src]!</span>")

--- a/code/game/objects/items/shards.dm
+++ b/code/game/objects/items/shards.dm
@@ -76,8 +76,13 @@
 	var/mob/living/M = AM
 	if(M.status_flags & INCORPOREAL)
 		return ..()
-
-	playsound(src.loc, 'sound/effects/glass_step.ogg', 25, 1) // not sure how to handle metal shards with sounds
+	
+	if(prob(20))
+		playsound(src.loc, 'sound/weapons/genhit.ogg', 25, 1)
+		Destroy()
+	else
+		playsound(src.loc, 'sound/effects/glass_step.ogg', 25, 1) // not sure how to handle metal shards with sounds
+	
 	if(!M.buckled)
 		to_chat(M, "<span class='danger'>[isxeno(M) ? "We" : "You"] step on \the [src]!</span>")
 		if(ishuman(M))

--- a/code/game/objects/items/shards.dm
+++ b/code/game/objects/items/shards.dm
@@ -79,9 +79,9 @@
 	
 	playsound(loc, 'sound/effects/glass_step.ogg', 25, TRUE)
 	if(prob(20))
-	    to_chat(M, "<span class='danger'>[isxeno(M) ? "We" : "You"] step on \the [src], shattering it!</span>")
+		to_chat(M, "<span class='danger'>[isxeno(M) ? "We" : "You"] step on \the [src], shattering it!</span>")
 		qdel(src)
-		return 
+		return ..()
 	
 	if(!M.buckled)
 		to_chat(M, "<span class='danger'>[isxeno(M) ? "We" : "You"] step on \the [src]!</span>")

--- a/code/game/objects/items/shards.dm
+++ b/code/game/objects/items/shards.dm
@@ -78,10 +78,10 @@
 		return ..()
 	
 	if(prob(20))
-		playsound(src.loc, 'sound/weapons/genhit.ogg', 25, 1)
-		Destroy()
+		playsound(src.loc, 'sound/weapons/genhit.ogg', 25, TRUE)
+		qdel(src)
 	else
-		playsound(src.loc, 'sound/effects/glass_step.ogg', 25, 1) // not sure how to handle metal shards with sounds
+		playsound(src.loc, 'sound/effects/glass_step.ogg', 25, TRUE) // not sure how to handle metal shards with sounds
 	
 	if(!M.buckled)
 		to_chat(M, "<span class='danger'>[isxeno(M) ? "We" : "You"] step on \the [src]!</span>")


### PR DESCRIPTION
## About The Pull Request

A small code addition that gives shards (includes **glass**/shrapnel/phoron shards due to current design) a chance to be destroyed when stepped on. Crunchy.

## Why It's Good For The Game

Glass shards specifically are annoying clutter that end up everywhere as rounds go on. This is a simple way to cut down on sound, chat, and visual spam caused by them while maintaining immersion.

## Changelog
:cl:
add: shards have a chance to be destroyed when stepped on
/:cl:
