### PR TITLE
TGUI call fixes

### DIFF
--- a/code/datums/gamemodes/game_mode.dm
+++ b/code/datums/gamemodes/game_mode.dm
@@ -612,7 +612,7 @@ Sensors indicate [numXenosShip || "no"] unknown lifeform signature[numXenosShip 
 	if(instant_join)
 		return pick(available_xenos) //Just picks something at random.
 
-	var/mob/living/carbon/xenomorph/new_xeno = tgui_input_list(usr, null, "Available Xenomorphs", null,  available_xenos)
+	var/mob/living/carbon/xenomorph/new_xeno = tgui_input_list(usr, null, "Available Xenomorphs", available_xenos)
 	if(!istype(new_xeno) || !xeno_candidate?.client)
 		return FALSE
 

--- a/code/game/objects/effects/decals/contraband.dm
+++ b/code/game/objects/effects/decals/contraband.dm
@@ -67,7 +67,7 @@ obj/structure/sign/poster/New(var/serial)
 	if(ruined)
 		return
 	var/temp_loc = user.loc
-	switch(tgui_alert(user, "Do I want to rip the poster from the wall?","You think...", list("Yes","No")))
+	switch(tgui_alert(user, "Do I want to rip the poster from the wall?", "You think...", list("Yes","No")))
 		if("Yes")
 			if(user.loc != temp_loc)
 				return

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -177,7 +177,7 @@
 
 		if(!registered_user) registered_user = user  //
 
-		switch(tgui_alert(user, "Would you like to display the ID, or retitle it?","Choose.",list("Rename","Show")))
+		switch(tgui_alert(user, "Would you like to display the ID, or retitle it?", "Choose.", list("Rename","Show")))
 			if("Rename")
 				var/newname = stripped_input(user, "What name would you like to put on this card?", "Agent card name", ishuman(user) ? user.real_name : user.name, max_length = 26)
 				if(!newname || newname == "Unknown" || newname == "floor" || newname == "wall" || newname == "r-wall") //Same as mob/new_player/prefrences.dm

--- a/code/game/objects/items/cosmetics.dm
+++ b/code/game/objects/items/cosmetics.dm
@@ -44,7 +44,7 @@
 		else
 			to_chat(user, "<span class='notice'>You attempt to apply [src] on [H]...</span>")
 			to_chat(H, "<span class='notice'>[user] is trying to apply [src] on your face...</span>")
-			if(tgui_alert(H,"Will you allow [user] to paint your face?", null, list("Sure","No")) == "Sure")
+			if(tgui_alert(H, "Will you allow [user] to paint your face?", null, list("Sure","No")) == "Sure")
 				if( user && loc == user && (user in range(1,H)) ) //Have to be close and hold the thing.
 					paint_face(H, user)
 					return 1

--- a/code/game/objects/machinery/cryopod.dm
+++ b/code/game/objects/machinery/cryopod.dm
@@ -350,7 +350,7 @@
 		return
 
 	if(M.client)
-		if(tgui_alert(M, "Would you like to enter cryosleep?", list("Yes", "No")) == "Yes")
+		if(tgui_alert(M, "Would you like to enter cryosleep?", null, list("Yes", "No")) == "Yes")
 			if(QDELETED(M) || !(G?.grabbed_thing == M))
 				return
 		else

--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -179,7 +179,7 @@
 			to_chat(usr, "Someone's already looking through [src].")
 			return
 		if(up && down)
-			switch( tgui_alert(usr ,"Look up or down the ladder?", "Ladder", list("Up", "Down", "Cancel")))
+			switch(tgui_alert(usr, "Look up or down the ladder?", "Ladder", list("Up", "Down", "Cancel")))
 				if("Up")
 					usr.visible_message("<span class='notice'>[usr] looks up [src]!</span>",
 					"<span class='notice'>You look up [src]!</span>")

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -120,7 +120,7 @@
 		to_chat(src, "You're already committing suicide! Be patient!")
 		return
 
-	var/confirm = tgui_alert("Are you sure you want to commit suicide?", "Confirm Suicide", list("Yes", "No"))
+	var/confirm = tgui_alert(usr, "Are you sure you want to commit suicide?", "Confirm Suicide", list("Yes", "No"))
 
 	if(confirm == "Yes")
 		if(!canmove || restrained())

--- a/code/modules/admin/fun_verbs.dm
+++ b/code/modules/admin/fun_verbs.dm
@@ -385,7 +385,7 @@
 		return
 
 	var/list/targets
-	var/style = tgui_alert(usr, "Do you want to play this globally or to the xenos/marines?", null,list("Globally", "Xenos", "Marines", "Locally"))
+	var/style = tgui_alert(usr, "Do you want to play this globally or to the xenos/marines?", null, list("Globally", "Xenos", "Marines", "Locally"))
 	switch(style)
 		if("Globally")
 			targets = GLOB.mob_list

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -129,7 +129,7 @@
 		to_chat(user, "<span class='danger'>Assembly part missing!</span>")
 		return
 	if(istype(a_left,a_right.type))//If they are the same type it causes issues due to window code
-		switch(tgui_alert(user, "Which side would you like to use?", null,list("Left","Right")))
+		switch(tgui_alert(user, "Which side would you like to use?", null, list("Left","Right")))
 			if("Left")
 				a_left.attack_self(user)
 			if("Right")

--- a/code/modules/detectivework/scanning_console.dm
+++ b/code/modules/detectivework/scanning_console.dm
@@ -219,7 +219,7 @@
 				to_chat(usr, "<spawn class='warning'>No record found.</span>")
 		if("delete")
 			if(href_list["identifier"])
-				if(tgui_alert(usr, "Are you sure you want to delete this record?","Record deletion", list("Yes", "No")) == "Yes")
+				if(tgui_alert(usr, "Are you sure you want to delete this record?", "Record deletion", list("Yes", "No")) == "Yes")
 					files.Remove(href_list["identifier"])
 					if(current && current.uid == href_list["identifier"])
 						current = null

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -303,7 +303,7 @@
 	if(IsSleeping())
 		to_chat(src, "<span class='warning'>You are already sleeping</span>")
 		return
-	if(tgui_alert(src,"You sure you want to sleep for a while?","Sleep", list("Yes","No")) == "Yes")
+	if(tgui_alert(src, "You sure you want to sleep for a while?", "Sleep", list("Yes","No")) == "Yes")
 		SetSleeping(40 SECONDS) //Short nap
 
 

--- a/code/modules/mob/living/carbon/give.dm
+++ b/code/modules/mob/living/carbon/give.dm
@@ -22,7 +22,7 @@
 	if(!istype(I) || (I.flags_item & (DELONDROP|NODROP)))
 		return
 	if(r_hand == null || l_hand == null)
-		switch(tgui_alert(src,"[usr] wants to give you \a [I]?", null,list("Yes","No")))
+		switch(tgui_alert(src, "[usr] wants to give you \a [I]?", null, list("Yes","No")))
 			if("Yes")
 				if(!I || !usr || !istype(I))
 					return

--- a/code/modules/mob/living/silicon/ai/ai_verbs.dm
+++ b/code/modules/mob/living/silicon/ai/ai_verbs.dm
@@ -38,7 +38,7 @@
 		return
 
 	var/list/ai_emotions = list("Very Happy", "Happy", "Neutral", "Unsure", "Confused", "Sad", "BSOD", "Blank", "Problems?", "Awesome", "Facepalm", "Thinking", "Friend Computer", "Dorfy", "Blue Glow", "Red Glow")
-	var/emote = tgui_input_list("Please, select a status!", "AI Status", ai_emotions)
+	var/emote = tgui_input_list(usr, "Please, select a status!", "AI Status", ai_emotions)
 	if(!emote)
 		return
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes some TGUI alert/input_list calls that had incorrect number of arguments. Adds some spaces after commas where they were missing.

Fixes:
- monkeys can now suicide (the prompt shows now), tested
- can pick xenos as ghost (fixes #6076), tested
- putting someone in cryo while they're not SSD prompts them to confirm, **not** tested, requires at least two people
- AI can change display status (fixes #6101), tested

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: taking over SSD xenos works again
fix: monkeys can suicide again
fix: prompt when someone tries to cryo you works again
fix: AI can change display status again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
