### PR TITLE
Fix maptables and command headset minimaps

### DIFF
--- a/code/controllers/subsystem/minimaps.dm
+++ b/code/controllers/subsystem/minimaps.dm
@@ -285,7 +285,7 @@ SUBSYSTEM_DEF(minimaps)
 		return hashed_minimaps[hash]
 	var/obj/screen/minimap/map = new(null, zlevel, flags)
 	if (!map.icon) //Don't wanna save an unusable minimap for a z-level.
-		return
+		CRASH("Empty and unusable minimap generated for '[zlevel]-[flags]'") //Can be caused by atoms calling this proc before minimap subsystem initializing.
 	hashed_minimaps[hash] = map
 	return map
 

--- a/code/controllers/subsystem/minimaps.dm
+++ b/code/controllers/subsystem/minimaps.dm
@@ -284,6 +284,8 @@ SUBSYSTEM_DEF(minimaps)
 	if(hashed_minimaps[hash])
 		return hashed_minimaps[hash]
 	var/obj/screen/minimap/map = new(null, zlevel, flags)
+	if (!map.icon) //Don't wanna save an unusable minimap for a z-level.
+		return
 	hashed_minimaps[hash] = map
 	return map
 

--- a/code/game/objects/machinery/cic_maptable.dm
+++ b/code/game/objects/machinery/cic_maptable.dm
@@ -14,10 +14,6 @@
 	///minimap obj ref that we will display to users
 	var/obj/screen/minimap/map
 
-/obj/machinery/cic_maptable/Initialize()
-	. = ..()
-	map = SSminimaps.fetch_minimap_object(targetted_zlevel, allowed_flags)
-
 /obj/machinery/cic_maptable/Destroy()
 	map = null
 	return ..()
@@ -28,6 +24,8 @@
 		return
 	if(!user.client)
 		return
+	if (!map)
+		map = SSminimaps.fetch_minimap_object(targetted_zlevel, allowed_flags)
 	user.client.screen += map
 
 /obj/machinery/cic_maptable/on_unset_interaction(mob/user)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Random bug i encountered while doing other stuff:
If a maptable exists roundstart , it will get an empty command groundside map and get that empty map saved in the subsystem.
Meaning that every map table and command headset with the groundside minimap (both of which share the same minimap) won't be able to open the minimap because an empty one from the maptable's fetch_minimap_object proccall was saved.
Happens most likely due to the atoms subsystems initializing the maptable waay before the minimap subsystem has the chance to generate the minimaps itself, causing fetch_minimap_object to fuck up.

This bug won't happen if the map doesn't start with a map table initially, which is the case for debugdalus. Might be why this bug got through, since spawning a maptable when one doesn't exist initially doesn't get the minimap fucked up and actually works as intended.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Maptable go brrrr

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Map tables in conjuntion with command headset minimaps should work again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
