### PR TITLE
Introduces Xeno Blood (better-name-pending) resource for xenos, Changes Sunder recovery

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -354,9 +354,7 @@
 	new /obj/effect/temp_visual/telekinesis(get_turf(target))
 	var/mob/living/carbon/xenomorph/patient = target
 
-	var/heal_amount = 1 + (patient.maxHealth * 0.03)
-	heal_amount += 0.008*patient.maxHealth*patient.recovery_aura
-	heal_amount *= SHRIKE_CURE_HEAL_MULTIPLIER
+	var/heal_amount = (1 + patient.maxHealth * 0.03 + patient.maxHealth* 0.008 * patient.recovery_aura) * SHRIKE_CURE_HEAL_MULTIPLIER
 	patient.adjustBruteLoss(-heal_amount)
 	patient.adjustFireLoss(-heal_amount)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -353,7 +353,13 @@
 	playsound(target,'sound/effects/magic.ogg', 75, 1)
 	new /obj/effect/temp_visual/telekinesis(get_turf(target))
 	var/mob/living/carbon/xenomorph/patient = target
-	patient.heal_wounds(SHRIKE_CURE_HEAL_MULTIPLIER)
+
+	var/heal_amount = 1 + (patient.maxHealth * 0.03)
+	heal_amount += 0.008*patient.maxHealth*patient.recovery_aura
+	heal_amount *= SHRIKE_CURE_HEAL_MULTIPLIER
+	patient.adjustBruteLoss(-heal_amount)
+	patient.adjustFireLoss(-heal_amount)
+
 	if(patient.health > 0) //If they are not in crit after the heal, let's remove evil debuffs.
 		patient.SetUnconscious(0)
 		patient.SetStun(0)

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -29,10 +29,8 @@
 		update_evolving()
 		handle_aura_emiter()
 
-	var/sunder_recov = xeno_caste.sunder_recover * -1
 	if(resting)
-		sunder_recov -= 0.5
-	adjust_sunder(sunder_recov)
+		adjust_sunder(-xeno_caste.sunder_recover)
 	handle_aura_receiver()
 	handle_living_health_updates()
 	handle_living_plasma_updates()

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -73,6 +73,9 @@
 	if(!T || !istype(T))
 		return
 
+	if(!xeno_blood)
+		return
+
 	var/ruler_healing_penalty = 0.5
 	if(hive?.living_xeno_ruler?.loc?.z == T.z || xeno_caste.caste_flags & CASTE_CAN_HEAL_WITHOUT_QUEEN) //if the living queen's z-level is the same as ours.
 		ruler_healing_penalty = 1
@@ -110,7 +113,7 @@
 		amount *= 1.25
 	else if(xeno_blood <= 50)
 		amount *= 0.70
-	xeno_blood -= min((0.5 + 0.12*recovery_aura)*multiplier, 100 - xeno_blood)
+	xeno_blood -= (0.5 + 0.12*recovery_aura)*multiplier
 
 	adjustBruteLoss(-amount)
 	adjustFireLoss(-amount)

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -69,6 +69,7 @@
 		return
 	if(health >= maxHealth || xeno_caste.hardcore || on_fire) //can't regenerate.
 		updatehealth() //Update health-related stats, like health itself (using brute and fireloss), health HUD and status.
+		xeno_blood += min(0.25, 100 - xeno_blood)
 		return
 	var/turf/T = loc
 	if(!T || !istype(T))
@@ -93,7 +94,7 @@
 		adjustBruteLoss(XENO_CRIT_DAMAGE - (warding_aura * 0.5)) //Warding can heavily lower the impact of bleedout. Halved at 5.
 
 /mob/living/carbon/xenomorph/proc/heal_wounds(multiplier = XENO_RESTING_HEAL, scaling = FALSE)
-	var/amount = 1 + (maxHealth * 0.03) // 1 damage + 2% max health, with scaling power.
+	var/amount = 1 + (maxHealth * 0.03) // 1 damage + 3% max health, with scaling power.
 	if(recovery_aura)
 		amount += recovery_aura * maxHealth * 0.008 // +0.8% max health per recovery level, up to +4%
 	if(scaling)
@@ -106,6 +107,13 @@
 			regen_power = min(regen_power + xeno_caste.regen_ramp_amount*20,1)
 		amount *= regen_power
 	amount *= multiplier
+
+	if(xeno_blood >= 80)
+		amount *= 1.25
+	else if(xeno_blood < 50)
+		amount *= 0.70
+	xeno_blood -= (0.5 + 0.12*recovery_aura)*multiplier
+
 	adjustBruteLoss(-amount)
 	adjustFireLoss(-amount)
 

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -109,11 +109,13 @@
 		amount *= regen_power
 	amount *= multiplier
 
+	var/xeno_blood_drain_rate = (0.5 + 0.12*recovery_aura)*multiplier
 	if(xeno_blood >= 80)
 		amount *= 1.25
 	else if(xeno_blood <= 50)
-		amount *= 0.70
-	xeno_blood -= (0.5 + 0.12*recovery_aura)*multiplier
+		amount *= 0.7
+		xeno_blood_drain_rate *= 0.7
+	xeno_blood -= xeno_blood_drain_rate
 
 	adjustBruteLoss(-amount)
 	adjustFireLoss(-amount)

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -110,9 +110,9 @@
 
 	if(xeno_blood >= 80)
 		amount *= 1.25
-	else if(xeno_blood < 50)
+	else if(xeno_blood <= 50)
 		amount *= 0.70
-	xeno_blood -= (0.5 + 0.12*recovery_aura)*multiplier
+	xeno_blood -= min((0.5 + 0.12*recovery_aura)*multiplier, 100 - xeno_blood)
 
 	adjustBruteLoss(-amount)
 	adjustFireLoss(-amount)

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -67,13 +67,13 @@
 		return
 	if(health >= maxHealth || xeno_caste.hardcore || on_fire) //can't regenerate.
 		updatehealth() //Update health-related stats, like health itself (using brute and fireloss), health HUD and status.
-		xeno_blood += min(0.25, 100 - xeno_blood)
+		xeno_blood_current += min(xeno_blood_regen_rate, xeno_blood_max - xeno_blood_current)
 		return
 	var/turf/T = loc
 	if(!T || !istype(T))
 		return
 
-	if(!xeno_blood)
+	if(!xeno_blood_current)
 		return
 
 	var/ruler_healing_penalty = 0.5
@@ -109,13 +109,13 @@
 		amount *= regen_power
 	amount *= multiplier
 
-	var/xeno_blood_drain_rate = (0.5 + 0.12*recovery_aura)*multiplier
-	if(xeno_blood >= 80)
+	var/xeno_blood_drain_rate = (xeno_blood_drain_rate_base + xeno_blood_drain_rate_base*recovery_aura*0.24)*multiplier
+	if(round((xeno_blood_current/xeno_blood_max)*100) >= 80)
 		amount *= 1.25
-	else if(xeno_blood <= 50)
+	else if(round((xeno_blood_current/xeno_blood_max)*100) <= 50)
 		amount *= 0.7
 		xeno_blood_drain_rate *= 0.7
-	xeno_blood -= xeno_blood_drain_rate
+	xeno_blood_current -= xeno_blood_drain_rate
 
 	adjustBruteLoss(-amount)
 	adjustFireLoss(-amount)

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -91,7 +91,7 @@
 
 	// *** Sunder *** //
 	///How much sunder is recovered per tick
-	var/sunder_recover = 0.5
+	var/sunder_recover = 1.5
 	///What is the max amount of sunder that can be applied to a xeno (100 = 100%)
 	var/sunder_max = 100
 

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -237,6 +237,9 @@
 	var/warding_aura = 0
 	var/recovery_aura = 0
 
+	///Determines how fast xenos heal
+	var/xeno_blood = 100
+
 	var/regen_power = 0 //Resets to -xeno_caste.regen_delay when you take damage.
 	//Negative values act as a delay while values greater than 0 act as a multiplier.
 	//Will increase by 10 every decisecond if under 0. Increases by xeno_caste.regen_ramp_amount every decisecond.

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -237,7 +237,7 @@
 	var/warding_aura = 0
 	var/recovery_aura = 0
 
-	///Xeno blood acts as a resource to fuel xeno's ability to regenerate
+	///Xeno blood acts as a resource to fuel xeno's ability to regenerate.
 	var/xeno_blood_current = 700
 	var/xeno_blood_max = 700
 	///Xeno blood drain every 2 seconds when passively healing, scaling up and down with passive healing modifiers. By default 0.34% of xeno_blood_max or 10 blood per 100% max health healed

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -237,13 +237,15 @@
 	var/warding_aura = 0
 	var/recovery_aura = 0
 
-	///Xeno blood acts as a resource to fuel xeno's ability to regenerate.
+	///Xeno blood acts as a resource to fuel a xeno's ability to regenerate.
+	///Represents a xeno's current blood amount
 	var/xeno_blood_current = 700
+	///Maximum amount of blood that a xeno can have
 	var/xeno_blood_max = 700
-	///Xeno blood drain every 2 seconds when passively healing, scaling up and down with passive healing modifiers. By default 0.34% of xeno_blood_max or 10 blood per 100% max health healed
+	///Xeno blood drains every 2 seconds when passively healing, scaling up and down with passive healing modifiers. By default 0.34% of xeno_blood_max while resting or 10% of maximum blood per 100% max health healed
 	var/xeno_blood_drain_rate_base = 2.4
-	///Passively regenerates xeno blood by this amount every 2 seconds. By default 0.17% of xeno_blood_max
-	var/xeno_blood_regen_rate = 1.19
+	///Passively regenerates xeno blood by this amount every 2 seconds when at maximum health. By default 0.17% of xeno_blood_max or half the rate at which it is drained while healing during resting
+	var/xeno_blood_regen_rate = 1.2
 
 	var/regen_power = 0 //Resets to -xeno_caste.regen_delay when you take damage.
 	//Negative values act as a delay while values greater than 0 act as a multiplier.

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -237,8 +237,13 @@
 	var/warding_aura = 0
 	var/recovery_aura = 0
 
-	///Determines how fast xenos heal
-	var/xeno_blood = 100
+	///Xeno blood acts as a resource to fuel xeno's ability to regenerate
+	var/xeno_blood_current = 700
+	var/xeno_blood_max = 700
+	///Xeno blood drain every 2 seconds when passively healing, scaling up and down with passive healing modifiers. By default 0.34% of xeno_blood_max or 10 blood per 100% max health healed
+	var/xeno_blood_drain_rate_base = 2.4
+	///Passively regenerates xeno blood by this amount every 2 seconds. By default 0.17% of xeno_blood_max
+	var/xeno_blood_regen_rate = 1.19
 
 	var/regen_power = 0 //Resets to -xeno_caste.regen_delay when you take damage.
 	//Negative values act as a delay while values greater than 0 act as a multiplier.

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -139,6 +139,8 @@
 	else //Upgrade process finished or impossible
 		stat("Upgrade Progress:", "(FINISHED)")
 
+	stat("Acid Blood:", "[round(xeno_blood)]%")
+
 	if(xeno_caste.plasma_max > 0)
 		stat("Plasma:", "[plasma_stored]/[xeno_caste.plasma_max]")
 

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -139,7 +139,7 @@
 	else //Upgrade process finished or impossible
 		stat("Upgrade Progress:", "(FINISHED)")
 
-	stat("Acid Blood:", "[round(xeno_blood)]%")
+	stat("Acid Blood:", "[round(xeno_blood, 0.01)]%")
 
 	switch(xeno_blood)
 		if(80 to INFINITY)

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -139,9 +139,9 @@
 	else //Upgrade process finished or impossible
 		stat("Upgrade Progress:", "(FINISHED)")
 
-	stat("Acid Blood:", "[round(xeno_blood, 0.01)]%")
+	stat("Acid Blood:", "[round((xeno_blood_current/xeno_blood_max)*100, 0.01)]%")
 
-	switch(xeno_blood)
+	switch(round((xeno_blood_current/xeno_blood_max)*100))
 		if(80 to INFINITY)
 			stat("Blood-based regeneration:", "+25%")
 		if(51 to 79)

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -139,9 +139,9 @@
 	else //Upgrade process finished or impossible
 		stat("Upgrade Progress:", "(FINISHED)")
 
-	stat("Acid Blood:", "[round((xeno_blood_current/xeno_blood_max)*100, 0.01)]%")
+	stat("Acid Blood:", "[PERCENT(xeno_blood_current/xeno_blood_max)]%")
 
-	switch(round((xeno_blood_current/xeno_blood_max)*100))
+	switch(PERCENT(xeno_blood_current/xeno_blood_max))
 		if(80 to INFINITY)
 			stat("Blood-based regeneration:", "+25%")
 		if(51 to 79)

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -141,6 +141,16 @@
 
 	stat("Acid Blood:", "[round(xeno_blood)]%")
 
+	switch(xeno_blood)
+		if(80 to INFINITY)
+			stat("Blood-based regeneration:", "+25%")
+		if(51 to 79)
+			stat("Blood-based regeneration", "+0%")
+		if(1 to 50)
+			stat("Blood-based regeneration:", "-30%")
+		if(-1 to 0)
+			stat("Blood-based regeneration", "-100%")
+
 	if(xeno_caste.plasma_max > 0)
 		stat("Plasma:", "[plasma_stored]/[xeno_caste.plasma_max]")
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This is the xeno version of blood and xenos' ability to regenerate is tied to it.

Stats:
Maximum of 700
Regenerates by 0.25% every tick when at full health
Drains by 0.34% + 0.24%*regeneration pheromones' tier every tick when damage is healed. This is also affected by the standing and resting heal multipliers so it is proportional to the amount healed.
While above 80% increases regeneration by 25%
While below 50% decreases regeneration by 30%, blood drains 30% slower
While at 0% stops innate regeneration

1% blood should equal to about 10% max health when blood is above 80.

Additionally increases overall sunder regeneration by 50% and makes sunder regenerate only while resting instead of regenerating at half the rate while not resting.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Currently when engaging xenos it is all or nothing. You either kill the xeno in question or it comes back at the same health. 

This change preserves the xeno's trait of universal and fast regeneration, while also rewarding marines for inflicting more damage than sustained losses by causing xenos to suffer fatigue for regenerating a lot of health too frequently. Thus acting as a middle ground for lost engagements where no xenos die. 

At the same time skilled xenos can utilise the increased health regeneration by pulling out of a fight at the right time and calculating their engages more.

## Changelog
:cl:Slotbot
add: Adds new xeno regeneration resource
tweak: makes sunder regenerate only while resting
tweak: increases sunder regeneration by 50%
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
