### PR TITLE
Port tgui input list improvements

### DIFF
--- a/code/modules/tgui/tgui_input_list.dm
+++ b/code/modules/tgui/tgui_input_list.dm
@@ -82,12 +82,16 @@
 	src.message = message
 	src.buttons = list()
 	src.buttons_map = list()
+	var/list/repeat_buttons = list()
 
 	// Gets rid of illegal characters
 	var/static/regex/whitelistedWords = regex(@{"([^\u0020-\u8000]+)"})
 
 	for(var/i in buttons)
 		var/string_key = whitelistedWords.Replace("[i]", "")
+
+		//avoids duplicated keys E.g: when areas have the same name
+		string_key = avoid_assoc_duplicate_keys(string_key, repeat_buttons)
 
 		src.buttons += string_key
 		src.buttons_map[string_key] = i

--- a/tgui/packages/tgui/interfaces/ListInput.js
+++ b/tgui/packages/tgui/interfaces/ListInput.js
@@ -7,10 +7,8 @@
 import { clamp01 } from 'common/math';
 import { useBackend, useLocalState } from '../backend';
 import { Box, Button, Section, Input, Stack } from '../components';
+import { KEY_DOWN, KEY_UP, KEY_ENTER, KEY_SPACE } from 'common/keycodes';
 import { Window } from '../layouts';
-
-const ARROW_KEY_UP = 38;
-const ARROW_KEY_DOWN = 40;
 
 let lastScrollTime = 0;
 
@@ -48,9 +46,9 @@ export const ListInput = (props, context) => {
     }
     lastScrollTime = performance.now() + 125;
 
-    if (e.keyCode === ARROW_KEY_UP || e.keyCode === ARROW_KEY_DOWN) {
+    if (e.keyCode === KEY_UP || e.keyCode === KEY_DOWN) {
       let direction = 1;
-      if (e.keyCode === ARROW_KEY_UP) direction = -1;
+      if (e.keyCode === KEY_UP) direction = -1;
 
       let index = 0;
       for (index; index < buttons.length; index++) {
@@ -62,6 +60,11 @@ export const ListInput = (props, context) => {
       setSelectedButton(buttons[index]);
       setLastCharCode(null);
       document.getElementById(buttons[index]).focus();
+      return;
+    }
+
+    if (e.keyCode === KEY_SPACE || e.keyCode === KEY_ENTER) {
+      act("choose", { choice: selectedButton });
       return;
     }
 


### PR DESCRIPTION

## About The Pull Request

Port of https://github.com/tgstation/tgstation/pull/59668

## Why It's Good For The Game

Better tgui lists.

## Changelog
:cl: jupyterkat, Wayland-Smithy
qol: you can now press space or enter to select in tgui input lists
fix: tgui input lists no longer break when duplicate keys are passed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
