### PR TITLE
Silo base spawn rate nerf

### DIFF
--- a/code/controllers/subsystem/silo.dm
+++ b/code/controllers/subsystem/silo.dm
@@ -4,7 +4,7 @@ SUBSYSTEM_DEF(silo)
 	can_fire = FALSE
 	init_order = INIT_ORDER_SPAWNING_POOL
 	///How many larva points each pool gives per minute with a maturity of zero
-	var/base_larva_spawn_rate = 0.65
+	var/base_larva_spawn_rate = 0.5
 	///How many larva points are added every minutes in total
 	var/current_larva_spawn_rate = 0
 	///If the silos are maturing

--- a/code/controllers/subsystem/silo.dm
+++ b/code/controllers/subsystem/silo.dm
@@ -4,7 +4,7 @@ SUBSYSTEM_DEF(silo)
 	can_fire = FALSE
 	init_order = INIT_ORDER_SPAWNING_POOL
 	///How many larva points each pool gives per minute with a maturity of zero
-	var/base_larva_spawn_rate = 0.35
+	var/base_larva_spawn_rate = 0.4
 	///How many larva points are added every minutes in total
 	var/current_larva_spawn_rate = 0
 	///If the silos are maturing

--- a/code/controllers/subsystem/silo.dm
+++ b/code/controllers/subsystem/silo.dm
@@ -4,7 +4,7 @@ SUBSYSTEM_DEF(silo)
 	can_fire = FALSE
 	init_order = INIT_ORDER_SPAWNING_POOL
 	///How many larva points each pool gives per minute with a maturity of zero
-	var/base_larva_spawn_rate = 0.5
+	var/base_larva_spawn_rate = 0.35
 	///How many larva points are added every minutes in total
 	var/current_larva_spawn_rate = 0
 	///If the silos are maturing


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Nerf base pool output from .65 to.4

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Marines are getting steamrolled. I don't think it's the right solution, but we need a bandaid before balance freeze so this will do

## Changelog
:cl:
balance: Silo output reduced
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
