### PR TITLE
Nerfs machinepistol fire rate to 0.2 from 0.15

### DIFF
--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -76,7 +76,7 @@
 	accuracy_mult_unwielded = 0.85
 	recoil_unwielded = 0
 	scatter = 15
-	fire_delay = 0.15 SECONDS
+	fire_delay = 0.2 SECONDS
 	scatter_unwielded = 0 //Made to be used one handed.
 	aim_slowdown = 0.15
 	burst_amount = 5


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This lowers the rpm by 100 basically.
0.15->0.2
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The machine pistol is too good compared to all the other secondaries, this should be a good nerf considering it has 30 rounds and assault rifle fire speed, and good one-handed performance.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: machine pistol fire speed reduced to 0.2 from 0.15, aka 100 rpm less
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
