### PR TITLE
Add Bull's charge modes descriptions to the codex

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/abilities_bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/abilities_bull.dm
@@ -5,6 +5,7 @@
 /datum/action/xeno_action/activable/bull_charge
 	name = "Plow Charge"
 	action_icon_state = "bull_charge"
+	mechanics_text = "The plow charge is similar to the crusher charge, as it deals damage and throws anyone hit out of your way. Hitting a host does not stop or slow you down."
 	ability_name = "plow charge"
 	keybind_signal = COMSIG_XENOABILITY_BULLCHARGE
 	var/new_charge_type = CHARGE_BULL
@@ -17,6 +18,7 @@
 /datum/action/xeno_action/activable/bull_charge/headbutt
 	name = "Headbutt Charge"
 	action_icon_state = "bull_headbutt"
+	mechanics_text = "The headbutt charge, when it hits a host, stops your charge while knocking them down stunned for some time."
 	ability_name = "headbutt charge"
 	keybind_signal = COMSIG_XENOABILITY_BULLHEADBUTT
 	new_charge_type = CHARGE_BULL_HEADBUTT
@@ -24,6 +26,7 @@
 /datum/action/xeno_action/activable/bull_charge/gore
 	name = "Gore Charge"
 	action_icon_state = "bull_gore"
+	mechanics_text = "The gore charge, when it hits a host, stops your charge while dealing a large amount of damage where you are targeting dependant on your charge speed."
 	ability_name = "gore charge"
 	keybind_signal = COMSIG_XENOABILITY_BULLGORE
 	new_charge_type = CHARGE_BULL_GORE


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Update the `mechanics_text` for Bull's charges so they are visible from the evolution panel for curious players perusal.

## Why It's Good For The Game

"This ability not found in codex." bad.

## Changelog
:cl:
qol: Codex now contains info on Bull's various charge modes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
