### PR TITLE
Doubles splint count, proper splint fall threshold, faster analyzer speeds, better self splint.

### DIFF
--- a/code/game/objects/items/scanners.dm
+++ b/code/game/objects/items/scanners.dm
@@ -83,7 +83,7 @@ REAGENT SCANNER
 		return
 	if(user.skills.getRating("medical") < skill_threshold)
 		to_chat(user, "<span class='warning'>You start fumbling around with [src]...</span>")
-		var/fduration = max(SKILL_TASK_AVERAGE - (1 SECONDS * user.skills.getRating("medical")), 0)
+		var/fduration = max(SKILL_TASK_EASY - (1 SECONDS * user.skills.getRating("medical")), 0)
 		if(!do_mob(user, M, fduration, BUSY_ICON_UNSKILLED))
 			return
 	if(isxeno(M))

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -276,8 +276,8 @@
 	name = "medical splints"
 	singular_name = "medical splint"
 	icon_state = "splint"
-	amount = 5
-	max_amount = 5
+	amount = 10
+	max_amount = 10
 
 
 /obj/item/stack/medical/splint/attack(mob/living/carbon/M, mob/user)

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -338,7 +338,7 @@
 		wounds += I
 		owner.custom_pain("You feel something rip in your [display_name]!", 1)
 
-	if(limb_status & LIMB_SPLINTED && damage > 5 && prob(50 + damage * 2.5)) //If they have it splinted, the splint won't hold.
+	if(limb_status & LIMB_SPLINTED && get_damage() > 40) //If they have it splinted, and the damage is 30 or above brute, burn, or brute + burn, the splint won't hold.
 		remove_limb_flags(LIMB_SPLINTED)
 		to_chat(owner, "<span class='userdanger'>The splint on your [display_name] comes apart!</span>")
 
@@ -1062,7 +1062,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	var/text2 = "<span class='notice'>You finish applying [S] to [target]'s [display_name].</span>"
 
 	if(target == user) //If self splinting, multiply delay by 4
-		delay *= 4
+		delay *= 2
 		text1 = "<span class='warning'>[user] successfully applies [S] to their [display_name].</span>"
 		text2 = "<span class='notice'>You successfully apply [S] to your [display_name].</span>"
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Splints go from 5 to a stack to 10 to a stack. Splints now fall off from 40 brute, 40 burn, or 20 burn + 20 brute. Analyzer now doesn't take a century to use on yourself. Self splinting now is 2x faster than before. Inspired by #6578 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Makes reliance on the crutch that is valk nonexistant, while still keeping the issue of permanent wounds. You will still have to evac and/or retreat to a MO / Synth if you wish to take care of broken bones. However, it is no longer as debilitating, as splints aren't RNG based anymore and actually have a damage threshold, self scanning yourself for issues is no longer a pain, and self splinting no longer takes a year.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Self splinting now 2x faster.
balance: Analyzing using a health analyzer is much faster now.
balance: Splints are now 10 stack instead of 5 stack.
balance: Splints now fall off at a combined damage threshold of 40 instead of RNG based; this means 20 burn 20 brute, or 40 brute, or 40 burn.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
