### PR TITLE
Fixes Bug With Rally Hive Not Being Removed From Demoted Ex-Leader Xenos

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -314,7 +314,7 @@
 	X.queen_chosen_lead = FALSE
 
 	if(!isxenoshrike(X) && !isxenoqueen(X) && !isxenohivemind(X)) //These innately have the Rally Hive ability
-		X.xeno_caste.actions -= /datum/action/xeno_action/activable/rally_hive
+		X.remove_rally_hive_ability()
 
 /datum/hive_status/proc/update_leader_pheromones() // helper function to easily trigger an update of leader pheromones
 	for(var/i in xeno_leader_list)

--- a/code/modules/mob/living/carbon/xenomorph/xeno_helpers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_helpers.dm
@@ -31,3 +31,13 @@
 	var/datum/action/xeno_action/activable/rally_hive/rally = new /datum/action/xeno_action/activable/rally_hive
 
 	rally.give_action(src)
+
+///Helper proc for removing the rally hive ability appropriately
+/mob/living/carbon/xenomorph/proc/remove_rally_hive_ability()
+
+	var/datum/action/xeno_action/activable/rally_hive/rally = actions_by_path[/datum/action/xeno_action/activable/rally_hive]
+
+	if(!rally) //We don't have Rally Hive; abort.
+		return
+
+	rally.remove_action(src)


### PR DESCRIPTION
## About The Pull Request

Per title.

## Why It's Good For The Game

Fixes: https://github.com/tgstation/TerraGov-Marine-Corps/issues/5723

## Changelog
:cl:
fix: Fixes a bug so that Rally Hive is properly removed from demoted xenos.
/:cl: