### PR TITLE
this adds the m25 to marine vendor just like the PPSH

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -113,6 +113,7 @@
 		/obj/item/weapon/gun/revolver/standard_revolver = 10,
 		/obj/item/weapon/gun/pistol/standard_heavypistol = 10,
 		/obj/item/weapon/gun/pistol/vp70 = 10,
+		/obj/item/ammo_magazine/smg/m25 = 5,
 		/obj/item/weapon/gun/smg/ppsh = 5,
 		/obj/item/weapon/gun/smg/standard_smg = 10,
 		/obj/item/weapon/gun/smg/standard_machinepistol = 10,
@@ -198,6 +199,7 @@
 		/obj/item/ammo_magazine/flamer_tank = 10,
 		/obj/item/ammo_magazine/smg/ppsh/ = 30,
 		/obj/item/ammo_magazine/smg/ppsh/extended = 10,
+		/obj/item/ammo_magazine/smg/m25 = 30,
 		/obj/item/ammo_magazine/rifle/bolt = 7,
 	)
 	premium = list()


### PR DESCRIPTION


<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
this adds the m25 to marine vendor just like the PPSH
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
gives marines another SMG option roundstart
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add:the m25 to marine vendor just like the PPSH
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
