### PR TITLE
Autolath requires raw mats to work

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -225,3 +225,8 @@
 // Xeno hives
 #define isnormalhive(hive) (istype(hive, /datum/hive_status/normal))
 #define isxenohive(A) ((A == XENO_HIVE_NONE) || (A == XENO_HIVE_NORMAL) || (A == XENO_HIVE_CORRUPTED) || (A == XENO_HIVE_ALPHA) || (A == XENO_HIVE_BETA) || (A == XENO_HIVE_ZETA) || (A == XENO_HIVE_ADMEME))
+
+// Autolath
+
+#define ismatsheet(A) (istype(A, /obj/item/stack/sheet/metal) || istype(A, /obj/item/stack/sheet/glass))
+

--- a/code/game/objects/machinery/autolathe.dm
+++ b/code/game/objects/machinery/autolathe.dm
@@ -140,12 +140,9 @@
 
 	//Resources are being loaded.
 	var/obj/item/eating = I
-	if(!eating.materials)
-		to_chat(user, "<span class='warning'>\The [eating] does not contain significant amounts of useful materials and cannot be accepted.</span>")
-		return
 
-	if(eating.flags_item & (NODROP|DELONDROP))
-		to_chat(user, "<span class='warning'>\The [eating] is stuck to you and cannot be placed into [src].</span>")
+	if(!ismatsheet(eating))
+		to_chat(user, "<span class='warning'>\The [src] needs raw materials!</span>")
 		return
 
 	var/filltype = 0       // Used to determine message.

--- a/code/game/objects/machinery/autolathe.dm
+++ b/code/game/objects/machinery/autolathe.dm
@@ -8,7 +8,7 @@
 	idle_power_usage = 10
 	active_power_usage = 2000
 
-	var/list/stored_material =  list(/datum/material/metal = 0, /datum/material/glass = 0)
+	var/list/stored_material =  list(/datum/material/metal = 150000, /datum/material/glass = 75000)
 	var/list/storage_capacity = list(/datum/material/metal = 0, /datum/material/glass = 0)
 	var/show_category = "All"
 
@@ -269,8 +269,8 @@
 	for(var/obj/item/stock_parts/matter_bin/MB in component_parts)
 		tot_rating += MB.rating
 
-	storage_capacity[/datum/material/metal] = tot_rating  * 25000
-	storage_capacity[/datum/material/glass] = tot_rating  * 12500
+	storage_capacity[/datum/material/metal] = tot_rating  * 50000
+	storage_capacity[/datum/material/glass] = tot_rating  * 25000
 
 /obj/machinery/autolathe/deconstruct()
 	var/list/sheets = list(/datum/material/metal = /obj/item/stack/sheet/metal, /datum/material/glass = /obj/item/stack/sheet/glass)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Autolath now requires sheets of metal and glass. It also starts full

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

No more GL grinding. This was nothing but bug abuse, and on top of that it was extremly boring. Better have cheaper metal for engie at start or lower the price in req. This is meant to go with https://github.com/tgstation/TerraGov-Marine-Corps/pull/6099

## Changelog
:cl:
tweak: Autolath can now longer grind objects to have free mats
tweak: Autolath has double the capacity for mats, and starts full
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
