### PR TITLE
Revert "Changes Marine Respawn Time"

### DIFF
--- a/code/_globalvars/admin.dm
+++ b/code/_globalvars/admin.dm
@@ -4,7 +4,7 @@ GLOBAL_VAR_INIT(dsay_allowed, TRUE)
 GLOBAL_VAR_INIT(enter_allowed, TRUE)
 GLOBAL_VAR_INIT(respawn_allowed, TRUE)
 
-GLOBAL_VAR_INIT(respawntime, 45 MINUTES)
+GLOBAL_VAR_INIT(respawntime, 30 MINUTES)
 GLOBAL_VAR_INIT(xenorespawntime, 2 MINUTES)
 GLOBAL_VAR_INIT(fileaccess_timer, 0)
 


### PR DESCRIPTION
Reverts tgstation/TerraGov-Marine-Corps#5843

Pools too strong.

Dying as marine means join Xeno or play on CM.

With how pools work currently, respawning marines by 30 minutes shouldn't be a problem when in a lot of the games, groundside is lost by 13:00.