### PR TITLE
Vending and computer repair fixes

### DIFF
--- a/code/game/objects/machinery.dm
+++ b/code/game/objects/machinery.dm
@@ -38,7 +38,7 @@
 
 
 /obj/machinery/proc/is_operational()
-	return !(machine_stat & (NOPOWER|BROKEN|MAINT|DISABLED))
+	return !(machine_stat & (NOPOWER|BROKEN|MAINT))
 
 
 /obj/machinery/deconstruct(disassembled = TRUE)
@@ -159,7 +159,7 @@
 	if(!is_operational())
 		return FALSE
 
-	if(iscarbon(usr) && (!in_range(src, user) || !isturf(loc)))
+	if(iscarbon(usr) && (!in_range(src, usr) || !isturf(loc)))
 		return FALSE
 
 	if(ishuman(user))
@@ -193,7 +193,7 @@
 	. = ..()
 	if(.)
 		return
-	message_admins("[can_interact(user)]")
+
 	if(!can_interact(user))
 		return
 

--- a/code/game/objects/machinery.dm
+++ b/code/game/objects/machinery.dm
@@ -159,7 +159,7 @@
 	if(!is_operational())
 		return FALSE
 
-	if(iscarbon(usr) && (!in_range(src, usr) || !isturf(loc)))
+	if(iscarbon(usr) && (!in_range(src, user) || !isturf(loc)))
 		return FALSE
 
 	if(ishuman(user))

--- a/code/game/objects/machinery.dm
+++ b/code/game/objects/machinery.dm
@@ -38,7 +38,7 @@
 
 
 /obj/machinery/proc/is_operational()
-	return !(machine_stat & (NOPOWER|BROKEN|MAINT))
+	return !(machine_stat & (NOPOWER|BROKEN|MAINT|DISABLED))
 
 
 /obj/machinery/deconstruct(disassembled = TRUE)
@@ -159,7 +159,7 @@
 	if(!is_operational())
 		return FALSE
 
-	if(iscarbon(usr) && (!in_range(src, usr) || !isturf(loc)))
+	if(iscarbon(usr) && (!in_range(src, user) || !isturf(loc)))
 		return FALSE
 
 	if(ishuman(user))
@@ -193,7 +193,7 @@
 	. = ..()
 	if(.)
 		return
-
+	message_admins("[can_interact(user)]")
 	if(!can_interact(user))
 		return
 

--- a/code/game/objects/machinery.dm
+++ b/code/game/objects/machinery.dm
@@ -159,7 +159,7 @@
 	if(!is_operational())
 		return FALSE
 
-	if(iscarbon(usr) && (!in_range(src, user) || !isturf(loc)))
+	if(iscarbon(user) && (!in_range(src, user) || !isturf(loc)))
 		return FALSE
 
 	if(ishuman(user))
@@ -175,6 +175,8 @@
 
 
 /obj/machinery/attack_ai(mob/living/silicon/ai/user)
+	if(!is_operational())
+		return FALSE
 	return interact(user)
 
 

--- a/code/game/objects/machinery.dm
+++ b/code/game/objects/machinery.dm
@@ -38,7 +38,7 @@
 
 
 /obj/machinery/proc/is_operational()
-	return !(machine_stat & (NOPOWER|BROKEN|MAINT))
+	return !(machine_stat & (NOPOWER|BROKEN|MAINT|DISABLED))
 
 
 /obj/machinery/deconstruct(disassembled = TRUE)

--- a/code/game/objects/machinery/computer/computer.dm
+++ b/code/game/objects/machinery/computer/computer.dm
@@ -106,7 +106,7 @@
 
 	var/obj/item/tool/weldingtool/welder = I
 
-	if(!machine_stat & DISABLED && durability == initial(durability))
+	if(!(machine_stat & DISABLED) && durability == initial(durability))
 		to_chat(user, "<span class='notice'>The [src] doesn't need welding!</span>")
 		return FALSE
 

--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -392,16 +392,17 @@ GLOBAL_LIST_INIT(vending_white_items, typecacheof(list(
 	. = ..()
 	if(.) // Handled by ui_interact
 		return
-	if(tipped_level == 2)
-		if(!iscarbon(user)) // AI can't heave remotely
-			return
-		user.visible_message("<span class='notice'> [user] begins to heave the vending machine back into place!</span>","<span class='notice'> You start heaving the vending machine back into place..</span>")
-		if(!do_after(user, 80, FALSE, src, BUSY_ICON_FRIENDLY))
-			return FALSE
+	if(tipped_level != 2) // only fix when fully tipped
+		return
 
-		user.visible_message("<span class='notice'> [user] rights the [src]!</span>","<span class='notice'> You right the [src]!</span>")
-		flip_back()
-		return TRUE
+	if(!iscarbon(user)) // AI can't heave remotely
+		return
+	user.visible_message("<span class='notice'> [user] begins to heave the vending machine back into place!</span>","<span class='notice'> You start heaving the vending machine back into place..</span>")
+	if(!do_after(user, 80, FALSE, src, BUSY_ICON_FRIENDLY))
+		return FALSE
+	user.visible_message("<span class='notice'> [user] rights the [src]!</span>","<span class='notice'> You right the [src]!</span>")
+	flip_back()
+	return TRUE
 
 /obj/machinery/vending/ui_interact(mob/user, datum/tgui/ui)
 	if(tipped_level != 0) // Don't show when tipped or being tipped

--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -216,7 +216,6 @@ GLOBAL_LIST_INIT(vending_white_items, typecacheof(list(
 	density = FALSE
 	A.Turn(90)
 	transform = A
-	malfunction()
 
 /obj/machinery/vending/proc/flip_back()
 	icon_state = initial(icon_state)
@@ -224,7 +223,6 @@ GLOBAL_LIST_INIT(vending_white_items, typecacheof(list(
 	density = TRUE
 	var/matrix/A = matrix()
 	transform = A
-	machine_stat &= ~BROKEN //Remove broken. MAGICAL REPAIRS
 
 /obj/machinery/vending/attackby(obj/item/I, mob/user, params)
 	. = ..()
@@ -370,10 +368,6 @@ GLOBAL_LIST_INIT(vending_white_items, typecacheof(list(
 			stack_trace("UNKNOWN PRODUCT: PID: [pid], CAT: [category] INSIDE [type]!")
 			return null
 
-/obj/machinery/vending/is_operational()
-	// Allow interact to fix the vendor when tipped
-	. = ..() || tipped_level == 2
-
 /obj/machinery/vending/can_interact(mob/user)
 	. = ..()
 	if(!.)
@@ -390,7 +384,27 @@ GLOBAL_LIST_INIT(vending_white_items, typecacheof(list(
 
 	return TRUE
 
+/// Used only when vendor is tipped to put it back up
+/// Normal usage is in ui_interact
+/obj/machinery/vending/interact(mob/user)
+	. = ..()
+	if(.) // Handled by ui_interact
+		return
+	if(tipped_level == 2)
+		if(!iscarbon(user)) // AI can't heave remotely
+			return
+		user.visible_message("<span class='notice'> [user] begins to heave the vending machine back into place!</span>","<span class='notice'> You start heaving the vending machine back into place..</span>")
+		if(!do_after(user, 80, FALSE, src, BUSY_ICON_FRIENDLY))
+			return FALSE
+
+		user.visible_message("<span class='notice'> [user] rights the [src]!</span>","<span class='notice'> You right the [src]!</span>")
+		flip_back()
+		return TRUE
+
 /obj/machinery/vending/ui_interact(mob/user, datum/tgui/ui)
+	if(tipped_level != 0) // Don't show when tipped or being tipped
+		return
+
 	ui = SStgui.try_update_ui(user, src, ui)
 
 	if(!ui)

--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -384,8 +384,10 @@ GLOBAL_LIST_INIT(vending_white_items, typecacheof(list(
 
 	return TRUE
 
-/// Used only when vendor is tipped to put it back up
-/// Normal usage is in ui_interact
+/**
+ * Used only when vendor is tipped to put it back up
+ * Normal usage is in ui_interact
+ */
 /obj/machinery/vending/interact(mob/user)
 	. = ..()
 	if(.) // Handled by ui_interact

--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -370,6 +370,10 @@ GLOBAL_LIST_INIT(vending_white_items, typecacheof(list(
 			stack_trace("UNKNOWN PRODUCT: PID: [pid], CAT: [category] INSIDE [type]!")
 			return null
 
+/obj/machinery/vending/is_operational()
+	// Allow interact to fix the vendor when tipped
+	. = ..() || tipped_level == 2
+
 /obj/machinery/vending/can_interact(mob/user)
 	. = ..()
 	if(!.)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows tipped vendors to be put back up. Makes disabled machinery unusable for AI and humans. Fixes #6127.

The tipped vendors are now powered, which allows interacting with them. Interaction will either be tgui (dispensing) if the vendor isn't tipped or putting it back up if it is.
 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes. Allows fixing vendors. Disallows AI from using broken things.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: disabled computers are now unusable (repair with blowtorch)
fix: tipped over vendors can be put back up
fix: AI can't use disabled machines now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
