### PR TITLE
Quick Cades, Barricade Anchoring and Barbed Wire Respect No Construction

### DIFF
--- a/code/game/objects/effects/effect_system/foam.dm
+++ b/code/game/objects/effects/effect_system/foam.dm
@@ -38,9 +38,12 @@
 		sleep(30)
 
 		if(metal == RAZOR_FOAM)
-			new /obj/structure/razorwire/foam(loc)
+			var/turf/open/T = get_turf(loc)
+			if(T.allow_construction) //No loopholes.
+				new /obj/structure/razorwire/foam(loc)
+
 		else if(metal == METAL_FOAM)
-			new /obj/structure/foamedmetal(loc)		
+			new /obj/structure/foamedmetal(loc)
 
 		flick("[icon_state]-disolve", src)
 		QDEL_IN(src, 5)

--- a/code/game/objects/effects/effect_system/foam.dm
+++ b/code/game/objects/effects/effect_system/foam.dm
@@ -38,6 +38,9 @@
 		sleep(30)
 
 		if(metal == RAZOR_FOAM)
+			if(!isopenturf(get_turf(loc)))
+				return FALSE
+
 			var/turf/open/T = get_turf(loc)
 			if(T.allow_construction) //No loopholes.
 				new /obj/structure/razorwire/foam(loc)

--- a/code/game/objects/effects/effect_system/foam.dm
+++ b/code/game/objects/effects/effect_system/foam.dm
@@ -38,10 +38,11 @@
 		sleep(30)
 
 		if(metal == RAZOR_FOAM)
-			if(!isopenturf(get_turf(loc)))
+			var/turf/mystery_turf = get_turf(loc)
+			if(!isopenturf(mystery_turf))
 				return FALSE
 
-			var/turf/open/T = get_turf(loc)
+			var/turf/open/T = mystery_turf
 			if(T.allow_construction) //No loopholes.
 				new /obj/structure/razorwire/foam(loc)
 

--- a/code/game/objects/items/quickdeploy_cade.dm
+++ b/code/game/objects/items/quickdeploy_cade.dm
@@ -39,9 +39,13 @@
 		return FALSE
 	if(!isturf(user.loc))
 		return FALSE
-	var/turf/placement_loc = user.loc
-	if(placement_loc.density)
+
+	var/turf/open/placement_loc = user.loc
+
+	if(placement_loc.density || !placement_loc.allow_construction) //We shouldn't be building here.
+		to_chat(user, "<span class='warning'>We can't build here!</span>")
 		return FALSE
+
 	for(var/obj/thing in user.loc)
 		if(!thing.density) //not dense, move on
 			continue

--- a/code/game/objects/items/quickdeploy_cade.dm
+++ b/code/game/objects/items/quickdeploy_cade.dm
@@ -37,11 +37,12 @@
 	. = ..()
 	if(!.)
 		return FALSE
-	if(!isturf(user.loc))
+
+	if(!isopenturf(user.loc))
+		to_chat(user, "<span class='warning'>We can't build here!</span>")
 		return FALSE
 
 	var/turf/open/placement_loc = user.loc
-
 	if(placement_loc.density || !placement_loc.allow_construction) //We shouldn't be building here.
 		to_chat(user, "<span class='warning'>We can't build here!</span>")
 		return FALSE

--- a/code/game/objects/items/quickdeploy_cade.dm
+++ b/code/game/objects/items/quickdeploy_cade.dm
@@ -38,11 +38,12 @@
 	if(!.)
 		return FALSE
 
-	if(!isopenturf(user.loc))
+	var/turf/mystery_turf = user.loc
+	if(!isopenturf(mystery_turf))
 		to_chat(user, "<span class='warning'>We can't build here!</span>")
 		return FALSE
 
-	var/turf/open/placement_loc = user.loc
+	var/turf/open/placement_loc = mystery_turf
 	if(placement_loc.density || !placement_loc.allow_construction) //We shouldn't be building here.
 		to_chat(user, "<span class='warning'>We can't build here!</span>")
 		return FALSE

--- a/code/game/objects/items/stacks/barbed_wire.dm
+++ b/code/game/objects/items/stacks/barbed_wire.dm
@@ -72,11 +72,12 @@
 /obj/item/stack/razorwire/attack_self(mob/user) //use barbed wire to deploy it
 	if(!ishuman(usr))
 		return
-	var/turf/open/target = get_step(user.loc,user.dir)
 
-	if(!istype(target))
+	if(!isopenturf(get_step(user.loc,user.dir)))
 		to_chat(user, "<span class='warning'>We can't build here!</span>")
 		return
+
+	var/turf/open/target = get_step(user.loc,user.dir)
 
 	if(check_blocked_turf(target)) //check if blocked
 		to_chat(user, "<span class='warning'>There is insufficient room to deploy [src]!</span>")

--- a/code/game/objects/items/stacks/barbed_wire.dm
+++ b/code/game/objects/items/stacks/barbed_wire.dm
@@ -73,11 +73,12 @@
 	if(!ishuman(usr))
 		return
 
-	if(!isopenturf(get_step(user.loc,user.dir)))
+	var/turf/mystery_turf = get_step(user.loc,user.dir)
+	if(!isopenturf(mystery_turf))
 		to_chat(user, "<span class='warning'>We can't build here!</span>")
 		return
 
-	var/turf/open/target = get_step(user.loc,user.dir)
+	var/turf/open/target = mystery_turf
 
 	if(check_blocked_turf(target)) //check if blocked
 		to_chat(user, "<span class='warning'>There is insufficient room to deploy [src]!</span>")

--- a/code/game/objects/items/stacks/barbed_wire.dm
+++ b/code/game/objects/items/stacks/barbed_wire.dm
@@ -72,12 +72,16 @@
 /obj/item/stack/razorwire/attack_self(mob/user) //use barbed wire to deploy it
 	if(!ishuman(usr))
 		return
-	var/turf/target = get_step(user.loc,user.dir)
+	var/turf/open/target = get_step(user.loc,user.dir)
 	if(!target)
 		return
 
 	if(check_blocked_turf(target)) //check if blocked
 		to_chat(user, "<span class='warning'>There is insufficient room to deploy [src]!</span>")
+		return
+
+	if(!target.allow_construction) //We shouldn't be building here.
+		to_chat(user, "<span class='warning'>We can't build here!</span>")
 		return
 
 	user.visible_message("<span class='notice'>[user] starts assembling [src].</span>",

--- a/code/game/objects/items/stacks/barbed_wire.dm
+++ b/code/game/objects/items/stacks/barbed_wire.dm
@@ -73,7 +73,9 @@
 	if(!ishuman(usr))
 		return
 	var/turf/open/target = get_step(user.loc,user.dir)
-	if(!target)
+
+	if(!istype(target))
+		to_chat(user, "<span class='warning'>We can't build here!</span>")
 		return
 
 	if(check_blocked_turf(target)) //check if blocked

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -660,6 +660,12 @@
 			return TRUE
 
 		if(BARRICADE_METAL_LOOSE) //Anchor bolts loosened step. Apply crowbar to unseat the panel and take apart the whole thing. Apply wrench to resecure anchor bolts
+
+			var/turf/open/T = get_turf(src)
+			if(T.allow_construction) //We shouldn't be able to anchor in areas we're not supposed to build; loophole closed.
+				to_chat(user, "<span class='warning'>We can't anchor the barricade here!</span>")
+				return TRUE
+
 			if(user.skills.getRating("construction") < SKILL_CONSTRUCTION_METAL)
 				user.visible_message("<span class='notice'>[user] fumbles around figuring out how to assemble [src].</span>",
 				"<span class='notice'>You fumble around figuring out how to assemble [src].</span>")
@@ -944,6 +950,12 @@
 				update_icon() //unanchored changes layer
 		if(BARRICADE_PLASTEEL_LOOSE) //Anchor bolts loosened step. Apply crowbar to unseat the panel and take apart the whole thing. Apply wrench to rescure anchor bolts
 			if(iswrench(I))
+
+				var/turf/open/T = get_turf(src)
+				if(T.allow_construction) //We shouldn't be able to anchor in areas we're not supposed to build; loophole closed.
+					to_chat(user, "<span class='warning'>We can't anchor the barricade here!</span>")
+					return TRUE
+
 				if(user.skills.getRating("engineer") < SKILL_ENGINEER_PLASTEEL)
 					user.visible_message("<span class='notice'>[user] fumbles around figuring out how to assemble [src].</span>",
 					"<span class='notice'>You fumble around figuring out how to assemble [src].</span>")

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -661,6 +661,10 @@
 
 		if(BARRICADE_METAL_LOOSE) //Anchor bolts loosened step. Apply crowbar to unseat the panel and take apart the whole thing. Apply wrench to resecure anchor bolts
 
+			if(!isopenturf(get_turf(src)))
+				to_chat(user, "<span class='warning'>We can't anchor the barricade here!</span>")
+				return TRUE
+
 			var/turf/open/T = get_turf(src)
 			if(T.allow_construction) //We shouldn't be able to anchor in areas we're not supposed to build; loophole closed.
 				to_chat(user, "<span class='warning'>We can't anchor the barricade here!</span>")
@@ -951,10 +955,14 @@
 		if(BARRICADE_PLASTEEL_LOOSE) //Anchor bolts loosened step. Apply crowbar to unseat the panel and take apart the whole thing. Apply wrench to rescure anchor bolts
 			if(iswrench(I))
 
+				if(!isopenturf(get_turf(src)))
+					to_chat(user, "<span class='warning'>We can't anchor the barricade here!</span>")
+					return
+
 				var/turf/open/T = get_turf(src)
 				if(T.allow_construction) //We shouldn't be able to anchor in areas we're not supposed to build; loophole closed.
 					to_chat(user, "<span class='warning'>We can't anchor the barricade here!</span>")
-					return TRUE
+					return
 
 				if(user.skills.getRating("engineer") < SKILL_ENGINEER_PLASTEEL)
 					user.visible_message("<span class='notice'>[user] fumbles around figuring out how to assemble [src].</span>",

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -661,11 +661,12 @@
 
 		if(BARRICADE_METAL_LOOSE) //Anchor bolts loosened step. Apply crowbar to unseat the panel and take apart the whole thing. Apply wrench to resecure anchor bolts
 
-			if(!isopenturf(get_turf(src)))
+			var/turf/mystery_turf = get_turf(src)
+			if(!isopenturf(mystery_turf))
 				to_chat(user, "<span class='warning'>We can't anchor the barricade here!</span>")
 				return TRUE
 
-			var/turf/open/T = get_turf(src)
+			var/turf/open/T = mystery_turf
 			if(T.allow_construction) //We shouldn't be able to anchor in areas we're not supposed to build; loophole closed.
 				to_chat(user, "<span class='warning'>We can't anchor the barricade here!</span>")
 				return TRUE
@@ -955,11 +956,12 @@
 		if(BARRICADE_PLASTEEL_LOOSE) //Anchor bolts loosened step. Apply crowbar to unseat the panel and take apart the whole thing. Apply wrench to rescure anchor bolts
 			if(iswrench(I))
 
-				if(!isopenturf(get_turf(src)))
+				var/turf/mystery_turf = get_turf(src)
+				if(!isopenturf(mystery_turf))
 					to_chat(user, "<span class='warning'>We can't anchor the barricade here!</span>")
 					return
 
-				var/turf/open/T = get_turf(src)
+				var/turf/open/T = mystery_turf
 				if(T.allow_construction) //We shouldn't be able to anchor in areas we're not supposed to build; loophole closed.
 					to_chat(user, "<span class='warning'>We can't anchor the barricade here!</span>")
 					return


### PR DESCRIPTION
## About The Pull Request

Fixes bugs pertaining to the ability to build and anchor barricades on dropships and other turfs with the no construction flag.

## Why It's Good For The Game

Bug fixes.

## Changelog
:cl:
fix: Barricades can no longer be anchored on the dropship or other no construction turfs.
fix: Quickcades and Barbed Wire can no longer be built on the dropship and other no construction turfs.
fix: Razorfoam will not produce barbed wire on no construction turfs.
/:cl: