### PR TITLE
Mk1 Jaeger modules in armor vendor

### DIFF
--- a/code/game/objects/items/storage/large_holster.dm
+++ b/code/game/objects/items/storage/large_holster.dm
@@ -71,6 +71,9 @@
 	icon_state = "machete_holster_full"
 	new /obj/item/weapon/claymore/mercsword/machete(src)
 
+/obj/item/storage/large_holster/machete/full_harvester
+	name = "H5 Pattern M2132 harvester scabbard"
+
 /obj/item/storage/large_holster/machete/full_harvester/Initialize()
 	. = ..()
 	icon_state = "machete_holster_full"

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -847,6 +847,12 @@
 			/obj/item/helmet_module/welding = 20,
 			/obj/item/helmet_module/binoculars = 20,
 			/obj/item/helmet_module/antenna = 20,
+			/obj/item/helmet_module/attachable/mimir_environment_protection/mark1 = 10,
+			/obj/item/armor_module/attachable/mimir_environment_protection/mark1 = 10,
+			/obj/item/armor_module/attachable/tyr_extra_armor/mark1 = 10,
+			/obj/item/armor_module/attachable/ballistic_armor = 10,
+			/obj/item/armor_module/attachable/better_shoulder_lamp/mark1 = 10,
+			/obj/item/armor_module/attachable/chemsystem = 10,
 		),
 	)
 
@@ -892,6 +898,7 @@
 			/obj/item/storage/belt/gun/pistol/standard_pistol = 10,
 			/obj/item/storage/belt/gun/revolver/standard_revolver = 10,
 			/obj/item/storage/large_holster/machete/full = 10,
+			/obj/item/storage/large_holster/machete/full_harvester = 10,
 		),
 		"Pouches" = list(
 			/obj/item/storage/pouch/pistol = 10,


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Puts all Mk1 jaeger modules in the armor vendor. Harvester blade at clothing vendor right below the machete scabbard.
Also harvester blade scabbard has unique name now so that it doesn't fuck with vendor entries.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Halp i accidentally picked wrong module lemme change it

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Mk1 Jaeger modules in armor vendor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
