### PR TITLE
Gens psych points outpute scale with server pop

### DIFF
--- a/code/controllers/subsystem/points.dm
+++ b/code/controllers/subsystem/points.dm
@@ -1,6 +1,8 @@
 // points per minute
 #define DROPSHIP_POINT_RATE 18 * (GLOB.current_orbit/3)
 #define SUPPLY_POINT_RATE 2 * (GLOB.current_orbit/3)
+//How many psych point one gen gives per person on the server
+#define BASE_PSYCH_POINT_OUTPUT 0.002
 
 SUBSYSTEM_DEF(points)
 	name = "Points"

--- a/code/controllers/subsystem/silo.dm
+++ b/code/controllers/subsystem/silo.dm
@@ -9,6 +9,8 @@ SUBSYSTEM_DEF(silo)
 	var/current_larva_spawn_rate = 0
 	///If the silos are maturing
 	var/silos_do_mature = FALSE
+	///How many psych points one corrupted generator gives
+	var/corrupted_gen_output
 
 
 /datum/controller/subsystem/silo/Initialize(timeofday)
@@ -21,6 +23,7 @@ SUBSYSTEM_DEF(silo)
 	for(var/obj/structure/resin/silo/silo AS in GLOB.xeno_resin_silos)
 		current_larva_spawn_rate += clamp(base_larva_spawn_rate * (1 + silo.maturity/(5400)), base_larva_spawn_rate, 2 * base_larva_spawn_rate)
 	xeno_job.add_job_points(current_larva_spawn_rate)
+	corrupted_gen_output = TGS_CLIENT_COUNT * BASE_PSYCH_POINT_OUTPUT
 
 ///Activate the subsystem when shutters open and remove the free spawning when marines are joining
 /datum/controller/subsystem/silo/proc/start_spawning()

--- a/code/modules/power/groundmap_geothermal.dm
+++ b/code/modules/power/groundmap_geothermal.dm
@@ -21,8 +21,8 @@
 	var/cur_tick = 0 //Tick updater
 	///Hive it should be powering and whether it should be generating hive psycic points instead of power on process()
 	var/corrupted = XENO_HIVE_NORMAL
-	///how many points this generator will make per tick
-	var/corrupt_point_amount = 0.1
+	///Multiplicator factor for psych points output
+	var/corrupt_point_factor = 1
 	///whether we wil allow these to be corrupted
 	var/is_corruptible = TRUE
 	///whether they should generate corruption if corrupted
@@ -89,7 +89,7 @@
 
 /obj/machinery/power/geothermal/process()
 	if(corrupted && corruption_on)
-		SSpoints.xeno_points_by_hive["[corrupted]"] += corrupt_point_amount
+		SSpoints.xeno_points_by_hive["[corrupted]"] += SSsilo.corrupted_gen_output *corrupt_point_factor
 		return
 	if(!is_on || buildstate || !anchored || !powernet) //Default logic checking
 		return PROCESS_KILL
@@ -297,7 +297,7 @@
 /obj/machinery/power/geothermal/bigred //used on big red
 	name = "\improper Reactor Turbine"
 	power_generation_max = 1e+6
-	corrupt_point_amount = 1
+	corrupt_point_factor = 10
 
 /obj/machinery/power/geothermal/reinforced
 	name = "\improper Reinforced Reactor Turbine"

--- a/code/modules/power/groundmap_geothermal.dm
+++ b/code/modules/power/groundmap_geothermal.dm
@@ -22,7 +22,7 @@
 	///Hive it should be powering and whether it should be generating hive psycic points instead of power on process()
 	var/corrupted = XENO_HIVE_NORMAL
 	///Multiplicator factor for psych points output
-	var/corrupt_point_factor = 1
+	var/corrupt_point_factor = 0.3
 	///whether we wil allow these to be corrupted
 	var/is_corruptible = TRUE
 	///whether they should generate corruption if corrupted
@@ -297,7 +297,7 @@
 /obj/machinery/power/geothermal/bigred //used on big red
 	name = "\improper Reactor Turbine"
 	power_generation_max = 1e+6
-	corrupt_point_factor = 10
+	corrupt_point_factor = 3
 
 /obj/machinery/power/geothermal/reinforced
 	name = "\improper Reinforced Reactor Turbine"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

A corrupted gen output of psych points will now scale with the server populatiob, AKA the number of client online. 
The base server pop for calculation is 50, so if there are 50 players the output will be of 0.03 psych per second per gens ( a third of currently) 

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Trying to make high pop and low pop have the same balance. Also, since psy drain is pretty strong, that passive outcome is no longer that needed

## Changelog
:cl:
balance: Corrupted generators output scale with the players count. Also big nerf compared to previous output
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
