### PR TITLE
Resin traps now are top of the pile of items

### DIFF
--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -126,7 +126,7 @@
 	opacity = FALSE
 	anchored = TRUE
 	max_integrity = 5
-	layer = RESIN_STRUCTURE_LAYER
+	layer = UPPER_ITEM_LAYER
 	var/obj/item/clothing/mask/facehugger/hugger = null
 
 /obj/effect/alien/resin/trap/Initialize(mapload)
@@ -258,7 +258,7 @@
 	SIGNAL_HANDLER
 	if(isxeno(atom_entering))
 		Open()
-	
+
 
 /obj/structure/mineral_door/resin/attack_paw(mob/living/carbon/human/user)
 	if(user.a_intent == INTENT_HARM)


### PR DESCRIPTION

## About The Pull Request
Resin traps from xenos are top of the pile of items.
Before
![image](https://user-images.githubusercontent.com/53350410/118411178-8bfd1980-b693-11eb-8776-9e62b06a0c1b.png)
After
![image](https://user-images.githubusercontent.com/53350410/118411184-94555480-b693-11eb-94a4-bc5b77fc8fff.png)


## Why It's Good For The Game
The marine cannot see it if it's hidden below items, so we have to do for don't use right click

## Changelog
:cl:
balance: Resin traps are UPPER_ITEM_LAYER 
/:cl:


