### PR TITLE
Minitadilicious

### DIFF
--- a/_maps/shuttles/minidropship.dmm
+++ b/_maps/shuttles/minidropship.dmm
@@ -1,271 +1,229 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/obj/structure/shuttle/engine/propulsion/burst/right,
-/turf/open/shuttle/dropship/three,
-/area/shuttle/minidropship)
-"b" = (
 /obj/structure/window/framed/mainship/spaceworthy{
 	icon_state = "col_window10"
 	},
 /turf/open/floor/mainship_hull,
 /area/shuttle/minidropship)
-"e" = (
-/obj/structure/barricade/plasteel{
-	dir = 4
-	},
+"b" = (
+/obj/effect/attach_point/weapon/minidropship,
+/turf/closed/wall/mainship/outer/reinforced,
+/area/shuttle/minidropship)
+"h" = (
 /turf/open/floor/mainship/orange{
 	dir = 4
 	},
 /area/shuttle/minidropship)
-"h" = (
-/obj/structure/window/framed/mainship/spaceworthy{
-	icon_state = "col_window1"
-	},
-/turf/open/floor/mainship_hull,
-/area/shuttle/minidropship)
 "i" = (
-/turf/open/floor/mainship/orange/corner{
-	dir = 1
-	},
-/area/shuttle/minidropship)
-"j" = (
-/turf/open/floor/mainship/orange/corner{
-	dir = 4
-	},
-/area/shuttle/minidropship)
-"n" = (
-/obj/structure/bed/chair/dropship/pilot{
-	dir = 1
-	},
-/turf/open/floor/mainship/orange/full,
-/area/shuttle/minidropship)
-"p" = (
-/obj/structure/bed/chair/dropship/passenger{
-	dir = 4
-	},
 /turf/open/floor/mainship/orange{
 	dir = 9
 	},
 /area/shuttle/minidropship)
-"r" = (
-/turf/open/floor/mainship/orange,
+"j" = (
+/obj/machinery/door_control{
+	id = "minidropship_podlock";
+	name = "outer door-control";
+	pixel_y = 32
+	},
+/turf/open/floor/mainship/orange{
+	dir = 5
+	},
 /area/shuttle/minidropship)
-"s" = (
+"n" = (
 /obj/structure/window/framed/mainship/spaceworthy{
-	icon_state = "col_window6"
+	icon_state = "col_window12"
 	},
 /turf/open/floor/mainship_hull,
 /area/shuttle/minidropship)
-"t" = (
-/obj/structure/bed/chair/dropship/passenger{
-	dir = 1
+"r" = (
+/obj/structure/barricade/plasteel,
+/obj/machinery/door/poddoor/shutters/transit{
+	dir = 2
 	},
-/obj/machinery/light,
-/obj/structure/barricade/plasteel{
-	dir = 4
+/obj/machinery/door/poddoor/mainship/open{
+	dir = 2;
+	id = "minidropship_podlock"
+	},
+/turf/open/floor/mainship/orange{
+	dir = 10
+	},
+/area/shuttle/minidropship)
+"s" = (
+/obj/structure/barricade/plasteel,
+/obj/machinery/door/poddoor/shutters/transit{
+	dir = 2
+	},
+/obj/machinery/door/poddoor/mainship/open{
+	dir = 2;
+	id = "minidropship_podlock"
+	},
+/turf/open/floor/mainship/orange,
+/area/shuttle/minidropship)
+"t" = (
+/obj/effect/attach_point/weapon/minidropship/pointing_east,
+/turf/closed/wall/mainship/outer/reinforced,
+/area/shuttle/minidropship)
+"u" = (
+/obj/machinery/computer/camera_advanced/shuttle_docker/minidropship,
+/turf/open/floor/mainship/orange,
+/area/shuttle/minidropship)
+"v" = (
+/obj/structure/barricade/plasteel,
+/obj/machinery/door/poddoor/shutters/transit{
+	dir = 2
+	},
+/obj/machinery/door/poddoor/mainship/open{
+	dir = 2;
+	id = "minidropship_podlock"
 	},
 /turf/open/floor/mainship/orange{
 	dir = 6
 	},
 /area/shuttle/minidropship)
-"u" = (
-/turf/open/floor/mainship/orange{
-	dir = 1
-	},
-/area/shuttle/minidropship)
-"v" = (
-/obj/machinery/door/poddoor/mainship/open{
-	dir = 2;
-	id = "minidropship_podlock"
-	},
-/obj/machinery/door/poddoor/shutters/transit{
-	dir = 2
-	},
-/obj/structure/barricade/plasteel,
-/turf/open/shuttle/dropship/five,
-/area/shuttle/minidropship)
 "B" = (
-/obj/structure/bed/chair/dropship/passenger{
-	dir = 1
-	},
-/obj/machinery/light,
-/obj/structure/barricade/plasteel{
-	dir = 8
-	},
-/turf/open/floor/mainship/orange{
-	dir = 10
-	},
+/obj/effect/attach_point/weapon/minidropship/pointing_west,
+/turf/closed/wall/mainship/outer/reinforced,
 /area/shuttle/minidropship)
 "E" = (
 /turf/template_noop,
 /area/space)
 "F" = (
 /obj/docking_port/mobile/marine_dropship/minidropship,
-/turf/open/floor/mainship/floor,
-/area/shuttle/minidropship)
-"H" = (
-/obj/structure/barricade/plasteel{
-	dir = 8
+/obj/structure/bed/chair/dropship/pilot{
+	dir = 1
 	},
 /turf/open/floor/mainship/orange{
-	dir = 8
+	dir = 1
 	},
 /area/shuttle/minidropship)
 "I" = (
-/obj/effect/attach_point/weapon/minidropship,
-/turf/closed/wall/mainship/outer/reinforced,
-/area/shuttle/minidropship)
-"K" = (
-/obj/machinery/door_control{
-	id = "minidropship_podlock";
-	name = "outer door-control";
-	pixel_y = 32
-	},
-/obj/structure/bed/chair/dropship/passenger{
-	dir = 8
-	},
-/turf/open/floor/mainship/orange{
-	dir = 5
-	},
-/area/shuttle/minidropship)
-"L" = (
-/obj/machinery/computer/camera_advanced/shuttle_docker/minidropship,
-/turf/open/floor/mainship/orange/full,
-/area/shuttle/minidropship)
-"N" = (
-/obj/structure/window/framed/mainship/spaceworthy{
-	icon_state = "col_window12"
-	},
-/turf/open/floor/mainship_hull,
-/area/shuttle/minidropship)
-"O" = (
-/obj/structure/bed/chair/dropship/passenger,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/barricade/plasteel{
-	dir = 8
-	},
-/turf/open/floor/mainship/orange{
-	dir = 9
-	},
-/area/shuttle/minidropship)
-"R" = (
 /obj/structure/shuttle/engine/propulsion/burst/left,
 /turf/open/shuttle/dropship/three,
 /area/shuttle/minidropship)
-"S" = (
-/turf/closed/wall/mainship/outer/reinforced,
-/area/shuttle/minidropship)
-"T" = (
-/obj/structure/bed/chair/dropship/passenger,
-/obj/machinery/light{
-	dir = 1
+"K" = (
+/obj/structure/window/framed/mainship/spaceworthy{
+	icon_state = "col_window1"
 	},
+/turf/open/floor/mainship_hull,
+/area/shuttle/minidropship)
+"L" = (
+/obj/structure/shuttle/engine/propulsion/burst/right,
+/turf/open/shuttle/dropship/three,
+/area/shuttle/minidropship)
+"O" = (
 /obj/structure/barricade/plasteel{
-	dir = 4
+	dir = 8
 	},
-/turf/open/floor/mainship/orange{
-	dir = 5
-	},
-/area/shuttle/minidropship)
-"U" = (
 /obj/machinery/door/poddoor/mainship/open{
 	id = "minidropship_podlock"
 	},
 /obj/machinery/door/poddoor/shutters/transit,
-/turf/open/shuttle/dropship/three,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
+/area/shuttle/minidropship)
+"S" = (
+/obj/structure/window/framed/mainship/spaceworthy{
+	icon_state = "col_window6"
+	},
+/turf/open/floor/mainship_hull,
+/area/shuttle/minidropship)
+"T" = (
+/obj/structure/barricade/plasteel{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/mainship/open{
+	id = "minidropship_podlock"
+	},
+/obj/machinery/door/poddoor/shutters/transit,
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
 /area/shuttle/minidropship)
 "V" = (
-/turf/open/floor/mainship/floor,
-/area/shuttle/minidropship)
-"W" = (
-/obj/effect/attach_point/weapon/minidropship/pointing_west,
-/turf/closed/wall/mainship/outer/reinforced,
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
 /area/shuttle/minidropship)
 "Y" = (
 /obj/effect/attach_point/crew_weapon/minidropship,
 /turf/open/floor/mainship/floor,
-/area/shuttle/minidropship)
-"Z" = (
-/obj/effect/attach_point/weapon/minidropship/pointing_east,
-/turf/closed/wall/mainship/outer/reinforced,
 /area/shuttle/minidropship)
 
 (1,1,1) = {"
 E
 E
 E
-S
-U
-U
-U
-W
-R
+E
+E
+E
+E
+E
+E
 "}
 (2,1,1) = {"
 E
 E
-I
-S
+E
+b
 O
-H
+O
 B
-S
-a
+I
+E
 "}
 (3,1,1) = {"
-s
-h
+E
+E
 S
-p
+K
 i
 V
 r
-v
+E
 E
 "}
 (4,1,1) = {"
-N
-L
+E
+E
 n
 u
 F
 Y
-r
-v
+s
+E
 E
 "}
 (5,1,1) = {"
-b
-h
-S
+E
+E
+a
 K
 j
-V
-r
+h
 v
+E
 E
 "}
 (6,1,1) = {"
 E
 E
-I
-S
+E
+b
 T
-e
+T
 t
-S
-R
+L
+E
 "}
 (7,1,1) = {"
 E
 E
 E
-S
-U
-U
-U
-Z
-a
+E
+E
+E
+E
+E
+E
 "}


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/4703210/118528348-37e44a80-b710-11eb-8e28-2bfcb760fe89.png)

Makes it as small as possible while being as functional as possible.

Also adds (1) and (2) extra sentry gun emplacements (the ones you can put on DS / tadpole) to PoS and Sulaco respectively. Fixes the issue of not being able to properly equip tadpole (old tad only had 2 sentry emplacements so this was never an issue, 2 is now mandatory and 4 is optimal).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The goal of tadpole was to be a rapid response combat bus / medevac but it was not possible to serve this purpose. After playing as PO, SL, and FC and using the current tadpole extensively, the issue is... the tadpole is too big and janky. The front of tadpole is hard to defend due to windows being wankily placed so its easy for the turrets to hit the windows themselves while trying to defend tad, its hard to manuever around front of tad to protect it due to the way the windows are positioned, and its hard to place it around cover which makes it easily crusher / acided from afar without much resistance put up.

This fixes the issue of tad being too big and bad window placement at front which now allows it to be a rapid response aircraft. Heal bus is still possible with this setup (though a bit cramped), and tadops will be a true riot to try and wrangle in this beastie.

Last but not least, even if it looks bad, I can tell you at least 3 different ways to properly compensate for the weaknesses of this new design; you just need to be a smart marine (hint: t-gas is one method).

Free method (won't tell you how to do it except that someone else taught me how to do this):



<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Tadpole has been made into a true Clowncar, Boxpol, minitad.
balance: Extra turrets given to the TGMC for free to properly outfit either the DS on all sides or tadpole on all sides.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
