### PR TITLE
Synth job time fix

### DIFF
--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -772,7 +772,7 @@ Use your office fax machine to communicate with corporate headquarters or to acq
 			new_human.wear_id.paygrade = "Mk.I"
 		if(601 to 3000) // 10 to 50 hrs
 			new_human.wear_id.paygrade = "Mk.II"
-		if(3000 to INFINITY) // more than 50 hrs
+		if(3001 to INFINITY) // more than 50 hrs
 			new_human.wear_id.paygrade = "Mk.III"
 
 /datum/job/terragov/silicon/synthetic/radio_help_message(mob/M)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -238,10 +238,9 @@
 //gets paygrade from ID
 //paygrade is a user's actual rank, as defined on their ID.  size 1 returns an abbreviation, size 0 returns the full rank name, the third input is used to override what is returned if no paygrade is assigned.
 /mob/living/carbon/human/get_paygrade(size = 1)
-	if(species.show_paygrade)
-		var/obj/item/card/id/id = wear_id
-		if(istype(id))
-			return get_paygrades(id.paygrade, size, gender)
+	var/obj/item/card/id/id = wear_id
+	if(istype(id))
+		return get_paygrades(id.paygrade, size, gender)
 	return ""
 
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -31,7 +31,6 @@
 	var/list/speech_chance
 	var/has_fine_manipulation = TRUE // Can use small items.
 	var/insulated                 // Immune to electrocution and glass shards to the feet.
-	var/show_paygrade = FALSE
 	var/count_human = FALSE // Does this count as a human?
 
 	// Some species-specific gibbing data.
@@ -287,7 +286,6 @@
 	primitive = /mob/living/carbon/monkey
 	unarmed_type = /datum/unarmed_attack/punch
 	species_flags = HAS_SKIN_TONE|HAS_LIPS|HAS_UNDERWEAR
-	show_paygrade = TRUE
 	count_human = TRUE
 
 	screams = list(MALE = "male_scream", FEMALE = "female_scream")
@@ -483,7 +481,6 @@
 	default_language_holder = /datum/language_holder/moth
 	eyes = "blank_eyes"
 	speech_verb_override = "flutters"
-	show_paygrade = TRUE
 	count_human = TRUE
 
 	species_flags = HAS_LIPS|HAS_NO_HAIR
@@ -543,7 +540,6 @@
 	default_language_holder = /datum/language_holder/sectoid
 	eyes = "blank_eyes"
 	speech_verb_override = "transmits"
-	show_paygrade = TRUE
 	count_human = TRUE
 
 	species_flags = HAS_NO_HAIR|NO_BREATHE|NO_POISON|NO_PAIN|USES_ALIEN_WEAPONS|NO_DAMAGE_OVERLAY
@@ -684,7 +680,6 @@
 	deform = 'icons/mob/human_races/r_skeleton.dmi'
 	unarmed_type = /datum/unarmed_attack/punch
 	speech_verb_override = "rattles"
-	show_paygrade = TRUE
 	count_human = TRUE
 
 	species_flags = NO_BREATHE|NO_SCAN|NO_BLOOD|NO_POISON|NO_CHEM_METABOLIZATION|DETACHABLE_HEAD // Where we're going, we don't NEED underwear.


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes synth paygrade (Mk. I, II, III) not showing. Always shows paygrade. Showing the paygrade was disabled in generic species class and only enabled in some, **not** including synthetics. But even if that variable was false the default paygrade was still shown. Because it wasn't used anywhere else I've deleted it to default to always show the paygrade.

Other fix would be to add `show_paygrade = TRUE` to synthetic species, but as explained I think it's better to remove that variable.

Fixes #6051 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bug fix and code simplification.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: synthetics' paygrade now displays properly
code: remove /datum/species/show_paygrade
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
