### PR TITLE
Psy drain cause clone damage to victim

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1213,6 +1213,8 @@
 	var/psy_points_reward = 60
 	///How much larva points it gives (8 points for one larva in distress)
 	var/larva_point_reward = 1
+	///How much clone damage it does 
+	var/clone_damage = 10
 
 /datum/action/xeno_action/activable/psydrain/can_use_ability(atom/A, silent = FALSE, override_flags)
 	. = ..() //do after checking the below stuff
@@ -1271,6 +1273,7 @@
 	victim.do_jitter_animation(2)
 
 	ADD_TRAIT(victim, TRAIT_PSY_DRAINED, TRAIT_PSY_DRAINED)
+	victim.apply_damage(clone_damage, CLONE)
 
 	SSpoints.xeno_points_by_hive[X.hivenumber] += psy_points_reward
 	var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Psy draining a body will give it 10 clone damage, that can only be healed in cryotube. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

So dying and dying again is a bit painfull for the marine, rather than being a 5 minutes wait like currently

## Changelog
:cl:
balance: psy drain gives 10 clone damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
