### PR TITLE
Changes Marine Respawn Time

### DIFF
--- a/code/_globalvars/admin.dm
+++ b/code/_globalvars/admin.dm
@@ -4,7 +4,7 @@ GLOBAL_VAR_INIT(dsay_allowed, TRUE)
 GLOBAL_VAR_INIT(enter_allowed, TRUE)
 GLOBAL_VAR_INIT(respawn_allowed, TRUE)
 
-GLOBAL_VAR_INIT(respawntime, 30 MINUTES)
+GLOBAL_VAR_INIT(respawntime, 45 MINUTES)
 GLOBAL_VAR_INIT(xenorespawntime, 2 MINUTES)
 GLOBAL_VAR_INIT(fileaccess_timer, 0)
 


### PR DESCRIPTION
## About The Pull Request

This changes marine respawn time from 30 minutes to 45 minutes, simple as.

## Why It's Good For The Game

Marine respawns were made 30 minutes after the addition of headbite, and aim mode has made marine even stronger since then.  Xenos seem to have an issue with killing marines fast enough to reduce their numbers effectively before marines respawn or get new latejoins, especially on highpop
EDIT:I am a monkey and fucked up the changelog
## Changelog
🆑 
balance: marines now take 45 minutes to respawn instead of 30
/🆑 
