### PR TITLE
Flamethrower Hugger Fix

### DIFF
--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -132,16 +132,16 @@
 
 /obj/effect/alien/resin/trap/flamer_fire_act()
 	if(hugger)
-		hugger.forceMove(loc)
 		hugger.kill_hugger()
+		hugger.forceMove(loc)
 		hugger = null
 		icon_state = "trap0"
 	..()
 
 /obj/effect/alien/resin/trap/fire_act()
 	if(hugger)
-		hugger.forceMove(loc)
 		hugger.kill_hugger()
+		hugger.forceMove(loc)
 		hugger = null
 		icon_state = "trap0"
 	..()


### PR DESCRIPTION
## About The Pull Request

Fixes flamers by letting them properly burn facehuggers popping out of burning egg traps. Changes a few lines in TerraGov-Marine-Corps/code/game/objects/structures/xeno.dm.

## Why It's Good For The Game

Program bugs bad. Working facehuggers good. Should help fix https://github.com/tgstation/TerraGov-Marine-Corps/issues/4596. 

## Changelog
:cl:
fix: fixed facehugger death not procing right on fire trigger in xeno.dm
/:cl:
