### PR TITLE
Buffs throwing knifes

### DIFF
--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -159,7 +159,7 @@
 	sharp = IS_SHARP_ITEM_ACCURATE
 	force = 10
 	w_class = WEIGHT_CLASS_TINY
-	throwforce = 35
+	throwforce = 100
 	throw_speed = 4
 	throw_range = 7
 	hitsound = 'sound/weapons/slash.ogg'


### PR DESCRIPTION
## About The Pull Request

Buffs throwing knifes to deal 100 damage when thrown.

## Why It's Good For The Game

Throwing knifes are the epidemy of useless, it's already hard enough to even hit a hostile target with them, and then it deals barely any damage.

I don't think that 100 damage is overpowered as Xenos move at incredible speeds so you need to have really good reflexes to get a hit off.

## Changelog
:cl:
balance: throwing knifes now deal 100 damage when thrown.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
