### PR TITLE
shields check runtime fix

### DIFF
--- a/code/game/objects/items/coins.dm
+++ b/code/game/objects/items/coins.dm
@@ -6,7 +6,6 @@
 	icon_state = "coin"
 	flags_atom = CONDUCT
 	force = 0.0
-	throwforce = 0.0
 	w_class = WEIGHT_CLASS_TINY
 	var/string_attached
 	var/sides = 2

--- a/code/game/objects/items/misc.dm
+++ b/code/game/objects/items/misc.dm
@@ -35,7 +35,6 @@
 	icon_state = "banana_peel"
 	item_state = "banana_peel"
 	w_class = WEIGHT_CLASS_TINY
-	throwforce = 0
 	throw_speed = 4
 	throw_range = 20
 

--- a/code/game/objects/items/stacks/sandbags.dm
+++ b/code/game/objects/items/stacks/sandbags.dm
@@ -8,7 +8,6 @@
 	icon_state = "sandbag_stack"
 	w_class = WEIGHT_CLASS_NORMAL
 	force = 2
-	throwforce = 0
 	throw_speed = 5
 	throw_range = 20
 	max_amount = 50

--- a/code/game/objects/items/stacks/snow.dm
+++ b/code/game/objects/items/stacks/snow.dm
@@ -8,7 +8,6 @@
 	icon_state = "snow_stack"
 	w_class = WEIGHT_CLASS_HUGE
 	force = 2
-	throwforce = 0
 	throw_speed = 5
 	throw_range = 1
 	max_amount = 25

--- a/code/game/objects/items/tools/cleaning_tools.dm
+++ b/code/game/objects/items/tools/cleaning_tools.dm
@@ -77,7 +77,6 @@
 	icon = 'icons/obj/items/items.dmi'
 	icon_state = "soap"
 	w_class = WEIGHT_CLASS_TINY
-	throwforce = 0
 	throw_speed = 4
 	throw_range = 20
 

--- a/code/game/objects/items/tools/misc_tools.dm
+++ b/code/game/objects/items/tools/misc_tools.dm
@@ -76,7 +76,6 @@
 	icon_state = "pen"
 	item_state = "pen"
 	flags_equip_slot = ITEM_SLOT_BELT|ITEM_SLOT_EARS
-	throwforce = 0
 	w_class = WEIGHT_CLASS_TINY
 	throw_speed = 7
 	throw_range = 15
@@ -162,14 +161,13 @@
 	icon = 'icons/obj/items/paper.dmi'
 	icon_state = "stamp-qm"
 	item_state = "stamp"
-	throwforce = 0
 	w_class = WEIGHT_CLASS_TINY
 	throw_speed = 7
 	throw_range = 15
 	attack_verb = list("stamped")
 
 /obj/item/tool/stamp/qm
-	name = "Quartermaster's Stamp"	
+	name = "Quartermaster's Stamp"
 
 /obj/item/tool/stamp/captain
 	name = "captain's rubber stamp"

--- a/code/game/objects/items/toys/toys.dm
+++ b/code/game/objects/items/toys/toys.dm
@@ -17,7 +17,6 @@
 
 /obj/item/toy
 	icon = 'icons/obj/items/toy.dmi'
-	throwforce = 0
 	throw_speed = 4
 	throw_range = 20
 	force = 0
@@ -94,7 +93,6 @@
 /obj/item/toy/syndicateballoon
 	name = "syndicate balloon"
 	desc = "There is a tag on the back that reads \"FUK NT!11!\"."
-	throwforce = 0
 	throw_speed = 4
 	throw_range = 20
 	force = 0
@@ -397,7 +395,6 @@
 	anchored = FALSE
 	w_class = WEIGHT_CLASS_SMALL
 	force = 0.0
-	throwforce = 0.0
 	throw_speed = 1
 	throw_range = 20
 

--- a/code/game/objects/items/weapons/holo_weapons.dm
+++ b/code/game/objects/items/weapons/holo_weapons.dm
@@ -10,7 +10,6 @@
 	force = 3.0
 	throw_speed = 1
 	throw_range = 5
-	throwforce = 0
 	w_class = WEIGHT_CLASS_SMALL
 	flags_item = NOBLUDGEON
 	var/sword_color

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -6,7 +6,6 @@
 	icon = 'icons/obj/items/items.dmi'
 	icon_state = "toyhammer"
 	flags_equip_slot = ITEM_SLOT_BELT
-	throwforce = 0
 	w_class = WEIGHT_CLASS_SMALL
 	throw_speed = 7
 	throw_range = 15

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -16,6 +16,7 @@
 	var/reliability = 100	//Used by SOME devices to determine how reliable they are.
 	var/crit_fail = 0
 
+	///throwforce needs to be at least 1 else it causes runtimes with shields
 	var/throwforce = 1
 
 	var/obj_flags = NONE

--- a/code/modules/hydroponics/grown_inedible.dm
+++ b/code/modules/hydroponics/grown_inedible.dm
@@ -167,7 +167,6 @@
 	icon_state = "corncob"
 	item_state = "corncob"
 	w_class = WEIGHT_CLASS_SMALL
-	throwforce = 0
 	throw_speed = 4
 	throw_range = 20
 

--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -3,7 +3,6 @@
 	icon = 'icons/obj/items/paper.dmi'
 	icon_state = "clipboard"
 	item_state = "clipboard"
-	throwforce = 0
 	w_class = WEIGHT_CLASS_SMALL
 	throw_speed = 3
 	throw_range = 10

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -9,7 +9,6 @@
 	icon = 'icons/obj/items/paper.dmi'
 	icon_state = "paper"
 	item_state = "paper"
-	throwforce = 0
 	w_class = WEIGHT_CLASS_TINY
 	throw_range = 1
 	throw_speed = 1

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -4,7 +4,6 @@
 	icon = 'icons/obj/items/paper.dmi'
 	icon_state = "paper"
 	item_state = "paper"
-	throwforce = 0
 	w_class = WEIGHT_CLASS_TINY
 	throw_range = 2
 	throw_speed = 1

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -391,7 +391,6 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list(new/datum/stack_recipe("cable restrain
 	color = "yellow"
 	var/cable_color = "yellow"
 	desc = "A coil of insulated power cable."
-	throwforce = 0
 	w_class = WEIGHT_CLASS_SMALL
 	throw_speed = 3
 	throw_range = 5

--- a/code/modules/power/pipecleaners.dm
+++ b/code/modules/power/pipecleaners.dm
@@ -182,7 +182,6 @@ By design, d1 is the smallest direction and d2 is the highest
 	amount = MAXCOIL
 	merge_type = /obj/item/stack/pipe_cleaner_coil // This is here to let its children merge between themselves
 	var/pipe_cleaner_color = "red"
-	throwforce = 0
 	w_class = WEIGHT_CLASS_SMALL
 	throw_speed = 3
 	throw_range = 5


### PR DESCRIPTION

## About The Pull Request

Fixes #4676

## Why It's Good For The Game

Some things had 0 throwforce, which was causing the stack trace. My assumption is that even the smallest, softest thing, should cause the minimum 1 damage when thrown by a grown adult.

## Changelog
:cl: Hughgent
fix: Runtime with 0 damage thrown objects and shields.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
