### PR TITLE
deletes evolution paths, every xenomorph can evo into the next tier

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
@@ -28,7 +28,13 @@
 	evolution_threshold = 180
 	upgrade_threshold = 120
 
-	evolves_to = list(/mob/living/carbon/xenomorph/crusher)
+	evolves_to = list(
+		/mob/living/carbon/xenomorph/boiler,
+		/mob/living/carbon/xenomorph/praetorian,
+		/mob/living/carbon/xenomorph/crusher,
+		/mob/living/carbon/xenomorph/ravager,
+		/mob/living/carbon/xenomorph/Defiler,
+	)
 	deevolves_to = /mob/living/carbon/xenomorph/runner
 
 	// *** Flags *** //

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/castedatum_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/castedatum_carrier.dm
@@ -32,7 +32,13 @@
 
 	deevolves_to = /mob/living/carbon/xenomorph/drone
 
-	evolves_to = list(/mob/living/carbon/xenomorph/Defiler)
+	evolves_to = list(
+		/mob/living/carbon/xenomorph/boiler,
+		/mob/living/carbon/xenomorph/praetorian,
+		/mob/living/carbon/xenomorph/crusher,
+		/mob/living/carbon/xenomorph/ravager,
+		/mob/living/carbon/xenomorph/Defiler,
+	)
 
 	// *** Flags *** //
 	caste_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_EVOLUTION_ALLOWED|CASTE_CAN_HOLD_FACEHUGGERS|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
@@ -30,7 +30,15 @@
 	evolution_threshold = 80
 	upgrade_threshold = 60
 
-	evolves_to = list(/mob/living/carbon/xenomorph/warrior)
+	evolves_to = list(
+		/mob/living/carbon/xenomorph/hunter,
+		/mob/living/carbon/xenomorph/bull,
+		/mob/living/carbon/xenomorph/spitter,
+		/mob/living/carbon/xenomorph/warrior,
+		/mob/living/carbon/xenomorph/carrier,
+		/mob/living/carbon/xenomorph/hivelord,
+	)
+
 
 	// *** Flags *** //
 	caste_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_EVOLUTION_ALLOWED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
@@ -31,6 +31,10 @@
 	evolves_to = list(
 		/mob/living/carbon/xenomorph/shrike,
 		/mob/living/carbon/xenomorph/queen,
+		/mob/living/carbon/xenomorph/hunter,
+		/mob/living/carbon/xenomorph/bull,
+		/mob/living/carbon/xenomorph/spitter,
+		/mob/living/carbon/xenomorph/warrior,
 		/mob/living/carbon/xenomorph/carrier,
 		/mob/living/carbon/xenomorph/hivelord,
 		/mob/living/carbon/xenomorph/hivemind,

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
@@ -31,7 +31,13 @@
 	evolution_threshold = 180
 	upgrade_threshold = 120
 
-	evolves_to = list(/mob/living/carbon/xenomorph/ravager)
+	evolves_to = list(
+		/mob/living/carbon/xenomorph/boiler,
+		/mob/living/carbon/xenomorph/praetorian,
+		/mob/living/carbon/xenomorph/crusher,
+		/mob/living/carbon/xenomorph/ravager,
+		/mob/living/carbon/xenomorph/Defiler,
+	)
 	deevolves_to = /mob/living/carbon/xenomorph/runner
 
 	// *** Flags *** //

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
@@ -37,6 +37,10 @@
 	evolves_to = list(
 		/mob/living/carbon/xenomorph/hunter,
 		/mob/living/carbon/xenomorph/bull,
+		/mob/living/carbon/xenomorph/spitter,
+		/mob/living/carbon/xenomorph/warrior,
+		/mob/living/carbon/xenomorph/carrier,
+		/mob/living/carbon/xenomorph/hivelord,
 	)
 
 	// *** Flags *** //

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/castedatum_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/castedatum_sentinel.dm
@@ -27,7 +27,14 @@
 	evolution_threshold = 80
 	upgrade_threshold = 60
 
-	evolves_to = list(/mob/living/carbon/xenomorph/spitter)
+	evolves_to = list(
+		/mob/living/carbon/xenomorph/hunter,
+		/mob/living/carbon/xenomorph/bull,
+		/mob/living/carbon/xenomorph/spitter,
+		/mob/living/carbon/xenomorph/warrior,
+		/mob/living/carbon/xenomorph/carrier,
+		/mob/living/carbon/xenomorph/hivelord,
+	)
 
 	// *** Flags *** //
 	caste_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_EVOLUTION_ALLOWED|CASTE_CAN_VENT_CRAWL|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER

--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
@@ -30,6 +30,9 @@
 	evolves_to = list(
 		/mob/living/carbon/xenomorph/boiler,
 		/mob/living/carbon/xenomorph/praetorian,
+		/mob/living/carbon/xenomorph/crusher,
+		/mob/living/carbon/xenomorph/ravager,
+		/mob/living/carbon/xenomorph/Defiler,
 	)
 	deevolves_to = /mob/living/carbon/xenomorph/sentinel
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/castedatum_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/castedatum_warrior.dm
@@ -28,7 +28,13 @@
 	evolution_threshold = 180
 	upgrade_threshold = 120
 
-	evolves_to = list(/mob/living/carbon/xenomorph/crusher)
+	evolves_to = list(
+		/mob/living/carbon/xenomorph/boiler,
+		/mob/living/carbon/xenomorph/praetorian,
+		/mob/living/carbon/xenomorph/crusher,
+		/mob/living/carbon/xenomorph/ravager,
+		/mob/living/carbon/xenomorph/Defiler,
+	)
 	deevolves_to = /mob/living/carbon/xenomorph/defender
 
 	// *** Flags *** //


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
t1s can evo into all t2s and all t2s into all t3s, the exception is drone since i have no clue how to that so only drone can become shrike/queen for now
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
evo paths are awful mechanics, they shouldn't exist anymore
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: every xenomorph can evo into their next tier with no restrictions, evo paths are gone
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
