### PR TITLE
Fixes Phantom Cells for Powerloaders

### DIFF
--- a/code/modules/vehicles/powerloader.dm
+++ b/code/modules/vehicles/powerloader.dm
@@ -31,6 +31,7 @@
 			usr.put_in_hands(cell)
 			playsound(src,'sound/machines/click.ogg', 25, 1)
 			to_chat(usr, "You take out the [cell] out of the [src].")
+			cell.update_icon()
 			set_cell(null)
 		else
 			to_chat(usr, "There is no cell in the [src].")
@@ -58,8 +59,8 @@
 			to_chat(user, "There already is a power cell in the [src].")
 			return
 
-		cell = C
-		C.forceMove(src)
+		user.transferItemToLoc(C, src)
+		set_cell(C)
 		visible_message("[user] puts a new power cell in the [src].")
 		to_chat(user, "You put a new cell in the [src] containing [cell.charge] charge.")
 		playsound(src,'sound/machines/click.ogg', 25, 1)


### PR DESCRIPTION
## About The Pull Request

Fixes cells not being properly removed/installed from/to powerloaders.

## Why It's Good For The Game

Fixes https://github.com/tgstation/TerraGov-Marine-Corps/issues/5535

## Changelog
:cl:
fix: Fixes cells not being properly removed/installed from/to powerloaders.
/:cl: