### PR TITLE
makes cloning vats announce on radio when a clone is ejected

### DIFF
--- a/code/game/objects/machinery/autodoc.dm
+++ b/code/game/objects/machinery/autodoc.dm
@@ -920,7 +920,7 @@
 
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 40
-	var/obj/item/radio/radio
+	var/obj/item/radio/headset/mainship/doc/radio
 	var/obj/item/reagent_containers/blood/OMinus/blood_pack
 
 

--- a/code/game/objects/machinery/cloning/cloning.dm
+++ b/code/game/objects/machinery/cloning/cloning.dm
@@ -49,6 +49,20 @@ These act as a respawn mechanic growning a body and offering it up to ghosts.
 	resistance_flags = UNACIDABLE | INDESTRUCTIBLE // For now, we should work out how we want xenos to counter this
 
 	var/obj/machinery/cloning/vats/linked_machine
+	var/obj/item/radio/headset/mainship/mcom/radio //God forgive me
+
+/obj/machinery/cloning_console/vats/Initialize()
+	. = ..()
+	radio = new(src)
+	radio.use_command = FALSE
+	radio.command = FALSE
+
+/obj/machinery/cloning_console/vats/Destroy()
+	QDEL_NULL(radio)
+	if(linked_machine)
+		linked_machine.linked_console = null
+		linked_machine = null
+	return ..()
 
 
 /obj/machinery/cloning_console/vats/attack_hand(mob/living/user)
@@ -65,6 +79,7 @@ These act as a respawn mechanic growning a body and offering it up to ghosts.
 			visible_message("[icon2html(src, viewers(src))] <span><b>[src]</b> beeps in error, 'connection not available'.</span>")
 			return TRUE
 
+		linked_machine.linked_console = src
 		visible_message("[icon2html(src, viewers(src))] <span><b>[src]</b> beeps as its boots up and connects to \the [linked_machine]</span>")
 		return TRUE
 
@@ -90,6 +105,7 @@ These act as a respawn mechanic growning a body and offering it up to ghosts.
 	var/timerid
 	var/mob/living/carbon/human/occupant
 	var/obj/item/reagent_containers/glass/beaker
+	var/obj/machinery/cloning_console/vats/linked_console
 
 	var/biomass_required = 40
 	var/grow_timer = 15 MINUTES
@@ -111,6 +127,9 @@ These act as a respawn mechanic growning a body and offering it up to ghosts.
 		eject_user()
 
 	QDEL_NULL(beaker)
+	if(linked_console)
+		linked_console.linked_machine = null
+		linked_console = null
 	return ..()
 
 
@@ -241,6 +260,7 @@ You remember nothing of your past life.
 
 You are weak, best rest up and get your strength before fighting.</span>"})
 	occupant.vomit()
-
+	linked_console.radio.talk_into(src, "<b>New clone: [occupant] has been grown in [src] at: [get_area(src)].</b>", RADIO_CHANNEL_MEDICAL)
+	linked_console.radio.talk_into(src, "<b>New clone: [occupant] has been grown in [src] at: [get_area(src)]. Please move the fresh clone to a squad using the squad distribution console.</b>", RADIO_CHANNEL_COMMAND)
 	occupant = null
 	update_icon()

--- a/code/game/objects/machinery/cloning/cloning.dm
+++ b/code/game/objects/machinery/cloning/cloning.dm
@@ -127,9 +127,8 @@ These act as a respawn mechanic growning a body and offering it up to ghosts.
 		eject_user()
 
 	QDEL_NULL(beaker)
-	if(linked_console)
-		linked_console.linked_machine = null
-		linked_console = null
+	linked_console?.linked_machine = null
+	linked_console = null
 	return ..()
 
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

makes cloning vats announce on medical and command radio when a clone is ejected
also fixes autodoc console using wrong radio channel to announce ejections

## Why It's Good For The Game

extra chance of clone soldiers being actually put in squads

## Changelog
:cl:
add: makes cloning vats announce on radio when a clone is ejected
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
