### PR TITLE
Tactical explosive vest balance attempt

### DIFF
--- a/code/game/objects/items/explosives/bombvest.dm
+++ b/code/game/objects/items/explosives/bombvest.dm
@@ -27,7 +27,11 @@
 	else
 		message_admins("[activator] has detonated an explosive vest with no warcry.")
 		log_game("[activator] has detonated an explosive vest with no warcry.")
-	activator.adjustBruteLoss(1200) //Oops we blew all our limbs off
+
+	for(var/datum/limb/E in activator.limbs) //Oops we blew all our limbs off
+		if(istype(E, /datum/limb/chest) || istype(E, /datum/limb/groin) || istype(E, /datum/limb/head))
+			continue
+		E.droplimb()
 	explosion(loc, 0, 2, 6, 5, 5)
 	qdel(src)
 
@@ -61,6 +65,10 @@
 	activator.say("ORBITAL BOMBARDMENT INBOUND!!")
 	message_admins("[activator] has detonated an Orbital Bombardment vest! Unga!")
 	log_game("[activator] has detonated an Orbital Bombardment vest! Unga!")
-	activator.adjustBruteLoss(1200) //Oops we blew all our limbs off
+
+	for(var/datum/limb/E in activator.limbs) //Oops we blew all our limbs off
+		if(istype(E, /datum/limb/chest) || istype(E, /datum/limb/groin) || istype(E, /datum/limb/head))
+			continue
+		E.droplimb()
 	explosion(loc, 15, 15, 15, 15, 15)
 	qdel(src)

--- a/code/game/objects/items/explosives/bombvest.dm
+++ b/code/game/objects/items/explosives/bombvest.dm
@@ -28,10 +28,10 @@
 		message_admins("[activator] has detonated an explosive vest with no warcry.")
 		log_game("[activator] has detonated an explosive vest with no warcry.")
 
-	for(var/datum/limb/E in activator.limbs) //Oops we blew all our limbs off
-		if(istype(E, /datum/limb/chest) || istype(E, /datum/limb/groin) || istype(E, /datum/limb/head))
+	for(var/datum/limb/appendage AS in activator.limbs) //Oops we blew all our limbs off
+		if(istype(appendage, /datum/limb/chest) || istype(appendage, /datum/limb/groin) || istype(appendage, /datum/limb/head))
 			continue
-		E.droplimb()
+		appendage.droplimb()
 	explosion(loc, 2, 2, 6, 5, 5)
 	qdel(src)
 
@@ -66,9 +66,9 @@
 	message_admins("[activator] has detonated an Orbital Bombardment vest! Unga!")
 	log_game("[activator] has detonated an Orbital Bombardment vest! Unga!")
 
-	for(var/datum/limb/E in activator.limbs) //Oops we blew all our limbs off
-		if(istype(E, /datum/limb/chest) || istype(E, /datum/limb/groin) || istype(E, /datum/limb/head))
+	for(var/datum/limb/appendage AS in activator.limbs) //Oops we blew all our limbs off
+		if(istype(appendage, /datum/limb/chest) || istype(appendage, /datum/limb/groin) || istype(appendage, /datum/limb/head))
 			continue
-		E.droplimb()
+		appendage.droplimb()
 	explosion(loc, 15, 15, 15, 15, 15)
 	qdel(src)

--- a/code/game/objects/items/explosives/bombvest.dm
+++ b/code/game/objects/items/explosives/bombvest.dm
@@ -18,6 +18,8 @@
 	if(activator.wear_suit != src)
 		to_chat(activator, "Due to the rigging of this device, it can only be detonated while worn.") //If you are going to use this, you have to accept death. No armor allowed.
 		return FALSE
+	if(!do_after(user, 3, TRUE, src, BUSY_ICON_DANGER, ignore_turf_checks = TRUE))
+		return FALSE
 	if(bomb_message) //Checks for a non null bomb message.
 		activator.say("[bomb_message]!!")
 		message_admins("[activator] has detonated an explosive vest with the warcry \"[bomb_message]\".") //Incase disputes show up about marines killing themselves and others.
@@ -25,7 +27,8 @@
 	else
 		message_admins("[activator] has detonated an explosive vest with no warcry.")
 		log_game("[activator] has detonated an explosive vest with no warcry.")
-	explosion(loc, 0, 2, 6, 5, 5) 
+	activator.adjustBruteLoss(1200) //Oops we blew all our limbs off
+	explosion(loc, 0, 2, 6, 5, 5)
 	qdel(src)
 
 ///Gets a warcry to scream on Control Click, checks for non allowed warcries.
@@ -53,8 +56,11 @@
 	if(activator.wear_suit != src)
 		to_chat(activator, "Due to the rigging of this device, it can only be detonated while worn.")
 		return FALSE
+	if(!do_after(user, 3, TRUE, src, BUSY_ICON_DANGER, ignore_turf_checks = TRUE))
+		return FALSE
 	activator.say("ORBITAL BOMBARDMENT INBOUND!!")
 	message_admins("[activator] has detonated an Orbital Bombardment vest! Unga!")
 	log_game("[activator] has detonated an Orbital Bombardment vest! Unga!")
+	activator.adjustBruteLoss(1200) //Oops we blew all our limbs off
 	explosion(loc, 15, 15, 15, 15, 15)
 	qdel(src)

--- a/code/game/objects/items/explosives/bombvest.dm
+++ b/code/game/objects/items/explosives/bombvest.dm
@@ -32,7 +32,7 @@
 		if(istype(E, /datum/limb/chest) || istype(E, /datum/limb/groin) || istype(E, /datum/limb/head))
 			continue
 		E.droplimb()
-	explosion(loc, 0, 2, 6, 5, 5)
+	explosion(loc, 1, 2, 6, 5, 5)
 	qdel(src)
 
 ///Gets a warcry to scream on Control Click, checks for non allowed warcries.

--- a/code/game/objects/items/explosives/bombvest.dm
+++ b/code/game/objects/items/explosives/bombvest.dm
@@ -32,7 +32,7 @@
 		if(istype(E, /datum/limb/chest) || istype(E, /datum/limb/groin) || istype(E, /datum/limb/head))
 			continue
 		E.droplimb()
-	explosion(loc, 1, 2, 6, 5, 5)
+	explosion(loc, 2, 2, 6, 5, 5)
 	qdel(src)
 
 ///Gets a warcry to scream on Control Click, checks for non allowed warcries.


### PR DESCRIPTION
## About The Pull Request

Blowing yourself up now takes a brief moment to trigger displaying a warning icon above your head (like when using a rocket launcher), and results in you losing all your limbs.

Devastation radius from 0 -> 2 allowing high caliber wearers to inflict serious wounds on any one or anything directly next to them.

## Why It's Good For The Game

Highly demanded. Removes the lack of a round removal disincentive that should come with a very strong "suicide" item. Prevents unfun instant jetpack explosion shenanigans. 

## Changelog
:cl:
balance: Tactical explosive vests now have a short wind up time, more close range damage, and a guarantee you will become a dead nugget.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
