### PR TITLE
Acid Wells and Hugger Traps Are Properly Deleted by Shuttle Crushing

### DIFF
--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -129,6 +129,12 @@
 	. = ..()
 	if(builder)
 		linked_carrier = builder
+	RegisterSignal(src, COMSIG_MOVABLE_SHUTTLE_CRUSH, .proc/shuttle_crush)
+
+/obj/effect/alien/resin/trap/proc/shuttle_crush() //No more trapping shuttles with huggies
+	SIGNAL_HANDLER
+	if(hugger)
+		QDEL_NULL(hugger)
 
 /obj/effect/alien/resin/trap/examine(mob/user)
 	. = ..()
@@ -771,9 +777,10 @@ TUNNEL
 		if(A)
 			to_chat(creator, "<span class='xenoannounce'>You sense your acid well at [A.name] has been destroyed!</span>")
 
-	var/datum/effect_system/smoke_spread/xeno/acid/A = new(get_turf(src))
-	A.set_up(clamp(charges,0,2),src)
-	A.start()
+	if(damage_flag) //Spawn the gas only if we actually get destroyed by damage
+		var/datum/effect_system/smoke_spread/xeno/acid/A = new(get_turf(src))
+		A.set_up(clamp(charges,0,2),src)
+		A.start()
 	return ..()
 
 /obj/effect/alien/resin/acidwell/examine(mob/user)

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -133,8 +133,7 @@
 
 /obj/effect/alien/resin/trap/proc/shuttle_crush() //No more trapping shuttles with huggies
 	SIGNAL_HANDLER
-	if(hugger)
-		QDEL_NULL(hugger)
+	QDEL_NULL(hugger)
 
 /obj/effect/alien/resin/trap/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

1. Acid Wells no longer discharge gas when destroyed by shuttle crushing.

2. Hugger Traps no longer discharge huggers when destroyed by shuttle crushing; they're now deleted.

## Why It's Good For The Game

Fixes an exploitative bug used to keep the Tadpole in check and stop its creation and abuse of overpowered checkpoints. Now that we've had map fixes per https://github.com/tgstation/TerraGov-Marine-Corps/pull/5472 , https://github.com/tgstation/TerraGov-Marine-Corps/pull/5471 and https://github.com/tgstation/TerraGov-Marine-Corps/pull/5470 this is no longer needed (mostly).'

Fixes: https://github.com/tgstation/TerraGov-Marine-Corps/issues/5459

## Changelog
:cl:
fix: Acid Wells no longer discharge gas when destroyed by shuttle crushing.
fix: Hugger Traps no longer discharge huggers when destroyed by shuttle crushing.
/:cl: