### PR TITLE
Makes gyroscopic stabilizer reduce aim mode movement speed reduction by 50%

### DIFF
--- a/code/modules/codex/entries/weapons_codex.dm
+++ b/code/modules/codex/entries/weapons_codex.dm
@@ -63,6 +63,8 @@
 		attach_strings += "Wield delay: [wield_delay_mod / 10] seconds."
 	if(attach_shell_speed_mod)
 		attach_strings += "Bullet speed: [attach_shell_speed_mod * 100]%"
+	if(aim_mode_movement_mult)
+		attach_strings += "Aim Mode slowdow modifier: [aim_mode_movement_mult*100]%"
 	if(movement_acc_penalty_mod)
 		attach_strings += "Running accuracy penalty: [movement_acc_penalty_mod * 100]%"
 	if(max_rounds)

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1541,7 +1541,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 
 /obj/item/attachable/gyro
 	name = "gyroscopic stabilizer"
-	desc = "A set of weights and balances to stabilize the weapon when burst firing or moving, especially while shooting one-handed. Greatly reduces movement penalties to accuracy. Significantly reduces burst scatter, recoil and general scatter."
+	desc = "A set of weights and balances to stabilize the weapon when burst firing or moving, especially while shooting one-handed. Greatly reduces movement penalties to accuracy. Significantly reduces burst scatter, recoil and general scatter. By increasing accuracy while moving, it let you move faster when taking aim."
 	icon_state = "gyro"
 	attach_icon = "gyro_a"
 	slot = "under"

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -89,6 +89,8 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	var/fire_delay_mod = 0
 	///Changes aim mode movement delay multiplicatively
 	var/aim_mode_movement_mult = 0
+	///Modifies projectile damage by a % when a marine gets passed, but not hit
+	var/shot_marine_damage_falloff = 0
 
 	///the delay between shots, for attachments that fire stuff
 	var/attachment_firing_delay = 0
@@ -181,6 +183,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	master_gun.scatter						+= scatter_mod
 	master_gun.scatter_unwielded			+= scatter_unwielded_mod
 	master_gun.aim_speed_modifier			+= initial(master_gun.aim_speed_modifier)*aim_mode_movement_mult
+	master_gun.iff_marine_damage_falloff	+= shot_marine_damage_falloff
 	if(delay_mod)
 		master_gun.modify_fire_delay(delay_mod)
 	if(burst_delay_mod)
@@ -243,6 +246,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	master_gun.scatter						-= scatter_mod
 	master_gun.scatter_unwielded			-= scatter_unwielded_mod
 	master_gun.aim_speed_modifier			-= initial(master_gun.aim_speed_modifier)*aim_mode_movement_mult
+	master_gun.iff_marine_damage_falloff	-= shot_marine_damage_falloff
 	if(delay_mod)
 		master_gun.modify_fire_delay(-delay_mod)
 	if(burst_delay_mod)
@@ -1551,6 +1555,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	scatter_unwielded_mod = -10
 	recoil_unwielded_mod = -1
 	aim_mode_movement_mult = -0.5
+	shot_marine_damage_falloff = -0.1
 
 /obj/item/attachable/lasersight
 	name = "laser sight"

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -87,6 +87,8 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	var/detach_delay = 30
 	///how long in deciseconds this adds to your base fire delay.
 	var/fire_delay_mod = 0
+	///Changes aim mode movement delay multiplicatively
+	var/aim_mode_movement_mult = 0
 
 	///the delay between shots, for attachments that fire stuff
 	var/attachment_firing_delay = 0
@@ -178,6 +180,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	master_gun.w_class						+= size_mod
 	master_gun.scatter						+= scatter_mod
 	master_gun.scatter_unwielded			+= scatter_unwielded_mod
+	master_gun.aim_speed_modifier			+= initial(master_gun.aim_speed_modifier)*aim_mode_movement_mult
 	if(delay_mod)
 		master_gun.modify_fire_delay(delay_mod)
 	if(burst_delay_mod)
@@ -239,6 +242,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	master_gun.w_class						-= size_mod
 	master_gun.scatter						-= scatter_mod
 	master_gun.scatter_unwielded			-= scatter_unwielded_mod
+	master_gun.aim_speed_modifier			-= initial(master_gun.aim_speed_modifier)*aim_mode_movement_mult
 	if(delay_mod)
 		master_gun.modify_fire_delay(-delay_mod)
 	if(burst_delay_mod)
@@ -1546,6 +1550,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	movement_acc_penalty_mod = -0.5
 	scatter_unwielded_mod = -10
 	recoil_unwielded_mod = -1
+	aim_mode_movement_mult = -0.5
 
 /obj/item/attachable/lasersight
 	name = "laser sight"

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -63,6 +63,8 @@
 	var/shell_speed_mod	= 0						//Modifies the speed of projectiles fired.
 	/// Determines which humans the gun's shot will pass through based on the victim's ID access list.
 	var/list/gun_iff_signal = null
+	///Modifies projectile damage by a % when a marine gets passed, but not hit
+	var/iff_marine_damage_falloff = 0
 	///Determines how fire delay is changed when aim mode is active
 	var/aim_fire_delay = 0
 	///Determines character slowdown from aim mode. Default is 66%
@@ -876,6 +878,7 @@ and you're good to go.
 	projectile_to_fire.damage_falloff *= damage_falloff_mult
 	projectile_to_fire.projectile_speed += shell_speed_mod
 	projectile_to_fire.projectile_iff = gun_iff_signal
+	projectile_to_fire.damage_marine_falloff = iff_marine_damage_falloff
 
 
 /obj/item/weapon/gun/proc/setup_bullet_accuracy(obj/projectile/projectile_to_fire, mob/user, bullets_fired = 1, dual_wield = FALSE)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -61,7 +61,10 @@
 	var/damage = 0
 	var/accuracy = 85 //Base projectile accuracy. Can maybe be later taken from the mob if desired.
 
-	var/damage_falloff = 0 //how many damage point the projectile loses per tiles travelled
+	///how many damage points the projectile loses per tiles travelled
+	var/damage_falloff = 0
+	///Modifies projectile damage by a % when a marine gets passed, but not hit
+	var/damage_marine_falloff = 0
 
 	var/scatter = 0 //Chance of scattering, also maximum amount scattered. High variance.
 
@@ -720,6 +723,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 
 /mob/living/carbon/human/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)
 	if(get_target_lock(proj.projectile_iff))
+		proj.damage += proj.damage*proj.damage_marine_falloff
 		return FALSE
 	if(mobility_aura)
 		. -= mobility_aura * 5


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes gyroscopic stabilizer reduce aim mode movement speed reduction by 50%, but also reduce damage by 10% for every marine passed. 

Damage decrease is multiplicative, so for a bullet dealing 30 damage, it will deal 30 with no marines then 27>24.3>21.87 and so on.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Adds more variety to attachments as sidegrades. Gives the option to be more mobile during aim mode at the cost of decreased damage when firing from the far back of a group, thus possibly rewarding spreading out or moving in smaller groups.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:Slotbot
balance: gyroscopic stabilizer reduces aim mode movement speed reduction by 50%, but also decreases bullet damage by 10% per marine passed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
