### PR TITLE
Fixes ammo bug when spam transferring between magazines

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -97,7 +97,8 @@ They're all essentially identical when it comes to getting the job done.
 	if(!source.current_rounds)
 		to_chat(user, "<span class='warning'>\The [source] is empty.</span>")
 		return
-//using handfuls; and filling internal mags has no delay.
+	
+	//using handfuls; and filling internal mags has no delay.
 	if(!istype(source, /obj/item/ammo_magazine/handful) && !istype(src, /obj/item/ammo_magazine/internal) ) 
 		to_chat(user, "<span class='notice'>You start refilling [src] with [source].</span>")
 		if(!do_after(user, 1.5 SECONDS, TRUE, src, BUSY_ICON_GENERIC))
@@ -105,14 +106,17 @@ They're all essentially identical when it comes to getting the job done.
 
 	to_chat(user, "<span class='notice'>You refill [src] with [source].</span>")
 
-	var/S = min(transfer_amount, max_rounds - current_rounds)
+	var/S = clamp(min(transfer_amount, max_rounds - current_rounds), 0, source.current_rounds)
 	source.current_rounds -= S
 	current_rounds += S
+	
 	if(source.current_rounds <= 0 && istype(source, /obj/item/ammo_magazine/handful)) //We want to delete it if it's a handful.
 		if(user)
 			user.temporarilyRemoveItemFromInventory(source)
 		qdel(source) //Dangerous. Can mean future procs break if they reference the source. Have to account for this.
-	else source.update_icon()
+	else 
+		source.update_icon()
+	
 	update_icon(S)
 	return S // We return the number transferred if it was successful.
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #4553 

Small code change that makes sure we use correct amounts of ammo when transferring between two magazines. The bug was due to async behavior (do_after()) not being considered when the player would spam the transfer action. Includes minor formatting cleanup.

## Why It's Good For The Game

No more mag transfer craziness

## Changelog
:cl:
fix: fixed magazine ammo transfer bug
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
