### PR TITLE
Bigbury follow-up

### DIFF
--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -7096,7 +7096,6 @@
 	dir = 4
 	},
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/tile/white/warningstripe{
 	dir = 8
 	},
@@ -11856,7 +11855,6 @@
 "aRs" = (
 /obj/machinery/light,
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/tile/yellow/full,
 /area/bigredv2/outside/hydroponics)
 "aRu" = (
@@ -20586,7 +20584,6 @@
 /area/bigredv2/outside/ne)
 "bZF" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/northwest)
 "cca" = (
@@ -20595,7 +20592,6 @@
 /area/bigredv2/caves/lambda_lab)
 "ccP" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/closed/wall,
 /area/bigredv2/outside/office_complex)
 "cfS" = (
@@ -20638,12 +20634,10 @@
 "cGZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor,
 /area/bigredv2/outside/hydroponics)
 "cTr" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/se)
 "cWF" = (
@@ -20685,7 +20679,6 @@
 	name = "\improper General Store"
 	},
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor,
 /area/bigredv2/outside/general_store)
 "dmd" = (
@@ -20721,7 +20714,6 @@
 /area/bigredv2/outside/virology)
 "dzS" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor,
 /area/bigredv2/outside/general_store)
 "dGd" = (
@@ -20985,7 +20977,6 @@
 /area/bigredv2/outside/se)
 "fLz" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/plating,
 /area/bigredv2/outside/nw)
 "fMu" = (
@@ -21167,7 +21158,6 @@
 /area/bigredv2/outside/cargo)
 "hvV" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/closed/wall,
 /area/bigredv2/outside/cargo)
 "hzx" = (
@@ -21182,7 +21172,6 @@
 /area/bigredv2/caves/southwest)
 "hEq" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/engineering)
 "hHN" = (
@@ -21194,7 +21183,6 @@
 "hIr" = (
 /obj/structure/cable,
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/plating,
 /area/bigredv2/outside/cargo)
 "hKr" = (
@@ -21226,7 +21214,6 @@
 /area/bigredv2/outside/general_offices)
 "hVF" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/closed/wall,
 /area/bigredv2/outside/admin_building)
 "iiY" = (
@@ -21247,7 +21234,6 @@
 "iCt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor,
 /area/bigredv2/outside/office_complex)
 "iNt" = (
@@ -21384,7 +21370,6 @@
 /area/bigredv2/outside/virology)
 "khG" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor,
 /area/bigredv2/outside/general_offices)
 "klu" = (
@@ -21483,7 +21468,6 @@
 /area/bigredv2/caves/southwest)
 "lji" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/outside/se)
 "ljC" = (
@@ -21492,7 +21476,6 @@
 /area/bigredv2/caves/east)
 "loj" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/engine/cult,
 /area/bigredv2/outside/chapel)
 "loH" = (
@@ -21584,7 +21567,6 @@
 /area/bigredv2/outside/engineering)
 "mcP" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/east)
 "mlt" = (
@@ -21753,7 +21735,6 @@
 /area/shuttle/drop2/lz2)
 "olJ" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/southeast)
 "onZ" = (
@@ -21864,7 +21845,6 @@
 	name = "\improper Engineering Shutters"
 	},
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/plating,
 /area/bigredv2/outside/engineering)
 "pbI" = (
@@ -21933,7 +21913,6 @@
 /area/bigredv2/outside/marshal_office)
 "pRv" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/c)
 "pRU" = (
@@ -22036,7 +22015,6 @@
 /area/bigredv2/outside/w)
 "qDI" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/south)
 "qEg" = (
@@ -22072,7 +22050,6 @@
 /area/bigredv2/caves/lambda_lab)
 "qKE" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/se)
 "qPG" = (
@@ -22160,7 +22137,6 @@
 /area/bigredv2/caves/lambda_lab)
 "rOm" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/east)
 "rQB" = (
@@ -22233,7 +22209,6 @@
 /area/bigredv2/outside/s)
 "sZi" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor,
 /area/bigredv2/outside/dorms)
 "sZl" = (
@@ -22365,7 +22340,6 @@
 "uja" = (
 /obj/structure/window/framed/colony/reinforced/hull,
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/plating,
 /area/bigredv2/outside/se)
 "ukJ" = (
@@ -22426,7 +22400,6 @@
 /area/bigredv2/outside/cargo)
 "uUn" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/nw)
 "uUK" = (
@@ -22461,7 +22434,6 @@
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "vsq" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/c)
 "vvM" = (
@@ -22472,7 +22444,6 @@
 /area/bigredv2/outside/w)
 "vAP" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/nw)
 "vCh" = (
@@ -22637,7 +22608,6 @@
 /area/bigredv2/outside/cargo)
 "xnD" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/closed/wall,
 /area/bigredv2/outside/dorms)
 "xpB" = (
@@ -22700,7 +22670,6 @@
 /area/bigredv2/outside/sw)
 "xHV" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/northwest)
 "xJh" = (

--- a/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -14683,7 +14683,6 @@
 /area/ice_colony/exterior/surface/landing_pad_external)
 "aWq" = (
 /obj/docking_port/stationary/marine_dropship/lz1,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/plating,
 /area/ice_colony/exterior/surface/landing_pad2)
 "aWr" = (
@@ -33149,7 +33148,6 @@
 /area/ice_colony/exterior/surface/valley/southeast)
 "lPy" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/plating/icefloor,
 /area/ice_colony/exterior/surface/landing_pad)
 "lSx" = (

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -2334,7 +2334,6 @@
 	},
 /obj/item/explosive/grenade/incendiary,
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/plating,
 /area/lv624/ground/tfort)
 "ajc" = (
@@ -6160,7 +6159,6 @@
 /area/lv624/lazarus/security)
 "ayX" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/ground/river,
 /area/lv624/ground/river1)
 "ayY" = (
@@ -12388,7 +12386,6 @@
 	},
 /obj/structure/cable,
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/main_hall)
 "bax" = (
@@ -16832,7 +16829,6 @@
 /area/lv624/ground/caves/central3)
 "bOR" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor,
 /area/lv624/ground/river2)
 "bRK" = (
@@ -16846,7 +16842,6 @@
 /area/lv624/ground/jungle9)
 "cat" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/closed/gm/dense,
 /area/lv624/ground/jungle7)
 "chK" = (
@@ -17043,7 +17038,6 @@
 /area/lv624/ground/jungle6)
 "dRM" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/closed/gm/dense,
 /area/lv624/ground/jungle9)
 "dTd" = (
@@ -17075,7 +17069,6 @@
 /area/lv624/ground/jungle4)
 "epV" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand2)
 "eql" = (
@@ -17471,7 +17464,6 @@
 /area/lv624/lazarus/engineering)
 "hDA" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/closed/wall,
 /area/lv624/ground/river2)
 "hHD" = (
@@ -17562,7 +17554,6 @@
 /area/shuttle/drop2/lz2)
 "iEQ" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/marking/bot,
 /area/shuttle/drop1/lz1)
 "iFV" = (
@@ -17611,7 +17602,6 @@
 /area/lv624/ground/jungle3)
 "jeZ" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/east1)
 "jij" = (
@@ -17648,7 +17638,6 @@
 /area/lv624/ground/filtration)
 "jzY" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand4)
 "jAh" = (
@@ -17667,7 +17656,6 @@
 /obj/structure/table,
 /obj/structure/cable,
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/tile/purple/taupepurple{
 	dir = 9
 	},
@@ -17716,7 +17704,6 @@
 /area/lv624/ground/caves/west1)
 "jVV" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/ground/river,
 /area/lv624/ground/river2)
 "jZC" = (
@@ -17726,7 +17713,6 @@
 /area/shuttle/drop2/lz2)
 "kir" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /obj/structure/fence,
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 1
@@ -17797,7 +17783,6 @@
 /area/lv624/lazarus/quartstorage)
 "kPi" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand5)
 "kYu" = (
@@ -17946,7 +17931,6 @@
 /area/lv624/ground/compound/sw)
 "mrh" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor,
 /area/lv624/ground/sand2)
 "mup" = (
@@ -17957,7 +17941,6 @@
 /area/shuttle/drop2/lz2)
 "mvX" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle7)
 "myp" = (
@@ -18278,7 +18261,6 @@
 "puV" = (
 /obj/structure/window/framed/colony,
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/plating,
 /area/lv624/lazarus/quartstorage)
 "pwm" = (
@@ -18524,7 +18506,6 @@
 /area/shuttle/drop2/lz2)
 "rDw" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/closed/wall,
 /area/lv624/ground/river3)
 "rJh" = (
@@ -18546,7 +18527,6 @@
 /area/lv624/lazarus/internal_affairs)
 "rOf" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/plating/platebotc,
 /area/lv624/lazarus/quartstorage/outdoors)
 "rPv" = (
@@ -18740,7 +18720,6 @@
 /area/lv624/ground/caves/east1)
 "tUO" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/west1)
 "tWO" = (
@@ -18807,7 +18786,6 @@
 "uNG" = (
 /obj/structure/jungle/plantbot1/alien,
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/ground/river,
 /area/lv624/ground/river1)
 "uVd" = (
@@ -18868,7 +18846,6 @@
 /area/lv624/ground/sand4)
 "vuY" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 4
 	},
@@ -18900,7 +18877,6 @@
 "vJf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor,
 /area/lv624/ground/sand8)
 "vJq" = (

--- a/_maps/map_files/Lava_Outpost/LavaOutpost.dmm
+++ b/_maps/map_files/Lava_Outpost/LavaOutpost.dmm
@@ -367,7 +367,6 @@
 /area/lavaland/engie/engine)
 "fH" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/closed/brock,
 /area/lavaland/cave/north)
 "fQ" = (
@@ -743,7 +742,6 @@
 /turf/open/floor/wood,
 /area/lavaland/civilian)
 "jH" = (
-/obj/docking_port/stationary/crashmode/bigbury,
 /obj/docking_port/stationary/crashmode,
 /turf/open/lavaland/basalt,
 /area/lavaland/cave/central)
@@ -1689,7 +1687,6 @@
 /area/lavaland/civilian/cargo)
 "tW" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/closed/brock,
 /area/lavaland/cave/southeast)
 "tY" = (
@@ -2130,7 +2127,6 @@
 /area/lavaland/cave/east)
 "yC" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/lavaland/lava,
 /area/lavaland/cave/north)
 "yH" = (
@@ -3629,7 +3625,6 @@
 /area/lavaland/engie/two)
 "Qi" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/lavaland/lava/side,
 /area/lavaland)
 "Qm" = (

--- a/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
+++ b/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
@@ -974,10 +974,6 @@
 /obj/item/weapon/gun/revolver/cmb,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/magmoor/cave/northwest)
-"baf" = (
-/obj/docking_port/stationary/crashmode/bigbury,
-/turf/open/floor/cult,
-/area/magmoor/cave/north)
 "bai" = (
 /turf/open/floor/mainship/green{
 	dir = 1
@@ -1265,10 +1261,6 @@
 	dir = 1
 	},
 /area/magmoor/compound/west)
-"bnG" = (
-/obj/docking_port/stationary/crashmode/bigbury,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/magmoor/cave/north)
 "boi" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -2530,10 +2522,6 @@
 "cjB" = (
 /turf/open/floor/plating/mainship,
 /area/magmoor/mining/garage)
-"cjJ" = (
-/obj/docking_port/stationary/crashmode/bigbury,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/magmoor/compound/south)
 "cjP" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -3826,10 +3814,6 @@
 	dir = 1
 	},
 /area/magmoor/cave/northwest)
-"cZT" = (
-/obj/docking_port/stationary/crashmode/bigbury,
-/turf/closed/mineral,
-/area/magmoor/cave/mining/fossil)
 "dae" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -8168,7 +8152,6 @@
 /obj/structure/closet/walllocker/hydrant/extinguisher{
 	dir = 8
 	},
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 9
 	},
@@ -8224,7 +8207,6 @@
 /turf/open/floor/mainship/purple/corner,
 /area/magmoor/research)
 "gfW" = (
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/mainship/purple,
 /area/magmoor/research)
 "gfX" = (
@@ -13680,12 +13662,6 @@
 	},
 /turf/open/floor/plating/ground/concrete/lines,
 /area/magmoor/cave/west)
-"koN" = (
-/obj/docking_port/stationary/crashmode/bigbury,
-/turf/open/lavaland/basalt/dirt{
-	dir = 5
-	},
-/area/magmoor/compound/south)
 "koY" = (
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 6
@@ -18533,11 +18509,6 @@
 	dir = 8
 	},
 /area/magmoor/cargo/storage)
-"oaQ" = (
-/obj/structure/largecrate/goat,
-/obj/docking_port/stationary/crashmode/bigbury,
-/turf/open/floor/mainship/mono,
-/area/magmoor/cargo/storage)
 "oaS" = (
 /turf/open/floor/mainship/orange/corner,
 /area/magmoor/engi/atmos)
@@ -18628,11 +18599,6 @@
 	dir = 8
 	},
 /area/magmoor/cave/southwest)
-"odP" = (
-/obj/structure/window/framed/colony/reinforced,
-/obj/docking_port/stationary/crashmode/bigbury,
-/turf/open/floor/plating,
-/area/magmoor/engi/atmos)
 "odR" = (
 /turf/open/lavaland/lava/lpiece,
 /area/magmoor/cave/southwest)
@@ -22171,10 +22137,6 @@
 "qDL" = (
 /turf/open/floor/plating,
 /area/magmoor/cave/south)
-"qEi" = (
-/obj/docking_port/stationary/crashmode/bigbury,
-/turf/open/floor/plating/ground/concrete/lines,
-/area/magmoor/compound)
 "qEj" = (
 /turf/open/floor/stairs/rampbottom{
 	dir = 4
@@ -23258,19 +23220,6 @@
 /obj/structure/cable,
 /turf/open/floor/freezer,
 /area/magmoor/civilian/cook)
-"ruw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/docking_port/stationary/crashmode/bigbury,
-/turf/open/floor/stairs/rampbottom{
-	dir = 4
-	},
-/area/magmoor/compound)
 "rux" = (
 /obj/structure/flora/rock/alt2,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -23384,7 +23333,6 @@
 	},
 /area/magmoor/landing)
 "rxE" = (
-/obj/docking_port/stationary/crashmode/bigbury,
 /obj/structure/closet/emcloset,
 /turf/open/floor/mainship/orange,
 /area/magmoor/engi/storage)
@@ -26599,12 +26547,6 @@
 	dir = 1
 	},
 /area/magmoor/compound/north)
-"tAp" = (
-/obj/docking_port/stationary/crashmode/bigbury,
-/turf/open/lavaland/basalt/dirt{
-	dir = 10
-	},
-/area/magmoor/compound/east)
 "tAz" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
@@ -26676,12 +26618,6 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/magmoor/landing)
-"tCQ" = (
-/obj/docking_port/stationary/crashmode/bigbury,
-/turf/open/lavaland/basalt/dirt{
-	dir = 5
-	},
-/area/magmoor/compound/northeast)
 "tDe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -26915,10 +26851,6 @@
 	dir = 5
 	},
 /area/magmoor/engi/storage)
-"tJV" = (
-/obj/docking_port/stationary/crashmode/bigbury,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/magmoor/compound/east)
 "tKf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -27753,10 +27685,6 @@
 	dir = 2
 	},
 /turf/closed/mineral,
-/area/magmoor/compound/northeast)
-"uoy" = (
-/obj/docking_port/stationary/crashmode/bigbury,
-/turf/open/floor/plating/ground/mars/random/dirt,
 /area/magmoor/compound/northeast)
 "uoK" = (
 /obj/structure/lattice,
@@ -28741,10 +28669,6 @@
 /obj/item/weapon/broken_bottle,
 /turf/open/floor/wood,
 /area/magmoor/civilian/bar)
-"uOB" = (
-/obj/docking_port/stationary/crashmode/bigbury,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/magmoor/compound/northwest)
 "uOY" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/wood,
@@ -29690,7 +29614,6 @@
 /obj/machinery/alarm{
 	dir = 8
 	},
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 4
 	},
@@ -31128,11 +31051,6 @@
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/wood,
 /area/magmoor/command/conference)
-"wkX" = (
-/obj/structure/window/framed/colony/reinforced,
-/obj/docking_port/stationary/crashmode/bigbury,
-/turf/open/floor/plating,
-/area/magmoor/compound/east)
 "wlF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -42154,7 +42072,7 @@ bcM
 tpi
 yla
 awJ
-uOB
+nYL
 nYL
 nYL
 nYL
@@ -44301,7 +44219,7 @@ jns
 jns
 slM
 slM
-cZT
+slM
 slM
 vZN
 kBQ
@@ -49200,7 +49118,7 @@ xSv
 xSv
 xSv
 scg
-qEi
+qey
 hkW
 hkW
 rCg
@@ -49756,7 +49674,7 @@ qkn
 qkn
 qkn
 aMD
-bnG
+aMD
 fvv
 bOi
 dCi
@@ -55346,7 +55264,7 @@ nhd
 nhd
 akz
 urr
-baf
+urr
 asn
 urr
 aMD
@@ -55731,7 +55649,7 @@ bhT
 csX
 csX
 csX
-cjJ
+csX
 csX
 csX
 sMg
@@ -64330,7 +64248,7 @@ wxu
 wGr
 hph
 wba
-ruw
+teL
 wba
 wba
 hph
@@ -64367,7 +64285,7 @@ csX
 csX
 csX
 bUz
-koN
+pwq
 jyE
 bsG
 oMH
@@ -64489,7 +64407,7 @@ quH
 nex
 nzy
 nNF
-odP
+wai
 kPM
 fsX
 tlp
@@ -65944,7 +65862,7 @@ dBh
 dBh
 dBh
 vIg
-tAp
+kls
 kDT
 hEq
 ppR
@@ -66145,7 +66063,7 @@ hCv
 hCv
 hCv
 hCv
-tCQ
+xhL
 rgp
 tUp
 ucX
@@ -67595,7 +67513,7 @@ wxp
 xUE
 wxp
 wxp
-wkX
+sTk
 pfd
 oRP
 oRP
@@ -70576,7 +70494,7 @@ hCv
 hCv
 hCv
 hCv
-uoy
+hCv
 hCv
 hCv
 uLF
@@ -71710,7 +71628,7 @@ ocQ
 rht
 nuR
 nkR
-oaQ
+euV
 nSr
 ofL
 oUn
@@ -74118,7 +74036,7 @@ kDT
 qtm
 dBh
 dBh
-tJV
+dBh
 dBh
 dBh
 dBh
@@ -75006,7 +74924,7 @@ tam
 sCq
 sxo
 ydi
-uoy
+hCv
 hCv
 hCv
 hCv
@@ -75684,7 +75602,7 @@ hCv
 hCv
 hCv
 hCv
-uoy
+hCv
 hCv
 hCv
 hCv

--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -41571,7 +41571,6 @@
 	dir = 1
 	},
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/toilet/canteen)
 "epq" = (
@@ -42904,7 +42903,6 @@
 /area/space)
 "tlK" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/closed/wall/prison,
 /area/prison/cellblock/vip)
 "tlV" = (
@@ -43322,7 +43320,6 @@
 	dir = 8
 	},
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/mediumsec/south)
 "ydX" = (

--- a/_maps/map_files/Research_Outpost/Research_Outpost.dmm
+++ b/_maps/map_files/Research_Outpost/Research_Outpost.dmm
@@ -267,7 +267,6 @@
 /area/outpost/science/research)
 "bx" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/outpost/yard/west)
 "bz" = (
@@ -363,7 +362,6 @@
 /area/outpost/yard/west)
 "ce" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/outpost/caves/south_east)
 "cf" = (
@@ -1535,7 +1533,6 @@
 /area/outpost/medbay/storage)
 "iu" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/plating,
 /area/outpost/lz1)
 "iw" = (
@@ -4379,7 +4376,6 @@
 /area/outpost/lz1)
 "xN" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/marking/asteroidwarning{
 	dir = 8
 	},
@@ -8883,7 +8879,6 @@
 /area/outpost/caves/north_west)
 "VZ" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/closed/mineral/bigred,
 /area/outpost/caves/east)
 "Wb" = (

--- a/_maps/map_files/Vapor_Processing/Vapor_Processing.dmm
+++ b/_maps/map_files/Vapor_Processing/Vapor_Processing.dmm
@@ -97,7 +97,6 @@
 "as" = (
 /obj/docking_port/stationary/marine_dropship/lz2,
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/plating,
 /area/shuttle/drop2/lz2)
 "at" = (
@@ -585,7 +584,6 @@
 "cb" = (
 /obj/docking_port/stationary/marine_dropship/lz1,
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/plating,
 /area/shuttle/drop1/lz1)
 "cc" = (
@@ -5503,7 +5501,6 @@
 /area/space)
 "FJ" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/grass,
 /area/lv624/ground/compound/se)
 "Gn" = (

--- a/_maps/map_files/desert/desert.dmm
+++ b/_maps/map_files/desert/desert.dmm
@@ -452,7 +452,6 @@
 /area/desert/outside/sw)
 "bT" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/tile/white,
 /area/desert/interior/main_building)
 "bU" = (
@@ -2480,7 +2479,6 @@
 /area/desert/outside/sw)
 "ja" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/tile/dark,
 /area/desert/interior/shipping/central)
 "jb" = (
@@ -2766,7 +2764,6 @@
 "kj" = (
 /obj/structure/cable,
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/plating,
 /area/desert/outside/nw)
 "kk" = (
@@ -3170,7 +3167,6 @@
 	dir = 1
 	},
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/closed/wall/r_wall,
 /area/desert/interior/shipping/north)
 "Bv" = (
@@ -3186,18 +3182,15 @@
 /area/desert/outside/nw)
 "EQ" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/plating/ground,
 /area/desert/outside)
 "EV" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/plating/plating_catwalk,
 /area/desert/interior/shipping/south)
 "OJ" = (
 /obj/effect/alien/weeds/node/strong,
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/plating/ground,
 /area/desert/outside)
 

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -4588,7 +4588,6 @@
 /area/icy_caves/outpost/LZ2)
 "rt" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
 "rx" = (
@@ -5078,7 +5077,6 @@
 /area/icy_caves/caves/OOB)
 "yl" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/dorms)
 "yx" = (
@@ -5167,7 +5165,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/open/floor/plating/ground/snow,
 /area/icy_caves/outpost/outside)
 "Bx" = (
@@ -5347,7 +5344,6 @@
 /area/icy_caves/outpost/LZ1)
 "LI" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/closed/ice_rock/single,
 /area/icy_caves/caves/west)
 "LX" = (
@@ -5391,7 +5387,6 @@
 /area/icy_caves/caves/OOB)
 "Nf" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
@@ -5482,7 +5477,6 @@
 /area/icy_caves/outpost/outside)
 "QK" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/refinery)
 "QR" = (
@@ -5561,7 +5555,6 @@
 /area/icy_caves/caves/east)
 "ST" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/closed/ice/thin/intersection,
 /area/icy_caves/caves/south)
 "SZ" = (
@@ -5603,7 +5596,6 @@
 /area/icy_caves/outpost/research)
 "Uk" = (
 /obj/docking_port/stationary/crashmode,
-/obj/docking_port/stationary/crashmode/bigbury,
 /turf/closed/ice/thin/junction{
 	dir = 1
 	},

--- a/_maps/shuttles/tgs_bigbury.dmm
+++ b/_maps/shuttles/tgs_bigbury.dmm
@@ -619,9 +619,6 @@
 /obj/effect/landmark/start/job/crash/squadengineer,
 /turf/open/floor/mainship/red/full,
 /area/shuttle/canterbury)
-"mk" = (
-/turf/open/floor/mainship/blue/full,
-/area/space)
 "ms" = (
 /obj/structure/bed/chair/dropship/passenger,
 /obj/effect/landmark/start/job/crash/squadmarine,
@@ -1505,7 +1502,7 @@ Uo
 Uo
 ad
 bJ
-mk
+MY
 bQ
 al
 Wl

--- a/_maps/shuttles/tgs_bigbury.dmm
+++ b/_maps/shuttles/tgs_bigbury.dmm
@@ -17,45 +17,41 @@
 "ae" = (
 /obj/structure/table/mainship,
 /obj/machinery/computer/security/marine_network,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship,
 /area/shuttle/canterbury/cic)
 "af" = (
 /obj/structure/table/mainship,
 /obj/machinery/computer/shuttle/shuttle_control/canterbury,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/blue{
+	dir = 9
+	},
 /area/shuttle/canterbury/cic)
 "ag" = (
 /obj/structure/shuttle/engine/propulsion/burst/left,
-/turf/open/space/basic,
+/turf/open/floor/podhatch/floor,
 /area/shuttle/canterbury)
 "ah" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/open/space/basic,
+/turf/open/floor/podhatch/floor,
 /area/shuttle/canterbury)
 "ai" = (
 /obj/structure/shuttle/engine/propulsion/burst/right,
-/turf/closed/wall/mainship/outer/canterbury,
-/area/shuttle/canterbury)
-"aj" = (
-/obj/structure/shuttle/engine/propulsion/burst/left,
-/turf/closed/wall/mainship/outer/canterbury,
-/area/shuttle/canterbury)
-"ak" = (
-/obj/structure/shuttle/engine/propulsion/burst/right,
-/turf/open/space/basic,
+/turf/open/floor/podhatch/floor,
 /area/shuttle/canterbury)
 "al" = (
 /turf/closed/wall/mainship/outer/canterbury,
 /area/shuttle/canterbury/cic)
 "am" = (
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/blue{
+	dir = 6
+	},
 /area/shuttle/canterbury/cic)
 "an" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/shuttle/canterbury)
 "ao" = (
 /obj/structure/cable,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/blue/full,
 /area/shuttle/canterbury/cic)
 "ap" = (
 /turf/closed/wall/mainship/outer/canterbury,
@@ -333,7 +329,7 @@
 	dir = 2;
 	name = "\improper Marine Hypersleep and Equipment Area"
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship,
 /area/shuttle/canterbury)
 "bq" = (
 /obj/structure/closet/secure_closet/engineering_personal,
@@ -423,7 +419,7 @@
 	dir = 1;
 	name = "\improper Command Cockpit"
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/blue/full,
 /area/shuttle/canterbury/cic)
 "bE" = (
 /obj/machinery/vending/marine/cargo_guns,
@@ -440,54 +436,64 @@
 "bH" = (
 /obj/structure/table/mainship,
 /obj/machinery/computer/camera_advanced/overwatch,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/blue/full,
 /area/shuttle/canterbury/cic)
 "bI" = (
 /obj/structure/table/mainship,
 /obj/machinery/faxmachine/cic,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/blue{
+	dir = 5
+	},
 /area/shuttle/canterbury/cic)
 "bJ" = (
 /obj/structure/table/mainship,
 /obj/machinery/computer/marine_card,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship,
 /area/shuttle/canterbury/cic)
 "bK" = (
 /obj/structure/bed/chair/dropship/pilot{
 	dir = 1
 	},
 /obj/effect/landmark/start/job/crash/fieldcommander,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/blue{
+	dir = 8
+	},
 /area/shuttle/canterbury/cic)
 "bL" = (
 /obj/machinery/marine_selector/clothes/leader,
 /obj/machinery/light/small,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/blue{
+	dir = 4
+	},
 /area/shuttle/canterbury/cic)
 "bM" = (
 /obj/machinery/marine_selector/gear/leader,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship,
 /area/shuttle/canterbury/cic)
 "bN" = (
 /obj/machinery/telecomms/relay/preset/telecomms,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/blue{
+	dir = 4
+	},
 /area/shuttle/canterbury/cic)
 "bO" = (
 /obj/machinery/alarm{
 	dir = 1
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship,
 /area/shuttle/canterbury/cic)
 "bP" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/mainship{
 	dir = 1
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/blue{
+	dir = 6
+	},
 /area/shuttle/canterbury/cic)
 "bQ" = (
 /obj/machinery/computer/crew,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship,
 /area/shuttle/canterbury/cic)
 "bR" = (
 /obj/structure/table/mainship,
@@ -495,16 +501,20 @@
 /obj/item/tool/pen,
 /obj/structure/paper_bin,
 /obj/item/pinpointer/advpinpointer,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/blue{
+	dir = 8
+	},
 /area/shuttle/canterbury/cic)
 "bS" = (
 /obj/structure/closet/secure_closet/guncabinet/canterbury,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship,
 /area/shuttle/canterbury/cic)
 "bT" = (
 /obj/machinery/marine_selector/clothes/synth,
 /obj/machinery/light/small,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/blue{
+	dir = 8
+	},
 /area/shuttle/canterbury/cic)
 "bU" = (
 /obj/machinery/door/poddoor/mainship{
@@ -556,11 +566,12 @@
 /area/shuttle/canterbury)
 "cR" = (
 /obj/machinery/door/window/westright,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/floor,
 /area/shuttle/canterbury)
 "fL" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/box/beakers,
+/obj/item/reagent_containers/glass/beaker/bluespace,
+/obj/item/reagent_containers/glass/beaker/bluespace,
 /turf/open/floor/mainship/sterile/dark,
 /area/shuttle/canterbury/medical)
 "gv" = (
@@ -585,7 +596,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/blue,
 /area/shuttle/canterbury/cic)
 "jq" = (
 /obj/machinery/light,
@@ -608,6 +619,9 @@
 /obj/effect/landmark/start/job/crash/squadengineer,
 /turf/open/floor/mainship/red/full,
 /area/shuttle/canterbury)
+"mk" = (
+/turf/open/floor/mainship/blue/full,
+/area/space)
 "ms" = (
 /obj/structure/bed/chair/dropship/passenger,
 /obj/effect/landmark/start/job/crash/squadmarine,
@@ -667,9 +681,6 @@
 	dir = 4
 	},
 /obj/machinery/vending/marine,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "qh" = (
@@ -750,6 +761,11 @@
 	},
 /turf/open/floor/mainship/red/full,
 /area/shuttle/canterbury)
+"uu" = (
+/turf/open/floor/mainship/blue{
+	dir = 4
+	},
+/area/shuttle/canterbury/cic)
 "uT" = (
 /obj/structure/bed/chair/dropship/passenger{
 	dir = 1
@@ -776,7 +792,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/floor,
 /area/shuttle/canterbury)
 "vY" = (
 /obj/machinery/body_scanconsole,
@@ -928,6 +944,9 @@
 /obj/item/stack/barbed_wire/full,
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
+"MY" = (
+/turf/open/floor/mainship/blue/full,
+/area/shuttle/canterbury/cic)
 "Ot" = (
 /obj/structure/cable,
 /obj/machinery/light/small,
@@ -941,14 +960,20 @@
 /obj/machinery/light,
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
+"OS" = (
+/obj/structure/bed/chair/dropship/pilot{
+	dir = 1
+	},
+/obj/effect/landmark/start/job/crash/fieldcommander,
+/turf/open/floor/mainship/blue{
+	dir = 4
+	},
+/area/shuttle/canterbury/cic)
 "PW" = (
 /obj/machinery/marine_selector/clothes/medic,
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "Qg" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/vending/nanomed,
 /turf/open/floor/mainship,
 /area/shuttle/canterbury)
@@ -971,6 +996,11 @@
 /obj/effect/landmark/start/job/crash/squadcorpsman,
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
+"Si" = (
+/turf/open/floor/mainship/blue{
+	dir = 10
+	},
+/area/shuttle/canterbury/cic)
 "SA" = (
 /obj/structure/bed/chair/dropship/passenger{
 	dir = 8
@@ -988,7 +1018,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/blue,
 /area/shuttle/canterbury/cic)
 "Ui" = (
 /obj/structure/window/reinforced{
@@ -997,15 +1027,22 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/floor,
 /area/shuttle/canterbury)
 "Ul" = (
 /obj/machinery/vending/nanomed,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/blue{
+	dir = 10
+	},
 /area/shuttle/canterbury/cic)
 "Uo" = (
 /turf/template_noop,
 /area/template_noop)
+"Uw" = (
+/turf/open/floor/mainship/blue{
+	dir = 8
+	},
+/area/shuttle/canterbury/cic)
 "UE" = (
 /obj/structure/bed/chair/dropship/passenger,
 /obj/effect/landmark/start/job/crash/medicalofficer,
@@ -1034,9 +1071,6 @@
 	dir = 4
 	},
 /obj/machinery/vending/marine,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "Wk" = (
@@ -1077,7 +1111,7 @@
 /area/shuttle/canterbury/medical)
 "Xp" = (
 /obj/machinery/door/window/eastleft,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/floor,
 /area/shuttle/canterbury)
 "XO" = (
 /obj/structure/bed/chair/dropship/passenger{
@@ -1240,7 +1274,7 @@ Uo
 Uo
 al
 al
-am
+uu
 bL
 al
 Rd
@@ -1273,7 +1307,7 @@ Uo
 Uo
 ad
 Ub
-am
+MY
 bM
 al
 AS
@@ -1306,7 +1340,7 @@ Uo
 Uo
 ad
 am
-am
+uu
 bN
 al
 FZ
@@ -1339,7 +1373,7 @@ Uo
 Uo
 ad
 ae
-am
+MY
 bO
 al
 qh
@@ -1405,7 +1439,7 @@ Uo
 Uo
 ad
 bH
-am
+MY
 ao
 bD
 as
@@ -1438,7 +1472,7 @@ Uo
 Uo
 ad
 bI
-bK
+OS
 bP
 al
 nM
@@ -1451,7 +1485,7 @@ ac
 ac
 ac
 ac
-ac
+an
 ac
 ac
 ac
@@ -1471,7 +1505,7 @@ Uo
 Uo
 ad
 bJ
-am
+mk
 bQ
 al
 Wl
@@ -1484,7 +1518,7 @@ FQ
 bF
 bE
 bG
-ac
+an
 ac
 Kh
 ny
@@ -1503,8 +1537,8 @@ Uo
 Uo
 Uo
 ad
-am
-am
+Si
+Uw
 bR
 al
 JX
@@ -1523,7 +1557,7 @@ ab
 ar
 ar
 ab
-ac
+bA
 bp
 ab
 ar
@@ -1537,7 +1571,7 @@ Uo
 Uo
 ad
 jo
-am
+MY
 bS
 al
 BZ
@@ -1563,14 +1597,14 @@ aZ
 UO
 KD
 ab
-aj
+ag
 "}
 (15,1,1) = {"
 Uo
 Uo
 al
 al
-am
+Uw
 bT
 al
 Rd
@@ -1684,8 +1718,8 @@ JM
 bz
 ow
 ab
-cF
-UO
+aM
+DI
 ye
 bA
 cF
@@ -1695,7 +1729,7 @@ aM
 DI
 aQ
 ab
-ak
+ai
 "}
 (19,1,1) = {"
 Uo

--- a/code/modules/shuttle/gamemodes/crash.dm
+++ b/code/modules/shuttle/gamemodes/crash.dm
@@ -3,46 +3,45 @@
 	id = "canterbury_dock"
 	name = "Canterbury Crash Site"
 	dir = SOUTH
-	width = 15
-	height = 24
-	dwidth = 7
-	dheight = 12
+	width = 19
+	height = 31
+	dwidth = 9
+	dheight = 15
 
-
-/obj/docking_port/stationary/crashmode/on_crash()
+///obj/docking_port/stationary/crashmode/on_crash()
 	//clear areas around the shuttle with explosions
-	var/turf/C = return_center_turf()
+	//var/turf/C = return_center_turf()
 
-	var/cos = 1
-	var/sin = 0
-	switch(dir)
-		if(WEST)
-			cos = 0
-			sin = 1
-		if(SOUTH)
-			cos = -1
-			sin = 0
-		if(EAST)
-			cos = 0
-			sin = -1
+	//var/cos = 1
+	//var/sin = 0
+	//switch(dir)
+		//if(WEST)
+			//cos = 0
+			//sin = 1
+		//if(SOUTH)
+			//cos = -1
+			//sin = 0
+		//if(EAST)
+			//cos = 0
+			//sin = -1
 
-	var/updown = (round(width/2))*sin + (round(height/2))*cos
-	var/leftright = (round(width/2))*cos - (round(height/2))*sin
+	//var/updown = (round(width/2))*sin + (round(height/2))*cos
+	//var/leftright = (round(width/2))*cos - (round(height/2))*sin
 
-	var/turf/front = locate(C.x, C.y - updown, C.z)
-	var/turf/rear = locate(C.x, C.y + updown, C.z)
-	var/turf/left = locate(C.x - leftright, C.y, C.z)
-	var/turf/right = locate(C.x + leftright, C.y, C.z)
+	//var/turf/front = locate(C.x, C.y - updown, C.z)
+	//var/turf/rear = locate(C.x, C.y + updown, C.z)
+	//var/turf/left = locate(C.x - leftright, C.y, C.z)
+	//var/turf/right = locate(C.x + leftright, C.y, C.z)
 
-	var/turf/front_right = locate(C.x - round(leftright/2), C.y - round(updown/2), C.z)
-	var/turf/front_left = locate(C.x + round(leftright/2), C.y - round(updown/2), C.z)
-	var/turf/rear_right = locate(C.x - round(leftright/2), C.y + round(updown/2), C.z)
-	var/turf/rear_left = locate(C.x + round(leftright/2), C.y + round(updown/2), C.z)
+	//var/turf/front_right = locate(C.x - round(leftright/2), C.y - round(updown/2), C.z)
+	//var/turf/front_left = locate(C.x + round(leftright/2), C.y - round(updown/2), C.z)
+	//var/turf/rear_right = locate(C.x - round(leftright/2), C.y + round(updown/2), C.z)
+	//var/turf/rear_left = locate(C.x + round(leftright/2), C.y + round(updown/2), C.z)
 
 
 	// just wipe the turfs
-	for(var/turf/T in range(3, rear)+range(3, left)+range(3, right)+range(3, front)+range(4, front_right)+range(4, front_left)+range(4, rear_right)+range(4, rear_left))
-		T.empty(/turf/open/floor/plating)
+	//for(var/turf/T in range(3, rear)+range(3, left)+range(3, right)+range(3, front)+range(4, front_right)+range(4, front_left)+range(4, rear_right)+range(4, rear_left))
+	//	T.empty(/turf/open/floor/plating)
 
 	// Big explosions
 
@@ -57,15 +56,6 @@
 	explosion(rear_left, 3, 4, 7, 0)
 */
 // -- Shuttles
-
-/obj/docking_port/stationary/crashmode/bigbury // How-to-use: Put ontop/below of an allready existing crash dock site.
-	id = "bigbury_dock"
-	name = "Bigbury Crash Site"
-	dir = SOUTH
-	width = 19
-	height = 31
-	dwidth = 9
-	dheight = 15
 
 /obj/docking_port/mobile/crashmode
 	name = "TGS Canterbury"

--- a/code/modules/shuttle/gamemodes/crash.dm
+++ b/code/modules/shuttle/gamemodes/crash.dm
@@ -8,42 +8,7 @@
 	dwidth = 9
 	dheight = 15
 
-///obj/docking_port/stationary/crashmode/on_crash()
-	//clear areas around the shuttle with explosions
-	//var/turf/C = return_center_turf()
-
-	//var/cos = 1
-	//var/sin = 0
-	//switch(dir)
-		//if(WEST)
-			//cos = 0
-			//sin = 1
-		//if(SOUTH)
-			//cos = -1
-			//sin = 0
-		//if(EAST)
-			//cos = 0
-			//sin = -1
-
-	//var/updown = (round(width/2))*sin + (round(height/2))*cos
-	//var/leftright = (round(width/2))*cos - (round(height/2))*sin
-
-	//var/turf/front = locate(C.x, C.y - updown, C.z)
-	//var/turf/rear = locate(C.x, C.y + updown, C.z)
-	//var/turf/left = locate(C.x - leftright, C.y, C.z)
-	//var/turf/right = locate(C.x + leftright, C.y, C.z)
-
-	//var/turf/front_right = locate(C.x - round(leftright/2), C.y - round(updown/2), C.z)
-	//var/turf/front_left = locate(C.x + round(leftright/2), C.y - round(updown/2), C.z)
-	//var/turf/rear_right = locate(C.x - round(leftright/2), C.y + round(updown/2), C.z)
-	//var/turf/rear_left = locate(C.x + round(leftright/2), C.y + round(updown/2), C.z)
-
-
-	// just wipe the turfs
-	//for(var/turf/T in range(3, rear)+range(3, left)+range(3, right)+range(3, front)+range(4, front_right)+range(4, front_left)+range(4, rear_right)+range(4, rear_left))
-	//	T.empty(/turf/open/floor/plating)
-
-	// Big explosions
+// Big explosions
 
 /*	explosion(front, 3, 4, 7, 0)
 	explosion(rear, 3, 4, 7, 0)
@@ -55,6 +20,7 @@
 	explosion(rear_right, 4, 6, 10, 0)
 	explosion(rear_left, 3, 4, 7, 0)
 */
+
 // -- Shuttles
 
 /obj/docking_port/mobile/crashmode

--- a/code/modules/shuttle/gamemodes/crash.dm
+++ b/code/modules/shuttle/gamemodes/crash.dm
@@ -58,7 +58,7 @@
 */
 // -- Shuttles
 
-/obj/docking_port/stationary/crashmode/bigbury
+/obj/docking_port/stationary/crashmode/bigbury // How-to-use: Put ontop/below of an allready existing crash dock site.
 	id = "bigbury_dock"
 	name = "Bigbury Crash Site"
 	dir = SOUTH


### PR DESCRIPTION
## About The Pull Request
![dreammaker_2020-09-05_17-19-34](https://user-images.githubusercontent.com/17747087/92308226-9dd2dc80-ef9c-11ea-845c-5cb2a3ef2ba8.png)
1: Replaced box of beakers with 2 bluespace beakers for the CMO to muck about with chemistry
2: Cockpit floor has been made more blue to fit the theme better.
3: The 2 storages places on the left and right got some mainship floor tiles so it looks a tiny bit better.
4: Deleted some code that was causing some issues with the bigbury shuttle during the original testing of the shuttle, and now the canterbury and bigbury share the same stationary ports.

## Why It's Good For The Game
More flavor from floors is allways good.
2 Bluespace beakers should allow CMO to have more fun with chemistry, seen a CMO or two that was slightly annoyed at the lack of them, and with the seemingly token box of beakers instead.
Also should make it so mappers don't have a big issue wondering why there is 2 crashmode docks with one being titled "bigbury".

## Changelog
:cl: Vondiech
tweak: The TGMC is now distributing blueprints of a revised bigbury ship, fixing small issues that was brought up about it.
/:cl:
