### PR TITLE
Shield Slowdown Now Works

### DIFF
--- a/code/datums/components/shield.dm
+++ b/code/datums/components/shield.dm
@@ -135,9 +135,23 @@
 		return
 	shield_affect_user(user)
 
+	var/obj/item/parent_item = parent //Apply in-hand slowdowns.
+	if(!ishuman(user) || !parent_item)
+		return
+	var/mob/living/carbon/human/human_user = user
+	if(parent_item.slowdown)
+		human_user.add_movespeed_modifier(parent.type, TRUE, 0, NONE, TRUE, parent_item.slowdown)
+
 /datum/component/shield/proc/shield_dropped(datum/source, mob/user)
 	SIGNAL_HANDLER
 	shield_detatch_from_user()
+
+	var/obj/item/parent_item = parent //Apply in-hand slowdowns.
+	if(!ishuman(user) || !parent_item)
+		return
+	var/mob/living/carbon/human/human_user = user
+	if(parent_item.slowdown)
+		human_user.remove_movespeed_modifier(parent.type)
 
 /datum/component/shield/proc/shield_affect_user(mob/living/user)
 	if(affected)

--- a/code/datums/components/shield.dm
+++ b/code/datums/components/shield.dm
@@ -136,7 +136,7 @@
 	shield_affect_user(user)
 
 	var/obj/item/parent_item = parent //Apply in-hand slowdowns.
-	if(!ishuman(user) || !parent_item)
+	if(!ishuman(user))
 		return
 	var/mob/living/carbon/human/human_user = user
 	if(parent_item.slowdown)
@@ -147,7 +147,7 @@
 	shield_detatch_from_user()
 
 	var/obj/item/parent_item = parent //Apply in-hand slowdowns.
-	if(!ishuman(user) || !parent_item)
+	if(!ishuman(user))
 		return
 	var/mob/living/carbon/human/human_user = user
 	if(parent_item.slowdown)


### PR DESCRIPTION
## About The Pull Request

Makes the shield slowdown parameter actually work so shields slowdown while in-hand.

## Why It's Good For The Game

Gives the shield a meaningful downside it was always meant to have since the very beginning as its slowdown parameter now works appropriately; curbs some of the strength of scatterlaser + point blank and spank meta.

## Changelog
:cl:
balance: Shield slowdown parameter now works as it should
/:cl: