### PR TITLE
Powerfist Part 2: Electric Balance-aloo

### DIFF
--- a/code/game/objects/items/weapons/misc.dm
+++ b/code/game/objects/items/weapons/misc.dm
@@ -88,7 +88,7 @@
 	if(!cell)
 		to_chat(user, "<span class='warning'>\The [src] can't operate without a source of power!</span>")
 		return
-	var/powerused = 500 * setting * setting
+	var/powerused = 370 * setting * setting
 	if(powerused > cell.charge)
 		to_chat(user, "<span class='warning'>\The [src]'s cell doesn't have enough power!</span>")
 		M.apply_damage((force/5), BRUTE)
@@ -97,8 +97,8 @@
 			"<span class='userdanger'>[user] punches you!</span>")
 		return
 	M.apply_damage(force * setting, BRUTE) // Extra damage on top of hitting with obj force
-	M.visible_message("<span class='danger'>[user]'s powerfist shudders as they punch [M.name], flinging them away!</span>", \
-		"<span class='userdanger'>[user]'s punch flings you backwards!</span>")
+	M.visible_message("<span class='danger'>[user]'s powerfist shudders as they punch [M.name], flinging [(M.mob_size >= MOB_SIZE_BIG) ? "themself" : "them"] away!</span>", \
+		"<span class='userdanger'>[user]'s punch flings [(M.mob_size >= MOB_SIZE_BIG) ? "them" : "you"] backwards!</span>")
 	playsound(loc, 'sound/weapons/energy_blast.ogg', 50, TRUE)
 	playsound(loc, 'sound/weapons/genhit2.ogg', 50, TRUE)
 	var/throw_range = 1 + setting
@@ -107,6 +107,7 @@
 
 	if(M.mob_size >= MOB_SIZE_BIG) // Hitting big xenos causes the user to be thrown instead
 		M.apply_damage(force * setting, BRUTE) // Also double ouchies
+		to_chat(user, "<span class='userdanger'>[M.name] is so massive the impact force hits twice as hard!</span>")
 		var/atom/self_throw_target = get_edge_target_turf(user, get_dir(M, user))
 		user.throw_at(self_throw_target, throw_range, 0.5 + (setting / 2))
 	else

--- a/code/game/objects/items/weapons/misc.dm
+++ b/code/game/objects/items/weapons/misc.dm
@@ -88,21 +88,28 @@
 	if(!cell)
 		to_chat(user, "<span class='warning'>\The [src] can't operate without a source of power!</span>")
 		return
-	var/powerused = setting*100
-	if(powerused >= cell.charge)
+	var/powerused = 500 * setting * setting
+	if(powerused > cell.charge)
 		to_chat(user, "<span class='warning'>\The [src]'s cell doesn't have enough power!</span>")
 		M.apply_damage((force/5), BRUTE)
 		playsound(loc, 'sound/weapons/punch1.ogg', 50, TRUE)
 		M.visible_message("<span class='danger'>[user]'s powerfist lets out a dull thunk as they punch [M.name]!</span>", \
 			"<span class='userdanger'>[user] punches you!</span>")
-		return ..()
-	M.apply_damage(force * setting, BRUTE)
+		return
+	M.apply_damage(force * setting, BRUTE) // Extra damage on top of hitting with obj force
 	M.visible_message("<span class='danger'>[user]'s powerfist shudders as they punch [M.name], flinging them away!</span>", \
-		"<span class='userdanger'>You [user]'s punch flings you backwards!</span>")
+		"<span class='userdanger'>[user]'s punch flings you backwards!</span>")
 	playsound(loc, 'sound/weapons/energy_blast.ogg', 50, TRUE)
 	playsound(loc, 'sound/weapons/genhit2.ogg', 50, TRUE)
+	var/throw_range_max = 6
+	if(M == user) // Self throws go almost nowhere, also ouch
+		throw_range_max = 2
+	if(M.mob_size >= MOB_SIZE_BIG) // Hitting big xenos causes equal opposite forces
+		throw_range_max = 3
+		var/atom/self_throw_target = get_edge_target_turf(user, get_dir(M, user))
+		user.throw_at(self_throw_target, throw_range_max * (setting / 3), 0.5 + (setting / 2))
 	var/atom/throw_target = get_edge_target_turf(M, get_dir(src, get_step_away(M, src)))
-	M.throw_at(throw_target, 5 * setting, 0.5 + (setting / 2))
+	M.throw_at(throw_target, throw_range_max * (setting / 3), 0.5 + (setting / 2))
 	cell.charge -= powerused
 	return ..()
 

--- a/code/game/objects/items/weapons/misc.dm
+++ b/code/game/objects/items/weapons/misc.dm
@@ -101,15 +101,18 @@
 		"<span class='userdanger'>[user]'s punch flings you backwards!</span>")
 	playsound(loc, 'sound/weapons/energy_blast.ogg', 50, TRUE)
 	playsound(loc, 'sound/weapons/genhit2.ogg', 50, TRUE)
-	var/throw_range_max = 6
+	var/throw_range = 1 + setting
 	if(M == user) // Self throws go almost nowhere, also ouch
-		throw_range_max = 2
-	if(M.mob_size >= MOB_SIZE_BIG) // Hitting big xenos causes equal opposite forces
-		throw_range_max = 3
+		throw_range = 1
+
+	if(M.mob_size >= MOB_SIZE_BIG) // Hitting big xenos causes the user to be thrown instead
+		M.apply_damage(force * setting, BRUTE) // Also double ouchies
 		var/atom/self_throw_target = get_edge_target_turf(user, get_dir(M, user))
-		user.throw_at(self_throw_target, throw_range_max * (setting / 3), 0.5 + (setting / 2))
-	var/atom/throw_target = get_edge_target_turf(M, get_dir(src, get_step_away(M, src)))
-	M.throw_at(throw_target, throw_range_max * (setting / 3), 0.5 + (setting / 2))
+		user.throw_at(self_throw_target, throw_range, 0.5 + (setting / 2))
+	else
+		var/atom/throw_target = get_edge_target_turf(M, get_dir(src, get_step_away(M, src)))
+		M.throw_at(throw_target, throw_range, 0.5 + (setting / 2))
+
 	cell.charge -= powerused
 	return ..()
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

TLDR It's a nerf 🦀

- Way worse power consumption: 3 max setting fists per ~10000 cell capacity, or 27 low setting fists
- Worse knockback overall, and if you fist a `MOB_SIZE_BIG` Xeno you go flying instead
- Hitting a `MOB_SIZE_BIG` also does double damage though

## Why It's Good For The Game

Balances a new feature. Once toned down other aspects can be looked at for the Powerfist, maybe it could be used like spring boots to launch off walls and cades as well as xenos.

I think the need for changing justifies itself. You can still carry like a dozen of the things and also plenty of backup power.

## Changelog
:cl:
balance: Increased Powerfist power cell depletion significantly.
balance: Increased Powerfist damage vs big Xenos but reversed the knockback, and reduced the fling distance in general.
spellcheck: Fixed a Powerfist hit message typo.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
