### PR TITLE
Making a pool create a tunnel next to it

### DIFF
--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -68,6 +68,12 @@
 		RegisterSignal(associated_hive, list(COMSIG_HIVE_XENO_MOTHER_PRE_CHECK, COMSIG_HIVE_XENO_MOTHER_CHECK), .proc/is_burrowed_larva_host)
 		associated_hive.handle_silo_death_timer()
 	silo_area = get_area(src)
+	var/turf/tunnel_turf
+	tunnel_turf = get_step(center_turf, NORTH)
+	if(tunnel_turf.can_dig_xeno_tunnel())
+		var/obj/structure/tunnel/newt = new(tunnel_turf)
+		newt.tunnel_desc = "[get_area(newt)] (X: [newt.x], Y: [newt.y])"
+		newt.name += "Tunnel for [name]"
 
 /obj/structure/resin/silo/Destroy()
 	GLOB.xeno_resin_silos -= src

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -68,8 +68,7 @@
 		RegisterSignal(associated_hive, list(COMSIG_HIVE_XENO_MOTHER_PRE_CHECK, COMSIG_HIVE_XENO_MOTHER_CHECK), .proc/is_burrowed_larva_host)
 		associated_hive.handle_silo_death_timer()
 	silo_area = get_area(src)
-	var/turf/tunnel_turf
-	tunnel_turf = get_step(center_turf, NORTH)
+	var/turf/tunnel_turf = get_step(center_turf, NORTH)
 	if(tunnel_turf.can_dig_xeno_tunnel())
 		var/obj/structure/tunnel/newt = new(tunnel_turf)
 		newt.tunnel_desc = "[get_area(newt)] (X: [newt.x], Y: [newt.y])"

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -73,7 +73,7 @@
 	if(tunnel_turf.can_dig_xeno_tunnel())
 		var/obj/structure/tunnel/newt = new(tunnel_turf)
 		newt.tunnel_desc = "[get_area(newt)] (X: [newt.x], Y: [newt.y])"
-		newt.name += "Tunnel for [name]"
+		newt.name += "[name]"
 
 /obj/structure/resin/silo/Destroy()
 	GLOB.xeno_resin_silos -= src


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Creating a pool will create a tunnel north of it, if the tile is empty

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Makes xenos able to quickly defend pool even if their is no hivelord in their rank. Maybe will allow xenos to spread the pools, which can be a good counter to big unga balls since losing one pool is not the end of the world

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Spawning a new silo will generate a tunnel north of it automaticly 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
