### PR TITLE
Rebalance Snub-nosed Revolvers

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -264,7 +264,7 @@
 #define COMSIG_GUN_AUTOFIREDELAY_MODIFIED "gun_firedelay_modified"
 #define COMSIG_GUN_BURST_SHOTS_TO_FIRE_MODIFIED "gun_burstamount_modified"
 #define COMSIG_GUN_BURST_SHOT_DELAY_MODIFIED "gun_burstdelay_modified"
-#define COMSIG_GUN_HAS_STAGGER_BARREL "gun_has_stagger_barrel"
+#define COMSIG_REVOLVER_AMMO_HIT_MOB "gun_revolver_ammo_hit"
 
 // /obj/item/clothing signals
 #define COMSIG_SHOES_STEP_ACTION "shoes_step_action"			//from base of obj/item/clothing/shoes/proc/step_action(): ()

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -264,6 +264,7 @@
 #define COMSIG_GUN_AUTOFIREDELAY_MODIFIED "gun_firedelay_modified"
 #define COMSIG_GUN_BURST_SHOTS_TO_FIRE_MODIFIED "gun_burstamount_modified"
 #define COMSIG_GUN_BURST_SHOT_DELAY_MODIFIED "gun_burstdelay_modified"
+#define COMSIG_GUN_HAS_STAGGER_BARREL "gun_has_stagger_barrel"
 
 // /obj/item/clothing signals
 #define COMSIG_SHOES_STEP_ACTION "shoes_step_action"			//from base of obj/item/clothing/shoes/proc/step_action(): ()

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -332,7 +332,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	sundering = 3
 
 /datum/ammo/bullet/revolver/on_hit_mob(mob/M,obj/projectile/P)
-	if(SEND_SIGNAL(P.shot_from, COMSIG_GUN_HAS_STAGGER_BARREL))
+	if(SEND_SIGNAL(P.shot_from, COMSIG_REVOLVER_AMMO_HIT_MOB))
 		staggerstun(M, P, stagger = 1, slowdown = 0.5, knockback = 1)
 	else
 		staggerstun(M, P, slowdown = 0.5)

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -332,13 +332,10 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	sundering = 3
 
 /datum/ammo/bullet/revolver/on_hit_mob(mob/M,obj/projectile/P)
-	var/obj/item/weapon/gun/shot_from = P.shot_from
-	var/stagger_knock = 0 // snub the snubnose stagger
-	if(!shot_from.attachable_allowed?.Find(/obj/item/attachable/standard_revolver_longbarrel))
-		stagger_knock = 1 // revolvers without the attachment always can :/
-	if(shot_from.attachments?.Find(ATTACHMENT_BARREL_MOD))
-		stagger_knock = 1
-	staggerstun(M, P, stagger = stagger_knock, slowdown = 0.5, knockback = stagger_knock)
+	if(SEND_SIGNAL(P.shot_from, COMSIG_GUN_HAS_STAGGER_BARREL))
+		staggerstun(M, P, stagger = 1, slowdown = 0.5, knockback = 1)
+	else
+		staggerstun(M, P, slowdown = 0.5)
 
 /datum/ammo/bullet/revolver/small
 	name = "small revolver bullet"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -332,7 +332,11 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	sundering = 3
 
 /datum/ammo/bullet/revolver/on_hit_mob(mob/M,obj/projectile/P)
-	staggerstun(M, P, stagger = 1, slowdown = 0.5, knockback = 1, shake = 0.5)
+	var/obj/item/weapon/gun/shot_from = P.shot_from
+	var/stagger_knock = 0 // snub the snubnose stagger
+	if(shot_from.attachments?.Find(ATTACHMENT_BARREL_MOD))
+		stagger_knock = 1
+	staggerstun(M, P, stagger = stagger_knock, slowdown = 0.5, knockback = stagger_knock, shake = 0.5)
 
 /datum/ammo/bullet/revolver/small
 	name = "small revolver bullet"
@@ -357,9 +361,6 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	penetration = 5
 	accuracy = -15
 
-/datum/ammo/bullet/revolver/heavy/on_hit_mob(mob/M,obj/projectile/P)
-	staggerstun(M, P, stagger = 1, slowdown = 0.5, knockback = 1)
-
 /datum/ammo/bullet/revolver/highimpact
 	name = "high-impact revolver bullet"
 	hud_state = "revolver_impact"
@@ -369,7 +370,11 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	sundering = 3
 
 /datum/ammo/bullet/revolver/highimpact/on_hit_mob(mob/M,obj/projectile/P)
-	staggerstun(M, P, weaken = 1, stagger = 1, slowdown = 1, knockback = 1)
+	var/obj/item/weapon/gun/shot_from = P.shot_from
+	var/stagger_knock = 0
+	if(shot_from.attachments?.Find(ATTACHMENT_BARREL_MOD))
+		stagger_knock = 1
+	staggerstun(M, P, weaken = 1, stagger = stagger_knock, slowdown = 1, knockback = stagger_knock)
 
 
 /datum/ammo/bullet/revolver/ricochet

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -334,6 +334,8 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 /datum/ammo/bullet/revolver/on_hit_mob(mob/M,obj/projectile/P)
 	var/obj/item/weapon/gun/shot_from = P.shot_from
 	var/stagger_knock = 0 // snub the snubnose stagger
+	if(!shot_from.attachable_allowed?.Find(/obj/item/attachable/standard_revolver_longbarrel))
+		stagger_knock = 1 // revolvers without the attachment always can :/
 	if(shot_from.attachments?.Find(ATTACHMENT_BARREL_MOD))
 		stagger_knock = 1
 	staggerstun(M, P, stagger = stagger_knock, slowdown = 0.5, knockback = stagger_knock)

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -336,7 +336,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	var/stagger_knock = 0 // snub the snubnose stagger
 	if(shot_from.attachments?.Find(ATTACHMENT_BARREL_MOD))
 		stagger_knock = 1
-	staggerstun(M, P, stagger = stagger_knock, slowdown = 0.5, knockback = stagger_knock, shake = 0.5)
+	staggerstun(M, P, stagger = stagger_knock, slowdown = 0.5, knockback = stagger_knock)
 
 /datum/ammo/bullet/revolver/small
 	name = "small revolver bullet"
@@ -370,11 +370,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	sundering = 3
 
 /datum/ammo/bullet/revolver/highimpact/on_hit_mob(mob/M,obj/projectile/P)
-	var/obj/item/weapon/gun/shot_from = P.shot_from
-	var/stagger_knock = 0
-	if(shot_from.attachments?.Find(ATTACHMENT_BARREL_MOD))
-		stagger_knock = 1
-	staggerstun(M, P, weaken = 1, stagger = stagger_knock, slowdown = 1, knockback = stagger_knock)
+	staggerstun(M, P, weaken = 1, stagger = 1, slowdown = 1, knockback = 1, shake = 0.5)
 
 
 /datum/ammo/bullet/revolver/ricochet

--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -36,7 +36,7 @@
 /obj/item/weapon/gun/revolver/Initialize()
 	. = ..()
 	replace_cylinder(current_mag.current_rounds)
-	RegisterSignal(src, COMSIG_GUN_HAS_STAGGER_BARREL, .proc/has_stagger_barrel)
+	RegisterSignal(src, COMSIG_REVOLVER_AMMO_HIT_MOB, .proc/has_stagger_barrel)
 
 /obj/item/weapon/gun/revolver/proc/has_stagger_barrel()
 	SIGNAL_HANDLER

--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -36,7 +36,12 @@
 /obj/item/weapon/gun/revolver/Initialize()
 	. = ..()
 	replace_cylinder(current_mag.current_rounds)
+	RegisterSignal(src, COMSIG_GUN_HAS_STAGGER_BARREL, .proc/has_stagger_barrel)
 
+/obj/item/weapon/gun/revolver/proc/has_stagger_barrel()
+	SIGNAL_HANDLER
+	if(!attachable_allowed?.Find(/obj/item/attachable/standard_revolver_longbarrel) || attachments?.Find(ATTACHMENT_BARREL_MOD))
+		return TRUE // has barrel or is a revolver without the option
 
 /obj/item/weapon/gun/revolver/examine_ammo_count(mob/user)
 	if(!current_mag)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes regular revolver ammo only stagger and knockback if fired via a long barrel. Moves shake to Mateba which it did not have before.

Call it a reactionary kneejerk salt PR all you want, but the ocelot gimmick is getting real aggravating to fight despite the new downsides of backpack revolvers with the stamina buffs.

## Why It's Good For The Game

2 revolver hits = 1 slug of stagger but you can fire 3.5 slugs worth and just keep dropping and pulling out more "slug shooters" making it strictly better than a shotgun for stagger, knockback, slow, and shake effects.

Stagger is a literal meme so much so Queen is snowflake immune:
```dm
var/stagger_immune = FALSE
if(isxeno(carbon_victim))
	var/mob/living/carbon/xenomorph/xeno_victim = victim
	if(isxenoqueen(xeno_victim)) //Stagger too powerful vs the Queen, so she's immune.
		stagger_immune = TRUE
```
..and it silences abilities until a periodic Life() tick comes along and decays your stagger stacks that revolver fire hoses onto you back down to 0.

This is not fun to prep or face:
![image](https://user-images.githubusercontent.com/64715958/120401727-6ad43400-c2f5-11eb-863c-a8f1c94cf3af.png)

Why are we letting a *sidearm* be so viable as a main weapon that effectively never needs to be reloaded?

Shorter barrel = less energy imparted on fired rounds, and should equal less impact on the target(s) too.

## Changelog
:cl:
balance: Snub-nosed TP-44 Revolvers no longer apply stagger or knockback to targets. Moves shake to Mateba which it did not have before.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
