### PR TITLE
Hotfix For Shield 100% Block Rate While Prone/Stunned/KO

### DIFF
--- a/code/datums/components/shield.dm
+++ b/code/datums/components/shield.dm
@@ -171,7 +171,7 @@
 	var/status_cover_modifier = 1
 
 	if(affected.IsSleeping() || affected.IsUnconscious() || affected.IsAdminSleeping() || affected.IsParalyzed()) //We don't do jack if we're literally KOed/sleeping/paralyzed.
-		return FALSE
+		return incoming_damage
 
 	if(affected.IsStun() || affected.IsKnockdown()) //Halve shield cover if we're paralyzed or stunned
 		status_cover_modifier *= 0.5


### PR DESCRIPTION
## About The Pull Request

Fixes 100% block rate for shields while the user is fully disabled.

## Why It's Good For The Game

Fixes a lame bug.

## Changelog
:cl:
fix: Fixes 100% shield block rate for fully disabled targets.
/:cl: