### PR TITLE
Add Runechat text to Imaginary Friends and other QoL

### DIFF
--- a/code/datums/jobs/job/other.dm
+++ b/code/datums/jobs/job/other.dm
@@ -85,3 +85,10 @@
 	w_uniform = /obj/item/clothing/under/liaison_suit/galaxy_blue
 	belt = null
 	back = null
+
+/datum/job/spatial_agent/xeno_suit
+	outfit = /datum/outfit/job/other/spatial_agent/xeno_suit
+
+/datum/outfit/job/other/spatial_agent/xeno_suit
+	head = /obj/item/clothing/head/xenos
+	wear_suit = /obj/item/clothing/suit/xenos

--- a/code/modules/mob/camera/imaginary_friend.dm
+++ b/code/modules/mob/camera/imaginary_friend.dm
@@ -58,6 +58,8 @@
 	real_name = name
 	gender = client.prefs.gender
 	var/outfit_choice = tgui_input_list(usr, "Choose your appearance:", "[src]", outfit_choices)
+	if(!outfit_choice)
+		outfit_choice = outfit_choices[1]
 	human_image = get_flat_human_icon(null, SSjob.GetJobType(outfit_choice), client.prefs)
 
 
@@ -109,6 +111,8 @@
 	set name = "Change Appearance"
 
 	var/outfit_choice = tgui_input_list(usr, "Choose your appearance:", "[src]", outfit_choices)
+	if(!outfit_choice)
+		return
 	human_image = get_flat_human_icon(null, SSjob.GetJobType(outfit_choice), client.prefs)
 	Show()
 

--- a/code/modules/mob/camera/imaginary_friend.dm
+++ b/code/modules/mob/camera/imaginary_friend.dm
@@ -118,7 +118,7 @@
 	var/dead_rendered = "<span class='game say'><span class='name'>[name] (Imaginary friend of [owner])</span> <span class='message'>[say_quote(message)]</span></span>"
 
 	to_chat(owner, "[rendered]")
-	if(owner.client?.prefs.chat_on_map)
+	if(owner.client?.prefs.chat_on_map && !hidden)
 		owner.create_chat_message(src, owner.get_default_language(), message)
 	to_chat(src, "[rendered]")
 	if(client?.prefs.chat_on_map)

--- a/code/modules/mob/camera/imaginary_friend.dm
+++ b/code/modules/mob/camera/imaginary_friend.dm
@@ -2,9 +2,10 @@
 	name = "imaginary friend"
 	real_name = "imaginary friend"
 	desc = "A wonderful yet fake friend."
-	mouse_opacity = MOUSE_OPACITY_OPAQUE
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	lighting_alpha = LIGHTING_PLANE_ALPHA_INVISIBLE
-	see_invisible = SEE_INVISIBLE_LIVING
+	see_invisible = SEE_INVISIBLE_OBSERVER
+	stat = DEAD // Keep hearing ghosts and other IFs
 	invisibility = INVISIBILITY_MAXIMUM
 	sight = SEE_MOBS|SEE_TURFS|SEE_OBJS
 	see_in_dark = 8
@@ -21,7 +22,8 @@
 
 	var/list/outfit_choices = list(/datum/job/spatial_agent,
 									/datum/job/spatial_agent/galaxy_red,
-									/datum/job/spatial_agent/galaxy_blue
+									/datum/job/spatial_agent/galaxy_blue,
+									/datum/job/spatial_agent/xeno_suit,
 									)
 
 /mob/camera/imaginary_friend/Login()
@@ -116,7 +118,11 @@
 	var/dead_rendered = "<span class='game say'><span class='name'>[name] (Imaginary friend of [owner])</span> <span class='message'>[say_quote(message)]</span></span>"
 
 	to_chat(owner, "[rendered]")
+	if(owner.client?.prefs.chat_on_map)
+		owner.create_chat_message(src, owner.get_default_language(), message)
 	to_chat(src, "[rendered]")
+	if(client?.prefs.chat_on_map)
+		create_chat_message(src, get_default_language(), message)
 
 	//speech bubble
 	var/mutable_appearance/MA = mutable_appearance('icons/mob/talk.dmi', src, "default[say_test(message)]", FLY_LAYER)
@@ -125,7 +131,7 @@
 
 	for(var/i in GLOB.dead_mob_list)
 		var/mob/M = i
-		if(isnewplayer(M))
+		if(isnewplayer(M) || src == i)
 			continue
 		var/link = FOLLOW_LINK(M, owner)
 		to_chat(M, "[link] [dead_rendered]")

--- a/code/modules/mob/camera/imaginary_friend.dm
+++ b/code/modules/mob/camera/imaginary_friend.dm
@@ -3,7 +3,7 @@
 	real_name = "imaginary friend"
 	desc = "A wonderful yet fake friend."
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
-	lighting_alpha = LIGHTING_PLANE_ALPHA_INVISIBLE
+	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 	see_invisible = SEE_INVISIBLE_OBSERVER
 	stat = DEAD // Keep hearing ghosts and other IFs
 	invisibility = INVISIBILITY_MAXIMUM
@@ -16,6 +16,10 @@
 	var/hidden = FALSE
 	var/move_delay = 0
 	var/mob/living/owner
+
+	//HUD toggles
+	var/xeno_mobhud = FALSE
+	var/med_squad_mobhud = FALSE
 
 	var/datum/action/innate/imaginary_join/join
 	var/datum/action/innate/imaginary_hide/hide
@@ -84,6 +88,51 @@
 
 	return ..()
 
+/mob/camera/imaginary_friend/verb/toggle_darkness()
+	set category = "Imaginary Friend"
+	set name = "Toggle Darkness"
+
+	switch(lighting_alpha)
+		if(LIGHTING_PLANE_ALPHA_VISIBLE)
+			lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
+		if(LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE)
+			lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
+		if(LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE)
+			lighting_alpha = LIGHTING_PLANE_ALPHA_INVISIBLE
+		else
+			lighting_alpha = LIGHTING_PLANE_ALPHA_VISIBLE
+
+	update_sight()
+
+/mob/camera/imaginary_friend/verb/update_outfit()
+	set category = "Imaginary Friend"
+	set name = "Change Appearance"
+
+	var/outfit_choice = tgui_input_list(usr, "Choose your appearance:", "[src]", outfit_choices)
+	human_image = get_flat_human_icon(null, SSjob.GetJobType(outfit_choice), client.prefs)
+	Show()
+
+/mob/camera/imaginary_friend/verb/toggle_xeno_mobhud()
+	set category = "Imaginary Friend"
+	set name = "Toggle Xeno Status HUD"
+
+	xeno_mobhud = !xeno_mobhud
+	var/datum/atom_hud/H = GLOB.huds[DATA_HUD_XENO_STATUS]
+	xeno_mobhud ? H.add_hud_to(src) : H.remove_hud_from(src)
+	to_chat(src, "<span class='notice'>You have [xeno_mobhud ? "enabled" : "disabled"] the Xeno Status HUD.</span>")
+
+/mob/camera/imaginary_friend/verb/toggle_human_mobhud()
+	set category = "Imaginary Friend"
+	set name = "Toggle Human Status HUD"
+
+	med_squad_mobhud = !med_squad_mobhud
+	var/datum/atom_hud/H = GLOB.huds[DATA_HUD_MEDICAL_OBSERVER]
+	med_squad_mobhud ? H.add_hud_to(src) : H.remove_hud_from(src)
+	H = GLOB.huds[DATA_HUD_SQUAD_TERRAGOV]
+	med_squad_mobhud ? H.add_hud_to(src) : H.remove_hud_from(src)
+	H = GLOB.huds[DATA_HUD_SQUAD_REBEL]
+	med_squad_mobhud ? H.add_hud_to(src) : H.remove_hud_from(src)
+	to_chat(src, "<span class='notice'>You have [med_squad_mobhud ? "enabled" : "disabled"] the Human Status HUD.</span>")
 
 /mob/camera/imaginary_friend/say(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language, ignore_spam = FALSE, forced)
 	if(!message)
@@ -210,20 +259,20 @@
 /datum/action/innate/imaginary_hide/Activate()
 	active = TRUE
 	var/mob/camera/imaginary_friend/I = owner
-	I.hidden = FALSE
+	I.hidden = TRUE
 	I.Show()
-	name = "Hide"
-	desc = "Hide yourself from your owner's sight."
-	action_icon_state = "hidemob"
+	name = "Show"
+	desc = "Become visible to your owner."
+	action_icon_state = "unhidemob"
 	update_button_icon()
 
 
 /datum/action/innate/imaginary_hide/Deactivate()
 	active = FALSE
 	var/mob/camera/imaginary_friend/I = owner
-	I.hidden = TRUE
+	I.hidden = FALSE
 	I.Show()
-	name = "Show"
-	desc = "Become visible to your owner."
-	action_icon_state = "unhidemob"
+	name = "Hide"
+	desc = "Hide yourself from your owner's sight."
+	action_icon_state = "hidemob"
 	update_button_icon()

--- a/code/modules/mob/camera/imaginary_friend.dm
+++ b/code/modules/mob/camera/imaginary_friend.dm
@@ -118,11 +118,12 @@
 	var/dead_rendered = "<span class='game say'><span class='name'>[name] (Imaginary friend of [owner])</span> <span class='message'>[say_quote(message)]</span></span>"
 
 	to_chat(owner, "[rendered]")
-	if(owner.client?.prefs.chat_on_map && !hidden)
-		owner.create_chat_message(src, owner.get_default_language(), message)
 	to_chat(src, "[rendered]")
-	if(client?.prefs.chat_on_map)
-		create_chat_message(src, get_default_language(), message)
+	if(!hidden) // runechat if we are visible
+		if(owner.client?.prefs.chat_on_map)
+			owner.create_chat_message(src, owner.get_default_language(), message)
+		if(client?.prefs.chat_on_map)
+			create_chat_message(src, get_default_language(), message)
 
 	//speech bubble
 	var/mutable_appearance/MA = mutable_appearance('icons/mob/talk.dmi', src, "default[say_test(message)]", FLY_LAYER)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title and changelog.

## Why It's Good For The Game

Makes figurative spoon feeding and hand holding easier.

## Changelog
:cl:
add: Added Runechat text to Imaginary Friends for them and their owners to see.
add: Added a Xeno Suit cosmetic for Imaginary Friends.
add: Added Darkness, Change Appearance, and HUD toggle verbs to Imaginary Friends.
qol: Imaginary Friends now continue to hear ghosts and other IFs while active.
fix: Fixed the Show/Hide ability button requiring two toggles to work the first time for Imaginary Friends.
fix: Fixed Imaginary Friends possibly being naked spatial agents and blocking clicks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
