### PR TITLE
Pistol Lace Nerf V1

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1691,6 +1691,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	slot = "muzzle" //so you cannot have this and RC at once aka balance
 	flags_attach_features = ATTACH_REMOVABLE|ATTACH_ACTIVATION
 	attachment_action_type = /datum/action/item_action/toggle
+	recoil_unwielded_mod = 10
 
 /obj/item/attachable/lace/activate_attachment(mob/living/user, turn_off)
 	if(lace_deployed)


### PR DESCRIPTION
## Please Read:
Do note this is a extreme band-aid PR, I'm avoiding as much as possible a real nerf to any guns.
I'm going to see if I can avoid this PR and instead simply nerf duel welding



## About The Pull Request

Gives the Pistol Lace 10 recoil if one handed. disallowing duel Tp-14s via massive recoil.
This is also apart of a test.
There are 2 PRs, V2 and this one, V1, players may vote on which gets merged, though the final choice is made via I and the Maintainers.
V2: https://github.com/tgstation/TerraGov-Marine-Corps/pull/6569

## Why It's Good For The Game

Some have proven to me that this is needed.
The recoil is about the same as if you'd use a stock Metaba one handed.
And if you are still crazy about using it, you may as use a PPSH or another type of Sub-machine gun in which you can improve the scatter and recoil of.

## Changelog
:cl:
balance: Pistol Lace unwielded has 10 recoil, comparable to a stock one handed Metaba.
/:cl:
