### PR TITLE
Revert "Making Lasrifle Overcharge Great Again"

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1213,10 +1213,10 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	name = "overcharged laser bolt"
 	icon_state = "heavylaser"
 	hud_state = "laser_sniper"
-	damage = 55
+	damage = 42
 	max_range = 40
-	penetration = 50
-	sundering = 15
+	penetration = 20
+	sundering = 10
 
 /datum/ammo/energy/lasgun/M43/heat
 	name = "microwave heat bolt"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reverts #5336, ignore linter going wacky mode

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

After being generally ignored on the original PR and discussions, and with zero real changes made, I did some testing.

![image](https://user-images.githubusercontent.com/44979174/101263011-40d0f900-373a-11eb-9158-2b2f7bcdc2ad.png)

This is how many shots it took me to kill the target, standing still. General range was about 4 tiles away, aside from the PFC sniper which was done at the edge of the screen. PB shots self-explanatory. All weapons had only a bayonet attached, aside from the PFC sniper which had no attachments.

The lasgun on overcharge fires faster and has more shots per magazine than all of the tested weapons. Generally, it's time to kill was faster than the other weapons, which I didn't record. It's ammo is also far more easily available than the mosin, can be recharged easily via the lasgun charger compared to the other ammo, and has multiple other firemodes enabling it to set xenos on fire, stagger them with disable, and more. 

Compared to the spread function on the lasgun, it can also be used at a longer range, making it far more flexible.

Compared to the PFC sniper, it can be used at a short range, making it far more versatile.

It has the same sunder as the Mosin and more sunder than both the other guns, meaning xenos suffer more in the long term if you don't succeed in the kill.

It has 20 more pen than the PFC sniper, 15 more pen than the Mosin rounds, and ***50*** more pen than the scatter laser.

Unlike the PFC sniper, shotgun and Mosin, it doesn't require to be bolted between shots.

Lowering the damage by 5 didn't change the impact of the PR. This was not a good change, zero feedback was taken, and it's going to have bad consequences as soon as people put the above together and realise it's the far preferable choice to the listed weapons, if not the rest. This also doesn't fit with the deescalation of weapons/armour intended.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Reverts lasgun overcharge buffs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
