### PR TITLE
Fixes rogue beach tile on Prison Station

### DIFF
--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -43019,11 +43019,6 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/space/sea,
 /area/space)
-"ogQ" = (
-/turf/open/ground/coast{
-	dir = 8
-	},
-/area/prison/residential/north)
 "oie" = (
 /turf/open/floor/prison/darkred,
 /area/prison/security/monitoring/highsec)
@@ -56047,7 +56042,7 @@ azg
 avN
 aCa
 aDJ
-ogQ
+aBV
 aBV
 aBV
 aBV


### PR DESCRIPTION


## About The Pull Request

removes a random beach tile where it shouldn't be on prison station

## Why It's Good For The Game

muh immursons

## Changelog
:cl:

fix: a rogue beach tile on prison station have been captured and sent to centcom for study

/:cl:

