### PR TITLE
Fixes hivemind collapse shipside win condition

### DIFF
--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -247,7 +247,7 @@
 	if(round_finished)
 		return
 	if(round_stage == DISTRESS_DROPSHIP_CRASHING)
-		round_finished = MODE_INFESTATION_M_MINOR
+		round_finished = MODE_INFESTATION_X_MINOR
 		return
 	round_finished = MODE_INFESTATION_M_MAJOR
 


### PR DESCRIPTION
Hivemind collapse shipside is now and supposed to be a Xeno minor victory.

<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hivemind collapse shipside is now a Xeno minor victory.

## Why It's Good For The Game

Fixes funny win condition left out previously.

## Changelog
:cl:
fix: fixed win conditions.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
