### PR TITLE
Miner Tweaks

### DIFF
--- a/code/game/objects/items/misc.dm
+++ b/code/game/objects/items/misc.dm
@@ -169,9 +169,3 @@
 	desc = "A box with a few pumps and a big drill, meant to replace the standard drill used in normal mining wells for faster extraction."
 	icon_state = "mining_drill_overclockeddisplay"
 	uptype = "high-efficiency drill"
-
-/obj/item/minerupgrade/compactor
-	name = "crystalizer module"
-	desc = "A bulky module meant to replace the normal crystalizer in mining wells, used to compress boxes for easy carrying."
-	icon_state = "mining_drill_compactordisplay"
-	uptype = "upgraded crystalizer module"

--- a/code/game/objects/machinery/autolathe_datums.dm
+++ b/code/game/objects/machinery/autolathe_datums.dm
@@ -119,11 +119,6 @@ GLOBAL_LIST_EMPTY(autolathe_categories)
 	path = /obj/item/minerupgrade/reinforcement
 	category = "Engineering"
 
-/datum/autolathe/recipe/miningwellcompactor
-	name = "mining well compactor upgrade"
-	path = /obj/item/minerupgrade/compactor
-	category = "Engineering"
-
 /datum/autolathe/recipe/miningwelloverclock
 	name = "mining well overclock upgrade"
 	path = /obj/item/minerupgrade/overclock

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -24,7 +24,7 @@
 	///Tracks how many ticks have passed since we last added a sheet of material
 	var/add_tick = 0
 	///How many times we neeed to tick for a resource to be created, in this case this is 2* the specified amount
-	var/required_ticks = 140  //make one crate every 280 seconds
+	var/required_ticks = 70  //make one crate every 140 seconds
 	///The mineral type that's produced
 	var/mineral_produced = /obj/item/compactorebox/phoron
 	///Health for the miner we use because changing obj_integrity is apparently bad
@@ -77,7 +77,7 @@
 			max_miner_integrity = 300
 			miner_integrity = 300
 		if(MINER_OVERCLOCKED)
-			required_ticks = 105
+			required_ticks = 50
 	miner_upgrade_type = upgrade.uptype
 	user.visible_message("<span class='notice'>[user] attaches the [miner_upgrade_type] to the [src]!</span>")
 	qdel(upgrade)
@@ -233,7 +233,7 @@
 	if(add_tick >= required_ticks)
 		stored_mineral += 1
 		add_tick = 0
-	if(stored_mineral >= 5)	//Stores 5 boxes worth of minerals
+	if(stored_mineral >= 8)	//Stores 8 boxes worth of minerals
 		stop_processing()
 	else
 		add_tick += 1

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -24,9 +24,9 @@
 	///Tracks how many ticks have passed since we last added a sheet of material
 	var/add_tick = 0
 	///How many times we neeed to tick for a resource to be created, in this case this is 2* the specified amount
-	var/required_ticks = 70  //make one crate every 140 seconds
+	var/required_ticks = 140  //make one crate every 280 seconds
 	///The mineral type that's produced
-	var/mineral_produced = /obj/structure/ore_box/phoron
+	var/mineral_produced = /obj/item/compactorebox/phoron
 	///Health for the miner we use because changing obj_integrity is apparently bad
 	var/miner_integrity = 100
 	///Max health of the miner
@@ -41,7 +41,7 @@
 /obj/machinery/miner/damaged/platinum
 	name = "\improper Nanotrasen platinum Mining Well"
 	desc = "A Nanotrasen platinum drill with an internal packaging module. Produces even more valuable materials than it's phoron counterpart"
-	mineral_produced = /obj/structure/ore_box/platinum
+	mineral_produced = /obj/item/compactorebox/platinum
 
 /obj/machinery/miner/Initialize()
 	. = ..()
@@ -50,10 +50,7 @@
 /obj/machinery/miner/update_icon()
 	switch(miner_status)
 		if(MINER_RUNNING)
-			if((mineral_produced == /obj/item/compactorebox/platinum) && (miner_upgrade_type == MINER_COMPACTOR))
-				icon_state = "mining_drill_active_platinum_[miner_upgrade_type]"
-			else
-				icon_state = "mining_drill_active_[miner_upgrade_type]"
+			icon_state = "mining_drill_active_[miner_upgrade_type]"
 		if(MINER_SMALL_DAMAGE)
 			icon_state = "mining_drill_braced_[miner_upgrade_type]"
 		if(MINER_MEDIUM_DAMAGE)
@@ -79,13 +76,8 @@
 		if(MINER_RESISTANT)
 			max_miner_integrity = 300
 			miner_integrity = 300
-		if(MINER_COMPACTOR)
-			if(mineral_produced == /obj/structure/ore_box/platinum)
-				mineral_produced = /obj/item/compactorebox/platinum
-			else
-				mineral_produced = /obj/item/compactorebox/phoron
 		if(MINER_OVERCLOCKED)
-			required_ticks = 35
+			required_ticks = 105
 	miner_upgrade_type = upgrade.uptype
 	user.visible_message("<span class='notice'>[user] attaches the [miner_upgrade_type] to the [src]!</span>")
 	qdel(upgrade)
@@ -127,9 +119,6 @@
 			if(MINER_OVERCLOCKED)
 				upgrade = new /obj/item/minerupgrade/overclock
 				required_ticks = initial(required_ticks)
-			if(MINER_COMPACTOR)
-				upgrade = new /obj/item/minerupgrade/compactor
-				mineral_produced = initial(mineral_produced)
 		upgrade.forceMove(user.loc)
 		miner_upgrade_type = null
 		update_icon()
@@ -244,7 +233,7 @@
 	if(add_tick >= required_ticks)
 		stored_mineral += 1
 		add_tick = 0
-	if(stored_mineral >= 2)	//Stores 2 boxes worth of minerals
+	if(stored_mineral >= 5)	//Stores 5 boxes worth of minerals
 		stop_processing()
 	else
 		add_tick += 1

--- a/code/modules/reqs/supplyexports.dm
+++ b/code/modules/reqs/supplyexports.dm
@@ -13,11 +13,11 @@
 	export_obj = /obj/structure/ore_box/phoron
 
 /datum/supply_export/compactorebox/phoron
-	cost = 25
+	cost = 50
 	export_obj = /obj/item/compactorebox/phoron
 
 /datum/supply_export/compactorebox/platinum
-	cost = 50
+	cost = 100
 	export_obj = /obj/item/compactorebox/platinum
 
 /datum/supply_export/xemomorph

--- a/code/modules/reqs/supplyexports.dm
+++ b/code/modules/reqs/supplyexports.dm
@@ -13,11 +13,11 @@
 	export_obj = /obj/structure/ore_box/phoron
 
 /datum/supply_export/compactorebox/phoron
-	cost = 50
+	cost = 25
 	export_obj = /obj/item/compactorebox/phoron
 
 /datum/supply_export/compactorebox/platinum
-	cost = 100
+	cost = 50
 	export_obj = /obj/item/compactorebox/platinum
 
 /datum/supply_export/xemomorph


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This does a few things
1) Increases miner crate capacity to 8 before it stops making more instead of 2
2) Makes the compactor upgrade the default behaviour
3) Nerfs the overclock upgrade which previously reduced production time from 140 seconds to 70 seconds. It now reduces to 100 seconds.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No one wants to be the guy who sits there dragging crates to an ASRS pad all round. It's boring and tedious. This makes selling crates less tedious and makes it need to be done less often. The miner holds enough crates in it you can get away with selling once every ~13 minutes on an overclocked miner or every ~19 minutes on a non overclocked one.
Nerfed the overclock upgrade a little bit because doubling the output of miners is actually insane (no wonder no one used the other upgrades.) It's still probably the best upgrade because resilience just isn't very good. I have some ideas for more stuff to do with upgrades in the future to make them a little more desirable compared to this one, but that's for another day.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Made the overclock upgrade a little less effective
tweak: The miner compactor upgrade is now the default behavior. The old upgrade has been removed.
tweak: Miners can hold more ore before being emptied
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
