### PR TITLE
Prison State Pipes/Disposal/Powernet Cleanup + Survivor Spawnpoint Rearrangement

### DIFF
--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -99,6 +99,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/prison/darkred/full,
 /area/prison/cellblock/maxsec/north)
 "acS" = (
@@ -111,13 +112,13 @@
 /turf/open/floor/prison/darkred/full,
 /area/prison/cellblock/maxsec/north)
 "acT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/prison/darkred/full,
@@ -143,17 +144,18 @@
 	id = "biological_testing_1"
 	},
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/structure/mineral_door/resin,
 /turf/open/floor/plating,
 /area/prison/research/secret/biolab)
 "acW" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
 	},
-/obj/machinery/door/window/northright,
 /obj/machinery/door/poddoor/shutters/mainship/open{
 	dir = 2;
 	id = "biological_testing_1"
 	},
+/obj/structure/mineral_door/resin,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating,
 /area/prison/research/secret/biolab)
@@ -251,6 +253,9 @@
 	dir = 4
 	},
 /obj/effect/decal/warning_stripes/thin,
+/obj/structure/disposalpipe/up{
+	dir = 1
+	},
 /turf/open/floor/prison/plate,
 /area/prison/research/secret/biolab)
 "adj" = (
@@ -501,6 +506,7 @@
 	dir = 4;
 	on = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/prison/darkred/full,
 /area/prison/cellblock/maxsec/north)
 "adV" = (
@@ -510,6 +516,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/prison/darkred/full,
 /area/prison/cellblock/maxsec/north)
 "adW" = (
@@ -999,11 +1006,11 @@
 /turf/open/floor/plating,
 /area/prison/research/secret/bioengineering)
 "afv" = (
-/obj/structure/xenoautopsy/tank/larva,
+/obj/structure/xenoautopsy/tank/hugger,
 /turf/open/floor/prison/marked,
 /area/prison/research/secret/bioengineering)
 "afw" = (
-/obj/structure/xenoautopsy/tank/broken,
+/obj/structure/xenoautopsy/tank/escaped,
 /turf/open/floor/prison/marked,
 /area/prison/research/secret/bioengineering)
 "afx" = (
@@ -1278,7 +1285,7 @@
 	},
 /obj/machinery/alarm,
 /turf/open/floor/prison,
-/area/prison/security/monitoring/maxsec/panopticon)
+/area/prison/cellblock/maxsec/north)
 "agi" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -1405,11 +1412,13 @@
 /turf/open/floor/prison,
 /area/prison/cellblock/maxsec/north)
 "agE" = (
+/obj/structure/cable,
 /turf/open/floor/prison,
-/area/prison/security/monitoring/maxsec/panopticon)
+/area/prison/cellblock/maxsec/north)
 "agF" = (
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/prison/security/monitoring/maxsec/panopticon)
+/area/prison/cellblock/maxsec/north)
 "agG" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -1460,9 +1469,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/podhatch/floor{
-	dir = 1
-	},
+/turf/closed/wall/resin,
 /area/prison/research/secret/biolab)
 "agO" = (
 /obj/structure/cable,
@@ -1477,9 +1484,7 @@
 /obj/machinery/shower{
 	dir = 8
 	},
-/turf/open/floor/podhatch/floor{
-	dir = 1
-	},
+/turf/closed/wall/resin,
 /area/prison/research/secret/biolab)
 "agQ" = (
 /obj/effect/landmark/corpsespawner/prisoner,
@@ -1497,9 +1502,6 @@
 	dir = 4
 	},
 /area/prison/research/secret/bioengineering)
-"agU" = (
-/turf/closed/wall/r_wall/prison,
-/area/prison/security/monitoring/maxsec/panopticon)
 "agV" = (
 /obj/machinery/vending/security,
 /turf/open/floor/prison/darkred{
@@ -1528,9 +1530,7 @@
 /obj/machinery/shower{
 	dir = 4
 	},
-/turf/open/floor/podhatch/floor{
-	dir = 1
-	},
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/research/secret/biolab)
 "aha" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1657,8 +1657,9 @@
 /area/prison/cellblock/maxsec/north)
 "ahs" = (
 /obj/effect/decal/cleanable/blood,
+/obj/structure/cable,
 /turf/open/floor/prison,
-/area/prison/security/monitoring/maxsec/panopticon)
+/area/prison/cellblock/maxsec/north)
 "aht" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
@@ -1669,7 +1670,7 @@
 	dir = 10
 	},
 /turf/open/floor/prison,
-/area/prison/security/monitoring/maxsec/panopticon)
+/area/prison/cellblock/maxsec/north)
 "ahu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -1684,7 +1685,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison,
-/area/prison/security/monitoring/maxsec/panopticon)
+/area/prison/cellblock/maxsec/north)
 "ahw" = (
 /obj/machinery/light{
 	dir = 4
@@ -1700,8 +1701,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/prison,
-/area/prison/security/monitoring/maxsec/panopticon)
+/area/prison/cellblock/maxsec/north)
 "ahy" = (
 /turf/open/floor/prison/darkpurple{
 	dir = 1
@@ -1818,13 +1820,13 @@
 	name = "Panopticon Monitoring"
 	},
 /turf/open/floor/prison/plate,
-/area/prison/security/monitoring/maxsec/panopticon)
+/area/prison/cellblock/maxsec/north)
 "ahP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison/plate,
-/area/prison/security/monitoring/maxsec/panopticon)
+/area/prison/cellblock/maxsec/north)
 "ahQ" = (
 /turf/open/floor/prison/darkpurple{
 	dir = 10
@@ -1993,7 +1995,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison,
-/area/prison/security/monitoring/maxsec/panopticon)
+/area/prison/cellblock/maxsec/north)
 "aik" = (
 /turf/open/floor/prison/darkpurple{
 	dir = 8
@@ -2184,7 +2186,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison,
-/area/prison/security/monitoring/maxsec/panopticon)
+/area/prison/cellblock/maxsec/north)
 "aiT" = (
 /obj/machinery/vending/robotics,
 /turf/open/floor/prison/whitepurple/full,
@@ -2311,7 +2313,7 @@
 	name = "Panopticon Monitoring"
 	},
 /turf/open/floor/prison/plate,
-/area/prison/security/monitoring/maxsec/panopticon)
+/area/prison/cellblock/maxsec/north)
 "ajj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -2321,7 +2323,7 @@
 	name = "Panopticon Monitoring"
 	},
 /turf/open/floor/prison/plate,
-/area/prison/security/monitoring/maxsec/panopticon)
+/area/prison/cellblock/maxsec/north)
 "ajk" = (
 /obj/structure/sink{
 	dir = 8
@@ -3094,7 +3096,7 @@
 	name = "Panopticon Monitoring"
 	},
 /turf/open/floor/prison,
-/area/prison/security/monitoring/maxsec/panopticon)
+/area/prison/cellblock/maxsec/north)
 "alu" = (
 /obj/structure/sink{
 	pixel_y = 15
@@ -3398,7 +3400,7 @@
 /area/prison/research/secret/chemistry)
 "amq" = (
 /obj/machinery/computer/robotics,
-/turf/open/floor,
+/turf/open/floor/prison/sterilewhite,
 /area/prison/research/RD)
 "amr" = (
 /obj/structure/closet/secure_closet/chemical,
@@ -3412,6 +3414,7 @@
 	name = "Medium-Security Monitoring"
 	},
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/structure/cable,
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/monitoring/maxsec/panopticon)
 "amt" = (
@@ -3537,6 +3540,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/prison/darkred/full,
 /area/prison/cellblock/maxsec/north)
 "amO" = (
@@ -3567,7 +3571,7 @@
 /obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	name = "Chemistry"
 	},
-/turf/open/floor/tile/white,
+/turf/open/floor/prison/sterilewhite,
 /area/prison/research/secret/chemistry)
 "amT" = (
 /obj/structure/cable,
@@ -3794,10 +3798,6 @@
 	dir = 6
 	},
 /area/prison/research/secret/chemistry)
-"any" = (
-/obj/effect/landmark/start/job/survivor,
-/turf/open/floor/prison/sterilewhite,
-/area/prison/medbay)
 "anz" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/prison/green/full,
@@ -3876,12 +3876,6 @@
 	dir = 4
 	},
 /area/prison/cellblock/maxsec/south)
-"anI" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/prison/security/monitoring/maxsec/panopticon)
 "anJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -3903,8 +3897,9 @@
 	dir = 8;
 	on = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/prison/security/monitoring/maxsec/panopticon)
+/area/prison/cellblock/maxsec/north)
 "anM" = (
 /obj/machinery/light{
 	dir = 4
@@ -4476,6 +4471,7 @@
 "apA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/prison/hangar/civilian)
 "apC" = (
@@ -4660,15 +4656,15 @@
 "aqe" = (
 /obj/structure/table/reinforced,
 /obj/machinery/faxmachine,
-/turf/open/floor,
+/turf/open/floor/prison/sterilewhite,
 /area/prison/research/RD)
 "aqf" = (
 /obj/machinery/computer/rdconsole,
-/turf/open/floor,
+/turf/open/floor/prison/sterilewhite,
 /area/prison/research/RD)
 "aqg" = (
 /obj/machinery/computer/mecha,
-/turf/open/floor,
+/turf/open/floor/prison/sterilewhite,
 /area/prison/research/RD)
 "aqh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
@@ -5631,7 +5627,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/mainship/command/free_access,
-/turf/open/floor,
+/turf/open/floor/prison/sterilewhite,
 /area/prison/research/RD)
 "asS" = (
 /obj/structure/cable,
@@ -6790,7 +6786,7 @@
 "awj" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/prison,
-/area/prison/security/monitoring/maxsec/panopticon)
+/area/prison/cellblock/maxsec/north)
 "awk" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -6879,7 +6875,7 @@
 "awz" = (
 /obj/machinery/light,
 /turf/open/floor/prison,
-/area/prison/security/monitoring/maxsec/panopticon)
+/area/prison/cellblock/maxsec/north)
 "awA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
@@ -7624,7 +7620,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/start/job/survivor,
 /turf/open/floor/prison/whitegreen{
 	dir = 10
 	},
@@ -7682,10 +7677,6 @@
 /obj/structure/table/reinforced,
 /obj/item/clothing/head/chefhat,
 /obj/item/tool/kitchen/rollingpin,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
 /turf/open/floor/prison/kitchen,
 /area/prison/research)
 "aze" = (
@@ -7717,10 +7708,6 @@
 /area/prison/residential/north)
 "azj" = (
 /obj/structure/table/reinforced,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
 /obj/item/clothing/suit/chef/classic,
 /obj/item/tool/kitchen/rollingpin,
 /turf/open/floor/prison/kitchen,
@@ -7990,7 +7977,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/landmark/start/job/survivor,
 /turf/open/floor/prison/whitepurple{
 	dir = 4
 	},
@@ -8242,7 +8228,7 @@
 /area/prison/residential/north)
 "aAO" = (
 /obj/structure/window/framed/prison/reinforced/hull,
-/turf/open/beach/sea,
+/turf/open/floor/plating/ground/dirt,
 /area/prison/cellblock/maxsec/north)
 "aAP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -8280,7 +8266,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/obj/effect/landmark/start/job/survivor,
 /turf/open/floor/prison/darkred,
 /area/prison/medbay/foyer)
 "aAU" = (
@@ -9287,6 +9272,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/nw)
 "aDF" = (
@@ -15153,10 +15141,6 @@
 	},
 /turf/open/floor/wood,
 /area/prison/recreation/staff)
-"aVj" = (
-/obj/effect/landmark/start/job/survivor,
-/turf/open/floor/wood,
-/area/prison/recreation/staff)
 "aVk" = (
 /turf/open/floor/wood,
 /area/prison/recreation/staff)
@@ -15942,8 +15926,12 @@
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/residential/central)
 "aXC" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/central)
 "aXD" = (
@@ -15970,6 +15958,9 @@
 /area/prison/residential/central)
 "aXH" = (
 /obj/structure/bed/chair/office/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/monitoring/maxsec/panopticon)
 "aXI" = (
@@ -16315,6 +16306,7 @@
 /turf/open/floor/prison/red/full,
 /area/prison/cellblock/highsec/north/south)
 "aYT" = (
+/obj/structure/cable,
 /turf/open/floor/prison/darkred{
 	dir = 10
 	},
@@ -17239,9 +17231,6 @@
 "bbM" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
 /obj/item/clothing/suit/chef/classic,
 /obj/item/tool/kitchen/rollingpin,
 /turf/open/floor/prison/kitchen,
@@ -17288,12 +17277,12 @@
 /area/prison/security/monitoring/highsec)
 "bbT" = (
 /obj/structure/largecrate/random,
-/turf/open/floor/prison/red,
+/turf/open/floor/prison/darkred,
 /area/prison/security/monitoring/highsec)
 "bbU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/prison/red,
+/turf/open/floor/prison/darkred,
 /area/prison/security/monitoring/highsec)
 "bbY" = (
 /obj/machinery/light/small{
@@ -17357,9 +17346,9 @@
 	},
 /area/prison/cellblock/lowsec/nw)
 "bci" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/central)
@@ -17524,7 +17513,7 @@
 	dir = 2;
 	name = "Yard"
 	},
-/turf/open/floor/prison/bright_clean,
+/turf/open/floor/prison/bright_clean/two,
 /area/prison/yard)
 "bcM" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -17734,6 +17723,8 @@
 /turf/open/floor/plating,
 /area/prison/hangar/main)
 "bds" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison/darkred{
 	dir = 6
 	},
@@ -17772,12 +17763,13 @@
 /turf/open/floor/wood,
 /area/prison/residential/central)
 "bdy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 2;
 	name = "Medium-Security Monitoring"
 	},
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/monitoring/maxsec/panopticon)
 "bdA" = (
@@ -18024,10 +18016,6 @@
 	dir = 4
 	},
 /turf/open/floor/prison/bright_clean,
-/area/prison/canteen)
-"bee" = (
-/obj/structure/table/reinforced,
-/turf/open/floor,
 /area/prison/canteen)
 "bef" = (
 /obj/structure/bed/chair{
@@ -19080,6 +19068,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/start/job/survivor,
 /turf/open/floor/prison/kitchen,
 /area/prison/kitchen)
 "bhj" = (
@@ -19711,11 +19700,12 @@
 	name = "Panopticon Monitoring"
 	},
 /turf/open/floor/prison,
-/area/prison/security/monitoring/maxsec/panopticon)
+/area/prison/cellblock/maxsec/north)
 "biL" = (
 /obj/effect/decal/cleanable/blood/splatter,
+/obj/structure/cable,
 /turf/open/floor/prison,
-/area/prison/security/monitoring/maxsec/panopticon)
+/area/prison/cellblock/maxsec/north)
 "biN" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
@@ -20322,6 +20312,12 @@
 /turf/open/floor/prison/bright_clean,
 /area/prison/canteen)
 "bkD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hangar/main)
 "bkE" = (
@@ -20350,6 +20346,7 @@
 /turf/open/floor/prison/darkred/full,
 /area/prison/hangar/main)
 "bkI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison/darkyellow{
 	dir = 9
 	},
@@ -20566,7 +20563,7 @@
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	name = "Yard"
 	},
-/turf/open/floor/prison/bright_clean,
+/turf/open/floor/prison/bright_clean/two,
 /area/prison/yard)
 "blp" = (
 /obj/machinery/light{
@@ -20575,7 +20572,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 4
 	},
-/turf/open/floor/prison/bright_clean,
+/turf/open/floor/prison/green{
+	dir = 1
+	},
 /area/prison/hallway/central)
 "blq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -20634,6 +20633,7 @@
 	},
 /area/prison/hangar/main)
 "blE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/prison/darkyellow{
 	dir = 8
 	},
@@ -20938,6 +20938,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/mineral_door/resin,
 /turf/open/floor/prison/cleanmarked,
 /area/prison/yard)
 "bmA" = (
@@ -21706,6 +21707,12 @@
 	dir = 2;
 	name = "Entrance Hallway"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hangar/main)
 "boK" = (
@@ -21808,6 +21815,8 @@
 	},
 /area/prison/hangar/main)
 "bpa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison/darkyellow/corner{
 	dir = 4
 	},
@@ -22038,6 +22047,7 @@
 /obj/structure/table/reinforced/flipped{
 	dir = 4
 	},
+/obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/prison/bright_clean,
 /area/prison/yard)
 "bpT" = (
@@ -22198,7 +22208,7 @@
 	dir = 4;
 	on = 1
 	},
-/turf/open/floor/prison/bright_clean,
+/turf/open/floor/prison/green,
 /area/prison/hallway/central)
 "bqu" = (
 /obj/structure/cable,
@@ -22263,9 +22273,6 @@
 /turf/open/floor/prison/darkred{
 	dir = 10
 	},
-/area/prison/security/monitoring/highsec)
-"bqK" = (
-/turf/open/floor/prison/red,
 /area/prison/security/monitoring/highsec)
 "bqL" = (
 /obj/machinery/light,
@@ -22488,10 +22495,14 @@
 /area/prison/canteen)
 "brq" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/blood,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/entrance)
 "brr" = (
@@ -23100,15 +23111,6 @@
 /obj/structure/flora/pottedplant,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/central)
-"bty" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/prison/sterilewhite,
-/area/prison/residential/central)
 "btz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -23666,6 +23668,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
+	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/visitation)
@@ -24433,12 +24438,6 @@
 "bxN" = (
 /turf/closed/wall/r_wall/prison_unmeltable,
 /area/prison/maintenance/residential/se)
-"bxO" = (
-/obj/effect/landmark/start/job/survivor,
-/turf/open/floor/prison/yellow{
-	dir = 9
-	},
-/area/prison/cellblock/mediumsec/north)
 "bxP" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -24609,6 +24608,9 @@
 /area/prison/monorail/west)
 "bys" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
@@ -25065,6 +25067,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/sw)
 "bzV" = (
@@ -25204,6 +25209,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/prison/bright_clean,
 /area/prison/visitation)
 "bAr" = (
@@ -25286,6 +25294,8 @@
 /area/prison/maintenance/hangar_barracks)
 "bAH" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
 "bAI" = (
@@ -26047,9 +26057,10 @@
 /area/prison/maintenance/hangar_barracks)
 "bCZ" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
 "bDa" = (
@@ -26677,8 +26688,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood/splatter,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
@@ -27389,8 +27400,12 @@
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/residential/south)
 "bGZ" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/south)
 "bHa" = (
@@ -28898,10 +28913,6 @@
 /area/prison/residential/south)
 "bLO" = (
 /obj/structure/table/reinforced,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
 /obj/item/clothing/suit/chef/classic,
 /obj/item/tool/kitchen/rollingpin,
 /turf/open/floor/prison/kitchen,
@@ -30053,11 +30064,6 @@
 	dir = 1
 	},
 /area/prison/recreation/highsec/s)
-"bPj" = (
-/obj/machinery/power/apc/drained,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/prison/engineering)
 "bPk" = (
 /obj/structure/monorail{
 	dir = 6
@@ -30771,6 +30777,7 @@
 /obj/item/tool/extinguisher,
 /obj/item/assembly/infra,
 /obj/effect/spawner/random/powercell,
+/obj/structure/cable,
 /turf/open/floor/prison,
 /area/prison/engineering)
 "bRH" = (
@@ -31128,10 +31135,6 @@
 /area/prison/security/checkpoint/medsec)
 "bSM" = (
 /obj/structure/table/reinforced,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
 /obj/item/clothing/suit/chef/classic,
 /obj/item/tool/kitchen/rollingpin,
 /obj/item/pizzabox,
@@ -31713,10 +31716,6 @@
 	dir = 4
 	},
 /area/prison/storage/medsec)
-"bUz" = (
-/obj/effect/landmark/start/job/survivor,
-/turf/open/floor/prison,
-/area/prison/storage/medsec)
 "bUA" = (
 /turf/open/floor/prison/blue{
 	dir = 10
@@ -32124,7 +32123,6 @@
 	dir = 4;
 	on = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/prison/engineering)
 "bWa" = (
@@ -32134,6 +32132,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/prison/engineering)
 "bWb" = (
@@ -32199,6 +32198,8 @@
 /area/prison/intake)
 "bWv" = (
 /obj/machinery/alarm,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
 /turf/open/floor/prison,
 /area/prison/execution)
 "bWw" = (
@@ -32473,8 +32474,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
 /obj/effect/decal/warning_stripes/thin,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/prison,
 /area/prison/hallway/east)
 "bXq" = (
@@ -32530,6 +32531,7 @@
 	dir = 2;
 	name = "SMES"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/prison/engineering)
 "bXB" = (
@@ -32561,9 +32563,6 @@
 /turf/open/floor/plating,
 /area/prison/engineering/atmos)
 "bXL" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
@@ -32935,10 +32934,6 @@
 "bYM" = (
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/protective)
-"bYN" = (
-/obj/effect/landmark/start/job/survivor,
-/turf/open/floor/wood,
-/area/prison/library)
 "bYP" = (
 /obj/effect/spawner/random/toolbox,
 /obj/structure/table/reinforced,
@@ -32969,6 +32964,7 @@
 "bYU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/prison/engineering)
 "bYV" = (
@@ -33412,6 +33408,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/prison/engineering)
 "caA" = (
@@ -34577,6 +34574,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/prison/cellblock/highsec/south/south)
 "cdy" = (
@@ -34587,7 +34585,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment/corner{
+/obj/structure/disposalpipe/junction/yjunc{
 	dir = 8
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
@@ -35275,6 +35273,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/marking/delivery,
 /area/prison/execution)
 "cfF" = (
@@ -35580,6 +35579,7 @@
 	dir = 2;
 	name = "Execution"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/prison,
 /area/prison/execution)
 "cgM" = (
@@ -35921,6 +35921,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
 /turf/open/floor/prison,
 /area/prison/execution)
 "chS" = (
@@ -37383,7 +37386,6 @@
 /turf/open/floor/plating,
 /area/prison/security/checkpoint/highsec_medsec)
 "cml" = (
-/obj/structure/cable,
 /obj/item/ammo_casing,
 /turf/open/floor/prison/red{
 	dir = 8
@@ -38224,7 +38226,6 @@
 /area/prison/execution)
 "coQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable,
 /obj/machinery/door/airlock/mainship/secure/free_access{
 	dir = 2;
 	name = "Execution Chamber"
@@ -41395,13 +41396,13 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/staff)
 "cQu" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/nw)
 "cRI" = (
@@ -41431,6 +41432,13 @@
 	},
 /turf/open/ground/grass,
 /area/prison/residential/central)
+"cTS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/prison/darkyellow{
+	dir = 8
+	},
+/area/prison/hangar/main)
 "dbh" = (
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/canteen)
@@ -41466,6 +41474,7 @@
 /area/prison/security/monitoring/lowsec/sw)
 "dDs" = (
 /obj/effect/landmark/xeno_silo_spawn,
+/obj/structure/cable,
 /turf/open/floor/prison/darkred{
 	dir = 8
 	},
@@ -41492,6 +41501,27 @@
 	},
 /turf/open/floor/wood/broken,
 /area/prison/residential/south)
+"dVK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/effect/landmark/start/job/survivor,
+/turf/open/floor/wood,
+/area/prison/residential/central)
+"dXA" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/start/job/survivor,
+/turf/open/floor/prison/yellow{
+	dir = 1
+	},
+/area/prison/cellblock/mediumsec/east)
 "eaN" = (
 /obj/effect/decal/woodsiding,
 /obj/effect/decal/woodsiding{
@@ -41518,6 +41548,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/wood/broken,
 /area/prison/residential/north)
+"ekK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/prison/darkyellow{
+	dir = 1
+	},
+/area/prison/hangar/civilian)
 "elG" = (
 /obj/structure/toilet{
 	dir = 1
@@ -41531,6 +41568,21 @@
 	},
 /turf/open/floor/prison,
 /area/prison/hangar/civilian)
+"etG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/turf/open/floor/prison,
+/area/prison/hangar/main)
+"etW" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/suit/chef/classic,
+/obj/item/tool/kitchen/rollingpin,
+/turf/open/floor/prison/kitchen,
+/area/prison/residential/central)
 "eur" = (
 /turf/open/ground/coast/corner{
 	dir = 1
@@ -41593,6 +41645,24 @@
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/cellblock/mediumsec/north)
+"ffu" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plating,
+/area/prison/hangar/civilian)
+"fgd" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/start/job/survivor,
+/turf/open/floor/prison/red,
+/area/prison/cellblock/highsec/south/north)
 "fgQ" = (
 /turf/open/floor/prison/darkred{
 	dir = 1
@@ -41643,10 +41713,31 @@
 	dir = 8
 	},
 /area/prison/hangar/main)
-"fRD" = (
-/obj/structure/cable,
-/turf/closed/wall/prison,
-/area/prison/engineering)
+"fIl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/prison/darkyellow{
+	dir = 1
+	},
+/area/prison/hangar/civilian)
+"fQU" = (
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
+/turf/open/floor/prison,
+/area/prison/execution)
+"gcs" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/structure/disposaloutlet{
+	dir = 1
+	},
+/obj/structure/disposalpipe/up,
+/turf/open/floor/plating,
+/area/prison/research/secret/biolab)
 "gcR" = (
 /obj/structure/lattice,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
@@ -41654,6 +41745,21 @@
 	},
 /turf/open/beach/sea,
 /area/space)
+"gdU" = (
+/obj/effect/landmark/start/job/xenomorph,
+/turf/open/floor/plating,
+/area/prison/research/secret/biolab)
+"gfK" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/prison/darkyellow{
+	dir = 1
+	},
+/area/prison/hangar/civilian)
 "ghl" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -41664,6 +41770,17 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/wall/prison,
 /area/prison/maintenance/hangar_barracks)
+"gmZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/landmark/start/job/survivor,
+/turf/open/floor/wood,
+/area/prison/security/monitoring/highsec)
 "gnb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -41681,12 +41798,23 @@
 	},
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/ne)
+"gux" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 4;
+	welded = 1
+	},
+/turf/open/floor/prison,
+/area/prison/hangar/main)
 "gvs" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
 	},
 /turf/open/floor/prison/bright_clean,
 /area/prison/execution)
+"gxT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/prison,
+/area/prison/hangar/main)
 "gyL" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -41716,6 +41844,23 @@
 	},
 /turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
+"gFT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/prison/darkyellow{
+	dir = 4
+	},
+/area/prison/hangar/main)
+"gGZ" = (
+/obj/effect/landmark/start/job/survivor,
+/turf/open/floor/prison/cellstripe{
+	dir = 8
+	},
+/area/prison/cellblock/highsec/north/south)
 "gIY" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/prison,
@@ -41754,7 +41899,7 @@
 /turf/open/floor/prison,
 /area/prison/hangar/main)
 "gWi" = (
-/obj/effect/overlay/palmtree_r,
+/obj/structure/flora/tree/jungle,
 /turf/open/floor/plating/ground/dirt,
 /area/space)
 "gWy" = (
@@ -41783,10 +41928,32 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/east)
+"hin" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/asteroid,
+/area/prison/residential/central)
 "hiX" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/wood,
 /area/prison/library)
+"hlJ" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 2;
+	name = "Civilian Residences Hangar"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/prison/darkyellow,
+/area/prison/hangar/civilian)
 "hnT" = (
 /obj/structure/monorail{
 	dir = 5
@@ -41802,6 +41969,21 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/yard)
+"hyA" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/alien/weeds/node,
+/turf/open/floor/prison/darkpurple,
+/area/prison/research/secret/containment)
+"hDh" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
+/turf/open/floor/prison/darkred/full,
+/area/prison/security/monitoring/maxsec/panopticon)
 "hEZ" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/machinery/landinglight/ds2/delayone,
@@ -41850,6 +42032,12 @@
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/maxsec/south)
+"igm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/prison/darkred/full,
+/area/prison/security/monitoring/maxsec/panopticon)
 "ilF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -41860,6 +42048,14 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/wood/broken,
 /area/prison/parole/protective_custody)
+"iqy" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plating,
+/area/prison/maintenance/hangar_barracks)
 "irw" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/prison/rampbottom{
@@ -41954,6 +42150,10 @@
 	},
 /turf/open/floor/prison/darkyellow,
 /area/prison/hangar/civilian)
+"iYm" = (
+/obj/effect/landmark/start/job/survivor,
+/turf/open/floor/prison/bright_clean,
+/area/prison/visitation)
 "jdI" = (
 /obj/machinery/computer/nuke_disk_generator/red,
 /turf/open/floor/prison,
@@ -41979,6 +42179,11 @@
 	dir = 4
 	},
 /area/prison/cellblock/lowsec/ne)
+"joX" = (
+/turf/open/floor/prison/green{
+	dir = 10
+	},
+/area/prison/security/monitoring/lowsec/sw)
 "jpX" = (
 /obj/structure/closet/wardrobe/atmospherics_yellow,
 /turf/open/floor/prison/darkyellow/full,
@@ -41987,6 +42192,12 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/prison,
 /area/prison/security/monitoring/highsec)
+"jtL" = (
+/obj/effect/decal/woodsiding,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/ground/grass,
+/area/prison/residential/central)
 "juK" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
@@ -42004,6 +42215,11 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/ground/dirt,
 /area/space)
+"jzd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/prison/darkyellow,
+/area/prison/hangar/main)
 "jAv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -42024,6 +42240,16 @@
 	dir = 1
 	},
 /area/space)
+"jEP" = (
+/obj/effect/landmark/start/job/survivor,
+/turf/open/floor/prison,
+/area/prison/cellblock/vip)
+"jEZ" = (
+/obj/effect/landmark/start/job/survivor,
+/turf/open/floor/prison/green{
+	dir = 8
+	},
+/area/prison/monorail/west)
 "jFi" = (
 /turf/closed/wall/r_wall/prison,
 /area/prison/hangar/civilian)
@@ -42046,8 +42272,20 @@
 	dir = 2
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/prison/hangar/civilian)
+"jRr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/prison/darkred/full,
+/area/prison/cellblock/maxsec/north)
 "jSF" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/prison,
@@ -42076,6 +42314,14 @@
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating,
 /area/prison/cellblock/mediumsec/south)
+"kin" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/effect/landmark/start/job/survivor,
+/turf/open/floor/wood,
+/area/prison/residential/north)
 "kja" = (
 /obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 2
@@ -42095,6 +42341,21 @@
 /obj/effect/alien/weeds/node,
 /turf/open/floor/prison/green,
 /area/prison/cellblock/lowsec/sw)
+"krU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/mineral_door/resin,
+/turf/open/floor/prison/cleanmarked,
+/area/prison/yard)
+"kva" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/landmark/start/job/xenomorph,
+/turf/open/floor/plating,
+/area/prison/research/secret/biolab)
 "kxw" = (
 /obj/structure/window/framed/prison/reinforced,
 /obj/effect/landmark/lv624/fog_blocker,
@@ -42120,6 +42381,13 @@
 /obj/structure/table/woodentable,
 /turf/open/floor/wood/broken,
 /area/prison/residential/south)
+"kGj" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/landmark/start/job/survivor,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/cellblock/mediumsec/north)
 "kGQ" = (
 /turf/open/floor/prison,
 /area/prison/recreation/highsec/n)
@@ -42142,6 +42410,15 @@
 "kYV" = (
 /turf/open/floor/plating/ground/dirt,
 /area/space)
+"kZy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/prison,
+/area/prison/hangar/main)
 "laO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -42162,11 +42439,23 @@
 	dir = 1
 	},
 /area/prison/cellblock/mediumsec/south)
+"ljw" = (
+/obj/structure/cable,
+/turf/open/floor/prison/darkred/full,
+/area/prison/cellblock/maxsec/north)
 "lue" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/shuttle/shuttle_control/dropship1,
 /turf/open/floor/plating,
 /area/prison/hangar/civilian)
+"lvX" = (
+/obj/effect/decal/woodsiding{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/ground/grass,
+/area/prison/residential/central)
 "lAp" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/prison,
@@ -42216,6 +42505,11 @@
 /obj/effect/alien/weeds/node,
 /turf/open/floor/plating,
 /area/prison/cellblock/mediumsec/south)
+"mnR" = (
+/obj/effect/alien/weeds/node,
+/obj/structure/cable,
+/turf/open/floor/prison,
+/area/prison/cellblock/maxsec/north)
 "mof" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/prison,
@@ -42254,14 +42548,47 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/prison,
 /area/prison/cellblock/lowsec/se)
+"mAN" = (
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	dir = 2;
+	name = "Panopticon Monitoring"
+	},
+/obj/structure/cable,
+/turf/open/floor/prison,
+/area/prison/cellblock/maxsec/north)
 "mBf" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/r_wall/prison_unmeltable,
 /area/prison/cellblock/mediumsec/south)
+"mKN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/prison/darkyellow,
+/area/prison/hangar/civilian)
+"mKT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/prison/rampbottom{
+	dir = 1
+	},
+/area/prison/maintenance/residential/sw)
 "mLZ" = (
 /obj/item/clothing/under/schoolgirl,
 /turf/open/floor/plating/ground/dirt,
 /area/space)
+"mMl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/hallway/entrance)
 "mNz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -42272,10 +42599,22 @@
 /obj/structure/cable,
 /turf/open/floor/prison/bright_clean,
 /area/prison/hallway/central)
+"mPV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plating,
+/area/prison/hangar/civilian)
 "mRK" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/prison/hangar/civilian)
+"mSO" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/prison,
+/area/prison/hangar/main)
 "mXp" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/plating,
@@ -42285,6 +42624,13 @@
 	dir = 6
 	},
 /area/prison/security/checkpoint/highsec/s)
+"mYC" = (
+/obj/machinery/power/apc/drained{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/prison/engineering)
 "naL" = (
 /turf/open/floor/wood/broken,
 /area/prison/residential/south)
@@ -42358,12 +42704,32 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/canteen)
+"nPv" = (
+/obj/effect/alien/weeds/node,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/turf/open/floor/prison/bright_clean,
+/area/prison/yard)
 "nQm" = (
 /obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 2;
 	name = "Hangar-Barracks Maintenance"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
+/area/prison/hangar/main)
+"nRo" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8;
+	welded = 1
+	},
+/turf/open/floor/prison,
 /area/prison/hangar/main)
 "oaB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -42414,14 +42780,35 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/south)
+"ovT" = (
+/obj/effect/decal/siding{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/asteroid,
+/area/prison/residential/central)
 "oyO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/nw)
+"oAL" = (
+/obj/effect/landmark/corpsespawner/prisoner,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/landmark/start/job/xenomorph,
+/turf/open/floor/plating,
+/area/prison/research/secret/biolab)
 "oGc" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/prison/darkpurple,
@@ -42430,6 +42817,12 @@
 /obj/structure/lattice,
 /turf/open/floor/plating/ground/dirt,
 /area/space)
+"oRe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/prison,
+/area/prison/hangar/main)
 "oRz" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -42441,9 +42834,14 @@
 	dir = 10
 	},
 /area/prison/hangar/civilian)
+"oRV" = (
+/obj/effect/landmark/start/job/survivor,
+/turf/open/floor/prison/plate,
+/area/prison/cellblock/highsec/north/north)
 "pcf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/nw)
 "ped" = (
@@ -42470,6 +42868,16 @@
 /obj/effect/alien/weeds/node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/research/secret/biolab)
+"pla" = (
+/obj/structure/window/framed/prison/reinforced,
+/obj/machinery/door/poddoor/shutters/mainship/open{
+	dir = 2;
+	id = "biological_testing_1"
+	},
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/prison/research/secret/biolab)
 "pAI" = (
 /turf/open/floor/prison/darkred{
 	dir = 10
@@ -42485,6 +42893,12 @@
 	},
 /turf/open/floor/plating,
 /area/prison/hangar_storage/research)
+"pDQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/prison,
+/area/prison/hangar/main)
 "pEh" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/prison/yellow,
@@ -42493,10 +42907,6 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/prison/bright_clean,
 /area/prison/hallway/central)
-"pJA" = (
-/obj/effect/overlay/palmtree_l,
-/turf/open/floor/plating/ground/dirt,
-/area/space)
 "pLL" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/prison/bright_clean/two,
@@ -42514,6 +42924,15 @@
 	},
 /turf/open/ground/grass,
 /area/prison/residential/central)
+"pSs" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/prison/darkyellow,
+/area/prison/hangar/civilian)
 "pVt" = (
 /obj/structure/window/framed/prison/reinforced/hull,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
@@ -42551,6 +42970,13 @@
 	dir = 5
 	},
 /area/prison/hangar/main)
+"pZG" = (
+/obj/structure/bed/chair/office/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/prison/darkred/full,
+/area/prison/security/monitoring/maxsec/panopticon)
 "qcr" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/r_wall/prison_unmeltable,
@@ -42628,6 +43054,17 @@
 	},
 /turf/open/floor/plating,
 /area/prison/hangar/civilian)
+"qDV" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/hallway/entrance)
 "qJf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -42642,6 +43079,14 @@
 	},
 /turf/open/floor/plating,
 /area/prison/hangar_storage/research)
+"qNQ" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/sw)
 "qST" = (
 /obj/structure/window/reinforced,
 /obj/effect/landmark/start/job/survivor,
@@ -42722,8 +43167,22 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/cellblock/highsec/south/north)
+"rEw" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8;
+	welded = 1
+	},
+/turf/open/floor/plating,
+/area/prison/hangar/civilian)
+"rES" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/prison,
+/area/prison/execution)
 "rFk" = (
 /obj/effect/alien/weeds/node,
+/obj/structure/mineral_door/resin,
 /turf/open/floor/prison/whitepurple/full,
 /area/prison/research/secret/biolab)
 "rGT" = (
@@ -42800,8 +43259,22 @@
 	dir = 4
 	},
 /area/prison/security)
+"soh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/turf/open/floor/prison/darkred{
+	dir = 4
+	},
+/area/prison/security/monitoring/maxsec/panopticon)
 "ssR" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/entrance)
 "swP" = (
@@ -42816,6 +43289,11 @@
 	dir = 1
 	},
 /area/prison/maintenance/hangar_barracks)
+"sBT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/prison,
+/area/prison/hangar/main)
 "sEQ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -42827,6 +43305,11 @@
 	dir = 4
 	},
 /area/prison/cellblock/mediumsec/west)
+"sHr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/start/job/survivor,
+/turf/open/floor/wood,
+/area/prison/quarters/research)
 "sJB" = (
 /obj/structure/cable,
 /obj/effect/alien/weeds/node,
@@ -42866,6 +43349,13 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/prison/bright_clean,
 /area/prison/canteen)
+"tbD" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/prison/hangar/civilian)
 "tgd" = (
 /obj/effect/overlay/coconut,
 /turf/open/floor/plating/ground/dirt,
@@ -42883,6 +43373,9 @@
 /area/prison/maintenance/hangar_barracks)
 "tme" = (
 /obj/effect/landmark/xeno_silo_spawn,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/prison/residential/south)
 "tnU" = (
@@ -42901,6 +43394,13 @@
 	dir = 4
 	},
 /area/prison/cellblock/mediumsec/east)
+"trU" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/mineral_door/resin,
+/turf/open/floor/prison/whitepurple/full,
+/area/prison/research/secret/biolab)
 "tsb" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -42920,6 +43420,7 @@
 "tDi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison/rampbottom,
 /area/prison/maintenance/residential/nw)
 "tHS" = (
@@ -42948,11 +43449,18 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/sw)
+"tPw" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 8;
+	welded = 1
+	},
+/turf/open/floor/plating,
+/area/prison/hangar/civilian)
 "tQK" = (
 /obj/item/stack/rods,
 /turf/open/ground/coast{
@@ -42965,6 +43473,10 @@
 	dir = 8
 	},
 /area/prison/monorail/west)
+"tXr" = (
+/obj/effect/landmark/start/job/survivor,
+/turf/open/floor/prison/plate,
+/area/prison/cellblock/mediumsec/south)
 "udZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -42984,6 +43496,12 @@
 	dir = 8
 	},
 /area/prison/cellblock/lowsec/sw)
+"uuc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/prison/darkred/full,
+/area/prison/security/monitoring/maxsec/panopticon)
 "uHe" = (
 /turf/open/ground/coast{
 	dir = 9
@@ -43059,6 +43577,13 @@
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/maxsec/south)
+"vdD" = (
+/obj/structure/disposaloutlet{
+	dir = 1
+	},
+/obj/structure/disposalpipe/up,
+/turf/open/floor/plating,
+/area/prison/research/secret/biolab)
 "vgS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -43151,6 +43676,10 @@
 "vEh" = (
 /turf/open/floor/wood/broken,
 /area/prison/parole/main)
+"vEU" = (
+/obj/structure/mineral_door/resin,
+/turf/open/floor/prison/cleanmarked,
+/area/prison/yard)
 "vFP" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/prison,
@@ -43164,6 +43693,15 @@
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/prison/plate,
 /area/prison/recreation/medsec)
+"vPB" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/machinery/shower{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/research/secret/biolab)
 "vQq" = (
 /obj/structure/window/framed/prison/reinforced/hull,
 /turf/open/floor/prison,
@@ -43179,11 +43717,24 @@
 /obj/effect/alien/weeds/node,
 /turf/open/floor/prison/green,
 /area/prison/cellblock/lowsec/nw)
+"vSy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/prison/darkred{
+	dir = 4
+	},
+/area/prison/security/monitoring/maxsec/panopticon)
 "vSO" = (
 /obj/structure/window/framed/prison/reinforced,
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
 /area/prison/hallway/central)
+"vVg" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/prison,
+/area/prison/research/secret/containment)
 "wcU" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/plating,
@@ -43192,11 +43743,36 @@
 /obj/structure/cable,
 /turf/open/floor/prison/bright_clean,
 /area/prison/hallway/central)
+"whB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/prison/darkyellow,
+/area/prison/hangar/civilian)
+"wmW" = (
+/obj/effect/landmark/start/job/survivor,
+/turf/open/floor/carpet,
+/area/prison/chapel)
 "woW" = (
 /obj/machinery/door/airlock/mainship/maint/free_access,
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
 /area/prison/security/monitoring/lowsec/sw)
+"wuG" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/prison/bright_clean,
+/area/prison/visitation)
+"wuP" = (
+/obj/structure/window/framed/prison/reinforced,
+/obj/machinery/door/poddoor/shutters/mainship/open{
+	dir = 2;
+	id = "biological_testing_2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/prison/research/secret/biolab)
 "wvr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -43227,6 +43803,15 @@
 	dir = 1
 	},
 /area/prison/maintenance/staff_research)
+"wOs" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/prison,
+/area/prison/hangar/main)
 "wWX" = (
 /obj/structure/lattice,
 /turf/open/ground/coast,
@@ -43250,16 +43835,49 @@
 "xdx" = (
 /turf/closed/wall/r_wall/prison_unmeltable,
 /area/prison/security/checkpoint/hangar)
+"xeM" = (
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plating,
+/area/prison/hangar/civilian)
 "xhO" = (
 /turf/open/ground/desertdam/river/clean/shallow_edge{
 	dir = 8
 	},
 /area/space)
+"xly" = (
+/obj/machinery/power/apc/drained{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/prison/darkred{
+	dir = 8
+	},
+/area/prison/security/monitoring/maxsec/panopticon)
+"xrp" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/start/job/survivor,
+/turf/open/floor/prison/yellow/corner{
+	dir = 8
+	},
+/area/prison/cellblock/mediumsec/south)
 "xtV" = (
 /turf/open/ground/desertdam/river/clean/shallow_edge{
 	dir = 6
 	},
 /area/space)
+"xwA" = (
+/obj/effect/landmark/start/job/survivor,
+/turf/open/floor/prison,
+/area/prison/hangar_storage/research)
 "xyF" = (
 /obj/item/stack/rods,
 /turf/open/floor/plating/ground/dirt,
@@ -43278,6 +43896,17 @@
 	dir = 4
 	},
 /area/prison/cellblock/highsec/south/north)
+"xKk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/prison/darkyellow{
+	dir = 8
+	},
+/area/prison/hangar/main)
 "xRQ" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -43288,6 +43917,11 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/prison,
 /area/prison/security/monitoring/lowsec/ne)
+"xZC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/sw)
 "ybf" = (
 /obj/structure/sink{
 	dir = 8
@@ -43295,6 +43929,13 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/mediumsec/south)
+"ybO" = (
+/obj/structure/window/framed/prison/cell,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/prison/whitepurple/full,
+/area/prison/research/secret/bioengineering)
 "ydX" = (
 /turf/open/floor/prison/rampbottom{
 	dir = 1
@@ -43307,6 +43948,17 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/security/monitoring/highsec)
+"yfJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/prison/rampbottom{
+	dir = 4
+	},
+/area/prison/hangar/main)
 "yfM" = (
 /turf/open/ground/coast{
 	dir = 4
@@ -43330,16 +43982,19 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/prison/bright_clean,
 /area/prison/laundry)
+"yiF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/turf/open/floor/prison,
+/area/prison/hangar/main)
 "yiT" = (
 /obj/structure/lattice,
 /turf/open/ground/coast/corner2{
 	dir = 1
 	},
 /area/space)
-"yjP" = (
-/obj/effect/landmark/start/job/survivor,
-/turf/open/floor/wood,
-/area/prison/parole/protective_custody)
 
 (1,1,1) = {"
 aab
@@ -48602,35 +49257,35 @@ pcf
 oyO
 jPD
 apA
-aok
-aok
-aok
-aok
-aok
-aok
-aok
-aok
-aok
-bgp
-bkv
-aok
-aok
-bgp
-bkv
-aok
-aok
-aok
-aok
-aok
-aok
-aok
-aok
-aok
-aok
-bFG
-sEQ
-bxf
-bfX
+mPV
+mPV
+ffu
+mPV
+mPV
+mPV
+mPV
+mPV
+mPV
+gfK
+whB
+mPV
+mPV
+ekK
+pSs
+mPV
+mPV
+mPV
+mPV
+mPV
+mPV
+tbD
+mPV
+mPV
+mPV
+xeM
+qNQ
+xZC
+mKT
 tKQ
 bEU
 bwu
@@ -48861,26 +49516,26 @@ amu
 aok
 aok
 aok
+tPw
 aok
 aok
 aok
 aok
 aok
 aok
-aok
-bgp
+fIl
 bkv
 aok
 aok
 bgp
-bkv
+mKN
 aok
 aok
 aok
 aok
 aok
 aok
-aok
+rEw
 aok
 aok
 aok
@@ -49125,12 +49780,12 @@ aAC
 aAC
 aAC
 ays
-bgp
+fIl
 bkv
 ays
 ays
 bgp
-bkv
+mKN
 ays
 aAC
 aAC
@@ -49382,12 +50037,12 @@ hdB
 hdB
 amu
 ays
-bgp
+fIl
 bkv
 ays
 ays
 bgp
-bkv
+mKN
 ays
 amu
 hdB
@@ -49639,12 +50294,12 @@ ogg
 iHW
 hdB
 epq
-bgp
+fIl
 bkv
 ays
 ays
 bgp
-bkv
+mKN
 tnU
 hdB
 ogg
@@ -49896,12 +50551,12 @@ aab
 iHW
 hdB
 ays
-bgp
+fIl
 bkv
 ays
 ays
 bgp
-bkv
+mKN
 ays
 hdB
 iHW
@@ -50153,12 +50808,12 @@ aWn
 pVt
 amu
 bjK
-bgp
+fIl
 iVD
 bjK
 bjK
 bgp
-iVD
+hlJ
 bjK
 amu
 pVt
@@ -50410,12 +51065,12 @@ bgb
 iTH
 mrt
 rpt
+ovT
 bmV
 bmV
 bmV
 bmV
-bmV
-bmV
+ovT
 cRI
 mrt
 vcu
@@ -50667,12 +51322,12 @@ aVO
 bgc
 bhY
 gZL
-bhC
+bkL
 bhC
 bhC
 cEC
 bhC
-bhC
+bkL
 cSJ
 bhY
 bgc
@@ -50902,7 +51557,7 @@ aJI
 avN
 azg
 azg
-aME
+kin
 avN
 avN
 avN
@@ -50924,12 +51579,12 @@ aVP
 bgd
 bhC
 bhC
+bkL
 bhC
 bhC
 bhC
 bhC
-bhC
-bhC
+bkL
 bhC
 bhC
 aVP
@@ -51177,21 +51832,21 @@ bbK
 bbK
 bdx
 bci
-aVP
-bgd
-bhC
-bhC
-bhC
-bhC
-bhC
-bhC
-bhC
-bhC
-bhC
-bhC
-aVP
-bgd
-bty
+lvX
+jtL
+bmX
+bmX
+hin
+bmX
+bmX
+bmX
+bmX
+hin
+bmX
+bmX
+lvX
+jtL
+bci
 bdx
 bbK
 bbK
@@ -51708,7 +52363,7 @@ bsV
 bdQ
 aWr
 bcO
-bbM
+etW
 baO
 aZT
 aWr
@@ -53250,7 +53905,7 @@ bsV
 bdQ
 aWr
 bcO
-bbM
+etW
 baO
 aZT
 aWr
@@ -55300,7 +55955,7 @@ blJ
 bpc
 aWr
 bcO
-bbM
+etW
 baO
 aZT
 aWr
@@ -55804,7 +56459,7 @@ aWx
 aXF
 aWr
 aZR
-baP
+dVK
 bbK
 bbK
 bdx
@@ -57618,7 +58273,7 @@ bry
 bru
 bry
 bry
-bry
+jEZ
 bry
 bry
 bry
@@ -59387,7 +60042,7 @@ kYV
 kYV
 kYV
 kYV
-pJA
+kYV
 kYV
 kYV
 voM
@@ -59657,7 +60312,7 @@ aZY
 aZY
 aZY
 aZY
-bdW
+gmZ
 aZY
 aZY
 baa
@@ -61196,7 +61851,7 @@ bng
 baa
 bab
 bba
-bqK
+oie
 baa
 bcp
 beT
@@ -63753,7 +64408,7 @@ aGg
 aDR
 aCl
 aGg
-aDR
+gGZ
 aCl
 aOF
 aES
@@ -63998,7 +64653,7 @@ aox
 aor
 azr
 aAe
-aox
+oRV
 aGb
 aCi
 aET
@@ -64312,7 +64967,7 @@ bvA
 bvA
 bvA
 byC
-bFT
+fgd
 bvA
 bvC
 bvG
@@ -65324,7 +65979,7 @@ bpo
 bla
 bqV
 brF
-bgD
+jEP
 bgD
 bfd
 bdN
@@ -70920,7 +71575,7 @@ amU
 amY
 akF
 alH
-aab
+wEG
 alH
 akF
 amY
@@ -71170,15 +71825,15 @@ akY
 akF
 alH
 alH
-aab
+kYV
 alH
 amZ
 anE
 aoz
 alH
-aab
-aab
-aab
+lAV
+ngQ
+rNI
 alH
 amZ
 anE
@@ -71425,17 +72080,17 @@ acO
 acO
 adc
 aff
-aab
-aab
-aab
+kYV
+kYV
+kYV
 alH
 ana
 anF
 ana
 alH
-aab
-aab
-aab
+kYV
+miY
+rNI
 alH
 ana
 asZ
@@ -71682,7 +72337,7 @@ ads
 ads
 ael
 aff
-aab
+kYV
 alH
 alH
 akF
@@ -71700,7 +72355,7 @@ anh
 akF
 alH
 alH
-aab
+lAV
 alH
 amT
 apD
@@ -71939,7 +72594,7 @@ aki
 acO
 adc
 aff
-aab
+kYV
 alH
 amd
 amw
@@ -71957,7 +72612,7 @@ aoA
 amw
 apE
 alH
-aab
+kYV
 alH
 amT
 akV
@@ -72196,7 +72851,7 @@ add
 acO
 adc
 aff
-aab
+kYV
 alH
 ame
 amx
@@ -72214,7 +72869,7 @@ ame
 arC
 and
 alH
-aab
+kYV
 alH
 amT
 akV
@@ -72453,7 +73108,7 @@ add
 acL
 adc
 aff
-adO
+oLt
 alH
 amf
 amy
@@ -72471,7 +73126,7 @@ aoC
 amy
 amf
 alH
-adO
+oLt
 alH
 amT
 akV
@@ -72710,7 +73365,7 @@ add
 acO
 adc
 aff
-adO
+oLt
 akF
 akK
 akK
@@ -72728,7 +73383,7 @@ akK
 akK
 akK
 akF
-adO
+oLt
 alH
 amT
 axh
@@ -72967,7 +73622,7 @@ add
 acO
 adc
 aff
-adO
+oLt
 alH
 amf
 amF
@@ -72985,7 +73640,7 @@ aoD
 amF
 aux
 alH
-adO
+oLt
 alH
 amT
 akV
@@ -73224,7 +73879,7 @@ add
 acO
 adc
 aff
-aab
+kYV
 alH
 ame
 amA
@@ -73242,7 +73897,7 @@ ame
 arD
 and
 alH
-aab
+kYV
 alH
 amT
 akV
@@ -73481,7 +74136,7 @@ add
 acO
 adc
 aff
-aab
+kYV
 alH
 amg
 amB
@@ -73499,7 +74154,7 @@ aoE
 atY
 apG
 alH
-aab
+kYV
 alH
 amT
 akV
@@ -73509,7 +74164,7 @@ azO
 ayH
 azB
 aCC
-aCC
+wmW
 ayH
 azB
 ayH
@@ -73738,7 +74393,7 @@ add
 acO
 adc
 aff
-aab
+kYV
 alH
 alH
 akF
@@ -73756,7 +74411,7 @@ anh
 akF
 alH
 alH
-aab
+kYV
 alH
 amT
 akV
@@ -73977,15 +74632,15 @@ aew
 aer
 aeK
 aff
-aab
-aab
-adO
-aab
-aab
-aab
-aab
-adO
-aab
+kYV
+kYV
+oLt
+kYV
+kYV
+kYV
+kYV
+oLt
+kYV
 acK
 aff
 aiQ
@@ -73995,25 +74650,25 @@ add
 acO
 adc
 aff
-aab
-aab
-aab
+kYV
+kYV
+kYV
 alH
 ana
 anG
 ana
 alH
-aab
-aab
-aab
+kYV
+kYV
+kYV
 alH
 ana
 ata
 ana
 alH
-aab
-aab
-aab
+kYV
+kYV
+kYV
 alH
 amT
 akV
@@ -74234,16 +74889,16 @@ add
 acK
 aeL
 aAO
-aab
-aab
-ags
-ags
-ags
-ags
-ags
-ags
-aab
-aab
+kYV
+kYV
+aff
+aff
+aff
+aff
+aff
+aff
+kYV
+kYV
 aff
 aff
 acK
@@ -74254,23 +74909,23 @@ akZ
 acK
 aff
 aff
-aab
+kYV
 alH
 amZ
 anH
 aoz
 alH
-aab
-aab
-aab
+kYV
+kYV
+kYV
 alH
 amZ
 anH
 aoz
 alH
-aab
-aab
-aab
+kYV
+kYV
+kYV
 alH
 axe
 avq
@@ -74479,30 +75134,30 @@ kYV
 ahN
 aol
 aEL
-aEL
+xly
 dDs
 aYT
 ams
 acR
-adE
-ajN
+jRr
+ljw
 mhw
 akj
 acK
-adO
-adO
-adO
-ags
-ags
-agE
+oLt
+oLt
+oLt
+aff
+aff
+aeQ
 awj
-agE
-agE
-ags
-ags
-adO
-adO
-adO
+aeQ
+aeQ
+aff
+aff
+oLt
+oLt
+oLt
 acK
 ajw
 akj
@@ -74518,7 +75173,7 @@ amV
 amY
 akF
 akF
-aab
+kYV
 akF
 akF
 amY
@@ -74526,8 +75181,8 @@ amV
 amY
 akF
 akF
-aab
-aab
+kYV
+kYV
 akF
 axf
 axi
@@ -74742,25 +75397,25 @@ aYU
 bdv
 acS
 ajN
-ajN
+ljw
 ayl
 ajN
-ahN
-ags
-ags
-ags
-ahN
-agE
-agF
+acK
+aff
+aff
+aff
+acK
+aeQ
+acO
 ahv
-agE
-anI
+aeQ
+ajc
 awz
-ahN
-ags
-ags
-ags
-ahN
+acK
+aff
+aff
+aff
+acK
 ajN
 ajN
 akH
@@ -75003,20 +75658,20 @@ adU
 ajN
 ajN
 biK
-agE
+aeQ
 awj
-agE
+aeQ
 alt
-agE
-agE
-agU
-agU
+aeQ
+aeQ
+add
+add
 agh
-agE
+aeQ
 ahO
-agE
+aeQ
 awj
-agE
+aeQ
 aji
 ajN
 ayl
@@ -75102,7 +75757,7 @@ bsR
 bsG
 bql
 bCo
-bFl
+joX
 bBh
 bGr
 bHx
@@ -75251,23 +75906,23 @@ ags
 akk
 aVp
 aVp
-aXH
+pZG
 bcK
 bdv
 acS
 ayl
 adV
 amN
-ajN
-biK
+ljw
+mAN
 biL
 agE
 agE
 agE
 ahs
 agE
-agU
-agU
+add
+add
 aht
 aij
 ahP
@@ -75378,7 +76033,7 @@ bPz
 bPz
 bGm
 bOq
-bxO
+cad
 cbp
 ccT
 cdW
@@ -75506,9 +76161,9 @@ kYV
 kYV
 ags
 afX
-aVp
-aVp
-aVp
+hDh
+uuc
+igm
 bcP
 bdv
 acS
@@ -75516,22 +76171,22 @@ ajN
 acS
 ajN
 ajN
-ahN
-ags
-ags
-ags
-ahN
-agE
+acK
+aff
+aff
+aff
+acK
+aeQ
 agF
 ahx
-awj
+mnR
 anL
 awz
-ahN
-ags
-ags
-ags
-ahN
+acK
+aff
+aff
+aff
+acK
 ajx
 ajN
 mhw
@@ -75650,7 +76305,7 @@ ccV
 cap
 cnQ
 ccV
-cap
+kGj
 cbA
 ccV
 cap
@@ -75764,8 +76419,8 @@ bWl
 ahN
 aDQ
 aXz
-aXz
-aXz
+soh
+vSy
 bds
 bdy
 acT
@@ -75774,20 +76429,20 @@ adE
 ajN
 akn
 acK
-adO
-adO
-adO
-ags
-ags
-agE
-agE
-agE
-agE
-ags
-ags
-adO
-adO
-adO
+oLt
+oLt
+oLt
+aff
+aff
+aeQ
+aeQ
+aeQ
+aeQ
+aff
+aff
+oLt
+oLt
+oLt
 acK
 ajN
 akn
@@ -75803,7 +76458,7 @@ ans
 amY
 akF
 akF
-aab
+kYV
 akF
 akF
 amY
@@ -75811,8 +76466,8 @@ ans
 amY
 akF
 akF
-aab
-aab
+kYV
+kYV
 alH
 axt
 axj
@@ -76033,16 +76688,16 @@ add
 acK
 aeL
 aAO
-aab
-aab
-ags
-ags
-ags
-ags
-ags
-ags
-aab
-aab
+kYV
+kYV
+aff
+aff
+aff
+aff
+aff
+aff
+kYV
+kYV
 aff
 aff
 acK
@@ -76053,23 +76708,23 @@ akZ
 acK
 aff
 aff
-aab
+kYV
 alH
 amZ
 anE
 aoz
 alH
-aab
-aab
-aab
+kYV
+kYV
+kYV
 alH
 asn
 anE
 atz
 alH
-aab
-aab
-aab
+kYV
+kYV
+kYV
 alH
 awD
 axl
@@ -76290,15 +76945,15 @@ aeq
 aer
 aeK
 aff
-aab
-aab
-adO
-aab
-aab
-aab
-aab
-adO
-aab
+kYV
+kYV
+oLt
+kYV
+kYV
+kYV
+kYV
+oLt
+kYV
 acK
 aff
 aeN
@@ -76308,25 +76963,25 @@ add
 acO
 adc
 aff
-aab
-aab
-aab
+kYV
+kYV
+kYV
 alH
 ana
 anM
 ana
 alH
-aab
-aab
-aab
+kYV
+kYV
+kYV
 alH
 aso
 atb
 aso
 alH
-aab
-aab
-aab
+kYV
+kYV
+kYV
 alH
 axt
 axj
@@ -76565,7 +77220,7 @@ add
 acO
 adc
 aff
-aab
+kYV
 alH
 alH
 akF
@@ -76583,7 +77238,7 @@ anh
 akF
 alH
 alH
-aab
+kYV
 alH
 axt
 axj
@@ -76822,7 +77477,7 @@ add
 acO
 adc
 aff
-aab
+kYV
 alH
 amd
 amw
@@ -76840,7 +77495,7 @@ aoA
 amw
 apE
 alH
-aab
+kYV
 alH
 axt
 axj
@@ -77079,7 +77734,7 @@ add
 acO
 adc
 aff
-aab
+kYV
 alH
 amj
 amD
@@ -77097,7 +77752,7 @@ amj
 arE
 ank
 alH
-aab
+kYV
 alH
 axt
 axQ
@@ -77199,7 +77854,7 @@ cdY
 ccV
 csH
 bKZ
-cvA
+tXr
 ctT
 cuY
 cvD
@@ -77336,7 +77991,7 @@ add
 acO
 adc
 aff
-adO
+oLt
 alH
 amf
 amE
@@ -77354,7 +78009,7 @@ aoC
 amE
 amf
 alH
-adO
+oLt
 alH
 awE
 axm
@@ -77593,7 +78248,7 @@ add
 acO
 adc
 aff
-adO
+oLt
 akF
 akK
 akK
@@ -77611,7 +78266,7 @@ akK
 akK
 akK
 akF
-adO
+oLt
 alH
 axA
 axn
@@ -77850,7 +78505,7 @@ add
 acL
 adc
 aff
-adO
+oLt
 alH
 amf
 anD
@@ -77868,7 +78523,7 @@ aoD
 anD
 auy
 alH
-adO
+oLt
 alH
 axt
 axj
@@ -77910,7 +78565,7 @@ aab
 aab
 adO
 bbp
-aHp
+aWR
 aHt
 boA
 aWR
@@ -78107,7 +78762,7 @@ add
 acO
 adc
 aff
-aab
+kYV
 alH
 amj
 amG
@@ -78125,7 +78780,7 @@ amj
 arF
 ank
 alH
-aab
+kYV
 alH
 axt
 axj
@@ -78168,9 +78823,9 @@ bbp
 bbp
 bcj
 bmz
-bck
-boD
-bck
+vEU
+krU
+vEU
 bcj
 bbp
 bbp
@@ -78364,7 +79019,7 @@ ahr
 acO
 adc
 aff
-aab
+kYV
 alH
 amg
 amB
@@ -78382,7 +79037,7 @@ aoE
 amB
 apG
 alH
-aab
+kYV
 alH
 axt
 axj
@@ -78424,10 +79079,10 @@ aWR
 aWR
 aWR
 bli
-aIv
-aIv
-boG
-aIv
+aWR
+aWR
+boA
+aWR
 bli
 aWR
 aHt
@@ -78621,7 +79276,7 @@ ads
 ads
 ael
 aff
-aab
+kYV
 alH
 alH
 akF
@@ -78639,7 +79294,7 @@ anh
 akF
 alH
 alH
-aab
+kYV
 alH
 axt
 axj
@@ -78878,25 +79533,25 @@ acO
 acO
 adc
 aff
-aab
-aab
-aab
+kYV
+kYV
+kYV
 alH
 ana
 anN
 ana
 alH
-aab
-aab
-aab
+kYV
+kYV
+kYV
 alH
 ana
 atc
 ana
 alH
-aab
-aab
-aab
+kYV
+kYV
+kYV
 alH
 axt
 axj
@@ -79137,23 +79792,23 @@ akY
 akF
 alH
 alH
-aab
+kYV
 alH
 amZ
 anH
 aoz
 alH
-aab
-aab
-aab
+yfM
+yfM
+yfM
 alH
 amZ
 anH
 aoz
 alH
-aab
-aab
-aab
+yfM
+yfM
+yfM
 alH
 axt
 axj
@@ -79401,7 +80056,7 @@ amV
 amY
 akF
 akF
-aab
+xhO
 akF
 akF
 amY
@@ -79409,7 +80064,7 @@ amV
 amY
 akF
 akF
-aab
+xhO
 alH
 akF
 axf
@@ -79710,7 +80365,7 @@ brS
 bjL
 bgQ
 bmA
-aWR
+aHp
 bjj
 bgQ
 bgQ
@@ -79875,11 +80530,11 @@ bWl
 bWl
 acE
 acF
+gdU
+gdU
+kva
 acF
-acF
-acG
-acF
-acF
+gdU
 acU
 adh
 adx
@@ -79971,7 +80626,7 @@ aWR
 aWR
 bll
 aWR
-aHt
+nPv
 blj
 bsI
 bgT
@@ -80134,10 +80789,10 @@ acE
 acF
 acG
 acF
+gdU
 acF
-acF
-acG
-acU
+gcs
+pla
 adi
 adx
 adH
@@ -80233,7 +80888,7 @@ bgQ
 blk
 aWR
 bfw
-bdE
+bju
 bvT
 bcj
 bbp
@@ -80389,11 +81044,11 @@ bWl
 bWl
 acE
 acG
-acJ
+oAL
 acG
 acF
-acG
-acG
+kva
+kva
 acV
 adj
 ady
@@ -80645,7 +81300,7 @@ bWl
 bWl
 bWl
 acE
-acF
+gdU
 acF
 iFe
 acG
@@ -80764,9 +81419,9 @@ aKP
 aLs
 aKN
 aKU
-aab
-aab
-aab
+shF
+iQZ
+kYV
 bOA
 bPR
 bHI
@@ -80809,7 +81464,7 @@ cvb
 cvb
 cvb
 oiK
-czh
+xrp
 cyr
 cyr
 cyr
@@ -80904,8 +81559,8 @@ bWl
 acE
 acF
 acG
-acF
-acF
+gdU
+gdU
 acG
 acJ
 acU
@@ -81021,9 +81676,9 @@ aQX
 brj
 aKN
 aKU
-aab
-aab
-aab
+shF
+ped
+yfM
 bOA
 bPS
 bRr
@@ -81159,11 +81814,11 @@ bWl
 bWl
 bWl
 acE
+gdU
+gdU
 acF
 acF
-acF
-acF
-acF
+gdU
 acF
 acU
 adh
@@ -81417,10 +82072,10 @@ bWl
 bWl
 acE
 acF
+gdU
 acF
 acF
-acF
-acF
+gdU
 acG
 acU
 adm
@@ -81518,7 +82173,7 @@ bgQ
 bsH
 aWR
 bfw
-bdE
+bju
 bvT
 bcj
 bbp
@@ -81947,7 +82602,7 @@ adG
 afF
 agg
 agu
-agO
+trU
 agO
 agu
 ahB
@@ -81972,7 +82627,7 @@ anJ
 apt
 apM
 apI
-any
+apI
 avY
 apI
 apI
@@ -82213,7 +82868,7 @@ agL
 agL
 agL
 agL
-agL
+vVg
 agL
 aks
 akM
@@ -82313,7 +82968,7 @@ bPL
 bPU
 bPN
 bPN
-bUz
+bPN
 bPL
 bXt
 bPL
@@ -82449,8 +83104,8 @@ acF
 arW
 arW
 arW
-acF
-acX
+vdD
+wuP
 adi
 adx
 adL
@@ -82462,7 +83117,7 @@ afP
 aeX
 xAI
 agP
-agP
+vPB
 xAI
 ahV
 ahX
@@ -83750,7 +84405,7 @@ agM
 ajh
 ahj
 ahy
-ahY
+hyA
 ahj
 ajh
 agM
@@ -83880,7 +84535,7 @@ cpY
 cpY
 cpY
 csL
-coI
+dXA
 cuc
 cux
 cqR
@@ -84629,7 +85284,7 @@ bRv
 bUC
 bRv
 bUC
-bYN
+bRv
 bUC
 bRv
 fwZ
@@ -85286,7 +85941,7 @@ oLt
 aeZ
 aeZ
 afL
-afL
+ybO
 afM
 afJ
 agq
@@ -88483,7 +89138,7 @@ cuU
 bTh
 bUF
 bVZ
-fRD
+bRC
 bYT
 cay
 cbK
@@ -88998,7 +89653,7 @@ bTh
 bUF
 bWb
 bRC
-bPj
+cdQ
 bXx
 cbM
 cdg
@@ -89276,7 +89931,7 @@ cqk
 cjR
 crz
 cse
-csO
+csP
 adO
 aab
 aab
@@ -89514,7 +90169,7 @@ cuT
 bRC
 bYX
 caA
-cdQ
+mYC
 ccn
 cbJ
 cft
@@ -89533,7 +90188,7 @@ cqk
 cjR
 cjR
 cjR
-csO
+csP
 adO
 aab
 aab
@@ -89779,7 +90434,7 @@ bRC
 bQi
 raF
 ciU
-yjP
+ciU
 bYq
 clm
 ciU
@@ -89790,7 +90445,7 @@ cqk
 cjR
 cjR
 cjR
-csO
+csP
 ctC
 aab
 aab
@@ -89982,7 +90637,7 @@ aVT
 aXd
 aYu
 aXf
-bee
+aXd
 aXd
 aXd
 bij
@@ -90047,7 +90702,7 @@ cqk
 cqW
 crB
 csf
-csO
+csP
 adO
 aab
 aab
@@ -91250,7 +91905,7 @@ aJv
 aKi
 blK
 aLH
-aFS
+sHr
 aMT
 aDA
 aOw
@@ -92785,7 +93440,7 @@ pBH
 avh
 aDA
 aEB
-aFS
+sHr
 aHc
 blK
 aJz
@@ -93889,7 +94544,7 @@ cer
 cfC
 cfD
 bWv
-chQ
+fQU
 chC
 ckR
 ckR
@@ -94117,7 +94772,7 @@ bwX
 bwX
 bwX
 bvd
-bvd
+wuG
 btt
 bAA
 bEA
@@ -94146,7 +94801,7 @@ bEI
 bEI
 cfD
 cfD
-chQ
+rES
 chC
 ckR
 ckR
@@ -94317,7 +94972,7 @@ aur
 auI
 avj
 avj
-auI
+xwA
 avj
 avj
 auI
@@ -94625,7 +95280,7 @@ bnG
 boV
 btt
 bul
-bvd
+iYm
 bvd
 bwX
 bwX
@@ -96912,7 +97567,7 @@ aQk
 aRy
 aSz
 aTJ
-aVj
+aVk
 aVk
 cEk
 aXm
@@ -97956,7 +98611,7 @@ biG
 bjE
 bdp
 blw
-blw
+qDV
 bdp
 bdp
 bdp
@@ -98213,12 +98868,12 @@ bcA
 bjF
 bcA
 bcA
+mMl
 bcA
 bcA
 bcA
 bcA
-bcA
-bcA
+mMl
 bcA
 bcA
 bjF
@@ -98470,12 +99125,12 @@ bcz
 bjG
 bcz
 bcz
-bcA
+mMl
 bcz
 bcz
 bcz
 bcz
-bcA
+mMl
 bcz
 bcz
 bjG
@@ -98727,12 +99382,12 @@ bbC
 bbC
 bmM
 bnM
-bcA
+mMl
 bcz
 bcz
 bcz
 bcz
-bcA
+mMl
 bnM
 bmM
 bbC
@@ -98984,12 +99639,12 @@ bbG
 bbH
 bbC
 bnM
-bcA
+mMl
 bcz
 bcz
 bcz
 bcz
-bcA
+mMl
 bnM
 bbC
 bbH
@@ -99241,12 +99896,12 @@ bbH
 bcN
 bbC
 bnM
-bcA
+mMl
 bcz
 bcz
 bcz
 bcz
-bcA
+mMl
 bnM
 bbC
 bmE
@@ -99498,12 +100153,12 @@ bcC
 bcC
 aFy
 bdw
-bcA
+mMl
 bcz
 bcz
 bcz
 bcz
-bcA
+mMl
 bkM
 aFy
 bcC
@@ -99755,12 +100410,12 @@ aab
 aab
 bcC
 bnM
-bcA
+mMl
 bcz
 bcz
 bcz
 bcz
-bcA
+mMl
 bnM
 bcC
 aab
@@ -100273,7 +100928,7 @@ bkD
 bnN
 bhw
 bhw
-byi
+bnQ
 boJ
 bhw
 aXt
@@ -100783,12 +101438,12 @@ biI
 gAI
 bkH
 blB
-bmU
+gFT
 bmU
 boZ
 blF
 bmU
-bmU
+gFT
 bpZ
 bkH
 pZB
@@ -101040,12 +101695,12 @@ biJ
 bjJ
 bhw
 bnQ
-bnQ
+kZy
 bnQ
 bkJ
 blG
 bqE
-bnQ
+kZy
 bnQ
 bhw
 bjJ
@@ -101297,12 +101952,12 @@ bhw
 bhw
 bhw
 blD
+yfJ
 bmT
 bmT
 bmT
 bmT
-bmT
-bmT
+yfJ
 bsf
 bhw
 bhw
@@ -101310,10 +101965,10 @@ bhw
 bhw
 aXt
 bnQ
-bnQ
-bnQ
+etG
+sBT
 nQm
-ghl
+iqy
 bAH
 bCZ
 bEM
@@ -101549,17 +102204,17 @@ pWB
 aXt
 beu
 vnS
+gux
 bnQ
 bnQ
 bnQ
 bnQ
-bnQ
-bnQ
+kZy
 bnQ
 bkJ
 blG
 bnQ
-bnQ
+kZy
 bnQ
 bnQ
 bnQ
@@ -101567,7 +102222,7 @@ bnQ
 bnQ
 aou
 bnQ
-bnQ
+kZy
 byi
 bzh
 sao
@@ -101806,25 +102461,25 @@ aXt
 aXt
 aVm
 bnQ
-bnQ
-bnQ
-bnQ
+oRe
+gxT
+gxT
 bkI
 blE
-blE
-blE
+xKk
+cTS
 bpa
-blG
-bnQ
-bnQ
-bnQ
-bnQ
-bnQ
-bnQ
-bnQ
-bnQ
-bnQ
-bnQ
+jzd
+sBT
+wOs
+sBT
+sBT
+sBT
+sBT
+sBT
+sBT
+sBT
+yiF
 bmw
 bzi
 bzi
@@ -102081,7 +102736,7 @@ aYM
 aYM
 aYM
 bnQ
-bnQ
+pDQ
 bnQ
 bzi
 bAI
@@ -102338,7 +102993,7 @@ aYM
 aYM
 aYM
 bnQ
-byi
+mSO
 byi
 bzj
 bAJ
@@ -102595,7 +103250,7 @@ aYM
 aYM
 aYM
 bnQ
-byi
+mSO
 bnQ
 bzi
 bAK
@@ -102852,7 +103507,7 @@ bew
 bfT
 bwo
 bnQ
-byi
+mSO
 bnQ
 bzk
 bAL
@@ -103109,7 +103764,7 @@ aYM
 aYM
 bwp
 bnQ
-byi
+mSO
 bnQ
 bzi
 bpW
@@ -103366,7 +104021,7 @@ aYM
 aYM
 bwq
 bnQ
-byi
+mSO
 gSk
 bzi
 bAN
@@ -103623,7 +104278,7 @@ aYM
 aYM
 bwr
 bnQ
-byi
+mSO
 bnQ
 xdx
 bAO
@@ -103880,7 +104535,7 @@ aYM
 aYM
 bws
 bnQ
-byi
+mSO
 bnQ
 aXt
 fuY
@@ -104137,7 +104792,7 @@ aYM
 aYM
 bwp
 bnQ
-byi
+nRo
 byl
 aXt
 bAP


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixed some missing pipes/cables/disposal pipes
Added a pair of vents and scrubbers to each LZ (They start welded)
Added more survivor spawn points
Added xeno spawn points in the far north research silo, added some resin doors
Fixed a misplaced area and added an APC
Added some sand/beach tiles in areas to help signify they're part of the "underground" section of the map.
Minor tile fixes.

## Why It's Good For The Game

Powernet should work correctly now, pipes don't suddenly stop.
Rushing xenos roundstart as a survivor takes a few more seconds.

## Changelog
:cl:
tweak: tweaked Prison Station Survivor and Xeno spawnpoints
fix: Prison Station Pipes/Disposals/Cables cleanup
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
