### PR TITLE
More Sulaco Fixes

### DIFF
--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -1145,14 +1145,6 @@
 	dir = 1
 	},
 /area/sulaco/engineering/atmos)
-"ahj" = (
-/obj/structure/ladder{
-	height = 2;
-	icon_state = "ladderdown";
-	id = "cargo"
-	},
-/turf/open/floor/prison/plate,
-/area/sulaco/cargo)
 "ahm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 8;
@@ -11632,14 +11624,6 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/mainship/command/self_destruct)
-"gPa" = (
-/obj/structure/ladder{
-	height = 2;
-	icon_state = "ladderdown";
-	id = "firing"
-	},
-/turf/open/floor/prison,
-/area/sulaco/hangar/one)
 "gPi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
@@ -41629,7 +41613,7 @@ abV
 hSX
 fCm
 kVY
-ahj
+bPM
 eul
 amB
 amd
@@ -43943,7 +43927,7 @@ uPG
 bhA
 bgd
 aRj
-gPa
+bhA
 alx
 cjh
 rEe

--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -297,12 +297,6 @@
 	dir = 4
 	},
 /area/sulaco/medbay/west)
-"acd" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
-/turf/open/floor/prison/whitegreen/corner{
-	dir = 1
-	},
-/area/sulaco/medbay/west)
 "ace" = (
 /obj/structure/target_stake,
 /turf/open/floor/prison/red{
@@ -390,12 +384,6 @@
 	dir = 4
 	},
 /area/sulaco/medbay)
-"acp" = (
-/obj/machinery/sleep_console,
-/turf/open/floor/prison/whitegreen/corner{
-	dir = 1
-	},
-/area/sulaco/medbay)
 "acr" = (
 /obj/machinery/bodyscanner,
 /turf/open/floor/prison/whitegreen/corner{
@@ -433,7 +421,6 @@
 "acw" = (
 /obj/structure/ladder{
 	height = 2;
-	icon_state = "ladderdown";
 	id = "hall3"
 	},
 /obj/machinery/camera/autoname,
@@ -563,7 +550,6 @@
 "ady" = (
 /obj/structure/ladder{
 	height = 2;
-	icon_state = "ladderdown";
 	id = "hall4"
 	},
 /obj/machinery/light{
@@ -598,6 +584,8 @@
 /obj/structure/table/mainship,
 /obj/item/reagent_containers/glass/beaker/bluespace,
 /obj/item/reagent_containers/glass/beaker/bluespace,
+/obj/machinery/reagentgrinder,
+/obj/item/stack/sheet/mineral/phoron,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 1
 	},
@@ -614,7 +602,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/medbay/west)
 "adK" = (
@@ -3318,7 +3305,6 @@
 "asD" = (
 /obj/structure/ladder{
 	height = 2;
-	icon_state = "ladderdown";
 	id = "hall1"
 	},
 /turf/open/floor/prison,
@@ -3326,7 +3312,6 @@
 "asE" = (
 /obj/structure/ladder{
 	height = 2;
-	icon_state = "ladderdown";
 	id = "hall2"
 	},
 /turf/open/floor/prison,
@@ -3354,7 +3339,6 @@
 	},
 /obj/structure/ladder{
 	height = 2;
-	icon_state = "ladderdown";
 	id = "hall10"
 	},
 /turf/open/floor/prison,
@@ -3966,7 +3950,6 @@
 "avf" = (
 /obj/structure/ladder{
 	height = 2;
-	icon_state = "ladderdown";
 	id = "hall7"
 	},
 /obj/structure/sign/directions/engineering{
@@ -4021,7 +4004,6 @@
 "avn" = (
 /obj/structure/ladder{
 	height = 2;
-	icon_state = "ladderdown";
 	id = "hall8"
 	},
 /turf/open/floor/prison,
@@ -4728,7 +4710,6 @@
 "ayI" = (
 /obj/structure/ladder{
 	height = 2;
-	icon_state = "ladderdown";
 	id = "hall5"
 	},
 /turf/open/floor/prison,
@@ -4737,7 +4718,6 @@
 /obj/machinery/light,
 /obj/structure/ladder{
 	height = 2;
-	icon_state = "ladderdown";
 	id = "hall6"
 	},
 /turf/open/floor/prison,
@@ -4756,7 +4736,6 @@
 "ayM" = (
 /obj/structure/ladder{
 	height = 2;
-	icon_state = "ladderdown";
 	id = "hall9"
 	},
 /obj/structure/cable,
@@ -6447,7 +6426,6 @@
 "aHh" = (
 /obj/structure/ladder{
 	height = 2;
-	icon_state = "ladderdown";
 	id = "hub2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -7546,7 +7524,6 @@
 "aMW" = (
 /obj/structure/ladder{
 	height = 1;
-	icon_state = "ladderup";
 	id = "hub2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -8752,7 +8729,6 @@
 "aUF" = (
 /obj/structure/ladder{
 	height = 1;
-	icon_state = "ladderup";
 	id = "hall8"
 	},
 /obj/machinery/light,
@@ -9297,7 +9273,6 @@
 "aZf" = (
 /obj/structure/ladder{
 	height = 1;
-	icon_state = "ladderup";
 	id = "hall5"
 	},
 /turf/open/floor/prison/marked,
@@ -9305,7 +9280,6 @@
 "aZg" = (
 /obj/structure/ladder{
 	height = 1;
-	icon_state = "ladderup";
 	id = "hall6"
 	},
 /turf/open/floor/prison/marked,
@@ -9313,7 +9287,6 @@
 "aZh" = (
 /obj/structure/ladder{
 	height = 1;
-	icon_state = "ladderup";
 	id = "hall7"
 	},
 /turf/open/floor/prison/marked,
@@ -9321,7 +9294,6 @@
 "aZj" = (
 /obj/structure/ladder{
 	height = 1;
-	icon_state = "ladderup";
 	id = "hall9"
 	},
 /turf/open/floor/prison/marked,
@@ -9575,7 +9547,6 @@
 /obj/effect/decal/cleanable/cobweb2,
 /obj/structure/ladder{
 	height = 2;
-	icon_state = "ladderdown";
 	id = "hub1"
 	},
 /turf/open/floor/plating,
@@ -11424,6 +11395,12 @@
 	dir = 1
 	},
 /area/sulaco/medbay/surgery_two)
+"gwQ" = (
+/obj/machinery/atmospherics/components/unary/cryo_cell,
+/turf/open/floor/prison/whitegreen/corner{
+	dir = 8
+	},
+/area/sulaco/medbay/west)
 "gAL" = (
 /obj/machinery/door/airlock/mainship/generic,
 /turf/open/floor/prison/sterilewhite,
@@ -11607,7 +11584,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/ladder{
 	height = 2;
-	icon_state = "ladderdown";
 	id = "morgue"
 	},
 /turf/open/floor/cult,
@@ -12380,7 +12356,6 @@
 	},
 /obj/structure/ladder{
 	height = 1;
-	icon_state = "ladderup";
 	id = "medsci"
 	},
 /turf/open/floor/prison/whitegreen/corner{
@@ -12627,6 +12602,7 @@
 /area/space)
 "kHl" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/machinery/sleeper,
 /turf/open/floor/prison/whitegreen/corner,
 /area/sulaco/medbay/west)
 "kJu" = (
@@ -13172,6 +13148,12 @@
 	dir = 4
 	},
 /area/space)
+"mbB" = (
+/obj/machinery/atmospherics/components/unary/cryo_cell,
+/turf/open/floor/prison/whitegreen/corner{
+	dir = 4
+	},
+/area/sulaco/medbay)
 "mbL" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -13957,7 +13939,6 @@
 "oxw" = (
 /obj/structure/ladder{
 	height = 2;
-	icon_state = "ladderdown";
 	id = "medsci"
 	},
 /turf/open/floor/prison/whitegreen{
@@ -14544,7 +14525,6 @@
 /turf/open/floor/plating,
 /area/sulaco/maintenance/north_solar_maint)
 "pNd" = (
-/obj/machinery/iv_drip,
 /obj/structure/sign/directions/science{
 	dir = 1
 	},
@@ -14758,6 +14738,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 4
 	},
@@ -15728,6 +15709,12 @@
 "sQE" = (
 /turf/open/floor/grass,
 /area/mainship/living/starboard_garden)
+"sSE" = (
+/obj/machinery/sleep_console,
+/turf/open/floor/prison/whitegreen/corner{
+	dir = 8
+	},
+/area/sulaco/medbay/west)
 "sTR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
@@ -16301,7 +16288,6 @@
 	},
 /obj/structure/ladder{
 	height = 1;
-	icon_state = "ladderup";
 	id = "hub1"
 	},
 /turf/open/floor/plating,
@@ -16532,6 +16518,12 @@
 	dir = 4
 	},
 /area/sulaco/showers)
+"vCj" = (
+/obj/machinery/iv_drip,
+/turf/open/floor/prison/whitegreen/corner{
+	dir = 8
+	},
+/area/sulaco/medbay/west)
 "vCN" = (
 /obj/structure/prop/mainship/sensor_computer3/sd,
 /turf/open/floor/mainship/tcomms,
@@ -17247,7 +17239,6 @@
 "xUM" = (
 /obj/structure/ladder{
 	height = 2;
-	icon_state = "ladderdown";
 	id = "hub3"
 	},
 /turf/open/floor/plating,
@@ -42478,7 +42469,7 @@ abD
 jDD
 abD
 woB
-adI
+vCj
 iFn
 xDJ
 saj
@@ -42992,7 +42983,7 @@ abD
 lrG
 adI
 lrG
-adI
+sSE
 lrG
 adI
 lvN
@@ -43504,7 +43495,7 @@ aXy
 aWG
 amz
 lrG
-eTR
+gwQ
 lrG
 aiq
 lrG
@@ -43512,7 +43503,7 @@ adI
 xgx
 hUh
 lrG
-adI
+eTR
 epP
 aew
 mDu
@@ -43761,7 +43752,7 @@ tvS
 aWG
 amz
 hto
-oRC
+adH
 hto
 air
 hto
@@ -43769,8 +43760,8 @@ adH
 afw
 adH
 adJ
-adH
-acd
+oRC
+hto
 aew
 mDu
 mDu
@@ -46595,7 +46586,7 @@ ahR
 adf
 esb
 adf
-aco
+mbB
 adf
 aco
 aeZ
@@ -46852,7 +46843,7 @@ abH
 abH
 lbq
 ade
-acp
+kMl
 ade
 kxt
 aeZ

--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -1027,6 +1027,10 @@
 	dir = 8
 	},
 /area/sulaco/medbay/west)
+"agm" = (
+/obj/machinery/vending/tool,
+/turf/open/floor/prison,
+/area/sulaco/hallway/lower_main_hall)
 "agz" = (
 /obj/machinery/door/airlock/mainship/medical/glass/CMO{
 	dir = 1
@@ -5076,15 +5080,8 @@
 /obj/item/storage/briefcase/inflatable,
 /turf/open/floor/prison,
 /area/sulaco/engineering/storage)
-"aAr" = (
-/obj/machinery/vending/engivend{
-	req_access = null
-	},
-/turf/open/floor/prison,
-/area/sulaco/engineering/storage)
 "aAs" = (
 /obj/machinery/alarm,
-/obj/machinery/vending/tool,
 /turf/open/floor/prison,
 /area/sulaco/engineering/storage)
 "aAt" = (
@@ -6500,8 +6497,8 @@
 /obj/machinery/power/apc/mainship{
 	dir = 1
 	},
-/mob/living/simple_animal/cat/Jones,
 /obj/structure/cable,
+/obj/structure/closet/secure_closet/captain,
 /turf/open/floor/wood,
 /area/sulaco/cap_office)
 "aHx" = (
@@ -7307,9 +7304,7 @@
 /area/sulaco/marine/alpha)
 "aLx" = (
 /obj/structure/prop/mainship/cannon_cable_connector,
-/turf/open/floor/prison/red/corner{
-	dir = 1
-	},
+/turf/open/floor/prison,
 /area/mainship/shipboard/weapon_room)
 "aLA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -7896,10 +7891,6 @@
 	},
 /turf/open/floor/prison/whitegreen/full,
 /area/sulaco/medbay/hangar)
-"aPx" = (
-/obj/structure/dropship_equipment/medevac_system,
-/turf/open/floor/prison,
-/area/sulaco/hangar)
 "aPA" = (
 /obj/structure/window/framed/mainship/gray/toughened,
 /obj/structure/sign/greencross,
@@ -8077,6 +8068,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 10
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
@@ -8846,7 +8840,6 @@
 /area/sulaco/maintenance/lower_maint)
 "aUX" = (
 /obj/structure/table/mainship,
-/obj/item/stack/sheet/mineral/phoron/medium_stack,
 /turf/open/floor/prison,
 /area/sulaco/maintenance/lower_maint)
 "aVc" = (
@@ -9497,7 +9490,6 @@
 /area/sulaco/telecomms)
 "baA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/structure/sink,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 8
 	},
@@ -9648,6 +9640,9 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table/mainship,
+/obj/item/stack/sheet/mineral/phoron/medium_stack,
+/obj/item/stack/sheet/mineral/phoron/medium_stack,
 /turf/open/floor/prison,
 /area/sulaco/hangar)
 "bbV" = (
@@ -10053,10 +10048,6 @@
 /obj/machinery/computer/crew,
 /turf/open/floor/carpet,
 /area/sulaco/liaison/quarters)
-"bHZ" = (
-/obj/structure/window/framed/mainship/gray,
-/turf/open/space/basic,
-/area/sulaco/cafeteria)
 "bIb" = (
 /obj/structure/sign/greencross,
 /turf/open/floor/prison,
@@ -10577,6 +10568,10 @@
 /obj/structure/cable,
 /turf/open/floor/prison/whitegreen/corner,
 /area/sulaco/medbay/storage2)
+"dDU" = (
+/obj/structure/window/framed/mainship/gray,
+/turf/open/floor/plating/platebotc,
+/area/mainship/shipboard/weapon_room)
 "dFk" = (
 /obj/machinery/camera/autoname,
 /turf/open/floor/prison/whitegreen{
@@ -10989,6 +10984,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/sulaco/engineering/ce)
+"eVE" = (
+/obj/machinery/light/small,
+/turf/open/floor/prison,
+/area/sulaco/hallway/lower_main_hall)
 "eXT" = (
 /obj/structure/rack,
 /obj/item/assembly/signaler,
@@ -11546,15 +11545,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall3)
 "gSo" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/mainship/engineering{
-	dir = 2
-	},
+/obj/machinery/door/airlock/mainship/engineering,
 /turf/open/floor/prison/red,
 /area/mainship/shipboard/weapon_room)
 "gSq" = (
@@ -11597,6 +11588,15 @@
 /obj/item/circuitboard/machine/smes,
 /turf/open/floor/prison,
 /area/sulaco/maintenance/lower_maint)
+"hbW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/ladder{
+	height = 2;
+	icon_state = "ladderdown";
+	id = "morgue"
+	},
+/turf/open/floor/cult,
+/area/sulaco/morgue)
 "hcB" = (
 /obj/effect/decal/siding{
 	dir = 4
@@ -11758,17 +11758,6 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/sulaco/engineering)
-"hNn" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 6
-	},
-/obj/structure/cable,
-/obj/docking_port/stationary/marine_dropship/crash_target,
-/turf/open/floor/prison,
-/area/sulaco/hallway/lower_main_hall)
 "hNA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -12011,6 +12000,12 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/mainship/command/self_destruct)
+"iqZ" = (
+/obj/machinery/vending/engivend{
+	req_access = null
+	},
+/turf/open/floor/prison,
+/area/sulaco/hallway/lower_main_hall)
 "iti" = (
 /obj/structure/closet/walllocker/hydrant,
 /obj/structure/closet/crate,
@@ -12241,7 +12236,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 6
 	},
@@ -12249,6 +12243,7 @@
 	dir = 6
 	},
 /obj/structure/cable,
+/obj/structure/dropship_equipment/medevac_system,
 /turf/open/floor/prison,
 /area/sulaco/maintenance/lower_maint)
 "jaQ" = (
@@ -12498,6 +12493,10 @@
 /obj/machinery/door_control/ai/interior,
 /turf/closed/wall/mainship/gray,
 /area/sulaco/command/ai)
+"kiJ" = (
+/obj/machinery/power/port_gen/pacman,
+/turf/open/floor/prison,
+/area/sulaco/hangar)
 "kji" = (
 /turf/open/floor/prison/red,
 /area/sulaco/hangar/one)
@@ -13252,6 +13251,11 @@
 	dir = 4
 	},
 /area/sulaco/cargo)
+"mub" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/reagent_containers/jerrycan,
+/turf/open/floor/prison,
+/area/sulaco/hangar)
 "mvt" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -13442,7 +13446,7 @@
 /area/sulaco/cryosleep)
 "mSU" = (
 /obj/machinery/door/airlock/mainship/generic,
-/turf/open/space/basic,
+/turf/open/floor/prison/red,
 /area/sulaco/cafeteria)
 "mSW" = (
 /obj/structure/sign/prop2,
@@ -13463,6 +13467,12 @@
 	dir = 8
 	},
 /area/sulaco/medbay/surgery_two)
+"mWe" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/framed/mainship/gray/toughened,
+/obj/docking_port/stationary/marine_dropship/crash_target,
+/turf/open/floor/plating/platebotc,
+/area/sulaco/hangar)
 "mYf" = (
 /turf/open/floor/prison/red,
 /area/sulaco/hallway/central_hall3)
@@ -13559,6 +13569,9 @@
 /area/mainship/shipboard/weapon_room)
 "nxz" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/structure/ladder{
+	id = "morgue"
+	},
 /turf/open/floor/prison/whitegreen/full,
 /area/sulaco/medbay/hangar)
 "nxT" = (
@@ -13593,7 +13606,6 @@
 /area/sulaco/hangar/one)
 "nGt" = (
 /obj/structure/table/mainship,
-/obj/item/stack/sheet/mineral/phoron/medium_stack,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
@@ -13723,6 +13735,7 @@
 /turf/open/floor/plating,
 /area/sulaco/maintenance/lower_maint2)
 "nWn" = (
+/obj/structure/closet/secure_closet/military_police,
 /turf/open/floor/prison/red/full{
 	dir = 8
 	},
@@ -14002,7 +14015,9 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
 	},
-/turf/open/space/basic,
+/turf/open/floor/prison/red{
+	dir = 1
+	},
 /area/sulaco/cafeteria)
 "oHK" = (
 /obj/structure/cable,
@@ -14139,6 +14154,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria)
 "oUA" = (
@@ -14165,8 +14181,10 @@
 /area/sulaco/hallway/lower_main_hall)
 "oXn" = (
 /obj/structure/bed/chair,
-/obj/item/radio/intercom/general,
 /obj/machinery/light,
+/obj/item/radio/intercom/general{
+	dir = 1
+	},
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 8
 	},
@@ -14229,7 +14247,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
-/obj/machinery/camera/autoname,
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
 "pgQ" = (
@@ -14741,10 +14758,6 @@
 "qDO" = (
 /turf/open/floor/mainship_hull/gray/dir,
 /area/space)
-"qIv" = (
-/obj/machinery/power/port_gen/pacman,
-/turf/open/floor/prison,
-/area/sulaco/maintenance/lower_maint)
 "qIA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
@@ -15100,10 +15113,11 @@
 "rzq" = (
 /turf/open/floor/prison,
 /area/sulaco/engineering/atmos)
+"rBq" = (
+/mob/living/simple_animal/cat/Jones,
+/turf/open/floor/wood,
+/area/sulaco/cap_office)
 "rBM" = (
-/obj/machinery/door/airlock/mainship/engineering{
-	dir = 2
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
@@ -15111,6 +15125,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
 	},
+/obj/machinery/door/airlock/mainship/engineering,
 /turf/open/floor/prison/red{
 	dir = 1
 	},
@@ -17110,6 +17125,12 @@
 /obj/machinery/atmospherics/pipe/manifold/yellow/hidden,
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
+"xzt" = (
+/obj/structure/sink,
+/turf/open/floor/prison/whitegreen/corner{
+	dir = 4
+	},
+/area/sulaco/medbay/surgery_two)
 "xzG" = (
 /turf/open/floor/plating,
 /area/sulaco/cap_office)
@@ -30341,7 +30362,7 @@ aaa
 aaa
 aaa
 aaa
-qDO
+aaa
 aaa
 aaa
 aaa
@@ -30598,7 +30619,7 @@ aaa
 aaa
 aaa
 aaa
-qDO
+aaa
 aUt
 aUt
 aUt
@@ -30854,8 +30875,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-qDO
+emV
+vyQ
 aUt
 aUt
 emV
@@ -30865,7 +30886,7 @@ vyQ
 aUt
 aUt
 emV
-aaa
+vyQ
 aaa
 aaa
 aaa
@@ -31111,7 +31132,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+nzi
 qDO
 aUt
 aUt
@@ -31122,7 +31143,7 @@ qDO
 aUt
 aUt
 nzi
-aaa
+qDO
 aaa
 aaa
 aaa
@@ -31368,7 +31389,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+nzi
 aIz
 aFy
 aFy
@@ -31379,15 +31400,15 @@ aIz
 aFy
 aFy
 aIz
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+mDu
+wRO
+wRO
+wRO
+wRO
+wRO
+wRO
+wRO
+wRO
 wRO
 wRO
 wRO
@@ -31625,7 +31646,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+nzi
 aIz
 aFG
 aFG
@@ -31636,15 +31657,15 @@ aIz
 aFG
 aFG
 aIz
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+mDu
+mDu
+mDu
+mDu
+mDu
+mDu
+mDu
+mDu
+mDu
 mDu
 mDu
 mDu
@@ -31882,7 +31903,7 @@ vyQ
 aaa
 aaa
 aaa
-aaa
+nzi
 aIz
 aFy
 aFy
@@ -32139,7 +32160,7 @@ qDO
 aaa
 aaa
 aaa
-aaa
+nzi
 aIz
 nwU
 aGD
@@ -32396,7 +32417,7 @@ mDu
 wRO
 wRO
 wRO
-aaa
+mDu
 aIz
 cwp
 aHz
@@ -32653,7 +32674,7 @@ mDu
 mDu
 mDu
 mDu
-aaa
+mDu
 aIz
 cwp
 qSH
@@ -34458,7 +34479,7 @@ aPg
 aIz
 aIz
 rBM
-aIz
+dDU
 gSo
 aIz
 mDu
@@ -36000,7 +36021,7 @@ anw
 anw
 anw
 oHm
-bHZ
+sZM
 mSU
 nWB
 nWB
@@ -39237,7 +39258,7 @@ aAZ
 aCv
 aDi
 aBN
-aFD
+rBq
 aFq
 lJS
 lJS
@@ -41914,7 +41935,7 @@ aWG
 xKR
 aWG
 ahd
-ahd
+xzt
 baA
 pYZ
 nyj
@@ -46796,9 +46817,9 @@ osv
 aWG
 xKR
 aWG
-aeZ
-aeZ
-aeZ
+abH
+abH
+abH
 abH
 abH
 abH
@@ -47053,9 +47074,9 @@ aPY
 aWG
 xKR
 aWG
-aPQ
-mDu
-aeZ
+iqZ
+aVY
+abH
 ajO
 aiA
 tXF
@@ -47310,9 +47331,9 @@ aPY
 aWG
 vmi
 aWG
-aPQ
-mDu
-aeZ
+eVE
+aVY
+abH
 yiP
 aio
 hvu
@@ -47567,9 +47588,9 @@ aGy
 aWG
 xKR
 aWG
-aPQ
-mDu
-aeZ
+agm
+aVY
+abH
 ajQ
 aiC
 ahF
@@ -47824,9 +47845,9 @@ aVZ
 aWG
 xKR
 aWG
-aPQ
-agH
-aeZ
+aVY
+abK
+abH
 abH
 ahG
 ahG
@@ -48334,8 +48355,8 @@ aPZ
 aPZ
 aSl
 aSv
-aJR
-hNn
+mWe
+iAq
 aSU
 uLr
 hKz
@@ -54128,7 +54149,7 @@ aQi
 aRl
 aRJ
 aSs
-sqS
+hbW
 aRJ
 aUc
 aRJ
@@ -54234,7 +54255,7 @@ aaa
 nzi
 mDu
 bFa
-aPF
+aRR
 aPF
 aYB
 aZS
@@ -54748,12 +54769,12 @@ aaa
 nzi
 mDu
 bFa
-aRR
+aPF
 aPF
 aPF
 gHU
 bVM
-aPF
+sKM
 aRQ
 aSu
 aPF
@@ -55272,7 +55293,7 @@ bFa
 aTq
 cdy
 aUL
-aTs
+mub
 aPY
 aPY
 aPY
@@ -56558,7 +56579,7 @@ aTt
 cdy
 aUO
 cdy
-vXo
+kiJ
 aPY
 kxY
 aWh
@@ -57586,7 +57607,7 @@ ubQ
 dLR
 aUL
 tpA
-aPx
+aMR
 aPY
 fVO
 aWh
@@ -58354,7 +58375,7 @@ tZr
 mDu
 mDu
 aTM
-qIv
+pWS
 mCT
 aZu
 aUu
@@ -58507,7 +58528,7 @@ mYf
 gRM
 axO
 pOF
-aAr
+aAu
 azb
 aCT
 azf

--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -17175,6 +17175,7 @@
 "xPO" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/yellow/hidden,
+/obj/structure/cable,
 /turf/open/floor/prison,
 /area/sulaco/briefing)
 "xTi" = (

--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -10109,6 +10109,10 @@
 "bPM" = (
 /turf/open/floor/prison/plate,
 /area/sulaco/cargo)
+"bSz" = (
+/obj/docking_port/stationary/marine_dropship/crash_target,
+/turf/closed/wall/mainship/gray,
+/area/sulaco/hangar)
 "bVz" = (
 /obj/machinery/light{
 	dir = 1
@@ -10721,17 +10725,6 @@
 	dir = 1
 	},
 /area/sulaco/cargo)
-"ecj" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/obj/docking_port/stationary/marine_dropship/crash_target,
-/turf/open/floor/freezer,
-/area/sulaco/showers)
 "eck" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -11887,10 +11880,6 @@
 	dir = 4
 	},
 /area/sulaco/marine/charlie)
-"hYU" = (
-/obj/docking_port/stationary/marine_dropship/crash_target,
-/turf/open/floor/prison/red,
-/area/sulaco/hallway/central_hall)
 "iaI" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
@@ -12894,6 +12883,7 @@
 /obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
 	dir = 1
 	},
+/obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria)
 "lpY" = (
@@ -13503,12 +13493,6 @@
 	dir = 8
 	},
 /area/sulaco/medbay/surgery_two)
-"mWe" = (
-/obj/machinery/door/firedoor,
-/obj/structure/window/framed/mainship/gray/toughened,
-/obj/docking_port/stationary/marine_dropship/crash_target,
-/turf/open/floor/plating/platebotc,
-/area/sulaco/hangar)
 "mYf" = (
 /turf/open/floor/prison/red,
 /area/sulaco/hallway/central_hall3)
@@ -13580,6 +13564,10 @@
 	},
 /turf/open/floor/mainship/tcomms,
 /area/sulaco/telecomms)
+"niS" = (
+/obj/docking_port/stationary/marine_dropship/crash_target,
+/turf/closed/wall/mainship/gray,
+/area/sulaco/bridge/quarters)
 "nrN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
@@ -13665,6 +13653,10 @@
 	dir = 8
 	},
 /area/sulaco/hangar/one)
+"nGL" = (
+/obj/docking_port/stationary/marine_dropship/crash_target,
+/turf/open/floor/freezer,
+/area/sulaco/showers)
 "nHz" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -16249,13 +16241,6 @@
 /obj/structure/cable,
 /turf/open/floor/prison/red,
 /area/sulaco/hallway/central_hall3)
-"uHq" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/obj/docking_port/stationary/marine_dropship/crash_target,
-/turf/open/floor/prison/sterilewhite,
-/area/sulaco/cafeteria)
 "uIN" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -37852,8 +37837,8 @@ aea
 agI
 ads
 aiO
-ecj
-aea
+gXd
+nGL
 aea
 ang
 any
@@ -39147,7 +39132,7 @@ any
 any
 lod
 sdn
-uHq
+sdn
 sdn
 sdn
 sdn
@@ -43914,8 +43899,8 @@ alQ
 amH
 aol
 edm
-hYU
-asQ
+arc
+niS
 asQ
 asQ
 azU
@@ -48396,7 +48381,7 @@ aPZ
 aPZ
 aSl
 aSv
-mWe
+aJR
 iAq
 aSU
 uLr
@@ -48653,7 +48638,7 @@ aPZ
 aPZ
 aSl
 aSw
-aPY
+bSz
 aTA
 aXA
 aWx

