### PR TITLE
Queen Screech Update PR. 

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -414,8 +414,8 @@ Contains most of the procs that are called when a mob is attacked by something
 	var/reduce_prot_aura = protection_aura * 0.1
 
 	var/reduction = max(min(1, reduce_within_sight - reduce_prot_aura), 0.1) // Capped at 90% reduction
-	var/stamina_damage = LERP(60, 130, dist_pct) * reduction //Max 130 beside Queen, 60 at the edge
-	var/stun_duration = (LERP(0.4, 1, dist_pct) * reduction) * 20 //Max 1.5 beside Queen, 0.4 at the edge.
+	var/stamina_damage = LERP(140, 70, dist_pct) * reduction //Max 140 under Queen, 130 beside Queen, 70 at the edge. Reduction of 10 per tile distance from Queen.
+	var/stun_duration = (LERP(1, 0.4, dist_pct) * reduction) * 20 //Max 1.5 beside Queen, 0.4 at the edge.
 
 	to_chat(src, "<span class='danger'>An ear-splitting guttural roar tears through your mind and makes your world convulse!</span>")
 	Stun(stun_duration)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Essentially, this fixes a bug I found recently that...probably has been here a long time? Probably. Maybe. Basically upon testing screech and examining the vars of the affected human at various ranges, I found that, well, screeching right next to the target was doing 70 stamina damage while screeching at screen edge from the target was doing 130, and the admittedly short stun time was also doing...wrong. So I took the numbers and swapped them and tested it and hey, wouldn't you know, it worked. Last seen numbers said in PRs have stated intended screech values as 130 beside Queen, and 70 at screen edge, so I've kept those numbers. The 140 is for purposes of having that be the actual numbers, since with the max as 130, you would be only getting 120 stamina damage while adjacent to the Queen. Adjusting the lower number to 70 is to keep the scaling(reduction of 10 per tile distance) the same. This will also mean that being on the same tile as the Queen will do 140 stamina damage, but, hey. Marines will just have to deal with taking a little more stamina damage if a Queen shouts while standing on their chest. 

## Why It's Good For The Game

Fixes a bug. It just works. 

## Changelog
:cl:
balance: Same tile screech does a bit more stamina damage. 
fix: Screech stamina damage no longer reversed. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
