### PR TITLE
Add synth check to throwing grenade in acid hole

### DIFF
--- a/code/game/objects/effects/acid_hole.dm
+++ b/code/game/objects/effects/acid_hole.dm
@@ -130,6 +130,10 @@
 	if(istype(I, /obj/item/explosive/grenade))
 		var/obj/item/explosive/grenade/G = I
 
+		if(issynth(user) && G.dangerous && !CONFIG_GET(flag/allow_synthetic_gun_use))
+			to_chat(H, "<span class='warning'>Your programming prevents you from doing this.</span>")
+			return
+
 		if(!T || T.density)
 			to_chat(user, "<span class='warning'>This hole leads nowhere!</span>")
 			return

--- a/code/game/objects/effects/acid_hole.dm
+++ b/code/game/objects/effects/acid_hole.dm
@@ -131,7 +131,7 @@
 		var/obj/item/explosive/grenade/G = I
 
 		if(issynth(user) && G.dangerous && !CONFIG_GET(flag/allow_synthetic_gun_use))
-			to_chat(H, "<span class='warning'>Your programming prevents you from doing this.</span>")
+			to_chat(user, "<span class='warning'>Your programming prevents you from doing this.</span>")
 			return
 
 		if(!T || T.density)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds synth check to throwing grenade in acid hole. Fixes #6126.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bug fix.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: synthetic cannot throw dangerous grenades in acid holes now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
