### PR TITLE
Miners give less points

### DIFF
--- a/code/modules/requisitions/_supply_export.dm
+++ b/code/modules/requisitions/_supply_export.dm
@@ -7,19 +7,19 @@
 	SSpoints.supply_points += .
 
 /obj/structure/ore_box/phoron/supply_export()
-	. = 20
+	. = 10
 	SSpoints.supply_points += .
 
 /obj/item/compactorebox/phoron/supply_export()
-	. = 20
+	. = 10
 	SSpoints.supply_points += .
 
 /obj/item/compactorebox/platinum/supply_export()
-	. = 40
+	. = 30
 	SSpoints.supply_points += .
 
 /obj/structure/ore_box/platinum/supply_export()
-	. = 40
+	. = 30
 	SSpoints.supply_points += .
 
 /mob/living/carbon/xenomorph/supply_export()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Or well ore boxes.

Phoron has been havled.
Plat lost 10 points.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ore miners after the advent of the tadpole and miner upgrades give too many points too fast, this seems like a better compromise than nerfing the miners themselves.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: ore miners nerfed to 10 for phoron and 30 for plat
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
