### PR TITLE
Removes the Tadpole's exterior mount points

### DIFF
--- a/_maps/shuttles/minidropship.dmm
+++ b/_maps/shuttles/minidropship.dmm
@@ -67,9 +67,6 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/minidropship)
 "u" = (
-/obj/effect/attach_point/weapon/minidropship{
-	dir = 8
-	},
 /turf/closed/wall/mainship/outer,
 /area/shuttle/minidropship)
 "z" = (
@@ -132,9 +129,6 @@
 /turf/open/floor/mainship/mono,
 /area/shuttle/minidropship)
 "U" = (
-/obj/effect/attach_point/weapon/minidropship{
-	dir = 4
-	},
 /turf/closed/wall/mainship/outer,
 /area/shuttle/minidropship)
 "X" = (


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the Tadpole's exterior mount points

## Why It's Good For The Game

Gauss cannons on the land anywhere dropship were a bad idea.

## Changelog
:cl:
balance: Tadpole exterior mount points are gone.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
