### PR TITLE
 lifesaver now fit  health analyzer and hyposprays.

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -151,9 +151,11 @@
 		/obj/item/reagent_containers/syringe,
 		/obj/item/storage/pill_bottle,
 		/obj/item/storage/syringe_case,
-		/obj/item/reagent_containers/hypospray/autoinjector,
+		/obj/item/reagent_containers/hypospray,
+		/obj/item/healthanalyzer,
 		/obj/item/storage/pill_bottle/packet,
 		/obj/item/stack/medical
+		
 	)
 
 /obj/item/storage/belt/combatLifesaver/Initialize()  //The belt, with all it's magic inside!


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
 This pr comes up to allow the life saver bag to hold hyposprays and health analyzers. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
 not being able to fit a health analyzer in a medical belt is borderline... annoying and serves very little balance wise it seems
hypos although rarely used can now fit in the belt. they are visually smaller than a bottle and you can already fit a syringe pouch with 2 bottles AND a syringe and volume wise thats for sure more than a hypo
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:Fernandos33
tweak: lifesaver can now fit hypos
tweak: lifesaver can now fit health analyzers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
