### PR TITLE
Resin Structures Not Blocked by Non-Nest Beds/Obstacles Easier to Clear

### DIFF
--- a/code/game/objects/machinery/doors/windowdoor.dm
+++ b/code/game/objects/machinery/doors/windowdoor.dm
@@ -6,7 +6,7 @@
 	layer = ABOVE_WINDOW_LAYER
 	resistance_flags = XENO_DAMAGEABLE
 	var/base_state = "left"
-	max_integrity = 150
+	max_integrity = 50
 	soft_armor = list("melee" = 20, "bullet" = 50, "laser" = 50, "energy" = 50, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 70, "acid" = 100)
 	visible = FALSE
 	use_power = FALSE
@@ -19,7 +19,7 @@
 	desc = "A strong, secure door."
 	icon_state = "leftsecure"
 	base_state = "leftsecure"
-	max_integrity = 300
+	max_integrity = 100
 
 
 /obj/machinery/door/window/Initialize(mapload, set_dir)

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -16,7 +16,7 @@
 	buckle_lying = 90
 	throwpass = TRUE
 	resistance_flags = XENO_DAMAGEABLE
-	max_integrity = 100
+	max_integrity = 40
 	resistance_flags = XENO_DAMAGEABLE
 	hit_sound = 'sound/effects/metalhit.ogg'
 	var/buildstacktype = /obj/item/stack/sheet/metal

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -7,7 +7,7 @@
 	desc = "A rectangular metallic frame sitting on four legs with a back panel. Designed to fit the sitting position, more or less comfortably."
 	icon_state = "chair"
 	buckle_lying = 0
-	max_integrity = 100
+	max_integrity = 20
 	var/propelled = 0 //Check for fire-extinguisher-driven chairs
 
 

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -21,7 +21,7 @@
 	var/reinforced = FALSE
 	var/flipped = FALSE
 	var/flip_cooldown = 0 //If flip cooldown exists, don't allow flipping or putting back. This carries a WORLD.TIME value
-	max_integrity = 100
+	max_integrity = 40
 
 /obj/structure/table/deconstruct(disassembled)
 	if(disassembled)
@@ -474,7 +474,7 @@
 	parts = /obj/item/frame/table/wood
 	table_prefix = "wood"
 	hit_sound = 'sound/effects/woodhit.ogg'
-	max_integrity = 50
+	max_integrity = 20
 /*
 * Gambling tables
 */
@@ -486,7 +486,7 @@
 	parts = /obj/item/frame/table/gambling
 	table_prefix = "gamble"
 	hit_sound = 'sound/effects/woodhit.ogg'
-	max_integrity = 50
+	max_integrity = 20
 /*
 * Reinforced tables
 */
@@ -494,7 +494,7 @@
 	name = "reinforced table"
 	desc = "A square metal surface resting on four legs. This one has side panels, making it useful as a desk, but impossible to flip."
 	icon_state = "reinftable"
-	max_integrity = 200
+	max_integrity = 100
 	reinforced = TRUE
 	table_prefix = "reinf"
 	parts = /obj/item/frame/table/reinforced
@@ -576,7 +576,7 @@
 	anchored = TRUE
 	throwpass = TRUE	//You can throw objects over this, despite it's density.
 	climbable = TRUE
-	max_integrity = 150
+	max_integrity = 40
 	resistance_flags = XENO_DAMAGEABLE
 	var/parts = /obj/item/frame/rack
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -547,7 +547,7 @@
 				if(P.chair_state != DROPSHIP_CHAIR_BROKEN)
 					has_obstacle = TRUE
 					break
-			else
+			else if(istype(O, /obj/structure/bed/nest)) //We don't care about other beds/chairs/whatever the fuck.
 				has_obstacle = TRUE
 				break
 		if(istype(O, /obj/effect/alien/hivemindcore))


### PR DESCRIPTION
## About The Pull Request

Stops most non-nest beds from blocking alien buildables for no good reason.

Makes most destructible obstacles less resilient so it's not a total PITA for xenos to clear out; this won't meaningfully affect the balance because it doesn't touch on the obstacles/barriers marines use to fortify.

## Why It's Good For The Game

Improves builder Xeno QoL.

## Changelog
:cl:
fix: Chairs, stools and most non-nest beds no longer block xeno buildables.
tweak: Integrity of most non-marine buildables/barricades significantly reduced.
/:cl: