### PR TITLE
Improve small silo active player count and notice

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -166,7 +166,7 @@
 		var/mob/M = GLOB.player_list[i]
 		if(!(M && M.client))
 			continue
-		if(alive_check && M.stat)
+		if(alive_check && M.stat == DEAD)
 			continue
 		else if(afk_check && M.client.is_afk())
 			continue

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1060,8 +1060,8 @@
 /datum/action/xeno_action/activable/build_silo/action_activate()
 	var/mob/living/carbon/xenomorph/X = owner
 	if(X.selected_ability == src)
-		if(get_active_player_count() > SMALL_SILO_MAXIMUM_PLAYER_COUNT)
-			to_chat(X, "<span class ='notice'>There are too many players to place a small silo</span>")
+		if(get_active_player_count(TRUE) > SMALL_SILO_MAXIMUM_PLAYER_COUNT)
+			to_chat(X, "<span class ='notice'>There are too many living sisters and hosts to place a small silo!</span>")
 			build_small_silo = FALSE
 			return
 		build_small_silo = !build_small_silo


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fix small silo build fail message.

Fix `get_active_player_count()` proc only used for small silo checks and events checking for any `mob.stat` instead of not dead.

## Why It's Good For The Game

Not checking for alive players only is stinky.

Xenos saying "players" over hivemind when they can't build a silo is bad.

## Changelog
:cl:
fix: Fixed get active players alive_check.
spellcheck: Fixed OOC wording on small silo text when there are too many players.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
