### PR TITLE
Allows xeno tracker target selection while resting

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -160,8 +160,6 @@
 		return
 
 	if(href_list["track_xeno_name"])
-		if(!check_state())
-			return
 		var/xeno_name = href_list["track_xeno_name"]
 		for(var/Y in hive.get_all_xenos())
 			var/mob/living/carbon/xenomorph/X = Y
@@ -176,8 +174,6 @@
 			break
 
 	if(href_list["track_silo_number"])
-		if(!check_state())
-			return
 		var/silo_number = href_list["track_silo_number"]
 		for(var/obj/structure/resin/silo/resin_silo AS in GLOB.xeno_resin_silos)
 			if(resin_silo.associated_hive == hive && num2text(resin_silo.number_silo) == silo_number)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes a couple `check_state()` so xenos may take the harmless action of setting their tracker target while resting.

## Why It's Good For The Game

While resting for heals and plasma is one of the best times to check hive status and select things to track.

Xenos can use a bunch of abilities while resting now including pheros, so why not something as simple and low impact as picking a xeno or silo to track?

## Changelog
:cl:
qol: Xeno tracker target can be updated while resting.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
