### PR TITLE
Slug Falloff

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -558,6 +558,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	shell_speed = 3
 	max_range = 15
 	damage = 80
+	damage_falloff = 0.25
 	penetration = 40
 	sundering = 7
 
@@ -591,6 +592,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	accuracy = -10
 	max_range = 15
 	damage = 40
+	damage_falloff = 0.5
 	penetration = 20
 	sundering = 2
 	bullet_color = COLOR_TAN_ORANGE
@@ -726,6 +728,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	shell_speed = 3
 	max_range = 15
 	damage = 40
+	damage_falloff = 0.5
 	penetration = 20
 
 /datum/ammo/bullet/shotgun/sx16_slug/on_hit_mob(mob/M, obj/projectile/P)
@@ -760,6 +763,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	shell_speed = 3
 	max_range = 15
 	damage = 60
+	damage_falloff = 0.25
 	penetration = 30
 	sundering = 3.5
 
@@ -797,6 +801,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	shell_speed = 5
 	max_range = 30
 	damage = 50
+	damage_falloff = 0.25
 	penetration = 40
 	sundering = 3
 


### PR DESCRIPTION

<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes slug falloff not worse then fletch. I dont know who thought a giant piece of metal would lose speed faster then a bunch of tumbling pieces of metal but youre wrong.

## Why It's Good For The Game

Gives slugs an actually falloff along with some other ammo. They already have bad damage (40 DPS in the case of 12g) the falloff was stupid considering it should keep speed better then most other ammo types on here. Now they wont lose a damage for every tile as well.

## Changelog
:cl:
balance: Some shotgun shells have better falloff
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
