### PR TITLE
Fixes autolathe material amount for metal and rods

### DIFF
--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -9,7 +9,7 @@
 	throwforce = 15.0
 	throw_speed = 5
 	throw_range = 20
-	materials = list(/datum/material/metal = 1875)
+	materials = list(/datum/material/metal = 1000)
 	max_amount = 60
 	attack_verb = list("hit", "bludgeoned", "whacked")
 

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -69,7 +69,7 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	desc = "Sheets made out of metal. It has been dubbed Metal Sheets."
 	singular_name = "metal sheet"
 	icon_state = "sheet-metal"
-	materials = list(/datum/material/metal = 3750)
+	materials = list(/datum/material/metal = 4000)
 	throwforce = 14.0
 	flags_atom = CONDUCT
 	merge_type = /obj/item/stack/sheet/metal


### PR DESCRIPTION
## About The Pull Request

Changes the material value of metal sheets and rods so you can't get infinite metal by recycling rods/tiles in the autolathe

## Why It's Good For The Game

Generating infinite metal is a very powerful exploit and needs fixing.
Closes #4732 

## Changelog
:cl:
fix: You can no longer get infinite metal by recycling in the autolathe.
/:cl:
