### PR TITLE
Add some fire alarms to the sulaco. Along with ONE camera because i can't be bothered to make another PR just for that one.

### DIFF
--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -280,6 +280,7 @@
 /obj/item/storage/belt/combatLifesaver,
 /obj/item/storage/belt/combatLifesaver,
 /obj/item/storage/belt/medical,
+/obj/machinery/firealarm,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 1
 	},
@@ -1534,6 +1535,9 @@
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/medical1,
+/obj/machinery/firealarm{
+	dir = 4
+	},
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 8
 	},
@@ -1897,6 +1901,9 @@
 /area/sulaco/engineering/ce)
 "ahe" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 8
+	},
 /turf/open/floor/prison,
 /area/sulaco/engineering/ce)
 "ahg" = (
@@ -1916,6 +1923,10 @@
 	dir = 1
 	},
 /area/sulaco/engineering/atmos)
+"ahj" = (
+/obj/machinery/firealarm,
+/turf/open/floor/prison,
+/area/sulaco/marine/charlie)
 "ahm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 8;
@@ -2259,6 +2270,7 @@
 /obj/item/clothing/glasses/hud/health,
 /obj/structure/paper_bin,
 /obj/item/tool/pen,
+/obj/machinery/firealarm,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 4
 	},
@@ -2303,6 +2315,9 @@
 /area/sulaco/cryosleep)
 "aka" = (
 /obj/structure/closet/secure_closet/req_officer,
+/obj/machinery/firealarm{
+	dir = 4
+	},
 /turf/open/floor/prison,
 /area/sulaco/cargo/office)
 "ake" = (
@@ -2348,6 +2363,9 @@
 /area/sulaco/engineering)
 "akn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/firealarm{
+	dir = 8
+	},
 /turf/open/floor/prison,
 /area/sulaco/engineering)
 "ako" = (
@@ -2459,6 +2477,9 @@
 /obj/item/healthanalyzer,
 /obj/effect/decal/warning_stripes/thick{
 	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	dir = 4
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cryosleep)
@@ -3782,6 +3803,9 @@
 /area/sulaco/engineering)
 "arP" = (
 /obj/structure/closet/firecloset,
+/obj/machinery/firealarm{
+	dir = 8
+	},
 /turf/open/floor/prison/darkyellow/full,
 /area/sulaco/engineering)
 "arQ" = (
@@ -4082,6 +4106,9 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall3)
 "atd" = (
+/obj/machinery/firealarm{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/sulaco/bridge/office)
 "atk" = (
@@ -6044,6 +6071,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/machinery/firealarm,
 /turf/open/floor/prison/darkyellow{
 	dir = 1
 	},
@@ -6177,6 +6205,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/machinery/firealarm,
 /turf/open/floor/wood,
 /area/sulaco/cap_office)
 "aCE" = (
@@ -6509,6 +6538,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm,
 /turf/open/floor/prison/darkyellow{
 	dir = 1
 	},
@@ -6655,6 +6685,7 @@
 /turf/open/floor/prison/blue/corner,
 /area/sulaco/marine/delta)
 "aEU" = (
+/obj/machinery/firealarm,
 /turf/open/floor/prison/blue,
 /area/sulaco/marine/delta)
 "aEV" = (
@@ -8742,6 +8773,7 @@
 /obj/machinery/alarm{
 	dir = 4
 	},
+/obj/machinery/firealarm,
 /turf/open/floor/prison/whitegreen/full,
 /area/sulaco/medbay/hangar)
 "aRb" = (
@@ -9584,6 +9616,7 @@
 /obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
 	dir = 1
 	},
+/obj/machinery/firealarm,
 /turf/open/floor/prison,
 /area/sulaco/hallway/lower_main_hall)
 "aWS" = (
@@ -10639,6 +10672,10 @@
 "bPM" = (
 /turf/open/floor/prison/plate,
 /area/sulaco/cargo)
+"bRu" = (
+/obj/machinery/firealarm,
+/turf/open/floor/prison/bright_clean,
+/area/sulaco/hangar)
 "bTI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/plate,
@@ -10659,6 +10696,13 @@
 	dir = 1
 	},
 /area/sulaco/hallway/central_hall)
+"bVU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 4
+	},
+/turf/open/floor/prison/bright_clean,
+/area/sulaco/hangar)
 "bWf" = (
 /turf/closed/wall/mainship/gray/outer,
 /area/sulaco/hangar/droppod)
@@ -10725,6 +10769,10 @@
 /obj/item/storage/bag/trash,
 /turf/open/floor/plating,
 /area/sulaco/maintenance/lower_maint2)
+"cmN" = (
+/obj/machinery/firealarm,
+/turf/open/floor/prison,
+/area/sulaco/briefing)
 "cnu" = (
 /obj/structure/cable,
 /turf/open/floor/prison,
@@ -10850,6 +10898,14 @@
 /obj/structure/cable,
 /turf/open/floor/prison/whitegreen,
 /area/sulaco/research)
+"cCN" = (
+/obj/machinery/firealarm{
+	dir = 8
+	},
+/turf/open/floor/prison/yellow{
+	dir = 4
+	},
+/area/sulaco/engineering/atmos)
 "cEF" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -10879,6 +10935,12 @@
 	},
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cryosleep)
+"cHY" = (
+/obj/machinery/firealarm{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/sulaco/engineering/smes)
 "cJh" = (
 /obj/machinery/cryopod,
 /obj/structure/cable,
@@ -11170,6 +11232,14 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cafeteria)
+"dyQ" = (
+/obj/machinery/firealarm{
+	dir = 4
+	},
+/turf/open/floor/prison/whitegreen/corner{
+	dir = 8
+	},
+/area/sulaco/medbay/west)
 "dyW" = (
 /obj/structure/largecrate/guns/merc,
 /obj/effect/decal/cleanable/dirt,
@@ -11687,6 +11757,12 @@
 /obj/structure/window/framed/mainship/gray/toughened/hull,
 /turf/open/floor/plating/platebotc,
 /area/sulaco/maintenance/lower_maint)
+"fbS" = (
+/obj/machinery/firealarm{
+	dir = 4
+	},
+/turf/open/floor/prison,
+/area/sulaco/hallway/central_hall3)
 "fdz" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/yellow/hidden,
@@ -11741,6 +11817,19 @@
 	},
 /turf/open/floor/plating,
 /area/sulaco/maintenance/north_solar_maint)
+"fmW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/obj/machinery/firealarm,
+/turf/open/floor/prison/whitegreen/corner{
+	dir = 1
+	},
+/area/sulaco/medbay)
 "fng" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -12072,6 +12161,12 @@
 	},
 /turf/open/floor/prison,
 /area/sulaco/engineering/engine)
+"glp" = (
+/obj/machinery/firealarm{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/sulaco/liaison/quarters)
 "gmD" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 9
@@ -12153,6 +12248,15 @@
 	dir = 1
 	},
 /area/sulaco/hangar/one)
+"gwK" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/machinery/firealarm{
+	dir = 8
+	},
+/turf/open/floor/prison,
+/area/sulaco/telecomms/office)
 "gyp" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/machinery/landinglight/ds2/delaythree,
@@ -12338,6 +12442,9 @@
 	height = 2;
 	id = "morgue"
 	},
+/obj/machinery/firealarm{
+	dir = 4
+	},
 /turf/open/floor/cult,
 /area/sulaco/morgue)
 "hcB" = (
@@ -12406,6 +12513,10 @@
 	dir = 1
 	},
 /area/sulaco/hallway/lower_main_hall)
+"hmD" = (
+/obj/machinery/firealarm,
+/turf/open/floor/prison,
+/area/sulaco/marine/bravo)
 "hnW" = (
 /obj/structure/target_stake,
 /obj/item/target,
@@ -12955,6 +13066,10 @@
 	},
 /turf/open/floor/prison/whitegreen/corner,
 /area/sulaco/medbay)
+"iLs" = (
+/obj/machinery/firealarm,
+/turf/open/floor/prison,
+/area/sulaco/marine/alpha)
 "iLZ" = (
 /obj/effect/landmark{
 	name = "JoinLate"
@@ -13016,6 +13131,10 @@
 	},
 /turf/open/floor/prison,
 /area/mainship/living/pilotbunks)
+"iWz" = (
+/obj/machinery/firealarm,
+/turf/open/floor/prison,
+/area/sulaco/hangar)
 "iWV" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -13070,6 +13189,14 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/prison/darkyellow/corner,
 /area/sulaco/engineering/ce)
+"jfN" = (
+/obj/machinery/firealarm{
+	dir = 8
+	},
+/turf/open/floor/prison/whitegreen{
+	dir = 5
+	},
+/area/sulaco/research)
 "jfR" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 8
@@ -13135,6 +13262,14 @@
 /obj/structure/window/framed/mainship/gray/toughened/hull,
 /turf/open/floor/plating/platebotc,
 /area/sulaco/marine/alpha)
+"jsB" = (
+/obj/machinery/firealarm{
+	dir = 8
+	},
+/turf/open/floor/prison/whitegreen{
+	dir = 4
+	},
+/area/sulaco/research)
 "jvc" = (
 /obj/structure/window/framed/mainship/gray/toughened,
 /obj/machinery/door/poddoor/shutters/opened/wy{
@@ -13466,6 +13601,12 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/prison,
 /area/sulaco/cargo/office)
+"ksu" = (
+/obj/machinery/firealarm{
+	dir = 8
+	},
+/turf/open/floor/prison,
+/area/sulaco/hallway/central_hall2)
 "ksU" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -13637,6 +13778,7 @@
 /obj/structure/bed/stool{
 	pixel_y = 8
 	},
+/obj/machinery/firealarm,
 /turf/open/floor/grass,
 /area/mainship/living/starboard_garden)
 "kSG" = (
@@ -14007,6 +14149,14 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/prison/red,
 /area/sulaco/hallway/central_hall2)
+"lIA" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/firealarm{
+	dir = 4
+	},
+/turf/open/floor/prison/plate,
+/area/sulaco/maintenance/south_solar_maint)
 "lJP" = (
 /obj/structure/table/mainship,
 /obj/item/reagent_containers/food/snacks/grilledcheese{
@@ -14120,6 +14270,9 @@
 /turf/open/floor/prison/arrow,
 /area/sulaco/cargo)
 "lZk" = (
+/obj/machinery/firealarm{
+	dir = 8
+	},
 /turf/open/floor/prison/whitegreen{
 	dir = 6
 	},
@@ -14602,6 +14755,10 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
+"nob" = (
+/obj/machinery/firealarm,
+/turf/open/floor/mainship/ai,
+/area/sulaco/command/ai)
 "npi" = (
 /obj/structure/ship_ammo/minirocket/illumination,
 /turf/open/floor/prison,
@@ -14787,6 +14944,12 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/prison/plate,
 /area/shuttle/distress/arrive_1)
+"nSK" = (
+/obj/machinery/firealarm{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/sulaco/liaison)
 "nTc" = (
 /obj/structure/prop/mainship/name_stencil{
 	icon_state = "TGMC2"
@@ -14802,6 +14965,13 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
+"nVR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 8
+	},
+/turf/open/floor/cult,
+/area/sulaco/morgue)
 "nVU" = (
 /obj/machinery/light/small,
 /obj/machinery/portable_atmospherics/pump,
@@ -14812,6 +14982,9 @@
 /area/sulaco/maintenance/lower_maint2)
 "nWn" = (
 /obj/structure/closet/secure_closet/staff_officer,
+/obj/machinery/firealarm{
+	dir = 8
+	},
 /turf/open/floor/prison/red/full{
 	dir = 8
 	},
@@ -14899,6 +15072,9 @@
 "oiA" = (
 /obj/effect/landmark/start/job/synthetic,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/machinery/firealarm{
+	dir = 4
+	},
 /turf/open/floor/prison,
 /area/sulaco/engineering/engine)
 "oiN" = (
@@ -15253,6 +15429,10 @@
 /obj/structure/cable,
 /turf/open/floor/prison/sterilewhite,
 /area/sulaco/cryosleep)
+"oOw" = (
+/obj/machinery/firealarm,
+/turf/open/floor/prison/darkyellow/corner,
+/area/sulaco/engineering)
 "oPl" = (
 /obj/structure/bed/chair,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -15320,6 +15500,9 @@
 "oVi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/firealarm{
+	dir = 8
+	},
 /turf/open/floor/prison/red,
 /area/sulaco/cargo)
 "oVU" = (
@@ -15541,6 +15724,12 @@
 /obj/item/lightreplacer,
 /turf/open/floor/prison/plate,
 /area/sulaco/cargo/office)
+"pum" = (
+/obj/machinery/firealarm{
+	dir = 8
+	},
+/turf/open/floor/prison,
+/area/sulaco/command/eva)
 "puw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -16187,6 +16376,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/plate,
 /area/shuttle/distress/arrive_1)
+"rms" = (
+/obj/machinery/firealarm,
+/turf/open/floor/prison/red,
+/area/sulaco/hallway/central_hall3)
 "rmV" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /turf/open/floor/plating/plating_catwalk/prison,
@@ -16277,6 +16470,10 @@
 /obj/structure/prop/mainship/sensor_computer1/sd,
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
+"rxh" = (
+/obj/machinery/firealarm,
+/turf/open/floor/prison,
+/area/sulaco/marine)
 "ryR" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -17278,6 +17475,10 @@
 	dir = 1
 	},
 /area/sulaco/bridge)
+"tPp" = (
+/obj/machinery/firealarm,
+/turf/open/floor/prison/sterilewhite,
+/area/sulaco/cafeteria)
 "tPQ" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
@@ -17447,6 +17648,9 @@
 /area/sulaco/engineering/storage)
 "uxf" = (
 /obj/structure/supply_drop/charlie,
+/obj/machinery/firealarm{
+	dir = 8
+	},
 /turf/open/floor/prison/plate,
 /area/sulaco/cargo)
 "uyf" = (
@@ -18055,6 +18259,12 @@
 	dir = 4
 	},
 /area/mainship/shipboard/weapon_room)
+"wkO" = (
+/obj/machinery/firealarm{
+	dir = 4
+	},
+/turf/open/floor/prison/sterilewhite,
+/area/sulaco/cryosleep)
 "wml" = (
 /obj/structure/shuttle/engine/propulsion/burst/left{
 	dir = 4
@@ -18081,6 +18291,14 @@
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/sulaco/engineering/engine)
+"wos" = (
+/obj/machinery/firealarm{
+	dir = 8
+	},
+/turf/open/floor/prison/red{
+	dir = 4
+	},
+/area/mainship/shipboard/weapon_room)
 "wpm" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/machinery/light{
@@ -18133,6 +18351,9 @@
 "wxY" = (
 /obj/effect/landmark/start/job/pilotofficer,
 /obj/structure/bed,
+/obj/machinery/firealarm{
+	dir = 8
+	},
 /turf/open/floor/prison,
 /area/mainship/living/pilotbunks)
 "wyp" = (
@@ -18403,6 +18624,12 @@
 "xca" = (
 /turf/closed/wall/mainship/gray,
 /area/sulaco/hangar/droppod)
+"xcr" = (
+/obj/machinery/firealarm{
+	dir = 4
+	},
+/turf/open/floor/mainship/tcomms,
+/area/sulaco/telecomms)
 "xgp" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
@@ -18509,6 +18736,11 @@
 "xrp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/plate,
+/area/sulaco/maintenance/south_solar_maint)
+"xta" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm,
+/turf/open/floor/prison,
 /area/sulaco/maintenance/south_solar_maint)
 "xur" = (
 /obj/structure/prop/mainship/sensor_computer2/sd,
@@ -18675,6 +18907,10 @@
 	dir = 4
 	},
 /area/sulaco/medbay/storage2)
+"yha" = (
+/obj/machinery/firealarm,
+/turf/open/floor/prison,
+/area/sulaco/hallway/lower_main_hall)
 "yht" = (
 /obj/effect/decal/siding{
 	dir = 9
@@ -18755,6 +18991,12 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/wood,
 /area/sulaco/liaison)
+"ymf" = (
+/obj/machinery/firealarm,
+/turf/open/floor/prison/red{
+	dir = 1
+	},
+/area/sulaco/hallway/central_hall)
 
 (1,1,1) = {"
 aaa
@@ -35137,7 +35379,7 @@ rJl
 hKJ
 gXA
 mVd
-wjX
+wos
 wjX
 sXi
 aIz
@@ -35379,7 +35621,7 @@ uNh
 jfX
 aQh
 aaY
-aaY
+wkO
 aaY
 aaY
 aaY
@@ -37203,7 +37445,7 @@ aGf
 aBk
 aBk
 aJS
-aJV
+ahj
 aKE
 aJy
 aJV
@@ -39259,7 +39501,7 @@ aGf
 aBk
 aBk
 aJX
-aKa
+hmD
 aKJ
 aKO
 aKa
@@ -39768,7 +40010,7 @@ axy
 aoR
 awY
 aDO
-aBk
+rxh
 aGk
 aBk
 aIg
@@ -40013,7 +40255,7 @@ gXd
 aea
 alq
 anw
-any
+tPp
 aoR
 aoR
 any
@@ -40545,7 +40787,7 @@ aBk
 bij
 aKb
 aKb
-aKK
+iLs
 aKK
 aKb
 aKb
@@ -42341,7 +42583,7 @@ fjF
 aam
 abZ
 ntk
-abD
+dyQ
 acG
 jYs
 add
@@ -43764,7 +44006,7 @@ asQ
 asQ
 atz
 asQ
-awI
+ymf
 bax
 aoi
 azq
@@ -44386,7 +44628,7 @@ alx
 lvm
 szj
 lpY
-aWG
+yha
 xKR
 bIb
 aan
@@ -45036,7 +45278,7 @@ aRh
 aRG
 aRI
 fkY
-fkY
+jsB
 tao
 tus
 aOW
@@ -45058,7 +45300,7 @@ tkS
 aHD
 eMk
 aAI
-aGC
+nob
 aGC
 aGC
 lsW
@@ -47094,7 +47336,7 @@ aEF
 aaf
 aEe
 aQM
-aRI
+jfN
 fkY
 aVO
 aoi
@@ -47627,7 +47869,7 @@ aDr
 aDC
 lnd
 aGv
-aFR
+lIA
 aFR
 aFR
 azp
@@ -47727,7 +47969,7 @@ erP
 erP
 erP
 erP
-aWG
+yha
 jPq
 aVv
 aaL
@@ -48251,7 +48493,7 @@ aeF
 aeK
 ehi
 aaJ
-lbq
+fmW
 ade
 jhf
 ade
@@ -48649,7 +48891,7 @@ aks
 aor
 apI
 apI
-aor
+ksu
 ank
 aDx
 xrp
@@ -50190,7 +50432,7 @@ oMn
 axd
 avn
 ank
-lmE
+xta
 umL
 azd
 wTd
@@ -52105,7 +52347,7 @@ aSV
 aSv
 aQr
 aTc
-gHU
+bVU
 aPF
 aSu
 rXl
@@ -52606,7 +52848,7 @@ aPp
 aPq
 aPA
 aRd
-aPF
+bRu
 aPF
 bbu
 aPF
@@ -52751,7 +52993,7 @@ aYZ
 eOP
 pMU
 akW
-anr
+cmN
 apT
 ars
 ihO
@@ -56610,7 +56852,7 @@ stF
 mNA
 xAc
 aQi
-mYf
+rms
 jVe
 atn
 ylT
@@ -57231,7 +57473,7 @@ aPF
 aPF
 aPF
 bFa
-cdy
+iWz
 nNP
 aUp
 cdy
@@ -57371,7 +57613,7 @@ aYZ
 aaW
 aQi
 aQA
-sqS
+nVR
 aQA
 aQA
 aQA
@@ -57392,7 +57634,7 @@ bcq
 baf
 bdj
 bdO
-bdM
+glp
 kvB
 aWU
 beL
@@ -57902,7 +58144,7 @@ aZa
 cYI
 aUU
 baf
-baf
+nSK
 bcS
 bvZ
 mDu
@@ -59196,7 +59438,7 @@ avN
 jwV
 avU
 avU
-avU
+fbS
 lMX
 aIb
 aIb
@@ -59434,7 +59676,7 @@ niH
 bcD
 bbV
 bbr
-baz
+xcr
 aZF
 aYM
 mYf
@@ -61750,7 +61992,7 @@ aRw
 baz
 aZN
 aYM
-mYf
+rms
 eck
 axN
 azf
@@ -62775,7 +63017,7 @@ lve
 bcK
 lwy
 bbx
-tSP
+gwK
 tSP
 aQT
 bYw
@@ -63295,7 +63537,7 @@ asI
 asj
 awa
 iSb
-akm
+oOw
 alu
 tDT
 aIt
@@ -63567,7 +63809,7 @@ bKl
 bKl
 aLN
 aIa
-aKl
+pum
 aKl
 aOo
 aOP
@@ -65083,12 +65325,12 @@ aeq
 aih
 rzq
 als
-roQ
+cCN
 jRo
 aom
 apf
 aqy
-aqy
+cHY
 aqy
 asX
 iSb


### PR DESCRIPTION
## About The Pull Request
The sulaco, unlike pillars of spring lacked fire alarms. 
Not even one.
I know it is an older model but it really should have some, at least in engineering. This PR fixes that.

## Why It's Good For The Game
Old ship can now pass some better safety standards. 

## Changelog
:cl:
fix: Fixed the complete absence of fire alarms on the sulaco
/:cl: