### PR TITLE
Remove Explosive Vests from RO vendor

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -333,7 +333,6 @@
 			/obj/item/ammo_magazine/shotgun/mbx900 = 2,
 			/obj/item/bodybag/tarp = 2,
 			/obj/item/explosive/plastique = 2,
-			/obj/item/clothing/suit/storage/marine/harness/boomvest = 20,
 			/obj/item/radio/headset/mainship/marine/alpha = -1,
 			/obj/item/radio/headset/mainship/marine/bravo = -1,
 			/obj/item/radio/headset/mainship/marine/charlie = -1,

--- a/code/game/objects/structures/crates_lockers/largecrate_supplies.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate_supplies.dm
@@ -243,6 +243,10 @@
 	desc = "A case containing twenty five 80mm flare mortar shells."
 	supplies = list(/obj/item/mortal_shell/flare = 25)
 
+/obj/structure/largecrate/supply/explosives/boomvest
+	name = "Tactical Explosive Vest (x20)"
+	desc = "A case containing twenty tactical explosive vests. Sayonara muchachos."
+	supplies = list(/obj/item/clothing/suit/storage/marine/harness/boomvest = 20)
 
 /obj/structure/largecrate/supply/supplies
 	name = "supplies crate"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes vests from ROs vendor. 

Adds a Crate type for them so perhaps in the future they can be added to a spawner in the future, like in the Self Destruct areas perhaps? or spawned in bulk by an admin.

## Why It's Good For The Game

Vests are just too powerful especially during high-pop allowing them to trade at up to a 1:4 marine to xeno ratio when each marine is worth just 1/2.5 the xeno. That means at 4 kills (which is on the high end, but not so hard with high population and time dilation) you are taking out 10 marines worth of xenos. Perhaps vests can return with a fresh balance pass to address this.

## Changelog
:cl:
balance: Explosive Vests are no longer in the RO vendor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
