### PR TITLE
Fixes an early return suppressing keybinding/up() - Shift examine stuck begone

### DIFF
--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -80,8 +80,7 @@
 			keys_held[i] = null
 			break
 
-	if(keys_held[_key])
-		keys_held -= _key
+	keys_held -= _key
 	var/movement = movement_keys[_key]
 	if(!(next_move_dir_add & movement))
 		next_move_dir_sub |= movement

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -80,9 +80,8 @@
 			keys_held[i] = null
 			break
 
-	if(!keys_held[_key])
-		return
-	keys_held -= _key
+	if(keys_held[_key])
+		keys_held -= _key
 	var/movement = movement_keys[_key]
 	if(!(next_move_dir_add & movement))
 		next_move_dir_sub |= movement


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes an early return suppressing `/datum/keybinding/up()` procs.

Possibly relates to: #4999 

Started as a fix for a runtime error:
```
examine_kb (/datum/keybinding/mob/examine): stack trace("mob_clickon overridden. Use ov...")
...
examine_kb (/datum/keybinding/mob/examine): down(ckey (/client))
```
Which happened when the user would press shift more than once because as it turns out the verb responsible for calling the `/datum/keybinding/mob/examine/up()` function where `UnregisterSignal()` lives for examine on click, or more exactly stop examining on click when shift is released was not ever being called.

Keybinding code is pretty hot and complex, so a testmerge may be in order.

## Why It's Good For The Game

Bug bad. Fix good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Wayland/spookydonut
fix: Fixed a bug with keybinds registering signals becoming stuck on.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
