### PR TITLE
Turrets are destroyed on hijack

### DIFF
--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -126,6 +126,7 @@
 #define COUNT_IGNORE_ALIVE_SSD (COUNT_IGNORE_HUMAN_SSD|COUNT_IGNORE_XENO_SSD)
 
 #define SILO_PRICE 900
+#define XENO_TURRET_PRICE 100
 
 //The minimum round time before siloless timer can start (13:00)
 #define MINIMUM_TIME_SILO_LESS_COLLAPSE 36000 

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1076,7 +1076,7 @@
 	/// How long does it take to build
 	var/build_time = 15 SECONDS
 	/// Pyschic point cost
-	var/psych_cost = 100
+	var/psych_cost = XENO_TURRET_PRICE
 
 
 /datum/action/xeno_action/activable/build_turret/can_use_ability(atom/A, silent, override_flags)

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -733,7 +733,7 @@ to_chat will check for valid clients itself already so no need to double check f
 			continue
 		qdel(silo)
 
-	SSpoints.xeno_points_by_hive[hivenumber] = SILO_PRICE //Give a free silo when going shipside
+	SSpoints.xeno_points_by_hive[hivenumber] = SILO_PRICE + XENO_TURRET_PRICE //Give a free silo when going shipside and a turret
 
 	var/list/living_player_list = SSticker.mode.count_humans_and_xenos(count_flags = COUNT_IGNORE_HUMAN_SSD)
 	var/num_humans = living_player_list[1]

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -208,8 +208,14 @@
 	START_PROCESSING(SSobj, src)
 	AddComponent(/datum/component/automatedfire/xeno_turret_autofire, firerate)
 	RegisterSignal(src, COMSIG_AUTOMATIC_SHOOTER_SHOOT, .proc/shoot)
+	RegisterSignal(SSdcs, COMSIG_GLOB_DROPSHIP_HIJACKED, .proc/destroy_on_hijack)
 	set_light(2, 2, LIGHT_COLOR_GREEN)
 	update_icon()
+
+///Signal handler to delete the turret when the alamo is hijacked
+/obj/structure/resin/xeno_turret/proc/destroy_on_hijack()
+	SIGNAL_HANDLER
+	qdel(src)
 
 /obj/structure/resin/xeno_turret/Destroy()
 	var/datum/effect_system/smoke_spread/xeno/smoke = new /datum/effect_system/smoke_spread/xeno/acid(src)
@@ -218,6 +224,7 @@
 	set_hostile(null)
 	set_last_hostile(null)
 	STOP_PROCESSING(SSobj, src)
+	UnregisterSignal(SSdcs, COMSIG_GLOB_DROPSHIP_HIJACKED)
 	return ..()
 
 /obj/structure/resin/xeno_turret/ex_act(severity)

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -224,7 +224,6 @@
 	set_hostile(null)
 	set_last_hostile(null)
 	STOP_PROCESSING(SSobj, src)
-	UnregisterSignal(SSdcs, COMSIG_GLOB_DROPSHIP_HIJACKED)
 	return ..()
 
 /obj/structure/resin/xeno_turret/ex_act(severity)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

All turrets are destroyed on hijack. A free turret on top of the free super silo is given when hijacking

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The psych points are reset when the alamo hijack. This is done so groundside and shipside are two clearly separated game moment, and a bit easier to balance (yeah i know, balancing shipside...) Piling in on 100 turrets in alamo makes it impossible for marines to ever breach it, on top of the super pool being busted

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Xeno turrets are destroyed on hijacking
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
