### PR TITLE
Xenos can now scout their tunnel's surroundings before coming out

### DIFF
--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -702,6 +702,10 @@ TUNNEL
 		to_chat(M, "<span class='xenowarning'>We can't climb through a tunnel while immobile.</span>")
 		return FALSE
 
+	if(length(GLOB.xeno_tunnels) < 2)
+		to_chat(M, "<span class='warning'>There are no other tunnels in the network!</span>")
+		return FALSE
+
 	for(var/tummy_resident in M.stomach_contents)
 		if(ishuman(tummy_resident))
 			var/mob/living/carbon/human/H = tummy_resident
@@ -709,11 +713,22 @@ TUNNEL
 				to_chat(M, "<span class='warning'>We cannot enter the tunnel while the host we devoured has signs of life. We should headbite it to finish it off.</span>")
 				return
 
+	pick_a_tunnel(M)
+
+
+/obj/structure/tunnel/proc/pick_a_tunnel(mob/living/carbon/xenomorph/M)
 	var/obj/structure/tunnel/targettunnel = input(M, "Choose a tunnel to crawl to", "Tunnel") as null|anything in GLOB.xeno_tunnels
 	if(!targettunnel)
 		return
+	if(targettunnel == src)
+		to_chat(M, "<span class='warning'>We're already here!</span>")
+		if(M.loc == src) //If we're in the tunnel and cancelling out, spit us out.
+			M.forceMove(loc)
+		return
 	if(targettunnel.z != z)
 		to_chat(M, "<span class='warning'>That tunnel isn't connected to this one!</span>")
+		if(M.loc == src) //If we're in the tunnel and cancelling out, spit us out.
+			M.forceMove(loc)
 		return
 	var/distance = get_dist(get_turf(src), get_turf(targettunnel))
 	var/tunnel_time = clamp(distance, HIVELORD_TUNNEL_MIN_TRAVEL_TIME, HIVELORD_TUNNEL_SMALL_MAX_TRAVEL_TIME)
@@ -731,9 +746,14 @@ TUNNEL
 
 	if(do_after(M, tunnel_time, FALSE, src, BUSY_ICON_GENERIC))
 		if(targettunnel && isturf(targettunnel.loc)) //Make sure the end tunnel is still there
-			M.forceMove(targettunnel.loc)
-			M.visible_message("<span class='xenonotice'>\The [M] pops out of \the [src].</span>", \
-			"<span class='xenonotice'>We pop out through the other side!</span>")
+			M.forceMove(targettunnel)
+			var/double_check = input(M, "Emerge here?", "Tunnel") as null|anything in list("Yes","Pick another tunnel")
+			if(double_check == "Pick another tunnel")
+				return targettunnel.pick_a_tunnel(M)
+			else //Whether we say yes or cancel out of it
+				M.forceMove(targettunnel.loc)
+				M.visible_message("<span class='xenonotice'>\The [M] pops out of \the [src].</span>", \
+				"<span class='xenonotice'>We pop out through the other side!</span>")
 		else
 			to_chat(M, "<span class='warning'>\The [src] ended unexpectedly, so we return back up.</span>")
 	else

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -715,7 +715,7 @@ TUNNEL
 
 	pick_a_tunnel(M)
 
-
+///Here we pick a tunnel to go to, then travel to that tunnel and peep out, confirming whether or not we want to emerge or go to another tunnel.
 /obj/structure/tunnel/proc/pick_a_tunnel(mob/living/carbon/xenomorph/M)
 	var/obj/structure/tunnel/targettunnel = input(M, "Choose a tunnel to crawl to", "Tunnel") as null|anything in GLOB.xeno_tunnels
 	if(!targettunnel)

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -747,7 +747,7 @@ TUNNEL
 	if(do_after(M, tunnel_time, FALSE, src, BUSY_ICON_GENERIC))
 		if(targettunnel && isturf(targettunnel.loc)) //Make sure the end tunnel is still there
 			M.forceMove(targettunnel)
-			var/double_check = input(M, "Emerge here?", "Tunnel") as null|anything in list("Yes","Pick another tunnel")
+			var/double_check = input(M, "Emerge here?", "Tunnel: [targettunnel]") as null|anything in list("Yes","Pick another tunnel")
 			if(double_check == "Pick another tunnel")
 				return targettunnel.pick_a_tunnel(M)
 			else //Whether we say yes or cancel out of it


### PR DESCRIPTION
## About The Pull Request

Allows Xenos to scout the surroundings of a tunnel they travel to.

## Why It's Good For The Game

Lets a xeno get its bearings before it decides to leave a tunnel, thus avoiding emerging into claymores/an ambush totally blind, or letting it lie in wait for a victim.

## Changelog
:cl:
add: Xenos can now scout out the surroundings of a tunnel they travel to.
/:cl:

![unknown (3)](https://user-images.githubusercontent.com/42553659/103648579-1a65cf80-4f2b-11eb-8342-35ea449a1236.png)
