### PR TITLE
disables magmoor under 60 players

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -52,7 +52,7 @@ map whiskey_outpost_v2
 endmap
 
 map magmoor_digsite_iv
-	minplayers 20
+	minplayers 60
 endmap
 
 map marine_hq


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
magmoor is a highpop map, and personally i'd make it 75+ but we don't get that population often anyway, and it shouldn't be played under 60 players as the map is literally too big for that.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
magmoor is a big map, it shouldn't be played under 60 players
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
config: magmoor min player upped to 60, you need 60 players to play magmoor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
