### PR TITLE
Humans now take low oxy damage when critdragged

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -279,7 +279,6 @@
 
 /atom/movable/proc/Moved(atom/oldloc, direction, Forced = FALSE)
 	SEND_SIGNAL(src, COMSIG_MOVABLE_MOVED, oldloc, direction, Forced)
-	var/mob/living/carbon/human/H = src
 	if(pulledby)
 		SEND_SIGNAL(src, COMSIG_MOVABLE_PULL_MOVED, oldloc, direction, Forced)
 	for(var/thing in light_sources) // Cycle through the light sources on this atom and tell them to update.

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -281,8 +281,6 @@
 	SEND_SIGNAL(src, COMSIG_MOVABLE_MOVED, oldloc, direction, Forced)
 	var/mob/living/carbon/human/H = src
 	if(pulledby)
-		if(istype(src, /mob/living/carbon/human) && istype(pulledby, /mob/living/carbon/xenomorph) && H.health < H.health_threshold_crit)
-			H.adjustOxyLoss(5) //if a human is dragged by a xenomorph while in crit they take 5 oxy damage per tile
 		SEND_SIGNAL(src, COMSIG_MOVABLE_PULL_MOVED, oldloc, direction, Forced)
 	for(var/thing in light_sources) // Cycle through the light sources on this atom and tell them to update.
 		var/datum/light_source/L = thing

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -481,7 +481,7 @@
 			
 /mob/living/carbon/human/set_stat(new_stat) //registers/unregisters critdragging signals
 	. = ..()
-	if(stat == UNCONSCIOUS)
+	if(new_stat == UNCONSCIOUS)
 		RegisterSignal(src, COMSIG_MOVABLE_PULL_MOVED, /mob/living/carbon/human.proc/oncritdrag)
 		return
 	if(. == UNCONSCIOUS)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -475,6 +475,12 @@
 	if(stat == UNCONSCIOUS)
 		blind_eyes(1)
 		disabilities |= DEAF
+		if(ishuman(src)) //registers signal for xeno critdragging
+			var/mob/living/carbon/human/human = src
+			RegisterSignal(human, COMSIG_MOVABLE_PULL_MOVED, /mob/living/carbon/human.proc/oncritdrag)
 	else if(. == UNCONSCIOUS)
 		adjust_blindness(-1)
 		disabilities &= ~DEAF
+		if(ishuman(src)) //unregisters signal for xeno critdragging
+			var/mob/living/carbon/human/human = src
+			UnregisterSignal(human, COMSIG_MOVABLE_PULL_MOVED)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -475,12 +475,14 @@
 	if(stat == UNCONSCIOUS)
 		blind_eyes(1)
 		disabilities |= DEAF
-		if(ishuman(src)) //registers signal for xeno critdragging
-			var/mob/living/carbon/human/human = src
-			RegisterSignal(human, COMSIG_MOVABLE_PULL_MOVED, /mob/living/carbon/human.proc/oncritdrag)
 	else if(. == UNCONSCIOUS)
 		adjust_blindness(-1)
 		disabilities &= ~DEAF
-		if(ishuman(src)) //unregisters signal for xeno critdragging
-			var/mob/living/carbon/human/human = src
-			UnregisterSignal(human, COMSIG_MOVABLE_PULL_MOVED)
+			
+/mob/living/carbon/human/set_stat(new_stat) //registers/unregisters critdragging signals
+	. = ..()
+	if(stat == UNCONSCIOUS)
+		RegisterSignal(src, COMSIG_MOVABLE_PULL_MOVED, /mob/living/carbon/human.proc/oncritdrag)
+		return
+	if(. == UNCONSCIOUS)
+		UnregisterSignal(src, COMSIG_MOVABLE_PULL_MOVED)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -44,7 +44,7 @@
 			else
 				hud_used.healths.icon_state = "health6"
 
-//damages humans by 5 oxy when dragged by a xeno, called on COMSIG_MOVABLE_PULL_MOVED
+///damages humans by 5 oxy when dragged by a xeno, called on COMSIG_MOVABLE_PULL_MOVED
 /mob/living/carbon/human/proc/oncritdrag() 
 	SIGNAL_HANDLER
 	if(isxeno(pulledby))

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -44,11 +44,11 @@
 			else
 				hud_used.healths.icon_state = "health6"
 
-///damages humans by 5 oxy when dragged by a xeno, called on COMSIG_MOVABLE_PULL_MOVED
+///gives humans oxy when dragged by a xeno, called on COMSIG_MOVABLE_PULL_MOVED
 /mob/living/carbon/human/proc/oncritdrag() 
 	SIGNAL_HANDLER
 	if(isxeno(pulledby))
-		adjustOxyLoss(5) //take 5 oxy damage per tile dragged
+		adjustOxyLoss(3) //take oxy damage per tile dragged
 
 /mob/living/carbon/update_stat()
 	. = ..()

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -43,7 +43,10 @@
 				hud_used.healths.icon_state = "health5"
 			else
 				hud_used.healths.icon_state = "health6"
-
+				
+/mob/living/carbon/human/proc/oncritdrag() //critdragging function, used in signals
+	if(isxeno(pulledby))
+		adjustOxyLoss(5)
 
 /mob/living/carbon/update_stat()
 	. = ..()

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -43,8 +43,10 @@
 				hud_used.healths.icon_state = "health5"
 			else
 				hud_used.healths.icon_state = "health6"
-				
-/mob/living/carbon/human/proc/oncritdrag() //critdragging function, used in signals
+
+//damages humans by 5 oxy when dragged by a xeno, called on COMSIG_MOVABLE_PULL_MOVED
+/mob/living/carbon/human/proc/oncritdrag() 
+	SIGNAL_HANDLER
 	if(isxeno(pulledby))
 		adjustOxyLoss(5) //take 5 oxy damage per tile dragged
 

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -46,7 +46,7 @@
 				
 /mob/living/carbon/human/proc/oncritdrag() //critdragging function, used in signals
 	if(isxeno(pulledby))
-		adjustOxyLoss(5)
+		adjustOxyLoss(5) //take 5 oxy damage per tile dragged
 
 /mob/living/carbon/update_stat()
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -224,7 +224,6 @@
 		if(L.stat == UNCONSCIOUS && !bypass_crit_delay)
 			if(!do_mob(src, L , XENO_PULL_CHARGE_TIME, BUSY_ICON_HOSTILE))
 				return FALSE
-	if(ishuman(L))				
 		if(L.stat == DEAD) //Can't drag dead human bodies
 			to_chat(usr,"<span class='xenowarning'>This looks gross, better not touch it</span>")
 			return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -221,9 +221,6 @@
 	if(L.buckled)
 		return FALSE //to stop xeno from pulling marines on roller beds.
 	if(ishuman(L))
-		if(L.stat == UNCONSCIOUS && !bypass_crit_delay)
-			if(!do_mob(src, L , XENO_PULL_CHARGE_TIME, BUSY_ICON_HOSTILE))
-				return FALSE
 		if(L.stat == DEAD) //Can't drag dead human bodies
 			to_chat(usr,"<span class='xenowarning'>This looks gross, better not touch it</span>")
 			return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -220,6 +220,10 @@
 	var/mob/living/L = AM
 	if(L.buckled)
 		return FALSE //to stop xeno from pulling marines on roller beds.
+	if(ishuman(L))
+		if(L.stat == UNCONSCIOUS && !bypass_crit_delay)
+			if(!do_mob(src, L , XENO_PULL_CHARGE_TIME, BUSY_ICON_HOSTILE))
+				return FALSE
 	if(ishuman(L))				
 		if(L.stat == DEAD) //Can't drag dead human bodies
 			to_chat(usr,"<span class='xenowarning'>This looks gross, better not touch it</span>")

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -220,12 +220,7 @@
 	var/mob/living/L = AM
 	if(L.buckled)
 		return FALSE //to stop xeno from pulling marines on roller beds.
-	if(ishuman(L))
-		if(L.health < L.get_crit_threshold() && L.stat != DEAD) //kill them if they're in crit
-			to_chat(usr,"<span class='xenowarning'>We attempt to get a grip on [L], but they appear to die from their critical injuries in the process. How disgusting!</span>")
-			L.death()
-			return FALSE
-				
+	if(ishuman(L))				
 		if(L.stat == DEAD) //Can't drag dead human bodies
 			to_chat(usr,"<span class='xenowarning'>This looks gross, better not touch it</span>")
 			return FALSE


### PR DESCRIPTION
## About the Pull Request
Humans in hardcrit now take low amounts of oxy damage when dragged while in hardcrit.
(originally insta death)
I have no idea what I'm doing with github, so let me know if I messed up the PR.

## Why it's Good for the Game

Critdragging helps xenomorphs secure kills and is seen as a good feature, but being dragged across the entire map, or having to drag someone across the entire map, is not fun gameplay. Making humans take around 5 oxygen damage each tile allows xenomorphs to still do what would reasonably already be expected, but stops singular marines being dragged to completely irrecoverable positions.

## Changelog
:cl: Chipswithchops
add: Humans in hardcrit now take low oxy damage per tile when dragged by a xenomorph 
\:cl:

