### PR TITLE
Flamer Nerf (Take 2 and softer)

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1516,7 +1516,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage_type = BURN
 	flags_ammo_behavior = AMMO_INCENDIARY|AMMO_IGNORE_ARMOR
 	armor_type = "fire"
-	max_range = 7
+	max_range = 6
 	damage = 50
 	var/fire_color = "red"
 	var/burnlevel = 24
@@ -1552,7 +1552,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 /datum/ammo/flamethrower/blue
 	name = "blue flame"
 	hud_state = "flame_blue"
-	max_range = 7
+	max_range = 6
 	fire_color = "blue"
 	burnlevel = 36
 	burntime = 40

--- a/code/modules/projectiles/magazines/flamer.dm
+++ b/code/modules/projectiles/magazines/flamer.dm
@@ -43,8 +43,8 @@
 	name = "large flamerthrower tank"
 	desc = "A large fuel tank of ultra thick napthal, a sticky combustable liquid chemical, for use in the TL-84 flamethrower."
 	icon_state = "flametank_large"
-	max_rounds = 70
-	current_rounds = 70
+	max_rounds = 75
+	current_rounds = 75
 	reload_delay = 3 SECONDS
 	gun_type = /obj/item/weapon/gun/flamer/marinestandard
 

--- a/code/modules/projectiles/magazines/flamer.dm
+++ b/code/modules/projectiles/magazines/flamer.dm
@@ -7,8 +7,9 @@
 	desc = "A fuel tank of usually ultra thick napthal, a sticky combustable liquid chemical, for use in the M240A1 incinerator unit. Handle with care."
 	icon_state = "flametank"
 	default_ammo = /datum/ammo/flamethrower //doesn't actually need bullets. But we'll get null ammo error messages if we don't
-	max_rounds = 60 //Per turf.
-	current_rounds = 60
+	max_rounds = 50 //Per turf.
+	current_rounds = 50
+	reload_delay = 3 SECONDS
 	w_class = WEIGHT_CLASS_NORMAL //making sure you can't sneak this onto your belt.
 	gun_type = /obj/item/weapon/gun/flamer
 	caliber = "UT-Napthal Fuel" //Ultra Thick Napthal Fuel, from the lore book.
@@ -42,8 +43,9 @@
 	name = "large flamerthrower tank"
 	desc = "A large fuel tank of ultra thick napthal, a sticky combustable liquid chemical, for use in the TL-84 flamethrower."
 	icon_state = "flametank_large"
-	max_rounds = 100
-	current_rounds = 100
+	max_rounds = 70
+	current_rounds = 70
+	reload_delay = 4 SECONDS
 	gun_type = /obj/item/weapon/gun/flamer/marinestandard
 
 /obj/item/ammo_magazine/flamer_tank/large/B

--- a/code/modules/projectiles/magazines/flamer.dm
+++ b/code/modules/projectiles/magazines/flamer.dm
@@ -9,7 +9,7 @@
 	default_ammo = /datum/ammo/flamethrower //doesn't actually need bullets. But we'll get null ammo error messages if we don't
 	max_rounds = 50 //Per turf.
 	current_rounds = 50
-	reload_delay = 3 SECONDS
+	reload_delay = 2 SECONDS
 	w_class = WEIGHT_CLASS_NORMAL //making sure you can't sneak this onto your belt.
 	gun_type = /obj/item/weapon/gun/flamer
 	caliber = "UT-Napthal Fuel" //Ultra Thick Napthal Fuel, from the lore book.
@@ -45,7 +45,7 @@
 	icon_state = "flametank_large"
 	max_rounds = 70
 	current_rounds = 70
-	reload_delay = 4 SECONDS
+	reload_delay = 3 SECONDS
 	gun_type = /obj/item/weapon/gun/flamer/marinestandard
 
 /obj/item/ammo_magazine/flamer_tank/large/B


### PR DESCRIPTION
## About The Pull Request
The changes to the flamethrower/flamethrower tanks are as-follows.

Normal/Blue flames (for the flamethrower only):
`max_range 7` -> `6` 

Normal tank:
`max_rounds 60` -> `50`
`reload_delay 2 SECONDS`

Large tank:
`max_rounds 100` -> `75`
`reload_delay 3 SECONDS`

## Why It's Good For The Game
As stated in my previous PR, i think the flamer has been in a pretty good spot for a long time, which has become more straining with the marines getting more and more methods to lockdown an area or a room with AOE emplacements, weapons, or grenades.

The intention of this PR is to force marines ~~not to re-enact vietnam~~ to be more conservative with using the flamer, so as to not have marines constantly chasing xenomorphs, because they can just keep popping in new tanks while never being really vunerable.

## Changelog
:cl: Vondiech
balance: The TGMC has decided to cut cost via cutting some corners with the TL-84 flamethrower, making it only spread fire through 6 tiles instead of the previous 7.
balance: Alongside the TGMC cutting the costs and abiding by new regulations imposed on the flamethrower, they have cut the ammo on the tanks that the flamethrowers use, alongside slowing down the amount of time needed to reload a flamethrower with a tank due to safety concerns. With the Normal tank now requiring 2 seconds to reload with and having it's 60 units of fuel being cut down to 50, and the Large tank now requiring 3 seconds to reload with and having it's 100 units of fuel being cut down to 75.
/:cl:
