### PR TITLE
Transit shutters has had its ID changed

### DIFF
--- a/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -2442,6 +2442,13 @@
 /obj/effect/turf_overlay/icerock,
 /turf/closed/ice_rock/corners,
 /area/ice_colony/exterior/surface/cliff)
+"ajQ" = (
+/obj/machinery/door_control{
+	name = "Storage Unit Control";
+	pixel_x = -24
+	},
+/turf/open/floor/plating/icefloor,
+/area/ice_colony/surface/requesitions)
 "ajR" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -41704,15 +41711,15 @@ abB
 acl
 acY
 abB
-abB
+ajQ
 ajo
 acY
 acH
-abB
+ajQ
 ajo
 acY
 abB
-abB
+ajQ
 ajo
 acY
 iYJ

--- a/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -2442,13 +2442,6 @@
 /obj/effect/turf_overlay/icerock,
 /turf/closed/ice_rock/corners,
 /area/ice_colony/exterior/surface/cliff)
-"ajQ" = (
-/obj/machinery/door_control{
-	name = "Storage Unit Control";
-	pixel_x = -24
-	},
-/turf/open/floor/plating/icefloor,
-/area/ice_colony/surface/requesitions)
 "ajR" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -41711,15 +41704,15 @@ abB
 acl
 acY
 abB
-ajQ
+abB
 ajo
 acY
 acH
-ajQ
+abB
 ajo
 acY
 abB
-ajQ
+abB
 ajo
 acY
 iYJ

--- a/code/game/objects/machinery/doors/shutters.dm
+++ b/code/game/objects/machinery/doors/shutters.dm
@@ -113,6 +113,7 @@
 	desc = "Safety shutters to prevent dangerous depressurization during flight"
 	icon = 'icons/obj/doors/mainship/blastdoors_shutters.dmi'
 	resistance_flags = UNACIDABLE|INDESTRUCTIBLE
+	id = "ghhjmugggggtgggbg" // do not have any button or thing have an ID assigned to this, it is a very bad idea.
 
 
 /obj/machinery/door/poddoor/shutters/mainship/open


### PR DESCRIPTION
## About The Pull Request
![dreammaker_2021-03-22_13-43-35](https://user-images.githubusercontent.com/17747087/111993399-ddb37880-8b16-11eb-969c-94d1b4232ec0.png)
simply adds the ID part to this

## Why It's Good For The Game
if any of the buttons on the place it landed has it's ID set to null then it would've triggered the transit shutters because the transit shutters were also null, **this is bad.**

~~kindadread owes me a crash token or two for this favor~~
## Changelog
:cl: Vondiech
fix: Transit shutters can no longer be triggered by any buttons on shipside or groundside that has its ID set to null
/:cl:
