### PR TITLE
Xeno get a message when silos/turrets are built. It is also registered in the game log

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1031,14 +1031,14 @@
 	
 	to_chat(owner, "<span class='notice'>We build a new silo for [final_psych_cost] psy points.</span>")
 	SSpoints.xeno_points_by_hive[X.hivenumber] -= final_psych_cost
-	log_game("[owner] has built a silo in [AREACOORD_NO_Z(A)], spending [final_psych_cost] psy points in the process")
+	log_game("[owner] has built a silo in [AREACOORD(A)], spending [final_psych_cost] psy points in the process")
 	succeed_activate()
 	if(build_small_silo)
 		new /obj/structure/resin/silo/small_silo (get_step(A, SOUTHWEST))
-		xeno_message("[X.name] has built a small silo at [AREACOORD_NO_Z(A)]!", "xenoannounce", 5, X.hivenumber)
+		xeno_message("[X.name] has built a small silo at [get_area(A)]!", "xenoannounce", 5, X.hivenumber)
 		return
 	new /obj/structure/resin/silo (get_step(A, SOUTHWEST))
-	xeno_message("[X.name] has built a silo at [AREACOORD_NO_Z(A)]!", "xenoannounce", 5, X.hivenumber)
+	xeno_message("[X.name] has built a silo at [get_area(A)]!", "xenoannounce", 5, X.hivenumber)
 
 
 ////////////////////
@@ -1109,8 +1109,8 @@
 	new /obj/structure/resin/xeno_turret(get_turf(A), X.hivenumber)
 
 	SSpoints.xeno_points_by_hive[X.hivenumber] -= psych_cost
-	log_game("[owner] built a turret in [AREACOORD_NO_Z(A)], spending [psych_cost] psy points in the process")
-	xeno_message("[X.name] has built a new turret at [AREACOORD_NO_Z(A)]!", "xenoannounce", 5, X.hivenumber)
+	log_game("[owner] built a turret in [AREACOORD(A)], spending [psych_cost] psy points in the process")
+	xeno_message("[X.name] has built a new turret at [get_area(A)]!", "xenoannounce", 5, X.hivenumber)
 
 	succeed_activate()
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1031,11 +1031,14 @@
 	
 	to_chat(owner, "<span class='notice'>We build a new silo for [final_psych_cost] psy points.</span>")
 	SSpoints.xeno_points_by_hive[X.hivenumber] -= final_psych_cost
+	log_game("[owner] has built a silo in [get_area(A)], spending [final_psych_cost] psy points in the process")
 	succeed_activate()
 	if(build_small_silo)
 		new /obj/structure/resin/silo/small_silo (get_step(A, SOUTHWEST))
+		xeno_message("[X.name] has built a small silo at [get_area(A)]!", "xenoannounce", 5, X.hivenumber)
 		return
 	new /obj/structure/resin/silo (get_step(A, SOUTHWEST))
+	xeno_message("[X.name] has built a silo at [get_area(A)]!", "xenoannounce", 5, X.hivenumber)
 
 
 ////////////////////
@@ -1106,6 +1109,8 @@
 	new /obj/structure/resin/xeno_turret(get_turf(A), X.hivenumber)
 
 	SSpoints.xeno_points_by_hive[X.hivenumber] -= psych_cost
+	log_game("[owner] built a turret in get_area(A), spending [psych_cost] psy points in the process")
+	xeno_message("[X.name] has built a new turret get_area(A)!", "xenoannounce", 5, X.hivenumber)
 
 	succeed_activate()
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1031,14 +1031,14 @@
 	
 	to_chat(owner, "<span class='notice'>We build a new silo for [final_psych_cost] psy points.</span>")
 	SSpoints.xeno_points_by_hive[X.hivenumber] -= final_psych_cost
-	log_game("[owner] has built a silo in [get_area(A)], spending [final_psych_cost] psy points in the process")
+	log_game("[owner] has built a silo in [AREACOORD_NO_Z(A)], spending [final_psych_cost] psy points in the process")
 	succeed_activate()
 	if(build_small_silo)
 		new /obj/structure/resin/silo/small_silo (get_step(A, SOUTHWEST))
-		xeno_message("[X.name] has built a small silo at [get_area(A)]!", "xenoannounce", 5, X.hivenumber)
+		xeno_message("[X.name] has built a small silo at [AREACOORD_NO_Z(A)]!", "xenoannounce", 5, X.hivenumber)
 		return
 	new /obj/structure/resin/silo (get_step(A, SOUTHWEST))
-	xeno_message("[X.name] has built a silo at [get_area(A)]!", "xenoannounce", 5, X.hivenumber)
+	xeno_message("[X.name] has built a silo at [AREACOORD_NO_Z(A)]!", "xenoannounce", 5, X.hivenumber)
 
 
 ////////////////////
@@ -1109,8 +1109,8 @@
 	new /obj/structure/resin/xeno_turret(get_turf(A), X.hivenumber)
 
 	SSpoints.xeno_points_by_hive[X.hivenumber] -= psych_cost
-	log_game("[owner] built a turret in get_area(A), spending [psych_cost] psy points in the process")
-	xeno_message("[X.name] has built a new turret at [get_area(A)]!", "xenoannounce", 5, X.hivenumber)
+	log_game("[owner] built a turret in [AREACOORD_NO_Z(A)], spending [psych_cost] psy points in the process")
+	xeno_message("[X.name] has built a new turret at [AREACOORD_NO_Z(A)]!", "xenoannounce", 5, X.hivenumber)
 
 	succeed_activate()
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1110,7 +1110,7 @@
 
 	SSpoints.xeno_points_by_hive[X.hivenumber] -= psych_cost
 	log_game("[owner] built a turret in get_area(A), spending [psych_cost] psy points in the process")
-	xeno_message("[X.name] has built a new turret get_area(A)!", "xenoannounce", 5, X.hivenumber)
+	xeno_message("[X.name] has built a new turret at [get_area(A)]!", "xenoannounce", 5, X.hivenumber)
 
 	succeed_activate()
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

So you can know when a hivelord is puttin turrets everywhere like it's TF2. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Xeno message is sent to the hive when silos/turrets are built
admin: Psy points spent are now saved in game log
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
