### PR TITLE
Add distance check for mobs crawling

### DIFF
--- a/code/game/objects/effects/acid_hole.dm
+++ b/code/game/objects/effects/acid_hole.dm
@@ -63,6 +63,10 @@
 
 	if(user.mob_size == MOB_SIZE_BIG || user.incapacitated() || user.lying_angle || user.buckled || user.anchored)
 		return
+	
+	var/dist = get_dist(user, src)
+	if(dist > 1)
+		return
 
 	var/mob_dir = get_dir(user, src)
 	var/crawl_dir = dir & mob_dir

--- a/code/game/objects/effects/acid_hole.dm
+++ b/code/game/objects/effects/acid_hole.dm
@@ -63,9 +63,8 @@
 
 	if(user.mob_size == MOB_SIZE_BIG || user.incapacitated() || user.lying_angle || user.buckled || user.anchored)
 		return
-	
-	var/dist = get_dist(user, src)
-	if(dist > 1)
+
+	if(!user.CanReach(src))
 		return
 
 	var/mob_dir = get_dir(user, src)


### PR DESCRIPTION
## About The Pull Request

This distance check _should_ close #5006, where mobs were not checked on their distance from an acid hole, allowing them to practically teleport to the hole, crawling through it. This was tested on a local copy.

## Why It's Good For The Game

Xenos cannot break the laws of physics, and it's exploitable.

## Changelog
:cl:
fix: Fixed issue where mobs can crawl through acid holes at any distance
/:cl:
