### PR TITLE
Buffs Incendiary OB fire into the same as X Fuel (Blue Fire) (This time not commited to master)

### DIFF
--- a/code/game/objects/structures/orbital_cannon.dm
+++ b/code/game/objects/structures/orbital_cannon.dm
@@ -377,7 +377,7 @@
 
 /obj/structure/ob_ammo/warhead/incendiary/warhead_impact(turf/target, inaccuracy_amt = 0)
 	var/range_num = max(15 - inaccuracy_amt, 12)
-	flame_radius(range_num, target)
+	flame_radius(range_num, target,	burn_intensity = 36, burn_duration = 40, colour = "blue")
 
 
 /obj/structure/ob_ammo/warhead/cluster


### PR DESCRIPTION

<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the fire to that of the same as the X fuel flames
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Incine OB only reliably kills if the target is in the middle of it. Even then higher tiers of xenos can wait out in the middle of the fire and wait for a extinguished flame tile and roll on it safely. This allows the fire to do more damage and last longer to prevent it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Incendiary OB flames were changed to the same stats as X fuel (Burn Intensity 36, Duration 40) Old stats were 25 Intensity and 25 Duration.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
