### PR TITLE
Fixed Bug With Scatterspit Projectiles Going Too Far

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/abilities_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/abilities_spitter.dm
@@ -128,7 +128,7 @@
 	newspit.permutated += X
 	newspit.def_zone = X.get_limbzone_target()
 
-	newspit.fire_at(target, X, null)
+	newspit.fire_at(target, X, null, newspit.ammo.max_range)
 
 	succeed_activate()
 	add_cooldown()

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1657,7 +1657,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	bonus_projectiles_type = /datum/ammo/xeno/acid/heavy/scatter
 	bonus_projectiles_amount = 5
 	bonus_projectiles_scatter = 10
-	max_range = 10
+	max_range = 8
 	puddle_duration = 2 SECONDS //Lasts 2-4 seconds
 
 /datum/ammo/xeno/boiler_gas

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1657,7 +1657,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	bonus_projectiles_type = /datum/ammo/xeno/acid/heavy/scatter
 	bonus_projectiles_amount = 5
 	bonus_projectiles_scatter = 10
-	max_range = 7
+	max_range = 10
 	puddle_duration = 2 SECONDS //Lasts 2-4 seconds
 
 /datum/ammo/xeno/boiler_gas


### PR DESCRIPTION
## About The Pull Request

Fixes bug with scatterspit projectiles going too far.

Max range increased to range 8.

## Why It's Good For The Game

Fixes bug with scatterspit projectiles going too far.

Fixes: https://github.com/tgstation/TerraGov-Marine-Corps/issues/6387

## Changelog
:cl:
fix: Fixes bug with scatterspit projectiles going too far.
balance: Scatterspit max range increased to 8 tiles.
/:cl: