### PR TITLE
QoL Improvements for Hivelord Tunnels

### DIFF
--- a/code/__DEFINES/atom_hud.dm
+++ b/code/__DEFINES/atom_hud.dm
@@ -21,6 +21,7 @@
 #define PAIN_HUD					"pain_hud" //displays human pain / preceived health.
 #define ARMOR_SUNDER_HUD			"armor_sunder_hud" //displays how much sunder has been applied.
 #define XENO_REAGENT_HUD            "xeno_reagent_hud" // displays sign based on reagent in human
+#define XENO_TUNNEL_HUD				"xeno_tunnel_hud" // displays xeno tunnels
 
 #define ADD_HUD_TO_COOLDOWN 20 //cooldown for being shown the images for any particular data hud
 
@@ -43,6 +44,12 @@
 #define DATA_HUD_ORDER					11
 #define DATA_HUD_AI_DETECT				12
 #define DATA_HUD_MEDICAL_PAIN			13
+#define DATA_HUD_XENO_STATUS			8
+#define DATA_HUD_SQUAD					9
+#define DATA_HUD_ORDER					10
+#define DATA_HUD_AI_DETECT				11
+#define DATA_HUD_MEDICAL_PAIN			12
+#define DATA_HUD_XENO_TUNNELS			13
 
 
 // Notification action types

--- a/code/__DEFINES/atom_hud.dm
+++ b/code/__DEFINES/atom_hud.dm
@@ -20,7 +20,7 @@
 #define AI_DETECT_HUD				"ai_detect_hud" //hud for displaying the AI eye's location
 #define PAIN_HUD					"pain_hud" //displays human pain / preceived health.
 #define ARMOR_SUNDER_HUD			"armor_sunder_hud" //displays how much sunder has been applied.
-#define XENO_REAGENT_HUD            "xeno_reagent_hud" // displays sign based on reagent in human
+#define XENO_REAGENT_HUD			"xeno_reagent_hud" // displays sign based on reagent in human
 #define XENO_TUNNEL_HUD				"xeno_tunnel_hud" // displays xeno tunnels
 
 #define ADD_HUD_TO_COOLDOWN 20 //cooldown for being shown the images for any particular data hud

--- a/code/__DEFINES/atom_hud.dm
+++ b/code/__DEFINES/atom_hud.dm
@@ -44,12 +44,7 @@
 #define DATA_HUD_ORDER					11
 #define DATA_HUD_AI_DETECT				12
 #define DATA_HUD_MEDICAL_PAIN			13
-#define DATA_HUD_XENO_STATUS			8
-#define DATA_HUD_SQUAD					9
-#define DATA_HUD_ORDER					10
-#define DATA_HUD_AI_DETECT				11
-#define DATA_HUD_MEDICAL_PAIN			12
-#define DATA_HUD_XENO_TUNNELS			13
+#define DATA_HUD_XENO_TUNNELS			14
 
 
 // Notification action types

--- a/code/datums/atom_hud.dm
+++ b/code/datums/atom_hud.dm
@@ -16,7 +16,9 @@ GLOBAL_LIST_INIT(huds, list(
 	DATA_HUD_SQUAD = new /datum/atom_hud/squad,
 	DATA_HUD_ORDER = new /datum/atom_hud/order,
 	DATA_HUD_AI_DETECT = new /datum/atom_hud/ai_detector,
-	DATA_HUD_MEDICAL_PAIN = new /datum/atom_hud/medical/pain
+	DATA_HUD_MEDICAL_PAIN = new /datum/atom_hud/medical/pain,
+	DATA_HUD_XENO_TUNNELS = new /datum/atom_hud/xeno_tunnels
+
 	))
 
 

--- a/code/datums/atom_hud.dm
+++ b/code/datums/atom_hud.dm
@@ -17,8 +17,7 @@ GLOBAL_LIST_INIT(huds, list(
 	DATA_HUD_ORDER = new /datum/atom_hud/order,
 	DATA_HUD_AI_DETECT = new /datum/atom_hud/ai_detector,
 	DATA_HUD_MEDICAL_PAIN = new /datum/atom_hud/medical/pain,
-	DATA_HUD_XENO_TUNNELS = new /datum/atom_hud/xeno_tunnels
-
+	DATA_HUD_XENO_TUNNELS = new /datum/atom_hud/xeno_tunnels,
 	))
 
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -64,8 +64,8 @@
 	var/chat_color
 	/// A luminescence-shifted value of the last color calculated for chatmessage overlays
 	var/chat_color_darkened
-
-	var/list/hud_possible //HUD images that this mob can provide.
+	///HUD images that this mob can provide.
+	var/list/hud_possible
 
 /*
 We actually care what this returns, since it can return different directives.

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -65,6 +65,7 @@
 	/// A luminescence-shifted value of the last color calculated for chatmessage overlays
 	var/chat_color_darkened
 
+	var/list/hud_possible //HUD images that this mob can provide.
 
 /*
 We actually care what this returns, since it can return different directives.
@@ -746,3 +747,10 @@ Proc for attack log creation, because really why not
 // For special click interactions (take first item out of container, quick-climb, etc.)
 /atom/proc/specialclick(mob/living/carbon/user)
 	return
+
+
+//Consolidating HUD infrastructure
+/atom/proc/prepare_huds()
+	hud_list = new
+	for(var/hud in hud_possible) //Providing huds.
+		hud_list[hud] = image('icons/mob/hud.dmi', src, "")

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -338,6 +338,9 @@
 //active reagent hud that apppears only for xenos
 /datum/atom_hud/xeno_reagents
 	hud_icons = list(XENO_REAGENT_HUD)
+//hud component for revealing tunnels to xenos
+/datum/atom_hud/xeno_tunnels
+	hud_icons = list(XENO_TUNNEL_HUD)
 
 //Xeno status hud, for xenos
 /datum/atom_hud/xeno
@@ -525,7 +528,3 @@
 		for(var/V in GLOB.aiEyes)
 			var/mob/camera/aiEye/E = V
 			E.update_ai_detect_hud()
-
-//hud component for revealing tunnels to xenos
-/datum/atom_hud/xeno_tunnels
-	hud_icons = list(XENO_TUNNEL_HUD)

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -338,6 +338,7 @@
 //active reagent hud that apppears only for xenos
 /datum/atom_hud/xeno_reagents
 	hud_icons = list(XENO_REAGENT_HUD)
+
 //hud component for revealing tunnels to xenos
 /datum/atom_hud/xeno_tunnels
 	hud_icons = list(XENO_TUNNEL_HUD)

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -339,7 +339,7 @@
 /datum/atom_hud/xeno_reagents
 	hud_icons = list(XENO_REAGENT_HUD)
 
-//hud component for revealing tunnels to xenos
+///hud component for revealing tunnels to xenos
 /datum/atom_hud/xeno_tunnels
 	hud_icons = list(XENO_TUNNEL_HUD)
 

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -525,3 +525,7 @@
 		for(var/V in GLOB.aiEyes)
 			var/mob/camera/aiEye/E = V
 			E.update_ai_detect_hud()
+
+//hud component for revealing tunnels to xenos
+/datum/atom_hud/xeno_tunnels
+	hud_icons = list(XENO_TUNNEL_HUD)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -32,8 +32,6 @@
 	///Optimization for dynamic explosion block values, for things whose explosion block is dependent on certain conditions.
 	var/real_explosion_block
 
-	var/list/hud_possible //HUD images that this mob can provide.
-
 /obj/Initialize()
 	. = ..()
 	if(islist(soft_armor))
@@ -180,8 +178,3 @@
 			setAnchored(var_value)
 			return TRUE
 	return ..()
-
-/obj/proc/prepare_huds()
-	hud_list = new
-	for(var/hud in hud_possible) //Providing huds.
-		hud_list[hud] = image('icons/mob/hud.dmi', src, "")

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -32,6 +32,7 @@
 	///Optimization for dynamic explosion block values, for things whose explosion block is dependent on certain conditions.
 	var/real_explosion_block
 
+	var/list/hud_possible //HUD images that this mob can provide.
 
 /obj/Initialize()
 	. = ..()
@@ -179,3 +180,8 @@
 			setAnchored(var_value)
 			return TRUE
 	return ..()
+
+/obj/proc/prepare_huds()
+	hud_list = new
+	for(var/hud in hud_possible) //Providing huds.
+		hud_list[hud] = image('icons/mob/hud.dmi', src, "")

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -623,7 +623,6 @@ TUNNEL
 	. = ..()
 	GLOB.xeno_tunnels += src
 	prepare_huds()
-	hud_set_xeno_tunnel()
 
 /obj/structure/tunnel/Destroy()
 	if(!QDELETED(creator))
@@ -719,15 +718,11 @@ TUNNEL
 	else
 		to_chat(M, "<span class='warning'>Our crawling was interrupted!</span>")
 
-/obj/structure/tunnel/proc/hud_set_xeno_tunnel() //called upon creation
-	var/image/holder = hud_list[XENO_TUNNEL_HUD]
-	if(!holder)
-		return
+/obj/structure/tunnel/proc/hud_set_xeno_tunnel() //called by the Dig Tunnel ability after creation; make this handy overlay exclusively visible to xenos of the same hive.
+	var/image/tunneloverlay = image('icons/mob/hud.dmi', src, "hudtraitor")
 
-	holder.icon_state = "hudtraitor"
-	holder.overlays += image('icons/mob/hud.dmi', src, "hudtraitor")
-
-	hud_list[XENO_TUNNEL_HUD] = holder
+	for(var/mob/living/carbon/xenomorph/X in creator.hive.get_all_xenos()) //Set hive specific image visibility
+		X.client.images += tunneloverlay
 
 
 //Resin Water Well

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -616,10 +616,13 @@ TUNNEL
 	max_integrity = 140
 	var/mob/living/carbon/xenomorph/hivelord/creator = null
 
+	hud_possible = list(XENO_TUNNEL_HUD)
+
+
 /obj/structure/tunnel/Initialize(mapload)
 	. = ..()
 	GLOB.xeno_tunnels += src
-
+	prepare_huds()
 
 /obj/structure/tunnel/Destroy()
 	GLOB.xeno_tunnels -= src

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -625,9 +625,15 @@ TUNNEL
 	prepare_huds()
 
 /obj/structure/tunnel/Destroy()
+	if(!QDELETED(creator))
+		to_chat(creator, "<span class='xenoannounce'>You sense your [sanitize(name)] at [tunnel_desc] has been destroyed!</span>") //Alert creator
+
+	xeno_message("<span class='xenoannounce'>Hive tunnel [sanitize(name)] at [tunnel_desc] has been destroyed!</span>", 2, creator.hivenumber) //Also alert hive because tunnels matter.
+
 	GLOB.xeno_tunnels -= src
 	if(creator)
 		creator.tunnels -= src
+
 	return ..()
 
 /obj/structure/tunnel/examine(mob/user)
@@ -711,6 +717,17 @@ TUNNEL
 			to_chat(M, "<span class='warning'>\The [src] ended unexpectedly, so we return back up.</span>")
 	else
 		to_chat(M, "<span class='warning'>Our crawling was interrupted!</span>")
+
+/obj/structure/tunnel/proc/hud_set_xeno_tunnel()
+	var/image/holder = hud_list[XENO_TUNNEL_HUD]
+	if(!holder)
+		return
+
+	holder.icon_state = "hudtraitor"
+	holder.overlays += image('icons/mob/hud.dmi', src, "hudtraitor")
+
+	hud_list[XENO_TUNNEL_HUD] = holder
+
 
 //Resin Water Well
 /obj/effect/alien/resin/acidwell

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -623,6 +623,7 @@ TUNNEL
 	. = ..()
 	GLOB.xeno_tunnels += src
 	prepare_huds()
+	hud_set_xeno_tunnel()
 
 /obj/structure/tunnel/Destroy()
 	if(!QDELETED(creator))
@@ -718,7 +719,7 @@ TUNNEL
 	else
 		to_chat(M, "<span class='warning'>Our crawling was interrupted!</span>")
 
-/obj/structure/tunnel/proc/hud_set_xeno_tunnel()
+/obj/structure/tunnel/proc/hud_set_xeno_tunnel() //called upon creation
 	var/image/holder = hud_list[XENO_TUNNEL_HUD]
 	if(!holder)
 		return

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -626,9 +626,9 @@ TUNNEL
 
 /obj/structure/tunnel/Destroy()
 	if(!QDELETED(creator))
-		to_chat(creator, "<span class='xenoannounce'>You sense your [sanitize(name)] at [tunnel_desc] has been destroyed!</span>") //Alert creator
+		to_chat(creator, "<span class='xenoannounce'>You sense your [name] at [tunnel_desc] has been destroyed!</span>") //Alert creator
 
-	xeno_message("<span class='xenoannounce'>Hive tunnel [sanitize(name)] at [tunnel_desc] has been destroyed!</span>", 2, creator.hivenumber) //Also alert hive because tunnels matter.
+	xeno_message("<span class='xenoannounce'>Hive tunnel [name] at [tunnel_desc] has been destroyed!</span>", 2, creator.hivenumber) //Also alert hive because tunnels matter.
 
 	GLOB.xeno_tunnels -= src
 	if(creator)

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -719,11 +719,8 @@ TUNNEL
 		to_chat(M, "<span class='warning'>Our crawling was interrupted!</span>")
 
 /obj/structure/tunnel/proc/hud_set_xeno_tunnel() //called by the Dig Tunnel ability after creation; make this handy overlay exclusively visible to xenos of the same hive.
-	var/image/tunneloverlay = image('icons/mob/hud.dmi', src, "hudtraitor")
-
-	for(var/mob/living/carbon/xenomorph/X in creator.hive.get_all_xenos()) //Set hive specific image visibility
-		X.client.images += tunneloverlay
-
+	var/image/holder = hud_list[XENO_TUNNEL_HUD]
+	holder.icon_state = "traitorhud"
 
 //Resin Water Well
 /obj/effect/alien/resin/acidwell

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -623,6 +623,7 @@ TUNNEL
 	. = ..()
 	GLOB.xeno_tunnels += src
 	prepare_huds()
+	hud_set_xeno_tunnel()
 
 /obj/structure/tunnel/Destroy()
 	if(!QDELETED(creator))
@@ -718,9 +719,13 @@ TUNNEL
 	else
 		to_chat(M, "<span class='warning'>Our crawling was interrupted!</span>")
 
-/obj/structure/tunnel/proc/hud_set_xeno_tunnel() //called by the Dig Tunnel ability after creation; make this handy overlay exclusively visible to xenos of the same hive.
+//Makes sure the tunnel is visible to other xenos even through obscuration.
+/obj/structure/tunnel/proc/hud_set_xeno_tunnel()
 	var/image/holder = hud_list[XENO_TUNNEL_HUD]
+	if(!holder)
+		return
 	holder.icon_state = "traitorhud"
+	hud_list[XENO_TUNNEL_HUD] = holder
 
 //Resin Water Well
 /obj/effect/alien/resin/acidwell

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -167,7 +167,6 @@ GLOBAL_LIST_INIT(thickenable_resin, typecacheof(list(
 	X.visible_message("<span class='xenonotice'>\The [X] digs out a tunnel entrance.</span>", \
 	"<span class='xenonotice'>We dig out a tunnel, connecting it to our network.</span>", null, 5)
 	var/obj/structure/tunnel/newt = new(T)
-	newt.hud_set_xeno_tunnel() //Add to HUD.
 
 	playsound(T, 'sound/weapons/pierce.ogg', 25, 1)
 
@@ -179,12 +178,13 @@ GLOBAL_LIST_INIT(thickenable_resin, typecacheof(list(
 
 	add_cooldown()
 
-	to_chat(X, "<span class='xenonotice'>We dig out a tunnel, connecting it to our hive's network. We now have [LAZYLEN(X.tunnels)] of [HIVELORD_TUNNEL_SET_LIMIT] tunnels.</span>")
+	to_chat(X, "<span class='xenonotice'>We now have [LAZYLEN(X.tunnels)] of [HIVELORD_TUNNEL_SET_LIMIT] tunnels.</span>")
 
 	var/msg = stripped_input(X, "Add a description to the tunnel:", "Tunnel Description")
 	newt.tunnel_desc = sanitize("[get_area(newt)] (X: [newt.x], Y: [newt.y]) [msg]")
 	newt.name += sanitize(" [msg]")
 
+	to_chat(X, "<span class='xenoannounce'>[sanitize(X.name)] has built a new tunnel named [newt.name] at [newt.tunnel_desc]!</span>")
 	xeno_message("<span class='xenoannounce'>[sanitize(X.name)] has built a new tunnel named [newt.name] at [newt.tunnel_desc]!</span>", 2, X.hivenumber)
 
 	if(LAZYLEN(X.tunnels) > HIVELORD_TUNNEL_SET_LIMIT) //if we exceed the limit, delete the oldest tunnel set.

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -195,15 +195,6 @@ GLOBAL_LIST_INIT(thickenable_resin, typecacheof(list(
 	succeed_activate()
 	playsound(T, 'sound/weapons/pierce.ogg', 25, 1)
 
-/obj/structure/tunnel/proc/hud_set_xeno_tunnel()
-	var/image/holder = hud_list[XENO_TUNNEL_HUD]
-	if(!holder)
-		return
-
-	holder.icon_state = "hudtraitor"
-	holder.overlays += image("icon" = 'icons/mob/hud.dmi', src, icon_state = "hudtraitor")
-
-	hud_list[XENO_TUNNEL_HUD] = holder
 
 // ***************************************
 // *********** plasma transfer

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -183,7 +183,7 @@ GLOBAL_LIST_INIT(thickenable_resin, typecacheof(list(
 
 	var/msg = stripped_input(X, "Add a description to the tunnel:", "Tunnel Description")
 	newt.tunnel_desc = sanitize("[get_area(newt)] (X: [newt.x], Y: [newt.y]) [msg]")
-	newt.name += sanitize(" [msg] at [get_area(newt)] (X: [newt.x], Y: [newt.y]) ")
+	newt.name += sanitize(" [msg]")
 
 	xeno_message("<span class='xenoannounce'>[sanitize(X.name)] has built a new tunnel named [newt.name] at [newt.tunnel_desc]!</span>", 2, X.hivenumber)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -182,10 +182,10 @@ GLOBAL_LIST_INIT(thickenable_resin, typecacheof(list(
 	to_chat(X, "<span class='xenonotice'>We now have <b>[LAZYLEN(X.tunnels)] of [HIVELORD_TUNNEL_SET_LIMIT]</b> tunnels.</span>")
 
 	var/msg = stripped_input(X, "Give your tunnel a descriptive name:", "Tunnel Name")
-	newt.tunnel_desc = sanitize("[get_area(newt)] (X: [newt.x], Y: [newt.y])")
-	newt.name += sanitize(" [msg]")
+	newt.tunnel_desc = "[get_area(newt)] (X: [newt.x], Y: [newt.y])"
+	newt.name += " [msg]"
 
-	xeno_message("<span class='xenoannounce'>[sanitize(X.name)] has built a new tunnel named [newt.name] at [newt.tunnel_desc]!</span>", 2, X.hivenumber)
+	xeno_message("<span class='xenoannounce'>[X.name] has built a new tunnel named [newt.name] at [newt.tunnel_desc]!</span>", 2, X.hivenumber)
 
 	if(LAZYLEN(X.tunnels) > HIVELORD_TUNNEL_SET_LIMIT) //if we exceed the limit, delete the oldest tunnel set.
 		var/obj/structure/tunnel/old_tunnel = X.tunnels[1]

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -181,8 +181,8 @@ GLOBAL_LIST_INIT(thickenable_resin, typecacheof(list(
 
 	to_chat(X, "<span class='xenonotice'>We now have <b>[LAZYLEN(X.tunnels)] of [HIVELORD_TUNNEL_SET_LIMIT]</b> tunnels.</span>")
 
-	var/msg = stripped_input(X, "Add a description to the tunnel:", "Tunnel Description")
-	newt.tunnel_desc = sanitize("[get_area(newt)] (X: [newt.x], Y: [newt.y]) [msg]")
+	var/msg = stripped_input(X, "Give your tunnel a descriptive name:", "Tunnel Name")
+	newt.tunnel_desc = sanitize("[get_area(newt)] (X: [newt.x], Y: [newt.y])")
 	newt.name += sanitize(" [msg]")
 
 	xeno_message("<span class='xenoannounce'>[sanitize(X.name)] has built a new tunnel named [newt.name] at [newt.tunnel_desc]!</span>", 2, X.hivenumber)

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -167,6 +167,8 @@ GLOBAL_LIST_INIT(thickenable_resin, typecacheof(list(
 	X.visible_message("<span class='xenonotice'>\The [X] digs out a tunnel entrance.</span>", \
 	"<span class='xenonotice'>We dig out a tunnel, connecting it to our network.</span>", null, 5)
 	var/obj/structure/tunnel/newt = new(T)
+	newt.hud_set_xeno_tunnel() //Add to HUD.
+
 	playsound(T, 'sound/weapons/pierce.ogg', 25, 1)
 
 
@@ -177,19 +179,31 @@ GLOBAL_LIST_INIT(thickenable_resin, typecacheof(list(
 
 	add_cooldown()
 
-	to_chat(X, "<span class='xenonotice'>We dig our tunnel to the nearest tunnel intersection, connecting it to the network. We now have [LAZYLEN(X.tunnels)] of [HIVELORD_TUNNEL_SET_LIMIT] tunnel sets.</span>")
+	to_chat(X, "<span class='xenonotice'>We dig out a tunnel, connecting it to our hive's network. We now have [LAZYLEN(X.tunnels)] of [HIVELORD_TUNNEL_SET_LIMIT] tunnels.</span>")
 
 	var/msg = stripped_input(X, "Add a description to the tunnel:", "Tunnel Description")
-	newt.tunnel_desc = "[get_area(newt)] (X: [newt.x], Y: [newt.y]) [msg]"
-	newt.name += " [msg]"
+	newt.tunnel_desc = sanitize("[get_area(newt)] (X: [newt.x], Y: [newt.y]) [msg]")
+	newt.name += sanitize(" [msg]")
+
+	xeno_message("<span class='xenoannounce'>[sanitize(X.name)] has built a new tunnel named [newt.name] at [newt.tunnel_desc]!</span>", 2, X.hivenumber)
 
 	if(LAZYLEN(X.tunnels) > HIVELORD_TUNNEL_SET_LIMIT) //if we exceed the limit, delete the oldest tunnel set.
 		var/obj/structure/tunnel/old_tunnel = X.tunnels[1]
 		old_tunnel.deconstruct(FALSE)
-		to_chat(X, "<span class='xenodanger'>Having exceeding our tunnel set limit, our oldest tunnel set has collapsed.</span>")
+		to_chat(X, "<span class='xenodanger'>Having exceeding our tunnel limit, our oldest tunnel has collapsed.</span>")
 
 	succeed_activate()
 	playsound(T, 'sound/weapons/pierce.ogg', 25, 1)
+
+/obj/structure/tunnel/proc/hud_set_xeno_tunnel()
+	var/image/holder = hud_list[XENO_TUNNEL_HUD]
+	if(!holder)
+		return
+
+	holder.icon_state = "hudtraitor"
+	holder.overlays += image("icon" = 'icons/mob/hud.dmi', src, icon_state = "hudtraitor")
+
+	hud_list[XENO_TUNNEL_HUD] = holder
 
 // ***************************************
 // *********** plasma transfer

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -173,18 +173,18 @@ GLOBAL_LIST_INIT(thickenable_resin, typecacheof(list(
 
 	newt.creator = X
 
-
 	X.tunnels.Add(newt)
 
 	add_cooldown()
 
-	to_chat(X, "<span class='xenonotice'>We now have [LAZYLEN(X.tunnels)] of [HIVELORD_TUNNEL_SET_LIMIT] tunnels.</span>")
+	newt.hud_set_xeno_tunnel()
+
+	to_chat(X, "<span class='xenonotice'>We now have <b>[LAZYLEN(X.tunnels)] of [HIVELORD_TUNNEL_SET_LIMIT]</b> tunnels.</span>")
 
 	var/msg = stripped_input(X, "Add a description to the tunnel:", "Tunnel Description")
 	newt.tunnel_desc = sanitize("[get_area(newt)] (X: [newt.x], Y: [newt.y]) [msg]")
-	newt.name += sanitize(" [msg]")
+	newt.name += sanitize(" [msg] at [get_area(newt)] (X: [newt.x], Y: [newt.y]) ")
 
-	to_chat(X, "<span class='xenoannounce'>[sanitize(X.name)] has built a new tunnel named [newt.name] at [newt.tunnel_desc]!</span>")
 	xeno_message("<span class='xenoannounce'>[sanitize(X.name)] has built a new tunnel named [newt.name] at [newt.tunnel_desc]!</span>", 2, X.hivenumber)
 
 	if(LAZYLEN(X.tunnels) > HIVELORD_TUNNEL_SET_LIMIT) //if we exceed the limit, delete the oldest tunnel set.
@@ -194,6 +194,7 @@ GLOBAL_LIST_INIT(thickenable_resin, typecacheof(list(
 
 	succeed_activate()
 	playsound(T, 'sound/weapons/pierce.ogg', 25, 1)
+
 
 
 // ***************************************

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -177,8 +177,6 @@ GLOBAL_LIST_INIT(thickenable_resin, typecacheof(list(
 
 	add_cooldown()
 
-	newt.hud_set_xeno_tunnel()
-
 	to_chat(X, "<span class='xenonotice'>We now have <b>[LAZYLEN(X.tunnels)] of [HIVELORD_TUNNEL_SET_LIMIT]</b> tunnels.</span>")
 
 	var/msg = stripped_input(X, "Give your tunnel a descriptive name:", "Tunnel Name")

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -267,6 +267,8 @@
 
 	hud_to_add = GLOB.huds[DATA_HUD_XENO_REAGENTS]
 	hud_to_add.add_hud_to(src)
+	hud_to_add = GLOB.huds[DATA_HUD_XENO_TUNNELS] //Allows us to see tunnels clearly via HUD elements
+	hud_to_add.add_hud_to(src)
 
 
 /mob/living/carbon/xenomorph/point_to_atom(atom/A, turf/T)

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -5,6 +5,40 @@
 
 	check_hive_status(src)
 
+/mob/living/carbon/xenomorph/verb/tunnel_list()
+	set name = "Tunnel List"
+	set desc = "See all currently active tunnels."
+	set category = "Alien"
+
+	check_tunnel_list(src)
+
+
+/proc/check_tunnel_list(mob/user) //Creates a handy list of all xeno tunnels
+	if(!SSticker)
+		return
+	var/dat = "<br>"
+
+	var/datum/hive_status/hive
+	if(isxeno(user))
+		var/mob/living/carbon/xenomorph/xeno_user = user
+		if(xeno_user.hive)
+			hive = xeno_user.hive
+	else
+		hive = GLOB.hive_datums[XENO_HIVE_NORMAL]
+
+	if(!hive)
+		CRASH("couldnt find a hive in check_tunnel_list")
+
+	dat += "<b>List of Hive Tunnels:</b><BR>"
+
+	for(var/obj/structure/tunnel/T in GLOB.xeno_tunnels)
+		if(T.creator.hive == hive)
+			dat += "<b>[T.name]</b> located at: <b><font color=green>([T.tunnel_desc])</b></font><BR>"
+
+	var/datum/browser/popup = new(user, "roundstatus", "<div align='center'>Tunnel List</div>", 600, 600)
+	popup.set_content(dat)
+	popup.open(FALSE)
+
 
 /proc/xeno_status_output(list/xenolist, can_overwatch = FALSE, ignore_leads = TRUE, user)
 	var/xenoinfo = ""

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -14,8 +14,6 @@
 
 
 /proc/check_tunnel_list(mob/user) //Creates a handy list of all xeno tunnels
-	if(!SSticker)
-		return
 	var/dat = "<br>"
 
 	var/datum/hive_status/hive

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -31,11 +31,22 @@
 
 	for(var/obj/structure/tunnel/T in GLOB.xeno_tunnels)
 		if(T.creator.hive == hive)
+			T.set_tunnel_overlay_for_client(user.client)
 			dat += "<b>[T.name]</b> located at: <b><font color=green>([T.tunnel_desc])</b></font><BR>"
 
 	var/datum/browser/popup = new(user, "roundstatus", "<div align='center'>Tunnel List</div>", 600, 600)
 	popup.set_content(dat)
 	popup.open(FALSE)
+
+
+/obj/structure/tunnel/proc/set_tunnel_overlay_for_client(client/C) //called by check_tunnel_list; allows clients that joined after a tunnel was created to see it
+
+	if(!C) //sanity
+		return
+
+	var/image/tunneloverlay = image('icons/mob/hud.dmi', src, "hudtraitor")
+	C.images -= tunneloverlay
+	C.images += tunneloverlay
 
 
 /proc/xeno_status_output(list/xenolist, can_overwatch = FALSE, ignore_leads = TRUE, user)

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -31,22 +31,12 @@
 
 	for(var/obj/structure/tunnel/T in GLOB.xeno_tunnels)
 		if(T.creator.hive == hive)
-			T.set_tunnel_overlay_for_client(user.client)
 			dat += "<b>[T.name]</b> located at: <b><font color=green>([T.tunnel_desc])</b></font><BR>"
 
 	var/datum/browser/popup = new(user, "roundstatus", "<div align='center'>Tunnel List</div>", 600, 600)
 	popup.set_content(dat)
 	popup.open(FALSE)
 
-
-/obj/structure/tunnel/proc/set_tunnel_overlay_for_client(client/C) //called by check_tunnel_list; allows clients that joined after a tunnel was created to see it
-
-	if(!C) //sanity
-		return
-
-	var/image/tunneloverlay = image('icons/mob/hud.dmi', src, "hudtraitor")
-	C.images -= tunneloverlay
-	C.images += tunneloverlay
 
 
 /proc/xeno_status_output(list/xenolist, can_overwatch = FALSE, ignore_leads = TRUE, user)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -103,13 +103,6 @@
 					continue
 				statpanel(listed_turf.name, null, A)
 
-
-/mob/proc/prepare_huds()
-	hud_list = new
-	for(var/hud in hud_possible) //Providing huds.
-		hud_list[hud] = image('icons/mob/hud.dmi', src, "")
-
-
 /mob/proc/show_message(msg, type, alt_msg, alt_type)
 	if(!client)
 		return

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -57,7 +57,6 @@
 	//HUD and overlays
 	var/hud_type = /datum/hud
 	var/datum/hud/hud_used
-	var/list/hud_possible //HUD images that this mob can provide.
 	var/list/progressbars //for stacking do_after bars
 	var/list/progbar_towers //for stacking the total pixel height of the aboves.
 	var/list/fullscreens = list()


### PR DESCRIPTION
## About The Pull Request

Improves QoL for the Hivelord's tunnels as follows:

1: Building a Hivelord tunnel announces its precise area and location to the hive automatically. Tunnels also now do a hive announcement on their destruction as well.

2: HUD component to allow xenos to see tunnels more easily through occlusion/obscurement; effectively allows Hivelords to more effectively hide their tunnels from ungas without hiding them from fellow Xenos (at least this should work if BYOND didn't decide to be fucktarded).

3: New tunnel list of existing hive tunnels in the Xeno tab.

Demo Pic: 
![image](https://user-images.githubusercontent.com/42553659/99161646-5f574d80-26c2-11eb-9413-eb60e1160299.png)


## Why It's Good For The Game

Makes Hivelord tunnels better to use/more useful.

## Changelog
:cl:
add: Tunnel List window that features existing hive tunnels in the Xeno tab.
tweak: Hivelord Tunnels are now auto-announced to the Hive upon creation and destruction along with their location.
fix: Minor wording fixes in light of network based tunnel mechanics that replaced the old paired tunnels.
refactor: Minor refactors; provides infrastructure for object based HUD elements.
/:cl: