### PR TITLE
Prevents huggers from being thrown over wired barricades

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
@@ -68,7 +68,6 @@
 			F.throw_at(AA, CARRIER_HUGGER_THROW_DISTANCE, CARRIER_HUGGER_THROW_SPEED)
 		X.visible_message("<span class='xenowarning'>\The [X] throws something towards \the [A]!</span>", \
 		"<span class='xenowarning'>We throw a facehugger towards \the [A]!</span>")
-		add_cooldown()
 		return succeed_activate()
 
 /mob/living/carbon/xenomorph/carrier/proc/store_hugger(obj/item/clothing/mask/facehugger/F, message = TRUE, forced = FALSE)

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
@@ -62,6 +62,7 @@
 		F.throw_at(A, CARRIER_HUGGER_THROW_DISTANCE, CARRIER_HUGGER_THROW_SPEED)
 		X.visible_message("<span class='xenowarning'>\The [X] throws something towards \the [A]!</span>", \
 		"<span class='xenowarning'>We throw a facehugger towards \the [A]!</span>")
+		add_cooldown()
 		return succeed_activate()
 
 /mob/living/carbon/xenomorph/carrier/proc/store_hugger(obj/item/clothing/mask/facehugger/F, message = TRUE, forced = FALSE)

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
@@ -45,7 +45,10 @@
 		if(istype(A, /turf/open) || istype(A, /mob/living/) || istype(A, /obj/effect/alien/weeds) || istype(A, /obj/effect/alien/resin))
 			X.dropItemToGround(F)
 			playsound(X, 'sound/effects/throw.ogg', 30, 1)
-			F.throw_at(A, CARRIER_HUGGER_THROW_DISTANCE, CARRIER_HUGGER_THROW_SPEED)
+			if(!(F.throw_at(A, CARRIER_HUGGER_THROW_DISTANCE, CARRIER_HUGGER_THROW_SPEED)))
+				var/obj/structure/barricade/B = F.find_barricade(X, A)
+				var/atom/AA = get_step(B, get_dir(B,X))
+				F.throw_at(AA, CARRIER_HUGGER_THROW_DISTANCE, CARRIER_HUGGER_THROW_SPEED)
 			X.visible_message("<span class='xenowarning'>\The [X] throws something towards \the [A]!</span>", \
 			"<span class='xenowarning'>We throw a facehugger towards \the [A]!</span>")
 		add_cooldown()
@@ -59,7 +62,10 @@
 		X.dropItemToGround(F)
 		F.go_active(TRUE)
 		playsound(X, 'sound/effects/throw.ogg', 30, TRUE)
-		F.throw_at(A, CARRIER_HUGGER_THROW_DISTANCE, CARRIER_HUGGER_THROW_SPEED)
+		if(!(F.throw_at(A, CARRIER_HUGGER_THROW_DISTANCE, CARRIER_HUGGER_THROW_SPEED)))
+			var/obj/structure/barricade/B = F.find_barricade(X, A)
+			var/atom/AA = get_step(B, get_dir(B,X))
+			F.throw_at(AA, CARRIER_HUGGER_THROW_DISTANCE, CARRIER_HUGGER_THROW_SPEED)
 		X.visible_message("<span class='xenowarning'>\The [X] throws something towards \the [A]!</span>", \
 		"<span class='xenowarning'>We throw a facehugger towards \the [A]!</span>")
 		add_cooldown()

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -241,7 +241,7 @@
 		if(found && found.is_wired)
 			if(!found.density)
 				continue
-			to_chat(usr,"<span class='danger'>You fumble your attempted throw over the barricade!</span>")
+			to_chat(usr,"<span class='danger'>You fumble your attempted throw over the [found]!</span>")
 			return COMPONENT_CANCEL_THROW
 
 /obj/item/clothing/mask/facehugger/proc/find_barricade(mob/living/carbon/xenomorph/X, atom/target)

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -53,6 +53,7 @@
 	. = ..()
 	if(stat == CONSCIOUS)
 		lifetimer = addtimer(CALLBACK(src, .proc/check_lifecycle), FACEHUGGER_DEATH, TIMER_STOPPABLE)
+	RegisterSignal(src, COMSIG_MOVABLE_PRE_THROW, .proc/check_barricade)
 
 /obj/item/clothing/mask/facehugger/Destroy()
 	. = ..()
@@ -231,6 +232,16 @@
 		HasProximity(finder)
 		return TRUE
 	return FALSE
+
+/obj/item/clothing/mask/facehugger/proc/check_barricade(datum/source, atom/target, range, thrower, spin)
+	var/mob/living/carbon/xenomorph/X = source
+	var/list/turf_between = getline(target,X)
+	for(var/turf/t in turf_between)
+		var/obj/structure/barricade/found = locate(/obj/structure/barricade) in t.loc
+		if(found)
+			if(!found.density)
+				continue
+			return COMPONENT_CANCEL_THROW
 
 /obj/item/clothing/mask/facehugger/throw_at(atom/target, range, speed)
 	. = ..()
@@ -562,6 +573,7 @@
 /obj/item/clothing/mask/facehugger/dead/Initialize()
 	. = ..()
 	update_icon()
+	UnregisterSignal(src,COMSIG_MOVABLE_PRE_THROW)
 
 #undef FACEHUGGER_DEATH
 #undef JUMP_COOLDOWN

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -234,13 +234,14 @@
 	return FALSE
 
 /obj/item/clothing/mask/facehugger/proc/check_barricade(datum/source, atom/target, range, thrower, spin)
-	var/mob/living/carbon/xenomorph/X = source
-	var/list/turf_between = getline(target,X)
-	for(var/turf/t in turf_between)
-		var/obj/structure/barricade/found = locate(/obj/structure/barricade) in t.loc
+	var/mob/living/carbon/xenomorph/X = usr
+	var/list/turf_between = getline(X,target)
+	for(var/turf/T in turf_between)
+		var/obj/structure/barricade/found = locate() in T
 		if(found)
 			if(!found.density)
 				continue
+			to_chat(usr,"<span class='danger'>The facehugger isnt able to be thrown over the barricade!</span>")
 			return COMPONENT_CANCEL_THROW
 
 /obj/item/clothing/mask/facehugger/throw_at(atom/target, range, speed)

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -238,7 +238,7 @@
 	var/list/turf_between = getline(X,target)
 	for(var/turf/T in turf_between)
 		var/obj/structure/barricade/found = locate() in T
-		if(found)
+		if(found && found.is_wired)
 			if(!found.density)
 				continue
 			to_chat(usr,"<span class='danger'>You fumble your attempted throw over the barricade!</span>")

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -244,6 +244,14 @@
 			to_chat(usr,"<span class='danger'>You fumble your attempted throw over the barricade!</span>")
 			return COMPONENT_CANCEL_THROW
 
+/obj/item/clothing/mask/facehugger/proc/find_barricade(mob/living/carbon/xenomorph/X, atom/target)
+	var/list/turf_between = getline(X,target)
+	for(var/turf/T in turf_between)
+		var/obj/structure/barricade/found = locate() in T
+		if(found)
+			return found
+	return null
+
 /obj/item/clothing/mask/facehugger/throw_at(atom/target, range, speed)
 	. = ..()
 	update_icon()

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -241,7 +241,7 @@
 		if(found)
 			if(!found.density)
 				continue
-			to_chat(usr,"<span class='danger'>The facehugger isnt able to be thrown over the barricade!</span>")
+			to_chat(usr,"<span class='danger'>You fumble your attempted throw over the barricade!</span>")
 			return COMPONENT_CANCEL_THROW
 
 /obj/item/clothing/mask/facehugger/throw_at(atom/target, range, speed)


### PR DESCRIPTION
## About The Pull Request

This PR prevents huggers from being thrown over wired barricades and will make them land infront of the barricade if they aim beyond a barricade with wire.

## Why It's Good For The Game

Being a lowpop groundside team having to constantly juggle shooting 5 huggers at a time only to miss one and lose someone is not exactly fun or balanced.

## Changelog
:cl:
balance: huggers can no longer be thrown over wired barricades
/:cl: