### PR TITLE
Allows health scanners and tweezers to fit in more storages

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -152,6 +152,7 @@
 	max_storage_space = 42
 	max_w_class = 2
 	can_hold = list(
+		/obj/item/healthanalyzer,
 		/obj/item/reagent_containers/glass/bottle,
 		/obj/item/reagent_containers/pill,
 		/obj/item/reagent_containers/syringe,
@@ -195,6 +196,7 @@
 	max_storage_space = 42
 	max_w_class = 2
 	can_hold = list(
+		/obj/item/healthanalyzer,
 		/obj/item/reagent_containers/glass/bottle,
 		/obj/item/reagent_containers/pill,
 		/obj/item/reagent_containers/syringe,

--- a/code/modules/clothing/under/ties.dm
+++ b/code/modules/clothing/under/ties.dm
@@ -558,6 +558,7 @@
 		/obj/item/tool/surgery,
 		/obj/item/stack/nanopaste,
 		/obj/item/stack/medical/advanced/bruise_pack,
+		/obj/item/tweezers,
 	)
 
 /obj/item/storage/internal/tie/white_vest/surgery/Initialize()
@@ -595,6 +596,7 @@
 		/obj/item/bodybag,
 		/obj/item/roller,
 		/obj/item/clothing/glasses/hud/health,
+		/obj/item/tweezers,
 	)
 
 /obj/item/clothing/tie/storage/knifeharness

--- a/code/modules/modular_armor/storage.dm
+++ b/code/modules/modular_armor/storage.dm
@@ -177,6 +177,7 @@
 		/obj/item/reagent_containers/hypospray/advanced,
 		/obj/item/reagent_containers/hypospray,
 		/obj/item/stack/medical,
+		/obj/item/tweezers,
 	)
 
 /obj/item/armor_module/storage/integrated


### PR DESCRIPTION
## Changelog
:cl:
qol: Made health analyzers and medical tweezers to be stored on more medical storages (medical belts for the former, webbings and medical armor modules for the latter)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
