### PR TITLE
Removes the chance for EORD Respawn verb to turn dead into xenomorphs, and prevents SSD Xenos searching for a mind pre/post round

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -463,6 +463,8 @@
 		return
 	if(client)
 		return
+	if (SSticker.current_state != GAME_STATE_PLAYING)
+		return
 
 	var/mob/picked = get_alien_candidate()
 	if(!picked)

--- a/code/modules/mob/mob_verbs.dm
+++ b/code/modules/mob/mob_verbs.dm
@@ -92,30 +92,17 @@
 		to_chat(src, "You can only use this when you're dead.")
 		return
 
-	var/list/spawn_types = pick(
-		500 ; /mob/living/carbon/human,
-		/mob/living/carbon/xenomorph/runner,
-		/mob/living/carbon/xenomorph/hunter,
-		/mob/living/carbon/xenomorph/spitter,
-		/mob/living/carbon/xenomorph/defender,
-		/mob/living/carbon/xenomorph/warrior,
-	)
 	var/spawn_location = pick(GLOB.deathmatch)
-	var/mob/living/L = new spawn_types(spawn_location)
+	var/mob/living/L = new /mob/living/carbon/human(spawn_location)
 	mind.transfer_to(L, TRUE)
 	L.mind.bypass_ff = TRUE
 	L.revive()
 
-	if(isxeno(L))
-		var/mob/living/carbon/xenomorph/X = L
-		X.transfer_to_hive(pick(XENO_HIVE_NORMAL, XENO_HIVE_CORRUPTED, XENO_HIVE_ALPHA, XENO_HIVE_BETA, XENO_HIVE_ZETA))
-
-	else if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		var/job = pick(/datum/job/clf/leader, /datum/job/freelancer/leader, /datum/job/upp/leader, /datum/job/som/leader, /datum/job/pmc/leader, /datum/job/freelancer/standard, /datum/job/som/standard, /datum/job/clf/standard)
-		var/datum/job/J = SSjob.GetJobType(job)
-		H.apply_assigned_role_to_spawn(J)
-		H.regenerate_icons()
+	var/mob/living/carbon/human/H = L
+	var/job = pick(/datum/job/clf/leader, /datum/job/freelancer/leader, /datum/job/upp/leader, /datum/job/som/leader, /datum/job/pmc/leader, /datum/job/freelancer/standard, /datum/job/som/standard, /datum/job/clf/standard)
+	var/datum/job/J = SSjob.GetJobType(job)
+	H.apply_assigned_role_to_spawn(J)
+	H.regenerate_icons()
 
 	to_chat(L, "<br><br><h1><span class='danger'>Fight for your life (again), try not to die this time!</span></h1><br><br>")
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Inspired by Snow mentioning it, and seeing many many catatonic resting xenos during EORD and finding out why that is.

Removes the random chance (weighted as it was) of becoming one of a few low xeno castes when using the verb.

Adds a check to `xenomorph/on_sdd_grace_period_end()` preventing it from searching for and shoving found candidates into xeno bodies pre and post round.

## Why It's Good For The Game

Xeno mob spam in EORD is bad. Getting shoved into one of those Xenos during EORD, because you had those settings enabled for the round (and it also does not care about your EORD preference to boot), while it is crit because someone got bad RNG and wanted to be a human so they ghosted and re-rolled is just as bad if not worse. Quality of life improvements are good.

Brings the EORD Respawn verb in-line with the EORD gamemode setup logic which makes all dead participants human only.

## Changelog
:cl:
tweak: The EORD Respawn verb now always respawns you as a Human.
fix: Fixes ghosts getting shoved into SSD Xenos before and after the round, like during EORD.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
