### PR TITLE
Removes Thermobaric from Requisitions

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1040,7 +1040,7 @@ ENGINEERING
 
 /datum/supply_packs/engineering/sandbags
 	name = "50 empty sandbags"
-	contains = list(/obj/item/stack/sandbags_empty/half)
+	contains = list(/obj/item/stack/sandbags_empty/full)
 	cost = 10
 
 /datum/supply_packs/engineering/metal50

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -175,11 +175,6 @@ WEAPONS
 	contains = list(/obj/item/storage/box/standard_hmg)
 	cost = 80
 
-/datum/supply_packs/weapons/quadlauncher
-	name = "M57A4 Quad Thermobaric Launcher"
-	contains = list(/obj/item/weapon/gun/launcher/rocket/m57a4)
-	cost = 250
-
 /datum/supply_packs/weapons/tesla
 	name = "Energy Ball Rifle"
 	contains = list(
@@ -471,11 +466,6 @@ AMMO
 	name = "Box of Incendiary Slugs"
 	contains = list(/obj/item/ammo_magazine/shotgun/incendiary)
 	cost = 10
-
-/datum/supply_packs/ammo/quadlauncher
-	name = "M57A4 thermobaric rocket array"
-	contains = list(/obj/item/ammo_magazine/rocket/m57a4)
-	cost = 50
 
 /datum/supply_packs/ammo/scout_regular
 	name = "M4RA scout magazine"

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1040,7 +1040,7 @@ ENGINEERING
 
 /datum/supply_packs/engineering/sandbags
 	name = "50 empty sandbags"
-	contains = list(/obj/item/stack/sandbags_empty/full)
+	contains = list(/obj/item/stack/sandbags_empty/half)
 	cost = 10
 
 /datum/supply_packs/engineering/metal50


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes Thermobaric and it's ammo from Requisitions


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

When I first redid Requisitions pricing and added the thermobaric at 250 points, it was added as a joke because if Req was able to stack up 250 points, it meant xenos were on the run/had no map control and the round was being dragged out. With the implementation of the Tadpole and miner modules, this became a far more achievable goal, so I'm removing the one-shot kill meme cannon.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Due to demand, the Underdecks has ran dry of Thermobaric Launchers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
