### PR TITLE
Fixes xeno_action's add_cooldown() sanity check to prevent 0 length timers

### DIFF
--- a/code/datums/actions/xeno_action.dm
+++ b/code/datums/actions/xeno_action.dm
@@ -138,10 +138,11 @@
 
 /datum/action/xeno_action/proc/add_cooldown()
 	SIGNAL_HANDLER
-	if(cooldown_id) // stop doubling up
+	var/cooldown_length = get_cooldown()
+	if(cooldown_id || !cooldown_length) // stop doubling up or waiting on zero
 		return
 	last_use = world.time
-	cooldown_id = addtimer(CALLBACK(src, .proc/on_cooldown_finish), get_cooldown(), TIMER_STOPPABLE)
+	cooldown_id = addtimer(CALLBACK(src, .proc/on_cooldown_finish), cooldown_length, TIMER_STOPPABLE)
 	button.overlays += cooldown_image
 	update_button_icon()
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a check for 0 length cooldowns to `add_cooldown()`

## Why It's Good For The Game

Fix good.

## Changelog
:cl:
fix: Fixed a timer error with 0 length cooldown xeno actions.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
