### PR TITLE
Fixes Vali not disabling if unequipped soon after turned on

### DIFF
--- a/code/datums/components/chem_booster.dm
+++ b/code/datums/components/chem_booster.dm
@@ -489,11 +489,12 @@
 	///Records the last time the action was used to avoid accidentally cancelling the effect when spamming the button in-combat
 	var/last_activated_time
 
-/datum/action/chem_booster/power/can_use_action()
-	. = ..()
-
+/datum/action/chem_booster/power/action_activate()
 	if(world.time < last_activated_time + 2 SECONDS)
-		return FALSE
+		return
+	last_activated_time = world.time
+
+	return ..()
 
 /datum/action/chem_booster/scan
 	name = "Activate Analyzer"

--- a/code/datums/components/chem_booster.dm
+++ b/code/datums/components/chem_booster.dm
@@ -237,8 +237,6 @@
 ///Handles turning on/off the processing part of the component, along with the negative effects related to this
 /datum/component/chem_booster/proc/on_off(datum/source)
 	if(boost_on)
-		if(world.time < processing_start + 2 SECONDS) // no accidental cancellation from spamming the action
-			return
 		STOP_PROCESSING(SSobj, src)
 
 		wearer.clear_fullscreen("degeneration")
@@ -488,6 +486,14 @@
 	name = "Power Vali Chemical Enhancement"
 	action_icon = 'icons/mob/actions.dmi'
 	action_icon_state = "cboost_off"
+	///Records the last time the action was used to avoid accidentally cancelling the effect when spamming the button in-combat
+	var/last_activated_time
+
+/datum/action/chem_booster/power/can_use_action()
+	. = ..()
+
+	if(world.time < last_activated_time + 2 SECONDS)
+		return FALSE
 
 /datum/action/chem_booster/scan
 	name = "Activate Analyzer"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes Vali not disabling if activated and immediately after that the exoskeleton is unequipped.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed vali not deactivating if activated and immediately after that the exoskeleton is unequipped
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
