### PR TITLE
razorwire rebalancing (github please stop messing up)

### DIFF
--- a/code/datums/elements/egrill_element.dm
+++ b/code/datums/elements/egrill_element.dm
@@ -40,8 +40,7 @@
 
 /datum/element/egrill/proc/attack_alien(obj/source, mob/living/carbon/xenomorph/attacker)
 	SIGNAL_HANDLER
-	if(shock(source, attacker))
-		return COMPONENT_NO_ATTACK_ALIEN
+	shock(source, attacker)
 
 /datum/element/egrill/proc/shock(obj/source, mob/living/user)
 	if(!source.anchored || source.obj_integrity <= source.integrity_failure)		// anchored/destroyed grilles are never connected

--- a/code/game/objects/structures/razorwire.dm
+++ b/code/game/objects/structures/razorwire.dm
@@ -121,19 +121,14 @@
 
 	if(istype(I, /obj/item/stack/sheet/metal))
 		var/obj/item/stack/sheet/metal/metal_sheets = I
-
-		visible_message("<span class='notice'>[user] begins to repair  \the [src].</span>")
-
+		visible_message("<span class='notice'>[user] begins to repair \the [src].</span>")
 		if(!do_after(user, 2 SECONDS, TRUE, src, BUSY_ICON_FRIENDLY) || obj_integrity >= max_integrity)
 			return
-
 		if(!metal_sheets.use(1))
 			return
-
 		repair_damage(max_integrity * 0.30)
 		visible_message("<span class='notice'>[user] repairs \the [src].</span>")
 		update_icon()
-
 		return
 
 	if(!istype(I, /obj/item/grab))

--- a/code/game/objects/structures/razorwire.dm
+++ b/code/game/objects/structures/razorwire.dm
@@ -119,6 +119,22 @@
 /obj/structure/razorwire/attackby(obj/item/I, mob/user, params)
 	. = ..()
 
+	if(istype(I, /obj/item/stack/sheet/metal))
+		var/obj/item/stack/sheet/metal/metal_sheets = I
+
+		visible_message("<span class='notice'>[user] begins to repair  \the [src].</span>")
+
+		if(!do_after(user, 2 SECONDS, TRUE, src, BUSY_ICON_FRIENDLY) || obj_integrity >= max_integrity)
+			return
+
+		if(!metal_sheets.use(1))
+			return
+
+		repair_damage(max_integrity * 0.30)
+		visible_message("<span class='notice'>[user] repairs \the [src].</span>")
+		update_icon()
+		return
+
 	if(!istype(I, /obj/item/grab))
 		return
 	if(isxeno(user))//I am very tempted to remove this >:)

--- a/code/game/objects/structures/razorwire.dm
+++ b/code/game/objects/structures/razorwire.dm
@@ -119,18 +119,6 @@
 /obj/structure/razorwire/attackby(obj/item/I, mob/user, params)
 	. = ..()
 
-	if(istype(I, /obj/item/stack/sheet/metal))
-		var/obj/item/stack/sheet/metal/metal_sheets = I
-		visible_message("<span class='notice'>[user] begins to repair \the [src].</span>")
-		if(!do_after(user, 2 SECONDS, TRUE, src, BUSY_ICON_FRIENDLY) || obj_integrity >= max_integrity)
-			return
-		if(!metal_sheets.use(1))
-			return
-		repair_damage(max_integrity * 0.30)
-		visible_message("<span class='notice'>[user] repairs \the [src].</span>")
-		update_icon()
-		return
-
 	if(!istype(I, /obj/item/grab))
 		return
 	if(isxeno(user))//I am very tempted to remove this >:)

--- a/code/game/objects/structures/razorwire.dm
+++ b/code/game/objects/structures/razorwire.dm
@@ -133,6 +133,7 @@
 		repair_damage(max_integrity * 0.30)
 		visible_message("<span class='notice'>[user] repairs \the [src].</span>")
 		update_icon()
+
 		return
 
 	if(!istype(I, /obj/item/grab))

--- a/code/game/objects/structures/razorwire.dm
+++ b/code/game/objects/structures/razorwire.dm
@@ -119,8 +119,25 @@
 /obj/structure/razorwire/attackby(obj/item/I, mob/user, params)
 	. = ..()
 
+	if(istype(I, /obj/item/stack/sheet/metal))
+		var/obj/item/stack/sheet/metal/metal_sheets = I
+
+		visible_message("<span class='notice'>[user] begins to repair  \the [src].</span>")
+
+		if(!do_after(user, 2 SECONDS, TRUE, src, BUSY_ICON_FRIENDLY) || obj_integrity >= max_integrity)
+			return
+
+		if(!metal_sheets.use(1))
+			return
+
+		repair_damage(max_integrity * 0.30)
+		visible_message("<span class='notice'>[user] repairs \the [src].</span>")
+		update_icon()
+		return
+
 	if(!istype(I, /obj/item/grab))
 		return
+
 	if(isxeno(user))//I am very tempted to remove this >:)
 		return
 

--- a/code/game/objects/structures/razorwire.dm
+++ b/code/game/objects/structures/razorwire.dm
@@ -133,7 +133,6 @@
 
 	if(!istype(I, /obj/item/grab))
 		return
-
 	if(isxeno(user))//I am very tempted to remove this >:)
 		return
 

--- a/code/game/objects/structures/razorwire.dm
+++ b/code/game/objects/structures/razorwire.dm
@@ -163,31 +163,6 @@
 	deconstruct(TRUE)
 	return TRUE
 
-/obj/structure/razorwire/welder_act(mob/living/user, obj/item/I)
-	var/obj/item/tool/weldingtool/WT = I
-	if(!WT.remove_fuel(0, user))
-		return TRUE
-
-	if(obj_integrity >= max_integrity)
-		to_chat(user, "<span class='notice'>[src] is already fully intact.</span>")
-		return TRUE
-
-	var/delay = SKILL_TASK_TOUGH - (1 SECONDS + user.skills.getRating("engineer") * 5)
-	user.visible_message("<span class='notice'>[user] begins repairing damage to [src].</span>",
-	"<span class='notice'>You begin repairing the damage to [src].</span>")
-	playsound(loc, 'sound/items/welder2.ogg', 25, 1)
-	var/old_loc = loc
-	if(!do_after(user, delay, TRUE, src, BUSY_ICON_FRIENDLY) || old_loc != loc)
-		return TRUE
-
-	user.visible_message("<span class='notice'>[user] repairs some damage on [src].</span>",
-	"<span class='notice'>You repair [src].</span>")
-	repair_damage(100)
-	update_icon()
-	playsound(loc, 'sound/items/welder2.ogg', 25, 1)
-	return TRUE
-
-
 /obj/structure/razorwire/attack_alien(mob/living/carbon/xenomorph/M)
 	M.apply_damage(rand(RAZORWIRE_BASE_DAMAGE * RAZORWIRE_MIN_DAMAGE_MULT_LOW, RAZORWIRE_BASE_DAMAGE * RAZORWIRE_MAX_DAMAGE_MULT_LOW)) //About a third as damaging as actually entering
 	UPDATEHEALTH(M)

--- a/code/game/objects/structures/razorwire.dm
+++ b/code/game/objects/structures/razorwire.dm
@@ -164,7 +164,7 @@
 	return TRUE
 
 /obj/structure/razorwire/attack_alien(mob/living/carbon/xenomorph/M)
-	M.apply_damage(rand(RAZORWIRE_BASE_DAMAGE * RAZORWIRE_MIN_DAMAGE_MULT_LOW, RAZORWIRE_BASE_DAMAGE * RAZORWIRE_MAX_DAMAGE_MULT_LOW)) //About a third as damaging as actually entering
+	M.apply_damage(rand(RAZORWIRE_BASE_DAMAGE * RAZORWIRE_MAX_DAMAGE_MULT_LOW, RAZORWIRE_BASE_DAMAGE * RAZORWIRE_MIN_DAMAGE_MULT_MED)) //About a third as damaging as actually entering
 	UPDATEHEALTH(M)
 	update_icon()
 	SEND_SIGNAL(M, COMSIG_XENOMORPH_ATTACK_RAZORWIRE)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -59,8 +59,9 @@
 			"<span class='danger'>You feel a powerful shock course through your body!</span>", \
 			"<span class='warning'> You hear a heavy electrical crack.</span>" \
 		)
-		if(isxeno(src) && mob_size == MOB_SIZE_BIG)
-			Paralyze(4 SECONDS)
+		if(isxeno(src))
+			if(mob_size != MOB_SIZE_BIG)
+				Paralyze(4 SECONDS)
 		else
 			Paralyze(8 SECONDS)
 	else

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -393,13 +393,10 @@
 		charge_datum.do_stop_momentum()
 		return PRECRUSH_STOPPED
 	if(anchored)
-		var/charge_damage = (CHARGE_SPEED(charge_datum) * 50)  // 2.1 * 50 = 105 max damage to inflict.
-		var/sunder_factor = clamp(1 - (charger.sunder/100),0.30,0.90) // Then sunder is taken into account. if its already been hit by one acid spit, a charge will kill it without the crusher taking damage from the razorwire. 2 mature boiler globs are enough too for a charge too.
-		. = charge_damage * sunder_factor
-		if(obj_integrity > .)
-			to_chat(charger, "<span class='danger'>Our weakened exoskeleton is less effective against [src]!</span>")
+		var/charge_damage = (CHARGE_SPEED(charge_datum) * 45)  // 2.1 * 45 = 94.5 max damage to inflict.
+		. = charge_damage
 		charge_datum.speed_down(3)
-		charger.adjust_sunder(15)
+		charger.adjust_sunder(10)
 		return
 	return (CHARGE_SPEED(charge_datum) * 20) //Damage to inflict.
 

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -393,8 +393,13 @@
 		charge_datum.do_stop_momentum()
 		return PRECRUSH_STOPPED
 	if(anchored)
-		. = (CHARGE_SPEED(charge_datum) * 36) // 2.1 * 30 = 75.60 Damage to inflict. if its already been hit by one acid spit, a charge will kill it without the crusher taking damage from the razorwire. 2 mature boiler globs are enough too for a charge too.
+		var/charge_damage = (CHARGE_SPEED(charge_datum) * 50)  // 2.1 * 50 = 105 max damage to inflict.
+		var/sunder_factor = clamp(1 - (charger.sunder/100),0.30,1.00) // Then sunder is taken into account. if its already been hit by one acid spit, a charge will kill it without the crusher taking damage from the razorwire. 2 mature boiler globs are enough too for a charge too.
+		. = charge_damage * sunder_factor
+		if(obj_integrity > .)
+			to_chat(charger, "<span class='danger'>Our weakened exoskeleton is less effective against [src]!</span>")
 		charge_datum.speed_down(3)
+		charger.adjust_sunder(15)
 		return
 	return (CHARGE_SPEED(charge_datum) * 20) //Damage to inflict.
 
@@ -470,7 +475,7 @@
 /obj/structure/razorwire/post_crush_act(mob/living/carbon/xenomorph/charger, datum/action/xeno_action/ready_charge/charge_datum)
 	if(!anchored)
 		return ..()
-	razorwire_tangle(charger, RAZORWIRE_ENTANGLE_DELAY * 0.20) //entangled for only 20% as long or 1 second
+	razorwire_tangle(charger, RAZORWIRE_ENTANGLE_DELAY * 0.10) //entangled for only 10% as long or 0.5 seconds
 	charger.visible_message("<span class='danger'>The barbed wire slices into [charger]!</span>",
 	"<span class='danger'>The barbed wire slices into you!</span>", null, 5)
 	charger.Paralyze(0.5 SECONDS)

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -394,7 +394,7 @@
 		return PRECRUSH_STOPPED
 	if(anchored)
 		var/charge_damage = (CHARGE_SPEED(charge_datum) * 50)  // 2.1 * 50 = 105 max damage to inflict.
-		var/sunder_factor = clamp(1 - (charger.sunder/100),0.30,1.00) // Then sunder is taken into account. if its already been hit by one acid spit, a charge will kill it without the crusher taking damage from the razorwire. 2 mature boiler globs are enough too for a charge too.
+		var/sunder_factor = clamp(1 - (charger.sunder/100),0.30,0.90) // Then sunder is taken into account. if its already been hit by one acid spit, a charge will kill it without the crusher taking damage from the razorwire. 2 mature boiler globs are enough too for a charge too.
 		. = charge_damage * sunder_factor
 		if(obj_integrity > .)
 			to_chat(charger, "<span class='danger'>Our weakened exoskeleton is less effective against [src]!</span>")

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -393,7 +393,7 @@
 		charge_datum.do_stop_momentum()
 		return PRECRUSH_STOPPED
 	if(anchored)
-		. = (CHARGE_SPEED(charge_datum) * 35) // 2.1 * 30 = 73.5 Damage to inflict. if its already been hit by one acid spit, a charge will kill it without the crusher taking damage from the razorwire. 
+		. = (CHARGE_SPEED(charge_datum) * 36) // 2.1 * 30 = 75.60 Damage to inflict. if its already been hit by one acid spit, a charge will kill it without the crusher taking damage from the razorwire. 2 mature boiler globs are enough too for a charge too.
 		charge_datum.speed_down(3)
 		return
 	return (CHARGE_SPEED(charge_datum) * 20) //Damage to inflict.

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -393,7 +393,7 @@
 		charge_datum.do_stop_momentum()
 		return PRECRUSH_STOPPED
 	if(anchored)
-		. = (CHARGE_SPEED(charge_datum) * 30) // 2.1 * 30 = 63 Damage to inflict. if its already been hit by an acid spit, a charge will kill it without the crusher taking damage from the razorwire. 
+		. = (CHARGE_SPEED(charge_datum) * 30) // 2.1 * 30 = 63 Damage to inflict. if its already been hit by 2 acid spits, a charge will kill it without the crusher taking damage from the razorwire. 
 		charge_datum.speed_down(3)
 		return
 	return (CHARGE_SPEED(charge_datum) * 20) //Damage to inflict.

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -393,7 +393,7 @@
 		charge_datum.do_stop_momentum()
 		return PRECRUSH_STOPPED
 	if(anchored)
-		. = (CHARGE_SPEED(charge_datum) * 30) // 2.1 * 30 = 63 Damage to inflict. if its already been hit by 2 acid spits, a charge will kill it without the crusher taking damage from the razorwire. 
+		. = (CHARGE_SPEED(charge_datum) * 35) // 2.1 * 30 = 73.5 Damage to inflict. if its already been hit by one acid spit, a charge will kill it without the crusher taking damage from the razorwire. 
 		charge_datum.speed_down(3)
 		return
 	return (CHARGE_SPEED(charge_datum) * 20) //Damage to inflict.

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -393,7 +393,7 @@
 		charge_datum.do_stop_momentum()
 		return PRECRUSH_STOPPED
 	if(anchored)
-		. = (CHARGE_SPEED(charge_datum) * 50) //Damage to inflict. 3 rams, 2 times taking damage.
+		. = (CHARGE_SPEED(charge_datum) * 30) // 2.1 * 30 = 63 Damage to inflict. if its already been hit by an acid spit, a charge will kill it without the crusher taking damage from the razorwire. 
 		charge_datum.speed_down(3)
 		return
 	return (CHARGE_SPEED(charge_datum) * 20) //Damage to inflict.


### PR DESCRIPTION
## About The Pull Request

this PR makes razorwire effective again, with crushers at max speed dealing 94.5 damage BEFORE any effects from the razorwire are applied, meaning that one acid spit from a spitter or praetorian hits this then the crusher charges, it will destroy the razorwire without consequences to the crusher. Razorwire cannot be repaired at all, and you can now attack it even if electrified. It deals a bit more damage to compensate for the non electrifying and non repairing.  

## Why It's Good For The Game

this makes razorwire usuable again, but without the inability to do its main function. Marines now have to use metal to maintain a razorwire shield effectively. There is no BS weld repairing infinity. Better hope its in good enough shape and when it breaks repair it fast.

## Changelog
:cl:
del: Removed the ability to repair razorwire with a welder
balance: crushers at full charge now deal 94.5 damage to razorwire, instead of 105. The razorwire still has 100 health.
balance: you can now attack razorwire even when it is electrified.
balance: you take a bit more damage from sharp parts of the razorwire when attacking, now you take 24 to 32 damage instead of 16 to 24 damage.
balance: one spit from a spitter or praetorian or 2 mature boiler acid globs are enough to allow a crusher to charge through it
balance: big xenos do not get stunned when attacking electrified razorwire, other xenos now get stunned for only 4 seconds, down from 8.
/:cl:
