### PR TITLE
Reorder end of round automatic votes, groundmap last

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -288,9 +288,9 @@ SUBSYSTEM_DEF(vote)
 
 ///Starts the automatic map vote at the end of each round
 /datum/controller/subsystem/vote/proc/automatic_vote()
-	initiate_vote("groundmap", null, TRUE)
+	initiate_vote("gamemode", null, TRUE)
 	addtimer(CALLBACK(src, .proc/initiate_vote, "shipmap", null, TRUE), CONFIG_GET(number/vote_period) + 3 SECONDS)
-	addtimer(CALLBACK(src, .proc/initiate_vote, "gamemode", null, TRUE), CONFIG_GET(number/vote_period) * 2 + 6 SECONDS)
+	addtimer(CALLBACK(src, .proc/initiate_vote, "groundmap", null, TRUE), CONFIG_GET(number/vote_period) * 2 + 6 SECONDS)
 
 /datum/controller/subsystem/vote/ui_state()
 	return GLOB.always_state


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

## Why It's Good For The Game

More people tend to vote in the later polls after they have died once or twice in EORD. The most important of the three should get the last slot especially because respawning makes you lose the vote UI button and must be found in the OOC tab.

Gamemode polls can always be started by players the following round if the turnout was subpar, but we are stuck with that map 1 or 2 people total voted for (Prison or Barrenquilla) without admin intervention.

## Changelog
:cl:
qol: Groundmap Vote is now the last of the post round automatic polls instead of the first.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
