### PR TITLE
Stamina projectiles no longer trigger FF limit

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1041,7 +1041,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 	if(. != BULLET_MESSAGE_HUMAN_SHOOTER)
 		return
 	var/mob/living/carbon/human/firingMob = proj.firer
-	if(!firingMob.mind?.bypass_ff && !mind?.bypass_ff && firingMob.faction == faction)
+	if(!firingMob.mind?.bypass_ff && !mind?.bypass_ff && firingMob.faction == faction && proj.ammo.damage_type != STAMINA)
 		var/turf/T = get_turf(firingMob)
 		firingMob.ff_check(damage, src)
 		log_ffattack("[key_name(firingMob)] shot [key_name(src)] with [proj] in [AREACOORD(T)].")


### PR DESCRIPTION

## About The Pull Request

Tazers are a hell of a drug.

## Why It's Good For The Game

Tazers do stamina damage, as opposed to having a paralyze effect on them. Thus they trigger the FF limit because you usually shoot allies with it.

It seems that admins wish this to not be the case. A side effect is that stamina damage projectiles no longer trigger FF logs as well.

Is this desirable?

## Changelog
:cl: Hughgent
tweak: Stamina damage projectiles no longer count as FF.
/:cl:

