### PR TITLE
Xeno can see the health of marines rather than their pain

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,12 +9,7 @@
     	"**/.yarn": true,
     	"**/.pnp.*": true
 	},
-	"workbench.editorAssociations": [
-		{
-			"filenamePattern": "*.dmi",
-			"viewtype": "imagePreview.previewEditor"
-		}
-	],
+	"workbench.editorAssociations": {},
 	"files.eol": "\n",
 	"gitlens.advanced.blame.customArguments": ["-w"],
 	"tgstationTestExplorer.project.resultsType": "json",

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/shrike.dm
@@ -28,26 +28,3 @@
 /mob/living/carbon/xenomorph/shrike/handle_decay()
 	if(prob(20+abs(3*upgrade_as_number())))
 		use_plasma(min(rand(1,2), plasma_stored))
-
-
-// ***************************************
-// *********** Pain Hud
-// ***************************************
-/mob/living/carbon/xenomorph/prepare_huds()
-	. = ..()
-	var/datum/atom_hud/pain_hud = GLOB.huds[DATA_HUD_MEDICAL_PAIN]
-	pain_hud.add_hud_to(src)
-
-
-/mob/living/carbon/xenomorph/shrike/verb/toggle_shrike_painhud()
-	set name = "Toggle Shrike Pain HUD"
-	set desc = "Toggles the pain hud appearing above humans."
-	set category = "Alien"
-
-	TOGGLE_BITFIELD(shrike_flags, SHRIKE_FLAG_PAIN_HUD_ON)
-	xeno_mobhud = !xeno_mobhud
-	var/datum/atom_hud/new_hud = GLOB.huds[DATA_HUD_MEDICAL_PAIN]
-	if(CHECK_BITFIELD(shrike_flags, SHRIKE_FLAG_PAIN_HUD_ON))
-		new_hud.add_hud_to(usr)
-	else
-		new_hud.remove_hud_from(usr)

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -279,6 +279,8 @@
 	hud_to_add.add_hud_to(src)
 	hud_to_add = GLOB.huds[DATA_HUD_XENO_TACTICAL] //Allows us to see xeno tactical elements clearly via HUD elements
 	hud_to_add.add_hud_to(src)
+	hud_to_add = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
+	hud_to_add.add_hud_to(src)
 
 
 /mob/living/carbon/xenomorph/point_to_atom(atom/A, turf/T)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Change the pain hud for a health hud

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Pain is a not a usefull information for xeno, it's even a trap at some times

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: xeno will see directly the health of marines, rather than their pain
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
