### PR TITLE
baldur is no longer free, costs more in req

### DIFF
--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -1058,7 +1058,6 @@ GLOBAL_LIST_INIT(available_specialist_sets, list("Scout Set", "Sniper Set", "Dem
 						/obj/item/clothing/shoes/marine,
 						/obj/item/attachable/bayonetknife,
 						/obj/item/storage/box/MRE,
-						/obj/item/armor_module/attachable/better_shoulder_lamp,
 						/obj/item/facepaint/green,
 						)
 
@@ -1077,7 +1076,6 @@ GLOBAL_LIST_INIT(available_specialist_sets, list("Scout Set", "Sniper Set", "Dem
 						/obj/item/clothing/shoes/marine,
 						/obj/item/attachable/bayonetknife,
 						/obj/item/storage/box/MRE,
-						/obj/item/armor_module/attachable/better_shoulder_lamp,
 						/obj/item/facepaint/green,
 						)
 
@@ -1120,7 +1118,6 @@ GLOBAL_LIST_INIT(available_specialist_sets, list("Scout Set", "Sniper Set", "Dem
 						/obj/item/clothing/shoes/marine,
 						/obj/item/attachable/bayonetknife,
 						/obj/item/storage/box/MRE,
-						/obj/item/armor_module/attachable/better_shoulder_lamp,
 						/obj/item/facepaint/green,
 						)
 
@@ -1143,7 +1140,6 @@ GLOBAL_LIST_INIT(available_specialist_sets, list("Scout Set", "Sniper Set", "Dem
 						/obj/item/clothing/shoes/marine,
 						/obj/item/attachable/bayonetknife,
 						/obj/item/storage/box/MRE,
-						/obj/item/armor_module/attachable/better_shoulder_lamp,
 						/obj/item/facepaint/green,
 						)
 
@@ -1167,7 +1163,6 @@ GLOBAL_LIST_INIT(available_specialist_sets, list("Scout Set", "Sniper Set", "Dem
 						/obj/item/clothing/shoes/marine,
 						/obj/item/attachable/bayonetknife,
 						/obj/item/storage/box/MRE,
-						/obj/item/armor_module/attachable/better_shoulder_lamp,
 						/obj/item/clothing/gloves/marine/insulated,
 						/obj/item/facepaint/green,
 						)

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -803,12 +803,8 @@ ARMOR
 	name = "Jaeger baldur modules"
 	contains = list(
 		/obj/item/armor_module/attachable/better_shoulder_lamp,
-		/obj/item/armor_module/attachable/better_shoulder_lamp,
-		/obj/item/armor_module/attachable/better_shoulder_lamp,
-		/obj/item/armor_module/attachable/better_shoulder_lamp,
-		/obj/item/armor_module/attachable/better_shoulder_lamp,
 	)
-	cost = 7
+	cost = 10
 
 /datum/supply_packs/armor/modular/attachments/valkyrie_autodoc
 	name = "Jaeger valkyrie modules"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Baldur is equivalent to free NVGs and makes flares and literally everything else essentially pointless, it shouldn't have ever been a free module.
It is no longer free and costs 10 points in req.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Returns the light game again rather than making it entirely pointless.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Baldur lights are no longer free in vendors. Baldur now costs 10 points in req and is only 1 per module like the other modules.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
