### PR TITLE
Revert "auxtools debugger (#5530)"

### DIFF
--- a/SpacemanDMM.toml
+++ b/SpacemanDMM.toml
@@ -3,6 +3,3 @@ dreamchecker = true
 
 [dmdoc]
 use_typepath_names = true
-
-[debugger]
-engine = "auxtools"

--- a/code/__DEFINES/spaceman_dmm.dm
+++ b/code/__DEFINES/spaceman_dmm.dm
@@ -28,14 +28,7 @@
 	#define VAR_PROTECTED var
 #endif
 
-/proc/auxtools_stack_trace(msg)
-	CRASH(msg)
-
-/proc/enable_debugging(mode, port)
-	CRASH("auxtools not loaded")
-
-/world/Del()
-	var/debug_server = world.GetConfig("env", "AUXTOOLS_DEBUG_DLL")
-	if (debug_server)
-		call(debug_server, "auxtools_shutdown")()
-	. = ..()
+/world/proc/enable_debugger()
+	var/dll = world.GetConfig("env", "EXTOOLS_DLL")
+	if (dll)
+		call(dll, "debug_initialize")()

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -8,10 +8,10 @@ GLOBAL_VAR(restart_counter)
 //This happens after the Master subsystem new(s) (it's a global datum)
 //So subsystems globals exist, but are not initialised
 /world/New()
-	var/debug_server = world.GetConfig("env", "AUXTOOLS_DEBUG_DLL")
-	if (debug_server)
-		call(debug_server, "auxtools_init")()
-		enable_debugging()
+	var/extools = world.GetConfig("env", "EXTOOLS_DLL") || "./byond-extools.dll"
+	if(fexists(extools))
+		call(extools, "maptick_initialize")()
+	enable_debugger()
 #ifdef REFERENCE_TRACKING
 	enable_reference_tracking()
 #endif


### PR DESCRIPTION
This reverts commit 6628f7fb6d5f06d8b54a37af124cbe7662af643f.

Breaks extools maptick tracking 
At least TM on the server unless it gets fixed
If i had to guess it isnt getting init by line 13 in world.dm