### PR TITLE
Small Remap of Sulaco synth room to prevent instant kill zone on alamo crash

### DIFF
--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -7404,8 +7404,9 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall3)
 "aIt" = (
-/turf/closed/wall/mainship/gray/outer,
-/area/sulaco/engineering)
+/obj/machinery/recharge_station,
+/turf/open/floor/prison,
+/area/sulaco/engineering/engine)
 "aIv" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -11625,6 +11626,10 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/mainship/living/pilotbunks)
+"euc" = (
+/obj/machinery/door/airlock/mainship/marine/general,
+/turf/open/floor/plating/platebotc,
+/area/sulaco/engineering/engine)
 "eul" = (
 /obj/structure/window/framed/mainship/gray/toughened,
 /obj/machinery/door/poddoor/shutters/mainship/req/ro{
@@ -12271,6 +12276,9 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/prison,
 /area/sulaco/engineering/engine)
 "glp" = (
@@ -12737,6 +12745,12 @@
 	dir = 8
 	},
 /area/sulaco/medbay/west)
+"hJw" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/prison,
+/area/sulaco/engineering/engine)
 "hKz" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
@@ -14913,6 +14927,10 @@
 /obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/closed/wall/mainship/gray,
 /area/sulaco/bridge/quarters)
+"nml" = (
+/obj/effect/landmark/start/job/synthetic,
+/turf/open/floor/prison,
+/area/sulaco/engineering/engine)
 "nmW" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -15240,11 +15258,7 @@
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
 "oiA" = (
-/obj/effect/landmark/start/job/synthetic,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/obj/machinery/firealarm{
-	dir = 4
-	},
 /turf/open/floor/prison,
 /area/sulaco/engineering/engine)
 "oiN" = (
@@ -16361,11 +16375,10 @@
 /turf/open/floor/prison,
 /area/sulaco/hallway/central_hall3)
 "qJW" = (
-/obj/machinery/light/small{
+/obj/machinery/firealarm{
 	dir = 4
 	},
-/obj/machinery/recharge_station,
-/turf/open/floor/prison,
+/turf/closed/wall/mainship/gray,
 /area/sulaco/engineering/engine)
 "qKm" = (
 /obj/docking_port/stationary/marine_dropship/cas,
@@ -17132,7 +17145,6 @@
 /turf/open/floor/prison/plate,
 /area/sulaco/cargo)
 "sxx" = (
-/obj/machinery/marine_selector/clothes/synth,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
@@ -18737,6 +18749,10 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/sulaco/hangar)
+"wLG" = (
+/obj/machinery/marine_selector/clothes/synth,
+/turf/open/floor/prison,
+/area/sulaco/engineering/engine)
 "wMn" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 5
@@ -62747,7 +62763,7 @@ eZL
 eoD
 tAS
 tAS
-tAS
+qJW
 tAS
 tAS
 avU
@@ -63261,7 +63277,7 @@ eck
 avU
 tAS
 sxx
-qJW
+aFr
 mBB
 tAS
 avU
@@ -63516,12 +63532,12 @@ iSb
 iSb
 aAy
 ayD
-apl
-qMX
-qMX
-qMX
-apl
-apl
+tAS
+aFr
+nml
+wLG
+tAS
+tAS
 aYX
 aHL
 tzU
@@ -63773,12 +63789,12 @@ iSb
 oOw
 alu
 tDT
+iSb
 aIt
-mDu
-mDu
-mDu
-mDu
-apl
+hJw
+aFr
+tAS
+tAS
 aJo
 aKg
 mNH
@@ -64030,12 +64046,12 @@ hDD
 rjt
 bCk
 aBW
-aIt
-apl
-qMX
-qMX
-qMX
-apl
+iSb
+tAS
+tAS
+euc
+tAS
+tAS
 aJp
 aKh
 bKl


### PR DESCRIPTION
Middle of the ship had a pointless space area that was creating instant kill zones on alamo crash in the area.

Just decided to get rid of the pointless space area and make synth's room a little more spacious in the process.

🆑
fix: fixed an instant kill zone caused by alamo crash on sulaco
qol: Synth's room is a little more spacious on sulaco.
/:cl: