### PR TITLE
More and cheaper smartgun drums

### DIFF
--- a/code/game/objects/items/storage/marine_boxes.dm
+++ b/code/game/objects/items/storage/marine_boxes.dm
@@ -16,6 +16,7 @@
 	new /obj/item/clothing/glasses/night/m56_goggles(src)
 	new /obj/item/weapon/gun/rifle/standard_smartmachinegun(src)
 	new /obj/item/ammo_magazine/standard_smartmachinegun(src)
+	new /obj/item/ammo_magazine/standard_smartmachinegun(src)
 
 /obj/item/smartgun_powerpack
 	name = "\improper M56 powerpack"

--- a/code/game/objects/items/storage/marine_boxes.dm
+++ b/code/game/objects/items/storage/marine_boxes.dm
@@ -6,7 +6,7 @@
 	icon = 'icons/Marine/marine-weapons.dmi'
 	icon_state = "smartgun_case"
 	w_class = WEIGHT_CLASS_HUGE
-	storage_slots = 3
+	storage_slots = 4
 	slowdown = 1
 	can_hold = list() //Nada. Once you take the stuff out it doesn't fit back in.
 	foldable = null

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -205,7 +205,7 @@
 		/obj/item/ammo_magazine/rifle/tx15_flechette = 50,
 		/obj/item/ammo_magazine/pistol/standard_pocketpistol = 50,
 		/obj/item/ammo_magazine/flamer_tank/large = 10,
-		/obj/item/ammo_magazine/standard_smartmachinegun = 4,
+		/obj/item/ammo_magazine/standard_smartmachinegun = 2,
 		/obj/item/ammo_magazine/flamer_tank = 10,
 		/obj/item/ammo_magazine/smg/ppsh/ = 30,
 		/obj/item/ammo_magazine/smg/ppsh/extended = 10,

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -205,7 +205,7 @@
 		/obj/item/ammo_magazine/rifle/tx15_flechette = 50,
 		/obj/item/ammo_magazine/pistol/standard_pocketpistol = 50,
 		/obj/item/ammo_magazine/flamer_tank/large = 10,
-		/obj/item/ammo_magazine/standard_smartmachinegun = 2,
+		/obj/item/ammo_magazine/standard_smartmachinegun = 4,
 		/obj/item/ammo_magazine/flamer_tank = 10,
 		/obj/item/ammo_magazine/smg/ppsh/ = 30,
 		/obj/item/ammo_magazine/smg/ppsh/extended = 10,

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -545,7 +545,7 @@ AMMO
 /datum/supply_packs/ammo/smartmachinegun
 	name = "T-29 smartmachinegun ammo"
 	contains = list(/obj/item/ammo_magazine/standard_smartmachinegun)
-	cost = 10
+	cost = 5
 
 /datum/supply_packs/ammo/sentry
 	name = "UA 571-C sentry ammunition"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

SG drums are now only 5 points in req, and i double the amount available in marine vendors. And sg get one more drum in their essential kit

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

With the aim mode, SG are less critical than what they used to. They should not always beg for req for their expensive ammo. I've put the drums at the same price as miniguns one, wich seem way more fair to me.

## Changelog
:cl:
balance: SG drums price reduced to 5 points, 2 more available in each marine vendor and 1 more in their essential kit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
