### PR TITLE
T19 buff

### DIFF
--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -77,7 +77,7 @@
 	recoil_unwielded = 0
 	scatter = 0
 	fire_delay = 0.15 SECONDS
-	scatter_unwielded = 0 //Made to be better used one handed.
+	scatter_unwielded = 5 //Made to be better used one handed.
 	aim_slowdown = 0.15
 	burst_amount = 5
 	movement_acc_penalty_mult = 0

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -76,8 +76,8 @@
 	accuracy_mult_unwielded = 0.85
 	recoil_unwielded = 0
 	scatter = 0
-	fire_delay = 0.2 SECONDS
-	scatter_unwielded = 10 //Made to be used one handed.
+	fire_delay = 0.15 SECONDS
+	scatter_unwielded = 0 //Made to be better used one handed.
 	aim_slowdown = 0.15
 	burst_amount = 5
 	movement_acc_penalty_mult = 0


### PR DESCRIPTION
makes it gooder one handed because gohunt says so, ups rof to T90 standard for SMGs

<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

buffs T19 ROF and reduces scatter to improve one handed use

## Why It's Good For The Game

Gohunt thinks it's good for the game, he's incapable of doing this, so I'll do it for him

## Changelog
:cl:
balance: buffs T19 ROF and scatter
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
