### PR TITLE
Kill sticky, weeds slow down

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,12 +9,7 @@
     	"**/.yarn": true,
     	"**/.pnp.*": true
 	},
-	"workbench.editorAssociations": [
-		{
-			"filenamePattern": "*.dmi",
-			"viewtype": "imagePreview.previewEditor"
-		}
-	],
+	"workbench.editorAssociations": {},
 	"files.eol": "\n",
 	"gitlens.advanced.blame.customArguments": ["-w"],
 	"tgstationTestExplorer.project.resultsType": "json",

--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -12,6 +12,8 @@
 	layer = XENO_WEEDS_LAYER
 	plane = FLOOR_PLANE
 	max_integrity = 25
+	///How much weeds are slowing down marines
+	var/slowdown_amount = 1
 
 	var/obj/effect/alien/weeds/node/parent_node
 
@@ -55,6 +57,10 @@
 	if(isxeno(AM))
 		var/mob/living/carbon/xenomorph/X = AM
 		X.next_move_slowdown += X.xeno_caste.weeds_speed_mod
+		return
+	if(ishuman(AM))
+		var/mob/living/carbon/human/human= AM
+		human.next_move_slowdown += slowdown_amount
 
 /obj/effect/alien/weeds/proc/update_neighbours(turf/U)
 	if(!U)

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -64,62 +64,6 @@
 	to_chat(usr, "<span class='warning'>You scrape ineffectively at \the [src].</span>")
 	return TRUE
 
-
-/obj/effect/alien/resin/sticky
-	name = "sticky resin"
-	desc = "A layer of disgusting sticky slime."
-	icon_state = "sticky"
-	density = FALSE
-	opacity = FALSE
-	max_integrity = 36
-	layer = RESIN_STRUCTURE_LAYER
-	hit_sound = "alien_resin_move"
-	var/slow_amt = 8
-
-	ignore_weed_destruction = TRUE
-
-/obj/effect/alien/resin/sticky/attack_alien(mob/living/carbon/xenomorph/X, damage_amount = X.xeno_caste.melee_damage, damage_type = BRUTE, damage_flag = "", effects = TRUE, armor_penetration = 0, isrightclick = FALSE)
-	if(X.status_flags & INCORPOREAL)
-		return FALSE
-
-	if(X.a_intent == INTENT_HARM) //Clear it out on hit; no need to double tap.
-		X.do_attack_animation(src, ATTACK_EFFECT_CLAW) //SFX
-		playsound(src, "alien_resin_break", 25) //SFX
-		deconstruct(TRUE)
-		return
-
-	return ..()
-
-
-/obj/effect/alien/resin/sticky/Crossed(atom/movable/AM)
-	. = ..()
-	if(!ishuman(AM))
-		return
-
-	if(CHECK_MULTIPLE_BITFIELDS(AM.flags_pass, HOVERING))
-		return
-
-	var/mob/living/carbon/human/H = AM
-
-	if(H.lying_angle)
-		return
-
-	H.next_move_slowdown += slow_amt
-
-
-// Praetorian Sticky Resin spit uses this.
-/obj/effect/alien/resin/sticky/thin
-	name = "thin sticky resin"
-	desc = "A thin layer of disgusting sticky slime."
-	max_integrity = 6
-	slow_amt = 4
-
-	ignore_weed_destruction = FALSE
-
-// Default for xeno structures
-	hud_possible = list(XENO_TACTICAL_HUD)
-
-
 //Carrier trap
 /obj/structure/xeno/trap
 	desc = "It looks like a hiding hole."

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -181,7 +181,6 @@
 	///List of buildable structures
 	var/list/buildable_structures = list(
 		/turf/closed/wall/resin/regenerating,
-		/obj/effect/alien/resin/sticky,
 		/obj/structure/mineral_door/resin)
 
 /datum/action/xeno_action/activable/secrete_resin/update_button_icon()
@@ -217,11 +216,9 @@
 	var/mob/living/carbon/xenomorph/X = owner
 
 	var/build_resin_modifier = 1
-	switch(X.selected_resin)
-		if(/obj/effect/alien/resin/sticky)
-			build_resin_modifier = 0.5
-		if(/obj/structure/mineral_door/resin)
-			build_resin_modifier = 3
+
+	if(X.selected_resin == /obj/structure/mineral_door/resin)
+		build_resin_modifier = 3
 
 	return (base_wait + scaling_wait - max(0, (scaling_wait * X.health / X.maxHealth))) * build_resin_modifier
 
@@ -313,11 +310,8 @@
 	else
 		new_resin = new X.selected_resin(T)
 
-	switch(X.selected_resin)
-		if(/obj/effect/alien/resin/sticky)
-			plasma_cost = initial(plasma_cost) / 3
-		if(/obj/structure/mineral_door/resin)
-			plasma_cost = initial(plasma_cost) * 3
+	if(X.selected_resin == /obj/structure/mineral_door/resin)
+		plasma_cost = initial(plasma_cost) * 3
 
 	if(new_resin)
 		add_cooldown()

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -10,7 +10,6 @@
 	plasma_cost = 100
 	buildable_structures = list(
 		/turf/closed/wall/resin/regenerating/thick,
-		/obj/effect/alien/resin/sticky,
 		/obj/structure/mineral_door/resin/thick,
 	)
 

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -711,16 +711,12 @@
 	visible_message("<span class='danger'>[src] explodes into a mess of viscous resin!</span>")
 	playsound(loc, get_sfx("alien_resin_build"), 50, 1)
 
-	for(var/turf/sticky_tile AS in RANGE_TURFS(1, loc))
-		if(!locate(/obj/effect/xenomorph/spray) in sticky_tile.contents)
-			new /obj/effect/alien/resin/sticky/thin(sticky_tile)
-
 	var/armor_block
 	for(var/mob/living/target in range(1, loc))
 		if(isxeno(target)) //Xenos aren't affected by sticky resin
 			continue
 
-		target.adjust_stagger(3)
+		target.adjust_stagger(5)
 		target.add_slowdown(15)
 		armor_block = target.run_armor_check(BODY_ZONE_CHEST, "bio")
 		target.apply_damage(100, STAMINA, BODY_ZONE_CHEST, armor_block) //Small amount of stamina damage; meant to stop sprinting.

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1,7 +1,5 @@
 #define DEBUG_STAGGER_SLOWDOWN 0
 
-GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/facehugger, /obj/effect/alien/egg, /obj/structure/mineral_door, /obj/effect/alien/resin, /obj/structure/bed/nest))) //For sticky/acid spit
-
 /datum/ammo
 	var/name 		= "generic bullet"
 	var/icon 		= 'icons/obj/items/projectiles.dmi'
@@ -1714,51 +1712,17 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage = 20 //minor; this is mostly just to provide confirmation of a hit
 	max_range = 40
 	bullet_color = COLOR_PURPLE
-	stagger_stacks = 2
-	slowdown_stacks = 3
+	stagger_stacks = 3
+	slowdown_stacks = 4
 
 
 /datum/ammo/xeno/sticky/on_hit_mob(mob/M,obj/projectile/P)
-	drop_resin(get_turf(M))
 	if(istype(M,/mob/living/carbon))
 		var/mob/living/carbon/C = M
 		if(C.issamexenohive(P.firer))
 			return
 		C.adjust_stagger(stagger_stacks) //stagger briefly; useful for support
 		C.add_slowdown(slowdown_stacks) //slow em down
-
-
-/datum/ammo/xeno/sticky/on_hit_obj(obj/O,obj/projectile/P)
-	var/turf/T = get_turf(O)
-	if(!T)
-		T = get_turf(P)
-
-	if(O.density && !(O.flags_atom & ON_BORDER))
-		T = get_turf(get_step(T, turn(P.dir, 180))) //If the object is dense and not a border object like barricades, we instead drop in the location just prior to the target
-
-	drop_resin(T)
-
-/datum/ammo/xeno/sticky/on_hit_turf(turf/T,obj/projectile/P)
-	if(!T)
-		T = get_turf(P)
-
-	if(isclosedturf(T))
-		T = get_turf(get_step(T, turn(P.dir, 180))) //If the turf is closed, we instead drop in the location just prior to the turf
-
-	drop_resin(T)
-
-/datum/ammo/xeno/sticky/do_at_max_range(obj/projectile/P)
-	drop_resin(get_turf(P))
-
-/datum/ammo/xeno/sticky/proc/drop_resin(turf/T)
-	if(T.density)
-		return
-
-	for(var/obj/O in T.contents)
-		if(is_type_in_typecache(O, GLOB.no_sticky_resin))
-			return
-
-	new /obj/effect/alien/resin/sticky/thin(T)
 
 /datum/ammo/xeno/acid
 	name = "acid spit"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Sticky no longer exist, sticky spit and sticky huggers have buffed slowdown and stagger to compensate

Weeds natively slowdown (1/4 of sticky slowdown)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Sticky is terribly boring to put in mazes, and then terrible to clear for marines. 
Meanwhile, they are almost necessary to win as a xeno, meaning that if drones/queen/shrike are too lazy (and you can't really blame them, cause putting sticky is so shit), you have automaticly lost 

The weeds are far easier to make, but also far easier to clear, so the game should feel better for both sides.

And marines are way too fast on weeds anyway IMO, xeno deserve that buff 

## Changelog
:cl:
del: Sticky no longer exist
balance: weeds natively slowdown
balance: sticky spit and hugger have more slowdown and stagger
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
