### PR TITLE
Updating the Shoulder Holster to fit the T19

### DIFF
--- a/code/modules/clothing/under/ties.dm
+++ b/code/modules/clothing/under/ties.dm
@@ -470,6 +470,7 @@
 	can_hold = list(
 		/obj/item/weapon/gun/pistol,
 		/obj/item/weapon/gun/revolver,
+		/obj/item/weapon/gun/smg/standard_machinepistol,
 	)
 
 /obj/item/clothing/tie/storage/holster/armpit


### PR DESCRIPTION
## About The Pull Request

David yelled at me to do this even though I have no experience with coding lmao. If it's wrong yell at him.
I fixed the shoulder holster to support the T-19 machinepistol since one of the more recent changes seems to have broken it.

**If I needed to account for weapon modifications like the extended barrel and T-19 Stock making the weapon to large to fit than that is something beyond my know-how.**

## Why It's Good For The Game

It's good for the game because the shoulder holster has historically allowed for the T-19 to be placed inside of it but a few days ago a change was made removing that functionality.

Changelog

## Changelog
:cl:
fix: Edited the /obj/item/storage/internal/tie/holster path to allow for the standard_machinepistol
/:cl:
