### PR TITLE
Larva now get to see what is outside the silo before spawning

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -587,7 +587,7 @@ to_chat will check for valid clients itself already so no need to double check f
 	if(length(possible_silos) > 1)
 		chosen_silo = input("Available Egg Silos") as null|anything in possible_silos
 		xeno_candidate.forceMove(chosen_silo)
-		var/double_check = input(xeno_candidate, "Spawn here?", "Spawn location", "Yes") as text|null
+		var/double_check = input(xeno_candidate, "Spawn here?", "Spawn location") as null|anything in list("Yes","No")
 		if(double_check != "Yes")
 			attempt_to_spawn_larva_in_silo(xeno_candidate, possible_silos)
 	else

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -586,6 +586,10 @@ to_chat will check for valid clients itself already so no need to double check f
 	var/obj/structure/resin/silo/chosen_silo
 	if(length(possible_silos) > 1)
 		chosen_silo = input("Available Egg Silos") as null|anything in possible_silos
+		xeno_candidate.forceMove(chosen_silo)
+		var/double_check = input(xeno_candidate, "Spawn here?", "Spawn location", "Yes") as text|null
+		if(double_check != "Yes")
+			attempt_to_spawn_larva_in_silo(xeno_candidate, possible_silos)
 	else
 		chosen_silo = possible_silos[1]
 


### PR DESCRIPTION
## About The Pull Request

I heard some marines were spawn camping silos. Tsk Tsk.

~~Needs a better `input()`  for the `double_check` as I couldn't easily find a "yes" "no" one.~~

## Why It's Good For The Game

Larva, the weak, poor, defenseless worms that they are, now get to see their spawn location and have a 'double check' of the surroundings to make sure it's safe or not to spawn.

## Changelog
:cl: Hughgent
add: Larva can see the silo they want to spawn at before they actually spawn.
/:cl:

