### PR TITLE
Makes machine guns difficult to aim

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -623,7 +623,7 @@
 	gun_skill_category = GUN_SKILL_HEAVY_WEAPONS
 	attachable_offset = list("muzzle_x" = 31, "muzzle_y" = 17,"rail_x" = 4, "rail_y" = 20, "under_x" = 16, "under_y" = 13, "stock_x" = 0, "stock_y" = 13)
 	actions_types = list(/datum/action/item_action/aim_mode)
-	aim_fire_delay = 0.18 SECONDS
+	aim_fire_delay = 0.8 SECONDS
 	aim_speed_modifier = 5
 
 	fire_delay = 0.18 SECONDS
@@ -675,7 +675,7 @@
 	gun_skill_category = GUN_SKILL_HEAVY_WEAPONS
 	attachable_offset = list("muzzle_x" = 41, "muzzle_y" = 21,"rail_x" = 8, "rail_y" = 23, "under_x" = 25, "under_y" = 14, "stock_x" = 11, "stock_y" = 14)
 	actions_types = list(/datum/action/item_action/aim_mode)
-	aim_fire_delay = 0.1 SECONDS
+	aim_fire_delay = 0.85 SECONDS
 	aim_speed_modifier = 6
 
 	fire_delay = 0.165 SECONDS


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Theyre giant hunks of metal, hard to raise high enough to aim down the sights. Current rate of fire in aim makes literal walls of bullets viable.


## Why It's Good For The Game

Every single weakness was removed from the two weapons. Im adding a new one that makes sense. Theyre machines guns. You aim by not pointing the barrel at your side. WW1 was famous for lines of people with machines guns marching to the other side of the trench followed by layers of aiming machine guns firing through their bodies but this is a fantasy game. No need to follow reality.

Seriously though, the only way to aim to not hit people with one realistically is to not aim at them. You know by not firing in their direction.

## Changelog
balance: t-60 and t-42 fire one bullet a second in aim mode
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
