### PR TITLE
Fixes attachments for M412L1 and M412 Elite

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -934,7 +934,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	scatter_mod = -10
 	movement_acc_penalty_mod = 0.1
 
-/obj/item/attachable/stock/irremoveable/rifle
+/obj/item/attachable/stock/rifle/irremoveable
 	name = "\improper M412 solid stock"
 	pixel_shift_x = 32
 	pixel_shift_y = 13

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -938,14 +938,8 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	name = "\improper M412 solid stock"
 	icon_state = "riflestock"
 	attach_icon = "riflestock_a"
-	wield_delay_mod = 0.2 SECONDS
-	size_mod = 1
 	pixel_shift_x = 32
 	pixel_shift_y = 13
-	accuracy_mod = 0.05
-	recoil_mod = -3
-	scatter_mod = -10
-	movement_acc_penalty_mod = 0.1
 
 /obj/item/attachable/stock/rifle/marksman
 	name = "\improper T-45 marksman stock"

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -934,10 +934,18 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	scatter_mod = -10
 	movement_acc_penalty_mod = 0.1
 
-/obj/item/attachable/stock/rifle/irremoveable
+/obj/item/attachable/stock/irremoveable/rifle
 	name = "\improper M412 solid stock"
+	icon_state = "riflestock"
+	attach_icon = "riflestock_a"
+	wield_delay_mod = 0.2 SECONDS
+	size_mod = 1
 	pixel_shift_x = 32
 	pixel_shift_y = 13
+	accuracy_mod = 0.05
+	recoil_mod = -3
+	scatter_mod = -10
+	movement_acc_penalty_mod = 0.1
 
 /obj/item/attachable/stock/rifle/marksman
 	name = "\improper T-45 marksman stock"

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -366,7 +366,7 @@
 	)
 
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 19,"rail_x" = 8, "rail_y" = 21, "under_x" = 22, "under_y" = 15, "stock_x" = 9, "stock_y" = 15)
-	starting_attachment_types = list(/obj/item/attachable/attached_gun/grenade, /obj/item/attachable/stock/rifle/irremoveable)
+	starting_attachment_types = list(/obj/item/attachable/attached_gun/grenade, /obj/item/attachable/stock/irremoveable/rifle)
 
 
 	burst_delay = 0.2 SECONDS
@@ -714,7 +714,7 @@
 		/obj/item/attachable/angledgrip,
 		/obj/item/attachable/flashlight,
 		/obj/item/attachable/bipod,
-		/obj/item/attachable/stock/rifle/irremoveable,
+		/obj/item/attachable/stock/irremoveable/rifle,
 		/obj/item/attachable/compensator,
 		/obj/item/attachable/magnetic_harness,
 		/obj/item/attachable/scope,
@@ -726,7 +726,7 @@
 	gun_firemode_list = list(GUN_FIREMODE_SEMIAUTO, GUN_FIREMODE_BURSTFIRE, GUN_FIREMODE_AUTOMATIC, GUN_FIREMODE_AUTOBURST)
 	gun_skill_category = GUN_SKILL_HEAVY_WEAPONS
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 19,"rail_x" = 8, "rail_y" = 21, "under_x" = 22, "under_y" = 15, "stock_x" = 9, "stock_y" = 15)
-	starting_attachment_types = list(/obj/item/attachable/stock/rifle/irremoveable)
+	starting_attachment_types = list(/obj/item/attachable/stock/irremoveable/rifle)
 	actions_types = list(/datum/action/item_action/aim_mode)
 	aim_fire_delay = 0.15 SECONDS
 	aim_speed_modifier = 2

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -714,7 +714,6 @@
 		/obj/item/attachable/angledgrip,
 		/obj/item/attachable/flashlight,
 		/obj/item/attachable/bipod,
-		/obj/item/attachable/stock/irremoveable/rifle,
 		/obj/item/attachable/compensator,
 		/obj/item/attachable/magnetic_harness,
 		/obj/item/attachable/scope,

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -366,7 +366,7 @@
 	)
 
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 19,"rail_x" = 8, "rail_y" = 21, "under_x" = 22, "under_y" = 15, "stock_x" = 9, "stock_y" = 15)
-	starting_attachment_types = list(/obj/item/attachable/attached_gun/grenade, /obj/item/attachable/stock/irremoveable/rifle)
+	starting_attachment_types = list(/obj/item/attachable/attached_gun/grenade, /obj/item/attachable/stock/rifle/irremoveable)
 
 
 	burst_delay = 0.2 SECONDS
@@ -714,17 +714,19 @@
 		/obj/item/attachable/angledgrip,
 		/obj/item/attachable/flashlight,
 		/obj/item/attachable/bipod,
-		/obj/item/attachable/stock/rifle,
+		/obj/item/attachable/stock/rifle/irremoveable,
 		/obj/item/attachable/compensator,
 		/obj/item/attachable/magnetic_harness,
 		/obj/item/attachable/scope,
+		/obj/item/attachable/scope/marine,
+		/obj/item/attachable/scope/mini,
 	)
 
 	flags_gun_features = GUN_AUTO_EJECTOR|GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER|GUN_WIELDED_FIRING_ONLY|GUN_LOAD_INTO_CHAMBER
 	gun_firemode_list = list(GUN_FIREMODE_SEMIAUTO, GUN_FIREMODE_BURSTFIRE, GUN_FIREMODE_AUTOMATIC, GUN_FIREMODE_AUTOBURST)
 	gun_skill_category = GUN_SKILL_HEAVY_WEAPONS
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 19,"rail_x" = 8, "rail_y" = 21, "under_x" = 22, "under_y" = 15, "stock_x" = 9, "stock_y" = 15)
-	starting_attachment_types = list(/obj/item/attachable/stock/irremoveable/rifle)
+	starting_attachment_types = list(/obj/item/attachable/stock/rifle/irremoveable)
 	actions_types = list(/datum/action/item_action/aim_mode)
 	aim_fire_delay = 0.15 SECONDS
 	aim_speed_modifier = 2


### PR DESCRIPTION
## About The Pull Request
Fixes the wrong stock icon showing on the M412L1, and M412 Elite. Allows M412L1 to attach rail-scope, and mini-scope
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Correct stock looks nice. M412L1 looks like it was originally meant to fit a scope, but couldn't because of sub types. Eris asked to have this fixed. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Sulaboy
fix: M412L1 and M412 Elite now show correct stock
fix: M412L1 can now attach rail-scope, and mini-scope
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
