### PR TITLE
Fix crit/stun/standing drags having no delay

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -225,7 +225,7 @@
 	if(ishuman(L))
 		if(!chestburst)
 			do_attack_animation(L, ATTACK_EFFECT_GRAB)
-			if(L.stat == DEAD && !L.headbitten) //Grab delay vs the non-headbitten dead
+			if(!L.headbitten) //Grab delay vs the non-headbitten dead
 				if(!do_mob(src, L , XENO_PULL_CHARGE_TIME, BUSY_ICON_HOSTILE))
 					return FALSE
 		pull_speed += XENO_DEADHUMAN_DRAG_SLOWDOWN


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tested all of them had no issues other then I dont have my preferences on the server and had issues headbitting but got it done somehow when I wasnt looking to test that headbites still have no delay. Basically adds delay to stunned and crit marines while also making it harder for wraith to walk up to a marine and teleport him a screen away or into lava.


## Why It's Good For The Game

Its better then decreasing the drag speed on xenos since you are still able to combat drag, just only if you are willing to be shot for 2 seconds before dragging. This allows hunters to sneak out crit marines or very long queen screech stuns fast enough for marines to not react, but only if they have enough time to grab said marine.

The alternative is much worse as marines would be able to hunt them down while dragging and is just worse altogether as no one like slowly dragging bodies into a corner to eat them.

## Changelog
:cl:
del: deleted the part where it said you have to be dead for dead speed reduction to count
balance: technically a nerf to xenos even if it was a bug
fix: fixed crit/stun drags
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
