### PR TITLE
Allows synths to use the hydro cannon

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1620,7 +1620,7 @@ Defined in conflicts.dm of the #defines folder.
 	icon_state = ""
 	attach_icon = ""
 	slot = "under"
-	flags_attach_features = ATTACH_ACTIVATION|ATTACH_UTILITY
+	flags_attach_features = ATTACH_ACTIVATION|ATTACH_UTILITY|GUN_ALLOW_SYNTHETIC
 	attachment_action_type = /datum/action/item_action/toggle
 
 /obj/item/attachable/hydro_cannon/activate_attachment(mob/living/user, turn_off)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows synths to use the hydro cannon attachment on the flamer. Not the flamer itself. Synths cannot use a flamethrower with this. Just the underbarrel extinguisher. 

## Why It's Good For The Game

Gives synths another option for helping marines via extinguisher without giving them another option for fighting xenos. 
## Changelog
:cl:
tweak: Synths can use hydro cannon
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
