### PR TITLE
Revolver Rail light pixel fix

### DIFF
--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -370,7 +370,7 @@
 						/obj/item/attachable/scope,
 						/obj/item/attachable/lasersight,
 						/obj/item/attachable/scope/mini)
-	attachable_offset = list("muzzle_x" = 30, "muzzle_y" = 21,"rail_x" = 17, "rail_y" = 23, "under_x" = 22, "under_y" = 17, "stock_x" = 22, "stock_y" = 19)
+	attachable_offset = list("muzzle_x" = 30, "muzzle_y" = 21,"rail_x" = 17, "rail_y" = 22, "under_x" = 22, "under_y" = 17, "stock_x" = 22, "stock_y" = 19)
 
 //-------------------------------------------------------
 //RUSSIAN REVOLVER //Based on the 7.62mm Russian revolvers.


### PR DESCRIPTION

## About The Pull Request

One pixel lower

## Why It's Good For The Game

aaaahhhhh
![scream1](https://user-images.githubusercontent.com/45076386/89964346-86a80580-dc0f-11ea-938d-9dd04d12c234.PNG)

AHHHHHH
![scream2](https://user-images.githubusercontent.com/45076386/89964366-8e67aa00-dc0f-11ea-9878-33656baeacb4.PNG)

**AAAAAAAHHHHHHHH**
![scream3](https://user-images.githubusercontent.com/45076386/89964388-97f11200-dc0f-11ea-9e7f-f2e6a7dc4ad4.PNG)

phew
![ahhh](https://user-images.githubusercontent.com/45076386/89964397-9d4e5c80-dc0f-11ea-9205-655c29e2f093.PNG)


## Changelog
:cl: Hughgent
fix: Standard Revolver rail attachments no longer hover.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
