### PR TITLE
huggers now can NOT be thrown over barricades

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -53,6 +53,7 @@
 	. = ..()
 	if(stat == CONSCIOUS)
 		lifetimer = addtimer(CALLBACK(src, .proc/check_lifecycle), FACEHUGGER_DEATH, TIMER_STOPPABLE)
+	RegisterSignal(src, COMSIG_MOVABLE_PRE_THROW, .proc/check_barricade)
 
 /obj/item/clothing/mask/facehugger/Destroy()
 	. = ..()
@@ -231,6 +232,16 @@
 		HasProximity(finder)
 		return TRUE
 	return FALSE
+
+/obj/item/clothing/mask/facehugger/proc/check_barricade(datum/source, atom/target, range, thrower, spin)
+	var/mob/living/carbon/xenomorph/X = source
+	var/list/turf_between = getline(target,X)
+	for(var/turf/t in turf_between)
+		var/obj/structure/barricade/found = locate(/obj/structure/barricade) in t.loc
+		if(found)
+			if(!found.density)
+				continue
+			return COMPONENT_CANCEL_THROW
 
 /obj/item/clothing/mask/facehugger/throw_at(atom/target, range, speed)
 	. = ..()
@@ -562,6 +573,7 @@
 /obj/item/clothing/mask/facehugger/dead/Initialize()
 	. = ..()
 	update_icon()
+	UnregisterSignal(src,COMSIG_MOVABLE_PRE_THROW)
 
 #undef FACEHUGGER_DEATH
 #undef JUMP_COOLDOWN

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -234,13 +234,14 @@
 	return FALSE
 
 /obj/item/clothing/mask/facehugger/proc/check_barricade(datum/source, atom/target, range, thrower, spin)
-	var/mob/living/carbon/xenomorph/X = source
-	var/list/turf_between = getline(target,X)
-	for(var/turf/t in turf_between)
-		var/obj/structure/barricade/found = locate(/obj/structure/barricade) in t.loc
+	var/mob/living/carbon/xenomorph/X = usr
+	var/list/turf_between = getline(X,target)
+	for(var/turf/T in turf_between)
+		var/obj/structure/barricade/found = locate() in T
 		if(found)
 			if(!found.density)
 				continue
+			to_chat(usr,"<span class='danger'>The facehugger isnt able to be thrown over the barricade!</span>")
 			return COMPONENT_CANCEL_THROW
 
 /obj/item/clothing/mask/facehugger/throw_at(atom/target, range, speed)

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -241,7 +241,7 @@
 		if(found)
 			if(!found.density)
 				continue
-			to_chat(usr,"<span class='danger'>The facehugger isnt able to be thrown over the barricade!</span>")
+			to_chat(usr,"<span class='danger'>You fumble your attempted throw over the barricade!</span>")
 			return COMPONENT_CANCEL_THROW
 
 /obj/item/clothing/mask/facehugger/throw_at(atom/target, range, speed)


### PR DESCRIPTION


## About The Pull Request

This PR makes huggers unable to be thrown over barricades

## Why It's Good For The Game

Hugger spam is nearly impossible to stop because shooting 5 huggers in a second isnt practical

## Changelog
:cl:
balance: huggers can now no longer be thrown over barricades, and will drop and go idle at your feet.
/:cl:
