### PR TITLE
Corpses spawned in silo in hunt fix

### DIFF
--- a/code/game/objects/effects/landmarks/corpsespawner.dm
+++ b/code/game/objects/effects/landmarks/corpsespawner.dm
@@ -55,6 +55,9 @@
 			victim.internal_organs_by_name -= "brain"
 			victim.internal_organs -= brain
 			victim.headbitten = TRUE
+			victim.chestburst = 2
+			victim.update_burst()
+			victim.update_headbite()
 			if(length(GLOB.xeno_resin_silos))
 				victim.loc = pick(GLOB.xeno_resin_silos)
 		if(HEADBITE_DEATH) //Headbite but left there
@@ -63,6 +66,7 @@
 			victim.internal_organs_by_name -= "brain"
 			victim.internal_organs -= brain
 			victim.headbitten = TRUE
+			victim.update_headbite()
 	qdel(src)
 			
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Forgot to update their burst flag, so a destroyed silo left out some bodies that could be siloed again

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Corpses spawned in silo in hunt cannot be siloed again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
