### PR TITLE
Defender Tweaks: Crest Defense and Tail Sweep

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -69,7 +69,7 @@
 	damage *= (1 + distance * 0.25) //More distance = more momentum = stronger Headbutt.
 	var/affecting = H.get_limb(ran_zone(null, 0))
 	if(!affecting) //Still nothing??
-		affecting = H.get_limb("chest") //Gotta have a torso?!
+		affecting = H.get_limb(BODY_ZONE_CHEST) //Gotta have a torso?!
 	var/armor_block = H.run_armor_check(affecting, "melee")
 	H.apply_damage(damage, BRUTE, affecting, armor_block) //We deal crap brute damage after armor...
 	H.apply_damage(damage, STAMINA) //...But some sweet armour ignoring Stamina
@@ -149,7 +149,7 @@
 			var/damage = X.xeno_caste.melee_damage
 			var/affecting = ran_zone(null, 0)
 			if(!affecting) //Still nothing??
-				affecting = "chest" //Gotta have a torso?!
+				affecting = BODY_ZONE_CHEST //Gotta have a torso?!
 			var/armor_block = victim.run_armor_check(affecting, "melee")
 			victim.apply_damage(damage, BRUTE, affecting, armor_block) //Crap base damage after armour...
 			victim.apply_damage(damage, STAMINA) //...But some sweet armour ignoring Stamina... not that it does much now that it can't be comboed with tackles

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -127,6 +127,8 @@
 	SSblackbox.record_feedback("tally", "round_statistics", 1, "defender_tail_sweeps")
 	X.visible_message("<span class='xenowarning'>\The [X] sweeps its tail in a wide circle!</span>", \
 	"<span class='xenowarning'>We sweep our tail in a wide circle!</span>")
+	X.add_filter("defender_tail_sweep", 2, list("type" = "blur", 3)) //Cool SFX
+	addtimer(CALLBACK(X, /atom.proc/remove_filter, "defender_tail_sweep"), 0.5 SECONDS)
 
 	X.spin(4, 1)
 
@@ -197,6 +199,7 @@
 /datum/action/xeno_action/activable/forward_charge/proc/charge_complete()
 	SIGNAL_HANDLER
 	UnregisterSignal(owner, list(COMSIG_XENO_OBJ_THROW_HIT, COMSIG_XENO_LIVING_THROW_HIT, COMSIG_XENO_NONE_THROW_HIT))
+	owner.remove_filter("defender_forward_charge")
 
 /datum/action/xeno_action/activable/forward_charge/proc/mob_hit(datum/source, mob/M)
 	SIGNAL_HANDLER
@@ -242,6 +245,9 @@
 	"<span class='danger'>We charge towards \the [A]!</span>" )
 	X.emote("roar")
 	succeed_activate()
+
+	X.add_filter("defender_forward_charge", 2, list("type" = "blur", 3)) //Cool SFX
+	addtimer(CALLBACK(X, /atom.proc/remove_filter, "defender_forward_charge"), 0.05 SECONDS * get_dist(X, A))
 
 	X.throw_at(A, 4, 70, X)
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -85,14 +85,10 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	var/impact_message = ""
 	if(isxeno(victim))
 		var/mob/living/carbon/xenomorph/xeno_victim = victim
-		if(xeno_victim.fortify) //If we're fortified we don't give a shit about staggerstun.
+		if(xeno_victim.fortify || xeno_victim.crest_defense) //If we're fortified or benefitting from Crest Defense we don't give a shit about staggerstun.
 			impact_message += "<span class='xenodanger'>Your fortified stance braces you against the impact.</span>"
 			return
-		if(xeno_victim.crest_defense) //Crest defense halves all effects, and protects us from the stun.
-			impact_message += "<span class='xenodanger'>Your crest protects you against some of the impact.</span>"
-			slowdown *= 0.5
-			stagger *= 0.5
-			stun = 0
+
 	if(shake)
 		shake_camera(victim, shake+2, shake+3)
 		if(isxeno(victim))


### PR DESCRIPTION
## About The Pull Request

1: Crest Defense now grants immunity to stagger, stun and slowdown from staggering munitions while active.

2: Tail Sweep now inflicts a small amount of soft CC and can affect enemy xenos.

## Why It's Good For The Game

Makes Crest Defense worthwhile, and compensates Tail Sweep for the removal of tackles which means the Stamina damage it inflicts has lost a great deal of value.

## Changelog
:cl:
balance: Crest Defense now provides immunity to the CC from staggering munitions while active.
balance: Tail Sweep imposes a small amount of slowdown and stagger stacks.
tweak: Tail Sweep now works on enemy xenos.
/:cl: