### PR TITLE
Fixes the big red "You are either AFK.." message showing when you are in fact not AFK and/or disconnected

### DIFF
--- a/code/controllers/subsystem/ping.dm
+++ b/code/controllers/subsystem/ping.dm
@@ -1,0 +1,32 @@
+SUBSYSTEM_DEF(ping)
+	name = "Ping"
+	priority = FIRE_PRIORITY_PING
+	wait = 15 SECONDS
+	flags = SS_NO_INIT
+	runlevels = RUNLEVEL_LOBBY|RUNLEVEL_SETUP|RUNLEVEL_GAME|RUNLEVEL_POSTGAME
+
+	var/list/currentrun = list()
+
+/datum/controller/subsystem/ping/stat_entry()
+	..("P:[length(GLOB.clients)]")
+
+
+/datum/controller/subsystem/ping/fire(resumed = FALSE)
+	if(!resumed)
+		src.currentrun = GLOB.clients.Copy()
+
+	//cache for sanic speed (lists are references anyways)
+	var/list/currentrun = src.currentrun
+
+	while(length(currentrun))
+		var/client/C = currentrun[length(currentrun)]
+		currentrun.len--
+
+		if(!C?.chatOutput?.loaded)
+			if(MC_TICK_CHECK)
+				return
+			continue
+
+		C.chatOutput.ehjax_send(data = "softPang")
+		if(MC_TICK_CHECK)
+			return

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -206,6 +206,7 @@
 #include "code\controllers\subsystem\npcpool.dm"
 #include "code\controllers\subsystem\overlays.dm"
 #include "code\controllers\subsystem\pathfinder.dm"
+#include "code\controllers\subsystem\ping.dm"
 #include "code\controllers\subsystem\points.dm"
 #include "code\controllers\subsystem\radio.dm"
 #include "code\controllers\subsystem\runechat.dm"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Brings back the `Ping` subsystem with a slight change to just send one way heartbeats to the client.

Now the message will only be displayed if you actually lose connection to the server for some reason.

## Why It's Good For The Game

Bug bad. Fix good.

## Changelog
:cl:
fix: Fixed goonchat showing the red "You are AFK" message while you are connected and playing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
