### PR TITLE
MarineMed can now be wrenched

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -316,7 +316,7 @@
 	name = "\improper Marine Food and Drinks Vendor"
 	desc = "Standard Issue Food and Drinks Vendor, containing standard military food and drinks."
 	icon_state = "sustenance"
-	wrenchable = FALSE
+	wrenchable = TRUE
 	products = list(/obj/item/reagent_containers/food/snacks/protein_pack = 50,
 					/obj/item/reagent_containers/food/snacks/mre_pack/meal1 = 15,
 					/obj/item/reagent_containers/food/snacks/mre_pack/meal2 = 15,
@@ -344,7 +344,7 @@
 	icon_deny = "marinemed-deny"
 	product_ads = "Go save some lives!;The best stuff for your medbay.;Only the finest tools.;All natural chemicals!;This stuff saves lives.;Don't you want some?;Ping!"
 	req_one_access = list(ACCESS_MARINE_MEDBAY, ACCESS_MARINE_CHEMISTRY, ACCESS_MARINE_MEDPREP) //Medics, doctors and researchers can access
-	wrenchable = FALSE
+	wrenchable = TRUE
 	products = list(/obj/item/reagent_containers/hypospray/autoinjector/quickclot = 6,
 					/obj/item/reagent_containers/hypospray/autoinjector/bicaridine = 6,
 					/obj/item/reagent_containers/hypospray/autoinjector/dexalinplus = 6,


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

MarineMed and Food vendor can now be wrenched/unwrenched.

## Why It's Good For The Game

Other medical vendors can be wrenched, there's no discernible reason the MarineMed (and food vendor) can't be moved either.

## Changelog
:cl:
tweak: MarineMed and Marine Food and Drinks vendors can now be wrenched and unwrenched.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
