### PR TITLE
Lets marine use bump attacks.

### DIFF
--- a/code/datums/components/bump_attack.dm
+++ b/code/datums/components/bump_attack.dm
@@ -70,14 +70,17 @@
 /datum/component/bump_attack/proc/human_bump_action(datum/source, atom/target)
 	SIGNAL_HANDLER
 	var/mob/living/carbon/human/bumper = parent
-	. = carbon_bump_action_checks(target)
-	if(!isnull(.))
+	if(!ismob(target))
+		return
+	if(bumper.next_move > world.time)
 		return
 	var/mob/living/living_target = target
 	if(bumper.faction == living_target.faction)
 		return //FF
-	return living_do_bump_action(target)
-
+	var/obj/item/weapon/gun/gun = bumper.get_active_held_item()
+	if(istype(gun, /obj/item/weapon/gun))
+		gun.attack(target, bumper, CHEST)
+		bumper.changeNext_move(CLICK_CD_MELEE)
 
 /datum/component/bump_attack/proc/xeno_bump_action(datum/source, atom/target)
 	SIGNAL_HANDLER

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -28,6 +28,8 @@
 	var/datum/action/skill/issue_order/focus/issue_order_focus = new
 	issue_order_focus.give_action(src)
 
+	AddComponent(/datum/component/bump_attack)
+
 	//makes order hud visible
 	var/datum/atom_hud/H = GLOB.huds[DATA_HUD_ORDER]
 	H.add_hud_to(usr)


### PR DESCRIPTION

## About The Pull Request

Gives marines the same bump attacks that xenos can use . Only works if you are carrying a gun and yes it will PB.
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
1. Fixes runners being unhittable to some degree
2. Same to the hunter

 Still got to add custom marine sprites for the button..
## Changelog
:cl:
add: Marines now have the reflexes enchanced , and now can PB by simply bumping into xenos.
/:cl:

