### PR TITLE
Jerry cans will pour on resin better

### DIFF
--- a/code/game/objects/items/reagent_containers/jerrycan.dm
+++ b/code/game/objects/items/reagent_containers/jerrycan.dm
@@ -50,3 +50,8 @@
 	playsound(loc, 'sound/effects/refill.ogg', 25, 1, 3)
 	to_chat(user, "<span class='notice'>You refill [src] with [fuel_transfer_amount] units of fuel.</span>")
 	return ..()
+
+/obj/item/reagent_containers/jerrycan/attack_obj(obj/O, mob/living/user)
+	if(istype(O, /obj/effect/alien/weeds))
+		return attack_turf(get_turf(O), user)
+	return ..()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

closes https://github.com/tgstation/TerraGov-Marine-Corps/issues/4637
## Why It's Good For The Game

Having to not altclick to pour good

## Changelog
:cl:
fix: Jerry cans will now pour on resin
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
