### PR TITLE
Ports runechat subsystem from TG

### DIFF
--- a/code/__DEFINES/_subsystems.dm
+++ b/code/__DEFINES/_subsystems.dm
@@ -92,6 +92,7 @@
 #define FIRE_PRIORITY_TGUI			110
 #define FIRE_PRIORITY_TICKER		200
 #define FIRE_PRIORITY_CHAT			400
+#define FIRE_PRIORITY_RUNECHAT		410
 #define FIRE_PRIORITY_OVERLAYS		500
 #define FIRE_PRIORITY_EXPLOSIONS	666
 #define FIRE_PRIORITY_INPUT			1000 // This must always always be the max highest priority. Player input must never be lost.

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -17,33 +17,44 @@
 //Checks for specific types in specifically structured (Assoc "type" = TRUE) lists ('typecaches')
 #define is_type_in_typecache(A, L) (A && length(L) && L[(ispath(A) ? A : A:type)])
 
-// binary search sorted insert
-// IN: Object to be inserted
-// LIST: List to insert object into
-// TYPECONT: The typepath of the contents of the list
-// COMPARE: The variable on the objects to compare
-#define BINARY_INSERT(IN, LIST, TYPECONT, COMPARE) \
-	var/__BIN_CTTL = length(LIST);\
-	if(!__BIN_CTTL) {\
-		LIST += IN;\
-	} else {\
-		var/__BIN_LEFT = 1;\
-		var/__BIN_RIGHT = __BIN_CTTL;\
-		var/__BIN_MID = (__BIN_LEFT + __BIN_RIGHT) >> 1;\
-		var/##TYPECONT/__BIN_ITEM;\
-		while(__BIN_LEFT < __BIN_RIGHT) {\
-			__BIN_ITEM = LIST[__BIN_MID];\
-			if(__BIN_ITEM.##COMPARE <= IN.##COMPARE) {\
-				__BIN_LEFT = __BIN_MID + 1;\
-			} else {\
-				__BIN_RIGHT = __BIN_MID;\
+/// Passed into BINARY_INSERT to compare keys
+#define COMPARE_KEY __BIN_LIST[__BIN_MID]
+/// Passed into BINARY_INSERT to compare values
+#define COMPARE_VALUE __BIN_LIST[__BIN_LIST[__BIN_MID]]
+
+/****
+	* Binary search sorted insert
+	* INPUT: Object to be inserted
+	* LIST: List to insert object into
+	* TYPECONT: The typepath of the contents of the list
+	* COMPARE: The object to compare against, usualy the same as INPUT
+	* COMPARISON: The variable on the objects to compare
+	*/
+#define BINARY_INSERT(INPUT, LIST, TYPECONT, COMPARE, COMPARISON, COMPTYPE) \
+	do {\
+		var/list/__BIN_LIST = LIST;\
+		var/__BIN_CTTL = length(__BIN_LIST);\
+		if(!__BIN_CTTL) {\
+			__BIN_LIST += INPUT;\
+		} else {\
+			var/__BIN_LEFT = 1;\
+			var/__BIN_RIGHT = __BIN_CTTL;\
+			var/__BIN_MID = (__BIN_LEFT + __BIN_RIGHT) >> 1;\
+			var/##TYPECONT/__BIN_ITEM;\
+			while(__BIN_LEFT < __BIN_RIGHT) {\
+				__BIN_ITEM = COMPTYPE;\
+				if(__BIN_ITEM.##COMPARISON <= COMPARE.##COMPARISON) {\
+					__BIN_LEFT = __BIN_MID + 1;\
+				} else {\
+					__BIN_RIGHT = __BIN_MID;\
+				};\
+				__BIN_MID = (__BIN_LEFT + __BIN_RIGHT) >> 1;\
 			};\
-			__BIN_MID = (__BIN_LEFT + __BIN_RIGHT) >> 1;\
+			__BIN_ITEM = COMPTYPE;\
+			__BIN_MID = __BIN_ITEM.##COMPARISON > COMPARE.##COMPARISON ? __BIN_MID : __BIN_MID + 1;\
+			__BIN_LIST.Insert(__BIN_MID, INPUT);\
 		};\
-		__BIN_ITEM = LIST[__BIN_MID];\
-		__BIN_MID = __BIN_ITEM.##COMPARE > IN.##COMPARE ? __BIN_MID : __BIN_MID + 1;\
-		LIST.Insert(__BIN_MID, IN);\
-	}
+	} while(FALSE)
 
 
 //Returns a list in plain english as a string

--- a/code/controllers/subsystem/runechat.dm
+++ b/code/controllers/subsystem/runechat.dm
@@ -1,0 +1,226 @@
+/// Controls how many buckets should be kept, each representing a tick. (30 seconds worth)
+#define BUCKET_LEN (world.fps * 1 * 30)
+/// Helper for getting the correct bucket for a given chatmessage
+#define BUCKET_POS(scheduled_destruction) (((round((scheduled_destruction - SSrunechat.head_offset) / world.tick_lag) + 1) % BUCKET_LEN) || BUCKET_LEN)
+/// Gets the maximum time at which messages will be handled in buckets, used for deferring to secondary queue
+#define BUCKET_LIMIT (world.time + TICKS2DS(min(BUCKET_LEN - (SSrunechat.practical_offset - DS2TICKS(world.time - SSrunechat.head_offset)) - 1, BUCKET_LEN - 1)))
+
+/**
+  * # Runechat Subsystem
+  *
+  * Maintains a timer-like system to handle destruction of runechat messages. Much of this code is modeled
+  * after or adapted from the timer subsystem.
+  *
+  * Note that this has the same structure for storing and queueing messages as the timer subsystem does
+  * for handling timers: the bucket_list is a list of chatmessage datums, each of which are the head
+  * of a circularly linked list. Any given index in bucket_list could be null, representing an empty bucket.
+  */
+SUBSYSTEM_DEF(runechat)
+	name = "Runechat"
+	flags = SS_TICKER | SS_NO_INIT
+	wait = 1
+	priority = FIRE_PRIORITY_RUNECHAT
+
+	/// world.time of the first entry in the bucket list, effectively the 'start time' of the current buckets
+	var/head_offset = 0
+	/// Index of the first non-empty bucket
+	var/practical_offset = 1
+	/// world.tick_lag the bucket was designed for
+	var/bucket_resolution = 0
+	/// How many messages are in the buckets
+	var/bucket_count = 0
+	/// List of buckets, each bucket holds every message that has to be killed that byond tick
+	var/list/bucket_list = list()
+	/// Queue used for storing messages that are scheduled for deletion too far in the future for the buckets
+	var/list/datum/chatmessage/second_queue = list()
+
+/datum/controller/subsystem/runechat/PreInit()
+	bucket_list.len = BUCKET_LEN
+	head_offset = world.time
+	bucket_resolution = world.tick_lag
+
+/datum/controller/subsystem/runechat/stat_entry(msg)
+	..("ActMsgs:[bucket_count] SecQueue:[length(second_queue)]")
+
+/datum/controller/subsystem/runechat/fire(resumed = FALSE)
+	// Store local references to datum vars as it is faster to access them this way
+	var/list/bucket_list = src.bucket_list
+
+	if (MC_TICK_CHECK)
+		return
+
+	// Check for when we need to loop the buckets, this occurs when
+	// the head_offset is approaching BUCKET_LEN ticks in the past
+	if (practical_offset > BUCKET_LEN)
+		head_offset += TICKS2DS(BUCKET_LEN)
+		practical_offset = 1
+		resumed = FALSE
+
+	// Store a reference to the 'working' chatmessage so that we can resume if the MC
+	// has us stop mid-way through processing
+	var/static/datum/chatmessage/cm
+	if (!resumed)
+		cm = null
+
+	// Iterate through each bucket starting from the practical offset
+	while (practical_offset <= BUCKET_LEN && head_offset + ((practical_offset - 1) * world.tick_lag) <= world.time)
+		var/datum/chatmessage/bucket_head = bucket_list[practical_offset]
+		if (!cm || !bucket_head || cm == bucket_head)
+			bucket_head = bucket_list[practical_offset]
+			cm = bucket_head
+
+		while (cm)
+			// If the chatmessage hasn't yet had its life ended then do that now
+			var/datum/chatmessage/next = cm.next
+			if (!cm.eol_complete)
+				cm.end_of_life()
+			else if (!QDELETED(cm)) // otherwise if we haven't deleted it yet, do so (this is after EOL completion)
+				qdel(cm)
+
+			if (MC_TICK_CHECK)
+				return
+
+			// Break once we've processed the entire bucket
+			cm = next
+			if (cm == bucket_head)
+				break
+
+		// Empty the bucket, check if anything in the secondary queue should be shifted to this bucket
+		bucket_list[practical_offset++] = null
+		var/i = 0
+		for (i in 1 to length(second_queue))
+			cm = second_queue[i]
+			if (cm.scheduled_destruction >= BUCKET_LIMIT)
+				i--
+				break
+
+			// Transfer the message into the bucket, performing necessary circular doubly-linked list operations
+			bucket_count++
+			var/bucket_pos = max(1, BUCKET_POS(cm.scheduled_destruction))
+			var/datum/timedevent/head = bucket_list[bucket_pos]
+			if (!head)
+				bucket_list[bucket_pos] = cm
+				cm.next = null
+				cm.prev = null
+				continue
+
+			if (!head.prev)
+				head.prev = head
+			cm.next = head
+			cm.prev = head.prev
+			cm.next.prev = cm
+			cm.prev.next = cm
+		if (i)
+			second_queue.Cut(1, i + 1)
+		cm = null
+
+/datum/controller/subsystem/runechat/Recover()
+	bucket_list |= SSrunechat.bucket_list
+	second_queue |= SSrunechat.second_queue
+
+/**
+  * Enters the runechat subsystem with this chatmessage, inserting it into the end-of-life queue
+  *
+  * This will also account for a chatmessage already being registered, and in which case
+  * the position will be updated to remove it from the previous location if necessary
+  *
+  * Arguments:
+  * * new_sched_destruction Optional, when provided is used to update an existing message with the new specified time
+  */
+/datum/chatmessage/proc/enter_subsystem(new_sched_destruction = 0)
+	// Get local references from subsystem as they are faster to access than the datum references
+	var/list/bucket_list = SSrunechat.bucket_list
+	var/list/second_queue = SSrunechat.second_queue
+
+	// When necessary, de-list the chatmessage from its previous position
+	if (new_sched_destruction)
+		if (scheduled_destruction >= BUCKET_LIMIT)
+			second_queue -= src
+		else
+			SSrunechat.bucket_count--
+			var/bucket_pos = BUCKET_POS(scheduled_destruction)
+			if (bucket_pos > 0)
+				var/datum/chatmessage/bucket_head = bucket_list[bucket_pos]
+				if (bucket_head == src)
+					bucket_list[bucket_pos] = next
+			if (prev != next)
+				prev.next = next
+				next.prev = prev
+			else
+				prev?.next = null
+				next?.prev = null
+			prev = next = null
+		scheduled_destruction = new_sched_destruction
+
+	// Ensure the scheduled destruction time is properly bound to avoid missing a scheduled event
+	scheduled_destruction = max(CEILING(scheduled_destruction, world.tick_lag), world.time + world.tick_lag)
+
+	// Handle insertion into the secondary queue if the required time is outside our tracked amounts
+	if (scheduled_destruction >= BUCKET_LIMIT)
+		BINARY_INSERT(src, SSrunechat.second_queue, datum/chatmessage, src, scheduled_destruction, COMPARE_KEY)
+		return
+
+	// Get bucket position and a local reference to the datum var, it's faster to access this way
+	var/bucket_pos = BUCKET_POS(scheduled_destruction)
+
+	// Get the bucket head for that bucket, increment the bucket count
+	var/datum/chatmessage/bucket_head = bucket_list[bucket_pos]
+	SSrunechat.bucket_count++
+
+	// If there is no existing head of this bucket, we can set this message to be that head
+	if (!bucket_head)
+		bucket_list[bucket_pos] = src
+		return
+
+	// Otherwise it's a simple insertion into the circularly doubly-linked list
+	if (!bucket_head.prev)
+		bucket_head.prev = bucket_head
+	next = bucket_head
+	prev = bucket_head.prev
+	next.prev = src
+	prev.next = src
+
+
+/**
+  * Removes this chatmessage datum from the runechat subsystem
+  */
+/datum/chatmessage/proc/leave_subsystem()
+	// Attempt to find the bucket that contains this chat message
+	var/bucket_pos = BUCKET_POS(scheduled_destruction)
+
+	// Get local references to the subsystem's vars, faster than accessing on the datum
+	var/list/bucket_list = SSrunechat.bucket_list
+	var/list/second_queue = SSrunechat.second_queue
+
+	// Attempt to get the head of the bucket
+	var/datum/chatmessage/bucket_head
+	if (bucket_pos > 0)
+		bucket_head = bucket_list[bucket_pos]
+
+	// Decrement the number of messages in buckets if the message is
+	// the head of the bucket, or has a SD less than BUCKET_LIMIT implying it fits
+	// into an existing bucket, or is otherwise not present in the secondary queue
+	if(bucket_head == src)
+		bucket_list[bucket_pos] = next
+		SSrunechat.bucket_count--
+	else if(scheduled_destruction < BUCKET_LIMIT)
+		SSrunechat.bucket_count--
+	else
+		var/l = length(second_queue)
+		second_queue -= src
+		if(l == length(second_queue))
+			SSrunechat.bucket_count--
+
+	// Remove the message from the bucket, ensuring to maintain
+	// the integrity of the bucket's list if relevant
+	if(prev != next)
+		prev.next = next
+		next.prev = prev
+	else
+		prev?.next = null
+		next?.prev = null
+	prev = next = null
+
+#undef BUCKET_LEN
+#undef BUCKET_POS
+#undef BUCKET_LIMIT

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -46,7 +46,7 @@ SUBSYSTEM_DEF(timer)
 
 	if(lit && lit < last_check && head_offset < last_check && last_invoke_warning < last_check)
 		last_invoke_warning = world.time
-		var/msg = "No regular timers processed in the last [BUCKET_LEN * 1.5] ticks[bucket_auto_reset ? ", resetting buckets" : ""]."
+		var/msg = "No regular timers processed in the last [BUCKET_LEN*1.5] ticks[bucket_auto_reset ? ", resetting buckets" : ""]!"
 		message_admins(msg)
 		WARNING(msg)
 		if(bucket_auto_reset)
@@ -94,7 +94,7 @@ SUBSYSTEM_DEF(timer)
 		if(ctime_timer.flags & TIMER_LOOP)
 			ctime_timer.spent = 0
 			ctime_timer.timeToRun = REALTIMEOFDAY + ctime_timer.wait
-			BINARY_INSERT(ctime_timer, clienttime_timers, datum/timedevent, timeToRun)
+			BINARY_INSERT(ctime_timer, clienttime_timers, datum/timedevent, ctime_timer, timeToRun, COMPARE_KEY)
 		else
 			qdel(ctime_timer)
 
@@ -279,7 +279,7 @@ SUBSYSTEM_DEF(timer)
 
 
 		if (!timer.callBack || timer.spent)
-			stack_trace("Invalid timer: [get_timer_debug_string(timer)] world.time: [world.time], head_offset: [head_offset], practical_offset: [practical_offset]")
+			WARNING("Invalid timer: [get_timer_debug_string(timer)] world.time: [world.time], head_offset: [head_offset], practical_offset: [practical_offset]")
 			if (timer.callBack)
 				qdel(timer)
 			continue
@@ -423,7 +423,7 @@ SUBSYSTEM_DEF(timer)
 		L = SStimer.second_queue
 
 	if(L)
-		BINARY_INSERT(src, L, datum/timedevent, timeToRun)
+		BINARY_INSERT(src, L, datum/timedevent, src, timeToRun, COMPARE_KEY)
 		return
 
 	//get the list of buckets
@@ -447,6 +447,7 @@ SUBSYSTEM_DEF(timer)
 	next.prev = src
 	prev.next = src
 
+///Returns a string of the type of the callback for this timer
 /datum/timedevent/proc/getcallingtype()
 	. = "ERROR"
 	if (callBack.object == GLOBAL_PROC)
@@ -454,6 +455,14 @@ SUBSYSTEM_DEF(timer)
 	else
 		. = "[callBack.object.type]"
 
+/**
+  * Create a new timer and insert it in the queue
+  *
+  * Arguments:
+  * * callback the callback to call on timer finish
+  * * wait deciseconds to run the timer for
+  * * flags flags for this timer, see: code\__DEFINES\subsystems.dm
+  */
 /proc/addtimer(datum/callback/callback, wait = 0, flags = 0)
 	if (!callback)
 		CRASH("addtimer called without a callback")
@@ -498,6 +507,12 @@ SUBSYSTEM_DEF(timer)
 	var/datum/timedevent/timer = new(callback, wait, flags, hash)
 	return timer.id
 
+/**
+  * Delete a timer
+  *
+  * Arguments:
+  * * id a timerid or a /datum/timedevent
+  */
 /proc/deltimer(id)
 	if (!id)
 		return FALSE
@@ -514,7 +529,12 @@ SUBSYSTEM_DEF(timer)
 		return TRUE
 	return FALSE
 
-// How long left on a timer
+/**
+  * Get the remaining deciseconds on a timer
+  *
+  * Arguments:
+  * * id a timerid or a /datum/timedevent
+  */
 /proc/timeleft(id)
 	if (!id)
 		return null

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -20,10 +20,16 @@
 	var/atom/message_loc
 	/// The client who heard this message
 	var/client/owned_by
-	/// Contains the scheduled destruction time
+	/// Contains the scheduled destruction time, used for scheduling EOL
 	var/scheduled_destruction
+	/// Contains the time that the EOL for the message will be complete, used for qdel scheduling
+	var/eol_complete
 	/// Contains the approximate amount of lines for height decay
 	var/approx_lines
+	/// Contains the reference to the next chatmessage in the bucket, used by runechat subsystem
+	var/datum/chatmessage/next
+	/// Contains the reference to the previous chatmessage in the bucket, used by runechat subsystem
+	var/datum/chatmessage/prev
 
 /**
   * Constructs a chat message overlay
@@ -53,6 +59,7 @@
 	owned_by = null
 	message_loc = null
 	message = null
+	leave_subsystem()
 	return ..()
 
 
@@ -134,11 +141,13 @@
 			var/datum/chatmessage/m = msg
 			animate(m.message, pixel_y = m.message.pixel_y + mheight, time = CHAT_MESSAGE_SPAWN_TIME)
 			combined_height += m.approx_lines
+
+			// When choosing to update the remaining time we have to be careful not to update the
+			// scheduled time once the EOL completion time has been set.
 			var/sched_remaining = m.scheduled_destruction - world.time
-			if (sched_remaining > CHAT_MESSAGE_SPAWN_TIME)
+			if (!m.eol_complete)
 				var/remaining_time = (sched_remaining) * (CHAT_MESSAGE_EXP_DECAY ** idx++) * (CHAT_MESSAGE_HEIGHT_DECAY ** combined_height)
-				m.scheduled_destruction = world.time + remaining_time
-				addtimer(CALLBACK(m, .proc/end_of_life), remaining_time, TIMER_UNIQUE|TIMER_OVERRIDE)
+				m.enter_subsystem(world.time + remaining_time) // push updated time to runechat SS
 
 	// Build message image
 	message = image(loc = message_loc, layer = CHAT_LAYER)
@@ -156,16 +165,17 @@
 	owned_by.images |= message
 	animate(message, alpha = 255, time = CHAT_MESSAGE_SPAWN_TIME)
 
-	// Prepare for destruction
+	// Register with the runechat SS to handle EOL and destruction
 	scheduled_destruction = world.time + (lifespan - CHAT_MESSAGE_EOL_FADE)
-	addtimer(CALLBACK(src, .proc/end_of_life), lifespan - CHAT_MESSAGE_EOL_FADE, TIMER_UNIQUE|TIMER_OVERRIDE)
+	enter_subsystem()
 
 /**
   * Applies final animations to overlay CHAT_MESSAGE_EOL_FADE deciseconds prior to message deletion
   */
 /datum/chatmessage/proc/end_of_life(fadetime = CHAT_MESSAGE_EOL_FADE)
+	eol_complete = scheduled_destruction + fadetime
 	animate(message, alpha = 0, time = fadetime, flags = ANIMATION_PARALLEL)
-	QDEL_IN(src, fadetime)
+	enter_subsystem(eol_complete) // re-enter the runechat SS with the EOL completion time to QDEL self
 
 /**
   * Creates a message overlay at a defined location for a given speaker

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -206,6 +206,7 @@
 #include "code\controllers\subsystem\ping.dm"
 #include "code\controllers\subsystem\points.dm"
 #include "code\controllers\subsystem\radio.dm"
+#include "code\controllers\subsystem\runechat.dm"
 #include "code\controllers\subsystem\server_maint.dm"
 #include "code\controllers\subsystem\shuttle.dm"
 #include "code\controllers\subsystem\stickyban.dm"


### PR DESCRIPTION
Original PR https://github.com/tgstation/tgstation/pull/52425

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This replaces all use of timers for Runechat with a dedicated subsystem. This subsystem uses a similar approach to the timer subsystem, with an event queue that is broken up into buckets for each tick and those buckets just being a circular doubly-linked list. The result is zero dependence on timers.

This is a tad experimental, comments welcome.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Moves Runechat into a more controllable and monitor-able state, removes any overhead that may be related to timers. Should reduce memory overhead of this system in particular as this was implemented with no additional datums.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: bobbahbrown
add: Runechat now runs under its own subsystem, this should improve performance and allow for finer control over its performance.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
