### PR TITLE
PFC Sniper bullet now respects minimum accurate range

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -883,7 +883,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 /datum/ammo/bullet/sniper/pfc
 	name = "high caliber rifle bullet"
 	hud_state = "minigun"
-	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
+	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING|AMMO_SNIPER
 	iff_signal = null
 	damage = 80
 	penetration = 30


### PR DESCRIPTION

## About The Pull Request

The PFC sniper ammo was not applying their minimum accurate range penalty.

## Why It's Good For The Game

should perform as intended now.

## Changelog
:cl: Hughgent
fix: PFC Sniper bullet now respects minimum accurate range
/:cl:

