### PR TITLE
Hivemind weeding error grammar

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -97,7 +97,7 @@
 		return ..()
 	var/mob/living/carbon/xenomorph/hivemind/hiveminde = owner
 	hiveminde.forceMove(get_turf(hiveminde.core))
-	to_chat(hiveminde, "<span class='xenonotice'>We can't plant a node without any weeds nearby, so we got moved to our core.</span>")
+	to_chat(hiveminde, "<span class='xenonotice'>We can't plant a node without weeds nearby, we've been moved back to our core.</span>")
 	return fail_activate()
 
 // Choose Resin

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -97,7 +97,7 @@
 		return ..()
 	var/mob/living/carbon/xenomorph/hivemind/hiveminde = owner
 	hiveminde.forceMove(get_turf(hiveminde.core))
-	to_chat(hiveminde, "<span class='xenonotice'>We can't place weeds with no weeds nearby, we got moved to our core.</span>")
+	to_chat(hiveminde, "<span class='xenonotice'>We can't plant a node without any weeds nearby, so we got moved to our core.</span>")
 	return fail_activate()
 
 // Choose Resin


### PR DESCRIPTION
Redoes the hivemind weeding error message in an attempt to get it to sound somewhat better.

:cl:
spellcheck: Re-worded the error when attempting to plant a weed node without weeds nearby as the hivemind.
/:cl: