### PR TITLE
Xeno abilities easier to land on targets

### DIFF
--- a/code/__DEFINES/actions.dm
+++ b/code/__DEFINES/actions.dm
@@ -17,5 +17,7 @@
 #define XABB_MOB_TARGET			(1 << 1) // ability targets mobs
 #define XABB_OBJ_TARGET			(1 << 2) // ability targets objects
 #define XABB_WALL_TARGET		(1 << 3) // ability targets walls
+#define XABB_HUMAN_TARGET		(1 << 4) // ability targets human
+#define XABB_XENO_TARGET		(1 << 5) // ability targets xeno
 
 #define XACT_KEYBIND_USE_ABILITY (1 << 0) // immediately activate even if selectable

--- a/code/__DEFINES/actions.dm
+++ b/code/__DEFINES/actions.dm
@@ -15,9 +15,7 @@
 
 #define XABB_TURF_TARGET		(1 << 0) // ability targets turfs
 #define XABB_MOB_TARGET			(1 << 1) // ability targets mobs
-#define XABB_OBJ_TARGET			(1 << 2) // ability targets objects
-#define XABB_WALL_TARGET		(1 << 3) // ability targets walls
-#define XABB_HUMAN_TARGET		(1 << 4) // ability targets human
-#define XABB_XENO_TARGET		(1 << 5) // ability targets xeno
+#define XABB_HUMAN_TARGET		(1 << 2) // ability targets human
+#define XABB_XENO_TARGET		(1 << 3) // ability targets xeno
 
 #define XACT_KEYBIND_USE_ABILITY (1 << 0) // immediately activate even if selectable

--- a/code/__DEFINES/actions.dm
+++ b/code/__DEFINES/actions.dm
@@ -15,7 +15,5 @@
 
 #define XABB_TURF_TARGET		(1 << 0) // ability targets turfs
 #define XABB_MOB_TARGET			(1 << 1) // ability targets mobs
-#define XABB_HUMAN_TARGET		(1 << 2) // ability targets human
-#define XABB_XENO_TARGET		(1 << 3) // ability targets xeno
 
 #define XACT_KEYBIND_USE_ABILITY (1 << 0) // immediately activate even if selectable

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -318,8 +318,6 @@ if(selected_ability.target_flags & flagname){\
 	TARGET_FLAGS_MACRO(XABB_HUMAN_TARGET, /mob/living/carbon/human)
 	TARGET_FLAGS_MACRO(XABB_XENO_TARGET, /mob/living/carbon/xenomorph)
 	TARGET_FLAGS_MACRO(XABB_MOB_TARGET, /mob/living)
-	TARGET_FLAGS_MACRO(XABB_OBJ_TARGET, /obj)
-	TARGET_FLAGS_MACRO(XABB_WALL_TARGET, /turf/closed/wall)
 	if(selected_ability.target_flags & XABB_TURF_TARGET)
 		return get_turf(A)
 	return A

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -315,8 +315,6 @@ if(selected_ability.target_flags & flagname){\
 		return;}}
 
 /mob/living/carbon/xenomorph/proc/ability_target(atom/A)
-	TARGET_FLAGS_MACRO(XABB_HUMAN_TARGET, /mob/living/carbon/human)
-	TARGET_FLAGS_MACRO(XABB_XENO_TARGET, /mob/living/carbon/xenomorph)
 	TARGET_FLAGS_MACRO(XABB_MOB_TARGET, /mob/living)
 	if(selected_ability.target_flags & XABB_TURF_TARGET)
 		return get_turf(A)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -315,6 +315,8 @@ if(selected_ability.target_flags & flagname){\
 		return;}}
 
 /mob/living/carbon/xenomorph/proc/ability_target(atom/A)
+	TARGET_FLAGS_MACRO(XABB_HUMAN_TARGET, /mob/living/carbon/human)
+	TARGET_FLAGS_MACRO(XABB_XENO_TARGET, /mob/living/carbon/xenomorph)
 	TARGET_FLAGS_MACRO(XABB_MOB_TARGET, /mob/living)
 	TARGET_FLAGS_MACRO(XABB_OBJ_TARGET, /obj)
 	TARGET_FLAGS_MACRO(XABB_WALL_TARGET, /turf/closed/wall)

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -424,6 +424,7 @@
 	var/transfer_delay = 2 SECONDS
 	var/max_range = 2
 	keybind_signal = COMSIG_XENOABILITY_TRANSFER_PLASMA
+	target_flags = XABB_XENO_TARGET
 
 /datum/action/xeno_action/activable/transfer_plasma/can_use_ability(atom/A, silent = FALSE, override_flags)
 	. = ..()
@@ -487,7 +488,7 @@
 	plasma_cost = 150
 	cooldown_timer = 12 SECONDS
 	keybind_signal = COMSIG_XENOABILITY_LARVAL_GROWTH_STING
-	target_flags = XABB_MOB_TARGET
+	target_flags = XABB_HUMAN_TARGET
 
 /datum/action/xeno_action/activable/larval_growth_sting/on_cooldown_finish()
 	playsound(owner.loc, 'sound/voice/alien_drool1.ogg', 50, 1)
@@ -758,6 +759,7 @@
 	ability_name = "xeno spit"
 	keybind_signal = COMSIG_XENOABILITY_XENO_SPIT
 	plasma_cost = 10
+	target_flags = XABB_MOB_TARGET
 
 /datum/action/xeno_action/activable/xeno_spit/update_button_icon()
 	var/mob/living/carbon/xenomorph/X = owner
@@ -860,6 +862,7 @@
 	cooldown_timer = 12 SECONDS
 	plasma_cost = 150
 	keybind_signal = COMSIG_XENOABILITY_NEUROTOX_STING
+	target_flags = XABB_HUMAN_TARGET
 
 /datum/action/xeno_action/activable/neurotox_sting/can_use_ability(atom/A, silent = FALSE, override_flags)
 	. = ..()
@@ -907,6 +910,7 @@
 	name = "Psychic Whisper"
 	action_icon_state = "psychic_whisper"
 	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_WHISPER
+	target_flags = XABB_HUMAN_TARGET
 
 
 /datum/action/xeno_action/psychic_whisper/action_activate()
@@ -1163,6 +1167,7 @@
 	use_state_flags = XACT_USE_STAGGERED|XACT_USE_FORTIFIED|XACT_USE_CRESTED //can't use while staggered, defender fortified or crest down
 	keybind_signal = COMSIG_XENOABILITY_HEADBITE
 	plasma_cost = 100
+	target_flags = XABB_HUMAN_TARGET
 	///How much psy points it give
 	var/psy_points_reward = 60
 	///How much larva points it gives (8 points for one larva in distress)
@@ -1247,6 +1252,7 @@
 	use_state_flags = XACT_USE_STAGGERED|XACT_USE_FORTIFIED|XACT_USE_CRESTED //can't use while staggered, defender fortified or crest down
 	keybind_signal = COMSIG_XENOABILITY_REGURGITATE
 	plasma_cost = 100
+	target_flags = XABB_HUMAN_TARGET
 	///In how much time the cocoon will be ejected
 	var/cocoon_production_time = 3 SECONDS
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -424,7 +424,7 @@
 	var/transfer_delay = 2 SECONDS
 	var/max_range = 2
 	keybind_signal = COMSIG_XENOABILITY_TRANSFER_PLASMA
-	target_flags = XABB_XENO_TARGET
+	target_flags = XABB_MOB_TARGET
 
 /datum/action/xeno_action/activable/transfer_plasma/can_use_ability(atom/A, silent = FALSE, override_flags)
 	. = ..()
@@ -488,7 +488,7 @@
 	plasma_cost = 150
 	cooldown_timer = 12 SECONDS
 	keybind_signal = COMSIG_XENOABILITY_LARVAL_GROWTH_STING
-	target_flags = XABB_HUMAN_TARGET
+	target_flags = XABB_MOB_TARGET
 
 /datum/action/xeno_action/activable/larval_growth_sting/on_cooldown_finish()
 	playsound(owner.loc, 'sound/voice/alien_drool1.ogg', 50, 1)
@@ -862,7 +862,7 @@
 	cooldown_timer = 12 SECONDS
 	plasma_cost = 150
 	keybind_signal = COMSIG_XENOABILITY_NEUROTOX_STING
-	target_flags = XABB_HUMAN_TARGET
+	target_flags = XABB_MOB_TARGET
 
 /datum/action/xeno_action/activable/neurotox_sting/can_use_ability(atom/A, silent = FALSE, override_flags)
 	. = ..()
@@ -910,7 +910,7 @@
 	name = "Psychic Whisper"
 	action_icon_state = "psychic_whisper"
 	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_WHISPER
-	target_flags = XABB_HUMAN_TARGET
+	target_flags = XABB_MOB_TARGET
 
 
 /datum/action/xeno_action/psychic_whisper/action_activate()
@@ -1167,7 +1167,7 @@
 	use_state_flags = XACT_USE_STAGGERED|XACT_USE_FORTIFIED|XACT_USE_CRESTED //can't use while staggered, defender fortified or crest down
 	keybind_signal = COMSIG_XENOABILITY_HEADBITE
 	plasma_cost = 100
-	target_flags = XABB_HUMAN_TARGET
+	target_flags = XABB_MOB_TARGET
 	///How much psy points it give
 	var/psy_points_reward = 60
 	///How much larva points it gives (8 points for one larva in distress)
@@ -1252,7 +1252,7 @@
 	use_state_flags = XACT_USE_STAGGERED|XACT_USE_FORTIFIED|XACT_USE_CRESTED //can't use while staggered, defender fortified or crest down
 	keybind_signal = COMSIG_XENOABILITY_REGURGITATE
 	plasma_cost = 100
-	target_flags = XABB_HUMAN_TARGET
+	target_flags = XABB_MOB_TARGET
 	///In how much time the cocoon will be ejected
 	var/cocoon_production_time = 3 SECONDS
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/abilities_bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/abilities_bull.dm
@@ -8,7 +8,6 @@
 	ability_name = "plow charge"
 	keybind_signal = COMSIG_XENOABILITY_BULLCHARGE
 	var/new_charge_type = CHARGE_BULL
-	target_flags = XABB_MOB_TARGET
 
 
 /datum/action/xeno_action/activable/action_activate()
@@ -30,8 +29,6 @@
 	ability_name = "headbutt charge"
 	keybind_signal = COMSIG_XENOABILITY_BULLHEADBUTT
 	new_charge_type = CHARGE_BULL_HEADBUTT
-	target_flags = XABB_MOB_TARGET
-
 
 /datum/action/xeno_action/activable/bull_charge/gore
 	name = "Gore Charge"

--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/abilities_bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/abilities_bull.dm
@@ -8,6 +8,7 @@
 	ability_name = "plow charge"
 	keybind_signal = COMSIG_XENOABILITY_BULLCHARGE
 	var/new_charge_type = CHARGE_BULL
+	target_flags = XABB_HUMAN_TARGET
 
 
 /datum/action/xeno_action/activable/action_activate()
@@ -29,6 +30,7 @@
 	ability_name = "headbutt charge"
 	keybind_signal = COMSIG_XENOABILITY_BULLHEADBUTT
 	new_charge_type = CHARGE_BULL_HEADBUTT
+	target_flags = XABB_MOB_TARGET
 
 
 /datum/action/xeno_action/activable/bull_charge/gore

--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/abilities_bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/abilities_bull.dm
@@ -8,7 +8,7 @@
 	ability_name = "plow charge"
 	keybind_signal = COMSIG_XENOABILITY_BULLCHARGE
 	var/new_charge_type = CHARGE_BULL
-	target_flags = XABB_HUMAN_TARGET
+	target_flags = XABB_MOB_TARGET
 
 
 /datum/action/xeno_action/activable/action_activate()

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
@@ -69,6 +69,7 @@
 	plasma_cost = 100
 	cooldown_timer = 18 SECONDS
 	keybind_signal = COMSIG_XENOABILITY_CRESTTOSS
+	target_flags = XABB_MOB_TARGET
 
 /datum/action/xeno_action/activable/cresttoss/on_cooldown_finish()
 	var/mob/living/carbon/xenomorph/X = owner

--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
@@ -9,6 +9,7 @@
 	ability_name = "defiler sting"
 	plasma_cost = 150
 	cooldown_timer = 20 SECONDS
+	target_flags = XABB_HUMAN_TARGET
 
 /datum/action/xeno_action/activable/larval_growth_sting/defiler/on_cooldown_finish()
 	playsound(owner.loc, 'sound/voice/alien_drool1.ogg', 50, 1)

--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
@@ -9,7 +9,7 @@
 	ability_name = "defiler sting"
 	plasma_cost = 150
 	cooldown_timer = 20 SECONDS
-	target_flags = XABB_HUMAN_TARGET
+	target_flags = XABB_MOB_TARGET
 
 /datum/action/xeno_action/activable/larval_growth_sting/defiler/on_cooldown_finish()
 	playsound(owner.loc, 'sound/voice/alien_drool1.ogg', 50, 1)

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
@@ -17,7 +17,7 @@
 	plasma_cost = 150
 	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_CURE
 	heal_range = DRONE_HEAL_RANGE
-	target_flags = XABB_XENO_TARGET
+	target_flags = XABB_MOB_TARGET
 
 /datum/action/xeno_action/activable/psychic_cure/acidic_salve/use_ability(atom/target)
 	if(owner.do_actions)

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
@@ -17,6 +17,7 @@
 	plasma_cost = 150
 	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_CURE
 	heal_range = DRONE_HEAL_RANGE
+	target_flags = XABB_XENO_TARGET
 
 /datum/action/xeno_action/activable/psychic_cure/acidic_salve/use_ability(atom/target)
 	if(owner.do_actions)

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -281,7 +281,7 @@ GLOBAL_LIST_INIT(thickenable_resin, typecacheof(list(
 	cooldown_timer = 12.5 SECONDS
 	plasma_cost = 200
 	keybind_signal = COMSIG_XENOABILITY_HEALING_INFUSION
-	target_flags = XABB_XENO_TARGET
+	target_flags = XABB_MOB_TARGET
 	var/heal_range = HIVELORD_HEAL_RANGE
 
 /datum/action/xeno_action/activable/healing_infusion/can_use_ability(atom/target, silent = FALSE, override_flags)

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -281,6 +281,7 @@ GLOBAL_LIST_INIT(thickenable_resin, typecacheof(list(
 	cooldown_timer = 12.5 SECONDS
 	plasma_cost = 200
 	keybind_signal = COMSIG_XENOABILITY_HEALING_INFUSION
+	target_flags = XABB_XENO_TARGET
 	var/heal_range = HIVELORD_HEAL_RANGE
 
 /datum/action/xeno_action/activable/healing_infusion/can_use_ability(atom/target, silent = FALSE, override_flags)

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -530,7 +530,7 @@
 	plasma_cost = 150
 	cooldown_timer = 8 SECONDS
 	keybind_signal = COMSIG_XENOABILITY_QUEEN_GIVE_PLASMA
-	target_flags = XABB_XENO_TARGET
+	target_flags = XABB_MOB_TARGET
 
 
 /datum/action/xeno_action/activable/queen_give_plasma/can_use_ability(atom/target, silent = FALSE, override_flags)

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -530,6 +530,7 @@
 	plasma_cost = 150
 	cooldown_timer = 8 SECONDS
 	keybind_signal = COMSIG_XENOABILITY_QUEEN_GIVE_PLASMA
+	target_flags = XABB_XENO_TARGET
 
 
 /datum/action/xeno_action/activable/queen_give_plasma/can_use_ability(atom/target, silent = FALSE, override_flags)

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -63,6 +63,7 @@
 	cooldown_timer = 12 SECONDS
 	plasma_cost = 100
 	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_FLING
+	target_flags = XABB_HUMAN_TARGET
 
 
 /datum/action/xeno_action/activable/psychic_fling/on_cooldown_finish()
@@ -221,6 +222,7 @@
 	plasma_cost = 200
 	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_CURE
 	var/heal_range = SHRIKE_HEAL_RANGE
+	target_flags = XABB_XENO_TARGET
 
 
 /datum/action/xeno_action/activable/psychic_cure/on_cooldown_finish()

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -63,7 +63,7 @@
 	cooldown_timer = 12 SECONDS
 	plasma_cost = 100
 	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_FLING
-	target_flags = XABB_HUMAN_TARGET
+	target_flags = XABB_MOB_TARGET
 
 
 /datum/action/xeno_action/activable/psychic_fling/on_cooldown_finish()
@@ -222,7 +222,7 @@
 	plasma_cost = 200
 	keybind_signal = COMSIG_XENOABILITY_PSYCHIC_CURE
 	var/heal_range = SHRIKE_HEAL_RANGE
-	target_flags = XABB_XENO_TARGET
+	target_flags = XABB_MOB_TARGET
 
 
 /datum/action/xeno_action/activable/psychic_cure/on_cooldown_finish()

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
@@ -468,6 +468,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	plasma_cost = 100
 	cooldown_timer = 20 SECONDS
 	keybind_signal = COMSIG_XENOABILITY_BANISH
+	target_flags = XABB_MOB_TARGET
 	///Target we've banished
 	var/atom/movable/banishment_target = null
 	///SFX indicating the banished target's position


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Add a lot of target flags on xeno abilities, so it's easier to hit the desired target. Hitting the turf where the target is will automaticly redirect your ability on the target

Remove unused targeting flags

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

With lag, byond being bad, high TD, you sometimes have to spam your abilities to manage to hit you target. This makes it easier to hit those, which is nice QOL

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Hitting the turf where the target is will automaticly redirect your ability on the target. This works for most xeno ability
code: Remove unused targeting flags
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
