### PR TITLE
Acid Wells No Longer Spawn Gas When Crushed by Dropship

### DIFF
--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -743,18 +743,9 @@ TUNNEL
 		if(A)
 			to_chat(creator, "<span class='xenoannounce'>You sense your acid well at [A.name] has been destroyed!</span>")
 
-	var/turf/open/T = get_turf(src)
-	if(!istype(T)) //We don't spawn gas on a closed turf.
-		return
-
-	if(!T.allow_construction) //We don't spawn gas on the dropship and other no-build tiles we shouldn't be on.
-		return
-
-	var/datum/effect_system/smoke_spread/xeno/acid/A = new(T)
+	var/datum/effect_system/smoke_spread/xeno/acid/A = new(get_turf(src))
 	A.set_up(clamp(charges,0,2),src)
 	A.start()
-	return ..()
-
 
 /obj/effect/alien/resin/acidwell/examine(mob/user)
 	..()

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -732,7 +732,7 @@ TUNNEL
 	. = ..()
 	update_icon()
 
-/obj/effect/alien/resin/acidwell/Destroy()
+/obj/effect/alien/resin/acidwell/obj_destruction(damage_flag)
 	if(!QDELETED(creator) && creator.stat == CONSCIOUS && creator.z == z)
 		var/area/A = get_area(src)
 		if(A)
@@ -752,6 +752,7 @@ TUNNEL
 	A.start()
 	creator = null
 	return ..()
+
 
 /obj/effect/alien/resin/acidwell/examine(mob/user)
 	..()

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -737,7 +737,17 @@ TUNNEL
 		var/area/A = get_area(src)
 		if(A)
 			to_chat(creator, "<span class='xenoannounce'>You sense your acid well at [A.name] has been destroyed!</span>")
-	var/datum/effect_system/smoke_spread/xeno/acid/A = new(get_turf(src))
+
+	var/turf/open/T = get_turf(src)
+	if(!istype(T)) //We don't spawn gas on a closed turf.
+		creator = null
+		return  ..()
+
+	if(!T.allow_construction) //We don't spawn gas on the dropship and other no-build tiles we shouldn't be on.
+		creator = null
+		return  ..()
+
+	var/datum/effect_system/smoke_spread/xeno/acid/A = new(T)
 	A.set_up(clamp(charges,0,2),src)
 	A.start()
 	creator = null

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -732,6 +732,11 @@ TUNNEL
 	. = ..()
 	update_icon()
 
+/obj/effect/alien/resin/acidwell/Destroy()
+	creator = null
+	return ..()
+
+
 /obj/effect/alien/resin/acidwell/obj_destruction(damage_flag)
 	if(!QDELETED(creator) && creator.stat == CONSCIOUS && creator.z == z)
 		var/area/A = get_area(src)
@@ -740,17 +745,14 @@ TUNNEL
 
 	var/turf/open/T = get_turf(src)
 	if(!istype(T)) //We don't spawn gas on a closed turf.
-		creator = null
-		return  ..()
+		return
 
 	if(!T.allow_construction) //We don't spawn gas on the dropship and other no-build tiles we shouldn't be on.
-		creator = null
-		return  ..()
+		return
 
 	var/datum/effect_system/smoke_spread/xeno/acid/A = new(T)
 	A.set_up(clamp(charges,0,2),src)
 	A.start()
-	creator = null
 	return ..()
 
 


### PR DESCRIPTION
## About The Pull Request

Acid wells no longer spawn acid gas when destroyed on a closed turf or on a no-build tile such as a dropship.

## Why It's Good For The Game

Bug fix.

## Changelog
:cl:
fix: Acid wells no longer spawn acid gas when destroyed on a closed turf or on a no-build tile such as a dropship.
/:cl: