### PR TITLE
LV Rework V3

### DIFF
--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -2088,10 +2088,9 @@
 	},
 /area/lv624/ground/river2)
 "akD" = (
-/obj/structure/window_frame/colony/reinforced,
-/obj/structure/window/framed/colony/reinforced,
-/turf/open/floor/plating,
-/area/lv624/lazarus/engineering)
+/obj/machinery/miner/damaged,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand8)
 "akE" = (
 /turf/open/ground/coast{
 	dir = 1
@@ -10668,12 +10667,9 @@
 /turf/open/floor/plating/ground/dirt,
 /area/shuttle/drop2/lz2)
 "bcC" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
+/obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/dirt,
-/area/shuttle/drop2/lz2)
+/area/lv624/ground/river1)
 "bcD" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/dirtgrassborder,
@@ -13391,9 +13387,13 @@
 /turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/ground/jungle2)
 "brF" = (
-/obj/structure/jungle/plantbot1,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8;
+	welded = 1
+	},
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/jungle2)
+/area/shuttle/drop2/lz2)
 "brH" = (
 /turf/open/ground/coast/corner{
 	dir = 8
@@ -14666,7 +14666,6 @@
 /area/lv624/lazarus/main_hall)
 "hHD" = (
 /obj/machinery/miner/damaged,
-/obj/effect/alien/weeds/node,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle3)
 "hIj" = (
@@ -15818,10 +15817,6 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/central3)
-"oqP" = (
-/obj/machinery/miner/damaged,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/sand8)
 "oqW" = (
 /obj/structure/jungle/vines/heavy,
 /turf/open/floor/plating/ground/dirtgrassborder/corner,
@@ -20267,7 +20262,7 @@ aIj
 aJb
 fkc
 avL
-avL
+bcC
 avL
 avL
 auH
@@ -21744,7 +21739,7 @@ bcg
 bcg
 bcg
 bfM
-bnE
+hHD
 bnE
 bnE
 bph
@@ -26213,7 +26208,7 @@ rTb
 rTb
 bfM
 bnE
-hHD
+pId
 bfa
 bch
 bfM
@@ -28993,7 +28988,7 @@ ajG
 ajG
 ajG
 ajG
-ajG
+akD
 ajG
 ajG
 ajG
@@ -29170,7 +29165,7 @@ acO
 acO
 ajG
 ajG
-oqP
+ajG
 ajG
 ajG
 ajH
@@ -30321,7 +30316,7 @@ aZl
 bIG
 jvx
 jvx
-quk
+brF
 jvx
 jvx
 cQH
@@ -30500,7 +30495,7 @@ aZW
 lhf
 nsb
 jvx
-quk
+bfY
 jvx
 jvx
 nxx
@@ -30679,9 +30674,9 @@ aES
 bbL
 nsb
 jvx
-bcC
-vFc
-vFc
+bfY
+bfY
+bfY
 vfU
 xtK
 xtK
@@ -32209,7 +32204,7 @@ alg
 alg
 ako
 aFq
-akD
+ako
 alg
 alg
 alg
@@ -32571,7 +32566,7 @@ gXL
 lGO
 lGO
 lGO
-akD
+ako
 ajG
 ajG
 ajG
@@ -33467,7 +33462,7 @@ lGO
 akc
 lGO
 boP
-akD
+ako
 akH
 akH
 aln
@@ -34182,7 +34177,7 @@ alg
 blk
 bnY
 aiD
-akD
+ako
 ajG
 ajG
 ajG
@@ -34350,7 +34345,7 @@ adh
 acO
 acO
 alg
-akD
+ako
 ako
 alg
 alg
@@ -34640,7 +34635,7 @@ bpx
 bqO
 brE
 qkT
-brF
+qkT
 osh
 boU
 aab

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -8369,12 +8369,11 @@
 "aQS" = (
 /obj/structure/jungle/planttop1,
 /obj/structure/jungle/vines/heavy,
-/turf/open/ground/grass,
+/turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/ground/jungle9)
 "aQT" = (
-/obj/effect/landmark/monkey_spawn,
 /obj/structure/jungle/vines/heavy,
-/turf/open/ground/grass,
+/turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/ground/jungle9)
 "aQU" = (
 /obj/structure/window/framed/colony/reinforced,
@@ -8525,7 +8524,7 @@
 "aRA" = (
 /obj/structure/jungle/plantbot1,
 /obj/structure/jungle/vines,
-/turf/open/ground/grass,
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle9)
 "aRB" = (
 /obj/structure/flora/ausbushes/fullgrass,
@@ -8618,7 +8617,9 @@
 /area/lv624/ground/jungle4)
 "aRY" = (
 /obj/structure/flora/ausbushes/fernybush,
-/turf/open/ground/grass,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
+	},
 /area/lv624/ground/jungle9)
 "aSa" = (
 /obj/effect/decal/remains/human,
@@ -10194,11 +10195,10 @@
 	},
 /area/lv624/ground/compound/sw)
 "aZW" = (
-/obj/structure/fence,
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 8
 	},
-/area/lv624/ground/compound/sw)
+/area/shuttle/drop2/lz2)
 "aZX" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /obj/structure/jungle/vines,
@@ -10411,7 +10411,7 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/jungle/vines,
 /turf/open/ground/grass,
-/area/lv624/ground/jungle9)
+/area/shuttle/drop2/lz2)
 "baM" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/ground/grass/grass2,
@@ -13359,8 +13359,8 @@
 /area/shuttle/drop2/lz2)
 "bry" = (
 /obj/structure/flora/ausbushes/fernybush,
-/turf/closed/gm/dense,
-/area/lv624/ground/jungle2)
+/turf/open/ground/grass,
+/area/shuttle/drop2/lz2)
 "brA" = (
 /obj/structure/jungle/vines/heavy,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -13441,7 +13441,9 @@
 /area/lv624/lazarus/secure_storage)
 "brN" = (
 /obj/structure/flora/tree/jungle/small,
-/turf/open/ground/grass,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 8
+	},
 /area/lv624/ground/jungle2)
 "brQ" = (
 /turf/open/ground/grass,
@@ -13561,6 +13563,10 @@
 /obj/structure/fence,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/sw)
+"bAk" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/shuttle/drop2/lz2)
 "bFI" = (
 /turf/open/floor/marking/warning,
 /area/lv624/ground/compound/sw)
@@ -13581,25 +13587,15 @@
 	},
 /area/lv624/ground/jungle7)
 "bIG" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/dirt,
-/area/shuttle/drop2/lz2)
+/obj/machinery/miner/damaged,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle9)
 "bKi" = (
 /obj/structure/fence,
 /obj/structure/jungle/vines/heavy,
 /obj/effect/alien/weeds/node,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle7)
-"bLx" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 1
-	},
-/area/shuttle/drop2/lz2)
 "bLL" = (
 /turf/closed/wall/resin/thick,
 /area/lv624/ground/caves/west1)
@@ -13627,8 +13623,11 @@
 	},
 /area/lv624/lazarus/engineering)
 "bZw" = (
-/obj/machinery/miner/damaged,
-/turf/open/ground/grass,
+/obj/effect/landmark/monkey_spawn,
+/obj/structure/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
+	},
 /area/lv624/ground/jungle9)
 "cah" = (
 /obj/effect/alien/weeds/node,
@@ -13675,6 +13674,13 @@
 	dir = 8
 	},
 /area/lv624/ground/jungle7)
+"cig" = (
+/obj/structure/fence,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/dirtgrassborder,
+/area/shuttle/drop2/lz2)
 "ciX" = (
 /obj/structure/jungle/vines,
 /obj/structure/jungle/vines,
@@ -13730,6 +13736,10 @@
 /obj/effect/alien/weeds/node,
 /turf/open/floor,
 /area/lv624/ground/sand9)
+"cta" = (
+/obj/structure/lazarus_sign,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle2)
 "cuw" = (
 /turf/closed/wall/indestructible/mineral,
 /area/lv624/ground/caves/west1)
@@ -13872,15 +13882,17 @@
 /turf/closed/wall/mineral/sandstone,
 /area/lv624/ground/caves/east1)
 "dcR" = (
-/obj/machinery/light{
+/obj/structure/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
 	dir = 8
 	},
-/turf/open/floor/plating/ground/dirt,
-/area/shuttle/drop2/lz2)
+/area/lv624/ground/jungle9)
 "dde" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic,
-/turf/open/floor/plating/ground/dirt,
-/area/shuttle/drop2/lz2)
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/floodlight/colony,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle9)
 "dnE" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -13916,10 +13928,10 @@
 /turf/open/floor/plating/platebotc,
 /area/lv624/lazarus/quartstorage/outdoors)
 "drA" = (
-/obj/structure/fence,
-/obj/structure/fence,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/jungle2)
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle9)
 "dtR" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor,
@@ -13997,10 +14009,12 @@
 /turf/open/ground/grass,
 /area/lv624/ground/jungle6)
 "dQo" = (
+/obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/jungle/vines,
-/obj/structure/jungle/vines,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/jungle2)
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 4
+	},
+/area/lv624/ground/jungle9)
 "dRM" = (
 /turf/open/space/basic,
 /area/lv624/ground/jungle9)
@@ -14400,6 +14414,9 @@
 	dir = 4
 	},
 /obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/dirt,
 /area/shuttle/drop2/lz2)
 "gef" = (
@@ -14429,6 +14446,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle6)
+"gno" = (
+/obj/effect/decal/warning_stripes/thick,
+/turf/open/floor,
+/area/shuttle/drop2/lz2)
 "gnD" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
@@ -14613,8 +14634,6 @@
 "hmT" = (
 /obj/structure/jungle/vines,
 /obj/effect/alien/weeds/node,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/dirt,
 /area/shuttle/drop2/lz2)
 "hnZ" = (
@@ -14626,6 +14645,12 @@
 /obj/effect/alien/egg,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/east1)
+"hpg" = (
+/obj/structure/window_frame/colony,
+/obj/structure/jungle/vines,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/ground/grass/grass2,
+/area/shuttle/drop2/lz2)
 "hpN" = (
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/dirt,
@@ -14684,6 +14709,11 @@
 "hLW" = (
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/ruin)
+"hOn" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/ground/grass,
+/area/shuttle/drop2/lz2)
 "hPX" = (
 /obj/structure/jungle/vines/heavy,
 /turf/open/ground/grass,
@@ -14783,12 +14813,9 @@
 /turf/open/floor/plating,
 /area/lv624/ground/sand8)
 "iAU" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/ground/grass,
-/area/shuttle/drop2/lz2)
+/obj/structure/jungle/vines,
+/turf/closed/gm/dense,
+/area/lv624/ground/jungle9)
 "iBb" = (
 /turf/closed/wall/r_wall,
 /area/lv624/ground/compound/sw)
@@ -14956,13 +14983,6 @@
 	},
 /turf/open/floor,
 /area/lv624/ground/compound/n)
-"jFX" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/ground/grass,
-/area/shuttle/drop2/lz2)
 "jGu" = (
 /obj/structure/table,
 /obj/structure/cable,
@@ -14979,8 +14999,6 @@
 "jIm" = (
 /obj/structure/window_frame/colony,
 /obj/structure/jungle/vines,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 1
 	},
@@ -15013,6 +15031,13 @@
 	dir = 4
 	},
 /area/lv624/ground/jungle6)
+"jSx" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/shuttle/drop2/lz2)
 "jTU" = (
 /turf/open/floor/marking/warning/corner{
 	dir = 8
@@ -15031,15 +15056,22 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/quartstorage/outdoors)
 "jYV" = (
-/obj/machinery/floodlight/colony{
-	dir = 4
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
 	},
-/turf/open/ground/grass,
-/area/lv624/ground/jungle9)
+/turf/open/floor/plating/ground/dirt,
+/area/shuttle/drop2/lz2)
 "jZC" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor,
 /area/lv624/ground/compound/sw)
+"kew" = (
+/obj/structure/jungle/vines,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/shuttle/drop2/lz2)
 "kfz" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/tile/whiteyellow/full,
@@ -15070,8 +15102,10 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/c)
 "kmn" = (
-/obj/machinery/light,
-/turf/closed/wall/r_wall,
+/obj/effect/decal/warning_stripes/thick{
+	dir = 9
+	},
+/turf/open/floor,
 /area/shuttle/drop2/lz2)
 "knr" = (
 /obj/structure/largecrate/chick,
@@ -15083,16 +15117,14 @@
 	},
 /turf/closed/gm/dense,
 /area/lv624/ground/jungle1)
-"ksq" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/closed/wall,
-/area/shuttle/drop2/lz2)
 "ksG" = (
-/turf/open/floor/plating/ground/dirtgrassborder/corner2{
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 8
 	},
-/area/lv624/ground/jungle9)
+/area/shuttle/drop2/lz2)
 "ktj" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral,
@@ -15184,10 +15216,10 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/c)
 "kKD" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
 	},
-/turf/open/ground/grass,
+/turf/closed/gm/dense,
 /area/shuttle/drop2/lz2)
 "kMj" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -15287,15 +15319,6 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/resin/thick,
 /area/lv624/ground/caves/east1)
-"lhf" = (
-/obj/structure/fence,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 8
-	},
-/area/shuttle/drop2/lz2)
 "lhR" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/tile/blue/whitebluecorner,
@@ -15350,6 +15373,7 @@
 /area/lv624/lazarus/toilet)
 "luc" = (
 /obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/fence,
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 1
 	},
@@ -15392,6 +15416,12 @@
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle9)
+"lCD" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 4
+	},
+/area/lv624/ground/jungle2)
 "lEt" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor,
@@ -15423,12 +15453,13 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand2)
 "lLQ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/fence,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
 	},
-/turf/open/floor/plating/ground/dirt,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 4
+	},
 /area/shuttle/drop2/lz2)
 "lQf" = (
 /obj/structure/jungle/vines/heavy,
@@ -15484,7 +15515,11 @@
 	},
 /area/lv624/ground/jungle3)
 "mek" = (
-/obj/structure/prop/mainship/hangar_stencil/two,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
 /turf/open/floor/plating/ground/dirt,
 /area/shuttle/drop2/lz2)
 "mfF" = (
@@ -15540,7 +15575,6 @@
 /turf/open/floor,
 /area/lv624/ground/sand2)
 "msP" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/wall,
 /area/shuttle/drop2/lz2)
 "mvX" = (
@@ -15574,13 +15608,14 @@
 	},
 /area/lv624/ground/jungle3)
 "mEj" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
 /turf/open/floor/plating/ground/dirtgrassborder/corner2{
 	dir = 4
 	},
 /area/shuttle/drop2/lz2)
+"mFX" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle2)
 "mGh" = (
 /obj/machinery/door/airlock/mainship/security/locked/free_access{
 	name = "\improper Nexus Dome Marshal Office"
@@ -15660,6 +15695,14 @@
 /obj/structure/jungle/vines/heavy,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle1)
+"nsa" = (
+/obj/structure/prop/mainship/hangar_stencil/two,
+/obj/effect/decal/warning_stripes/thick,
+/obj/effect/decal/warning_stripes/thick{
+	dir = 8
+	},
+/turf/open/floor,
+/area/shuttle/drop2/lz2)
 "nsb" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/drop2/lz2)
@@ -15888,9 +15931,12 @@
 /turf/closed/wall/r_wall,
 /area/lv624/ground/jungle4)
 "oNb" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/obj/structure/fence,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
 /turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 4
+	dir = 8
 	},
 /area/shuttle/drop2/lz2)
 "oNd" = (
@@ -15898,17 +15944,17 @@
 /turf/open/floor/plating,
 /area/lv624/ground/river3)
 "oOC" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/closed/gm/dense,
-/area/lv624/ground/jungle2)
+/obj/machinery/door/airlock/multi_tile/mainship/generic,
+/turf/open/floor/plating/ground/dirt,
+/area/shuttle/drop2/lz2)
 "oQb" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/quartstorage)
 "oTD" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic{
-	dir = 1
-	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/airlock/multi_tile/mainship/generic,
 /turf/open/floor/plating/ground/dirt,
 /area/shuttle/drop2/lz2)
 "oVq" = (
@@ -15931,10 +15977,9 @@
 /turf/open/ground/coast,
 /area/lv624/ground/river3)
 "phK" = (
-/turf/open/floor/plating/ground/dirtgrassborder/corner2{
-	dir = 1
-	},
-/area/lv624/ground/jungle9)
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/closed/gm/dense,
+/area/shuttle/drop2/lz2)
 "pjD" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -15952,9 +15997,11 @@
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/canteen)
 "pqu" = (
-/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
 /turf/closed/wall,
-/area/lv624/ground/jungle9)
+/area/shuttle/drop2/lz2)
 "prx" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/sign/botany,
@@ -15979,8 +16026,10 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle5)
 "ptS" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/closed/gm/dense,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirt,
 /area/shuttle/drop2/lz2)
 "puF" = (
 /turf/closed/wall/r_wall,
@@ -16066,8 +16115,6 @@
 "pOv" = (
 /obj/structure/window_frame/colony,
 /obj/structure/jungle/vines,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/dirtgrassborder,
 /area/shuttle/drop2/lz2)
 "pPr" = (
@@ -16096,8 +16143,10 @@
 /turf/open/floor/plating,
 /area/lv624/ground/sand8)
 "pZg" = (
-/obj/structure/fence,
-/turf/open/floor/plating/ground/dirt,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/ground/grass,
 /area/shuttle/drop2/lz2)
 "pZl" = (
 /turf/open/ground/coast,
@@ -16110,6 +16159,12 @@
 /obj/effect/alien/weeds/node,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/sw)
+"qbi" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/shuttle/drop2/lz2)
 "qdb" = (
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/dirtgrassborder/corner2{
@@ -16123,10 +16178,9 @@
 	},
 /area/lv624/ground/jungle9)
 "qhe" = (
-/obj/machinery/light{
-	dir = 8
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 4
 	},
-/turf/open/ground/grass,
 /area/shuttle/drop2/lz2)
 "qhx" = (
 /obj/machinery/miner/damaged,
@@ -16337,10 +16391,6 @@
 /turf/open/floor,
 /area/lv624/ground/river3)
 "rzH" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/obj/structure/fence,
 /turf/open/floor/plating/ground/dirtgrassborder/corner2,
 /area/shuttle/drop2/lz2)
 "rAj" = (
@@ -16386,10 +16436,11 @@
 /turf/open/ground/coast,
 /area/lv624/ground/jungle9)
 "rKY" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/airlock/multi_tile/mainship/generic,
-/turf/open/floor/plating/ground/dirt,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/ground/grass,
 /area/shuttle/drop2/lz2)
 "rLa" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -16427,8 +16478,10 @@
 /turf/open/floor,
 /area/lv624/ground/compound/sw)
 "rYi" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/ground/dirt,
+/obj/effect/decal/warning_stripes/thick{
+	dir = 8
+	},
+/turf/open/floor,
 /area/shuttle/drop2/lz2)
 "rYZ" = (
 /turf/open/floor/marking/warning{
@@ -16477,6 +16530,13 @@
 	dir = 4
 	},
 /area/lv624/ground/jungle2)
+"ska" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/shuttle/drop2/lz2)
 "sqN" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/plating/ground/dirt,
@@ -16533,7 +16593,9 @@
 /area/lv624/lazarus/kitchen)
 "sGX" = (
 /obj/structure/fence,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plating/ground/dirtgrassborder,
 /area/shuttle/drop2/lz2)
 "sHi" = (
@@ -16555,10 +16617,11 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle9)
 "sQw" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/shuttle/shuttle_control/dropship2,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/lazarus/console)
+/area/shuttle/drop2/lz2)
 "sRg" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/tile/whiteyellow/full,
@@ -16592,13 +16655,10 @@
 	},
 /area/lv624/ground/jungle6)
 "tfA" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 1
-	},
-/area/shuttle/drop2/lz2)
+/obj/structure/table/reinforced,
+/obj/machinery/computer/shuttle/shuttle_control/dropship2,
+/turf/open/ground/grass,
+/area/lv624/lazarus/console)
 "thI" = (
 /obj/effect/alien/egg,
 /turf/open/floor/plating/ground/dirt,
@@ -16643,6 +16703,10 @@
 	dir = 1
 	},
 /area/lv624/ground/jungle7)
+"ttd" = (
+/obj/machinery/light,
+/turf/open/ground/grass,
+/area/shuttle/drop2/lz2)
 "txw" = (
 /obj/structure/catwalk,
 /turf/open/ground/coast,
@@ -16653,7 +16717,6 @@
 /turf/open/floor/freezer,
 /area/lv624/lazarus/toilet)
 "tCW" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /obj/structure/fence,
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 1
@@ -16662,6 +16725,14 @@
 "tDV" = (
 /obj/machinery/camera/autoname/lz_camera,
 /turf/open/floor/plating,
+/area/shuttle/drop2/lz2)
+"tEF" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
+	},
 /area/shuttle/drop2/lz2)
 "tGv" = (
 /turf/closed/wall/indestructible/mineral,
@@ -16733,6 +16804,16 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/drop2/lz2)
+"ueh" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/thick,
+/obj/effect/decal/warning_stripes/thick{
+	dir = 4
+	},
+/turf/open/floor,
+/area/shuttle/drop2/lz2)
 "ugM" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/dirtgrassborder/corner,
@@ -16790,9 +16871,8 @@
 /turf/open/floor/engine/cult,
 /area/lv624/ground/caves/west1)
 "urV" = (
-/obj/structure/jungle/vines,
 /obj/machinery/light{
-	dir = 8
+	dir = 4
 	},
 /turf/open/ground/grass,
 /area/shuttle/drop2/lz2)
@@ -16846,7 +16926,7 @@
 "uFY" = (
 /obj/structure/fence,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/open/floor/plating/ground/dirtgrassborder/corner2,
+/turf/open/floor/plating/ground/dirt,
 /area/shuttle/drop2/lz2)
 "uHv" = (
 /turf/open/ground/grass,
@@ -16915,6 +16995,10 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/ground/grass,
 /area/shuttle/drop2/lz2)
+"vfD" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/plating/ground/dirtgrassborder,
+/area/shuttle/drop2/lz2)
 "vfU" = (
 /obj/machinery/landinglight/ds1,
 /turf/open/floor/plating,
@@ -16932,16 +17016,17 @@
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/ground/jungle3)
-"vmR" = (
-/obj/machinery/button/door/open_only/landing_zone/lz2,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
+"vmE" = (
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
+/turf/open/ground/grass,
+/area/shuttle/drop2/lz2)
+"vmR" = (
+/obj/effect/decal/warning_stripes/thick{
 	dir = 1
 	},
-/turf/open/floor/plating/ground/dirt,
+/turf/open/floor,
 /area/shuttle/drop2/lz2)
 "vof" = (
 /obj/structure/jungle/vines/heavy{
@@ -16955,9 +17040,14 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle9)
 "vpr" = (
-/obj/structure/lazarus_sign,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/compound/sw)
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/thick{
+	dir = 5
+	},
+/turf/open/floor,
+/area/shuttle/drop2/lz2)
 "vpP" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/plating/ground/dirt,
@@ -16981,10 +17071,7 @@
 /turf/open/ground/grass,
 /area/shuttle/drop2/lz2)
 "vso" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 1
-	},
+/turf/open/floor,
 /area/shuttle/drop2/lz2)
 "vuY" = (
 /obj/docking_port/stationary/crashmode,
@@ -17066,12 +17153,6 @@
 "vNz" = (
 /turf/open/floor,
 /area/storage/testroom)
-"vPL" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/dirtgrassborder,
-/area/shuttle/drop2/lz2)
 "vRN" = (
 /turf/closed/wall/indestructible/mineral,
 /area/lv624/ground/caves/central1)
@@ -17199,9 +17280,11 @@
 /turf/open/floor,
 /area/lv624/ground/jungle4)
 "wKk" = (
-/obj/machinery/miner/damaged,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/jungle9)
+/obj/effect/decal/warning_stripes/thick{
+	dir = 4
+	},
+/turf/open/floor,
+/area/shuttle/drop2/lz2)
 "wKy" = (
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/dirt,
@@ -17243,6 +17326,12 @@
 /obj/structure/jungle/plantbot1,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle9)
+"wUQ" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
+	},
+/area/shuttle/drop2/lz2)
 "wVw" = (
 /obj/structure/jungle/vines,
 /turf/open/ground/grass,
@@ -17270,6 +17359,17 @@
 /obj/effect/alien/weeds/node,
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/lazarus/quart)
+"xcN" = (
+/obj/machinery/button/door/open_only/landing_zone/lz2,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/shuttle/drop2/lz2)
 "xfC" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/tile/green/whitegreencorner{
@@ -17345,13 +17445,6 @@
 /obj/structure/largecrate/guns,
 /turf/open/floor,
 /area/lv624/ground/compound/sw)
-"xDf" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/open/ground/grass,
-/area/shuttle/drop2/lz2)
 "xDk" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/structure/mineral_door/resin/thick,
@@ -17408,7 +17501,6 @@
 /turf/open/ground/grass,
 /area/lv624/ground/jungle9)
 "xRD" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/dirtgrassborder,
 /area/shuttle/drop2/lz2)
 "xRX" = (
@@ -17420,6 +17512,15 @@
 /obj/effect/alien/egg,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/west2)
+"xUp" = (
+/obj/structure/fence,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
+	},
+/area/shuttle/drop2/lz2)
 "xUE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
@@ -17429,6 +17530,11 @@
 "xVM" = (
 /turf/open/space/basic,
 /area/lv624/lazarus/atmos)
+"xWk" = (
+/obj/structure/jungle/vines,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle2)
 "xYN" = (
 /obj/machinery/floodlight/colony{
 	dir = 1
@@ -25686,7 +25792,7 @@ bpx
 bpx
 bqO
 boU
-bpx
+bqe
 boU
 aab
 "}
@@ -25865,7 +25971,7 @@ bpx
 bpx
 boU
 boU
-bpx
+qkT
 boU
 aab
 "}
@@ -26044,7 +26150,7 @@ bpx
 bpx
 bqO
 boU
-bpx
+qkT
 boU
 aab
 "}
@@ -26219,11 +26325,11 @@ aZl
 bcA
 box
 aZk
-bpy
-bpx
+lCD
+bqe
 boU
 boU
-bpx
+qkT
 boU
 aab
 "}
@@ -26397,12 +26503,12 @@ bbo
 aZl
 pZX
 aZl
-beo
-bpx
-bpy
-bqO
-bqO
-bpx
+bzO
+qkT
+mFX
+bqU
+bqU
+bsn
 boU
 aab
 "}
@@ -26576,12 +26682,12 @@ aZk
 aZl
 bcA
 aZl
-beo
-bpy
-bpx
-bqO
-bqO
-bpx
+bzO
+mFX
+bsn
+bqU
+bqU
+qkT
 boU
 aab
 "}
@@ -26756,11 +26862,11 @@ aZl
 bcA
 aZl
 aZk
-bpx
+bqg
 brN
 fRV
 boU
-bqO
+bqU
 boU
 aab
 "}
@@ -26939,7 +27045,7 @@ bpx
 bpx
 fRV
 boU
-bqO
+bqU
 boU
 aab
 "}
@@ -27102,23 +27208,23 @@ rTb
 rTb
 rTb
 rTb
-aZl
-aZl
-aZl
-aZl
-aZl
-aZl
-aZl
-aZl
-aZl
-aZl
-aZl
-beo
-bpy
-bpx
+jYV
+fvx
+fvx
+fvx
+fvx
+fvx
+fvx
+fvx
+fvx
+fvx
+fvx
+tji
+hOn
+wPr
+kKD
 boU
-boU
-bqO
+xWk
 boU
 aab
 "}
@@ -27281,23 +27387,23 @@ rTb
 rTb
 rTb
 rTb
-aZW
-aZW
-aZk
-aZl
-aZl
-aZl
-aZl
-aZk
-aZW
-aZW
-aZW
-aZk
-bpx
-bpx
-bpy
-bpx
-bpx
+oNb
+nsb
+nsb
+nsb
+jvx
+qbi
+nsb
+nsb
+nsb
+nsb
+nsb
+nsb
+nsb
+nsb
+ska
+qkT
+qkT
 boU
 aab
 "}
@@ -27460,22 +27566,22 @@ rTb
 rTb
 rTb
 aES
-aES
-aES
-bbo
-aZl
-aZl
-blb
-aZl
-beo
-uHv
-bpx
-bpx
-bpx
-bpy
-bpx
-bqO
-bqO
+bbL
+nsb
+cig
+jvx
+jvx
+jvx
+jvx
+xUp
+brQ
+vmE
+brQ
+vmE
+rPI
+nsb
+kew
+xWk
 boU
 boU
 aab
@@ -27639,24 +27745,24 @@ rTb
 rTb
 rTb
 bbL
-wPr
-wPr
+bbL
+nsb
 sGX
-fvx
-fvx
-fvx
-fvx
+jvx
+jvx
+jvx
+jvx
 tCW
-wPr
-wPr
-wPr
-wPr
-wPr
-wPr
-wPr
-wPr
-ptS
-ptS
+brQ
+brQ
+brQ
+brQ
+ttd
+nsb
+jYV
+jvx
+gcB
+gcB
 aab
 "}
 (58,1,1) = {"
@@ -27820,22 +27926,22 @@ rTb
 bbL
 gcB
 nsb
-nsb
+hkV
 jvx
-oTD
 jvx
-tfA
+jvx
+jvx
+tCW
+brQ
+brQ
+brQ
+brQ
+brQ
 nsb
-nsb
-nsb
-nsb
-nsb
-nsb
-nsb
-gcB
-gcB
-gcB
-gcB
+phK
+phK
+phK
+phK
 aab
 "}
 (59,1,1) = {"
@@ -27982,7 +28088,7 @@ kvA
 aMy
 aFB
 aFB
-aET
+iAU
 rTb
 rTb
 rTb
@@ -27999,17 +28105,17 @@ rTb
 egH
 gcB
 nsb
-nsb
+sGX
 jvx
-oTD
 jvx
-oTD
-nsb
-nsb
-nsb
-nsb
-nsb
-nsb
+jvx
+jvx
+tCW
+brQ
+brQ
+brQ
+brQ
+brQ
 gcB
 gcB
 gcB
@@ -28161,11 +28267,11 @@ aEx
 aEx
 aFB
 aFB
-aET
-aET
-aES
-aES
-aES
+aKu
+aKu
+aKs
+aKs
+aKs
 rTb
 rTb
 rTb
@@ -28177,17 +28283,17 @@ vfc
 vfc
 vfc
 gcB
-urV
+vsm
 hkV
 jvx
 jvx
 jvx
-pZg
-bLx
+jvx
+tCW
 brQ
-iAU
+rPI
 brQ
-qhe
+brQ
 gcB
 gcB
 gcB
@@ -28338,13 +28444,13 @@ aJD
 kFc
 aEx
 aEx
-ksG
-aKs
-aKs
-aKu
-aKu
-aKs
-oNb
+aEx
+aEx
+fvx
+fvx
+fvx
+fvx
+fvx
 uFY
 fvx
 doV
@@ -28361,7 +28467,7 @@ hkV
 jvx
 jvx
 jvx
-pZg
+jvx
 luc
 brQ
 brQ
@@ -28519,16 +28625,16 @@ sWJ
 aEx
 sWJ
 aEx
-aEx
-aMy
-aMy
-kvA
-bIG
+jYV
 nsb
 nsb
-quk
-oTD
 nsb
+nsb
+nsb
+nsb
+jSx
+nsb
+gcB
 gcB
 gcB
 gcB
@@ -28540,8 +28646,8 @@ hkV
 jvx
 jvx
 jvx
-pZg
-erE
+jvx
+tCW
 brQ
 brQ
 rPI
@@ -28698,16 +28804,16 @@ aMy
 aEx
 aEx
 aEx
-aEx
-kvA
-aMy
-aMy
-bIG
+jYV
 nsb
-dcR
+ptS
+sQw
+jvx
+sQw
+jvx
 gdH
 jvx
-dcR
+jvx
 gIc
 wot
 wot
@@ -28875,14 +28981,14 @@ aJB
 aMy
 aMy
 aMy
-phK
-aKt
-aKt
-aFG
-aFG
-aKt
-mEj
+aFB
+aFB
+ksG
 nsb
+aZW
+aZW
+mEj
+jvx
 jvx
 quk
 jvx
@@ -29056,15 +29162,15 @@ aMy
 aMy
 aFB
 aFB
-aFB
-aFB
-aFB
-aES
-vPL
-kmn
+kKD
+nsb
+pZg
+brQ
+xRD
+jvx
 jvx
 quk
-mek
+jvx
 jvx
 nxx
 xtK
@@ -29235,12 +29341,12 @@ sWJ
 aEx
 aFB
 aFB
-aFB
-aET
-aES
-aES
-vPL
+kKD
 nsb
+brQ
+tfA
+xRD
+jvx
 jvx
 quk
 jvx
@@ -29413,13 +29519,13 @@ aEx
 vpq
 aEx
 aKZ
-aGk
-aFB
 aES
-aES
-jYV
-vPL
+kKD
 nsb
+pZg
+brQ
+xRD
+jvx
 jvx
 quk
 jvx
@@ -29593,12 +29699,12 @@ axC
 axC
 aEy
 qXT
-qXT
-qXT
-qXT
-qXT
+lLQ
+nsb
+qhe
+qhe
 rzH
-kmn
+jvx
 jvx
 quk
 jvx
@@ -29772,15 +29878,15 @@ kKo
 aMm
 aMm
 aMm
-aMm
-aMm
-aZl
-aZl
-bIG
-dde
+jYV
+oOC
+jvx
+jvx
+jvx
+jvx
 jvx
 quk
-sQw
+jvx
 jvx
 nxx
 xtK
@@ -29951,11 +30057,11 @@ aMm
 aMm
 aPX
 aMm
-aMm
-kKo
-aZl
-aZl
-bIG
+jYV
+jvx
+jvx
+jvx
+jvx
 jvx
 jvx
 quk
@@ -30130,12 +30236,12 @@ aOi
 aOi
 aOi
 guw
-aOi
-aOi
-aZm
-qnO
-lLQ
-rKY
+mek
+oTD
+vFc
+vFc
+vFc
+vFc
 vFc
 bcB
 jvx
@@ -30309,11 +30415,11 @@ aMm
 aMm
 aMm
 aMm
-aMm
-aMm
-aZl
-aZl
-bIG
+jYV
+jvx
+jvx
+jvx
+jvx
 jvx
 jvx
 brF
@@ -30488,12 +30594,12 @@ jLQ
 aSd
 aSd
 aLt
-aMn
-aLt
-aZW
-aZW
-lhf
+oNb
 nsb
+aZW
+aZW
+mEj
+jvx
 jvx
 bfY
 jvx
@@ -30667,12 +30773,12 @@ aJD
 vpq
 aEx
 aLa
-aES
-aEy
-aFD
-aES
 bbL
 nsb
+rKY
+brQ
+xRD
+jvx
 jvx
 bfY
 bfY
@@ -30846,14 +30952,14 @@ nMR
 sWJ
 vsg
 aXf
-aES
-aET
-aES
-aES
-egH
+bbL
+nsb
+brQ
+brQ
+xRD
 kmn
 rYi
-jvx
+nsa
 jvx
 bfY
 gIc
@@ -31024,15 +31130,15 @@ aFB
 aJD
 aEx
 aMy
-aFB
-aFB
-aFB
-aET
-aES
-jFX
+aKZ
+kKD
 nsb
-nsb
-jvx
+pZg
+brQ
+xRD
+vmR
+vso
+gno
 jvx
 bfY
 bfY
@@ -31053,10 +31159,10 @@ erE
 brQ
 brQ
 brQ
-brQ
-brQ
-brQ
-gcB
+xRD
+jvx
+jvx
+erE
 gcB
 aab
 "}
@@ -31200,42 +31306,42 @@ aES
 aGk
 aFB
 aFB
-aFB
+aJD
 aMy
 aMy
-aFB
-aFB
-aFB
-aFB
-aFB
-bbL
+aKZ
+kKD
 nsb
-nsb
-nsb
+brQ
+urV
+xRD
+vpr
+wKk
+ueh
 jvx
 dTj
 jvx
 dTj
-jvx
+xcN
 dTj
 jvx
 dTj
 jss
-dTj
-jvx
-vmR
-dTj
 jvx
 jvx
-dTj
+jvx
+jvx
+jvx
+jvx
+jvx
 erE
-kKD
 brQ
-kKD
 brQ
-kKD
 brQ
-gcB
+xRD
+jvx
+jvx
+erE
 gcB
 aab
 "}
@@ -31373,7 +31479,7 @@ aOo
 aEO
 aPZ
 aMm
-aMm
+kKo
 aOY
 aES
 aFB
@@ -31383,13 +31489,9 @@ aJB
 aMy
 kvA
 aKZ
-aFB
-aFB
-aFB
-aET
-bbL
-wPr
-wPr
+kKD
+nsb
+nsb
 nsb
 nsb
 nsb
@@ -31405,16 +31507,20 @@ nsb
 nsb
 nsb
 jvx
-oTD
-nsb
-nsb
-nsb
-nsb
-nsb
-nsb
-nsb
-nsb
-gcB
+jvx
+jvx
+jvx
+jvx
+jvx
+jvx
+erE
+brQ
+brQ
+brQ
+xRD
+jvx
+jvx
+erE
 gcB
 aab
 "}
@@ -31551,8 +31657,8 @@ aGb
 aEN
 aEN
 aQa
-aMn
-aMn
+jLQ
+aSd
 aLt
 aES
 aET
@@ -31562,38 +31668,38 @@ aJB
 aEx
 aEx
 aKZ
-aFB
-aFB
-aET
-aET
-aES
-aES
-bbL
+kKD
+phK
+phK
+phK
+phK
+phK
+vfD
+fvx
+fvx
+fvx
+fvx
+fvx
+fvx
+fvx
+wUQ
+kKD
 nsb
-nsb
-nsb
-nsb
-nsb
-nsb
-nsb
-nsb
-nsb
-nsb
-nsb
-nsb
-nsb
-nsb
+ptS
 jvx
-oTD
-nsb
-nsb
-nsb
-nsb
-nsb
-nsb
-nsb
-nsb
-gcB
+jvx
+jvx
+jvx
+jvx
+jvx
+erE
+brQ
+brQ
+brQ
+xRD
+jvx
+jvx
+erE
 gcB
 aab
 "}
@@ -31730,9 +31836,9 @@ auX
 aEO
 aES
 aES
-aES
-aES
-aES
+aJD
+aEx
+aKZ
 aES
 aFB
 aFB
@@ -31741,39 +31847,39 @@ aJD
 aEx
 aEx
 aKZ
-aFB
-aFB
-aET
-aET
+gcB
+gcB
+vsm
+vsm
 baK
-aES
-xDf
-ksq
+brQ
+xRD
+msP
 pOv
 hmT
 jIm
 msP
-fvx
-fvx
-fvx
-fvx
-fvx
-fvx
-fvx
-fvx
-fvx
-fvx
-fvx
-fvx
-vso
-wPr
-wPr
-wPr
+bAk
+jvx
+erE
+kKD
+nsb
+jvx
+jvx
+jvx
+jvx
+jvx
+jvx
+jvx
+erE
+brQ
+brQ
+brQ
 xRD
-fvx
-fvx
-vso
-ptS
+jvx
+jvx
+erE
+gcB
 aab
 "}
 (81,1,1) = {"
@@ -31909,8 +32015,8 @@ avr
 aEO
 aES
 aES
-aES
-aFD
+aJD
+vpq
 aRY
 aET
 aFB
@@ -31935,24 +32041,24 @@ aEy
 aOs
 aOs
 aOs
-aEy
-aEy
-axC
-aZl
-aZl
-aZl
-aZl
-aZl
-aZl
-beo
-bpx
-bpx
-bpy
-brE
-qkT
-qkT
-osh
-boU
+pqu
+nsb
+ptS
+jvx
+jvx
+jvx
+jvx
+jvx
+jvx
+erE
+brQ
+brQ
+rPI
+xRD
+jvx
+jvx
+erE
+gcB
 aab
 "}
 (82,1,1) = {"
@@ -32088,14 +32194,14 @@ aFp
 aEO
 aES
 aFB
-aES
-aHT
-aET
+aJD
+rHv
+taV
 aGk
 aFB
 aFB
 aFB
-aFB
+aJD
 aMy
 aMy
 taV
@@ -32115,23 +32221,23 @@ wvF
 aya
 aET
 pqu
-nMR
-axC
-aZl
-vpr
-aZl
-nAc
-aZl
-aZl
-beo
-bpx
-boU
+nsb
+jvx
+jvx
+jvx
+jvx
+jvx
+jvx
+jvx
+erE
+brQ
+brQ
 bry
-uJY
-dQo
-bqU
-mSv
-boU
+xRD
+jvx
+jvx
+erE
+gcB
 aab
 "}
 (83,1,1) = {"
@@ -32267,14 +32373,14 @@ aFV
 avs
 aFB
 aFB
-aET
+aJB
+sWJ
 bZw
-aQT
 aET
 aHT
 aHT
 aET
-aFB
+aJD
 aMy
 aEx
 taV
@@ -32293,24 +32399,24 @@ bgN
 bgN
 emp
 baf
-aOs
-nMR
-axC
-aZl
-aZl
-aZl
-aZl
-aZl
-aZl
-beo
-bpx
-oOC
-boU
-uJY
-bqU
-dQo
-mSv
-boU
+pqu
+nsb
+ptS
+jvx
+jvx
+jvx
+jvx
+jvx
+jvx
+erE
+brQ
+rPI
+brQ
+xRD
+jvx
+jvx
+erE
+gcB
 aab
 "}
 (84,1,1) = {"
@@ -32446,9 +32552,9 @@ aES
 aHT
 aFB
 aET
-aET
-aGk
-aET
+aJB
+aNu
+taV
 aHT
 aFD
 aES
@@ -32472,24 +32578,24 @@ qtw
 anL
 bhm
 xQl
-aOs
-aJD
-bpM
-qkT
-qkT
-qkT
-qkT
-qkT
-qkT
-bpJ
-bpx
-bqO
-bqO
-brE
-qkT
-qkT
-osh
-boU
+pqu
+nsb
+jvx
+dTj
+jvx
+dTj
+jvx
+jvx
+jvx
+erE
+urV
+brQ
+urV
+xRD
+dTj
+jvx
+tEF
+gcB
 aab
 "}
 (85,1,1) = {"
@@ -32627,9 +32733,9 @@ aFB
 aGk
 aQS
 aRA
-aET
-aHT
-aES
+dcR
+dQo
+aKs
 aLt
 aPW
 sus
@@ -32651,24 +32757,24 @@ dvr
 anL
 bhm
 aXg
-aEy
-hAH
-drA
-bpM
-bpM
-bpM
-qkT
-qkT
-qkT
-bpJ
-bpx
-bqO
-bqO
-brE
-bsn
-qkT
-osh
-boU
+pqu
+nsb
+nsb
+nsb
+nsb
+nsb
+nsb
+jvx
+qbi
+nsb
+nsb
+nsb
+nsb
+nsb
+nsb
+nsb
+nsb
+gcB
 aab
 "}
 (86,1,1) = {"
@@ -32805,11 +32911,11 @@ aHT
 aET
 aGk
 aQT
-aET
-aES
-aES
-aES
-aLs
+aMy
+aEx
+aEx
+sWJ
+aSd
 aMm
 aMm
 aMm
@@ -32830,24 +32936,24 @@ pZl
 anL
 bhm
 azg
-biV
-qkT
-qkT
-qkT
-qkT
-bpM
-qkT
-bsn
-qkT
-bpJ
-bpx
-boU
-boU
-brE
-qkT
-qkT
-osh
-boU
+hpg
+fvx
+fvx
+fvx
+fvx
+uFY
+fvx
+fvx
+fvx
+tji
+wPr
+phK
+phK
+vfD
+fvx
+fvx
+wUQ
+phK
 aab
 "}
 (87,1,1) = {"
@@ -32983,12 +33089,12 @@ aES
 aET
 aET
 aFB
-aFB
-aES
-aRY
-aFD
-aQe
-aLs
+aJD
+sWJ
+eQc
+vpq
+oAW
+aSd
 aMm
 abF
 aMm
@@ -33011,12 +33117,12 @@ qxe
 aMy
 aMy
 qkT
-qkT
+bsn
 qkT
 qkT
 bpM
 qkT
-qkT
+bsn
 qkT
 bpJ
 bpx
@@ -33162,12 +33268,12 @@ aFx
 aOs
 aPe
 aES
-aFB
-aES
-aES
-aFD
-aFD
-aLs
+aJD
+aEx
+aEx
+vpq
+vpq
+aSd
 aMm
 aMm
 aMm
@@ -33192,7 +33298,7 @@ biV
 qkT
 qkT
 qkT
-qkT
+bsn
 bpM
 qkT
 qkT
@@ -33341,11 +33447,11 @@ aGF
 avt
 aGj
 aGk
-aFB
-aRB
-aKs
-aSR
-aES
+aEW
+aSg
+aKt
+aSg
+aKt
 aLt
 aMm
 aMm
@@ -33521,9 +33627,9 @@ avu
 aFx
 aES
 aGk
-aJD
-lyK
-aLa
+aFD
+dde
+drA
 aQe
 aLs
 aMm
@@ -33549,7 +33655,7 @@ aHT
 aOs
 bpx
 bpx
-bpx
+cta
 bpx
 bmK
 qkT
@@ -33700,9 +33806,9 @@ avK
 aFw
 aES
 aES
-aEW
-aSg
-aLc
+aES
+drA
+aES
 aFD
 aLs
 aMm
@@ -34798,7 +34904,7 @@ aMy
 aMy
 lQf
 aEx
-wKk
+aEx
 aKZ
 aEW
 aKt
@@ -35131,7 +35237,7 @@ aNt
 aGF
 aFx
 aES
-aES
+bIG
 aEW
 aSg
 aLc
@@ -35530,7 +35636,7 @@ bqv
 bqv
 bmN
 bqU
-qkT
+bsn
 osh
 boU
 aab

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -4067,12 +4067,6 @@
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle6)
-"ate" = (
-/obj/structure/flora/ausbushes/reedbush,
-/turf/open/ground/coast/corner2{
-	dir = 1
-	},
-/area/lv624/ground/river1)
 "atf" = (
 /turf/open/floor/plating/ground/dirtgrassborder/corner,
 /area/lv624/ground/compound/sw)
@@ -4590,11 +4584,6 @@
 	dir = 1
 	},
 /area/lv624/lazarus/hydroponics)
-"avI" = (
-/obj/structure/jungle/planttop1,
-/obj/structure/jungle/vines,
-/turf/open/ground/grass,
-/area/lv624/ground/jungle7)
 "avJ" = (
 /obj/structure/jungle/vines,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -6369,7 +6358,7 @@
 /area/lv624/ground/river1)
 "aEK" = (
 /obj/item/tool/kitchen/knife/butcher,
-/turf/open/ground/river,
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/river1)
 "aEL" = (
 /turf/open/ground/grass,
@@ -6966,7 +6955,9 @@
 /area/lv624/ground/jungle9)
 "aHU" = (
 /obj/structure/jungle/planttop1,
-/turf/open/ground/grass,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 8
+	},
 /area/lv624/ground/jungle9)
 "aHW" = (
 /obj/machinery/light/small{
@@ -6992,16 +6983,9 @@
 	dir = 8
 	},
 /area/lv624/ground/compound/ne)
-"aIi" = (
-/turf/open/ground/coast/corner2{
-	dir = 1
-	},
-/area/lv624/ground/river1)
 "aIj" = (
 /obj/structure/jungle/plantbot1/alien,
-/turf/open/ground/coast{
-	dir = 1
-	},
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/river1)
 "aIk" = (
 /obj/structure/fence,
@@ -7113,7 +7097,7 @@
 	},
 /obj/effect/decal/cleanable/blood/splatter/animated,
 /obj/item/weapon/harpoon,
-/turf/open/ground/river,
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/river1)
 "aJj" = (
 /obj/machinery/door/poddoor/mainship{
@@ -7262,11 +7246,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/ground/jungle5)
-"aJN" = (
-/turf/open/ground/coast/corner{
-	dir = 8
-	},
-/area/lv624/ground/river1)
 "aKb" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/tile/purple/whitepurple{
@@ -7671,7 +7650,7 @@
 /area/lv624/ground/jungle5)
 "aMa" = (
 /obj/structure/flora/ausbushes/stalkybush,
-/turf/open/ground/river,
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/river1)
 "aMc" = (
 /obj/structure/jungle/vines,
@@ -9956,10 +9935,6 @@
 	dir = 4
 	},
 /area/lv624/ground/compound/c)
-"aXi" = (
-/obj/structure/fence,
-/turf/open/ground/grass,
-/area/lv624/ground/compound/c)
 "aXj" = (
 /obj/structure/table,
 /obj/structure/mirror{
@@ -10977,10 +10952,6 @@
 	dir = 8
 	},
 /area/shuttle/drop2/lz2)
-"bcJ" = (
-/obj/structure/fence,
-/turf/open/ground/grass/grass2,
-/area/lv624/ground/compound/c)
 "bcK" = (
 /obj/structure/jungle/vines,
 /turf/closed/wall/r_wall,
@@ -11655,7 +11626,7 @@
 "bgc" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/jungle/vines,
-/turf/open/ground/grass/grass2,
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle9)
 "bge" = (
 /obj/structure/jungle/vines,
@@ -11849,7 +11820,9 @@
 "bhq" = (
 /obj/effect/landmark/monkey_spawn,
 /obj/structure/jungle/vines/heavy,
-/turf/open/ground/grass/grass2,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 4
+	},
 /area/lv624/ground/jungle9)
 "bhs" = (
 /turf/closed/wall/r_wall,
@@ -12170,13 +12143,11 @@
 /obj/structure/foamedmetal,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle9)
-"bja" = (
-/obj/structure/foamedmetal,
-/turf/open/ground/grass/grass2,
-/area/lv624/ground/jungle9)
 "bjb" = (
 /obj/item/weapon/claymore/mercsword/machete,
-/turf/open/ground/grass,
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
+	dir = 8
+	},
 /area/lv624/ground/jungle9)
 "bjc" = (
 /obj/structure/jungle/vines,
@@ -12733,6 +12704,7 @@
 /area/lv624/lazarus/engineering)
 "blU" = (
 /obj/item/clothing/head/hardhat/orange,
+/obj/effect/alien/weeds/node,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/engineering)
 "blY" = (
@@ -13576,7 +13548,6 @@
 	dir = 4;
 	on = 1
 	},
-/obj/effect/alien/weeds/node,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/secure_storage)
 "bps" = (
@@ -14224,6 +14195,11 @@
 "bLL" = (
 /turf/closed/wall/resin/thick,
 /area/lv624/ground/caves/west1)
+"bNH" = (
+/obj/structure/jungle/plantbot1/alien,
+/obj/structure/catwalk,
+/turf/open/ground/river,
+/area/lv624/ground/river1)
 "bNK" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
@@ -14276,11 +14252,6 @@
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 1
 	},
-/area/lv624/ground/jungle7)
-"cfh" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/alien/weeds/node,
-/turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle7)
 "cfn" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -14503,6 +14474,13 @@
 /obj/effect/alien/weeds/node,
 /turf/closed/wall/resin/thick,
 /area/lv624/ground/caves/central1)
+"doB" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 4
+	},
+/area/lv624/ground/jungle9)
 "doR" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/cable,
@@ -14598,6 +14576,12 @@
 /obj/structure/mineral_door/resin,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand1)
+"dWx" = (
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 4
+	},
+/area/lv624/ground/jungle7)
 "dXe" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/gm/dense,
@@ -14750,18 +14734,10 @@
 /obj/effect/landmark/monkey_spawn,
 /turf/closed/gm/dense,
 /area/lv624/ground/jungle3)
-"fcf" = (
-/turf/open/ground/coast,
-/area/lv624/ground/jungle6)
 "fdG" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/wall,
 /area/lv624/lazarus/canteen)
-"feI" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/alien/weeds/node,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/jungle3)
 "ffi" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/plating/ground/dirt,
@@ -14809,6 +14785,12 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral,
 /area/lv624/ground/caves/west1)
+"fpC" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
+	dir = 8
+	},
+/area/lv624/ground/jungle7)
 "frj" = (
 /obj/machinery/floodlight/colony{
 	dir = 1
@@ -15064,6 +15046,12 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/quartstorage/outdoors)
+"gJa" = (
+/obj/structure/jungle/plantbot1,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 8
+	},
+/area/lv624/ground/jungle9)
 "gJn" = (
 /obj/machinery/floodlight/colony{
 	dir = 8
@@ -15434,12 +15422,6 @@
 	dir = 8
 	},
 /area/shuttle/drop1/lz1)
-"jiZ" = (
-/obj/structure/flora/ausbushes/reedbush,
-/turf/open/ground/coast/corner{
-	dir = 1
-	},
-/area/lv624/ground/jungle6)
 "jjQ" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/indestructible/mineral,
@@ -15610,6 +15592,11 @@
 	},
 /turf/closed/gm/dense,
 /area/lv624/ground/jungle1)
+"ksG" = (
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
+	dir = 8
+	},
+/area/lv624/ground/jungle9)
 "ktj" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral,
@@ -15845,6 +15832,11 @@
 /obj/effect/alien/weeds/node,
 /turf/open/floor/plating,
 /area/lv624/ground/sand7)
+"lyr" = (
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
+	dir = 1
+	},
+/area/lv624/ground/compound/c)
 "lyK" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/floodlight/colony,
@@ -15885,6 +15877,10 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor,
 /area/shuttle/drop2/lz2)
+"lSd" = (
+/obj/machinery/floodlight/colony,
+/turf/open/floor/plating/ground/dirtgrassborder,
+/area/lv624/ground/jungle9)
 "lUQ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/wall/r_wall,
@@ -16266,6 +16262,10 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/resin/thick,
 /area/lv624/ground/caves/west2)
+"oAW" = (
+/obj/structure/flora/grass/green,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
 "oCh" = (
 /turf/open/floor/plating/ground/dirtgrassborder/corner,
 /area/lv624/ground/jungle4)
@@ -16325,15 +16325,16 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/resin,
 /area/lv624/ground/caves/east2)
-"oXT" = (
-/obj/structure/jungle/plantbot1,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/jungle7)
 "oYK" = (
 /obj/structure/jungle/vines,
 /obj/structure/catwalk,
 /turf/open/ground/coast,
 /area/lv624/ground/river3)
+"phK" = (
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
+	dir = 1
+	},
+/area/lv624/ground/jungle9)
 "pkT" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -16593,6 +16594,12 @@
 	dir = 4
 	},
 /area/shuttle/drop2/lz2)
+"qSm" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/ground/grass,
+/area/lv624/ground/jungle6)
 "qSA" = (
 /obj/machinery/button/door/open_only/landing_zone,
 /obj/structure/window/reinforced,
@@ -16793,14 +16800,6 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral,
 /area/lv624/ground/caves/central1)
-"see" = (
-/obj/structure/cable,
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/effect/alien/weeds/node,
-/turf/open/floor/plating/platebot,
-/area/lv624/lazarus/engineering)
 "sez" = (
 /obj/effect/alien/egg,
 /turf/open/floor/plating/ground/dirt,
@@ -16826,11 +16825,6 @@
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand5)
-"snU" = (
-/obj/structure/jungle/planttop1,
-/obj/effect/alien/weeds/node,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/jungle7)
 "sqN" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/plating/ground/dirt,
@@ -17395,6 +17389,13 @@
 	dir = 5
 	},
 /area/shuttle/drop2/lz2)
+"wuU" = (
+/obj/structure/jungle/vines,
+/obj/structure/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 4
+	},
+/area/lv624/ground/jungle7)
 "wvF" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/jungle/vines,
@@ -17422,7 +17423,7 @@
 /area/shuttle/drop2/lz2)
 "wKk" = (
 /obj/machinery/miner/damaged,
-/turf/open/ground/grass/grass2,
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle9)
 "wKy" = (
 /obj/machinery/floodlight/colony,
@@ -17532,6 +17533,11 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand1)
+"xwG" = (
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
+	dir = 4
+	},
+/area/lv624/ground/jungle9)
 "xxs" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor,
@@ -19775,7 +19781,7 @@ bck
 bch
 vlW
 bnE
-feI
+pId
 bfa
 bch
 bch
@@ -20262,16 +20268,16 @@ awg
 awg
 awg
 awC
-auZ
-are
-atA
-are
-atA
-are
-aDt
-avM
-avM
-aJN
+txw
+aCl
+bNH
+aCl
+bNH
+aCl
+agd
+avL
+avL
+avL
 ayY
 avP
 avP
@@ -20441,24 +20447,24 @@ awg
 awg
 awC
 awC
-auZ
-are
-are
-are
-are
-are
-are
-atA
+txw
+aCl
+aCl
+aCl
+aCl
+aCl
+agd
+aIj
 aJb
-aDt
-avM
-avM
-avM
-aJN
+avL
+avL
+avL
+avL
+avL
 auH
-axQ
-fYD
-aVS
+avd
+qSm
+gWo
 aUF
 aMV
 dVC
@@ -20620,24 +20626,24 @@ awg
 awg
 awC
 awC
-auZ
-are
-are
-are
-are
-are
-are
+txw
+aCl
+aCl
+aCl
+aCl
+aCl
+agd
 aEK
-are
-are
-are
-atz
-are
-awZ
+avL
+avL
+avL
+avO
+avL
+avL
 auH
-axQ
-fYD
-aVS
+avd
+qSm
+gWo
 aUF
 aZw
 dVC
@@ -20805,18 +20811,18 @@ are
 are
 are
 avb
-auf
-aIi
-are
-are
-are
-are
-are
-awZ
+avc
+avL
+avL
+avL
+avL
+avL
+avL
+avL
 auH
-axQ
-fYD
-aVS
+avd
+qSm
+gWo
 aUF
 aZo
 dVC
@@ -20985,17 +20991,17 @@ are
 are
 awZ
 atc
-aEI
-ate
-are
-are
-are
-avb
-avc
+avL
+avO
+avL
+avL
+avL
+avL
+avL
 auH
-axQ
-fYD
-aVS
+avd
+qSm
+gWo
 aUF
 aZp
 dVC
@@ -21165,10 +21171,10 @@ are
 awZ
 atH
 aBM
-aEI
-ate
-are
-are
+avL
+avO
+avL
+avL
 aIj
 aug
 auk
@@ -21345,10 +21351,10 @@ awZ
 auH
 axx
 aBM
-fcf
-are
-are
-awZ
+axR
+avL
+avL
+avL
 dxb
 axb
 axQ
@@ -21524,10 +21530,10 @@ awZ
 auH
 ndi
 avx
-fcf
+axR
 aMa
-are
-awZ
+avL
+avL
 dxb
 avd
 axQ
@@ -21703,10 +21709,10 @@ awZ
 auH
 dQh
 avx
-jiZ
-auf
-auf
-avc
+atc
+avL
+avL
+avL
 dxb
 avd
 axQ
@@ -25512,7 +25518,7 @@ bla
 bnM
 bnJ
 bpr
-bnJ
+bFY
 bnJ
 bla
 bqO
@@ -28528,10 +28534,10 @@ aJD
 kFc
 aEx
 aEx
-aFB
-aFB
-aFB
-aET
+ksG
+aKs
+aKs
+aKu
 aKu
 aKs
 aKs
@@ -29065,11 +29071,11 @@ aJB
 aMy
 aMy
 aMy
-aFB
-aFB
-aFB
-aFB
-aFB
+phK
+aKt
+aKt
+aKt
+aKt
 aKt
 aKt
 nsb
@@ -34276,7 +34282,7 @@ aOs
 aEy
 hAH
 bkD
-see
+bln
 blj
 bkA
 bnq
@@ -34622,16 +34628,16 @@ aMm
 aMm
 aMm
 aMm
-bbT
-aXi
-aET
-aET
-aET
-aya
-aXg
+aWG
+aPW
+aKu
+aKu
+aKu
+doB
+aKu
 bhq
-aXg
-biZ
+aKu
+aLb
 hAH
 bkD
 bln
@@ -34801,16 +34807,16 @@ aMm
 kKo
 aMm
 aMm
-bbT
-bcJ
-aQe
-aET
-aXg
+aMm
+aSd
+oAW
+aMy
+aMy
 bgc
-bet
-bet
-aET
-biZ
+aNu
+aNu
+aMy
+aKZ
 bjJ
 bkF
 blo
@@ -34980,16 +34986,16 @@ aMm
 aMm
 aMm
 aMm
-bbT
-aXi
-aES
-aXg
-aXg
-aXg
-bet
-aES
+aMm
+aSd
+aEx
+aMy
+aMy
+aMy
+aNu
+aEx
 wKk
-bja
+aKZ
 biZ
 biZ
 aES
@@ -35159,20 +35165,20 @@ aMm
 aMm
 aMm
 aMm
-bbT
-aXi
-aES
-aET
-aFB
-aFB
-aXg
-aES
-aES
+lyr
+aMn
+aKt
+aFG
+aKt
+aKt
+aFG
+xwG
+aEx
 bjb
-aES
-aES
-aES
-aES
+aKs
+aKs
+aKs
+aKs
 bmL
 czY
 bnX
@@ -35345,14 +35351,14 @@ bet
 aFB
 aXg
 aYw
-dZV
-aES
-aES
-aES
-aES
-aYw
-aES
-bmM
+lSd
+aEx
+aEx
+aEx
+aEx
+aEx
+aEx
+boQ
 bnt
 siq
 czY
@@ -35523,15 +35529,15 @@ bbW
 bbW
 bbW
 bet
-aFB
-aFB
-aFB
-aET
 aES
-aYw
-aYw
-aES
-bmM
+aJD
+aEx
+aMy
+aEx
+aEx
+aEx
+aEx
+boQ
 bnt
 bnX
 bnt
@@ -35704,12 +35710,12 @@ bbW
 bge
 bbW
 aFB
-aFB
-aFB
-aET
+aKt
+aKt
+aFG
 aHU
-aIK
-aES
+gJa
+aKt
 bmN
 bnt
 bnX
@@ -35884,7 +35890,7 @@ beu
 bbW
 bhs
 bhs
-aFB
+aES
 aES
 aES
 aES
@@ -39934,16 +39940,16 @@ apf
 arn
 arl
 auT
-avl
-arW
-arW
-arW
-atX
-atX
-auN
-auO
-arW
-arW
+fpC
+auS
+auS
+auS
+aun
+aun
+wuU
+dWx
+auS
+arZ
 atl
 atl
 atl
@@ -40113,16 +40119,16 @@ aqI
 ark
 arl
 arl
+arl
+arl
+gJp
+arl
+awf
+ayf
+awf
+gJp
+arl
 arp
-arW
-arW
-arW
-atX
-auN
-atX
-asW
-arW
-arW
 arW
 atl
 atl
@@ -40292,16 +40298,16 @@ alb
 arl
 arl
 auT
-arp
-arW
-arY
-arW
+arl
+arl
+auT
+arl
 auN
-atX
-arW
-arW
-arW
-arW
+awf
+arl
+arl
+arl
+arp
 axp
 arW
 atl
@@ -40471,16 +40477,16 @@ alb
 arl
 gJp
 arl
-arp
-arW
-arW
-atX
-auN
-atX
-arW
-arW
-arW
-atY
+aro
+asU
+asU
+auL
+ayg
+auL
+asU
+aus
+arl
+arq
 auS
 auS
 auS
@@ -40656,12 +40662,12 @@ atX
 arW
 atX
 atl
-avI
-asX
-arW
+atX
 atQ
-auT
 arl
+arl
+auT
+gJp
 awf
 ayO
 atX
@@ -40836,9 +40842,9 @@ atX
 atl
 atl
 atl
-atX
-arW
-aut
+axq
+asU
+asU
 aus
 awf
 ayf
@@ -42453,7 +42459,7 @@ atl
 atl
 aCK
 arl
-cfh
+gJp
 arl
 azM
 aAk
@@ -43343,8 +43349,8 @@ gJp
 arl
 arl
 arl
-snU
-oXT
+gJp
+arl
 arl
 arl
 gJp

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -2284,12 +2284,6 @@
 	dir = 4
 	},
 /area/lv624/ground/river2)
-"akR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
-/obj/effect/alien/weeds/node,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/compound/sw)
 "akT" = (
 /obj/structure/jungle/vines,
 /obj/structure/jungle/plantbot1/alien,
@@ -3112,7 +3106,6 @@
 /obj/structure/barricade/wooden{
 	dir = 4
 	},
-/obj/effect/alien/weeds/node,
 /turf/open/floor/wood,
 /area/lv624/ground/ruin)
 "anY" = (
@@ -5352,7 +5345,6 @@
 /obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	name = "\improper Hydroponics Dome"
 	},
-/obj/effect/alien/weeds/node,
 /turf/open/floor/tile/green/greentaupe{
 	dir = 1
 	},
@@ -5462,7 +5454,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/alien/weeds/node,
 /turf/open/floor/tile/green/greentaupe{
 	dir = 1
 	},
@@ -11790,7 +11781,6 @@
 /obj/structure/flora/grass/both,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
-/obj/effect/alien/weeds/node,
 /turf/open/floor/grass,
 /area/lv624/lazarus/main_hall)
 "bgU" = (
@@ -15454,12 +15444,6 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/indestructible/mineral,
 /area/lv624/ground/caves/west1)
-"jnF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable,
-/obj/effect/alien/weeds/node,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/lazarus/quartstorage/outdoors)
 "jqE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
@@ -16636,10 +16620,6 @@
 	dir = 4
 	},
 /area/lv624/ground/jungle3)
-"qYJ" = (
-/obj/effect/alien/weeds/node,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/compound/ne)
 "qZa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -16884,6 +16864,10 @@
 	dir = 4
 	},
 /area/shuttle/drop2/lz2)
+"sDV" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle1)
 "sED" = (
 /obj/structure/lazarus_sign,
 /turf/open/floor/plating/ground/dirtgrassborder,
@@ -17264,10 +17248,6 @@
 	dir = 4
 	},
 /area/shuttle/drop1/lz1)
-"vzO" = (
-/obj/effect/alien/weeds/node,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/jungle4)
 "vAw" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/effect/alien/weeds/node,
@@ -17292,13 +17272,6 @@
 /obj/structure/window_frame/colony,
 /turf/open/floor/plating,
 /area/lv624/ground/jungle9)
-"vEO" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/effect/alien/weeds/node,
-/turf/open/floor,
-/area/lv624/ground/river2)
 "vEP" = (
 /obj/item/frame/table,
 /obj/effect/alien/weeds/node,
@@ -17521,6 +17494,12 @@
 /obj/effect/alien/weeds/node,
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/lazarus/quart)
+"xfC" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/green/whitegreencorner{
+	dir = 8
+	},
+/area/lv624/lazarus/main_hall)
 "xib" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral,
@@ -17561,6 +17540,13 @@
 /obj/structure/jungle/vines,
 /turf/closed/gm/dense,
 /area/lv624/ground/jungle3)
+"xBg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/sw)
 "xCo" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/dirt,
@@ -22806,7 +22792,7 @@ wlI
 axR
 wNe
 wNe
-vzO
+wNe
 wNe
 wNe
 vpP
@@ -24052,7 +24038,7 @@ avq
 aIZ
 avq
 axR
-wlI
+axR
 axR
 xVM
 xVM
@@ -24250,9 +24236,9 @@ xVM
 xVM
 mos
 tqW
-nAc
-vDD
 aZl
+vDD
+nAc
 aZl
 nAc
 aZl
@@ -24791,7 +24777,7 @@ aEy
 leX
 aEy
 aZl
-beX
+xBg
 aZl
 blb
 fRf
@@ -25149,7 +25135,7 @@ aES
 aFD
 bcD
 aZl
-nAc
+aZl
 aZl
 aZl
 bdu
@@ -26209,7 +26195,7 @@ pNb
 aPS
 aLt
 aMm
-kHl
+usu
 aMm
 aLt
 aPS
@@ -26366,7 +26352,7 @@ auJ
 axQ
 aCr
 ayo
-wlI
+axR
 axR
 aXH
 aXH
@@ -26567,7 +26553,7 @@ aPS
 aPS
 aLs
 aMm
-usu
+kHl
 aMm
 aOY
 pNb
@@ -26721,8 +26707,8 @@ wlI
 ayo
 aAG
 aBg
-axR
 wlI
+axR
 axR
 axR
 aXH
@@ -27128,7 +27114,7 @@ rTb
 rTb
 rTb
 xmL
-akR
+xmL
 xmL
 xmL
 qnO
@@ -27278,7 +27264,7 @@ aXH
 aXH
 aXH
 aMm
-stw
+bfQ
 aMm
 aMm
 aMm
@@ -28730,7 +28716,7 @@ kvA
 aEx
 bgH
 aZl
-pZX
+bcA
 aZl
 beo
 aFB
@@ -32503,7 +32489,7 @@ bcD
 blb
 aZl
 aZl
-nAc
+aZl
 aZl
 cnD
 bpG
@@ -33498,7 +33484,7 @@ aoE
 aji
 aji
 aji
-vEO
+aji
 aji
 aji
 aji
@@ -35672,7 +35658,7 @@ axm
 awP
 aBz
 avZ
-aAb
+ffi
 aAb
 aDC
 aAb
@@ -36043,7 +36029,7 @@ aET
 aET
 aGk
 aJB
-sWJ
+aEx
 aLa
 aHT
 aET
@@ -36211,7 +36197,7 @@ avE
 avZ
 aAb
 aAb
-ohD
+aDC
 aAb
 aEz
 aET
@@ -36919,7 +36905,7 @@ arW
 arW
 arY
 atQ
-gJp
+arl
 aro
 aEh
 aEh
@@ -38732,7 +38718,7 @@ aKw
 aKw
 aLP
 aME
-nGf
+aNz
 aNC
 aNz
 aME
@@ -39068,7 +39054,7 @@ atX
 atX
 arY
 avA
-gJp
+arl
 aEh
 aEh
 aEh
@@ -39117,7 +39103,7 @@ aWQ
 beF
 aRI
 aRI
-aRI
+xfC
 aRI
 aRI
 aRI
@@ -40154,7 +40140,7 @@ arY
 arW
 aFa
 aDc
-qYJ
+aDc
 aDc
 aEZ
 aHZ
@@ -42531,7 +42517,7 @@ bdh
 bdi
 biN
 boZ
-boY
+sDV
 bpU
 bkk
 bdh
@@ -43197,7 +43183,7 @@ aEi
 aCG
 aCG
 aCG
-aCG
+dpa
 aEi
 aEi
 azJ
@@ -43245,7 +43231,7 @@ bdh
 bhQ
 bdi
 biM
-boY
+sDV
 bpS
 blC
 bdh
@@ -43430,7 +43416,7 @@ bkk
 bdh
 biM
 boY
-boY
+sDV
 bkk
 bdi
 bdk
@@ -43554,11 +43540,11 @@ arY
 aAo
 aCG
 aCd
-dpa
+aCG
 aCd
 azJ
 aAk
-jXK
+aAk
 aHs
 aJG
 aJH
@@ -44063,8 +44049,8 @@ apm
 aoO
 aqN
 aqg
-aro
-arV
+arl
+arp
 arW
 asW
 arW
@@ -44241,9 +44227,9 @@ aoO
 aoO
 aoO
 aqf
-aro
-arV
-arW
+arl
+arl
+arp
 arW
 arY
 atl
@@ -44420,9 +44406,9 @@ aoO
 aqN
 aqw
 aqg
-arp
-arW
-arY
+arl
+arl
+avl
 atl
 arW
 atl
@@ -44598,9 +44584,9 @@ aoO
 aoO
 aqf
 mcB
-asU
-arV
-arW
+aus
+gJp
+arl
 atl
 atl
 atl
@@ -44777,9 +44763,9 @@ aoO
 aqN
 aqg
 arp
-arW
-arW
-arY
+atQ
+arl
+auT
 atl
 atl
 atl
@@ -44956,10 +44942,10 @@ aqN
 aqg
 aos
 aot
-ask
-auc
-aoY
-aoY
+aqk
+apP
+apP
+apV
 aoY
 anr
 anr
@@ -45000,7 +44986,7 @@ puV
 aAk
 aAk
 eHq
-aAk
+jXK
 xnH
 lYR
 aSB
@@ -45136,9 +45122,9 @@ aos
 aot
 ask
 anO
+apP
+apP
 aud
-auB
-auB
 apK
 anr
 anr
@@ -45156,9 +45142,9 @@ ayj
 ayj
 azO
 ayj
-aAT
-aBC
 eEp
+aBC
+aAT
 aAT
 aDm
 puV
@@ -45177,7 +45163,7 @@ puV
 puV
 puV
 iVB
-jnF
+iVB
 rOB
 blN
 fyU
@@ -45489,7 +45475,7 @@ apo
 ajB
 aqN
 aqg
-aps
+asD
 aot
 aqk
 anN
@@ -47476,7 +47462,7 @@ anr
 aoY
 aoY
 aqZ
-apP
+fsZ
 aAT
 aDP
 azP

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -298,23 +298,19 @@
 /obj/structure/cable,
 /turf/open/floor/tile/blue/whitebluecorner,
 /area/lv624/lazarus/medbay)
-"abR" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
 "abU" = (
 /obj/effect/landmark/monkey_spawn,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/east2)
 "acd" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 8
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/item/weapon/gun/smg/m25,
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
+/turf/open/floor/plating/warning{
+	dir = 1
+	},
+/area/lv624/lazarus/engineering)
 "ace" = (
 /obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/plating/ground/dirt,
@@ -323,10 +319,12 @@
 /turf/closed/wall/resin/membrane,
 /area/lv624/ground/caves/west1)
 "ack" = (
-/obj/structure/table/reinforced/flipped,
-/obj/item/ammo_casing,
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
+/obj/structure/closet/toolcloset,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/engineering)
 "acr" = (
 /turf/closed/wall/resin/membrane,
 /area/lv624/ground/caves/west2)
@@ -790,8 +788,9 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/central3)
 "aev" = (
-/turf/closed/mineral,
-/area/lv624/ground/sand5)
+/obj/effect/decal/remains/xeno,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central3)
 "aew" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/ground/coast/corner2,
@@ -1122,8 +1121,8 @@
 /area/lv624/ground/caves/east1)
 "afR" = (
 /obj/effect/decal/remains/xeno,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/sand5)
+/turf/closed/mineral,
+/area/lv624/ground/caves/central3)
 "afS" = (
 /obj/structure/cargo_container/horizontal{
 	dir = 1
@@ -1224,8 +1223,12 @@
 /turf/closed/wall/mineral/sandstone,
 /area/lv624/ground/caves/east1)
 "agn" = (
-/turf/open/ground/coast/corner2,
-/area/lv624/ground/sand8)
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	dir = 1;
+	name = "\improper Engineering Dome"
+	},
+/turf/open/floor/plating/platebotc,
+/area/lv624/lazarus/engineering)
 "agp" = (
 /turf/open/floor/marking/loadingarea{
 	dir = 8
@@ -1361,10 +1364,11 @@
 	},
 /area/lv624/ground/river1)
 "agU" = (
-/turf/open/ground/coast/corner2{
-	dir = 8
-	},
-/area/lv624/ground/sand8)
+/obj/structure/dispenser/oxygen,
+/obj/structure/largecrate/random,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
 "agV" = (
 /obj/item/ammo_casing,
 /turf/open/floor/plating/ground/dirt,
@@ -1388,10 +1392,15 @@
 /turf/open/floor,
 /area/lv624/ground/sand2)
 "agZ" = (
-/turf/open/ground/coast/corner{
-	dir = 4
+/obj/machinery/colony_floodlight_switch{
+	pixel_y = 30
 	},
-/area/lv624/ground/sand8)
+/obj/effect/decal/warning_stripes{
+	pixel_y = 30
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
 "aha" = (
 /obj/structure/cargo_container/horizontal,
 /turf/open/floor,
@@ -1400,11 +1409,9 @@
 /turf/open/floor/scorched,
 /area/lv624/ground/sand2)
 "ahc" = (
-/obj/structure/catwalk,
-/turf/open/ground/coast{
-	dir = 4
-	},
-/area/lv624/ground/sand8)
+/obj/machinery/computer/nuke_disk_generator/blue,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "ahd" = (
 /obj/structure/cargo_container/green{
 	dir = 8
@@ -1434,41 +1441,10 @@
 	},
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/ground/caves/east1)
-"ahj" = (
-/obj/machinery/floodlight,
-/obj/item/ammo_casing,
-/turf/open/floor/plating/warning{
-	dir = 9
-	},
-/area/lv624/ground/tfort)
-"ahk" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 1
-	},
-/turf/open/floor/plating/warning{
-	dir = 1
-	},
-/area/lv624/ground/tfort)
-"ahl" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 1
-	},
-/obj/item/ammo_casing,
-/turf/open/floor/plating/warning{
-	dir = 1
-	},
-/area/lv624/ground/tfort)
 "ahm" = (
-/turf/open/floor/plating/warning{
-	dir = 1
-	},
-/area/lv624/ground/tfort)
-"ahn" = (
-/obj/machinery/floodlight,
-/turf/open/floor/plating/warning{
-	dir = 5
-	},
-/area/lv624/ground/tfort)
+/obj/machinery/vending/engineering,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "aho" = (
 /turf/open/floor/marking/loadingarea{
 	dir = 1
@@ -1497,25 +1473,16 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand4)
 "ahv" = (
-/obj/structure/mineral_door/resin,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/sand2)
+/obj/machinery/power/smes/buildable/empty{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/platebotc,
+/area/lv624/lazarus/engineering)
 "ahw" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/sand2)
-"ahx" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 8
-	},
-/turf/open/floor/plating/warning{
-	dir = 8
-	},
-/area/lv624/ground/tfort)
-"ahy" = (
-/obj/item/ammo_magazine/smg/uzi/extended,
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
+/area/lv624/ground/caves/central3)
 "ahz" = (
 /obj/structure/disposalpipe/junction/flipped{
 	dir = 8
@@ -1528,35 +1495,17 @@
 "ahA" = (
 /turf/open/floor/plating,
 /area/lv624/ground/sand2)
-"ahB" = (
-/obj/item/ammo_casing,
-/obj/item/ammo_casing,
-/obj/item/ammo_casing,
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
 "ahC" = (
-/obj/machinery/floodlight,
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
-"ahD" = (
-/obj/item/ammo_casing,
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
-"ahE" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 4
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Engineering Dome"
 	},
-/turf/open/floor/plating/warning{
-	dir = 4
-	},
-/area/lv624/ground/tfort)
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "ahF" = (
-/obj/structure/fence,
-/turf/open/floor/plating/warning{
-	dir = 1
-	},
-/area/lv624/ground/sand8)
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/warning,
+/area/lv624/lazarus/engineering)
 "ahG" = (
 /obj/structure/ore_box,
 /turf/open/floor,
@@ -1572,30 +1521,30 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand3)
 "ahJ" = (
-/turf/closed/wall/cult,
-/area/lv624/ground/sand4)
+/obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/engineering)
 "ahK" = (
-/turf/closed/wall/cult,
-/area/lv624/ground/sand2)
-"ahL" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 8
-	},
-/obj/effect/decal/remains/human,
+/obj/structure/cable,
 /turf/open/floor/plating/warning{
-	dir = 8
+	dir = 4
 	},
-/area/lv624/ground/tfort)
+/area/lv624/lazarus/engineering)
+"ahL" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/engineering)
 "ahM" = (
-/obj/item/ammo_casing,
-/obj/item/ammo_casing,
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
-"ahN" = (
-/obj/item/attachable/reddot,
-/obj/effect/alien/weeds/node,
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
+/obj/machinery/power/geothermal,
+/obj/structure/lattice,
+/obj/structure/cable,
+/turf/open/floor/plating/warning{
+	dir = 9
+	},
+/area/lv624/lazarus/engineering)
 "ahO" = (
 /obj/structure/fence,
 /turf/open/floor/marking/warning,
@@ -1628,22 +1577,13 @@
 /turf/open/ground/river,
 /area/lv624/ground/sand8)
 "ahY" = (
-/obj/effect/decal/cleanable/blood,
-/obj/item/weapon/gun/smg/uzi,
-/obj/effect/alien/weeds/node,
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
-"ahZ" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
-"aia" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 1
+/obj/machinery/power/geothermal,
+/obj/structure/lattice,
+/obj/structure/cable,
+/turf/open/floor/plating/warning{
+	dir = 8
 	},
-/obj/item/healthanalyzer,
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
+/area/lv624/lazarus/engineering)
 "aib" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1653,13 +1593,6 @@
 	dir = 6
 	},
 /area/lv624/ground/filtration)
-"aic" = (
-/obj/effect/decal/remains/human,
-/obj/structure/table/reinforced/flipped{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
 "aid" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4
@@ -1669,10 +1602,6 @@
 	dir = 2
 	},
 /area/lv624/ground/filtration)
-"aie" = (
-/obj/item/flashlight/lantern,
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
 "aig" = (
 /obj/structure/fence,
 /turf/open/floor/marking/warning{
@@ -1712,40 +1641,36 @@
 /turf/open/floor/freezer,
 /area/lv624/lazarus/toilet)
 "aio" = (
-/obj/structure/mineral_door/resin,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/sand4)
-"aip" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 8
+/obj/machinery/power/geothermal,
+/obj/structure/lattice,
+/obj/structure/cable,
+/turf/open/floor/plating/warning{
+	dir = 5
 	},
-/obj/item/explosive/grenade/incendiary,
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
+/area/lv624/lazarus/engineering)
 "aiq" = (
-/obj/item/attachable/bayonet,
-/obj/item/ammo_magazine/smg/uzi/extended,
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
-"air" = (
-/obj/effect/decal/cleanable/blood/oil,
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
-"ais" = (
-/obj/effect/decal/remains/human,
-/obj/item/weapon/gun/smg/m25,
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
-"ait" = (
-/obj/structure/table/reinforced/flipped{
+/obj/machinery/power/geothermal,
+/obj/structure/lattice,
+/obj/structure/cable,
+/turf/open/floor/plating/warning{
 	dir = 4
 	},
+/area/lv624/lazarus/engineering)
+"ais" = (
+/obj/machinery/power/apc/drained,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/lv624/ground/tfort)
+/area/lv624/lazarus/engineering)
+"ait" = (
+/obj/machinery/vending/engivend,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "aiu" = (
-/obj/item/weapon/gun/shotgun/pump/cmb,
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "aiv" = (
 /obj/structure/jungle/vines,
 /turf/open/ground/coast/corner{
@@ -1768,50 +1693,30 @@
 /obj/structure/jungle/vines/heavy,
 /turf/closed/gm/dense,
 /area/lv624/ground/river3)
-"aiB" = (
-/turf/open/floor/plating/warning{
-	dir = 8
-	},
-/area/lv624/ground/tfort)
-"aiC" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 8
-	},
-/obj/item/explosive/grenade/frag,
-/obj/item/ammo_magazine/smg/m25,
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
 "aiD" = (
-/obj/item/attachable/quickfire,
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/engineering)
 "aiE" = (
-/obj/structure/table,
-/obj/item/storage/belt/marine,
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
-"aiF" = (
-/obj/item/ammo_magazine/smg/m25,
-/obj/item/ammo_magazine/smg/m25,
-/obj/item/ammo_magazine/smg/m25,
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
-"aiG" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 4
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
 	},
-/obj/item/ammo_magazine/smg/m25,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/lv624/ground/tfort)
+/area/lv624/lazarus/engineering)
 "aiH" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
-"aiI" = (
-/turf/open/floor/plating/warning{
+/obj/structure/bed/stool,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/area/lv624/ground/tfort)
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"aiI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "aiJ" = (
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/river2)
@@ -1869,11 +1774,14 @@
 "aiV" = (
 /obj/structure/girder/displaced,
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/sand4)
+/area/lv624/ground/caves/west1)
 "aiW" = (
-/obj/machinery/floodlight,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/lv624/ground/tfort)
+/area/lv624/lazarus/engineering)
 "aiX" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/structure/disposalpipe/segment{
@@ -1885,31 +1793,33 @@
 	},
 /area/lv624/ground/filtration)
 "aiY" = (
-/obj/structure/table,
-/obj/item/storage/backpack/marine,
-/obj/item/explosive/grenade/incendiary,
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
-"aiZ" = (
-/obj/machinery/floodlight,
-/obj/item/ammo_casing,
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
-"aja" = (
-/obj/structure/table,
-/obj/item/ammo_casing,
-/obj/item/weapon/gun/pistol/holdout,
-/obj/item/attachable/suppressor,
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
-"ajb" = (
-/obj/structure/table/reinforced/flipped{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/item/explosive/grenade/incendiary,
-/obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating,
-/area/lv624/ground/tfort)
+/area/lv624/lazarus/engineering)
+"aiZ" = (
+/obj/machinery/light,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"aja" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"ajb" = (
+/obj/item/weapon/gun/pistol/rt3,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "ajc" = (
 /turf/open/ground/coast/corner,
 /area/lv624/ground/sand2)
@@ -1959,45 +1869,14 @@
 /obj/structure/jungle/vines/heavy,
 /turf/open/ground/coast,
 /area/lv624/ground/river3)
-"ajo" = (
-/obj/item/ammo_casing,
-/turf/open/floor/plating/warning{
-	dir = 8
-	},
-/area/lv624/ground/tfort)
-"ajp" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 8
-	},
-/obj/item/ammo_magazine/pistol,
-/obj/item/ammo_casing,
-/obj/item/ammo_magazine/smg/m25,
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
-"ajq" = (
-/obj/effect/decal/remains/human,
-/obj/item/ammo_casing,
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
-"ajr" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/o2{
-	pixel_x = 4;
-	pixel_y = 6
-	},
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
 "ajs" = (
-/obj/effect/decal/remains/human,
-/obj/item/ammo_casing,
-/obj/item/ammo_casing,
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	dir = 1;
+	name = "\improper Engineering Dome"
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/lv624/ground/tfort)
+/area/lv624/lazarus/engineering)
 "ajt" = (
 /obj/effect/alien/weeds/node,
 /obj/structure/disposalpipe/segment{
@@ -2005,12 +1884,6 @@
 	},
 /turf/open/floor/plating/catwalk,
 /area/lv624/ground/sand9)
-"aju" = (
-/obj/item/ammo_casing,
-/turf/open/floor/plating/warning{
-	dir = 4
-	},
-/area/lv624/ground/tfort)
 "ajv" = (
 /turf/open/ground/coast/corner2,
 /area/lv624/ground/sand2)
@@ -2071,32 +1944,27 @@
 /turf/open/floor/plating/warning,
 /area/lv624/ground/sand8)
 "ajM" = (
-/obj/item/ammo_casing,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/sand8)
+/obj/machinery/power/monitor{
+	name = "Main Power Grid Monitoring"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
 "ajN" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 8
-	},
+/obj/structure/cable,
+/obj/machinery/power/geothermal,
 /turf/open/floor/plating,
-/area/lv624/ground/tfort)
-"ajO" = (
-/obj/item/ammo_casing,
-/obj/item/weapon/gun/pistol/rt3,
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
+/area/lv624/lazarus/engineering)
 "ajP" = (
-/obj/effect/decal/cleanable/blood,
-/obj/item/ammo_casing,
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
-"ajQ" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 4
+/obj/structure/extinguisher_cabinet{
+	dir = 1
 	},
-/obj/item/attachable/suppressor,
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"ajQ" = (
+/obj/structure/rack,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "ajR" = (
 /turf/open/ground/river,
 /area/lv624/ground/sand8)
@@ -2110,10 +1978,10 @@
 /turf/open/floor/mech_bay_recharge_floor/asteroid,
 /area/lv624/ground/caves/west1)
 "ajY" = (
-/turf/open/ground/coast/corner{
-	dir = 1
-	},
-/area/lv624/ground/sand8)
+/obj/item/clothing/head/hardhat/orange,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "ajZ" = (
 /obj/effect/decal/remains/xeno,
 /turf/open/floor/plating/ground/dirt,
@@ -2123,16 +1991,15 @@
 /turf/open/floor/plating/catwalk,
 /area/lv624/ground/sand8)
 "akb" = (
-/obj/structure/table/reinforced/flipped,
-/obj/effect/decal/remains/human,
-/obj/item/ammo_casing,
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
+/obj/effect/landmark/start/job/survivor,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "akc" = (
-/obj/structure/table/reinforced/flipped,
-/obj/item/explosive/grenade/incendiary,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/alien/weeds/node,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/lv624/ground/tfort)
+/area/lv624/lazarus/engineering)
 "ake" = (
 /obj/structure/jungle/vines,
 /obj/structure/jungle/vines/heavy,
@@ -2153,7 +2020,7 @@
 /turf/open/floor/freezer,
 /area/lv624/lazarus/kitchen)
 "akl" = (
-/turf/open/ground/coast/corner,
+/turf/closed/wall/indestructible/mineral,
 /area/lv624/ground/sand8)
 "akm" = (
 /turf/open/ground/coast/corner2,
@@ -2163,14 +2030,9 @@
 /turf/open/floor/plating/catwalk,
 /area/lv624/ground/river2)
 "ako" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 4
-	},
-/obj/item/ammo_magazine/smg/uzi/extended,
-/turf/open/floor/plating/warning{
-	dir = 4
-	},
-/area/lv624/ground/tfort)
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
 "akp" = (
 /obj/structure/jungle/plantbot1/alien,
 /turf/open/ground/river,
@@ -2198,11 +2060,6 @@
 /obj/structure/jungle/vines/heavy,
 /turf/open/ground/river,
 /area/lv624/ground/river3)
-"akv" = (
-/obj/machinery/power/apc/drained,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/lv624/lazarus/engineering)
 "akw" = (
 /obj/structure/jungle/vines/heavy,
 /obj/structure/jungle/plantbot1/alien,
@@ -2231,9 +2088,10 @@
 	},
 /area/lv624/ground/river2)
 "akD" = (
-/obj/item/weapon/gun/smg/uzi,
+/obj/structure/window_frame/colony/reinforced,
+/obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
-/area/lv624/ground/tfort)
+/area/lv624/lazarus/engineering)
 "akE" = (
 /turf/open/ground/coast{
 	dir = 1
@@ -2302,8 +2160,7 @@
 	},
 /area/lv624/ground/river3)
 "akX" = (
-/obj/structure/girder,
-/turf/open/floor/tile/red/yellowfull,
+/turf/closed/wall/r_wall,
 /area/lv624/ground/sand4)
 "akY" = (
 /obj/item/analyzer,
@@ -2333,40 +2190,34 @@
 	},
 /area/lv624/ground/river2)
 "ale" = (
-/obj/machinery/floodlight,
-/turf/open/floor/plating/warning{
-	dir = 10
+/obj/machinery/door/airlock/colony/engineering/smes{
+	dir = 1
 	},
-/area/lv624/ground/tfort)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
 "alf" = (
-/obj/structure/table/reinforced/flipped,
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/structure/cable,
 /turf/open/floor/plating/warning{
-	dir = 2
+	dir = 4
 	},
-/area/lv624/ground/tfort)
+/area/lv624/lazarus/engineering)
 "alg" = (
-/obj/structure/table/reinforced/flipped{
-	dir = 2
-	},
-/turf/open/floor/plating/warning{
-	dir = 2
-	},
-/area/lv624/ground/tfort)
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/engineering)
 "alh" = (
-/obj/structure/table/reinforced/flipped,
-/obj/item/ammo_magazine/smg/uzi/extended,
-/turf/open/floor/plating/warning{
-	dir = 2
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
 	},
-/area/lv624/ground/tfort)
+/obj/structure/cable,
+/obj/machinery/power/monitor,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
 "ali" = (
-/obj/machinery/floodlight,
-/turf/open/floor/plating/warning{
-	dir = 6
-	},
-/area/lv624/ground/tfort)
+/obj/structure/jungle/planttop1,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand8)
 "alj" = (
 /turf/open/ground/coast/corner2{
 	dir = 4
@@ -2463,7 +2314,7 @@
 /turf/open/floor,
 /area/lv624/ground/sand8)
 "alC" = (
-/obj/item/ammo_casing,
+/obj/structure/cable,
 /turf/open/floor,
 /area/lv624/ground/sand8)
 "alE" = (
@@ -2542,12 +2393,9 @@
 /turf/open/floor/plating,
 /area/lv624/ground/sand8)
 "alV" = (
-/obj/item/ammo_casing,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/turf/open/floor,
-/area/lv624/ground/sand8)
+/obj/machinery/vending/coffee,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "alW" = (
 /obj/structure/disposalpipe/junction/flipped{
 	dir = 2
@@ -2839,6 +2687,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor,
 /area/lv624/ground/sand8)
 "amZ" = (
@@ -2955,6 +2804,7 @@
 /area/lv624/ground/sand8)
 "anw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
 /turf/open/floor,
 /area/lv624/ground/sand8)
 "anx" = (
@@ -3251,6 +3101,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
 /turf/open/floor,
 /area/lv624/ground/river2)
 "aoG" = (
@@ -3406,6 +3257,7 @@
 "apq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/alien/weeds/node,
+/obj/structure/cable,
 /turf/open/floor,
 /area/lv624/ground/compound/n)
 "aps" = (
@@ -3452,6 +3304,7 @@
 /area/lv624/lazarus/secure_storage)
 "apC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
 /turf/open/floor,
 /area/lv624/ground/river2)
 "apG" = (
@@ -4015,6 +3868,7 @@
 /area/lv624/ground/jungle7)
 "asO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
 /turf/open/floor,
 /area/lv624/ground/jungle7)
 "asP" = (
@@ -4067,21 +3921,10 @@
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle6)
-"atf" = (
-/turf/open/floor/plating/ground/dirtgrassborder/corner,
-/area/lv624/ground/compound/sw)
 "atg" = (
 /obj/effect/landmark/monkey_spawn,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand1)
-"ati" = (
-/turf/open/floor/plating/ground/dirtgrassborder/corner{
-	dir = 1
-	},
-/area/lv624/ground/compound/sw)
-"atj" = (
-/turf/open/ground/grass,
-/area/lv624/ground/compound/sw)
 "atk" = (
 /turf/open/floor/plating/warning{
 	dir = 6
@@ -4108,6 +3951,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
 /turf/open/floor,
 /area/lv624/ground/jungle7)
 "atq" = (
@@ -4153,26 +3997,12 @@
 /obj/structure/jungle/plantbot1/alien,
 /turf/open/ground/river,
 /area/lv624/ground/river1)
-"atB" = (
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 4
-	},
-/area/lv624/ground/compound/sw)
 "atC" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/ground/coast/corner{
 	dir = 4
 	},
 /area/lv624/ground/river1)
-"atE" = (
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 8
-	},
-/area/lv624/ground/compound/sw)
-"atF" = (
-/obj/structure/flora/grass/green,
-/turf/open/floor/plating/ground/dirtgrassborder,
-/area/lv624/ground/compound/sw)
 "atG" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -4204,12 +4034,13 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
 /turf/open/floor,
 /area/lv624/ground/jungle7)
 "atP" = (
-/obj/structure/flora/tree/jungle/small,
-/turf/open/floor/plating/ground/dirtgrassborder/corner,
-/area/lv624/ground/jungle7)
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "atQ" = (
 /turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/ground/jungle7)
@@ -4278,11 +4109,6 @@
 	dir = 1
 	},
 /area/lv624/ground/river1)
-"auh" = (
-/obj/structure/jungle/vines,
-/obj/structure/flora/tree/jungle/small,
-/turf/open/ground/grass,
-/area/lv624/ground/jungle9)
 "aui" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/effect/decal/warning_stripes/thin{
@@ -4307,6 +4133,7 @@
 /area/lv624/ground/jungle7)
 "auo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle7)
 "aup" = (
@@ -4323,8 +4150,10 @@
 /turf/open/floor/plating/ground/dirtgrassborder/corner,
 /area/lv624/ground/jungle7)
 "aur" = (
-/turf/open/floor/plating/ground/dirtgrassborder/corner2,
-/area/lv624/ground/jungle7)
+/turf/open/floor/plating/warning{
+	dir = 10
+	},
+/area/lv624/lazarus/engineering)
 "aus" = (
 /turf/open/floor/plating/ground/dirtgrassborder/corner2{
 	dir = 4
@@ -4412,9 +4241,10 @@
 /turf/open/ground/grass,
 /area/lv624/ground/jungle6)
 "auK" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/ground/grass/grass2,
-/area/lv624/ground/jungle7)
+/turf/open/floor/plating/warning{
+	dir = 4
+	},
+/area/lv624/lazarus/engineering)
 "auL" = (
 /obj/structure/jungle/vines,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -4492,18 +4322,24 @@
 /turf/open/ground/grass,
 /area/lv624/ground/jungle6)
 "avf" = (
-/turf/open/ground/jungle,
-/area/lv624/ground/jungle7)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
 "avg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle7)
 "avh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle7)
 "avi" = (
@@ -5546,8 +5382,8 @@
 /area/lv624/lazarus/secure_storage)
 "azI" = (
 /obj/structure/jungle/plantbot1/alien,
-/turf/open/floor/plating/ground/dirtgrassborder/corner{
-	dir = 4
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 8
 	},
 /area/lv624/ground/jungle7)
 "azJ" = (
@@ -5672,6 +5508,7 @@
 /area/lv624/ground/jungle5)
 "aAt" = (
 /obj/structure/jungle/planttop1,
+/obj/structure/jungle/vines/heavy,
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 8
 	},
@@ -5727,10 +5564,12 @@
 /turf/open/ground/grass,
 /area/lv624/ground/jungle6)
 "aAG" = (
-/obj/structure/jungle/vines,
-/obj/structure/jungle/vines/heavy,
-/turf/open/floor/plating/ground/dirtgrassborder,
-/area/lv624/ground/jungle6)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "aAK" = (
 /obj/structure/table,
 /obj/item/reagent_containers/hypospray,
@@ -5819,12 +5658,12 @@
 	},
 /area/lv624/ground/river1)
 "aBf" = (
-/obj/structure/jungle/vines,
-/obj/structure/jungle/vines/heavy,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 4
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	dir = 1;
+	name = "\improper Engineering Dome"
 	},
-/area/lv624/ground/jungle6)
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "aBg" = (
 /obj/structure/jungle/vines,
 /obj/structure/jungle/vines/heavy,
@@ -6239,6 +6078,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/n)
 "aDC" = (
@@ -6386,6 +6226,7 @@
 	name = "\improper Research Dome"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/research)
 "aES" = (
@@ -6455,9 +6296,14 @@
 	},
 /area/lv624/lazarus/research)
 "aFq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/tile/white,
-/area/lv624/lazarus/research)
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Engineering Dome"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "aFr" = (
 /obj/effect/decal/cleanable/blood/splatter/animated,
 /turf/open/floor/tile/purple/whitepurple{
@@ -6538,7 +6384,7 @@
 /turf/open/floor/marking/warning{
 	dir = 9
 	},
-/area/shuttle/drop2/lz2)
+/area/lv624/ground/jungle6)
 "aFU" = (
 /obj/structure/jungle/plantbot1,
 /turf/open/ground/grass,
@@ -6929,13 +6775,14 @@
 	},
 /area/lv624/lazarus/research)
 "aHN" = (
-/obj/machinery/door/airlock/mainship/research/open/free_access{
-	dir = 1;
-	name = "\improper Research Dome"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/tile/white,
-/area/lv624/lazarus/research)
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/warning{
+	dir = 1
+	},
+/area/lv624/lazarus/engineering)
 "aHP" = (
 /obj/structure/closet/lasertag/red,
 /turf/open/floor/tile/purple/whitepurplecorner{
@@ -6996,7 +6843,7 @@
 "aIl" = (
 /obj/structure/fence,
 /turf/open/floor,
-/area/shuttle/drop2/lz2)
+/area/lv624/ground/jungle6)
 "aIu" = (
 /obj/structure/table,
 /obj/effect/decal/remains/human,
@@ -7072,11 +6919,6 @@
 /obj/structure/jungle/plantbot1,
 /turf/open/ground/grass,
 /area/lv624/ground/compound/ne)
-"aIX" = (
-/obj/structure/powerloader_wreckage,
-/obj/effect/decal/cleanable/blood/oil,
-/turf/open/floor/mech_bay_recharge_floor,
-/area/shuttle/drop2/lz2)
 "aIY" = (
 /obj/effect/decal/cleanable/blood/splatter/animated,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -7593,17 +7435,15 @@
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/main_hall)
 "aLN" = (
-/obj/machinery/door/poddoor/mainship{
-	density = 0;
-	dir = 2;
-	icon_state = "pdoor0";
-	id = "nexus_blast";
-	name = "\improper Nexus Blast Door";
-	opacity = 0
+/obj/structure/sign/electricshock,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/tile/white,
-/area/lv624/lazarus/main_hall)
+/turf/open/floor/plating/warning{
+	dir = 1
+	},
+/area/lv624/lazarus/engineering)
 "aLO" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/machinery/door/poddoor/mainship{
@@ -7838,10 +7678,6 @@
 	dir = 1
 	},
 /area/lv624/ground/jungle5)
-"aMV" = (
-/obj/machinery/landinglight/ds1,
-/turf/open/floor/plating,
-/area/shuttle/drop2/lz2)
 "aNi" = (
 /turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/ground/compound/c)
@@ -8309,21 +8145,6 @@
 "aPA" = (
 /turf/closed/gm/dense,
 /area/lv624/ground/jungle4)
-"aPD" = (
-/obj/machinery/landinglight/ds1{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/drop2/lz2)
-"aPE" = (
-/obj/machinery/camera/autoname/lz_camera,
-/turf/open/floor/plating,
-/area/shuttle/drop2/lz2)
-"aPK" = (
-/turf/open/floor/marking/warning{
-	dir = 6
-	},
-/area/shuttle/drop2/lz2)
 "aPO" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/plating/ground/dirtgrassborder/corner2{
@@ -8505,22 +8326,20 @@
 /obj/structure/cable,
 /turf/open/floor/vault,
 /area/lv624/lazarus/quartstorage)
-"aQD" = (
-/obj/machinery/landinglight/ds1/delayone{
-	dir = 4
+"aQK" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
 	},
 /turf/open/floor/plating,
-/area/shuttle/drop2/lz2)
-"aQK" = (
-/obj/structure/flora/ausbushes/fernybush,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/open/ground/grass,
-/area/lv624/ground/jungle4)
+/area/lv624/lazarus/engineering)
 "aQL" = (
-/turf/open/floor/plating/ground/dirtgrassborder/corner2{
-	dir = 1
-	},
-/area/lv624/ground/jungle4)
+/obj/structure/table/reinforced,
+/obj/item/flashlight,
+/obj/effect/spawner/random/tool,
+/obj/effect/spawner/random/toolbox,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "aQO" = (
 /obj/structure/jungle/vines/heavy,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -8699,9 +8518,7 @@
 /area/lv624/lazarus/quartstorage)
 "aRs" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/ground/dirtgrassborder/corner2{
-	dir = 4
-	},
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle4)
 "aRy" = (
 /turf/open/ground/grass,
@@ -8793,12 +8610,6 @@
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating,
 /area/lv624/lazarus/quartstorage)
-"aRU" = (
-/obj/machinery/landinglight/ds1/delayone{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/drop2/lz2)
 "aRV" = (
 /obj/effect/decal/remains/human,
 /obj/structure/jungle/vines,
@@ -9177,16 +8988,9 @@
 	},
 /area/shuttle/drop1/lz1)
 "aTy" = (
-/obj/structure/jungle/vines,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/dirtgrassborder/corner{
-	dir = 8
-	},
-/area/lv624/ground/jungle4)
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "aTz" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 1
 	},
@@ -9397,29 +9201,6 @@
 /obj/structure/jungle/vines,
 /turf/open/ground/grass,
 /area/lv624/lazarus/robotics)
-"aUE" = (
-/obj/machinery/button/door/open_only/landing_zone/lz2,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/marking/warning{
-	dir = 1
-	},
-/area/shuttle/drop2/lz2)
-"aUF" = (
-/turf/open/floor/marking/warning{
-	dir = 1
-	},
-/area/shuttle/drop2/lz2)
-"aUG" = (
-/turf/open/floor/marking/warning{
-	dir = 5
-	},
-/area/shuttle/drop2/lz2)
 "aUK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/ground/dirt,
@@ -9588,11 +9369,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/drop1/lz1)
-"aVo" = (
-/turf/open/floor/marking/warning{
-	dir = 8
-	},
-/area/shuttle/drop2/lz2)
 "aVt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -9693,9 +9469,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/drop1/lz1)
-"aVS" = (
-/turf/closed/gm/dense,
-/area/shuttle/drop2/lz2)
 "aWa" = (
 /obj/effect/glowshroom,
 /turf/open/floor/freezer,
@@ -9905,20 +9678,9 @@
 "aWX" = (
 /turf/open/floor/plating/ground/dirtgrassborder/corner2,
 /area/shuttle/drop1/lz1)
-"aXb" = (
-/turf/open/floor,
-/area/shuttle/drop2/lz2)
 "aXc" = (
 /turf/open/ground/grass,
 /area/lv624/lazarus/atmos)
-"aXd" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/marking/warning{
-	dir = 1
-	},
-/area/shuttle/drop2/lz2)
 "aXf" = (
 /obj/structure/jungle/plantbot1,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -10067,15 +9829,6 @@
 "aXH" = (
 /turf/open/space/basic,
 /area/lv624/lazarus/robotics)
-"aXM" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor,
-/area/shuttle/drop2/lz2)
-"aXN" = (
-/obj/structure/cable,
-/turf/open/floor,
-/area/shuttle/drop2/lz2)
 "aXT" = (
 /obj/machinery/door/poddoor/mainship{
 	density = 0;
@@ -10164,13 +9917,12 @@
 /turf/open/floor/marking/bot,
 /area/shuttle/drop1/lz1)
 "aYj" = (
-/obj/machinery/floodlight/landing,
-/obj/effect/decal/warning_stripes,
-/turf/open/floor/mech_bay_recharge_floor,
-/area/shuttle/drop2/lz2)
+/obj/effect/alien/weeds/node,
+/turf/open/floor,
+/area/lv624/ground/jungle6)
 "aYp" = (
 /turf/open/floor/marking/bot,
-/area/shuttle/drop2/lz2)
+/area/lv624/ground/compound/sw)
 "aYv" = (
 /obj/structure/flora/grass/green,
 /obj/structure/jungle/vines,
@@ -10325,7 +10077,7 @@
 	dir = 1
 	},
 /turf/open/floor/marking/bot,
-/area/shuttle/drop2/lz2)
+/area/lv624/ground/compound/sw)
 "aZk" = (
 /turf/closed/wall,
 /area/lv624/ground/compound/sw)
@@ -10337,22 +10089,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/sw)
-"aZo" = (
-/obj/machinery/landinglight/ds1/delaytwo,
-/turf/open/floor/plating,
-/area/shuttle/drop2/lz2)
-"aZp" = (
-/obj/machinery/landinglight/ds1/delayone,
-/turf/open/floor/plating,
-/area/shuttle/drop2/lz2)
 "aZu" = (
 /obj/structure/jungle/vines,
 /turf/open/floor/plating/platebotc,
 /area/lv624/ground/jungle9)
-"aZw" = (
-/obj/machinery/landinglight/ds1/delaythree,
-/turf/open/floor/plating,
-/area/shuttle/drop2/lz2)
 "aZx" = (
 /obj/structure/fence,
 /turf/open/ground/grass/grass2,
@@ -10465,12 +10205,6 @@
 /obj/structure/jungle/vines,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle6)
-"aZY" = (
-/obj/machinery/landinglight/ds1/delaythree{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/drop2/lz2)
 "baa" = (
 /obj/structure/flora/ausbushes/leafybush,
 /obj/structure/jungle/vines,
@@ -10805,10 +10539,11 @@
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/main_hall)
 "bbL" = (
-/turf/open/floor/plating/ground/dirtgrassborder/corner{
-	dir = 4
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
 	},
-/area/lv624/lazarus/atmos/outside)
+/turf/open/ground/grass,
+/area/shuttle/drop2/lz2)
 "bbM" = (
 /turf/open/ground/grass/beach,
 /area/lv624/ground/jungle9)
@@ -10930,28 +10665,24 @@
 "bcB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/effect/alien/weeds/node,
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/compound/sw)
+/area/shuttle/drop2/lz2)
 "bcC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/compound/sw)
+/area/shuttle/drop2/lz2)
 "bcD" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/ground/jungle9)
 "bcE" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/open/floor/marking/warning{
 	dir = 8
 	},
-/area/shuttle/drop2/lz2)
+/area/lv624/ground/jungle6)
 "bcK" = (
 /obj/structure/jungle/vines,
 /turf/closed/wall/r_wall,
@@ -11100,21 +10831,22 @@
 	dir = 1
 	},
 /turf/open/floor,
-/area/shuttle/drop2/lz2)
+/area/lv624/ground/jungle6)
 "bdn" = (
-/turf/open/floor/marking/warning,
-/area/shuttle/drop2/lz2)
+/obj/effect/alien/weeds/node,
+/turf/open/floor,
+/area/lv624/ground/jungle4)
 "bdp" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor,
-/area/shuttle/drop2/lz2)
+/area/lv624/ground/jungle6)
 "bdu" = (
 /turf/closed/wall,
 /area/lv624/ground/jungle3)
 "bdH" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /obj/structure/jungle/vines,
-/turf/open/ground/grass/grass2,
+/turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/ground/jungle9)
 "bdK" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -11569,13 +11301,10 @@
 /turf/open/floor,
 /area/shuttle/drop1/lz1)
 "bfK" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 5
-	},
-/turf/open/floor/plating/ground/dirtgrassborder/corner{
-	dir = 8
-	},
-/area/lv624/ground/jungle3)
+/obj/item/ammo_magazine/pistol,
+/obj/structure/cable,
+/turf/open/floor/plating/warning,
+/area/lv624/lazarus/engineering)
 "bfL" = (
 /turf/open/floor/plating/ground/dirtgrassborder/corner,
 /area/lv624/ground/jungle3)
@@ -11589,7 +11318,7 @@
 /area/lv624/ground/jungle3)
 "bfO" = (
 /obj/structure/flora/ausbushes/ywflowers,
-/turf/open/ground/grass,
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle3)
 "bfP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -11612,16 +11341,8 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/c)
 "bfY" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/ground/dirtgrassborder/corner2{
-	dir = 1
-	},
-/area/lv624/ground/compound/sw)
-"bfZ" = (
-/obj/machinery/landinglight/ds1{
-	dir = 8
-	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
 /area/shuttle/drop2/lz2)
 "bgc" = (
 /obj/structure/flora/ausbushes/fernybush,
@@ -11693,7 +11414,7 @@
 /turf/open/floor/marking/warning{
 	dir = 10
 	},
-/area/shuttle/drop2/lz2)
+/area/lv624/ground/compound/sw)
 "bgx" = (
 /obj/structure/largecrate/random,
 /turf/open/floor/marking/warning{
@@ -11718,10 +11439,6 @@
 	},
 /turf/open/ground/grass,
 /area/lv624/ground/jungle3)
-"bgH" = (
-/obj/structure/fence,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/compound/sw)
 "bgL" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/ground/grass/grass2,
@@ -11943,7 +11660,9 @@
 /area/lv624/ground/jungle3)
 "bif" = (
 /obj/structure/flora/ausbushes/brflowers,
-/turf/open/ground/grass,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
+	},
 /area/lv624/ground/jungle9)
 "bim" = (
 /obj/structure/bed,
@@ -12260,13 +11979,6 @@
 	dir = 1
 	},
 /area/lv624/ground/jungle3)
-"bjH" = (
-/turf/closed/wall/r_wall,
-/area/lv624/lazarus/engineering)
-"bjJ" = (
-/obj/structure/jungle/vines,
-/turf/closed/wall/r_wall,
-/area/lv624/lazarus/engineering)
 "bjK" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/machinery/door/poddoor/mainship{
@@ -12390,41 +12102,16 @@
 	dir = 4
 	},
 /area/lv624/ground/jungle1)
-"bkw" = (
-/obj/structure/dispenser/oxygen,
-/obj/structure/largecrate/random,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/lv624/lazarus/engineering)
 "bkz" = (
-/obj/machinery/vending/engineering,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
-"bkA" = (
-/turf/closed/wall,
+/obj/structure/closet/secure_closet/engineering_welding,
+/turf/open/floor/plating/platebot,
 /area/lv624/lazarus/engineering)
 "bkB" = (
-/obj/machinery/colony_floodlight_switch{
-	pixel_y = 30
-	},
-/obj/effect/decal/warning_stripes{
-	pixel_y = 30
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/lv624/lazarus/engineering)
-"bkD" = (
-/obj/machinery/power/smes/buildable/empty{
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/cable,
-/turf/open/floor/plating/platebotc,
-/area/lv624/lazarus/engineering)
-"bkF" = (
-/obj/structure/window_frame/colony/reinforced,
-/obj/structure/jungle/vines,
-/obj/structure/foamedmetal,
-/turf/open/floor/plating,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/tile/dark,
 /area/lv624/lazarus/engineering)
 "bkG" = (
 /obj/structure/window_frame/colony/reinforced,
@@ -12515,31 +12202,9 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/sw)
-"blh" = (
-/obj/effect/alien/weeds/node,
-/turf/open/floor/plating/warning,
-/area/lv624/lazarus/engineering)
-"blj" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/lv624/lazarus/engineering)
 "blk" = (
-/obj/machinery/door/airlock/mainship/engineering/free_access{
-	name = "\improper Engineering Dome"
-	},
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
-"bln" = (
-/obj/structure/cable,
-/obj/machinery/power/terminal{
-	dir = 1
-	},
+/obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/plating/platebot,
-/area/lv624/lazarus/engineering)
-"blo" = (
-/obj/structure/window/framed/colony/reinforced,
-/turf/open/floor/plating,
 /area/lv624/lazarus/engineering)
 "blp" = (
 /obj/structure/window/framed/colony/reinforced,
@@ -12668,45 +12333,19 @@
 	dir = 1
 	},
 /area/lv624/lazarus/quartstorage/outdoors)
-"blO" = (
-/obj/structure/cable,
-/turf/open/floor/plating/warning{
+"blS" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
 	dir = 4
 	},
-/area/lv624/lazarus/engineering)
-"blP" = (
-/obj/machinery/power/geothermal,
-/obj/structure/lattice,
-/obj/structure/cable,
-/turf/open/floor/plating/warning{
-	dir = 9
-	},
-/area/lv624/lazarus/engineering)
-"blR" = (
-/obj/machinery/power/geothermal,
-/obj/structure/lattice,
-/obj/structure/cable,
-/turf/open/floor/plating/warning{
-	dir = 5
-	},
-/area/lv624/lazarus/engineering)
-"blS" = (
-/turf/open/floor/plating/warning{
-	dir = 8
-	},
-/area/lv624/lazarus/engineering)
+/area/lv624/ground/jungle2)
 "blT" = (
-/obj/machinery/power/monitor{
-	name = "Main Power Grid Monitoring"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/lv624/lazarus/engineering)
+/turf/closed/wall/cult,
+/area/lv624/ground/sand8)
 "blU" = (
-/obj/item/clothing/head/hardhat/orange,
-/obj/effect/alien/weeds/node,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
+/obj/effect/decal/remains/xeno,
+/turf/closed/wall/indestructible/mineral,
+/area/lv624/ground/sand8)
 "blY" = (
 /obj/structure/jungle/vines,
 /turf/open/ground/grass,
@@ -12742,8 +12381,8 @@
 /turf/open/floor/plating,
 /area/lv624/lazarus/hop)
 "bme" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
 	},
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/main_hall)
@@ -12792,22 +12431,19 @@
 /obj/structure/largecrate/random,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle1)
-"bmq" = (
-/obj/machinery/landinglight/ds1/delaythree{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/drop2/lz2)
 "bmr" = (
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 4
 	},
 /area/lv624/ground/jungle4)
 "bms" = (
-/turf/open/floor/plating/ground/dirtgrassborder/corner{
+/obj/machinery/light{
 	dir = 4
 	},
-/area/lv624/ground/jungle4)
+/obj/structure/cable,
+/obj/machinery/power/geothermal,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
 "bmu" = (
 /obj/structure/rack,
 /obj/item/attachable/lasersight,
@@ -12865,35 +12501,13 @@
 	dir = 8
 	},
 /area/lv624/ground/jungle3)
-"bmH" = (
-/obj/machinery/power/geothermal,
-/obj/structure/lattice,
-/obj/structure/cable,
-/turf/open/floor/plating/warning{
-	dir = 8
-	},
-/area/lv624/lazarus/engineering)
-"bmJ" = (
-/obj/machinery/power/geothermal,
-/obj/structure/lattice,
-/obj/structure/cable,
-/turf/open/floor/plating/warning{
-	dir = 4
-	},
-/area/lv624/lazarus/engineering)
 "bmK" = (
-/obj/machinery/door/airlock/colony/engineering/smes{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/lv624/lazarus/engineering)
-"bmL" = (
-/obj/structure/sign/directions/engineering{
-	dir = 8
-	},
 /obj/structure/fence,
 /turf/open/floor/plating/ground/dirtgrassborder,
+/area/lv624/ground/jungle2)
+"bmL" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/corner2,
 /area/lv624/ground/compound/se)
 "bmM" = (
 /obj/structure/fence,
@@ -13025,35 +12639,6 @@
 "bnj" = (
 /turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/ground/compound/sw)
-"bnm" = (
-/obj/effect/decal/cleanable/blood/oil,
-/obj/structure/cable,
-/turf/open/floor/plating/warning{
-	dir = 4
-	},
-/area/lv624/lazarus/engineering)
-"bnn" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/power/monitor,
-/turf/open/floor/plating,
-/area/lv624/lazarus/engineering)
-"bno" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
-"bnq" = (
-/obj/machinery/vending/engivend,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
-"bns" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
 "bnt" = (
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/se)
@@ -13073,10 +12658,9 @@
 /turf/open/floor/grimy,
 /area/lv624/lazarus/hop)
 "bny" = (
-/obj/structure/barricade/wooden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/tile/white,
-/area/lv624/lazarus/main_hall)
+/obj/structure/bed/stool,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "bnA" = (
 /obj/item/reagent_containers/food/snacks/grown/banana{
 	pixel_x = -8
@@ -13129,67 +12713,14 @@
 	},
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/secure_storage)
-"bnP" = (
-/turf/open/floor/plating/warning{
-	dir = 10
-	},
-/area/lv624/lazarus/engineering)
-"bnQ" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/lv624/lazarus/engineering)
-"bnR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	on = 1
-	},
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
-"bnS" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/lv624/lazarus/engineering)
-"bnU" = (
-/obj/structure/bed/stool,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/lv624/lazarus/engineering)
-"bnV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
-"bnW" = (
-/obj/machinery/door/airlock/mainship/engineering/free_access{
-	name = "\improper Engineering Dome"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
 "bnX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/compound/se)
+/obj/effect/spawner/random/powercell,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "bnY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/effect/alien/weeds/node,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/compound/se)
+/obj/structure/closet/secure_closet/engineering_personal,
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/engineering)
 "bnZ" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/dirtgrassborder/corner2{
@@ -13214,26 +12745,22 @@
 /turf/open/floor/plating,
 /area/lv624/lazarus/hop)
 "bod" = (
-/obj/item/stack/sheet/wood,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/turf/open/floor/tile/white,
-/area/lv624/lazarus/main_hall)
+/obj/structure/rack,
+/obj/effect/spawner/random/tool,
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/engineering)
 "boe" = (
-/obj/structure/barricade/wooden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/tile/white,
-/area/lv624/lazarus/main_hall)
+/obj/structure/table/reinforced,
+/obj/item/tool/lighter,
+/obj/item/analyzer,
+/obj/item/multitool,
+/obj/item/assembly/prox_sensor,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "bof" = (
-/obj/item/stack/sheet/wood,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/turf/open/floor/tile/white,
-/area/lv624/lazarus/main_hall)
+/obj/machinery/power/port_gen/pacman/super,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "bog" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/structure/barricade/wooden,
@@ -13348,94 +12875,14 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/sw)
-"boD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/lv624/lazarus/engineering)
-"boE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/alien/weeds/node,
-/turf/open/floor/plating/warning{
-	dir = 1
-	},
-/area/lv624/lazarus/engineering)
-"boF" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plating/warning{
-	dir = 1
-	},
-/area/lv624/lazarus/engineering)
-"boG" = (
-/obj/structure/sign/electricshock,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plating/warning{
-	dir = 1
-	},
-/area/lv624/lazarus/engineering)
-"boH" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/lv624/lazarus/engineering)
-"boI" = (
-/obj/machinery/light,
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/alien/weeds/node,
-/turf/open/floor/plating,
-/area/lv624/lazarus/engineering)
-"boJ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/turf/open/floor/plating,
-/area/lv624/lazarus/engineering)
-"boK" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/lv624/lazarus/engineering)
-"boL" = (
-/obj/item/weapon/gun/pistol/rt3,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
-"boM" = (
-/obj/structure/table/reinforced,
-/obj/item/folder,
-/obj/item/assembly/signaler,
-/obj/item/radio/survivor,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
-"boN" = (
-/obj/structure/table/reinforced,
-/obj/item/flashlight,
-/obj/effect/spawner/random/tool,
-/obj/effect/spawner/random/toolbox,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
 "boP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/compound/se)
+/obj/structure/bookcase,
+/obj/item/book/manual/engineering_construction,
+/obj/item/book/manual/engineering_guide,
+/obj/item/book/manual/engineering_hacking,
+/obj/item/book/manual/atmospipes,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "boQ" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/dirt,
@@ -13580,22 +13027,16 @@
 	dir = 1
 	},
 /area/lv624/ground/compound/sw)
-"bpI" = (
-/obj/structure/window_frame/colony/reinforced,
-/turf/open/floor/plating,
-/area/lv624/lazarus/engineering)
 "bpJ" = (
-/obj/item/ammo_magazine/pistol,
-/obj/structure/cable,
-/turf/open/floor/plating/warning,
-/area/lv624/lazarus/engineering)
-"bpM" = (
-/obj/machinery/door/airlock/mainship/engineering/free_access{
-	dir = 1;
-	name = "\improper Engineering Dome"
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
 	},
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
+/area/lv624/ground/jungle2)
+"bpM" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle2)
 "bpN" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -13676,42 +13117,37 @@
 	},
 /area/lv624/ground/jungle2)
 "bqh" = (
-/obj/structure/fence,
-/turf/open/ground/grass,
-/area/lv624/ground/jungle2)
+/obj/machinery/floodlight,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand8)
 "bqj" = (
+/obj/machinery/floodlight,
 /obj/structure/cable,
-/obj/machinery/power/geothermal,
-/turf/open/floor/plating,
-/area/lv624/lazarus/engineering)
+/turf/open/floor,
+/area/lv624/ground/sand8)
 "bqm" = (
-/obj/structure/closet/secure_closet/engineering_welding,
-/turf/open/floor/plating/platebot,
-/area/lv624/lazarus/engineering)
-"bqn" = (
-/obj/structure/extinguisher_cabinet{
+/obj/effect/decal/warning_stripes/thin{
 	dir = 1
 	},
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
-"bqo" = (
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
+/obj/machinery/floodlight,
+/turf/open/floor,
+/area/lv624/ground/sand8)
 "bqp" = (
-/obj/structure/rack,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
+/turf/open/floor/plating/ground/dirtgrassborder/corner2,
+/area/lv624/ground/jungle2)
 "bqq" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
+/obj/structure/cable,
+/turf/open/floor,
+/area/lv624/ground/sand8)
 "bqr" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
-/turf/open/floor/plating/platebot,
-/area/lv624/lazarus/engineering)
+/obj/structure/catwalk,
+/turf/open/ground/coast{
+	dir = 9
+	},
+/area/lv624/ground/river3)
 "bqs" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/ground/dirtgrassborder/corner,
@@ -13780,75 +13216,57 @@
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle9)
-"bqL" = (
-/turf/open/floor/plating/ground/dirtgrassborder/corner{
-	dir = 8
-	},
-/area/lv624/ground/jungle2)
-"bqM" = (
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 1
-	},
-/area/lv624/ground/jungle2)
-"bqN" = (
-/turf/open/floor/plating/ground/dirtgrassborder/corner{
-	dir = 4
-	},
-/area/lv624/ground/jungle2)
 "bqO" = (
 /obj/structure/jungle/vines,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle2)
 "bqR" = (
-/obj/machinery/light{
+/obj/structure/catwalk,
+/turf/open/ground/coast/corner{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/power/geothermal,
-/turf/open/floor/plating,
-/area/lv624/lazarus/engineering)
+/area/lv624/ground/river3)
 "bqS" = (
-/obj/structure/closet/toolcloset,
-/obj/machinery/light{
+/obj/structure/jungle/plantbot1/alien,
+/obj/structure/catwalk,
+/turf/open/ground/river,
+/area/lv624/ground/river2)
+"bqT" = (
+/obj/effect/alien/weeds/node,
+/obj/structure/jungle/vines,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle2)
+"bqU" = (
+/obj/structure/jungle/vines,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle2)
+"bqV" = (
+/obj/structure/sign/directions/engineering{
 	dir = 8
 	},
-/turf/open/floor/plating/platebot,
-/area/lv624/lazarus/engineering)
-"bqT" = (
-/obj/effect/landmark/start/job/survivor,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
-"bqU" = (
-/obj/effect/decal/cleanable/blood/oil,
-/obj/effect/alien/weeds/node,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
-"bqV" = (
-/obj/structure/bed/stool,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
+/turf/closed/wall,
+/area/lv624/ground/river2)
 "bqW" = (
-/obj/effect/spawner/random/powercell,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
+/obj/structure/catwalk,
+/turf/open/ground/coast/corner{
+	dir = 8
+	},
+/area/lv624/ground/river2)
 "bqX" = (
-/obj/structure/closet/secure_closet/engineering_personal,
-/turf/open/floor/plating/platebot,
-/area/lv624/lazarus/engineering)
+/obj/structure/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirtgrassborder,
+/area/lv624/ground/jungle7)
 "bqY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
+/obj/structure/jungle/vines,
 /obj/effect/alien/weeds/node,
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/compound/se)
+/area/lv624/ground/jungle6)
 "bqZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
+/obj/structure/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
+	dir = 1
 	},
-/obj/effect/alien/weeds/node,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/compound/se)
+/area/lv624/ground/jungle6)
 "brb" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/ground/dirtgrassborder/corner2{
@@ -13938,43 +13356,43 @@
 	},
 /area/lv624/lazarus/secure_storage)
 "brx" = (
-/obj/structure/flora/grass/green,
-/turf/open/ground/grass,
-/area/lv624/ground/jungle2)
+/obj/machinery/landinglight/ds1/delaytwo{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/drop2/lz2)
 "bry" = (
 /obj/structure/flora/ausbushes/fernybush,
-/turf/open/ground/grass,
+/turf/closed/gm/dense,
 /area/lv624/ground/jungle2)
 "brA" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/tool,
-/turf/open/floor/plating/platebot,
-/area/lv624/lazarus/engineering)
+/obj/structure/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 4
+	},
+/area/lv624/ground/jungle7)
 "brB" = (
-/obj/structure/table/reinforced,
-/obj/item/tool/lighter,
-/obj/item/analyzer,
-/obj/item/multitool,
-/obj/item/assembly/prox_sensor,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/jungle/vines/heavy,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle7)
 "brC" = (
-/obj/machinery/power/port_gen/pacman/super,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
+/obj/machinery/floodlight/colony,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle7)
 "brD" = (
-/obj/structure/grille/broken,
-/obj/structure/foamedmetal,
-/turf/open/floor/plating/platebot,
-/area/lv624/lazarus/engineering)
+/obj/structure/fence,
+/obj/structure/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 4
+	},
+/area/lv624/ground/jungle7)
 "brE" = (
-/obj/structure/window_frame/colony/reinforced,
-/obj/structure/foamedmetal,
-/turf/open/floor/plating,
-/area/lv624/lazarus/engineering)
+/turf/open/floor/plating/ground/dirtgrassborder,
+/area/lv624/ground/jungle2)
 "brF" = (
 /obj/structure/jungle/plantbot1,
-/turf/open/ground/grass,
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle2)
 "brH" = (
 /turf/open/ground/coast/corner{
@@ -14025,23 +13443,9 @@
 /obj/structure/flora/tree/jungle/small,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle2)
-"brP" = (
-/obj/structure/jungle/vines,
-/obj/structure/flora/tree/jungle/small,
-/turf/open/ground/grass,
-/area/lv624/ground/jungle2)
 "brQ" = (
-/obj/effect/landmark/monkey_spawn,
 /turf/open/ground/grass,
-/area/lv624/ground/jungle2)
-"brR" = (
-/obj/structure/bookcase,
-/obj/item/book/manual/engineering_construction,
-/obj/item/book/manual/engineering_guide,
-/obj/item/book/manual/engineering_hacking,
-/obj/item/book/manual/atmospipes,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
+/area/shuttle/drop2/lz2)
 "brS" = (
 /obj/structure/jungle/vines,
 /turf/closed/wall,
@@ -14133,29 +13537,14 @@
 /obj/structure/largecrate/supply/supplies/water,
 /turf/open/floor/plating/platebot,
 /area/lv624/lazarus/secure_storage)
-"bsg" = (
-/obj/structure/foamedmetal,
-/turf/open/ground/grass,
-/area/lv624/ground/jungle2)
-"bsh" = (
-/obj/structure/flora/grass/green,
-/obj/structure/foamedmetal,
-/turf/open/ground/grass,
-/area/lv624/ground/jungle2)
-"bsi" = (
-/obj/structure/jungle/planttop1,
-/turf/open/ground/grass,
-/area/lv624/ground/jungle2)
 "bsl" = (
 /obj/structure/jungle/vines,
 /obj/structure/jungle/planttop1,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle3)
 "bsn" = (
-/obj/structure/sign/electricshock{
-	dir = 1
-	},
-/turf/open/ground/grass,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle2)
 "bsp" = (
 /obj/structure/jungle/plantbot1,
@@ -14168,10 +13557,13 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/c)
+"bzO" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/sw)
 "bFI" = (
-/obj/machinery/light,
 /turf/open/floor/marking/warning,
-/area/shuttle/drop2/lz2)
+/area/lv624/ground/compound/sw)
 "bFY" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/tile/dark,
@@ -14188,10 +13580,26 @@
 	dir = 1
 	},
 /area/lv624/ground/jungle7)
+"bIG" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/shuttle/drop2/lz2)
 "bKi" = (
-/obj/machinery/computer/nuke_disk_generator/blue,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
+/obj/structure/fence,
+/obj/structure/jungle/vines/heavy,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle7)
+"bLx" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
+	},
+/area/shuttle/drop2/lz2)
 "bLL" = (
 /turf/closed/wall/resin/thick,
 /area/lv624/ground/caves/west1)
@@ -14214,10 +13622,10 @@
 	},
 /area/lv624/ground/jungle9)
 "bZg" = (
-/obj/item/attachable/quickfire,
-/obj/effect/alien/weeds/node,
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
+/turf/open/floor/plating/warning{
+	dir = 8
+	},
+/area/lv624/lazarus/engineering)
 "bZw" = (
 /obj/machinery/miner/damaged,
 /turf/open/ground/grass,
@@ -14261,16 +13669,18 @@
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/secure_storage)
 "chK" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/obj/structure/fence,
+/obj/structure/jungle/vines/heavy,
 /turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 1
+	dir = 8
 	},
-/area/lv624/ground/compound/sw)
+/area/lv624/ground/jungle7)
 "ciX" = (
 /obj/structure/jungle/vines,
 /obj/structure/jungle/vines,
-/turf/open/ground/grass,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 8
+	},
 /area/lv624/ground/jungle3)
 "clw" = (
 /turf/closed/wall/indestructible/mineral,
@@ -14289,12 +13699,11 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/east1)
 "cnD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/compound/sw)
+/area/lv624/ground/jungle7)
 "cof" = (
 /obj/machinery/floodlight/colony{
 	dir = 4
@@ -14321,41 +13730,42 @@
 /obj/effect/alien/weeds/node,
 /turf/open/floor,
 /area/lv624/ground/sand9)
-"csn" = (
-/obj/machinery/landinglight/ds1/delaytwo{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/drop2/lz2)
 "cuw" = (
 /turf/closed/wall/indestructible/mineral,
 /area/lv624/ground/caves/west1)
 "cvB" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/open/floor/plating/ground/dirtgrassborder,
-/area/lv624/ground/jungle6)
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/floodlight/colony,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle7)
 "cyG" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/sign/botany{
 	dir = 8
 	},
-/turf/open/ground/grass,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 4
+	},
 /area/lv624/ground/jungle7)
-"czY" = (
-/obj/structure/foamedmetal,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/compound/se)
-"cAB" = (
-/obj/effect/spawner/modularmap/lv624/domes,
-/turf/open/space/basic,
-/area/lv624/lazarus/comms)
-"cAZ" = (
+"czS" = (
 /obj/structure/fence,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
+	dir = 1
+	},
+/area/lv624/ground/compound/se)
+"czY" = (
+/obj/structure/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 8
+	},
+/area/lv624/ground/jungle5)
+"cAL" = (
+/obj/structure/jungle/vines,
+/obj/structure/jungle/vines,
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 1
 	},
-/area/lv624/ground/jungle3)
+/area/lv624/ground/jungle2)
 "cBt" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/plating,
@@ -14372,9 +13782,9 @@
 	},
 /area/lv624/lazarus/fitness)
 "cGD" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/open/ground/grass,
-/area/lv624/ground/jungle4)
+/obj/structure/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle5)
 "cIv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -14384,7 +13794,7 @@
 "cJc" = (
 /obj/structure/cargo_container,
 /turf/open/floor/marking/bot,
-/area/shuttle/drop2/lz2)
+/area/lv624/ground/compound/sw)
 "cJN" = (
 /turf/open/floor/plating/warning{
 	dir = 9
@@ -14395,6 +13805,10 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral,
 /area/lv624/ground/caves/central1)
+"cQH" = (
+/obj/machinery/landinglight/ds1/delaytwo,
+/turf/open/floor/plating,
+/area/shuttle/drop2/lz2)
 "cRw" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -14437,6 +13851,12 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral,
 /area/lv624/ground/caves/central3)
+"cZJ" = (
+/obj/structure/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder/corner{
+	dir = 8
+	},
+/area/lv624/ground/jungle2)
 "cZY" = (
 /obj/structure/catwalk,
 /turf/open/ground/coast/corner2{
@@ -14451,19 +13871,16 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/mineral/sandstone,
 /area/lv624/ground/caves/east1)
-"dcr" = (
-/obj/effect/decal/cleanable/blood/oil,
-/obj/structure/bed/chair/comfy{
+"dcR" = (
+/obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/marking/warning{
-	dir = 4
-	},
+/turf/open/floor/plating/ground/dirt,
 /area/shuttle/drop2/lz2)
-"dgb" = (
-/obj/structure/cable,
-/turf/open/floor/plating/warning,
-/area/lv624/lazarus/engineering)
+"dde" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic,
+/turf/open/floor/plating/ground/dirt,
+/area/shuttle/drop2/lz2)
 "dnE" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -14486,10 +13903,23 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/sw)
+"doV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/plating/ground/dirt,
+/area/shuttle/drop2/lz2)
 "dpa" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/plating/platebotc,
 /area/lv624/lazarus/quartstorage/outdoors)
+"drA" = (
+/obj/structure/fence,
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle2)
 "dtR" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor,
@@ -14566,12 +13996,23 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle6)
+"dQo" = (
+/obj/structure/jungle/vines,
+/obj/structure/jungle/vines,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle2)
 "dRM" = (
 /turf/open/space/basic,
 /area/lv624/ground/jungle9)
-"dVC" = (
-/turf/open/floor/plating,
+"dTj" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirt,
 /area/shuttle/drop2/lz2)
+"dVC" = (
+/turf/open/floor,
+/area/lv624/ground/jungle6)
 "dWl" = (
 /obj/structure/mineral_door/resin,
 /turf/open/floor/plating/ground/dirt,
@@ -14600,6 +14041,13 @@
 /obj/structure/jungle/vines/heavy,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle7)
+"egH" = (
+/obj/structure/jungle/vines,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/ground/grass,
+/area/shuttle/drop2/lz2)
 "ekH" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/indestructible/mineral,
@@ -14632,13 +14080,22 @@
 /turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/ground/jungle4)
 "epV" = (
-/obj/docking_port/stationary/crashmode,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/sand2)
+/area/lv624/ground/compound/n)
 "eql" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/closed/gm/dense,
-/area/lv624/ground/jungle3)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/n)
+"erE" = (
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
+	},
+/area/shuttle/drop2/lz2)
 "esC" = (
 /obj/structure/jungle/plantbot1/alien,
 /turf/open/floor,
@@ -14668,11 +14125,6 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/main_hall)
-"eBP" = (
-/turf/open/floor/plating/warning{
-	dir = 4
-	},
-/area/lv624/lazarus/engineering)
 "eCO" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor,
@@ -14692,15 +14144,10 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/quartstorage/outdoors)
 "eJQ" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/closed/mineral,
-/area/lv624/ground/sand4)
-"eKN" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/shuttle/drop2/lz2)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/n)
 "eLX" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/ground/dirt,
@@ -14718,18 +14165,12 @@
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle9)
-"eXq" = (
-/obj/machinery/landinglight/ds1/delaytwo{
-	dir = 8
+"eSB" = (
+/obj/structure/cargo_container/nt{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/shuttle/drop2/lz2)
-"eYd" = (
-/obj/machinery/vending/cigarette/colony,
-/turf/open/floor/marking/warning{
-	dir = 4
-	},
-/area/shuttle/drop2/lz2)
+/turf/open/floor,
+/area/lv624/ground/compound/sw)
 "fca" = (
 /obj/effect/landmark/monkey_spawn,
 /turf/closed/gm/dense,
@@ -14751,13 +14192,9 @@
 /turf/open/space/basic,
 /area/lv624/ground/jungle9)
 "fkc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/structure/cable,
-/obj/structure/cable,
+/obj/effect/alien/weeds/node,
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/compound/sw)
+/area/lv624/ground/river1)
 "flw" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral,
@@ -14774,6 +14211,12 @@
 /obj/effect/alien/weeds/node,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/quartstorage)
+"fnQ" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
+	dir = 8
+	},
+/area/lv624/ground/compound/sw)
 "fpr" = (
 /obj/structure/jungle/plantbot1,
 /turf/open/floor/plating/ground/dirtgrassborder/corner{
@@ -14802,14 +14245,21 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle8)
 "fug" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/open/ground/grass,
-/area/lv624/ground/jungle6)
+/obj/effect/decal/warning_stripes/thin,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
 "fvw" = (
 /obj/item/reagent_containers/food/snacks/worm,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/ruin)
+"fvx" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/plating/ground/dirt,
+/area/shuttle/drop2/lz2)
 "fvY" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/ground/grass,
@@ -14854,26 +14304,10 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/west1)
-"fEQ" = (
-/obj/machinery/door/airlock/mainship/engineering/free_access{
-	name = "\improper Engineering Dome"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
 "fHY" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/closed/mineral,
-/area/lv624/ground/sand5)
-"fIp" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/ground/grass,
-/area/lv624/ground/jungle3)
+/obj/structure/cargo_container,
+/turf/open/floor,
+/area/lv624/ground/jungle6)
 "fKO" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/jungle/vines,
@@ -14888,13 +14322,10 @@
 /turf/open/floor/tile/barber,
 /area/lv624/lazarus/kitchen)
 "fPb" = (
-/obj/machinery/power/apc/drained,
-/obj/structure/cable,
-/obj/structure/cable,
 /turf/open/floor/marking/warning{
 	dir = 1
 	},
-/area/shuttle/drop2/lz2)
+/area/lv624/ground/jungle4)
 "fPB" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/plating,
@@ -14909,9 +14340,10 @@
 	dir = 1
 	},
 /area/lv624/ground/jungle3)
-"fTB" = (
-/turf/open/space/basic,
-/area/lv624/lazarus/comms)
+"fRV" = (
+/obj/structure/jungle/vines,
+/turf/closed/gm/dense,
+/area/lv624/ground/jungle2)
 "fUr" = (
 /obj/machinery/floodlight/colony{
 	dir = 4
@@ -14946,10 +14378,10 @@
 	},
 /area/lv624/lazarus/research)
 "fYD" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
+/obj/structure/cargo_container{
+	dir = 1
 	},
-/turf/closed/gm/dense,
+/turf/open/floor,
 /area/lv624/ground/jungle6)
 "fZf" = (
 /obj/structure/flora/ausbushes/fullgrass,
@@ -14959,6 +14391,9 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/ground/compound/sw)
+"gcB" = (
+/turf/closed/gm/dense,
+/area/shuttle/drop2/lz2)
 "gdH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -14966,15 +14401,17 @@
 	},
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/compound/sw)
+/area/shuttle/drop2/lz2)
 "gef" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/engine/cult,
 /area/lv624/ground/caves/west2)
 "giD" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/closed/gm/dense,
-/area/lv624/ground/jungle4)
+/obj/structure/cargo_container{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/ground/jungle6)
 "gkq" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/ground/grass/grass2,
@@ -15005,6 +14442,12 @@
 	dir = 8
 	},
 /area/lv624/ground/jungle1)
+"gqi" = (
+/obj/structure/cargo_container{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/ground/compound/sw)
 "gro" = (
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -15029,23 +14472,29 @@
 	},
 /turf/open/ground/grass,
 /area/lv624/ground/jungle5)
+"gBG" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
+	dir = 8
+	},
+/area/lv624/ground/jungle2)
 "gEH" = (
 /obj/effect/decal/warning_stripes/thick{
 	dir = 8
 	},
 /turf/open/floor,
 /area/shuttle/drop1/lz1)
-"gFA" = (
-/obj/structure/window/framed/colony/reinforced,
-/obj/structure/foamedmetal,
-/turf/open/floor/plating,
-/area/lv624/lazarus/engineering)
 "gHn" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/quartstorage/outdoors)
+"gIc" = (
+/obj/machinery/floodlight/landing,
+/obj/effect/decal/warning_stripes,
+/turf/open/floor/mech_bay_recharge_floor,
+/area/shuttle/drop2/lz2)
 "gJa" = (
 /obj/structure/jungle/plantbot1,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -15066,11 +14515,11 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle7)
 "gKE" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/ground/dirtgrassborder{
+/obj/structure/cargo_container/nt{
 	dir = 8
 	},
-/area/lv624/ground/jungle3)
+/turf/open/floor,
+/area/lv624/ground/jungle6)
 "gMe" = (
 /obj/structure/jungle/vines,
 /obj/effect/alien/weeds/node,
@@ -15094,19 +14543,12 @@
 /obj/structure/catwalk,
 /turf/open/ground/river,
 /area/lv624/ground/river3)
-"gPc" = (
-/obj/machinery/door/airlock/mainship/engineering/free_access{
-	dir = 1;
-	name = "\improper Engineering Dome"
-	},
-/turf/open/floor/plating/platebotc,
-/area/lv624/lazarus/engineering)
 "gPv" = (
-/obj/machinery/miner/damaged,
-/turf/open/floor/plating/ground/dirtgrassborder{
+/obj/structure/cargo_container/nt{
 	dir = 1
 	},
-/area/lv624/ground/compound/sw)
+/turf/open/floor,
+/area/lv624/ground/jungle6)
 "gPR" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/alien/egg,
@@ -15126,17 +14568,26 @@
 /area/lv624/ground/sand9)
 "gWo" = (
 /turf/closed/wall/r_wall,
-/area/shuttle/drop2/lz2)
+/area/lv624/ground/jungle6)
 "gXL" = (
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
+/obj/structure/cable,
+/turf/open/floor/plating/warning,
+/area/lv624/lazarus/engineering)
+"gZz" = (
+/turf/open/floor/plating/ground/dirtgrassborder/corner{
+	dir = 8
+	},
+/area/lv624/ground/jungle2)
+"hcx" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
 "hdZ" = (
-/obj/item/ammo_magazine/smg/m25,
-/obj/item/ammo_magazine/smg/m25,
-/obj/item/ammo_magazine/smg/m25,
-/obj/effect/alien/weeds/node,
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	on = 1
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
 "heg" = (
 /obj/structure/flora/tree/jungle,
 /turf/open/ground/grass,
@@ -15155,11 +14606,17 @@
 /obj/effect/spawner/modularmap/lv624/domes,
 /turf/open/space/basic,
 /area/lv624/lazarus/atmos)
+"hkV" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder,
+/area/shuttle/drop2/lz2)
 "hmT" = (
 /obj/structure/jungle/vines,
 /obj/effect/alien/weeds/node,
-/turf/open/floor/plating/platebotc,
-/area/lv624/ground/jungle9)
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/plating/ground/dirt,
+/area/shuttle/drop2/lz2)
 "hnZ" = (
 /turf/open/floor/plating/ground/dirtgrassborder/corner2{
 	dir = 8
@@ -15178,12 +14635,6 @@
 /obj/structure/mineral_door/resin,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/east1)
-"hvg" = (
-/obj/machinery/landinglight/ds1{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/drop2/lz2)
 "hxR" = (
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/dirt,
@@ -15193,9 +14644,8 @@
 /turf/closed/wall/cult,
 /area/lv624/ground/caves/west2)
 "hAH" = (
-/obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/lv624/lazarus/engineering)
+/turf/closed/wall,
+/area/lv624/ground/jungle2)
 "hBj" = (
 /obj/machinery/floodlight/colony{
 	dir = 8
@@ -15216,7 +14666,13 @@
 /area/lv624/lazarus/main_hall)
 "hHD" = (
 /obj/machinery/miner/damaged,
-/turf/open/ground/grass,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"hIj" = (
+/obj/structure/jungle/vines,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle3)
 "hJZ" = (
 /obj/structure/barricade/wooden{
@@ -15238,7 +14694,7 @@
 	dir = 4
 	},
 /turf/open/floor/marking/bot,
-/area/shuttle/drop2/lz2)
+/area/lv624/ground/compound/sw)
 "hVH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -15252,7 +14708,7 @@
 "icy" = (
 /obj/structure/largecrate/random,
 /turf/open/floor/marking/bot,
-/area/shuttle/drop2/lz2)
+/area/lv624/ground/compound/sw)
 "igg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -15307,9 +14763,9 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/west1)
 "ixc" = (
-/obj/docking_port/stationary/marine_dropship/lz2,
-/turf/open/floor/plating,
-/area/shuttle/drop2/lz2)
+/obj/structure/largecrate/random/secure,
+/turf/open/floor,
+/area/lv624/ground/jungle4)
 "ixC" = (
 /obj/structure/jungle/vines,
 /turf/closed/gm/dense,
@@ -15327,31 +14783,41 @@
 /obj/structure/catwalk,
 /turf/open/floor/plating,
 /area/lv624/ground/sand8)
-"iBb" = (
-/obj/effect/decal/warning_stripes/thin{
+"iAU" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/light{
 	dir = 8
 	},
-/turf/closed/wall/r_wall,
+/turf/open/ground/grass,
 /area/shuttle/drop2/lz2)
+"iBb" = (
+/turf/closed/wall/r_wall,
+/area/lv624/ground/compound/sw)
 "iEQ" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/marking/bot,
 /area/shuttle/drop1/lz1)
-"iFV" = (
-/obj/machinery/vending/coffee,
-/obj/structure/foamedmetal,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
 "iGf" = (
+/obj/structure/cargo_container/nt{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/ground/jungle6)
+"iGF" = (
+/obj/structure/cargo_container/nt{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/ground/compound/sw)
+"iGY" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/open/floor/plating/ground/dirtgrassborder,
-/area/lv624/ground/compound/sw)
-"iIt" = (
-/obj/effect/decal/remains/human,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/obj/effect/alien/weeds/node,
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/compound/sw)
+/area/lv624/ground/jungle3)
+"iIt" = (
+/obj/structure/largecrate/random/secure,
+/turf/open/floor,
+/area/lv624/ground/jungle6)
 "iII" = (
 /turf/closed/wall/indestructible/mineral,
 /area/lv624/ground/caves/east1)
@@ -15363,7 +14829,7 @@
 "iLV" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/cult,
-/area/lv624/ground/sand4)
+/area/lv624/ground/caves/west1)
 "iMd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	on = 1
@@ -15408,6 +14874,12 @@
 	dir = 1
 	},
 /area/lv624/ground/jungle3)
+"jcb" = (
+/obj/structure/jungle/plantbot1,
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
+	dir = 1
+	},
+/area/lv624/ground/jungle3)
 "jeV" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/tile/dark,
@@ -15416,6 +14888,12 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/east1)
+"jgU" = (
+/obj/machinery/landinglight/ds1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/drop2/lz2)
 "jij" = (
 /obj/structure/cable,
 /turf/open/floor/marking/warning{
@@ -15433,6 +14911,13 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/sw)
+"jss" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/drained{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/shuttle/drop2/lz2)
 "juq" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/effect/decal/warning_stripes/thin{
@@ -15446,11 +14931,15 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/east2)
-"jvZ" = (
-/obj/effect/decal/cleanable/blood,
-/obj/item/clothing/head/tgmccap/req,
-/turf/open/floor,
+"jvx" = (
+/turf/open/floor/plating/ground/dirt,
 /area/shuttle/drop2/lz2)
+"jxq" = (
+/obj/structure/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder/corner{
+	dir = 4
+	},
+/area/lv624/ground/jungle2)
 "jzT" = (
 /turf/open/floor/plating,
 /area/lv624/ground/filtration)
@@ -15458,12 +14947,6 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand4)
-"jAh" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/marking/warning{
-	dir = 4
-	},
-/area/shuttle/drop2/lz2)
 "jAP" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/tile/barber,
@@ -15474,6 +14957,13 @@
 	},
 /turf/open/floor,
 /area/lv624/ground/compound/n)
+"jFX" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/ground/grass,
+/area/shuttle/drop2/lz2)
 "jGu" = (
 /obj/structure/table,
 /obj/structure/cable,
@@ -15482,16 +14972,18 @@
 	dir = 9
 	},
 /area/lv624/lazarus/sleep_female)
-"jGE" = (
-/obj/structure/jungle/vines,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/ground/grass,
-/area/lv624/ground/jungle3)
 "jGW" = (
 /turf/open/floor/marking/loadingarea{
 	dir = 4
+	},
+/area/lv624/ground/compound/sw)
+"jIm" = (
+/obj/structure/window_frame/colony,
+/obj/structure/jungle/vines,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
 	},
 /area/shuttle/drop2/lz2)
 "jJh" = (
@@ -15509,14 +15001,6 @@
 	dir = 4
 	},
 /area/lv624/ground/compound/c)
-"jLW" = (
-/obj/structure/bed/chair/comfy{
-	dir = 8
-	},
-/turf/open/floor/marking/warning{
-	dir = 4
-	},
-/area/shuttle/drop2/lz2)
 "jMR" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -15529,12 +15013,12 @@
 /turf/open/floor/marking/warning{
 	dir = 4
 	},
-/area/shuttle/drop2/lz2)
+/area/lv624/ground/jungle6)
 "jTU" = (
 /turf/open/floor/marking/warning/corner{
 	dir = 8
 	},
-/area/shuttle/drop2/lz2)
+/area/lv624/ground/jungle4)
 "jUj" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral,
@@ -15551,13 +15035,12 @@
 /obj/machinery/floodlight/colony{
 	dir = 4
 	},
-/turf/open/floor/plating/ground/dirt,
+/turf/open/ground/grass,
 /area/lv624/ground/jungle9)
 "jZC" = (
-/obj/item/clipboard,
-/obj/item/tool/pen,
+/obj/effect/alien/weeds/node,
 /turf/open/floor,
-/area/shuttle/drop2/lz2)
+/area/lv624/ground/compound/sw)
 "kfz" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/tile/whiteyellow/full,
@@ -15566,6 +15049,12 @@
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/ground/jungle7)
+"kgp" = (
+/obj/machinery/landinglight/ds1/delaytwo{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/drop2/lz2)
 "kir" = (
 /obj/docking_port/stationary/crashmode,
 /obj/structure/fence,
@@ -15581,17 +15070,25 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/c)
+"kmn" = (
+/obj/machinery/light,
+/turf/closed/wall/r_wall,
+/area/shuttle/drop2/lz2)
 "knr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/alien/weeds/node,
-/turf/open/floor/tile/white,
-/area/lv624/lazarus/main_hall)
+/obj/structure/largecrate/chick,
+/turf/open/floor,
+/area/lv624/ground/jungle6)
 "krI" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
 /turf/closed/gm/dense,
 /area/lv624/ground/jungle1)
+"ksq" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/closed/wall,
+/area/shuttle/drop2/lz2)
 "ksG" = (
 /turf/open/floor/plating/ground/dirtgrassborder/corner2{
 	dir = 8
@@ -15624,6 +15121,18 @@
 /obj/structure/jungle/vines,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle1)
+"kAC" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
+	dir = 1
+	},
+/area/lv624/ground/jungle2)
+"kBa" = (
+/obj/structure/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
+	},
+/area/lv624/ground/jungle3)
 "kCe" = (
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/dirt,
@@ -15675,6 +15184,12 @@
 /obj/effect/alien/weeds/node,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/c)
+"kKD" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/ground/grass,
+/area/shuttle/drop2/lz2)
 "kMj" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -15686,12 +15201,6 @@
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle6)
-"kPh" = (
-/obj/machinery/floodlight/colony{
-	dir = 8
-	},
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/jungle9)
 "kPi" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/dirt,
@@ -15715,9 +15224,18 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/east2)
+"kTS" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirtgrassborder,
+/area/lv624/ground/jungle3)
+"kUu" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/jungle/vines,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
 "kYu" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/closed/gm/dense,
+/obj/structure/largecrate/guns,
+/turf/open/floor,
 /area/lv624/ground/jungle6)
 "kZI" = (
 /obj/machinery/floodlight/colony,
@@ -15731,10 +15249,17 @@
 /turf/open/space/basic,
 /area/lv624/lazarus/internal_affairs)
 "lcf" = (
-/obj/structure/jungle/vines,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/open/ground/grass,
-/area/lv624/ground/jungle6)
+/obj/effect/decal/warning_stripes/thin,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
 "lcH" = (
 /turf/open/floor,
 /area/lv624/ground/river3)
@@ -15763,14 +15288,23 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/resin/thick,
 /area/lv624/ground/caves/east1)
+"lhf" = (
+/obj/structure/fence,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 8
+	},
+/area/shuttle/drop2/lz2)
 "lhR" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/tile/blue/whitebluecorner,
 /area/lv624/lazarus/medbay)
 "ljt" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/open/floor/plating/ground/dirtgrassborder,
-/area/lv624/ground/compound/sw)
+/obj/structure/cargo_container,
+/turf/open/floor,
+/area/lv624/ground/jungle4)
 "lki" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/tile/green/whitegreencorner,
@@ -15787,6 +15321,10 @@
 	dir = 1
 	},
 /area/lv624/ground/jungle7)
+"lpo" = (
+/obj/structure/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder,
+/area/lv624/ground/jungle3)
 "lpJ" = (
 /turf/open/floor/plating/warning{
 	dir = 2
@@ -15811,6 +15349,12 @@
 /obj/effect/alien/weeds/node,
 /turf/open/floor/plating,
 /area/lv624/lazarus/toilet)
+"luc" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
+	},
+/area/shuttle/drop2/lz2)
 "lwi" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/ground/dirt,
@@ -15826,12 +15370,19 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/alien/weeds/node,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/quartstorage)
 "lxH" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/plating,
 /area/lv624/ground/sand7)
+"lxP" = (
+/obj/machinery/landinglight/ds1{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/drop2/lz2)
 "lyr" = (
 /turf/open/floor/plating/ground/dirtgrassborder/corner2{
 	dir = 1
@@ -15859,10 +15410,9 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/central1)
 "lGO" = (
-/obj/item/ammo_casing,
-/obj/effect/alien/weeds/node,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/lv624/ground/tfort)
+/area/lv624/lazarus/engineering)
 "lIv" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/dirt,
@@ -15873,10 +15423,19 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand2)
-"lRQ" = (
-/obj/effect/decal/cleanable/blood/oil,
-/turf/open/floor,
+"lLQ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/dirt,
 /area/shuttle/drop2/lz2)
+"lQf" = (
+/obj/structure/jungle/vines/heavy,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
 "lSd" = (
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/dirtgrassborder,
@@ -15904,11 +15463,10 @@
 /turf/open/floor/tile/bar,
 /area/lv624/lazarus/canteen)
 "mbU" = (
-/obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/marking/warning{
 	dir = 1
 	},
-/area/shuttle/drop2/lz2)
+/area/lv624/ground/jungle6)
 "mcB" = (
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/dirtgrassborder/corner2{
@@ -15926,6 +15484,10 @@
 	dir = 1
 	},
 /area/lv624/ground/jungle3)
+"mek" = (
+/obj/structure/prop/mainship/hangar_stencil/two,
+/turf/open/floor/plating/ground/dirt,
+/area/shuttle/drop2/lz2)
 "mfF" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 5
@@ -15939,7 +15501,9 @@
 /area/lv624/ground/caves/east1)
 "miq" = (
 /obj/structure/sign/redcross,
-/turf/open/ground/grass,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
+	},
 /area/lv624/ground/jungle7)
 "mjZ" = (
 /obj/structure/sign/botany{
@@ -15962,6 +15526,12 @@
 "mos" = (
 /turf/open/floor/plating/ground/dirtgrassborder/corner2,
 /area/lv624/ground/compound/sw)
+"mqu" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 8
+	},
+/area/lv624/ground/jungle3)
 "mqz" = (
 /obj/structure/mineral_door/resin/thick,
 /turf/open/floor/engine/cult,
@@ -15970,15 +15540,15 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor,
 /area/lv624/ground/sand2)
-"mup" = (
-/obj/machinery/landinglight/ds1/delayone{
-	dir = 1
-	},
-/turf/open/floor/plating,
+"msP" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/closed/wall,
 /area/shuttle/drop2/lz2)
 "mvX" = (
 /obj/docking_port/stationary/crashmode,
-/turf/open/ground/grass,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
+	},
 /area/lv624/ground/jungle7)
 "myp" = (
 /obj/structure/jungle/vines,
@@ -16004,24 +15574,25 @@
 	dir = 4
 	},
 /area/lv624/ground/jungle3)
+"mEj" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
+	dir = 4
+	},
+/area/shuttle/drop2/lz2)
 "mGh" = (
 /obj/machinery/door/airlock/mainship/security/locked/free_access{
 	name = "\improper Nexus Dome Marshal Office"
 	},
 /turf/open/floor,
 /area/lv624/lazarus/security)
-"mLT" = (
-/obj/machinery/computer/shuttle/shuttle_control/dropship2,
-/obj/structure/table/reinforced,
-/turf/open/floor/marking/warning{
-	dir = 4
-	},
-/area/lv624/lazarus/console)
 "mNl" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
+/obj/structure/cargo_container{
+	dir = 1
 	},
-/turf/closed/gm/dense,
+/turf/open/floor,
 /area/lv624/ground/jungle4)
 "mPv" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
@@ -16029,6 +15600,18 @@
 	},
 /turf/open/ground/grass,
 /area/lv624/ground/jungle1)
+"mSv" = (
+/obj/structure/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
+	},
+/area/lv624/ground/jungle2)
+"mTR" = (
+/obj/machinery/landinglight/ds1{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/drop2/lz2)
 "mWY" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral,
@@ -16044,7 +15627,9 @@
 /area/lv624/ground/caves/central1)
 "ndO" = (
 /obj/structure/flora/tree/jungle/small,
-/turf/open/ground/grass,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 4
+	},
 /area/lv624/ground/jungle3)
 "njQ" = (
 /obj/structure/flora/ausbushes/fullgrass,
@@ -16060,15 +15645,15 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle8)
 "npP" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
+/obj/structure/cargo_container{
+	dir = 4
 	},
-/turf/open/ground/grass,
-/area/lv624/ground/jungle3)
+/turf/open/floor,
+/area/lv624/ground/jungle4)
 "nqK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/alien/weeds/node,
+/obj/structure/cable,
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/research)
 "nrB" = (
@@ -16077,30 +15662,23 @@
 /turf/open/ground/grass,
 /area/lv624/ground/jungle1)
 "nsb" = (
-/obj/structure/fence,
-/turf/open/floor/plating/ground/dirtgrassborder/corner2{
-	dir = 4
-	},
-/area/lv624/ground/compound/sw)
+/turf/closed/wall/r_wall,
+/area/shuttle/drop2/lz2)
 "nwR" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 1
-	},
-/area/lv624/ground/jungle4)
-"nzG" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/obj/structure/bed/chair/comfy{
+/obj/structure/cargo_container/nt{
 	dir = 8
 	},
+/turf/open/floor,
+/area/lv624/ground/jungle4)
+"nxx" = (
+/obj/machinery/landinglight/ds1/delayone,
+/turf/open/floor/plating,
+/area/shuttle/drop2/lz2)
+"nzG" = (
 /turf/open/floor/marking/warning{
 	dir = 4
 	},
-/area/shuttle/drop2/lz2)
+/area/lv624/ground/compound/sw)
 "nAc" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/plating/ground/dirt,
@@ -16121,9 +15699,11 @@
 /turf/closed/gm/dense,
 /area/lv624/ground/jungle6)
 "nDI" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/jungle6)
+/obj/structure/cargo_container/nt{
+	dir = 1
+	},
+/turf/open/floor,
+/area/lv624/ground/jungle4)
 "nEe" = (
 /obj/machinery/floodlight/colony{
 	dir = 1
@@ -16137,6 +15717,7 @@
 /obj/structure/sign/redcross{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/n)
 "nEC" = (
@@ -16144,19 +15725,17 @@
 /turf/open/floor/engine/cult,
 /area/lv624/ground/caves/east2)
 "nFI" = (
-/obj/structure/prop/mainship/hangar_stencil/two,
-/turf/open/floor/marking/warning{
-	dir = 10
-	},
-/area/shuttle/drop2/lz2)
+/turf/open/floor,
+/area/lv624/ground/jungle4)
 "nGf" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/main_hall)
 "nGq" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/open/ground/grass,
+/obj/structure/cargo_container/nt{
+	dir = 4
+	},
+/turf/open/floor,
 /area/lv624/ground/jungle4)
 "nMR" = (
 /obj/structure/flora/ausbushes/fullgrass,
@@ -16169,9 +15748,9 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/central1)
 "nQe" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/compound/sw)
+/obj/structure/largecrate/chick,
+/turf/open/floor,
+/area/lv624/ground/jungle4)
 "nSy" = (
 /obj/effect/alien/weeds/node,
 /obj/structure/mineral_door/resin/thick,
@@ -16196,6 +15775,12 @@
 	dir = 1
 	},
 /turf/open/floor/marking/bot,
+/area/lv624/ground/compound/sw)
+"oet" = (
+/obj/machinery/landinglight/ds1/delaythree{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/shuttle/drop2/lz2)
 "oeN" = (
 /turf/closed/wall,
@@ -16250,6 +15835,11 @@
 	dir = 8
 	},
 /area/shuttle/drop1/lz1)
+"osh" = (
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
+	},
+/area/lv624/ground/jungle2)
 "otV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -16300,17 +15890,32 @@
 /turf/open/ground/river,
 /area/lv624/ground/river2)
 "oMU" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/wall/r_wall,
+/area/lv624/ground/jungle4)
+"oNb" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 4
+	},
 /area/shuttle/drop2/lz2)
 "oNd" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/plating,
 /area/lv624/ground/river3)
+"oOC" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/closed/gm/dense,
+/area/lv624/ground/jungle2)
 "oQb" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/quartstorage)
+"oTD" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/shuttle/drop2/lz2)
 "oVq" = (
 /obj/structure/sign/botany{
 	dir = 4
@@ -16335,6 +15940,12 @@
 	dir = 1
 	},
 /area/lv624/ground/jungle9)
+"pjD" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 4
+	},
+/area/lv624/ground/jungle3)
 "pkT" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -16352,7 +15963,9 @@
 "prx" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/sign/botany,
-/turf/open/ground/grass,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
+	},
 /area/lv624/ground/jungle7)
 "prA" = (
 /obj/structure/flora/tree/jungle/small,
@@ -16363,16 +15976,19 @@
 /turf/open/floor/plating/ground/dirtgrassborder/corner{
 	dir = 4
 	},
-/area/lv624/ground/jungle3)
+/area/lv624/ground/compound/sw)
 "ptu" = (
 /obj/machinery/floodlight/colony{
 	dir = 1
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle5)
+"ptS" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/closed/gm/dense,
+/area/shuttle/drop2/lz2)
 "puF" = (
-/obj/structure/girder,
-/turf/open/floor/tile/red/yellowfull,
+/turf/closed/wall/r_wall,
 /area/lv624/ground/shelter)
 "puV" = (
 /turf/open/space/basic,
@@ -16386,8 +16002,9 @@
 	},
 /area/shuttle/drop1/lz1)
 "pxE" = (
-/turf/closed/wall/cult,
-/area/lv624/ground/sand8)
+/obj/structure/largecrate/cow,
+/turf/open/floor,
+/area/lv624/ground/jungle4)
 "pxU" = (
 /obj/machinery/floodlight/colony{
 	dir = 1
@@ -16411,7 +16028,7 @@
 	dir = 4
 	},
 /turf/open/floor/marking/bot,
-/area/shuttle/drop2/lz2)
+/area/lv624/ground/compound/sw)
 "pDe" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/tile/green/greentaupe{
@@ -16428,10 +16045,6 @@
 /obj/machinery/floodlight/colony,
 /turf/open/floor,
 /area/lv624/ground/sand9)
-"pDQ" = (
-/obj/item/paper/manifest,
-/turf/open/floor,
-/area/shuttle/drop2/lz2)
 "pEU" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -16455,6 +16068,13 @@
 /obj/structure/jungle/vines,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle4)
+"pOv" = (
+/obj/structure/window_frame/colony,
+/obj/structure/jungle/vines,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/plating/ground/dirtgrassborder,
+/area/shuttle/drop2/lz2)
 "pPr" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/plating,
@@ -16480,6 +16100,10 @@
 /obj/effect/alien/weeds/node,
 /turf/open/floor/plating,
 /area/lv624/ground/sand8)
+"pZg" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirt,
+/area/shuttle/drop2/lz2)
 "pZl" = (
 /turf/open/ground/coast,
 /area/lv624/ground/jungle9)
@@ -16503,6 +16127,12 @@
 	dir = 4
 	},
 /area/lv624/ground/jungle9)
+"qhe" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/ground/grass,
+/area/shuttle/drop2/lz2)
 "qhx" = (
 /obj/machinery/miner/damaged,
 /turf/open/ground/grass,
@@ -16516,12 +16146,8 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/sw)
 "qkT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/alien/weeds/node,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle2)
 "qlb" = (
 /turf/open/floor/plating/warning{
 	dir = 5
@@ -16541,15 +16167,20 @@
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand2)
+"qrL" = (
+/obj/docking_port/stationary/marine_dropship/lz2,
+/turf/open/floor/plating,
+/area/shuttle/drop2/lz2)
 "qtw" = (
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/ground/river,
 /area/lv624/ground/jungle9)
-"qtN" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
+"quk" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/plating/asteroidfloor,
+/turf/open/floor/plating/ground/dirt,
 /area/shuttle/drop2/lz2)
 "qxe" = (
 /obj/structure/catwalk,
@@ -16560,13 +16191,21 @@
 "qzs" = (
 /turf/closed/gm/dense,
 /area/shuttle/drop1/lz1)
+"qzF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
 "qBt" = (
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/ground/grass/grass2,
 /area/lv624/ground/jungle9)
 "qEL" = (
-/turf/closed/wall/indestructible/mineral,
-/area/lv624/ground/sand5)
+/obj/structure/largecrate/guns,
+/turf/open/floor,
+/area/lv624/ground/jungle4)
 "qGH" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -16578,28 +16217,22 @@
 "qMS" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/sand5)
+/area/lv624/ground/caves/central3)
 "qNX" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/tile/red/full,
 /area/lv624/lazarus/security)
 "qQj" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/bed/chair/comfy{
-	dir = 8
-	},
 /turf/open/floor/marking/warning{
 	dir = 4
 	},
-/area/shuttle/drop2/lz2)
+/area/lv624/ground/jungle4)
 "qSm" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
+	dir = 8
 	},
-/turf/open/ground/grass,
-/area/lv624/ground/jungle6)
+/area/lv624/ground/jungle9)
 "qSA" = (
 /obj/machinery/button/door/open_only/landing_zone,
 /obj/structure/window/reinforced,
@@ -16620,13 +16253,11 @@
 	},
 /area/lv624/lazarus/sleep_female)
 "qXT" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 9
-	},
-/turf/open/floor/plating/ground/dirtgrassborder/corner{
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 4
 	},
-/area/lv624/ground/jungle3)
+/area/lv624/ground/jungle9)
 "qZa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -16640,34 +16271,38 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/west2)
 "rbx" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
+/turf/open/floor/marking/warning{
+	dir = 5
 	},
-/turf/open/ground/grass,
 /area/lv624/ground/jungle4)
 "rbW" = (
-/obj/machinery/miner/damaged,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/alien/weeds/node,
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/caves/west1)
+/area/lv624/ground/jungle9)
 "rgp" = (
 /turf/open/floor/plating/ground/dirtgrassborder/corner{
 	dir = 4
 	},
 /area/lv624/ground/river1)
 "rlb" = (
-/obj/effect/alien/weeds/node,
-/turf/open/floor/plating,
-/area/lv624/ground/tfort)
-"rmy" = (
-/obj/machinery/landinglight/ds1/delaythree{
+/obj/structure/table/reinforced,
+/obj/item/folder,
+/obj/item/assembly/signaler,
+/obj/item/radio/survivor,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"rlc" = (
+/obj/machinery/landinglight/ds1/delayone{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/shuttle/drop2/lz2)
 "rnp" = (
-/obj/structure/jungle/vines,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/open/ground/grass,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/marking/warning{
+	dir = 4
+	},
 /area/lv624/ground/jungle4)
 "rnW" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -16677,9 +16312,10 @@
 /turf/open/floor,
 /area/lv624/ground/jungle7)
 "rsK" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/closed/wall/indestructible/mineral,
-/area/lv624/ground/sand5)
+/turf/open/floor/marking/warning{
+	dir = 8
+	},
+/area/lv624/ground/compound/sw)
 "rtd" = (
 /obj/structure/mineral_door/resin/thick,
 /turf/open/floor/plating/ground/dirt,
@@ -16705,17 +16341,18 @@
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/floor,
 /area/lv624/ground/river3)
+"rzH" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/corner2,
+/area/shuttle/drop2/lz2)
 "rAj" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/bed/chair/comfy{
-	dir = 8
-	},
 /turf/open/floor/marking/warning{
 	dir = 5
 	},
-/area/shuttle/drop2/lz2)
+/area/lv624/ground/compound/sw)
 "rCH" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/tile/purple/whitepurplecorner{
@@ -16734,6 +16371,17 @@
 /obj/effect/alien/weeds/node,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/se)
+"rHv" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/jungle/vines,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
+"rIb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/sw)
 "rJh" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/ground/grass,
@@ -16742,6 +16390,12 @@
 /obj/structure/catwalk,
 /turf/open/ground/coast,
 /area/lv624/ground/jungle9)
+"rKY" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/airlock/multi_tile/mainship/generic,
+/turf/open/floor/plating/ground/dirt,
+/area/shuttle/drop2/lz2)
 "rLa" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -16766,25 +16420,26 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/quartstorage/outdoors)
+"rPI" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/ground/grass,
+/area/shuttle/drop2/lz2)
 "rTb" = (
 /turf/open/space/basic,
 /area/lv624/lazarus/internal_affairs)
 "rXx" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 1
-	},
-/area/lv624/ground/jungle3)
+/obj/structure/largecrate/random/secure,
+/turf/open/floor,
+/area/lv624/ground/compound/sw)
+"rYi" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirt,
+/area/shuttle/drop2/lz2)
 "rYZ" = (
-/obj/structure/bed/chair/comfy{
-	dir = 8
-	},
 /turf/open/floor/marking/warning{
 	dir = 6
 	},
-/area/shuttle/drop2/lz2)
+/area/lv624/ground/compound/sw)
 "sax" = (
 /obj/effect/decal/warning_stripes/thick{
 	dir = 4
@@ -16811,12 +16466,9 @@
 /turf/open/floor/tile/bar,
 /area/lv624/lazarus/canteen)
 "siq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/alien/weeds/node,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/compound/se)
+/obj/structure/largecrate/random,
+/turf/open/floor,
+/area/lv624/ground/compound/sw)
 "six" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/dirt,
@@ -16825,10 +16477,21 @@
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand5)
+"sjr" = (
+/turf/open/floor/plating/ground/dirtgrassborder/corner{
+	dir = 4
+	},
+/area/lv624/ground/jungle2)
 "sqN" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand6)
+"ssy" = (
+/obj/structure/cargo_container{
+	dir = 1
+	},
+/turf/open/floor,
+/area/lv624/ground/compound/sw)
 "ssJ" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -16846,30 +16509,38 @@
 /turf/open/floor/plating/ground/dirtgrassborder/corner2,
 /area/lv624/ground/compound/c)
 "szb" = (
-/obj/machinery/landinglight/ds1/delaytwo{
-	dir = 1
+/turf/open/floor,
+/area/lv624/ground/compound/sw)
+"sCg" = (
+/obj/structure/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder/corner{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/shuttle/drop2/lz2)
+/area/lv624/ground/jungle3)
 "sCq" = (
-/obj/structure/cable,
-/obj/structure/cable,
+/obj/effect/alien/weeds/node,
 /turf/open/floor/marking/warning{
 	dir = 4
 	},
-/area/shuttle/drop2/lz2)
+/area/lv624/ground/compound/sw)
 "sDV" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle1)
 "sED" = (
-/obj/structure/lazarus_sign,
-/turf/open/floor/plating/ground/dirtgrassborder,
+/turf/open/floor/marking/warning/corner{
+	dir = 8
+	},
 /area/lv624/ground/compound/sw)
 "sET" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/freezer,
 /area/lv624/lazarus/kitchen)
+"sGX" = (
+/obj/structure/fence,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/plating/ground/dirtgrassborder,
+/area/shuttle/drop2/lz2)
 "sHi" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/dirt,
@@ -16880,17 +16551,6 @@
 	},
 /turf/open/floor,
 /area/shuttle/drop1/lz1)
-"sKw" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 8
-	},
-/area/lv624/ground/jungle3)
 "sLE" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/resin/thick,
@@ -16899,6 +16559,11 @@
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle9)
+"sQw" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/shuttle/shuttle_control/dropship2,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/console)
 "sRg" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/tile/whiteyellow/full,
@@ -16931,6 +16596,14 @@
 	dir = 4
 	},
 /area/lv624/ground/jungle6)
+"tfA" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
+	},
+/area/shuttle/drop2/lz2)
 "thI" = (
 /obj/effect/alien/egg,
 /turf/open/floor/plating/ground/dirt,
@@ -16939,12 +16612,17 @@
 /obj/effect/alien/weeds/node,
 /turf/open/floor/plating,
 /area/lv624/ground/sand6)
+"tji" = (
+/obj/structure/fence,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
+	},
+/area/shuttle/drop2/lz2)
 "tjA" = (
 /obj/machinery/floodlight/colony,
 /obj/structure/catwalk,
-/turf/open/ground/coast{
-	dir = 8
-	},
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand8)
 "tni" = (
 /obj/effect/alien/weeds/node,
@@ -16979,25 +16657,40 @@
 /obj/effect/alien/weeds/node,
 /turf/open/floor/freezer,
 /area/lv624/lazarus/toilet)
-"tDc" = (
-/obj/effect/decal/warning_stripes/thin{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
+"tCW" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/obj/structure/fence,
 /turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 4
+	dir = 1
 	},
-/area/lv624/ground/jungle3)
+/area/shuttle/drop2/lz2)
+"tDV" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating,
+/area/shuttle/drop2/lz2)
 "tGv" = (
 /turf/closed/wall/indestructible/mineral,
 /area/lv624/ground/caves/east2)
+"tGK" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/jungle/vines,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle2)
 "tGT" = (
 /obj/machinery/floodlight/colony,
 /obj/structure/catwalk,
 /turf/open/ground/river,
 /area/lv624/ground/sand8)
+"tHa" = (
+/obj/machinery/landinglight/ds1/delayone{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/drop2/lz2)
+"tMx" = (
+/obj/structure/jungle/planttop1,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
 "tOe" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/alien/weeds/node,
@@ -17039,6 +16732,12 @@
 /obj/structure/jungle/vines,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle3)
+"ubT" = (
+/obj/machinery/landinglight/ds1/delaytwo{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/drop2/lz2)
 "ugM" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/dirtgrassborder/corner,
@@ -17055,6 +16754,12 @@
 	dir = 1
 	},
 /area/lv624/ground/jungle1)
+"uio" = (
+/obj/structure/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
+	dir = 4
+	},
+/area/lv624/ground/jungle2)
 "uip" = (
 /obj/effect/alien/weeds/node,
 /turf/open/floor/plating/ground/dirt,
@@ -17076,9 +16781,8 @@
 /turf/open/space/basic,
 /area/lv624/lazarus/quartstorage)
 "unH" = (
-/obj/structure/cable,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/open/floor/plating/ground/dirt,
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor,
 /area/lv624/ground/compound/sw)
 "upF" = (
 /obj/structure/cable,
@@ -17090,6 +16794,13 @@
 /obj/effect/alien/egg,
 /turf/open/floor/engine/cult,
 /area/lv624/ground/caves/west1)
+"urV" = (
+/obj/structure/jungle/vines,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/ground/grass,
+/area/shuttle/drop2/lz2)
 "usu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -17097,6 +16808,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/c)
+"uuh" = (
+/obj/structure/cargo_container/nt{
+	dir = 8
+	},
+/turf/open/floor,
+/area/lv624/ground/compound/sw)
 "uuI" = (
 /turf/closed/wall/indestructible/mineral,
 /area/lv624/ground/caves/central3)
@@ -17133,10 +16850,10 @@
 /area/lv624/lazarus/main_hall)
 "uFY" = (
 /obj/structure/fence,
-/turf/open/floor/plating/ground/dirtgrassborder/corner2,
-/area/lv624/ground/compound/sw)
-"uHv" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/plating/ground/dirtgrassborder/corner2,
+/area/shuttle/drop2/lz2)
+"uHv" = (
 /turf/open/ground/grass,
 /area/lv624/ground/compound/sw)
 "uIJ" = (
@@ -17152,6 +16869,10 @@
 	},
 /turf/open/ground/grass,
 /area/lv624/ground/jungle1)
+"uJY" = (
+/obj/structure/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder,
+/area/lv624/ground/jungle2)
 "uMG" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/resin,
@@ -17161,6 +16882,15 @@
 /obj/structure/catwalk,
 /turf/open/ground/coast,
 /area/lv624/ground/river1)
+"uRT" = (
+/turf/open/floor/plating/ground/dirtgrassborder/corner,
+/area/lv624/ground/compound/sw)
+"uSS" = (
+/obj/machinery/landinglight/ds1/delayone{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/drop2/lz2)
 "uVd" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -17178,10 +16908,22 @@
 	dir = 1
 	},
 /area/lv624/ground/jungle5)
+"veN" = (
+/turf/open/floor/plating/ground/dirtgrassborder/corner,
+/area/lv624/ground/jungle2)
 "veV" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/gm/dense,
 /area/lv624/ground/jungle3)
+"vfc" = (
+/obj/structure/jungle/vines,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/ground/grass,
+/area/shuttle/drop2/lz2)
+"vfU" = (
+/obj/machinery/landinglight/ds1,
+/turf/open/floor/plating,
+/area/shuttle/drop2/lz2)
 "vgi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/alien/weeds/node,
@@ -17195,6 +16937,17 @@
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/ground/jungle3)
+"vmR" = (
+/obj/machinery/button/door/open_only/landing_zone/lz2,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/shuttle/drop2/lz2)
 "vof" = (
 /obj/structure/jungle/vines/heavy{
 	pixel_x = -28
@@ -17207,30 +16960,37 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle9)
 "vpr" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/structure/cable,
+/obj/structure/lazarus_sign,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/sw)
 "vpP" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 1
-	},
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle4)
 "vrA" = (
-/obj/structure/mineral_door/resin,
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/sand4)
+/obj/structure/largecrate/cow,
+/turf/open/floor,
+/area/lv624/ground/compound/sw)
+"vrB" = (
+/obj/machinery/landinglight/ds1/delaythree{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/drop2/lz2)
 "vsg" = (
 /obj/structure/jungle/planttop1,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle9)
+"vsm" = (
+/obj/structure/jungle/vines,
+/turf/open/ground/grass,
+/area/shuttle/drop2/lz2)
+"vso" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
+	},
+/area/shuttle/drop2/lz2)
 "vuY" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -17266,6 +17026,11 @@
 /obj/effect/alien/weeds/node,
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/main_hall)
+"vFc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plating/ground/dirt,
+/area/shuttle/drop2/lz2)
 "vIv" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/dirt,
@@ -17283,6 +17048,7 @@
 "vJf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/docking_port/stationary/crashmode,
+/obj/structure/cable,
 /turf/open/floor,
 /area/lv624/ground/sand8)
 "vJq" = (
@@ -17305,9 +17071,21 @@
 "vNz" = (
 /turf/open/floor,
 /area/storage/testroom)
+"vPL" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/dirtgrassborder,
+/area/shuttle/drop2/lz2)
 "vRN" = (
 /turf/closed/wall/indestructible/mineral,
 /area/lv624/ground/caves/central1)
+"vSR" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 1
+	},
+/turf/open/floor,
+/area/lv624/ground/compound/sw)
 "vTe" = (
 /obj/structure/sign/botany{
 	dir = 4
@@ -17339,14 +17117,12 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle7)
 "vZo" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
 /turf/closed/gm/dense,
-/area/lv624/ground/jungle3)
+/area/lv624/ground/compound/sw)
 "waG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/alien/weeds/node,
+/obj/structure/cable,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle7)
 "wdm" = (
@@ -17376,13 +17152,20 @@
 /obj/effect/alien/weeds/node,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle6)
-"wpG" = (
-/obj/structure/bed/chair/comfy{
-	dir = 8
+"wot" = (
+/obj/machinery/landinglight/ds1/delaythree{
+	dir = 4
 	},
+/turf/open/floor/plating,
+/area/shuttle/drop2/lz2)
+"wpG" = (
 /turf/open/floor/marking/warning{
 	dir = 5
 	},
+/area/lv624/ground/jungle6)
+"wsZ" = (
+/obj/machinery/landinglight/ds1/delaythree,
+/turf/open/floor/plating,
 /area/shuttle/drop2/lz2)
 "wuU" = (
 /obj/structure/jungle/vines,
@@ -17396,26 +17179,30 @@
 /obj/structure/jungle/vines,
 /turf/open/ground/grass/grass2,
 /area/lv624/ground/jungle9)
+"wyu" = (
+/obj/structure/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
+	dir = 4
+	},
+/area/lv624/ground/jungle3)
 "wBX" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/open/floor/plating/ground/dirt,
+/obj/structure/largecrate/chick,
+/turf/open/floor,
 /area/lv624/ground/compound/sw)
 "wDz" = (
 /obj/structure/cargo_container/nt{
 	dir = 8
 	},
 /turf/open/floor/marking/bot,
-/area/shuttle/drop2/lz2)
+/area/lv624/ground/compound/sw)
 "wDI" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/engine/cult,
 /area/lv624/ground/caves/east2)
 "wJZ" = (
 /obj/structure/window/framed/colony/reinforced,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor,
-/area/shuttle/drop2/lz2)
+/area/lv624/ground/jungle4)
 "wKk" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/dirt,
@@ -17448,11 +17235,9 @@
 /turf/closed/wall/cult,
 /area/lv624/ground/caves/central3)
 "wPr" = (
-/obj/machinery/floodlight/colony{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/compound/sw)
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/ground/grass,
+/area/shuttle/drop2/lz2)
 "wPI" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -17500,6 +17285,10 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral,
 /area/lv624/ground/caves/east1)
+"xjh" = (
+/obj/structure/cargo_container,
+/turf/open/floor,
+/area/lv624/ground/compound/sw)
 "xmL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
@@ -17514,16 +17303,19 @@
 	},
 /area/lv624/lazarus/quartstorage/outdoors)
 "xtK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 1;
-	on = 1
-	},
-/turf/open/ground/grass,
-/area/lv624/ground/jungle2)
+/turf/open/floor/plating,
+/area/shuttle/drop2/lz2)
 "xuD" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
 /area/lv624/ground/river1)
+"xvy" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 8
+	},
+/area/lv624/ground/jungle2)
 "xvZ" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/dirt,
@@ -17541,6 +17333,12 @@
 /obj/structure/jungle/vines,
 /turf/closed/gm/dense,
 /area/lv624/ground/jungle3)
+"xzG" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
+	dir = 8
+	},
+/area/lv624/ground/jungle3)
 "xBg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -17549,9 +17347,16 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/sw)
 "xCo" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/sand4)
+/obj/structure/largecrate/guns,
+/turf/open/floor,
+/area/lv624/ground/compound/sw)
+"xDf" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/ground/grass,
+/area/shuttle/drop2/lz2)
 "xDk" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/structure/mineral_door/resin/thick,
@@ -17571,6 +17376,12 @@
 /obj/machinery/floodlight/colony,
 /turf/open/floor,
 /area/lv624/ground/sand9)
+"xFo" = (
+/obj/structure/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 8
+	},
+/area/lv624/ground/jungle3)
 "xFH" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/tile/bar,
@@ -17601,6 +17412,10 @@
 /obj/structure/jungle/vines,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle9)
+"xRD" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/plating/ground/dirtgrassborder,
+/area/shuttle/drop2/lz2)
 "xRX" = (
 /obj/structure/jungle/plantbot1/alien,
 /obj/structure/catwalk,
@@ -17641,11 +17456,10 @@
 /turf/open/floor/freezer,
 /area/lv624/lazarus/toilet)
 "ykF" = (
-/obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/marking/warning{
 	dir = 8
 	},
-/area/shuttle/drop2/lz2)
+/area/lv624/ground/jungle4)
 
 (1,1,1) = {"
 aab
@@ -18668,35 +18482,35 @@ axQ
 axQ
 axQ
 axQ
-fYD
-kYu
-kYu
-kYu
-kYu
-kYu
-giD
-giD
-giD
-giD
-giD
-giD
-giD
-giD
-giD
-giD
-giD
-giD
-giD
-giD
-giD
-giD
-giD
-giD
-giD
-eql
-eql
-eql
-vZo
+axQ
+axQ
+axQ
+axQ
+axQ
+axQ
+aPA
+aPA
+aPA
+aPA
+aPA
+aPA
+aPA
+aPA
+aPA
+aPA
+aPA
+aPA
+aPA
+aPA
+aPA
+aPA
+aPA
+aPA
+aPA
+bcg
+bcg
+bcg
+bcg
 bcg
 bcg
 bch
@@ -18847,34 +18661,34 @@ axQ
 axQ
 axQ
 axQ
-fYD
-aVS
-aVS
-aVS
-aVS
-aVS
-aVS
-aVS
-aVS
-aVS
-aVS
-aVS
-aVS
-aVS
-aVS
-aVS
-aVS
-aVS
-aVS
-aVS
-aVS
-aVS
-aVS
-aVS
-aVS
-aVS
-aVS
-aVS
+axQ
+axQ
+axQ
+axQ
+axQ
+axQ
+aPA
+aPA
+aPA
+aPA
+aPA
+aPA
+aPA
+aPA
+aPA
+aPA
+aPA
+vZo
+vZo
+vZo
+vZo
+vZo
+vZo
+vZo
+vZo
+vZo
+vZo
+vZo
 vZo
 bcg
 bcg
@@ -19026,34 +18840,34 @@ axQ
 axQ
 axQ
 axQ
-fYD
-aVS
+axQ
+axQ
 aFT
-aVo
-aVo
 bcE
-aVo
+bcE
+bcE
 ykF
-aVo
-aVo
-aVo
-aVo
-aVo
-aVo
-aVo
-aVo
-aVo
-aVo
-aVo
-aVo
-aVo
-aVo
-aVo
-bcE
-aVo
-aVo
+ykF
+ykF
+ykF
+ykF
+ykF
+ykF
+ykF
+ykF
+ykF
+ykF
+rsK
+rsK
+rsK
+rsK
+rsK
+rsK
+rsK
+rsK
+rsK
 bgw
-aVS
+vZo
 vZo
 bcg
 bcg
@@ -19205,34 +19019,34 @@ axQ
 axQ
 axQ
 axQ
-fYD
-aVS
-aUF
+axQ
+axQ
+mbU
 aYj
-aZY
-aZY
-aPD
-aQD
-csn
-aZY
-aPD
-aQD
-csn
-aZY
-aYj
-aQD
-csn
-aZY
-aPD
-aQD
-csn
-aZY
-aPD
-aQD
-csn
-aYj
+dVC
+dVC
+nFI
+nFI
+nFI
+nFI
+nFI
 bdn
-aVS
+nFI
+nFI
+nFI
+bdn
+nFI
+szb
+szb
+jZC
+szb
+szb
+szb
+szb
+szb
+szb
+bFI
+vZo
 vZo
 bcg
 bcg
@@ -19384,34 +19198,34 @@ axQ
 axQ
 axQ
 axQ
-fYD
-aVS
-aUF
-aZo
-dVC
-dVC
-aPE
+axQ
+axQ
+mbU
 dVC
 dVC
 dVC
-dVC
-dVC
-dVC
-dVC
-aPE
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-aPE
-dVC
-rmy
 bdn
-aVS
+nFI
+nFI
+nFI
+nFI
+nFI
+nFI
+nFI
+nFI
+nFI
+nFI
+szb
+szb
+szb
+szb
+szb
+szb
+jZC
+szb
+szb
+bFI
+vZo
 vZo
 bcg
 bcg
@@ -19563,34 +19377,34 @@ avd
 axQ
 axQ
 axQ
-fYD
-aVS
-aXd
-aZp
+axQ
+axQ
+mbU
 dVC
+fHY
 dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-hvg
+nFI
+nFI
+ljt
+nFI
+bdn
+nFI
+ljt
+nFI
+nFI
+nFI
+ljt
+szb
+szb
+szb
+xjh
+szb
+rXx
+szb
+xjh
+szb
 bFI
-aVS
+vZo
 vZo
 bcg
 bck
@@ -19742,34 +19556,34 @@ axa
 axQ
 axQ
 axQ
+axQ
+axQ
+mbU
+dVC
 fYD
-aVS
-aUF
-aMV
 dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-mup
-bdn
-aVS
+nFI
+nFI
+mNl
+ixc
+nFI
+nFI
+mNl
+nFI
+nQe
+nFI
+mNl
+rXx
+szb
+szb
+ssy
+szb
+szb
+szb
+ssy
+szb
+bFI
+vZo
 vZo
 bcg
 bck
@@ -19921,36 +19735,36 @@ avd
 avd
 axQ
 axQ
+axQ
+axQ
+mbU
+dVC
 fYD
-aVS
-aUF
-aZw
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-szb
+iIt
 bdn
-eKN
-tDc
-bfK
+nFI
+mNl
+nQe
+nFI
+nFI
+mNl
+nQe
+nFI
+nFI
+mNl
+szb
+vrA
+szb
+ssy
+rXx
+szb
+szb
+ssy
+szb
+bFI
+iBb
+uHv
+bch
 bch
 bfL
 boo
@@ -20100,36 +19914,36 @@ axb
 avd
 avd
 axQ
-fYD
-aVS
-aUF
-aZo
+axQ
+axQ
+mbU
 dVC
+giD
 dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-rmy
-bdn
-gWo
-qtN
-rXx
+nFI
+nFI
+npP
+nFI
+qEL
+nFI
+npP
+nFI
+qEL
+nFI
+npP
+siq
+szb
+szb
+gqi
+szb
+xCo
+szb
+gqi
+jZC
+bFI
+iBb
+uHv
+bch
 bcm
 bfM
 bnE
@@ -20279,36 +20093,36 @@ avP
 avP
 auG
 axQ
-fYD
-aVS
-aUF
-aZp
+axQ
+axQ
+mbU
 dVC
 dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-ixc
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-hvg
+knr
+nFI
+nFI
+nFI
+nFI
 bdn
-gWo
-qtN
-rXx
+nFI
+nFI
+nFI
+ixc
+nFI
+nFI
+szb
+szb
+szb
+szb
+jZC
+szb
+szb
+szb
+szb
+bFI
+iBb
+uHv
+bch
 bch
 bfM
 bnE
@@ -20451,43 +20265,43 @@ aCl
 agd
 aIj
 aJb
-avL
+fkc
 avL
 avL
 avL
 avL
 auH
 avd
-qSm
+avd
 gWo
-aUF
-aMV
+mbU
 dVC
 dVC
 dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-mup
-bdn
-gWo
-qtN
-rXx
+nFI
+nFI
+nFI
+nFI
+nFI
+nFI
+nFI
+nFI
+nFI
+nFI
+nFI
+jZC
+szb
+szb
+vrA
+szb
+szb
+szb
+szb
+szb
+bFI
+iBb
+uHv
+bch
 bch
 bfM
 pId
@@ -20633,40 +20447,40 @@ avL
 avL
 avL
 avO
-avL
+fkc
 avL
 auH
 avd
-qSm
+avd
 gWo
-aUF
-aZw
+mbU
 dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-szb
+gKE
+kYu
 bdn
+nFI
+nwR
+nFI
+ixc
+nFI
+nwR
+nFI
+bdn
+nFI
+nwR
+szb
+wBX
+szb
+uuh
+szb
+vrA
+szb
+uuh
+szb
+bFI
 iBb
-sKw
-qXT
+uHv
+bch
 bch
 bfM
 cml
@@ -20808,7 +20622,7 @@ are
 avb
 avc
 avL
-avL
+fkc
 avL
 avL
 avL
@@ -20816,35 +20630,35 @@ avL
 avL
 auH
 avd
-qSm
+avd
 gWo
-aUF
-aZo
+mbU
 dVC
+gPv
 dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-rmy
-bdn
-gWo
-fIp
+nFI
+nFI
+nDI
+nFI
+nFI
+nFI
+nDI
+pxE
+nFI
+nFI
+nDI
+szb
+szb
+szb
+eSB
+szb
+szb
+szb
+eSB
+szb
+bFI
+iBb
+uHv
 bcm
 bci
 bfN
@@ -20995,35 +20809,35 @@ avL
 avL
 auH
 avd
-qSm
+avd
 gWo
-aUF
-aZp
+mbU
 dVC
+iGf
 dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-hvg
+ixc
+nFI
+nGq
+pxE
 bdn
-gWo
-fIp
+nFI
+nGq
+nFI
+nQe
+nFI
+nGq
+szb
+xCo
+szb
+iGF
+szb
+siq
+szb
+iGF
+szb
+bFI
+iBb
+uHv
 bck
 bck
 bck
@@ -21142,7 +20956,7 @@ abb
 abb
 abb
 abc
-rbW
+wLx
 abc
 abc
 abc
@@ -21174,35 +20988,35 @@ aIj
 aug
 auk
 axQ
-fYD
-aVS
-aUF
-aMV
+axQ
+axQ
+mbU
 dVC
 dVC
-aPE
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-aPE
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-dVC
-aPE
-dVC
-mup
+knr
+nFI
+nFI
+nFI
+nFI
+nFI
+nFI
+nFI
+nFI
+nFI
+nFI
+nFI
+jZC
+szb
+vrA
+szb
+szb
+szb
+szb
+szb
+jZC
 bFI
-gWo
-jGE
+iBb
+uHv
 bck
 bcg
 bcg
@@ -21334,7 +21148,7 @@ awg
 awC
 awC
 awC
-awC
+awX
 awC
 aAD
 ava
@@ -21347,41 +21161,41 @@ auH
 axx
 aBM
 axR
-avL
+fkc
 avL
 avL
 dxb
 axb
 axQ
-fYD
-aVS
-aUF
+axQ
+axQ
+mbU
 aYj
-aRU
-aRU
-bfZ
-bmq
-eXq
-aRU
-bfZ
-bmq
-eXq
-aRU
-aYj
-bmq
-eXq
-aRU
-bfZ
-bmq
-eXq
-aRU
-bfZ
-bmq
-eXq
-aYj
+dVC
+dVC
+nFI
+nFI
+nFI
+nFI
+nFI
 bdn
-aVS
+nFI
+nFI
+nFI
+nFI
+nFI
+szb
+szb
+szb
+szb
+szb
+szb
+szb
+szb
+szb
+bFI
 vZo
+uHv
 bcg
 bcg
 bcg
@@ -21528,39 +21342,39 @@ avx
 axR
 aMa
 avL
-avL
+fkc
 dxb
 avd
 axQ
-fYD
-aVS
-aUF
-aXb
-aFT
-aVo
+axQ
+axQ
+mbU
+dVC
+dVC
+dVC
 nFI
-aXb
-aXb
-aXb
-aXb
-aXb
-aXb
-aXb
-aXb
-aXb
-aXb
-aXb
-aXb
-aXb
-aXb
-aXb
-aXb
-aXb
-aXb
-aXb
-bdn
-aVS
+nFI
+nFI
+nFI
+nFI
+nFI
+nFI
+nFI
+nFI
+nFI
+nFI
+szb
+szb
+szb
+szb
+jZC
+szb
+szb
+szb
+szb
+bFI
 vZo
+uHv
 bcg
 bcg
 bcg
@@ -21711,35 +21525,35 @@ avL
 dxb
 avd
 axQ
-fYD
+axQ
 aIl
-aXd
-aXb
-aUF
-aIX
+mbU
+dVC
+dVC
+dVC
 bdn
-aXb
-aXb
-aXb
-aXb
-aXb
-aXb
-aXb
-aXb
-aXb
-aXb
-aXb
-aXb
+nFI
+nFI
+nFI
+nFI
+nFI
+nFI
+nFI
+nFI
+nFI
+nFI
+szb
+szb
 aYp
 cJc
 aYp
 icy
 aYp
 wDz
-aXb
-bdn
-aVS
+szb
+bFI
 vZo
+uHv
 bcg
 bcg
 iTb
@@ -21890,35 +21704,35 @@ auF
 rgp
 avd
 axQ
-fYD
+axQ
 aIl
 mbU
-aXb
-aUG
-jOz
-aPK
-aXb
-aXb
-lRQ
-aXb
-aXb
-aXb
-aXb
-aXb
-aXb
-aXb
-aXb
-aXb
+dVC
+dVC
+dVC
+nFI
+nFI
+nFI
+nFI
+nFI
+bdn
+nFI
+nFI
+nFI
+bdn
+nFI
+szb
+szb
 aYp
 aYX
 icy
 icy
 aYp
 oer
-aXb
-bdn
-aVS
+szb
+bFI
 vZo
+uHv
 bcg
 bcg
 fca
@@ -22069,35 +21883,35 @@ avd
 avd
 axb
 axQ
-fYD
+axQ
 aIl
 wpG
-jLW
 jOz
 jOz
-dcr
-jLW
-eYd
-jAh
+jOz
 qQj
-jLW
-mLT
+qQj
+qQj
+qQj
+qQj
+qQj
+qQj
 jTU
-aXb
-aXb
-aXb
-jvZ
-aXb
+nFI
+nFI
+nFI
+szb
+szb
 aYp
 aYX
 icy
 icy
 aYp
 pBc
-aXb
-bdn
-aVS
+szb
+bFI
 vZo
+uHv
 bcg
 bcg
 iTb
@@ -22107,8 +21921,8 @@ bcg
 bcg
 bcg
 bcg
-bch
-bfM
+bmz
+boo
 cml
 bnE
 bph
@@ -22226,7 +22040,7 @@ cuw
 rDm
 awg
 awC
-awC
+awX
 awC
 awC
 awX
@@ -22248,35 +22062,35 @@ auJ
 avd
 axQ
 axQ
-fYD
+axQ
 gWo
 bdp
 bdp
-aXb
+dVC
 bdl
-bdp
-bdp
-gWo
-aVS
-aVS
-aVS
-gWo
-aUE
-aXb
-aXb
-aXb
+wJZ
+wJZ
+oMU
+aPA
+aPA
+aPA
+oMU
+fPb
+nFI
+nFI
+nFI
 jZC
-pDQ
+szb
 aYp
 hUK
 aYp
 aYp
 aYp
 aYp
-aXb
-bdn
-gWo
-jGE
+szb
+bFI
+iBb
+uHv
 biQ
 biQ
 bch
@@ -22285,9 +22099,9 @@ bcg
 bcg
 bcg
 bcg
-bch
-bch
-bfM
+bnE
+bnE
+bnE
 pId
 bnE
 bfa
@@ -22427,35 +22241,35 @@ axQ
 avd
 auJ
 auJ
-kYu
-lcf
-fug
-cvB
-nDI
-nDI
+axQ
+avd
+avd
+avx
+axR
+axR
 aTz
-aQK
-rnp
-giD
-giD
-mNl
-gWo
+aPS
+aPS
+aPS
+aPS
+aPS
+oMU
 fPb
-aXN
-aXN
-aXN
-aXN
-aXM
+nFI
+nFI
+nFI
+szb
+szb
 icy
 icy
-lRQ
-aXb
+szb
+szb
 aYp
 aYp
-aXb
+jZC
 bFI
-gWo
-fIp
+iBb
+uHv
 bch
 bcm
 bch
@@ -22463,10 +22277,10 @@ bch
 bcg
 bcg
 bch
-bck
-bch
-bch
-bfM
+lpo
+bnE
+pId
+bnE
 bnE
 bnE
 bfa
@@ -22617,35 +22431,35 @@ bmr
 aSJ
 aRV
 aSJ
-aTy
-bdp
-aUF
-aXb
-aXb
-aXb
-aXb
-aXN
+bmr
+wJZ
+fPb
+nFI
+nFI
+nFI
+szb
+szb
 jGW
 jGW
-aXb
-aXb
+szb
+jZC
 jGW
 jGW
-aXb
-bdn
-gWo
-fIp
-bch
-bch
-bch
-bci
-bch
+szb
+bFI
+iBb
+uRT
+bmz
+bmz
+bmz
+bmz
+bmz
+biO
+bmz
+boo
 bck
-bch
-bch
-bck
-bcm
-bfN
+cml
+bph
 bmB
 bmB
 bfb
@@ -22792,39 +22606,39 @@ axR
 wlI
 axR
 wNe
-wNe
+vpP
 wNe
 wNe
 wNe
 vpP
-bdp
-wpG
-jLW
-jLW
-jOz
-jTU
-aXN
-aXb
-aXb
-aXb
-aXb
-aXb
-aXb
-aXb
-bdn
-gWo
-fIp
-bch
-bch
-bch
-bci
-bci
-bch
-bch
-bck
-bck
-bch
-bch
+wJZ
+rbx
+qQj
+rnp
+qQj
+sED
+szb
+szb
+szb
+szb
+szb
+szb
+szb
+szb
+bFI
+iBb
+bnj
+bnE
+pId
+bnE
+bnE
+pId
+bnE
+bnE
+biP
+biP
+pId
+bfa
 hBj
 bch
 beh
@@ -22971,39 +22785,39 @@ axR
 axR
 axR
 wNe
-aQL
+wNe
 aRs
 wNe
 wNe
-nwR
+wNe
 oMU
 wJZ
-bdp
-bdp
-gWo
+wJZ
+wJZ
+oMU
 rAj
 nzG
 sCq
-jOz
-jLW
-jLW
-jOz
-jOz
-jLW
+nzG
+nzG
+nzG
+nzG
+sCq
+nzG
 rYZ
-gWo
-fIp
-bch
-bjA
-bhR
-bch
-bch
-bcm
-bch
-bck
+iBb
+bnj
+bnE
+tMx
+jcb
+bmB
+bmB
+mqu
+bmB
+xFo
 ciX
-bch
-bch
+bmB
+bfb
 bch
 beh
 bck
@@ -23150,31 +22964,31 @@ atH
 awi
 awi
 bhd
-bms
+bhd
 xVM
 xVM
 xVM
 xVM
 xVM
-cGD
-nGq
-rbx
+aPS
+aPS
+aPS
 oMU
-wJZ
-bdp
-aXN
-bdl
-bdp
-bdp
-aXb
-bdl
-bdp
-bdp
-gWo
-npP
-bch
-bcm
-bch
+unH
+unH
+szb
+vSR
+unH
+unH
+szb
+vSR
+unH
+unH
+iBb
+bnj
+pId
+cml
+bfa
 bcg
 bcg
 bck
@@ -23298,7 +23112,7 @@ abb
 flw
 awg
 awC
-awC
+awX
 awC
 lxH
 aym
@@ -23340,20 +23154,20 @@ xVM
 xVM
 xVM
 uHv
-ljt
-unH
-nQe
-chK
-iGf
-nQe
-iIt
-nQe
-wBX
-cAZ
-fIp
-bcm
-bch
-bck
+bnj
+aZl
+aZl
+bpG
+bnj
+aZl
+aZl
+aZl
+bpG
+uHv
+bnj
+cml
+bnE
+kBa
 xyp
 bcg
 bcg
@@ -23521,18 +23335,18 @@ xVM
 cRw
 bnj
 tqW
-aZl
+nAc
 bpG
-sED
+bnj
 sHi
+nAc
 aZl
-aZl
-bdu
+aZk
 ptc
-bch
+bnj
 bfO
-bch
-bch
+bnE
+bfa
 bck
 bcg
 bcg
@@ -23629,7 +23443,7 @@ abb
 abc
 abc
 abc
-rbW
+wLx
 abk
 abk
 abk
@@ -23654,7 +23468,7 @@ abc
 abc
 aaI
 aqD
-aqD
+arH
 aqD
 aqD
 aqD
@@ -23706,12 +23520,12 @@ bnj
 ibX
 aZl
 aZl
-fRf
-bch
-bch
-bcm
-bci
-bch
+beo
+uHv
+bnj
+cml
+bnE
+bfa
 bck
 bcg
 bcg
@@ -23836,7 +23650,7 @@ aqD
 aqD
 aqD
 aqD
-aqD
+arH
 aqD
 aqD
 auZ
@@ -23885,12 +23699,12 @@ wOk
 aZl
 aZl
 aZl
-fRf
-bch
-bfL
-bmz
-beY
-bch
+beo
+uHv
+bnj
+bnE
+pId
+bfa
 bck
 bcg
 bcg
@@ -24039,7 +23853,7 @@ avq
 aIZ
 avq
 axR
-axR
+wlI
 axR
 xVM
 xVM
@@ -24065,11 +23879,11 @@ aZl
 aZl
 aZl
 bdu
-bch
-bfM
-fVK
+bmz
+boo
+bnE
+bnE
 bfa
-bch
 bck
 bck
 bcg
@@ -24243,12 +24057,12 @@ nAc
 aZl
 nAc
 aZl
-fRf
-bch
-bfN
-gKE
-bfb
-bch
+hcx
+bnE
+bnE
+cml
+bnE
+bfa
 bhT
 biO
 bjB
@@ -24391,7 +24205,7 @@ ixC
 axQ
 avd
 aOj
-axR
+wlI
 axR
 axR
 wlI
@@ -24422,12 +24236,12 @@ biS
 biS
 boA
 aZl
-fRf
-bch
-bch
-bch
-bch
-bck
+hcx
+bnE
+pId
+bnE
+bnE
+kBa
 bcg
 biP
 bjC
@@ -24576,7 +24390,7 @@ axR
 axR
 ayo
 axR
-axR
+wlI
 axR
 xVM
 xVM
@@ -24603,10 +24417,10 @@ beX
 aZl
 bdu
 iVg
-bch
-bci
-bch
-bck
+bmB
+bmB
+bmB
+sCg
 bck
 bcg
 beh
@@ -24728,7 +24542,7 @@ ara
 aqD
 aqD
 aqD
-aqD
+arH
 aqD
 auC
 auZ
@@ -25137,7 +24951,7 @@ aFD
 bcD
 aZl
 aZl
-aZl
+nAc
 aZl
 bdu
 bch
@@ -25318,13 +25132,13 @@ aEy
 aZl
 aZl
 aZl
-fRf
-bcm
+xzG
+pjD
 ndO
-bch
-bch
-bch
-bch
+bmz
+bmz
+bmz
+bmz
 bcg
 bcg
 bcg
@@ -25467,7 +25281,7 @@ avd
 aOj
 axR
 axR
-axR
+wlI
 kir
 avd
 auJ
@@ -25496,15 +25310,15 @@ aFB
 bcD
 blb
 aZl
-aZl
-fRf
-bch
-bch
-bcm
-bch
-bch
-bck
-bck
+nAc
+hcx
+bnE
+bnE
+iGY
+bnE
+bnE
+biP
+biP
 bcg
 bcg
 bcg
@@ -25676,15 +25490,15 @@ bcD
 aZl
 aZl
 aZl
-fRf
-bch
-bch
-bcm
-bcm
-bch
-biQ
-bck
-bck
+hcx
+bnE
+bnE
+cml
+cml
+bnE
+kUu
+biP
+kBa
 bcg
 bcg
 bcg
@@ -25698,7 +25512,7 @@ aAC
 bqO
 bqO
 bqO
-boU
+bpx
 boU
 aab
 "}
@@ -25856,14 +25670,14 @@ rTb
 rTb
 rTb
 rTb
-bch
-bch
-bch
-bch
-bck
-biQ
-bck
-bch
+bmB
+bmB
+bmB
+bmB
+wyu
+kUu
+hIj
+bfa
 bcg
 bcg
 bcg
@@ -25877,7 +25691,7 @@ bpx
 bpx
 bqO
 boU
-boU
+bpx
 boU
 aab
 "}
@@ -26039,24 +25853,24 @@ rTb
 rTb
 rTb
 rTb
-bck
-bck
-bch
-bch
+lpo
+biP
+bnE
+bfa
 bck
 bcg
 bch
 bch
 bbo
 aZl
-bcA
+pZX
 box
 beo
 bpx
 bpx
 boU
 boU
-boU
+bpx
 boU
 aab
 "}
@@ -26196,7 +26010,7 @@ pNb
 aPS
 aLt
 aMm
-usu
+kHl
 aMm
 aLt
 aPS
@@ -26218,10 +26032,10 @@ rTb
 rTb
 rTb
 rTb
-bcm
-bch
-bch
-bcm
+kTS
+bnE
+bnE
+iXy
 bch
 bfL
 bmz
@@ -26235,7 +26049,7 @@ bpx
 bpx
 bqO
 boU
-boU
+bpx
 boU
 aab
 "}
@@ -26349,7 +26163,7 @@ axR
 axR
 ayY
 avP
-auJ
+avT
 axQ
 aCr
 ayo
@@ -26397,10 +26211,10 @@ rTb
 rTb
 rTb
 rTb
-bch
-bch
+bfM
+bnE
 hHD
-bch
+bfa
 bch
 bfM
 fVK
@@ -26414,7 +26228,7 @@ bpy
 bpx
 boU
 boU
-boU
+bpx
 boU
 aab
 "}
@@ -26528,7 +26342,7 @@ axR
 axR
 ayo
 ayo
-aBf
+aBg
 axR
 axR
 axR
@@ -26576,10 +26390,10 @@ rTb
 rTb
 rTb
 rTb
-bcm
-bch
-bch
-bch
+kTS
+bnE
+bnE
+bfa
 bcm
 bfN
 bmB
@@ -26591,9 +26405,9 @@ aZl
 beo
 bpx
 bpy
+bqO
+bqO
 bpx
-bpx
-boU
 boU
 aab
 "}
@@ -26706,7 +26520,7 @@ avL
 avL
 wlI
 ayo
-aAG
+aBg
 aBg
 wlI
 axR
@@ -26756,9 +26570,9 @@ rTb
 rTb
 rTb
 rTb
-aZV
-aZV
-aZV
+bzO
+bzO
+fnQ
 aZk
 aZV
 aZV
@@ -26770,9 +26584,9 @@ aZl
 beo
 bpy
 bpx
+bqO
+bqO
 bpx
-boU
-boU
 boU
 aab
 "}
@@ -26842,7 +26656,7 @@ abu
 abu
 abc
 abc
-rbW
+wLx
 abc
 abc
 abd
@@ -26949,9 +26763,9 @@ aZl
 aZk
 bpx
 brN
-bqO
+fRV
 boU
-bpx
+bqO
 boU
 aab
 "}
@@ -27026,7 +26840,7 @@ abc
 abc
 abc
 iuG
-aht
+abc
 ahu
 jzY
 aht
@@ -27097,7 +26911,7 @@ aUK
 vgi
 aUK
 aUK
-aUK
+vgi
 aUK
 rTb
 rTb
@@ -27115,22 +26929,22 @@ rTb
 rTb
 rTb
 xmL
-xmL
+rIb
 xmL
 xmL
 qnO
 aZm
 aZm
 aZm
-aZm
+qnO
 bpt
 aZl
 beo
 bpx
 bpx
-bqO
+fRV
 boU
-bpx
+bqO
 boU
 aab
 "}
@@ -27198,21 +27012,21 @@ aeK
 acN
 acN
 aeP
-aht
-aht
-ahU
-ahU
-aht
-aht
+abc
+abc
+abb
+abb
+abc
+abc
 iLV
-ahJ
+abk
 aht
 aht
 aht
 aht
 aht
 aht
-aht
+ahu
 aht
 aht
 aht
@@ -27271,7 +27085,7 @@ aMm
 aMm
 aMm
 aMm
-aMm
+kKo
 aMm
 aMm
 aMm
@@ -27307,7 +27121,7 @@ aZl
 beo
 bpy
 bpx
-bpx
+boU
 boU
 bqO
 boU
@@ -27377,17 +27191,17 @@ uuI
 uuI
 uuI
 aeP
-ahu
-aht
-ahU
-ahU
-ahU
-aht
+abd
+abc
+abb
+abb
+abb
+abc
 iLV
-ahJ
+abk
 aht
 aht
-aht
+ahu
 aht
 aht
 aht
@@ -27478,8 +27292,8 @@ aZk
 aZl
 aZl
 aZl
+aZl
 aZk
-aZW
 aZW
 aZW
 aZW
@@ -27556,14 +27370,14 @@ uuI
 uuI
 uuI
 aeP
-aht
-aht
-ahU
-ahU
-ahU
+abc
+abc
+abb
+abb
+abb
 aiV
 iLV
-ahJ
+abk
 aht
 aht
 aky
@@ -27632,7 +27446,7 @@ aES
 aET
 aJD
 aEx
-vpq
+rbW
 bqK
 aKZ
 aES
@@ -27650,17 +27464,17 @@ rTb
 rTb
 rTb
 rTb
-aEU
-aKs
-aLb
+aES
+aES
+aES
 bbo
 aZl
 aZl
 blb
+aZl
 beo
-atf
-atB
-bqL
+uHv
+bpx
 bpx
 bpx
 bpy
@@ -27735,14 +27549,14 @@ uuI
 uuI
 uuI
 aeP
-aht
-ahu
-ahU
-ahU
-ahU
+abc
+abd
+abb
+abb
+abb
 iLV
-ahJ
-ahJ
+abk
+abk
 aht
 aht
 aky
@@ -27829,25 +27643,25 @@ rTb
 rTb
 rTb
 rTb
-aJD
-bqK
-aKZ
-bbo
-aZl
-aZl
-aZl
-beo
-bnj
+bbL
 wPr
-bqM
-bpx
-bpx
-bpx
-bqO
-bqO
-bqO
-boU
-boU
+wPr
+sGX
+fvx
+fvx
+fvx
+fvx
+tCW
+wPr
+wPr
+wPr
+wPr
+wPr
+wPr
+wPr
+wPr
+ptS
+ptS
 aab
 "}
 (58,1,1) = {"
@@ -27914,14 +27728,14 @@ uuI
 uuI
 uuI
 aeP
-aht
-aht
-ahU
-ahU
-ahU
-eJQ
-aht
-aht
+abc
+abc
+abb
+abb
+abb
+flw
+abc
+abc
 aht
 aht
 akz
@@ -27990,8 +27804,8 @@ aGk
 aFB
 aFB
 aET
-aEx
-aEx
+aMy
+aMy
 taV
 aES
 aES
@@ -28008,25 +27822,25 @@ rTb
 rTb
 rTb
 rTb
-aEW
-aKt
-aLc
-bbo
-aZl
-nAc
-aZl
-beo
-ati
-atE
-bqN
-bpx
-bpx
-bqO
-bqO
-boU
-boU
-boU
-boU
+bbL
+gcB
+nsb
+nsb
+jvx
+oTD
+jvx
+tfA
+nsb
+nsb
+nsb
+nsb
+nsb
+nsb
+nsb
+gcB
+gcB
+gcB
+gcB
 aab
 "}
 (59,1,1) = {"
@@ -28093,16 +27907,16 @@ uuI
 uuI
 uuI
 aeP
+abc
+abd
+abb
+abb
+abb
+flw
+abc
+abc
 aht
 ahu
-ahU
-ahU
-ahU
-eJQ
-aht
-aht
-aht
-aht
 akA
 akZ
 akZ
@@ -28111,7 +27925,7 @@ akZ
 akZ
 akA
 aht
-aht
+ahu
 aht
 anu
 aht
@@ -28187,25 +28001,25 @@ rTb
 rTb
 rTb
 rTb
-aMx
-aTE
-aES
-aZk
-aZl
-aZl
-aZl
-aZk
-atj
-atj
-bpx
-bpx
-bpx
-bqO
-boU
-boU
-boU
-boU
-boU
+egH
+gcB
+nsb
+nsb
+jvx
+oTD
+jvx
+oTD
+nsb
+nsb
+nsb
+nsb
+nsb
+nsb
+gcB
+gcB
+gcB
+gcB
+gcB
 aab
 "}
 (60,1,1) = {"
@@ -28272,14 +28086,14 @@ acN
 acN
 acN
 aeP
-aht
-aht
-ahU
-ahU
-eJQ
-ahU
-aht
-aht
+abc
+abc
+abb
+abb
+flw
+abb
+abc
+abc
 aht
 aht
 akz
@@ -28362,29 +28176,29 @@ rTb
 rTb
 rTb
 rTb
-aES
-aET
-aET
-aET
-aET
-aFB
-aET
-bbo
-aZl
-aZl
-aZl
-beo
-atj
-atj
-bpy
-bpx
-bqO
-boU
-boU
-boU
-boU
-boU
-boU
+wPr
+vfc
+vfc
+vfc
+vfc
+gcB
+urV
+hkV
+jvx
+jvx
+jvx
+pZg
+bLx
+brQ
+iAU
+brQ
+qhe
+gcB
+gcB
+gcB
+gcB
+gcB
+gcB
 aab
 "}
 (61,1,1) = {"
@@ -28451,14 +28265,14 @@ adh
 aeP
 acN
 aeP
-aht
-ahu
-ahU
-eJQ
-ahU
-ahU
-ahu
-aht
+abc
+abd
+abb
+flw
+abb
+abb
+abd
+abc
 aht
 aht
 aky
@@ -28535,35 +28349,35 @@ aKs
 aKu
 aKu
 aKs
-aKs
+oNb
 uFY
-aZl
-bcA
-aZl
-beo
-aES
-aFB
-aFB
-aFB
-aFB
-aFB
-aET
-bbo
-aZl
-aZl
-aZl
-beo
-wNx
-atj
-bpx
-bpx
-bqO
-boU
-boU
-boU
-boU
-boU
-boU
+fvx
+doV
+fvx
+tji
+wPr
+gcB
+gcB
+gcB
+gcB
+gcB
+vsm
+hkV
+jvx
+jvx
+jvx
+pZg
+luc
+brQ
+brQ
+brQ
+brQ
+gcB
+gcB
+gcB
+gcB
+gcB
+gcB
 aab
 "}
 (62,1,1) = {"
@@ -28630,14 +28444,14 @@ acO
 aeP
 acN
 aeP
-aht
-aht
-aht
-vrA
-aht
-aht
-aht
-aht
+abc
+abc
+abc
+iuG
+abc
+abc
+abc
+abc
 aht
 ahu
 aky
@@ -28706,43 +28520,43 @@ aSO
 aTE
 aJB
 aEx
-aEx
+sWJ
 aEx
 sWJ
 aEx
 aEx
-aEx
+aMy
 aMy
 kvA
-aEx
-bgH
-aZl
-bcA
-aZl
-beo
-aFB
-aFB
-aFB
-aFB
-aFB
-aES
-aET
-bbo
-aZl
-aZl
-aZl
-beo
-atj
-atj
-bpx
-bpy
-bqO
-boU
-boU
-boU
-boU
-boU
-boU
+bIG
+nsb
+nsb
+quk
+oTD
+nsb
+gcB
+gcB
+gcB
+gcB
+gcB
+gcB
+vsm
+hkV
+jvx
+jvx
+jvx
+pZg
+erE
+brQ
+brQ
+rPI
+brQ
+gcB
+gcB
+gcB
+gcB
+gcB
+gcB
 aab
 "}
 (63,1,1) = {"
@@ -28809,14 +28623,14 @@ acO
 acN
 acN
 aeP
-ahu
-aht
-xCo
-aio
-aht
-aht
-aht
-aht
+abd
+abc
+vkR
+ahr
+abc
+abc
+abc
+abc
 aht
 aht
 aht
@@ -28890,38 +28704,38 @@ aEx
 aEx
 aEx
 aEx
-aEx
+kvA
 aMy
 aMy
-aEx
-aZk
-aZl
+bIG
+nsb
+dcR
 gdH
-aZl
-beo
-aES
-aET
-auh
-aES
-aES
-aES
-aET
-aZk
-blb
-nAc
-aZl
-aZk
-atj
-atj
-bpy
-bpx
-bpx
-bqO
-bqO
-boU
-boU
-boU
-boU
+jvx
+dcR
+gIc
+wot
+wot
+jgU
+uSS
+ubT
+wot
+jgU
+uSS
+ubT
+wot
+gIc
+uSS
+ubT
+wot
+jgU
+uSS
+ubT
+wot
+jgU
+uSS
+ubT
+gIc
 aab
 "}
 (64,1,1) = {"
@@ -28988,20 +28802,20 @@ acO
 acN
 acN
 aeP
-xCo
+vkR
 iLV
-ahJ
-ahJ
-ahJ
-ahJ
-ahJ
-ahJ
+abk
+abk
+abk
+abk
+abk
+abk
 aht
 aht
 aht
 aht
 aht
-aht
+ahu
 aht
 aht
 aht
@@ -29069,38 +28883,38 @@ aMy
 phK
 aKt
 aKt
+aFG
+aFG
 aKt
-aKt
-aKt
-aKt
+mEj
 nsb
-aZl
-bcA
-aZl
-aZk
-aES
-aET
-aGN
-aES
-aES
-aET
-aES
-bbo
-aZl
-aZl
-aZl
-beo
-atj
-atf
-bqe
-bqL
-bpx
-bpx
-bpx
-boU
-boU
-boU
-boU
+jvx
+quk
+jvx
+jvx
+cQH
+xtK
+xtK
+tDV
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+tDV
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+tDV
+xtK
+vrB
 aab
 "}
 (65,1,1) = {"
@@ -29167,14 +28981,14 @@ aeP
 cZd
 wOz
 wOz
-ahv
-ahK
-ahK
-ahK
-ahK
-ahK
-ahK
-pxE
+aeu
+aeP
+aeP
+aeP
+aeP
+aeP
+aeP
+aeP
 ajG
 ajG
 ajG
@@ -29204,7 +29018,7 @@ avb
 avc
 avO
 avL
-axR
+wlI
 axR
 axR
 axR
@@ -29251,35 +29065,35 @@ aFB
 aFB
 aFB
 aES
-aES
-bbo
-aZl
-pZX
-aZl
-beo
-aES
-auh
-aES
-aFB
-aFB
-aFB
-aET
-bbo
-aZl
-aZl
-aZl
-beo
-atj
-atF
-frj
-bqM
-bpx
-bpx
-bpx
-bqO
-boU
-boU
-boU
+vPL
+kmn
+jvx
+quk
+mek
+jvx
+nxx
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+mTR
 aab
 "}
 (66,1,1) = {"
@@ -29345,15 +29159,15 @@ aeP
 hgM
 uuI
 aeP
-agv
-agv
-ahK
-agv
-agv
-agv
-agv
-agv
-ajG
+acO
+acO
+aeP
+acO
+acO
+acO
+acO
+acO
+acO
 ajG
 ajG
 oqP
@@ -29362,7 +29176,7 @@ ajG
 ajH
 ajG
 ajG
-ajG
+ajH
 ajG
 aiJ
 aiJ
@@ -29428,37 +29242,37 @@ aFB
 aFB
 aFB
 aET
-aEU
-aKs
-aLb
-aZk
-aZl
-bcA
-aZl
-beo
 aES
-aET
 aES
-aFB
-aFB
-aET
-aET
-bbo
-aZl
-aZl
-aZl
-beo
-atj
-ati
-bqg
-bqN
-bpx
-bpx
-bpx
-bqO
-boU
-boU
-boU
+vPL
+nsb
+jvx
+quk
+jvx
+jvx
+vfU
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+rlc
 aab
 "}
 (67,1,1) = {"
@@ -29523,18 +29337,18 @@ acN
 cZd
 uuI
 uuI
-agv
-agI
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-ajG
-ajG
-ajG
+acO
+acO
+acO
+acO
+acO
+acO
+acO
+adh
+acO
+acO
+blT
+blT
 ajG
 ajG
 ajG
@@ -29597,7 +29411,7 @@ aMm
 bfQ
 aMm
 aSe
-aLc
+aKZ
 aES
 aJD
 aEx
@@ -29607,37 +29421,37 @@ aKZ
 aGk
 aFB
 aES
-aJD
+aES
 jYV
-aKZ
-bbo
-aZl
-bcA
-aZl
-beo
-aES
-aET
-aES
-aET
-aET
-aES
-aES
-fTB
-fTB
-fTB
-fTB
-fTB
-atj
-atj
-bpx
-bpx
-bpx
-bpx
-bqO
-bqO
-boU
-boU
-boU
+vPL
+nsb
+jvx
+quk
+jvx
+jvx
+wsZ
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+kgp
 aab
 "}
 (68,1,1) = {"
@@ -29701,19 +29515,19 @@ acN
 cZd
 acN
 acN
-agv
-agv
-agv
-agv
-agv
-agv
-agI
-agv
-agv
-agv
-ajG
-ajG
-ajG
+acO
+acO
+adh
+acO
+acN
+acN
+aeP
+acO
+acO
+acO
+acN
+ajT
+ajT
 ajG
 ajG
 ajG
@@ -29775,48 +29589,48 @@ aLs
 aMm
 bfQ
 aMm
-aOY
-aES
-aES
-aJD
-aEx
-aEx
-aEx
-aKZ
-aES
-aES
-aES
-aEW
-aKt
-aLc
-bbo
-aZl
-bcA
-aZl
-aZk
-aES
-auh
-aES
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-bpx
-bpx
-brP
-bqO
-boU
-boU
-boU
+aLt
+qSm
+qXT
+aEy
+axC
+axC
+axC
+aEy
+qXT
+qXT
+qXT
+qXT
+qXT
+rzH
+kmn
+jvx
+quk
+jvx
+jvx
+cQH
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+vrB
 aab
 "}
 (69,1,1) = {"
@@ -29880,20 +29694,20 @@ hgM
 acN
 acN
 acN
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-ajH
-ajG
+acO
+acO
+acO
+acO
+aeP
+acN
+acN
+acO
+acO
+acO
+acN
 akl
-akB
+akl
+ajG
 ajG
 ajG
 alR
@@ -29954,48 +29768,48 @@ aLs
 aMm
 bfQ
 aMm
-aLt
-aPW
-aPW
-aPW
-aLt
-aSd
-aSd
-aLt
-aPW
-aPW
-aLt
-aZV
-aZV
-aZV
-aZk
+aMm
+aMm
+aMm
+aMm
+aMm
+kKo
+aMm
+aMm
+aMm
+aMm
+aMm
 aZl
-bcA
 aZl
-beo
-aET
-aES
-aES
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-bpy
-bpx
-bpx
-bqO
-boU
-boU
-boU
+bIG
+dde
+jvx
+quk
+sQw
+jvx
+nxx
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+qrL
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+mTR
 aab
 "}
 (70,1,1) = {"
@@ -30057,23 +29871,23 @@ cZd
 uuI
 uuI
 acN
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
+acO
+acO
+acO
+acO
+acO
+acO
+acN
+acO
+acO
+acO
+acO
+acO
+acN
+akl
 ajG
 ajG
-afK
-akF
-akB
+ajG
 ajG
 alp
 aln
@@ -30134,7 +29948,7 @@ aMm
 stw
 aMm
 aMm
-aMm
+kKo
 aMm
 aMm
 aMm
@@ -30143,38 +29957,38 @@ aMm
 aPX
 aMm
 aMm
-aMm
+kKo
 aZl
 aZl
-aZl
-aZl
-aZl
-bcA
-aZl
-beo
-aET
-aET
-aES
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-bpx
-bpx
-bpx
-bqO
-boU
-boU
-boU
+bIG
+jvx
+jvx
+quk
+jvx
+jvx
+vfU
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+rlc
 aab
 "}
 (71,1,1) = {"
@@ -30234,25 +30048,25 @@ uuI
 cZd
 acN
 acN
-aen
-aen
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
+acN
+acO
+acO
+adh
+acO
+acO
+adh
+acO
+acN
+uuI
+uuI
+acO
+adh
+acO
+aeP
+ajT
+ajT
 ajG
 ajG
-afK
-ajR
-akE
 ajG
 ajG
 alo
@@ -30274,7 +30088,7 @@ ajS
 atG
 kOK
 aCr
-avQ
+bqY
 avQ
 avQ
 axR
@@ -30325,35 +30139,35 @@ aOi
 aOi
 aZm
 qnO
-aZm
-aZm
-aZm
+lLQ
+rKY
+vFc
 bcB
-aZl
-beo
-aES
-aES
-aRY
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-bpy
-bpx
-bpx
-bpx
-boU
-boU
-boU
+jvx
+jvx
+wsZ
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+kgp
 aab
 "}
 (72,1,1) = {"
@@ -30412,27 +30226,27 @@ uuI
 hgM
 acN
 acN
-aen
-aen
-aeE
-agv
-agv
-agv
-agv
-agI
-agv
-agv
-agv
-agv
-agv
-agv
-ajc
-ajI
-ajI
-agn
-ajR
-akF
-ahc
+acN
+acN
+acO
+acO
+acN
+acN
+aeP
+acO
+acO
+acN
+uuI
+uuI
+acO
+acO
+acO
+aeP
+ajT
+ajT
+ajT
+ajG
+alA
 akI
 akq
 amV
@@ -30450,11 +30264,11 @@ amq
 alL
 ams
 atk
-atH
-awi
-aBh
-aBh
-aBh
+axR
+axR
+avQ
+avQ
+bqZ
 aBh
 ayp
 awi
@@ -30504,35 +30318,35 @@ aMm
 aMm
 aZl
 aZl
-aZl
-aZl
-aZl
-bcA
-aZl
-aZk
-aZV
-aZV
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-bpx
-bpx
-brx
-boU
-boU
-boU
+bIG
+jvx
+jvx
+quk
+jvx
+jvx
+cQH
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+vrB
 aab
 "}
 (73,1,1) = {"
@@ -30590,29 +30404,29 @@ cZd
 hgM
 uuI
 acN
-aen
-aen
-aen
-aen
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-ajx
-ajR
-ajR
-ajR
-ajR
-ajR
-tGT
-ahF
+acN
+acN
+acN
+acO
+acO
+acN
+acN
+acN
+acO
+acO
+acN
+aeP
+aeP
+acO
+acO
+acO
+aeP
+ajT
+ajT
+ajT
+ajG
+tjA
+akr
 ahX
 amV
 ahX
@@ -30629,11 +30443,11 @@ arO
 aqI
 ald
 arl
+arl
+awf
+awf
+arl
 arp
-atX
-atX
-arW
-arW
 arY
 auM
 arW
@@ -30675,43 +30489,43 @@ aMn
 aMn
 aMn
 aLt
-aMn
+jLQ
+aSd
 aSd
 aLt
 aMn
-aMn
 aLt
 aZW
 aZW
-aZW
-aZk
-aZl
-bcA
-aZl
-aZl
-aZl
-aZl
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-bpx
-bpx
-bpx
-boU
-boU
-boU
+lhf
+nsb
+jvx
+quk
+jvx
+jvx
+nxx
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+mTR
 aab
 "}
 (74,1,1) = {"
@@ -30768,30 +30582,30 @@ cZd
 acN
 acN
 acN
-aen
-aen
-aen
-aen
-aen
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agw
-ajx
-ajR
-ajR
-ajR
-ajR
-ajR
-ajR
-ahF
+acN
+acN
+acN
+acN
+acO
+acO
+aeP
+acN
+acN
+acO
+acO
+acO
+adh
+acO
+acO
+aev
+acO
+acN
+ajT
+ajT
+ajG
+ajG
+ajG
+akr
 ahX
 uvs
 ahX
@@ -30808,11 +30622,11 @@ ajz
 alb
 aiJ
 gJp
-arp
 atl
-arW
-asu
-arW
+atl
+arl
+arl
+arp
 arW
 avV
 avV
@@ -30859,38 +30673,38 @@ vpq
 aEx
 aLa
 aES
-aES
+aEy
 aFD
 aES
-aES
-bbo
-aZl
+bbL
+nsb
+jvx
 bcC
-aZm
-aZm
-aZm
-aZm
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-cAB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
+vFc
+vFc
+vfU
 xtK
-bpx
-bqO
-boU
-boU
-boU
+xtK
+tDV
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+tDV
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+xtK
+tDV
+xtK
+rlc
 aab
 "}
 (75,1,1) = {"
@@ -30945,32 +30759,32 @@ uuI
 uuI
 hgM
 uuI
-aen
-aeE
-aen
-aen
-aen
-aen
-aen
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agI
-agv
-agv
-ajd
-afz
-ajR
-ajR
-ajR
-ajR
-ajR
-alU
+acN
+uuI
+uuI
+uuI
+acN
+acN
+adh
+acO
+acN
+acN
+acN
+adh
+acO
+acO
+acO
+acO
+acO
+acO
+acO
+acN
+akl
+ajG
+ajG
+ajG
+ajG
+akr
 ahX
 amV
 ahX
@@ -30989,9 +30803,9 @@ arl
 arl
 atl
 atl
-arW
-arW
-arW
+arl
+gJp
+arp
 arW
 avV
 awG
@@ -31034,42 +30848,42 @@ nEe
 aKZ
 aES
 nMR
-aEx
+sWJ
 vsg
 aXf
-aFB
+aES
 aET
 aES
 aES
-aET
-bbo
-blb
-aZl
-aZl
-aZl
-aZl
-aZl
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
+egH
+kmn
+rYi
+jvx
+jvx
+bfY
+gIc
+tHa
+tHa
+lxP
+oet
 brx
-bpx
-bqO
-boU
-boU
-boU
+tHa
+lxP
+oet
+brx
+tHa
+gIc
+oet
+brx
+tHa
+lxP
+oet
+brx
+tHa
+lxP
+oet
+brx
+gIc
 aab
 "}
 (76,1,1) = {"
@@ -31124,32 +30938,32 @@ uuI
 uuI
 hgM
 uuI
-aen
-aen
-aen
-aen
-aen
-aen
-aen
-agv
-agI
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-afK
-ajR
-ajR
-ajR
-ajR
-ajR
-ajR
+acN
+uuI
+uuI
+uuI
+acN
+acN
+acO
+acO
+uuI
+uuI
+aeP
+acO
+acO
+uuI
+uuI
+aeP
+acO
+adh
+acO
+acN
+akl
+akl
+ajT
+ajG
+ajG
+ajG
 ahX
 amV
 ahX
@@ -31168,10 +30982,10 @@ arl
 arl
 atl
 atl
-arW
-arW
-arW
-arY
+eci
+eci
+nVu
+brB
 avV
 awH
 awn
@@ -31220,35 +31034,35 @@ aFB
 aFB
 aET
 aES
-aFD
-aZk
-aZW
-aZk
-aZl
-nAc
-aZl
+jFX
+nsb
+nsb
+jvx
+jvx
 bfY
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-bpx
-bpx
-bqO
-boU
-boU
-boU
+bfY
+bfY
+bfY
+bfY
+bfY
+bfY
+bfY
+jvx
+jvx
+jvx
+jvx
+jvx
+jvx
+jvx
+erE
+brQ
+brQ
+brQ
+brQ
+brQ
+brQ
+gcB
+gcB
 aab
 "}
 (77,1,1) = {"
@@ -31299,36 +31113,36 @@ acO
 acO
 acO
 acO
+adh
 acO
+oqF
+acO
+acO
+acO
+acO
+adh
+acO
+acO
+acO
+acO
+uuI
+uuI
+uuI
+acO
+acO
+uuI
+uuI
 acN
-cZd
-aev
-aen
-aen
-aen
-aeE
-aen
-aen
-aen
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-ajY
-afz
-ajR
-ajR
-ajR
-ajR
-ajR
+acO
+acO
+acO
+aeP
+ajT
+ajT
+ajT
+ajG
+ajG
+ajG
 ahX
 amV
 ahX
@@ -31346,10 +31160,10 @@ alb
 arl
 arl
 atl
-atX
-arW
-avf
-arY
+aCK
+arl
+arl
+avl
 arW
 avV
 arM
@@ -31366,15 +31180,15 @@ aBS
 ayq
 aAb
 aDB
-aDa
-aDa
+eJQ
+eJQ
 aEP
-aFq
-aFq
+aLz
+aLz
 nqK
-aFq
-aHN
-aFq
+aLz
+aKT
+aLz
 aJp
 aKd
 aKT
@@ -31399,35 +31213,35 @@ aFB
 aFB
 aFB
 aFB
-aEU
-aKs
-aLb
-bcD
-aZl
-aZl
-aZl
-aEz
-bgL
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-bpx
-bpx
+bbL
+nsb
+nsb
+nsb
+jvx
+dTj
+jvx
+dTj
+jvx
+dTj
+jvx
+dTj
+jss
+dTj
+jvx
+vmR
+dTj
+jvx
+jvx
+dTj
+erE
+kKD
 brQ
-bqO
-boU
-boU
-boU
+kKD
+brQ
+kKD
+brQ
+gcB
+gcB
 aab
 "}
 (78,1,1) = {"
@@ -31480,34 +31294,34 @@ acO
 aeK
 acO
 acO
-cZd
-aev
-aen
-aen
-aen
-aen
-aen
-aen
-aen
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
+oqF
+acO
+adh
+acO
+acO
+acO
+acO
+acO
+acO
+acO
+uuI
+uuI
+uuI
+acO
+adh
+acN
+acO
+acN
+acO
+acO
+acO
+aeP
+ajT
+ajT
+ajT
 ajG
-ajY
-afz
-ajR
-ajR
-ajR
-ajR
+ajG
+ajG
 ahX
 amV
 ahX
@@ -31525,9 +31339,9 @@ alb
 gJp
 kCe
 nVu
-atX
-arW
-arW
+aCK
+arl
+arl
 miq
 avV
 avV
@@ -31572,41 +31386,41 @@ aFB
 aFB
 aJB
 aMy
-aMy
+kvA
 aKZ
 aFB
 aFB
 aFB
 aET
-aJD
-kPh
-aKZ
-bcD
-aZl
-aZl
-aZl
-aEz
-aYw
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-bpx
-bpx
-bpx
-bpx
-boU
-boU
-boU
+bbL
+wPr
+wPr
+nsb
+nsb
+nsb
+nsb
+nsb
+nsb
+nsb
+nsb
+nsb
+nsb
+nsb
+nsb
+nsb
+nsb
+jvx
+oTD
+nsb
+nsb
+nsb
+nsb
+nsb
+nsb
+nsb
+nsb
+gcB
+gcB
 aab
 "}
 (79,1,1) = {"
@@ -31660,33 +31474,33 @@ acO
 acO
 acO
 hgM
-qEL
-aen
-aen
-aen
-aen
-aen
-aen
-aen
-agv
-agv
-agv
-agv
-agI
-agv
-agv
-agv
-agw
-agv
-agv
-agv
+uuI
+acN
+uuI
+uuI
+uuI
+acN
+acN
+acO
+adh
+aeP
+acN
+aeP
+acO
+acO
+acN
+acO
+aev
+acO
+adh
+acO
+uuI
+akl
 ajG
 ajG
-ajY
-afz
-agU
+ajG
 tjA
-alU
+akr
 akq
 uvs
 akq
@@ -31704,10 +31518,10 @@ alb
 arl
 arl
 nVu
-atX
-arW
-arW
-arW
+aCK
+arl
+gJp
+arp
 avV
 blI
 awK
@@ -31723,7 +31537,7 @@ aBn
 awn
 aCw
 ayq
-aDC
+epV
 aAb
 aAb
 aEN
@@ -31757,35 +31571,35 @@ aFB
 aFB
 aET
 aET
-aEW
-aKt
-bbL
-bcD
-aZl
-aZl
-aZl
-aEz
 aES
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-bpy
-bpx
-bpx
-bqO
-boU
-boU
-boU
+aES
+bbL
+nsb
+nsb
+nsb
+nsb
+nsb
+nsb
+nsb
+nsb
+nsb
+nsb
+nsb
+nsb
+nsb
+nsb
+jvx
+oTD
+nsb
+nsb
+nsb
+nsb
+nsb
+nsb
+nsb
+nsb
+gcB
+gcB
 aab
 "}
 (80,1,1) = {"
@@ -31839,31 +31653,31 @@ acO
 adh
 acO
 hgM
-qEL
-aev
-aen
-aen
-aen
-aen
-aen
-aen
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
+uuI
+acN
+uuI
+uuI
+uuI
+acN
+acN
+acO
+acO
+acN
+acN
+acN
+acO
+acO
+acN
+acN
+acO
+acO
+acO
+acO
+acN
+blU
+akl
+ajT
 ajG
-ajZ
-ajG
-ajY
-agZ
 alA
 akI
 alo
@@ -31883,9 +31697,9 @@ ald
 arl
 arl
 arp
-atI
-auK
-arW
+bqX
+auV
+arl
 mvX
 avV
 awn
@@ -31902,7 +31716,7 @@ amP
 aBT
 aCx
 aCY
-aDD
+eql
 aAb
 aAb
 aAb
@@ -31938,33 +31752,33 @@ aET
 aET
 baK
 aES
-aES
-aEy
-aOs
+xDf
+ksq
+pOv
 hmT
-aOs
-aEy
-aES
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-fTB
-bpx
-bpx
-bpx
-bqO
-boU
-boU
-boU
+jIm
+msP
+fvx
+fvx
+fvx
+fvx
+fvx
+fvx
+fvx
+fvx
+fvx
+fvx
+fvx
+fvx
+vso
+wPr
+wPr
+wPr
+xRD
+fvx
+fvx
+vso
+ptS
 aab
 "}
 (81,1,1) = {"
@@ -32018,29 +31832,29 @@ acN
 aeu
 aeu
 aeu
-fHY
-aev
-aev
-aen
-aen
-aen
-aen
-aen
-agv
-agv
-agv
-agv
-agv
+cZd
+acN
+uuI
+uuI
+uuI
+acN
+acN
+acO
+acO
+acN
+acN
+acN
+adh
 ahw
-agV
-agV
-agv
-agv
-agv
-agv
-ajH
-ajG
-ajG
+aeP
+uuI
+acN
+acO
+acO
+acO
+aeP
+akl
+ajT
 ajG
 ajG
 ajG
@@ -32062,10 +31876,10 @@ ala
 arl
 arl
 arp
-atI
-arW
-arW
-arY
+bqX
+arl
+arl
+avl
 avV
 awm
 awL
@@ -32081,7 +31895,7 @@ aBp
 awn
 aCw
 ayq
-aDC
+epV
 aAb
 aAb
 aAb
@@ -32108,7 +31922,7 @@ aFB
 aFB
 aFB
 aJB
-aEx
+sWJ
 aEx
 aKZ
 aFB
@@ -32120,29 +31934,29 @@ aOs
 aOs
 aEy
 bdH
-wvF
-aXg
+rHv
+taV
 aEy
 aOs
 aOs
 aOs
 aEy
-aES
-fTB
-fTB
-fTB
-fTB
-fTB
+aEy
+axC
 aZl
 aZl
-gPv
-bqh
+aZl
+aZl
+aZl
+aZl
+beo
+bpx
 bpx
 bpy
-bpx
-boU
-boU
-boU
+brE
+qkT
+qkT
+osh
 boU
 aab
 "}
@@ -32198,29 +32012,29 @@ acO
 acO
 acO
 aeK
-fHY
-aev
-aen
-aen
-aeE
+cZd
+uuI
+uuI
+uuI
+acN
 afR
-aen
-agv
-agv
-epV
-agv
-agv
-agv
-agv
-agV
-agv
-agv
-agV
-agV
-ajM
-ajG
-ajG
-ajG
+acO
+acO
+uuI
+uuI
+acN
+acO
+acO
+uuI
+uuI
+acN
+acO
+adh
+acO
+acN
+ajT
+ajT
+ajT
 ajG
 ajG
 ajG
@@ -32242,8 +32056,8 @@ gJp
 arl
 atl
 atl
-arW
-arW
+arl
+arl
 miq
 avV
 avV
@@ -32298,30 +32112,30 @@ azg
 aYw
 qBt
 aFD
-aES
-aYw
+aJD
+aEx
 bif
 aXg
 wvF
 aya
 aET
 pqu
-bgL
-bcD
+nMR
+axC
 aZl
 vpr
-xmL
-xmL
-xmL
-fkc
-bpG
-bqh
+aZl
+nAc
+aZl
+aZl
+beo
 bpx
+boU
 bry
-bpx
-bqO
-boU
-boU
+uJY
+dQo
+bqU
+mSv
 boU
 aab
 "}
@@ -32377,33 +32191,33 @@ acO
 acO
 acO
 aeK
-fHY
-aev
-aen
+cZd
+acN
+acN
 afR
-aen
-aen
-aen
-agv
-agI
-agv
-agV
-ahj
-ahx
+acN
+acN
+adh
+acO
+uuI
+acN
+alg
 ahL
-ahx
-ahx
-aiB
-aiB
-ajo
-ahx
-ahx
-ahx
-ahx
-ale
+ahL
+ahL
+alg
+alg
+ako
+aFq
+akD
+alg
+alg
+alg
+alg
 ajG
 ajG
 ajG
+bqh
 amU
 ang
 akI
@@ -32421,9 +32235,9 @@ arl
 arl
 atl
 atl
-atX
-arW
-arW
+awf
+gJp
+arp
 asW
 avV
 asH
@@ -32439,7 +32253,7 @@ aBq
 aBU
 ayq
 aAb
-aDC
+epV
 aAb
 aAb
 atx
@@ -32485,22 +32299,22 @@ bgN
 emp
 baf
 aOs
-bgL
-bcD
-blb
+nMR
+axC
 aZl
 aZl
 aZl
 aZl
-cnD
-bpG
-bqh
-bpy
+aZl
+aZl
+beo
 bpx
-bpx
-bpx
-bqO
+oOC
 boU
+uJY
+bqU
+dQo
+mSv
 boU
 aab
 "}
@@ -32556,30 +32370,30 @@ acO
 acO
 acO
 aeK
-rsK
-qEL
-aen
-aen
-aen
+hgM
+uuI
+acN
+acN
+acN
 afR
-aen
-agv
-agv
-agv
-agV
-ahk
-ahy
-gXL
-gXL
-ahy
-gXL
-aiW
-ahD
-gXL
-gXL
-ahM
-aiu
+acO
+acO
+acN
+acN
+ahL
+ahL
+lGO
+ahK
+ahK
 alf
+ahK
+aiW
+bfK
+ajN
+ajN
+ajN
+ako
+ajG
 ajG
 ajG
 ajG
@@ -32599,11 +32413,11 @@ ald
 arl
 arl
 atl
-arW
-atX
-arW
-atY
-auS
+atl
+awf
+eci
+nVu
+atI
 avV
 awN
 axk
@@ -32618,7 +32432,7 @@ awn
 aBV
 ayq
 aAb
-aDC
+epV
 aAb
 ffi
 aAb
@@ -32646,7 +32460,7 @@ aES
 aET
 aJD
 aEx
-aEx
+sWJ
 aKZ
 aFD
 aYw
@@ -32664,22 +32478,22 @@ anL
 bhm
 xQl
 aOs
-aES
-hAH
-hAH
-hAH
-bjH
-bjH
-blo
-fEQ
-bpI
-bjH
-bjH
-bjH
-bjH
-bsg
+aJD
+bpM
+qkT
+qkT
+qkT
+qkT
+qkT
+qkT
+bpJ
+bpx
 bqO
-boU
+bqO
+brE
+qkT
+qkT
+osh
 boU
 aab
 "}
@@ -32735,31 +32549,31 @@ acO
 acO
 adh
 aeK
-rsK
-qEL
+hgM
+uuI
+acN
+acN
+acN
+acN
+acO
 aev
-aev
-aen
-aen
-aen
-agw
-agv
-agv
-agv
-ahk
+acN
+acN
+ahL
+agU
 gXL
 ahM
 ahY
+ahY
+aur
+aHN
 gXL
-gXL
-gXL
-gXL
-rlb
-gXL
-ahM
-ahD
-alg
-ajM
+lGO
+lGO
+lGO
+akD
+ajG
+ajG
 ajG
 alo
 amU
@@ -32779,10 +32593,10 @@ gJp
 arl
 atl
 atl
-atX
-arW
-atQ
-kCe
+awf
+arl
+arp
+brC
 avV
 awG
 axe
@@ -32797,7 +32611,7 @@ aBr
 aAM
 ayq
 aAb
-aDC
+epV
 aAb
 aAb
 aCZ
@@ -32844,21 +32658,21 @@ bhm
 aXg
 aEy
 hAH
-hAH
-blj
-blO
-blO
-bnm
-blO
-boD
+drA
+bpM
+bpM
+bpM
+qkT
+qkT
+qkT
 bpJ
-bqj
-bqj
-bqj
-blo
-bsg
 bpx
-boU
+bqO
+bqO
+brE
+bsn
+qkT
+osh
 boU
 aab
 "}
@@ -32914,30 +32728,30 @@ acO
 acO
 acO
 aeK
-qEL
-rsK
+uuI
+hgM
+acN
+acN
+acN
+acN
+acO
+adh
+acO
 aev
-aev
-aen
-aen
-aeE
-agv
-agv
-agw
-agV
-ahl
-gXL
+agn
 lGO
-gXL
-aip
-aiC
+ahF
+lGO
+lGO
+lGO
+lGO
 acd
-ajp
-ajN
-ahD
-ahD
 gXL
-alg
+ajN
+bms
+ajN
+ako
+ajG
 ajG
 ajG
 alo
@@ -32958,10 +32772,10 @@ arl
 arl
 atl
 atl
-atX
+awf
+gJp
+avl
 arW
-atR
-asU
 avV
 avV
 avV
@@ -32976,7 +32790,7 @@ ayq
 ayq
 avV
 aAb
-aDC
+epV
 aAb
 aAb
 aAb
@@ -33022,22 +32836,22 @@ anL
 bhm
 azg
 biV
-hAH
-bkw
-dgb
-blP
-bmH
-bmH
-bnP
-boE
-dgb
-blj
-blj
-blj
+qkT
+qkT
+qkT
+qkT
+bpM
+qkT
+bsn
+qkT
+bpJ
+bpx
+boU
+boU
 brE
-bsh
-bpx
-bpx
+qkT
+qkT
+osh
 boU
 aab
 "}
@@ -33093,29 +32907,29 @@ acO
 acO
 acO
 aeK
-qEL
-qEL
-fHY
+uuI
+uuI
+cZd
+acN
+acN
+acN
 aev
-aev
-aen
-afR
-agv
-agv
-agv
-agV
-ahk
-ahB
-ahM
-ahZ
+acO
+acO
+acO
+alg
+lGO
+gXL
+aio
 aiq
-ahZ
-gXL
-ajq
-ajO
-gXL
-ahD
-gXL
+aiq
+auK
+aLN
+alg
+alg
+alg
+alg
+alg
 alg
 ajG
 ajG
@@ -33137,9 +32951,9 @@ kSB
 auT
 atl
 aun
-auS
-atn
-auS
+arl
+auT
+arq
 auS
 auS
 auS
@@ -33155,7 +32969,7 @@ aAN
 aAN
 aCy
 aAb
-aDC
+epV
 aAb
 aAb
 aAb
@@ -33199,24 +33013,24 @@ aEx
 rJn
 uvx
 qxe
-aXg
-aXg
-gPc
-blj
-blh
-blj
-blj
-blj
-blj
-boF
-dgb
-bqj
-bqR
-bqj
-blo
-bsh
+aMy
+aMy
+qkT
+qkT
+qkT
+qkT
+bpM
+qkT
+qkT
+qkT
+bpJ
 bpx
-bqO
+boU
+boU
+brE
+qkT
+qkT
+osh
 boU
 aab
 "}
@@ -33272,32 +33086,32 @@ adh
 acO
 acO
 aeK
-qEL
-qEL
-aev
-fHY
-aev
-aen
+uuI
+uuI
+acN
+cZd
+acN
+acN
 qMS
-agv
-agw
-agv
-agw
+acO
+aev
+adh
+ahL
 ahm
-gXL
-ahD
-aia
-ahy
+lGO
+bZg
+bZg
+bZg
 bZg
 aiY
-aiF
-gXL
+alg
+bkz
 ack
-ahD
-ahD
-gXL
+bod
+ajQ
+ako
 alB
-alV
+alm
 amv
 qZa
 ang
@@ -33334,7 +33148,7 @@ aAb
 aAb
 aCz
 aCZ
-aDC
+epV
 aAb
 aAb
 aAb
@@ -33380,22 +33194,22 @@ dvr
 bhm
 aXg
 biV
-bjH
-blj
-dgb
-blR
-bmJ
-bmJ
-eBP
-boG
-bkA
-bkA
-bkA
-bkA
-bjH
-bjH
-bsn
+qkT
+qkT
+qkT
+qkT
+bpM
+qkT
+qkT
+qkT
+bpJ
 bpx
+boU
+boU
+brE
+qkT
+bsn
+osh
 boU
 aab
 "}
@@ -33451,34 +33265,34 @@ acO
 acO
 aeK
 aeK
+acN
+acN
+acN
+cZd
+acN
+acN
 aev
-aev
-aev
-fHY
-aev
-aen
-afR
-agv
-agv
-agv
-agI
-ahm
+acO
+acO
+acO
+ahL
+alg
 ahC
-gXL
-abR
-gXL
+alg
+alg
+alh
 aiE
 aiZ
-ajr
+alg
 ajP
 akb
-ahD
-aiW
-ahD
+lGO
+lGO
+ajs
 alC
-ajG
-alm
-amV
+alC
+bqj
+bqq
 anv
 alB
 aoE
@@ -33560,21 +33374,21 @@ bhm
 aXg
 aEy
 hAH
-bkz
-blj
+bqg
+bqg
+bqg
 blS
-blS
-blS
-blS
-boH
-bkA
-bqm
-bqS
-brA
+qkT
+qkT
+qkT
+gBG
+bqe
+boU
+boU
 bqp
-blo
-bpx
-bpx
+qkT
+qkT
+osh
 boU
 aab
 "}
@@ -33630,30 +33444,30 @@ acO
 acO
 aeK
 acN
-aev
-aev
-aev
-fHY
-aev
-aen
-aen
-agv
-agv
-agv
-agv
-ahm
-gXL
-ahM
-aic
-air
+acN
+acN
+acN
+cZd
+acN
+acN
+acO
+acO
+acO
+acO
+ahL
+agZ
+lGO
+ajM
+alg
+aiu
 hdZ
 aja
 ajs
-ahD
+lGO
 akc
-rlb
-gXL
-gXL
+lGO
+boP
+akD
 akH
 akH
 aln
@@ -33738,22 +33552,22 @@ dEz
 gMl
 aHT
 aOs
-hAH
-bkA
-blk
-bkA
-bkA
-bnn
-bnQ
-boI
-bkA
-bqn
-bqT
-bqo
-bqo
+bpx
+bpx
+bpx
+bpx
+bmK
+qkT
+bsn
+qkT
 bpM
-bpx
-bpx
+qkT
+bqT
+qkT
+qkT
+qkT
+qkT
+osh
 boU
 aab
 "}
@@ -33809,36 +33623,36 @@ acO
 acO
 aeK
 acN
-qEL
-qEL
+uuI
+uuI
+acN
+cZd
+acN
+acN
+adh
 aev
-fHY
+acO
 aev
-aen
-aeE
-agw
-agv
-agw
-agv
-ahk
-ahD
-gXL
-ahM
+ahL
+ahc
+lGO
+ajY
+alg
 ais
-gXL
-gXL
-ahD
-ahy
-gXL
-ahD
-gXL
+avf
+aQK
+aBf
+aTy
+aTy
+boe
+alg
 alg
 ajG
 ajG
 alo
 amU
 alm
-akq
+alm
 aoG
 ajj
 xxs
@@ -33917,22 +33731,22 @@ bbP
 bhn
 aYv
 aOs
-hAH
-bkB
-blj
-blT
-bkA
-bno
-bnR
-boJ
-bpM
-bqo
-bqU
-bqo
-brR
-brE
 bpx
-bqO
+bpx
+bpx
+bpx
+bmK
+qkT
+qkT
+qkT
+bpM
+qkT
+bqU
+qkT
+qkT
+bsn
+qkT
+osh
 boU
 aab
 "}
@@ -33988,30 +33802,30 @@ adh
 acO
 aeK
 acN
-qEL
-qEL
-aev
-fHY
-aev
+uuI
+uuI
+acN
+cZd
+acN
 afR
-aen
-agv
-agv
-agv
-agv
-ahk
-gXL
+acO
+acO
+acO
+adh
+ahL
+ahv
+ahJ
 lGO
-gXL
-ait
-aiG
-ajb
-aiG
-ajQ
-gXL
-ahD
-air
 alg
+ait
+aiY
+ajb
+alg
+ajQ
+bny
+bof
+ako
+ajG
 ajG
 ajG
 alo
@@ -34034,7 +33848,7 @@ arl
 arl
 arl
 arl
-arl
+gJp
 avX
 avE
 avE
@@ -34097,21 +33911,21 @@ aya
 aET
 kuU
 hAH
-bKi
-blj
-blU
-bkA
-akv
-bnS
-boK
-bpM
-bqo
-bqo
-brB
-bjH
-bjH
-bsn
-bqO
+bpx
+boU
+boU
+bmK
+qkT
+qkT
+qkT
+kAC
+bqg
+boU
+boU
+uio
+bqU
+bqU
+cAL
 boU
 aab
 "}
@@ -34167,30 +33981,30 @@ acO
 acO
 aeK
 aeK
-qEL
-qEL
+uuI
+uuI
+acN
+cZd
+acN
+acN
 aev
-fHY
+acO
 aev
-aev
-afR
-agv
-agw
-agV
-agV
-ahk
-ahD
-ahN
-ahD
-gXL
+acO
+ahL
+ahv
+ahJ
+lGO
+ale
+lGO
 aiH
 rlb
-gXL
-gXL
-gXL
-ajq
-ahy
-alh
+alg
+bkB
+bnX
+bof
+ako
+ajG
 ajG
 ajG
 alo
@@ -34206,7 +34020,7 @@ lEt
 alS
 alS
 alS
-alS
+bqV
 asR
 asU
 asq
@@ -34276,21 +34090,21 @@ aOs
 aOs
 aEy
 hAH
-bkD
-bln
-blj
-bkA
-bnq
-boH
-boL
-bkA
-bqp
-bqV
-brC
-blo
 bpx
+boU
+boU
+bmK
+qkT
+bsn
+qkT
+bpJ
 bpx
-bpx
+boU
+boU
+uJY
+bqU
+bqU
+mSv
 boU
 aab
 "}
@@ -34346,30 +34160,30 @@ acO
 adh
 acO
 aeK
-qEL
-qEL
-aev
-aev
-fHY
-aev
-aev
-agv
-agv
-agv
-agV
-ahk
-gXL
-gXL
-aie
+uuI
+uuI
+acN
+acN
+cZd
+acN
+acN
+acO
+acO
+acO
+ahL
+ahv
+ahJ
+lGO
+alg
 aiu
-gXL
-aiW
-gXL
-ahD
-gXL
+aAG
+aQL
+alg
+blk
+bnY
 aiD
 akD
-alg
+ajG
 ajG
 ajG
 alo
@@ -34454,22 +34268,22 @@ azg
 bet
 aET
 biZ
-hAH
-bkD
-bln
-blj
+veN
+bqe
+bqe
+gZz
 bmK
-blj
-bnU
-boM
-bkA
-bqq
-bqW
-brC
-blo
-brx
+qkT
+qkT
+qkT
+bpJ
 bpx
-bqO
+boU
+boU
+brE
+qkT
+bsn
+mSv
 boU
 aab
 "}
@@ -34525,33 +34339,33 @@ acO
 acO
 acO
 aeK
-qEL
-qEL
-aev
-aev
-aev
-fHY
-aev
-agv
-agv
-agv
-agv
-ahn
-ahE
-ahE
-ahE
-ahE
-aiI
-aiI
-aju
-ahE
-ahE
+uuI
+uuI
+acN
+acN
+acN
+cZd
+acN
+adh
+acO
+acO
+alg
+akD
 ako
-ahE
+alg
+alg
+alV
+aiI
+aTy
+alg
+ako
+ako
+ako
+alg
 ali
 ajH
 ajG
-alo
+bqm
 amU
 akq
 ane
@@ -34633,22 +34447,22 @@ aKu
 bhq
 aKu
 aLb
-hAH
-bkD
-bln
-blj
-bkA
-bno
-qkT
-boN
-bkA
-bqr
-bqX
-brD
 brE
+qkT
+qkT
+osh
+bmK
+qkT
+qkT
+qkT
+bpJ
 bpx
-bpx
-bqO
+boU
+boU
+brE
+qkT
+qkT
+mSv
 boU
 aab
 "}
@@ -34704,25 +34518,25 @@ acO
 acO
 acO
 aeK
-qEL
-qEL
-fHY
-fHY
-fHY
-aev
-aev
+uuI
+uuI
+cZd
+cZd
+cZd
+acN
+acN
+acO
+acO
+acO
 agv
 agv
 agv
 agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
-agv
+alg
+atP
+aBf
+atP
+alg
 ajG
 ajG
 ajG
@@ -34812,22 +34626,22 @@ aNu
 aNu
 aMy
 aKZ
-bjJ
-bkF
-blo
-bjH
-bjH
-bns
-bnV
-iFV
-bjH
-blo
-blo
 brE
-bjH
-bsi
+qkT
+qkT
+osh
+bmK
+qkT
+bsn
+qkT
+bpJ
+bpx
+bpx
+bqO
+brE
+qkT
 brF
-boU
+osh
 boU
 aab
 "}
@@ -34883,12 +34697,12 @@ aeK
 acO
 aeK
 aeK
-fHY
-fHY
-aev
-aev
-aev
-aev
+cZd
+cZd
+acN
+acN
+acN
+acN
 aen
 agv
 agv
@@ -34907,7 +34721,7 @@ ajZ
 ajH
 ajG
 ajG
-oqP
+ajG
 ajG
 ajG
 uvs
@@ -34981,32 +34795,32 @@ aMm
 aMm
 aMm
 aMm
-aMm
+kKo
 aSd
 aEx
+kvA
 aMy
 aMy
-aMy
-aNu
+lQf
 aEx
 wKk
 aKZ
-biZ
-biZ
-aES
-aES
-bjH
-gFA
-bnW
-gFA
-bjH
-bpx
-bpx
-bpx
+aEW
+aKt
+aKt
+aLc
+bmK
+qkT
+qkT
+qkT
+bpJ
 bpx
 bpx
 bqO
-boU
+brE
+qkT
+qkT
+osh
 boU
 aab
 "}
@@ -35061,10 +34875,10 @@ adQ
 aaH
 acO
 aeK
-fHY
-aev
-aev
-aev
+cZd
+acN
+acN
+acN
 aen
 aen
 aen
@@ -35168,24 +34982,24 @@ aKt
 aKt
 aFG
 xwG
-aEx
+sWJ
 bjb
 aKs
 aKs
 aKs
 aKs
 bmL
-czY
-bnX
-czY
+bnt
+bnt
+bnt
 bpN
 bqs
 bqe
-bqL
-bpx
-bpx
-bpx
-boU
+cZJ
+brE
+bsn
+qkT
+osh
 boU
 aab
 "}
@@ -35240,8 +35054,8 @@ bNK
 afb
 oqF
 kFx
-aev
-aev
+acN
+acN
 aen
 aen
 aen
@@ -35285,8 +35099,8 @@ alb
 arp
 atR
 aus
-aro
-arV
+gJp
+arp
 avE
 awb
 awa
@@ -35349,22 +35163,22 @@ aYw
 lSd
 aEx
 aEx
+sWJ
 aEx
-aEx
-aEx
+sWJ
 aEx
 boQ
 bnt
-siq
-czY
+rGv
+bnt
 bpN
 bqt
 frj
-bqM
-bpx
-bpx
-bqO
-boU
+mSv
+brE
+qkT
+qkT
+osh
 boU
 aab
 "}
@@ -35418,8 +35232,8 @@ acS
 adR
 aeb
 aen
-aeT
-aev
+acS
+acN
 aen
 afD
 afL
@@ -35463,8 +35277,8 @@ ajz
 alb
 arq
 dJX
-aut
-arV
+atQ
+arl
 prx
 avZ
 avZ
@@ -35534,16 +35348,16 @@ aEx
 aEx
 boQ
 bnt
-bnX
+bnt
 bnt
 bpN
 bqu
 bqg
-bqN
-bpx
-bpx
-bqO
-boU
+jxq
+brE
+qkT
+qkT
+osh
 boU
 aab
 "}
@@ -35597,8 +35411,8 @@ uuI
 adR
 adR
 aen
-qEL
-qEL
+uuI
+uuI
 aen
 afE
 adR
@@ -35642,9 +35456,9 @@ ajz
 akC
 ats
 arp
-arW
-arW
-arW
+atQ
+arl
+arp
 arY
 avZ
 awu
@@ -35713,16 +35527,16 @@ gJa
 aKt
 bmN
 bnt
-bnX
+bnt
 bnt
 bmN
 bqv
 bqv
 bqv
 bmN
-bpx
-bpx
-bqO
+bqU
+qkT
+osh
 boU
 aab
 "}
@@ -35776,8 +35590,8 @@ uuI
 aeW
 afc
 afh
-qEL
-qEL
+uuI
+uuI
 aen
 afE
 adR
@@ -35821,9 +35635,9 @@ ajz
 ajz
 alb
 atT
-arW
-arY
-auO
+atQ
+auT
+atU
 arW
 avE
 awv
@@ -35892,16 +35706,16 @@ aES
 aES
 bmM
 eLX
-bnX
 bnt
 bnt
 bnt
 bnt
 bnt
-bpN
-bpx
-bpx
-bpx
+bnt
+boQ
+bqU
+qkT
+osh
 boU
 aab
 "}
@@ -35955,8 +35769,8 @@ acN
 adR
 aeO
 aen
-aev
-aev
+acN
+acN
 aen
 afE
 adR
@@ -36000,9 +35814,9 @@ ajz
 ajz
 alb
 arp
-arW
-arW
-arW
+atQ
+gJp
+arp
 arY
 awc
 aww
@@ -36071,16 +35885,16 @@ aES
 aES
 bmM
 bnt
-bnY
-boP
-boP
-boP
-bqY
+rGv
 bnt
-bpN
-bpy
-bqO
-boU
+bnt
+bnt
+rGv
+bnt
+czS
+xvy
+bqg
+sjr
 boU
 aab
 "}
@@ -36134,8 +35948,8 @@ acS
 aeb
 aeO
 aen
-aeT
-aev
+acS
+acN
 aen
 afD
 adR
@@ -36179,9 +35993,9 @@ ajz
 ajz
 alb
 atU
-asu
-arW
-arY
+atQ
+arl
+avl
 arW
 avX
 avE
@@ -36254,11 +36068,11 @@ bnt
 bnt
 bnt
 bnt
-bnX
+bnt
 bnt
 bpN
-bpy
-bpx
+tGK
+bqO
 boU
 boU
 aab
@@ -36358,14 +36172,14 @@ ajz
 ajz
 aqJ
 arp
-arW
-arW
-arW
-atX
-atX
-arW
-arW
-arW
+atQ
+arl
+arq
+aun
+brD
+auS
+auS
+arZ
 avZ
 avE
 ayL
@@ -36433,11 +36247,11 @@ bnZ
 boQ
 bmN
 bnt
-bnX
+bnt
 bnt
 bmN
 bpy
-bqO
+bpx
 boU
 boU
 aab
@@ -36537,18 +36351,18 @@ ajz
 ajz
 alb
 arp
-arY
-arW
-atX
-atX
-atX
-arW
-arW
-arW
+avA
+gJp
+awf
+awf
+bKi
+arl
+arl
+arq
 cyG
-arY
-arY
-atY
+atn
+atn
+auS
 aqr
 aEh
 aEh
@@ -36612,11 +36426,11 @@ aEW
 qez
 boQ
 bnt
-bnX
+bnt
 bnt
 bpN
 bpy
-bqO
+bpx
 boU
 boU
 aab
@@ -36716,18 +36530,18 @@ ajz
 aqI
 ald
 gro
-arW
-atX
-atX
-atX
-arW
-arY
-arW
-arW
-arW
-arW
-atY
-aur
+aut
+auL
+auL
+auL
+chK
+cnD
+arl
+gJp
+arl
+arl
+gJp
+arl
 arl
 aEh
 aEh
@@ -36791,7 +36605,7 @@ aMx
 boS
 bnZ
 bnt
-bnX
+bnt
 bnt
 bpN
 bpx
@@ -36899,15 +36713,15 @@ atl
 atl
 atl
 atl
-atX
-arY
-arW
-arW
-arW
-arY
-atQ
+aul
+avA
 arl
-aro
+arl
+arl
+auT
+arl
+arl
+arl
 aEh
 aEh
 aEh
@@ -36970,7 +36784,7 @@ aET
 aES
 bmN
 bnt
-siq
+rGv
 eLX
 bpN
 bqO
@@ -37079,12 +36893,12 @@ atl
 atl
 atl
 atl
-arY
-arY
-atP
-atn
-arZ
 atR
+avC
+asU
+avC
+asU
+avC
 asU
 azI
 aEh
@@ -37149,7 +36963,7 @@ aET
 aET
 bmM
 bnt
-bnX
+bnt
 bnt
 bmN
 bqO
@@ -37260,9 +37074,9 @@ atl
 atl
 arW
 arY
-avA
-vYG
-avl
+arY
+cvB
+arY
 arY
 azp
 arW
@@ -37328,7 +37142,7 @@ aET
 dZV
 bmM
 bnt
-bnX
+bnt
 bnt
 bpN
 bpx
@@ -37421,16 +37235,16 @@ ang
 aod
 alu
 amw
-ajz
-ajz
-ajz
-ajz
-ajz
-ajz
-ajz
-ajz
-ajz
-alb
+amw
+amw
+amw
+amw
+amw
+amw
+amw
+amw
+amw
+amO
 arq
 arZ
 atl
@@ -37439,9 +37253,9 @@ atl
 atX
 arW
 arY
-aut
-asU
-arV
+arW
+arW
+arW
 arW
 arW
 atl
@@ -37507,7 +37321,7 @@ aES
 aET
 bmM
 bnt
-bnX
+bnt
 bnt
 bpN
 bpy
@@ -37600,17 +37414,17 @@ ang
 aod
 alu
 amw
-ajz
-ajz
-ajz
-ajz
-ajz
-ajz
-ajz
-ajz
-ajz
-akC
-ala
+amw
+amw
+amw
+amw
+amw
+amw
+amw
+amw
+amw
+arS
+bqW
 auu
 atl
 atl
@@ -37686,7 +37500,7 @@ bhE
 aES
 bmN
 bnt
-siq
+rGv
 bnt
 bmN
 bpy
@@ -37779,17 +37593,17 @@ anz
 akn
 alx
 amw
-ajz
-ajz
-ajz
-ajz
-ajz
-akp
-ajz
-ajz
-ajz
-ajz
-alb
+amw
+amw
+amw
+amw
+amw
+bqS
+amw
+amw
+amw
+amw
+amO
 auu
 atX
 atI
@@ -37865,7 +37679,7 @@ bob
 aES
 bmM
 bnt
-bnX
+bnt
 bnt
 bpN
 bpy
@@ -38044,7 +37858,7 @@ boc
 aES
 bmM
 bnt
-bnX
+bnt
 bnt
 bpN
 bpx
@@ -38223,7 +38037,7 @@ bhE
 aLL
 bmN
 bnt
-bnX
+bnt
 bnt
 bmN
 bpx
@@ -38402,7 +38216,7 @@ aYf
 aLM
 bnt
 bnt
-bnX
+bnt
 bnt
 bpN
 bpx
@@ -38569,19 +38383,19 @@ aNz
 aNz
 aNz
 aNz
-aNz
+nGf
 aNz
 aRd
 aNz
 aNz
-aQm
+qzF
 aNz
 aNC
-bod
-aLN
-boP
-boP
-bqZ
+aNC
+aLQ
+bnt
+bnt
+rGv
 bnt
 bpN
 bqO
@@ -38756,9 +38570,9 @@ aNz
 aQm
 aNz
 aYf
-boe
+aYf
 aLO
-bnt
+rGv
 bnt
 bnt
 bnt
@@ -38933,9 +38747,9 @@ bjS
 bkO
 aNA
 bme
-knr
-bny
-bof
+nGf
+aYf
+aNC
 boT
 bnt
 bnt
@@ -39286,11 +39100,11 @@ aNz
 aNz
 aNz
 aNz
+nGf
 aNz
 aNz
 aNz
-aNz
-aNz
+nGf
 aNC
 aYf
 bog
@@ -39403,7 +39217,7 @@ arW
 atl
 cat
 atl
-atl
+aut
 auL
 awd
 atX
@@ -39582,7 +39396,7 @@ arW
 arY
 atl
 atl
-arW
+atI
 atl
 atl
 atI
@@ -41769,7 +41583,7 @@ aHz
 aRl
 aRM
 aKB
-aEk
+jeV
 aKy
 aVf
 aVf
@@ -42478,10 +42292,10 @@ aKy
 jeV
 aFc
 aML
-aHz
+fug
 aOQ
 aPy
-kGz
+lcf
 aGp
 aRP
 aSy
@@ -42805,7 +42619,7 @@ arW
 arW
 auR
 arW
-arW
+atI
 atl
 arW
 arW
@@ -42984,7 +42798,7 @@ auS
 auS
 auS
 auS
-auS
+brA
 aun
 auS
 auS
@@ -43163,8 +42977,8 @@ arl
 auT
 arl
 arl
-arl
-arl
+eci
+eci
 arl
 arl
 arl
@@ -43342,8 +43156,8 @@ arl
 arl
 gJp
 arl
-arl
-arl
+eci
+eci
 gJp
 arl
 arl
@@ -43521,8 +43335,8 @@ arl
 arl
 auT
 arl
-arl
-arl
+eci
+eci
 arl
 arl
 arl
@@ -43700,8 +43514,8 @@ asU
 asU
 asU
 avC
-asU
-asU
+nAV
+nAV
 auL
 nAV
 auL
@@ -43879,8 +43693,8 @@ arW
 arW
 arW
 arW
-arW
-arW
+atI
+atI
 atI
 atX
 atI
@@ -44783,7 +44597,7 @@ arY
 arW
 atX
 atX
-arY
+brB
 atX
 arW
 arW
@@ -44962,7 +44776,7 @@ aAS
 aAS
 ayQ
 azr
-aAS
+asi
 azr
 aAS
 aAS
@@ -45115,10 +44929,10 @@ xNt
 esC
 lcH
 apo
-aoO
-aoO
-aoO
-aqf
+apo
+apo
+apo
+arw
 aos
 aot
 ask
@@ -45294,10 +45108,10 @@ lcH
 lcH
 lcH
 apo
-aoO
-aoO
-aqN
-aqg
+apo
+apo
+bqr
+bqR
 apV
 ask
 anN
@@ -45321,7 +45135,7 @@ ayj
 ayj
 tTR
 ayj
-aAT
+cGD
 aAT
 aAT
 aBC
@@ -45499,7 +45313,7 @@ arx
 ayk
 ayk
 azs
-aBD
+czY
 aAt
 aAU
 aBD
@@ -45678,8 +45492,8 @@ aDP
 aBG
 azQ
 azt
-azQ
-azP
+aDp
+aDT
 azP
 aBE
 aCf
@@ -45858,7 +45672,7 @@ aBG
 aAV
 aAV
 aAV
-azP
+aDT
 azP
 aBF
 azP

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -16998,11 +16998,6 @@
 /obj/structure/catwalk,
 /turf/open/ground/river,
 /area/lv624/ground/sand8)
-"tJm" = (
-/obj/effect/alien/weeds/node,
-/obj/effect/alien/weeds/node,
-/turf/closed/gm/dense,
-/area/lv624/ground/jungle7)
 "tOe" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/alien/weeds/node,
@@ -44073,7 +44068,7 @@ atl
 atl
 atl
 fxk
-tJm
+atl
 atl
 atl
 atl

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -33857,7 +33857,7 @@ avi
 arl
 arl
 arl
-arl
+gJp
 arl
 avZ
 avE

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -87,6 +87,7 @@
 /area/lv624/ground/caves/central3)
 "aaI" = (
 /obj/effect/landmark/lv624/fog_blocker,
+/obj/structure/mineral_door/resin,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand1)
 "aaJ" = (
@@ -276,6 +277,11 @@
 /obj/item/explosive/grenade/frag,
 /turf/open/floor/plating,
 /area/lv624/ground/sand6)
+"abF" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/c)
 "abG" = (
 /obj/structure/mineral_door/resin,
 /turf/open/floor/plating/ground/dirt,
@@ -732,7 +738,9 @@
 	dir = 4
 	},
 /obj/structure/catwalk,
-/turf/open/floor/plating/warning,
+/turf/open/floor/plating/warning{
+	dir = 2
+	},
 /area/lv624/ground/filtration)
 "aej" = (
 /turf/open/floor/plating/ground/dirt,
@@ -975,10 +983,6 @@
 /obj/structure/table,
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/ground/caves/east1)
-"afo" = (
-/obj/structure/girder,
-/turf/open/floor/plating,
-/area/lv624/ground/river1)
 "afp" = (
 /obj/structure/cargo_container/horizontal{
 	dir = 4
@@ -1074,7 +1078,6 @@
 /obj/structure/table,
 /obj/item/toy/deck,
 /obj/item/storage/fancy/cigarettes,
-/obj/structure/cable,
 /turf/open/floor/tile/blue/taupebluecorner,
 /area/lv624/lazarus/sleep_male)
 "afK" = (
@@ -1109,6 +1112,12 @@
 /area/lv624/ground/sand6)
 "afQ" = (
 /obj/machinery/door/airlock/sandstone,
+/obj/machinery/door/airlock/sandstone{
+	desc = "This strange temple is covered in runes. It looks extremely ancient.";
+	icon_state = "door_locked";
+	locked = 1;
+	name = "Strange Temple"
+	},
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/ground/caves/east1)
 "afR" = (
@@ -1512,7 +1521,9 @@
 	dir = 8
 	},
 /obj/structure/catwalk,
-/turf/open/floor/plating/warning,
+/turf/open/floor/plating/warning{
+	dir = 2
+	},
 /area/lv624/ground/filtration)
 "ahA" = (
 /turf/open/floor/plating,
@@ -1582,6 +1593,7 @@
 /area/lv624/ground/tfort)
 "ahN" = (
 /obj/item/attachable/reddot,
+/obj/effect/alien/weeds/node,
 /turf/open/floor/plating,
 /area/lv624/ground/tfort)
 "ahO" = (
@@ -1611,12 +1623,6 @@
 "ahU" = (
 /turf/closed/mineral,
 /area/lv624/ground/sand4)
-"ahV" = (
-/turf/open/floor/mech_bay_recharge_floor/asteroid,
-/area/lv624/ground/sand2)
-"ahW" = (
-/turf/open/floor/plating/asteroidfloor,
-/area/lv624/ground/sand2)
 "ahX" = (
 /obj/structure/catwalk,
 /turf/open/ground/river,
@@ -1624,6 +1630,7 @@
 "ahY" = (
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/gun/smg/uzi,
+/obj/effect/alien/weeds/node,
 /turf/open/floor/plating,
 /area/lv624/ground/tfort)
 "ahZ" = (
@@ -1658,7 +1665,9 @@
 	dir = 4
 	},
 /obj/structure/catwalk,
-/turf/open/floor/plating/warning,
+/turf/open/floor/plating/warning{
+	dir = 2
+	},
 /area/lv624/ground/filtration)
 "aie" = (
 /obj/item/flashlight/lantern,
@@ -1871,7 +1880,9 @@
 	dir = 4
 	},
 /obj/structure/catwalk,
-/turf/open/floor/plating/warning,
+/turf/open/floor/plating/warning{
+	dir = 2
+	},
 /area/lv624/ground/filtration)
 "aiY" = (
 /obj/structure/table,
@@ -2036,13 +2047,6 @@
 /obj/structure/girder,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/west1)
-"ajE" = (
-/turf/open/floor/plating/asteroidfloor,
-/area/lv624/ground/sand4)
-"ajF" = (
-/obj/structure/girder,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/sand4)
 "ajG" = (
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand8)
@@ -2280,6 +2284,12 @@
 	dir = 4
 	},
 /area/lv624/ground/river2)
+"akR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/sw)
 "akT" = (
 /obj/structure/jungle/vines,
 /obj/structure/jungle/plantbot1/alien,
@@ -2297,6 +2307,10 @@
 	dir = 5
 	},
 /area/lv624/ground/river3)
+"akX" = (
+/obj/structure/girder,
+/turf/open/floor/tile/red/yellowfull,
+/area/lv624/ground/sand4)
 "akY" = (
 /obj/item/analyzer,
 /turf/open/floor/tile/red/yellowfull,
@@ -2334,16 +2348,24 @@
 /obj/structure/table/reinforced/flipped,
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood,
-/turf/open/floor/plating/warning,
+/turf/open/floor/plating/warning{
+	dir = 2
+	},
 /area/lv624/ground/tfort)
 "alg" = (
-/obj/structure/table/reinforced/flipped,
-/turf/open/floor/plating/warning,
+/obj/structure/table/reinforced/flipped{
+	dir = 2
+	},
+/turf/open/floor/plating/warning{
+	dir = 2
+	},
 /area/lv624/ground/tfort)
 "alh" = (
 /obj/structure/table/reinforced/flipped,
 /obj/item/ammo_magazine/smg/uzi/extended,
-/turf/open/floor/plating/warning,
+/turf/open/floor/plating/warning{
+	dir = 2
+	},
 /area/lv624/ground/tfort)
 "ali" = (
 /obj/machinery/floodlight,
@@ -2360,10 +2382,6 @@
 /obj/structure/girder/displaced,
 /turf/open/ground/river,
 /area/lv624/ground/sand8)
-"all" = (
-/obj/structure/fence,
-/turf/open/floor/plating,
-/area/lv624/ground/river2)
 "alm" = (
 /turf/open/floor,
 /area/lv624/ground/sand8)
@@ -2688,12 +2706,6 @@
 /obj/structure/catwalk,
 /turf/open/ground/river,
 /area/lv624/ground/river2)
-"amx" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/ground/dirtgrassborder/corner2{
-	dir = 8
-	},
-/area/lv624/ground/jungle7)
 "amy" = (
 /obj/effect/decal/remains/xeno,
 /obj/effect/decal/warning_stripes/thin{
@@ -2794,14 +2806,11 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood/splatter/animated,
+/obj/effect/alien/weeds/node,
 /turf/open/floor/tile/purple/whitepurple{
 	dir = 5
 	},
 /area/lv624/lazarus/research)
-"amR" = (
-/obj/structure/girder,
-/turf/open/ground/river,
-/area/lv624/ground/river3)
 "amS" = (
 /obj/effect/landmark/corpsespawner/scientist{
 	corpseback = null;
@@ -2870,14 +2879,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plating/warning,
+/turf/open/floor/plating/warning{
+	dir = 2
+	},
 /area/lv624/ground/filtration)
 "and" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
 	on = 1
 	},
-/turf/open/floor/plating/warning,
+/turf/open/floor/plating/warning{
+	dir = 2
+	},
 /area/lv624/ground/filtration)
 "ane" = (
 /turf/open/floor/plating/warning,
@@ -2988,6 +3001,7 @@
 /obj/structure/disposalpipe/junction/flipped{
 	dir = 2
 	},
+/obj/structure/catwalk,
 /turf/open/ground/river,
 /area/lv624/ground/river3)
 "anC" = (
@@ -3098,6 +3112,7 @@
 /obj/structure/barricade/wooden{
 	dir = 4
 	},
+/obj/effect/alien/weeds/node,
 /turf/open/floor/wood,
 /area/lv624/ground/ruin)
 "anY" = (
@@ -3213,12 +3228,6 @@
 	dir = 8
 	},
 /area/lv624/ground/ruin)
-"aoz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/ground/river,
-/area/lv624/ground/river2)
 "aoB" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/effect/decal/warning_stripes/thin{
@@ -3267,17 +3276,16 @@
 /turf/open/floor,
 /area/lv624/ground/river2)
 "aoI" = (
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/fence,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/lv624/ground/river2)
 "aoJ" = (
 /turf/open/floor/plating,
 /area/lv624/ground/jungle7)
 "aoL" = (
+/obj/structure/catwalk,
 /turf/open/floor/plating/warning{
 	dir = 4
 	},
@@ -3286,6 +3294,7 @@
 /obj/structure/disposalpipe/segment{
 	name = "water pipe"
 	},
+/obj/structure/catwalk,
 /turf/open/ground/river,
 /area/lv624/ground/river2)
 "aoN" = (
@@ -3355,19 +3364,9 @@
 	dir = 8
 	},
 /area/lv624/ground/ruin)
-"ape" = (
-/obj/structure/flora/tree/jungle/small,
-/turf/open/floor/plating/ground/dirtgrassborder/corner2{
-	dir = 8
-	},
-/area/lv624/ground/jungle6)
 "apf" = (
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/ground/river,
-/area/lv624/ground/river2)
-"apg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plating,
 /area/lv624/ground/river2)
 "aph" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -3413,6 +3412,7 @@
 /area/lv624/ground/river3)
 "apq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/alien/weeds/node,
 /turf/open/floor,
 /area/lv624/ground/compound/n)
 "aps" = (
@@ -3534,10 +3534,6 @@
 "apY" = (
 /turf/open/ground/river,
 /area/lv624/ground/sand4)
-"apZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/ground/river,
-/area/lv624/ground/river2)
 "aqa" = (
 /obj/structure/girder,
 /turf/open/ground/river,
@@ -3569,13 +3565,14 @@
 /area/lv624/ground/river3)
 "aqi" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 1
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
+	dir = 8
 	},
 /area/lv624/ground/jungle8)
 "aqj" = (
 /obj/structure/jungle/vines,
-/turf/open/floor/plating/ground/dirtgrassborder/corner,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle8)
 "aqk" = (
 /turf/open/floor/plating/ground/dirtgrassborder,
@@ -3590,16 +3587,6 @@
 	},
 /turf/open/ground/river,
 /area/lv624/ground/river2)
-"aqo" = (
-/obj/structure/jungle/vines/heavy,
-/turf/open/floor/plating/ground/dirtgrassborder/corner{
-	dir = 1
-	},
-/area/lv624/ground/jungle8)
-"aqq" = (
-/obj/structure/jungle/vines/heavy,
-/turf/open/floor/plating/ground/dirtgrassborder/corner2,
-/area/lv624/ground/jungle8)
 "aqr" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/sign/botany{
@@ -3629,12 +3616,6 @@
 	dir = 1
 	},
 /area/lv624/ground/river3)
-"aqz" = (
-/obj/structure/jungle/vines/heavy,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 4
-	},
-/area/lv624/ground/jungle8)
 "aqA" = (
 /obj/structure/jungle/vines,
 /turf/closed/wall/wood,
@@ -3696,19 +3677,13 @@
 	dir = 4
 	},
 /area/lv624/ground/jungle8)
-"aqT" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 4
-	},
-/area/lv624/ground/jungle8)
 "aqU" = (
 /obj/item/flashlight/flare,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle8)
 "aqV" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/open/ground/grass,
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle8)
 "aqW" = (
 /obj/structure/flora/grass/brown,
@@ -3716,7 +3691,7 @@
 /area/lv624/ground/jungle8)
 "aqX" = (
 /obj/structure/flora/ausbushes/reedbush,
-/turf/open/ground/grass,
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle8)
 "aqZ" = (
 /obj/structure/flora/ausbushes/fullgrass,
@@ -3737,10 +3712,6 @@
 "are" = (
 /turf/open/ground/river,
 /area/lv624/ground/river1)
-"arf" = (
-/obj/structure/flora/tree/jungle,
-/turf/open/ground/grass,
-/area/lv624/ground/jungle8)
 "ark" = (
 /turf/open/ground/coast/corner{
 	dir = 4
@@ -3793,7 +3764,7 @@
 /area/lv624/ground/river3)
 "arx" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/ground/dirtgrassborder/corner{
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
 	dir = 1
 	},
 /area/lv624/ground/jungle5)
@@ -3896,11 +3867,6 @@
 	dir = 1
 	},
 /area/lv624/ground/river1)
-"arU" = (
-/turf/open/floor/plating/ground/dirtgrassborder/corner2{
-	dir = 1
-	},
-/area/lv624/ground/river2)
 "arV" = (
 /turf/open/floor/plating/ground/dirtgrassborder/corner{
 	dir = 4
@@ -3908,10 +3874,6 @@
 /area/lv624/ground/jungle7)
 "arW" = (
 /turf/open/ground/grass,
-/area/lv624/ground/jungle7)
-"arX" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/ground/grass/grass2,
 /area/lv624/ground/jungle7)
 "arY" = (
 /obj/structure/flora/ausbushes/fullgrass,
@@ -3978,10 +3940,6 @@
 /turf/open/ground/river,
 /area/lv624/ground/river2)
 "asu" = (
-/turf/open/ground/grass/grass2,
-/area/lv624/ground/jungle7)
-"asv" = (
-/obj/structure/flora/tree/jungle/small,
 /turf/open/ground/grass/grass2,
 /area/lv624/ground/jungle7)
 "asw" = (
@@ -4116,9 +4074,6 @@
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle6)
-"atd" = (
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/river3)
 "ate" = (
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/ground/coast/corner2{
@@ -4194,12 +4149,6 @@
 	dir = 1
 	},
 /area/lv624/ground/jungle7)
-"atv" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/ground/dirtgrassborder/corner{
-	dir = 8
-	},
-/area/lv624/ground/jungle7)
 "atw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -4256,7 +4205,7 @@
 "atJ" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/jungle/vines,
-/turf/closed/wall,
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle7)
 "atK" = (
 /obj/structure/cable,
@@ -4269,10 +4218,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor,
-/area/lv624/ground/jungle7)
-"atO" = (
-/obj/structure/jungle/vines,
-/turf/closed/wall,
 /area/lv624/ground/jungle7)
 "atP" = (
 /obj/structure/flora/tree/jungle/small,
@@ -4455,8 +4400,10 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand1)
 "auE" = (
-/obj/structure/jungle/planttop1,
-/turf/open/floor/plating/ground/dirtgrassborder,
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
+	dir = 4
+	},
 /area/lv624/ground/jungle6)
 "auF" = (
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -4471,12 +4418,6 @@
 "auH" = (
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 1
-	},
-/area/lv624/ground/jungle6)
-"auI" = (
-/obj/structure/jungle/vines/heavy,
-/turf/open/floor/plating/ground/dirtgrassborder/corner{
-	dir = 4
 	},
 /area/lv624/ground/jungle6)
 "auJ" = (
@@ -4563,10 +4504,6 @@
 "avd" = (
 /turf/open/ground/grass,
 /area/lv624/ground/jungle6)
-"ave" = (
-/obj/structure/jungle/vines,
-/turf/open/ground/grass/grass2,
-/area/lv624/ground/jungle6)
 "avf" = (
 /turf/open/ground/jungle,
 /area/lv624/ground/jungle7)
@@ -4584,16 +4521,7 @@
 /area/lv624/ground/jungle7)
 "avi" = (
 /obj/structure/flora/ausbushes/fernybush,
-/turf/open/floor/plating/ground/dirtgrassborder/corner2{
-	dir = 1
-	},
-/area/lv624/ground/jungle7)
-"avk" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/jungle/vines,
-/turf/open/floor/plating/ground/dirtgrassborder/corner{
-	dir = 8
-	},
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle7)
 "avl" = (
 /obj/structure/flora/ausbushes/fullgrass,
@@ -4646,16 +4574,6 @@
 /area/lv624/ground/jungle6)
 "avx" = (
 /turf/open/floor/plating/ground/dirtgrassborder,
-/area/lv624/ground/jungle6)
-"avy" = (
-/obj/structure/jungle/vines/heavy,
-/turf/open/floor/plating/ground/dirtgrassborder/corner{
-	dir = 1
-	},
-/area/lv624/ground/jungle6)
-"avz" = (
-/obj/structure/jungle/vines,
-/turf/open/floor/plating/ground/dirtgrassborder/corner,
 /area/lv624/ground/jungle6)
 "avA" = (
 /obj/structure/flora/ausbushes/fullgrass,
@@ -4717,18 +4635,6 @@
 /obj/structure/jungle/vines,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle6)
-"avR" = (
-/obj/structure/jungle/vines,
-/turf/open/floor/plating/ground/dirtgrassborder/corner2{
-	dir = 4
-	},
-/area/lv624/ground/jungle6)
-"avS" = (
-/obj/structure/jungle/vines,
-/turf/open/floor/plating/ground/dirtgrassborder/corner{
-	dir = 1
-	},
-/area/lv624/ground/jungle6)
 "avT" = (
 /obj/structure/jungle/vines,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -4774,10 +4680,6 @@
 "awg" = (
 /turf/closed/mineral,
 /area/lv624/ground/sand7)
-"awh" = (
-/obj/structure/jungle/plantbot1,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/jungle6)
 "awi" = (
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 8
@@ -4794,13 +4696,6 @@
 	dir = 8
 	},
 /area/lv624/ground/jungle6)
-"awl" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/jungle/vines,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 1
-	},
-/area/lv624/ground/jungle7)
 "awm" = (
 /obj/structure/closet/secure_closet/medical3,
 /turf/open/floor/tile/blue/whitebluecorner,
@@ -5032,12 +4927,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle6)
-"axc" = (
-/obj/structure/jungle/vines,
-/turf/open/floor/plating/ground/dirtgrassborder/corner{
-	dir = 8
-	},
-/area/lv624/ground/jungle6)
 "axd" = (
 /obj/structure/jungle/vines,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -5052,6 +4941,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/alien/weeds/node,
 /turf/open/floor/tile/blue/whitebluecorner,
 /area/lv624/lazarus/medbay)
 "axg" = (
@@ -5078,6 +4968,7 @@
 /area/lv624/lazarus/medbay)
 "axk" = (
 /obj/item/tool/surgery/retractor,
+/obj/effect/alien/weeds/node,
 /turf/open/floor/tile/blue/whitebluecorner,
 /area/lv624/lazarus/medbay)
 "axl" = (
@@ -5129,10 +5020,6 @@
 "axu" = (
 /turf/closed/wall,
 /area/lv624/ground/compound/n)
-"axw" = (
-/obj/structure/flora/ausbushes/fernybush,
-/turf/open/floor/plating/ground/dirtgrassborder/corner,
-/area/lv624/ground/jungle6)
 "axx" = (
 /turf/open/floor/plating/ground/dirtgrassborder/corner{
 	dir = 1
@@ -5387,6 +5274,7 @@
 /turf/open/floor/tile/blue/whitebluecorner,
 /area/lv624/lazarus/medbay)
 "ayw" = (
+/obj/structure/cable,
 /obj/structure/table,
 /obj/machinery/door_control{
 	id = "OR2";
@@ -5464,6 +5352,7 @@
 /obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	name = "\improper Hydroponics Dome"
 	},
+/obj/effect/alien/weeds/node,
 /turf/open/floor/tile/green/greentaupe{
 	dir = 1
 	},
@@ -5485,12 +5374,6 @@
 /obj/structure/jungle/vines,
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 4
-	},
-/area/lv624/ground/jungle5)
-"ayS" = (
-/obj/structure/jungle/vines,
-/turf/open/floor/plating/ground/dirtgrassborder/corner2{
-	dir = 1
 	},
 /area/lv624/ground/jungle5)
 "ayT" = (
@@ -5529,10 +5412,6 @@
 /obj/structure/jungle/vines,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle6)
-"aza" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/ground/dirtgrassborder/corner2,
-/area/lv624/ground/jungle6)
 "azb" = (
 /obj/item/shard,
 /obj/structure/window_frame/colony/reinforced,
@@ -5543,6 +5422,7 @@
 	dir = 4;
 	on = 1
 	},
+/obj/effect/alien/weeds/node,
 /turf/open/floor/tile/blue/whitebluecorner,
 /area/lv624/lazarus/medbay)
 "aze" = (
@@ -5582,6 +5462,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/alien/weeds/node,
 /turf/open/floor/tile/green/greentaupe{
 	dir = 1
 	},
@@ -5646,10 +5527,6 @@
 /obj/structure/fence,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/n)
-"azx" = (
-/obj/structure/girder,
-/turf/open/floor/plating,
-/area/lv624/ground/sand7)
 "azB" = (
 /obj/machinery/bodyscanner,
 /turf/open/floor/tile/blue/whitebluecorner,
@@ -5706,9 +5583,7 @@
 /area/lv624/lazarus/quartstorage/outdoors)
 "azM" = (
 /obj/structure/fence,
-/turf/open/floor/plating/ground/dirtgrassborder/corner2{
-	dir = 4
-	},
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/lazarus/quartstorage/outdoors)
 "azN" = (
 /turf/open/floor/plating/ground/dirtgrassborder/corner{
@@ -5718,9 +5593,7 @@
 "azO" = (
 /obj/structure/jungle/plantbot1/alien,
 /obj/structure/jungle/vines,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 1
-	},
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle5)
 "azP" = (
 /turf/open/ground/grass,
@@ -5814,17 +5687,13 @@
 /obj/structure/jungle/vines,
 /turf/open/floor/plating/ground/dirtgrassborder/corner,
 /area/lv624/ground/jungle5)
-"aAr" = (
-/obj/structure/jungle/vines,
-/turf/open/floor/plating/ground/dirtgrassborder,
-/area/lv624/ground/jungle5)
 "aAs" = (
 /turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/ground/jungle5)
 "aAt" = (
 /obj/structure/jungle/planttop1,
-/turf/open/floor/plating/ground/dirtgrassborder/corner{
-	dir = 1
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 8
 	},
 /area/lv624/ground/jungle5)
 "aAw" = (
@@ -5877,21 +5746,10 @@
 /obj/structure/flora/tree/jungle/small,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle6)
-"aAF" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/ground/dirtgrassborder/corner,
-/area/lv624/ground/jungle6)
 "aAG" = (
 /obj/structure/jungle/vines,
 /obj/structure/jungle/vines/heavy,
 /turf/open/floor/plating/ground/dirtgrassborder,
-/area/lv624/ground/jungle6)
-"aAH" = (
-/obj/structure/jungle/vines,
-/obj/structure/jungle/vines/heavy,
-/turf/open/floor/plating/ground/dirtgrassborder/corner{
-	dir = 1
-	},
 /area/lv624/ground/jungle6)
 "aAK" = (
 /obj/structure/table,
@@ -6026,6 +5884,7 @@
 /area/lv624/lazarus/medbay)
 "aBp" = (
 /obj/machinery/door/window/southleft,
+/obj/effect/alien/weeds/node,
 /turf/open/floor/tile/blue/whitebluecorner,
 /area/lv624/lazarus/medbay)
 "aBq" = (
@@ -6235,12 +6094,6 @@
 /obj/structure/jungle/plantbot1/alien,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle6)
-"aCu" = (
-/obj/structure/jungle/vines,
-/turf/open/floor/plating/ground/dirtgrassborder/corner{
-	dir = 4
-	},
-/area/lv624/ground/jungle6)
 "aCw" = (
 /obj/structure/bed/roller,
 /turf/open/floor/tile/blue/whitebluecorner,
@@ -6265,6 +6118,7 @@
 	name = "\improper Hydroponics Dome"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/alien/weeds/node,
 /turf/open/floor/tile/green/greentaupe{
 	dir = 1
 	},
@@ -6273,6 +6127,7 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
 	},
+/obj/effect/alien/weeds/node,
 /turf/open/floor,
 /area/lv624/ground/jungle6)
 "aCD" = (
@@ -6474,11 +6329,6 @@
 	dir = 1
 	},
 /area/lv624/ground/jungle6)
-"aEf" = (
-/turf/open/floor/plating/ground/dirtgrassborder/corner2{
-	dir = 8
-	},
-/area/lv624/ground/compound/n)
 "aEh" = (
 /turf/open/space/basic,
 /area/lv624/ground/jungle7)
@@ -6512,6 +6362,7 @@
 /obj/item/stack/sheet/wood{
 	amount = 2
 	},
+/obj/effect/alien/weeds/node,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/quartstorage)
 "aED" = (
@@ -6776,12 +6627,16 @@
 /area/lv624/lazarus/research)
 "aGe" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/open/ground/grass,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
+	},
 /area/lv624/ground/compound/n)
 "aGf" = (
 /obj/structure/jungle/planttop1,
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/open/ground/grass,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
+	},
 /area/lv624/ground/compound/n)
 "aGg" = (
 /turf/open/ground/grass,
@@ -6863,6 +6718,7 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
+/obj/effect/alien/weeds/node,
 /turf/open/floor/tile/purple/whitepurple{
 	dir = 5
 	},
@@ -7288,6 +7144,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/effect/alien/weeds/node,
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/research)
 "aJm" = (
@@ -7337,7 +7194,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/research)
 "aJu" = (
@@ -7353,7 +7209,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/tile/purple/whitepurple{
 	dir = 5
 	},
@@ -7364,19 +7219,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/cable,
+/obj/effect/alien/weeds/node,
 /turf/open/floor,
 /area/lv624/lazarus/research)
 "aJw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
-/obj/structure/cable,
 /turf/open/floor,
 /area/lv624/lazarus/fitness)
 "aJx" = (
 /obj/effect/decal/cleanable/blood/splatter/animated,
-/obj/structure/cable,
 /turf/open/floor/tile/purple/whitepurple{
 	dir = 5
 	},
@@ -8422,6 +8275,7 @@
 "aPs" = (
 /obj/item/reagent_containers/food/snacks/donkpocket,
 /obj/structure/flora/pottedplant,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /turf/open/floor/tile/purple/taupepurple{
 	dir = 9
 	},
@@ -8436,6 +8290,7 @@
 /area/lv624/lazarus/sleep_female)
 "aPu" = (
 /obj/item/stack/sheet/metal,
+/obj/effect/alien/weeds/node,
 /turf/open/floor/tile/purple/taupepurple{
 	dir = 9
 	},
@@ -8559,7 +8414,6 @@
 /obj/structure/bed/chair/office/light{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/tile/blue/taupebluecorner,
 /area/lv624/lazarus/sleep_male)
 "aQj" = (
@@ -8681,11 +8535,6 @@
 /obj/structure/cable,
 /turf/open/floor/vault,
 /area/lv624/lazarus/quartstorage)
-"aQz" = (
-/obj/effect/decal/cleanable/blood,
-/obj/structure/cable,
-/turf/open/floor/tile/blue/taupebluecorner,
-/area/lv624/lazarus/sleep_male)
 "aQD" = (
 /obj/machinery/landinglight/ds1/delayone{
 	dir = 4
@@ -8702,6 +8551,12 @@
 	dir = 1
 	},
 /area/lv624/ground/jungle4)
+"aQO" = (
+/obj/structure/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 8
+	},
+/area/lv624/ground/jungle8)
 "aQP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -8768,7 +8623,6 @@
 /obj/structure/bed/chair/wood/wings{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/tile/blue/taupebluecorner,
 /area/lv624/lazarus/sleep_male)
 "aQZ" = (
@@ -8780,7 +8634,6 @@
 	dir = 1;
 	name = "\improper Nexus Dome Male Dormitories"
 	},
-/obj/structure/cable,
 /turf/open/floor/tile/blue/taupebluecorner,
 /area/lv624/lazarus/sleep_male)
 "aRc" = (
@@ -9040,6 +8893,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/effect/alien/weeds/node,
 /turf/open/floor/tile/blue/taupebluecorner,
 /area/lv624/lazarus/sleep_male)
 "aSl" = (
@@ -9467,6 +9321,7 @@
 	dir = 4;
 	on = 1
 	},
+/obj/effect/alien/weeds/node,
 /turf/open/floor/freezer,
 /area/lv624/lazarus/toilet)
 "aUi" = (
@@ -9768,6 +9623,11 @@
 	dir = 8
 	},
 /area/shuttle/drop2/lz2)
+"aVt" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/c)
 "aVu" = (
 /obj/machinery/shower{
 	dir = 8
@@ -9790,6 +9650,7 @@
 /area/lv624/lazarus/chapel)
 "aVx" = (
 /obj/structure/cable,
+/obj/effect/alien/weeds/node,
 /turf/open/floor/wood,
 /area/lv624/lazarus/chapel)
 "aVy" = (
@@ -9865,12 +9726,6 @@
 "aVS" = (
 /turf/closed/gm/dense,
 /area/shuttle/drop2/lz2)
-"aVZ" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/ground/dirtgrassborder/corner{
-	dir = 1
-	},
-/area/lv624/ground/jungle9)
 "aWa" = (
 /obj/effect/glowshroom,
 /turf/open/floor/freezer,
@@ -9916,6 +9771,7 @@
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
+/obj/effect/alien/weeds/node,
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/lazarus/quart)
 "aWk" = (
@@ -9985,10 +9841,6 @@
 	dir = 4
 	},
 /area/lv624/ground/compound/c)
-"aWF" = (
-/obj/structure/flora/tree/jungle,
-/turf/open/ground/grass,
-/area/lv624/ground/jungle9)
 "aWG" = (
 /turf/open/floor/plating/ground/dirtgrassborder/corner2{
 	dir = 8
@@ -10013,6 +9865,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
+/obj/effect/alien/weeds/node,
 /turf/open/floor/freezer,
 /area/lv624/lazarus/toilet)
 "aWL" = (
@@ -10099,7 +9952,9 @@
 "aXf" = (
 /obj/structure/jungle/plantbot1,
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/open/ground/grass,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
+	},
 /area/lv624/ground/jungle9)
 "aXg" = (
 /obj/structure/jungle/vines,
@@ -10300,6 +10155,7 @@
 /area/lv624/lazarus/main_hall)
 "aYb" = (
 /obj/effect/decal/cleanable/vomit,
+/obj/effect/alien/weeds/node,
 /turf/open/floor/tile/blue/whiteblue{
 	dir = 10
 	},
@@ -10456,6 +10312,7 @@
 	name = "Automatic Teller Machine";
 	pixel_y = 30
 	},
+/obj/effect/alien/weeds/node,
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/main_hall)
 "aYO" = (
@@ -10675,6 +10532,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
+/obj/effect/alien/weeds/node,
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/main_hall)
 "bai" = (
@@ -11106,6 +10964,7 @@
 "bcB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/effect/alien/weeds/node,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/sw)
 "bcC" = (
@@ -11208,11 +11067,13 @@
 /area/lv624/lazarus/main_hall)
 "bcV" = (
 /obj/item/trash/raisins,
+/obj/effect/alien/weeds/node,
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/main_hall)
 "bcW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
+/obj/effect/alien/weeds/node,
 /turf/open/floor/tile/green/whitegreen,
 /area/lv624/lazarus/main_hall)
 "bcY" = (
@@ -11895,6 +11756,10 @@
 	},
 /turf/open/ground/grass,
 /area/lv624/ground/jungle3)
+"bgH" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/sw)
 "bgL" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/ground/grass/grass2,
@@ -11925,6 +11790,7 @@
 /obj/structure/flora/grass/both,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
+/obj/effect/alien/weeds/node,
 /turf/open/floor/grass,
 /area/lv624/lazarus/main_hall)
 "bgU" = (
@@ -12167,6 +12033,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/alien/weeds/node,
 /turf/open/floor/wood{
 	icon_state = "wood-broken6"
 	},
@@ -12188,6 +12055,7 @@
 /area/lv624/lazarus/hop)
 "biv" = (
 /obj/structure/flora/bush,
+/obj/machinery/atmospherics/pipe/manifold4w/cyan/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
 /turf/open/floor/grass,
@@ -12326,6 +12194,7 @@
 /area/lv624/lazarus/captain)
 "bje" = (
 /obj/structure/cable,
+/obj/effect/alien/weeds/node,
 /turf/open/floor/grimy,
 /area/lv624/lazarus/captain)
 "bjf" = (
@@ -12501,6 +12370,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/alien/weeds/node,
 /turf/open/floor/grass,
 /area/lv624/lazarus/main_hall)
 "bjT" = (
@@ -12562,6 +12432,7 @@
 "bkw" = (
 /obj/structure/dispenser/oxygen,
 /obj/structure/largecrate/random,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/lv624/lazarus/engineering)
 "bkz" = (
@@ -12579,12 +12450,13 @@
 	pixel_y = 30
 	},
 /obj/structure/cable,
-/obj/machinery/computer/nuke_disk_generator/blue,
 /turf/open/floor/plating,
 /area/lv624/lazarus/engineering)
 "bkD" = (
+/obj/machinery/power/smes/buildable/empty{
+	dir = 1
+	},
 /obj/structure/cable,
-/obj/machinery/power/terminal,
 /turf/open/floor/plating/platebotc,
 /area/lv624/lazarus/engineering)
 "bkF" = (
@@ -12683,6 +12555,7 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/sw)
 "blh" = (
+/obj/effect/alien/weeds/node,
 /turf/open/floor/plating/warning,
 /area/lv624/lazarus/engineering)
 "blj" = (
@@ -12698,7 +12571,7 @@
 /area/lv624/lazarus/engineering)
 "bln" = (
 /obj/structure/cable,
-/obj/machinery/power/smes/buildable/empty{
+/obj/machinery/power/terminal{
 	dir = 1
 	},
 /turf/open/floor/plating/platebot,
@@ -12834,6 +12707,12 @@
 	dir = 1
 	},
 /area/lv624/lazarus/quartstorage/outdoors)
+"blO" = (
+/obj/structure/cable,
+/turf/open/floor/plating/warning{
+	dir = 4
+	},
+/area/lv624/lazarus/engineering)
 "blP" = (
 /obj/machinery/power/geothermal,
 /obj/structure/lattice,
@@ -13067,6 +12946,7 @@
 /area/lv624/lazarus/hop)
 "bmP" = (
 /obj/structure/filingcabinet/chestdrawer,
+/obj/effect/alien/weeds/node,
 /turf/open/floor/grimy,
 /area/lv624/lazarus/hop)
 "bmQ" = (
@@ -13123,6 +13003,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/alien/weeds/node,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/secure_storage)
 "bna" = (
@@ -13184,6 +13065,7 @@
 /area/lv624/ground/compound/sw)
 "bnm" = (
 /obj/effect/decal/cleanable/blood/oil,
+/obj/structure/cable,
 /turf/open/floor/plating/warning{
 	dir = 4
 	},
@@ -13343,6 +13225,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
+/obj/effect/alien/weeds/node,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/se)
 "bnZ" = (
@@ -13514,8 +13397,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/structure/cable/layer1,
+/obj/effect/alien/weeds/node,
 /turf/open/floor/plating/warning{
 	dir = 1
 	},
@@ -13525,7 +13407,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/cable/layer1,
 /turf/open/floor/plating/warning{
 	dir = 1
 	},
@@ -13556,6 +13437,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/alien/weeds/node,
 /turf/open/floor/plating,
 /area/lv624/lazarus/engineering)
 "boJ" = (
@@ -13704,6 +13586,7 @@
 	dir = 4;
 	on = 1
 	},
+/obj/effect/alien/weeds/node,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/secure_storage)
 "bps" = (
@@ -13742,6 +13625,7 @@
 /area/lv624/lazarus/engineering)
 "bpJ" = (
 /obj/item/ammo_magazine/pistol,
+/obj/structure/cable,
 /turf/open/floor/plating/warning,
 /area/lv624/lazarus/engineering)
 "bpM" = (
@@ -13975,6 +13859,7 @@
 /area/lv624/lazarus/engineering)
 "bqU" = (
 /obj/effect/decal/cleanable/blood/oil,
+/obj/effect/alien/weeds/node,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/engineering)
 "bqV" = (
@@ -13993,12 +13878,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
+/obj/effect/alien/weeds/node,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/se)
 "bqZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
+/obj/effect/alien/weeds/node,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/se)
 "brb" = (
@@ -14324,6 +14211,10 @@
 /obj/machinery/light,
 /turf/open/floor/marking/warning,
 /area/shuttle/drop2/lz2)
+"bFY" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
 "bGG" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -14337,7 +14228,7 @@
 	},
 /area/lv624/ground/jungle7)
 "bKi" = (
-/obj/structure/cable,
+/obj/machinery/computer/nuke_disk_generator/blue,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/engineering)
 "bLL" = (
@@ -14356,18 +14247,27 @@
 	dir = 4
 	},
 /area/lv624/ground/jungle9)
-"bRL" = (
-/obj/structure/cable/layer1,
-/turf/open/floor/plating/warning,
-/area/lv624/lazarus/engineering)
+"bZg" = (
+/obj/item/attachable/quickfire,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating,
+/area/lv624/ground/tfort)
 "bZw" = (
 /obj/machinery/miner/damaged,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle9)
+"cah" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/security)
 "cat" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/gm/dense,
 /area/lv624/ground/jungle7)
+"cay" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor,
+/area/lv624/ground/sand2)
 "cbi" = (
 /obj/structure/prop/mainship/hangar_stencil,
 /obj/effect/decal/warning_stripes/thick{
@@ -14376,6 +14276,29 @@
 /obj/effect/decal/warning_stripes/thick,
 /turf/open/floor,
 /area/shuttle/drop1/lz1)
+"cdx" = (
+/obj/effect/decal/warning_stripes/thin,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"ceg" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
+	},
+/area/lv624/ground/jungle7)
+"cfh" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle7)
+"cfn" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
 "chK" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
@@ -14388,6 +14311,9 @@
 /obj/structure/jungle/vines,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle3)
+"clw" = (
+/turf/closed/wall/indestructible/mineral,
+/area/lv624/ground/sand1)
 "cml" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/ground/dirt,
@@ -14418,12 +14344,31 @@
 /obj/structure/catwalk,
 /turf/open/ground/grass/beach,
 /area/lv624/ground/jungle9)
+"cpb" = (
+/obj/machinery/door/airlock/sandstone{
+	desc = "This strange temple is covered in runes. It looks extremely ancient.";
+	icon_state = "door_locked";
+	locked = 1;
+	name = "Strange Temple"
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1)
+"cpl" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/alien/weeds/node,
+/turf/open/floor,
+/area/lv624/ground/sand9)
 "csn" = (
 /obj/machinery/landinglight/ds1/delaytwo{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/shuttle/drop2/lz2)
+"cuw" = (
+/turf/closed/wall/indestructible/mineral,
+/area/lv624/ground/caves/west1)
 "cvB" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/dirtgrassborder,
@@ -14450,14 +14395,40 @@
 	dir = 1
 	},
 /area/lv624/ground/jungle3)
+"cBt" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating,
+/area/lv624/ground/river1)
+"cBC" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle6)
+"cCd" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/white/warningstripe{
+	dir = 8
+	},
+/area/lv624/lazarus/fitness)
 "cGD" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle4)
+"cIv" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/n)
 "cJc" = (
 /obj/structure/cargo_container,
 /turf/open/floor/marking/bot,
 /area/shuttle/drop2/lz2)
+"cJN" = (
+/turf/open/floor/plating/warning{
+	dir = 9
+	},
+/area/lv624/ground/river1)
 "cMZ" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -14474,9 +14445,6 @@
 /area/lv624/lazarus/quartstorage)
 "cTN" = (
 /obj/machinery/computer/intel_computer,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /turf/open/floor/grimy,
 /area/lv624/lazarus/hop)
 "cTX" = (
@@ -14488,11 +14456,11 @@
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/central1)
-"cUM" = (
-/obj/structure/table,
-/obj/structure/cable,
-/turf/open/floor/tile/blue/taupebluecorner,
-/area/lv624/lazarus/sleep_male)
+"cXD" = (
+/obj/structure/jungle/vines,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle5)
 "cYA" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
@@ -14502,12 +14470,18 @@
 /area/lv624/ground/jungle1)
 "cYJ" = (
 /obj/effect/alien/weeds/node,
-/turf/closed/mineral,
+/turf/closed/wall/indestructible/mineral,
 /area/lv624/ground/sand1)
 "cZd" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral,
 /area/lv624/ground/caves/central3)
+"cZY" = (
+/obj/structure/catwalk,
+/turf/open/ground/coast/corner2{
+	dir = 1
+	},
+/area/lv624/ground/river3)
 "dav" = (
 /obj/machinery/floodlight/colony,
 /turf/open/ground/grass,
@@ -14544,6 +14518,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/sw)
+"dpa" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/platebotc,
+/area/lv624/lazarus/quartstorage/outdoors)
+"dtR" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor,
+/area/lv624/ground/sand5)
 "duU" = (
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 4
@@ -14566,6 +14548,10 @@
 	dir = 1
 	},
 /area/lv624/ground/river1)
+"dzq" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/wood/broken,
+/area/lv624/ground/ruin)
 "dBQ" = (
 /obj/effect/decal/warning_stripes/thick{
 	dir = 5
@@ -14577,6 +14563,10 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle1)
+"dEu" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/research)
 "dEz" = (
 /turf/open/ground/coast/corner2,
 /area/lv624/ground/jungle9)
@@ -14586,6 +14576,10 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle1)
+"dFh" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
 "dIo" = (
 /obj/machinery/floodlight/colony,
 /turf/open/floor,
@@ -14596,6 +14590,10 @@
 	dir = 8
 	},
 /area/lv624/ground/jungle7)
+"dNC" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/ground/caves/east1)
 "dQh" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/open/ground/grass,
@@ -14606,19 +14604,38 @@
 "dVC" = (
 /turf/open/floor/plating,
 /area/shuttle/drop2/lz2)
+"dWl" = (
+/obj/structure/mineral_door/resin,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand1)
 "dXe" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/gm/dense,
 /area/lv624/ground/jungle1)
+"dYX" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/red/redtaupe{
+	dir = 9
+	},
+/area/lv624/lazarus/security)
 "dZV" = (
 /obj/machinery/floodlight/colony,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle9)
-"eaL" = (
-/obj/structure/cable,
-/obj/structure/cable/layer1,
-/turf/open/floor/plating,
-/area/lv624/lazarus/engineering)
+"eci" = (
+/obj/structure/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle7)
+"ekH" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/wall/indestructible/mineral,
+/area/lv624/ground/caves/west1)
+"elc" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
+	dir = 8
+	},
+/area/lv624/ground/jungle6)
 "emp" = (
 /turf/open/ground/grass/beach/corner{
 	dir = 4
@@ -14631,6 +14648,12 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/quartstorage)
+"emG" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/corner{
+	dir = 8
+	},
+/area/lv624/ground/jungle6)
 "enr" = (
 /turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/ground/jungle4)
@@ -14642,6 +14665,10 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/gm/dense,
 /area/lv624/ground/jungle3)
+"esC" = (
+/obj/structure/jungle/plantbot1/alien,
+/turf/open/floor,
+/area/lv624/ground/river3)
 "etu" = (
 /obj/structure/resin/xeno_turret,
 /turf/open/floor/plating/ground/dirt,
@@ -14672,6 +14699,17 @@
 	dir = 4
 	},
 /area/lv624/lazarus/engineering)
+"eCO" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"eEp" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle5)
+"eEB" = (
+/turf/closed/wall/indestructible/mineral,
+/area/lv624/ground/caves/west2)
 "eHq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -14702,6 +14740,10 @@
 "eOl" = (
 /turf/closed/wall/resin/thick,
 /area/lv624/ground/caves/west2)
+"eQc" = (
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
 "eXq" = (
 /obj/machinery/landinglight/ds1/delaytwo{
 	dir = 8
@@ -14725,6 +14767,15 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/wall,
 /area/lv624/lazarus/canteen)
+"feI" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"ffi" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/n)
 "fgu" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/cult,
@@ -14745,6 +14796,18 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral,
 /area/lv624/ground/caves/west1)
+"flP" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
 "fpr" = (
 /obj/structure/jungle/plantbot1,
 /turf/open/floor/plating/ground/dirtgrassborder/corner{
@@ -14762,10 +14825,10 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle2)
-"ftB" = (
-/obj/machinery/miner/damaged,
+"fsZ" = (
+/obj/effect/alien/weeds/node,
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/sand2)
+/area/lv624/ground/jungle8)
 "fug" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
@@ -14783,6 +14846,14 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral,
 /area/lv624/ground/sand1)
+"fwS" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand9)
+"fxk" = (
+/obj/effect/alien/weeds/node,
+/turf/closed/gm/dense,
+/area/lv624/ground/jungle7)
 "fyU" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -14791,6 +14862,16 @@
 	dir = 4
 	},
 /area/lv624/lazarus/quartstorage/outdoors)
+"fBc" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
 "fCU" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -14842,6 +14923,10 @@
 	dir = 1
 	},
 /area/shuttle/drop2/lz2)
+"fPB" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating,
+/area/lv624/ground/river2)
 "fQW" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/dirt,
@@ -14859,7 +14944,7 @@
 /obj/machinery/floodlight/colony{
 	dir = 4
 	},
-/turf/open/floor/plating/ground/dirt,
+/turf/open/ground/grass,
 /area/lv624/ground/jungle6)
 "fUI" = (
 /obj/structure/jungle/vines,
@@ -14914,10 +14999,6 @@
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/engine/cult,
 /area/lv624/ground/caves/west2)
-"ghv" = (
-/obj/machinery/miner/damaged,
-/turf/open/floor/plating/ground/dirtgrassborder/corner,
-/area/lv624/ground/jungle7)
 "giD" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/gm/dense,
@@ -14958,6 +15039,12 @@
 	dir = 1
 	},
 /area/lv624/ground/jungle7)
+"guw" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/c)
 "gwG" = (
 /obj/structure/jungle/vines,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -14996,18 +15083,39 @@
 	dir = 8
 	},
 /area/lv624/ground/jungle7)
+"gJp" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle7)
 "gKE" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 8
 	},
 /area/lv624/ground/jungle3)
+"gMe" = (
+/obj/structure/jungle/vines,
+/obj/effect/alien/weeds/node,
+/turf/open/floor,
+/area/lv624/ground/river3)
 "gMl" = (
 /obj/structure/jungle/vines,
 /turf/open/ground/grass/beach{
 	dir = 1
 	},
 /area/lv624/ground/jungle9)
+"gNA" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/turf/open/ground/river,
+/area/lv624/ground/river2)
+"gOC" = (
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/catwalk,
+/turf/open/ground/river,
+/area/lv624/ground/river3)
 "gPc" = (
 /obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
@@ -15044,14 +15152,36 @@
 "gXL" = (
 /turf/open/floor/plating,
 /area/lv624/ground/tfort)
+"hdZ" = (
+/obj/item/ammo_magazine/smg/m25,
+/obj/item/ammo_magazine/smg/m25,
+/obj/item/ammo_magazine/smg/m25,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating,
+/area/lv624/ground/tfort)
 "heg" = (
 /obj/structure/flora/tree/jungle,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle1)
+"hfG" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 4
+	},
+/area/lv624/ground/jungle7)
+"hgM" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/wall/indestructible/mineral,
+/area/lv624/ground/caves/central3)
 "hkc" = (
 /obj/effect/spawner/modularmap/lv624/domes,
 /turf/open/space/basic,
 /area/lv624/lazarus/atmos)
+"hmT" = (
+/obj/structure/jungle/vines,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/platebotc,
+/area/lv624/ground/jungle9)
 "hnZ" = (
 /turf/open/floor/plating/ground/dirtgrassborder/corner2{
 	dir = 8
@@ -15065,6 +15195,11 @@
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle5)
+"hsW" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/structure/mineral_door/resin,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1)
 "hvg" = (
 /obj/machinery/landinglight/ds1{
 	dir = 1
@@ -15079,16 +15214,28 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/cult,
 /area/lv624/ground/caves/west2)
+"hAH" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/engineering)
 "hBj" = (
 /obj/machinery/floodlight/colony{
 	dir = 8
 	},
 /turf/open/ground/grass,
 /area/lv624/ground/jungle3)
+"hCZ" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating,
+/area/lv624/ground/river3)
 "hDA" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/wall,
 /area/lv624/ground/river2)
+"hGZ" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/main_hall)
 "hHD" = (
 /obj/machinery/miner/damaged,
 /turf/open/ground/grass,
@@ -15114,6 +15261,12 @@
 	},
 /turf/open/floor/marking/bot,
 /area/shuttle/drop2/lz2)
+"hVH" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/research)
 "ibX" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating/ground/dirt,
@@ -15144,6 +15297,7 @@
 /obj/structure/window/framed/colony/reinforced,
 /obj/machinery/door/poddoor/mainship{
 	density = 0;
+	dir = 4;
 	icon_state = "pdoor0";
 	id = "nexus_blast";
 	name = "\improper Nexus Blast Door";
@@ -15164,6 +15318,11 @@
 	dir = 4
 	},
 /area/shuttle/drop1/lz1)
+"ipV" = (
+/obj/effect/alien/weeds/node,
+/obj/structure/resin/xeno_turret,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central3)
 "iuG" = (
 /obj/structure/mineral_door/resin,
 /obj/effect/landmark/lv624/fog_blocker,
@@ -15177,6 +15336,19 @@
 /obj/structure/jungle/vines,
 /turf/closed/gm/dense,
 /area/lv624/ground/jungle6)
+"iyJ" = (
+/obj/effect/alien/weeds/node,
+/turf/closed/wall/cult,
+/area/lv624/ground/caves/west1)
+"iAy" = (
+/obj/structure/cable,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle6)
+"iAI" = (
+/obj/structure/catwalk,
+/turf/open/floor/plating,
+/area/lv624/ground/sand8)
 "iBb" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -15202,6 +15374,9 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/sw)
+"iII" = (
+/turf/closed/wall/indestructible/mineral,
+/area/lv624/ground/caves/east1)
 "iIS" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/jungle/vines,
@@ -15219,6 +15394,16 @@
 	dir = 4
 	},
 /area/lv624/ground/jungle6)
+"iMC" = (
+/obj/structure/resin/xeno_turret,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1)
+"iQX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/c)
 "iTb" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/closed/gm/dense,
@@ -15245,6 +15430,10 @@
 	dir = 1
 	},
 /area/lv624/ground/jungle3)
+"jeV" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
 "jeZ" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/dirt,
@@ -15261,6 +15450,16 @@
 	dir = 1
 	},
 /area/lv624/ground/jungle6)
+"jjQ" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall/indestructible/mineral,
+/area/lv624/ground/caves/west1)
+"jnF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/quartstorage/outdoors)
 "jqE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
@@ -15299,6 +15498,10 @@
 	dir = 4
 	},
 /area/shuttle/drop2/lz2)
+"jAP" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/kitchen)
 "jCY" = (
 /obj/structure/sign/redcross{
 	dir = 8
@@ -15325,6 +15528,21 @@
 	dir = 4
 	},
 /area/shuttle/drop2/lz2)
+"jJh" = (
+/obj/structure/catwalk,
+/obj/structure/catwalk,
+/turf/open/ground/river,
+/area/lv624/ground/river2)
+"jJK" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/wall/indestructible/mineral,
+/area/lv624/ground/caves/central1)
+"jLQ" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
+	dir = 4
+	},
+/area/lv624/ground/compound/c)
 "jLW" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
@@ -15359,6 +15577,10 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/ground/river,
 /area/lv624/ground/river2)
+"jXK" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/quartstorage/outdoors)
 "jYV" = (
 /obj/machinery/floodlight/colony{
 	dir = 4
@@ -15370,6 +15592,14 @@
 /obj/item/tool/pen,
 /turf/open/floor,
 /area/shuttle/drop2/lz2)
+"kfz" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/ground/ruin)
+"kfW" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/plating/ground/dirtgrassborder,
+/area/lv624/ground/jungle7)
 "kir" = (
 /obj/docking_port/stationary/crashmode,
 /obj/structure/fence,
@@ -15385,6 +15615,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/c)
+"knr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
 "krI" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -15403,6 +15638,15 @@
 	dir = 8
 	},
 /area/lv624/ground/jungle1)
+"kuU" = (
+/obj/structure/cable,
+/turf/closed/wall,
+/area/lv624/ground/jungle9)
+"kvA" = (
+/obj/structure/jungle/vines,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
 "kyC" = (
 /obj/structure/jungle/vines,
 /obj/structure/jungle/vines,
@@ -15413,6 +15657,10 @@
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle7)
+"kFc" = (
+/obj/effect/landmark/monkey_spawn,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
 "kFx" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/resin,
@@ -15444,6 +15692,18 @@
 	dir = 8
 	},
 /area/shuttle/drop1/lz1)
+"kHl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/c)
+"kKo" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/c)
 "kMj" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -15504,6 +15764,9 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle6)
+"lcH" = (
+/turf/open/floor,
+/area/lv624/ground/river3)
 "lda" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral,
@@ -15520,14 +15783,27 @@
 	dir = 8
 	},
 /area/lv624/ground/jungle9)
+"lfP" = (
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/hop)
 "lgm" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/resin/thick,
 /area/lv624/ground/caves/east1)
+"lhR" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/blue/whitebluecorner,
+/area/lv624/lazarus/medbay)
 "ljt" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/ground/compound/sw)
+"lki" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/green/whitegreencorner,
+/area/lv624/lazarus/main_hall)
 "lkM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -15541,8 +15817,16 @@
 	},
 /area/lv624/ground/jungle7)
 "lpJ" = (
-/turf/open/floor/plating/warning,
+/turf/open/floor/plating/warning{
+	dir = 2
+	},
 /area/lv624/ground/filtration)
+"lsc" = (
+/obj/structure/catwalk,
+/turf/open/ground/coast{
+	dir = 6
+	},
+/area/lv624/ground/river3)
 "lsn" = (
 /obj/machinery/miner/damaged,
 /turf/open/ground/grass/grass2,
@@ -15552,6 +15836,10 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/west1)
+"ltG" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating,
+/area/lv624/lazarus/toilet)
 "lwi" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/ground/dirt,
@@ -15569,11 +15857,19 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/quartstorage)
+"lxH" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating,
+/area/lv624/ground/sand7)
 "lyK" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle9)
+"lEt" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor,
+/area/lv624/ground/river2)
 "lFb" = (
 /obj/structure/barricade/wooden{
 	dir = 4
@@ -15586,6 +15882,11 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/central1)
+"lGO" = (
+/obj/item/ammo_casing,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating,
+/area/lv624/ground/tfort)
 "lIv" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/dirt,
@@ -15666,6 +15967,12 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/n)
+"mlI" = (
+/obj/structure/jungle/plantbot1/alien,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
+	},
+/area/lv624/ground/jungle6)
 "mmj" = (
 /obj/effect/decal/warning_stripes/thick{
 	dir = 4
@@ -15730,10 +16037,6 @@
 	dir = 4
 	},
 /area/lv624/lazarus/console)
-"mMl" = (
-/obj/structure/cable/layer1,
-/turf/open/floor/plating,
-/area/lv624/lazarus/engineering)
 "mNl" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -15783,11 +16086,22 @@
 	},
 /turf/open/ground/grass,
 /area/lv624/ground/jungle3)
+"nqK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/research)
 "nrB" = (
 /obj/structure/jungle/vines/heavy,
 /obj/structure/jungle/vines/heavy,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle1)
+"nsb" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
+	dir = 4
+	},
+/area/lv624/ground/compound/sw)
 "nwR" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
@@ -15807,10 +16121,25 @@
 	dir = 4
 	},
 /area/shuttle/drop2/lz2)
+"nAc" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/sw)
 "nAQ" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle4)
+"nAV" = (
+/obj/structure/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 8
+	},
+/area/lv624/ground/jungle7)
+"nCi" = (
+/obj/structure/jungle/vines,
+/obj/structure/jungle/vines/heavy,
+/turf/closed/gm/dense,
+/area/lv624/ground/jungle6)
 "nDI" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/dirt,
@@ -15840,11 +16169,19 @@
 	dir = 10
 	},
 /area/shuttle/drop2/lz2)
+"nGf" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
 "nGq" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle4)
+"nMR" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirtgrassborder,
+/area/lv624/ground/jungle9)
 "nNn" = (
 /obj/effect/alien/weeds/node,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -15860,6 +16197,20 @@
 /obj/structure/mineral_door/resin/thick,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/west2)
+"nVu" = (
+/obj/structure/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
+	},
+/area/lv624/ground/jungle7)
+"obS" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
 "oer" = (
 /obj/structure/cargo_container/nt{
 	dir = 1
@@ -15869,6 +16220,13 @@
 "oeN" = (
 /turf/closed/wall,
 /area/storage/testroom)
+"ohD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/n)
 "ohL" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/dirt,
@@ -15887,6 +16245,10 @@
 /obj/structure/resin/xeno_turret,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/central1)
+"opM" = (
+/obj/machinery/miner/damaged,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle6)
 "oqF" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/dirt,
@@ -15895,6 +16257,10 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand8)
+"oqW" = (
+/obj/structure/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirtgrassborder/corner,
+/area/lv624/ground/jungle6)
 "orD" = (
 /obj/machinery/power/apc/drained{
 	dir = 4
@@ -15904,6 +16270,14 @@
 	dir = 8
 	},
 /area/shuttle/drop1/lz1)
+"otV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
 "ozL" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/resin/thick,
@@ -15945,6 +16319,10 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/wall/r_wall,
 /area/shuttle/drop2/lz2)
+"oNd" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating,
+/area/lv624/ground/river3)
 "oQb" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/tile/dark,
@@ -15955,10 +16333,23 @@
 	},
 /turf/open/floor,
 /area/lv624/ground/compound/n)
+"oWd" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/wall/indestructible/mineral,
+/area/lv624/ground/sand1)
 "oWX" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/resin,
 /area/lv624/ground/caves/east2)
+"oXT" = (
+/obj/structure/jungle/plantbot1,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle7)
+"oYK" = (
+/obj/structure/jungle/vines,
+/obj/structure/catwalk,
+/turf/open/ground/coast,
+/area/lv624/ground/river3)
 "pkT" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -16009,6 +16400,9 @@
 	dir = 1
 	},
 /area/shuttle/drop1/lz1)
+"pxE" = (
+/turf/closed/wall/cult,
+/area/lv624/ground/sand8)
 "pxU" = (
 /obj/machinery/floodlight/colony{
 	dir = 1
@@ -16033,6 +16427,12 @@
 	},
 /turf/open/floor/marking/bot,
 /area/shuttle/drop2/lz2)
+"pDe" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics)
 "pDN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16058,6 +16458,10 @@
 	},
 /turf/open/floor,
 /area/shuttle/drop1/lz1)
+"pId" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
 "pMV" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/engine/cult,
@@ -16066,6 +16470,17 @@
 /obj/structure/jungle/vines,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle4)
+"pPr" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating,
+/area/lv624/lazarus/kitchen)
+"pQE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/research)
 "pRf" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/ground/dirtgrassborder/corner{
@@ -16076,9 +16491,21 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/plating/ground/dirtgrassborder/corner,
 /area/lv624/ground/jungle6)
+"pWM" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating,
+/area/lv624/ground/sand8)
 "pZl" = (
 /turf/open/ground/coast,
 /area/lv624/ground/jungle9)
+"pZX" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/sw)
 "qdb" = (
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/dirtgrassborder/corner2{
@@ -16103,20 +16530,32 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/sw)
+"qkT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"qlb" = (
+/turf/open/floor/plating/warning{
+	dir = 5
+	},
+/area/lv624/ground/river1)
 "qmj" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/wall/r_wall,
 /area/lv624/lazarus/canteen)
+"qnO" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/sw)
 "qow" = (
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand2)
-"qrL" = (
-/obj/machinery/miner/damaged,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 4
-	},
-/area/lv624/ground/jungle6)
 "qtw" = (
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/ground/river,
@@ -16140,6 +16579,9 @@
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/ground/grass/grass2,
 /area/lv624/ground/jungle9)
+"qEL" = (
+/turf/closed/wall/indestructible/mineral,
+/area/lv624/ground/sand5)
 "qGH" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -16148,14 +16590,14 @@
 /obj/structure/cable,
 /turf/open/floor/grass,
 /area/lv624/lazarus/main_hall)
-"qHa" = (
-/obj/machinery/floodlight/colony,
-/turf/open/ground/grass,
-/area/lv624/ground/jungle7)
 "qMS" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand5)
+"qNX" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/red/full,
+/area/lv624/lazarus/security)
 "qQj" = (
 /obj/machinery/light{
 	dir = 4
@@ -16180,6 +16622,12 @@
 	dir = 5
 	},
 /area/shuttle/drop1/lz1)
+"qVg" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
 "qXT" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 9
@@ -16188,6 +16636,17 @@
 	dir = 4
 	},
 /area/lv624/ground/jungle3)
+"qYJ" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/ne)
+"qZa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/alien/weeds/node,
+/turf/open/floor,
+/area/lv624/ground/sand8)
 "rbd" = (
 /obj/effect/alien/egg,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -16199,11 +16658,19 @@
 	},
 /turf/open/ground/grass,
 /area/lv624/ground/jungle4)
+"rbW" = (
+/obj/machinery/miner/damaged,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/west1)
 "rgp" = (
 /turf/open/floor/plating/ground/dirtgrassborder/corner{
 	dir = 4
 	},
 /area/lv624/ground/river1)
+"rlb" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating,
+/area/lv624/ground/tfort)
 "rmy" = (
 /obj/machinery/landinglight/ds1/delaythree{
 	dir = 1
@@ -16215,6 +16682,17 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle4)
+"rnW" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
+	},
+/obj/effect/alien/weeds/node,
+/turf/open/floor,
+/area/lv624/ground/jungle7)
+"rsK" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/wall/indestructible/mineral,
+/area/lv624/ground/sand5)
 "rtd" = (
 /obj/structure/mineral_door/resin/thick,
 /turf/open/floor/plating/ground/dirt,
@@ -16236,6 +16714,10 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral,
 /area/lv624/ground/caves/west2)
+"ryU" = (
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/floor,
+/area/lv624/ground/river3)
 "rAj" = (
 /obj/machinery/light{
 	dir = 1
@@ -16247,10 +16729,24 @@
 	dir = 5
 	},
 /area/shuttle/drop2/lz2)
+"rCH" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"rDm" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/wall/indestructible/mineral,
+/area/lv624/ground/sand7)
 "rDw" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/wall,
 /area/lv624/ground/river3)
+"rGv" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/se)
 "rJh" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/ground/grass,
@@ -16266,9 +16762,7 @@
 /area/lv624/ground/caves/east2)
 "rLP" = (
 /obj/machinery/floodlight/colony,
-/turf/open/floor/plating/ground/dirtgrassborder/corner2{
-	dir = 8
-	},
+/turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/river2)
 "rLV" = (
 /obj/effect/decal/warning_stripes/thick,
@@ -16311,10 +16805,22 @@
 /obj/effect/decal/warning_stripes/thick,
 /turf/open/floor,
 /area/shuttle/drop1/lz1)
+"scG" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
 "scW" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral,
 /area/lv624/ground/caves/central1)
+"see" = (
+/obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/engineering)
 "sez" = (
 /obj/effect/alien/egg,
 /turf/open/floor/plating/ground/dirt,
@@ -16325,6 +16831,13 @@
 	},
 /turf/open/floor/tile/bar,
 /area/lv624/lazarus/canteen)
+"siq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/se)
 "six" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/dirt,
@@ -16333,11 +16846,31 @@
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand5)
+"snU" = (
+/obj/structure/jungle/planttop1,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle7)
+"sqN" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand6)
 "ssJ" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/east2)
+"stw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/c)
+"sus" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/corner2,
+/area/lv624/ground/compound/c)
 "szb" = (
 /obj/machinery/landinglight/ds1/delaytwo{
 	dir = 1
@@ -16355,6 +16888,10 @@
 /obj/structure/lazarus_sign,
 /turf/open/floor/plating/ground/dirtgrassborder,
 /area/lv624/ground/compound/sw)
+"sET" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/kitchen)
 "sHi" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/dirt,
@@ -16388,10 +16925,28 @@
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/ground/caves/east1)
+"sTm" = (
+/turf/closed/wall/indestructible/mineral,
+/area/lv624/ground/sand4)
 "sUi" = (
 /obj/item/reagent_containers/food/snacks/worm,
-/turf/open/floor/plating/ground/dirt,
+/turf/open/floor/plating/ground/dirtgrassborder/corner2,
 /area/lv624/ground/jungle7)
+"sWe" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/structure/mineral_door/resin,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east2)
+"sWJ" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
+"taV" = (
+/obj/structure/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
+	},
+/area/lv624/ground/jungle9)
 "tes" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/ground/dirtgrassborder/corner2{
@@ -16402,6 +16957,10 @@
 /obj/effect/alien/egg,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/west1)
+"tiN" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating,
+/area/lv624/ground/sand6)
 "tjA" = (
 /obj/machinery/floodlight/colony,
 /obj/structure/catwalk,
@@ -16409,6 +16968,12 @@
 	dir = 8
 	},
 /area/lv624/ground/sand8)
+"tni" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
 "tod" = (
 /obj/structure/window/framed/colony,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
@@ -16421,6 +16986,21 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/sw)
+"trg" = (
+/obj/structure/jungle/plantbot1,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
+	},
+/area/lv624/ground/jungle7)
+"txw" = (
+/obj/structure/catwalk,
+/turf/open/ground/coast,
+/area/lv624/ground/river1)
+"tzJ" = (
+/obj/structure/cable,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/toilet)
 "tDc" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -16432,11 +17012,19 @@
 	dir = 4
 	},
 /area/lv624/ground/jungle3)
+"tGv" = (
+/turf/closed/wall/indestructible/mineral,
+/area/lv624/ground/caves/east2)
 "tGT" = (
 /obj/machinery/floodlight/colony,
 /obj/structure/catwalk,
 /turf/open/ground/river,
 /area/lv624/ground/sand8)
+"tJm" = (
+/obj/effect/alien/weeds/node,
+/obj/effect/alien/weeds/node,
+/turf/closed/gm/dense,
+/area/lv624/ground/jungle7)
 "tOe" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/alien/weeds/node,
@@ -16453,6 +17041,16 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral,
 /area/lv624/ground/caves/east1)
+"tTL" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor,
+/area/lv624/lazarus/quartstorage)
+"tTR" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/jungle/vines,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle5)
 "tUO" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/dirt,
@@ -16484,10 +17082,18 @@
 	dir = 1
 	},
 /area/lv624/ground/jungle1)
+"uip" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/ruin)
 "ujY" = (
 /obj/structure/resin/xeno_turret,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/west1)
+"ukt" = (
+/obj/structure/jungle/planttop1,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle7)
 "umw" = (
 /obj/effect/alien/egg,
 /turf/open/floor/plating/ground/dirt,
@@ -16518,6 +17124,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/compound/c)
+"uuI" = (
+/turf/closed/wall/indestructible/mineral,
+/area/lv624/ground/caves/central3)
+"uvs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating,
+/area/lv624/ground/sand8)
 "uvx" = (
 /obj/structure/catwalk,
 /turf/open/ground/river,
@@ -16526,10 +17142,35 @@
 /obj/effect/alien/weeds/node,
 /turf/closed/wall/resin/thick,
 /area/lv624/ground/caves/west2)
+"uwl" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/marking/bot,
+/area/lv624/ground/sand2)
+"uAq" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/c)
+"uEj" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/whiteyellow,
+/area/lv624/lazarus/main_hall)
+"uFY" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/corner2,
+/area/lv624/ground/compound/sw)
 "uHv" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/ground/grass,
 /area/lv624/ground/compound/sw)
+"uIJ" = (
+/obj/structure/jungle/vines,
+/obj/structure/catwalk,
+/turf/open/ground/river,
+/area/lv624/ground/river3)
 "uJR" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/jungle/vines,
@@ -16543,9 +17184,9 @@
 /turf/closed/wall/resin,
 /area/lv624/ground/caves/west1)
 "uNG" = (
-/obj/structure/jungle/plantbot1/alien,
 /obj/docking_port/stationary/crashmode,
-/turf/open/ground/river,
+/obj/structure/catwalk,
+/turf/open/ground/coast,
 /area/lv624/ground/river1)
 "uVd" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -16558,10 +17199,21 @@
 /obj/structure/rack,
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/lazarus/quart)
+"vdR" = (
+/obj/structure/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
+	},
+/area/lv624/ground/jungle5)
 "veV" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/gm/dense,
 /area/lv624/ground/jungle3)
+"vgi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/c)
 "vkR" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/dirt,
@@ -16577,6 +17229,10 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle3)
+"vpq" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
 "vpr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -16593,24 +17249,33 @@
 	dir = 1
 	},
 /area/lv624/ground/jungle4)
-"vqo" = (
-/obj/structure/cable/multilayer/layer12,
-/turf/open/floor/tile/dark,
-/area/lv624/lazarus/engineering)
 "vrA" = (
 /obj/structure/mineral_door/resin,
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand4)
+"vsg" = (
+/obj/structure/jungle/planttop1,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
 "vuY" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 4
 	},
 /area/shuttle/drop1/lz1)
-"vzz" = (
-/turf/open/floor/plating,
-/area/lv624/lazarus/engineering)
+"vzO" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle4)
+"vAw" = (
+/obj/effect/decal/warning_stripes/thin,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"vAL" = (
+/turf/closed/wall/indestructible/mineral,
+/area/lv624/ground/sand7)
 "vAO" = (
 /obj/structure/catwalk,
 /turf/open/ground/grass/beach{
@@ -16627,6 +17292,18 @@
 /obj/structure/window_frame/colony,
 /turf/open/floor/plating,
 /area/lv624/ground/jungle9)
+"vEO" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/alien/weeds/node,
+/turf/open/floor,
+/area/lv624/ground/river2)
+"vEP" = (
+/obj/item/frame/table,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
 "vIv" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/dirt,
@@ -16666,8 +17343,10 @@
 "vNz" = (
 /turf/open/floor,
 /area/storage/testroom)
+"vRN" = (
+/turf/closed/wall/indestructible/mineral,
+/area/lv624/ground/caves/central1)
 "vTe" = (
-/obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/sign/botany{
 	dir = 4
 	},
@@ -16680,6 +17359,12 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle1)
+"vXZ" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/chapel{
+	dir = 4
+	},
+/area/lv624/lazarus/chapel)
 "vYo" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/ground/grass/beach{
@@ -16697,6 +17382,11 @@
 	},
 /turf/closed/gm/dense,
 /area/lv624/ground/jungle3)
+"waG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle7)
 "wdm" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/effect/decal/warning_stripes/thin{
@@ -16705,13 +17395,25 @@
 /obj/machinery/floodlight/colony,
 /turf/open/floor,
 /area/lv624/ground/jungle7)
+"wfG" = (
+/obj/structure/jungle/vines,
+/turf/open/floor,
+/area/lv624/ground/river3)
 "wgy" = (
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand9)
+"wiE" = (
+/obj/structure/fence,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle6)
 "wiK" = (
 /turf/closed/wall,
 /area/lv624/ground/filtration)
+"wlI" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle6)
 "wpG" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
@@ -16788,14 +17490,10 @@
 	},
 /turf/closed/gm/dense,
 /area/lv624/lazarus/quartstorage/outdoors)
-"wQI" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 8;
-	on = 1
-	},
+"wPJ" = (
+/obj/structure/jungle/plantbot1,
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/jungle6)
+/area/lv624/ground/jungle9)
 "wVw" = (
 /obj/structure/jungle/vines,
 /turf/open/ground/grass,
@@ -16811,12 +17509,18 @@
 /obj/structure/jungle/vines,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle4)
-"xhd" = (
-/obj/machinery/floodlight/colony,
-/turf/open/floor/plating/ground/dirtgrassborder{
-	dir = 8
-	},
-/area/lv624/ground/jungle9)
+"wYx" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating,
+/area/lv624/ground/river2)
+"wYU" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/plating,
+/area/lv624/ground/sand9)
+"xar" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/quart)
 "xib" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral,
@@ -16841,14 +17545,18 @@
 	},
 /turf/open/ground/grass,
 /area/lv624/ground/jungle2)
-"xtV" = (
-/obj/structure/cable,
-/turf/open/floor/tile/blue/taupebluecorner,
-/area/lv624/lazarus/sleep_male)
+"xuD" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating,
+/area/lv624/ground/river1)
 "xvZ" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand1)
+"xxs" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor,
+/area/lv624/ground/river2)
 "xyp" = (
 /obj/structure/jungle/vines,
 /turf/closed/gm/dense,
@@ -16893,13 +17601,24 @@
 /obj/structure/sign/redcross{
 	dir = 4
 	},
-/turf/open/ground/grass,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 8
+	},
 /area/lv624/ground/jungle6)
+"xNt" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor,
+/area/lv624/ground/river3)
 "xQl" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/jungle/vines,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle9)
+"xRX" = (
+/obj/structure/jungle/plantbot1/alien,
+/obj/structure/catwalk,
+/turf/open/ground/river,
+/area/lv624/ground/river3)
 "xUe" = (
 /obj/effect/alien/egg,
 /turf/open/floor/plating/ground/dirt,
@@ -16907,6 +17626,7 @@
 "xUE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
+/obj/effect/alien/weeds/node,
 /turf/open/floor/tile/bar,
 /area/lv624/lazarus/canteen)
 "xVM" = (
@@ -16923,6 +17643,16 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/main_hall)
+"ybF" = (
+/obj/structure/fence,
+/obj/structure/catwalk,
+/obj/structure/catwalk,
+/turf/open/floor/plating/warning,
+/area/lv624/ground/sand8)
+"ygX" = (
+/obj/effect/alien/weeds/node,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/toilet)
 "ykF" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/marking/warning{
@@ -17152,6 +17882,8 @@ aaa
 aaa
 aaa
 abb
+cuw
+cuw
 abb
 abb
 abb
@@ -17162,6 +17894,21 @@ abb
 abb
 abb
 abb
+abb
+abb
+abb
+abb
+abb
+abb
+abb
+abb
+abb
+abb
+cuw
+cuw
+abb
+abb
+jUj
 abb
 abb
 abb
@@ -17192,25 +17939,8 @@ abb
 abb
 abb
 abb
-abb
-abb
-abb
-jUj
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-ktj
+cuw
+rDm
 awg
 awg
 awg
@@ -17331,6 +18061,8 @@ aaa
 aaa
 aaa
 abb
+cuw
+cuw
 abb
 abb
 abb
@@ -17341,6 +18073,21 @@ abb
 abb
 abb
 abb
+abb
+abb
+abb
+abb
+abb
+abb
+abb
+abb
+abb
+abb
+cuw
+cuw
+abb
+abb
+jUj
 abb
 abb
 abb
@@ -17371,25 +18118,8 @@ abb
 abb
 abb
 abb
-abb
-abb
-abb
-jUj
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-ktj
+cuw
+rDm
 awg
 awg
 awg
@@ -17510,6 +18240,8 @@ aaa
 aaa
 aaa
 abb
+cuw
+cuw
 abb
 abb
 abb
@@ -17520,6 +18252,21 @@ abb
 abb
 abb
 abb
+abb
+abb
+abb
+abb
+abb
+abb
+abb
+abb
+abb
+abb
+cuw
+cuw
+abb
+abb
+jUj
 abb
 abb
 abb
@@ -17550,25 +18297,8 @@ abb
 abb
 abb
 abb
-abb
-abb
-abb
-jUj
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-ktj
+cuw
+rDm
 awg
 awg
 awg
@@ -17689,6 +18419,8 @@ aaa
 aaa
 aaa
 abb
+cuw
+cuw
 abb
 abb
 abb
@@ -17699,6 +18431,21 @@ abb
 abb
 abb
 abb
+abb
+abb
+abb
+abb
+abb
+abb
+abb
+abb
+abb
+abb
+cuw
+cuw
+abb
+abb
+jUj
 abb
 abb
 abb
@@ -17729,25 +18476,8 @@ abb
 abb
 abb
 abb
-abb
-abb
-abb
-jUj
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-ktj
+cuw
+rDm
 awg
 awg
 awg
@@ -17868,6 +18598,8 @@ aaa
 aaa
 aaa
 abb
+cuw
+cuw
 abb
 abb
 abb
@@ -17878,6 +18610,21 @@ abb
 abb
 abb
 abb
+abb
+abb
+abb
+abb
+abb
+abb
+abb
+abb
+abb
+abb
+cuw
+cuw
+abb
+abb
+jUj
 abb
 abb
 abb
@@ -17908,25 +18655,8 @@ abb
 abb
 abb
 abb
-abb
-abb
-abb
-jUj
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-ktj
+cuw
+rDm
 awg
 awg
 awg
@@ -18047,6 +18777,8 @@ aaa
 aaa
 aaa
 abb
+cuw
+cuw
 abb
 abb
 abb
@@ -18057,6 +18789,21 @@ abb
 abb
 abb
 abb
+abb
+abb
+abb
+abb
+abb
+abb
+abb
+abb
+abb
+abb
+cuw
+cuw
+abb
+abb
+jUj
 abb
 abb
 abb
@@ -18087,25 +18834,8 @@ abb
 abb
 abb
 abb
-abb
-abb
-abb
-jUj
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-abb
-ktj
+cuw
+rDm
 awg
 awg
 awg
@@ -18226,6 +18956,8 @@ aaA
 aaA
 aaA
 jUj
+cuw
+cuw
 abb
 abb
 abb
@@ -18246,30 +18978,30 @@ abb
 abb
 abb
 abb
+cuw
+cuw
 abb
 abb
+jUj
 abb
+abb
+abk
+abk
+abk
+abk
+abk
+abk
+abk
+abk
+abk
+abk
+abk
 abb
 abb
 abb
 jUj
 abb
 abb
-abk
-abk
-abk
-abk
-abk
-abk
-abk
-abk
-abk
-abk
-abk
-abb
-abb
-abb
-jUj
 abb
 abb
 abb
@@ -18281,10 +19013,8 @@ abb
 abb
 abb
 abb
-abb
-abb
-abb
-ktj
+cuw
+rDm
 awg
 awg
 awg
@@ -18352,7 +19082,7 @@ veV
 bnC
 bok
 bpe
-bpe
+kfz
 bpe
 brj
 bnC
@@ -18405,6 +19135,8 @@ aaa
 aaa
 aaa
 jUj
+cuw
+cuw
 abb
 abb
 abb
@@ -18425,10 +19157,8 @@ abb
 abb
 abb
 abb
-abb
-abb
-abb
-abb
+cuw
+cuw
 abb
 abb
 jUj
@@ -18462,8 +19192,8 @@ abb
 abb
 abb
 abb
-abb
-ktj
+cuw
+rDm
 awg
 awg
 awg
@@ -18584,6 +19314,8 @@ aaa
 aaa
 aaa
 jUj
+cuw
+cuw
 abb
 abb
 abb
@@ -18604,10 +19336,8 @@ abb
 abb
 abb
 abb
-abb
-abb
-abb
-abb
+cuw
+cuw
 abb
 abb
 jUj
@@ -18630,7 +19360,7 @@ abk
 uMG
 abc
 abc
-abc
+abd
 abc
 abc
 abc
@@ -18641,8 +19371,8 @@ abc
 abc
 abb
 abb
-abb
-ktj
+cuw
+rDm
 awg
 awg
 awg
@@ -18763,6 +19493,8 @@ aej
 aaa
 aaa
 jUj
+cuw
+cuw
 abb
 abb
 abb
@@ -18783,10 +19515,8 @@ abb
 abb
 abb
 abb
-abb
-abb
-abb
-abb
+cuw
+cuw
 abb
 abb
 jUj
@@ -18820,8 +19550,8 @@ abc
 abc
 abb
 abb
-abb
-ktj
+cuw
+rDm
 awg
 awg
 awg
@@ -18891,7 +19621,7 @@ boj
 bpe
 bpe
 bpe
-hLW
+uip
 bnC
 bsa
 bck
@@ -18942,6 +19672,8 @@ aal
 aaa
 aaa
 jUj
+cuw
+cuw
 abb
 abb
 abb
@@ -18962,10 +19694,8 @@ abb
 abb
 abb
 abb
-abb
-abb
-abb
-abb
+cuw
+cuw
 abb
 abb
 jUj
@@ -18999,8 +19729,8 @@ abc
 abc
 abc
 abk
-abb
-ktj
+cuw
+rDm
 awg
 awg
 awg
@@ -19059,7 +19789,7 @@ bck
 bch
 vlW
 bnE
-cml
+feI
 bfa
 bch
 bch
@@ -19067,7 +19797,7 @@ bcg
 veV
 bnC
 bol
-bpe
+kfz
 hLW
 bqF
 boj
@@ -19121,6 +19851,8 @@ aej
 aaa
 aaa
 jUj
+cuw
+cuw
 abb
 abb
 abb
@@ -19141,10 +19873,8 @@ abb
 abb
 abb
 abb
-abb
-abb
-abb
-abb
+cuw
+cuw
 abb
 abb
 jUj
@@ -19178,8 +19908,8 @@ abc
 abc
 abc
 abb
-abb
-ktj
+cuw
+rDm
 awg
 awg
 awg
@@ -19300,6 +20030,8 @@ aej
 aej
 aaa
 jUj
+cuw
+cuw
 abb
 abb
 abb
@@ -19320,10 +20052,8 @@ abb
 abb
 abb
 abb
-abb
-abb
-abb
-abb
+cuw
+cuw
 abb
 abb
 jUj
@@ -19357,8 +20087,8 @@ abc
 abc
 abc
 abb
-abb
-ktj
+cuw
+rDm
 awg
 awg
 awg
@@ -19479,6 +20209,8 @@ eOl
 eOl
 aaa
 jUj
+cuw
+cuw
 abb
 abb
 abb
@@ -19499,10 +20231,8 @@ abb
 abb
 abb
 abb
-abb
-abb
-abb
-abb
+cuw
+cuw
 abb
 abb
 jUj
@@ -19536,8 +20266,8 @@ abc
 abc
 abc
 abk
-abb
-ktj
+cuw
+rDm
 awg
 awg
 awg
@@ -19658,6 +20388,8 @@ aej
 xUe
 aej
 jUj
+cuw
+cuw
 abb
 abb
 abb
@@ -19678,10 +20410,8 @@ abb
 abb
 abb
 abb
-abb
-abb
-abb
-abb
+cuw
+cuw
 abb
 abb
 jUj
@@ -19715,8 +20445,8 @@ abd
 abc
 abc
 abk
-abb
-ktj
+cuw
+rDm
 awg
 awg
 awg
@@ -19773,7 +20503,7 @@ qtN
 rXx
 bch
 bfM
-bnE
+pId
 bnE
 bfa
 bch
@@ -19837,6 +20567,8 @@ aej
 aal
 aej
 jUj
+cuw
+cuw
 abb
 abb
 abb
@@ -19857,10 +20589,8 @@ abb
 abb
 abb
 abb
-abb
-abb
-abb
-abb
+cuw
+cuw
 abb
 abb
 jUj
@@ -19883,7 +20613,7 @@ abc
 fDX
 abc
 abc
-abc
+abd
 abb
 abb
 abb
@@ -19894,8 +20624,8 @@ abc
 abc
 abc
 abb
-abb
-ktj
+cuw
+rDm
 awg
 awg
 awg
@@ -20016,6 +20746,8 @@ xUe
 aej
 xUe
 jUj
+cuw
+cuw
 abb
 abb
 abb
@@ -20036,10 +20768,8 @@ abb
 abb
 abb
 abb
-abb
-abb
-abb
-abb
+cuw
+cuw
 abb
 abb
 jUj
@@ -20064,8 +20794,8 @@ abc
 abc
 abc
 abc
-abb
-abc
+cuw
+cuw
 abc
 abc
 abc
@@ -20073,8 +20803,8 @@ abc
 abd
 abc
 abb
-abb
-ktj
+cuw
+rDm
 awg
 awg
 awg
@@ -20145,7 +20875,7 @@ bcg
 bcg
 bck
 bfM
-bnE
+pId
 bfa
 bck
 bcg
@@ -20195,6 +20925,8 @@ eOl
 eOl
 aaa
 jUj
+cuw
+cuw
 abb
 abb
 abb
@@ -20215,10 +20947,8 @@ abb
 abb
 abb
 abb
-abb
-abb
-abb
-abb
+cuw
+cuw
 abb
 abb
 jUj
@@ -20236,15 +20966,15 @@ abd
 abc
 abc
 abc
-abc
-abc
+cuw
+cuw
 fDX
 abc
 abc
 abc
 abc
-abb
-abb
+cuw
+cuw
 abc
 abc
 abc
@@ -20252,8 +20982,8 @@ abc
 abc
 abc
 abb
-abb
-ktj
+cuw
+rDm
 awg
 awg
 awg
@@ -20374,6 +21104,8 @@ eOl
 eOl
 aaa
 jUj
+cuw
+cuw
 abb
 abb
 abb
@@ -20394,10 +21126,8 @@ abb
 abb
 abb
 abb
-abb
-abb
-abb
-abb
+cuw
+cuw
 abb
 abb
 jUj
@@ -20415,8 +21145,8 @@ abc
 abc
 abc
 abc
-abc
-abc
+cuw
+cuw
 fDX
 abc
 abc
@@ -20425,14 +21155,14 @@ abb
 abb
 abb
 abc
-wLx
+rbW
 abc
 abc
 abc
 abc
 abk
-abb
-ktj
+cuw
+rDm
 awg
 awg
 awg
@@ -20575,8 +21305,8 @@ abb
 abb
 abb
 abb
-abb
-abb
+cuw
+cuw
 abb
 abb
 jUj
@@ -20587,15 +21317,15 @@ abb
 abc
 ujY
 abc
-abc
-abb
-abc
-abc
-abc
+cuw
+cuw
+cuw
 abc
 abc
 abc
 abc
+cuw
+cuw
 fDX
 abc
 abd
@@ -20610,8 +21340,8 @@ abc
 abc
 abc
 abk
-abb
-ktj
+cuw
+rDm
 awg
 awg
 awC
@@ -20680,7 +21410,7 @@ bch
 bfL
 bmz
 boo
-bnE
+pId
 bfa
 bch
 bch
@@ -20754,8 +21484,8 @@ abb
 abb
 abb
 abb
-abb
-abb
+cuw
+cuw
 abb
 abb
 jUj
@@ -20766,9 +21496,9 @@ abc
 abd
 abc
 abc
-abb
-abb
-abb
+cuw
+cuw
+cuw
 abc
 abc
 abc
@@ -20789,8 +21519,8 @@ abc
 abc
 abc
 abk
-abb
-ktj
+cuw
+rDm
 awg
 awg
 awC
@@ -20933,8 +21663,8 @@ abb
 abb
 abb
 abb
-abb
-abb
+cuw
+cuw
 abb
 abb
 jUj
@@ -20944,10 +21674,10 @@ abc
 abc
 abc
 abc
-abb
-abb
-abb
 abc
+cuw
+cuw
+cuw
 abc
 abc
 abc
@@ -20959,7 +21689,7 @@ abc
 abc
 abc
 abc
-abc
+abd
 ahr
 abc
 abc
@@ -21036,7 +21766,7 @@ bcg
 bfL
 bmz
 boo
-bnE
+pId
 bnE
 mdx
 bfb
@@ -21112,8 +21842,8 @@ abb
 abb
 abb
 abb
-abb
-abb
+cuw
+cuw
 abb
 abb
 jUj
@@ -21135,7 +21865,7 @@ abc
 abc
 fDX
 abc
-abb
+cuw
 abc
 abc
 abc
@@ -21291,8 +22021,8 @@ jUj
 jUj
 jUj
 fpz
-abb
-abb
+cuw
+cuw
 abb
 abb
 jUj
@@ -21313,14 +22043,14 @@ abc
 abc
 abc
 jUj
-abb
-abb
-abb
+cuw
+cuw
+cuw
 ahr
 ahr
-abb
-abb
-abb
+cuw
+cuw
+cuw
 abc
 abc
 abd
@@ -21469,9 +22199,9 @@ abk
 abk
 abk
 abb
-jUj
-abb
-abb
+jjQ
+cuw
+cuw
 abb
 abb
 jUj
@@ -21492,27 +22222,27 @@ abc
 abc
 abc
 jUj
-abb
+cuw
 abk
 abk
 abc
 abc
 abk
 abk
-abb
+cuw
 abc
 abc
 abc
 abc
 abb
-abb
-ktj
+cuw
+rDm
 awg
 awC
 awC
 awC
 awC
-awC
+awX
 auZ
 are
 are
@@ -21571,7 +22301,7 @@ bcg
 bch
 bch
 bfM
-bnE
+pId
 bnE
 bfa
 bch
@@ -21648,11 +22378,11 @@ abc
 abd
 abk
 abk
-jUj
+jjQ
+cuw
+cuw
 abb
 abb
-abb
-abb
 jUj
 jUj
 jUj
@@ -21671,7 +22401,7 @@ jUj
 jUj
 jUj
 jUj
-abb
+cuw
 abk
 abc
 abc
@@ -21684,8 +22414,8 @@ abc
 abc
 abc
 abb
-flw
-awg
+ekH
+vAL
 awg
 awC
 awC
@@ -21793,8 +22523,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+eEB
+eEB
 aaa
 aaa
 aaa
@@ -21827,9 +22557,9 @@ abc
 xLJ
 abc
 abk
-jUj
-abb
-abb
+jjQ
+cuw
+cuw
 abk
 abk
 abk
@@ -21853,7 +22583,7 @@ abb
 abb
 abk
 abc
-abc
+abd
 abc
 abc
 abc
@@ -21863,8 +22593,8 @@ abc
 abc
 abb
 abb
-ktj
-awg
+rDm
+vAL
 awX
 awC
 awC
@@ -21972,8 +22702,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+eEB
+eEB
 aaa
 aaa
 aaa
@@ -22023,9 +22753,9 @@ abc
 abc
 abc
 abc
-abb
-abb
-abb
+cuw
+cuw
+cuw
 abb
 abb
 abk
@@ -22042,17 +22772,17 @@ abc
 abc
 abb
 abb
-ktj
-awg
+rDm
+vAL
 awC
 lWC
 aaL
 aym
 aym
 aym
-aaW
-afo
-aDv
+xuD
+xuD
+xuD
 aaW
 aaW
 aaW
@@ -22072,11 +22802,11 @@ avP
 aCp
 axR
 axR
+wlI
 axR
-axR
 wNe
 wNe
-wNe
+vzO
 wNe
 wNe
 vpP
@@ -22151,8 +22881,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+eEB
+eEB
 aaa
 aaa
 aaa
@@ -22202,9 +22932,9 @@ abc
 abc
 abc
 abc
-abb
-abb
-abb
+cuw
+cuw
+cuw
 abk
 abk
 abk
@@ -22212,17 +22942,17 @@ abc
 abc
 abc
 abc
+iyJ
+abk
+abk
+abk
+abk
 abd
 abc
-abc
-abc
-abc
-abd
-abc
 abb
-flw
-awg
-awg
+ekH
+vAL
+vAL
 awC
 aaL
 aaO
@@ -22231,7 +22961,7 @@ aaS
 aaU
 aCl
 aDv
-aDv
+cBt
 aCl
 aCl
 agd
@@ -22240,11 +22970,11 @@ aCC
 aui
 axR
 axR
+wlI
 axR
 axR
 axR
-axR
-axR
+wlI
 axR
 axR
 aSa
@@ -22364,8 +23094,8 @@ bLL
 xDn
 xDn
 abk
-jUj
-abb
+jjQ
+cuw
 abk
 abc
 abc
@@ -22391,16 +23121,16 @@ abc
 abc
 abc
 abc
-abc
-abc
-abc
-abc
-abc
+abk
+cuw
+cuw
+cuw
+abk
 abc
 abc
 abb
-flw
-awg
+ekH
+vAL
 awC
 awC
 aaM
@@ -22543,8 +23273,8 @@ bLL
 ahr
 xDn
 abk
-jUj
-abb
+jjQ
+cuw
 abk
 abc
 abc
@@ -22556,8 +23286,8 @@ abc
 abc
 abk
 abk
-abb
-abb
+cuw
+cuw
 abb
 abb
 abb
@@ -22570,26 +23300,26 @@ abc
 abc
 abc
 abc
+abk
+cuw
+cuw
+cuw
+abk
 abc
 abc
-abc
-abd
-abc
-abc
-abb
 abb
 flw
 awg
 awC
 awC
 awC
-aaM
+lxH
 aym
 aym
-azx
-aDv
-aaW
-aaW
+aym
+xuD
+xuD
+xuD
 aaW
 aaW
 aaW
@@ -22606,7 +23336,7 @@ awi
 awi
 tes
 axR
-ayo
+cBC
 axR
 auH
 xVM
@@ -22688,8 +23418,8 @@ aai
 aaa
 aaA
 aaa
-aaa
-aaa
+eEB
+eEB
 aaa
 aaa
 aaa
@@ -22735,8 +23465,8 @@ abc
 abd
 abc
 abk
-abb
-abb
+cuw
+cuw
 abb
 abb
 abk
@@ -22749,13 +23479,13 @@ abc
 abc
 abd
 abc
+abk
+abk
+abk
+abk
+abk
 abc
 abc
-abc
-abc
-abc
-abc
-ahr
 aaI
 aqD
 aqD
@@ -22867,8 +23597,8 @@ aai
 aai
 aaA
 aaa
-aaa
-aaa
+eEB
+eEB
 aaa
 aaa
 aaa
@@ -22900,26 +23630,26 @@ abd
 abc
 abc
 abd
-abk
+ahr
+abc
+abc
+abc
+abc
+abc
+abc
+abc
 abb
-abb
-abk
 abc
 abc
 abc
-abc
-abb
-abc
-abc
-abc
-wLx
+rbW
 abk
 abk
 abk
 abk
 abk
 abk
-abc
+abd
 abc
 abc
 abc
@@ -22934,7 +23664,7 @@ abc
 abc
 abc
 abc
-ahr
+abc
 aaI
 aqD
 aqD
@@ -22954,8 +23684,8 @@ are
 awZ
 auH
 axb
-axa
-axb
+axQ
+aFR
 aFR
 axQ
 avd
@@ -23005,7 +23735,7 @@ bla
 bmX
 bnH
 boq
-boq
+cfn
 boq
 bqG
 brm
@@ -23046,8 +23776,8 @@ eOl
 aai
 aaA
 aaa
-aaa
-aaa
+eEB
+eEB
 aaa
 aaa
 aaa
@@ -23079,32 +23809,32 @@ abc
 abc
 abc
 abc
+ahr
+abc
+abc
+abc
+abc
+abc
+abd
+abc
+abb
+abb
+abc
+abc
+abc
+abc
+abc
+abc
+abc
+abc
+abc
+abc
+abc
 abk
-abb
-abb
-abb
-abc
-abc
-abd
-abc
-abb
-abb
-abc
-abc
-abc
-abc
-abc
-abc
-abc
-abc
-abc
-abc
-abc
-abc
-abc
-abc
-abc
-abc
+abk
+abk
+abk
+abk
 abc
 abc
 abc
@@ -23112,10 +23842,10 @@ abd
 abc
 abc
 abc
-abb
-flw
-ara
-ara
+abc
+vkR
+dWl
+aqD
 aqD
 aqD
 aqD
@@ -23133,7 +23863,7 @@ are
 awZ
 ayY
 awk
-avd
+axQ
 aFl
 avd
 avd
@@ -23225,8 +23955,8 @@ eOl
 aai
 aaA
 aaa
-aaa
-aaa
+eEB
+eEB
 aaa
 aaa
 aaa
@@ -23259,9 +23989,9 @@ abc
 abc
 abk
 abk
-abb
-abb
-abb
+cuw
+cuw
+cuw
 abc
 abc
 abc
@@ -23279,11 +24009,11 @@ abc
 abc
 abc
 abc
-abc
-abu
-abu
-abc
-abc
+abk
+cuw
+cuw
+cuw
+abk
 abc
 abc
 abc
@@ -23291,12 +24021,12 @@ abc
 abc
 abc
 abb
+clw
+oWd
+clw
 ara
-fwR
 ara
-aqD
-aqD
-aqD
+arH
 aqD
 aqD
 aqD
@@ -23310,7 +24040,7 @@ are
 atA
 are
 awZ
-axR
+wlI
 auH
 axb
 avd
@@ -23322,7 +24052,7 @@ avq
 aIZ
 avq
 axR
-axR
+wlI
 axR
 xVM
 xVM
@@ -23404,8 +24134,8 @@ eOl
 aai
 aaA
 aaa
-aaa
-aaa
+eEB
+eEB
 aaa
 aaa
 aaa
@@ -23432,15 +24162,15 @@ abd
 abc
 abc
 abd
-abc
+ujY
 abc
 abc
 abc
 abk
 abb
-abb
-abb
-abb
+cuw
+cuw
+cuw
 abc
 abc
 abc
@@ -23458,23 +24188,23 @@ abc
 abc
 abc
 abc
-abc
-abu
-abu
-abc
-abc
+abk
+cuw
+cuw
+cuw
+abk
 abc
 abc
 abc
 abc
 abc
 abb
-abb
-fwR
+cuw
+oWd
+clw
+clw
 ara
 ara
-aqD
-aqD
 aqD
 aqD
 aqD
@@ -23520,11 +24250,11 @@ xVM
 xVM
 mos
 tqW
-aZl
+nAc
 vDD
 aZl
 aZl
-aZl
+nAc
 aZl
 fRf
 bch
@@ -23546,7 +24276,7 @@ bos
 bot
 bnJ
 bro
-bqH
+vAw
 bsd
 bla
 bck
@@ -23625,9 +24355,9 @@ abc
 abc
 abc
 abc
-abb
-abb
-abb
+cuw
+cuw
+cuw
 abc
 abc
 abc
@@ -23637,20 +24367,20 @@ abc
 abd
 abc
 abc
-abc
-abc
-abc
-abc
-abc
+abk
+abk
+abk
+abk
+abk
 abc
 abc
 abc
 ara
 ara
-ara
-ara
-fwR
-ara
+clw
+clw
+oWd
+clw
 aqD
 aqD
 aqD
@@ -23670,14 +24400,14 @@ atA
 awZ
 axR
 auH
-auJ
+ixC
 axQ
 avd
 aOj
 axR
 axR
 axR
-axR
+wlI
 axR
 axR
 axR
@@ -23804,9 +24534,9 @@ abc
 abc
 abc
 abc
-abb
-abb
-abb
+cuw
+cuw
+cuw
 abc
 abc
 abc
@@ -23825,9 +24555,9 @@ abc
 abc
 abc
 ara
-ara
-fwR
-fwR
+clw
+oWd
+oWd
 ara
 ara
 aqD
@@ -23848,10 +24578,10 @@ are
 are
 awZ
 axR
-aEa
+elc
 axQ
-auJ
-avd
+ixC
+avP
 avq
 axR
 axR
@@ -23898,7 +24628,7 @@ bla
 blH
 bmw
 bnc
-bnJ
+bFY
 bov
 bos
 bov
@@ -23974,8 +24704,8 @@ abc
 abc
 abc
 abk
-abb
-abb
+cuw
+cuw
 abd
 abc
 abc
@@ -23983,20 +24713,20 @@ abb
 abc
 abd
 abc
-abb
-abb
-abb
+cuw
+cuw
+cuw
 abc
 abc
 abc
 abc
 abc
 abc
-abc
-abu
-abu
-abu
-abc
+abk
+abk
+abk
+abk
+abk
 abc
 abc
 abc
@@ -24026,12 +24756,12 @@ are
 are
 avb
 avc
-atH
-auk
-avd
-avd
-avd
-aOj
+axR
+axR
+wlI
+axR
+axR
+awD
 axR
 axR
 axR
@@ -24120,12 +24850,12 @@ aai
 aaa
 aaA
 aaa
+eEB
+eEB
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+eEB
+eEB
 aaa
 aaa
 aej
@@ -24153,38 +24883,38 @@ abc
 abd
 abc
 abk
-abb
-abb
+cuw
+cuw
 abc
 abc
-abb
-abb
-abb
-abc
-abc
-abc
-abc
-abb
-abb
+cuw
+cuw
 abb
 abc
 abc
 abc
 abc
-abc
-abu
-abu
-abu
-abc
-abc
-abc
-abc
-abc
-abc
 abb
-fwR
-ara
-ara
+abb
+abb
+abc
+abc
+abc
+abc
+abk
+cuw
+cuw
+cuw
+abk
+abc
+abc
+abc
+abc
+abc
+abc
+aaI
+aqD
+aqD
 aqD
 aqD
 arH
@@ -24204,15 +24934,15 @@ avb
 auf
 auf
 avc
-atH
-auk
-avd
-avd
-avd
-avd
-aOj
 axR
 axR
+axR
+axR
+axR
+axR
+awD
+axR
+wlI
 axR
 kir
 avd
@@ -24259,7 +24989,7 @@ bne
 bmw
 bnJ
 bos
-bnJ
+bFY
 bqH
 brr
 brM
@@ -24299,12 +25029,12 @@ aai
 aaa
 aaA
 aaa
+eEB
+eEB
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+eEB
+eEB
 aaa
 aaa
 aaa
@@ -24336,8 +25066,8 @@ abb
 abk
 abc
 abc
-abb
-abb
+cuw
+cuw
 abb
 abc
 abc
@@ -24350,19 +25080,19 @@ abb
 abc
 abd
 abc
+abk
+cuw
+cuw
+cuw
+abk
 abc
 abc
 abc
 abc
 abc
-abc
-abc
-abc
-abc
-abb
-flw
-ara
-ara
+vkR
+dWl
+arH
 aqD
 aqD
 aqD
@@ -24380,15 +25110,15 @@ are
 are
 avb
 atC
+axR
+axR
+axR
+wlI
+axR
 atH
 awi
 awi
-auk
-avd
-avd
-avd
-avd
-avd
+awi
 avq
 axR
 ayo
@@ -24419,7 +25149,7 @@ aES
 aFD
 bcD
 aZl
-aZl
+nAc
 aZl
 aZl
 bdu
@@ -24478,12 +25208,12 @@ aaA
 aaA
 aaA
 aaa
+eEB
+eEB
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+eEB
+eEB
 aaa
 aaa
 aej
@@ -24524,16 +25254,16 @@ abc
 abc
 abc
 abc
+cuw
+cuw
 abb
-abb
-abb
 abc
 abc
-abc
-abc
-abc
-abc
-abc
+abk
+abk
+abk
+abk
+abk
 abc
 abc
 abc
@@ -24559,13 +25289,13 @@ are
 avb
 avc
 atH
-auk
-avd
-qhx
-avd
-axb
-avd
-avd
+aBM
+axR
+opM
+axR
+ayo
+axQ
+axQ
 auJ
 avd
 aOj
@@ -24657,12 +25387,12 @@ aaa
 aaa
 aaa
 aaa
+eEB
+eEB
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+eEB
+eEB
 aaa
 aaa
 aej
@@ -24686,11 +25416,11 @@ abc
 abc
 abu
 abk
-abb
-abb
-abb
-abb
-abb
+cuw
+cuw
+cuw
+cuw
+cuw
 abk
 abc
 abd
@@ -24703,8 +25433,8 @@ abc
 abc
 abd
 abc
-abb
-abb
+cuw
+cuw
 abc
 abc
 abc
@@ -24717,8 +25447,8 @@ abd
 abc
 abc
 ara
-fwR
-ara
+oWd
+clw
 ara
 aqD
 aqD
@@ -24739,11 +25469,11 @@ avc
 atH
 auk
 axQ
-avd
-avd
-avd
-avd
-avd
+axR
+axR
+axR
+axR
+axQ
 axQ
 auJ
 avd
@@ -24865,11 +25595,11 @@ abd
 abc
 abu
 abk
-abb
-abb
-abb
-abb
-abb
+cuw
+cuw
+cuw
+cuw
+cuw
 abk
 abc
 abc
@@ -24882,8 +25612,8 @@ abc
 abc
 abc
 abc
-abb
-abb
+cuw
+cuw
 abc
 abc
 abc
@@ -24896,9 +25626,9 @@ abc
 abc
 abb
 fwR
+clw
+clw
 ara
-ara
-aqD
 aqD
 aqD
 aqD
@@ -24918,10 +25648,10 @@ avL
 auH
 auJ
 axQ
-ayn
-auJ
-auJ
-auJ
+aCr
+avQ
+avQ
+avQ
 axQ
 axQ
 avd
@@ -25074,13 +25804,13 @@ abc
 abc
 abb
 flw
+clw
+clw
+clw
 ara
-ara
-aqD
-arH
 atg
 aqD
-aqD
+arH
 auC
 auY
 avv
@@ -25097,11 +25827,11 @@ atH
 auk
 axQ
 axQ
-auJ
-auJ
-avd
-avd
-avd
+avQ
+avQ
+wlI
+axR
+auH
 axb
 avd
 avd
@@ -25231,8 +25961,8 @@ abk
 abc
 abc
 abc
-abb
-abb
+cuw
+cuw
 abc
 abk
 abk
@@ -25252,11 +25982,11 @@ abc
 abc
 abb
 flw
-abb
+cuw
+clw
+clw
+clw
 ara
-aqD
-aqD
-aqD
 aqD
 aqD
 aqD
@@ -25276,10 +26006,10 @@ auH
 avd
 axQ
 axQ
-avw
-ahH
-avP
-auG
+axR
+aCr
+axR
+axR
 aXH
 aXH
 aXH
@@ -25410,8 +26140,8 @@ abu
 abc
 abc
 abb
-abb
-abb
+cuw
+cuw
 abc
 abk
 ajC
@@ -25430,12 +26160,12 @@ abc
 abb
 abb
 abb
-flw
-abb
+ekH
+cuw
+clw
+clw
+clw
 ara
-aqD
-aqD
-aqD
 aqD
 aqD
 aqD
@@ -25455,10 +26185,10 @@ auH
 aAE
 axQ
 axQ
-avx
+axR
 aCr
 kOK
-auH
+axR
 aXH
 aXH
 aXH
@@ -25479,7 +26209,7 @@ pNb
 aPS
 aLt
 aMm
-usu
+kHl
 aMm
 aLt
 aPS
@@ -25596,25 +26326,25 @@ abk
 ajD
 abc
 abc
-abb
-abb
+cuw
+cuw
 abc
 vkR
 vkR
-abb
-abc
+cuw
+cuw
 abc
 vkR
 vkR
 flw
-flw
-flw
-ahU
+ekH
+ekH
+sTm
 cYJ
-aqD
-aqD
-aqD
-aqD
+clw
+clw
+clw
+ara
 aqD
 aqD
 aqD
@@ -25628,16 +26358,16 @@ are
 are
 awZ
 avL
-atH
-awi
-auk
-avd
+axR
+axR
+ayY
+avP
 auJ
 axQ
-aBO
+aCr
 ayo
-atH
-auk
+wlI
+axR
 aXH
 aXH
 aXH
@@ -25775,13 +26505,13 @@ abk
 abc
 abc
 flw
-flw
-flw
+ekH
+ekH
 iuG
 ahr
 abb
-flw
-flw
+ekH
+ekH
 flw
 ahr
 ahr
@@ -25789,34 +26519,34 @@ abb
 abb
 abb
 ahU
+ara
+ara
+ara
+ara
+ara
 aqD
 aqD
-aqD
-aqD
-aqD
-aqD
-aqD
-aqD
+arH
 auD
-auZ
-are
-are
-are
-are
-are
-avb
+cJN
+aCl
+aCl
+aCl
+aCl
+aCl
+awj
 avc
 avL
-ayY
-auG
-axb
-aAF
-aBf
-avP
-aCp
 axR
-auH
-avd
+axR
+ayo
+ayo
+aBf
+axR
+axR
+axR
+axR
+axR
 aXH
 aXH
 aXH
@@ -25869,7 +26599,7 @@ bmB
 bfb
 bbo
 aZl
-bcA
+pZX
 aZl
 beo
 bpx
@@ -25977,24 +26707,24 @@ aqD
 aqD
 aqD
 aqD
-auZ
-are
-are
-are
-atA
-are
-awZ
+aDv
+aaW
+aaW
+xuD
+aaW
+aaW
+aDv
 avL
 avL
 avL
-auH
-axb
+wlI
+ayo
 aAG
 aBg
 axR
+wlI
 axR
 axR
-auH
 aXH
 aXH
 aXH
@@ -26125,7 +26855,7 @@ abu
 abu
 abc
 abc
-wLx
+rbW
 abc
 abc
 abd
@@ -26133,8 +26863,8 @@ ahr
 vkR
 abc
 abc
-abb
-abb
+abc
+abc
 aht
 aht
 ahu
@@ -26156,24 +26886,24 @@ aqD
 aqD
 aqD
 aqD
-auZ
+aDv
 uNG
-are
-are
-atz
-are
-awZ
+aCl
+aDv
+aCl
+agd
+aDv
 axO
-atH
-awi
-auk
-avd
-aAH
-aBh
-aBM
+axR
+axR
+axR
+axR
+aBg
+avQ
+axR
 aCq
 axR
-auH
+axR
 aXH
 aXH
 aXH
@@ -26274,8 +27004,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+eEB
+eEB
 aaa
 aaa
 aaa
@@ -26335,21 +27065,21 @@ arH
 aqD
 aqD
 aqD
-auZ
-are
-are
-are
-are
-are
-awZ
+cBt
+txw
+aCl
+cBt
+aCl
+agd
+cBt
 avL
-auH
-avd
+atH
+awi
 axQ
 axQ
 axQ
-ayn
-avx
+aBP
+aBM
 axR
 atH
 iMd
@@ -26372,12 +27102,12 @@ aSb
 bfP
 aSb
 aSb
-aSb
+iQX
 aSb
 kjU
 aUK
 aUK
-aUK
+vgi
 aUK
 aUK
 aUK
@@ -26398,10 +27128,10 @@ rTb
 rTb
 rTb
 xmL
+akR
 xmL
 xmL
-xmL
-aZm
+qnO
 aZm
 aZm
 aZm
@@ -26453,8 +27183,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+eEB
+eEB
 aaa
 aaa
 aaa
@@ -26488,7 +27218,7 @@ ahU
 aht
 aht
 iLV
-aht
+ahJ
 aht
 aht
 aht
@@ -26514,13 +27244,13 @@ aqD
 aqD
 aqD
 auD
-auZ
-are
-are
-are
-are
-are
-awZ
+aDv
+aaW
+aaW
+xuD
+aaW
+aaW
+aDv
 avL
 auH
 avd
@@ -26531,7 +27261,7 @@ axQ
 aBi
 aCr
 axd
-avd
+ayn
 aXH
 aXH
 aXH
@@ -26548,7 +27278,7 @@ aXH
 aXH
 aXH
 aMm
-bfQ
+stw
 aMm
 aMm
 aMm
@@ -26632,8 +27362,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+eEB
+eEB
 aaa
 aaa
 aaa
@@ -26656,9 +27386,9 @@ acO
 aeK
 acN
 acN
-acN
-acN
-acN
+uuI
+uuI
+uuI
 aeP
 ahu
 aht
@@ -26667,7 +27397,7 @@ ahU
 ahU
 aht
 iLV
-aht
+ahJ
 aht
 aht
 aht
@@ -26693,24 +27423,24 @@ aqD
 aqD
 aqD
 arb
-ava
-are
-are
-are
-are
-are
-awZ
+qlb
+aCl
+aCl
+aCl
+aCl
+aCl
+awE
 avL
 auH
 avd
-avd
+axQ
 axQ
 axQ
 axQ
 aBO
 vJq
 aCV
-avd
+ayn
 aXH
 aXH
 aXH
@@ -26734,8 +27464,8 @@ aMn
 aMn
 aMn
 aLt
-aMn
-aMn
+jLQ
+aSd
 aLt
 aSd
 aSe
@@ -26811,8 +27541,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+eEB
+eEB
 aaa
 aaa
 aaa
@@ -26835,18 +27565,18 @@ acO
 aeK
 acN
 acN
-acN
-acN
-acN
+uuI
+uuI
+uuI
 aeP
 aht
 aht
-aht
+ahU
 ahU
 ahU
 aiV
 iLV
-ajE
+ahJ
 aht
 aht
 aky
@@ -26882,13 +27612,13 @@ awZ
 avL
 auH
 avd
-axb
-auJ
-azY
-avd
-axx
-awi
-auk
+aFR
+ixC
+nCi
+axQ
+aCp
+axR
+auH
 avd
 avd
 aXH
@@ -26913,11 +27643,11 @@ aES
 aES
 aES
 aET
-aES
-aES
-aVZ
-xhd
-aLc
+aJD
+aEx
+vpq
+bqK
+aKZ
 aES
 aES
 rTb
@@ -27014,13 +27744,13 @@ acO
 aeK
 aeK
 acN
-acN
-acN
-acN
+uuI
+uuI
+uuI
 aeP
 aht
 ahu
-aht
+ahU
 ahU
 ahU
 iLV
@@ -27064,12 +27794,12 @@ avd
 axb
 azY
 auJ
+avx
+axR
+wlI
+auH
 avd
 avd
-avd
-avw
-avP
-auG
 aXH
 aXH
 aXH
@@ -27093,10 +27823,10 @@ aES
 aES
 aFB
 aFB
-aES
-aHU
-aIK
-aES
+aEx
+vsg
+wPJ
+aKZ
 aES
 aFD
 rTb
@@ -27193,13 +27923,13 @@ acO
 acO
 aeK
 acN
-acN
-acN
-acN
+uuI
+uuI
+uuI
 aeP
 aht
 aht
-aht
+ahU
 ahU
 ahU
 eJQ
@@ -27237,18 +27967,18 @@ are
 are
 are
 awZ
-atH
-auk
-axb
-axb
-axQ
-axQ
-avd
-aAE
-avd
-avx
-kOK
+wlI
 auH
+axb
+axb
+axQ
+axQ
+avx
+axR
+axR
+auH
+aAf
+avd
 aXH
 aXH
 aXH
@@ -27264,7 +27994,7 @@ aXH
 aXH
 aNi
 aPX
-bfQ
+stw
 aMm
 aOY
 aES
@@ -27273,9 +28003,9 @@ aGk
 aFB
 aFB
 aET
-aES
-aES
-aET
+aEx
+aEx
+taV
 aES
 aES
 rTb
@@ -27296,7 +28026,7 @@ aKt
 aLc
 bbo
 aZl
-aZl
+nAc
 aZl
 beo
 ati
@@ -27344,16 +28074,16 @@ abe
 abe
 abe
 abe
-abe
+vRN
+uuI
 acN
 acN
+uuI
+uuI
 acN
 acN
-acN
-acN
-acN
-acN
-acN
+uuI
+uuI
 acN
 acN
 acN
@@ -27372,13 +28102,13 @@ acO
 adh
 acO
 acN
-acN
-acN
-acN
+uuI
+uuI
+uuI
 aeP
 aht
 ahu
-aht
+ahU
 ahU
 ahU
 eJQ
@@ -27416,18 +28146,18 @@ are
 are
 are
 awZ
+axR
 auH
-avd
 axb
 axQ
 avd
 axQ
+avx
+axR
+atH
+axQ
 avd
 avd
-avd
-axx
-awi
-auk
 aXH
 aXH
 aXH
@@ -27451,9 +28181,9 @@ aES
 aGk
 aFB
 aFB
-aET
-aET
-aET
+aMy
+kvA
+aMy
 aFB
 aFB
 aET
@@ -27523,16 +28253,16 @@ abe
 abe
 abe
 abe
-abe
+vRN
+uuI
 acN
 acN
+uuI
+uuI
 acN
 acN
-acN
-acN
-acN
-acN
-acN
+uuI
+uuI
 acN
 acN
 acN
@@ -27557,10 +28287,10 @@ acN
 aeP
 aht
 aht
-aht
+ahU
 ahU
 eJQ
-aht
+ahU
 aht
 aht
 aht
@@ -27595,16 +28325,16 @@ are
 atz
 awY
 avc
+axR
 auH
-avd
 avd
 axQ
 ayn
 axQ
-avd
-avd
-aCt
-auJ
+avx
+axR
+mlI
+ixC
 auJ
 auJ
 avd
@@ -27630,9 +28360,9 @@ aET
 aFB
 aFB
 aFB
-aES
-aES
-aES
+aEx
+aEx
+aEx
 aFB
 aFB
 aET
@@ -27702,16 +28432,16 @@ abe
 abe
 abe
 abe
-abe
+vRN
+uuI
 acN
 acN
+uuI
+uuI
 acN
 acN
-acN
-acN
-acN
-acN
-acN
+uuI
+uuI
 acN
 acN
 acN
@@ -27736,16 +28466,16 @@ acN
 aeP
 aht
 ahu
-aht
+ahU
 eJQ
-aht
-aht
+ahU
+ahU
 ahu
 aht
 aht
 aht
 aky
-puF
+akX
 akZ
 akZ
 akZ
@@ -27774,15 +28504,15 @@ are
 are
 awZ
 avL
+axR
 auH
-avd
 avd
 ayn
 auJ
 axQ
-avw
-avP
-auG
+avx
+axR
+auH
 axQ
 axQ
 axQ
@@ -27792,7 +28522,7 @@ avd
 avd
 aOj
 axR
-wQI
+atK
 axR
 kir
 avx
@@ -27808,18 +28538,18 @@ aES
 aFB
 aFB
 aFB
-aES
-aGN
-aES
-aES
+aJD
+kFc
+aEx
+aEx
 aFB
 aFB
 aFB
 aET
-aET
-aES
-aES
-bbo
+aKu
+aKs
+aKs
+uFY
 aZl
 bcA
 aZl
@@ -27881,16 +28611,16 @@ abe
 abe
 abe
 abe
-abe
+vRN
+uuI
 acN
 acN
+uuI
+uuI
 acN
 acN
-acN
-acN
-acN
-acN
-acN
+uuI
+uuI
 acN
 acN
 acN
@@ -27952,15 +28682,15 @@ are
 are
 avb
 avc
-atH
-auk
-avd
+axR
+axR
+auH
 axQ
 axQ
 auJ
 axQ
 aBi
-ayo
+cBC
 auH
 axQ
 axQ
@@ -27980,27 +28710,27 @@ aWy
 aLu
 aLs
 aMm
-bfQ
+stw
 aMm
 aOY
 aES
 aET
 aSO
 aTE
-aET
-aES
-aES
-aES
-aFB
-aFB
-aFB
-aFB
-aFB
-aES
-aES
-bbo
+aJB
+aEx
+aEx
+aEx
+sWJ
+aEx
+aEx
+aEx
+aMy
+kvA
+aEx
+bgH
 aZl
-bcA
+pZX
 aZl
 beo
 aFB
@@ -28060,16 +28790,16 @@ abe
 abe
 abe
 abe
-abe
+vRN
+uuI
 acN
 acN
+uuI
+uuI
 acN
 acN
-acN
-acN
-acN
-acN
-acN
+uuI
+uuI
 acN
 acN
 acN
@@ -28098,8 +28828,8 @@ xCo
 aio
 aht
 aht
-ahJ
-ajF
+aht
+aht
 aht
 aht
 aht
@@ -28130,10 +28860,10 @@ are
 are
 avb
 avc
-atH
-auk
-avd
-avd
+axR
+axR
+axR
+auH
 axQ
 axQ
 avd
@@ -28145,7 +28875,7 @@ avd
 axQ
 axQ
 axQ
-avd
+axQ
 auJ
 axQ
 aOj
@@ -28166,17 +28896,17 @@ aPW
 aLt
 aFB
 aFB
-aET
-aET
-aET
-aES
-aFB
-aFB
-aFB
-aFB
-aFB
-aET
-aES
+aJB
+aMy
+aMy
+aEx
+aEx
+aEx
+aEx
+aEx
+aMy
+aMy
+aEx
 aZk
 aZl
 gdH
@@ -28191,7 +28921,7 @@ aES
 aET
 aZk
 blb
-aZl
+nAc
 aZl
 aZk
 atj
@@ -28289,7 +29019,7 @@ aht
 aht
 aht
 aht
-aht
+ahu
 aht
 aht
 ajf
@@ -28308,25 +29038,25 @@ atz
 avb
 auf
 avc
-atH
-auk
-avd
-avd
-avd
+axR
+axR
+wlI
+axR
+auH
 axQ
 axQ
 avd
 auJ
-avS
-aBP
-aCu
+aBi
+aCr
+axd
 auJ
 axQ
 axQ
 axQ
-avd
 axQ
-avd
+axQ
+axQ
 avq
 axR
 aPa
@@ -28345,18 +29075,18 @@ aMm
 aSc
 aLb
 aFB
-aET
-aET
-aET
-aET
+aJB
+aMy
+aMy
+aMy
 aFB
 aFB
 aFB
 aFB
 aFB
-aES
-aES
-bbo
+aKt
+aKt
+nsb
 aZl
 bcA
 aZl
@@ -28452,12 +29182,12 @@ wOz
 wOz
 ahv
 ahK
-ahV
-ahW
-agv
-agv
-agv
-ajG
+ahK
+ahK
+ahK
+ahK
+ahK
+pxE
 ajG
 ajG
 ajG
@@ -28487,33 +29217,33 @@ avb
 avc
 avO
 avL
+axR
+axR
+axR
+axR
 auH
-axa
-aAE
-avd
-avd
 avd
 axQ
 axQ
 ayn
-ayn
-ayn
-ayn
+aBO
+aCr
+aCV
 ayn
 auJ
 axQ
 axQ
 axQ
 axQ
-avd
+axQ
 aOj
 axR
-atK
+iAy
 atK
 atK
 axR
 axR
-aMm
+kKo
 aMm
 aMm
 aMm
@@ -28524,10 +29254,10 @@ aMm
 aSd
 pxU
 aES
-aES
-aRY
-aET
-aET
+aJD
+eQc
+aMy
+aMy
 aFB
 aFB
 aFB
@@ -28537,7 +29267,7 @@ aES
 aES
 bbo
 aZl
-bcA
+pZX
 aZl
 beo
 aES
@@ -28625,13 +29355,13 @@ acO
 adh
 acO
 aeP
-cZd
-acN
+hgM
+uuI
 aeP
 agv
 agv
 ahK
-ahW
+agv
 agv
 agv
 agv
@@ -28642,7 +29372,7 @@ ajG
 oqP
 ajG
 ajG
-ajG
+ajH
 ajG
 ajG
 ajG
@@ -28663,28 +29393,28 @@ alc
 ajA
 auf
 avc
-aug
-auF
-awi
-auk
-avd
-avd
-axb
-avd
+avL
+avL
+axR
+axR
+axR
+axR
+axR
+auH
 ayZ
 axQ
 axQ
 axQ
-avd
+aOj
+aCr
+axd
 ayn
 auJ
-ayn
-auJ
 axQ
 axQ
 axQ
 ayn
-avd
+axQ
 aOj
 axR
 ayo
@@ -28698,15 +29428,15 @@ aLt
 aMm
 aMm
 aMm
-bfQ
+stw
 aMm
 aLt
 aKZ
 aFD
-aES
-aES
-aES
-aFB
+aJD
+aEx
+sWJ
+aEx
 aFB
 aFB
 aFB
@@ -28769,23 +29499,23 @@ abf
 abf
 abf
 abe
+vRN
+vRN
+abe
+vRN
+vRN
 abe
 abe
-abe
-abe
-abe
-abe
-abe
-abe
+vRN
+uuI
 acN
 acN
+uuI
+uuI
 acN
 acN
-acN
-acN
-acN
-acN
-acN
+uuI
+uuI
 acN
 acO
 acO
@@ -28804,8 +29534,8 @@ acO
 acO
 acN
 cZd
-acN
-acN
+uuI
+uuI
 agv
 agI
 agv
@@ -28839,24 +29569,24 @@ alL
 alQ
 api
 ald
-arU
-auF
-auF
-auk
-avd
-avd
-avd
-axb
-axb
-axQ
-ayn
-ayn
-avd
-avd
-avd
-avd
-avd
-avd
+aiJ
+avL
+avL
+axR
+axR
+axR
+axR
+ayo
+ayo
+axR
+aCV
+oqW
+avP
+avP
+auG
+aOj
+axR
+auH
 avd
 aCt
 avd
@@ -28882,11 +29612,11 @@ aMm
 aSe
 aLc
 aES
-aES
-aES
-aFD
-aES
-aES
+aJD
+aEx
+vpq
+aEx
+aKZ
 aGk
 aFB
 aES
@@ -28948,23 +29678,23 @@ abf
 abe
 abe
 abe
+vRN
+vRN
+abe
+vRN
+vRN
 abe
 abe
-abe
-abe
-abe
-abe
-abe
-abe
+vRN
+uuI
 acN
 acN
+uuI
+uuI
 acN
 acN
-acN
-acN
-acN
-acN
-acN
+uuI
+uuI
 acN
 acO
 acO
@@ -29010,33 +29740,33 @@ aji
 alS
 alS
 alS
-alS
-aqa
-ajS
+wYx
+wYx
+wYx
 alS
 alS
 alS
 ajS
 aoB
 rLP
-auG
-avd
-avw
+axR
+axR
+wlI
+axR
+axR
+wlI
+avQ
+aCr
+axR
+auH
+aBO
+axR
+axR
+auH
+aOj
+wlI
+ayY
 avP
-auG
-avd
-auJ
-ayn
-axQ
-axQ
-ayn
-avd
-avd
-avd
-avd
-avd
-avd
-avw
 avP
 auG
 avd
@@ -29061,11 +29791,11 @@ aMm
 aOY
 aES
 aES
-aES
-aES
-aES
-aES
-aES
+aJD
+aEx
+aEx
+aEx
+aKZ
 aES
 aES
 aES
@@ -29127,23 +29857,23 @@ abH
 abe
 abe
 abe
+vRN
+vRN
+abe
+vRN
+vRN
 abe
 abe
-abe
-abe
-abe
-abe
-abe
-abe
+vRN
+uuI
 acN
 acN
+uuI
+uuI
 acN
 acN
-acN
-acN
-acN
-acN
-acN
+uuI
+uuI
 acN
 acO
 acO
@@ -29154,12 +29884,12 @@ acN
 acN
 acN
 acN
+uuI
+uuI
 acN
 acN
-acN
-acN
-cZd
-cZd
+hgM
+hgM
 acN
 acN
 acN
@@ -29181,41 +29911,41 @@ ajG
 ajG
 alR
 amv
-alm
+eCO
 alm
 alm
 ajj
-ajj
+xxs
 ajS
 apQ
 amw
 amw
-ajS
+fPB
 ajS
 amw
 amw
 amO
-ajS
+fPB
 aoD
 aui
-auH
-avd
-avx
+axR
+axR
+axR
 avQ
-ape
-qrL
-axc
-auJ
-axQ
-avd
-avw
-avP
-auG
-avd
-avd
-avd
-avw
-aza
+axR
+opM
+avQ
+avQ
+axR
+auH
+avx
+axR
+axR
+auH
+aOj
+axR
+axR
+ayo
 axR
 auH
 aAE
@@ -29226,7 +29956,7 @@ axb
 avd
 aOj
 axR
-atK
+iAy
 axR
 kir
 avx
@@ -29242,8 +29972,8 @@ aPW
 aPW
 aPW
 aLt
-aPW
-aPW
+aSd
+aSd
 aLt
 aPW
 aPW
@@ -29306,39 +30036,39 @@ abf
 abe
 abe
 abe
+vRN
+vRN
+abe
+vRN
+vRN
 abe
 abe
-abe
-abe
-abe
-abe
-abe
-abe
+vRN
+uuI
 acN
 acN
+uuI
+uuI
 acN
 acN
-acN
-acN
-acN
-acN
-acN
+uuI
+uuI
 acN
 acO
 acO
 adh
 acO
 acN
+uuI
+uuI
 acN
 acN
-acN
-acN
-acN
-acN
+uuI
+uuI
 acN
 cZd
-acN
-acN
+uuI
+uuI
 acN
 agv
 agv
@@ -29377,29 +30107,29 @@ amO
 ajS
 aoP
 atG
-auH
-auJ
-avy
-avR
+axR
+avQ
+aCr
 avQ
 avQ
-axd
-axw
-avP
-avP
-aCp
-ayo
-auH
-avd
-avd
-avd
-auE
-awh
+avQ
+avQ
+aLo
 axR
 ayY
-avP
-auG
-avd
+aCp
+cBC
+axR
+auH
+avq
+aNO
+auE
+awD
+awD
+aIk
+aIZ
+emG
+wiE
 avd
 aEL
 aEL
@@ -29414,7 +30144,7 @@ auk
 avd
 aLs
 aMm
-bfQ
+stw
 aMm
 aMm
 aMm
@@ -29508,12 +30238,12 @@ acO
 acO
 acO
 acN
+uuI
+uuI
 acN
 acN
-acN
-acN
-acN
-acN
+uuI
+uuI
 cZd
 acN
 acN
@@ -29547,37 +30277,37 @@ aph
 alS
 alS
 alS
-ajS
-alS
-alS
+wYx
+wYx
+wYx
 alS
 alS
 alS
 ajS
 atG
-rxR
-auI
-ave
-auJ
-avS
-awi
-awi
-auk
+kOK
+aCr
+avQ
+avQ
+avQ
+axR
+axR
+wlI
+axR
+axR
+axR
+axR
+axR
+axR
+auH
+avd
+avd
 avx
 axR
 axR
 axR
-atH
-auk
-avw
-avP
-auG
-avq
-awD
-awD
-awD
-awD
-aIk
+axR
+ayY
 aEN
 aFV
 aFV
@@ -29598,16 +30328,16 @@ aOi
 aOi
 aOi
 aOi
+guw
 aOi
 aOi
 aOi
 aOi
-aOi
-aOi
+guw
 aOi
 aOi
 aZm
-aZm
+qnO
 aZm
 aZm
 aZm
@@ -29691,8 +30421,8 @@ acN
 acN
 acN
 acN
-acN
-cZd
+uuI
+hgM
 acN
 acN
 aen
@@ -29704,7 +30434,7 @@ agv
 agv
 agI
 agv
-ftB
+agv
 agv
 agv
 agv
@@ -29734,26 +30464,26 @@ alL
 ams
 atk
 atH
-auk
-auJ
-auJ
-avz
-avT
-awk
-avd
-avd
-axx
+awi
+aBh
+aBh
+aBh
+aBh
+ayp
+awi
+awi
+awi
 kFH
 awi
 ayp
-auk
+awi
 xMw
-avx
+auk
 fUr
-auH
-aOj
+avd
+avx
 axR
-axR
+wlI
 ayo
 axR
 aLo
@@ -29870,8 +30600,8 @@ acN
 acN
 acN
 cZd
-cZd
-acN
+hgM
+uuI
 acN
 aen
 aen
@@ -29899,7 +30629,7 @@ ahF
 ahX
 amV
 ahX
-ajL
+ybF
 oKh
 ajz
 ajz
@@ -29911,14 +30641,14 @@ ajz
 arO
 aqI
 ald
-aro
-arV
+arl
+arp
 atX
 atX
 arW
-atQ
-auT
-awl
+arW
+arY
+auM
 arW
 arW
 arW
@@ -29927,10 +30657,10 @@ ayq
 azb
 ayq
 avV
-axx
-awi
-auk
-aOj
+avd
+avd
+avd
+avx
 ayo
 axR
 axR
@@ -29947,7 +30677,7 @@ aKb
 aHM
 aLw
 aMq
-aLw
+dEu
 aEO
 aNi
 aMm
@@ -29959,7 +30689,7 @@ aMn
 aMn
 aLt
 aMn
-aMn
+aSd
 aLt
 aMn
 aMn
@@ -30041,7 +30771,7 @@ acO
 acO
 aeu
 acO
-adh
+ipV
 acO
 aeK
 acN
@@ -30076,10 +30806,10 @@ ajR
 ajR
 ahF
 ahX
-amV
+uvs
 ahX
-ajR
-aoz
+ahX
+alu
 ajz
 ajz
 ajz
@@ -30089,14 +30819,14 @@ ajz
 ajz
 ajz
 alb
-arU
-arV
-arW
+aiJ
+gJp
+arp
 atl
 arW
 asu
-aut
-asU
+arW
+arW
 avV
 avV
 avV
@@ -30130,17 +30860,17 @@ awI
 aEO
 aNi
 aMm
-aNk
+uAq
 aMm
 aOY
 aEU
 aKs
 aLb
 aES
-aES
-aFD
-aES
-aFD
+aJD
+vpq
+aEx
+aLa
 aES
 aES
 aFD
@@ -30224,10 +30954,10 @@ acO
 acO
 aeK
 acN
-acN
-acN
-cZd
-acN
+uuI
+uuI
+hgM
+uuI
 aen
 aeE
 aen
@@ -30257,8 +30987,8 @@ alU
 ahX
 amV
 ahX
-ajR
-aoz
+ahX
+alu
 ajz
 ajz
 ajz
@@ -30268,8 +30998,8 @@ ajz
 ajz
 ajz
 alb
-arp
-arW
+arl
+arl
 atl
 atl
 arW
@@ -30316,9 +31046,9 @@ aJD
 nEe
 aKZ
 aES
-aFD
-aES
-aHU
+nMR
+aEx
+vsg
 aXf
 aFB
 aET
@@ -30403,10 +31133,10 @@ acO
 acO
 aeK
 acN
-acN
-acN
-cZd
-acN
+uuI
+uuI
+hgM
+uuI
 aen
 aen
 aen
@@ -30436,8 +31166,8 @@ ajR
 ahX
 amV
 ahX
-ajR
-aoz
+ahX
+alu
 ajz
 ajz
 amw
@@ -30447,8 +31177,8 @@ ajz
 ajz
 ajz
 alb
-arp
-atl
+arl
+arl
 atl
 atl
 arW
@@ -30461,7 +31191,7 @@ awn
 abB
 axS
 ayt
-awn
+lhR
 azC
 awn
 awn
@@ -30495,9 +31225,9 @@ aEW
 aKt
 eva
 aFB
-aES
-aES
-aET
+aJD
+aEx
+aMy
 aFB
 aFB
 aFB
@@ -30508,7 +31238,7 @@ aZk
 aZW
 aZk
 aZl
-aZl
+nAc
 aZl
 bfY
 fTB
@@ -30615,7 +31345,7 @@ ajR
 ahX
 amV
 ahX
-akq
+iAI
 alu
 ajz
 ajz
@@ -30626,8 +31356,8 @@ ajz
 ajz
 ajz
 alb
-arp
-arW
+arl
+arl
 atl
 atX
 arW
@@ -30654,7 +31384,7 @@ aDa
 aEP
 aFq
 aFq
-aFq
+nqK
 aFq
 aHN
 aFq
@@ -30663,7 +31393,7 @@ aKd
 aKT
 aLz
 aKd
-aKd
+hVH
 aKd
 awU
 aOi
@@ -30675,8 +31405,8 @@ aGk
 aFB
 aFB
 aFB
-aET
-aET
+aMy
+aMy
 aFB
 aFB
 aFB
@@ -30749,13 +31479,13 @@ abf
 acN
 acN
 acN
+uuI
+uuI
+uuI
 acN
 acN
-acN
-acN
-acN
-acN
-acN
+uuI
+uuI
 acN
 aeK
 acO
@@ -30794,7 +31524,7 @@ ajR
 ahX
 amV
 ahX
-anZ
+ajL
 alu
 apf
 ajz
@@ -30805,9 +31535,9 @@ ajz
 ajz
 ajz
 alb
-arp
-qHa
-atI
+gJp
+kCe
+nVu
 atX
 arW
 arW
@@ -30828,7 +31558,7 @@ awJ
 avV
 avV
 nEg
-aAb
+ffi
 aAb
 aEO
 aFr
@@ -30853,10 +31583,10 @@ aES
 aFB
 aFB
 aFB
-aET
-aET
-aET
-aES
+aJB
+aMy
+aMy
+aKZ
 aFB
 aFB
 aFB
@@ -30928,13 +31658,13 @@ abe
 acN
 acN
 acN
+uuI
+uuI
+uuI
 acN
 acN
-acN
-acN
-acN
-acN
-acN
+uuI
+uuI
 acN
 acN
 acN
@@ -30942,8 +31672,8 @@ acO
 acO
 acO
 acO
-cZd
-aev
+hgM
+qEL
 aen
 aen
 aen
@@ -30971,7 +31701,7 @@ agU
 tjA
 alU
 akq
-amV
+uvs
 akq
 aka
 oKh
@@ -30984,9 +31714,9 @@ apf
 ajz
 arP
 alb
-arp
-arW
-atI
+arl
+arl
+nVu
 atX
 arW
 arW
@@ -31032,10 +31762,10 @@ aES
 aET
 aFB
 aFB
-aET
-aES
-aES
-aES
+aJB
+aEx
+aEx
+aKZ
 aFB
 aFB
 aET
@@ -31107,13 +31837,13 @@ abe
 acN
 acN
 acN
+uuI
+uuI
+uuI
 acN
 acN
-acN
-acN
-acN
-acN
-acN
+uuI
+uuI
 acN
 acN
 acN
@@ -31121,8 +31851,8 @@ acN
 acO
 adh
 acO
-cZd
-aev
+hgM
+qEL
 aev
 aen
 aen
@@ -31163,9 +31893,9 @@ ajz
 ajz
 aqI
 ald
-arq
-arZ
-arW
+arl
+arl
+arp
 atI
 auK
 arW
@@ -31177,7 +31907,7 @@ amM
 awn
 axV
 awn
-awn
+lhR
 awn
 awn
 aAL
@@ -31211,10 +31941,10 @@ aES
 aFB
 aFB
 aFB
-aES
-aES
-aWF
-aES
+aJD
+aEx
+aEx
+aKZ
 aFB
 aFB
 aET
@@ -31224,7 +31954,7 @@ aES
 aES
 aEy
 aOs
-aZu
+hmT
 aOs
 aEy
 aES
@@ -31286,16 +32016,16 @@ abe
 acN
 acN
 acN
+uuI
+uuI
+uuI
 acN
 acN
+uuI
+uuI
 acN
-acN
-acN
-acN
-acN
-acN
-acN
-acN
+uuI
+uuI
 acN
 acN
 aeu
@@ -31321,7 +32051,7 @@ agv
 agv
 agv
 agv
-ajG
+ajH
 ajG
 ajG
 ajG
@@ -31343,8 +32073,8 @@ ajz
 arQ
 ala
 arl
+arl
 arp
-arW
 atI
 arW
 arW
@@ -31374,10 +32104,10 @@ aGC
 aHi
 aHM
 aGd
-aJt
+pQE
 aKf
 aHM
-aGd
+tni
 aMt
 avr
 aEO
@@ -31390,10 +32120,10 @@ aET
 aFB
 aFB
 aFB
-aET
-aES
-aES
-aES
+aJB
+aEx
+aEx
+aKZ
 aFB
 aET
 aES
@@ -31473,8 +32203,8 @@ acN
 acN
 acN
 acN
-acN
-acN
+uuI
+uuI
 acN
 acN
 acO
@@ -31521,8 +32251,8 @@ ajz
 ajz
 ajz
 alb
+gJp
 arl
-arp
 atl
 atl
 arW
@@ -31570,9 +32300,9 @@ aFB
 aFB
 aFB
 aFB
-aET
-aET
-aET
+aMy
+aMy
+taV
 aFB
 aYv
 aES
@@ -31640,17 +32370,17 @@ dnU
 abm
 abm
 scW
-abe
+vRN
+uuI
 acN
 acN
+uuI
+uuI
+uuI
 acN
 acN
-acN
-acN
-acN
-acN
-acN
-acN
+uuI
+uuI
 acN
 acN
 acN
@@ -31700,8 +32430,8 @@ ajz
 ajz
 ajz
 alb
-aro
-arV
+arl
+arl
 atl
 atl
 atX
@@ -31749,9 +32479,9 @@ aHT
 aHT
 aET
 aFB
-aET
-aES
-aXg
+aMy
+aEx
+taV
 aES
 aFD
 aES
@@ -31773,7 +32503,7 @@ bcD
 blb
 aZl
 aZl
-aZl
+nAc
 aZl
 cnD
 bpG
@@ -31819,17 +32549,17 @@ abf
 acs
 abm
 scW
-abe
+vRN
+uuI
 acN
 acN
+uuI
+uuI
+uuI
 acN
 acN
-acN
-acN
-acN
-acN
-acN
-acN
+uuI
+uuI
 acN
 acN
 acN
@@ -31839,8 +32569,8 @@ acO
 acO
 acO
 aeK
-fHY
-aev
+rsK
+qEL
 aen
 aen
 aen
@@ -31866,7 +32596,7 @@ alf
 ajG
 ajG
 ajG
-amU
+qZa
 ang
 anZ
 alu
@@ -31879,8 +32609,8 @@ ajz
 ajz
 aqI
 ald
-arp
-atl
+arl
+arl
 atl
 arW
 atX
@@ -31903,9 +32633,9 @@ ayq
 aAb
 aDC
 aAb
+ffi
 aAb
 aAb
-atZ
 aGe
 aGg
 aNX
@@ -31927,10 +32657,10 @@ aHT
 aFD
 aES
 aET
-aES
-aES
-aES
-aES
+aJD
+aEx
+aEx
+aKZ
 aFD
 aYw
 aET
@@ -31948,9 +32678,9 @@ bhm
 xQl
 aOs
 aES
-bjH
-bjH
-bjH
+hAH
+hAH
+hAH
 bjH
 bjH
 blo
@@ -31998,17 +32728,17 @@ abf
 abf
 abm
 scW
-abe
+vRN
+uuI
 acN
 acN
+uuI
+uuI
+uuI
 acN
 acN
-acN
-acN
-acN
-acN
-acN
-acN
+uuI
+uuI
 acN
 acN
 acN
@@ -32018,8 +32748,8 @@ acO
 acO
 adh
 aeK
-fHY
-aev
+rsK
+qEL
 aev
 aev
 aen
@@ -32037,7 +32767,7 @@ gXL
 gXL
 gXL
 gXL
-gXL
+rlb
 gXL
 ahM
 ahD
@@ -32058,8 +32788,8 @@ ajz
 ajz
 arR
 aiJ
-arp
-atl
+gJp
+arl
 atl
 atl
 atX
@@ -32081,10 +32811,10 @@ aAM
 ayq
 aAb
 aDC
-aAO
-aBs
+aAb
+aAb
 aCZ
-atZ
+aAb
 aGf
 aGD
 aNX
@@ -32106,10 +32836,10 @@ aHT
 aES
 aLt
 aPW
-aPW
-aPW
+sus
+aSd
 aLt
-aPW
+aSc
 aPW
 aPW
 aEy
@@ -32126,13 +32856,13 @@ anL
 bhm
 aXg
 aEy
-bjH
-bjH
-vzz
-eBP
-eBP
+hAH
+hAH
+blj
+blO
+blO
 bnm
-eBP
+blO
 boD
 bpJ
 bqj
@@ -32177,17 +32907,17 @@ abf
 abm
 abm
 scW
-abe
+vRN
+uuI
 acN
 acN
+uuI
+uuI
+uuI
 acN
 acN
-acN
-acN
-acN
-acN
-acN
-acN
+uuI
+uuI
 acN
 acO
 acO
@@ -32197,20 +32927,20 @@ acO
 acO
 acO
 aeK
-aev
-fHY
+qEL
+rsK
 aev
 aev
 aen
 aen
-aen
+aeE
 agv
 agv
 agw
 agV
 ahl
 gXL
-ahD
+lGO
 gXL
 aip
 aiC
@@ -32237,8 +32967,8 @@ ajz
 ajz
 alb
 aiJ
-arp
-atl
+arl
+arl
 atl
 atl
 atX
@@ -32260,11 +32990,11 @@ ayq
 avV
 aAb
 aDC
-aEf
-aCy
+aAb
+aAb
+aAb
 aAb
 atZ
-aGg
 kZI
 aGg
 aPb
@@ -32305,17 +33035,17 @@ anL
 bhm
 azg
 biV
-bjH
+hAH
 bkw
-blh
+dgb
 blP
 bmH
 bmH
 bnP
 boE
-bRL
-eaL
-vqo
+dgb
+blj
+blj
 blj
 brE
 bsh
@@ -32376,8 +33106,8 @@ acO
 acO
 acO
 aeK
-aev
-aev
+qEL
+qEL
 fHY
 aev
 aev
@@ -32408,21 +33138,21 @@ ang
 ane
 oKh
 amw
-ajz
-ajz
-ajz
-ajz
-ajz
-ajz
+amw
+amw
+amw
+amw
+amw
+amw
 arS
 asp
 kSB
-arX
+auT
 atl
-atX
-arW
-arY
-atY
+aun
+auS
+atn
+auS
 auS
 auS
 auS
@@ -32442,7 +33172,7 @@ aDC
 aAb
 aAb
 aAb
-atZ
+aAb
 aGe
 aGg
 aGg
@@ -32464,11 +33194,11 @@ aFD
 aQe
 aLs
 aMm
-aPX
+abF
 aMm
 aMm
 aMm
-aMm
+kKo
 aMm
 aZu
 aET
@@ -32485,14 +33215,14 @@ qxe
 aXg
 aXg
 gPc
-vzz
-dgb
 blj
-vqo
-eaL
-mMl
-boF
 blh
+blj
+blj
+blj
+blj
+boF
+dgb
 bqj
 bqR
 bqj
@@ -32555,8 +33285,8 @@ adh
 acO
 acO
 aeK
-aev
-aev
+qEL
+qEL
 aev
 fHY
 aev
@@ -32571,7 +33301,7 @@ gXL
 ahD
 aia
 ahy
-aiD
+bZg
 aiY
 aiF
 gXL
@@ -32582,30 +33312,30 @@ gXL
 alB
 alV
 amv
-amU
+qZa
 ang
 akI
-all
-all
 alS
-ajS
-ajS
-ajz
-aqa
-ajS
-ajS
+alS
+alS
+lEt
+lEt
+lEt
+alS
+alS
+alS
 asq
 asM
-atn
+auT
 atJ
-atX
-atY
-auS
-aur
+awf
+arl
+arl
+arl
 auV
 arl
 arl
-auT
+arl
 arl
 jCY
 apG
@@ -32621,7 +33351,7 @@ aDC
 aAb
 aAb
 aAb
-atZ
+aAb
 aFw
 aFx
 aFx
@@ -32664,7 +33394,7 @@ bhm
 aXg
 biV
 bjH
-vzz
+blj
 dgb
 blR
 bmJ
@@ -32714,17 +33444,17 @@ abm
 abe
 abe
 scW
-abe
+vRN
+uuI
 acN
 acN
+uuI
+uuI
+uuI
 acN
 acN
-acN
-acN
-acN
-acN
-acN
-acN
+uuI
+uuI
 acN
 acN
 acN
@@ -32744,7 +33474,7 @@ afR
 agv
 agv
 agv
-agv
+agI
 ahm
 ahC
 gXL
@@ -32766,23 +33496,23 @@ anv
 alB
 aoE
 aji
-ajj
-ajS
-ajz
-ajz
-ajz
+aji
+aji
+vEO
+aji
+aji
 aji
 aji
 aji
 asN
 ato
-amx
-aun
-aur
+auT
+awf
+arl
 avg
 auo
 auo
-auo
+waG
 auo
 auo
 auo
@@ -32791,16 +33521,16 @@ apH
 arD
 atw
 aAc
+cIv
 aAc
 aAc
 aAc
-aAc
-aAc
+cIv
 aDF
 aAb
+ffi
 aAb
 aAb
-atZ
 aFx
 aGF
 aHm
@@ -32842,7 +33572,7 @@ pZl
 bhm
 aXg
 aEy
-bjH
+hAH
 bkz
 blj
 blS
@@ -32893,17 +33623,17 @@ abm
 abe
 abe
 scW
-abe
+vRN
+uuI
 acN
 acN
+uuI
+uuI
+uuI
 acN
 acN
-acN
-acN
-acN
-acN
-acN
-acN
+uuI
+uuI
 acN
 acN
 acN
@@ -32929,12 +33659,12 @@ gXL
 ahM
 aic
 air
-aiF
+hdZ
 aja
 ajs
 ahD
 akc
-gXL
+rlb
 gXL
 gXL
 akH
@@ -32944,11 +33674,11 @@ amX
 anw
 vJf
 aoF
-apg
 apC
-apg
-apZ
-apZ
+apC
+apC
+apC
+apC
 apC
 apC
 apC
@@ -32959,11 +33689,11 @@ atL
 auo
 auo
 avh
-auT
-aro
-asU
-asU
-aus
+arl
+arl
+arl
+arl
+arl
 vTe
 aoC
 apG
@@ -32979,7 +33709,7 @@ aDG
 aCZ
 aAb
 aAb
-aEf
+aAb
 aFx
 aGG
 aGh
@@ -32989,7 +33719,7 @@ aJA
 aKk
 aKV
 aLE
-aLE
+cCd
 aLE
 avu
 aFx
@@ -33021,7 +33751,7 @@ dEz
 gMl
 aHT
 aOs
-bjH
+hAH
 bkA
 blk
 bkA
@@ -33072,17 +33802,17 @@ abe
 abe
 abe
 scW
-abe
+vRN
+uuI
 acN
 acN
+uuI
+uuI
+uuI
 acN
 acN
-acN
-acN
-acN
-acN
-acN
-acN
+uuI
+uuI
 acN
 acN
 acN
@@ -33092,8 +33822,8 @@ acO
 acO
 aeK
 acN
-aev
-aev
+qEL
+qEL
 aev
 fHY
 aev
@@ -33124,25 +33854,25 @@ alm
 akq
 aoG
 ajj
-ajS
-ajz
-ajz
-ajS
-ajz
+xxs
 ajj
-ajz
+ajj
+ajj
+ajj
+xxs
+ajj
 ajj
 asP
-atq
+rnW
 atr
 arl
-arl
+gJp
 avi
-asU
-avo
-arW
-arW
-aut
+arl
+arl
+arl
+arl
+arl
 avZ
 avE
 ayF
@@ -33180,7 +33910,7 @@ aLc
 aFD
 aLs
 aMm
-aMm
+kKo
 aMm
 aEz
 aJD
@@ -33200,7 +33930,7 @@ bbP
 bhn
 aYv
 aOs
-bjH
+hAH
 bkB
 blj
 blT
@@ -33251,17 +33981,17 @@ abe
 abe
 abe
 scW
-abe
+vRN
+uuI
 acN
 acN
+uuI
+uuI
+uuI
 acN
 acN
-acN
-acN
-acN
-acN
-acN
-acN
+uuI
+uuI
 acN
 acN
 acN
@@ -33271,8 +34001,8 @@ adh
 acO
 aeK
 acN
-aev
-aev
+qEL
+qEL
 aev
 fHY
 aev
@@ -33284,7 +34014,7 @@ agv
 agv
 ahk
 gXL
-ahD
+lGO
 gXL
 ait
 aiG
@@ -33305,19 +34035,19 @@ aoH
 aph
 aph
 aph
-ajz
-ajj
-ajS
-ajz
 aph
-ajS
+aph
+aph
+aph
+aph
+aph
 asQ
 atr
-aro
-asU
-auL
-atW
-arY
+arl
+arl
+arl
+arl
+arl
 avX
 avE
 avE
@@ -33343,7 +34073,7 @@ aGI
 aGh
 aGh
 aGh
-aGh
+rCH
 aKk
 aKX
 aMu
@@ -33378,10 +34108,10 @@ iIS
 aXg
 aya
 aET
-aEy
-bjH
+kuU
+hAH
 bKi
-vzz
+blj
 blU
 bkA
 akv
@@ -33430,17 +34160,17 @@ scW
 scW
 scW
 cMZ
-abe
+vRN
+uuI
 acN
 acN
+uuI
+uuI
+uuI
 acN
 acN
-acN
-acN
-acN
-acN
-acN
-acN
+uuI
+uuI
 acN
 acN
 acO
@@ -33450,8 +34180,8 @@ acO
 acO
 aeK
 aeK
-aev
-aev
+qEL
+qEL
 aev
 fHY
 aev
@@ -33467,7 +34197,7 @@ ahN
 ahD
 gXL
 aiH
-gXL
+rlb
 gXL
 gXL
 gXL
@@ -33477,26 +34207,26 @@ alh
 ajG
 ajG
 alo
-amU
+qZa
 ang
 akI
 aoI
-ajS
-ajS
-ajz
-ajS
-ajj
 alS
-ajS
-all
+alS
+lEt
+lEt
+lEt
+alS
+alS
+alS
 alS
 asR
 asU
-atO
-atX
-atX
-atX
-arY
+asq
+arl
+arl
+arl
+arl
 avE
 awp
 awO
@@ -33518,7 +34248,7 @@ aAb
 aAb
 aFx
 aGh
-aGh
+rCH
 aGh
 aGh
 aGh
@@ -33558,9 +34288,9 @@ aOs
 aOs
 aOs
 aEy
-bjH
+hAH
 bkD
-bln
+see
 blj
 bkA
 bnq
@@ -33609,17 +34339,17 @@ abe
 abe
 abe
 abe
-abe
+vRN
+uuI
 acN
 acN
+uuI
+uuI
+uuI
 acN
 acN
-acN
-acN
-acN
-acN
-acN
-acN
+uuI
+uuI
 acN
 acO
 acO
@@ -33629,8 +34359,8 @@ acO
 adh
 acO
 aeK
-aev
-aev
+qEL
+qEL
 aev
 aev
 fHY
@@ -33661,21 +34391,21 @@ alm
 anZ
 oKh
 amw
-ajz
-ajz
-ajz
-ajz
-ajz
-ajz
+amw
+amw
+amw
+amw
+amw
+amw
 amr
 amO
 gJn
 arZ
-arW
-arW
-auM
-auM
-arY
+atQ
+arl
+arl
+arl
+arl
 avE
 awq
 awP
@@ -33704,20 +34434,20 @@ aGJ
 aGJ
 aKm
 aGi
+otV
 aGi
 aGi
 aGi
-aGi
-aGi
+otV
 aFy
 aOi
 aOi
-aOi
+guw
 upF
 aOi
 aOi
 aOi
-aQP
+aVt
 aMm
 aWG
 aXh
@@ -33737,7 +34467,7 @@ azg
 bet
 aET
 biZ
-bjH
+hAH
 bkD
 bln
 blj
@@ -33788,17 +34518,17 @@ abe
 abe
 abe
 abe
-abe
+vRN
+uuI
 acN
 acN
+uuI
+uuI
+uuI
 acN
 acN
-acN
-acN
-acN
-acN
-acN
-acN
+uuI
+uuI
 acN
 acO
 acO
@@ -33808,8 +34538,8 @@ acO
 acO
 acO
 aeK
-aev
-aev
+qEL
+qEL
 aev
 aev
 aev
@@ -33832,7 +34562,7 @@ ahE
 ako
 ahE
 ali
-ajG
+ajH
 ajG
 alo
 amU
@@ -33850,18 +34580,18 @@ aqb
 alb
 aiJ
 arp
-arW
-ghv
-atn
-avk
-auM
+atQ
+arl
+gJp
+arl
+arl
 avX
 awr
 awP
 axm
 axm
 awa
-awa
+pDe
 awa
 axn
 axn
@@ -33872,7 +34602,7 @@ aAb
 aAb
 aDC
 aAb
-aAb
+ffi
 aAb
 aFz
 aGh
@@ -33916,13 +34646,13 @@ aXg
 bhq
 aXg
 biZ
-bjH
+hAH
 bkD
 bln
 blj
 bkA
 bno
-bnV
+qkT
 boN
 bkA
 bqr
@@ -33987,8 +34717,8 @@ acO
 acO
 acO
 aeK
-aev
-aev
+qEL
+qEL
 fHY
 fHY
 fHY
@@ -34017,7 +34747,7 @@ alm
 amV
 akq
 ane
-aoz
+alu
 ajz
 akp
 ajz
@@ -34029,8 +34759,8 @@ ajz
 ass
 ala
 arp
-atP
-aur
+kfW
+arl
 arl
 lou
 avX
@@ -34075,14 +34805,14 @@ aMn
 aMn
 aLt
 aMm
+kKo
 aMm
 aMm
-aMm
-aMm
+kKo
 aMm
 aNk
 aMm
-aMm
+kKo
 aMm
 aMm
 bbT
@@ -34175,25 +34905,25 @@ aev
 aen
 agv
 agv
+agI
 agv
 agv
 agv
 agv
 agv
-agv
-agv
+agI
 agv
 agv
 agv
 ajG
 ajZ
-ajG
+ajH
 ajG
 ajG
 oqP
 ajG
 ajG
-amV
+uvs
 akq
 alU
 alu
@@ -34334,9 +35064,9 @@ cZd
 cZd
 acN
 acN
-acN
-acN
-acN
+uuI
+uuI
+uuI
 acN
 acO
 acN
@@ -34392,17 +35122,17 @@ arl
 arl
 arp
 avF
+pDe
 awa
 awa
-awa
-awa
+pDe
 awa
 ayc
 avZ
 azm
 awa
 awa
-awa
+pDe
 aBx
 aBX
 aCB
@@ -34419,7 +35149,7 @@ aGK
 aGK
 aGK
 aGh
-aGh
+rCH
 aGh
 aGh
 aGh
@@ -34513,9 +35243,9 @@ acS
 acS
 cZd
 acN
-acN
-acN
-acN
+uuI
+uuI
+uuI
 acN
 acN
 cZd
@@ -34541,7 +35271,7 @@ agw
 qow
 agV
 agv
-agv
+agI
 ajc
 ajI
 ajI
@@ -34586,7 +35316,7 @@ awa
 awa
 avE
 aAb
-aDC
+ohD
 aAb
 aAb
 aAb
@@ -34638,7 +35368,7 @@ aYw
 aES
 bmM
 bnt
-bnX
+siq
 czY
 bpN
 bqt
@@ -34692,9 +35422,9 @@ adr
 acS
 acN
 cZd
-cZd
-cZd
-cZd
+hgM
+hgM
+hgM
 cZd
 cZd
 acS
@@ -34876,12 +35606,12 @@ acS
 acS
 acS
 acS
-acN
+uuI
 adR
 adR
 aen
-aev
-aev
+qEL
+qEL
 aen
 afE
 adR
@@ -34935,7 +35665,7 @@ awS
 axn
 axn
 awa
-awa
+pDe
 awa
 axm
 axm
@@ -35055,12 +35785,12 @@ adJ
 adV
 adV
 acS
-acN
+uuI
 aeW
 afc
 afh
-aev
-aev
+qEL
+qEL
 aen
 afE
 adR
@@ -35088,7 +35818,7 @@ alj
 alE
 akI
 alo
-amU
+qZa
 alm
 akI
 alu
@@ -35256,7 +35986,7 @@ agy
 ahO
 agv
 agv
-agv
+agI
 ajc
 aew
 ajR
@@ -35313,7 +36043,7 @@ aET
 aET
 aGk
 aJB
-aEx
+sWJ
 aLa
 aHT
 aET
@@ -35328,7 +36058,7 @@ aMA
 aTG
 aUg
 aUM
-aUM
+ygX
 aUM
 aWH
 aXj
@@ -35336,12 +36066,12 @@ aTH
 aNz
 aNz
 aRd
-aNz
+nGf
 aNz
 bbW
 bcL
 bdM
-bdM
+cah
 bdM
 bdM
 bbW
@@ -35449,7 +36179,7 @@ alo
 amU
 ajR
 akq
-aoz
+alu
 jVV
 amw
 ajz
@@ -35481,7 +36211,7 @@ avE
 avZ
 aAb
 aAb
-aDC
+ohD
 aAb
 aEz
 aET
@@ -35628,7 +36358,7 @@ alo
 amU
 akq
 ajR
-aoz
+alu
 ajz
 ajz
 ajz
@@ -35788,7 +36518,7 @@ agA
 agA
 agA
 agy
-agz
+uwl
 agy
 ahO
 agv
@@ -35804,10 +36534,10 @@ alk
 ajR
 ajR
 akq
-amU
+qZa
 ajR
 ajR
-aoz
+alu
 ajz
 ajz
 ajz
@@ -35862,11 +36592,11 @@ aPi
 aRD
 aSi
 aPl
-aTI
+ltG
 aUi
 aUO
 aUO
-aWb
+tzJ
 aWb
 aUM
 aTH
@@ -36057,7 +36787,7 @@ aNz
 bbW
 bcO
 bdP
-bdP
+dYX
 bfq
 bdP
 bbW
@@ -36189,7 +36919,7 @@ arW
 arW
 arY
 atQ
-arl
+gJp
 aro
 aEh
 aEh
@@ -36229,7 +36959,7 @@ aTH
 aTH
 aTH
 aYE
-aZA
+uEj
 bal
 bba
 bbx
@@ -36253,7 +36983,7 @@ aET
 aES
 bmN
 bnt
-bnX
+siq
 eLX
 bpN
 bqO
@@ -36396,7 +37126,7 @@ aMB
 aPj
 aPl
 aQX
-aPl
+dFh
 aSl
 aSW
 aNy
@@ -36411,7 +37141,7 @@ aLd
 aZA
 bal
 bba
-bgU
+vEP
 bbW
 bcP
 bdQ
@@ -36497,7 +37227,7 @@ aen
 afE
 adR
 aee
-adR
+dtR
 adR
 adR
 agy
@@ -36520,7 +37250,7 @@ alU
 alU
 akI
 alo
-amU
+qZa
 ang
 alS
 vJc
@@ -36583,7 +37313,7 @@ aUl
 aUR
 aUl
 aUR
-aUl
+vXZ
 aUR
 aUp
 aYG
@@ -36753,7 +37483,7 @@ aMA
 aQW
 aPl
 aQj
-cUM
+aQZ
 aRF
 aSn
 aSY
@@ -36774,7 +37504,7 @@ bbX
 bfs
 bdS
 bey
-bdR
+qNX
 ayW
 bbW
 bhA
@@ -36783,7 +37513,7 @@ bji
 bhE
 bhE
 bhE
-bma
+lfP
 bmO
 bhE
 aES
@@ -36860,22 +37590,22 @@ adR
 adR
 agy
 agy
+cay
 agy
 agy
 agy
 agy
-agy
-agy
+cay
 agy
 aho
 agy
 agy
 alm
-akq
+pWM
 alm
 alm
 alm
-alm
+eCO
 alm
 aeQ
 amU
@@ -36932,7 +37662,7 @@ aMA
 aNy
 aNy
 aQk
-cUM
+aQZ
 aRF
 aSm
 aSX
@@ -36969,7 +37699,7 @@ bhE
 aES
 bmN
 bnt
-bnX
+siq
 bnt
 bmN
 bpy
@@ -37111,8 +37841,8 @@ aNw
 aOE
 aPm
 aQl
-xtV
 aPl
+dFh
 aSn
 aSZ
 aNy
@@ -37125,7 +37855,7 @@ aWN
 aWN
 aiy
 aYF
-aRd
+obS
 bbc
 aXt
 bbW
@@ -37187,11 +37917,11 @@ abf
 acs
 abf
 abe
-abe
-abe
-abe
-acN
-acN
+vRN
+vRN
+vRN
+uuI
+uuI
 acN
 cZd
 adl
@@ -37290,7 +38020,7 @@ aNx
 aOF
 aPn
 aQl
-aQz
+aQj
 aPl
 aSo
 aTa
@@ -37366,11 +38096,11 @@ abf
 abf
 abf
 abe
-abe
-abe
-abe
-acN
-acN
+vRN
+vRN
+vRN
+uuI
+uuI
 acN
 cZd
 acS
@@ -37418,7 +38148,7 @@ amD
 anb
 abA
 alS
-ajz
+amw
 ajz
 ajz
 ajz
@@ -37545,11 +38275,11 @@ abf
 abf
 abf
 abe
-abe
-abe
-abe
-acN
-acN
+vRN
+vRN
+vRN
+uuI
+uuI
 cZd
 acN
 acS
@@ -37597,7 +38327,7 @@ amD
 anc
 aei
 aof
-ajz
+amw
 ajz
 ajz
 ajz
@@ -37648,7 +38378,7 @@ aNz
 aOG
 aPo
 aQm
-aYF
+aNz
 aNz
 aNz
 aTb
@@ -37766,7 +38496,7 @@ agv
 agv
 agv
 ajG
-ajG
+ajH
 ajG
 ajG
 alo
@@ -37785,9 +38515,9 @@ ajz
 ajz
 alc
 ald
-arU
-asU
-arV
+aiJ
+arl
+arp
 atl
 arW
 auO
@@ -37827,9 +38557,9 @@ aNz
 aMC
 aNz
 aQn
-aYF
 aNz
 aNz
+nGf
 aNz
 aNz
 aNz
@@ -37930,7 +38660,7 @@ aen
 adR
 aee
 adR
-adR
+dtR
 adR
 agy
 agy
@@ -37963,8 +38693,8 @@ akp
 ajz
 ajz
 alb
-arU
-arV
+aiJ
+arl
 atl
 atl
 atl
@@ -37972,7 +38702,7 @@ atl
 arW
 aut
 aus
-arl
+gJp
 arl
 arp
 arW
@@ -38002,18 +38732,18 @@ aKw
 aKw
 aLP
 aME
-aNz
+nGf
 aNC
 aNz
 aME
-aYF
+aNz
 aRG
 aRG
 aRG
 aRG
 aRG
 aRG
-aRG
+lki
 aWf
 aWO
 aXt
@@ -38119,7 +38849,7 @@ agz
 agy
 ahO
 agv
-agv
+agI
 agv
 agv
 agv
@@ -38134,7 +38864,7 @@ amF
 anc
 aei
 aoh
-ajz
+amw
 ajz
 ajz
 ajz
@@ -38142,8 +38872,8 @@ ajz
 ajz
 ajz
 alb
-arp
-arW
+gJp
+arl
 atl
 atl
 atl
@@ -38216,7 +38946,7 @@ bjS
 bkO
 aNA
 bme
-aNA
+knr
 bny
 bof
 boT
@@ -38259,8 +38989,8 @@ abf
 abf
 abe
 abe
-abe
-abe
+vRN
+vRN
 mWY
 acI
 acI
@@ -38313,7 +39043,7 @@ jzT
 anc
 aib
 alS
-ajz
+amw
 ajz
 akp
 ajz
@@ -38321,9 +39051,9 @@ ajz
 ajz
 aqI
 ark
+arl
+arl
 arp
-arW
-arW
 atl
 atl
 atl
@@ -38338,7 +39068,7 @@ atX
 atX
 arY
 avA
-arl
+gJp
 aEh
 aEh
 aEh
@@ -38438,8 +39168,8 @@ abf
 abe
 abe
 abe
-abe
-mWY
+vRN
+jJK
 abe
 acI
 acJ
@@ -38455,12 +39185,12 @@ aer
 acP
 acR
 aey
-aey
+sqN
 acR
 acR
 aey
 acR
-acR
+tiN
 aey
 aey
 acR
@@ -38492,7 +39222,7 @@ jzT
 and
 anF
 aof
-ajz
+amw
 ajz
 ajz
 ajz
@@ -38500,9 +39230,9 @@ ajz
 ajz
 alb
 arl
-arp
-arW
-arY
+arl
+arl
+avl
 atl
 atl
 atl
@@ -38541,12 +39271,12 @@ aLP
 aMC
 aNC
 aMC
-aNz
+nGf
 aNz
 aRd
 aNz
 aNz
-aNz
+nGf
 aNz
 aNz
 aNz
@@ -38579,7 +39309,7 @@ aYf
 bog
 aLM
 bnt
-bnt
+rGv
 bnt
 bnt
 bpN
@@ -38617,8 +39347,8 @@ abe
 abe
 abe
 abe
-abe
-mWY
+vRN
+jJK
 abe
 acJ
 acJ
@@ -38652,7 +39382,7 @@ agz
 agz
 agy
 agz
-agz
+uwl
 agy
 ahb
 agv
@@ -38671,7 +39401,7 @@ jzT
 lpJ
 anG
 aof
-ajz
+amw
 ajz
 ajz
 ajz
@@ -38679,9 +39409,9 @@ ajz
 ajz
 alb
 arl
-arp
+arl
 arW
-asW
+ceg
 arW
 atl
 cat
@@ -38731,7 +39461,7 @@ aUq
 aNz
 aRd
 aNz
-aNz
+nGf
 aXu
 aYa
 aYa
@@ -38739,7 +39469,7 @@ aYa
 bat
 aYa
 aYa
-aYa
+hGZ
 aNz
 aNz
 aNz
@@ -38796,8 +39526,8 @@ abe
 abe
 abe
 abe
-abe
-mWY
+vRN
+jJK
 abe
 acK
 abE
@@ -38850,7 +39580,7 @@ jzT
 lpJ
 anH
 aof
-ajz
+amw
 ajz
 ajz
 ajz
@@ -38858,9 +39588,9 @@ ajz
 ajz
 alb
 arl
+arl
+auT
 arp
-arY
-arW
 arW
 arY
 atl
@@ -38914,7 +39644,7 @@ aTL
 aXq
 aNz
 aNz
-aNz
+nGf
 bau
 aNz
 aNz
@@ -38932,7 +39662,7 @@ bdV
 bdV
 bdV
 bdV
-bjX
+pPr
 bjX
 bmW
 aLL
@@ -38975,8 +39705,8 @@ abe
 abe
 abe
 abe
-abe
-mWY
+vRN
+jJK
 abe
 acL
 acI
@@ -39003,7 +39733,7 @@ afw
 aey
 aey
 aey
-acR
+tiN
 agi
 agr
 agE
@@ -39029,7 +39759,7 @@ amG
 lpJ
 anI
 aof
-ajz
+amw
 ajz
 ajz
 ajz
@@ -39037,9 +39767,9 @@ ajz
 ajz
 akC
 arm
+gJp
+arl
 arp
-asu
-arW
 asW
 arW
 arW
@@ -39154,8 +39884,8 @@ abe
 abe
 abe
 abe
-abe
-mWY
+vRN
+jJK
 abe
 acI
 acI
@@ -39174,7 +39904,7 @@ aey
 aey
 aey
 acR
-aey
+sqN
 aey
 afq
 acW
@@ -39208,7 +39938,7 @@ jzT
 lpJ
 abA
 alS
-ajz
+amw
 ajz
 ajz
 ajz
@@ -39216,9 +39946,9 @@ ajz
 ajz
 apf
 arn
-arp
-arY
-arX
+arl
+auT
+avl
 arW
 arW
 arW
@@ -39260,7 +39990,7 @@ aOJ
 aPq
 aQq
 aRg
-aPr
+qVg
 aSr
 aTe
 aTL
@@ -39370,7 +40100,7 @@ agv
 agv
 agv
 agv
-agv
+agI
 agv
 agv
 agv
@@ -39379,7 +40109,7 @@ agG
 ajT
 ajG
 ajG
-ajG
+ajH
 alo
 wiK
 amg
@@ -39387,7 +40117,7 @@ amH
 lpJ
 aei
 hDA
-ajz
+amw
 akp
 ajz
 ajz
@@ -39395,9 +40125,9 @@ ajz
 ajz
 aqI
 ark
+arl
+arl
 arp
-asu
-arW
 arW
 arW
 arW
@@ -39424,7 +40154,7 @@ arY
 arW
 aFa
 aDc
-aDc
+qYJ
 aDc
 aEZ
 aHZ
@@ -39459,11 +40189,11 @@ bcd
 bcZ
 bdW
 beJ
-bfy
+jAP
 bgq
 bgW
 bfy
-biy
+sET
 biy
 bjV
 bdV
@@ -39507,11 +40237,11 @@ abf
 abf
 abf
 abe
-abe
-abe
-abe
-abe
-abe
+vRN
+vRN
+vRN
+vRN
+vRN
 abe
 abe
 abe
@@ -39528,7 +40258,7 @@ acP
 acP
 acP
 acP
-aey
+sqN
 aey
 aey
 acP
@@ -39566,17 +40296,17 @@ jzT
 lpJ
 aid
 aog
-aoN
+gNA
 ajz
 ajz
 ajz
 ajz
 ajz
 alb
-aro
-arV
-arY
-arW
+arl
+arl
+auT
+arp
 arW
 arY
 arW
@@ -39633,7 +40363,7 @@ aNz
 aZI
 bax
 baZ
-aNz
+nGf
 bcd
 bda
 bdW
@@ -39686,11 +40416,11 @@ abf
 abf
 abf
 abe
-abe
-abe
-abe
-abe
-abe
+vRN
+vRN
+vRN
+vRN
+vRN
 abe
 abe
 abe
@@ -39715,7 +40445,7 @@ aey
 aey
 aey
 afx
-aey
+sqN
 aey
 aey
 acI
@@ -39745,17 +40475,17 @@ jzT
 lpJ
 aei
 aog
-aoN
+gNA
 ajz
 ajz
 ajz
 ajz
 ajz
 alb
+arl
+gJp
+arl
 arp
-arW
-asv
-asu
 arW
 arW
 atX
@@ -39825,7 +40555,7 @@ bdV
 bdV
 bjX
 bdV
-bjX
+pPr
 bjX
 bmW
 bmW
@@ -39924,17 +40654,17 @@ amI
 lpJ
 aiX
 aof
-ajz
+amw
 ajz
 ajz
 ajz
 akp
 ajz
 alb
+arl
+auT
+arl
 arp
-arX
-arW
-arW
 arW
 atX
 arW
@@ -39976,13 +40706,13 @@ aMJ
 aPt
 aQs
 aRi
-aPr
+qVg
 aSs
 aTg
 aTL
 aUt
 aVc
-aVH
+xar
 aVd
 aVH
 aWn
@@ -40051,15 +40781,15 @@ aag
 aag
 aag
 aaf
-aaf
-aaf
-aaf
+tGv
+tGv
+tGv
 aaf
 aaf
 abg
-abg
-abg
-abg
+iII
+iII
+iII
 abg
 ohY
 abg
@@ -40068,7 +40798,7 @@ abg
 aey
 aey
 aey
-aey
+sqN
 aey
 aey
 aey
@@ -40103,17 +40833,17 @@ amJ
 lpJ
 ajg
 alS
-ajz
+jJh
 ajz
 ajz
 ajz
 ajz
 ajz
 alb
+arl
+auT
+arl
 arp
-arX
-arW
-arW
 arW
 atX
 atX
@@ -40132,15 +40862,15 @@ azK
 aAk
 aAk
 aAk
+jXK
 aAk
 aAk
 aAk
 aAk
+jXK
 aAk
 aAk
-aAk
-aAk
-aAk
+jXK
 aAk
 aHu
 aIb
@@ -40230,15 +40960,15 @@ aaf
 aaf
 aag
 aaf
-aaf
-aaf
-aaf
+tGv
+tGv
+tGv
 aaf
 aaf
 abg
-abg
-abg
-abg
+iII
+iII
+iII
 abg
 abg
 ohY
@@ -40282,17 +41012,17 @@ alH
 anf
 anA
 alS
-ajz
+amw
 ajz
 ajz
 ajz
 ajz
 ajz
 alb
-arp
-arY
-arW
-asv
+arl
+auT
+arl
+ceg
 arY
 atX
 atl
@@ -40359,7 +41089,7 @@ bdc
 bdc
 aiR
 biB
-bdb
+scG
 bjZ
 bjZ
 bdb
@@ -40409,15 +41139,15 @@ aaj
 aaf
 aag
 aaf
-aaf
-aaf
-aaf
+tGv
+tGv
+tGv
 aaf
 aaf
 abg
-abg
-abg
-abg
+iII
+iII
+iII
 abg
 abg
 abg
@@ -40454,24 +41184,24 @@ ahf
 ahf
 ahh
 akK
-akK
+fwS
 akK
 akK
 amK
 anh
 ajh
 aoi
-aoO
+apo
 aoO
 aoO
 aoO
 aoO
 aoO
 aqf
-arq
-arZ
-asw
-asX
+arl
+arl
+ukt
+trg
 arW
 atX
 atl
@@ -40528,7 +41258,7 @@ aNz
 aZA
 baj
 bba
-aNz
+nGf
 bcc
 bcc
 bcc
@@ -40640,7 +41370,7 @@ amK
 anh
 ajh
 aoi
-aoO
+apo
 aoO
 aoO
 aoO
@@ -40648,9 +41378,9 @@ apm
 aoO
 aqM
 arm
+gJp
+arl
 arp
-arW
-asu
 arW
 atX
 atl
@@ -40667,7 +41397,7 @@ arW
 arW
 azK
 aAk
-aAk
+jXK
 aAm
 aAk
 aCb
@@ -40819,7 +41549,7 @@ amK
 anh
 ajh
 aoi
-aoO
+apo
 aoO
 aoO
 aoO
@@ -40827,9 +41557,9 @@ aoO
 aoO
 aoO
 arn
+arl
+auT
 arp
-arY
-arW
 arW
 atl
 atl
@@ -40876,7 +41606,7 @@ aKA
 aEk
 aDL
 aUx
-aUx
+tTL
 aUx
 aUx
 aDL
@@ -40944,9 +41674,9 @@ aaj
 abI
 abI
 abI
-aag
-aaf
-aaf
+sWe
+abI
+aaj
 aaf
 aaf
 aaf
@@ -40969,7 +41699,7 @@ abg
 ohY
 acI
 abi
-abi
+abo
 abi
 acI
 acI
@@ -40998,7 +41728,7 @@ amK
 anh
 ajh
 aoi
-aoO
+apo
 aoO
 aoO
 aoO
@@ -41006,9 +41736,9 @@ apm
 aoO
 aqN
 ark
+arl
+arl
 arp
-arW
-asu
 asu
 arW
 auw
@@ -41020,8 +41750,8 @@ atl
 atl
 atl
 arW
-asW
-atY
+hfG
+auS
 auS
 azL
 aAk
@@ -41045,7 +41775,7 @@ aHZ
 aEj
 aEk
 aEk
-aFc
+cdx
 aOM
 aPv
 aHz
@@ -41064,7 +41794,7 @@ aNz
 aNz
 aXu
 aRd
-aNz
+nGf
 aNz
 aNz
 aNz
@@ -41123,9 +41853,9 @@ abI
 abI
 sez
 abI
-aag
-aaf
-aaf
+sWe
+abI
+abI
 aaf
 aaf
 aaf
@@ -41173,21 +41903,21 @@ akK
 akK
 akK
 akK
-amK
+cpl
 anh
 ajh
 aoi
-aoO
+apo
 aoO
 aoO
 aoO
 aoO
 aoO
 aqf
-aro
-arV
-asu
-arY
+arl
+arl
+arl
+avl
 asu
 asw
 asX
@@ -41198,9 +41928,9 @@ atl
 atl
 atl
 arW
-arW
-arW
 atQ
+arl
+arl
 kCe
 azJ
 aAk
@@ -41211,7 +41941,7 @@ aCb
 aDf
 aAk
 aCG
-aCG
+dpa
 aCG
 aCG
 aCG
@@ -41228,7 +41958,7 @@ aNI
 aON
 aON
 aQv
-ihA
+flP
 ihA
 ayJ
 ayK
@@ -41303,8 +42033,8 @@ abI
 abI
 aaf
 aag
-aaf
-aaf
+abI
+abI
 aaf
 aaf
 aaf
@@ -41356,17 +42086,17 @@ amK
 anh
 ajh
 aoi
-aoO
+apo
 apm
 aoO
 aoO
 aoO
 aoO
 aqf
-arq
-arZ
-arW
-arW
+arl
+arl
+arl
+arp
 asu
 arW
 atX
@@ -41377,17 +42107,17 @@ atl
 atl
 atl
 arW
-arW
-arY
-aut
-avC
+atQ
+auT
+arl
+auT
 azM
 aAk
 aAk
 aAk
 aCa
 aAk
-aAk
+jXK
 aAk
 aCG
 aCG
@@ -41482,8 +42212,8 @@ abI
 aaf
 aaf
 aag
-aaf
-aaf
+abI
+abI
 aaf
 aaf
 aaf
@@ -41508,7 +42238,7 @@ acI
 abi
 abi
 abi
-abi
+abo
 abi
 abi
 abi
@@ -41535,7 +42265,7 @@ amK
 anh
 ajh
 aoj
-aoO
+apo
 aoO
 aoO
 aoO
@@ -41543,9 +42273,9 @@ aoO
 aoO
 aqP
 ars
+gJp
+arl
 arp
-arW
-arW
 asu
 arW
 asW
@@ -41556,13 +42286,13 @@ atl
 atl
 atl
 atl
-arW
-arW
-arW
-arW
-azK
+atQ
+arl
+arl
+arl
+azM
 aAm
-aAk
+jXK
 aAk
 aCH
 aCG
@@ -41575,7 +42305,7 @@ aCG
 aCG
 aGR
 aCG
-aCG
+dpa
 aCG
 aCG
 aKy
@@ -41661,8 +42391,8 @@ aag
 aag
 aag
 rLa
-aaf
-aaf
+abI
+aaj
 aaf
 aaf
 abI
@@ -41714,7 +42444,7 @@ aeV
 anh
 ajh
 aoj
-aoO
+apo
 aoO
 aoO
 aoO
@@ -41722,9 +42452,9 @@ aoO
 aoO
 aoO
 aqf
+arl
+arl
 arp
-arW
-arW
 asu
 arW
 arW
@@ -41735,14 +42465,14 @@ atl
 atl
 atl
 atl
-atX
-arW
-arY
-arW
-azK
-aAn
-aAn
-aAn
+aCK
+arl
+cfh
+arl
+azM
+aAk
+aAk
+aAk
 aCd
 aCG
 aCG
@@ -41758,7 +42488,7 @@ aCG
 aCG
 aCG
 aKy
-aEk
+jeV
 aFc
 aML
 aHz
@@ -41886,14 +42616,14 @@ ahf
 ahf
 ahh
 akK
-akK
+fwS
 akK
 akK
 amK
 anh
 ajt
 aoj
-aoO
+apo
 aoO
 aoO
 aoO
@@ -41901,9 +42631,9 @@ aoO
 aoO
 aoO
 aqf
-arq
-arZ
-arW
+arl
+arl
+arp
 arW
 arW
 arW
@@ -41914,18 +42644,18 @@ atl
 atl
 atl
 arW
-atY
-auS
-arZ
-arW
+atQ
+arl
+arl
+arl
 azJ
-aAo
-aAo
-aAo
+aNN
+aNN
+aNN
 azJ
 azJ
 aDh
-aCG
+dpa
 aCG
 aCG
 aCG
@@ -42014,9 +42744,9 @@ abI
 abI
 aaf
 aaf
-aaf
-aaf
-aaf
+tGv
+tGv
+tGv
 aaf
 abI
 abI
@@ -42029,8 +42759,8 @@ abi
 abi
 abi
 abg
-abg
-abg
+iII
+iII
 abg
 abg
 abi
@@ -42052,7 +42782,7 @@ afr
 agH
 abi
 abi
-abi
+abo
 abi
 afg
 abi
@@ -42076,13 +42806,13 @@ aly
 aly
 alK
 aly
-aoO
+apo
 alK
 aly
 amn
 aoJ
-arq
-arZ
+arl
+arp
 arW
 arW
 arW
@@ -42092,12 +42822,12 @@ arW
 atl
 arW
 arW
-atY
-aur
+arW
+atQ
 auT
+arl
+arl
 arp
-arW
-arW
 arW
 arW
 arW
@@ -42107,7 +42837,7 @@ aDi
 aCG
 aCG
 aCG
-aCG
+dpa
 aCG
 aDK
 aCG
@@ -42124,7 +42854,7 @@ aON
 aON
 aQw
 aON
-aON
+fBc
 aKA
 aTm
 dva
@@ -42193,9 +42923,9 @@ abI
 aaf
 aaf
 aaf
-aaf
-aaf
-aaf
+tGv
+tGv
+tGv
 aaf
 abI
 abI
@@ -42208,8 +42938,8 @@ abi
 abi
 abi
 abg
-abg
-abg
+iII
+iII
 abg
 abg
 abi
@@ -42220,7 +42950,7 @@ abi
 dbI
 dbI
 dbI
-afr
+dNC
 abi
 afr
 afQ
@@ -42253,30 +42983,30 @@ xDO
 aol
 rDw
 aoS
-aoS
-aoS
-app
+hCZ
+hCZ
+hCZ
 aoS
 aoS
 aoS
 aoJ
 wdm
 arq
-atv
-arW
-arW
-asu
-asu
-arW
-atX
-arW
-arW
-atQ
+atn
+auS
+auS
+auS
+auS
+auS
+aun
+auS
+auS
+auS
 sUi
-aro
-arV
-atX
-arW
+arl
+arl
+awf
+arp
 aAp
 arW
 arY
@@ -42372,9 +43102,9 @@ abI
 aaf
 aaf
 aaf
-aaf
-aaf
-aaf
+tGv
+tGv
+tGv
 aaf
 aaf
 abI
@@ -42441,21 +43171,21 @@ arw
 aoJ
 apA
 ato
-arp
-atY
-atn
-auS
-arZ
-arW
-arW
-arW
-arW
-aut
-asU
-arV
-arY
-atI
-atX
+arl
+arl
+auT
+arl
+arl
+arl
+arl
+arl
+arl
+arl
+arl
+arl
+auT
+eci
+auu
 arW
 axp
 arW
@@ -42477,7 +43207,7 @@ aJH
 aEj
 aEk
 aEk
-aFc
+cdx
 aOS
 aHB
 kGz
@@ -42582,11 +43312,11 @@ abi
 afr
 afr
 abi
+dNC
 afr
+cpb
 afr
-abi
-afr
-afr
+dNC
 afV
 afr
 afg
@@ -42604,36 +43334,36 @@ ahf
 akL
 akL
 akK
-akK
+fwS
 amK
 anj
 anR
+wYU
 aom
-aom
+app
+app
+oNd
 app
 app
 app
-app
-app
-app
-app
+oNd
 aoJ
 asP
 apJ
-arp
-atQ
+gJp
 arl
 arl
-arp
-arW
-arW
-asw
-asX
-arW
-arW
-arW
-atI
-atI
+gJp
+arl
+arl
+arl
+snU
+oXT
+arl
+arl
+gJp
+eci
+eci
 atl
 arW
 arW
@@ -42741,10 +43471,10 @@ abI
 abI
 aaf
 aaf
-abg
-abg
-abg
-abg
+iII
+iII
+iII
+iII
 abg
 abg
 abg
@@ -42799,19 +43529,19 @@ arw
 aoJ
 atq
 atr
-arp
-aut
-aus
+arl
+arl
+arl
 auT
-arp
-arW
-arW
-arW
-arW
-arW
-arW
-arY
-arW
+arl
+arl
+arl
+arl
+arl
+arl
+arl
+auT
+arl
 atl
 atl
 atl
@@ -42824,11 +43554,11 @@ arY
 aAo
 aCG
 aCd
-aCG
+dpa
 aCd
 azJ
 aAk
-aAk
+jXK
 aHs
 aJG
 aJH
@@ -42920,10 +43650,10 @@ abI
 aaf
 aaf
 aaf
-abg
-abg
-abg
-abg
+iII
+iII
+iII
+iII
 abg
 abg
 abg
@@ -42951,7 +43681,7 @@ afg
 abi
 abi
 abi
-abi
+abo
 abi
 ahf
 ahf
@@ -42969,27 +43699,27 @@ pDN
 aol
 aol
 aoS
-aoS
-app
-aoO
+hCZ
+hCZ
+hCZ
 aoS
 aoS
 aoS
 aoJ
 juq
 aro
-arV
-arW
-aut
 asU
-avo
-arW
-arW
-atX
-atI
-atX
-arW
-arW
+asU
+asU
+asU
+avC
+asU
+asU
+auL
+nAV
+auL
+asU
+aus
 atl
 atl
 atl
@@ -43075,8 +43805,8 @@ aaf
 abI
 abI
 abI
-aaf
-aaf
+tGv
+tGv
 abI
 abI
 abI
@@ -43099,10 +43829,10 @@ aaf
 aaf
 aaf
 aaf
-abg
-abg
-abg
-abg
+iII
+iII
+iII
+iII
 abg
 abg
 abg
@@ -43141,7 +43871,7 @@ ahf
 akL
 akL
 akL
-ahQ
+aoT
 amK
 anh
 ajJ
@@ -43149,8 +43879,8 @@ akO
 alz
 alI
 anB
-aoO
-aoO
+apo
+apo
 aml
 aly
 amo
@@ -43254,8 +43984,8 @@ aaf
 abI
 abI
 abI
-aaf
-aaf
+tGv
+tGv
 abI
 abI
 abI
@@ -43320,15 +44050,15 @@ ahf
 akL
 akL
 ahS
-aii
+lsc
 amK
 anh
+apo
 aoO
 aoO
 aoO
 aoO
 aoO
-amR
 apm
 aoO
 aqN
@@ -43350,8 +44080,8 @@ atl
 atl
 atl
 atl
-atl
-atl
+fxk
+tJm
 atl
 atl
 atl
@@ -43499,10 +44229,10 @@ ahf
 akL
 aoO
 aoO
-aoO
+apo
 amL
 anl
-aoO
+apo
 aoO
 aoO
 aoO
@@ -43528,7 +44258,7 @@ atX
 atl
 atl
 atl
-atl
+fxk
 atl
 atl
 atl
@@ -43554,7 +44284,7 @@ aJI
 aJI
 azJ
 eHq
-aAk
+jXK
 gHn
 lYR
 aSB
@@ -43617,8 +44347,8 @@ aaf
 aaf
 abI
 aaj
-aaf
-aaf
+tGv
+tGv
 aaf
 aaf
 abI
@@ -43660,15 +44390,15 @@ afr
 afr
 afg
 afr
-afr
+dNC
 afr
 afn
 abi
-abi
-abi
+iMC
+abo
 afg
-abi
-abi
+afg
+afg
 ahf
 ahf
 ahf
@@ -43678,14 +44408,14 @@ ahf
 aoO
 apm
 aoO
-ajB
-aoO
-aoO
-aoO
-aoO
-amR
-aoO
+gOC
+lcH
+xNt
 apo
+aoO
+aoO
+aoO
+aoO
 aoO
 aqN
 aqw
@@ -43796,8 +44526,8 @@ abI
 aaf
 abI
 abI
-aaf
-aaf
+tGv
+tGv
 aaf
 abI
 abI
@@ -43845,9 +44575,9 @@ afn
 abi
 abi
 abi
-atd
-atd
-abl
+aiU
+aiU
+aiU
 atb
 atb
 ahf
@@ -43857,10 +44587,10 @@ ahf
 aoO
 aoO
 aoO
-aoO
-aoO
-aoO
-aoO
+apo
+lcH
+lcH
+apo
 aoO
 aoO
 aoO
@@ -43879,7 +44609,7 @@ atl
 atX
 atQ
 arl
-arl
+gJp
 arq
 arZ
 arW
@@ -43975,8 +44705,8 @@ abI
 abI
 abI
 abI
-aaf
-aaf
+tGv
+tGv
 aaf
 abI
 abI
@@ -43985,11 +44715,11 @@ abI
 aaf
 aaf
 aaf
-aaf
-aaf
-aaf
-aaf
-aaf
+tGv
+tGv
+tGv
+tGv
+tGv
 aaf
 aaf
 abI
@@ -44013,7 +44743,7 @@ ohY
 afr
 afr
 afr
-afr
+dNC
 afr
 afr
 afQ
@@ -44036,10 +44766,10 @@ apm
 aoO
 aoO
 aoO
-aoO
-aoO
-aoO
-aoO
+apo
+lcH
+lcH
+apo
 apm
 aoO
 aoO
@@ -44164,11 +44894,11 @@ aaf
 aaf
 aaf
 aaf
-aaf
-aaf
-aaf
-aaf
-aaf
+tGv
+tGv
+tGv
+tGv
+tGv
 aaf
 aaf
 abI
@@ -44188,8 +44918,8 @@ abi
 abi
 abi
 abi
-ohY
-afr
+hsW
+dNC
 afr
 abg
 afr
@@ -44205,20 +44935,20 @@ abi
 abi
 ahQ
 aoO
-apm
-aoO
-aix
-atb
-atb
-atb
-aoO
-aoO
-aoO
-aoO
-aoO
-aoO
-ajB
-aoO
+xRX
+apo
+uIJ
+apo
+apo
+apo
+apo
+apo
+apo
+apo
+apo
+lcH
+ryU
+apo
 aoO
 aoO
 aoO
@@ -44240,13 +44970,13 @@ aqk
 nor
 aqU
 aqi
-aoY
-azP
-ayh
+auB
+aAS
+aAS
 ayQ
 azr
-azN
-aAq
+aAS
+azr
 aAS
 aAS
 ayi
@@ -44343,11 +45073,11 @@ aaf
 aaf
 aaf
 aaf
-aaf
-aaf
-aaf
-aaf
-aaf
+tGv
+tGv
+tGv
+tGv
+tGv
 aaf
 aaf
 aak
@@ -44366,8 +45096,8 @@ abG
 abg
 abi
 abi
-abg
-ohY
+abi
+hsW
 afr
 afr
 abg
@@ -44384,20 +45114,20 @@ abi
 abi
 ahQ
 aoO
-aoO
-aoO
-aix
-atb
-atb
-aoO
-aoO
-aoO
-aoO
-aoO
-aoO
-apm
-aoO
-aoO
+apo
+lcH
+wfG
+lcH
+lcH
+lcH
+lcH
+lcH
+lcH
+lcH
+xNt
+esC
+lcH
+apo
 aoO
 aoO
 aoO
@@ -44417,18 +45147,18 @@ anr
 anr
 asl
 aue
-aue
-aot
-aoY
-ayh
-ayi
+apT
+apP
+fsZ
+aAT
+aAT
 ayj
 ayj
 azO
-aAr
+ayj
 aAT
 aBC
-aAT
+eEp
 aAT
 aDm
 puV
@@ -44447,7 +45177,7 @@ puV
 puV
 puV
 iVB
-iVB
+jnF
 rOB
 blN
 fyU
@@ -44563,20 +45293,20 @@ abi
 abi
 ahR
 aqw
-aij
-aix
-aix
-aix
-aoO
-aoO
-aoO
-aoO
-aoO
-aoO
-aoO
-aoO
-aoO
-aoO
+cZY
+wfG
+gMe
+wfG
+lcH
+lcH
+xNt
+lcH
+lcH
+lcH
+lcH
+lcH
+lcH
+apo
 aoO
 aoO
 aqN
@@ -44596,15 +45326,15 @@ anr
 anr
 anr
 anr
-aoY
+aqk
 aqX
-aoY
-aJM
+apP
+aBC
 ayj
-ayS
-azs
-ayT
-aAs
+ayj
+tTR
+ayj
+aAT
 aAT
 aAT
 aBC
@@ -44733,29 +45463,29 @@ abi
 abi
 abi
 abi
+abo
 abi
 abi
 abi
 abi
 abi
+abo
 abi
 abi
-abi
-abi
-aik
-aix
-aix
-aoO
-aoO
-aoO
-aiU
-aoO
-apm
-aoO
-aoO
-aoO
-aoO
-aoO
+oYK
+uIJ
+uIJ
+apo
+apo
+apo
+apo
+apo
+xRX
+apo
+apo
+apo
+apo
+apo
 ajB
 aqN
 aqg
@@ -44769,20 +45499,20 @@ aoo
 anN
 apP
 aud
-auc
-aoY
+auB
+auB
 anr
 anr
 anr
-aoY
-aoY
-aoY
-arf
+auB
+anO
+apP
+apP
 arx
 ayk
-ayT
-azt
-azP
+ayk
+azs
+aBD
 aAt
 aAU
 aBD
@@ -44889,8 +45619,8 @@ aag
 aaf
 aaf
 aaf
-abg
-abg
+iII
+iII
 xib
 xib
 xib
@@ -44905,7 +45635,7 @@ xib
 tTs
 abg
 afr
-afr
+dNC
 afr
 abg
 abg
@@ -44945,19 +45675,19 @@ anN
 anW
 anW
 aoR
-anP
+dzq
 apP
 apP
-apV
-aoY
-aqj
-aqz
-aqT
-auc
-aoY
-ask
-auB
-azN
+apP
+apP
+asD
+aqv
+aqV
+apP
+apP
+apP
+apP
+aDP
 aBG
 azQ
 azt
@@ -45068,8 +45798,8 @@ aag
 aaf
 aaf
 aaf
-abg
-abg
+iII
+iII
 xib
 abg
 abg
@@ -45127,14 +45857,14 @@ aoV
 anN
 apP
 apP
-aqi
+aqV
 aqj
-aqq
+aqv
 asD
 apP
-aqi
-aoY
-aqk
+aqV
+fsZ
+apP
 wKy
 aDP
 aBG
@@ -45228,8 +45958,8 @@ abn
 aaj
 abI
 abU
-aaf
-aaf
+tGv
+tGv
 aaj
 abI
 aap
@@ -45247,8 +45977,8 @@ aag
 aaf
 aaf
 aaf
-abg
-abg
+iII
+iII
 xib
 abg
 abg
@@ -45306,16 +46036,16 @@ aoW
 anN
 apP
 apP
-apV
-aql
+apP
+asD
 aqv
-aps
-aue
-aot
+asD
+apP
+apP
 aqV
-asl
-aue
-ayT
+apP
+apP
+vdR
 aAV
 aAV
 aAV
@@ -45407,8 +46137,8 @@ abn
 abI
 abI
 aaf
-aaf
-aaf
+tGv
+tGv
 abI
 abI
 aaj
@@ -45426,8 +46156,8 @@ aag
 aaf
 aaf
 aaf
-abg
-abg
+iII
+iII
 xib
 abg
 abg
@@ -45452,8 +46182,8 @@ abg
 abg
 abg
 abg
-abg
-abg
+iII
+iII
 ahf
 ahf
 ahf
@@ -45485,14 +46215,14 @@ aoX
 anN
 apT
 aqd
-aot
-aqo
+aue
+aQO
 aqx
 aqS
 anr
-aou
-aov
-aou
+aqx
+aQO
+aqx
 anr
 aAV
 aAV
@@ -45605,8 +46335,8 @@ aag
 aaf
 aaf
 aaf
-abg
-abg
+iII
+iII
 xib
 abg
 abi
@@ -45631,8 +46361,8 @@ abg
 abg
 abg
 abg
-abg
-abg
+iII
+iII
 ahf
 ahf
 ahf
@@ -45641,7 +46371,7 @@ aiw
 atb
 ahQ
 aoO
-aiU
+aoO
 aoO
 aoO
 aoO
@@ -45784,8 +46514,8 @@ aag
 aaf
 aaf
 aaf
-abg
-abg
+iII
+iII
 xib
 abg
 abi
@@ -45803,15 +46533,15 @@ abg
 abg
 abg
 afr
-afr
+dNC
 abg
 abg
 abg
 abg
 abg
 abg
-abg
-abg
+iII
+iII
 ahf
 ahf
 ahf
@@ -45963,8 +46693,8 @@ fgu
 aaf
 aaf
 aaf
-abg
-abg
+iII
+iII
 xib
 abg
 abo
@@ -45989,8 +46719,8 @@ abg
 abg
 abg
 abg
-abg
-abg
+iII
+iII
 ahf
 ahf
 ahf
@@ -46142,8 +46872,8 @@ fgu
 aaf
 aaf
 aaf
-abg
-abg
+iII
+iII
 xib
 abi
 abi
@@ -46168,8 +46898,8 @@ abg
 abg
 abg
 abg
-abg
-abg
+iII
+iII
 ahf
 ahf
 ahf
@@ -46321,8 +47051,8 @@ fgu
 aaf
 aaf
 aaf
-abg
-abg
+iII
+iII
 xib
 abi
 abi
@@ -46347,8 +47077,8 @@ abg
 abg
 abg
 abg
-abg
-abg
+iII
+iII
 ahf
 ahf
 ahf
@@ -46500,8 +47230,8 @@ fgu
 aaf
 aaf
 aaf
-abg
-abg
+iII
+iII
 xib
 abg
 abi
@@ -46526,8 +47256,8 @@ abg
 abg
 abg
 abg
-abg
-abg
+iII
+iII
 ahf
 ahf
 ahf
@@ -46591,7 +47321,7 @@ azN
 azQ
 aAs
 aKF
-ayj
+cXD
 ayj
 aAV
 aAV
@@ -46679,8 +47409,8 @@ fgu
 aaf
 aaf
 aaf
-abg
-abg
+iII
+iII
 xib
 abg
 abg
@@ -46705,8 +47435,8 @@ abg
 abg
 abg
 abg
-abg
-abg
+iII
+iII
 ahf
 ahf
 ahf
@@ -46858,8 +47588,8 @@ fgu
 aaf
 aaf
 aaf
-abg
-abg
+iII
+iII
 xib
 abg
 abg
@@ -46876,7 +47606,7 @@ xib
 ohY
 abg
 afB
-afr
+dNC
 afr
 afB
 abg
@@ -46884,8 +47614,8 @@ abg
 abg
 abg
 abg
-abg
-abg
+iII
+iII
 ahf
 ahf
 ahf
@@ -46944,7 +47674,7 @@ aAV
 aAV
 aCf
 aCe
-aAT
+eEp
 aDP
 azP
 aCf
@@ -47037,8 +47767,8 @@ aag
 aaf
 aaf
 aaf
-abg
-abg
+iII
+iII
 xib
 abg
 abg
@@ -47063,8 +47793,8 @@ abg
 abg
 abg
 abg
-abg
-abg
+iII
+iII
 ahf
 ahf
 ahf
@@ -47216,8 +47946,8 @@ aag
 aaf
 aaf
 aaf
-abg
-abg
+iII
+iII
 xib
 abg
 abg
@@ -47242,8 +47972,8 @@ abg
 abg
 abg
 abg
-abg
-abg
+iII
+iII
 ahf
 ahf
 ahf
@@ -47291,7 +48021,7 @@ azP
 arG
 aAT
 aAT
-aAT
+eEp
 asj
 aDO
 azP
@@ -47395,8 +48125,8 @@ aag
 aaf
 aaf
 aaf
-abg
-abg
+iII
+iII
 xib
 abg
 abg
@@ -47421,8 +48151,8 @@ abg
 abg
 abg
 abg
-abg
-abg
+iII
+iII
 ahf
 ahf
 ahf
@@ -47574,8 +48304,8 @@ aag
 aaf
 aaf
 aaf
-abg
-abg
+iII
+iII
 xib
 abg
 abg
@@ -47600,8 +48330,8 @@ abg
 abg
 abg
 abg
-abg
-abg
+iII
+iII
 ahf
 ahf
 ahf
@@ -47753,8 +48483,8 @@ rLa
 aaf
 aaf
 aaf
-abg
-abg
+iII
+iII
 xib
 abg
 abg
@@ -47779,8 +48509,8 @@ abg
 abg
 abg
 abg
-abg
-abg
+iII
+iII
 ahf
 ahf
 ahf
@@ -47932,8 +48662,8 @@ aaf
 aaf
 aaf
 aaf
-abg
-abg
+iII
+iII
 xib
 abg
 abg
@@ -47958,8 +48688,8 @@ abg
 abg
 abg
 abg
-abg
-abg
+iII
+iII
 ahf
 ahf
 ahf


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A lot of changes to make LV much less of a grass and river hell hole that forces xenos to constantly fight in caves only.

1) LV starts pre-weeded everywhere except domes (as they are randomized and I really don't want to touch that as a new mapper).
2) Indestructible rocks on certain parts of the caves to prevent PC cheese, while still retaining the PC as a good tool.
3) Opened up certain flanks while closing other flanks; makes far east and far west caves less of a death trap.
4) Adds and repairs several bridges to make river combat less shit.
5) Adds more dirt and removes a lot of grass so that xenos can weed more on colony / near rivers so that fighting near them isn't suicide.
6) Adds more "lanes" in Colony; more flank points so as to slow marines down.
7) Fixes the easy west cave miners; 3 of them have been converted to phoron miners instead.

If you find any mistakes or anything please tell me; this is my first major mapping edit (and first time mapping seriously in general) so feedback is appreciated.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

LV is a really bad map for xenos; if you fight in Colony (which is advised to slow down marine advance), you have to deal with grass (unweedable so no speed boost or heals), river (the bridges suck ass and some are even broken, huge slowdown if your caught in the middle of a retreat and hence death). This doesn't even take account the weather (acid rain, while not as shitty to xenos, is still enough to force them to take cover).

This PR's aim is to fix or alleviate some of these issues.

It also rebalances some aspects of LV that create stalemates / drawn out matches, such as the easy west cave plat miners due to proximity to caves, and easily PC-able caves which cause wide open fronts that xenos cannot push out from but at some point in the game marines refuse to push into.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds structural support to LV caves; there are now indestructible rock walls in certain parts of the caves to prevent digging around the entire mountain, or making huge openings. Certain lanes, however, remain open for PC usage.
add: Adds several new flanks in all of the caves, while closing off others; far west and east caves are now less of a deathtrap for xenos AND marines alike.
add: Adds in a new, smaller bridge near west caves, and repairs all catwalks + bridges currently on LV.
add: Opens up a lot of grass areas, turning them to dirt so that Colony is not as bad to fight in. This includes around bridges to make them easier to fight around.
add: Adds in a few more flanks with dirt in Colony to give more choices for xenos, alongside more danger for marines.
balance: Makes west LZ-2 into South LZ-2; it is now placed near where Engineering used to be.
balance: Engineering is now moved near Caves, exactly where Tfort was. Tfort is no more.
balance: Extended the caves near engineering and made another flank into caves which can be used by xenos to flank but can also be secured by marines to push into caves.
balance: Adds a small amount of turrets around some of the new flanks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
