### PR TITLE
Reduced the damaged of Flechette bonus projectiles

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -754,7 +754,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	name = "additional flechette"
 	icon_state = "flechette"
 	max_range = 15
-	damage = 17
+	damage = 14
 	damage_falloff = 0.25
 	penetration = 15
 


### PR DESCRIPTION
## About The Pull Request

A few PRS ago we made bonus projectiles get the same damage mods as the main (https://github.com/tgstation/TerraGov-Marine-Corps/pull/4376), but the spread ammo didn't actually get modified so it was a free buff.

## Why It's Good For The Game

Flechette can do some crazy damage, this nerfs that a little


## Changelog
:cl:
balance: reduced the damaged of Flechette bonus projectiles
/:cl:
