### PR TITLE
Vendor fixes

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -13,12 +13,16 @@
 	products = list(
 					/obj/item/weapon/gun/pistol/standard_pistol = 25,
 					/obj/item/ammo_magazine/pistol/standard_pistol = 30,
+					/obj/item/weapon/gun/pistol/standard_heavypistol = 10,
+					/obj/item/ammo_magazine/pistol/standard_heavypistol = 25,
 					/obj/item/weapon/gun/revolver/standard_revolver = 15,
 					/obj/item/ammo_magazine/revolver/standard_revolver = 25,
-					/obj/item/weapon/gun/smg/standard_smg = 20,
-					/obj/item/ammo_magazine/smg/standard_smg = 30,
 					/obj/item/weapon/gun/smg/standard_machinepistol = 20,
 					/obj/item/ammo_magazine/smg/standard_machinepistol = 30,
+					/obj/item/weapon/gun/pistol/standard_pocketpistol = 25,
+					/obj/item/ammo_magazine/pistol/standard_pocketpistol = 50,
+					/obj/item/weapon/gun/smg/standard_smg = 20,
+					/obj/item/ammo_magazine/smg/standard_smg = 30,
 					/obj/item/weapon/gun/rifle/standard_carbine = 25,
 					/obj/item/ammo_magazine/rifle/standard_carbine = 25,
 					/obj/item/weapon/gun/rifle/standard_assaultrifle = 25,
@@ -31,12 +35,10 @@
 					/obj/item/ammo_magazine/rifle/standard_dmr = 25,
 					/obj/item/weapon/gun/rifle/standard_br = 10,
 					/obj/item/ammo_magazine/rifle/standard_br = 25,
-					/obj/item/weapon/gun/pistol/standard_heavypistol = 10,
-					/obj/item/ammo_magazine/pistol/standard_heavypistol = 25,
-					/obj/item/weapon/gun/energy/lasgun/lasrifle = 10,
-					/obj/item/cell/lasgun/lasrifle = 20,
 					/obj/item/weapon/gun/rifle/chambered = 20,
 					/obj/item/ammo_magazine/rifle/chamberedrifle = 20,
+					/obj/item/weapon/gun/energy/lasgun/lasrifle = 10,
+					/obj/item/cell/lasgun/lasrifle = 20,
 					/obj/item/weapon/gun/shotgun/pump/t35 = 10,
 					/obj/item/weapon/gun/shotgun/combat/standardmarine = 10,
 					/obj/item/ammo_magazine/shotgun = 10,
@@ -47,8 +49,6 @@
 					/obj/item/ammo_magazine/rifle/tx15_flechette = 25,
 					/obj/item/weapon/gun/launcher/m92/standardmarine = 10,
 					/obj/item/explosive/grenade/frag = 30,
-					/obj/item/weapon/gun/pistol/standard_pocketpistol = 25,
-					/obj/item/ammo_magazine/pistol/standard_pocketpistol = 50,
 					/obj/item/attachable/bayonetknife = 20,
 					/obj/item/weapon/throwing_knife = 5,
 					/obj/item/storage/box/m94 = 5,
@@ -335,7 +335,7 @@
 
 /obj/machinery/vending/MarineMed
 	name = "\improper MarineMed"
-	desc = "Marine Medical Drug Dispenser - Provided by Nanotrasen Pharmaceuticals Division(TM)"
+	desc = "Marine Medical drug dispenser - Provided by Nanotrasen Pharmaceuticals Division(TM)."
 	icon_state = "marinemed"
 	icon_deny = "marinemed-deny"
 	product_ads = "Go save some lives!;The best stuff for your medbay.;Only the finest tools.;All natural chemicals!;This stuff saves lives.;Don't you want some?;Ping!"
@@ -381,7 +381,7 @@
 
 /obj/machinery/vending/MarineMed/Blood
 	name = "\improper MM Blood Dispenser"
-	desc = "Marine Med brand Blood Pack Dispensery"
+	desc = "Marine Med brand Blood Pack dispensery."
 	icon_state = "bloodvendor"
 	icon_deny = "bloodvendor-deny"
 	product_ads = "The best blood on the market!"
@@ -410,7 +410,7 @@
 			if(!temp_list.len) break
 
 /obj/machinery/vending/marine_medic
-	name = "\improper ColMarTech Medic Vendor"
+	name = "\improper TerraGovTech Medic Vendor"
 	desc = "A marine medic equipment vendor"
 	product_ads = "They were gonna die anyway.;Let's get space drugged!"
 	req_access = list(ACCESS_MARINE_MEDPREP)
@@ -440,7 +440,7 @@
 
 
 /obj/machinery/vending/marine_special
-	name = "\improper ColMarTech Specialist Vendor"
+	name = "\improper TerraGovTech Specialist Vendor"
 	desc = "A marine specialist equipment vendor"
 	product_ads = "If it moves, it's hostile!;How many enemies have you killed today?;Shoot first, perform autopsy later!;Your ammo is right here.;Guns!;Die, scumbag!;Don't shoot me bro!;Shoot them, bro.;Why not have a donut?"
 	req_access = list(ACCESS_MARINE_SPECPREP)
@@ -472,7 +472,7 @@
 
 
 /obj/machinery/vending/shared_vending/marine_special
-	name = "\improper ColMarTech Specialist Vendor"
+	name = "\improper TerraGovTech Specialist Vendor"
 	desc = "A marine specialist equipment vendor"
 	product_ads = "If it moves, it's hostile!;How many enemies have you killed today?;Shoot first, perform autopsy later!;Your ammo is right here.;Guns!;Die, scumbag!;Don't shoot me bro!;Shoot them, bro.;Why not have a donut?"
 	req_access = list(ACCESS_MARINE_SPECPREP)
@@ -499,7 +499,7 @@
 
 
 /obj/machinery/vending/shared_vending/marine_engi
-	name = "\improper ColMarTech Engineer System Vendor"
+	name = "\improper TerraGovTech Engineer System Vendor"
 	desc = "A marine engineering system vendor"
 	product_ads = "If it breaks, wrench it!;If it wrenches, weld it!;If it snips, snip it!"
 	req_access = list(ACCESS_MARINE_ENGPREP)
@@ -524,7 +524,7 @@
 
 
 /obj/machinery/vending/marine_smartgun
-	name = "\improper ColMarTech Smartgun Vendor"
+	name = "\improper TerraGovTech Smartgun Vendor"
 	desc = "A marine smartgun equipment vendor"
 	hacking_safety = 1
 	product_ads = "If it moves, it's hostile!;How many enemies have you killed today?;Shoot first, perform autopsy later!;Your ammo is right here.;Guns!;Die, scumbag!;Don't shoot me bro!;Shoot them, bro.;Why not have a donut?"
@@ -545,7 +545,7 @@
 	prices = list()
 
 /obj/machinery/vending/marine_leader
-	name = "\improper ColMarTech Leader Vendor"
+	name = "\improper TerraGovTech Leader Vendor"
 	desc = "A marine leader equipment vendor"
 	hacking_safety = 1
 	product_ads = "If it moves, it's hostile!;How many enemies have you killed today?;Shoot first, perform autopsy later!;Your ammo is right here.;Guns!;Die, scumbag!;Don't shoot me bro!;Shoot them, bro.;Why not have a donut?"
@@ -579,8 +579,8 @@
 
 
 /obj/machinery/vending/attachments
-	name = "\improper Armat Systems Attachments Vendor"
-	desc = "A subsidiary-owned vendor of weapon attachments. This can only be accessed by the Requisitions Officer and Cargo Techs."
+	name = "\improper Terran Armories Attachments Vendor"
+	desc = "A subsidiary-owned vendor of weapon attachments."
 	product_ads = "If it moves, it's hostile!;How many enemies have you killed today?;Shoot first, perform autopsy later!;Your ammo is right here.;Guns!;Die, scumbag!;Don't shoot me bro!;Shoot them, bro.;Why not have a donut?"
 	icon_state = "robotics"
 	icon_deny = "robotics-deny"
@@ -628,7 +628,7 @@
 
 /obj/machinery/vending/uniform_supply
 	name = "\improper Surplus Equipment Vendor"
-	desc = "A automated weapon rack hooked up to a colossal storage of uniforms and accessories."
+	desc = "A automated equipment rack hooked up to a colossal storage of uniforms and accessories."
 	icon_state = "marineuniform"
 	icon_vend = "marineuniform_vend"
 	icon_deny = "marineuniform"
@@ -718,8 +718,8 @@
 	prices = list()
 
 /obj/machinery/vending/dress_supply
-	name = "\improper ColMarTech dress uniform vendor"
-	desc = "A automated weapon rack hooked up to a colossal storage of dress uniforms"
+	name = "\improper TerraGovTech dress uniform vendor"
+	desc = "A automated rack hooked up to a colossal storage of dress uniforms."
 	icon_state = "marineuniform"
 	icon_vend = "marineuniform_vend"
 	icon_deny = "marineuniform"

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -290,6 +290,7 @@ GLOBAL_LIST_INIT(marine_selector_cats, list(
 		CAT_AMR = list(MARINE_CAN_BUY_ARMOR),
 		CAT_BAK = list(MARINE_CAN_BUY_BACKPACK),
 		CAT_WEB = list(MARINE_CAN_BUY_WEBBING),
+		CAT_BEL = list(MARINE_CAN_BUY_BELT),
 		CAT_POU = list(MARINE_CAN_BUY_R_POUCH,MARINE_CAN_BUY_L_POUCH),
 		CAT_MAS = list(MARINE_CAN_BUY_MASK),
 		CAT_ATT = list(MARINE_CAN_BUY_ATTACHMENT,MARINE_CAN_BUY_ATTACHMENT2),
@@ -297,9 +298,10 @@ GLOBAL_LIST_INIT(marine_selector_cats, list(
 
 	listed_products = list(
 		/obj/effect/essentials_set/basic = list(CAT_STD, "Standard Kit", 0, "white"),
-		/obj/effect/essentials_set/modular/infantry = list(CAT_AMR, "Infantry Jaeger kit", 0, "black"),
-		/obj/effect/essentials_set/modular/skirmisher = list(CAT_AMR, "Skirmisher Jaeger kit", 0, "black"),
-		/obj/effect/essentials_set/modular/assault = list(CAT_AMR, "Assault Jaeger kit", 0, "black"),
+		/obj/effect/essentials_set/basicmodular = list(CAT_STD, "Essential Jaeger Kit", 0, "white"),
+		/obj/effect/essentials_set/modular/infantry = list(CAT_AMR, "Infantry Jaeger kit", 0, "orange"),
+		/obj/effect/essentials_set/modular/skirmisher = list(CAT_AMR, "Skirmisher Jaeger kit", 0, "orange"),
+		/obj/effect/essentials_set/modular/assault = list(CAT_AMR, "Assault Jaeger kit", 0, "orange"),
 		/obj/item/clothing/head/helmet/marine/standard = list(CAT_HEL, "Regular helmet", 0, "orange"),
 		/obj/item/clothing/suit/storage/marine/pasvest = list(CAT_AMR, "Regular armor", 0, "orange"),
 		/obj/item/storage/backpack/marine/satchel = list(CAT_BAK, "Satchel", 0, "orange"),
@@ -309,12 +311,12 @@ GLOBAL_LIST_INIT(marine_selector_cats, list(
 		/obj/item/clothing/tie/holster = list(CAT_WEB, "Shoulder handgun holster", 0, "black"),
 		/obj/item/storage/belt/sparepouch = list(CAT_BEL, "Utility belt", 0, "black"),
 		/obj/item/storage/belt/marine = list(CAT_BEL, "Standard ammo belt", 0, "orange"),
-		/obj/item/storage/belt/shotgun = list(CAT_BEL, "Shotgun ammo belt", 0, "black"),
+		/obj/item/storage/belt/shotgun = list(CAT_BEL, "Shotgun ammo belt", 0, "orange"),
 		/obj/item/storage/belt/knifepouch = list(CAT_BEL, "Knives belt", 0, "black"),
 		/obj/item/storage/belt/gun/pistol/standard_pistol = list(CAT_BEL, "Pistol belt", 0, "black"),
 		/obj/item/storage/belt/gun/revolver/standard_revolver = list(CAT_BEL, "Revolver belt", 0, "black"),
 		/obj/item/belt_harness/marine = list(CAT_BEL, "Belt harness", 0, "black"),
-		/obj/item/storage/pouch/shotgun = list(CAT_POU, "Shotgun shell pouch", 0, "orange"),
+		/obj/item/storage/pouch/shotgun = list(CAT_POU, "Shotgun shell pouch", 0, "black"),
 		/obj/item/storage/pouch/magazine = list(CAT_POU, "Magazine pouch", 0, "black"),
 		/obj/item/storage/pouch/flare/full = list(CAT_POU, "Flare pouch", 0, "orange"),
 		/obj/item/storage/pouch/firstaid/full = list(CAT_POU, "Firstaid pouch", 0,"orange"),
@@ -378,9 +380,10 @@ GLOBAL_LIST_INIT(marine_selector_cats, list(
 
 	listed_products = list(
 		/obj/effect/essentials_set/basic_engineer = list(CAT_STD, "Standard kit", 0, "white"),
-		/obj/effect/essentials_set/modular/infantry = list(CAT_AMR, "Infantry Jaeger kit", 0, "black"),
-		/obj/effect/essentials_set/modular/skirmisher = list(CAT_AMR, "Skirmisher Jaeger kit", 0, "black"),
-		/obj/effect/essentials_set/modular/assault = list(CAT_AMR, "Assault Jaeger kit", 0, "black"),
+		/obj/effect/essentials_set/basic_engineermodular = list(CAT_STD, "Essential Jaeger Kit", 0, "white"),
+		/obj/effect/essentials_set/modular/infantry = list(CAT_AMR, "Infantry Jaeger kit", 0, "orange"),
+		/obj/effect/essentials_set/modular/skirmisher = list(CAT_AMR, "Skirmisher Jaeger kit", 0, "orange"),
+		/obj/effect/essentials_set/modular/assault = list(CAT_AMR, "Assault Jaeger kit", 0, "orange"),
 		/obj/item/clothing/suit/storage/marine/pasvest = list(CAT_AMR, "Regular armor", 0, "orange"),
 		/obj/item/storage/backpack/marine/satchel/tech = list(CAT_BAK, "Satchel", 0, "orange"),
 		/obj/item/storage/backpack/marine/tech = list(CAT_BAK, "Backpack", 0, "black"),
@@ -389,7 +392,7 @@ GLOBAL_LIST_INIT(marine_selector_cats, list(
 		/obj/item/clothing/tie/storage/brown_vest = list(CAT_WEB, "Tactical brown vest", 0, "orange"),
 		/obj/item/clothing/tie/storage/webbing = list(CAT_WEB, "Tactical webbing", 0, "black"),
 		/obj/item/clothing/tie/holster = list(CAT_WEB, "Shoulder handgun holster", 0, "black"),
-		/obj/item/storage/belt/utility/full = list(CAT_BEL, "Tool belt", 0, "orange"),
+		/obj/item/storage/belt/utility/full = list(CAT_BEL, "Tool belt", 0, "white"),
 		/obj/item/storage/pouch/shotgun = list(CAT_POU, "Shotgun shell pouch", 0, "black"),
 		/obj/item/storage/pouch/construction = list(CAT_POU, "Construction pouch", 0, "orange"),
 		/obj/item/storage/pouch/explosive = list(CAT_POU, "Explosive pouch", 0, "black"),
@@ -434,9 +437,10 @@ GLOBAL_LIST_INIT(marine_selector_cats, list(
 
 	listed_products = list(
 		/obj/effect/essentials_set/basic_medic = list(CAT_STD, "Standard kit", 0, "white"),
-		/obj/effect/essentials_set/modular/infantry = list(CAT_AMR, "Infantry Jaeger kit", 0, "black"),
-		/obj/effect/essentials_set/modular/skirmisher = list(CAT_AMR, "Skirmisher Jaeger kit", 0, "black"),
-		/obj/effect/essentials_set/modular/assault = list(CAT_AMR, "Assault Jaeger kit", 0, "black"),
+		/obj/effect/essentials_set/basic_medicmodular = list(CAT_STD, "Essential Jaeger Kit", 0, "white"),
+		/obj/effect/essentials_set/modular/infantry = list(CAT_AMR, "Infantry Jaeger kit", 0, "orange"),
+		/obj/effect/essentials_set/modular/skirmisher = list(CAT_AMR, "Skirmisher Jaeger kit", 0, "orange"),
+		/obj/effect/essentials_set/modular/assault = list(CAT_AMR, "Assault Jaeger kit", 0, "orange"),
 		/obj/item/clothing/suit/storage/marine/pasvest = list(CAT_AMR, "Regular armor", 0, "orange"),
 		/obj/item/storage/backpack/marine/satchel/corpsman = list(CAT_BAK, "Satchel", 0, "orange"),
 		/obj/item/storage/backpack/marine/corpsman = list(CAT_BAK, "Backpack", 0, "black"),
@@ -494,21 +498,22 @@ GLOBAL_LIST_INIT(marine_selector_cats, list(
 
 	listed_products = list(
 		/obj/effect/essentials_set/basic_smartgunner = list(CAT_STD, "Standard kit", 0, "white"),
-		/obj/effect/essentials_set/modular/infantry = list(CAT_AMR, "Infantry Jaeger kit", 0, "black"),
-		/obj/effect/essentials_set/modular/skirmisher = list(CAT_AMR, "Skirmisher Jaeger kit", 0, "black"),
-		/obj/effect/essentials_set/modular/assault = list(CAT_AMR, "Assault Jaeger kit", 0, "black"),
+		/obj/effect/essentials_set/basic_smartgunnermodular = list(CAT_STD, "Essential Jaeger Kit", 0, "white"),
+		/obj/effect/essentials_set/modular/infantry = list(CAT_AMR, "Infantry Jaeger kit", 0, "orange"),
+		/obj/effect/essentials_set/modular/skirmisher = list(CAT_AMR, "Skirmisher Jaeger kit", 0, "orange"),
+		/obj/effect/essentials_set/modular/assault = list(CAT_AMR, "Assault Jaeger kit", 0, "orange"),
 		/obj/item/clothing/suit/storage/marine/pasvest = list(CAT_AMR, "Regular armor", 0, "orange"),
 		/obj/item/clothing/head/helmet/marine/standard = list(CAT_HEL, "Regular helmet", 0, "orange"),
-		/obj/item/clothing/head/helmet/marine/heavy = list(CAT_HEL, "Heavy helmet", 0, "black"),
+		/obj/item/clothing/head/helmet/marine/heavy = list(CAT_HEL, "Heavy helmet", 0, "orange"),
 		/obj/item/clothing/tie/storage/black_vest = list(CAT_WEB, "Tactical black vest", 0, "orange"),
 		/obj/item/clothing/tie/storage/webbing = list(CAT_WEB, "Tactical webbing", 0, "black"),
 		/obj/item/clothing/tie/holster = list(CAT_WEB, "Shoulder handgun holster", 0, "black"),
 		/obj/item/storage/belt/marine = list(CAT_BEL, "Standard ammo belt", 0, "black"),
 		/obj/item/storage/belt/shotgun = list(CAT_BEL, "Shotgun ammo belt", 0, "black"),
 		/obj/item/storage/belt/knifepouch = list(CAT_BEL, "Knives belt", 0, "black"),
-		/obj/item/storage/belt/gun/pistol/standard_pistol = list(CAT_BEL, "Pistol belt", 0, "black"),
-		/obj/item/storage/belt/gun/revolver/standard_revolver = list(CAT_BEL, "Revolver belt", 0, "black"),
-		/obj/item/storage/belt/sparepouch = list(CAT_BEL, "G8 general utility pouch", 0, "black"),
+		/obj/item/storage/belt/gun/pistol/standard_pistol = list(CAT_BEL, "Pistol belt", 0, "orange"),
+		/obj/item/storage/belt/gun/revolver/standard_revolver = list(CAT_BEL, "Revolver belt", 0, "orange"),
+		/obj/item/storage/belt/sparepouch = list(CAT_BEL, "G8 general utility pouch", 0, "orange"),
 		/obj/item/storage/pouch/shotgun = list(CAT_POU, "Shotgun shell pouch", 0, "black"),
 		/obj/item/storage/pouch/grenade/slightlyfull = list(CAT_POU, "Grenade pouch (grenades included)", 0,"black"),
 		/obj/item/storage/pouch/magazine = list(CAT_POU, "Magazine pouch", 0, "black"),
@@ -616,7 +621,8 @@ GLOBAL_LIST_INIT(marine_selector_cats, list(
 	gives_webbing = FALSE
 
 	listed_products = list(
-		/obj/effect/essentials_set/basic_squadleader = list(CAT_STD, "Standard kit", 0, "white"),
+		/obj/effect/essentials_set/basic_squadleader = list(CAT_STD, "Standard kit (vest included)", 0, "white"),
+		/obj/effect/essentials_set/basic_squadleadermodular = list(CAT_STD, "Essential Jaeger Kit", 0, "white"),
 		/obj/effect/essentials_set/modular/infantry = list(CAT_AMR, "Infantry Jaeger kit", 0, "black"),
 		/obj/effect/essentials_set/modular/skirmisher = list(CAT_AMR, "Skirmisher Jaeger kit", 0, "black"),
 		/obj/effect/essentials_set/modular/assault = list(CAT_AMR, "Assault Jaeger kit", 0, "black"),
@@ -638,7 +644,7 @@ GLOBAL_LIST_INIT(marine_selector_cats, list(
 		/obj/item/storage/pouch/magazine/large = list(CAT_POU, "Large magazine pouch", 0, "black"),
 		/obj/item/storage/pouch/flare/full = list(CAT_POU, "Flare pouch", 0, "black"),
 		/obj/item/storage/pouch/firstaid/injectors/full = list(CAT_POU, "Injector pouch", 0,"orange"),
-		/obj/item/storage/pouch/firstaid/full = list(CAT_POU, "Firstaid pouch", 0, "black"),
+		/obj/item/storage/pouch/firstaid/full = list(CAT_POU, "Firstaid pouch", 0, "orange"),
 		/obj/item/storage/pouch/medkit = list(CAT_POU, "Medkit pouch", 0, "black"),
 		/obj/item/storage/pouch/tools/full = list(CAT_POU, "Tool pouch (tools included)", 0, "black"),
 		/obj/item/storage/pouch/grenade/slightlyfull = list(CAT_POU, "Grenade pouch (grenades included)", 0,"black"),
@@ -1000,6 +1006,16 @@ GLOBAL_LIST_INIT(available_specialist_sets, list("Scout Set", "Sniper Set", "Dem
 						/obj/item/storage/box/MRE,
 						)
 
+/obj/effect/essentials_set/basicmodular
+	spawned_gear_list = list(
+						/obj/item/clothing/under/marine/jaeger,
+						/obj/item/clothing/suit/modular,
+						/obj/item/clothing/shoes/marine,
+						/obj/item/attachable/bayonetknife,
+						/obj/item/storage/box/MRE,
+						/obj/item/armor_module/attachable/better_shoulder_lamp,
+						/obj/item/facepaint/green,
+						)
 
 /obj/effect/essentials_set/basic_smartgunner
 	spawned_gear_list = list(
@@ -1007,6 +1023,17 @@ GLOBAL_LIST_INIT(available_specialist_sets, list("Scout Set", "Sniper Set", "Dem
 						/obj/item/clothing/shoes/marine,
 						/obj/item/attachable/bayonetknife,
 						/obj/item/storage/box/MRE
+						)
+
+/obj/effect/essentials_set/basic_smartgunnermodular
+	spawned_gear_list = list(
+						/obj/item/clothing/under/marine/jaeger,
+						/obj/item/clothing/suit/modular,
+						/obj/item/clothing/shoes/marine,
+						/obj/item/attachable/bayonetknife,
+						/obj/item/storage/box/MRE,
+						/obj/item/armor_module/attachable/better_shoulder_lamp,
+						/obj/item/facepaint/green,
 						)
 
 /obj/effect/essentials_set/basic_specialist
@@ -1028,6 +1055,19 @@ GLOBAL_LIST_INIT(available_specialist_sets, list("Scout Set", "Sniper Set", "Dem
 						/obj/item/storage/box/MRE
 						)
 
+/obj/effect/essentials_set/basic_squadleadermodular
+	spawned_gear_list = list(
+						/obj/item/clothing/under/marine/jaeger,
+						/obj/item/clothing/suit/modular,
+						/obj/item/clothing/head/helmet/marine/leader,
+						/obj/item/clothing/glasses/hud/health,
+						/obj/item/clothing/shoes/marine,
+						/obj/item/attachable/bayonetknife,
+						/obj/item/storage/box/MRE,
+						/obj/item/armor_module/attachable/better_shoulder_lamp,
+						/obj/item/facepaint/green,
+						)
+
 /obj/effect/essentials_set/basic_medic
 	spawned_gear_list = list(
 						/obj/item/clothing/head/helmet/marine/corpsman,
@@ -1038,6 +1078,19 @@ GLOBAL_LIST_INIT(available_specialist_sets, list("Scout Set", "Sniper Set", "Dem
 						/obj/item/storage/box/MRE
 						)
 
+/obj/effect/essentials_set/basic_medicmodular
+	spawned_gear_list = list(
+						/obj/item/clothing/under/marine/jaeger,
+						/obj/item/clothing/suit/modular,
+						/obj/item/clothing/head/helmet/marine/corpsman,
+						/obj/item/clothing/glasses/hud/health,
+						/obj/item/clothing/shoes/marine,
+						/obj/item/attachable/bayonetknife,
+						/obj/item/storage/box/MRE,
+						/obj/item/armor_module/attachable/better_shoulder_lamp,
+						/obj/item/facepaint/green,
+						)
+
 /obj/effect/essentials_set/basic_engineer
 	spawned_gear_list = list(
 						/obj/item/clothing/head/helmet/marine/tech,
@@ -1046,7 +1099,21 @@ GLOBAL_LIST_INIT(available_specialist_sets, list("Scout Set", "Sniper Set", "Dem
 						/obj/item/clothing/shoes/marine,
 						/obj/item/attachable/bayonetknife,
 						/obj/item/storage/box/MRE,
-						/obj/item/clothing/gloves/marine/insulated
+						/obj/item/clothing/gloves/marine/insulated,
+						)
+
+/obj/effect/essentials_set/basic_engineermodular
+	spawned_gear_list = list(
+						/obj/item/clothing/under/marine/jaeger,
+						/obj/item/clothing/suit/modular,
+						/obj/item/clothing/head/helmet/marine/tech,
+						/obj/item/clothing/glasses/welding,
+						/obj/item/clothing/shoes/marine,
+						/obj/item/attachable/bayonetknife,
+						/obj/item/storage/box/MRE,
+						/obj/item/armor_module/attachable/better_shoulder_lamp,
+						/obj/item/clothing/gloves/marine/insulated,
+						/obj/item/facepaint/green,
 						)
 
 /obj/effect/essentials_set/medic
@@ -1098,39 +1165,30 @@ GLOBAL_LIST_INIT(available_specialist_sets, list("Scout Set", "Sniper Set", "Dem
 						)
 
 /obj/effect/essentials_set/modular/infantry
-	desc = "A set of Infantry pattern Jaeger armor, including an exoskeleton, helmet, armor plates and a lamp attachment."
+	desc = "A set of light Infantry pattern Jaeger armor, including an exoskeleton, helmet, and armor plates."
 	spawned_gear_list = list(
-						/obj/item/clothing/suit/modular,
-						/obj/item/clothing/under/marine/jaeger,
 						/obj/item/clothing/head/modular/marine,
 						/obj/item/armor_module/armor/chest/marine,
 						/obj/item/armor_module/armor/arms/marine,
 						/obj/item/armor_module/armor/legs/marine,
-						/obj/item/armor_module/attachable/better_shoulder_lamp,
 						)
 
 /obj/effect/essentials_set/modular/skirmisher
-	desc = "A set of Skirmisher pattern Jaeger armor, including an exoskeleton, helmet, armor plates and a lamp attachment."
+	desc = "A set of medium Skirmisher pattern Jaeger armor, including an exoskeleton, helmet, and armor plates."
 	spawned_gear_list = list(
-						/obj/item/clothing/suit/modular,
-						/obj/item/clothing/under/marine/jaeger,
 						/obj/item/clothing/head/modular/marine/skirmisher,
 						/obj/item/armor_module/armor/chest/marine/skirmisher,
 						/obj/item/armor_module/armor/arms/marine/skirmisher,
 						/obj/item/armor_module/armor/legs/marine/skirmisher,
-						/obj/item/armor_module/attachable/better_shoulder_lamp,
 						)
 
 /obj/effect/essentials_set/modular/assault
-	desc = "A set of Assault pattern Jaeger armor, including an exoskeleton, helmet, armor plates and a lamp attachment."
+	desc = "A set of heavy Assault pattern Jaeger armor, including an exoskeleton, helmet, and armor plates."
 	spawned_gear_list = list(
-						/obj/item/clothing/suit/modular,
-						/obj/item/clothing/under/marine/jaeger,
 						/obj/item/clothing/head/modular/marine/assault,
 						/obj/item/armor_module/armor/chest/marine/assault,
 						/obj/item/armor_module/armor/arms/marine/assault,
 						/obj/item/armor_module/armor/legs/marine/assault,
-						/obj/item/armor_module/attachable/better_shoulder_lamp,
 						)
 
 #undef MARINE_CAN_BUY_UNIFORM

--- a/code/game/objects/machinery/vending/vending_types.dm
+++ b/code/game/objects/machinery/vending/vending_types.dm
@@ -171,7 +171,7 @@
 
 /obj/machinery/vending/medical
 	name = "NanotrasenMed Plus"
-	desc = "Medical Pharmaceutical dispenser.  Provided by Nanotrasen Pharmaceuticals Division(TM)"
+	desc = "Medical Pharmaceutical dispenser.  Provided by Nanotrasen Pharmaceuticals Division(TM)."
 	icon_state = "med"
 	icon_deny = "med-deny"
 	//product_ads = "Go save some lives!;The best stuff for your medbay.;Only the finest tools.;Natural chemicals!;This stuff saves lives.;Don't you want some?;Ping!"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes vendors.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Because fixing vendors save lives.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added an essential Jaeger kit in GHMME vendors, no longer that you need to dump out your uniform for the undersuit to clutter your workspace! Comes with the Jaeger undersuit, exoskeleton, Baldhur lamp and facepaint and other standard equipment when vendored.
tweak: Renamed most instances of ColMarTech to TerraGovTech for vendors.
tweak: Renamed the Armat Systems Attachment vendor to Terran Armories Attachment vendor. Removed the outdated latter line in its description.
tweak: Reordered the heavy pistol, pocket pistol and machine pistol inside the weapon vendor.
tweak: Tweaked some "Recommended" and "Not Recommended" buys.
fix: Belt options inside the GHMME vendor is broke (as in, went down to the lowest order), so reordered to be below webbing options now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
