### PR TITLE
Fix say.dm index out of bounds

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -245,9 +245,9 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 
 /mob/living/proc/get_key(message)
-	var/key = message[1]
-	if(key in GLOB.department_radio_prefixes)
-		return lowertext(message[1 + length(key)])
+	var/prefix = message[1]
+	if(length(message) >= 2 && (prefix in GLOB.department_radio_prefixes))
+		return lowertext(message[2])
 
 /mob/living/proc/get_message_language(message)
 	if(length(message) >= 2 && message[1] == ",")


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a runtime caused by saying just "." or ":" trying to access the next non-existent character in the message for a department key.

## Why It's Good For The Game

Fix good.

## Changelog
:cl:
fix: Say verb get_key() no longer runtimes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
