### PR TITLE
Fixes a bug allowing xenos to expand holes in walls from a distance

### DIFF
--- a/code/game/objects/effects/acid_hole.dm
+++ b/code/game/objects/effects/acid_hole.dm
@@ -44,6 +44,8 @@
 /obj/effect/acid_hole/specialclick(mob/living/carbon/user)
 	if(!isxeno(user))
 		return
+	if(!user.CanReach(src))
+		return
 	if(holed_wall)
 		if(user.mob_size == MOB_SIZE_BIG)
 			expand_hole(user)
@@ -62,9 +64,6 @@
 /obj/effect/acid_hole/proc/use_wall_hole(mob/user)
 
 	if(user.mob_size == MOB_SIZE_BIG || user.incapacitated() || user.lying_angle || user.buckled || user.anchored)
-		return
-
-	if(!user.CanReach(src))
 		return
 
 	var/mob_dir = get_dir(user, src)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Moves a `user.CanReach()` check to a spot earlier in the logic so it applies to all ctrl+click actions and not just crawling through.

Probably would have been included in #5028, but I think the author wanted to confirm their partial measure didn't cause other issues first.

## Why It's Good For The Game

Exploitable bug bad. Fix Good.

## Changelog
:cl:
fix: Fixed a bug allowing xenos to expand holes in walls from a distance.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
