### PR TITLE
Fix a gap in ice colony containment shutters that wraith could phase through

### DIFF
--- a/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -43445,7 +43445,7 @@ aaa
 aaa
 aaa
 bSw
-aaG
+iII
 iII
 vrh
 vrh


### PR DESCRIPTION
## Changelog
:cl:
fix: Wraith can't phase into ice colony LZ1 through a gap in the shutters
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
