### PR TITLE
Small silo linked with pop

### DIFF
--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -131,5 +131,7 @@
 #define SILO_PRICE 1200
 #define XENO_TURRET_PRICE 150
 
+#define SMALL_SILO_MAXIMUM_PLAYER_COUNT 30
+
 //The minimum round time before siloless timer can start (13:00)
 #define MINIMUM_TIME_SILO_LESS_COLLAPSE 36000 

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1003,7 +1003,7 @@
 	var/mob/living/carbon/xenomorph/X = owner
 	if(X.selected_ability == src)
 		if(get_active_player_count() < SMALL_SILO_MAXIMUM_PLAYER_COUNT)
-			to_chat(X, "<span class ='notice'>There is too many players to place a small silo</span>")
+			to_chat(X, "<span class ='notice'>There are too many players to place a small silo</span>")
 			build_small_silo = FALSE
 			return
 		build_small_silo = !build_small_silo

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1002,6 +1002,10 @@
 /datum/action/xeno_action/activable/build_silo/action_activate()
 	var/mob/living/carbon/xenomorph/X = owner
 	if(X.selected_ability == src)
+		if(get_active_player_count() < SMALL_SILO_MAXIMUM_PLAYER_COUNT)
+			to_chat(X, "<span class ='notice'>There is too many players to place a small silo</span>")
+			build_small_silo = FALSE
+			return
 		build_small_silo = !build_small_silo
 		var/silo_type = build_small_silo ? "small" : "regular"
 		to_chat(X, "<span class ='notice'> You will now build a [silo_type] silo </span>")


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You can no longer build small silos if the active pop of the server is superior to 30

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The full small silo start for xenos is too good, and more important, it is actively discouraging marines to push. 
I'm keeping small silos cause they are nice to have in small pop

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Can no longer place small silos in medium-high pop
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
