### PR TITLE
Move hardcoded speaking keys into keybind defaults

### DIFF
--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -22,10 +22,6 @@ SUBSYSTEM_DEF(input)
 	macro_set = list(
 	"Any" = "\"KeyDown \[\[*\]\]\"",
 	"Any+UP" = "\"KeyUp \[\[*\]\]\"",
-	"O" = "ooc",
-	"L" = "looc",
-	"T" = ".say",
-	"M" = ".me",
 	"Back" = "\".winset \\\"input.text=\\\"\\\"\\\"\"",
 	"Tab" = "\".winset \\\"input.focus=true ? map.focus=true : input.focus=true\\\"\"",
 	"Escape" = "\".winset \\\"input.text=\\\"\\\"\\\"\"")

--- a/code/datums/keybinding/client.dm
+++ b/code/datums/keybinding/client.dm
@@ -52,6 +52,7 @@
 	name = "ooc"
 	full_name = "OOC"
 	hotkey_keys = list("O")
+	classic_keys = list("O")
 	description = "Speak in OOC"
 	keybind_signal = COMSIG_KB_CLIENT_OOC_DOWN
 
@@ -67,6 +68,7 @@
 	name = "looc"
 	full_name = "LOOC"
 	hotkey_keys = list("L")
+	classic_keys = list("L")
 	description = "Speak in local OOC"
 	keybind_signal = COMSIG_KB_CLIENT_LOOC_DOWN
 

--- a/code/datums/keybinding/client.dm
+++ b/code/datums/keybinding/client.dm
@@ -50,7 +50,8 @@
 
 /datum/keybinding/client/ooc
 	name = "ooc"
-	full_name = "OOC (Other than O)"
+	full_name = "OOC"
+	hotkey_keys = list("O")
 	description = "Speak in OOC"
 	keybind_signal = COMSIG_KB_CLIENT_OOC_DOWN
 
@@ -64,7 +65,8 @@
 
 /datum/keybinding/client/looc
 	name = "looc"
-	full_name = "LOOC (Other than L)"
+	full_name = "LOOC"
+	hotkey_keys = list("L")
 	description = "Speak in local OOC"
 	keybind_signal = COMSIG_KB_CLIENT_LOOC_DOWN
 

--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -134,6 +134,7 @@
 	name = "say"
 	full_name = "Say"
 	hotkey_keys = list("T")
+	classic_keys = list("T")
 	description = ""
 	keybind_signal = COMSIG_KB_MOB_SAY_DOWN
 
@@ -149,6 +150,7 @@
 	name = "me"
 	full_name = "Me"
 	hotkey_keys = list("M")
+	classic_keys = list("M")
 	description = ""
 	keybind_signal = COMSIG_KB_MOB_ME_DOWN
 

--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -132,7 +132,8 @@
 
 /datum/keybinding/mob/say
 	name = "say"
-	full_name = "Say (Other than S)"
+	full_name = "Say"
+	hotkey_keys = list("T")
 	description = ""
 	keybind_signal = COMSIG_KB_MOB_SAY_DOWN
 
@@ -146,7 +147,8 @@
 
 /datum/keybinding/mob/me
 	name = "me"
-	full_name = "Me (Other than M)"
+	full_name = "Me"
+	hotkey_keys = list("M")
 	description = ""
 	keybind_signal = COMSIG_KB_MOB_ME_DOWN
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
classic key mode? lalalala can't hear you
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
people with non-qwerty keyboards literally couldnt play the game.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: OOC, LOOC, me, say keys are now set as keybind defaults instead of being hardcoded, double check your keybinds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
