### PR TITLE
general purpose storage module max weight is small instead of normal

### DIFF
--- a/code/modules/modular_armor/storage.dm
+++ b/code/modules/modular_armor/storage.dm
@@ -71,7 +71,7 @@
 /** General storage */
 /obj/item/armor_module/storage/general
 	name = "General Purpose Storage module"
-	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Certainly not as specialised as any other storage modules, but definitely able to hold some larger things, like binoculars, maps, and motion detectors."
+	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Certainly not as specialised as any other storage modules, but definitely able to hold some small things, like binoculars, maps, and motion detectors. Able to hold magazines."
 	icon_state = "mod_general_bag"
 	storage_type =  /obj/item/storage/internal/modular/general
 	slowdown = 0.1
@@ -79,7 +79,7 @@
 /obj/item/storage/internal/modular/general
 	max_storage_space = 6
 	storage_slots = 2
-	max_w_class = WEIGHT_CLASS_NORMAL
+	max_w_class = WEIGHT_CLASS_SMALL
 
 	bypass_w_limit = list(
 		/obj/item/ammo_magazine/rifle,


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
its supposed to hold generally smaller items and magazines, not up to normal sized.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
GPSM shouldn't hold normal sized items.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: general purpose storage mooudle only holds up to small items, most magazines are unaffected
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
