### PR TITLE
Synthetics can now get their blood back via nanopaste

### DIFF
--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -17,6 +17,9 @@
 		var/mob/living/carbon/human/H = M
 		var/datum/limb/S = H.get_limb(user.zone_selected)
 
+		if(H.species.species_flags & IS_SYNTHETIC)
+			H.blood_volume = BLOOD_VOLUME_NORMAL
+
 		if(S.surgery_open_stage == 0)
 			if (S && (S.limb_status & LIMB_ROBOT))
 				if(user.action_busy || !do_after(user, 1 SECONDS, TRUE, src, BUSY_ICON_MEDICAL))

--- a/code/modules/mob/living/carbon/carbon_status_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_status_procs.dm
@@ -37,8 +37,6 @@
 
 
 /mob/living/carbon/proc/adjust_nutrition(amount)
-	if(species.species_flags & IS_SYNTHETIC) //robots don't eat
-		return
 	. = nutrition
 	nutrition = max(nutrition + amount, 0)
 	adjust_nutrition_speed(.)

--- a/code/modules/mob/living/carbon/carbon_status_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_status_procs.dm
@@ -37,7 +37,7 @@
 
 
 /mob/living/carbon/proc/adjust_nutrition(amount)
-	if(IS_SYNTHETIC in species.species_flags) //robots don't eat
+	if(species.species_flags & IS_SYNTHETIC) //robots don't eat
 		return
 	. = nutrition
 	nutrition = max(nutrition + amount, 0)

--- a/code/modules/mob/living/carbon/carbon_status_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_status_procs.dm
@@ -37,6 +37,8 @@
 
 
 /mob/living/carbon/proc/adjust_nutrition(amount)
+	if(IS_SYNTHETIC in species.species_flags) //robots don't eat
+		return
 	. = nutrition
 	nutrition = max(nutrition + amount, 0)
 	adjust_nutrition_speed(.)


### PR DESCRIPTION
## About The Pull Request

Fixes #4338 

Organ damage and bloodloss are still things that happen to synthetics

## Why It's Good For The Game

Synthetics, when they take a lot of bleeding or damage, can now get their blood back whenever they are touched by nanopaste in the course of repairing their limbs.

## Changelog
:cl: Hughgent
fix: Synthetics can get their blood back with nanopaste
/:cl:

