### PR TITLE
More PoS Changes

### DIFF
--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -883,6 +883,14 @@
 "cC" = (
 /turf/closed/wall/mainship/white,
 /area/mainship/medical/operating_room_one)
+"cD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/mainship,
+/area/mainship/living/cafeteria_starboard)
 "cE" = (
 /obj/machinery/light{
 	dir = 1
@@ -895,6 +903,15 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"cG" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/shipboard/weapon_room)
 "cH" = (
 /obj/effect/decal/siding{
 	dir = 8
@@ -976,11 +993,6 @@
 /obj/machinery/autodoc_console,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
-"cW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
-/turf/open/floor/mainship/cargo,
-/area/mainship/squads/general)
 "cX" = (
 /obj/structure/largecrate/supply,
 /turf/open/floor/mainship/mono,
@@ -1007,6 +1019,13 @@
 	},
 /turf/open/floor/mainship/sterile/plain,
 /area/mainship/hallways/hangar)
+"db" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8;
+	on = 1
+	},
+/turf/open/floor/mainship,
+/area/mainship/living/cafeteria_starboard)
 "dc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -1070,6 +1089,10 @@
 "do" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/port_garden)
+"dp" = (
+/obj/effect/decal/warning_stripes/thin,
+/turf/open/floor/mainship/mono,
+/area/mainship/shipboard/weapon_room)
 "dq" = (
 /obj/machinery/vending/nanomed,
 /turf/open/floor/mainship/mono,
@@ -1089,7 +1112,10 @@
 	},
 /area/mainship/hallways/hangar)
 "dt" = (
-/obj/machinery/alarm,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/mainship,
 /area/mainship/living/cafeteria_starboard)
 "du" = (
@@ -1123,6 +1149,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/starboard_missiles)
+"dC" = (
+/obj/structure/closet/crate,
+/obj/item/target/syndicate,
+/obj/item/target/syndicate,
+/obj/item/target/syndicate,
+/obj/item/target/syndicate,
+/obj/item/target/syndicate,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/shipboard/firing_range)
 "dE" = (
 /obj/effect/attach_point/weapon/dropship2{
 	dir = 8;
@@ -1345,6 +1380,10 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
+"ev" = (
+/obj/machinery/vending/uniform_supply,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "ex" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct{
@@ -1494,6 +1533,7 @@
 	dir = 8
 	},
 /obj/structure/bed,
+/obj/item/bedsheet/brown,
 /obj/effect/landmark/start/job/pilotofficer,
 /turf/open/floor/wood,
 /area/mainship/living/pilotbunks)
@@ -1582,6 +1622,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"fO" = (
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/medical/lower_medical)
 "fP" = (
 /turf/closed/wall/mainship,
 /area/mainship/shipboard/port_missiles)
@@ -1609,17 +1654,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/commandbunks)
-"fV" = (
-/obj/machinery/marine_selector/clothes,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "fW" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/effect/decal/warning_stripes/thin{
@@ -1884,12 +1918,11 @@
 "gZ" = (
 /obj/machinery/vending/marine,
 /obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "hb" = (
@@ -2034,19 +2067,14 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
-"hF" = (
-/obj/machinery/vending/marine/cargo_guns,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "hG" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"hH" = (
+/turf/open/floor/mainship/sterile,
+/area/mainship/medical/lower_medical)
 "hI" = (
 /obj/structure/table/reinforced,
 /obj/item/autopsy_scanner,
@@ -2139,7 +2167,6 @@
 /obj/machinery/door/firedoor/mainship{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "hQ" = (
@@ -2296,19 +2323,6 @@
 /obj/structure/foamedmetal,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
-"io" = (
-/obj/machinery/marine_selector/clothes,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "ip" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -2391,7 +2405,6 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "iF" = (
-/obj/structure/cable,
 /obj/structure/table/mainship,
 /obj/item/reagent_containers/food/drinks/cans/iced_tea,
 /turf/open/floor/mainship,
@@ -2718,24 +2731,6 @@
 	dir = 8
 	},
 /area/mainship/shipboard/firing_range)
-"jR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/mainship/red{
-	dir = 4
-	},
-/area/mainship/shipboard/firing_range)
-"jS" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/marine_selector/clothes,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "jT" = (
 /obj/structure/sink{
 	dir = 4;
@@ -2748,14 +2743,6 @@
 "jU" = (
 /turf/open/floor/mainship/cargo,
 /area/mainship/squads/general)
-"jW" = (
-/obj/machinery/vending/marine,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "jX" = (
 /obj/structure/closet/l3closet/virology,
 /obj/machinery/light{
@@ -2764,12 +2751,15 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "ka" = (
-/obj/machinery/firealarm,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
-"kb" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction{
+	dir = 8
 	},
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
@@ -2787,12 +2777,9 @@
 	},
 /area/mainship/hallways/hangar)
 "kf" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
+/obj/machinery/marine_selector/clothes,
+/obj/structure/window/reinforced{
 	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
 	},
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
@@ -2800,9 +2787,7 @@
 /obj/structure/target_stake,
 /obj/item/target,
 /obj/item/clothing/suit/replica,
-/turf/open/floor/plating/mainship/striped{
-	dir = 4
-	},
+/turf/open/floor/plating/mainship,
 /area/mainship/shipboard/firing_range)
 "kh" = (
 /obj/machinery/atm,
@@ -2813,6 +2798,12 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/port_hallway)
+"kj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "kl" = (
 /obj/structure/closet/secure_closet/pilot_officer,
 /obj/item/clothing/mask/rebreather/scarf,
@@ -2861,7 +2852,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "kt" = (
@@ -2882,19 +2872,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/mainship/hull/lower_hull)
-"kv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "kw" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/living/port_garden)
@@ -2926,7 +2903,13 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/lower_medical)
 "kB" = (
-/obj/machinery/power/apc/mainship,
+/obj/structure/disposalpipe/segment/corner,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
 /obj/structure/cable,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
@@ -2950,13 +2933,13 @@
 /area/mainship/squads/req)
 "kF" = (
 /obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
+	dir = 4
 	},
 /obj/structure/cable,
 /turf/open/floor/mainship,
@@ -3027,18 +3010,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/vending/tool,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
-"kQ" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "kS" = (
 /obj/structure/barricade/metal{
 	dir = 1
@@ -3210,6 +3184,13 @@
 /obj/machinery/firealarm,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/ce_room)
+"lo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8;
+	on = 1
+	},
+/turf/open/floor/mainship/sterile/plain,
+/area/mainship/hallways/hangar)
 "lp" = (
 /obj/structure/table/mainship,
 /obj/machinery/computer/security/marinemainship{
@@ -3265,6 +3246,16 @@
 	dir = 5
 	},
 /area/mainship/command/cic)
+"ly" = (
+/obj/structure/window/framed/mainship/requisitions,
+/obj/machinery/door/poddoor/shutters/mainship/req/ro{
+	dir = 2
+	},
+/obj/structure/sign/ROsign{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/mainship/squads/req)
 "lz" = (
 /obj/machinery/computer/camera_advanced/overwatch/alpha,
 /turf/open/floor/mainship/red{
@@ -3383,18 +3374,11 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/port_emb)
 "lT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
-"lX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
-/turf/open/floor/mainship/cargo,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "lZ" = (
 /obj/machinery/door/airlock/mainship/maint,
@@ -3609,6 +3593,16 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/airoom)
+"mJ" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 9
+	},
+/obj/effect/decal/warning_stripes/thin,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 5
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/shipboard/weapon_room)
 "mK" = (
 /obj/structure/prop/mainship/sensor_computer2,
 /turf/open/floor/mainship/mono,
@@ -3701,8 +3695,11 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/mainship/red{
-	dir = 8
+/obj/structure/target_stake,
+/obj/item/target,
+/obj/item/clothing/suit/storage/militia,
+/turf/open/floor/plating/mainship/striped{
+	dir = 4
 	},
 /area/mainship/shipboard/firing_range)
 "nb" = (
@@ -3711,12 +3708,17 @@
 	},
 /area/mainship/living/commandbunks)
 "nd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
 /obj/structure/table/mainship,
 /obj/item/storage/donut_box,
 /turf/open/floor/mainship,
 /area/mainship/living/cafeteria_starboard)
+"ne" = (
+/obj/effect/decal/warning_stripes/thin,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 9
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/shipboard/weapon_room)
 "nf" = (
 /obj/machinery/door/poddoor/shutters/mainship/req/ro{
 	dir = 2
@@ -3737,18 +3739,11 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor/medbay/free_access,
-/turf/open/floor/mainship/sterile/dark,
+/turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
 "nk" = (
 /turf/closed/wall/mainship/white,
 /area/mainship/medical/chemistry)
-"nm" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 4
-	},
-/obj/machinery/alarm,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "no" = (
 /obj/structure/table/mainship,
 /obj/item/folder/black_random,
@@ -3947,15 +3942,14 @@
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor/medbay/free_access{
 	dir = 1
 	},
-/turf/open/floor/mainship/sterile/dark,
+/turf/open/floor/mainship/sterile,
 /area/mainship/medical/lower_medical)
 "nZ" = (
-/obj/machinery/vending/marine,
-/obj/structure/window/reinforced,
+/obj/machinery/marine_selector/clothes,
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 8
 	},
-/turf/open/floor/mainship,
+/turf/open/floor/mainship/cargo,
 /area/mainship/squads/general)
 "ob" = (
 /obj/machinery/door/airlock/mainship/marine/general/corps,
@@ -4089,6 +4083,16 @@
 	dir = 8
 	},
 /area/mainship/squads/req)
+"oy" = (
+/obj/machinery/vending/marine,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "oz" = (
 /obj/machinery/door/poddoor/railing{
 	dir = 8;
@@ -4216,7 +4220,6 @@
 	dir = 4
 	},
 /obj/machinery/holopad,
-/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "oS" = (
@@ -4416,6 +4419,13 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/port_emb)
+"pN" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "pO" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -4493,11 +4503,6 @@
 /obj/item/reagent_containers/food/drinks/cans/souto/grape/diet,
 /turf/open/floor/mainship,
 /area/mainship/living/cafeteria_starboard)
-"qg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable,
-/turf/open/floor/mainship/cargo,
-/area/mainship/squads/general)
 "qh" = (
 /obj/structure/table/mainship,
 /obj/structure/paper_bin{
@@ -4679,9 +4684,7 @@
 /area/space)
 "qP" = (
 /obj/machinery/camera/autoname/mainship,
-/turf/open/floor/plating/mainship/striped{
-	dir = 4
-	},
+/turf/open/floor/plating/mainship,
 /area/mainship/shipboard/firing_range)
 "qQ" = (
 /obj/structure/window/reinforced{
@@ -4965,10 +4968,8 @@
 /area/mainship/command/telecomms)
 "rW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
 "rX" = (
@@ -5113,18 +5114,11 @@
 	},
 /turf/open/floor/mainship/cargo,
 /area/mainship/engineering/port_atmos)
-"ss" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/camera/autoname/mainship,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "su" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/open/floor/mainship,
+/turf/open/floor/mainship/cargo,
 /area/mainship/squads/general)
 "sv" = (
 /obj/structure/bed/chair/comfy/black{
@@ -5184,7 +5178,6 @@
 /turf/closed/wall/mainship/outer,
 /area/mainship/hallways/starboard_hallway)
 "sH" = (
-/obj/structure/cable,
 /obj/structure/table/mainship,
 /obj/item/reagent_containers/food/snacks/jellysandwich/cherry,
 /turf/open/floor/mainship,
@@ -5359,6 +5352,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "tj" = (
@@ -5521,6 +5517,7 @@
 /turf/open/floor/mainship/cargo/arrow,
 /area/mainship/shipboard/weapon_room)
 "tJ" = (
+/obj/structure/prop/mainship/sensor_computer3,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "tK" = (
@@ -5549,6 +5546,12 @@
 /area/mainship/living/numbertwobunks)
 "tN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 10
+	},
+/obj/effect/decal/warning_stripes/thin{
 	dir = 4
 	},
 /turf/open/floor/mainship/mono,
@@ -5829,20 +5832,15 @@
 	},
 /turf/open/floor/plating,
 /area/mainship/hallways/starboard_umbilical)
-"uA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "uB" = (
 /obj/structure/closet/firecloset,
 /obj/item/clothing/mask/gas,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/cargo,
 /area/mainship/hallways/starboard_umbilical)
 "uC" = (
 /obj/structure/closet/emcloset,
 /obj/item/clothing/mask/gas,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/cargo,
 /area/mainship/hallways/starboard_umbilical)
 "uD" = (
 /obj/structure/table/mainship,
@@ -5911,6 +5909,9 @@
 "uS" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 9
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
@@ -5984,6 +5985,7 @@
 	},
 /area/mainship/hallways/starboard_umbilical)
 "vf" = (
+/obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/mainship/cargo,
 /area/mainship/shipboard/weapon_room)
 "vg" = (
@@ -6127,7 +6129,7 @@
 "vD" = (
 /obj/structure/closet/toolcloset,
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/cargo,
 /area/mainship/hallways/starboard_umbilical)
 "vE" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
@@ -6199,9 +6201,10 @@
 /area/mainship/command/airoom)
 "vP" = (
 /obj/structure/ship_rail_gun,
-/turf/open/floor/mainship/red{
-	dir = 9
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
 	},
+/turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "vQ" = (
 /obj/structure/rack,
@@ -6209,9 +6212,6 @@
 /obj/structure/ob_ammo/ob_fuel,
 /obj/structure/ob_ammo/ob_fuel,
 /obj/structure/ob_ammo/ob_fuel,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/structure/ob_ammo/ob_fuel,
 /turf/open/floor/mainship/red{
@@ -6224,11 +6224,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/starboard_missiles)
 "vT" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
 	},
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/weapon_room)
@@ -6375,6 +6375,7 @@
 	dir = 4
 	},
 /obj/structure/bed,
+/obj/item/bedsheet/brown,
 /obj/effect/landmark/start/job/pilotofficer,
 /turf/open/floor/wood,
 /area/mainship/living/pilotbunks)
@@ -6657,6 +6658,12 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
+"xn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/mainship,
+/area/mainship/living/cafeteria_starboard)
 "xp" = (
 /obj/docking_port/stationary/ert/target{
 	name = "Hangar"
@@ -6670,15 +6677,14 @@
 /obj/structure/ob_ammo/ob_fuel,
 /obj/structure/ob_ammo/ob_fuel,
 /obj/structure/rack,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/red{
+	dir = 6
+	},
 /area/mainship/shipboard/weapon_room)
 "xt" = (
 /turf/open/floor/mainship/mono,
@@ -6904,9 +6910,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/turf/open/floor/mainship/red{
-	dir = 8
+/obj/effect/decal/warning_stripes/thin,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
 	},
+/turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "yf" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -7033,6 +7041,10 @@
 /obj/item/storage/box/donkpockets,
 /turf/open/floor/mainship/mono,
 /area/mainship/engineering/engineering_workshop)
+"yD" = (
+/obj/structure/window/framed/mainship/requisitions,
+/turf/open/floor/plating,
+/area/mainship/shipboard/firing_range)
 "yE" = (
 /obj/structure/table/mainship,
 /obj/item/frame/fire_alarm,
@@ -7832,7 +7844,13 @@
 	dir = 10
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/mainship/mono,
+/obj/structure/rack,
+/obj/structure/ob_ammo/ob_fuel,
+/obj/structure/ob_ammo/ob_fuel,
+/obj/structure/ob_ammo/ob_fuel,
+/turf/open/floor/mainship/red{
+	dir = 5
+	},
 /area/mainship/shipboard/weapon_room)
 "Bm" = (
 /obj/machinery/door/airlock/mainship/maint{
@@ -7846,17 +7864,6 @@
 	},
 /turf/open/floor/plating/mainship,
 /area/mainship/hull/lower_hull)
-"Bo" = (
-/obj/machinery/marine_selector/clothes,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "Bp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7870,25 +7877,14 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
-"Bq" = (
-/obj/machinery/vending/marine,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
-"Br" = (
+"Bs" = (
 /obj/machinery/marine_selector/clothes,
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 8
 	},
-/obj/structure/window/reinforced,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
-"Bs" = (
-/obj/machinery/vending/attachments,
-/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -7903,6 +7899,10 @@
 "Bv" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
 	},
 /turf/open/floor/mainship,
 /area/mainship/living/cafeteria_starboard)
@@ -7979,7 +7979,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "BJ" = (
@@ -7994,7 +7993,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
 "BL" = (
@@ -8108,6 +8106,18 @@
 	},
 /turf/open/floor/mainship_hull,
 /area/space)
+"BX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
+/area/mainship/medical/lower_medical)
 "BZ" = (
 /obj/machinery/telecomms/server/presets/alpha,
 /turf/open/floor/mainship/tcomms,
@@ -8208,13 +8218,20 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/mainship,
 /area/mainship/living/cafeteria_starboard)
 "Cp" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 2
 	},
-/obj/machinery/firealarm,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/mainship,
 /area/mainship/living/cafeteria_starboard)
 "Cr" = (
@@ -8252,6 +8269,14 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/port_emb)
+"Cx" = (
+/obj/machinery/camera/autoname/mainship,
+/obj/machinery/vending/marine,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "Cy" = (
 /obj/effect/decal/siding{
 	dir = 5
@@ -8378,8 +8403,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/mainship,
+/turf/open/floor/mainship/cargo,
 /area/mainship/squads/general)
 "CZ" = (
 /obj/structure/disposalpipe/segment,
@@ -8727,19 +8751,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 10
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "DW" = (
 /obj/machinery/door/airlock/mainship/maint,
 /turf/open/floor/plating/mainship,
 /area/mainship/medical/lower_medical)
-"DY" = (
-/obj/machinery/vending/marineFood,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/mainship,
-/area/mainship/living/cafeteria_starboard)
 "DZ" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment/corner{
@@ -9086,6 +9109,17 @@
 	},
 /turf/open/floor/mainship,
 /area/mainship/living/cafeteria_starboard)
+"EZ" = (
+/obj/machinery/vending/marine,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "Fa" = (
 /obj/machinery/door/airlock/mainship/marine/general/engi,
 /turf/open/floor/mainship,
@@ -9620,12 +9654,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "GN" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	on = 1
-	},
 /obj/machinery/door/firedoor/mainship{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/aft_hallway)
 "GO" = (
@@ -10001,10 +10033,6 @@
 	},
 /turf/open/floor/mainship/orange,
 /area/mainship/engineering/lower_engineering)
-"HI" = (
-/obj/structure/cable,
-/turf/closed/wall/mainship,
-/area/mainship/engineering/lower_engineering)
 "HJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 1
@@ -10168,7 +10196,7 @@
 /area/mainship/hull/lower_hull)
 "If" = (
 /obj/effect/landmark/start/job/ai,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/tcomms,
 /area/mainship/command/airoom)
 "Ig" = (
 /obj/machinery/firealarm{
@@ -10284,12 +10312,10 @@
 /obj/machinery/marine_selector/gear/smartgun,
 /turf/open/floor/mainship,
 /area/mainship/squads/general)
-"Iy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
-/obj/structure/bed/chair,
-/turf/open/floor/mainship,
-/area/mainship/living/cafeteria_starboard)
+"Iz" = (
+/obj/structure/window/framed/mainship/requisitions,
+/turf/open/floor/plating,
+/area/mainship/hallways/starboard_hallway)
 "IA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -10347,6 +10373,7 @@
 	dir = 4;
 	on = 1
 	},
+/obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "IM" = (
@@ -10393,6 +10420,11 @@
 	dir = 4
 	},
 /area/space)
+"IV" = (
+/obj/machinery/vending/marine/cargo_guns,
+/obj/docking_port/stationary/marine_dropship/crash_target,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "IW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -10403,6 +10435,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
+"IX" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mainship,
+/area/mainship/living/cafeteria_starboard)
 "IY" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -10661,15 +10699,12 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "JC" = (
-/obj/structure/rack,
-/obj/structure/ob_ammo/ob_fuel,
-/obj/structure/ob_ammo/ob_fuel,
-/obj/structure/ob_ammo/ob_fuel,
 /obj/structure/cable,
 /obj/machinery/alarm{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "JE" = (
@@ -10865,18 +10900,16 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
 "Kk" = (
-/obj/item/target/syndicate,
-/obj/item/target/syndicate,
-/obj/item/target/syndicate,
-/obj/item/target/syndicate,
-/obj/item/target/syndicate,
-/obj/structure/closet/crate,
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/food/drinks/bottle/vodka,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
 /turf/open/floor/mainship/red/full,
 /area/mainship/shipboard/firing_range)
 "Kl" = (
@@ -11110,6 +11143,12 @@
 /turf/open/floor/mainship/red,
 /area/mainship/shipboard/weapon_room)
 "KG" = (
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
@@ -11134,15 +11173,17 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
-"KQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 1;
-	on = 1
+"KO" = (
+/obj/structure/window/framed/mainship,
+/turf/open/floor/plating,
+/area/mainship/squads/general)
+"KP" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
 	},
-/obj/structure/cable,
-/obj/structure/table/mainship,
-/turf/open/floor/mainship,
-/area/mainship/living/cafeteria_starboard)
+/obj/effect/decal/warning_stripes/thin,
+/turf/open/floor/mainship/mono,
+/area/mainship/shipboard/weapon_room)
 "KR" = (
 /obj/structure/cable,
 /turf/open/floor/mainship,
@@ -11154,6 +11195,9 @@
 /obj/structure/cable,
 /obj/structure/bed/chair{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/mainship,
 /area/mainship/living/cafeteria_starboard)
@@ -11176,6 +11220,16 @@
 	},
 /turf/open/floor/mainship,
 /area/mainship/living/cryo_cells)
+"KW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile,
+/area/mainship/medical/lower_medical)
 "KX" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
@@ -11253,6 +11307,10 @@
 	dir = 5
 	},
 /area/mainship/engineering/engine_core)
+"Lp" = (
+/obj/structure/prop/mainship/sensor_computer2,
+/turf/open/floor/mainship/mono,
+/area/mainship/shipboard/weapon_room)
 "Ls" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -11293,6 +11351,18 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"LC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
+/area/mainship/medical/lower_medical)
 "LF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1
@@ -11300,6 +11370,8 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship,
 /area/mainship/living/cafeteria_starboard)
 "LH" = (
@@ -11330,9 +11402,6 @@
 /obj/structure/ob_ammo/ob_fuel,
 /obj/structure/ob_ammo/ob_fuel,
 /obj/structure/ob_ammo/ob_fuel,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
 /obj/structure/ob_ammo/ob_fuel,
 /turf/open/floor/mainship/red{
 	dir = 1
@@ -11342,9 +11411,6 @@
 /obj/structure/rack,
 /obj/structure/ob_ammo/warhead/cluster,
 /obj/structure/ob_ammo/warhead/cluster,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 5
-	},
 /obj/machinery/light/small,
 /turf/open/floor/mainship/red{
 	dir = 6
@@ -11353,6 +11419,12 @@
 "LQ" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/shipboard/starboard_missiles)
+"LS" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "LU" = (
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/mainship/mono,
@@ -11782,6 +11854,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
 "Nh" = (
@@ -11984,14 +12059,14 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "NM" = (
-/obj/structure/disposalpipe/junction/flipped{
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/mainship,
@@ -12051,6 +12126,10 @@
 	dir = 8
 	},
 /area/mainship/command/self_destruct)
+"Oe" = (
+/obj/structure/prop/mainship/sensor_computer1,
+/turf/open/floor/mainship/mono,
+/area/mainship/shipboard/weapon_room)
 "Of" = (
 /obj/machinery/vending/nanomed,
 /turf/closed/wall/mainship,
@@ -12063,6 +12142,10 @@
 /obj/machinery/vending/nanomed,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/aft_hallway)
+"Ol" = (
+/obj/structure/target_stake,
+/turf/open/floor/plating/mainship,
+/area/mainship/shipboard/firing_range)
 "Op" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -12260,6 +12343,16 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/squads/req)
+"OZ" = (
+/obj/machinery/vending/marine,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "Pc" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -12402,17 +12495,6 @@
 	dir = 9
 	},
 /area/mainship/command/self_destruct)
-"PA" = (
-/obj/machinery/vending/uniform_supply,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "PB" = (
 /obj/structure/window/framed/mainship,
 /turf/open/floor/plating,
@@ -12442,13 +12524,6 @@
 /obj/machinery/telecomms/processor/preset_four,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
-"PK" = (
-/obj/machinery/vending/marine,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "PL" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/firealarm{
@@ -12517,6 +12592,12 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
+"Ql" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/turf/open/floor/mainship/cargo,
+/area/mainship/hallways/hangar)
 "Qm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
@@ -12621,8 +12702,6 @@
 /turf/open/floor/mainship/cargo/arrow,
 /area/mainship/hallways/hangar)
 "QO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
 /obj/structure/table/mainship,
 /obj/item/storage/bible/booze,
 /turf/open/floor/mainship,
@@ -12633,6 +12712,17 @@
 	},
 /turf/closed/wall/mainship,
 /area/mainship/command/self_destruct)
+"QR" = (
+/obj/machinery/vending/marine,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "QS" = (
 /obj/machinery/light{
 	dir = 1
@@ -12669,6 +12759,9 @@
 /obj/structure/disposalpipe/sortjunction,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
@@ -12707,22 +12800,10 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/mainship/shipboard/weapon_room)
-"Re" = (
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/structure/closet/crate,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 5
+/turf/open/floor/mainship/red{
+	dir = 4
 	},
-/obj/item/reagent_containers/food/drinks/bottle/vodka,
-/turf/open/floor/mainship/red/full,
-/area/mainship/shipboard/firing_range)
+/area/mainship/shipboard/weapon_room)
 "Rf" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -12764,6 +12845,12 @@
 /obj/machinery/computer/supplycomp,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"Rp" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/plating/mainship,
+/area/mainship/shipboard/weapon_room)
 "Rq" = (
 /obj/structure/prop/mainship/name_stencil{
 	icon_state = "TGMC3"
@@ -12784,6 +12871,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
+"Rs" = (
+/obj/machinery/door/window/southleft,
+/turf/open/floor/mainship/stripesquare,
+/area/mainship/shipboard/firing_range)
 "Rz" = (
 /obj/machinery/vending/nanomed{
 	dir = 1
@@ -12809,7 +12900,7 @@
 /area/mainship/hallways/starboard_hallway)
 "RE" = (
 /obj/structure/closet/toolcloset,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/cargo,
 /area/mainship/hallways/starboard_hallway)
 "RF" = (
 /obj/effect/decal/warning_stripes/thin,
@@ -12823,6 +12914,14 @@
 /obj/item/reagent_containers/jerrycan,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"RJ" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 5
+	},
+/turf/open/floor/mainship/red{
+	dir = 8
+	},
+/area/mainship/shipboard/firing_range)
 "RK" = (
 /obj/structure/closet/crate/medical,
 /turf/open/floor/mainship/mono,
@@ -12969,6 +13068,12 @@
 "SJ" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
+"SK" = (
+/obj/machinery/alarm{
+	dir = 8
+	},
+/turf/open/floor/mainship,
+/area/mainship/living/cafeteria_starboard)
 "SL" = (
 /obj/structure/prop/mainship/name_stencil{
 	icon_state = "TGMC4"
@@ -12982,6 +13087,16 @@
 	},
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
+"SO" = (
+/obj/machinery/marine_selector/clothes,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "SP" = (
 /obj/machinery/light{
 	dir = 1
@@ -13014,8 +13129,13 @@
 /turf/open/floor/mainship/red/full,
 /area/mainship/shipboard/firing_range)
 "Td" = (
-/obj/machinery/vending/marine/cargo_ammo,
-/obj/structure/window/reinforced,
+/obj/machinery/marine_selector/clothes,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -13027,7 +13147,6 @@
 	},
 /area/mainship/shipboard/firing_range)
 "Tg" = (
-/obj/structure/cable,
 /obj/structure/table/mainship,
 /obj/item/toy/deck/kotahi,
 /turf/open/floor/mainship,
@@ -13081,6 +13200,15 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
+"Tw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "TA" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -13136,6 +13264,10 @@
 	dir = 5
 	},
 /area/mainship/living/grunt_rnr)
+"TJ" = (
+/obj/structure/window/framed/mainship,
+/turf/open/floor/plating,
+/area/mainship/living/briefing)
 "TL" = (
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/black{
@@ -13187,15 +13319,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/lower_hull)
-"TY" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/mainship/red{
-	dir = 4
-	},
-/area/mainship/shipboard/firing_range)
 "Uf" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/job/squadmarine,
@@ -13211,12 +13334,12 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/aft_hallway)
 "Ui" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/largecrate/random/case/double,
-/turf/open/floor/mainship/red/full,
-/area/mainship/shipboard/firing_range)
+/obj/machinery/power/apc/mainship,
+/obj/structure/cable,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "Uk" = (
 /obj/machinery/door/airlock/mainship/maint,
 /turf/open/floor/mainship/mono,
@@ -13270,6 +13393,15 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/numbertwobunks)
+"Uz" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor/mainship/red/full,
+/area/mainship/shipboard/firing_range)
 "UA" = (
 /obj/machinery/power/apc/mainship{
 	dir = 4
@@ -13549,6 +13681,15 @@
 	dir = 8
 	},
 /area/mainship/command/self_destruct)
+"VQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mainship/red{
+	dir = 4
+	},
+/area/mainship/shipboard/firing_range)
 "VR" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/effect/decal/warning_stripes/thin{
@@ -13563,6 +13704,10 @@
 	},
 /turf/open/floor/mainship/tcomms,
 /area/mainship/shipboard/starboard_missiles)
+"VW" = (
+/obj/machinery/vending/uniform_supply,
+/turf/open/floor/mainship,
+/area/mainship/living/cafeteria_starboard)
 "VZ" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 9
@@ -13597,12 +13742,21 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
 "Wn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
 /obj/structure/table/mainship,
 /obj/item/reagent_containers/food/snacks/mre_pack/meal2,
 /turf/open/floor/mainship,
 /area/mainship/living/cafeteria_starboard)
+"Wp" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
+"Wr" = (
+/obj/machinery/vending/attachments,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "Ws" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/cargo/arrow{
@@ -13629,10 +13783,6 @@
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/stern_hallway)
-"WE" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/sterile/dark,
-/area/mainship/medical/medical_science)
 "WK" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -13677,11 +13827,6 @@
 /obj/structure/cable,
 /turf/closed/wall/mainship,
 /area/mainship/engineering/lower_engine_monitoring)
-"WY" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/structure/cable,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "WZ" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -13716,14 +13861,6 @@
 /obj/item/ashtray/glass,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
-"Xs" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/mainship/red{
-	dir = 4
-	},
-/area/mainship/shipboard/firing_range)
 "Xt" = (
 /obj/machinery/door/airlock/mainship/maint,
 /obj/structure/disposalpipe/segment{
@@ -13771,6 +13908,10 @@
 /obj/structure/closet/crate/alpha,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"XH" = (
+/obj/machinery/vending/marine/cargo_ammo,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "XI" = (
 /obj/effect/decal/siding{
 	dir = 9
@@ -13793,16 +13934,6 @@
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /turf/open/floor/mainship/cargo,
 /area/mainship/engineering/engineering_workshop)
-"XL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "XN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -13859,6 +13990,16 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/starboard_missiles)
+"XZ" = (
+/obj/machinery/marine_selector/clothes,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "Ya" = (
 /obj/machinery/light{
 	dir = 4
@@ -13891,10 +14032,10 @@
 "Yh" = (
 /obj/structure/orbital_cannon,
 /obj/effect/decal/warning_stripes/thin{
-	dir = 1
+	dir = 8
 	},
 /obj/effect/decal/warning_stripes/thin{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
@@ -13905,8 +14046,6 @@
 /turf/open/shuttle/escapepod/four,
 /area/mainship/command/self_destruct)
 "Yn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
 /obj/structure/table/mainship,
 /obj/item/reagent_containers/food/snacks/fortunecookie,
 /turf/open/floor/mainship,
@@ -13982,10 +14121,6 @@
 /obj/machinery/telecomms/server/presets/security,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
-"YK" = (
-/obj/docking_port/stationary/marine_dropship/crash_target,
-/turf/open/floor/mainship/cargo,
-/area/mainship/squads/general)
 "YL" = (
 /obj/machinery/landinglight/ds1{
 	dir = 8
@@ -14053,7 +14188,7 @@
 /area/mainship/shipboard/firing_range)
 "Zd" = (
 /obj/structure/closet/emcloset,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/mainship/cargo,
 /area/mainship/hallways/starboard_hallway)
 "Ze" = (
 /obj/structure/morgue/crematorium,
@@ -14067,6 +14202,15 @@
 /obj/item/toy/deck,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
+"Zh" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/shipboard/weapon_room)
 "Zj" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/machinery/power/smes/preset,
@@ -14107,13 +14251,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"Zq" = (
-/obj/structure/cable,
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/turf/open/floor/mainship,
-/area/mainship/living/cafeteria_starboard)
 "Zt" = (
 /obj/structure/bed,
 /obj/item/bedsheet/captain,
@@ -14131,9 +14268,23 @@
 "ZE" = (
 /turf/open/floor/mainship/mono,
 /area/mainship/living/pilotbunks)
+"ZF" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/largecrate/random/case/double,
+/turf/open/floor/mainship/red{
+	dir = 4
+	},
+/area/mainship/shipboard/firing_range)
 "ZH" = (
 /turf/open/floor/mainship/cargo,
 /area/mainship/shipboard/starboard_missiles)
+"ZL" = (
+/obj/machinery/vending/marine/cargo_guns,
+/turf/open/floor/mainship,
+/area/mainship/squads/general)
 "ZM" = (
 /obj/structure/table/mainship,
 /obj/machinery/computer/marine_card,
@@ -14177,14 +14328,6 @@
 /obj/item/lightreplacer,
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
-"ZS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/mainship,
-/area/mainship/squads/general)
 "ZV" = (
 /obj/structure/cable,
 /obj/machinery/power/apc,
@@ -34916,7 +35059,7 @@ ad
 tl
 tl
 OB
-tJ
+Lp
 OB
 tl
 tl
@@ -35173,7 +35316,7 @@ ad
 gR
 gR
 OB
-tJ
+Oe
 OB
 gR
 gR
@@ -35431,10 +35574,10 @@ tm
 tm
 vT
 Yh
-tJ
-tJ
-tJ
-tJ
+ne
+tm
+un
+Zh
 vP
 ye
 wc
@@ -35686,12 +35829,12 @@ Po
 Mb
 tm
 tm
-un
+Rp
 uP
 vf
-tJ
-tJ
-tJ
+tm
+un
+KP
 vQ
 ZP
 wd
@@ -35945,10 +36088,10 @@ tm
 tm
 uo
 uQ
-tJ
-tJ
-tJ
-tJ
+dp
+tm
+un
+KP
 LO
 ZP
 KF
@@ -36203,9 +36346,9 @@ tm
 up
 uR
 IJ
-tJ
-tJ
-tJ
+tm
+un
+KP
 LO
 ZP
 we
@@ -36460,9 +36603,9 @@ tI
 uq
 uS
 tN
-uq
-uq
-tJ
+cG
+cG
+mJ
 ns
 ML
 LP
@@ -39511,7 +39654,7 @@ Fg
 id
 nD
 ek
-WE
+iL
 oR
 oS
 iL
@@ -41328,11 +41471,11 @@ KE
 KE
 KE
 KE
-KE
+TJ
 Bc
 Js
 Bc
-KE
+TJ
 KE
 Dr
 Jx
@@ -41550,7 +41693,7 @@ VA
 lO
 ga
 nj
-aY
+fO
 aY
 Fg
 aY
@@ -41806,8 +41949,8 @@ bh
 kH
 qE
 ga
-aY
-aY
+hH
+fO
 aY
 aY
 aY
@@ -43353,8 +43496,8 @@ bw
 bM
 ce
 nk
-nQ
-BA
+BX
+LC
 hy
 Kn
 nI
@@ -43610,7 +43753,7 @@ bz
 bP
 bz
 nk
-nQ
+KW
 nY
 ic
 ic
@@ -43672,7 +43815,7 @@ Ch
 OL
 zy
 HG
-HI
+OL
 YZ
 Ls
 Mb
@@ -43929,7 +44072,7 @@ Cj
 OL
 zz
 HH
-HI
+OL
 Lm
 Ls
 Mb
@@ -44186,7 +44329,7 @@ Mt
 OL
 OL
 HF
-HI
+OL
 Ln
 Lt
 Mb
@@ -44444,7 +44587,7 @@ Ad
 Ms
 Hz
 Lh
-yx
+Lh
 Ap
 Mb
 Nx
@@ -44669,7 +44812,7 @@ WP
 WP
 WP
 WP
-PE
+Iz
 GA
 Du
 Fz
@@ -44926,7 +45069,7 @@ WP
 WP
 WP
 WP
-PE
+Iz
 kX
 Dv
 kX
@@ -45440,7 +45583,7 @@ WP
 WP
 WP
 WP
-PE
+Iz
 sd
 DA
 sd
@@ -45697,7 +45840,7 @@ WP
 WP
 WP
 WP
-PE
+Iz
 jy
 FU
 jy
@@ -46681,7 +46824,7 @@ bh
 bh
 bh
 hz
-ar
+Ql
 GN
 Nr
 Nr
@@ -46938,7 +47081,7 @@ bh
 bh
 bh
 gM
-af
+dV
 mU
 mU
 ih
@@ -47195,7 +47338,7 @@ bh
 bh
 bh
 Ri
-af
+lo
 mU
 WM
 ZE
@@ -47206,7 +47349,7 @@ gd
 kM
 kM
 qG
-de
+ly
 de
 de
 de
@@ -47736,8 +47879,8 @@ Dx
 Dx
 Dx
 Dx
-Dx
 wQ
+Dx
 wS
 Dx
 CG
@@ -47988,13 +48131,13 @@ gd
 gd
 gd
 gd
-FB
-jy
-jy
+gd
 jy
 BG
 jy
+jy
 Bp
+jy
 AR
 jy
 jy
@@ -48240,18 +48383,18 @@ eF
 eF
 NU
 NU
-NU
-NU
-NU
-NU
-NU
-NU
+yD
+yD
+yD
 NU
 NZ
+PF
+NZ
 NU
-NU
+KO
 jl
 ko
+KO
 qC
 qC
 qC
@@ -48259,17 +48402,17 @@ qC
 qC
 qC
 ob
-qC
+KO
 qC
 qC
 qC
 Iu
-qC
+KO
 qC
 qC
 qC
 Kl
-qC
+KO
 qC
 qC
 sM
@@ -48496,19 +48639,19 @@ LQ
 ZH
 AW
 fj
+Qf
+SE
+dC
 Mx
-Xs
-Qf
-Qf
-SE
-SE
-NU
+Rs
+Uz
+RJ
 Kk
-Re
-Ui
 NZ
+Ui
+Wp
 ka
-kv
+XQ
 kZ
 qr
 ru
@@ -48526,7 +48669,7 @@ EY
 pQ
 pQ
 pQ
-pQ
+VW
 Ne
 MB
 sN
@@ -48755,25 +48898,25 @@ VR
 fj
 qA
 qA
-qA
 gK
-qA
 qA
 qV
 qW
 XO
 SY
 NU
+ev
+jl
 kB
 NM
 lT
-lT
-lT
-lT
-lT
-lT
-lT
-Bt
+Tw
+kj
+kj
+kj
+kj
+kj
+cD
 LF
 LF
 LF
@@ -49014,28 +49157,28 @@ fB
 Pv
 fB
 fB
-fB
-fB
 qV
 IG
 hW
 pH
 jQ
 jl
+jl
+jl
 kF
-lX
+jl
 rW
-cW
-uA
-uA
-uA
-uA
-Iy
+jl
+jl
+jl
+jl
+jl
+pR
 QO
 Wn
 Yn
 nd
-KQ
+kc
 sH
 iF
 KS
@@ -49269,9 +49412,7 @@ eF
 fj
 fB
 fB
-fB
 Pv
-fB
 fB
 qV
 IG
@@ -49279,14 +49420,16 @@ hW
 Te
 Te
 jl
-kb
+XH
+jl
+kF
 Bs
 CY
-Bs
+OZ
+XZ
+jU
+EZ
 jl
-XQ
-jl
-PA
 pR
 qd
 kc
@@ -49528,28 +49671,28 @@ Pv
 fB
 fB
 fB
-fB
-fB
 qV
 IG
 hW
 Uv
 NZ
-jS
-kb
-jU
-CY
-jU
+Wr
+IV
 jl
-Bo
+kF
 jl
-jU
+rW
+jl
+jl
+jl
+jl
+jl
 pQ
 pY
 pY
 pY
 pY
-Zq
+pY
 pY
 pY
 Cp
@@ -49782,33 +49925,33 @@ uN
 nA
 fj
 qP
-My
+fB
 kg
-My
-My
-My
+fB
 qV
 IG
 hW
 ZN
 NU
-YK
-kb
+LS
+XH
+jl
+kF
 Td
 CY
-Td
-jl
+oy
+SO
 jU
+QR
 jl
-PA
 pQ
-pQ
+SK
 pQ
 pQ
 pQ
 ge
-pQ
-pQ
+KR
+KR
 dt
 pQ
 pQ
@@ -50038,35 +50181,35 @@ To
 Vm
 nA
 pF
-Mx
+My
 na
-Mx
-Mx
-pH
-pH
+My
+My
 qV
 IG
 hW
 rF
 NZ
-jW
-XL
-qg
-WY
-jU
+Wr
+ZL
 jl
-Bq
+kF
 jl
-jU
+rW
+jl
+jl
+jl
 jl
 jl
 qC
 qC
 Fa
-qC
+KO
 qC
 qC
 rJ
+pQ
+xn
 pQ
 pQ
 sy
@@ -50300,23 +50443,21 @@ NU
 NU
 PF
 NU
-NU
-NU
 hw
 Jn
 Mz
 jQ
-nm
-kQ
-hF
+jl
+jl
+jl
+kF
+Td
 su
-hF
+oy
+SO
+jU
+QR
 jl
-Br
-jl
-fV
-jl
-io
 qC
 Yx
 jl
@@ -50324,6 +50465,8 @@ jl
 Wa
 qC
 qs
+pQ
+db
 pQ
 rh
 Ne
@@ -50556,24 +50699,22 @@ cj
 fB
 fB
 fB
-fB
-fB
 qz
 qY
 Vv
 dI
-jR
-ZS
+VQ
+pN
+pN
+pN
 KG
-jU
 jl
-jU
 jl
-jU
 jl
-jU
 jl
-jU
+jl
+jl
+jl
 qC
 jH
 jl
@@ -50581,6 +50722,8 @@ jl
 jH
 qC
 qD
+pQ
+pQ
 pQ
 rh
 Ne
@@ -50810,27 +50953,25 @@ ad
 DR
 NU
 Zb
-fB
-fB
-fB
-fB
+Ol
+Ol
 fB
 NU
 XP
 PN
 ZZ
 NU
-ss
+ev
 jl
+jl
+XQ
 jl
 jl
 jl
 jl
 gZ
-jl
+jU
 nZ
-jl
-PK
 qC
 jt
 Is
@@ -50839,7 +50980,9 @@ jt
 qC
 Cz
 pQ
-DY
+pQ
+IX
+rh
 Ne
 sx
 sz
@@ -51071,12 +51214,12 @@ NU
 NU
 Or
 NU
-NU
-NU
 ix
-TY
+ZF
 wO
 NU
+Cx
+wT
 kf
 kW
 jU
@@ -51085,17 +51228,17 @@ kW
 wT
 UR
 qC
+qC
+qC
+qC
+qC
+qC
+qC
+qC
 Mb
-Mb
-Mb
-qC
-qC
-qC
-qC
-qC
-qC
 Mb
 rj
+Mb
 Mb
 Mb
 Mb
@@ -51332,8 +51475,8 @@ NU
 NU
 NU
 NU
-NU
-NU
+qC
+qC
 qC
 qC
 qC

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -49420,7 +49420,7 @@ hW
 Te
 Te
 jl
-XH
+jl
 jl
 kF
 Bs
@@ -49678,7 +49678,7 @@ Uv
 NZ
 Wr
 IV
-jl
+XH
 kF
 jl
 rW
@@ -49934,7 +49934,7 @@ hW
 ZN
 NU
 LS
-XH
+jl
 jl
 kF
 Td
@@ -50192,7 +50192,7 @@ rF
 NZ
 Wr
 ZL
-jl
+XH
 kF
 jl
 rW


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Re-arranges prep area, more regular marine vendors.
Minor changes to OB area decals.
Minor medical tile changes.
Rearranges pipes and wires in prep/canteen.

## Why It's Good For The Game

More vendors in prep so marines don't have to wait as much.
Self-serve req vendors moved so they're not mistaken for marine prep vendors.

https://i.imgur.com/0HIPefS.png

## Changelog
:cl:
tweak: Pillar of Spring Cateen/Prep room rearranged (again)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
