### PR TITLE
Fixes T3 Limit Displays for the Hive Status

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/death.dm
+++ b/code/modules/mob/living/carbon/xenomorph/death.dm
@@ -13,8 +13,8 @@
 	GLOB.alive_xeno_list -= src
 	GLOB.dead_xeno_list += src
 
-	hive.update_tier_limits() //Update our tier limits.
 	hive?.on_xeno_death(src)
+	hive.update_tier_limits() //Update our tier limits.
 
 	if(LAZYLEN(stomach_contents))
 		empty_gut()

--- a/code/modules/mob/living/carbon/xenomorph/death.dm
+++ b/code/modules/mob/living/carbon/xenomorph/death.dm
@@ -12,6 +12,8 @@
 /mob/living/carbon/xenomorph/on_death()
 	GLOB.alive_xeno_list -= src
 	GLOB.dead_xeno_list += src
+
+	hive.update_tier_limits() //Update our tier limits.
 	hive?.on_xeno_death(src)
 
 	if(LAZYLEN(stomach_contents))

--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -349,7 +349,6 @@
 	qdel(src)
 	INVOKE_ASYNC(new_xeno, /mob/living.proc/do_jitter_animation, 1000)
 
-	new_xeno.hive.update_tier_limits()
 
 #undef TO_XENO_TIER_2_FORMULA
 #undef TO_XENO_TIER_3_FORMULA

--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -349,5 +349,7 @@
 	qdel(src)
 	INVOKE_ASYNC(new_xeno, /mob/living.proc/do_jitter_animation, 1000)
 
+	hive.update_tier_limits()
+
 #undef TO_XENO_TIER_2_FORMULA
 #undef TO_XENO_TIER_3_FORMULA

--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -349,7 +349,7 @@
 	qdel(src)
 	INVOKE_ASYNC(new_xeno, /mob/living.proc/do_jitter_animation, 1000)
 
-	hive.update_tier_limits()
+	new_xeno.hive.update_tier_limits()
 
 #undef TO_XENO_TIER_2_FORMULA
 #undef TO_XENO_TIER_3_FORMULA

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -17,6 +17,8 @@
 	var/list/dead_xenos // xenos that are still assigned to this hive but are dead.
 	var/list/ssd_xenos
 	var/list/list/xenos_by_zlevel
+	var/tier3_xeno_limit
+	var/tier2_xeno_limit
 
 // ***************************************
 // *********** Init
@@ -183,6 +185,7 @@
 	generate_name()
 
 	SSdirection.start_tracking(HS.hivenumber, src)
+	hive.update_tier_limits() //Update our tier limits.
 
 /mob/living/carbon/xenomorph/queen/add_to_hive(datum/hive_status/HS, force=FALSE) // override to ensure proper queen/hive behaviour
 	. = ..()
@@ -1075,3 +1078,7 @@ to_chat will check for valid clients itself already so no need to double check f
 			var/datum/xeno_caste/caste = GLOB.xeno_caste_datums[text2path(params["path"])][XENO_UPGRADE_BASETYPE]
 			xeno.do_evolve(caste.caste_type_path, caste.display_name) // All the checks for can or can't are handled inside do_evolve
 			return
+
+/datum/hive_status/proc/update_tier_limits()
+	tier3_xeno_limit = max(length(xenos_by_tier[XENO_TIER_THREE]),FLOOR((length(xenos_by_tier[XENO_TIER_ZERO])+length(xenos_by_tier[XENO_TIER_ONE])+length(xenos_by_tier[XENO_TIER_TWO]))/3,1))
+	tier2_xeno_limit = max(length(xenos_by_tier[XENO_TIER_TWO]),length(xenos_by_tier[XENO_TIER_ZERO]) + length(xenos_by_tier[XENO_TIER_ONE]) - length(xenos_by_tier[XENO_TIER_THREE]))

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -167,6 +167,7 @@
 		LAZYADD(ssd_xenos, X)
 
 	xenos_by_typepath[X.caste_base_type] += X
+	update_tier_limits() //Update our tier limits.
 
 	return TRUE
 
@@ -210,6 +211,7 @@
 		CRASH("add_to_hive_by_hivenumber called with invalid hivenumber")
 	var/datum/hive_status/HS = GLOB.hive_datums[hivenumber]
 	add_to_hive(HS, force)
+	hive.update_tier_limits() //Update our tier limits.
 
 // This is a special proc called only when a xeno is first created to set their hive and name properly
 /mob/living/carbon/xenomorph/proc/set_initial_hivenumber()
@@ -255,6 +257,7 @@
 	UnregisterSignal(X, COMSIG_MOVABLE_Z_CHANGED)
 
 	remove_leader(X)
+	update_tier_limits() //Update our tier limits.
 
 	return TRUE
 
@@ -272,6 +275,7 @@
 
 	hive = null
 	hivenumber = XENO_HIVE_NONE // failsafe value
+	hive.update_tier_limits() //Update our tier limits.
 
 /mob/living/carbon/xenomorph/queen/remove_from_hive() // override to ensure proper queen/hive behaviour
 	var/datum/hive_status/hive_removed_from = hive
@@ -1080,5 +1084,5 @@ to_chat will check for valid clients itself already so no need to double check f
 			return
 
 /datum/hive_status/proc/update_tier_limits()
-	tier3_xeno_limit = max(length(xenos_by_tier[XENO_TIER_THREE]),FLOOR((length(xenos_by_tier[XENO_TIER_ZERO])+length(xenos_by_tier[XENO_TIER_ONE])+length(xenos_by_tier[XENO_TIER_TWO]))/3,1))
-	tier2_xeno_limit = max(length(xenos_by_tier[XENO_TIER_TWO]),length(xenos_by_tier[XENO_TIER_ZERO]) + length(xenos_by_tier[XENO_TIER_ONE]) - length(xenos_by_tier[XENO_TIER_THREE]))
+	tier3_xeno_limit = max(length(xenos_by_tier[XENO_TIER_THREE]),FLOOR((length(xenos_by_tier[XENO_TIER_ZERO])+length(xenos_by_tier[XENO_TIER_ONE])+length(xenos_by_tier[XENO_TIER_TWO]))/3+1,1))
+	tier2_xeno_limit = max(length(xenos_by_tier[XENO_TIER_TWO]),length(xenos_by_tier[XENO_TIER_ZERO]) + length(xenos_by_tier[XENO_TIER_ONE])+1 - length(xenos_by_tier[XENO_TIER_THREE]))

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -273,9 +273,10 @@
 
 	SSdirection.stop_tracking(hive.hivenumber, src)
 
+	var/datum/hive_status/reference_hive = hive
 	hive = null
 	hivenumber = XENO_HIVE_NONE // failsafe value
-	hive.update_tier_limits() //Update our tier limits.
+	reference_hive.update_tier_limits() //Update our tier limits.
 
 /mob/living/carbon/xenomorph/queen/remove_from_hive() // override to ensure proper queen/hive behaviour
 	var/datum/hive_status/hive_removed_from = hive

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -63,7 +63,6 @@
 	ADD_TRAIT(src, TRAIT_BATONIMMUNE, TRAIT_XENO)
 	ADD_TRAIT(src, TRAIT_FLASHBANGIMMUNE, TRAIT_XENO)
 
-
 /mob/living/carbon/xenomorph/proc/set_datum()
 	if(!caste_base_type)
 		CRASH("xeno spawned without a caste_base_type set")
@@ -202,6 +201,7 @@
 	GLOB.xeno_mob_list -= src
 	GLOB.dead_xeno_list -= src
 
+	hive.update_tier_limits() //Update our tier limits.
 	remove_from_hive()
 
 	vis_contents -= wound_overlay

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -62,6 +62,7 @@
 
 	ADD_TRAIT(src, TRAIT_BATONIMMUNE, TRAIT_XENO)
 	ADD_TRAIT(src, TRAIT_FLASHBANGIMMUNE, TRAIT_XENO)
+	hive.update_tier_limits()
 
 /mob/living/carbon/xenomorph/proc/set_datum()
 	if(!caste_base_type)
@@ -201,8 +202,9 @@
 	GLOB.xeno_mob_list -= src
 	GLOB.dead_xeno_list -= src
 
-	hive.update_tier_limits() //Update our tier limits.
+	var/datum/hive_status/hive_placeholder = hive
 	remove_from_hive()
+	hive_placeholder.update_tier_limits() //Update our tier limits.
 
 	vis_contents -= wound_overlay
 	QDEL_NULL(wound_overlay)

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -118,14 +118,21 @@
 	xenoinfo += xeno_status_output(hive.xenos_by_typepath[/mob/living/carbon/xenomorph/larva], can_overwatch, TRUE, user)
 
 	var/hivemind_text = length(hive.xenos_by_typepath[/mob/living/carbon/xenomorph/hivemind]) > 0 ? "Active" : "Inactive"
-	var/xeno_tier_three_cap = max(length(hive.xenos_by_tier[XENO_TIER_THREE]),FLOOR((length(hive.xenos_by_tier[XENO_TIER_ZERO])+length(hive.xenos_by_tier[XENO_TIER_ONE])+length(hive.xenos_by_tier[XENO_TIER_TWO]))/3,1))
-	var/xeno_tier_two_cap = max(length(hive.xenos_by_tier[XENO_TIER_TWO]),1 + length(hive.xenos_by_tier[XENO_TIER_ZERO]) + length(hive.xenos_by_tier[XENO_TIER_ONE]) - length(hive.xenos_by_tier[XENO_TIER_THREE]))
+	var/mob/living/carbon/xenomorph/queen/hive_queen = hive.living_xeno_queen
+
+	var/queen_text = "[hive_queen ? "[hive_queen]": "None"]"
+	if(!hive_queen.client)
+		queen_text += " <i>(SSD)</i>"
+
+	var/xeno_tier_three_cap = hive.tier3_xeno_limit
+	var/xeno_tier_two_cap = hive.tier2_xeno_limit
 
 	dat += "<b>Total Living Sisters: [hive.get_total_xeno_number()]</b><BR>"
 	dat += "<b>Tier 3: ([length(hive.xenos_by_tier[XENO_TIER_THREE])]/[xeno_tier_three_cap]) Sisters</b>[tier3counts]<BR>"
 	dat += "<b>Tier 2: ([length(hive.xenos_by_tier[XENO_TIER_TWO])]/[xeno_tier_two_cap]) Sisters</b>[tier2counts]<BR>"
 	dat += "<b>Tier 1: [length(hive.xenos_by_tier[XENO_TIER_ONE])] Sisters</b>[tier1counts]<BR>"
 	dat += "<b>Larvas: [length(hive.xenos_by_typepath[/mob/living/carbon/xenomorph/larva])] Sisters<BR>"
+	dat += "<b>Queen: [queen_text]<BR>"
 	dat += "<b>Hivemind: [hivemind_text]<BR>"
 	if(hive.hivenumber == XENO_HIVE_NORMAL)
 		var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
@@ -645,3 +652,5 @@
 	if(.)
 		return
 	return (sunder * -0.01) + 1
+
+up

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -127,12 +127,9 @@
 		if(!hive_queen.client)
 			queen_text += " <i>(SSD)</i>"
 
-	var/xeno_tier_three_cap = hive.tier3_xeno_limit
-	var/xeno_tier_two_cap = hive.tier2_xeno_limit
-
 	dat += "<b>Total Living Sisters: [hive.get_total_xeno_number()]</b><BR>"
-	dat += "<b>Tier 3: ([length(hive.xenos_by_tier[XENO_TIER_THREE])]/[xeno_tier_three_cap]) Sisters</b>[tier3counts]<BR>"
-	dat += "<b>Tier 2: ([length(hive.xenos_by_tier[XENO_TIER_TWO])]/[xeno_tier_two_cap]) Sisters</b>[tier2counts]<BR>"
+	dat += "<b>Tier 3: ([length(hive.xenos_by_tier[XENO_TIER_THREE])]/[hive.tier3_xeno_limit]) Sisters</b>[tier3counts]<BR>"
+	dat += "<b>Tier 2: ([length(hive.xenos_by_tier[XENO_TIER_TWO])]/[hive.tier2_xeno_limit]) Sisters</b>[tier2counts]<BR>"
 	dat += "<b>Tier 1: [length(hive.xenos_by_tier[XENO_TIER_ONE])] Sisters</b>[tier1counts]<BR>"
 	dat += "<b>Larvas: [length(hive.xenos_by_typepath[/mob/living/carbon/xenomorph/larva])] Sisters<BR>"
 	dat += "<b>Queen: [queen_text]<BR>"

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -118,7 +118,7 @@
 	xenoinfo += xeno_status_output(hive.xenos_by_typepath[/mob/living/carbon/xenomorph/larva], can_overwatch, TRUE, user)
 
 	var/hivemind_text = length(hive.xenos_by_typepath[/mob/living/carbon/xenomorph/hivemind]) > 0 ? "Active" : "Inactive"
-	var/xeno_tier_three_cap = max(length(hive.xenos_by_tier[XENO_TIER_THREE]),CEILING((length(hive.xenos_by_tier[XENO_TIER_ZERO])+length(hive.xenos_by_tier[XENO_TIER_ONE])+length(hive.xenos_by_tier[XENO_TIER_TWO]))/3+1,1))
+	var/xeno_tier_three_cap = max(length(hive.xenos_by_tier[XENO_TIER_THREE]),FLOOR((length(hive.xenos_by_tier[XENO_TIER_ZERO])+length(hive.xenos_by_tier[XENO_TIER_ONE])+length(hive.xenos_by_tier[XENO_TIER_TWO]))/3,1))
 	var/xeno_tier_two_cap = max(length(hive.xenos_by_tier[XENO_TIER_TWO]),1 + length(hive.xenos_by_tier[XENO_TIER_ZERO]) + length(hive.xenos_by_tier[XENO_TIER_ONE]) - length(hive.xenos_by_tier[XENO_TIER_THREE]))
 
 	dat += "<b>Total Living Sisters: [hive.get_total_xeno_number()]</b><BR>"

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -120,9 +120,12 @@
 	var/hivemind_text = length(hive.xenos_by_typepath[/mob/living/carbon/xenomorph/hivemind]) > 0 ? "Active" : "Inactive"
 	var/mob/living/carbon/xenomorph/queen/hive_queen = hive.living_xeno_queen
 
-	var/queen_text = "[hive_queen ? "[hive_queen]": "None"]"
-	if(!hive_queen.client)
-		queen_text += " <i>(SSD)</i>"
+	var/queen_text = "None" //Define the Queen
+	if(hive_queen)
+		queen_text = "[hive_queen]"
+
+		if(!hive_queen.client)
+			queen_text += " <i>(SSD)</i>"
 
 	var/xeno_tier_three_cap = hive.tier3_xeno_limit
 	var/xeno_tier_two_cap = hive.tier2_xeno_limit

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -652,5 +652,3 @@
 	if(.)
 		return
 	return (sunder * -0.01) + 1
-
-up


### PR DESCRIPTION
## About The Pull Request

Fixes a lingering bug with the Hive Status info calcs for T3s occasionally displaying a limit one higher than reality.

Creates hive specific vars defining tier limits that are calculated as needed rather than upon opening the Hive Status window.

Displays current xeno queen.

## Why It's Good For The Game

Fixes an annoying bug.

## Changelog
:cl:
fix: Fixes displayed T3 Hive Status.
refactor: Adds T2 and T3 limit vars for Hive datums.
/:cl: