### PR TITLE
Weeds nodes get destroyed by plasma cutter

### DIFF
--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -170,6 +170,14 @@
 	node_turfs = filled_turfs(src, node_range, "square")
 	SSweeds.add_node(src)
 
+/obj/effect/alien/weeds/node/attackby(obj/item/I, mob/user, params)
+	. = ..()
+
+	if(istype(I, /obj/item/tool/pickaxe/plasmacutter))
+		Destroy()
+		playsound(I.loc, 'sound/machines/click.ogg', 25, 1, 5)
+		playsound(src, "alien_resin_break", 25)
+
 
 // =================
 // stronger weed node

--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -170,14 +170,6 @@
 	node_turfs = filled_turfs(src, node_range, "square")
 	SSweeds.add_node(src)
 
-/obj/effect/alien/weeds/node/attackby(obj/item/I, mob/user, params)
-	. = ..()
-
-	if(istype(I, /obj/item/tool/pickaxe/plasmacutter))
-		Destroy()
-		playsound(I.loc, 'sound/machines/click.ogg', 25, 1, 5)
-		playsound(src, "alien_resin_break", 25)
-
 
 // =================
 // stronger weed node

--- a/code/game/objects/items/tools/mining_tools.dm
+++ b/code/game/objects/items/tools/mining_tools.dm
@@ -328,6 +328,13 @@
 
 
 /obj/item/tool/pickaxe/plasmacutter/attack_obj(obj/O, mob/living/user)
+	if(istype(O, /obj/effect/alien/weeds/node))
+		var/obj/effect/alien/weeds/node/N = O
+		playsound(user.loc, 'sound/machines/click.ogg', 5, 1, 5)
+		user.do_attack_animation(N, used_item = src)
+		N.Destroy()
+		return TRUE
+
 	if(!powered || user.action_busy || CHECK_BITFIELD(O.resistance_flags, INDESTRUCTIBLE))
 		. = ..()
 		return TRUE


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Weeds nodes get destroyed by plasma cutter in 1 hit.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You don't need to take both machete and plasma cutter to clear xeno structures and weeds, since taking both takes a lot of space and carrying them around is cumbersome. A lot of times marines push into areas with xeno walls without clearing them because no one has bothered taking a plasma cutter.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:Slotbot
balance: plasma cutter destroys weeds nodes with 1 hit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
