### PR TITLE
Makes carrier into a t3

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/carrier.dm
@@ -11,7 +11,7 @@
 	mob_size = MOB_SIZE_BIG
 	var/list/huggers = list()
 	var/eggs_cur = 0
-	tier = XENO_TIER_TWO
+	tier = XENO_TIER_THREE
 	upgrade = XENO_UPGRADE_ZERO
 	pixel_x = -16 //Needed for 2x2
 	old_x = -16

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/castedatum_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/castedatum_carrier.dm
@@ -6,7 +6,7 @@
 
 	caste_type_path = /mob/living/carbon/xenomorph/carrier
 
-	tier = XENO_TIER_TWO
+	tier = XENO_TIER_THREE
 	upgrade = XENO_UPGRADE_BASETYPE
 	wound_type = "carrier" //used to match appropriate wound overlays
 
@@ -30,9 +30,7 @@
 	evolution_threshold = 180
 	upgrade_threshold = 120
 
-	deevolves_to = /mob/living/carbon/xenomorph/drone
-
-	evolves_to = list(/mob/living/carbon/xenomorph/Defiler)
+	deevolves_to = /mob/living/carbon/xenomorph/hivelord
 
 	// *** Flags *** //
 	caste_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_EVOLUTION_ALLOWED|CASTE_CAN_HOLD_FACEHUGGERS|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER

--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/castedatum_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/castedatum_defiler.dm
@@ -29,7 +29,7 @@
 	// *** Evolution *** //
 	upgrade_threshold = 250
 
-	deevolves_to = /mob/living/carbon/xenomorph/carrier
+	deevolves_to = /mob/living/carbon/xenomorph/hivelord
 
 	// *** Flags *** //
 	caste_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_EVOLUTION_ALLOWED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER|CASTE_CAN_VENT_CRAWL

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
@@ -28,7 +28,7 @@
 	evolution_threshold = 80
 	upgrade_threshold = 60
 
-	evolves_to = list(/mob/living/carbon/xenomorph/shrike, /mob/living/carbon/xenomorph/queen, /mob/living/carbon/xenomorph/carrier, /mob/living/carbon/xenomorph/hivelord, /mob/living/carbon/xenomorph/hivemind)
+	evolves_to = list(/mob/living/carbon/xenomorph/shrike, /mob/living/carbon/xenomorph/queen, /mob/living/carbon/xenomorph/hivelord, /mob/living/carbon/xenomorph/hivemind)
 
 	// *** Flags *** //
 	caste_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_EVOLUTION_ALLOWED|CASTE_CAN_HOLD_FACEHUGGERS|CASTE_CAN_VENT_CRAWL|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/castedatum_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/castedatum_hivelord.dm
@@ -30,7 +30,7 @@
 
 	deevolves_to = /mob/living/carbon/xenomorph/drone
 
-	evolves_to = list(/mob/living/carbon/xenomorph/Defiler)
+	evolves_to = list(/mob/living/carbon/xenomorph/Defiler, /mob/living/carbon/xenomorph/carrier)
 
 	// *** Flags *** //
 	caste_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_EVOLUTION_ALLOWED|CASTE_CAN_HOLD_FACEHUGGERS|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER|CASTE_CAN_HOLD_JELLY


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes carrier into a t3 and does the according changes, makes defiler devo into hivelord instead of carrier.
Carrier is effectively t3 strength as it is and it shouldn't be interchangeable with a t2 slot at all in the current gameplay
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
having a death stun machine is actually a choice now
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance:carriers are t3 now

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
