### PR TITLE
Removes access restrictions for marinemeds

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -339,7 +339,6 @@
 	icon_state = "marinemed"
 	icon_deny = "marinemed-deny"
 	product_ads = "Go save some lives!;The best stuff for your medbay.;Only the finest tools.;All natural chemicals!;This stuff saves lives.;Don't you want some?;Ping!"
-	req_one_access = list(ACCESS_MARINE_MEDBAY, ACCESS_MARINE_CHEMISTRY, ACCESS_MARINE_MEDPREP) //Medics, doctors and researchers can access
 	wrenchable = FALSE
 	products = list(/obj/item/reagent_containers/hypospray/autoinjector/quickclot = 6,
 					/obj/item/reagent_containers/hypospray/autoinjector/bicaridine = 6,


### PR DESCRIPTION
## About The Pull Request

Removes the medic/doctor access requirement for marinemeds.

## Why It's Good For The Game

"Haha, yes, Philip, let's put a vending machine filled with meds in the medbay lobby, for all to use. The trick? Ninety-five percent of all marines won't be able to access it without hacking! And the other kicker; let's call it the MarineMed. Funniest shit I've ever come up with."
Really, though, QoL and stuff.

## Changelog
:cl:
del: Removed Marinemed access requirements.
:cl: