### PR TITLE
Pool pinpointer is gone. Welcome psy tracker

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -640,3 +640,7 @@
 #define COMSIG_GET_BURST_FIRE "get_burst_fire"
 	#define BURST_FIRING (1<<0)
 #define COMSIG_DISABLE_BURST_FIRE "disable_burst_fire"
+
+//Signals for psy tracker
+#define COMSIG_SILO_DESTROYED "silo destroyed"
+#define COMSIG_SILO_CREATED "silo created"

--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -85,10 +85,83 @@
 			continue
 		to_chat(user, "Extreme danger.  Arming signal detected.   Time remaining: [bomb.timeleft]")
 
-/obj/item/pinpointer/pool
-	name = "pool pinpointer"
-	desc = "A pinpointer able to detect the psychic energy emmaning from spawning pools"
+/obj/item/psy_tracker
+	name = "psy tracker"
+	desc = "A pinpointer able to detect the psychic energy emmaning from resin silos, and from the hive ruler if there are no silos"
+	icon_state = "pinoff"
+	flags_atom = CONDUCT
+	flags_equip_slot = ITEM_SLOT_BELT
+	w_class = WEIGHT_CLASS_TINY
+	item_state = "electronic"
+	throw_speed = 4
+	throw_range = 20
+	/// The atom tracked by the psy tracker
+	var/atom/target
 
-/obj/item/pinpointer/pool/Initialize()
+/obj/item/psy_tracker/Initialize()
 	. = ..()
-	tracked_list = GLOB.xeno_resin_silos
+	RegisterSignal(SSdcs, COMSIG_SILO_CREATED, .proc/silo_created)
+	RegisterSignal(SSdcs, COMSIG_SILO_DESTROYED, .proc/silo_destroyed)
+
+/obj/item/psy_tracker/proc/set_target(atom/_target)
+	if(target == _target)
+		return
+	if(target)
+		UnregisterSignal(target, COMSIG_PARENT_QDELETING)
+	target = _target
+	if(target)
+		START_PROCESSING(SSobj, src)
+		RegisterSignal(target, COMSIG_PARENT_QDELETING, .proc/clean_target)
+
+/// Signal handler to prevent hard del of target
+/obj/item/psy_tracker/proc/clean_target()
+	SIGNAL_HANDLER
+	set_target(null)
+	STOP_PROCESSING(SSobj, src)
+
+/// Signal handler to notify the psy tracker user that a new silo has been created
+/obj/item/psy_tracker/proc/silo_created()
+	SIGNAL_HANDLER
+	if(!istype(target, /obj/structure/resin/silo))
+		set_target(null)
+	if(!is_ground_level(loc.z))
+		return
+	say("A new silo has been created, total number of psy sources : [GLOB.xeno_resin_silos.len]")
+
+/// Signal handler to notify the psy tracker user that a silo has been destroyed
+/obj/item/psy_tracker/proc/silo_destroyed(datum/source)
+	SIGNAL_HANDLER
+	if(!is_ground_level(loc.z))
+		return
+	say("A silo has been destroyed, total number of psy sources : [GLOB.xeno_resin_silos.len]")
+
+/obj/item/psy_tracker/attack_self(mob/living/user)
+	if(!is_ground_level(loc.z))
+		to_chat(user, "<span class='warning'>No signals has been detected, interferences from ship is the most likely cause.</span>")
+		return
+	if(!GLOB.xeno_resin_silos.len)
+		to_chat(user, "<span class='warning'>No silo signal detected.</span>")
+		var/datum/hive_status/normal_hive = GLOB.hive_datums[XENO_HIVE_NORMAL]
+		if(!normal_hive.living_xeno_ruler)
+			return
+		to_chat(user, "<span class='warning'>Able to track a weaker mobile psy source!</span>")
+		set_target(normal_hive.living_xeno_ruler)
+		return
+	set_target(tgui_input_list(user, "Select the silo you wish to track.", "Psy tracker", GLOB.xeno_resin_silos))
+
+/obj/item/psy_tracker/process()
+	if(!target)
+		icon_state = "pinonnull"
+		STOP_PROCESSING(SSobj, src)
+		return
+
+	setDir(get_dir(src, target))
+	switch(get_dist(src, target))
+		if(0)
+			icon_state = "pinondirect"
+		if(1 to 8)
+			icon_state = "pinonclose"
+		if(9 to 16)
+			icon_state = "pinonmedium"
+		if(16 to INFINITY)
+			icon_state = "pinonfar"

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -57,7 +57,7 @@
 	. = ..()
 	new /obj/item/binoculars/tactical(src)
 	new /obj/item/megaphone(src)
-	new /obj/item/pinpointer/pool(src)
+	new /obj/item/psy_tracker(src)
 
 
 /obj/item/storage/pouch/general/som

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -1325,7 +1325,7 @@ GLOBAL_LIST_INIT(available_specialist_sets, list("Scout Set", "Sniper Set", "Dem
 		/obj/item/radio,
 		/obj/item/motiondetector,
 		/obj/item/binoculars/tactical,
-		/obj/item/pinpointer/pool,
+		/obj/item/psy_tracker,
 	)
 
 /obj/effect/essentials_set/commander

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -72,7 +72,7 @@ OPERATIONS
 	cost = 20
 
 /datum/supply_packs/operations/pinpointer
-	name = "pool tracker crate"
+	name = "psy tracker crate"
 	contains = list(/obj/item/psy_tracker)
 	cost = 20
 

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -73,7 +73,7 @@ OPERATIONS
 
 /datum/supply_packs/operations/pinpointer
 	name = "pool tracker crate"
-	contains = list(/obj/item/pinpointer/pool)
+	contains = list(/obj/item/psy_tracker)
 	cost = 20
 
 /datum/supply_packs/operations/flares

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -49,6 +49,7 @@
 	number++
 	GLOB.xeno_resin_silos += src
 	center_turf = get_step(src, NORTHEAST)
+	SEND_GLOBAL_SIGNAL(COMSIG_SILO_CREATED)
 	if(!istype(center_turf))
 		center_turf = loc
 
@@ -96,6 +97,7 @@
 
 	silo_area = null
 	center_turf = null
+	SEND_GLOBAL_SIGNAL(COMSIG_SILO_DESTROYED)
 	STOP_PROCESSING(SSslowprocess, src)
 	return ..()
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Psy tracker, some QOL compared to pool pinpointer (message when a silo is placed / destroyed). Cannot get information on silo while shipside.

Most important, able to track the hive ruler if there are no silos on the map

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This is meant for two things:

Prevent extra delay end game with the hive ruler running around everywhere with no pool, or placing one at the last moment. This just leads to extra boredom for all marines, and make the game longer for no reason

Make silo less strategy a bit harder to pull off. You are still able to do it, but that means the hive leader will be tracked.
That allows xeno to not be forced to defend a defensive position if they do not wish too, but while still giving marines an objective they can kill.
Silo less strat are often a competition to see who will wander around alone because of boredom, and that's no good


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Psy tracker, to replace the pool pinpointer. Able to track the hive ruler if no silos are on the map
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
