### PR TITLE
changes invisible facepaint on surplus vendors to green facepaint

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -727,7 +727,7 @@
 					/obj/item/clothing/head/modular/heavy = 20,
 					/obj/item/clothing/head/modular/medium = 20,
 					/obj/item/clothing/head/modular/light = 20,
-					/obj/item/facepaint/ = 20
+					/obj/item/facepaint/green = 20
 					)
 
 	prices = list()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Small tweak to fix the invisible facepaints on surplus vendors. It replaces them with green facepaints.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
No more annoying invisible sprite

## Changelog
:cl:
fix: invisible facepaint on vendors changed to green facepaint
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
