### PR TITLE
Fixes a few instances of xenos moving bodies beyond critdrag range

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -50,6 +50,7 @@
 #define CARBON_RECOVERY_OXYLOSS -5 //the amount of oxyloss recovery per successful breath tick.
 
 #define CARBON_KO_OXYLOSS 50
+#define HUMAN_CRITDRAG_OXYLOSS 3 //the amount of oxyloss taken per tile a human is dragged by a xeno while unconscious
 
 #define HEAT_DAMAGE_LEVEL_1 1 //Amount of damage applied when your body temperature just passes the 360.15k safety point
 #define HEAT_DAMAGE_LEVEL_2 2 //Amount of damage applied when your body temperature passes the 400K point

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -45,10 +45,10 @@
 				hud_used.healths.icon_state = "health6"
 
 ///gives humans oxy when dragged by a xeno, called on COMSIG_MOVABLE_PULL_MOVED
-/mob/living/carbon/human/proc/oncritdrag() 
+/mob/living/carbon/human/proc/oncritdrag()
 	SIGNAL_HANDLER
 	if(isxeno(pulledby))
-		adjustOxyLoss(3) //take oxy damage per tile dragged
+		adjustOxyLoss(HUMAN_CRITDRAG_OXYLOSS) //take oxy damage per tile dragged
 
 /mob/living/carbon/update_stat()
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -186,11 +186,11 @@
 				affected.Shake(4, 4, 20)
 				continue
 			if(ishuman(affected)) //if they're human, they also should get knocked off their feet from the blast.
-				var/mob/living/L = affected
-				if(L.stat == DEAD) //unless they are dead, then the blast mysteriously ignores them.
+				var/mob/living/carbon/human/H = affected
+				if(H.stat == DEAD) //unless they are dead, then the blast mysteriously ignores them.
 					continue
-				L.apply_effects(1, 1) 	// Stun
-				shake_camera(L, 2, 1)
+				H.apply_effects(1, 1) 	// Stun
+				shake_camera(H, 2, 1)
 			var/throwlocation = affected.loc //first we get the target's location
 			for(var/x in 1 to 6)
 				throwlocation = get_step(throwlocation, owner.dir) //then we find where they're being thrown to, checking tile by tile.

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -185,14 +185,16 @@
 			if(!ishuman(affected) && !istype(affected, /obj/item))
 				affected.Shake(4, 4, 20)
 				continue
+			if(ishuman(affected)) //if they're human, they also should get knocked off their feet from the blast.
+				var/mob/living/L = affected
+				if(L.stat == DEAD) //unless they are dead, then the blast mysteriously ignores them.
+					continue
+				L.apply_effects(1, 1) 	// Stun
+				shake_camera(L, 2, 1)
 			var/throwlocation = affected.loc //first we get the target's location
 			for(var/x in 1 to 6)
 				throwlocation = get_step(throwlocation, owner.dir) //then we find where they're being thrown to, checking tile by tile.
 			affected.throw_at(throwlocation, 6, 1, owner, TRUE)
-			if(ishuman(affected)) //if they're human, they also should get knocked off their feet from the blast.
-				var/mob/living/carbon/human = affected
-				human.apply_effects(1, 1) 	// Stun
-				shake_camera(affected, 2, 1)
 
 	owner.visible_message("<span class='xenowarning'>[owner] sends out a huge blast of psychic energy!</span>", \
 	"<span class='xenowarning'>We send out a huge blast of psychic energy!</span>")

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -112,8 +112,13 @@
 
 /datum/action/xeno_action/activable/lunge/proc/lunge_grab(mob/living/carbon/xenomorph/warrior/X, atom/A)
 	X.remove_filter("warrior_lunge")
-	if (!X.Adjacent(A))
+	if(!X.Adjacent(A))
 		return
+
+	if(isliving(A))
+		var/mob/living/L = A
+		if(L.stat == DEAD)
+			return
 
 	X.swap_hand()
 	X.start_pulling(A, lunge = TRUE)
@@ -148,6 +153,9 @@
 		return FALSE
 
 	if(!isliving(A))
+		return FALSE
+	var/mob/living/L = A
+	if(L.stat == DEAD)
 		return FALSE
 
 /datum/action/xeno_action/activable/fling/use_ability(atom/A)

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -115,11 +115,6 @@
 	if(!X.Adjacent(A))
 		return
 
-	if(isliving(A))
-		var/mob/living/L = A
-		if(L.stat == DEAD)
-			return
-
 	X.swap_hand()
 	X.start_pulling(A, lunge = TRUE)
 	X.swap_hand()

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
@@ -400,7 +400,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 			if(ishuman(pulled_target))
 				var/mob/living/carbon/human/H = pulled_target
 				if(H.stat == UNCONSCIOUS) //Apply critdrag damage as if they were quickly pulled the same distance
-					H.adjustOxyLoss(HUMAN_CRITDRAG_OXYLOSS * get_dist(X.loc, T))
+					H.adjustOxyLoss(HUMAN_CRITDRAG_OXYLOSS * get_dist(H.loc, T))
 
 		to_chat(X, "<span class='xenodanger'>We bring [pulled_target] with us. We won't be ready to blink again for [cooldown_timer * cooldown_mod * 0.1] seconds due to the strain of doing so.</span>")
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
@@ -397,6 +397,10 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 			if(!do_after(owner, 0.5 SECONDS, TRUE, owner, BUSY_ICON_HOSTILE)) //Grap-porting hostiles has a slight wind up
 				return fail_activate()
 			cooldown_mod = X.xeno_caste.wraith_blink_drag_nonfriendly_living_multiplier
+			if(ishuman(pulled_target))
+				var/mob/living/carbon/human/H = pulled_target
+				if(H.stat == UNCONSCIOUS) //Apply critdrag damage as if they were quickly pulled the same distance
+					H.adjustOxyLoss(HUMAN_CRITDRAG_OXYLOSS * get_dist(X.loc, T))
 
 		to_chat(X, "<span class='xenodanger'>We bring [pulled_target] with us. We won't be ready to blink again for [cooldown_timer * cooldown_mod * 0.1] seconds due to the strain of doing so.</span>")
 
@@ -638,4 +642,3 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	banish_check.banish_deactivate()
 	succeed_activate()
 	add_cooldown()
-


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.
Fixes: #6503

## Why It's Good For The Game

I guess permadeath for marines is bad during Distress Signal rounds? Here your crutch is a little better now.

## Changelog
:cl:
fix: Shrike's unrelenting force no longer displaces dead humans.
fix: Warrior's fling no longer works on dead humans.
fix: Unconscious humans pulled through a Wraith teleport receive equivalent critdrag damage based on distance traveled. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
