### PR TITLE
Detpack minimum detonation time reduced from 5 to 2 seconds

### DIFF
--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -105,7 +105,7 @@
 //=================================================
 
 //Define detpack
-#define DETPACK_TIMER_MIN			5
+#define DETPACK_TIMER_MIN			2
 #define DETPACK_TIMER_MAX			300
 
 //Define sniper laser multipliers

--- a/code/game/objects/items/radio/detpack.dm
+++ b/code/game/objects/items/radio/detpack.dm
@@ -11,7 +11,7 @@
 	var/frequency = 1457
 	var/on = FALSE
 	var/armed = FALSE
-	var/timer = 5
+	var/timer = 2
 	var/code = 2
 	var/det_mode = FALSE //FALSE for breach, TRUE for demolition.
 	var/atom/plant_target = null //which atom the detpack is planted on


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changed both detpack default and minimum timer values from 5 to 2
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Detonation packs see no use by anyone ever. They are easily seen by xeno and give a loud warning on top of the slow detonation time. Their price is probably still not worth it but hopefully this will give it some use.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Detpack detonation timer is buffed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
