### PR TITLE
The healing of doctor's delight now factors in the reagent effect multiplier

### DIFF
--- a/code/modules/reagents/reagents/drink.dm
+++ b/code/modules/reagents/reagents/drink.dm
@@ -473,10 +473,10 @@
 	adj_dizzy = - 10
 
 /datum/reagent/consumable/drink/doctor_delight/on_mob_life(mob/living/L, metabolism)
-	L.adjustBruteLoss(-0.5, 0)
-	L.adjustFireLoss(-0.5, 0)
-	L.adjustToxLoss(-0.5, 0)
-	L.adjustOxyLoss(-0.5, 0)
+	L.adjustBruteLoss(-1 * REM, 0)
+	L.adjustFireLoss(-1 * REM, 0)
+	L.adjustToxLoss(-1 * REM, 0)
+	L.adjustOxyLoss(-1 * REM, 0)
 	L.AdjustConfused(-10 SECONDS)
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request

See the title. Note that this PR currently should have no effect on the in-game healing speed of doctor's delight, as I've compensated for the REM currently being 0.5.

DD's confusion and dizziness reduction effects have not been touched by this PR.

## Why It's Good For The Game

If some absolute madman changes the REM in the future, doctor's delight won't dodge the adjustment.

## Changelog
:cl: ATHATH
tweak: Doctor's delight's healing now factors in the reagent effect multiplier. This should have no effect on gameplay, as it heals just as much as it did before (and at the same rate as it did before, too).
/:cl: