### PR TITLE
Spitter Buff Balance Tweaks

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/abilities_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/abilities_spitter.dm
@@ -6,8 +6,8 @@
 	action_icon_state = "spray_acid"
 	mechanics_text = "Spray a line of dangerous acid at your target."
 	ability_name = "spray acid"
-	plasma_cost = 250
-	cooldown_timer = 30 SECONDS
+	plasma_cost = 200
+	cooldown_timer = 20 SECONDS
 
 /datum/action/xeno_action/activable/spray_acid/line/use_ability(atom/A)
 	var/mob/living/carbon/xenomorph/X = owner

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1463,11 +1463,10 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	sound_hit 	 = "acid_hit"
 	sound_bounce	= "acid_bounce"
 	damage_type = BURN
-	added_spit_delay = 5
-	spit_cost = 75
-	flags_ammo_behavior = AMMO_XENO|AMMO_EXPLOSIVE
+	spit_cost = 50
+	flags_ammo_behavior = AMMO_XENO|AMMO_EXPLOSIVE|AMMO_SKIPS_ALIENS
 	armor_type = "acid"
-	damage = 18
+	damage = 20
 	max_range = 8
 	bullet_color = COLOR_PALE_GREEN_GRAY
 


### PR DESCRIPTION
## About The Pull Request

1. Medium and light acid spit no longer have any added delay.

2. Base cost of medium and light acid spit decreased to 50 plasma.

3. Light acid spit increased to 20 damage up from 18.

4. Spitter acid spray cooldown decreased from 30 to 20 seconds, and plasma cost decreased from 250 to 200.

5. Acid spit now ignores xeno targets.

## Why It's Good For The Game

Makes Spitter not suck.


## Changelog
:cl:
balance: Spitter acid spray cooldown decreased from 30 to 20 seconds, and plasma cost decreased from 250 to 200.
balance: Medium and light acid spit no longer have any added delay.
balance: Base cost of medium and light acid spit decreased to 50 plasma.
balance: Light acid spit increased to 20 damage up from 18.
balance: Acid spit projectiles now ignore xeno targets.
/:cl: