### PR TITLE
Improved Xeno Structure Placement

### DIFF
--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -14,7 +14,7 @@ GLOBAL_LIST_EMPTY(ladder_list)
 GLOBAL_LIST_EMPTY(brig_closets)
 GLOBAL_LIST_EMPTY(supply_pad_list)
 
-GLOBAL_LIST_EMPTY(xeno_tunnels)						//list of all /obj/structure/tunnel
+GLOBAL_LIST_EMPTY(xeno_tunnels)						//list of all /obj/structure/xeno/tunnel
 GLOBAL_LIST_EMPTY(machines)					        //NOTE: this is a list of ALL machines now. The processing machines list is SSmachine.processing !
 GLOBAL_LIST_EMPTY(faxmachines)
 GLOBAL_LIST_EMPTY(intel_computers)					//All the intel computers for the random events

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -118,9 +118,10 @@
 
 
 //Carrier trap
-/obj/effect/alien/resin/trap
+/obj/structure/xeno/trap
 	desc = "It looks like a hiding hole."
 	name = "resin hole"
+	icon = 'icons/Xeno/Effects.dmi'
 	icon_state = "trap0"
 	density = FALSE
 	opacity = FALSE
@@ -129,25 +130,25 @@
 	layer = RESIN_STRUCTURE_LAYER
 	var/obj/item/clothing/mask/facehugger/hugger = null
 
-/obj/effect/alien/resin/trap/Initialize(mapload)
+/obj/structure/xeno/trap/Initialize(mapload)
 	. = ..()
 	RegisterSignal(src, COMSIG_MOVABLE_SHUTTLE_CRUSH, .proc/shuttle_crush)
 	RegisterSignal(src, COMSIG_MOVABLE_CROSSED_BY, .proc/trigger_hugger_trap) //Set up the trap signal on our turf
 
 
-/obj/effect/alien/resin/trap/obj_destruction(damage_amount, damage_type, damage_flag)
+/obj/structure/xeno/trap/obj_destruction(damage_amount, damage_type, damage_flag)
 	if(damage_amount && hugger && loc)
 		drop_hugger()
 
 	return ..()
 
 ///Ensures that no huggies will be released when the trap is crushed by a shuttle; no more trapping shuttles with huggies
-/obj/effect/alien/resin/trap/proc/shuttle_crush()
+/obj/structure/xeno/trap/proc/shuttle_crush()
 	SIGNAL_HANDLER
 	qdel(src)
 
 
-/obj/effect/alien/resin/trap/examine(mob/user)
+/obj/structure/xeno/trap/examine(mob/user)
 	. = ..()
 	if(isxeno(user))
 		to_chat(user, "A hole for a little one to hide in ambush.")
@@ -157,7 +158,7 @@
 			to_chat(user, "It's empty.")
 
 
-/obj/effect/alien/resin/trap/flamer_fire_act()
+/obj/structure/xeno/trap/flamer_fire_act()
 	if(hugger)
 		hugger.forceMove(loc)
 		hugger.kill_hugger()
@@ -165,7 +166,7 @@
 		icon_state = "trap0"
 	..()
 
-/obj/effect/alien/resin/trap/fire_act()
+/obj/structure/xeno/trap/fire_act()
 	if(hugger)
 		hugger.forceMove(loc)
 		hugger.kill_hugger()
@@ -174,7 +175,7 @@
 	..()
 
 ///Triggers the hugger trap
-/obj/effect/alien/resin/trap/proc/trigger_hugger_trap(datum/source, atom/movable/AM, oldloc)
+/obj/structure/xeno/trap/proc/trigger_hugger_trap(datum/source, atom/movable/AM, oldloc)
 	SIGNAL_HANDLER
 	if(!iscarbon(AM) || !hugger)
 		return
@@ -188,14 +189,14 @@
 	xeno_message("A facehugger trap at [AREACOORD_NO_Z(src)] has been triggered!", "xenoannounce", 5, hugger.hivenumber,  FALSE, get_turf(src), 'sound/voice/alien_talk2.ogg', FALSE, null, /obj/screen/arrow/attack_order_arrow, COLOR_ORANGE, TRUE) //Follow the trend of hive wide alerts for important events
 	drop_hugger()
 
-/obj/effect/alien/resin/trap/proc/drop_hugger()
+/obj/structure/xeno/trap/proc/drop_hugger()
 	hugger.forceMove(loc)
 	hugger.go_active(TRUE, TRUE) //Removes stasis
 	icon_state = "trap0"
 	visible_message("<span class='warning'>[hugger] gets out of [src]!</span>")
 	hugger = null
 
-/obj/effect/alien/resin/trap/attack_alien(mob/living/carbon/xenomorph/X, damage_amount = X.xeno_caste.melee_damage, damage_type = BRUTE, damage_flag = "", effects = TRUE, armor_penetration = 0, isrightclick = FALSE)
+/obj/structure/xeno/trap/attack_alien(mob/living/carbon/xenomorph/X, damage_amount = X.xeno_caste.melee_damage, damage_type = BRUTE, damage_flag = "", effects = TRUE, armor_penetration = 0, isrightclick = FALSE)
 	if(X.status_flags & INCORPOREAL)
 		return FALSE
 
@@ -213,7 +214,7 @@
 	to_chat(X, "<span class='xenonotice'>We remove the facehugger from [src].</span>")
 
 
-/obj/effect/alien/resin/trap/attackby(obj/item/I, mob/user, params)
+/obj/structure/xeno/trap/attackby(obj/item/I, mob/user, params)
 	. = ..()
 
 	if(istype(I, /obj/item/clothing/mask/facehugger) && isxeno(user))
@@ -258,7 +259,7 @@
 	SIGNAL_HANDLER
 	if(isxeno(atom_entering))
 		Open()
-	
+
 
 /obj/structure/mineral_door/resin/attack_paw(mob/living/carbon/human/user)
 	if(user.a_intent == INTENT_HARM)
@@ -611,7 +612,7 @@ TUNNEL
 */
 
 
-/obj/structure/tunnel
+/obj/structure/xeno/tunnel
 	name = "tunnel"
 	desc = "A tunnel entrance. Looks like it was dug by some kind of clawed beast."
 	icon = 'icons/Xeno/effects.dmi'
@@ -635,7 +636,7 @@ TUNNEL
 
 
 
-/obj/structure/tunnel/Initialize(mapload)
+/obj/structure/xeno/tunnel/Initialize(mapload)
 	. = ..()
 	GLOB.xeno_tunnels += src
 	prepare_huds()
@@ -643,7 +644,7 @@ TUNNEL
 		xeno_tac_hud.add_to_hud(src)
 	hud_set_xeno_tunnel()
 
-/obj/structure/tunnel/Destroy()
+/obj/structure/xeno/tunnel/Destroy()
 	var/drop_loc = get_turf(src)
 	for(var/atom/movable/thing AS in contents) //Empty the tunnel of contents
 		thing.forceMove(drop_loc)
@@ -662,18 +663,18 @@ TUNNEL
 
 	return ..()
 
-/obj/structure/tunnel/examine(mob/user)
+/obj/structure/xeno/tunnel/examine(mob/user)
 	. = ..()
 	if(!isxeno(user) && !isobserver(user))
 		return
 	if(tunnel_desc)
 		to_chat(user, "<span class='info'>The Hivelord scent reads: \'[tunnel_desc]\'</span>")
 
-/obj/structure/tunnel/deconstruct(disassembled = TRUE)
+/obj/structure/xeno/tunnel/deconstruct(disassembled = TRUE)
 	visible_message("<span class='danger'>[src] suddenly collapses!</span>")
 	return ..()
 
-/obj/structure/tunnel/ex_act(severity)
+/obj/structure/xeno/tunnel/ex_act(severity)
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
 			take_damage(210)
@@ -682,12 +683,12 @@ TUNNEL
 		if(EXPLODE_LIGHT)
 			take_damage(70)
 
-/obj/structure/tunnel/attackby(obj/item/I, mob/user, params)
+/obj/structure/xeno/tunnel/attackby(obj/item/I, mob/user, params)
 	if(!isxeno(user))
 		return ..()
 	attack_alien(user)
 
-/obj/structure/tunnel/attack_alien(mob/living/carbon/xenomorph/X, damage_amount = X.xeno_caste.melee_damage, damage_type = BRUTE, damage_flag = "", effects = TRUE, armor_penetration = 0, isrightclick = FALSE)
+/obj/structure/xeno/tunnel/attack_alien(mob/living/carbon/xenomorph/X, damage_amount = X.xeno_caste.melee_damage, damage_type = BRUTE, damage_flag = "", effects = TRUE, armor_penetration = 0, isrightclick = FALSE)
 	if(!istype(X) || X.stat || X.lying_angle || X.status_flags & INCORPOREAL)
 		return
 
@@ -716,13 +717,13 @@ TUNNEL
 
 	pick_a_tunnel(X)
 
-/obj/structure/tunnel/attack_larva(mob/living/carbon/xenomorph/larva/L) //So larvas can actually use tunnels
+/obj/structure/xeno/tunnel/attack_larva(mob/living/carbon/xenomorph/larva/L) //So larvas can actually use tunnels
 	attack_alien(L)
 
 
 ///Here we pick a tunnel to go to, then travel to that tunnel and peep out, confirming whether or not we want to emerge or go to another tunnel.
-/obj/structure/tunnel/proc/pick_a_tunnel(mob/living/carbon/xenomorph/M)
-	var/obj/structure/tunnel/targettunnel = tgui_input_list(M, "Choose a tunnel to crawl to", "Tunnel", GLOB.xeno_tunnels)
+/obj/structure/xeno/tunnel/proc/pick_a_tunnel(mob/living/carbon/xenomorph/M)
+	var/obj/structure/xeno/tunnel/targettunnel = tgui_input_list(M, "Choose a tunnel to crawl to", "Tunnel", GLOB.xeno_tunnels)
 	if(QDELETED(src)) //Make sure we still exist in the event the player keeps the interface open
 		return
 	if(!M.Adjacent(src) && M.loc != src) //Make sure we're close enough to our tunnel; either adjacent to or in one
@@ -774,7 +775,7 @@ TUNNEL
 		to_chat(M, "<span class='warning'>Our crawling was interrupted!</span>")
 
 //Makes sure the tunnel is visible to other xenos even through obscuration.
-/obj/structure/tunnel/proc/hud_set_xeno_tunnel()
+/obj/structure/xeno/tunnel/proc/hud_set_xeno_tunnel()
 	var/image/holder = hud_list[XENO_TACTICAL_HUD]
 	if(!holder)
 		return
@@ -783,7 +784,7 @@ TUNNEL
 	hud_list[XENO_TACTICAL_HUD] = holder
 
 //Resin Water Well
-/obj/effect/alien/resin/acidwell
+/obj/structure/xeno/acidwell
 	name = "acid well"
 	desc = "An acid well. It stores acid to put out fires."
 	icon = 'icons/Xeno/acid_pool.dmi'
@@ -801,21 +802,21 @@ TUNNEL
 	var/ccharging = FALSE
 	var/mob/living/carbon/xenomorph/creator = null
 
-/obj/effect/alien/resin/acidwell/Initialize()
+/obj/structure/xeno/acidwell/Initialize()
 	. = ..()
 	update_icon()
 
-/obj/effect/alien/resin/acidwell/Destroy()
+/obj/structure/xeno/acidwell/Destroy()
 	creator = null
 	return ..()
 
 ///Ensures that no acid gas will be released when the well is crushed by a shuttle
-/obj/effect/alien/resin/acidwell/proc/shuttle_crush()
+/obj/structure/xeno/acidwell/proc/shuttle_crush()
 	SIGNAL_HANDLER
 	qdel(src)
 
 
-/obj/effect/alien/resin/acidwell/obj_destruction(damage_amount, damage_type, damage_flag)
+/obj/structure/xeno/acidwell/obj_destruction(damage_amount, damage_type, damage_flag)
 	if(!QDELETED(creator) && creator.stat == CONSCIOUS && creator.z == z)
 		var/area/A = get_area(src)
 		if(A)
@@ -827,22 +828,22 @@ TUNNEL
 		A.start()
 	return ..()
 
-/obj/effect/alien/resin/acidwell/examine(mob/user)
+/obj/structure/xeno/acidwell/examine(mob/user)
 	..()
 	if(!isxeno(user) && !isobserver(user))
 		return
 	to_chat(user, "<span class='xenoannounce'>This is an acid well made by [creator].</span>")
 
-/obj/effect/alien/resin/acidwell/deconstruct(disassembled = TRUE)
+/obj/structure/xeno/acidwell/deconstruct(disassembled = TRUE)
 	visible_message("<span class='danger'>[src] suddenly collapses!</span>")
 	return ..()
 
-/obj/effect/alien/resin/acidwell/update_icon()
+/obj/structure/xeno/acidwell/update_icon()
 	. = ..()
 	icon_state = "well[charges]"
 	set_light(charges , charges / 2, LIGHT_COLOR_GREEN)
 
-/obj/effect/alien/resin/acidwell/ex_act(severity)
+/obj/structure/xeno/acidwell/ex_act(severity)
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
 			take_damage(210)
@@ -851,12 +852,12 @@ TUNNEL
 		if(EXPLODE_LIGHT)
 			take_damage(70)
 
-/obj/effect/alien/resin/acidwell/attackby(obj/item/I, mob/user, params)
+/obj/structure/xeno/acidwell/attackby(obj/item/I, mob/user, params)
 	if(!isxeno(user))
 		return ..()
 	attack_alien(user)
 
-/obj/effect/alien/resin/acidwell/attack_alien(mob/living/carbon/xenomorph/X, damage_amount = X.xeno_caste.melee_damage, damage_type = BRUTE, damage_flag = "", effects = TRUE, armor_penetration = 0, isrightclick = FALSE)
+/obj/structure/xeno/acidwell/attack_alien(mob/living/carbon/xenomorph/X, damage_amount = X.xeno_caste.melee_damage, damage_type = BRUTE, damage_flag = "", effects = TRUE, armor_penetration = 0, isrightclick = FALSE)
 	if(X.a_intent != INTENT_HARM)
 		if(charges >= 5)
 			to_chat(X, "<span class='xenoannounce'>[src] is already full!</span>")
@@ -882,14 +883,14 @@ TUNNEL
 			deconstruct(FALSE)
 		return
 
-/obj/effect/alien/resin/acidwell/Crossed(atom/A)
+/obj/structure/xeno/acidwell/Crossed(atom/A)
 	. = ..()
 	if(CHECK_MULTIPLE_BITFIELDS(A.flags_pass, HOVERING))
 		return
 	if(iscarbon(A))
 		HasProximity(A)
 
-/obj/effect/alien/resin/acidwell/HasProximity(atom/movable/AM)
+/obj/structure/xeno/acidwell/HasProximity(atom/movable/AM)
 	if(!iscarbon(AM))
 		return
 	var/mob/living/carbon/C = AM
@@ -912,7 +913,7 @@ TUNNEL
 		update_icon()
 		return
 
-/obj/structure/resin_jelly_pod
+/obj/structure/xeno/resin_jelly_pod
 	name = "Resin jelly pod"
 	desc = "A large resin pod. Inside is a thick, viscous fluid that looks like it doesnt burn easily."
 	icon = 'icons/Xeno/resinpod.dmi'
@@ -936,16 +937,16 @@ TUNNEL
 	///Countdown to the next time we generate a jelly
 	var/nextjelly = 0
 
-/obj/structure/resin_jelly_pod/Initialize()
+/obj/structure/xeno/resin_jelly_pod/Initialize()
 	. = ..()
 	add_overlay(image(icon, "resinpod_inside", layer + 0.01, dir))
 	START_PROCESSING(SSslowprocess, src)
 
-/obj/structure/resin_jelly_pod/Destroy()
+/obj/structure/xeno/resin_jelly_pod/Destroy()
 	STOP_PROCESSING(SSslowprocess, src)
 	return ..()
 
-/obj/effect/alien/resin/resin_jelly_pod/ex_act(severity)
+/obj/structure/xeno/resin_jelly_pod/ex_act(severity)
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
 			take_damage(210)
@@ -954,12 +955,12 @@ TUNNEL
 		if(EXPLODE_LIGHT)
 			take_damage(70)
 
-/obj/structure/resin_jelly_pod/examine(mob/user, distance, infix, suffix)
+/obj/structure/xeno/resin_jelly_pod/examine(mob/user, distance, infix, suffix)
 	. = ..()
 	if(isxeno(user))
 		to_chat(user, "It has [chargesleft] jelly globules remaining[datum_flags & DF_ISPROCESSING ? ", and will create a new jelly in [(recharge_rate-nextjelly)*5] seconds": " and seems latent"].")
 
-/obj/structure/resin_jelly_pod/process()
+/obj/structure/xeno/resin_jelly_pod/process()
 	if(nextjelly <= recharge_rate)
 		nextjelly++
 		return
@@ -968,7 +969,7 @@ TUNNEL
 	if(chargesleft >= maxcharges)
 		return PROCESS_KILL
 
-/obj/structure/resin_jelly_pod/attack_alien(mob/living/carbon/xenomorph/X, damage_amount = X.xeno_caste.melee_damage, damage_type = BRUTE, damage_flag = "", effects = TRUE, armor_penetration = 0, isrightclick = FALSE)
+/obj/structure/xeno/resin_jelly_pod/attack_alien(mob/living/carbon/xenomorph/X, damage_amount = X.xeno_caste.melee_damage, damage_type = BRUTE, damage_flag = "", effects = TRUE, armor_penetration = 0, isrightclick = FALSE)
 	if(X.status_flags & INCORPOREAL)
 		return FALSE
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -522,7 +522,7 @@
 	return !slayer && ..()
 
 
-/** 
+/**
  * Checks for whether we can build advanced xeno structures here
  * Returns TRUE if present, FALSE otherwise
  */
@@ -534,24 +534,26 @@
 		return FALSE
 	return TRUE
 
-/** 
- * Check if alien abilities can construct structure on the turf 
+/**
+ * Check if alien abilities can construct structure on the turf
  * Return TRUE if allowed, FALSE otherwise
  */
 /turf/proc/check_alien_construction(mob/living/builder, silent = FALSE, planned_building)
 	var/has_obstacle
 	for(var/obj/O in contents)
 		if(istype(O, /obj/item/clothing/mask/facehugger))
-			if(!silent)
-				to_chat(builder, "<span class='warning'>There is a little one here already. Best move it.</span>")
-			return FALSE
+			var/obj/item/clothing/mask/facehugger/hugger_check = O
+			if(hugger_check.stat != DEAD) //We don't care about dead huggers.
+				if(!silent)
+					to_chat(builder, "<span class='warning'>There is a little one here already. Best move it.</span>")
+				return FALSE
 		if(istype(O, /obj/effect/alien/egg))
 			if(!silent)
-				to_chat(builder, "<span class='warning'>There's already an egg.</span>")
+				to_chat(builder, "<span class='warning'>There's already an egg here.</span>")
 			return FALSE
-		if(istype(O, /obj/effect/alien/resin/trap))
+		if(istype(O, /obj/structure/xeno))
 			if(!silent)
-				to_chat(builder, "<span class='warning'>There is already a trap here!</span>")
+				to_chat(builder, "<span class='warning'>There's already a resin structure here!</span>")
 			return FALSE
 		if(istype(O, /obj/structure/mineral_door) || istype(O, /obj/effect/alien/resin))
 			has_obstacle = TRUE
@@ -575,7 +577,7 @@
 		if(istype(O, /obj/structure/cocoon))
 			has_obstacle = TRUE
 			break
-		
+
 		if(O.density && !(O.flags_atom & ON_BORDER))
 			has_obstacle = TRUE
 			break

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -122,7 +122,7 @@
 	if(!T.check_alien_construction(owner, FALSE))
 		return fail_activate()
 
-	if(locate(/obj/effect/alien/resin/trap) in T)
+	if(locate(/obj/structure/xeno/trap) in T)
 		to_chat(owner, "<span class='warning'>There is a resin trap in the way!</span>")
 		return fail_activate()
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
@@ -165,12 +165,6 @@ GLOBAL_LIST_INIT(hugger_type_list, typecacheof(list(
 	if(!T.check_alien_construction(owner, silent) || !T.check_disallow_alien_fortification(owner, silent))
 		return FALSE
 
-	if(locate(/obj/effect/alien/weeds/node) in T)
-		if(!silent)
-			to_chat(owner, "<span class='warning'>There is a resin node in the way!</span>")
-		return FALSE
-
-
 /datum/action/xeno_action/place_trap/action_activate()
 	var/turf/T = get_turf(owner)
 
@@ -179,7 +173,7 @@ GLOBAL_LIST_INIT(hugger_type_list, typecacheof(list(
 	playsound(T, "alien_resin_build", 25)
 	GLOB.round_statistics.carrier_traps++
 	SSblackbox.record_feedback("tally", "round_statistics", 1, "carrier_traps")
-	new /obj/effect/alien/resin/trap(T)
+	new /obj/structure/xeno/trap(T)
 	to_chat(owner, "<span class='xenonotice'>We place a hugger trap on the weeds, it still needs a facehugger.</span>")
 
 // ***************************************

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
@@ -162,6 +162,11 @@ GLOBAL_LIST_INIT(hugger_type_list, typecacheof(list(
 			to_chat(owner, "<span class='warning'>We can only shape on weeds. We must find some resin before we start building!</span>")
 		return FALSE
 
+	if(locate(/obj/effect/alien/weeds/node) in T)
+		if(!silent)
+			to_chat(owner, "<span class='warning'>There is a resin node in the way!</span>")
+		return FALSE
+
 	if(!T.check_alien_construction(owner, silent) || !T.check_disallow_alien_fortification(owner, silent))
 		return FALSE
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -107,7 +107,7 @@
 	if(!.)
 		return FALSE
 	var/turf/T = get_turf(owner)
-	if(locate(/obj/structure/tunnel) in T)
+	if(locate(/obj/structure/xeno/tunnel) in T)
 		if(!silent)
 			to_chat(owner, "<span class='warning'>There already is a tunnel here.</span>")
 		return
@@ -140,7 +140,7 @@
 	var/mob/living/carbon/xenomorph/hivelord/X = owner
 	X.visible_message("<span class='xenonotice'>\The [X] digs out a tunnel entrance.</span>", \
 	"<span class='xenonotice'>We dig out a tunnel, connecting it to our network.</span>", null, 5)
-	var/obj/structure/tunnel/newt = new(T)
+	var/obj/structure/xeno/tunnel/newt = new(T)
 
 	playsound(T, 'sound/weapons/pierce.ogg', 25, 1)
 
@@ -160,7 +160,7 @@
 	xeno_message("[X.name] has built a new tunnel named [newt.name] at [newt.tunnel_desc]!", "xenoannounce", 5, X.hivenumber)
 
 	if(LAZYLEN(X.tunnels) > HIVELORD_TUNNEL_SET_LIMIT) //if we exceed the limit, delete the oldest tunnel set.
-		var/obj/structure/tunnel/old_tunnel = X.tunnels[1]
+		var/obj/structure/xeno/tunnel/old_tunnel = X.tunnels[1]
 		old_tunnel.deconstruct(FALSE)
 		to_chat(X, "<span class='xenodanger'>Having exceeding our tunnel limit, our oldest tunnel has collapsed.</span>")
 
@@ -205,18 +205,13 @@
 	if(!T.check_alien_construction(owner, silent))
 		return FALSE
 
-	if(locate(/obj/effect/alien/weeds/node) in T)
-		if(!silent)
-			to_chat(owner, "<span class='warning'>There is a resin node in the way!</span>")
-		return FALSE
-
 /datum/action/xeno_action/place_jelly_pod/action_activate()
 	var/turf/T = get_turf(owner)
 
 	succeed_activate()
 
 	playsound(T, "alien_resin_build", 25)
-	var/obj/structure/resin_jelly_pod/pod = new(T)
+	var/obj/structure/xeno/resin_jelly_pod/pod = new(T)
 	to_chat(owner, "<span class='xenonotice'>We shape some resin into \a [pod].</span>")
 
 /datum/action/xeno_action/create_jelly

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -199,6 +199,11 @@
 			to_chat(owner, "<span class='warning'>We can only shape on weeds. We must find some resin before we start building!</span>")
 		return FALSE
 
+	if(locate(/obj/effect/alien/weeds/node) in T)
+		if(!silent)
+			to_chat(owner, "<span class='warning'>There is a resin node in the way!</span>")
+		return FALSE
+
 	if(!T.check_disallow_alien_fortification(owner, silent))
 		return FALSE
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -318,16 +318,11 @@
 	if(!T.check_disallow_alien_fortification(owner, silent))
 		return FALSE
 
-	if(locate(/obj/effect/alien/weeds/node) in T)
-		if(!silent)
-			to_chat(owner, "<span class='warning'>There is a resin node in the way!</span>")
-		return FALSE
-
 /datum/action/xeno_action/place_acidwell/action_activate()
 	var/turf/T = get_turf(owner)
 	succeed_activate()
 
 	playsound(T, "alien_resin_build", 25)
-	var/obj/effect/alien/resin/acidwell/AC = new /obj/effect/alien/resin/acidwell(T, owner)
+	var/obj/structure/xeno/acidwell/AC = new /obj/structure/xeno/acidwell(T, owner)
 	AC.creator = owner
 	to_chat(owner, "<span class='xenonotice'>We place an acid well. It can still be charged more.</span>")

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -312,6 +312,11 @@
 			to_chat(owner, "<span class='warning'>We can only shape on weeds. We must find some resin before we start building!</span>")
 		return FALSE
 
+	if(locate(/obj/effect/alien/weeds/node) in T)
+		if(!silent)
+			to_chat(owner, "<span class='warning'>There is a resin node in the way!</span>")
+		return FALSE
+
 	if(!T.check_alien_construction(owner, silent))
 		return FALSE
 

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -277,7 +277,7 @@
 			E.deploy_egg_triggers()
 			go_idle(TRUE)
 			return FALSE
-		var/obj/effect/alien/resin/trap/T = locate() in loc
+		var/obj/structure/xeno/trap/T = locate() in loc
 		if(T && !T.hugger)
 			visible_message("<span class='xenowarning'>[src] crawls into [T]!</span>")
 			forceMove(T)

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -1067,7 +1067,7 @@ to_chat will check for valid clients itself already so no need to double check f
 /mob/living/carbon/xenomorph/get_xeno_hivenumber()
 	return hivenumber
 
-/obj/structure/tunnel/get_xeno_hivenumber()
+/obj/structure/xeno/tunnel/get_xeno_hivenumber()
 	return hivenumber
 
 /obj/structure/resin/xeno_turret/get_xeno_hivenumber()

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -246,7 +246,7 @@
 	var/sunder = 0 // sunder affects armour values and does a % removal before dmg is applied. 50 sunder == 50% effective armour values
 	var/fire_resist_modifier = 0
 
-	var/obj/structure/tunnel/start_dig = null
+	var/obj/structure/xeno/tunnel/start_dig = null
 	var/datum/ammo/xeno/ammo = null //The ammo datum for our spit projectiles. We're born with this, it changes sometimes.
 	var/pslash_delay = 0
 

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -18,7 +18,7 @@
 
 	dat += "<b>List of Hive Tunnels:</b><BR>"
 
-	for(var/obj/structure/tunnel/T AS in GLOB.xeno_tunnels)
+	for(var/obj/structure/xeno/tunnel/T AS in GLOB.xeno_tunnels)
 		if(user.issamexenohive(T))
 			var/distance = get_dist(user, T)
 			dat += "<b>[T.name]</b> located at: <b><font color=green>([T.tunnel_desc][distance > 0 ? " <b>Distance: [distance])</b>" : ""]</b></font><BR>"

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -636,7 +636,7 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 /obj/effect/alien/egg/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)
 	return src == proj.original_target
 
-/obj/effect/alien/resin/trap/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)
+/obj/structure/xeno/trap/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)
 	return src == proj.original_target
 
 /obj/item/clothing/mask/facehugger/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -73,7 +73,7 @@
 	silo_area = get_area(src)
 	var/turf/tunnel_turf = get_step(center_turf, NORTH)
 	if(tunnel_turf.can_dig_xeno_tunnel())
-		var/obj/structure/tunnel/newt = new(tunnel_turf)
+		var/obj/structure/xeno/tunnel/newt = new(tunnel_turf)
 		newt.tunnel_desc = "[AREACOORD_NO_Z(newt)]"
 		newt.name += " [name]"
 


### PR DESCRIPTION
## About The Pull Request

Standardizes xeno structures/buildable category for future changes.
Fixes structure stacking.
Resin pods no longer block buildings.

## Why It's Good For The Game

Standardizes xeno structures/buildable category for future changes.
Fixes structure stacking. Fixes: https://github.com/tgstation/TerraGov-Marine-Corps/issues/5869
Resin pods no longer block buildings; QOL.

## Changelog
:cl:
code: Standardizes xeno structures/buildables categories for future changes.
fix: Fixes xeno structure stacking.
qol: Resin pods no longer block buildings; QOL.
/:cl: