### PR TITLE
Adds a bluespace selling pad for requisitions 

### DIFF
--- a/code/game/objects/machinery/sellingpad.dm
+++ b/code/game/objects/machinery/sellingpad.dm
@@ -48,19 +48,13 @@
 	addtimer(VARSET_CALLBACK(src, use_power, IDLE_POWER_USE), 30 SECONDS)
 
 
-/obj/machinery/exportpad/attackby(obj/item/I, mob/user, params)
-	. = ..()
-
-	if(!ishuman(user))
-		return
-
-	if(iswrench(I))
-		anchored = !anchored
-		if(anchored)
-			to_chat(user, "You bolt the [src] to the ground, activating it.")
-			playsound(loc, 'sound/items/ratchet.ogg', 25, TRUE)
-			icon_state = "broadcaster"
-		else
-			to_chat(user, "You unbolt the [src] from the ground, deactivating it.")
-			playsound(loc, 'sound/items/ratchet.ogg', 25, TRUE)
-			icon_state = "broadcaster_off"
+/obj/machinery/exportpad/wrench_act(mob/living/user, obj/item/I)
+	anchored = !anchored
+	if(anchored)
+		to_chat(user, "You bolt the [src] to the ground, activating it.")
+		playsound(loc, 'sound/items/ratchet.ogg', 25, TRUE)
+		icon_state = "broadcaster"
+	else
+		to_chat(user, "You unbolt the [src] from the ground, deactivating it.")
+		playsound(loc, 'sound/items/ratchet.ogg', 25, TRUE)
+		icon_state = "broadcaster_off"

--- a/code/game/objects/machinery/sellingpad.dm
+++ b/code/game/objects/machinery/sellingpad.dm
@@ -1,0 +1,65 @@
+/obj/machinery/sellingpad
+	name = "ASRS Bluespace Selling Point"
+	desc = "A bluespace telepad for sending valuble assets, such as valuble minerals and alien corpses. It needs to be wrenched down in a powered area to function."
+	icon = 'icons/obj/machines/telecomms.dmi'
+	icon_state = "broadcaster_off"
+	density = FALSE
+	anchored = FALSE
+	use_power = IDLE_POWER_USE
+	wrenchable = TRUE
+	idle_power_usage = 300
+	active_power_usage = 300
+	var/selling_cooldown = 0
+
+
+/obj/machinery/sellingpad/attack_hand(mob/living/user)
+	. = ..()
+
+	if (!anchored)
+		to_chat(user, "<span class='warning'>Nothing happens. The [src] must be bolted to the ground first.</span>")
+		return
+
+	if (!powered())
+		to_chat(user, "<span class='warning'>A red light flashes on the [src]. It seems it doesn't have enough power.</span>")
+		playsound(loc,'sound/machines/buzz-two.ogg', 25, FALSE)
+		return
+
+	if(selling_cooldown > world.time)
+		to_chat(user, "<span class='warning'>The [src] is not ready to send yet!</span>")
+		return
+
+	for(var/i in get_turf(src))
+		var/atom/movable/onpad = i
+		if(!isxeno(onpad) && !istype(onpad,/obj/structure/ore_box))
+			continue
+		if(isxeno(onpad))
+			var/mob/living/carbon/xenomorph/sellxeno = onpad
+			if(sellxeno.stat != DEAD)
+				to_chat(user, "<span class='warning'>The [src] buzzes: Live animals cannot be sold.</span>")
+				continue
+
+		. = onpad.supply_export()
+		visible_message("<span class='notice'>The [src] buzzes: The [onpad] has been sold for [. ? . : "no"] point[. == 1 ? "" : "s"].</span>")
+		qdel(onpad)
+
+	do_sparks(5, TRUE, src)
+	playsound(loc,'sound/effects/phasein.ogg', 50, FALSE)
+	selling_cooldown = world.time + 15 SECONDS
+
+
+/obj/machinery/sellingpad/attackby(obj/item/I, mob/user, params)
+	. = ..()
+
+	if(!ishuman(user))
+		return
+
+	if(iswrench(I))
+		anchored = !anchored
+		if(anchored)
+			to_chat(user, "You bolt the [src] to the ground, activating it.")
+			playsound(loc, 'sound/items/ratchet.ogg', 25, 1)
+			icon_state = "broadcaster"
+		else
+			to_chat(user, "You unbolt the [src] from the ground, deactivating it.")
+			playsound(loc, 'sound/items/ratchet.ogg', 25, 1)
+			icon_state = "broadcaster_off"

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -70,9 +70,9 @@ OPERATIONS
 	contains = list(/obj/item/bodybag/tarp)
 	cost = 6
 
-/datum/supply_packs/operations/sellingpad
-	name = "ASRS Bluespace Selling Point"
-	contains = list(/obj/machinery/sellingpad)
+/datum/supply_packs/operations/exportpad
+	name = "ASRS Bluespace Export Point"
+	contains = list(/obj/machinery/exportpad)
 	cost = 50
 
 /datum/supply_packs/operations/alpha

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -70,6 +70,11 @@ OPERATIONS
 	contains = list(/obj/item/bodybag/tarp)
 	cost = 6
 
+/datum/supply_packs/operations/sellingpad
+	name = "ASRS Bluespace Selling Point"
+	contains = list(/obj/machinery/sellingpad)
+	cost = 50
+
 /datum/supply_packs/operations/alpha
 	name = "Alpha Supply Crate"
 	contains = list(/obj/structure/closet/crate/alpha)

--- a/code/modules/requisitions/_supply_export.dm
+++ b/code/modules/requisitions/_supply_export.dm
@@ -6,17 +6,24 @@
 	. = 3
 	SSpoints.supply_points += .
 
+/obj/structure/ore_box/phoron/supply_export()
+	. = 20
+	SSpoints.supply_points += .
+
+/obj/structure/ore_box/platinum/supply_export()
+	. = 40
+	SSpoints.supply_points += .
 
 /mob/living/carbon/xenomorph/supply_export()
 	switch(tier)
 		if(XENO_TIER_ZERO)
-			. = 1
+			. = 15
 		if(XENO_TIER_ONE)
-			. = 5
-		if(XENO_TIER_TWO)
-			. = 10
-		if(XENO_TIER_THREE)
 			. = 30
-		if(XENO_TIER_FOUR)
+		if(XENO_TIER_TWO)
+			. = 40
+		if(XENO_TIER_THREE)
 			. = 50
+		if(XENO_TIER_FOUR)
+			. = 100
 	SSpoints.supply_points += .

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -661,6 +661,7 @@
 #include "code\game\objects\machinery\scoreboard.dm"
 #include "code\game\objects\machinery\seed_extractor.dm"
 #include "code\game\objects\machinery\self_destruct.dm"
+#include "code\game\objects\machinery\sellingpad.dm"
 #include "code\game\objects\machinery\sentries.dm"
 #include "code\game\objects\machinery\shield_gen.dm"
 #include "code\game\objects\machinery\Sleeper.dm"


### PR DESCRIPTION
## About The Pull Request
This adds the Bluespace Selling Point, a piece of equipment that can be bought from requisitions and used to sell xeno corpses and ore boxes groundside. It just uses old telecomms sprites for now.

## Why It's Good For The Game
Having to depend on the alamo going up and down to deliver xeno bodies and crates back to req doesn't work very well as a mechanic, since the alamo is the only dropship and it usually is busy getting marines on the planet. The selling pad should't change balance much since it has to be bought and deployed, and it needs a powered APC to function. If this ends up making it too easy for req to get points then the price/cooldown for the pad can always be changed

## Changelog
:cl:
add: Requisitions can now order an ASRS Bluespace Selling Point to remotely sell valubles on the planet.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
