### PR TITLE
Flamer changes

### DIFF
--- a/code/game/objects/items/tools/maintenance_tools.dm
+++ b/code/game/objects/items/tools/maintenance_tools.dm
@@ -381,7 +381,7 @@
 	icon = 'icons/obj/items/items.dmi'
 	icon_state = "welderpack"
 	w_class = WEIGHT_CLASS_BULKY
-	var/max_fuel = 600 //Because the marine backpack can carry 260, and still allows you to take items, there should be a reason to still use this one.
+	var/max_fuel = 500 //Because the marine backpack can carry 260, and still allows you to take items, there should be a reason to still use this one.
 
 /obj/item/tool/weldpack/Initialize()
 	. = ..()
@@ -462,4 +462,4 @@
 	flags_equip_slot = ITEM_SLOT_BACK
 	icon_state = "marine_flamerpack"
 	w_class = WEIGHT_CLASS_BULKY
-	max_fuel = 700 //Because the marine backpack can carry 260, and still allows you to take items, there should be a reason to still use this one.
+	max_fuel = 500 //Because the marine backpack can carry 260, and still allows you to take items, there should be a reason to still use this one.

--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -25,7 +25,7 @@
 	flags_gun_features = GUN_UNUSUAL_DESIGN|GUN_WIELDED_FIRING_ONLY|GUN_AMMO_COUNTER
 	gun_skill_category = GUN_SKILL_HEAVY_WEAPONS
 	attachable_offset = list("rail_x" = 12, "rail_y" = 23)
-	fire_delay = 20
+	fire_delay = 4
 
 
 /obj/item/weapon/gun/flamer/unique_action(mob/user)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
 Changes flamers. Much higher firerate, lowered welding kit capacity.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Flamers are currently inferior to miniflamers in nearly every niche due to reload speed and firerate. This isn't really acceptable for a primary, so this changes that without significantly affecting the DPS. 

You still do roughly the same damage, but a miss isn't a "well fuck, guess I'm getting beat to shit", and you can reliably coat large areas. 

Also, being able to carry around 0.7 Welding Fuel tanks feels wrong so I lowered it to 0.5 Welding Fuel tanks (a 50% increase over a satchel full of fuel tanks) so that you might actually need to restock occasionally.

Also, given as we have 2 backpack tanks with the same capacity and stats, but different sprites, there's a clear niche to move one (ideally the standard pack) to the belt slot with ~350u (for a 50% increase over the 3 tanks you could normally hold there), but mobsprites are hard so I'll leave that to kuro. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Lowered both flamer fire delays from 2 seconds to 0.4 seconds. 
balance: Lowered welding fuel backpacks capacity from 600 and 700 to 500 for both.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
