### PR TITLE
Fixes the Martini Henry ammo belt.

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -501,6 +501,8 @@
 
 	var/obj/item/ammo_magazine/handful/existing_handful = I
 	existing_handful.create_handful(user, 1)
+	if(existing_handful.current_rounds <= 0)
+		qdel(existing_handful)
 	update_icon()
 
 


### PR DESCRIPTION
## About The Pull Request

Fixes the empty handful that is created by the Martini Henry ammo belt
fixes:
https://github.com/tgstation/TerraGov-Marine-Corps/issues/6949

## Why It's Good For The Game
Fix

## Changelog
:cl:
fix: Fixes the Martini Henry ammo belt.
/:cl:
