### PR TITLE
Adds a shortcut for the AI to turn on & off fire alarms using shift & Ctrl click.

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -171,6 +171,17 @@
 		return
 	toggle_breaker(usr)
 
+/* Firealarm */
+/obj/machinery/firealarm/AICtrlClick(mob/living/silicon/ai/user) // turn on the fire alarm
+	if(z != user.z)
+		return
+	alarm()
+
+/obj/machinery/firealarm/AICtrlShiftClick(mob/living/silicon/ai/user) // turn off the fire alarm
+	if(z != user.z)
+		return
+	reset()
+
 
 //
 // Override TurfAdjacent for AltClicking


### PR DESCRIPTION
## About The Pull Request
Just lets you use that thing more swiftly. QoL

## Why It's Good For The Game
Qol again

## Changelog
:cl:
qol: Adds a shortcut for the AI to turn on & off fire alarms using shift & Ctrl click.
/:cl:

