### PR TITLE
Simplifies Vali

### DIFF
--- a/code/datums/components/chem_booster.dm
+++ b/code/datums/components/chem_booster.dm
@@ -228,7 +228,8 @@
 	if(update_boost_amount)
 		boost_amount += amount
 		to_chat(wearer, "<span class='notice'>Power set to [boost_amount+1].</span>")
-	resource_drain_amount = (boost_amount^2)*4
+	resource_drain_amount = boost_amount*(4 + boost_amount)
+	message_admins("resource drain amount > [resource_drain_amount]")
 
 ///Used to scan the person
 /datum/component/chem_booster/proc/scan_user(datum/source)
@@ -298,8 +299,6 @@
 /datum/component/chem_booster/proc/update_resource(amount)
 	var/amount_added = min(resource_storage_max - resource_storage_current, amount)
 	resource_storage_current = max(resource_storage_current + amount_added, 0)
-	message_admins("current resource > [resource_storage_current]")
-	message_admins("update amount > [amount]")
 	wearer.overlays -= resource_overlay
 	resource_overlay.alpha = resource_storage_current/resource_storage_max*255
 	wearer.overlays += resource_overlay

--- a/code/datums/components/chem_booster.dm
+++ b/code/datums/components/chem_booster.dm
@@ -133,7 +133,6 @@
 	wearer.heal_limb_damage(6*boost_amount, 6*boost_amount)
 	if(connected_weapon && world.time - processing_start < 20 SECONDS)
 		wearer.adjustStaminaLoss(-7*((20 - (world.time - processing_start)/10)/20)) //stamina gain scales inversely with passed time, up to 20 seconds
-		message_admins("stamina regenned > [-7*((20 - (world.time - processing_start)/10)/20)]")
 	if(world.time - processing_start > 12 SECONDS && world.time - processing_start < 15 SECONDS)
 		wearer.overlay_fullscreen("degeneration", /obj/screen/fullscreen/infection, 1)
 		to_chat(wearer, "<span class='highdanger'>WARNING: You have [(200 - (world.time - processing_start))/10] seconds before necrotic tissue forms on your limbs.</span>")
@@ -230,7 +229,6 @@
 		boost_amount += amount
 		to_chat(wearer, "<span class='notice'>Power set to [boost_amount+1].</span>")
 	resource_drain_amount = boost_amount*(3 + boost_amount)
-	message_admins("resource drain amount > [resource_drain_amount]")
 
 ///Used to scan the person
 /datum/component/chem_booster/proc/scan_user(datum/source)

--- a/code/datums/components/chem_booster.dm
+++ b/code/datums/components/chem_booster.dm
@@ -130,9 +130,10 @@
 		on_off()
 	update_resource(-resource_drain_amount)
 
-	wearer.heal_limb_damage(4*boost_amount, 4*boost_amount)
-	if(connected_weapon)
-		wearer.adjustStaminaLoss(-7*((20 - (world.time - processing_start)/10)/20)) //stamina gain scales inversely with passed time, becoming negative after 20 seconds
+	wearer.heal_limb_damage(6*boost_amount, 6*boost_amount)
+	if(connected_weapon && world.time - processing_start < 20 SECONDS)
+		wearer.adjustStaminaLoss(-7*((20 - (world.time - processing_start)/10)/20)) //stamina gain scales inversely with passed time, up to 20 seconds
+		message_admins("stamina regenned > [-7*((20 - (world.time - processing_start)/10)/20)]")
 	if(world.time - processing_start > 12 SECONDS && world.time - processing_start < 15 SECONDS)
 		wearer.overlay_fullscreen("degeneration", /obj/screen/fullscreen/infection, 1)
 		to_chat(wearer, "<span class='highdanger'>WARNING: You have [(200 - (world.time - processing_start))/10] seconds before necrotic tissue forms on your limbs.</span>")
@@ -184,10 +185,10 @@
 		if(necrotized_counter >= 1)
 			for(var/X in shuffle(wearer.limbs))
 				var/datum/limb/L = X
-				if(L.germ_level < 600)
+				if(L.germ_level > 700)
 					continue
 				to_chat(wearer, "<span class='warning'>You can feel the life force in your [L.display_name] draining away...</span>")
-				L.germ_level += INFECTION_LEVEL_THREE + 50
+				L.germ_level += max(INFECTION_LEVEL_THREE + 50 - L.germ_level, 200)
 				necrotized_counter -= 1
 				if(necrotized_counter < 1)
 					break

--- a/code/datums/components/chem_booster.dm
+++ b/code/datums/components/chem_booster.dm
@@ -228,7 +228,7 @@
 	if(update_boost_amount)
 		boost_amount += amount
 		to_chat(wearer, "<span class='notice'>Power set to [boost_amount+1].</span>")
-	resource_drain_amount = boost_amount*(4 + boost_amount)
+	resource_drain_amount = boost_amount*(3 + boost_amount)
 	message_admins("resource drain amount > [resource_drain_amount]")
 
 ///Used to scan the person


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes reagent modification from Vali. Replaces it with brute/burn heal and stamina regen.
- Restores 6 or 12 brute and burn based on effect
- Stamina regen happens if you have a connected weapon and scales inversely with active time, from 7 and becoming 0 past 20 seconds.

Changes the reagent storage function to store and inject only 30u so that people don't accidentally overdose.
Connection a weapon takes 1 second instead of 2.

Now the suit checks for germ level rather than necrotized limb flag when deciding on what limb to increase the germ amount pf past 20s. This is due to the necrotized flag not doing damage or other effects associated with high germ levels and thus allowing a way to circumvent the system in specific cases. It shouldn't change almost anything in practice.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes Vali more foolproof so that I could add more mechanics without it feeling too complicated.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: vali now heals 6/12 brute/burn instead of boosting reagents and provides stamina regen if you have a connected weapon. Reduced reagent storage from 60u to 30u. Weapon takes 1s to connect instead of 2s. 
fix: vali checks for germ level instead of necrotized limb flag since the negatives associated with necrotized limbs are based on germ levels
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
