### PR TITLE
Fix psy drained trait being applied too often

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -46,7 +46,6 @@
 
 /mob/living/carbon/human/proc/set_undefibbable()
 	ADD_TRAIT(src, TRAIT_UNDEFIBBABLE , TRAIT_UNDEFIBBABLE)
-	ADD_TRAIT(src, TRAIT_PSY_DRAINED, TRAIT_PSY_DRAINED)
 	SSmobs.stop_processing(src) //Last round of processing.
 
 	if(CHECK_BITFIELD(status_flags, XENO_HOST))

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -87,6 +87,7 @@
 		H.internal_organs_by_name -= "brain"
 		H.internal_organs -= O
 		H.set_undefibbable()
+		ADD_TRAIT(H, TRAIT_PSY_DRAINED, TRAIT_PSY_DRAINED) //for xeno hud
 
 	X.do_attack_animation(victim, ATTACK_EFFECT_BITE)
 	playsound(victim, pick( 'sound/weapons/alien_tail_attack.ogg', 'sound/weapons/alien_bite1.ogg'), 50)
@@ -1025,7 +1026,7 @@
 		to_use.update_burst()
 		to_use.forceMove(hivesilo)
 		moved_human_number++
-	
+
 	succeed_activate()
 
 ////////////////////


### PR DESCRIPTION
## About The Pull Request

Don't apply `TRAIT_PSY_DRAINED` during `set_undefibbable()` anymore.

Do apply it on successful headbite, so we can still get the use out of the hud icon for non distress modes.

## Why It's Good For The Game

Eating a bullet, going cold, or calling undefibbable any other way prevents psy draining for some reason. This is the fix.

## Changelog
:cl:
fix: Fixed psy drain not working on some corpses which it should.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
