### PR TITLE
Death to Upgrade Shitcode

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/xenoupgrade.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoupgrade.dm
@@ -22,8 +22,6 @@
 			var/datum/action/xeno_action/A = new new_action_path()
 			A.give_action(src)
 
-	remove_abilities()
-	add_abilities()
 	SEND_SIGNAL(src, COMSIG_XENOMORPH_ABILITY_ON_UPGRADE)
 	if(selected_ability_type)
 		for(var/datum/action/xeno_action/activable/activable_ability in actions)

--- a/code/modules/mob/living/carbon/xenomorph/xenoupgrade.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoupgrade.dm
@@ -10,6 +10,18 @@
 	do_jitter_animation(1000)
 	set_datum()
 	var/selected_ability_type = selected_ability?.type
+
+	for(var/check_existing_actions in xeno_abilities) //Remove xenos actions we shouldn't have
+		var/datum/action/xeno_action/existing_action_path = check_existing_actions
+		if(!locate(existing_action_path) in xeno_caste.actions)
+			existing_action_path.remove_action(src)
+
+	for(var/check_new_actions in xeno_caste.actions) //Give the xenos actions we don't currently have
+		var/datum/action/xeno_action/new_action_path = check_new_actions
+		if(!locate(new_action_path) in xeno_abilities)
+			var/datum/action/xeno_action/A = new new_action_path()
+			A.give_action(src)
+
 	remove_abilities()
 	add_abilities()
 	SEND_SIGNAL(src, COMSIG_XENOMORPH_ABILITY_ON_UPGRADE)


### PR DESCRIPTION
## About The Pull Request

Upgrading no longer qdels and replaces ability lists wholesale.

## Why It's Good For The Game

Upgrading no longer qdels and replaces ability lists wholesale, thus upgrading will not break tons of abilities it used to.

## Changelog
:cl:
code: Upgrading no longer qdels and replaces ability lists wholesale.
/:cl: