### PR TITLE
Make it so the OB beacons always have squad or human name tied to them.

### DIFF
--- a/code/game/objects/machinery/squad_supply/supply_beacon.dm
+++ b/code/game/objects/machinery/squad_supply/supply_beacon.dm
@@ -92,7 +92,6 @@
 	icon_activated = "motion1"
 	///The squad this OB beacon belongs to
 	var/datum/squad/squad = null
-	var/alt_name = null
 
 /obj/item/beacon/orbital_bombardment_beacon/activate(mob/living/carbon/human/H)
 	. = ..()
@@ -102,10 +101,10 @@
 		squad = H.assigned_squad
 		name += " ([squad.name])"
 		squad.squad_orbital_beacons += src
-	else	//So we can just get a goshdarn name.
-		alt_name = H.name
 		name += " ([H])"
-		//alt_name.squad_orbital_beacons += src
+		return
+	else	//So we can just get a goshdarn name.
+		name += " ([H])"
 
 /obj/item/beacon/orbital_bombardment_beacon/deactivate(mob/living/carbon/human/H)
 	. = ..()
@@ -163,14 +162,14 @@
 	var/faction = ""
 
 /datum/supply_beacon/New(_name, turf/_drop_location, _faction, life_time = 0 SECONDS)
-	name= _name 
-	drop_location = _drop_location	
+	name= _name
+	drop_location = _drop_location
 	faction = _faction
 	GLOB.supply_beacon[name] = src
 	if(life_time)
 		addtimer(CALLBACK(src, .proc/qdel), life_time)
 
-/// Remove that beacon from the list of glob supply beacon 
+/// Remove that beacon from the list of glob supply beacon
 /datum/supply_beacon/Destroy()
 	GLOB.supply_beacon[name] = null
 	return ..()

--- a/code/game/objects/machinery/squad_supply/supply_beacon.dm
+++ b/code/game/objects/machinery/squad_supply/supply_beacon.dm
@@ -104,7 +104,7 @@
 		squad.squad_orbital_beacons += src
 	else	//So we can just get a goshdarn name.
 		alt_name = H.name
-		name += " ([alt_name])"
+		name += " ([H])"
 		//alt_name.squad_orbital_beacons += src
 
 /obj/item/beacon/orbital_bombardment_beacon/deactivate(mob/living/carbon/human/H)

--- a/code/game/objects/machinery/squad_supply/supply_beacon.dm
+++ b/code/game/objects/machinery/squad_supply/supply_beacon.dm
@@ -92,6 +92,7 @@
 	icon_activated = "motion1"
 	///The squad this OB beacon belongs to
 	var/datum/squad/squad = null
+	var/alt_name = null
 
 /obj/item/beacon/orbital_bombardment_beacon/activate(mob/living/carbon/human/H)
 	. = ..()
@@ -101,6 +102,10 @@
 		squad = H.assigned_squad
 		name += " ([squad.name])"
 		squad.squad_orbital_beacons += src
+	else	//So we can just get a goshdarn name.
+		alt_name = H.name
+		name += " ([alt_name])"
+		//alt_name.squad_orbital_beacons += src
 
 /obj/item/beacon/orbital_bombardment_beacon/deactivate(mob/living/carbon/human/H)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Make it so the OB beacons always have squad or human name tied to them. Like  
`
Orbital beacon (Mandalore gaming)
`
## Why It's Good For The Game
Hopefully make it easier to avoid some friendly fire accidents.

## Changelog
:cl:
add: Added a new way to ID the beacons
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
