### PR TITLE
Fixes Bug With Fire and Acid Not Properly Updating Snow Stack Visuals

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -127,7 +127,7 @@
 #define COMSIG_ATOM_INITIALIZED_ON "atom_initialized_on"		//called from atom/Initialize() of target: (atom/target)
 #define COMSIG_ATOM_ORBIT_BEGIN "atom_orbit_begin"				//called when an atom starts orbiting another atom: (atom)
 #define COMSIG_ATOM_ORBIT_STOP "atom_orbit_stop"				//called when an atom stops orbiting another atom: (atom)
-#define COMSIG_ATOM_ACIDSPRAY_ACT "atom_acidspray_act"			//from base of atom/acidspray_act()
+#define COMSIG_ATOM_ACIDSPRAY_ACT "atom_acidspray_act"			//called when acid spray acts on an entity; associated with /acidspray_act(): (obj/effect/xenomorph/spray/acid_puddle)
 
 
 ///from base of atom/set_opacity(): (new_opacity)

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -127,7 +127,7 @@
 #define COMSIG_ATOM_INITIALIZED_ON "atom_initialized_on"		//called from atom/Initialize() of target: (atom/target)
 #define COMSIG_ATOM_ORBIT_BEGIN "atom_orbit_begin"				//called when an atom starts orbiting another atom: (atom)
 #define COMSIG_ATOM_ORBIT_STOP "atom_orbit_stop"				//called when an atom stops orbiting another atom: (atom)
-#define COMSIG_ATOM_ACIDSPRAY_ACT "atom_acidspray_act"			//from base of atom/acidspray_act():
+#define COMSIG_ATOM_ACIDSPRAY_ACT "atom_acidspray_act"			//from base of atom/acidspray_act()
 
 
 ///from base of atom/set_opacity(): (new_opacity)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -333,6 +333,10 @@ directive is properly returned.
 /atom/proc/fire_act()
 	return
 
+
+/atom/proc/acidspray_act()
+
+
 /atom/proc/hitby(atom/movable/AM)
 	if(density)
 		AM.set_throwing(FALSE)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -334,9 +334,6 @@ directive is properly returned.
 	return
 
 
-/atom/proc/acidspray_act()
-
-
 /atom/proc/hitby(atom/movable/AM)
 	if(density)
 		AM.set_throwing(FALSE)

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -65,8 +65,6 @@
 /mob/living/carbon/human/proc/acid_spray_crossed(datum/source, obj/effect/xenomorph/spray/acid_spray, acid_damage, slow_amt)
 	SIGNAL_HANDLER
 
-	message_admins("source: [source], acid_spray: [acid_spray], acid_damage: [acid_damage], slow_amt: [slow_amt]")
-
 	if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_ACID))
 		return
 

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -91,10 +91,11 @@
 		qdel(src)
 		return
 
-	for(var/mob/living/carbon/human/H in loc)
+	for(var/mob/living/carbon/human/H in T)
 		H.acid_spray_crossed(acid_damage, slow_amt)
 
-	for(var/atom/A in loc) //Infrastructure for other interactions
+	SEND_SIGNAL(T, COMSIG_ATOM_ACIDSPRAY_ACT, src) //Signal the turf
+	for(var/atom/A in T) //Infrastructure for other interactions
 		SEND_SIGNAL(A, COMSIG_ATOM_ACIDSPRAY_ACT, src)
 
 //Medium-strength acid

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -70,21 +70,22 @@
 
 	TIMER_COOLDOWN_START(src, COOLDOWN_ACID, 1 SECONDS)
 	if(HAS_TRAIT(src, TRAIT_FLOORED))
-		take_overall_damage_armored(acid_damage, BURN, "acid", updating_health = TRUE)
+		INVOKE_ASYNC(src, .proc/take_overall_damage_armored, acid_damage, BURN, "acid", FALSE, FALSE, TRUE)
 		to_chat(src, "<span class='danger'>You are scalded by the burning acid!</span>")
 		return
 	to_chat(src, "<span class='danger'>Your feet scald and burn! Argh!</span>")
 	if(!(species.species_flags & NO_PAIN))
-		emote("pain")
+		INVOKE_ASYNC(src, .proc/emote, "pain")
+
 	next_move_slowdown += slow_amt
 	var/datum/limb/affecting = get_limb(BODY_ZONE_PRECISE_L_FOOT)
 	var/armor_block = run_armor_check(affecting, "acid")
-	if(istype(affecting) && affecting.take_damage_limb(0, acid_damage/2, FALSE, FALSE, armor_block, TRUE))
-		UpdateDamageIcon()
+	INVOKE_ASYNC(affecting, /datum/limb/.proc/take_damage_limb, 0, acid_damage/2, FALSE, FALSE, armor_block)
+
 	affecting = get_limb(BODY_ZONE_PRECISE_R_FOOT)
 	armor_block = run_armor_check(affecting, "acid")
-	if(istype(affecting) && affecting.take_damage_limb(0, acid_damage/2, FALSE, FALSE, armor_block, TRUE, updating_health = TRUE))
-		UpdateDamageIcon()
+	INVOKE_ASYNC(affecting, /datum/limb/.proc/take_damage_limb, 0, acid_damage/2, FALSE, FALSE, armor_block, TRUE)
+
 
 /obj/effect/xenomorph/spray/process()
 	var/turf/T = loc

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -91,12 +91,15 @@
 		qdel(src)
 		return
 
-	for(var/mob/living/carbon/human/H in T)
-		H.acid_spray_crossed(acid_damage, slow_amt)
-
 	SEND_SIGNAL(T, COMSIG_ATOM_ACIDSPRAY_ACT, src) //Signal the turf
-	for(var/atom/A in T) //Infrastructure for other interactions
+	for(var/H in T)
+
+		var/atom/A = H
 		SEND_SIGNAL(A, COMSIG_ATOM_ACIDSPRAY_ACT, src)
+
+		if(ishuman(A))
+			var/mob/living/carbon/human/H2 = H
+			H2.acid_spray_crossed(acid_damage, slow_amt)
 
 //Medium-strength acid
 /obj/effect/xenomorph/acid

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -59,11 +59,14 @@
 
 /obj/effect/xenomorph/spray/Crossed(atom/movable/AM)
 	. = ..()
-	if(ishuman(AM))
-		var/mob/living/carbon/human/H = AM
-		H.acid_spray_crossed(acid_damage, slow_amt)
+	SEND_SIGNAL(AM, COMSIG_ATOM_ACIDSPRAY_ACT, src, acid_damage, slow_amt)
 
-/mob/living/carbon/human/proc/acid_spray_crossed(acid_damage, slow_amt)
+
+/mob/living/carbon/human/proc/acid_spray_crossed(datum/source, obj/effect/xenomorph/spray/acid_spray, acid_damage, slow_amt)
+	SIGNAL_HANDLER
+
+	message_admins("source: [source], acid_spray: [acid_spray], acid_damage: [acid_damage], slow_amt: [slow_amt]")
+
 	if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_ACID))
 		return
 
@@ -95,11 +98,7 @@
 	for(var/H in T)
 
 		var/atom/A = H
-		SEND_SIGNAL(A, COMSIG_ATOM_ACIDSPRAY_ACT, src)
-
-		if(ishuman(A))
-			var/mob/living/carbon/human/H2 = H
-			H2.acid_spray_crossed(acid_damage, slow_amt)
+		SEND_SIGNAL(A, COMSIG_ATOM_ACIDSPRAY_ACT, src, acid_damage, slow_amt)
 
 //Medium-strength acid
 /obj/effect/xenomorph/acid

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -71,7 +71,7 @@
 /obj/structure/closet/bodybag/Initialize(mapload, foldedbag)
 	. = ..()
 	foldedbag_instance = foldedbag
-	RegisterSignal(src, COMSIG_ATOM_ACIDSPRAY_ACT, /atom/.proc/acidspray_act)
+	RegisterSignal(src, COMSIG_ATOM_ACIDSPRAY_ACT, .proc/acidspray_act)
 
 /obj/structure/closet/bodybag/Destroy()
 	open()
@@ -82,7 +82,7 @@
 			stack_trace("[src] destroyed while the [foldedbag_instance] foldedbag_instance was neither destroyed nor in nullspace. This shouldn't happen.")
 		QDEL_NULL(foldedbag_instance)
 
-	UnregisterSignal(src, COMSIG_ATOM_ACIDSPRAY_ACT, /atom/.proc/acidspray_act)
+	UnregisterSignal(src, COMSIG_ATOM_ACIDSPRAY_ACT, .proc/acidspray_act)
 	return ..()
 
 
@@ -232,10 +232,8 @@
 			visible_message("<span class='danger'>\The shockwave blows [name] apart!</span>")
 			qdel(src) //blown apart
 
-/obj/structure/closet/bodybag/acidspray_act(datum/source, obj/effect/xenomorph/spray/acid_puddle)
+/obj/structure/closet/bodybag/proc/acidspray_act(datum/source, obj/effect/xenomorph/spray/acid_puddle)
 	if(!opened && bodybag_occupant)
-		if(!source) //Sanity
-			return
 
 		if(ishuman(bodybag_occupant))
 			var/mob/living/carbon/human/H = bodybag_occupant

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -233,7 +233,6 @@
 			qdel(src) //blown apart
 
 /obj/structure/closet/bodybag/acidspray_act(datum/source, obj/effect/xenomorph/spray/acid_puddle)
-	SIGNAL_HANDLER
 	if(!opened && bodybag_occupant)
 		if(!source) //Sanity
 			return

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -71,7 +71,7 @@
 /obj/structure/closet/bodybag/Initialize(mapload, foldedbag)
 	. = ..()
 	foldedbag_instance = foldedbag
-	RegisterSignal(src, COMSIG_ATOM_ACIDSPRAY_ACT, .proc/acidspray_act)
+	RegisterSignal(src, COMSIG_ATOM_ACIDSPRAY_ACT, /atom/.proc/acidspray_act)
 
 /obj/structure/closet/bodybag/Destroy()
 	open()
@@ -82,7 +82,7 @@
 			stack_trace("[src] destroyed while the [foldedbag_instance] foldedbag_instance was neither destroyed nor in nullspace. This shouldn't happen.")
 		QDEL_NULL(foldedbag_instance)
 
-	UnregisterSignal(src, COMSIG_ATOM_ACIDSPRAY_ACT, .proc/acidspray_act)
+	UnregisterSignal(src, COMSIG_ATOM_ACIDSPRAY_ACT, /atom/.proc/acidspray_act)
 	return ..()
 
 
@@ -232,16 +232,15 @@
 			visible_message("<span class='danger'>\The shockwave blows [name] apart!</span>")
 			qdel(src) //blown apart
 
-/obj/structure/closet/bodybag/proc/acidspray_act()
+/obj/structure/closet/bodybag/acidspray_act(datum/source, obj/effect/xenomorph/spray/acid_puddle)
 	SIGNAL_HANDLER
 	if(!opened && bodybag_occupant)
-		var/obj/effect/xenomorph/spray/S = locate() in range(0, src) //get the acid Hans
-		if(!S) //Sanity
+		if(!source) //Sanity
 			return
 
 		if(ishuman(bodybag_occupant))
 			var/mob/living/carbon/human/H = bodybag_occupant
-			INVOKE_ASYNC(H, /mob/living/carbon/human.proc/acid_spray_crossed, S.slow_amt) //tarp isn't acid proof; pass it on to the occupant
+			INVOKE_ASYNC(H, /mob/living/carbon/human.proc/acid_spray_crossed, acid_puddle.acid_damage, acid_puddle.slow_amt) //tarp isn't acid proof; pass it on to the occupant
 
 		to_chat(bodybag_occupant, "<span class='danger'>The sizzling acid forces us out of [name]!</span>")
 		open() //Get out

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -237,7 +237,7 @@
 
 		if(ishuman(bodybag_occupant))
 			var/mob/living/carbon/human/H = bodybag_occupant
-			INVOKE_ASYNC(H, /mob/living/carbon/human.proc/acid_spray_crossed, acid_puddle.acid_damage, acid_puddle.slow_amt) //tarp isn't acid proof; pass it on to the occupant
+			SEND_SIGNAL(H, COMSIG_ATOM_ACIDSPRAY_ACT, src, acid_puddle.acid_damage, acid_puddle.slow_amt) //tarp isn't acid proof; pass it on to the occupant
 
 		to_chat(bodybag_occupant, "<span class='danger'>The sizzling acid forces us out of [name]!</span>")
 		open() //Get out

--- a/code/game/turfs/snow.dm
+++ b/code/game/turfs/snow.dm
@@ -144,15 +144,14 @@
 		if(EXPLODE_DEVASTATE)
 			if(slayer)
 				slayer = 0
-				update_icon(1, 0)
 		if(EXPLODE_HEAVY)
 			if(slayer && prob(60))
 				slayer = max(slayer - 2, 0)
-				update_icon(1, 0)
 		if(EXPLODE_LIGHT)
 			if(slayer && prob(20))
 				slayer = max(slayer - 1, 0)
-				update_icon(1, 0)
+
+	update_icon(1, 0)
 	return ..()
 
 //Fire act; fire now melts snow as it should; fire beats ice
@@ -164,13 +163,12 @@
 	switch(burnlevel)
 		if(1 to 10)
 			slayer = max(0, slayer - 1)
-			update_icon(1, 0)
 		if(11 to 24)
 			slayer = max(0, slayer - 2)
-			update_icon(1, 0)
 		if(25 to INFINITY)
 			slayer = 0
-			update_icon(1, 0)
+
+	update_icon(1, 0)
 
 /turf/open/floor/plating/ground/snow/proc/acidspray_act()
 

--- a/code/game/turfs/snow.dm
+++ b/code/game/turfs/snow.dm
@@ -173,7 +173,6 @@
 			update_icon(1, 0)
 
 /turf/open/floor/plating/ground/snow/acidspray_act()
-	SIGNAL_HANDLER
 
 	if(!slayer) //Don't bother if there's no snow to melt or if there's no burn stacks
 		return

--- a/code/game/turfs/snow.dm
+++ b/code/game/turfs/snow.dm
@@ -14,7 +14,8 @@
 
 /turf/open/floor/plating/ground/snow/Initialize(mapload)
 	. = ..()
-	RegisterSignal(src, COMSIG_ATOM_ACIDSPRAY_ACT, .proc/acidspray_act)
+	RegisterSignal(src, COMSIG_ATOM_ACIDSPRAY_ACT, /atom/.proc/acidspray_act)
+	update_icon(1,1) //Update icon and sides on start, but skip nearby check for turfs.
 
 // Melting snow
 /turf/open/floor/plating/ground/snow/fire_act(exposed_temperature, exposed_volume)
@@ -69,12 +70,6 @@
 		L.set_light(2)
 		playsound(user, 'sound/weapons/genhit.ogg', 25, 1)
 
-
-
-//Update icon and sides on start, but skip nearby check for turfs.
-/turf/open/floor/plating/ground/snow/Initialize()
-	. = ..()
-	update_icon(1,1)
 
 /turf/open/floor/plating/ground/snow/Entered(atom/movable/AM)
 	if(slayer > 0)
@@ -156,7 +151,7 @@
 				update_icon(1, 0)
 		if(EXPLODE_LIGHT)
 			if(slayer && prob(20))
-				slayer -= 1
+				slayer = max(slayer - 1, 0)
 				update_icon(1, 0)
 	return ..()
 
@@ -168,19 +163,23 @@
 
 	switch(burnlevel)
 		if(1 to 10)
-			slayer--
+			slayer = max(0, slayer - 1)
+			update_icon(1, 0)
 		if(11 to 24)
 			slayer = max(0, slayer - 2)
+			update_icon(1, 0)
 		if(25 to INFINITY)
 			slayer = 0
+			update_icon(1, 0)
 
-/turf/open/floor/plating/ground/snow/proc/acidspray_act()
+/turf/open/floor/plating/ground/snow/acidspray_act()
 	SIGNAL_HANDLER
 
 	if(!slayer) //Don't bother if there's no snow to melt or if there's no burn stacks
 		return
 
-	slayer-- //Melt a layer
+	slayer = max(0, slayer - 1) //Melt a layer
+	update_icon(1, 0)
 
 
 //SNOW LAYERS-----------------------------------//

--- a/code/game/turfs/snow.dm
+++ b/code/game/turfs/snow.dm
@@ -14,7 +14,7 @@
 
 /turf/open/floor/plating/ground/snow/Initialize(mapload)
 	. = ..()
-	RegisterSignal(src, COMSIG_ATOM_ACIDSPRAY_ACT, /atom/.proc/acidspray_act)
+	RegisterSignal(src, COMSIG_ATOM_ACIDSPRAY_ACT, .proc/acidspray_act)
 	update_icon(1,1) //Update icon and sides on start, but skip nearby check for turfs.
 
 // Melting snow
@@ -172,7 +172,7 @@
 			slayer = 0
 			update_icon(1, 0)
 
-/turf/open/floor/plating/ground/snow/acidspray_act()
+/turf/open/floor/plating/ground/snow/proc/acidspray_act()
 
 	if(!slayer) //Don't bother if there's no snow to melt or if there's no burn stacks
 		return

--- a/code/game/turfs/snow.dm
+++ b/code/game/turfs/snow.dm
@@ -171,6 +171,7 @@
 	update_icon(1, 0)
 
 /turf/open/floor/plating/ground/snow/proc/acidspray_act()
+	SIGNAL_HANDLER
 
 	if(!slayer) //Don't bother if there's no snow to melt or if there's no burn stacks
 		return

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -34,6 +34,7 @@
 
 	randomize_appearance()
 
+	RegisterSignal(src, COMSIG_ATOM_ACIDSPRAY_ACT, .proc/acid_spray_crossed)
 	RegisterSignal(src, list(COMSIG_KB_QUICKEQUIP, COMSIG_CLICK_QUICKEQUIP), .proc/do_quick_equip)
 	RegisterSignal(src, COMSIG_KB_HOLSTER, .proc/do_holster)
 	RegisterSignal(src, COMSIG_KB_UNIQUEACTION, .proc/do_unique_action)


### PR DESCRIPTION
## About The Pull Request

Fire and acid now both properly update snow stack visuals.

## Why It's Good For The Game

Fixes a bug.

Fixes: https://github.com/tgstation/TerraGov-Marine-Corps/issues/5766

## Changelog
:cl:
fix: Fire and acid now both properly update snow stack visuals.
refactor: Refactored elements of acidspray_act and related procs.
/:cl: