### PR TITLE
Bulletproof vest rebalance #3

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -120,11 +120,17 @@
 	item_state = "bulletproof"
 	blood_overlay_type = "armor"
 	flags_armor_protection = CHEST
-	soft_armor = list("melee" = 20, "bullet" = 50, "laser" = 25, "energy" = 10, "bomb" = 15, "bio" = 0, "rad" = 0, "fire" = 10, "acid" = 10)
+	soft_armor = list("melee" = 30, "bullet" = 55, "laser" = 0, "energy" = 0, "bomb" = 30, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 15)
+	hard_armor = list("melee" = 0, "bullet" = 20, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 5)
 	siemens_coefficient = 0.7
 	permeability_coefficient = 0.9
 	time_to_unequip = 20
 	time_to_equip = 20
+	allowed = list(/obj/item/weapon/gun/,
+		/obj/item/flashlight,
+		/obj/item/storage/large_holster/machete,
+		/obj/item/storage/belt/gun/m4a3,
+		/obj/item/storage/belt/gun/m44)
 
 /obj/item/clothing/suit/armor/riot
 	name = "riot suit"


### PR DESCRIPTION
## About The Pull Request

This vest will now almost stop the bullet without getting shrapnel hit due to 20 hard armor. Now it can carry machete, holsters and flashlight. 
Essentially, nothing has changed since #5030, just added carriying item ability, like guns, machetes and holsters I think.

## Why It's Good For The Game

Like, it partially protects only your torso from friendly fire bullets. 
Vest will not replace a regular exoskeleton or any other armor, since its weaker in all other parts, because protection is not parted throughout the body so, now it's balanced enough, any limb on your body can be easily torn off due to same reason.

## Changelog
:cl:
balance: hard and soft vaiables changed, bullet and meele protection increased, +5 acid armor, decreased energy, fire and laser protection to zero.
/:cl:
