### PR TITLE
autominers aren't acqureable by autolathe, req only

### DIFF
--- a/code/game/objects/machinery/autolathe_datums.dm
+++ b/code/game/objects/machinery/autolathe_datums.dm
@@ -124,11 +124,6 @@ GLOBAL_LIST_EMPTY(autolathe_categories)
 	path = /obj/item/minerupgrade/overclock
 	category = "Engineering"
 
-/datum/autolathe/recipe/miningwellautomation
-	name = "Mining well automation upgrade"
-	path = /obj/item/minerupgrade/automatic
-	category = "Engineering"
-
 /datum/autolathe/recipe/airalarm
 	name = "air alarm electronics"
 	path = /obj/item/circuitboard/airalarm

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -333,6 +333,7 @@
 			/obj/item/ammo_magazine/shotgun/mbx900 = 2,
 			/obj/item/bodybag/tarp = 2,
 			/obj/item/explosive/plastique = 2,
+			/obj/item/minerupgrade/automatic = 3,
 			/obj/item/clothing/suit/storage/marine/harness/boomvest = 20,
 			/obj/item/radio/headset/mainship/marine/alpha = -1,
 			/obj/item/radio/headset/mainship/marine/bravo = -1,

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -166,6 +166,11 @@ OPERATIONS
 	containertype = null
 	available_against_xeno_only = TRUE
 
+/datum/supply_packs/operations/autominer
+	name = "Autominer upgrade"
+	contains = list(/obj/item/minerupgrade/automatic)
+	cost = 15
+
 /*******************************************************************************
 WEAPONS
 *******************************************************************************/


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
marines get 2 free autominers, 15 points for more
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Autominers should not be effectively free.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance:autominers are only acquireable by req
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
