### PR TITLE
The AI can now buy things.

### DIFF
--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -539,7 +539,9 @@
 			if(!istype(R) || !R.product_path || R.amount == 0)
 				return
 
-			if(R.price == null)
+			if(isAI(usr))
+				vend(R, usr)
+			else if(R.price == null)
 				vend(R, usr)
 			else
 				currently_vending = R


### PR DESCRIPTION
## About The Pull Request
No money concerns for lighters. Nanotrasen trusts that no AI's will abuse this. Because they can't. Nothing powerful is behind money, just fluff.

## Why It's Good For The Game
Makes the AI more in control of a couple machines. Better fluff. 
They couldn't at all before.

## Changelog
:cl:
qol: The AI can now vend from MONEY restricted vendors.
/:cl:

