### PR TITLE
allows engineers to repair three separate barricades at a time, but only 1 repair at a time per barricade

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -125,7 +125,7 @@
 	var/datum/progressbar/P = prog_bar ? new prog_bar(user, delay, progtarget, user_display, target_display) : null
 
 	user.action_busy++
-	user.actioned_list.Add(target)
+	user.do_afters[target]++
 	var/endtime = world.time + delay
 	var/starttime = world.time
 	. = TRUE
@@ -148,7 +148,7 @@
 	if(P)
 		qdel(P)
 	user.action_busy--
-	user.actioned_list.Remove(target)
+	user.do_afters -= target
 
 
 /mob/proc/do_after_coefficent() // This gets added to the delay on a do_after, default 1

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -125,6 +125,7 @@
 	var/datum/progressbar/P = prog_bar ? new prog_bar(user, delay, progtarget, user_display, target_display) : null
 
 	user.action_busy++
+	user.actioned_list.Add(target)
 	var/endtime = world.time + delay
 	var/starttime = world.time
 	. = TRUE
@@ -147,6 +148,7 @@
 	if(P)
 		qdel(P)
 	user.action_busy--
+	user.actioned_list.Remove(target)
 
 
 /mob/proc/do_after_coefficent() // This gets added to the delay on a do_after, default 1

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -455,7 +455,7 @@
 
 
 /obj/structure/barricade/metal/welder_act(mob/living/user, obj/item/I)
-	if(user.action_busy)
+	if(user.action_busy >= 3 || user.actioned_list.Find(src))
 		return FALSE
 
 	var/obj/item/tool/weldingtool/WT = I

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -455,7 +455,7 @@
 
 
 /obj/structure/barricade/metal/welder_act(mob/living/user, obj/item/I)
-	if(user.action_busy >= 3 || user.actioned_list.Find(src))
+	if(user.action_busy >= 3 || user.do_afters[src] > 0)
 		return FALSE
 
 	var/obj/item/tool/weldingtool/WT = I

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -79,7 +79,7 @@
 	var/obj/item/clothing/mask/wear_mask //Carbon
 	var/turf/listed_turf	//the current turf being examined in the stat panel
 	var/dextrous = FALSE //Has enough dexterity to interact with advanced objects?
-
+	var/list/actioned_list = list()
 	/// The machine the mob is interacting with (this is very bad old code btw)
 	var/obj/machinery/machine = null
 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -79,7 +79,9 @@
 	var/obj/item/clothing/mask/wear_mask //Carbon
 	var/turf/listed_turf	//the current turf being examined in the stat panel
 	var/dextrous = FALSE //Has enough dexterity to interact with advanced objects?
-	var/list/actioned_list = list()
+
+	///list that stores the atom targets of our current do_afters
+	var/list/do_afters = list()
 	/// The machine the mob is interacting with (this is very bad old code btw)
 	var/obj/machinery/machine = null
 


### PR DESCRIPTION


## About The Pull Request

This PR adds an actioned_list which allows for tracking of do_after targets and should lead to future usage for it, while also allowing engineers to repair 3 separate barricades, only one time each (no spam repairing). 

## Why It's Good For The Game

This will make spitter's incredibly undeescalated spit damage less effective. This does not improve repairing on anything else but metal barricades.

## Changelog
:cl:
add: Added new list in mob_defines that is used for storing action targets.
balance: welders can now repair up to 3 metal barricades, but only 1 repair action per barricade.

/:cl: