### PR TITLE
Improved Hive Information

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -20,8 +20,10 @@
 		if(!X.client)
 			xenoinfo += " <i>(SSD)</i>"
 
+		xenoinfo += " <b><font color=red>Health: ([X.health]/[X.maxHealth])</font></b>"
+
 		var/area/A = get_area(X)
-		xenoinfo += " <b><font color=green>([A ? A.name : null])</b></td></tr>"
+		xenoinfo += " <b><font color=green>([A ? A.name : null], X: [X.x], Y: [X.y])</b></td></tr>"
 
 	return xenoinfo
 
@@ -89,7 +91,7 @@
 	dat += "<table cellspacing=4>"
 	dat += xenoinfo
 	dat += "</table>"
-	var/datum/browser/popup = new(user, "roundstatus", "<div align='center'>Hive Status</div>", 600, 600)
+	var/datum/browser/popup = new(user, "roundstatus", "<div align='center'>Hive Status</div>", 650, 650)
 	popup.set_content(dat)
 	popup.open(FALSE)
 

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -78,10 +78,12 @@
 	xenoinfo += xeno_status_output(hive.xenos_by_typepath[/mob/living/carbon/xenomorph/larva], can_overwatch, TRUE, user)
 
 	var/hivemind_text = length(hive.xenos_by_typepath[/mob/living/carbon/xenomorph/hivemind]) > 0 ? "Active" : "Inactive"
+	var/xeno_tier_three_cap = CEILING(max(length(hive.xenos_by_tier[XENO_TIER_THREE]),(length(hive.xenos_by_tier[XENO_TIER_ZERO])+length(hive.xenos_by_tier[XENO_TIER_ONE])+length(hive.xenos_by_tier[XENO_TIER_TWO]))/3),1)
+	var/xeno_tier_two_cap = max(length(hive.xenos_by_tier[XENO_TIER_TWO]),length(hive.xenos_by_tier[XENO_TIER_ZERO])+length(hive.xenos_by_tier[XENO_TIER_ONE])-length(hive.xenos_by_tier[XENO_TIER_THREE]))
 
 	dat += "<b>Total Living Sisters: [hive.get_total_xeno_number()]</b><BR>"
-	dat += "<b>Tier 3: [length(hive.xenos_by_tier[XENO_TIER_THREE])] Sisters</b>[tier3counts]<BR>"
-	dat += "<b>Tier 2: [length(hive.xenos_by_tier[XENO_TIER_TWO])] Sisters</b>[tier2counts]<BR>"
+	dat += "<b>Tier 3: ([length(hive.xenos_by_tier[XENO_TIER_THREE])]/[xeno_tier_three_cap]) Sisters</b>[tier3counts]<BR>"
+	dat += "<b>Tier 2: ([length(hive.xenos_by_tier[XENO_TIER_TWO])]/[xeno_tier_two_cap]) Sisters</b>[tier2counts]<BR>"
 	dat += "<b>Tier 1: [length(hive.xenos_by_tier[XENO_TIER_ONE])] Sisters</b>[tier1counts]<BR>"
 	dat += "<b>Larvas: [length(hive.xenos_by_typepath[/mob/living/carbon/xenomorph/larva])] Sisters<BR>"
 	dat += "<b>Hivemind: [hivemind_text]<BR>"


### PR DESCRIPTION
## About The Pull Request

Adds the max number of tier 2s and 3s the hive can support, as well as the coordinates and current and max health of all xenos of the same hive to the Hive Status information.

Atomized from https://github.com/tgstation/TerraGov-Marine-Corps/pull/5286

## Why It's Good For The Game

Improves the flow of useful information between xenos, allowing for better coordinated play.

## Changelog
:cl:
add: Hive Status now displays the current and maximum hit points and exact coordinates of each hive member, as well as max number of T2s and T3s the hive can support.
/:cl: