### PR TITLE
Nerf psydrain, nerf generators psy points output, rebalance cocoon

### DIFF
--- a/code/controllers/subsystem/points.dm
+++ b/code/controllers/subsystem/points.dm
@@ -2,7 +2,7 @@
 #define DROPSHIP_POINT_RATE 18 * ((GLOB.current_orbit+3)/6)
 #define SUPPLY_POINT_RATE 2 * (GLOB.current_orbit/3)
 //How many psych point one gen gives per person on the server
-#define BASE_PSYCH_POINT_OUTPUT 0.002
+#define BASE_PSYCH_POINT_OUTPUT 0.001
 
 SUBSYSTEM_DEF(points)
 	name = "Points"

--- a/code/controllers/subsystem/points.dm
+++ b/code/controllers/subsystem/points.dm
@@ -2,7 +2,7 @@
 #define DROPSHIP_POINT_RATE 18 * ((GLOB.current_orbit+3)/6)
 #define SUPPLY_POINT_RATE 2 * (GLOB.current_orbit/3)
 //How many psych point one gen gives per person on the server
-#define BASE_PSYCH_POINT_OUTPUT 0.001
+#define BASE_PSYCH_POINT_OUTPUT 0.0015
 
 SUBSYSTEM_DEF(points)
 	name = "Points"

--- a/code/game/objects/items/cocoon.dm
+++ b/code/game/objects/items/cocoon.dm
@@ -14,7 +14,7 @@
 	///What is inside the cocoon
 	var/mob/living/victim
 	///How much time the cocoon takes to deplete the life force of the marine
-	var/cocoon_life_time = 10 MINUTES
+	var/cocoon_life_time = 5 MINUTES
 	///How many psych points it is generating every 5 seconds
 	var/psych_points_output = 1.2
 	///Standard busy check

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1254,7 +1254,7 @@
 	gamemode_flags = ABILITY_DISTRESS
 	plasma_cost = 100
 	///How much psy points it give
-	var/psy_points_reward = 60
+	var/psy_points_reward = 40
 	///How much larva points it gives (8 points for one larva in distress)
 	var/larva_point_reward = 1
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See CL

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Xeno are getting too much psy points now, which lead to short games (when xeno kill a push, even if the push managed to kill pools, they will be able to produce so much silo behind that that it's game over)

This will make games longer, and give marines a second / third shot

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Psy drain from 60 psy points to 40
balance: Cocoon now only works for 5 minutes, so it produces 80 points rather than 160 but is less risky to make
balance: Psy points generated from generators are reduced by 25%
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
