### PR TITLE
Removes the LZ 2 Phoron Miner on Prison

### DIFF
--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -44093,10 +44093,6 @@
 "xAI" = (
 /turf/closed/wall/r_wall/prison,
 /area/prison/research/secret/biolab)
-"xGi" = (
-/obj/machinery/miner/damaged,
-/turf/open/floor/asteroid,
-/area/prison/residential/central)
 "xHS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -54880,7 +54876,7 @@ bhC
 bkL
 bhC
 bhC
-xGi
+bhC
 bhC
 aVP
 bRB


### PR DESCRIPTION
## About The Pull Request

Removes the phoron miner thats literally almost inside of LZ 2.

![image](https://user-images.githubusercontent.com/41198990/98593390-186fef00-22a1-11eb-8df6-bd0159b38423.png)

Image is how it looks after the change

## Why It's Good For The Game

Imagine actually needing to push out to earn req points?

## Changelog
:cl:
del: Removes LZ 2 phoron miner on Prison.
/:cl:

