### PR TITLE
Shrapnel and bonebreaks actually do damage now.

### DIFF
--- a/code/game/objects/items/embedding.dm
+++ b/code/game/objects/items/embedding.dm
@@ -116,7 +116,7 @@
 
 
 /datum/limb/proc/process_embedded(obj/item/embedded)
-	if(limb_status & (LIMB_SPLINTED|LIMB_STABILIZED) || (owner.m_intent == MOVE_INTENT_WALK && !owner.pulledby))
+	if(limb_status & (LIMB_SPLINTED|LIMB_STABILIZED))
 		return
 	if(!prob(embedded.embedding.embed_process_chance))
 		return

--- a/code/modules/mob/living/carbon/human/life/handle_organs.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_organs.dm
@@ -36,7 +36,7 @@
 
 		E.process()
 
-		if(!lying_angle && world.time - last_move_time < 15 && m_intent != MOVE_INTENT_WALK || pulledby)
+		if(!lying_angle && world.time - last_move_time < 15)
 			if(E.is_broken() && E.internal_organs && prob(15))
 				var/datum/internal_organ/I = pick(E.internal_organs)
 				custom_pain("You feel broken bones moving in your [E.display_name]!", 1)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Shrapnel and bones actually do damage now.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Kinda weird that they didn't do damage before, but there's history behind it.

Surrealistic changed bones to do no damage on walk intent, which was good.
Rohesie changed walk intent to be the default, which was also good.

Together, that means that no one takes shrapnel or broken bone damage. This changes that. Also, being pulled (and probably being carried) or being splinted is still damage-immunity.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Shrapnel and bonebreaks do damage on walk intent.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
