### PR TITLE
Removes melee_accuracy mob var

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -156,7 +156,7 @@
 	if(!force)
 		return FALSE
 
-	if(M != user && !prob(user.melee_accuracy)) // Attacking yourself can't miss
+	if(M != user) // Attacking yourself can't miss
 		user.do_attack_animation(M)
 		playsound(loc, 'sound/weapons/punchmiss.ogg', 25, TRUE)
 		if(user in viewers(COMBAT_MESSAGE_RANGE, M))

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -86,7 +86,7 @@
 			if(!attack.is_usable(H))
 				return FALSE
 
-			if(!H.melee_damage || !prob(H.melee_accuracy))
+			if(!H.melee_damage)
 				H.do_attack_animation(src)
 				playsound(loc, attack.miss_sound, 25, TRUE)
 				visible_message("<span class='danger'>[H] tried to [pick(attack.attack_verb)] [src]!</span>", null, null, 5)

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -26,12 +26,6 @@
 
 
 /mob/living/proc/attack_alien_disarm(mob/living/carbon/xenomorph/X, dam_bonus)
-	if(!prob(X.melee_accuracy))
-		X.do_attack_animation(src)
-		playsound(loc, 'sound/weapons/slashmiss.ogg', 25, TRUE)
-		X.visible_message("<span class='danger'>\The [X] shoves at [src], narroly missing!</span>",
-		"<span class='danger'>Our tackle against [src] narroly misses!</span>")
-		return FALSE
 	SEND_SIGNAL(src, COMSIG_LIVING_MELEE_ALIEN_DISARMED, X)
 	X.do_attack_animation(src, ATTACK_EFFECT_DISARM2)
 	playsound(loc, 'sound/weapons/alien_knockdown.ogg', 25, TRUE)
@@ -96,12 +90,6 @@
 
 /mob/living/proc/attack_alien_harm(mob/living/carbon/xenomorph/X, dam_bonus, set_location = FALSE, random_location = FALSE, no_head = FALSE, no_crit = FALSE, force_intent = null)
 	if(!can_xeno_slash(X))
-		return FALSE
-
-	if(!prob(X.melee_accuracy))
-		playsound(loc, 'sound/weapons/slashmiss.ogg', 25, TRUE)
-		X.visible_message("<span class='danger'>\The [X] slashes at [src], narroly missing!</span>",
-		"<span class='danger'>Our slash against [src] narroly misses!</span>")
 		return FALSE
 
 	var/damage = X.xeno_caste.melee_damage

--- a/code/modules/mob/living/carbon/xenomorph/xenoattacks.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoattacks.dm
@@ -72,7 +72,7 @@
 			if(!attack.is_usable(H))
 				return FALSE
 
-			if(!H.melee_damage || !prob(H.melee_accuracy))
+			if(!H.melee_damage)
 				H.do_attack_animation(src)
 				playsound(loc, attack.miss_sound, 25, TRUE)
 				visible_message("<span class='danger'>[H] tried to [pick(attack.attack_verb)] [src]!</span>", null, null, 5)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -63,7 +63,6 @@
 	var/cameraFollow
 
 	var/melee_damage = 0
-	var/melee_accuracy = 100
 	var/attacktext = "attacks"
 	var/attack_sound
 	var/friendly = "nuzzles"

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -203,9 +203,6 @@
 
 		if(INTENT_HARM, INTENT_DISARM)
 			user.do_attack_animation(src)
-			if(!prob(user.melee_accuracy))
-				user.visible_message("<span class='danger'>[user] misses [src]!</span>", null, null, 5)
-				return FALSE
 			user.do_attack_animation(src, ATTACK_EFFECT_KICK)
 			visible_message("<span class='danger'>[user] [response_harm] [src]!</span>",
 			"<span class='userdanger'>[user] [response_harm] [src]!</span>")

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -381,16 +381,6 @@
 		if(MOVE_INTENT_RUN)
 			add_movespeed_modifier(MOVESPEED_ID_MOB_WALK_RUN_CONFIG_SPEED, TRUE, 100, NONE, TRUE, 3 + CONFIG_GET(number/movedelay/run_delay))
 
-
-/mob/living/carbon/human/update_move_intent_effects()
-	. = ..()
-	switch(m_intent)
-		if(MOVE_INTENT_WALK)
-			melee_accuracy = initial(melee_accuracy)
-		if(MOVE_INTENT_RUN)
-			melee_accuracy = 80
-
-
 /mob/proc/cadecheck()
 	var/list/coords = list(list(x + 1, y, z), list(x, y + 1, z), list(x - 1, y, z), list(x, y - 1, z))
 	for(var/i in coords)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes melee_accuracy mob var from code. Code-wise xenos have effects for when they fail the melee accuracy check, but it is always at 100%. For marines, it is only changed to 80% when they run and doesn't present engaging choices to make regarding it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Marines don't have a 20% chance to fail a melee attack because they toggled the run intent, which makes melee consistent and removes unclear interactions.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed 20% chance to miss melee attack when running
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
