### PR TITLE
Gives the 102 a hud like the sentries

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -522,3 +522,16 @@
 
 	var/amount = round(rounds * 100 / rounds_max, 10)
 	holder.icon_state = "plasma[amount]"
+
+/obj/machinery/standard_hmg/proc/hud_set_hsg_ammo()
+	var/image/holder = hud_list[SENTRY_AMMO_HUD]
+
+	if(!holder)
+		return
+
+	if(!rounds)
+		holder.icon_state = "plasma0"
+		return
+	
+	var/amount = round(rounds * 100 / rounds_max, 10)
+	holder.icon_state = "plasma[amount]"

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -523,6 +523,7 @@
 	var/amount = round(rounds * 100 / rounds_max, 10)
 	holder.icon_state = "plasma[amount]"
 
+//Makes tl-102 ammo visible
 /obj/machinery/standard_hmg/proc/hud_set_hsg_ammo()
 	var/image/holder = hud_list[SENTRY_AMMO_HUD]
 

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -523,7 +523,7 @@
 	var/amount = round(rounds * 100 / rounds_max, 10)
 	holder.icon_state = "plasma[amount]"
 
-//Makes tl-102 ammo visible
+///Makes tl-102 ammo visible
 /obj/machinery/standard_hmg/proc/hud_set_hsg_ammo()
 	var/image/holder = hud_list[SENTRY_AMMO_HUD]
 

--- a/code/game/objects/machinery/smartgun_mount.dm
+++ b/code/game/objects/machinery/smartgun_mount.dm
@@ -189,7 +189,7 @@
 	for(var/datum/atom_hud/squad/sentry_status_hud in GLOB.huds) //Add to the squad HUD
 		sentry_status_hud.add_to_hud(src)
 	hud_set_machine_health()
-	hud_set_sentry_ammo()
+	hud_set_hsg_ammo()
 
 /obj/machinery/standard_hmg/Destroy() //Make sure we pick up our trash.
 	operator?.unset_interaction()
@@ -247,6 +247,7 @@
 			D.current_rounds = rounds - (rounds_max - M.current_rounds)
 		rounds = min(rounds + M.current_rounds, rounds_max)
 		update_icon()
+		hud_set_hsg_ammo()
 		qdel(I)
 
 /obj/machinery/standard_hmg/welder_act(mob/living/user, obj/item/I)
@@ -376,6 +377,7 @@
 		return //No ammo.
 	if(last_fired)
 		return //still shooting.
+	hud_set_hsg_ammo()
 
 	if(!is_bursting)
 		last_fired = TRUE

--- a/code/game/objects/machinery/smartgun_mount.dm
+++ b/code/game/objects/machinery/smartgun_mount.dm
@@ -162,6 +162,7 @@
 	use_power = 0
 	max_integrity = 300
 	soft_armor = list("melee" = 0, "bullet" = 50, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 0, "fire" = 0, "acid" = 0)
+	hud_possible = list(MACHINE_HEALTH_HUD, SENTRY_AMMO_HUD)
 	var/rounds = 0 //Have it be empty upon spawn.
 	var/rounds_max = 300
 	var/fire_delay = 2 //Gotta have rounds down quick. // Ren's changes
@@ -184,6 +185,11 @@
 	. = ..()
 	ammo = GLOB.ammo_list[ammo] //dunno how this works but just sliding this in from sentry-code.
 	update_icon()
+	prepare_huds() //Set up HUDS
+	for(var/datum/atom_hud/squad/sentry_status_hud in GLOB.huds) //Add to the squad HUD
+		sentry_status_hud.add_to_hud(src)
+	hud_set_machine_health()
+	hud_set_sentry_ammo()
 
 /obj/machinery/standard_hmg/Destroy() //Make sure we pick up our trash.
 	operator?.unset_interaction()
@@ -282,6 +288,7 @@
 	user.visible_message("<span class='notice'>[user] repairs some damage on [src].</span>",
 	"<span class='notice'>You repair [src].</span>")
 	repair_damage(120)
+	hud_set_machine_health()
 	update_icon()
 	playsound(loc, 'sound/items/welder2.ogg', 25, TRUE)
 	return TRUE
@@ -317,6 +324,10 @@
 	SEND_SIGNAL(X, COMSIG_XENOMORPH_ATTACK_M56)
 	return ..()
 
+/obj/machinery/standard_hmg/take_damage(damage_amount, damage_type, damage_flag, effects, attack_dir, armour_penetration)
+	. = ..()
+	hud_set_machine_health()
+	
 
 /obj/machinery/standard_hmg/proc/load_into_chamber()
 	if(in_chamber)


### PR DESCRIPTION
## About The Pull Request

Gives the TL-102 HSG a health and ammo indicator like the Sentries have.

## Why It's Good For The Game

Gives some visual feedback for ammo and health of the TL-102

![Screenshot (8)](https://user-images.githubusercontent.com/43631032/109730172-eb0bc180-7b6d-11eb-8988-8bc0be07fdea.png)


## Changelog
:cl:
add: Gives the TL-102 HSG a health and ammo indicator like the Sentries have.
/:cl:
