### PR TITLE
Fix Vendor product_name encoding issue

### DIFF
--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -3,7 +3,7 @@
 #define CAT_COIN 2
 
 #define MAKE_VENDING_RECORD_DATA(record) list(\
-		"product_name" = adminscrub(record.product_name),\
+		"product_name" = record.product_name,\
 		"product_color" = record.display_color,\
 		"prod_price" = record.price,\
 		"prod_desc" = initial(record.product_path.desc),\

--- a/tgui/packages/tgui/interfaces/Vending.tsx
+++ b/tgui/packages/tgui/interfaces/Vending.tsx
@@ -219,7 +219,7 @@ const ProductEntry = (props: VendingProductEntryProps, context) => {
           </Button>
         </>
       }
-      label={decodeHtmlEntities(product_name)}>
+      label={product_name}>
       {!!prod_desc && (
         <Button
           onClick={() => setShowDesc(prod_desc)}>?


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Stop encoding and decoding from breaking strings. Delete `adminscrub()` altogether next?

## Why It's Good For The Game

Items with special characters in names can be dispensed. Like the "S&W .357 revolver"

## Changelog
:cl:
fix: Fixed a problem with vendors refusing to vend items containing symbols in their name.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
