### PR TITLE
fixes stacking cades with fob drone

### DIFF
--- a/code/modules/mining/remote_fob/remote_fob_actions_misc.dm
+++ b/code/modules/mining/remote_fob/remote_fob_actions_misc.dm
@@ -26,6 +26,9 @@
 	if(build_area.density)
 		to_chat(owner, "<span class='warning'>No space to build anything here.")
 		return FALSE
+	if(fobdrone.action_busy)
+		to_chat(owner, "<span class='warning'>You are already building something.")
+		return FALSE	
 
 	return TRUE
 


### PR DESCRIPTION

## About The Pull Request

this PR fixes stacking cades via spam clicking when using the fob drone
Closes #4543
## Why It's Good For The Game

nice exploit marines, its a shame it breaks the game

## Changelog
:cl:
fix: fixed a bug in which crafty bastard engineers would spam click the build barricade buttons to make xenos madder than they usually are via cade stacking
/:cl:
