### PR TITLE
Banish Now Toggles On/Off; Recall Removed

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -594,7 +594,6 @@
 #define COMSIG_XENOABILITY_RESYNC "xenoability_resync"
 #define COMSIG_XENOABILITY_BLINK "xenoability_blink"
 #define COMSIG_XENOABILITY_BANISH "xenoability_banish"
-#define COMSIG_XENOABILITY_RECALL "xenoability_recall"
 
 #define COMSIG_XENOABILITY_SCATTER_SPIT "xenoability_scatter_spit"
 

--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -11,5 +11,6 @@
 #define ON_FIRE				(1<<2) //currently on fire
 #define XENO_DAMAGEABLE		(1<<3) //xenos can damage this by slashing and spitting
 #define DROPSHIP_IMMUNE		(1<<4) //dropship cannot land on it
+#define SELF_BANISHED		(1<<5) //Wraith that has banished itself so it can get around click restrictions to recall
 
 #define RESIST_ALL (UNACIDABLE|INDESTRUCTIBLE)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -54,7 +54,7 @@
 	if(check_click_intercept(params, A))
 		return
 
-	if(notransform)
+	if(notransform && !CHECK_BITFIELD(A.resistance_flags, SELF_BANISHED)) //If we're in notransform stasis and we haven't banished ourselves, cancel out
 		return
 
 	if(SEND_SIGNAL(src, COMSIG_MOB_CLICKON, A, params) & COMSIG_MOB_CLICK_CANCELED)

--- a/code/datums/keybinding/xeno.dm
+++ b/code/datums/keybinding/xeno.dm
@@ -516,10 +516,4 @@
 	description = "Banish a creature or object a short distance away within line of sight to null space. Can target oneself and allies. Can be manually cancelled with Recall."
 	keybind_signal = COMSIG_XENOABILITY_BANISH
 
-/datum/keybinding/xeno/recall
-	name = "recall"
-	full_name = "Wraith: Recall"
-	description = "Recall a target from netherspace, ending Banish's effect."
-	keybind_signal = COMSIG_XENOABILITY_RECALL
-
 //Wraith keybinds - END

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
@@ -501,7 +501,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 // ***************************************
 /datum/action/xeno_action/activable/banish
 	name = "Banish"
-	action_icon_state = "banish"
+	action_icon_state = "Banish"
 	mechanics_text = "We banish a target object or creature within line of sight to nullspace for a short duration. Can target onself and allies. Non-friendlies are banished for half as long."
 	use_state_flags = XACT_TARGET_SELF
 	plasma_cost = 100
@@ -516,12 +516,23 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	var/banish_duration_timer_id
 	///Phantom zone reserved area
 	var/datum/turf_reservation/reserved_area
+	///Cooldown modifier
+	var/cooldown_mod = 1
 
 /datum/action/xeno_action/activable/banish/Destroy()
 	QDEL_NULL(reserved_area) //clean up
 	return ..()
 
+/datum/action/xeno_action/activable/banish/can_use_action(silent = FALSE, override_flags)
+	if(banishment_target) //Toggle off if we have a Banished target
+		return TRUE
+
+	return ..()
+
 /datum/action/xeno_action/activable/banish/can_use_ability(atom/A, silent = FALSE, override_flags)
+	if(banishment_target) //Toggle off if we have a Banished target
+		return TRUE
+
 	. = ..()
 
 	if(owner.status_flags & INCORPOREAL) //We can't use this while phased out.
@@ -549,7 +560,12 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 
 
 /datum/action/xeno_action/activable/banish/use_ability(atom/movable/A)
+	if(banishment_target) //Toggle off if we have a Banished target
+		banish_deactivate()
+		return
+
 	. = ..()
+
 	var/mob/living/carbon/xenomorph/wraith/ghost = owner
 	var/banished_turf = get_turf(A) //Set the banishment turf.
 	banishment_target = A //Set the banishment target
@@ -562,9 +578,11 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 
 	if(isliving(A))
 		var/mob/living/stasis_target = banishment_target
-		stasis_target.apply_status_effect(/datum/status_effect/incapacitating/unconscious) //Force the target to KO
 		stasis_target.notransform = TRUE //Stasis
+		stasis_target.apply_status_effect(/datum/status_effect/incapacitating/unconscious) //Force the target to KO
 		stasis_target.overlay_fullscreen("banish", /obj/screen/fullscreen/blind) //Force the blind overlay
+		if(A == ghost)
+			stasis_target.resistance_flags = RESIST_ALL|SELF_BANISHED //So we can get around click restrictions that arise from notransform
 
 	if(!reserved_area) //If we don't have a reserved area, set one
 		reserved_area = SSmapping.RequestBlockReservation(3,3, SSmapping.transit.z_value, /datum/turf_reservation/banish)
@@ -582,7 +600,6 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	animate(portal.get_filter("banish_portal_1"), x = 20*rand() - 10, y = 20*rand() - 10, time = 0.5 SECONDS, loop = -1, flags=ANIMATION_PARALLEL)
 	animate(portal.get_filter("banish_portal_2"), x = 20*rand() - 10, y = 20*rand() - 10, time = 0.5 SECONDS, loop = -1, flags=ANIMATION_PARALLEL)
 
-	var/cooldown_mod = 1
 	if(isliving(banishment_target) && !(banishment_target.issamexenohive(ghost))) //We halve the max duration for living non-allies
 		duration *= WRAITH_BANISH_NONFRIENDLY_LIVING_MULTIPLIER
 	else if (banishment_target.issamexenohive(ghost))
@@ -601,8 +618,10 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	addtimer(CALLBACK(src, .proc/banish_warning), duration * 0.7) //Warn when Banish is about to end
 	banish_duration_timer_id = addtimer(CALLBACK(src, .proc/banish_deactivate), duration, TIMER_STOPPABLE) //store the timer ID
 
+	keybind_flags = XACT_KEYBIND_USE_ABILITY|XACT_IGNORE_SELECTED_ABILITY
 	succeed_activate()
-	add_cooldown(cooldown_timer * cooldown_mod)
+	name = "Recall"
+	update_button_icon(name)
 
 	GLOB.round_statistics.wraith_banishes++
 	SSblackbox.record_feedback("tally", "round_statistics", 1, "wraith_banishes") //Statistics
@@ -645,41 +664,22 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	QDEL_NULL(portal) //Eliminate the Brazil portal if we need to
 
 	banishment_target = null
+	name = initial(name)
+	update_button_icon(name)
+	add_cooldown(cooldown_timer * cooldown_mod) //Now trigger the proper cooldown since we've actually used it
+	cooldown_mod = initial(cooldown_mod) //Revert the cooldown modifier
+	keybind_flags = initial(keybind_flags)
 
-	return TRUE //For the recall sub-ability
 
 /datum/action/xeno_action/activable/banish/on_cooldown_finish()
 	to_chat(owner, "<span class='xenodanger'>We are able to banish again.</span>")
 	owner.playsound_local(owner, 'sound/effects/xeno_newlarva.ogg', 25, 0, 1)
 	return ..()
 
-// ***************************************
-// *********** Recall
-// ***************************************
-/datum/action/xeno_action/recall
-	name = "Recall"
-	action_icon_state = "recall"
-	mechanics_text = "We recall a target we've banished back from the depths of nullspace."
-	use_state_flags = XACT_USE_NOTTURF|XACT_USE_STAGGERED|XACT_USE_INCAP|XACT_USE_LYING //So we can recall ourselves from nether Brazil
-	cooldown_timer = 1 SECONDS //Token for anti-spam
-	keybind_signal = COMSIG_XENOABILITY_RECALL
-
-/datum/action/xeno_action/recall/can_use_action(silent = FALSE, override_flags)
-	. = ..()
-
-	var/datum/action/xeno_action/activable/banish/banish_check = owner.actions_by_path[/datum/action/xeno_action/activable/banish]
-	if(!banish_check) //Mainly for when we transition on upgrading
-		return FALSE
-
-	if(!banish_check.banishment_target)
-		if(!silent)
-			to_chat(owner,"<span class='xenodanger'>We have no targets banished!</span>")
-		return FALSE
-
-
-/datum/action/xeno_action/recall/action_activate()
-	. = ..()
-	var/datum/action/xeno_action/activable/banish/banish_check = owner.actions_by_path[/datum/action/xeno_action/activable/banish]
-	banish_check.banish_deactivate()
-	succeed_activate()
-	add_cooldown()
+/datum/action/xeno_action/activable/banish/update_button_icon(input) //So we display the proper icon
+	if(!input) //If we're not overriding, proceed as normal
+		return ..()
+	button.overlays.Cut()
+	button.name = input
+	button.overlays += image('icons/mob/actions.dmi', button, input)
+	return ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/castedatum_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/castedatum_wraith.dm
@@ -49,7 +49,6 @@
 		/datum/action/xeno_action/activable/devour,
 		/datum/action/xeno_action/activable/blink,
 		/datum/action/xeno_action/activable/banish,
-		/datum/action/xeno_action/recall,
 		/datum/action/xeno_action/place_warp_shadow,
 		/datum/action/xeno_action/hyperposition,
 		/datum/action/xeno_action/phase_shift,


### PR DESCRIPTION
## About The Pull Request

Banish Now Toggles On/Off; Recall Removed

## Why It's Good For The Game

Declutters interface; better QoL

## Changelog
:cl:
qol: Banish now toggles off; Recall removed. To end Banish early while self-banished use Banish on self or use a Banish keybind.
/:cl: