### PR TITLE
Less xenos per marines spawn

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -118,8 +118,8 @@ MEDICAL_OFFICER, MEDICAL_RESEARCHER, SQUAD_LEADER, SQUAD_SPECIALIST, SQUAD_SMART
 
 // how much a job is going to contribute towards burrowed larva. see config for points required to larva. old balance was 1 larva per 3 humans.
 #define LARVA_POINTS_SHIPSIDE 1
-#define LARVA_POINTS_SHIPSIDE_STRONG 2
-#define LARVA_POINTS_REGULAR 3
+#define LARVA_POINTS_SHIPSIDE_STRONG 1.5
+#define LARVA_POINTS_REGULAR 2.5
 #define LARVA_POINTS_STRONG 6
 
 #define SURVIVOR_POINTS_REGULAR 1


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Shipside role will give 1.5 points instead of 2
Marine will give 2.5 points instead of 3
You need 8 points for a larva

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

The ratio marine/xenos is crazy at start, which mean instant FOBhugging by xenos who have a very very hard time to even get a miner against not-retarded xenos. I think the presence of turrets should help xenos to not get crushed by marine unga ball, even with lower numbers.

Should make the game less frustrating for marines, and allowing a more skirmishy game flow

## Changelog
:cl:
balance: The number of larva points per marine spawn is reduced 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
