### PR TITLE
Added Grapple Toss Keybind; Improved Grapple Toss Implementation

### DIFF
--- a/code/datums/keybinding/xeno.dm
+++ b/code/datums/keybinding/xeno.dm
@@ -414,31 +414,31 @@
 /datum/keybinding/xeno/toggle_agility
 	name = "toggle_agility"
 	full_name = "Warrior: Toggle Agility"
-	description = ""
+	description = "Toggles Agility mode. While in Agility mode, you move much more quickly but can't use abilities and your armor is greatly reduced."
 	keybind_signal = COMSIG_XENOABILITY_TOGGLE_AGILITY
 
 /datum/keybinding/xeno/lunge
 	name = "lunge"
 	full_name = "Warrior: Lunge"
-	description = ""
+	description = "Charges towards a target, then neckgrabs them if they're adjacent to you. Stuns on upon grabbing for 1 second."
 	keybind_signal = COMSIG_XENOABILITY_LUNGE
 
 /datum/keybinding/xeno/fling
 	name = "fling"
 	full_name = "Warrior: Fling"
-	description = ""
+	description = "Quickly flings a target 4 tiles away and inflicts a short stun. Shared cooldown with Grapple Toss."
 	keybind_signal = COMSIG_XENOABILITY_FLING
-/*
+
 /datum/keybinding/xeno/grapple_toss
 	name = "grapple_toss"
 	full_name = "Warrior: Grapple Toss"
-	description = ""
+	description = "Throw a target you're grabbing up to 5 tiles away. Inflicts a short stun and stagger and slow stacks. Shared cooldown with Fling."
 	keybind_signal = COMSIG_XENOABILITY_GRAPPLE_TOSS
-*/
+
 /datum/keybinding/xeno/punch
 	name = "punch"
 	full_name = "Warrior: Punch"
-	description = ""
+	description = "Punch a hostile creature, a structure or piece of machinery. Damage and status durations are doubled vs creatures you are grabbing. Damage is quadrupled vs structures and machinery."
 	keybind_signal = COMSIG_XENOABILITY_PUNCH
 
 /datum/keybinding/xeno/psychic_choke

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -37,12 +37,14 @@
 		var/armor_change = X.xeno_caste.agility_speed_armor
 		X.soft_armor = X.soft_armor.modifyAllRatings(armor_change)
 		last_agility_bonus = armor_change
+		owner.toggle_move_intent(MOVE_INTENT_RUN) //By default we swap to running when activating agility
 	else
 		to_chat(X, "<span class='xenowarning'>We raise ourselves to stand on two feet, hard scales setting back into place.</span>")
 		X.remove_movespeed_modifier(MOVESPEED_ID_WARRIOR_AGILITY)
 		X.soft_armor = X.soft_armor.modifyAllRatings(-last_agility_bonus)
 		last_agility_bonus = 0
 	X.update_icons()
+
 	add_cooldown()
 	return succeed_activate()
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -86,12 +86,6 @@
 		return ..()
 	return TRUE
 
-/datum/action/xeno_action/activable/lunge/on_cooldown_finish()
-	var/mob/living/carbon/xenomorph/X = owner
-	to_chat(X, "<span class='xenodanger'>We are ready to lunge again.</span>")
-	owner.playsound_local(owner, 'sound/effects/xeno_newlarva.ogg', 25, 0, 1)
-	return ..()
-
 /datum/action/xeno_action/activable/lunge/use_ability(atom/A)
 	var/mob/living/carbon/xenomorph/warrior/X = owner
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -258,7 +258,6 @@
 /datum/action/xeno_action/activable/toss/use_ability(atom/A)
 	var/mob/living/carbon/xenomorph/X = owner
 	var/atom/movable/target = owner.pulling
-	var/facing = get_dir(X, A)
 	var/fling_distance = 5
 	var/stagger_slow_stacks = 3
 	var/stun_duration = 1 SECONDS
@@ -291,18 +290,9 @@
 		victim.ParalyzeNoChain(stun_duration)
 		shake_camera(victim, 2, 1)
 
-	var/turf/T = X.loc
-	var/turf/temp = X.loc
-
-	for (var/x in 1 to fling_distance)
-		temp = get_step(T, facing)
-		if(locate(X) in temp) //Allows us to fluidly toss the target behind us
-			target.forceMove(temp)
-		if (!temp)
-			break
-		T = temp
+	target.forceMove(get_turf(X)) //First force them into our space so we can toss them behind us without problems
 	X.do_attack_animation(target, ATTACK_EFFECT_DISARM2)
-	target.throw_at(T, fling_distance, 1, X, 1)
+	target.throw_at(get_turf(A), fling_distance, 1, X, 1)
 
 	succeed_activate()
 	add_cooldown()

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -261,15 +261,13 @@
 	var/fling_distance = 5
 	var/stagger_slow_stacks = 3
 	var/stun_duration = 1 SECONDS
-
+	var/big_mob_message
 
 	X.face_atom(A)
 
 	GLOB.round_statistics.warrior_flings++ //I'm going to consider this a fling for the purpose of statistics
 	SSblackbox.record_feedback("tally", "round_statistics", 1, "warrior_flings")
 
-	X.visible_message("<span class='xenowarning'>\The [X] throws [target] away!</span>", \
-	"<span class='xenowarning'>We throw [target] away!</span>")
 	playsound(target,'sound/weapons/alien_claw_block.ogg', 75, 1)
 
 	if(isliving(target))
@@ -277,6 +275,7 @@
 
 		if(victim.mob_size >= MOB_SIZE_BIG) //Penalize fling distance for big creatures
 			fling_distance = FLOOR(fling_distance * 0.5, 1)
+			big_mob_message = ", struggling mightily to heft its bulk"
 
 		if(isxeno(victim))
 			var/mob/living/carbon/xenomorph/x_victim = victim
@@ -293,6 +292,9 @@
 	target.forceMove(get_turf(X)) //First force them into our space so we can toss them behind us without problems
 	X.do_attack_animation(target, ATTACK_EFFECT_DISARM2)
 	target.throw_at(get_turf(A), fling_distance, 1, X, 1)
+
+	X.visible_message("<span class='xenowarning'>\The [X] throws [target] away[big_mob_message]!</span>", \
+	"<span class='xenowarning'>We throw [target] away[big_mob_message]!</span>")
 
 	succeed_activate()
 	add_cooldown()


### PR DESCRIPTION
## About The Pull Request

1. Grapple Toss now has a keybind.

2. Added descriptions for Warrior ability Keybinds.

3. Eliminated a great deal of unnecessary code for Grapple Toss' implementation; functionality is the same.

4. Eliminated redundant cooldown notifications for Lunge.

5. QoL change for Agility; it now automatically swaps to run intent when activated.

## Why It's Good For The Game

Adds a useful keybind to the game.

Makes Grapple Toss more resource efficient.

## Changelog
:cl:
tweak: The Warrior Grapple Toss ability can now be keybound.
tweak: Keybind descriptions added for Warrior abilities.
code: Minor refactor of Grapple Toss code.
/:cl: