### PR TITLE
Nerfs GPMG's aim mode rate of fire.

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -671,7 +671,7 @@
 	gun_skill_category = GUN_SKILL_HEAVY_WEAPONS
 	attachable_offset = list("muzzle_x" = 41, "muzzle_y" = 21,"rail_x" = 8, "rail_y" = 23, "under_x" = 25, "under_y" = 14, "stock_x" = 11, "stock_y" = 14)
 	actions_types = list(/datum/action/item_action/aim_mode)
-	aim_fire_delay = 0.16 SECONDS
+	aim_fire_delay = 0.2 SECONDS
 	aim_speed_modifier = 6
 
 	fire_delay = 0.15 SECONDS

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -671,7 +671,7 @@
 	gun_skill_category = GUN_SKILL_HEAVY_WEAPONS
 	attachable_offset = list("muzzle_x" = 41, "muzzle_y" = 21,"rail_x" = 8, "rail_y" = 23, "under_x" = 25, "under_y" = 14, "stock_x" = 11, "stock_y" = 14)
 	actions_types = list(/datum/action/item_action/aim_mode)
-	aim_fire_delay = 0.1 SECONDS
+	aim_fire_delay = 0.16 SECONDS
 	aim_speed_modifier = 6
 
 	fire_delay = 0.15 SECONDS


### PR DESCRIPTION
## About The Pull Request

Makes general-purpose machine gun shoot slower with aim mode on.

## Why It's Good For The Game

Currently, marines can just spam GPMGs with little to no penalties, as it has a superior fire rate with AND without aim mode.

## Changelog
:cl:
balance: General-purpose machine gun shoots a bit slower with aim mode on.
/:cl: