### PR TITLE
Renames xeno structure typepath

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -107,7 +107,7 @@
 #define isxenohivemind(A) (istype(A, /mob/living/carbon/xenomorph/hivemind))
 #define isxenowraith(A) (istype(A, /mob/living/carbon/xenomorph/wraith))
 
-#define isresinsilo(A) (istype(A, /obj/structure/resin/silo))
+#define isresinsilo(A) (istype(A, /obj/structure/xeno/resin/silo))
 
 //Silicon mobs
 #define issilicon(A) (istype(A, /mob/living/silicon))

--- a/code/controllers/subsystem/silo.dm
+++ b/code/controllers/subsystem/silo.dm
@@ -15,7 +15,7 @@ SUBSYSTEM_DEF(silo)
 /datum/controller/subsystem/silo/fire(resumed = 0)
 	var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
 	current_larva_spawn_rate = 0
-	for(var/obj/structure/resin/silo/silo AS in GLOB.xeno_resin_silos)
+	for(var/obj/structure/xeno/resin/silo/silo AS in GLOB.xeno_resin_silos)
 		current_larva_spawn_rate += silo.larva_spawn_rate
 	current_larva_spawn_rate *= larva_rate_boost
 	xeno_job.add_job_points(current_larva_spawn_rate, SILO_ORIGIN)

--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -81,8 +81,8 @@
 /datum/game_mode/infestation/crash/post_setup()
 	. = ..()
 	for(var/i in GLOB.xeno_resin_silo_turfs)
-		new /obj/structure/resin/silo(i)
-	
+		new /obj/structure/xeno/resin/silo(i)
+
 	for(var/obj/effect/landmark/corpsespawner/corpse AS in GLOB.corpse_landmarks_list)
 		corpse.create_mob(HEADBITE_DEATH)
 

--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -34,7 +34,7 @@
 	addtimer(CALLBACK(GLOB.hive_datums[XENO_HIVE_NORMAL], /datum/hive_status/proc/handle_silo_death_timer), MINIMUM_TIME_SILO_LESS_COLLAPSE)
 
 	for(var/i in GLOB.xeno_turret_turfs)
-		new /obj/structure/resin/xeno_turret(i)
+		new /obj/structure/xeno/resin/xeno_turret(i)
 	for(var/obj/effect/landmark/corpsespawner/corpse AS in GLOB.corpse_landmarks_list)
 		corpse.create_mob(COCOONED_DEATH)
 

--- a/code/datums/gamemodes/hunt.dm
+++ b/code/datums/gamemodes/hunt.dm
@@ -30,7 +30,7 @@
 /datum/game_mode/infestation/hunt/post_setup()
 	. = ..()
 	for(var/i in GLOB.xeno_resin_silo_turfs)
-		new /obj/structure/resin/silo(i)
+		new /obj/structure/xeno/resin/silo(i)
 	for(var/obj/effect/landmark/corpsespawner/corpse AS in GLOB.corpse_landmarks_list)
 		corpse.create_mob(SILO_DEATH)
 	addtimer(CALLBACK(src, .proc/announce_bioscans, FALSE, 1), 5 MINUTES)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -224,7 +224,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 
 	else if(href_list["track_silo_number"])
 		var/silo_number = href_list["track_silo_number"]
-		for(var/obj/structure/resin/silo/resin_silo AS in GLOB.xeno_resin_silos)
+		for(var/obj/structure/xeno/resin/silo/resin_silo AS in GLOB.xeno_resin_silos)
 			if(resin_silo.associated_hive == GLOB.hive_datums[XENO_HIVE_NORMAL] && num2text(resin_silo.number_silo) == silo_number)
 				var/mob/dead/observer/ghost = usr
 				ghost.forceMove(resin_silo.loc)

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1025,7 +1025,7 @@
 	if(!do_after(owner, build_time, TRUE, A, BUSY_ICON_BUILD))
 		return fail_activate()
 
-	var/obj/structure/resin/silo/hivesilo = new(get_step(A, SOUTHWEST))
+	var/obj/structure/xeno/resin/silo/hivesilo = new(get_step(A, SOUTHWEST))
 
 	var/moved_human_number = 0
 	for(var/mob/living/to_use AS in valid_mobs)
