### PR TITLE
Xenos keep their targeting zone selection across evolutions

### DIFF
--- a/code/_onclick/hud/screen_objects/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects/screen_objects.dm
@@ -453,7 +453,7 @@
 
 	if(choice != selecting)
 		selecting = choice
-		update_icon(usr)
+		update_icon(user)
 	return TRUE
 
 /obj/screen/zone_sel/update_icon(mob/user)

--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -166,7 +166,7 @@
 		if(xenojob.required_playtime_remaining(client))
 			to_chat(src, "<span class='warning'>[get_exp_format(xenojob.required_playtime_remaining(client))] as [xenojob.get_exp_req_type()] required to play the queen role.</span>")
 			return
-		
+
 		if(hive.living_xeno_queen)
 			to_chat(src, "<span class='warning'>There already is a living Queen.</span>")
 			return
@@ -369,6 +369,8 @@
 	new_xeno.upgrade_stored = upgrade_stored
 	while(new_xeno.upgrade_possible() && new_xeno.upgrade_stored >= new_xeno.xeno_caste.upgrade_threshold)
 		new_xeno.upgrade_xeno(new_xeno.upgrade_next(), TRUE)
+	var/obj/screen/zone_sel/selector = new_xeno.hud_used.zone_sel
+	selector.set_selected_zone(zone_selected, new_xeno)
 	qdel(src)
 	INVOKE_ASYNC(new_xeno, /mob/living.proc/do_jitter_animation, 1000)
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a bit of evolution code to retain `zone_selected` when xenos change caste.

Fixed a small bug causing `set_selected_zone()` to pass the wrong mob to an overridden `update_icon()` making it fail to update `zone_selected` in some cases.

## Why It's Good For The Game

QoL good. Xenos needing to rundown a post evolution checklist in order to get back to full readiness is bad. It was worse when it reset the old mmb/shiftclick pref and this is almost as annoying.

## Changelog
:cl:
qol: Xenos now keep their selected targeting zone when evolving/regressing.
fix: Fixed a small bug with the zone selection hud.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
