### PR TITLE
Fixes Tier 0 Xenos (Larva) Evolving to Tier 2+ castes by abusing regression

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -143,6 +143,10 @@
 		to_chat(src, "<span class='warning'>Nuh-uhh.</span>")
 		return
 
+	if(!forced && !(new_caste_type in xeno_caste.evolves_to))
+		to_chat(src, "<span class='warning'>We can't evolve to that caste from our current one.</span>")
+		return
+
 	// used below
 	var/tierzeros //Larva and burrowed larva if it's a certain kinda hive
 	var/tierones


### PR DESCRIPTION
## About The Pull Request

Adds a `xeno_caste.evolves_to` sanity check to `do_evolve()` code. Has the derpy negative forced check also so we can run it pre special role (queen, shrike, hivemind) logic as they are also exploitable if we only use the last else block.

Fixes: #4796 

## Why It's Good For The Game

Exploit bad. Sanity checks good.

## Changelog
:cl:
fix: Xenos can no longer evolve to the wrong castes after regressing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
