### PR TITLE
Bug Fix for Sentries

### DIFF
--- a/code/__DEFINES/objects.dm
+++ b/code/__DEFINES/objects.dm
@@ -111,7 +111,7 @@ GLOBAL_LIST_INIT(restricted_camera_networks, list( //Those networks can only be 
 #define SENTRY_ALERT_BATTERY			5
 #define SENTRY_ALERT_DELAY				20 SECONDS
 #define SENTRY_DAMAGE_ALERT_DELAY		5 SECONDS
-
+#define SENTRY_LIGHT_POWER				7
 
 //Scout cloak defines
 #define SCOUT_CLOAK_ENERGY	100


### PR DESCRIPTION
## About The Pull Request

Fixes the following bugs:

1. Sentry lights being removed after shooting (not sure if this has been reported).

2. Duplicating minisentries without cells upon folding them: Fixes https://github.com/tgstation/TerraGov-Marine-Corps/issues/4876

3. Sentry lights not properly shutting off (not sure if this has been reported).

## Why It's Good For The Game

Fixes bugs.

## Changelog
:cl:
fix: Fixed minisentry duplication bug.
fix: Fixed lighting bugs for sentries.
refactor: Minor sentry refactors and removal/revision of old code.
/:cl: