### PR TITLE
Fixes Xeno overwatch of numbers and space containing names, and delayed hud update

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -287,6 +287,7 @@
 	if(old_xeno)
 		stop_overwatch(FALSE)
 	watcher.observed_xeno = target
+	target.hud_set_queen_overwatch()
 	watcher.reset_perspective()
 	RegisterSignal(target, COMSIG_HIVE_XENO_DEATH, .proc/on_xeno_death)
 	RegisterSignal(target, list(COMSIG_XENOMORPH_EVOLVED, COMSIG_XENOMORPH_DEEVOLVED), .proc/on_xeno_evolution)

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
@@ -107,8 +107,12 @@
 		var/xeno_name = href_list["watch_xeno_name"]
 		for(var/Y in hive.get_watchable_xenos())
 			var/mob/living/carbon/xenomorph/X = Y
-			if(X.nicknumber != xeno_name)
-				continue
+			if(isnum(X.nicknumber))
+				if(num2text(X.nicknumber) != xeno_name)
+					continue
+			else
+				if(X.nicknumber != xeno_name)
+					continue
 			SEND_SIGNAL(src, COMSIG_XENOMORPH_WATCHXENO, X)
 			break
 

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -47,7 +47,7 @@
 		if(ignore_leads && X.queen_chosen_lead)
 			continue
 		if(can_overwatch)
-			xenoinfo += "<tr><td>[leadprefix]<a href=?src=\ref[user];watch_xeno_name=[X.nicknumber]>[X.name]</a> "
+			xenoinfo += "<tr><td>[leadprefix]<a href='byond://?src=\ref[user];watch_xeno_name=[X.nicknumber]'>[X.name]</a> "
 		else
 			xenoinfo += "<tr><td>[leadprefix][X.name] "
 		if(!X.client)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Added a check to prevent comparison between numbers and text data type.

Added the protocol and wrapping quotes to overwatch links href data.

Added a call to `hud_set_queen_overwatch()` when starting overwatch to immediately update the HUD.

## Why It's Good For The Game

Fixes: #5467 

Bug bad, fix good.

## Changelog
:cl:
fix: Fixed Queen overwatch from hive status and chat not working on numbers or names with spaces.
fix: Fixed Xeno HUD for the observed not updating when starting overwatch.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
