### PR TITLE
Better Sight Check for Binos

### DIFF
--- a/code/game/objects/items/binoculars.dm
+++ b/code/game/objects/items/binoculars.dm
@@ -64,7 +64,7 @@
 	if(!pa.Find("ctrl") && pa.Find("shift"))
 		acquire_coordinates(object, user)
 		return TRUE
-
+	
 	if(pa.Find("ctrl") && !pa.Find("shift"))
 		acquire_target(object, user)
 		return TRUE

--- a/code/game/objects/items/binoculars.dm
+++ b/code/game/objects/items/binoculars.dm
@@ -64,7 +64,7 @@
 	if(!pa.Find("ctrl") && pa.Find("shift"))
 		acquire_coordinates(object, user)
 		return TRUE
-	
+
 	if(pa.Find("ctrl") && !pa.Find("shift"))
 		acquire_target(object, user)
 		return TRUE
@@ -168,7 +168,7 @@
 		to_chat(user, "<span class='warning'>You can't focus properly through \the [src] while looking through something else.</span>")
 		return
 
-	if(!can_see(user, A, 25))
+	if(!(A in view(user,25)))
 		to_chat(user, "<span class='warning'>You can't see anything there.</span>")
 		return
 


### PR DESCRIPTION

<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Tac Binos sight check for lasing uses view() instead of can_see()
Hugh originally used can_see because he didn't want you to be able to bypass the check with mesons, but meson vision does not work while you're in binoculars anyways so it's not a concern

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The sight check for binoculars functions more intuitively. No more mashing tiles trying to figure out which one you can "see"

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The sight check for lasing with tac binos is more intuitive. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
