### PR TITLE
Make accidentally opening the admin dsay dialog less annoying

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -534,7 +534,7 @@
 	set name = "dsay"
 	set hidden = TRUE
 
-	if(!check_rights(R_ADMIN|R_MENTOR))
+	if(!msg || !check_rights(R_ADMIN|R_MENTOR))
 		return
 
 	if(is_mentor(src) && mob.stat != DEAD)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -534,7 +534,12 @@
 	set name = "dsay"
 	set hidden = TRUE
 
-	if(!msg || !check_rights(R_ADMIN|R_MENTOR))
+	if(!check_rights(R_ADMIN|R_MENTOR))
+		return
+
+	msg = copytext_char(sanitize(msg), 1, MAX_MESSAGE_LEN)
+
+	if(!msg)
 		return
 
 	if(is_mentor(src) && mob.stat != DEAD)
@@ -546,11 +551,6 @@
 		return
 
 	if(handle_spam_prevention(msg, MUTE_DEADCHAT))
-		return
-
-	msg = copytext_char(sanitize(msg), 1, MAX_MESSAGE_LEN)
-
-	if(!msg)
 		return
 
 	log_dsay("[key_name(src)]: [msg]")


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Simply adds a check for a message body to early return for short circuiting further dsay code if there is no message to send in the first place.

## Why It's Good For The Game

Less pointless warnings good.

## Changelog
:cl:
admin: DSAY no longer pesters mentors who cancel or submit an empty message with a notice about needing to be dead to do the thing they canceled doing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
