### PR TITLE
Magnetic Harness now puts gun on back as well.

### DIFF
--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -169,22 +169,25 @@ should be alright.
 		var/obj/item/B = owner.belt	//if they don't have a magharness, are they wearing a harness belt?
 		if(!istype(B, /obj/item/belt_harness))
 			return FALSE
-	var/obj/item/I = owner.wear_suit
-	if(!is_type_in_list(I, list(/obj/item/clothing/suit/storage, /obj/item/clothing/suit/armor, /obj/item/clothing/suit/modular)))
-		return FALSE
 	addtimer(CALLBACK(src, .proc/harness_return, user), 0.3 SECONDS, TIMER_UNIQUE)
 	return TRUE
 
 
 /obj/item/weapon/gun/proc/harness_return(mob/living/carbon/human/user)
-	if(!isturf(loc) || QDELETED(user) || !isnull(user.s_store))
+	if(!isturf(loc) || QDELETED(user) || !isnull(user.s_store) && !isnull(user.back))
 		return
 
-	user.equip_to_slot_if_possible(src, SLOT_S_STORE)
+	user.equip_to_slot_if_possible(src, SLOT_S_STORE, TRUE, FALSE, FALSE)
 	if(user.s_store == src)
 		var/obj/item/I = user.wear_suit
 		to_chat(user, "<span class='warning'>[src] snaps into place on [I].</span>")
-	user.update_inv_s_store()
+		user.update_inv_s_store()
+		return
+	
+	user.equip_to_slot_if_possible(src, SLOT_BACK, TRUE, FALSE, FALSE)
+	if(user.back == src)
+		to_chat(user, "<span class='warning'>[src] snaps into place on your back.</span>")
+	user.update_inv_back()
 
 
 /obj/item/weapon/gun/attack_self(mob/user)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
magnetic harness on guns will also put guns on back if can't put on suit storage.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
makes mag harness more usefull for players with dual guns or more guns loadouts, and makes trading your satchel/backpack for a gun more safe.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: magnetics harnesses can now also put guns on back slot.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
