### PR TITLE
Silo pinpointers have max range

### DIFF
--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -86,9 +86,28 @@
 		to_chat(user, "Extreme danger.  Arming signal detected.   Time remaining: [bomb.timeleft]")
 
 /obj/item/pinpointer/pool
-	name = "pool pinpointer"
-	desc = "A pinpointer able to detect the psychic energy emmaning from spawning pools"
+	name = "silo pinpointer"
+	desc = "A pinpointer able to detect the psychic energy emmaning from silos"
 
 /obj/item/pinpointer/pool/Initialize()
 	. = ..()
 	tracked_list = GLOB.xeno_resin_silos
+
+/obj/item/pinpointer/pool/process()
+	if(!target)
+		icon_state = "pinonnull"
+		active = FALSE
+		return
+
+	setDir(get_dir(src, target))
+	switch(get_dist(src, target))
+		if(0)
+			icon_state = "pinondirect"
+		if(1 to 8)
+			icon_state = "pinonclose"
+		if(9 to 16)
+			icon_state = "pinonmedium"
+		if(16 to 35)
+			icon_state = "pinonfar"
+		if(36 to INFINITY)
+			icon_state = "pinonnull"

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -56,6 +56,7 @@
 		/obj/item/attachable/flashlight = 10,
 		/obj/item/explosive/grenade/mirage = 5,
 		/obj/item/weapon/powerfist = 3,
+		/obj/item/pinpointer/pool = 1,
 	)
 	prices = list()
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Silo pinpointer cannot track the location when the silo is farther than 35 tiles.
Standard marine can get a silo pinpointer in his vendor

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This will allow xenos to have way more variety in their silo placement. This forces marines to do some scouting, will lower the usefullness of marines ungaball and maybe (maybe) promotes smaller squad play. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Silo pinpointer cannot track silos that are at a distance greater than 35 tiles
balance: Each standard marine get a silo pinpointer in its vendor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
