### PR TITLE
Neuraline cost increased by 1

### DIFF
--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -195,6 +195,17 @@
 	icon_state = "autoinjector-6"
 	list_reagents = list(/datum/reagent/medicine/neuraline = 12)
 
+/obj/item/reagent_containers/hypospray/autoinjector/neuraline_expired
+	name = "Expired neuraline autoinjector"
+	desc = "An auto-injector loaded with 2 doses of neuraline, an extremely powerful stimulant. This one is expired by 2 months.. !DO NOT USE MORE THAN ONCE AT A TIME!"
+	amount_per_transfer_from_this = 6
+	volume = 12
+	icon_state = "autoinjector-1"
+	list_reagents = list(
+		/datum/reagent/medicine/neuraline = 6,
+		/datum/reagent/toxin = 6,
+	)
+
 /obj/item/reagent_containers/hypospray/autoinjector/peridaxon_plus
 	name = "Peridaxon Plus autoinjector"
 	desc = "An auto-injector loaded with 3 doses of Peridaxon Plus, a chemical that heals organs while causing a buildup of toxins. Use with antitoxin. !DO NOT USE IN ACTIVE COMBAT!"

--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -195,17 +195,6 @@
 	icon_state = "autoinjector-6"
 	list_reagents = list(/datum/reagent/medicine/neuraline = 12)
 
-/obj/item/reagent_containers/hypospray/autoinjector/neuraline_expired
-	name = "Expired neuraline autoinjector"
-	desc = "An auto-injector loaded with 2 doses of neuraline, an extremely powerful stimulant. This one is expired by 2 months.. !DO NOT USE MORE THAN ONCE AT A TIME!"
-	amount_per_transfer_from_this = 6
-	volume = 12
-	icon_state = "autoinjector-1"
-	list_reagents = list(
-		/datum/reagent/medicine/neuraline = 6,
-		/datum/reagent/toxin = 6,
-	)
-
 /obj/item/reagent_containers/hypospray/autoinjector/peridaxon_plus
 	name = "Peridaxon Plus autoinjector"
 	desc = "An auto-injector loaded with 3 doses of Peridaxon Plus, a chemical that heals organs while causing a buildup of toxins. Use with antitoxin. !DO NOT USE IN ACTIVE COMBAT!"

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -943,7 +943,7 @@ GLOBAL_LIST_INIT(marine_selector_cats, list(
 		/obj/item/reagent_containers/hypospray/autoinjector/hypervene = list(CAT_MEDSUP, "Injector (Hypervene)", 1, "black"),
 		/obj/item/reagent_containers/hypospray/autoinjector/quickclotplus = list(CAT_MEDSUP, "Injector (QuickclotPlus)", 3, "orange"),
 		/obj/item/reagent_containers/hypospray/autoinjector/synaptizine = list(CAT_MEDSUP, "Injector (Synaptizine)", 4, "orange"),
-		/obj/item/reagent_containers/hypospray/autoinjector/neuraline = list(CAT_MEDSUP, "Injector (Neuraline)", 13, "orange"),
+		/obj/item/reagent_containers/hypospray/autoinjector/neuraline = list(CAT_MEDSUP, "Injector (Neuraline)", 14, "orange"),
 		/obj/item/reagent_containers/hypospray/advanced = list(CAT_MEDSUP, "Advanced hypospray", 2, "black"),
 		/obj/item/clothing/glasses/hud/health = list(CAT_MEDSUP, "Medical HUD glasses", 2, "black"),
 		/obj/item/attachable/suppressor = list(CAT_ATT, "Suppressor", 0, "black"),

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -943,7 +943,7 @@ GLOBAL_LIST_INIT(marine_selector_cats, list(
 		/obj/item/reagent_containers/hypospray/autoinjector/hypervene = list(CAT_MEDSUP, "Injector (Hypervene)", 1, "black"),
 		/obj/item/reagent_containers/hypospray/autoinjector/quickclotplus = list(CAT_MEDSUP, "Injector (QuickclotPlus)", 3, "orange"),
 		/obj/item/reagent_containers/hypospray/autoinjector/synaptizine = list(CAT_MEDSUP, "Injector (Synaptizine)", 4, "orange"),
-		/obj/item/reagent_containers/hypospray/autoinjector/neuraline = list(CAT_MEDSUP, "Injector (Neuraline)", 13, "orange"),
+		/obj/item/reagent_containers/hypospray/autoinjector/neuraline = list(CAT_MEDSUP, "Injector (Neuraline)", 31, "orange"),
 		/obj/item/reagent_containers/hypospray/advanced = list(CAT_MEDSUP, "Advanced hypospray", 2, "black"),
 		/obj/item/clothing/glasses/hud/health = list(CAT_MEDSUP, "Medical HUD glasses", 2, "black"),
 		/obj/item/attachable/suppressor = list(CAT_ATT, "Suppressor", 0, "black"),
@@ -1262,6 +1262,7 @@ GLOBAL_LIST_INIT(available_specialist_sets, list("Scout Set", "Sniper Set", "Dem
 		/obj/item/medevac_beacon,
 		/obj/item/roller,
 		/obj/item/reagent_containers/hypospray/advanced/oxycodone,
+		/obj/item/reagent_containers/hypospray/autoinjector/neuraline_expired,
 		/obj/item/storage/firstaid/adv,
 	)
 

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -943,7 +943,7 @@ GLOBAL_LIST_INIT(marine_selector_cats, list(
 		/obj/item/reagent_containers/hypospray/autoinjector/hypervene = list(CAT_MEDSUP, "Injector (Hypervene)", 1, "black"),
 		/obj/item/reagent_containers/hypospray/autoinjector/quickclotplus = list(CAT_MEDSUP, "Injector (QuickclotPlus)", 3, "orange"),
 		/obj/item/reagent_containers/hypospray/autoinjector/synaptizine = list(CAT_MEDSUP, "Injector (Synaptizine)", 4, "orange"),
-		/obj/item/reagent_containers/hypospray/autoinjector/neuraline = list(CAT_MEDSUP, "Injector (Neuraline)", 31, "orange"),
+		/obj/item/reagent_containers/hypospray/autoinjector/neuraline = list(CAT_MEDSUP, "Injector (Neuraline)", 13, "orange"),
 		/obj/item/reagent_containers/hypospray/advanced = list(CAT_MEDSUP, "Advanced hypospray", 2, "black"),
 		/obj/item/clothing/glasses/hud/health = list(CAT_MEDSUP, "Medical HUD glasses", 2, "black"),
 		/obj/item/attachable/suppressor = list(CAT_ATT, "Suppressor", 0, "black"),
@@ -1262,7 +1262,6 @@ GLOBAL_LIST_INIT(available_specialist_sets, list("Scout Set", "Sniper Set", "Dem
 		/obj/item/medevac_beacon,
 		/obj/item/roller,
 		/obj/item/reagent_containers/hypospray/advanced/oxycodone,
-		/obj/item/reagent_containers/hypospray/autoinjector/neuraline_expired,
 		/obj/item/storage/firstaid/adv,
 	)
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Nerfs neuraline to cost 14rather than 13, making it so you can't get 240u of meraderm and neuraline.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Getting 240+advanced combat pouch (so 180) and neuraline was way too much. Neuraline injectors were also way too cheap for their effectiveness (13 cost for 3 shots of a chem that basically makes you literally invincible. Epic. and you get 240u of advanced chems. Epic.)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: neuraline injector increased by 1 to 14 in medic vendor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
