### PR TITLE
Adds the AOE-generator  to the ships , adds it as a req purchaseable

### DIFF
--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -10142,6 +10142,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
+"Ht" = (
+/obj/machinery/power/port_gen/pacman/mobile_power,
+/turf/open/floor/mainship/mono,
+/area/mainship/engineering/engineering_workshop)
 "Hv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 1;
@@ -49138,7 +49142,7 @@ OU
 zv
 OM
 zT
-zR
+Ht
 OV
 Az
 Mb

--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -17041,6 +17041,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/power/port_gen/pacman/mobile_power,
 /turf/open/floor/prison,
 /area/sulaco/hangar)
 "tqa" = (

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1158,6 +1158,7 @@ ENGINEERING
 	name = "Combat Grade Floodlight"
 	contains = list(/obj/machinery/floodlightcombat)
 	cost = 5
+
 /datum/supply_packs/engineering/advanced_generator
 	name = "Wireless power generator"
 	contains = list(/obj/machinery/power/port_gen/pacman/mobile_power)

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1158,6 +1158,10 @@ ENGINEERING
 	name = "Combat Grade Floodlight"
 	contains = list(/obj/machinery/floodlightcombat)
 	cost = 5
+/datum/supply_packs/engineering/advanced_generator
+	name = "Wireless power generator"
+	contains = list(/obj/machinery/power/port_gen/pacman/mobile_power)
+	cost = 20
 
 /*******************************************************************************
 SUPPLIES

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1159,7 +1159,7 @@ ENGINEERING
 	contains = list(/obj/machinery/floodlightcombat)
 	cost = 5
 /datum/supply_packs/engineering/advanced_generator
-	name = "wireless power generator"
+	name = "Wireless power generator"
 	contains = list(/obj/machinery/power/port_gen/pacman/mobile_power)
 	cost = 20
 

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1159,7 +1159,7 @@ ENGINEERING
 	contains = list(/obj/machinery/floodlightcombat)
 	cost = 5
 /datum/supply_packs/engineering/advanced_generator
-	name = "Wireless power generator"
+	name = "wireless power generator"
 	contains = list(/obj/machinery/power/port_gen/pacman/mobile_power)
 	cost = 20
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds 1 A.D.V.P.A.C.M.A.N mobile-power generator to each ship map in rotation , adds it to req , 1 generator for 20 points.
## Why It's Good For The Game

Less reliance on easy to saboutage APC's.

## Changelog
:cl:
add:  A.D.V.P.A.C.M.A.N AOE Generator on all ship maps.
add:  A.D.V.P.A.C.M.A.N as a purchaseable requisitions item.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
