### PR TITLE
Removes shields from Automated Armaments Vendor

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -137,7 +137,6 @@
 		/obj/item/explosive/grenade/cloakbomb = 25,
 		/obj/item/storage/box/m94 = 30,
 		/obj/item/storage/box/recoilless_system = 1,
-		/obj/item/weapon/shield/riot/marine = 3,
 	)
 
 	premium = list()


### PR DESCRIPTION
## About The Pull Request

Removes the defensive shield from all Automated Armaments Vendors that marines have at roundstart. It's still available for purchase at requisitions, for 10 credits.

## Why It's Good For The Game

No-drop shielders have literally no counter besides a humongous swarm of xenos. And marines can get up to 6 of them for free at prep. Who.... who thought this was a good idea? At least give them the valk treatment and make them purchase-only.

## Changelog
:cl:
del: Removed defensive shield from roundstart vendors/:cl: