### PR TITLE
Cocoon rebalance

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -133,6 +133,7 @@ MEDICAL_OFFICER, MEDICAL_RESEARCHER, SQUAD_LEADER, SQUAD_SPECIALIST, SQUAD_SMART
 
 #define MARINE_SPAWN_ORIGIN "xenos from marine spawn"
 #define PSY_DRAIN_ORIGIN "xenos from psy drained bodies"
+#define COCOON_ORIGIN "xenos from cocooned bodies"
 #define SILO_ORIGIN "xenos from silo generation"
 
 #define SQUAD_MAX_POSITIONS(total_positions) CEILING(total_positions / length(SSjob.active_squads), 1)

--- a/code/game/objects/items/cocoon.dm
+++ b/code/game/objects/items/cocoon.dm
@@ -16,7 +16,7 @@
 	///How much time the cocoon takes to deplete the life force of the marine
 	var/cocoon_life_time = 5 MINUTES
 	///How many psych points it is generating every 5 seconds (84 in total)
-	var/psych_points_output = 0.7
+	var/psych_points_output = 1.4
 	///How many larva points it gives when the timer is over
 	var/larva_points_reward = 1.5
 	///Standard busy check

--- a/code/game/objects/items/cocoon.dm
+++ b/code/game/objects/items/cocoon.dm
@@ -14,7 +14,7 @@
 	///What is inside the cocoon
 	var/mob/living/victim
 	///How much time the cocoon takes to deplete the life force of the marine
-	var/cocoon_life_time = 10 MINUTES
+	var/cocoon_life_time = 5 MINUTES
 	///How many psych points it is generating every 5 seconds (84 in total)
 	var/psych_points_output = 0.7
 	///How many larva points it gives when the timer is over

--- a/code/game/objects/items/cocoon.dm
+++ b/code/game/objects/items/cocoon.dm
@@ -15,8 +15,10 @@
 	var/mob/living/victim
 	///How much time the cocoon takes to deplete the life force of the marine
 	var/cocoon_life_time = 10 MINUTES
-	///How many psych points it is generating every 5 seconds
+	///How many psych points it is generating every 5 seconds (84 in total)
 	var/psych_points_output = 0.7
+	///How many larva points it gives when the timer is over
+	var/larva_points_reward = 1.5
 	///Standard busy check
 	var/busy = FALSE
 
@@ -58,6 +60,8 @@
 	if(anchored)
 		unanchor_from_nest()
 	if(must_release_victim)
+		var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
+		xeno_job.add_job_points(larva_points_reward, COCOON_ORIGIN)
 		release_victim()
 	update_icon()
 

--- a/code/game/objects/items/cocoon.dm
+++ b/code/game/objects/items/cocoon.dm
@@ -16,7 +16,7 @@
 	///How much time the cocoon takes to deplete the life force of the marine
 	var/cocoon_life_time = 10 MINUTES
 	///How many psych points it is generating every 5 seconds
-	var/psych_points_output = 1.2
+	var/psych_points_output = 0.7
 	///Standard busy check
 	var/busy = FALSE
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -115,6 +115,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/list/exp = list()
 	var/list/menuoptions = list()
 
+	///Automated vendor saved loadout list. Assoc list
+	var/list/loadout_list
+
 	// Hud tooltip
 	var/tooltips = TRUE
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Cocoon will give 80 points rather than 140, in 5 minutes
Also give 1.5 larva points if the cocoon reach maturity (5 minutes), or the alamo is hijacked. If a marine break the cocoon before, no larva points will be generated

Should not be merged without this https://github.com/tgstation/TerraGov-Marine-Corps/pull/6473

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Right now, if a marine push manage to kill all xeno silo but are dying in the process, it's a net loss, because their bodies will contribute to contribute to create more silos than there were originally.

I beleive this kind of situation should lead to no side clearly leading. Losing a silo should be a bit more significant than it is currently is.

With this PR, marines dying BUT succeeding in their mission means that the game is still very on, rather than being something the xenos can take a net profit

## Changelog
:cl:
balance: Cocoon will give 80 points rather than 140 points in 5 minutes. Also gives 1/8th of a larva at the end of the timer, this won't happen if a marine break open the cocoon first
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
