### PR TITLE
robotize limbs are actual robots again

### DIFF
--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -946,6 +946,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 /datum/limb/proc/robotize()
 	rejuvenate()
+	add_limb_flags(LIMB_ROBOT)
 	for(var/c in children)
 		var/datum/limb/child_limb = c
 		child_limb.robotize()


### PR DESCRIPTION
## About The Pull Request

Turns out that when limb flags were added, the synthetic limbs were 'real' limbs. This makes them robotic again.

![image](https://user-images.githubusercontent.com/45076386/87204490-952a9680-c2ca-11ea-8e94-b02588616311.png)


## Why It's Good For The Game

Losing limbs is meant to be bad/different for the player. You fix them with welding and wires, not medicine.

## Changelog
:cl: Hughgent
fix: Robot limbs are now robotic again.
/:cl:

