### PR TITLE
Allthehypo

### DIFF
--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -272,7 +272,7 @@
 	name = "Combat hyspospray"
 	desc = "An hyspospray loaded with several doses of advanced healing and painkilling chemicals. Intended for use in active combat."
 	list_reagents = list(
-		/datum/reagent/medicine/bicardine = 20,
+		/datum/reagent/medicine/bicaridine = 20,
 		/datum/reagent/medicine/kelotane = 20,
 		/datum/reagent/medicine/tramadol = 20,
 	)	

--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -283,7 +283,7 @@
 	list_reagents = list(
 		/datum/reagent/medicine/meralyne = 20,
 		/datum/reagent/medicine/dermaline = 20,
-		/datum/reagent/medicine/oxycodone = 20
+		/datum/reagent/medicine/oxycodone = 20,
 	)
 
 /obj/item/reagent_containers/hypospray/advanced/meraderm
@@ -291,21 +291,21 @@
 	desc = "An hyspospray loaded with meralyne and dermaline."
 	list_reagents = list(
 		/datum/reagent/medicine/meralyne = 30,
-		/datum/reagent/medicine/dermaline = 30
+		/datum/reagent/medicine/dermaline = 30,
 	)
 
 /obj/item/reagent_containers/hypospray/advanced/meralyne
 	name = "A meralyne hyspospray"
 	desc = "An hyspospray loaded with meralyne."
 	list_reagents = list(
-		/datum/reagent/medicine/meralyne = 60
+		/datum/reagent/medicine/meralyne = 60,
 	)
 
 /obj/item/reagent_containers/hypospray/advanced/dermaline
 	name = "A dermaline hyspospray"
 	desc = "An hyspospray loaded with dermaline."
 	list_reagents = list(
-		/datum/reagent/medicine/dermaline = 60
+		/datum/reagent/medicine/dermaline = 60,
 	)
 	
 /obj/item/reagent_containers/hypospray/advanced/ironsugar
@@ -313,7 +313,7 @@
 	desc = "An hyspospray loaded with ironsugar."
 	list_reagents = list(
 		/datum/reagent/iron = 30, 
-		/datum/reagent/consumable/sugar = 30
+		/datum/reagent/consumable/sugar = 30,
 	)
 
 /obj/item/reagent_containers/hypospray/advanced/update_icon()

--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -269,8 +269,8 @@
 	list_reagents = list(/datum/reagent/medicine/oxycodone = 60)
 	
 /obj/item/reagent_containers/hypospray/advanced/combat
-	name = "Combat hyspospray"
-	desc = "An hyspospray loaded with several doses of advanced healing and painkilling chemicals. Intended for use in active combat."
+	name = "Combat hypospray"
+	desc = "An hypospray loaded with several doses of advanced healing and painkilling chemicals. Intended for use in active combat."
 	list_reagents = list(
 		/datum/reagent/medicine/bicaridine = 20,
 		/datum/reagent/medicine/kelotane = 20,
@@ -278,8 +278,8 @@
 	)	
 	
 /obj/item/reagent_containers/hypospray/advanced/combat_advanced
-	name = "Advanced combat hyspospray"
-	desc = "An hyspospray loaded with several doses of advanced healing and painkilling chemicals. Intended for use in active combat."
+	name = "Advanced combat hypospray"
+	desc = "An hypospray loaded with several doses of advanced healing and painkilling chemicals. Intended for use in active combat."
 	list_reagents = list(
 		/datum/reagent/medicine/meralyne = 20,
 		/datum/reagent/medicine/dermaline = 20,
@@ -287,30 +287,30 @@
 	)
 
 /obj/item/reagent_containers/hypospray/advanced/meraderm
-	name = "A meraderm hyspospray"
-	desc = "An hyspospray loaded with meralyne and dermaline."
+	name = "A meraderm hypospray"
+	desc = "An hypospray loaded with meralyne and dermaline."
 	list_reagents = list(
 		/datum/reagent/medicine/meralyne = 30,
 		/datum/reagent/medicine/dermaline = 30,
 	)
 
 /obj/item/reagent_containers/hypospray/advanced/meralyne
-	name = "A meralyne hyspospray"
-	desc = "An hyspospray loaded with meralyne."
+	name = "A meralyne hypospray"
+	desc = "An hypospray loaded with meralyne."
 	list_reagents = list(
 		/datum/reagent/medicine/meralyne = 60,
 	)
 
 /obj/item/reagent_containers/hypospray/advanced/dermaline
-	name = "A dermaline hyspospray"
-	desc = "An hyspospray loaded with dermaline."
+	name = "A dermaline hypospray"
+	desc = "An hypospray loaded with dermaline."
 	list_reagents = list(
 		/datum/reagent/medicine/dermaline = 60,
 	)
 	
 /obj/item/reagent_containers/hypospray/advanced/ironsugar
-	name = "A ironsugar hyspospray"
-	desc = "An hyspospray loaded with ironsugar."
+	name = "A ironsugar hypospray"
+	desc = "An hypospray loaded with ironsugar."
 	list_reagents = list(
 		/datum/reagent/iron = 30, 
 		/datum/reagent/consumable/sugar = 30,

--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -274,7 +274,7 @@
 	list_reagents = list(
 		/datum/reagent/medicine/bicardine = 20,
 		/datum/reagent/medicine/kelotane = 20,
-		/datum/reagent/medicine/tramadol = 20
+		/datum/reagent/medicine/tramadol = 20,
 	)	
 	
 /obj/item/reagent_containers/hypospray/advanced/combat_advanced

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -455,11 +455,10 @@
 
 /obj/item/storage/pouch/hypospray/corps
 	name = "Corps hypospray pouch"
-	desc = It can contain hyposprays and autoinjectors, this one got a terragov corpsmans logo on its back."
+	desc = "It can contain hyposprays and autoinjectors, this one got a terragov corpsmans logo on its back."
 	icon_state = "syringe"
 	storage_slots = 4 //1 extra for corps
 	can_hold = list(/obj/item/reagent_containers/hypospray)
-	)
 
 /obj/item/storage/pouch/hypospray/corps/full/Initialize()   //literally the same stuff as the other pouch but instead of 4 combat AUTO injectors get 1 hypo of the mix
 	. = ..()

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -455,7 +455,7 @@
 
 /obj/item/storage/pouch/hypospray/corps
 	name = "Corps hypospray pouch"
-	desc = "It can contain hyposprays and autoinjectors, this one got a terragov corpsmans logo on its back."
+	desc = "It can contain hyposprays and autoinjectors, this one has a Terragov corpsman logo on its back."
 	icon_state = "syringe"
 	storage_slots = 4 //1 extra for corps
 	can_hold = list(/obj/item/reagent_containers/hypospray)

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -961,11 +961,11 @@ GLOBAL_LIST_INIT(marine_selector_cats, list(
 
 		/obj/item/storage/pill_bottle/paracetamol = list(CAT_MEDSUP, "Paracetamol pills", 10, "orange"),
 		/obj/item/storage/syringe_case/meralyne = list(CAT_MEDSUP, "syringe Case (120u Meralyne)", 16, "orange"),
-		/obj/item/reagent_containers/hypospray/advanced/meralyne list(CAT_MEDSUP, "hysposray (60u Meralyne)", 8, "orange"), //half the units of the mera case half the price
+		/obj/item/reagent_containers/hypospray/advanced/meralyne = list(CAT_MEDSUP, "hysposray (60u Meralyne)", 8, "orange"), //half the units of the mera case half the price
 		/obj/item/storage/syringe_case/dermaline = list(CAT_MEDSUP, "syringe Case (120u Dermaline)", 16, "orange"), 
-		/obj/item/reagent_containers/hypospray/advanced/dermaline list(CAT_MEDSUP, "hysposray (60u dermaline)", 8, "orange"), //half the units of the derm case half the price
+		/obj/item/reagent_containers/hypospray/advanced/dermaline = list(CAT_MEDSUP, "hysposray (60u dermaline)", 8, "orange"), //half the units of the derm case half the price
 		/obj/item/storage/syringe_case/meraderm = list(CAT_MEDSUP, "syringe Case (120u Meraderm)", 16, "orange"),
-		/obj/item/reagent_containers/hypospray/advanced/meraderm list(CAT_MEDSUP, "hysposray (60u Meraderm)", 8, "orange"), //half the units of the meraderm case half the price
+		/obj/item/reagent_containers/hypospray/advanced/meraderm = list(CAT_MEDSUP, "hysposray (60u Meraderm)", 8, "orange"), //half the units of the meraderm case half the price
 		/obj/item/storage/syringe_case/ironsugar = list(CAT_MEDSUP, "syringe Case (120u Ironsugar)", 5, "black"),
 		/obj/item/reagent_containers/hypospray/advanced/ironsugar = list(CAT_MEDSUP, "hysposray (60u Ironsugar)", 3, "black"), //bit more than half of the ironsugar case
 		/obj/item/reagent_containers/hypospray/autoinjector/combat_advanced = list(CAT_MEDSUP, "Injector (Advanced)", 5, "black"),

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -487,7 +487,7 @@ GLOBAL_LIST_INIT(marine_selector_cats, list(
 		/obj/item/storage/belt/medicLifesaver = list(CAT_BEL, "Lifesaver medic belt", 0, "orange"),
 		/obj/item/storage/belt/medical = list(CAT_BEL, "Medical belt", 0, "black"),
 		/obj/item/storage/pouch/autoinjector/advanced/full = list(CAT_POU, "Advanced Autoinjector pouch", 0, "orange"),
-		/obj/item/storage/pouch/hypospray/corps/full = list(CAT_POU, "Advanced Hypospray pouch", 0, "orange"),
+		/obj/item/storage/pouch/hypospray/corps/full = list(CAT_POU, "Advanced hypospray pouch", 0, "orange"),
 		/obj/item/helmet_module/welding = list(CAT_HEL, "Jaeger welding module", 0, "orange"),
 		/obj/item/helmet_module/binoculars =  list(CAT_HEL, "Jaeger binoculars module", 0, "orange"),
 		/obj/item/helmet_module/antenna = list(CAT_HEL, "Jaeger Antenna module", 0, "orange"),
@@ -961,13 +961,13 @@ GLOBAL_LIST_INIT(marine_selector_cats, list(
 
 		/obj/item/storage/pill_bottle/paracetamol = list(CAT_MEDSUP, "Paracetamol pills", 10, "orange"),
 		/obj/item/storage/syringe_case/meralyne = list(CAT_MEDSUP, "syringe Case (120u Meralyne)", 16, "orange"),
-		/obj/item/reagent_containers/hypospray/advanced/meralyne = list(CAT_MEDSUP, "hysposray (60u Meralyne)", 8, "orange"), //half the units of the mera case half the price
+		/obj/item/reagent_containers/hypospray/advanced/meralyne = list(CAT_MEDSUP, "hypospray (60u Meralyne)", 8, "orange"), //half the units of the mera case half the price
 		/obj/item/storage/syringe_case/dermaline = list(CAT_MEDSUP, "syringe Case (120u Dermaline)", 16, "orange"), 
-		/obj/item/reagent_containers/hypospray/advanced/dermaline = list(CAT_MEDSUP, "hysposray (60u dermaline)", 8, "orange"), //half the units of the derm case half the price
+		/obj/item/reagent_containers/hypospray/advanced/dermaline = list(CAT_MEDSUP, "hypospray (60u dermaline)", 8, "orange"), //half the units of the derm case half the price
 		/obj/item/storage/syringe_case/meraderm = list(CAT_MEDSUP, "syringe Case (120u Meraderm)", 16, "orange"),
-		/obj/item/reagent_containers/hypospray/advanced/meraderm = list(CAT_MEDSUP, "hysposray (60u Meraderm)", 8, "orange"), //half the units of the meraderm case half the price
+		/obj/item/reagent_containers/hypospray/advanced/meraderm = list(CAT_MEDSUP, "hypospray (60u Meraderm)", 8, "orange"), //half the units of the meraderm case half the price
 		/obj/item/storage/syringe_case/ironsugar = list(CAT_MEDSUP, "syringe Case (120u Ironsugar)", 5, "black"),
-		/obj/item/reagent_containers/hypospray/advanced/ironsugar = list(CAT_MEDSUP, "hysposray (60u Ironsugar)", 3, "black"), //bit more than half of the ironsugar case
+		/obj/item/reagent_containers/hypospray/advanced/ironsugar = list(CAT_MEDSUP, "hypospray (60u Ironsugar)", 3, "black"), //bit more than half of the ironsugar case
 		/obj/item/reagent_containers/hypospray/autoinjector/combat_advanced = list(CAT_MEDSUP, "Injector (Advanced)", 5, "black"),
 		/obj/item/reagent_containers/hypospray/autoinjector/oxycodone = list(CAT_MEDSUP, "Injector (Oxycodone)", 1, "black"),
 		/obj/item/reagent_containers/hypospray/autoinjector/hypervene = list(CAT_MEDSUP, "Injector (Hypervene)", 1, "black"),

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -487,7 +487,7 @@ GLOBAL_LIST_INIT(marine_selector_cats, list(
 		/obj/item/storage/belt/medicLifesaver = list(CAT_BEL, "Lifesaver medic belt", 0, "orange"),
 		/obj/item/storage/belt/medical = list(CAT_BEL, "Medical belt", 0, "black"),
 		/obj/item/storage/pouch/autoinjector/advanced/full = list(CAT_POU, "Advanced Autoinjector pouch", 0, "orange"),
-		/obj/item/storage/pouch/hypospray/corps/full = list(CAT_POU, "Advanced Hypospray pouch", 0, "orange")
+		/obj/item/storage/pouch/hypospray/corps/full = list(CAT_POU, "Advanced Hypospray pouch", 0, "orange"),
 		/obj/item/helmet_module/welding = list(CAT_HEL, "Jaeger welding module", 0, "orange"),
 		/obj/item/helmet_module/binoculars =  list(CAT_HEL, "Jaeger binoculars module", 0, "orange"),
 		/obj/item/helmet_module/antenna = list(CAT_HEL, "Jaeger Antenna module", 0, "orange"),

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -487,6 +487,7 @@ GLOBAL_LIST_INIT(marine_selector_cats, list(
 		/obj/item/storage/belt/medicLifesaver = list(CAT_BEL, "Lifesaver medic belt", 0, "orange"),
 		/obj/item/storage/belt/medical = list(CAT_BEL, "Medical belt", 0, "black"),
 		/obj/item/storage/pouch/autoinjector/advanced/full = list(CAT_POU, "Advanced Autoinjector pouch", 0, "orange"),
+		/obj/item/storage/pouch/hypospray/corps/full = list(CAT_POU, "Advanced Hypospray pouch", 0, "orange")
 		/obj/item/helmet_module/welding = list(CAT_HEL, "Jaeger welding module", 0, "orange"),
 		/obj/item/helmet_module/binoculars =  list(CAT_HEL, "Jaeger binoculars module", 0, "orange"),
 		/obj/item/helmet_module/antenna = list(CAT_HEL, "Jaeger Antenna module", 0, "orange"),
@@ -960,9 +961,13 @@ GLOBAL_LIST_INIT(marine_selector_cats, list(
 
 		/obj/item/storage/pill_bottle/paracetamol = list(CAT_MEDSUP, "Paracetamol pills", 10, "orange"),
 		/obj/item/storage/syringe_case/meralyne = list(CAT_MEDSUP, "syringe Case (120u Meralyne)", 16, "orange"),
-		/obj/item/storage/syringe_case/dermaline = list(CAT_MEDSUP, "syringe Case (120u Dermaline)", 16, "orange"),
+		/obj/item/reagent_containers/hypospray/advanced/meralyne list(CAT_MEDSUP, "hysposray (60u Meralyne)", 8, "orange"), //half the units of the mera case half the price
+		/obj/item/storage/syringe_case/dermaline = list(CAT_MEDSUP, "syringe Case (120u Dermaline)", 16, "orange"), 
+		/obj/item/reagent_containers/hypospray/advanced/dermaline list(CAT_MEDSUP, "hysposray (60u dermaline)", 8, "orange"), //half the units of the derm case half the price
 		/obj/item/storage/syringe_case/meraderm = list(CAT_MEDSUP, "syringe Case (120u Meraderm)", 16, "orange"),
+		/obj/item/reagent_containers/hypospray/advanced/meraderm list(CAT_MEDSUP, "hysposray (60u Meraderm)", 8, "orange"), //half the units of the meraderm case half the price
 		/obj/item/storage/syringe_case/ironsugar = list(CAT_MEDSUP, "syringe Case (120u Ironsugar)", 5, "black"),
+		/obj/item/reagent_containers/hypospray/advanced/ironsugar = list(CAT_MEDSUP, "hysposray (60u Ironsugar)", 3, "black"), //bit more than half of the ironsugar case
 		/obj/item/reagent_containers/hypospray/autoinjector/combat_advanced = list(CAT_MEDSUP, "Injector (Advanced)", 5, "black"),
 		/obj/item/reagent_containers/hypospray/autoinjector/oxycodone = list(CAT_MEDSUP, "Injector (Oxycodone)", 1, "black"),
 		/obj/item/reagent_containers/hypospray/autoinjector/hypervene = list(CAT_MEDSUP, "Injector (Hypervene)", 1, "black"),


### PR DESCRIPTION
## About The Pull Request

adds a new pouch type thats able to hold hypos and autoinjectors "just like the autoinjector one but smaller"

adds this pouch to medical vendor (as a alternative to the injector one. comes preloaded with the same ammount of chems as the original pouch of autoinjecors)

adds new prefilled hyposprays like:


-  ```

  		 combat
 		/datum/reagent/medicine/bicardine = 20,
 		/datum/reagent/medicine/kelotane = 20,
 		/datum/reagent/medicine/tramadol = 20	
   ```
 

- ```

 
 	name = "Advanced combat hyspospray"
 		/datum/reagent/medicine/meralyne = 20,
 		/datum/reagent/medicine/dermaline = 20,
 		/datum/reagent/medicine/oxycodone = 20
 	
  ```
 
 

- ```

 	name = "A meraderm hyspospray"
 		/datum/reagent/medicine/meralyne = 30,
 		/datum/reagent/medicine/dermaline = 30
 
  ```
 

- ```

 
 	name = "A meralyne hyspospray"
		/datum/reagent/medicine/meralyne = 60
 
  ```
 

- ```

 
 	name = "A dermaline hyspospray"
 		/datum/reagent/medicine/dermaline = 60
 
  ```
 

- ```

 	name = "A ironsugar hyspospray"
 		/datum/reagent/iron = 30, 
		/datum/reagent/consumable/sugar = 30


## Why It's Good For The Game

gives corpsmans new options for the preparations

## Changelog
:cl:
add: new hypospray pouch
add: hypospray pouch to corpsman prep
add: new pre filled hyposprays
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
