### PR TITLE
Makes head reattach surgery work properly

### DIFF
--- a/code/modules/surgery/headreattach.dm
+++ b/code/modules/surgery/headreattach.dm
@@ -168,7 +168,7 @@
 	target.UpdateDamageIcon()
 
 	//Prepare mind datum
-	if(B.brainmob.mind)
+	if(B.brainmob?.mind)
 		B.brainmob.mind.transfer_to(target)
 
 	//Deal with the head item properly


### PR DESCRIPTION
## About The Pull Request

turns out if a synthetic doesn't have a mind currently in the mob, this would runtime.

fixes #4975 

## Why It's Good For The Game

Synthetic heads now actually get put onto peoples heads when being reattached.

## Changelog
:cl: Hughgent
fix: Synthetic head reattachment surgery will now use the head up.
/:cl:

