### PR TITLE
Revolver ammo refactor, fix speed loader bug

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -265,6 +265,7 @@
 #define COMSIG_GUN_BURST_SHOTS_TO_FIRE_MODIFIED "gun_burstamount_modified"
 #define COMSIG_GUN_BURST_SHOT_DELAY_MODIFIED "gun_burstdelay_modified"
 #define COMSIG_REVOLVER_AMMO_HIT_MOB "gun_revolver_ammo_hit"
+	#define COMSIG_REVOLVER_AMMO_SNUBNOSE_BARREL (1<<0)
 
 // /obj/item/clothing signals
 #define COMSIG_SHOES_STEP_ACTION "shoes_step_action"			//from base of obj/item/clothing/shoes/proc/step_action(): ()

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -116,7 +116,7 @@ SUBSYSTEM_DEF(persistence)
 	name = "pistols bucket 1"
 	description = "Pistol guns, previously at import"
 	item_list = list(
-		/datum/supply_packs/imports/rev357 = -1,
+		/obj/item/weapon/gun/revolver/small = -1,
 		/obj/item/ammo_magazine/revolver/small = -1,
 		/obj/item/weapon/gun/revolver/m44 = -1,
 		/obj/item/ammo_magazine/revolver = -1,

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -337,7 +337,13 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	sundering = 3
 
 /datum/ammo/bullet/revolver/on_hit_mob(mob/M,obj/projectile/P)
-	if(SEND_SIGNAL(P.shot_from, COMSIG_REVOLVER_AMMO_HIT_MOB))
+	staggerstun(M, P, stagger = 1, slowdown = 0.5, knockback = 1)
+
+datum/ammo/bullet/revolver/tp44
+	name = "standard revolver bullet"
+
+/datum/ammo/bullet/revolver/tp44/on_hit_mob(mob/M,obj/projectile/P)
+	if(SEND_SIGNAL(P.shot_from, COMSIG_REVOLVER_AMMO_HIT_MOB) & COMSIG_REVOLVER_AMMO_SNUBNOSE_BARREL)
 		staggerstun(M, P, stagger = 1, slowdown = 0.5, knockback = 1)
 	else
 		staggerstun(M, P, slowdown = 0.5)

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1783,6 +1783,17 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	detach_delay = 0
 	gun_attachment_offset_mod = list("muzzle_x" = 7)
 
+/obj/item/attachable/standard_revolver_longbarrel/attach_to_gun(obj/item/weapon/gun/gun_to_attach, mob/user)
+	. = ..()
+	RegisterSignal(gun_to_attach, COMSIG_REVOLVER_AMMO_HIT_MOB, .proc/ammo_hit_mob)
+
+/obj/item/attachable/standard_revolver_longbarrel/detach_from_master_gun(mob/user)
+	UnregisterSignal(master_gun, COMSIG_REVOLVER_AMMO_HIT_MOB)
+	return ..()
+
+/obj/item/attachable/standard_revolver_longbarrel/proc/ammo_hit_mob()
+	SIGNAL_HANDLER
+	return COMSIG_REVOLVER_AMMO_SNUBNOSE_BARREL
 
 /obj/item/attachable/mateba_longbarrel
 	name = "Mateba long barrel"

--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -135,7 +135,7 @@
 					replace_cylinder(current_mag.current_rounds)
 					playsound(user, reload_sound, 25, 1) // Reloading via speedloader.
 			else
-				to_chat(user, "<span class='warning'>That [magazine] doesn't fit!</span>")
+				to_chat(user, "<span class='warning'>\The [magazine] doesn't fit!</span>")
 		else
 			to_chat(user, "<span class='warning'>You can't load a speedloader when there's something in the cylinder!</span>")
 

--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -36,12 +36,6 @@
 /obj/item/weapon/gun/revolver/Initialize()
 	. = ..()
 	replace_cylinder(current_mag.current_rounds)
-	RegisterSignal(src, COMSIG_REVOLVER_AMMO_HIT_MOB, .proc/has_stagger_barrel)
-
-/obj/item/weapon/gun/revolver/proc/has_stagger_barrel()
-	SIGNAL_HANDLER
-	if(!attachable_allowed?.Find(/obj/item/attachable/standard_revolver_longbarrel) || attachments?.Find(ATTACHMENT_BARREL_MOD))
-		return TRUE // has barrel or is a revolver without the option
 
 /obj/item/weapon/gun/revolver/examine_ammo_count(mob/user)
 	if(!current_mag)

--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -446,8 +446,6 @@
 	recoil = 0
 	recoil_unwielded = 0
 
-/obj/item/weapon/gun/revolver/small/unique_action(mob/user)
-	return revolver_trick(user)
 
 //-------------------------------------------------------
 //Mateba is pretty well known. The cylinder folds up instead of to the side. This has a non-marine version and a marine version.

--- a/code/modules/projectiles/magazines/revolvers.dm
+++ b/code/modules/projectiles/magazines/revolvers.dm
@@ -28,7 +28,7 @@
 /obj/item/ammo_magazine/revolver/standard_revolver
 	name = "\improper TP-44 magnum speed loader (.44)"
 	desc = "A revolver speed loader."
-	default_ammo = /datum/ammo/bullet/revolver
+	default_ammo = /datum/ammo/bullet/revolver/tp44
 	flags_equip_slot = NONE
 	caliber = CALIBER_44
 	icon_state = "tp44"
@@ -95,7 +95,7 @@
 
 /obj/item/ammo_magazine/internal/revolver/standard_revolver
 	caliber = CALIBER_44
-	default_ammo = /datum/ammo/bullet/revolver
+	default_ammo = /datum/ammo/bullet/revolver/tp44
 	max_rounds = 7
 	gun_type = /obj/item/weapon/gun/revolver/standard_revolver
 

--- a/code/modules/projectiles/magazines/revolvers.dm
+++ b/code/modules/projectiles/magazines/revolvers.dm
@@ -74,7 +74,7 @@
 /obj/item/ammo_magazine/magnum
 	name = "packet of .44 magnum"
 	icon_state = "box_44mag" //Maybe change this
-	default_ammo = /datum/ammo/bullet/revolver
+	default_ammo = /datum/ammo/bullet/revolver/tp44
 	caliber = CALIBER_44
 	current_rounds = 50
 	max_rounds = 50

--- a/code/modules/projectiles/magazines/revolvers.dm
+++ b/code/modules/projectiles/magazines/revolvers.dm
@@ -46,7 +46,7 @@
 
 /obj/item/ammo_magazine/revolver/small
 	name = "\improper S&W speed loader (.357)"
-	default_ammo = /datum/ammo/bullet/revolver/small
+	default_ammo = /datum/ammo/bullet/revolver/ricochet/four
 	caliber = CALIBER_357
 	icon_state = "sw357"
 	max_rounds = 6
@@ -79,6 +79,7 @@
 	current_rounds = 50
 	max_rounds = 50
 	icon_state_mini = "ammo_packet"
+	gun_type = /obj/item/weapon/gun/revolver/standard_revolver
 
 //INTERNAL MAGAZINES
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Splits tp-44 ammo into its own type, and improves signal code, and more in changelog.

## Why It's Good For The Game

Better code.

Fixes: #5827

## Changelog
:cl:
refactor: Refactored some revolver ammo code for less signal headaches later.
fix: Fixed handfuls of loose .44 ammo breaking speed loaders.
fix: Fixed the .357 seasonal item ref and speed loader ammo type.
spellcheck: Removed an extra "That" from revolver ammo rejection notices.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
