### PR TITLE
Slug Penetration Reduced, Sunder Increased

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -559,7 +559,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
 	shell_speed = 3
 	max_range = 15
-	damage = 80
+	damage = 90
 	penetration = 10
 	sundering = 15
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -560,8 +560,8 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	shell_speed = 3
 	max_range = 15
 	damage = 80
-	penetration = 40
-	sundering = 7
+	penetration = 10
+	sundering = 15
 
 /datum/ammo/bullet/shotgun/slug/on_hit_mob(mob/M,obj/projectile/P)
 	staggerstun(M, P, weaken = 1, stagger = 2, knockback = 1)


### PR DESCRIPTION
## About The Pull Request

Slug Penetration reduced from 40 (wtf) to 10.

Slug Sunder increased from 7 to 15.

Slug Damage increased from 80 to 90.

## Why It's Good For The Game

Slug stats now make sense, gain a strong niche as an armor breaker (and reinforces their niche as a support round), and can be used more safely with less FF risk.

I value Damage and Sunder at roughly 1.5 : 1 vs Pen.

## Changelog
:cl:
balance: Slug Damage increased from 80 to 90,
balance: Slug Penetration reduced from 40 to 10.
balance: Slug Sunder increased from 7 to 15.
/:cl: