### PR TITLE
Computers Can Be Smashed So They Don't Block Movement

### DIFF
--- a/code/__DEFINES/objects.dm
+++ b/code/__DEFINES/objects.dm
@@ -29,6 +29,7 @@
 #define MAINT		(1<<3)		// under maintaince
 #define EMPED		(1<<4)		// temporary broken by EMP pulse
 #define PANEL_OPEN	(1<<5)
+#define DISABLED	(1<<6)		// can be fixed with a welder; removes density. Used primary to stop otherwise indestructible computers from obstructing pathing.
 #define MACHINE_DO_NOT_PROCESS 32768 //Do not added these to processing queue.
 
 #define ENGINE_EJECT_Z	3

--- a/code/game/objects/machinery.dm
+++ b/code/game/objects/machinery.dm
@@ -454,3 +454,13 @@
 	. = . % 9
 	AM.pixel_x = -8 + ((.%3)*8)
 	AM.pixel_y = -8 + (round( . / 3)*8)
+
+///Currently used for computers only; it can be repaired with a welder after a 5 second wind up
+/obj/machinery/proc/set_disabled()
+
+	if(machine_stat & (BROKEN|DISABLED)) //If we're already broken or disabled, don't bother
+		return
+
+	machine_stat |= DISABLED
+	density = FALSE
+	update_icon()

--- a/code/game/objects/machinery/computer/arcade.dm
+++ b/code/game/objects/machinery/computer/arcade.dm
@@ -173,7 +173,7 @@
 
 
 /obj/machinery/computer/arcade/emp_act(severity)
-	if(machine_stat & (NOPOWER|BROKEN))
+	if(machine_stat & (NOPOWER|BROKEN|DISABLED))
 		..(severity)
 		return
 	var/empprize = null

--- a/code/game/objects/machinery/computer/atmos_alert.dm
+++ b/code/game/objects/machinery/computer/atmos_alert.dm
@@ -54,7 +54,7 @@
 
 /obj/machinery/computer/atmos_alert/update_icon()
 	..()
-	if(machine_stat & (NOPOWER|BROKEN))
+	if(machine_stat & (NOPOWER|BROKEN|DISABLED))
 		return
 	if(priority_alarms.len)
 		icon_state = "alert:2"

--- a/code/game/objects/machinery/computer/camera_advanced.dm
+++ b/code/game/objects/machinery/computer/camera_advanced.dm
@@ -74,7 +74,7 @@
 
 
 /obj/machinery/computer/camera_advanced/check_eye(mob/living/user)
-	if(machine_stat & (NOPOWER|BROKEN) || user.incapacitated(TRUE))
+	if(machine_stat & (NOPOWER|BROKEN|DISABLED) || user.incapacitated(TRUE))
 		user.unset_interaction()
 	if(isAI(user))
 		return

--- a/code/game/objects/machinery/computer/camera_console.dm
+++ b/code/game/objects/machinery/computer/camera_console.dm
@@ -20,7 +20,7 @@
 /obj/machinery/computer/security/check_eye(mob/living/user)
 	if(!istype(user))
 		return
-	if((machine_stat & (NOPOWER|BROKEN)) || user.incapacitated() || user.eye_blind )
+	if((machine_stat & (NOPOWER|BROKEN|DISABLED)) || user.incapacitated() || user.eye_blind )
 		user.unset_interaction()
 		return
 	if(!(user in watchers))
@@ -169,7 +169,7 @@
 
 /obj/machinery/computer/security/telescreen/update_icon()
 	icon_state = initial(icon_state)
-	if(machine_stat & BROKEN)
+	if(machine_stat & (BROKEN|DISABLED))
 		icon_state += "b"
 	return
 

--- a/code/game/objects/machinery/computer/computer.dm
+++ b/code/game/objects/machinery/computer/computer.dm
@@ -8,7 +8,8 @@
 	idle_power_usage = 300
 	active_power_usage = 300
 	var/processing = 0
-	var/durability = 2 //How many times the computer can be smashed by a Xeno before it is disabled.
+	///How many times the computer can be smashed by a Xeno before it is disabled.
+	var/durability = 2
 	resistance_flags = UNACIDABLE
 
 /obj/machinery/computer/Initialize()
@@ -21,7 +22,7 @@
 	power_change()
 
 /obj/machinery/computer/examine(mob/user)
-	..()
+	. = ..()
 	if(machine_stat & (NOPOWER))
 		to_chat(user, "<span class='warning'>It is currently unpowered.</span>")
 
@@ -99,36 +100,47 @@
 	text = replacetext(text, "\n", "<BR>")
 	return text
 
+/obj/machinery/computer/welder_act(mob/living/user, obj/item/I)
+	if(user.action_busy)
+		return FALSE
+
+	var/obj/item/tool/weldingtool/welder = I
+
+	if(!machine_stat & (DISABLED) && durability == initial(durability))
+		to_chat(user, "<span class='notice'>The [src] doesn't need welding!</span>")
+		return FALSE
+
+	if(!welder.tool_use_check(user, 2))
+		return FALSE
+
+	if(user.skills.getRating("engineer") < SKILL_ENGINEER_MASTER)
+		user.visible_message("<span class='notice'>[user] fumbles around figuring out how to deconstruct [src].</span>",
+		"<span class='notice'>You fumble around figuring out how to deconstruct [src].</span>")
+		var/fumbling_time = 50 * ( SKILL_ENGINEER_MASTER - user.skills.getRating("engineer") )
+		if(!do_after(user, fumbling_time, TRUE, src, BUSY_ICON_UNSKILLED))
+			return
+
+	user.visible_message("<span class='notice'>[user] begins repairing damage to [src].</span>",
+	"<span class='notice'>You begin repairing the damage to [src].</span>")
+	playsound(loc, 'sound/items/welder2.ogg', 25, 1)
+
+	if(!do_after(user, 5 SECONDS, TRUE, src, BUSY_ICON_BUILD))
+		return
+
+	if(!welder.remove_fuel(2, user))
+		to_chat(user, "<span class='warning'>Not enough fuel to finish the task.</span>")
+		return TRUE
+
+	user.visible_message("<span class='notice'>[user] repairs [src]'s damage.</span>",
+	"<span class='notice'>You repair [src].</span>")
+	machine_stat &= ~DISABLED //Remove the disabled flag
+	durability = initial(durability) //Reset its durability to its initial value
+	update_icon()
+	playsound(loc, 'sound/items/welder2.ogg', 25, 1)
+
 
 /obj/machinery/computer/attackby(obj/item/I, mob/user, params)
 	. = ..()
-	if(iswelder(I) && machine_stat & (DISABLED))
-		if(user.skills.getRating("engineer") < SKILL_ENGINEER_MASTER)
-			user.visible_message("<span class='notice'>[user] fumbles around figuring out how to deconstruct [src].</span>",
-			"<span class='notice'>You fumble around figuring out how to deconstruct [src].</span>")
-			var/fumbling_time = 50 * ( SKILL_ENGINEER_MASTER - user.skills.getRating("engineer") )
-			if(!do_after(user, fumbling_time, TRUE, src, BUSY_ICON_UNSKILLED))
-				return
-
-		var/obj/item/tool/weldingtool/welder = I
-
-		if(!welder.remove_fuel(0, user))
-			return FALSE
-
-		user.visible_message("<span class='notice'>[user] begins repairing damage to [src].</span>",
-		"<span class='notice'>You begin repairing the damage to [src].</span>")
-		playsound(loc, 'sound/items/welder2.ogg', 25, 1)
-
-		if(!do_after(user, 5 SECONDS, TRUE, src, BUSY_ICON_FRIENDLY))
-			return
-
-		user.visible_message("<span class='notice'>[user] repairs some damage on [src].</span>",
-		"<span class='notice'>You repair [src].</span>")
-		machine_stat &= ~DISABLED //Remove the disabled flag
-		durability = initial(durability) //Reset its durability to its initial value
-		update_icon()
-		playsound(loc, 'sound/items/welder2.ogg', 25, 1)
-
 
 	if(isscrewdriver(I) && circuit)
 		if(user.skills.getRating("engineer") < SKILL_ENGINEER_MASTER)

--- a/code/game/objects/machinery/computer/computer.dm
+++ b/code/game/objects/machinery/computer/computer.dm
@@ -116,7 +116,7 @@
 	if(user.skills.getRating("engineer") < SKILL_ENGINEER_MASTER)
 		user.visible_message("<span class='notice'>[user] fumbles around figuring out how to deconstruct [src].</span>",
 		"<span class='notice'>You fumble around figuring out how to deconstruct [src].</span>")
-		var/fumbling_time = 50 * (SKILL_ENGINEER_MASTER - user.skills.getRating("engineer"))
+		var/fumbling_time = 5 SECONDS * (SKILL_ENGINEER_MASTER - user.skills.getRating("engineer"))
 		if(!do_after(user, fumbling_time, TRUE, src, BUSY_ICON_UNSKILLED))
 			return
 

--- a/code/game/objects/machinery/computer/computer.dm
+++ b/code/game/objects/machinery/computer/computer.dm
@@ -191,6 +191,9 @@
 
 ///So Xenos can smash computers out of the way without actually breaking them
 /obj/machinery/computer/attack_alien(mob/living/carbon/xenomorph/X)
+	if(resistance_flags & INDESTRUCTIBLE)
+		to_chat(X, "<span class='xenowarning'>We're unable to damage this!</span>")
+		return
 
 	if(machine_stat & (BROKEN|DISABLED)) //If we're already broken or disabled, don't bother
 		to_chat(X, "<span class='xenowarning'>This peculiar thing is already broken!</span>")

--- a/code/game/objects/machinery/computer/computer.dm
+++ b/code/game/objects/machinery/computer/computer.dm
@@ -195,14 +195,3 @@
 	X.do_attack_animation(src, ATTACK_EFFECT_DISARM2) //SFX
 	playsound(loc, pick('sound/effects/bang.ogg','sound/effects/metal_crash.ogg','sound/effects/meteorimpact.ogg'), 25, 1) //SFX
 	Shake(4, 4, 2 SECONDS)
-
-
-///Disables the computer; it can be repaired with a welder after a 5 second wind up
-/obj/machinery/computer/proc/set_disabled()
-
-	if(machine_stat & (BROKEN|DISABLED)) //If we're already broken or disabled, don't bother
-		return
-
-	machine_stat |= DISABLED
-	density = FALSE
-	update_icon()

--- a/code/game/objects/machinery/computer/computer.dm
+++ b/code/game/objects/machinery/computer/computer.dm
@@ -23,16 +23,16 @@
 
 /obj/machinery/computer/examine(mob/user)
 	. = ..()
-	if(machine_stat & (NOPOWER))
+	if(machine_stat & NOPOWER)
 		to_chat(user, "<span class='warning'>It is currently unpowered.</span>")
 
 	if(durability < initial(durability))
 		to_chat(user, "<span class='warning'>It is damaged, and can be fixed with a welder.</span>")
 
-	if(machine_stat & (DISABLED))
+	if(machine_stat & DISABLED)
 		to_chat(user, "<span class='warning'>It is currently disabled, and can be fixed with a welder.</span>")
 
-	if(machine_stat & (BROKEN))
+	if(machine_stat & BROKEN)
 		to_chat(user, "<span class='warning'>It is broken and needs to be rebuilt.</span>")
 
 /obj/machinery/computer/process()
@@ -106,7 +106,7 @@
 
 	var/obj/item/tool/weldingtool/welder = I
 
-	if(!machine_stat & (DISABLED) && durability == initial(durability))
+	if(!machine_stat & DISABLED && durability == initial(durability))
 		to_chat(user, "<span class='notice'>The [src] doesn't need welding!</span>")
 		return FALSE
 
@@ -116,7 +116,7 @@
 	if(user.skills.getRating("engineer") < SKILL_ENGINEER_MASTER)
 		user.visible_message("<span class='notice'>[user] fumbles around figuring out how to deconstruct [src].</span>",
 		"<span class='notice'>You fumble around figuring out how to deconstruct [src].</span>")
-		var/fumbling_time = 50 * ( SKILL_ENGINEER_MASTER - user.skills.getRating("engineer") )
+		var/fumbling_time = 50 * (SKILL_ENGINEER_MASTER - user.skills.getRating("engineer"))
 		if(!do_after(user, fumbling_time, TRUE, src, BUSY_ICON_UNSKILLED))
 			return
 
@@ -137,7 +137,6 @@
 	durability = initial(durability) //Reset its durability to its initial value
 	update_icon()
 	playsound(loc, 'sound/items/welder2.ogg', 25, 1)
-
 
 /obj/machinery/computer/attackby(obj/item/I, mob/user, params)
 	. = ..()

--- a/code/game/objects/machinery/computer/crew.dm
+++ b/code/game/objects/machinery/computer/crew.dm
@@ -23,7 +23,7 @@
 	ui_y = 800
 
 /obj/machinery/computer/crew/update_icon()
-	if(machine_stat & BROKEN)
+	if(machine_stat & (BROKEN|DISABLED))
 		icon_state = "crewb"
 	else if(machine_stat & NOPOWER)
 		icon_state = "crew0"

--- a/code/game/objects/machinery/computer/station_alert.dm
+++ b/code/game/objects/machinery/computer/station_alert.dm
@@ -48,7 +48,7 @@
 
 
 /obj/machinery/computer/station_alert/proc/triggerAlarm(class, area/A, O, alarmsource)
-	if(machine_stat & (BROKEN))
+	if(machine_stat & (BROKEN|DISABLED))
 		return
 	var/list/L = src.alarms[class]
 	for (var/I in L)
@@ -71,7 +71,7 @@
 
 
 /obj/machinery/computer/station_alert/proc/cancelAlarm(class, area/A as area, obj/origin)
-	if(machine_stat & (BROKEN))
+	if(machine_stat & (BROKEN|DISABLED))
 		return
 	var/list/L = src.alarms[class]
 	var/cleared = 0
@@ -91,7 +91,7 @@
 	if (machine_stat &(NOPOWER))
 		icon_state = "atmos0"
 		return
-	if(machine_stat & (BROKEN))
+	if(machine_stat & (BROKEN|DISABLED))
 		icon_state = "atmosb"
 		return
 	var/active_alarms = 0

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -387,11 +387,14 @@
 			wires.cut_all()
 			visible_message("<span class='danger'>\The [src]'s wires snap apart in a rain of sparks!</span>", null, null, 5)
 
-	if(istype(src, /obj/machinery/computer)) //Currently only computers use this; falcon punch away its density
-		set_disabled()
+
 
 	update_icon()
 	return TRUE
+
+/obj/machinery/computer/punch_act(mob/living/carbon/xenomorph/X, damage, target_zone) //Break open the machine
+	set_disabled() //Currently only computers use this; falcon punch away its density
+	return ..()
 
 /obj/machinery/light/punch_act(mob/living/carbon/xenomorph/X)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -387,8 +387,6 @@
 			wires.cut_all()
 			visible_message("<span class='danger'>\The [src]'s wires snap apart in a rain of sparks!</span>", null, null, 5)
 
-
-
 	update_icon()
 	return TRUE
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -387,6 +387,9 @@
 			wires.cut_all()
 			visible_message("<span class='danger'>\The [src]'s wires snap apart in a rain of sparks!</span>", null, null, 5)
 
+	if(istype(src, /obj/machinery/computer)) //Currently only computers use this; falcon punch away its density
+		set_disabled()
+
 	update_icon()
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request

1. Xenos can disable computers by attacking them; 3 hits will disable a computer by default.

2. A disabled computer can't be used and doesn't obstruct pathing. It can be repaired with a welder after a 5 second delay.

3. Broken computers do not obstruct pathing.

4. The Warrior's punch will instantly disable a computer.

## Why It's Good For The Game

Stops computers from being obnoxious, inexplicably indestructible road blocks for the xenos.

## Changelog
:cl:
tweak: Computers can now be disabled by multiple xeno attacks or a Warrior punch. Disabled computers do not obstruct pathing and can be repaired by a welder.
/:cl: