### PR TITLE
Readds Thermo to req at an increased cost.

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -206,7 +206,6 @@ WEAPONS
 	contains = list(/obj/item/storage/box/recoilless_system)
 	cost = 40
 
-
 /datum/supply_packs/weapons/railgun
 	name = "TX-220 Railgun"
 	contains = list(/obj/item/weapon/gun/rifle/railgun)
@@ -221,6 +220,11 @@ WEAPONS
 	name = "Demolitionist Specialist kit"
 	contains = list(/obj/item/weapon/gun/launcher/rocket/sadar)
 	cost = SADAR_PRICE
+
+/datum/supply_packs/weapons/quadlauncher
+	name = "M57A4 Quad Thermobaric Launcher"
+	contains = list(/obj/item/weapon/gun/launcher/rocket/m57a4)
+	cost = 250
 
 /datum/supply_packs/weapons/autosniper
 	name = "IFF Auto Sniper kit"
@@ -553,6 +557,11 @@ AMMO
 	name = "T-152 RPG WP rocket"
 	contains = list(/obj/item/ammo_magazine/rocket/sadar/wp)
 	cost = 7
+
+/datum/supply_packs/ammo/quadlauncher
+	name = "M57A4 thermobaric rocket array"
+	contains = list(/obj/item/ammo_magazine/rocket/m57a4)
+	cost = 25
 
 /datum/supply_packs/ammo/shell_regular
 	name = "T-160 RR HE shell"

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -1142,45 +1142,6 @@
 				<li class="bugfix">you can no longer give marines ripley hands to move crates fast</li>
 				<li class="bugfix">weapon verbs are now only in Weapons verb tab</li>
 			</ul>
-
-			<h2 class="date">23 February 2021</h2>
-			<h3 class="author">BraveMole updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">No more instant death on ice colony</li>
-				<li class="bugfix">CIC orders no longer runtime</li>
-				<li class="bugfix">Making a new silo will now correctly reset the siloless timer</li>
-			</ul>
-			<h3 class="author">SplinterGP updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">synths can now have numbers in name.</li>
-				<li class="bugfix">people now can have numbers in name to account for vatborns.</li>
-				<li class="bugfix">fixes runtimes caused by medevac stretchers</li>
-			</ul>
-			<h3 class="author">Surrealaser updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">Larva can now use tunnels.</li>
-				<li class="bugfix">Fixes minor copy pasta bug with the Healing Infusion effect end message.</li>
-				<li class="bugfix">Ancient Xenos now provide the proper upgrade point yield when targeted with Salvage Biomass, counting as a maxed out Elder Xeno.</li>
-			</ul>
-			<h3 class="author">TiviPlus updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="refactor">Monkeys are now at last a human species rather than a seperate type</li>
-				<li class="bugfix">various monkey inconsistencies</li>
-			</ul>
-			<h3 class="author">XSlayer300 updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">fixes guardsman armor, now they appear in any map.</li>
-			</ul>
-			<h3 class="author">mokulus updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">synthetic cannot throw dangerous grenades in acid holes now</li>
-				<li class="bugfix">boiler neurotoxin properly extinguishes xenos</li>
-				<li class="bugfix">disabled computers are now unusable (repair with blowtorch)</li>
-				<li class="bugfix">tipped over vendors can be put back up</li>
-				<li class="bugfix">AI can't use disabled machines now</li>
-				<li class="qol">defibrillator recharging hints</li>
-				<li class="bugfix">overwatch jump to camera works again</li>
-			</ul>
 		</div>
 
 <b>GoonStation 13 Development Team</b>

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -1181,31 +1181,6 @@
 				<li class="qol">defibrillator recharging hints</li>
 				<li class="bugfix">overwatch jump to camera works again</li>
 			</ul>
-
-			<h2 class="date">21 February 2021</h2>
-			<h3 class="author">BraveMole updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">You can defib people now</li>
-				<li class="refactor">DNR code</li>
-			</ul>
-			<h3 class="author">Pariah919 updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="balance">baldur mk1 slowdown reduced and light range slightly higher, mk2 has no slowdown</li>
-			</ul>
-			<h3 class="author">SplinterGP updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="rscadd">Added TGChat in place of Goonchat.</li>
-				<li class="rscdel">Goonchat removed.</li>
-				<li class="code_imp">updated icon2base64 proc to not use a global file that doens't exist anymore.</li>
-			</ul>
-			<h3 class="author">Surrealaser updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="balance">Healing Infusion ticks increased from 5 to 10. Healing per tick is now 6 + 0.03% of max HP Sunder restored per tick is now 1.8. Healing Infusion cooldown decreased from 30 seconds back to 5 seconds. Healing Infusion no longer restores Sunder unless its target is on weeds.</li>
-			</ul>
-			<h3 class="author">TiviPlus updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="code_imp">Adds code for rightclicking with empty hand</li>
-			</ul>
 		</div>
 
 <b>GoonStation 13 Development Team</b>

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -1126,22 +1126,6 @@
 			<ul class="changes bgimages16">
 				<li class="qol">harvester fill up amount is based on beaker setting as opposed to the maximum possible amount</li>
 			</ul>
-
-			<h2 class="date">25 February 2021</h2>
-			<h3 class="author">Gohunt updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="imageadd">Lobby UI button tweaks</li>
-			</ul>
-			<h3 class="author">lbnesquik updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">fixed the description</li>
-				<li class="rscadd">Added many holopads.</li>
-			</ul>
-			<h3 class="author">mokulus updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">you can no longer give marines ripley hands to move crates fast</li>
-				<li class="bugfix">weapon verbs are now only in Weapons verb tab</li>
-			</ul>
 		</div>
 
 <b>GoonStation 13 Development Team</b>


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Readds Thermobaric to requisitions but it now costs 500 points.
Ammo cost is lowered to 25.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
With the changes to mining in general and it being harder to gain and accumulate a large number of points, the thermobaric launcher is a good way to reward marines managing to hold out long enough or help end stalemates giving them that extra firepower they need to push out in pools or hunt.

Cadehugging and holding FOB rarely ever generates enough points to get a thermo but if marines are constantly pushing, killing and gaining enough ground to secure several miners and manage to generate enough spare points for a weapon that can help them push better, then why not?

## Changelog
:cl:
add: The Quad launcher and it's ammo is back in stock.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
