### PR TITLE
Adds more bandannas to Surplus / Adds squad headsets to Ops Vendor

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -785,26 +785,6 @@
 
 /obj/machinery/vending/uniform_supply/Initialize()
 	. = ..()
-	var/products2[]
-	switch(squad_tag)
-		if("Alpha")
-			products2 = list(/obj/item/radio/headset/mainship/marine/alpha = 20,
-								/obj/item/clothing/mask/bandanna/alpha = 10)
-		if("Bravo")
-			products2 = list(/obj/item/radio/headset/mainship/marine/bravo = 20,
-							/obj/item/clothing/mask/bandanna/bravo = 10)
-		if("Charlie")
-			products2 = list(/obj/item/radio/headset/mainship/marine/charlie = 20,
-							/obj/item/clothing/mask/bandanna/charlie = 10)
-		if("Delta")
-			products2 = list(/obj/item/radio/headset/mainship/marine/delta = 20,
-							/obj/item/clothing/mask/bandanna/delta = 10)
-		else
-			products2 = list(/obj/item/radio/headset/mainship/marine/generic = 20,
-							/obj/item/clothing/mask/bandanna = 10)
-	build_inventory(products2)
-	GLOB.marine_vendors.Add(src)
-
 
 /obj/machinery/vending/uniform_supply/Destroy()
 	. = ..()

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -97,6 +97,10 @@
 		/obj/item/ammo_magazine/shotgun/mbx900 = 2,
 		/obj/item/bodybag/tarp = 2,
 		/obj/item/explosive/plastique = 2,
+		/obj/item/radio/headset/mainship/marine/alpha = 20,
+		/obj/item/radio/headset/mainship/marine/bravo = 20,
+		/obj/item/radio/headset/mainship/marine/charlie = 20,
+		/obj/item/radio/headset/mainship/marine/delta = 20,
 	)
 
 /obj/machinery/vending/marine/cargo_guns
@@ -709,11 +713,17 @@
 		/obj/item/clothing/head/slouch = 40,
 		/obj/item/clothing/glasses/mgoggles = 10,
 		/obj/item/clothing/glasses/mgoggles/prescription = 10,
+		/obj/item/radio/headset/mainship/marine/generic = 20,
 		/obj/item/clothing/mask/rebreather/scarf = 10,
 		/obj/item/clothing/mask/bandanna/skull = 10,
 		/obj/item/clothing/mask/bandanna/green = 10,
 		/obj/item/clothing/mask/bandanna/white = 10,
 		/obj/item/clothing/mask/bandanna/black = 10,
+		/obj/item/clothing/mask/bandanna = 10,
+		/obj/item/clothing/mask/bandanna/alpha = 10,
+		/obj/item/clothing/mask/bandanna/bravo = 10,
+		/obj/item/clothing/mask/bandanna/charlie = 10,
+		/obj/item/clothing/mask/bandanna/delta = 10,
 		/obj/item/clothing/mask/rebreather = 10,
 		/obj/item/clothing/mask/breath = 10,
 		/obj/item/clothing/mask/gas = 10,


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds previously-existing squad-colour bandannas into the Surplus Uniform vendor.
Adds previously-existing squad radio headsets to the Requisitions Operations vendor.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

These existed previously but there was a funky switch if/else statement chain thing going on that didn't work because something something vendor specific, so it would always only spawn tan bandannas and generic headsets. This means funky coloured bandannas are available to everyone (yay, customisation!) and squad radio headsets are available for people without one (yay, vatborns!)

@ snowflakes
![image](https://user-images.githubusercontent.com/44979174/100914512-14637580-34cb-11eb-94a1-35018b1fe697.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds bandannas in a variety of squad-based colours. Scratch n' Sniff!
add: Adds squad-based radio headsets to the Requisitions Operations Vendor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
