### PR TITLE
CAS Balance Tweaks

### DIFF
--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -79,10 +79,10 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "am" = (
-/obj/structure/ship_ammo/minirocket/illumination,
 /obj/machinery/camera/autoname/mainship{
 	dir = 1
 	},
+/obj/structure/ship_ammo/minirocket/illumination,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "an" = (
@@ -132,7 +132,7 @@
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "aw" = (
-/obj/structure/ship_ammo/rocket/keeper,
+/obj/structure/ship_ammo/rocket/widowmaker,
 /turf/open/floor/mainship/sterile/plain,
 /area/mainship/hallways/hangar)
 "ax" = (
@@ -191,8 +191,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
 "aM" = (
-/obj/structure/ship_ammo/rocket/keeper,
-/turf/open/floor/mainship/mono,
+/obj/structure/ship_ammo/minirocket,
+/turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "aN" = (
 /turf/open/floor/plating/plating_catwalk,
@@ -801,8 +801,8 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/chemistry)
 "cq" = (
-/obj/structure/ship_ammo/rocket/widowmaker,
-/turf/open/floor/mainship/mono,
+/obj/structure/ship_ammo/rocket/banshee,
+/turf/open/floor/mainship/sterile/plain,
 /area/mainship/hallways/hangar)
 "cs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -846,10 +846,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
-"cx" = (
-/obj/structure/dropship_equipment/electronics/spotlights,
-/turf/open/floor/mainship/cargo,
-/area/mainship/hallways/hangar)
 "cy" = (
 /obj/machinery/bodyscanner{
 	dir = 8
@@ -2611,7 +2607,6 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
 "ja" = (
-/obj/structure/dropship_equipment/sentry_holder,
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
@@ -2645,7 +2640,6 @@
 	},
 /area/mainship/command/cic)
 "jg" = (
-/obj/structure/dropship_equipment/electronics/targeting_system,
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
 	},
@@ -2704,10 +2698,6 @@
 /obj/effect/decal/siding,
 /turf/open/floor/mainship/terragov/east,
 /area/space)
-"js" = (
-/obj/structure/dropship_equipment/electronics/spotlights,
-/turf/open/floor/mainship/cargo/arrow,
-/area/mainship/hallways/hangar)
 "jt" = (
 /obj/machinery/marine_selector/gear/engi,
 /turf/open/floor/mainship,
@@ -2870,7 +2860,6 @@
 /turf/open/floor/mainship,
 /area/mainship/living/cafeteria_starboard)
 "ke" = (
-/obj/structure/dropship_equipment/medevac_system,
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
@@ -3160,10 +3149,10 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/command/cic)
 "kY" = (
-/obj/structure/dropship_equipment/mg_holder,
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
+/obj/structure/dropship_equipment/electronics/targeting_system,
 /turf/open/floor/mainship/orange{
 	dir = 8
 	},
@@ -3379,7 +3368,7 @@
 	},
 /area/mainship/command/cic)
 "lC" = (
-/obj/structure/dropship_equipment/weapon/minirocket_pod,
+/obj/structure/dropship_equipment/sentry_holder,
 /turf/open/floor/mainship/orange{
 	dir = 4
 	},
@@ -3435,6 +3424,7 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
+/obj/structure/dropship_equipment/mg_holder,
 /turf/open/floor/mainship/orange{
 	dir = 8
 	},
@@ -3531,11 +3521,11 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
 "mj" = (
-/obj/structure/dropship_equipment/weapon/heavygun,
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
 /obj/effect/decal/warning_stripes/thin,
+/obj/structure/dropship_equipment/operatingtable,
 /turf/open/floor/mainship/orange{
 	dir = 8
 	},
@@ -9656,7 +9646,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Ge" = (
-/obj/structure/ship_ammo/rocket/banshee,
+/obj/structure/dropship_equipment/electronics/spotlights,
 /turf/open/floor/mainship/sterile/plain,
 /area/mainship/hallways/hangar)
 "Gf" = (
@@ -9760,10 +9750,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
-"Gu" = (
-/obj/structure/ship_ammo/minirocket,
-/turf/open/floor/mainship/sterile/plain,
-/area/mainship/hallways/hangar)
 "Gv" = (
 /obj/structure/dropship_equipment/weapon/minirocket_pod,
 /turf/open/floor/mainship/sterile/plain,
@@ -12208,10 +12194,6 @@
 	},
 /turf/open/floor/mainship,
 /area/mainship/hallways/aft_hallway)
-"Nu" = (
-/obj/structure/ship_ammo/rocket/widowmaker,
-/turf/open/floor/mainship/sterile/plain,
-/area/mainship/hallways/hangar)
 "Nw" = (
 /obj/structure/cable,
 /obj/machinery/light/small{
@@ -13087,10 +13069,6 @@
 /obj/machinery/landinglight/ds1/delaytwo{
 	dir = 1
 	},
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/hangar)
-"QN" = (
-/obj/structure/ship_ammo/minirocket,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "QO" = (
@@ -46718,9 +46696,9 @@ ad
 Ge
 Ge
 Ge
-Ge
-Gu
-Gu
+af
+af
+af
 Mb
 Mb
 aW
@@ -46976,8 +46954,8 @@ af
 af
 ap
 ap
-QN
-Gu
+ap
+af
 Mb
 aU
 YS
@@ -47486,9 +47464,9 @@ aa
 Tm
 rc
 ad
-ah
-ah
-cx
+aM
+aM
+ar
 Gg
 Mb
 Mb
@@ -48261,7 +48239,7 @@ al
 al
 at
 aQ
-js
+aA
 ay
 TE
 ci
@@ -48773,7 +48751,7 @@ rc
 ad
 ah
 ah
-cx
+ar
 bf
 Mb
 Mb
@@ -49286,11 +49264,11 @@ Tm
 rc
 ad
 aw
-aw
-aM
 cq
-cq
-Nu
+ap
+ap
+ap
+af
 Mb
 ad
 aH

--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -1794,8 +1794,9 @@
 	},
 /area/sulaco/engineering/atmos)
 "agb" = (
-/turf/closed/wall/mainship/white,
-/area/sulaco/hallway/lower_main_hall)
+/obj/structure/dropship_equipment/weapon/minirocket_pod,
+/turf/open/floor/prison,
+/area/sulaco/hangar)
 "agm" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/prison,
@@ -8126,10 +8127,6 @@
 "aMF" = (
 /turf/closed/wall/mainship/gray/outer,
 /area/sulaco/marine/bravo)
-"aMK" = (
-/obj/machinery/dropship_part_fabricator,
-/turf/open/floor/prison,
-/area/sulaco/hangar)
 "aMP" = (
 /obj/structure/dropship_equipment/weapon/heavygun,
 /turf/open/floor/prison,
@@ -13270,7 +13267,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/ship_ammo/minirocket,
+/obj/structure/ship_ammo/minirocket/illumination,
 /turf/open/floor/prison,
 /area/sulaco/hangar)
 "jWd" = (
@@ -13849,11 +13846,6 @@
 /obj/machinery/vending/uniform_supply,
 /turf/open/floor/prison,
 /area/sulaco/cargo)
-"lvp" = (
-/obj/structure/ship_ammo/rocket/banshee,
-/obj/effect/decal/warning_stripes/thin,
-/turf/open/floor/prison,
-/area/sulaco/hangar)
 "lwy" = (
 /obj/structure/closet/toolcloset,
 /obj/item/radio/intercom/general{
@@ -14442,10 +14434,6 @@
 /obj/machinery/door/airlock/mainship/generic,
 /turf/open/floor/prison/red,
 /area/sulaco/cafeteria)
-"mTZ" = (
-/obj/structure/ship_ammo/rocket/widowmaker,
-/turf/open/floor/prison,
-/area/sulaco/hangar)
 "mUa" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -14564,7 +14552,7 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
 "npi" = (
-/obj/structure/dropship_equipment/weapon/minirocket_pod,
+/obj/structure/ship_ammo/minirocket/illumination,
 /turf/open/floor/prison,
 /area/sulaco/hangar)
 "nqJ" = (
@@ -14832,11 +14820,6 @@
 /obj/machinery/door/firedoor/mainship,
 /turf/open/floor/plating/platebotc,
 /area/sulaco/medbay)
-"odD" = (
-/obj/structure/ship_ammo/rocket/keeper,
-/obj/effect/decal/warning_stripes/thin,
-/turf/open/floor/prison,
-/area/sulaco/hangar)
 "ofF" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
@@ -14955,11 +14938,6 @@
 /obj/structure/cable,
 /turf/open/floor/prison/plate,
 /area/sulaco/cargo)
-"oqn" = (
-/obj/structure/ship_ammo/rocket/widowmaker,
-/obj/effect/decal/warning_stripes/thin,
-/turf/open/floor/prison,
-/area/sulaco/hangar)
 "oqN" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -15571,7 +15549,7 @@
 /turf/closed/wall/mainship/gray/outer,
 /area/sulaco/liaison/quarters)
 "pAt" = (
-/obj/structure/dropship_equipment/medevac_system,
+/obj/structure/dropship_equipment/operatingtable,
 /turf/open/floor/prison,
 /area/sulaco/maintenance/lower_maint)
 "pBw" = (
@@ -15690,7 +15668,7 @@
 /turf/open/floor/plating,
 /area/sulaco/engineering/smes)
 "pWC" = (
-/obj/structure/ship_ammo/rocket/banshee,
+/obj/machinery/dropship_part_fabricator,
 /turf/open/floor/prison,
 /area/sulaco/hangar)
 "pWS" = (
@@ -17563,7 +17541,7 @@
 /area/sulaco/hallway/lower_main_hall)
 "uXj" = (
 /obj/machinery/camera/autoname,
-/obj/structure/ship_ammo/rocket/widowmaker,
+/obj/structure/ship_ammo/rocket/banshee,
 /turf/open/floor/prison,
 /area/sulaco/hangar)
 "uXn" = (
@@ -17631,7 +17609,7 @@
 /turf/open/floor/prison,
 /area/sulaco/hangar)
 "vfc" = (
-/obj/structure/ship_ammo/rocket/keeper,
+/obj/structure/ship_ammo/rocket/widowmaker,
 /turf/open/floor/prison,
 /area/sulaco/hangar)
 "vgl" = (
@@ -47899,16 +47877,16 @@ bFa
 aQa
 cdy
 aMP
-cpN
-cpN
+cdy
+agb
 nOM
 cpN
 lDT
 kut
 nqJ
-kut
+npi
 jVN
-cdy
+npi
 npi
 aSl
 aPY
@@ -48150,7 +48128,7 @@ nzi
 mDu
 bFa
 pWC
-lvp
+rpN
 bUI
 dFt
 qUq
@@ -48663,8 +48641,8 @@ aaa
 nzi
 mDu
 aSN
-pWC
-lvp
+cdy
+rpN
 xKB
 aPZ
 aPZ
@@ -49177,8 +49155,8 @@ aaa
 nzi
 mDu
 bFa
-mTZ
-oqn
+cdy
+rpN
 ebD
 aPZ
 aPZ
@@ -50206,7 +50184,7 @@ nzi
 mDu
 bFa
 vfc
-odD
+rpN
 gyp
 aPZ
 aPZ
@@ -50719,7 +50697,7 @@ aaa
 nzi
 mDu
 aSN
-vfc
+cdy
 rpN
 gZO
 aPZ
@@ -56902,7 +56880,7 @@ aPF
 aPF
 aPF
 bFa
-aMK
+cdy
 cdy
 aUL
 aaO

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -51,6 +51,13 @@
 	mouse_opacity = 0 //can't click to examine it
 	var/effect_duration = 10 //in deciseconds
 
+/obj/effect/overlay/blinking_laser //Used to indicate incoming CAS
+	name = "blinking laser"
+	anchored = TRUE
+	mouse_opacity = 0
+	icon = 'icons/obj/items/projectiles.dmi'
+	icon_state = "laser_target3"
+
 /obj/effect/overlay/temp/Initialize()
 	. = ..()
 	flick(icon_state, src)
@@ -154,8 +161,7 @@
 	. = ..()
 	GLOB.active_laser_targets -= src
 
-//used to show where dropship ordnance will impact.
-/obj/effect/overlay/temp/blinking_laser
+/obj/effect/overlay/temp/blinking_laser //not used for CAS anymore but some admin buttons still use it
 	name = "blinking laser"
 	anchored = TRUE
 	effect_duration = 10

--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -12,7 +12,7 @@
 	climbable = TRUE
 	resistance_flags = XENO_DAMAGEABLE
 	///Time before the ammo impacts
-	var/travelling_time = 10 SECONDS
+	var/travelling_time = 10 * (GLOB.current_orbit/3) SECONDS
 	///type of equipment that accept this type of ammo.
 	var/equipment_type
 	var/ammo_count
@@ -21,7 +21,7 @@
 	var/ammo_id
 	///whether the ammo inside this magazine can be transfered to another magazine.
 	var/transferable_ammo = FALSE
-	var/accuracy_range = 3 //how many tiles the ammo can deviate from the laser target
+	var/accuracy_range = 0 //how many tiles the ammo can deviate from the laser target
 	///sound played mere seconds before impact
 	var/warning_sound = 'sound/machines/hydraulics_2.ogg'
 	var/ammo_used_per_firing = 1
@@ -80,13 +80,12 @@
 	icon_state = "30mm_crate"
 	desc = "A crate full of 30mm bullets used on the dropship heavy guns."
 	equipment_type = /obj/structure/dropship_equipment/weapon/heavygun
-	accuracy_range = 0 //always hits
-	travelling_time = 6 SECONDS
+	travelling_time =  6 * (GLOB.current_orbit/3) SECONDS
 	ammo_count = 200
 	max_ammo_count = 200
 	transferable_ammo = TRUE
 	ammo_used_per_firing = 20
-	point_cost = 50
+	point_cost = 75
 	///Radius of the square that the bullets will strafe
 	var/bullet_spread_range = 2
 	///Width of the square we are attacking, so you can make rectangular attacks later
@@ -140,11 +139,11 @@
 	name = "high-velocity 30mm ammo crate"
 	icon_state = "30mm_crate_hv"
 	desc = "A crate full of 30mm high-velocity bullets used on the dropship heavy guns."
-	travelling_time = 6 SECONDS
-	ammo_count = 400
-	max_ammo_count = 400
-	ammo_used_per_firing = 40
-	bullet_spread_range = 5
+	travelling_time = 5 * (GLOB.current_orbit/3) SECONDS
+	ammo_count = 200
+	max_ammo_count = 200
+	ammo_used_per_firing = 20
+	bullet_spread_range = 3
 	point_cost = 150
 
 
@@ -155,14 +154,13 @@
 	name = "high-capacity laser battery"
 	icon_state = "laser_battery"
 	desc = "A high-capacity laser battery used to power laser beam weapons."
-	travelling_time = 1 SECONDS
+	travelling_time = 1 * (GLOB.current_orbit/3) SECONDS
 	ammo_count = 100
 	max_ammo_count = 100
 	ammo_used_per_firing = 40
 	equipment_type = /obj/structure/dropship_equipment/weapon/laser_beam_gun
 	ammo_name = "charge"
 	transferable_ammo = TRUE
-	accuracy_range = 0 //its a laser
 	ammo_used_per_firing = 10
 	warning_sound = 'sound/effects/nightvision.ogg'
 	point_cost = 150
@@ -224,7 +222,7 @@
 	ammo_id = ""
 	bound_width = 64
 	bound_height = 32
-	travelling_time = 6 SECONDS //faster than 30mm rounds
+	travelling_time = 6 * (GLOB.current_orbit/3) SECONDS
 	point_cost = 0
 	ammo_type = CAS_MISSILE
 
@@ -237,7 +235,7 @@
 	name = "\improper AIM-224 'Widowmaker'"
 	desc = "The AIM-224 is the latest in air to air missile technology. Earning the nickname of 'Widowmaker' from various dropship pilots after improvements to its guidence warhead prevents it from being jammed leading to its high kill rate. Not well suited for ground bombardment, but its high velocity makes it reach its target quickly."
 	icon_state = "single"
-	travelling_time = 4 SECONDS //not powerful, but reaches target fast
+	travelling_time = 4 * (GLOB.current_orbit/3) SECONDS //not powerful, but reaches target fast
 	ammo_id = ""
 	point_cost = 150
 
@@ -276,7 +274,6 @@
 	desc = "The SM-17 'Fatty' is a cluster-bomb type ordnance that only requires laser-guidance when first launched."
 	icon_state = "fatty"
 	ammo_id = "f"
-	travelling_time = 7 SECONDS //slower but deadly accurate, even if laser guidance is stopped mid-travel.
 	point_cost = 300
 
 /obj/structure/ship_ammo/rocket/fatty/detonate_on(turf/impact, attackdir = NORTH)
@@ -322,7 +319,7 @@
 	ammo_count = 6
 	max_ammo_count = 6
 	ammo_name = "minirocket"
-	travelling_time = 7 SECONDS //faster than 30mm cannon, slower than real rockets
+	travelling_time = 6 * (GLOB.current_orbit/3) SECONDS
 	transferable_ammo = TRUE
 	point_cost = 100
 	ammo_type = CAS_MINI_ROCKET

--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -12,7 +12,7 @@
 	climbable = TRUE
 	resistance_flags = XENO_DAMAGEABLE
 	///Time before the ammo impacts
-	var/travelling_time = 10 * (GLOB.current_orbit/3) SECONDS
+	var/travelling_time = 10 SECONDS
 	///type of equipment that accept this type of ammo.
 	var/equipment_type
 	var/ammo_count
@@ -80,7 +80,7 @@
 	icon_state = "30mm_crate"
 	desc = "A crate full of 30mm bullets used on the dropship heavy guns."
 	equipment_type = /obj/structure/dropship_equipment/weapon/heavygun
-	travelling_time =  6 * (GLOB.current_orbit/3) SECONDS
+	travelling_time =  6 SECONDS
 	ammo_count = 200
 	max_ammo_count = 200
 	transferable_ammo = TRUE
@@ -139,7 +139,7 @@
 	name = "high-velocity 30mm ammo crate"
 	icon_state = "30mm_crate_hv"
 	desc = "A crate full of 30mm high-velocity bullets used on the dropship heavy guns."
-	travelling_time = 5 * (GLOB.current_orbit/3) SECONDS
+	travelling_time = 5 SECONDS
 
 
 
@@ -217,7 +217,7 @@
 	ammo_id = ""
 	bound_width = 64
 	bound_height = 32
-	travelling_time = 6 * (GLOB.current_orbit/3) SECONDS
+	travelling_time = 6 SECONDS
 	point_cost = 0
 	ammo_type = CAS_MISSILE
 
@@ -230,7 +230,7 @@
 	name = "\improper AIM-224 'Widowmaker'"
 	desc = "The AIM-224 is the latest in air to air missile technology. Earning the nickname of 'Widowmaker' from various dropship pilots after improvements to its guidence warhead prevents it from being jammed leading to its high kill rate. Not well suited for ground bombardment, but its high velocity makes it reach its target quickly."
 	icon_state = "single"
-	travelling_time = 4 * (GLOB.current_orbit/3) SECONDS //not powerful, but reaches target fast
+	travelling_time = 4 SECONDS //not powerful, but reaches target fast
 	ammo_id = ""
 	point_cost = 150
 
@@ -314,7 +314,7 @@
 	ammo_count = 6
 	max_ammo_count = 6
 	ammo_name = "minirocket"
-	travelling_time = 6 * (GLOB.current_orbit/3) SECONDS
+	travelling_time = 6 SECONDS
 	transferable_ammo = TRUE
 	point_cost = 100
 	ammo_type = CAS_MINI_ROCKET

--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -418,7 +418,6 @@
 	var/bullet_spread_range = 5
 	var/attack_width = 3
 	travelling_time = 6 SECONDS
-	point_cost = 0
 
 /obj/structure/ship_ammo/railgun/detonate_on(turf/impact, attackdir = NORTH)
 	var/turf/beginning = impact

--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -141,6 +141,14 @@
 	travelling_time = 5 SECONDS
 	point_cost = 150
 
+/obj/structure/ship_ammo/heavygun/railgun
+	name = "Railgun Ammo"
+	desc = "This is not meant to exist"
+	ammo_count = 400
+	max_ammo_count = 400
+	ammo_used_per_firing = 40
+	bullet_spread_range = 5
+	point_cost = 0
 
 
 //laser battery
@@ -406,46 +414,3 @@
 	T.visible_message("<span class='warning'>You see a tiny flash, and then a blindingly bright light from a flare as it lights off in the sky!</span>")
 	playsound(T, 'sound/weapons/guns/fire/flare.ogg', 50, 1, 4) // stolen from the mortar i'm not even sorry
 	QDEL_IN(src, rand(70 SECONDS, 90 SECONDS)) // About the same burn time as a flare, considering it requires it's own CAS run.
-
-//Railgun, currently the same as GAU, but being seperated so that changes to the GAU don't affect the railgun
-/obj/structure/ship_ammo/railgun
-	name = "Railgun Ammo"
-	desc = "This is not meant to exist"
-	travelling_time = 6 SECONDS
-	ammo_count = 400
-	max_ammo_count = 400
-	ammo_used_per_firing = 40
-	var/bullet_spread_range = 5
-	var/attack_width = 3
-	travelling_time = 6 SECONDS
-
-/obj/structure/ship_ammo/railgun/detonate_on(turf/impact, attackdir = NORTH)
-	var/turf/beginning = impact
-	var/revdir = REVERSE_DIR(attackdir)
-	for(var/i=0 to bullet_spread_range)
-		beginning = get_step(beginning, revdir)
-	var/list/strafelist = list(beginning)
-	strafelist += get_step(beginning, turn(attackdir, 90))
-	strafelist += get_step(beginning, turn(attackdir, -90)) //Build this list 3 turfs at a time for strafe_turfs
-	for(var/b=0 to bullet_spread_range*2)
-		beginning = get_step(beginning, attackdir)
-		strafelist += beginning
-		strafelist += get_step(beginning, turn(attackdir, 90))
-		strafelist += get_step(beginning, turn(attackdir, -90))
-	strafe_turfs(strafelist)
-
-///Takes the top 3 turfs and miniguns them, then repeats until none left
-/obj/structure/ship_ammo/railgun/proc/strafe_turfs(list/strafelist)
-	var/turf/strafed
-	playsound(strafelist[1], get_sfx("explosion"), 40, 1, 20, falloff = 3)
-	for(var/i=1 to attack_width)
-		strafed = strafelist[1]
-		strafelist -= strafed
-		strafed.ex_act(EXPLODE_LIGHT)
-		new /obj/effect/particle_effect/expl_particles(strafed)
-		new /obj/effect/temp_visual/heavyimpact(strafed)
-		for(var/atom/movable/AM as() in strafed)
-			AM.ex_act(EXPLODE_LIGHT)
-
-	if(length(strafelist))
-		addtimer(CALLBACK(src, .proc/strafe_turfs, strafelist), 2)

--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -406,3 +406,47 @@
 	T.visible_message("<span class='warning'>You see a tiny flash, and then a blindingly bright light from a flare as it lights off in the sky!</span>")
 	playsound(T, 'sound/weapons/guns/fire/flare.ogg', 50, 1, 4) // stolen from the mortar i'm not even sorry
 	QDEL_IN(src, rand(70 SECONDS, 90 SECONDS)) // About the same burn time as a flare, considering it requires it's own CAS run.
+
+//Railgun, currently the same as GAU, but being seperated so that changes to the GAU don't affect the railgun
+/obj/structure/ship_ammo/railgun
+	name = "Railgun Ammo"
+	desc = "This is not meant to exist"
+	travelling_time = 6 SECONDS
+	ammo_count = 400
+	max_ammo_count = 400
+	ammo_used_per_firing = 40
+	var/bullet_spread_range = 5
+	var/attack_width = 3
+	travelling_time = 6 SECONDS
+	point_cost = 0
+
+/obj/structure/ship_ammo/railgun/detonate_on(turf/impact, attackdir = NORTH)
+	var/turf/beginning = impact
+	var/revdir = REVERSE_DIR(attackdir)
+	for(var/i=0 to bullet_spread_range)
+		beginning = get_step(beginning, revdir)
+	var/list/strafelist = list(beginning)
+	strafelist += get_step(beginning, turn(attackdir, 90))
+	strafelist += get_step(beginning, turn(attackdir, -90)) //Build this list 3 turfs at a time for strafe_turfs
+	for(var/b=0 to bullet_spread_range*2)
+		beginning = get_step(beginning, attackdir)
+		strafelist += beginning
+		strafelist += get_step(beginning, turn(attackdir, 90))
+		strafelist += get_step(beginning, turn(attackdir, -90))
+	strafe_turfs(strafelist)
+
+///Takes the top 3 turfs and miniguns them, then repeats until none left
+/obj/structure/ship_ammo/railgun/proc/strafe_turfs(list/strafelist)
+	var/turf/strafed
+	playsound(strafelist[1], get_sfx("explosion"), 40, 1, 20, falloff = 3)
+	for(var/i=1 to attack_width)
+		strafed = strafelist[1]
+		strafelist -= strafed
+		strafed.ex_act(EXPLODE_LIGHT)
+		new /obj/effect/particle_effect/expl_particles(strafed)
+		new /obj/effect/temp_visual/heavyimpact(strafed)
+		for(var/atom/movable/AM as() in strafed)
+			AM.ex_act(EXPLODE_LIGHT)
+
+	if(length(strafelist))
+		addtimer(CALLBACK(src, .proc/strafe_turfs, strafelist), 2)

--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -140,11 +140,6 @@
 	icon_state = "30mm_crate_hv"
 	desc = "A crate full of 30mm high-velocity bullets used on the dropship heavy guns."
 	travelling_time = 5 * (GLOB.current_orbit/3) SECONDS
-	ammo_count = 200
-	max_ammo_count = 200
-	ammo_used_per_firing = 20
-	bullet_spread_range = 3
-	point_cost = 150
 
 
 
@@ -154,7 +149,7 @@
 	name = "high-capacity laser battery"
 	icon_state = "laser_battery"
 	desc = "A high-capacity laser battery used to power laser beam weapons."
-	travelling_time = 1 * (GLOB.current_orbit/3) SECONDS
+	travelling_time = 1 SECONDS
 	ammo_count = 100
 	max_ammo_count = 100
 	ammo_used_per_firing = 40

--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -21,7 +21,6 @@
 	var/ammo_id
 	///whether the ammo inside this magazine can be transfered to another magazine.
 	var/transferable_ammo = FALSE
-	var/accuracy_range = 0 //how many tiles the ammo can deviate from the laser target
 	///sound played mere seconds before impact
 	var/warning_sound = 'sound/machines/hydraulics_2.ogg'
 	var/ammo_used_per_firing = 1
@@ -140,6 +139,7 @@
 	icon_state = "30mm_crate_hv"
 	desc = "A crate full of 30mm high-velocity bullets used on the dropship heavy guns."
 	travelling_time = 5 SECONDS
+	point_cost = 150
 
 
 

--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -658,19 +658,17 @@
 	if(firing_sound)
 		playsound(loc, firing_sound, 70, 1)
 	var/obj/structure/ship_ammo/SA = ammo_equipped //necessary because we nullify ammo_equipped when firing big rockets
-	var/ammo_accuracy_range = SA.accuracy_range
 	var/ammo_travelling_time = SA.travelling_time * (GLOB.current_orbit/3) //how long the rockets/bullets take to reach the ground target.
 	var/ammo_warn_sound = SA.warning_sound
 	deplete_ammo()
 	COOLDOWN_START(src, last_fired, firing_delay)
 	if(linked_shuttle)
 		for(var/obj/structure/dropship_equipment/electronics/targeting_system/TS in linked_shuttle.equipments)
-			ammo_accuracy_range = max(ammo_accuracy_range-2, 0) //targeting system increase accuracy and reduce travelling time.
-			ammo_travelling_time = max(ammo_travelling_time - 2 SECONDS, 1 SECONDS)
+			ammo_travelling_time = max(ammo_travelling_time - 2 SECONDS, 1 SECONDS) //targeting system reduces travelling time
 			break
 
 	var/list/possible_turfs = list()
-	for(var/turf/TU as() in RANGE_TURFS(ammo_accuracy_range, target_turf))
+	for(var/turf/TU as() in (target_turf))
 		possible_turfs += TU
 	var/turf/impact = pick(possible_turfs)
 	if(ammo_warn_sound)

--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -675,9 +675,9 @@
 	var/turf/impact = pick(possible_turfs)
 	if(ammo_warn_sound)
 		playsound(impact, ammo_warn_sound, 70, 1)
-	new /obj/effect/overlay/temp/blinking_laser (impact)
+	var/obj/effect/overlay/blinking_laser/laser = new (impact)
 	addtimer(CALLBACK(SA, /obj/structure/ship_ammo.proc/detonate_on, impact, attackdir), ammo_travelling_time)
-
+	addtimer(CALLBACK(GLOBAL_PROC, .proc/qdel, laser), ammo_travelling_time)
 /obj/structure/dropship_equipment/weapon/heavygun
 	name = "\improper GAU-21 30mm cannon"
 	desc = "A dismounted GAU-21 'Rattler' 30mm rotary cannon. It seems to be missing its feed links and has exposed connection wires. Capable of firing 5200 rounds a minute, feared by many for its power. Earned the nickname 'Rattler' from the vibrations it would cause on dropships in its inital production run."

--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -667,14 +667,10 @@
 			ammo_travelling_time = max(ammo_travelling_time - 2 SECONDS, 1 SECONDS) //targeting system reduces travelling time
 			break
 
-	var/list/possible_turfs = list()
-	for(var/turf/TU as() in (target_turf))
-		possible_turfs += TU
-	var/turf/impact = pick(possible_turfs)
 	if(ammo_warn_sound)
-		playsound(impact, ammo_warn_sound, 70, 1)
-	var/obj/effect/overlay/blinking_laser/laser = new (impact)
-	addtimer(CALLBACK(SA, /obj/structure/ship_ammo.proc/detonate_on, impact, attackdir), ammo_travelling_time)
+		playsound(target_turf, ammo_warn_sound, 70, 1)
+	var/obj/effect/overlay/blinking_laser/laser = new (target_turf)
+	addtimer(CALLBACK(SA, /obj/structure/ship_ammo.proc/detonate_on, target_turf, attackdir), ammo_travelling_time)
 	addtimer(CALLBACK(GLOBAL_PROC, .proc/qdel, laser), ammo_travelling_time)
 /obj/structure/dropship_equipment/weapon/heavygun
 	name = "\improper GAU-21 30mm cannon"

--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -659,7 +659,7 @@
 		playsound(loc, firing_sound, 70, 1)
 	var/obj/structure/ship_ammo/SA = ammo_equipped //necessary because we nullify ammo_equipped when firing big rockets
 	var/ammo_accuracy_range = SA.accuracy_range
-	var/ammo_travelling_time = SA.travelling_time //how long the rockets/bullets take to reach the ground target.
+	var/ammo_travelling_time = SA.travelling_time * (GLOB.current_orbit/3) //how long the rockets/bullets take to reach the ground target.
 	var/ammo_warn_sound = SA.warning_sound
 	deplete_ammo()
 	COOLDOWN_START(src, last_fired, firing_delay)

--- a/code/game/objects/structures/orbital_cannon.dm
+++ b/code/game/objects/structures/orbital_cannon.dm
@@ -543,13 +543,13 @@
 	resistance_flags = UNACIDABLE|INDESTRUCTIBLE
 	var/cannon_busy = FALSE
 	var/last_firing = 0 //stores the last time it was fired to check when we can fire again
-	var/obj/structure/ship_ammo/railgun/rail_gun_ammo
+	var/obj/structure/ship_ammo/heavygun/railgun/rail_gun_ammo
 
 /obj/structure/ship_rail_gun/Initialize()
 	. = ..()
 	if(!GLOB.marine_main_ship.rail_gun)
 		GLOB.marine_main_ship.rail_gun = src
-	rail_gun_ammo = new /obj/structure/ship_ammo/railgun(src)
+	rail_gun_ammo = new /obj/structure/ship_ammo/heavygun/railgun(src)
 	rail_gun_ammo.max_ammo_count = 8000 //200 uses or 15 full minutes of firing.
 	rail_gun_ammo.ammo_count = 8000
 

--- a/code/game/objects/structures/orbital_cannon.dm
+++ b/code/game/objects/structures/orbital_cannon.dm
@@ -543,13 +543,13 @@
 	resistance_flags = UNACIDABLE|INDESTRUCTIBLE
 	var/cannon_busy = FALSE
 	var/last_firing = 0 //stores the last time it was fired to check when we can fire again
-	var/obj/structure/ship_ammo/heavygun/highvelocity/rail_gun_ammo
+	var/obj/structure/ship_ammo/railgun/rail_gun_ammo
 
 /obj/structure/ship_rail_gun/Initialize()
 	. = ..()
 	if(!GLOB.marine_main_ship.rail_gun)
 		GLOB.marine_main_ship.rail_gun = src
-	rail_gun_ammo = new /obj/structure/ship_ammo/heavygun/highvelocity(src)
+	rail_gun_ammo = new /obj/structure/ship_ammo/railgun(src)
 	rail_gun_ammo.max_ammo_count = 8000 //200 uses or 15 full minutes of firing.
 	rail_gun_ammo.ammo_count = 8000
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
1) Removes the random inaccuracy from all CAS munitions that had it
2) Makes CAS munitions travel time affected by orbit
3) Makes High velocity ammo the same as 30mm but with slightly less travel time
4) Slightly increases the cost of GAU ammo cost
5) Dramatically reduces the amount of free ammo/weapons CAS starts with:
     CAS starts with 1 banshee, 1 widowmaker, 2 boxes of 30mm, 2 HE rocket stacks, 1 GAU, 1 mini rocket, 1 rocket pod on both the Sulaco and the POS. 
6) Replaces the useless medevac with an operating table for the alamo
7) Slightly buffs mini rocket and fatty fly time (7 to 6 seconds at base orbit)
8) Moves the dropship printer closer to the condor on the sulaco
9) The blinking green dot of CAS stays up for the entire duration a CAS projectile is coming in.
10) Makes railgun ammo it's own subtype instead of using high velocity rounds. Still functions the same as it used to.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
1) The random inaccuracy made the already more niche rockets and mini rockets unreliable, especially if they had smaller explosions.
2) Gives a benefit to lower orbit which is almost never used because it sucks while simultaneously making CAS not significantly better at higher orbits (since CAS point generation is affected by orbit already, meaning CAS got quite a bit more ammo at higher orbits)
3) The high velocity ammo going faster is not only more intutive but currently this ammo just isn't worth using, it affects a longer area which makes it more dangerous to use near marines and makes it easier for xenos to dodge. It also costs more points than regular 30mm. At least you're getting something valuable for spending twice as many points on your GAU ammo now. 
4) GAU ammo costs 75 instead of 50 because the GAU is too spamable for how useful it is.
5) Part of the reason CAS can be spammed so much is because they just start with so much ammo that you basically never have to buy rockets or mini rockets (which is partially due to how niche they are) unless you want to use a rocket type you dont start with for free (fatty/napalm) and you start with less 30mm because starting 4 was also part of the reason 30mm was so spammable. 
6) The medevac is useless and this should also make MOs wanting to do Alamo surgery  not at odds with POs who desperately want to get their laser gun on the go ASAP
7) The fatty doesn't need extra fly time, it's already a very expensive rocket. Mini rockets having more fly time than the GAU is laughable considering how much less safe it is to use near marines since it blinds them even if you don't hit them.
8) Makes CAS less of a PITA on sulaco since you don't have to walk all the way across the hangar to get ammo to the condor
9) Makes it harder to get hit by a projectile with sheer luck due to the fact that it has such long travel time you couldn't see it coming, but also makes it a little easier for marines to avoid getting FFed.
10) Railgun doesn't get changed by CAS changes.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Sulaco dropship fab is now near the condor
balance: the free dropship medevac has been replaced with an operating table
balance: Orbit level affects how long it takes for CAS munitions to reach the ground
balance: CAS gets much less free ammo. CAS Munition random inaccuracy removed from all current munitions that had it. Minirockets fly time reduced to 6 seconds. GAU Ammo price increased slightly. Fatty fly time reduced to 6 seconds. High velocity 30mm ammo is now the same as 30mm but with less fly time.
balance: The blinking dot that indicates incoming CAS remains until the projectile hits
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
