### PR TITLE
Fixes Xenos being stuck resting while ventcrawling if they were previously Ghosted/SSD

### DIFF
--- a/code/datums/gamemodes/game_mode.dm
+++ b/code/datums/gamemodes/game_mode.dm
@@ -623,11 +623,12 @@ Sensors indicate [numXenosShip || "no"] unknown lifeform signature[numXenosShip 
 	to_chat(xeno_candidate, "<span class='warning'>This is unavailable in this gamemode.</span>")
 	return FALSE
 
-/datum/game_mode/proc/transfer_xeno(mob/xeno_candidate, mob/living/carbon/xenomorph/X)
+/datum/game_mode/proc/transfer_xeno(mob/xeno_candidate, mob/living/carbon/xenomorph/X, silent = FALSE)
 	if(QDELETED(X))
 		stack_trace("[xeno_candidate] was put into a qdeleted mob [X]")
 		return
-	message_admins("[key_name(xeno_candidate)] has joined as [ADMIN_TPMONTY(X)].")
+	if(!silent)
+		message_admins("[key_name(xeno_candidate)] has joined as [ADMIN_TPMONTY(X)].")
 	xeno_candidate.mind.transfer_to(X, TRUE)
 	if(X.is_ventcrawling)  //If we are in a vent, fetch a fresh vent map
 		X.add_ventcrawl(X.loc)

--- a/code/datums/gamemodes/game_mode.dm
+++ b/code/datums/gamemodes/game_mode.dm
@@ -631,6 +631,7 @@ Sensors indicate [numXenosShip || "no"] unknown lifeform signature[numXenosShip 
 	xeno_candidate.mind.transfer_to(X, TRUE)
 	if(X.is_ventcrawling)  //If we are in a vent, fetch a fresh vent map
 		X.add_ventcrawl(X.loc)
+		X.get_up()
 
 
 /datum/game_mode/proc/attempt_to_join_as_xeno(mob/xeno_candidate, instant_join = FALSE)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -576,9 +576,14 @@ below 100 is not dizzy
 		log_game("[key_name(M)] has taken over [key_name_admin(src)].")
 		message_admins("[key_name_admin(M)] has taken over [ADMIN_TPMONTY(src)].")
 
+	GLOB.offered_mob_list -= src
+
+	if(isxeno(src))
+		SSticker.mode.transfer_xeno(M, src, TRUE)
+		return TRUE
+
 	M.mind.transfer_to(src, TRUE)
 	fully_replace_character_name(M.real_name, real_name)
-	GLOB.offered_mob_list -= src
 	return TRUE
 
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a call to `get_up()` from `transfer_xeno()` where there is already specific ventcrawl logic and makes sure the Offer/Take mob proc uses it for xenos.

## Why It's Good For The Game

Taking over a xeno from the Take Offered Mobs menu, Chat (Claim) link, Join as Xeno menu, or worst of all being shoved in after the SSD grace period only to be stuck resting in a vent unable to move or unrest requiring admin intervention to get unstuck sucks.

Bug bad. Fix good.

## Changelog
:cl:
fix: Fixed Xenos that are taken over while ventcrawling being stuck resting and unable to stop resting/move.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
