### PR TITLE
adds black vest to marine vendor

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -693,6 +693,7 @@
 					/obj/item/storage/pouch/field_pouch = 10,
 					/obj/item/storage/pouch/general/large = 10,
 					/obj/item/storage/pouch/document = 10,
+					/obj/item/clothing/tie/storage/black_vest = 10,
 					/obj/item/clothing/tie/storage/brown_vest = 10,
 					/obj/item/clothing/tie/storage/white_vest/medic = 10,
 					/obj/item/clothing/tie/storage/webbing = 10,


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

adds black vest to unifomr vendor, isnt there for some reason

## Why It's Good For The Game

brown vest is identical in function but looks uglier, now you have a choice

## Changelog
:cl:
tweak: adds black vest to marine vendor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
