### PR TITLE
Tweaks for Spits That Drop Residual Effects

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1432,6 +1432,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 		var/mob/living/carbon/C = M
 		if(C.issamexenohive(P.firer))
 			return
+		C.adjust_stagger(2) //stagger briefly; useful for support
 		C.add_slowdown(3) //slow em down
 
 
@@ -1439,11 +1440,19 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	var/turf/T = get_turf(O)
 	if(!T)
 		T = get_turf(P)
+
+	if(O.density && !(O.flags_atom & ON_BORDER))
+		T = get_turf(get_step(T, turn(P.dir, 180))) //If the object is dense and not a border object like barricades, we instead drop in the location just prior to the target
+
 	drop_resin(T)
 
 /datum/ammo/xeno/sticky/on_hit_turf(turf/T,obj/projectile/P)
 	if(!T)
 		T = get_turf(P)
+
+	if(isclosedturf(T))
+		T = get_turf(get_step(T, turn(P.dir, 180))) //If the turf is closed, we instead drop in the location just prior to the turf
+
 	drop_resin(T)
 
 /datum/ammo/xeno/sticky/do_at_max_range(obj/projectile/P)
@@ -1496,12 +1505,20 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	var/turf/T = get_turf(O)
 	if(!T)
 		T = get_turf(P)
+
+	if(O.density && !(O.flags_atom & ON_BORDER))
+		T = get_turf(get_step(T, turn(P.dir, 180))) //If the object is dense and not a border object like barricades, we instead drop in the location just prior to the target
+
 	drop_nade(T)
 
 
 /datum/ammo/xeno/acid/heavy/on_hit_turf(turf/T,obj/projectile/P)
 	if(!T)
 		T = get_turf(P)
+
+	if(isclosedturf(T))
+		T = get_turf(get_step(T, turn(P.dir, 180))) //If the turf is closed, we instead drop in the location just prior to the turf
+
 	drop_nade(T)
 
 /datum/ammo/xeno/acid/heavy/do_at_max_range(obj/projectile/P)


### PR DESCRIPTION
## About The Pull Request

Fixes the residual effects that spawn from sticky and heavy acid spit to spawn correctly in the turfs immediately prior to the dense full tile objects and closed turfs they impact, rather than them trying to spawn in the closed turf/dense object.

Also makes Sticky Resin more useful in a combat support capacity by having it add 2 stagger stacks to the target.

## Why It's Good For The Game

1: Fixes residual effect spawning for heavy acid and sticky acid spit so they work more intuitively.
2: Makes Sticky Spit a more effective combat support option.

## Changelog
:cl:
fix: Fixes residual effect spawning for heavy acid and sticky acid spit so they work more intuitively (and properly).
balance: Sticky Spit now applies 2 stagger stacks to improve its combat support capabilities.
/:cl: