### PR TITLE
Update Prison south LZ1 

### DIFF
--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -25138,8 +25138,8 @@
 /area/prison/visitation)
 "byu" = (
 /obj/structure/cable,
-/obj/machinery/door/airlock/mainship/security/free_access{
-	name = "Main Hangar Traffic Control"
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 8
 	},
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 8
@@ -25389,13 +25389,17 @@
 	name = "Hangar-Barracks Maintenance"
 	},
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/prison/hangar/main)
 "bzi" = (
-/turf/closed/wall/r_wall/prison,
-/area/prison/security/checkpoint/hangar)
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 8
+	},
+/obj/structure/window/framed/prison/reinforced/hull,
+/turf/open/floor/plating,
+/area/space)
 "bzj" = (
 /obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 2;
@@ -25601,11 +25605,12 @@
 /turf/open/floor/plating,
 /area/prison/security/checkpoint/highsec/s)
 "bzS" = (
-/obj/machinery/alarm,
-/turf/open/floor/prison/darkyellow{
-	dir = 1
+/obj/structure/window/framed/prison/reinforced/hull,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 8
 	},
-/area/prison/maintenance/hangar_barracks)
+/turf/open/floor/plating,
+/area/space)
 "bzT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -26376,7 +26381,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/prison/darkyellow{
-	dir = 8
+	dir = 9
 	},
 /area/prison/maintenance/hangar_barracks)
 "bCr" = (
@@ -26603,16 +26608,16 @@
 /turf/open/floor/prison,
 /area/prison/quarters/security)
 "bCY" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber{
-	dir = 4
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall/prison_unmeltable,
 /area/prison/maintenance/hangar_barracks)
 "bCZ" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
 "bDa" = (
@@ -26706,7 +26711,7 @@
 "bDs" = (
 /obj/machinery/alarm,
 /turf/open/floor/prison/trim/red{
-	dir = 1
+	dir = 5
 	},
 /area/prison/security)
 "bDt" = (
@@ -26850,14 +26855,21 @@
 	},
 /area/prison/cellblock/lowsec/sw)
 "bDQ" = (
-/turf/open/floor/prison/darkyellow{
-	dir = 9
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	dir = 2;
+	name = "Hangar-Barracks Maintenance"
 	},
-/area/prison/maintenance/hangar_barracks)
-"bDR" = (
-/turf/open/floor/prison/darkyellow{
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 1
 	},
+/turf/closed/wall/r_wall/prison_unmeltable,
+/area/prison/hangar/main)
+"bDR" = (
+/obj/structure/largecrate/random,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
 "bDS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -27230,9 +27242,10 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/east)
 "bEF" = (
-/turf/open/floor/prison/darkyellow{
-	dir = 5
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 8
 	},
+/turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
 "bEG" = (
 /obj/effect/decal/cleanable/blood,
@@ -27609,14 +27622,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/east)
-"bFN" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/mainship/secure/free_access{
-	name = "Telecommunications"
-	},
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/prison,
-/area/prison/maintenance/hangar_barracks)
 "bFO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
@@ -27772,10 +27777,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/highsec/south/north)
-"bGg" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall/r_wall/prison,
-/area/prison/maintenance/hangar_barracks)
 "bGh" = (
 /turf/open/shuttle/dropship/floor,
 /area/prison/monorail/east)
@@ -27906,10 +27907,8 @@
 /turf/open/floor/prison,
 /area/prison/quarters/security)
 "bGI" = (
-/obj/structure/hoop,
-/turf/open/floor/prison/darkyellow{
-	dir = 1
-	},
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall/r_wall/prison_unmeltable,
 /area/prison/maintenance/hangar_barracks)
 "bGJ" = (
 /obj/machinery/light/small{
@@ -27920,14 +27919,9 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
-"bGK" = (
-/obj/structure/cable,
-/turf/open/floor/prison/darkyellow{
-	dir = 8
-	},
-/area/prison/maintenance/hangar_barracks)
 "bGL" = (
-/turf/open/floor/prison,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall/prison,
 /area/prison/maintenance/hangar_barracks)
 "bGN" = (
 /obj/machinery/power/apc/drained,
@@ -27938,9 +27932,8 @@
 /area/prison/recreation/highsec/s)
 "bGO" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison/darkyellow{
-	dir = 4
-	},
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall/prison,
 /area/prison/maintenance/hangar_barracks)
 "bGP" = (
 /obj/machinery/alarm,
@@ -28302,28 +28295,26 @@
 /turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
 "bHZ" = (
-/obj/effect/landmark/monkey_spawn,
-/turf/open/floor/prison,
+/turf/open/floor/prison/darkyellow{
+	dir = 1
+	},
 /area/prison/maintenance/hangar_barracks)
 "bIa" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison,
 /area/prison/maintenance/hangar_barracks)
 "bIb" = (
-/obj/item/radio/headset/survivor,
-/turf/open/floor/prison,
+/obj/machinery/alarm,
+/turf/open/floor/prison/darkyellow{
+	dir = 1
+	},
 /area/prison/maintenance/hangar_barracks)
 "bIc" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/prison/darkyellow{
-	dir = 4
-	},
-/area/prison/maintenance/hangar_barracks)
-"bId" = (
-/turf/open/floor/prison/darkyellow{
-	dir = 8
+	dir = 5
 	},
 /area/prison/maintenance/hangar_barracks)
 "bIe" = (
@@ -28800,7 +28791,6 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/east)
 "bJt" = (
-/obj/structure/largecrate/random,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
@@ -28814,20 +28804,32 @@
 /turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
 "bJv" = (
+/obj/structure/hoop{
+	dir = 4;
+	id = "basketball";
+	side = "left"
+	},
+/obj/structure/cable,
 /turf/open/floor/prison/darkyellow{
-	dir = 10
+	dir = 8
 	},
 /area/prison/maintenance/hangar_barracks)
 "bJw" = (
-/turf/open/floor/prison/darkyellow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
 /area/prison/maintenance/hangar_barracks)
 "bJx" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/prison,
 /area/prison/maintenance/hangar_barracks)
 "bJy" = (
+/obj/structure/hoop{
+	dir = 8;
+	id = "basketball";
+	side = "right"
+	},
 /turf/open/floor/prison/darkyellow{
-	dir = 6
+	dir = 4
 	},
 /area/prison/maintenance/hangar_barracks)
 "bJz" = (
@@ -28990,13 +28992,11 @@
 	},
 /area/prison/cellblock/mediumsec/north)
 "bKb" = (
-/obj/structure/bed/chair/office/dark{
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/prison/darkyellow{
 	dir = 1
 	},
-/turf/open/floor/prison/trim/red{
-	dir = 1
-	},
-/area/prison/security)
+/area/prison/maintenance/hangar_barracks)
 "bKc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -29032,7 +29032,6 @@
 /turf/open/floor/prison,
 /area/prison/quarters/security)
 "bKf" = (
-/obj/item/toy/beach_ball/basketball,
 /turf/open/floor/prison,
 /area/prison/maintenance/hangar_barracks)
 "bKg" = (
@@ -29223,8 +29222,10 @@
 /turf/open/floor,
 /area/storage/testroom)
 "bKO" = (
-/obj/structure/largecrate/random,
-/turf/open/floor/prison/darkyellow/full,
+/obj/structure/cable,
+/turf/open/floor/prison/darkyellow{
+	dir = 8
+	},
 /area/prison/maintenance/hangar_barracks)
 "bKP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -29458,23 +29459,14 @@
 /turf/open/floor/prison/darkred/full,
 /area/prison/security)
 "bLB" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/secure_data,
-/turf/open/floor/prison/darkred/full,
+/turf/closed/wall/r_wall/prison_unmeltable,
 /area/prison/security)
 "bLC" = (
 /obj/machinery/computer/prisoner,
 /turf/open/floor/prison/darkred/full,
 /area/prison/security)
 "bLD" = (
-/obj/machinery/disposal,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/prison/trim/red{
-	dir = 5
-	},
+/turf/open/floor/prison/rampbottom,
 /area/prison/security)
 "bLE" = (
 /obj/structure/sink{
@@ -29758,12 +29750,6 @@
 	},
 /turf/open/floor/wood,
 /area/prison/parole/main)
-"bMw" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/prison/trim/red{
-	dir = 4
-	},
-/area/prison/security)
 "bMy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
@@ -30033,31 +30019,29 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/security)
 "bNk" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/bed/chair/office/dark{
 	dir = 4
 	},
-/turf/open/floor/prison,
-/area/prison/security)
-"bNl" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
-	},
+/obj/structure/disposalpipe/segment/corner,
 /turf/open/floor/prison/trim/red{
 	dir = 4
 	},
+/area/prison/security)
+"bNl" = (
+/turf/open/floor/plating,
 /area/prison/security)
 "bNm" = (
 /turf/closed/wall/prison,
 /area/prison/toilet/security)
 "bNn" = (
-/obj/machinery/shower{
-	pixel_y = 15
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/prison/kitchen,
-/area/prison/toilet/security)
+/obj/structure/cable,
+/turf/open/floor/prison/darkyellow{
+	dir = 8
+	},
+/area/prison/maintenance/hangar_barracks)
 "bNo" = (
 /turf/closed/wall/r_wall/prison_unmeltable,
 /area/prison/toilet/security)
@@ -30452,6 +30436,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/sink{
+	pixel_y = 15
+	},
+/obj/structure/mirror{
+	pixel_y = 28
+	},
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/toilet/security)
 "bOu" = (
@@ -30592,27 +30582,9 @@
 	},
 /turf/open/ground/grass,
 /area/prison/residential/central)
-"bOQ" = (
-/obj/structure/sink{
-	pixel_y = 15
-	},
-/obj/structure/mirror{
-	pixel_y = 28
-	},
-/obj/effect/landmark/corpsespawner/prison_security,
-/turf/open/floor/prison/bright_clean/two,
-/area/prison/toilet/security)
-"bOR" = (
-/turf/open/floor/prison/bright_clean/two,
-/area/prison/toilet/security)
 "bOS" = (
-/obj/structure/sink{
-	pixel_y = 15
-	},
-/obj/structure/mirror{
-	pixel_y = 28
-	},
-/turf/open/floor/prison/bright_clean/two,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall/prison,
 /area/prison/toilet/security)
 "bOT" = (
 /turf/open/floor/prison/trim/red{
@@ -31561,6 +31533,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/corpsespawner/prison_security,
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/toilet/security)
 "bSd" = (
@@ -42200,6 +42173,14 @@
 "dbh" = (
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/canteen)
+"dkO" = (
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
+/turf/open/floor/prison/trim/red{
+	dir = 4
+	},
+/area/prison/security)
 "dpL" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/wall/prison,
@@ -42228,6 +42209,13 @@
 	dir = 8
 	},
 /area/prison/security/monitoring/maxsec/panopticon)
+"dOH" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/prison,
+/area/prison/security)
 "dOO" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/prison/bright_clean/two,
@@ -42239,6 +42227,14 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating,
 /area/prison/cellblock/mediumsec/west)
+"dXe" = (
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	dir = 2;
+	name = "Hangar-Barracks Maintenance"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/prison/security)
 "ecN" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/prison/darkyellow/full,
@@ -42295,10 +42291,9 @@
 /area/prison/maintenance/research_medbay)
 "fug" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
+	dir = 1
 	},
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall/r_wall/prison,
+/turf/closed/wall/prison,
 /area/prison/security/checkpoint/hangar)
 "fvh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -42507,12 +42502,17 @@
 /turf/open/floor/plating,
 /area/prison/hangar/civilian)
 "jJk" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 8
+/obj/machinery/door/airlock/mainship/secure/free_access{
+	name = "Telecommunications"
 	},
-/turf/closed/wall/r_wall/prison,
-/area/prison/security/checkpoint/hangar)
+/obj/structure/cable,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating,
+/area/prison/maintenance/hangar_barracks)
+"jMx" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/prison/security)
 "jNw" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/prison,
@@ -42553,6 +42553,10 @@
 	dir = 4
 	},
 /area/prison/cellblock/highsec/south/north)
+"kyo" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall/r_wall/prison_unmeltable,
+/area/prison/toilet/security)
 "kyN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -42568,6 +42572,11 @@
 /obj/machinery/vending/cigarette/colony,
 /turf/open/floor/prison/darkred/full,
 /area/prison/monorail/east)
+"kRD" = (
+/turf/open/floor/prison/darkyellow{
+	dir = 6
+	},
+/area/prison/maintenance/hangar_barracks)
 "laO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -42605,6 +42614,20 @@
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/canteen)
+"mbj" = (
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "Hangar-Barracks Maintenance"
+	},
+/obj/structure/cable,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating,
+/area/prison/maintenance/hangar_barracks)
+"mja" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/prison/security)
 "mmo" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/wood,
@@ -42727,6 +42750,15 @@
 	},
 /turf/open/floor/plating,
 /area/prison/hangar/main)
+"pSJ" = (
+/obj/structure/sink{
+	pixel_y = 15
+	},
+/obj/structure/mirror{
+	pixel_y = 28
+	},
+/turf/open/floor/prison/bright_clean/two,
+/area/prison/toilet/security)
 "pWz" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
@@ -42775,6 +42807,14 @@
 	},
 /turf/open/floor/plating,
 /area/prison/hangar/civilian)
+"qCJ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/prison/darkyellow{
+	dir = 4
+	},
+/area/prison/maintenance/hangar_barracks)
 "qMm" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 5
@@ -42826,6 +42866,12 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/r_wall/prison_unmeltable,
 /area/prison/security/monitoring/maxsec/panopticon)
+"sNc" = (
+/obj/structure/cable,
+/turf/open/floor/prison/darkyellow{
+	dir = 10
+	},
+/area/prison/maintenance/hangar_barracks)
 "sRe" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -42859,9 +42905,13 @@
 /turf/open/floor/plating,
 /area/prison/hangar_storage/research)
 "tyd" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall/r_wall/prison_unmeltable,
-/area/prison/maintenance/hangar_barracks)
+/obj/structure/window/framed/prison/reinforced,
+/turf/open/floor/prison,
+/area/prison/quarters/security)
+"tUQ" = (
+/obj/machinery/computer/prisoner,
+/turf/open/floor/prison,
+/area/prison/security)
 "udZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -42879,7 +42929,7 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 8
 	},
-/turf/closed/wall/r_wall/prison,
+/turf/closed/wall/r_wall/prison_unmeltable,
 /area/prison/security/checkpoint/hangar)
 "uQX" = (
 /obj/machinery/vending/cigarette/colony,
@@ -42951,6 +43001,13 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
 /area/prison/hallway/central)
+"waz" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/secure_data,
+/turf/open/floor/prison/trim/red{
+	dir = 1
+	},
+/area/prison/security)
 "wfY" = (
 /obj/structure/cable,
 /turf/open/floor/prison/bright_clean,
@@ -42960,6 +43017,10 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
 /area/prison/security/monitoring/lowsec/sw)
+"wvq" = (
+/obj/effect/landmark/monkey_spawn,
+/turf/open/floor/prison,
+/area/prison/maintenance/hangar_barracks)
 "wvr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -42983,14 +43044,16 @@
 	dir = 1
 	},
 /area/prison/maintenance/staff_research)
+"wNl" = (
+/turf/open/floor/prison/darkyellow,
+/area/prison/maintenance/hangar_barracks)
 "xar" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/prison,
 /area/prison/cellblock/mediumsec/south)
 "xdx" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
+	dir = 1
 	},
 /turf/closed/wall/r_wall/prison_unmeltable,
 /area/prison/security/checkpoint/hangar)
@@ -43022,6 +43085,10 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/mediumsec/south)
+"ybW" = (
+/obj/item/toy/beach_ball/basketball,
+/turf/open/floor/prison,
+/area/prison/maintenance/hangar_barracks)
 "ydX" = (
 /turf/open/floor/prison/rampbottom{
 	dir = 1
@@ -99480,7 +99547,7 @@ bBl
 bHV
 bJo
 bAD
-bKL
+tyd
 bLx
 bMs
 bNi
@@ -99994,12 +100061,12 @@ bAD
 bAD
 bIE
 bAD
-bKL
+tyd
 bDs
-bMu
+bRU
 bNk
-bMu
-bMu
+dkO
+bNS
 bNO
 bRX
 bQo
@@ -100251,11 +100318,11 @@ bAC
 bAC
 bIE
 bAC
-bKL
+bzg
 bLA
-bLz
-bNk
-bMu
+waz
+tUQ
+dOH
 bMu
 bQt
 bRY
@@ -100507,13 +100574,13 @@ bAF
 bAF
 bAF
 bIH
-bAF
-bAF
+bFX
+bFX
 bLB
-bKb
-bNk
-bMu
-bMu
+bZp
+bZp
+bZp
+bZp
 bNY
 bMu
 bQp
@@ -100752,25 +100819,25 @@ btv
 biJ
 bvk
 pOU
-aab
-aab
-aab
-bFX
-bAG
-bAG
+bzi
+bzi
+bzS
 bCY
+bAG
+bDR
+bAG
 bEL
 bGe
 bDa
 bAH
 bIJ
-bAG
-bAF
-bLC
-bLz
-bNk
-bMu
-bMu
+bAH
+bDa
+bLD
+bNl
+mja
+jMx
+dXe
 bNY
 bMu
 bTB
@@ -101009,11 +101076,11 @@ bhw
 bhw
 bhw
 aXt
-dqy
-dqy
-dqy
-iVk
-bAG
+bnQ
+bnQ
+bnQ
+bDQ
+bDa
 bAH
 bCZ
 bEM
@@ -101021,13 +101088,13 @@ bDc
 bGJ
 bHY
 bJt
-bAG
-bAF
+bAH
+bDa
 bLD
-bMw
 bNl
-bNS
-bNS
+bNl
+jMx
+bZp
 bNZ
 bNS
 bTC
@@ -101272,19 +101339,19 @@ byi
 bzh
 bAH
 bAH
-bDa
+bEF
 bEN
-bGg
-bGg
-bFN
-bGg
-bGg
-bGg
-bGg
-bGg
-bNm
-bNm
-bNm
+bGe
+bDa
+bGL
+bGL
+jJk
+bGL
+bGL
+bGL
+bGL
+mbj
+bOS
 bOa
 bNm
 bNm
@@ -101527,21 +101594,21 @@ bnQ
 bnQ
 bmw
 upV
-upV
+bDb
 byu
 bDb
-upV
-jJk
-bDQ
-bGK
+bDb
+bDb
+bDa
+bGL
 bCq
-bId
+bKO
 bJv
 bKO
-bGg
+bKO
 bNn
-bVt
-bOR
+sNc
+bOS
 bOh
 bJU
 bVt
@@ -101783,22 +101850,22 @@ aYM
 bnQ
 bnQ
 bnQ
-bzi
+bzl
 bAI
 byv
 bBj
 bAN
 fug
-bDR
+bDa
 bGL
 bHZ
 bJx
 bJw
-bKO
-bGg
-bNm
-bNm
-bOQ
+bKf
+bIa
+bJw
+wNl
+bOS
 bOs
 bSb
 bNm
@@ -102046,16 +102113,16 @@ bBM
 bDd
 bBQ
 fug
-bGI
+bDa
 bGL
-bIa
+bKb
 bKf
-bJw
-bKO
-bGg
-bNn
-bVt
-bOR
+bKf
+ybW
+bKf
+bKf
+wNl
+bOS
 bQz
 bSc
 bVt
@@ -102297,23 +102364,23 @@ aYM
 bnQ
 byi
 bnQ
-bzi
+bzl
 bAK
 bBM
 bDe
 bDh
 fug
-bzS
+bDa
 bGL
 bIb
 bIa
+bKf
 bJw
-bKO
-bGg
-bNm
-bNm
+bKf
+wvq
+wNl
 bOS
-bOR
+pSJ
 bSd
 bNm
 bNm
@@ -102560,16 +102627,16 @@ bBM
 bDf
 bEO
 fug
-bEF
+bDa
 bGO
 bIc
 bIe
 bJy
-bKO
-bGg
-bNn
-bVt
-bOR
+bIe
+bIe
+qCJ
+kRD
+bOS
 bQA
 bSe
 bVt
@@ -102811,22 +102878,22 @@ bwp
 bnQ
 byi
 bnQ
-bzi
+bzl
 bpW
 bBP
 bDg
 bEP
 xdx
 bJu
-bJu
+bGI
 bFX
 bJu
 bJu
 bFX
-tyd
-bNo
-bNo
-bNo
+bFX
+bFX
+bFX
+kyo
 bQB
 bNo
 bNo
@@ -103068,7 +103135,7 @@ bwq
 bnQ
 byi
 gSk
-bzi
+bzl
 bAN
 bBQ
 bDh


### PR DESCRIPTION
## About The Pull Request

Updates the maint area south of LZ1. This increases the space a little and replaces the office walls with lesser walls that can be acid'd.
This gives xenos extra ways to leave the hive there so its harder to be camped.
Additionally extends the maint entrance a little lower into security

## Why It's Good For The Game
Balance idk.

## Changelog
:cl:
add: More exits to the south maint near LZ1 on prison.
/:cl:
