### PR TITLE
evac that marine already. hes a mummy!!!

### DIFF
--- a/code/__DEFINES/objects.dm
+++ b/code/__DEFINES/objects.dm
@@ -103,8 +103,8 @@ GLOBAL_LIST_INIT(restricted_camera_networks, list( //Those networks can only be 
 #define TOKEN_ALL				15
 
 //MEDEVAC DEFINES
-#define MEDEVAC_COOLDOWN		1800 //180 seconds or 3 minutes
-#define MEDEVAC_TELE_DELAY		30 //3 seconds
+#define MEDEVAC_COOLDOWN		1500 //150 seconds or 2,5 minutes aka 2 minutes and 30 secs
+#define MEDEVAC_TELE_DELAY		50 // 5 seconds
 //Sentry defines
 #define SENTRY_ALERT_AMMO				1
 #define SENTRY_ALERT_HOSTILE			2

--- a/code/__DEFINES/objects.dm
+++ b/code/__DEFINES/objects.dm
@@ -103,8 +103,8 @@ GLOBAL_LIST_INIT(restricted_camera_networks, list( //Those networks can only be 
 #define TOKEN_ALL				15
 
 //MEDEVAC DEFINES
-#define MEDEVAC_COOLDOWN		3000 //300 seconds or 5 minutes
-#define MEDEVAC_TELE_DELAY		50 //5 seconds
+#define MEDEVAC_COOLDOWN		1800 //180 seconds or 3 minutes
+#define MEDEVAC_TELE_DELAY		30 //3 seconds
 //Sentry defines
 #define SENTRY_ALERT_AMMO				1
 #define SENTRY_ALERT_HOSTILE			2


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
this changes the cooldown from 5min to 2.5 mins ((2 mins and 30 seconds))
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
makes medevacs more used. doctors get more work corpsman ACTUALLY evac marines. and you wont have marines walking around with 5splints, not wanting to
risk the walk back to fob
wait alamo to cycle
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: medevac cooldown from 5 to 2,5
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
