### PR TITLE
Sulaco Dirt + SD

### DIFF
--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -160,6 +160,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/sulaco/disposal)
 "aaK" = (
@@ -192,6 +193,10 @@
 	},
 /turf/open/floor/prison/plate,
 /area/sulaco/cargo)
+"aaO" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/sulaco/hangar)
 "aaP" = (
 /obj/item/clothing/head/ushanka,
 /obj/effect/decal/cleanable/cobweb,
@@ -645,6 +650,7 @@
 "acu" = (
 /obj/machinery/power/apc/mainship,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 1
 	},
@@ -933,6 +939,7 @@
 /obj/effect/decal/cleanable/cobweb{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/sulaco/disposal)
 "ady" = (
@@ -1123,6 +1130,7 @@
 /area/sulaco/hangar/one)
 "aef" = (
 /obj/structure/bed/roller,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 8
 	},
@@ -1938,6 +1946,7 @@
 /turf/closed/wall/mainship/gray,
 /area/sulaco/medbay/surgery_two)
 "ahe" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/sulaco/engineering/ce)
 "ahg" = (
@@ -2794,6 +2803,7 @@
 /area/sulaco/engineering/engine)
 "akk" = (
 /obj/structure/closet/toolcloset,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/darkyellow/full,
 /area/sulaco/engineering)
 "akl" = (
@@ -3682,6 +3692,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall)
 "aoi" = (
@@ -3918,6 +3929,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/sulaco/engineering/smes)
 "apk" = (
@@ -4432,6 +4444,7 @@
 	name = "Briefing Shutters";
 	pixel_x = -30
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/sulaco/briefing)
 "arn" = (
@@ -4950,6 +4963,7 @@
 /obj/effect/decal/cleanable/cobweb{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/sulaco/engineering/smes)
 "asZ" = (
@@ -5155,6 +5169,7 @@
 /turf/open/floor/prison/red,
 /area/sulaco/hallway/central_hall)
 "atC" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/red{
 	dir = 6
 	},
@@ -5840,6 +5855,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/sulaco/briefing)
 "avK" = (
@@ -5858,6 +5874,7 @@
 /turf/open/floor/prison/kitchen,
 /area/sulaco/cafeteria)
 "avR" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/darkyellow,
 /area/sulaco/engineering)
 "avT" = (
@@ -5932,6 +5949,7 @@
 /obj/structure/closet/fireaxecabinet{
 	pixel_y = 30
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/darkyellow{
 	dir = 9
 	},
@@ -6022,6 +6040,7 @@
 /obj/structure/platform{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/sulaco/briefing)
 "awt" = (
@@ -6141,6 +6160,7 @@
 /turf/open/floor/prison,
 /area/sulaco/bridge)
 "awV" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/red{
 	dir = 9
 	},
@@ -7611,6 +7631,7 @@
 	name = "Door Bolt Control";
 	pixel_y = -30
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/darkyellow{
 	dir = 6
 	},
@@ -7841,6 +7862,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/darkyellow{
 	dir = 1
 	},
@@ -7877,6 +7899,7 @@
 /obj/item/clothing/head/hardhat/red,
 /obj/item/clothing/glasses/meson,
 /obj/effect/decal/cleanable/cobweb2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/mainship,
 /area/mainship/shipboard/weapon_room)
 "aEo" = (
@@ -8757,6 +8780,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall3)
 "aIo" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/darkyellow{
 	dir = 4
 	},
@@ -9853,11 +9877,13 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/red{
 	dir = 8
 	},
 /area/sulaco/command/eva)
 "aNH" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/red/corner,
 /area/sulaco/command/eva)
 "aNI" = (
@@ -10416,6 +10442,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/cult,
 /area/sulaco/morgue)
 "aRj" = (
@@ -10800,6 +10827,7 @@
 /area/sulaco/research)
 "aTb" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/cult,
 /area/sulaco/morgue)
 "aTc" = (
@@ -11463,6 +11491,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_main_hall)
 "aWL" = (
@@ -11820,6 +11849,7 @@
 /area/sulaco/maintenance/lower_maint)
 "aZD" = (
 /obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/sulaco/maintenance/lower_maint)
 "aZF" = (
@@ -11958,6 +11988,7 @@
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/sulaco/briefing)
 "bat" = (
@@ -11970,6 +12001,17 @@
 /obj/structure/largecrate/random,
 /turf/open/floor/plating,
 /area/sulaco/maintenance/south_solar_maint)
+"bax" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/sulaco/hallway/central_hall)
 "baz" = (
 /turf/open/floor/mainship/tcomms,
 /area/sulaco/telecomms)
@@ -12043,6 +12085,7 @@
 /area/sulaco/hallway/lower_main_hall)
 "baR" = (
 /obj/structure/closet/walllocker/hydrant,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/sulaco/hallway/lower_main_hall)
 "baS" = (
@@ -12124,6 +12167,7 @@
 /obj/machinery/alarm{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/sulaco/hangar)
 "bbV" = (
@@ -12238,6 +12282,10 @@
 /obj/machinery/light,
 /turf/open/floor/plating,
 /area/sulaco/hallway/lower_main_hall)
+"bcY" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/darkyellow/corner,
+/area/sulaco/engineering)
 "bde" = (
 /obj/machinery/telecomms/server/presets/engineering,
 /turf/open/floor/mainship/tcomms,
@@ -12483,6 +12531,10 @@
 	},
 /turf/open/floor/cult,
 /area/sulaco/morgue)
+"bkk" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/sulaco/cargo)
 "bkX" = (
 /obj/structure/closet/crate/construction,
 /turf/open/floor/prison/plate,
@@ -12579,12 +12631,14 @@
 /area/sulaco/hallway/central_hall3)
 "bLu" = (
 /obj/structure/closet/crate/freezer,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/whitegreen/corner,
 /area/sulaco/medbay/surgery_two)
 "bMV" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 5
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/mainship,
 /area/sulaco/engineering/engine)
 "bNO" = (
@@ -12593,6 +12647,10 @@
 	},
 /turf/open/floor/prison/plate,
 /area/shuttle/distress/arrive_1)
+"bOh" = (
+/obj/structure/window/framed/mainship/gray/toughened/hull,
+/turf/open/floor/plating/platebotc,
+/area/sulaco/cargo)
 "bOX" = (
 /obj/effect/step_trigger/teleporter/random{
 	affect_ghosts = 1;
@@ -12659,6 +12717,12 @@
 	},
 /turf/open/floor/wood,
 /area/sulaco/liaison)
+"cly" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/mainship/living/pilotbunks)
 "cnu" = (
 /obj/structure/cable,
 /turf/open/floor/prison,
@@ -12741,6 +12805,11 @@
 /obj/structure/bed,
 /turf/open/floor/prison,
 /area/mainship/living/pilotbunks)
+"cEc" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/cult,
+/area/sulaco/morgue)
 "cEF" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -12882,6 +12951,11 @@
 /obj/structure/disposalpipe/segment/corner,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/hallway/central_hall2)
+"cYh" = (
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/bright_clean,
+/area/sulaco/hangar)
 "cYI" = (
 /obj/structure/flora/pottedplant,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -12937,6 +13011,10 @@
 	},
 /turf/open/floor/plating,
 /area/sulaco/maintenance/south_solar_maint)
+"dnW" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/sulaco/cargo)
 "dse" = (
 /obj/machinery/door/poddoor/open/engine{
 	dir = 1
@@ -12978,6 +13056,7 @@
 /area/sulaco/cargo/office)
 "dyW" = (
 /obj/structure/largecrate/guns/merc,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/plate,
 /area/sulaco/cargo)
 "dzy" = (
@@ -13013,6 +13092,13 @@
 /obj/machinery/alarm,
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_main_hall)
+"dJG" = (
+/obj/structure/largecrate/random,
+/obj/effect/decal/cleanable/cobweb{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/sulaco/maintenance/lower_maint)
 "dLt" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic/garden,
 /obj/structure/cable,
@@ -13054,6 +13140,7 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/mainship,
 /area/sulaco/engineering/engine)
 "dQr" = (
@@ -13131,13 +13218,6 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/mainship/ai,
 /area/sulaco/command/ai)
-"eip" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/bed/stool{
-	pixel_y = 8
-	},
-/turf/open/floor/grass,
-/area/space)
 "ejj" = (
 /obj/structure/table/mainship,
 /obj/item/healthanalyzer,
@@ -13227,6 +13307,14 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall2)
+"eBz" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/sulaco/engineering)
 "eCX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/prison,
@@ -13251,18 +13339,14 @@
 	},
 /turf/closed/wall/mainship/gray,
 /area/sulaco/engineering/atmos)
+"eKx" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/plate,
+/area/sulaco/cargo)
 "eLg" = (
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/prison,
 /area/sulaco/cargo/office)
-"eLL" = (
-/obj/structure/bed/stool{
-	pixel_y = 8
-	},
-/obj/machinery/power/apc/mainship,
-/obj/structure/cable,
-/turf/open/floor/grass,
-/area/space)
 "eMk" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -13318,6 +13402,7 @@
 /turf/open/floor/plating/platebotc,
 /area/mainship/living/starboard_garden)
 "faO" = (
+/obj/structure/window/framed/mainship/gray/toughened/hull,
 /turf/open/floor/plating/platebotc,
 /area/sulaco/maintenance/lower_maint)
 "fdF" = (
@@ -13327,6 +13412,12 @@
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/prison/bright_clean,
 /area/mainship/command/self_destruct)
+"feM" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/red{
+	dir = 1
+	},
+/area/mainship/shipboard/weapon_room)
 "feO" = (
 /obj/effect/decal/siding{
 	dir = 5
@@ -13334,10 +13425,6 @@
 /turf/open/floor/mainship/terragov/north{
 	dir = 5
 	},
-/area/space)
-"fgG" = (
-/obj/item/reagent_containers/food/snacks/grown/poppy,
-/turf/open/floor/mainship/mono,
 /area/space)
 "fhh" = (
 /obj/structure/cable,
@@ -13361,6 +13448,11 @@
 	dir = 4
 	},
 /area/sulaco/research)
+"fng" = (
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/red,
+/area/mainship/shipboard/weapon_room)
 "fpa" = (
 /obj/structure/sign/nosmoking_2,
 /turf/closed/wall/mainship/gray,
@@ -13377,6 +13469,10 @@
 	},
 /turf/open/floor/wood,
 /area/sulaco/liaison)
+"fqv" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/sulaco/maintenance/south_solar_maint)
 "frR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -13442,6 +13538,13 @@
 /obj/item/assembly/infra,
 /turf/open/floor/prison,
 /area/sulaco/maintenance/lower_maint)
+"fDl" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/sulaco/telecomms/office)
 "fEL" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -13453,6 +13556,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
 "fFh" = (
@@ -13522,6 +13626,15 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/prison,
 /area/sulaco/engineering/storage)
+"fSi" = (
+/obj/structure/ship_ammo/heavygun,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/sulaco/maintenance/lower_maint)
+"fVO" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/sulaco/maintenance/lower_maint)
 "fWv" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -13590,6 +13703,14 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/sulaco/maintenance/lower_maint)
+"ggt" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/sulaco/bridge/office)
+"ggy" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/sulaco/disposal)
 "ggM" = (
 /obj/structure/table/mainship,
 /obj/machinery/light/small{
@@ -13611,10 +13732,6 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/prison/red,
 /area/sulaco/briefing)
-"gid" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/grass,
-/area/space)
 "giH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -13640,6 +13757,16 @@
 	},
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
+"gnu" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/bright_clean,
+/area/sulaco/hangar)
 "gsz" = (
 /obj/effect/decal/siding{
 	dir = 8
@@ -13686,6 +13813,10 @@
 /obj/structure/cable,
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
+"gHU" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/bright_clean,
+/area/sulaco/hangar)
 "gKi" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
@@ -13698,6 +13829,7 @@
 "gKw" = (
 /obj/effect/decal/warning_stripes,
 /obj/structure/dropship_equipment/fuel/cooling_system,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/sulaco/hangar)
 "gKQ" = (
@@ -13751,6 +13883,13 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall3)
+"gSq" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/sulaco/bridge/quarters)
 "gVb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
@@ -13758,6 +13897,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison,
 /area/sulaco/engineering)
+"gWY" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "garbage"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/sulaco/disposal)
 "gXd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -13806,6 +13953,10 @@
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/open/floor/plating,
 /area/sulaco/hangar)
+"hhb" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/red,
+/area/sulaco/hallway/central_hall)
 "hhn" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -13824,9 +13975,17 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/maintenance/lower_maint)
-"hmS" = (
-/turf/open/floor/mainship/mono,
-/area/space)
+"hjU" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/sulaco/hallway/central_hall3)
 "hnW" = (
 /obj/structure/target_stake,
 /obj/item/target,
@@ -13835,6 +13994,12 @@
 	dir = 4
 	},
 /area/sulaco/hangar/one)
+"hoF" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/whitegreen{
+	dir = 10
+	},
+/area/sulaco/research)
 "hto" = (
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 1
@@ -13897,10 +14062,6 @@
 	dir = 4
 	},
 /area/sulaco/medbay)
-"hNN" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/grass,
-/area/space)
 "hPG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13952,6 +14113,10 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/cargo)
+"hTi" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/sulaco/telecomms/office)
 "hTL" = (
 /obj/machinery/door/poddoor/railing{
 	dir = 8;
@@ -13966,6 +14131,7 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/sulaco/maintenance/lower_maint)
 "hWi" = (
@@ -14017,6 +14183,11 @@
 	},
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
+"idd" = (
+/obj/structure/bed/roller,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/bright_clean,
+/area/sulaco/hangar)
 "iea" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -14080,6 +14251,20 @@
 	},
 /turf/open/floor/prison/whitegreen,
 /area/sulaco/research)
+"inz" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/sulaco/hallway/central_hall3)
 "inB" = (
 /obj/structure/mirror,
 /turf/open/floor/freezer,
@@ -14134,6 +14319,11 @@
 /obj/machinery/alarm,
 /turf/open/floor/plating,
 /area/sulaco/disposal)
+"iuI" = (
+/obj/machinery/iv_drip,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/whitegreen/corner,
+/area/sulaco/medbay/storage)
 "iuM" = (
 /obj/effect/decal/cleanable/cobweb{
 	dir = 8
@@ -14212,6 +14402,13 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /turf/open/floor/freezer,
 /area/sulaco/showers)
+"iKy" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/marked,
+/area/sulaco/hangar/one)
 "iNl" = (
 /obj/machinery/light,
 /turf/open/floor/wood,
@@ -14296,6 +14493,13 @@
 /obj/item/assembly/voice,
 /turf/open/floor/prison,
 /area/sulaco/maintenance/lower_maint)
+"joi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/sulaco/disposal)
 "joP" = (
 /obj/machinery/vending/marine,
 /turf/open/floor/prison,
@@ -14312,9 +14516,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating/platebotc,
 /area/sulaco/liaison)
-"jyM" = (
-/turf/open/floor/grass,
-/area/space)
 "jAp" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -14362,11 +14563,6 @@
 	},
 /turf/open/floor/freezer,
 /area/sulaco/showers)
-"jHO" = (
-/obj/structure/prop/mainship/ship_memorial,
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/space)
 "jJe" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/machinery/light{
@@ -14434,6 +14630,10 @@
 	dir = 10
 	},
 /area/space)
+"jYO" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/sulaco/maintenance/lower_maint)
 "kcn" = (
 /obj/machinery/computer3/server/rack,
 /obj/machinery/light/small{
@@ -14458,6 +14658,13 @@
 	},
 /turf/open/floor/grass,
 /area/mainship/living/starboard_garden)
+"kkA" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/bright_clean,
+/area/sulaco/hangar)
 "kla" = (
 /obj/structure/sign/prop1,
 /turf/closed/wall/mainship/gray,
@@ -14481,6 +14688,10 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/marine)
+"koN" = (
+/obj/structure/window/framed/mainship/gray/toughened/hull,
+/turf/open/floor/plating/platebotc,
+/area/sulaco/hallway/central_hall3)
 "kqp" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/prison,
@@ -14624,10 +14835,25 @@
 	},
 /turf/open/floor/prison/plate,
 /area/sulaco/cargo)
+"kWb" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/sulaco/engineering/storage)
 "kXs" = (
 /obj/machinery/autolathe,
 /turf/open/floor/prison,
 /area/sulaco/cargo/office)
+"kYg" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/sulaco/hallway/central_hall2)
+"kYl" = (
+/obj/structure/largecrate/random,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/sulaco/hallway/lower_main_hall)
 "kYL" = (
 /obj/machinery/door/airlock/mainship/secure{
 	name = "Self Destruct Room"
@@ -14678,6 +14904,12 @@
 	dir = 4
 	},
 /area/sulaco/engineering)
+"lfO" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/red{
+	dir = 8
+	},
+/area/sulaco/hangar/one)
 "lkp" = (
 /turf/open/floor/prison/red,
 /area/mainship/shipboard/weapon_room)
@@ -14686,6 +14918,16 @@
 /obj/machinery/door/poddoor/open/bridge,
 /turf/open/floor/plating,
 /area/sulaco/cap_office)
+"lmE" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/sulaco/maintenance/south_solar_maint)
+"lnd" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/plate,
+/area/sulaco/maintenance/south_solar_maint)
 "lnH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14732,6 +14974,13 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/sulaco/command/ai)
+"ltQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/sulaco/maintenance/lower_maint)
 "lvm" = (
 /obj/machinery/vending/uniform_supply,
 /turf/open/floor/prison,
@@ -14753,6 +15002,20 @@
 	dir = 1
 	},
 /area/sulaco/medbay/storage2)
+"lCa" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/sulaco/hallway/central_hall2)
 "lDs" = (
 /obj/structure/table/mainship,
 /obj/item/stack/medical/ointment,
@@ -14798,6 +15061,10 @@
 	dir = 8
 	},
 /area/sulaco/briefing)
+"lId" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/mainship,
+/area/sulaco/engineering/engine)
 "lIs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
@@ -14824,6 +15091,10 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/sulaco/maintenance/south_solar_maint)
+"lMX" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/sulaco/hallway/central_hall3)
 "lNU" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/effect/decal/warning_stripes/thin{
@@ -14892,6 +15163,13 @@
 	dir = 4
 	},
 /area/space)
+"mbL" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/sulaco/hallway/central_hall3)
 "mcG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -14902,6 +15180,10 @@
 	},
 /turf/open/floor/prison/red,
 /area/mainship/shipboard/weapon_room)
+"mdt" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/red,
+/area/sulaco/cargo)
 "mfo" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 5
@@ -14995,6 +15277,7 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 9
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/mainship,
 /area/sulaco/engineering/engine)
 "myy" = (
@@ -15090,6 +15373,10 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/cult,
 /area/sulaco/morgue)
+"mNH" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/sulaco/command/eva)
 "mOD" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
 	dir = 1
@@ -15106,6 +15393,10 @@
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cryosleep)
+"mPO" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/plate,
+/area/shuttle/distress/arrive_1)
 "mRl" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/prison,
@@ -15199,6 +15490,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/hallway/central_hall3)
+"nmq" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/sulaco/hallway/central_hall3)
 "nob" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
@@ -15258,12 +15556,14 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/sulaco/maintenance/lower_maint)
 "nGG" = (
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/red{
 	dir = 8
 	},
@@ -15300,6 +15600,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/sulaco/engineering/smes)
+"nJV" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/sulaco/hangar/one)
 "nKB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
@@ -15327,6 +15631,10 @@
 	},
 /turf/open/floor/prison/whitegreen/corner,
 /area/sulaco/medbay/west)
+"nOS" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/sulaco/engineering/smes)
 "nOT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -15425,6 +15733,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall3)
+"okC" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/sulaco/maintenance/south_solar_maint)
 "okJ" = (
 /obj/machinery/light{
 	dir = 8
@@ -15522,6 +15841,7 @@
 /turf/open/floor/mainship/stripesquare,
 /area/sulaco/command/ai)
 "oBC" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/yellow{
 	dir = 9
 	},
@@ -15580,6 +15900,10 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_main_hall)
+"oLM" = (
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating,
+/area/sulaco/maintenance/lower_maint)
 "oMn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -15643,6 +15967,10 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall3)
+"oXE" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/sulaco/cap_office)
 "oYE" = (
 /turf/open/floor/plating,
 /area/sulaco/hub/top)
@@ -15693,10 +16021,6 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
-"pfX" = (
-/obj/structure/cable,
-/turf/open/floor/grass,
-/area/space)
 "pks" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -15758,6 +16082,12 @@
 	},
 /turf/open/floor/prison/plate,
 /area/sulaco/cargo)
+"pnR" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/whitegreen/corner{
+	dir = 8
+	},
+/area/sulaco/medbay/surgery_two)
 "ptg" = (
 /obj/structure/table/mainship,
 /obj/item/storage/belt/utility/full,
@@ -15785,6 +16115,7 @@
 /area/sulaco/hallway/central_hall3)
 "pxX" = (
 /obj/structure/largecrate/guns/russian,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/plate,
 /area/sulaco/cargo)
 "pxY" = (
@@ -15827,6 +16158,13 @@
 /obj/machinery/door/poddoor/open/bridge,
 /turf/open/floor/plating/platebotc,
 /area/sulaco/cap_office)
+"pCP" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/bright_clean,
+/area/sulaco/hangar)
 "pDe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -15876,6 +16214,7 @@
 "pMx" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/sulaco/maintenance/lower_maint)
 "pOF" = (
@@ -15885,6 +16224,10 @@
 	},
 /turf/open/floor/plating/platebotc,
 /area/sulaco/engineering/storage)
+"pQL" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/sulaco/hallway/lower_main_hall)
 "pTo" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -15903,10 +16246,18 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/darkyellow/corner{
 	dir = 4
 	},
 /area/sulaco/engineering)
+"pYk" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/plate,
+/area/shuttle/distress/arrive_1)
 "pYq" = (
 /obj/machinery/light{
 	dir = 4
@@ -16003,6 +16354,7 @@
 	dir = 10
 	},
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/sulaco/maintenance/lower_maint)
 "qqM" = (
@@ -16032,6 +16384,13 @@
 /obj/item/reagent_containers/food/drinks/bottle/sake,
 /turf/open/floor/wood,
 /area/sulaco/liaison/quarters)
+"qxr" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/sulaco/maintenance/lower_maint)
 "qyF" = (
 /obj/machinery/door/airlock/external,
 /turf/open/floor/prison,
@@ -16081,6 +16440,11 @@
 /obj/machinery/recharge_station,
 /turf/open/floor/prison,
 /area/sulaco/engineering/engine)
+"qLv" = (
+/obj/structure/closet/emcloset,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/sulaco/hallway/lower_main_hall)
 "qMR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mainship/engineering,
@@ -16118,6 +16482,10 @@
 	dir = 4
 	},
 /area/sulaco/showers)
+"qSH" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/mainship/shipboard/weapon_room)
 "qTF" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
 	dir = 1
@@ -16159,6 +16527,7 @@
 "qZW" = (
 /obj/structure/largecrate/guns,
 /obj/machinery/camera/autoname,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/plate,
 /area/sulaco/cargo)
 "rai" = (
@@ -16260,6 +16629,13 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/mainship/command/self_destruct)
+"rmq" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/plate,
+/area/shuttle/distress/arrive_1)
 "rmV" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /turf/open/floor/plating/plating_catwalk/prison,
@@ -16279,6 +16655,17 @@
 	dir = 4
 	},
 /area/sulaco/engineering/atmos)
+"rpi" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/sulaco/hallway/lower_main_hall)
 "rpk" = (
 /turf/open/floor/prison/blue{
 	dir = 4
@@ -16319,6 +16706,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/darkyellow/corner{
 	dir = 4
 	},
@@ -16331,6 +16719,11 @@
 /obj/structure/prop/mainship/sensor_computer1/sd,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
+"ryR" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/bright_clean,
+/area/sulaco/hangar)
 "rzl" = (
 /turf/closed/wall/mainship/gray/outer,
 /area/sulaco/cargo)
@@ -16392,6 +16785,17 @@
 /obj/item/tool/stamp/denied,
 /turf/open/floor/prison,
 /area/sulaco/cargo/office)
+"rJi" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/sulaco/engineering/atmos)
+"rJo" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/sulaco/hallway/central_hall3)
 "rJr" = (
 /turf/open/floor/mainship/terragov/west{
 	dir = 8
@@ -16400,6 +16804,12 @@
 "rOj" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/prison,
+/area/sulaco/maintenance/lower_maint)
+"rPw" = (
+/obj/effect/decal/cleanable/cobweb{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/sulaco/maintenance/lower_maint)
 "rPM" = (
 /obj/machinery/door/airlock/mainship/marine/general{
@@ -16415,10 +16825,6 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/engineering/engine)
-"rQi" = (
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/space)
 "rQp" = (
 /obj/machinery/vending/marine/cargo_ammo,
 /turf/open/floor/prison,
@@ -16479,6 +16885,20 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/prison,
 /area/sulaco/engineering/atmos)
+"sbx" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/sulaco/hallway/central_hall3)
 "sbP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -16616,6 +17036,10 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
+"sqS" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/cult,
+/area/sulaco/morgue)
 "srT" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -16684,6 +17108,12 @@
 	dir = 1
 	},
 /area/sulaco/cargo)
+"sAL" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/red{
+	dir = 1
+	},
+/area/sulaco/hallway/central_hall3)
 "sAN" = (
 /obj/effect/landmark/start/job/squadmarine,
 /obj/effect/decal/warning_stripes/thick{
@@ -16694,6 +17124,14 @@
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cryosleep)
+"sBl" = (
+/obj/structure/closet/secure_closet/medical1,
+/obj/item/storage/box/rxglasses,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/whitegreen/corner{
+	dir = 4
+	},
+/area/sulaco/medbay/storage2)
 "sBt" = (
 /turf/open/shuttle/escapepod{
 	icon_state = "floor8"
@@ -16724,6 +17162,11 @@
 	},
 /turf/open/floor/plating,
 /area/sulaco/maintenance/lower_maint2)
+"sGd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/largecrate/random,
+/turf/open/floor/plating,
+/area/sulaco/maintenance/lower_maint)
 "sGr" = (
 /obj/structure/largecrate/random,
 /obj/effect/decal/cleanable/cobweb{
@@ -16758,10 +17201,18 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
+"sKV" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/darkyellow,
+/area/sulaco/engineering/engine)
 "sLY" = (
 /obj/structure/window/framed/mainship/gray/toughened/hull,
 /turf/open/floor/plating/platebotc,
 /area/sulaco/marine/delta)
+"sMg" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/sulaco/hallway/lower_main_hall)
 "sMD" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -16859,6 +17310,10 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/prison,
 /area/sulaco/cargo/office)
+"sTR" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/sulaco/hallway/central_hall)
 "sWl" = (
 /obj/structure/closet/secure_closet/medical2,
 /turf/open/floor/prison/whitegreen/corner,
@@ -16966,6 +17421,11 @@
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/closed/wall/mainship/gray,
 /area/sulaco/medbay/west)
+"tny" = (
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/sulaco/briefing)
 "tpA" = (
 /obj/structure/dropship_equipment/electronics/targeting_system,
 /obj/machinery/light{
@@ -17058,11 +17518,22 @@
 "tAS" = (
 /turf/closed/wall/mainship/gray,
 /area/sulaco/engineering/engine)
+"tBz" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/red,
+/area/sulaco/hangar/one)
 "tBB" = (
 /obj/machinery/status_display,
 /turf/closed/wall/mainship/gray/outer,
 /area/sulaco/engineering/engine)
+"tDT" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/darkyellow/corner{
+	dir = 4
+	},
+/area/sulaco/engineering)
 "tIY" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/red{
 	dir = 6
 	},
@@ -17157,6 +17628,7 @@
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/sulaco/hangar)
 "ueP" = (
@@ -17271,6 +17743,10 @@
 /obj/structure/closet/crate,
 /turf/open/floor/prison,
 /area/sulaco/engineering/storage)
+"uAS" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/sulaco/engineering)
 "uBn" = (
 /obj/structure/sign/nosmoking_1,
 /turf/closed/wall/mainship/gray,
@@ -17348,6 +17824,11 @@
 	},
 /turf/open/floor/plating,
 /area/sulaco/hallway/lower_main_hall)
+"uNX" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/sulaco/engineering/smes)
 "uOd" = (
 /obj/structure/table/mainship,
 /obj/item/weapon/gun/rifle/m41a1,
@@ -17473,6 +17954,11 @@
 	dir = 10
 	},
 /area/space)
+"vyW" = (
+/obj/machinery/door/poddoor/open/port,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/sulaco/cargo)
 "vAN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -17565,6 +18051,13 @@
 	dir = 10
 	},
 /area/sulaco/hangar/one)
+"vSc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/sulaco/cargo)
 "vTd" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -17625,6 +18118,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/red,
 /area/sulaco/cargo)
 "wie" = (
@@ -17704,6 +18198,7 @@
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/sulaco/disposal)
 "wsa" = (
@@ -17828,6 +18323,10 @@
 	},
 /turf/open/floor/plating,
 /area/sulaco/disposal)
+"wGO" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/sulaco/maintenance/lower_maint2)
 "wHe" = (
 /obj/machinery/light{
 	dir = 4
@@ -17836,6 +18335,10 @@
 /obj/structure/table/mainship,
 /turf/open/floor/prison,
 /area/sulaco/engineering)
+"wHi" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/sulaco/maintenance/north_solar_maint)
 "wHk" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
@@ -17890,6 +18393,10 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/marine/alpha)
+"wOA" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/sulaco/briefing)
 "wRO" = (
 /turf/open/floor/mainship_hull/gray/dir{
 	dir = 8
@@ -17942,17 +18449,12 @@
 "wVV" = (
 /turf/open/floor/prison,
 /area/mainship/living/starboard_garden)
-"wVZ" = (
-/obj/structure/bed/stool{
-	pixel_y = 8
-	},
-/turf/open/floor/grass,
-/area/space)
 "wXI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/sulaco/disposal)
 "wYN" = (
@@ -17997,6 +18499,10 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/engineering/atmos)
+"xip" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison,
+/area/sulaco/engineering/storage)
 "xjl" = (
 /obj/structure/window/framed/mainship/gray/toughened,
 /turf/open/floor/plating/platebotc,
@@ -18016,6 +18522,10 @@
 "xpm" = (
 /turf/closed/wall/mainship/gray,
 /area/mainship/living/pilotbunks)
+"xpA" = (
+/obj/structure/window/framed/mainship/gray/toughened/hull,
+/turf/open/floor/plating/platebotc,
+/area/mainship/living/starboard_garden)
 "xpK" = (
 /obj/machinery/door/airlock/mainship/ai{
 	dir = 1
@@ -18024,6 +18534,10 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /turf/open/floor/mainship/ai,
 /area/sulaco/command/ai)
+"xrp" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/prison/plate,
+/area/sulaco/maintenance/south_solar_maint)
 "xur" = (
 /obj/structure/prop/mainship/sensor_computer2/sd,
 /turf/open/floor/mainship/tcomms,
@@ -18077,6 +18591,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 9
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/cult,
 /area/sulaco/morgue)
 "xBs" = (
@@ -18111,8 +18626,22 @@
 "xFO" = (
 /obj/structure/table/mainship,
 /obj/effect/spawner/random/toolbox,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/sulaco/maintenance/lower_maint)
+"xGR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/sulaco/engineering/storage)
 "xLr" = (
 /obj/structure/bed/chair,
 /obj/structure/disposalpipe/segment{
@@ -18166,11 +18695,6 @@
 	},
 /turf/open/floor/prison/plate,
 /area/shuttle/distress/arrive_1)
-"xTI" = (
-/obj/item/reagent_containers/food/snacks/grown/poppy,
-/obj/structure/cable,
-/turf/open/floor/mainship/mono,
-/area/space)
 "xVg" = (
 /obj/structure/table/mainship,
 /obj/item/reagent_containers/spray,
@@ -38624,7 +39148,7 @@ aAU
 aBh
 tbJ
 xzG
-xzG
+oXE
 aDi
 aIz
 aFy
@@ -39122,7 +39646,7 @@ wRO
 vyQ
 nzi
 ghk
-sBO
+ggt
 sBO
 tbJ
 anY
@@ -39143,13 +39667,13 @@ aDi
 aIz
 cwp
 aHz
-aHz
-aHz
+qSH
+qSH
 aHz
 aOY
 aHz
 aHz
-fNG
+fng
 aIz
 mDu
 qDO
@@ -39399,8 +39923,8 @@ xzG
 aDi
 aIz
 cwp
-aHz
-aHz
+qSH
+qSH
 aKT
 aHz
 aPa
@@ -39661,7 +40185,7 @@ aJA
 aLx
 aHz
 aHz
-aHz
+qSH
 aHz
 lkp
 tRj
@@ -39917,8 +40441,8 @@ aDi
 aDi
 cwp
 aHz
-aHz
-aHz
+qSH
+qSH
 aHz
 lkp
 tRj
@@ -40403,7 +40927,7 @@ agX
 agX
 agX
 dgY
-myy
+pnR
 dZa
 myy
 ahd
@@ -40943,7 +41467,7 @@ aDi
 aIy
 aGZ
 aDi
-cwp
+feM
 aHz
 aVF
 aIz
@@ -41291,22 +41815,22 @@ aQN
 aRg
 aQw
 aQw
+wGO
+aRg
+aQw
+wGO
 aQw
 aRg
 aQw
 aQw
 aQw
-aRg
+aQw
+aQw
+wGO
 aQw
 aQw
 aQw
-aQw
-aQw
-aQw
-aQw
-aQw
-aQw
-aQw
+wGO
 aQw
 aQD
 htN
@@ -41705,11 +42229,11 @@ awI
 ayB
 aoi
 aoi
-aoi
+sTR
 aDm
 aDm
 aDm
-cwp
+feM
 its
 wjX
 ufk
@@ -41809,11 +42333,11 @@ aEJ
 aFv
 ieK
 aZV
-mYD
+hoF
 aRh
 aWG
 aWG
-aWG
+pQL
 aYM
 aZF
 baz
@@ -42485,10 +43009,10 @@ azq
 azq
 aCg
 aCg
+fqv
 aCg
 aCg
-aCg
-aCg
+fqv
 aCg
 aCg
 dlV
@@ -42572,7 +43096,7 @@ aaa
 nzi
 mDu
 aPg
-aQw
+wGO
 aVc
 aVc
 aVc
@@ -42595,7 +43119,7 @@ baz
 bdy
 aYM
 aQh
-aQw
+wGO
 aPg
 mDu
 qDO
@@ -42738,7 +43262,7 @@ azq
 azq
 aEs
 aCg
-aCg
+fqv
 aCg
 aCg
 iuM
@@ -42980,7 +43504,7 @@ rcP
 adI
 abJ
 abD
-aoi
+sTR
 dAO
 arc
 asQ
@@ -43108,7 +43632,7 @@ cjc
 pzX
 baz
 aPM
-aQw
+wGO
 aQw
 aPg
 mDu
@@ -43246,7 +43770,7 @@ asQ
 atz
 asQ
 awI
-aon
+bax
 aoi
 azq
 aEs
@@ -43263,7 +43787,7 @@ aGC
 xuU
 aAI
 aCg
-aCg
+fqv
 aJm
 mDu
 qDO
@@ -43612,7 +44136,7 @@ lZk
 aHm
 aTi
 aWG
-aYl
+qLv
 aYM
 aZL
 aTJ
@@ -43764,7 +44288,7 @@ jGA
 aoi
 azq
 aEu
-aCg
+fqv
 aCg
 lMO
 aAI
@@ -43877,10 +44401,10 @@ aRw
 bbX
 bcI
 bdf
-bcI
+hTi
 aYS
 aQw
-aQw
+wGO
 aPg
 mDu
 qDO
@@ -44010,7 +44534,7 @@ ahz
 abH
 anN
 xvh
-arc
+hhb
 asQ
 atJ
 asQ
@@ -44033,7 +44557,7 @@ aAI
 aFz
 aAI
 aAI
-aCg
+fqv
 aJm
 aJm
 mDu
@@ -44371,7 +44895,7 @@ emV
 mDu
 mDu
 aPg
-aQw
+wGO
 aRh
 dFk
 tao
@@ -44393,8 +44917,8 @@ bcJ
 qHi
 bdA
 aYS
-aQw
-aQw
+wGO
+wGO
 aPg
 mDu
 mDu
@@ -44522,13 +45046,13 @@ wAz
 adf
 alP
 amA
-aoi
+sTR
 dez
 arg
 aun
 atL
 atP
-atL
+gSq
 aun
 azT
 wBd
@@ -44647,7 +45171,7 @@ aYS
 aYS
 aYi
 baW
-xgp
+fDl
 bdB
 aYS
 aQw
@@ -44766,7 +45290,7 @@ aaa
 nzi
 mDu
 add
-abG
+iuI
 acY
 abG
 abo
@@ -44899,7 +45423,7 @@ aTi
 aXA
 aWG
 aYS
-bcI
+hTi
 aTV
 bcI
 bcI
@@ -45142,7 +45666,7 @@ nzi
 mDu
 aPg
 aQw
-aQw
+wGO
 siA
 aRh
 aSq
@@ -45165,7 +45689,7 @@ bdh
 bdC
 aYS
 aQw
-aQw
+wGO
 aQw
 htN
 aPg
@@ -45562,7 +46086,7 @@ awI
 jGA
 aoi
 azq
-aCg
+fqv
 aCg
 aCg
 aCg
@@ -45575,7 +46099,7 @@ aGC
 aGC
 xuU
 aAI
-aCg
+fqv
 wbm
 aJm
 mDu
@@ -45655,7 +46179,7 @@ aaa
 nzi
 mDu
 aPg
-aQw
+wGO
 aQi
 aQi
 aQi
@@ -45917,7 +46441,7 @@ aQi
 aRl
 aRJ
 aSs
-aQy
+sqS
 aRJ
 aUc
 aRJ
@@ -46175,7 +46699,7 @@ aRm
 aQy
 aQy
 aQy
-aQy
+sqS
 aQy
 aQy
 aRi
@@ -46196,7 +46720,7 @@ bea
 bdM
 ezr
 bdj
-aQw
+wGO
 aRk
 aPg
 mDu
@@ -46324,7 +46848,7 @@ ahz
 aoi
 dAO
 aoi
-aoi
+sTR
 arc
 aoi
 awI
@@ -46336,7 +46860,7 @@ azq
 aCg
 aCg
 aCg
-aCg
+fqv
 aCg
 aCg
 vlG
@@ -46345,7 +46869,7 @@ azq
 azq
 aEr
 aCg
-aCg
+fqv
 aCg
 xNO
 aJm
@@ -46427,9 +46951,9 @@ nzi
 mDu
 aPh
 aNv
+cEc
 aNv
-aNv
-aNv
+cEc
 aNv
 aNv
 aNv
@@ -46438,7 +46962,7 @@ aNv
 uzq
 aQi
 aWG
-aXw
+rpi
 aWG
 aZa
 baa
@@ -46595,7 +47119,7 @@ aEu
 aCg
 aCg
 aCg
-aCg
+fqv
 aCg
 onG
 aCg
@@ -46951,7 +47475,7 @@ stF
 mNA
 xAc
 aQi
-aWG
+pQL
 vmi
 aWG
 aZa
@@ -47095,7 +47619,7 @@ anh
 aor
 frR
 aor
-aor
+kYg
 atR
 ain
 avl
@@ -47106,7 +47630,7 @@ aCF
 ank
 aDr
 aDC
-aFR
+lnd
 aGv
 aFR
 aFR
@@ -47197,9 +47721,9 @@ aaa
 nzi
 mDu
 aPh
+sqS
 aQy
-aQy
-aQy
+sqS
 aQy
 aQy
 aQy
@@ -47225,7 +47749,7 @@ bdM
 beK
 bdj
 aQw
-aQw
+wGO
 aPg
 mDu
 qDO
@@ -47375,7 +47899,7 @@ azq
 aCg
 aCg
 aCg
-aCg
+fqv
 aJm
 mDu
 mDu
@@ -47458,14 +47982,14 @@ aQy
 aQy
 aQy
 aQy
-aQy
+sqS
 aQy
 aQy
 bjV
 aQy
-aQy
+sqS
 aUP
-aWG
+pQL
 aXw
 aWG
 jvc
@@ -47481,8 +48005,8 @@ bel
 aWU
 beL
 bdj
-aQw
-aQw
+wGO
+wGO
 aPg
 mDu
 qDO
@@ -47604,7 +48128,7 @@ ahF
 aiC
 ajQ
 abH
-aaW
+wHi
 ank
 aos
 gcO
@@ -47613,7 +48137,7 @@ asA
 atR
 aip
 bID
-aor
+kYg
 aor
 oMn
 aor
@@ -47712,7 +48236,7 @@ mDu
 mDu
 aPh
 aQA
-aQy
+sqS
 aQA
 aQA
 aQA
@@ -47882,13 +48406,13 @@ azq
 aHN
 lEF
 aHN
-bNO
+pYk
 xTi
 aHN
 rta
 aHN
 aHN
-aHN
+mPO
 giH
 aHN
 bNO
@@ -48116,14 +48640,14 @@ iiM
 agC
 aiD
 asR
-adP
+sBl
 abK
 aaW
 ank
 aor
 apI
 aql
-aor
+kYg
 atR
 pni
 aks
@@ -48133,7 +48657,7 @@ apI
 aor
 ank
 aDx
-gje
+xrp
 gje
 azq
 aHN
@@ -48149,8 +48673,8 @@ dsw
 iAC
 ube
 ube
-ube
-ube
+rmq
+rmq
 aVy
 mDu
 qDO
@@ -48218,13 +48742,7 @@ aaa
 nzi
 mDu
 bFa
-aPF
-aPF
-aPF
-aPF
-aPF
-aQr
-aPF
+gHU
 aPF
 aPF
 aPF
@@ -48233,12 +48751,18 @@ aQr
 aPF
 aPF
 aPF
+gHU
 aPF
+aQr
+aPF
+aPF
+aPF
+gHU
 aSu
 aPY
 aWM
 cNY
-aWG
+pQL
 aZa
 aZa
 aZa
@@ -48247,11 +48771,11 @@ aZa
 aZa
 aZa
 aQw
-aQw
+wGO
 aQD
 aQw
 aQw
-aQw
+wGO
 aQw
 aPg
 aPg
@@ -48480,7 +49004,7 @@ aRx
 aRx
 aRx
 aRx
-aRx
+pCP
 aRx
 aRx
 aRx
@@ -48890,13 +49414,13 @@ agH
 agH
 aYZ
 aaW
-aaW
+wHi
 aow
 aeM
 ank
 asD
 atV
-eTC
+lCa
 axd
 ayI
 ank
@@ -49014,13 +49538,13 @@ aKv
 bae
 baN
 nob
-nob
+cly
 wzm
 ldY
 yfW
 aQh
 pDe
-aQw
+wGO
 aQh
 mDu
 mDu
@@ -49160,7 +49684,7 @@ vQX
 ayK
 uMT
 azd
-wTd
+okC
 aJm
 mDu
 mDu
@@ -49405,7 +49929,7 @@ mDu
 aYZ
 alY
 aaW
-aaW
+wHi
 acx
 aby
 acw
@@ -49671,7 +50195,7 @@ gcO
 axd
 avn
 ank
-azd
+lmE
 umL
 azd
 wTd
@@ -50046,7 +50570,7 @@ bcs
 bcT
 aVY
 baT
-baT
+sMg
 aPQ
 mDu
 mDu
@@ -50293,11 +50817,11 @@ aSl
 aJR
 aWb
 aTi
-aWG
+pQL
 aWG
 aZg
 aVY
-baQ
+kYl
 baT
 baT
 baT
@@ -50426,7 +50950,7 @@ mDu
 mDu
 mDu
 mDu
-iJu
+xpA
 slc
 kjm
 xWz
@@ -50444,7 +50968,7 @@ anr
 akW
 akW
 anr
-anr
+wOA
 aHx
 aJm
 mDu
@@ -50556,7 +51080,7 @@ aZh
 aVY
 baR
 baT
-baT
+sMg
 bcU
 aVY
 bdP
@@ -50660,11 +51184,11 @@ aaa
 aaa
 aaa
 aaa
-wVZ
-hNN
-jyM
-gid
-jyM
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -50683,7 +51207,7 @@ mDu
 mDu
 mDu
 mDu
-iJu
+xpA
 kSh
 kML
 hQN
@@ -50793,7 +51317,7 @@ bFa
 bFa
 bFa
 aPF
-aPF
+gHU
 aPF
 aPY
 aRd
@@ -50803,7 +51327,7 @@ aPq
 aPA
 aRd
 aPF
-aPF
+gHU
 aVZ
 aWd
 aTi
@@ -50917,11 +51441,11 @@ aaa
 aaa
 aaa
 aaa
-eLL
-rQi
-jHO
-xTI
-pfX
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -50940,7 +51464,7 @@ mDu
 mDu
 mDu
 mDu
-iJu
+xpA
 kSh
 kML
 kML
@@ -50957,7 +51481,7 @@ ghD
 ayO
 aAb
 akW
-aAb
+tny
 akW
 aCt
 aKy
@@ -51068,12 +51592,12 @@ aTD
 aWG
 aZj
 aWg
-baT
+sMg
 baT
 bct
 uNQ
 aRA
-baT
+sMg
 tbp
 aPQ
 mDu
@@ -51174,11 +51698,11 @@ aaa
 aaa
 aaa
 aaa
-eip
-hmS
-hmS
-fgG
-jyM
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -51317,7 +51841,7 @@ nxz
 aTj
 aRd
 aQC
-aQC
+cYh
 aPY
 aVZ
 aUN
@@ -51469,7 +51993,7 @@ aoB
 xPO
 anr
 anr
-anr
+wOA
 akW
 anr
 aDH
@@ -51581,12 +52105,12 @@ aUT
 aVU
 aPF
 aPF
-aSv
+idd
 aSV
 aSv
 aSW
 aTc
-aPF
+gHU
 aPF
 aSu
 rXl
@@ -51710,7 +52234,7 @@ aaW
 aaW
 aaW
 aaW
-aaW
+wHi
 xvj
 sQE
 kML
@@ -51841,13 +52365,13 @@ aPF
 aPF
 aPF
 aPF
-aPF
+gHU
 aPF
 aPF
 aTd
 aPF
 aPF
-aPF
+gHU
 aPF
 bFa
 mDu
@@ -51963,7 +52487,7 @@ aYZ
 aaU
 aaW
 aaW
-aaW
+wHi
 aaW
 aaW
 acy
@@ -52085,8 +52609,8 @@ fEL
 iea
 oBM
 iea
-iea
-iea
+gnu
+gnu
 iea
 iea
 bbu
@@ -52474,7 +52998,7 @@ emV
 mDu
 mDu
 aYZ
-aaW
+wHi
 aaw
 aaw
 som
@@ -52850,7 +53374,7 @@ aaa
 nzi
 mDu
 aSN
-aPF
+gHU
 aPF
 rts
 aPZ
@@ -53132,8 +53656,8 @@ aPZ
 aPZ
 aPZ
 aSl
-aPF
-aPF
+gHU
+gHU
 bFa
 aYA
 okJ
@@ -53392,7 +53916,7 @@ aSl
 aPF
 aYD
 bFa
-aPF
+gHU
 aYD
 bFa
 bFa
@@ -53520,7 +54044,7 @@ akW
 anr
 anr
 anr
-anr
+wOA
 auc
 anr
 axs
@@ -53622,7 +54146,7 @@ nzi
 mDu
 bFa
 aPF
-aPF
+gHU
 rts
 aPZ
 aPZ
@@ -53645,7 +54169,7 @@ aPZ
 aPZ
 aPZ
 aPZ
-aSl
+kkA
 aPF
 aPF
 bap
@@ -53907,7 +54431,7 @@ aPF
 tha
 bFa
 aPF
-aPF
+gHU
 bFa
 bFa
 wRO
@@ -54161,9 +54685,9 @@ aPZ
 aPZ
 aSl
 aPF
-aPF
+gHU
 bFa
-aYA
+ryR
 aYA
 bFa
 bFa
@@ -54296,7 +54820,7 @@ aum
 avI
 axv
 ayV
-anr
+wOA
 aBC
 akW
 aDK
@@ -54548,11 +55072,11 @@ akW
 anr
 anr
 anr
-anr
+wOA
 auc
 avJ
 axs
-anr
+wOA
 bas
 aBD
 akW
@@ -55188,7 +55712,7 @@ aRE
 aRE
 aRE
 aQL
-aPF
+gHU
 gQS
 bFa
 mDu
@@ -55427,7 +55951,7 @@ pfc
 aPF
 aPF
 aPF
-aPF
+gHU
 aPF
 scV
 aPF
@@ -55437,7 +55961,7 @@ aPF
 aPF
 aPF
 aPF
-aPF
+gHU
 aPF
 aPF
 rto
@@ -55680,19 +56204,19 @@ bFa
 aRR
 aPF
 xkd
-aPF
+gHU
 bVM
 aPF
 aRQ
 aSu
 aPF
 scV
+gHU
+gHU
 aPF
 aPF
 aPF
-aPF
-aPF
-aPF
+gHU
 aPF
 aPF
 aPF
@@ -55707,8 +56231,8 @@ bFa
 bFa
 mDu
 mDu
+wRO
 vyQ
-aaa
 aDS
 aDS
 aDS
@@ -55956,7 +56480,7 @@ aPF
 aPF
 bbh
 aRQ
-aPF
+gHU
 aPF
 aPF
 aPF
@@ -55964,8 +56488,8 @@ bFa
 mDu
 mDu
 mDu
+mDu
 qDO
-aaa
 aaa
 aaa
 aaa
@@ -56220,9 +56744,9 @@ aPY
 bFa
 bFa
 bFa
+aTM
 mDu
 qDO
-aaa
 aaa
 aaa
 aaa
@@ -56458,7 +56982,7 @@ bFa
 aMK
 cdy
 aUL
-cdy
+aaO
 aMP
 aPY
 aUu
@@ -56474,12 +56998,12 @@ aWm
 aZw
 aWh
 aWh
-bal
+qxr
+aWh
 bJT
 aTM
 mDu
 qDO
-aaa
 aaa
 aaa
 aaa
@@ -56733,10 +57257,10 @@ aWh
 aWh
 aWh
 aWh
+aWh
 aTM
 mDu
 qDO
-aaa
 aaa
 aaa
 aaa
@@ -56976,7 +57500,7 @@ vXo
 aMR
 aPY
 jaQ
-aWh
+fVO
 aWh
 aZw
 aPN
@@ -56989,11 +57513,11 @@ aZw
 aPN
 aPN
 aZw
-aWh
+aUu
+aUu
 aTM
 mDu
 qDO
-aaa
 aaa
 aaa
 aaa
@@ -57247,10 +57771,10 @@ aND
 aWm
 aZw
 aWh
-aTM
+ltQ
+faO
 mDu
 qDO
-aaa
 aaa
 aaa
 aaa
@@ -57491,7 +58015,7 @@ vXo
 aPY
 kxY
 aWh
-aWh
+fVO
 aZw
 aNE
 aUy
@@ -57503,11 +58027,11 @@ aOm
 aUy
 cCg
 aZw
+kxY
 aWh
-aTM
+faO
 mDu
 qDO
-aaa
 aaa
 aaa
 aaa
@@ -57761,10 +58285,10 @@ sBt
 aWm
 aZw
 aWh
-aTM
+aWh
+faO
 mDu
 qDO
-aaa
 aaa
 aaa
 aaa
@@ -58017,11 +58541,11 @@ sOb
 sBt
 aWm
 aZw
-aWh
+aUu
+aUu
 aTM
 mDu
 qDO
-aaa
 aaa
 aaa
 aaa
@@ -58254,11 +58778,11 @@ nzi
 mDu
 aSN
 gKw
-cdy
+aaO
 cdy
 aUL
 cdy
-cdy
+aaO
 aPY
 aWh
 aWh
@@ -58275,10 +58799,10 @@ aUy
 dVV
 aZw
 aWh
-aTM
+sGd
+faO
 mDu
 qDO
-aaa
 aaa
 aaa
 aaa
@@ -58517,7 +59041,7 @@ aUL
 tpA
 aPx
 aPY
-aWh
+fVO
 aWh
 aWh
 aZw
@@ -58531,12 +59055,12 @@ sOb
 sBt
 aWm
 aZw
+kxY
 aWh
-aTM
+faO
 mDu
 mDu
 vyQ
-aaa
 aaa
 aaa
 aaa
@@ -58641,8 +59165,8 @@ aaa
 nzi
 mDu
 rzl
-bPM
-bPM
+eKx
+eKx
 aeR
 aeR
 aal
@@ -58788,12 +59312,12 @@ kBL
 sBt
 aWm
 aZw
+rPw
 aWh
-aTM
+faO
 mDu
 mDu
 qDO
-aaa
 aaa
 aaa
 aaa
@@ -58897,13 +59421,13 @@ aaa
 aaa
 nzi
 mDu
-rzl
+bOh
 bPM
-bPM
+eKx
 sPp
 bPM
 bPM
-bPM
+eKx
 bPM
 bPM
 blt
@@ -58921,7 +59445,7 @@ ajp
 auv
 avT
 axO
-avU
+lMX
 avU
 aBL
 avT
@@ -58929,7 +59453,7 @@ avU
 avU
 avU
 aDq
-avU
+lMX
 aHe
 aHc
 aHc
@@ -59033,7 +59557,7 @@ aUu
 aUu
 aUu
 aWh
-aWh
+fVO
 aZw
 aNE
 aUy
@@ -59045,12 +59569,12 @@ aOv
 aUy
 cCg
 aZw
-aWh
+aUu
+aUu
 aTM
 aTM
 mDu
 qDO
-aaa
 aaa
 aaa
 aaa
@@ -59154,7 +59678,7 @@ aaa
 aaa
 nzi
 mDu
-rzl
+bOh
 bPM
 fCm
 dFM
@@ -59183,18 +59707,18 @@ avU
 avU
 dka
 avU
-avU
+lMX
 dWU
 aDB
 avU
 avU
 avU
 avU
+lMX
 avU
 avU
-avU
-avU
-aIb
+lMX
+mbL
 aIb
 aIb
 aIb
@@ -59204,7 +59728,7 @@ avU
 avU
 avU
 aCY
-avU
+lMX
 avU
 aEO
 mDu
@@ -59302,12 +59826,12 @@ gNZ
 bbk
 aWm
 aZw
-aWh
-aWh
-aTM
+oLM
+fVO
+bJT
+faO
 mDu
 qDO
-aaa
 aaa
 aaa
 aaa
@@ -59450,9 +59974,9 @@ avU
 aLp
 aHc
 aNs
-avU
-avU
-avU
+lMX
+lMX
+lMX
 avU
 avU
 avU
@@ -59463,7 +59987,7 @@ aIp
 wzB
 avU
 aIv
-aEO
+koN
 mDu
 qDO
 aaa
@@ -59560,11 +60084,11 @@ yiZ
 olH
 aZw
 aZw
+kxY
 aWh
-aTM
+faO
 mDu
 qDO
-aaa
 aaa
 aaa
 aaa
@@ -59668,7 +60192,7 @@ aaa
 aaa
 nzi
 mDu
-rzl
+bOh
 abn
 fCm
 qod
@@ -59706,7 +60230,7 @@ aYO
 avU
 avU
 avU
-avU
+lMX
 avU
 aIb
 aIb
@@ -59720,7 +60244,7 @@ cOP
 tyX
 avU
 aIv
-aEO
+koN
 mDu
 qDO
 aaa
@@ -59797,7 +60321,7 @@ aaa
 nzi
 mDu
 aTM
-pAt
+fSi
 wTC
 aZu
 aUu
@@ -59818,10 +60342,10 @@ lNU
 rwk
 aZw
 aWh
-aTM
+aWh
+faO
 mDu
 qDO
-aaa
 aaa
 aaa
 aaa
@@ -59925,7 +60449,7 @@ aaa
 aaa
 nzi
 mDu
-rzl
+bOh
 bPM
 fCm
 qod
@@ -59947,7 +60471,7 @@ hCz
 nIP
 hCz
 mYf
-vUF
+inz
 axO
 azf
 aAq
@@ -59961,16 +60485,16 @@ avU
 avU
 wlR
 nme
+nmq
+nme
+ojB
+ojB
+nme
 nme
 nme
 ojB
 ojB
-nme
-nme
-nme
-ojB
-ojB
-ojB
+rJo
 ojB
 ojB
 jXZ
@@ -60074,11 +60598,11 @@ peL
 lNU
 xur
 aZw
-aZD
+aUu
+aUu
 aTM
 mDu
 qDO
-aaa
 aaa
 aaa
 aaa
@@ -60208,10 +60732,10 @@ qdr
 axO
 azg
 aAq
-aAu
+xip
 aAo
 azf
-aFl
+xGR
 azf
 aHe
 aIl
@@ -60229,12 +60753,12 @@ aIb
 avU
 avU
 avU
-avU
+lMX
 ncn
 avU
 avU
 aIv
-aEO
+koN
 mDu
 qDO
 aaa
@@ -60332,10 +60856,10 @@ lNU
 vCN
 aZw
 aWh
-aTM
+aWh
+faO
 mDu
 qDO
-aaa
 aaa
 aaa
 aaa
@@ -60439,7 +60963,7 @@ aaa
 aaa
 nzi
 mDu
-rzl
+bOh
 pxX
 fCm
 qod
@@ -60483,7 +61007,7 @@ avU
 avU
 avU
 avU
-avU
+lMX
 aLL
 aHc
 avU
@@ -60491,7 +61015,7 @@ aIp
 avU
 avU
 aIv
-aEO
+koN
 mDu
 qDO
 aaa
@@ -60588,11 +61112,11 @@ fKE
 uIN
 fKE
 aZw
-aWh
-aTM
+kxY
+fVO
+faO
 mDu
 qDO
-aaa
 aaa
 aaa
 aaa
@@ -60696,9 +61220,9 @@ aaa
 aaa
 nzi
 mDu
-rzl
+bOh
 dyW
-fCm
+dnW
 qod
 abV
 abV
@@ -60711,7 +61235,7 @@ pnM
 ajb
 eul
 amB
-amB
+bkk
 anJ
 sId
 amB
@@ -60733,10 +61257,10 @@ aJe
 eck
 avU
 avU
+lMX
 avU
 avU
-avU
-avU
+lMX
 avU
 avU
 avU
@@ -60827,11 +61351,11 @@ mDu
 aTM
 gfJ
 pWS
-pWS
+jYO
 aUu
 aWh
 aWh
-aWh
+fVO
 aZw
 nui
 pks
@@ -60845,11 +61369,11 @@ oGg
 fWv
 oGg
 aZw
+rPw
 aWh
-aTM
+faO
 mDu
 qDO
-aaa
 aaa
 aaa
 aaa
@@ -60971,7 +61495,7 @@ alm
 alm
 anK
 otR
-alm
+vSc
 alm
 rBN
 auw
@@ -61003,7 +61527,7 @@ avU
 avU
 avU
 avU
-avU
+lMX
 avU
 aEO
 mDu
@@ -61086,7 +61610,7 @@ gfJ
 pWS
 pWS
 mDs
-aWh
+fVO
 aWh
 aWh
 aZw
@@ -61102,11 +61626,11 @@ sML
 hSt
 izd
 aZw
-aWh
+aUu
+aUu
 aTM
 mDu
 qDO
-aaa
 aaa
 aaa
 aaa
@@ -61210,9 +61734,9 @@ aaa
 aaa
 nzi
 mDu
-rzl
+bOh
 bPM
-fCm
+dnW
 fCm
 fCm
 fCm
@@ -61230,7 +61754,7 @@ uig
 amB
 amB
 amB
-asu
+vyW
 mYf
 avX
 axl
@@ -61239,7 +61763,7 @@ axW
 tqa
 aCW
 azf
-aFl
+xGR
 azf
 aDE
 aHc
@@ -61359,11 +61883,11 @@ aPN
 aPN
 aPN
 aPN
+fVO
 aWh
 aTM
 mDu
 qDO
-aaa
 aaa
 aaa
 aaa
@@ -61467,8 +61991,8 @@ aaa
 aaa
 nzi
 mDu
-rzl
-bPM
+bOh
+eKx
 bPM
 bPM
 xYS
@@ -61478,7 +62002,7 @@ qWI
 agR
 ahg
 bPM
-bPM
+eKx
 pGN
 eul
 hKB
@@ -61493,7 +62017,7 @@ qdr
 axS
 azg
 ayr
-aAu
+xip
 aza
 azf
 aFl
@@ -61598,29 +62122,29 @@ mDu
 aTM
 uLM
 pWS
-pWS
+jYO
 aUu
 aVG
 aWh
 aWh
 aWh
+fVO
 aWh
 aWh
 aWh
-aWh
-aWh
+fVO
 aWh
 aWh
 aWh
 aWh
 nHz
+fVO
 aWh
 aWh
 guI
 aTM
 mDu
 qDO
-aaa
 aaa
 aaa
 aaa
@@ -61725,7 +62249,7 @@ aaa
 nzi
 mDu
 rzl
-bPM
+eKx
 bPM
 bPM
 aap
@@ -61746,7 +62270,7 @@ lvm
 szj
 lpY
 auA
-qdr
+sbx
 axO
 azg
 uAc
@@ -61860,12 +62384,13 @@ aUu
 aUu
 aXY
 aWh
-aWh
+fVO
 aWh
 nHz
 aWh
 aWh
-jaQ
+aWh
+dJG
 aTM
 aTM
 aTM
@@ -61877,7 +62402,6 @@ aTM
 aTM
 mDu
 qDO
-aaa
 aaa
 aaa
 aaa
@@ -62016,7 +62540,7 @@ fFI
 fFI
 aJj
 gRM
-avU
+lMX
 aHc
 aHP
 aHP
@@ -62133,8 +62657,8 @@ mDu
 mDu
 mDu
 mDu
+mDu
 qDO
-aaa
 aaa
 aaa
 aaa
@@ -62241,7 +62765,7 @@ mDu
 aPn
 aaK
 abj
-abj
+lfO
 nGG
 mlv
 abj
@@ -62272,7 +62796,7 @@ azf
 aHc
 aIs
 avU
-eck
+hjU
 avU
 aHc
 aHP
@@ -62370,11 +62894,11 @@ pWS
 mCT
 pWS
 pWS
-pWS
+jYO
 fCq
 aUu
 aUu
-aWh
+fVO
 aTM
 mDu
 mDu
@@ -62390,8 +62914,8 @@ vDU
 vDU
 vDU
 vDU
+vDU
 wFA
-aaa
 aaa
 aaa
 aaa
@@ -62498,14 +63022,14 @@ mDu
 aPn
 ace
 vuy
+nJV
 bhA
 bhA
 bhA
-bhA
-kji
+tBz
 aRy
 uBX
-bhA
+nJV
 kji
 dkR
 bhA
@@ -62525,7 +63049,7 @@ nHJ
 rbr
 aGt
 aEI
-aGt
+kWb
 rbr
 nHJ
 nHJ
@@ -63012,13 +63536,13 @@ mDu
 aPn
 ace
 bhA
-bhA
+nJV
 bhA
 vuy
 bhA
 kji
 aRy
-aPL
+iKy
 bhA
 aiV
 eAf
@@ -63026,13 +63550,13 @@ bhA
 alx
 amB
 rEe
-alx
+mdt
 amB
 jSM
 ocn
 mYf
 avU
-axO
+sAL
 avU
 bCk
 nHJ
@@ -63042,7 +63566,7 @@ oiA
 wAB
 tAS
 pxV
-avU
+lMX
 gRM
 avU
 aHc
@@ -63136,14 +63660,14 @@ nzi
 mDu
 aTM
 him
-pWS
+jYO
 pWS
 pbw
 aTM
 ggM
 pWS
 pWS
-pWS
+jYO
 mDs
 guI
 aTM
@@ -63301,7 +63825,7 @@ tAS
 avU
 avU
 gRM
-avU
+lMX
 aHc
 aHP
 aHP
@@ -63398,7 +63922,7 @@ tkV
 xVg
 aTM
 hUr
-pWS
+jYO
 pWS
 hbz
 aTM
@@ -63651,7 +64175,7 @@ mDu
 aTM
 mRl
 pWS
-pWS
+jYO
 iRG
 aUV
 xFO
@@ -63806,7 +64330,7 @@ awa
 iSb
 azn
 aAp
-ajo
+tDT
 aIt
 mDu
 mDu
@@ -63815,7 +64339,7 @@ mDu
 apl
 aJo
 aKg
-aKl
+mNH
 aLq
 aLq
 aLq
@@ -63913,7 +64437,7 @@ tXc
 tXc
 pWS
 pWS
-pWS
+jYO
 eXT
 aTM
 mDu
@@ -64055,7 +64579,7 @@ fLC
 oUD
 gVb
 ayG
-gVb
+eBz
 fXK
 sXg
 rwa
@@ -64165,10 +64689,10 @@ mDu
 aTM
 aTM
 bjL
-pWS
+jYO
 pWS
 tXc
-pWS
+jYO
 pWS
 eRL
 aTM
@@ -64295,7 +64819,7 @@ aaa
 nzi
 aan
 aar
-aaQ
+ggy
 aaQ
 aaQ
 aaQ
@@ -64309,7 +64833,7 @@ aic
 ajo
 alt
 anf
-bWL
+uAS
 ajo
 arO
 akm
@@ -64564,7 +65088,7 @@ wyr
 ahe
 aeh
 ajj
-akm
+bcY
 alu
 alw
 ans
@@ -64582,7 +65106,7 @@ iSb
 iSb
 aDM
 aFr
-aVq
+sKV
 tAS
 aGw
 aKi
@@ -64809,7 +65333,7 @@ aaa
 nzi
 mDu
 aar
-aaQ
+ggy
 aaJ
 aai
 aaQ
@@ -65084,7 +65608,7 @@ iSb
 iSb
 iSb
 nJD
-aqy
+nOS
 auI
 wJL
 awe
@@ -65342,7 +65866,7 @@ aqy
 aqy
 pTo
 pTo
-pTo
+uNX
 vbF
 awe
 bWL
@@ -65580,11 +66104,11 @@ aaa
 nzi
 mDu
 aar
-aaQ
+ggy
 abl
 abB
 aaQ
-acL
+joi
 aeq
 aeq
 aeq
@@ -65613,7 +66137,7 @@ aFr
 aVq
 tAS
 aJs
-aKl
+mNH
 aKl
 shi
 iIg
@@ -65838,16 +66362,16 @@ nzi
 mDu
 aar
 aaQ
-abl
+gWY
 aai
-aaQ
-acL
+ggy
+joi
 aeq
 afa
 afd
 afW
 qqM
-rzq
+rJi
 ajq
 aeq
 aeq
@@ -66110,7 +66634,7 @@ afY
 afY
 aly
 aeq
-aoN
+lId
 aoN
 aoN
 aoN
@@ -66364,7 +66888,7 @@ aii
 rzq
 bmI
 fys
-rzq
+rJi
 lPh
 aeq
 aoN
@@ -66372,7 +66896,7 @@ aoN
 aoN
 aoN
 arV
-aoN
+lId
 aoN
 qjm
 aAj
@@ -66891,7 +67415,7 @@ aoN
 aqF
 aoN
 aoN
-aoN
+lId
 tAS
 apl
 qMX
@@ -67396,7 +67920,7 @@ rzq
 alA
 aeq
 aaZ
-aoN
+lId
 aoN
 aqO
 aqO
@@ -67648,7 +68172,7 @@ rzq
 rzq
 rzq
 rzq
-rzq
+rJi
 rzq
 alB
 aeq

--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -11969,12 +11969,12 @@
 /turf/open/floor/plating,
 /area/sulaco/maintenance/lower_maint)
 "bam" = (
-/obj/machinery/door/airlock/mainship/secure{
-	dir = 1;
-	name = "Self Destruct Room"
-	},
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct{
 	dir = 1
+	},
+/obj/machinery/door/airlock/mainship/secure/free_access{
+	dir = 2;
+	name = "Self Destruct Room"
 	},
 /turf/open/floor/plating,
 /area/mainship/command/self_destruct)
@@ -13326,11 +13326,11 @@
 /turf/open/floor/plating/warning,
 /area/sulaco/command/eva)
 "eEP" = (
-/obj/machinery/door/airlock/mainship/secure{
-	name = "Self Destruct Room"
-	},
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct,
 /obj/structure/cable,
+/obj/machinery/door/airlock/mainship/secure/free_access{
+	name = "Self Destruct Room"
+	},
 /turf/open/floor/prison/bright_clean,
 /area/mainship/command/self_destruct)
 "eKm" = (
@@ -14289,7 +14289,7 @@
 /area/sulaco/hallway/central_hall2)
 "iqO" = (
 /obj/structure/cable,
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/free_access{
 	name = "Self Destruct Room"
 	},
 /turf/open/floor/prison/bright_clean,
@@ -14854,12 +14854,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/sulaco/hallway/lower_main_hall)
-"kYL" = (
-/obj/machinery/door/airlock/mainship/secure{
-	name = "Self Destruct Room"
-	},
-/turf/open/floor/prison/bright_clean,
-/area/mainship/command/self_destruct)
 "lae" = (
 /obj/effect/landmark/start/job/medicalofficer,
 /turf/open/floor/prison/whitegreen/corner,
@@ -15115,9 +15109,9 @@
 /turf/open/floor/prison,
 /area/mainship/shipboard/weapon_room)
 "lTe" = (
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/airlock/mainship/secure/free_access{
 	dir = 2;
-	name = "\improper Exterior Airlock"
+	name = "Self Destruct Room"
 	},
 /turf/open/floor/prison/bright_clean,
 /area/mainship/command/self_destruct)
@@ -15752,8 +15746,8 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
 "olH" = (
-/obj/machinery/door/airlock/mainship/secure{
-	name = "\improper Self Destruct Control Room"
+/obj/machinery/door/airlock/mainship/secure/free_access{
+	name = "Self Destruct Room"
 	},
 /turf/open/floor/prison/bright_clean,
 /area/mainship/command/self_destruct)
@@ -17856,10 +17850,10 @@
 /turf/closed/wall/mainship/gray,
 /area/sulaco/cafeteria)
 "uXx" = (
-/obj/machinery/door/airlock/mainship/secure{
+/obj/machinery/door/poddoor/shutters/mainship/selfdestruct,
+/obj/machinery/door/airlock/mainship/secure/free_access{
 	name = "Self Destruct Room"
 	},
-/obj/machinery/door/poddoor/shutters/mainship/selfdestruct,
 /turf/open/floor/prison/bright_clean,
 /area/mainship/command/self_destruct)
 "uYq" = (
@@ -57508,7 +57502,7 @@ aPN
 aZw
 iqO
 yiZ
-kYL
+olH
 aZw
 aPN
 aPN


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds some dirt to the Sulaco's floors.
Re-arranged Sulaco's SD a bit.
Added some extra windows.
Removes the memorial floating in space.

## Why It's Good For The Game

SD is slightly easier to defend.
SD: https://i.imgur.com/tME2OCu.png
Dirt.

## Changelog
:cl:
add: Dirt on the floors in the Sulaco
tweak: Sulaco SD is slightly easier to defend
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
