### PR TITLE
ERT Fix

### DIFF
--- a/_maps/shuttles/distress.dmm
+++ b/_maps/shuttles/distress.dmm
@@ -77,8 +77,8 @@
 	},
 /area/shuttle/ert)
 "p" = (
-/obj/machinery/door/airlock/mainship/generic,
 /obj/machinery/door/poddoor/shutters/transit/open,
+/obj/machinery/door/airlock/mainship/generic/ert,
 /turf/open/shuttle/dropship/three,
 /area/shuttle/ert)
 "q" = (
@@ -164,10 +164,10 @@
 	},
 /area/shuttle/ert)
 "I" = (
-/obj/machinery/door/airlock/mainship/generic{
+/obj/machinery/door/poddoor/shutters/transit/open{
 	dir = 2
 	},
-/obj/machinery/door/poddoor/shutters/transit/open{
+/obj/machinery/door/airlock/mainship/generic/ert{
 	dir = 2
 	},
 /turf/open/shuttle/dropship/floor,

--- a/_maps/shuttles/distress_pmc.dmm
+++ b/_maps/shuttles/distress_pmc.dmm
@@ -79,8 +79,8 @@
 	},
 /area/shuttle/ert/pmc)
 "p" = (
-/obj/machinery/door/airlock/mainship/generic,
 /obj/machinery/door/poddoor/shutters/transit/open,
+/obj/machinery/door/airlock/mainship/generic/ert,
 /turf/open/shuttle/dropship/three,
 /area/shuttle/ert/pmc)
 "q" = (
@@ -176,10 +176,10 @@
 /turf/open/shuttle/dropship/floor,
 /area/shuttle/ert/pmc)
 "I" = (
-/obj/machinery/door/airlock/mainship/generic{
+/obj/machinery/door/poddoor/shutters/transit/open{
 	dir = 2
 	},
-/obj/machinery/door/poddoor/shutters/transit/open{
+/obj/machinery/door/airlock/mainship/generic/ert{
 	dir = 2
 	},
 /turf/open/shuttle/dropship/floor,

--- a/_maps/shuttles/distress_ufo.dmm
+++ b/_maps/shuttles/distress_ufo.dmm
@@ -139,10 +139,10 @@
 	},
 /area/shuttle/ert)
 "C" = (
-/obj/machinery/door/airlock/mainship/generic{
+/obj/machinery/door/poddoor/shutters/transit/open{
 	dir = 2
 	},
-/obj/machinery/door/poddoor/shutters/transit/open{
+/obj/machinery/door/airlock/mainship/generic/ert{
 	dir = 2
 	},
 /turf/open/shuttle/dropship/floor,

--- a/_maps/shuttles/distress_upp.dmm
+++ b/_maps/shuttles/distress_upp.dmm
@@ -79,8 +79,8 @@
 	},
 /area/shuttle/ert/upp)
 "p" = (
-/obj/machinery/door/airlock/mainship/generic,
 /obj/machinery/door/poddoor/shutters/transit/open,
+/obj/machinery/door/airlock/mainship/generic/ert,
 /turf/open/shuttle/dropship/three,
 /area/shuttle/ert/upp)
 "q" = (
@@ -173,10 +173,10 @@
 /turf/open/shuttle/dropship/floor,
 /area/shuttle/ert/upp)
 "I" = (
-/obj/machinery/door/airlock/mainship/generic{
+/obj/machinery/door/poddoor/shutters/transit/open{
 	dir = 2
 	},
-/obj/machinery/door/poddoor/shutters/transit/open{
+/obj/machinery/door/airlock/mainship/generic/ert{
 	dir = 2
 	},
 /turf/open/shuttle/dropship/floor,

--- a/code/game/objects/machinery/doors/airlock_types.dm
+++ b/code/game/objects/machinery/doors/airlock_types.dm
@@ -543,6 +543,11 @@
 /obj/machinery/door/airlock/mainship/generic/pilot/quarters
 	name = "\improper Pilot's Quarters"
 
+/obj/machinery/door/airlock/mainship/generic/ert
+	name = "\improper Airlock"
+	icon = 'icons/obj/doors/mainship/personaldoor.dmi'
+	interaction_flags = INTERACT_MACHINE_NOSILICON //go away naughty AI
+
 /obj/machinery/door/airlock/mainship/marine
 	name = "\improper Airlock"
 	icon = 'icons/obj/doors/mainship/prepdoor.dmi'

--- a/code/modules/shuttle/ert.dm
+++ b/code/modules/shuttle/ert.dm
@@ -122,7 +122,6 @@
 		return
 
 	if(href_list["depart"])
-		log_game("[key_name(usr)] has departed an ERT shuttle")
 		var/obj/docking_port/mobile/ert/M = SSshuttle.getShuttle(shuttleId)
 
 		if(M.departing)
@@ -130,6 +129,7 @@
 			visible_message("<span class='warning'>ERROR: Launch protocols already in process. Please standby.</span>", 3)
 			return
 
+		log_game("[key_name(usr)] has departed an ERT shuttle")
 		M.on_ignition()
 		addtimer(VARSET_CALLBACK(M, departing, TRUE), M.ignitionTime)
 

--- a/code/modules/shuttle/ert.dm
+++ b/code/modules/shuttle/ert.dm
@@ -86,7 +86,7 @@
 
 
 /obj/machinery/computer/shuttle/ert
-	interaction_flags = INTERACT_MACHINE_NOSILICON //No AIs allowed
+	interaction_flags = INTERACT_OBJ_NANO //No AIs allowed
 
 /obj/machinery/computer/shuttle/ert/valid_destinations()
 	var/obj/docking_port/mobile/ert/M = SSshuttle.getShuttle(shuttleId)
@@ -122,6 +122,7 @@
 		return
 
 	if(href_list["depart"])
+		log_game("[key_name(usr)] has departed an ERT shuttle")
 		var/obj/docking_port/mobile/ert/M = SSshuttle.getShuttle(shuttleId)
 
 		if(M.departing)
@@ -131,16 +132,16 @@
 
 		log_game("[key_name(usr)] has departed an ERT shuttle")
 		M.on_ignition()
-		M.setTimer(M.ignitionTime)
 		addtimer(VARSET_CALLBACK(M, departing, TRUE), M.ignitionTime)
 
 	updateUsrDialog()
 
 
-/obj/docking_port/mobile/ert/proc/do_launch()
-	if(!departing)
+/obj/docking_port/mobile/ert/check()
+	if(departing)
+		intoTheSunset()
 		return
-	intoTheSunset()
+	return ..()
 
 
 /obj/machinery/computer/shuttle/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)

--- a/code/modules/shuttle/ert.dm
+++ b/code/modules/shuttle/ert.dm
@@ -130,7 +130,6 @@
 			visible_message("<span class='warning'>ERROR: Launch protocols already in process. Please standby.</span>", 3)
 			return
 
-		log_game("[key_name(usr)] has departed an ERT shuttle")
 		M.on_ignition()
 		addtimer(VARSET_CALLBACK(M, departing, TRUE), M.ignitionTime)
 

--- a/code/modules/shuttle/ert.dm
+++ b/code/modules/shuttle/ert.dm
@@ -86,7 +86,7 @@
 
 
 /obj/machinery/computer/shuttle/ert
-	interaction_flags = INTERACT_OBJ_NANO //No AIs allowed
+	interaction_flags = INTERACT_MACHINE_TGUI|INTERACT_MACHINE_NOSILICON //No AIs allowed
 
 /obj/machinery/computer/shuttle/ert/valid_destinations()
 	var/obj/docking_port/mobile/ert/M = SSshuttle.getShuttle(shuttleId)

--- a/code/modules/shuttle/ert.dm
+++ b/code/modules/shuttle/ert.dm
@@ -22,6 +22,7 @@
 	var/departing = FALSE
 	ignitionTime = 10 SECONDS
 	prearrivalTime = 10 SECONDS
+	rechargeTime = 3 MINUTES
 	callTime = 1 MINUTES
 
 	shuttle_flags = GAMEMODE_IMMUNE
@@ -83,14 +84,9 @@
 				shutters += O
 	close_shutters()
 
-/obj/docking_port/mobile/ert/check()
-	if(departing)
-		intoTheSunset()
-		return
-	return ..()
 
 /obj/machinery/computer/shuttle/ert
-
+	interaction_flags = INTERACT_MACHINE_NOSILICON //No AIs allowed
 
 /obj/machinery/computer/shuttle/ert/valid_destinations()
 	var/obj/docking_port/mobile/ert/M = SSshuttle.getShuttle(shuttleId)
@@ -114,7 +110,7 @@
 			for(var/obj/docking_port/stationary/S in M.get_destinations())
 				dat += "<A href='?src=[REF(src)];move=[S.id]'>Send to [S.name]</A><br>"
 		else
-			dat += "<A href='?src=[REF(src)];depart=1'>Depart</A><br>"
+			dat += "<A href='?src=[REF(src)];depart=1'>Depart.</A><br>"
 
 	var/datum/browser/popup = new(user, "computer", M ? M.name : "shuttle", 300, 200)
 	popup.set_content("<center>[dat]</center>")
@@ -126,13 +122,26 @@
 		return
 
 	if(href_list["depart"])
-		log_game("[key_name(usr)] has departed an ERT shuttle")
 		var/obj/docking_port/mobile/ert/M = SSshuttle.getShuttle(shuttleId)
+
+		if(M.departing)
+			playsound(loc, 'sound/machines/twobeep.ogg', 25, 1)
+			visible_message("<span class='warning'>ERROR: Launch protocols already in process. Please standby.</span>", 3)
+			return
+
+		log_game("[key_name(usr)] has departed an ERT shuttle")
 		M.on_ignition()
 		M.setTimer(M.ignitionTime)
 		addtimer(VARSET_CALLBACK(M, departing, TRUE), M.ignitionTime)
 
 	updateUsrDialog()
+
+
+/obj/docking_port/mobile/ert/proc/do_launch()
+	if(!departing)
+		return
+	intoTheSunset()
+
 
 /obj/machinery/computer/shuttle/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
 	if(port && (shuttleId == initial(shuttleId) || override))


### PR DESCRIPTION
## About The Pull Request

1. ERTs can no longer choose to depart immediately; there is a 3 minute delay before they can choose to do so.

2. ERTs no longer insta launch; they have a 10 second take off time now. No more shuttle camping and cheesing Xenos that don't know any better.

3. ERT airlocks and consoles can no longer be interacted with by the AI.

## Why It's Good For The Game

Gets rid of ridiculous ERT insta depart cheese, and AI cheese.

Fixes: https://github.com/tgstation/TerraGov-Marine-Corps/issues/5569

Hugh fixed the insta launch earlier.

## Changelog
:cl:
fix: ERT shuttles can no longer depart instantly; the shuttle now has a 3 minute recharge time, and a 10 second depart time.
fix: AIs can no longer interact with the ERT ship airlocks and consoles.
/:cl: