### PR TITLE
Nerfs angled grip wield delay removal to 0.1 than 0.3 and gives a scatter mod

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1520,16 +1520,17 @@ Defined in conflicts.dm of the #defines folder.
 
 /obj/item/attachable/angledgrip
 	name = "angled grip"
-	desc = "A custom-built improved foregrip for less recoil, and faster wielding time. \nHowever, it also increases weapon size, and slightly hinders unwielded firing."
+	desc = "A custom-built improved foregrip for less recoil, and faster wielding time. \nHowever, it also increases weapon size, scatter and slightly hinders unwielded firing."
 	icon_state = "angledgrip"
 	attach_icon = "angledgrip_a"
-	wield_delay_mod = -0.3 SECONDS
+	wield_delay_mod = -0.1 SECONDS
 	size_mod = 1
 	slot = "under"
 	pixel_shift_x = 20
 	recoil_mod = -1
 	accuracy_unwielded_mod = -0.1
 	scatter_unwielded_mod = 5
+	scatter_mod = 10
 
 
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
angled grip has 0.1 wield delay bonus than 0.3
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Let's look at Pre-PR angled grip.
It gives you -0.3 wield delay, which on paper isn't much but in practice is a lot since wield delays are generally less a second long outside of LMG level weapons.
The angled grip also effectively counters its own downside in the first place because you can wield incredibly fast.
angled grip is literally bar none the best underbarreled attachment in the game because of this.
You can put ARs down to half a second. You can put carbines below that, you can get most guns to sub 0.3~ ms wield delay which makes secondaries irrelevant and just makes wield delay irrelevant, it is bar none the best underbarrel attachment if you don't want a attached gun.

This attachment by far has the most effect compared to the other stat underbarreled attachments-

Gyro gives your gun a small boost to one handed firing and makes you better at firing with slightly less scatter
Vertical grip gives you bonuses to scatters at the cost of wield delay (and is effectively the opposite of this gun.)
Bipod is bruh on 99.9% of guns other than the GPMG.
BFA kinda just exists, as most people don't use burst fire anymore outside of 6 shot carbine gamers.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: angled grips have been nerfed to -0.1 wield delay, they increase your scatter by 10
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
