### PR TITLE
makes the corner CL bookcase accessible on Sulaco

### DIFF
--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -9810,15 +9810,6 @@
 	dir = 8
 	},
 /area/sulaco/engineering/atmos)
-"bev" = (
-/obj/structure/bookcase{
-	dir = 4
-	},
-/obj/item/book/manual/evaguide,
-/obj/item/book/manual/supermatter_engine,
-/obj/item/book/manual/ripley_build_and_repair,
-/turf/open/floor/wood,
-/area/sulaco/liaison/quarters)
 "bew" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -9837,6 +9828,9 @@
 	},
 /obj/item/book/manual/engineering_hacking,
 /obj/item/book/manual/nuclear,
+/obj/item/book/manual/ripley_build_and_repair,
+/obj/item/book/manual/supermatter_engine,
+/obj/item/book/manual/evaguide,
 /turf/open/floor/wood,
 /area/sulaco/liaison/quarters)
 "beH" = (
@@ -55780,7 +55774,7 @@ bdj
 bdI
 bdY
 bHC
-bev
+bdM
 beG
 cPc
 cPc


### PR DESCRIPTION
## About The Pull Request

Moves the contents of the removed bookcase to the corner one.
fixes #4802 

## Why It's Good For The Game

having access to all the things in the room is preferable.

## Changelog
:cl: Hughgent
fix: The Sulaco CL can now access their corner bookcase.
/:cl:
