### PR TITLE
Cleans up some code to do with hunter stealth and pouncing, stealth cd starts at exit

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -388,6 +388,7 @@
 	#define COMSIG_ACCURATE_ZONE (1<<0)
 
 #define COMSIG_XENOMORPH_POUNCE "xenomorph_pounce"
+#define COMSIG_XENOMORPH_POUNCE_END "xenomorph_pounce_end"
 
 #define COMSIG_XENOMORPH_HEADBITE "headbite"
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -47,7 +47,7 @@
 
 /datum/action/xeno_action/stealth/remove_action(mob/living/L)
 	UnregisterSignal(L, list(
-		COMSIG_XENOMORPH_POUNCE,
+		COMSIG_XENOMORPH_POUNCE_END,
 		COMSIG_XENO_LIVING_THROW_HIT,
 		COMSIG_XENOMORPH_ATTACK_LIVING,
 		COMSIG_XENOMORPH_DISARM_HUMAN,

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -19,7 +19,7 @@
 	RegisterSignal(L, COMSIG_XENOMORPH_POUNCE_END, .proc/sneak_attack_pounce)
 	RegisterSignal(L, COMSIG_XENO_LIVING_THROW_HIT, .proc/mob_hit)
 	RegisterSignal(L, COMSIG_XENOMORPH_ATTACK_LIVING, .proc/sneak_attack_slash)
-	RegisterSignal(L, COMSIG_XENOMORPH_DISARM_HUMAN, .proc/sneak_attack_disarm)
+	RegisterSignal(L, COMSIG_XENOMORPH_DISARM_HUMAN, .proc/sneak_attack_slash)
 	RegisterSignal(L, COMSIG_XENOMORPH_ZONE_SELECT, .proc/sneak_attack_zone)
 	RegisterSignal(L, COMSIG_XENOMORPH_PLASMA_REGEN, .proc/plasma_regen)
 
@@ -166,27 +166,6 @@
 		to_chat(owner, "<span class='xenodanger'>Pouncing from the shadows, we stagger our victim.</span>")
 
 /datum/action/xeno_action/stealth/proc/sneak_attack_slash(datum/source, mob/living/target, damage, list/damage_mod, list/armor_mod)
-	SIGNAL_HANDLER
-	if(!stealth || !can_sneak_attack)
-		return
-
-	var/staggerslow_stacks = 2
-	var/flavour
-	if(owner.m_intent == MOVE_INTENT_RUN && ( owner.last_move_intent > (world.time - HUNTER_SNEAK_ATTACK_RUN_DELAY) ) ) //Allows us to slash while running... but only if we've been stationary for awhile
-		flavour = "vicious"
-	else
-		armor_mod += HUNTER_SNEAK_SLASH_ARMOR_PEN
-		staggerslow_stacks *= 2
-		flavour = "deadly"
-
-	owner.visible_message("<span class='danger'>\The [owner] strikes [target] with [flavour] precision!</span>", \
-	"<span class='danger'>We strike [target] with [flavour] precision!</span>")
-	target.adjust_stagger(staggerslow_stacks)
-	target.add_slowdown(staggerslow_stacks)
-
-	cancel_stealth()
-
-/datum/action/xeno_action/stealth/proc/sneak_attack_disarm(datum/source, mob/living/target, damage, list/damage_mod, list/armor_mod)
 	SIGNAL_HANDLER
 	if(!stealth || !can_sneak_attack)
 		return

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -87,6 +87,8 @@
 /datum/action/xeno_action/activable/pounce/proc/pounce_complete()
 	SIGNAL_HANDLER
 	UnregisterSignal(owner, list(COMSIG_XENO_OBJ_THROW_HIT, COMSIG_MOVABLE_POST_THROW, COMSIG_XENO_LIVING_THROW_HIT))
+	var/mob/living/carbon/xenomorph/X = owner
+	SEND_SIGNAL(X, COMSIG_XENOMORPH_POUNCE_END)
 
 /datum/action/xeno_action/activable/pounce/proc/obj_hit(datum/source, obj/target, speed)
 	SIGNAL_HANDLER

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -87,8 +87,7 @@
 /datum/action/xeno_action/activable/pounce/proc/pounce_complete()
 	SIGNAL_HANDLER
 	UnregisterSignal(owner, list(COMSIG_XENO_OBJ_THROW_HIT, COMSIG_MOVABLE_POST_THROW, COMSIG_XENO_LIVING_THROW_HIT))
-	var/mob/living/carbon/xenomorph/X = owner
-	SEND_SIGNAL(X, COMSIG_XENOMORPH_POUNCE_END)
+	SEND_SIGNAL(owner, COMSIG_XENOMORPH_POUNCE_END)
 
 /datum/action/xeno_action/activable/pounce/proc/obj_hit(datum/source, obj/target, speed)
 	SIGNAL_HANDLER


### PR DESCRIPTION
There's code in place for pouncing someone while stealthed, but it never got reached due to the relevant destealth signal firing at pounce start instead of end. It's more or less nothing (1 slowdown 3 stagger) since hunter already inherits runner's 2 second paralyze regardless of stealth.

Also cleans up some duplicate code (attacking out of stealth with harm and disarm intent is line for line identical) and some code that wouldn't be reached (once you unstealth via pounce you can't sneak attack).

Nerfs hunter stealth by making the five second cooldown start when you leave stealth instead of only having a cooldown when you first enter it and when you deactivate it manually, which was weird. Thoughts on this welcome, given its use and plasma cost I'm not sure the cooldown matters at all.

:cl:
fix: Hunter pounce out of stealth now correctly gets its tiny sneak attack bonus
code: Misc. hunter stealth code cleanup
balance: Hunter stealth cooldown starts on leaving stealth.
/:cl:
