### PR TITLE
New xeno respawns on distress

### DIFF
--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -42,6 +42,7 @@
 #define MODE_LZ_SHUTTERS		(1<<6)
 #define MODE_XENO_SPAWN_PROTECT	(1<<7)
 #define MODE_XENO_RULER			(1<<8)
+#define MODE_XENO_RESPAWN_WAVE	(1<<9) /// Xenos will respawn in waves
 
 #define MODE_LANDMARK_RANDOM_ITEMS			(1<<0)
 #define MODE_LANDMARK_SPAWN_XENO_TUNNELS	(1<<1)

--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -85,7 +85,7 @@
 	priority_announce(SSmapping.configs[GROUND_MAP].announce_text, SSmapping.configs[SHIP_MAP].map_name)
 
 
-/datum/game_mode/infestation/disstress/spawn_resin_silos()
+/datum/game_mode/infestation/distress/spawn_resin_silos()
 	// Want a max of only 5 silos
 	var/all_silos = GLOB.xeno_resin_silo_turfs.Copy()
 	for(var/i in 1 to 5)

--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -113,9 +113,7 @@
 
 /datum/game_mode/infestation/distress/scale_burrowed_larva()
 	. = ..()
-	to_chat(world, "starting [larva_check_interval]")
 	larva_check_interval -= length(GLOB.xeno_resin_silos) * xeno_respawn_silo_reduction
-	to_chat(world, "finished [larva_check_interval] reduced by [length(GLOB.xeno_resin_silos) * xeno_respawn_silo_reduction]")
 
 /datum/game_mode/infestation/distress/check_finished()
 	if(round_finished)

--- a/code/datums/gamemodes/game_mode.dm
+++ b/code/datums/gamemodes/game_mode.dm
@@ -98,7 +98,9 @@
 
 
 /datum/game_mode/process()
-	return TRUE
+	if(round_finished)
+		return TRUE
+	return FALSE
 
 
 /datum/game_mode/proc/create_characters()
@@ -338,6 +340,7 @@ Sensors indicate [numXenosShip || "no"] unknown lifeform signature[numXenosShip 
 
 	for(var/i in GLOB.player_list)
 		var/mob/M = i
+		grant_eord_respawn(null, M)
 		if(isnewplayer(M))
 			continue
 		if(!(M.client?.prefs?.be_special & BE_DEATHMATCH))

--- a/code/datums/gamemodes/infestation.dm
+++ b/code/datums/gamemodes/infestation.dm
@@ -1,7 +1,7 @@
 /datum/game_mode/infestation
 	/// How often do the xenos get new larva to spawn from
 	var/larva_check_interval = 0
-	var/xeno_respawn_wave_timer = 30 SECONDS
+	var/xeno_respawn_wave_timer = 30 MINUTES
 	var/xeno_respawn_silo_reduction = 2 MINUTES
 
 /datum/game_mode/infestation/post_setup()

--- a/code/datums/gamemodes/infestation.dm
+++ b/code/datums/gamemodes/infestation.dm
@@ -1,4 +1,21 @@
 /datum/game_mode/infestation
+	/// How often do the xenos get new larva to spawn from
+	var/larva_check_interval = 0
+	var/xeno_respawn_wave_timer = 30 SECONDS
+	var/xeno_respawn_silo_reduction = 2 MINUTES
+
+/datum/game_mode/infestation/post_setup()
+	. = ..()
+	spawn_resin_silos()
+
+
+/datum/game_mode/infestation/process()
+	. = ..()
+	if(.)
+		return
+	// Burrowed Larva
+	if((flags_round_type & MODE_XENO_RESPAWN_WAVE) && world.time > larva_check_interval)
+		scale_burrowed_larva()
 
 /datum/game_mode/infestation/scale_roles()
 	. = ..()
@@ -6,3 +23,27 @@
 		return
 	var/datum/job/scaled_job = SSjob.GetJobType(/datum/job/terragov/squad/smartgunner)
 	scaled_job.job_points_needed  = 20 //For every 10 marine late joins, 1 extra SG
+
+/datum/game_mode/infestation/proc/spawn_resin_silos()
+	for(var/i in GLOB.xeno_resin_silo_turfs)
+		new /obj/structure/resin/silo(i)
+
+/datum/game_mode/infestation/proc/scale_burrowed_larva()
+	larva_check_interval = world.time + xeno_respawn_wave_timer
+
+	var/datum/hive_status/normal/xeno_hive = GLOB.hive_datums[XENO_HIVE_NORMAL]
+	var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
+	var/stored_larva = xeno_job.total_positions - xeno_job.current_positions
+	var/num_xenos = xeno_hive.get_total_xeno_number() + stored_larva
+	var/larvapoints = (get_total_joblarvaworth() - (num_xenos * xeno_job.job_points_needed )) / xeno_job.job_points_needed
+	if(!num_xenos)
+		if(!length(GLOB.xeno_resin_silos))
+			check_finished(TRUE)
+			return //RIP benos.
+		if(stored_larva)
+			return //No need for respawns nor to end the game. They can use their burrowed larvas.
+		xeno_job.add_job_positions(max(1, round(larvapoints, 1))) //At least one, rounded to nearest integer if more.
+		return
+	if(round(larvapoints, 1) < 1)
+		return //Things are balanced, no burrowed needed
+	xeno_job.add_job_positions(round(larvapoints, 1)) //However many burrowed they can afford to buy, rounded to nearest integer.


### PR DESCRIPTION

## About The Pull Request
Adds larva respawns for xenos on distress.
Starting at 15minutes reduced by 2 minutes for every active silo.

This uses the same larvapoints formula, so the number will never get too high.

## Why It's Good For The Game

comebacks and mistakes should be a thing.
Also marines get respawns, why not xenos.
Reduces pressure on getting a capture.


## Changelog
:cl:
add: Added respawns for xenos on distress, timed based on the number of silos available.
/:cl:
