### PR TITLE
All revolvers lose raillight

### DIFF
--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -343,7 +343,6 @@
 	attachable_allowed = list(
 		/obj/item/attachable/bayonet,
 		/obj/item/attachable/reddot,
-		/obj/item/attachable/flashlight,
 		/obj/item/attachable/heavy_barrel,
 		/obj/item/attachable/gyro,
 		/obj/item/attachable/extended_barrel,
@@ -375,7 +374,6 @@
 	attachable_allowed = list(
 		/obj/item/attachable/bayonet,
 		/obj/item/attachable/reddot,
-		/obj/item/attachable/flashlight,
 		/obj/item/attachable/heavy_barrel,
 		/obj/item/attachable/quickfire,
 		/obj/item/attachable/extended_barrel,
@@ -403,7 +401,6 @@
 	force = 8
 	attachable_allowed = list(
 		/obj/item/attachable/suppressor,
-		/obj/item/attachable/flashlight,
 		/obj/item/attachable/compensator,
 		/obj/item/attachable/extended_barrel,
 		/obj/item/attachable/lace,
@@ -430,7 +427,6 @@
 	force = 6
 	attachable_allowed = list(
 		/obj/item/attachable/reddot,
-		/obj/item/attachable/flashlight,
 		/obj/item/attachable/extended_barrel,
 		/obj/item/attachable/compensator,
 		/obj/item/attachable/scope,
@@ -464,7 +460,6 @@
 	force = 15
 	attachable_allowed = list(
 		/obj/item/attachable/reddot,
-		/obj/item/attachable/flashlight,
 		/obj/item/attachable/lasersight,
 		/obj/item/attachable/scope/mini,
 		/obj/item/attachable/heavy_barrel,
@@ -507,7 +502,6 @@
 	force = 12
 	attachable_allowed = list(
 		/obj/item/attachable/reddot,
-		/obj/item/attachable/flashlight,
 		/obj/item/attachable/extended_barrel,
 		/obj/item/attachable/heavy_barrel,
 		/obj/item/attachable/quickfire,


### PR DESCRIPTION

<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Revolverman meme is funny, but revolverman meme that covers half the map in flares that never go out is not funny. Used to be fine, till the loadout vendor meant you could automate adding flashlights.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

No more free flashlights covering half the map when ocelot plays

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: revolvers can't take flashlights anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
