### PR TITLE
Silo nerf 

### DIFF
--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -33,7 +33,7 @@
 	bound_height = 96
 	max_integrity = 1000
 	///How many larva points one silo produce in one minute
-	var/larva_spawn_rate = 0.5
+	var/larva_spawn_rate = 0.4
 	var/turf/center_turf
 	var/datum/hive_status/associated_hive
 	var/silo_area
@@ -170,7 +170,7 @@
 	name = "small resin silo"
 	icon_state = "weed_silo"
 	max_integrity = 500
-	larva_spawn_rate = 0.25
+	larva_spawn_rate = 0.2
 
 /obj/structure/resin/xeno_turret
 	icon = 'icons/Xeno/acidturret.dmi'


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Silo basic larva rate from 0.5 to 0.4.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

This is to compensate the silo pinpointer nerf, and to give marines less pressure to find the silos. Also, xenos have no trouble holding up against marine respawn right now

## Changelog
:cl:
balance: Silo base output from 0.5 to 0.4 (so a regular silo is producing one larva every 20 minutes)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
