### PR TITLE
Shield Intercept Ratio Fixed 

### DIFF
--- a/code/datums/components/shield.dm
+++ b/code/datums/components/shield.dm
@@ -189,11 +189,11 @@
 			incoming_damage *= (100 - soft_armor.getRating(damage_type)) * 0.01
 			return prob(50 - round(incoming_damage / 3))
 		if(COMBAT_MELEE_ATTACK, COMBAT_PROJ_ATTACK)
-			var/absorbing_damage = max(0, incoming_damage - hard_armor.getRating(damage_type) * status_cover_modifier) //We apply hard armor *first* _not_ *after* soft armor
+			var/absorbing_damage = incoming_damage * cover.getRating(damage_type) * 0.01 * status_cover_modifier  //Determine cover ratio; this is the % of damage we actually intercept.
+			absorbing_damage = max(0, absorbing_damage - hard_armor.getRating(damage_type)) //We apply hard armor *first* _not_ *after* soft armor
 			if(!absorbing_damage)
 				return incoming_damage //We are transparent to this kind of damage.
 			. = incoming_damage - absorbing_damage
-			absorbing_damage = incoming_damage * cover.getRating(damage_type) * 0.01 * status_cover_modifier  //Determine cover ratio
 			absorbing_damage *= (100 - soft_armor.getRating(damage_type)) * 0.01 //Now apply soft armor
 			if(absorbing_damage <= 0)
 				if(!silent)

--- a/code/datums/components/shield.dm
+++ b/code/datums/components/shield.dm
@@ -170,10 +170,10 @@
 	var/obj/item/parent_item = parent
 	var/status_cover_modifier = 1
 
-	if(affected.IsSleeping() || affected.IsUnconscious() || affected.IsAdminSleeping() || affected.IsParalyzed()) //We don't do jack if we're literally KOed/sleeping/paralyzed.
+	if(affected.IsSleeping() || affected.IsUnconscious() || affected.IsAdminSleeping()) //We don't do jack if we're literally KOed/sleeping/paralyzed.
 		return incoming_damage
 
-	if(affected.IsStun() || affected.IsKnockdown()) //Halve shield cover if we're paralyzed or stunned
+	if(affected.IsStun() || affected.IsKnockdown() || affected.IsParalyzed()) //Halve shield cover if we're paralyzed or stunned
 		status_cover_modifier *= 0.5
 
 	if(iscarbon(affected))


### PR DESCRIPTION
## About The Pull Request

1: Minor bugfix/reordering of the item_intercept_attack proc under Shield.dm that fixes the shield damage absorption so it calculates properly; prior to this it was calculating it out of order. Order has been fixed as follows (double checked with testing):

A: Determines the actual % of damage intercepted and modified by the shield, including modifiers from statuses such as Stun and Stagger. This is the cover variable. The target takes the full amount of damage that isn't intercepted at this stage.

B: Deducts hard armor from that damage.

C: Deducts soft armor from that %.

D: Result is deducted from the shield's integrity, and from the target's health.

Example: 20 input damage from Ancient Drone, 80% melee cover, 5 hard armor vs melee, 50% soft armor vs melee, target is staggered (cover reduced by 25%).

Step A:  8 damage goes straight to the target, the remainder of 12 which is actually intercepted by the shield per it's modified cover value goes on to Step B: (20 Damage * 0.80 Cover * 0.75 Stagger modifier)   = 12. (20 - 20 * 0.8 * 0.75)  = 8 direct damage.
Step B: 12 damage is reduced by 5 hard armor to 7.
Step C: 7 damage is reduced by 50% soft armor to 3.5
Step D: The target takes 3.5 additional damage for a total of 11.5 and the shield takes 3.5 integrity damage.

Without Stagger the values would be as follows: 4 direct damage to the target, 5.5 integrity damage, 5.5 additional damage to the target (9.5 total to the target) = (20 * 0.8 - 5) * 0.5 = 5.5 and (20 - 20 * 0.8) = 4

2: 'Paralyze' (which is really more the proning + stun that is the standard hard CC) now only halves shield cover instead of negating it entirely due to its commonality.

## Why It's Good For The Game

Fixes the shield damage absorption to work properly, executing steps in the correct order.

As is, debuffs literally **improve** shield performance instead of denigrating it.

## Changelog
:cl:
fix: Fixes the shield damage absorption calculation. 
tweak: 'Paralyze' status effect (i.e. proning) only halves the shield's cover value instead of negating it completely.
/:cl: