### PR TITLE
Observers Can Now Properly Move to Rally Hive and Resin Silo Death Alerts

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1188,7 +1188,7 @@
 	X.face_atom(A) //Face towards the target so we don't look silly
 
 	xeno_message("<span class='xenoannounce'>Our leader [X] is rallying the hive to [AREACOORD_NO_Z(A)]!</span>", 3, X.hivenumber, FALSE, get_turf(A), 'sound/voice/alien_distantroar_3.ogg')
-	notify_ghosts("\ [X] is rallying the hive to [AREACOORD_NO_Z(A)]!", source = get_turf(A), action = NOTIFY_ORBIT)
+	notify_ghosts("\ [X] is rallying the hive to [AREACOORD_NO_Z(A)]!", source = get_turf(A), action = NOTIFY_JUMP)
 
 	succeed_activate()
 	add_cooldown()

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -72,7 +72,7 @@
 		//Since resin silos are more important now, we need a better notification.
 		associated_hive.xeno_message("<span class='xenoannounce'>A resin silo has been destroyed at [AREACOORD_NO_Z(src)]!</span>", 2, FALSE, src, 'sound/voice/alien_help2.ogg')
 		associated_hive = null
-		notify_ghosts("\ A resin silo has been destroyed at [AREACOORD_NO_Z(src)]!", source = get_turf(src), action = NOTIFY_ORBIT)
+		notify_ghosts("\ A resin silo has been destroyed at [AREACOORD_NO_Z(src)]!", source = get_turf(src), action = NOTIFY_JUMP)
 
 	for(var/i in contents)
 		var/atom/movable/AM = i


### PR DESCRIPTION
## About The Pull Request

Per title.

## Why It's Good For The Game

Fixes a bug.

Fixes: https://github.com/tgstation/TerraGov-Marine-Corps/issues/5669

## Changelog
:cl:
fix: Observers can now properly move to Rally Hive and Resin Silo death alerts
/:cl: