### PR TITLE
Revert "Engies build faster (#6318)"

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -163,7 +163,7 @@
 		if(R.skill_req && usr.skills.getRating("construction") < R.skill_req)
 			building_time += R.time * ( R.skill_req - usr.skills.getRating("construction") ) * 0.5 // +50% time each skill point lacking.
 		if(R.skill_req && usr.skills.getRating("construction") > R.skill_req)
-			building_time -= clamp(R.time * ( usr.skills.getRating("construction") - R.skill_req ) * 0.40, 0 , 0.85 * building_time) // -40% time each extra skill point
+			building_time -= R.time * ( usr.skills.getRating("construction") - R.skill_req ) * 0.1 // -10% time each extra skill point
 		if(building_time)
 			if(building_time > R.time)
 				usr.visible_message("<span class='notice'>[usr] fumbles around figuring out how to build \a [R.title].</span>",


### PR DESCRIPTION
This reverts the PR https://github.com/tgstation/TerraGov-Marine-Corps/pull/6318

<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Engies are not helping the push, they are just fobbiting harder. All of these PR are detrimental to the game

## Changelog
:cl:
balance: Engie are building at the same speed than before
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
