### PR TITLE
Barricade QOL

### DIFF
--- a/code/game/objects/items/stacks/barbed_wire.dm
+++ b/code/game/objects/items/stacks/barbed_wire.dm
@@ -4,6 +4,7 @@
 	desc = "A spiky length of wire."
 	icon = 'icons/Marine/marine-items.dmi'
 	icon_state = "barbed_wire"
+	flags_item = NOBLUDGEON
 	singular_name = "length"
 	w_class = WEIGHT_CLASS_SMALL
 	force = 0

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -70,6 +70,7 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	desc = "Sheets made out of metal. It has been dubbed Metal Sheets."
 	singular_name = "metal sheet"
 	icon_state = "sheet-metal"
+	flags_item = NOBLUDGEON
 	materials = list(/datum/material/metal = 4000)
 	throwforce = 14.0
 	flags_atom = CONDUCT
@@ -105,6 +106,7 @@ GLOBAL_LIST_INIT(plasteel_recipes, list ( \
 	desc = "This sheet is an alloy of iron and phoron."
 	icon_state = "sheet-plasteel"
 	item_state = "sheet-metal"
+	flags_item = NOBLUDGEON
 	materials = list(/datum/material/metal = 7500)
 	throwforce = 15.0
 	flags_atom = CONDUCT


### PR DESCRIPTION
## Changelog
:cl:
qol: Metal/Plasteel sheets and barbed wire now have the NOBLUDGEON flag, which prevents accidentally damaging the cades while hitting them on harm intent. This also means you cannot attack anyone with it anymore, not like it really matters...
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
