### PR TITLE
Fixes blade sound only playing for owner

### DIFF
--- a/code/game/objects/items/implants/implant_items.dm
+++ b/code/game/objects/items/implants/implant_items.dm
@@ -56,11 +56,11 @@
 
 /obj/item/implant/deployitem/blade/put_in_slots()
 	. = ..()
-	playsound(implant_owner, 'sound/weapons/wristblades_on.ogg', 15, 0, 1)
+	playsound(implant_owner.loc, 'sound/weapons/wristblades_on.ogg', 15, 0, 1)
 
 /obj/item/implant/deployitem/blade/fetch_item()
 	. = ..()
-	playsound(implant_owner, 'sound/weapons/wristblades_off.ogg', 15, 0, 1)
+	playsound(implant_owner.loc, 'sound/weapons/wristblades_off.ogg', 15, 0, 1)
 
 /obj/item/weapon/mantisblade
 	name = "mantis arm blade"

--- a/code/game/objects/items/implants/implant_items.dm
+++ b/code/game/objects/items/implants/implant_items.dm
@@ -56,11 +56,11 @@
 
 /obj/item/implant/deployitem/blade/put_in_slots()
 	. = ..()
-	playsound(implant_owner.loc, 'sound/weapons/wristblades_on.ogg', 15, 0, 1)
+	playsound(implant_owner.loc, 'sound/weapons/wristblades_on.ogg', 15, TRUE)
 
 /obj/item/implant/deployitem/blade/fetch_item()
 	. = ..()
-	playsound(implant_owner.loc, 'sound/weapons/wristblades_off.ogg', 15, 0, 1)
+	playsound(implant_owner.loc, 'sound/weapons/wristblades_off.ogg', 15, TRUE)
 
 /obj/item/weapon/mantisblade
 	name = "mantis arm blade"


### PR DESCRIPTION


## Changelog
:cl:
fix: Fixes blade sound only playing for owner
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
