### PR TITLE
Hivelord Infusion Nerf

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -330,7 +330,7 @@ GLOBAL_LIST_INIT(thickenable_resin, typecacheof(list(
 		return FALSE
 
 	owner.face_atom(target) //Face the target so we don't look stupid
-	owner.visible_message(user, "<span class='xenodanger'>\the [owner] begins channeling mysterious energies towards [target] ...</span>")
+	user.visible_message(user, "<span class='xenodanger'>\the [owner] begins channeling mysterious energies towards [target] ...</span>")
 	if(!do_after(user, 15 SECONDS, TRUE, src, BUSY_ICON_BUILD))
 		return FALSE
 	owner.visible_message("<span class='xenodanger'>\the [owner] infuses [target] with mysterious energy!</span>", \

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -331,7 +331,8 @@ GLOBAL_LIST_INIT(thickenable_resin, typecacheof(list(
 
 	owner.face_atom(target) //Face the target so we don't look stupid
 	owner.visible_message(owner, "<span class='xenodanger'>\the [owner] begins channeling mysterious energies towards [target] ...</span>")
-	if(!do_mob(owner, target, 3 SECONDS, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL))
+	if(!do_mob(owner, target, 4 SECONDS, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL))
+		owner.beam(target,"medbeam",'icons/effects/beam.dmi',10, 10,/obj/effect/ebeam,1)
 		return FALSE
 	owner.visible_message("<span class='xenodanger'>\the [owner] infuses [target] with mysterious energy!</span>", \
 	"<span class='xenodanger'>We empower [target] with our [src]!</span>")

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -331,7 +331,7 @@ GLOBAL_LIST_INIT(thickenable_resin, typecacheof(list(
 
 	owner.face_atom(target) //Face the target so we don't look stupid
 	owner.visible_message(owner, "<span class='xenodanger'>\the [owner] begins channeling mysterious energies towards [target] ...</span>")
-	if(!do_after(owner, 8 SECONDS, TRUE, src, BUSY_ICON_MEDICAL))
+	if(!do_mob(owner, target, 3 SECONDS, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL))
 		return FALSE
 	owner.visible_message("<span class='xenodanger'>\the [owner] infuses [target] with mysterious energy!</span>", \
 	"<span class='xenodanger'>We empower [target] with our [src]!</span>")

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -331,8 +331,8 @@ GLOBAL_LIST_INIT(thickenable_resin, typecacheof(list(
 
 	owner.face_atom(target) //Face the target so we don't look stupid
 	owner.visible_message(owner, "<span class='xenodanger'>\the [owner] begins channeling mysterious energies towards [target] ...</span>")
-	if(!do_mob(owner, target, 4 SECONDS, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL))
-		owner.beam(target,"medbeam",'icons/effects/beam.dmi',10, 10,/obj/effect/ebeam,1)
+	owner.beam(target,"medbeam",'icons/effects/beam.dmi',10, 10,/obj/effect/ebeam,4)
+	if(!do_mob(owner, target, 4 SECONDS, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL)))
 		return FALSE
 	owner.visible_message("<span class='xenodanger'>\the [owner] infuses [target] with mysterious energy!</span>", \
 	"<span class='xenodanger'>We empower [target] with our [src]!</span>")

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -331,8 +331,8 @@ GLOBAL_LIST_INIT(thickenable_resin, typecacheof(list(
 
 	owner.face_atom(target) //Face the target so we don't look stupid
 	owner.visible_message(owner, "<span class='xenodanger'>\the [owner] begins channeling mysterious energies towards [target] ...</span>")
-	owner.beam(target,"medbeam",'icons/effects/beam.dmi',40, 10,/obj/effect/ebeam,1)
 	if(!do_mob(owner, target, 4 SECONDS, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL))
+		owner.beam(target,"medbeam",'icons/effects/beam.dmi',40, 10,/obj/effect/ebeam,1)
 		return FALSE
 	owner.visible_message("<span class='xenodanger'>\the [owner] infuses [target] with mysterious energy!</span>", \
 	"<span class='xenodanger'>We empower [target] with our [src]!</span>")

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -331,16 +331,13 @@ GLOBAL_LIST_INIT(thickenable_resin, typecacheof(list(
 
 	owner.face_atom(target) //Face the target so we don't look stupid
 	owner.visible_message(owner, "<span class='xenodanger'>\the [owner] begins channeling mysterious energies towards [target] ...</span>")
-	if(!do_mob(owner.beam(target,"medbeam",'icons/effects/beam.dmi',40, 10,/obj/effect/ebeam,1)))
-		return FALSE
-	if(!do_mob(owner, target, 4 SECONDS, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL))
+	if(!do_mob(owner, target, 4 SECONDS, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL, owner.beam(target,"medbeam",'icons/effects/beam.dmi',40, 10,/obj/effect/ebeam,1)))
 		return FALSE
 	owner.visible_message("<span class='xenodanger'>\the [owner] infuses [target] with mysterious energy!</span>", \
 	"<span class='xenodanger'>We empower [target] with our [src]!</span>")
 
 	playsound(target, 'sound/effects/magic.ogg', 25) //Cool SFX
 	playsound(owner, 'sound/effects/magic.ogg', 25) //Cool SFX
-	owner.beam(target,"medbeam",'icons/effects/beam.dmi',10, 10,/obj/effect/ebeam,1)
 	new /obj/effect/temp_visual/telekinesis(get_turf(owner))
 	new /obj/effect/temp_visual/telekinesis(get_turf(target))
 	to_chat(target, "<span class='xenodanger'>Our wounds begin to knit and heal rapidly as [owner]'s healing energies infuse us.</span>") //Let the target know.

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -330,8 +330,8 @@ GLOBAL_LIST_INIT(thickenable_resin, typecacheof(list(
 		return FALSE
 
 	owner.face_atom(target) //Face the target so we don't look stupid
-	user.visible_message(user, "<span class='xenodanger'>\the [owner] begins channeling mysterious energies towards [target] ...</span>")
-	if(!do_after(user, 15 SECONDS, TRUE, src, BUSY_ICON_BUILD))
+	owner.visible_message(owner, "<span class='xenodanger'>\the [owner] begins channeling mysterious energies towards [target] ...</span>")
+	if(!do_after(owner, 8 SECONDS, TRUE, src, BUSY_ICON_BUILD))
 		return FALSE
 	owner.visible_message("<span class='xenodanger'>\the [owner] infuses [target] with mysterious energy!</span>", \
 	"<span class='xenodanger'>We empower [target] with our [src]!</span>")

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -278,7 +278,7 @@ GLOBAL_LIST_INIT(thickenable_resin, typecacheof(list(
 	name = "Healing Infusion"
 	action_icon_state = "healing_infusion"
 	mechanics_text = "Psychically infuses a friendly xeno with regenerative energies, greatly improving its natural healing. Doesn't work if the target can't naturally heal."
-	cooldown_timer = 5 SECONDS
+	cooldown_timer = 30 SECONDS
 	plasma_cost = 200
 	keybind_signal = COMSIG_XENOABILITY_HEALING_INFUSION
 	var/heal_range = HIVELORD_HEAL_RANGE
@@ -330,7 +330,10 @@ GLOBAL_LIST_INIT(thickenable_resin, typecacheof(list(
 		return FALSE
 
 	owner.face_atom(target) //Face the target so we don't look stupid
-
+	// WINDUP HERE - CHAZ
+	owner.visible_message(user, "<span class='xenodanger'>\the [owner] begins channeling mysterious energies towards [target] ...</span>")
+	if(!do_after(user, 15 SECONDS, TRUE, src, BUSY_ICON_BUILD))
+		return FALSE
 	owner.visible_message("<span class='xenodanger'>\the [owner] infuses [target] with mysterious energy!</span>", \
 	"<span class='xenodanger'>We empower [target] with our [src]!</span>")
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -331,7 +331,7 @@ GLOBAL_LIST_INIT(thickenable_resin, typecacheof(list(
 
 	owner.face_atom(target) //Face the target so we don't look stupid
 	owner.visible_message(owner, "<span class='xenodanger'>\the [owner] begins channeling mysterious energies towards [target] ...</span>")
-	if(!do_mob(owner.beam(target,"medbeam",'icons/effects/beam.dmi',40, 10,/obj/effect/ebeam,1))
+	if(!do_mob(owner.beam(target,"medbeam",'icons/effects/beam.dmi',40, 10,/obj/effect/ebeam,1)))
 	if(!do_mob(owner, target, 4 SECONDS, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL))
 		return FALSE
 	owner.visible_message("<span class='xenodanger'>\the [owner] infuses [target] with mysterious energy!</span>", \

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -332,6 +332,7 @@ GLOBAL_LIST_INIT(thickenable_resin, typecacheof(list(
 	owner.face_atom(target) //Face the target so we don't look stupid
 	owner.visible_message(owner, "<span class='xenodanger'>\the [owner] begins channeling mysterious energies towards [target] ...</span>")
 	if(!do_mob(owner.beam(target,"medbeam",'icons/effects/beam.dmi',40, 10,/obj/effect/ebeam,1)))
+		return FALSE
 	if(!do_mob(owner, target, 4 SECONDS, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL))
 		return FALSE
 	owner.visible_message("<span class='xenodanger'>\the [owner] infuses [target] with mysterious energy!</span>", \

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -331,7 +331,7 @@ GLOBAL_LIST_INIT(thickenable_resin, typecacheof(list(
 
 	owner.face_atom(target) //Face the target so we don't look stupid
 	owner.visible_message(owner, "<span class='xenodanger'>\the [owner] begins channeling mysterious energies towards [target] ...</span>")
-	if(!do_after(owner, 8 SECONDS, TRUE, src, BUSY_ICON_BUILD))
+	if(!do_after(owner, 8 SECONDS, TRUE, src, BUSY_ICON_MED))
 		return FALSE
 	owner.visible_message("<span class='xenodanger'>\the [owner] infuses [target] with mysterious energy!</span>", \
 	"<span class='xenodanger'>We empower [target] with our [src]!</span>")

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -338,7 +338,7 @@ GLOBAL_LIST_INIT(thickenable_resin, typecacheof(list(
 
 	playsound(target, 'sound/effects/magic.ogg', 25) //Cool SFX
 	playsound(owner, 'sound/effects/magic.ogg', 25) //Cool SFX
-	owner.beam(target,"medbeam",'icons/effects/beam.dmi',40, 10,/obj/effect/ebeam,1)
+	owner.beam(target,"medbeam",'icons/effects/beam.dmi',10, 10,/obj/effect/ebeam,1)
 	new /obj/effect/temp_visual/telekinesis(get_turf(owner))
 	new /obj/effect/temp_visual/telekinesis(get_turf(target))
 	to_chat(target, "<span class='xenodanger'>Our wounds begin to knit and heal rapidly as [owner]'s healing energies infuse us.</span>") //Let the target know.

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -383,7 +383,7 @@ GLOBAL_LIST_INIT(thickenable_resin, typecacheof(list(
 
 	new /obj/effect/temp_visual/healing(get_turf(patient)) //Cool SFX
 
-	var/total_heal_amount = 10 + patient.maxHealth * 0.05 //Base amount 10 HP plus 5% of max
+	var/total_heal_amount = 25
 	if(patient.recovery_aura)
 		total_heal_amount *= (1 + patient.recovery_aura * 0.05) //Recovery aura multiplier; 5% bonus per full level
 
@@ -430,7 +430,7 @@ GLOBAL_LIST_INIT(thickenable_resin, typecacheof(list(
 
 	new /obj/effect/temp_visual/telekinesis(get_turf(patient)) //Visual confirmation
 
-	patient.adjust_sunder(-3 * (1 + patient.recovery_aura * 0.05)) //5% bonus per rank of our recovery aura
+	patient.adjust_sunder(-3 * (0.5 + patient.recovery_aura * 0.05)) //5% bonus per rank of our recovery aura
 	#ifdef DEBUG_HIVELORD_ABILITIES
 	message_admins("HIVELORD_ABILITIES_DEBUG: Sunder reduction from Healing Infusion: [-3 * (1 + patient.recovery_aura * 0.1)]")
 	#endif

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -331,8 +331,8 @@ GLOBAL_LIST_INIT(thickenable_resin, typecacheof(list(
 
 	owner.face_atom(target) //Face the target so we don't look stupid
 	owner.visible_message(owner, "<span class='xenodanger'>\the [owner] begins channeling mysterious energies towards [target] ...</span>")
-	owner.beam(target,"medbeam",'icons/effects/beam.dmi',10, 10,/obj/effect/ebeam,4)
-	if(!do_mob(owner, target, 4 SECONDS, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL)))
+	owner.beam(target,"medbeam",'icons/effects/beam.dmi',40, 10,/obj/effect/ebeam,1)
+	if(!do_mob(owner, target, 4 SECONDS, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL))
 		return FALSE
 	owner.visible_message("<span class='xenodanger'>\the [owner] infuses [target] with mysterious energy!</span>", \
 	"<span class='xenodanger'>We empower [target] with our [src]!</span>")

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -331,7 +331,7 @@ GLOBAL_LIST_INIT(thickenable_resin, typecacheof(list(
 
 	owner.face_atom(target) //Face the target so we don't look stupid
 	owner.visible_message(owner, "<span class='xenodanger'>\the [owner] begins channeling mysterious energies towards [target] ...</span>")
-	if(!do_after(owner, 8 SECONDS, TRUE, src, BUSY_ICON_MED))
+	if(!do_after(owner, 8 SECONDS, TRUE, src, BUSY_ICON_MEDICAL))
 		return FALSE
 	owner.visible_message("<span class='xenodanger'>\the [owner] infuses [target] with mysterious energy!</span>", \
 	"<span class='xenodanger'>We empower [target] with our [src]!</span>")

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -331,13 +331,14 @@ GLOBAL_LIST_INIT(thickenable_resin, typecacheof(list(
 
 	owner.face_atom(target) //Face the target so we don't look stupid
 	owner.visible_message(owner, "<span class='xenodanger'>\the [owner] begins channeling mysterious energies towards [target] ...</span>")
-	if(!do_mob(owner, target, 4 SECONDS, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL, owner.beam(target,"medbeam",'icons/effects/beam.dmi',40, 10,/obj/effect/ebeam,1)))
+	if(!do_mob(owner, target, 4 SECONDS, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL))
 		return FALSE
 	owner.visible_message("<span class='xenodanger'>\the [owner] infuses [target] with mysterious energy!</span>", \
 	"<span class='xenodanger'>We empower [target] with our [src]!</span>")
 
 	playsound(target, 'sound/effects/magic.ogg', 25) //Cool SFX
 	playsound(owner, 'sound/effects/magic.ogg', 25) //Cool SFX
+	owner.beam(target,"medbeam",'icons/effects/beam.dmi',40, 10,/obj/effect/ebeam,1)
 	new /obj/effect/temp_visual/telekinesis(get_turf(owner))
 	new /obj/effect/temp_visual/telekinesis(get_turf(target))
 	to_chat(target, "<span class='xenodanger'>Our wounds begin to knit and heal rapidly as [owner]'s healing energies infuse us.</span>") //Let the target know.

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -330,7 +330,6 @@ GLOBAL_LIST_INIT(thickenable_resin, typecacheof(list(
 		return FALSE
 
 	owner.face_atom(target) //Face the target so we don't look stupid
-	// WINDUP HERE - CHAZ
 	owner.visible_message(user, "<span class='xenodanger'>\the [owner] begins channeling mysterious energies towards [target] ...</span>")
 	if(!do_after(user, 15 SECONDS, TRUE, src, BUSY_ICON_BUILD))
 		return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -331,8 +331,8 @@ GLOBAL_LIST_INIT(thickenable_resin, typecacheof(list(
 
 	owner.face_atom(target) //Face the target so we don't look stupid
 	owner.visible_message(owner, "<span class='xenodanger'>\the [owner] begins channeling mysterious energies towards [target] ...</span>")
+	if(!do_mob(owner.beam(target,"medbeam",'icons/effects/beam.dmi',40, 10,/obj/effect/ebeam,1))
 	if(!do_mob(owner, target, 4 SECONDS, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL))
-		owner.beam(target,"medbeam",'icons/effects/beam.dmi',40, 10,/obj/effect/ebeam,1)
 		return FALSE
 	owner.visible_message("<span class='xenodanger'>\the [owner] infuses [target] with mysterious energy!</span>", \
 	"<span class='xenodanger'>We empower [target] with our [src]!</span>")


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes healing a flat 25 modified by regen pheremone level, instead of 10+5%maxHP modified by regen pheremone level.
Halves default sunder healing from the ability.
4 second windup cancelled by movement from either involved.
30 second cooldown.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Hivelords can no longer allow xenos to frontline 24/7 with a frankly ridiculously overpowered heal on both health and sunder that could be spammed until the cows come home. I was going to fiddle more with making the beam part of the channel, but I'd rather get the ability in a state that doesn't throw gameplay out the window.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Hivelord Infusion cooldown increased, windup added, sunder healing and health healing lowered.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
