### PR TITLE
No Siloless collapse until 12:33

### DIFF
--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -129,5 +129,5 @@
 #define SILO_PRICE 1200
 #define XENO_TURRET_PRICE 150
 
-//The minimum round time before siloless timer can start (13:00)
-#define MINIMUM_TIME_SILO_LESS_COLLAPSE 36000 
+//The minimum round time before siloless timer can start (12:33)
+#define MINIMUM_TIME_SILO_LESS_COLLAPSE 18000 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes the minimum time for siloless collapse from 13:03 as it is now, to 12:33 instead. 

## Why It's Good For The Game

A fairly popular strategy for hives is to not place pools until absolutely necessary, so as to deny marines the existence of their objective.  There isn't a lot marines can do against this strategy except maybe just go maximum cadehug, and that's just not fun for anyone. There will, however, still be time to actually place them, instead of having to rush to do it. 

## Changelog
:cl:
balance: No more siloless collapse before 12:33! If you didn't put a silo before that time, the timer will show up even if you never lost any silos. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
