### PR TITLE
Misc Sulaco map fix + public engi vendor QoL

### DIFF
--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -1802,7 +1802,9 @@
 /turf/open/floor/prison,
 /area/sulaco/hangar)
 "agm" = (
-/obj/machinery/vending/tool,
+/obj/machinery/vending/engivend{
+	req_access = null
+	},
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_main_hall)
 "agy" = (
@@ -12779,9 +12781,7 @@
 /turf/open/floor/prison/bright_clean,
 /area/mainship/command/self_destruct)
 "iqZ" = (
-/obj/machinery/vending/engivend{
-	req_access = null
-	},
+/obj/machinery/vending/tool,
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_main_hall)
 "iti" = (
@@ -48467,8 +48467,8 @@ bPx
 aWG
 xKR
 aWG
-iqZ
-cdy
+aWG
+agm
 aaJ
 ajO
 aiA
@@ -48724,8 +48724,8 @@ bPx
 aWG
 vmi
 aWG
+aWG
 eVE
-cdy
 aaJ
 yiP
 aio
@@ -48981,8 +48981,8 @@ aGy
 aWG
 xKR
 aWG
-agm
-cdy
+aWG
+iqZ
 aaJ
 ajQ
 aeL
@@ -49238,7 +49238,7 @@ aVZ
 aWG
 xKR
 qxQ
-cdy
+aaQ
 aaQ
 aaJ
 aaJ


### PR DESCRIPTION
## About The Pull Request
Fixes the walls being fucked up near the vendor and while I was at it I made the vendors a little further back so you can stand in front of them without blocking anyone going through the hallway

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bug bad
Not standing in the hall is just nice little QoL if a lot of people are walking by

## Changelog
:cl:
fix: Filled in a missing wall on the sulaco, made a light fixture not float.
qol: There is a little more space to stand in front of the public engi vendors on sulaco without taking up space in the hallway.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
