### PR TITLE
Makes fireman carry easier

### DIFF
--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -163,6 +163,9 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 
 #undef SKILLSID
 
+/datum/skills/proc/getPercent(rating, max_rating)
+	return CLAMP01(vars[rating] * 100 / max_rating * 0.01)
+
 /datum/skills/proc/getRating(rating)
 	return vars[rating]
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -37,6 +37,7 @@
 	RegisterSignal(src, list(COMSIG_KB_QUICKEQUIP, COMSIG_CLICK_QUICKEQUIP), .proc/do_quick_equip)
 	RegisterSignal(src, COMSIG_KB_HOLSTER, .proc/do_holster)
 	RegisterSignal(src, COMSIG_KB_UNIQUEACTION, .proc/do_unique_action)
+	RegisterSignal(src, COMSIG_GRAB_SELF_ATTACK, .proc/fireman_carry_grabbed) // Fireman carry
 	AddComponent(/datum/component/footstep, FOOTSTEP_MOB_HUMAN)
 
 /mob/living/carbon/human/proc/human_z_changed(datum/source, old_z, new_z)
@@ -757,15 +758,15 @@
 	return ..()
 
 
-/mob/living/carbon/human/mouse_buckle_handling(atom/movable/dropping, mob/living/user)
-	. = ..()
-	if(!isliving(.))
-		return
-	if(pulling == . && grab_state >= GRAB_AGGRESSIVE && stat == CONSCIOUS && user != . && can_be_firemanned(.))
+/mob/living/carbon/human/proc/fireman_carry_grabbed()
+	var/mob/living/grabbed = pulling
+	if(!istype(grabbed))
+		return NONE
+	if(/*grab_state >= GRAB_AGGRESSIVE &&*/ stat == CONSCIOUS && can_be_firemanned(grabbed))
 		//If you dragged them to you and you're aggressively grabbing try to fireman carry them
-		fireman_carry(.)
-		return TRUE
-	return FALSE
+		fireman_carry(grabbed)
+		return COMSIG_GRAB_SUCCESSFUL_SELF_ATTACK
+	return NONE
 
 //src is the user that will be carrying, target is the mob to be carried
 /mob/living/carbon/human/proc/can_be_firemanned(mob/living/carbon/target)
@@ -777,7 +778,8 @@
 		return
 	visible_message("<span class='notice'>[src] starts lifting [target] onto [p_their()] back...</span>",
 	"<span class='notice'>You start to lift [target] onto your back...</span>")
-	if(!do_mob(src, target, 5 SECONDS, target_display = BUSY_ICON_HOSTILE))
+	var/delay = 1 SECONDS + LERP(0 SECONDS, 4 SECONDS, skills.getPercent("medical", SKILL_MEDICAL_MASTER))
+	if(!do_mob(src, target, delay, target_display = BUSY_ICON_HOSTILE))
 		visible_message("<span class='warning'>[src] fails to fireman carry [target]!</span>")
 		return
 	//Second check to make sure they're still valid to be carried


### PR DESCRIPTION
## About The Pull Request
Makes doing a firemans carry easier
people with medical skills will be faster.

This makes it inline with what xenos do, keeping it consistent between mobs

Additionally adds a new getPercent for skills that should make it easier to see how much of a skill you have that can be lerp'd against.

## Changelog
:cl:
tweak: you now firemans carry people by dragging and clicking yourself.
/:cl:
