### PR TITLE
Miner points is linked to pop + overall miner buff

### DIFF
--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -10,8 +10,8 @@
 #define MINER_RESISTANT	"reinforced components"
 #define MINER_OVERCLOCKED "high-efficiency drill"
 
-#define PHORON_CRATE_SELL_AMOUNT 15
-#define PLATINUM_CRATE_SELL_AMOUNT 30
+#define PHORON_CRATE_SELL_AMOUNT 0.5
+#define PLATINUM_CRATE_SELL_AMOUNT 1
 
 ///Resource generator that produces a certain material that can be repaired by marines and attacked by xenos, Intended as an objective for marines to play towards to get more req gear
 /obj/machinery/miner
@@ -93,7 +93,7 @@
 			required_ticks = 60
 		if(MINER_AUTOMATED)
 			if(stored_mineral)
-				SSpoints.supply_points[faction] += mineral_value * stored_mineral
+				SSpoints.supply_points[faction] += mineral_value * stored_mineral * get_active_player_count()
 				do_sparks(5, TRUE, src)
 				playsound(loc,'sound/effects/phasein.ogg', 50, FALSE)
 				say("Ore shipment has been sold for [mineral_value * stored_mineral] points.")
@@ -245,7 +245,7 @@
 		to_chat(user, "<span class='warning'>[src] is not ready to produce a shipment yet!</span>")
 		return
 
-	SSpoints.supply_points[faction] += mineral_value * stored_mineral
+	SSpoints.supply_points[faction] += mineral_value * stored_mineral * get_active_player_count()
 	do_sparks(5, TRUE, src)
 	playsound(loc,'sound/effects/phasein.ogg', 50, FALSE)
 	say("Ore shipment has been sold for [mineral_value * stored_mineral] points.")
@@ -261,7 +261,7 @@
 			for(var/direction in GLOB.cardinals)
 				if(!isopenturf(get_step(loc, direction))) //Must be open on one side to operate
 					continue
-				SSpoints.supply_points[faction] += mineral_value
+				SSpoints.supply_points[faction] += mineral_value * get_active_player_count()
 				do_sparks(5, TRUE, src)
 				playsound(loc,'sound/effects/phasein.ogg', 50, FALSE)
 				say("Ore shipment has been sold for [mineral_value] points.")


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The amount of supply points a miner give will be linear with pop.
With this calibration, one phoron shipment gives 0.5 points for each active player.

Overall, it's a miner buff

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Always good to link balance things with pop.
I also want to buff miner, because marines really have issues to keep up with xeno in midgame, even when they manage to have a ton of miners.

IMO, if marines manage to keep 5+ miners, they should definitly win most of the time. And this is not the case, in part because marines level is bad (FF with sadar...), but also because it's impossible to equip properly marines with better gear than at start.

Marines need a better force scale factor, and this is far from being enough

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Miners points output is linked with active player pop
balance: Overall, miners are producing more in mid pop (40 players)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
