### PR TITLE
Neurotox Rework

### DIFF
--- a/code/modules/reagents/reagents/toxin.dm
+++ b/code/modules/reagents/reagents/toxin.dm
@@ -442,7 +442,7 @@
 	description = "A debilitating nerve toxin. Impedes motor control in high doses. Causes progressive loss of mobility over time."
 	reagent_state = LIQUID
 	color = "#CF3600" // rgb: 207, 54, 0
-	custom_metabolism = REAGENTS_METABOLISM * 2
+	custom_metabolism = REAGENTS_METABOLISM * 4
 	purge_list = list(/datum/reagent/medicine)
 	purge_rate = 0.2 //same as metabolism rate, effictevelly halving the use of drugs while not really purgin it all at once
 	overdose_threshold = 10000 //Overdosing for neuro is a lie
@@ -454,18 +454,17 @@
 	var/power
 	switch(current_cycle)
 		if(1 to 20)
-			power = (8*effect_str) //While stamina loss is going, stamina regen apparently doesn't happen, so I can keep this smaller.
-			L.reagent_pain_modifier -= PAIN_REDUCTION_VERY_LIGHT
-			L.jitter(2)
-		if(21 to 45)
-			power = (4*effect_str)
-			L.reagent_pain_modifier -= PAIN_REDUCTION_LIGHT
-			L.jitter(4) //Shows that things are bad
+			power = ((15-(current_cycle*0.35)*effect_str))  //will start strong and grow weaker as stamina depleets
+			L.reagent_pain_modifier -= PAIN_REDUCTION_VERY_LIGHT //some pain for benos pleasure
+
 		if(46 to INFINITY)
-			power = (2*effect_str)
-			L.reagent_pain_modifier -= PAIN_REDUCTION_HEAVY //only cause pain. if your in it for a long ass time
+			power = (((current_cycle*0.35)-15)*effect_str) //will start to pick up again. if not treated
+			L.reagent_pain_modifier -= PAIN_REDUCTION_HEAVY //only cause REAL pain. if your in it for a long ass time
+			L.adjustToxLoss(0.2)
 			L.jitter(8) //Shows that things are *really* bad
 
+
+	L.jitter(current_cycle*0.17) //so it get worst overtime letting you know how bad you are
 	L.stuttering = max(L.stuttering, 1)
 	L.adjustStaminaLoss(min(power, max(0, stamina_loss_limit - L.staminaloss)))   //the power decreases over time since you will already have lots most of the stamina
 

--- a/code/modules/reagents/reagents/toxin.dm
+++ b/code/modules/reagents/reagents/toxin.dm
@@ -454,12 +454,12 @@
 	var/power
 	switch(current_cycle)
 		if(1 to 30)
-			if(stamina_loss < 0)
+			if(stamina_loss < 100)
 				power = ((8-(current_cycle*0.27)*effect_str))  //will start strong at 8 and grow weaker as stamina depleets
 				L.reagent_pain_modifier -= PAIN_REDUCTION_VERY_LIGHT //some pain for benos pleasure
 				return
 
-			power = 1 //if marine is already in orange levels of stamina hold on a bit
+			power = 0.1 //if marine is already in orange levels of stamina hold on a bit
 			L.reagent_pain_modifier -= PAIN_REDUCTION_LIGHT //the pain also picks up if you get here
 
 		if(31 to INFINITY)

--- a/code/modules/reagents/reagents/toxin.dm
+++ b/code/modules/reagents/reagents/toxin.dm
@@ -442,9 +442,9 @@
 	description = "A debilitating nerve toxin. Impedes motor control in high doses. Causes progressive loss of mobility over time."
 	reagent_state = LIQUID
 	color = "#CF3600" // rgb: 207, 54, 0
-	custom_metabolism = REAGENTS_METABOLISM * 4
+	custom_metabolism = REAGENTS_METABOLISM * 2
 	purge_list = list(/datum/reagent/medicine)
-	purge_rate = 0.2 //same as metabolism rate, effictevelly halving the use of drugs while not really purgin it all at once
+	purge_rate = 1 //same as metabolism rate, effictevelly halving the use of drugs while not really purgin it all at once
 	overdose_threshold = 10000 //Overdosing for neuro is a lie
 	scannable = TRUE
 	toxpwr = 0
@@ -466,6 +466,8 @@
 
 	L.jitter(current_cycle*0.17) //so it get worst overtime letting you know how bad you are
 	L.stuttering = max(L.stuttering, 1)
+
+	var/stamina_loss_limit = L.maxHealth * 2
 	L.adjustStaminaLoss(min(power, max(0, stamina_loss_limit - L.staminaloss)))   //the power decreases over time since you will already have lots most of the stamina
 
 	if(prob(25))

--- a/code/modules/reagents/reagents/toxin.dm
+++ b/code/modules/reagents/reagents/toxin.dm
@@ -454,7 +454,7 @@
 	var/power
 	switch(current_cycle)
 		if(1 to 30)
-			if(L.stamina_loss < 100)
+			if(L.staminaloss < 100)
 				power = ((8-(current_cycle*0.27)*effect_str))  //will start strong at 8 and grow weaker as stamina depleets
 				L.reagent_pain_modifier -= PAIN_REDUCTION_VERY_LIGHT //some pain for benos pleasure
 				return

--- a/code/modules/reagents/reagents/toxin.dm
+++ b/code/modules/reagents/reagents/toxin.dm
@@ -453,12 +453,17 @@
 /datum/reagent/toxin/xeno_neurotoxin/on_mob_life(mob/living/L, metabolism)
 	var/power
 	switch(current_cycle)
-		if(1 to 20)
-			power = ((15-(current_cycle*0.35)*effect_str))  //will start strong and grow weaker as stamina depleets
-			L.reagent_pain_modifier -= PAIN_REDUCTION_VERY_LIGHT //some pain for benos pleasure
+		if(1 to 30)
+			if(stamina_loss < 0)
+				power = ((8-(current_cycle*0.27)*effect_str))  //will start strong at 8 and grow weaker as stamina depleets
+				L.reagent_pain_modifier -= PAIN_REDUCTION_VERY_LIGHT //some pain for benos pleasure
+				return
 
-		if(46 to INFINITY)
-			power = (((current_cycle*0.35)-15)*effect_str) //will start to pick up again. if not treated
+			power = 1 //if marine is already in orange levels of stamina hold on a bit
+			L.reagent_pain_modifier -= PAIN_REDUCTION_LIGHT //the pain also picks up if you get here
+
+		if(31 to INFINITY)
+			power = (((current_cycle*0.27)-8)*effect_str) //will start to pick up again, and rather quick since you will already be in orange
 			L.reagent_pain_modifier -= PAIN_REDUCTION_HEAVY //only cause REAL pain. if your in it for a long ass time
 			L.adjustToxLoss(0.2)
 			L.jitter(8) //Shows that things are *really* bad

--- a/code/modules/reagents/reagents/toxin.dm
+++ b/code/modules/reagents/reagents/toxin.dm
@@ -457,10 +457,9 @@
 			if(L.staminaloss < 100)
 				power = ((8-(current_cycle*0.27)*effect_str))  //will start strong at 8 and grow weaker as stamina depleets
 				L.reagent_pain_modifier -= PAIN_REDUCTION_VERY_LIGHT //some pain for benos pleasure
-				return
-
-			power = 0.1 //if marine is already in orange levels of stamina hold on a bit
-			L.reagent_pain_modifier -= PAIN_REDUCTION_LIGHT //the pain also picks up if you get here
+			else
+				power = 0.1 //if marine is already in orange levels of stamina hold on a bit
+				L.reagent_pain_modifier -= PAIN_REDUCTION_LIGHT //the pain also picks up if you get here
 
 		if(31 to INFINITY)
 			power = (((current_cycle*0.27)-8)*effect_str) //will start to pick up again, and rather quick since you will already be in orange

--- a/code/modules/reagents/reagents/toxin.dm
+++ b/code/modules/reagents/reagents/toxin.dm
@@ -454,7 +454,7 @@
 	var/power
 	switch(current_cycle)
 		if(1 to 30)
-			if(stamina_loss < 100)
+			if(L.stamina_loss < 100)
 				power = ((8-(current_cycle*0.27)*effect_str))  //will start strong at 8 and grow weaker as stamina depleets
 				L.reagent_pain_modifier -= PAIN_REDUCTION_VERY_LIGHT //some pain for benos pleasure
 				return

--- a/code/modules/reagents/reagents/toxin.dm
+++ b/code/modules/reagents/reagents/toxin.dm
@@ -444,8 +444,8 @@
 	color = "#CF3600" // rgb: 207, 54, 0
 	custom_metabolism = REAGENTS_METABOLISM * 2
 	purge_list = list(/datum/reagent/medicine)
-	purge_rate = 1
-	overdose_threshold = 10000 //Overdosing for neuro is what happens when you run out of stamina to avoid its oxy and toxin damage
+	purge_rate = 0.2 //same as metabolism rate, effictevelly halving the use of drugs while not really purgin it all at once
+	overdose_threshold = 10000 //Overdosing for neuro is a lie
 	scannable = TRUE
 	toxpwr = 0
 
@@ -454,28 +454,23 @@
 	var/power
 	switch(current_cycle)
 		if(1 to 20)
-			power = (2*effect_str) //While stamina loss is going, stamina regen apparently doesn't happen, so I can keep this smaller.
-			L.reagent_pain_modifier -= PAIN_REDUCTION_LIGHT
+			power = (8*effect_str) //While stamina loss is going, stamina regen apparently doesn't happen, so I can keep this smaller.
+			L.reagent_pain_modifier -= PAIN_REDUCTION_VERY_LIGHT
+			L.jitter(2)
 		if(21 to 45)
-			power = (6*effect_str)
-			L.reagent_pain_modifier -= PAIN_REDUCTION_HEAVY
+			power = (4*effect_str)
+			L.reagent_pain_modifier -= PAIN_REDUCTION_LIGHT
 			L.jitter(4) //Shows that things are bad
 		if(46 to INFINITY)
-			power = (15*effect_str)
-			L.reagent_pain_modifier -= PAIN_REDUCTION_VERY_HEAVY
+			power = (2*effect_str)
+			L.reagent_pain_modifier -= PAIN_REDUCTION_HEAVY //only cause pain. if your in it for a long ass time
 			L.jitter(8) //Shows that things are *really* bad
 
-	//Apply stamina damage, then apply any 'excess' stamina damage beyond our maximum as tox and oxy damage
-	var/stamina_loss_limit = L.maxHealth * 2
-	L.adjustStaminaLoss(min(power, max(0, stamina_loss_limit - L.staminaloss))) //If we're under our stamina_loss limit, apply the difference between our limit and current stamina damage or power, whichever's less
-
-	var/stamina_excess_damage = (L.staminaloss + power) - stamina_loss_limit
-	if(stamina_excess_damage > 0) //If we exceed maxHealth * 2 stamina damage, apply any excess as toxloss and oxyloss
-		L.adjustToxLoss(stamina_excess_damage * 0.5)
-		L.adjustOxyLoss(stamina_excess_damage * 0.5)
-		L.Losebreath(2) //So the oxy loss actually means something.
-
 	L.stuttering = max(L.stuttering, 1)
+	L.adjustStaminaLoss(min(power, max(0, stamina_loss_limit - L.staminaloss)))   //the power decreases over time since you will already have lots most of the stamina
+
+	if(prob(25))
+		to_chat(L, "<span class='warning'>You feel the fatigue building up.</span>")
 
 	if(current_cycle < 21) //Additional effects at higher cycles
 		return ..()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
neurotox no longer deal EXTRA TOX damage. and OXY damage on its own.

it will only deal as much as the stamina crit already do

the stam damage got changes tho

it starts at 8 now and drops down to 0.1 over 30cycles

if the marine gets in orange stamina "aka" slowdown but still no crit then the toxin will only halt stamina regen

BUT.. if left un atended after 31ticks it will start to pick up again and go up no matter what. "untill its purged"

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game ##
TLDR:

if the marine is alread low at stamina or gets really close to crit before 31 cycles.
he will be kept from taking more stam damage "FROM THE NEUROTOX: if queen screeches. then you still take damage"
if the marine got full stamina it will deplet the starting stamina faster and slowdown for a while when hits orange

after 31 cycles no matter how much stamina the marine got the stam damage will grow over time untill treated or fully metabolized

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: neurotox have a higher stam damage upfront that lowers overtime
balance: neurotox have a "sweet spot" where the marine is slowdown but not lying down in crit yet
balance: neurotox stam will grow back again after 31 cycles if the marine does nothing about it
balance: neurotox extra oxy and Tox damage removed so will only take damage from the stamina itself
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
