### PR TITLE
Fix shooting behind with autofire

### DIFF
--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -512,8 +512,6 @@ User can be passed as null, (a gun reloading itself for instance), so we need to
 		dual_wield = TRUE
 	if(gun_user.in_throw_mode)
 		return
-	if(gun_user.Adjacent(object)) //Dealt with by attack code
-		return
 	if(QDELETED(object))
 		return
 	var/list/modifiers = params2list(params)
@@ -537,6 +535,8 @@ User can be passed as null, (a gun reloading itself for instance), so we need to
 
 ///Set the target and take care of hard delete
 /obj/item/weapon/gun/proc/set_target(atom/object)
+	if(gun_user.Adjacent(object))
+		return
 	if(object == target)
 		return
 	if(target)
@@ -665,7 +665,7 @@ and you're good to go.
 //----------------------------------------------------------
 
 /obj/item/weapon/gun/proc/Fire()
-	if(QDELETED(gun_user) || !ismob(gun_user) || !able_to_fire(gun_user) || !target)
+	if(QDELETED(gun_user) || !ismob(gun_user) || !able_to_fire(gun_user) || !target || gun_user.Adjacent(target))
 		return
 
 	//The gun should return the bullet that it already loaded from the end cycle of the last Fire().


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes this : 

https://user-images.githubusercontent.com/25491240/122566660-17c5e500-d048-11eb-9926-84a9b31274c4.mp4

Makes it so you can no longer shoot on your own tile (which can lead to shoot behind you if you are walking)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's not perfect, but i think it's better to prevent firing behind than what is currently is.

Don't think i can do better because of byond

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fix bug that caused people to shoot behind them while running
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
