### PR TITLE
Bulletproof vest var changes in armor.dm

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -124,8 +124,8 @@
 	siemens_coefficient = 0.7
 	permeability_coefficient = 0.9
 	time_to_unequip = 30
-    time_to_equip = 45
-  allowed = list(/obj/item/weapon/gun/,
+   time_to_equip = 45
+    allowed = list(/obj/item/weapon/gun/,
     /obj/item/storage/large_holster/machete)
 
 /obj/item/clothing/suit/armor/riot

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -126,7 +126,6 @@
 	time_to_unequip = 30
 	time_to_equip = 45
     allowed = list(/obj/item/weapon/gun/,
-		/obj/item/flashlight,
 		/obj/item/storage/large_holster/machete)
 
 /obj/item/clothing/suit/armor/riot

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -126,7 +126,7 @@
 	time_to_unequip = 30
   time_to_equip = 45
   allowed = list(/obj/item/weapon/gun/,
-       /obj/item/storage/large_holster/machete)
+      /obj/item/storage/large_holster/machete)
 
 /obj/item/clothing/suit/armor/riot
 	name = "riot suit"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -126,7 +126,7 @@
 	time_to_unequip = 30
   time_to_equip = 45
   allowed = list(/obj/item/weapon/gun/,
-    /obj/item/storage/large_holster/machete)
+       /obj/item/storage/large_holster/machete)
 
 /obj/item/clothing/suit/armor/riot
 	name = "riot suit"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -124,8 +124,8 @@
 	siemens_coefficient = 0.7
 	permeability_coefficient = 0.9
 	time_to_unequip = 30
-   time_to_equip = 45
-    allowed = list(/obj/item/weapon/gun/,
+  time_to_equip = 45
+  allowed = list(/obj/item/weapon/gun/,
     /obj/item/storage/large_holster/machete)
 
 /obj/item/clothing/suit/armor/riot

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -124,9 +124,9 @@
 	siemens_coefficient = 0.7
 	permeability_coefficient = 0.9
 	time_to_unequip = 30
-	time_to_equip = 45
-    allowed = list(/obj/item/weapon/gun/,
-		/obj/item/storage/large_holster/machete)
+    time_to_equip = 45
+  allowed = list(/obj/item/weapon/gun/,
+    /obj/item/storage/large_holster/machete)
 
 /obj/item/clothing/suit/armor/riot
 	name = "riot suit"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -120,11 +120,11 @@
 	item_state = "bulletproof"
 	blood_overlay_type = "armor"
 	flags_armor_protection = CHEST
-	soft_armor = list("melee" = 20, "bullet" = 50, "laser" = 25, "energy" = 10, "bomb" = 15, "bio" = 0, "rad" = 0, "fire" = 10, "acid" = 10)
+	soft_armor = list("melee" = 35, "bullet" = 95, "laser" = 0, "energy" = 0, "bomb" = 60, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 15)
 	siemens_coefficient = 0.7
 	permeability_coefficient = 0.9
-	time_to_unequip = 20
-	time_to_equip = 20
+	time_to_unequip = 30
+	time_to_equip = 45
 
 /obj/item/clothing/suit/armor/riot
 	name = "riot suit"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -124,9 +124,11 @@
 	siemens_coefficient = 0.7
 	permeability_coefficient = 0.9
 	time_to_unequip = 30
-  time_to_equip = 45
-  allowed = list(/obj/item/weapon/gun/,
-      /obj/item/storage/large_holster/machete)
+    time_to_equip = 45
+	allowed = list (
+		/obj/item/flashlight,
+		/obj/item/storage/large_holster/machete
+	)
 
 /obj/item/clothing/suit/armor/riot
 	name = "riot suit"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -125,6 +125,9 @@
 	permeability_coefficient = 0.9
 	time_to_unequip = 30
 	time_to_equip = 45
+    allowed = list(/obj/item/weapon/gun/,
+		/obj/item/flashlight,
+		/obj/item/storage/large_holster/machete)
 
 /obj/item/clothing/suit/armor/riot
 	name = "riot suit"


### PR DESCRIPTION
Now this vest stopping bullets for real, no shrapnel up to 10x27mm should now pass now thru the vest I guess. 

Some protection added against what it would stop irl, when applied only to the chest; some explosions and meele attacks.

![image](https://user-images.githubusercontent.com/68795324/96185640-df16be80-0f42-11eb-8599-92e79b85bf65.png)

Before 9mm(!) pistol, SMG or assault rifle could leave you shrapnel and cause you problems. Fixed. Vest still protects only chest group, limbs receiving same damage as before. Increased bomb resist, minorly increased meele-acid attacks, as it would've stopped them irl. Fire-energy-laser protection turned down to zero, time-equip increased in twice.