### PR TITLE
Fuel Puddle & Jerrycan Logging

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/fuel.dm
+++ b/code/game/objects/effects/decals/Cleanable/fuel.dm
@@ -74,6 +74,8 @@
 	. = ..()
 	if(istype(I, /obj/item/tool/lighter))
 		ignite_fuel()
+		user.visible_message("<span class='notice'>[user] ignites \the [src]</span>", "<span class='notice'>You ignite some fuel on [src]</span>")
+		log_attack("[key_name(user)] ignites [src] in fuel in [AREACOORD(user)]")
 
 /obj/effect/decal/cleanable/liquid_fuel/flamer_fire_act()
 	. = ..()

--- a/code/game/objects/items/reagent_containers/jerrycan.dm
+++ b/code/game/objects/items/reagent_containers/jerrycan.dm
@@ -23,6 +23,7 @@
 	new /obj/effect/decal/cleanable/liquid_fuel(A, fuel_usage/2)
 	reagents.remove_reagent(/datum/reagent/fuel, fuel_usage)
 	user.visible_message("<span class='notice'>[user] splashes some fuel on \the [A]</span>", "<span class='notice'>You splash some fuel on [A]</span>")
+	log_attack("[key_name(user)] has doused [A] in fuel in [AREACOORD(user)]")
 
 /obj/item/reagent_containers/jerrycan/attack(mob/living/M, mob/living/user)
 	. = ..()
@@ -32,8 +33,8 @@
 	M.adjust_fire_stacks(10)
 	reagents.remove_reagent(/datum/reagent/fuel, fuel_usage)
 	user.visible_message("<span class='notice'>[user] splashes some fuel on [M]</span>", "<span class='notice'>You splash some fuel on [M]</span>", ignored_mob = M)
-	to_chat(M, "<span class='warning'>[user] drenches you in fuel from [src]!<span>")
-	log_attack("[user] has doused [M] in fuel")
+	to_chat(M, "<span class='warning'>[user] drenches you in fuel from [M]!<span>")
+	log_attack("[key_name(user)] has doused [M] in fuel in [AREACOORD(user)]")
 
 /obj/item/reagent_containers/jerrycan/afterattack(obj/O as obj, mob/user as mob, proximity)
 	if(!proximity)

--- a/code/game/objects/structures/reagent_dispensers.dm
+++ b/code/game/objects/structures/reagent_dispensers.dm
@@ -103,6 +103,7 @@
 		user.visible_message("[user] wrenches [src]'s faucet [modded ? "closed" : "open"].", \
 		"You wrench [src]'s faucet [modded ? "closed" : "open"]")
 		modded = !modded
+		log_attack("[key_name(user)] has wrenched [src] open in [AREACOORD(user)]")
 		if(modded)
 			leak_fuel(amount_per_transfer_from_this)
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Splashing fuel puddles on turfs/people is now logged in attack logs.
Wrenching fuel tanks is now logged in attack logs.
Igniting fuel puddles with lighters is now logged in attack logs.
Shows in chat who ignited the puddle.

## Why It's Good For The Game
Griefers go and stay go.

## Changelog
:cl:
add: Logging for fuel puddles
fix: Grief puddles are now logged
spellcheck: fixed a few typos
code: Logging for fuel puddles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
