### PR TITLE
Bumpattacks no longer target mobs laying down

### DIFF
--- a/code/datums/components/bump_attack.dm
+++ b/code/datums/components/bump_attack.dm
@@ -13,13 +13,10 @@
 	var/toggle_path
 	if(ishuman(parent))
 		bump_action_path = .proc/human_bump_action
-		cross_action_path = .proc/human_bump_action
 	else if(isxeno(parent))
 		bump_action_path = .proc/xeno_bump_action
-		cross_action_path = .proc/xeno_bump_action
 	else
 		bump_action_path = .proc/living_bump_action
-		cross_action_path = .proc/living_bump_action
 	toggle_path = .proc/living_activation_toggle
 	toggle_action.give_action(parent)
 	toggle_action.update_button_icon(active)

--- a/code/datums/components/bump_attack.dm
+++ b/code/datums/components/bump_attack.dm
@@ -1,7 +1,6 @@
 /datum/component/bump_attack
 	var/active = TRUE
 	var/bump_action_path
-	var/cross_action_path
 	var/datum/action/bump_attack_toggle/toggle_action
 
 
@@ -23,7 +22,6 @@
 	RegisterSignal(toggle_action, COMSIG_ACTION_TRIGGER, toggle_path)
 	if(active)
 		RegisterSignal(parent, COMSIG_MOVABLE_BUMP, bump_action_path)
-		RegisterSignal(parent, COMSIG_MOVABLE_CROSSED, cross_action_path)
 
 /datum/component/bump_attack/Destroy(force, silent)
 	QDEL_NULL(toggle_action)
@@ -36,9 +34,8 @@
 	to_chat(bumper, "<span class='notice'>You will now [active ? "attack" : "push"] enemies who are in your way.</span>")
 	if(active)
 		RegisterSignal(bumper, COMSIG_MOVABLE_BUMP, bump_action_path)
-		RegisterSignal(bumper, COMSIG_MOVABLE_CROSSED, cross_action_path)
 	else
-		UnregisterSignal(bumper, list(COMSIG_MOVABLE_BUMP, COMSIG_MOVABLE_CROSSED))
+		UnregisterSignal(bumper, COMSIG_MOVABLE_BUMP)
 	toggle_action.update_button_icon(active)
 
 


### PR DESCRIPTION
## About The Pull Request

Bumpattacks will no longer work on people laying down/knocked down.

## Why It's Good For The Game

This was originally added to balance crawling marines which got removed. Xenos being able to stun people and then run them over back and forth like a car is cheap and makes hit and run attacks too easy. Manually clicking a still target laying on the ground is much easier to do then melee vs a standing marine, so there isn't really a need for autoattacks here.

## Changelog
:cl:
balance: Bump autoattacks will no longer target people laying down or knocked down.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
