### PR TITLE
Removes the m44 stock attachment from vendors.

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -618,7 +618,6 @@
 						/obj/item/attachable/verticalgrip = 25,
 
 						/obj/item/attachable/stock/t19stock = 25,
-						/obj/item/attachable/stock/revolver = 25,
 						/obj/item/attachable/stock/t35stock = 25,
 						/obj/item/attachable/stock/tactical = 25,
 


### PR DESCRIPTION

## About The Pull Request

Fixes #4464 

## Why It's Good For The Game

Vendor bloat reduction

## Changelog
:cl:
fix: Unused revolver stock attachment removed from attachment vendor
/:cl:

