### PR TITLE
invisible helmets bad

### DIFF
--- a/code/modules/modular_armor/modular.dm
+++ b/code/modules/modular_armor/modular.dm
@@ -366,6 +366,9 @@
 		"black", "snow", "desert", "gray", "brown", "red", "blue", "yellow", "green", "aqua", "purple", "orange"
 	))
 
+	if(!new_color)
+		return
+
 	if(!do_after(user, 1 SECONDS, TRUE, src, BUSY_ICON_GENERIC))
 		return TRUE
 


### PR DESCRIPTION

## About The Pull Request

Fixes invisible jaeger helmets created when trying to cancel coloring them.
Adds a check after color selection in helmet coloring code to actually cancel coloring when no color is selected.

## Why It's Good For The Game

bug fix good

## Changelog
:cl:
fix: Fixes invisible jaeger helmets created when trying to cancel coloring them.
/:cl: