### PR TITLE
Psy points output depends on the number of players

### DIFF
--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -127,12 +127,22 @@
 #define SILO_PRICE 800
 #define XENO_TURRET_PRICE 100
 #define XENO_KING_PRICE 1800
-//How many psych point one gen gives per person on the server
-#define BASE_PSYCH_POINT_OUTPUT 0.008
-//How many psy points are gave for each marine psy drained
-#define PSY_DRAIN_REWARD 60
-//How many psy points are gave every 5 second by a cocoon
-#define COCOON_PSY_POINTS_REWARD 2
+
+//How many psych point one gen gives every second
+#define GENERATOR_PSYCH_POINT_OUTPUT 0.03
+//How many psy points are gave for each marine psy drained at low pop
+#define PSY_DRAIN_REWARD_MAX 80
+//How many psy points are gave for each marine psy drained at high pop
+#define PSY_DRAIN_REWARD_MIN 30
+//How many psy points are gave every 5 second by a cocoon at low pop
+#define COCOON_PSY_POINTS_REWARD_MAX 2.6
+//How many psy points are gave every 5 second by a cocoon at high pop
+#define COCOON_PSY_POINTS_REWARD_MIN 1
+
+//The pop considered to be medium marine pop for the psy points calculation
+#define MEDIUM_MARINE_POP 40
+
+
 
 #define INVOKE_KING_TIME_LOCK 1 HOURS
 

--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -131,16 +131,16 @@
 //How many psych point one gen gives every second
 #define GENERATOR_PSYCH_POINT_OUTPUT 0.03
 //How many psy points are gave for each marine psy drained at low pop
-#define PSY_DRAIN_REWARD_MAX 80
+#define PSY_DRAIN_REWARD_MAX 90
 //How many psy points are gave for each marine psy drained at high pop
 #define PSY_DRAIN_REWARD_MIN 30
 //How many psy points are gave every 5 second by a cocoon at low pop
-#define COCOON_PSY_POINTS_REWARD_MAX 2.6
+#define COCOON_PSY_POINTS_REWARD_MAX 3
 //How many psy points are gave every 5 second by a cocoon at high pop
 #define COCOON_PSY_POINTS_REWARD_MIN 1
 
 //The pop considered to be medium marine pop for the psy points calculation
-#define MEDIUM_MARINE_POP 40
+#define MEDIUM_MARINE_POP 50
 
 
 

--- a/code/game/objects/items/cocoon.dm
+++ b/code/game/objects/items/cocoon.dm
@@ -15,8 +15,6 @@
 	var/mob/living/victim
 	///How much time the cocoon takes to deplete the life force of the marine
 	var/cocoon_life_time = 5 MINUTES
-	///How many psych points it is generating every 5 seconds
-	var/psych_points_output = COCOON_PSY_POINTS_REWARD
 	///Standard busy check
 	var/busy = FALSE
 	///How much larva points it gives at the end of its life time (8 points for one larva in distress)
@@ -41,6 +39,8 @@
 		to_chat(user, "<span class='notice'>There seems to be someone inside it. You think you can open it with a sharp object.</span>")
 
 /obj/structure/cocoon/process()
+	var/psych_points_output = COCOON_PSY_POINTS_REWARD_MIN + (MEDIUM_MARINE_POP - length(GLOB.humans_by_zlevel["2"]) / MEDIUM_MARINE_POP * (COCOON_PSY_POINTS_REWARD_MAX - COCOON_PSY_POINTS_REWARD_MIN))
+	psych_points_output = clamp(psych_points_output, COCOON_PSY_POINTS_REWARD_MIN, COCOON_PSY_POINTS_REWARD_MAX)
 	SSpoints.add_psy_points(hivenumber, psych_points_output)
 
 /obj/structure/cocoon/take_damage(damage_amount, damage_type, damage_flag, effects, attack_dir, armour_penetration)

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1233,8 +1233,6 @@
 	keybind_signal = COMSIG_XENOABILITY_HEADBITE
 	gamemode_flags = ABILITY_DISTRESS
 	plasma_cost = 100
-	///How much psy points it give
-	var/psy_points_reward = PSY_DRAIN_REWARD
 	///How much larva points it gives (8 points for one larva in distress)
 	var/larva_point_reward = 1
 
@@ -1301,7 +1299,8 @@
 	ADD_TRAIT(victim, TRAIT_PSY_DRAINED, TRAIT_PSY_DRAINED)
 	if(HAS_TRAIT(victim, TRAIT_UNDEFIBBABLE))
 		victim.med_hud_set_status()
-
+	var/psy_points_reward = PSY_DRAIN_REWARD_MIN + (MEDIUM_MARINE_POP - length(GLOB.humans_by_zlevel["2"]) / MEDIUM_MARINE_POP * (PSY_DRAIN_REWARD_MAX - PSY_DRAIN_REWARD_MIN))
+	psy_points_reward = clamp(psy_points_reward, PSY_DRAIN_REWARD_MIN, PSY_DRAIN_REWARD_MAX)
 	SSpoints.add_psy_points(X.hivenumber, psy_points_reward)
 	var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
 	xeno_job.add_job_points(larva_point_reward, COCOON_ORIGIN)

--- a/code/modules/power/groundmap_geothermal.dm
+++ b/code/modules/power/groundmap_geothermal.dm
@@ -89,8 +89,8 @@
 	start_processing()
 
 /obj/machinery/power/geothermal/process()
-	if(corrupted && corruption_on)
-		SSpoints.add_psy_points("[corrupted]", length(GLOB.humans_by_zlevel["2"]) * BASE_PSYCH_POINT_OUTPUT * corrupt_point_factor)
+	if(corrupted && corruption_on && length(GLOB.humans_by_zlevel["2"]) > 0.2 * length(GLOB.alive_human_list))
+		SSpoints.add_psy_points("[corrupted]", GENERATOR_PSYCH_POINT_OUTPUT * corrupt_point_factor)
 		return
 	if(!is_on || buildstate || !anchored || !powernet) //Default logic checking
 		return PROCESS_KILL


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Continuation of the last distress rework:

The number of psy points generated by cocoon and psy drain is now linked with the number of players.

The more marines are on the ground, the less points these abilities gives.

On the contrary, generator output will now be independant of the number of marines, as long as some marines are on the ground

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Since the output of silo is now proportional of the number of marines on the ground, not compensating on the psy points output means that small hive will have issues having new silos, while big hive will have a ton of silo

This is an issue, because big hive will have way more larva proportionally than small hives.

This solution is not perfect, but it's better than nothing

## Changelog
:cl:
balance: The number of psy points generated by cocoon and psy drain is now linked with the number of players. The more marines are on the ground, the less points these abilities gives.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
