### PR TITLE
Xenos targeting removed

### DIFF
--- a/code/_onclick/hud/_defines.dm
+++ b/code/_onclick/hud/_defines.dm
@@ -41,9 +41,11 @@
 #define ui_dropbutton "EAST-4:22,1:5"
 #define ui_drop_throw "EAST-1:28,SOUTH+1:7"
 #define ui_acti "EAST-3:24,SOUTH:5"
+#define ui_acti_alien "EAST-2:26,SOUTH:5"
 #define ui_above_movement "EAST-2:26,SOUTH+1:7"
 #define ui_above_intent "EAST-3:24, SOUTH+1:7"
 #define ui_movi "EAST-2:26,SOUTH:5"
+#define ui_movi_alien "EAST -1:28,SOUTH:5"
 #define ui_zonesel "EAST-1:28,SOUTH:5"
 #define ui_acti_alt "EAST-1:28,1:5" //alternative intent switcher for when the interface is hidden (F12)
 #define ui_crafting	"EAST-4:22,SOUTH:5"

--- a/code/_onclick/hud/screen_objects/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects/screen_objects.dm
@@ -154,6 +154,8 @@
 	else if(_x>=17 && _y>=17)
 		usr.a_intent_change(INTENT_DISARM)
 
+/obj/screen/act_intent/corner/alien
+	screen_loc = ui_acti_alien
 
 /obj/screen/internals
 	name = "toggle internals"
@@ -257,6 +259,7 @@
 
 /obj/screen/mov_intent/alien
 	icon = 'icons/mob/screen/alien.dmi'
+	screen_loc = ui_movi_alien
 
 /obj/screen/rest
 	name = "rest"

--- a/code/_onclick/hud/xeno/xeno.dm
+++ b/code/_onclick/hud/xeno/xeno.dm
@@ -50,7 +50,7 @@
 	var/obj/screen/using
 	var/obj/screen/inventory/inv_box
 
-	using = new /obj/screen/act_intent/corner()
+	using = new /obj/screen/act_intent/corner/alien()
 	using.alpha = ui_alpha
 	using.icon_state = owner.a_intent
 	static_inventory += using
@@ -129,10 +129,6 @@
 	pull_icon.alpha = ui_alpha
 	pull_icon.update_icon(owner)
 	hotkeybuttons += pull_icon
-
-	zone_sel = new /obj/screen/zone_sel/alien()
-	zone_sel.update_icon(owner)
-	static_inventory += zone_sel
 
 /datum/hud/alien/persistent_inventory_update()
 	if(!mymob)

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -80,10 +80,8 @@
 		affecting = get_limb(ran_zone(null, 0))
 	else if(set_location)
 		affecting = get_limb(set_location)
-	else if(SEND_SIGNAL(X, COMSIG_XENOMORPH_ZONE_SELECT) & COMSIG_ACCURATE_ZONE)
-		affecting = get_limb(X.zone_selected)
 	else
-		affecting = get_limb(ran_zone(X.zone_selected, 70))
+		affecting = get_limb(ran_zone(X.zone_selected, 70))//Will be chest by default, can't be change by xenos
 	if(!affecting || (ignore_destroyed && !affecting.is_usable())) //No organ or it's destroyed, just get a random one
 		affecting = get_limb(ran_zone(null, 0))
 	if(!affecting || (no_head && affecting == get_limb("head")) || (ignore_destroyed && !affecting.is_usable()))
@@ -156,7 +154,7 @@
 
 	return TRUE
 
-/mob/living/silicon/attack_alien_disarm(mob/living/carbon/xenomorph/X, dam_bonus, set_location = FALSE, random_location = FALSE, no_head = FALSE, no_crit = FALSE, force_intent = null)
+/mob/living/silicon/attack_alien_disarm(mob/living/carbon/xenomorph/X, dam_bonus, set_location = FALSE, random_location = TRUE, no_head = FALSE, no_crit = FALSE, force_intent = null)
 	if(stat == DEAD) //A bit of visual flavor for attacking Cyborgs. Sparks!
 		return FALSE
 	. = ..()
@@ -169,7 +167,8 @@
 	spark_system.start(src)
 	playsound(loc, "alien_claw_metal", 25, TRUE)
 
-/mob/living/silicon/attack_alien_harm(mob/living/carbon/xenomorph/X, dam_bonus, set_location = FALSE, random_location = FALSE, no_head = FALSE, no_crit = FALSE, force_intent = null)
+
+/mob/living/silicon/attack_alien_harm(mob/living/carbon/xenomorph/X, dam_bonus, set_location = FALSE, random_location = TRUE, no_head = FALSE, no_crit = FALSE, force_intent = null)
 	if(stat == DEAD) //A bit of visual flavor for attacking Cyborgs. Sparks!
 		return FALSE
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -76,19 +76,21 @@
 
 /mob/living/carbon/get_xeno_slash_zone(mob/living/carbon/xenomorph/X, set_location = FALSE, random_location = FALSE, no_head = FALSE, ignore_destroyed = TRUE)
 	var/datum/limb/affecting
-	if(set_location)
+	if(random_location && !set_location)
+		affecting = get_limb(ran_zone(null, 0))
+	else if(set_location)
 		affecting = get_limb(set_location)
 	else if(SEND_SIGNAL(X, COMSIG_XENOMORPH_ZONE_SELECT) & COMSIG_ACCURATE_ZONE)
 		affecting = get_limb(X.zone_selected)
 	else
 		affecting = get_limb(ran_zone(X.zone_selected, 70))
-	if(!affecting || (random_location && !set_location) || (ignore_destroyed && !affecting.is_usable())) //No organ or it's destroyed, just get a random one
+	if(!affecting || (ignore_destroyed && !affecting.is_usable())) //No organ or it's destroyed, just get a random one
 		affecting = get_limb(ran_zone(null, 0))
 	if(!affecting || (no_head && affecting == get_limb("head")) || (ignore_destroyed && !affecting.is_usable()))
 		affecting = get_limb("chest")
 	return affecting
 
-/mob/living/proc/attack_alien_harm(mob/living/carbon/xenomorph/X, dam_bonus, set_location = FALSE, random_location = FALSE, no_head = FALSE, no_crit = FALSE, force_intent = null)
+/mob/living/proc/attack_alien_harm(mob/living/carbon/xenomorph/X, dam_bonus, set_location = FALSE, random_location = TRUE, no_head = FALSE, no_crit = FALSE, force_intent = null)
 	if(!can_xeno_slash(X))
 		return FALSE
 
@@ -189,7 +191,7 @@
 	return ..()
 
 
-/mob/living/carbon/human/attack_alien_harm(mob/living/carbon/xenomorph/X, dam_bonus, set_location = FALSE, random_location = FALSE, no_head = FALSE, no_crit = FALSE, force_intent = null)
+/mob/living/carbon/human/attack_alien_harm(mob/living/carbon/xenomorph/X, dam_bonus, set_location = FALSE, random_location = TRUE, no_head = FALSE, no_crit = FALSE, force_intent = null)
 	if(stat == DEAD)
 		if(istype(wear_ear, /obj/item/radio/headset/mainship))
 			var/obj/item/radio/headset/mainship/cam_headset = wear_ear


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Xenos can't chose which limb they target anymore, it's random. For the record, it was previously a 70% chance of hitting the targeted limb, or it was a random body part that was hit

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Remove the need to balance each limbs, which is a hot subject among maintainers. The "target right arm" is a meme, and not really balanced IMO. This makes marines a little bit tankier (no more right arm that's broke or cut off in 4 secs), which is I think a good thing for balance


## Changelog
:cl:
remove: Xenos can't target a specific limb. They will hit a random body part
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
