### PR TITLE
Personal Runechat Color

### DIFF
--- a/code/__DEFINES/runechat_defines.dm
+++ b/code/__DEFINES/runechat_defines.dm
@@ -1,0 +1,1 @@
+GLOBAL_LIST_EMPTY(runechat_color_names)

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -109,6 +109,23 @@
 	if (length_char(text) > maxlen)
 		text = copytext_char(text, 1, maxlen + 1) + "..." // BYOND index moment
 
+	//Totally didn't steal from Skyrat, not at all.
+	// Calculate target color if not already present
+	if (!target.chat_color || target.chat_color_name != target.name)
+		var/mob/M = target
+		if(GLOB.runechat_color_names[target.name])
+			target.chat_color = GLOB.runechat_color_names[target.name]
+		else if (ismob(target) && M.client?.prefs?.enable_personal_chat_color && M.name == M.real_name && M.name == M.client.prefs.real_name)
+			var/per_color = M.client.prefs.personal_chat_color
+			GLOB.runechat_color_names[target.name] = per_color
+			target.chat_color = per_color
+		else
+			target.chat_color = colorize_string(target.name)
+
+		target.chat_color_darkened = color_shift(target.chat_color, 0.85, 0.85)
+		target.chat_color_name = target.name
+	//~XS300
+
 	// Calculate target color if not already present
 	if (!target.chat_color || target.chat_color_name != target.name)
 		target.chat_color = colorize_string(target.name)
@@ -270,16 +287,27 @@
 	x = (x + m) * 255
 	c = (c + m) * 255
 	m *= 255
+	var/final_val
 	switch(h_int)
 		if(0)
-			return "#[num2hex(c, 2)][num2hex(x, 2)][num2hex(m, 2)]"
+			final_val = "#[num2hex(c, 2)][num2hex(x, 2)][num2hex(m, 2)]"
 		if(1)
-			return "#[num2hex(x, 2)][num2hex(c, 2)][num2hex(m, 2)]"
+			final_val = "#[num2hex(x, 2)][num2hex(c, 2)][num2hex(m, 2)]"
 		if(2)
-			return "#[num2hex(m, 2)][num2hex(c, 2)][num2hex(x, 2)]"
+			final_val = "#[num2hex(m, 2)][num2hex(c, 2)][num2hex(x, 2)]"
 		if(3)
-			return "#[num2hex(m, 2)][num2hex(x, 2)][num2hex(c, 2)]"
+			final_val = "#[num2hex(m, 2)][num2hex(x, 2)][num2hex(c, 2)]"
 		if(4)
-			return "#[num2hex(x, 2)][num2hex(m, 2)][num2hex(c, 2)]"
+			final_val = "#[num2hex(x, 2)][num2hex(m, 2)][num2hex(c, 2)]"
 		if(5)
-			return "#[num2hex(c, 2)][num2hex(m, 2)][num2hex(x, 2)]"
+			final_val = "#[num2hex(c, 2)][num2hex(m, 2)][num2hex(x, 2)]"
+
+	GLOB.runechat_color_names[name] = final_val
+	return final_val
+
+/datum/chatmessage/proc/color_shift(color, sat_shift = 1, lum_shift = 1)
+	var/list/HSL = rgb2hsl(hex2num(copytext(color, 2, 4)), hex2num(copytext(color, 4, 6)), hex2num(copytext(color, 6, 8)))
+	HSL[2] = HSL[2] * sat_shift
+	HSL[3] = HSL[3] * lum_shift
+	var/list/RGB = hsl2rgb(arglist(HSL))
+	return "#[num2hex(RGB[1],2)][num2hex(RGB[2],2)][num2hex(RGB[3],2)]"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -126,6 +126,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/max_chat_length = CHAT_MESSAGE_MAX_LENGTH
 	///Whether emotes will be displayed on runechat. Requires chat_on_map to have effect.
 	var/see_rc_emotes = TRUE
+	var/enable_personal_chat_color = FALSE
+	var/personal_chat_color = "#ffffff"
 
 	var/auto_fit_viewport = TRUE
 
@@ -356,6 +358,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	dat += "<b>Runechat message char limit:</b> <a href='?_src_=prefs;preference=max_chat_length;task=input'>[max_chat_length]</a><br>"
 	dat += "<b>See Runechat for non-mobs:</b> <a href='?_src_=prefs;preference=see_chat_non_mob'>[see_chat_non_mob ? "Enabled" : "Disabled"]</a><br>"
 	dat += "<b>See Runechat emotes:</b> <a href='?_src_=prefs;preference=see_rc_emotes'>[see_rc_emotes ? "Enabled" : "Disabled"]</a><br>"
+	dat += "<b>Custom runechat color :</b> <a href='?_src_=prefs;preference=enable_personal_chat_color'>[enable_personal_chat_color ? "Enabled" : "Disabled"]</a> [enable_personal_chat_color ? "<span style='border: 1px solid #161616; background-color: [personal_chat_color];'>&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=personal_chat_color;task=input'>Change</a>" : ""]<br>"
 
 	dat += "<h2>UI Customization:</h2>"
 	dat += "<b>Style:</b> <a href='?_src_=prefs;preference=ui'>[ui_style]</a><br>"
@@ -1003,12 +1006,26 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		if("see_rc_emotes")
 			see_rc_emotes = !see_rc_emotes
 
+		if("enable_personal_chat_color")
+			enable_personal_chat_color = !enable_personal_chat_color
+
 		if("tooltips")
 			tooltips = !tooltips
 			if(!tooltips)
 				closeToolTip(usr)
 			else if(!usr.client.tooltips && tooltips)
 				usr.client.tooltips = new /datum/tooltip(usr.client)
+
+		if("personal_chat_color")
+			var/new_chat_color = input(user, "Choose your character's runechat color:", "Character Preference",personal_chat_color) as color|null
+			if(new_chat_color)
+				var/list/temp_hsl = rgb2hsl(ReadRGB(new_chat_color)[1],ReadRGB(new_chat_color)[2],ReadRGB(new_chat_color)[3])
+				if(new_chat_color == "#000000")
+					personal_chat_color = "#FFFFFF"
+				else if(temp_hsl[3] >= 0.65 && temp_hsl[2] >= 0.15)
+					personal_chat_color = sanitize_hexcolor(new_chat_color, 6, 1)
+				else
+					to_chat(user, "<span class='danger'>Invalid color. Your color is not bright enough.</span>")
 
 		if("keybindings_menu")
 			ShowKeybindings(user)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -109,6 +109,9 @@
 			save_character()
 			return FALSE
 
+	S["enable_personal_chat_color"]			>> enable_personal_chat_color
+	S["personal_chat_color"]			>> personal_chat_color
+
 	READ_FILE(S["default_slot"], default_slot)
 	READ_FILE(S["lastchangelog"], lastchangelog)
 	READ_FILE(S["ooccolor"], ooccolor)
@@ -187,6 +190,8 @@
 	max_chat_length		= sanitize_integer(max_chat_length, 1, CHAT_MESSAGE_MAX_LENGTH, initial(max_chat_length))
 	see_chat_non_mob	= sanitize_integer(see_chat_non_mob, FALSE, TRUE, initial(see_chat_non_mob))
 	see_rc_emotes	= sanitize_integer(see_rc_emotes, FALSE, TRUE, initial(see_rc_emotes))
+	enable_personal_chat_color	= sanitize_integer(enable_personal_chat_color, 0, 1, initial(enable_personal_chat_color))
+	personal_chat_color	= sanitize_hexcolor(personal_chat_color, 6, 1, "#FFFFFF")
 
 	return TRUE
 
@@ -279,6 +284,8 @@
 	WRITE_FILE(S["max_chat_length"], max_chat_length)
 	WRITE_FILE(S["see_chat_non_mob"], see_chat_non_mob)
 	WRITE_FILE(S["see_rc_emotes"], see_rc_emotes)
+	WRITE_FILE(S["enable_personal_chat_color"], enable_personal_chat_color)
+	WRITE_FILE(S["personal_chat_color"], personal_chat_color)
 
 	return TRUE
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -13,8 +13,70 @@ proc/is_blind(A)
 proc/hasorgans(A)
 	return ishuman(A)
 
-/proc/hsl2rgb(h, s, l)
-	return //TODO: Implement
+//colour formats
+/proc/rgb2hsl(red, green, blue)
+	red /= 255;green /= 255;blue /= 255;
+	var/max = max(red,green,blue)
+	var/min = min(red,green,blue)
+	var/range = max-min
+
+	var/hue=0;var/saturation=0;var/lightness=0;
+	lightness = (max + min)/2
+	if(range != 0)
+		if(lightness < 0.5)
+			saturation = range/(max+min)
+		else
+			saturation = range/(2-max-min)
+
+		var/dred = ((max-red)/(6*max)) + 0.5
+		var/dgreen = ((max-green)/(6*max)) + 0.5
+		var/dblue = ((max-blue)/(6*max)) + 0.5
+
+		if(max==red)
+			hue = dblue - dgreen
+		else if(max==green)
+			hue = dred - dblue + (1/3)
+		else
+			hue = dgreen - dred + (2/3)
+		if(hue < 0)
+			hue++
+		else if(hue > 1)
+			hue--
+
+	return list(hue, saturation, lightness)
+
+/proc/hsl2rgb(hue, saturation, lightness)
+	var/red;var/green;var/blue;
+	if(saturation == 0)
+		red = lightness * 255
+		green = red
+		blue = red
+	else
+		var/a;var/b;
+		if(lightness < 0.5)
+			b = lightness*(1+saturation)
+		else
+			b = (lightness+saturation) - (saturation*lightness)
+		a = 2*lightness - b
+
+		red = round(255 * hue2rgb(a, b, hue+(1/3)))
+		green = round(255 * hue2rgb(a, b, hue))
+		blue = round(255 * hue2rgb(a, b, hue-(1/3)))
+
+	return list(red, green, blue)
+
+/proc/hue2rgb(a, b, hue)
+	if(hue < 0)
+		hue++
+	else if(hue > 1)
+		hue--
+	if(6*hue < 1)
+		return (a+(b-a)*6*hue)
+	if(2*hue < 1)
+		return b
+	if(3*hue < 2)
+		return (a+(b-a)*((2/3)-hue)*6)
+	return a
 
 
 
@@ -517,7 +579,7 @@ mob/proc/get_standard_bodytemperature()
 
 /mob/living/carbon/human/proc/do_activate_rail_attachment()
 	SIGNAL_HANDLER
-	
+
 	var/obj/item/weapon/gun/active_gun = get_active_firearm(src)
 	active_gun?.toggle_rail_attachment()
 	return COMSIG_KB_ACTIVATED

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -1161,27 +1161,6 @@
 				<li class="code_imp">Microoptimized Keyloop()</li>
 				<li class="code_imp">Optimizes getviewsize()</li>
 			</ul>
-
-			<h2 class="date">06 December 2020</h2>
-			<h3 class="author">Daytona updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="rscadd">Added new dropped sprites</li>
-			</ul>
-			<h3 class="author">Surrealaser updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">Fixes the shield damage absorption calculation.</li>
-				<li class="tweak">'Paralyze' status effect (i.e. proning) only halves the shield's cover value instead of negating it completely.</li>
-			</ul>
-			<h3 class="author">Wayland-Smithy updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="rscdel">Removed the arbitrary limit on resin silos.</li>
-				<li class="balance">Silo construction cooldown reduced from 120 to 60 seconds.</li>
-			</ul>
-			<h3 class="author">jroinc updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="balance">Rebalanced toxheal chems</li>
-				<li class="spellcheck">Fixed a bad copy/paste on a pill description</li>
-			</ul>
 		</div>
 
 <b>GoonStation 13 Development Team</b>

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -1129,24 +1129,6 @@
 			<ul class="changes bgimages16">
 				<li class="bugfix">Russian Red doesn't yoink your arms anymore.</li>
 			</ul>
-
-			<h2 class="date">08 December 2020</h2>
-			<h3 class="author">Pariah919 updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="balance">nerfed lasgun overcharge to 5 sunder and 40 damage</li>
-			</ul>
-			<h3 class="author">SplinterGP updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">fixes generating negative burrowed when hijacking.</li>
-			</ul>
-			<h3 class="author">Surrealaser updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">Fixed minisentry duplication bug.</li>
-				<li class="bugfix">Fixed lighting bugs for sentries.</li>
-				<li class="refactor">Minor sentry refactors and removal/revision of old code.</li>
-				<li class="bugfix">Hotkey added for Evasion.</li>
-				<li class="bugfix">Minor bug with Evasion corrected.</li>
-			</ul>
 		</div>
 
 <b>GoonStation 13 Development Team</b>

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -1147,20 +1147,6 @@
 				<li class="bugfix">Hotkey added for Evasion.</li>
 				<li class="bugfix">Minor bug with Evasion corrected.</li>
 			</ul>
-
-			<h2 class="date">07 December 2020</h2>
-			<h3 class="author">SplinterGP updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">fixes a bug where scopes would give negative accuracy to guns.</li>
-				<li class="code_imp">optimizes zoom code to reduce lag.</li>
-			</ul>
-			<h3 class="author">TiviPlus updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="code_imp">Optimized get_hear()</li>
-				<li class="code_imp">Optimized get_hearers_in_view()</li>
-				<li class="code_imp">Microoptimized Keyloop()</li>
-				<li class="code_imp">Optimizes getviewsize()</li>
-			</ul>
 		</div>
 
 <b>GoonStation 13 Development Team</b>

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -370,6 +370,10 @@
 			<h3 class="author">joookschad updated:</h3>
 			<ul class="changes bgimages16">
 				<li class="soundadd">added a new sound on the beginning of a vote, ripped from TF2</li>
+			<h2 class="date">04 February 2021</h2>
+			<h3 class="author">BraveMole updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="bugfix">Game no longer end when hijacking</li>
 			</ul>
 
 			<h2 class="date">03 February 2021</h2>
@@ -1099,6 +1103,136 @@
 				<li class="bugfix">fixes fire not lighting xenos on fire.</li>
 				<li class="bugfix">fixes acid globs stored on boiler not glowing.</li>
 				<li class="code_imp">makes xenos use newlights.</li>
+			</ul>
+
+			<h2 class="date">12 December 2020</h2>
+			<h3 class="author">SplinterGP updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="code_imp">makes acid use SSslowprocess instead of SSprocessing, saving performance.</li>
+			</ul>
+
+			<h2 class="date">09 December 2020</h2>
+			<h3 class="author">Hughgent updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="bugfix">Autoburst firemode now properly applying burst accuracy penalty.</li>
+			</ul>
+			<h3 class="author">TiviPlus updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="code_imp">Removes dead/unused huds</li>
+			</ul>
+			<h3 class="author">Wayland-Smithy updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="rscadd">Added the Salvage Biomass ability to Hivelord.</li>
+				<li class="bugfix">Fixed Crest Toss buckled mob interactions, and a visual feedback bug.</li>
+			</ul>
+			<h3 class="author">jroinc updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="bugfix">Russian Red doesn't yoink your arms anymore.</li>
+			</ul>
+
+			<h2 class="date">08 December 2020</h2>
+			<h3 class="author">Pariah919 updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="balance">nerfed lasgun overcharge to 5 sunder and 40 damage</li>
+			</ul>
+			<h3 class="author">SplinterGP updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="bugfix">fixes generating negative burrowed when hijacking.</li>
+			</ul>
+			<h3 class="author">Surrealaser updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="bugfix">Fixed minisentry duplication bug.</li>
+				<li class="bugfix">Fixed lighting bugs for sentries.</li>
+				<li class="refactor">Minor sentry refactors and removal/revision of old code.</li>
+				<li class="bugfix">Hotkey added for Evasion.</li>
+				<li class="bugfix">Minor bug with Evasion corrected.</li>
+			</ul>
+
+			<h2 class="date">07 December 2020</h2>
+			<h3 class="author">SplinterGP updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="bugfix">fixes a bug where scopes would give negative accuracy to guns.</li>
+				<li class="code_imp">optimizes zoom code to reduce lag.</li>
+			</ul>
+			<h3 class="author">TiviPlus updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="code_imp">Optimized get_hear()</li>
+				<li class="code_imp">Optimized get_hearers_in_view()</li>
+				<li class="code_imp">Microoptimized Keyloop()</li>
+				<li class="code_imp">Optimizes getviewsize()</li>
+			</ul>
+
+			<h2 class="date">06 December 2020</h2>
+			<h3 class="author">Daytona updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="rscadd">Added new dropped sprites</li>
+			</ul>
+			<h3 class="author">Surrealaser updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="bugfix">Fixes the shield damage absorption calculation.</li>
+				<li class="tweak">'Paralyze' status effect (i.e. proning) only halves the shield's cover value instead of negating it completely.</li>
+			</ul>
+			<h3 class="author">Wayland-Smithy updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="rscdel">Removed the arbitrary limit on resin silos.</li>
+				<li class="balance">Silo construction cooldown reduced from 120 to 60 seconds.</li>
+			</ul>
+			<h3 class="author">jroinc updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="balance">Rebalanced toxheal chems</li>
+				<li class="spellcheck">Fixed a bad copy/paste on a pill description</li>
+			</ul>
+
+			<h2 class="date">05 December 2020</h2>
+			<h3 class="author">Chaznoodles updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="rscadd">Adds bandannas in a variety of squad-based colours. Scratch n' Sniff!</li>
+				<li class="rscadd">Adds squad-based radio headsets to the Requisitions Operations Vendor.</li>
+			</ul>
+			<h3 class="author">Hughgent updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="tweak">Spaceship retreat can now be prevented by admins</li>
+				<li class="tweak">Spaceship navigation console now automatically logs out after 1 minute</li>
+				<li class="tweak">Spaceship orbit cannot be changed before the 30 minute mark.</li>
+				<li class="rscadd">Xenos now get notified via announcement when marines start the retreat timer.</li>
+			</ul>
+			<h3 class="author">MLGTASTICa updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="rscadd">Mining well upgrades!</li>
+			</ul>
+			<h3 class="author">SplinterGP updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="bugfix">fixes a runtime caused by non damage projectiles not sending the proj() to airburst() by shield.</li>
+				<li class="tweak">makes silos at dropship not break on hijacking dropship</li>
+				<li class="bugfix">fixes a bug when xenos launching to shipside with hijacked dropship would not give xenos burrowed to the xeno/marine ratio if xenos had less than half marine numbers.</li>
+			</ul>
+			<h3 class="author">StiffRobot updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="bugfix">Fixed the flak vest being unable to hold standard issue holster rigs</li>
+			</ul>
+			<h3 class="author">Surrealaser updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="rscadd">Added the Evasion ability to the Runner.</li>
+				<li class="balance">Lasrifle Overcharge damage increased from 42 to 55, Penetration increased from 20 to 50, and Sunder increased from 10 to 15.</li>
+				<li class="balance">Tadpole side entrances/exits expanded.</li>
+				<li class="balance">All of the Tadpole interior is now no-build; entrance and hardpoint tiles are still buildable.</li>
+			</ul>
+			<h3 class="author">Walarks updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="balance">removes 4s lock on transvitox's effect being able to be triggered</li>
+				<li class="rscadd">added Aim Mode to some rifles</li>
+				<li class="refactor">refactored IFF code</li>
+			</ul>
+			<h3 class="author">Wayland-Smithy updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="bugfix">Fixed Crest Toss bypassing CanPass checks like for Xeno Silo fog.</li>
+				<li class="bugfix">Fixed Crest Toss failing from "there's no room" when there is.</li>
+				<li class="code_imp">The Weather datum has gained a "repeatable" field for optionally preventing back to back random selection.</li>
+				<li class="tweak">Hivemind Collapse will now only occur faster if there is a living Drone or Larva when initiated.</li>
+			</ul>
+			<h3 class="author">jroinc updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="balance">Shrapnel and bonebreaks do damage on walk intent.</li>
 			</ul>
 		</div>
 

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -370,10 +370,6 @@
 			<h3 class="author">joookschad updated:</h3>
 			<ul class="changes bgimages16">
 				<li class="soundadd">added a new sound on the beginning of a vote, ripped from TF2</li>
-			<h2 class="date">04 February 2021</h2>
-			<h3 class="author">BraveMole updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">Game no longer end when hijacking</li>
 			</ul>
 
 			<h2 class="date">03 February 2021</h2>
@@ -1103,31 +1099,6 @@
 				<li class="bugfix">fixes fire not lighting xenos on fire.</li>
 				<li class="bugfix">fixes acid globs stored on boiler not glowing.</li>
 				<li class="code_imp">makes xenos use newlights.</li>
-			</ul>
-
-			<h2 class="date">12 December 2020</h2>
-			<h3 class="author">SplinterGP updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="code_imp">makes acid use SSslowprocess instead of SSprocessing, saving performance.</li>
-			</ul>
-
-			<h2 class="date">09 December 2020</h2>
-			<h3 class="author">Hughgent updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">Autoburst firemode now properly applying burst accuracy penalty.</li>
-			</ul>
-			<h3 class="author">TiviPlus updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="code_imp">Removes dead/unused huds</li>
-			</ul>
-			<h3 class="author">Wayland-Smithy updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="rscadd">Added the Salvage Biomass ability to Hivelord.</li>
-				<li class="bugfix">Fixed Crest Toss buckled mob interactions, and a visual feedback bug.</li>
-			</ul>
-			<h3 class="author">jroinc updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">Russian Red doesn't yoink your arms anymore.</li>
 			</ul>
 		</div>
 

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -1182,58 +1182,6 @@
 				<li class="balance">Rebalanced toxheal chems</li>
 				<li class="spellcheck">Fixed a bad copy/paste on a pill description</li>
 			</ul>
-
-			<h2 class="date">05 December 2020</h2>
-			<h3 class="author">Chaznoodles updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="rscadd">Adds bandannas in a variety of squad-based colours. Scratch n' Sniff!</li>
-				<li class="rscadd">Adds squad-based radio headsets to the Requisitions Operations Vendor.</li>
-			</ul>
-			<h3 class="author">Hughgent updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="tweak">Spaceship retreat can now be prevented by admins</li>
-				<li class="tweak">Spaceship navigation console now automatically logs out after 1 minute</li>
-				<li class="tweak">Spaceship orbit cannot be changed before the 30 minute mark.</li>
-				<li class="rscadd">Xenos now get notified via announcement when marines start the retreat timer.</li>
-			</ul>
-			<h3 class="author">MLGTASTICa updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="rscadd">Mining well upgrades!</li>
-			</ul>
-			<h3 class="author">SplinterGP updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">fixes a runtime caused by non damage projectiles not sending the proj() to airburst() by shield.</li>
-				<li class="tweak">makes silos at dropship not break on hijacking dropship</li>
-				<li class="bugfix">fixes a bug when xenos launching to shipside with hijacked dropship would not give xenos burrowed to the xeno/marine ratio if xenos had less than half marine numbers.</li>
-			</ul>
-			<h3 class="author">StiffRobot updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">Fixed the flak vest being unable to hold standard issue holster rigs</li>
-			</ul>
-			<h3 class="author">Surrealaser updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="rscadd">Added the Evasion ability to the Runner.</li>
-				<li class="balance">Lasrifle Overcharge damage increased from 42 to 55, Penetration increased from 20 to 50, and Sunder increased from 10 to 15.</li>
-				<li class="balance">Tadpole side entrances/exits expanded.</li>
-				<li class="balance">All of the Tadpole interior is now no-build; entrance and hardpoint tiles are still buildable.</li>
-			</ul>
-			<h3 class="author">Walarks updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="balance">removes 4s lock on transvitox's effect being able to be triggered</li>
-				<li class="rscadd">added Aim Mode to some rifles</li>
-				<li class="refactor">refactored IFF code</li>
-			</ul>
-			<h3 class="author">Wayland-Smithy updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">Fixed Crest Toss bypassing CanPass checks like for Xeno Silo fog.</li>
-				<li class="bugfix">Fixed Crest Toss failing from "there's no room" when there is.</li>
-				<li class="code_imp">The Weather datum has gained a "repeatable" field for optionally preventing back to back random selection.</li>
-				<li class="tweak">Hivemind Collapse will now only occur faster if there is a living Drone or Larva when initiated.</li>
-			</ul>
-			<h3 class="author">jroinc updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="balance">Shrapnel and bonebreaks do damage on walk intent.</li>
-			</ul>
 		</div>
 
 <b>GoonStation 13 Development Team</b>

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -74,6 +74,7 @@
 #include "code\__DEFINES\qdel.dm"
 #include "code\__DEFINES\radio.dm"
 #include "code\__DEFINES\reagents.dm"
+#include "code\__DEFINES\runechat_defines.dm"
 #include "code\__DEFINES\rust_g.dm"
 #include "code\__DEFINES\say.dm"
 #include "code\__DEFINES\shuttles.dm"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
As I requested in #feeback, this is a port of _that one specific server_ that allows us snowflakes to choose our own Runechat color. I also did improvements on the mob_helpers code as well, so it can be a bit of a refractor.

![image](https://user-images.githubusercontent.com/35091844/107878439-b7922b80-6f0d-11eb-9821-1558b36de7ed.png)

![image](https://user-images.githubusercontent.com/35091844/107878516-2ec7bf80-6f0e-11eb-8142-9af0d2d9b82a.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Again, snowflakes.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Runechat colors can either be randomized or based on your own preferences!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
