### PR TITLE
GPGM nerf

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -674,7 +674,7 @@
 	gun_skill_category = GUN_SKILL_HEAVY_WEAPONS
 	attachable_offset = list("muzzle_x" = 41, "muzzle_y" = 21,"rail_x" = 8, "rail_y" = 23, "under_x" = 25, "under_y" = 14, "stock_x" = 11, "stock_y" = 14)
 	actions_types = list(/datum/action/item_action/aim_mode)
-	aim_fire_delay = 0.05 SECONDS
+	aim_fire_delay = 0.2 SECONDS
 	aim_speed_modifier = 6
 
 	fire_delay = 0.2 SECONDS

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -674,11 +674,11 @@
 	gun_skill_category = GUN_SKILL_HEAVY_WEAPONS
 	attachable_offset = list("muzzle_x" = 41, "muzzle_y" = 21,"rail_x" = 8, "rail_y" = 23, "under_x" = 25, "under_y" = 14, "stock_x" = 11, "stock_y" = 14)
 	actions_types = list(/datum/action/item_action/aim_mode)
-	aim_fire_delay = 0.2 SECONDS
+	aim_fire_delay = 0.05 SECONDS
 	aim_speed_modifier = 6
 
-	fire_delay = 0.15 SECONDS
-	damage_falloff_mult = 0.5
+	fire_delay = 0.2 SECONDS
+	damage_falloff_mult = 0.25
 	burst_amount = 1
 	accuracy_mult_unwielded = 0.4
 	accuracy_mult = 1


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

ROF from 0.15 to 0.2 seconds like it was before
damage_falloff_mult to 0.25 from 0.5 like it was before

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

GPMG is a cancerous weapon to deal with. The last buff made it almost as good for pushing than minigun, and that for free and roundstart. 

This gun is not thaat broke, but it encourages a way of playing that is atrocious to play against as a xenos, and frankly midly interesting to play as a marine (Requires zero skill?). 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: GPGM ROF back to 0.2, damage_falloff_mult back to 0.25
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
