### PR TITLE
Guns Rattle When Low Ammo

### DIFF
--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -28,7 +28,8 @@
 	///State for a fire animation if the gun has any
 	var/fire_animation = null
 	var/fire_sound 		= 'sound/weapons/guns/fire/gunshot.ogg'
-	var/fire_rattle		= null ///Does our gun have a unique empty mag sound? If so use instead of pitch shifting.
+	///Does our gun have a unique empty mag sound? If so use instead of pitch shifting.
+	var/fire_rattle		= null
 	var/dry_fire_sound	= 'sound/weapons/guns/fire/empty.ogg'
 	var/unload_sound 	= 'sound/weapons/flipblade.ogg'
 	var/empty_sound 	= 'sound/weapons/guns/misc/empty_alarm.ogg'

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -875,7 +875,6 @@ and you're good to go.
 		playsound(user, fire_rattle, 60, FALSE)
 		return
 	playsound(user, fire_sound, 60, firing_sndfreq ? TRUE : FALSE, frequency = firing_sndfreq)
-	return
 
 
 /obj/item/weapon/gun/proc/apply_gun_modifiers(obj/projectile/projectile_to_fire, atom/target)

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -870,7 +870,7 @@ and you're good to go.
 	if(flags_gun_features & GUN_SILENCED)
 		playsound(user, fire_sound, 25, TRUE, frequency = firing_sndfreq)
 		return
-    if(fire_rattle)
+	if(fire_rattle)
 		playsound(user, fire_rattle, 60, FALSE)
 		return
 	playsound(user, fire_sound, 60, firing_sndfreq ? TRUE : FALSE, frequency = firing_sndfreq)

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -28,6 +28,7 @@
 	///State for a fire animation if the gun has any
 	var/fire_animation = null
 	var/fire_sound 		= 'sound/weapons/guns/fire/gunshot.ogg'
+	var/fire_rattle		= null //Does our gun have a unique empty mag sound? If so use instead of pitch shifting.
 	var/dry_fire_sound	= 'sound/weapons/guns/fire/empty.ogg'
 	var/unload_sound 	= 'sound/weapons/flipblade.ogg'
 	var/empty_sound 	= 'sound/weapons/guns/misc/empty_alarm.ogg'
@@ -860,14 +861,20 @@ and you're good to go.
 
 
 /obj/item/weapon/gun/proc/play_fire_sound(mob/user)
+	//Guns with low ammo have their firing sound
+	var/firing_sndfreq = ((current_mag?.current_rounds / current_mag?.max_rounds) > 0.25) ? FALSE : 55000
 	if(active_attachable && active_attachable.flags_attach_features & ATTACH_PROJECTILE)
 		if(active_attachable.fire_sound) //If we're firing from an attachment, use that noise instead.
 			playsound(user, active_attachable.fire_sound, 50)
 		return
-	if(flags_gun_features & GUN_SILENCED)
-		playsound(user, fire_sound, 25)
-		return
-	playsound(user, fire_sound, 60)
+	if(!(flags_gun_features & GUN_SILENCED))
+		if (firing_sndfreq && fire_rattle)
+			playsound(user, fire_rattle, 60, FALSE)//if the gun has a unique 'mag rattle' SFX play that instead of pitch shifting.
+		else
+			playsound(user, fire_sound, 60, TRUE, frequency = firing_sndfreq)
+	else
+		playsound(user, fire_sound, 25, TRUE, frequency = firing_sndfreq)
+	return 1
 
 
 /obj/item/weapon/gun/proc/apply_gun_modifiers(obj/projectile/projectile_to_fire, atom/target)

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -868,7 +868,7 @@ and you're good to go.
 			playsound(user, active_attachable.fire_sound, 50)
 		return
 	if(flags_gun_features & GUN_SILENCED)
-		playsound(user, fire_sound, 25, TRUE, frequency = firing_sndfreq)
+		playsound(user, fire_sound, 25, firing_sndfreq ? TRUE : FALSE, frequency = firing_sndfreq)
 		return
 	if(fire_rattle)
 		playsound(user, fire_rattle, 60, FALSE)

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -867,14 +867,14 @@ and you're good to go.
 		if(active_attachable.fire_sound) //If we're firing from an attachment, use that noise instead.
 			playsound(user, active_attachable.fire_sound, 50)
 		return
-	if(!(flags_gun_features & GUN_SILENCED))
-		if (firing_sndfreq && fire_rattle)
-			playsound(user, fire_rattle, 60, FALSE)//if the gun has a unique 'mag rattle' SFX play that instead of pitch shifting.
-		else
-			playsound(user, fire_sound, 60, TRUE, frequency = firing_sndfreq)
-	else
+	if(flags_gun_features & GUN_SILENCED)
 		playsound(user, fire_sound, 25, TRUE, frequency = firing_sndfreq)
-	return 1
+		return
+    if(fire_rattle)
+		playsound(user, fire_rattle, 60, FALSE)
+		return
+	playsound(user, fire_sound, 60, firing_sndfreq ? TRUE : FALSE, frequency = firing_sndfreq)
+	return
 
 
 /obj/item/weapon/gun/proc/apply_gun_modifiers(obj/projectile/projectile_to_fire, atom/target)

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -28,7 +28,7 @@
 	///State for a fire animation if the gun has any
 	var/fire_animation = null
 	var/fire_sound 		= 'sound/weapons/guns/fire/gunshot.ogg'
-	var/fire_rattle		= null //Does our gun have a unique empty mag sound? If so use instead of pitch shifting.
+	var/fire_rattle		= null ///Does our gun have a unique empty mag sound? If so use instead of pitch shifting.
 	var/dry_fire_sound	= 'sound/weapons/guns/fire/empty.ogg'
 	var/unload_sound 	= 'sound/weapons/flipblade.ogg'
 	var/empty_sound 	= 'sound/weapons/guns/misc/empty_alarm.ogg'

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -73,6 +73,17 @@
 	else
 		return FLOOR(cell.charge / max(charge_cost, 1),1)
 
+// energy guns, however, do not use gun rattles.
+/obj/item/weapon/gun/energy/play_fire_sound(mob/user)
+	if(active_attachable && active_attachable.flags_attach_features & ATTACH_PROJECTILE)
+		if(active_attachable.fire_sound) //If we're firing from an attachment, use that noise instead.
+			playsound(user, active_attachable.fire_sound, 50)
+		return
+	if(flags_gun_features & GUN_SILENCED)
+		playsound(user, fire_sound, 25)
+		return
+	playsound(user, fire_sound, 60)
+
 
 /obj/item/weapon/gun/energy/taser
 	name = "taser gun"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
As per title. Ported from CM, that isn't crapcode.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
To know you are running out of ammo in the heat of battle.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Ballistic weapons have a rattling sound when fired at 25% ammo left.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
