### PR TITLE
Adds lever action rifle to standard vendor

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -152,6 +152,7 @@
 			/obj/item/weapon/powerfist = 100,
 			/obj/item/weapon/throwing_knife = 500,
 			/obj/item/ammo_magazine/standard_smartmachinegun = 4,
+			/obj/item/weapon/gun/shotgun/pump/lever = 20,
 		),
 		"Grenades" = list(
 			/obj/item/explosive/grenade/frag = 600,


### PR DESCRIPTION
## About The Pull Request

Adds the lever action rifle to the standard marine vendors.

## Why It's Good For The Game

It's literally the revolver but worse. This just allows for more yeehaw in our lives.
I tested it out on a local server, worked fine.

## Changelog
:cl:
add: lever action .44 rifle to vendors.
/:cl: