### PR TITLE
Remove useless check when in local serb

### DIFF
--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -60,6 +60,8 @@
 				xeno_candidate = TRUE
 				break
 	if(!xeno_candidate && !bypass_checks)
+		if(SSticker.roundend_check_paused)
+			return TRUE
 		to_chat(world, "<b>Unable to start [name].</b> No xeno candidate found.")
 		return FALSE
 

--- a/code/datums/gamemodes/game_mode.dm
+++ b/code/datums/gamemodes/game_mode.dm
@@ -40,8 +40,8 @@
 		addtimer(CALLBACK(SSvote, /datum/controller/subsystem/vote.proc/initiate_vote, "gamemode", "SERVER"), 10 SECONDS)
 		return FALSE
 	if(length(GLOB.ready_players) < required_players && !bypass_checks)
-		to_chat(world, "<b>Unable to start [name].</b> Not enough players, [required_players] players needed.")
-		return FALSE
+		to_chat(world, "Not enough players, [required_players] players needed. Round end check disabled")
+		SSticker.roundend_check_paused = TRUE
 	if(!set_valid_job_types() && !bypass_checks)
 		return FALSE
 	if(!set_valid_squads() && !bypass_checks)

--- a/code/datums/gamemodes/game_mode.dm
+++ b/code/datums/gamemodes/game_mode.dm
@@ -40,7 +40,7 @@
 		addtimer(CALLBACK(SSvote, /datum/controller/subsystem/vote.proc/initiate_vote, "gamemode", "SERVER"), 10 SECONDS)
 		return FALSE
 	if(length(GLOB.ready_players) < required_players && !bypass_checks)
-		to_chat(world, "Not enough players, [required_players] players needed. Round end check disabled")
+		to_chat(world, "Not enough players, [required_players] players needed. Round end check disabled.")
 		SSticker.roundend_check_paused = TRUE
 	if(!set_valid_job_types() && !bypass_checks)
 		return FALSE


### PR DESCRIPTION
You don't have to click two times on start the server when hosting locally, even in distress and crash. Will save everyone 5 seconds everytime they boot up the serb


## Changelog
:cl:
code: Launching a round in distress/crash is now quicker in local serb
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
