### PR TITLE
CentCom Galactic Ban DB

### DIFF
--- a/code/__DEFINES/rust_g.dm
+++ b/code/__DEFINES/rust_g.dm
@@ -1,12 +1,71 @@
 // rust_g.dm - DM API for rust_g extension library
-#define RUST_G "rust_g"
+//
+// To configure, create a `rust_g.config.dm` and set what you care about from
+// the following options:
+//
+// #define RUST_G "path/to/rust_g"
+// Override the .dll/.so detection logic with a fixed path or with detection
+// logic of your own.
+//
+// #define RUSTG_OVERRIDE_BUILTINS
+// Enable replacement rust-g functions for certain builtins. Off by default.
+
+#ifndef RUST_G
+// Default automatic RUST_G detection.
+// On Windows, looks in the standard places for `rust_g.dll`.
+// On Linux, looks in `.`, `$LD_LIBRARY_PATH`, and `~/.byond/bin` for either of
+// `librust_g.so` (preferred) or `rust_g` (old).
+
+/* This comment bypasses grep checks */ /var/__rust_g
+
+/proc/__detect_rust_g()
+	if (world.system_type == UNIX)
+		if (fexists("./librust_g.so"))
+			// No need for LD_LIBRARY_PATH badness.
+			return __rust_g = "./librust_g.so"
+		else if (fexists("./rust_g"))
+			// Old dumb filename.
+			return __rust_g = "./rust_g"
+		else if (fexists("[world.GetConfig("env", "HOME")]/.byond/bin/rust_g"))
+			// Old dumb filename in `~/.byond/bin`.
+			return __rust_g = "rust_g"
+		else
+			// It's not in the current directory, so try others
+			return __rust_g = "librust_g.so"
+	else
+		return __rust_g = "rust_g"
+
+#define RUST_G (__rust_g || __detect_rust_g())
+#endif
+
+#define RUSTG_JOB_NO_RESULTS_YET "NO RESULTS YET"
+#define RUSTG_JOB_NO_SUCH_JOB "NO SUCH JOB"
+#define RUSTG_JOB_ERROR "JOB PANICKED"
 
 #define rustg_dmi_strip_metadata(fname) call(RUST_G, "dmi_strip_metadata")(fname)
+#define rustg_dmi_create_png(path, width, height, data) call(RUST_G, "dmi_create_png")(path, width, height, data)
+
+#define rustg_noise_get_at_coordinates(seed, x, y) call(RUST_G, "noise_get_at_coordinates")(seed, x, y)
 
 #define rustg_git_revparse(rev) call(RUST_G, "rg_git_revparse")(rev)
 #define rustg_git_commit_date(rev) call(RUST_G, "rg_git_commit_date")(rev)
 
-#define rustg_log_write(fname, text) call(RUST_G, "log_write")(fname, text)
+#define rustg_log_write(fname, text, format) call(RUST_G, "log_write")(fname, text, format)
+/proc/rustg_log_close_all() return call(RUST_G, "log_close_all")()
 
-/proc/rustg_log_close_all()
-	return call(RUST_G, "log_close_all")()
+#define RUSTG_HTTP_METHOD_GET "get"
+#define RUSTG_HTTP_METHOD_PUT "put"
+#define RUSTG_HTTP_METHOD_DELETE "delete"
+#define RUSTG_HTTP_METHOD_PATCH "patch"
+#define RUSTG_HTTP_METHOD_HEAD "head"
+#define RUSTG_HTTP_METHOD_POST "post"
+#define rustg_http_request_blocking(method, url, body, headers) call(RUST_G, "http_request_blocking")(method, url, body, headers)
+#define rustg_http_request_async(method, url, body, headers) call(RUST_G, "http_request_async")(method, url, body, headers)
+#define rustg_http_check_request(req_id) call(RUST_G, "http_check_request")(req_id)
+
+#define rustg_sql_connect_pool(options) call(RUST_G, "sql_connect_pool")(options)
+#define rustg_sql_query_async(handle, query, params) call(RUST_G, "sql_query_async")(handle, query, params)
+#define rustg_sql_query_blocking(handle, query, params) call(RUST_G, "sql_query_blocking")(handle, query, params)
+#define rustg_sql_connected(handle) call(RUST_G, "sql_connected")(handle)
+#define rustg_sql_disconnect_pool(handle) call(RUST_G, "sql_disconnect_pool")(handle)
+#define rustg_sql_check_query(job_id) call(RUST_G, "sql_check_query")("[job_id]")

--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -6,13 +6,20 @@
 #define SEND_TEXT(target, text) DIRECT_OUTPUT(target, text)
 #define WRITE_FILE(file, text) DIRECT_OUTPUT(file, text)
 #define READ_FILE(file, text) DIRECT_INPUT(file, text)
-#define WRITE_LOG(log, text) rustg_log_write(log, text)
-
+//This is an external call, "true" and "false" are how rust parses out booleans
+#define WRITE_LOG(log, text) rustg_log_write(log, text, "true")
+#define WRITE_LOG_NO_FORMAT(log, text) rustg_log_write(log, text, "false")
 
 //print a warning message to world.log
-#define WARNING(MSG) warning("[MSG] in [__FILE__] at line [__LINE__] src: [src] usr: [usr].")
+#define WARNING(MSG) warning("[MSG] in [__FILE__] at line [__LINE__] src: [UNLINT(src)] usr: [usr].")
 /proc/warning(msg)
 	msg = "## WARNING: [msg]"
+	log_world(msg)
+
+//not an error or a warning, but worth to mention on the world log, just in case.
+#define NOTICE(MSG) notice(MSG)
+/proc/notice(msg)
+	msg = "## NOTICE: [msg]"
 	log_world(msg)
 
 #ifdef UNIT_TESTS
@@ -191,8 +198,8 @@
 /proc/log_paper(text)
 	WRITE_LOG(GLOB.world_paper_log, "PAPER: [text]")
 
-/* ui logging */ 
- 
+/* ui logging */
+
 /proc/log_tgui(text)
 	WRITE_LOG(GLOB.tgui_log, text)
 

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -29,6 +29,8 @@ Basics, the most important.
 
 /datum/config_entry/string/dburl
 
+/// URL for the CentCom Galactic Ban DB API
+/datum/config_entry/string/centcom_ban_db
 
 /// Host of the webmap
 /datum/config_entry/string/webmap_host

--- a/code/datums/http.dm
+++ b/code/datums/http.dm
@@ -1,0 +1,74 @@
+/datum/http_request
+	var/id
+	var/in_progress = FALSE
+
+	var/method
+	var/body
+	var/headers
+	var/url
+
+	var/_raw_response
+
+/datum/http_request/proc/prepare(method, url, body = "", list/headers)
+	if (!length(headers))
+		headers = ""
+	else
+		headers = json_encode(headers)
+
+	src.method = method
+	src.url = url
+	src.body = body
+	src.headers = headers
+
+/datum/http_request/proc/execute_blocking()
+	_raw_response = rustg_http_request_blocking(method, url, body, headers)
+
+/datum/http_request/proc/begin_async()
+	if (in_progress)
+		CRASH("Attempted to re-use a request object.")
+
+	id = rustg_http_request_async(method, url, body, headers)
+
+	if (isnull(text2num(id)))
+		stack_trace("Proc error: [id]")
+		_raw_response = "Proc error: [id]"
+	else
+		in_progress = TRUE
+
+/datum/http_request/proc/is_complete()
+	if (isnull(id))
+		return TRUE
+
+	if (!in_progress)
+		return TRUE
+
+	var/r = rustg_http_check_request(id)
+
+	if (r == RUSTG_JOB_NO_RESULTS_YET)
+		return FALSE
+	else
+		_raw_response = r
+		in_progress = FALSE
+		return TRUE
+
+/datum/http_request/proc/into_response()
+	var/datum/http_response/R = new()
+
+	try
+		var/list/L = json_decode(_raw_response)
+		R.status_code = L["status_code"]
+		R.headers = L["headers"]
+		R.body = L["body"]
+	catch
+		R.errored = TRUE
+		R.error = _raw_response
+
+	return R
+
+/datum/http_response
+	var/status_code
+	var/body
+	var/list/headers
+
+	var/errored = FALSE
+	var/error

--- a/code/modules/admin/panels/player_panel.dm
+++ b/code/modules/admin/panels/player_panel.dm
@@ -402,7 +402,7 @@
 
 	body += "<b>CentCom Galactic Ban DB: </b> "
 	if(CONFIG_GET(string/centcom_ban_db))
-		body += "<a href='?_src_=holder;[HrefToken()];centcomlookup=[M.client.ckey]'>Search</a>"
+		body += "<a href='?_src_=holder;[HrefToken()];centcomlookup=[M?.ckey]'>Search for ([M?.ckey])</a>"
 	else
 		body += "<i>Disabled</i>"
 

--- a/code/modules/admin/panels/player_panel.dm
+++ b/code/modules/admin/panels/player_panel.dm
@@ -400,6 +400,13 @@
 
 	body += "<b>CID:</b> [M.computer_id] | <b>IP:</b> [M.ip_address]<br>"
 
+	body += "<b>CentCom Galactic Ban DB: </b> "
+	if(CONFIG_GET(string/centcom_ban_db))
+		body += "<a href='?_src_=holder;[HrefToken()];centcomlookup=[M.client.ckey]'>Search</a>"
+	else
+		body += "<i>Disabled</i>"
+
+	body += "<br><br>"
 	if(M.client)
 		body += "<a href='?src=[ref];playtime=[REF(M)]'>Playtime</a> | "
 		body += "<a href='?src=[ref];kick=[REF(M)]'>Kick</a> | "

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -77,6 +77,60 @@ Status: [status ? status : "Unknown"] | Damage: [health ? health : "None"]
 		var/mob/M = locate(href_list["playerpanel"])
 		show_player_panel(M)
 
+	else if(href_list["centcomlookup"])
+		if(!check_rights(R_ADMIN))
+			return
+
+		if(!CONFIG_GET(string/centcom_ban_db))
+			to_chat(usr, "<span class='warning'>Centcom Galactic Ban DB is disabled!</span>")
+			return
+
+		var/ckey = href_list["centcomlookup"]
+
+		// Make the request
+		var/datum/http_request/request = new()
+		request.prepare(RUSTG_HTTP_METHOD_GET, "[CONFIG_GET(string/centcom_ban_db)]/[ckey]", "", "")
+		request.begin_async()
+		UNTIL(request.is_complete() || !usr)
+		if (!usr)
+			return
+		var/datum/http_response/response = request.into_response()
+
+		var/list/bans
+
+		var/list/dat = list("<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'><body>")
+
+		if(response.errored)
+			dat += "<br>Failed to connect to CentCom."
+		else if(response.status_code != 200)
+			dat += "<br>Failed to connect to CentCom. Status code: [response.status_code]"
+		else
+			if(response.body == "[]")
+				dat += "<center><b>0 bans detected for [ckey]</b></center>"
+			else
+				bans = json_decode(response["body"])
+				dat += "<center><b>[bans.len] ban\s detected for [ckey]</b></center>"
+				for(var/list/ban in bans)
+					dat += "<b>Server: </b> [sanitize(ban["sourceName"])]<br>"
+					dat += "<b>RP Level: </b> [sanitize(ban["sourceRoleplayLevel"])]<br>"
+					dat += "<b>Type: </b> [sanitize(ban["type"])]<br>"
+					dat += "<b>Banned By: </b> [sanitize(ban["bannedBy"])]<br>"
+					dat += "<b>Reason: </b> [sanitize(ban["reason"])]<br>"
+					dat += "<b>Datetime: </b> [sanitize(ban["bannedOn"])]<br>"
+					var/expiration = ban["expires"]
+					dat += "<b>Expires: </b> [expiration ? "[sanitize(expiration)]" : "Permanent"]<br>"
+					if(ban["type"] == "job")
+						dat += "<b>Jobs: </b> "
+						var/list/jobs = ban["jobs"]
+						dat += sanitize(jobs.Join(", "))
+						dat += "<br>"
+					dat += "<hr>"
+
+		dat += "<br></body>"
+		var/datum/browser/popup = new(usr, "centcomlookup-[ckey]", "<div align='center'>Central Command Galactic Ban Database</div>", 700, 600)
+		popup.set_content(dat.Join())
+		popup.open(0)
+
 
 	else if(href_list["subtlemessage"])
 		var/mob/M = locate(href_list["subtlemessage"])

--- a/config/config.txt
+++ b/config/config.txt
@@ -21,7 +21,7 @@ ADMIN_LEGACY_SYSTEM
 ## Add a # infront of this to disable the shutdown server verb.
 ALLOW_SHUTDOWN
 
-## If you use /tg/station-server 3 and you want to allow the shutdown server verb, 
+## If you use /tg/station-server 3 and you want to allow the shutdown server verb,
 ##	the server needs to be able to tell tgs3 that the shutdown is not a crash.
 ## This should be the path to the TGCommandLine.exe program in your tgstation-server install.
 ## Defaults to C:\Program Files (x86)\TG Station Server\TGCommandLine.exe if not set.
@@ -47,13 +47,10 @@ PROTECT_LEGACY_RANKS
 #GITHUBURL
 #BANAPPEALS
 
-## Feel free to just uncomment these.
-#SHIPURL https://goo.gl/utUdpq
-#LV624URL https://goo.gl/6tuwfg
-#BIGREDURL https://goo.gl/TN7mmT
-#ICECOLONYURL https://goo.gl/KYKNgJ
-#PRISONSTATIONURL https://goo.gl/GXoxnA
-#WHISKEYOUTPOSTURL https://goo.gl/ZwTS5X
+## Uncomment to enable global ban DB using the provided URL. The API should expect to receive a ckey at the end of the URL.
+## More API details can be found here: https://centcom.melonmesa.com
+CENTCOM_BAN_DB https://centcom.melonmesa.com/ban/search
+
 
 ## Logging. Recommended you keep all of these on.
 LOG_OOC
@@ -91,7 +88,7 @@ LIMBS_CAN_BREAK
 ## Only enable this if you have youtube-dl installed!
 # INVOKE_YOUTUBEDL youtube-dl
 
-#Here are the lobby music configs. 
+#Here are the lobby music configs.
 #index link startSecond endSecond
 
 #Space Hero

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -235,6 +235,7 @@
 #include "code\datums\emotes.dm"
 #include "code\datums\fluff_emails.dm"
 #include "code\datums\holocall.dm"
+#include "code\datums\http.dm"
 #include "code\datums\map_config.dm"
 #include "code\datums\marine_main_ship.dm"
 #include "code\datums\materials.dm"


### PR DESCRIPTION
Ports https://github.com/tgstation/tgstation/pull/52588
Which ports https://github.com/BeeStation/BeeStation-Hornet/pull/2207


----


Admins will now be able to look up a player's bans from several other servers via the player panel.

My hope is that porting this to as many servers as possible will encourage more servers to make their bans publicly viewable so they can be included in this system. Direct access to a server's database is not required (or even supported).

Supported servers:

- BeeStation
- /vg/station
- OracleStation
- FTL13


Planned support (WIP):

- World Server
- Yogstation
- Halo: SSE
- Fulp(?)
- Any other server willing to make their bans publicly visible.

API: https://centcom.melonmesa.com
Source: https://github.com/bobbahbrown/CentCom



## Changelog
:cl: ike709 and bobbahbrown
add: Admins can now see your bans on (some) other servers.
/:cl: