### PR TITLE
Use unrelenting force via keybind instead of just selecting

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -139,6 +139,7 @@
 	mechanics_text = "Unleashes our raw psychic power, pushing aside anyone who stands in our path."
 	cooldown_timer = 50 SECONDS
 	plasma_cost = 300
+	keybind_flags = XACT_KEYBIND_USE_ABILITY | XACT_IGNORE_SELECTED_ABILITY
 	keybind_signal = COMSIG_XENOABILITY_UNRELENTING_FORCE
 
 
@@ -152,7 +153,8 @@
 	add_cooldown()
 	addtimer(CALLBACK(owner, /mob.proc/update_icons), 1 SECONDS)
 	owner.icon_state = "Shrike Screeching"
-	owner.face_atom(target)
+	if(target) // Keybind use doesn't have a target
+		owner.face_atom(target)
 
 	var/turf/lower_left
 	var/turf/upper_right


### PR DESCRIPTION

## About The Pull Request
When you use the keybind currently it just selects the ability for use.
Since all you need is a direction if you use via keybind you can just shout in that direction instead.
## Why It's Good For The Game

Playing shrike a little easier

## Changelog
:cl:
tweak: unrelenting force can be used directly from a keybinding
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
