### PR TITLE
Fix orbital change priority message callback runtime

### DIFF
--- a/code/modules/orbits/spaceship.dm
+++ b/code/modules/orbits/spaceship.dm
@@ -190,8 +190,8 @@ GLOBAL_VAR_INIT(current_orbit,STANDARD_ORBIT)
 	changing_orbit = TRUE
 	engine_shudder()
 
-	var/message = "Arriving at new orbital level.<br><br>Prepare for engine ignition and stabilization."
-	addtimer(CALLBACK(src, .proc/priority_announce, message, "Orbit Change"), 290 SECONDS)
+	var/message = "Arriving at new orbital level. Prepare for engine ignition and stabilization."
+	addtimer(CALLBACK(GLOBAL_PROC, .proc/priority_announce, message, "Orbit Change"), 290 SECONDS)
 	addtimer(CALLBACK(src, .proc/orbit_gets_changed, current_orbit, direction), 5 MINUTES)
 
 /obj/machinery/computer/navigation/proc/orbit_gets_changed(current_orbit, direction)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fix:
```
Runtime in callback.dm, line 98: undefined proc or verb /obj/machinery/computer/navigation/priority announce(). 
proc name: Invoke (/datum/callback/proc/Invoke)
```

## Why It's Good For The Game

Bug bad. Fix good.

## Changelog
:cl:
fix: Fixed the orbital level change arrival message never being announced.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
