### PR TITLE
Making Stagger Great Again

### DIFF
--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -118,6 +118,9 @@
 #define ENERGY_OVERCHARGE_AMMO_COST		80
 #define ENERGY_OVERCHARGE_FIRE_DELAY		10
 
+//Define stagger damage multipliers
+#define STAGGER_DAMAGE_MULTIPLIER		0.5 //-50% damage dealt by the staggered target after all other mods.
+
 //Define smoke effects
 #define SMOKE_COUGH			(1<<0)
 #define SMOKE_GASP			(1<<1)

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -10,9 +10,6 @@
 #define PAIN_REDUCTION_VERY_HEAVY	-80 //tramadol
 #define PAIN_REDUCTION_FULL			-200 //oxycodone, neuraline
 
-//Stagger accuracy reduction
-#define STAGGER_ACCURACY_PENALTY	0.75 //Removes this % of accuracy after mods
-
 
 //Nutrition
 

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -10,6 +10,9 @@
 #define PAIN_REDUCTION_VERY_HEAVY	-80 //tramadol
 #define PAIN_REDUCTION_FULL			-200 //oxycodone, neuraline
 
+//Stagger accuracy reduction
+#define STAGGER_ACCURACY_PENALTY	0.75 //Removes this % of accuracy after mods
+
 
 //Nutrition
 

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -671,9 +671,18 @@ and you're good to go.
 		. = ..()
 		if(!.)
 			return
+
+		if(iscarbon(user)) //Check to see if we're staggered; if so, no point blank auto-accuracy
+			var/mob/living/carbon/C = user
+			if(C.stagger)
+				user.visible_message("<span class='danger'>[user] tries to fire [src] point blank at [M], but is disoriented!</span>")
+				Fire(M, user)
+				return TRUE
+
 		if(!active_attachable && gun_firemode == GUN_FIREMODE_BURSTFIRE && burst_amount > 1)
 			Fire(M, user)
 			return TRUE
+
 		DISABLE_BITFIELD(flags_gun_features, GUN_BURST_FIRING)
 		//Point blanking simulates firing the bullet proper but without actually firing it.
 		var/obj/projectile/projectile_to_fire = load_into_chamber(user)

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -672,13 +672,6 @@ and you're good to go.
 		if(!.)
 			return
 
-		if(iscarbon(user)) //Check to see if we're staggered; if so, no point blank auto-accuracy
-			var/mob/living/carbon/C = user
-			if(C.stagger)
-				user.visible_message("<span class='danger'>[user] tries to fire [src] point blank at [M], but is disoriented!</span>")
-				Fire(M, user)
-				return TRUE
-
 		if(!active_attachable && gun_firemode == GUN_FIREMODE_BURSTFIRE && burst_amount > 1)
 			Fire(M, user)
 			return TRUE

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -789,8 +789,8 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 			if(living_soft_armor)
 				living_soft_armor = max(0, living_soft_armor - penetration) //Flat removal.
 
-		var/mob/living/carbon/shooter_carbon = proj.firer
-		if(iscarbon(shooter_carbon))
+		if(iscarbon(proj.firer))
+			var/mob/living/carbon/shooter_carbon = proj.firer
 			if(shooter_carbon.stagger)
 				damage *= STAGGER_DAMAGE_MULTIPLIER //Since we hate RNG, stagger reduces damage by a % instead of reducing accuracy; consider it a 'glancing' hit due to being disoriented.
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -668,12 +668,6 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 				. += shooter_human.marksman_aura * 3
 				. += proj.distance_travelled * shooter_human.marksman_aura * 0.35
 
-		if(iscarbon(proj.firer))
-			var/mob/living/carbon/shooter_carbon = shooter_living
-			if(shooter_carbon.stagger)
-				BULLET_DEBUG("Staggered (Accuracy reduced by the higher of 30 or 75% of total accuracy).")
-				. -= max(30, STAGGER_ACCURACY_PENALTY * .) //Being staggered fucks your aim badly; higher of -30 to accuracy, or 75% of your accuracy, whichever is higher
-
 	BULLET_DEBUG("Hit zone penalty (-[GLOB.base_miss_chance[proj.def_zone]]) ([proj.def_zone])")
 	. -= GLOB.base_miss_chance[proj.def_zone] //Reduce accuracy based on spot.
 
@@ -794,6 +788,11 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 				living_hard_armor = max(0, living_hard_armor - (living_hard_armor * penetration * 0.01)) //AP reduces a % of hard armor.
 			if(living_soft_armor)
 				living_soft_armor = max(0, living_soft_armor - penetration) //Flat removal.
+
+		var/mob/living/carbon/shooter_carbon = proj.firer
+		if(iscarbon(shooter_carbon))
+			if(shooter_carbon.stagger)
+				damage *= STAGGER_DAMAGE_MULTIPLIER //Since we hate RNG, stagger reduces damage by a % instead of reducing accuracy; consider it a 'glancing' hit due to being disoriented.
 
 		if(!living_hard_armor && !living_soft_armor) //Armor fully penetrated.
 			feedback_flags |= BULLET_FEEDBACK_PEN

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -663,13 +663,16 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 			var/mob/living/carbon/human/shooter_human = shooter_living
 			BULLET_DEBUG("Traumatic shock (-[round(min(30, shooter_human.traumatic_shock * 0.2))]).")
 			. -= round(min(30, shooter_human.traumatic_shock * 0.2)) //Chance to hit declines with pain, being reduced by 0.2% per point of pain.
-			if(shooter_human.stagger)
-				BULLET_DEBUG("Stagged (-30).")
-				. -= 30 //Being staggered fucks your aim.
 			if(shooter_human.marksman_aura) //Accuracy bonus from active focus order: flat bonus + bonus per tile traveled
 				BULLET_DEBUG("marksman_aura (+[shooter_human.marksman_aura * 3] + [proj.distance_travelled * shooter_human.marksman_aura * 0.35]).")
 				. += shooter_human.marksman_aura * 3
 				. += proj.distance_travelled * shooter_human.marksman_aura * 0.35
+
+		if(iscarbon(proj.firer))
+			var/mob/living/carbon/human/shooter_carbon = shooter_living
+			if(shooter_carbon.stagger)
+				BULLET_DEBUG("Staggered (Accuracy reduced by the higher of 30 or 75% of total accuracy).")
+				. -= max(30, STAGGER_ACCURACY_PENALTY * .) //Being staggered fucks your aim badly; higher of -30 to accuracy, or 75% of your accuracy, whichever is higher
 
 	BULLET_DEBUG("Hit zone penalty (-[GLOB.base_miss_chance[proj.def_zone]]) ([proj.def_zone])")
 	. -= GLOB.base_miss_chance[proj.def_zone] //Reduce accuracy based on spot.

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -669,7 +669,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 				. += proj.distance_travelled * shooter_human.marksman_aura * 0.35
 
 		if(iscarbon(proj.firer))
-			var/mob/living/carbon/human/shooter_carbon = shooter_living
+			var/mob/living/carbon/shooter_carbon = shooter_living
 			if(shooter_carbon.stagger)
 				BULLET_DEBUG("Staggered (Accuracy reduced by the higher of 30 or 75% of total accuracy).")
 				. -= max(30, STAGGER_ACCURACY_PENALTY * .) //Being staggered fucks your aim badly; higher of -30 to accuracy, or 75% of your accuracy, whichever is higher


### PR DESCRIPTION
## About The Pull Request

Stagger is now meaningful for carbons per the following:

Halves all projectile damage after all other mods due to the concussion turning hits into glancing ones.

## Why It's Good For The Game

Makes Stagger meaningful as a debuff for non-Xeno targets. Also opens up debuff based counterplay to point blank builds.

Makes Stagger a notable substitute for debuffs/control CC in lieu of stuns.

## Changelog
:cl:
tweak: The Stagger debuff now halves all projectile damage.
/:cl: