### PR TITLE
Distress Nuke Win Condition

### DIFF
--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -6008,7 +6008,7 @@
 /area/bigredv2/caves/lambda_lab)
 "avp" = (
 /obj/machinery/light,
-/obj/effect/landmark/nuke_spawn,
+/obj/machinery/nuclearbomb,
 /turf/open/floor/tile/dark/purple2/corner{
 	dir = 4
 	},

--- a/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -750,7 +750,7 @@
 	},
 /area/ice_colony/exterior/surface/landing_pad2)
 "adp" = (
-/obj/effect/landmark/nuke_spawn,
+/obj/machinery/nuclearbomb,
 /turf/open/shuttle/dropship/three,
 /area/ice_colony/underground/responsehangar)
 "adq" = (

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -309,7 +309,7 @@
 /area/lv624/lazarus/medbay)
 "abC" = (
 /obj/structure/cable,
-/obj/effect/landmark/nuke_spawn,
+/obj/machinery/nuclearbomb,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/secure_storage)
 "abD" = (

--- a/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
+++ b/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
@@ -12708,7 +12708,6 @@
 /area/magmoor/medical/lobby)
 "jtH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/nuke_spawn,
 /obj/effect/decal/warning_stripes,
 /turf/open/floor/mainship/mono,
 /area/magmoor/security/storage)

--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -14,7 +14,7 @@
 	},
 /area/prison/security/checkpoint/maxsec_highsec)
 "aad" = (
-/obj/effect/landmark/nuke_spawn,
+/obj/machinery/nuclearbomb,
 /turf/open/floor/plating/platebot,
 /area/prison/pirate)
 "acD" = (

--- a/_maps/map_files/Research_Outpost/Research_Outpost.dmm
+++ b/_maps/map_files/Research_Outpost/Research_Outpost.dmm
@@ -1517,7 +1517,7 @@
 	},
 /area/outpost/medbay/storage)
 "iq" = (
-/obj/effect/landmark/nuke_spawn,
+/obj/machinery/nuclearbomb,
 /turf/open/floor/tile/dark/red2{
 	dir = 1
 	},

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -27,7 +27,7 @@
 /area/lv624/lazarus/console)
 "ag" = (
 /obj/effect/decal/cleanable/blood/xeno,
-/obj/effect/landmark/nuke_spawn,
+/obj/machinery/nuclearbomb,
 /turf/open/floor/plating/dmg3,
 /area/icy_caves/caves/crashed_ship)
 "ah" = (

--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -320,7 +320,7 @@
 
 /datum/game_mode/infestation/distress/proc/on_nuclear_explosion(datum/source, z_level)
 	SIGNAL_HANDLER
-	planet_nuked = CRASH_NUKE_INPROGRESS
+	planet_nuked = CRASH_NUKE_INPROGRESS  //to do: other conditions for nuke blowing up on the ship somehow
 	INVOKE_ASYNC(src, .proc/play_cinematic, z_level)
 
 /datum/game_mode/infestation/distress/proc/on_nuke_started(obj/machinery/nuclearbomb/nuke)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Groundmaps now always have a nuke spawn in.
Win conditions for setting the nuke off.

## Why It's Good For The Game

Marines need a new win condition besides "kill da xenos". This should also encourage more pushes towards objectives (disks and nuke), and provides a way to kill xenos without chasing them down in the caves.

## Changelog
:cl:
add: New win condition for distress: Set off the nuke!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
