### PR TITLE
Allows IFF Bullets to pass over the TL-102 HSG

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -616,14 +616,14 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 	return TRUE
 
 /obj/machinery/marine_turret/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)
-    for(var/access_tag in proj.projectile_iff)
+	for(var/access_tag in proj.projectile_iff)
 		if(access_tag in iff_signal) //Checks IFF
 			proj.damage += proj.damage*proj.damage_marine_falloff
 			return FALSE
 	return src == proj.original_target
 
 /obj/machinery/standard_hmg/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)
-    for(var/access_tag in proj.projectile_iff)
+	for(var/access_tag in proj.projectile_iff)
 		if(access_tag in iff_signal) //Checks IFF
 			proj.damage += proj.damage*proj.damage_marine_falloff
 			return FALSE

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -629,6 +629,20 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 
 	return FALSE
 
+/obj/machinery/standard_hmg/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)
+	if(hmg_verify_iff(proj.projectile_iff))
+		proj.damage += proj.damage*proj.damage_marine_falloff
+		return FALSE
+	return src == proj.original_target
+
+///Checks to see whether IFF matches
+/obj/machinery/standard_hmg/proc/hmg_verify_iff(list/unique_access)
+	for(var/access_tag in unique_access)
+		if(access_tag in iff_signal)
+			return TRUE
+
+	return FALSE
+
 /obj/machinery/door/poddoor/railing/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)
 	return src == proj.original_target
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -616,32 +616,18 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 	return TRUE
 
 /obj/machinery/marine_turret/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)
-	if(sentry_verify_iff(proj.projectile_iff))
-		proj.damage += proj.damage*proj.damage_marine_falloff
-		return FALSE
+    for(var/access_tag in proj.projectile_iff)
+		if(access_tag in iff_signal) //Checks IFF
+			proj.damage += proj.damage*proj.damage_marine_falloff
+			return FALSE
 	return src == proj.original_target
-
-///Checks to see whether IFF matches
-/obj/machinery/marine_turret/proc/sentry_verify_iff(list/unique_access)
-	for(var/access_tag in unique_access)
-		if(access_tag in iff_signal)
-			return TRUE
-
-	return FALSE
 
 /obj/machinery/standard_hmg/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)
-	if(hmg_verify_iff(proj.projectile_iff))
-		proj.damage += proj.damage*proj.damage_marine_falloff
-		return FALSE
+    for(var/access_tag in proj.projectile_iff)
+		if(access_tag in iff_signal) //Checks IFF
+			proj.damage += proj.damage*proj.damage_marine_falloff
+			return FALSE
 	return src == proj.original_target
-
-///Checks to see whether IFF matches
-/obj/machinery/standard_hmg/proc/hmg_verify_iff(list/unique_access)
-	for(var/access_tag in unique_access)
-		if(access_tag in iff_signal)
-			return TRUE
-
-	return FALSE
 
 /obj/machinery/door/poddoor/railing/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)
 	return src == proj.original_target


### PR DESCRIPTION
## About The Pull Request

Gives the TL-102 HSG the ability to have IFF bullets pass over it the same way it does with Sentries.

## Why It's Good For The Game

From my experience I've found that the main reason the TL-102 dies is because it gets FFd in five seconds. I figure since its function is similar to a Sentry it shouldn't be able to be killed by FF.

## Changelog
:cl:
balance:  Gives the TL-102 HSG the ability to have IFF bullets pass over it the same way it does with Sentries.
/:cl:

