### PR TITLE
Psychic Beacon Gamemode

### DIFF
--- a/_maps/shuttles/resin_pod.dmm
+++ b/_maps/shuttles/resin_pod.dmm
@@ -1,0 +1,68 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/template_noop,
+/area/shuttle/ert/resinpod)
+"i" = (
+/obj/effect/alien/weeds/node/strong,
+/obj/effect/landmark/distress,
+/obj/effect/landmark/distress,
+/obj/effect/landmark/distress,
+/turf/open/shuttle/blackfloor,
+/area/shuttle/ert/resinpod)
+"j" = (
+/obj/structure/mineral_door/resin/thick,
+/obj/effect/alien/weeds,
+/turf/open/shuttle/blackfloor,
+/area/shuttle/ert/resinpod)
+"y" = (
+/obj/effect/landmark/distress,
+/obj/effect/alien/weeds,
+/obj/effect/landmark/distress,
+/obj/effect/landmark/distress,
+/turf/open/shuttle/blackfloor,
+/area/shuttle/ert/resinpod)
+"S" = (
+/obj/docking_port/mobile/ert,
+/obj/structure/mineral_door/resin/thick,
+/obj/effect/alien/weeds,
+/turf/open/shuttle/blackfloor,
+/area/shuttle/ert/resinpod)
+"W" = (
+/turf/closed/wall/resin/thick,
+/area/shuttle/ert/resinpod)
+
+(1,1,1) = {"
+a
+W
+j
+W
+a
+"}
+(2,1,1) = {"
+W
+y
+y
+y
+W
+"}
+(3,1,1) = {"
+S
+y
+i
+y
+j
+"}
+(4,1,1) = {"
+W
+y
+y
+y
+W
+"}
+(5,1,1) = {"
+a
+W
+j
+W
+a
+"}

--- a/_maps/shuttles/resin_pod.dmm
+++ b/_maps/shuttles/resin_pod.dmm
@@ -1,9 +1,11 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/template_noop,
+/turf/closed/wall/resin/regenerating/thick,
 /area/shuttle/ert/resinpod)
 "i" = (
 /obj/effect/alien/weeds/node/strong,
+/obj/effect/landmark/distress,
+/obj/effect/landmark/distress,
 /obj/effect/landmark/distress,
 /obj/effect/landmark/distress,
 /obj/effect/landmark/distress,
@@ -15,54 +17,42 @@
 /turf/open/shuttle/blackfloor,
 /area/shuttle/ert/resinpod)
 "y" = (
-/obj/effect/landmark/distress,
+/obj/structure/mineral_door/resin/thick,
+/obj/docking_port/mobile/ert,
 /obj/effect/alien/weeds,
-/obj/effect/landmark/distress,
-/obj/effect/landmark/distress,
 /turf/open/shuttle/blackfloor,
 /area/shuttle/ert/resinpod)
 "S" = (
-/obj/docking_port/mobile/ert,
-/obj/structure/mineral_door/resin/thick,
+/obj/effect/landmark/distress,
 /obj/effect/alien/weeds,
+/obj/effect/landmark/distress,
+/obj/effect/landmark/distress,
+/obj/effect/landmark/distress,
+/obj/effect/landmark/distress,
 /turf/open/shuttle/blackfloor,
-/area/shuttle/ert/resinpod)
-"W" = (
-/turf/closed/wall/resin/thick,
 /area/shuttle/ert/resinpod)
 
 (1,1,1) = {"
 a
-W
 j
-W
+j
 a
 "}
 (2,1,1) = {"
-W
 y
-y
-y
-W
+S
+S
+j
 "}
 (3,1,1) = {"
-S
-y
+j
 i
-y
+S
 j
 "}
 (4,1,1) = {"
-W
-y
-y
-y
-W
-"}
-(5,1,1) = {"
 a
-W
 j
-W
+j
 a
 "}

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -209,6 +209,7 @@
 //Gamemode
 #define isdistress(O) (istype(O, /datum/game_mode/infestation/distress))
 #define iscrashgamemode(O) (istype(O, /datum/game_mode/infestation/crash))
+#define ispsychicbeacon(O) (istype(O, /datum/game_mode/infestation/psychicbeacon))
 
 #define isxenoresearcharea(A) (istype(A, /area/mainship/medical/medical_science))
 

--- a/code/datums/gamemodes/psychicbeacon.dm
+++ b/code/datums/gamemodes/psychicbeacon.dm
@@ -1,0 +1,291 @@
+#define PSYCHICBEACON_MARINE_DEPLOYMENT 0
+#define PSYCHICBEACON_DROPSHIP_CRASHED 1
+
+/datum/game_mode/infestation/psychicbeacon
+	name = "Psychic Beacon"
+	config_tag = "Psychic Beacon"
+	required_players = 2
+	flags_round_type = MODE_INFESTATION|MODE_LZ_SHUTTERS|MODE_XENO_RULER
+	flags_landmarks = MODE_LANDMARK_SPAWN_XENO_TUNNELS|MODE_LANDMARK_SPAWN_MAP_ITEM
+	round_end_states = list(MODE_INFESTATION_X_MAJOR, MODE_INFESTATION_M_MAJOR, MODE_INFESTATION_X_MINOR, MODE_INFESTATION_M_MINOR, MODE_INFESTATION_DRAW_DEATH)
+
+	valid_job_types = list(
+		/datum/job/terragov/command/captain = 1,
+		/datum/job/terragov/command/fieldcommander = 1,
+		/datum/job/terragov/command/staffofficer = 4,
+		/datum/job/terragov/command/pilot = 2,
+		/datum/job/terragov/engineering/chief = 1,
+		/datum/job/terragov/engineering/tech = 2,
+		/datum/job/terragov/requisitions/officer = 1,
+		/datum/job/terragov/medical/professor = 1,
+		/datum/job/terragov/medical/medicalofficer = 6,
+		/datum/job/terragov/medical/researcher = 2,
+		/datum/job/terragov/civilian/liaison = 1,
+		/datum/job/terragov/silicon/synthetic = 1,
+		/datum/job/terragov/silicon/ai = 1,
+		/datum/job/terragov/squad/engineer = 8,
+		/datum/job/terragov/squad/corpsman = 8,
+		/datum/job/terragov/squad/smartgunner = 1,
+		/datum/job/terragov/squad/leader = 1,
+		/datum/job/terragov/squad/standard = -1,
+		/datum/job/xenomorph = 2,
+		/datum/job/xenomorph/queen = 1
+	)
+
+	var/round_stage = PSYCHICBEACON_MARINE_DEPLOYMENT
+
+	var/bioscan_current_interval = 45 MINUTES
+	var/bioscan_ongoing_interval = 20 MINUTES
+	var/orphan_hive_timer
+
+
+/datum/game_mode/infestation/psychicbeacon/announce()
+	to_chat(world, "<span class='round_header'>The current map is - [SSmapping.configs[GROUND_MAP].map_name]!</span>")
+
+
+/datum/game_mode/infestation/psychicbeacon/can_start(bypass_checks = FALSE)
+	. = ..()
+	if(!.)
+		return
+	var/xeno_candidate = FALSE //Let's guarantee there's at least one xeno.
+	for(var/level = JOBS_PRIORITY_HIGH; level >= JOBS_PRIORITY_LOW; level--)
+		for(var/p in GLOB.ready_players)
+			var/mob/new_player/player = p
+			if(player.client.prefs.job_preferences[ROLE_XENO_QUEEN] == level && SSjob.AssignRole(player, SSjob.GetJobType(/datum/job/xenomorph/queen)))
+				xeno_candidate = TRUE
+				break
+			if(player.client.prefs.job_preferences[ROLE_XENOMORPH] == level && SSjob.AssignRole(player, SSjob.GetJobType(/datum/job/xenomorph)))
+				xeno_candidate = TRUE
+				break
+	if(!xeno_candidate && !bypass_checks)
+		to_chat(world, "<b>Unable to start [name].</b> No xeno candidate found.")
+		return FALSE
+
+
+/datum/game_mode/infestation/psychicbeacon/pre_setup()
+	. = ..()
+	addtimer(CALLBACK(SSticker.mode, .proc/map_announce), 5 SECONDS)
+
+
+/datum/game_mode/infestation/psychicbeacon/post_setup()
+	. = ..()
+	scale_gear()
+	for(var/i in GLOB.xeno_resin_silo_turfs)
+		new /obj/structure/resin/silo(i)
+
+	addtimer(CALLBACK(src, .proc/announce_bioscans, FALSE, 1), rand(30 SECONDS, 1 MINUTES)) //First scan shows no location but more precise numbers.
+
+/datum/game_mode/infestation/psychicbeacon/proc/map_announce()
+	if(!SSmapping.configs[GROUND_MAP].announce_text)
+		return
+
+	priority_announce(SSmapping.configs[GROUND_MAP].announce_text, SSmapping.configs[SHIP_MAP].map_name)
+
+
+/datum/game_mode/infestation/psychicbeacon/process()
+	if(round_finished)
+		return FALSE
+
+	//Automated bioscan / Queen Mother message
+	if(world.time > bioscan_current_interval)
+		announce_bioscans()
+		var/total[] = count_humans_and_xenos(count_flags = COUNT_IGNORE_XENO_SPECIAL_AREA)
+		var/marines = total[1]
+		var/xenos = total[2]
+		var/bioscan_scaling_factor = xenos / max(marines, 1)
+		bioscan_scaling_factor = max(bioscan_scaling_factor, 0.25)
+		bioscan_scaling_factor = min(bioscan_scaling_factor, 1.5)
+		bioscan_current_interval += bioscan_ongoing_interval * bioscan_scaling_factor
+
+
+/datum/game_mode/infestation/psychicbeacon/check_finished()
+	if(round_finished)
+		return TRUE
+
+	if(world.time < (SSticker.round_start_time + 5 SECONDS))
+		return FALSE
+
+	var/living_player_list[] = count_humans_and_xenos(count_flags = COUNT_IGNORE_ALIVE_SSD|COUNT_IGNORE_XENO_SPECIAL_AREA)
+	var/num_humans = living_player_list[1]
+	var/num_xenos = living_player_list[2]
+
+	if(SSevacuation.dest_status == NUKE_EXPLOSION_FINISHED)
+		message_admins("Round finished: [MODE_GENERIC_DRAW_NUKE]") //ship blows, no one wins
+		round_finished = MODE_GENERIC_DRAW_NUKE
+		return TRUE
+	if(!num_humans)
+		if(!num_xenos)
+			message_admins("Round finished: [MODE_INFESTATION_DRAW_DEATH]") //everyone died at the same time, no one wins
+			round_finished = MODE_INFESTATION_DRAW_DEATH
+			return TRUE
+		if(round_stage == PSYCHICBEACON_DROPSHIP_CRASHED)
+			message_admins("Round finished: [MODE_INFESTATION_X_MAJOR]") //xenos wiped our marines, xeno major victory
+			round_finished = MODE_INFESTATION_X_MAJOR
+			return TRUE
+		message_admins("Round finished: [MODE_INFESTATION_X_MAJOR]") //xenos wiped out ALL the marines without hijacking, xeno major victory
+		round_finished = MODE_INFESTATION_X_MAJOR
+		return TRUE
+	if(!num_xenos)
+		if(round_stage == PSYCHICBEACON_DROPSHIP_CRASHED)
+			message_admins("Round finished: [MODE_INFESTATION_X_MINOR]") //xenos hijacked the shuttle and won groundside but died on the ship, minor victory
+			round_finished = MODE_INFESTATION_X_MINOR
+			return TRUE
+		message_admins("Round finished: [MODE_INFESTATION_M_MAJOR]") //marines win big or go home
+		round_finished = MODE_INFESTATION_M_MAJOR
+		return TRUE
+	return FALSE
+
+
+/datum/game_mode/infestation/psychicbeacon/declare_completion()
+	. = ..()
+	to_chat(world, "<span class='round_header'>|Round Complete|</span>")
+
+	to_chat(world, "<span class='round_body'>Thus ends the story of the brave men and women of the [SSmapping.configs[SHIP_MAP].map_name] and their struggle on [SSmapping.configs[GROUND_MAP].map_name].</span>")
+	var/sound/xeno_track
+	var/sound/human_track
+	var/sound/ghost_track
+	switch(round_finished)
+		if(MODE_INFESTATION_X_MAJOR)
+			xeno_track = pick('sound/theme/winning_triumph1.ogg', 'sound/theme/winning_triumph2.ogg')
+			human_track = pick('sound/theme/sad_loss1.ogg', 'sound/theme/sad_loss2.ogg')
+			ghost_track = xeno_track
+		if(MODE_INFESTATION_M_MAJOR)
+			xeno_track = pick('sound/theme/sad_loss1.ogg', 'sound/theme/sad_loss2.ogg')
+			human_track = pick('sound/theme/winning_triumph1.ogg', 'sound/theme/winning_triumph2.ogg')
+			ghost_track = human_track
+		if(MODE_INFESTATION_X_MINOR)
+			xeno_track = pick('sound/theme/neutral_hopeful1.ogg', 'sound/theme/neutral_hopeful2.ogg')
+			human_track = pick('sound/theme/neutral_melancholy1.ogg', 'sound/theme/neutral_melancholy2.ogg')
+			ghost_track = xeno_track
+		if(MODE_INFESTATION_M_MINOR)
+			xeno_track = pick('sound/theme/neutral_melancholy1.ogg', 'sound/theme/neutral_melancholy2.ogg')
+			human_track = pick('sound/theme/neutral_hopeful1.ogg', 'sound/theme/neutral_hopeful2.ogg')
+			ghost_track = human_track
+		if(MODE_INFESTATION_DRAW_DEATH)
+			ghost_track = pick('sound/theme/nuclear_detonation1.ogg', 'sound/theme/nuclear_detonation2.ogg')
+			xeno_track = ghost_track
+			human_track = ghost_track
+
+	xeno_track = sound(xeno_track)
+	xeno_track.channel = CHANNEL_CINEMATIC
+	human_track = sound(human_track)
+	human_track.channel = CHANNEL_CINEMATIC
+	ghost_track = sound(ghost_track)
+	ghost_track.channel = CHANNEL_CINEMATIC
+
+	for(var/i in GLOB.xeno_mob_list)
+		var/mob/M = i
+		SEND_SOUND(M, xeno_track)
+
+	for(var/i in GLOB.human_mob_list)
+		var/mob/M = i
+		SEND_SOUND(M, human_track)
+
+	for(var/i in GLOB.observer_list)
+		var/mob/M = i
+		if(ishuman(M.mind.current))
+			SEND_SOUND(M, human_track)
+			continue
+
+		if(isxeno(M.mind.current))
+			SEND_SOUND(M, xeno_track)
+			continue
+
+		SEND_SOUND(M, ghost_track)
+
+	log_game("[round_finished]\nGame mode: [name]\nRound time: [duration2text()]\nEnd round player population: [length(GLOB.clients)]\nTotal xenos spawned: [GLOB.round_statistics.total_xenos_created]\nTotal humans spawned: [GLOB.round_statistics.total_humans_created]")
+
+	announce_xenomorphs()
+	announce_medal_awards()
+	announce_round_stats()
+
+
+/datum/game_mode/infestation/psychicbeacon/scale_roles(initial_players_assigned)
+	. = ..()
+	if(!.)
+		return
+	var/datum/job/scaled_job = SSjob.GetJobType(/datum/job/xenomorph) //Xenos
+	scaled_job.job_points_needed  = CONFIG_GET(number/psychicbeacon_larvapoints_required)
+
+	scaled_job = SSjob.GetJobType(/datum/job/survivor/rambo) //Survivors
+	scaled_job.job_points_needed  = 3
+
+
+/datum/game_mode/infestation/psychicbeacon/proc/scale_gear()
+	var/marine_pop_size = 0
+
+	for(var/i in GLOB.alive_human_list)
+		var/mob/living/carbon/human/H = i
+		if(ismarinefaction(H))
+			marine_pop_size++
+
+	var/scale = max(marine_pop_size / MARINE_GEAR_SCALING, 1) //This gives a decimal value representing a scaling multiplier. Cannot go below 1
+
+	//Scale the amount of cargo points through a direct multiplier
+	SSpoints.scale_supply_points(scale)
+
+
+/datum/game_mode/infestation/psychicbeacon/proc/announce_xenomorphs()
+	var/datum/hive_status/normal/HN = GLOB.hive_datums[XENO_HIVE_NORMAL]
+	if(!HN.living_xeno_ruler)
+		return
+
+	var/dat = "<span class='round_body'>The surviving xenomorph ruler was:<br>[HN.living_xeno_ruler.key] as <span class='boldnotice'>[HN.living_xeno_ruler]</span></span>"
+
+	to_chat(world, dat)
+
+
+/datum/game_mode/infestation/psychicbeacon/mode_new_player_panel(mob/new_player/NP)
+
+	var/output = "<div align='center'>"
+	output += "<br><i>You are part of the <b>TerraGov Marine Corps</b>, a military branch of the TerraGov council.</i>"
+	output +="<hr>"
+	output += "<p><a href='byond://?src=[REF(NP)];lobby_choice=show_preferences'>Setup Character</A> | <a href='byond://?src=[REF(NP)];lobby_choice=lore'>Background</A><br><br><a href='byond://?src=[REF(NP)];lobby_choice=observe'>Observe</A></p>"
+	output +="<hr>"
+	output += "<center><p>Current character: <b>[NP.client ? NP.client.prefs.real_name : "Unknown User"]</b></p></center>"
+
+	if(SSticker.current_state <= GAME_STATE_PREGAME)
+		output += "<p>\[ [NP.ready? "<b>Ready</b>":"<a href='byond://?src=\ref[src];lobby_choice=ready'>Ready</a>"] | [NP.ready? "<a href='byond://?src=[REF(NP)];lobby_choice=ready'>Not Ready</a>":"<b>Not Ready</b>"] \]</p>"
+	else
+		output += "<a href='byond://?src=[REF(NP)];lobby_choice=manifest'>View the Crew Manifest</A><br>"
+		output += "<p><a href='byond://?src=[REF(NP)];lobby_choice=late_join'>Join the Game!</A></p>"
+
+	output += append_player_votes_link(NP)
+
+	output += "</div>"
+
+	var/datum/browser/popup = new(NP, "playersetup", "<div align='center'>Welcome to TGMC[SSmapping?.configs ? " - [SSmapping.configs[SHIP_MAP].map_name]" : ""]</div>", 300, 375)
+	popup.set_window_options("can_close=0")
+	popup.set_content(output)
+	popup.open(FALSE)
+
+	return TRUE
+
+
+/datum/game_mode/infestation/psychicbeacon/orphan_hivemind_collapse()
+	if(!(flags_round_type & MODE_INFESTATION))
+		return
+	if(round_finished)
+		return
+	if(round_stage == PSYCHICBEACON_DROPSHIP_CRASHED)
+		round_finished = MODE_INFESTATION_M_MINOR
+		return
+	round_finished = MODE_INFESTATION_M_MAJOR
+
+
+/datum/game_mode/infestation/psychicbeacon/get_hivemind_collapse_countdown()
+	if(!orphan_hive_timer)
+		return
+	var/eta = timeleft(orphan_hive_timer) * 0.1
+	if(eta > 0)
+		return "[(eta / 60) % 60]:[add_leading(num2text(eta % 60), 2, "0")]"
+
+
+/datum/game_mode/infestation/psychicbeacon/attempt_to_join_as_larva(mob/xeno_candidate)
+	var/datum/hive_status/normal/HS = GLOB.hive_datums[XENO_HIVE_NORMAL]
+	return HS.attempt_to_spawn_larva(xeno_candidate)
+
+
+/datum/game_mode/infestation/psychicbeacon/spawn_larva(mob/xeno_candidate, mob/living/carbon/xenomorph/mother)
+	var/datum/hive_status/normal/HS = GLOB.hive_datums[XENO_HIVE_NORMAL]
+	return HS.spawn_larva(xeno_candidate, mother)

--- a/code/game/area/areas/shuttles.dm
+++ b/code/game/area/areas/shuttles.dm
@@ -50,6 +50,9 @@
 /area/shuttle/ert/ufo
 	name = "Small UFO"
 
+/area/shuttle/ert/resinpod
+	name = "Resin Drop Pod"
+
 /area/shuttle/transit
 	name = "Hyperspace"
 	desc = "Weeeeee"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<details>
  <summary>Design Doc</summary>
Xenos will construct a psionic monolith that calls other hives for help.
Monolith will be a hivemind that only the hive leader can create, and creates a global message to xenos with the location, and an general announcement of completion to marines.
Monolith can only be constructed in non-underground areas, and only after X minutes after the round has started so marines have time to gear up and create a FOB.
Regular hivemind will not be available to evolve into.
Monolith's age progresses slowly, can be sped up by consuming burrowed larva.
Monolith calls an XRT that scales based on Monolith's age and living players.
A small around around the monolith cannot be targeted by OB/CAS/Mortar due to a psychic shield.
Xenomorph leader cannot hijack the Alamo.
Queen tracker on ship points to closest human.
If the monolith is destroyed, psychic backlash kills shrike and queen and prevents a new one from emerging, giving the hive a couple minutes to finish off the crew on the ship and have a draw.

Win Conditions:
If no humans on the marine ship after X minutes, major xeno win.
Marine Major - Wipe out the xenos; destroy the monolith
Draw - Monolith destroyed + hivemind collapse + no humans on the ship
</details>

- [x] Resin drop pods for XRTs
- [ ] Crash spots on ship for resin pods
- [ ] Queen tracker points to closest human when on ship Z level
- [ ] Hivemind is the Monolith
- [ ] Hivemind can only be evolved into after X minutes
- [ ] Hivemind autocalls XRT based on age
- [ ] Hivemind's death kills shrike and queen, and prevents a new leader from evolving
- [ ] Hivemind cannot be evolved in an underground area
- [ ] Hivemind has an area around it that prevents mortar/OB/cas/drop pods
- [ ] Hivemind can consume burrowed larva to speed up evolution process
- [ ] Hivemind crumples the marine ship like paper after becoming ancient and X minutes pass
- [ ] Global announcements for XRTs
- [ ] Global announcement for Hivemind's final ability to destroy the ship
- [ ] Prevent more than X resin walls from being placed near each other to prevent ultra turtling?
- [ ] Two radii around the Hivemind, one spawns in a resin maze, the other prevents walls from being made inside of it?

Win Conditions

- [ ] Xenos cannot call/hijack Alamo
- [ ] Xeno Major - If no humans are on the marine ship after X minutes
- [ ] Xeno Major - If X minutes pass after the hivemind is ancient, it crumples the marine ship like paper
- [ ] Marine Major - Wipe out the xenos; destroy the monolith
- [ ] Draw - Monolith destroyed + hivemind collapse + no humans on the ship

## Why It's Good For The Game

Distress is diseased. Rotten to the core. There's no saving it -- we need to pull it out by the roots. Wipe the slate clean. BURN IT DOWN! And from the ashes a new gamemode will be born.

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
