### PR TITLE
right click menu has been disabled, right click has been freed

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -87,12 +87,10 @@
 		return
 	if(modifiers["shift"] && modifiers["right"])
 		ShiftRightClickOn(A)
-		return 1
+		return
 	if(modifiers["alt"] && modifiers["right"])
-		AltRightClickOn(A)
-		return 1
-	if(modifiers["right"])
-		RightClickOn(A)
+		return
+	if(modifiers["right"] && RightClickOn(A))
 		return
 
 	if(incapacitated(TRUE))
@@ -333,22 +331,28 @@ if(selected_ability.target_flags & flagname){\
 */
 
 
+///Called when a owner mob Rightmouseclicks an atom
 /mob/proc/RightClickOn(atom/A)
 	A.RightClick(src)
 
+///Called when a owner mob Shift + Rightmouseclicks an atom
 /mob/proc/ShiftRightClickOn(atom/A)
 	A.ShiftRightClick(src)
 
+///Called when a owner mob Alt + Rightmouseclicks an atom, given that Altclick does not return TRUE
 /mob/proc/AltRightClickOn(atom/A)
 	A.AltRightClick(src)
 
+///Called when a mob Rightmouseclicks this atom
+/atom/proc/RightClick(mob/user)
+	return
+
+///Called when a mob Shift + Rightmouseclicks this atom
 /atom/proc/ShiftRightClick(mob/user)
 	return
-
+	
+///Called when a mob Alt + Rightmouseclicks this atom, given that mobs Altclick() does not return TRUE
 /atom/proc/AltRightClick(mob/user)
-	return
-
-/atom/proc/RightClick(mob/user)
 	return
 
 /*

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -85,6 +85,15 @@
 	if(modifiers["ctrl"])
 		CtrlClickOn(A)
 		return
+	if(modifiers["shift"] && modifiers["right"])
+		ShiftRightClickOn(A)
+		return 1
+	if(modifiers["alt"] && modifiers["right"])
+		AltRightClickOn(A)
+		return 1
+	if(modifiers["right"])
+		RightClickOn(A)
+		return
 
 	if(incapacitated(TRUE))
 		return
@@ -318,6 +327,29 @@ if(selected_ability.target_flags & flagname){\
 	A = ability_target(A)
 	if(selected_ability.can_use_ability(A))
 		selected_ability.use_ability(A)
+
+/*
+	Right click
+*/
+
+
+/mob/proc/RightClickOn(var/atom/A)
+	A.RightClick(src)
+
+/mob/proc/ShiftRightClickOn(var/atom/A)
+	A.ShiftRightClick(src)
+
+/mob/proc/AltRightClickOn(var/atom/A)
+	A.AltRightClick(src)
+
+/atom/proc/ShiftRightClick(var/mob/user)
+	return
+
+/atom/proc/AltRightClick(var/mob/user)
+	return
+
+/atom/proc/RightClick(var/mob/user)
+	return
 
 /*
 	Shift click

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -333,22 +333,22 @@ if(selected_ability.target_flags & flagname){\
 */
 
 
-/mob/proc/RightClickOn(var/atom/A)
+/mob/proc/RightClickOn(atom/A)
 	A.RightClick(src)
 
-/mob/proc/ShiftRightClickOn(var/atom/A)
+/mob/proc/ShiftRightClickOn(atom/A)
 	A.ShiftRightClick(src)
 
-/mob/proc/AltRightClickOn(var/atom/A)
+/mob/proc/AltRightClickOn(atom/A)
 	A.AltRightClick(src)
 
-/atom/proc/ShiftRightClick(var/mob/user)
+/atom/proc/ShiftRightClick(mob/user)
 	return
 
-/atom/proc/AltRightClick(var/mob/user)
+/atom/proc/AltRightClick(mob/user)
 	return
 
-/atom/proc/RightClick(var/mob/user)
+/atom/proc/RightClick(mob/user)
 	return
 
 /*

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1224,3 +1224,19 @@
 	qdel(frommob)
 
 	return TRUE
+
+//A verb so that admins can toggle right click if they need to use debug stuff. - Matt, thanks matt
+/client/proc/toggle_right_click()
+	set name = "Toggle Right Click"
+	set category = "Admin"
+
+	if(!show_popup_menus)
+		show_popup_menus = TRUE
+		to_chat(src, "<span class='interface'>Right click enabled.</span>")
+	else
+		show_popup_menus = FALSE
+		to_chat(src, "<span class='interface'>Right click disabled.</span>")
+
+	if(!check_rights(R_ADMIN))
+		return
+

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1224,19 +1224,3 @@
 	qdel(frommob)
 
 	return TRUE
-
-//A verb so that admins can toggle right click if they need to use debug stuff. - Matt, thanks matt
-/client/proc/toggle_right_click()
-	set name = "Toggle Right Click"
-	set category = "Admin"
-
-	if(!show_popup_menus)
-		show_popup_menus = TRUE
-		to_chat(src, "<span class='interface'>Right click enabled.</span>")
-	else
-		show_popup_menus = FALSE
-		to_chat(src, "<span class='interface'>Right click disabled.</span>")
-
-	if(!check_rights(R_ADMIN))
-		return
-

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -92,3 +92,5 @@
 
 	/// Messages currently seen by this client
 	var/list/seen_messages
+
+	show_popup_menus = FALSE // right click menu no longer shows up

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -330,3 +330,14 @@ GLOBAL_LIST_INIT(ghost_others_options, list(GHOST_OTHERS_SIMPLE, GHOST_OTHERS_DE
 	usr.client.prefs.save_preferences()
 
 	to_chat(usr, "<span class='notice'>You will [(usr.client.prefs.toggles_sound & SOUND_INSTRUMENTS_OFF) ? "no longer" : "now"] hear instruments.</span>")
+
+client/proc/toggle_right_click()
+	set name = "Toggle Right Click"
+	set category = "Admin"
+
+	if(!show_popup_menus)
+		show_popup_menus = TRUE
+		to_chat(src, "<span class='interface'>Right click enabled.</span>")
+	else
+		show_popup_menus = FALSE
+		to_chat(src, "<span class='interface'>Right click disabled.</span>")

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -331,13 +331,10 @@ GLOBAL_LIST_INIT(ghost_others_options, list(GHOST_OTHERS_SIMPLE, GHOST_OTHERS_DE
 
 	to_chat(usr, "<span class='notice'>You will [(usr.client.prefs.toggles_sound & SOUND_INSTRUMENTS_OFF) ? "no longer" : "now"] hear instruments.</span>")
 
-client/verb/toggle_right_click()
+///Toggles the right click menu on and off
+/client/verb/toggle_right_click()
 	set name = "Toggle Right Click"
 	set category = "Preferences"
 
-	if(!show_popup_menus)
-		show_popup_menus = TRUE
-		to_chat(src, "<span class='interface'>Right click enabled.</span>")
-	else
-		show_popup_menus = FALSE
-		to_chat(src, "<span class='interface'>Right click disabled.</span>")
+	show_popup_menus = !show_popup_menus
+	to_chat(src, "<span class='interface'>Right click [show_popup_menus ? "en" : "dis"]abled.</span>")

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -331,9 +331,9 @@ GLOBAL_LIST_INIT(ghost_others_options, list(GHOST_OTHERS_SIMPLE, GHOST_OTHERS_DE
 
 	to_chat(usr, "<span class='notice'>You will [(usr.client.prefs.toggles_sound & SOUND_INSTRUMENTS_OFF) ? "no longer" : "now"] hear instruments.</span>")
 
-client/proc/toggle_right_click()
+client/verb/toggle_right_click()
 	set name = "Toggle Right Click"
-	set category = "Admin"
+	set category = "Preferences"
 
 	if(!show_popup_menus)
 		show_popup_menus = TRUE

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -89,7 +89,7 @@
 			//						   	  \\
 //----------------------------------------------------------
 
-/obj/item/weapon/gun/AltClick(mob/user)
+/obj/item/weapon/gun/RightClick(mob/user)
 	toggle_gun_safety()
 
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports this from is12, thanks matt. All credit to him.

Admins still have the ability to setup the pop up menu.

Safety is now right click for guns as a proof of concept
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
GIves us way more control over our controls. And allows for more use of the mouse rather than having an antiquated shhitty right click menu
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Right click menu is now toggleable in preferences
tweak: moved safety from alt click to right click
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
