### PR TITLE
Automatically show testmerges on login if there are any

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -275,6 +275,11 @@
 	generate_clickcatcher()
 	apply_clickcatcher()
 
+	var/datum/getrev/revdata = GLOB.revdata
+	var/tm_info = revdata.GetTestMergeInfo()
+	if(tm_info)
+		to_chat(src, tm_info)
+
 	if(prefs.lastchangelog != GLOB.changelog_hash) //bolds the changelog button on the interface so we know there are updates.
 		to_chat(src, "<span class='info'>You have unread updates in the changelog.</span>")
 		if(CONFIG_GET(flag/aggressive_changelog))

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -275,11 +275,6 @@
 	generate_clickcatcher()
 	apply_clickcatcher()
 
-	var/datum/getrev/revdata = GLOB.revdata
-	var/tm_info = revdata.GetTestMergeInfo()
-	if(tm_info)
-		to_chat(src, tm_info)
-
 	if(prefs.lastchangelog != GLOB.changelog_hash) //bolds the changelog button on the interface so we know there are updates.
 		to_chat(src, "<span class='info'>You have unread updates in the changelog.</span>")
 		if(CONFIG_GET(flag/aggressive_changelog))

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -2,6 +2,11 @@
 	if(GLOB.motd)
 		to_chat(src, "<div class='motd'>[GLOB.motd]</div>")
 
+	var/datum/getrev/revdata = GLOB.revdata
+	var/tm_info = revdata.GetTestMergeInfo()
+	if(tm_info)
+		to_chat(src, tm_info)
+
 	if(CONFIG_GET(flag/use_exp_tracking))
 		client?.set_exp_from_db()
 
@@ -15,5 +20,3 @@
 	sight |= SEE_TURFS
 
 	client?.play_title_music()
-
-


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Copypasta some `/client/verb/showrevinfo()` code to be run during `/mob/new_player/Login()` upon connection.

Probably a candidate for a TM itself as I do not know how to simulate the conditions needed to spoof testmerges for testing with or without tgs running.

## Why It's Good For The Game

Informed players good. Hopefully will reduce confusion when things come and go without a trace in the changelog.

## Changelog
:cl:
qol: You will now be notified of any active testmerges automatically when you login.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
