### PR TITLE
Adds emissive jaeger visors that glow in the dark

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -214,7 +214,7 @@
 #define COMSIG_ITEM_ATTACK_SELF "item_attack_self"				//from base of obj/item/attack_self(): (/mob)
 	#define COMPONENT_NO_INTERACT (1<<0)
 #define COMSIG_ITEM_EQUIPPED "item_equip"						//from base of obj/item/equipped(): (/mob/equipper, slot)
-#define COMSIG_ITEM_EQUIPPED_TO_SLOT "item_equip_to_slot"			//from base of obj/item/equipped(): (/mob/equipper)
+#define COMSIG_ITEM_EQUIPPED_TO_SLOT "item_equip_to_slot"			//from base of obj/item/equipped(): (/mob/equipper, slot)
 #define COMSIG_ITEM_EQUIPPED_NOT_IN_SLOT "item_equip_not_in_slot"	//from base of obj/item/equipped(): (/mob/equipper, slot)
 #define COMSIG_ITEM_UNEQUIPPED "item_unequip"						//from base of obj/item/unequipped(): (/mob/unequipper, slot)
 #define COMSIG_ITEM_DROPPED "item_drop"							//from base of obj/item/dropped(): (mob/user)
@@ -347,6 +347,10 @@
 #define COMSIG_HUMAN_MELEE_UNARMED_ATTACK "human_melee_unarmed_attack"	//from mob/living/carbon/human/UnarmedAttack(): (atom/target)
 #define COMSIG_HUMAN_DAMAGE_TAKEN "human_damage_taken"					//from human damage receiving procs: (mob/living/carbon/human/wearer, damage)
 #define COMSIG_HUMAN_LIMB_FRACTURED "human_limb_fractured"				//from [datum/limb/proc/fracture]: (mob/living/carbon/human/wearer, datum/limb/limb)
+///from [/mob/living/carbon/human/proc/apply_overlay]: (cache_index, list/overlays_to_apply)
+#define COMSIG_HUMAN_APPLY_OVERLAY "human_overlay_applied"
+///from [/mob/living/carbon/human/proc/remove_overlay]: (cache_index, list/overlays_to_remove)
+#define COMSIG_HUMAN_REMOVE_OVERLAY "human_overlay_removed"
 
 // shuttle signals
 #define COMSIG_SHUTTLE_SETMODE "shuttle_setmode"

--- a/code/datums/components/clothing_tint.dm
+++ b/code/datums/components/clothing_tint.dm
@@ -57,7 +57,7 @@
 	tinted_mob.update_sight()
 	mob_tinted = FALSE
 
-/datum/component/clothing_tint/proc/equipped_to_slot(datum/source, mob/user)
+/datum/component/clothing_tint/proc/equipped_to_slot(datum/source, mob/user, slot)
 	SIGNAL_HANDLER
 	tinted_mob = user
 	add_tint()

--- a/code/datums/elements/special_clothing_overlay.dm
+++ b/code/datums/elements/special_clothing_overlay.dm
@@ -1,0 +1,87 @@
+/**
+ * # Special_clothing_overlay element
+ *
+ * Handles special clothing overlays for humans that cannot use the standing overlays system
+ * Example uses include the use of emissives and similar
+ *
+ * primarily functions through child overrides to specify what should be applied when,
+ * see the Attach and [/datum/element/special_clothing_overlay/proc/get_overlay_icon()] (get_overlay_icon)
+ * procs for details
+ */
+/datum/element/special_clothing_overlay
+	id_arg_index = 2
+	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH
+	///The image/icon/mutable_appearance we arre going to be applying to here
+	var/overlay_to_apply
+	///when this layer is updated on the wearer, overlay_to_apply will be applied/removed with it
+	var/target_layer
+
+//override the args for this to create the desired overlay
+/datum/element/special_clothing_overlay/Attach(datum/target, applytarget)
+	. = ..()
+	if(!isclothing(target)|| !applytarget)
+		return ELEMENT_INCOMPATIBLE
+	if(!overlay_to_apply)
+		target_layer = applytarget
+		overlay_to_apply = get_overlay_icon()
+		if(!overlay_to_apply)
+			return ELEMENT_INCOMPATIBLE
+	RegisterSignal(target, COMSIG_ITEM_EQUIPPED_TO_SLOT, .proc/equipped)
+
+/datum/element/special_clothing_overlay/Detach(datum/source, force)
+	. = ..()
+	UnregisterSignal(source, COMSIG_ITEM_EQUIPPED_TO_SLOT)
+
+/**
+ * Fetches the special overlay we are going to be applying
+ */
+/datum/element/special_clothing_overlay/proc/get_overlay_icon()
+	CRASH("UNIMPLEMENTED OVERLAY GOTTEN")
+
+/**
+ * Called on owner equip, sets it up to update the wearers icon
+ */
+/datum/element/special_clothing_overlay/proc/equipped(obj/item/source, mob/equipper, slot)
+	SIGNAL_HANDLER
+	RegisterSignal(equipper, COMSIG_HUMAN_APPLY_OVERLAY, .proc/add_as_overlay)
+	RegisterSignal(equipper, COMSIG_HUMAN_REMOVE_OVERLAY, .proc/remove_as_overlay)
+	RegisterSignal(source, list(COMSIG_ITEM_EQUIPPED_NOT_IN_SLOT, COMSIG_ITEM_DROPPED), .proc/dropped)
+
+/**
+ * Signal handler for adding the overlay to the wearer
+ */
+/datum/element/special_clothing_overlay/proc/add_as_overlay(mob/source, cache_index, list/overlays)
+	SIGNAL_HANDLER
+	if(cache_index == target_layer)
+		overlays += overlay_to_apply
+
+/**
+ * Signal handler for removing the overlay from the  wearer
+ */
+/datum/element/special_clothing_overlay/proc/remove_as_overlay(mob/source, cache_index, list/overlays)
+	SIGNAL_HANDLER
+	if(cache_index == target_layer)
+		overlays += overlay_to_apply
+
+/**
+ * Signal handler for when the owner is taken off
+ */
+/datum/element/special_clothing_overlay/proc/dropped(datum/source, mob/equipper)
+	SIGNAL_HANDLER
+	UnregisterSignal(source, list(COMSIG_ITEM_EQUIPPED_NOT_IN_SLOT, COMSIG_ITEM_DROPPED))
+	UnregisterSignal(equipper, list(COMSIG_HUMAN_APPLY_OVERLAY, COMSIG_HUMAN_REMOVE_OVERLAY))
+
+/**
+ * Adds an emissive greyscale overlay to the wearer as the helmets visor
+ */
+/datum/element/special_clothing_overlay/modular_helmet_visor
+	///greyscale icon we fetch to make worn icon with
+	var/icon/special_icon
+
+/datum/element/special_clothing_overlay/modular_helmet_visor/Attach(datum/target, applytarget, greyscale_type, color_string)
+	if(!special_icon)
+		special_icon = SSgreyscale.GetColoredIconByType(greyscale_type, list(color_string))
+	return ..()
+
+/datum/element/special_clothing_overlay/modular_helmet_visor/get_overlay_icon()
+	return emissive_appearance(special_icon, "")

--- a/code/datums/greyscale/greyscale_configs.dm
+++ b/code/datums/greyscale/greyscale_configs.dm
@@ -126,3 +126,31 @@
 /datum/greyscale_config/modularlegs_skirmisher
 	icon_file = 'icons/mob/modular/skirmisher.dmi'
 	json_config = 'code/datums/greyscale/json_configs/modularlegs.json'
+
+
+/*
+ * MODULAR VISORS
+ */
+
+/datum/greyscale_config/modular_helmet_visor_emissive
+	icon_file = 'icons/mob/modular/infantry.dmi'
+	json_config = 'code/datums/greyscale/json_configs/modular_visor_emissive.json'
+
+/datum/greyscale_config/modular_helmet_visor_emissive/assault
+	icon_file = 'icons/mob/modular/assault.dmi'
+
+/datum/greyscale_config/modular_helmet_visor_emissive/eod
+	icon_file = 'icons/mob/modular/eod.dmi'
+
+/datum/greyscale_config/modular_helmet_visor_emissive/eva
+	icon_file = 'icons/mob/modular/eva.dmi'
+
+/datum/greyscale_config/modular_helmet_visor_emissive/scout
+	icon_file = 'icons/mob/modular/scout.dmi'
+
+/datum/greyscale_config/modular_helmet_visor_emissive/skirmisher
+	icon_file = 'icons/mob/modular/skirmisher.dmi'
+
+/datum/greyscale_config/modular_helmet_visor_emissive_skull
+	icon_file = 'icons/mob/modular/eva.dmi'
+	json_config = 'code/datums/greyscale/json_configs/modular_visor_emissive_skull.json'

--- a/code/datums/greyscale/json_configs/modular_visor_emissive.json
+++ b/code/datums/greyscale/json_configs/modular_visor_emissive.json
@@ -1,0 +1,10 @@
+{
+	"": [
+		{
+			"type": "icon_state",
+			"icon_state": "visor",
+			"blend_mode": "overlay",
+			"color_ids": [ 1 ]
+		}
+	]
+}

--- a/code/datums/greyscale/json_configs/modular_visor_emissive_skull.json
+++ b/code/datums/greyscale/json_configs/modular_visor_emissive_skull.json
@@ -1,0 +1,15 @@
+{
+	"": [
+		{
+			"type": "icon_state",
+			"icon_state": "visor",
+			"blend_mode": "overlay",
+			"color_ids": [ 1 ]
+		},
+		{
+			"type": "icon_state",
+			"icon_state": "helmet_skull",
+			"blend_mode": "overlay"
+		}
+	]
+}

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -306,7 +306,7 @@
 
 	var/equipped_to_slot = flags_equip_slot & slotdefine2slotbit(slot)
 	if(equipped_to_slot) // flags_equip_slot is a bitfield
-		SEND_SIGNAL(src, COMSIG_ITEM_EQUIPPED_TO_SLOT, user)
+		SEND_SIGNAL(src, COMSIG_ITEM_EQUIPPED_TO_SLOT, user, slot)
 	else
 		SEND_SIGNAL(src, COMSIG_ITEM_EQUIPPED_NOT_IN_SLOT, user, slot)
 

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -70,14 +70,20 @@ There are several things that need to be remembered:
 
 
 /mob/living/carbon/human/apply_overlay(cache_index)
+	var/list/to_add = list()
+	SEND_SIGNAL(src, COMSIG_HUMAN_APPLY_OVERLAY, cache_index, to_add)
 	var/image/I = overlays_standing[cache_index]
 	if(I)
-		overlays += I
+		to_add += I
+	overlays += to_add
 
 /mob/living/carbon/human/remove_overlay(cache_index)
+	var/list/to_remove = list()
+	SEND_SIGNAL(src, COMSIG_HUMAN_REMOVE_OVERLAY, cache_index, to_remove)
 	if(overlays_standing[cache_index])
-		overlays -= overlays_standing[cache_index]
+		to_remove += overlays_standing[cache_index]
 		overlays_standing[cache_index] = null
+	overlays -= to_remove
 
 /mob/living/carbon/human/apply_underlay(cache_index)
 	var/image/I = underlays_standing[cache_index]

--- a/code/modules/modular_armor/modular.dm
+++ b/code/modules/modular_armor/modular.dm
@@ -354,6 +354,13 @@
 	/// How long it takes to attach or detach to this item
 	var/equip_delay = 3 SECONDS
 
+	///whether this helmet should be using its emissive overlay or not
+	var/visor_emissive_on = TRUE
+	///Initial hex color we use when applying the visor color
+	var/visor_color_hex = "#f7fb58"
+	///Greyscale config color we use for the visor
+	var/visor_greyscale_config = /datum/greyscale_config/modular_helmet_visor_emissive
+
 	///Assoc list of color-hex for colors we're allowed to color this armor
 	var/static/list/colorable_colors = list(
 		"black" = "#474A50",
@@ -371,10 +378,28 @@
 		"pink" = "#D354BA",
 	)
 
+/obj/item/clothing/head/modular/Initialize(mapload)
+	. = ..()
+	if(!visor_emissive_on || !visor_greyscale_config)
+		return
+	AddElement(/datum/element/special_clothing_overlay/modular_helmet_visor, HEAD_LAYER, visor_greyscale_config, visor_color_hex)
+	update_icon()
+
+/obj/item/clothing/head/modular/Destroy()
+	QDEL_NULL(installed_module)
+	return ..()
+
 /obj/item/clothing/head/modular/update_greyscale(list/colors, update)
 	. = ..()
 	item_icons = list(slot_head_str = icon)
 	item_state = list(slot_head_str = "")
+	if(length(colors) >= 2) //for only single color helmets with no visor
+		visor_color_hex = colors[2]
+
+/obj/item/clothing/head/modular/examine(mob/user, distance, infix, suffix)
+	. = ..()
+	if(visor_greyscale_config)
+		to_chat(user, "Right click the helmet to toggle the visor internal lighting.")
 
 /obj/item/clothing/head/modular/attackby(obj/item/I, mob/user, params)
 	. = ..()
@@ -398,17 +423,23 @@
 	if(!do_after(user, 1 SECONDS, TRUE, src, BUSY_ICON_GENERIC))
 		return TRUE
 
-	var/list/raw_colors = splittext(greyscale_colors, "#")
 	var/list/split_colors = list(new_color)
-	if(length(raw_colors) >= 3) //for only single color helmets
-		split_colors += "#[raw_colors[3]]" //gets the visor color and keeps it(for now, rhis allows visor coloring later)
+	if(visor_color_hex)
+		split_colors += visor_color_hex
 	set_greyscale_colors(split_colors)
 	return TRUE
 
-
-/obj/item/clothing/head/modular/Destroy()
-	QDEL_NULL(installed_module)
-	return ..()
+/obj/item/clothing/head/modular/attack_hand_alternate(mob/living/carbon/human/user)
+	if(user.head == src)
+		return //must NOT be worn to toggle
+	if(!visor_greyscale_config)
+		return
+	visor_emissive_on = !visor_emissive_on
+	if(visor_emissive_on)
+		AddElement(/datum/element/special_clothing_overlay/modular_helmet_visor, HEAD_LAYER, visor_greyscale_config, visor_color_hex)
+	else
+		RemoveElement(/datum/element/special_clothing_overlay/modular_helmet_visor, HEAD_LAYER, visor_greyscale_config, visor_color_hex)
+	update_icon()
 
 /obj/item/clothing/head/modular/item_action_slot_check(mob/user, slot)
 	if(!ishuman(user))
@@ -462,6 +493,8 @@
 	. = ..()
 	if(installed_module)
 		. += image(installed_module.icon, installed_module.item_state)
+	if(visor_emissive_on)
+		. += emissive_appearance('icons/mob/modular/infantry.dmi', "visor")
 
 /obj/item/clothing/head/modular/apply_custom(image/standing)
 	if(installed_module)
@@ -508,42 +541,49 @@
 	soft_armor = list("melee" = 50, "bullet" = 50, "laser" = 50, "energy" = 50, "bomb" = 50, "bio" = 50, "rad" = 50, "fire" = 50, "acid" = 50)
 	accuracy_mod = 0
 	greyscale_config = /datum/greyscale_config/modularhelmet_infantry
+	visor_greyscale_config = /datum/greyscale_config/modular_helmet_visor_emissive
 
 /obj/item/clothing/head/modular/marine/skirmisher
 	name = "Jaeger Pattern Skirmisher Helmet"
 	desc = "Usually paired with the Jaeger Combat Exoskeleton. Can mount utility functions on the helmet hard points. Has Skirmisher markings."
 	icon_state = "skirmisher_helmet"
 	greyscale_config = /datum/greyscale_config/modularhelmet_skirmisher
+	visor_greyscale_config = /datum/greyscale_config/modular_helmet_visor_emissive/skirmisher
 
 /obj/item/clothing/head/modular/marine/assault
 	name = "Jaeger Pattern Assault Helmet"
 	desc = "Usually paired with the Jaeger Combat Exoskeleton. Can mount utility functions on the helmet hard points. Has Assault markings."
 	icon_state = "assault_helmet"
 	greyscale_config = /datum/greyscale_config/modularhelmet_assault
+	visor_greyscale_config = /datum/greyscale_config/modular_helmet_visor_emissive/assault
 
 /obj/item/clothing/head/modular/marine/eva
 	name = "Jaeger Pattern EVA Helmet"
 	desc = "Usually paired with the Jaeger Combat Exoskeleton. Can mount utility functions on the helmet hard points. Has EVA markings."
 	icon_state = "eva_helmet"
 	greyscale_config = /datum/greyscale_config/modularhelmet_eva
+	visor_greyscale_config = /datum/greyscale_config/modular_helmet_visor_emissive/eva
 
 /obj/item/clothing/head/modular/marine/eva/skull
 	name = "Jaeger Pattern EVA Skull Helmet"
 	desc = "Usually paired with the Jaeger Combat Exoskeleton. Can mount utility functions on the helmet hard points. Has EVA markings and a skull on the visor."
 	icon_state = "eva_skull_helmet"
 	greyscale_config = /datum/greyscale_config/modularhelmet_eva_skull
+	visor_greyscale_config = /datum/greyscale_config/modular_helmet_visor_emissive_skull
 
 /obj/item/clothing/head/modular/marine/eod
 	name = "Jaeger Pattern EOD Helmet"
 	desc = "Usually paired with the Jaeger Combat Exoskeleton. Can mount utility functions on the helmet hard points. Has EOD markings"
 	icon_state = "eod_helmet"
 	greyscale_config = /datum/greyscale_config/modularhelmet_eod
+	visor_greyscale_config = /datum/greyscale_config/modular_helmet_visor_emissive/eod
 
 /obj/item/clothing/head/modular/marine/scout
 	name = "Jaeger Pattern Scout Helmet"
 	desc = "Usually paired with the Jaeger Combat Exoskeleton. Can mount utility functions on the helmet hard points. Has Scout markings"
 	icon_state = "scout_helmet"
 	greyscale_config = /datum/greyscale_config/modularhelmet_scout
+	visor_greyscale_config = /datum/greyscale_config/modular_helmet_visor_emissive/scout
 
 /obj/item/clothing/head/modular/marine/infantry
 	name = "Jaeger Pattern Infantry-Open Helmet"
@@ -551,3 +591,5 @@
 	icon_state = "infantryopen_helmet"
 	greyscale_colors = "#5B6036"
 	greyscale_config = /datum/greyscale_config/modularhelmet_infantry_open
+	visor_color_hex = null //no visor, no color
+	visor_greyscale_config = null

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -322,6 +322,7 @@
 #include "code\datums\elements\pathfinder.dm"
 #include "code\datums\elements\scalping.dm"
 #include "code\datums\elements\shrapnel_removal.dm"
+#include "code\datums\elements\special_clothing_overlay.dm"
 #include "code\datums\elements\undertile.dm"
 #include "code\datums\elements\windowshutter.dm"
 #include "code\datums\emergency_calls\clf.dm"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/57223640/116993739-28a8da00-acd8-11eb-97a2-c6e30d4e776c.png)

## Why It's Good For The Game

Jaeger vendor next
Has a toggle because why not

## Changelog
:cl:
qol: Jaeger visors now glow in the dark, this can also be toggled with right clicking on the helmet
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
