### PR TITLE
Shield Fix

### DIFF
--- a/code/datums/components/shield.dm
+++ b/code/datums/components/shield.dm
@@ -168,20 +168,33 @@
 
 /datum/component/shield/proc/item_intercept_attack(attack_type, incoming_damage, damage_type, silent)
 	var/obj/item/parent_item = parent
+	var/status_cover_modifier = 1
+
+	if(affected.IsSleeping() || affected.IsUnconscious() || affected.IsAdminSleeping() || affected.IsParalyzed()) //We don't do jack if we're literally KOed/sleeping/paralyzed.
+		return FALSE
+
+	if(affected.IsStun() || affected.IsKnockdown() ) //Halve shield cover if we're paralyzed or stunned
+		status_cover_modifier *= 0.5
+
+	if(iscarbon(affected) )
+		var/mob/living/carbon/C = affected
+		if(C.stagger) //Lesser penalty to shield cover for being staggered.
+			status_cover_modifier *= 0.75
+
 	switch(attack_type)
 		if(COMBAT_TOUCH_ATTACK)
-			if(!prob(cover.getRating(damage_type)))
+			if(!prob(cover.getRating(damage_type) * status_cover_modifier))
 				return FALSE //Bypassed the shield.
 			incoming_damage = max(0, incoming_damage - hard_armor.getRating(damage_type))
 			incoming_damage *= (100 - soft_armor.getRating(damage_type)) * 0.01
 			return prob(50 - round(incoming_damage / 3))
 		if(COMBAT_MELEE_ATTACK, COMBAT_PROJ_ATTACK)
-			var/absorbing_damage = incoming_damage * cover.getRating(damage_type) * 0.01
+			var/absorbing_damage = max(0, incoming_damage - hard_armor.getRating(damage_type) * status_cover_modifier) //We apply hard armor *first* _not_ *after* soft armor
 			if(!absorbing_damage)
 				return incoming_damage //We are transparent to this kind of damage.
 			. = incoming_damage - absorbing_damage
-			absorbing_damage = max(0, absorbing_damage - hard_armor.getRating(damage_type))
-			absorbing_damage *= (100 - soft_armor.getRating(damage_type)) * 0.01
+			absorbing_damage = incoming_damage * cover.getRating(damage_type) * 0.01 * status_cover_modifier  //Determine cover ratio
+			absorbing_damage *= (100 - soft_armor.getRating(damage_type)) * 0.01 //Now apply soft armor
 			if(absorbing_damage <= 0)
 				if(!silent)
 					to_chat(affected, "<span class='avoidharm'>\The [parent_item.name] [. ? "softens" : "soaks"] the damage!</span>")

--- a/code/datums/components/shield.dm
+++ b/code/datums/components/shield.dm
@@ -135,23 +135,9 @@
 		return
 	shield_affect_user(user)
 
-	var/obj/item/parent_item = parent //Apply in-hand slowdowns.
-	if(!ishuman(user) || !parent_item)
-		return
-	var/mob/living/carbon/human/human_user = user
-	if(parent_item.slowdown)
-		human_user.add_movespeed_modifier(parent.type, TRUE, 0, NONE, TRUE, parent_item.slowdown)
-
 /datum/component/shield/proc/shield_dropped(datum/source, mob/user)
 	SIGNAL_HANDLER
 	shield_detatch_from_user()
-
-	var/obj/item/parent_item = parent //Apply in-hand slowdowns.
-	if(!ishuman(user) || !parent_item)
-		return
-	var/mob/living/carbon/human/human_user = user
-	if(parent_item.slowdown)
-		human_user.remove_movespeed_modifier(parent.type)
 
 /datum/component/shield/proc/shield_affect_user(mob/living/user)
 	if(affected)

--- a/code/datums/components/shield.dm
+++ b/code/datums/components/shield.dm
@@ -135,9 +135,23 @@
 		return
 	shield_affect_user(user)
 
+	var/obj/item/parent_item = parent //Apply in-hand slowdowns.
+	if(!ishuman(user) || !parent_item)
+		return
+	var/mob/living/carbon/human/human_user = user
+	if(parent_item.slowdown)
+		human_user.add_movespeed_modifier(parent.type, TRUE, 0, NONE, TRUE, parent_item.slowdown)
+
 /datum/component/shield/proc/shield_dropped(datum/source, mob/user)
 	SIGNAL_HANDLER
 	shield_detatch_from_user()
+
+	var/obj/item/parent_item = parent //Apply in-hand slowdowns.
+	if(!ishuman(user) || !parent_item)
+		return
+	var/mob/living/carbon/human/human_user = user
+	if(parent_item.slowdown)
+		human_user.remove_movespeed_modifier(parent.type)
 
 /datum/component/shield/proc/shield_affect_user(mob/living/user)
 	if(affected)

--- a/code/datums/components/shield.dm
+++ b/code/datums/components/shield.dm
@@ -173,10 +173,10 @@
 	if(affected.IsSleeping() || affected.IsUnconscious() || affected.IsAdminSleeping() || affected.IsParalyzed()) //We don't do jack if we're literally KOed/sleeping/paralyzed.
 		return FALSE
 
-	if(affected.IsStun() || affected.IsKnockdown() ) //Halve shield cover if we're paralyzed or stunned
+	if(affected.IsStun() || affected.IsKnockdown()) //Halve shield cover if we're paralyzed or stunned
 		status_cover_modifier *= 0.5
 
-	if(iscarbon(affected) )
+	if(iscarbon(affected))
 		var/mob/living/carbon/C = affected
 		if(C.stagger) //Lesser penalty to shield cover for being staggered.
 			status_cover_modifier *= 0.75

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -345,7 +345,9 @@
 	if(!M)
 		return FALSE
 
-	if(slot != SLOT_L_HAND && slot != SLOT_R_HAND && CHECK_BITFIELD(flags_item, NODROP)) //No drops can only be equipped to a hand slot
+	if(CHECK_BITFIELD(flags_item, NODROP) && slot != SLOT_L_HAND && slot != SLOT_R_HAND) //No drops can only be equipped to a hand slot
+		if(istype(src, /obj/item/weapon/shield/riot))
+			to_chat(M, "<span class='notice'>We must first loosen [src]'s straps!</span>")
 		return FALSE
 
 	if(ishuman(M))

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -345,6 +345,9 @@
 	if(!M)
 		return FALSE
 
+	if(slot != SLOT_L_HAND && slot != SLOT_R_HAND && CHECK_BITFIELD(flags_item, NODROP)) //No drops can only be equipped to a hand slot
+		return FALSE
+
 	if(ishuman(M))
 		//START HUMAN
 		var/mob/living/carbon/human/H = M

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -346,8 +346,8 @@
 		return FALSE
 
 	if(CHECK_BITFIELD(flags_item, NODROP) && slot != SLOT_L_HAND && slot != SLOT_R_HAND) //No drops can only be equipped to a hand slot
-		if(istype(src, /obj/item/weapon/shield/riot))
-			to_chat(M, "<span class='notice'>We must first loosen [src]'s straps!</span>")
+		if(slot == SLOT_L_HAND || slot == SLOT_R_HAND)
+			to_chat(M, "<span class='notice'>[src] is stuck to our hand!</span>")
 		return FALSE
 
 	if(ishuman(M))

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -138,9 +138,8 @@
 	slowdown = 0.2
 
 /obj/item/weapon/shield/riot/marine/mob_can_equip(mob/M, slot, warning = TRUE)
-	if(slot == SLOT_BACK && CHECK_BITFIELD(flags_item, NODROP)) //If we're equipping the shield to the back, remove NODROP so it doesn't get stuck there
-		to_chat(M, "<span class='notice'>We must first loosen [src]'s straps before we can place it on our back!</span>")
-		return FALSE
+	if(slot != SLOT_L_HAND && slot != SLOT_R_HAND && CHECK_BITFIELD(flags_item, NODROP)) //Let the player know why they can't move the shield to non-hand slots
+		to_chat(M, "<span class='notice'>We must first loosen [src]'s straps!</span>")
 
 	return ..()
 

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -133,7 +133,7 @@
 	flags_equip_slot = ITEM_SLOT_BACK
 	max_integrity = 300
 	soft_armor = list("melee" = 50, "bullet" = 50, "laser" = 0, "energy" = 100, "bomb" = 30, "bio" = 100, "rad" = 100, "fire" = 0, "acid" = 35)
-	hard_armor = list("melee" = 0, "bullet" = 5, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+	hard_armor = list("melee" = 5, "bullet" = 5, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	force = 20
 	slowdown = 0.2
 

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -137,6 +137,11 @@
 	force = 20
 	slowdown = 0.2
 
+/obj/item/weapon/shield/riot/marine/equipped(mob/user, slot)
+	if(slot == SLOT_BACK && CHECK_BITFIELD(flags_item, NODROP)) //If we're equipping the shield to the back, remove NODROP so it doesn't get stuck there
+		TOGGLE_BITFIELD(flags_item, NODROP)
+		to_chat(user, "<span class='notice'>You loosen the strap of [src] as you place it onto your back.</span>")
+
 /obj/item/weapon/shield/riot/marine/AltClick(mob/user)
 	if(!can_interact(user))
 		return ..()

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -137,11 +137,12 @@
 	force = 20
 	slowdown = 0.2
 
-/obj/item/weapon/shield/riot/marine/equipped(mob/user, slot)
-	. = ..()
+/obj/item/weapon/shield/riot/marine/mob_can_equip(mob/M, slot, warning = TRUE)
 	if(slot == SLOT_BACK && CHECK_BITFIELD(flags_item, NODROP)) //If we're equipping the shield to the back, remove NODROP so it doesn't get stuck there
-		TOGGLE_BITFIELD(flags_item, NODROP)
-		to_chat(user, "<span class='notice'>You loosen the strap of [src] as you place it onto your back.</span>")
+		to_chat(M, "<span class='notice'>We must first loosen [src]'s straps before we can place it on our back!</span>")
+		return FALSE
+
+	return ..()
 
 /obj/item/weapon/shield/riot/marine/AltClick(mob/user)
 	if(!can_interact(user))

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -137,12 +137,6 @@
 	force = 20
 	slowdown = 0.2
 
-/obj/item/weapon/shield/riot/marine/mob_can_equip(mob/M, slot, warning = TRUE)
-	if(slot != SLOT_L_HAND && slot != SLOT_R_HAND && CHECK_BITFIELD(flags_item, NODROP)) //Let the player know why they can't move the shield to non-hand slots
-		to_chat(M, "<span class='notice'>We must first loosen [src]'s straps!</span>")
-
-	return ..()
-
 /obj/item/weapon/shield/riot/marine/AltClick(mob/user)
 	if(!can_interact(user))
 		return ..()

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -138,6 +138,7 @@
 	slowdown = 0.2
 
 /obj/item/weapon/shield/riot/marine/equipped(mob/user, slot)
+	. = ..()
 	if(slot == SLOT_BACK && CHECK_BITFIELD(flags_item, NODROP)) //If we're equipping the shield to the back, remove NODROP so it doesn't get stuck there
 		TOGGLE_BITFIELD(flags_item, NODROP)
 		to_chat(user, "<span class='notice'>You loosen the strap of [src] as you place it onto your back.</span>")


### PR DESCRIPTION
## About The Pull Request

Hard armor damage reduction is now applied first; cover ratio applies; shields regain their 5 hard armor.

Being unconscious/asleep/paralyzed nullifies shields completely; you can't block shit while you're not awake/completely incapable of movement.

Being stunned or knocked prone reduces your shield cover rating by 50%

Being staggered reduces your shield cover rating by 25%

Fixed Shields sticking to the back due to NODROP. You can no longer equip NODROP items to non-hand locations.


## Why It's Good For The Game

Adds actual counterplay to shields that makes some goddamn sense. Also bugfixes.

Fixes: https://github.com/tgstation/TerraGov-Marine-Corps/issues/5214
Fixes: https://github.com/tgstation/TerraGov-Marine-Corps/issues/5148

## Changelog
:cl:
tweak: Shields now reduce incoming damage by hard armor before applying soft armor reduction.
tweak: Shield cover ratings are now modified by statuses; KO/Sleep/Paralysis disables shield benefits entirely as they should. Stun/Knockdown reduces cover by 50%. Stagger reduces cover by 25%.
tweak: Shields regain their 5 hard armor vs melee in light of these changes.
fix: Fixed Shields sticking to the back due to NODROP. You can no longer equip NODROP items to non-hand locations.
/:cl: