### PR TITLE
minor droid grammar fixes

### DIFF
--- a/code/modules/vehicles/unmanned/unmanned_droid.dm
+++ b/code/modules/vehicles/unmanned/unmanned_droid.dm
@@ -49,7 +49,7 @@
 /obj/vehicle/unmanned/droid/scout/examine(mob/user, distance, infix, suffix)
 	. = ..()
 	if(ishuman(user))
-		to_chat(user, "Use <b>Right Click</b> when piloting the droid to activate it's cloak.")
+		to_chat(user, "Use <b>right click</b> when piloting the droid to activate its cloaking systems.")
 
 /obj/vehicle/unmanned/droid/scout/on_remote_toggle(datum/source, is_on, mob/user)
 	. = ..()

--- a/code/modules/vehicles/unmanned/unmanned_vehicle.dm
+++ b/code/modules/vehicles/unmanned/unmanned_vehicle.dm
@@ -67,8 +67,8 @@
 		if(turret_pattern != turret.turret_pattern)
 			to_chat(user, "<span class='notice'>You can't attach that type of turret!</span>")
 			return
-	user.visible_message("<span class='notice'>You start to attach [I] to [src].</span>",
-	"<span class='notice'>[user] starts to attach [I] to [src].</span>")
+	user.visible_message("<span class='notice'>[user] starts to attach [I] to [src].</span>",
+	"<span class='notice'>You start to attach [I] to [src].</span>")
 	if(!do_after(user, 3 SECONDS, TRUE, src, BUSY_ICON_GENERIC))
 		return
 	if(istype(I, /obj/item/uav_turret))
@@ -77,8 +77,8 @@
 		ammo = GLOB.ammo_list[turret.ammo_type]
 	else if(istype(I, /obj/item/explosive/plastique))
 		turret_type = TURRET_TYPE_EXPLOSIVE
-	user.visible_message("<span class='notice'>You attach [I] to [src].</span>",
-	"<span class='notice'>[user] attaches [I] to [src].</span>")
+	user.visible_message("<span class='notice'>[user] attaches [I] to [src].</span>",
+	"<span class='notice'>You attach [I] to [src].</span>")
 	update_icon()
 	SEND_SIGNAL(src, COMSIG_UNMANNED_TURRET_UPDATED, turret_type)
 	qdel(I)

--- a/code/modules/vehicles/unmanned/unmanned_vehicle_remote.dm
+++ b/code/modules/vehicles/unmanned/unmanned_vehicle_remote.dm
@@ -1,6 +1,6 @@
 /obj/item/unmanned_vehicle_remote
-	name = "Handheld Vehicle Controller"
-	desc = "Used to control an unmanned vehicle."
+	name = "handheld vehicle controller"
+	desc = "Used to control an unmanned vehicle.<br>Tap the vehicle you want to control with the controller to link it."
 	icon = 'icons/obj/items/items.dmi'
 	icon_state = "multitool2"
 	///reference to the unmanned vehicle that we're connected to or remote control


### PR DESCRIPTION
## Changelog
:cl:
spellcheck: Fixed some grammar errors regarding with droids
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
