### PR TITLE
Fixes SSD Xenos keeping their old name or number when taken over by a ghost with no name set

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/login.dm
+++ b/code/modules/mob/living/carbon/xenomorph/login.dm
@@ -11,4 +11,9 @@
 
 	if(client.prefs?.xeno_name != "Undefined")
 		nicknumber = client.prefs.xeno_name
-		generate_name()
+	else
+		//Reset the nicknumber, otherwise we could keep the old minds custom name/random number
+		nicknumber = 0
+		generate_nicknumber()
+
+	generate_name()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reset the nicknumber on Xeno `login()` if they do not have one configured before calling `generate_name()`

## Why It's Good For The Game

If Xenos do have a name configured then it properly gets updated, so letting random number xenos keep their old name was probably never intended in the first place when IC names were added.

Identity theft bug bad. Fix good.

## Changelog
:cl:
fix: Fixes SSD Xenos keeping their old name or number when taken over by a ghost with no name set.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
