### PR TITLE
Foam razorwire doesn't exist anymore.

### DIFF
--- a/code/game/objects/effects/effect_system/foam.dm
+++ b/code/game/objects/effects/effect_system/foam.dm
@@ -44,7 +44,7 @@
 
 			var/turf/open/T = mystery_turf
 			if(T.allow_construction) //No loopholes.
-				new /obj/structure/razorwire/foam(loc)
+				new /obj/structure/razorwire(loc)
 
 		else if(metal == METAL_FOAM)
 			new /obj/structure/foamedmetal(loc)

--- a/code/game/objects/structures/razorwire.dm
+++ b/code/game/objects/structures/razorwire.dm
@@ -17,11 +17,6 @@
 	max_integrity = RAZORWIRE_MAX_HEALTH
 	var/soak = 5
 
-/obj/structure/razorwire/foam
-	desc = "A bundle of barbed wire supported by metal rods, crudely built by iron-consuming nanites. Weld them to bring them to their full strength."
-	max_integrity = RAZORWIRE_MAX_HEALTH
-	obj_integrity = RAZORWIRE_MAX_HEALTH/2
-
 /obj/structure/razorwire/deconstruct(disassembled = TRUE)
 	if(disassembled)
 		if(obj_integrity > max_integrity * 0.5)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Razorburn gas makes regular razorwire. You can't repair it anymore without metal, so I believe this is acceptable.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Tweak to make a marginal item more relevant and keep crushers out. Also prevent acid from one-shotting a whole canister in one go.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Razorburn starts at full HP.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
