### PR TITLE
Fixes the POS' hull.

### DIFF
--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -40055,7 +40055,7 @@ ad
 ad
 ad
 ad
-Mb
+ad
 ad
 ad
 ad


### PR DESCRIPTION

## About The Pull Request

Fixes being able to cut trough the POS' outer hull.

![image](https://user-images.githubusercontent.com/47011211/103431799-553bd080-4bd6-11eb-9280-994a236b3f26.png)


## Why It's Good For The Game

It is my solem duty as a coder to remove fun.

## Changelog
:cl:
fix: You can no longer cut trough the POS' hull into space.
/:cl:

