### PR TITLE
Fix exploit with binos and cameras

### DIFF
--- a/code/game/objects/items/binoculars.dm
+++ b/code/game/objects/items/binoculars.dm
@@ -153,6 +153,10 @@
 		to_chat(user, "<span class='warning'>[src]'s laser battery is recharging.</span>")
 		return
 
+	if(user.client.eye != src)
+		to_chat(user, "<span class='warning'>You can't focus properly through \the [src] while looking through something else.</span>")
+		return
+
 	if(!user.mind)
 		return
 	var/datum/squad/S = user.assigned_squad

--- a/code/game/objects/machinery/overwatch.dm
+++ b/code/game/objects/machinery/overwatch.dm
@@ -360,6 +360,10 @@ GLOBAL_LIST_EMPTY(active_laser_targets)
 		if("dropbomb")
 			handle_bombard()
 		if("shootrailgun")
+			var/mob/living/user = usr
+			if(user.interactee)
+				to_chat(usr, "[icon2html(src, usr)] <span class='warning'>Your busy doing something else, and press the wrong button!</span>")
+				return
 			if((GLOB.marine_main_ship?.rail_gun?.last_firing + 600) > world.time)
 				to_chat(usr, "[icon2html(src, usr)] <span class='warning'>The Rail Gun hasn't cooled down yet!</span>")
 			else if(!selected_target)


### PR DESCRIPTION
## About The Pull Request

Stops users pushing the OB Fire button while doing other things. This stops them using binos or computers to coordinate solo attacks and relys on communication instead.
This also stops using bino laser while looking through cameras or other devices

## Why It's Good For The Game
Solo OBS bad.
