### PR TITLE
Fix bump attack message

### DIFF
--- a/code/datums/components/bump_attack.dm
+++ b/code/datums/components/bump_attack.dm
@@ -33,7 +33,7 @@
 	if(should_enable == active)
 		return
 	var/mob/living/bumper = parent
-	to_chat(bumper, "<span class='notice'>You will now [active ? "attack" : "push"] enemies who are in your way.</span>")
+	to_chat(bumper, "<span class='notice'>You will now [should_enable ? "attack" : "push"] enemies who are in your way.</span>")
 	toggle_action?.update_button_icon(should_enable)
 	if(should_enable)
 		active = TRUE


### PR DESCRIPTION
## About The Pull Request

Fixes an invert bump attack message
looks to have been broken in https://github.com/tgstation/TerraGov-Marine-Corps/pull/6377


## Why It's Good For The Game

Bug fix - although there isn't an issue report, there was one on discord.
https://discord.com/channels/498569646014857217/504094319075131402/835344058171523134

## Changelog
:cl:
fix: bump attack toggle message was inverted
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
