### PR TITLE
Add hard restarts after x rounds

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -30,7 +30,7 @@ Basics, the most important.
 /datum/config_entry/string/dburl
 
 
- /// Host of the webmap
+/// Host of the webmap
 /datum/config_entry/string/webmap_host
 	config_entry_value = "https://affectedarc07.co.uk/tgmc.php?m="
 
@@ -191,6 +191,9 @@ Voting
 /datum/config_entry/flag/default_no_vote
 
 /datum/config_entry/flag/no_dead_vote
+
+/datum/config_entry/number/rounds_until_hard_restart
+	config_entry_value = -1 // -1 is disabled by default, 0 is every round, x is after so many rounds
 
 /datum/config_entry/number/vote_delay	// Minimum time between voting sessions. (deciseconds, 10 minute default)
 	config_entry_value = 6000

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -238,6 +238,27 @@ GLOBAL_VAR(restart_counter)
 		FinishTestRun()
 		return
 
+	if(TgsAvailable())
+		var/do_hard_reboot
+		// check the hard reboot counter
+		var/ruhr = CONFIG_GET(number/rounds_until_hard_restart)
+		switch(ruhr)
+			if(-1)
+				do_hard_reboot = FALSE
+			if(0)
+				do_hard_reboot = TRUE
+			else
+				if(GLOB.restart_counter >= ruhr)
+					do_hard_reboot = TRUE
+				else
+					text2file("[++GLOB.restart_counter]", RESTART_COUNTER_PATH)
+					do_hard_reboot = FALSE
+
+		if(do_hard_reboot)
+			log_world("World rebooted at [time_stamp()]")
+			shutdown_logging() // Past this point, no logging procs can be used, at risk of data loss.
+			TgsEndProcess()
+
 	var/linkylink = CONFIG_GET(string/server)
 	if(linkylink)
 		for(var/cli in GLOB.clients)


### PR DESCRIPTION
## About The Pull Request

Using the round counter, allow hard restarts of byond after x rounds.
This will reconnect everyone automatically after the restart and should be no different from a players pov.

## Why It's Good For The Game

Helps to contain the small memory leak we are seeing within byond.

## Changelog
:cl:
server: added hard restarts after x rounds 
/:cl:
