### PR TITLE
Revert "Salvage dead xenos is gone (#6366)"

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -568,6 +568,13 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 
 //Drone defines
 
+#define DRONE_SALVAGE_BIOMASS_WINDUP		5 SECONDS //Delay before the target is salvaged
+#define DRONE_SALVAGE_BIOMASS_RANGE			1
+#define DRONE_SALVAGE_BIOMASS_SALVAGE_RATIO	0.1 //Percentile of stored upgrade and evolution salvaged from the target
+#define DRONE_SALVAGE_COOLDOWN				60 SECONDS //Can only salvage one corpse per 60 seconds; try not to die *too* quickly.
+#define DRONE_SALVAGE_UPGRADE_FILTER_LIST	list(XENO_UPGRADE_THREE, XENO_UPGRADE_INVALID)
+#define DRONE_SALVAGE_EVOLUTION_FILTER_LIST	list(XENO_TIER_ZERO, XENO_TIER_THREE, XENO_TIER_FOUR)
+
 //Runner defines
 #define RUNNER_EVASION_DURATION						2 SECONDS //How long Evasion lasts.
 #define RUNNER_EVASION_RUN_DELAY					0.5 SECONDS //If the time since the Runner last moved is equal to or greater than this, its Evasion ends.

--- a/code/datums/gamemodes/game_mode.dm
+++ b/code/datums/gamemodes/game_mode.dm
@@ -437,6 +437,8 @@ Sensors indicate [numXenosShip || "no"] unknown lifeform signature[numXenosShip 
 		dat += "[GLOB.round_statistics.carrier_traps] hidey holes for huggers were made."
 	if(GLOB.round_statistics.sentinel_neurotoxin_stings)
 		dat += "[GLOB.round_statistics.sentinel_neurotoxin_stings] number of times Sentinels stung."
+	if(GLOB.round_statistics.drone_salvage_biomass)
+		dat += "[GLOB.round_statistics.drone_salvage_biomass] number of times Drones salvaged biomass from corpses."
 	if(GLOB.round_statistics.defiler_defiler_stings)
 		dat += "[GLOB.round_statistics.defiler_defiler_stings] number of times Defilers stung."
 	if(GLOB.round_statistics.defiler_neurogas_uses)

--- a/code/datums/round_statistics.dm
+++ b/code/datums/round_statistics.dm
@@ -57,6 +57,7 @@ GLOBAL_DATUM_INIT(round_statistics, /datum/round_statistics, new)
 	var/defiler_inject_egg_neurogas = 0
 	var/defiler_reagent_slashes = 0
 	var/larval_growth_stings = 0
+	var/drone_salvage_biomass = 0
 	var/xeno_unarmed_attacks = 0
 	var/xeno_bump_attacks = 0
 	var/xeno_headbites = 0

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1110,6 +1110,100 @@
 
 	succeed_activate()
 
+// Salvage Biomass
+/datum/action/xeno_action/activable/salvage_biomass
+	name = "Salvage Biomass"
+	action_icon_state = "salvage_plasma"
+	ability_name = "salvage biomass"
+	keybind_signal = COMSIG_XENOABILITY_SALVAGE_PLASMA
+	cooldown_timer = DRONE_SALVAGE_COOLDOWN
+
+/datum/action/xeno_action/activable/salvage_biomass/on_cooldown_finish()
+	owner.playsound_local(owner, 'sound/voice/alien_drool1.ogg', 25, 0, 1)
+	to_chat(owner, "<span class='notice'>We are ready to salvage xeno biomass again.</span>")
+	return ..()
+
+/datum/action/xeno_action/activable/salvage_biomass/can_use_ability(atom/A, silent = FALSE, override_flags)
+	. = ..()
+	if(!.)
+		return FALSE
+
+	var/mob/living/carbon/xenomorph/X = owner
+	if(!isxeno(A))
+		to_chat(X, "<span class='xenowarning'>We can only salvage the biomass of deceased xenomorphs!</span>")
+		return FALSE
+
+	var/mob/living/carbon/xenomorph/target = A
+
+	if(target.stat != DEAD)
+		to_chat(X, "<span class='xenowarning'>We can't salvage the biomass of living sisters!</span>")
+		return FALSE
+
+	var/distance = get_dist(X, target)
+	if(distance > DRONE_SALVAGE_BIOMASS_RANGE)
+		to_chat(X, "<span class='xenowarning'>We need to be [distance -  DRONE_SALVAGE_BIOMASS_RANGE] tiles closer to [target].</span>")
+		return FALSE
+
+
+/datum/action/xeno_action/activable/salvage_biomass/use_ability(atom/A)
+
+	var/mob/living/carbon/xenomorph/X = owner
+	var/mob/living/carbon/xenomorph/target = A
+
+
+	X.face_atom(target) //Face the target so we don't look like an ass
+	to_chat(X, "<span class='xenowarning'>We begin to salvage the biomass of [target]...</span>")
+	playsound(X, pick('sound/voice/alien_drool1.ogg','sound/voice/alien_drool2.ogg'), 25)
+
+	if(!do_after(X, DRONE_SALVAGE_BIOMASS_WINDUP, TRUE, target, BUSY_ICON_FRIENDLY)) //Wind up
+		return fail_activate()
+
+
+	X.face_atom(target) //Face the target so we don't look like an ass
+
+	if(!can_use_ability(target, FALSE, XACT_IGNORE_PLASMA)) //Check to make sure the target hasn't gone anywhere/been exploded/etc
+		return fail_activate()
+
+	succeed_activate()
+
+	var/upgrade_amount = target.upgrade_stored * DRONE_SALVAGE_BIOMASS_SALVAGE_RATIO //We only recover a small portion of the target's upgrade and evo points.
+	if(target.upgrade == XENO_UPGRADE_THREE)
+		upgrade_amount = target.xeno_caste.upgrade_threshold * DRONE_SALVAGE_BIOMASS_SALVAGE_RATIO //Ancient xenos count as having maximum upgrade points
+	var/evo_amount = target.evolution_stored * DRONE_SALVAGE_BIOMASS_SALVAGE_RATIO
+
+	//Take all the plas-mar
+	X.gain_plasma(target.plasma_stored)
+
+	//Distribute the upgrade and evo points the target had to the hive:
+	var/list/list_of_upgrade_xenos = list()
+	var/list/list_of_evolve_xenos = list()
+
+	for(var/mob/living/carbon/xenomorph/filter in X.hive.get_all_xenos())
+		if(!(filter.upgrade in DRONE_SALVAGE_UPGRADE_FILTER_LIST)) //Only Xenos who can use the salvage get it; filter them
+			list_of_upgrade_xenos += filter
+		if(!(filter.tier in DRONE_SALVAGE_EVOLUTION_FILTER_LIST) && (filter.evolution_stored < filter.xeno_caste.evolution_threshold))
+			list_of_evolve_xenos += filter
+
+	if(length(list_of_upgrade_xenos))
+		upgrade_amount /= length(list_of_upgrade_xenos) //get the amount distributed to each xeno; protect against dividing by 0
+		for(var/mob/living/carbon/xenomorph/beneficiary in list_of_upgrade_xenos) //Distribute the upgrade salvage to those who can use it
+			beneficiary.upgrade_stored += upgrade_amount
+
+	if(length(list_of_evolve_xenos))
+		evo_amount /= length(list_of_evolve_xenos)
+		for(var/mob/living/carbon/xenomorph/beneficiary in list_of_evolve_xenos) //Distribute the evolve salvage to those who can use it
+			beneficiary.evolution_stored = min(beneficiary.xeno_caste.evolution_threshold, beneficiary.evolution_stored + evo_amount) //Prevents janky overflow
+
+	playsound(target, 'sound/effects/alien_egg_burst.ogg', 25)
+	X.hive.xeno_message("[target]'s remains were salvaged by [X], recovering [upgrade_amount] upgrade points for [length(list_of_upgrade_xenos)] sisters and [evo_amount] evolution points for [length(list_of_evolve_xenos) ] sisters.") //Notify hive and give credit to the good boy drone
+	X.visible_message("<span class='xenowarning'>\ [X] gruesomely absorbs and devours the remains of [target]!</span>", \
+	"<span class='xenowarning'>We messily devour the remains of [target], absorbing [target.plasma_stored] plasma and distributing our deceased sister's essence throughout the hive. We now have [X.plasma_stored]/[X.xeno_caste.plasma_max] plasma stored.</span>") //Narrative description.
+
+	target.gib() //Destroy the corpse
+
+	GLOB.round_statistics.drone_salvage_biomass++ //Statistic incrementation
+	SSblackbox.record_feedback("tally", "round_statistics", 1, "drone_salvage_biomass")
+
 /////////////////////////////////////////////////////////////////////////////////////////////
 
 ////////////////////

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
@@ -59,6 +59,7 @@
 		/datum/action/xeno_action/activable/secrete_resin,
 		/datum/action/xeno_action/activable/psychic_cure/acidic_salve,
 		/datum/action/xeno_action/activable/transfer_plasma/drone,
+		/datum/action/xeno_action/activable/salvage_biomass,
 		/datum/action/xeno_action/activable/corrosive_acid/drone,
 		/datum/action/xeno_action/activable/larval_growth_sting,
 		/datum/action/xeno_action/toggle_pheromones,

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/castedatum_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/castedatum_hivelord.dm
@@ -61,6 +61,7 @@
 		/datum/action/xeno_action/activable/build_silo,
 		/datum/action/xeno_action/activable/build_turret,
 		/datum/action/xeno_action/activable/transfer_plasma/improved,
+		/datum/action/xeno_action/activable/salvage_biomass,
 		/datum/action/xeno_action/activable/corrosive_acid,
 		/datum/action/xeno_action/build_tunnel,
 		/datum/action/xeno_action/toggle_speed,


### PR DESCRIPTION
This reverts commit 9cb7b564fcc2f11ac7d962aa12f6e59a4f8b3468.

<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Put back salvage xeno ability

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Was a mistake. Marines gets enough points from miner, they don't really need that extra amount of points. 
And xenos were not always managing to snatch back bodies, so it was actually interresting 

## Changelog
:cl:
balance: Put back salvage dead xeno ability
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
