### PR TITLE
Slight buff to the T-18 carbine by giving it 4 more bullets

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -49,7 +49,7 @@
 	unload_sound = 'sound/weapons/guns/interact/t18_unload.ogg'
 	reload_sound = 'sound/weapons/guns/interact/t18_reload.ogg'
 	caliber = "10x24mm caseless" //codex
-	max_shells = 32 //codex
+	max_shells = 36 //codex
 	force = 20
 	current_mag = /obj/item/ammo_magazine/rifle/standard_carbine
 	attachable_allowed = list(

--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -45,7 +45,7 @@
 	icon_state = "t18"
 	w_class = WEIGHT_CLASS_NORMAL
 	default_ammo = /datum/ammo/bullet/rifle
-	max_rounds = 32
+	max_rounds = 36
 	gun_type = /obj/item/weapon/gun/rifle/standard_carbine
 
 //-------------------------------------------------------


### PR DESCRIPTION
## About The Pull Request

Slightly buffs the T-18 carbine by giving it 4 more bullets per magazine, to 36 per mag from 32.

## Why It's Good For The Game

A slight buff to the T-18 carbine which has a powerful burst, but is underused because of its punishing ammo capacity. An additional click per magazine can go a long way to providing more sustainability to the gun and a bit more room for errors. It also brings it in line with the BFA attachment to be divisible by 6, for anyone with OCD.

## Changelog
:cl:
balance: added 4 more bullets per magazine for the T-18, for a total of 36 bullets from 32.
/:cl: