### PR TITLE
Silo have the same output whole game

### DIFF
--- a/code/controllers/subsystem/silo.dm
+++ b/code/controllers/subsystem/silo.dm
@@ -4,11 +4,9 @@ SUBSYSTEM_DEF(silo)
 	can_fire = FALSE
 	init_order = INIT_ORDER_SPAWNING_POOL
 	///How many larva points each pool gives per minute with a maturity of zero
-	var/base_larva_spawn_rate = 0.4
+	var/base_larva_spawn_rate = 0.5
 	///How many larva points are added every minutes in total
 	var/current_larva_spawn_rate = 0
-	///If the silos are maturing
-	var/silos_do_mature = FALSE
 	///How many psych points one corrupted generator gives
 	var/corrupted_gen_output
 
@@ -21,7 +19,7 @@ SUBSYSTEM_DEF(silo)
 	var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
 	current_larva_spawn_rate = 0
 	for(var/obj/structure/resin/silo/silo AS in GLOB.xeno_resin_silos)
-		current_larva_spawn_rate += clamp(base_larva_spawn_rate * (1 + silo.maturity/(5400)), base_larva_spawn_rate, 2 * base_larva_spawn_rate)
+		current_larva_spawn_rate += base_larva_spawn_rate
 	xeno_job.add_job_points(current_larva_spawn_rate)
 	corrupted_gen_output = TGS_CLIENT_COUNT * BASE_PSYCH_POINT_OUTPUT
 
@@ -30,4 +28,3 @@ SUBSYSTEM_DEF(silo)
 	SIGNAL_HANDLER
 	UnregisterSignal(SSdcs, list(COMSIG_GLOB_OPEN_TIMED_SHUTTERS_LATE, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_XENO_HIVEMIND, COMSIG_GLOB_OPEN_SHUTTERS_EARLY))
 	can_fire = TRUE
-	silos_do_mature = TRUE


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

No more maturity. Base output is up to compensate a bit

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Less urgency to win first push. Maturity was needed because xenos would lose against first marine respawn, this is less true if they manage to get a lot of cocoon.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: silos no longer mature. base output is 0.5 instead of 0.4
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
