### PR TITLE
changes to the orbits mechanic

### DIFF
--- a/code/modules/orbits/spaceship.dm
+++ b/code/modules/orbits/spaceship.dm
@@ -159,7 +159,7 @@ GLOBAL_VAR_INIT(current_orbit,STANDARD_ORBIT)
 		if(choice != "Yes")
 			return
 		message_admins("[ADMIN_TPMONTY(usr)] Is going to finish the round via the spaceship orbits mechanic. set GLOB.current_orbit to 4 to prevent this.")
-		priority_announce("The coward hosts are attempting to flee!", "Prey is escaping!", ANNOUNCEMENT_REGULAR, 'sound/voice/alien_drool1.ogg', receivers = GLOB.alive_xeno_list + GLOB.observer_list)
+		priority_announce("The tall hosts are attempting to flee!", "Prey is escaping!", ANNOUNCEMENT_REGULAR, 'sound/voice/alien_drool1.ogg', receivers = GLOB.alive_xeno_list + GLOB.observer_list)
 		do_orbit_checks("escape")
 		TIMER_COOLDOWN_START(src, COOLDOWN_ORBIT_CHANGE, 1 MINUTES)
 		//end the round, xeno minor.

--- a/code/modules/orbits/spaceship.dm
+++ b/code/modules/orbits/spaceship.dm
@@ -7,6 +7,7 @@
 #define SKIM_ATMOSPHERE 	1
 
 #define REQUIRED_POWER_AMOUNT 250000
+#define AUTO_LOGOUT_TIME 1 MINUTES
 
 #define AUTHORIZED 		1
 #define AUTHORIZED_PLUS	2
@@ -121,7 +122,7 @@ GLOBAL_VAR_INIT(current_orbit,STANDARD_ORBIT)
 		if(isAI(usr))
 			authenticated = AUTHORIZED_PLUS
 			updateUsrDialog()
-			addtimer(VARSET_CALLBACK(src, authenticated, FALSE), 1 MINUTES) //autologout
+			addtimer(VARSET_CALLBACK(src, authenticated, FALSE), AUTO_LOGOUT_TIME) //autologout
 			return
 		var/mob/living/carbon/human/C = usr
 		var/obj/item/card/id/I = C.get_active_held_item()
@@ -130,7 +131,7 @@ GLOBAL_VAR_INIT(current_orbit,STANDARD_ORBIT)
 				authenticated = AUTHORIZED
 			if(ACCESS_MARINE_BRIDGE in I.access)
 				authenticated = AUTHORIZED_PLUS
-			addtimer(VARSET_CALLBACK(src, authenticated, FALSE), 1 MINUTES) //autologout
+			addtimer(VARSET_CALLBACK(src, authenticated, FALSE), AUTO_LOGOUT_TIME) //autologout
 		else
 			I = C.wear_id
 			if(istype(I))
@@ -138,7 +139,7 @@ GLOBAL_VAR_INIT(current_orbit,STANDARD_ORBIT)
 					authenticated = AUTHORIZED
 				if(ACCESS_MARINE_BRIDGE in I.access)
 					authenticated = AUTHORIZED_PLUS
-				addtimer(VARSET_CALLBACK(src, authenticated, FALSE), 1 MINUTES) //autologout
+				addtimer(VARSET_CALLBACK(src, authenticated, FALSE), AUTO_LOGOUT_TIME) //autologout
 	if(href_list["logout"])
 		authenticated = FALSE
 

--- a/code/modules/orbits/spaceship.dm
+++ b/code/modules/orbits/spaceship.dm
@@ -20,9 +20,14 @@ GLOBAL_VAR_INIT(current_orbit,STANDARD_ORBIT)
 	density = TRUE
 	anchored = TRUE
 	idle_power_usage = 10
-	var/changing_orbit = FALSE
+	req_access = list(ACCESS_MARINE_BRIDGE)
+	///boolean the spaceship it currently in the process of changing orbits
+	var/changing_orbit = TRUE
+	///boolean there is an authorized person logged into this console. TRUE = logged in authorized person
 	var/authenticated = FALSE
+	///boolean this machine is cut off from power and is sparking uncontrollably FALSE = everything fine
 	var/shorted = FALSE
+	///boolean this machine can be interacted with by the AI player. FELSE = can interact
 	var/aidisabled = FALSE
 
 //-------------------------------------------
@@ -44,6 +49,7 @@ GLOBAL_VAR_INIT(current_orbit,STANDARD_ORBIT)
 /obj/machinery/computer/navigation/Initialize() //need anything special?
 	. = ..()
 	desc = "The navigation console for the [SSmapping.configs[SHIP_MAP].map_name]."
+	addtimer(VARSET_CALLBACK(src, changing_orbit, FALSE), 1 HOURS) //people running away far too quickly it seems
 
 /obj/machinery/computer/navigation/proc/reset(wire)
 	switch(wire)
@@ -115,6 +121,7 @@ GLOBAL_VAR_INIT(current_orbit,STANDARD_ORBIT)
 		if(isAI(usr))
 			authenticated = AUTHORIZED_PLUS
 			updateUsrDialog()
+			addtimer(VARSET_CALLBACK(src, authenticated, FALSE), 1 MINUTES) //autologout
 			return
 		var/mob/living/carbon/human/C = usr
 		var/obj/item/card/id/I = C.get_active_held_item()
@@ -123,6 +130,7 @@ GLOBAL_VAR_INIT(current_orbit,STANDARD_ORBIT)
 				authenticated = AUTHORIZED
 			if(ACCESS_MARINE_BRIDGE in I.access)
 				authenticated = AUTHORIZED_PLUS
+			addtimer(VARSET_CALLBACK(src, authenticated, FALSE), 1 MINUTES) //autologout
 		else
 			I = C.wear_id
 			if(istype(I))
@@ -130,6 +138,7 @@ GLOBAL_VAR_INIT(current_orbit,STANDARD_ORBIT)
 					authenticated = AUTHORIZED
 				if(ACCESS_MARINE_BRIDGE in I.access)
 					authenticated = AUTHORIZED_PLUS
+				addtimer(VARSET_CALLBACK(src, authenticated, FALSE), 1 MINUTES) //autologout
 	if(href_list["logout"])
 		authenticated = FALSE
 
@@ -148,7 +157,8 @@ GLOBAL_VAR_INIT(current_orbit,STANDARD_ORBIT)
 		var/choice = alert(usr, "This will end the round. Are you certain you wish to leave any groundside marines behind?", "Escape Velocity", "Cancel", "Yes", "Cancel")
 		if(choice != "Yes")
 			return
-		message_admins("[ADMIN_TPMONTY(usr)] Is going to finish the round via the spaceship orbits mechanic")
+		message_admins("[ADMIN_TPMONTY(usr)] Is going to finish the round via the spaceship orbits mechanic. set GLOB.current_orbit to 4 to prevent this.")
+		priority_announce("The coward hosts are attempting to flee!", "Prey is escaping!", ANNOUNCEMENT_REGULAR, 'sound/voice/alien_drool1.ogg', receivers = GLOB.alive_xeno_list + GLOB.observer_list)
 		do_orbit_checks("escape")
 		TIMER_COOLDOWN_START(src, COOLDOWN_ORBIT_CHANGE, 1 MINUTES)
 		//end the round, xeno minor.
@@ -237,6 +247,10 @@ GLOBAL_VAR_INIT(current_orbit,STANDARD_ORBIT)
 		CHECK_TICK
 
 /obj/machinery/computer/navigation/proc/retreat()
+
+	if(GLOB.current_orbit != 5)
+		message_admins("This is the moment when the space ship orbit would have done the retreat, but an admin has adjusted the GLOB.current_orbit variable to prevent this.")
+		return
 
 	if(isdistress(SSticker.mode))
 		var/datum/game_mode/infestation/distress/distress_mode = SSticker.mode

--- a/code/modules/orbits/spaceship.dm
+++ b/code/modules/orbits/spaceship.dm
@@ -50,7 +50,7 @@ GLOBAL_VAR_INIT(current_orbit,STANDARD_ORBIT)
 /obj/machinery/computer/navigation/Initialize() //need anything special?
 	. = ..()
 	desc = "The navigation console for the [SSmapping.configs[SHIP_MAP].map_name]."
-	addtimer(VARSET_CALLBACK(src, changing_orbit, FALSE), 1 HOURS) //people running away far too quickly it seems
+	addtimer(VARSET_CALLBACK(src, changing_orbit, FALSE), 30 MINUTES) //people running away far too quickly it seems
 
 /obj/machinery/computer/navigation/proc/reset(wire)
 	switch(wire)

--- a/code/modules/orbits/spaceship.dm
+++ b/code/modules/orbits/spaceship.dm
@@ -248,7 +248,7 @@ GLOBAL_VAR_INIT(current_orbit,STANDARD_ORBIT)
 
 /obj/machinery/computer/navigation/proc/retreat()
 
-	if(GLOB.current_orbit != 5)
+	if(GLOB.current_orbit != ESCAPE_VELOCITY)
 		message_admins("This is the moment when the space ship orbit would have done the retreat, but an admin has adjusted the GLOB.current_orbit variable to prevent this.")
 		return
 


### PR DESCRIPTION
## About The Pull Request

Admins were getting angry about not being able to stop marines retreating. And that marines were retreating too early.

## Why It's Good For The Game

I personally don't think this makes the game 'better'. It makes it different, and allows more control by admins.

## Changelog
:cl: Hughgent
tweak: Spaceship retreat can now be prevented by admins
tweak: Spaceship navigation console now automatically logs out after 1 minute
tweak: Spaceship orbit cannot be changed before the 30 minute mark.
add: Xenos now get notified via announcement when marines start the retreat timer.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
