### PR TITLE
Automated miners require an open side to sell ore

### DIFF
--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -256,13 +256,14 @@
 	if(add_tick >= required_ticks)
 		if(miner_upgrade_type == MINER_AUTOMATED)
 			for(var/direction in GLOB.cardinals)
-				if(istype(get_step(loc, direction), /turf/open)) //Must be open on one side to operate
-					SSpoints.supply_points += mineral_value
-					do_sparks(5, TRUE, src)
-					playsound(loc,'sound/effects/phasein.ogg', 50, FALSE)
-					say("Ore shipment has been sold for [mineral_value] points.")
-					add_tick = 0
-					return
+				if(!isopenturf(get_step(loc, direction))) //Must be open on one side to operate
+					continue
+				SSpoints.supply_points += mineral_value
+				do_sparks(5, TRUE, src)
+				playsound(loc,'sound/effects/phasein.ogg', 50, FALSE)
+				say("Ore shipment has been sold for [mineral_value] points.")
+				add_tick = 0
+				return
 			playsound(loc,'sound/machines/buzz-two.ogg', 35, FALSE)
 			add_tick = 0
 			return

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -255,10 +255,15 @@
 		return
 	if(add_tick >= required_ticks)
 		if(miner_upgrade_type == MINER_AUTOMATED)
-			SSpoints.supply_points += mineral_value
-			do_sparks(5, TRUE, src)
-			playsound(loc,'sound/effects/phasein.ogg', 50, FALSE)
-			say("Ore shipment has been sold for [mineral_value] points.")
+			for(var/direction in GLOB.cardinals)
+				if(istype(get_step(loc, direction), /turf/open)) //Must be open on one side to operate
+					SSpoints.supply_points += mineral_value
+					do_sparks(5, TRUE, src)
+					playsound(loc,'sound/effects/phasein.ogg', 50, FALSE)
+					say("Ore shipment has been sold for [mineral_value] points.")
+					add_tick = 0
+					return
+			playsound(loc,'sound/machines/buzz-two.ogg', 35, FALSE)
 			add_tick = 0
 			return
 		stored_mineral += 1


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a check of cardinal directions around miners for an open turf for shipments to happen.

## Why It's Good For The Game

Wraith can no longer phase in to make a walled in miner work against the marines, so it's time for this meta strat that can guarantee 30+ points per miner setup this way to die.

## Changelog
:cl:
balance: Automated miners require an open side to properly operate.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
