### PR TITLE
Praetorian cone sprays rework + acid spray exploit fix

### DIFF
--- a/code/__DEFINES/cooldowns.dm
+++ b/code/__DEFINES/cooldowns.dm
@@ -31,6 +31,7 @@
 #define COOLDOWN_CLOAK_IMPLANT "cloak_implant"
 #define COOLDOWN_DRONE_CLOAK "drone_cloak"
 #define COOLDOWN_XENO_TURRETS_ALERT "xeno_turrets_alert"
+#define COOLDOWN_PARALYSE_ACID "acid_spray_paralyse"
 
 //// COOLDOWN SYSTEMS
 /*

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -46,12 +46,15 @@
 	var/slow_amt = 0.8
 	var/duration = 10 SECONDS
 	var/acid_damage = XENO_DEFAULT_ACID_PUDDLE_DAMAGE
+	/// World.time when it was initialized
+	var/creation_time
 
 /obj/effect/xenomorph/spray/Initialize(mapload, duration = 10 SECONDS, damage = XENO_DEFAULT_ACID_PUDDLE_DAMAGE) //Self-deletes
 	. = ..()
 	START_PROCESSING(SSprocessing, src)
 	QDEL_IN(src, duration + rand(0, 2 SECONDS))
 	acid_damage = damage
+	creation_time = world.time
 
 /obj/effect/xenomorph/spray/Destroy()
 	STOP_PROCESSING(SSprocessing, src)
@@ -69,6 +72,9 @@
 	
 	if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_ACID))
 		return
+	
+	if(world.time <= acid_spray.creation_time + 3) //To prevent being able to walk "over" acid sprays
+		Paralyze(20)
 
 	TIMER_COOLDOWN_START(src, COOLDOWN_ACID, 1 SECONDS)
 	if(HAS_TRAIT(src, TRAIT_FLOORED))

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -74,6 +74,8 @@
 		return
 	
 	if(world.time <= acid_spray.creation_time + 5) //To prevent being able to walk "over" acid sprays
+		take_overall_damage_armored(damage, BURN, "acid", updating_health = TRUE)
+		emote("scream")
 		Paralyze(20)
 
 	TIMER_COOLDOWN_START(src, COOLDOWN_ACID, 1 SECONDS)

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -67,6 +67,7 @@
 	. = ..()
 	SEND_SIGNAL(AM, COMSIG_ATOM_ACIDSPRAY_ACT, src, acid_damage, slow_amt)
 
+/// Set xeno_owner to null to avoid hard del
 /obj/effect/xenomorph/spray/proc/clean_mob_owner()
 	UnregisterSignal(xeno_owner, COMSIG_PARENT_QDELETING)
 	xeno_owner = null

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -48,13 +48,16 @@
 	var/acid_damage = XENO_DEFAULT_ACID_PUDDLE_DAMAGE
 	/// World.time when it was initialized
 	var/creation_time
+	/// Who created that spray
+	var/mob/xeno_owner
 
-/obj/effect/xenomorph/spray/Initialize(mapload, duration = 10 SECONDS, damage = XENO_DEFAULT_ACID_PUDDLE_DAMAGE) //Self-deletes
+/obj/effect/xenomorph/spray/Initialize(mapload, duration = 10 SECONDS, damage = XENO_DEFAULT_ACID_PUDDLE_DAMAGE, mob/living/_xeno_owner) //Self-deletes
 	. = ..()
 	START_PROCESSING(SSprocessing, src)
 	QDEL_IN(src, duration + rand(0, 2 SECONDS))
 	acid_damage = damage
 	creation_time = world.time
+	xeno_owner = _xeno_owner
 
 /obj/effect/xenomorph/spray/Destroy()
 	STOP_PROCESSING(SSprocessing, src)
@@ -74,9 +77,7 @@
 		return
 	
 	if(world.time <= acid_spray.creation_time + 5) //To prevent being able to walk "over" acid sprays
-		take_overall_damage_armored(acid_damage, BURN, "acid", updating_health = TRUE)
-		emote("scream")
-		Paralyze(20)
+		acid_spray_act(acid_spray.xeno_owner)
 		return
 
 	TIMER_COOLDOWN_START(src, COOLDOWN_ACID, 1 SECONDS)

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -73,7 +73,7 @@
 	if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_ACID))
 		return
 	
-	if(world.time <= acid_spray.creation_time + 3) //To prevent being able to walk "over" acid sprays
+	if(world.time <= acid_spray.creation_time + 5) //To prevent being able to walk "over" acid sprays
 		Paralyze(20)
 
 	TIMER_COOLDOWN_START(src, COOLDOWN_ACID, 1 SECONDS)

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -74,9 +74,10 @@
 		return
 	
 	if(world.time <= acid_spray.creation_time + 5) //To prevent being able to walk "over" acid sprays
-		take_overall_damage_armored(damage, BURN, "acid", updating_health = TRUE)
+		take_overall_damage_armored(acid_damage, BURN, "acid", updating_health = TRUE)
 		emote("scream")
 		Paralyze(20)
+		return
 
 	TIMER_COOLDOWN_START(src, COOLDOWN_ACID, 1 SECONDS)
 	if(HAS_TRAIT(src, TRAIT_FLOORED))

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -7,7 +7,7 @@
 	mechanics_text = "Spray a cone of dangerous acid at your target."
 	ability_name = "spray acid"
 	plasma_cost = 200
-	cooldown_timer = 40 SECONDS
+	cooldown_timer = 1 SECONDS
 
 /datum/action/xeno_action/activable/spray_acid/cone/use_ability(atom/A)
 	var/mob/living/carbon/xenomorph/X = owner
@@ -32,7 +32,7 @@
 	"<span class='xenowarning'>We spew forth a cone of acid!</span>", null, 5)
 
 	X.add_movespeed_modifier(type, TRUE, 0, NONE, TRUE, 2)
-	do_acid_spray_cone(target, X.xeno_caste.acid_spray_range)
+	start_acid_spray_cone(target, X.xeno_caste.acid_spray_range)
 	add_cooldown()
 	addtimer(CALLBACK(src, .proc/reset_speed), rand(2 SECONDS, 3 SECONDS))
 
@@ -58,111 +58,61 @@
 
 GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj/vehicle/multitile/root/cm_armored, /obj/structure/razorwire)))
 
-/datum/action/xeno_action/activable/spray_acid/cone/proc/do_acid_spray_cone(turf/T, range)
-	set waitfor = FALSE
+#define CONE_PART_MIDDLE (1<<0)
+#define CONE_PART_LEFT (1<<1)
+#define CONE_PART_RIGHT (1<<2)
+#define CONE_PART_DIAG_LEFT (1<<3)
+#define CONE_PART_DIAG_RIGHT (1<<4)
+#define CONE_PART_MIDDLE_DIAG (1<<5)
 
-	var/facing = get_cardinal_dir(owner, T)
+///Start the acid cone spray in the correct direction
+/datum/action/xeno_action/activable/spray_acid/cone/proc/start_acid_spray_cone(turf/T, range)
+	var/facing = angle_to_dir(Get_Angle(owner, T))
 	owner.setDir(facing)
-
-	T = get_turf(owner)
-	for (var/i in 1 to range)
-
-		var/turf/next_T = get_step(T, facing)
-
-		for (var/obj/O in T)
-			if(!O.CheckExit(owner, next_T))
-				if(is_type_in_typecache(O, GLOB.acid_spray_hit) && O.acid_spray_act(owner))
-					return // returned true if normal density applies
-				if(O.density && !O.throwpass && !(O.flags_atom & ON_BORDER))
-					return
-
-		T = next_T
-
-		if (T.density)
-			return
-
-		for (var/obj/O in T)
-			if(!O.CanPass(owner, get_turf(owner)))
-				if(is_type_in_typecache(O, GLOB.acid_spray_hit) && O.acid_spray_act(owner))
-					return // returned true if normal density applies
-				if(O.density && !O.throwpass && !(O.flags_atom & ON_BORDER))
-					return
-
-		var/obj/effect/xenomorph/spray/S = acid_splat_turf(T)
-		do_acid_spray_cone_normal(T, i, facing, S)
-		sleep(3)
-
-// Normal refers to the mathematical normal
-/datum/action/xeno_action/activable/spray_acid/cone/proc/do_acid_spray_cone_normal(turf/T, distance, facing, obj/effect/xenomorph/spray/source_spray)
-	if (!distance)
+	switch(facing)
+		if(NORTH, SOUTH, EAST, WEST)
+			do_acid_cone_spray(get_step(owner.loc, facing), range, facing, CONE_PART_MIDDLE|CONE_PART_LEFT|CONE_PART_RIGHT, owner)
+		if(NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST)
+			do_acid_cone_spray(get_step(owner.loc, facing), range, facing, CONE_PART_MIDDLE_DIAG, owner)
+			do_acid_cone_spray(get_step(owner.loc, facing), range + 1, facing, CONE_PART_DIAG_LEFT|CONE_PART_DIAG_RIGHT, owner)
+	
+///Check if it's possible to create a spray, and if yes, check if the spray must continue
+/datum/action/xeno_action/activable/spray_acid/cone/proc/do_acid_cone_spray(turf/T, distance_left, facing, direction_flag, source_spray)
+	if(distance_left <= 0)
+		return
+	if(T.density)
+		return
+	var/is_blocked = FALSE
+	for (var/obj/O in T)
+		if(!O.CanPass(source_spray, get_turf(source_spray)))
+			is_blocked = TRUE
+	if(is_blocked)
 		return
 
-	var/obj/effect/xenomorph/spray/left_S = source_spray
-	var/obj/effect/xenomorph/spray/right_S = source_spray
+	var/mob/living/carbon/xenomorph/praetorian/xeno_owner = owner
+	
+	var/obj/effect/xenomorph/spray/spray = new(T, xeno_owner.xeno_caste.acid_spray_duration, xeno_owner.xeno_caste.acid_spray_damage)
+	var/turf/next_normal_turf = get_step(T, facing)
+	for (var/atom/A AS in T)
+		A.acid_spray_act(owner)
+		if((A.density && !A.throwpass && !(A.flags_atom & ON_BORDER)) || !A.CheckExit(source_spray, next_normal_turf))
+			is_blocked = TRUE
+	if(!is_blocked)
+		addtimer(CALLBACK(src, .proc/continue_acid_cone_spray, T, next_normal_turf, distance_left, facing, direction_flag, spray), 3)
+	
 
-	var/normal_dir = turn(facing, 90)
-	var/inverse_normal_dir = turn(facing, -90)
-
-	var/turf/normal_turf = T
-	var/turf/inverse_normal_turf = T
-
-	var/normal_density_flag = 0
-	var/inverse_normal_density_flag = 0
-
-	for (var/i in 1 to distance)
-		if (normal_density_flag && inverse_normal_density_flag)
-			return
-
-		if (!normal_density_flag)
-			var/next_normal_turf = get_step(normal_turf, normal_dir)
-
-			for (var/obj/O in normal_turf)
-				if(!O.CheckExit(left_S, next_normal_turf))
-					normal_density_flag = TRUE
-					if(is_type_in_typecache(O, GLOB.acid_spray_hit))
-						normal_density_flag = O.acid_spray_act(owner)
-					break
-
-			normal_turf = next_normal_turf
-
-			if(!normal_density_flag)
-				normal_density_flag = normal_turf.density
-
-			if(!normal_density_flag)
-				for (var/obj/O in normal_turf)
-					if(!O.CanPass(left_S, left_S.loc))
-						normal_density_flag = TRUE
-						if(is_type_in_typecache(O, GLOB.acid_spray_hit))
-							normal_density_flag = O.acid_spray_act(owner)
-						break
-
-			if (!normal_density_flag)
-				left_S = acid_splat_turf(normal_turf)
-
-
-		if (!inverse_normal_density_flag)
-
-			var/next_inverse_normal_turf = get_step(inverse_normal_turf, inverse_normal_dir)
-
-			for (var/obj/O in inverse_normal_turf)
-				if(!O.CheckExit(right_S, next_inverse_normal_turf))
-					inverse_normal_density_flag = TRUE
-					if(is_type_in_typecache(O, GLOB.acid_spray_hit))
-						inverse_normal_density_flag = O.acid_spray_act(owner)
-					break
-
-			inverse_normal_turf = next_inverse_normal_turf
-
-			if(!inverse_normal_density_flag)
-				inverse_normal_density_flag = inverse_normal_turf.density
-
-			if(!inverse_normal_density_flag)
-				for (var/obj/O in inverse_normal_turf)
-					if(!O.CanPass(right_S, right_S.loc))
-						inverse_normal_density_flag = TRUE //passable for acid spray
-						if(is_type_in_typecache(O, GLOB.acid_spray_hit))
-							inverse_normal_density_flag = O.acid_spray_act(owner)
-						break
-
-			if (!inverse_normal_density_flag)
-				right_S = acid_splat_turf(inverse_normal_turf)
+///Call the next steps of the cone spray, 
+/datum/action/xeno_action/activable/spray_acid/cone/proc/continue_acid_cone_spray(turf/current_turf, turf/next_normal_turf, distance_left, facing, direction_flag, spray)
+	if(CHECK_BITFIELD(direction_flag, CONE_PART_MIDDLE))
+		do_acid_cone_spray(next_normal_turf, distance_left - 1 , facing, CONE_PART_MIDDLE, spray, owner)
+	if(CHECK_BITFIELD(direction_flag, CONE_PART_RIGHT))
+		do_acid_cone_spray(get_step(next_normal_turf, turn(facing, 90)), distance_left - 1, facing, CONE_PART_RIGHT|CONE_PART_MIDDLE, spray, owner)
+	if(CHECK_BITFIELD(direction_flag, CONE_PART_LEFT))
+		do_acid_cone_spray(get_step(next_normal_turf, turn(facing, -90)), distance_left - 1, facing, CONE_PART_LEFT|CONE_PART_MIDDLE, spray, owner)
+	if(CHECK_BITFIELD(direction_flag, CONE_PART_DIAG_LEFT))
+		do_acid_cone_spray(get_step(current_turf, turn(facing, 45)), distance_left - 1, turn(facing, 45), CONE_PART_MIDDLE, spray, owner)
+	if(CHECK_BITFIELD(direction_flag, CONE_PART_DIAG_RIGHT))
+		do_acid_cone_spray(get_step(current_turf, turn(facing, -45)), distance_left - 1, turn(facing, -45), CONE_PART_MIDDLE, spray, owner)
+	if(CHECK_BITFIELD(direction_flag, CONE_PART_MIDDLE_DIAG))
+		do_acid_cone_spray(next_normal_turf, distance_left - 1, facing, CONE_PART_DIAG_LEFT|CONE_PART_DIAG_RIGHT, spray, owner)
+		do_acid_cone_spray(next_normal_turf, distance_left - 2, facing, CONE_PART_MIDDLE, spray, owner)

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -72,7 +72,7 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 	switch(facing)
 		if(NORTH, SOUTH, EAST, WEST)
 			do_acid_cone_spray(get_step(owner.loc, facing), range, facing, CONE_PART_MIDDLE|CONE_PART_LEFT|CONE_PART_RIGHT, owner)
-		if(NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST)
+		if(NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST) //Carefull, this is not perfectly symetrical when range != 4
 			do_acid_cone_spray(get_step(owner.loc, facing), range, facing, CONE_PART_MIDDLE_DIAG, owner)
 			do_acid_cone_spray(get_step(owner.loc, facing), range + 1, facing, CONE_PART_DIAG_LEFT|CONE_PART_DIAG_RIGHT, owner)
 	
@@ -84,6 +84,8 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 		return
 	var/is_blocked = FALSE
 	for (var/obj/O in T)
+		if(is_type_in_typecache(O, GLOB.acid_spray_hit))
+			O.acid_spray_act(owner)
 		if(!O.CanPass(source_spray, get_turf(source_spray)))
 			is_blocked = TRUE
 	if(is_blocked)
@@ -115,4 +117,7 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 		do_acid_cone_spray(get_step(current_turf, turn(facing, -45)), distance_left - 1, turn(facing, -45), CONE_PART_MIDDLE, spray, owner)
 	if(CHECK_BITFIELD(direction_flag, CONE_PART_MIDDLE_DIAG))
 		do_acid_cone_spray(next_normal_turf, distance_left - 1, facing, CONE_PART_DIAG_LEFT|CONE_PART_DIAG_RIGHT, spray, owner)
-		do_acid_cone_spray(next_normal_turf, distance_left - 2, facing, CONE_PART_MIDDLE, spray, owner)
+		if(distance_left <= 5)
+			do_acid_cone_spray(next_normal_turf, distance_left - 2, facing, CONE_PART_MIDDLE, spray, owner)
+		else
+			do_acid_cone_spray(next_normal_turf, distance_left - 1, facing, CONE_PART_MIDDLE_DIAG, spray, owner)

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -7,7 +7,7 @@
 	mechanics_text = "Spray a cone of dangerous acid at your target."
 	ability_name = "spray acid"
 	plasma_cost = 200
-	cooldown_timer = 1 SECONDS
+	cooldown_timer = 40 SECONDS
 
 /datum/action/xeno_action/activable/spray_acid/cone/use_ability(atom/A)
 	var/mob/living/carbon/xenomorph/X = owner

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -95,7 +95,7 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 	
 	var/obj/effect/xenomorph/spray/spray = new(T, xeno_owner.xeno_caste.acid_spray_duration, xeno_owner.xeno_caste.acid_spray_damage, src)
 	var/turf/next_normal_turf = get_step(T, facing)
-	for (var/atom/A AS in T)
+	for (var/atom/movable/A AS in T)
 		A.acid_spray_act(owner)
 		if((A.density && !A.throwpass && !(A.flags_atom & ON_BORDER)) || !A.CheckExit(source_spray, next_normal_turf))
 			is_blocked = TRUE
@@ -117,7 +117,4 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 		do_acid_cone_spray(get_step(current_turf, turn(facing, -45)), distance_left - 1, turn(facing, -45), CONE_PART_MIDDLE, spray, owner)
 	if(CHECK_BITFIELD(direction_flag, CONE_PART_MIDDLE_DIAG))
 		do_acid_cone_spray(next_normal_turf, distance_left - 1, facing, CONE_PART_DIAG_LEFT|CONE_PART_DIAG_RIGHT, spray, owner)
-		if(distance_left <= 5)
-			do_acid_cone_spray(next_normal_turf, distance_left - 2, facing, CONE_PART_MIDDLE, spray, owner)
-		else
-			do_acid_cone_spray(next_normal_turf, distance_left - 1, facing, CONE_PART_MIDDLE_DIAG, spray, owner)
+		do_acid_cone_spray(next_normal_turf, distance_left - 2, facing, (distance_left < 5) ? CONE_PART_MIDDLE : CONE_PART_MIDDLE_DIAG, spray, owner)

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -91,7 +91,7 @@ GLOBAL_LIST_INIT(acid_spray_hit, typecacheof(list(/obj/structure/barricade, /obj
 
 	var/mob/living/carbon/xenomorph/praetorian/xeno_owner = owner
 	
-	var/obj/effect/xenomorph/spray/spray = new(T, xeno_owner.xeno_caste.acid_spray_duration, xeno_owner.xeno_caste.acid_spray_damage)
+	var/obj/effect/xenomorph/spray/spray = new(T, xeno_owner.xeno_caste.acid_spray_duration, xeno_owner.xeno_caste.acid_spray_damage, src)
 	var/turf/next_normal_turf = get_step(T, facing)
 	for (var/atom/A AS in T)
 		A.acid_spray_act(owner)

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
@@ -40,7 +40,7 @@
 	spit_types = list(/datum/ammo/xeno/toxin/heavy, /datum/ammo/xeno/acid/heavy)
 
 	acid_spray_duration = 10 SECONDS
-	acid_spray_range = 6
+	acid_spray_range = 4
 	acid_spray_damage = 16
 	acid_spray_damage_on_hit = 35
 	acid_spray_structure_damage = 45
@@ -174,4 +174,3 @@
 
 	// *** Pheromones *** //
 	aura_strength = 4.5
-

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
@@ -40,7 +40,7 @@
 	spit_types = list(/datum/ammo/xeno/toxin/heavy, /datum/ammo/xeno/acid/heavy)
 
 	acid_spray_duration = 10 SECONDS
-	acid_spray_range = 4
+	acid_spray_range = 6
 	acid_spray_damage = 16
 	acid_spray_damage_on_hit = 35
 	acid_spray_structure_damage = 45

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -562,30 +562,24 @@
 
 // this mess will be fixed by obj damage refactor
 /atom/proc/acid_spray_act(mob/living/carbon/xenomorph/X)
-	return TRUE
+	return FALSE
 
 /obj/structure/acid_spray_act(mob/living/carbon/xenomorph/X)
-	if(!is_type_in_typecache(src, GLOB.acid_spray_hit))
-		return TRUE // normal density flag
-	take_damage(X.xeno_caste.acid_spray_structure_damage, "acid", "acid")
-	return TRUE // normal density flag
+	if(is_type_in_typecache(src, GLOB.acid_spray_hit))
+		take_damage(X.xeno_caste.acid_spray_structure_damage, "acid", "acid")
+	return density // normal density flag
 
 /obj/structure/razorwire/acid_spray_act(mob/living/carbon/xenomorph/X)
 	. = ..()
 	return FALSE // not normal density flag
 
-/obj/vehicle/multitile/root/cm_armored/acid_spray_act(mob/living/carbon/xenomorph/X)
-	take_damage_type(X.xeno_caste.acid_spray_structure_damage, "acid", src)
-	healthcheck()
-	return TRUE
-
 /mob/living/carbon/acid_spray_act(mob/living/carbon/xenomorph/X)
 	ExtinguishMob()
 	if(isnestedhost(src))
-		return
+		return FALSE
 
 	if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_ACID))
-		return
+		return FALSE
 	TIMER_COOLDOWN_START(src, COOLDOWN_ACID, 2 SECONDS)
 
 	if(isxenopraetorian(X))
@@ -596,6 +590,7 @@
 	var/damage = X.xeno_caste.acid_spray_damage_on_hit
 	apply_acid_spray_damage(damage, armor_block)
 	to_chat(src, "<span class='xenodanger'>\The [X] showers you in corrosive acid!</span>")
+	return FALSE
 
 /mob/living/carbon/proc/apply_acid_spray_damage(damage, armor_block)
 	apply_damage(damage, BURN, null, armor_block, updating_health = TRUE)

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -562,7 +562,7 @@
 
 // this mess will be fixed by obj damage refactor
 /atom/proc/acid_spray_act(mob/living/carbon/xenomorph/X)
-	return FALSE
+	return
 
 /obj/structure/acid_spray_act(mob/living/carbon/xenomorph/X)
 	if(is_type_in_typecache(src, GLOB.acid_spray_hit))

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -562,24 +562,30 @@
 
 // this mess will be fixed by obj damage refactor
 /atom/proc/acid_spray_act(mob/living/carbon/xenomorph/X)
-	return
+	return TRUE
 
 /obj/structure/acid_spray_act(mob/living/carbon/xenomorph/X)
-	if(is_type_in_typecache(src, GLOB.acid_spray_hit))
-		take_damage(X.xeno_caste.acid_spray_structure_damage, "acid", "acid")
-	return density // normal density flag
+	if(!is_type_in_typecache(src, GLOB.acid_spray_hit))
+		return TRUE // normal density flag
+	take_damage(X.xeno_caste.acid_spray_structure_damage, "acid", "acid")
+	return TRUE // normal density flag
 
 /obj/structure/razorwire/acid_spray_act(mob/living/carbon/xenomorph/X)
 	. = ..()
 	return FALSE // not normal density flag
 
+/obj/vehicle/multitile/root/cm_armored/acid_spray_act(mob/living/carbon/xenomorph/X)
+	take_damage_type(X.xeno_caste.acid_spray_structure_damage, "acid", src)
+	healthcheck()
+	return TRUE
+
 /mob/living/carbon/acid_spray_act(mob/living/carbon/xenomorph/X)
 	ExtinguishMob()
 	if(isnestedhost(src))
-		return FALSE
+		return
 
 	if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_ACID))
-		return FALSE
+		return
 	TIMER_COOLDOWN_START(src, COOLDOWN_ACID, 2 SECONDS)
 
 	if(isxenopraetorian(X))
@@ -590,7 +596,6 @@
 	var/damage = X.xeno_caste.acid_spray_damage_on_hit
 	INVOKE_ASYNC(src, .proc/apply_acid_spray_damage, damage, armor_block)
 	to_chat(src, "<span class='xenodanger'>\The [X] showers you in corrosive acid!</span>")
-	return FALSE
 
 /mob/living/carbon/proc/apply_acid_spray_damage(damage, armor_block)
 	apply_damage(damage, BURN, null, armor_block, updating_health = TRUE)

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -588,7 +588,7 @@
 
 	var/armor_block = run_armor_check(BODY_ZONE_CHEST, "acid")
 	var/damage = X.xeno_caste.acid_spray_damage_on_hit
-	apply_acid_spray_damage(damage, armor_block)
+	INVOKE_ASYNC(src, .proc/apply_acid_spray_damage, damage, armor_block)
 	to_chat(src, "<span class='xenodanger'>\The [X] showers you in corrosive acid!</span>")
 	return FALSE
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Make the cone spray more consistent in the way it is blocked by obstacles. You can now spray in diagonals. Remove all ugly sleep with timers. You will now fall over when crossing a fresh acid spray poodle, to prevent the bug when you could avoid the paralyse by walking toward the praetorian, spitter or boiler

fixes https://github.com/tgstation/TerraGov-Marine-Corps/issues/5859

Collision : 
![image](https://user-images.githubusercontent.com/25491240/112508065-810ec280-8d8f-11eb-8b70-07db019cb530.png)

Diag cone:
![image](https://user-images.githubusercontent.com/25491240/112508795-29bd2200-8d90-11eb-8db3-5fa5b69c044d.png)



<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Code is a bit neater, diagonal cone is cool, remove possible exploit

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: Acid spray cone code no longer uses sleep.
refactor: Cone spray use recursive code, which mean blocking the middle row will not block the other part of the cone. In short, collisions are more consistent
add: Praetorian can spray diagonally
fix: You can no longer avoid acid spray by running towards the caster. Works for boiler, prae and spitter
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
