### PR TITLE
Saved recipes persist through rounds

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -44,6 +44,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	// Custom Keybindings
 	var/list/key_bindings = null
 
+	///Saves chemical recipes based on client so they persist through games
+	var/list/chem_macros = list()
+
 	//Synthetic specific preferences
 	var/synthetic_name = "David"
 	var/synthetic_type = "Synthetic"

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -134,6 +134,7 @@
 	READ_FILE(S["clientfps"], clientfps)
 	READ_FILE(S["tooltips"], tooltips)
 	READ_FILE(S["key_bindings"], key_bindings)
+	READ_FILE(S["chem_macros"], chem_macros)
 
 	READ_FILE(S["mute_self_combat_messages"], mute_self_combat_messages)
 	READ_FILE(S["mute_others_combat_messages"], mute_others_combat_messages)
@@ -175,6 +176,7 @@
 	tooltips		= sanitize_integer(tooltips, FALSE, TRUE, initial(tooltips))
 
 	key_bindings 	= sanitize_islist(key_bindings, list())
+	chem_macros 	= sanitize_islist(chem_macros, list())
 
 	mute_self_combat_messages	= sanitize_integer(mute_self_combat_messages, FALSE, TRUE, initial(mute_self_combat_messages))
 	mute_others_combat_messages	= sanitize_integer(mute_others_combat_messages, FALSE, TRUE, initial(mute_others_combat_messages))
@@ -219,6 +221,7 @@
 	windowflashing	= sanitize_integer(windowflashing, FALSE, TRUE, initial(windowflashing))
 	auto_fit_viewport= sanitize_integer(auto_fit_viewport, FALSE, TRUE, initial(auto_fit_viewport))
 	key_bindings	= sanitize_islist(key_bindings, list())
+	chem_macros		= sanitize_islist(chem_macros, list())
 	ghost_vision	= sanitize_integer(ghost_vision, FALSE, TRUE, initial(ghost_vision))
 	ghost_orbit		= sanitize_inlist(ghost_orbit, GLOB.ghost_orbits, initial(ghost_orbit))
 	ghost_form		= sanitize_inlist_assoc(ghost_form, GLOB.ghost_forms, initial(ghost_form))
@@ -254,6 +257,7 @@
 	WRITE_FILE(S["auto_fit_viewport"], auto_fit_viewport)
 	WRITE_FILE(S["menuoptions"], menuoptions)
 	WRITE_FILE(S["key_bindings"], key_bindings)
+	WRITE_FILE(S["chem_macros"], chem_macros)
 	WRITE_FILE(S["ghost_vision"], ghost_vision)
 	WRITE_FILE(S["ghost_orbit"], ghost_orbit)
 	WRITE_FILE(S["ghost_form"], ghost_form)

--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -20,7 +20,11 @@
 	var/amount = 30
 	var/recharge_amount = 10
 	var/recharge_counter = 0
-	var/possible_transfer_amounts = list(1,5,10,15,20,30,60)
+
+	///UI data holder
+	var/data = list()
+	///Reagent amounts that are dispenced
+	var/static/list/possible_transfer_amounts = list(1,5,10,15,20,30,60)
 
 	var/working_state = "dispenser_working"
 
@@ -126,13 +130,14 @@
 		ui = new(user, src, ui_key, "ChemDispenser", name, ui_x, ui_y, master_ui, state)
 		ui.open()
 
+/obj/machinery/chem_dispenser/ui_static_data(mob/user)
+	data["beakerTransferAmounts"] = possible_transfer_amounts
+
 /obj/machinery/chem_dispenser/ui_data(mob/user)
-	var/data = list()
 	data["amount"] = amount
 	data["energy"] = cell.charge ? cell.charge * powerefficiency : "0" //To prevent NaN in the UI.
 	data["maxEnergy"] = cell.maxcharge * powerefficiency
 	data["isBeakerLoaded"] = beaker ? 1 : 0
-	data["beakerTransferAmounts"] = possible_transfer_amounts
 
 	var/beakerContents[0]
 	var/beakerCurrentVolume = 0

--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -139,11 +139,11 @@
 	.["maxEnergy"] = cell.maxcharge * powerefficiency
 	.["isBeakerLoaded"] = beaker ? 1 : 0
 
-	var/beakerContents[0]
+	var/list/beakerContents = list()
 	var/beakerCurrentVolume = 0
 	if(beaker && beaker.reagents && beaker.reagents.reagent_list.len)
 		for(var/datum/reagent/R in beaker.reagents.reagent_list)
-			beakerContents.Add(list(list("name" = R.name, "volume" = R.volume))) // list in a list because Byond merges the first list...
+			beakerContents += list(list("name" = R.name, "volume" = R.volume))	 // list in a list because Byond merges the first list...
 			beakerCurrentVolume += R.volume
 	.["beakerContents"] = beakerContents
 

--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -237,6 +237,7 @@
 			var/yesno = alert("Clear all recipes?",, "Yes","No")
 			if(yesno == "Yes")
 				usr.client.prefs.chem_macros = list()
+				usr.client.prefs.save_preferences()
 			. = TRUE
 		if("record_recipe")
 			if(!is_operational())
@@ -261,6 +262,7 @@
 						playsound(src, 'sound/machines/buzz-two.ogg', 50, TRUE)
 						return
 				usr.client.prefs.chem_macros[name] = recording_recipe
+				usr.client.prefs.save_preferences()
 				recording_recipe = null
 				. = TRUE
 		if("cancel_recording")

--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -21,8 +21,6 @@
 	var/recharge_amount = 10
 	var/recharge_counter = 0
 
-	///UI data holder
-	var/data = list()
 	///Reagent amounts that are dispenced
 	var/static/list/possible_transfer_amounts = list(1,5,10,15,20,30,60)
 
@@ -131,13 +129,15 @@
 		ui.open()
 
 /obj/machinery/chem_dispenser/ui_static_data(mob/user)
-	data["beakerTransferAmounts"] = possible_transfer_amounts
+	. = list()
+	.["beakerTransferAmounts"] = possible_transfer_amounts
 
 /obj/machinery/chem_dispenser/ui_data(mob/user)
-	data["amount"] = amount
-	data["energy"] = cell.charge ? cell.charge * powerefficiency : "0" //To prevent NaN in the UI.
-	data["maxEnergy"] = cell.maxcharge * powerefficiency
-	data["isBeakerLoaded"] = beaker ? 1 : 0
+	. = list()
+	.["amount"] = amount
+	.["energy"] = cell.charge ? cell.charge * powerefficiency : "0" //To prevent NaN in the UI.
+	.["maxEnergy"] = cell.maxcharge * powerefficiency
+	.["isBeakerLoaded"] = beaker ? 1 : 0
 
 	var/beakerContents[0]
 	var/beakerCurrentVolume = 0
@@ -145,14 +145,14 @@
 		for(var/datum/reagent/R in beaker.reagents.reagent_list)
 			beakerContents.Add(list(list("name" = R.name, "volume" = R.volume))) // list in a list because Byond merges the first list...
 			beakerCurrentVolume += R.volume
-	data["beakerContents"] = beakerContents
+	.["beakerContents"] = beakerContents
 
 	if (beaker)
-		data["beakerCurrentVolume"] = beakerCurrentVolume
-		data["beakerMaxVolume"] = beaker.volume
+		.["beakerCurrentVolume"] = beakerCurrentVolume
+		.["beakerMaxVolume"] = beaker.volume
 	else
-		data["beakerCurrentVolume"] = null
-		data["beakerMaxVolume"] = null
+		.["beakerCurrentVolume"] = null
+		.["beakerMaxVolume"] = null
 
 	var/list/chemicals = list()
 	for(var/re in dispensable_reagents)
@@ -160,11 +160,10 @@
 		if(temp)
 			var/chemname = temp.name
 			chemicals.Add(list(list("title" = chemname, "id" = ckey(temp.name))))
-	data["chemicals"] = chemicals
-	data["recipes"] = user.client.prefs.chem_macros
+	.["chemicals"] = chemicals
+	.["recipes"] = user.client.prefs.chem_macros
 
-	data["recordingRecipe"] = recording_recipe
-	return data
+	.["recordingRecipe"] = recording_recipe
 
 /obj/machinery/chem_dispenser/ui_act(action, params)
 	if(..())

--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -145,7 +145,6 @@
 	if (beaker)
 		data["beakerCurrentVolume"] = beakerCurrentVolume
 		data["beakerMaxVolume"] = beaker.volume
-
 	else
 		data["beakerCurrentVolume"] = null
 		data["beakerMaxVolume"] = null


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Chemical recipes are saved on the client, meaning they are always available and persist through games. Up to 10 can be saved.

https://user-images.githubusercontent.com/45896482/102711935-fa48d600-42c5-11eb-9ca4-a1742f3251ff.mp4

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

While making custom mixes is fun, having to input the same combination of chems each round can be tedious. If common usage of chems makes marines too powerful, they should be balanced accordingly.

## Changelog
:cl:Slotbot
tweak: saved chem recipes are persistent
tweak: adds 1u as an option when dispensing chems
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->