### PR TITLE
Fix Xeno Silo Fog and Tunnels blocking passage of headbit/headless marines

### DIFF
--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -115,9 +115,16 @@
 		return TRUE
 	if(isxeno(mover))
 		var/mob/living/carbon/xenomorph/moving_xeno = mover
-		if(LAZYLEN(moving_xeno.stomach_contents))
-			return FALSE
+		for(var/tummy_resident in moving_xeno.stomach_contents)
+			if(ishuman(tummy_resident))
+				var/mob/living/carbon/human/H = tummy_resident
+				if(check_tod(H))
+					return FALSE
 		return TRUE
+	if(ishuman(mover))
+		var/mob/living/carbon/human/H = mover
+		if(!check_tod(H)) // Allow pulled perma-dead humans to cross
+			return TRUE
 	return FALSE
 
 /obj/effect/forcefield/fog/passable_fog

--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -121,7 +121,7 @@
 				if(check_tod(H))
 					return FALSE
 		return TRUE
-	if(ishuman(mover))
+	if(ishuman(mover) && !issynth(mover))
 		var/mob/living/carbon/human/H = mover
 		if(!check_tod(H)) // Allow pulled perma-dead humans to cross
 			return TRUE

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -700,9 +700,12 @@ TUNNEL
 		to_chat(M, "<span class='xenowarning'>We can't climb through a tunnel while immobile.</span>")
 		return FALSE
 
-	if(LAZYLEN(M.stomach_contents))
-		to_chat(M, "<span class='warning'>We must spit out the host inside of us first.</span>")
-		return
+	for(var/tummy_resident in M.stomach_contents)
+		if(ishuman(tummy_resident))
+			var/mob/living/carbon/human/H = tummy_resident
+			if(check_tod(H))
+				to_chat(M, "<span class='warning'>We cannot enter the tunnel while the host we devoured has signs of life. We should headbite it to finish it off.</span>")
+				return
 
 	var/obj/structure/tunnel/targettunnel = input(M, "Choose a tunnel to crawl to", "Tunnel") as null|anything in GLOB.xeno_tunnels
 	if(!targettunnel)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the checks for `stomach_contents` more robust in places to account for defibable status, and let perma-dead human corpses pass through fog.

## Why It's Good For The Game

Fixes frustrating mechanics of a bygone era.

## Changelog
:cl:
fix: Xeno Silo Fog on Crash now allows perma-dead humans to pass, as well as Xenos with one inside its tummy.
fix: Tunnels now allow xenos to travel with a devoured perma-dead human.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
