### PR TITLE
Make Tadpole land if the console is killed mid-air

### DIFF
--- a/code/modules/shuttle/mini_dropship.dm
+++ b/code/modules/shuttle/mini_dropship.dm
@@ -152,12 +152,12 @@
 	if(damaged)
 		return
 	X.visible_message("[X] begins to slash delicately at the computer",
-	"You start slashing delicately at the computer.")
+	"We start slashing delicately at the computer. This will take a while.")
 	if(!do_after(X, 10 SECONDS, TRUE, src, BUSY_ICON_DANGER, BUSY_ICON_HOSTILE))
 		return
 	visible_message("The inner wiring is visible, it can be slashed!")
 	X.visible_message("[X] continue to slash at the computer",
-	"You continue slashing at the computer.")
+	"We continue slashing at the computer. If we stop now we will have to start all over again.")
 	var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
 	s.set_up(3, 1, src)
 	s.start()
@@ -169,6 +169,14 @@
 	s2.start()
 	damaged = TRUE
 	remove_eye_control(ui_user)
+	if(fly_state == SHUTTLE_IN_ATMOSPHERE && last_valid_ground_port)
+		visible_message("Autopilot detects loss of helm control. INITIATING EMERGENCY LANDING!")
+		shuttle_port.callTime = SHUTTLE_LANDING_CALLTIME
+		next_fly_state = SHUTTLE_ON_GROUND
+		open_prompt = FALSE
+		remove_eye_control(ui_user)
+		shuttle_port.set_mode(SHUTTLE_CALL)
+		SSshuttle.moveShuttleToDock(shuttleId, last_valid_ground_port, TRUE)
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/minidropship/ui_state(mob/user)
 	return GLOB.dropship_state
@@ -246,4 +254,5 @@
 	origin.open_prompt = FALSE
 	origin.remove_eye_control(origin.ui_user)
 	origin.shuttle_port.set_mode(SHUTTLE_CALL)
+	origin.last_valid_ground_port = origin.my_port
 	SSshuttle.moveShuttleToDock(origin.shuttleId, origin.my_port, TRUE)

--- a/code/modules/shuttle/mini_dropship.dm
+++ b/code/modules/shuttle/mini_dropship.dm
@@ -168,15 +168,20 @@
 	s2.set_up(3, 1, src)
 	s2.start()
 	damaged = TRUE
+	open_prompt = FALSE
 	remove_eye_control(ui_user)
+
 	if(fly_state == SHUTTLE_IN_ATMOSPHERE && last_valid_ground_port)
 		visible_message("Autopilot detects loss of helm control. INITIATING EMERGENCY LANDING!")
 		shuttle_port.callTime = SHUTTLE_LANDING_CALLTIME
 		next_fly_state = SHUTTLE_ON_GROUND
-		open_prompt = FALSE
-		remove_eye_control(ui_user)
 		shuttle_port.set_mode(SHUTTLE_CALL)
 		SSshuttle.moveShuttleToDock(shuttleId, last_valid_ground_port, TRUE)
+		return
+
+	if(next_fly_state == SHUTTLE_IN_ATMOSPHERE)
+		shuttle_port.set_idle() // don't go up with a broken console, cencel spooling
+		visible_message("Autopilot detects loss of helm control. Halting take off!")
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/minidropship/ui_state(mob/user)
 	return GLOB.dropship_state

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -17,6 +17,8 @@
 	var/list/jumpto_ports = list()
 	/// The custom docking port placed by this console
 	var/obj/docking_port/stationary/my_port
+	/// The previous custom docking port that was safely landed at, for emergency landings
+	var/obj/docking_port/stationary/last_valid_ground_port
 	/// The mobile docking port of the connected shuttle
 	var/obj/docking_port/mobile/shuttle_port
 	/// Traits forbided for custom docking


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

Makes the console slashing messages to the xeno a little clearer and follow the collective centric notice conventions.

## Why It's Good For The Game

Currently the ship stays in brazil if this happens. That is bad right?

## Changelog
:cl:
fix: Fixed Tadpole getting stuck in the air with a slashed console.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
