### PR TITLE
Prison Area Fix

### DIFF
--- a/code/game/area/prison.dm
+++ b/code/game/area/prison.dm
@@ -50,7 +50,7 @@
 
 /area/prison/security/monitoring/highsec
 	name = "High-Security Monitoring"
-	ceiling = CEILING_DEEP_UNDERGROUND_METAL
+	ceiling = CEILING_METAL
 
 /area/prison/security/monitoring/maxsec
 	name = "Maximum-Security Monitoring"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changed some areas close to LZ to no longer be underground.

## Why It's Good For The Game

Marines can now OB an area they should have been able to.

## Changelog
:cl:
fix: Fixed a few areas in Prison Station being underground when they should not have been
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
