### PR TITLE
Fix runtime when xeno are gibbed

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/update_icons.dm
+++ b/code/modules/mob/living/carbon/xenomorph/update_icons.dm
@@ -100,6 +100,8 @@
 	return I
 
 /mob/living/carbon/xenomorph/proc/update_wounds()
+	if(QDELETED(src))
+		return
 	var/health_thresholds
 	wound_overlay.layer = layer + 0.3
 	if(health > health_threshold_crit)


### PR DESCRIPTION
Fix a runtime that happened when xeno were gibbed, and still tried to update wound overlay
