### PR TITLE
Synth job addition

### DIFF
--- a/code/datums/gamemodes/infestation.dm
+++ b/code/datums/gamemodes/infestation.dm
@@ -6,3 +6,10 @@
 		return
 	var/datum/job/scaled_job = SSjob.GetJobType(/datum/job/terragov/squad/smartgunner)
 	scaled_job.job_points_needed  = 20 //For every 10 marine late joins, 1 extra SG
+
+/datum/game_mode/infestation/scale_roles()
+	. = ..()
+	if(!.)
+		return
+	var/datum/job/scaled_job = SSjob.GetJobType(/datum/job/terragov/synth)
+	scaled_job.job_points_needed  = 40 //For every 40 marines there will be 1 extra Synth.

--- a/code/datums/jobs/access.dm
+++ b/code/datums/jobs/access.dm
@@ -343,5 +343,11 @@
 			. = size ? "MERC " : "MERC Engineer"
 		if("VM")
 			. = size ? "VAT " : "VatGrown Marine"
+		if("CS")
+			. = size ? "CS " : "Chief Synthetic"
+		if("MS")
+			. = size ? "MS" : "Major Synthetic"
+		if("SO1")
+			. = size ? "SO1 " : "Synthetic First Class"
 		else
 			. = paygrade + " " //custom paygrade

--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -741,6 +741,22 @@ Use your office fax machine to communicate with corporate headquarters or to acq
 		return /datum/skills/early_synthetic
 	return ..()
 
+/datum/job/terragov/silicon/synthetic/after_spawn(mob/living/carbon/new_mob, mob/user, latejoin = FALSE)
+	. = ..()
+	if(!ishuman(new_mob))
+		return
+	var/mob/living/carbon/human/new_human = new_mob
+	var/playtime_mins = user?.client?.get_exp(title)
+	if(!playtime_mins || playtime_mins < 1 )
+		return
+	switch(playtime_mins)
+		if(601 to 1500) // 10 hrs
+			new_human.wear_id.paygrade = "SO1"
+		if(1501 to 6000) // 50 hrs
+			new_human.wear_id.paygrade = "MS"
+		if(6001 to INFINITY) // 100 hrs
+			new_human.wear_id.paygrade = "CS"
+
 /datum/job/terragov/silicon/synthetic/radio_help_message(mob/M)
 	. = ..()
 	to_chat(M, {"Your primary job is to support and assist all TGMC departments and personnel on-board.


### PR DESCRIPTION

## About The Pull Request

Adds Synthetic job slot every 40 pop.

## Why It's Good For The Game

As we are constantly moving towards high pop, I believe synthetics getting more slot every 40 pop makes sense as generally there is a lack of command. Synthetics can do most shipside job, and as the pop increases, it generally gets difficult to manage shipside. Addition of a support role of Synthetic will ensure this.

I may change the pop number upon testing and feedback. This needs testing.

## Changelog
:cl: SpaceLove
balance: Gives 1 Synth job slot every 40 pop.

/:cl:

