### PR TITLE
Nerfs DB damage by 25%

### DIFF
--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -431,6 +431,7 @@ can cause issues with ammo types getting mixed up during the burst.
 	accuracy_mult = 1.15
 	accuracy_mult_unwielded = 0.85
 	scatter = 10
+	damage_mult = 0.75
 	scatter_unwielded = 40
 	recoil = 2
 	recoil_unwielded = 4


### PR DESCRIPTION
## About The Pull Request

the marine double barrel now deals 25% less damage per shot

## Why It's Good For The Game

A gun that fires faster than the combat shotgun shouldn't be doing full shotgun damage,rocket tag memes begone

## Changelog
:cl:
balance:the marine double barreled shotgun now deals 25% less damage
/:cl: