### PR TITLE
Fixes martini belts giving you a fixme sprite when you pull out the last round from a stack

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -495,7 +495,7 @@
 	if(!draw_mode || !ishuman(user) && !contents.len)
 		open(user)
 
-	if(!contents.len)
+	if(!length(contents))
 		return
 
 	var/obj/item/I = contents[contents.len]

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -495,11 +495,19 @@
 	if(!draw_mode || !ishuman(user) && !contents.len)
 		open(user)
 
+	if(!contents.len)
+		return
+
 	var/obj/item/I = contents[contents.len]
 	if(!istype(I, /obj/item/ammo_magazine/handful))
 		return
 
 	var/obj/item/ammo_magazine/handful/existing_handful = I
+
+	if(existing_handful.current_rounds == 1)
+		user.put_in_hands(existing_handful)
+		return
+
 	existing_handful.create_handful(user, 1)
 	update_icon()
 


### PR DESCRIPTION
## About The Pull Request

Does what the title says.
Also verifies there's actually something in the martini belt before attempting to access it because runtimes.

## Why It's Good For The Game

Bug fix good.

## Changelog
:cl:
fix: Martini Belts can no longer give you invalid 'fixme' items
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

Fixes https://github.com/tgstation/TerraGov-Marine-Corps/issues/6949
