### PR TITLE
Charging xenos now plow snow when at full steam

### DIFF
--- a/code/game/turfs/snow.dm
+++ b/code/game/turfs/snow.dm
@@ -88,7 +88,7 @@
 			if(X.is_charging >= CHARGE_ON) // chargers = snow plows
 				slayer = 0
 				update_icon(1, 0)
-	..()
+	return ..()
 
 
 //Update icon
@@ -206,6 +206,5 @@
 /turf/open/floor/plating/ground/snow/layer3
 	icon_state = "snow_3"
 	slayer = 3
-
 
 

--- a/code/game/turfs/snow.dm
+++ b/code/game/turfs/snow.dm
@@ -81,12 +81,13 @@
 			C.next_move_slowdown += 0.5 * slayer
 			if(prob(1))
 				to_chat(C, "<span class='warning'>Moving through [src] slows you down.</span>")
-			if(isxeno(C))
-				C.next_move_slowdown -= 0.25 * slayer
-				var/mob/living/carbon/xenomorph/X = C
-				if(X.is_charging == CHARGE_MAX) // chargers = snow plows
-					slayer = 0
-					update_icon(1, 0)
+			if(!isxeno(C))
+				return ..()
+			C.next_move_slowdown -= 0.25 * slayer
+			var/mob/living/carbon/xenomorph/X = C
+			if(X.is_charging >= CHARGE_ON) // chargers = snow plows
+				slayer = 0
+				update_icon(1, 0)
 	..()
 
 

--- a/code/game/turfs/snow.dm
+++ b/code/game/turfs/snow.dm
@@ -78,9 +78,15 @@
 	if(slayer > 0)
 		if(iscarbon(AM))
 			var/mob/living/carbon/C = AM
-			C.next_move_slowdown += (isxeno(C) ? 0.25 : 0.5) * slayer
+			C.next_move_slowdown += 0.5 * slayer
 			if(prob(1))
 				to_chat(C, "<span class='warning'>Moving through [src] slows you down.</span>")
+			if(isxeno(C))
+				C.next_move_slowdown -= 0.25 * slayer
+				var/mob/living/carbon/xenomorph/X = C
+				if(X.is_charging == CHARGE_MAX) // chargers = snow plows
+					slayer = 0
+					update_icon(1, 0)
 	..()
 
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Melts snow when crossed by a charging charger.

## Why It's Good For The Game

Snow sucks. This adds a fun way for xenos to clear it.

## Changelog
:cl:
add: Crusher's and Bull's charges now double as snow plows!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
