### PR TITLE
Refactor hivemind movement

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -285,6 +285,7 @@
 	#define COMPONENT_NO_STUN (1<<0)			//For all of them
 
 #define COMSIG_LIVING_ADD_VENTCRAWL "living_add_ventcrawl"
+#define COMSIG_LIVING_WEEDS_ADJACENT_REMOVED "living_weeds_adjacent_removed"	///from obj/effect/alien/weeds/Destroy()
 
 //mob/living/carbon signals
 #define COMSIG_CARBON_DEVOURED_BY_XENO "carbon_devoured_by_xeno"
@@ -359,6 +360,8 @@
 #define COMSIG_XENOMORPH_EVOLVED "xenomorph_evolved"
 #define COMSIG_XENOMORPH_DEEVOLVED "xenomorph_deevolved"
 #define COMSIG_XENOMORPH_WATCHXENO "xenomorph_watchxeno"
+
+#define COMSIG_XENOMORPH_CORE_RETURN "xenomorph_core_return"
 
 #define COMSIG_XENO_OBJ_THROW_HIT "xeno_obj_throw_hit"				///from [/mob/living/carbon/xenomorph/throw_impact]: (obj/target, speed)
 #define COMSIG_XENO_NONE_THROW_HIT "xeno_none_throw_hit"			///from [/mob/living/carbon/xenomorph/throw_impact]: ()

--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -32,6 +32,8 @@
 	update_neighbours()
 
 /obj/effect/alien/weeds/Destroy()
+	for(var/mob/living/L in range(1, src))
+		SEND_SIGNAL(L, COMSIG_LIVING_WEEDS_ADJACENT_REMOVED)
 	for(var/obj/effect/alien/A in loc.contents)
 		if(QDELETED(A) || A == src || A.ignore_weed_destruction)
 			continue

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/abilities_hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/abilities_hivemind.dm
@@ -1,1 +1,7 @@
-// empty file for now
+/datum/action/xeno_action/return_to_core
+	name = "Return to Core"
+	action_icon_state = "lay_hivemind"
+	mechanics_text = "Teleport back to your core."
+
+/datum/action/xeno_action/return_to_core/action_activate()
+	SEND_SIGNAL(owner, COMSIG_XENOMORPH_CORE_RETURN)

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/castedatum_hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/castedatum_hivemind.dm
@@ -48,6 +48,7 @@
 
 	// *** Abilities *** //
 	actions = list(
+		/datum/action/xeno_action/return_to_core,
 		/datum/action/xeno_action/plant_weeds/slow,
 		/datum/action/xeno_action/psychic_whisper,
 	)

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
@@ -58,6 +58,8 @@
 /mob/living/carbon/xenomorph/hivemind/proc/check_weeds(turf/T)
 	SHOULD_BE_PURE(TRUE)
 	. = TRUE
+	if(locate(/obj/flamer_fire) in T)
+		return FALSE
 	for(var/obj/effect/alien/weeds/W in range(1, T ? T : get_turf(src)))
 		if(QDESTROYING(W))
 			continue
@@ -98,8 +100,7 @@
 		var/mob/living/carbon/xenomorph/xeno = locate(href_list["hivemind_jump"])
 		if(!istype(xeno))
 			return
-		var/obj/effect/alien/weeds/nearby_weed = locate() in range("3x3", get_turf(xeno))
-		if(!istype(nearby_weed))
+		if(!check_weeds(get_turf(xeno)))
 			to_chat(src, "<span class='warning'>They are not near any weeds we can jump to.</span>")
 			return
 		forceMove(get_turf(nearby_weed))

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
@@ -103,7 +103,7 @@
 		if(!check_weeds(get_turf(xeno)))
 			to_chat(src, "<span class='warning'>They are not near any weeds we can jump to.</span>")
 			return
-		forceMove(get_turf(nearby_weed))
+		forceMove(get_turf(xeno))
 
 /// Hivemind just doesn't have any icons to update, disabled for now
 /mob/living/carbon/xenomorph/hivemind/update_icons()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This was absolute shitcode and awful for players
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You no longer just get yeeted back to your core when you mistep, and have a new button if you want to manually move back to your core.
Losing weeds nearby now works correctly as does the effect of flamer fire.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Hivemind is now unable to move to turfs that previously caused it to be moved back to it's core, it now has an action button to manually move back to the core.
fix: Hivemind now is moved back to the core when it loses weeds nearby or is hit by flamer fire
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
