### PR TITLE
Fix psych points when hijacking

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -727,11 +727,9 @@ to_chat will check for valid clients itself already so no need to double check f
 		if(xeno_job.total_positions < (-difference + xeno_job.current_positions))
 			xeno_job.set_job_positions(-difference + xeno_job.current_positions)
 	for(var/obj/structure/resin/spawning_pool/spawning_pool as() in GLOB.xeno_resin_spawning_pools)
-		if(!is_ground_level(spawning_pool.z))
-			continue
-		qdel(spawning_pool)
+		spawning_pool.Destroy()
 
-	SSpoints.xeno_points_by_hive["hivenumber"] = 900 //Give a free spawning pool to the hive when going shipside
+	SSpoints.xeno_points_by_hive[hivenumber] = POOL_PRICE //Give a free spawning pool to the hive when going shipside
 
 	var/list/living_player_list = SSticker.mode.count_humans_and_xenos(count_flags = COUNT_IGNORE_HUMAN_SSD)
 	var/num_humans = living_player_list[1]

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -727,7 +727,7 @@ to_chat will check for valid clients itself already so no need to double check f
 		if(xeno_job.total_positions < (-difference + xeno_job.current_positions))
 			xeno_job.set_job_positions(-difference + xeno_job.current_positions)
 	for(var/obj/structure/resin/spawning_pool/spawning_pool as() in GLOB.xeno_resin_spawning_pools)
-		spawning_pool.Destroy()
+		qdel(spawning_pool)
 
 	SSpoints.xeno_points_by_hive[hivenumber] = POOL_PRICE //Give a free spawning pool to the hive when going shipside
 

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -81,9 +81,6 @@
 				associated_hive = null
 				notify_ghosts("\ A resin spawning_pool has been destroyed at [AREACOORD_NO_Z(src)]!", source = get_turf(src), action = NOTIFY_JUMP)
 
-	for(var/i in contents)
-		var/atom/movable/AM = i
-		AM.forceMove(get_step(center_turf, pick(CARDINAL_ALL_DIRS)))
 	playsound(loc,'sound/effects/alien_egg_burst.ogg', 75)
 
 	spawning_pool_area = null


### PR DESCRIPTION
## Changelog
:cl:
fix: Hive will correctly be given enough points for a pool when going shipside.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
