### PR TITLE
ERT Shuttles now have a 'proper' windup and depart

### DIFF
--- a/code/modules/shuttle/ert.dm
+++ b/code/modules/shuttle/ert.dm
@@ -129,8 +129,8 @@
 		log_game("[key_name(usr)] has departed an ERT shuttle")
 		var/obj/docking_port/mobile/ert/M = SSshuttle.getShuttle(shuttleId)
 		M.on_ignition()
-		M.departing = TRUE
 		M.setTimer(M.ignitionTime)
+		addtimer(VARSET_CALLBACK(M, departing, TRUE), M.ignitionTime)
 
 	updateUsrDialog()
 


### PR DESCRIPTION
## About The Pull Request

ERT Shuttles now get a timer equal to their ignition time before beginning movement.

fixes #5460 

## Why It's Good For The Game

That one queen that got yoinked because it instantly departed won't be able to complain anymore.

## Changelog
:cl: Hughgent
fix: ERT shuttles now have a proper 10 second windup before departing.
/:cl:
