### PR TITLE
Revert "binoculars can no longer target things the user cannot see."

### DIFF
--- a/code/game/objects/items/binoculars.dm
+++ b/code/game/objects/items/binoculars.dm
@@ -156,10 +156,6 @@
 		to_chat(user, "<span class='warning'>You can't focus properly through \the [src] while looking through something else.</span>")
 		return
 
-	if(!can_see(user, A, 25))
-		to_chat(user, "<span class='warning'>You can't see anything there.</span>")
-		return
-
 	if(!user.mind)
 		return
 	var/datum/squad/S = user.assigned_squad


### PR DESCRIPTION
## About The Pull Request
Reverts tgstation/TerraGov-Marine-Corps#5166

I really feel as this went too overboard with it, as this makes pushing using the railgun or OB much much harder, and encourages the FOB camp meta too much. 
And yes, it may have fixed a thing, but it should've been made a part of the game instead of sledged into a "fixed" place.

## Why It's Good For The Game
FOB camp b-gone, make marines push again.

## Changelog
:cl:
balance: Reverted the tactical binocular nerf.
/:cl:
