### PR TITLE
Fix Colony floodlight switch staying on after power loss

### DIFF
--- a/code/game/objects/machinery/floodlight.dm
+++ b/code/game/objects/machinery/floodlight.dm
@@ -365,7 +365,7 @@
 
 /obj/machinery/colony_floodlight_switch/power_change()
 	. = ..()
-	if(machine_stat && NOPOWER)
+	if(machine_stat & NOPOWER)
 		if(turned_on)
 			toggle_lights(FALSE)
 			turned_on = FALSE


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title

## Why It's Good For The Game

Fix

## Changelog
:cl:
fix: Fixed colony floodlight switch staying on after power loss.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
