### PR TITLE
hivemind now has a 30 second cooldown on weeding

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -90,7 +90,7 @@
 	return TRUE
 
 /datum/action/xeno_action/plant_weeds/slow
-	cooldown_timer = 12 SECONDS
+	cooldown_timer = 30 SECONDS
 
 // Choose Resin
 /datum/action/xeno_action/choose_resin


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Hivemind makes weed attrition literally impossible because of the 12 second cooldown on weeds overtime. Other than it being annoying and nearly impossible to get rid of as marine then it shouldn't be effectively free weeds all game<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Nobody really likes playing against hivemind, its just annoying to play against and is literally an invisible drone you can't do anything against
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:

balance: hivemind now has a 30 second cooldown on weeding instead of 12

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
