### PR TITLE
Nerfs dead marine headset cameras by allowing xenos to disable them like lights

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -241,6 +241,15 @@
 
 /mob/living/carbon/human/attack_alien_harm(mob/living/carbon/xenomorph/X, dam_bonus, set_location = FALSE, random_location = FALSE, no_head = FALSE, no_crit = FALSE, force_intent = null)
 	if(stat == DEAD)
+		if(istype(wear_ear, /obj/item/radio/headset/mainship))
+			var/obj/item/radio/headset/mainship/cam_headset = wear_ear
+			if(cam_headset.camera.status)
+				cam_headset.camera.toggle_cam(null, FALSE)
+				playsound(loc, "alien_claw_metal", 25, 1)
+				X.do_attack_animation(src, ATTACK_EFFECT_CLAW)
+				to_chat(X, "<span class='warning'>We disable the creatures hivemind sight apparatus.</span>")
+				return FALSE
+
 		if(length(light_sources) || locate(/obj/effect/overlay/light_visible) in vis_contents)
 			playsound(loc, "alien_claw_metal", 25, 1)
 			X.do_attack_animation(src, ATTACK_EFFECT_CLAW)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds additional special attack logic to `attack_alien_harm()` so if they are dead with a headset camera enabled a slash will turn it off.

## Why It's Good For The Game

Facehuggers already do it, and so do all castes when devouring (which can not be done to dead marines (yet)) so this addresses the lack of camera sight attrition when marines die with their cams still enabled.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Xenos will now disable dead marine headset cameras when slashing just like they do with lights.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
