### PR TITLE
Halves Number of Sandbags from Requisitions

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1050,7 +1050,7 @@ ENGINEERING
 
 /datum/supply_packs/engineering/sandbags
 	name = "50 empty sandbags"
-	contains = list(/obj/item/stack/sandbags_empty/full)
+	contains = list(/obj/item/stack/sandbags_empty/half)
 	cost = 10
 
 /datum/supply_packs/engineering/metal50


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Haha atomisation go brr

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Halves number of sandbags per order. Metal cades keep being nerfed so people are just spamming sandbags instead as they're far more effective. When I originally fixed Requisitions prices, I was under the impression 25 sandbags was a full stack so left it as is - I was wrong. This fixes that. 50 sandbags per order was 1 point per barricade.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Halved the number of sandbags per Requisitions order to 25. Our technicians ran out of shirt sleeves to repurpose.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
