### PR TITLE
Tadpole Map Rework

### DIFF
--- a/_maps/shuttles/minidropship.dmm
+++ b/_maps/shuttles/minidropship.dmm
@@ -16,22 +16,17 @@
 /obj/structure/bed/chair/dropship/passenger{
 	dir = 8
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/shuttle/dropship/floor,
 /area/shuttle/minidropship)
 "h" = (
 /obj/structure/bed/chair/dropship/passenger{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/mainship/mono,
+/turf/open/shuttle/dropship/floor,
 /area/shuttle/minidropship)
 "i" = (
 /obj/machinery/light,
-/turf/open/floor/mainship/blue{
-	dir = 10
-	},
+/turf/open/shuttle/blackfloor,
 /area/shuttle/minidropship)
 "l" = (
 /obj/structure/bed/chair/dropship/passenger{
@@ -40,7 +35,10 @@
 /obj/machinery/vending/nanomed{
 	dir = 8
 	},
-/turf/open/floor/mainship/mono,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/floor,
 /area/shuttle/minidropship)
 "o" = (
 /turf/closed/wall/mainship/outer,
@@ -74,48 +72,36 @@
 /area/shuttle/minidropship)
 "z" = (
 /obj/machinery/computer/dropship_weapons/minidropship,
-/turf/open/floor/mainship/mono,
+/turf/open/shuttle/blackfloor,
 /area/shuttle/minidropship)
 "A" = (
 /obj/structure/window/framed/mainship/hull,
 /turf/open/floor/mainship/mono,
 /area/shuttle/minidropship)
-"E" = (
-/obj/machinery/light,
-/turf/open/floor/mainship/blue{
-	dir = 6
-	},
-/area/shuttle/minidropship)
 "F" = (
 /obj/docking_port/mobile/marine_dropship/minidropship,
-/turf/open/floor/plating/plating_catwalk,
-/area/shuttle/minidropship)
-"K" = (
-/obj/structure/bed/chair/dropship/passenger{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
+/turf/open/shuttle/dropship/grating,
 /area/shuttle/minidropship)
 "L" = (
 /obj/machinery/computer/shuttle/minidropship,
-/turf/open/floor/mainship/mono,
+/turf/open/shuttle/blackfloor,
 /area/shuttle/minidropship)
 "N" = (
 /obj/structure/bed/chair/dropship/pilot{
 	dir = 1
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/shuttle/blackfloor,
 /area/shuttle/minidropship)
 "O" = (
 /obj/machinery/door/airlock/mainship/command/canterbury{
 	dir = 1;
 	name = "\improper Command Cockpit"
 	},
-/turf/open/floor/mainship/mono,
+/turf/open/shuttle/dropship/floor,
 /area/shuttle/minidropship)
 "S" = (
 /obj/machinery/computer/camera_advanced/shuttle_docker/minidropship,
-/turf/open/floor/mainship/mono,
+/turf/open/shuttle/blackfloor,
 /area/shuttle/minidropship)
 "T" = (
 /obj/structure/bed/chair/dropship/passenger{
@@ -126,10 +112,7 @@
 	name = "outer door-control";
 	pixel_y = 32
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/mainship/mono,
+/turf/open/shuttle/dropship/floor,
 /area/shuttle/minidropship)
 "U" = (
 /obj/effect/attach_point/weapon/minidropship{
@@ -144,10 +127,13 @@
 /obj/machinery/vending/nanomed{
 	dir = 4
 	},
-/turf/open/floor/mainship/mono,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/shuttle/dropship/floor,
 /area/shuttle/minidropship)
 "Y" = (
-/turf/open/floor/plating/plating_catwalk,
+/turf/open/shuttle/dropship/grating,
 /area/shuttle/minidropship)
 
 (1,1,1) = {"
@@ -166,7 +152,7 @@ o
 A
 o
 o
-o
+s
 s
 o
 o
@@ -178,9 +164,9 @@ S
 i
 o
 h
-K
+h
 X
-K
+h
 q
 "}
 (4,1,1) = {"
@@ -197,7 +183,7 @@ q
 (5,1,1) = {"
 A
 z
-E
+i
 o
 T
 g
@@ -210,7 +196,7 @@ o
 A
 o
 o
-o
+s
 s
 o
 o

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -221,6 +221,10 @@
 /turf/open/shuttle/dropship/eight
 	icon_state = "rasputin8"
 
+/turf/open/shuttle/dropship/grating
+	icon = 'icons/turf/elevator.dmi'
+	icon_state = "floor_grating"
+
 //not really plating, just the look
 /turf/open/shuttle/plating
 	name = "plating"


### PR DESCRIPTION
## About The Pull Request

1. Most of Tadpole is no-build except for the hardpoint and the entrance tiles.

2. Expanded the side entrances/exits.

## Why It's Good For The Game

Makes the Tadpole a little more assailable and prevents fortifying up the entirety of its interior with layers of barricades.

## Changelog
:cl:
balance: Tadpole side entrances/exits expanded.
balance: All of the Tadpole interior is now no-build; entrance and hardpoint tiles are still buildable.
/:cl:

https://imgur.com/ONbjFf5