### PR TITLE
Improves Crushers abilities a little, removes stam damage

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
@@ -40,9 +40,8 @@
 			step_away(M, X, 1) //Knock away
 			shake_camera(M, 2, 2)
 			to_chat(M, "<span class='highdanger'>You reel from the shockwave of [X]'s stomp!</span>")
+			M.take_overall_damage_armored(damage, BRUTE, "melee", FALSE, FALSE, TRUE) // give half damage brute instead of stamina
 			M.Paralyze(0.5 SECONDS)
-
-		M.apply_damage(damage, STAMINA, updating_health = TRUE) //Armour ignoring Stamina
 
 /datum/action/xeno_action/activable/stomp/ai_should_start_consider()
 	return TRUE
@@ -143,10 +142,9 @@
 
 	//Handle the damage
 	if(!X.issamexenohive(L)) //Friendly xenos don't take damage.
-		var/damage = toss_distance * 5
+		var/damage = toss_distance * 6
 
-		L.take_overall_damage_armored(damage, BRUTE, "melee")
-		L.apply_damage(damage, STAMINA, updating_health = TRUE) //...But decent armour ignoring Stamina
+		L.take_overall_damage_armored(damage, BRUTE, "melee", updating_health = TRUE)
 		shake_camera(L, 2, 2)
 		playsound(L,pick('sound/weapons/alien_claw_block.ogg','sound/weapons/alien_bite2.ogg'), 50, 1)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
@@ -24,7 +24,7 @@
 	"<span class='xenodanger'>We smash into the ground!</span>")
 	X.create_stomp() //Adds the visual effect. Wom wom wom
 
-	for(var/mob/living/M in range(0,X.loc))
+	for(var/mob/living/M in range(1,X.loc))
 		if(isxeno(M) || M.stat == DEAD || isnestedhost(M))
 			continue
 		var/distance = get_dist(M, X)
@@ -32,18 +32,16 @@
 		if(distance == 0) //If we're on top of our victim, give him the full impact
 			GLOB.round_statistics.crusher_stomp_victims++
 			SSblackbox.record_feedback("tally", "round_statistics", 1, "crusher_stomp_victims")
-			M.take_overall_damage_armored(damage, BRUTE, "melee", FALSE, FALSE)
-			M.Paralyze(20)
+			M.take_overall_damage_armored(damage, BRUTE, "melee", FALSE, FALSE, TRUE)
+			M.Paralyze(3 SECONDS)
 			to_chat(M, "<span class='highdanger'>You are stomped on by [X]!</span>")
 			shake_camera(M, 3, 3)
 		else
 			step_away(M, X, 1) //Knock away
 			shake_camera(M, 2, 2)
 			to_chat(M, "<span class='highdanger'>You reel from the shockwave of [X]'s stomp!</span>")
-		if(distance < 2) //If we're beside or adjacent to the Crusher, we get knocked down.
-			M.Paralyze(20)
-		else
-			M.Stun(20) //Otherwise we just get stunned.
+			M.Paralyze(0.5 SECONDS)
+
 		M.apply_damage(damage, STAMINA, updating_health = TRUE) //Armour ignoring Stamina
 
 /datum/action/xeno_action/activable/stomp/ai_should_start_consider()
@@ -66,8 +64,8 @@
 	action_icon_state = "cresttoss"
 	mechanics_text = "Fling an adjacent target over and behind you. Also works over barricades."
 	ability_name = "crest toss"
-	plasma_cost = 100
-	cooldown_timer = 18 SECONDS
+	plasma_cost = 60
+	cooldown_timer = 10 SECONDS
 	keybind_signal = COMSIG_XENOABILITY_CRESTTOSS
 	target_flags = XABB_MOB_TARGET
 
@@ -86,10 +84,6 @@
 	var/mob/living/L = A
 	if(L.stat == DEAD || isnestedhost(L)) //no bully
 		return FALSE
-	if(L.mob_size >= MOB_SIZE_BIG)
-		if(!silent)
-			to_chat(owner, "<span class='xenowarning'>[L] is too large to fling!</span>")
-		return FALSE
 
 /datum/action/xeno_action/activable/cresttoss/use_ability(atom/A)
 	var/mob/living/carbon/xenomorph/X = owner
@@ -100,6 +94,12 @@
 	var/toss_distance = X.xeno_caste.crest_toss_distance
 	var/turf/T = X.loc
 	var/turf/temp = X.loc
+	var/big_mob_message
+
+	if(L.mob_size >= MOB_SIZE_BIG) //Penalize toss distance for big creatures
+		toss_distance = FLOOR(toss_distance * 0.5, 1)
+		big_mob_message = ", struggling mightily to heft its bulk"
+
 	if(X.a_intent == INTENT_HARM) //If we use the ability on hurt intent, we throw them in front; otherwise we throw them behind.
 		for(var/x in 1 to toss_distance)
 			temp = get_step(T, facing)
@@ -134,8 +134,8 @@
 
 	X.icon_state = "Crusher Charging"  //Momentarily lower the crest for visual effect
 
-	X.visible_message("<span class='xenowarning'>\The [X] flings [L] away with its crest!</span>", \
-	"<span class='xenowarning'>We fling [L] away with our crest!</span>")
+	X.visible_message("<span class='xenowarning'>\The [X] flings [L] away with its crest[big_mob_message]!</span>", \
+	"<span class='xenowarning'>We fling [L] away with our crest[big_mob_message]!</span>")
 
 	succeed_activate()
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
@@ -25,7 +25,7 @@
 	X.create_stomp() //Adds the visual effect. Wom wom wom
 
 	for(var/mob/living/M in range(1,X.loc))
-		if(isxeno(M) || M.stat == DEAD || isnestedhost(M))
+		if(X.issamexenohive(M) || M.stat == DEAD || isnestedhost(M))
 			continue
 		var/distance = get_dist(M, X)
 		var/damage = X.xeno_caste.stomp_damage/max(1, distance + 1)

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
@@ -63,8 +63,8 @@
 	action_icon_state = "cresttoss"
 	mechanics_text = "Fling an adjacent target over and behind you. Also works over barricades."
 	ability_name = "crest toss"
-	plasma_cost = 60
-	cooldown_timer = 10 SECONDS
+	plasma_cost = 75
+	cooldown_timer = 12 SECONDS
 	keybind_signal = COMSIG_XENOABILITY_CRESTTOSS
 	target_flags = XABB_MOB_TARGET
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
@@ -24,7 +24,7 @@
 	"<span class='xenodanger'>We smash into the ground!</span>")
 	X.create_stomp() //Adds the visual effect. Wom wom wom
 
-	for(var/mob/living/M in range(1,X.loc))
+	for(var/mob/living/M in range(1, get_turf(X)))
 		if(X.issamexenohive(M) || M.stat == DEAD || isnestedhost(M))
 			continue
 		var/distance = get_dist(M, X)

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
@@ -12,7 +12,7 @@
 	keybind_signal = COMSIG_XENOABILITY_STOMP
 
 /datum/action/xeno_action/activable/stomp/use_ability(atom/A)
-	var/mob/living/carbon/xenomorph/crusher/X = owner
+	var/mob/living/carbon/xenomorph/X = owner
 	succeed_activate()
 	add_cooldown()
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
@@ -40,7 +40,7 @@
 			step_away(M, X, 1) //Knock away
 			shake_camera(M, 2, 2)
 			to_chat(M, "<span class='highdanger'>You reel from the shockwave of [X]'s stomp!</span>")
-			M.take_overall_damage_armored(damage, BRUTE, "melee", FALSE, FALSE, TRUE) // give half damage brute instead of stamina
+			M.take_overall_damage_armored(damage, BRUTE, "melee", FALSE, FALSE, TRUE) 
 			M.Paralyze(0.5 SECONDS)
 
 /datum/action/xeno_action/activable/stomp/ai_should_start_consider()

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -39,7 +39,7 @@
 
 	// *** Crusher Abilities *** //
 	stomp_damage = 45
-	crest_toss_distance = 4
+	crest_toss_distance = 3
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
@@ -83,6 +83,7 @@
 
 	// *** Abilities *** //
 	stomp_damage = 50
+	crest_toss_distance = 4
 
 /datum/xeno_caste/crusher/elder
 	upgrade_name = "Elder"
@@ -114,6 +115,7 @@
 
 	// *** Abilities *** //
 	stomp_damage = 55
+	crest_toss_distance = 5
 
 /datum/xeno_caste/crusher/ancient
 	upgrade_name = "Ancient"
@@ -144,3 +146,4 @@
 	soft_armor = list("melee" = 90, "bullet" = 75, "laser" = 75, "energy" = 75, "bomb" = XENO_BOMB_RESIST_3, "bio" = 100, "rad" = 100, "fire" = 75, "acid" = 100)
 	// *** Abilities *** //
 	stomp_damage = 60
+	crest_toss_distance = 6


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Buffs Crusher a little, see changelog. Feel free to suggest different numbers or argue why unga do not deserve this in the comments.

Fixes a missing `updating_health` arg.

Brings Crest Toss friendly fire mechanics in line with that of Warriors displacements.

Removes and/or converts Crest Toss and Stomp stam damage to brute.

Some Stomp discussion: https://discord.com/channels/498569646014857217/504094319075131402/848408671897124865

## Why It's Good For The Game

Brings stomp back from the desolation of overnerfdom. It should not be something you just quickly get up and run away from. It can actually be used for melee range brawls and escapes from chasing harvesters.

Why is crest toss such high cooldown and plasma cost anyway? It is supposed to counter cade huggers last I checked. The stam damage is on its way to useless, so having it available more often gives slow crusher more chances to use it for escape or saving allies.

TL;DR stam buffs will make most of this imperceptible anyway. Any extra throw distance or stun here is easily made up for with a little sprint, but hopefully crushers can have a little more fun dying to the 7 layer FOBurrito instead of a lone PAS flech shotgunner.

## Changelog
:cl:
fix: Fixed Crusher Stomp damage delay.
qol: Crusher Crest Toss now works on big allies with a penalty like Warrior Fling.
balance: Crusher Stomp briefly knocks down anyone adjacent to crusher for a half second. Victims directly under foot stun increased by one second.
balance: Crusher Crest Toss increases distance with age from 3 to 6 (still less than half max powerfist), and has less cooldown.
balance: Crest Toss and Stomp no longer deal stamina damage, only brute.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