@@ -1096,7 +1096,7 @@
 		to_chat(owner, "<span class='xenowarning'>The hive doesn't have the necessary psychic points for you to do that!</span>")
 		return FALSE
 
-	for(var/obj/structure/resin/silo/silo AS in GLOB.xeno_resin_silos)
+	for(var/obj/structure/xeno/resin/silo/silo AS in GLOB.xeno_resin_silos)
 		if(get_dist(silo, A) < 15)
 			to_chat(owner, "<span class='xenowarning'>Another silo is too close!</span>")
 			return FALSE
@@ -1116,10 +1116,10 @@
 	log_game("[owner] has built a silo in [AREACOORD(A)], spending [final_psych_cost] psy points in the process")
 	succeed_activate()
 	if(build_small_silo)
-		new /obj/structure/resin/silo/small_silo (get_step(A, SOUTHWEST))
+		new /obj/structure/xeno/resin/silo/small_silo (get_step(A, SOUTHWEST))
 		xeno_message("[X.name] has built a small silo at [get_area(A)]!", "xenoannounce", 5, X.hivenumber)
 		return
-	new /obj/structure/resin/silo (get_step(A, SOUTHWEST))
+	new /obj/structure/xeno/resin/silo (get_step(A, SOUTHWEST))
 	xeno_message("[X.name] has built a silo at [get_area(A)]!", "xenoannounce", 5, X.hivenumber)
 
 
@@ -1171,7 +1171,7 @@
 		to_chat(X, "<span class='warning'>We can only shape on weeds. We must find some resin before we start building!</span>")
 		return FALSE
 
-	if(!T.check_alien_construction(X, planned_building = /obj/structure/resin/xeno_turret) || !T.check_disallow_alien_fortification(X))
+	if(!T.check_alien_construction(X, planned_building = /obj/structure/xeno/resin/xeno_turret) || !T.check_disallow_alien_fortification(X))
 		return FALSE
 
 	if(SSpoints.xeno_points_by_hive[X.hivenumber] < psych_cost)
@@ -1189,7 +1189,7 @@
 		return fail_activate()
 
 	to_chat(owner, "<span class='xenowarning'>We build a new acid turret, spending 100 psychic points in the process</span>")
-	new /obj/structure/resin/xeno_turret(get_turf(A), X.hivenumber)
+	new /obj/structure/xeno/resin/xeno_turret(get_turf(A), X.hivenumber)
 
 	SSpoints.xeno_points_by_hive[X.hivenumber] -= psych_cost
 	log_game("[owner] built a turret in [AREACOORD(A)], spending [psych_cost] psy points in the process")

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -286,7 +286,7 @@
 
 	if(isobj(crushed))
 		var/obj/crushed_obj = crushed
-		if(istype(crushed_obj, /obj/structure/resin/silo) || istype(crushed_obj, /obj/structure/resin/xeno_turret))
+		if(istype(crushed_obj, /obj/structure/xeno/resin/silo) || istype(crushed_obj, /obj/structure/xeno/resin/xeno_turret))
 			return precrush2signal(crushed_obj.post_crush_act(charger, src))
 		playsound(crushed_obj.loc, "punch", 25, 1)
 		var/crushed_behavior = crushed_obj.crushed_special_behavior()

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -626,7 +626,7 @@ to_chat will check for valid clients itself already so no need to double check f
 
 
 /datum/hive_status/proc/attempt_to_spawn_larva_in_silo(mob/xeno_candidate, possible_silos, larva_already_reserved = FALSE)
-	var/obj/structure/resin/silo/chosen_silo
+	var/obj/structure/xeno/resin/silo/chosen_silo
 	if(length(possible_silos) > 1)
 		chosen_silo = tgui_input_list(xeno_candidate, "Available Egg Silos", "Spawn location", possible_silos)
 		if(!chosen_silo)
@@ -734,7 +734,7 @@ to_chat will check for valid clients itself already so no need to double check f
 		if(xeno_job.total_positions < (-difference + xeno_job.current_positions))
 			xeno_job.set_job_positions(-difference + xeno_job.current_positions)
 
-	for(var/obj/structure/resin/silo/silo AS in GLOB.xeno_resin_silos)
+	for(var/obj/structure/xeno/resin/silo/silo AS in GLOB.xeno_resin_silos)
 		if(!is_ground_level(silo.z))
 			continue
 		qdel(silo)
