### PR TITLE
Remove Sight Check from Tac Binos

### DIFF
--- a/code/game/objects/items/binoculars.dm
+++ b/code/game/objects/items/binoculars.dm
@@ -64,7 +64,7 @@
 	if(!pa.Find("ctrl") && pa.Find("shift"))
 		acquire_coordinates(object, user)
 		return TRUE
-	
+
 	if(pa.Find("ctrl") && !pa.Find("shift"))
 		acquire_target(object, user)
 		return TRUE
@@ -168,9 +168,6 @@
 		to_chat(user, "<span class='warning'>You can't focus properly through \the [src] while looking through something else.</span>")
 		return
 
-	if(!can_see(user, A, 25))
-		to_chat(user, "<span class='warning'>You can't see anything there.</span>")
-		return
 
 	if(!user.mind)
 		return


### PR DESCRIPTION
## About The Pull Request

Removes the sight check from tac binos

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Trying to find a tile you can "see" on the current sight check is inaccurate and CBT
Alternative sight check options are also bad for one reason or another.
Plus the ability to get a lase in a spot you can't see is fine since most fire support is pretty easy for xenos to avoid if they use their brains anyway

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Tactical Binoculars terrible sight check removed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
