### PR TITLE
Fix OB beacons being activatable on dropships like Alamo

### DIFF
--- a/code/game/objects/machinery/squad_supply/supply_beacon.dm
+++ b/code/game/objects/machinery/squad_supply/supply_beacon.dm
@@ -34,6 +34,9 @@
 	if(A && istype(A) && A.ceiling >= CEILING_DEEP_UNDERGROUND)
 		to_chat(H, "<span class='warning'>This won't work if you're standing deep underground.</span>")
 		return FALSE
+	if(istype(A, /area/shuttle/dropship))
+		to_chat(H, "<span class='warning'>You have to be outside the dropship to use this or it won't transmit.</span>")
+		return FALSE
 	var/delay = max(1.5 SECONDS, activation_time - 2 SECONDS * H.skills.getRating("leadership"))
 	H.visible_message("<span class='notice'>[H] starts setting up [src] on the ground.</span>",
 	"<span class='notice'>You start setting up [src] on the ground and inputting all the data it needs.</span>")


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a check for `/area/shuttle/dropship` when activating because just checking the z level is not enough it seems when that can change by going groundside. An alternate solution is to have them auto de-activate in an `onShuttleMove()` override.

## Why It's Good For The Game

OB beacons are meant to be used "on the planet" and as such the only way to get one planted on the Alamo is to fly it groundside first then attempt to plant a beacon, however that beacon stays activated even after hijack for funny dropship OB memes. This change rectifies that.

## Changelog
:cl:
fix: Fixed OB beacons being activatable on dropships.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
