### PR TITLE
Distress Victory Conditions

### DIFF
--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -123,7 +123,7 @@
 			message_admins("Round finished: [MODE_INFESTATION_X_MAJOR]") //xenos wiped our marines, xeno major victory
 			round_finished = MODE_INFESTATION_X_MAJOR
 			return TRUE
-		message_admins("Round finished: [MODE_INFESTATION_X_MINOR]") //xenos wiped out ALL the marines without hijacking, xeno major victory
+		message_admins("Round finished: [MODE_INFESTATION_X_MAJOR]") //xenos wiped out ALL the marines without hijacking, xeno major victory
 		round_finished = MODE_INFESTATION_X_MAJOR
 		return TRUE
 	if(!num_xenos)

--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -111,27 +111,27 @@
 	var/num_xenos = living_player_list[2]
 
 	if(SSevacuation.dest_status == NUKE_EXPLOSION_FINISHED)
-		message_admins("Round finished: [MODE_GENERIC_DRAW_NUKE]")
+		message_admins("Round finished: [MODE_GENERIC_DRAW_NUKE]") //ship blows, no one wins
 		round_finished = MODE_GENERIC_DRAW_NUKE
 		return TRUE
 	if(!num_humans)
 		if(!num_xenos)
-			message_admins("Round finished: [MODE_INFESTATION_DRAW_DEATH]")
+			message_admins("Round finished: [MODE_INFESTATION_DRAW_DEATH]") //everyone died at the same time, no one wins
 			round_finished = MODE_INFESTATION_DRAW_DEATH
 			return TRUE
 		if(round_stage == DISTRESS_DROPSHIP_CRASHED)
-			message_admins("Round finished: [MODE_INFESTATION_X_MAJOR]")
+			message_admins("Round finished: [MODE_INFESTATION_X_MAJOR]") //xenos wiped our marines, xeno major victory
 			round_finished = MODE_INFESTATION_X_MAJOR
 			return TRUE
-		message_admins("Round finished: [MODE_INFESTATION_X_MINOR]")
-		round_finished = MODE_INFESTATION_X_MINOR
+		message_admins("Round finished: [MODE_INFESTATION_X_MINOR]") //xenos wiped out ALL the marines without hijacking, xeno major victory
+		round_finished = MODE_INFESTATION_X_MAJOR
 		return TRUE
 	if(!num_xenos)
 		if(round_stage == DISTRESS_DROPSHIP_CRASHED)
-			message_admins("Round finished: [MODE_INFESTATION_M_MINOR]")
+			message_admins("Round finished: [MODE_INFESTATION_X_MINOR]") //xenos hijacked the shuttle and won groundside but died on the ship, minor victory
 			round_finished = MODE_INFESTATION_M_MINOR
 			return TRUE
-		message_admins("Round finished: [MODE_INFESTATION_M_MAJOR]")
+		message_admins("Round finished: [MODE_INFESTATION_M_MAJOR]") //marines win big or go home
 		round_finished = MODE_INFESTATION_M_MAJOR
 		return TRUE
 	return FALSE


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Marine Major: Kill all xenos on the planet
Xeno Major: Kill all marines
Xeno Minor: Hijack the Alamo but die on the main ship
Draw: Self Destruct blows up

## Why It's Good For The Game

Some of the old win conditions were nonsensical. Xenos got a minor victory if every marine died on the planet and none were left on the ship.

Marines can no longer evac planetside to try and cheese a victory on the ship. Losing groundside means you've given up hope of victory, and the best you can hope for is a draw if you blow SD. Evac is now a last resort.

Groundside combat is the main focus of the game, and the win conditions should reflect that.

## Changelog
:cl:
fix: Fixed case where a xeno major was instead being recorded as a xeno minor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
