### PR TITLE
Improves Crusher Crest Toss backwards tossibility checks

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
@@ -108,16 +108,21 @@
 			T = temp
 	else
 		facing = get_dir(L, X)
-		if(!X.check_blocked_turf(get_step(T, facing) ) ) //Make sure we can actually go to the target turf
-			L.loc = get_step(T, facing) //Move the target behind us before flinging
-			for(var/x = 0, x < toss_distance, x++)
-				temp = get_step(T, facing)
-				if (!temp)
-					break
-				T = temp
-		else
+		var/turf/throw_origin = get_step(T, facing)
+		if(isclosedturf(throw_origin)) //Make sure the victim can actually go to the target turf
 			to_chat(X, "<span class='xenowarning'>We try to fling [L] behind us, but there's no room!</span>")
 			return fail_activate()
+		for(var/obj/O in throw_origin)
+			if(!O.CanPass(L, get_turf(X)) && !istype(O, /obj/structure/barricade)) //Ignore barricades because they will once thrown anyway
+				to_chat(X, "<span class='xenowarning'>We try to fling [L] behind us, but there's no room!</span>")
+				return fail_activate()
+
+		L.loc = throw_origin //Move the victim behind us before flinging
+		for(var/x = 0, x < toss_distance, x++)
+			temp = get_step(T, facing)
+			if (!temp)
+				break
+			T = temp //Throw target
 
 	//The target location deviates up to 1 tile in any direction //No.
 	/*var/scatter_x = rand(-1,1)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Upgrades a simple `check_blocked_turf()` to a `isclosedturf()` and rigorous `CanPass()`

Fixes: #4942 

Before you could only toss someone over unwired barricades behind you if there is at least a 1 tile gap:
![UJtR0WujOT](https://user-images.githubusercontent.com/64715958/100555931-8af63e00-3253-11eb-886a-6007803ca118.gif)

After you'll be able to toss them into the cade just as you can pluck them out from one before the throw is applied:
![OnLftQzg7I](https://user-images.githubusercontent.com/64715958/100555974-e294a980-3253-11eb-9ed2-34521e4de8e0.gif)
Currently when sandwiched between barricades trying this would just yield a lot of `We try to fling [L] behind us, but there's no room!`

## Why It's Good For The Game

Fix good.

## Changelog
:cl:
fix: Fixed Crest Toss bypassing CanPass checks like for Xeno Silo fog.
fix: Fixed Crest Toss failing from "there's no room" when there is.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
