### PR TITLE
Sentries Gain IFF Prot, Integrity / Ammo Indicators /w HUD Components.

### DIFF
--- a/code/__DEFINES/atom_hud.dm
+++ b/code/__DEFINES/atom_hud.dm
@@ -17,6 +17,8 @@
 #define ARMOR_SUNDER_HUD			"armor_sunder_hud" //displays how much sunder has been applied.
 #define XENO_REAGENT_HUD			"xeno_reagent_hud" // displays sign based on reagent in human
 #define XENO_TACTICAL_HUD			"xeno_tactical_hud" // displays xeno tactical elements such as tunnels and rally hive pings
+#define MACHINE_HEALTH_HUD			"machine_health_hud" // displays machine health; part of /datum/atom_hud/squad
+#define SENTRY_AMMO_HUD				"sentry_ammo_hud" // displays sentry ammo; part of /datum/atom_hud/squad
 
 #define ADD_HUD_TO_COOLDOWN 20 //cooldown for being shown the images for any particular data hud
 

--- a/code/__DEFINES/objects.dm
+++ b/code/__DEFINES/objects.dm
@@ -111,8 +111,9 @@ GLOBAL_LIST_INIT(restricted_camera_networks, list( //Those networks can only be 
 #define SENTRY_ALERT_FALLEN				3
 #define SENTRY_ALERT_DAMAGE				4
 #define SENTRY_ALERT_BATTERY			5
+#define SENTRY_ALERT_DESTROYED			6
 #define SENTRY_ALERT_DELAY				20 SECONDS
-#define SENTRY_DAMAGE_ALERT_DELAY		5 SECONDS
+#define SENTRY_DAMAGE_ALERT_DELAY		4 SECONDS
 #define SENTRY_LIGHT_POWER				7
 
 //Scout cloak defines

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -109,7 +109,7 @@
 
 //medical hud used by ghosts
 /datum/atom_hud/medical/observer
-	hud_icons = list(HEALTH_HUD, XENO_EMBRYO_HUD, XENO_REAGENT_HUD, STATUS_HUD)
+	hud_icons = list(HEALTH_HUD, XENO_EMBRYO_HUD, XENO_REAGENT_HUD, STATUS_HUD, MACHINE_HEALTH_HUD, SENTRY_AMMO_HUD)
 
 
 /datum/atom_hud/medical/pain
@@ -455,7 +455,7 @@
 
 
 /datum/atom_hud/squad
-	hud_icons = list(SQUAD_HUD)
+	hud_icons = list(SQUAD_HUD, MACHINE_HEALTH_HUD, SENTRY_AMMO_HUD)
 
 
 /mob/proc/hud_set_squad()
@@ -518,3 +518,32 @@
 
 	hud_list[ORDER_HUD] = holder
 
+///Makes sentry health visible
+/obj/machinery/proc/hud_set_machine_health()
+	var/image/holder = hud_list[MACHINE_HEALTH_HUD]
+
+	if(!holder)
+		return
+
+	if(obj_integrity < 1)
+		holder.icon_state = "xenohealth0"
+		return
+
+	var/amount = round(obj_integrity * 100 / max_integrity, 10)
+	if(!amount)
+		amount = 1 //don't want the 'zero health' icon when we still have 4% of our health
+	holder.icon_state = "xenohealth[amount]"
+
+///Makes sentry ammo visible
+/obj/machinery/marine_turret/proc/hud_set_sentry_ammo()
+	var/image/holder = hud_list[SENTRY_AMMO_HUD]
+
+	if(!holder)
+		return
+
+	if(!rounds)
+		holder.icon_state = "plasma0"
+		return
+
+	var/amount = round(rounds * 100 / rounds_max, 10)
+	holder.icon_state = "plasma[amount]"

--- a/code/game/objects/machinery/sentries.dm
+++ b/code/game/objects/machinery/sentries.dm
@@ -226,7 +226,8 @@
 	layer = ABOVE_MOB_LAYER //So you can't hide it under corpses
 	use_power = 0
 	req_one_access = list(ACCESS_MARINE_ENGINEERING, ACCESS_MARINE_ENGPREP, ACCESS_MARINE_LEADER)
-	var/turret_flags = TURRET_HAS_CAMERA|TURRET_SAFETY
+	hud_possible = list(MACHINE_HEALTH_HUD, SENTRY_AMMO_HUD)
+	var/turret_flags = TURRET_HAS_CAMERA|TURRET_SAFETY|TURRET_ALERTS
 	var/list/iff_signal = list(ACCESS_IFF_MARINE)
 	var/rounds = 500
 	var/rounds_max = 500
@@ -262,8 +263,15 @@
 
 /obj/machinery/marine_turret/examine(mob/user)
 	. = ..()
+	if(isxeno(user))
+		to_chat(user, "<span class='warning'>There's many strange numbers and indicators on this device we don't understand.</span>")
+		return
+
 	var/list/details = list()
+
 	if(CHECK_BITFIELD(turret_flags, TURRET_ON))
+		details +=("Its diagnostic display reads <b>([obj_integrity]/[max_integrity])</b> integrity.</br>")
+		details +=("Its ammo counter reads <b>([rounds]/[rounds_max])</b>.</br>")
 		details +=("It's turned on.</br>")
 
 	if(CHECK_BITFIELD(turret_flags, TURRET_SAFETY))
@@ -303,6 +311,11 @@
 	ammo = GLOB.ammo_list[ammo]
 	update_icon()
 	GLOB.marine_turrets += src
+	prepare_huds() //Set up HUDS
+	for(var/datum/atom_hud/squad/sentry_status_hud in GLOB.huds) //Add to the squad HUD
+		sentry_status_hud.add_to_hud(src)
+	hud_set_machine_health()
+	hud_set_sentry_ammo()
 
 /obj/machinery/marine_turret/proc/turn_off() //We turn the turret off
 	if(!CHECK_BITFIELD(turret_flags, TURRET_ON)) //We're already off
@@ -324,6 +337,10 @@
 	alert_list = list()
 	stop_processing()
 	GLOB.marine_turrets -= src
+	. = ..()
+
+/obj/machinery/marine_turret/obj_destruction(damage_amount, damage_type, damage_flag)
+	sentry_alert(SENTRY_ALERT_DESTROYED)
 	. = ..()
 
 /obj/machinery/marine_turret/attack_hand(mob/living/user)
@@ -625,6 +642,7 @@
 		user.visible_message("<span class='notice'>[user] repairs [src].</span>",
 		"<span class='notice'>You repair [src].</span>")
 		repair_damage(50)
+		hud_set_machine_health() //Update our HUD health
 		playsound(loc, 'sound/items/welder2.ogg', 25, 1)
 
 	else if(iscrowbar(I))
@@ -691,6 +709,7 @@
 			var/obj/item/ammo_magazine/S = new magazine_type(user.loc)
 			S.current_rounds = rounds
 		rounds = min(M.current_rounds, rounds_max)
+		hud_set_sentry_ammo()
 		qdel(I)
 
 
@@ -741,11 +760,6 @@
 
 
 /obj/machinery/marine_turret/take_damage(dam)
-	if(dam > 0) //We don't report repairs.
-		if(CHECK_BITFIELD(turret_flags, TURRET_ON) && CHECK_BITFIELD(turret_flags, TURRET_ALERTS) && (world.time > (last_damage_alert + SENTRY_DAMAGE_ALERT_DELAY) || obj_integrity <= 0) ) //Alert friendlies
-			sentry_alert(SENTRY_ALERT_DAMAGE)
-			last_damage_alert = world.time
-
 	if(!machine_stat && dam > 0 && !CHECK_BITFIELD(turret_flags, TURRET_IMMOBILE))
 		if(prob(10))
 			spark_system.start()
@@ -755,7 +769,13 @@
 			if(CHECK_BITFIELD(turret_flags, TURRET_ALERTS) && CHECK_BITFIELD(turret_flags, TURRET_ON))
 				sentry_alert(SENTRY_ALERT_FALLEN)
 
-	return ..()
+	..()
+
+	if(dam > 0 && CHECK_BITFIELD(turret_flags, TURRET_ON) && CHECK_BITFIELD(turret_flags, TURRET_ALERTS) && (world.time > (last_damage_alert + SENTRY_DAMAGE_ALERT_DELAY))) //Alert friendlies
+		sentry_alert(SENTRY_ALERT_DAMAGE)
+		last_damage_alert = world.time
+
+	hud_set_machine_health() //Update our HUD health
 
 
 /obj/machinery/marine_turret/proc/check_power(power)
@@ -953,6 +973,7 @@
 		if(CHECK_BITFIELD(turret_flags, TURRET_ALERTS))
 			sentry_alert(SENTRY_ALERT_AMMO)
 
+	hud_set_sentry_ammo()
 	return TRUE
 
 /obj/machinery/marine_turret/proc/muzzle_flash(angle)
@@ -1009,7 +1030,6 @@
 			path -= get_turf(src)
 			if(CHECK_BITFIELD(turret_flags, TURRET_ALERTS)) //They're within our field of detection and thus can trigger the alarm
 				if(world.time > (last_alert + SENTRY_ALERT_DELAY) || !(M in alert_list)) //if we're not on cooldown or the target isn't in the list, sound the alarm
-					playsound(loc, 'sound/machines/warning-buzzer.ogg', 50, FALSE)
 					sentry_alert(SENTRY_ALERT_HOSTILE, M)
 					alert_list.Add(M)
 					last_alert = world.time
@@ -1156,19 +1176,19 @@
 	var/notice
 	switch(alert_code)
 		if(SENTRY_ALERT_AMMO)
-			notice = "<b>ALERT! [src]'s ammo depleted at: [get_area(src)]. Coordinates: (X: [x], Y: [y]).</b>"
+			notice = "<b>ALERT! [src]'s ammo depleted at: [AREACOORD_NO_Z(src)].</b>"
 		if(SENTRY_ALERT_HOSTILE)
-			notice = "<b>ALERT! [src] detected Hostile/Unknown: [M.name] at: [get_area(M)]. Coordinates: (X: [M.x], Y: [M.y]).</b>"
+			notice = "<b>ALERT! [src] detected Hostile/Unknown: [M.name] at: [AREACOORD_NO_Z(src)].</b>"
 		if(SENTRY_ALERT_FALLEN)
-			notice = "<b>ALERT! [src] has been knocked over at: [get_area(src)]. Coordinates: (X: [x], Y: [y]).</b>"
+			notice = "<b>ALERT! [src] has been knocked over at: [AREACOORD_NO_Z(src)].</b>"
 		if(SENTRY_ALERT_DAMAGE)
-			var/percent = max(0, (obj_integrity / max(1, max_integrity)) * 100)
-			if(percent)
-				notice = "<b>ALERT! [src] at: [get_area(src)] has taken damage. Coordinates: (X: [x], Y: [y]). Remaining Structural Integrity: [percent]%</b>"
-			else
-				notice = "<b>ALERT! [src] at: [get_area(src)], Coordinates: (X: [x], Y: [y]) has been destroyed.</b>"
+			notice = "<b>ALERT! [src] has taken damage at: [AREACOORD_NO_Z(src)]. Remaining Structural Integrity: ([obj_integrity]/[max_integrity])[obj_integrity < 50 ? " CONDITION CRITICAL!!" : ""]</b>"
+		if(SENTRY_ALERT_DESTROYED)
+			notice = "<b>ALERT! [src] at: [AREACOORD_NO_Z(src)] has been destroyed!</b>"
 		if(SENTRY_ALERT_BATTERY)
-			notice = "<b>ALERT! [src]'s battery depleted at: [get_area(src)]. Coordinates: (X: [x], Y: [y]).</b>"
+			notice = "<b>ALERT! [src]'s battery depleted at: [AREACOORD_NO_Z(src)].</b>"
+
+	playsound(loc, 'sound/machines/warning-buzzer.ogg', 50, FALSE)
 	radio.talk_into(src, "[notice]", FREQ_COMMON)
 
 /obj/machinery/marine_turret/mini
@@ -1262,7 +1282,7 @@
 	icon_state = "minisentry_packed"
 	item_state = "minisentry_packed"
 	w_class = WEIGHT_CLASS_BULKY
-	max_integrity = 200 //We keep track of this when folding up the sentry.
+	max_integrity = 100
 	var/rounds = 500
 	var/obj/item/cell/cell
 	flags_equip_slot = ITEM_SLOT_BACK

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -616,6 +616,20 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 		return FALSE
 	return TRUE
 
+/obj/machinery/marine_turret/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)
+	if(sentry_verify_iff(proj.projectile_iff))
+		proj.damage += proj.damage*proj.damage_marine_falloff
+		return FALSE
+	return src == proj.original_target
+
+///Checks to see whether IFF matches
+/obj/machinery/marine_turret/proc/sentry_verify_iff(list/unique_access)
+	for(var/access_tag in unique_access)
+		if(access_tag in iff_signal)
+			return TRUE
+
+	return FALSE
+
 /obj/machinery/door/poddoor/railing/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)
 	return src == proj.original_target
 


### PR DESCRIPTION
## About The Pull Request

1. Sentries now have HUD indicators displaying current health and ammo. Those with the Squad HUD can see this.
2. Sentries now display health and ammo info to non-xenos examining it.
3. Sentries now don't get hit by friendly IFF munitions.
4. Sentry damage alerts more accurate and responsive.
5. Sentry destruction alerts now work properly.

## Why It's Good For The Game

Adds QoL and needed functionality to sentries.

## Changelog
:cl:
add: Sentries now have HUD indicators displaying current health and ammo. Those with the Squad HUD can see this.
add: Sentries now display health and ammo info to non-xenos examining it.
add: Sentries now don't get hit by friendly IFF munitions.
code: Sentry damage alerts more accurate and responsive.
fix: Sentry damage alerts now work properly.
/:cl:
![image](https://user-images.githubusercontent.com/42553659/105156455-dbfb1380-5ad9-11eb-8bce-27d861fd0602.png)
