### PR TITLE
Fixes marine headset Cameras not toggling with Squad HUD

### DIFF
--- a/code/game/objects/items/radio/headset.dm
+++ b/code/game/objects/items/radio/headset.dm
@@ -216,6 +216,8 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 /obj/item/radio/headset/mainship/proc/enable_squadhud()
 	squadhud.add_hud_to(wearer)
 	headset_hud_on = TRUE
+	if(!camera.status)
+		camera.toggle_cam(null, FALSE)
 	if(wearer.mind && wearer.assigned_squad && !sl_direction)
 		enable_sl_direction()
 	to_chat(wearer, "<span class='notice'>You toggle the Squad HUD on.</span>")
@@ -225,6 +227,8 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 /obj/item/radio/headset/mainship/proc/disable_squadhud()
 	squadhud.remove_hud_from(wearer)
 	headset_hud_on = FALSE
+	if(camera.status)
+		camera.toggle_cam(null, FALSE)
 	if(sl_direction)
 		disable_sl_direction()
 	to_chat(wearer, "<span class='notice'>You toggle the Squad HUD off.</span>")

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -405,7 +405,7 @@
 				if(istype(H.wear_ear, /obj/item/radio/headset/mainship/marine))
 					var/obj/item/radio/headset/mainship/marine/R = H.wear_ear
 					if(R.camera.status)
-						R.camera.status = FALSE //Turn camera off.
+						R.camera.toggle_cam(null, FALSE) //Turn camera off.
 						to_chat(H, "<span class='danger'>Your headset camera flickers off; you'll need to reactivate it by rebooting your headset HUD!<span>")
 
 	if(blocked)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -183,7 +183,7 @@
 	if(istype(wear_ear, /obj/item/radio/headset/mainship/marine))
 		var/obj/item/radio/headset/mainship/marine/marine_headset = wear_ear
 		if(marine_headset.camera.status)
-			marine_headset.camera.status = FALSE //Turn camera off.
+			marine_headset.camera.toggle_cam(null, FALSE) //Turn camera off.
 			to_chat(src, "<span class='danger'>Your headset camera flickers off as you are devoured; you'll need to reactivate it by rebooting your headset HUD!<span>")
 	return ..()
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a few `camera.toggle_cam()` where appropriate.

Headset cameras now toggle off and on with the HUD, its state on initialize (like already on an ear perhaps) is unchanged.

Maybe warrants a test merge because cameras are pretty hot.

## Why It's Good For The Game

Marine gear stuck broken, and partial toggling is bad. Fix good.

## Changelog
:cl:
fix: Fixed marine headset Cameras not toggling with Squad HUD.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
