### PR TITLE
Fixes orbiters glide_size not syncing with the orbit target, and fix breaking on xeno evo

### DIFF
--- a/code/datums/components/orbiter.dm
+++ b/code/datums/components/orbiter.dm
@@ -18,6 +18,7 @@
 	begin_orbit(orbiter, radius, clockwise, rotation_speed, rotation_segments, pre_rotation)
 
 /datum/component/orbiter/RegisterWithParent()
+	RegisterSignal(parent, COMSIG_MOVABLE_UPDATE_GLIDE_SIZE, .proc/orbiter_glide_size_update)
 	var/atom/target = parent
 
 	target.orbiters = src
@@ -40,7 +41,6 @@
 
 /datum/component/orbiter/InheritComponent(datum/component/orbiter/newcomp, original, atom/movable/orbiter, radius, clockwise, rotation_speed, rotation_segments, pre_rotation)
 	if(!newcomp)
-		RegisterSignal(parent, COMSIG_MOVABLE_UPDATE_GLIDE_SIZE, .proc/orbiter_glide_size_update)
 		begin_orbit(arglist(args.Copy(3)))
 		return
 	// The following only happens on component transfers

--- a/code/datums/components/orbiter.dm
+++ b/code/datums/components/orbiter.dm
@@ -50,6 +50,7 @@
 	if(!isatom(parent) || isarea(parent) || !get_turf(parent))
 		return COMPONENT_INCOMPATIBLE
 	move_react(parent)
+	orbiter_glide_size_update(src, parent)
 
 /datum/component/orbiter/proc/begin_orbit(atom/movable/orbiter, radius, clockwise, rotation_speed, rotation_segments, pre_rotation)
 	if(orbiter.orbiting)

--- a/code/datums/components/orbiter.dm
+++ b/code/datums/components/orbiter.dm
@@ -25,6 +25,7 @@
 		tracker = new(target, CALLBACK(src, .proc/move_react))
 
 /datum/component/orbiter/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_MOVABLE_UPDATE_GLIDE_SIZE)
 	var/atom/target = parent
 	target.orbiters = null
 	QDEL_NULL(tracker)
@@ -39,6 +40,7 @@
 
 /datum/component/orbiter/InheritComponent(datum/component/orbiter/newcomp, original, atom/movable/orbiter, radius, clockwise, rotation_speed, rotation_segments, pre_rotation)
 	if(!newcomp)
+		RegisterSignal(parent, COMSIG_MOVABLE_UPDATE_GLIDE_SIZE, .proc/orbiter_glide_size_update)
 		begin_orbit(arglist(args.Copy(3)))
 		return
 	// The following only happens on component transfers
@@ -79,6 +81,7 @@
 	orbiter.SpinAnimation(rotation_speed, -1, clockwise, rotation_segments, parallel = FALSE)
 
 	orbiter.forceMove(get_turf(parent))
+	orbiter_glide_size_update(src, parent)
 	to_chat(orbiter, "<span class='notice'>Now orbiting [parent].</span>")
 
 /datum/component/orbiter/proc/end_orbit(atom/movable/orbiter, refreshing=FALSE)
@@ -92,6 +95,7 @@
 	orbiters -= orbiter
 	orbiter.stop_orbit(src)
 	orbiter.orbiting = null
+	orbiter.glide_size = 8 //Reset to the default for atom/movable as ours was matched to the orbit target
 	if(!refreshing && !length(orbiters) && !QDELING(src))
 		qdel(src)
 
@@ -121,6 +125,12 @@
 	if(orbiter.loc == get_turf(parent))
 		return
 	end_orbit(orbiter)
+
+/datum/component/orbiter/proc/orbiter_glide_size_update(datum/source, target)
+	var/atom/movable/movable_target = target
+	for(var/orbiter in orbiters)
+		var/atom/movable/movable_orbiter = orbiter
+		movable_orbiter.glide_size = movable_target.glide_size
 
 /////////////////////
 

--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -309,6 +309,7 @@
 	new_xeno.nicknumber = nicknumber
 	new_xeno.hivenumber = hivenumber
 	new_xeno.transfer_to_hive(hivenumber)
+	transfer_observers_to(new_xeno)
 
 	if(new_xeno.health - getBruteLoss(src) - getFireLoss(src) > 0) //Cmon, don't kill the new one! Shouldnt be possible though
 		new_xeno.bruteloss = src.bruteloss //Transfers the damage over.


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Add signals and logic for handling `glide_size` sync between ghosts and the things they orbit.
Adds a call to `transfer_observers_to()` when xenos evolve into a new mob.

Before:
![tEOI8uvR7c](https://user-images.githubusercontent.com/64715958/94296589-edf7eb80-ff17-11ea-8770-23f1dc5e0308.gif)

After:
![clxQ1WpbgQ](https://user-images.githubusercontent.com/64715958/94296612-f5b79000-ff17-11ea-8d32-75d350ea6d35.gif)

## Why It's Good For The Game

Less nausea inducement is good. Not having to re-orbit a xeno after evolving is equally good.

## Changelog
:cl:
fix: Fixes ghosts smooth movement not syncing with what they orbit.
fix: Fixes ghosts orbits of xenos ending when they evolve.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
