### PR TITLE
Pickup macro made null for two handed weapons (or 2 of them unwielded)

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -4,6 +4,9 @@
 	var/unwieldsound
 	flags_item = TWOHANDED
 
+/obj/item/weapon/twohanded/Initialize()
+	. = ..()
+	verbs -= /obj/item/verb/verb_pickup
 
 /obj/item/weapon/twohanded/update_icon()
 	return


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

No longer can you pull off inhuman throw and pickup speeds with multiple spears, or any other two handed weapons, in melee range.

## Why It's Good For The Game

While we can't stop in keyboard or in mouse keypress macros to switch hands, toggle throw, and click the targets direction we can make it a little harder to give yourself godlike DPS on the reload.

Anyone looking to argue that they need to use a pickup macro to use the weapons should then also be okay with balancing throw force based on the fastest possible tool/macro assisted throw and pickup speed of the weapons.

## Changelog
:cl:
code: Two-handed weapons can no longer be picked up with a macro.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
