### PR TITLE
Oogga - Fix some cameras orientation on Sulaco

### DIFF
--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -2897,9 +2897,6 @@
 /turf/open/floor/prison,
 /area/sulaco/cargo/office)
 "anI" = (
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 4
@@ -16073,6 +16070,12 @@
 "pLJ" = (
 /turf/closed/wall/mainship/gray/outer,
 /area/sulaco/bridge/office)
+"pLQ" = (
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/turf/open/floor/prison/marked,
+/area/sulaco/hallway/central_hall)
 "pLR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
@@ -42436,7 +42439,7 @@ mDu
 aYZ
 apB
 asn
-asn
+pLQ
 anI
 aoh
 awI

--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -528,9 +528,6 @@
 /obj/structure/sign/directions/science{
 	dir = 1
 	},
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 1
 	},
@@ -11195,6 +11192,12 @@
 	},
 /turf/open/floor/wood,
 /area/sulaco/liaison)
+"daG" = (
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/turf/open/floor/prison/whitegreen/corner,
+/area/sulaco/medbay/west)
 "dbH" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -12180,9 +12183,7 @@
 /area/sulaco/medbay/west)
 "fYC" = (
 /obj/machinery/iv_drip,
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/prison/whitegreen/corner,
 /area/sulaco/medbay/west)
 "gbY" = (
@@ -44609,7 +44610,7 @@ leD
 qxQ
 aam
 abE
-abG
+daG
 abY
 acm
 acy


### PR DESCRIPTION
## About The Pull Request
Cameras were pointing into the wall. Bad 

## Why It's Good For The Game
Realism. 60fps. What else.

## Changelog
:cl:
fix: Sulaco medical had cameras pointing the wrong way.
/:cl:

