### PR TITLE
Medical Officer Rank Progression 

### DIFF
--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -592,9 +592,9 @@ Make sure that the doctors and nurses are doing their jobs and keeping the marin
 	switch(playtime_mins)
 		if(0 to 1500) // starting
 			new_human.wear_id.paygrade = "O1"
-		if(1501 to 6000) // 25 hrs
+		if(1501 to 3000) // 25 hrs
 			new_human.wear_id.paygrade = "O2"
-		if(6001 to INFINITY) // 100 hrs
+		if(3001 to INFINITY) // 50 hrs
 			new_human.wear_id.paygrade = "O3"
 
 /datum/job/terragov/medical/medicalofficer/radio_help_message(mob/M)

--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -581,6 +581,22 @@ Make sure that the doctors and nurses are doing their jobs and keeping the marin
 		/datum/job/terragov/squad/smartgunner = SMARTIE_POINTS_REGULAR,
 	)
 
+/datum/job/terragov/medical/medicalofficer/after_spawn(mob/living/carbon/new_mob, mob/user, latejoin = FALSE)
+	. = ..()
+	if(!ishuman(new_mob))
+		return
+	var/mob/living/carbon/human/new_human = new_mob
+	var/playtime_mins = user?.client?.get_exp(title)
+	if(!playtime_mins || playtime_mins < 1 )
+		return
+	switch(playtime_mins)
+		if(0 to 1500) // starting
+			new_human.wear_id.paygrade = "O1"
+		if(1501 to 6000) // 25 hrs
+			new_human.wear_id.paygrade = "O2"
+		if(6001 to INFINITY) // 100 hrs
+			new_human.wear_id.paygrade = "O3"
+
 /datum/job/terragov/medical/medicalofficer/radio_help_message(mob/M)
 	. = ..()
 	to_chat(M, {"You are a military doctor stationed aboard the [SSmapping.configs[SHIP_MAP].map_name].


### PR DESCRIPTION
## About The Pull Request
PR Adds rank progression for MOs. They still begin as Ensign. Progressing to LT Junior Grade at 25 hours and Lieutenant at 50 hours 

## Why It's Good For The Game

It has long annoyed me that MO has no rank progression. 
_This is my first foray into coding so I thought I start simple_

## Changelog
:cl:
Add: adds ranks for Medical Officer hopefully 
/:cl:

