### PR TITLE
Neurospit Tweak: Stamina Damage Nerfed, Weak Neurogas Spawn and Neurotoxin Reagent Transfer Added

### DIFF
--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -140,6 +140,7 @@
 #define SMOKE_XENO_HEMODILE (1<<12)
 #define SMOKE_XENO_TRANSVITOX (1<<13)
 #define SMOKE_CHEM			(1<<14)
+#define SMOKE_EXTINGUISH	(1<<15) //Extinguishes fires and mobs that are on fire
 
 //Incapacitated
 #define INCAPACITATED_IGNORE_RESTRAINED (1<<0)

--- a/code/__DEFINES/conflict.dm
+++ b/code/__DEFINES/conflict.dm
@@ -141,6 +141,7 @@
 #define SMOKE_XENO_TRANSVITOX (1<<13)
 #define SMOKE_CHEM			(1<<14)
 #define SMOKE_EXTINGUISH	(1<<15) //Extinguishes fires and mobs that are on fire
+#define SMOKE_NEURO_LIGHT	(1<<16) //Effectively a sub-flag of Neuro; precludes higher impact effects
 
 //Incapacitated
 #define INCAPACITATED_IGNORE_RESTRAINED (1<<0)

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -408,6 +408,12 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 
 #define BASE_GRAB_SLOWDOWN		3 //Slowdown called by /mob/setGrabState(newstate) in mob.dm when grabbing a target aggressively.
 
+///Stamina exhaustion
+
+#define LIVING_STAMINA_EXHAUSTION_COOLDOWN	10 SECONDS //Amount of time between 0 stamina exhaustion events
+#define STAMINA_EXHAUSTION_DEBUFF_STACKS	6 //Amount of slow and stagger stacks applied on stamina exhaustion events
+
+
 //Xeno Defines
 
 #define HIVE_CAN_HIJACK (1<<0)

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -563,6 +563,8 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 
 #define HYPERVENE_REMOVAL_AMOUNT	8
 
+#define GAS_INHALE_REAGENT_TRANSFER_AMOUNT	7
+
 // Squad ID defines moved from game\jobs\job\squad.dm
 #define NO_SQUAD 0
 #define ALPHA_SQUAD 1

--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -272,6 +272,12 @@
 	color = "#ffbf58" //Mustard orange?
 	smoke_traits = SMOKE_XENO|SMOKE_XENO_NEURO|SMOKE_GASP|SMOKE_COUGH
 
+//Xeno neurotox smoke.
+/obj/effect/particle_effect/smoke/xeno/neuro/light
+	alpha = 60
+	opacity = FALSE
+	smoke_can_spread_through = TRUE
+
 /obj/effect/particle_effect/smoke/xeno/hemodile
 	alpha = 40
 	opacity = FALSE
@@ -320,6 +326,9 @@ datum/effect_system/smoke_spread/tactical
 
 /datum/effect_system/smoke_spread/xeno/neuro
 	smoke_type = /obj/effect/particle_effect/smoke/xeno/neuro
+
+/datum/effect_system/smoke_spread/xeno/neuro/light
+	smoke_type = /obj/effect/particle_effect/smoke/xeno/neuro/light
 
 /////////////////////////////////////////////
 // Chem smoke

--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -270,13 +270,14 @@
 //Xeno neurotox smoke.
 /obj/effect/particle_effect/smoke/xeno/neuro
 	color = "#ffbf58" //Mustard orange?
-	smoke_traits = SMOKE_XENO|SMOKE_XENO_NEURO|SMOKE_GASP|SMOKE_COUGH
+	smoke_traits = SMOKE_XENO|SMOKE_XENO_NEURO|SMOKE_GASP|SMOKE_COUGH|SMOKE_EXTINGUISH
 
 //Xeno neurotox smoke.
 /obj/effect/particle_effect/smoke/xeno/neuro/light
 	alpha = 60
 	opacity = FALSE
 	smoke_can_spread_through = TRUE
+	smoke_traits = SMOKE_XENO|SMOKE_XENO_NEURO|SMOKE_GASP|SMOKE_COUGH //Light neuro smoke doesn't extinguish
 
 /obj/effect/particle_effect/smoke/xeno/hemodile
 	alpha = 40

--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -277,7 +277,7 @@
 	alpha = 60
 	opacity = FALSE
 	smoke_can_spread_through = TRUE
-	smoke_traits = SMOKE_XENO|SMOKE_XENO_NEURO|SMOKE_GASP|SMOKE_COUGH //Light neuro smoke doesn't extinguish
+	smoke_traits = SMOKE_XENO|SMOKE_XENO_NEURO|SMOKE_GASP|SMOKE_COUGH|SMOKE_NEURO_LIGHT //Light neuro smoke doesn't extinguish
 
 /obj/effect/particle_effect/smoke/xeno/hemodile
 	alpha = 40

--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -272,7 +272,12 @@
 	color = "#ffbf58" //Mustard orange?
 	smoke_traits = SMOKE_XENO|SMOKE_XENO_NEURO|SMOKE_GASP|SMOKE_COUGH|SMOKE_EXTINGUISH
 
-//Xeno neurotox smoke.
+///Xeno neurotox smoke for Defilers; doesn't extinguish
+/obj/effect/particle_effect/smoke/xeno/neuro/medium
+	color = "#ffbf58" //Mustard orange?
+	smoke_traits = SMOKE_XENO|SMOKE_XENO_NEURO|SMOKE_GASP|SMOKE_COUGH
+
+///Xeno neurotox smoke for neurospit; doesn't extinguish or blind
 /obj/effect/particle_effect/smoke/xeno/neuro/light
 	alpha = 60
 	opacity = FALSE
@@ -327,6 +332,9 @@ datum/effect_system/smoke_spread/tactical
 
 /datum/effect_system/smoke_spread/xeno/neuro
 	smoke_type = /obj/effect/particle_effect/smoke/xeno/neuro
+
+/datum/effect_system/smoke_spread/xeno/neuro/medium
+	smoke_type = /obj/effect/particle_effect/smoke/xeno/neuro/medium
 
 /datum/effect_system/smoke_spread/xeno/neuro/light
 	smoke_type = /obj/effect/particle_effect/smoke/xeno/neuro/light

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -124,7 +124,9 @@
 
 
 /mob/living/carbon/proc/do_vomit()
-	Stun(10 SECONDS)
+	adjust_stagger(3)
+	add_slowdown(3)
+
 	visible_message("<spawn class='warning'>[src] throws up!","<spawn class='warning'>You throw up!", null, 5)
 	playsound(loc, 'sound/effects/splat.ogg', 25, TRUE, 7)
 

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -35,7 +35,7 @@
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO_NEURO))
 		if(!is_blind(src) && has_eyes())
 			to_chat(src, "<span class='danger'>Your eyes sting. You can't see!</span>")
-		if(!istype(S, /obj/effect/particle_effect/smoke/xeno/neuro/light)) //Only full neurogas blinds
+		if(!CHECK_BITFIELD(S.smoke_traits, SMOKE_NEURO_LIGHT)) //Only full neurogas blinds
 			blind_eyes(2)
 		blur_eyes(4)
 		reagents.add_reagent(/datum/reagent/toxin/xeno_neurotoxin, GAS_INHALE_REAGENT_TRANSFER_AMOUNT * S.strength)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -33,11 +33,10 @@
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO_ACID))
 		adjustOxyLoss(4 + S.strength * 2)
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO_NEURO))
-		if(!is_blind(src) && has_eyes())
+		if(!CHECK_BITFIELD(S.smoke_traits, SMOKE_NEURO_LIGHT) && !is_blind(src) && has_eyes()) //Only full neurogas blinds
 			to_chat(src, "<span class='danger'>Your eyes sting. You can't see!</span>")
-		if(!CHECK_BITFIELD(S.smoke_traits, SMOKE_NEURO_LIGHT)) //Only full neurogas blinds
 			blind_eyes(2)
-		blur_eyes(4)
+			blur_eyes(4)
 		reagents.add_reagent(/datum/reagent/toxin/xeno_neurotoxin, GAS_INHALE_REAGENT_TRANSFER_AMOUNT * S.strength)
 		if(prob(10 * S.strength)) //Likely to momentarily freeze up/fall due to arms/hands seizing up
 			to_chat(src, "<span class='danger'>You feel your body going numb and lifeless!</span>")

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -29,7 +29,7 @@
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_PLASMALOSS))
 		adjustToxLoss(0.25)
 		adjustStaminaLoss(3)
-		blur_eyes(2)	
+		blur_eyes(2)
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO_ACID))
 		adjustOxyLoss(4 + S.strength * 2)
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO_NEURO))
@@ -37,13 +37,13 @@
 			to_chat(src, "<span class='danger'>Your eyes sting. You can't see!</span>")
 		blur_eyes(4)
 		blind_eyes(2)
-		reagents.add_reagent(/datum/reagent/toxin/xeno_neurotoxin, 5 + S.strength * 2)
+		reagents.add_reagent(/datum/reagent/toxin/xeno_neurotoxin, GAS_INHALE_REAGENT_TRANSFER_AMOUNT * S.strength)
 		if(prob(10 * S.strength)) //Likely to momentarily freeze up/fall due to arms/hands seizing up
 			to_chat(src, "<span class='danger'>You feel your body going numb and lifeless!</span>")
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO_HEMODILE))
-		reagents.add_reagent(/datum/reagent/toxin/xeno_hemodile, 5 + S.strength * 2)
+		reagents.add_reagent(/datum/reagent/toxin/xeno_hemodile, GAS_INHALE_REAGENT_TRANSFER_AMOUNT * S.strength)
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO_TRANSVITOX))
-		reagents.add_reagent(/datum/reagent/toxin/xeno_transvitox, 5 + S.strength * 2)
+		reagents.add_reagent(/datum/reagent/toxin/xeno_transvitox, GAS_INHALE_REAGENT_TRANSFER_AMOUNT * S.strength)
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_CHEM))
 		S.pre_chem_effect(src)
 
@@ -51,14 +51,14 @@
 	. = ..()
 	var/protection = .
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO_NEURO) && (internal || has_smoke_protection())) //either inhaled or this.
-		reagents.add_reagent(/datum/reagent/toxin/xeno_neurotoxin, round((3 + S.strength) * protection, 0.1))
+		reagents.add_reagent(/datum/reagent/toxin/xeno_neurotoxin, round(GAS_INHALE_REAGENT_TRANSFER_AMOUNT * 0.6 * S.strength * protection, 0.1))
 		if(prob(10 * S.strength * protection))
 			to_chat(src, "<span class='danger'>Your body goes numb where the gas touches it!</span>")
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO_HEMODILE) && (internal || has_smoke_protection())) //either inhaled or this.
-		reagents.add_reagent(/datum/reagent/toxin/xeno_hemodile, round((3 + S.strength) * protection, 0.1))
+		reagents.add_reagent(/datum/reagent/toxin/xeno_hemodile, round(GAS_INHALE_REAGENT_TRANSFER_AMOUNT * 0.6 * S.strength * protection, 0.1))
 		if(prob(10 * S.strength * protection))
 			to_chat(src, "<span class='danger'>Your muscles' strength drains away where the gas makes contact!</span>")
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO_TRANSVITOX) && (internal || has_smoke_protection())) //either inhaled or this.
-		reagents.add_reagent(/datum/reagent/toxin/xeno_transvitox, round((3 + S.strength) * protection, 0.1))
+		reagents.add_reagent(/datum/reagent/toxin/xeno_transvitox, round(GAS_INHALE_REAGENT_TRANSFER_AMOUNT * 0.6 * S.strength * protection, 0.1))
 		if(prob(10 * S.strength * protection))
 			to_chat(src, "<span class='danger'>Your exposed wounds coagulate with a dark green tint!</span>")

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -35,8 +35,9 @@
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO_NEURO))
 		if(!is_blind(src) && has_eyes())
 			to_chat(src, "<span class='danger'>Your eyes sting. You can't see!</span>")
+		if(!istype(S, /obj/effect/particle_effect/smoke/xeno/neuro/light)) //Only full neurogas blinds
+			blind_eyes(2)
 		blur_eyes(4)
-		blind_eyes(2)
 		reagents.add_reagent(/datum/reagent/toxin/xeno_neurotoxin, GAS_INHALE_REAGENT_TRANSFER_AMOUNT * S.strength)
 		if(prob(10 * S.strength)) //Likely to momentarily freeze up/fall due to arms/hands seizing up
 			to_chat(src, "<span class='danger'>You feel your body going numb and lifeless!</span>")

--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
@@ -104,7 +104,7 @@
 		smoke_range = 3
 	else if(X.selected_reagent == /datum/reagent/toxin/xeno_transvitox)
 		N.smoke_type = /obj/effect/particle_effect/smoke/xeno/transvitox
-		N.strength = -0.75
+		N.strength = 0.75
 		smoke_range = 4
 	while(count)
 		if(X.stagger) //If we got staggered, return

--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
@@ -97,7 +97,7 @@
 	var/mob/living/carbon/xenomorph/Defiler/X = owner
 	set waitfor = FALSE
 	var/smoke_range = 2
-	var/datum/effect_system/smoke_spread/xeno/neuro/N = new(X)
+	var/datum/effect_system/smoke_spread/xeno/neuro/medium/N = new(X)
 	N.strength = 1
 	if(X.selected_reagent == /datum/reagent/toxin/xeno_hemodile)
 		N.smoke_type = /obj/effect/particle_effect/smoke/xeno/hemodile

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -249,7 +249,7 @@
 	smoke_delay = FALSE
 
 /mob/living/proc/smoke_contact(obj/effect/particle_effect/smoke/S)
-	var/protection = max(1 - get_permeability_protection() * S.bio_protection)
+	var/protection = max(1 - get_permeability_protection() * S.bio_protection, 0)
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_BLISTERING))
 		adjustFireLoss(15 * protection)
 		to_chat(src, "<span class='danger'>It feels as if you've been dumped into an open fire!</span>")

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -239,6 +239,8 @@
 		smokecloak_on()
 	if(smoke_delay)
 		return FALSE
+	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_EXTINGUISH))
+		ExtinguishMob()
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO) && (stat == DEAD || isnestedhost(src)))
 		return FALSE
 	smoke_delay = TRUE
@@ -250,6 +252,8 @@
 
 /mob/living/proc/smoke_contact(obj/effect/particle_effect/smoke/S)
 	var/protection = max(1 - get_permeability_protection() * S.bio_protection, 0)
+	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_EXTINGUISH))
+		ExtinguishMob()
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_BLISTERING))
 		adjustFireLoss(15 * protection)
 		to_chat(src, "<span class='danger'>It feels as if you've been dumped into an open fire!</span>")

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -239,8 +239,6 @@
 		smokecloak_on()
 	if(smoke_delay)
 		return FALSE
-	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_EXTINGUISH))
-		ExtinguishMob()
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO) && (stat == DEAD || isnestedhost(src)))
 		return FALSE
 	smoke_delay = TRUE

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -125,3 +125,6 @@
 	var/slowdown = 0
 	///Temporary inability to use special actions; hurts projectile damage. Regenerates each tick.
 	var/stagger = 0
+
+	/// This is the cooldown on suffering additional effects for when we exhaust all stamina
+	COOLDOWN_DECLARE(last_stamina_exhaustion)

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -59,7 +59,14 @@
 /mob/living/proc/adjustStaminaLoss(amount, update = TRUE, feedback = TRUE)
 	if(status_flags & GODMODE)
 		return FALSE	//godmode
-	staminaloss = clamp(staminaloss + amount, -max_stamina_buffer, maxHealth * 2)
+
+	var/stamina_loss_adjustment = staminaloss + amount
+	var/health_limit = maxHealth * 2
+	if(stamina_loss_adjustment > health_limit) //If we exceed maxHealth * 2 stamina damage, apply any excess as oxyloss
+		adjustOxyLoss(stamina_loss_adjustment - health_limit)
+
+	staminaloss = clamp(stamina_loss_adjustment, -max_stamina_buffer, health_limit)
+
 	if(amount > 0)
 		last_staminaloss_dmg = world.time
 	if(update)
@@ -73,13 +80,18 @@
 		updateStamina(feedback)
 
 /mob/living/proc/updateStamina(feedback = TRUE)
-	if(staminaloss < max(health * 1.5,0))
+	if(staminaloss < max(health * 1.5,0) || !(COOLDOWN_CHECK(src, last_stamina_exhaustion))) //If we're on cooldown for stamina exhaustion, don't bother
 		return
-	if(!IsParalyzed())
-		if(feedback)
-			visible_message("<span class='warning'>\The [src] slumps to the ground, too weak to continue fighting.</span>",
-				"<span class='warning'>You slump to the ground, you're too exhausted to keep going...</span>")
-	Paralyze(80)
+
+	if(feedback)
+		visible_message("<span class='warning'>\The [src] slumps to the ground, too weak to continue fighting.</span>",
+			"<span class='warning'>You slump to the ground, you're too exhausted to keep going...</span>")
+
+	ParalyzeNoChain(1 SECONDS) //Short stun
+	adjust_stagger(STAMINA_EXHAUSTION_DEBUFF_STACKS)
+	add_slowdown(STAMINA_EXHAUSTION_DEBUFF_STACKS)
+	adjust_blurriness(STAMINA_EXHAUSTION_DEBUFF_STACKS)
+	COOLDOWN_START(src, last_stamina_exhaustion, LIVING_STAMINA_EXHAUSTION_COOLDOWN) //set the cooldown.
 
 
 /mob/living/carbon/human/updateStamina(feedback = TRUE)

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1382,7 +1382,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	max_range = 10
 	accuracy_var_low = 3
 	accuracy_var_high = 3
-	damage = 20
+	damage = 30
 	stagger_stacks = 1
 	slowdown_stacks = 1
 	smoke_strength = 0.5
@@ -1465,6 +1465,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	name = "neurotoxic spatter"
 	added_spit_delay = 10
 	spit_cost = 75
+	damage = 35
 	smoke_strength = 0.6
 	reagent_transfer_amount = 7.5
 
@@ -1485,6 +1486,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	name = "neurotoxic splash"
 	added_spit_delay = 15
 	spit_cost = 100
+	damage = 40
 	smoke_strength = 0.65
 	reagent_transfer_amount = 8.5
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1380,14 +1380,13 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage = 20
 	stagger_stacks = 1
 	slowdown_stacks = 1
-	smoke_strength = 1
+	smoke_strength = 0.65
 	smoke_range = 0
 	reagent_transfer_amount = 5
 
 /datum/ammo/xeno/toxin/proc/set_reagents()
 	spit_reagents = list(/datum/reagent/toxin/xeno_neurotoxin = reagent_transfer_amount)
-	message_admins("Neuro Amount = [spit_reagents[1]]")
-	message_admins("Reagent Transfer Amount = [reagent_transfer_amount]")
+
 
 /datum/ammo/xeno/toxin/on_hit_mob(mob/living/carbon/C, obj/projectile/P)
 	drop_neuro_smoke(get_turf(C))
@@ -1403,10 +1402,8 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 
 	set_reagents()
 	var/armor_block = 1 - C.run_armor_check(null, armor_type) //Check the target's armor mod
-	message_admins("Armor Block = [armor_block]")
 	for(var/r_id in spit_reagents) //modify by armor
 		spit_reagents[r_id] *= armor_block
-		message_admins("Spit Reagents = [spit_reagents[r_id]]")
 
 	C.reagents.add_reagent_list(spit_reagents) //transfer reagents
 
@@ -1447,15 +1444,15 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	smoke_system.start()
 
 /datum/ammo/xeno/toxin/upgrade1
-	smoke_strength = 1.05
+	smoke_strength = 0.7
 	reagent_transfer_amount = 6
 
 /datum/ammo/xeno/toxin/upgrade2
-	smoke_strength = 1.1
+	smoke_strength = 0.75
 	reagent_transfer_amount = 7
 
 /datum/ammo/xeno/toxin/upgrade3
-	smoke_strength = 1.15
+	smoke_strength = 0.8
 	reagent_transfer_amount = 8
 
 
@@ -1463,19 +1460,19 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	name = "neurotoxic spatter"
 	added_spit_delay = 10
 	spit_cost = 75
-	smoke_strength = 1.05
+	smoke_strength = 0.75
 	reagent_transfer_amount = 6
 
 /datum/ammo/xeno/toxin/medium/upgrade1
-	smoke_strength = 1.1
+	smoke_strength = 0.8
 	reagent_transfer_amount = 7
 
 /datum/ammo/xeno/toxin/medium/upgrade2
-	smoke_strength = 1.15
+	smoke_strength = 0.85
 	reagent_transfer_amount = 8
 
 /datum/ammo/xeno/toxin/medium/upgrade3
-	smoke_strength = 1.2
+	smoke_strength = 0.9
 	reagent_transfer_amount = 9
 
 
@@ -1484,19 +1481,19 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	added_spit_delay = 15
 	spit_cost = 100
 	smoke_range = 1
-	smoke_strength = 1.1
+	smoke_strength = 0.85
 	reagent_transfer_amount = 7
 
 /datum/ammo/xeno/toxin/heavy/upgrade1
-	smoke_strength = 1.15
+	smoke_strength = 0.9
 	reagent_transfer_amount = 8
 
 /datum/ammo/xeno/toxin/heavy/upgrade2
-	smoke_strength = 1.2
+	smoke_strength = 0.95
 	reagent_transfer_amount = 9
 
 /datum/ammo/xeno/toxin/heavy/upgrade3
-	smoke_strength = 1.25
+	smoke_strength = 1
 	reagent_transfer_amount = 10
 
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1360,7 +1360,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	accuracy_var_high = 3
 	bullet_color = COLOR_LIME
 	var/datum/effect_system/smoke_spread/xeno/smoke_system
-	var/list/spit_reagents = new/list()
+	var/list/datum/reagent/spit_reagents = new/list()
 	var/reagent_transfer_amount
 	var/stagger_stacks
 	var/slowdown_stacks
@@ -1373,7 +1373,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	spit_cost = 50
 	added_spit_delay = 5
 	damage_type = STAMINA
-	accurate_range = 7
+	accurate_range = 5
 	max_range = 10
 	accuracy_var_low = 3
 	accuracy_var_high = 3
@@ -1386,7 +1386,6 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 
 /datum/ammo/xeno/toxin/proc/set_reagents()
 	spit_reagents = list(/datum/reagent/toxin/xeno_neurotoxin = reagent_transfer_amount)
-
 
 /datum/ammo/xeno/toxin/on_hit_mob(mob/living/carbon/C, obj/projectile/P)
 	drop_neuro_smoke(get_turf(C))
@@ -1401,9 +1400,9 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	C.add_slowdown(slowdown_stacks) //slow em down
 
 	set_reagents()
-	var/armor_block = 1 - C.run_armor_check(null, armor_type) //Check the target's armor mod
-	for(var/r_id in spit_reagents) //modify by armor
-		spit_reagents[r_id] *= armor_block
+	var/armor_block = (1 - C.run_armor_check(BODY_ZONE_CHEST, armor_type) * 0.01) //Check the target's armor mod; default to chest
+	for(var/reagent_id in spit_reagents) //modify by armor
+		spit_reagents[reagent_id] *= armor_block
 
 	C.reagents.add_reagent_list(spit_reagents) //transfer reagents
 
@@ -1480,7 +1479,6 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	name = "neurotoxic splash"
 	added_spit_delay = 15
 	spit_cost = 100
-	smoke_range = 1
 	smoke_strength = 0.65
 	reagent_transfer_amount = 6.5
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1359,70 +1359,145 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	accuracy_var_low = 3
 	accuracy_var_high = 3
 	bullet_color = COLOR_LIME
+	var/datum/effect_system/smoke_spread/xeno/smoke_system
+	var/list/spit_reagents = new/list()
+	var/reagent_transfer_amount
+	var/stagger_stacks
+	var/slowdown_stacks
+	var/smoke_strength
+	var/smoke_range
 
 /datum/ammo/xeno/toxin
 	name = "neurotoxic spit"
-	flags_ammo_behavior = AMMO_XENO
+	flags_ammo_behavior = AMMO_XENO|AMMO_EXPLOSIVE
 	spit_cost = 50
 	added_spit_delay = 5
 	damage_type = STAMINA
-	accurate_range = 5
+	accurate_range = 7
 	max_range = 10
 	accuracy_var_low = 3
 	accuracy_var_high = 3
-	damage = 45
+	damage = 20
+	stagger_stacks = 1
+	slowdown_stacks = 1
+	smoke_strength = 1
+	smoke_range = 0
+	reagent_transfer_amount = 5
+
+/datum/ammo/xeno/toxin/proc/set_reagents()
+	spit_reagents = list(/datum/reagent/toxin/xeno_neurotoxin = reagent_transfer_amount)
+	message_admins("Neuro Amount = [spit_reagents[1]]")
+	message_admins("Reagent Transfer Amount = [reagent_transfer_amount]")
 
 /datum/ammo/xeno/toxin/on_hit_mob(mob/living/carbon/C, obj/projectile/P)
+	drop_neuro_smoke(get_turf(C))
+
 	if(!istype(C) || C.stat == DEAD || C.issamexenohive(P.firer) )
 		return
 
 	if(isnestedhost(C))
 		return
 
-	staggerstun(C, P, stagger = 1, slowdown = 1) //Staggers and slows down briefly
+	C.adjust_stagger(stagger_stacks) //stagger briefly; useful for support
+	C.add_slowdown(slowdown_stacks) //slow em down
+
+	set_reagents()
+	var/armor_block = 1 - C.run_armor_check(null, armor_type) //Check the target's armor mod
+	message_admins("Armor Block = [armor_block]")
+	for(var/r_id in spit_reagents) //modify by armor
+		spit_reagents[r_id] *= armor_block
+		message_admins("Spit Reagents = [spit_reagents[r_id]]")
+
+	C.reagents.add_reagent_list(spit_reagents) //transfer reagents
 
 	return ..()
 
+/datum/ammo/xeno/toxin/on_hit_obj(obj/O,obj/projectile/P)
+	var/turf/T = get_turf(O)
+	if(!T)
+		T = get_turf(P)
+
+	if(O.density && !(O.flags_atom & ON_BORDER))
+		T = get_turf(get_step(T, turn(P.dir, 180))) //If the object is dense and not a border object like barricades, we instead drop in the location just prior to the target
+
+	drop_neuro_smoke(T)
+
+/datum/ammo/xeno/toxin/on_hit_turf(turf/T,obj/projectile/P)
+	if(!T)
+		T = get_turf(P)
+
+	if(isclosedturf(T))
+		T = get_turf(get_step(T, turn(P.dir, 180))) //If the turf is closed, we instead drop in the location just prior to the turf
+
+	drop_neuro_smoke(T)
+
+/datum/ammo/xeno/toxin/do_at_max_range(obj/projectile/P)
+	drop_neuro_smoke(get_turf(P))
+
+/datum/ammo/xeno/toxin/set_smoke()
+	smoke_system = new /datum/effect_system/smoke_spread/xeno/neuro/light()
+
+/datum/ammo/xeno/toxin/proc/drop_neuro_smoke(turf/T)
+	if(T.density)
+		return
+
+	set_smoke()
+	smoke_system.strength = smoke_strength
+	smoke_system.set_up(smoke_range, T)
+	smoke_system.start()
+
 /datum/ammo/xeno/toxin/upgrade1
-	damage = 50
+	smoke_strength = 1.05
+	reagent_transfer_amount = 6
 
 /datum/ammo/xeno/toxin/upgrade2
-	damage = 55
+	smoke_strength = 1.1
+	reagent_transfer_amount = 7
 
 /datum/ammo/xeno/toxin/upgrade3
-	damage = 60
+	smoke_strength = 1.15
+	reagent_transfer_amount = 8
 
 
 /datum/ammo/xeno/toxin/medium //Queen
 	name = "neurotoxic spatter"
 	added_spit_delay = 10
 	spit_cost = 75
-	damage = 55
+	smoke_strength = 1.05
+	reagent_transfer_amount = 6
 
 /datum/ammo/xeno/toxin/medium/upgrade1
-	damage = 60
+	smoke_strength = 1.1
+	reagent_transfer_amount = 7
 
 /datum/ammo/xeno/toxin/medium/upgrade2
-	damage = 65
+	smoke_strength = 1.15
+	reagent_transfer_amount = 8
 
 /datum/ammo/xeno/toxin/medium/upgrade3
-	damage = 70
+	smoke_strength = 1.2
+	reagent_transfer_amount = 9
 
 
 /datum/ammo/xeno/toxin/heavy //Praetorian
 	name = "neurotoxic splash"
 	added_spit_delay = 15
 	spit_cost = 100
-	damage = 60
+	smoke_range = 1
+	smoke_strength = 1.1
+	reagent_transfer_amount = 7
 
 /datum/ammo/xeno/toxin/heavy/upgrade1
-	damage = 65
+	smoke_strength = 1.15
+	reagent_transfer_amount = 8
 
 /datum/ammo/xeno/toxin/heavy/upgrade2
-	damage = 70
+	smoke_strength = 1.2
+	reagent_transfer_amount = 9
 
 /datum/ammo/xeno/toxin/heavy/upgrade3
-	damage = 75
+	smoke_strength = 1.25
+	reagent_transfer_amount = 10
 
 
 /datum/ammo/xeno/sticky
@@ -1438,6 +1513,8 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage = 20 //minor; this is mostly just to provide confirmation of a hit
 	max_range = 40
 	bullet_color = COLOR_PURPLE
+	stagger_stacks = 2
+	slowdown_stacks = 3
 
 
 /datum/ammo/xeno/sticky/on_hit_mob(mob/M,obj/projectile/P)
@@ -1446,8 +1523,8 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 		var/mob/living/carbon/C = M
 		if(C.issamexenohive(P.firer))
 			return
-		C.adjust_stagger(2) //stagger briefly; useful for support
-		C.add_slowdown(3) //slow em down
+		C.adjust_stagger(stagger_stacks) //stagger briefly; useful for support
+		C.add_slowdown(slowdown_stacks) //slow em down
 
 
 /datum/ammo/xeno/sticky/on_hit_obj(obj/O,obj/projectile/P)
@@ -1548,7 +1625,6 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	icon_state = "boiler_gas2"
 	ping = "ping_x"
 	flags_ammo_behavior = AMMO_XENO|AMMO_SKIPS_ALIENS|AMMO_EXPLOSIVE
-	var/datum/effect_system/smoke_spread/xeno/smoke_system
 	var/danger_message = "<span class='danger'>A glob of acid lands with a splat and explodes into noxious fumes!</span>"
 	armor_type = "bio"
 	accuracy_var_high = 10

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1359,11 +1359,16 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	accuracy_var_low = 3
 	accuracy_var_high = 3
 	bullet_color = COLOR_LIME
-	var/datum/effect_system/smoke_spread/xeno/smoke_system
-	var/list/datum/reagent/spit_reagents = new/list()
+	///List of reagents transferred upon spit impact if any
+	var/list/datum/reagent/spit_reagents
+	///Amount of reagents transferred upon spit impact if any
 	var/reagent_transfer_amount
+	///Amount of stagger stacks imposed on impact if any
 	var/stagger_stacks
+	///Amount of slowdown stacks imposed on impact if any
 	var/slowdown_stacks
+	///These define the reagent transfer strength of the smoke caused by the spit, if any, and its aoe
+	var/datum/effect_system/smoke_spread/xeno/smoke_system
 	var/smoke_strength
 	var/smoke_range
 
@@ -1384,6 +1389,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	smoke_range = 0
 	reagent_transfer_amount = 5
 
+///Set up the list of reagents the spit transfers upon impact
 /datum/ammo/xeno/toxin/proc/set_reagents()
 	spit_reagents = list(/datum/reagent/toxin/xeno_neurotoxin = reagent_transfer_amount)
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1387,7 +1387,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	slowdown_stacks = 1
 	smoke_strength = 0.5
 	smoke_range = 0
-	reagent_transfer_amount = 5
+	reagent_transfer_amount = 6.5
 
 ///Set up the list of reagents the spit transfers upon impact
 /datum/ammo/xeno/toxin/proc/set_reagents()
@@ -1450,15 +1450,15 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 
 /datum/ammo/xeno/toxin/upgrade1
 	smoke_strength = 0.55
-	reagent_transfer_amount = 5.5
+	reagent_transfer_amount = 7
 
 /datum/ammo/xeno/toxin/upgrade2
 	smoke_strength = 0.6
-	reagent_transfer_amount = 6
+	reagent_transfer_amount = 7.5
 
 /datum/ammo/xeno/toxin/upgrade3
 	smoke_strength = 0.65
-	reagent_transfer_amount = 6.5
+	reagent_transfer_amount = 8
 
 
 /datum/ammo/xeno/toxin/medium //Queen
@@ -1466,19 +1466,19 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	added_spit_delay = 10
 	spit_cost = 75
 	smoke_strength = 0.6
-	reagent_transfer_amount = 6
+	reagent_transfer_amount = 7.5
 
 /datum/ammo/xeno/toxin/medium/upgrade1
 	smoke_strength = 0.65
-	reagent_transfer_amount = 6.5
+	reagent_transfer_amount = 8
 
 /datum/ammo/xeno/toxin/medium/upgrade2
 	smoke_strength = 0.7
-	reagent_transfer_amount = 7
+	reagent_transfer_amount = 8.5
 
 /datum/ammo/xeno/toxin/medium/upgrade3
 	smoke_strength = 0.75
-	reagent_transfer_amount = 7.5
+	reagent_transfer_amount = 9
 
 
 /datum/ammo/xeno/toxin/heavy //Praetorian
@@ -1486,19 +1486,19 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	added_spit_delay = 15
 	spit_cost = 100
 	smoke_strength = 0.65
-	reagent_transfer_amount = 6.5
+	reagent_transfer_amount = 8.5
 
 /datum/ammo/xeno/toxin/heavy/upgrade1
 	smoke_strength = 0.7
-	reagent_transfer_amount = 7
+	reagent_transfer_amount = 9
 
 /datum/ammo/xeno/toxin/heavy/upgrade2
 	smoke_strength = 0.75
-	reagent_transfer_amount = 7.5
+	reagent_transfer_amount = 9.5
 
 /datum/ammo/xeno/toxin/heavy/upgrade3
 	smoke_strength = 0.8
-	reagent_transfer_amount = 8
+	reagent_transfer_amount = 10
 
 
 /datum/ammo/xeno/sticky

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1380,7 +1380,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage = 20
 	stagger_stacks = 1
 	slowdown_stacks = 1
-	smoke_strength = 0.65
+	smoke_strength = 0.5
 	smoke_range = 0
 	reagent_transfer_amount = 5
 
@@ -1444,36 +1444,36 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	smoke_system.start()
 
 /datum/ammo/xeno/toxin/upgrade1
-	smoke_strength = 0.7
-	reagent_transfer_amount = 6
+	smoke_strength = 0.55
+	reagent_transfer_amount = 5.5
 
 /datum/ammo/xeno/toxin/upgrade2
-	smoke_strength = 0.75
-	reagent_transfer_amount = 7
+	smoke_strength = 0.6
+	reagent_transfer_amount = 6
 
 /datum/ammo/xeno/toxin/upgrade3
-	smoke_strength = 0.8
-	reagent_transfer_amount = 8
+	smoke_strength = 0.65
+	reagent_transfer_amount = 6.5
 
 
 /datum/ammo/xeno/toxin/medium //Queen
 	name = "neurotoxic spatter"
 	added_spit_delay = 10
 	spit_cost = 75
-	smoke_strength = 0.75
+	smoke_strength = 0.6
 	reagent_transfer_amount = 6
 
 /datum/ammo/xeno/toxin/medium/upgrade1
-	smoke_strength = 0.8
-	reagent_transfer_amount = 7
+	smoke_strength = 0.65
+	reagent_transfer_amount = 6.5
 
 /datum/ammo/xeno/toxin/medium/upgrade2
-	smoke_strength = 0.85
-	reagent_transfer_amount = 8
+	smoke_strength = 0.7
+	reagent_transfer_amount = 7
 
 /datum/ammo/xeno/toxin/medium/upgrade3
-	smoke_strength = 0.9
-	reagent_transfer_amount = 9
+	smoke_strength = 0.75
+	reagent_transfer_amount = 7.5
 
 
 /datum/ammo/xeno/toxin/heavy //Praetorian
@@ -1481,20 +1481,20 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	added_spit_delay = 15
 	spit_cost = 100
 	smoke_range = 1
-	smoke_strength = 0.85
-	reagent_transfer_amount = 7
+	smoke_strength = 0.65
+	reagent_transfer_amount = 6.5
 
 /datum/ammo/xeno/toxin/heavy/upgrade1
-	smoke_strength = 0.9
-	reagent_transfer_amount = 8
+	smoke_strength = 0.7
+	reagent_transfer_amount = 7
 
 /datum/ammo/xeno/toxin/heavy/upgrade2
-	smoke_strength = 0.95
-	reagent_transfer_amount = 9
+	smoke_strength = 0.75
+	reagent_transfer_amount = 7.5
 
 /datum/ammo/xeno/toxin/heavy/upgrade3
-	smoke_strength = 1
-	reagent_transfer_amount = 10
+	smoke_strength = 0.8
+	reagent_transfer_amount = 8
 
 
 /datum/ammo/xeno/sticky

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1374,7 +1374,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 
 /datum/ammo/xeno/toxin
 	name = "neurotoxic spit"
-	flags_ammo_behavior = AMMO_XENO|AMMO_EXPLOSIVE
+	flags_ammo_behavior = AMMO_XENO|AMMO_EXPLOSIVE|AMMO_SKIPS_ALIENS
 	spit_cost = 50
 	added_spit_delay = 5
 	damage_type = STAMINA

--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -643,7 +643,10 @@
 	take_overall_damage_armored(round(burnlevel*0.5)* fire_mod, BURN, "fire", updating_health = TRUE)
 	to_chat(src, "<span class='danger'>You are burned!</span>")
 
-
+/obj/flamer_fire/effect_smoke(obj/effect/particle_effect/smoke/S)
+	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_EXTINGUISH)) //Fire suppressing smoke
+		firelevel -= 20 //Water level extinguish
+		updateicon()
 
 /mob/living/carbon/human/flamer_fire_crossed(burnlevel, firelevel, fire_mod = 1)
 	if(hard_armor.getRating("fire") >= 100)

--- a/code/modules/reagents/reagents/toxin.dm
+++ b/code/modules/reagents/reagents/toxin.dm
@@ -469,12 +469,14 @@
 			L.adjustStaminaLoss(2*effect_str) //While stamina loss is going, stamina regen apparently doesn't happen, so I can keep this smaller.
 			L.reagent_pain_modifier -= PAIN_REDUCTION_LIGHT
 		if(21 to 45)
+			L.adjust_drugginess(1.1) //Move this to stage 2 and 3 so it's not so obnoxious
 			L.adjustStaminaLoss(6*effect_str)
 			L.reagent_pain_modifier -= PAIN_REDUCTION_HEAVY
 		if(46 to INFINITY)
+			L.adjust_drugginess(1.1)
 			L.adjustStaminaLoss(15*effect_str)
 			L.reagent_pain_modifier -= PAIN_REDUCTION_VERY_HEAVY
-	L.adjust_drugginess(1.1)
+	L.adjust_blurriness(1.3)
 	L.stuttering = max(L.stuttering, 1)
 	return ..()
 

--- a/code/modules/reagents/reagents/toxin.dm
+++ b/code/modules/reagents/reagents/toxin.dm
@@ -480,14 +480,13 @@
 			L.jitter(8) //Shows that things are *really* bad
 
 	//Apply stamina damage, or tox damage if our stamina loss is maxed out
-	var/health_limit = L.maxHealth * 2
-	if(L.staminaloss + power > health_limit) //If we exceed maxHealth * 2 stamina damage, apply any excess as toxloss and oxyloss
-		var/stamina_excess_damage = L.staminaloss + power * 0.5 - health_limit
+	var/stamina_loss_limit = L.maxHealth * 2
+	if(L.staminaloss + power > stamina_loss_limit) //If we exceed maxHealth * 2 stamina damage, apply any excess as toxloss and oxyloss
+		var/stamina_excess_damage = (L.staminaloss + power * 0.5) - stamina_loss_limit
 		L.adjustToxLoss(stamina_excess_damage)
 		L.adjustOxyLoss(stamina_excess_damage)
 
-	else
-		L.adjustStaminaLoss(power)
+	L.adjustStaminaLoss(min(power, max(0, stamina_loss_limit - L.staminaloss))) //If we're under our stamina_loss limit, apply the difference between our limit and current stamina damage or power, whichever's less
 
 	if(L.eye_blurry < 30) //So we don't have the visual acuity of Mister Magoo forever
 		L.adjust_blurriness(1.3)

--- a/code/modules/reagents/reagents/toxin.dm
+++ b/code/modules/reagents/reagents/toxin.dm
@@ -469,32 +469,37 @@
 			power = (2*effect_str) //While stamina loss is going, stamina regen apparently doesn't happen, so I can keep this smaller.
 			L.reagent_pain_modifier -= PAIN_REDUCTION_LIGHT
 		if(21 to 45)
-			L.adjust_drugginess(1.1) //Move this to stage 2 and 3 so it's not so obnoxious
 			power = (6*effect_str)
 			L.reagent_pain_modifier -= PAIN_REDUCTION_HEAVY
 			L.jitter(4) //Shows that things are bad
 		if(46 to INFINITY)
-			L.adjust_drugginess(1.1)
 			power = (15*effect_str)
 			L.reagent_pain_modifier -= PAIN_REDUCTION_VERY_HEAVY
 			L.jitter(8) //Shows that things are *really* bad
 
-	//Apply stamina damage, or tox damage if our stamina loss is maxed out
+	//Apply stamina damage, then apply any 'excess' stamina damage beyond our maximum as tox and oxy damage
 	var/stamina_loss_limit = L.maxHealth * 2
-	if(L.staminaloss + power > stamina_loss_limit) //If we exceed maxHealth * 2 stamina damage, apply any excess as toxloss and oxyloss
-		var/stamina_excess_damage = (L.staminaloss + power * 0.5) - stamina_loss_limit
-		L.adjustToxLoss(stamina_excess_damage)
-		L.adjustOxyLoss(stamina_excess_damage)
-
 	L.adjustStaminaLoss(min(power, max(0, stamina_loss_limit - L.staminaloss))) //If we're under our stamina_loss limit, apply the difference between our limit and current stamina damage or power, whichever's less
+
+	var/stamina_excess_damage = (L.staminaloss + power) - stamina_loss_limit
+	if(stamina_excess_damage > 0) //If we exceed maxHealth * 2 stamina damage, apply any excess as toxloss and oxyloss
+		L.adjustToxLoss(stamina_excess_damage * 0.5)
+		L.adjustOxyLoss(stamina_excess_damage * 0.5)
+		L.Losebreath(2) //So the oxy loss actually means something.
+
+	L.stuttering = max(L.stuttering, 1)
+
+	if(current_cycle < 21) //Additional effects at higher cycles
+		return ..()
+
+	L.adjust_drugginess(1.1) //Move this to stage 2 and 3 so it's not so obnoxious
 
 	if(L.eye_blurry < 30) //So we don't have the visual acuity of Mister Magoo forever
 		L.adjust_blurriness(1.3)
-	L.stuttering = max(L.stuttering, 1)
+
+
 	return ..()
 
-/datum/reagent/toxin/xeno_neurotoxin/overdose_crit_process(mob/living/L, metabolism)
-	L.Losebreath(1) //Can't breathe; for punishing the bullies
 
 /datum/reagent/toxin/xeno_growthtoxin
 	name = "Larval Accelerant"


### PR DESCRIPTION
## About The Pull Request

Neurospit reworked to output much lower Stamina damage, transfer neurotoxin chems to the target (subject to bio armor) and create weak, translucent neurotoxin gas.

Boiler neurotoxin gas now extinguishes fire and burning mobs.

Losing all Stamina now no longer causes an 8 second stun; instead it imposes a 1 second stun and ~11 seconds of slow and stagger that recurs up to once per 10 seconds while Stamina is still depleted. This allows people with fully depleted Stamina to still act.

Stamina damage dealt to a target that has maxed Stamina damage now deals an equal amount of oxy damage instead.

Neurotoxin no longer overdoses. While a victim with maxed Stamina damage would take Stamina damage from neuro, it instead takes half this amount as oxy damage and half as toxin damage, while causing loss of breath.

Puking slows and staggers for about 5 seconds instead of stunning for 10.

Neuroglobs now deal 50 stamina damage on hit with 40 pen, standardizing their damage/pen with acid globs.

Neuroglobs now transfer 30U Neurotoxin on hit subject to chest bio armor.

Neuroglobs now stun only for 0.5 seconds down from 2.1 seconds.

## Why It's Good For The Game

Eliminates the last remaining source of spike Stamina damage that can be exploited to easily secure captures, replacing it with more tactically and mechanically interesting area denial smoke and reagent transfer that imposes deferred/delayed Stamina damage, and acts as an ongoing debuff/pre-med counter. 

Neurosmoke much more useful for the boiler.

Also gas masks and anti-tox/neuro meds are now much more useful.

Pukes no longer stun for 10 seconds, and penalizes while allowing for player agency.

Stamina depletion no longer hard CCs for 8 seconds, allowing for more player agency.


## Changelog
:cl:
balance: Base Stamina damage dealt by neurospit reduced to 30/35/40. Neurospit now transfers neurotoxin to the target which is reduced by bio armor.
balance: Neurospit now spawns a small area of weak neuro gas; strength of neurogas scales with the user's upgrade level. Praetorian neurospit gas area is larger.
balance: Boiler neurogas extinguishes fire and burning mobs.
balance: Neuro no longer overdoses, and it now deals oxy and toxin damage instead of stamina damage while its victim's stamina is fully depleted.
balance: Neuroglobs now deal 50 stamina damage on hit with 40 pen, standardizing their damage/pen with acid globs.
balance: Neuroglobs now transfer 30U Neurotoxin on hit subject to chest bio armor.
balance: Neuroglobs now stun only for 0.5 seconds down from 2.1 seconds.
refactor: Gas strength calculations refactored to utilize multipliers. Adjusted gas strengths as needed.
tweak: Puking now only slows and staggers for about 5 seconds instead of stunning for 10.
tweak: Having Stamina depleted now only briefly stuns and slows and staggers once every 10 seconds instead of stunning for 8 seconds each time Stamina damage is taken while Stamina is depleted.
tweak: Neuro no longer applies drugginess until its effect has progressed, making this more obvious.
/:cl: