### PR TITLE
Valkyrie module has a larger delay between heals

### DIFF
--- a/code/modules/modular_armor/attachables.dm
+++ b/code/modules/modular_armor/attachables.dm
@@ -57,7 +57,7 @@
 	var/list/tramadol = list(/datum/reagent/medicine/tramadol)
 	/// This will do nothing without the autodoc update
 	var/list/supported_limbs = list(CHEST, GROIN, ARM_LEFT, ARM_RIGHT, HAND_LEFT, HAND_RIGHT, LEG_LEFT, LEG_RIGHT, FOOT_LEFT, FOOT_RIGHT)
-	parent.AddComponent(/datum/component/suit_autodoc, 2.5 MINUTES, tricord, tricord, tricord, tricord, tramadol, 0.5)
+	parent.AddComponent(/datum/component/suit_autodoc, 4 MINUTES, tricord, tricord, tricord, tricord, tramadol, 0.5)
 	parent.AddElement(/datum/element/limb_support, supported_limbs)
 
 


### PR DESCRIPTION
## About The Pull Request
Increases the time between heals on the valkyrie from 2.5 minutes to 4.

## Why It's Good For The Game
Currently with valk you won't die unless under constant assault.
This nerfs that to make it heal less often, but still as strong.

## Changelog
:cl:
balance: Valkyrie module has a larger delay between heals (2.5 minutes to 4minutes)
/:cl:
