### PR TITLE
Flamer flames generally nerfed/tweaked

### DIFF
--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -157,25 +157,25 @@
 	var/fire_color = "red"
 	switch(ammo.name)
 		if("flame")
-			burnlevel = 24
-			burntime = 17
-			max_range = 7
+			burnlevel = 19
+			burntime = 12
+			max_range = 4
 			fire_delay = 20
 
 		// Area denial, light damage, large AOE, long burntime
 		if("green flame")
-			burnlevel = 10
-			burntime = 50
-			max_range = 4
+			burnlevel = 5
+			burntime = 45
+			max_range = 3
 			playsound(user, fire_sound, 50, 1)
 			triangular_flame(target, user, burntime, burnlevel)
 			fire_delay = 35
 			return
 
 		if("blue flame") //Probably can end up as a spec fuel or DS flamer fuel. Also this was the original fueltype, the madman i am.
-			burnlevel = 36
-			burntime = 40
-			max_range = 7
+			burnlevel = 31
+			burntime = 35
+			max_range = 4
 			fire_color = "blue"
 			fire_delay = 35
 

--- a/code/modules/projectiles/magazines/flamer.dm
+++ b/code/modules/projectiles/magazines/flamer.dm
@@ -7,8 +7,8 @@
 	desc = "A fuel tank of usually ultra thick napthal, a sticky combustable liquid chemical, for use in the M240A1 incinerator unit. Handle with care."
 	icon_state = "flametank"
 	default_ammo = /datum/ammo/flamethrower //doesn't actually need bullets. But we'll get null ammo error messages if we don't
-	max_rounds = 60 //Per turf.
-	current_rounds = 60
+	max_rounds = 30 //Per turf.
+	current_rounds = 30
 	w_class = WEIGHT_CLASS_NORMAL //making sure you can't sneak this onto your belt.
 	gun_type = /obj/item/weapon/gun/flamer
 	caliber = "UT-Napthal Fuel" //Ultra Thick Napthal Fuel, from the lore book.
@@ -42,8 +42,8 @@
 	name = "large flamerthrower tank"
 	desc = "A large fuel tank of ultra thick napthal, a sticky combustable liquid chemical, for use in the TL-84 flamethrower."
 	icon_state = "flametank_large"
-	max_rounds = 100
-	current_rounds = 100
+	max_rounds = 70
+	current_rounds = 70
 	gun_type = /obj/item/weapon/gun/flamer/marinestandard
 
 /obj/item/ammo_magazine/flamer_tank/large/B


### PR DESCRIPTION
## About The Pull Request
Cut down `burntime` and `burnlevel` by 5 across the board for flamers.
Cut down `max_range` by 3 between blue & normal fire.
Cut down `max_range` by 1 for green fire.
`max_rounds` and `current_rounds` cut down on tanks by 30.


Normal Flames:
`burnlevel = 24` -> `burnlevel = 19`
`burntime = 17` -> `burntime = 12`
`max_range = 7` -> `max_range = 4`

Green Flames:
`burnlevel = 10` -> `burnlevel = 5`
`burntime = 50` -> `burntime = 45`
`max_range = 4` -> `max_range = 3`

Blue Flames:
`burnlevel = 36` -> `burnlevel = 31`
`burntime = 40` -> `burntime = 35`
`max_range = 7` -> `max_range = 4`

Regular Tank:
`max_rounds = 60` ->`max_rounds = 30`
`current_rounds = 60` -> `current_rounds = 30`

Large Tank:
`max_rounds = 100` -> `max_rounds = 70`
`current_rounds = 100` -> `current_rounds = 70`

## Why It's Good For The Game
Flamers flames in their current state are both ridiculously good for AOE, and ridiculously for damage, _and_ incredibly good for dealing with resin structures, while having pretty much no counter other than sitting and waiting for the flames to be gone.

Alongside this fact, marines have allready quite an arsenal for AOE, railguns, MG emplacements, U-580 sentries, and grenades for days.

I, atleast personally, feel like the server/codebase would just benefit overall if marines didn't ~~re-enact vietnam~~ completely lock down any points or charges just by spending a tiny bit of flamer ammo and almost completely block xenos from attacking.

## Changelog
:cl: Vondiech
tweak: Cut down burntime and burnlevel by 5 across the board for flamers, cut down max_range by 3 between blue & normal fire, and cut down max_range by 1 for green fire.
tweak: max_rounds and current_rounds cut down on both large and regular flamer tanks by 30.
/:cl: