### PR TITLE
Allow the designation of "non-repeatable" weather types (perpetual acid rain fix)

### DIFF
--- a/code/controllers/subsystem/weather.dm
+++ b/code/controllers/subsystem/weather.dm
@@ -12,6 +12,7 @@ SUBSYSTEM_DEF(weather)
 	var/list/processing = list()
 	var/list/eligible_zlevels = list()
 	var/list/next_hit_by_zlevel = list() //Used by barometers to know when the next storm is coming
+	var/list/last_datum_by_zlevel = list()
 
 /datum/controller/subsystem/weather/fire()
 	// process active weather
@@ -26,12 +27,16 @@ SUBSYSTEM_DEF(weather)
 
 	// start random weather on relevant levels
 	for(var/z in eligible_zlevels)
-		var/possible_weather = eligible_zlevels[z]
-		var/datum/weather/W = pickweight(possible_weather)
+		var/list/possible_weather = deepCopyList(eligible_zlevels[z])
+		var/datum/weather/W = last_datum_by_zlevel[z]
+		if(!isnull(W) && !initial(W.repeatable))
+			possible_weather -= last_datum_by_zlevel[z]
+		W = pickweight(possible_weather)
+		last_datum_by_zlevel[z] = W
 		run_weather(W, list(text2num(z)))
-		eligible_zlevels -= z
 		var/randTime = rand(3000, 6000)
-		next_hit_by_zlevel["[z]"] = addtimer(CALLBACK(src, .proc/make_eligible, z, possible_weather), randTime + initial(W.weather_duration_upper), TIMER_UNIQUE|TIMER_STOPPABLE) //Around 5-10 minutes between weathers
+		next_hit_by_zlevel["[z]"] = addtimer(CALLBACK(src, .proc/make_eligible, z, eligible_zlevels[z]), randTime + initial(W.weather_duration_upper), TIMER_UNIQUE|TIMER_STOPPABLE) //Around 5-10 minutes between weathers
+		eligible_zlevels -= z
 
 /datum/controller/subsystem/weather/Initialize(start_timeofday)
 	for(var/V in subtypesof(/datum/weather))

--- a/code/controllers/subsystem/weather.dm
+++ b/code/controllers/subsystem/weather.dm
@@ -12,7 +12,7 @@ SUBSYSTEM_DEF(weather)
 	var/list/processing = list()
 	var/list/eligible_zlevels = list()
 	var/list/next_hit_by_zlevel = list() //Used by barometers to know when the next storm is coming
-	var/list/last_datum_by_zlevel = list()
+	var/list/last_weather_by_zlevel = list()
 
 /datum/controller/subsystem/weather/fire()
 	// process active weather
@@ -28,11 +28,11 @@ SUBSYSTEM_DEF(weather)
 	// start random weather on relevant levels
 	for(var/z in eligible_zlevels)
 		var/list/possible_weather = deepCopyList(eligible_zlevels[z])
-		var/datum/weather/W = last_datum_by_zlevel[z]
+		var/datum/weather/W = last_weather_by_zlevel[z]
 		if(!isnull(W) && !initial(W.repeatable))
-			possible_weather -= last_datum_by_zlevel[z]
+			possible_weather -= last_weather_by_zlevel[z]
 		W = pickweight(possible_weather)
-		last_datum_by_zlevel[z] = W
+		last_weather_by_zlevel[z] = W
 		run_weather(W, list(text2num(z)))
 		var/randTime = rand(3000, 6000)
 		next_hit_by_zlevel["[z]"] = addtimer(CALLBACK(src, .proc/make_eligible, z, eligible_zlevels[z]), randTime + initial(W.weather_duration_upper), TIMER_UNIQUE|TIMER_STOPPABLE) //Around 5-10 minutes between weathers

--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -68,6 +68,8 @@
 
 	/// Weight amongst other eligible weather. If zero, will never happen randomly.
 	var/probability = 0
+	/// If this weather can happen multiple times in a row.
+	var/repeatable = TRUE
 	/// The z-level trait to affect when run randomly or when not overridden.
 	var/target_trait = ZTRAIT_STATION
 

--- a/code/datums/weather/weather_types/acid_rain.dm
+++ b/code/datums/weather/weather_types/acid_rain.dm
@@ -25,6 +25,7 @@
 	barometer_predictable = TRUE
 
 	probability = 40
+	repeatable = FALSE
 
 	var/datum/looping_sound/acidrain/midsound = new(list(), FALSE, TRUE)
 
@@ -66,3 +67,4 @@
 	aesthetic = TRUE
 
 	probability = 60
+	repeatable = TRUE

--- a/code/datums/weather/weather_types/sand_storm.dm
+++ b/code/datums/weather/weather_types/sand_storm.dm
@@ -18,6 +18,7 @@
 	target_trait = ZTRAIT_SANDSTORM
 
 	probability = 40
+	repeatable = FALSE
 
 /datum/weather/ash_storm/sand/weather_act(mob/living/L)
 	if(L.stat == DEAD)
@@ -43,3 +44,4 @@
 	aesthetic = TRUE
 
 	probability = 60
+	repeatable = TRUE


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the `repeatable` var to `/datum/weather` and `list/last_weather_by_zlevel` to the sub-system so that it can be checked each time a new weather event is _randomly_ selected to prevent back to back repeats where appropriate. Like in the case of harmful ones.

Weather events started manually via fun verbs are not effected.

## Why It's Good For The Game

Allows for better fine tuning of the automatic weather selection system.

## Changelog
:cl:
code: The Weather datum has gained a "repeatable" field for optionally preventing back to back random selection.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
