### PR TITLE
Rank times standardisation, field commander max rank time fix (now actually functional)

### DIFF
--- a/code/datums/jobs/job/marines.dm
+++ b/code/datums/jobs/job/marines.dm
@@ -44,15 +44,15 @@ Make your way to the cafeteria for some post-cryosleep chow, and then get equipp
 	if(!playtime_mins || playtime_mins < 1 )
 		return
 	switch(playtime_mins)
-		if(0 to 600)
+		if(0 to 600) // starting
 			new_human.wear_id.paygrade = "E1"
-		if(601 to 6600)
+		if(601 to 6000) // 10hrs
 			new_human.wear_id.paygrade = "E2"
-		if(6601 to 18000)
+		if(6001 to 18000) // 100 hrs
 			new_human.wear_id.paygrade = "E3"
-		if(18001 to 60000)
+		if(18001 to 60000) // 300 hrs
 			new_human.wear_id.paygrade = "E3E"
-		if(60001 to INFINITY)
+		if(60001 to INFINITY) // 1000 hrs
 			new_human.wear_id.paygrade = "E8" //If you play way too much TGMC. 1000 hours.
 
 /datum/job/terragov/squad/standard/radio_help_message(mob/M)
@@ -153,11 +153,11 @@ Your squaddies will look to you when it comes to construction in the field of ba
 	if(!playtime_mins || playtime_mins < 1 )
 		return
 	switch(playtime_mins)
-		if(0 to 1500)
+		if(0 to 1500) // starting
 			new_human.wear_id.paygrade = "E3"
-		if(1501 to 6000)
+		if(1501 to 6000) // 25 hrs
 			new_human.wear_id.paygrade = "E4"
-		if(6001 to INFINITY)
+		if(6001 to INFINITY) // 100 hrs
 			new_human.wear_id.paygrade = "E5"
 
 //Squad Corpsman
@@ -234,11 +234,11 @@ You may not be a fully-fledged doctor, but you stand between life and death when
 	if(!playtime_mins || playtime_mins < 1 )
 		return
 	switch(playtime_mins)
-		if(0 to 1500)
+		if(0 to 1500) // starting
 			new_human.wear_id.paygrade = "E3"
-		if(1501 to 6000)
+		if(1501 to 6000) // 25 hrs
 			new_human.wear_id.paygrade = "E4"
-		if(6001 to INFINITY)
+		if(6001 to INFINITY) // 100 hrs
 			new_human.wear_id.paygrade = "E5"
 
 //Squad Smartgunner
@@ -269,11 +269,11 @@ You may not be a fully-fledged doctor, but you stand between life and death when
 	if(!playtime_mins || playtime_mins < 1 )
 		return
 	switch(playtime_mins)
-		if(0 to 1500)
+		if(0 to 1500) // starting
 			new_human.wear_id.paygrade = "E3"
-		if(1501 to 6000)
+		if(1501 to 6000) // 25 hrs
 			new_human.wear_id.paygrade = "E4"
-		if(6001 to INFINITY)
+		if(6001 to INFINITY) // 100 hrs
 			new_human.wear_id.paygrade = "E5"
 
 /datum/outfit/job/marine/smartgunner
@@ -435,11 +435,11 @@ You are also in charge of communicating with command and letting them know about
 	if(!playtime_mins || playtime_mins < 1 )
 		return
 	switch(playtime_mins)
-		if(0 to 3000)
+		if(0 to 1500) // starting
 			new_human.wear_id.paygrade = "E5"
-		if(3001 to 7500)
+		if(1501 to 7500) // 25 hrs
 			new_human.wear_id.paygrade = "E6"
-		if(7501 to INFINITY)
+		if(7501 to INFINITY) // 125 hrs
 			new_human.wear_id.paygrade = "E7"
 
 

--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -67,11 +67,11 @@ Godspeed, captain! And remember, you are not above the law."})
 	if(!playtime_mins || playtime_mins < 1 )
 		return
 	switch(playtime_mins)
-		if(0 to 500)
+		if(0 to 1500) // starting
 			new_human.wear_id.paygrade = "O6"
-		if(501 to 10000)
+		if(1501 to 7500) // 25hrs
 			new_human.wear_id.paygrade = "O7"
-		if(10001 to INFINITY)
+		if(7501 to INFINITY) //125 hrs
 			new_human.wear_id.paygrade = "O8"
 
 //Field Commander
@@ -116,11 +116,11 @@ Make the TGMC proud!"})
 	if(!playtime_mins || playtime_mins < 1 )
 		return
 	switch(playtime_mins)
-		if(0 to 600)
+		if(0 to 1500) //starting
 			new_human.wear_id.paygrade = "O3"
-		if(601 to 6600)
+		if(1500 to 7500) // 25 hrs
 			new_human.wear_id.paygrade = "MO4"
-		if(6601 to 18000)
+		if(7501 to INFINITY) // 125 hrs
 			new_human.wear_id.paygrade = "MO5"
 
 
@@ -177,9 +177,9 @@ You are in charge of logistics and the overwatch system. You are also in line to
 	if(!playtime_mins || playtime_mins < 1 )
 		return
 	switch(playtime_mins)
-		if(0 to 3000)
+		if(0 to 3000) // starting
 			new_human.wear_id.paygrade = "O4"
-		if(3001 to INFINITY)
+		if(3001 to INFINITY) // 50 hrs
 			new_human.wear_id.paygrade = "O5"
 
 /datum/outfit/job/command/staffofficer
@@ -224,13 +224,13 @@ You are in charge of logistics and the overwatch system. You are also in line to
 	if(!playtime_mins || playtime_mins < 1 )
 		return
 	switch(playtime_mins)
-		if(0 to 1500) // starting
+		if(0 to 600) // starting
 			new_human.wear_id.paygrade = "WO"
-		if(1501 to 3000) // 25 hrs
+		if(601 to 3000) // 10 hrs
 			new_human.wear_id.paygrade = "CWO"
-		if(1501 to 3000)
+		if(3001 to 6000) // 50 hrs
 			new_human.wear_id.paygrade = "O1"
-		if(3001 to INFINITY)
+		if(6001 to INFINITY) // 100 hrs
 			new_human.wear_id.paygrade = "O2"
 
 /datum/job/terragov/command/pilot/radio_help_message(mob/M)
@@ -340,11 +340,11 @@ You could use STs help to repair and replace hardpoints."})
 	if(!playtime_mins || playtime_mins < 1 )
 		return
 	switch(playtime_mins)
-		if(0 to 1500)
+		if(0 to 1500) // starting
 			new_human.wear_id.paygrade = "O2"
-		if(1501 to 3000)
+		if(1501 to 6000) // 25 hrs
 			new_human.wear_id.paygrade = "O3"
-		if(3001 to INFINITY)
+		if(6001 to INFINITY) // 50 hrs
 			new_human.wear_id.paygrade = "O4"
 
 /datum/job/terragov/engineering/chief/radio_help_message(mob/M)
@@ -400,13 +400,13 @@ You are also next in the chain of command, should the bridge crew fall in the li
 	if(!playtime_mins || playtime_mins < 1 )
 		return
 	switch(playtime_mins)
-		if(0 to 1500) // starting
+		if(0 to 600) // starting
 			new_human.wear_id.paygrade = "PO3"
-		if(1501 to 3000) // 25 hrs
+		if(601 to 3000) // 10 hrs
 			new_human.wear_id.paygrade = "PO2"
-		if(1501 to 3000)
+		if(3001 to 6000) // 50 hrs
 			new_human.wear_id.paygrade = "PO1"
-		if(3001 to INFINITY)
+		if(6001 to INFINITY) // 100 hrs
 			new_human.wear_id.paygrade = "CPO"
 
 /datum/job/terragov/engineering/tech/radio_help_message(mob/M)
@@ -470,13 +470,13 @@ requisitions line and later on to be ready to send supplies for marines who are 
 	if(!playtime_mins || playtime_mins < 1 )
 		return
 	switch(playtime_mins)
-		if(0 to 600)
+		if(0 to 600) // starting
 			new_human.wear_id.paygrade = "CPO"
-		if(601 to 1500)
+		if(601 to 1500) // 10 hrs
 			new_human.wear_id.paygrade = "WO"
-		if(1501 to 3000)
+		if(1501 to 6000) // 50 hrs
 			new_human.wear_id.paygrade = "CWO"
-		if(3001 to INFINITY)
+		if(6001 to INFINITY) // 100 hrs
 			new_human.wear_id.paygrade = "O1"
 
 /datum/job/terragov/requisitions/officer/radio_help_message(mob/M)

--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -224,9 +224,9 @@ You are in charge of logistics and the overwatch system. You are also in line to
 	if(!playtime_mins || playtime_mins < 1 )
 		return
 	switch(playtime_mins)
-		if(0 to 600)
+		if(0 to 1500) // starting
 			new_human.wear_id.paygrade = "WO"
-		if(601 to 1500)
+		if(1501 to 3000) // 25 hrs
 			new_human.wear_id.paygrade = "CWO"
 		if(1501 to 3000)
 			new_human.wear_id.paygrade = "O1"
@@ -400,9 +400,9 @@ You are also next in the chain of command, should the bridge crew fall in the li
 	if(!playtime_mins || playtime_mins < 1 )
 		return
 	switch(playtime_mins)
-		if(0 to 600)
+		if(0 to 1500) // starting
 			new_human.wear_id.paygrade = "PO3"
-		if(601 to 1500)
+		if(1501 to 3000) // 25 hrs
 			new_human.wear_id.paygrade = "PO2"
 		if(1501 to 3000)
 			new_human.wear_id.paygrade = "PO1"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes the time of max rank for the Field Commander, allows it to extend out to infinity, as it should.
Standardises rank times, better distribution for some roles that previously had a very cluttered lineup.

Adds comments in code next to times in hours, bit of qol.

(Remade the PR due to being based off my fork's master, and having issues arise from that.)
## Why It's Good For The Game

Rank times were a mess, now all are standardised to set times depending on position, e.g. all of command having 0/25/125.
Made on suggestions by RenGusta.

Some roles like the PO had a very compressed set of ranks that got maxed by hour 50, fixed by extending times for it and roles with a similar problem.

## Changelog
:cl: E25
tweak: Marine ranks are now 0/10/100/300/1000 hours.
tweak: All Command ranks are now 0/25/125 hours.
tweak: PO, RO and Ship engie ranks are now 0/25/50/100 hours.
fix: Fixed Field Commander's max rank not extending out to infinity.
/:cl: