### PR TITLE
Larva output of super pool was wrong

### DIFF
--- a/code/controllers/subsystem/silo.dm
+++ b/code/controllers/subsystem/silo.dm
@@ -19,7 +19,8 @@ SUBSYSTEM_DEF(silo)
 	current_larva_spawn_rate = 0
 	for(var/obj/structure/resin/silo/silo AS in GLOB.xeno_resin_silos)
 		current_larva_spawn_rate += silo.larva_spawn_rate
-	xeno_job.add_job_points(current_larva_spawn_rate * larva_rate_boost, SILO_ORIGIN)
+	current_larva_spawn_rate *= larva_rate_boost
+	xeno_job.add_job_points(current_larva_spawn_rate, SILO_ORIGIN)
 	corrupted_gen_output = TGS_CLIENT_COUNT * BASE_PSYCH_POINT_OUTPUT
 
 ///Activate the subsystem when shutters open and remove the free spawning when marines are joining


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Xenos had the right amount of larva per minute shipiside, but the number in hive status were wrong

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Larva output number in hivestatus is now correct shipside
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
