### PR TITLE
Prison Station LZ 1 & 2 adjustments

### DIFF
--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -12308,11 +12308,8 @@
 /turf/open/floor/wood,
 /area/prison/residential/north)
 "aMC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 4;
-	on = 1
-	},
-/turf/open/floor/wood,
+/obj/machinery/smartfridge,
+/turf/open/floor/prison/kitchen,
 /area/prison/residential/north)
 "aMD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -12328,11 +12325,8 @@
 /turf/open/floor/wood,
 /area/prison/residential/north)
 "aMF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/turf/open/floor/wood,
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/prison/kitchen,
 /area/prison/residential/north)
 "aMG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -13024,22 +13018,6 @@
 "aOW" = (
 /turf/open/floor/wood,
 /area/prison/command/office)
-"aOX" = (
-/obj/machinery/door/window/eastright,
-/turf/open/floor/prison/sterilewhite,
-/area/prison/residential/north)
-"aOY" = (
-/obj/structure/sink{
-	dir = 4
-	},
-/obj/structure/mirror{
-	pixel_x = 26
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/prison/sterilewhite,
-/area/prison/residential/north)
 "aOZ" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -13629,15 +13607,6 @@
 /obj/structure/table/woodentable,
 /turf/open/floor/wood,
 /area/prison/command/office)
-"aQz" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/shower{
-	dir = 1
-	},
-/turf/open/floor/prison/sterilewhite,
-/area/prison/residential/north)
 "aQA" = (
 /obj/structure/toilet{
 	dir = 1
@@ -14292,6 +14261,7 @@
 /area/prison/maintenance/residential/nw)
 "aSP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber,
+/obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/nw)
 "aSQ" = (
@@ -16233,17 +16203,9 @@
 "aYI" = (
 /turf/open/floor/carpet,
 /area/prison/command/quarters)
-"aYJ" = (
-/obj/structure/bed,
-/turf/open/floor/carpet,
-/area/prison/command/quarters)
 "aYK" = (
-/obj/structure/toilet,
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/open/floor/prison/kitchen,
+/turf/open/floor/carpet,
 /area/prison/command/quarters)
 "aYL" = (
 /turf/closed/wall/r_wall/prison,
@@ -16571,13 +16533,6 @@
 	},
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/lowsec/nw)
-"aZJ" = (
-/obj/structure/bed/chair/comfy,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/prison/command/quarters)
 "aZK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -16588,6 +16543,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/prison/command/quarters)
 "aZM" = (
@@ -16597,16 +16553,6 @@
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/prison/toilet/staff)
-"aZN" = (
-/obj/structure/sink{
-	dir = 4
-	},
-/obj/structure/mirror{
-	pixel_x = 28
-	},
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/open/floor/prison/kitchen,
-/area/prison/command/quarters)
 "aZO" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -16813,20 +16759,6 @@
 /obj/structure/table/woodentable,
 /obj/item/flashlight/lamp,
 /turf/open/floor/carpet,
-/area/prison/command/quarters)
-"baC" = (
-/obj/structure/bed/chair/comfy{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/prison/command/quarters)
-"baD" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/machinery/door/window/northright,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/open/floor/prison/kitchen,
 /area/prison/command/quarters)
 "baE" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -20411,12 +20343,6 @@
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/central)
-"bkV" = (
-/obj/machinery/door/airlock/mainship/generic{
-	name = "Toilet"
-	},
-/turf/open/floor/freezer,
-/area/prison/command/quarters)
 "bkW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -25278,13 +25204,6 @@
 "bAF" = (
 /turf/closed/wall/prison,
 /area/prison/maintenance/hangar_barracks)
-"bAG" = (
-/obj/structure/largecrate/random,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
-/turf/open/floor/plating,
-/area/prison/maintenance/hangar_barracks)
 "bAH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -25475,7 +25394,6 @@
 /turf/open/floor/prison/cellstripe,
 /area/prison/cellblock/lowsec/sw)
 "bBl" = (
-/obj/structure/bed,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
@@ -26029,21 +25947,10 @@
 	dir = 5
 	},
 /area/prison/hallway/east)
-"bCW" = (
-/obj/structure/bed,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/prison,
-/area/prison/quarters/security)
-"bCX" = (
-/obj/structure/bed,
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/prison,
-/area/prison/quarters/security)
 "bCY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 4
 	},
-/obj/structure/largecrate/random,
 /turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
 "bCZ" = (
@@ -26660,9 +26567,7 @@
 	},
 /area/prison/hallway/east)
 "bEK" = (
-/obj/structure/bed,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/corpsespawner/prison_security,
 /turf/open/floor/prison,
 /area/prison/quarters/security)
 "bEL" = (
@@ -26670,7 +26575,6 @@
 	dir = 4;
 	on = 1
 	},
-/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
 "bEM" = (
@@ -27013,7 +26917,8 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/east)
 "bFN" = (
-/turf/closed/wall/r_wall/prison,
+/obj/structure/grille,
+/turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
 "bFO" = (
 /obj/structure/cable,
@@ -27170,11 +27075,6 @@
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/highsec/south/north)
-"bGg" = (
-/obj/machinery/light/small,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/open/floor/plating,
-/area/prison/maintenance/hangar_barracks)
 "bGh" = (
 /turf/open/shuttle/dropship/floor,
 /area/prison/monorail/east)
@@ -27310,15 +27210,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
-"bGK" = (
-/obj/structure/cable,
-/turf/open/floor/prison/darkyellow{
-	dir = 9
-	},
-/area/prison/maintenance/hangar_barracks)
-"bGL" = (
-/turf/open/floor/prison,
-/area/prison/maintenance/hangar_barracks)
 "bGN" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
@@ -27328,7 +27219,7 @@
 /area/prison/recreation/highsec/s)
 "bGO" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall/prison,
+/turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
 "bGP" = (
 /obj/machinery/alarm,
@@ -27355,15 +27246,6 @@
 /area/prison/residential/south)
 "bGU" = (
 /turf/closed/wall/prison,
-/area/prison/residential/south)
-"bGV" = (
-/obj/machinery/shower{
-	pixel_y = 15
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/prison/sterilewhite,
 /area/prison/residential/south)
 "bGW" = (
 /obj/structure/sink{
@@ -27674,7 +27556,6 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/east)
 "bHV" = (
-/obj/structure/bed,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/prison,
 /area/prison/quarters/security)
@@ -27689,44 +27570,19 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
-"bHZ" = (
-/obj/effect/landmark/monkey_spawn,
-/turf/open/floor/prison/darkyellow{
-	dir = 1
-	},
-/area/prison/maintenance/hangar_barracks)
-"bIa" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/prison,
-/area/prison/maintenance/hangar_barracks)
-"bIb" = (
-/obj/item/radio/headset/survivor,
-/turf/open/floor/prison/darkyellow{
-	dir = 1
-	},
-/area/prison/maintenance/hangar_barracks)
 "bIc" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/hoop,
-/turf/open/floor/prison/darkyellow{
-	dir = 5
-	},
-/area/prison/maintenance/hangar_barracks)
-"bId" = (
-/obj/structure/cable,
 /obj/machinery/power/apc/drained{
-	dir = 4
-	},
-/turf/open/floor/prison/darkyellow{
 	dir = 8
 	},
+/turf/open/floor/plating,
+/area/prison/maintenance/hangar_barracks)
+"bId" = (
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
 "bIe" = (
-/turf/open/floor/prison/darkyellow{
-	dir = 4
-	},
+/obj/structure/largecrate/random,
+/turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
 "bIf" = (
 /obj/structure/table/woodentable,
@@ -27744,15 +27600,17 @@
 /turf/open/floor/wood,
 /area/prison/residential/south)
 "bIi" = (
-/obj/machinery/door/window/eastleft,
-/turf/open/floor/prison/sterilewhite,
+/obj/structure/toilet{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/prison/residential/south)
 "bIk" = (
 /obj/structure/toilet{
 	dir = 8;
 	pixel_x = -4
 	},
-/turf/open/floor/prison/sterilewhite,
+/turf/open/floor/wood,
 /area/prison/residential/south)
 "bIl" = (
 /obj/structure/cable,
@@ -27944,19 +27802,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/highsec/south/north)
-"bIH" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/door/airlock/mainship/maint/free_access{
-	name = "Hangar-Barracks Maintenance"
-	},
-/turf/open/floor/plating,
-/area/prison/maintenance/hangar_barracks)
 "bII" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
@@ -28205,21 +28050,9 @@
 /obj/structure/window/framed/prison/reinforced/hull,
 /turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
-"bJv" = (
-/obj/machinery/alarm{
-	dir = 4
-	},
-/turf/open/floor/prison/darkyellow{
-	dir = 10
-	},
-/area/prison/maintenance/hangar_barracks)
-"bJw" = (
-/turf/open/floor/prison/darkyellow,
-/area/prison/maintenance/hangar_barracks)
 "bJy" = (
-/turf/open/floor/prison/darkyellow{
-	dir = 6
-	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
 "bJz" = (
 /turf/closed/shuttle,
@@ -28406,10 +28239,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison,
 /area/prison/quarters/security)
-"bKf" = (
-/obj/item/toy/beach_ball/basketball,
-/turf/open/floor/prison,
-/area/prison/maintenance/hangar_barracks)
 "bKg" = (
 /turf/closed/wall,
 /area/storage/testroom)
@@ -28588,8 +28417,8 @@
 /turf/open/floor,
 /area/storage/testroom)
 "bKO" = (
-/obj/structure/largecrate/random,
-/turf/open/floor/prison/darkyellow/full,
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
 "bKP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -28611,12 +28440,6 @@
 /area/prison/residential/south)
 "bKR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber,
-/turf/open/floor/wood,
-/area/prison/residential/south)
-"bKS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber{
-	dir = 4
-	},
 /turf/open/floor/wood,
 /area/prison/residential/south)
 "bKT" = (
@@ -28654,13 +28477,6 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/prison/hallway/central)
-"bKV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/wood,
-/area/prison/residential/south)
 "bKX" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
@@ -30121,13 +29937,6 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/prison/bright_clean,
 /area/prison/laundry)
-"bPw" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic{
-	dir = 2;
-	name = "Bar"
-	},
-/turf/open/floor/prison/kitchen,
-/area/prison/residential/central)
 "bPx" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	name = "Laundry"
@@ -41318,6 +41127,10 @@
 	dir = 6
 	},
 /area/prison/security/monitoring/medsec/south)
+"cCM" = (
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/sw)
 "cEk" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/wood,
@@ -41412,6 +41225,12 @@
 	},
 /turf/open/ground/grass,
 /area/prison/residential/central)
+"dqM" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/turf/open/floor/wood/broken,
+/area/prison/residential/south)
 "dsF" = (
 /obj/structure/monorail{
 	dir = 5
@@ -41425,6 +41244,12 @@
 	icon_state = "bright_clean2"
 	},
 /area/prison/holding/holding1)
+"dAe" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/closed/wall/r_wall/prison_unmeltable,
+/area/prison/command/quarters)
 "dBh" = (
 /obj/structure/window/framed/prison/reinforced,
 /obj/effect/landmark/lv624/fog_blocker,
@@ -41437,6 +41262,10 @@
 	dir = 8
 	},
 /area/prison/security/monitoring/maxsec/panopticon)
+"dEx" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/nw)
 "dNd" = (
 /turf/open/ground/coast{
 	dir = 6
@@ -41576,6 +41405,10 @@
 	dir = 4
 	},
 /area/prison/cellblock/highsec/north/south)
+"eCN" = (
+/obj/structure/bed/chair/comfy,
+/turf/open/floor/carpet,
+/area/prison/command/quarters)
 "eLE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -41588,6 +41421,10 @@
 	dir = 5
 	},
 /area/prison/command/secretary_office)
+"eWq" = (
+/obj/structure/largecrate/random,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/nw)
 "eZF" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/prison/bright_clean/two,
@@ -41644,6 +41481,10 @@
 	dir = 8
 	},
 /area/space)
+"frU" = (
+/obj/item/reagent_containers/glass/bucket/janibucket,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/sw)
 "fuY" = (
 /obj/structure/lattice,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
@@ -41670,11 +41511,29 @@
 /obj/structure/bookcase,
 /turf/open/floor/wood/broken,
 /area/prison/library)
+"fze" = (
+/obj/structure/barricade/wooden{
+	icon_state = "wooden";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/sw)
+"fDq" = (
+/obj/structure/flora/pottedplant/twentytwo,
+/turf/open/floor/wood,
+/area/prison/residential/central)
 "fDy" = (
 /turf/open/floor/prison/darkred{
 	dir = 8
 	},
 /area/prison/hangar/main)
+"fGm" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/obj/item/frame/air_alarm,
+/turf/open/floor/plating,
+/area/prison/maintenance/hangar_barracks)
 "fIl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -41686,6 +41545,11 @@
 	dir = 1
 	},
 /area/prison/hangar/civilian)
+"fLi" = (
+/obj/structure/table/woodentable,
+/obj/machinery/light/small,
+/turf/open/floor/wood,
+/area/prison/residential/south)
 "fLx" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -41698,6 +41562,13 @@
 	},
 /turf/open/floor/prison,
 /area/prison/execution)
+"fUu" = (
+/obj/machinery/door/airlock/mainship/generic{
+	dir = 2;
+	name = "Civilian Kitchen"
+	},
+/turf/open/floor/prison/kitchen,
+/area/prison/residential/north)
 "fWv" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -41753,7 +41624,8 @@
 /area/prison/maintenance/hangar_barracks)
 "ghU" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/closed/wall/prison,
+/obj/structure/largecrate/random,
+/turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
 "gmZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -41772,6 +41644,10 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/prison/red/corner,
 /area/prison/cellblock/highsec/north/south)
+"gnd" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/prison/kitchen,
+/area/prison/residential/north)
 "gne" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/machinery/landinglight/ds2/delaythree,
@@ -41781,6 +41657,13 @@
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/plating,
 /area/prison/hangar/main)
+"gok" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating,
+/area/prison/maintenance/hangar_barracks)
 "grr" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -41821,6 +41704,10 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/access/south)
+"gCu" = (
+/obj/structure/flora/pottedplant,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/nw)
 "gCN" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/machinery/landinglight/ds2,
@@ -41954,6 +41841,16 @@
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating/ground/dirt,
 /area/space)
+"hre" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood/broken,
+/area/prison/residential/south)
+"hvJ" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/sw)
 "hwj" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/prison/bright_clean/two,
@@ -41987,10 +41884,21 @@
 	},
 /turf/open/floor/plating,
 /area/prison/hangar/main)
+"hFK" = (
+/obj/structure/table/reinforced,
+/obj/item/tool/kitchen/tray,
+/obj/item/tool/kitchen/tray,
+/obj/item/tool/kitchen/tray,
+/turf/open/floor/prison/kitchen,
+/area/prison/residential/north)
 "hJL" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/prison/green,
 /area/prison/cellblock/lowsec/se)
+"hNa" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/nw)
 "hXd" = (
 /turf/open/floor/wood/broken,
 /area/prison/library)
@@ -42030,6 +41938,13 @@
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/maxsec/south)
+"ics" = (
+/obj/structure/largecrate/random,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/prison/maintenance/hangar_barracks)
 "igm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -42063,6 +41978,9 @@
 /area/prison/maintenance/hangar_barracks)
 "irw" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/prison/rampbottom{
 	dir = 1
 	},
@@ -42105,6 +42023,10 @@
 	},
 /turf/open/beach/sea,
 /area/space)
+"iJd" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/sw)
 "iLv" = (
 /obj/item/stack/rods,
 /turf/open/beach/sea,
@@ -42118,6 +42040,12 @@
 	},
 /turf/open/floor/prison/red,
 /area/prison/cellblock/highsec/north/north)
+"iQO" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/prison/residential/south)
 "iQZ" = (
 /turf/open/ground/coast{
 	dir = 1
@@ -42155,6 +42083,13 @@
 	},
 /turf/open/floor/prison/darkyellow,
 /area/prison/hangar/civilian)
+"iXj" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/obj/structure/lattice,
+/turf/open/beach/sea,
+/area/space)
 "iXP" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -42198,6 +42133,10 @@
 	dir = 10
 	},
 /area/prison/security/monitoring/lowsec/sw)
+"jpw" = (
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/plating,
+/area/prison/maintenance/hangar_barracks)
 "jpX" = (
 /obj/structure/closet/wardrobe/atmospherics_yellow,
 /turf/open/floor/prison/darkyellow/full,
@@ -42341,12 +42280,10 @@
 /turf/open/floor/plating,
 /area/prison/cellblock/mediumsec/south)
 "kin" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/effect/landmark/start/job/survivor,
-/turf/open/floor/wood,
+/obj/structure/table,
+/obj/item/tool/kitchen/knife,
+/obj/item/tool/kitchen/rollingpin,
+/turf/open/floor/prison/kitchen,
 /area/prison/residential/north)
 "kja" = (
 /obj/machinery/door/airlock/mainship/maint/free_access{
@@ -42377,6 +42314,11 @@
 /obj/structure/mineral_door/resin,
 /turf/open/floor/prison/cleanmarked,
 /area/prison/yard)
+"ksS" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/prison/command/quarters)
 "kva" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/landmark/start/job/xenomorph,
@@ -42435,6 +42377,9 @@
 	},
 /turf/open/floor/plating,
 /area/prison/hangar/civilian)
+"kNK" = (
+/turf/open/floor/plating,
+/area/prison/command/office)
 "kPu" = (
 /obj/machinery/vending/cigarette/colony,
 /turf/open/floor/prison/darkred/full,
@@ -42504,6 +42449,11 @@
 	},
 /turf/open/floor/plating,
 /area/prison/hangar/civilian)
+"lvG" = (
+/obj/structure/bed,
+/obj/item/bedsheet/red,
+/turf/open/floor/carpet,
+/area/prison/command/quarters)
 "lvX" = (
 /obj/effect/decal/woodsiding{
 	dir = 1
@@ -42516,6 +42466,17 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/prison,
 /area/prison/cellblock/lowsec/sw)
+"lAs" = (
+/obj/structure/barricade/wooden{
+	icon_state = "wooden";
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/nw)
+"lAu" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/plating,
+/area/prison/maintenance/hangar_barracks)
 "lAV" = (
 /turf/open/ground/coast{
 	dir = 8
@@ -42545,11 +42506,26 @@
 	},
 /turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
+"lWq" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/closed/wall/r_wall/prison_unmeltable,
+/area/space)
 "maz" = (
 /turf/open/floor/prison/darkred{
 	dir = 6
 	},
 /area/prison/security/checkpoint/highsec/n)
+"mbM" = (
+/obj/structure/barricade/wooden{
+	icon_state = "wooden";
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/sw)
+"mfh" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/prison/maintenance/hangar_barracks)
 "mhw" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/prison/darkred/full,
@@ -42655,6 +42631,11 @@
 /obj/structure/cable,
 /turf/open/floor/prison/bright_clean,
 /area/prison/hallway/central)
+"mPA" = (
+/obj/structure/bed,
+/obj/effect/landmark/corpsespawner/prison_security,
+/turf/open/floor/prison,
+/area/prison/quarters/security)
 "mPV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -42754,6 +42735,25 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/prison/darkred,
 /area/prison/security)
+"noS" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/sw)
+"nzC" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	name = "Hangar-Barracks Maintenance"
+	},
+/turf/open/floor/prison,
+/area/prison/quarters/security)
 "nEB" = (
 /obj/structure/monorail{
 	dir = 10
@@ -42778,6 +42778,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/canteen)
+"nPd" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/nw)
 "nPv" = (
 /obj/effect/alien/weeds/node,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -42805,6 +42809,16 @@
 	},
 /turf/open/floor/prison,
 /area/prison/hangar/main)
+"nSA" = (
+/obj/structure/flora/pottedplant/twentytwo,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/nw)
+"nZE" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/sw)
 "oaB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -42818,6 +42832,15 @@
 /obj/structure/window/framed/prison/reinforced/hull,
 /turf/open/floor/plating,
 /area/prison/hangar/main)
+"oeg" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/prison/maintenance/hangar_barracks)
 "ogg" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/beach/sea,
@@ -42862,6 +42885,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/prison/sterilewhite,
+/area/prison/residential/south)
+"ovz" = (
+/obj/machinery/door/airlock/mainship/generic{
+	dir = 2;
+	name = "Bedroom"
+	},
+/turf/open/floor/wood/broken,
 /area/prison/residential/south)
 "ovT" = (
 /obj/effect/decal/siding{
@@ -42921,6 +42951,16 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/highsec/north/north)
+"oUh" = (
+/obj/structure/table,
+/turf/open/floor/prison/kitchen,
+/area/prison/residential/north)
+"oYc" = (
+/obj/structure/table,
+/obj/item/clothing/suit/chef/classic,
+/obj/item/reagent_containers/spray,
+/turf/open/floor/prison/kitchen,
+/area/prison/residential/north)
 "pcf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
@@ -42959,6 +42999,10 @@
 /obj/effect/alien/weeds/node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/research/secret/biolab)
+"pkD" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/nw)
 "pla" = (
 /obj/structure/window/framed/prison/reinforced,
 /obj/machinery/door/poddoor/shutters/mainship/open{
@@ -42969,6 +43013,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/prison/research/secret/biolab)
+"ptw" = (
+/obj/structure/flora/pottedplant/twentyone,
+/turf/open/floor/wood,
+/area/prison/residential/central)
+"pzF" = (
+/obj/structure/barricade/wooden{
+	icon_state = "wooden";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/prison/maintenance/hangar_barracks)
 "pAI" = (
 /turf/open/floor/prison/darkred{
 	dir = 10
@@ -43035,6 +43090,12 @@
 	},
 /turf/open/floor/prison/darkyellow,
 /area/prison/hangar/civilian)
+"pTF" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/prison/kitchen,
+/area/prison/residential/north)
 "pVt" = (
 /obj/structure/window/framed/prison/reinforced/hull,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
@@ -43090,6 +43151,10 @@
 	dir = 8
 	},
 /area/prison/cellblock/mediumsec/south)
+"qea" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/sw)
 "qfo" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -43133,6 +43198,10 @@
 /area/space)
 "qxc" = (
 /obj/machinery/light/small,
+/obj/structure/barricade/wooden{
+	icon_state = "wooden";
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/sw)
 "qxz" = (
@@ -43149,6 +43218,10 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/hallway/central)
+"qAw" = (
+/obj/structure/flora/pottedplant/twentyone,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/nw)
 "qBi" = (
 /obj/structure/cable,
 /obj/machinery/light{
@@ -43181,6 +43254,13 @@
 	},
 /turf/open/floor/plating,
 /area/prison/hangar_storage/research)
+"qNy" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/bed/chair/comfy,
+/turf/open/floor/carpet,
+/area/prison/command/quarters)
 "qNQ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -43214,6 +43294,17 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/prison/plate,
 /area/prison/recreation/highsec/n)
+"reb" = (
+/obj/item/tool/mop,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/sw)
+"rfz" = (
+/obj/structure/barricade/wooden{
+	icon_state = "wooden";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/nw)
 "rhE" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/prison/plate,
@@ -43243,6 +43334,10 @@
 "rqK" = (
 /turf/open/floor/prison/rampbottom,
 /area/prison/maintenance/residential/nw)
+"rqR" = (
+/obj/machinery/light,
+/turf/open/floor/prison/kitchen,
+/area/prison/residential/north)
 "rrt" = (
 /turf/closed/wall/r_wall/prison_unmeltable,
 /area/prison/research/secret/biolab)
@@ -43309,6 +43404,17 @@
 /obj/structure/mineral_door/resin,
 /turf/open/floor/prison/whitepurple/full,
 /area/prison/research/secret/biolab)
+"rGJ" = (
+/obj/machinery/power/apc/drained{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/structure/barricade/wooden{
+	icon_state = "wooden";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/nw)
 "rGT" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/prison/sterilewhite,
@@ -43330,11 +43436,6 @@
 	dir = 4
 	},
 /area/prison/cellblock/mediumsec/south)
-"rTX" = (
-/obj/machinery/power/apc/drained,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/prison/maintenance/residential/nw)
 "rZZ" = (
 /obj/machinery/door/poddoor/four_tile_ver/secure{
 	name = "Civilian Hangar Door"
@@ -43351,13 +43452,6 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/r_wall/prison_unmeltable,
 /area/prison/research/secret/biolab)
-"sgh" = (
-/obj/machinery/door/airlock/mainship/maint/free_access{
-	name = "Hangar-Barracks Maintenance"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/prison/maintenance/hangar_barracks)
 "shC" = (
 /obj/item/toy/beach_ball,
 /turf/open/floor/plating/ground/dirt,
@@ -43407,12 +43501,6 @@
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/mediumsec/west)
-"syz" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/prison/darkyellow{
-	dir = 1
-	},
-/area/prison/maintenance/hangar_barracks)
 "sBT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -43429,6 +43517,11 @@
 	dir = 4
 	},
 /area/prison/cellblock/mediumsec/west)
+"sHd" = (
+/obj/item/bedsheet,
+/obj/structure/bed,
+/turf/open/floor/wood,
+/area/prison/residential/south)
 "sHr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/landmark/start/job/survivor,
@@ -43439,6 +43532,10 @@
 /obj/effect/alien/weeds/node,
 /turf/open/floor/prison/green/corner,
 /area/prison/cellblock/lowsec/se)
+"sMg" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/nw)
 "sMp" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/r_wall/prison_unmeltable,
@@ -43487,6 +43584,12 @@
 /obj/effect/overlay/coconut,
 /turf/open/floor/plating/ground/dirt,
 /area/space)
+"tgu" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/turf/open/floor/prison/kitchen,
+/area/prison/command/quarters)
 "tlK" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/wall/prison,
@@ -43534,6 +43637,10 @@
 	},
 /turf/open/floor/plating,
 /area/prison/hangar_storage/research)
+"tuK" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/sw)
 "tuQ" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/prison/yellow{
@@ -43556,6 +43663,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/prison/rampbottom,
 /area/prison/maintenance/residential/nw)
+"tGm" = (
+/obj/machinery/light/small,
+/obj/structure/table/woodentable,
+/obj/item/clothing/head/beret/sec/warden,
+/turf/open/floor/carpet,
+/area/prison/command/quarters)
 "tGN" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -43633,18 +43746,34 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/canteen)
+"ufB" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/sw)
 "ulZ" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/prison/green{
 	dir = 8
 	},
 /area/prison/cellblock/lowsec/sw)
+"uua" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/prison/kitchen,
+/area/prison/residential/north)
 "uuc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/monitoring/maxsec/panopticon)
+"uvz" = (
+/obj/structure/flora/pottedplant/ten,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/nw)
+"uEg" = (
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/prison/command/quarters)
 "uHe" = (
 /turf/open/ground/coast{
 	dir = 9
@@ -43682,6 +43811,10 @@
 	dir = 4
 	},
 /area/prison/cellblock/mediumsec/north)
+"uVo" = (
+/obj/structure/window/reinforced,
+/turf/open/floor/prison/kitchen,
+/area/prison/command/quarters)
 "uWT" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -43814,6 +43947,14 @@
 	},
 /turf/open/ground/grass,
 /area/prison/residential/central)
+"vvI" = (
+/obj/structure/barricade/wooden{
+	icon_state = "wooden";
+	dir = 8
+	},
+/obj/structure/janitorialcart,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/sw)
 "vxB" = (
 /turf/open/ground/coast/corner2,
 /area/space)
@@ -43922,11 +44063,27 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/carpet,
 /area/prison/chapel)
+"wnT" = (
+/obj/structure/table/woodentable,
+/obj/effect/landmark/weapon_spawn/tier2_weapon_spawn,
+/turf/open/floor/carpet,
+/area/prison/command/quarters)
 "woW" = (
 /obj/machinery/door/airlock/mainship/maint/free_access,
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
 /area/prison/security/monitoring/lowsec/sw)
+"wus" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/machinery/door/window,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/prison/kitchen,
+/area/prison/command/quarters)
 "wuG" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -43970,6 +44127,10 @@
 	},
 /turf/closed/wall/r_wall/prison_unmeltable,
 /area/prison/monorail/east)
+"wBR" = (
+/obj/machinery/processor,
+/turf/open/floor/prison/kitchen,
+/area/prison/residential/north)
 "wEG" = (
 /turf/open/ground/desertdam/river/clean/shallow_edge{
 	dir = 4
@@ -43992,6 +44153,10 @@
 	},
 /turf/open/floor/prison,
 /area/prison/hangar/main)
+"wOX" = (
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/nw)
 "wWX" = (
 /obj/structure/lattice,
 /turf/open/ground/coast,
@@ -44045,6 +44210,14 @@
 	dir = 8
 	},
 /area/prison/security/monitoring/maxsec/panopticon)
+"xqK" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/obj/machinery/power/apc/drained{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/prison/command/quarters)
 "xrp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
@@ -44073,6 +44246,10 @@
 "xAI" = (
 /turf/closed/wall/r_wall/prison,
 /area/prison/research/secret/biolab)
+"xFW" = (
+/obj/machinery/gibber,
+/turf/open/floor/prison/kitchen,
+/area/prison/residential/north)
 "xHS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -44080,6 +44257,15 @@
 	dir = 4
 	},
 /area/prison/cellblock/highsec/south/north)
+"xKi" = (
+/obj/structure/sink{
+	dir = 4
+	},
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/turf/open/floor/prison/kitchen,
+/area/prison/command/quarters)
 "xKk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -44091,6 +44277,14 @@
 	dir = 8
 	},
 /area/prison/hangar/main)
+"xKV" = (
+/obj/structure/window/framed/prison/reinforced/hull,
+/turf/open/beach/sea,
+/area/prison/command/quarters)
+"xRA" = (
+/obj/structure/flora/pottedplant/ten,
+/turf/open/floor/wood,
+/area/prison/residential/central)
 "xRQ" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -44176,6 +44370,13 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/prison,
 /area/prison/hangar/main)
+"yiK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/prison/command/quarters)
 "yiT" = (
 /obj/structure/lattice,
 /turf/open/ground/coast/corner2{
@@ -48406,11 +48607,11 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
+aRS
+aRS
+aRS
+aRS
+aRS
 aab
 aab
 iHW
@@ -48661,13 +48862,13 @@ avl
 avm
 avm
 avm
-avl
-aab
-aab
-aab
-aab
-aab
-aab
+aRS
+aRS
+aRS
+hNa
+eWq
+nPd
+aRS
 aab
 aab
 iHW
@@ -48918,12 +49119,12 @@ avN
 avM
 aLK
 avK
-avl
-aab
-aab
-aab
-aRS
-aRS
+aRT
+lAs
+lAs
+aSN
+rfz
+rGJ
 aRS
 aRS
 aRS
@@ -48962,10 +49163,10 @@ bwu
 bwu
 bwu
 bwu
-aab
-aab
-aab
-bKl
+bwu
+bwu
+bwu
+bwu
 bGR
 bLI
 bGT
@@ -49175,12 +49376,12 @@ avN
 aLa
 axb
 awi
-avl
-aab
-aab
-aab
-aRS
-rTX
+aRT
+eWq
+aSN
+aSN
+aSN
+iSZ
 iSZ
 rqK
 aSN
@@ -49217,12 +49418,12 @@ sEQ
 bxf
 bfX
 bvR
+iJd
+noS
+mbM
 bxf
-bwu
-aab
-aab
-aab
-bKl
+mbM
+bwv
 bIf
 bJB
 cFk
@@ -49432,11 +49633,11 @@ avN
 avM
 axb
 axa
-avl
-aab
-aab
-aab
-aRS
+aRT
+eWq
+hNa
+aSN
+aSN
 qiV
 cQu
 tDi
@@ -49475,11 +49676,11 @@ xZC
 mKT
 tKQ
 bEU
-bwu
-aab
-aab
-aab
-bKl
+bxf
+iJd
+bxf
+tuK
+bwv
 bJA
 bJB
 bGT
@@ -49689,12 +49890,12 @@ avN
 avN
 aLL
 avN
-avl
-adO
-adO
-adO
-aRS
-qfo
+aRT
+rfz
+rfz
+aSN
+aSN
+hNa
 aTW
 aRS
 aRS
@@ -49731,12 +49932,12 @@ yhs
 bwu
 bwu
 bBJ
-qxc
-bwu
-adO
-adO
-adO
-bKl
+bxf
+fze
+bxf
+bxf
+fze
+bwv
 bGU
 bLJ
 bGU
@@ -49946,11 +50147,11 @@ aKs
 aLb
 aLb
 aMB
-avm
-aab
-aab
-aab
-aRS
+aRT
+pkD
+pkD
+rfz
+aSN
 aSN
 aDE
 aRS
@@ -49989,11 +50190,11 @@ aab
 bwu
 bzT
 bxf
-bwu
-aab
-aab
-aab
-bGQ
+ufB
+cCM
+cCM
+cCM
+bwv
 bKR
 bLK
 bLK
@@ -50203,11 +50404,11 @@ azg
 aLc
 azg
 avK
-avl
-aab
-aab
-aab
-aRS
+aRT
+gCu
+pkD
+pkD
+eWq
 aSN
 aDE
 aRS
@@ -50246,11 +50447,11 @@ aab
 bwu
 bzT
 bxf
-bwu
-aab
-aab
-aab
-bKl
+ufB
+bxf
+bxf
+hvJ
+bwv
 bGR
 bLL
 bMB
@@ -50460,12 +50661,12 @@ azg
 aLc
 azg
 avK
-avl
-aab
-aab
-aab
-aRS
-aOf
+aRT
+nSA
+aSN
+wOX
+aSN
+hNa
 aTW
 aRS
 aab
@@ -50503,11 +50704,11 @@ aab
 bwu
 byj
 bxf
-bwu
-aab
-aab
-aab
-bKl
+cCM
+iJd
+nZE
+qea
+bwv
 vmo
 bLL
 bMB
@@ -50717,11 +50918,11 @@ avN
 avN
 avN
 avN
-avl
-avm
-avm
-avm
-aRS
+aRT
+uvz
+qAw
+wOX
+aSN
 aSN
 aTW
 aRS
@@ -50760,11 +50961,11 @@ aWn
 bwu
 bBJ
 bxf
-bwu
-bGQ
-bGQ
-bGQ
-bKl
+ufB
+ufB
+bwv
+bwv
+bwv
 bGU
 bGU
 bGU
@@ -50971,14 +51172,14 @@ aBV
 aBV
 aJG
 avN
-avK
-avK
+xFW
+pTF
 aMC
-avN
-axa
-awi
-avK
-aRT
+aRS
+aRS
+aRS
+aRS
+aOf
 aSN
 aTW
 aRT
@@ -51017,14 +51218,14 @@ aWo
 bwv
 bBJ
 bxf
+tuK
+vvI
 bwv
-bGR
-bIf
-bJA
+fLi
 bGU
-bKS
-bGR
-bGR
+bJB
+naL
+sHd
 bGU
 bMY
 bCb
@@ -51228,14 +51429,14 @@ aJJ
 aIt
 aJH
 avN
-azg
-azg
-aMD
-axE
-axb
-axb
-avL
-aRT
+axG
+axG
+oYc
+avm
+adO
+aab
+aRS
+lAs
 aSN
 aTW
 aRT
@@ -51273,15 +51474,15 @@ bRz
 aWp
 bwv
 bBJ
+iJd
 bxf
+reb
 bwv
-bGS
 naL
-bJB
-bKm
-bIO
-bLL
-bLL
+ovz
+naL
+naL
+naL
 bGU
 bKQ
 bOX
@@ -51485,15 +51686,15 @@ aBV
 aHe
 aBV
 avN
-azV
-azV
-aMD
-avN
-avM
-awk
-avM
-aRT
-aSN
+wBR
+axG
+oUh
+avm
+bHd
+aab
+aRS
+dEx
+hNa
 aTW
 aRT
 aWq
@@ -51531,14 +51732,14 @@ aWq
 bwv
 bBJ
 bxf
+bxf
+frU
 bwv
-bGT
-bIh
-bGT
+naL
 bGU
-bIO
-bMC
-bMC
+sHd
+bJB
+naL
 bGU
 bCb
 bNK
@@ -51740,16 +51941,16 @@ aBV
 aBV
 aBV
 aHe
-aJI
+aBV
 avN
-azg
-azg
+uua
+axG
 kin
-avN
-avN
-avN
-avN
-aRT
+avm
+adO
+aab
+aRS
+rfz
 aSN
 aTW
 aRT
@@ -51788,14 +51989,14 @@ aWr
 bwv
 bBJ
 bxf
+tuK
+bwv
 bwv
 bGU
 bGU
-bGU
-bGU
-bIT
-bLL
-bLL
+hre
+naL
+bJB
 bGU
 bOc
 bNK
@@ -51995,19 +52196,19 @@ avl
 avl
 avl
 avl
-aBV
+aJI
 aIw
 aBU
-aAN
-azi
-azi
+fUu
+axG
+axG
 aMF
-aNa
-avN
-aOX
-aQz
-aRT
+avl
+adO
+adO
+aRS
 qfo
+aSN
 aTW
 aRT
 aWs
@@ -52046,13 +52247,13 @@ bwv
 bBJ
 qxc
 bwv
-bGV
+bwv
 bIi
 bGU
-bKn
-bKV
-bLN
-bLN
+bJB
+naL
+bJB
+naL
 bNs
 bOd
 bPd
@@ -52259,11 +52460,11 @@ avN
 axG
 axG
 axG
-axG
-axc
-awm
-aQf
-aRT
+avl
+aab
+adO
+aRS
+sMg
 aSN
 aTW
 aRT
@@ -52281,10 +52482,10 @@ eaN
 bhC
 aWr
 aWr
-bga
-aZS
-bPw
-bga
+xRA
+aYR
+aYR
+bRj
 aWr
 aWr
 bhC
@@ -52301,15 +52502,15 @@ aWI
 btX
 bwv
 bBJ
-bxf
+iJd
 bwv
-bGW
-cvm
+dqM
+naL
 bVs
-bKo
-bKo
-bKo
-bKo
+naL
+bJB
+naL
+bJB
 bGU
 bCb
 bNL
@@ -52513,14 +52714,14 @@ aBV
 aHe
 aBV
 avN
-azW
-azj
-aym
-axH
-avN
-aOY
-aQB
-aRT
+axG
+axG
+rqR
+avl
+aab
+adO
+aRS
+rfz
 aSP
 aTZ
 aRT
@@ -52560,13 +52761,13 @@ bwv
 bDw
 bEV
 bwv
-bGX
+bIk
 bIk
 bGU
-bKp
-bKX
-bLO
-bMD
+naL
+iQO
+bGR
+iQO
 bGU
 bCb
 bNK
@@ -52770,13 +52971,13 @@ aBV
 aHe
 aBV
 avN
-avN
-avN
-avN
-avN
-avN
-avN
-avN
+hFK
+gnd
+gnd
+avl
+avm
+avm
+aRS
 aRT
 aRT
 aTX
@@ -54337,10 +54538,10 @@ pPu
 bhC
 aWr
 aWr
-bga
-aZS
-bPw
-bga
+ptw
+aYR
+aYR
+fDq
 aWr
 aWr
 bhC
@@ -100331,7 +100532,7 @@ aXp
 aXp
 aXp
 aXr
-bcC
+aFy
 bcC
 bcC
 bcC
@@ -100586,9 +100787,9 @@ aWj
 aXp
 aYE
 aZH
+aYI
 baz
 aXr
-aab
 aab
 aab
 adO
@@ -100613,15 +100814,15 @@ aab
 aab
 aab
 bzg
-bAD
+bHV
 bBG
-bCW
+bEK
 bEK
 bGb
 bBl
 bHV
 bJo
-bAD
+bAE
 bKL
 bLx
 bMs
@@ -100843,9 +101044,9 @@ aWk
 aXq
 aYF
 aZt
-baA
-aXr
-aab
+aYI
+wnT
+aXs
 aab
 pWB
 fuY
@@ -100873,7 +101074,7 @@ bzg
 bAE
 bBH
 bAE
-bAE
+bHV
 bGc
 bGH
 bHW
@@ -101099,10 +101300,10 @@ aVo
 aWl
 aXp
 aVf
-aZJ
+aZK
+eCN
 baA
-aXr
-adO
+aXs
 adO
 gcR
 obp
@@ -101129,9 +101330,9 @@ adO
 bzg
 bAD
 bAE
-bCX
 bAD
-bAE
+mPA
+bGd
 bAD
 bAD
 bIE
@@ -101351,15 +101552,15 @@ aNF
 aOT
 aRJ
 aOT
-aNF
-aNG
-aNF
-aXr
+aON
+aON
+aON
+aXp
 aTg
-aZK
+yiK
+aYI
 baB
-aXr
-aab
+aXs
 aab
 vsh
 obp
@@ -101384,15 +101585,15 @@ vsh
 aab
 aab
 bzg
-bAC
-bAE
-bAC
-bAC
-bGd
-bAC
-bAC
-bIE
-bAC
+bKL
+bKL
+bKL
+bKL
+bKL
+bKL
+bKL
+nzC
+bKL
 bKL
 bLA
 vBj
@@ -101607,16 +101808,16 @@ adO
 aab
 aNH
 aRK
-aNH
-aab
-aab
-aab
-aXs
+kNK
+aXp
+tgu
+wus
+aYI
 aYI
 aZL
 aYI
+baz
 aXr
-aab
 aab
 vsh
 obp
@@ -101642,14 +101843,14 @@ pWB
 pWB
 iAQ
 ghU
-bAF
-bAF
-bAF
-bAF
-bAF
-bAF
-bIH
-bAF
+lPZ
+bIe
+mfh
+bGe
+gok
+pzF
+bIJ
+pzF
 bAF
 bAF
 bAF
@@ -101864,17 +102065,17 @@ adO
 aab
 aNH
 aRK
-aNH
-aab
-aab
-aab
-aXr
-aYJ
+kNK
+aXp
+xKi
+uVo
 aYI
-baC
-aXr
-pWB
-pWB
+aYI
+uEg
+aYI
+lvG
+qqc
+lWq
 pWB
 obp
 bhv
@@ -101898,8 +102099,8 @@ vQq
 vQq
 vQq
 aXt
-bAG
-lPZ
+ghl
+bDa
 bCY
 bEL
 bGe
@@ -101908,7 +102109,7 @@ bDa
 bIJ
 bDa
 bDa
-bDa
+lAu
 nJI
 bDa
 tlV
@@ -102123,14 +102324,14 @@ aOT
 aRJ
 aOT
 aOT
-adO
-adO
 aXr
-aXp
-bkV
-aXp
+xKV
 aXr
-gcR
+qNy
+uEg
+aYI
+tGm
+dAe
 aXt
 obp
 bfS
@@ -102165,7 +102366,7 @@ bHY
 bJt
 bDa
 bDa
-bLD
+bDa
 bMw
 bNl
 bAF
@@ -102384,10 +102585,10 @@ aNH
 pWB
 qqc
 aYK
-aZN
-baD
-qqc
-pWB
+ksS
+ksS
+ksS
+xqK
 aXt
 beu
 vnS
@@ -102417,13 +102618,13 @@ sao
 sSf
 sSf
 irw
-bGg
+sSf
+bDa
+lAu
 bFN
-sgh
-bFN
-bFN
-bFN
-bFN
+bDa
+bLD
+bAF
 bNm
 bNm
 bNm
@@ -102674,13 +102875,13 @@ byu
 bDb
 bzi
 bzi
-ghl
+fGm
+bDa
 bFN
-bGK
 bId
-bJv
-bKO
-bFN
+bDa
+bLD
+bAF
 bNn
 bVt
 bOR
@@ -102895,7 +103096,7 @@ aRO
 aSJ
 aTQ
 aNH
-vsh
+iXj
 obp
 aYM
 aYM
@@ -102932,12 +103133,12 @@ bBj
 bAN
 bzi
 ghl
+bDa
 bFN
-bHZ
-bGL
-bJw
+lAu
+bDa
 bKO
-bFN
+bAF
 bNm
 bNm
 bOQ
@@ -103188,13 +103389,13 @@ bBM
 bDd
 bBQ
 bzi
-ghl
-bFN
-syz
-bKf
-bJw
-bKO
-bFN
+oeg
+jpw
+bId
+bDa
+bDa
+bMw
+bAF
 bNn
 bVt
 bOR
@@ -103445,13 +103646,13 @@ bBM
 bDe
 bDh
 bzi
-bAG
-bFN
-bIb
-bIa
-bJw
-bKO
-bFN
+ghl
+mfh
+bDa
+bDa
+lAu
+bNl
+bAF
 bNm
 bNm
 bOS
@@ -103702,13 +103903,13 @@ bBM
 bDf
 bEO
 bzi
-bAG
+ghl
 bGO
 bIc
 bIe
 bJy
-bKO
-bFN
+ics
+bAF
 bNn
 bVt
 bOR

--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -21982,8 +21982,10 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/store)
 "bpW" = (
-/obj/machinery/power/apc/drained,
-/obj/structure/cable,
+/obj/structure/table/reinforced,
+/obj/machinery/computer/security{
+	network = list("PRISON")
+	},
 /turf/open/floor/prison/darkred{
 	dir = 5
 	},
@@ -25231,6 +25233,7 @@
 	},
 /area/prison/security/checkpoint/hangar)
 "bAL" = (
+/obj/machinery/computer/prisoner,
 /turf/open/floor/prison/darkred{
 	dir = 1
 	},
@@ -25386,6 +25389,10 @@
 /area/prison/cellblock/lowsec/sw)
 "bBj" = (
 /obj/effect/decal/cleanable/blood,
+/obj/machinery/power/apc/drained{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/prison/darkred{
 	dir = 10
 	},
@@ -25576,7 +25583,6 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison/darkred{
 	dir = 4
@@ -25975,10 +25981,6 @@
 	dir = 1
 	},
 /area/prison/maintenance/hangar_barracks)
-"bDd" = (
-/obj/structure/bed/chair/office/dark,
-/turf/open/floor/prison/darkred,
-/area/prison/security/checkpoint/hangar)
 "bDe" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison/darkred,
@@ -25992,7 +25994,6 @@
 	},
 /area/prison/security/checkpoint/hangar)
 "bDh" = (
-/obj/machinery/computer/prisoner,
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/checkpoint/hangar)
 "bDi" = (
@@ -26595,6 +26596,7 @@
 /area/prison/security/checkpoint/hangar)
 "bEP" = (
 /obj/structure/table/reinforced,
+/obj/machinery/computer/secure_data,
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/checkpoint/hangar)
 "bEQ" = (
@@ -42200,6 +42202,12 @@
 	dir = 1
 	},
 /area/space)
+"jBM" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/prison/darkred/full,
+/area/prison/security/checkpoint/hangar)
 "jEP" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/prison,
@@ -43019,6 +43027,9 @@
 /obj/structure/flora/pottedplant/twentyone,
 /turf/open/floor/wood,
 /area/prison/residential/central)
+"puv" = (
+/turf/open/floor/prison,
+/area/prison/security/checkpoint/hangar)
 "pzF" = (
 /obj/structure/barricade/wooden{
 	icon_state = "wooden";
@@ -43098,6 +43109,13 @@
 	},
 /turf/open/floor/prison/kitchen,
 /area/prison/residential/north)
+"pUb" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/security{
+	network = list("PRISON")
+	},
+/turf/open/floor/prison/darkred/full,
+/area/prison/security/checkpoint/hangar)
 "pVt" = (
 /obj/structure/window/framed/prison/reinforced/hull,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
@@ -43712,6 +43730,10 @@
 	},
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/sw)
+"tNX" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/prison/darkred/full,
+/area/prison/security/checkpoint/hangar)
 "tPw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 8;
@@ -102864,11 +102886,11 @@ sBT
 yiF
 bmw
 bzi
-bzi
+bDb
 byu
 bDb
-bzi
-bzi
+bDb
+bDb
 fGm
 bDa
 bFN
@@ -103124,8 +103146,8 @@ bzi
 bAI
 byv
 bBj
-bAN
-bzi
+jBM
+bDb
 ghl
 bDa
 bFN
@@ -103380,9 +103402,9 @@ byi
 bzj
 bAJ
 bBM
-bDd
-bBQ
-bzi
+bDf
+tNX
+bDb
 oeg
 jpw
 bId
@@ -103636,10 +103658,10 @@ mSO
 bnQ
 bzi
 bAK
-bBM
+puv
 bDe
 bDh
-bzi
+bDb
 ghl
 mfh
 bDa
@@ -103893,10 +103915,10 @@ mSO
 bnQ
 bzk
 bAL
-bBM
+puv
 bDf
 bEO
-bzi
+bDb
 ghl
 bGO
 bIc
@@ -104408,8 +104430,8 @@ gSk
 bzi
 bAN
 bBQ
-bDh
 bEQ
+pUb
 bAO
 vsh
 aab

--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -41248,7 +41248,14 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
-/turf/closed/wall/r_wall/prison_unmeltable,
+/obj/machinery/power/apc/drained{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/carpet,
 /area/prison/command/quarters)
 "dBh" = (
 /obj/structure/window/framed/prison/reinforced,
@@ -42314,11 +42321,6 @@
 /obj/structure/mineral_door/resin,
 /turf/open/floor/prison/cleanmarked,
 /area/prison/yard)
-"ksS" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/obj/structure/cable,
-/turf/open/floor/carpet,
-/area/prison/command/quarters)
 "kva" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/landmark/start/job/xenomorph,
@@ -44210,14 +44212,6 @@
 	dir = 8
 	},
 /area/prison/security/monitoring/maxsec/panopticon)
-"xqK" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/obj/machinery/power/apc/drained{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/carpet,
-/area/prison/command/quarters)
 "xrp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
@@ -101816,7 +101810,7 @@ aYI
 aYI
 aZL
 aYI
-baz
+tGm
 aXr
 aab
 vsh
@@ -102329,8 +102323,8 @@ xKV
 aXr
 qNy
 uEg
-aYI
-tGm
+uEg
+uEg
 dAe
 aXt
 obp
@@ -102585,10 +102579,10 @@ aNH
 pWB
 qqc
 aYK
-ksS
-ksS
-ksS
-xqK
+aYK
+aYK
+aYK
+aYK
 aXt
 beu
 vnS


### PR DESCRIPTION
## About The Pull Request
This PR modifies the entry points of LZ1 and LZ2.

![dreammaker_2021-02-15_14-37-20](https://user-images.githubusercontent.com/17747087/107953660-b4de1780-6f9b-11eb-91a4-6d569d99f1d0.png)
![dreammaker_2021-02-15_14-37-24](https://user-images.githubusercontent.com/17747087/107953662-b60f4480-6f9b-11eb-843a-85b34f4c19a2.png)
![dreammaker_2021-02-15_14-37-29](https://user-images.githubusercontent.com/17747087/107953667-b7407180-6f9b-11eb-934b-b907494b5a9e.png)
![dreammaker_2021-02-15_14-37-32](https://user-images.githubusercontent.com/17747087/107953669-b7d90800-6f9b-11eb-97c6-623decb827f4.png)
![dreammaker_2021-02-15_14-37-36](https://user-images.githubusercontent.com/17747087/107953672-b90a3500-6f9b-11eb-9dea-86a6c5f37285.png)

Compare and contrast pictures with the [webmap](https://affectedarc07.github.io/SS13WebMap/TGMC/PrisonStation/)

## Why It's Good For The Game
As have been mentioned by people on the discord ~~(and kindadread who owes me a crash token after this)~~ the siege of prison stations LZ's at the moment is complete torture as you can only really siege the entrance as neither crushers nor boilers can effectively make use of their main abilities on any spots which isn't the front entrance, this plus the additional fact that any other breaching points other than the entrance are extreme choke holds which makes it practically impossible to make good use of them.

This PR will alleviate these issues via expanding the breaching points as to make xenos have more breathing room and make the crushers and boilers more able to effectively use their main abilities, which would also make sieges on prison station have a lot less brain-damage inducing properties and make the experience of sieging the LZ's more interesting/fun.

## Changelog
:cl: Vondiech
balance: The areas around LZ1 and LZ2 on Prison Station have been changed to make siege more viable and less painful for both sides involved.
/:cl: