### PR TITLE
Fixes weird unicode rendering in command announcements

### DIFF
--- a/code/__HELPERS/announce.dm
+++ b/code/__HELPERS/announce.dm
@@ -11,19 +11,19 @@
 
 	switch(type)
 		if(ANNOUNCEMENT_REGULAR)
-			announcement += "<br><h2 class='alert'>[html_encode(title)]</h2>"
+			announcement += "<meta charset='UTF-8'><br><h2 class='alert'>[html_encode(title)]</h2>"
 
 		if(ANNOUNCEMENT_PRIORITY)
-			announcement += "<h1 class='alert'>Priority Announcement</h1>"
+			announcement += "<meta charset='UTF-8'><h1 class='alert'>Priority Announcement</h1>"
 			if(title && title != "Announcement")
-				announcement += "<br><h2 class='alert'>[html_encode(title)]</h2>"
+				announcement += "<meta charset='UTF-8'><br><h2 class='alert'>[html_encode(title)]</h2>"
 
 		if(ANNOUNCEMENT_COMMAND)
-			announcement += "<h1 class='alert'>Command Announcement</h1>"
+			announcement += "<meta charset='UTF-8'><h1 class='alert'>Command Announcement</h1>"
 
 
-	announcement += "<br><span class='alert'>[html_encode(message)]</span><br>"
-	announcement += "<br>"
+	announcement += "<meta charset='UTF-8'><br><span class='alert'>[html_encode(message)]</span><br>"
+	announcement += "<meta charset='UTF-8'><br>"
 
 	var/s = sound(sound, channel = CHANNEL_ANNOUNCEMENTS)
 	for(var/i in receivers)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

e.g ' gets replaced with & # 39; and all that

![image](https://user-images.githubusercontent.com/47011211/106825162-8a7b8880-6684-11eb-94b8-9f2353e7eb30.png)
Proof that it works.

ports: https://github.com/BeeStation/BeeStation-Hornet/pull/3567
## Why It's Good For The Game

it's a fix
## Changelog 
:cl: jupyterkat BeloneX
fix: fixed weird announcement text renderings
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
