### PR TITLE
Only external physical damage should damage objects

### DIFF
--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -2,6 +2,9 @@
 	if(QDELETED(src))
 		CRASH("[src] taking damage after deletion")
 
+	if(damage_type != BRUTE || damage_type != BURN) //special human damage should not break objects (OXY, STAMINA and so on).
+		return
+
 	if(effects)
 		play_attack_sound(damage_amount, damage_type, damage_flag)
 

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -2,11 +2,11 @@
 	if(QDELETED(src))
 		CRASH("[src] taking damage after deletion")
 
-	if(damage_type != BRUTE || damage_type != BURN) //special human damage should not break objects (OXY, STAMINA and so on).
-		return
-
 	if(effects)
 		play_attack_sound(damage_amount, damage_type, damage_flag)
+
+	if(damage_type != BRUTE || damage_type != BURN) //special human damage should not break objects (OXY, STAMINA and so on).
+		return
 
 	if((resistance_flags & INDESTRUCTIBLE) || obj_integrity <= 0)
 		return


### PR DESCRIPTION
## About The Pull Request

objects could take a bunch of different types of damage. This limits it to `BRUTE` or `BURN`

## Why It's Good For The Game

Certain things could be destroyed by tasers and such, because they do `STAMINA` damage, which tends to be some very high number.
fixes #4977 

## Changelog
:cl: Hughgent
fix: Objects now shrug off odd damage types.
/:cl:

