### PR TITLE
Dreamchecker Spawn return fix

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -729,10 +729,7 @@
 			F.icon_state = "frame"
 			user.client.screen += F
 			flick("[hud_state_empty]_flash", F)
-			spawn(20)
-				user.client.screen -= F
-				qdel(F)
-				overlays += empty
+			addtimer(CALLBACK(src, .proc/update_hud_async, user, F, empty), 2 SECONDS)
 	else
 		warned = FALSE
 		overlays += image('icons/mob/ammoHUD.dmi', src, "[hud_state]")
@@ -754,3 +751,8 @@
 			overlays += image('icons/mob/ammoHUD.dmi', src, "o9")
 			overlays += image('icons/mob/ammoHUD.dmi', src, "t9")
 			overlays += image('icons/mob/ammoHUD.dmi', src, "h9")
+
+/obj/screen/ammo/proc/update_hud_async(mob/living/user, ammo, empty)
+	user.client.screen -= ammo
+	qdel(ammo)
+	overlays += empty

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -371,6 +371,7 @@
 
 	SEND_SIGNAL(src, COMSIG_MOVABLE_IMPACT, hit_atom)
 
+///handles a step of a thing hitting a wall like other thing, the bounce back.
 /atom/movable/proc/throw_impact_async()
 	step(src, turn(dir, 180))
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -364,14 +364,15 @@
 		set_throwing(FALSE)
 		var/turf/T = hit_atom
 		if(T.density)
-			spawn(2)
-				step(src, turn(dir, 180))
+			addtimer(CALLBACK(src, .proc/throw_impact_async), 2)
 			if(isliving(src))
 				var/mob/living/M = src
 				M.turf_collision(T, speed)
 
 	SEND_SIGNAL(src, COMSIG_MOVABLE_IMPACT, hit_atom)
 
+/atom/movable/proc/throw_impact_async()
+	step(src, turn(dir, 180))
 
 //decided whether a movable atom being thrown can pass through the turf it is in.
 /atom/movable/proc/hit_check(speed)

--- a/code/game/objects/effects/effect_system/foam.dm
+++ b/code/game/objects/effects/effect_system/foam.dm
@@ -40,7 +40,7 @@
 		if(metal == RAZOR_FOAM)
 			var/turf/mystery_turf = get_turf(loc)
 			if(!isopenturf(mystery_turf))
-				return FALSE
+				return
 
 			var/turf/open/T = mystery_turf
 			if(T.allow_construction) //No loopholes.

--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -57,10 +57,7 @@
 		setDir(ndir)
 		..(nloc)
 
-		spawn(20)
-			loc = null
-
-
+		addtimer(VARSET_CALLBACK(src, loc, null), 2 SECONDS)
 
 /obj/effect/rune/attunement
 	luminosity = 5

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -135,7 +135,9 @@
 				to_chat(user, "<span class='warning'>\The [H] needs at least two wrists before you can cuff them together!</span>")
 				return
 
-		spawn(30)
-			if(!C)	return
-			if(p_loc == user.loc && p_loc_m == C.loc)
-				C.update_handcuffed(new /obj/item/restraints/handcuffs(C))
+		addtimer(CALLBACK(src, .proc/make_handcuffed, C, user, p_loc, p_loc_m) 3 SECONDS)
+
+/obj/item/restraints/handcuffs/cyborg/proc/make_handcuffed(mob/living/carbon/C as mob, mob/user as mob, p_loc, p_loc_m)
+	if(!C)	return
+	if(p_loc == user.loc && p_loc_m == C.loc)
+		C.update_handcuffed(new /obj/item/restraints/handcuffs(C))

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -135,7 +135,7 @@
 				to_chat(user, "<span class='warning'>\The [H] needs at least two wrists before you can cuff them together!</span>")
 				return
 
-		addtimer(CALLBACK(src, .proc/make_handcuffed, C, user, p_loc, p_loc_m) 3 SECONDS)
+		addtimer(CALLBACK(src, .proc/make_handcuffed, C, user, p_loc, p_loc_m), 3 SECONDS)
 
 /obj/item/restraints/handcuffs/cyborg/proc/make_handcuffed(mob/living/carbon/C as mob, mob/user as mob, p_loc, p_loc_m)
 	if(!C)	return

--- a/code/game/objects/items/storage/internal.dm
+++ b/code/game/objects/items/storage/internal.dm
@@ -61,6 +61,7 @@
 			return 0
 	return 0
 
+///handles the actual movement of an item when it starts to be unequipped.
 /obj/item/storage/internal/proc/unequip_check(mob/user as mob, obj/over_object as obj, hand)
 	if(master_item.time_to_unequip)
 		if(!do_after(user, master_item.time_to_unequip, TRUE, master_item, BUSY_ICON_FRIENDLY))

--- a/code/game/objects/items/storage/internal.dm
+++ b/code/game/objects/items/storage/internal.dm
@@ -66,7 +66,7 @@
 							else
 								user.dropItemToGround(master_item)
 								user.put_in_r_hand(master_item)
-							return 0
+							return
 					else
 						user.dropItemToGround(master_item)
 						user.put_in_r_hand(master_item)
@@ -78,7 +78,7 @@
 							else
 								user.dropItemToGround(master_item)
 								user.put_in_l_hand(master_item)
-							return 0
+							return
 					else
 						user.dropItemToGround(master_item)
 						user.put_in_l_hand(master_item)

--- a/code/game/objects/items/storage/internal.dm
+++ b/code/game/objects/items/storage/internal.dm
@@ -57,33 +57,22 @@
 			return 0
 
 		if(!user.incapacitated())
-			switch(over_object.name)
-				if("r_hand")
-					if(master_item.time_to_unequip)
-						spawn(0)
-							if(!do_after(user, master_item.time_to_unequip, TRUE, master_item, BUSY_ICON_FRIENDLY))
-								to_chat(user, "You stop taking off \the [master_item]")
-							else
-								user.dropItemToGround(master_item)
-								user.put_in_r_hand(master_item)
-							return
-					else
-						user.dropItemToGround(master_item)
-						user.put_in_r_hand(master_item)
-				if("l_hand")
-					if(master_item.time_to_unequip)
-						spawn(0)
-							if(!do_after(user, master_item.time_to_unequip, TRUE, master_item, BUSY_ICON_FRIENDLY))
-								to_chat(user, "You stop taking off \the [master_item]")
-							else
-								user.dropItemToGround(master_item)
-								user.put_in_l_hand(master_item)
-							return
-					else
-						user.dropItemToGround(master_item)
-						user.put_in_l_hand(master_item)
+			INVOKE_ASYNC(src, .proc/unequip_check, user, over_object, over_object.name)
 			return 0
 	return 0
+
+/obj/item/storage/internal/proc/unequip_check(mob/user as mob, obj/over_object as obj, hand)
+	if(master_item.time_to_unequip)
+		if(!do_after(user, master_item.time_to_unequip, TRUE, master_item, BUSY_ICON_FRIENDLY))
+			to_chat(user, "You stop taking off \the [master_item]")
+			return
+	user.dropItemToGround(master_item)
+	switch(hand)
+		if(BODY_ZONE_PRECISE_R_HAND)
+			user.put_in_r_hand(master_item)
+		if(BODY_ZONE_PRECISE_L_HAND)
+			user.put_in_l_hand(master_item)
+
 
 //Items that use internal storage have the option of calling this to emulate default storage attack_hand behaviour.
 //Returns 1 if the master item's parent's attack_hand() should be called, 0 otherwise.

--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -23,9 +23,9 @@ mob/living/carbon/proc/dream()
 			sleep(rand(40,70))
 			if(!IsUnconscious())
 				dreaming = 0
-				return 0
+				return
 		dreaming = 0
-		return 1
+		return
 
 mob/living/carbon/proc/handle_dreams()
 	if(client && !dreaming && prob(5))

--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -19,7 +19,7 @@ mob/living/carbon/proc/dream()
 
 	INVOKE_ASYNC(src, .proc/dream_async)
 
-
+///handles the display of dream text to the player.
 mob/living/carbon/proc/dream_async()
 	for(var/i = rand(1,4),i > 0, i--)
 		to_chat(src, "<span class='notice'><i>... [pick(POSSIBLE_DREAM_TOPICS)] ...</i></span>")

--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -17,15 +17,18 @@
 mob/living/carbon/proc/dream()
 	dreaming = 1
 
-	spawn(0)
-		for(var/i = rand(1,4),i > 0, i--)
-			to_chat(src, "<span class='notice'><i>... [pick(POSSIBLE_DREAM_TOPICS)] ...</i></span>")
-			sleep(rand(40,70))
-			if(!IsUnconscious())
-				dreaming = 0
-				return
-		dreaming = 0
-		return
+	INVOKE_ASYNC(src, .proc/dream_async)
+
+
+mob/living/carbon/proc/dream_async()
+	for(var/i = rand(1,4),i > 0, i--)
+		to_chat(src, "<span class='notice'><i>... [pick(POSSIBLE_DREAM_TOPICS)] ...</i></span>")
+		sleep(rand(40,70))
+		if(!IsUnconscious())
+			dreaming = 0
+			return
+	dreaming = 0
+	return
 
 mob/living/carbon/proc/handle_dreams()
 	if(client && !dreaming && prob(5))


### PR DESCRIPTION
## About The Pull Request

Dreamchecker is complaining about these five things returning values because they are behind a `spawn()`

![image](https://user-images.githubusercontent.com/45076386/103114578-ca326780-4624-11eb-8c9f-d0e899f7a0d6.png)

## Why It's Good For The Game

No change to the overall game

## Changelog
:cl: Hughgent
code: removes the warnings of the codebase related to spawn()
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
