### PR TITLE
Adds the ability to override the default respawn timers via a config value

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -121,3 +121,13 @@
 ///If TRUE, the evo proc will consider spawn roony instead of runner on evo
 /datum/config_entry/flag/roony
 	config_entry_value = FALSE
+
+/datum/config_entry/number/marine_respawn
+	config_entry_value = 30 MINUTES
+	max_val = 30 MINUTES
+	min_val = 0
+
+/datum/config_entry/number/xeno_respawn
+	config_entry_value = 30 MINUTES
+	max_val = 30 MINUTES
+	min_val = 0

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -41,6 +41,9 @@ SUBSYSTEM_DEF(ticker)
 
 /datum/controller/subsystem/ticker/Initialize(timeofday)
 	load_mode()
+	
+	GLOB.respawntime = CONFIG_GET(number/marine_respawn)
+	GLOB.xenorespawntime = CONFIG_GET(number/xeno_respawn)
 
 	var/all_music = CONFIG_GET(keyed_list/lobby_music)
 	var/key = SAFEPICK(all_music)

--- a/config/config.txt
+++ b/config/config.txt
@@ -193,3 +193,7 @@ CHECK_RANDOMIZER
 
 ##Set this number to the maximum number of players you want, after which game mode votes cannot be started
 MAXIMUM_CLIENTS_FOR_GAMEMODE_VOTE 40
+
+## Uncomment these to set a custom respawn timer; the delay is in ticks.
+#MARINE_RESPAWN 18000
+#XENO_RESPAWN 1200


### PR DESCRIPTION
Adds config values to override the respawn timers for both marines and xenomorphs which are read on the Ticker's Initialize.

MARINE_RESPAWN and XENO_RESPAWN are now config values that you can set to override the default respawn timers.
Hard-coded values are bad and this lets the values be changed globally without needing to be manually changed ingame.

## Changelog
:cl:
server: Two new config values for overriding the respawn timers of both marines and xenomorphs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
