### PR TITLE
Removes xenohide from runner.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
@@ -215,7 +215,7 @@
 	pounce_delay = 13 SECONDS
 
 	// *** Abilities *** ///
-	actions = list(actions = list(
+	actions = list(
 		/datum/action/xeno_action/xeno_resting,
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/activable/headbite,

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
@@ -56,7 +56,6 @@
 		/datum/action/xeno_action/activable/psydrain,
 		/datum/action/xeno_action/activable/headbite,
 		/datum/action/xeno_action/activable/devour,
-		/datum/action/xeno_action/xenohide,
 		/datum/action/xeno_action/activable/pounce,
 		/datum/action/xeno_action/toggle_savage,
 		/datum/action/xeno_action/evasion,
@@ -219,7 +218,6 @@
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
 		/datum/action/xeno_action/activable/psydrain,
-		/datum/action/xeno_action/xenohide,
 		/datum/action/xeno_action/activable/pounce,
 		/datum/action/xeno_action/toggle_savage,
 		/datum/action/xeno_action/evasion,

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
@@ -223,6 +223,7 @@
 		/datum/action/xeno_action/activable/pounce,
 		/datum/action/xeno_action/toggle_savage,
 		/datum/action/xeno_action/evasion,
+		)
 
 /datum/xeno_caste/roony/young
 	upgrade_name = "Young"

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
@@ -215,13 +215,14 @@
 	pounce_delay = 13 SECONDS
 
 	// *** Abilities *** ///
-	actions = list(
+	actions = list(actions = list(
 		/datum/action/xeno_action/xeno_resting,
 		/datum/action/xeno_action/activable/psydrain,
+		/datum/action/xeno_action/activable/headbite,
+		/datum/action/xeno_action/activable/devour,
 		/datum/action/xeno_action/activable/pounce,
 		/datum/action/xeno_action/toggle_savage,
 		/datum/action/xeno_action/evasion,
-	)
 
 /datum/xeno_caste/roony/young
 	upgrade_name = "Young"

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
@@ -223,7 +223,7 @@
 		/datum/action/xeno_action/activable/pounce,
 		/datum/action/xeno_action/toggle_savage,
 		/datum/action/xeno_action/evasion,
-		)
+	)
 
 /datum/xeno_caste/roony/young
 	upgrade_name = "Young"


### PR DESCRIPTION


## About The Pull Request

See title. 

## Why It's Good For The Game

Runner hide pounce OP, please remove.
## Changelog
:cl:
del: hide from runner
fix: proper roony abilities
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
