### PR TITLE
Snow Clear Time Improved for Xenos

### DIFF
--- a/code/game/turfs/snow.dm
+++ b/code/game/turfs/snow.dm
@@ -37,7 +37,7 @@
 
 		M.visible_message("<span class='notice'>\The [M] clears out \the [src].</span>", \
 		"<span class='notice'>We clear out \the [src].</span>", null, 5)
-		slayer -= 1
+		slayer = 0
 		update_icon(1, 0)
 
 	//PLACING/REMOVING/BUILDING

--- a/code/game/turfs/snow.dm
+++ b/code/game/turfs/snow.dm
@@ -28,7 +28,7 @@
 		M.visible_message("<span class='notice'>\The [M] starts clearing out \the [src].</span>", \
 		"<span class='notice'>We start clearing out \the [src].</span>", null, 5)
 		playsound(M.loc, 'sound/weapons/alien_claw_swipe.ogg', 25, 1)
-		if(!do_after(M, 25, FALSE, src, BUSY_ICON_BUILD))
+		if(!do_after(M, 5, FALSE, src, BUSY_ICON_BUILD))
 			return FALSE
 
 		if(!slayer)


### PR DESCRIPTION
## About The Pull Request

Snow now takes 0.5 seconds to clear out per stack, down from 2.5, with all snow stacks being cleared.

## Why It's Good For The Game

Makes snow so much less cancerous to clear out for xenos.

## Changelog
:cl:
tweak: Snow clear time for Xenos reduced from 2.5 seconds to 0.5 seconds, and all snow stacks are cleared.
/:cl: