### PR TITLE
Shows the Hiveminds nickname in its radio chat.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/say.dm
+++ b/code/modules/mob/living/carbon/xenomorph/say.dm
@@ -23,7 +23,7 @@
 	return "<span class='hivemind xenoshrike'>Hivemind, <span class='name'>[name]</span>"
 
 /mob/living/carbon/xenomorph/hivemind/hivemind_start()
-	return "<span class='hivemind xenohivemind'><span class='name'>The Hivemind</span>"
+	return "<span class='hivemind xenohivemind'><span class='name'>The Hivemind </span><span class='name'>([nicknumber])</span>"
 
 
 /mob/living/carbon/xenomorph/proc/render_hivemind_message(message)

--- a/code/modules/mob/living/carbon/xenomorph/say.dm
+++ b/code/modules/mob/living/carbon/xenomorph/say.dm
@@ -23,7 +23,7 @@
 	return "<span class='hivemind xenoshrike'>Hivemind, <span class='name'>[name]</span>"
 
 /mob/living/carbon/xenomorph/hivemind/hivemind_start()
-	return "<span class='hivemind xenohivemind'><span class='name'>The Hivemind </span><span class='name'>([nicknumber])</span>"
+	return "<span class='hivemind xenohivemind'><span class='name'>The Hivemind ([nicknumber])</span>"
 
 
 /mob/living/carbon/xenomorph/proc/render_hivemind_message(message)


### PR DESCRIPTION
## About The Pull Request

Shows the Hiveminds nickname in its radio chat.
![Screenshot (51)](https://user-images.githubusercontent.com/43631032/115946335-5b033d80-a475-11eb-8c31-d7f7b2ad6d19.png)

## Why It's Good For The Game

It allows Xenos to be able to tell who the hivemind is.

## Changelog
:cl:
qol: Shows the Hiveminds nickname in its radio chat.
/:cl:
