### PR TITLE
Neurospit Tweak: Stamina Damage Nerfed, Weak Neurogas Spawn and Neurotoxin Reagent Transfer Added

### DIFF
--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -138,6 +138,7 @@
 #define SMOKE_XENO_HEMODILE (1<<12)
 #define SMOKE_XENO_TRANSVITOX (1<<13)
 #define SMOKE_CHEM			(1<<14)
+#define SMOKE_EXTINGUISH	(1<<15) //Extinguishes fires and mobs that are on fire
 
 //Incapacitated
 #define INCAPACITATED_IGNORE_RESTRAINED (1<<0)

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -553,6 +553,8 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 
 #define HYPERVENE_REMOVAL_AMOUNT	8
 
+#define GAS_INHALE_REAGENT_TRANSFER_AMOUNT	7
+
 // Squad ID defines moved from game\jobs\job\squad.dm
 #define NO_SQUAD 0
 #define ALPHA_SQUAD 1

--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -272,6 +272,12 @@
 	color = "#ffbf58" //Mustard orange?
 	smoke_traits = SMOKE_XENO|SMOKE_XENO_NEURO|SMOKE_GASP|SMOKE_COUGH
 
+//Xeno neurotox smoke.
+/obj/effect/particle_effect/smoke/xeno/neuro/light
+	alpha = 60
+	opacity = FALSE
+	smoke_can_spread_through = TRUE
+
 /obj/effect/particle_effect/smoke/xeno/hemodile
 	alpha = 40
 	opacity = FALSE
@@ -320,6 +326,9 @@ datum/effect_system/smoke_spread/tactical
 
 /datum/effect_system/smoke_spread/xeno/neuro
 	smoke_type = /obj/effect/particle_effect/smoke/xeno/neuro
+
+/datum/effect_system/smoke_spread/xeno/neuro/light
+	smoke_type = /obj/effect/particle_effect/smoke/xeno/neuro/light
 
 /////////////////////////////////////////////
 // Chem smoke

--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -270,13 +270,14 @@
 //Xeno neurotox smoke.
 /obj/effect/particle_effect/smoke/xeno/neuro
 	color = "#ffbf58" //Mustard orange?
-	smoke_traits = SMOKE_XENO|SMOKE_XENO_NEURO|SMOKE_GASP|SMOKE_COUGH
+	smoke_traits = SMOKE_XENO|SMOKE_XENO_NEURO|SMOKE_GASP|SMOKE_COUGH|SMOKE_EXTINGUISH
 
 //Xeno neurotox smoke.
 /obj/effect/particle_effect/smoke/xeno/neuro/light
 	alpha = 60
 	opacity = FALSE
 	smoke_can_spread_through = TRUE
+	smoke_traits = SMOKE_XENO|SMOKE_XENO_NEURO|SMOKE_GASP|SMOKE_COUGH //Light neuro smoke doesn't extinguish
 
 /obj/effect/particle_effect/smoke/xeno/hemodile
 	alpha = 40

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -29,7 +29,7 @@
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_PLASMALOSS))
 		adjustToxLoss(0.25)
 		adjustStaminaLoss(3)
-		blur_eyes(2)	
+		blur_eyes(2)
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO_ACID))
 		adjustOxyLoss(4 + S.strength * 2)
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO_NEURO))
@@ -37,13 +37,13 @@
 			to_chat(src, "<span class='danger'>Your eyes sting. You can't see!</span>")
 		blur_eyes(4)
 		blind_eyes(2)
-		reagents.add_reagent(/datum/reagent/toxin/xeno_neurotoxin, 5 + S.strength * 2)
+		reagents.add_reagent(/datum/reagent/toxin/xeno_neurotoxin, GAS_INHALE_REAGENT_TRANSFER_AMOUNT * S.strength)
 		if(prob(10 * S.strength)) //Likely to momentarily freeze up/fall due to arms/hands seizing up
 			to_chat(src, "<span class='danger'>You feel your body going numb and lifeless!</span>")
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO_HEMODILE))
-		reagents.add_reagent(/datum/reagent/toxin/xeno_hemodile, 5 + S.strength * 2)
+		reagents.add_reagent(/datum/reagent/toxin/xeno_hemodile, GAS_INHALE_REAGENT_TRANSFER_AMOUNT * S.strength)
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO_TRANSVITOX))
-		reagents.add_reagent(/datum/reagent/toxin/xeno_transvitox, 5 + S.strength * 2)
+		reagents.add_reagent(/datum/reagent/toxin/xeno_transvitox, GAS_INHALE_REAGENT_TRANSFER_AMOUNT * S.strength)
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_CHEM))
 		S.pre_chem_effect(src)
 
@@ -51,14 +51,14 @@
 	. = ..()
 	var/protection = .
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO_NEURO) && (internal || has_smoke_protection())) //either inhaled or this.
-		reagents.add_reagent(/datum/reagent/toxin/xeno_neurotoxin, round((3 + S.strength) * protection, 0.1))
+		reagents.add_reagent(/datum/reagent/toxin/xeno_neurotoxin, round(GAS_INHALE_REAGENT_TRANSFER_AMOUNT * 0.6 * S.strength * protection, 0.1))
 		if(prob(10 * S.strength * protection))
 			to_chat(src, "<span class='danger'>Your body goes numb where the gas touches it!</span>")
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO_HEMODILE) && (internal || has_smoke_protection())) //either inhaled or this.
-		reagents.add_reagent(/datum/reagent/toxin/xeno_hemodile, round((3 + S.strength) * protection, 0.1))
+		reagents.add_reagent(/datum/reagent/toxin/xeno_hemodile, round(GAS_INHALE_REAGENT_TRANSFER_AMOUNT * 0.6 * S.strength * protection, 0.1))
 		if(prob(10 * S.strength * protection))
 			to_chat(src, "<span class='danger'>Your muscles' strength drains away where the gas makes contact!</span>")
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO_TRANSVITOX) && (internal || has_smoke_protection())) //either inhaled or this.
-		reagents.add_reagent(/datum/reagent/toxin/xeno_transvitox, round((3 + S.strength) * protection, 0.1))
+		reagents.add_reagent(/datum/reagent/toxin/xeno_transvitox, round(GAS_INHALE_REAGENT_TRANSFER_AMOUNT * 0.6 * S.strength * protection, 0.1))
 		if(prob(10 * S.strength * protection))
 			to_chat(src, "<span class='danger'>Your exposed wounds coagulate with a dark green tint!</span>")

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -35,8 +35,9 @@
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO_NEURO))
 		if(!is_blind(src) && has_eyes())
 			to_chat(src, "<span class='danger'>Your eyes sting. You can't see!</span>")
+		if(!istype(S, /obj/effect/particle_effect/smoke/xeno/neuro/light)) //Only full neurogas blinds
+			blind_eyes(2)
 		blur_eyes(4)
-		blind_eyes(2)
 		reagents.add_reagent(/datum/reagent/toxin/xeno_neurotoxin, GAS_INHALE_REAGENT_TRANSFER_AMOUNT * S.strength)
 		if(prob(10 * S.strength)) //Likely to momentarily freeze up/fall due to arms/hands seizing up
 			to_chat(src, "<span class='danger'>You feel your body going numb and lifeless!</span>")

--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
@@ -105,7 +105,7 @@
 		smoke_range = 3
 	else if(X.selected_reagent == /datum/reagent/toxin/xeno_transvitox)
 		N.smoke_type = /obj/effect/particle_effect/smoke/xeno/transvitox
-		N.strength = -0.75
+		N.strength = 0.75
 		smoke_range = 4
 	while(count)
 		if(X.stagger) //If we got staggered, return

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -248,7 +248,7 @@
 	smoke_delay = FALSE
 
 /mob/living/proc/smoke_contact(obj/effect/particle_effect/smoke/S)
-	var/protection = max(1 - get_permeability_protection() * S.bio_protection)
+	var/protection = max(1 - get_permeability_protection() * S.bio_protection, 0)
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_BLISTERING))
 		adjustFireLoss(15 * protection)
 		to_chat(src, "<span class='danger'>It feels as if you've been dumped into an open fire!</span>")

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -238,6 +238,8 @@
 		smokecloak_on()
 	if(smoke_delay)
 		return FALSE
+	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_EXTINGUISH))
+		ExtinguishMob()
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO) && (stat == DEAD || isnestedhost(src)))
 		return FALSE
 	smoke_delay = TRUE
@@ -249,6 +251,8 @@
 
 /mob/living/proc/smoke_contact(obj/effect/particle_effect/smoke/S)
 	var/protection = max(1 - get_permeability_protection() * S.bio_protection, 0)
+	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_EXTINGUISH))
+		ExtinguishMob()
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_BLISTERING))
 		adjustFireLoss(15 * protection)
 		to_chat(src, "<span class='danger'>It feels as if you've been dumped into an open fire!</span>")

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1351,14 +1351,13 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage = 20
 	stagger_stacks = 1
 	slowdown_stacks = 1
-	smoke_strength = 1
+	smoke_strength = 0.65
 	smoke_range = 0
 	reagent_transfer_amount = 5
 
 /datum/ammo/xeno/toxin/proc/set_reagents()
 	spit_reagents = list(/datum/reagent/toxin/xeno_neurotoxin = reagent_transfer_amount)
-	message_admins("Neuro Amount = [spit_reagents[1]]")
-	message_admins("Reagent Transfer Amount = [reagent_transfer_amount]")
+
 
 /datum/ammo/xeno/toxin/on_hit_mob(mob/living/carbon/C, obj/projectile/P)
 	drop_neuro_smoke(get_turf(C))
@@ -1374,10 +1373,8 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 
 	set_reagents()
 	var/armor_block = 1 - C.run_armor_check(null, armor_type) //Check the target's armor mod
-	message_admins("Armor Block = [armor_block]")
 	for(var/r_id in spit_reagents) //modify by armor
 		spit_reagents[r_id] *= armor_block
-		message_admins("Spit Reagents = [spit_reagents[r_id]]")
 
 	C.reagents.add_reagent_list(spit_reagents) //transfer reagents
 
@@ -1418,15 +1415,15 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	smoke_system.start()
 
 /datum/ammo/xeno/toxin/upgrade1
-	smoke_strength = 1.05
+	smoke_strength = 0.7
 	reagent_transfer_amount = 6
 
 /datum/ammo/xeno/toxin/upgrade2
-	smoke_strength = 1.1
+	smoke_strength = 0.75
 	reagent_transfer_amount = 7
 
 /datum/ammo/xeno/toxin/upgrade3
-	smoke_strength = 1.15
+	smoke_strength = 0.8
 	reagent_transfer_amount = 8
 
 
@@ -1434,19 +1431,19 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	name = "neurotoxic spatter"
 	added_spit_delay = 10
 	spit_cost = 75
-	smoke_strength = 1.05
+	smoke_strength = 0.75
 	reagent_transfer_amount = 6
 
 /datum/ammo/xeno/toxin/medium/upgrade1
-	smoke_strength = 1.1
+	smoke_strength = 0.8
 	reagent_transfer_amount = 7
 
 /datum/ammo/xeno/toxin/medium/upgrade2
-	smoke_strength = 1.15
+	smoke_strength = 0.85
 	reagent_transfer_amount = 8
 
 /datum/ammo/xeno/toxin/medium/upgrade3
-	smoke_strength = 1.2
+	smoke_strength = 0.9
 	reagent_transfer_amount = 9
 
 
@@ -1455,19 +1452,19 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	added_spit_delay = 15
 	spit_cost = 100
 	smoke_range = 1
-	smoke_strength = 1.1
+	smoke_strength = 0.85
 	reagent_transfer_amount = 7
 
 /datum/ammo/xeno/toxin/heavy/upgrade1
-	smoke_strength = 1.15
+	smoke_strength = 0.9
 	reagent_transfer_amount = 8
 
 /datum/ammo/xeno/toxin/heavy/upgrade2
-	smoke_strength = 1.2
+	smoke_strength = 0.95
 	reagent_transfer_amount = 9
 
 /datum/ammo/xeno/toxin/heavy/upgrade3
-	smoke_strength = 1.25
+	smoke_strength = 1
 	reagent_transfer_amount = 10
 
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1331,7 +1331,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	accuracy_var_high = 3
 	bullet_color = COLOR_LIME
 	var/datum/effect_system/smoke_spread/xeno/smoke_system
-	var/list/spit_reagents = new/list()
+	var/list/datum/reagent/spit_reagents = new/list()
 	var/reagent_transfer_amount
 	var/stagger_stacks
 	var/slowdown_stacks
@@ -1344,7 +1344,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	spit_cost = 50
 	added_spit_delay = 5
 	damage_type = STAMINA
-	accurate_range = 7
+	accurate_range = 5
 	max_range = 10
 	accuracy_var_low = 3
 	accuracy_var_high = 3
@@ -1357,7 +1357,6 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 
 /datum/ammo/xeno/toxin/proc/set_reagents()
 	spit_reagents = list(/datum/reagent/toxin/xeno_neurotoxin = reagent_transfer_amount)
-
 
 /datum/ammo/xeno/toxin/on_hit_mob(mob/living/carbon/C, obj/projectile/P)
 	drop_neuro_smoke(get_turf(C))
@@ -1372,9 +1371,9 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	C.add_slowdown(slowdown_stacks) //slow em down
 
 	set_reagents()
-	var/armor_block = 1 - C.run_armor_check(null, armor_type) //Check the target's armor mod
-	for(var/r_id in spit_reagents) //modify by armor
-		spit_reagents[r_id] *= armor_block
+	var/armor_block = (1 - C.run_armor_check(BODY_ZONE_CHEST, armor_type) * 0.01) //Check the target's armor mod; default to chest
+	for(var/reagent_id in spit_reagents) //modify by armor
+		spit_reagents[reagent_id] *= armor_block
 
 	C.reagents.add_reagent_list(spit_reagents) //transfer reagents
 
@@ -1451,7 +1450,6 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	name = "neurotoxic splash"
 	added_spit_delay = 15
 	spit_cost = 100
-	smoke_range = 1
 	smoke_strength = 0.65
 	reagent_transfer_amount = 6.5
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1351,7 +1351,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage = 20
 	stagger_stacks = 1
 	slowdown_stacks = 1
-	smoke_strength = 0.65
+	smoke_strength = 0.5
 	smoke_range = 0
 	reagent_transfer_amount = 5
 
@@ -1415,36 +1415,36 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	smoke_system.start()
 
 /datum/ammo/xeno/toxin/upgrade1
-	smoke_strength = 0.7
-	reagent_transfer_amount = 6
+	smoke_strength = 0.55
+	reagent_transfer_amount = 5.5
 
 /datum/ammo/xeno/toxin/upgrade2
-	smoke_strength = 0.75
-	reagent_transfer_amount = 7
+	smoke_strength = 0.6
+	reagent_transfer_amount = 6
 
 /datum/ammo/xeno/toxin/upgrade3
-	smoke_strength = 0.8
-	reagent_transfer_amount = 8
+	smoke_strength = 0.65
+	reagent_transfer_amount = 6.5
 
 
 /datum/ammo/xeno/toxin/medium //Queen
 	name = "neurotoxic spatter"
 	added_spit_delay = 10
 	spit_cost = 75
-	smoke_strength = 0.75
+	smoke_strength = 0.6
 	reagent_transfer_amount = 6
 
 /datum/ammo/xeno/toxin/medium/upgrade1
-	smoke_strength = 0.8
-	reagent_transfer_amount = 7
+	smoke_strength = 0.65
+	reagent_transfer_amount = 6.5
 
 /datum/ammo/xeno/toxin/medium/upgrade2
-	smoke_strength = 0.85
-	reagent_transfer_amount = 8
+	smoke_strength = 0.7
+	reagent_transfer_amount = 7
 
 /datum/ammo/xeno/toxin/medium/upgrade3
-	smoke_strength = 0.9
-	reagent_transfer_amount = 9
+	smoke_strength = 0.75
+	reagent_transfer_amount = 7.5
 
 
 /datum/ammo/xeno/toxin/heavy //Praetorian
@@ -1452,20 +1452,20 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	added_spit_delay = 15
 	spit_cost = 100
 	smoke_range = 1
-	smoke_strength = 0.85
-	reagent_transfer_amount = 7
+	smoke_strength = 0.65
+	reagent_transfer_amount = 6.5
 
 /datum/ammo/xeno/toxin/heavy/upgrade1
-	smoke_strength = 0.9
-	reagent_transfer_amount = 8
+	smoke_strength = 0.7
+	reagent_transfer_amount = 7
 
 /datum/ammo/xeno/toxin/heavy/upgrade2
-	smoke_strength = 0.95
-	reagent_transfer_amount = 9
+	smoke_strength = 0.75
+	reagent_transfer_amount = 7.5
 
 /datum/ammo/xeno/toxin/heavy/upgrade3
-	smoke_strength = 1
-	reagent_transfer_amount = 10
+	smoke_strength = 0.8
+	reagent_transfer_amount = 8
 
 
 /datum/ammo/xeno/sticky

--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -505,7 +505,10 @@
 		UPDATEHEALTH(src)
 	to_chat(src, "<span class='danger'>You are burned!</span>")
 
-
+/obj/flamer_fire/effect_smoke(obj/effect/particle_effect/smoke/S)
+	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_EXTINGUISH)) //Fire suppressing smoke
+		firelevel -= 20 //Water level extinguish
+		updateicon()
 
 /mob/living/carbon/human/flamer_fire_crossed(burnlevel, firelevel, fire_mod = 1)
 	if(hard_armor.getRating("fire") >= 100)

--- a/code/modules/reagents/reagents/toxin.dm
+++ b/code/modules/reagents/reagents/toxin.dm
@@ -469,12 +469,14 @@
 			L.adjustStaminaLoss(4*REM) //While stamina loss is going, stamina regen apparently doesn't happen, so I can keep this smaller.
 			L.reagent_pain_modifier -= PAIN_REDUCTION_LIGHT
 		if(21 to 45)
+			L.adjust_drugginess(1.1) //Move this to stage 2 and 3 so it's not so obnoxious
 			L.adjustStaminaLoss(12*REM)
 			L.reagent_pain_modifier -= PAIN_REDUCTION_HEAVY
 		if(46 to INFINITY)
+			L.adjust_drugginess(1.1)
 			L.adjustStaminaLoss(30*REM)
 			L.reagent_pain_modifier -= PAIN_REDUCTION_VERY_HEAVY
-	L.adjust_drugginess(1.1)
+	L.adjust_blurriness(1.3)
 	L.stuttering = max(L.stuttering, 1)
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request

Neurospit reworked to output much lower Stamina damage, transfer neurotoxin chems to the target (subject to bio armor) and create weak, translucent neurotoxin gas.

Full neurotoxin gas (such as from the Defiler and Boiler) now extinguishes fire and burning mobs.

## Why It's Good For The Game

Eliminates the last remaining source of spike Stamina damage that can be exploited to easily secure captures, replacing it with more tactically and mechanically interesting area denial smoke and reagent transfer that imposes deferred/delayed Stamina damage, and acts as an ongoing debuff/pre-med counter. Also gas masks are now much more useful.

## Changelog
:cl:
tweak: Stamina damage dealt by neurospit reduced to 20 across the board. 
tweak: Neurospit now spawns a small area of weak neuro gas; strength of neurogas scales with the user's upgrade level. Praetorian neurospit gas area is larger.
tweak: Defiler and Boiler (full) neurogas extinguishes fire and burning mobs.
/:cl: