### PR TITLE
Banished Targets Now Disgorge Living Contents

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
@@ -534,6 +534,10 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	new /area/arrival(target_turf) //So we don't get instagibbed from the space area
 
 	for(var/mob/living/living_contents in banishment_target.contents) //Safety measure so living mobs inside the target don't get lost in Brazilspace forever
+		if(isxeno(banishment_target)) //If we're a xeno, disgorge all vored contents
+			var/mob/living/carbon/xenomorph/xeno_target = banishment_target
+			xeno_target.eject_victim()
+
 		living_contents.forceMove(banished_turf)
 
 	banishment_target.forceMove(target_turf)

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
@@ -532,6 +532,10 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 
 	var/turf/target_turf = reserved_area.reserved_turfs[5]
 	new /area/arrival(target_turf) //So we don't get instagibbed from the space area
+
+	for(var/mob/living/living_contents in banishment_target.contents) //Safety measure so living mobs inside the target don't get lost in Brazilspace forever
+		living_contents.forceMove(banished_turf)
+
 	banishment_target.forceMove(target_turf)
 
 	var/duration = ghost.xeno_caste.wraith_banish_base_duration //Set the duration

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
@@ -533,11 +533,11 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	var/turf/target_turf = reserved_area.reserved_turfs[5]
 	new /area/arrival(target_turf) //So we don't get instagibbed from the space area
 
-	for(var/mob/living/living_contents in banishment_target.contents) //Safety measure so living mobs inside the target don't get lost in Brazilspace forever
-		if(isxeno(banishment_target)) //If we're a xeno, disgorge all vored contents
-			var/mob/living/carbon/xenomorph/xeno_target = banishment_target
-			xeno_target.eject_victim()
+	if(isxeno(banishment_target)) //If we're a xeno, disgorge all vored contents
+		var/mob/living/carbon/xenomorph/xeno_target = banishment_target
+		xeno_target.eject_victim()
 
+	for(var/mob/living/living_contents in banishment_target.contents) //Safety measure so living mobs inside the target don't get lost in Brazilspace forever
 		living_contents.forceMove(banished_turf)
 
 	banishment_target.forceMove(target_turf)


### PR DESCRIPTION
## About The Pull Request

Banished Targets Now Disgorge Living Contents

## Why It's Good For The Game

Stops living contents from leaving/being ejected from banished targets in Brazilspace, thus being trapped there forever.

## Changelog
:cl:
code: Banished targets are now emptied of all living mobs before being sent to Brazilspace.
/:cl: