### PR TITLE
Psych balance tweak

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -102,12 +102,9 @@ SUBSYSTEM_DEF(job)
 		JobDebug("Successfuly assigned marine role to a squad. Player: [player.key], Job: [job.title], Squad: [player.assigned_squad]")
 	if(!latejoin)
 		unassigned -= player
-	if(job.job_category != JOB_CAT_XENO)
-		if(SSmonitor.gamestate == SHUTTERS_CLOSED)
-			SSpoints.xeno_points_by_hive[XENO_HIVE_NORMAL] += SILO_PRICE / 15
-		else
-			SSpoints.xeno_points_by_hive[XENO_HIVE_NORMAL] += SILO_PRICE / 45
-	job.occupy_job_positions(1)
+	if(job.job_category != JOB_CAT_XENO && !GLOB.joined_player_list.Find(player.ckey))
+		SSpoints.xeno_points_by_hive[XENO_HIVE_NORMAL] += SILO_PRICE / 15
+	job.occupy_job_positions(1, GLOB.joined_player_list.Find(player.ckey))
 	player.assigned_role = job
 	JobDebug("Player: [player] is now Job: [job.title], JCP:[job.current_positions], JPL:[job.total_positions]")
 	return TRUE

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -102,7 +102,7 @@ SUBSYSTEM_DEF(job)
 		JobDebug("Successfuly assigned marine role to a squad. Player: [player.key], Job: [job.title], Squad: [player.assigned_squad]")
 	if(!latejoin)
 		unassigned -= player
-	if(!isxenosjob(src))
+	if(job.job_category != JOB_CAT_XENO))
 		if(SSmonitor.gamestate == SHUTTERS_CLOSED)
 			SSpoints.xeno_points_by_hive[XENO_HIVE_NORMAL] += SILO_PRICE / 15
 		else

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -102,6 +102,8 @@ SUBSYSTEM_DEF(job)
 		JobDebug("Successfuly assigned marine role to a squad. Player: [player.key], Job: [job.title], Squad: [player.assigned_squad]")
 	if(!latejoin)
 		unassigned -= player
+	if(!isxenosjob(src))
+		SSpoints.xeno_points_by_hive[XENO_HIVE_NORMAL] += SILO_PRICE / 15
 	job.occupy_job_positions(1)
 	player.assigned_role = job
 	JobDebug("Player: [player] is now Job: [job.title], JCP:[job.current_positions], JPL:[job.total_positions]")

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -102,7 +102,7 @@ SUBSYSTEM_DEF(job)
 		JobDebug("Successfuly assigned marine role to a squad. Player: [player.key], Job: [job.title], Squad: [player.assigned_squad]")
 	if(!latejoin)
 		unassigned -= player
-	if(job.job_category != JOB_CAT_XENO))
+	if(job.job_category != JOB_CAT_XENO)
 		if(SSmonitor.gamestate == SHUTTERS_CLOSED)
 			SSpoints.xeno_points_by_hive[XENO_HIVE_NORMAL] += SILO_PRICE / 15
 		else

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -103,7 +103,10 @@ SUBSYSTEM_DEF(job)
 	if(!latejoin)
 		unassigned -= player
 	if(!isxenosjob(src))
-		SSpoints.xeno_points_by_hive[XENO_HIVE_NORMAL] += SILO_PRICE / 15
+		if(SSmonitor.gamestate == SHUTTERS_CLOSED)
+			SSpoints.xeno_points_by_hive[XENO_HIVE_NORMAL] += SILO_PRICE / 15
+		else
+			SSpoints.xeno_points_by_hive[XENO_HIVE_NORMAL] += SILO_PRICE / 45
 	job.occupy_job_positions(1)
 	player.assigned_role = job
 	JobDebug("Player: [player] is now Job: [job.title], JCP:[job.current_positions], JPL:[job.total_positions]")

--- a/code/controllers/subsystem/silo.dm
+++ b/code/controllers/subsystem/silo.dm
@@ -28,6 +28,3 @@ SUBSYSTEM_DEF(silo)
 	UnregisterSignal(SSdcs, list(COMSIG_GLOB_OPEN_TIMED_SHUTTERS_LATE, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_XENO_HIVEMIND, COMSIG_GLOB_OPEN_SHUTTERS_EARLY))
 	can_fire = TRUE
 	silos_do_mature = TRUE
-	for(var/job in SSjob.occupations)
-		var/datum/job/j = job
-		j.jobworth[/datum/job/xenomorph] = 0

--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -72,12 +72,6 @@
 /datum/game_mode/infestation/distress/post_setup()
 	. = ..()
 	scale_gear()
-	if(TGS_CLIENT_COUNT < 20)
-		SSpoints.xeno_points_by_hive[XENO_HIVE_NORMAL] = SILO_PRICE
-	else
-		SSpoints.xeno_points_by_hive[XENO_HIVE_NORMAL] = SILO_PRICE / 20 * TGS_CLIENT_COUNT
-
-	addtimer(CALLBACK(src, .proc/announce_bioscans, FALSE, 1), rand(30 SECONDS, 1 MINUTES)) //First scan shows no location but more precise numbers.
 
 /datum/game_mode/infestation/distress/proc/map_announce()
 	if(!SSmapping.configs[GROUND_MAP].announce_text)

--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -72,6 +72,7 @@
 /datum/game_mode/infestation/distress/post_setup()
 	. = ..()
 	scale_gear()
+	addtimer(CALLBACK(src, .proc/announce_bioscans, FALSE, 1), rand(30 SECONDS, 1 MINUTES)) //First scan shows no location but more precise numbers.
 
 /datum/game_mode/infestation/distress/proc/map_announce()
 	if(!SSmapping.configs[GROUND_MAP].announce_text)

--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -72,20 +72,10 @@
 /datum/game_mode/infestation/distress/post_setup()
 	. = ..()
 	scale_gear()
-	var/silo_number
-	switch(TGS_CLIENT_COUNT)
-		if(0 to 20)
-			silo_number = 1
-		if(20 to 40)
-			silo_number = 2
-		if(40 to 60)
-			silo_number = 3
-		if(60 to 80)
-			silo_number = 4
-		if(80 to INFINITY)
-			silo_number = 5
-
-	SSpoints.xeno_points_by_hive[XENO_HIVE_NORMAL] = silo_number * SILO_PRICE
+	if(TGS_CLIENT_COUNT < 20)
+		SSpoints.xeno_points_by_hive[XENO_HIVE_NORMAL] = SILO_PRICE
+	else
+		SSpoints.xeno_points_by_hive[XENO_HIVE_NORMAL] = SILO_PRICE / 20 * TGS_CLIENT_COUNT
 
 	addtimer(CALLBACK(src, .proc/announce_bioscans, FALSE, 1), rand(30 SECONDS, 1 MINUTES)) //First scan shows no location but more precise numbers.
 

--- a/code/datums/jobs/job/job.dm
+++ b/code/datums/jobs/job/job.dm
@@ -187,13 +187,15 @@ GLOBAL_PROTECT(exp_specialmap)
 /datum/job/proc/get_special_name(client/preference_source)
 	return
 
-/datum/job/proc/occupy_job_positions(amount)
+/datum/job/proc/occupy_job_positions(amount, respawn = FALSE)
 	if(amount <= 0)
 		CRASH("free_job_positions() called with amount: [amount]")
 	current_positions += amount
 	for(var/index in jobworth)
 		var/datum/job/scaled_job = SSjob.GetJobType(index)
 		if(!(scaled_job in SSjob.active_joinable_occupations))
+			continue
+		if(isxenosjob(scaled_job) && respawn)
 			continue
 		scaled_job.add_job_points(jobworth[index])
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Xenos will get larva (same as before pools) and psych points (1/15 of a silo) everytime a marine spawn for the first time. Respawn will not give anything

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

This deals with the issue of people joining up late, and only chosing marine making the game unbalance for xenos. This system is more fair for xenos, while still retaining the current philosophy of "no free larva for marine respawn"

## Changelog
:cl:
balance: Xenos gain larva and psych points everytime a marine spawn , even for very late joins. Doesn't work for respawn
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
