### PR TITLE
Xenos can no long buckle humans into OpTables

### DIFF
--- a/code/game/objects/machinery/OpTable.dm
+++ b/code/game/objects/machinery/OpTable.dm
@@ -69,6 +69,9 @@
 		return FALSE
 	if(buckling_mob == user)
 		return FALSE
+	if(!ishuman(user)) //xenos buckling humans into op tables and applying anesthetic masks? no way.
+		to_chat(user, "<span class='xenowarning'>We don't have the manual dexterity to do this.</span>")
+		return FALSE
 	if(buckling_mob != victim)
 		to_chat(user, "<span class='warning'>Lay the patient on the table first!</span>")
 		return FALSE


### PR DESCRIPTION

## About The Pull Request

fixes #5466 

## Why It's Good For The Game

Xenos shouldn't be able to fit an anesthetic mask over a human on an operating table.

## Changelog
:cl: Hughgent
fix: Xenos no longer have the manual dexterity to work with operating tables anesthetic masks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
