### PR TITLE
Halves slowdown from wounds

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -23,8 +23,8 @@
 
 	var/health_deficiency = max((maxHealth - health), staminaloss)
 
-	if(health_deficiency >= 40)
-		add_movespeed_modifier(MOVESPEED_ID_DAMAGE_SLOWDOWN, TRUE, 0, NONE, TRUE, health_deficiency / 25)
+	if(health_deficiency >= 50)
+		add_movespeed_modifier(MOVESPEED_ID_DAMAGE_SLOWDOWN, TRUE, 0, NONE, TRUE, health_deficiency / 50)
 	else
 		remove_movespeed_modifier(MOVESPEED_ID_DAMAGE_SLOWDOWN)
 


### PR DESCRIPTION
## About The Pull Request
Halves slowdown from wounds, and makes it happen when you have 50 or more damage (up from 40).

## Why It's Good For The Game
Reduces a big source of slowdown for marines, which coupled with stuff like Jaeger suits and other sources of slowdown, reduced marine speed drastically.

## Changelog
:cl: Lewdcifer
balance: Wound slowdown halved, appears slightly later
/:cl: