### PR TITLE
Fix Synths being able to use Powerfist

### DIFF
--- a/code/game/objects/items/weapons/misc.dm
+++ b/code/game/objects/items/weapons/misc.dm
@@ -85,6 +85,10 @@
 
 
 /obj/item/weapon/powerfist/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+	if(issynth(user) && !CONFIG_GET(flag/allow_synthetic_gun_use))
+		to_chat(user, "<span class='warning'>Your programming prevents you from powerfisting.</span>")
+		return
+
 	if(!cell)
 		to_chat(user, "<span class='warning'>\The [src] can't operate without a source of power!</span>")
 		return

--- a/code/game/objects/items/weapons/misc.dm
+++ b/code/game/objects/items/weapons/misc.dm
@@ -86,7 +86,7 @@
 
 /obj/item/weapon/powerfist/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	if(issynth(user) && !CONFIG_GET(flag/allow_synthetic_gun_use))
-		to_chat(user, "<span class='warning'>Your programming prevents you from powerfisting.</span>")
+		to_chat(user, "<span class='warning'>Your programming prevents you from operating the powerfist.</span>")
 		return
 
 	if(!cell)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds synth check code to powerfist attacks.

## Why It's Good For The Game

Less synth combat, less synth FF, and less incentive for synths to be anywhere near xenos willingly.

> the fact anyone feels this will impact balance is exactly why it is a problem

It never should have impacted synth balance in the first place.

## Changelog
:cl:
fix: Fixed Synths being able to use Powerfist without gun use enabled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
