### PR TITLE
Rework some tick defines to better yield to byond's processing needs

### DIFF
--- a/code/__DEFINES/_tick.dm
+++ b/code/__DEFINES/_tick.dm
@@ -1,14 +1,17 @@
 /// Percentage of tick to leave for master controller to run
-#define MAPTICK_MC_MIN_RESERVE 70
+#define MAPTICK_MC_MIN_RESERVE 40
 /// internal_tick_usage is updated every tick by extools
 #define MAPTICK_LAST_INTERNAL_TICK_USAGE ((GLOB.internal_tick_usage / world.tick_lag) * 100)
-/// Tick limit while running normally
+/// Amount of a tick to reserve for byond if MAPTICK_LAST_INTERNAL_TICK_USAGE is 0 or not working.
 #define TICK_BYOND_RESERVE 2
+/// Tick limit while running normally
 #define TICK_LIMIT_RUNNING (max(100 - TICK_BYOND_RESERVE - MAPTICK_LAST_INTERNAL_TICK_USAGE, MAPTICK_MC_MIN_RESERVE))
+/// Precent of a tick to require to even bother running anything. (10 percent of the tick_limit_running by default)
+#define TICK_MIN_RUNTIME (TICK_LIMIT_RUNNING * 0.1)
 /// Tick limit used to resume things in stoplag
-#define TICK_LIMIT_TO_RUN 70
+#define TICK_LIMIT_TO_RUN (Master.current_ticklimit - TICK_MIN_RUNTIME)
 /// Tick limit for MC while running
-#define TICK_LIMIT_MC 70
+#define TICK_LIMIT_MC (TICK_LIMIT_RUNNING - TICK_MIN_RUNTIME)
 /// Tick limit while initializing
 #define TICK_LIMIT_MC_INIT_DEFAULT (100 - TICK_BYOND_RESERVE)
 


### PR DESCRIPTION
This is a copy of an idea I had for /tg/, that doesn't work over there because the mc needed more time then this would allow it to get. 

Looking at tgmc performance on high pop, this will work over here, as most of the cpu time is spent on byond processing (50 to 90%), and most mc usage of cpu time is spikey, meaning it would benefit from automagically spreading cpu across ticks from yielding to byond more aggressively.

