### PR TITLE
Gives the TL-102 description the information of how to repair it.

### DIFF
--- a/code/game/objects/machinery/smartgun_mount.dm
+++ b/code/game/objects/machinery/smartgun_mount.dm
@@ -44,7 +44,7 @@
 // The actual gun itself.
 /obj/item/standard_hmg
 	name = "\improper TL-102 mounted heavy smartgun"
-	desc = "The TL-102 heavy machinegun, it's too heavy to be carried or to be operated without the tripod. IFF capable. No extra work required, just deploy it."
+	desc = "The TL-102 heavy machinegun, it's too heavy to be carried or to be operated without the tripod. IFF capable. No extra work required, just deploy it. Can be repaired with a blowtorch when deployed."
 	max_integrity = 300
 	w_class = WEIGHT_CLASS_HUGE
 	flags_equip_slot = ITEM_SLOT_BACK
@@ -152,7 +152,7 @@
 // The actual Machinegun itself, going to borrow some stuff from current sentry code to make sure it functions. Also because they're similiar.
 /obj/machinery/standard_hmg
 	name = "\improper TL-102 mounted heavy smartgun"
-	desc = "A deployed and mounted heavy smartgun, ready to rock. While it is capable of taking the same rounds as the smartmachinegun, it fires specialized tungsten rounds for increased armor penetration.\n<span class='notice'>Use (ctrl-click) to toggle burstfire.</span>"
+	desc = "A deployed and mounted heavy smartgun, ready to rock. While it is capable of taking the same rounds as the smartmachinegun, it fires specialized tungsten rounds for increased armor penetration.\n<span class='notice'>Use (ctrl-click) to toggle burstfire. Can be repaired with a blowtorch.</span>"
 	icon = 'icons/Marine/marine-hmg.dmi'
 	icon_state = "turret"
 	anchored = TRUE

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -629,6 +629,20 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 
 	return FALSE
 
+/obj/machinery/standard_hmg/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)
+	if(hmg_verify_iff(proj.projectile_iff))
+		proj.damage += proj.damage*proj.damage_marine_falloff
+		return FALSE
+	return src == proj.original_target
+
+///Checks to see whether IFF matches
+/obj/machinery/standard_hmg/proc/hmg_verify_iff(list/unique_access)
+	for(var/access_tag in unique_access)
+		if(access_tag in iff_signal)
+			return TRUE
+
+	return FALSE
+
 /obj/machinery/door/poddoor/railing/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)
 	return src == proj.original_target
 


### PR DESCRIPTION

## About The Pull Request

Adds a line to the TL-102 description informing readers that it can be repaired with a blowtorch.

## Why It's Good For The Game

The TL-102 can be repaired. No one knows this however, a description telling people this would be useful.

## Changelog
:cl:
add: The TL-102 can be repaired with a blowtorch, adds that information to its description.
/:cl:
