### PR TITLE
Removes the shields hard armour.

### DIFF
--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -133,7 +133,7 @@
 	flags_equip_slot = ITEM_SLOT_BACK
 	max_integrity = 300
 	soft_armor = list("melee" = 50, "bullet" = 50, "laser" = 0, "energy" = 100, "bomb" = 30, "bio" = 100, "rad" = 100, "fire" = 0, "acid" = 35)
-	hard_armor = list("melee" = 5, "bullet" = 5, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+	hard_armor = list("melee" = 0, "bullet" = 5, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	force = 20
 	slowdown = 0.2
 


### PR DESCRIPTION


## About The Pull Request
Removes all of the shields hard armour
## Why It's Good For The Game
The shield gives 50% melle resist at the cost of 0.2 slowdown , the lightest armour available would give a total of 80% melle resist at the cost of 0.5 slowdown. If  someone uses the PAS armour ,they would be getting 90% soft melle resist at the cost of 0.7 slowdown. The shield  soft armour already turns people into tanks . The hard armour turns any attack so weak not even 4 xenos can slash a shield user down in a reasonable amount of time as long as they are on meds.
## Changelog
:cl:
balance:  Shield no longer has hard armour.
/:cl:
