### PR TITLE
Removes RNG from light stick trampling for big mobs only (queen, crusher, etc..)

### DIFF
--- a/code/game/objects/items/lightstick.dm
+++ b/code/game/objects/items/lightstick.dm
@@ -11,7 +11,9 @@
 
 /obj/item/lightstick/Crossed(mob/living/L)
 	. = ..()
-	if(!anchored || !istype(L) || isxenolarva(L) || prob(80))
+	if(!anchored || !istype(L) || isxenolarva(L))
+		return
+	if(L.mob_size != MOB_SIZE_BIG && prob(80))
 		return
 	visible_message("<span class='danger'>[L] tramples the [src]!</span>")
 	playsound(src, 'sound/weapons/genhit.ogg', 25, 1)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes a `prob(80)` early return so it also requires `mob_size != MOB_SIZE_BIG` when a planted light stick is crossed.

## Why It's Good For The Game

I think it just makes sense for big mobs to bypass the 1/5 roll for smashing these things, and for xenos especially because they can not click them to uproot them like humans.

Perhaps being the size and speed of a barn could have some benefits when it comes to breaking little sticks on the ground?

## Changelog
:cl:
tweak: Big mobs will now always trample light sticks on the first crossing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
