### PR TITLE
defilers can no longer vent crawl

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/castedatum_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/castedatum_defiler.dm
@@ -32,7 +32,7 @@
 	deevolves_to = /mob/living/carbon/xenomorph/carrier
 
 	// *** Flags *** //
-	caste_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_EVOLUTION_ALLOWED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER|CASTE_CAN_VENT_CRAWL
+	caste_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_EVOLUTION_ALLOWED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER
 
 	// *** Defense *** //
 	soft_armor = list("melee" = 30, "bullet" = 25, "laser" = 15, "energy" = 30, "bomb" = XENO_BOMB_RESIST_0, "bio" = 30, "rad" = 30, "fire" = 25, "acid" = 30)


### PR DESCRIPTION


## About The Pull Request

defilers can no longer vent crawl, this will prevent them from coming out of vents and instantly spreading gas and infecting.

## Why It's Good For The Game

this is cancer, and defilers are way too powerful for this, and too large

## Changelog
:cl:
balance: defilers can no longer vent crawl
/:cl: