### PR TITLE
Hunter Stealth Stun removal

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -477,7 +477,7 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define HUNTER_POUNCE_SNEAKATTACK_DELAY 		30 //3 seconds before we can sneak attack
 #define HANDLE_STEALTH_CHECK					1
 #define HANDLE_SNEAK_ATTACK_CHECK				3
-#define HUNTER_SNEAK_SLASH_ARMOR_PEN			0.8 //1 - this value = the actual penetration
+#define HUNTER_SNEAK_SLASH_ARMOR_PEN			0.6 //1 - this value = the actual penetration
 #define HUNTER_SNEAK_ATTACK_RUN_DELAY			2 SECONDS
 #define HUNTER_SNEAKATTACK_MAX_MULTIPLIER		2.0
 #define HUNTER_SNEAKATTACK_RUN_REDUCTION		0.2

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -477,7 +477,7 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define HUNTER_POUNCE_SNEAKATTACK_DELAY 		30 //3 seconds before we can sneak attack
 #define HANDLE_STEALTH_CHECK					1
 #define HANDLE_SNEAK_ATTACK_CHECK				3
-#define HUNTER_SNEAK_SLASH_ARMOR_PEN			0.6 //1 - this value = the actual penetration
+#define HUNTER_SNEAK_SLASH_ARMOR_PEN			0.8 //1 - this value = the actual penetration
 #define HUNTER_SNEAK_ATTACK_RUN_DELAY			2 SECONDS
 #define HUNTER_SNEAKATTACK_MAX_MULTIPLIER		2.0
 #define HUNTER_SNEAKATTACK_RUN_REDUCTION		0.2

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -189,7 +189,6 @@
 
 	owner.visible_message("<span class='danger'>\The [owner] strikes [target] with [flavour] precision!</span>", \
 	"<span class='danger'>We strike [target] with [flavour] precision!</span>")
-	target.ParalyzeNoChain(1 SECONDS)
 	target.adjust_stagger(staggerslow_stacks)
 	target.add_slowdown(staggerslow_stacks)
 
@@ -211,7 +210,6 @@
 
 	owner.visible_message("<span class='danger'>\The [owner] strikes [target] with [flavour] precision!</span>", \
 	"<span class='danger'>We strike [target] with [flavour] precision!</span>")
-	target.ParalyzeNoChain(1 SECONDS)
 	target.adjust_stagger(staggerslow_stacks)
 	target.add_slowdown(staggerslow_stacks)
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the Hunter Stealth stun and increases the Sneak Attack armor penetration.
## Why It's Good For The Game

Hunter is a bit too strong and cheesy with the sneak attack stun combined with the pounce, eventually stunlocking marines for easy kills. This change makes it easier to counteract without taking away too much of the hunter's skirmishing capability.

## Changelog
:cl: Naaanii
balance: removed stealth stun and increased armor pen from 20% to 40% on sneak attack.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
