### PR TITLE
Removes Xeno and Marine minors.

### DIFF
--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -49,8 +49,6 @@
 
 #define MODE_INFESTATION_X_MAJOR		"Xenomorph Major Victory"
 #define MODE_INFESTATION_M_MAJOR		"Marine Major Victory"
-#define MODE_INFESTATION_X_MINOR		"Xenomorph Minor Victory"
-#define MODE_INFESTATION_M_MINOR		"Marine Minor Victory"
 #define MODE_INFESTATION_DRAW_DEATH		"DRAW: Mutual Annihilation"
 #define MODE_INFESTATION_DRAW_RETREAT	"DRAW: Marine Retreat"
 
@@ -64,16 +62,12 @@
 // Crash gamemode
 #define MODE_CRASH_X_MAJOR		"Xenomorph Major Victory"
 #define MODE_CRASH_M_MAJOR		"Marine Major Victory"
-#define MODE_CRASH_X_MINOR		"Xenomorph Minor Victory"
-#define MODE_CRASH_M_MINOR		"Marine Minor Victory"
 #define MODE_CRASH_DRAW_DEATH	"DRAW: Mutual Annihilation"
 #define MODE_GENERIC_DRAW_NUKE			"DRAW: Nuclear Explosion"
 
 #define CRASH_DRAW (1 << 0)
 #define CRASH_XENO_MAJOR (1 << 1)
-#define CRASH_XENO_MINOR (1 << 2)
-#define CRASH_MARINE_MINOR (1 << 3)
-#define CRASH_MARINE_MAJOR (1 << 4)
+#define CRASH_MARINE_MAJOR (1 << 2)
 
 #define CRASH_EVAC_NONE "CRASH_EVAC_NONE"
 #define CRASH_EVAC_INPROGRESS "CRASH_EVAC_INPROGRESS"

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -161,12 +161,12 @@
 	var/victory_options = ((planet_nuked == CRASH_NUKE_NONE && marines_evac == CRASH_EVAC_NONE) && (num_humans == 0 && num_xenos == 0)) << 0
 	// XENO Major (All marines killed)
 	victory_options |= (planet_nuked == CRASH_NUKE_NONE && num_humans == 0 && num_xenos > 0) << 1
-	// Draw, (Marines evac'd for over 5 mins without a nuke)
-	victory_options |= (planet_nuked == CRASH_NUKE_NONE && (marines_evac == CRASH_EVAC_COMPLETED || (!length(GLOB.active_nuke_list) && marines_evac != CRASH_EVAC_NONE)))	<< 2
+	// Xeno Major, (Marines evac'd for over 5 mins without a nuke)
+	victory_options |= (planet_nuked == CRASH_NUKE_NONE && (marines_evac == CRASH_EVAC_COMPLETED || (!length(GLOB.active_nuke_list) && marines_evac != CRASH_EVAC_NONE)))	<< 1
 	// Draw, (Planet nuked, no one evac'd)
-	victory_options |= (planet_nuked == CRASH_NUKE_COMPLETED && marines_evac == CRASH_EVAC_NONE) << 3
+	victory_options |= (planet_nuked == CRASH_NUKE_COMPLETED && marines_evac == CRASH_EVAC_NONE) << 0
 	// Marine Major (Planet nuked, marines evac, or they wiped the xenos out)
-	victory_options |= ((planet_nuked == CRASH_NUKE_COMPLETED && marines_evac != CRASH_EVAC_NONE) || (planet_nuked == CRASH_NUKE_NONE && num_xenos == 0)) << 4
+	victory_options |= ((planet_nuked == CRASH_NUKE_COMPLETED && marines_evac != CRASH_EVAC_NONE) || (planet_nuked == CRASH_NUKE_NONE && num_xenos == 0)) << 2
 
 	switch(victory_options)
 		if(CRASH_DRAW)

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -5,7 +5,7 @@
 	flags_round_type = MODE_INFESTATION|MODE_XENO_SPAWN_PROTECT
 	flags_landmarks = MODE_LANDMARK_SPAWN_XENO_TUNNELS|MODE_LANDMARK_SPAWN_MAP_ITEM
 
-	round_end_states = list(MODE_CRASH_X_MAJOR, MODE_CRASH_M_MAJOR, MODE_CRASH_X_MINOR, MODE_CRASH_M_MINOR, MODE_CRASH_DRAW_DEATH)
+	round_end_states = list(MODE_CRASH_X_MAJOR, MODE_CRASH_M_MAJOR, MODE_CRASH_DRAW_DEATH)
 	deploy_time_lock = 45 MINUTES
 
 	squads_max_number = 1
@@ -161,9 +161,9 @@
 	var/victory_options = ((planet_nuked == CRASH_NUKE_NONE && marines_evac == CRASH_EVAC_NONE) && (num_humans == 0 && num_xenos == 0)) << 0
 	// XENO Major (All marines killed)
 	victory_options |= (planet_nuked == CRASH_NUKE_NONE && num_humans == 0 && num_xenos > 0) << 1
-	// XENO Minor (Marines evac'd for over 5 mins without a nuke)
+	// Draw, (Marines evac'd for over 5 mins without a nuke)
 	victory_options |= (planet_nuked == CRASH_NUKE_NONE && (marines_evac == CRASH_EVAC_COMPLETED || (!length(GLOB.active_nuke_list) && marines_evac != CRASH_EVAC_NONE)))	<< 2
-	// Marine minor (Planet nuked, no one evac'd)
+	// Draw, (Planet nuked, no one evac'd)
 	victory_options |= (planet_nuked == CRASH_NUKE_COMPLETED && marines_evac == CRASH_EVAC_NONE) << 3
 	// Marine Major (Planet nuked, marines evac, or they wiped the xenos out)
 	victory_options |= ((planet_nuked == CRASH_NUKE_COMPLETED && marines_evac != CRASH_EVAC_NONE) || (planet_nuked == CRASH_NUKE_NONE && num_xenos == 0)) << 4
@@ -175,12 +175,6 @@
 		if(CRASH_XENO_MAJOR)
 			message_admins("Round finished: [MODE_CRASH_X_MAJOR]")
 			round_finished = MODE_CRASH_X_MAJOR
-		if(CRASH_XENO_MINOR)
-			message_admins("Round finished: [MODE_CRASH_X_MINOR]")
-			round_finished = MODE_CRASH_X_MINOR
-		if(CRASH_MARINE_MINOR)
-			message_admins("Round finished: [MODE_CRASH_M_MINOR]")
-			round_finished = MODE_CRASH_M_MINOR
 		if(CRASH_MARINE_MAJOR)
 			message_admins("Round finished: [MODE_CRASH_M_MAJOR]")
 			round_finished = MODE_CRASH_M_MAJOR
@@ -206,12 +200,6 @@
 		if(MODE_CRASH_M_MAJOR)
 			xeno_track = pick('sound/theme/sad_loss1.ogg','sound/theme/sad_loss2.ogg')
 			human_track = pick('sound/theme/winning_triumph1.ogg','sound/theme/winning_triumph2.ogg')
-		if(MODE_CRASH_X_MINOR)
-			xeno_track = pick('sound/theme/neutral_hopeful1.ogg','sound/theme/neutral_hopeful2.ogg')
-			human_track = pick('sound/theme/neutral_melancholy1.ogg','sound/theme/neutral_melancholy2.ogg')
-		if(MODE_CRASH_M_MINOR)
-			xeno_track = pick('sound/theme/neutral_melancholy1.ogg','sound/theme/neutral_melancholy2.ogg')
-			human_track = pick('sound/theme/neutral_hopeful1.ogg','sound/theme/neutral_hopeful2.ogg')
 		if(MODE_CRASH_DRAW_DEATH)
 			xeno_track = pick('sound/theme/nuclear_detonation1.ogg','sound/theme/nuclear_detonation2.ogg')
 			human_track = pick('sound/theme/nuclear_detonation1.ogg','sound/theme/nuclear_detonation2.ogg')

--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -8,7 +8,7 @@
 	required_players = 2
 	flags_round_type = MODE_INFESTATION|MODE_LZ_SHUTTERS|MODE_XENO_RULER
 	flags_landmarks = MODE_LANDMARK_SPAWN_XENO_TUNNELS|MODE_LANDMARK_SPAWN_MAP_ITEM
-	round_end_states = list(MODE_INFESTATION_X_MAJOR, MODE_INFESTATION_M_MAJOR, MODE_INFESTATION_X_MINOR, MODE_INFESTATION_M_MINOR, MODE_INFESTATION_DRAW_DEATH)
+	round_end_states = list(MODE_INFESTATION_X_MAJOR, MODE_INFESTATION_M_MAJOR, MODE_INFESTATION_DRAW_DEATH)
 
 	valid_job_types = list(
 		/datum/job/terragov/command/captain = 1,
@@ -115,10 +115,10 @@
 		message_admins("Round finished: [MODE_GENERIC_DRAW_NUKE]") //ship blows, no one wins
 		round_finished = MODE_GENERIC_DRAW_NUKE
 		return TRUE
-	
+
 	if(round_stage == DISTRESS_MARINE_RETREAT)
-		message_admins("Round finished: [MODE_INFESTATION_X_MINOR]")
-		round_finished = MODE_INFESTATION_X_MINOR
+		message_admins("Round finished: [MODE_INFESTATION_DRAW_DEATH]")
+		round_finished = MODE_INFESTATION_DRAW_DEATH
 		return TRUE
 
 	if(!num_humans)
@@ -135,8 +135,8 @@
 		return TRUE
 	if(!num_xenos)
 		if(round_stage == DISTRESS_DROPSHIP_CRASHED)
-			message_admins("Round finished: [MODE_INFESTATION_X_MINOR]") //xenos hijacked the shuttle and won groundside but died on the ship, minor victory
-			round_finished = MODE_INFESTATION_X_MINOR
+			message_admins("Round finished: [MODE_INFESTATION_DRAW_DEATH]") //xenos hijacked the shuttle and won groundside but died on the ship, draw
+			round_finished = MODE_INFESTATION_DRAW_DEATH
 			return TRUE
 		message_admins("Round finished: [MODE_INFESTATION_M_MAJOR]") //marines win big or go home
 		round_finished = MODE_INFESTATION_M_MAJOR
@@ -161,13 +161,6 @@
 			xeno_track = pick('sound/theme/sad_loss1.ogg', 'sound/theme/sad_loss2.ogg')
 			human_track = pick('sound/theme/winning_triumph1.ogg', 'sound/theme/winning_triumph2.ogg')
 			ghost_track = human_track
-		if(MODE_INFESTATION_X_MINOR)
-			xeno_track = pick('sound/theme/neutral_hopeful1.ogg', 'sound/theme/neutral_hopeful2.ogg')
-			human_track = pick('sound/theme/neutral_melancholy1.ogg', 'sound/theme/neutral_melancholy2.ogg')
-			ghost_track = xeno_track
-		if(MODE_INFESTATION_M_MINOR)
-			xeno_track = pick('sound/theme/neutral_melancholy1.ogg', 'sound/theme/neutral_melancholy2.ogg')
-			human_track = pick('sound/theme/neutral_hopeful1.ogg', 'sound/theme/neutral_hopeful2.ogg')
 			ghost_track = human_track
 		if(MODE_INFESTATION_DRAW_DEATH)
 			ghost_track = pick('sound/theme/nuclear_detonation1.ogg', 'sound/theme/nuclear_detonation2.ogg')
@@ -276,7 +269,7 @@
 	if(round_finished)
 		return
 	if(round_stage == DISTRESS_DROPSHIP_CRASHED)
-		round_finished = MODE_INFESTATION_M_MINOR
+		round_finished = MODE_INFESTATION_DRAW_DEATH
 		return
 	round_finished = MODE_INFESTATION_M_MAJOR
 

--- a/code/modules/orbits/spaceship.dm
+++ b/code/modules/orbits/spaceship.dm
@@ -162,7 +162,7 @@ GLOBAL_VAR_INIT(current_orbit,STANDARD_ORBIT)
 		priority_announce("The tall hosts are attempting to flee!", "Prey is escaping!", ANNOUNCEMENT_REGULAR, 'sound/voice/alien_drool1.ogg', receivers = GLOB.alive_xeno_list + GLOB.observer_list)
 		do_orbit_checks("escape")
 		TIMER_COOLDOWN_START(src, COOLDOWN_ORBIT_CHANGE, 1 MINUTES)
-		//end the round, xeno minor.
+		//end the round, draw
 
 	updateUsrDialog()
 


### PR DESCRIPTION
## Changelog
:cl:
del: removed xeno and marine minors.
/:cl:


## Why It's Good For The Game

These server as nothing further than a cope and are a big source of toxicity within this community, quite frankly if I could I'd just remove winrates altogether.

What once was a Marine/Xeno Minor now counts as a draw except for Marine evac on crash, that's a Xeno major now.
