### PR TITLE
Spaceship Orbit affects supply point generation

### DIFF
--- a/code/controllers/subsystem/points.dm
+++ b/code/controllers/subsystem/points.dm
@@ -1,6 +1,6 @@
 // points per minute
-#define DROPSHIP_POINT_RATE 18
-#define SUPPLY_POINT_RATE 2
+#define DROPSHIP_POINT_RATE 18 * (GLOB.current_orbit/3)
+#define SUPPLY_POINT_RATE 2 * (GLOB.current_orbit/3)
 
 SUBSYSTEM_DEF(points)
 	name = "Points"


### PR DESCRIPTION

## About The Pull Request

Spaceship orbits should affect this. minor though it is.

## Why It's Good For The Game

Provides another incentive to adjust the ship level, being closer is not always better.

The closer you are, the slower the ship generates req points passively.

## Changelog
:cl: Hughgent
tweak: Spaceship orbit level now adjusts the rate of passive req point generation, closer is slower.
/:cl:

