### PR TITLE
Getting up as a xeno takes 1 sec

### DIFF
--- a/code/modules/mob/living/living_verbs.dm
+++ b/code/modules/mob/living/living_verbs.dm
@@ -22,7 +22,7 @@
 	else if(do_actions)
 		to_chat(src, "<span class='warning'>You are still in the process of standing up.</span>")
 		return
-	else if(do_mob(src, src, 5, ignore_flags = (IGNORE_LOC_CHANGE|IGNORE_HAND)))
+	else if(do_mob(src, src, 1 SECONDS, ignore_flags = (IGNORE_LOC_CHANGE|IGNORE_HAND)))
 		get_up()
 
 /mob/living/proc/get_up()

--- a/code/modules/mob/living/living_verbs.dm
+++ b/code/modules/mob/living/living_verbs.dm
@@ -22,7 +22,7 @@
 	else if(do_actions)
 		to_chat(src, "<span class='warning'>You are still in the process of standing up.</span>")
 		return
-	else if(do_mob(src, src, 2 SECONDS, ignore_flags = (IGNORE_LOC_CHANGE|IGNORE_HAND)))
+	else if(do_mob(src, src, 5, ignore_flags = (IGNORE_LOC_CHANGE|IGNORE_HAND)))
 		get_up()
 
 /mob/living/proc/get_up()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title. It is 2 sec currently

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

You can't do anything against a marine running towards you. You see the light, you hit rest keybind, too bad, you're dead. Completly unfair

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Getting up as a xeno takes 1 sec rather than 2
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
