### PR TITLE
Imaginary friends can now select from a list of approved outfits

### DIFF
--- a/code/datums/jobs/job/other.dm
+++ b/code/datums/jobs/job/other.dm
@@ -69,3 +69,19 @@
 	gloves = /obj/item/clothing/gloves/marine/officer/chief/sa
 	glasses = /obj/item/clothing/glasses/sunglasses/sa/nodrop
 	back = /obj/item/storage/backpack/marine/satchel
+
+/datum/job/spatial_agent/galaxy_red
+	outfit = /datum/outfit/job/other/spatial_agent/galaxy_red
+
+/datum/outfit/job/other/spatial_agent/galaxy_red
+	w_uniform = /obj/item/clothing/under/liaison_suit/galaxy_red
+	belt = null
+	back = null
+
+/datum/job/spatial_agent/galaxy_blue
+	outfit = /datum/outfit/job/other/spatial_agent/galaxy_blue
+
+/datum/outfit/job/other/spatial_agent/galaxy_blue
+	w_uniform = /obj/item/clothing/under/liaison_suit/galaxy_blue
+	belt = null
+	back = null

--- a/code/modules/mob/camera/imaginary_friend.dm
+++ b/code/modules/mob/camera/imaginary_friend.dm
@@ -19,6 +19,10 @@
 	var/datum/action/innate/imaginary_join/join
 	var/datum/action/innate/imaginary_hide/hide
 
+	var/list/outfit_choices = list(/datum/job/spatial_agent,
+									/datum/job/spatial_agent/galaxy_red,
+									/datum/job/spatial_agent/galaxy_blue
+									)
 
 /mob/camera/imaginary_friend/Login()
 	. = ..()
@@ -47,7 +51,8 @@
 	name = client.prefs.real_name
 	real_name = name
 	gender = client.prefs.gender
-	human_image = get_flat_human_icon(null, SSjob.GetJobType(/datum/job/spatial_agent), client.prefs)
+	var/outfit_choice = input("Choose your appearance:", "[src]") as null|anything in outfit_choices
+	human_image = get_flat_human_icon(null, SSjob.GetJobType(outfit_choice), client.prefs)
 
 
 /mob/camera/imaginary_friend/proc/Show()

--- a/code/modules/mob/camera/imaginary_friend.dm
+++ b/code/modules/mob/camera/imaginary_friend.dm
@@ -51,7 +51,7 @@
 	name = client.prefs.real_name
 	real_name = name
 	gender = client.prefs.gender
-	var/outfit_choice = input("Choose your appearance:", "[src]") as null|anything in outfit_choices
+	var/outfit_choice = input("Choose your appearance:", "[src]") as anything in outfit_choices
 	human_image = get_flat_human_icon(null, SSjob.GetJobType(outfit_choice), client.prefs)
 
 


### PR DESCRIPTION

## About The Pull Request

Imaginary Friends always looked like Spatial Agents, and nothing else.

This allows people who use that verb to have a little control over the image they present to players.

I also created two more 'outfits' that use the animated undersuits.

## Why It's Good For The Game

Allows mentors and admins to be more noticeable and customizable in their appearance when helping players.

This list is only from testing.
![image](https://user-images.githubusercontent.com/45076386/95403039-bb1a0400-08d6-11eb-99a1-2d26d32b7fa5.png)
![image](https://user-images.githubusercontent.com/45076386/95403054-c53c0280-08d6-11eb-94e8-c5a087c45624.png)


## Changelog
:cl:Hughgent
tweak: Allows Mentors and Admins to select the appearance of their imaginary friend.
/:cl:

