### PR TITLE
Makes the General Storage Module actually General

### DIFF
--- a/code/modules/modular_armor/storage.dm
+++ b/code/modules/modular_armor/storage.dm
@@ -77,25 +77,9 @@
 	slowdown = 0.1
 
 /obj/item/storage/internal/modular/general
-	max_storage_space = 10
+	max_storage_space = 6
 	storage_slots = 2
 	max_w_class = WEIGHT_CLASS_NORMAL
-	can_hold = list(
-		/obj/item/weapon/combat_knife,
-		/obj/item/attachable/bayonetknife,
-		/obj/item/flashlight/flare,
-		/obj/item/explosive/grenade/flare,
-		/obj/item/ammo_magazine/rifle,
-		/obj/item/cell/lasgun,
-		/obj/item/ammo_magazine/smg,
-		/obj/item/ammo_magazine/pistol,
-		/obj/item/ammo_magazine/revolver,
-		/obj/item/ammo_magazine/sniper,
-		/obj/item/ammo_magazine/handful,
-		/obj/item/explosive/grenade,
-		/obj/item/explosive/mine,
-		/obj/item/reagent_containers/food/snacks,
-	)
 
 /obj/item/armor_module/storage/ammo_mag
 	name = "Magazine Storage module"


### PR DESCRIPTION

## About The Pull Request

Fixes #4226 

## Why It's Good For The Game

So it turns out the 'general purpose storage module' was actually just a worse copy of the ammo bad module. This turns it into a true general purpose storage thing.

If its size 3 or less, it'll fit.

## Changelog
:cl: Hughgent
fix: General Purpose Storage module now actually general purpose.
/:cl:

