### PR TITLE
Tadpole loses shutters

### DIFF
--- a/_maps/shuttles/minidropship.dmm
+++ b/_maps/shuttles/minidropship.dmm
@@ -20,11 +20,6 @@
 	},
 /area/shuttle/minidropship)
 "j" = (
-/obj/machinery/door_control{
-	id = "minidropship_podlock";
-	name = "outer door-control";
-	pixel_y = 32
-	},
 /turf/open/floor/mainship/orange{
 	dir = 5
 	},
@@ -54,13 +49,18 @@
 /obj/machinery/door/poddoor/shutters/transit{
 	dir = 2
 	},
-/obj/machinery/door/poddoor/mainship/open{
-	dir = 2;
-	id = "minidropship_podlock"
-	},
 /obj/structure/barricade/plasteel,
 /turf/open/floor/mainship/orange{
 	dir = 10
+	},
+/area/shuttle/minidropship)
+"w" = (
+/obj/machinery/door/poddoor/shutters/transit,
+/obj/structure/barricade/plasteel{
+	dir = 8
+	},
+/turf/open/floor/mainship/orange{
+	dir = 4
 	},
 /area/shuttle/minidropship)
 "B" = (
@@ -100,19 +100,12 @@
 /obj/machinery/door/poddoor/shutters/transit{
 	dir = 2
 	},
-/obj/machinery/door/poddoor/mainship/open{
-	dir = 2;
-	id = "minidropship_podlock"
-	},
 /obj/structure/barricade/plasteel,
 /turf/open/floor/mainship/orange,
 /area/shuttle/minidropship)
 "O" = (
 /obj/structure/barricade/plasteel{
 	dir = 8
-	},
-/obj/machinery/door/poddoor/mainship/open{
-	id = "minidropship_podlock"
 	},
 /obj/machinery/door/poddoor/shutters/transit,
 /turf/open/floor/mainship/orange{
@@ -122,10 +115,6 @@
 "R" = (
 /obj/machinery/door/poddoor/shutters/transit{
 	dir = 2
-	},
-/obj/machinery/door/poddoor/mainship/open{
-	dir = 2;
-	id = "minidropship_podlock"
 	},
 /obj/structure/barricade/plasteel,
 /turf/open/floor/mainship/orange{
@@ -141,9 +130,6 @@
 "T" = (
 /obj/structure/barricade/plasteel{
 	dir = 4
-	},
-/obj/machinery/door/poddoor/mainship/open{
-	id = "minidropship_podlock"
 	},
 /obj/machinery/door/poddoor/shutters/transit,
 /turf/open/floor/mainship/orange{
@@ -181,7 +167,7 @@ E
 E
 b
 O
-O
+w
 B
 L
 E


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

No longer any shutters in tadpole

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Shutters in general only serve as a xeno noob trap. It requires no skill, you just need a green xeno against you to make a kill.
This is especially true with the new tadpole, where you can pretty consistently make lame strat with it, and just wait for number xeno to die on you

## Changelog
:cl:
del: Tadpole loses shutters
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
