### PR TITLE
Stun changes part 1- shrike

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -117,7 +117,7 @@
 	succeed_activate()
 	add_cooldown()
 	if(ishuman(victim))
-		victim.apply_effects(1, 2) 	// Stun
+		victim.apply_effects(1, 0.1) 	// The fling stuns you enough to remove your gun, otherwise the marine effectively isn't stunned for long.
 		shake_camera(victim, 2, 1)
 
 	var/facing = get_dir(owner, victim)
@@ -188,7 +188,7 @@
 			affected.throw_at(throwlocation, 6, 1, owner, TRUE)
 			if(ishuman(affected)) //if they're human, they also should get knocked off their feet from the blast.
 				var/mob/living/carbon/human = affected
-				human.apply_effects(1, 2) 	// Stun
+				human.apply_effects(1, 1) 	// Stun
 				shake_camera(affected, 2, 1)
 
 	owner.visible_message("<span class='xenowarning'>[owner] sends out a huge blast of psychic energy!</span>", \


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Stuns bad, time to kill some CC

PART 1-
Shrike

NERFS
Psychic fling is nerfed to effectively only really stun you for 0.1 seconds or so, and basically just disarms your weapon. Its more a displacement tool now.

Shrike screech only stuns you for half the time.

Compensation (If any)
Shrike is still an incredibly good caste, so the only compensation is slightly better pheros at ancient.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Stuns bad, down with the stuns.
Shrike should've been nerfed stunwise a long time ago. They had 2 ranged stuns, pheromones, healing and building in their kit? This nerfs them and gives them slightly better pheromones. As I still personally think they'll still be good at displacing marines.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Shrikes stuns have been nerfed, psychic fling effectively no longer stuns other than basically disarming. Screech only stuns for half the time, slightly better ancient pheros
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
