### PR TITLE
SD Cinematic Fix

### DIFF
--- a/code/controllers/subsystem/evacuation.dm
+++ b/code/controllers/subsystem/evacuation.dm
@@ -178,7 +178,7 @@ SUBSYSTEM_DEF(evacuation)
 
 	var/f = SSmapping.levels_by_trait(ZTRAIT_MARINE_MAIN_SHIP)
 	if(f in z_levels)
-		ship_intact = FALSE
+		ship_intact = TRUE
 
 	for(var/x in GLOB.player_list)
 		var/mob/M = x


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
ship_intact = TRUE

## Why It's Good For The Game

The proper cinematic should play for blowing the self-destruct on the ship.

## Changelog
:cl:
fix: Self destruct cinematic should now show the ship blowing up
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
