### PR TITLE
Fix xeno charge steps resetting from null direction signals

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -82,7 +82,7 @@
 	var/mob/living/carbon/xenomorph/charger = owner
 	if(charger.is_charging == CHARGE_OFF)
 		return
-	if(old_dir == new_dir)
+	if(!old_dir || !new_dir || old_dir == new_dir) //Check for null direction from help shuffle signals
 		return
 	do_stop_momentum()
 
@@ -147,7 +147,7 @@
 
 /datum/action/xeno_action/ready_charge/proc/check_momentum(newdir)
 	var/mob/living/carbon/xenomorph/charger = owner
-	if(ISDIAGONALDIR(newdir) || charge_dir != newdir)
+	if(newdir && (ISDIAGONALDIR(newdir) || charge_dir != newdir)) //Check for null direction from help shuffle signals
 		return FALSE
 
 	if(next_move_limit && world.time > next_move_limit)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fix `COMSIG_MOVABLE_MOVED` and `COMSIG_ATOM_DIR_CHANGE` signal handler (and child procs) code that does direction comparison to check for changes interpreting one or more `null` directions as an actual change.

## Why It's Good For The Game

Fix good. Mitigated only by the fact plow charges move blocking mobs out of your way first once full on charging.

## Changelog
:cl:
balance: Body blocking xeno chargers while they are in CHARGE_BUILDINGUP phase no longer resets their momentum if they shuffle through you.
fix: Fixed some xeno charger movement signal handlers not checking for null directions.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
