### PR TITLE
TP-44 and mateba are blacklisted from fitting in backpacks

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -15,7 +15,7 @@
 
 	cant_hold = list(
 		/obj/item/weapon/gun/revolver/standard_revolver,
-		obj/item/weapon/gun/revolver/mateba,
+		/obj/item/weapon/gun/revolver/mateba,
 		/obj/item/weapon/gun/revolver/m44,
 
 	)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -16,6 +16,8 @@
 	cant_hold = list(
 		/obj/item/weapon/gun/revolver/standard_revolver,
 		obj/item/weapon/gun/revolver/mateba,
+		/obj/item/weapon/gun/revolver/m44,
+
 	)
 
 /obj/item/storage/backpack/attack_hand(mob/living/user)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -15,6 +15,7 @@
 
 	cant_hold = list(
 		/obj/item/weapon/gun/revolver/standard_revolver,
+		obj/item/weapon/gun/revolver/mateba,
 	)
 
 /obj/item/storage/backpack/attack_hand(mob/living/user)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -13,6 +13,10 @@
 	max_storage_space = 24
 	var/worn_accessible = FALSE //whether you can access its content while worn on the back
 
+	cant_hold = list(
+		/obj/item/weapon/gun/revolver/standard_revolver,
+	)
+
 /obj/item/storage/backpack/attack_hand(mob/living/user)
 	if(!worn_accessible && ishuman(user))
 		var/mob/living/carbon/human/H = user

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -17,7 +17,6 @@
 		/obj/item/weapon/gun/revolver/standard_revolver,
 		/obj/item/weapon/gun/revolver/mateba,
 		/obj/item/weapon/gun/revolver/m44,
-
 	)
 
 /obj/item/storage/backpack/attack_hand(mob/living/user)

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -536,6 +536,7 @@
 
 	cant_hold = list(
 		/obj/item/weapon/gun/revolver/standard_revolver,
+		/obj/item/weapon/gun/revolver/mateba,
 	)
 
 

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -534,6 +534,9 @@
 	icon_state= "sparepouch"
 	item_state= "sparepouch"
 
+	cant_hold = list(
+		/obj/item/weapon/gun/revolver/standard_revolver,
+	)
 
 
 
@@ -632,12 +635,12 @@
 	if(!istype(I, /obj/item/weapon/gun/pistol))
 		return ..()
 	var/obj/item/weapon/gun/pistol/gun = I
-	for(var/obj/item/ammo_magazine/mag in contents) 
+	for(var/obj/item/ammo_magazine/mag in contents)
 		if(!istype(gun, mag.gun_type))
 			continue
 		if(user.l_hand && user.r_hand || gun.current_mag)
 			gun.tactical_reload(mag, user)
-		else 
+		else
 			gun.reload(user, mag)
 		orient2hud()
 		return

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -537,6 +537,7 @@
 	cant_hold = list(
 		/obj/item/weapon/gun/revolver/standard_revolver,
 		/obj/item/weapon/gun/revolver/mateba,
+		/obj/item/weapon/gun/revolver/m44,
 	)
 
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title, they are not fittable in bags anymore.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It was a funny run for the bag revolvers, it is time for them to be laid to rest with raid boss queen and xeno king in the realm of bad design memes.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: TP-44 revolvers and Matebas no longer fit in bags
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
