### PR TITLE
QoL Corpsmen Storage

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -119,7 +119,6 @@
 	wrenchable = FALSE
 	req_one_access = list(ACCESS_MARINE_CARGO, ACCESS_MARINE_LOGISTICS)
 	products = list(
-		/obj/item/storage/box/ammo = 30,
 		/obj/item/storage/box/nade_box = 2,
 		/obj/item/storage/box/nade_box/HIDP = 2,
 		/obj/item/storage/box/nade_box/M15 = 2,
@@ -300,6 +299,7 @@
 		/obj/item/ammo_magazine/box10x24mm = 50,
 		/obj/item/ammo_magazine/box10x26mm = 50,
 		/obj/item/ammo_magazine/box10x27mm = 50,
+		/obj/item/storage/box/ammo = 15,
 	)
 	premium = list()
 

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -976,6 +976,7 @@ GLOBAL_LIST_INIT(marine_selector_cats, list(
 
 		/obj/item/storage/pill_bottle/bicamera = list(CAT_MEDSUP, "BicaMera pills", 30, "orange"),
 		/obj/item/storage/pill_bottle/keloderm = list(CAT_MEDSUP, "KeloDerm pills", 30, "orange"),
+		/obj/item/storage/backpack/lightpack = list(CAT_MEDSUP, "Combat Backpack", 15, "orange"),
 		/obj/item/storage/pill_bottle/paracetamol = list(CAT_MEDSUP, "Paracetamol pills", 8, "orange"),
 		/obj/item/storage/pill_bottle/bicaridine = list(CAT_MEDSUP, "Bicaridine pills", 8, "black"),
 		/obj/item/storage/pill_bottle/kelotane = list(CAT_MEDSUP, "Kelotane pills", 8, "black"),


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a 15 point buyable to corpsmen vendors; the combat backpack. Balanced around the fact that you get 2 less meraderm hypos / case, and/or 1 less neuraline in return for greatly increased storage space.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

With the constant addition of anti-chems (neuro, larvae injection being used more, neurotox clouds, ranged prae neuro) and the nerf to webbing (no surgical vest), corpsmen gaming is at an all time low. One of the issues is that storage is a huge issue; you have to carry extra hypervene (or ryt if your a gamer like fernando), dylovene (to deal with OD's of these xeno chems) and dexalin (same reason), alongside other specialized meds such as iron sugar. This means you basically have little to no room for ammo to be an actual corpsman; a healer and defender of your patients. This PR helps to alleviate that while still having a drawback for choosing it.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Combat backpack to corpsmen point vendor for 15 points.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
