### PR TITLE
Changes tadpole windows and walls to breakable ones

### DIFF
--- a/_maps/shuttles/minidropship.dmm
+++ b/_maps/shuttles/minidropship.dmm
@@ -77,7 +77,7 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/minidropship)
 "A" = (
-/obj/structure/window/framed/mainship/hull,
+/obj/structure/window/framed/mainship,
 /turf/open/floor/mainship/mono,
 /area/shuttle/minidropship)
 "E" = (

--- a/_maps/shuttles/minidropship.dmm
+++ b/_maps/shuttles/minidropship.dmm
@@ -43,7 +43,7 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/minidropship)
 "o" = (
-/turf/closed/wall/mainship/outer,
+/turf/closed/wall/mainship/,
 /area/shuttle/minidropship)
 "q" = (
 /obj/machinery/door/poddoor/mainship/open{

--- a/_maps/shuttles/minidropship.dmm
+++ b/_maps/shuttles/minidropship.dmm
@@ -43,7 +43,7 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/minidropship)
 "o" = (
-/turf/closed/wall/mainship/,
+/turf/closed/wall/mainship/reinforced,
 /area/shuttle/minidropship)
 "q" = (
 /obj/machinery/door/poddoor/mainship/open{
@@ -77,7 +77,7 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/minidropship)
 "A" = (
-/obj/structure/window/framed/mainship,
+/obj/structure/window/framed/mainship/toughened,
 /turf/open/floor/mainship/mono,
 /area/shuttle/minidropship)
 "E" = (

--- a/_maps/shuttles/minidropship.dmm
+++ b/_maps/shuttles/minidropship.dmm
@@ -77,7 +77,7 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/minidropship)
 "A" = (
-/obj/structure/window/framed/mainship/toughened,
+/obj/structure/window/framed/mainship/,
 /turf/open/floor/mainship/mono,
 /area/shuttle/minidropship)
 "E" = (

--- a/_maps/shuttles/minidropship.dmm
+++ b/_maps/shuttles/minidropship.dmm
@@ -43,7 +43,7 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/minidropship)
 "o" = (
-/turf/closed/wall/mainship/reinforced,
+/turf/closed/wall/mainship/,
 /area/shuttle/minidropship)
 "q" = (
 /obj/machinery/door/poddoor/mainship/open{


### PR DESCRIPTION
## About The Pull Request
Changes tadpole windows to be breakable, and walls acidable. Yes this is a salt pr, but so is every other tadpole pr so far

## Why It's Good For The Game
Theres a lot of areas where ungas can fit tadpole to block off most, entrances, making defense awfully easy. Now they can be broken, and the walls can be acided, so you better park it somewhere you can defend them, or your tadpole might get turned into flying floortiles.
If you got a better idea, make your own pr instead of complaining, mkay? I did, so you have no excuse.


## Changelog
:cl: Triel
tweak: Tadpole windows and walls are breakable now.
/:cl:

