### PR TITLE
CAS Balance Pass (orbit effect reduction, rocket buff)

### DIFF
--- a/code/controllers/subsystem/points.dm
+++ b/code/controllers/subsystem/points.dm
@@ -1,5 +1,5 @@
 // points per minute
-#define DROPSHIP_POINT_RATE 18 * (GLOB.current_orbit/3)
+#define DROPSHIP_POINT_RATE 18 * ((GLOB.current_orbit+3)/6)
 #define SUPPLY_POINT_RATE 2 * (GLOB.current_orbit/3)
 
 SUBSYSTEM_DEF(points)

--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -224,7 +224,7 @@
 	ammo_id = ""
 	bound_width = 64
 	bound_height = 32
-	travelling_time = 6 SECONDS
+	travelling_time = 4 SECONDS
 	point_cost = 0
 	ammo_type = CAS_MISSILE
 
@@ -237,9 +237,9 @@
 	name = "\improper AIM-224 'Widowmaker'"
 	desc = "The AIM-224 is the latest in air to air missile technology. Earning the nickname of 'Widowmaker' from various dropship pilots after improvements to its guidence warhead prevents it from being jammed leading to its high kill rate. Not well suited for ground bombardment, but its high velocity makes it reach its target quickly."
 	icon_state = "single"
-	travelling_time = 4 SECONDS //not powerful, but reaches target fast
+	travelling_time = 3 SECONDS //not powerful, but reaches target fast
 	ammo_id = ""
-	point_cost = 150
+	point_cost = 75
 
 /obj/structure/ship_ammo/rocket/widowmaker/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(3)
@@ -251,7 +251,7 @@
 	desc = "The AGM-227 missile is a mainstay of the overhauled dropship fleet against any mobile or armored ground targets. It's earned the nickname of 'Banshee' from the sudden wail that it emitts right before hitting a target. Useful to clear out large areas."
 	icon_state = "banshee"
 	ammo_id = "b"
-	point_cost = 175
+	point_cost = 150
 
 /obj/structure/ship_ammo/rocket/banshee/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(3)
@@ -276,7 +276,7 @@
 	desc = "The SM-17 'Fatty' is a cluster-bomb type ordnance that only requires laser-guidance when first launched."
 	icon_state = "fatty"
 	ammo_id = "f"
-	point_cost = 300
+	point_cost = 200
 
 /obj/structure/ship_ammo/rocket/fatty/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(2)
@@ -298,7 +298,7 @@
 	desc = "The XN-99 'Napalm' is an incendiary rocket used to turn specific targeted areas into giant balls of fire for a long time."
 	icon_state = "napalm"
 	ammo_id = "n"
-	point_cost = 350
+	point_cost = 200
 
 /obj/structure/ship_ammo/rocket/napalm/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(3)
@@ -321,14 +321,14 @@
 	ammo_count = 6
 	max_ammo_count = 6
 	ammo_name = "minirocket"
-	travelling_time = 6 SECONDS
+	travelling_time = 4 SECONDS
 	transferable_ammo = TRUE
 	point_cost = 100
 	ammo_type = CAS_MINI_ROCKET
 
 /obj/structure/ship_ammo/minirocket/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(2)
-	explosion(impact, 0, 2, 4, 5, adminlog = FALSE, small_animation = TRUE)//no messaging admin, that'd spam them.
+	explosion(impact, 0, 2, 4, 2, adminlog = FALSE, small_animation = TRUE)//no messaging admin, that'd spam them.
 	var/datum/effect_system/expl_particles/P = new
 	P.set_up(4, 0, impact)
 	P.start()

--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -658,7 +658,7 @@
 	if(firing_sound)
 		playsound(loc, firing_sound, 70, 1)
 	var/obj/structure/ship_ammo/SA = ammo_equipped //necessary because we nullify ammo_equipped when firing big rockets
-	var/ammo_travelling_time = SA.travelling_time * (GLOB.current_orbit/3) //how long the rockets/bullets take to reach the ground target.
+	var/ammo_travelling_time = SA.travelling_time * ((GLOB.current_orbit+3)/6) //how long the rockets/bullets take to reach the ground target.
 	var/ammo_warn_sound = SA.warning_sound
 	deplete_ammo()
 	COOLDOWN_START(src, last_fired, firing_delay)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Standard Rocket fly time reduced to 4 seconds (from 6): affects all rockets except widowmaker and mini rocket
Widowmaker price reduced to 75 (from 175) and fly time reduced to 3 (from 4)
Banshee cost reduced to 150 (from 175)
Napalm cost reduced to 200 (from 350)
Fatty cost reduced to 200 (from 300)
Minirocket fly time reduced to 4 seconds and flash range reduced
Orbit level now impacts fly time and point generation half as much (+-16.6% per orbit level above or below standard)

Keepers didn't get a price reduction because they're the only rocket I believe was deadly enough to warrant it's crazy high price, the reduced fly time is good enough for it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Most good POs use only laser/GAU because rockets just aren't good. They're very expensive and not faster than the GAU. The GAU costs 7.5 points per shot (10 shots per ammo, 75 points) compared to rockets which were costing a minimum of 175 points per shot (over 20x as much) for an effect that isn't that much greater which was just not worth using at all. Rockets have been sped up and most of them had their price reduced somewhat so it might actually be reasonable to print rockets now and not just laser/GAU ammo. 

Mini rockets had their flash range reduced because they were blinding marines from super far away even if you weren't in range of the actual damage, which meant that even if you have a good hit with it, it will usually have no payout because the marines who can potentially finish the xeno off are completely blind.

After the orbit effects being in for a few weeks, I feel they were a little too extreme. 1/3 the fly time at orbit 1 was a mega PITA and difficult to deal with for xenos while simultaneously being extremely restrictive on CAS due to barely being able to afford ammo. High orbit CAS is basically useless because xenos had 30 years to get away from the projectiles while simultaneously giving CAS so much ammo they will have a hard time draining it if they tried. Halving the effect of orbit on CAS  should lessen these extremes, while still making you change your outlook on how you're going to approach your fire missions at different orbit levels.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: CAS rockets are faster and most are less expensive, mini rockets don't blind marines as much
balance: Orbit level affects CAS less, both in terms of dropship point generation and fly time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
