### PR TITLE
vendor duping bug fix

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -70,13 +70,6 @@
 	. = ..()
 	GLOB.marine_vendors.Remove(src)
 
-/obj/machinery/vending/marine/attackby(obj/item/I, mob/user, params)
-	. = ..()
-
-	if(istype(I, /obj/item/weapon/gun) || istype(I, /obj/item/ammo_magazine))
-		stock(I, user)
-		return TRUE
-
 //What do grenade do against candy machine?
 /obj/machinery/vending/marine/ex_act(severity)
 	return
@@ -251,13 +244,6 @@
 				icon_state = "lascharger_50"
 			if(0.25 to 0.01)
 				icon_state = "lascharger_25"
-
-/obj/machinery/vending/lasgun/attackby(obj/item/I, mob/user, params)
-	. = ..()
-
-	if(istype(I, /obj/item/cell/lasgun))
-		stock(I, user, TRUE)
-		return TRUE
 
 /obj/machinery/vending/lasgun/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Marines can dupe ammunition and weapons by vending them and stocking them. This was made possible due to overridden/redundant attackby() functions that call super on both machinery/vending/marine and /machinery/vending/lasgun. Deleting these two functions returns expected function (the checks they did are already effectively done by stock() function).

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Duping bad

## Changelog
:cl:
fix: fixed vendor bug that allowed duping guns and ammo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
