### PR TITLE
Fixes Observer Hive Status Runtimes for Resin Silos

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -68,10 +68,10 @@
 
 
 ///Relays health and location data about resin silos belonging to the same hive as the input user
-/proc/resin_silo_status_output(mob/living/carbon/xenomorph/user)
+/proc/resin_silo_status_output(mob/living/carbon/xenomorph/user, datum/hive_status/hive)
 	. = "<BR><b>List of Resin Silos:</b><BR><table cellspacing=4>" //Resin silo data
 	for(var/obj/structure/resin/silo/resin_silo as() in GLOB.xeno_resin_silos)
-		if(resin_silo.associated_hive == user.hive)
+		if(resin_silo.associated_hive == hive)
 
 			var/hp_color = "green"
 			switch(resin_silo.obj_integrity/resin_silo.max_integrity)
@@ -159,7 +159,7 @@
 	dat += "<table cellspacing=4>"
 	dat += xenoinfo
 	dat += "</table>"
-	dat += resin_silo_status_output(user)
+	dat += resin_silo_status_output(user, hive)
 
 	var/datum/browser/popup = new(user, "roundstatus", "<div align='center'>Hive Status</div>", 650, 650)
 	popup.set_content(dat)


### PR DESCRIPTION
## About The Pull Request

Fixes silo related runtimes when observers try to look at Hive Status.

## Why It's Good For The Game

Fixes a bug.

## Changelog
:cl:
fix: Fixes silo related runtimes when observers try to look at Hive Status.
/:cl: