### PR TITLE
Moves coffees effect to another chemical

### DIFF
--- a/code/modules/reagents/reagents/drink.dm
+++ b/code/modules/reagents/reagents/drink.dm
@@ -206,38 +206,9 @@
 	adj_sleepy = -2
 	adj_temp = 20
 	taste_description = "bitterness"
-	purge_list = list(/datum/reagent/consumable/frostoil, /datum/reagent/medicine/oxycodone)
 	purge_rate = 2
 	trait_flags = TACHYCARDIC
 
-/datum/reagent/consumable/drink/coffee/on_mob_add(mob/living/L, metabolism)
-	. = ..()
-	L.add_movespeed_modifier(type, TRUE, 0, NONE, TRUE, -0.2)
-
-/datum/reagent/consumable/drink/coffee/on_mob_delete(mob/living/L, metabolism)
-	L.remove_movespeed_modifier(type)
-	var/amount = (current_cycle * 0.5) // 15/cup
-	L.adjustStaminaLoss(amount)
-
-
-/datum/reagent/consumable/drink/coffee/on_mob_life(mob/living/L, metabolism)
-	switch(current_cycle)
-		if(1 to 10)
-			L.adjustStaminaLoss(-2*REM)
-		if(11 to 30)
-			L.adjustStaminaLoss(-1*REM)
-		if(11 to 60)
-			L.adjustStaminaLoss(-0.5*REM)
-			L.jitter(1)
-		if(61 to 150)
-			L.adjustStaminaLoss(0.5*REM)
-			L.apply_damage(0.2, TOX)
-			L.jitter(2)
-		if(151 to INFINITY)
-			L.adjustStaminaLoss(5*REM)
-			L.apply_damage(0.5, TOX) //someone'll antitox you eventually, which purges coffee at 3x speed
-			L.jitter(5)
-	return ..()
 
 /datum/reagent/consumable/drink/coffee/overdose_process(mob/living/L, metabolism)
 	L.apply_damage(0.2, TOX)
@@ -260,6 +231,53 @@
 		var/datum/internal_organ/heart/E = H.internal_organs_by_name["heart"]
 		if(E)
 			E.take_damage(1, TRUE)
+
+//nice one jpr
+/datum/reagent/consumable/drink/coffee/atomiccoffee
+	name = "Atomic Coffee"
+	description = "TThis coffee is a brewed drink prepared from roasted seeds and enriched from use in atomic coffemaker. Consume in moderation"
+	color = "#482000" // rgb: 72, 32, 0
+	nutriment_factor = 0
+	overdose_threshold = REAGENTS_OVERDOSE * 2
+	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL * 3
+	custom_metabolism = REAGENTS_METABOLISM * 5 //1u/tick
+	adj_dizzy = -5
+	adj_drowsy = -3
+	adj_sleepy = -2
+	adj_temp = 20
+	taste_description = "bitterness"
+	purge_list = list(/datum/reagent/consumable/frostoil, /datum/reagent/medicine/oxycodone)
+	purge_rate = 2
+	trait_flags = TACHYCARDIC
+
+/datum/reagent/consumable/drink/atomiccoffee/on_mob_add(mob/living/L, metabolism)
+	. = ..()
+	L.add_movespeed_modifier(type, TRUE, 0, NONE, TRUE, -0.2)
+
+/datum/reagent/consumable/drink/atomiccoffee/on_mob_delete(mob/living/L, metabolism)
+	L.remove_movespeed_modifier(type)
+	var/amount = (current_cycle * 0.5) // 15/cup
+	L.adjustStaminaLoss(amount)
+
+
+/datum/reagent/consumable/drink/atomiccoffee/on_mob_life(mob/living/L, metabolism)
+	switch(current_cycle)
+		if(1 to 10)
+			L.adjustStaminaLoss(-2*REM)
+		if(11 to 30)
+			L.adjustStaminaLoss(-1*REM)
+		if(11 to 60)
+			L.adjustStaminaLoss(-0.5*REM)
+			L.jitter(1)
+		if(61 to 150)
+			L.adjustStaminaLoss(0.5*REM)
+			L.apply_damage(5, TOX)
+			L.jitter(2)
+		if(151 to INFINITY)
+			L.adjustStaminaLoss(5*REM)
+			L.apply_damage(10, TOX) //You're having a bad day.
+			L.jitter(5)
+	return ..()
 
 /datum/reagent/consumable/drink/coffee/icecoffee
 	name = "Iced Coffee"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Pretty much the title.
JPR made it so coffee and all its children have the same effect, and thus you could stack it to run like a madman.
Bonus if you get the reference
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Coffee no longer stacks, and is back to being the rp chem
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: coffee no longer has its effect, now there is atomic coffee
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
