### PR TITLE
Cloning Vats have actual power state usage

### DIFF
--- a/code/game/objects/machinery/cloning/cloning.dm
+++ b/code/game/objects/machinery/cloning/cloning.dm
@@ -100,7 +100,8 @@ These act as a respawn mechanic growning a body and offering it up to ghosts.
 	icon = 'icons/obj/machines/cloning.dmi'
 	icon_state = "cell_0"
 	use_power = IDLE_POWER_USE
-	idle_power_usage = 30000
+	idle_power_usage = 3000
+	active_power_usage = 30000
 
 	var/timerid
 	var/mob/living/carbon/human/occupant
@@ -213,6 +214,7 @@ These act as a respawn mechanic growning a body and offering it up to ghosts.
 
 
 /obj/machinery/cloning/vats/proc/grow_human(instant = FALSE)
+	use_power = ACTIVE_POWER_USE
 	// Ensure we cleanup the beaker contents
 	if(beaker)
 		beaker.reagents.remove_all(biomass_required)
@@ -227,6 +229,7 @@ These act as a respawn mechanic growning a body and offering it up to ghosts.
 
 
 /obj/machinery/cloning/vats/proc/finish_growing_human()
+	use_power = IDLE_POWER_USE
 	occupant = new(src)
 	var/datum/job/job_instance = SSjob.GetJobType(/datum/job/terragov/squad/vatgrown)
 	occupant.apply_assigned_role_to_spawn(job_instance)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Cloning vats no longer always use 30000 power each tick.
Active power usage for cloning vats is 30000
Idle power usage is now 3000

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

"Engineers, why is medbay dark?"

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Cloning Vats use less power if not running
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
