### PR TITLE
Hive Status and Tunnel List Info Now Includes Distance

### DIFF
--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -643,7 +643,7 @@ TUNNEL
 
 	max_integrity = 140
 	var/mob/living/carbon/xenomorph/hivelord/creator = null
-
+	///Hive number of the structure; defaults to standard.
 	var/hivenumber = XENO_HIVE_NORMAL
 	hud_possible = list(XENO_TACTICAL_HUD)
 

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -644,6 +644,7 @@ TUNNEL
 	max_integrity = 140
 	var/mob/living/carbon/xenomorph/hivelord/creator = null
 
+	var/hivenumber = XENO_HIVE_NORMAL
 	hud_possible = list(XENO_TACTICAL_HUD)
 
 

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -639,13 +639,16 @@ TUNNEL
 	resistance_flags = UNACIDABLE
 	layer = RESIN_STRUCTURE_LAYER
 
-	var/tunnel_desc = "" //description added by the hivelord.
-
 	max_integrity = 140
+
+	hud_possible = list(XENO_TACTICAL_HUD)
+
+	var/tunnel_desc = "" //description added by the hivelord.
 	var/mob/living/carbon/xenomorph/hivelord/creator = null
+
 	///Hive number of the structure; defaults to standard.
 	var/hivenumber = XENO_HIVE_NORMAL
-	hud_possible = list(XENO_TACTICAL_HUD)
+
 
 
 /obj/structure/tunnel/Initialize(mapload)

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -175,7 +175,7 @@ GLOBAL_LIST_INIT(thickenable_resin, typecacheof(list(
 
 	playsound(T, 'sound/weapons/pierce.ogg', 25, 1)
 
-
+	newt.hivenumber = X.hive //Set our structure's hive
 	newt.creator = X
 
 	X.tunnels.Add(newt)

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -1060,6 +1060,9 @@ to_chat will check for valid clients itself already so no need to double check f
 /mob/living/carbon/xenomorph/get_xeno_hivenumber()
 	return hivenumber
 
+/obj/structure/tunnel/get_xeno_hivenumber()
+	return hivenumber
+
 /obj/structure/resin/xeno_turret/get_xeno_hivenumber()
 	return associated_hive.hivenumber
 

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -18,7 +18,7 @@
 
 	dat += "<b>List of Hive Tunnels:</b><BR>"
 
-	for(var/obj/structure/tunnel/T in GLOB.xeno_tunnels)
+	for(var/obj/structure/tunnel/T AS in GLOB.xeno_tunnels)
 		if(user.issamexenohive(T))
 			var/distance = get_dist(user, T)
 			dat += "<b>[T.name]</b> located at: <b><font color=green>([T.tunnel_desc][distance > 0 ? " <b>Distance: [distance])</b>" : ""]</b></font><BR>"

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -31,9 +31,10 @@
 
 	for(var/obj/structure/tunnel/T in GLOB.xeno_tunnels)
 		if(T.creator.hive == hive)
-			dat += "<b>[T.name]</b> located at: <b><font color=green>([T.tunnel_desc])</b></font><BR>"
+			var/distance = get_dist(user, T)
+			dat += "<b>[T.name]</b> located at: <b><font color=green>([T.tunnel_desc][distance > 0 ? " <b>Distance: [distance])</b>" : ""]</b></font><BR>"
 
-	var/datum/browser/popup = new(user, "roundstatus", "<div align='center'>Tunnel List</div>", 600, 600)
+	var/datum/browser/popup = new(user, "tunnelstatus", "<div align='center'>Tunnel List</div>", 600, 600)
 	popup.set_content(dat)
 	popup.open(FALSE)
 
@@ -57,9 +58,11 @@
 			if(0 to 0.33)
 				hp_color = "red"
 
+		var/distance = get_dist(user, X)
+
 		xenoinfo += " <b><font color=[hp_color]>Health: ([X.health]/[X.maxHealth])</font></b>"
 
-		xenoinfo += " <b><font color=green>([AREACOORD_NO_Z(X)])</b></td></tr>"
+		xenoinfo += " <b><font color=green>([AREACOORD_NO_Z(X)][distance > 0 ? " <b>Distance: [distance]</b>" : ""])</font></b></td></tr>"
 
 	return xenoinfo
 

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -16,21 +16,10 @@
 /proc/check_tunnel_list(mob/user) //Creates a handy list of all xeno tunnels
 	var/dat = "<br>"
 
-	var/datum/hive_status/hive
-	if(isxeno(user))
-		var/mob/living/carbon/xenomorph/xeno_user = user
-		if(xeno_user.hive)
-			hive = xeno_user.hive
-	else
-		hive = GLOB.hive_datums[XENO_HIVE_NORMAL]
-
-	if(!hive)
-		CRASH("couldnt find a hive in check_tunnel_list")
-
 	dat += "<b>List of Hive Tunnels:</b><BR>"
 
 	for(var/obj/structure/tunnel/T in GLOB.xeno_tunnels)
-		if(T.creator.hive == hive)
+		if(user.issamexenohive(T))
 			var/distance = get_dist(user, T)
 			dat += "<b>[T.name]</b> located at: <b><font color=green>([T.tunnel_desc][distance > 0 ? " <b>Distance: [distance])</b>" : ""]</b></font><BR>"
 

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -68,14 +68,14 @@
 	var/turf/tunnel_turf = get_step(center_turf, NORTH)
 	if(tunnel_turf.can_dig_xeno_tunnel())
 		var/obj/structure/tunnel/newt = new(tunnel_turf)
-		newt.tunnel_desc = " [get_area(newt)] (X: [newt.x], Y: [newt.y])"
-		newt.name += "[name]"
+		newt.tunnel_desc = "[AREACOORD_NO_Z(newt)]"
+		newt.name += " [name]"
 
 /obj/structure/resin/silo/Destroy()
 	GLOB.xeno_resin_silos -= src
 	if(associated_hive)
 		UnregisterSignal(associated_hive, list(COMSIG_HIVE_XENO_MOTHER_PRE_CHECK, COMSIG_HIVE_XENO_MOTHER_CHECK))
-		
+
 		if(isdistress(SSticker.mode)) //Silo can only be destroy in distress mode, but this check can create bugs if new gamemodes are added.
 			var/datum/game_mode/infestation/distress/distress_mode
 			distress_mode = SSticker.mode


### PR DESCRIPTION
## About The Pull Request

1. Distance data is now included for Hive and Tunnel status lists.

2. Should fix a bug that stopped Tunnel lists from being openable.

## Why It's Good For The Game

1. Distance data is now included for Hive and Tunnel status lists.

2. Should fix a bug that stopped Tunnel lists from being openable.

## Changelog
:cl:
code: Distance data is now included for Hive and Tunnel status lists.
fix: Should fix a bug that stopped Tunnel lists from being openable.
/:cl: