### PR TITLE
Adds ammo vendor to FC Prep

### DIFF
--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -6323,6 +6323,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/landmark/start/job/fieldcommander,
 /turf/open/floor/carpet{
 	dir = 5;
 	icon_state = "carpetside"
@@ -6408,9 +6409,7 @@
 	},
 /area/mainship/living/numbertwobunks)
 "vi" = (
-/obj/structure/bed,
-/obj/item/bedsheet/hop,
-/obj/effect/landmark/start/job/fieldcommander,
+/obj/machinery/vending/marine,
 /turf/open/floor/carpet{
 	dir = 6;
 	icon_state = "carpetside"


### PR DESCRIPTION


<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a marine vendor with ammo + weapons to FC's office. Also removes his bed and bedsheet; stop sleeping, command! Wake up! Also moves his spawn position 1 up north so he doesn't spawn right in the vendors.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes an oversight and a QoL improvement. Even the PO, who doesn't need prep vendors, has it while the FC who needs it does not.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds marine prep vendor to FC office; contains weapons and ammo, etc.
del: Removes the FC's bed and bedsheet; no sleeping on the job.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
