### PR TITLE
Marine respawn from 45 minutes to 30 minutes

### DIFF
--- a/code/_globalvars/admin.dm
+++ b/code/_globalvars/admin.dm
@@ -4,7 +4,7 @@ GLOBAL_VAR_INIT(dsay_allowed, TRUE)
 GLOBAL_VAR_INIT(enter_allowed, TRUE)
 GLOBAL_VAR_INIT(respawn_allowed, TRUE)
 
-GLOBAL_VAR_INIT(respawntime, 45 MINUTES)
+GLOBAL_VAR_INIT(respawntime, 30 MINUTES)
 GLOBAL_VAR_INIT(xenorespawntime, 2 MINUTES)
 GLOBAL_VAR_INIT(fileaccess_timer, 0)
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ttile

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Don't know if people will like it, but I think the marines push mid round are a bit sad. This will maybe allow marines to make a second push mid round that's more dangerous than the one they are currently doing

Give feedback

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Respawn for marines are now 30 minutes instead of 45
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
