### PR TITLE
Remove (Weapon) verbs from Commands tab

### DIFF
--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -449,6 +449,7 @@ should be alright.
 
 
 /obj/item/weapon/gun/verb/field_strip()
+	set category = null
 	set name = "Field Strip (Weapon)"
 	set desc = "Remove all attachables from a weapon."
 
@@ -558,6 +559,7 @@ should be alright.
 
 
 /obj/item/weapon/gun/verb/toggle_autofire()
+	set category = null
 	set name = "Toggle Auto Fire (Weapon)"
 	set desc = "Toggle automatic firemode, if the gun has it."
 
@@ -589,6 +591,7 @@ should be alright.
 
 
 /obj/item/weapon/gun/verb/toggle_burstfire()
+	set category = null
 	set name = "Toggle Burst Fire (Weapon)"
 	set desc = "Toggle burst firemode, if the gun has it."
 
@@ -620,6 +623,7 @@ should be alright.
 
 
 /obj/item/weapon/gun/verb/toggle_firemode()
+	set category = null
 	set name = "Toggle Fire Mode (Weapon)"
 	set desc = "Toggle between fire modes, if the gun has more than has one."
 
@@ -734,6 +738,7 @@ should be alright.
 
 
 /obj/item/weapon/gun/verb/empty_mag()
+	set category = null
 	set name = "Unload Weapon (Weapon)"
 	set desc = "Removes the magazine from your current gun and drops it on the ground, or clears the chamber if your gun is already empty."
 
@@ -752,6 +757,7 @@ should be alright.
 
 
 /obj/item/weapon/gun/verb/use_unique_action()
+	set category = null
 	set name = "Unique Action (Weapon)"
 	set desc = "Use anything unique your firearm is capable of. Includes pumping a shotgun or spinning a revolver."
 
@@ -770,6 +776,7 @@ should be alright.
 
 
 /obj/item/weapon/gun/verb/toggle_gun_safety()
+	set category = null
 	set name = "Toggle Gun Safety (Weapon)"
 	set desc = "Toggle the safety of the held gun."
 
@@ -790,6 +797,7 @@ should be alright.
 
 
 /obj/item/weapon/gun/verb/activate_attachment_verb()
+	set category = null
 	set name = "Load From Attachment (Weapon)"
 	set desc = "Load from a gun attachment, such as a mounted grenade launcher, shotgun, or flamethrower."
 
@@ -829,6 +837,7 @@ should be alright.
 	G.toggle_rail_attachment()
 
 /obj/item/weapon/gun/verb/toggle_rail_attachment()
+	set category = null
 	set name = "Toggle Rail Attachment (Weapon)"
 	set desc = "Uses the rail attachement currently attached to the gun."
 
@@ -849,6 +858,7 @@ should be alright.
 
 
 /obj/item/weapon/gun/verb/toggle_ammo_hud()
+	set category = null
 	set name = "Toggle Ammo HUD (Weapon)"
 	set desc = "Toggles the Ammo HUD for this weapon."
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #6153. The default tab for verbs is actually Commands. Or rather [default_verb_category client var](http://www.byond.com/docs/ref/info.html#/client/var/default_verb_category). This removes that tab, so the old weapon verbs are available only in right-click menu. The better mob verbs are in Weapons tab.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bug fix.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: weapon verbs are now only in Weapons verb tab
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
