### PR TITLE
rens vendor heavy armament changes

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -514,17 +514,12 @@
 	wrenchable = FALSE
 	tokensupport = TOKEN_ENGI
 
-	products = list(
-					/obj/item/coin/marine/engineer = 1,
-					)
 	contraband = list(/obj/item/cell/super = 1)
 
-	premium = list(
-					/obj/item/storage/box/sentry = 1,
-					/obj/item/storage/box/standard_hmg = 1
-					)
 	shared = list(
 				/obj/structure/closet/crate/mortar_ammo/mortar_kit = 1,
+				/obj/item/storage/box/sentry = 3,
+				/obj/item/storage/box/standard_hmg = 1
 				)
 	prices = list()
 


### PR DESCRIPTION

## About The Pull Request

this pr gets rid of premium engineer coins and instead makes 3 sentries, 1 hmg and 1 mortar shared across all engineers

## Why It's Good For The Game

ren told me to do this ren big brain, also this should give engineers more stuff to manage

## Changelog
:cl:
balance: engineers now have 3 sentries, 1 hmg and 1 mortar to share with each other
/:cl:
