### PR TITLE
Chestburst Is No Longer Permadeath

### DIFF
--- a/code/game/objects/items/defibrillator.dm
+++ b/code/game/objects/items/defibrillator.dm
@@ -234,6 +234,7 @@
 	user.visible_message("<span class='notice'>[icon2html(src, viewers(user))] \The [src] beeps: Defibrillation successful.</span>")
 	H.set_stat(UNCONSCIOUS)
 	H.emote("gasp")
+	H.chestburst = 0 //reset our chestburst state
 	H.regenerate_icons()
 	H.reload_fullscreens()
 	H.flash_act()

--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -206,11 +206,17 @@
 		var/datum/internal_organ/O
 		for(var/i in list("heart", "lungs", "liver", "kidneys", "appendix")) //Bruise all torso internal organs
 			O = H.internal_organs_by_name[i]
-			O.take_damage(O.min_bruised_damage, TRUE)
+
+			if(!H.mind && !H.client) //If we have no client or mind, permadeath time; remove the organs. Mainly for the NPC colonist bodies
+				H.internal_organs_by_name[i] -= i
+				H.internal_organs -= O
+			else
+				O.take_damage(O.min_bruised_damage, TRUE)
 
 		var/datum/limb/chest = H.get_limb("chest")
 		var/datum/wound/internal_bleeding/I = new (15) //Apply internal bleeding to chest
 		chest.wounds += I
+		chest.fracture()
 
 
 	victim.chestburst = 2

--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -202,11 +202,16 @@
 
 	if(ishuman(victim))
 		var/mob/living/carbon/human/H = victim
+		H.apply_damage(200, BRUTE, H.get_limb("chest"), updating_health = TRUE) //lethal armor ignoring brute damage
 		var/datum/internal_organ/O
-		for(var/i in list("heart", "lungs")) //This removes (and later garbage collects) both organs. No heart means instant death.
+		for(var/i in list("heart", "lungs", "stomach")) //Bruise all torso internal organs
 			O = H.internal_organs_by_name[i]
-			H.internal_organs_by_name -= i
-			H.internal_organs -= O
+			O.take_damage(O.min_bruised_damage, TRUE)
+
+		var/datum/limb/chest = H.get_limb("chest")
+		var/datum/wound/internal_bleeding/I = new (15) //Apply internal bleeding to chest
+		chest.wounds += I
+
 
 	victim.chestburst = 2
 	victim.update_burst()

--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -204,7 +204,7 @@
 		var/mob/living/carbon/human/H = victim
 		H.apply_damage(200, BRUTE, H.get_limb("chest"), updating_health = TRUE) //lethal armor ignoring brute damage
 		var/datum/internal_organ/O
-		for(var/i in list("heart", "lungs", "stomach")) //Bruise all torso internal organs
+		for(var/i in list("heart", "lungs", "liver", "kidneys", "appendix")) //Bruise all torso internal organs
 			O = H.internal_organs_by_name[i]
 			O.take_damage(O.min_bruised_damage, TRUE)
 

--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -208,7 +208,7 @@
 			O = H.internal_organs_by_name[i]
 
 			if(!H.mind && !H.client) //If we have no client or mind, permadeath time; remove the organs. Mainly for the NPC colonist bodies
-				H.internal_organs_by_name[i] -= i
+				H.internal_organs_by_name -= i
 				H.internal_organs -= O
 			else
 				O.take_damage(O.min_bruised_damage, TRUE)


### PR DESCRIPTION
## About The Pull Request

Chest bursting now inflicts lethal brute damage, and organ damage, rib fractures and internal bleeding from which the victim can be revived.

## Why It's Good For The Game

Removes a source of perma death from the game, enabling bursted players to get back into the fight; makes getting treated for larva less absolutely critical.

## Changelog
:cl:
balance: Chestburst victims are now revivable, albeit with internal bleeding, rib fractures and organ damage.
/:cl: