### PR TITLE
Fixes Right Click Mode for Xenos

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -334,7 +334,7 @@ if(selected_ability.target_flags & flagname){\
 		if(selected_ability.can_use_ability(A))
 			selected_ability.use_ability(A)
 			return TRUE
-	. = ..()
+	return ..()
 
 /*
 	Right click

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -329,12 +329,12 @@ if(selected_ability.target_flags & flagname){\
 		selected_ability.use_ability(A)
 
 /mob/living/carbon/xenomorph/RightClickOn(atom/A)
+	. = ..()
 	if(selected_ability) //If we have a selected ability that we can use, return TRUE
 		A = ability_target(A)
 		if(selected_ability.can_use_ability(A))
 			selected_ability.use_ability(A)
 			return TRUE
-	return ..()
 
 /*
 	Right click

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -329,12 +329,12 @@ if(selected_ability.target_flags & flagname){\
 		selected_ability.use_ability(A)
 
 /mob/living/carbon/xenomorph/RightClickOn(atom/A)
+	if(selected_ability) //If we have a selected ability that we can use, return TRUE
+		A = ability_target(A)
+		if(selected_ability.can_use_ability(A))
+			selected_ability.use_ability(A)
+			return TRUE
 	. = ..()
-	if(!selected_ability)
-		return FALSE
-	A = ability_target(A)
-	if(selected_ability.can_use_ability(A))
-		selected_ability.use_ability(A)
 
 /*
 	Right click

--- a/code/_onclick/xeno.dm
+++ b/code/_onclick/xeno.dm
@@ -3,10 +3,7 @@
 		return FALSE
 
 	if(!isturf(A)) //We don't care about turfs; they don't trigger our melee click cooldown
-		if(xeno_caste)
-			changeNext_move(xeno_caste.attack_delay)
-		else
-			changeNext_move(CLICK_CD_MELEE)
+		changeNext_move(xeno_caste ? xeno_caste.attack_delay : CLICK_CD_MELEE)
 
 	var/atom/S = A.handle_barriers(src)
 	S.attack_alien(src, isrightclick = islist(modifiers) ? modifiers["right"] : FALSE)

--- a/code/_onclick/xeno.dm
+++ b/code/_onclick/xeno.dm
@@ -2,7 +2,7 @@
 	if(lying_angle)
 		return FALSE
 
-	if(!isturf(A)) //We don't care about turfs; they don't trigger our melee click cooldown
+	if(!isopenturf(A)) //We don't care about open turfs; they don't trigger our melee click cooldown
 		changeNext_move(xeno_caste ? xeno_caste.attack_delay : CLICK_CD_MELEE)
 
 	var/atom/S = A.handle_barriers(src)

--- a/code/_onclick/xeno.dm
+++ b/code/_onclick/xeno.dm
@@ -2,10 +2,11 @@
 	if(lying_angle)
 		return FALSE
 
-	if(xeno_caste)
-		changeNext_move(xeno_caste.attack_delay)
-	else
-		changeNext_move(CLICK_CD_MELEE)
+	if(!isturf(A)) //We don't care about turfs; they don't trigger our melee click cooldown
+		if(xeno_caste)
+			changeNext_move(xeno_caste.attack_delay)
+		else
+			changeNext_move(CLICK_CD_MELEE)
 
 	var/atom/S = A.handle_barriers(src)
 	S.attack_alien(src, isrightclick = islist(modifiers) ? modifiers["right"] : FALSE)


### PR DESCRIPTION
## About The Pull Request

Fixes Right Click mode for Xenos so that it doesn't try to auto-attack at the same time it uses an ability (thus triggering bump slash cooldowns).

Also stops turf targeting with melee attacks from triggering bump slash cooldowns.

## Why It's Good For The Game

Fixes Right Click mode for Xenos so that it doesn't try to auto-attack at the same time it uses an ability (thus triggering bump slash cooldowns). This will allow things like the Wraith's Blink to be used much more fluidly with bump attacks and slashes in general.

Also stops turf targeting with melee attacks from triggering bump slash cooldowns.

## Changelog
:cl:
fix: Fixes Right Click mode for Xenos so that it doesn't try to attack at the same time it uses an ability (thus triggering click/bump slash cooldowns).
fix: Turf targeting with melee attacks no longer triggers click/bump slash cooldowns.
/:cl: