### PR TITLE
Carbons Can Now Special Click on Window Frame Weeds to Climb Frames

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -287,6 +287,7 @@
 #define COMSIG_MOB_GUN_AUTOFIRED "mob_gun_autofired"
 #define COMSIG_MOB_ATTACHMENT_FIRED "mob_attachment_fired"
 #define COMSIG_MOB_TOGGLEMOVEINTENT "mob_togglemoveintent"		//drom base of mob/toggle_move_intent(): (new_intent)
+#define COMSIG_MOB_SPECIAL_CLICK "mob_special_click"
 
 //mob/dead/observer
 #define COMSIG_OBSERVER_CLICKON "observer_clickon"				//from mob/dead/observer/ClickOn(): (atom/A, params)

--- a/code/datums/keybinding/carbon.dm
+++ b/code/datums/keybinding/carbon.dm
@@ -146,3 +146,4 @@
 		UnregisterSignal(user, (COMSIG_MOB_CLICKON))
 		return
 	A.specialclick(user)
+	SEND_SIGNAL(A, COMSIG_MOB_SPECIAL_CLICK, user)

--- a/code/datums/keybinding/carbon.dm
+++ b/code/datums/keybinding/carbon.dm
@@ -146,4 +146,3 @@
 		UnregisterSignal(user, (COMSIG_MOB_CLICKON))
 		return
 	A.specialclick(user)
-	SEND_SIGNAL(A, COMSIG_MOB_SPECIAL_CLICK, user)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -792,6 +792,7 @@ Proc for attack log creation, because really why not
 
 // For special click interactions (take first item out of container, quick-climb, etc.)
 /atom/proc/specialclick(mob/living/carbon/user)
+	SEND_SIGNAL(src, COMSIG_MOB_SPECIAL_CLICK, user)
 	return
 
 

--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -98,6 +98,17 @@
 	plane = GAME_PLANE
 	icon_state = "weedwall"
 
+/obj/effect/alien/weeds/weedwall/Initialize()
+	. = ..()
+	RegisterSignal(src, COMSIG_MOB_SPECIAL_CLICK, .proc/special_click_signal)
+
+/obj/effect/alien/weeds/weedwall/proc/special_click_signal(datum/source, mob/living/carbon/user)
+	SIGNAL_HANDLER
+	var/obj/structure/window_frame/F = locate() in loc
+	if(!F)
+		return
+	return INVOKE_ASYNC(F, /obj/structure/window_frame/proc.specialclick, user)
+
 /obj/effect/alien/weeds/weedwall/update_sprite()
 	if(iswallturf(loc))
 		var/turf/closed/wall/W = loc
@@ -110,10 +121,6 @@
 /obj/effect/alien/weeds/weedwall/window
 	layer = ABOVE_TABLE_LAYER
 
-/obj/effect/alien/weeds/weedwall/window/Initialize()
-	. = ..()
-	RegisterSignal(src, COMSIG_MOB_SPECIAL_CLICK, .proc/special_click_signal)
-
 /obj/effect/alien/weeds/weedwall/window/update_sprite()
 	var/obj/structure/window/framed/F = locate() in loc
 	if(F && F.junction)
@@ -125,19 +132,8 @@
 		return ..()
 	return F.MouseDrop_T(dropping, user)
 
-/obj/effect/alien/weeds/weedwall/window/proc/special_click_signal(datum/source, mob/living/carbon/user)
-	SIGNAL_HANDLER
-	var/obj/structure/window_frame/F = locate() in loc
-	if(!F)
-		return
-	return INVOKE_ASYNC(F, /obj/structure/window_frame/proc.specialclick, user)
-
 /obj/effect/alien/weeds/weedwall/frame
 	layer = ABOVE_TABLE_LAYER
-
-/obj/effect/alien/weeds/weedwall/frame/Initialize()
-	. = ..()
-	RegisterSignal(src, COMSIG_MOB_SPECIAL_CLICK, .proc/special_click_signal)
 
 /obj/effect/alien/weeds/weedwall/frame/update_sprite()
 	var/obj/structure/window_frame/WF = locate() in loc
@@ -149,13 +145,6 @@
 	if(!WF)
 		return ..()
 	return WF.MouseDrop_T(dropping, user)
-
-/obj/effect/alien/weeds/weedwall/frame/proc/special_click_signal(datum/source, mob/living/carbon/user)
-	SIGNAL_HANDLER
-	var/obj/structure/window_frame/WF = locate() in loc
-	if(!WF)
-		return
-	return INVOKE_ASYNC(WF, /obj/structure/window_frame/proc.specialclick, user)
 
 
 // =================

--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -110,6 +110,10 @@
 /obj/effect/alien/weeds/weedwall/window
 	layer = ABOVE_TABLE_LAYER
 
+/obj/effect/alien/weeds/weedwall/window/Initialize()
+	. = ..()
+	RegisterSignal(src, COMSIG_MOB_SPECIAL_CLICK, .proc/special_click_signal)
+
 /obj/effect/alien/weeds/weedwall/window/update_sprite()
 	var/obj/structure/window/framed/F = locate() in loc
 	if(F && F.junction)
@@ -121,7 +125,8 @@
 		return ..()
 	return F.MouseDrop_T(dropping, user)
 
-/obj/effect/alien/weeds/weedwall/window/specialclick(mob/living/carbon/user)
+/obj/effect/alien/weeds/weedwall/window/proc/special_click_signal(datum/source, mob/living/carbon/user)
+	SIGNAL_HANDLER
 	var/obj/structure/window/framed/F = locate() in loc
 	if(!F)
 		return ..()
@@ -129,6 +134,10 @@
 
 /obj/effect/alien/weeds/weedwall/frame
 	layer = ABOVE_TABLE_LAYER
+
+/obj/effect/alien/weeds/weedwall/frame/Initialize()
+	. = ..()
+	RegisterSignal(src, COMSIG_MOB_SPECIAL_CLICK, .proc/special_click_signal)
 
 /obj/effect/alien/weeds/weedwall/frame/update_sprite()
 	var/obj/structure/window_frame/WF = locate() in loc
@@ -141,7 +150,8 @@
 		return ..()
 	return WF.MouseDrop_T(dropping, user)
 
-/obj/effect/alien/weeds/weedwall/frame/specialclick(mob/living/carbon/user)
+/obj/effect/alien/weeds/weedwall/frame/proc/special_click_signal(datum/source, mob/living/carbon/user)
+	SIGNAL_HANDLER
 	var/obj/structure/window_frame/WF = locate() in loc
 	if(!WF)
 		return ..()

--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -121,6 +121,12 @@
 		return ..()
 	return F.MouseDrop_T(dropping, user)
 
+/obj/effect/alien/weeds/weedwall/window/specialclick(mob/living/carbon/user)
+	var/obj/structure/window/framed/F = locate() in loc
+	if(!F)
+		return ..()
+	return F.specialclick(user)
+
 /obj/effect/alien/weeds/weedwall/frame
 	layer = ABOVE_TABLE_LAYER
 
@@ -134,6 +140,12 @@
 	if(!WF)
 		return ..()
 	return WF.MouseDrop_T(dropping, user)
+
+/obj/effect/alien/weeds/weedwall/frame/specialclick(mob/living/carbon/user)
+	var/obj/structure/window_frame/WF = locate() in loc
+	if(!WF)
+		return ..()
+	return WF.specialclick(user)
 
 
 // =================

--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -129,7 +129,7 @@
 	SIGNAL_HANDLER
 	var/obj/structure/window_frame/F = locate() in loc
 	if(!F)
-		return ..()
+		return
 	return INVOKE_ASYNC(F, /obj/structure/window_frame/proc.specialclick, user)
 
 /obj/effect/alien/weeds/weedwall/frame
@@ -154,7 +154,7 @@
 	SIGNAL_HANDLER
 	var/obj/structure/window_frame/WF = locate() in loc
 	if(!WF)
-		return ..()
+		return
 	return INVOKE_ASYNC(WF, /obj/structure/window_frame/proc.specialclick, user)
 
 

--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -127,10 +127,10 @@
 
 /obj/effect/alien/weeds/weedwall/window/proc/special_click_signal(datum/source, mob/living/carbon/user)
 	SIGNAL_HANDLER
-	var/obj/structure/window/framed/F = locate() in loc
+	var/obj/structure/window_frame/F = locate() in loc
 	if(!F)
 		return ..()
-	return F.specialclick(user)
+	return INVOKE_ASYNC(F, /obj/structure/window_frame/proc.specialclick, user)
 
 /obj/effect/alien/weeds/weedwall/frame
 	layer = ABOVE_TABLE_LAYER
@@ -155,7 +155,7 @@
 	var/obj/structure/window_frame/WF = locate() in loc
 	if(!WF)
 		return ..()
-	return WF.specialclick(user)
+	return INVOKE_ASYNC(WF, /obj/structure/window_frame/proc.specialclick, user)
 
 
 // =================


### PR DESCRIPTION
## About The Pull Request

Weeds no longer obstruct special click from climbing window frames.

## Why It's Good For The Game

Weeds no longer obstruct special click from climbing window frames.

## Changelog
:cl:
code: Weeds no longer obstruct special click from climbing window frames.
/:cl: