### PR TITLE
Correctly set ground trait on maps

### DIFF
--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -116,11 +116,12 @@
 
 	traits = json["traits"]
 	if (islist(traits))
-		// "Station" is set by default, but it's assumed if you're setting
+		// "Ground" is set by default, but it's assumed if you're setting
 		// traits you want to customize which level is cross-linked
+		// we only set ground if not mainship
 		for (var/level in traits)
-			if (!(ZTRAIT_STATION in level))
-				level[ZTRAIT_STATION] = TRUE
+			if (!(ZTRAIT_GROUND in level) && !(ZTRAIT_MARINE_MAIN_SHIP in level))
+				level[ZTRAIT_GROUND] = TRUE
 	// "traits": null or absent -> default
 	else if (!isnull(traits))
 		log_world("map_config traits is not a list!")

--- a/code/modules/mapping/space_management/traits.dm
+++ b/code/modules/mapping/space_management/traits.dm
@@ -71,3 +71,8 @@
 /datum/controller/subsystem/mapping/proc/get_station_center()
 	var/station_z = levels_by_trait(ZTRAIT_STATION)[1]
 	return locate(round(world.maxx * 0.5, 1), round(world.maxy * 0.5, 1), station_z)
+
+// Prefer not to use this one too often
+/datum/controller/subsystem/mapping/proc/get_mainship_center()
+	var/mainship_z = levels_by_trait(ZTRAIT_MARINE_MAIN_SHIP)[1]
+	return locate(round(world.maxx * 0.5, 1), round(world.maxy * 0.5, 1), mainship_z)


### PR DESCRIPTION
## About The Pull Request
Since this is ported from tg station, it was setting station as the default for things with traits.
We want those to be ground though, as maps will set marine mainship if they are not.

This updates the map config for that.

## Changelog
:cl:
fix: fixes the map loader to assign the correct traits
/:cl:
