### PR TITLE
Fixes medevac stretcher runtime

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -438,7 +438,7 @@ GLOBAL_LIST_EMPTY(activated_medevac_stretchers)
 	"<span class='warning'>You activate [src]'s bluespace engine, causing it to rev to life.</span>")
 	playsound(loc,'sound/mecha/powerup.ogg', 25, FALSE)
 	teleport_timer = addtimer(CALLBACK(src, .proc/medevac_teleport, user), MEDEVAC_TELE_DELAY, TIMER_STOPPABLE|TIMER_UNIQUE) //Activate after 5 second delay.
-	RegisterSignal(src, COMSIG_MOVABLE_UNBUCKLE, .proc/on_mob_unbuckle)
+	RegisterSignal(src, COMSIG_MOVABLE_UNBUCKLE, .proc/on_mob_unbuckle, TRUE)
 
 /obj/structure/bed/medevac_stretcher/proc/on_mob_unbuckle(datum/source, mob/living/buckled_mob, force = FALSE)
 	SIGNAL_HANDLER
@@ -449,6 +449,7 @@ GLOBAL_LIST_EMPTY(activated_medevac_stretchers)
 
 
 /obj/structure/bed/medevac_stretcher/proc/medevac_teleport(mob/user)
+	UnregisterSignal(src, COMSIG_MOVABLE_UNBUCKLE)
 	if(!linked_beacon || !linked_beacon.check_power() || !linked_beacon.planted) //Beacon has to be planted in a powered area.
 		playsound(loc,'sound/machines/buzz-two.ogg', 25, FALSE)
 		visible_message("<span class='warning'>[src]'s safeties kick in before displacement as it fails to detect a powered, linked, and planted medvac beacon.</span>")
@@ -467,7 +468,6 @@ GLOBAL_LIST_EMPTY(activated_medevac_stretchers)
 		visible_message("<span class='warning'>[src]'s bluespace engine aborts displacement, being unable to detect an appropriate evacuee.</span>")
 		return
 
-	UnregisterSignal(src, COMSIG_MOVABLE_UNBUCKLE)
 	visible_message("<span class='notice'><b>[M] vanishes in a flash of sparks as [src]'s bluespace engine generates its displacement field.</b></span>")
 	if(buckled_bodybag)
 		var/obj/structure/closet/bodybag/teleported_bodybag = buckled_bodybag

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -438,7 +438,7 @@ GLOBAL_LIST_EMPTY(activated_medevac_stretchers)
 	"<span class='warning'>You activate [src]'s bluespace engine, causing it to rev to life.</span>")
 	playsound(loc,'sound/mecha/powerup.ogg', 25, FALSE)
 	teleport_timer = addtimer(CALLBACK(src, .proc/medevac_teleport, user), MEDEVAC_TELE_DELAY, TIMER_STOPPABLE|TIMER_UNIQUE) //Activate after 5 second delay.
-	RegisterSignal(src, COMSIG_MOVABLE_UNBUCKLE, .proc/on_mob_unbuckle, TRUE)
+	RegisterSignal(src, COMSIG_MOVABLE_UNBUCKLE, .proc/on_mob_unbuckle)
 
 /obj/structure/bed/medevac_stretcher/proc/on_mob_unbuckle(datum/source, mob/living/buckled_mob, force = FALSE)
 	SIGNAL_HANDLER


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes:

[18:27:57] Runtime in unsorted.dm, line 39: unbuckle overridden. Use override = TRUE to suppress this warning
proc name: stack trace (/datum/proc/stack_trace)
usr: Fernandos33/(Case Husk)
usr.loc: (Tadpole Drop Shuttle (150, 83, 3))
src: the medevac stretcher (/obj/structure/bed/medevac_stretcher)
src.loc: the floor (151,82,3) (/turf/open/shuttle/dropship/floor)
call stack:
the medevac stretcher (/obj/structure/bed/medevac_stretcher): stack trace("unbuckle overridden. Use overr...")
the medevac stretcher (/obj/structure/bed/medevac_stretcher): RegisterSignal(the medevac stretcher (/obj/structure/bed/medevac_stretcher), "unbuckle", /obj/structure/bed/medevac_str... (/obj/structure/bed/medevac_stretcher/proc/on_mob_unbuckle), 0)
the medevac stretcher (/obj/structure/bed/medevac_stretcher): activate medevac teleport(Case Husk (/mob/living/carbon/human))
the medevac stretcher (/obj/structure/bed/medevac_stretcher): Activate Medevac Displacement Field()

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixes runtimes caused by medevac stretchers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
