### PR TITLE
hypervene no longer is purged by /medicine purges

### DIFF
--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -141,7 +141,7 @@
 	amount_per_transfer_from_this = 12
 	volume = 36
 	icon_state = "autoinjector-8" //TEMP
-	list_reagents = list(/datum/reagent/medicine/hypervene = 36)
+	list_reagents = list(/datum/reagent/hypervene = 36)
 
 /obj/item/reagent_containers/hypospray/autoinjector/hyperzine
 	name = "hyperzine autoinjector"

--- a/code/game/objects/items/reagent_containers/glass/bottle.dm
+++ b/code/game/objects/items/reagent_containers/glass/bottle.dm
@@ -186,7 +186,7 @@
 	desc = "A very small bottle. Contains Hypervene - A purge chem for flushing toxins. Causes pain and vomiting."
 	icon_state = "bottle3"
 	volume = 10
-	list_reagents = list(/datum/reagent/medicine/hypervene = 10)
+	list_reagents = list(/datum/reagent/hypervene = 10)
 
 /obj/item/reagent_containers/glass/bottle/tricordrazine
 	name = "\improper Tricordrazine bottle"

--- a/code/game/objects/items/reagent_containers/pill.dm
+++ b/code/game/objects/items/reagent_containers/pill.dm
@@ -234,7 +234,7 @@
 
 /obj/item/reagent_containers/pill/hypervene
 	pill_desc = "A hypervene pill. A purge medication used to treat overdoses and rapidly remove toxins. Causes pain and vomiting."
-	list_reagents = list(/datum/reagent/medicine/hypervene = 12)
+	list_reagents = list(/datum/reagent/hypervene = 12)
 	pill_id = 14
 
 /obj/item/reagent_containers/pill/ultrazine

--- a/code/game/objects/items/scanners.dm
+++ b/code/game/objects/items/scanners.dm
@@ -302,7 +302,7 @@ REAGENT SCANNER
 		// Show pulse
 		var/pulse = H.handle_pulse()
 		dat += "\tPulse: <font color='[pulse == PULSE_THREADY || pulse == PULSE_NONE ? "red" : ""]'>[H.get_pulse(GETPULSE_TOOL)] bpm.</font>\n"
-		
+
 		if(H.has_working_organs())
 			//Chems that conflict with others:
 			var/synaptizine_amount = reagents_in_body[/datum/reagent/medicine/synaptizine]
@@ -338,7 +338,7 @@ REAGENT SCANNER
 				if(reagents_in_body[/datum/reagent/iron] < 5)
 					iron = " or one dose of iron."
 				advice += "<span class='scanner'><b>Low Blood:</b> Administer or recommend consumption of food[iron]</span>\n"
-			if(overdosed && reagents_in_body[/datum/reagent/medicine/hypervene] < 3)
+			if(overdosed && reagents_in_body[/datum/reagent/hypervene] < 3)
 				advice += "<span class='scanner'><b>Overdose:</b> Administer one dose of hypervene or perform dialysis on patient via sleeper.</span>\n"
 			if(unknown_body)
 				advice += "<span class='scanner'><b>Shrapnel/Embedded Object(s):</b> Seek surgical remedy to remove embedded object(s).</span>\n"

--- a/code/modules/reagents/reactions/medical.dm
+++ b/code/modules/reagents/reactions/medical.dm
@@ -170,7 +170,7 @@
 
 /datum/chemical_reaction/hypervene //New purge chem.
 	name = "Hypervene"
-	results = list(/datum/reagent/medicine/hypervene = 3)
+	results = list(/datum/reagent/hypervene = 3)
 	required_reagents = list(/datum/reagent/medicine/arithrazine = 1, /datum/reagent/medicine/dylovene = 1, /datum/reagent/medicine/ethylredoxrazine = 1)
 
 /datum/chemical_reaction/neuraline

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1055,7 +1055,7 @@
 /datum/reagent/medicine/ethylredoxrazine/overdose_crit_process(mob/living/L, metabolism)
 	L.apply_damage(2*effect_str, TOX)
 
-/datum/reagent/hypervene
+/datum/reagent/hypervene // this isn't under /medicine so things that purge /datum/reagent/medicine like neuro/larval don't purge it
 	name = "Hypervene"
 	description = "Quickly purges the body of toxin damage, radiation and all other chemicals. Causes significant pain."
 	color = "#19C832"

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1055,7 +1055,7 @@
 /datum/reagent/medicine/ethylredoxrazine/overdose_crit_process(mob/living/L, metabolism)
 	L.apply_damage(2*effect_str, TOX)
 
-/datum/reagent/medicine/hypervene
+/datum/reagent/hypervene
 	name = "Hypervene"
 	description = "Quickly purges the body of toxin damage, radiation and all other chemicals. Causes significant pain."
 	color = "#19C832"
@@ -1068,19 +1068,19 @@
 	taste_description = "punishment"
 	taste_multi = 8
 
-/datum/reagent/medicine/hypervene/on_mob_life(mob/living/L, metabolism)
+/datum/reagent/hypervene/on_mob_life(mob/living/L, metabolism)
 	L.reagent_shock_modifier -= PAIN_REDUCTION_HEAVY //Significant pain while metabolized.
 	if(prob(5)) //causes vomiting
 		L.vomit()
 	return ..()
 
-/datum/reagent/medicine/hypervene/overdose_process(mob/living/L, metabolism)
+/datum/reagent/hypervene/overdose_process(mob/living/L, metabolism)
 	L.apply_damages(effect_str, effect_str)
 	if(prob(10)) //heavy vomiting
 		L.vomit()
 	L.reagent_shock_modifier -= PAIN_REDUCTION_VERY_HEAVY * 1.25//Massive pain.
 
-/datum/reagent/medicine/hypervene/overdose_crit_process(mob/living/L, metabolism)
+/datum/reagent/hypervene/overdose_crit_process(mob/living/L, metabolism)
 	L.apply_damages(2*effect_str, 2*effect_str)
 	if(prob(50)) //violent vomiting
 		L.vomit()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
this mainly affects neurotoxin and larval accel
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
it makes no sense that the purging chemical is purged by common battlefield afflictions making it annoying to heal people ut of toxin damage, and having it as a medicine child makes no sense from a game design standpoint in my opinion
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: hypervene isn't purged by chems that purge any medicine like neuro/larval.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
