### PR TITLE
Flamer Fire Rate Change 2

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1636,7 +1636,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	var/fire_color = "red"
 	var/burnlevel = 24
 	var/burntime = 17
-	var/fire_delay = 20
+	var/fire_delay = 4
 
 /datum/ammo/flamethrower/on_hit_mob(mob/M,obj/projectile/P)
 	drop_flame(get_turf(P))
@@ -1672,7 +1672,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	fire_color = "blue"
 	burnlevel = 36
 	burntime = 40
-	fire_delay = 35
+	fire_delay = 20
 	bullet_color = COLOR_NAVY
 
 /datum/ammo/water


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Basically just does what #4800 tried to do to the flamer's fire rate. Also brings blue more in line, comparison-wise, with the new fire rate. It is a 100 point purchase, and has some noticable downsides to go with it. 

## Why It's Good For The Game

This was intended to be done before, and didn't work. So, I'm doing it again. Again again. 

## Changelog
:cl:
balance: Flamer fires faster. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
