### PR TITLE
rolling buffer improvements

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -85,7 +85,7 @@
 #define MAX_COMMANDS_PER_KEY 5
 ///Max amount of keypress messages per second over two seconds before client is autokicked
 #define MAX_KEYPRESS_AUTOKICK 50
-///Length of held key rolling buffer
+///Length of held key buffer
 #define HELD_KEY_BUFFER_LENGTH 15
 ///Maximum keys allowed per keybind
 #define MAX_KEYS_PER_KEYBIND 3

--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -24,7 +24,8 @@ SUBSYSTEM_DEF(input)
 	"Any+UP" = "\"KeyUp \[\[*\]\]\"",
 	"Back" = "\".winset \\\"input.text=\\\"\\\"\\\"\"",
 	"Tab" = "\".winset \\\"input.focus=true ? map.focus=true : input.focus=true\\\"\"",
-	"Escape" = "\".winset \\\"input.text=\\\"\\\"\\\"\"")
+	"Escape" = "Reset-Held-Keys",
+	)
 
 
 /datum/controller/subsystem/input/proc/refresh_client_macro_sets()

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -42,11 +42,11 @@
 		winset(src, null, "input.focus=true ; input.text=[url_encode(_key)]")
 		return
 
-	//offset by 1 because the buffer address is 0 indexed because the math was simpler
-	keys_held[current_key_address + 1] = _key
+	if(length(keys_held) >= HELD_KEY_BUFFER_LENGTH && !keys_held[_key])
+		keyUp(keys_held[1]) //We are going over the number of possible held keys, so let's remove the first one.
+
 	//the time a key was pressed isn't actually used anywhere (as of 2019-9-10) but this allows easier access usage/checking
 	keys_held[_key] = world.time
-	current_key_address = ((current_key_address + 1) % HELD_KEY_BUFFER_LENGTH)
 	var/movement = movement_keys[_key]
 	if(!(next_move_dir_sub & movement) && !keys_held["Ctrl"])
 		next_move_dir_add |= movement
@@ -80,11 +80,9 @@
 			keys_held[i] = null
 			break
 
-	//Can't just do a remove because it would alter the length of the rolling buffer, instead search for the key then null it out if it exists
-	for(var/i in 1 to HELD_KEY_BUFFER_LENGTH)
-		if(keys_held[i] == _key)
-			keys_held[i] = null
-			break
+	if(!keys_held[_key])
+		return
+	keys_held -= _key
 	var/movement = movement_keys[_key]
 	if(!(next_move_dir_add & movement))
 		next_move_dir_sub |= movement
@@ -96,6 +94,17 @@
 		if(kb.up(src))
 			break
 
+/**
+  * Manually clears any held keys, in case due to lag or other undefined behavior a key gets stuck.
+  *
+  * Hardcoded to the ESC key.
+  */
+/client/verb/reset_held_keys()
+	set name = "Reset Held Keys"
+	set hidden = TRUE
+
+	for(var/key in keys_held)
+		keyUp(key)
 
 // Called every game tick
 /client/keyLoop()

--- a/code/modules/keybindings/setup.dm
+++ b/code/modules/keybindings/setup.dm
@@ -16,9 +16,9 @@
 /client/proc/set_macros()
 	set waitfor = FALSE
 
-	keys_held.Cut()
-	for(var/i in 1 to HELD_KEY_BUFFER_LENGTH)
-		keys_held += null
+	//Reset the buffer
+	for(var/key in keys_held)
+		keyUp(key)
 
 	erase_all_macros()
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

https://github.com/tgstation/tgstation/pull/53773/files
## Changelog
:cl:
fix: Keys no longer have a lifetime of 15 keypresses, meaning you can ctrl+movement keys ad infinitum again.
add: Pressing Esc now has the same effect as releasing all held/pressed keys from the keyboard. Handy if one gets stuck.
tweak: Removed the old functionality in which Esc would delete what's on the input bar when not focused. Remove/backspace still does that.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
