### PR TITLE
Reduces mining well time for ore crate generation from 5 minutes to 2 minutes

### DIFF
--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -19,7 +19,7 @@
 	///Tracks how many ticks have passed since we last added a sheet of material
 	var/add_tick = 0
 	///How many times we neeed to tick for a resource to be created, in this case this is 2* the specified amount
-	var/required_ticks = 60  //make one crate every 120
+	var/required_ticks = 70  //make one crate every 120
 	///The mineral type that's produced
 	var/mineral_produced = /obj/structure/ore_box/phoron
 	///Health for the miner we use because changing obj_integrity is apparently bad

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -19,7 +19,7 @@
 	///Tracks how many ticks have passed since we last added a sheet of material
 	var/add_tick = 0
 	///How many times we neeed to tick for a resource to be created, in this case this is 2* the specified amount
-	var/required_ticks = 70  //make one crate every 120
+	var/required_ticks = 70  //make one crate every 140 seconds
 	///The mineral type that's produced
 	var/mineral_produced = /obj/structure/ore_box/phoron
 	///Health for the miner we use because changing obj_integrity is apparently bad

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -19,7 +19,7 @@
 	///Tracks how many ticks have passed since we last added a sheet of material
 	var/add_tick = 0
 	///How many times we neeed to tick for a resource to be created, in this case this is 2* the specified amount
-	var/required_ticks = 150  //make one crate every 300 seconds
+	var/required_ticks = 60  //make one crate every 120
 	///The mineral type that's produced
 	var/mineral_produced = /obj/structure/ore_box/phoron
 	///Health for the miner we use because changing obj_integrity is apparently bad


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
reduces the ore generation time from mining wells from 5 minutes to 2 minutes.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
marines wastes materials protecting mining wells, while they take 5 minutes to generate 20 points worth, being 20 points able to buy only 50 metal sheets, that is not even enough generally to make the cades to protect such mining well.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: reduces mining wells ore crates generation time from 5 minutes to 2 minutes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
