### PR TITLE
Praetorian Acid Spray Nerf

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -16,7 +16,7 @@
 	if(!istype(target)) //Something went horribly wrong. Clicked off edge of map probably
 		return
 
-	if(!do_after(X, 5, TRUE, target, BUSY_ICON_DANGER))
+	if(!do_after(X, 8, TRUE, target, BUSY_ICON_DANGER))
 		return fail_activate()
 
 	if(!can_use_ability(A, TRUE, override_flags = XACT_IGNORE_SELECTED_ABILITY))


### PR DESCRIPTION
## Why It's Good For The Game

The praetorian Acid spray is slightly overtuned in my opinion. This slight increase in the windup should help bring it back in line.

## Changelog
:cl:
balance: changed windup on Praetorian acid spray from 5 to 8
/:cl:

