### PR TITLE
Codex fluff move-about

### DIFF
--- a/code/controllers/subsystem/codex.dm
+++ b/code/controllers/subsystem/codex.dm
@@ -66,6 +66,7 @@ SUBSYSTEM_DEF(codex)
 	if(entry && istype(presenting_to) && presenting_to.client)
 		var/list/dat = list()
 		if(entry.lore_text)
+			dat += "<h3>Lore Information</h3>"
 			dat += "<font color='#abdb9b'>[entry.lore_text]</font>"
 		if(entry.mechanics_text)
 			dat += "<h3>OOC Information</h3>"

--- a/code/controllers/subsystem/codex.dm
+++ b/code/controllers/subsystem/codex.dm
@@ -65,12 +65,12 @@ SUBSYSTEM_DEF(codex)
 /datum/controller/subsystem/codex/proc/present_codex_entry(mob/presenting_to, datum/codex_entry/entry)
 	if(entry && istype(presenting_to) && presenting_to.client)
 		var/list/dat = list()
-		if(entry.lore_text)
-			dat += "<h3>Lore Information</h3>"
-			dat += "<font color='#abdb9b'>[entry.lore_text]</font>"
 		if(entry.mechanics_text)
 			dat += "<h3>OOC Information</h3>"
 			dat += "<font color='#9ebcd8'>[entry.mechanics_text]</font>"
+		if(entry.lore_text)
+			dat += "<h3>Lore Information</h3>"
+			dat += "<font color='#abdb9b'>[entry.lore_text]</font>"
 		var/datum/browser/popup = new(presenting_to, "codex", "Codex - [entry.display_name]")
 		popup.set_content(jointext(dat, null))
 		popup.open()

--- a/code/modules/codex/entries/guns_codex.dm
+++ b/code/modules/codex/entries/guns_codex.dm
@@ -14,11 +14,6 @@
 	. = ..()
 	var/list/traits = list()
 
-	var/list/entries = SScodex.retrieve_entries_for_string(general_codex_key)
-	var/datum/codex_entry/general_entry = LAZYACCESS(entries, 1)
-	if(general_entry && general_entry.mechanics_text)
-		traits += general_entry.mechanics_text
-
 	if(flags_gun_features & GUN_WIELDED_FIRING_ONLY)
 		traits += "This can only be fired with a two-handed grip."
 	else
@@ -96,6 +91,11 @@
 	if(burst_amount > 1)
 		traits += "Shots fired on burst mode: [burst_amount]"
 		traits += "Time between burst-fire: [(min((burst_delay * 2), (fire_delay * 3))) / 10] seconds"
+
+	var/list/entries = SScodex.retrieve_entries_for_string(general_codex_key)
+	var/datum/codex_entry/general_entry = LAZYACCESS(entries, 1)
+	if(general_entry && general_entry.mechanics_text)
+		traits += general_entry.mechanics_text
 
 	. += jointext(traits, "<br>")
 

--- a/code/modules/codex/entries/guns_codex.dm
+++ b/code/modules/codex/entries/guns_codex.dm
@@ -92,6 +92,7 @@
 		traits += "Shots fired on burst mode: [burst_amount]"
 		traits += "Time between burst-fire: [(min((burst_delay * 2), (fire_delay * 3))) / 10] seconds"
 
+	traits += "<br>"
 	var/list/entries = SScodex.retrieve_entries_for_string(general_codex_key)
 	var/datum/codex_entry/general_entry = LAZYACCESS(entries, 1)
 	if(general_entry && general_entry.mechanics_text)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Moves the fluff text of lore and operation in the codex pages of guns to the bottom, making what truly matters quickly accessible: **stats**.

Example of new layout:
![image](https://user-images.githubusercontent.com/67213021/98302419-40ff9c80-1fb4-11eb-93c0-62195ec0a8f4.png)


## Why It's Good For The Game
Lore behind ammo types and why they are still used in the game's setting, is something  that like 5 people care about.
This is all the while it's at the top of the codex page, which is pretty much only looked at to check what attachments a gun can fit and stat it sports.
By moving it to the bottom, it is given a proper place fit for it's status: to be forgotten.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: E25
tweak: Moves lore and operation text in codex of guns to the bottom, adds a header for it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
