### PR TITLE
Unskilled marines can now apply Miner Modules

### DIFF
--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -65,9 +65,12 @@
 	if(miner_upgrade_type)
 		to_chat(user, "<span class='info'>The [src]'s module sockets are already occupied by the [miner_upgrade_type].</span>")
 		return FALSE
-	if(user.skills.getRating("construction")<SKILL_CONSTRUCTION_ADVANCED)
-		to_chat(user, "<span class='info'>You can't figure out how to install the complex module.</span>")
-		return FALSE
+	if(user.skills.getRating("engineer") < SKILL_ENGINEER_ENGI)
+		user.visible_message("<span class='notice'>[user] fumbles around figuring out how to install the module on [src].</span>",
+		"<span class='notice'>You fumble around figuring out how to install the module on [src].</span>")
+		var/fumbling_time = 10 SECONDS - 2 SECONDS * user.skills.getRating("engineer")
+		if(!do_after(user, fumbling_time, TRUE, src, BUSY_ICON_UNSKILLED))
+			return FALSE
 	user.visible_message("<span class='notice'>[user] begins attaching a module to [src]'s sockets.</span>")
 	to_chat(user, "<span class='info'>You begin installing the [upgrade] on the miner.</span>")
 	if(!do_after(user, 15 SECONDS, TRUE, src, BUSY_ICON_BUILD))

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -68,7 +68,7 @@
 	if(user.skills.getRating("engineer") < SKILL_ENGINEER_ENGI)
 		user.visible_message("<span class='notice'>[user] fumbles around figuring out how to install the module on [src].</span>",
 		"<span class='notice'>You fumble around figuring out how to install the module on [src].</span>")
-		var/fumbling_time = 10 SECONDS - 2 SECONDS * user.skills.getRating("engineer")
+		var/fumbling_time = 15 SECONDS - 2 SECONDS * user.skills.getRating("engineer")
 		if(!do_after(user, fumbling_time, TRUE, src, BUSY_ICON_UNSKILLED))
 			return FALSE
 	user.visible_message("<span class='notice'>[user] begins attaching a module to [src]'s sockets.</span>")


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows marines without the prerequisite engineering level to apply mining modules to miners, with an appropriate 15-second fumble timer.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Hard locks on something as common as this aren't good, and it allows regular marines to contribute more to Reqpoint gain and get involved more in non-shooty activities. It also stops the Tadpole from stealing every engineer within arms reach.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: There are now instructional pictures on mining modules, to allow the regular Joe to install them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
