### PR TITLE
Big Red LZ1 Buffs

### DIFF
--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -2107,6 +2107,9 @@
 /area/bigredv2/outside/nw)
 "ahS" = (
 /obj/structure/cable,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
 /turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/nw)
 "ahT" = (
@@ -2116,6 +2119,9 @@
 /area/bigredv2/outside/nw)
 "ahU" = (
 /obj/structure/solaris_sign,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
 /turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/nw)
 "ahV" = (
@@ -2126,6 +2132,9 @@
 "ahW" = (
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/nw)
 "ahX" = (
@@ -2136,12 +2145,18 @@
 /obj/item/stack/sheet/metal,
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/nw)
 "ahZ" = (
 /obj/item/stack/rods,
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/nw)
 "aia" = (
@@ -20501,6 +20516,13 @@
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/southeast)
+"bQc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/outside/nw)
 "bSC" = (
 /obj/machinery/light{
 	dir = 8
@@ -20513,6 +20535,13 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/ne)
+"bXE" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/closed/mineral/bigred,
+/area/bigredv2/caves/northwest)
 "bZF" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -20559,6 +20588,14 @@
 	dir = 9
 	},
 /area/shuttle/drop2/lz2)
+"cyL" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 10
+	},
+/area/bigredv2/outside/nw)
 "cBD" = (
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/bigredv2/outside/sw)
@@ -20567,6 +20604,12 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor,
 /area/bigredv2/outside/hydroponics)
+"cQC" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/northwest)
 "cTr" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/wall/r_wall,
@@ -20793,12 +20836,22 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor,
 /area/bigredv2/outside/hydroponics)
+"eRn" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/northwest)
 "eRJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/marking/asteroidwarning{
 	dir = 1
 	},
 /area/shuttle/drop2/lz2)
+"eTT" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/closed/mineral/bigred,
+/area/bigredv2/caves/northwest)
 "eVX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -20916,6 +20969,12 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
+"fNY" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/outside/nw)
 "fOi" = (
 /obj/structure/cable,
 /turf/open/floor/marking/asteroidwarning{
@@ -21112,6 +21171,14 @@
 /obj/docking_port/stationary/crashmode,
 /turf/closed/wall,
 /area/bigredv2/outside/cargo)
+"hwL" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 4
+	},
+/area/bigredv2/outside/nw)
 "hzx" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral/bigred,
@@ -21168,6 +21235,14 @@
 /obj/docking_port/stationary/crashmode,
 /turf/closed/wall,
 /area/bigredv2/outside/admin_building)
+"hXl" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/floor/marking/asteroidwarning{
+	dir = 6
+	},
+/area/bigredv2/outside/nw)
 "iiY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
@@ -21245,6 +21320,10 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
 /area/bigredv2/caves/south)
+"jsp" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/outside/nw)
 "jtk" = (
 /turf/open/floor/plating,
 /area/bigredv2/caves/south)
@@ -21350,6 +21429,12 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/outside/s)
+"ktH" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/closed/mineral/bigred,
+/area/bigredv2/caves/northwest)
 "kvX" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -21499,6 +21584,14 @@
 	},
 /turf/open/floor/tile/blue/whitebluefull,
 /area/bigredv2/outside/general_store)
+"lPV" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/floor/marking/asteroidwarning{
+	dir = 10
+	},
+/area/bigredv2/outside/nw)
 "lVv" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -21649,6 +21742,13 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
+"nOm" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/northwest)
 "nRT" = (
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/west)
@@ -21820,6 +21920,10 @@
 /obj/structure/mineral_door/resin,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/southeast)
+"pOZ" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/closed/mineral/bigred,
+/area/bigredv2/caves/northwest)
 "pQK" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 8
@@ -22035,6 +22139,12 @@
 	dir = 1
 	},
 /area/bigredv2/outside/chapel)
+"rBN" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/bigredv2/outside/nw)
 "rMV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -22143,6 +22253,12 @@
 "tku" = (
 /turf/closed/wall/indestructible/mineral,
 /area/storage/testroom)
+"tkR" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/floor/marking/asteroidwarning,
+/area/bigredv2/outside/nw)
 "tnm" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -22286,6 +22402,12 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/south)
+"uHG" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/mars/random/cave/rock,
+/area/bigredv2/caves/northwest)
 "uHK" = (
 /obj/item/tool/wet_sign,
 /obj/effect/decal/cleanable/dirt,
@@ -22424,6 +22546,7 @@
 /area/bigredv2/caves/lambda_lab)
 "wgk" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/northwest)
 "wmv" = (
@@ -23977,26 +24100,26 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+pOZ
+pOZ
+pOZ
+pOZ
+pOZ
+pOZ
+pOZ
+pOZ
+pOZ
+pOZ
 wgk
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+pOZ
+pOZ
+pOZ
+pOZ
+pOZ
+pOZ
+pOZ
+pOZ
+pOZ
 aac
 aac
 aac
@@ -24194,7 +24317,7 @@ aac
 aac
 aac
 aac
-aac
+ktH
 acA
 acA
 acA
@@ -24213,7 +24336,7 @@ aae
 aae
 aae
 aae
-aac
+ktH
 aac
 aac
 aac
@@ -24411,7 +24534,7 @@ aac
 aac
 aac
 aac
-aac
+ktH
 acA
 acY
 adq
@@ -24430,7 +24553,7 @@ aaf
 aaf
 aaf
 aae
-aac
+ktH
 aac
 aac
 aac
@@ -24628,7 +24751,7 @@ aac
 aac
 aac
 aac
-aac
+ktH
 acA
 acZ
 ade
@@ -24647,7 +24770,7 @@ aaf
 aaf
 alH
 aae
-aac
+ktH
 aac
 aac
 aac
@@ -24845,7 +24968,7 @@ aac
 aac
 aac
 aac
-aac
+ktH
 acA
 ada
 ade
@@ -24864,7 +24987,7 @@ gkA
 aaf
 vbs
 aae
-mAi
+uHG
 aad
 aac
 aac
@@ -25062,7 +25185,7 @@ aac
 aac
 aac
 aac
-aac
+ktH
 acA
 ada
 adr
@@ -25081,7 +25204,7 @@ aaf
 aaf
 alH
 aae
-aad
+cQC
 aad
 aad
 aad
@@ -25276,10 +25399,10 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
+pOZ
+pOZ
+pOZ
+ktH
 acA
 acQ
 acQ
@@ -25298,7 +25421,7 @@ aaf
 aaf
 jLQ
 aae
-aad
+cQC
 aad
 aad
 aad
@@ -25493,7 +25616,7 @@ aac
 aac
 aac
 aac
-aac
+ktH
 aae
 aae
 aae
@@ -25515,7 +25638,7 @@ aaf
 aaf
 alH
 aae
-aad
+cQC
 aad
 aad
 aad
@@ -25710,7 +25833,7 @@ aac
 aac
 aac
 aac
-aac
+ktH
 aae
 abQ
 aas
@@ -25732,7 +25855,7 @@ aaf
 aaf
 vbs
 aae
-aad
+cQC
 aad
 aad
 aad
@@ -25927,7 +26050,7 @@ aac
 aac
 aac
 aac
-aac
+ktH
 aae
 aaf
 acJ
@@ -25949,7 +26072,7 @@ gkA
 aaf
 alH
 aae
-aac
+ktH
 aac
 aac
 aac
@@ -26135,16 +26258,16 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+pOZ
+pOZ
+pOZ
+pOZ
+pOZ
+pOZ
+pOZ
+pOZ
+pOZ
+ktH
 aae
 aaf
 aas
@@ -26166,7 +26289,7 @@ aaf
 aaf
 aaf
 aae
-aac
+ktH
 aac
 aac
 aac
@@ -26352,7 +26475,7 @@ aac
 aac
 aac
 aac
-aac
+ktH
 aae
 aae
 aae
@@ -26383,7 +26506,7 @@ aaf
 aaf
 aaf
 aae
-aac
+ktH
 aac
 aac
 aac
@@ -26569,7 +26692,7 @@ aac
 aac
 aac
 aac
-aac
+ktH
 aae
 aaf
 aaf
@@ -26600,7 +26723,7 @@ aaf
 aaf
 fVb
 aae
-aac
+ktH
 aac
 aac
 aac
@@ -26786,7 +26909,7 @@ aac
 aac
 aac
 aac
-aac
+ktH
 aae
 aaf
 aaf
@@ -26817,7 +26940,7 @@ acJ
 acJ
 acJ
 aae
-aac
+ktH
 aac
 aac
 aac
@@ -27003,7 +27126,7 @@ aac
 aac
 aac
 aac
-aac
+ktH
 aae
 aag
 aaf
@@ -27034,7 +27157,7 @@ aaf
 aaf
 fYS
 aae
-aac
+ktH
 aac
 aac
 aac
@@ -27220,7 +27343,7 @@ aac
 aac
 aac
 aac
-aac
+ktH
 aae
 gFh
 aaf
@@ -27251,7 +27374,7 @@ aaf
 aaf
 fYS
 aae
-aac
+ktH
 aac
 aac
 aac
@@ -27437,7 +27560,7 @@ aac
 aac
 aac
 aac
-aac
+ktH
 aae
 gFh
 aai
@@ -27468,7 +27591,7 @@ aaf
 gkA
 fYS
 aae
-aac
+ktH
 aac
 aac
 aac
@@ -27654,7 +27777,7 @@ aac
 aac
 aac
 aac
-aac
+ktH
 aae
 gFh
 aaj
@@ -27685,7 +27808,7 @@ aaf
 aaf
 fYS
 aae
-aac
+ktH
 aac
 aad
 aad
@@ -27871,7 +27994,7 @@ aac
 aac
 aac
 aac
-aac
+ktH
 aae
 gFh
 aak
@@ -27902,7 +28025,7 @@ aaf
 aaf
 fYS
 aae
-aad
+cQC
 aad
 aad
 aad
@@ -28088,7 +28211,7 @@ aac
 aac
 aac
 aac
-aac
+ktH
 aae
 gFh
 aal
@@ -28119,7 +28242,7 @@ aaf
 aaf
 amb
 aae
-aad
+cQC
 mAi
 aad
 aad
@@ -28305,7 +28428,7 @@ aac
 aac
 aac
 aac
-aac
+ktH
 aae
 gFh
 aai
@@ -28336,7 +28459,7 @@ aaf
 aaf
 fYS
 aae
-aad
+cQC
 aad
 aac
 aac
@@ -28522,7 +28645,7 @@ aac
 aac
 aac
 aac
-aac
+ktH
 aae
 iUZ
 aaj
@@ -28553,7 +28676,7 @@ aaf
 aaf
 fYS
 aae
-aac
+ktH
 aac
 aac
 aac
@@ -28739,7 +28862,7 @@ aac
 aac
 aac
 aac
-aac
+ktH
 aae
 gFh
 aak
@@ -28770,7 +28893,7 @@ gkA
 aaf
 iFE
 aae
-aac
+ktH
 aac
 aac
 aac
@@ -28956,7 +29079,7 @@ aac
 aac
 aac
 aac
-aac
+ktH
 aae
 gFh
 aal
@@ -28987,7 +29110,7 @@ aaf
 aaf
 fYS
 aae
-aac
+ktH
 aac
 aac
 aac
@@ -29173,7 +29296,7 @@ aac
 aac
 aac
 aac
-aac
+ktH
 aae
 gFh
 aai
@@ -29204,7 +29327,7 @@ aaf
 aaf
 fYS
 aae
-aac
+ktH
 aac
 aac
 aac
@@ -29390,7 +29513,7 @@ aac
 aac
 aac
 aac
-aac
+ktH
 aae
 gFh
 aaj
@@ -29421,7 +29544,7 @@ aaf
 aaf
 fYS
 aae
-aac
+ktH
 aac
 aac
 aac
@@ -29607,7 +29730,7 @@ aac
 aac
 aac
 aac
-aac
+ktH
 aae
 gFh
 aak
@@ -29638,7 +29761,7 @@ aaf
 aaf
 fYS
 aae
-aac
+ktH
 aac
 aac
 aac
@@ -29824,7 +29947,7 @@ aac
 aac
 aac
 aac
-aac
+ktH
 aae
 gFh
 aaf
@@ -29855,7 +29978,7 @@ aaf
 aaf
 fYS
 aae
-aac
+ktH
 aac
 aeI
 aeI
@@ -30041,7 +30164,7 @@ aac
 aac
 aac
 aac
-aac
+ktH
 aae
 aag
 aam
@@ -30072,7 +30195,7 @@ aam
 aam
 ago
 aae
-aac
+ktH
 aac
 aeI
 aeI
@@ -30258,7 +30381,7 @@ aac
 aac
 aac
 aac
-aac
+ktH
 aae
 aah
 aah
@@ -30289,7 +30412,7 @@ aah
 aah
 aaK
 aae
-aac
+ktH
 aeI
 aeI
 aeI
@@ -30475,7 +30598,7 @@ aac
 aac
 aac
 aac
-aac
+ktH
 aae
 aah
 aah
@@ -30506,7 +30629,7 @@ aah
 aah
 aaK
 aae
-ahO
+cyL
 aeI
 aeI
 aeI
@@ -30692,7 +30815,7 @@ aac
 aac
 aac
 aac
-aac
+ktH
 aae
 aah
 aah
@@ -30723,7 +30846,7 @@ aah
 aah
 aaK
 aae
-ahP
+rBN
 ahO
 aeI
 aeI
@@ -30909,7 +31032,7 @@ aac
 aac
 aac
 aac
-aac
+ktH
 aae
 aah
 adL
@@ -30940,7 +31063,7 @@ aah
 aah
 wQg
 aae
-ahQ
+lPV
 ahP
 ahO
 aeI
@@ -31126,7 +31249,7 @@ aac
 aac
 aac
 aac
-aac
+ktH
 aae
 aae
 aae
@@ -31157,7 +31280,7 @@ aah
 aah
 aaK
 aae
-ahR
+tkR
 ahP
 ahP
 ahO
@@ -31343,10 +31466,10 @@ hzx
 hzx
 hzx
 hzx
-hkk
-hkk
-hkk
-hkk
+eRn
+eRn
+eRn
+nOm
 aae
 aah
 aah
@@ -31374,7 +31497,7 @@ aah
 aah
 agq
 ahe
-ahQ
+lPV
 aiw
 aiw
 aiw
@@ -31563,7 +31686,7 @@ aac
 aad
 aad
 aad
-hkk
+nOm
 aae
 aaq
 aaK
@@ -31780,7 +31903,7 @@ aad
 aad
 aad
 aad
-hkk
+nOm
 aae
 abR
 aaK
@@ -31808,7 +31931,7 @@ aah
 aah
 ags
 aam
-ahT
+hXl
 aiy
 aiy
 ajx
@@ -31997,7 +32120,7 @@ aad
 aad
 aad
 aad
-hzx
+bXE
 aae
 aaw
 aaM
@@ -32214,7 +32337,7 @@ aad
 aad
 aad
 aad
-hzx
+bXE
 aae
 aax
 aaM
@@ -32242,7 +32365,7 @@ aah
 aah
 rkk
 aae
-ahT
+hXl
 ahP
 ahP
 ajy
@@ -32431,7 +32554,7 @@ aad
 aad
 aad
 aad
-hzx
+bXE
 aae
 aay
 aaO
@@ -32459,7 +32582,7 @@ aah
 aah
 agv
 aae
-ahV
+hwL
 ahV
 ahP
 ajy
@@ -32648,7 +32771,7 @@ aad
 aad
 aad
 aac
-hzx
+bXE
 aae
 aaB
 aaO
@@ -32865,7 +32988,7 @@ aad
 aad
 aad
 aac
-hzx
+bXE
 aae
 aaB
 aaP
@@ -32893,7 +33016,7 @@ aah
 afM
 agw
 agv
-ahX
+bQc
 ahX
 aiA
 ajy
@@ -33082,7 +33205,7 @@ aad
 aad
 aac
 aac
-hzx
+bXE
 aae
 aaA
 aaO
@@ -33299,7 +33422,7 @@ aad
 aad
 aac
 aac
-hzx
+bXE
 aae
 aaO
 aaO
@@ -33327,7 +33450,7 @@ aah
 aah
 afM
 agw
-aeI
+fNY
 ahX
 aiA
 ajy
@@ -33516,7 +33639,7 @@ aad
 aad
 aac
 aac
-hzx
+bXE
 aae
 aaC
 aaQ
@@ -33733,7 +33856,7 @@ aad
 aad
 aac
 aac
-hzx
+bXE
 aae
 aae
 aae
@@ -33761,7 +33884,7 @@ aah
 aah
 afM
 ahh
-ahX
+bQc
 aeI
 aiA
 ajy
@@ -33950,16 +34073,16 @@ aad
 aad
 aad
 aac
-hzx
-hzx
-hzx
-hzx
-hzx
-hzx
-hzx
-hzx
-hzx
-hzx
+eTT
+eTT
+eTT
+eTT
+eTT
+eTT
+eTT
+eTT
+eTT
+bXE
 aae
 aae
 aae
@@ -33978,7 +34101,7 @@ aae
 aae
 aae
 vwf
-ahX
+bQc
 aeI
 aiA
 ajz
@@ -34176,26 +34299,26 @@ aac
 aac
 aac
 aac
-aac
-hzx
-hzx
-hzx
-hzx
-hzx
-hzx
-hzx
-hzx
-hzx
-hzx
-hkk
-hkk
-hzx
-aac
-aac
-aac
-aac
-aac
-aeI
+pOZ
+eTT
+eTT
+eTT
+eTT
+eTT
+eTT
+eTT
+eTT
+eTT
+eTT
+eRn
+eRn
+eTT
+pOZ
+pOZ
+pOZ
+pOZ
+pOZ
+jsp
 aeI
 aiA
 ajy

--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -62,15 +62,11 @@
 	},
 /turf/open/floor/plating,
 /area/bigredv2/outside/space_port)
-"aar" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/asteroidfloor,
-/area/bigredv2/outside/telecomm)
 "aas" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/asteroidfloor,
-/area/bigredv2/outside/telecomm)
+/area/bigredv2/outside/space_port)
 "aat" = (
 /obj/machinery/landinglight/ds1{
 	dir = 4
@@ -118,9 +114,6 @@
 /obj/effect/spawner/random/tool,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/space_port)
-"aaD" = (
-/turf/open/floor/plating/asteroidplating,
-/area/bigredv2/outside/telecomm)
 "aaE" = (
 /obj/machinery/landinglight/ds1/delayone{
 	dir = 4
@@ -471,12 +464,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/lambda_lab)
-"abP" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/asteroidfloor,
-/area/bigredv2/outside/telecomm)
 "abQ" = (
 /obj/machinery/light{
 	dir = 8
@@ -735,10 +722,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/marshal_office)
-"acH" = (
-/obj/structure/cable,
-/turf/open/floor/asteroidfloor,
-/area/bigredv2/outside/telecomm)
 "acJ" = (
 /obj/structure/cable,
 /turf/open/floor/asteroidfloor,
@@ -1733,6 +1716,7 @@
 /area/bigredv2/outside/marshal_office)
 "ago" = (
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/marking/asteroidwarning{
 	dir = 6
 	},
@@ -1948,17 +1932,6 @@
 /obj/effect/alien/weeds/node,
 /turf/open/floor/tile/white,
 /area/bigredv2/caves/lambda_lab)
-"ahc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/asteroidfloor,
-/area/bigredv2/outside/telecomm)
-"ahd" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/asteroidfloor,
-/area/bigredv2/outside/telecomm)
 "ahe" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 8
@@ -2116,10 +2089,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/lambda_lab)
-"ahN" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall,
-/area/bigredv2/outside/telecomm)
 "ahO" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 10
@@ -2138,9 +2107,6 @@
 /area/bigredv2/outside/nw)
 "ahS" = (
 /obj/structure/cable,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
 /turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/nw)
 "ahT" = (
@@ -2150,9 +2116,6 @@
 /area/bigredv2/outside/nw)
 "ahU" = (
 /obj/structure/solaris_sign,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
 /turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/nw)
 "ahV" = (
@@ -2163,9 +2126,6 @@
 "ahW" = (
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/nw)
 "ahX" = (
@@ -2176,18 +2136,12 @@
 /obj/item/stack/sheet/metal,
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/nw)
 "ahZ" = (
 /obj/item/stack/rods,
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/nw)
 "aia" = (
@@ -2284,11 +2238,6 @@
 	},
 /turf/open/floor/tile/white,
 /area/bigredv2/caves/lambda_lab)
-"aiv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall,
-/area/bigredv2/outside/telecomm)
 "aiw" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 8
@@ -3084,9 +3033,6 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
-"all" = (
-/turf/open/floor/marking/asteroidwarning,
-/area/bigredv2/outside/telecomm)
 "alm" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -3206,14 +3152,8 @@
 	},
 /area/bigredv2/caves/northeast)
 "alH" = (
-/obj/structure/window/framed/colony,
-/obj/machinery/door/poddoor/shutters/mainship{
-	dir = 2;
-	id = "tcomms";
-	name = "\improper Telecommunications Shutters"
-	},
-/turf/open/floor/plating,
-/area/bigredv2/outside/telecomm)
+/turf/open/floor/marking/asteroidwarning,
+/area/bigredv2/outside/space_port)
 "alI" = (
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 10
@@ -3303,7 +3243,8 @@
 /area/bigredv2/outside/nw)
 "amb" = (
 /obj/structure/sign/safety/hazard,
-/turf/open/floor/asteroidfloor,
+/obj/structure/cable,
+/turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/space_port)
 "amc" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -3447,10 +3388,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/marshal_office)
-"amw" = (
-/obj/structure/sign/safety/hazard,
-/turf/open/floor/marking/asteroidwarning,
-/area/bigredv2/outside/telecomm)
 "amx" = (
 /obj/structure/window/framed/colony,
 /obj/machinery/door/poddoor/shutters/mainship{
@@ -15931,12 +15868,6 @@
 	},
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/c)
-"biy" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/bigredv2/outside/nw)
 "biz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/marking/asteroidwarning{
@@ -20758,12 +20689,6 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/grimy,
 /area/bigredv2/outside/marshal_office)
-"dTN" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/bigredv2/outside/nw)
 "dWa" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -20924,13 +20849,6 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/cargo)
-"flA" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/bigredv2/caves/northwest)
 "fmD" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -20961,6 +20879,13 @@
 	dir = 1
 	},
 /area/shuttle/drop2/lz2)
+"fyt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/asteroidfloor,
+/area/bigredv2/outside/space_port)
 "fAx" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -21001,6 +20926,11 @@
 /obj/structure/sign/safety/breakroom,
 /turf/closed/wall,
 /area/bigredv2/outside/engineering)
+"fVb" = (
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/asteroidfloor,
+/area/bigredv2/outside/space_port)
 "fVM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -21017,10 +20947,23 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
+"fYS" = (
+/obj/structure/cable,
+/turf/open/floor/marking/asteroidwarning,
+/area/bigredv2/outside/space_port)
 "gel" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/west)
+"geQ" = (
+/obj/machinery/door/poddoor/shutters/mainship{
+	dir = 2;
+	id = "tcomms";
+	name = "\improper Telecommunications Shutters"
+	},
+/obj/structure/window/framed/colony,
+/turf/open/floor/plating,
+/area/bigredv2/outside/telecomm)
 "ggp" = (
 /obj/machinery/button/door/open_only/landing_zone,
 /obj/structure/window/reinforced,
@@ -21047,6 +20990,10 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/general_offices)
+"gkA" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/asteroidfloor,
+/area/bigredv2/outside/space_port)
 "gnu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -21064,7 +21011,7 @@
 /area/bigredv2/outside/w)
 "gva" = (
 /turf/closed/wall/r_wall,
-/area/bigredv2/outside/sw)
+/area/shuttle/drop2/lz2)
 "gxC" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
@@ -21078,6 +21025,11 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/north)
+"gFh" = (
+/turf/open/floor/marking/asteroidwarning{
+	dir = 1
+	},
+/area/bigredv2/outside/space_port)
 "gMM" = (
 /obj/structure/cable,
 /turf/open/floor/marking/asteroidwarning{
@@ -21236,11 +21188,24 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor,
 /area/bigredv2/outside/office_complex)
+"iFE" = (
+/obj/structure/cable,
+/obj/machinery/light,
+/turf/open/floor/marking/asteroidwarning,
+/area/bigredv2/outside/space_port)
 "iNt" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"iUZ" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/marking/asteroidwarning{
+	dir = 1
+	},
+/area/bigredv2/outside/space_port)
 "iWB" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -21249,6 +21214,12 @@
 	dir = 4
 	},
 /area/bigredv2/outside/s)
+"iXG" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/asteroidfloor,
+/area/bigredv2/outside/space_port)
 "jcs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -21285,28 +21256,20 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/se)
-"jCY" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 4
-	},
-/area/bigredv2/outside/nw)
 "jDW" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/bigredv2/outside/sw)
-"jHL" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/closed/mineral/bigred,
-/area/bigredv2/caves/northwest)
 "jKb" = (
 /obj/structure/sign/safety/blast_door,
 /turf/open/floor/tile/dark/purple2/corner{
 	dir = 4
 	},
 /area/bigredv2/caves/lambda_lab)
+"jLQ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/marking/asteroidwarning,
+/area/bigredv2/outside/space_port)
 "jMC" = (
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/west)
@@ -21376,13 +21339,6 @@
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/northeast)
-"kmK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/bigredv2/outside/nw)
 "knF" = (
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/outside/engineering)
@@ -21394,12 +21350,6 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/outside/s)
-"kvs" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
-/turf/closed/mineral/bigred,
-/area/bigredv2/caves/northwest)
 "kvX" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -21413,12 +21363,6 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/bigredv2/outside/s)
-"kDL" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/mars/random/cave/rock,
-/area/bigredv2/caves/northwest)
 "kEl" = (
 /obj/structure/largecrate/random,
 /turf/open/floor/marking/bot,
@@ -21462,6 +21406,10 @@
 	},
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/medical)
+"len" = (
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating/dmg1,
+/area/bigredv2/outside/space_port)
 "liu" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral/bigred,
@@ -21579,14 +21527,6 @@
 /obj/effect/alien/weeds/node,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/east)
-"mqM" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
-/turf/open/floor/marking/asteroidwarning{
-	dir = 10
-	},
-/area/bigredv2/outside/nw)
 "msI" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -21715,11 +21655,6 @@
 "nSc" = (
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/w)
-"nTD" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/bigredv2/caves/northwest)
 "nTN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
@@ -21748,12 +21683,6 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/w)
-"oqE" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
-/turf/open/floor/marking/asteroidwarning,
-/area/bigredv2/outside/nw)
 "orX" = (
 /obj/machinery/light{
 	dir = 4
@@ -21855,11 +21784,6 @@
 	dir = 8
 	},
 /area/bigredv2/caves/lambda_lab)
-"pck" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/closed/mineral/bigred,
-/area/bigredv2/caves/northwest)
 "pmR" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/elevatorshaft,
@@ -21896,12 +21820,6 @@
 /obj/structure/mineral_door/resin,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/southeast)
-"pKv" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/bigredv2/caves/northwest)
 "pQK" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 8
@@ -22094,6 +22012,10 @@
 	dir = 8
 	},
 /area/bigredv2/outside/virology)
+"rkk" = (
+/obj/machinery/light,
+/turf/open/floor/plating,
+/area/bigredv2/outside/space_port)
 "rvh" = (
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/lambda_lab)
@@ -22221,14 +22143,6 @@
 "tku" = (
 /turf/closed/wall/indestructible/mineral,
 /area/storage/testroom)
-"tmH" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 10
-	},
-/area/bigredv2/outside/nw)
 "tnm" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -22415,6 +22329,10 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/outside/s)
+"vbs" = (
+/obj/structure/sign/safety/hazard,
+/turf/open/floor/marking/asteroidwarning,
+/area/bigredv2/outside/space_port)
 "veE" = (
 /obj/structure/table,
 /obj/effect/spawner/random/toolbox,
@@ -22442,6 +22360,9 @@
 	dir = 8
 	},
 /area/bigredv2/outside/w)
+"vwf" = (
+/turf/closed/mineral/bigred,
+/area/bigredv2/outside/space_port)
 "vAP" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/asteroidfloor,
@@ -22471,13 +22392,6 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/south)
-"vPO" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
-/turf/closed/mineral/bigred,
-/area/bigredv2/caves/northwest)
 "vTU" = (
 /obj/effect/alien/weeds/node,
 /turf/open/ground/jungle/clear,
@@ -22508,6 +22422,10 @@
 /obj/effect/alien/weeds/node,
 /turf/open/floor/tile/darkish,
 /area/bigredv2/caves/lambda_lab)
+"wgk" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/mineral/bigred,
+/area/bigredv2/caves/northwest)
 "wmv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -22545,20 +22463,24 @@
 	dir = 1
 	},
 /area/bigredv2/outside/c)
-"wDh" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
-/turf/open/floor/marking/asteroidwarning{
-	dir = 6
-	},
-/area/bigredv2/outside/nw)
 "wFG" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
 	},
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/virology)
+"wQg" = (
+/obj/structure/cable,
+/obj/machinery/light,
+/turf/open/floor/plating,
+/area/bigredv2/outside/space_port)
+"wQP" = (
+/obj/structure/cable,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/asteroidfloor,
+/area/bigredv2/outside/space_port)
 "wUc" = (
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 1
@@ -22676,6 +22598,13 @@
 /obj/effect/alien/weeds/node,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/east)
+"xQm" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/asteroidfloor,
+/area/bigredv2/outside/space_port)
 "xRR" = (
 /obj/machinery/light{
 	dir = 1
@@ -23185,23 +23114,23 @@ aac
 aac
 aac
 aac
-kvs
-jHL
-jHL
-jHL
-jHL
-jHL
-jHL
-jHL
-jHL
-jHL
-jHL
-jHL
-jHL
-jHL
-jHL
-jHL
-kvs
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aac
 aac
 aac
@@ -23402,23 +23331,23 @@ aac
 aac
 aac
 aac
-kvs
-acA
-acA
-acA
-acA
-acA
-acA
-acA
-acA
-acA
-acA
-acA
-acA
-acA
-acA
-acA
-kvs
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aac
 aac
 aac
@@ -23619,23 +23548,23 @@ aac
 aac
 aac
 aac
-kvs
-acA
-aas
-aas
-aas
-aas
-aas
-aas
-aas
-aas
-aas
-aas
-aas
-aas
-aas
-acA
-kvs
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aac
 aac
 aac
@@ -23836,23 +23765,23 @@ aac
 aac
 aac
 aac
-kvs
-acA
-aas
-aas
-aas
-aas
-aas
-aas
-aas
-aas
-aas
-aas
-aas
-aas
-aas
-acA
-kvs
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aac
 aac
 aac
@@ -24053,23 +23982,23 @@ aac
 aac
 aac
 aac
-kvs
-acA
-aas
-aas
-acQ
-acQ
-acQ
-acQ
-acQ
-acQ
-acQ
-acQ
-acQ
-ahc
-aas
-ahN
-kvs
+aac
+aac
+aac
+aac
+aac
+wgk
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aac
 aac
 aac
@@ -24266,27 +24195,27 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-kvs
 acA
-aas
-aas
-acQ
-acY
-adq
-adH
-aea
-aeB
-ade
-afI
-acQ
-aas
-aas
-aiv
-kvs
+acA
+acA
+acA
+acA
+acA
+acA
+acA
+acA
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aac
+aac
+aac
 aac
 aac
 aac
@@ -24483,27 +24412,27 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-kvs
 acA
-aas
-aas
+acY
+adq
+adH
+aea
+aeB
+ade
+afI
 acQ
-acZ
-ade
-ade
-aeb
-aeC
-ade
-adc
-alH
-ahd
-ahd
-acA
-kvs
+gkA
+aaf
+aaf
+xQm
+aaf
+aaf
+aaf
+aaf
+aae
+aac
+aac
+aac
 aac
 aac
 aac
@@ -24700,33 +24629,33 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-kvs
 acA
-aas
-aas
-acQ
-ada
+acZ
 ade
 ade
+aeb
+aeC
 ade
-ade
-afc
-ade
+adc
+geQ
+gkA
+aaf
+aaf
+aaf
+aaf
+aaf
+aaf
 alH
-ahd
-ahd
-acA
-jHL
-jHL
-jHL
-jHL
-jHL
-jHL
-kvs
+aae
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aac
 aac
 aac
@@ -24917,34 +24846,34 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-kvs
 acA
-aas
-aas
-acQ
 ada
-adr
 ade
 ade
 ade
-adr
-afJ
-alH
-aas
-aas
-acA
-acA
-acA
-acA
-acA
-ahN
-acA
-kDL
+ade
+afc
+ade
+geQ
+aaf
+aaf
+aaf
+aaf
+aaf
+gkA
+aaf
+vbs
+aae
 mAi
+aad
+aac
+aac
+aac
+aac
+aac
+aad
+aad
+aad
 aad
 aad
 aad
@@ -25134,33 +25063,33 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-kvs
 acA
-aas
-aas
-acQ
-acQ
-acQ
-acQ
-aec
-acQ
-acQ
-acQ
-acQ
-aas
-aas
-aas
-ahd
-ahd
-ahd
-ahd
-amw
-acA
-pKv
+ada
+adr
+ade
+ade
+ade
+adr
+afJ
+geQ
+gkA
+aaf
+aaf
+aaf
+aaf
+aaf
+aaf
+alH
+aae
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
 aad
 aad
 mAi
@@ -25341,43 +25270,43 @@ aac
 aac
 aac
 aac
-kvs
-jHL
-jHL
-jHL
-jHL
-jHL
-jHL
-jHL
-jHL
-jHL
-jHL
-jHL
-jHL
-jHL
-kvs
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 acA
-aas
-aas
 acQ
-adb
-ads
-adf
-aed
-ade
-abs
-afK
 acQ
-aas
-aas
-ahd
-ahd
-aas
-ahd
-ahd
-all
-acA
-pKv
+acQ
+aec
+acQ
+acQ
+acQ
+acQ
+fyt
+aaf
+aaf
+gkA
+aaf
+aaf
+aaf
+jLQ
+aae
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
 aad
 aad
 aad
@@ -25558,43 +25487,43 @@ aac
 aac
 aac
 aac
-kvs
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aae
+aae
+aae
 acA
-acA
-acA
-acA
-acA
-acA
-acA
-acA
-acA
-acA
-acA
-acA
-acA
-acA
-acA
-aas
-aas
-acQ
-adc
-adt
-adt
-adt
+adb
+ads
+adf
+aed
 ade
-aeE
-acZ
+abs
+afK
+acQ
+aaf
+aaf
+aaf
+aaf
+aaf
+aaf
+aaf
 alH
-ahd
-ahd
-aas
-aas
-aas
-aas
-aas
-all
-acA
-pKv
+aae
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
 aad
 aad
 aad
@@ -25775,43 +25704,43 @@ aac
 aac
 aac
 aac
-kvs
-acA
-aar
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aae
+abQ
 aas
-aas
-aas
-aas
-aar
-aas
-aas
-aas
-aas
-aas
-aas
-aar
-aas
-aas
-acH
-acR
+acQ
+adc
+adt
+adt
+adt
+ade
 aeE
-adu
-adu
-adu
-aeE
-aeE
-afL
-alH
-aas
-aas
-aas
-aas
-aas
-ahd
-aas
-all
-acA
-pKv
+acZ
+geQ
+aaf
+aaf
+aaf
+aaf
+aaf
+aaf
+aaf
+vbs
+aae
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
 aad
 aad
 aad
@@ -25992,43 +25921,43 @@ aac
 aac
 aac
 aac
-kvs
-acA
-aas
-aaD
-ahd
-aas
-aas
-aas
-aas
-aas
-aas
-aas
-aas
-aas
-aas
-aas
-aas
-acH
-acQ
-ade
-ade
-ade
-adt
-ade
-ade
-acZ
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aae
+aaf
+acJ
+acR
+aeE
+adu
+adu
+adu
+aeE
+aeE
+afL
+geQ
+aaf
+aaf
+aaf
+aaf
+aaf
+gkA
+aaf
 alH
-aas
-ahd
-ahd
-aas
-aas
-ahd
-aas
-all
-acA
-kvs
+aae
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aad
 aad
 aad
@@ -26206,47 +26135,47 @@ aac
 aac
 aac
 aac
-kvs
-jHL
-jHL
-kvs
-acA
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aae
+aaf
 aas
-aas
-aas
-aas
-aas
-aas
-aas
-aas
-aas
-aas
-aas
-aas
-aas
-aas
-aas
-acH
 acQ
-adf
-adv
-adI
-aef
 ade
 ade
-afL
-acQ
-aas
-ahd
-ahd
-aas
-aas
-ahd
-aas
-amw
-acA
-kvs
-aad
+ade
+adt
+ade
+ade
+acZ
+geQ
+aaf
+gkA
+aaf
+aaf
+aaf
+aaf
+aaf
+aaf
+aae
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aad
 aad
 aad
@@ -26423,46 +26352,46 @@ aac
 aac
 aac
 aac
-kvs
+aac
 aae
 aae
 aae
-acA
-aas
-aas
-aas
-aas
-aas
-aas
-aas
-aas
-abP
-aas
-aas
-aas
-aas
-aas
-aas
-acH
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aaf
+acJ
 acQ
+adf
+adv
+adI
+aef
+ade
+ade
+afL
 acQ
-acQ
-acQ
-acQ
-acQ
-acQ
-acQ
-acQ
-acA
-ahN
-acA
-acA
-acA
-acA
-acA
-acA
-acA
-kvs
+aaf
+aaf
+aaf
+aaf
+aaf
+aaf
+aaf
+aaf
+aae
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aac
 aac
 aad
@@ -26640,46 +26569,46 @@ aac
 aac
 aac
 aac
-kvs
+aac
 aae
 aaf
 aaf
 aaf
 aaf
 aaf
+iXG
 aaf
 aaf
 aaf
-aaf
-aaf
-abC
-aae
-abZ
-aaf
-aaf
-aaf
-aaf
-aaf
+gkA
 acJ
-abQ
+acQ
+acQ
+acQ
+acQ
+acQ
+acQ
+acQ
+acQ
+acQ
+aaf
+aaf
+gkA
 aaf
 aaf
 aaf
 aaf
-aaf
-aaf
-aaf
-aaf
+fVb
 aae
-jHL
-jHL
-jHL
-jHL
-jHL
-jHL
-jHL
-jHL
-kvs
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aac
 aac
 aad
@@ -26857,27 +26786,27 @@ aac
 aac
 aac
 aac
-kvs
+aac
 aae
 aaf
 aaf
+gkA
 aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-abQ
-aaf
-aaf
-aaf
+abC
+aae
+abZ
 aaf
 aaf
 aaf
 acJ
+acJ
+acJ
+acJ
+acJ
+wQP
+acJ
+acJ
+aas
 acJ
 acJ
 acJ
@@ -26888,7 +26817,7 @@ acJ
 acJ
 acJ
 aae
-kvs
+aac
 aac
 aac
 aac
@@ -27074,13 +27003,24 @@ aac
 aac
 aac
 aac
-kvs
+aac
 aae
 aag
 aaf
 aaf
 aaf
 aaf
+abQ
+aaf
+aaf
+aaf
+aaf
+aaf
+aaf
+aaf
+aag
+aaf
+aaf
 aaf
 aaf
 aaf
@@ -27092,20 +27032,9 @@ aaf
 aag
 aaf
 aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aag
-aaf
-aaf
-acJ
+fYS
 aae
-kvs
+aac
 aac
 aac
 aac
@@ -27291,9 +27220,9 @@ aac
 aac
 aac
 aac
-kvs
+aac
 aae
-aaf
+gFh
 aaf
 aba
 aat
@@ -27320,9 +27249,9 @@ aaf
 aaf
 aaf
 aaf
-acJ
+fYS
 aae
-kvs
+aac
 aac
 aac
 aac
@@ -27508,9 +27437,9 @@ aac
 aac
 aac
 aac
-kvs
+aac
 aae
-aaf
+gFh
 aai
 aao
 aao
@@ -27536,10 +27465,10 @@ aao
 aeh
 aaf
 aaf
-aaf
-acJ
+gkA
+fYS
 aae
-kvs
+aac
 aac
 aac
 aac
@@ -27725,9 +27654,9 @@ aac
 aac
 aac
 aac
-kvs
+aac
 aae
-aaf
+gFh
 aaj
 aao
 aao
@@ -27754,9 +27683,9 @@ aei
 aaf
 aaf
 aaf
-acJ
+fYS
 aae
-kvs
+aac
 aac
 aad
 aad
@@ -27942,9 +27871,9 @@ aac
 aac
 aac
 aac
-kvs
+aac
 aae
-aaf
+gFh
 aak
 aao
 aao
@@ -27971,9 +27900,9 @@ aej
 aaf
 aaf
 aaf
-acJ
+fYS
 aae
-pKv
+aad
 aad
 aad
 aad
@@ -28038,7 +27967,7 @@ aQy
 wFG
 yhx
 yhx
-oXG
+yhx
 oXG
 oXG
 oXG
@@ -28159,9 +28088,9 @@ aac
 aac
 aac
 aac
-kvs
+aac
 aae
-aaf
+gFh
 aal
 aao
 aao
@@ -28190,7 +28119,7 @@ aaf
 aaf
 amb
 aae
-pKv
+aad
 mAi
 aad
 aad
@@ -28253,8 +28182,8 @@ dcO
 aMz
 aMz
 wFG
-aMz
-oXG
+yhx
+yhx
 oXG
 oXG
 oXG
@@ -28376,9 +28305,9 @@ aac
 aac
 aac
 aac
-kvs
+aac
 aae
-aaf
+gFh
 aai
 aao
 aao
@@ -28405,9 +28334,9 @@ aeh
 aaf
 aaf
 aaf
-acJ
+fYS
 aae
-pKv
+aad
 aad
 aac
 aac
@@ -28470,8 +28399,8 @@ aRF
 aNc
 bco
 vpv
-aMz
-oXG
+yhx
+yhx
 oXG
 oXG
 oXG
@@ -28593,9 +28522,9 @@ aac
 aac
 aac
 aac
-kvs
+aac
 aae
-aaf
+iUZ
 aaj
 aao
 aao
@@ -28622,9 +28551,9 @@ aei
 aaf
 aaf
 aaf
-acJ
+fYS
 aae
-kvs
+aac
 aac
 aac
 aac
@@ -28687,7 +28616,7 @@ aNc
 aNc
 aNc
 vpv
-aMz
+yhx
 oXG
 oXG
 oXG
@@ -28810,9 +28739,9 @@ aac
 aac
 aac
 aac
-kvs
+aac
 aae
-aaf
+gFh
 aak
 aao
 aao
@@ -28837,11 +28766,11 @@ aao
 aao
 aej
 aaf
+gkA
 aaf
-aaf
-acJ
+iFE
 aae
-kvs
+aac
 aac
 aac
 aac
@@ -29027,9 +28956,9 @@ aac
 aac
 aac
 aac
-kvs
+aac
 aae
-aaf
+gFh
 aal
 aao
 aao
@@ -29056,9 +28985,9 @@ aek
 aaf
 aaf
 aaf
-acJ
+fYS
 aae
-kvs
+aac
 aac
 aac
 aac
@@ -29244,9 +29173,9 @@ aac
 aac
 aac
 aac
-kvs
+aac
 aae
-aaf
+gFh
 aai
 aao
 aao
@@ -29273,9 +29202,9 @@ aeh
 aaf
 aaf
 aaf
-acJ
+fYS
 aae
-kvs
+aac
 aac
 aac
 aac
@@ -29461,9 +29390,9 @@ aac
 aac
 aac
 aac
-kvs
+aac
 aae
-aaf
+gFh
 aaj
 aao
 aao
@@ -29490,9 +29419,9 @@ aei
 aaf
 aaf
 aaf
-acJ
+fYS
 aae
-kvs
+aac
 aac
 aac
 aac
@@ -29678,9 +29607,9 @@ aac
 aac
 aac
 aac
-kvs
+aac
 aae
-aaf
+gFh
 aak
 aao
 aao
@@ -29707,9 +29636,9 @@ aej
 aaf
 aaf
 aaf
-acJ
+fYS
 aae
-kvs
+aac
 aac
 aac
 aac
@@ -29895,9 +29824,9 @@ aac
 aac
 aac
 aac
-kvs
+aac
 aae
-aaf
+gFh
 aaf
 aap
 aav
@@ -29924,9 +29853,9 @@ aaf
 aaf
 aaf
 aaf
-acJ
+fYS
 aae
-kvs
+aac
 aac
 aeI
 aeI
@@ -30112,7 +30041,7 @@ aac
 aac
 aac
 aac
-kvs
+aac
 aae
 aag
 aam
@@ -30143,8 +30072,8 @@ aam
 aam
 ago
 aae
-biy
-aeI
+aac
+aac
 aeI
 aeI
 aeI
@@ -30329,7 +30258,7 @@ aac
 aac
 aac
 aac
-kvs
+aac
 aae
 aah
 aah
@@ -30360,7 +30289,7 @@ aah
 aah
 aaK
 aae
-biy
+aac
 aeI
 aeI
 aeI
@@ -30546,7 +30475,7 @@ aac
 aac
 aac
 aac
-kvs
+aac
 aae
 aah
 aah
@@ -30577,7 +30506,7 @@ aah
 aah
 aaK
 aae
-tmH
+ahO
 aeI
 aeI
 aeI
@@ -30763,7 +30692,7 @@ aac
 aac
 aac
 aac
-kvs
+aac
 aae
 aah
 aah
@@ -30794,7 +30723,7 @@ aah
 aah
 aaK
 aae
-dTN
+ahP
 ahO
 aeI
 aeI
@@ -30980,10 +30909,10 @@ aac
 aac
 aac
 aac
-kvs
+aac
 aae
 aah
-aah
+adL
 aah
 aah
 aah
@@ -31009,9 +30938,9 @@ aah
 aah
 aah
 aah
-aaK
+wQg
 aae
-mqM
+ahQ
 ahP
 ahO
 aeI
@@ -31197,7 +31126,7 @@ aac
 aac
 aac
 aac
-pKv
+aac
 aae
 aae
 aae
@@ -31228,7 +31157,7 @@ aah
 aah
 aaK
 aae
-oqE
+ahR
 ahP
 ahP
 ahO
@@ -31413,11 +31342,11 @@ hzx
 hzx
 hzx
 hzx
+hzx
 hkk
-flA
-nTD
-nTD
-nTD
+hkk
+hkk
+hkk
 aae
 aah
 aah
@@ -31445,7 +31374,7 @@ aah
 aah
 agq
 ahe
-mqM
+ahQ
 aiw
 aiw
 aiw
@@ -31629,12 +31558,12 @@ aab
 aac
 aac
 aac
+aac
+aac
 aad
 aad
 aad
-aad
-aad
-flA
+hkk
 aae
 aaq
 aaK
@@ -31845,13 +31774,13 @@ aaa
 aab
 aac
 aac
+aac
+aac
 aad
 aad
 aad
 aad
-aad
-aad
-flA
+hkk
 aae
 abR
 aaK
@@ -31879,7 +31808,7 @@ aah
 aah
 ags
 aam
-wDh
+ahT
 aiy
 aiy
 ajx
@@ -31964,10 +31893,10 @@ hsK
 gva
 gva
 gva
-blJ
+gva
 bmi
 boD
-blJ
+gva
 qyl
 qyl
 bdJ
@@ -32062,13 +31991,13 @@ aaa
 aab
 aac
 aac
+aac
 aad
 aad
 aad
 aad
 aad
-aad
-flA
+hzx
 aae
 aaw
 aaM
@@ -32285,7 +32214,7 @@ aad
 aad
 aad
 aad
-flA
+hzx
 aae
 aax
 aaM
@@ -32311,9 +32240,9 @@ aah
 aah
 aah
 aah
-aah
+rkk
 aae
-wDh
+ahT
 ahP
 ahP
 ajy
@@ -32502,7 +32431,7 @@ aad
 aad
 aad
 aad
-flA
+hzx
 aae
 aay
 aaO
@@ -32530,7 +32459,7 @@ aah
 aah
 agv
 aae
-jCY
+ahV
 ahV
 ahP
 ajy
@@ -32614,7 +32543,7 @@ blb
 aXK
 bmd
 bmd
-bme
+bmd
 xyM
 bmi
 ekm
@@ -32718,8 +32647,8 @@ aad
 aad
 aad
 aad
-aad
-flA
+aac
+hzx
 aae
 aaB
 aaO
@@ -32831,7 +32760,7 @@ blb
 aXK
 bmd
 bmd
-bme
+bmd
 xyM
 bmi
 ekm
@@ -32935,8 +32864,8 @@ aac
 aad
 aad
 aad
-aad
-flA
+aac
+hzx
 aae
 aaB
 aaP
@@ -32964,7 +32893,7 @@ aah
 afM
 agw
 agv
-kmK
+ahX
 ahX
 aiA
 ajy
@@ -33151,9 +33080,9 @@ aac
 aad
 aad
 aad
-aad
-aad
-vPO
+aac
+aac
+hzx
 aae
 aaA
 aaO
@@ -33264,7 +33193,7 @@ bkz
 aXK
 aXK
 bmd
-bme
+bmd
 bme
 xyM
 bmi
@@ -33368,9 +33297,9 @@ aac
 aad
 aad
 aad
-aad
-aad
-vPO
+aac
+aac
+hzx
 aae
 aaO
 aaO
@@ -33398,7 +33327,7 @@ aah
 aah
 afM
 agw
-biy
+aeI
 ahX
 aiA
 ajy
@@ -33480,7 +33409,7 @@ aZw
 blb
 bld
 aXK
-bme
+bmd
 bme
 bme
 xyM
@@ -33585,9 +33514,9 @@ aac
 aad
 aad
 aad
-aad
-aad
-vPO
+aac
+aac
+hzx
 aae
 aaC
 aaQ
@@ -33613,7 +33542,7 @@ aah
 aah
 aah
 agv
-afh
+len
 agv
 ahZ
 aeI
@@ -33802,9 +33731,9 @@ aac
 aad
 aad
 aad
-aad
-aad
-vPO
+aac
+aac
+hzx
 aae
 aae
 aae
@@ -33832,7 +33761,7 @@ aah
 aah
 afM
 ahh
-kmK
+ahX
 aeI
 aiA
 ajy
@@ -34020,17 +33949,17 @@ aad
 aad
 aad
 aad
-aad
-kvs
-pck
-pck
-pck
-pck
-pck
-pck
-pck
-pck
-pck
+aac
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
 aae
 aae
 aae
@@ -34048,8 +33977,8 @@ aae
 aae
 aae
 aae
-aae
-kmK
+vwf
+ahX
 aeI
 aiA
 ajz
@@ -34247,26 +34176,26 @@ aac
 aac
 aac
 aac
-jHL
-pck
-pck
-pck
-pck
-pck
-pck
-pck
-pck
-pck
-pck
-nTD
-nTD
-pck
-jHL
-jHL
-jHL
-jHL
-jHL
-biy
+aac
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hzx
+hkk
+hkk
+hzx
+aac
+aac
+aac
+aac
+aac
+aeI
 aeI
 aiA
 ajy


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reworked Big Red's LZ1 to be more defensible.

## Why It's Good For The Game

LZ1 has a lot of walls that xenos can easily breach, this  makes the LZ a bit more defensible.

Before: https://i.imgur.com/36dYwpU.png
After: https://i.imgur.com/ZlfHClu.png

## Changelog
:cl:
tweak: Big Red LZ1 is more defensible
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
