### PR TITLE
Gives light to miners if repaired.

### DIFF
--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -2,10 +2,6 @@
 #define MINER_SMALL_DAMAGE	1
 #define MINER_MEDIUM_DAMAGE	2
 #define MINER_DESTROYED	3
-#define MINER_LIGHT_RUNNING 8
-#define MINER_LIGHT_SDAMAGE 4
-#define MINER_LIGHT_MDAMAGE 2
-#define MINER_LIGHT_DESTROYED 0
 #define MINER_AUTOMATED "mining computer"
 #define MINER_RESISTANT	"reinforced components"
 #define MINER_OVERCLOCKED "high-efficiency drill"
@@ -36,6 +32,12 @@
 	var/max_miner_integrity = 100
 	///What type of upgrade it has installed , used to change the icon of the miner.
 	var/miner_upgrade_type
+	//Brightness of the miner
+	var/brightness_on = 0
+
+/obj/machinery/miner/Initialize()
+	. = ..()
+	set_light(brightness_on)
 
 /obj/machinery/miner/damaged	//mapping and all that shebang
 	miner_status = MINER_DESTROYED
@@ -54,16 +56,16 @@
 	switch(miner_status)
 		if(MINER_RUNNING)
 			icon_state = "mining_drill_active_[miner_upgrade_type]"
-			set_light(MINER_LIGHT_RUNNING)
+			set_light(8)
 		if(MINER_SMALL_DAMAGE)
 			icon_state = "mining_drill_braced_[miner_upgrade_type]"
-			set_light(MINER_LIGHT_SDAMAGE)
+			set_light(4)
 		if(MINER_MEDIUM_DAMAGE)
 			icon_state = "mining_drill_[miner_upgrade_type]"
-			set_light(MINER_LIGHT_MDAMAGE)
+			set_light(2)
 		if(MINER_DESTROYED)
 			icon_state = "mining_drill_error_[miner_upgrade_type]"
-			set_light(MINER_LIGHT_DESTROYED)
+			set_light(brightness_on)
 /// Called whenever someone attacks the miner with a object which is considered a upgrade.The object needs to have a uptype var.
 /obj/machinery/miner/proc/attempt_upgrade(obj/item/minerupgrade/upgrade, mob/user, params)
 	if(miner_upgrade_type)

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -2,6 +2,10 @@
 #define MINER_SMALL_DAMAGE	1
 #define MINER_MEDIUM_DAMAGE	2
 #define MINER_DESTROYED	3
+#define MINER_LIGHT_RUNNING 8
+#define MINER_LIGHT_SDAMAGE 4
+#define MINER_LIGHT_MDAMAGE 2
+#define MINER_LIGHT_DESTROYED 0
 #define MINER_AUTOMATED "mining computer"
 #define MINER_RESISTANT	"reinforced components"
 #define MINER_OVERCLOCKED "high-efficiency drill"
@@ -56,16 +60,16 @@
 	switch(miner_status)
 		if(MINER_RUNNING)
 			icon_state = "mining_drill_active_[miner_upgrade_type]"
-			set_light(8)
+			set_light(MINER_LIGHT_RUNNING)
 		if(MINER_SMALL_DAMAGE)
 			icon_state = "mining_drill_braced_[miner_upgrade_type]"
-			set_light(4)
+			set_light(MINER_LIGHT_SDAMAGE)
 		if(MINER_MEDIUM_DAMAGE)
 			icon_state = "mining_drill_[miner_upgrade_type]"
-			set_light(2)
+			set_light(MINER_LIGHT_MDAMAGE)
 		if(MINER_DESTROYED)
 			icon_state = "mining_drill_error_[miner_upgrade_type]"
-			set_light(brightness_on)
+			set_light(MINER_LIGHT_DESTROYED)
 /// Called whenever someone attacks the miner with a object which is considered a upgrade.The object needs to have a uptype var.
 /obj/machinery/miner/proc/attempt_upgrade(obj/item/minerupgrade/upgrade, mob/user, params)
 	if(miner_upgrade_type)

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -36,12 +36,6 @@
 	var/max_miner_integrity = 100
 	///What type of upgrade it has installed , used to change the icon of the miner.
 	var/miner_upgrade_type
-	//Brightness of the miner
-	var/brightness_on = 0
-
-/obj/machinery/miner/Initialize()
-	. = ..()
-	set_light(brightness_on)
 
 /obj/machinery/miner/damaged	//mapping and all that shebang
 	miner_status = MINER_DESTROYED

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -2,6 +2,10 @@
 #define MINER_SMALL_DAMAGE	1
 #define MINER_MEDIUM_DAMAGE	2
 #define MINER_DESTROYED	3
+#define MINER_LIGHT_RUNNING 8
+#define MINER_LIGHT_SDAMAGE 4
+#define MINER_LIGHT_MDAMAGE 2
+#define MINER_LIGHT_DESTROYED 0
 #define MINER_AUTOMATED "mining computer"
 #define MINER_RESISTANT	"reinforced components"
 #define MINER_OVERCLOCKED "high-efficiency drill"
@@ -32,12 +36,6 @@
 	var/max_miner_integrity = 100
 	///What type of upgrade it has installed , used to change the icon of the miner.
 	var/miner_upgrade_type
-	//Brightness of the miner
-	var/brightness_on = 0
-
-/obj/machinery/miner/Initialize()
-	. = ..()
-	set_light(brightness_on)
 
 /obj/machinery/miner/damaged	//mapping and all that shebang
 	miner_status = MINER_DESTROYED
@@ -56,16 +54,16 @@
 	switch(miner_status)
 		if(MINER_RUNNING)
 			icon_state = "mining_drill_active_[miner_upgrade_type]"
-			set_light(8)
+			set_light(MINER_LIGHT_RUNNING)
 		if(MINER_SMALL_DAMAGE)
 			icon_state = "mining_drill_braced_[miner_upgrade_type]"
-			set_light(4)
+			set_light(MINER_LIGHT_SDAMAGE)
 		if(MINER_MEDIUM_DAMAGE)
 			icon_state = "mining_drill_[miner_upgrade_type]"
-			set_light(2)
+			set_light(MINER_LIGHT_MDAMAGE)
 		if(MINER_DESTROYED)
 			icon_state = "mining_drill_error_[miner_upgrade_type]"
-			set_light(brightness_on)
+			set_light(MINER_LIGHT_DESTROYED)
 /// Called whenever someone attacks the miner with a object which is considered a upgrade.The object needs to have a uptype var.
 /obj/machinery/miner/proc/attempt_upgrade(obj/item/minerupgrade/upgrade, mob/user, params)
 	if(miner_upgrade_type)

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -32,6 +32,12 @@
 	var/max_miner_integrity = 100
 	///What type of upgrade it has installed , used to change the icon of the miner.
 	var/miner_upgrade_type
+	//Brightness of the miner
+	var/brightness_on = 0
+
+/obj/machinery/miner/Initialize()
+	. = ..()
+	set_light(brightness_on)
 
 /obj/machinery/miner/damaged	//mapping and all that shebang
 	miner_status = MINER_DESTROYED
@@ -50,12 +56,16 @@
 	switch(miner_status)
 		if(MINER_RUNNING)
 			icon_state = "mining_drill_active_[miner_upgrade_type]"
+			set_light(8)
 		if(MINER_SMALL_DAMAGE)
 			icon_state = "mining_drill_braced_[miner_upgrade_type]"
+			set_light(4)
 		if(MINER_MEDIUM_DAMAGE)
 			icon_state = "mining_drill_[miner_upgrade_type]"
+			set_light(2)
 		if(MINER_DESTROYED)
 			icon_state = "mining_drill_error_[miner_upgrade_type]"
+			set_light(brightness_on)
 /// Called whenever someone attacks the miner with a object which is considered a upgrade.The object needs to have a uptype var.
 /obj/machinery/miner/proc/attempt_upgrade(obj/item/minerupgrade/upgrade, mob/user, params)
 	if(miner_upgrade_type)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I used my understanding of combat floodlight code to do this, so it might not be THE BEST way to do this, but it works and when I tested it I got no errors.

As for what this does, it makes have no light when broken, small light when light repair, decent light when medium repaired, and 8 tiles of light when fully operational. This also simulates the intense mining that a miner does; your drilling into the earth and such, yada yada.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

A buff to properly defended miners (at minimum caded, at max with turrets and cades), while a nerf to stealth mining (the light is 1 tile extra of a floodlight; a single xeno patrol for 30 seconds to 1 min is now enough to spot stealth miners since they give off huge light).

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Miners now give off their own light; both in the repairing process and in the final running phase.
balance: This buffs properly defended miners.
Balance: However, stealth mining is now nerfed, since fully operational miners give off huge light, which is easy to spot on most maps.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
