### PR TITLE
Increases harvester bica heal from 10 to 25

### DIFF
--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -151,7 +151,7 @@
 			if(!do_after(user, 2 SECONDS, TRUE, M, BUSY_ICON_DANGER))
 				return FALSE
 			new /obj/effect/temp_visual/telekinesis(get_turf(M))
-			M.heal_overall_damage(10, 0, TRUE)
+			M.heal_overall_damage(25, 0, TRUE)
 			loaded_reagent = null
 			return FALSE
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Increases harvester's bicaridine heal from 10 to 25 brute. For reference, when metabolized 10u of bicaridine heals 50 brute and if the volume is above 20, 10u heals 75 brute, while also giving 60% of tramadol's pain reduction.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Harvester's bicaridine heal offers quicker healing for highly decreased efficiency. At 10 healing for 10u it poses too much of a waste of resources to use, while at 25 it is still inefficient, but could feel more enticing to use in some scenarios. It also can't be used in-combat, so it doesn't increase marines' durability.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: increased harvester's bicaridine healing from 10 to 25 brute
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
