### PR TITLE
Fix hunt/distress MODE_PSY_POINTS flag collision

### DIFF
--- a/code/controllers/subsystem/silo.dm
+++ b/code/controllers/subsystem/silo.dm
@@ -27,5 +27,5 @@ SUBSYSTEM_DEF(silo)
 /datum/controller/subsystem/silo/proc/start_spawning()
 	SIGNAL_HANDLER
 	UnregisterSignal(SSdcs, list(COMSIG_GLOB_OPEN_TIMED_SHUTTERS_LATE, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_XENO_HIVEMIND, COMSIG_GLOB_OPEN_SHUTTERS_EARLY, COMSIG_GLOB_TADPOLE_LAUNCHED))
-	if(SSticker.mode?.flags_round_type & MODE_PSY_POINTS)
+	if(SSticker.mode?.flags_round_type & MODE_PSY_POINTS_ROUNDSTART)
 		can_fire = TRUE

--- a/code/datums/jobs/job/job.dm
+++ b/code/datums/jobs/job/job.dm
@@ -201,7 +201,7 @@ GLOBAL_PROTECT(exp_specialmap)
 		var/datum/job/scaled_job = SSjob.GetJobType(index)
 		if(!(scaled_job in SSjob.active_joinable_occupations))
 			continue
-		if(isxenosjob(scaled_job) && respawn && (SSticker.mode?.flags_round_type & MODE_PSY_POINTS))
+		if(isxenosjob(scaled_job) && respawn && (SSticker.mode?.flags_round_type & MODE_PSY_POINTS_ROUNDSTART))
 			continue
 		scaled_job.add_job_points(jobworth[index])
 	return TRUE

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -739,7 +739,7 @@ to_chat will check for valid clients itself already so no need to double check f
 			continue
 		qdel(silo)
 
-	if(SSticker.mode?.flags_round_type & MODE_PSY_POINTS)
+	if(SSticker.mode?.flags_round_type & MODE_PSY_POINTS_ROUNDSTART)
 		SSpoints.xeno_points_by_hive[hivenumber] = SILO_PRICE + XENO_TURRET_PRICE //Give a free silo when going shipside and a turret
 
 	var/list/living_player_list = SSticker.mode.count_humans_and_xenos(count_flags = COUNT_IGNORE_HUMAN_SSD)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adjusted some logic checking for `MODE_PSY_POINTS` that should now be checking for `MODE_PSY_POINTS_ROUNDSTART` since both Hunt and Distress Signal gamemodes use `MODE_PSY_POINTS` now, but only Distress has `MODE_PSY_POINTS_ROUNDSTART`

Closes: #6892

## Why It's Good For The Game

Mode breaking bugs bad. Fix good.

## Changelog
:cl:
fix: Fixed silos generating larva during Hunt.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
