### PR TITLE
replaces iron sugar with blood bag syringe case

### DIFF
--- a/code/game/objects/items/reagent_containers/blood_pack.dm
+++ b/code/game/objects/items/reagent_containers/blood_pack.dm
@@ -52,3 +52,10 @@
 	name = "Empty BloodPack"
 	desc = "Seems pretty useless... Maybe if there were a way to fill it?"
 	icon_state = "empty"
+
+/obj/item/reagent_containers/blood/OMinus/medic
+	name = "O- emergency bloodbag"
+	desc = "An emergency blood bag meant to be used by syringes to inject blood into patients that have bloodloss. Requires a regular syringe to function."
+	icon_state = "bottle"
+	volume = 100
+	init_reagent_flags = AMOUNT_ESTIMEE|DRAWABLE

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -158,6 +158,7 @@
 		/obj/item/reagent_containers/glass/bottle,
 		/obj/item/paper,
 		/obj/item/reagent_containers/syringe,
+		/obj/item/reagent_containers/blood/OMinus/medic,
 		/obj/item/reagent_containers/hypospray/autoinjector,
 	)
 
@@ -251,6 +252,15 @@
 	new /obj/item/reagent_containers/hypospray/autoinjector/combat(src)
 	new /obj/item/reagent_containers/hypospray/autoinjector/combat(src)
 
+/obj/item/storage/syringe_case/blood
+	name = "syringe case (blood)"
+	desc = "It's a medical case for storing blood bags and syringes."
+
+/obj/item/storage/syringe_case/blood/PopulateContents()
+	. = ..()
+	new /obj/item/reagent_containers/syringe(src)
+	new /obj/item/reagent_containers/blood/OMinus/medic(src)
+	new /obj/item/reagent_containers/blood/OMinus/medic(src)
 
 /*
 * Pill Bottles

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -947,7 +947,7 @@ GLOBAL_LIST_INIT(marine_selector_cats, list(
 		/obj/item/storage/syringe_case/meralyne = list(CAT_MEDSUP, "syringe Case (120u Meralyne)", 16, "orange"),
 		/obj/item/storage/syringe_case/dermaline = list(CAT_MEDSUP, "syringe Case (120u Dermaline)", 16, "orange"),
 		/obj/item/storage/syringe_case/meraderm = list(CAT_MEDSUP, "syringe Case (120u Meraderm)", 16, "orange"),
-		/obj/item/storage/syringe_case/ironsugar = list(CAT_MEDSUP, "syringe Case (120u Ironsugar)", 5, "black"),
+		/obj/item/storage/syringe_case/blood = list(CAT_MEDSUP, "syringe Case (200u Blood)", 5, "black"),
 		/obj/item/reagent_containers/hypospray/autoinjector/combat_advanced = list(CAT_MEDSUP, "Injector (Advanced)", 5, "black"),
 		/obj/item/reagent_containers/hypospray/autoinjector/oxycodone = list(CAT_MEDSUP, "Injector (Oxycodone)", 1, "black"),
 		/obj/item/reagent_containers/hypospray/autoinjector/hypervene = list(CAT_MEDSUP, "Injector (Hypervene)", 1, "black"),


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
you can inject people with blood instead of giving them pills which are pure noobtraps for medics
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
~~jpr said i'd close this~~ removes a noob trap option and replaces it with something that does the job actually decently
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added emergency drawable O- blood bags that are drawable, a syringe case that has 2, added to medic vendor
del:ironsugar from medic vendosrs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
