### PR TITLE
Up the base silo output, make them maturing slower

### DIFF
--- a/code/controllers/subsystem/silo.dm
+++ b/code/controllers/subsystem/silo.dm
@@ -4,7 +4,7 @@ SUBSYSTEM_DEF(silo)
 	can_fire = FALSE
 	init_order = INIT_ORDER_SPAWNING_POOL
 	///How many larva points each pool gives per minute with a maturity of zero
-	var/base_larva_spawn_rate = 0.4
+	var/base_larva_spawn_rate = 0.5
 	///How many larva points are added every minutes in total
 	var/current_larva_spawn_rate = 0
 	///If the silos are maturing
@@ -19,7 +19,7 @@ SUBSYSTEM_DEF(silo)
 	var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
 	current_larva_spawn_rate = 0
 	for(var/obj/structure/resin/silo/silo AS in GLOB.xeno_resin_silos)
-		current_larva_spawn_rate += clamp(base_larva_spawn_rate * (1 + silo.maturity/(5400)), base_larva_spawn_rate, 2 * base_larva_spawn_rate)
+		current_larva_spawn_rate += clamp(base_larva_spawn_rate * (1 + silo.maturity/(9000)), base_larva_spawn_rate, 2 * base_larva_spawn_rate)
 	xeno_job.add_job_points(current_larva_spawn_rate)
 
 ///Activate the subsystem when shutters open and remove the free spawning when marines are joining


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Base output of silos is now 0.5 instead of 0.4. Make them reach peak maturity after 2h30 instead of 1h30 (so the base output of a silo that was created 1h15 ago is 0.75, and 1 after 2h30)

Base output could be more from what i've seen, but i'm hoping that psy drain will make the difference

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Two objectives: making the early round less hard for xenos, and giving less incentives to marines to bumrush silos.
That way, if the marines were not wiped out during first push, they can still try a second time

## Changelog
:cl:
balance: Base silo output is now 0.5
balance: Silos mature slower
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
