### PR TITLE
Pump shotgun rework+Paladin 12 attachments

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -637,7 +637,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	hud_state = "shotgun_buckshot"
 	flags_ammo_behavior = AMMO_BALLISTIC
 	bonus_projectiles_type = /datum/ammo/bullet/shotgun/spread
-	bonus_projectiles_amount = 4
+	bonus_projectiles_amount = 5
 	bonus_projectiles_scatter = 5
 	accuracy_var_low = 9
 	accuracy_var_high = 9
@@ -659,7 +659,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	accuracy_var_high = 9
 	accurate_range = 3
 	max_range = 10
-	damage = 20
+	damage = 25
 	damage_falloff = 2
 	penetration = 0
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -560,7 +560,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	sundering = 7
 
 /datum/ammo/bullet/shotgun/slug/on_hit_mob(mob/M,obj/projectile/P)
-	staggerstun(M, P, weaken = 1, stagger = 2, knockback = 1)
+	staggerstun(M, P, weaken = 1, stagger = 2, slowdown = 0.5, knockback = 1)
 
 
 /datum/ammo/bullet/shotgun/beanbag
@@ -614,10 +614,10 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	accuracy_var_low = 8
 	accuracy_var_high = 8
 	max_range = 15
-	damage = 40
+	damage = 50
 	damage_falloff = 0.5
 	penetration = 15
-	sundering = 3.5
+	sundering = 3
 
 /datum/ammo/bullet/shotgun/flechette_spread
 	name = "additional flechette"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -614,10 +614,10 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	accuracy_var_low = 8
 	accuracy_var_high = 8
 	max_range = 15
-	damage = 50
+	damage = 40
 	damage_falloff = 0.5
 	penetration = 15
-	sundering = 3
+	sundering = 3.5
 
 /datum/ammo/bullet/shotgun/flechette_spread
 	name = "additional flechette"
@@ -637,19 +637,19 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	hud_state = "shotgun_buckshot"
 	flags_ammo_behavior = AMMO_BALLISTIC
 	bonus_projectiles_type = /datum/ammo/bullet/shotgun/spread
-	bonus_projectiles_amount = 5
-	bonus_projectiles_scatter = 10
+	bonus_projectiles_amount = 4
+	bonus_projectiles_scatter = 5
 	accuracy_var_low = 9
 	accuracy_var_high = 9
 	accurate_range = 3
 	max_range = 10
 	damage = 40
-	damage_falloff = 4
+	damage_falloff = 2
 	penetration = 0
 
 
 /datum/ammo/bullet/shotgun/buckshot/on_hit_mob(mob/M,obj/projectile/P)
-	staggerstun(M, P, weaken = 1, stagger = 1, knockback = 2, slowdown = 0.5, max_range = 3)
+	staggerstun(M, P, weaken = 1, stagger = 1, knockback = 3, slowdown = 0.5, max_range = 5)
 
 /datum/ammo/bullet/shotgun/spread
 	name = "additional buckshot"
@@ -659,9 +659,12 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	accuracy_var_high = 9
 	accurate_range = 3
 	max_range = 10
-	damage = 40
-	damage_falloff = 4
+	damage = 20
+	damage_falloff = 2
 	penetration = 0
+
+/datum/ammo/bullet/shotgun/spread/on_hit_mob(mob/M,obj/projectile/P)
+	staggerstun(M, P, slowdown = 0.1, max_range = 5)
 
 //buckshot variant only used by the masterkey shotgun attachment.
 /datum/ammo/bullet/shotgun/buckshot/masterkey

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -569,6 +569,8 @@ can cause issues with ammo types getting mixed up during the burst.
 	attachable_allowed = list(
 						/obj/item/attachable/reddot,
 						/obj/item/attachable/gyro,
+						/obj/item/attachable/bayonetknife,
+						/obj/item/attachable/bayonet,
 						/obj/item/attachable/flashlight,
 						/obj/item/attachable/compensator,
 						/obj/item/attachable/scope/mini,


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Buckshot no longer deals 240 damage, now deals 165 damage if all pellets connect.

Max range of the effects of the main pellet and side pellets staggerstuff is now 5. Halved falloff and less spread. 3 knockback rather than 2.
Side pellets deal /1 slowdown.  Per hit
Flechette deals 10 less damage, .5 more sunder.

Slugs deal 0.5 slowdown
Paladin 12 has bayonets now.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
12 gauge shotguns should honestly be relegated to a more support oriented role rather than being this stupid big dick damage machine that encourages rocket tag gameplay, they were the last vestiage of the rocket tag era in tgmc and this aims to reduce them to a more reasonable level.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Buckshot deals 165 from 240 damage, flechette unchanged, slugs now deal slowdown once again. Buckshot knocks back a tile further and all the pellets deal slowdown.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
