### PR TITLE
jaeger storage modules no longer slow you down

### DIFF
--- a/code/modules/modular_armor/storage.dm
+++ b/code/modules/modular_armor/storage.dm
@@ -74,7 +74,6 @@
 	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Certainly not as specialised as any other storage modules, but definitely able to hold some larger things, like binoculars, maps, and motion detectors. Looks like it might slow you down a bit."
 	icon_state = "mod_general_bag"
 	storage_type =  /obj/item/storage/internal/modular/general
-	slowdown = 0.1
 
 /obj/item/storage/internal/modular/general
 	max_storage_space = 6
@@ -124,7 +123,6 @@
 	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Can hold about as much as a tool pouch, and sometimes small spools of things like barbed wire, or an entrenching tool. Looks like it might slow you down a bit."
 	icon_state = "mod_engineer_bag"
 	storage_type =  /obj/item/storage/internal/modular/engineering
-	slowdown = 0.1
 
 /obj/item/storage/internal/modular/engineering
 	max_storage_space = 15
@@ -160,7 +158,6 @@
 	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Can hold a substantial variety of medical supplies and apparatus, but cannot hold as much as a medkit could. Looks like it might slow you down a bit."
 	icon_state = "mod_medic_bag"
 	storage_type =  /obj/item/storage/internal/modular/medical
-	slowdown = 0.1
 
 /obj/item/storage/internal/modular/medical
 	max_storage_space = 30


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
jaeger storage modules no longer slow you down
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This is no longer necessary honestly, you don't need to be penalized for having a storage module and I did this with an entirely different expectation and belief that there'd be a wide variety of storage modules for you to pick, but then they literally never got expanded.
This doesn't need to exist anymore outside of extreme cases.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: medical, general and engineering jaeger storage no longer slow you down at all, from 0.1.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
