### PR TITLE
Disables Carrier Evolution/Regression

### DIFF
--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -46,7 +46,7 @@ GLOBAL_LIST_EMPTY(all_species)
 
 GLOBAL_LIST_EMPTY_TYPED(xeno_caste_datums, /list/datum/xeno_caste)
 GLOBAL_LIST_INIT(xeno_types_tier_one, list(/mob/living/carbon/xenomorph/runner, /mob/living/carbon/xenomorph/drone, /mob/living/carbon/xenomorph/sentinel, /mob/living/carbon/xenomorph/defender))
-GLOBAL_LIST_INIT(xeno_types_tier_two, list(/mob/living/carbon/xenomorph/hunter, /mob/living/carbon/xenomorph/warrior, /mob/living/carbon/xenomorph/spitter, /mob/living/carbon/xenomorph/hivelord, /mob/living/carbon/xenomorph/carrier, /mob/living/carbon/xenomorph/bull))
+GLOBAL_LIST_INIT(xeno_types_tier_two, list(/mob/living/carbon/xenomorph/hunter, /mob/living/carbon/xenomorph/warrior, /mob/living/carbon/xenomorph/spitter, /mob/living/carbon/xenomorph/hivelord, /mob/living/carbon/xenomorph/bull)) // reinsert '/mob/living/carbon/xenomorph/carrier' to enable them to be devolved to
 GLOBAL_LIST_INIT(xeno_types_tier_three, list(/mob/living/carbon/xenomorph/ravager, /mob/living/carbon/xenomorph/praetorian, /mob/living/carbon/xenomorph/boiler, /mob/living/carbon/xenomorph/Defiler, /mob/living/carbon/xenomorph/crusher, /mob/living/carbon/xenomorph/shrike))
 
 GLOBAL_LIST_EMPTY_TYPED(hive_datums, /datum/hive_status) // init by makeDatumRefLists()

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
@@ -31,7 +31,7 @@
 	evolves_to = list(
 		/mob/living/carbon/xenomorph/shrike,
 		/mob/living/carbon/xenomorph/queen,
-//		/mob/living/carbon/xenomorph/carrier,
+//		/mob/living/carbon/xenomorph/carrier,	uncomment to enable evolution to Carrier again
 		/mob/living/carbon/xenomorph/hivelord,
 		/mob/living/carbon/xenomorph/hivemind,
 	)

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
@@ -31,7 +31,7 @@
 	evolves_to = list(
 		/mob/living/carbon/xenomorph/shrike,
 		/mob/living/carbon/xenomorph/queen,
-		/mob/living/carbon/xenomorph/carrier,
+//		/mob/living/carbon/xenomorph/carrier,
 		/mob/living/carbon/xenomorph/hivelord,
 		/mob/living/carbon/xenomorph/hivemind,
 	)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes/Disables Carrier Evolution/Regression. Can still be adminspawned.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Every time we 'fix' carrier, people break it again. It's a nonstop source of cheese and bug abuse that isn't particularly fun or engaging for those on the receiving end compared to xenos they can actively contest, and we can't really punish people for doing it because _every_ carrier does it. There's about 15-ish relevant bugfixes for carriers, far more than any other issue in the game, and none of them matter because people always find a way around it. This disables carriers via two comments until they're in a better spot, have been properly fixed, or a different implementation is merged.

![image](https://user-images.githubusercontent.com/44979174/103649254-1307eb80-4f56-11eb-8186-e176a32a99cb.png)


Naaanii, I sentence you to death
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Carriers disabled due to rampant circumvention of intended mechanics.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
