### PR TITLE
Win Condition Revert

### DIFF
--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -135,8 +135,8 @@
 		return TRUE
 	if(!num_xenos)
 		if(round_stage == DISTRESS_DROPSHIP_CRASHED)
-			message_admins("Round finished: [MODE_INFESTATION_X_MINOR]") //xenos hijacked the shuttle and won groundside but died on the ship, minor victory
-			round_finished = MODE_INFESTATION_X_MINOR
+			message_admins("Round finished: [MODE_INFESTATION_M_MINOR]") //marines lost the ground battle but wiped the xenos shipside, marine minor victory
+			round_finished = MODE_INFESTATION_M_MINOR
 			return TRUE
 		message_admins("Round finished: [MODE_INFESTATION_M_MAJOR]") //marines win big or go home
 		round_finished = MODE_INFESTATION_M_MAJOR


### PR DESCRIPTION
Reverts the win condition where if Xenos all die shipside, it is a Marine Minor Victory.

<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reverts the win conditions. If Xenos die shipside, it is a Marine Minor Victory.

## Why It's Good For The Game

Rewards and encourages marines to be more aggressive during shipside combat and they still have the option to deny a Xeno victory by being more defensive and using SD instead.

While the focus is on groundside combat, Xenos should not be encouraged to be suicidal at all for a free win condition nor should they be rewarded for dying and actually force the marines to self destruct as a better alternative than getting wiped out.

Marines have the option to AO retreat if they feel that the Xeno force is too overwhelming to give the Xenos the minor victory.

## Changelog
:cl:
tweak: changed round end win conditions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
