### PR TITLE
Removes Engineer skill requirement for Mortar

### DIFF
--- a/code/game/objects/structures/mortar.dm
+++ b/code/game/objects/structures/mortar.dm
@@ -37,12 +37,6 @@
 		to_chat(user, "<span class='warning'>[src]'s barrel is still steaming hot. Wait a few seconds and stop firing it.</span>")
 		return
 
-	if(user.skills.getRating("engineer") < SKILL_ENGINEER_ENGI)
-		user.visible_message("<span class='notice'>[user] fumbles around figuring out how to use [src].</span>",
-		"<span class='notice'>You fumble around figuring out how to use [src].</span>")
-		var/fumbling_time = 4 SECONDS * ( SKILL_ENGINEER_ENGI - user.skills.getRating("engineer") )
-		if(!do_after(user, fumbling_time, TRUE, src, BUSY_ICON_UNSKILLED))
-			return
 	ui_interact(user)
 
 
@@ -145,13 +139,6 @@
 	if(istype(I, /obj/item/mortal_shell))
 		var/obj/item/mortal_shell/mortar_shell = I
 
-		if(user.skills.getRating("engineer") < SKILL_ENGINEER_ENGI)
-			user.visible_message("<span class='notice'>[user] fumbles around figuring out how to fire [src].</span>",
-			"<span class='notice'>You fumble around figuring out how to fire [src].</span>")
-			var/fumbling_time = 2 SECONDS * ( SKILL_ENGINEER_ENGI - user.skills.getRating("engineer") )
-			if(!do_after(user, fumbling_time, TRUE, src, BUSY_ICON_UNSKILLED))
-				return
-
 		if(issynth(user) && !CONFIG_GET(flag/allow_synthetic_gun_use))
 			to_chat(user, "<span class='warning'>Your programming restricts operating heavy weaponry.</span>")
 			return
@@ -218,12 +205,6 @@
 	firing = FALSE
 
 /obj/structure/mortar/wrench_act(mob/living/user, obj/item/I)
-	if(user.skills.getRating("engineer") < SKILL_ENGINEER_ENGI)
-		user.visible_message("<span class='notice'>[user] fumbles around figuring out how to undeploy [src].</span>",
-		"<span class='notice'>You fumble around figuring out how to undeploy [src].</span>")
-		var/fumbling_time = 5 SECONDS * ( SKILL_ENGINEER_ENGI - user.skills.getRating("engineer"))
-		if(!do_after(user, fumbling_time, TRUE, src, BUSY_ICON_UNSKILLED))
-			return
 
 	if(fixed)
 		to_chat(user, "<span class='warning'>[src]'s supports are bolted and welded into the floor. It looks like it's going to be staying there.</span>")
@@ -265,12 +246,6 @@
 
 
 /obj/item/mortar_kit/attack_self(mob/user)
-	if(user.skills.getRating("engineer") < SKILL_ENGINEER_ENGI)
-		user.visible_message("<span class='notice'>[user] fumbles around figuring out how to deploy [src].</span>",
-		"<span class='notice'>You fumble around figuring out how to deploy [src].</span>")
-		var/fumbling_time = 5 SECONDS * ( SKILL_ENGINEER_ENGI - user.skills.getRating("engineer") )
-		if(!do_after(user, fumbling_time, TRUE, src, BUSY_ICON_UNSKILLED))
-			return
 	if(!is_ground_level(user.z))
 		to_chat(user, "<span class='warning'>You cannot deploy [src] here.</span>")
 		return


### PR DESCRIPTION
## About The Pull Request

Removes the delays for operating the Mortar without the engineering skill. Any PFC can operate it as fast as anyone else.

## Why It's Good For The Game

The Mortar is hardly used as it requires a valuable engineer to camp at the FOB all day. I personally like using the Mortar however I don't because Engineers are too valuable to sit at the Mortar all day. This allows an regular old squad marine to use the mortar as effectively as anyone else.

## Changelog
:cl:
balance: Removes Engineer skill requirements for Mortar.
/:cl:

