### PR TITLE
Makes Carrier stunnable

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/carrier.dm
@@ -7,8 +7,6 @@
 	health = 200
 	maxHealth = 200
 	plasma_stored = 50
-	drag_delay = 6 //pulling a big dead xeno is hard
-	mob_size = MOB_SIZE_BIG
 	var/list/huggers = list()
 	var/eggs_cur = 0
 	tier = XENO_TIER_TWO


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reduces carrier size to MOB_SIZE_XENO instead of MOB_SIZE_BIG. This makes them able to be stunned, because they're apparently immune to stuns, and also keeps them from doing other things. Why the fuck is a T2 unstunnable?

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Carrier is for whatever reason completely impossible to stun, and also capable of tearing holes in acid hole walls. Why is this on a T2 and not its T3 evolution is beyond me. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Removed two lines of code that made carrier MOB_SIZE_BIG and slower to drag. That last one is mostly just because every other MOB_SIZE_BIG xeno has that bit, and it's just for precedent's sake.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
