### PR TITLE
Less Logistic Miners

### DIFF
--- a/code/game/objects/items/misc.dm
+++ b/code/game/objects/items/misc.dm
@@ -116,38 +116,6 @@
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "ectoplasm"
 
-
-/obj/item/compactorebox
-	name = "compressed ore box"
-	desc = "A heavy and pretty solid box, filled to the brim with ore"
-	icon = 'icons/obj/items/items.dmi'
-	icon_state = "phoronbox_compact"
-	item_state = "phoronbox_compact"
-	max_integrity = 20
-	w_class = WEIGHT_CLASS_HUGE
-	flags_item = TWOHANDED
-	force = 5
-	throw_range = 3
-	throwforce = 15 // Heavy box. heavy damage.
-
-/obj/item/compactorebox/pickup(mob/user)
-	. = ..()
-	wield(user)
-
-/obj/item/compactorebox/dropped(mob/user)
-	. = ..()
-	unwield(user)
-
-/obj/item/compactorebox/phoron
-	name = "compressed phoron box"
-	desc = "A heavy and pretty solid box, filled to the brim with compressed phoron crystals."
-
-/obj/item/compactorebox/platinum
-	name = "compressed platinum box"
-	desc = "A very heavy and solid box, filled with pure titanium."
-	icon_state = "platinumbox_compact"
-	item_state = "platinumbox_comact"
-
 /obj/item/minerupgrade
 	name = "miner upgrade"
 	desc = "Subtype item, should not exist."
@@ -170,8 +138,3 @@
 	icon_state = "mining_drill_overclockeddisplay"
 	uptype = "high-efficiency drill"
 
-/obj/item/minerupgrade/compactor
-	name = "crystalizer module"
-	desc = "A bulky module meant to replace the normal crystalizer in mining wells, used to compress boxes for easy carrying."
-	icon_state = "mining_drill_compactordisplay"
-	uptype = "upgraded crystalizer module"

--- a/code/game/objects/machinery/autolathe_datums.dm
+++ b/code/game/objects/machinery/autolathe_datums.dm
@@ -119,11 +119,6 @@ GLOBAL_LIST_EMPTY(autolathe_categories)
 	path = /obj/item/minerupgrade/reinforcement
 	category = "Engineering"
 
-/datum/autolathe/recipe/miningwellcompactor
-	name = "mining well compactor upgrade"
-	path = /obj/item/minerupgrade/compactor
-	category = "Engineering"
-
 /datum/autolathe/recipe/miningwelloverclock
 	name = "mining well overclock upgrade"
 	path = /obj/item/minerupgrade/overclock

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -4,14 +4,13 @@
 #define MINER_DESTROYED	3
 
 #define MINER_RESISTANT	"reinforced components"
-#define MINER_COMPACTOR	"upgraded crystalizer module"
 #define MINER_OVERCLOCKED "high-efficiency drill"
 
 
 ///Resource generator that produces a certain material that can be repaired by marines and attacked by xenos, Intended as an objective for marines to play towards to get more req gear
 /obj/machinery/miner
 	name = "\improper Nanotrasen phoron Mining Well"
-	desc = "Top-of-the-line Nanotrasen research drill with it's own packaging module, used to extract phoron in vast quantities. Selling the phoron mined by these would net a nice profit..."
+	desc = "Top-of-the-line Nanotrasen research drill with it's own export module, used to extract phoron in vast quantities. Selling the phoron mined by these would net a nice profit..."
 	icon = 'icons/obj/mining_drill.dmi'
 	density = TRUE
 	icon_state = "mining_drill_active"
@@ -26,7 +25,7 @@
 	///How many times we neeed to tick for a resource to be created, in this case this is 2* the specified amount
 	var/required_ticks = 70  //make one crate every 140 seconds
 	///The mineral type that's produced
-	var/mineral_produced = /obj/structure/ore_box/phoron
+	var/mineral_value = 20
 	///Health for the miner we use because changing obj_integrity is apparently bad
 	var/miner_integrity = 100
 	///Max health of the miner
@@ -40,8 +39,8 @@
 
 /obj/machinery/miner/damaged/platinum
 	name = "\improper Nanotrasen platinum Mining Well"
-	desc = "A Nanotrasen platinum drill with an internal packaging module. Produces even more valuable materials than it's phoron counterpart"
-	mineral_produced = /obj/structure/ore_box/platinum
+	desc = "A Nanotrasen platinum drill with an internal export module. Produces even more valuable materials than it's phoron counterpart"
+	mineral_value = 40
 
 /obj/machinery/miner/Initialize()
 	. = ..()
@@ -50,10 +49,7 @@
 /obj/machinery/miner/update_icon()
 	switch(miner_status)
 		if(MINER_RUNNING)
-			if((mineral_produced == /obj/item/compactorebox/platinum) && (miner_upgrade_type == MINER_COMPACTOR))
-				icon_state = "mining_drill_active_platinum_[miner_upgrade_type]"
-			else
-				icon_state = "mining_drill_active_[miner_upgrade_type]"
+			icon_state = "mining_drill_active_[miner_upgrade_type]"
 		if(MINER_SMALL_DAMAGE)
 			icon_state = "mining_drill_braced_[miner_upgrade_type]"
 		if(MINER_MEDIUM_DAMAGE)
@@ -79,11 +75,6 @@
 		if(MINER_RESISTANT)
 			max_miner_integrity = 300
 			miner_integrity = 300
-		if(MINER_COMPACTOR)
-			if(mineral_produced == /obj/structure/ore_box/platinum)
-				mineral_produced = /obj/item/compactorebox/platinum
-			else
-				mineral_produced = /obj/item/compactorebox/phoron
 		if(MINER_OVERCLOCKED)
 			required_ticks = 35
 	miner_upgrade_type = upgrade.uptype
@@ -127,9 +118,6 @@
 			if(MINER_OVERCLOCKED)
 				upgrade = new /obj/item/minerupgrade/overclock
 				required_ticks = initial(required_ticks)
-			if(MINER_COMPACTOR)
-				upgrade = new /obj/item/minerupgrade/compactor
-				mineral_produced = initial(mineral_produced)
 		upgrade.forceMove(user.loc)
 		miner_upgrade_type = null
 		update_icon()
@@ -233,9 +221,11 @@
 		to_chat(user, "<span class='warning'>[src] is not ready to produce a shipment yet!</span>")
 		return
 
-	new mineral_produced(user.loc, stored_mineral)
-	stored_mineral -= 1
-	start_processing()
+	SSpoints.supply_points += mineral_value * stored_mineral
+	do_sparks(5, TRUE, src)
+	playsound(loc,'sound/effects/phasein.ogg', 50, FALSE)
+	visible_message("<span class='notice'>The [src] buzzes: Ore shipment has been sold for [mineral_value * stored_mineral] points.</span>")
+	stored_mineral = 0
 
 /obj/machinery/miner/process()
 	if(miner_status != MINER_RUNNING)

--- a/code/game/objects/machinery/sellingpad.dm
+++ b/code/game/objects/machinery/sellingpad.dm
@@ -29,7 +29,7 @@
 
 	for(var/i in get_turf(src))
 		var/atom/movable/onpad = i
-		if(!isxeno(onpad) && !istype(onpad,/obj/structure/ore_box) && !istype(onpad, /obj/item/alien_embryo) && !istype(onpad, /obj/item/compactorebox))
+		if(!isxeno(onpad) && !istype(onpad, /obj/item/alien_embryo))
 			continue
 		if(isxeno(onpad))
 			var/mob/living/carbon/xenomorph/sellxeno = onpad

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -6,17 +6,3 @@
 	density = TRUE
 	anchored = FALSE
 	resistance_flags = XENO_DAMAGEABLE
-
-/obj/structure/ore_box/phoron
-	name = "phoron ore crate"
-	desc = "A large crate filled with raw phoron crystals."
-	icon_state = "orebox_phoron"
-	max_integrity = 100
-	soft_armor = list("acid" = 100)
-
-/obj/structure/ore_box/platinum
-	name = "platinum ore crate"
-	desc = "A large crate filled with raw platinum ore."
-	icon_state = "orebox_platinum"
-	max_integrity = 100
-	soft_armor = list("acid" = 100)

--- a/code/modules/reqs/supplyexports.dm
+++ b/code/modules/reqs/supplyexports.dm
@@ -4,22 +4,6 @@
 	var/cost = null
 	var/export_obj = null
 
-/datum/supply_export/platinum
-	cost = 50
-	export_obj = /obj/structure/ore_box/platinum
-
-/datum/supply_export/phoron
-	cost = 25
-	export_obj = /obj/structure/ore_box/phoron
-
-/datum/supply_export/compactorebox/phoron
-	cost = 25
-	export_obj = /obj/item/compactorebox/phoron
-
-/datum/supply_export/compactorebox/platinum
-	cost = 50
-	export_obj = /obj/item/compactorebox/platinum
-
 /datum/supply_export/xemomorph
 	cost = 0
 	export_obj = /mob/living/carbon/xenomorph

--- a/code/modules/requisitions/_supply_export.dm
+++ b/code/modules/requisitions/_supply_export.dm
@@ -6,22 +6,6 @@
 	. = 3
 	SSpoints.supply_points += .
 
-/obj/structure/ore_box/phoron/supply_export()
-	. = 20
-	SSpoints.supply_points += .
-
-/obj/item/compactorebox/phoron/supply_export()
-	. = 20
-	SSpoints.supply_points += .
-
-/obj/item/compactorebox/platinum/supply_export()
-	. = 40
-	SSpoints.supply_points += .
-
-/obj/structure/ore_box/platinum/supply_export()
-	. = 40
-	SSpoints.supply_points += .
-
 /mob/living/carbon/xenomorph/supply_export()
 	switch(tier)
 		if(XENO_TIER_ZERO)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Miners now sell ore on their own no need to drag crates around.
Remove obsolete compactor upgrade
Remove obsolete ore boxes

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Babysitting miners is boring and tedious this significantly reduces the amount of babying miners need. I've also seen interest to make marines try and control multiple miners rather than just sitting on 1/2 miner the whole round, if that is ever going to be the case each miner needs to be lower maintenance. Right now getting the logistics and support you need to run a single miner can already be pretty taxing. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Miners now sell ore on their own, no crate dragging or export pad required.
atomic: Intended to be bundled with my other miner PRs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
