### PR TITLE
Harvester effects small rework

### DIFF
--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -111,7 +111,7 @@
 		to_chat(user, "<span class='rose'>The blade is powered with [loaded_reagent.name]. You can release the effect by stabbing a creature.</span>")
 		return FALSE
 
-	if(beaker.reagents.total_volume < 10)
+	if(beaker.reagents.total_volume < 5)
 		to_chat(user, "<span class='rose'>You don't have enough substance.</span>")
 		return FALSE
 
@@ -124,7 +124,7 @@
 		return FALSE
 
 	loaded_reagent = beaker.reagents.reagent_list[1]
-	beaker.reagents.remove_any(10)
+	beaker.reagents.remove_any(5)
 	return TRUE
 
 /obj/item/weapon/claymore/harvester/attack(mob/living/M, mob/living/user)
@@ -136,22 +136,25 @@
 
 	switch(loaded_reagent.type)
 		if(/datum/reagent/medicine/tramadol)
-			M.apply_status_effect(/datum/status_effect/incapacitating/harvester_slowdown, 2 SECONDS)
+			M.apply_damage(force*0.6, BRUTE, user.zone_selected)
+			M.apply_status_effect(/datum/status_effect/incapacitating/harvester_slowdown, 1 SECONDS)
 
 		if(/datum/reagent/medicine/kelotane)
-			var/turf/target = get_turf(M)
-			target.ignite()
 			var/list/cone_turfs = generate_cone(user, 2, 1, 91, Get_Angle(user, M.loc))
 			for(var/X in cone_turfs)
 				var/turf/T = X
-				T.ignite()
+				for(var/mob/living/C in T)
+					C.flamer_fire_act(10)
+					C.apply_damage(20, BURN, user.zone_selected, C.get_soft_armor("fire", user.zone_selected))
+					if(C.IgniteMob())
+						C.visible_message("<span class='danger'>[C] bursts into flames!</span>","[isxeno(C)?"<span class='xenodanger'>":"<span class='highdanger'>"]You burst into flames!</span>")
 
 		if(/datum/reagent/medicine/bicaridine)
 			to_chat(user, "<span class='rose'>You prepare to stab [M]!</span>")
 			if(!do_after(user, 2 SECONDS, TRUE, M, BUSY_ICON_DANGER))
 				return FALSE
 			new /obj/effect/temp_visual/telekinesis(get_turf(M))
-			M.heal_overall_damage(25, 0, TRUE)
+			M.heal_overall_damage(12.5, 0, TRUE)
 			loaded_reagent = null
 			return FALSE
 

--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -151,7 +151,7 @@
 			if(!do_after(user, 2 SECONDS, TRUE, M, BUSY_ICON_DANGER))
 				return FALSE
 			new /obj/effect/temp_visual/telekinesis(get_turf(M))
-			M.heal_overall_damage(10, 0, TRUE)
+			M.heal_overall_damage(25, 0, TRUE)
 			loaded_reagent = null
 			return FALSE
 

--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -65,11 +65,11 @@
 
 /obj/item/weapon/claymore/harvester/attackby(obj/item/I, mob/user)
 	if(user.do_actions)
-		return FALSE
+		return TRUE
 
 	if(istype(I, /obj/item/reagent_containers/pill))
 		to_chat(user, "<span class='rose'>[I] isn't compatible with [src].</span>")
-		return FALSE
+		return TRUE
 
 	var/trans
 	var/obj/item/reagent_containers/container = I
@@ -80,27 +80,27 @@
 
 	if(length(container.reagents.reagent_list) > 1)
 		to_chat(user, "<span class='rose'>The solution needs to be uniform and contain only a single type of reagent to be compatible.</span>")
-		return FALSE
+		return TRUE
 
 	if(beaker.reagents.total_volume && (container.reagents.reagent_list[1].type != beaker.reagents.reagent_list[1].type))
 		to_chat(user, "<span class='rose'>[src]'s internal storage can contain only one kind of solution at the same time. It currently contains <b>[beaker.reagents.reagent_list[1].name]</b></span>")
-		return FALSE
+		return TRUE
 
 	if(!locate(container.reagents.reagent_list[1].type) in loadable_reagents)
 		to_chat(user, "<span class='rose'>This reagent is not compatible with the weapon's mechanism. Check the engraved symbols for further information.</span>")
-		return FALSE
+		return TRUE
 
 	if(container.reagents.total_volume < 5)
 		to_chat(user, "<span class='rose'>At least 5u of the substance is needed.</span>")
-		return FALSE
+		return TRUE
 
 	if(beaker.reagents.total_volume >= 30)
 		to_chat(user, "<span class='rose'>The internal storage is full.</span>")
-		return FALSE
+		return TRUE
 
 	to_chat(user, "<span class='notice'>You begin filling up the [src] with [container.reagents.reagent_list[1]].</span>")
 	if(!do_after(user, 1 SECONDS, TRUE, src, BUSY_ICON_BAR, null, PROGRESS_BRASS))
-		return FALSE
+		return TRUE
 
 	trans = container.reagents.trans_to(beaker, container.amount_per_transfer_from_this)
 	to_chat(user, "<span class='rose'>You load [trans]u into the internal system. It now holds [beaker.reagents.total_volume]u.</span>")
@@ -150,11 +150,15 @@
 						C.visible_message("<span class='danger'>[C] bursts into flames!</span>","[isxeno(C)?"<span class='xenodanger'>":"<span class='highdanger'>"]You burst into flames!</span>")
 
 		if(/datum/reagent/medicine/bicaridine)
-			to_chat(user, "<span class='rose'>You prepare to stab [M]!</span>")
-			if(!do_after(user, 2 SECONDS, TRUE, M, BUSY_ICON_DANGER))
-				return FALSE
+			if(isxeno(M))
+				return ..()
+			to_chat(user, "<span class='rose'>You prepare to stab <b>[M != user ? "[M]" : "yourself"]</b>!</span>")
 			new /obj/effect/temp_visual/telekinesis(get_turf(M))
-			M.heal_overall_damage(12.5, 0, TRUE)
+			if((M != user) && do_after(user, 2 SECONDS, TRUE, M, BUSY_ICON_DANGER))
+				M.heal_overall_damage(12.5, 0, TRUE)
+			else
+				M.adjustStaminaLoss(-30)
+				M.heal_overall_damage(6, 0, TRUE)
 			loaded_reagent = null
 			return FALSE
 

--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -143,11 +143,11 @@
 			var/list/cone_turfs = generate_cone(user, 2, 1, 91, Get_Angle(user, M.loc))
 			for(var/X in cone_turfs)
 				var/turf/T = X
-				for(var/mob/living/C in T)
-					C.flamer_fire_act(10)
-					C.apply_damage(20, BURN, user.zone_selected, C.get_soft_armor("fire", user.zone_selected))
-					if(C.IgniteMob())
-						C.visible_message("<span class='danger'>[C] bursts into flames!</span>","[isxeno(C)?"<span class='xenodanger'>":"<span class='highdanger'>"]You burst into flames!</span>")
+				for(var/mob/living/victim in T)
+					victim.flamer_fire_act(10)
+					victim.apply_damage(max(0, 20 - 20*victim.hard_armor.getRating("fire")), BURN, user.zone_selected, victim.get_soft_armor("fire", user.zone_selected))
+					if(victim.IgniteMob())
+						victim.visible_message("<span class='danger'>[victim] bursts into flames!</span>","[isxeno(victim)?"<span class='xenodanger'>":"<span class='highdanger'>"]You burst into flames!</span>")
 
 		if(/datum/reagent/medicine/bicaridine)
 			if(isxeno(M))


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes harvester effect slightly and moves them from longer effects to shorter ones with more immediate impact.

Changed harvester effects cost from 10u to 5u. 
- Kelotane effect now ignites all mobs in the cone, dealing additional fire damage, without leaving fire tiles. 
- Tramadol effect deals 60% bonus damage that ignores armor, but the slow lasts 1s instead of 2s. 
- Bicaridine effect heals 12.5 brute instead of 10 brute. If you target yourself, it instantly (without the usual channeling delay) heals 6 brute and restores 30 stamina.
> For reference, when metabolized 10u of bicaridine heals 50 brute and if the volume is above 20, 10u heals 75 brute, while also giving 60% of tramadol's pain reduction.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
First, I think these changes should be tested before merge.

The changes allow for harvester to deal more damage without giving it a flat force increase and help it warrant the danger of having to get closer to the xenos to use it. It decreases the duration of the kelotane and tramadol effects in exchange for higher mobility or damage when applying them.

The tramadol effect now slows for less, but with the added armor-penetrating damage, it allows to deal damage to more armored xenos and xenos have higher melee armor than bullet armor, while not being too strong against xenos with lower armor or health.
The kelotane effect changes allow for followup instead of blocking the engage route or allowing the xeno to shuffle the marine into the fire.
Harvester's bicaridine heal offers quicker healing for highly decreased efficiency. At 10 healing for 10u it poses too much of a waste of resources to use, while at 25 it is still inefficient, but could feel more enticing to use in some scenarios. It can also be used in-combat for less than half healing, but with stamina regeneration for increased mobility.

As the effects last less, I think it would be fair to have lower reagent costs.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: changed harvester effects cost from 10u to 5u. Kelotane effect now ignites all mobs in the cone, dealing additional fire damage, without leaving fire tiles. Tramadol effect deals 60% bonus damage that ignores armor, but the slow lasts 1s instead of 2s. Bicaridine effect heals 12.5 brute instead of 10 brute. If you target yourself, it instantly restores 6 brute and 30 stamina.
qol: failing to fill the harvester no longer makes you lose reagents from the liquid container, this wasn't an intended thing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
