### PR TITLE
Changes boiler zoom offset to be the same as the railscope.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
@@ -20,7 +20,7 @@
 			"<span class='notice'>We start focusing your sight to look off into the distance.</span>", null, 5)
 		if(!do_after(X, 1 SECONDS, FALSE, null, BUSY_ICON_GENERIC) || X.is_zoomed)
 			return
-		X.zoom_in()
+		X.zoom_in(11)
 		..()
 
 // ***************************************
@@ -84,7 +84,7 @@
 	else
 		X.neuro_ammo++
 		to_chat(X, "<span class='notice'>We prepare a neurotoxic gas globule.</span>")
-	X.updateBoilerGlow() 
+	X.updateBoilerGlow()
 	update_button_icon()
 
 /datum/action/xeno_action/create_boiler_bomb/update_button_icon()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the offset of the boiler zoom to make it the same as the railscope.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Marines with railscopes could shoot boilers from farther than the boilers could see causing boilers to be useless since there is always a handful of marines with railscopes. Now the playing field is even as boilers and snipers have the same range of vision while zoomed.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Boilers can now see farther zoomed at the cost of not being able to see behind them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
