### PR TITLE
Delete Obsolete Compactor Upgrade

### DIFF
--- a/code/game/objects/items/misc.dm
+++ b/code/game/objects/items/misc.dm
@@ -138,13 +138,6 @@
 	icon_state = "mining_drill_overclockeddisplay"
 	uptype = "high-efficiency drill"
 
-
-/obj/item/minerupgrade/compactor
-	name = "crystalizer module"
-	desc = "A bulky module meant to replace the normal crystalizer in mining wells, used to compress boxes for easy carrying."
-	icon_state = "mining_drill_compactordisplay"
-	uptype = "upgraded crystalizer module"
-
 /obj/item/dropship_points_voucher
 	name = "dropship fabricator voucher"
 	desc = "A small keycard stamped by a Terra Gov logo. It contains points you can redeem at a dropship fabricator. One use only."


### PR DESCRIPTION
This thing is obsolete and unused, I removed it with my miner PR but I think it got reverted by someone fixing a merge conflict

## Changelog
:cl:
code: got rid of unused/obsolete compactor upgrade
/:cl:
