### PR TITLE
Tweaks Xeno Leaders Hivemind messages to give them more size and authority

### DIFF
--- a/code/modules/goonchat/browserOutput.css
+++ b/code/modules/goonchat/browserOutput.css
@@ -313,6 +313,7 @@ h1.alert, h2.alert		{color: #99aab5;}
 .xenoqueen				{font-size: 1.4em;}
 .xenoshrike				{font-size: 1.2em;}
 .xenohivemind			{font-size: 1.2em;}
+.xenoleader				{font-size: 1.2em;}
 .hivemind				{color: #c586c0;}
 
 .alien					{color: #543354;}

--- a/code/modules/goonchat/browserOutput_white.css
+++ b/code/modules/goonchat/browserOutput_white.css
@@ -310,6 +310,8 @@ h1.alert, h2.alert		{color: #000000;}
 .hivemind				{color: purple;}
 .xenoqueen				{font-size: 1.4em;}
 .xenoshrike				{font-size: 1.2em;}
+.xenohivemind			{font-size: 1.2em;}
+.xenoleader				{font-size: 1.2em;}
 
 .alien					{color: #543354;}
 .newscaster				{color: #800000;}

--- a/code/modules/mob/living/carbon/xenomorph/say.dm
+++ b/code/modules/mob/living/carbon/xenomorph/say.dm
@@ -1,15 +1,15 @@
 /**
 	Called to create the prefix for xeno hivemind messages
-	
-	Used to apply styling for queen/shrike/hivemind, giving them largetext and specific colouring.
+
+	Used to apply styling for queen/shrike/hivemind/leaders, giving them largetext and specific colouring.
 	This is also paired with [/mob/living/carbon/xenomorph/hivemind_end]
 */
 /mob/living/carbon/xenomorph/proc/hivemind_start()
-	return "<span class='game say hivemind'>Hivemind, <span class='name'>[name]</span>"
+	return "<span class='game say hivemind [queen_chosen_lead?"xenoleader":""]'>Hivemind, <span class='name'>[name]</span>"
 
 /**
 	Called to create the suffix for xeno hivemind messages
-	
+
 	This should be used to close off any opened elements from [/mob/living/carbon/xenomorph/hivemind_start].
 */
 /mob/living/carbon/xenomorph/proc/hivemind_end()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/64715958/94316635-97030e00-ff39-11ea-8180-33a1a01ae673.png)

## Why It's Good For The Game

Part of the message you receive when being picked as a leader by the Queen says that other Xenos must listen to you, so it only makes sense for leaders to have bigger authoritative Hivemind messages.

## Changelog
:cl:
tweak: Xeno leaders are now louder over Hivemind making their orders easier to distinguish as such.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
