### PR TITLE
disables valkyrie modules

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -761,7 +761,6 @@ ARMOR
 /datum/supply_packs/armor/modular/attachments/mixed
 	name = "Jaeger experimental mark 2 modules"
 	contains = list(
-		/obj/item/armor_module/attachable/valkyrie_autodoc,
 		/obj/item/armor_module/attachable/fire_proof,
 		/obj/item/armor_module/attachable/tyr_extra_armor,
 		/obj/item/armor_module/attachable/mimir_environment_protection,
@@ -776,13 +775,6 @@ ARMOR
 		/obj/item/armor_module/attachable/better_shoulder_lamp,
 	)
 	cost = 10
-
-/datum/supply_packs/armor/modular/attachments/valkyrie_autodoc
-	name = "Jaeger valkyrie modules"
-	contains = list(
-		/obj/item/armor_module/attachable/valkyrie_autodoc,
-	)
-	cost = 12
 
 /datum/supply_packs/armor/modular/attachments/fire_proof
 	name = "Jaeger surt modules"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
i don't want this merged, but i do want it tested after seeing shit like this 
![image](https://user-images.githubusercontent.com/46353991/114462555-35428280-9bb1-11eb-9693-70b5ba27c229.png)
for refusing to spend all my points as captain on fucking valkyrie modules because i wanted to actually try something else roundstart for once
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
i want to see if people will cater to more interesting roundstart pick and options rather than spending 120 points on fucking valkyrie modules, though it might just be better to nerf the module itself
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: valkyrie modules disabled
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
