### PR TITLE
Removes all of CAS guns/ammo at roundstart, give them points instead.

### DIFF
--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -32,8 +32,8 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "ah" = (
-/obj/structure/ship_ammo/heavygun,
-/turf/open/floor/mainship/cargo,
+/obj/structure/dropship_equipment/mg_holder,
+/turf/open/floor/mainship/sterile/plain,
 /area/mainship/hallways/hangar)
 "ai" = (
 /obj/machinery/vending/nanomed,
@@ -61,14 +61,13 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "al" = (
-/obj/structure/ship_ammo/minirocket/illumination,
-/turf/open/floor/mainship/cargo,
+/obj/structure/dropship_equipment/operatingtable,
+/turf/open/floor/mainship/sterile/plain,
 /area/mainship/hallways/hangar)
 "am" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 1
 	},
-/obj/structure/ship_ammo/minirocket/illumination,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "an" = (
@@ -116,10 +115,6 @@
 	dir = 10
 	},
 /turf/open/floor/mainship/cargo,
-/area/mainship/hallways/hangar)
-"aw" = (
-/obj/structure/ship_ammo/rocket/widowmaker,
-/turf/open/floor/mainship/sterile/plain,
 /area/mainship/hallways/hangar)
 "ax" = (
 /turf/open/floor/mainship/sterile/plain,
@@ -180,10 +175,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/lower_hull)
-"aM" = (
-/obj/structure/ship_ammo/minirocket,
-/turf/open/floor/mainship/cargo,
-/area/mainship/hallways/hangar)
 "aN" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/hangar)
@@ -786,10 +777,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/chemistry)
-"cq" = (
-/obj/structure/ship_ammo/rocket/banshee,
-/turf/open/floor/mainship/sterile/plain,
-/area/mainship/hallways/hangar)
 "cs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 1
@@ -3228,15 +3215,6 @@
 	},
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/command/cic)
-"kY" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/structure/dropship_equipment/electronics/targeting_system,
-/turf/open/floor/mainship/orange{
-	dir = 8
-	},
-/area/mainship/hallways/hangar)
 "kZ" = (
 /obj/machinery/vending/armor_supply,
 /turf/open/floor/mainship/black{
@@ -3443,12 +3421,6 @@
 	dir = 8
 	},
 /area/mainship/command/cic)
-"lC" = (
-/obj/structure/dropship_equipment/sentry_holder,
-/turf/open/floor/mainship/orange{
-	dir = 4
-	},
-/area/mainship/hallways/hangar)
 "lE" = (
 /turf/closed/wall/mainship/outer,
 /area/mainship/shipboard/port_missiles)
@@ -3496,15 +3468,6 @@
 /obj/machinery/computer/emails,
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
-"lM" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/structure/dropship_equipment/mg_holder,
-/turf/open/floor/mainship/orange{
-	dir = 8
-	},
-/area/mainship/hallways/hangar)
 "lN" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
@@ -3594,7 +3557,6 @@
 	dir = 8
 	},
 /obj/effect/decal/warning_stripes/thin,
-/obj/structure/dropship_equipment/operatingtable,
 /turf/open/floor/mainship/orange{
 	dir = 8
 	},
@@ -3652,7 +3614,6 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/living/port_garden)
 "ms" = (
-/obj/structure/dropship_equipment/weapon/heavygun,
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/mainship/orange{
 	dir = 4
@@ -9822,7 +9783,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "Ge" = (
-/obj/structure/dropship_equipment/electronics/spotlights,
+/obj/structure/dropship_equipment/electronics/targeting_system,
 /turf/open/floor/mainship/sterile/plain,
 /area/mainship/hallways/hangar)
 "Gf" = (
@@ -9926,10 +9887,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/aft_hallway)
-"Gv" = (
-/obj/structure/dropship_equipment/weapon/minirocket_pod,
-/turf/open/floor/mainship/sterile/plain,
-/area/mainship/hallways/hangar)
 "Gw" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -12329,10 +12286,6 @@
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_umbilical)
-"Nk" = (
-/obj/structure/dropship_equipment/weapon/rocket_pod,
-/turf/open/floor/mainship/sterile/plain,
-/area/mainship/hallways/hangar)
 "Nl" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -47130,10 +47083,10 @@ rc
 rc
 rc
 ad
-Ge
-Ge
-Ge
 af
+Ge
+ah
+al
 af
 af
 Mb
@@ -47649,7 +47602,7 @@ ak
 aJ
 Gf
 ag
-Gv
+af
 Mb
 Mb
 aO
@@ -47901,8 +47854,8 @@ aa
 Tm
 rc
 ad
-aM
-aM
+ar
+ar
 ar
 Gg
 Mb
@@ -48416,7 +48369,7 @@ Tm
 rc
 ad
 am
-al
+ar
 at
 av
 iB
@@ -48672,8 +48625,8 @@ aa
 Tm
 rc
 ad
-al
-al
+ar
+at
 at
 aQ
 aA
@@ -49186,8 +49139,8 @@ aa
 Tm
 rc
 ad
-ah
-ah
+ar
+ar
 ar
 bf
 Mb
@@ -49448,7 +49401,7 @@ ao
 aK
 bH
 aB
-Nk
+af
 Mb
 ad
 aW
@@ -49469,8 +49422,8 @@ aA
 bn
 ja
 ke
-kY
-lM
+ke
+ke
 mj
 Np
 mU
@@ -49700,8 +49653,8 @@ aa
 Tm
 rc
 ad
-aw
-cq
+af
+af
 ap
 ap
 ap
@@ -49726,7 +49679,7 @@ ze
 iR
 jg
 kG
-lC
+kG
 kG
 ms
 Cu

--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -1821,10 +1821,6 @@
 	dir = 4
 	},
 /area/sulaco/engineering/atmos)
-"agb" = (
-/obj/structure/dropship_equipment/weapon/minirocket_pod,
-/turf/open/floor/prison,
-/area/sulaco/hangar)
 "agm" = (
 /obj/machinery/vending/engivend{
 	req_access = null
@@ -8250,10 +8246,6 @@
 "aMF" = (
 /turf/closed/wall/mainship/gray/outer,
 /area/sulaco/marine/bravo)
-"aMP" = (
-/obj/structure/dropship_equipment/weapon/heavygun,
-/turf/open/floor/prison,
-/area/sulaco/hangar)
 "aMR" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/prison,
@@ -10891,10 +10883,6 @@
 	dir = 9
 	},
 /area/sulaco/research)
-"cpN" = (
-/obj/structure/ship_ammo/heavygun,
-/turf/open/floor/prison,
-/area/sulaco/hangar)
 "crv" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 1
@@ -13581,7 +13569,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/ship_ammo/minirocket/illumination,
 /turf/open/floor/prison,
 /area/sulaco/hangar)
 "jWd" = (
@@ -13770,10 +13757,6 @@
 	dir = 8
 	},
 /turf/open/floor/prison/bright_clean,
-/area/sulaco/hangar)
-"kut" = (
-/obj/structure/ship_ammo/minirocket,
-/turf/open/floor/prison,
 /area/sulaco/hangar)
 "kuz" = (
 /obj/machinery/camera/autoname,
@@ -14928,15 +14911,6 @@
 /obj/machinery/firealarm,
 /turf/open/floor/mainship/ai,
 /area/sulaco/command/ai)
-"npi" = (
-/obj/structure/ship_ammo/minirocket/illumination,
-/turf/open/floor/prison,
-/area/sulaco/hangar)
-"nqJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/ship_ammo/minirocket,
-/turf/open/floor/prison,
-/area/sulaco/hangar)
 "nrN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden/layer1{
@@ -15075,7 +15049,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/ship_ammo/heavygun,
 /turf/open/floor/prison,
 /area/sulaco/hangar)
 "nOO" = (
@@ -16403,7 +16376,6 @@
 /turf/open/floor/prison,
 /area/mainship/living/pilotbunks)
 "qOd" = (
-/obj/structure/ship_ammo/minirocket/illumination,
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
@@ -18055,7 +18027,6 @@
 /area/sulaco/hallway/lower_main_hall)
 "uXj" = (
 /obj/machinery/camera/autoname,
-/obj/structure/ship_ammo/rocket/banshee,
 /turf/open/floor/prison,
 /area/sulaco/hangar)
 "uXn" = (
@@ -18121,10 +18092,6 @@
 /obj/structure/rack,
 /obj/item/reagent_containers/jerrycan,
 /obj/item/reagent_containers/jerrycan,
-/turf/open/floor/prison,
-/area/sulaco/hangar)
-"vfc" = (
-/obj/structure/ship_ammo/rocket/widowmaker,
 /turf/open/floor/prison,
 /area/sulaco/hangar)
 "vgl" = (
@@ -48445,18 +48412,18 @@ bFa
 bFa
 aQa
 cdy
-aMP
 cdy
-agb
+cdy
+cdy
 nOM
-cpN
+cdy
 lDT
-kut
-nqJ
+cdy
+aaO
 qOd
-jVN
-npi
-npi
+nOM
+cdy
+cdy
 aSl
 aPY
 aWG
@@ -50752,7 +50719,7 @@ aaa
 nzi
 mDu
 bFa
-vfc
+cdy
 rpN
 gyp
 aPZ

--- a/code/controllers/subsystem/points.dm
+++ b/code/controllers/subsystem/points.dm
@@ -12,7 +12,7 @@ SUBSYSTEM_DEF(points)
 
 	wait = 10 SECONDS
 
-	var/dropship_points = 0
+	var/dropship_points = 2275			// hey imagine a drone except they are sleeping on your couch and ur jacket is kind of under them with the blankets do you wake em up"
 	var/supply_points = 120
 	///Assoc list of xeno points: xeno_points_by_hive["hivenum"]
 	var/list/xeno_points_by_hive = list()


### PR DESCRIPTION
## About The Pull Request
This PR deletes all of the CAS ammo & guns from Sulaco & POS, replacing them with a direct point cost equivalent at roundstart.

## Why It's Good For The Game
Currently, PO's are a bit forced to use what you get at roundstart given the few options to get more points.
Either req spends on you, you wait a while or you move to high orbit where you can't hit anything, but you have more points.

This means the best bang for your buck is to take the guns you have at the start and only buy ammo for them at the start.
Smart, but also not very engaging.

This aims to change that, by giving more freedom for things PO's can build on. 
You want four napalm rockets and nothing else? Sure. Only miniguns, why not. 
You'll just have to spend the points on all of those guns (half your budget at least given the cheapest gun costs 400) and then on the ammo.

## Changelog
:cl:
balance: CAS no longer free equipment at roundstart. They get an injection of points which they then need to spend on everything. 
/:cl:
