### PR TITLE
Fixes the last vestige of SADAR rockets in the RR via op supplies vendor oversight

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -91,7 +91,7 @@
 					/obj/item/storage/box/nade_box/M15 = 2,
 					/obj/item/ammo_magazine/sniper = 3,
 					/obj/item/ammo_magazine/rifle/m4ra = 3,
-					/obj/item/ammo_magazine/rocket = 3,
+					/obj/item/ammo_magazine/rocket/sadar = 3,
 					/obj/item/ammo_magazine/minigun = 2,
 					/obj/item/ammo_magazine/shotgun/mbx900 = 2,
 					/obj/item/bodybag/tarp = 2,

--- a/code/modules/projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/magazines/specialist.dm
@@ -104,8 +104,8 @@ obj/item/ammo_magazine/rifle/m4ra/smart
 //M5 RPG
 
 /obj/item/ammo_magazine/rocket
-	name = "\improper 84mm high-explosive rocket"
-	desc = "A rocket tube for the T-152 rocket launcher."
+	name = "\improper generic high-explosive rocket"
+	desc = "A precursor to all kinds of rocket ammo unfit for normal use. How did you get this anyway?"
 	caliber = "rocket"
 	icon_state = "rocket"
 	w_class = WEIGHT_CLASS_NORMAL


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Remove the last reference to the plain `/obj/item/ammo_magazine/rocket` that allowed it to still be used during normal play.

Updates the description of the aforementioned base type to hopefully make it easier to avoid accidentally reintroducing it.

Related to: #4927

## Why It's Good For The Game

Cheap SADAR cheese bug bad. Fix good.

## Changelog
:cl:
fix: Operational Supplies Vendors no longer contain SADAR ammo that can be loaded in the RR.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
