### PR TITLE
Fixes infinite metal from reinforced floors exploit

### DIFF
--- a/code/game/turfs/floor_types.dm
+++ b/code/game/turfs/floor_types.dm
@@ -324,6 +324,8 @@
 	return
 
 /turf/open/floor/engine/attackby(obj/item/I, mob/user, params)
+	if(iscrowbar(I)) // Prevent generation of infinite 'floor_tile' objs caused by the overridden make_plating() above never clearing the var
+		return
 	. = ..()
 
 	if(iswrench(I))


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes: #6342 

Please give this one a thorough review and suggest any better alternatives as I did not want to waste a ton of time to figure out why rfloors are `/turf/open/floor/engine` in the first place or why `/turf/open/floor/engine/make_plating()` the proc that usually handles tile removals so they can't be duplicated is totally bypassed for this type. My guess is there are some very old legacy reasons and if I were to change it could have unforeseen and dire consequences.

## Why It's Good For The Game

Bug bad. Fix good.

## Changelog
:cl:
fix: Fixed a glitch which could break the metal economy. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