--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -67,7 +67,6 @@
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cryosleep)
 "aaB" = (
-/obj/machinery/vending/nanomed,
 /obj/effect/landmark/start/job/squadleader,
 /obj/effect/decal/warning_stripes/thick{
 	dir = 1
@@ -83,14 +82,6 @@
 /area/sulaco/cryosleep)
 "aaD" = (
 /obj/machinery/vending/nanomed,
-/obj/effect/decal/warning_stripes/thick{
-	dir = 1
-	},
-/turf/open/floor/prison/sterilewhite,
-/area/sulaco/cryosleep)
-"aaE" = (
-/obj/machinery/alarm,
-/obj/effect/landmark/start/job/squadleader,
 /obj/effect/decal/warning_stripes/thick{
 	dir = 1
 	},
@@ -2562,13 +2553,13 @@
 /obj/machinery/vending/nanomed{
 	dir = 4
 	},
-/obj/structure/table/mainship,
+/obj/structure/closet/secure_closet/guncabinet/mp_armory,
 /turf/open/floor/prison/red{
 	dir = 9
 	},
 /area/sulaco/bridge)
 "app" = (
-/obj/machinery/alarm,
+/obj/machinery/vending/security,
 /turf/open/floor/prison/red{
 	dir = 1
 	},
@@ -3385,10 +3376,10 @@
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria)
 "asP" = (
-/obj/structure/table/mainship,
-/obj/structure/paper_bin,
-/obj/item/tool/pen,
 /obj/machinery/camera/autoname,
+/obj/item/storage/pouch/medical,
+/obj/structure/rack,
+/obj/item/storage/firstaid/adv,
 /turf/open/floor/prison/red/full,
 /area/sulaco/bridge)
 "asQ" = (
@@ -4727,11 +4718,11 @@
 /area/sulaco/engineering)
 "ayF" = (
 /obj/structure/window/reinforced,
-/obj/machinery/computer/secure_data,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
 	},
 /obj/structure/table/mainship,
+/obj/machinery/computer/shuttle/shuttle_control/dropship1,
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/bridge)
 "ayI" = (
@@ -4933,6 +4924,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/structure/closet/secure_closet/staff_officer,
 /turf/open/floor/prison/red/full{
 	dir = 8
 	},
@@ -5164,7 +5156,7 @@
 /turf/closed/wall/mainship/gray,
 /area/sulaco/command/ai)
 "aAN" = (
-/obj/structure/table/mainship,
+/obj/structure/closet/secure_closet/guncabinet/m41aMK1,
 /turf/open/floor/prison/red{
 	dir = 10
 	},
@@ -5387,6 +5379,7 @@
 /obj/machinery/power/terminal{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/prison/red/full{
 	dir = 1
 	},
@@ -5442,10 +5435,13 @@
 	},
 /area/sulaco/engineering)
 "aCf" = (
-/obj/structure/table/mainship,
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/item/clothing/suit/armor/bulletproof,
 /turf/open/floor/prison/red/full{
 	dir = 1
 	},
@@ -10160,6 +10156,12 @@
 "cfA" = (
 /turf/closed/wall/mainship/gray/outer,
 /area/sulaco/marine)
+"chQ" = (
+/obj/machinery/alarm{
+	dir = 8
+	},
+/turf/open/floor/prison/sterilewhite,
+/area/sulaco/cryosleep)
 "cjc" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /turf/open/floor/mainship/tcomms,
@@ -10488,6 +10490,13 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/prison/arrow,
 /area/sulaco/marine)
+"drJ" = (
+/obj/structure/cable,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/sulaco/maintenance/north_solar_maint)
 "dse" = (
 /obj/machinery/door/poddoor/open/engine{
 	dir = 1
@@ -10941,6 +10950,15 @@
 	dir = 4
 	},
 /area/sulaco/medbay/surgery_one)
+"eMY" = (
+/obj/machinery/door_control{
+	id = "mbayexit";
+	name = "medbay exit";
+	normaldoorcontrol = 1;
+	pixel_y = 28
+	},
+/turf/open/floor/prison/whitegreen/corner,
+/area/sulaco/medbay)
 "eOE" = (
 /obj/machinery/computer/supplycomp,
 /turf/open/floor/prison/plate,
@@ -11367,6 +11385,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
+"gnG" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/prison,
+/area/sulaco/hallway/central_hall2)
 "gqU" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
 	dir = 1
@@ -12169,6 +12191,13 @@
 /obj/machinery/light,
 /turf/open/floor/wood,
 /area/sulaco/cap_office)
+"iNW" = (
+/obj/effect/decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/machinery/vending/nanomed,
+/turf/open/floor/prison/sterilewhite,
+/area/sulaco/cryosleep)
 "iOf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1,
@@ -12911,6 +12940,13 @@
 	},
 /turf/open/floor/prison/whitegreen/corner,
 /area/sulaco/medbay/surgery_two)
+"lsO" = (
+/obj/structure/closet/secure_closet/military_police,
+/obj/item/weapon/gun/energy/taser,
+/turf/open/floor/prison/red{
+	dir = 1
+	},
+/area/sulaco/bridge)
 "lsW" = (
 /obj/machinery/door/poddoor/mainship/ai/interior{
 	dir = 1
@@ -13491,6 +13527,12 @@
 	dir = 1
 	},
 /area/sulaco/cargo)
+"nan" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/sulaco/maintenance/north_solar_maint)
 "nbD" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -13570,6 +13612,7 @@
 "nxz" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /obj/structure/ladder{
+	height = 1;
 	id = "morgue"
 	},
 /turf/open/floor/prison/whitegreen/full,
@@ -13735,7 +13778,7 @@
 /turf/open/floor/plating,
 /area/sulaco/maintenance/lower_maint2)
 "nWn" = (
-/obj/structure/closet/secure_closet/military_police,
+/obj/structure/closet/secure_closet/staff_officer,
 /turf/open/floor/prison/red/full{
 	dir = 8
 	},
@@ -14830,6 +14873,10 @@
 /obj/structure/cable,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cryosleep)
+"qRA" = (
+/obj/machinery/vending/uniform_supply,
+/turf/open/floor/prison/red,
+/area/sulaco/bridge)
 "qSH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
@@ -16335,6 +16382,10 @@
 /obj/structure/sign/greencross/star,
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_main_hall)
+"uXn" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/sulaco/maintenance/south_solar_maint)
 "uXx" = (
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct,
 /obj/machinery/door/airlock/mainship/secure/free_access{
@@ -16392,7 +16443,6 @@
 /turf/open/floor/plating,
 /area/sulaco/maintenance/lower_maint2)
 "viB" = (
-/obj/machinery/power/apc/mainship,
 /obj/structure/rack,
 /obj/structure/ob_ammo/warhead/plasmaloss,
 /obj/structure/ob_ammo/warhead/plasmaloss,
@@ -16741,15 +16791,6 @@
 	dir = 1
 	},
 /area/space)
-"wvj" = (
-/obj/machinery/door_control{
-	id = "mbayexit";
-	name = "medbay exit";
-	normaldoorcontrol = 1;
-	pixel_y = -22
-	},
-/turf/open/floor/prison/whitegreen/corner,
-/area/sulaco/medbay)
 "wwl" = (
 /obj/structure/table/mainship,
 /obj/item/storage/surgical_tray,
@@ -34715,7 +34756,7 @@ aaa
 nzi
 mDu
 abq
-aay
+iNW
 qPv
 qPv
 qPv
@@ -36162,7 +36203,7 @@ aaa
 aaa
 aEH
 gNS
-apu
+lsO
 asr
 asd
 aqu
@@ -36170,7 +36211,7 @@ asV
 ayF
 asd
 asr
-aAU
+qRA
 gNS
 aEH
 aaa
@@ -36928,9 +36969,9 @@ aaa
 aaa
 aaa
 nzi
-qDO
-aaa
-aaa
+mDu
+wRO
+wRO
 aEH
 tbJ
 apr
@@ -36944,9 +36985,9 @@ asr
 aDd
 tbJ
 aEH
-aaa
-aaa
-nzi
+wRO
+wRO
+mDu
 qDO
 aaa
 aaa
@@ -37185,9 +37226,9 @@ aaa
 aaa
 aaa
 nzi
-qDO
-aaa
-aaa
+mDu
+mDu
+mDu
 aEH
 tbJ
 aoO
@@ -37201,9 +37242,9 @@ awn
 avv
 tbJ
 aEH
-aaa
-aaa
-nzi
+mDu
+mDu
+mDu
 qDO
 aaa
 aaa
@@ -38570,7 +38611,7 @@ aaa
 nzi
 mDu
 riP
-aaE
+aaB
 aay
 aaY
 aaY
@@ -39342,7 +39383,7 @@ nzi
 mDu
 abq
 aaG
-aaY
+chQ
 lDs
 ejj
 cwG
@@ -40292,7 +40333,7 @@ aDi
 aDi
 aDi
 aDi
-aCg
+uXn
 aJm
 mDu
 mDu
@@ -40544,7 +40585,7 @@ apB
 azq
 aEn
 aCg
-aCg
+onG
 aEs
 aCg
 aCg
@@ -41299,7 +41340,7 @@ aYZ
 aYZ
 aYZ
 aYZ
-aaW
+nan
 aaW
 aaw
 apD
@@ -42833,7 +42874,7 @@ aaa
 nzi
 mDu
 aYZ
-aaW
+aaV
 aVc
 aVc
 aVc
@@ -44996,7 +45037,7 @@ nzi
 mDu
 mDu
 aPg
-aQw
+phy
 aQw
 aQw
 aQw
@@ -45661,7 +45702,7 @@ tZr
 mDu
 mDu
 aYZ
-aaW
+aaV
 aRh
 aEF
 aTa
@@ -45670,7 +45711,7 @@ aQM
 aRI
 fkY
 aVO
-aCE
+aoi
 aon
 cnu
 cnu
@@ -46292,7 +46333,7 @@ mDu
 mDu
 mDu
 aPg
-aQw
+phy
 oBg
 sQE
 xve
@@ -46307,9 +46348,9 @@ ahz
 kMl
 ade
 kMl
-wvj
-abH
 ade
+abH
+eMY
 lbq
 ade
 kMl
@@ -46441,7 +46482,7 @@ aaW
 aaw
 anj
 ank
-aor
+gnG
 eTC
 aor
 asz
@@ -46694,7 +46735,7 @@ mDu
 mDu
 mDu
 aYZ
-aaW
+aaV
 aaw
 wHi
 ank
@@ -46798,7 +46839,7 @@ mDu
 mDu
 mDu
 aPg
-aQw
+phy
 aQw
 aQw
 aQw
@@ -50037,7 +50078,7 @@ aaa
 nzi
 mDu
 aYZ
-alI
+drJ
 aaw
 aoA
 apP
@@ -51064,7 +51105,7 @@ aaa
 nzi
 mDu
 aYZ
-aaW
+aaV
 pMU
 aaw
 anr
@@ -53120,7 +53161,7 @@ mDu
 mDu
 mDu
 aYZ
-aaW
+aaV
 aaW
 abs
 anr
@@ -53887,7 +53928,7 @@ mDu
 aYZ
 aYZ
 aYZ
-aaW
+aaV
 aQi
 aQi
 aQi
@@ -55427,7 +55468,7 @@ aaa
 nzi
 mDu
 aYZ
-aaW
+aaV
 aWW
 sqS
 aQy
@@ -56971,7 +57012,7 @@ mDu
 mDu
 aYZ
 aYZ
-aaW
+aaV
 aaW
 aaW
 aaW
@@ -58514,7 +58555,7 @@ aaa
 nzi
 mDu
 aYZ
-aaW
+aaV
 aYM
 bdx
 baz
@@ -60569,7 +60610,7 @@ mDu
 mDu
 mDu
 aYZ
-aaW
+aaV
 aaW
 aYS
 bdA
@@ -61850,7 +61891,7 @@ aaa
 nzi
 mDu
 aYZ
-aaW
+aaV
 aeh
 aeV
 afQ

--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -186,6 +186,15 @@
 	dir = 4
 	},
 /area/sulaco/hangar/one)
+"abh" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/turf/open/floor/prison,
+/area/mainship/shipboard/weapon_room)
 "abj" = (
 /turf/open/floor/prison/red{
 	dir = 8
@@ -5007,12 +5016,6 @@
 /obj/machinery/light,
 /turf/open/floor/prison,
 /area/sulaco/briefing)
-"aAd" = (
-/obj/machinery/door/airlock/mainship/engineering{
-	dir = 2
-	},
-/turf/open/floor/prison,
-/area/mainship/shipboard/weapon_room)
 "aAe" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -5253,14 +5256,11 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall)
 "aBo" = (
-/obj/machinery/door/airlock/mainship/engineering{
+/obj/machinery/door/airlock/mainship/maint{
 	dir = 2
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/turf/open/floor/prison,
-/area/mainship/shipboard/weapon_room)
+/turf/open/floor/plating,
+/area/sulaco/maintenance/south_solar_maint)
 "aBt" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 8
@@ -5835,14 +5835,6 @@
 /obj/machinery/marine_selector/gear/leader,
 /turf/open/floor/prison,
 /area/sulaco/marine/charlie)
-"aDY" = (
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/turf/open/floor/prison/red{
-	dir = 4
-	},
-/area/mainship/shipboard/weapon_room)
 "aDZ" = (
 /turf/open/floor/mainship/research/containment/floor2{
 	dir = 9
@@ -5930,19 +5922,10 @@
 	},
 /area/sulaco/engineering/engine)
 "aEn" = (
-/obj/structure/rack{
-	dir = 1
-	},
-/obj/item/clothing/suit/fire/firefighter,
-/obj/item/tank/oxygen,
-/obj/item/clothing/mask/gas,
-/obj/item/tool/extinguisher,
-/obj/item/clothing/head/hardhat/red,
-/obj/item/clothing/glasses/meson,
-/obj/effect/decal/cleanable/cobweb2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/mainship,
-/area/mainship/shipboard/weapon_room)
+/obj/structure/closet/firecloset,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating,
+/area/sulaco/maintenance/south_solar_maint)
 "aEo" = (
 /obj/machinery/power/apc/mainship,
 /obj/structure/cable,
@@ -6225,13 +6208,6 @@
 /obj/machinery/door_control/ai/exterior,
 /turf/closed/wall/mainship/gray,
 /area/sulaco/command/ai)
-"aFL" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/turf/open/floor/prison/red/corner{
-	dir = 4
-	},
-/area/mainship/shipboard/weapon_room)
 "aFR" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
@@ -6384,22 +6360,6 @@
 /obj/item/radio/intercom/general,
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall3)
-"aGA" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/turf/open/floor/prison/red{
-	dir = 8
-	},
-/area/mainship/shipboard/weapon_room)
-"aGB" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/turf/open/floor/prison/red{
-	dir = 9
-	},
-/area/mainship/shipboard/weapon_room)
 "aGC" = (
 /turf/open/floor/mainship/ai,
 /area/sulaco/command/ai)
@@ -6544,29 +6504,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/sulaco/cap_office)
-"aHq" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 1
-	},
-/turf/open/floor/plating/mainship,
-/area/mainship/shipboard/weapon_room)
-"aHr" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/turf/open/floor/prison/red{
-	dir = 8
-	},
-/area/mainship/shipboard/weapon_room)
-"aHw" = (
-/obj/machinery/camera/autoname,
-/turf/open/floor/prison/red{
-	dir = 1
-	},
-/area/mainship/shipboard/weapon_room)
 "aHx" = (
 /obj/structure/table/mainship,
 /obj/structure/paper_bin,
@@ -6578,11 +6515,6 @@
 	},
 /area/sulaco/engineering/engine)
 "aHz" = (
-/turf/open/floor/prison,
-/area/mainship/shipboard/weapon_room)
-"aHA" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/prison,
 /area/mainship/shipboard/weapon_room)
 "aHD" = (
@@ -6978,12 +6910,6 @@
 /obj/structure/orbital_cannon,
 /turf/open/floor/prison/red{
 	dir = 8
-	},
-/area/mainship/shipboard/weapon_room)
-"aJA" = (
-/obj/structure/prop/mainship/cannon_cables,
-/turf/open/floor/prison/red{
-	dir = 4
 	},
 /area/mainship/shipboard/weapon_room)
 "aJF" = (
@@ -7418,24 +7344,6 @@
 	dir = 4
 	},
 /area/sulaco/marine/alpha)
-"aLH" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 9
-	},
-/turf/open/floor/prison/red,
-/area/mainship/shipboard/weapon_room)
-"aLI" = (
-/obj/structure/ob_ammo/warhead/incendiary,
-/obj/structure/ob_ammo/warhead/incendiary,
-/obj/structure/ob_ammo/warhead/incendiary,
-/obj/structure/rack,
-/turf/open/floor/prison/red{
-	dir = 4
-	},
-/area/mainship/shipboard/weapon_room)
 "aLJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
@@ -7547,15 +7455,6 @@
 	},
 /turf/open/floor/prison/whitegreen/full,
 /area/sulaco/research)
-"aMi" = (
-/obj/structure/ob_ammo/warhead/explosive,
-/obj/structure/ob_ammo/warhead/explosive,
-/obj/structure/ob_ammo/warhead/explosive,
-/obj/structure/rack,
-/turf/open/floor/prison/red{
-	dir = 4
-	},
-/area/mainship/shipboard/weapon_room)
 "aMj" = (
 /obj/machinery/light{
 	dir = 4
@@ -7673,14 +7572,6 @@
 	dir = 4
 	},
 /area/sulaco/marine/charlie)
-"aMZ" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/prison/red{
-	dir = 1
-	},
-/area/mainship/shipboard/weapon_room)
 "aNa" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /turf/open/floor/prison/darkyellow{
@@ -7720,15 +7611,6 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall3)
-"aNt" = (
-/obj/structure/ob_ammo/warhead/cluster,
-/obj/structure/ob_ammo/warhead/cluster,
-/obj/structure/ob_ammo/warhead/cluster,
-/obj/structure/rack,
-/turf/open/floor/prison/red{
-	dir = 6
-	},
-/area/mainship/shipboard/weapon_room)
 "aNu" = (
 /obj/machinery/light{
 	dir = 8
@@ -7964,27 +7846,6 @@
 /obj/machinery/light/small,
 /obj/vehicle/powerloader,
 /turf/open/floor/prison,
-/area/mainship/shipboard/weapon_room)
-"aPb" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/turf/open/floor/prison/red/corner,
-/area/mainship/shipboard/weapon_room)
-"aPc" = (
-/obj/machinery/alarm{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/turf/open/floor/prison/red,
 /area/mainship/shipboard/weapon_room)
 "aPd" = (
 /obj/structure/sign/chemistry,
@@ -9069,16 +8930,6 @@
 "aVB" = (
 /turf/closed/wall/indestructible/bulkhead,
 /area/sulaco/command/eva)
-"aVF" = (
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/turf/open/floor/prison/red,
-/area/mainship/shipboard/weapon_room)
 "aVG" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -10188,8 +10039,10 @@
 	},
 /area/sulaco/marine/charlie)
 "bHs" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 5
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria)
@@ -10200,6 +10053,10 @@
 /obj/machinery/computer/crew,
 /turf/open/floor/carpet,
 /area/sulaco/liaison/quarters)
+"bHZ" = (
+/obj/structure/window/framed/mainship/gray,
+/turf/open/space/basic,
+/area/sulaco/cafeteria)
 "bIb" = (
 /obj/structure/sign/greencross,
 /turf/open/floor/prison,
@@ -10595,6 +10452,13 @@
 /obj/machinery/vending/dress_supply,
 /turf/open/floor/prison/red/full,
 /area/sulaco/bridge)
+"dhK" = (
+/obj/machinery/power/apc/mainship,
+/obj/structure/cable,
+/turf/open/floor/prison/red{
+	dir = 5
+	},
+/area/mainship/shipboard/weapon_room)
 "dka" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -10693,6 +10557,12 @@
 /obj/structure/window/framed/mainship/gray/toughened/hull,
 /turf/open/floor/plating/platebotc,
 /area/sulaco/engineering/atmos)
+"dzL" = (
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/sulaco/maintenance/lower_maint2)
 "dAO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/yellow/hidden,
@@ -11155,12 +11025,6 @@
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/prison/bright_clean,
 /area/mainship/command/self_destruct)
-"feM" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison/red{
-	dir = 1
-	},
-/area/mainship/shipboard/weapon_room)
 "feO" = (
 /obj/effect/decal/siding{
 	dir = 5
@@ -11309,6 +11173,18 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall3)
+"fFy" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/rack,
+/obj/structure/ob_ammo/warhead/explosive,
+/obj/structure/ob_ammo/warhead/explosive,
+/obj/structure/ob_ammo/warhead/explosive,
+/turf/open/floor/prison/red{
+	dir = 1
+	},
+/area/mainship/shipboard/weapon_room)
 "fGh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
@@ -11388,19 +11264,17 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/mainship/command/self_destruct)
-"fXX" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/turf/open/floor/prison/red/corner{
-	dir = 4
-	},
-/area/mainship/shipboard/weapon_room)
 "gcc" = (
 /turf/open/floor/prison/red{
 	dir = 10
 	},
 /area/sulaco/hangar/one)
+"gcq" = (
+/obj/structure/prop/mainship/cannon_cables,
+/turf/open/floor/prison/red/corner{
+	dir = 1
+	},
+/area/mainship/shipboard/weapon_room)
 "gdq" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -11650,6 +11524,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria)
 "gRI" = (
@@ -11670,6 +11545,18 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall3)
+"gSo" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/mainship/engineering{
+	dir = 2
+	},
+/turf/open/floor/prison/red,
+/area/mainship/shipboard/weapon_room)
 "gSq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
@@ -11687,6 +11574,11 @@
 	},
 /turf/open/floor/freezer,
 /area/sulaco/showers)
+"gXA" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/turf/open/floor/prison,
+/area/mainship/shipboard/weapon_room)
 "gZO" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/machinery/camera/autoname,
@@ -11746,6 +11638,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/hallway/central_hall3)
+"hlP" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 6
+	},
+/turf/open/floor/prison/red{
+	dir = 1
+	},
+/area/sulaco/hallway/lower_main_hall)
 "hnW" = (
 /obj/structure/target_stake,
 /obj/item/target,
@@ -11833,6 +11737,15 @@
 "hKB" = (
 /turf/open/floor/prison/red/corner,
 /area/sulaco/cargo)
+"hKJ" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 6
+	},
+/turf/open/floor/prison,
+/area/mainship/shipboard/weapon_room)
 "hLm" = (
 /obj/effect/decal/siding{
 	dir = 9
@@ -12103,16 +12016,6 @@
 /obj/structure/closet/crate,
 /turf/open/floor/prison,
 /area/sulaco/engineering/storage)
-"its" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/turf/open/floor/prison/red/corner,
-/area/mainship/shipboard/weapon_room)
 "iuI" = (
 /obj/machinery/iv_drip,
 /obj/effect/decal/cleanable/dirt,
@@ -12185,6 +12088,15 @@
 	},
 /turf/open/floor/prison/plate,
 /area/shuttle/distress/arrive_1)
+"iCj" = (
+/obj/structure/rack,
+/obj/structure/ob_ammo/warhead/cluster,
+/obj/structure/ob_ammo/warhead/cluster,
+/obj/structure/ob_ammo/warhead/cluster,
+/turf/open/floor/prison/red{
+	dir = 1
+	},
+/area/mainship/shipboard/weapon_room)
 "iEv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
@@ -12612,6 +12524,18 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/maintenance/lower_maint)
+"knr" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 10
+	},
+/turf/open/floor/prison/red{
+	dir = 1
+	},
+/area/sulaco/hallway/lower_main_hall)
 "koN" = (
 /obj/structure/window/framed/mainship/gray/toughened/hull,
 /turf/open/floor/plating/platebotc,
@@ -12900,6 +12824,14 @@
 	dir = 8
 	},
 /area/sulaco/hangar/one)
+"ljR" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/prison/red{
+	dir = 1
+	},
+/area/sulaco/hallway/lower_main_hall)
 "lkp" = (
 /turf/open/floor/prison/red,
 /area/mainship/shipboard/weapon_room)
@@ -13222,16 +13154,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall3)
-"mcG" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 9
-	},
-/turf/open/floor/prison/red,
-/area/mainship/shipboard/weapon_room)
 "mdt" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/red,
@@ -13518,10 +13440,23 @@
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cryosleep)
+"mSU" = (
+/obj/machinery/door/airlock/mainship/generic,
+/turf/open/space/basic,
+/area/sulaco/cafeteria)
 "mSW" = (
 /obj/structure/sign/prop2,
 /turf/closed/wall/mainship/gray/outer,
 /area/sulaco/hallway/central_hall3)
+"mVd" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/prison/red/corner,
+/area/mainship/shipboard/weapon_room)
 "mVu" = (
 /obj/structure/table/mainship,
 /turf/open/floor/prison/whitegreen/corner{
@@ -13719,6 +13654,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/prison,
 /area/sulaco/hangar)
+"nOn" = (
+/turf/open/floor/prison/red{
+	dir = 1
+	},
+/area/sulaco/hallway/lower_main_hall)
 "nOS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -13890,6 +13830,16 @@
 /obj/structure/rack,
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
+"olF" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/sulaco/hallway/central_hall)
 "olH" = (
 /obj/machinery/door/airlock/mainship/secure/free_access{
 	name = "Self Destruct Room"
@@ -14044,8 +13994,15 @@
 /turf/open/floor/prison,
 /area/sulaco/marine/delta)
 "oHm" = (
-/obj/machinery/door/airlock/mainship/maint,
-/turf/open/floor/plating,
+/obj/machinery/door/airlock/mainship/generic,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/turf/open/space/basic,
 /area/sulaco/cafeteria)
 "oHK" = (
 /obj/structure/cable,
@@ -14176,11 +14133,11 @@
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria)
 "oSV" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 6
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria)
@@ -14196,6 +14153,16 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /turf/open/floor/prison/red,
 /area/sulaco/cargo)
+"oVU" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/prison,
+/area/sulaco/hallway/lower_main_hall)
 "oXn" = (
 /obj/structure/bed/chair,
 /obj/item/radio/intercom/general,
@@ -14265,6 +14232,18 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
+"pgQ" = (
+/obj/machinery/camera/autoname,
+/turf/open/floor/prison/red{
+	dir = 1
+	},
+/area/sulaco/hallway/lower_main_hall)
+"phy" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/sulaco/maintenance/lower_maint2)
 "pks" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -14368,6 +14347,19 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/telecomms/office)
+"pxD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/turf/open/floor/prison/red/corner{
+	dir = 1
+	},
+/area/mainship/shipboard/weapon_room)
 "pxV" = (
 /obj/machinery/light{
 	dir = 1
@@ -14382,18 +14374,6 @@
 "pxY" = (
 /turf/closed/wall/mainship/gray/outer,
 /area/sulaco/liaison/quarters)
-"pzN" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 6
-	},
-/turf/open/floor/prison/red{
-	dir = 8
-	},
-/area/mainship/shipboard/weapon_room)
 "pzX" = (
 /obj/structure/cable,
 /turf/closed/wall/mainship/gray,
@@ -14486,6 +14466,16 @@
 "pLJ" = (
 /turf/closed/wall/mainship/gray/outer,
 /area/sulaco/bridge/office)
+"pLR" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/turf/open/floor/prison/sterilewhite,
+/area/sulaco/cafeteria)
 "pMx" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
@@ -14731,6 +14721,19 @@
 /obj/machinery/door/airlock/external,
 /turf/open/floor/prison,
 /area/sulaco/command/eva)
+"qyL" = (
+/turf/open/floor/prison/red,
+/area/sulaco/hallway/lower_main_hall)
+"qzc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/sulaco/hallway/lower_main_hall)
 "qAW" = (
 /obj/structure/cable,
 /turf/open/floor/prison,
@@ -15048,6 +15051,10 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
+"rtA" = (
+/obj/machinery/light/small,
+/turf/open/floor/prison/red,
+/area/sulaco/hallway/lower_main_hall)
 "rtC" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/yellow/hidden,
@@ -15093,6 +15100,21 @@
 "rzq" = (
 /turf/open/floor/prison,
 /area/sulaco/engineering/atmos)
+"rBM" = (
+/obj/machinery/door/airlock/mainship/engineering{
+	dir = 2
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/turf/open/floor/prison/red{
+	dir = 1
+	},
+/area/mainship/shipboard/weapon_room)
 "rDF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1,
@@ -15134,6 +15156,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/sulaco/engineering/atmos)
+"rJl" = (
+/obj/machinery/camera/autoname,
+/obj/structure/rack,
+/obj/structure/ob_ammo/warhead/incendiary,
+/obj/structure/ob_ammo/warhead/incendiary,
+/obj/structure/ob_ammo/warhead/incendiary,
+/turf/open/floor/prison/red{
+	dir = 1
+	},
+/area/mainship/shipboard/weapon_room)
 "rJr" = (
 /turf/open/floor/mainship/terragov/west{
 	dir = 8
@@ -15664,6 +15696,11 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/wood,
 /area/sulaco/liaison/quarters)
+"sXi" = (
+/turf/open/floor/prison/red{
+	dir = 6
+	},
+/area/mainship/shipboard/weapon_room)
 "sXj" = (
 /obj/structure/table/mainship,
 /turf/open/floor/prison/whitegreen/corner{
@@ -15860,11 +15897,12 @@
 	},
 /area/sulaco/engineering)
 "tIY" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/prison/red{
-	dir = 6
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/decal/cleanable/cobweb{
+	dir = 8
 	},
-/area/mainship/shipboard/weapon_room)
+/turf/open/floor/plating,
+/area/sulaco/maintenance/south_solar_maint)
 "tIZ" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/prison/kitchen,
@@ -15912,10 +15950,6 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/wood,
 /area/sulaco/liaison/quarters)
-"tRj" = (
-/obj/structure/window/framed/mainship/gray/toughened/hull,
-/turf/open/floor/plating/platebotc,
-/area/mainship/shipboard/weapon_room)
 "tSP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
@@ -16014,15 +16048,6 @@
 	},
 /turf/open/floor/prison/marked,
 /area/sulaco/cargo)
-"ufk" = (
-/obj/machinery/power/apc/mainship{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/prison/red{
-	dir = 4
-	},
-/area/mainship/shipboard/weapon_room)
 "ufs" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -16162,13 +16187,6 @@
 /obj/structure/cable,
 /turf/open/floor/prison/red,
 /area/sulaco/hallway/central_hall3)
-"uGh" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/turf/open/floor/prison/red{
-	dir = 8
-	},
-/area/mainship/shipboard/weapon_room)
 "uHq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
@@ -16358,6 +16376,16 @@
 /obj/machinery/door/airlock/mainship/maint,
 /turf/open/floor/plating,
 /area/sulaco/maintenance/lower_maint2)
+"viB" = (
+/obj/machinery/power/apc/mainship,
+/obj/structure/rack,
+/obj/structure/ob_ammo/warhead/plasmaloss,
+/obj/structure/ob_ammo/warhead/plasmaloss,
+/obj/structure/ob_ammo/warhead/plasmaloss,
+/turf/open/floor/prison/red{
+	dir = 1
+	},
+/area/mainship/shipboard/weapon_room)
 "viK" = (
 /obj/structure/sign/atmosplaque,
 /turf/closed/wall/mainship/gray,
@@ -16476,19 +16504,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/sulaco/maintenance/lower_maint2)
-"vJm" = (
-/obj/structure/rack,
-/obj/structure/ob_ammo/warhead/plasmaloss,
-/obj/structure/ob_ammo/warhead/plasmaloss,
-/obj/structure/ob_ammo/warhead/plasmaloss,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/turf/open/floor/prison/red,
-/area/mainship/shipboard/weapon_room)
 "vMB" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/prison,
@@ -16568,6 +16583,12 @@
 /obj/item/reagent_containers/jerrycan,
 /turf/open/floor/prison,
 /area/sulaco/hangar)
+"vXS" = (
+/obj/machinery/alarm{
+	dir = 1
+	},
+/turf/open/floor/prison/red,
+/area/mainship/shipboard/weapon_room)
 "waf" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/structure/window/framed/mainship/gray/toughened,
@@ -17135,6 +17156,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/sulaco/maintenance/lower_maint)
+"xJd" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/prison,
+/area/sulaco/hallway/lower_main_hall)
 "xKR" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
@@ -30310,7 +30341,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+qDO
 aaa
 aaa
 aaa
@@ -30567,16 +30598,16 @@ aaa
 aaa
 aaa
 aaa
+qDO
+aUt
+aUt
+aUt
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aUt
+aUt
+aUt
+aUt
 aaa
 aaa
 aaa
@@ -30824,16 +30855,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+qDO
+aUt
+aUt
+emV
+wRO
+wRO
+vyQ
+aUt
+aUt
+emV
 aaa
 aaa
 aaa
@@ -31081,16 +31112,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+qDO
+aUt
+aUt
+nzi
+mDu
+mDu
+qDO
+aUt
+aUt
+nzi
 aaa
 aaa
 aaa
@@ -31338,6 +31369,16 @@ aaa
 aaa
 aaa
 aaa
+aIz
+aFy
+aFy
+aIz
+mDu
+mDu
+aIz
+aFy
+aFy
+aIz
 aaa
 aaa
 aaa
@@ -31347,16 +31388,6 @@ aaa
 aaa
 aaa
 aaa
-emV
-wRO
-wRO
-wRO
-wRO
-wRO
-wRO
-wRO
-wRO
-wRO
 wRO
 wRO
 wRO
@@ -31595,6 +31626,16 @@ aaa
 aaa
 aaa
 aaa
+aIz
+aFG
+aFG
+aIz
+mDu
+mDu
+aIz
+aFG
+aFG
+aIz
 aaa
 aaa
 aaa
@@ -31604,16 +31645,6 @@ aaa
 aaa
 aaa
 aaa
-nzi
-mDu
-mDu
-mDu
-mDu
-mDu
-mDu
-mDu
-mDu
-mDu
 mDu
 mDu
 mDu
@@ -31852,17 +31883,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-nzi
-mDu
+aIz
+aFy
+aFy
+aIz
+aIz
+aIz
+aIz
+aFy
+aFy
+aIz
+aIz
 aOH
 aOH
 aOH
@@ -32109,17 +32140,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-nzi
-mDu
+aIz
+nwU
+aGD
+aJz
+aGD
+aGD
+aOT
+aGD
+aGD
+aPC
+aIz
 aOH
 aCt
 aKy
@@ -32365,19 +32396,19 @@ mDu
 wRO
 wRO
 wRO
-wRO
-wRO
-wRO
-wRO
-vyQ
 aaa
-aaa
-aaa
-aaa
-aaa
-nzi
-mDu
-aOH
+aIz
+cwp
+aHz
+qSH
+qSH
+aHz
+aOY
+aHz
+aHz
+fng
+aIz
+aDH
 aCt
 aFY
 aFY
@@ -32622,19 +32653,19 @@ mDu
 mDu
 mDu
 mDu
-mDu
-mDu
-mDu
-mDu
-qDO
 aaa
-aaa
-aaa
-aaa
-aaa
-nzi
-mDu
-aOH
+aIz
+cwp
+qSH
+qSH
+aKT
+aHz
+aPa
+aHz
+aHz
+lkp
+aIz
+aDH
 aCt
 aFY
 aFY
@@ -32880,18 +32911,18 @@ aPg
 aPg
 aPg
 aPg
-aPg
-aPg
-mDu
-qDO
-aaa
-aaa
-aaa
-aaa
-aaa
-nzi
-mDu
-aOH
+aIz
+aBO
+wjX
+gcq
+aLx
+aHz
+aHz
+qSH
+aHz
+lkp
+aIz
+aDH
 aDH
 aFY
 aFY
@@ -33138,17 +33169,17 @@ aQw
 aQw
 aQw
 aQw
-aPg
-mDu
-qDO
-aaa
-aaa
-aaa
-aaa
-emV
-mDu
-mDu
-aOH
+aQh
+aDm
+iCj
+aHz
+aHz
+qSH
+qSH
+aHz
+vXS
+aIz
+aDH
 aET
 aGa
 aGR
@@ -33395,17 +33426,17 @@ fdF
 fdF
 aQh
 aQw
-aPg
-mDu
-qDO
-aaa
-aaa
-aaa
-aaa
-nzi
-mDu
-mDu
-aOH
+aQh
+aDm
+fFy
+aHz
+eCX
+sjB
+lSf
+mHk
+fNG
+aIz
+aDH
 aEU
 aGb
 aGS
@@ -33651,18 +33682,18 @@ ajV
 akZ
 akq
 aQh
-aQw
-aPg
-mDu
-qDO
-aaa
-aaa
-aaa
-aaa
-nzi
-mDu
-aOH
-aOH
+phy
+aQh
+aDm
+rJl
+hKJ
+gXA
+mVd
+wjX
+wjX
+sXi
+aIz
+aDH
 aEV
 aFA
 aHS
@@ -33909,16 +33940,16 @@ aaY
 ame
 aQh
 aQw
-aPg
-mDu
-qDO
-aaa
-aaa
-aaa
-aaa
-nzi
-mDu
-aOH
+aQh
+aDm
+viB
+abh
+aHz
+lkp
+aIz
+aIz
+aIz
+aIz
 aDH
 aAD
 aFX
@@ -34166,14 +34197,14 @@ abT
 amf
 aQh
 aQw
-aPg
+aQh
+aDm
+dhK
+pxD
+aHz
+fNG
+aIz
 mDu
-qDO
-aaa
-aaa
-aaa
-aaa
-nzi
 mDu
 cfA
 aDI
@@ -34424,13 +34455,13 @@ abQ
 aQh
 aQw
 aPg
+aIz
+aIz
+rBM
+aIz
+gSo
+aIz
 mDu
-qDO
-aaa
-aaa
-aaa
-aaa
-nzi
 mDu
 cfA
 aBk
@@ -34682,12 +34713,12 @@ aQh
 aQw
 aPg
 mDu
-qDO
-aaa
-aaa
-aaa
-aaa
-nzi
+aPQ
+knr
+xJd
+qyL
+aPQ
+mDu
 mDu
 cfA
 aDK
@@ -34939,11 +34970,11 @@ aQh
 aQw
 aPg
 mDu
-mDu
-wRO
-wRO
-wRO
-wRO
+aPQ
+nOn
+qzc
+qyL
+aPQ
 mDu
 mDu
 cfA
@@ -35196,11 +35227,11 @@ aQh
 aQw
 aPg
 mDu
-mDu
-mDu
-mDu
-mDu
-mDu
+aPQ
+ljR
+qzc
+rtA
+aPQ
 mDu
 mDu
 cfA
@@ -35454,10 +35485,10 @@ aQw
 aPg
 aPg
 aPg
-aPg
-aPg
-mDu
-mDu
+pgQ
+qzc
+qyL
+aPQ
 mDu
 mDu
 cfA
@@ -35710,11 +35741,11 @@ aQh
 aQw
 aQw
 aQw
-aQw
-aQw
-aPg
-mDu
-mDu
+dzL
+hlP
+oVU
+qyL
+aPQ
 mDu
 mDu
 cfA
@@ -35969,8 +36000,8 @@ anw
 anw
 anw
 oHm
-nWB
-nWB
+bHZ
+mSU
 nWB
 nWB
 nWB
@@ -36225,7 +36256,7 @@ anc
 anc
 anc
 anc
-any
+pLR
 any
 any
 auX
@@ -36382,15 +36413,15 @@ aaa
 aaa
 nzi
 qDO
-aUt
-aUt
-aUt
 aaa
 aaa
-aUt
-aUt
-aUt
-aUt
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -36482,7 +36513,7 @@ ane
 any
 any
 any
-any
+pLR
 any
 any
 any
@@ -36639,17 +36670,17 @@ aaa
 aaa
 nzi
 qDO
-aUt
-aUt
-emV
-wRO
-wRO
-vyQ
-aUt
-aUt
-emV
-wRO
-vyQ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -36739,7 +36770,7 @@ ano
 aoP
 aoP
 any
-any
+pLR
 aoP
 aoP
 any
@@ -36896,17 +36927,17 @@ aaa
 aaa
 nzi
 qDO
-aUt
-aUt
-nzi
-mDu
-mDu
-qDO
-aUt
-aUt
-nzi
-mDu
-qDO
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -36996,7 +37027,7 @@ ane
 aoQ
 apt
 any
-any
+pLR
 asG
 oST
 any
@@ -37152,19 +37183,19 @@ aEH
 aaa
 aaa
 nzi
-aIz
-aFy
-aFy
-aIz
-mDu
-mDu
-aIz
-aFy
-aFy
-aIz
-mDu
-mDu
-vyQ
+qDO
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -37253,7 +37284,7 @@ anu
 aoR
 aoR
 any
-any
+pLR
 aoR
 lJP
 any
@@ -37409,19 +37440,19 @@ aEH
 pBw
 pBw
 lJS
-aIz
-aFG
-aFG
-aIz
-mDu
-mDu
-aIz
-aFG
-aFG
-aIz
-mDu
-mDu
 qDO
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -37665,20 +37696,20 @@ aBh
 tbJ
 xzG
 oXE
-aDi
-aDm
-aFy
-aFy
-aIz
-aIz
-aIz
-aIz
-aFy
-aFy
-aIz
-aIz
-mDu
+lJS
 qDO
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -37922,20 +37953,20 @@ aBR
 sJR
 xzG
 qpo
-aDi
-aDm
-nwU
-aGD
-aJz
-aGD
-aGD
-aOT
-aGD
-aGD
-aPC
-aIz
-mDu
+lJS
 qDO
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -38179,20 +38210,20 @@ tOJ
 tbJ
 xzG
 xzG
-aDi
-aDm
-cwp
-aHz
-qSH
-qSH
-aHz
-aOY
-aHz
-aHz
-fng
-aIz
-mDu
+lJS
 qDO
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -38436,20 +38467,20 @@ ldh
 tbJ
 xzG
 xzG
-aDi
-aDm
-cwp
-qSH
-qSH
-aKT
-aHz
-aPa
-aHz
-aHz
-lkp
-tRj
-mDu
+lJS
 qDO
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -38693,20 +38724,20 @@ soQ
 tbJ
 aDi
 llL
-aDi
-aDm
-aBO
-wjX
-aJA
-aLx
-aHz
-aHz
-qSH
-aHz
-lkp
-tRj
+lJS
 mDu
-qDO
+wRO
+wRO
+wRO
+wRO
+vyQ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -38950,20 +38981,20 @@ aDi
 aDi
 aJf
 iNl
-aDi
-aDi
-aDi
-aDi
-aDi
-cwp
-aHz
-qSH
-qSH
-aHz
-lkp
-tRj
+lJS
+lJS
 mDu
-qDO
+mDu
+mDu
+mDu
+mDu
+wRO
+vyQ
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -39208,19 +39239,19 @@ aDi
 aBN
 aFD
 aFq
-aDi
-aDi
-aDi
-aDi
-aMZ
-eCX
-sjB
-lSf
-mHk
-fNG
-aIz
+lJS
+lJS
+lJS
+lJS
+mDu
+mDu
 mDu
 qDO
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -39468,16 +39499,16 @@ aHp
 aDi
 aIw
 aJx
-aDi
-aHw
-aHz
-aPb
-aLI
-aMi
-aNt
-aIz
+lJS
+aJm
+aJm
 mDu
 qDO
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -39726,15 +39757,15 @@ aKn
 aIx
 aIx
 aIP
-cwp
-aHz
-vJm
-aIz
-aIz
-aIz
-aIz
+vlG
+aJm
 mDu
 qDO
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -39983,15 +40014,15 @@ aDi
 aIy
 aGZ
 aDi
-feM
-aHz
-aVF
-aIz
-mDu
-mDu
-mDu
+aCg
+aJm
 mDu
 qDO
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -40240,15 +40271,15 @@ aDi
 aDi
 aDi
 aDi
-cwp
-aHz
-aPc
-aIz
+aCg
+aJm
 mDu
 mDu
-mDu
-mDu
-qDO
+wRO
+vyQ
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -40489,23 +40520,23 @@ asn
 asn
 asn
 apB
-aDm
+azq
 aEn
-aHq
-nwU
-pzN
-aHr
-aGA
-uGh
-aFL
-aHA
-aLH
-aIz
-mDu
-mDu
+aCg
+aCg
+aEs
+aCg
+aCg
+aCg
+aCg
+aJm
+aJm
 mDu
 mDu
 qDO
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -40746,23 +40777,23 @@ ayB
 aoi
 aoi
 sTR
-aDm
-aDm
-aDm
-feM
-its
-wjX
-ufk
-wjX
-wjX
-wjX
-tIY
-aIz
+azq
+aCg
+aCg
+aCg
+aCg
+aCg
+aCg
+aCg
+aCg
+aIB
+aJm
 mDu
 mDu
 mDu
-mDu
-mDu
+wRO
+wRO
+wRO
 wRO
 vyQ
 aaa
@@ -41001,19 +41032,19 @@ nrN
 azT
 dOi
 kLk
-nrN
-aol
+olF
+aoi
 aBo
-aGB
-aHr
-fXX
-mcG
+aCg
+aCg
+aCg
+aCg
 azq
 azq
 azq
 azq
 sfP
-azq
+aJm
 aJm
 aJm
 mDu
@@ -41260,10 +41291,10 @@ asq
 azM
 jGA
 aoi
-aAd
-aBO
-aDY
-wjX
+azq
+aEs
+aEs
+aCg
 tIY
 azq
 bau

--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -397,7 +397,7 @@
 	},
 /area/sulaco/medbay)
 "acr" = (
-/obj/machinery/sleeper,
+/obj/machinery/bodyscanner,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 1
 	},
@@ -1942,18 +1942,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/sulaco/maintenance/north_solar_maint)
-"alL" = (
-/obj/machinery/bodyscanner,
-/turf/open/floor/prison/whitegreen/corner{
-	dir = 4
-	},
-/area/sulaco/medbay/west)
-"alM" = (
-/obj/machinery/body_scanconsole,
-/turf/open/floor/prison/whitegreen/corner{
-	dir = 1
-	},
-/area/sulaco/medbay/west)
 "alN" = (
 /obj/machinery/door/airlock/mainship/command/FCDRquarters{
 	dir = 1
@@ -11126,6 +11114,12 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall2)
+"eTR" = (
+/obj/machinery/cloning/vats,
+/turf/open/floor/prison/whitegreen/corner{
+	dir = 8
+	},
+/area/sulaco/medbay/west)
 "eVy" = (
 /obj/machinery/door/airlock/mainship/engineering/CSEoffice{
 	dir = 2
@@ -14173,6 +14167,10 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_main_hall)
+"oRC" = (
+/obj/machinery/cloning_console/vats,
+/turf/open/floor/prison/whitegreen/corner,
+/area/sulaco/medbay/west)
 "oRM" = (
 /obj/effect/landmark/start/latejoin,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
@@ -43443,8 +43441,8 @@ aWG
 aXy
 aWG
 amz
-alL
-adI
+lrG
+eTR
 lrG
 aiq
 lrG
@@ -43700,8 +43698,8 @@ iAq
 tvS
 aWG
 amz
-alM
-adH
+hto
+oRC
 hto
 air
 hto


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a missing wire to the Sulaco's top floor.
Adds a cloning pod and console to the Sulaco's medbay.
Railgun/OB moved to bottom floor.
Captain's locker in captain's quarters.
Moved engi/tool vendors in the hall going to the hangar.
Moved PACMAN generator and fuel closer to Alamo.
Surplus equipment and Security vendors in CIC.
Alamo console in CIC.
Emergency gun cabinets in CIC.
Fixed the medbay exit button.

## Why It's Good For The Game
Sulaco was missing cloning, unlike the PoS.
Powerloaders are now able to reach the OB.
I missed one single wire.

## Changelog
:cl:
add: The Sulaco now has a functioning cloning pod in medbay
add: Added a captain's locker to the Sulaco
add: Ladder connecting the morgue and the emergency medbay in the hangar of the Sulaco
tweak: Moved engi and tool vendors in the main Sulaco hallway
tweak: Moved PACMAN gen and fuel closer to Alamo on the Sulaco
fix: Sulaco's powernet on the top floor had a missing wire fixed
fix: Moved the OB/Rail to the bottom floor, as powerloaders can't move up ladders
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
