### PR TITLE
armor.dm changes in bulletproof vest variables

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -120,10 +120,11 @@
 	item_state = "bulletproof"
 	blood_overlay_type = "armor"
 	flags_armor_protection = CHEST
-	soft_armor = list("melee" = 30, "bullet" = 95, "laser" = 0, "energy" = 0, "bomb" = 60, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 15)
+	soft_armor = list("melee" = 30, "bullet" = 55, "laser" = 0, "energy" = 0, "bomb" = 30, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 15)
+	hard_armor = list("melee" = 0, "bullet" = 20, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 5)
 	siemens_coefficient = 0.7
 	permeability_coefficient = 0.9
-	time_to_unequip = 30
+	time_to_unequip = 20
 	time_to_equip = 45
 	allowed = list (
 		/obj/item/flashlight,

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -120,11 +120,11 @@
 	item_state = "bulletproof"
 	blood_overlay_type = "armor"
 	flags_armor_protection = CHEST
-	soft_armor = list("melee" = 20, "bullet" = 50, "laser" = 25, "energy" = 10, "bomb" = 15, "bio" = 0, "rad" = 0, "fire" = 10, "acid" = 10)
+	soft_armor = list("melee" = 30, "bullet" = 95, "laser" = 0, "energy" = 0, "bomb" = 60, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 15)
 	siemens_coefficient = 0.7
 	permeability_coefficient = 0.9
-	time_to_unequip = 20
-	time_to_equip = 20
+	time_to_unequip = 30
+	time_to_equip = 45
 
 /obj/item/clothing/suit/armor/riot
 	name = "riot suit"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -125,6 +125,10 @@
 	permeability_coefficient = 0.9
 	time_to_unequip = 30
 	time_to_equip = 45
+	allowed = list (
+		/obj/item/flashlight,
+		/obj/item/storage/large_holster/machete
+	)
 
 /obj/item/clothing/suit/armor/riot
 	name = "riot suit"


### PR DESCRIPTION
## About The Pull Request

Now this vest stopping bullets for real, no shrapnel up to 10x27mm should now pass now thru the vest I guess.

## Why It's Good For The Game

Some protection added against what it would stop irl, when applied only to the chest; some explosions and meele attacks. Before 9mm(!) pistol, SMG or assault rifle could leave you shrapnel and cause you problems. Fixed. Vest still protects only chest group, limbs receiving same damage as before. Increased bomb resist, minorly increased meele-acid attacks, as it would've stopped them irl. Fire-energy-laser protection turned down to zero, time-equip increased in twice.

![image](https://user-images.githubusercontent.com/68795324/96190024-31a7a900-0f4a-11eb-98e2-b39333d42404.png)

## Changelog
:cl:
tweak: increased meele, acid, bullet and bomb protection
balance: fire, laser and energy protection decreased to zero
fix: now vest should stop shrapnel up to 10x27mm ammo, now can equip shrapnel or flashlight on the vest slot
/:cl:
