### PR TITLE
Add defibrillator recharge hint

### DIFF
--- a/code/game/objects/items/defibrillator.dm
+++ b/code/game/objects/items/defibrillator.dm
@@ -56,6 +56,32 @@
 		icon_state += "_empty"
 
 
+/obj/item/defibrillator/examine(mob/living/carbon/human/user)
+	. = ..()
+	maybe_message_recharge_hint(user)
+
+
+/**
+ * Message user with a hint to recharge defibrillator
+ * and how to do it if the battery is low.
+ * Arguments:
+ * user: user to message
+*/
+/obj/item/defibrillator/proc/maybe_message_recharge_hint(mob/living/carbon/human/user)
+	if(!dcell)
+		return
+
+	var/message
+	if(dcell.charge < charge_cost)
+		message = "The battery is empty."
+	else if(round(dcell.charge * 100 / dcell.maxcharge) <= 33)
+		message = "The battery is low."
+
+	if(!message)
+		return
+	to_chat(user, "<span class='notice'>[message] You can click-drag defibrillator on corpsman backpack to recharge it.</span>")
+
+
 /obj/item/defibrillator/attack_self(mob/living/carbon/human/user)
 	if(!istype(user))
 		return
@@ -111,7 +137,7 @@
 
 	if(!heart || heart.is_broken() || !has_brain())
 		return FALSE
-	
+
 	return TRUE
 
 /obj/item/defibrillator/attack(mob/living/carbon/human/H, mob/living/carbon/human/user)
@@ -144,6 +170,7 @@
 		return
 	if(dcell.charge <= charge_cost)
 		user.visible_message("<span class='warning'>[icon2html(src, viewers(user))] \The [src] buzzes: Internal battery depleted. Cannot analyze nor administer shock.</span>")
+		maybe_message_recharge_hint(user)
 		return
 	if(H.stat != DEAD)
 		user.visible_message("<span class='warning'>[icon2html(src, viewers(user))] \The [src] buzzes: Vital signs detected. Aborting.</span>")


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a hint to defibrillator on examine and when the battery runs out. Meant to inform people that they can recharge defibrillators with corpsman backpack.

Fixes #6119. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Informs about game mechanics. Increases the chance of revival.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: defibrillator recharging hints
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
