### PR TITLE
Hivemind Return to Core fix

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/castedatum_hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/castedatum_hivemind.dm
@@ -71,6 +71,7 @@
 
 	// *** Abilities *** //
 	actions = list(
+		/datum/action/xeno_action/return_to_core,
 		/datum/action/xeno_action/plant_weeds/slow,
 		/datum/action/xeno_action/psychic_whisper,
 		/datum/action/xeno_action/activable/psychic_cure,
@@ -93,6 +94,7 @@
 
 	// *** Abilities *** //
 	actions = list(
+		/datum/action/xeno_action/return_to_core,
 		/datum/action/xeno_action/plant_weeds/slow,
 		/datum/action/xeno_action/psychic_whisper,
 		/datum/action/xeno_action/activable/psychic_cure,
@@ -116,6 +118,7 @@
 
 	// *** Abilities *** //
 	actions = list(
+		/datum/action/xeno_action/return_to_core,
 		/datum/action/xeno_action/plant_weeds/slow,
 		/datum/action/xeno_action/psychic_whisper,
 		/datum/action/xeno_action/activable/psychic_cure,


### PR DESCRIPTION

## About The Pull Request

Hivemind should always have their return to core ability.

tsk tsk Spooky, though I am at fault also.

## Why It's Good For The Game

As above

## Changelog
:cl: Hughgent
fix: Hivemind always has their return to core ability.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
