### PR TITLE
Reenable survivor and xeno pregame changes

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -28,6 +28,7 @@
 #define COMSIG_GLOB_MOB_LOGIN "!mob_login"
 #define COMSIG_GLOB_MOB_LOGOUT "!mob_logout"
 #define COMSIG_GLOB_MOB_DEATH "!mob_death"
+	#define DEATH_STOPPED (1<<0)
 
 
 /// Sent when a marine dropship enters transit level
@@ -621,3 +622,6 @@
 #define COMSIG_AUTOMATIC_SHOOTER_START_SHOOTING_AT "start_shooting_at"
 #define COMSIG_AUTOMATIC_SHOOTER_STOP_SHOOTING_AT "stop_shooting_at"
 #define COMSIG_AUTOMATIC_SHOOTER_SHOOT "shoot"
+
+///datum/controller/subsystem/monitor signals
+#define COMSIG_MONITOR_STATE_CHANGE "monitor_state_change"

--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -300,7 +300,7 @@
 		CRASH("Xeno attempted prespawn revive while Monitor gamestate dissalowed it")
 	var/mob/living/carbon/xenomorph/xeno = dier
 	xeno.revive()
-	xeno.visible_message("<span class='warning'> [xeno] contorts as the space around it tears and consumes it!</span>", "<span class='xenodanger'>YOU IGNORANT CHILD! I will keep you in this world if I must, but at your expense!</span>")
+	xeno.visible_message("<span class='warning'>[xeno] contorts as the space around it tears and consumes it!</span>", "<span class='xenodanger'>YOU IGNORANT CHILD! I will keep you in this world if I must, but at your expense!</span>")
 	xeno.forceMove(pick(GLOB.xeno_resin_silo_turfs))
 	xeno.upgrade_stored /= 2
 	xeno.set_stagger(10)

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -39,7 +39,8 @@
 			qdel(src)
 		return
 
-	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_MOB_DEATH, src)
+	if(SEND_GLOBAL_SIGNAL(COMSIG_GLOB_MOB_DEATH, src) & DEATH_STOPPED)
+		return
 	SEND_SIGNAL(src, COMSIG_MOB_DEATH, gibbing)
 	log_combat(src, src, "[deathmessage]")
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Xenos will now take a upgrade penalty when dying pre-shutters and be teleported to a silo turf
![image](https://user-images.githubusercontent.com/57223640/110471908-febea700-80dc-11eb-93b7-5e514a3494f7.png)

Also fixes SSmonitor not setting gamestate
## Why It's Good For The Game

Survs are back, and maybe not shit this time

## Changelog
:cl:
add: Survs are back
add: Xenos dying before shutters open will have their upgrade points halved and be teleported to a silo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
