### PR TITLE
Prae spit extinguishes fire

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1624,17 +1624,17 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	var/turf/T = get_turf(M)
 	if(!T)
 		T = get_turf(P)
-	for (var/atom in T)
-		if(istype(atom, /obj/flamer_fire))
-			var/obj/flamer_fire/FF = atom
+	for (var/thing in T)
+		if(istype(thing, /obj/flamer_fire))
+			var/obj/flamer_fire/FF = thing
 			if(FF.firelevel > 20)
 				FF.firelevel -= 20
 				FF.updateicon()
 				continue
-			qdel(atom)
+			qdel(thing)
 			continue
-		if(istype(atom, /mob/living))
-			var/mob/living/target = atom
+		if(istype(thing, /mob/living))
+			var/mob/living/target =thing
 			target.ExtinguishMob()
 	drop_nade(T)
 
@@ -1646,17 +1646,17 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	if(O.density && !(O.flags_atom & ON_BORDER))
 		T = get_turf(get_step(T, turn(P.dir, 180))) //If the object is dense and not a border object like barricades, we instead drop in the location just prior to the target
 
-	for (var/atom in T)
-		if(istype(atom, /obj/flamer_fire))
-			var/obj/flamer_fire/FF = atom
+	for (var/thing in T)
+		if(istype(thing, /obj/flamer_fire))
+			var/obj/flamer_fire/FF = thing
 			if(FF.firelevel > 20)
 				FF.firelevel -= 20
 				FF.updateicon()
 				continue
-			qdel(atom)
+			qdel(thing)
 			continue
-		if(istype(atom, /mob/living))
-			var/mob/living/target = atom
+		if(istype(thing, /mob/living))
+			var/mob/living/target = thing
 			target.ExtinguishMob()
 
 	drop_nade(T)
@@ -1667,17 +1667,17 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 		T = get_turf(P)
 	if(isclosedturf(T))
 		T = get_turf(get_step(T, turn(P.dir, 180))) //If the turf is closed, we instead drop in the location just prior to the turf
-	for (var/atom in T)
-		if(istype(atom, /obj/flamer_fire))
-			var/obj/flamer_fire/FF = atom
+	for (var/thing in T)
+		if(istype(thing, /obj/flamer_fire))
+			var/obj/flamer_fire/FF = thing
 			if(FF.firelevel > 20)
 				FF.firelevel -= 20
 				FF.updateicon()
 				continue
-			qdel(atom)
+			qdel(thing)
 			continue
-		if(istype(atom, /mob/living))
-			var/mob/living/target = atom
+		if(istype(thing, /mob/living))
+			var/mob/living/target = thing
 			target.ExtinguishMob()
 	drop_nade(T)
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1215,7 +1215,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	max_range = 15
 	accurate_range = 10
 	bullet_color = COLOR_VIVID_YELLOW
-	
+
 /datum/ammo/energy/taser/on_hit_mob(mob/M,obj/projectile/P)
 	staggerstun(M, P, stun = 10)
 
@@ -1624,17 +1624,17 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	var/turf/T = get_turf(M)
 	if(!T)
 		T = get_turf(P)
-	for (var/A in T)		
-		if(istype(A, /obj/flamer_fire))
-			var/obj/flamer_fire/FF = A
+	for (var/atom in T)
+		if(istype(atom, /obj/flamer_fire))
+			var/obj/flamer_fire/FF = atom
 			if(FF.firelevel > 20)
 				FF.firelevel -= 20
 				FF.updateicon()
 				continue
-			qdel(A)
+			qdel(atom)
 			continue
-		if(istype(A, /mob/living))
-			var/mob/living/target = A
+		if(istype(atom, /mob/living))
+			var/mob/living/target = atom
 			target.ExtinguishMob()
 	drop_nade(T)
 
@@ -1646,17 +1646,17 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	if(O.density && !(O.flags_atom & ON_BORDER))
 		T = get_turf(get_step(T, turn(P.dir, 180))) //If the object is dense and not a border object like barricades, we instead drop in the location just prior to the target
 
-	for (var/A in T)		
-		if(istype(A, /obj/flamer_fire))
-			var/obj/flamer_fire/FF = A
+	for (var/atom in T)
+		if(istype(atom, /obj/flamer_fire))
+			var/obj/flamer_fire/FF = atom
 			if(FF.firelevel > 20)
 				FF.firelevel -= 20
 				FF.updateicon()
 				continue
-			qdel(A)
+			qdel(atom)
 			continue
-		if(istype(A, /mob/living))
-			var/mob/living/target = A
+		if(istype(atom, /mob/living))
+			var/mob/living/target = atom
 			target.ExtinguishMob()
 
 	drop_nade(T)
@@ -1667,17 +1667,17 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 		T = get_turf(P)
 	if(isclosedturf(T))
 		T = get_turf(get_step(T, turn(P.dir, 180))) //If the turf is closed, we instead drop in the location just prior to the turf
-	for (var/A in T)		
-		if(istype(A, /obj/flamer_fire))
-			var/obj/flamer_fire/FF = A
+	for (var/atom in T)
+		if(istype(atom, /obj/flamer_fire))
+			var/obj/flamer_fire/FF = atom
 			if(FF.firelevel > 20)
 				FF.firelevel -= 20
 				FF.updateicon()
-			else
-				qdel(A)
+				continue
+			qdel(atom)
 			continue
-		if(istype(A, /mob/living))
-			var/mob/living/target = A
+		if(istype(atom, /mob/living))
+			var/mob/living/target = atom
 			target.ExtinguishMob()
 	drop_nade(T)
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1624,6 +1624,18 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	var/turf/T = get_turf(M)
 	if(!T)
 		T = get_turf(P)
+	for (var/A in T)		
+		if(istype(A, /obj/flamer_fire))
+			var/obj/flamer_fire/FF = A
+			if(FF.firelevel > 20)
+				FF.firelevel -= 20
+				FF.updateicon()
+				continue
+			qdel(A)
+			continue
+		if(istype(A, /mob/living))
+			var/mob/living/target = A
+			target.ExtinguishMob()
 	drop_nade(T)
 
 /datum/ammo/xeno/acid/heavy/on_hit_obj(obj/O,obj/projectile/P)
@@ -1634,16 +1646,39 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	if(O.density && !(O.flags_atom & ON_BORDER))
 		T = get_turf(get_step(T, turn(P.dir, 180))) //If the object is dense and not a border object like barricades, we instead drop in the location just prior to the target
 
+	for (var/A in T)		
+		if(istype(A, /obj/flamer_fire))
+			var/obj/flamer_fire/FF = A
+			if(FF.firelevel > 20)
+				FF.firelevel -= 20
+				FF.updateicon()
+				continue
+			qdel(A)
+			continue
+		if(istype(A, /mob/living))
+			var/mob/living/target = A
+			target.ExtinguishMob()
+
 	drop_nade(T)
 
 
 /datum/ammo/xeno/acid/heavy/on_hit_turf(turf/T,obj/projectile/P)
 	if(!T)
 		T = get_turf(P)
-
 	if(isclosedturf(T))
 		T = get_turf(get_step(T, turn(P.dir, 180))) //If the turf is closed, we instead drop in the location just prior to the turf
-
+	for (var/A in T)		
+		if(istype(A, /obj/flamer_fire))
+			var/obj/flamer_fire/FF = A
+			if(FF.firelevel > 20)
+				FF.firelevel -= 20
+				FF.updateicon()
+			else
+				qdel(A)
+			continue
+		if(istype(A, /mob/living))
+			var/mob/living/target = A
+			target.ExtinguishMob()
 	drop_nade(T)
 
 /datum/ammo/xeno/acid/heavy/do_at_max_range(obj/projectile/P)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Will extinguish all mobs hit by the projectile (including human, so double edged sword). Will also remove some fire stacks from the tile, or extinguish the turf if the fire is weak enough

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Marines have more and more way of setting xenos on fire. 
Cas was introduced, then the vali, then the plasma pistol, then the latest mortar buff.
Meanwhile, xeno keeps having only two way of "contering" flamers, acid wells (terrible, cost so much plasma, so long to refill),
acid spray(usefull)
and of course hivelord, with jelly. 

Basicly, if you are against flamer, you NEED an hivelord, and sometimes you just can't have it with your comp.

This gives prae some utility against flames, nothing too crazy. 
This will also make prae as usefull to counter fire as spitter; 30 seconds between each spray is not enough to extinguish players, unlike spitter who can do it reliably. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Prae spit extinguishes fire
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
