### PR TITLE
Hugger Traps Can Now Explode

### DIFF
--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -135,6 +135,15 @@
 	RegisterSignal(src, COMSIG_MOVABLE_SHUTTLE_CRUSH, .proc/shuttle_crush)
 	RegisterSignal(src, COMSIG_MOVABLE_CROSSED_BY, .proc/trigger_hugger_trap) //Set up the trap signal on our turf
 
+/obj/structure/xeno/trap/ex_act(severity)
+	switch(severity)
+		if(EXPLODE_DEVASTATE)
+			take_damage(400)
+		if(EXPLODE_HEAVY)
+			take_damage(200)
+		if(EXPLODE_LIGHT)
+			take_damage(100)
+
 
 /obj/structure/xeno/trap/obj_destruction(damage_amount, damage_type, damage_flag)
 	if(damage_amount && hugger && loc)


### PR DESCRIPTION
## About The Pull Request

Hugger traps can now explode normally.

## Why It's Good For The Game

Hugger traps can now explode normally.

## Changelog
:cl:
fix: Hugger traps can now explode normally.
/:cl:
