### PR TITLE
Fix PB shot missing

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -155,23 +155,7 @@
 
 	if(!force)
 		return FALSE
-
-	if(M != user) // Attacking yourself can't miss
-		user.do_attack_animation(M)
-		playsound(loc, 'sound/weapons/punchmiss.ogg', 25, TRUE)
-		if(user in viewers(COMBAT_MESSAGE_RANGE, M))
-			M.visible_message("<span class='danger'>[user] misses [M] with \the [src]!</span>",
-				"<span class='userdanger'>[user] missed us with \the [src]!</span>", null, COMBAT_MESSAGE_RANGE)
-		else
-			M.visible_message("<span class='avoidharm'>\The [src] misses [M]!</span>",
-				"<span class='avoidharm'>\The [src] narrowly misses you!</span>", null, COMBAT_MESSAGE_RANGE)
-		log_combat(user, M, "attacked", src, "(missed) (INTENT: [uppertext(user.a_intent)]) (DAMTYE: [uppertext(damtype)])")
-		if(force && !user.mind?.bypass_ff && !M.mind?.bypass_ff && user.faction == M.faction)
-			var/turf/T = get_turf(M)
-			log_ffattack("[key_name(user)] missed [key_name(M)] with \the [src] in [AREACOORD(T)].")
-			msg_admin_ff("[ADMIN_TPMONTY(user)] missed [ADMIN_TPMONTY(M)] with \the [src] in [ADMIN_VERBOSEJMP(T)].")
-		return FALSE
-
+	
 	. = M.attacked_by(src, user)
 	if(. && hitsound)
 		playsound(loc, hitsound, 25, TRUE)


### PR DESCRIPTION
PB shots and melee were missing 100% of the time

## Changelog
:cl:
fix: Melee and PB shots don't miss
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
