### PR TITLE
Robo limbs proper malfunction and slight damage reduction buff.

### DIFF
--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -169,8 +169,8 @@
 			brute *= owner.species.brute_mod
 			burn *= owner.species.burn_mod
 		else
-			brute *= 0.66 //~2/3 damage for ROBOLIMBS
-			burn *= 0.66 //~2/3 damage for ROBOLIMBS
+			brute *= 0.50 // half damage for ROBOLIMBS
+			burn *= 0.50 // half damage for ROBOLIMBS
 
 	//High brute damage or sharp objects may damage internal organs
 	if(internal_organs && ((sharp && brute >= 10) || brute >= 20) && prob(5))
@@ -1038,7 +1038,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			var/emote_scream = pick("screams in pain and", "lets out a sharp cry and", "cries out and")
 			owner.emote("me", 1, "[(owner.species && owner.species.species_flags & NO_PAIN) ? "" : emote_scream ] drops what they were holding in their [hand_name]!")
 	if(is_malfunctioning())
-		if(prob(10))
+		if(prob(0))
 			owner.dropItemToGround(c_hand)
 			owner.emote("me", 1, "drops what they were holding, their [hand_name] malfunctioning!")
 			new /datum/effect_system/spark_spread(owner, owner, 5, 0, TRUE, 1 SECONDS)

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -1038,7 +1038,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			var/emote_scream = pick("screams in pain and", "lets out a sharp cry and", "cries out and")
 			owner.emote("me", 1, "[(owner.species && owner.species.species_flags & NO_PAIN) ? "" : emote_scream ] drops what they were holding in their [hand_name]!")
 	if(is_malfunctioning())
-		if(prob(15))
+		if(prob(5))
 			owner.dropItemToGround(c_hand)
 			owner.emote("me", 1, "drops what they were holding, their [hand_name] malfunctioning!")
 			new /datum/effect_system/spark_spread(owner, owner, 5, 0, TRUE, 1 SECONDS)

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -1025,7 +1025,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	return ((limb_status & LIMB_BROKEN) && !(limb_status & LIMB_SPLINTED) && !(limb_status & LIMB_STABILIZED))
 
 /datum/limb/proc/is_malfunctioning()
-	return ((limb_status & LIMB_ROBOT) && prob(brute_dam + burn_dam))
+	return ((limb_status & LIMB_ROBOT) && (get_damage() > min_broken_damage))
 
 //for arms and hands
 /datum/limb/proc/process_grasp(obj/item/c_hand, hand_name)
@@ -1038,7 +1038,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			var/emote_scream = pick("screams in pain and", "lets out a sharp cry and", "cries out and")
 			owner.emote("me", 1, "[(owner.species && owner.species.species_flags & NO_PAIN) ? "" : emote_scream ] drops what they were holding in their [hand_name]!")
 	if(is_malfunctioning())
-		if(prob(0))
+		if(prob(15))
 			owner.dropItemToGround(c_hand)
 			owner.emote("me", 1, "drops what they were holding, their [hand_name] malfunctioning!")
 			new /datum/effect_system/spark_spread(owner, owner, 5, 0, TRUE, 1 SECONDS)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so you have a proper malfunction threshold with robo limbs and slight buff from 0.66 to 0.50 reduction to damage.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Currently, robo limbs penalize you too much. They malfunction randomly (with no way to fix this except full repair), do not benefit from autodoc / chems, and on top of this require you to restructure your entire setup around it (welder, jaeger helmet or welding helmet if you use PAS, and cables).

This PR seeks to alleviate the worst aspect of the robo limbs (random malfunctions) by removing them entirely, and buffing the amount of damage robo limbs take. This still forces a permanent condition on marines (since they still have to re-order their gear around it), but it also makes it not a "im delimbed, might as well cryo" moment.

Reason why it is important to keep this aspect of the game still is that delimbs are one of the only ways to stop competent marines from constantly pushing; perma kills are basically gone, broken bones are fixed by valk, B18, or splinting.

This is more of a "I am not really good enough at coding to fix this issue entirely but I am good enough to fix it with a bandaid" kinda situations.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Robo limbs now malfunction at a proper threshold, and do it at a lower probability than fleshy limbs.
balance: Robo limbs take more punishment; from 0.66 reduction to 0.50 reduction to brute and burn damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
