### PR TITLE
Fix AI Eye permanent deletion if looking at an escape shuttle

### DIFF
--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -134,7 +134,7 @@
 
 
 /mob/living/silicon/ai/proc/create_eye()
-	if(eyeobj)
+	if(!QDELETED(eyeobj))
 		return
 	eyeobj = new /mob/camera/aiEye()
 	all_eyes += eyeobj


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

One line fix to check for eyeobj existence.

## Why It's Good For The Game

Fix

## Changelog
:cl:
fix: AI can now recover from a camera blackout if it was looking at an escape shuttle, or anything else causes deletion.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
