### PR TITLE
Building near FOB will be 3 times slower than in the field

### DIFF
--- a/code/__DEFINES/cooldowns.dm
+++ b/code/__DEFINES/cooldowns.dm
@@ -33,6 +33,7 @@
 #define COOLDOWN_XENO_TURRETS_ALERT "xeno_turrets_alert"
 #define COOLDOWN_HIVEMIND_DOOR "hivemind_manipulate_door"
 #define COOLDOWN_PARALYSE_ACID "acid_spray_paralyse"
+#define COOLDOWN_NOTIFY_SLOW_BUILDING "slow_build_in_fob_alert"
 
 //// COOLDOWN SYSTEMS
 /*

--- a/code/game/objects/items/stacks/sandbags.dm
+++ b/code/game/objects/items/stacks/sandbags.dm
@@ -106,6 +106,10 @@
 	user.visible_message("<span class='notice'>[user] starts assembling a sandbag barricade.</span>",
 	"<span class='notice'>You start assembling a sandbag barricade.</span>")
 	var/building_time = LERP(2 SECONDS, 1 SECONDS, user.skills.getPercent("construction", SKILL_ENGINEER_MASTER))
+	var/area/build_area = get_area(usr)
+	if(CHECK_BITFIELD(build_area.flags_area, NEAR_FOB))
+		building_time *= 3
+		to_chat(usr, "<span class ='warning'>The fuel residues of the space ship prevent us from using our power tool, we build slower!</span>")
 	if(!do_after(user, building_time, TRUE, src, BUSY_ICON_BUILD))
 		return
 	for(var/obj/O in user.loc) //Objects, we don't care about mobs. Turfs are checked elsewhere

--- a/code/game/objects/items/stacks/sandbags.dm
+++ b/code/game/objects/items/stacks/sandbags.dm
@@ -109,7 +109,9 @@
 	var/area/build_area = get_area(usr)
 	if(CHECK_BITFIELD(build_area.flags_area, NEAR_FOB))
 		building_time *= 3
-		to_chat(usr, "<span class ='warning'>The fuel residues of the space ship prevent us from using our power tool, we build slower!</span>")
+		if(TIMER_COOLDOWN_CHECK(usr, COOLDOWN_NOTIFY_SLOW_BUILDING))
+			to_chat(usr, "<span class ='warning'>The fuel residues of the space ship prevent us from using our power tool, we build slower!</span>")
+			TIMER_COOLDOWN_START(usr, COOLDOWN_NOTIFY_SLOW_BUILDING, 30 SECONDS)
 	if(!do_after(user, building_time, TRUE, src, BUSY_ICON_BUILD))
 		return
 	for(var/obj/O in user.loc) //Objects, we don't care about mobs. Turfs are checked elsewhere

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -171,6 +171,10 @@
 			else
 				usr.visible_message("<span class='notice'>[usr] starts building \a [R.title].</span>",
 				"<span class='notice'>You start building \a [R.title]...</span>")
+			var/area/build_area = get_area(usr)
+			if(CHECK_BITFIELD(build_area.flags_area, NEAR_FOB))
+				building_time *= 3
+				to_chat(usr, "<span class ='warning'>The fuel residues of the space ship prevent us from using our power tool, we build slower!</span>")
 			if(!do_after(usr, building_time, TRUE, src, BUSY_ICON_BUILD))
 				return
 			if(!building_checks(R, multiplier))

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -174,7 +174,9 @@
 			var/area/build_area = get_area(usr)
 			if(CHECK_BITFIELD(build_area.flags_area, NEAR_FOB))
 				building_time *= 3
-				to_chat(usr, "<span class ='warning'>The fuel residues of the space ship prevent us from using our power tool, we build slower!</span>")
+				if(TIMER_COOLDOWN_CHECK(usr, COOLDOWN_NOTIFY_SLOW_BUILDING))
+					to_chat(usr, "<span class ='warning'>The fuel residues of the space ship prevent us from using our power tool, we build slower!</span>")
+					TIMER_COOLDOWN_START(usr, COOLDOWN_NOTIFY_SLOW_BUILDING, 30 SECONDS)
 			if(!do_after(usr, building_time, TRUE, src, BUSY_ICON_BUILD))
 				return
 			if(!building_checks(R, multiplier))


### PR DESCRIPTION

<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Building near FOB will be 3 times slower than building in the field.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Engies are full fobiting, this is extremly detrimental to the game:
- They are not helping the push, so marines are getting shreded with no place to rest and heal
- They are slowing down the end of the game tremendously, because xeno do not have proper siege capabilities. This is not making marines win; this is not making people have fun; this is just a pain for everyone

Most, if not all are playing minecraft. This would be fine if that was not ruining the game for everyone else. This PR is made to incentivize engie to actually try to be usefull, rather than just playing on their own producing absolutly nothing

## Changelog
:cl:
balance: Building near FOB will be 3 times slower than in the field
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
