### PR TITLE
Miners are more durable

### DIFF
--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -280,17 +280,15 @@
 /obj/machinery/miner/attack_alien(mob/living/carbon/xenomorph/X, damage_amount = X.xeno_caste.melee_damage, damage_type = BRUTE, damage_flag = "", effects = TRUE, armor_penetration = 0, isrightclick = FALSE)
 	if(X.status_flags & INCORPOREAL) //Incorporeal xenos cannot attack physically.
 		return
-	if(!do_after(X, 3 SECONDS, TRUE, src, BUSY_ICON_DANGER, BUSY_ICON_HOSTILE))
-		return
-	X.do_attack_animation(src, ATTACK_EFFECT_CLAW)
-	X.visible_message("<span class='danger'>[X] slashes \the [src]!</span>", \
-	"<span class='danger'>We slash \the [src]!</span>", null, 5)
-	playsound(loc, "alien_claw_metal", 25, TRUE)
-	if(miner_status == MINER_DESTROYED)
-		to_chat(X, "<span class='warning'>[src] is already destroyed!</span>")
-		return
-	miner_integrity -= 25
-	set_miner_status()
+	while(miner_status != MINER_DESTROYED)
+		if(!do_after(X, 3 SECONDS, TRUE, src, BUSY_ICON_DANGER, BUSY_ICON_HOSTILE))
+			return
+		X.do_attack_animation(src, ATTACK_EFFECT_CLAW)
+		X.visible_message("<span class='danger'>[X] slashes \the [src]!</span>", \
+		"<span class='danger'>We slash \the [src]!</span>", null, 5)
+		playsound(loc, "alien_claw_metal", 25, TRUE)
+		miner_integrity -= 25
+		set_miner_status()
 
 /obj/machinery/miner/proc/set_miner_status()
 	var/health_percent = round((miner_integrity / max_miner_integrity) * 100)

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -280,6 +280,8 @@
 /obj/machinery/miner/attack_alien(mob/living/carbon/xenomorph/X, damage_amount = X.xeno_caste.melee_damage, damage_type = BRUTE, damage_flag = "", effects = TRUE, armor_penetration = 0, isrightclick = FALSE)
 	if(X.status_flags & INCORPOREAL) //Incorporeal xenos cannot attack physically.
 		return
+	if(!do_after(X, 3 SECONDS, TRUE, src, BUSY_ICON_DANGER, BUSY_ICON_HOSTILE))
+		return
 	X.do_attack_animation(src, ATTACK_EFFECT_CLAW)
 	X.visible_message("<span class='danger'>[X] slashes \the [src]!</span>", \
 	"<span class='danger'>We slash \the [src]!</span>", null, 5)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A 3 second windup is needed to damage miners. This makes them more durable, and way more easy to defend against wraith or fast runners

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Miner integrity system was never designed for wraith, so it was stupidly easy to kill miners with it witout taking any risks.

## Changelog
:cl:
balance: Miners now take time to disable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
