### PR TITLE
Actually make it so the engineering shutters have their own buttons.

### DIFF
--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -2819,6 +2819,10 @@
 "jU" = (
 /turf/open/floor/mainship/cargo,
 /area/mainship/squads/general)
+"jW" = (
+/obj/machinery/door_control/mainship/engineering/armory,
+/turf/closed/wall/mainship,
+/area/mainship/engineering/upper_engineering)
 "jX" = (
 /obj/structure/closet/l3closet/virology,
 /obj/machinery/light{
@@ -7848,7 +7852,7 @@
 /area/mainship/command/cic)
 "AG" = (
 /obj/effect/decal/warning_stripes/thin,
-/obj/machinery/door/poddoor/shutters/mainship/cic/armory{
+/obj/machinery/door/poddoor/shutters/mainship/engineering/armory{
 	dir = 2
 	},
 /turf/open/floor/plating/mainship,
@@ -45743,7 +45747,7 @@ uW
 OK
 wY
 OR
-OK
+jW
 yy
 zs
 yx

--- a/code/game/objects/machinery/door_control.dm
+++ b/code/game/objects/machinery/door_control.dm
@@ -229,6 +229,12 @@
 	id = "tcomms"
 	req_one_access = list(ACCESS_MARINE_ENGINEERING, ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_BRIDGE)
 
+/obj/machinery/door_control/mainship/engineering/armory
+	name = "Engineering Armory Lockdown"
+	id = "engi_armory"
+	req_one_access = list(ACCESS_MARINE_ENGINEERING, ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_BRIDGE)
+
+
 /obj/machinery/door_control/mainship/corporate
 	name = "Privacy Shutters"
 	id = "cl_shutters"

--- a/code/game/objects/machinery/doors/shutters.dm
+++ b/code/game/objects/machinery/doors/shutters.dm
@@ -212,6 +212,11 @@
 	id = "cic_armory"
 	icon_state = "shutter1"
 
+/obj/machinery/door/poddoor/shutters/mainship/engineering/armory
+	name = "\improper Engineering Armory Shutters"
+	id = "engi_armory"
+	icon_state = "shutter1"
+
 /obj/machinery/door/poddoor/shutters/mainship/corporate
 	name = "\improper Privacy Shutters"
 	id = "cl_shutters"


### PR DESCRIPTION
## About The Pull Request
You can now control the shutters for the engi armory more easily.

## Why It's Good For The Game
It makes things tidier and actually work.

## Changelog
:cl:
fix: Fixes a missing button for the armory shutters on PoS engineering.
/:cl: