### PR TITLE
Adds a Memorial to the Sulaco

### DIFF
--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -881,10 +881,6 @@
 	dir = 8
 	},
 /area/sulaco/medbay/storage2)
-"adm" = (
-/obj/structure/table/mainship,
-/turf/open/floor/plating,
-/area/sulaco/maintenance/north_solar_maint)
 "adn" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1082,17 +1078,6 @@
 	dir = 4
 	},
 /area/sulaco/medbay/storage2)
-"adS" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/largecrate/random,
-/turf/open/floor/plating,
-/area/sulaco/maintenance/north_solar_maint)
-"adU" = (
-/obj/machinery/vending/tool,
-/turf/open/floor/plating,
-/area/sulaco/maintenance/north_solar_maint)
 "adX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/prison/sterilewhite,
@@ -2854,11 +2839,6 @@
 /obj/item/clothing/glasses/welding,
 /turf/open/floor/prison/darkyellow/corner,
 /area/sulaco/engineering)
-"akp" = (
-/obj/structure/sign/prop1,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/sulaco/maintenance/north_solar_maint)
 "akq" = (
 /obj/structure/table/mainship,
 /turf/open/floor/prison/sterilewhite,
@@ -2998,9 +2978,6 @@
 /area/sulaco/maintenance/north_solar_maint)
 "akW" = (
 /turf/closed/wall/mainship/gray,
-/area/sulaco/briefing)
-"akX" = (
-/turf/open/floor/plating,
 /area/sulaco/briefing)
 "akZ" = (
 /obj/structure/table/mainship,
@@ -3176,7 +3153,7 @@
 /obj/machinery/door/airlock/mainship/maint,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/sulaco/maintenance/north_solar_maint)
+/area/mainship/living/starboard_garden)
 "alJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3281,8 +3258,8 @@
 /area/sulaco/maintenance/north_solar_maint)
 "alZ" = (
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/sulaco/maintenance/north_solar_maint)
+/turf/open/floor/grass,
+/area/mainship/living/starboard_garden)
 "ama" = (
 /obj/machinery/vending/MarineMed,
 /obj/structure/sign/greencross,
@@ -4112,7 +4089,6 @@
 /area/sulaco/briefing)
 "apQ" = (
 /obj/structure/bed/chair,
-/obj/structure/cable,
 /turf/open/floor/prison/red{
 	dir = 9
 	},
@@ -4476,13 +4452,6 @@
 	},
 /turf/open/floor/prison/red,
 /area/sulaco/briefing)
-"arp" = (
-/obj/structure/bed/chair,
-/obj/structure/cable,
-/turf/open/floor/prison/red{
-	dir = 8
-	},
-/area/sulaco/briefing)
 "arq" = (
 /obj/structure/bed/chair,
 /turf/open/floor/prison/darkyellow{
@@ -4826,11 +4795,12 @@
 /turf/open/floor/prison,
 /area/sulaco/cargo)
 "asv" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 1
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/bed/stool{
+	pixel_y = 8
 	},
-/turf/open/floor/plating,
-/area/sulaco/briefing)
+/turf/open/floor/grass,
+/area/mainship/living/starboard_garden)
 "asz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -10816,6 +10786,11 @@
 	dir = 10
 	},
 /area/sulaco/research)
+"aSZ" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/cable,
+/turf/open/floor/grass,
+/area/mainship/living/starboard_garden)
 "aTa" = (
 /obj/machinery/chem_dispenser,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -12872,6 +12847,10 @@
 /obj/machinery/computer3/server,
 /turf/open/floor/mainship/ai,
 /area/sulaco/command/ai)
+"cSg" = (
+/obj/item/clothing/head/modular/marine,
+/turf/open/floor/prison/sterilewhite,
+/area/mainship/living/starboard_garden)
 "cSO" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor/prison,
@@ -13034,6 +13013,11 @@
 /obj/machinery/alarm,
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_main_hall)
+"dLt" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic/garden,
+/obj/structure/cable,
+/turf/open/floor/prison,
+/area/mainship/living/starboard_garden)
 "dLR" = (
 /obj/machinery/light{
 	dir = 4
@@ -13059,6 +13043,10 @@
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/hallway/central_hall2)
+"dOR" = (
+/obj/structure/prop/mainship/valmoric,
+/turf/open/floor/prison/sterilewhite,
+/area/mainship/living/starboard_garden)
 "dQm" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 5
@@ -13143,6 +13131,13 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/mainship/ai,
 /area/sulaco/command/ai)
+"eip" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/bed/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/grass,
+/area/space)
 "ejj" = (
 /obj/structure/table/mainship,
 /obj/item/healthanalyzer,
@@ -13171,6 +13166,9 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall3)
+"erP" = (
+/turf/closed/wall/mainship/gray,
+/area/mainship/living/starboard_garden)
 "esb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -13194,6 +13192,10 @@
 	},
 /turf/open/floor/plating/platebotc,
 /area/sulaco/cargo)
+"euA" = (
+/obj/machinery/status_display,
+/turf/closed/wall/mainship/gray,
+/area/mainship/living/starboard_garden)
 "ews" = (
 /obj/effect/landmark/start/job/shiptech,
 /obj/structure/cable,
@@ -13253,6 +13255,14 @@
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/prison,
 /area/sulaco/cargo/office)
+"eLL" = (
+/obj/structure/bed/stool{
+	pixel_y = 8
+	},
+/obj/machinery/power/apc/mainship,
+/obj/structure/cable,
+/turf/open/floor/grass,
+/area/space)
 "eMk" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -13303,12 +13313,10 @@
 /turf/open/floor/prison,
 /area/sulaco/maintenance/lower_maint)
 "eZy" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 1
-	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/sulaco/briefing)
+/obj/structure/window/framed/mainship/gray,
+/turf/open/floor/plating/platebotc,
+/area/mainship/living/starboard_garden)
 "faO" = (
 /turf/open/floor/plating/platebotc,
 /area/sulaco/maintenance/lower_maint)
@@ -13326,6 +13334,10 @@
 /turf/open/floor/mainship/terragov/north{
 	dir = 5
 	},
+/area/space)
+"fgG" = (
+/obj/item/reagent_containers/food/snacks/grown/poppy,
+/turf/open/floor/mainship/mono,
 /area/space)
 "fhh" = (
 /obj/structure/cable,
@@ -13599,6 +13611,10 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/prison/red,
 /area/sulaco/briefing)
+"gid" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/grass,
+/area/space)
 "giH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -13808,6 +13824,9 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/maintenance/lower_maint)
+"hmS" = (
+/turf/open/floor/mainship/mono,
+/area/space)
 "hnW" = (
 /obj/structure/target_stake,
 /obj/item/target,
@@ -13878,6 +13897,10 @@
 	dir = 4
 	},
 /area/sulaco/medbay)
+"hNN" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
+/area/space)
 "hPG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13900,6 +13923,10 @@
 	},
 /turf/open/floor/mainship/ai,
 /area/sulaco/command/ai)
+"hQN" = (
+/obj/structure/prop/mainship/ship_memorial,
+/turf/open/floor/prison/sterilewhite,
+/area/mainship/living/starboard_garden)
 "hSa" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 9
@@ -14177,6 +14204,9 @@
 /obj/structure/cable,
 /turf/open/floor/prison/darkyellow,
 /area/sulaco/engineering/engine)
+"iJu" = (
+/turf/closed/wall/mainship/gray/outer,
+/area/mainship/living/starboard_garden)
 "iKv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
@@ -14282,6 +14312,9 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating/platebotc,
 /area/sulaco/liaison)
+"jyM" = (
+/turf/open/floor/grass,
+/area/space)
 "jAp" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -14329,6 +14362,21 @@
 	},
 /turf/open/floor/freezer,
 /area/sulaco/showers)
+"jHO" = (
+/obj/structure/prop/mainship/ship_memorial,
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/space)
+"jJe" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/bed/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/grass,
+/area/mainship/living/starboard_garden)
 "jKe" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold4w/cyan/hidden/layer1,
@@ -14400,6 +14448,20 @@
 "kji" = (
 /turf/open/floor/prison/red,
 /area/sulaco/hangar/one)
+"kjm" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/bed/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/grass,
+/area/mainship/living/starboard_garden)
+"kla" = (
+/obj/structure/sign/prop1,
+/turf/closed/wall/mainship/gray,
+/area/sulaco/briefing)
 "kme" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -14530,6 +14592,15 @@
 /obj/machinery/door/poddoor/open/sb,
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall2)
+"kML" = (
+/turf/open/floor/prison/sterilewhite,
+/area/mainship/living/starboard_garden)
+"kSh" = (
+/obj/structure/bed/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/grass,
+/area/mainship/living/starboard_garden)
 "kTk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
@@ -14810,9 +14881,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 1
-	},
+/obj/machinery/door/airlock/mainship/maint,
 /turf/open/floor/plating,
 /area/sulaco/cryosleep)
 "mak" = (
@@ -15083,6 +15152,10 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall3)
+"ngh" = (
+/obj/structure/window/framed/mainship/gray,
+/turf/open/floor/plating/platebotc,
+/area/sulaco/briefing)
 "nhR" = (
 /obj/structure/closet/crate/medical,
 /obj/machinery/power/apc/mainship{
@@ -15408,6 +15481,10 @@
 /obj/structure/cable,
 /turf/open/floor/mainship_hull/gray,
 /area/space)
+"osv" = (
+/obj/structure/window/framed/mainship/gray,
+/turf/open/floor/plating/platebotc,
+/area/mainship/living/starboard_garden)
 "otR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
@@ -15542,6 +15619,13 @@
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
+"oUA" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/bed/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/grass,
+/area/mainship/living/starboard_garden)
 "oUD" = (
 /obj/effect/landmark/start/job/shiptech,
 /obj/structure/cable,
@@ -15609,6 +15693,10 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
+"pfX" = (
+/obj/structure/cable,
+/turf/open/floor/grass,
+/area/space)
 "pks" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -15854,6 +15942,16 @@
 /obj/structure/disposalpipe/segment/corner,
 /turf/open/floor/freezer,
 /area/sulaco/showers)
+"qcz" = (
+/obj/machinery/power/apc/mainship{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/bed/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/grass,
+/area/mainship/living/starboard_garden)
 "qdr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -16063,6 +16161,10 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/prison/plate,
 /area/sulaco/cargo)
+"rai" = (
+/obj/structure/window/framed/mainship/gray,
+/turf/open/floor/plating/platebotc,
+/area/sulaco/cryosleep)
 "rbr" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 1
@@ -16313,6 +16415,10 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/engineering/engine)
+"rQi" = (
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/space)
 "rQp" = (
 /obj/machinery/vending/marine/cargo_ammo,
 /turf/open/floor/prison,
@@ -16476,6 +16582,13 @@
 	dir = 8
 	},
 /area/sulaco/briefing)
+"slc" = (
+/obj/machinery/alarm,
+/obj/structure/bed/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/grass,
+/area/mainship/living/starboard_garden)
 "smG" = (
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/closed/wall/mainship/gray,
@@ -16486,6 +16599,10 @@
 /obj/structure/window/framed/mainship/gray/toughened/hull,
 /turf/open/floor/plating/platebotc,
 /area/sulaco/maintenance/lower_maint)
+"som" = (
+/obj/machinery/door/airlock/mainship/maint,
+/turf/open/floor/plating,
+/area/sulaco/maintenance/north_solar_maint)
 "soQ" = (
 /obj/structure/cable,
 /turf/open/floor/prison/red/full{
@@ -16724,6 +16841,9 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/plating,
 /area/sulaco/maintenance/lower_maint2)
+"sQE" = (
+/turf/open/floor/grass,
+/area/mainship/living/starboard_garden)
 "sSu" = (
 /obj/structure/closet/secure_closet/medical2,
 /turf/open/floor/prison/sterilewhite,
@@ -16919,6 +17039,13 @@
 /obj/structure/cable,
 /turf/open/space,
 /area/space)
+"tzw" = (
+/obj/structure/bed/stool{
+	pixel_y = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/grass,
+/area/mainship/living/starboard_garden)
 "tzU" = (
 /obj/machinery/door/airlock/hatch/engineering{
 	name = "EVA"
@@ -17066,6 +17193,13 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/cargo)
+"uiN" = (
+/obj/structure/cable,
+/obj/structure/bed/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/grass,
+/area/mainship/living/starboard_garden)
 "ulm" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -17805,6 +17939,15 @@
 	dir = 8
 	},
 /area/sulaco/medbay/west)
+"wVV" = (
+/turf/open/floor/prison,
+/area/mainship/living/starboard_garden)
+"wVZ" = (
+/obj/structure/bed/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/grass,
+/area/space)
 "wXI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
@@ -17889,6 +18032,10 @@
 /obj/machinery/computer3/server/rack,
 /turf/open/floor/mainship/ai,
 /area/sulaco/command/ai)
+"xve" = (
+/obj/item/reagent_containers/food/snacks/grown/poppy,
+/turf/open/floor/prison/sterilewhite,
+/area/mainship/living/starboard_garden)
 "xvh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -17902,6 +18049,13 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall)
+"xvj" = (
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 2;
+	name = "Custodial Closet"
+	},
+/turf/open/floor/plating,
+/area/mainship/living/starboard_garden)
 "xxV" = (
 /obj/structure/cable,
 /turf/closed/wall/mainship/outer,
@@ -17925,6 +18079,13 @@
 	},
 /turf/open/floor/cult,
 /area/sulaco/morgue)
+"xBs" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/bed/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/grass,
+/area/mainship/living/starboard_garden)
 "xCi" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/decal/cleanable/cobweb{
@@ -18005,6 +18166,11 @@
 	},
 /turf/open/floor/prison/plate,
 /area/shuttle/distress/arrive_1)
+"xTI" = (
+/obj/item/reagent_containers/food/snacks/grown/poppy,
+/obj/structure/cable,
+/turf/open/floor/mainship/mono,
+/area/space)
 "xVg" = (
 /obj/structure/table/mainship,
 /obj/item/reagent_containers/spray,
@@ -18015,6 +18181,13 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/sulaco/maintenance/lower_maint)
+"xWz" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/bed/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/grass,
+/area/mainship/living/starboard_garden)
 "xWH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
@@ -49996,13 +50169,13 @@ cJZ
 mDu
 mDu
 mDu
-mDu
-aYZ
-aYZ
-aYZ
-aYZ
+iJu
+iJu
+iJu
+iJu
+iJu
 alI
-akW
+erP
 akW
 akW
 akW
@@ -50253,13 +50426,13 @@ mDu
 mDu
 mDu
 mDu
-mDu
-aYZ
-aiE
-ajU
-akT
+iJu
+slc
+kjm
+xWz
+qcz
 alZ
-akW
+euA
 anr
 apa
 arm
@@ -50487,11 +50660,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+wVZ
+hNN
+jyM
+gid
+jyM
 aaa
 aaa
 aaa
@@ -50510,13 +50683,13 @@ mDu
 mDu
 mDu
 mDu
-mDu
-aYZ
-aiF
-aaW
-aaW
-alZ
-akW
+iJu
+kSh
+kML
+hQN
+xve
+uiN
+erP
 aoz
 apO
 arn
@@ -50744,11 +50917,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eLL
+rQi
+jHO
+xTI
+pfX
 aaa
 aaa
 aaa
@@ -50767,13 +50940,13 @@ mDu
 mDu
 mDu
 mDu
-mDu
-aYZ
-aiG
-aaW
-aaW
-akp
-akW
+iJu
+kSh
+kML
+kML
+xve
+uiN
+erP
 aoA
 apP
 apP
@@ -51001,11 +51174,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+eip
+hmS
+hmS
+fgG
+jyM
 aaa
 aaa
 aaa
@@ -51017,7 +51190,6 @@ aaa
 nzi
 mDu
 mDu
-mDu
 aYZ
 aYZ
 aYZ
@@ -51025,17 +51197,18 @@ aYZ
 aYZ
 aYZ
 aYZ
-aYZ
-aiH
-aaW
-aaW
-alZ
+iJu
+xBs
+kML
+dOR
+cSg
+tzw
 eZy
-aoB
+anr
 apQ
-arp
-arp
-arp
+awb
+awb
+awb
 cVn
 awb
 ayP
@@ -51275,24 +51448,24 @@ mDu
 mDu
 mDu
 aYZ
-aYZ
-acx
-aaW
-adS
+aiE
+ajU
+akT
+aiH
+aiG
 aeM
-aaW
-aaW
-anZ
-aaW
-aaW
-akV
-amb
-abs
-anr
-anr
-anr
-anr
-anr
+erP
+kSh
+xve
+hQN
+xve
+aSZ
+dLt
+aoB
+aoB
+aoB
+aoB
+aoB
 xPO
 anr
 anr
@@ -51532,19 +51705,19 @@ mDu
 aYZ
 aYZ
 aYZ
-acx
+aiF
 aaW
 aaW
 aaW
 aaW
 aaW
-aaW
-aaw
-aaw
-aaw
-akW
-akW
-akW
+xvj
+sQE
+kML
+kML
+kML
+sQE
+wVV
 anr
 apR
 arq
@@ -51795,13 +51968,13 @@ aaW
 aaW
 acy
 aaW
-aaW
-aaW
-aaW
-aaW
-akX
+erP
+oUA
+jJe
+kSh
+xBs
 asv
-anr
+osv
 anr
 apS
 apS
@@ -52046,18 +52219,18 @@ mDu
 aYZ
 aaV
 aaW
-acy
 aaW
-adm
-adU
+aaW
+akV
+amb
 aaw
 aaw
 fdF
 fdF
 fdF
-fdF
-akW
-akW
+rai
+ngh
+kla
 akW
 anr
 apT
@@ -52304,7 +52477,7 @@ aYZ
 aaW
 aaw
 aaw
-anZ
+som
 aaw
 aaw
 aaw

--- a/strings/tips/marine.txt
+++ b/strings/tips/marine.txt
@@ -5,7 +5,6 @@ Using a multitool on a lasgun battery will turn it into an improvised explosive 
 In a pinch, you can use lasgun batteries to power APCs and sentry guns.
 Lasgun batteries can be recharged in APCs and power cell rechargers, if the generators are on.
 As a marine, if you aren't a PFC, then you have a special room in prep with special gear vendors.
-AP, Hollowpoint or Incendiary bullets aren't always better: they have their own specialized uses; AP deals less damage, but better at piercing through armor. Hollowpoint is the reverse and Incendiary bullets makes any target burst into flames upon impact!
 Sidearms aren't complete garbage. They are often faster than reloading if in a very tight situation, it may save your life. 
 The Revolver and Service Pistol can be decent primary weapons if used properly, though with the short magazine capacity, expect to run dry on ammo quick!
 There is no "best" loadout. Experiment and find what works for you.
@@ -80,3 +79,4 @@ As the Captain, you have a unique Mateba revolver that takes a chunk of a target
 As the Captain or the Field Commander, you have a unique T-90A smartgun inside the emergency gun cabinet. You can use this as your primary weapon should you decide to fight.
 Even if a patient dies a second after being successfully revived by a defibrillator, this resets the time it takes for them to become permanently brain dead.
 Don't forget that xenomorphs spawn infinitely during the Crash gamemode. Don't waste too much time hunting xenomorphs down!
+You can memorialize fallen marines by using their dogtags on the ship's memorial! Memorialized solders will be displayed at the end of the round.


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a memorial to the Sulaco.
Adds a tip about using memorial slabs.
Removes an outdated tip on ammo types.

## Why It's Good For The Game

The Sulaco was missing the extremely important element of being able to memorialize fallen marines.

Added a tip so people know you can use dogtags on memorials.

Preview: https://i.imgur.com/FkBQ9ZW.png
## Changelog
:cl:
add: The Sulaco now has a memorial above the briefing room.
add: Added a tip explaining how to use dogtags on memorials.
del: Removed an outdated tip on ammo types.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
