### PR TITLE
Silo Point Adjustments

### DIFF
--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -143,7 +143,7 @@
 		playsound(loc, 'sound/effects/blobattack.ogg', 25)
 
 	var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
-	xeno_job.add_job_points(3.3)
+	xeno_job.add_job_points(2.3) //3 corpses per burrowed; 7 points per larva
 
 	log_combat(victim, user, "was consumed by a resin silo")
 	log_game("[key_name(victim)] was consumed by a resin silo at [AREACOORD(victim.loc)].")

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -143,7 +143,7 @@
 		playsound(loc, 'sound/effects/blobattack.ogg', 25)
 
 	var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
-	xeno_job.add_job_points(2.3) //3 corpses per burrowed; 7 points per larva
+	xeno_job.add_job_points(2) //4 corpses per burrowed; 8 points per larva
 
 	log_combat(victim, user, "was consumed by a resin silo")
 	log_game("[key_name(victim)] was consumed by a resin silo at [AREACOORD(victim.loc)].")

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -143,7 +143,7 @@
 		playsound(loc, 'sound/effects/blobattack.ogg', 25)
 
 	var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
-	xeno_job.add_job_points(2) //4 corpses per burrowed; 8 points per larva
+	xeno_job.add_job_points(1.75) //4 corpses per burrowed; 7 points per larva
 
 	log_combat(victim, user, "was consumed by a resin silo")
 	log_game("[key_name(victim)] was consumed by a resin silo at [AREACOORD(victim.loc)].")


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reduces larva points per corpse

## Why It's Good For The Game
I found out xenos need 8 job points per larva instead of 9 like I thought. Silo point generation adjusted accordingly.

## Changelog
:cl:
tweak: Resin Silos generate less xeno job points per corpse
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
