### PR TITLE
Transvitox No Longer Sucks

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -600,6 +600,7 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 
 #define WRAITH_TELEPORT_DEBUFF_STACKS			1 //Stagger and slow stacks applied to adjacent living hostiles before/after a teleport
 
+#define DEFILER_TRANSVITOX_CAP					180 //Max toxin damage transvitox will allow
 
 //misc
 

--- a/code/modules/reagents/reagents/toxin.dm
+++ b/code/modules/reagents/reagents/toxin.dm
@@ -549,7 +549,7 @@
 
 /datum/reagent/toxin/xeno_transvitox //when damage is received, converts brute/burn equal to 50% of damage received to tox damage
 	name = "Transvitox"
-	description = "Heals brute and burn wounds, while producing toxins."
+	description = "Converts burn damage to toxin damage over time, and causes brute damage received to inflict extra toxin damage."
 	reagent_state = LIQUID
 	color = "#94FF00"
 	custom_metabolism = 0.4
@@ -561,18 +561,48 @@
 	RegisterSignal(L, COMSIG_HUMAN_DAMAGE_TAKEN, .proc/transvitox_human_damage_taken)
 
 /datum/reagent/toxin/xeno_transvitox/on_mob_life(mob/living/L, metabolism)
-	if(prob(25))
-		to_chat(L, "<span class='warning'>You notice being strangely revitalised.</span>")
+	if(prob(10))
+		to_chat(L, "<span class='warning'>You notice your wounds crusting over with disgusting green ichor.</span>")
+
+	var/fire_loss = L.getFireLoss()
+	if(!fire_loss) //If we have no burn damage, cancel out
+		return ..()
+
+	var/tox_cap_multiplier = 1
+
+	if(L.reagents.get_reagent_amount(/datum/reagent/toxin/xeno_hemodile)) //Each other Defiler toxin doubles the multiplier
+		tox_cap_multiplier *= 2
+
+	if(L.reagents.get_reagent_amount(/datum/reagent/toxin/xeno_neurotoxin))
+		tox_cap_multiplier *= 2
+
+	var/tox_loss = L.getToxLoss()
+	if(tox_loss > DEFILER_TRANSVITOX_CAP) //If toxin levels are already at their cap, cancel out
+		return ..()
+
+	var/dam = (current_cycle * 0.25 * tox_cap_multiplier) //Converts burn damage at this rate to toxin damage
+
+	if(fire_loss < dam) //If burn damage is less than damage to be converted, have the conversion value be equal to the burn damage
+		dam = fire_loss
+
+	L.heal_limb_damage(burn = dam, updating_health = TRUE) //Heal damage equal to toxin damage dealt; heal before applying toxin damage so we don't flash kill the target
+	L.adjustToxLoss(dam)
+
 	return ..()
 
 /datum/reagent/toxin/xeno_transvitox/proc/transvitox_human_damage_taken(mob/living/L, damage)
 	SIGNAL_HANDLER
-	var/dam = min(damage*0.4, 45 - L.getToxLoss()) // hard caps damage conversion to not exceed 45 tox
-	if((L.getBruteLoss() + L.getFireLoss()) < dam)
+
+	var/tox_cap_multiplier = 1
+
+	if(L.reagents.get_reagent_amount(/datum/reagent/toxin/xeno_hemodile)) //Each other Defiler toxin doubles the multiplier
+		tox_cap_multiplier *= 2
+
+	if(L.reagents.get_reagent_amount(/datum/reagent/toxin/xeno_neurotoxin))
+		tox_cap_multiplier *= 2
+
+	var/tox_loss = L.getToxLoss()
+	if(tox_loss > DEFILER_TRANSVITOX_CAP) //If toxin levels are already at their cap, cancel out
 		return
-	L.adjustToxLoss(dam)
-	var/healed_brute = min(dam, L.getBruteLoss())
-	L.heal_limb_damage(healed_brute)
-	if(!L.getFireLoss())
-		return
-	L.heal_limb_damage(0, dam - healed_brute)
+
+	L.setToxLoss(clamp(tox_loss + min(L.getBruteLoss() * 0.1 * tox_cap_multiplier, damage * 0.1 * tox_cap_multiplier), tox_loss, DEFILER_TRANSVITOX_CAP)) //Deal bonus tox damage equal to a % of the lesser of the damage taken or the target's brute damage; capped at DEFILER_TRANSVITOX_CAP.


### PR DESCRIPTION
## About The Pull Request

1. Transvitox: Each tick converts 0.25 * the number of cycles this toxin has been in the victim's body * 2x for each other Xeno chem in the victim's system burn damage to toxin.

2. Whenever its victim takes brute damage, Transvitox deals extra toxin damage to it if its current toxin doesn't exceed 180 toxin, equal to 10% of the damage dealt up to a maximum of 180 tox damage. This extra damage is doubled for each other Xeno chem in the victim's system.


## Why It's Good For The Game

Transvitox doesn't suck ass anymore.


## Changelog
:cl:
balance: Transvitox reworked: it now converts only burn damage to toxin, and whenever its victim takes brute damage, Transvitox deals extra toxin damage to it equal to a % of this damage. Toxin damage inflicted/converted in this way is capped at 180. Effect is enhanced for each other Xeno toxin in the victim's system.
/:cl:
