### PR TITLE
Weapon toggles QoL changes

### DIFF
--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -449,7 +449,6 @@ should be alright.
 
 
 /obj/item/weapon/gun/verb/field_strip()
-	set category = null
 	set name = "Field Strip (Weapon)"
 	set desc = "Remove all attachables from a weapon."
 
@@ -559,7 +558,6 @@ should be alright.
 
 
 /obj/item/weapon/gun/verb/toggle_autofire()
-	set category = null
 	set name = "Toggle Auto Fire (Weapon)"
 	set desc = "Toggle automatic firemode, if the gun has it."
 
@@ -591,7 +589,6 @@ should be alright.
 
 
 /obj/item/weapon/gun/verb/toggle_burstfire()
-	set category = null
 	set name = "Toggle Burst Fire (Weapon)"
 	set desc = "Toggle burst firemode, if the gun has it."
 
@@ -623,7 +620,6 @@ should be alright.
 
 
 /obj/item/weapon/gun/verb/toggle_firemode()
-	set category = null
 	set name = "Toggle Fire Mode (Weapon)"
 	set desc = "Toggle between fire modes, if the gun has more than has one."
 
@@ -738,7 +734,6 @@ should be alright.
 
 
 /obj/item/weapon/gun/verb/empty_mag()
-	set category = null
 	set name = "Unload Weapon (Weapon)"
 	set desc = "Removes the magazine from your current gun and drops it on the ground, or clears the chamber if your gun is already empty."
 
@@ -757,7 +752,6 @@ should be alright.
 
 
 /obj/item/weapon/gun/verb/use_unique_action()
-	set category = null
 	set name = "Unique Action (Weapon)"
 	set desc = "Use anything unique your firearm is capable of. Includes pumping a shotgun or spinning a revolver."
 
@@ -776,7 +770,6 @@ should be alright.
 
 
 /obj/item/weapon/gun/verb/toggle_gun_safety()
-	set category = null
 	set name = "Toggle Gun Safety (Weapon)"
 	set desc = "Toggle the safety of the held gun."
 
@@ -797,7 +790,6 @@ should be alright.
 
 
 /obj/item/weapon/gun/verb/activate_attachment_verb()
-	set category = null
 	set name = "Load From Attachment (Weapon)"
 	set desc = "Load from a gun attachment, such as a mounted grenade launcher, shotgun, or flamethrower."
 
@@ -837,7 +829,6 @@ should be alright.
 	G.toggle_rail_attachment()
 
 /obj/item/weapon/gun/verb/toggle_rail_attachment()
-	set category = null
 	set name = "Toggle Rail Attachment (Weapon)"
 	set desc = "Uses the rail attachement currently attached to the gun."
 
@@ -858,7 +849,6 @@ should be alright.
 
 
 /obj/item/weapon/gun/verb/toggle_ammo_hud()
-	set category = null
 	set name = "Toggle Ammo HUD (Weapon)"
 	set desc = "Toggles the Ammo HUD for this weapon."
 

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -442,7 +442,10 @@ should be alright.
 	set name = "Field Strip Weapon"
 	set desc = "Remove all attachables from a weapon."
 
-	get_active_firearm(usr)?.field_strip()
+	var/obj/item/weapon/gun/G = get_active_firearm(usr)
+	if(!G)
+		return
+	G.field_strip()
 
 
 /obj/item/weapon/gun/verb/field_strip()
@@ -549,7 +552,10 @@ should be alright.
 	set name = "Toggle Auto Fire"
 	set desc = "Toggle automatic firemode, if the gun has it."
 
-	get_active_firearm(usr)?.toggle_autofire()
+	var/obj/item/weapon/gun/G = get_active_firearm(usr)
+	if(!G)
+		return
+	G.toggle_autofire()
 
 
 /obj/item/weapon/gun/verb/toggle_autofire()
@@ -578,7 +584,10 @@ should be alright.
 	set name = "Toggle Burst Fire"
 	set desc = "Toggle burst firemode, if the gun has it."
 
-	get_active_firearm(usr)?.toggle_burstfire()
+	var/obj/item/weapon/gun/G = get_active_firearm(usr)
+	if(!G)
+		return
+	G.toggle_burstfire()
 
 
 /obj/item/weapon/gun/verb/toggle_burstfire()
@@ -607,7 +616,10 @@ should be alright.
 	set name = "Toggle Fire Mode"
 	set desc = "Toggle between fire modes, if the gun has more than has one."
 
-	get_active_firearm(usr)?.toggle_firemode()
+	var/obj/item/weapon/gun/G = get_active_firearm(usr)
+	if(!G)
+		return
+	G.toggle_firemode()
 
 
 /obj/item/weapon/gun/verb/toggle_firemode()
@@ -719,7 +731,10 @@ should be alright.
 	set name = "Unload Weapon"
 	set desc = "Removes the magazine from your current gun and drops it on the ground, or clears the chamber if your gun is already empty."
 
-	get_active_firearm(usr)?.empty_mag()
+	var/obj/item/weapon/gun/G = get_active_firearm(usr)
+	if(!G)
+		return
+	G.empty_mag()
 
 
 /obj/item/weapon/gun/verb/empty_mag()
@@ -735,7 +750,10 @@ should be alright.
 	set name = "Unique Action"
 	set desc = "Use anything unique your firearm is capable of. Includes pumping a shotgun or spinning a revolver."
 
-	get_active_firearm(usr)?.use_unique_action()
+	var/obj/item/weapon/gun/G = get_active_firearm(usr)
+	if(!G)
+		return
+	G.use_unique_action()
 
 
 /obj/item/weapon/gun/verb/use_unique_action()
@@ -751,7 +769,10 @@ should be alright.
 	set name = "Toggle Gun Safety"
 	set desc = "Toggle the safety of the held gun."
 
-	get_active_firearm(usr)?.toggle_gun_safety()
+	var/obj/item/weapon/gun/G = get_active_firearm(usr)
+	if(!G)
+		return
+	G.toggle_gun_safety()
 
 
 /obj/item/weapon/gun/verb/toggle_gun_safety()
@@ -769,7 +790,10 @@ should be alright.
 	set name = "Load From Attachment"
 	set desc = "Load from a gun attachment, such as a mounted grenade launcher, shotgun, or flamethrower."
 
-	get_active_firearm(usr)?.activate_attachment_verb()
+	var/obj/item/weapon/gun/G = get_active_firearm(usr)
+	if(!G)
+		return
+	G.activate_attachment_verb()
 
 
 /obj/item/weapon/gun/verb/activate_attachment_verb()
@@ -807,7 +831,10 @@ should be alright.
 	set name = "Toggle Rail Attachment"
 	set desc = "Uses the rail attachement currently attached to the gun."
 
-	get_active_firearm(usr)?.toggle_rail_attachment()
+	var/obj/item/weapon/gun/G = get_active_firearm(usr)
+	if(!G)
+		return
+	G.toggle_rail_attachment()
 
 /obj/item/weapon/gun/verb/toggle_rail_attachment()
 	set category = null
@@ -824,7 +851,10 @@ should be alright.
 	set name = "Toggle Ammo HUD"
 	set desc = "Toggles the Ammo HUD for this weapon."
 
-	get_active_firearm(usr)?.toggle_ammo_hud()
+	var/obj/item/weapon/gun/G = get_active_firearm(usr)
+	if(!G)
+		return
+	G.toggle_ammo_hud()
 
 
 /obj/item/weapon/gun/verb/toggle_ammo_hud()

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -437,15 +437,18 @@ should be alright.
 					//				   \\
 //----------------------------------------------------------
 
-/obj/item/weapon/gun/verb/field_strip()
+/mob/living/carbon/human/verb/field_strip()
 	set category = "Weapons"
 	set name = "Field Strip Weapon"
 	set desc = "Remove all attachables from a weapon."
 
-	var/obj/item/weapon/gun/G = get_active_firearm(usr)
+	get_active_firearm(usr)?.field_strip()
 
-	if(!G)
-		return
+
+/obj/item/weapon/gun/verb/field_strip()
+	set category = null
+	set name = "Field Strip (Weapon)"
+	set desc = "Remove all attachables from a weapon."
 
 	if(usr.do_actions)
 		return
@@ -454,7 +457,7 @@ should be alright.
 		to_chat(usr, "<span class='warning'>You cannot conceviably do that while looking down \the [src]'s scope!</span>")
 		return
 
-	if(G.overcharge == TRUE)
+	if(src.overcharge)
 		to_chat(usr, "[icon2html(src, usr)] You need to disable overcharge mode to remove attachments.")
 		return
 
@@ -481,7 +484,7 @@ should be alright.
 	if(possible_attachments.len == 1)
 		A = possible_attachments[1]
 	else
-		A = tgui_input_list(usr, "Which attachment to remove?", null,possible_attachments)
+		A = tgui_input_list(usr, "Which attachment to remove?", null, possible_attachments)
 
 	if(!A)
 		return
@@ -541,19 +544,19 @@ should be alright.
 	user.update_action_buttons()
 
 
-/obj/item/weapon/gun/verb/toggle_autofire()
+/mob/living/carbon/human/verb/toggle_autofire()
 	set category = "Weapons"
 	set name = "Toggle Auto Fire"
 	set desc = "Toggle automatic firemode, if the gun has it."
-	set src = usr.contents
 
-	var/obj/item/weapon/gun/automatic_gun = get_active_firearm(usr)
-	if(!automatic_gun)
-		return
-	automatic_gun.do_toggle_automatic(usr)
+	get_active_firearm(usr)?.toggle_autofire()
 
 
-/obj/item/weapon/gun/proc/do_toggle_automatic(mob/user)
+/obj/item/weapon/gun/verb/toggle_autofire()
+	set category = null
+	set name = "Toggle Auto Fire (Weapon)"
+	set desc = "Toggle automatic firemode, if the gun has it."
+
 	var/new_firemode
 	switch(gun_firemode)
 		if(GUN_FIREMODE_SEMIAUTO)
@@ -565,24 +568,24 @@ should be alright.
 		if(GUN_FIREMODE_AUTOBURST)
 			new_firemode = GUN_FIREMODE_BURSTFIRE
 	if(!(new_firemode in gun_firemode_list))
-		to_chat(user, "<span class='warning'>[src] lacks a [new_firemode]!</span>")
+		to_chat(usr, "<span class='warning'>[src] lacks a [new_firemode]!</span>")
 		return
-	do_toggle_firemode(user, new_firemode)
+	do_toggle_firemode(usr, new_firemode)
 
 
-/obj/item/weapon/gun/verb/toggle_burstfire()
+/mob/living/carbon/human/verb/toggle_burstfire()
 	set category = "Weapons"
 	set name = "Toggle Burst Fire"
 	set desc = "Toggle burst firemode, if the gun has it."
-	set src = usr.contents
 
-	var/obj/item/weapon/gun/automatic_gun = get_active_firearm(usr)
-	if(!automatic_gun)
-		return
-	automatic_gun.do_toggle_burst(usr)
+	get_active_firearm(usr)?.toggle_burstfire()
 
 
-/obj/item/weapon/gun/proc/do_toggle_burst(mob/user)
+/obj/item/weapon/gun/verb/toggle_burstfire()
+	set category = null
+	set name = "Toggle Burst Fire (Weapon)"
+	set desc = "Toggle burst firemode, if the gun has it."
+
 	var/new_firemode
 	switch(gun_firemode)
 		if(GUN_FIREMODE_SEMIAUTO)
@@ -594,21 +597,25 @@ should be alright.
 		if(GUN_FIREMODE_AUTOBURST)
 			new_firemode = GUN_FIREMODE_AUTOMATIC
 	if(!(new_firemode in gun_firemode_list))
-		to_chat(user, "<span class='warning'>[src] lacks a [new_firemode]!</span>")
+		to_chat(usr, "<span class='warning'>[src] lacks a [new_firemode]!</span>")
 		return
-	do_toggle_firemode(user, new_firemode)
+	do_toggle_firemode(usr, new_firemode)
 
 
-/obj/item/weapon/gun/verb/toggle_firemode()
+/mob/living/carbon/human/verb/toggle_firemode()
 	set category = "Weapons"
 	set name = "Toggle Fire Mode"
 	set desc = "Toggle between fire modes, if the gun has more than has one."
-	set src = usr.contents
 
-	var/obj/item/weapon/gun/G = get_active_firearm(usr)
-	if(!G)
-		return
-	G.do_toggle_firemode(usr)
+	get_active_firearm(usr)?.toggle_firemode()
+
+
+/obj/item/weapon/gun/verb/toggle_firemode()
+	set category = null
+	set name = "Toggle Fire Mode (Weapon)"
+	set desc = "Toggle between fire modes, if the gun has more than has one."
+
+	do_toggle_firemode(usr)
 
 
 /obj/item/weapon/gun/proc/do_toggle_firemode(mob/user, new_firemode)
@@ -707,55 +714,70 @@ should be alright.
 	ammo_diff = initial(ammo_diff)
 
 
-/obj/item/weapon/gun/verb/empty_mag()
+/mob/living/carbon/human/verb/empty_mag()
 	set category = "Weapons"
 	set name = "Unload Weapon"
 	set desc = "Removes the magazine from your current gun and drops it on the ground, or clears the chamber if your gun is already empty."
 
-	var/obj/item/weapon/gun/G = get_active_firearm(usr)
-	if(!G)
-		return
+	get_active_firearm(usr)?.empty_mag()
+
+
+/obj/item/weapon/gun/verb/empty_mag()
+	set category = null
+	set name = "Unload Weapon (Weapon)"
+	set desc = "Removes the magazine from your current gun and drops it on the ground, or clears the chamber if your gun is already empty."
 
 	unload(usr,,1) //We want to drop the mag on the ground.
 
-/obj/item/weapon/gun/verb/use_unique_action()
+
+/mob/living/carbon/human/verb/use_unique_action()
 	set category = "Weapons"
 	set name = "Unique Action"
 	set desc = "Use anything unique your firearm is capable of. Includes pumping a shotgun or spinning a revolver."
 
-	var/obj/item/weapon/gun/G = get_active_firearm(usr)
-	if(!G)
-		return
+	get_active_firearm(usr)?.use_unique_action()
+
+
+/obj/item/weapon/gun/verb/use_unique_action()
+	set category = null
+	set name = "Unique Action (Weapon)"
+	set desc = "Use anything unique your firearm is capable of. Includes pumping a shotgun or spinning a revolver."
 
 	unique_action(usr)
 
 
-/obj/item/weapon/gun/verb/toggle_gun_safety()
+/mob/living/carbon/human/verb/toggle_gun_safety()
 	set category = "Weapons"
 	set name = "Toggle Gun Safety"
 	set desc = "Toggle the safety of the held gun."
 
-	var/obj/item/weapon/gun/G = get_active_firearm(usr)
-	if(!G)
-		return
+	get_active_firearm(usr)?.toggle_gun_safety()
+
+
+/obj/item/weapon/gun/verb/toggle_gun_safety()
+	set category = null
+	set name = "Toggle Gun Safety (Weapon)"
+	set desc = "Toggle the safety of the held gun."
 
 	to_chat(usr, "<span class='notice'>You toggle the safety [flags_gun_features & GUN_TRIGGER_SAFETY ? "<b>off</b>" : "<b>on</b>"].</span>")
 	playsound(usr, 'sound/weapons/guns/interact/selector.ogg', 15, 1)
 	flags_gun_features ^= GUN_TRIGGER_SAFETY
 
 
-/obj/item/weapon/gun/verb/activate_attachment_verb()
+/mob/living/carbon/human/verb/activate_attachment_verb()
 	set category = "Weapons"
 	set name = "Load From Attachment"
 	set desc = "Load from a gun attachment, such as a mounted grenade launcher, shotgun, or flamethrower."
 
-	var/obj/item/weapon/gun/G = get_active_firearm(usr)
-	if(!G)
-		return
+	get_active_firearm(usr)?.activate_attachment_verb()
 
-	var/obj/item/attachable/A
 
-	var/list/usable_attachments = list() //Basic list of attachments to compare later.
+/obj/item/weapon/gun/verb/activate_attachment_verb()
+	set category = null
+	set name = "Load From Attachment (Weapon)"
+	set desc = "Load from a gun attachment, such as a mounted grenade launcher, shotgun, or flamethrower."
+
+	var/list/usable_attachments = list()
 // rail attachment use the button to toggle flashlight instead.
 //	if(rail && (rail.flags_attach_features & ATTACH_ACTIVATION) )
 //		usable_attachments += rail
@@ -769,42 +791,46 @@ should be alright.
 	if(!usable_attachments.len) //No usable attachments.
 		to_chat(usr, "<span class='warning'>[src] does not have any usable attachment!</span>")
 		return
-
-	if(usable_attachments.len == 1) //Activates the only attachment if there is only one.
+	var/obj/item/attachable/A
+	if(usable_attachments.len == 1)
 		A = usable_attachments[1]
 	else
-		A = input("Which attachment to activate?") as null|anything in usable_attachments
-		if(!A || A.loc != src)
-			return
-	if(A)
-		A.ui_action_click(usr, null, src)
+		A = tgui_input_list(usr, "Which attachment to activate?", null, usable_attachments)
+
+	if(!A)
+		return
+	A.ui_action_click(usr, null, src)
 
 
-/obj/item/weapon/gun/verb/toggle_rail_attachment()
+/mob/living/carbon/human/verb/toggle_rail_attachment()
 	set category = "Weapons"
 	set name = "Toggle Rail Attachment"
 	set desc = "Uses the rail attachement currently attached to the gun."
-	set src = usr.contents
 
-	var/obj/item/weapon/gun/G = get_active_firearm(usr)
-	if(!G)
-		return
+	get_active_firearm(usr)?.toggle_rail_attachment()
 
-	if(!G.rail)
+/obj/item/weapon/gun/verb/toggle_rail_attachment()
+	set category = null
+	set name = "Toggle Rail Attachment (Weapon)"
+	set desc = "Uses the rail attachement currently attached to the gun."
+
+	if(!src.rail)
 		to_chat(usr, "<span class='warning'>[src] does not have any usable rail attachment!</span>")
 		return
+	src.rail.activate_attachment(usr)
 
-	G.rail.activate_attachment(usr)
-
-
-/obj/item/weapon/gun/verb/toggle_ammo_hud()
+/mob/living/carbon/human/verb/toggle_ammo_hud()
 	set category = "Weapons"
 	set name = "Toggle Ammo HUD"
 	set desc = "Toggles the Ammo HUD for this weapon."
 
-	var/obj/item/weapon/gun/G = get_active_firearm(usr)
-	if(!G)
-		return
+	get_active_firearm(usr)?.toggle_ammo_hud()
+
+
+/obj/item/weapon/gun/verb/toggle_ammo_hud()
+	set category = null
+	set name = "Toggle Ammo HUD (Weapon)"
+	set desc = "Toggles the Ammo HUD for this weapon."
 
 	hud_enabled = !hud_enabled
 	var/obj/screen/ammo/A = usr.hud_used.ammo

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -459,7 +459,7 @@ should be alright.
 		to_chat(usr, "<span class='warning'>You cannot conceviably do that while looking down \the [src]'s scope!</span>")
 		return
 
-	if(src.overcharge)
+	if(overcharge)
 		to_chat(usr, "[icon2html(src, usr)] You need to disable overcharge mode to remove attachments.")
 		return
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Weapon toggles (field strip, toggle fire mode, eject mag etc) were implemented as verbs for `/obj/item/weapon/gun`, which leads to issues when you have more than one gun equipped (see #6049). I've added similar verbs for `/mob/living/carbon/human` which pick the active firearm (the one in your current hand or if it's empty in the other hand). This doesn't affect gun in inventory slot, because you wouldn't be able to do anything with it because of later checks, while the old verbs allow you to select it. I've left the verbs for guns so they are still in right click menu. I had to add "(Weapon)" because otherwise both usage tips show in Weapons category tab. I've also simplified the code a bit.

Fixes #6049

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The game no longer asks you to choose which weapon to toggle when you have one in hand and one in suit slot (picks in hand), or when you have a weapon in each hand (picks in active hand).

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: weapon toggle verbs that prioritize current gun
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
