### PR TITLE
fix IB cure with bica overdose mechanic

### DIFF
--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -541,7 +541,11 @@ Note that amputating the affected organ does in fact remove the infection from t
 				W.open_wound(0.1 * wound_update_accuracy)
 			if(bicardose >= 30)	//overdose of bicaridine begins healing IB
 				W.damage = max(0, W.damage - 0.2)
-
+			
+			if(W.damage <= 0)
+				wounds -= W // otherwise we are stuck with a 0 damage IB for a while
+				continue
+			
 			if(!owner.reagents.get_reagent_amount(/datum/reagent/medicine/quickclot)) //Quickclot stops bleeding, magic!
 				owner.blood_volume = max(0, owner.blood_volume - wound_update_accuracy * W.damage/40) //line should possibly be moved to handle_blood, so all the bleeding stuff is in one place.
 				if(prob(1 * wound_update_accuracy))


### PR DESCRIPTION
## About The Pull Request

This is a minor code change that makes curing IB using a bicaridine overdose work as intended by removing the wound when it reaches 0 damage. Currently you can heal all the IB wound's damage but still have to wait for a total of 10 minutes before the wound is actually removed -  causing quite a bit of confusion. (note: we should probably refactor this function at some point)

## Why It's Good For The Game

Less confusion good

## Changelog
:cl:
fix: makes curing IB with bica OD work as intended
/:cl: