### PR TITLE
Rebalances standard issue pistol sunder (TP14 to 1.65, TP23 to 2.15)

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -220,7 +220,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage = 20
 	penetration = 5
 	accurate_range = 5
-	sundering = 2
+	sundering = 1.4
 
 /datum/ammo/bullet/pistol/tiny
 	name = "light pistol bullet"
@@ -256,6 +256,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	hud_state = "pistol_hollow"
 	accuracy = -15
 	shrapnel_chance = 45
+	sundering = 2
 
 /datum/ammo/bullet/pistol/hollow/on_hit_mob(mob/M,obj/projectile/P)
 	staggerstun(M, P, stagger = 1, slowdown = 0.5, knockback = 1)
@@ -267,6 +268,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	accuracy = 10
 	penetration = 12.5
 	shrapnel_chance = 25
+	sundering = 2
 
 /datum/ammo/bullet/pistol/heavy
 	name = "heavy pistol bullet"
@@ -274,6 +276,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage = 30
 	penetration = 5
 	shrapnel_chance = 25
+	sundering = 2
 
 /datum/ammo/bullet/pistol/incendiary
 	name = "incendiary pistol bullet"
@@ -291,6 +294,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage = 32
 	penetration = 10
 	shrapnel_chance = 25
+	sundering = 2
 
 /datum/ammo/bullet/pistol/mankey
 	name = "live monkey"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -220,7 +220,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage = 20
 	penetration = 5
 	accurate_range = 5
-	sundering = 1.4
+	sundering = 1.65
 
 /datum/ammo/bullet/pistol/tiny
 	name = "light pistol bullet"
@@ -276,7 +276,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage = 30
 	penetration = 5
 	shrapnel_chance = 25
-	sundering = 2
+	sundering = 2.15
 
 /datum/ammo/bullet/pistol/incendiary
 	name = "incendiary pistol bullet"


### PR DESCRIPTION
## About The Pull Request

See title.

## Why It's Good For The Game

Large disparity between the sunder per second and sunder per magazine between the TP14 and TP23, which are supposed to be side-grades. Doing this lowers said disparity to more reasonable levels, and doesn't make the TP14 effectively a straight upgrade over the TP23.

Also helps with the giant meme that is dual TP14s shredding ancient queens in the time it takes to empty one magazine (~3 seconds).

Done at the request of Georgeur/Revy

## Changelog
:cl:
balance: lowered TP14 sunder to 1.4, kept most commonly used ammo types at 2.
balance: changes TP14 to 1.65, buffs TP23 bullet sunder to 2.15.
/:cl: