### PR TITLE
Removes Survivor from the pickable jobs in Distress

### DIFF
--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -29,7 +29,6 @@
 		/datum/job/terragov/squad/smartgunner = 1,
 		/datum/job/terragov/squad/leader = 1,
 		/datum/job/terragov/squad/standard = -1,
-		/datum/job/survivor/rambo = 1,
 		/datum/job/xenomorph = 2,
 		/datum/job/xenomorph/queen = 1
 	)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes survivor job from being picked.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Survivors exploit xenos being afk while waiting for the round to start or young xenos overextending far from weeds, thinking survivors are worse than marines, to kill them in a semi-RNG fashion.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: removed survivor from pickable jobs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
