### PR TITLE
Burger's Attempt at a Xeno Regeneration Nerf

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -133,7 +133,7 @@
 	if(updating_health)
 		updatehealth()
 
-	regen_power = 0
+	regen_power = -5 //This will take 10 seconds to kick in as I have been told that 1 life tick is 2 seconds.
 
 	return damage
 

--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -132,6 +132,9 @@
 
 	if(updating_health)
 		updatehealth()
+
+	regen_power = 0
+
 	return damage
 
 

--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -133,7 +133,7 @@
 	if(updating_health)
 		updatehealth()
 
-	regen_power = -5 //This will take 10 seconds to kick in as I have been told that 1 life tick is 2 seconds.
+	regen_power = -xeno_caste.regen_delay //Remember, this is in deciseconds.
 
 	return damage
 

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -98,7 +98,7 @@
 		amount += recovery_aura * maxHealth * 0.008 // +0.8% max health per recovery level, up to +4%
 	if(scaling)
 		if(recovery_aura)
-			regen_power = clamp(regen_power + 0.2,0.2,1) //Ignores the 10 second cooldown.
+			regen_power = clamp(regen_power + 0.4,0.4,1) //Ignores the 10 second cooldown, and gives a boost.
 		else if(regen_power < 0) // We're not supposed to regenerate yet. This will take 10 seconds to kick from being damaged in as I have been told that 1 life tick is 2 seconds.
 			regen_power++
 			return

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -80,9 +80,9 @@
 
 	if(locate(/obj/effect/alien/weeds) in T || xeno_caste.caste_flags & CASTE_INNATE_HEALING) //We regenerate on weeds or can on our own.
 		if(lying_angle || resting || xeno_caste.caste_flags & CASTE_QUICK_HEAL_STANDING)
-			heal_wounds(XENO_RESTING_HEAL * ruler_healing_penalty)
+			heal_wounds(XENO_RESTING_HEAL * ruler_healing_penalty, TRUE)
 		else
-			heal_wounds(XENO_STANDING_HEAL * ruler_healing_penalty) //Major healing nerf if standing.
+			heal_wounds(XENO_STANDING_HEAL * ruler_healing_penalty, TRUE) //Major healing nerf if standing.
 	updatehealth()
 
 /mob/living/carbon/xenomorph/proc/handle_critical_health_updates()
@@ -92,8 +92,11 @@
 	else
 		adjustBruteLoss(XENO_CRIT_DAMAGE - warding_aura) //Warding can heavily lower the impact of bleedout. Halved at 2.5 phero, stopped at 5 phero
 
-/mob/living/carbon/xenomorph/proc/heal_wounds(multiplier = XENO_RESTING_HEAL)
-	var/amount = (1 + (maxHealth * 0.03) ) // 1 damage + 3% max health
+/mob/living/carbon/xenomorph/proc/heal_wounds(multiplier = XENO_RESTING_HEAL, var/scaling = FALSE)
+	var/amount = 1 + (maxHealth * 0.02 * regen_power) // 1 damage + 2% max health, with scaling power.
+	if(scaling)
+		regen_power = min(regen_power + 0.08,1)
+		amount *= regen_power
 	if(recovery_aura)
 		amount += recovery_aura * maxHealth * 0.008 // +0.8% max health per recovery level, up to +4%
 	amount *= multiplier

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -94,14 +94,17 @@
 
 /mob/living/carbon/xenomorph/proc/heal_wounds(multiplier = XENO_RESTING_HEAL, var/scaling = FALSE)
 	var/amount = 1 + (maxHealth * 0.02) // 1 damage + 2% max health, with scaling power.
-	if(scaling)
-		if(regen_power < 0) // We're not supposed to regenerate yet. This will take 10 seconds to kick from being damaged in as I have been told that 1 life tick is 2 seconds.
-			regen_power++
-			return
-		regen_power = min(regen_power + 0.08,1)
-		amount *= regen_power
 	if(recovery_aura)
 		amount += recovery_aura * maxHealth * 0.008 // +0.8% max health per recovery level, up to +4%
+	if(scaling)
+		if(recovery_aura)
+			regen_power = clamp(regen_power + 0.2,0.2,1) //Ignores the 10 second cooldown.
+		else if(regen_power < 0) // We're not supposed to regenerate yet. This will take 10 seconds to kick from being damaged in as I have been told that 1 life tick is 2 seconds.
+			regen_power++
+			return
+		else
+			regen_power = min(regen_power + 0.2,1) //0.2 means 10% regen every second, up to 100%.
+		amount *= regen_power
 	amount *= multiplier
 	adjustBruteLoss(-amount)
 	adjustFireLoss(-amount)

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -93,7 +93,7 @@
 		adjustBruteLoss(XENO_CRIT_DAMAGE - warding_aura) //Warding can heavily lower the impact of bleedout. Halved at 2.5 phero, stopped at 5 phero
 
 /mob/living/carbon/xenomorph/proc/heal_wounds(multiplier = XENO_RESTING_HEAL, var/scaling = FALSE)
-	var/amount = 1 + (maxHealth * 0.02) // 1 damage + 2% max health, with scaling power.
+	var/amount = 1 + (maxHealth * 0.03) // 1 damage + 2% max health, with scaling power.
 	if(recovery_aura)
 		amount += recovery_aura * maxHealth * 0.008 // +0.8% max health per recovery level, up to +4%
 	if(scaling)

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -93,8 +93,11 @@
 		adjustBruteLoss(XENO_CRIT_DAMAGE - warding_aura) //Warding can heavily lower the impact of bleedout. Halved at 2.5 phero, stopped at 5 phero
 
 /mob/living/carbon/xenomorph/proc/heal_wounds(multiplier = XENO_RESTING_HEAL, var/scaling = FALSE)
-	var/amount = 1 + (maxHealth * 0.02 * regen_power) // 1 damage + 2% max health, with scaling power.
+	var/amount = 1 + (maxHealth * 0.02) // 1 damage + 2% max health, with scaling power.
 	if(scaling)
+		if(regen_power < 0) // We're not supposed to regenerate yet. This will take 10 seconds to kick from being damaged in as I have been told that 1 life tick is 2 seconds.
+			regen_power++
+			return
 		regen_power = min(regen_power + 0.08,1)
 		amount *= regen_power
 	if(recovery_aura)

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -92,18 +92,18 @@
 	else
 		adjustBruteLoss(XENO_CRIT_DAMAGE - warding_aura) //Warding can heavily lower the impact of bleedout. Halved at 2.5 phero, stopped at 5 phero
 
-/mob/living/carbon/xenomorph/proc/heal_wounds(multiplier = XENO_RESTING_HEAL, var/scaling = FALSE)
+/mob/living/carbon/xenomorph/proc/heal_wounds(multiplier = XENO_RESTING_HEAL, scaling = FALSE)
 	var/amount = 1 + (maxHealth * 0.03) // 1 damage + 2% max health, with scaling power.
 	if(recovery_aura)
 		amount += recovery_aura * maxHealth * 0.008 // +0.8% max health per recovery level, up to +4%
 	if(scaling)
 		if(recovery_aura)
-			regen_power = clamp(regen_power + 0.4,0.4,1) //Ignores the 10 second cooldown, and gives a boost.
-		else if(regen_power < 0) // We're not supposed to regenerate yet. This will take 10 seconds to kick from being damaged in as I have been told that 1 life tick is 2 seconds.
-			regen_power++
+			regen_power = clamp(regen_power + xeno_caste.regen_ramp_amount*30,0,1) //Ignores the cooldown, and gives a 50% boost.
+		else if(regen_power < 0) // We're not supposed to regenerate yet. Start a countdown for regeneration.
+			regen_power += 2 SECONDS //Life ticks are 2 seconds.
 			return
 		else
-			regen_power = min(regen_power + 0.2,1) //0.2 means 10% regen every second, up to 100%.
+			regen_power = min(regen_power + xeno_caste.regen_ramp_amount*20,1)
 		amount *= regen_power
 	amount *= multiplier
 	adjustBruteLoss(-amount)

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -32,6 +32,10 @@
 	// *** Speed *** //
 	var/speed = 1
 
+	// *** Regeneration Delay ***//
+	var/regen_delay = 10 SECONDS //Time after you take damage before you can regen.
+	var/regen_ramp_amount = 0.005 //Regeneration power increases by this amount evey decisecond.
+
 	// *** Plasma *** //
 	var/plasma_max = 10
 	var/plasma_gain = 5
@@ -176,7 +180,10 @@
 	var/warding_aura = 0
 	var/recovery_aura = 0
 
-	var/regen_power = 0 //Increases by 0.1 every time you regen. Resets when you take damage.
+	var/regen_power = 0 //Resets to -xeno_caste.regen_delay when you take damage.
+	//Negative values act as a delay while values greater than 0 act as a multiplier.
+	//Will increase by 10 every decisecond if under 0. Increases by xeno_caste.regen_ramp_amount every decisecond.
+	//If you want to balance this, look at the xeno_caste defines mentioned above.
 
 	var/is_zoomed = 0
 	var/zoom_turf = null

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -176,6 +176,8 @@
 	var/warding_aura = 0
 	var/recovery_aura = 0
 
+	var/regen_power = 0 //Increases by 0.1 every time you regen. Resets when you take damage.
+
 	var/is_zoomed = 0
 	var/zoom_turf = null
 	var/attack_delay = 0 //Bonus or pen to time in between attacks. + makes slashes slower.


### PR DESCRIPTION
## About The Pull Request

When you take damage as a xenomorph, you cannot regenerate your health PASSIVELY for 10 seconds. A regen aura bypasses this.
When you can regenerate, your regeneration powers start off at 0. It increases by 5% every 1 second, up to 100%. A regen aura changes this to bypass the initial 10 second cooldown, and increases it by 7.5% every 1 seconds. Note that the 1 health per 2 seconds that you gain is not affected by this.


## Why It's Good For The Game

As a returning player, I noticed that Xenos were buffed like crazy when it comes to passive health regeneration. While this does improve the flow of gameplay a certain amount, it creates a new problem where Xenomorphs can shrug off insane amounts of damage after encounters like it was nothing, resulting in xenos charging in mindlessly and then running away after they take 50% of their max health, only to regenerate it after a few seconds and repeat the process.

This PR aims to make it so that it is no longer as easy to do this. If you take significant damage, you must actually wait some time before returning to perform hit and run attacks instead of shrugging it off 5 seconds later. I've played several Xeno rounds and noticed that it is super easy to make attacks on marines, flee for 4 seconds while resting, and then get back up again. This PR also makes it so that it is faster to regenerate 75% of your health once than regenerating 25% of your health 3 times with the scaling system.

## Changelog
:cl: BurgerBB
balance: Taking damage as a Xenomorph disables PASSIVE regeneration for 10 seconds. When the 10 seconds are up, you regenerate your health at 0% strength, but it increases by 5% every second, up to 100%.
balance: A regeneration aura changes this behavior by disabling the 10 second cooldown, and regenerating your health by  0% strength, but it increases by 7.5% every second, up to 100%.
/:cl:
