### PR TITLE
Fix Xeno Hivemind overriding skill targeting by removing camera mob mouse_opacity override

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
@@ -20,7 +20,6 @@
 	tier = XENO_TIER_ZERO
 	upgrade = XENO_UPGRADE_ZERO
 
-	mouse_opacity = MOUSE_OPACITY_OPAQUE
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 	see_invisible = SEE_INVISIBLE_LIVING
 	invisibility = INVISIBILITY_MAXIMUM


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Very simple one line deletion which will allow the byond `mouse_opacity` var to remain its default value of `1` which will both allow right-clicking for admins to easily access PP and XP etc.. while preventing it from having skills like Crusher: Crest Toss wasted on flinging around the Hiveminds AI-Eye because that is what a value of `2` does while a value of `0` makes it not appear in the context menu for the tile or be clickable at all.

@psykzz hopefully this gets your attention now, please see https://discordapp.com/channels/498569646014857217/498576390753615882/758585661523230721
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bug bad. Fix good. Having an ability cast stolen because the Hivemind did not know it was supposed to avoid placing itself on-top of targets is not fun for anyone involved on the side of the xenos.

No more:
![OnE5j3YYho](https://user-images.githubusercontent.com/64715958/94287943-bd11b980-ff0b-11ea-923b-cf988d5191d4.gif)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The Hivemind camera mob no longer steals left-clicks from mobs/objects on the same tile. 
admin: Hivemind camera mobs can still be accessed from the right-click menu (while a ghost) for ease of administration.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
