### PR TITLE
ERT can no longer metarush SD

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -60,6 +60,7 @@
 
 //Job/role helpers
 #define ismarinefaction(H) (H.faction == "TerraGov")
+#define isterragovjob(J) (istype(J, /datum/job/terragov))
 #define ismedicaljob(J) (istype(J, /datum/job/terragov/medical))
 #define isengineeringjob(J) (istype(J, /datum/job/terragov/engineering))
 #define ismarinejob(J) (istype(J, /datum/job/terragov/squad))

--- a/code/game/objects/machinery/self_destruct.dm
+++ b/code/game/objects/machinery/self_destruct.dm
@@ -41,7 +41,7 @@
 	. = ..()
 	if(!.)
 		return
-	if(marine_only_activate && !ismarinejob(user?.job))
+	if(marine_only_activate && !isterragovjob(user?.job))
 		to_chat(user, "<span class='warning'>The [src] beeps, \"Marine Retinal scan failed!\".</span>")
 		return FALSE
 	return TRUE

--- a/code/game/objects/machinery/self_destruct.dm
+++ b/code/game/objects/machinery/self_destruct.dm
@@ -42,7 +42,7 @@
 	if(!.)
 		return
 	if(marine_only_activate && !isterragovjob(user?.job))
-		to_chat(user, "<span class='warning'>The [src] beeps, \"Marine Retinal scan failed!\".</span>")
+		to_chat(user, "<span class='warning'>The [src] beeps, \"Marine retinal scan failed!\".</span>")
 		return FALSE
 	return TRUE
 

--- a/code/game/objects/machinery/self_destruct.dm
+++ b/code/game/objects/machinery/self_destruct.dm
@@ -6,6 +6,8 @@
 	resistance_flags = RESIST_ALL
 	interaction_flags = INTERACT_MACHINE_TGUI
 	var/active_state = SELF_DESTRUCT_MACHINE_INACTIVE
+	///Whether only marines can activate this. left here in case of admins feeling nice or events
+	var/marine_only_activate = TRUE
 	ui_x = 470
 	ui_y = 290
 
@@ -34,6 +36,15 @@
 	SSevacuation.dest_rods = null
 	return ..()
 
+
+/obj/machinery/self_destruct/console/can_interact(mob/living/carbon/user)
+	. = ..()
+	if(!.)
+		return
+	if(marine_only_activate && !ismarinejob(user?.job))
+		to_chat(user, "<span class='warning'>The [src] beeps, \"Marine Retinal scan failed!\".</span>")
+		return FALSE
+	return TRUE
 
 /obj/machinery/self_destruct/console/toggle(lock)
 	playsound(src, 'sound/machines/hydraulics_1.ogg', 25, 1)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Unless an admin changes it the SD button needs to be triggered by a terragov job human

## Why It's Good For The Game

Spamming ERT for them to just sneakily rush SD while xenos are away bad mkay

## Changelog
:cl:
balance: Selfdestruct can only be triggered by marines (looking at you ERT rushing Selfdestruct)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
