### PR TITLE
Removes the limit on Resin Silo construction, and lowers the cooldown

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1005,7 +1005,7 @@
 	ability_name = "secrete resin"
 	plasma_cost = 150
 	keybind_signal = COMSIG_XENOABILITY_SECRETE_RESIN_SILO
-	cooldown_timer = 120 SECONDS
+	cooldown_timer = 60 SECONDS
 
 	/// How long does it take to build
 	var/build_time = 10 SECONDS
@@ -1017,12 +1017,6 @@
 	. = ..()
 	if(!.)
 		return FALSE
-
-	if(length(GLOB.xeno_resin_silos) > 5)
-		if(!silent)
-			to_chat(owner, "<span class='warning'>The Hive can't support another silo.</span>")
-		return FALSE
-
 
 	if(!in_range(owner, A))
 		if(!silent)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Deleted the Silo limit check in `build_silo/can_use_ability`

Halved the cooldown.

## Why It's Good For The Game

The silo limit is bad and only serves to prevent xenos form building ones near battle lines. Not sure why spam was a concern before, but now it is in the best interest of the xenos to take bodies to existing ones for the larva points anyway.

## Changelog
:cl:
del: Removed the arbitrary limit on resin silos.
balance: Silo construction cooldown reduced from 120 to 60 seconds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
