### PR TITLE
Turret Price Change

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -175,12 +175,12 @@ WEAPONS
 /datum/supply_packs/weapons/sentry
 	name = "UA 571-C Base Defense Sentry"
 	contains = list(/obj/item/storage/box/sentry)
-	cost = 100
+	cost = 60
 
 /datum/supply_packs/weapons/minisentry
 	name = "UA-580 Portable Sentry"
 	contains = list(/obj/item/storage/box/minisentry)
-	cost = 40
+	cost = 30
 
 /datum/supply_packs/weapons/m56d_emplacement
 	name = "TL-102 Mounted Heavy Smartgun"


### PR DESCRIPTION

<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes portables to 30 points and base to 60 points in requisitions.

## Why It's Good For The Game

This PR puts the turret prices in line to around 4-5 mins of profit from a phoron (for portable) or 4-5 mins of time of profit for plat (for base) without overclock. This allows marines to be actively rewarded for capturing miners because they can finally defend them without having to pull half the force from the front (which makes miners useless since if half the marine force isn't at front they usually fall apart due to how marines and xenos are balanced). Capture a phoron and portable it on alarm mode and cade it to protect against T1's and Wraith's (who can still affect miner outposts; they just have to actually put effort now). Base turrets for plats if marines get that far and are willing to spend the cash on defense. Portable turrets also finally fulfill their niche of mobile alarms that spook xenos with light bullets; making covering flanks at the very front possible due to alarms.

The only thing I can think of as niche cases that might make this too OP is tadpole bases (landing right on several plats and shitting out turrets) which can usually be dealt with by boiler, or marines spending money on just base turrets and making a doom fort. Hence id say this might need a TM alongside the marine materials buff currently going on to see if these changes are abuseable.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Portable turrets are now 30 points and base turrets are 60 points in requisitions.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
