### PR TITLE
binoculars can no longer target things the user cannot see.

### DIFF
--- a/code/game/objects/items/binoculars.dm
+++ b/code/game/objects/items/binoculars.dm
@@ -156,6 +156,10 @@
 		to_chat(user, "<span class='warning'>You can't focus properly through \the [src] while looking through something else.</span>")
 		return
 
+	if(!can_see(user, A, 25))
+		to_chat(user, "<span class='warning'>You can't see anything there.</span>")
+		return
+
 	if(!user.mind)
 		return
 	var/datum/squad/S = user.assigned_squad


### PR DESCRIPTION

## About The Pull Request

Fixes #4693 

## Why It's Good For The Game

If you can't see it, you can't laze it.

## Changelog
:cl: Hughgent
fix: Tactical binos cannot laze things the user cannot see.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
