### PR TITLE
smg buff, 0.15 fire rate and aim mode, and mags fit in black webbing, t19 scatter changes

### DIFF
--- a/code/modules/clothing/under/ties.dm
+++ b/code/modules/clothing/under/ties.dm
@@ -521,7 +521,6 @@
 	cant_hold = list(
 		/obj/item/stack/razorwire,
 		/obj/item/stack/sheet,
-		/obj/item/ammo_magazine/smg/standard_smg,
 		/obj/item/stack/sandbags,
 		/obj/item/stack/snow,
 	)

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -96,6 +96,8 @@
 	flags_equip_slot = ITEM_SLOT_BACK
 	wield_delay = 0.5 SECONDS
 	force = 20
+	aim_speed_modifier = 0.4
+	aim_fire_delay = 0.2 SECONDS
 	current_mag = /obj/item/ammo_magazine/smg/standard_smg
 	type_of_casings = null
 	attachable_allowed = list(
@@ -117,7 +119,7 @@
 	accuracy_mult = 1.15
 	accuracy_mult_unwielded = 0.8
 	scatter = 0
-	fire_delay = 0.165 SECONDS
+	fire_delay = 0.15 SECONDS
 	scatter_unwielded = 30
 	aim_slowdown = 0.25
 	burst_amount = 0

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -75,9 +75,9 @@
 	accuracy_mult = 1.5
 	accuracy_mult_unwielded = 0.85
 	recoil_unwielded = 0
-	scatter = 15
+	scatter = 0
 	fire_delay = 0.2 SECONDS
-	scatter_unwielded = 0 //Made to be used one handed.
+	scatter_unwielded = 10 //Made to be used one handed.
 	aim_slowdown = 0.15
 	burst_amount = 5
 	movement_acc_penalty_mult = 0


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This gives the p90 some level of niche, giving it better of gives it better ttk than it used to have due to bullets coming out faster, and it has the aim mode it should have.
Black webbing fitting is fine for now, though I can remove it

I personally think this is a better solution than whatever #5789 does since that pr is incredibly player unfriendly due to the fact that it basically makes the smg literally useless past 3 tiles for whatever reason, and breaks LITERALLY EVERY OTHER NORMAL BULLET SMG IN THE GAME while its at it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
P90 needs a niche and this possibly gives it won't
past mjp thought that scatter unwielded did something entirely different, so I made t19 scatter different
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: p90 buffs, 0.15 fire rate from 0.165 and aim mode, mags fit in black webbing. T19 has 10 scatter unwielded 0 wielded now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
