### PR TITLE
Added 2 cryopod consoles to Sulacos cryo storage

### DIFF
--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -1216,10 +1216,10 @@
 	},
 /area/sulaco/medbay/storage2)
 "ahJ" = (
-/obj/structure/table/mainship,
-/obj/item/tool/crowbar,
-/obj/item/flashlight/flare,
 /obj/effect/decal/warning_stripes/thick{
+	dir = 8
+	},
+/obj/machinery/computer/cryopod{
 	dir = 8
 	},
 /turf/open/floor/prison/sterilewhite,
@@ -1456,12 +1456,13 @@
 	},
 /area/sulaco/engineering/atmos)
 "aiX" = (
-/obj/structure/table/mainship,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/item/camera,
 /obj/effect/decal/warning_stripes/thick{
+	dir = 8
+	},
+/obj/machinery/computer/cryopod{
 	dir = 8
 	},
 /turf/open/floor/prison/sterilewhite,
@@ -1703,6 +1704,7 @@
 /area/sulaco/engineering)
 "akq" = (
 /obj/structure/table/mainship,
+/obj/item/camera,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cryosleep)
 "akr" = (


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
There are now two cryo consoles to the left of the cryo bay replacing the tables on the side.
![image](https://user-images.githubusercontent.com/39524296/103173613-61353480-485c-11eb-980f-51917f1615d8.png)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Roomba ate a whole bag of SL gear
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Sulaco now has cryo consoles, allowing you to retrieve whatever the ~~stupid vacuum cleaner~~ Roomba *"cleaned up"*
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
