### PR TITLE
Nerfs arm aiming.

### DIFF
--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -1140,7 +1140,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "l_arm"
 	display_name = "left arm"
 	icon_name = "l_arm"
-	max_damage = 100
+	max_damage = 125
 	min_broken_damage = 50
 	body_part = ARM_LEFT
 	cover_index = 7
@@ -1163,7 +1163,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	name = "r_arm"
 	display_name = "right arm"
 	icon_name = "r_arm"
-	max_damage = 100
+	max_damage = 125
 	min_broken_damage = 50
 	body_part = ARM_RIGHT
 	cover_index = 7


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Recently arm has been very much aimed by most people and this nerfs it, my consideration for buffing the arm its that it has same armor as chest with alot of debuffs once broken/removed, unlike leg, so i've buffed its health to 125, needing more 25 damage for delimbing, also robolimbs suck they need buffs.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes arm aiming not alot way superior than the other limbs, its now harder to delimb.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: arm is now harder to delimb, max damage raised to 125
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
