### PR TITLE
QoL Ammo Box

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -119,7 +119,6 @@
 	wrenchable = FALSE
 	req_one_access = list(ACCESS_MARINE_CARGO, ACCESS_MARINE_LOGISTICS)
 	products = list(
-		/obj/item/storage/box/ammo = 30,
 		/obj/item/storage/box/nade_box = 2,
 		/obj/item/storage/box/nade_box/HIDP = 2,
 		/obj/item/storage/box/nade_box/M15 = 2,
@@ -300,6 +299,7 @@
 		/obj/item/ammo_magazine/box10x24mm = 50,
 		/obj/item/ammo_magazine/box10x26mm = 50,
 		/obj/item/ammo_magazine/box10x27mm = 50,
+		/obj/item/storage/box/ammo = 15,
 	)
 	premium = list()
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Moves ammo boxes from RO vendor to Big Ammo vendors. A QoL improvement so 30 ammo boxes aren't all sitting on one tile as most RO's just vend them all into a crate and off load it. Marines do not have to bother RO's for something this simple anymore (especially on rounds without a dedicated RO this is annoying).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

QoL improvement for low and mid pop. Slight lag reduction (no longer are 30 + ammo boxes stacked on one tile) and anti-roomba (since ammo boxes spawn on the vendor and roomba can't move on vendor tiles). I no longer have to fucking spam left click 30 times every round im RO. On sulaco, there are 30 ammo boxes; on PoS, there are 45 (due to the PO vendors existence).

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: RO Ammo boxes moved to big ammo vendors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
