### PR TITLE
Queen Screech Buff

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -119,7 +119,7 @@
 	mechanics_text = "A large area knockdown that causes pain and screen-shake."
 	ability_name = "screech"
 	plasma_cost = 250
-	cooldown_timer = 100 SECONDS
+	cooldown_timer = 60 SECONDS
 	keybind_flags = XACT_KEYBIND_USE_ABILITY
 	keybind_signal = COMSIG_XENOABILITY_SCREECH
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

With the constant nerfs to queen's primary unga ball handling tool, I thought its time to at least buff it in terms of CD; Queen screech CD is lowered by almost half from 100 seconds to 60 seconds.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Queen screech used to be really, REALLY powerful; but has since had constant nerfs. From the actual stun removed and made a drop stun (something done ages ago), to removal of the stam crit, queen screech now is just there to setting up team plays as the stun is momentary. It isn't good at doing that, however, because the CD for queen screech is almost the same as its had since the start yet is overall weaker. This should let queens who know what they are doing setup plays much better against good marine players.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Queen screech CD from 100 seconds to 60 seconds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
