### PR TITLE
You cannot headbite someone without a head

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -382,6 +382,7 @@ In most cases it makes more sense to use apply_damage() instead! And make sure t
 This function restores all limbs.
 */
 /mob/living/carbon/human/restore_all_organs(updating_health = FALSE)
+	. = ..()
 	for(var/datum/limb/E in limbs)
 		E.rejuvenate()
 

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -217,6 +217,7 @@
 	return FALSE
 
 /mob/living/proc/restore_all_organs()
+	headbitten = FALSE
 	return
 
 

--- a/code/modules/organs/limb_objects.dm
+++ b/code/modules/organs/limb_objects.dm
@@ -155,11 +155,7 @@ obj/item/limb/New(loc, mob/living/carbon/human/H)
 				log_combat(user, brainmob, "debrained", I, "(INTENT: [uppertext(user.a_intent)])")
 
 				//TODO: ORGAN REMOVAL UPDATE.
-				var/obj/item/organ/brain/B
-				if(contents)
-					B = contents[1] //on droplimb() a brain gets put into the head contents
-				else
-					B = new brain_item_type(loc)
+				var/obj/item/organ/brain/B = new brain_item_type(loc)
 				if(brainmob.stat != DEAD)
 					brainmob.death() //brain mob doesn't survive outside a head
 				B.transfer_identity(brainmob)

--- a/code/modules/organs/limb_objects.dm
+++ b/code/modules/organs/limb_objects.dm
@@ -155,7 +155,11 @@ obj/item/limb/New(loc, mob/living/carbon/human/H)
 				log_combat(user, brainmob, "debrained", I, "(INTENT: [uppertext(user.a_intent)])")
 
 				//TODO: ORGAN REMOVAL UPDATE.
-				var/obj/item/organ/brain/B = new brain_item_type(loc)
+				var/obj/item/organ/brain/B
+				if(contents)
+					B = contents[1] //on droplimb() a brain gets put into the head contents
+				else
+					B = new brain_item_type(loc)
 				if(brainmob.stat != DEAD)
 					brainmob.death() //brain mob doesn't survive outside a head
 				B.transfer_identity(brainmob)

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -786,6 +786,12 @@ Note that amputating the affected organ does in fact remove the infection from t
 				organ = new /obj/item/limb/head/synth(owner.loc, owner)
 			else
 				organ = new /obj/item/limb/head(owner.loc, owner)
+				var/datum/internal_organ/O
+				O = owner.internal_organs_by_name["brain"] //This removes (and later garbage collects) the organ. No brain means instant death.
+				owner.internal_organs_by_name -= "brain"
+				owner.internal_organs -= O
+				organ.contents += O //stuff it into the head object. Who knows, someone might care in the future.
+				owner.headbitten = TRUE //if the mob doesn't have a head, they can't be headbitten.
 			owner.dropItemToGround(owner.glasses, force = TRUE)
 			owner.dropItemToGround(owner.head, force = TRUE)
 			owner.dropItemToGround(owner.wear_ear, force = TRUE)

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -786,11 +786,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 				organ = new /obj/item/limb/head/synth(owner.loc, owner)
 			else
 				organ = new /obj/item/limb/head(owner.loc, owner)
-				var/datum/internal_organ/O
-				O = owner.internal_organs_by_name["brain"] //This removes (and later garbage collects) the organ. No brain means instant death.
-				owner.internal_organs_by_name -= "brain"
-				owner.internal_organs -= O
-				organ.contents += O //stuff it into the head object. Who knows, someone might care in the future.
 				owner.headbitten = TRUE //if the mob doesn't have a head, they can't be headbitten.
 			owner.dropItemToGround(owner.glasses, force = TRUE)
 			owner.dropItemToGround(owner.head, force = TRUE)


### PR DESCRIPTION
## About The Pull Request

This one has either a 1 line fix, or a more involved variation. As it currently stands this is the more involved solution.

The 1 line fix is to just add `owner.headbitten = TRUE` to `dropLimb()` for non-synthetics.

The current fix is to remove the brain organ from the mob, and put it into the contents of the new head object. This is not strictly needed as it would only be used for a kind of disembodied head surgery it seems. A holdover from baystation I suspect.

I had considered an additional check in the headbite `can_use()` for head limb status, but I don't think the effort equals the reward in this situation (a slightly more appropriate `to_chat()`).

## Why It's Good For The Game

You cannot headbite someone without a head.
fixes #5301 

## Changelog
:cl: Hughgent
fix: You cannot headbite someone without a head.
/:cl:

