### PR TITLE
Replaces M42A ammo with T-81 auto-sniper ammo in the op supplies vendor

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -90,7 +90,7 @@
 					/obj/item/storage/box/nade_box/HIDP = 2,
 					/obj/item/storage/box/nade_box/M15 = 2,
 					/obj/item/storage/box/nade_box/plasma_drain_gas = 2,
-					/obj/item/ammo_magazine/sniper = 3,
+					/obj/item/ammo_magazine/rifle/autosniper = 3,
 					/obj/item/ammo_magazine/rifle/m4ra = 3,
 					/obj/item/ammo_magazine/rocket = 3,
 					/obj/item/ammo_magazine/minigun = 2,


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes **/obj/item/ammo_magazine/sniper** -> **/obj/item/ammo_magazine/rifle/autosniper** keeping quantity the same.

As requested by `MJP#4043` and `Mr. Skeltal#6852`

## Why It's Good For The Game

This probably more useful ammo in this vendor is good (I think). If you disagree tell us why.

## Changelog
:cl:
tweak: Replaced M42A ammo with T-81 auto-sniper ammo in the op supplies vendor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
