### PR TITLE
Making Lasrifle Overcharge Great Again

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1228,10 +1228,10 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	name = "overcharged laser bolt"
 	icon_state = "heavylaser"
 	hud_state = "laser_sniper"
-	damage = 42
+	damage = 65
 	max_range = 40
-	penetration = 20
-	sundering = 10
+	penetration = 50
+	sundering = 15
 
 /datum/ammo/energy/lasgun/M43/heat
 	name = "microwave heat bolt"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1228,7 +1228,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	name = "overcharged laser bolt"
 	icon_state = "heavylaser"
 	hud_state = "laser_sniper"
-	damage = 65
+	damage = 60
 	max_range = 40
 	penetration = 50
 	sundering = 15

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1228,7 +1228,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	name = "overcharged laser bolt"
 	icon_state = "heavylaser"
 	hud_state = "laser_sniper"
-	damage = 60
+	damage = 55
 	max_range = 40
 	penetration = 50
 	sundering = 15


### PR DESCRIPTION
## About The Pull Request

As a xeno player I'm probably going to regret this; don't say I didn't give the marines anything (y'know besides the litany of stuff about a year and a half ago).

Improves the Overcharge mode so it's actually worth using vs heavily armored targets (Ancient Rav or better); Lasrifle Overcharge damage increased from 42 to 60, Penetration increased from 20 to 50, and Sunder increased from 10 to 15.

**Math vs Ancient Rav (50% laser resistance) at range 5 over 1 second of firing; standard bolts have 5x the fire rate of Overcharge:**

**Standard Bolt:**  Base Damage With Falloff (20-0.25 * 5) * Fire Rate Mod (10/2) * Armor Mod (1-1 * (0.5-0.1)) = 56.25
**Overcharge Bolt:** (55-0.25 * 5) * (10/10) * (1-1 * (0.5-0.5)) = 53.75
Overcharge deals +2.5 more Sunder

**vs Ancient Defiler:**
**Standard Bolt:**  (20-0.25 * 5) * (10/2) * (1-1 * (0.4-0.1)) = 65.625
**Overcharge Bolt:** (55-0.25 * 5) * (10/10) * 1 (can't be less than 1) = 53.75
Overcharge deals +2.5 more Sunder

**vs Ancient Hunter:**
**Standard Bolt:**  (20-0.25 * 5) * (10/2) * (1-1 * (0.3-0.1)) = 75
**Overcharge Bolt:** (55-0.25 * 5) * (10/10) * 1 (can't be less than 1) = 53.75
Overcharge deals +2.5 more Sunder


## Why It's Good For The Game

Makes the lasrifle overcharge worth a shit, and situationally good for Sunder, ghetto sniping and vs heavily armored Xenos.

## Changelog
:cl:
balance: Lasrifle Overcharge damage increased from 42 to 55, Penetration increased from 20 to 50, and Sunder increased from 10 to 15.
/:cl: