### PR TITLE
Pistol Lace nerf V2

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1691,6 +1691,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	slot = "muzzle" //so you cannot have this and RC at once aka balance
 	flags_attach_features = ATTACH_REMOVABLE|ATTACH_ACTIVATION
 	attachment_action_type = /datum/action/item_action/toggle
+	size_mod = 1
 
 /obj/item/attachable/lace/activate_attachment(mob/living/user, turn_off)
 	if(lace_deployed)


### PR DESCRIPTION
## Please Read:
Do note this is a extreme band-aid PR, I'm avoiding as much as possible a real nerf to any guns.
I'm going to see if I can avoid this PR and instead simply nerf duel welding. 


## About The Pull Request
Gives the Pistol Lace a increase by size of 1, disallowing any gun with it on to be stored in any bags or pouches.
This PR is apart of a test.
There are 2 PRs, V1 and this one, V2, players may vote on which gets merged, though the final choice is made via I and the Maintainers.
V1: https://github.com/tgstation/TerraGov-Marine-Corps/pull/6568

## Why It's Good For The Game
A few have proven to me that they wanted this, and so I'll give it to them.
You'll only be able to use it now in belt and armor slots without belts if you still want to duel wield with the attachment in question.


## Changelog
:cl:
balance: Increases Pistol Lace size by 1, making it unable to be put into bags or pouches of any kind.
/:cl: