### PR TITLE
Fixes varedit marking

### DIFF
--- a/code/modules/admin/verbs/datumvars.dm
+++ b/code/modules/admin/verbs/datumvars.dm
@@ -617,18 +617,14 @@
 		src.debug_variables(DAT)
 
 
-	else if(href_list["mark_object"])
+	else if(href_list[VV_HK_MARK])
 		if(!check_rights(R_DEBUG))
 			return
 
-		var/datum/D = locate(href_list["mark_object"])
+		var/datum/D = locate(href_list[VV_HK_MARK])
 		if(!istype(D))
 			return
-
-		if(holder.marked_datum)
-			vv_update_display(holder.marked_datum, "marked", "")
-		holder.marked_datum = D
-		vv_update_display(D, "marked", VV_MSG_MARKED)
+		mark_datum(D)
 
 
 	else if(href_list["proc_call"])

--- a/code/modules/admin/view_variables/mark_datum.dm
+++ b/code/modules/admin/view_variables/mark_datum.dm
@@ -1,0 +1,19 @@
+/client/proc/mark_datum(datum/D)
+	if(!holder)
+		return
+	if(holder.marked_datum)
+		holder.UnregisterSignal(holder.marked_datum, COMSIG_PARENT_QDELETING)
+		vv_update_display(holder.marked_datum, "marked", "")
+	holder.marked_datum = D
+	holder.RegisterSignal(holder.marked_datum, COMSIG_PARENT_QDELETING, /datum/admins/proc/handle_marked_del)
+	vv_update_display(D, "marked", VV_MSG_MARKED)
+
+/client/proc/mark_datum_mapview(datum/D as mob|obj|turf|area in view(view))
+	set category = "Debug"
+	set name = "Mark Object"
+	mark_datum(D)
+
+/datum/admins/proc/handle_marked_del(datum/source)
+	SIGNAL_HANDLER
+	UnregisterSignal(marked_datum, COMSIG_PARENT_QDELETING)
+	marked_datum = null

--- a/code/modules/admin/view_variables/mark_datum.dm
+++ b/code/modules/admin/view_variables/mark_datum.dm
@@ -1,3 +1,11 @@
+/**
+ * # `mark_datum(datum/D)`
+ * This proc marks a datum for the holder of this client, by setting the holder's marked_datum var.
+ * If the holder already had a marked datum, unmarks said datum beforehand.
+ * The client obviously must have a holder for this to work.
+ * * Arg: The datum to mark.
+ * * Has no return value.
+*/
 /client/proc/mark_datum(datum/D)
 	if(!holder)
 		return

--- a/code/modules/admin/view_variables/mark_datum.dm
+++ b/code/modules/admin/view_variables/mark_datum.dm
@@ -2,18 +2,6 @@
 	if(!holder)
 		return
 	if(holder.marked_datum)
-		holder.UnregisterSignal(holder.marked_datum, COMSIG_PARENT_QDELETING)
 		vv_update_display(holder.marked_datum, "marked", "")
 	holder.marked_datum = D
-	holder.RegisterSignal(holder.marked_datum, COMSIG_PARENT_QDELETING, /datum/admins/proc/handle_marked_del)
 	vv_update_display(D, "marked", VV_MSG_MARKED)
-
-/client/proc/mark_datum_mapview(datum/D as mob|obj|turf|area in view(view))
-	set category = "Debug"
-	set name = "Mark Object"
-	mark_datum(D)
-
-/datum/admins/proc/handle_marked_del(datum/source)
-	SIGNAL_HANDLER
-	UnregisterSignal(marked_datum, COMSIG_PARENT_QDELETING)
-	marked_datum = null

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -981,6 +981,7 @@
 #include "code\modules\admin\verbs\whitelist.dm"
 #include "code\modules\admin\view_variables\filterrific.dm"
 #include "code\modules\admin\view_variables\greyscale_modify_menu.dm"
+#include "code\modules\admin\view_variables\mark_datum.dm"
 #include "code\modules\admin\view_variables\reference_tracking.dm"
 #include "code\modules\ai\effect_node.dm"
 #include "code\modules\ai\ai_behaviors\ai_behavior.dm"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I was testing stuff on local and wanted to proccall something with a marked thing, but mark no work. This annoyed me enough to fix it, so, here we go.
Also moves marking into its own file as a proc so it can be used in the future if someone bothers porting other vv stuff.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Admins being able to mark stuff is pretty neat.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Admins can now actually mark things via the varedit dropdown.
code: Moved marking into its own file as a proc for easier access in the future.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
