### PR TITLE
Tesla Is now 0.1 shell speed, lowers total drain time, and slowdown up.

### DIFF
--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -173,8 +173,8 @@
 		if(living in blacklistmobs)
 			continue
 		source.beam(living, icon_state="lightning[rand(1,12)]", time = 3, maxdistance = zap_range + 2)
-		living.apply_status_effect(/datum/status_effect/noplasmaregen, 30 SECONDS/length(.))
-		living.apply_status_effect(/datum/status_effect/plasmadrain, 30 SECONDS/length(.))
+		living.apply_status_effect(/datum/status_effect/noplasmaregen, 20 SECONDS/length(.))
+		living.apply_status_effect(/datum/status_effect/plasmadrain, 20 SECONDS/length(.))
 		living.adjust_stagger(1)
-		living.add_slowdown(0.5)
+		living.add_slowdown(2)
 		log_attack("[living] was zapped by [source]")

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1225,6 +1225,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	hud_state = "taser"
 	hud_state_empty = "battery_empty"
 	flags_ammo_behavior = AMMO_ENERGY|AMMO_CHAINING
+	shell_speed = 0.1
 	damage = 20
 	penetration = 20
 	bullet_color = COLOR_TESLA_BLUE


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Lowers tesla shell speed from 2 to 0.1, lowers drain, and plasma regen disable from 30 to 20, and increases the slow telsagun has 0.5 to 2.
I copypasted code onto beam.dm, probably gonna get yelled by tivi.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No one uses tesla since plasma nades outperform it, even with the stagger buff I did to it, lowering the speed lets it stagger, drain, and slow xenos for longer.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Lowers tesla shell speed (2 to 0.1), lowers drain, and plasma regen disable (30 to 20), and increases the slow telsagun has (0.5 to 2)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
