### PR TITLE
Adds TGUI compability mode as a byond verb

### DIFF
--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -340,3 +340,13 @@ GLOBAL_LIST_INIT(ghost_others_options, list(GHOST_OTHERS_SIMPLE, GHOST_OTHERS_DE
 
 	show_popup_menus = !show_popup_menus
 	to_chat(src, "<span class='interface'>Right click [show_popup_menus ? "en" : "dis"]abled.</span>")
+
+ //Same thing as the character creator preference, but as a byond verb, because not everyone could reach it
+/client/verb/toggle_tgui_fancy()
+	set name = "Toggle TGUI Window Compability Mode"
+	set category = "Preferences"
+
+	usr.client.prefs.tgui_fancy = !usr.client.prefs.tgui_fancy
+	usr.client.prefs.save_preferences()
+	SStgui.update_user_uis(usr)
+	to_chat(src, "<span class='interface'>TGUI window mode is now [usr.client.prefs.tgui_fancy ? "dis" : "en"]abled.</span>")

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -341,7 +341,7 @@ GLOBAL_LIST_INIT(ghost_others_options, list(GHOST_OTHERS_SIMPLE, GHOST_OTHERS_DE
 	show_popup_menus = !show_popup_menus
 	to_chat(src, "<span class='interface'>Right click [show_popup_menus ? "en" : "dis"]abled.</span>")
 
- //Same thing as the character creator preference, but as a byond verb, because not everyone could reach it
+///Same thing as the character creator preference, but as a byond verb, because not everyone can reach it in tgui preference menu
 /client/verb/toggle_tgui_fancy()
 	set name = "Toggle TGUI Window Compability Mode"
 	set category = "Preferences"
@@ -349,4 +349,4 @@ GLOBAL_LIST_INIT(ghost_others_options, list(GHOST_OTHERS_SIMPLE, GHOST_OTHERS_DE
 	usr.client.prefs.tgui_fancy = !usr.client.prefs.tgui_fancy
 	usr.client.prefs.save_preferences()
 	SStgui.update_user_uis(usr)
-	to_chat(src, "<span class='interface'>TGUI window mode is now [usr.client.prefs.tgui_fancy ? "dis" : "en"]abled.</span>")
+	to_chat(src, "<span class='interface'>TGUI compatibility mode is now [usr.client.prefs.tgui_fancy ? "dis" : "en"]abled.</span>")


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the TGUI compability button present in the character setup as a byond verb, in the preferences tab.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Some people have issues with tgui, and using tgui to fix a tgui issue is not good, and leaves them stuck.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: You can now toggle TGUI window compability mode from the preferences tab too
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
