### PR TITLE
Fixes FOB drone on ice colony LZ2

### DIFF
--- a/code/modules/mining/remote_fob/remote_fob_fobdrone.dm
+++ b/code/modules/mining/remote_fob/remote_fob_fobdrone.dm
@@ -1,6 +1,6 @@
 /////////For remote construction of FOB using a computer on the ship during setup phase
 GLOBAL_LIST_INIT(dropship_lzs, typecacheof(list(/area/shuttle/drop1/lz1, /area/shuttle/drop2/lz2)))
-GLOBAL_LIST_INIT(blocked_remotebuild_turfs, typecacheof(list(/turf/closed, /turf/open/beach/sea, /turf/open/floor/plating/ground/ice)))
+GLOBAL_LIST_INIT(blocked_remotebuild_turfs, typecacheof(list(/turf/closed, /turf/open/beach/sea)))
 GLOBAL_LIST_INIT(blocked_remotebuild_objs, typecacheof(list(/obj/machinery/computer/camera_advanced/remote_fob, /obj/structure/window, /obj/machinery/door/poddoor)))
 /////////////////////////////// Drone Mob
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
FOB drone can move on ice turfs now, I'm not sure why they were blacklisted in the first place but if someone can come up with a compelling reason to keep them black listed I'll remap the ice off the LZ instead.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

LZ2 ice colony not a pain in the ass to use

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The FOB drone can now move on ice tiles in ice colony LZ2
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
