### PR TITLE
Anti early fob camp tweak

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -520,8 +520,10 @@
 	return !slayer && ..()
 
 
-//Check if shutters are opened. Proced when constructing resin, acid wells, 
-//jelly pod dispensers and hugger traps 
+/** 
+ * Check if shutters are closed in the area. 
+ * Proced when constructing resin, acid wells, jelly pod dispensers and hugger traps 
+ */
 /turf/proc/check_disallow_alien_fortification(mob/living/builder, silent = FALSE)
 	var/area/ourarea = loc
 	if(ourarea.flags_area & DISALLOW_WEEDING)
@@ -529,6 +531,10 @@
 			to_chat(builder, "<span class='warning'>We cannot build in this area before the talls are out!</span>")
 		return FALSE
 	return TRUE
+
+/** 
+ * Check if alien abilities can construct structure on the turf 
+ * Proced when constructing every kind of xenos structure, including weeds*/
 
 /turf/proc/check_alien_construction(mob/living/builder, silent = FALSE, planned_building)
 	var/has_obstacle

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -521,8 +521,8 @@
 
 
 /** 
- * Check if shutters are closed in the area. 
- * Proced when constructing resin, acid wells, jelly pod dispensers and hugger traps 
+ * Checks for whether we can build advanced xeno structures here
+ * Returns TRUE if present, FALSE otherwise
  */
 /turf/proc/check_disallow_alien_fortification(mob/living/builder, silent = FALSE)
 	var/area/ourarea = loc

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -521,12 +521,15 @@
 
 
 
-/turf/proc/check_alien_construction(mob/living/builder, silent = FALSE, planned_building)
+/turf/proc/check_disallow_alien_fortification(mob/living/builder, silent = FALSE)
 	var/area/ourarea = loc
 	if(ourarea.flags_area & DISALLOW_WEEDING)
 		if(!silent)
 			to_chat(builder, "<span class='warning'>We cannot build in this area!</span>")
 		return FALSE
+	return TRUE
+
+/turf/proc/check_alien_construction(mob/living/builder, silent = FALSE, planned_building)
 	var/has_obstacle
 	for(var/obj/O in contents)
 		if(istype(O, /obj/item/clothing/mask/facehugger))

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -519,8 +519,6 @@
 /turf/open/floor/plating/ground/snow/is_weedable()
 	return !slayer && ..()
 
-
-
 /turf/proc/check_disallow_alien_fortification(mob/living/builder, silent = FALSE)
 	var/area/ourarea = loc
 	if(ourarea.flags_area & DISALLOW_WEEDING)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -519,11 +519,14 @@
 /turf/open/floor/plating/ground/snow/is_weedable()
 	return !slayer && ..()
 
+
+//Check if shutters are opened. Proced when constructing resin, acid wells, 
+//jelly pod dispensers and hugger traps 
 /turf/proc/check_disallow_alien_fortification(mob/living/builder, silent = FALSE)
 	var/area/ourarea = loc
 	if(ourarea.flags_area & DISALLOW_WEEDING)
 		if(!silent)
-			to_chat(builder, "<span class='warning'>We cannot build in this area!</span>")
+			to_chat(builder, "<span class='warning'>We cannot build in this area before the talls are out!</span>")
 		return FALSE
 	return TRUE
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -534,7 +534,7 @@
 
 /** 
  * Check if alien abilities can construct structure on the turf 
- * Proced when constructing every kind of xenos structure, including weeds*/
+ * Return TRUE if allowed, FALSE otherwise
  */
 /turf/proc/check_alien_construction(mob/living/builder, silent = FALSE, planned_building)
 	var/has_obstacle

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -535,7 +535,7 @@
 /** 
  * Check if alien abilities can construct structure on the turf 
  * Proced when constructing every kind of xenos structure, including weeds*/
-
+ */
 /turf/proc/check_alien_construction(mob/living/builder, silent = FALSE, planned_building)
 	var/has_obstacle
 	for(var/obj/O in contents)

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -262,7 +262,7 @@
 		to_chat(X, "<span class='warning'>We can only shape on weeds. We must find some resin before we start building!</span>")
 		return fail_activate()
 
-	if(!T.check_alien_construction(X, planned_building = X.selected_resin))
+	if(!T.check_alien_construction(X, planned_building = X.selected_resin) || !T.check_disallow_alien_fortification(X))
 		return fail_activate()
 
 	if(X.selected_resin == /obj/structure/mineral_door/resin)
@@ -297,7 +297,7 @@
 	if(!alien_weeds)
 		return fail_activate()
 
-	if(!T.check_alien_construction(X, planned_building = X.selected_resin))
+	if(!T.check_alien_construction(X, planned_building = X.selected_resin) || !T.check_disallow_alien_fortification(X))
 		return fail_activate()
 
 	if(X.selected_resin == /obj/structure/mineral_door/resin)
@@ -995,7 +995,7 @@
 	if(!do_after(owner, 3 SECONDS, FALSE, alien_weeds))
 		return FALSE
 
-	if(!current_turf.check_alien_construction(owner))
+	if(!current_turf.check_alien_construction(owner) || !current_turf.check_disallow_alien_fortification(owner))
 		return FALSE
 
 	owner.visible_message("<span class='xenowarning'>\The [owner] has laid an egg!</span>", \

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
@@ -158,7 +158,7 @@
 			to_chat(owner, "<span class='warning'>We can only shape on weeds. We must find some resin before we start building!</span>")
 		return FALSE
 
-	if(!T.check_alien_construction(owner, silent))
+	if(!T.check_alien_construction(owner, silent) || !T.check_disallow_alien_fortification(owner, silent))
 		return FALSE
 
 	if(locate(/obj/effect/alien/weeds/node) in T)

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -224,6 +224,9 @@ GLOBAL_LIST_INIT(thickenable_resin, typecacheof(list(
 		if(!silent)
 			to_chat(owner, "<span class='warning'>We can only shape on weeds. We must find some resin before we start building!</span>")
 		return FALSE
+	
+	if(!T.check_disallow_alien_fortification(owner, silent))
+		return FALSE
 
 	if(!T.check_alien_construction(owner, silent))
 		return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -402,7 +402,8 @@
 
 /datum/action/xeno_action/place_acidwell/action_activate()
 	var/turf/T = get_turf(owner)
-
+	if(!T.check_disallow_alien_fortification(owner))
+		return FALSE
 	succeed_activate()
 
 	playsound(T, "alien_resin_build", 25)

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -395,6 +395,9 @@
 	if(!T.check_alien_construction(owner, silent))
 		return FALSE
 
+	if(!T.check_disallow_alien_fortification(owner, silent))
+		return FALSE
+
 	if(locate(/obj/effect/alien/weeds/node) in T)
 		if(!silent)
 			to_chat(owner, "<span class='warning'>There is a resin node in the way!</span>")
@@ -402,8 +405,6 @@
 
 /datum/action/xeno_action/place_acidwell/action_activate()
 	var/turf/T = get_turf(owner)
-	if(!T.check_disallow_alien_fortification(owner))
-		return FALSE
 	succeed_activate()
 
 	playsound(T, "alien_resin_build", 25)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

You can now weed near LZ shutters even when they are close. You can't put any resin (wall etc), acid wells, jelly pod and such. Tunnel get a pass because why not. Everything that ressembles a fortification will still be banned near FOB before shutters open

## Why It's Good For The Game

Made fighting survivors or early tadpole a pain for no good reason. It still prevent any kind of stupid FOB maze at start, but you can heal near the fight with survs now. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Allow weeding near shutters even before they are opened
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
