### PR TITLE
Revert "Nerfs the DMR/BR/SNIPER damage. Nerfs BR/Bolt action rifle damage"

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -525,7 +525,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
 	accurate_range_min = 0
 	accurate_range = 30
-	damage = 60
+	damage = 65
 	scatter = -15
 	penetration = 15
 	sundering = 2
@@ -878,7 +878,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	hud_state = "minigun"
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING|AMMO_SNIPER
 	iff_signal = null
-	damage = 70
+	damage = 80
 	penetration = 30
 	sundering = 7.5
 	accurate_range_min = 2

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -253,7 +253,7 @@
 	starting_attachment_types = list(/obj/item/attachable/stock/br,/obj/item/attachable/scope/mini)
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 18,"rail_x" = 17, "rail_y" = 18, "under_x" = 25, "under_y" = 12, "stock_x" = 14, "stock_y" = 10)
 
-	fire_delay = 0.4 SECONDS
+	fire_delay = 0.35 SECONDS
 	damage_mult = 0.5 //uses the marksman bullet, like the DMR.
 	accuracy_mult = 1.25
 	scatter = -10
@@ -868,7 +868,7 @@
 		/obj/item/attachable/stock/tl127stock,
 	)
 	burst_amount = 0
-	fire_delay = 1.5 SECONDS
+	fire_delay = 1.35 SECONDS
 	accuracy_mult = 1.35
 	accuracy_mult_unwielded = 0.7
 	scatter = -30


### PR DESCRIPTION
Reverts tgstation/TerraGov-Marine-Corps#4510

This was made before the Xenomorphs health buffs came in, and as per right now the AR bullet class of weapons are king, with these guns being worse.

If needed I'll adjust these stats, ping "@David_Stormwell" in our discord balance channel if you feel they may need adjusting.