### PR TITLE
ROF Compensation Buffs to the GPMG and LMG

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -476,7 +476,6 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	hud_state = "rifle_heavy"
 	damage = 20
 	penetration = 10
-	damage_falloff = 0.50
 
 /datum/ammo/bullet/rifle/m4ra
 	name = "A19 high velocity bullet"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -476,6 +476,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	hud_state = "rifle_heavy"
 	damage = 20
 	penetration = 10
+	damage_falloff = 0.50
 
 /datum/ammo/bullet/rifle/m4ra
 	name = "A19 high velocity bullet"

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -618,7 +618,8 @@
 	aim_fire_delay = 0.18 SECONDS
 	aim_speed_modifier = 5
 
-	fire_delay = 0.18 SECONDS
+	fire_delay = 0.2 SECONDS
+	damage_mult = 1.1
 	burst_amount = 1
 	accuracy_mult_unwielded = 0.5
 	accuracy_mult = 1
@@ -670,7 +671,7 @@
 	aim_fire_delay = 0.1 SECONDS
 	aim_speed_modifier = 6
 
-	fire_delay = 0.165 SECONDS
+	fire_delay = 0.15 SECONDS
 	damage_falloff_mult = 0.25
 	burst_amount = 1
 	accuracy_mult_unwielded = 0.4

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -675,7 +675,7 @@
 	aim_speed_modifier = 6
 
 	fire_delay = 0.15 SECONDS
-	damage_falloff_mult = 0.50
+	damage_falloff_mult = 0.5
 	burst_amount = 1
 	accuracy_mult_unwielded = 0.4
 	accuracy_mult = 1

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -596,6 +596,7 @@
 		/obj/item/attachable/flashlight,
 		/obj/item/attachable/lasersight,
 		/obj/item/attachable/bipod,
+		/obj/item/attachable/angledgrip,
 		/obj/item/attachable/extended_barrel,
 		/obj/item/attachable/heavy_barrel,
 		/obj/item/attachable/suppressor,
@@ -607,6 +608,9 @@
 		/obj/item/attachable/compensator,
 		/obj/item/attachable/stock/t42stock,
 		/obj/item/attachable/magnetic_harness,
+		/obj/item/attachable/attached_gun/grenade,
+		/obj/item/attachable/attached_gun/flamer,
+		/obj/item/attachable/attached_gun/shotgun,
 	)
 
 	flags_gun_features = GUN_AUTO_EJECTOR|GUN_AMMO_COUNTER|GUN_LOAD_INTO_CHAMBER
@@ -619,7 +623,6 @@
 	aim_speed_modifier = 5
 
 	fire_delay = 0.2 SECONDS
-	damage_mult = 1.1
 	burst_amount = 1
 	accuracy_mult_unwielded = 0.5
 	accuracy_mult = 1

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -675,7 +675,7 @@
 	aim_speed_modifier = 6
 
 	fire_delay = 0.15 SECONDS
-	damage_falloff_mult = 0.25
+	damage_falloff_mult = 0.50
 	burst_amount = 1
 	accuracy_mult_unwielded = 0.4
 	accuracy_mult = 1


### PR DESCRIPTION
## About The Pull Request

GPMG now fires faster and LMG has more attachies to use.

## Why It's Good For The Game

Fire rate only works in incrementals of 0.05 which means guns like the GPMG (0.165 rof) and LMG (0.180 rof) actually end up with a rof of 0.2 which is the same as the assault rifle,meaning that they are much weaker than what they were supposed to be,I'm compensating that by making the GPMG have 0.15 firerate (same as p90) and increasing the damage falloff to make up for the extra 0.015 rof, and making the LMG have more attachies,it's not perfect but IDK if that problem will ever be fixed so letting these guns have worse performance than they should in the meantime doesn't sit well with me.

## Changelog
:cl:
balance:Buffed GPMG fire rate and increased damage fall off.
balance:LMG now can use agrip/underbarrel flamer/greande launcher/masterkey.
/:cl:
