### PR TITLE
Improves fences

### DIFF
--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -7,7 +7,7 @@
 	throwpass = TRUE //So people and xenos can shoot through!
 	anchored = TRUE //We can not be moved.
 	layer = WINDOW_LAYER
-	max_integrity = 200 //Its cheap but still viable to repair, cant be moved around, about 7 runner hits to take down
+	max_integrity = 150 //Its cheap but still viable to repair, cant be moved around, about 7 runner hits to take down
 	resistance_flags = XENO_DAMAGEABLE
 	minimap_color = MINIMAP_FENCE
 	var/cut = FALSE //Cut fences can be passed through
@@ -20,9 +20,9 @@
 		if(EXPLODE_DEVASTATE)
 			deconstruct(FALSE)
 		if(EXPLODE_HEAVY)
-			take_damage(rand(175, 225))//Almost broken or half way
+			take_damage(rand(100, 125))//Almost broken or half way
 		if(EXPLODE_LIGHT)
-			take_damage(rand(125, 175))
+			take_damage(rand(50, 75))
 
 /obj/structure/fence/attackby(obj/item/I, mob/user, params)
 	. = ..()

--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -13,6 +13,7 @@
 	var/cut = FALSE //Cut fences can be passed through
 	var/junction = 0 //Because everything is terrible, I'm making this a fence-level var
 	var/basestate = "fence"
+	coverage = 0 //Were like 4 rods
 	//We dont have armor do to being a bit more healthy!
 
 /obj/structure/fence/ex_act(severity)
@@ -36,9 +37,9 @@
 				return
 
 		var/obj/item/stack/rods/R = I
-		var/amount_needed = 2
+		var/amount_needed = 4
 		if(obj_integrity)
-			amount_needed = 1
+			amount_needed = 4
 
 		if(R.amount < amount_needed)
 			to_chat(user, "<span class='warning'>You need more metal rods to repair [src].")

--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -21,9 +21,9 @@
 		if(EXPLODE_DEVASTATE)
 			deconstruct(FALSE)
 		if(EXPLODE_HEAVY)
-			take_damage(rand(125, 200)//Almost broken or half way
+			take_damage(rand(175, 225))//Almost broken or half way
 		if(EXPLODE_LIGHT)
-			take_damage(rand(55, 75)
+			take_damage(rand(125, 175))
 
 /obj/structure/fence/attackby(obj/item/I, mob/user, params)
 	. = ..()

--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -7,14 +7,13 @@
 	throwpass = TRUE //So people and xenos can shoot through!
 	anchored = TRUE //We can not be moved.
 	layer = WINDOW_LAYER
-	max_integrity = 250 //Its cheap but still viable to repair, cant be moved around, about 7 runner hits to take down
+	max_integrity = 200 //Its cheap but still viable to repair, cant be moved around, about 7 runner hits to take down
 	resistance_flags = XENO_DAMAGEABLE
 	minimap_color = MINIMAP_FENCE
 	var/cut = FALSE //Cut fences can be passed through
 	var/junction = 0 //Because everything is terrible, I'm making this a fence-level var
 	var/basestate = "fence"
-	//Form metal grills and then nerfed a bit
-	soft_armor = list("melee" = 20, "bullet" = 10, "laser" = 70, "energy" = 90, "bomb" = 10, "bio" = 50, "rad" = 100, "fire" = 0, "acid" = 0)
+	//We dont have armor do to being a bit more healthy!
 
 /obj/structure/fence/ex_act(severity)
 	switch(severity)

--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -4,25 +4,26 @@
 	icon = 'icons/obj/structures/fence.dmi'
 	icon_state = "fence0"
 	density = TRUE
-	anchored = TRUE
+	throwpass = TRUE //So people and xenos can shoot through!
+	anchored = TRUE //We can not be moved.
 	layer = WINDOW_LAYER
-	max_integrity = 100
+	max_integrity = 250 //Its cheap but still viable to repair, cant be moved around, about 7 runner hits to take down
 	resistance_flags = XENO_DAMAGEABLE
 	minimap_color = MINIMAP_FENCE
 	var/cut = FALSE //Cut fences can be passed through
 	var/junction = 0 //Because everything is terrible, I'm making this a fence-level var
 	var/basestate = "fence"
-
+	//Form metal grills and then nerfed a bit
+	soft_armor = list("melee" = 20, "bullet" = 10, "laser" = 70, "energy" = 90, "bomb" = 10, "bio" = 50, "rad" = 100, "fire" = 0, "acid" = 0)
 
 /obj/structure/fence/ex_act(severity)
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
 			deconstruct(FALSE)
 		if(EXPLODE_HEAVY)
-			deconstruct(FALSE)
+			take_damage(rand(125, 200)//Almost broken or half way
 		if(EXPLODE_LIGHT)
-			take_damage(rand(25, 55))
-
+			take_damage(rand(55, 75)
 
 /obj/structure/fence/attackby(obj/item/I, mob/user, params)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Those map start broken fences are now less horrible. How are they bad?
Despite making only of rods, they could not be shot past... Why? No idea... Likely a oversight, this has now been corrected!
Bombs are less likely to end fences life
Fences now have a bit more HP to reflect on that they are used
Also shocking fences even tho they are made out of rods, the same ones that make grills had no armor.
Thus giving them a small bit of armor similar to grills would help make them ever more consistent 
Ups the amout of rods needed to 4 as thats how many the sprite has
## Why It's Good For The Game

No one ever fixes these and for good reason, they harm everyone by blocking fire, taking metal and being unmovable.
If there is ever, EVER a reason repair them its for looks as they are right now as a xeno can safely without being shot brake them.

## Changelog
:cl:
balance: Fences now need 4 rods rather then 2.
balance: Repaired fences are now a bit harder to brake
fix: Repaired fences are no longer bullet/acid sponges
/:cl:
