### PR TITLE
Tweak new Hive Status health color to be less red all the time

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -20,7 +20,14 @@
 		if(!X.client)
 			xenoinfo += " <i>(SSD)</i>"
 
-		xenoinfo += " <b><font color=red>Health: ([X.health]/[X.maxHealth])</font></b>"
+		var/hp_color = "green"
+		switch(X.health/X.maxHealth)
+			if(0.33 to 0.66)
+				hp_color = "orange"
+			if(0 to 0.33)
+				hp_color = "red"
+
+		xenoinfo += " <b><font color=[hp_color]>Health: ([X.health]/[X.maxHealth])</font></b>"
 
 		var/area/A = get_area(X)
 		xenoinfo += " <b><font color=green>([A ? A.name : null], X: [X.x], Y: [X.y])</b></td></tr>"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the health numbers color change from green, to orange, to red depending on the value.

## Why It's Good For The Game

Less unimportant red text demanding attention.

## Changelog
:cl:
tweak: Hive Status health text is now only red when below a third of max health.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
