### PR TITLE
Removes devastation from the Suicide Vest

### DIFF
--- a/code/game/objects/items/explosives/bombvest.dm
+++ b/code/game/objects/items/explosives/bombvest.dm
@@ -18,8 +18,7 @@
 	if(activator.wear_suit != src)
 		to_chat(activator, "Due to the rigging of this device, it can only be detonated while worn.") //If you are going to use this, you have to accept death. No armor allowed.
 		return FALSE
-	if(!do_after(user, 3, TRUE, src, BUSY_ICON_DANGER, ignore_turf_checks = TRUE))
-		return FALSE
+	
 	if(bomb_message) //Checks for a non null bomb message.
 		activator.say("[bomb_message]!!")
 		message_admins("[activator] has detonated an explosive vest with the warcry \"[bomb_message]\".") //Incase disputes show up about marines killing themselves and others.
@@ -27,12 +26,15 @@
 	else
 		message_admins("[activator] has detonated an explosive vest with no warcry.")
 		log_game("[activator] has detonated an explosive vest with no warcry.")
+	
+	if(!do_after(user, 3, TRUE, src, BUSY_ICON_DANGER, ignore_turf_checks = TRUE))
+		return FALSE
 
 	for(var/datum/limb/appendage AS in activator.limbs) //Oops we blew all our limbs off
 		if(istype(appendage, /datum/limb/chest) || istype(appendage, /datum/limb/groin) || istype(appendage, /datum/limb/head))
 			continue
 		appendage.droplimb()
-	explosion(loc, 2, 2, 6, 5, 5)
+	explosion(loc, 0, 2, 6, 5, 5)
 	qdel(src)
 
 ///Gets a warcry to scream on Control Click, checks for non allowed warcries.


### PR DESCRIPTION
## About The Pull Request

Removes the devastation aspect from the Suicide Vest also makes you yell the warcry before the windup cuz it looks better.

## Why It's Good For The Game

You shouldnt be able to do this:
![Screenshot (60)](https://user-images.githubusercontent.com/43631032/116604871-91144780-a8e3-11eb-8a20-68d3ea223536.png)


## Changelog
:cl:
balance: Removes devastation from the Suicide Vest
/:cl:
