### PR TITLE
Fixes tadpole being able to land in underground buildings on magmoor

### DIFF
--- a/code/game/area/magmoor_digsite.dm
+++ b/code/game/area/magmoor_digsite.dm
@@ -112,7 +112,7 @@
 /area/magmoor/medical
 	name = "Medical Clinic"
 	icon_state = "lava_med"
-	ceiling = CEILING_UNDERGROUND_METAL
+	ceiling = CEILING_DEEP_UNDERGROUND_METAL
 
 /area/magmoor/medical/chemistry
 	name = "Medical Clinic Chemistry"
@@ -156,7 +156,7 @@
 /area/magmoor/engi/
 	name = "Engineering"
 	icon_state = "lava_engie"
-	ceiling = CEILING_UNDERGROUND_METAL
+	ceiling = CEILING_DEEP_UNDERGROUND_METAL
 	ambience = list('sound/ambience/ambisin1.ogg', 'sound/ambience/ambisin2.ogg', 'sound/ambience/ambisin3.ogg', 'sound/ambience/ambisin4.ogg')
 
 /area/magmoor/engi/atmos
@@ -253,7 +253,7 @@
 /area/magmoor/research
 	name = "Research & Archaeology"
 	icon_state = "lava_research"
-	ceiling = CEILING_UNDERGROUND_METAL
+	ceiling = CEILING_DEEP_UNDERGROUND_METAL
 	ambience = list('sound/ambience/ambitech.ogg', 'sound/ambience/ambitech2.ogg')
 
 /area/magmoor/research/containment
@@ -358,7 +358,7 @@
 /area/magmoor/mining/
 	name = "Mining Equipment & Break Room"
 	icon_state = "lava_mining"
-	ceiling = CEILING_UNDERGROUND_METAL
+	ceiling = CEILING_DEEP_UNDERGROUND_METAL
 
 /area/magmoor/mining/garage
 	name = "Mining Garage & Storage"


### PR DESCRIPTION

## About The Pull Request
Changes All Engineering , Mining , Medical and Research areas from CEILING_UNDERGROUND_METAL to CEILING_DEEP_UNDERGROUND_METAL
## Why It's Good For The Game
Fixes it landing in unintended places , adds some realism
## Changelog
:cl:
fix: fixed Tadpole being able to land in magmoor underground buildings.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
