### PR TITLE
Adds a  distance limit to how close resin can be built near the Landing Zones

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -166,6 +166,11 @@
 		to_chat(X, "<span class='warning'>We can only shape on weeds. We must find some resin before we start building!</span>")
 		return fail_activate()
 
+	var/obj/machinery/door/poddoor/timed_late/containment/shutter = locate(/obj/machinery/door/poddoor/timed_late/containment) in range(8, owner.loc)
+	if(!shutter?.density)
+		to_chat(owner,"<span class='xenonotice'>You cannot build so close to the strange material.</span>")
+		return fail_activate()
+
 	if(!T.check_alien_construction(X, planned_building = X.selected_resin))
 		return fail_activate()
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -167,7 +167,7 @@
 		return fail_activate()
 
 	var/obj/machinery/door/poddoor/timed_late/containment/shutter = locate(/obj/machinery/door/poddoor/timed_late/containment) in range(8, owner.loc)
-	if(!shutter?.density)
+	if(shutter?.density)
 		to_chat(owner,"<span class='xenonotice'>You cannot build so close to the strange material.</span>")
 		return fail_activate()
 


### PR DESCRIPTION

## About The Pull Request

This PR adds a 8 (maybe 9) tile distance limit to how close xenos can spam walls near the LZ containment shutters.

## Why It's Good For The Game

This is a request made by Ren, and is designed to stop xeno wall spam or at least alleviate it to a degree.

## Changelog
:cl:
balance: added an area of 8 or 9 tiles away from the LZ containment shutters so that xenos cannot build any resin structures (WALLS) there
/:cl: