### PR TITLE
Fixes broken miniflamer and nerfs it too

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1312,7 +1312,7 @@ Defined in conflicts.dm of the #defines folder.
 	fire_sound = 'sound/weapons/guns/fire/flamethrower3.ogg'
 	flags_attach_features = ATTACH_REMOVABLE|ATTACH_ACTIVATION|ATTACH_RELOADABLE|ATTACH_WEAPON
 	attachment_firing_delay = 25
-	var/last_fired = 0		//When it was last fired, related to world.time.
+	COOLDOWN_DECLARE(last_fired)
 
 
 /obj/item/attachable/attached_gun/flamer/unremovable
@@ -1395,13 +1395,7 @@ Defined in conflicts.dm of the #defines folder.
 	if(get_dist(user,target) > max_range+3)
 		to_chat(user, "<span class='warning'>Too far to fire the attachment!</span>")
 		return
-	var/added_delay = attachment_firing_delay
-	if(!user.skills.getRating("firearms")) //no training in any firearms
-		added_delay += 3 //untrained humans fire more slowly.
-	if(world.time <= last_fired + added_delay)
-		return
-	last_fired = world.time
-	if(current_rounds)
+	if(current_rounds && COOLDOWN_CHECK(src, last_fired))
 		unleash_flame(target, user)
 
 
@@ -1411,6 +1405,10 @@ Defined in conflicts.dm of the #defines folder.
 	var/distance = 0
 	var/turf/prev_T
 	playsound(user, 'sound/weapons/guns/fire/flamethrower2.ogg', 50, 1)
+	var/fire_delay = attachment_firing_delay
+	if(!user.skills.getRating("firearms")) //no training in any firearms
+		fire_delay += 3 //untrained humans fire more slowly.
+	COOLDOWN_START(src, last_fired, fire_delay)
 	for(var/turf/T in turfs)
 		if(T == user.loc)
 			prev_T = T

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1407,7 +1407,7 @@ Defined in conflicts.dm of the #defines folder.
 	playsound(user, 'sound/weapons/guns/fire/flamethrower2.ogg', 50, 1)
 	var/fire_delay = attachment_firing_delay
 	if(!user.skills.getRating("firearms")) //no training in any firearms
-		fire_delay += 3 //untrained humans fire more slowly.
+		fire_delay += 0.3 SECONDS //untrained humans fire more slowly.
 	COOLDOWN_START(src, last_fired, fire_delay)
 	for(var/turf/T in turfs)
 		if(T == user.loc)

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1311,7 +1311,8 @@ Defined in conflicts.dm of the #defines folder.
 	slot = "under"
 	fire_sound = 'sound/weapons/guns/fire/flamethrower3.ogg'
 	flags_attach_features = ATTACH_REMOVABLE|ATTACH_ACTIVATION|ATTACH_RELOADABLE|ATTACH_WEAPON
-	attachment_firing_delay = 35
+	attachment_firing_delay = 25
+	var/last_fired = 0		//When it was last fired, related to world.time.
 
 
 /obj/item/attachable/attached_gun/flamer/unremovable
@@ -1394,6 +1395,12 @@ Defined in conflicts.dm of the #defines folder.
 	if(get_dist(user,target) > max_range+3)
 		to_chat(user, "<span class='warning'>Too far to fire the attachment!</span>")
 		return
+	var/added_delay = attachment_firing_delay
+	if(!user.skills.getRating("firearms")) //no training in any firearms
+		added_delay += 3 //untrained humans fire more slowly.
+	if(world.time <= last_fired + added_delay)
+		return
+	last_fired = world.time
 	if(current_rounds)
 		unleash_flame(target, user)
 
@@ -1409,6 +1416,8 @@ Defined in conflicts.dm of the #defines folder.
 			prev_T = T
 			continue
 		if(!current_rounds)
+			break
+		if(T.density || isspaceturf(T))
 			break
 		if(distance >= max_range)
 			break


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Closes: #5160 

Adds a density and space turf check during `unleash_flame()` similar to the flamer.

Utilizes the attachments existing `attachment_firing_delay` to calculate and respect a firing delay similar to the flamer.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Broken abusable attachment bad. Fix good.

## Changelog
:cl:
fix: Fixed miniflamer flames going through solid walls.
balance: Greatly increased the independent cooldown between miniflamer uses.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
