### PR TITLE
AI can use fob drone, no more mats limit for it

### DIFF
--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -11862,29 +11862,6 @@
 "MD" = (
 /obj/item/storage/box/sentry,
 /obj/structure/rack,
-/obj/item/stack/sheet/glass{
-	amount = 50;
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/stack/sheet/plasteel/medium_stack,
-/obj/item/stack/sheet/plasteel/medium_stack,
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/sheet/metal{
-	amount = 50;
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/stack/sheet/metal{
-	amount = 50;
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "ME" = (

--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -9140,22 +9140,6 @@
 "aTt" = (
 /obj/structure/rack,
 /obj/item/storage/box/sentry,
-/obj/item/stack/sheet/plasteel/medium_stack,
-/obj/item/stack/sheet/plasteel/medium_stack,
-/obj/item/stack/sheet/metal/large_stack,
-/obj/item/stack/sheet/metal/large_stack,
-/obj/item/stack/sheet/metal{
-	amount = 50;
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/stack/sheet/metal{
-	amount = 50;
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/stack/sheet/metal/medium_stack,
-/obj/item/stack/sheet/metal/small_stack,
 /turf/open/floor/prison,
 /area/sulaco/hangar)
 "aTw" = (

--- a/code/__DEFINES/objects.dm
+++ b/code/__DEFINES/objects.dm
@@ -211,6 +211,10 @@ GLOBAL_LIST_INIT(restricted_camera_networks, list( //Those networks can only be 
 #define POD_DESC 3
 #define POD_NUMBER 4
 
+//For fob drone
+#define EJECT_PLASTEEL 0
+#define EJECT_METAL 1
+
 //Item sprite variants
 #define ITEM_JUNGLE_VARIANT	(1<<0)
 #define ITEM_ICE_VARIANT	(1<<1)

--- a/code/modules/mining/remote_fob/remote_fob_actions_misc.dm
+++ b/code/modules/mining/remote_fob/remote_fob_actions_misc.dm
@@ -159,43 +159,34 @@
 	turret = new /obj/machinery/marine_turret(buildplace)
 	turret.setDir(fobdrone.dir)
 
-/datum/action/innate/remote_fob/eject_metal
+/datum/action/innate/remote_fob/eject_metal_action
 	name = "Eject All Metal"
 	action_icon_state = "fobpc-eject_m"
 
-/datum/action/innate/remote_fob/eject_metal/Activate()
+/datum/action/innate/remote_fob/eject_metal_action/Activate()
 	. = ..()
 	if(.)
 		return
 	if(console.metal_remaining <= 0)
 		to_chat(owner, "<span class='warning'>Nothing to eject.</span>")
 		return
-	var/obj/item/stack/sheet/metal/stack = /obj/item/stack/sheet/metal
-	var/turf/consolespot = get_turf(console)
-	stack = new /obj/item/stack/sheet/metal(consolespot)
-	stack.amount = console.metal_remaining
-	console.metal_remaining = 0
-	to_chat(owner, "<span class='notice'>Ejected [stack.amount] metal sheets.</span>")
-	flick("fobpc-eject", console)
+	console.eject_metal()
+	to_chat(owner, "<span class='notice'>Metal sheets ejected.</span>")
+	
 
-/datum/action/innate/remote_fob/eject_plasteel
+/datum/action/innate/remote_fob/eject_plasteel_action
 	name = "Eject All Plasteel"
 	action_icon_state = "fobpc-eject_p"
 
-/datum/action/innate/remote_fob/eject_plasteel/Activate()
+/datum/action/innate/remote_fob/eject_plasteel_action/Activate()
 	. = ..()
 	if(.)
 		return
 	if(console.plasteel_remaining <= 0)
 		to_chat(owner, "<span class='warning'>Nothing to eject.</span>")
 		return
-	flick("fobpc-eject", console)
-	var/obj/item/stack/sheet/plasteel/stack = /obj/item/stack/sheet/plasteel
-	var/turf/consolespot = get_turf(console)
-	stack = new /obj/item/stack/sheet/plasteel(consolespot)
-	stack.amount = console.plasteel_remaining
-	console.plasteel_remaining = 0
-	to_chat(owner, "<span class='notice'>Ejected [stack.amount] plasteel sheets.</span>")
+	console.eject_plasteel()
+	to_chat(owner, "<span class='notice'>Plasteel sheets ejected.</span>")
 
 
 /obj/item/stack/voucher/sentry

--- a/code/modules/mining/remote_fob/remote_fob_actions_misc.dm
+++ b/code/modules/mining/remote_fob/remote_fob_actions_misc.dm
@@ -170,7 +170,7 @@
 	if(console.metal_remaining <= 0)
 		to_chat(owner, "<span class='warning'>Nothing to eject.</span>")
 		return
-	console.eject_metal()
+	console.eject_mat(EJECT_METAL)
 	to_chat(owner, "<span class='notice'>Metal sheets ejected.</span>")
 	
 
@@ -185,7 +185,7 @@
 	if(console.plasteel_remaining <= 0)
 		to_chat(owner, "<span class='warning'>Nothing to eject.</span>")
 		return
-	console.eject_plasteel()
+	console.eject_mat(EJECT_PLASTEEL)
 	to_chat(owner, "<span class='notice'>Plasteel sheets ejected.</span>")
 
 

--- a/code/modules/mining/remote_fob/remote_fob_computer.dm
+++ b/code/modules/mining/remote_fob/remote_fob_computer.dm
@@ -37,8 +37,8 @@
 /obj/machinery/computer/camera_advanced/remote_fob/proc/disable_drone_creation()
 	SIGNAL_HANDLER
 	drone_creation_allowed = FALSE
-	eject_metal()
-	eject_plasteel()
+	eject_mat(EJECT_METAL)
+	eject_mat(EJECT_PLASTEEL)
 	UnregisterSignal(SSdcs, COMSIG_GLOB_DROPSHIP_TRANSIT)
 
 
@@ -71,25 +71,24 @@
 	if(eyeobj.eye_initialized)
 		eyeobj.setLoc(get_turf(spawn_spot))
 
-///Eject all the metal from the fob drone console
-/obj/machinery/computer/camera_advanced/remote_fob/proc/eject_metal()
+///Eject all of the selected mat from the fob drone console
+/obj/machinery/computer/camera_advanced/remote_fob/proc/eject_mat(mattype)
 	flick("fobpc-eject", src)
-	var/obj/item/stack/sheet/metal/stack = /obj/item/stack/sheet/metal
 	var/turf/consolespot = get_turf(loc)
-	while(metal_remaining>0)
-		stack = new /obj/item/stack/sheet/metal(consolespot)
-		stack.amount = min(metal_remaining, 50)
-		metal_remaining -= stack.amount
-
-///Eject all the plasteel from the fob drone console
-/obj/machinery/computer/camera_advanced/remote_fob/proc/eject_plasteel()
-	flick("fobpc-eject", src)
-	var/obj/item/stack/sheet/plasteel/stack = /obj/item/stack/sheet/plasteel
-	var/turf/consolespot = get_turf(loc)
-	while(plasteel_remaining>0)
-		stack = new /obj/item/stack/sheet/plasteel(consolespot)
-		stack.amount = min(plasteel_remaining, 50)
-		plasteel_remaining -= stack.amount
+	switch(mattype)
+		if(EJECT_METAL)
+			var/obj/item/stack/sheet/metal/stack = /obj/item/stack/sheet/metal
+			while(metal_remaining>0)
+				stack = new /obj/item/stack/sheet/metal(consolespot)
+				stack.amount = min(metal_remaining, 50)
+				metal_remaining -= stack.amount
+			return
+		if(EJECT_PLASTEEL)
+			var/obj/item/stack/sheet/plasteel/stack = /obj/item/stack/sheet/plasteel
+			while(plasteel_remaining>0)
+				stack = new /obj/item/stack/sheet/plasteel(consolespot)
+				stack.amount = min(plasteel_remaining, 50)
+				plasteel_remaining -= stack.amount
 
 /obj/machinery/computer/camera_advanced/remote_fob/interact(mob/living/user)
 	if(machine_stat & (NOPOWER|BROKEN))

--- a/code/modules/mining/remote_fob/remote_fob_computer.dm
+++ b/code/modules/mining/remote_fob/remote_fob_computer.dm
@@ -13,11 +13,9 @@
 	var/drone_creation_allowed = TRUE
 	var/obj/docking_port/stationary/marine_dropship/spawn_spot
 	var/datum/action/innate/remote_fob/metal_cade/metal_cade
-	var/max_metal = 50 //mostly to prevent jokers collecting all the metal and dumping it in
-	var/metal_remaining = 0
+	var/metal_remaining = 200
 	var/datum/action/innate/remote_fob/plast_cade/plast_cade
-	var/max_plasteel = 50
-	var/plasteel_remaining = 0
+	var/plasteel_remaining = 100
 	var/datum/action/innate/remote_fob/toggle_wiring/toggle_wiring //whether or not new barricades will be wired
 	var/do_wiring = FALSE
 	var/datum/action/innate/remote_fob/sentry/sentry
@@ -74,9 +72,6 @@
 /obj/machinery/computer/camera_advanced/remote_fob/interact(mob/living/user)
 	if(machine_stat & (NOPOWER|BROKEN))
 		return
-	if(isAI(user))
-		to_chat(user, "<span class='warning'>#ERROR! Drone terminated AI connection on handshake. Error thrown: 'We don't want machines building machines, but good try.'</span>")
-		return // In order to allow AIs to use this update_sight() needs to be refactored to properly handle living
 	if(!allowed(user))
 		to_chat(user, "<span class='warning'>Access Denied!</span>")
 		return

--- a/code/modules/mining/remote_fob/remote_fob_computer.dm
+++ b/code/modules/mining/remote_fob/remote_fob_computer.dm
@@ -76,18 +76,20 @@
 	flick("fobpc-eject", src)
 	var/obj/item/stack/sheet/metal/stack = /obj/item/stack/sheet/metal
 	var/turf/consolespot = get_turf(loc)
-	stack = new /obj/item/stack/sheet/metal(consolespot)
-	stack.amount = metal_remaining
-	metal_remaining = 0
+	while(metal_remaining>0)
+		stack = new /obj/item/stack/sheet/metal(consolespot)
+		stack.amount = min(metal_remaining, 50)
+		metal_remaining -= stack.amount
 
 ///Eject all the plasteel from the fob drone console
 /obj/machinery/computer/camera_advanced/remote_fob/proc/eject_plasteel()
 	flick("fobpc-eject", src)
 	var/obj/item/stack/sheet/plasteel/stack = /obj/item/stack/sheet/plasteel
 	var/turf/consolespot = get_turf(loc)
-	stack = new /obj/item/stack/sheet/plasteel(consolespot)
-	stack.amount = plasteel_remaining
-	plasteel_remaining = 0
+	while(plasteel_remaining>0)
+		stack = new /obj/item/stack/sheet/plasteel(consolespot)
+		stack.amount = min(plasteel_remaining, 50)
+		plasteel_remaining -= stack.amount
 
 /obj/machinery/computer/camera_advanced/remote_fob/interact(mob/living/user)
 	if(machine_stat & (NOPOWER|BROKEN))


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Remove the check making AI unable to use fob drone. The fob drone starts with already full mats, and has no longer any limits in mats. Mats are auto ejected when alamo leaves

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

QOL additions

## Changelog
:cl:
balance: AI can use fob drone
qol: Fob drone is prefilled with mats, and you can put as many mats in it as you want
qol: Mats are automaticly ejected when alamo leaves
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
