### PR TITLE
Include a notice with sand storm damage like acid rain does

### DIFF
--- a/code/datums/weather/weather_types/sand_storm.dm
+++ b/code/datums/weather/weather_types/sand_storm.dm
@@ -26,6 +26,7 @@
 	if(is_storm_immune(L))
 		return
 	L.adjustBruteLoss(6)
+	to_chat(L, "<span class='boldannounce'>You are battered by the coarse sand!</span>")
 
 /datum/weather/ash_storm/sand/harmless
 	name = "Sandfall"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a chat notice to the sand storm `weather_act` just like the acid rain has. 

## Why It's Good For The Game

Taking damage with no feedback is bad, even if there was an alarm before the storm.

## Changelog
:cl:
qol: Damage taken from harmful sand storms now comes with a combat log notification.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
