### PR TITLE
Adds One SG box to Cargo weapons vendor. SG mags are more expensive in req.

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -205,6 +205,7 @@
 		/obj/item/storage/box/m94 = 30,
 		/obj/item/storage/box/m94/cas = 10,
 		/obj/item/storage/box/recoilless_system = 1,
+		/obj/item/storage/box/t26_system = 1,
 		/obj/item/weapon/shield/riot/marine = 3,
 	)
 

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -567,7 +567,7 @@ AMMO
 /datum/supply_packs/ammo/smartmachinegun
 	name = "T-29 smartmachinegun ammo"
 	contains = list(/obj/item/ammo_magazine/standard_smartmachinegun)
-	cost = 5
+	cost = 10
 
 /datum/supply_packs/ammo/sentry
 	name = "UA 571-C sentry ammunition"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Adds ONE SG to the cargo weapon vendor and increases the prices of SG mags in req, making them harder to maintain without regular point income.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Allows marines to get one SG, (max 2-3 depending on the ship) giving them slightly better ability to push out at the start but also makes it harder to maintain if no points are gained.

## Changelog
:cl:
add: Added SG crate to Automated Arnaments vendor.
balance: Increased the price of SG mags in req.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
