### PR TITLE
Stagger and Slow Stack Overrides Added to Explosion Procs

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -21,7 +21,7 @@
 /// from /obj/machinery/setAnchored(): (machine, anchoredstate)
 #define COMSIG_GLOB_MACHINERY_ANCHORED_CHANGE "!machinery_anchored_change"
 
-/// called after an explosion happened : (epicenter, devastation_range, heavy_impact_range, light_impact_range, took, orig_dev_range, orig_heavy_range, orig_light_range)
+/// called after an explosion happened : (epicenter, devastation_range, heavy_impact_range, light_impact_range, took, orig_dev_range, orig_heavy_range, orig_light_range, stagger_override, slowdown_override)
 #define COMSIG_GLOB_EXPLOSION "!explosion"
 
 #define COMSIG_GLOB_MOB_LOGIN "!mob_login"

--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -382,7 +382,7 @@ This way we'll be able to draw the explosion's expansion path without having to 
 			if(QDELETED(object_to_explode))
 				continue
 			for(var/explosion_source in high_mov_atom[object_to_explode])
-				object_to_explode.ex_act(EXPLODE_DEVASTATE, input_stagger_override = stagger_override, input_slowdown_override = slowdown_override)
+				object_to_explode.ex_act(EXPLODE_DEVASTATE)
 				if(QDELETED(object_to_explode))
 					break
 		cost_highMovAtom = MC_AVERAGE(cost_highMovAtom, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
@@ -395,7 +395,7 @@ This way we'll be able to draw the explosion's expansion path without having to 
 			if(QDELETED(object_to_explode))
 				continue
 			for(var/explosion_source in med_mov_atom[object_to_explode])
-				object_to_explode.ex_act(EXPLODE_HEAVY, input_stagger_override = stagger_override, input_slowdown_override = slowdown_override)
+				object_to_explode.ex_act(EXPLODE_HEAVY)
 				if(QDELETED(object_to_explode))
 					break
 		cost_medMovAtom = MC_AVERAGE(cost_medMovAtom, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
@@ -408,7 +408,7 @@ This way we'll be able to draw the explosion's expansion path without having to 
 			if(QDELETED(object_to_explode))
 				continue
 			for(var/explosion_source in low_mov_atom[object_to_explode])
-				object_to_explode.ex_act(EXPLODE_LIGHT, input_stagger_override = stagger_override, input_slowdown_override = slowdown_override)
+				object_to_explode.ex_act(EXPLODE_LIGHT)
 				if(QDELETED(object_to_explode))
 					break
 		cost_lowMovAtom = MC_AVERAGE(cost_lowMovAtom, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -324,10 +324,10 @@ directive is properly returned.
 /atom/proc/relaymove()
 	return
 
-/atom/proc/ex_act(severity, epicenter_dist, impact_range)
+/atom/proc/ex_act(severity, epicenter_dist, impact_range, input_stagger_override = 0, input_stagger_override = 0)
 	if(!(flags_atom & PREVENT_CONTENTS_EXPLOSION))
-		contents_explosion(severity, epicenter_dist, impact_range)
-	SEND_SIGNAL(src, COMSIG_ATOM_EX_ACT, severity, epicenter_dist, impact_range)
+		contents_explosion(severity, epicenter_dist, impact_range, input_stagger_override, input_stagger_override)
+	SEND_SIGNAL(src, COMSIG_ATOM_EX_ACT, severity, epicenter_dist, impact_range, input_stagger_override, input_stagger_override)
 
 /atom/proc/fire_act()
 	return

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -324,10 +324,10 @@ directive is properly returned.
 /atom/proc/relaymove()
 	return
 
-/atom/proc/ex_act(severity, epicenter_dist, impact_range, input_stagger_override = 0, input_stagger_override = 0)
+/atom/proc/ex_act(severity, epicenter_dist, impact_range, input_stagger_override = 0, input_slowdown_override = 0)
 	if(!(flags_atom & PREVENT_CONTENTS_EXPLOSION))
-		contents_explosion(severity, epicenter_dist, impact_range, input_stagger_override, input_stagger_override)
-	SEND_SIGNAL(src, COMSIG_ATOM_EX_ACT, severity, epicenter_dist, impact_range, input_stagger_override, input_stagger_override)
+		contents_explosion(severity, epicenter_dist, impact_range)
+	SEND_SIGNAL(src, COMSIG_ATOM_EX_ACT, severity, epicenter_dist, impact_range)
 
 /atom/proc/fire_act()
 	return

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -65,7 +65,7 @@
 			playsound(loc, 'sound/items/welder.ogg', 50, 1)
 
 
-/obj/ex_act(severity, input_stagger_override = 0, input_slowdown_override = 0)
+/obj/ex_act(severity)
 	if(resistance_flags & INDESTRUCTIBLE)
 		return
 	. = ..() //contents explosion

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -65,7 +65,7 @@
 			playsound(loc, 'sound/items/welder.ogg', 50, 1)
 
 
-/obj/ex_act(severity)
+/obj/ex_act(severity, input_stagger_override = 0, input_slowdown_override = 0)
 	if(resistance_flags & INDESTRUCTIBLE)
 		return
 	. = ..() //contents explosion

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -103,13 +103,15 @@
 		if(marksman_aura)
 			stat(null, "You are affected by a FOCUS order.")
 
-/mob/living/carbon/human/ex_act(severity)
+/mob/living/carbon/human/ex_act(severity, input_stagger_override = 0, input_slowdown_override = 0)
 	if(status_flags & GODMODE)
 		return
 
 	var/b_loss = 0
 	var/f_loss = 0
 	var/armor = getarmor(null, "bomb") * 0.01
+	var/stagger_stacks
+	var/slowdown_stacks
 
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
@@ -119,8 +121,8 @@
 			if(!istype(wear_ear, /obj/item/clothing/ears/earmuffs))
 				adjust_ear_damage(60 - (60 * armor), 240 - (240 * armor))
 
-			adjust_stagger(12 - (12 * armor))
-			add_slowdown((120 - round(120 * armor, 1)) * 0.01)
+			stagger_stacks = (12 - (12 * armor))
+			slowdown_stacks = ((120 - round(120 * armor, 1)) * 0.01)
 
 		if(EXPLODE_HEAVY)
 			b_loss += rand(80, 100)
@@ -129,8 +131,8 @@
 			if(!istype(wear_ear, /obj/item/clothing/ears/earmuffs))
 				adjust_ear_damage(30 - (30 * armor), 120 - (120 * armor))
 
-			adjust_stagger(6 - (6 * armor))
-			add_slowdown((60 - round(60 * armor, 1)) * 0.1)
+			stagger_stacks = (6 - (6 * armor))
+			slowdown_stacks = ((60 - round(60 * armor, 1)) * 0.1)
 
 		if(EXPLODE_LIGHT)
 			b_loss += rand(40, 50)
@@ -139,8 +141,17 @@
 			if(!istype(wear_ear, /obj/item/clothing/ears/earmuffs))
 				adjust_ear_damage(10 - (10 * armor), 30 - (30 * armor))
 
-			adjust_stagger(3 - (3 * armor))
-			add_slowdown((30 - round(30 * armor, 1)) * 0.1)
+			stagger_stacks = (3 - (3 * armor))
+			slowdown_stacks = ((30 - round(30 * armor, 1)) * 0.1)
+
+	if(input_stagger_override)
+		stagger_stacks = max(0, input_stagger_override)
+
+	if(input_slowdown_override)
+		slowdown_stacks = max(0, input_slowdown_override)
+
+	adjust_stagger(stagger_stacks)
+	add_slowdown(slowdown_stacks)
 
 	#ifdef DEBUG_HUMAN_ARMOR
 	to_chat(world, "DEBUG EX_ACT: armor: [armor * 100], b_loss: [b_loss], f_loss: [f_loss]")

--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -3,7 +3,7 @@
 		return
 	return ..()
 
-/mob/living/carbon/xenomorph/ex_act(severity)
+/mob/living/carbon/xenomorph/ex_act(severity, input_stagger_override = 0, input_slowdown_override = 0)
 	if(status_flags & GODMODE)
 		return
 
@@ -14,28 +14,31 @@
 	var/bomb_armor = soft_armor.getRating("bomb")
 	var/b_loss = 0
 	var/f_loss = 0
+	var/stagger_stacks
+	var/slowdown_stacks
+
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
 			switch(bomb_armor)
 				if(XENO_BOMB_RESIST_4 to INFINITY)
-					add_slowdown(2)
+					slowdown_stacks = 2
 					return
 				if(XENO_BOMB_RESIST_3 to XENO_BOMB_RESIST_4)
 					b_loss = rand(70, 80)
 					f_loss = rand(70, 80)
-					add_slowdown(3)
+					slowdown_stacks = 3
 					adjust_sunder(80)
 				if(XENO_BOMB_RESIST_2 to XENO_BOMB_RESIST_3)
 					b_loss = rand(75, 85)
 					f_loss = rand(75, 85)
-					adjust_stagger(4)
-					add_slowdown(4)
+					stagger_stacks = 4
+					slowdown_stacks = 4
 					adjust_sunder(90)
 				if(XENO_BOMB_RESIST_1 to XENO_BOMB_RESIST_2)
 					b_loss = rand(80, 90)
 					f_loss = rand(80, 90)
-					adjust_stagger(5)
-					add_slowdown(5)
+					stagger_stacks = 5
+					slowdown_stacks = 5
 					adjust_sunder(100)
 				else //Lower than XENO_BOMB_RESIST_1
 					return gib()
@@ -47,25 +50,25 @@
 				if(XENO_BOMB_RESIST_3 to XENO_BOMB_RESIST_4)
 					b_loss = rand(50, 60)
 					f_loss = rand(50, 60)
-					add_slowdown(2)
+					slowdown_stacks = 2
 					adjust_sunder(35)
 				if(XENO_BOMB_RESIST_2 to XENO_BOMB_RESIST_3)
 					b_loss = rand(55, 55)
 					f_loss = rand(55, 55)
-					adjust_stagger(1)
-					add_slowdown(3)
+					stagger_stacks = 1
+					slowdown_stacks = 3
 					adjust_sunder(40)
 				if(XENO_BOMB_RESIST_1 to XENO_BOMB_RESIST_2)
 					b_loss = rand(60, 70)
 					f_loss = rand(60, 70)
-					adjust_stagger(4)
-					add_slowdown(4)
+					stagger_stacks = 4
+					slowdown_stacks = 4
 					adjust_sunder(45)
 				else //Lower than XENO_BOMB_RESIST_1
 					b_loss = rand(65, 75)
 					f_loss = rand(65, 75)
-					adjust_stagger(5)
-					add_slowdown(5)
+					stagger_stacks = 5
+					slowdown_stacks = 5
 					adjust_sunder(50)
 		if(EXPLODE_LIGHT)
 			switch(bomb_armor)
@@ -77,18 +80,26 @@
 				if(XENO_BOMB_RESIST_2 to XENO_BOMB_RESIST_3)
 					b_loss = rand(35, 45)
 					f_loss = rand(35, 45)
-					add_slowdown(1)
+					slowdown_stacks = 1
 				if(XENO_BOMB_RESIST_1 to XENO_BOMB_RESIST_2)
 					b_loss = rand(40, 50)
 					f_loss = rand(40, 50)
-					adjust_stagger(2)
-					add_slowdown(2)
+					stagger_stacks = 2
+					slowdown_stacks = 2
 				else //Lower than XENO_BOMB_RESIST_1
 					b_loss = rand(45, 55)
 					f_loss = rand(45, 55)
-					adjust_stagger(4)
-					add_slowdown(4)
+					stagger_stacks = 4
+					slowdown_stacks = 4
 
+	if(input_stagger_override)
+		stagger_stacks = max(0, input_stagger_override)
+
+	if(input_slowdown_override)
+		slowdown_stacks = max(0, input_slowdown_override)
+
+	adjust_stagger(stagger_stacks)
+	add_slowdown(slowdown_stacks)
 	apply_damage(b_loss, BRUTE)
 	apply_damage(f_loss, BURN)
 	UPDATEHEALTH(src)


### PR DESCRIPTION
## About The Pull Request

Adds stagger and slow override parameters to explosion procs. This allows for finer balance/effect tuning when it comes to explosive based weaponry.

Negative numbers can be used to force 0 stagger and stun effects.

## Why It's Good For The Game

Adds more levers for balancing explosive weaponry.

## Changelog
:cl:
code: Stagger and slow override parameters added to explosion procs. 
/:cl: