### PR TITLE
Fixes Defiler Emit Gas so That Last Puff is Actually Larger as Intended

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
@@ -119,7 +119,7 @@
 		if(count > 1)
 			N.set_up(smoke_range, T)
 		else //last emission is larger
-			N.set_up(round(smoke_range*1.3), T)
+			N.set_up(CEILING(smoke_range*1.3,1), T)
 		N.start()
 		T.visible_message("<span class='danger'>Noxious smoke billows from the hulking xenomorph!</span>")
 		count = max(0,count - 1)


### PR DESCRIPTION
## About The Pull Request

Fixes Defiler Emit Gas so That Last Puff is Actually Larger as Intended.

Despite the obvious intent of the comments, the smoke size is always rounded down, so the last puff never achieves the intended increment in size.

## Why It's Good For The Game

Fixes Defiler Emit Gas so That Last Puff is Actually Larger as Intended; bug fix.

## Changelog
:cl:
fix: Emit Noxious Gas's last puff is now larger as previously intended.
/:cl: