### PR TITLE
Gun Cabinet tweak

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
@@ -38,7 +38,6 @@
 /obj/structure/closet/secure_closet/guncabinet/canterbury/PopulateContents()
 	new /obj/item/weapon/gun/shotgun/combat/standardmarine(src)
 	new /obj/item/weapon/gun/rifle/m412(src)
-	new /obj/item/weapon/gun/rifle/standard_smartmachinegun(src)
 	new /obj/item/weapon/gun/flamer/marinestandard(src)
 	new /obj/item/ammo_magazine/flamer_tank/large(src)
 	new /obj/item/weapon/gun/smg/m25(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
@@ -36,21 +36,20 @@
 
 
 /obj/structure/closet/secure_closet/guncabinet/canterbury/PopulateContents()
-	new /obj/item/weapon/gun/shotgun/combat(src)
-	new /obj/item/ammo_magazine/shotgun(src)
-	new /obj/item/clothing/suit/storage/marine/smartgunner/fancy(src)
-	new /obj/item/weapon/gun/smartgun(src)
-	new /obj/item/smartgun_powerpack/fancy(src)
-	new /obj/item/weapon/gun/flamer(src)
-	new /obj/item/ammo_magazine/flamer_tank(src)
-	new /obj/item/weapon/gun/shotgun/combat(src)
-	new /obj/item/weapon/gun/smg/standard_smg(src)
-	new /obj/item/weapon/gun/pistol/rt3(src)
+	new /obj/item/weapon/gun/shotgun/combat/standardmarine(src)
+	new /obj/item/weapon/gun/rifle/m412(src)
+	new /obj/item/weapon/gun/rifle/standard_smartmachinegun(src)
+	new /obj/item/weapon/gun/flamer/marinestandard(src)
+	new /obj/item/ammo_magazine/flamer_tank/large(src)
+	new /obj/item/weapon/gun/smg/m25(src)
+	new /obj/item/weapon/gun/revolver/mateba(src)
 
 	var/list/to_spawn = list(
-		/obj/item/ammo_magazine/shotgun/buckshot = 3,
-		/obj/item/clothing/suit/armor/bulletproof = 4,
-		/obj/item/ammo_magazine/pistol/ap = 2,
+		/obj/item/ammo_magazine/shotgun/incendiary = 2, // Incendiaries are quite rare, soo...
+		/obj/item/ammo_magazine/rifle = 3,
+		/obj/item/ammo_magazine/smg/m25 = 3,
+		/obj/item/clothing/suit/armor/bulletproof = 2, // Synths might make use of it.
+		/obj/item/ammo_magazine/revolver/mateba = 2,
 	)
 	for(var/typepath in to_spawn)
 		for(var/i in 1 to to_spawn[typepath])


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
As per title. Replaces the following:

> MK221 with 3 buckshot boxes
T-90A smartgun equipment
M240 flamer
M4A3 with AP mags
T-90 SMG

to

> M412 pulse rifle (3 spare mags)
T-39 combat SG (with two incendiary boxes)
M25 SMG (3 spare mags)
Mateba (2 spare speedloaders)
TL-84 flamer (1 spare tank)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Because we're removing more CM guns and making them restricted to only admins.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Tweaked the TGMC gun cabinet inside the Canterbury, removing most of the outdated options with the current ones.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
