### PR TITLE
Changes win conditions

### DIFF
--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -129,10 +129,10 @@
 		return TRUE
 	if(!num_xenos)
 		if(round_stage == DISTRESS_DROPSHIP_CRASHING)
-			message_admins("Round finished: [MODE_INFESTATION_X_MINOR]") //xenos hijacked the shuttle and won groundside but died on the ship, minor victory
-			round_finished = MODE_INFESTATION_X_MINOR
+			message_admins("Round finished: [MODE_INFESTATION_X_MINOR]") //marines lost the ground operation but managed to wipe out Xenos on the ship at a greater cost, minor victory
+			round_finished = MODE_INFESTATION_M_MINOR
 			return TRUE
-		message_admins("Round finished: [MODE_INFESTATION_M_MAJOR]") //marines win big or go home
+		message_admins("Round finished: [MODE_INFESTATION_M_MAJOR]") //marines win big
 		round_finished = MODE_INFESTATION_M_MAJOR
 		return TRUE
 	if(round_stage == DISTRESS_DROPSHIP_CRASHING && !num_humans_ship)


### PR DESCRIPTION
Changes win conditions regarding shipside.

<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Marines wiping out Xenos shipside is now a Marine minor victory.

## Why It's Good For The Game

Xenos get a super pool when boarding the ship and enough points to spawn a turret or two before boarding and after as well. This encourages marines to push and try to salvage the round whilst they still have the option to hold SD and attain a draw to deny the Xeno victory. Xenos still have the option to avoid getting destroyed by early evacs or marines hoarding req points to ensure wins by just capturing the alamo. Wiping out Xenos at the cost of the ship is a small victory but at a much greater cost.


If Xenos camp the FOB and force an early evac and still hijack:
https://github.com/tgstation/TerraGov-Marine-Corps/pull/5734#issuecomment-761137632

This also punishes Xenos for stealth jacking.

## Changelog
:cl:
balance: Gives marines the minor victory option.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
