### PR TITLE
Xenomorphs can no longer destroy colony floodlight switches.

### DIFF
--- a/code/game/objects/machinery/floodlight.dm
+++ b/code/game/objects/machinery/floodlight.dm
@@ -351,7 +351,7 @@
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 5
 	active_power_usage = 0
-	resistance_flags = UNACIDABLE|XENO_DAMAGEABLE
+	resistance_flags = RESIST_ALL
 	var/turned_on = FALSE //has to be toggled in engineering
 
 /obj/machinery/colony_floodlight_switch/update_icon()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes resistance flags for the colony floodlight switch to make it indestructible.

## Why It's Good For The Game

The colony floodlight switch is responsible for turning on/off the colony floodlights, and is irreplaceable. It can also be destroyed by xenos, (usually done at roundstart), rendering the floodlights permanently inoperable. This is clearly an oversight.
## Changelog
:cl:Terrariola
balance: Colony floodlight switches can no longer be destroyed by xenomorphs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
