### PR TITLE
Kills shield vest combo

### DIFF
--- a/code/__DEFINES/cooldowns.dm
+++ b/code/__DEFINES/cooldowns.dm
@@ -39,6 +39,7 @@
 #define COOLDOWN_LOADOUT_EQUIPPED "cooldown_loadout_equipped"
 #define COOLDOWN_LOADOUT_VISUALIZATION "cooldown_loadout_visualization"
 #define COOLDOWN_TADPOLE_LAUNCHING "cooldown_tadpole_launching"
+#define COOLDOWN_BOMBVEST_SHIELD_DROP "cooldown_bombvest_shield_drop"
 
 //// COOLDOWN SYSTEMS
 /*

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -297,6 +297,7 @@
 #define COMSIG_MOB_UPDATE_SIGHT "mob_update_sight"				//from base of /mob/update_sight(): ()
 #define COMSIG_MOB_HUD_CREATED "mob_hud_created"				//from base of mob/create_mob_hud(): ()
 
+#define COMSIG_MOB_SHIELD_DROPPED "mob_shield_dropped"
 #define COMSIG_MOB_ITEM_ATTACK "mob_item_attack"				//from base of /obj/item/attack(): (mob/target, /obj/item/attacking_item)
 #define COMSIG_MOB_ITEM_ATTACK_ALTERNATE "mob_item_attack_alt"	//from base of /obj/item/attack_alternate(): (mob/target, /obj/item/attacking_item)
 	#define COMPONENT_ITEM_NO_ATTACK (1<<0)						//return this if you dont want attacka and altattacks to run

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -297,7 +297,7 @@
 #define COMSIG_MOB_UPDATE_SIGHT "mob_update_sight"				//from base of /mob/update_sight(): ()
 #define COMSIG_MOB_HUD_CREATED "mob_hud_created"				//from base of mob/create_mob_hud(): ()
 
-#define COMSIG_MOB_SHIELD_DROPPED "mob_shield_dropped"
+#define COMSIG_MOB_SHIELD_DETATCH "mob_shield_detatched"
 #define COMSIG_MOB_ITEM_ATTACK "mob_item_attack"				//from base of /obj/item/attack(): (mob/target, /obj/item/attacking_item)
 #define COMSIG_MOB_ITEM_ATTACK_ALTERNATE "mob_item_attack_alt"	//from base of /obj/item/attack_alternate(): (mob/target, /obj/item/attacking_item)
 	#define COMPONENT_ITEM_NO_ATTACK (1<<0)						//return this if you dont want attacka and altattacks to run

--- a/code/datums/components/shield.dm
+++ b/code/datums/components/shield.dm
@@ -143,6 +143,7 @@
 		human_user.add_movespeed_modifier(parent_item.type, TRUE, 0, ((parent_item.flags_item & IMPEDE_JETPACK) ? SLOWDOWN_IMPEDE_JETPACK : NONE), TRUE, parent_item.slowdown)
 /datum/component/shield/proc/shield_dropped(datum/source, mob/user)
 	SIGNAL_HANDLER
+	SEND_SIGNAL(user, COMSIG_MOB_SHIELD_DROPPED)
 	shield_detatch_from_user()
 
 	var/obj/item/parent_item = parent //Apply in-hand slowdowns.

--- a/code/datums/components/shield.dm
+++ b/code/datums/components/shield.dm
@@ -143,7 +143,6 @@
 		human_user.add_movespeed_modifier(parent_item.type, TRUE, 0, ((parent_item.flags_item & IMPEDE_JETPACK) ? SLOWDOWN_IMPEDE_JETPACK : NONE), TRUE, parent_item.slowdown)
 /datum/component/shield/proc/shield_dropped(datum/source, mob/user)
 	SIGNAL_HANDLER
-	SEND_SIGNAL(user, COMSIG_MOB_SHIELD_DROPPED)
 	shield_detatch_from_user()
 
 	var/obj/item/parent_item = parent //Apply in-hand slowdowns.
@@ -171,6 +170,7 @@
 /datum/component/shield/proc/shield_detatch_from_user()
 	if(!affected)
 		return
+	SEND_SIGNAL(affected, COMSIG_MOB_SHIELD_DETATCH)
 	deactivate_with_user()
 	affected = null
 

--- a/code/game/objects/items/explosives/bombvest.dm
+++ b/code/game/objects/items/explosives/bombvest.dm
@@ -8,10 +8,6 @@
 	var/bomb_message
 	///List of warcries that are not allowed.
 	var/bad_warcries_regex = "allahu ackbar|allah|ackbar"
-	///How long must be waited after a shiled drop for detonation
-	var/shield_wait_time = 5 SECONDS
-	///Time a shiled was last dropped
-	var/shield_dropped_last = 0
 
 /obj/item/clothing/suit/storage/marine/harness/boomvest/equipped(mob/user, slot)
 	. = ..()
@@ -24,7 +20,7 @@
 ///Updates the last shield drop time when one is dropped
 /obj/item/clothing/suit/storage/marine/harness/boomvest/proc/shield_dropped()
 	SIGNAL_HANDLER
-	shield_dropped_last = world.time
+	TIMER_COOLDOWN_START(src, COOLDOWN_BOMBVEST_SHIELD_DROP, 5 SECONDS)
 
 ///Overwrites the parent function for activating a light. Instead it now detonates the bomb.
 /obj/item/clothing/suit/storage/marine/harness/boomvest/attack_self(mob/user)
@@ -38,7 +34,7 @@
 	if(istype(activator.l_hand, /obj/item/weapon/shield/riot) || istype(activator.r_hand, /obj/item/weapon/shield/riot) || istype(activator.back, /obj/item/weapon/shield/riot))
 		to_chat(activator, "<span class='warning'>Your bulky shield prevents you from reaching the detonator!</span>")
 		return FALSE
-	if(shield_dropped_last + shield_wait_time > world.time)
+	if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_BOMBVEST_SHIELD_DROP))
 		to_chat(activator, "<span class='warning'>You dropped a shield too recently to detonate, wait a few seconds!</span>")
 		return FALSE
 	if(!do_after(user, 3, TRUE, src, BUSY_ICON_DANGER, ignore_turf_checks = TRUE))

--- a/code/game/objects/items/explosives/bombvest.dm
+++ b/code/game/objects/items/explosives/bombvest.dm
@@ -9,6 +9,15 @@
 	///List of warcries that are not allowed.
 	var/bad_warcries_regex = "allahu ackbar|allah|ackbar"
 
+/obj/item/clothing/suit/storage/marine/harness/boomvest/mob_can_equip(mob/M, slot, warning = TRUE, override_nodrop = FALSE)
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(istype(H.get_inactive_held_item(), /obj/item/weapon/shield/riot) || istype(H.back, /obj/item/weapon/shield/riot))
+			if(warning)
+				to_chat(H, "<span class='warning'>Your bulky shield prevents you from putting that on.</span>")
+			return FALSE
+	return ..()
+
 ///Overwrites the parent function for activating a light. Instead it now detonates the bomb.
 /obj/item/clothing/suit/storage/marine/harness/boomvest/attack_self(mob/user)
 	var/mob/living/carbon/human/activator = user

--- a/code/game/objects/items/explosives/bombvest.dm
+++ b/code/game/objects/items/explosives/bombvest.dm
@@ -11,11 +11,11 @@
 
 /obj/item/clothing/suit/storage/marine/harness/boomvest/equipped(mob/user, slot)
 	. = ..()
-	RegisterSignal(user, COMSIG_MOB_SHIELD_DROPPED, .proc/shield_dropped)
+	RegisterSignal(user, COMSIG_MOB_SHIELD_DETATCH, .proc/shield_dropped)
 
 /obj/item/clothing/suit/storage/marine/harness/boomvest/unequipped(mob/unequipper, slot)
 	. = ..()
-	UnregisterSignal(unequipper, COMSIG_MOB_SHIELD_DROPPED)
+	UnregisterSignal(unequipper, COMSIG_MOB_SHIELD_DETATCH)
 
 ///Updates the last shield drop time when one is dropped
 /obj/item/clothing/suit/storage/marine/harness/boomvest/proc/shield_dropped()

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -29,6 +29,7 @@
 	destroy_sound = 'sound/effects/glassbr3.ogg'
 	var/cooldown = 0 //shield bash cooldown. based on world.time
 
+
 /obj/item/weapon/shield/riot/examine(mob/user, distance, infix, suffix)
 	. = ..()
 	var/health_status = (obj_integrity * 100) / max_integrity

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -33,7 +33,7 @@
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		if(istype(H.wear_suit, /obj/item/clothing/suit/storage/marine/harness/boomvest))
-			to_chat(user, "<span class='warning'>You think better about trying to block your own vest explosion and leave the shiled alone.</span>")
+			to_chat(user, "<span class='warning'>You think better about trying to block your own vest explosion and leave the shield alone.</span>")
 			return
 	return ..()
 

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -29,14 +29,6 @@
 	destroy_sound = 'sound/effects/glassbr3.ogg'
 	var/cooldown = 0 //shield bash cooldown. based on world.time
 
-/obj/item/weapon/shield/riot/attack_hand(mob/living/user)
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(istype(H.wear_suit, /obj/item/clothing/suit/storage/marine/harness/boomvest))
-			to_chat(user, "<span class='warning'>You think better about trying to block your own vest explosion and leave the shield alone.</span>")
-			return
-	return ..()
-
 /obj/item/weapon/shield/riot/examine(mob/user, distance, infix, suffix)
 	. = ..()
 	var/health_status = (obj_integrity * 100) / max_integrity

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -29,6 +29,13 @@
 	destroy_sound = 'sound/effects/glassbr3.ogg'
 	var/cooldown = 0 //shield bash cooldown. based on world.time
 
+/obj/item/weapon/shield/riot/attack_hand(mob/living/user)
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(istype(H.wear_suit, /obj/item/clothing/suit/storage/marine/harness/boomvest))
+			to_chat(user, "<span class='warning'>You think better about trying to block your own vest explosion and leave the shiled alone.</span>")
+			return
+	return ..()
 
 /obj/item/weapon/shield/riot/examine(mob/user, distance, infix, suffix)
 	. = ..()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds checks that *should* prevent anyone from using this silly combo.

## Why It's Good For The Game

It's either this, or deletion. Look on the bright side the sprite is still mostly visible from just one face.

Shield + vest is extra bad for 2 reasons:

1. Blocks the one face of the vest sprite that is easy to see.
2. Adds armor to a build that is supposed to be the definition of a glass cannon.

## Changelog
:cl:
balance: Shield now stops the bomb vest from exploding when equipped and up to 5 seconds after drop.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
