### PR TITLE
Adds flechettes and mr-25s/m412s to the armories in lv and big red

### DIFF
--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -1435,13 +1435,17 @@
 "afo" = (
 /obj/structure/rack,
 /obj/item/weapon/gun/revolver/cmb,
+/obj/item/ammo_magazine/revolver/cmb,
 /turf/open/floor/tile/vault{
 	dir = 8
 	},
 /area/bigredv2/outside/marshal_office)
 "afp" = (
 /obj/structure/rack,
-/obj/item/ammo_magazine/revolver/cmb,
+/obj/item/weapon/gun/smg/m25,
+/obj/item/ammo_magazine/smg/m25,
+/obj/item/ammo_magazine/smg/m25,
+/obj/item/ammo_magazine/smg/m25,
 /turf/open/floor/tile/vault{
 	dir = 8
 	},
@@ -1451,7 +1455,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/ammo_magazine/revolver/cmb,
+/obj/item/weapon/gun/rifle/m412,
+/obj/item/ammo_magazine/rifle,
+/obj/item/ammo_magazine/rifle,
+/obj/item/ammo_magazine/rifle,
 /turf/open/floor/tile/vault{
 	dir = 8
 	},
@@ -1792,6 +1799,7 @@
 /obj/item/weapon/gun/shotgun/pump/cmb,
 /obj/item/ammo_magazine/shotgun,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_magazine/shotgun/flechette,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/marshal_office)
 "agG" = (

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -11978,6 +11978,10 @@
 /obj/item/ammo_magazine/pistol/b92fs,
 /obj/item/ammo_magazine/pistol/b92fs,
 /obj/item/ammo_magazine/pistol/b92fs,
+/obj/item/weapon/gun/rifle/m412,
+/obj/item/ammo_magazine/rifle,
+/obj/item/ammo_magazine/rifle,
+/obj/item/ammo_magazine/rifle,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/security)
 "bdM" = (
@@ -14525,6 +14529,7 @@
 /obj/structure/rack,
 /obj/item/ammo_magazine/shotgun,
 /obj/item/ammo_magazine/shotgun/buckshot,
+/obj/item/ammo_magazine/shotgun/flechette,
 /turf/open/floor/plating/platebot,
 /area/lv624/lazarus/secure_storage)
 "bqe" = (


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
LV and big bread suck ass for survivor, this would help them out immensely in my opinion, and the armory on big red is a bit barren for its size, 

In total I've added 1 box of flechettes to both maps pretty sure.

I've added one M412 to the small security armory in LV because all it has is an mp5 (i might replace that with an m25 too, its more in setting really)

I've added an M25 to the LV armory and a M412 as well, 3 magazines each iirc.

I've done this because the armories literally only have shotguns which while flavorful does make it quite the same. Giving survivors a bit more option is nice.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Survivors bad for 99% of playerbase, hopefully make less bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Added M412s to LV security armory, added flechette to big red and LV, gave M412/MR25 to big red armory, they've been spending money on modernization
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
