### PR TITLE
Adds Aim Mode keybinding

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -557,6 +557,7 @@
 #define COMSIG_KB_HOLSTER "keybinding_holster"
 #define COMSIG_KB_UNIQUEACTION "keybinding_uniqueaction"
 #define COMSIG_KB_RAILATTACHMENT "keybinding_railattachment"
+#define COMSIG_KB_AIMMODE "keybinding_aimmode"
 
 // Ability adding/removing signals
 #define ACTION_GIVEN "gave_an_action"		//from base of /datum/action/proc/give_action(): (datum/action)

--- a/code/datums/actions/item_action.dm
+++ b/code/datums/actions/item_action.dm
@@ -90,6 +90,14 @@
 /datum/action/item_action/aim_mode
 	name = "Take Aim"
 
+/datum/action/item_action/aim_mode/give_action(mob/M)
+	. = ..()
+	RegisterSignal(M, COMSIG_KB_AIMMODE, .proc/action_activate)
+
+/datum/action/item_action/aim_mode/remove_action(mob/M)
+	UnregisterSignal(M, COMSIG_KB_AIMMODE, .proc/action_activate)
+	return ..()
+
 /datum/action/item_action/aim_mode/update_button_icon()
 	button.overlays.Cut()
 	button.overlays += image('icons/mob/actions.dmi', null, "aim_mode", ABOVE_HUD_LAYER)

--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -32,3 +32,10 @@
 	full_name = "Activate Rail attachment"
 	description = ""
 	keybind_signal = COMSIG_KB_RAILATTACHMENT
+
+/datum/keybinding/human/toggle_aim_mode
+	hotkey_keys = list("6")
+	name = "toggle_aim_mode"
+	full_name = "Toggle aim mode"
+	description = ""
+	keybind_signal = COMSIG_KB_AIMMODE


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gives a keybinding to Aim Mode button, 6 by default.<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I got asked to add one.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: adds aim mode keybinding, 6 by default
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->