### PR TITLE
Revert "Engies build faster"

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -163,7 +163,7 @@
 		if(R.skill_req && usr.skills.getRating("construction") < R.skill_req)
 			building_time += R.time * ( R.skill_req - usr.skills.getRating("construction") ) * 0.5 // +50% time each skill point lacking.
 		if(R.skill_req && usr.skills.getRating("construction") > R.skill_req)
-			building_time -= clamp(R.time * ( usr.skills.getRating("construction") - R.skill_req ) * 0.40, 0 , 0.85 * building_time) // -40% time each extra skill point
+			building_time -= R.time * ( usr.skills.getRating("construction") - R.skill_req ) * 0.1 // -10% time each extra skill point
 		if(building_time)
 			if(building_time > R.time)
 				usr.visible_message("<span class='notice'>[usr] fumbles around figuring out how to build \a [R.title].</span>",


### PR DESCRIPTION
Reverts tgstation/TerraGov-Marine-Corps#6318

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Reverts the cades build time buff.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Being spammed to build on FOB leading to longer sieges and delays.
With the inventory buff, sandbags and barbed wire can still fill this role fine.
## Changelog
:cl:
balance: Reverts the shortened build time for cades.
/:cl:
