### PR TITLE
Making Sticky Resin Great Again

### DIFF
--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -86,7 +86,7 @@
 		deconstruct(TRUE)
 		return
 
-	..()
+	return ..()
 
 
 /obj/effect/alien/resin/sticky/Crossed(atom/movable/AM)

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -78,6 +78,16 @@
 
 	ignore_weed_destruction = TRUE
 
+/obj/effect/alien/resin/sticky/attack_alien(mob/living/carbon/xenomorph/M)
+
+	if(M.a_intent == INTENT_HARM) //Clear it out on hit; no need to double tap.
+		M.do_attack_animation(src, ATTACK_EFFECT_CLAW) //SFX
+		playsound(src, "alien_resin_break", 25) //SFX
+		deconstruct(TRUE)
+		return
+
+	..()
+
 
 /obj/effect/alien/resin/sticky/Crossed(atom/movable/AM)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -234,7 +234,12 @@
 	if(!scaling_wait)
 		return
 	var/mob/living/carbon/xenomorph/X = owner
-	return base_wait + scaling_wait - max(0, (scaling_wait * X.health / X.maxHealth))
+
+	var/sticky_resin_modifier = 1
+	if(X.selected_resin == /obj/effect/alien/resin/sticky) //Sticky resin builds twice as fast
+		sticky_resin_modifier = 0.5
+
+	return (base_wait + scaling_wait - max(0, (scaling_wait * X.health / X.maxHealth))) * sticky_resin_modifier
 
 /datum/action/xeno_action/activable/secrete_resin/proc/build_resin(turf/T)
 	var/mob/living/carbon/xenomorph/X = owner
@@ -324,9 +329,14 @@
 	else
 		new_resin = new X.selected_resin(T)
 
+	if(X.selected_resin == /obj/effect/alien/resin/sticky) //Sticky resin is discounted because let's face it, it's nowhere near as good as a wall or door
+		plasma_cost = 25
+
 	if(new_resin)
 		add_cooldown()
 		succeed_activate()
+
+	plasma_cost = initial(plasma_cost) //Reset the plasma cost
 
 // Slower version of the secret resin
 /datum/action/xeno_action/activable/secrete_resin/slow


### PR DESCRIPTION
## About The Pull Request

1: Sticky resin now costs 25 plasma to build, and requires half the time to build that other buildables do.

2: Xenos now auto-destroy sticky resin when attacking it on Harm intent instead of having to double tap it for QoL.

## Why It's Good For The Game

Makes hard building sticky resin worthwhile again vis a vis sticky spit. Also prices sticky resin appropriately in terms of time and plasma cost vis a vis doors and walls.

Improves Xeno QoL by making resin removal take less time and clicks.

## Changelog
:cl:
tweak: Xenos now auto-remove sticky resin when clicking it on Harm intent.
tweak: Sticky Resin build cost down from 75 to 25, and build time has been halved.
/:cl: