### PR TITLE
Increase T-12 Magazine Capacity From 50 to 60

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -114,7 +114,7 @@
 	unload_sound = 'sound/weapons/guns/interact/t18_unload.ogg'
 	reload_sound = 'sound/weapons/guns/interact/t18_reload.ogg'
 	caliber = CALIBER_10X24_CASELESS //codex
-	max_shells = 50 //codex
+	max_shells = 60 //codex
 	force = 20
 	current_mag = /obj/item/ammo_magazine/rifle/standard_assaultrifle
 	attachable_allowed = list(

--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -63,19 +63,19 @@
 	icon_state = "t12"
 	w_class = WEIGHT_CLASS_NORMAL
 	default_ammo = /datum/ammo/bullet/rifle
-	max_rounds = 50
+	max_rounds = 60
 	gun_type = /obj/item/weapon/gun/rifle/standard_assaultrifle
 	icon_state_mini = "mag_rifle_big"
 
 /obj/item/ammo_magazine/box10x24mm
 	name = "box of 10x24mm"
-	desc = "A box containing 150 rounds of 10x24mm caseless.."
+	desc = "A box containing 180 rounds of 10x24mm caseless.."
 	caliber = CALIBER_10X24_CASELESS
 	icon_state = "box_10x24mm"
 	w_class = WEIGHT_CLASS_NORMAL
 	default_ammo = /datum/ammo/bullet/rifle
-	current_rounds = 150
-	max_rounds = 150
+	current_rounds = 180
+	max_rounds = 180
 	icon_state_mini = "ammo_packet"
 
 //-------------------------------------------------------


### PR DESCRIPTION

## About The Pull Request

Increases T-12 Magazine Capacity from 50 -> 60
Additionally increases the 10x24 ammo box capacity from 150 -> 180 to fit the capacity increase.

## Why It's Good For The Game

Lets the T-12 last longer in the field and be a slightly better "generalist" weapon. Intended to make the T-12 more appealing when compared to other weapons without increasing its moment to moment power.

Additionally this makes the 3-round burst fire setting actually fully drain the weapon instead of having an awkward 2-shot burst at the end.

## Changelog
:cl: Tupina
balance: T-12 magazine capacity increased from 50 -> 60
/:cl: