### PR TITLE
Rephrases a codex entry to clarify attachment burst_scatter_mod

### DIFF
--- a/code/modules/codex/entries/weapons_codex.dm
+++ b/code/modules/codex/entries/weapons_codex.dm
@@ -46,7 +46,7 @@
 	if(damage_falloff_mod)
 		attach_strings += "Damage falloff: [damage_falloff_mod * 100]%"
 	if(burst_scatter_mod)
-		attach_strings += "Scatter chance: [burst_scatter_mod * 100]%"
+		attach_strings += "Burst scatter multiplier: [burst_scatter_mod]"
 	if(silence_mod)
 		attach_strings += "This can silence the weapon if it is attached."
 	if(light_mod)


### PR DESCRIPTION
Because a vertical grip doesn't actually reduce scatter chance by 100%. burst_scatter_mod is multiplied by burst size to determine additional scatter for non-semiauto fire.
Fixes #6522 

## Changelog
:cl:
spellcheck: Rephrased codex entries for attachments with burst scatter modifiers
/:cl: