### PR TITLE
Stun changes part 5 - Ravager

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -6,8 +6,8 @@
 	action_icon_state = "charge"
 	mechanics_text = "Charge up to 4 tiles and viciously attack your target."
 	ability_name = "charge"
-	cooldown_timer = 10 SECONDS //Balanced by the inability to use either ability more than twice in a row without needing a lengthy plasma charge
-	plasma_cost = 300
+	cooldown_timer = 20 SECONDS
+	plasma_cost = 600 //Can't ignore pain/Charge and ravage in the same timeframe, but you can combo one of them.
 	keybind_flags = XACT_KEYBIND_USE_ABILITY | XACT_IGNORE_SELECTED_ABILITY
 	keybind_signal = COMSIG_XENOABILITY_RAVAGER_CHARGE
 
@@ -85,7 +85,7 @@
 	action_icon_state = "ravage"
 	mechanics_text = "Attacks and knockbacks enemies in the direction your facing."
 	ability_name = "ravage"
-	plasma_cost = 250
+	plasma_cost = 200
 	cooldown_timer = 6 SECONDS
 	keybind_flags = XACT_KEYBIND_USE_ABILITY | XACT_IGNORE_SELECTED_ABILITY
 	keybind_signal = COMSIG_XENOABILITY_RAVAGE
@@ -118,7 +118,7 @@
 			victims++
 			step_away(H, X, sweep_range, 2)
 			shake_camera(H, 2, 1)
-			H.Paralyze(2 SECONDS)
+			H.Paralyze(1 SECONDS)
 
 	succeed_activate()
 	add_cooldown()
@@ -145,8 +145,8 @@
 	action_icon_state = "ignore_pain"
 	mechanics_text = "For the next few moments you will not go into crit, but you still die."
 	ability_name = "ignore pain"
-	plasma_cost = 50
-	cooldown_timer = 2 MINUTES
+	plasma_cost = 175
+	cooldown_timer = 1 MINUTES
 	keybind_flags = XACT_KEYBIND_USE_ABILITY | XACT_IGNORE_SELECTED_ABILITY
 	keybind_signal = COMSIG_XENOABILITY_IGNORE_PAIN
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -146,7 +146,7 @@
 	mechanics_text = "For the next few moments you will not go into crit, but you still die."
 	ability_name = "ignore pain"
 	plasma_cost = 175
-	cooldown_timer = 1 MINUTES
+	cooldown_timer = 40 SECONDS
 	keybind_flags = XACT_KEYBIND_USE_ABILITY | XACT_IGNORE_SELECTED_ABILITY
 	keybind_signal = COMSIG_XENOABILITY_IGNORE_PAIN
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
@@ -19,7 +19,7 @@
 	speed = -0.7
 
 	// *** Plasma *** //
-	plasma_max = 400
+	plasma_max = 600
 	plasma_gain = 20
 
 	// *** Health *** //
@@ -67,7 +67,7 @@
 	speed = -0.8
 
 	// *** Plasma *** //
-	plasma_max = 500 //Enables using either both abilities at once or one after another
+	plasma_max = 700 //Enables using either both abilities at once or one after another
 	plasma_gain = 30
 
 	// *** Health *** //
@@ -95,7 +95,7 @@
 	speed = -0.9
 
 	// *** Plasma *** //
-	plasma_max = 550
+	plasma_max = 750
 	plasma_gain = 35
 
 	// *** Health *** //
@@ -123,7 +123,7 @@
 	speed = -1
 
 	// *** Plasma *** //
-	plasma_max = 600
+	plasma_max = 800
 	plasma_gain = 40
 
 	// *** Health *** //


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
PART 5-
Ravager

NERFS
Eviscerating charge now has 20 second cooldown
Ravage stuns for less time

Compensation (If any)
Ravager now has ignore pain on 40 second cooldown, and has to choose between being able to survive for more time incombat or the ability to stun again, the higher plasma allows you to recover faster as you have more spare plasma overall
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Stuns bad, ravager might need another button after this though.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: eviscerating charge nerfed to 20 seconds, ravage stun nerfed, can use 2 of the three abilities at any time before running out of plasma at any level, ignore pain reduced to 40 seconds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
