### PR TITLE
Sunder Now Affects Non-Xeno Targets as Extra Penetration

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -779,6 +779,10 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 	var/living_soft_armor = (proj.ammo.flags_ammo_behavior & AMMO_IGNORE_ARMOR) ? 0 : get_soft_armor(proj.armor_type, proj.def_zone, proj.dir)
 	if(living_hard_armor || living_soft_armor)
 		var/penetration = proj.ammo.penetration
+
+		if(proj.ammo.flags_ammo_behavior & AMMO_SUNDERING && !isxeno(src)) //Versus non-xenos, Sunder counts as extra penetration; concussive force that transmits through armor
+			penetration += proj.ammo.sundering
+
 		if(penetration > 0)
 			if(proj.shot_from && src == proj.shot_from.sniper_target(src))
 				damage *= SNIPER_LASER_DAMAGE_MULTIPLIER

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -781,7 +781,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 		var/penetration = proj.ammo.penetration
 
 		if(proj.ammo.flags_ammo_behavior & AMMO_SUNDERING && !isxeno(src)) //Versus non-xenos, Sunder counts as extra penetration; concussive force that transmits through armor
-			penetration += proj.ammo.sundering
+			penetration += (proj.ammo.sundering * 2) //Multiply by 2 or it is pretty much irrelevant for the vast, vast majority of projectiles
 
 		if(penetration > 0)
 			if(proj.shot_from && src == proj.shot_from.sniper_target(src))


### PR DESCRIPTION
## About The Pull Request

Projectiles with Sunder and the Sunder flag now deal extra pen to non-Xeno targets equal to twice their Sunder value.

This is explained as Sunder weapons imparting armor-penetrating kinetic shock/transfer upon their target.

## Why It's Good For The Game

Eliminates Sunder as being a wholly one-sided specifically anti-xeno metric in violation of the double-edge rule followed by virtually every other primary projectile trait that acts on a target. Sunder is currently a pure profit metric unlike damage, penetration, stagger, stun and incendiary stacks with no FF risk to balance out the reward.

## Changelog
:cl:
rebalance: Sundering projectiles now apply twice their Sunder value as extra penetration to non-Xeno targets.
/:cl: