### PR TITLE
Taking guns out of bags now has a delay

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -186,7 +186,7 @@
 	var/remove_successful = TRUE
 	if(istype(loc, /obj/item/storage))
 		var/obj/item/storage/S = loc
-		remove_successful = S.remove_from_storage(src, user.loc)
+		remove_successful = S.remove_from_storage(src, user.loc, user)
 
 	set_throwing(FALSE)
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -183,9 +183,10 @@
 		to_chat(user, "[src] is anchored to the ground.")
 		return
 
+	var/remove_successful = TRUE
 	if(istype(loc, /obj/item/storage))
 		var/obj/item/storage/S = loc
-		S.remove_from_storage(src, user.loc)
+		remove_successful = S.remove_from_storage(src, user.loc)
 
 	set_throwing(FALSE)
 
@@ -196,7 +197,7 @@
 		return
 
 	pickup(user)
-	if(!user.put_in_active_hand(src))
+	if(!user.put_in_active_hand(src) || !remove_successful)
 		user.dropItemToGround(src)
 		dropped(user)
 

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -213,7 +213,7 @@
 	update_icon()
 
 // Instead of removing
-/obj/item/storage/bag/sheetsnatcher/remove_from_storage(obj/item/W as obj, atom/new_location)
+/obj/item/storage/bag/sheetsnatcher/remove_from_storage(obj/item/W as obj, atom/new_location, mob/user)
 	var/obj/item/stack/sheet/S = W
 	if(!istype(S)) return 0
 
@@ -227,7 +227,7 @@
 		temp.amount = S.amount - S.max_amount
 		S.amount = S.max_amount
 
-	return ..(S,new_location)
+	return ..(S,new_location,user)
 
 // -----------------------------
 //    Sheet Snatcher (Cyborg)

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -11,6 +11,7 @@
 	attack_verb = list("whipped", "lashed", "disciplined")
 	w_class = WEIGHT_CLASS_BULKY
 	allow_drawing_method = TRUE
+	fumble_guns = FALSE
 
 
 

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -31,7 +31,7 @@
 /obj/item/storage/fancy/update_icon_state()
 	icon_state = "[icon_type]box[length(contents)]"
 
-/obj/item/storage/fancy/remove_from_storage(obj/item/W, atom/new_location)
+/obj/item/storage/fancy/remove_from_storage(obj/item/W, atom/new_location, mob/user)
 	. = ..()
 	if(.)
 		update_icon()
@@ -149,7 +149,7 @@
 	icon_state = "[initial(icon_state)][contents.len]"
 
 
-/obj/item/storage/fancy/cigarettes/remove_from_storage(obj/item/W, atom/new_location)
+/obj/item/storage/fancy/cigarettes/remove_from_storage(obj/item/W, atom/new_location, mob/user)
 	var/obj/item/clothing/mask/cigarette/C = W
 	if(istype(C))
 		return ..()
@@ -161,7 +161,7 @@
 	if(M == user && user.zone_selected == "mouth" && contents.len > 0 && !user.wear_mask)
 		var/obj/item/clothing/mask/cigarette/C = locate() in src
 		if(C)
-			remove_from_storage(C, get_turf(user))
+			remove_from_storage(C, get_turf(user), user)
 			user.equip_to_slot_if_possible(C, SLOT_WEAR_MASK)
 			to_chat(user, "<span class='notice'>You take a cigarette out of the pack.</span>")
 			update_icon()
@@ -254,7 +254,7 @@
 	if(M == user && user.zone_selected == "mouth" && contents.len > 0 && !user.wear_mask)
 		var/obj/item/clothing/mask/cigarette/cigar/C = locate() in src
 		if(C)
-			remove_from_storage(C, get_turf(user))
+			remove_from_storage(C, get_turf(user), user)
 			user.equip_to_slot_if_possible(C, SLOT_WEAR_MASK)
 			to_chat(user, "<span class='notice'>You take a cigar out of the case.</span>")
 			update_icon()

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -298,7 +298,7 @@
 		return
 	if(contents.len)
 		var/obj/item/I = contents[1]
-		if(!remove_from_storage(I,user))
+		if(!remove_from_storage(I,user,user))
 			return
 		if(user.put_in_inactive_hand(I))
 			to_chat(user, "<span class='notice'>You take a pill out of \the [src].</span>")

--- a/code/game/objects/items/storage/internal.dm
+++ b/code/game/objects/items/storage/internal.dm
@@ -122,7 +122,7 @@
 	master_item.on_pocket_insertion()
 
 
-/obj/item/storage/internal/remove_from_storage(obj/item/W, atom/new_location)
+/obj/item/storage/internal/remove_from_storage(obj/item/W, atom/new_location, mob/user)
 	. = ..()
 	master_item.on_pocket_removal()
 

--- a/code/game/objects/items/storage/large_holster.dm
+++ b/code/game/objects/items/storage/large_holster.dm
@@ -38,7 +38,7 @@
 	return 1
 
 //Call this proc to handle the removal of an item from the storage item. The item will be moved to the atom sent as new_target
-/obj/item/storage/large_holster/remove_from_storage(obj/item/W, atom/new_location)
+/obj/item/storage/large_holster/remove_from_storage(obj/item/W, atom/new_location, mob/user)
 	. = ..()
 	if(. && drawSound)
 		playsound(src,drawSound, 15, 1)

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -416,6 +416,10 @@
 	if(!istype(I))
 		return FALSE
 
+	var/removal_good = TRUE
+	if(isgun(I) && !istype(src, /obj/item/storage/belt)) // If its a belt we dont care; they're supposed to be 'easy access'
+		removal_good = remove_gun_from_storage(I)
+
 	for(var/i in can_see_content())
 		var/mob/M = i
 		if(!M.client)
@@ -445,7 +449,17 @@
 		I.mouse_opacity = initial(I.mouse_opacity)
 
 	update_icon()
-	return TRUE
+	return removal_good
+
+/obj/item/storage/proc/remove_gun_from_storage(obj/item/weapon/gun/gun)
+	var/mob/user = usr
+	if(!istype(user))
+		return TRUE
+	to_chat(user, "<span class='notice'>You begin drawing [gun].</span>")
+	if(do_after(user, 0.5 SECONDS, TRUE, src))
+		return TRUE
+	to_chat(user, "<span class='warning'>You fumble with the [gun] and it drops to the ground!</span>")
+	return FALSE
 
 //This proc is called when you want to place an item into the storage item.
 /obj/item/storage/attackby(obj/item/I, mob/user, params)

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -450,7 +450,7 @@
 	if(isgun(I) && fumble_guns && user)
 		to_chat(user, "<span class='notice'>You begin drawing [I].</span>")
 		if(!do_after(user, 0.5 SECONDS, TRUE, src))
-			to_chat(user, "<span class='warning'>You fumble with [gun] and it drops to the ground!</span>")
+			to_chat(user, "<span class='warning'>You fumble with [I] and it drops to the ground!</span>")
 			return FALSE
 
 	return TRUE

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -417,15 +417,6 @@
 	if(!istype(I))
 		return FALSE
 
-	var/removal_good = TRUE
-	if(isgun(I) && fumble_guns)
-		if(user)
-			var/obj/item/weapon/gun/gun = I
-			to_chat(user, "<span class='notice'>You begin drawing [gun].</span>")
-			if(!do_after(user, 0.5 SECONDS, TRUE, src))
-				removal_good = FALSE
-				to_chat(user, "<span class='warning'>You fumble with [gun] and it drops to the ground!</span>")
-
 	for(var/i in can_see_content())
 		var/mob/M = i
 		if(!M.client)
@@ -455,7 +446,15 @@
 		I.mouse_opacity = initial(I.mouse_opacity)
 
 	update_icon()
-	return removal_good
+
+	if(isgun(I) && fumble_guns && user)
+		var/obj/item/weapon/gun/gun = I
+		to_chat(user, "<span class='notice'>You begin drawing [gun].</span>")
+		if(!do_after(user, 0.5 SECONDS, TRUE, src))
+			to_chat(user, "<span class='warning'>You fumble with [gun] and it drops to the ground!</span>")
+			return FALSE
+
+	return TRUE
 
 //This proc is called when you want to place an item into the storage item.
 /obj/item/storage/attackby(obj/item/I, mob/user, params)

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -448,7 +448,6 @@
 	update_icon()
 
 	if(isgun(I) && fumble_guns && user)
-		var/obj/item/weapon/gun/gun = I
 		to_chat(user, "<span class='notice'>You begin drawing [gun].</span>")
 		if(!do_after(user, 0.5 SECONDS, TRUE, src))
 			to_chat(user, "<span class='warning'>You fumble with [gun] and it drops to the ground!</span>")

--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -448,7 +448,7 @@
 	update_icon()
 
 	if(isgun(I) && fumble_guns && user)
-		to_chat(user, "<span class='notice'>You begin drawing [gun].</span>")
+		to_chat(user, "<span class='notice'>You begin drawing [I].</span>")
 		if(!do_after(user, 0.5 SECONDS, TRUE, src))
 			to_chat(user, "<span class='warning'>You fumble with [gun] and it drops to the ground!</span>")
 			return FALSE

--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -30,8 +30,8 @@
 	var/obj/item/card/id/front_id = null
 
 
-/obj/item/storage/wallet/remove_from_storage(obj/item/W as obj, atom/new_location)
-	. = ..(W, new_location)
+/obj/item/storage/wallet/remove_from_storage(obj/item/W as obj, atom/new_location, mob/user)
+	. = ..(W, new_location, user)
 	if(.)
 		if(W == front_id)
 			front_id = null

--- a/code/game/objects/machinery/kitchen/smartfridge.dm
+++ b/code/game/objects/machinery/kitchen/smartfridge.dm
@@ -99,7 +99,7 @@
 				to_chat(user, "<span class='notice'>\The [src] is full.</span>")
 				return TRUE
 
-			P.remove_from_storage(G, src)
+			P.remove_from_storage(G, src, user)
 			if(item_quants[G.name])
 				item_quants[G.name]++
 			else

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -532,7 +532,7 @@
 
 			if(istype(item_to_stock.loc, /obj/item/storage)) //inside a storage item
 				var/obj/item/storage/S = item_to_stock.loc
-				S.remove_from_storage(item_to_stock, user.loc)
+				S.remove_from_storage(item_to_stock, user.loc, user)
 
 			qdel(item_to_stock)
 			if(!recharge)

--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -674,7 +674,7 @@
 
 		if(istype(item_to_stock.loc, /obj/item/storage)) //inside a storage item
 			var/obj/item/storage/S = item_to_stock.loc
-			S.remove_from_storage(item_to_stock, user.loc)
+			S.remove_from_storage(item_to_stock, user.loc, user)
 
 		qdel(item_to_stock)
 		if(!recharge)

--- a/code/modules/clothing/under/ties.dm
+++ b/code/modules/clothing/under/ties.dm
@@ -325,7 +325,7 @@
 	var/turf/T = get_turf(src)
 	hold.hide_from(usr)
 	for(var/obj/item/I in hold.contents)
-		hold.remove_from_storage(I, T)
+		hold.remove_from_storage(I, T, user)
 
 /obj/item/clothing/tie/storage/webbing
 	name = "webbing"

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -259,7 +259,7 @@ should be alright.
 		return
 	if(istype(new_magazine.loc, /obj/item/storage))
 		var/obj/item/storage/S = new_magazine.loc
-		S.remove_from_storage(new_magazine, get_turf(user))
+		S.remove_from_storage(new_magazine, get_turf(user), user)
 	user.put_in_any_hand_if_possible(new_magazine)
 	reload(user, new_magazine)
 

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -100,7 +100,7 @@
 		var/obj/item/storage/bag/trash/T = I
 		to_chat(user, "<span class='notice'>You empty the bag into [src].</span>")
 		for(var/obj/item/O in T.contents)
-			T.remove_from_storage(O, src)
+			T.remove_from_storage(O, src, user)
 		T.update_icon()
 		update()
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

If you attempt to pull a gun out of any storage that isn't a belt it takes half a second.
If you move or 'fumble' during this period you simply drop the gun on the ground instead.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

What if we nerfed revolver spam without actually nerfing the revolver?

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Attempting to pull any gun out of a storage item has a delay; excludingbelts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
