### PR TITLE
gun_attachables documentation

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1,21 +1,22 @@
 
-/**Gun attachable items code. Lets you add various effects to firearms.
-  *Some attachables are hardcoded in the projectile firing system, like grenade launchers, flamethrowers.
-  *
-  *When you are adding new guns into the attachment list, or even old guns, make sure that said guns
-  *properly accept overlays. You can find the proper offsets in the individual gun dms, so make sure
-  *you set them right. It's a pain to go back to find which guns are set incorrectly.
-  *To summarize: rail attachments should go on top of the rail. For rifles, this usually means the middle of the gun.
-  *For handguns, this is usually toward the back of the gun. SMGs usually follow rifles.
-  *Muzzle attachments should connect to the barrel, not sit under or above it. The only exception is the bayonet.
-  *Underrail attachments should just fit snugly, that's about it. Stocks are pretty obvious.
-  *
-  *All attachment offsets are now in a list, including stocks. Guns that don't take attachments can keep the list null.
-  *~N
-  *
-  *Anything that isn't used as the gun fires should be a flat number, never a percentange. It screws with the calculations,
-  *and can mean that the order you attach something/detach something will matter in the final number. It's also completely
-  *inaccurate. Don't worry if force is ever negative, it won't runtime.
+/** Gun attachable items code. Lets you add various effects to firearms.
+
+Some attachables are hardcoded in the projectile firing system, like grenade launchers, flamethrowers.
+
+When you are adding new guns into the attachment list, or even old guns, make sure that said guns
+properly accept overlays. You can find the proper offsets in the individual gun dms, so make sure
+you set them right. It's a pain to go back to find which guns are set incorrectly.
+To summarize: rail attachments should go on top of the rail. For rifles, this usually means the middle of the gun.
+For handguns, this is usually toward the back of the gun. SMGs usually follow rifles.
+Muzzle attachments should connect to the barrel, not sit under or above it. The only exception is the bayonet.
+Underrail attachments should just fit snugly, that's about it. Stocks are pretty obvious.
+
+All attachment offsets are now in a list, including stocks. Guns that don't take attachments can keep the list null.
+~N
+
+Anything that isn't used as the gun fires should be a flat number, never a percentange. It screws with the calculations,
+and can mean that the order you attach something/detach something will matter in the final number. It's also completely
+inaccurate. Don't worry if force is ever negative, it won't runtime.
   */
 
 /obj/item/attachable

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -689,9 +689,9 @@
 	///how many tiles to increase the users view box
 	var/zoom_viewsize = 12
 	scoped_accuracy_mod = SCOPE_RAIL
-	///BOOLEAN as to whether a scope can apply nightvision
+	///boolean as to whether a scope can apply nightvision
 	var/has_nightvision = FALSE
-	///BOOLEAN as to whether the attachment is currently giving nightvision
+	///boolean as to whether the attachment is currently giving nightvision
 	var/active_nightvision = FALSE
 
 

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -13,13 +13,9 @@
   *All attachment offsets are now in a list, including stocks. Guns that don't take attachments can keep the list null.
   *~N
   *
-  *Defined in conflicts.dm of the #defines folder.
-  *#define ATTACH_REMOVABLE		(1<<0)
-  *#define ATTACH_ACTIVATION	(1<<1)
-  *#define ATTACH_PROJECTILE	(1<<2)
-  *#define ATTACH_RELOADABLE	(1<<3)
-  *#define ATTACH_WEAPON		(1<<4)
-  *#define ATTACH_UTILITY		(1<<5)
+  *Anything that isn't used as the gun fires should be a flat number, never a percentange. It screws with the calculations,
+  *and can mean that the order you attach something/detach something will matter in the final number. It's also completely
+  *inaccurate. Don't worry if force is ever negative, it won't runtime.
   */
 
 /obj/item/attachable
@@ -41,16 +37,6 @@
 	force = 1.0
 	///"muzzle", "rail", "under", "stock" the particular 'slot' the attachment can attach to. must always be a singular slot.
 	var/slot = null
-
-	/**
-	  *Anything that isn't used as the gun fires should be a flat number, never a percentange. It screws with the calculations,
-	  *and can mean that the order you attach something/detach something will matter in the final number. It's also completely
-	  *inaccurate. Don't worry if force is ever negative, it won't runtime.
-	  *
-	  *These bonuses are applied only as the gun fires a projectile.
-	  *
-	  *These are flat bonuses applied and are passive, though they may be applied at different points.
-	  */
 
 	///Modifier to firing accuracy, works off a multiplier.
 	var/accuracy_mod 	= 0
@@ -107,7 +93,7 @@
 	///The specific sound played when activating this attachment.
 	var/activation_sound = 'sound/machines/click.ogg'
 
-	///various yes no flags associated with attachments
+	///various yes no flags associated with attachments. See defines for these: [ATTACH_REMOVABLE]
 	var/flags_attach_features = ATTACH_REMOVABLE
 
 	///only used by bipod, denotes whether the bipod is currently deployed
@@ -703,9 +689,9 @@
 	///how many tiles to increase the users view box
 	var/zoom_viewsize = 12
 	scoped_accuracy_mod = SCOPE_RAIL
-	///TRUE FALSE as to whether a scope can apply nightvision
+	///BOOLEAN as to whether a scope can apply nightvision
 	var/has_nightvision = FALSE
-	///TRUE FALSE as to whether the attachment is currently giving nightvision
+	///BOOLEAN as to whether the attachment is currently giving nightvision
 	var/active_nightvision = FALSE
 
 

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -2,25 +2,25 @@
 ///Gun attachable items code. Lets you add various effects to firearms.
 ///Some attachables are hardcoded in the projectile firing system, like grenade launchers, flamethrowers.
 /**
- *When you are adding new guns into the attachment list, or even old guns, make sure that said guns
- *properly accept overlays. You can find the proper offsets in the individual gun dms, so make sure
- *you set them right. It's a pain to go back to find which guns are set incorrectly.
- *To summarize: rail attachments should go on top of the rail. For rifles, this usually means the middle of the gun.
- *For handguns, this is usually toward the back of the gun. SMGs usually follow rifles.
- *Muzzle attachments should connect to the barrel, not sit under or above it. The only exception is the bayonet.
- *Underrail attachments should just fit snugly, that's about it. Stocks are pretty obvious.
- *
- *All attachment offsets are now in a list, including stocks. Guns that don't take attachments can keep the list null.
- *~N
- *
- *Defined in conflicts.dm of the #defines folder.
- *#define ATTACH_REMOVABLE	1
- *#define ATTACH_ACTIVATION	2
- *#define ATTACH_PROJECTILE	4
- *#define ATTACH_RELOADABLE	8
- *#define ATTACH_WEAPON		16
- *#define ATTACH_UTILITY	32
- */
+  *When you are adding new guns into the attachment list, or even old guns, make sure that said guns
+  *properly accept overlays. You can find the proper offsets in the individual gun dms, so make sure
+  *you set them right. It's a pain to go back to find which guns are set incorrectly.
+  *To summarize: rail attachments should go on top of the rail. For rifles, this usually means the middle of the gun.
+  *For handguns, this is usually toward the back of the gun. SMGs usually follow rifles.
+  *Muzzle attachments should connect to the barrel, not sit under or above it. The only exception is the bayonet.
+  *Underrail attachments should just fit snugly, that's about it. Stocks are pretty obvious.
+  *
+  *All attachment offsets are now in a list, including stocks. Guns that don't take attachments can keep the list null.
+  *~N
+  *
+  *Defined in conflicts.dm of the #defines folder.
+  *#define ATTACH_REMOVABLE	1
+  *#define ATTACH_ACTIVATION	2
+  *#define ATTACH_PROJECTILE	4
+  *#define ATTACH_RELOADABLE	8
+  *#define ATTACH_WEAPON		16
+  *#define ATTACH_UTILITY	32
+  */
 
 /obj/item/attachable
 	name = "attachable item"
@@ -43,14 +43,14 @@
 	var/slot = null
 
 	/**
-	 *Anything that isn't used as the gun fires should be a flat number, never a percentange. It screws with the calculations,
-	 *and can mean that the order you attach something/detach something will matter in the final number. It's also completely
-	 *inaccurate. Don't worry if force is ever negative, it won't runtime.
-	 *
-	 *These bonuses are applied only as the gun fires a projectile.
-	 *
-	 *These are flat bonuses applied and are passive, though they may be applied at different points.
-	 */
+	  *Anything that isn't used as the gun fires should be a flat number, never a percentange. It screws with the calculations,
+	  *and can mean that the order you attach something/detach something will matter in the final number. It's also completely
+	  *inaccurate. Don't worry if force is ever negative, it won't runtime.
+	  *
+	  *These bonuses are applied only as the gun fires a projectile.
+	  *
+	  *These are flat bonuses applied and are passive, though they may be applied at different points.
+	  */
 
 	///Modifier to firing accuracy, works off a multiplier.
 	var/accuracy_mod 	= 0

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1,7 +1,7 @@
 
-///Gun attachable items code. Lets you add various effects to firearms.
-///Some attachables are hardcoded in the projectile firing system, like grenade launchers, flamethrowers.
-/**
+/**Gun attachable items code. Lets you add various effects to firearms.
+  *Some attachables are hardcoded in the projectile firing system, like grenade launchers, flamethrowers.
+  *
   *When you are adding new guns into the attachment list, or even old guns, make sure that said guns
   *properly accept overlays. You can find the proper offsets in the individual gun dms, so make sure
   *you set them right. It's a pain to go back to find which guns are set incorrectly.
@@ -14,12 +14,12 @@
   *~N
   *
   *Defined in conflicts.dm of the #defines folder.
-  *#define ATTACH_REMOVABLE	1
-  *#define ATTACH_ACTIVATION	2
-  *#define ATTACH_PROJECTILE	4
-  *#define ATTACH_RELOADABLE	8
-  *#define ATTACH_WEAPON		16
-  *#define ATTACH_UTILITY	32
+  *#define ATTACH_REMOVABLE		(1<<0)
+  *#define ATTACH_ACTIVATION	(1<<1)
+  *#define ATTACH_PROJECTILE	(1<<2)
+  *#define ATTACH_RELOADABLE	(1<<3)
+  *#define ATTACH_WEAPON		(1<<4)
+  *#define ATTACH_UTILITY		(1<<5)
   */
 
 /obj/item/attachable
@@ -75,7 +75,7 @@
 	///Modifier to scatter from wielded burst fire, works off a multiplier.
 	var/burst_scatter_mod = 0
 	///Adds silenced to weapon. changing its fire sound, muzzle flash, and volume. TRUE or FALSE
-	var/silence_mod 	= 0
+	var/silence_mod 	= FALSE
 	///Adds an x-brightness flashlight to the weapon, which can be toggled on and off.
 	var/light_mod 		= 0
 	///Changes firing delay. Cannot go below 0.

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1225,11 +1225,11 @@
 /obj/item/attachable/attached_gun
 	attachment_action_type = /datum/action/item_action/toggle
 	//Some attachments may be fired. So here are the variables related to that.
-	///the ammo datum that an attachment gun fires
-	var/datum/ammo/ammo = null //If it has a default bullet-like ammo.
+	///the ammo datum that an attachment gun fires, If it has a default bullet-like ammo
+	var/datum/ammo/ammo = null
 	///the type of casing an attachment gun leaves behind, if any.
 	var/type_of_casings = null
-	///Sound to play when firing it alternately
+	///Sound to play when firing the attachment gun.
 	var/fire_sound = null
 
 


### PR DESCRIPTION
## About The Pull Request

more documentation is good. as well as another bug found.

## Why It's Good For The Game

scopes were not applying their zoomed in accuracy when actually zoomed in. This was because their special zoomed accuracy variable was not used anywhere.

## Changelog
:cl: Hughgent
fix: scopes now actually apply their accuracy modifier when zoomed in.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
