### PR TITLE
Ancient Xenos Now Provide Proper Salvage Biomass Upgrade Yields

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1119,6 +1119,8 @@
 	succeed_activate()
 
 	var/upgrade_amount = target.upgrade_stored * DRONE_SALVAGE_BIOMASS_SALVAGE_RATIO //We only recover a small portion of the target's upgrade and evo points.
+	if(target.upgrade == XENO_UPGRADE_THREE)
+		upgrade_amount = target.xeno_caste.upgrade_threshold * DRONE_SALVAGE_BIOMASS_SALVAGE_RATIO //Ancient xenos count as having maximum upgrade points
 	var/evo_amount = target.evolution_stored * DRONE_SALVAGE_BIOMASS_SALVAGE_RATIO
 
 	//Take all the plas-mar

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
@@ -166,6 +166,9 @@
 	// *** Health *** //
 	max_health = 325
 
+	// *** Evolution *** //
+	upgrade_threshold = 1000
+
 	// *** Defense *** //
 	soft_armor = list("melee" = 45, "bullet" = 45, "laser" = 45, "energy" = 45, "bomb" = XENO_BOMB_RESIST_0, "bio" = 37, "rad" = 37, "fire" = 45, "acid" = 37)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -134,6 +134,9 @@
 	// *** Health *** //
 	max_health = 400
 
+	// *** Evolution *** //
+	upgrade_threshold = 1000
+
 	// *** Defense *** //
 	soft_armor = list("melee" = 90, "bullet" = 75, "laser" = 75, "energy" = 75, "bomb" = XENO_BOMB_RESIST_3, "bio" = 100, "rad" = 100, "fire" = 75, "acid" = 100)
 	// *** Abilities *** //

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
@@ -148,6 +148,9 @@
 	// *** Health *** //
 	max_health = 300
 
+	// *** Evolution *** //
+	upgrade_threshold = 240
+
 	// *** Defense *** //
 	soft_armor = list("melee" = 31, "bullet" = 31, "laser" = 31, "energy" = 31, "bomb" = XENO_BOMB_RESIST_0, "bio" = 15, "rad" = 15, "fire" = 31, "acid" = 15)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
@@ -158,6 +158,9 @@
 	// *** Health *** //
 	max_health = 360
 
+	// *** Evolution *** //
+	upgrade_threshold = 1000
+
 	// *** Defense *** //
 	soft_armor = list("melee" = 45, "bullet" = 50, "laser" = 50, "energy" = 50, "bomb" = XENO_BOMB_RESIST_0, "bio" = 38, "rad" = 38, "fire" = 50, "acid" = 38)
 


### PR DESCRIPTION
## About The Pull Request

Ancient Xenos now provide the proper upgrade point yield when targeted with Salvage Biomass.

## Why It's Good For The Game

Fixes: https://github.com/tgstation/TerraGov-Marine-Corps/issues/6150

## Changelog
:cl:
fix: Ancient Xenos now provide the proper upgrade point yield when targeted with Salvage Biomass, counting as a maxed out Elder Xeno.
/:cl:
