### PR TITLE
makes some power weapons (m4ra, railgun, anti material rifle) cheaper

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -205,12 +205,12 @@ WEAPONS
 /datum/supply_packs/weapons/railgun
 	name = "TX-220 Railgun"
 	contains = list(/obj/item/weapon/gun/rifle/railgun)
-	cost = 130
+	cost = 75
 
 /datum/supply_packs/weapons/specscoutm4ra
 	name = "Scout Specialist kit (M4RA)"
 	contains = list(/obj/item/weapon/gun/rifle/m4ra)
-	cost = 80
+	cost = 50
 
 /datum/supply_packs/weapons/specdemo
 	name = "Demolitionist Specialist kit"
@@ -225,7 +225,7 @@ WEAPONS
 /datum/supply_packs/weapons/antimaterial
 	name = "T-26 Antimaterial rifle kit"
 	contains = list(/obj/item/weapon/gun/rifle/sniper/antimaterial)
-	cost = 120
+	cost = 70
 
 /datum/supply_packs/weapons/specminigun
 	name = "MIC-A7 Vindicator Minigun"
@@ -521,12 +521,12 @@ AMMO
 /datum/supply_packs/ammo/antimaterial
 	name = "T-26 magazine"
 	contains = list(/obj/item/ammo_magazine/sniper)
-	cost = 10
+	cost = 5
 
 /datum/supply_packs/ammo/railgun
 	name = "Railgun round"
 	contains = list(/obj/item/ammo_magazine/railgun)
-	cost = 4
+	cost = 3
 
 /datum/supply_packs/ammo/shotguntracker
 	name = "12 Gauge Tracker Shells"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
railgun goes from 130 to 75, rounds reduced from 4 to 3 as you only get one. 
anti mat from 120 to 70, ammo normal halved in price
M4RA goes from 80 to 50
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
These guns are incredibly niche and only useful in certain situations and I don't really see the point of making as expensive anymore. Xenomorphs get infinite respawns now so power weapons don't need to be as limited
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance:  power req guns reduced in price. railgun goes from 130 to 75, rounds reduced as you only get one. anti mat from 120 to 70, ammo normal halved in price M4RA goes from 80 to 50
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
