### PR TITLE
Splints require additional hits to break based on medical skill

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -278,6 +278,7 @@
 	icon_state = "splint"
 	amount = 5
 	max_amount = 5
+	var/applied_splint_stacks = 1
 
 
 /obj/item/stack/medical/splint/attack(mob/living/carbon/M, mob/user)
@@ -314,5 +315,5 @@
 			user.visible_message("<span class='warning'>[user] starts to apply [src] to their [limb].</span>",
 			"<span class='notice'>You start to apply [src] to your [limb], hold still.</span>")
 
-		if(affecting.apply_splints(src, user, M)) // Referenced in external organ helpers.
+		if(affecting.apply_splints(src, applied_splint_stacks, user, M)) // Referenced in external organ helpers.
 			use(1)

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -315,5 +315,5 @@
 			user.visible_message("<span class='warning'>[user] starts to apply [src] to their [limb].</span>",
 			"<span class='notice'>You start to apply [src] to your [limb], hold still.</span>")
 
-		if(affecting.apply_splints(src, applied_splint_stacks, user, M)) // Referenced in external organ helpers.
+		if(affecting.apply_splints(src, user == M ? (applied_splint_stacks*user.skills.getRating("medical") - 1) : applied_splint_stacks*user.skills.getRating("medical"), user, M)) // Referenced in external organ helpers.
 			use(1)

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -278,7 +278,8 @@
 	icon_state = "splint"
 	amount = 5
 	max_amount = 5
-	var/applied_splint_stacks = 1
+	///How much splint health per medical skill is applied
+	var/applied_splint_health = 15
 
 
 /obj/item/stack/medical/splint/attack(mob/living/carbon/M, mob/user)
@@ -315,5 +316,5 @@
 			user.visible_message("<span class='warning'>[user] starts to apply [src] to their [limb].</span>",
 			"<span class='notice'>You start to apply [src] to your [limb], hold still.</span>")
 
-		if(affecting.apply_splints(src, user == M ? (applied_splint_stacks*user.skills.getRating("medical") - 1) : applied_splint_stacks*user.skills.getRating("medical"), user, M)) // Referenced in external organ helpers.
+		if(affecting.apply_splints(src, user == M ? (applied_splint_health*max(user.skills.getRating("medical") - 1, 0)) : applied_splint_health*user.skills.getRating("medical"), user, M)) // Referenced in external organ helpers.
 			use(1)

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -1058,7 +1058,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		to_chat(user, "<span class='warning'>There's nothing there to splint!</span>")
 		return FALSE
 
-	if(limb_status & LIMB_SPLINTED)
+	if(limb_status & LIMB_SPLINTED && applied_stacks <= splint_stacks)
 		to_chat(user, "<span class='warning'>This limb is already splinted!</span>")
 		return FALSE
 

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -340,7 +340,7 @@
 		wounds += I
 		owner.custom_pain("You feel something rip in your [display_name]!", 1)
 
-	if(limb_status & LIMB_SPLINTED && damage > 5 && prob(50 + damage * 2.5)) //If they have it splinted, the splint won't hold.
+	if(limb_status & LIMB_SPLINTED && damage > 10) //If they have it splinted and no splint stacks, the splint won't hold.
 		if(splint_stacks <= 0)
 			remove_limb_flags(LIMB_SPLINTED)
 			to_chat(owner, "<span class='userdanger'>The splint on your [display_name] comes apart!</span>")

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -19,7 +19,7 @@
 	var/last_dam = -1
 	var/supported = FALSE
 	///How many instances of damage the limb can take before its splints fall off
-	var/splint_stacks = 0
+	var/splint_health = 0
 
 	var/datum/armor/soft_armor
 	var/datum/armor/hard_armor
@@ -340,12 +340,12 @@
 		wounds += I
 		owner.custom_pain("You feel something rip in your [display_name]!", 1)
 
-	if(limb_status & LIMB_SPLINTED && damage > 10) //If they have it splinted and no splint stacks, the splint won't hold.
-		if(splint_stacks <= 0)
+	if(limb_status & LIMB_SPLINTED) //If they have it splinted and no splint health, the splint won't hold.
+		if(splint_health <= 0)
 			remove_limb_flags(LIMB_SPLINTED)
 			to_chat(owner, "<span class='userdanger'>The splint on your [display_name] comes apart!</span>")
 		else
-			splint_stacks -= 1
+			splint_health = max(splint_health - damage, 0)
 
 	// first check whether we can widen an existing wound
 	var/datum/wound/W
@@ -1049,7 +1049,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			new /datum/effect_system/spark_spread(owner, owner, 5, 0, TRUE, 1 SECONDS)
 
 
-/datum/limb/proc/apply_splints(obj/item/stack/medical/splint/S, applied_stacks, mob/living/user, mob/living/carbon/human/target)
+/datum/limb/proc/apply_splints(obj/item/stack/medical/splint/S, applied_health, mob/living/user, mob/living/carbon/human/target)
 
 	if(!istype(user))
 		return
@@ -1058,7 +1058,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		to_chat(user, "<span class='warning'>There's nothing there to splint!</span>")
 		return FALSE
 
-	if(limb_status & LIMB_SPLINTED && applied_stacks <= splint_stacks)
+	if(limb_status & LIMB_SPLINTED && applied_health <= splint_health)
 		to_chat(user, "<span class='warning'>This limb is already splinted!</span>")
 		return FALSE
 
@@ -1079,7 +1079,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		"[text1]",
 		"[text2]")
 		add_limb_flags(LIMB_SPLINTED)
-		splint_stacks = max(splint_stacks, applied_stacks)
+		splint_health = applied_health
 		return TRUE
 
 

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -18,6 +18,8 @@
 	var/max_size = 0
 	var/last_dam = -1
 	var/supported = FALSE
+	///How many instances of damage the limb can take before its splints fall off
+	var/splint_stacks = 0
 
 	var/datum/armor/soft_armor
 	var/datum/armor/hard_armor
@@ -339,8 +341,11 @@
 		owner.custom_pain("You feel something rip in your [display_name]!", 1)
 
 	if(limb_status & LIMB_SPLINTED && damage > 5 && prob(50 + damage * 2.5)) //If they have it splinted, the splint won't hold.
-		remove_limb_flags(LIMB_SPLINTED)
-		to_chat(owner, "<span class='userdanger'>The splint on your [display_name] comes apart!</span>")
+		if(splint_stacks <= 0)
+			remove_limb_flags(LIMB_SPLINTED)
+			to_chat(owner, "<span class='userdanger'>The splint on your [display_name] comes apart!</span>")
+		else
+			splint_stacks -= 1
 
 	// first check whether we can widen an existing wound
 	var/datum/wound/W
@@ -1044,7 +1049,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			new /datum/effect_system/spark_spread(owner, owner, 5, 0, TRUE, 1 SECONDS)
 
 
-/datum/limb/proc/apply_splints(obj/item/stack/medical/splint/S, mob/living/user, mob/living/carbon/human/target)
+/datum/limb/proc/apply_splints(obj/item/stack/medical/splint/S, applied_stacks, mob/living/user, mob/living/carbon/human/target)
 
 	if(!istype(user))
 		return
@@ -1074,6 +1079,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		"[text1]",
 		"[text2]")
 		add_limb_flags(LIMB_SPLINTED)
+		splint_stacks = max(splint_stacks, applied_stacks)
 		return TRUE
 
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gives a splint health variable to limbs. Splint health gets decreased every time a splinted limb takes damage by the amount of damage and the splint gets removed at 0 health. Applied splint health is 15 per medical skill rank. If you splint yourself, you get 15 less splint health, but the amount can't be below 0.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
As it stands right now valk's autosplint feature makes it a bit too convenient over the other modules, this should bring up the bottom line, while valk still has the benefits of instant and infinite splints.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: splints require taking a certain amount of damage to break, based on medical skill of the one applying it. Anyone with medical skill adds 15 splint health per medical skill rank. If you splint yourself, this is reduced by 15, but can't be lower than 0.
balance: removes small chance for splints to not be damaged
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
