### PR TITLE
Hotkey for Choose Hugger

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -524,6 +524,7 @@
 #define COMSIG_XENOABILITY_RETRIEVE_EGG "xenoability_retrieve_egg"
 #define COMSIG_XENOABILITY_PLACE_TRAP "xenoability_place_trap"
 #define COMSIG_XENOABILITY_SPAWN_HUGGER "xenoability_spawn_hugger"
+#define COMSIG_XENOABILITY_CHOOSE_HUGGER_TYPE "xenoability_chooose_hugger_type"
 
 #define COMSIG_XENOABILITY_STOMP "xenoability_stomp"
 #define COMSIG_XENOABILITY_TOGGLE_CHARGE "xenoability_toggle_charge"

--- a/code/datums/keybinding/xeno.dm
+++ b/code/datums/keybinding/xeno.dm
@@ -177,6 +177,12 @@
 	description = ""
 	keybind_signal = COMSIG_XENOABILITY_SPAWN_HUGGER
 
+/datum/keybinding/xeno/choose_hugger
+	name = "choose_hugger"
+	full_name = "Carrier: Choose Hugger"
+	description = "Cycles the hugger type you will deploy with the Throw Hugger ability."
+	keybind_signal = COMSIG_XENOABILITY_CHOOSE_HUGGER_TYPE
+
 /datum/keybinding/xeno/stomp
 	name = "stomp"
 	full_name = "Crusher: Stomp"

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
@@ -220,7 +220,7 @@ GLOBAL_LIST_INIT(hugger_type_list, typecacheof(list(
 	name = "Choose Hugger Type"
 	action_icon_state = "facehugger"
 	mechanics_text = "Selects which hugger type you will build with the Spawn Hugger ability."
-	//keybind_signal = COMSIG_XENOABILITY_CHOOSE_RESIN
+	keybind_signal = COMSIG_XENOABILITY_CHOOSE_HUGGER_TYPE
 
 /datum/action/xeno_action/choose_hugger_type/give_action(mob/living/L)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Adds a hotkey bind to cycle through hugger types for the Carrier caste.

## Why It's Good For The Game

Adds a hotkey bind to cycle through hugger types for the Carrier caste.

## Changelog
:cl:
qol: Adds a hotkey bind to cycle through hugger types for the Carrier caste.
/:cl:
