### PR TITLE
Balance plasma pistol

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1509,7 +1509,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	icon_state = "overchargedlaser"
 	hud_state = "laser_sniper"
 	damage = 40
-	max_range = 40
+	max_range = 7
 	penetration = 5
 	shell_speed = 1.5
 	flags_ammo_behavior = AMMO_ENERGY|AMMO_INCENDIARY|AMMO_EXPLOSIVE

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -98,7 +98,6 @@
 		/obj/item/attachable/lasersight,
 		/obj/item/attachable/gyro,
 		/obj/item/attachable/lace,
-		/obj/item/attachable/scope/marine,
 	)
 
 	muzzleflash_iconstate = "muzzle_flash_laser"

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -85,7 +85,7 @@
 	icon_state = "tx7"
 	item_state = "tx7"
 	caliber = CALIBER_PLASMA
-	max_shots = 10
+	max_shots = 3
 	reload_sound = 'sound/weapons/guns/interact/tp14_reload.ogg'
 	fire_sound = 'sound/weapons/guns/fire/laser3.ogg'
 	current_mag = /obj/item/ammo_magazine/pistol/plasma_pistol

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -85,7 +85,7 @@
 	icon_state = "tx7"
 	item_state = "tx7"
 	caliber = CALIBER_PLASMA
-	max_shots = 3
+	max_shots = 10
 	reload_sound = 'sound/weapons/guns/interact/tp14_reload.ogg'
 	fire_sound = 'sound/weapons/guns/fire/laser3.ogg'
 	current_mag = /obj/item/ammo_magazine/pistol/plasma_pistol

--- a/code/modules/projectiles/magazines/pistols.dm
+++ b/code/modules/projectiles/magazines/pistols.dm
@@ -30,7 +30,7 @@
 	desc = "An energy cell for the TX-7 plasma pistol."
 	caliber = CALIBER_PLASMA
 	icon_state = "tx7"
-	max_rounds = 10
+	max_rounds = 3
 	w_class = WEIGHT_CLASS_SMALL
 	default_ammo = /datum/ammo/energy/plasma_pistol
 	gun_type = /obj/item/weapon/gun/pistol/plasma_pistol

--- a/code/modules/projectiles/magazines/pistols.dm
+++ b/code/modules/projectiles/magazines/pistols.dm
@@ -30,7 +30,7 @@
 	desc = "An energy cell for the TX-7 plasma pistol."
 	caliber = CALIBER_PLASMA
 	icon_state = "tx7"
-	max_rounds = 3
+	max_rounds = 10
 	w_class = WEIGHT_CLASS_SMALL
 	default_ammo = /datum/ammo/energy/plasma_pistol
 	gun_type = /obj/item/weapon/gun/pistol/plasma_pistol


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes scope attachment slot and reduces ammo max range.


## Why It's Good For The Game

No other *normal* pistol in the game allows you to attach full blown scopes to it. How did this even get past review? I heard it was a shitpost speedmerge.

Gun should be more specialized and situational, not the perfect tool for long range flame area denial. Flamer and miniflamer do exist, and this is only a *sidearm*.

Actually balance this uber utility weapon. Make people happy.

## Changelog
:cl:
balance: Plasma pistol no longer accepts scope attachments.
balance: Plasma pistol now has 7 range, not 40.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
