### PR TITLE
Fix giving powerloader clamps

### DIFF
--- a/code/modules/vehicles/powerloader.dm
+++ b/code/modules/vehicles/powerloader.dm
@@ -153,21 +153,21 @@
 	name = "\improper RPL-Y Cargo Loader Hydraulic Claw"
 	icon_state = "loader_clamp"
 	force = 20
-	flags_item = ITEM_ABSTRACT //to prevent placing the item on a table/closet.
-								//We're controlling the clamp but the item isn't really in our hand.
+	// ITEM_ABSTRACT to prevent placing the item on a table/closet.
+	// DELONDROP to prevent giving the clamp to others.
+	flags_item = ITEM_ABSTRACT|DELONDROP
 	var/obj/vehicle/powerloader/linked_powerloader
 	var/obj/loaded
 
+
 /obj/item/powerloader_clamp/dropped(mob/user)
+	// Don't call ..() so it's not deleted
+	// We actually store the clamps in powerloader
 	if(!linked_powerloader)
 		qdel(src)
 		return
 	forceMove(linked_powerloader)
-	for(var/m in linked_powerloader.buckled_mobs)
-		if(m != user)
-			continue
-		linked_powerloader.unbuckle_mob(user) //drop a clamp, you auto unbuckle from the powerloader.
-		break
+	linked_powerloader.unbuckle_mob(user)
 
 
 /obj/item/powerloader_clamp/attack(mob/living/victim, mob/living/user, def_zone)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Added DELONDROP to powerloader clamps so you can't give them. They aren't actually deleted, but moved into powerloader object storage. It's a bit hacky, but allows exiting by pressing Q. Refactors the code a bit. Fixes #6044.

Alternative fix would be to make them NODROP and only allow to exit ripley by unbuckling, but I think it's worse, because Q won't longer work.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Game exploit fix.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: you can no longer give marines ripley hands to move crates fast
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