@@ -1070,7 +1070,7 @@ to_chat will check for valid clients itself already so no need to double check f
 /obj/structure/xeno/tunnel/get_xeno_hivenumber()
 	return hivenumber
 
-/obj/structure/resin/xeno_turret/get_xeno_hivenumber()
+/obj/structure/xeno/resin/xeno_turret/get_xeno_hivenumber()
 	return associated_hive.hivenumber
 
 /datum/hive_status/ui_state(mob/user)

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -59,7 +59,7 @@
 ///Relays health and location data about resin silos belonging to the same hive as the input user
 /proc/resin_silo_status_output(mob/living/carbon/xenomorph/user, datum/hive_status/hive)
 	. = "<BR><b>List of Resin Silos:</b><BR><table cellspacing=4>" //Resin silo data
-	for(var/obj/structure/resin/silo/resin_silo AS in GLOB.xeno_resin_silos)
+	for(var/obj/structure/xeno/resin/silo/resin_silo AS in GLOB.xeno_resin_silos)
 		if(resin_silo.associated_hive == hive)
 
 			var/hp_color = "green"
@@ -175,7 +175,7 @@
 
 	if(href_list["track_silo_number"])
 		var/silo_number = href_list["track_silo_number"]
-		for(var/obj/structure/resin/silo/resin_silo AS in GLOB.xeno_resin_silos)
+		for(var/obj/structure/xeno/resin/silo/resin_silo AS in GLOB.xeno_resin_silos)
 			if(resin_silo.associated_hive == hive && num2text(resin_silo.number_silo) == silo_number)
 				tracked = resin_silo
 				to_chat(usr,"<span class='notice'> You will now track [resin_silo.name]</span>")

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -1,10 +1,14 @@
-/obj/structure/resin
+/obj/structure/xeno
+	///Bitflags specific to xeno structures
+	var/xeno_structure_flags
+
+/obj/structure/xeno/resin
 	hit_sound = "alien_resin_break"
 	layer = RESIN_STRUCTURE_LAYER
 	resistance_flags = UNACIDABLE
 
 
-/obj/structure/resin/ex_act(severity)
+/obj/structure/xeno/resin/ex_act(severity)
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
 			take_damage(210)
@@ -13,18 +17,18 @@
 		if(EXPLODE_LIGHT)
 			take_damage(70)
 
-/obj/structure/resin/attack_hand(mob/living/user)
+/obj/structure/xeno/resin/attack_hand(mob/living/user)
 	to_chat(user, "<span class='warning'>You scrape ineffectively at \the [src].</span>")
 	return TRUE
 
-/obj/structure/resin/flamer_fire_act()
+/obj/structure/xeno/resin/flamer_fire_act()
 	take_damage(10, BURN, "fire")
 
-/obj/structure/resin/fire_act()
+/obj/structure/xeno/resin/fire_act()
 	take_damage(10, BURN, "fire")
 
 
-/obj/structure/resin/silo
+/obj/structure/xeno/resin/silo
 	name = "resin silo"
 	icon = 'icons/Xeno/resin_silo.dmi'
 	icon_state = "weed_silo"
@@ -42,7 +46,7 @@
 	COOLDOWN_DECLARE(silo_damage_alert_cooldown)
 	COOLDOWN_DECLARE(silo_proxy_alert_cooldown)
 
-/obj/structure/resin/silo/Initialize()
+/obj/structure/xeno/resin/silo/Initialize()
 	. = ..()
 	var/static/number = 1
 	name = "[name] [number]"
@@ -60,7 +64,7 @@
 	return INITIALIZE_HINT_LATELOAD
 
 
-/obj/structure/resin/silo/LateInitialize()
+/obj/structure/xeno/resin/silo/LateInitialize()
 	. = ..()
 	if(!locate(/obj/effect/alien/weeds) in center_turf)
 		new /obj/effect/alien/weeds/node(center_turf)
@@ -77,7 +81,7 @@
 		newt.tunnel_desc = "[AREACOORD_NO_Z(newt)]"
 		newt.name += " [name]"
 
-/obj/structure/resin/silo/obj_destruction(damage_amount, damage_type, damage_flag)
+/obj/structure/xeno/resin/silo/obj_destruction(damage_amount, damage_type, damage_flag)
 	. = ..()
 	if(associated_hive)
 		UnregisterSignal(associated_hive, list(COMSIG_HIVE_XENO_MOTHER_PRE_CHECK, COMSIG_HIVE_XENO_MOTHER_CHECK))
@@ -88,7 +92,7 @@
 		playsound(loc,'sound/effects/alien_egg_burst.ogg', 75)
 
 
-/obj/structure/resin/silo/Destroy()
+/obj/structure/xeno/resin/silo/Destroy()
 	GLOB.xeno_resin_silos -= src
 
 	for(var/i in contents)
@@ -101,7 +105,7 @@
 	return ..()
 
 
-/obj/structure/resin/silo/examine(mob/user)
+/obj/structure/xeno/resin/silo/examine(mob/user)
 	. = ..()
 	var/current_integrity = (obj_integrity / max_integrity) * 100
 	switch(current_integrity)
@@ -117,7 +121,7 @@
 			to_chat(user, "<span class='info'>It appears in good shape, pulsating healthily.</span>")
 
 
-/obj/structure/resin/silo/take_damage(damage_amount, damage_type, damage_flag, sound_effect, attack_dir, armour_penetration)
+/obj/structure/xeno/resin/silo/take_damage(damage_amount, damage_type, damage_flag, sound_effect, attack_dir, armour_penetration)
 	. = ..()
 
 	//We took damage, so it's time to start regenerating if we're not already processing
@@ -126,7 +130,7 @@
 
 	resin_silo_damage_alert()
 
-/obj/structure/resin/silo/proc/resin_silo_damage_alert()
+/obj/structure/xeno/resin/silo/proc/resin_silo_damage_alert()
 	if(!COOLDOWN_CHECK(src, silo_damage_alert_cooldown))
 		return
 
@@ -134,7 +138,7 @@
 	COOLDOWN_START(src, silo_damage_alert_cooldown, XENO_SILO_HEALTH_ALERT_COOLDOWN) //set the cooldown.
 
 ///Alerts the Hive when hostiles get too close to their resin silo
-/obj/structure/resin/silo/proc/resin_silo_proxy_alert(datum/source, atom/hostile)
+/obj/structure/xeno/resin/silo/proc/resin_silo_proxy_alert(datum/source, atom/hostile)
 	SIGNAL_HANDLER
 
 	if(!COOLDOWN_CHECK(src, silo_proxy_alert_cooldown)) //Proxy alert triggered too recently; abort
@@ -155,12 +159,12 @@
 	associated_hive.xeno_message("Our [name] has detected a nearby hostile [hostile] at [get_area(hostile)] (X: [hostile.x], Y: [hostile.y]).", "xenoannounce", 5, FALSE, hostile, 'sound/voice/alien_help1.ogg', FALSE, null, /obj/screen/arrow/leader_tracker_arrow)
 	COOLDOWN_START(src, silo_proxy_alert_cooldown, XENO_SILO_DETECTION_COOLDOWN) //set the cooldown.
 
-/obj/structure/resin/silo/process()
+/obj/structure/xeno/resin/silo/process()
 	//Regenerate if we're at less than max integrity
 	if(obj_integrity < max_integrity)
 		obj_integrity = min(obj_integrity + 25, max_integrity) //Regen 5 HP per sec
 
-/obj/structure/resin/silo/proc/is_burrowed_larva_host(datum/source, list/mothers, list/silos)
+/obj/structure/xeno/resin/silo/proc/is_burrowed_larva_host(datum/source, list/mothers, list/silos)
 	SIGNAL_HANDLER
 	if(associated_hive)
 		silos += src
@@ -169,7 +173,7 @@
 //*******************
 //Corpse recyclinging
 //*******************
-/obj/structure/resin/silo/attackby(obj/item/I, mob/user, params)
+/obj/structure/xeno/resin/silo/attackby(obj/item/I, mob/user, params)
 	. = ..()
 	if(!isxeno(user)) //only xenos can deposit corpses
 		return
@@ -218,7 +222,7 @@
 	SSblackbox.record_feedback("tally", "round_statistics", 1, "xeno_silo_corpses")
 
 /// Make the silo shake
-/obj/structure/resin/silo/proc/shake(duration)
+/obj/structure/xeno/resin/silo/proc/shake(duration)
 	/// How important should be the shaking movement
 	var/offset = prob(50) ? -2 : 2
 	/// Track the last position of the silo for the animation
@@ -231,17 +235,17 @@
 	addtimer(CALLBACK(src, .proc/stop_shake, old_pixel_x), duration)
 
 /// Stop the shaking animation
-/obj/structure/resin/silo/proc/stop_shake(old_px)
+/obj/structure/xeno/resin/silo/proc/stop_shake(old_px)
 	animate(src)
 	pixel_x = old_px
 
-/obj/structure/resin/silo/small_silo
+/obj/structure/xeno/resin/silo/small_silo
 	name = "small resin silo"
 	icon_state = "purple_silo"
 	max_integrity = 500
 	larva_spawn_rate = 0.25
 
-/obj/structure/resin/xeno_turret
+/obj/structure/xeno/resin/xeno_turret
 	icon = 'icons/Xeno/acidturret.dmi'
 	icon_state = "acid_turret"
 	name = "resin acid turret"
@@ -270,7 +274,7 @@
 	///The last time the sentry did a scan
 	var/last_scan_time
 
-/obj/structure/resin/xeno_turret/Initialize(mapload, hivenumber = XENO_HIVE_NORMAL)
+/obj/structure/xeno/resin/xeno_turret/Initialize(mapload, hivenumber = XENO_HIVE_NORMAL)
 	. = ..()
 	ammo = GLOB.ammo_list[/datum/ammo/xeno/acid/heavy/turret]
 	ammo.max_range = range + 2 //To prevent funny gamers to abuse the turrets that easily
@@ -284,25 +288,25 @@
 	update_icon()
 
 ///Signal handler to delete the turret when the alamo is hijacked
-/obj/structure/resin/xeno_turret/proc/destroy_on_hijack()
+/obj/structure/xeno/resin/xeno_turret/proc/destroy_on_hijack()
 	SIGNAL_HANDLER
 	qdel(src)
 
-/obj/structure/resin/xeno_turret/obj_destruction(damage_amount, damage_type, damage_flag)
+/obj/structure/xeno/resin/xeno_turret/obj_destruction(damage_amount, damage_type, damage_flag)
 	if(damage_amount) //Spawn the gas only if we actually get destroyed by damage
 		var/datum/effect_system/smoke_spread/xeno/smoke = new /datum/effect_system/smoke_spread/xeno/acid(src)
 		smoke.set_up(1, get_turf(src))
 		smoke.start()
 	return ..()
 
-/obj/structure/resin/xeno_turret/Destroy()
+/obj/structure/xeno/resin/xeno_turret/Destroy()
 	set_hostile(null)
 	set_last_hostile(null)
 	STOP_PROCESSING(SSobj, src)
 	playsound(loc,'sound/effects/xeno_turret_death.ogg', 70)
 	return ..()
 
-/obj/structure/resin/xeno_turret/ex_act(severity)
+/obj/structure/xeno/resin/xeno_turret/ex_act(severity)
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
 			take_damage(1500)
@@ -311,22 +315,22 @@
 		if(EXPLODE_LIGHT)
 			take_damage(300)
 
-/obj/structure/resin/xeno_turret/flamer_fire_act()
+/obj/structure/xeno/resin/xeno_turret/flamer_fire_act()
 	take_damage(60, BURN, "fire")
 	ENABLE_BITFIELD(resistance_flags, ON_FIRE)
 
-/obj/structure/resin/xeno_turret/fire_act()
+/obj/structure/xeno/resin/xeno_turret/fire_act()
 	take_damage(60, BURN, "fire")
 	ENABLE_BITFIELD(resistance_flags, ON_FIRE)
 
-/obj/structure/resin/xeno_turret/update_overlays()
+/obj/structure/xeno/resin/xeno_turret/update_overlays()
 	. = ..()
 	if(obj_integrity <= max_integrity / 2)
 		. += image('icons/Xeno/acidturret.dmi', src, "+turret_damage")
 	if(CHECK_BITFIELD(resistance_flags, ON_FIRE))
 		. += image('icons/Xeno/acidturret.dmi', src, "+turret_on_fire")
 
-/obj/structure/resin/xeno_turret/process()
+/obj/structure/xeno/resin/xeno_turret/process()
 	//Turrets regen some HP, every 2 sec
 	if(obj_integrity < max_integrity)
 		obj_integrity = min(obj_integrity + TURRET_HEALTH_REGEN, max_integrity)
@@ -349,7 +353,7 @@
 		set_last_hostile(hostile)
 		SEND_SIGNAL(src, COMSIG_AUTOMATIC_SHOOTER_START_SHOOTING_AT)
 
-/obj/structure/resin/xeno_turret/attackby(obj/item/I, mob/living/user, params)
+/obj/structure/xeno/resin/xeno_turret/attackby(obj/item/I, mob/living/user, params)
 	if(I.flags_item & NOBLUDGEON || !isliving(user))
 		return attack_hand(user)
 
@@ -372,29 +376,29 @@
 	playsound(src, "alien_resin_break", 25)
 
 ///Signal handler for hard del of hostile
-/obj/structure/resin/xeno_turret/proc/unset_hostile()
+/obj/structure/xeno/resin/xeno_turret/proc/unset_hostile()
 	SIGNAL_HANDLER
 	hostile = null
 
 ///Signal handler for hard del of last_hostile
-/obj/structure/resin/xeno_turret/proc/unset_last_hostile()
+/obj/structure/xeno/resin/xeno_turret/proc/unset_last_hostile()
 	SIGNAL_HANDLER
 	last_hostile = null
 
 ///Setter for hostile with hard del in mind
-/obj/structure/resin/xeno_turret/proc/set_hostile(_hostile)
+/obj/structure/xeno/resin/xeno_turret/proc/set_hostile(_hostile)
 	if(hostile != _hostile)
 		hostile = _hostile
 		RegisterSignal(hostile, COMSIG_PARENT_QDELETING, .proc/unset_hostile)
 
 ///Setter for last_hostile with hard del in mind
-/obj/structure/resin/xeno_turret/proc/set_last_hostile(_last_hostile)
+/obj/structure/xeno/resin/xeno_turret/proc/set_last_hostile(_last_hostile)
 	if(last_hostile)
 		UnregisterSignal(last_hostile, COMSIG_PARENT_QDELETING)
 	last_hostile = _last_hostile
 
 ///Look for the closest human in range and in light of sight. If no human is in range, will look for xenos of other hives
-/obj/structure/resin/xeno_turret/proc/get_target()
+/obj/structure/xeno/resin/xeno_turret/proc/get_target()
 	var/distance = range + 0.5 //we add 0.5 so if a potential target is at range, it is accepted by the system
 	var/buffer_distance
 	var/list/turf/path = list()
@@ -428,7 +432,7 @@
 			. = nearby_hostile
 
 ///Return TRUE if a possible target is near
-/obj/structure/resin/xeno_turret/proc/scan()
+/obj/structure/xeno/resin/xeno_turret/proc/scan()
 	potential_hostiles.Cut()
 	for (var/mob/living/carbon/human/nearby_human AS in cheap_get_humans_near(src, TURRET_SCAN_RANGE))
 		if(nearby_human.stat == DEAD)
@@ -443,7 +447,7 @@
 
 
 ///Signal handler to make the turret shoot at its target
-/obj/structure/resin/xeno_turret/proc/shoot()
+/obj/structure/xeno/resin/xeno_turret/proc/shoot()
 	SIGNAL_HANDLER
 	if(!hostile)
 		SEND_SIGNAL(src, COMSIG_AUTOMATIC_SHOOTER_STOP_SHOOTING_AT)

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -140,7 +140,7 @@ if grep -ni '/obj/structure/mineral_door/resin' _maps/**/*.dmm; then
     echo "Do not directly add resin doors on maps, use landmarks."
     st=1
 fi;
-if grep -ni '/obj/structure/resin/xeno_turret' _maps/**/*.dmm; then
+if grep -ni '/obj/structure/xeno/resin/xeno_turret' _maps/**/*.dmm; then
     echo "Do not directly add xeno turrets on maps, use landmarks."
     st=1
 fi;


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Renames "/obj/structure/resin" typepath to "/obj/structure/xeno/resin" and adds xeno_structure_flags var in "/obj/structure/xeno". The flag is for bitflags I'm adding in #6979 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Adds a way to make general changes to xeno structures instead of having "xeno" and "resin" structures that don't come from the same place.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: changed xeno structures typepaths, adds xeno_structure_flags var
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
