### PR TITLE
Give distress vessels their thrusters

### DIFF
--- a/_maps/shuttles/distress.dmm
+++ b/_maps/shuttles/distress.dmm
@@ -158,6 +158,12 @@
 	},
 /turf/open/shuttle/dropship/floor,
 /area/shuttle/ert)
+"G" = (
+/turf/closed/shuttle/ert{
+	icon_state = "leftengine_3";
+	opacity = 0
+	},
+/area/shuttle/ert)
 "H" = (
 /turf/closed/shuttle/ert{
 	icon_state = "stan1"
@@ -182,6 +188,36 @@
 	icon_state = "stan3"
 	},
 /area/shuttle/ert)
+"N" = (
+/turf/closed/shuttle/ert{
+	icon_state = "rightengine_3";
+	opacity = 0
+	},
+/area/shuttle/ert)
+"O" = (
+/turf/closed/shuttle/ert{
+	icon_state = "leftengine_2";
+	opacity = 0
+	},
+/area/shuttle/ert)
+"Q" = (
+/turf/closed/shuttle/ert{
+	icon_state = "rightengine_1";
+	opacity = 0
+	},
+/area/shuttle/ert)
+"R" = (
+/turf/closed/shuttle/ert{
+	icon_state = "leftengine_1";
+	opacity = 0
+	},
+/area/shuttle/ert)
+"S" = (
+/turf/closed/shuttle/ert{
+	icon_state = "rightengine_2";
+	opacity = 0
+	},
+/area/shuttle/ert)
 
 (1,1,1) = {"
 a
@@ -194,9 +230,9 @@ i
 p
 i
 x
-a
-a
-a
+G
+O
+R
 "}
 (2,1,1) = {"
 a
@@ -284,7 +320,7 @@ o
 p
 o
 B
-a
-a
-a
+N
+S
+Q
 "}

--- a/_maps/shuttles/distress_pmc.dmm
+++ b/_maps/shuttles/distress_pmc.dmm
@@ -209,6 +209,12 @@
 	icon_state = "nt_rightengine"
 	},
 /area/shuttle/ert/pmc)
+"O" = (
+/turf/closed/shuttle/ert{
+	icon_state = "rightengine_1";
+	opacity = 0
+	},
+/area/shuttle/ert/pmc)
 "Q" = (
 /turf/closed/shuttle/ert{
 	icon_state = "nt1"
@@ -224,6 +230,36 @@
 	icon_state = "nt3"
 	},
 /area/shuttle/ert/pmc)
+"T" = (
+/turf/closed/shuttle/ert{
+	icon_state = "leftengine_1";
+	opacity = 0
+	},
+/area/shuttle/ert/pmc)
+"U" = (
+/turf/closed/shuttle/ert{
+	icon_state = "rightengine_3";
+	opacity = 0
+	},
+/area/shuttle/ert/pmc)
+"V" = (
+/turf/closed/shuttle/ert{
+	icon_state = "leftengine_2";
+	opacity = 0
+	},
+/area/shuttle/ert/pmc)
+"W" = (
+/turf/closed/shuttle/ert{
+	icon_state = "rightengine_2";
+	opacity = 0
+	},
+/area/shuttle/ert/pmc)
+"X" = (
+/turf/closed/shuttle/ert{
+	icon_state = "leftengine_3";
+	opacity = 0
+	},
+/area/shuttle/ert/pmc)
 
 (1,1,1) = {"
 a
@@ -236,9 +272,9 @@ B
 p
 F
 K
-a
-a
-a
+X
+V
+T
 "}
 (2,1,1) = {"
 a
@@ -326,7 +362,7 @@ D
 p
 J
 N
-a
-a
-a
+U
+W
+O
 "}

--- a/_maps/shuttles/distress_upp.dmm
+++ b/_maps/shuttles/distress_upp.dmm
@@ -196,6 +196,42 @@
 	icon_state = "upp3"
 	},
 /area/shuttle/ert/upp)
+"N" = (
+/turf/closed/shuttle/ert{
+	icon_state = "leftengine_2";
+	opacity = 0
+	},
+/area/shuttle/ert/upp)
+"Q" = (
+/turf/closed/shuttle/ert{
+	icon_state = "leftengine_3";
+	opacity = 0
+	},
+/area/shuttle/ert/upp)
+"U" = (
+/turf/closed/shuttle/ert{
+	icon_state = "leftengine_1";
+	opacity = 0
+	},
+/area/shuttle/ert/upp)
+"V" = (
+/turf/closed/shuttle/ert{
+	icon_state = "rightengine_3";
+	opacity = 0
+	},
+/area/shuttle/ert/upp)
+"X" = (
+/turf/closed/shuttle/ert{
+	icon_state = "rightengine_1";
+	opacity = 0
+	},
+/area/shuttle/ert/upp)
+"Z" = (
+/turf/closed/shuttle/ert{
+	icon_state = "rightengine_2";
+	opacity = 0
+	},
+/area/shuttle/ert/upp)
 
 (1,1,1) = {"
 a
@@ -208,9 +244,9 @@ i
 p
 i
 A
-a
-a
-a
+Q
+N
+U
 "}
 (2,1,1) = {"
 a
@@ -298,7 +334,7 @@ o
 p
 o
 F
-a
-a
-a
+V
+Z
+X
 "}


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The human distress vessels have missing engines on their aft. This can be noticed when comparing them to the PMC replica on Ice Colony. Here is how they look now:

![image](https://user-images.githubusercontent.com/57928673/104241908-f66f2600-5423-11eb-9cb1-5990f8f2706f.png)

Do note that these are technically walls.

## Why It's Good For The Game

Doesn't this look wrong as hell?

![image](https://user-images.githubusercontent.com/57928673/104242054-31715980-5424-11eb-834a-9b255f70247b.png)


## Changelog
:cl:
tweak: Terran Shipyards has released a recall on ERT vessels without their thrusters.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
