### PR TITLE
Changes all typepaths of russianRed into russian_red

### DIFF
--- a/code/game/objects/items/reagent_containers/pill.dm
+++ b/code/game/objects/items/reagent_containers/pill.dm
@@ -179,7 +179,7 @@
 
 /obj/item/reagent_containers/pill/russian_red
 	pill_desc = "A Russian Red pill. A last-resort revival drug."
-	list_reagents = list(/datum/reagent/medicine/russianred = 10)
+	list_reagents = list(/datum/reagent/medicine/russian_red = 10)
 	pill_id = 15
 
 /obj/item/reagent_containers/pill/ryetalyn

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -132,7 +132,7 @@
 
 /obj/item/storage/firstaid/rad/fill_firstaid_kit()
 	new /obj/item/healthanalyzer(src)
-	new /obj/item/storage/pill_bottle/russianRed(src)
+	new /obj/item/storage/pill_bottle/russian_red(src)
 	new /obj/item/storage/pill_bottle/dylovene(src)
 	new /obj/item/reagent_containers/hypospray/autoinjector/tricordrazine(src)
 	new /obj/item/reagent_containers/hypospray/autoinjector/tricordrazine(src)
@@ -371,7 +371,7 @@
 	icon_state = "pill_canister10"
 	pill_type_to_fill = /obj/item/reagent_containers/pill/peridaxon
 
-/obj/item/storage/pill_bottle/russianRed
+/obj/item/storage/pill_bottle/russian_red
 	name = "\improper Russian Red pill bottle"
 	desc = "Contains pills that heal all damage rapidly at the cost of small amounts of unhealable damage."
 	icon_state = "pill_canister1"

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -379,7 +379,7 @@
 		/obj/item/storage/pill_bottle/tricordrazine = 3,
 		/obj/item/storage/pill_bottle/imidazoline = 3,
 		/obj/item/storage/pill_bottle/tramadol = 3,
-		/obj/item/storage/pill_bottle/russianRed = 5,
+		/obj/item/storage/pill_bottle/russian_red = 5,
 		/obj/item/storage/pill_bottle/peridaxon = 2,
 		/obj/item/storage/pill_bottle/quickclot = 2,
 		/obj/item/storage/pill_bottle/hypervene = 2,

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -495,17 +495,17 @@
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL/3
 	scannable = TRUE
 
-/datum/reagent/medicine/russianred/on_mob_life(mob/living/L, metabolism)
+/datum/reagent/medicine/russian_red/on_mob_life(mob/living/L, metabolism)
 	L.heal_limb_damage(10*REM, 10*REM)
 	L.adjustToxLoss(-5*REM)
 	L.adjustCloneLoss(4*REM)
 	return ..()
 
-/datum/reagent/medicine/russianred/overdose_process(mob/living/L, metabolism)
+/datum/reagent/medicine/russian_red/overdose_process(mob/living/L, metabolism)
 	L.apply_damages(2*REM, 0, 0)
 	L.adjustBrainLoss(2*REM, TRUE)
 
-/datum/reagent/medicine/russianred/overdose_crit_process(mob/living/L, metabolism)
+/datum/reagent/medicine/russian_red/overdose_crit_process(mob/living/L, metabolism)
 	L.apply_damages(2*REM, 4*REM, 2*REM)
 	L.adjustBrainLoss(2*REM, TRUE)
 


### PR DESCRIPTION

## About The Pull Request

does the thing that JPR said he won't do.

## Why It's Good For The Game

makes Russian red function as intended. This was because the medicine was `russian_red`, but the stuff it does was for a non-existent `russianred`

## Changelog
:cl: Hughgent
fix: Russian Red functions as it was intended
/:cl:

