### PR TITLE
Wraith Buffs

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -604,7 +604,8 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define WRAITH_BANISH_NONFRIENDLY_LIVING_MULTIPLIER 0.5
 #define WRAITH_BANISH_VERY_SHORT_MULTIPLIER 0.3
 
-#define WRAITH_TELEPORT_DEBUFF_STACKS 1 //Stagger and slow stacks applied to adjacent living hostiles before/after a teleport
+#define WRAITH_TELEPORT_DEBUFF_STAGGER_STACKS 2 //Stagger and slow stacks applied to adjacent living hostiles before/after a teleport
+#define WRAITH_TELEPORT_DEBUFF_SLOWDOWN_STACKS 3 //Stagger and slow stacks applied to adjacent living hostiles before/after a teleport
 
 #define DEFILER_TRANSVITOX_CAP 180 //Max toxin damage transvitox will allow
 

--- a/code/datums/actions/xeno_action.dm
+++ b/code/datums/actions/xeno_action.dm
@@ -116,10 +116,10 @@
 /datum/action/xeno_action/fail_activate()
 	update_button_icon()
 
-/datum/action/xeno_action/proc/succeed_activate()
+/datum/action/xeno_action/proc/succeed_activate(plasma_mod = 1)
 	var/mob/living/carbon/xenomorph/X = owner
 	if(plasma_cost && !QDELETED(owner))
-		X.use_plasma(plasma_cost)
+		X.use_plasma(plasma_cost * plasma_mod)
 
 //checks if the linked ability is on some cooldown.
 //The action can still be activated by clicking the button

--- a/code/datums/actions/xeno_action.dm
+++ b/code/datums/actions/xeno_action.dm
@@ -116,10 +116,16 @@
 /datum/action/xeno_action/fail_activate()
 	update_button_icon()
 
-/datum/action/xeno_action/proc/succeed_activate(plasma_mod = 1)
+///Plasma cost override allows for actions/abilities to override the normal plasma costs
+/datum/action/xeno_action/proc/succeed_activate(plasma_cost_override)
+	if(QDELETED(owner))
+		return
 	var/mob/living/carbon/xenomorph/X = owner
-	if(plasma_cost && !QDELETED(owner))
-		X.use_plasma(plasma_cost * plasma_mod)
+	if(plasma_cost_override)
+		X.use_plasma(plasma_cost_override)
+		return
+	if(plasma_cost)
+		X.use_plasma(plasma_cost)
 
 //checks if the linked ability is on some cooldown.
 //The action can still be activated by clicking the button

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
@@ -485,9 +485,9 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 					continue
 
 			shake_camera(living_target, 2, 1)
-			living_target.adjust_stagger(WRAITH_TELEPORT_DEBUFF_STACKS)
-			living_target.add_slowdown(WRAITH_TELEPORT_DEBUFF_STACKS)
-			living_target.adjust_blurriness(WRAITH_TELEPORT_DEBUFF_STACKS) //minor visual distortion
+			living_target.adjust_stagger(WRAITH_TELEPORT_DEBUFF_STAGGER_STACKS)
+			living_target.add_slowdown(WRAITH_TELEPORT_DEBUFF_SLOWDOWN_STACKS)
+			living_target.adjust_blurriness(WRAITH_TELEPORT_DEBUFF_SLOWDOWN_STACKS) //minor visual distortion
 			to_chat(living_target, "<span class='warning'>You feel nauseous as reality warps around you!</span>")
 
 /datum/action/xeno_action/activable/blink/on_cooldown_finish()
@@ -590,13 +590,14 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	animate(portal.get_filter("banish_portal_2"), x = 20*rand() - 10, y = 20*rand() - 10, time = 0.5 SECONDS, loop = -1, flags=ANIMATION_PARALLEL)
 
 	var/cooldown_mod = 1
+	var/plasma_mod = 1
 	if(isliving(banishment_target) && !(banishment_target.issamexenohive(ghost))) //We halve the max duration for living non-allies
 		duration *= WRAITH_BANISH_NONFRIENDLY_LIVING_MULTIPLIER
-	else if (banishment_target.issamexenohive(ghost))
-		cooldown_mod = 0.6 //40% cooldown reduction if used on friendly targets.
-
 	else if(is_type_in_typecache(banishment_target, GLOB.wraith_banish_very_short_duration_list)) //Barricades should only be gone long enough to admit an infiltrator xeno or two; one way.
 		duration *= WRAITH_BANISH_VERY_SHORT_MULTIPLIER
+	else
+		cooldown_mod = 0.6 //40% cooldown reduction if used on non-hostile, non-blacklisted targets.
+		plasma_mod = 0.4 //60% plasma cost reduction if used on non-hostile, non-blacklisted targets.
 
 	banishment_target.visible_message("<span class='warning'>Space abruptly twists and warps around [banishment_target] as it suddenly vanishes!</span>", \
 	"<span class='highdanger'>The world around you reels, reality seeming to twist and tear until you find yourself trapped in a forsaken void beyond space and time.</span>")
@@ -608,7 +609,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	addtimer(CALLBACK(src, .proc/banish_warning), duration * 0.7) //Warn when Banish is about to end
 	banish_duration_timer_id = addtimer(CALLBACK(src, .proc/banish_deactivate), duration, TIMER_STOPPABLE) //store the timer ID
 
-	succeed_activate()
+	succeed_activate(plasma_mod)
 	add_cooldown(cooldown_timer * cooldown_mod)
 
 	GLOB.round_statistics.wraith_banishes++

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
@@ -239,6 +239,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	phase_shift_active = TRUE //Flag phase shift as being active
 	update_button_icon("phase_shift_off") //Set to resync icon while active
 	succeed_activate()
+	plasma_cost = 0 //Toggling is free
 
 ///Warns the user when Phase Shift is about to end.
 /datum/action/xeno_action/phase_shift/proc/phase_shift_warning()
@@ -317,6 +318,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 		ghost.adjust_sunder(plasma_deficit)
 
 	starting_turf = null
+	plasma_cost = initial(plasma_cost) //Revert the plasma cost to its initial amount
 	add_cooldown()
 
 /datum/action/xeno_action/phase_shift/on_cooldown_finish()

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
@@ -611,7 +611,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	addtimer(CALLBACK(src, .proc/banish_warning), duration * 0.7) //Warn when Banish is about to end
 	banish_duration_timer_id = addtimer(CALLBACK(src, .proc/banish_deactivate), duration, TIMER_STOPPABLE) //store the timer ID
 
-	succeed_activate(plasma_mod)
+	succeed_activate(plasma_cost * plasma_mod)
 	add_cooldown(cooldown_timer * cooldown_mod)
 
 	GLOB.round_statistics.wraith_banishes++


### PR DESCRIPTION
## About The Pull Request

1. Debuff stacks from the Wraith's warp field are increased; 2 stagger stacks up from 1, and 3 slowdown stacks up from 1.

2. Banish cooldown and plasma cost decreased for friendly living targets and non-barricade targets to 60% and 40% respectively.

3. Fixes bug with Phase Shift toggling off consuming its baseline plasma cost.

4. Hyperposition windup will increase by 0.25 seconds per tile after 20 tiles of distance down from 0.5 seconds per tile after 10 tiles of distance.

5. Using Resync while phased out (reverting to your prior location at the start of the Phase Shift) mostly removes the next cooldown for Phase Shift, reducing it to 3 seconds.

## Why It's Good For The Game

Makes Wraith a little easier to use and more impactful at lower skill levels.

Allows Wraith to use Banish more readily for utility purposes.

## Changelog
:cl:
balance: Debuff stacks from the Wraith's warp field are increased; 2 stagger stacks up from 1, and 3 slowdown stacks up from 1.
balance: Banish cooldown and plasma cost decreased for friendly living targets and non-barricade targets to 60% and 40% respectively.
balance: Hyperposition windup will increase by 0.25 seconds per tile after 20 tiles of distance down from 0.5 seconds per tile after 10 tiles of distance.
balance: Using Resync while phased out (reverting to your prior location at the start of the Phase Shift) mostly removes the next cooldown for Phase Shift, reducing it to 3 seconds.
bug: Phase Shift no longer consumes its baseline plasma cost when toggled off.
/:cl: