### PR TITLE
Reagent Mixing QoL

### DIFF
--- a/code/game/objects/items/reagent_containers/food/drinks.dm
+++ b/code/game/objects/items/reagent_containers/food/drinks.dm
@@ -217,7 +217,7 @@
 	desc = "A metal shaker to mix drinks in."
 	icon_state = "shaker"
 	amount_per_transfer_from_this = 10
-	volume = 100
+	volume = 120
 	center_of_mass = list("x"=17, "y"=10)
 
 /obj/item/reagent_containers/food/drinks/flask

--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -22,7 +22,7 @@
 	var/recharge_counter = 0
 
 	///Reagent amounts that are dispenced
-	var/static/list/possible_transfer_amounts = list(1,5,10,15,20,30,60)
+	var/static/list/possible_transfer_amounts = list(1,5,10,15,20,30,40,60,120)
 
 	var/working_state = "dispenser_working"
 


### PR DESCRIPTION

## About The Pull Request

Just tweaks some numbers chem dispensers and the shaker so that mixing chems/drinks is slightly more natural.


## Changelog
:cl:
tweak: You can now have the option to dispense 40 and 120 units from a chem dispenser. Whoop dee doo.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
