### PR TITLE
Allows reloading from pistol belt.

### DIFF
--- a/code/datums/jobs/job/pmc.dm
+++ b/code/datums/jobs/job/pmc.dm
@@ -17,7 +17,7 @@
 	jobtype = /datum/job/pmc/standard
 
 	id = /obj/item/card/id/silver
-	belt = /obj/item/storage/belt/gun/m4a3/vp70
+	belt = /obj/item/storage/belt/gun/pistol/m4a3/vp70
 	ears = /obj/item/radio/headset/distress/PMC
 	w_uniform = /obj/item/clothing/under/marine/veteran/PMC
 	shoes = /obj/item/clothing/shoes/veteran/PMC
@@ -61,7 +61,7 @@
 	jobtype = /datum/job/pmc/gunner
 
 	id = /obj/item/card/id/silver
-	belt = /obj/item/storage/belt/gun/m4a3/vp70
+	belt = /obj/item/storage/belt/gun/pistol/m4a3/vp70
 	ears = /obj/item/radio/headset/distress/PMC
 	w_uniform = /obj/item/clothing/under/marine/veteran/PMC
 	shoes = /obj/item/clothing/shoes/veteran/PMC
@@ -111,7 +111,7 @@
 	jobtype = /datum/job/pmc/sniper
 
 	id = /obj/item/card/id/silver
-	belt = /obj/item/storage/belt/gun/m4a3/vp70
+	belt = /obj/item/storage/belt/gun/pistol/m4a3/vp70
 	ears = /obj/item/radio/headset/distress/PMC
 	w_uniform = /obj/item/clothing/under/marine/veteran/PMC
 	shoes = /obj/item/clothing/shoes/veteran/PMC
@@ -155,7 +155,7 @@
 	jobtype = /datum/job/pmc/leader
 
 	id = /obj/item/card/id/silver
-	belt = /obj/item/storage/belt/gun/m4a3/vp78
+	belt = /obj/item/storage/belt/gun/pistol/m4a3/vp78
 	ears = /obj/item/radio/headset/distress/PMC
 	w_uniform = /obj/item/clothing/under/marine/veteran/PMC/leader
 	shoes = /obj/item/clothing/shoes/veteran/PMC

--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -141,7 +141,7 @@ Make the TGMC proud!"})
 	r_store = /obj/item/storage/pouch/general/large/command
 	l_store = /obj/item/hud_tablet/fieldcommand
 	back = /obj/item/storage/backpack/marine/satchel
-	suit_store = /obj/item/storage/belt/gun/m4a3/fieldcommander/
+	suit_store = /obj/item/storage/belt/gun/pistol/m4a3/fieldcommander/
 
 
 //Staff Officer
@@ -190,7 +190,7 @@ You are in charge of logistics and the overwatch system. You are also in line to
 	jobtype = /datum/job/terragov/command/staffofficer
 
 	id = /obj/item/card/id/silver
-	belt = /obj/item/storage/belt/gun/m4a3/officer
+	belt = /obj/item/storage/belt/gun/pistol/m4a3/officer
 	ears = /obj/item/radio/headset/mainship/mcom
 	w_uniform = /obj/item/clothing/under/marine/officer/bridge
 	shoes = /obj/item/clothing/shoes/marine/full
@@ -250,7 +250,7 @@ If you are not piloting, there is an autopilot fallback for command, but don't l
 	jobtype = /datum/job/terragov/command/pilot
 
 	id = /obj/item/card/id/silver
-	belt = /obj/item/storage/belt/gun/m4a3/vp70
+	belt = /obj/item/storage/belt/gun/pistol/m4a3/vp70
 	ears = /obj/item/radio/headset/mainship/mcom
 	w_uniform = /obj/item/clothing/under/marine/officer/pilot
 	wear_suit = /obj/item/clothing/suit/armor/vest/pilot

--- a/code/game/objects/effects/landmarks/corpsespawner.dm
+++ b/code/game/objects/effects/landmarks/corpsespawner.dm
@@ -288,7 +288,7 @@
 	corpseshoes = /obj/item/clothing/shoes/jackboots
 	corpsesuit = /obj/item/clothing/suit/armor/vest/security
 	corpseback = /obj/item/storage/backpack/satchel
-	corpsebelt = /obj/item/storage/belt/gun/m4a3/vp70
+	corpsebelt = /obj/item/storage/belt/gun/pistol/m4a3/vp70
 	corpsegloves = /obj/item/clothing/gloves/marine/veteran/PMC
 	corpsehelmet = /obj/item/clothing/head/helmet/marine/veteran/PMC
 	corpsemask = /obj/item/clothing/mask/gas/PMC/damaged

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -635,10 +635,9 @@
 	for(var/obj/item/ammo_magazine/mag in contents) 
 		if(!istype(gun, mag.gun_type))
 			continue
-		else
-			gun.reload(user, mag)
-			orient2hud()
-			return
+		gun.reload(user, mag)
+		orient2hud()
+		return
 
 /obj/item/storage/belt/gun/pistol/examine(mob/user, distance, infix, suffix)
 	. = ..()
@@ -861,4 +860,3 @@
 	var/obj/item/weapon/gun/new_gun = new /obj/item/weapon/gun/shotgun/double/marine(src)
 	new /obj/item/ammo_magazine/shotgun(src)
 	new_gun.on_enter_storage(src)
-

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -557,6 +557,7 @@
 		/obj/item/weapon/gun/pistol,
 		/obj/item/ammo_magazine/pistol,
 	)
+	var/reload_on = FALSE
 
 /obj/item/storage/belt/gun/Destroy()
 	if(gun_underlay)
@@ -618,6 +619,37 @@
 				to_chat(usr, "<span class='warning'>[src] can't hold any more magazines.</span>")
 			return FALSE
 	return TRUE
+
+/obj/item/storage/belt/gun/attackby(obj/item/I, mob/user, params)
+	if(!istype(I, /obj/item/weapon/gun/pistol) || !reload_on)
+		return ..()
+	var/obj/item/weapon/gun/pistol/gun = I
+	if(gun.current_mag)
+		return ..()
+	for(var/obj/item/ammo_magazine/mag in contents) 
+		if(!istype(gun, mag.gun_type))
+			continue
+		else
+			gun.reload(user, mag)
+			orient2hud()
+			return
+
+/obj/item/storage/belt/gun/examine(mob/user, distance, infix, suffix)
+	. = ..()
+	to_chat(user, "<span class='notice'>Control-Click to toggle \'Tactical Reload Mode\'. While on, clicking on the belt with an empty pistol will perform a reload with the ammo inside.</span>")
+	if(!reload_on)
+		to_chat(user, "<span class='notice'>Reload mode is OFF</span>")
+	if(reload_on)
+		to_chat(user, "<span class='notice'>Reload mode is ON</span>")
+
+/obj/item/storage/belt/gun/CtrlClick(mob/user)
+	if(src.loc != user)
+		return ..()
+	reload_on = !reload_on
+	if(!reload_on)
+		to_chat(user, "<span class='notice'>You toggle the reload mode OFF.</span>")
+	if(reload_on)
+		to_chat(user, "<span class='notice'>You toggle the reload mode ON.</span>")
 
 /obj/item/storage/belt/gun/m4a3
 	name = "\improper M4A3 holster rig"

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -557,7 +557,6 @@
 		/obj/item/weapon/gun/pistol,
 		/obj/item/ammo_magazine/pistol,
 	)
-	var/reload_on = FALSE
 
 /obj/item/storage/belt/gun/Destroy()
 	if(gun_underlay)
@@ -620,8 +619,15 @@
 			return FALSE
 	return TRUE
 
-/obj/item/storage/belt/gun/attackby(obj/item/I, mob/user, params)
-	if(!istype(I, /obj/item/weapon/gun/pistol) || !reload_on)
+//This deliniates between belt/gun/pistol and belt/gun/revolver
+/obj/item/storage/belt/gun/pistol
+	name = "generic pistol belt"
+	desc = "A pistol belt that is not a revolver belt"
+	icon_state = "m4a3_holster"
+	item_state = "m4a3_holster"
+
+/obj/item/storage/belt/gun/pistol/attackby_alternate(obj/item/I, mob/user, params)
+	if(!istype(I, /obj/item/weapon/gun/pistol))
 		return ..()
 	var/obj/item/weapon/gun/pistol/gun = I
 	if(gun.current_mag)
@@ -634,24 +640,11 @@
 			orient2hud()
 			return
 
-/obj/item/storage/belt/gun/examine(mob/user, distance, infix, suffix)
+/obj/item/storage/belt/gun/pistol/examine(mob/user, distance, infix, suffix)
 	. = ..()
-	to_chat(user, "<span class='notice'>Control-Click to toggle \'Tactical Reload Mode\'. While on, clicking on the belt with an empty pistol will perform a reload with the ammo inside.</span>")
-	if(!reload_on)
-		to_chat(user, "<span class='notice'>Reload mode is OFF</span>")
-	if(reload_on)
-		to_chat(user, "<span class='notice'>Reload mode is ON</span>")
+	to_chat(user, "<span class='notice'>To perform a reload with the amunition inside, disable right click and right click on the belt with an empty pistol.</span>")
 
-/obj/item/storage/belt/gun/CtrlClick(mob/user)
-	if(src.loc != user)
-		return ..()
-	reload_on = !reload_on
-	if(!reload_on)
-		to_chat(user, "<span class='notice'>You toggle the reload mode OFF.</span>")
-	if(reload_on)
-		to_chat(user, "<span class='notice'>You toggle the reload mode ON.</span>")
-
-/obj/item/storage/belt/gun/m4a3
+/obj/item/storage/belt/gun/pistol/m4a3
 	name = "\improper M4A3 holster rig"
 	desc = "The M4A3 is a common holster belt. It consists of a modular belt with various clips. This version has a holster assembly that allows one to carry a handgun. It also contains side pouches that can store 9mm or .45 magazines."
 	can_hold = list(
@@ -659,7 +652,7 @@
 		/obj/item/ammo_magazine/pistol,
 	)
 
-/obj/item/storage/belt/gun/m4a3/full/Initialize()
+/obj/item/storage/belt/gun/pistol/m4a3/full/Initialize()
 	. = ..()
 	var/obj/item/weapon/gun/new_gun = new /obj/item/weapon/gun/pistol/rt3(src)
 	new /obj/item/ammo_magazine/pistol/ap(src)
@@ -670,7 +663,7 @@
 	new /obj/item/ammo_magazine/pistol/extended(src)
 	new_gun.on_enter_storage(src)
 
-/obj/item/storage/belt/gun/m4a3/officer/Initialize()
+/obj/item/storage/belt/gun/pistol/m4a3/officer/Initialize()
 	. = ..()
 	var/obj/item/weapon/gun/new_gun = new /obj/item/weapon/gun/pistol/rt3(src)
 	new /obj/item/ammo_magazine/pistol/hp(src)
@@ -681,7 +674,7 @@
 	new /obj/item/ammo_magazine/pistol/ap(src)
 	new_gun.on_enter_storage(src)
 
-/obj/item/storage/belt/gun/m4a3/fieldcommander/Initialize()
+/obj/item/storage/belt/gun/pistol/m4a3/fieldcommander/Initialize()
 	. = ..()
 	var/obj/item/weapon/gun/new_gun = new /obj/item/weapon/gun/pistol/m1911/custom(src)
 	new /obj/item/ammo_magazine/pistol/m1911(src)
@@ -692,7 +685,7 @@
 	new /obj/item/ammo_magazine/pistol/m1911(src)
 	new_gun.on_enter_storage(src)
 
-/obj/item/storage/belt/gun/m4a3/vp70/Initialize()
+/obj/item/storage/belt/gun/pistol/m4a3/vp70/Initialize()
 	. = ..()
 	var/obj/item/weapon/gun/new_gun = new /obj/item/weapon/gun/pistol/vp70(src)
 	new /obj/item/ammo_magazine/pistol/vp70(src)
@@ -703,7 +696,7 @@
 	new /obj/item/ammo_magazine/pistol/vp70(src)
 	new_gun.on_enter_storage(src)
 
-/obj/item/storage/belt/gun/m4a3/vp78/Initialize()
+/obj/item/storage/belt/gun/pistol/m4a3/vp78/Initialize()
 	. = ..()
 	var/obj/item/weapon/gun/new_gun = new /obj/item/weapon/gun/pistol/vp78(src)
 	new /obj/item/ammo_magazine/pistol/vp78(src)
@@ -715,13 +708,13 @@
 	new_gun.on_enter_storage(src)
 
 
-/obj/item/storage/belt/gun/m4a3/som
+/obj/item/storage/belt/gun/pistol/m4a3/som
 	name = "\improper S19 holster rig"
 	desc = "A belt with origins to old colony security holster rigs."
 	icon_state = "som_belt_pistol"
 	item_state = "som_belt_pistol"
 
-/obj/item/storage/belt/gun/stand
+/obj/item/storage/belt/gun/pistol/stand
 	name = "\improper M276 pattern M4A3 holster rig"
 	desc = "The M276 is the standard load-bearing equipment of the TGMC. It consists of a modular belt with various clips. This version has a holster assembly that allows one to carry the M4A3 comfortably secure. It also contains side pouches that can store 9mm or .45 magazines."
 	can_hold = list(

--- a/code/game/objects/items/storage/marine_boxes.dm
+++ b/code/game/objects/items/storage/marine_boxes.dm
@@ -676,7 +676,7 @@
 	new /obj/item/clothing/suit/storage/marine/M3HB(src)
 	new /obj/item/clothing/head/helmet/marine/heavy(src)
 	new /obj/item/weapon/gun/rifle/standard_lmg/autorifleman(src)
-	new /obj/item/storage/belt/gun/m4a3/full(src)
+	new /obj/item/storage/belt/gun/pistol/m4a3/full(src)
 	new /obj/item/storage/pouch/flare/full(src)
 	new /obj/item/reagent_containers/food/snacks/enrg_bar(src)
 	new /obj/item/reagent_containers/food/snacks/enrg_bar(src)
@@ -872,7 +872,7 @@
 
 /obj/item/storage/box/squadmarine/smartgunnerm4a3/Initialize(mapload, ...)
 	. = ..()
-	new /obj/item/storage/belt/gun/m4a3/full(src)
+	new /obj/item/storage/belt/gun/pistol/m4a3/full(src)
 	new /obj/item/storage/pouch/magazine/pistol/large/full(src)
 	new /obj/item/clothing/tie/storage/brown_vest(src)
 	new /obj/item/ammo_magazine/pistol(src)

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -134,7 +134,7 @@
 		/obj/item/weapon/gun/,
 		/obj/item/flashlight,
 		/obj/item/storage/large_holster/machete,
-		/obj/item/storage/belt/gun/m4a3,
+		/obj/item/storage/belt/gun/pistol/m4a3,
 		/obj/item/storage/belt/gun/m44,
 	)
 


### PR DESCRIPTION
## About The Pull Request

Completes one of these approved suggestions.
https://tgstation13.org/phpBB/viewtopic.php?f=65&t=20487

Allows an empty pistol to be reloaded from a pistol belt using right click so long as right click is disabled and there is no ammo within.

## Why It's Good For The Game

https://tgstation13.org/phpBB/viewtopic.php?f=65&t=20487
It was an approved suggestion.
I think it would make reloading these low capacity weapons far easier. 

## Changelog
:cl:
add: Allows an empty pistol to be reloaded from a pistol belt using right click so long as right click is disabled and there is no ammo within.
/:cl:
