### PR TITLE
Psych points are generated when shutters open early

### DIFF
--- a/code/modules/power/groundmap_geothermal.dm
+++ b/code/modules/power/groundmap_geothermal.dm
@@ -30,7 +30,7 @@
 
 /obj/machinery/power/geothermal/Initialize()
 	. = ..()
-	RegisterSignal(SSdcs, list(COMSIG_GLOB_OPEN_TIMED_SHUTTERS_LATE, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_CRASH, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_XENO_HIVEMIND), .proc/activate_corrution)
+	RegisterSignal(SSdcs, list(COMSIG_GLOB_OPEN_TIMED_SHUTTERS_LATE, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_CRASH, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_XENO_HIVEMIND, COMSIG_GLOB_OPEN_SHUTTERS_EARLY), .proc/activate_corrution)
 	update_icon()
 
 /obj/machinery/power/geothermal/examine(mob/user, distance, infix, suffix)
@@ -80,6 +80,7 @@
 /obj/machinery/power/geothermal/power_change()
 	return
 
+///Allow generator to generate psych points
 /obj/machinery/power/geothermal/proc/activate_corrution(datum/source)
 	SIGNAL_HANDLER
 	corruption_on = TRUE


### PR DESCRIPTION
They were generated only after 12:33 (late shutters time), while larva are generated at shutters drop

## Changelog
:cl:
fix: Corruptors give psych points when shutters drop early
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
