### PR TITLE
adds an autolathe to crash ships

### DIFF
--- a/_maps/shuttles/tgs_bigbury.dmm
+++ b/_maps/shuttles/tgs_bigbury.dmm
@@ -719,6 +719,10 @@
 /obj/effect/landmark/start/job/crash/squadmarine,
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
+"sR" = (
+/obj/machinery/autolathe,
+/turf/open/floor/mainship/cargo,
+/area/shuttle/canterbury)
 "te" = (
 /obj/structure/rack,
 /obj/machinery/alarm{
@@ -1347,7 +1351,7 @@ uZ
 an
 ac
 uT
-bE
+sR
 ab
 bw
 Ot

--- a/_maps/shuttles/tgs_canterbury.dmm
+++ b/_maps/shuttles/tgs_canterbury.dmm
@@ -269,7 +269,7 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "aN" = (
-/obj/machinery/vending/marine/cargo_guns,
+/obj/machinery/autolathe,
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "aO" = (


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

what the title says, it replaces that secondary gun vendor

## Why It's Good For The Game

you can now print some tools or circuitboards which is nice for the gamemode where that matters the most probably

## Changelog
:cl:
add: adds an autolathe to crash ships
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
