### PR TITLE
Makes retreating a xeno minor

### DIFF
--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -117,8 +117,8 @@
 		return TRUE
 	
 	if(round_stage == DISTRESS_MARINE_RETREAT)
-		message_admins("Round finished: [MODE_INFESTATION_DRAW_RETREAT]")
-		round_finished = MODE_INFESTATION_DRAW_RETREAT
+		message_admins("Round finished: [MODE_INFESTATION_X_MINOR]")
+		round_finished = MODE_INFESTATION_X_MINOR
 		return TRUE
 
 	if(!num_humans)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
title

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Xenos winning groundside, but marines retreating makes it seem like xenos win less than they actually do. Additionally, the aspect in the distress gamemode is put on winning groundside, so whichever side wins that should at least get a minor.

## Changelog
:cl:Slotbot
tweak: makes marines retreating a xeno minor victory
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
