### PR TITLE
Fix xeno tracker not updating for crash nuke activation

### DIFF
--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -183,7 +183,7 @@
 	var/datum/hive_status/normal/HS = GLOB.hive_datums[XENO_HIVE_NORMAL]
 	var/area_name = get_area_name(nuke)
 	HS.xeno_message("An overwhelming wave of dread ripples throughout the hive... A nuke has been activated[area_name ? " in [area_name]":""]!")
-	HS.set_all_trackers(nuke)
+	HS.set_all_xeno_trackers(nuke)
 
 /datum/game_mode/infestation/crash/proc/play_cinematic(z_level)
 	GLOB.enter_allowed = FALSE

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -142,7 +142,7 @@
 
 	if(num_humans && planet_nuked == CRASH_NUKE_NONE && marines_evac == CRASH_EVAC_NONE && !force_end)
 		return FALSE
-	
+
 	if(planet_nuked == CRASH_NUKE_NONE)
 		if(!num_humans)
 			message_admins("Round finished: [MODE_INFESTATION_X_MAJOR]") //xenos wiped out ALL the marines
@@ -152,13 +152,13 @@
 			message_admins("Round finished: [MODE_INFESTATION_X_MINOR]") //marines evaced without a nuke
 			round_finished = MODE_INFESTATION_X_MINOR
 			return TRUE
-	
+
 	if(planet_nuked == CRASH_NUKE_COMPLETED)
 		if(marines_evac == CRASH_EVAC_NONE)
 			message_admins("Round finished: [MODE_INFESTATION_M_MINOR]") //marines nuked the planet but didn't evac
 			round_finished = MODE_INFESTATION_M_MINOR
 			return TRUE
-		message_admins("Round finished: [MODE_INFESTATION_M_MAJOR]") //marines nuked the planet and managed to evac 
+		message_admins("Round finished: [MODE_INFESTATION_M_MAJOR]") //marines nuked the planet and managed to evac
 		round_finished = MODE_INFESTATION_M_MAJOR
 		return TRUE
 	return FALSE
@@ -178,11 +178,12 @@
 	planet_nuked = CRASH_NUKE_INPROGRESS
 	INVOKE_ASYNC(src, .proc/play_cinematic, z_level)
 
-/datum/game_mode/infestation/crash/proc/on_nuke_started(obj/machinery/nuclearbomb/nuke)
+/datum/game_mode/infestation/crash/proc/on_nuke_started(datum/source, obj/machinery/nuclearbomb/nuke)
 	SIGNAL_HANDLER
 	var/datum/hive_status/normal/HS = GLOB.hive_datums[XENO_HIVE_NORMAL]
 	var/area_name = get_area_name(nuke)
 	HS.xeno_message("An overwhelming wave of dread ripples throughout the hive... A nuke has been activated[area_name ? " in [area_name]":""]!")
+	HS.set_all_trackers(nuke)
 
 /datum/game_mode/infestation/crash/proc/play_cinematic(z_level)
 	GLOB.enter_allowed = FALSE

--- a/code/game/objects/machinery/nuclearbomb.dm
+++ b/code/game/objects/machinery/nuclearbomb.dm
@@ -63,8 +63,6 @@
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_NUKE_START, src)
 	notify_ghosts("[usr] enabled the [src], it has [timeleft] seconds on the timer.", source = src, action = NOTIFY_ORBIT, extra_large = TRUE)
 
-	// Set the nuke as the hive leader so its tracked
-	SSdirection.set_leader(XENO_HIVE_NORMAL, src)
 
 
 /obj/machinery/nuclearbomb/stop_processing()
@@ -72,11 +70,6 @@
 	countdown.stop()
 	GLOB.active_nuke_list -= src
 	timeleft = initial(timeleft)
-
-	// Reset the hive leader
-	var/datum/hive_status/HS = GLOB.hive_datums[XENO_HIVE_NORMAL]
-	SSdirection.set_leader(XENO_HIVE_NORMAL, HS.living_xeno_ruler)
-
 	return ..()
 
 

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -540,8 +540,8 @@ to_chat will check for valid clients itself already so no need to double check f
 		X.receive_hivemind_message(sender, message)
 
 ///Used for setting the trackers of all xenos in the hive, like when a nuke activates
-/datum/hive_status/proc/set_all_trackers(atom/target)
-	for(var/i in get_all_xenos())
+/datum/hive_status/proc/set_all_xeno_trackers(atom/target)
+	for(var/i AS in get_all_xenos())
 		var/mob/living/carbon/xenomorph/X = i
 		X.tracked = target
 		to_chat(X, "<span class='notice'> Now tracking [target.name]</span>")

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -539,6 +539,13 @@ to_chat will check for valid clients itself already so no need to double check f
 		var/mob/living/carbon/xenomorph/X = i
 		X.receive_hivemind_message(sender, message)
 
+///Used for setting the trackers of all xenos in the hive, like when a nuke activates
+/datum/hive_status/proc/set_all_trackers(atom/target)
+	for(var/i in get_all_xenos())
+		var/mob/living/carbon/xenomorph/X = i
+		X.tracked = target
+		to_chat(X, "<span class='notice'> Now tracking [target.name]</span>")
+
 // ***************************************
 // *********** Normal Xenos
 // ***************************************

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -541,8 +541,7 @@ to_chat will check for valid clients itself already so no need to double check f
 
 ///Used for setting the trackers of all xenos in the hive, like when a nuke activates
 /datum/hive_status/proc/set_all_xeno_trackers(atom/target)
-	for(var/i AS in get_all_xenos())
-		var/mob/living/carbon/xenomorph/X = i
+	for(var/mob/living/carbon/xenomorph/X AS in get_all_xenos())
 		X.tracked = target
 		to_chat(X, "<span class='notice'> Now tracking [target.name]</span>")
 

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -327,7 +327,7 @@
 
 	var/fire_luminosity = 0 //Luminosity of the current fire while burning
 
-	///The xenos/silo currently tracked by the xeno_tracker arrow
+	///The xenos/silo/nuke currently tracked by the xeno_tracker arrow
 	var/tracked
 
 	COOLDOWN_DECLARE(xeno_health_alert_cooldown)

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -323,10 +323,10 @@
 		if(xeno_tracked == src) // No need to track ourselves
 			LL_dir.icon_state = "trackoff"
 			return
-		if(xeno_tracked.z != z || get_dist(src,xeno_tracked) < 1)
+		if(xeno_tracked.z != z || get_dist(src, xeno_tracked) < 1)
 			LL_dir.icon_state = "trackondirect"
 			return
-		var/area/A = get_area(src.loc)
+		var/area/A = get_area(loc)
 		var/area/QA = get_area(xeno_tracked.loc)
 		if(A.fake_zlevel == QA.fake_zlevel)
 			LL_dir.icon_state = "trackon"
@@ -341,11 +341,11 @@
 		if(QDELETED(silo_tracked))
 			tracked = null
 			return
-		if(silo_tracked.z != z || get_dist(src,silo_tracked) < 1)
+		if(silo_tracked.z != z || get_dist(src, silo_tracked) < 1)
 			LL_dir.icon_state = "trackondirect"
 			return
 
-		var/area/A = get_area(src.loc)
+		var/area/A = get_area(loc)
 		var/area/QA = get_area(silo_tracked.loc)
 		if(A.fake_zlevel == QA.fake_zlevel)
 			LL_dir.icon_state = "trackon"
@@ -362,10 +362,10 @@
 		if(!nuke_tracked.timer_enabled)
 			LL_dir.icon_state = "trackoff"
 			return
-		if(nuke_tracked.z != z || get_dist(src,nuke_tracked) < 1)
+		if(nuke_tracked.z != z || get_dist(src, nuke_tracked) < 1)
 			LL_dir.icon_state = "trackondirect"
 			return
-		var/area/A = get_area(src.loc)
+		var/area/A = get_area(loc)
 		var/area/QA = get_area(nuke_tracked.loc)
 		if(A.fake_zlevel == QA.fake_zlevel)
 			LL_dir.icon_state = "trackon"

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -308,14 +308,14 @@
 	if(!hud_used?.locate_leader)
 		return
 	var/obj/screen/LL_dir = hud_used.locate_leader
-	if (!tracked)
+	if(!tracked)
 		if(hive.living_xeno_ruler)
 			tracked = hive.living_xeno_ruler
 		else
 			LL_dir.icon_state = "trackoff"
 			return
 
-	if (isxeno(tracked))
+	if(isxeno(tracked))
 		var/mob/living/carbon/xenomorph/xeno_tracked = tracked
 		if(QDELETED(xeno_tracked))
 			tracked = null
@@ -336,7 +336,7 @@
 		LL_dir.icon_state = "trackondirect"
 		return
 
-	if (isresinsilo(tracked))
+	if(isresinsilo(tracked))
 		var/mob/living/carbon/xenomorph/silo_tracked = tracked
 		if(QDELETED(silo_tracked))
 			tracked = null
@@ -352,6 +352,28 @@
 			LL_dir.setDir(get_dir(src, silo_tracked))
 			return
 		LL_dir.icon_state = "trackondirect"
+		return
+
+	if(istype(tracked, /obj/machinery/nuclearbomb))
+		var/obj/machinery/nuclearbomb/nuke_tracked = tracked
+		if(QDELETED(nuke_tracked))
+			tracked = null
+			return
+		if(!nuke_tracked.timer_enabled)
+			LL_dir.icon_state = "trackoff"
+			return
+		if(nuke_tracked.z != z || get_dist(src,nuke_tracked) < 1)
+			LL_dir.icon_state = "trackondirect"
+			return
+		var/area/A = get_area(src.loc)
+		var/area/QA = get_area(nuke_tracked.loc)
+		if(A.fake_zlevel == QA.fake_zlevel)
+			LL_dir.icon_state = "trackon"
+			LL_dir.setDir(get_dir(src, nuke_tracked))
+			return
+
+		LL_dir.icon_state = "trackondirect"
+		return
 
 
 /mob/living/carbon/xenomorph/clear_leader_tracking()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Updated the crash nuke logic to be compatible with the new xeno tracker.

Added a `set_all_trackers` proc to the hive_datum.

Fixed the nuke activated `SIGNAL_HANDLER` args so they actually work.

## Why It's Good For The Game

Fix good.

## Changelog
:cl:
fix: Fixed the xeno tracker not pinpointing the active nuke during crash.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
