### PR TITLE
Fixes Lying Angles for Buckled/Unbuckled Living Mobs

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -56,6 +56,10 @@ obj/structure/bed/Destroy()
 		density = FALSE
 	update_icon()
 
+	if(isliving(buckled_mob)) //Properly update whether we're lying or not
+		var/mob/living/unbuckled_target = buckled_mob
+		if(HAS_TRAIT(unbuckled_target, TRAIT_FLOORED))
+			unbuckled_target.set_lying_angle(pick(90, 270))
 
 //Unsafe proc
 /obj/structure/bed/proc/buckle_bodybag(obj/structure/closet/bodybag/B, mob/user)

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -26,6 +26,10 @@
 
 /obj/structure/bed/chair/post_buckle_mob(mob/buckling_mob)
 	. = ..()
+	if(isliving(buckling_mob)) //Properly update whether we're lying or not; no more people lying on chairs; ridiculous
+		var/mob/living/buckled_target = buckling_mob
+		buckled_target.set_lying_angle(0)
+
 	handle_layer()
 
 /obj/structure/bed/chair/post_unbuckle_mob(mob/buckled_mob)


### PR DESCRIPTION
## About The Pull Request

Per title. Buckled mobs now properly go prone or upright when buckled/unbuckled.

## Why It's Good For The Game

Fixes a stupid looking bug.

## Changelog
:cl:
fix: Fixes lying angles for buckled/unbuckled living mobs.
/:cl: