### PR TITLE
50HP buff to metal cades so they aren't helpless againsts crushers

### DIFF
--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -420,7 +420,7 @@
 	name = "metal barricade"
 	desc = "A sturdy and easily assembled barricade made of metal plates, often used for quick fortifications. Use a blowtorch to repair."
 	icon_state = "metal_0"
-	max_integrity = 200
+	max_integrity = 250
 	soft_armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 0, "fire" = 80, "acid" = 40)
 	coverage = 128
 	stack_type = /obj/item/stack/sheet/metal


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Increased metal barricade base health to 250 making it 300 when wired
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Metal barricades are the standard barricade option for engineers. Metal is more expensive than sandbags(which have higher health) and metal is a mandatory material since other cades need barbed wire. Despite being upgradable the 200HP makes it always worse than sandbags in every scenario. The main point of metal cades is that they are repairable for free but the low HP makes them drop to "unrepairable" health with a single crusher charge and since frontline cades are mostly a single cadeline that makes the entire cadeline fall.

This PR is made assuming the current state of meta assures that when a marine push fails/wipes the FOB will not hold the xeno wave since they will likely control most of the map and have extra pools up which will make them outnumber marines and win unless a serious comeback happens. As such I'm hoping that FOB "autism" forts will not be a problem and the overall impact of frontline cades increases without making it too strong.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Increased metal barricade health points by 50
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
