### PR TITLE
Fix bioscan issue

### DIFF
--- a/code/controllers/subsystem/server_maint.dm
+++ b/code/controllers/subsystem/server_maint.dm
@@ -54,7 +54,7 @@ SUBSYSTEM_DEF(server_maint)
 				cleanup_ticker++
 			if(25)
 				var/found = FALSE
-				for(var/level in GLOB.hive_datums[XENO_HIVE_NORMAL].xenos_by_zlevel["[level]"])
+				for(var/level in GLOB.hive_datums[XENO_HIVE_NORMAL].xenos_by_zlevel)
 					if(listclearnulls(GLOB.hive_datums[XENO_HIVE_NORMAL].xenos_by_zlevel["[level]"]))
 						found = TRUE
 				if(found)

--- a/code/controllers/subsystem/server_maint.dm
+++ b/code/controllers/subsystem/server_maint.dm
@@ -45,6 +45,22 @@ SUBSYSTEM_DEF(server_maint)
 					log_world("Found a null in human_mob_list!")
 				cleanup_ticker++
 			if(20)
+				var/found = FALSE
+				for(var/level in GLOB.humans_by_zlevel)
+					if(listclearnulls(GLOB.humans_by_zlevel["[level]"]))
+						found = TRUE
+				if(found)
+					log_world("Found a null in humans_by_zlevel!")
+				cleanup_ticker++
+			if(25)
+				var/found = FALSE
+				for(var/level in GLOB.hive_datums[XENO_HIVE_NORMAL].xenos_by_zlevel["[level]"])
+					if(listclearnulls(GLOB.hive_datums[XENO_HIVE_NORMAL].xenos_by_zlevel["[level]"]))
+						found = TRUE
+				if(found)
+					log_world("Found a null in GLOB.hive_datums(XENO_HIVE_NORMAL).xenos_by_zlevel!")
+				cleanup_ticker++
+			if(30)
 				cleanup_ticker = 0
 			else
 				cleanup_ticker++

--- a/code/datums/gamemodes/game_mode.dm
+++ b/code/datums/gamemodes/game_mode.dm
@@ -475,6 +475,8 @@ Sensors indicate [numXenosShip || "no"] unknown lifeform signature[numXenosShip 
 	for(var/z in z_levels)
 		for(var/i in GLOB.hive_datums[XENO_HIVE_NORMAL].xenos_by_zlevel["[z]"])
 			var/mob/living/carbon/xenomorph/X = i
+			if(!istype(X)) // Small fix?
+				continue
 			if(count_flags & COUNT_IGNORE_XENO_SSD && !X.client)
 				continue
 			if(count_flags & COUNT_IGNORE_XENO_SPECIAL_AREA && is_xeno_in_forbidden_zone(X))


### PR DESCRIPTION
Ignores nulls during bioscan and adds the lists to the server maint subsystem to cleanup regularly.
Ideally this should never happen, but something is happening.


```
[16:18:55] Runtime in hive_datum.dm, line 263: failed to remove xeno from a hive
proc name: remove from hive (/mob/living/carbon/xenomorph/proc/remove_from_hive)
usr: -snip-
usr.loc: (Northeast NT Compound (128, 53, 2))
src: Elder Carrier (687) (/mob/living/carbon/xenomorph/carrier)
src.loc: the grass (131,54,2) (/turf/open/ground/grass)
call stack:
Elder Carrier (687) (/mob/living/carbon/xenomorph/carrier): remove from hive()
Elder Carrier (687) (/mob/living/carbon/xenomorph/carrier): Destroy(0)
qdel(Elder Carrier (687) (/mob/living/carbon/xenomorph/carrier), 0)
Elder Carrier (687) (/mob/living/carbon/xenomorph/carrier): death(1, "lets out a waning guttural scr...", null)
Elder Carrier (687) (/mob/living/carbon/xenomorph/carrier): death(1, "lets out a waning guttural scr...", null)
Elder Carrier (687) (/mob/living/carbon/xenomorph/carrier): gib()
Elder Carrier (687) (/mob/living/carbon/xenomorph/carrier): gib()
Elder Carrier (687) (/mob/living/carbon/xenomorph/carrier): update stat()
Elder Carrier (687) (/mob/living/carbon/xenomorph/carrier): update stat()
Elder Carrier (687) (/mob/living/carbon/xenomorph/carrier): updatehealth()
/datum/callback (/datum/callback): Invoke()
world: PushUsr(Charles Mason (/mob/living/carbon/human), /datum/callback (/datum/callback))
/datum/callback (/datum/callback): InvokeAsync()
Timer (/datum/controller/subsystem/timer): fire(0)
Timer (/datum/controller/subsystem/timer): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop()
Master (/datum/controller/master): StartProcessing(0)
```