### PR TITLE
Fixes Lava Outpost

### DIFF
--- a/_maps/map_files/Lava_Outpost/LavaOutpost.dmm
+++ b/_maps/map_files/Lava_Outpost/LavaOutpost.dmm
@@ -1,4 +1,24 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
+	},
+/turf/closed/brock,
+/area/shuttle/drop1/lz1)
+"ab" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/closed/brock,
+/area/shuttle/drop1/lz1)
+"ac" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/lavaland/basalt,
+/area/shuttle/drop1/lz1)
+"ad" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
+	},
+/turf/open/lavaland/catwalk,
+/area/shuttle/drop1/lz1)
 "ae" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/lavaland/basalt,
@@ -7,12 +27,68 @@
 /obj/machinery/light,
 /turf/open/floor/tile/white,
 /area/lavaland/security/infocenter)
+"ag" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 1
+	},
+/turf/open/lavaland/basalt,
+/area/shuttle/drop1/lz1)
 "ah" = (
 /turf/closed/wall/indestructible/mineral,
 /area/lavaland/cave/north)
+"ai" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/lavaland/catwalk,
+/area/shuttle/drop1/lz1)
+"aj" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 1
+	},
+/turf/open/lavaland/basalt,
+/area/shuttle/drop2/lz2)
+"ak" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 1
+	},
+/turf/closed/brock,
+/area/shuttle/drop2/lz2)
 "al" = (
 /turf/closed/brock,
 /area/lavaland/cave/north)
+"am" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 8
+	},
+/turf/closed/brock,
+/area/shuttle/drop2/lz2)
+"an" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 8
+	},
+/turf/open/lavaland/basalt,
+/area/shuttle/drop2/lz2)
+"ao" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 8
+	},
+/turf/open/lavaland/lava/lpiece,
+/area/shuttle/drop2/lz2)
+"ap" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 8
+	},
+/turf/open/lavaland/lava/side{
+	dir = 4
+	},
+/area/shuttle/drop2/lz2)
+"aq" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 8
+	},
+/turf/open/lavaland/lava/lpiece{
+	dir = 4
+	},
+/area/shuttle/drop2/lz2)
 "as" = (
 /turf/open/lavaland/lava/side{
 	dir = 4
@@ -386,12 +462,6 @@
 	},
 /turf/open/lavaland/basalt,
 /area/lavaland/cave/south)
-"fU" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 1
-	},
-/turf/open/floor/plating/asteroidfloor,
-/area/shuttle/drop2/lz2)
 "fV" = (
 /obj/structure/toilet{
 	dir = 4
@@ -911,12 +981,6 @@
 	},
 /turf/open/floor/tile/dark2,
 /area/lavaland/civilian)
-"la" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 8
-	},
-/turf/open/floor/plating/asteroidfloor,
-/area/shuttle/drop2/lz2)
 "le" = (
 /turf/open/floor/tile/dark2,
 /area/lavaland/civilian)
@@ -1598,15 +1662,6 @@
 "sA" = (
 /turf/open/floor/tile/dark,
 /area/lavaland/security/nuke)
-"sG" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 1
-	},
-/turf/open/floor/plating/asteroidfloor,
-/area/shuttle/drop1/lz1)
 "sN" = (
 /obj/structure/closet/secure_closet/engineering_welding,
 /obj/machinery/light{
@@ -1782,12 +1837,6 @@
 	},
 /turf/open/floor/tile/dark2,
 /area/lavaland/civilian)
-"uH" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 1
-	},
-/turf/open/floor/plating/asteroidfloor,
-/area/shuttle/drop1/lz1)
 "uI" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /turf/open/floor/tile/dark2,
@@ -2253,12 +2302,6 @@
 	},
 /turf/open/floor/freezer,
 /area/lavaland/civilian)
-"Ap" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 1
-	},
-/turf/closed/wall/r_wall,
-/area/shuttle/drop1/lz1)
 "Ay" = (
 /obj/machinery/light{
 	dir = 8
@@ -2701,10 +2744,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/lavaland/security/nuke)
-"EU" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/closed/wall/r_wall,
-/area/shuttle/drop1/lz1)
 "EV" = (
 /obj/machinery/door/airlock/mainship/security{
 	dir = 1
@@ -3044,12 +3083,6 @@
 /obj/item/weapon/gun/pistol/m4a3,
 /turf/open/floor/plating/platebot,
 /area/lavaland/security/nuke)
-"IZ" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 8
-	},
-/turf/closed/wall/r_wall,
-/area/shuttle/drop2/lz2)
 "Jb" = (
 /obj/machinery/landinglight/ds2/delayone{
 	dir = 8
@@ -3187,12 +3220,6 @@
 	dir = 1
 	},
 /area/lavaland/cave/southwest)
-"Kv" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 1
-	},
-/turf/closed/wall/r_wall,
-/area/shuttle/drop2/lz2)
 "Ky" = (
 /obj/item/defibrillator,
 /obj/structure/table,
@@ -3888,15 +3915,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/white,
 /area/lavaland/medical)
-"SH" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 1
-	},
-/turf/open/floor/plating/asteroidfloor,
-/area/shuttle/drop1/lz1)
 "SL" = (
 /obj/structure/closet/secure_closet/chemical,
 /obj/machinery/light{
@@ -4128,10 +4146,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/lavaland/medical)
-"Vv" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/open/floor/plating/asteroidfloor,
-/area/shuttle/drop1/lz1)
 "Vz" = (
 /turf/open/lavaland/basalt,
 /area/lavaland/cave/southwest)
@@ -8708,8 +8722,8 @@ rK
 rK
 rK
 QR
-QR
-fU
+aj
+yb
 yb
 yb
 yb
@@ -8965,8 +8979,8 @@ rK
 rK
 QR
 QR
-QR
-fU
+aj
+yb
 yb
 yb
 yb
@@ -9222,8 +9236,8 @@ QR
 QR
 QR
 QR
-QR
-fU
+aj
+yb
 yb
 yb
 yb
@@ -9479,8 +9493,8 @@ QR
 QR
 QR
 QR
-QR
-fU
+aj
+yb
 yb
 yb
 yb
@@ -9736,8 +9750,8 @@ QR
 QR
 QR
 QR
-QR
-fU
+aj
+yb
 yb
 yb
 yb
@@ -9780,8 +9794,8 @@ yb
 yb
 yb
 yb
-Kv
-ZN
+Gv
+aj
 ZN
 ZW
 ZW
@@ -9993,8 +10007,8 @@ QR
 QR
 Ls
 QR
-QR
-fU
+aj
+yb
 yb
 yb
 yb
@@ -10037,8 +10051,8 @@ yb
 yb
 yb
 yb
-Kv
-ZN
+Gv
+aj
 ZN
 ZN
 ZW
@@ -10250,8 +10264,8 @@ QR
 QR
 QR
 QR
-QR
-fU
+aj
+yb
 yb
 yb
 yb
@@ -10294,8 +10308,8 @@ yb
 yb
 yb
 yb
-Kv
-ZN
+Gv
+aj
 ZN
 ZN
 ZN
@@ -10507,8 +10521,8 @@ QR
 QR
 QR
 QR
-QR
-fU
+aj
+yb
 yb
 yb
 yb
@@ -10551,8 +10565,8 @@ yb
 yb
 yb
 yb
-Kv
-ZN
+Gv
+aj
 ZN
 ZN
 ZN
@@ -10764,8 +10778,8 @@ QR
 QR
 QR
 QR
-QR
-fU
+aj
+yb
 yb
 yb
 yb
@@ -10808,8 +10822,8 @@ yb
 yb
 yb
 yb
-Kv
-ZN
+Gv
+aj
 ZN
 ZN
 ZN
@@ -11021,8 +11035,8 @@ QR
 QR
 QR
 QR
-QR
-fU
+aj
+yb
 yb
 yb
 yb
@@ -11065,8 +11079,8 @@ yb
 yb
 yb
 yb
-Kv
-ZN
+Gv
+aj
 ZN
 ZN
 ZN
@@ -11278,8 +11292,8 @@ rK
 QR
 QR
 QR
-QR
-fU
+aj
+yb
 yb
 yb
 yb
@@ -11322,8 +11336,8 @@ yb
 yb
 yb
 yb
-Kv
-ZN
+Gv
+aj
 ZN
 ZN
 ZN
@@ -11535,12 +11549,12 @@ rK
 rK
 rK
 rK
-rK
-IZ
-IZ
-IZ
-IZ
-IZ
+ak
+Gv
+Gv
+Gv
+Gv
+Gv
 yb
 yb
 dv
@@ -11579,8 +11593,8 @@ yb
 yb
 yb
 yb
-Kv
-ZN
+Gv
+aj
 ZN
 ZN
 ZN
@@ -11792,12 +11806,12 @@ rK
 rK
 rK
 rK
-rK
-rK
-rK
-rK
-rK
-Kv
+am
+am
+am
+am
+am
+Gv
 yb
 yb
 yb
@@ -11836,8 +11850,8 @@ yb
 yb
 yb
 yb
-Kv
-ZN
+Gv
+aj
 ZN
 ZN
 ZN
@@ -12053,8 +12067,8 @@ rK
 rK
 rK
 rK
-rK
-Kv
+ak
+Gv
 yb
 yb
 yb
@@ -12093,8 +12107,8 @@ yb
 yb
 yb
 yb
-Kv
-ZN
+Gv
+aj
 ZN
 ZN
 ZN
@@ -12310,8 +12324,8 @@ rK
 rK
 rK
 rK
-rK
-Kv
+ak
+Gv
 yb
 yb
 yb
@@ -12350,8 +12364,8 @@ yb
 yb
 yb
 yb
-Kv
-ZN
+Gv
+aj
 ZN
 ZN
 ZN
@@ -12567,16 +12581,16 @@ rK
 rK
 rK
 rK
-rK
-IZ
-IZ
-IZ
-IZ
-IZ
-IZ
-IZ
-IZ
-IZ
+ak
+Gv
+Gv
+Gv
+Gv
+Gv
+Gv
+Gv
+Gv
+Gv
 yb
 yb
 yb
@@ -12588,27 +12602,27 @@ yb
 yb
 yb
 yb
-IZ
-IZ
-IZ
-IZ
-IZ
-IZ
-IZ
-IZ
-IZ
-IZ
-IZ
-IZ
-IZ
-IZ
-IZ
-IZ
-IZ
-IZ
-IZ
-IZ
-ZW
+Gv
+Gv
+Gv
+Gv
+Gv
+Gv
+Gv
+Gv
+Gv
+Gv
+Gv
+Gv
+Gv
+Gv
+Gv
+Gv
+Gv
+Gv
+Gv
+Gv
+aj
 ZN
 ZN
 ZN
@@ -12824,16 +12838,16 @@ rK
 rK
 rK
 rK
-rK
-rK
-rK
-rK
-rK
-rK
-rK
-rK
-rK
-Kv
+am
+am
+am
+am
+am
+am
+am
+am
+am
+Gv
 yb
 yb
 yb
@@ -12845,27 +12859,27 @@ yb
 yb
 yb
 yb
-Kv
-ZW
-ZW
-ZW
-ZW
-ZW
-ZW
-Gs
-as
-as
-as
-as
-as
-as
-eu
-ZW
-ZW
-ZW
-ZW
-ZW
-ZW
+Gv
+am
+am
+am
+am
+am
+am
+ao
+ap
+ap
+ap
+ap
+ap
+ap
+aq
+am
+am
+am
+am
+am
+am
 ZW
 ZW
 ZW
@@ -13089,8 +13103,8 @@ rK
 rK
 rK
 rK
-rK
-Kv
+ak
+Gv
 yb
 yb
 yb
@@ -13102,8 +13116,8 @@ yb
 yb
 yb
 yb
-Kv
-ZW
+Gv
+ak
 ZW
 ZW
 ZW
@@ -13346,8 +13360,8 @@ rK
 rK
 rK
 rK
-rK
-Kv
+ak
+Gv
 yb
 yb
 yb
@@ -13359,8 +13373,8 @@ yb
 yb
 yb
 yb
-Kv
-ZW
+Gv
+ak
 ZW
 ZW
 ZW
@@ -13603,8 +13617,8 @@ rK
 rK
 rK
 rK
-rK
-Kv
+ak
+Gv
 yb
 yb
 yb
@@ -13616,8 +13630,8 @@ yb
 yb
 yb
 yb
-Kv
-ZW
+Gv
+ak
 ZW
 ZW
 ZW
@@ -13860,21 +13874,21 @@ rK
 rK
 rK
 rK
-rK
-IZ
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-la
-IZ
-ZW
+ak
+Gv
+yb
+yb
+yb
+yb
+yb
+yb
+yb
+yb
+yb
+yb
+yb
+Gv
+ak
 ZW
 ZW
 ZW
@@ -14117,21 +14131,21 @@ rK
 rK
 rK
 rK
-rK
-rK
-QR
-ZN
-ZN
-ZN
-ZN
-ZN
-ZN
-ZN
-ZN
-ZN
-ZN
-ZW
-ZW
+am
+am
+an
+an
+an
+an
+an
+an
+an
+an
+an
+an
+an
+am
+am
 ZW
 ZW
 ZW
@@ -52384,19 +52398,19 @@ Va
 Va
 Va
 Va
-Va
-Va
-Bz
-Bz
-Bz
-TO
-TO
-TO
-Bz
-Bz
-Bz
-Va
-Va
+ad
+ai
+ai
+ai
+ai
+ai
+ai
+ai
+ai
+ai
+ai
+ai
+ad
 Va
 Va
 Va
@@ -52641,19 +52655,19 @@ sa
 sa
 sa
 sa
-sa
-Ap
-Vv
-Vv
-Vv
-Vv
-Vv
-Vv
-Vv
-Vv
-Vv
-Ap
-sa
+aa
+AK
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+AK
+aa
 sa
 sa
 sa
@@ -52898,8 +52912,8 @@ sa
 sa
 sa
 sa
-sa
-Ap
+aa
+AK
 AQ
 FO
 FO
@@ -52909,8 +52923,8 @@ FO
 FO
 FO
 FO
-Ap
-sa
+AK
+aa
 sa
 sa
 sa
@@ -53155,8 +53169,8 @@ sa
 sa
 sa
 sa
-sa
-Ap
+aa
+AK
 Pg
 FO
 FO
@@ -53166,8 +53180,8 @@ FO
 FO
 FO
 gf
-Ap
-sa
+AK
+aa
 sa
 sa
 sa
@@ -53405,15 +53419,15 @@ sa
 sa
 sa
 sa
-sa
-sa
-sa
-sa
-sa
-sa
-sa
-sa
-Ap
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+AK
 xG
 FO
 FO
@@ -53423,15 +53437,15 @@ FO
 FO
 FO
 FO
-Ap
-sa
-sa
-sa
-sa
-sa
-sa
-sa
-sa
+AK
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+aa
 sa
 sa
 sa
@@ -53662,15 +53676,15 @@ sa
 sa
 sa
 sa
-sa
-Ap
-EU
-EU
-EU
-EU
-EU
-EU
-Ap
+aa
+AK
+AK
+AK
+AK
+AK
+AK
+AK
+AK
 FO
 FO
 FO
@@ -53680,15 +53694,15 @@ FO
 FO
 FO
 FO
-Ap
-EU
-EU
-EU
-EU
-EU
-EU
-Ap
-sa
+AK
+AK
+AK
+AK
+AK
+AK
+AK
+AK
+aa
 sa
 sa
 sa
@@ -53919,8 +53933,8 @@ sa
 sa
 sa
 sa
-sa
-Ap
+aa
+AK
 BL
 Hw
 Hw
@@ -53944,13 +53958,13 @@ Jp
 LL
 RO
 BL
-Ap
-sa
-sa
-sa
-sa
-sa
-sa
+AK
+aa
+ab
+ab
+ab
+ab
+aa
 sa
 sa
 sa
@@ -54176,8 +54190,8 @@ sa
 sa
 sa
 sa
-sa
-Ap
+aa
+AK
 ES
 HR
 HR
@@ -54201,13 +54215,13 @@ HR
 HR
 HR
 ky
-Ap
-EU
-EU
-EU
-EU
-Ap
-sa
+AK
+AK
+AK
+AK
+AK
+AK
+aa
 sa
 sa
 sa
@@ -54433,8 +54447,8 @@ sa
 sa
 sa
 sa
-sa
-Ap
+aa
+AK
 FE
 HR
 HR
@@ -54463,8 +54477,8 @@ FO
 FO
 FO
 FO
-SH
-OD
+Ay
+ag
 OD
 OD
 OD
@@ -54690,8 +54704,8 @@ sa
 sa
 sa
 sa
-sa
-Ap
+aa
+AK
 Gw
 HR
 HR
@@ -54720,8 +54734,8 @@ FO
 FO
 FO
 FO
-uH
-OD
+FO
+ag
 OD
 OD
 OD
@@ -54947,8 +54961,8 @@ sa
 sa
 sa
 sa
-sa
-Ap
+aa
+AK
 GQ
 HR
 HR
@@ -54977,8 +54991,8 @@ FO
 FO
 FO
 FO
-uH
-OD
+FO
+ag
 OD
 OD
 OD
@@ -55204,8 +55218,8 @@ sa
 sa
 sa
 sa
-sa
-Ap
+aa
+AK
 ES
 HR
 HR
@@ -55234,8 +55248,8 @@ FO
 FO
 FO
 FO
-uH
-OD
+FO
+ag
 OD
 OD
 OD
@@ -55461,8 +55475,8 @@ sa
 sa
 sa
 sa
-sa
-Ap
+aa
+AK
 FE
 HR
 HR
@@ -55491,8 +55505,8 @@ FO
 FO
 FO
 FO
-uH
-OD
+FO
+ag
 OD
 pr
 OD
@@ -55718,8 +55732,8 @@ sa
 sa
 sa
 sa
-sa
-Ap
+aa
+AK
 Gw
 HR
 HR
@@ -55748,8 +55762,8 @@ FO
 FO
 FO
 FO
-uH
-OD
+FO
+ag
 OD
 OD
 OD
@@ -55975,8 +55989,8 @@ sa
 sa
 sa
 sa
-sa
-Ap
+aa
+AK
 GQ
 HR
 HR
@@ -56005,8 +56019,8 @@ FO
 FO
 FO
 FO
-uH
-OD
+FO
+ag
 OD
 OD
 OD
@@ -56232,8 +56246,8 @@ sa
 sa
 sa
 sa
-sa
-Ap
+aa
+AK
 ES
 HR
 HR
@@ -56262,8 +56276,8 @@ FO
 FO
 FO
 FO
-uH
-OD
+FO
+ag
 OD
 OD
 OD
@@ -56489,8 +56503,8 @@ sa
 sa
 sa
 sa
-sa
-Ap
+aa
+AK
 FE
 HR
 HR
@@ -56519,8 +56533,8 @@ FO
 FO
 FO
 FO
-sG
-OD
+Iy
+ag
 OD
 OD
 OD
@@ -56746,8 +56760,8 @@ sa
 sa
 sa
 sa
-sa
-Ap
+aa
+AK
 Gw
 HR
 HR
@@ -56771,13 +56785,13 @@ HR
 HR
 HR
 vo
-Ap
-EU
-EU
-EU
-EU
-Ap
-sa
+AK
+AK
+AK
+AK
+AK
+AK
+aa
 sa
 sa
 sa
@@ -57003,8 +57017,8 @@ sa
 sa
 sa
 sa
-sa
-Ap
+aa
+AK
 BL
 Jb
 Jb
@@ -57028,13 +57042,13 @@ JH
 Rh
 at
 BL
-Ap
-sa
-sa
-sa
-sa
-sa
-sa
+AK
+aa
+ab
+ab
+ab
+ab
+aa
 sa
 sa
 sa
@@ -57260,15 +57274,15 @@ sa
 sa
 sa
 sa
-sa
-Ap
-EU
-EU
-EU
-EU
-EU
-EU
-Ap
+aa
+AK
+AK
+AK
+AK
+AK
+AK
+AK
+AK
 FO
 FO
 FO
@@ -57278,15 +57292,15 @@ FO
 FO
 FO
 FO
-Ap
-EU
-EU
-EU
-EU
-EU
-EU
-Ap
-sa
+AK
+AK
+AK
+AK
+AK
+AK
+AK
+AK
+aa
 sa
 sa
 sa
@@ -57517,15 +57531,15 @@ sa
 sa
 sa
 sa
-sa
-sa
-OD
-OD
-OD
-OD
-OD
-OD
-Ap
+aa
+ab
+ac
+ac
+ac
+ac
+ac
+ag
+AK
 FO
 FO
 FO
@@ -57535,15 +57549,15 @@ FO
 FO
 FO
 FO
-Ap
-OD
-OD
-OD
-OD
-OD
-OD
-sa
-sa
+AK
+ag
+ac
+ac
+ac
+ac
+ac
+ab
+aa
 sa
 sa
 sa
@@ -57781,8 +57795,8 @@ OD
 OD
 OD
 OD
-OD
-Ap
+ag
+AK
 FO
 FO
 FO
@@ -57792,8 +57806,8 @@ FO
 FO
 FO
 FO
-Ap
-OD
+AK
+ag
 OD
 OD
 OD
@@ -58038,8 +58052,8 @@ OD
 OD
 OD
 OD
-OD
-Ap
+ag
+AK
 FO
 FO
 FO
@@ -58049,8 +58063,8 @@ FO
 FO
 FO
 FO
-Ap
-OD
+AK
+ag
 OD
 OD
 OD
@@ -58295,8 +58309,8 @@ OD
 OD
 OD
 OD
-OD
-Ap
+ag
+AK
 FO
 FO
 FO
@@ -58306,8 +58320,8 @@ FO
 FO
 FO
 FO
-Ap
-OD
+AK
+ag
 OD
 OD
 OD
@@ -58552,8 +58566,8 @@ OD
 OD
 OD
 OD
-OD
-Ap
+ag
+AK
 FO
 FO
 FO
@@ -58563,8 +58577,8 @@ FO
 FO
 FO
 FO
-Ap
-OD
+AK
+ag
 OD
 OD
 OD
@@ -58809,8 +58823,8 @@ OD
 OD
 OD
 OD
-OD
-Ap
+ag
+AK
 FO
 FO
 FO
@@ -58820,8 +58834,8 @@ FO
 FO
 FO
 FO
-Ap
-OD
+AK
+ag
 OD
 OD
 OD
@@ -59066,8 +59080,8 @@ OD
 OD
 OD
 OD
-OD
-Ap
+ag
+AK
 FO
 FO
 FO
@@ -59077,8 +59091,8 @@ FO
 FO
 FO
 FO
-Ap
-OD
+AK
+ag
 OD
 OD
 OD
@@ -59323,8 +59337,8 @@ OD
 OD
 OD
 OD
-OD
-Ap
+ag
+AK
 FO
 FO
 FO
@@ -59334,8 +59348,8 @@ FO
 FO
 FO
 FO
-Ap
-sa
+AK
+aa
 sa
 sa
 sa
@@ -59580,19 +59594,19 @@ fh
 fh
 fh
 fh
-sa
-Ap
-EU
-EU
-EU
-EU
-EU
-EU
-EU
-EU
-EU
-Ap
-sa
+aa
+AK
+AK
+AK
+AK
+AK
+AK
+AK
+AK
+AK
+AK
+AK
+aa
 sa
 sa
 sa
@@ -59837,19 +59851,19 @@ OD
 OD
 OD
 OD
-sa
-sa
-OD
-OD
-OD
-OD
-OD
-OD
-OD
-OD
-OD
-sa
-sa
+aa
+ab
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ab
+aa
 sa
 sa
 sa

--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -85,7 +85,6 @@
 
 /turf/closed/brock/Initialize(mapload)
 	. = ..()
-	icon_state = setDir(pick(NORTH,SOUTH,EAST,WEST))
 	for(var/direction in GLOB.cardinals)
 		var/turf/turf_to_check = get_step(src, direction)
 		if(istype(turf_to_check, /turf/open))


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Lava Outpost now has exterior walls, also basalt rock from there broke, so I fixed it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Because fixing things is fun.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Laval Outpost's containment shutters are now expanded by one tile, no more rushing for benos.
fix: Fixed Lava Outpost's basalt rocks for having no sprite.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
