### PR TITLE
Fixes shuffle hugging part 42: the shuffle kerfuffle

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -226,6 +226,11 @@
 	if(stat == CONSCIOUS)
 		HasProximity(target)
 
+/obj/item/clothing/mask/facehugger/Uncross(atom/movable/AM)
+	. = ..()
+	if(. && stat == CONSCIOUS && isxeno(AM)) //shuffle hug prevention, if a xeno steps off go_idle()
+		go_idle()
+
 /obj/item/clothing/mask/facehugger/on_found(mob/finder)
 	if(stat == CONSCIOUS)
 		HasProximity(finder)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a call to `go_idle()` on huggers that get successfully `Uncross()` by any xeno preventing them from passing the `Crossed()` check caused by marines that makes stepped on huggers do their thing.

Uses `Uncross()` over `Uncrossed()` because the latter happens after the `Crossed()` caused by the victim. Making sure we only `go_idle()` if conscious prevents multiple calls during the myriad of checks for `Uncross()` that happen for a single move.

Closes: #5065 

## Why It's Good For The Game

Shuffle hugging is bad (even if I love it and it is hilarious), need I say more?

## Changelog
:cl:
fix: Fixed shuffle hugging.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
