### PR TITLE
Removes boiler's bombard's random offset

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
@@ -195,8 +195,7 @@
 
 /datum/action/xeno_action/activable/bombard/use_ability(atom/A)
 	var/mob/living/carbon/xenomorph/boiler/X = owner
-	var/turf/T = get_turf(A)
-	var/turf/target = locate(T.x, T.y, T.z)
+	var/turf/target = get_turf(A)
 
 	if(!istype(target))
 		return

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
@@ -196,15 +196,7 @@
 /datum/action/xeno_action/activable/bombard/use_ability(atom/A)
 	var/mob/living/carbon/xenomorph/boiler/X = owner
 	var/turf/T = get_turf(A)
-	var/offset_x = rand(-1, 1)
-	var/offset_y = rand(-1, 1)
-
-	if(prob(30))
-		offset_x = 0
-	if(prob(30))
-		offset_y = 0
-
-	var/turf/target = locate(T.x + offset_x, T.y + offset_y, T.z)
+	var/turf/target = locate(T.x, T.y, T.z)
 
 	if(!istype(target))
 		return


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes chance for bombard's target to be offset by a tile.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Boiler doesn't have a random chance to be screwed over and have to prepare another bombard. Having this happen 2-3 times in a row can mean the spot you wanted to shoot at is no longer a good target anyways. If boiler glob is too strong, it should be balanced accordingly since as a tactical ability, the person in my opinion should have the ability to reliably use it when it is available.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: removes random boiler bombard offset
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
