### PR TITLE
powercells must be recharged before restocking them

### DIFF
--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -588,10 +588,10 @@ GLOBAL_LIST_INIT(vending_white_items, typecacheof(list(
 			if(P.pcell.charge < P.pcell.maxcharge)
 				to_chat(user, "<span class='warning'>The [P] cell isn't full. You must recharge it before you can restock it.</span>")
 				return
-		else if(istype(item_to_stock, /obj/item/cell/lasgun))
-			var/obj/item/cell/lasgun/lascell = item_to_stock
-			if(lascell.charge < lascell.maxcharge)
-				to_chat(user, "<span class='warning'>\The [lascell] isn't full. You must recharge it before you can restock it.</span>")
+		else if(istype(item_to_stock, /obj/item/cell))
+			var/obj/item/cell/cell = item_to_stock
+			if(cell.charge < cell.maxcharge)
+				to_chat(user, "<span class='warning'>\The [cell] isn't full. You must recharge it before you can restock it.</span>")
 				return
 		if(item_to_stock.loc == user) //Inside the mob's inventory
 			if(item_to_stock.flags_item & WIELDED)


### PR DESCRIPTION
## About The Pull Request

fixes #4699 

## Why It's Good For The Game

The vendor is just a vendor, it is not an infinite free power source

## Changelog
:cl: Hughgent
balance: vending machines with power cells no longer give free power by restocking batteries
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
