### PR TITLE
Hivemind door open cooldown gets the axe

### DIFF
--- a/code/__DEFINES/cooldowns.dm
+++ b/code/__DEFINES/cooldowns.dm
@@ -31,7 +31,6 @@
 #define COOLDOWN_CLOAK_IMPLANT "cloak_implant"
 #define COOLDOWN_DRONE_CLOAK "drone_cloak"
 #define COOLDOWN_XENO_TURRETS_ALERT "xeno_turrets_alert"
-#define COOLDOWN_HIVEMIND_DOOR "hivemind_manipulate_door"
 #define COOLDOWN_PARALYSE_ACID "acid_spray_paralyse"
 #define COOLDOWN_RELAY_MOVE "remote_relay_moves"
 #define COOLDOWN_PROJECTOR_LIGHT "projector_light"

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
@@ -117,21 +117,17 @@
 /mob/living/carbon/xenomorph/hivemind/CtrlClick(mob/user)
 	return FALSE
 
-/mob/living/carbon/xenomorph/hivemind/CtrlClickOn(atom/A)
-	return FALSE
-
 /mob/living/carbon/xenomorph/hivemind/CtrlShiftClickOn(atom/A)
 	return FALSE
 
 /mob/living/carbon/xenomorph/hivemind/CtrlClickOn(atom/A)
+	if(istype(A, /obj/structure/mineral_door/resin))
+		var/obj/structure/mineral_door/resin/door = A
+		door.TryToSwitchState(src)
 	return FALSE
 
 /mob/living/carbon/xenomorph/hivemind/AltClickOn(atom/A)
 	if(istype(A, /obj/structure/mineral_door/resin))
-		if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_HIVEMIND_DOOR))
-			to_chat(src, "<span class='xenonotice'>You manipulated a door too recently, wait a bit more!</span>")
-			return
-		TIMER_COOLDOWN_START(src, COOLDOWN_HIVEMIND_DOOR, 5 SECONDS)
 		var/obj/structure/mineral_door/resin/door = A
 		door.TryToSwitchState(src)
 	return FALSE


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See changelog.

## Why It's Good For The Game

Doors are weak and needing to wait to close them as hivemind is just garbage. Will not make doors "over powered" for trapping marines (unless they are dumb enough to rush past a ton of open ones anyway), and just gives them an extra incentive to blow up or burn doors before crossing or hunt down the hivemind dedicating its time to playing antimov AI with doors.

## Changelog
:cl:
balance: Hivemind resin door manipulation cooldown is gone.
qol: Hivemind can now open and close doors with Ctrl+Click as well as Alt+Click.
fix: Fixed a duplicate proc override for /xenomorph/hivemind/
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
