### PR TITLE
Removes maid spawn.

### DIFF
--- a/code/game/objects/effects/landmarks/itemspawner.dm
+++ b/code/game/objects/effects/landmarks/itemspawner.dm
@@ -40,13 +40,6 @@
 	/obj/item/clothing/shoes/jackboots)
 
 
-/obj/effect/landmark/itemspawner/maid
-	items_to_spawn = list(\
-	/obj/item/clothing/under/color/black,\
-	/obj/item/clothing/head/rabbitears,\
-	/obj/item/clothing/glasses/sunglasses/blindfold)
-
-
 /obj/effect/landmark/itemspawner/butler
 	items_to_spawn = list(\
 	/obj/item/clothing/suit/wcoat,\


### PR DESCRIPTION
## About The Pull Request

Removes spawn" maid itemspawner. It spawns blindfold, bunny ears and black skirt altogether.

## Why It's Good For The Game

We are a MRP server based on the lore of marines vs xenomorphs. Even with RP events here and there, I don't see a reason to keep these maid outfits especially with bunny ears, blindfold, black skirt that may potentially promote rule 8 violations(erotic, lewd rp). Unlike the bartender loadout which does have a reason sometimes to exist for the sake of RP events.

## Changelog
:cl: SpaceLove
del: Removed Maid outfit spawn command.
admin: Removes Admin ability to spawn maid loadout.
/:cl:
