### PR TITLE
Evasion Made More Reasonable

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -549,7 +549,7 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define DRONE_SALVAGE_EVOLUTION_FILTER_LIST	list(XENO_TIER_ZERO, XENO_TIER_THREE, XENO_TIER_FOUR)
 
 //Runner defines
-#define RUNNER_EVASION_STACKS				250 //How much projectile damage we auto-dodge.
+#define RUNNER_EVASION_STACKS				100 //How much projectile damage we auto-dodge.
 #define RUNNER_EVASION_DURATION				8 SECONDS //How long Evasion lasts.
 #define RUNNER_EVASION_DURATION_WARNING		0.7 //After what % of Evasion's time elapsed do we warn the user
 #define RUNNER_EVASION_RUN_DELAY			0.5 SECONDS //If the time since the Runner last moved is equal to or greater than this, its Evasion ends.


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Drops runner evasion stacks from 250 to 100, meaning 150 less damage evaded. I plan to make runner evasion based on your speed modifier in future, but this is a nice change until then.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

250 effectively gave runner the same health pool as an Ancient Empress, making it nigh-invulnerable because by the time evasion had stopped, it had broken your arm, removed it, or you were crit. This now means it's going to survive a few bullets rather than your entire magazine, making it a difference between life and death rather than godmode.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Runner evasion stacks dropped to 100, from 250.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
