### PR TITLE
Hypervene and Water Buffs

### DIFF
--- a/code/game/objects/items/reagent_containers/food/cans.dm
+++ b/code/game/objects/items/reagent_containers/food/cans.dm
@@ -36,7 +36,7 @@
 	desc = "Overpriced 'Spring' water. Bottled by Nanotrasen."
 	icon_state = "bottled_water"
 	center_of_mass = list("x"=15, "y"=8)
-	list_reagents = list(/datum/reagent/water = 30)
+	list_reagents = list(/datum/reagent/water = 60)
 
 /obj/item/reagent_containers/food/drinks/cans/beer
 	name = "can of beer"

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1070,8 +1070,12 @@
 
 /datum/reagent/hypervene/on_mob_life(mob/living/L, metabolism)
 	L.reagent_shock_modifier -= PAIN_REDUCTION_HEAVY //Significant pain while metabolized.
-	if(prob(5)) //causes vomiting
+	L.adjustToxLoss(-effect_str*5) //Toxin damage gets rapidly purged
+
+	var/puke_probability = clamp(L.getToxLoss(), 5, 100) //Puke chance equal to current toxin damage; minimum 5%, max 100%.
+	if(prob(puke_probability)) //causes vomiting
 		L.vomit()
+
 	return ..()
 
 /datum/reagent/hypervene/overdose_process(mob/living/L, metabolism)

--- a/code/modules/reagents/reagents/other.dm
+++ b/code/modules/reagents/reagents/other.dm
@@ -57,6 +57,7 @@
 
 
 /datum/reagent/water/on_mob_life(mob/living/L,metabolism)
+	L.adjustToxLoss(-effect_str*0.25)
 	switch(current_cycle)
 		if(4 to 5) //1 sip, starting at the end
 			L.adjustStaminaLoss(-2*effect_str)


### PR DESCRIPTION
## About The Pull Request

#1: Hypervene now actually rapidly purges toxin damage as advertised at a rate of 5 per tick. Probability of puking now scales with total toxin damage (minimum of 5% per tick) as it forces your body to work overtime purging and flushing toxins/chems.
#2: Water now slowly purges toxin damage at a rate of 0.25 / tick. Stay hydrated.
#3: Water bottle capacity increased to 60U.

## Why It's Good For The Game

Marines have better counters to chemical warfare.

## Changelog
:cl:
balance: Hypervene now actually rapidly purges toxin damage as advertised at a rate of 5 per tick. Probability of puking now scales with total toxin damage.
balance: Water now slowly purges toxin damage at a rate of 0.25 / tick. Stay hydrated.
balance: Water bottle capacity increased to 60U.
/:cl: