### PR TITLE
Ice LZ2 QOL fence removal

### DIFF
--- a/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -31689,6 +31689,11 @@
 /obj/effect/alien/weeds/node,
 /turf/open/floor/plating,
 /area/ice_colony/underground/maintenance/central)
+"gkO" = (
+/obj/effect/turf_underlay/icefloor,
+/obj/structure/fence,
+/turf/closed/ice/thin/single,
+/area/ice_colony/exterior/surface/valley/southeast)
 "gly" = (
 /obj/effect/turf_underlay/icefloor,
 /obj/effect/alien/weeds/node,
@@ -32632,6 +32637,11 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/ice,
 /area/ice_colony/underground/maintenance/east)
+"nLv" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/obj/structure/fence,
+/turf/open/floor/plating/ground/ice,
+/area/ice_colony/exterior/surface/valley/southeast)
 "nLw" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/tile/dark/yellow2{
@@ -76702,7 +76712,7 @@ abN
 awL
 awL
 awL
-awL
+aMt
 nlt
 aUP
 aUP
@@ -76959,7 +76969,7 @@ aEC
 awL
 awL
 awL
-awL
+aMt
 nlt
 aUP
 aUP
@@ -77216,7 +77226,7 @@ awL
 awL
 awL
 awL
-awL
+aMt
 nlt
 aUP
 aUP
@@ -77473,7 +77483,7 @@ awL
 awL
 awL
 awL
-awL
+aMt
 nlt
 aUP
 aUP
@@ -77730,7 +77740,7 @@ awL
 awL
 awL
 awL
-awL
+aMt
 nlt
 aUP
 aUP
@@ -77987,7 +77997,7 @@ awL
 awL
 awL
 sGc
-sGc
+nLv
 nlt
 aUP
 aUP
@@ -82095,7 +82105,7 @@ azG
 azG
 awL
 awL
-awL
+aMt
 nlt
 awL
 aUP
@@ -82352,7 +82362,7 @@ awx
 azG
 azG
 azG
-awL
+aMt
 nlt
 awL
 aUP
@@ -82609,7 +82619,7 @@ awx
 awx
 awx
 azG
-awL
+aMt
 nlt
 awL
 awL
@@ -82866,7 +82876,7 @@ awx
 awx
 awx
 azG
-azG
+aus
 nlt
 sGc
 sGc
@@ -83123,11 +83133,11 @@ awx
 awx
 awx
 azG
-awL
-awL
-awL
-awL
-auW
+aMt
+aMt
+aMt
+aMt
+gkO
 aaU
 gtM
 aar

--- a/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -14938,10 +14938,6 @@
 	dir = 5
 	},
 /area/ice_colony/exterior/surface/landing_pad)
-"aYJ" = (
-/obj/structure/fence,
-/turf/open/floor/plating/ground/ice,
-/area/ice_colony/exterior/surface/landing_pad_external)
 "aYK" = (
 /turf/closed/ice/straight{
 	dir = 4
@@ -76708,7 +76704,7 @@ awL
 awL
 awL
 nlt
-aYJ
+aUP
 aUP
 aUP
 aUP
@@ -76965,7 +76961,7 @@ awL
 awL
 awL
 nlt
-aYJ
+aUP
 aUP
 aUP
 aUP
@@ -77222,7 +77218,7 @@ awL
 awL
 awL
 nlt
-aYJ
+aUP
 aUP
 aUP
 aUP
@@ -77479,7 +77475,7 @@ awL
 awL
 awL
 nlt
-aYJ
+aUP
 aUP
 aUP
 aUP
@@ -77736,7 +77732,7 @@ awL
 awL
 awL
 nlt
-aYJ
+aUP
 aUP
 aZr
 baC
@@ -77993,7 +77989,7 @@ awL
 sGc
 sGc
 nlt
-aYJ
+aUP
 aUP
 aUP
 aYa
@@ -78250,7 +78246,7 @@ awf
 mpH
 acv
 abN
-aYJ
+aUP
 aUP
 aUP
 aUP
@@ -82101,7 +82097,7 @@ awL
 awL
 awL
 nlt
-aMt
+awL
 aUP
 aWp
 bmg
@@ -82358,7 +82354,7 @@ azG
 azG
 awL
 nlt
-aMt
+awL
 aUP
 aUP
 aUP
@@ -82615,10 +82611,10 @@ awx
 azG
 awL
 nlt
-aMt
-aMt
-aMt
-aMt
+awL
+awL
+awL
+awL
 aaC
 aUP
 aUP


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
annoying fence gets in way of FOB drone

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
can build cades in spot the useless fence is in

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: moved fences on the ice colony LZ2 flanks, this means you can put cades where they used to be on the FOB drone now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
