### PR TITLE
Revert "Fix incorrect icon update procs (#6746)"

### DIFF
--- a/code/game/objects/items/implants/implantcase.dm
+++ b/code/game/objects/items/implants/implantcase.dm
@@ -17,7 +17,7 @@
 		update_icon()
 
 
-/obj/item/implantcase/update_icon_state()
+/obj/item/implantcase/update_icon()
 	if(imp)
 		icon_state = "implantcase-[imp.implant_color]"
 	else

--- a/code/game/objects/items/motion_detector.dm
+++ b/code/game/objects/items/motion_detector.dm
@@ -34,7 +34,7 @@
 	target_turf = null
 	return ..()
 
-/obj/effect/detector_blip/update_icon_state()
+/obj/effect/detector_blip/update_icon()
 	icon_state = "detector_blip[edge_blip ? "_dir" : ""][identifier]"
 
 /obj/item/motiondetector

--- a/code/game/objects/items/radio/detpack.dm
+++ b/code/game/objects/items/radio/detpack.dm
@@ -64,7 +64,7 @@
 	radio_connection = SSradio.add_object(src, frequency, RADIO_SIGNALER)
 
 
-/obj/item/detpack/update_icon_state()
+/obj/item/detpack/update_icon()
 	icon_state = "detpack_[plant_target ? "set_" : ""]"
 	if(on)
 		icon_state = "[icon_state][armed ? "armed" : "on"]"

--- a/code/game/objects/items/reagent_containers/blood_pack.dm
+++ b/code/game/objects/items/reagent_containers/blood_pack.dm
@@ -19,7 +19,7 @@
 /obj/item/reagent_containers/blood/on_reagent_change()
 	update_icon()
 
-/obj/item/reagent_containers/blood/update_icon_state()
+/obj/item/reagent_containers/blood/update_icon()
 
 	var/percent = PERCENT(reagents.total_volume / volume)
 	switch(percent)

--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -178,15 +178,14 @@
 	. = ..()
 	update_icon()
 
-/obj/item/reagent_containers/hypospray/update_icon_state()
-	if(!ismob(loc))
+/obj/item/reagent_containers/hypospray/update_icon()
+	if(ismob(loc))
+		if(inject_mode)
+			icon_state = "hypo_i"
+		else
+			icon_state = "hypo_d"
+	else
 		icon_state = "hypo"
-		return
-	if(inject_mode)
-		icon_state = "hypo_i"
-		return
-	icon_state = "hypo_d"
-
 
 /obj/item/reagent_containers/hypospray/advanced
 	icon_state = "hypo"

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -158,7 +158,7 @@
 	dir = NORTH
 	flags_atom = DIRLOCK
 
-/obj/item/stack/medical/advanced/update_icon_state()
+/obj/item/stack/medical/advanced/update_icon()
 	if(max_amount < 1 || amount > max_amount)
 		return
 	var/percentage = round(amount / max_amount) * 100

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -315,7 +315,7 @@
 	else
 		to_chat(user, "<span class='warning'>Its defibrillator recharge unit does not have a power cell installed!</span>")
 
-/obj/item/storage/backpack/marine/corpsman/update_icon_state()
+/obj/item/storage/backpack/marine/corpsman/update_icon()
 	icon_state = icon_skin
 	if(cell?.charge >= 0)
 		switch(PERCENT(cell.charge/cell.maxcharge))

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -38,15 +38,14 @@
 	can_hold = list() // any
 	cant_hold = list(/obj/item/disk/nuclear)
 
-/obj/item/storage/bag/trash/update_icon_state()
+/obj/item/storage/bag/trash/update_icon()
 	if(contents.len == 0)
 		icon_state = "trashbag0"
 	else if(contents.len < 12)
 		icon_state = "trashbag1"
 	else if(contents.len < 21)
 		icon_state = "trashbag2"
-	else
-		icon_state = "trashbag3"
+	else icon_state = "trashbag3"
 
 
 // -----------------------------

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -309,7 +309,7 @@
 	spawn_type = /obj/item/explosive/mine
 	spawn_number = 5
 
-/obj/item/storage/box/explosive_mines/update_icon_state()
+/obj/item/storage/box/explosive_mines/update_icon()
 	icon_state = initial(icon_state)
 	if(!length(contents))
 		icon_state += "_e"
@@ -357,7 +357,7 @@
 	spawn_type = /obj/item/explosive/grenade/frag
 	spawn_number = 25
 
-/obj/item/storage/box/nade_box/update_icon_state()
+/obj/item/storage/box/nade_box/update_icon()
 	icon_state = initial(icon_state)
 	if(!length(contents))
 		icon_state += "_e"
@@ -501,7 +501,7 @@
 
 	var/deployed = FALSE
 
-/obj/item/storage/box/ammo/update_icon_state()
+/obj/item/storage/box/ammo/update_icon()
 	if(!deployed)
 		icon_state = "[initial(icon_state)]"
 	else if(!(length(contents)))

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -28,7 +28,7 @@
 		for(var/i in 1 to spawn_number)
 			new spawn_type(src)
 
-/obj/item/storage/fancy/update_icon_state()
+/obj/item/storage/fancy/update_icon()
 	icon_state = "[icon_type]box[length(contents)]"
 
 /obj/item/storage/fancy/remove_from_storage(obj/item/W, atom/new_location)
@@ -145,7 +145,7 @@
 	for(var/i in 1 to storage_slots)
 		new /obj/item/clothing/mask/cigarette(src)
 
-/obj/item/storage/fancy/cigarettes/update_icon_state()
+/obj/item/storage/fancy/cigarettes/update_icon()
 	icon_state = "[initial(icon_state)][contents.len]"
 
 

--- a/code/game/objects/items/storage/large_holster.dm
+++ b/code/game/objects/items/storage/large_holster.dm
@@ -127,7 +127,8 @@
 	flags_equip_slot = ITEM_SLOT_BELT
 	can_hold = list(/obj/item/weapon/gun/smg/m25)
 
-/obj/item/storage/large_holster/m25/update_icon_state()
+/obj/item/storage/large_holster/m25/update_icon()
+	var/mob/user = loc
 	if(contents.len)
 		var/obj/I = contents[1]
 		icon_state = "[base_icon]_full_[I.icon_state]"
@@ -135,9 +136,7 @@
 	else
 		icon_state = base_icon
 		item_state = base_icon
-	if(ismob(loc))
-		var/mob/user = loc
-		user.update_inv_belt()
+	if(istype(user)) user.update_inv_belt()
 
 /obj/item/storage/large_holster/m25/full/Initialize()
 	. = ..()

--- a/code/game/objects/items/storage/surgical_tray.dm
+++ b/code/game/objects/items/storage/surgical_tray.dm
@@ -27,7 +27,7 @@
 	new /obj/item/tool/surgery/FixOVein(src)
 	new /obj/item/stack/nanopaste(src)
 
-/obj/item/storage/surgical_tray/update_icon_state()
+/obj/item/storage/surgical_tray/update_icon()
 	if(!contents.len)
 		icon_state = "surgical_tray_e"
 	else

--- a/code/game/objects/items/tools/flame_tools.dm
+++ b/code/game/objects/items/tools/flame_tools.dm
@@ -33,14 +33,13 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	light_color = LIGHT_COLOR_FIRE
 	var/wax = 800
 
-/obj/item/tool/candle/update_icon_state()
+/obj/item/tool/candle/update_icon()
 	var/i
 	if(wax>150)
 		i = 1
 	else if(wax>80)
 		i = 2
-	else
-		i = 3
+	else i = 3
 	icon_state = "candle[i][heat ? "_lit" : ""]"
 
 /obj/item/tool/candle/Destroy()

--- a/code/game/objects/items/toys/cards.dm
+++ b/code/game/objects/items/toys/cards.dm
@@ -38,14 +38,11 @@
 		qdel(I)
 		to_chat(user, "You place your cards on the bottom of the deck.")
 
-/obj/item/toy/deck/update_icon_state()
+/obj/item/toy/deck/update_icon()
 	switch(cards.len)
-		if(52)
-			icon_state = "deck"
-		if(1 to 51)
-			icon_state = "deck_open"
-		if(0)
-			icon_state = "deck_empty"
+		if(52) icon_state = "deck"
+		if(1 to 51) icon_state = "deck_open"
+		if(0) icon_state = "deck_empty"
 
 /obj/item/toy/deck/verb/draw_card()
 

--- a/code/game/objects/items/toys/toy_weapons.dm
+++ b/code/game/objects/items/toys/toy_weapons.dm
@@ -65,11 +65,11 @@
 
 	var/amount_left = 7
 
-/obj/item/toy/gun_ammo/update_icon_state()
-	if(amount_left)
-		icon_state = "cap_ammo"
-	else
-		icon_state = "cap_ammo_e"
+	update_icon()
+		if(amount_left)
+			icon_state = "cap_ammo"
+		else
+			icon_state = "cap_ammo_e"
 
 
 /*

--- a/code/game/objects/items/toys/toys.dm
+++ b/code/game/objects/items/toys/toys.dm
@@ -83,8 +83,8 @@
 		src.icon_state = "burst"
 		QDEL_IN(src, 5)
 
-/obj/item/toy/balloon/update_icon_state()
-	if(reagents.total_volume)
+/obj/item/toy/balloon/update_icon()
+	if(src.reagents.total_volume >= 1)
 		icon_state = "waterballoon"
 		item_state = "balloon"
 	else

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -37,7 +37,7 @@
 			update_icon()
 			return 0
 
-/obj/item/weapon/baton/update_icon_state()
+/obj/item/weapon/baton/update_icon()
 	if(status)
 		icon_state = "[initial(name)]_active"
 	else if(!bcell)
@@ -222,7 +222,7 @@
 	return FIRELOSS
 
 
-/obj/item/weapon/stunprod/update_icon_state()
+/obj/item/weapon/stunprod/update_icon()
 	if(status)
 		icon_state = "stunbaton_active"
 	else

--- a/code/game/objects/machinery/autodoc.dm
+++ b/code/game/objects/machinery/autodoc.dm
@@ -90,7 +90,7 @@
 	go_out(AUTODOC_NOTICE_NO_POWER)
 
 
-/obj/machinery/autodoc/update_icon_state()
+/obj/machinery/autodoc/update_icon()
 	if(machine_stat & NOPOWER)
 		icon_state = "autodoc_off"
 	else if(surgery)
@@ -935,7 +935,7 @@
 	return ..()
 
 
-/obj/machinery/autodoc_console/update_icon_state()
+/obj/machinery/autodoc_console/update_icon()
 	if(machine_stat & NOPOWER)
 		icon_state = "sleeperconsole-p"
 	else

--- a/code/game/objects/machinery/autolathe.dm
+++ b/code/game/objects/machinery/autolathe.dm
@@ -107,7 +107,7 @@
 	popup.set_content(dat)
 	popup.open()
 
-/obj/machinery/autolathe/update_icon_state()
+/obj/machinery/autolathe/update_icon()
 	icon_state = (CHECK_BITFIELD(machine_stat, PANEL_OPEN) ? "autolathe_t": "autolathe")
 
 /obj/machinery/autolathe/attackby(obj/item/I, mob/user, params)

--- a/code/game/objects/machinery/bioprinter.dm
+++ b/code/game/objects/machinery/bioprinter.dm
@@ -80,14 +80,14 @@
 	..()
 	to_chat(user, "It has [stored_matter] matter and [stored_metal] metal left.")
 
-/obj/machinery/bioprinter/update_icon_state()
+/obj/machinery/bioprinter/update_icon()
 	if(machine_stat & NOPOWER)
 		icon_state = "bioprinter_off"
-		return
-	if(working)
-		icon_state = "bioprinter_busy"
 	else
-		icon_state = "bioprinter"
+		if(working)
+			icon_state = "bioprinter_busy"
+		else
+			icon_state = "bioprinter"
 
 /obj/machinery/bioprinter/stocked
 	stored_metal = 1000

--- a/code/game/objects/machinery/buttons.dm
+++ b/code/game/objects/machinery/buttons.dm
@@ -26,7 +26,7 @@
 	update_icon()
 
 
-/obj/machinery/button/update_icon_state()
+/obj/machinery/button/update_icon()
 	if(machine_stat & (NOPOWER|BROKEN))
 		icon_state = "[initial(icon_state)]-p"
 	else
@@ -208,7 +208,7 @@
 	active = FALSE
 	update_icon()
 
-/obj/machinery/medical_help_button/update_icon_state()
+/obj/machinery/medical_help_button/update_icon()
 	if(machine_stat & NOPOWER)
 		icon_state = "doorctrl-p"
 	else

--- a/code/game/objects/machinery/cloning/cloning.dm
+++ b/code/game/objects/machinery/cloning/cloning.dm
@@ -201,7 +201,7 @@ These act as a respawn mechanic growning a body and offering it up to ghosts.
 		return
 
 
-/obj/machinery/cloning/vats/update_icon_state()
+/obj/machinery/cloning/vats/update_icon()
 	if(!beaker)
 		icon_state = "cell_0"
 		return

--- a/code/game/objects/machinery/computer/camera_console.dm
+++ b/code/game/objects/machinery/computer/camera_console.dm
@@ -167,7 +167,7 @@
 	circuit = null
 
 
-/obj/machinery/computer/security/telescreen/update_icon_state()
+/obj/machinery/computer/security/telescreen/update_icon()
 	icon_state = initial(icon_state)
 	if(machine_stat & (BROKEN|DISABLED))
 		icon_state += "b"

--- a/code/game/objects/machinery/computer/crew.dm
+++ b/code/game/objects/machinery/computer/crew.dm
@@ -20,7 +20,7 @@
 	var/sortkey = "name"
 
 
-/obj/machinery/computer/crew/update_icon_state()
+/obj/machinery/computer/crew/update_icon()
 	if(machine_stat & (BROKEN|DISABLED))
 		icon_state = "crewb"
 	else if(machine_stat & NOPOWER)

--- a/code/game/objects/machinery/door_control.dm
+++ b/code/game/objects/machinery/door_control.dm
@@ -115,7 +115,7 @@
 	pressed = FALSE
 	update_icon()
 
-/obj/machinery/door_control/update_icon_state()
+/obj/machinery/door_control/update_icon()
 	if(machine_stat & NOPOWER)
 		icon_state = "doorctrl-p"
 	else if(pressed)

--- a/code/game/objects/machinery/doors/airlock_control.dm
+++ b/code/game/objects/machinery/doors/airlock_control.dm
@@ -150,15 +150,14 @@ obj/machinery/airlock_sensor
 	var/alert = 0
 	var/previousPressure
 
-obj/machinery/airlock_sensor/update_icon_state()
+obj/machinery/airlock_sensor/update_icon()
 	if(on)
-		icon_state = "airlock_sensor_off"
-		return
-	if(alert)
-		icon_state = "airlock_sensor_alert"
+		if(alert)
+			icon_state = "airlock_sensor_alert"
+		else
+			icon_state = "airlock_sensor_standby"
 	else
-		icon_state = "airlock_sensor_standby"
-
+		icon_state = "airlock_sensor_off"
 
 obj/machinery/airlock_sensor/attack_hand(mob/living/user)
 	. = ..()
@@ -228,7 +227,7 @@ obj/machinery/access_button
 	var/on = 1
 
 
-obj/machinery/access_button/update_icon_state()
+obj/machinery/access_button/update_icon()
 	if(on)
 		icon_state = "access_button_standby"
 	else

--- a/code/game/objects/machinery/doors/poddoor.dm
+++ b/code/game/objects/machinery/doors/poddoor.dm
@@ -21,7 +21,7 @@
 /obj/machinery/door/poddoor/try_to_activate_door(mob/user)
 	return
 
-/obj/machinery/door/poddoor/update_icon_state()
+/obj/machinery/door/poddoor/update_icon()
 	if(density)
 		icon_state = "pdoor1"
 	else

--- a/code/game/objects/machinery/doors/railing.dm
+++ b/code/game/objects/machinery/doors/railing.dm
@@ -39,7 +39,7 @@
 	. = ..()
 	if(!density)
 		return 1
-
+	
 	if(get_dir(loc, target) == dir)
 		return 0
 	else
@@ -58,7 +58,7 @@
 	return TRUE
 
 
-/obj/machinery/door/poddoor/railing/update_icon_state()
+/obj/machinery/door/poddoor/railing/update_icon()
 	if(density)
 		icon_state = "railing1"
 	else

--- a/code/game/objects/machinery/doors/shutters.dm
+++ b/code/game/objects/machinery/doors/shutters.dm
@@ -54,7 +54,7 @@
 	operating = FALSE
 
 
-/obj/machinery/door/poddoor/shutters/update_icon_state()
+/obj/machinery/door/poddoor/shutters/update_icon()
 	if(operating)
 		return
 	icon_state = "shutter[density]"

--- a/code/game/objects/machinery/doors/windowdoor.dm
+++ b/code/game/objects/machinery/doors/windowdoor.dm
@@ -37,7 +37,7 @@
 	. = ..()
 
 
-/obj/machinery/door/window/update_icon_state()
+/obj/machinery/door/window/update_icon()
 	if(operating)
 		return
 	icon_state = density ? base_state : "[base_state]open"

--- a/code/game/objects/machinery/dropship_part_fabricator.dm
+++ b/code/game/objects/machinery/dropship_part_fabricator.dm
@@ -12,7 +12,7 @@
 	icon_state = "drone_fab_idle"
 	var/busy = FALSE
 
-/obj/machinery/dropship_part_fabricator/update_icon_state()
+/obj/machinery/dropship_part_fabricator/update_icon()
 	if(machine_stat & NOPOWER)
 		icon_state = "drone_fab_nopower"
 		return

--- a/code/game/objects/machinery/flasher.dm
+++ b/code/game/objects/machinery/flasher.dm
@@ -33,8 +33,8 @@
 	density = TRUE
 
 
-/obj/machinery/flasher/update_icon_state()
-	if(!(machine_stat & NOPOWER))
+/obj/machinery/flasher/update_icon()
+	if ( !(machine_stat & NOPOWER) )
 		icon_state = "[base_state]1"
 	else
 		icon_state = "[base_state]1-p"

--- a/code/game/objects/machinery/hologram.dm
+++ b/code/game/objects/machinery/hologram.dm
@@ -298,7 +298,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 		set_light(0)
 	update_icon()
 
-/obj/machinery/holopad/update_icon_state()
+/obj/machinery/holopad/update_icon()
 	var/total_users = LAZYLEN(masters) + LAZYLEN(holo_calls)
 	if(ringing)
 		icon_state = "holopad_ringing"

--- a/code/game/objects/machinery/holosign.dm
+++ b/code/game/objects/machinery/holosign.dm
@@ -16,7 +16,7 @@
 	lit = !lit
 	update_icon()
 
-/obj/machinery/holosign/update_icon_state()
+/obj/machinery/holosign/update_icon()
 	if(!lit)
 		icon_state = "sign_off"
 	else

--- a/code/game/objects/structures/crates_lockers/closets/coffin.dm
+++ b/code/game/objects/structures/crates_lockers/closets/coffin.dm
@@ -6,7 +6,7 @@
 	icon_opened = "coffin_open"
 	anchored = FALSE
 
-/obj/structure/closet/coffin/update_icon_state()
+/obj/structure/closet/coffin/update_icon()
 	if(!opened)
 		icon_state = icon_closed
 	else

--- a/code/game/objects/structures/crates_lockers/closets/gimmick.dm
+++ b/code/game/objects/structures/crates_lockers/closets/gimmick.dm
@@ -5,7 +5,7 @@
 	icon_closed = "cabinet_closed"
 	icon_opened = "cabinet_open"
 
-/obj/structure/closet/cabinet/update_icon_state()
+/obj/structure/closet/cabinet/update_icon()
 	if(!opened)
 		icon_state = icon_closed
 	else

--- a/code/game/objects/structures/crates_lockers/closets/secure/bar.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/bar.dm
@@ -22,18 +22,17 @@
 	new /obj/item/reagent_containers/food/drinks/cans/beer( src )
 	new /obj/item/reagent_containers/food/drinks/cans/beer( src )
 
-/obj/structure/closet/secure_closet/bar/update_icon_state()
+/obj/structure/closet/secure_closet/bar/update_icon()
 	if(broken)
 		icon_state = icon_broken
-		return
-	if(opened)
-		icon_state = icon_opened
-		return
-	if(locked)
-		icon_state = icon_locked
 	else
-		icon_state = icon_closed
-
+		if(!opened)
+			if(locked)
+				icon_state = icon_locked
+			else
+				icon_state = icon_closed
+		else
+			icon_state = icon_opened
 
 /obj/structure/closet/secure_closet/bar/captain
 	name = "Success Cabinet"

--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -7,17 +7,17 @@
 	icon_broken = "fridgebroken"
 	icon_off = "fridge1"
 
-/obj/structure/closet/secure_closet/freezer/update_icon_state()
+/obj/structure/closet/secure_closet/freezer/update_icon()
 	if(broken)
 		icon_state = icon_broken
-		return
-	if(opened)
-		icon_state = icon_opened
-		return
-	if(locked)
-		icon_state = icon_locked
 	else
-		icon_state = icon_closed
+		if(!opened)
+			if(locked)
+				icon_state = icon_locked
+			else
+				icon_state = icon_closed
+		else
+			icon_state = icon_opened
 
 /obj/structure/closet/secure_closet/freezer/kitchen
 	name = "Kitchen Cabinet"

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -88,10 +88,10 @@
 	take_damage(5, BURN, "fire")
 
 
-/obj/structure/flora/tree/update_overlays()
-	. = ..()
+/obj/structure/flora/tree/update_icon()
+	overlays.Cut()
 	if(on_fire)
-		. += image(icon, "fire")
+		overlays += "fire"
 
 /obj/structure/flora/stump
 	name = "stump"

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -325,7 +325,7 @@
 	return ..()
 
 
-/obj/structure/girder/update_icon_state()
+/obj/structure/girder/update_icon()
 	switch(girder_state)
 		if(GIRDER_BROKEN, GIRDER_BROKEN_PATCHED)
 			icon_state = "[icon_prefix]_damaged"

--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -52,7 +52,7 @@
 	GLOB.ladder_list -= src
 	. = ..()
 
-/obj/structure/ladder/update_icon_state()
+/obj/structure/ladder/update_icon()
 	if(up && down)
 		icon_state = "ladder11"
 

--- a/code/game/objects/structures/orbital_cannon.dm
+++ b/code/game/objects/structures/orbital_cannon.dm
@@ -38,14 +38,14 @@
 	tray.linked_ob = src
 
 
-/obj/structure/orbital_cannon/update_icon_state()
+/obj/structure/orbital_cannon/update_icon()
 	if(chambered_tray)
 		icon_state = "OBC_chambered"
-		return
-	if(loaded_tray)
-		icon_state = "OBC_loaded"
 	else
-		icon_state = "OBC_unloaded"
+		if(loaded_tray)
+			icon_state = "OBC_loaded"
+		else
+			icon_state = "OBC_unloaded"
 
 
 /obj/structure/orbital_cannon/proc/load_tray(mob/user)
@@ -246,12 +246,13 @@
 	. = ..()
 
 
-/obj/structure/orbital_tray/update_overlays()
-	. = ..()
+/obj/structure/orbital_tray/update_icon()
+	overlays.Cut()
+	icon_state = "cannon_tray"
 	if(warhead)
-		. += image("cannon_tray_[warhead.warhead_kind]")
+		overlays += image("cannon_tray_[warhead.warhead_kind]")
 	if(fuel_amt)
-		. += image("cannon_tray_[fuel_amt]")
+		overlays += image("cannon_tray_[fuel_amt]")
 
 
 /obj/structure/orbital_tray/attackby(obj/item/I, mob/user, params)

--- a/code/game/objects/structures/razorwire.dm
+++ b/code/game/objects/structures/razorwire.dm
@@ -214,7 +214,7 @@
 		deconstruct(FALSE)
 		return TRUE
 
-/obj/structure/razorwire/update_icon_state()
+/obj/structure/razorwire/update_icon()
 	var/health_percent = round(obj_integrity/max_integrity * 100)
 	var/remaining = CEILING(health_percent, 25)
 	icon_state = "[base_icon_state]_[remaining]"

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -94,7 +94,7 @@ FLOOR SAFES
 		tumbler_2_pos = 0
 
 
-/obj/structure/safe/update_icon_state()
+/obj/structure/safe/update_icon()
 	if(open)
 		icon_state = "[initial(icon_state)]-open"
 	else

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -27,13 +27,12 @@
 	var/accepts_bodybag = FALSE //Whether you can buckle bodybags to this bed
 	var/base_bed_icon //Used by beds that change sprite when something is buckled to them
 
-/obj/structure/bed/update_icon_state()
-	if(!base_bed_icon)
-		return
-	if(LAZYLEN(buckled_mobs) || buckled_bodybag)
-		icon_state = "[base_bed_icon]_up"
-	else
-		icon_state = "[base_bed_icon]_down"
+/obj/structure/bed/update_icon()
+	if(base_bed_icon)
+		if(LAZYLEN(buckled_mobs) || buckled_bodybag)
+			icon_state = "[base_bed_icon]_up"
+		else
+			icon_state = "[base_bed_icon]_down"
 
 obj/structure/bed/Destroy()
 	if(buckled_bodybag)

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -45,7 +45,7 @@ obj/structure/windoor_assembly/Destroy()
 	. = ..()
 	update_icon()
 
-/obj/structure/windoor_assembly/update_icon_state()
+/obj/structure/windoor_assembly/update_icon()
 	icon_state = "[facing]_[secure]windoor_assembly[state]"
 
 /obj/structure/windoor_assembly/CanAllowThrough(atom/movable/mover, turf/target)

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -20,12 +20,13 @@
 		playsound(src, 'sound/weapons/handcuffs.ogg', 30, TRUE, -3)
 
 
-/obj/item/assembly/mousetrap/update_icon_state()
+/obj/item/assembly/mousetrap/update_icon()
 	if(armed)
 		icon_state = "mousetraparmed"
 	else
 		icon_state = "mousetrap"
-	holder?.update_icon()
+	if(holder)
+		holder.update_icon()
 
 
 /obj/item/assembly/mousetrap/proc/triggered(mob/target, type = "feet")

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -47,10 +47,14 @@
 				circ1 = null
 				circ2 = null
 
-/obj/machinery/power/generator/update_overlays()
-	. = ..()
-	if(lastgenlev != 0)
-		. += image('icons/obj/power.dmi', "teg-op[lastgenlev]")
+/obj/machinery/power/generator/update_icon()
+	if(machine_stat & (NOPOWER|BROKEN))
+		overlays.Cut()
+	else
+		overlays.Cut()
+
+		if(lastgenlev != 0)
+			overlays += image('icons/obj/power.dmi', "teg-op[lastgenlev]")
 
 /obj/machinery/power/generator/process()
 	if(!circ1 || !circ2 || !anchored || machine_stat & (BROKEN|NOPOWER))

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -55,7 +55,7 @@
 		update_icon()
 		soundloop.start()
 
-/obj/machinery/power/port_gen/update_icon_state()
+/obj/machinery/power/port_gen/update_icon()
 	icon_state = "[base_icon]"
 
 /obj/machinery/power/port_gen/process()

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -191,7 +191,7 @@ bullets/shells. ~N
 	flags_magazine = AMMUNITION_HANDFUL
 	attack_speed = 3 // should make reloading less painful
 
-/obj/item/ammo_magazine/handful/update_icon_state() //Handles the icon itself as well as some bonus things.
+/obj/item/ammo_magazine/handful/update_icon() //Handles the icon itself as well as some bonus things.
 	if(max_rounds >= current_rounds)
 		var/I = current_rounds*50 // For the metal.
 		materials = list(/datum/material/metal = I)
@@ -327,14 +327,12 @@ Turn() or Shift() as there is virtually no overhead. ~N
 	var/max_bullet_amount = 800
 	var/caliber = CALIBER_10X24_CASELESS
 
-/obj/item/big_ammo_box/update_icon_state()
-	if(bullet_amount)
-		icon_state = base_icon_state
-		return
-	icon_state = "[base_icon_state]_e"
+/obj/item/big_ammo_box/update_icon()
+	if(bullet_amount) icon_state = base_icon_state
+	else icon_state = "[base_icon_state]_e"
 
 /obj/item/big_ammo_box/examine(mob/user)
-	. = ..()
+	..()
 	if(bullet_amount)
 		to_chat(user, "It contains [bullet_amount] round\s.")
 	else


### PR DESCRIPTION
Reverts #6746

Some movement blocking objects are losing their icon at map load. Shutters (LZ, Privacy, CIC, Containment, all of them), windoors, and probably other things too.