### PR TITLE
Tadpole Windows Are Now Breakable

### DIFF
--- a/_maps/shuttles/minidropship.dmm
+++ b/_maps/shuttles/minidropship.dmm
@@ -35,9 +35,6 @@
 /obj/machinery/vending/nanomed{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/open/shuttle/dropship/floor,
 /area/shuttle/minidropship)
 "o" = (
@@ -70,13 +67,37 @@
 	},
 /turf/closed/wall/mainship/outer,
 /area/shuttle/minidropship)
+"y" = (
+/obj/machinery/light,
+/obj/machinery/door_control{
+	id = "minidropship_podlock";
+	name = "outer door-control";
+	pixel_y = -32
+	},
+/turf/open/shuttle/blackfloor,
+/area/shuttle/minidropship)
 "z" = (
 /obj/machinery/computer/dropship_weapons/minidropship,
 /turf/open/shuttle/blackfloor,
 /area/shuttle/minidropship)
 "A" = (
-/obj/structure/window/framed/mainship/hull,
+/obj/machinery/door/poddoor/mainship/open{
+	id = "minidropship_podlock"
+	},
+/obj/machinery/door/poddoor/shutters/transit{
+	dir = 2
+	},
+/obj/structure/window/framed/mainship/tadpole,
 /turf/open/floor/mainship/mono,
+/area/shuttle/minidropship)
+"E" = (
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/shuttle/dropship/floor,
 /area/shuttle/minidropship)
 "F" = (
 /obj/docking_port/mobile/marine_dropship/minidropship,
@@ -98,6 +119,14 @@
 	name = "\improper Command Cockpit"
 	},
 /turf/open/shuttle/dropship/floor,
+/area/shuttle/minidropship)
+"P" = (
+/obj/machinery/door/poddoor/mainship/open{
+	id = "minidropship_podlock"
+	},
+/obj/machinery/door/poddoor/shutters/transit,
+/obj/structure/window/framed/mainship/tadpole,
+/turf/open/floor/mainship/mono,
 /area/shuttle/minidropship)
 "S" = (
 /obj/machinery/computer/camera_advanced/shuttle_docker/minidropship,
@@ -127,13 +156,19 @@
 /obj/machinery/vending/nanomed{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/open/shuttle/dropship/floor,
 /area/shuttle/minidropship)
 "Y" = (
 /turf/open/shuttle/dropship/grating,
+/area/shuttle/minidropship)
+"Z" = (
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/floor,
 /area/shuttle/minidropship)
 
 (1,1,1) = {"
@@ -149,7 +184,7 @@ a
 "}
 (2,1,1) = {"
 o
-A
+P
 o
 o
 s
@@ -161,12 +196,12 @@ o
 (3,1,1) = {"
 A
 S
-i
+y
 o
 h
 h
 X
-h
+E
 q
 "}
 (4,1,1) = {"
@@ -188,12 +223,12 @@ o
 T
 g
 l
-g
+Z
 q
 "}
 (6,1,1) = {"
 o
-A
+P
 o
 o
 s

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -397,6 +397,14 @@
 	desc = "A very tough looking glass window with a special rod matrice, probably bullet proof."
 	max_integrity = 300
 
+/obj/structure/window/framed/mainship/tadpole
+	name = "tadpole hull window"
+	desc = "A borosilicate armored window rated for atmospheric entry and reforced with exotic fibres and mounted within a special shock-absorbing frame. Acid proof and impact resistant; this is gonna be seriously hard to break through."
+	//icon_state = "rwindow0_debug" //Uncomment to check hull in the map editor
+	deconstructable = FALSE
+	resistance_flags = UNACIDABLE
+	max_integrity = 500
+
 /obj/structure/window/framed/mainship/hull
 	name = "hull window"
 	desc = "A glass window with a special rod matrice inside a wall frame. This one was made out of exotic materials to prevent hull breaches. No way to get through here."

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -389,6 +389,12 @@
 		unbuckle_mob(m)
 	return (CHARGE_SPEED(charge_datum) * 20) //Damage to inflict.
 
+
+/obj/structure/window/framed/mainship/tadpole/pre_crush_act(mob/living/carbon/xenomorph/charger, datum/action/xeno_action/ready_charge/charge_datum)
+	charge_datum.do_stop_momentum() //These frames are uncrushable
+	return PRECRUSH_STOPPED
+
+
 /obj/structure/razorwire/pre_crush_act(mob/living/carbon/xenomorph/charger, datum/action/xeno_action/ready_charge/charge_datum)
 	if(CHECK_BITFIELD(resistance_flags, INDESTRUCTIBLE) || charger.is_charging < CHARGE_ON)
 		charge_datum.do_stop_momentum()

--- a/code/modules/shuttle/mini_dropship.dm
+++ b/code/modules/shuttle/mini_dropship.dm
@@ -26,6 +26,7 @@
 	x_offset = 0
 	y_offset = 0
 	designate_time = 100
+	density = FALSE //So benos can move past
 
 // No lockable side or rear doors
 /obj/machinery/computer/shuttle/minidropship
@@ -40,3 +41,4 @@
 	name = "\improper 'Tadpole' weapons controls"
 	shuttle_tag = "minidropship"
 	req_access = list(ACCESS_MARINE_DROPSHIP)
+	density = FALSE //So benos can move past


### PR DESCRIPTION
## About The Pull Request

1. Tadpole Windows can now be broken. They are acid and crush proof and have 500 integrity.

2. Tadpole now has shutters for the cockpit windows and a shutter control has been added to the cockpit.

3. The Tadpole Navigation and Weapons computers are no longer dense; mobs can move on top of them.

## Why It's Good For The Game

Prevents the cockpit from being cheesily used as a completely impassable and indestructible obstacle. 

## Changelog
:cl:
mapping: Tadpole windows are now destructible but are crushing and acid immune.
mapping: Tadpole cockpit now has shutters.
/:cl: