### PR TITLE
Instant death tile on magmoor removed

### DIFF
--- a/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
+++ b/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
@@ -6510,9 +6510,6 @@
 /obj/effect/alien/egg,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/magmoor/cave/west)
-"eUz" = (
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/space)
 "eUO" = (
 /turf/open/floor/plating/ground/concrete/lines{
 	dir = 9
@@ -69515,7 +69512,7 @@ lfG
 ebf
 lfG
 lfG
-eUz
+eEq
 izb
 izb
 izb


### PR DESCRIPTION
## About The Pull Request
![dreammaker_2021-02-26_17-33-38](https://user-images.githubusercontent.com/17747087/109327869-184c2d00-7859-11eb-8668-0ea91bc3cefe.png)
adds a eastern lavaland area to that one tile with an X in the middle

## Why It's Good For The Game
Instant death tiles in a playable area is not a good idea

## Changelog
:cl: Vondiech
fix: A rouny made of space dust has fixed so that an instant death tile on magmoor is no more.
/:cl: