### PR TITLE
Evasion Thwarted By Debuffs and Stagger/Slow Partial Refactor

### DIFF
--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -52,6 +52,7 @@
 #define AMMO_BALLISTIC			(1<<11)
 #define AMMO_SUNDERING			(1<<12)
 #define AMMO_CHAINING			(1<<13)
+#define AMMO_SENTRY				(1<<14) //Used to identify ammo from sentry guns and other automated sources
 
 //Gun defines for gun related thing. More in the projectile folder.
 //flags_gun_features

--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -53,6 +53,7 @@
 #define AMMO_SUNDERING			(1<<12)
 #define AMMO_CHAINING			(1<<13)
 #define AMMO_SENTRY				(1<<14) //Used to identify ammo from sentry guns and other automated sources
+#define AMMO_FLAME				(1<<15) //Used to identify flamethrower projectiles and similar projectiles
 
 //Gun defines for gun related thing. More in the projectile folder.
 //flags_gun_features

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -128,7 +128,6 @@
 #define COMSIG_ATOM_ORBIT_BEGIN "atom_orbit_begin"				//called when an atom starts orbiting another atom: (atom)
 #define COMSIG_ATOM_ORBIT_STOP "atom_orbit_stop"				//called when an atom stops orbiting another atom: (atom)
 #define COMSIG_ATOM_ACIDSPRAY_ACT "atom_acidspray_act"			//from base of atom/acidspray_act():
-#define COMSIG_ATOM_FLAMER_HIT "flamer_hit"						//called when a flamer projectile hits something
 
 ///from base of atom/set_opacity(): (new_opacity)
 #define COMSIG_ATOM_SET_OPACITY "atom_set_opacity"
@@ -388,6 +387,8 @@
 #define COMSIG_XENO_NONE_THROW_HIT "xeno_none_throw_hit"			///from [/mob/living/carbon/xenomorph/throw_impact]: ()
 #define COMSIG_XENO_LIVING_THROW_HIT "xeno_living_throw_hit"		///from [/mob/living/carbon/xenomorph/throw_impact]: (mob/living/target)
 	#define COMPONENT_KEEP_THROWING (1<<0)
+#define COMSIG_XENO_PROJECTILE_HIT "xeno_projectile_hit"			///from [/mob/living/carbon/xenomorph/projectile_hit] called when a projectile hits a xeno but before confirmation of a hit (can miss due to inaccuracy/evasion)
+	#define COMPONENT_EVASION_DODGE (1<<0)
 
 //human signals
 #define COMSIG_CLICK_QUICKEQUIP "click_quickequip"

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -388,7 +388,7 @@
 #define COMSIG_XENO_LIVING_THROW_HIT "xeno_living_throw_hit"		///from [/mob/living/carbon/xenomorph/throw_impact]: (mob/living/target)
 	#define COMPONENT_KEEP_THROWING (1<<0)
 #define COMSIG_XENO_PROJECTILE_HIT "xeno_projectile_hit"			///from [/mob/living/carbon/xenomorph/projectile_hit] called when a projectile hits a xeno but before confirmation of a hit (can miss due to inaccuracy/evasion)
-	#define COMPONENT_EVASION_DODGE (1<<0)
+	#define COMPONENT_PROJECTILE_DODGE (1<<0)
 
 //human signals
 #define COMSIG_CLICK_QUICKEQUIP "click_quickequip"

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -300,6 +300,9 @@
 #define COMSIG_LIVING_STATUS_UNCONSCIOUS "living_unconscious"	//from base of mob/living/Unconscious() (amount, update, ignore)
 #define COMSIG_LIVING_STATUS_SLEEP "living_sleeping"			//from base of mob/living/Sleeping() (amount, update, ignore)
 #define COMSIG_LIVING_STATUS_CONFUSED "living_confused"			//from base of mob/living/Confused() (amount, update, ignore)
+#define COMSIG_LIVING_STATUS_STAGGER "living_stagger"			//from base of mob/living/adjust_stagger() (amount, update, ignore)
+#define COMSIG_LIVING_STATUS_SLOWDOWN "living_slowdown"			//from base of mob/living/set_slowdown() (amount, update)
+
 	#define COMPONENT_NO_STUN (1<<0)			//For all of them
 
 #define COMSIG_LIVING_ADD_VENTCRAWL "living_add_ventcrawl"

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -128,7 +128,7 @@
 #define COMSIG_ATOM_ORBIT_BEGIN "atom_orbit_begin"				//called when an atom starts orbiting another atom: (atom)
 #define COMSIG_ATOM_ORBIT_STOP "atom_orbit_stop"				//called when an atom stops orbiting another atom: (atom)
 #define COMSIG_ATOM_ACIDSPRAY_ACT "atom_acidspray_act"			//from base of atom/acidspray_act():
-
+#define COMSIG_ATOM_FLAMER_HIT "flamer_hit"						//called when a flamer projectile hits something
 
 ///from base of atom/set_opacity(): (new_opacity)
 #define COMSIG_ATOM_SET_OPACITY "atom_set_opacity"

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -542,9 +542,8 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define DRONE_SALVAGE_EVOLUTION_FILTER_LIST	list(XENO_TIER_ZERO, XENO_TIER_THREE, XENO_TIER_FOUR)
 
 //Runner defines
-#define RUNNER_EVASION_STACKS				250 //How much projectile damage we auto-dodge.
-#define RUNNER_EVASION_DURATION				8 SECONDS //How long Evasion lasts.
-#define RUNNER_EVASION_DURATION_WARNING		0.7 //After what % of Evasion's time elapsed do we warn the user
+#define RUNNER_EVASION_DURATION				6 SECONDS //How long Evasion lasts.
+#define RUNNER_EVASION_DURATION_WARNING		2 SECONDS //We warn the user when this amount of duration remains
 #define RUNNER_EVASION_RUN_DELAY			0.5 SECONDS //If the time since the Runner last moved is equal to or greater than this, its Evasion ends.
 #define RUNNER_EVASION_DANGER_RATIO			0.5 //If we have this % of auto-dodge damage remaining or less, warn the user.
 #define RUNNER_BURN_DEPLETION_MODIFIER		4 //We lose Evasion stacks per life tick equal to damage from burning times this amount

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -542,11 +542,10 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define DRONE_SALVAGE_EVOLUTION_FILTER_LIST	list(XENO_TIER_ZERO, XENO_TIER_THREE, XENO_TIER_FOUR)
 
 //Runner defines
-#define RUNNER_EVASION_DURATION				6 SECONDS //How long Evasion lasts.
-#define RUNNER_EVASION_DURATION_WARNING		2 SECONDS //We warn the user when this amount of duration remains
-#define RUNNER_EVASION_RUN_DELAY			0.5 SECONDS //If the time since the Runner last moved is equal to or greater than this, its Evasion ends.
-#define RUNNER_EVASION_DANGER_RATIO			0.5 //If we have this % of auto-dodge damage remaining or less, warn the user.
-#define RUNNER_BURN_DEPLETION_MODIFIER		4 //We lose Evasion stacks per life tick equal to damage from burning times this amount
+#define RUNNER_EVASION_DURATION						2 SECONDS //How long Evasion lasts.
+#define RUNNER_EVASION_RUN_DELAY					0.5 SECONDS //If the time since the Runner last moved is equal to or greater than this, its Evasion ends.
+#define RUNNER_EVASION_BURN_DEPLETION_MODIFIER		4 //We lose Evasion stacks per life tick equal to damage from burning times this amount
+#define RUNNER_EVASION_COOLDOWN_REFRESH_THRESHOLD	120 //If we dodge this much damage while evading, refresh the cooldown of Evasion.
 
 //misc
 

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -547,6 +547,7 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define RUNNER_EVASION_DURATION_WARNING		0.7 //After what % of Evasion's time elapsed do we warn the user
 #define RUNNER_EVASION_RUN_DELAY			0.5 SECONDS //If the time since the Runner last moved is equal to or greater than this, its Evasion ends.
 #define RUNNER_EVASION_DANGER_RATIO			0.5 //If we have this % of auto-dodge damage remaining or less, warn the user.
+#define RUNNER_BURN_DEPLETION_MODIFIER		4 //We lose Evasion stacks per life tick equal to damage from burning times this amount
 
 //misc
 

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -544,8 +544,7 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 //Runner defines
 #define RUNNER_EVASION_DURATION						2 SECONDS //How long Evasion lasts.
 #define RUNNER_EVASION_RUN_DELAY					0.5 SECONDS //If the time since the Runner last moved is equal to or greater than this, its Evasion ends.
-#define RUNNER_EVASION_BURN_DEPLETION_MODIFIER		4 //We lose Evasion stacks per life tick equal to damage from burning times this amount
-#define RUNNER_EVASION_COOLDOWN_REFRESH_THRESHOLD	120 //If we dodge this much damage while evading, refresh the cooldown of Evasion.
+#define RUNNER_EVASION_COOLDOWN_REFRESH_THRESHOLD	120 //If we dodge this much damage times our streak count plus 1 while evading, refresh the cooldown of Evasion.
 
 //misc
 

--- a/code/datums/keybinding/xeno.dm
+++ b/code/datums/keybinding/xeno.dm
@@ -407,7 +407,7 @@
 
 /datum/keybinding/xeno/evasion
 	name = "evasion"
-	full_name = "Evasion"
+	full_name = "Runner: Evasion"
 	description = "Take evasive action, forcing non-friendly projectiles that would hit you to miss so long as you keep moving."
 	keybind_signal = COMSIG_XENOABILITY_EVASION
 

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -25,10 +25,6 @@
 	var/traumatic_shock = 0
 	var/shock_stage = 0
 
-	//Stagger vars
-	var/slowdown = 0 //Temporary penalty on movement. Regenerates each tick.
-	var/stagger = 0 //Temporary inability to use special actions; hurts accuracy. Regenerates each tick.
-
 	var/losebreath = 0
 	var/nutrition = NUTRITION_WELLFED
 

--- a/code/modules/mob/living/carbon/carbon_status_procs.dm
+++ b/code/modules/mob/living/carbon/carbon_status_procs.dm
@@ -10,32 +10,6 @@
 /mob/living/carbon/proc/set_stagger(amount)
 	stagger = max(amount, 0)
 
-
-/mob/living/carbon/proc/set_slowdown(amount)
-	if(slowdown == amount)
-		return
-	slowdown = amount
-	if(slowdown)
-		add_movespeed_modifier(MOVESPEED_ID_STAGGERSTUN, TRUE, 0, NONE, TRUE, slowdown)
-		return
-	remove_movespeed_modifier(MOVESPEED_ID_STAGGERSTUN)
-
-/mob/living/carbon/proc/adjust_slowdown(amount)
-	if(amount > 0)
-		set_slowdown(max(slowdown, amount)) //Slowdown overlaps rather than stacking.
-	else
-		set_slowdown(max(slowdown + amount, 0))
-	return slowdown
-
-/mob/living/carbon/add_slowdown(amount)
-	adjust_slowdown(amount * STANDARD_SLOWDOWN_REGEN)
-
-/mob/living/carbon/xenomorph/add_slowdown(amount)
-	if(is_charging >= CHARGE_ON) //If we're charging we're immune to slowdown.
-		return
-	adjust_slowdown(amount * XENO_SLOWDOWN_REGEN)
-
-
 /mob/living/carbon/proc/adjust_nutrition(amount)
 	. = nutrition
 	nutrition = max(nutrition + amount, 0)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -164,23 +164,7 @@
 			reagent_shock_modifier += PAIN_REDUCTION_HEAVY
 
 	handle_stagger()
-	handle_slowdown()
 	handle_disabilities()
-
-
-/mob/living/carbon/proc/handle_stagger()
-	if(stagger)
-		adjust_stagger(-1)
-	return stagger
-
-/mob/living/carbon/adjust_stagger(amount)
-	stagger = max(stagger + amount,0)
-	return stagger
-
-/mob/living/carbon/proc/handle_slowdown()
-	if(slowdown)
-		adjust_slowdown(-STANDARD_SLOWDOWN_REGEN)
-	return slowdown
 
 /mob/living/carbon/proc/breathe()
 	if(!need_breathe())

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -337,7 +337,7 @@
 		evasion_stacks += proj.damage //Add to evasion stacks for the purposes of determining whether or not our cooldown refreshes
 
 	var/evasion_stack_target = RUNNER_EVASION_COOLDOWN_REFRESH_THRESHOLD * (1 + evasion_streak) //Each streak increases the amount we have to dodge by the initial value
-	R.visible_message("<span class='warning'>[name] effortlessly dodges the [proj.name]!</span>", \
+	R.visible_message("<span class='warning'>[R] effortlessly dodges the [proj.name]!</span>", \
 	"<span class='xenodanger'>We effortlessly dodge the [proj.name]![(evasion_stack_target - evasion_stacks) > 0 ? " We must dodge [evasion_stack_target - evasion_stacks] more projectile damage before Evasion's cooldown refreshes." : ""]</span>")
 
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -206,6 +206,27 @@
 	cooldown_timer = 30 SECONDS
 	keybind_signal = COMSIG_XENOABILITY_EVASION
 
+/datum/action/xeno_action/evasion/give_action(mob/living/L)
+	. = ..()
+	RegisterSignal(L, list(COMSIG_LIVING_STATUS_STUN,
+		COMSIG_LIVING_STATUS_KNOCKDOWN,
+		COMSIG_LIVING_STATUS_PARALYZE,
+		COMSIG_LIVING_STATUS_IMMOBILIZE,
+		COMSIG_LIVING_STATUS_UNCONSCIOUS,
+		COMSIG_LIVING_STATUS_SLEEP,
+		COMSIG_LIVING_STATUS_STAGGER), .proc/evasion_debuff_check)
+
+/datum/action/xeno_action/stealth/remove_action(mob/living/L)
+	UnregisterSignal(L, list(
+		COMSIG_LIVING_STATUS_STUN,
+		COMSIG_LIVING_STATUS_KNOCKDOWN,
+		COMSIG_LIVING_STATUS_PARALYZE,
+		COMSIG_LIVING_STATUS_IMMOBILIZE,
+		COMSIG_LIVING_STATUS_UNCONSCIOUS,
+		COMSIG_LIVING_STATUS_SLEEP,
+		COMSIG_LIVING_STATUS_STAGGER))
+	return ..()
+
 
 /datum/action/xeno_action/evasion/action_activate()
 	var/mob/living/carbon/xenomorph/runner/R = owner
@@ -225,9 +246,16 @@
 	SSblackbox.record_feedback("tally", "round_statistics", 1, "runner_evasions") //Statistics
 	add_cooldown()
 
+/datum/action/xeno_action/evasion/proc/evasion_debuff_check(amount)
+	SIGNAL_HANDLER
+	var/mob/living/carbon/xenomorph/runner/R = owner
+	if(!amount || !R.evasion_stacks) //We actually have to gain debuff stacks/duration
+		return
+	to_chat(owner, "<span class='highdanger'>Our movements have been interrupted!</span>")
+	evasion_deactivate()
+
 
 /datum/action/xeno_action/evasion/proc/evasion_deactivate()
-
 	var/mob/living/carbon/xenomorph/runner/R = owner
 	if(R.evasion_stacks) //If our evasion stacks are already depleted, don't tell us again.
 		R.evasion_stacks = 0

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -237,12 +237,12 @@
 
 	R.do_jitter_animation(1000)
 	R.visible_message("<span class='warning'>[R.name] begins to move erratically!</span>", \
-	"<span class='xenodanger'>We move erratically, making us impossible to hit with projectiles; the next [RUNNER_EVASION_STACKS] projectile damage that would hit us will now miss.</span>")
+	"<span class='xenodanger'>We move erratically, making us impossible to hit with projectiles; the next [R.xeno_caste.maturity_evasion_stacks] projectile damage that would hit us will now miss.</span>")
 
-	addtimer(CALLBACK(src, .proc/evasion_warning), RUNNER_EVASION_DURATION * RUNNER_EVASION_DURATION_WARNING) //Warn the runner when the duration is about to expire.
+	addtimer(CALLBACK(src, .proc/evasion_warning), RUNNER_EVASION_DURATION - RUNNER_EVASION_DURATION_WARNING) //Warn the runner when the duration is about to expire.
 	addtimer(CALLBACK(src, .proc/evasion_deactivate), RUNNER_EVASION_DURATION)
 
-	R.evasion_stacks = RUNNER_EVASION_STACKS
+	R.evasion_stacks = R.xeno_caste.maturity_evasion_stacks
 
 	succeed_activate()
 
@@ -290,7 +290,7 @@
 	if(!R.evasion_stacks) //Check to see if we actually have any evasion stacks remaining.
 		return
 
-	to_chat(owner,"<span class='highdanger'>We begin to slow down as we tire. We can only keep this up for [RUNNER_EVASION_DURATION * (1-RUNNER_EVASION_DURATION_WARNING) * 0.1] more seconds!</span>")
+	to_chat(owner,"<span class='highdanger'>We begin to slow down as we tire. We can only keep this up for [RUNNER_EVASION_DURATION_WARNING * 0.1] more seconds!</span>")
 	owner.playsound_local(owner, 'sound/voice/hiss4.ogg', 50, 0, 1)
 
 
@@ -324,7 +324,7 @@
 		A.dir = src.dir //match the direction of the runner
 		i++
 
-	if(evasion_stacks > RUNNER_EVASION_DANGER_RATIO * RUNNER_EVASION_STACKS) //We have more evasion stacks than needed to trigger alerts.
+	if(evasion_stacks > RUNNER_EVASION_DANGER_RATIO * xeno_caste.maturity_evasion_stacks) //We have more evasion stacks than needed to trigger alerts.
 		return FALSE
 
 	to_chat(src, "<span class='highdanger'>We [evasion_stacks > 0 ? "can dodge only [evasion_stacks] more projectile damage!" : "can't dodge any more projectile damage!"] </span>")

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -328,7 +328,7 @@
 		return TRUE
 
 	if(R.issamexenohive(proj.firer)) //We automatically dodge allied projectiles at no cost, and no benefit to our evasion stacks
-		return COMPONENT_EVASION_DODGE
+		return COMPONENT_PROJECTILE_DODGE
 
 	if(proj.ammo.flags_ammo_behavior & AMMO_FLAME) //We can't dodge literal fire
 		return TRUE
@@ -338,7 +338,7 @@
 
 	var/evasion_stack_target = RUNNER_EVASION_COOLDOWN_REFRESH_THRESHOLD * (1 + evasion_streak) //Each streak increases the amount we have to dodge by the initial value
 	R.visible_message("<span class='warning'>[R] effortlessly dodges the [proj.name]!</span>", \
-	"<span class='xenodanger'>We effortlessly dodge the [proj.name]![(evasion_stack_target - evasion_stacks) > 0 ? " We must dodge [evasion_stack_target - evasion_stacks] more projectile damage before Evasion's cooldown refreshes." : ""]</span>")
+	"<span class='xenodanger'>We effortlessly dodge the [proj.name]![(evasion_stack_target - evasion_stacks) > 0 ? " We must dodge [evasion_stack_target - evasion_stacks] more projectile damage before [src]'s cooldown refreshes." : ""]</span>")
 
 
 	R.add_filter("runner_evasion", 2, list("type" = "blur", 5)) //Cool SFX
@@ -363,4 +363,4 @@
 		if(evasion_streak > 3) //Easter egg shoutout
 			to_chat(R, "<span class='xenodanger'>Damn we're good.</span>")
 
-	return COMPONENT_EVASION_DODGE
+	return COMPONENT_PROJECTILE_DODGE

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -203,7 +203,7 @@
 	action_icon_state = "evasion"
 	mechanics_text = "Take evasive action, forcing non-friendly projectiles that would hit you to miss for a short duration so long as you keep moving."
 	plasma_cost = 10
-	cooldown_timer = 8 SECONDS
+	cooldown_timer = 10 SECONDS
 	keybind_signal = COMSIG_XENOABILITY_EVASION
 	///Whether evasion is currently active
 	var/evade_active = FALSE
@@ -340,7 +340,7 @@
 	if(!(proj.ammo.flags_ammo_behavior & AMMO_SENTRY)) //We ignore projectiles from automated sources/sentries for the purpose of contributions towards our cooldown refresh
 		R.evasion_stacks += proj.damage //Add to evasion stacks for the purposes of determining whether or not our cooldown refreshes
 
-	var/evasion_stack_target = RUNNER_EVASION_COOLDOWN_REFRESH_THRESHOLD * (1 + evasion_streak * 0.5)
+	var/evasion_stack_target = RUNNER_EVASION_COOLDOWN_REFRESH_THRESHOLD * (1 + evasion_streak) //Each streak increases the amount we have to dodge by the initial value
 	R.visible_message("<span class='warning'>[name] effortlessly dodges the [proj.name]!</span>", \
 	"<span class='xenodanger'>We effortlessly dodge the [proj.name]![(evasion_stack_target - R.evasion_stacks) > 0 ? " We must dodge [evasion_stack_target - R.evasion_stacks] more projectile damage before Evasion's cooldown refreshes." : ""]</span>")
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -203,7 +203,7 @@
 	action_icon_state = "evasion"
 	mechanics_text = "Take evasive action, forcing non-friendly projectiles that would hit you to miss for a short duration so long as you keep moving."
 	plasma_cost = 10
-	cooldown_timer = 6 SECONDS
+	cooldown_timer = 8 SECONDS
 	keybind_signal = COMSIG_XENOABILITY_EVASION
 	var/evade_active = FALSE
 
@@ -212,15 +212,13 @@
 
 	if(evade_active) //Can't evade while we're already evading.
 		if(!silent)
-			to_chat(owner, "<span class='xenowarning'>We're already taking evasive action!</span>")
+			to_chat(owner, "<span class='xenodanger'>We're already taking evasive action!</span>")
 		return FALSE
 
 /datum/action/xeno_action/evasion/action_activate()
 	var/mob/living/carbon/xenomorph/runner/R = owner
 
-	R.do_jitter_animation(1000)
-	R.visible_message("<span class='warning'>[R.name] begins to move erratically!</span>", \
-	"<span class='xenodanger'>We move erratically, making us impossible to hit with projectiles for the next [RUNNER_EVASION_DURATION * 0.1] seconds.</span>")
+	to_chat(R, "<span class='highdanger'>We take evasive action, making us impossible to hit with projectiles for the next [RUNNER_EVASION_DURATION * 0.1] seconds.</span>")
 
 	addtimer(CALLBACK(src, .proc/evasion_deactivate), RUNNER_EVASION_DURATION)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
@@ -34,9 +34,6 @@
 	evolution_threshold = 80
 	upgrade_threshold = 60
 
-	// *** Runner Abilities *** //
-	maturity_evasion_stacks = 175 //Defines the number of evasion stacks the runner gets when using evasion.
-
 	evolves_to = list(
 		/mob/living/carbon/xenomorph/hunter,
 		/mob/living/carbon/xenomorph/bull,
@@ -92,9 +89,6 @@
 	// *** Evolution *** //
 	upgrade_threshold = 120
 
-	// *** Runner Abilities *** //
-	maturity_evasion_stacks = 200
-
 	// *** Defense *** //
 	soft_armor = list("melee" = 10, "bullet" = 10, "laser" = 10, "energy" = 10, "bomb" = XENO_BOMB_RESIST_0, "bio" = 3, "rad" = 3, "fire" = 10, "acid" = 3)
 
@@ -127,9 +121,6 @@
 
 	// *** Evolution *** //
 	upgrade_threshold = 240
-
-	// *** Runner Abilities *** //
-	maturity_evasion_stacks = 225
 
 	// *** Defense *** //
 	soft_armor = list("melee" = 15, "bullet" = 15, "laser" = 15, "energy" = 15, "bomb" = XENO_BOMB_RESIST_0, "bio" = 5, "rad" = 5, "fire" = 15, "acid" = 5)
@@ -164,9 +155,6 @@
 
 	// *** Evolution *** //
 	upgrade_threshold = 240
-
-	// *** Runner Abilities *** //
-	maturity_evasion_stacks = 240
 
 	// *** Defense *** //
 	soft_armor = list("melee" = 19, "bullet" = 19, "laser" = 19, "energy" = 19, "bomb" = XENO_BOMB_RESIST_0, "bio" = 7, "rad" = 7, "fire" = 19, "acid" = 7)

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
@@ -35,7 +35,7 @@
 	upgrade_threshold = 60
 
 	// *** Runner Abilities *** //
-	maturity_evasion_stacks = 150 //Defines the number of evasion stacks the runner gets when using evasion.
+	maturity_evasion_stacks = 175 //Defines the number of evasion stacks the runner gets when using evasion.
 
 	evolves_to = list(
 		/mob/living/carbon/xenomorph/hunter,
@@ -93,7 +93,7 @@
 	upgrade_threshold = 120
 
 	// *** Runner Abilities *** //
-	maturity_evasion_stacks = 175
+	maturity_evasion_stacks = 200
 
 	// *** Defense *** //
 	soft_armor = list("melee" = 10, "bullet" = 10, "laser" = 10, "energy" = 10, "bomb" = XENO_BOMB_RESIST_0, "bio" = 3, "rad" = 3, "fire" = 10, "acid" = 3)
@@ -129,7 +129,7 @@
 	upgrade_threshold = 240
 
 	// *** Runner Abilities *** //
-	maturity_evasion_stacks = 200
+	maturity_evasion_stacks = 225
 
 	// *** Defense *** //
 	soft_armor = list("melee" = 15, "bullet" = 15, "laser" = 15, "energy" = 15, "bomb" = XENO_BOMB_RESIST_0, "bio" = 5, "rad" = 5, "fire" = 15, "acid" = 5)
@@ -166,7 +166,7 @@
 	upgrade_threshold = 240
 
 	// *** Runner Abilities *** //
-	maturity_evasion_stacks = 225
+	maturity_evasion_stacks = 240
 
 	// *** Defense *** //
 	soft_armor = list("melee" = 19, "bullet" = 19, "laser" = 19, "energy" = 19, "bomb" = XENO_BOMB_RESIST_0, "bio" = 7, "rad" = 7, "fire" = 19, "acid" = 7)

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
@@ -34,6 +34,9 @@
 	evolution_threshold = 80
 	upgrade_threshold = 60
 
+	// *** Runner Abilities *** //
+	maturity_evasion_stacks = 150 //Defines the number of evasion stacks the runner gets when using evasion.
+
 	evolves_to = list(
 		/mob/living/carbon/xenomorph/hunter,
 		/mob/living/carbon/xenomorph/bull,
@@ -89,6 +92,9 @@
 	// *** Evolution *** //
 	upgrade_threshold = 120
 
+	// *** Runner Abilities *** //
+	maturity_evasion_stacks = 175
+
 	// *** Defense *** //
 	soft_armor = list("melee" = 10, "bullet" = 10, "laser" = 10, "energy" = 10, "bomb" = XENO_BOMB_RESIST_0, "bio" = 3, "rad" = 3, "fire" = 10, "acid" = 3)
 
@@ -121,6 +127,9 @@
 
 	// *** Evolution *** //
 	upgrade_threshold = 240
+
+	// *** Runner Abilities *** //
+	maturity_evasion_stacks = 200
 
 	// *** Defense *** //
 	soft_armor = list("melee" = 15, "bullet" = 15, "laser" = 15, "energy" = 15, "bomb" = XENO_BOMB_RESIST_0, "bio" = 5, "rad" = 5, "fire" = 15, "acid" = 5)
@@ -155,6 +164,9 @@
 
 	// *** Evolution *** //
 	upgrade_threshold = 240
+
+	// *** Runner Abilities *** //
+	maturity_evasion_stacks = 225
 
 	// *** Defense *** //
 	soft_armor = list("melee" = 19, "bullet" = 19, "laser" = 19, "energy" = 19, "bomb" = XENO_BOMB_RESIST_0, "bio" = 7, "rad" = 7, "fire" = 19, "acid" = 7)

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -167,6 +167,10 @@
 	///Amount of leaders allowed
 	var/queen_leader_limit = 0
 
+	// *** Runner Abilities *** //
+	///Number of Evasion stacks gained per maturity level
+	var/maturity_evasion_stacks = 0
+
 	///the 'abilities' available to a caste.
 	var/list/actions
 

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -167,10 +167,6 @@
 	///Amount of leaders allowed
 	var/queen_leader_limit = 0
 
-	// *** Runner Abilities *** //
-	///Number of Evasion stacks gained per maturity level
-	var/maturity_evasion_stacks = 0
-
 	///the 'abilities' available to a caste.
 	var/list/actions
 

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -296,8 +296,6 @@
 	//Runner vars
 	var/savage = FALSE
 	var/savage_used = FALSE
-	///Defines how much projectile damage evasion can still absorb
-	var/evasion_stacks = 0
 
 	// *** Ravager vars *** //
 	var/ignore_pain = FALSE // when true the rav will not go into crit or take crit damage.

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -652,3 +652,13 @@
 	if(.)
 		return
 	return (sunder * -0.01) + 1
+
+/mob/living/carbon/xenomorph/adjust_stagger(amount)
+	if(is_charging >= CHARGE_ON) //If we're charging we don't accumulate more stagger stacks.
+		return FALSE
+	return ..()
+
+/mob/living/carbon/xenomorph/add_slowdown(amount)
+	if(is_charging >= CHARGE_ON) //If we're charging we're immune to slowdown.
+		return
+	adjust_slowdown(amount * XENO_SLOWDOWN_REGEN)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -18,7 +18,8 @@
 	handle_drugged()
 	handle_stuttering()
 	handle_slurring()
-
+	handle_slowdown()
+	handle_stagger()
 
 /mob/living/proc/handle_organs()
 	reagent_shock_modifier = 0
@@ -52,12 +53,6 @@
 /mob/living/proc/handle_regular_hud_updates()
 	if(!client)
 		return FALSE
-
-/mob/living/proc/add_slowdown(amount)
-	return
-
-/mob/living/proc/adjust_stagger(amount)
-	return
 
 /mob/living/proc/updatehealth()
 	if(status_flags & GODMODE)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -119,3 +119,7 @@
 
 	/// How much friendly fire damage has this mob done in the last 30 seconds.
 	var/list/friendly_fire = list()
+
+	//Stagger and slow vars
+	var/slowdown = 0 //Temporary penalty on movement. Regenerates each tick.
+	var/stagger = 0 //Temporary inability to use special actions; hurts projectile damage. Regenerates each tick.

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -121,5 +121,7 @@
 	var/list/friendly_fire = list()
 
 	///Stagger and slow vars; Stagger penalizes projectile damage for non-Xenos and disables ability use for Xenos. Slowdown is obvious.
-	var/slowdown = 0 //Temporary penalty on movement. Regenerates each tick.
-	var/stagger = 0 //Temporary inability to use special actions; hurts projectile damage. Regenerates each tick.
+	///Temporary penalty on movement. Regenerates each tick.
+	var/slowdown = 0
+	///Temporary inability to use special actions; hurts projectile damage. Regenerates each tick.
+	var/stagger = 0

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -120,6 +120,6 @@
 	/// How much friendly fire damage has this mob done in the last 30 seconds.
 	var/list/friendly_fire = list()
 
-	//Stagger and slow vars
+	///Stagger and slow vars; Stagger penalizes projectile damage for non-Xenos and disables ability use for Xenos. Slowdown is obvious.
 	var/slowdown = 0 //Temporary penalty on movement. Regenerates each tick.
 	var/stagger = 0 //Temporary inability to use special actions; hurts projectile damage. Regenerates each tick.

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -643,6 +643,7 @@
 		return
 	remove_movespeed_modifier(MOVESPEED_ID_STAGGERSTUN)
 
+///This is where we normalize the set_slowdown input to be at least 0
 /mob/living/proc/adjust_slowdown(amount)
 	if(amount > 0)
 		set_slowdown(max(slowdown, amount)) //Slowdown overlaps rather than stacking.

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -609,6 +609,7 @@
 
 ////////////////////////////// STAGGER ////////////////////////////////////
 
+///Returns number of stagger stacks if any
 /mob/living/proc/IsStaggered() //If we're staggered
 	return stagger
 
@@ -617,6 +618,7 @@
 		adjust_stagger(-1)
 	return stagger
 
+///Where the magic happens. Actually applies stagger stacks.
 /mob/living/proc/adjust_stagger(amount, ignore_canstun = FALSE)
 	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_STUN, amount, ignore_canstun) & COMPONENT_NO_STUN) //Stun immunity also provides immunity to its lesser cousin stagger
 		return
@@ -630,9 +632,11 @@
 
 ////////////////////////////// SLOW ////////////////////////////////////
 
+///Returns number of slowdown stacks if any
 /mob/living/proc/IsSlowed() //If we're slowed
 	return slowdown
 
+///Where the magic happens. Actually applies slow stacks.
 /mob/living/proc/set_slowdown(amount)
 	if(slowdown == amount)
 		return

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -613,6 +613,7 @@
 /mob/living/proc/IsStaggered() //If we're staggered
 	return stagger
 
+///Standard stagger regen called by life.dm
 /mob/living/proc/handle_stagger()
 	if(stagger)
 		adjust_stagger(-1)
@@ -624,11 +625,6 @@
 		return
 	stagger = max(stagger + amount,0)
 	return stagger
-
-/mob/living/carbon/xenomorph/adjust_stagger(amount)
-	if(is_charging >= CHARGE_ON) //If we're charging we don't accumulate more stagger stacks.
-		return FALSE
-	return ..()
 
 ////////////////////////////// SLOW ////////////////////////////////////
 
@@ -657,11 +653,7 @@
 /mob/living/proc/add_slowdown(amount)
 	adjust_slowdown(amount * STANDARD_SLOWDOWN_REGEN)
 
-/mob/living/carbon/xenomorph/add_slowdown(amount)
-	if(is_charging >= CHARGE_ON) //If we're charging we're immune to slowdown.
-		return
-	adjust_slowdown(amount * XENO_SLOWDOWN_REGEN)
-
+///Standard slowdown regen called by life.dm
 /mob/living/proc/handle_slowdown()
 	if(slowdown)
 		adjust_slowdown(-STANDARD_SLOWDOWN_REGEN)

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -941,7 +941,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 /datum/ammo/bullet/turret
 	name = "autocannon bullet"
 	icon_state 	= "redbullet" //Red bullets to indicate friendly fire restriction
-	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
+	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING|AMMO_SENTRY
 	accurate_range = 10
 	accuracy_var_low = 3
 	accuracy_var_high = 3

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1618,12 +1618,15 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	var/fire_delay = 20
 
 /datum/ammo/flamethrower/on_hit_mob(mob/M,obj/projectile/P)
+	SEND_SIGNAL(M, COMSIG_ATOM_FLAMER_HIT, M, P)
 	drop_flame(get_turf(P))
 
 /datum/ammo/flamethrower/on_hit_obj(obj/O,obj/projectile/P)
+	SEND_SIGNAL(O, COMSIG_ATOM_FLAMER_HIT, O, P)
 	drop_flame(get_turf(P))
 
 /datum/ammo/flamethrower/on_hit_turf(turf/T,obj/projectile/P)
+	SEND_SIGNAL(T, COMSIG_ATOM_FLAMER_HIT, T, P)
 	drop_flame(get_turf(P))
 
 /datum/ammo/flamethrower/do_at_max_range(obj/projectile/P)

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1607,7 +1607,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	hud_state = "flame"
 	hud_state_empty = "flame_empty"
 	damage_type = BURN
-	flags_ammo_behavior = AMMO_INCENDIARY|AMMO_IGNORE_ARMOR
+	flags_ammo_behavior = AMMO_INCENDIARY|AMMO_IGNORE_ARMOR|AMMO_FLAME
 	armor_type = "fire"
 	max_range = 6
 	damage = 50
@@ -1618,15 +1618,12 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	var/fire_delay = 20
 
 /datum/ammo/flamethrower/on_hit_mob(mob/M,obj/projectile/P)
-	SEND_SIGNAL(M, COMSIG_ATOM_FLAMER_HIT, M, P)
 	drop_flame(get_turf(P))
 
 /datum/ammo/flamethrower/on_hit_obj(obj/O,obj/projectile/P)
-	SEND_SIGNAL(O, COMSIG_ATOM_FLAMER_HIT, O, P)
 	drop_flame(get_turf(P))
 
 /datum/ammo/flamethrower/on_hit_turf(turf/T,obj/projectile/P)
-	SEND_SIGNAL(T, COMSIG_ATOM_FLAMER_HIT, T, P)
 	drop_flame(get_turf(P))
 
 /datum/ammo/flamethrower/do_at_max_range(obj/projectile/P)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -731,6 +731,9 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 
 
 /mob/living/carbon/xenomorph/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)
+	if(SEND_SIGNAL(src, COMSIG_XENO_PROJECTILE_HIT, proj, cardinal_move, uncrossing) & COMPONENT_EVASION_DODGE)
+		return FALSE
+
 	if(proj.ammo.flags_ammo_behavior & AMMO_SKIPS_ALIENS)
 		return FALSE
 	if(mob_size == MOB_SIZE_BIG)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -731,7 +731,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 
 
 /mob/living/carbon/xenomorph/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)
-	if(SEND_SIGNAL(src, COMSIG_XENO_PROJECTILE_HIT, proj, cardinal_move, uncrossing) & COMPONENT_EVASION_DODGE)
+	if(SEND_SIGNAL(src, COMSIG_XENO_PROJECTILE_HIT, proj, cardinal_move, uncrossing) & COMPONENT_PROJECTILE_DODGE)
 		return FALSE
 
 	if(proj.ammo.flags_ammo_behavior & AMMO_SKIPS_ALIENS)


### PR DESCRIPTION
## About The Pull Request

1. Evasion is now stopped by debuffs such as stagger and stun.

2. Partial refactor and standardization of stagger and slow so they're not arbitrary constrained to carbons; was done in the process of creating and adding signals for Stagger to trigger cancellation of Evasion.

3. Evasion now lasts 2 seconds down from 8.

4. Evasion cooldown is now 10 seconds down from 30.

5. Evasion's plasma cost is now 10 down from 20.

6. Evasion stacks are no longer depleted; as long as Evasion is active, the user dodges all projectiles. Instead, the Evasion user now accumulates Evasion stacks while dodging equal to projectile damage avoided during Evasion. At 120+ stacks, Evasion's current cooldown resets. Projectiles from sentries/automated sources don't contribute to Evasion stacks accumulated in this way.

7. Each time you clear Evasion's cooldown by dodging damage, the amount of damage you must dodge to clear its cooldown increases by 100% of the base amount. This increase is cumulative and resets when its cooldown clears normally.

7. Burning now zeroes out Evasion stacks, and prevents their accumulation.

8. Flamer direct hits now sharply reduce Evasion stacks.

## Why It's Good For The Game

Gives an additional counter to Evasion.

Standardizes stagger and slow.

Makes Evasion require more skill to use well, as its duration is extremely short, and one must carefully time its use in order to chain it through cooldown resets rewarded for projectile damage dodged.

Hopefully stops a couple of people from complaining to me on discord.

## Changelog
:cl:
tweak: Evasion can now be forcibly cancelled by stagger, stun and other immobilizing debuffs. 
tweak: Burning now zeroes out Evasion stacks, and prevents their accumulation.
tweak: Flamer direct hits now deplete Evasion stacks.
balance: Evasion duration reduced to 2 seconds. Cooldown reduced from 30 seconds to 10 seconds. Plasma cost reduced from 20 to 10.
balance: Evasion no longer has a cap on projectile damage it can dodge now; instead the user accumulates Evasion Stacks equal to projectile damage dodged while Evasion is active. If 120+ stacks are accumulated during the same Evasion duration, its current cooldown resets.
balance: Each time you clear Evasion's cooldown by dodging damage, the amount of damage you must dodge to clear its cooldown increases by 100% of the base amount. This increase is cumulative and resets when its cooldown clears normally.
refactor: Slow and stagger statuses partially refactored and standardized.
/:cl:

https://cdn.discordapp.com/attachments/504094319075131402/785830130508627978/unknown.png