### PR TITLE
runner weed speed/slash nerf

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
@@ -12,7 +12,7 @@
 	gib_flick = "gibbed-a-runner"
 
 	// *** Melee Attacks *** //
-	melee_damage = 17
+	melee_damage = 15
 	attack_delay = 6
 
 	savage_cooldown = 30 SECONDS
@@ -22,6 +22,7 @@
 
 	// *** Speed *** //
 	speed = -1.3
+	weeds_speed_mod = -0.1
 
 	// *** Plasma *** //
 	plasma_max = 100
@@ -102,7 +103,7 @@
 	upgrade = XENO_UPGRADE_TWO
 
 	// *** Melee Attacks *** //
-	melee_damage = 21
+	melee_damage = 20
 
 	savage_cooldown = 30 SECONDS
 
@@ -138,7 +139,7 @@
 	savage_cooldown = 30 SECONDS
 
 	// *** Melee Attacks *** //
-	melee_damage = 21
+	melee_damage = 20
 
 	// *** Tackle *** //
 	tackle_damage = 21
@@ -186,6 +187,7 @@
 
 	// *** Speed *** //
 	speed = -1.3
+	weeds_speed_mod = -0.1
 
 	// *** Plasma *** //
 	plasma_max = 100
@@ -265,7 +267,7 @@
 	upgrade = XENO_UPGRADE_TWO
 
 	// *** Melee Attacks *** //
-	melee_damage = 21
+	melee_damage = 20
 
 	savage_cooldown = 30 SECONDS
 
@@ -301,7 +303,7 @@
 	savage_cooldown = 30 SECONDS
 
 	// *** Melee Attacks *** //
-	melee_damage = 21
+	melee_damage = 20
 
 	// *** Tackle *** //
 	tackle_damage = 21


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
mjp has come to break rounys legs

anyways i nerfed slash damage by 2 points at yung and 1 at elder/ancient and made weed speed -0.1.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
rouny is way too fast on weeds and deals a bit too much damage in my opinion for a t1, considering pools make losing xennomorphs 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: runner has lost 2 points of damage at yung/mature to 15 from 17, lost 1 at elder/ancient to 20. Only gets -0.1 weed speed bonus.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
