### PR TITLE
Slight RR buff.

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1182,7 +1182,7 @@ datum/ammo/bullet/revolver/tp44
 	accuracy = 40
 	accurate_range = 20
 	max_range = 30
-	damage = 100
+	damage = 140
 	penetration = 50
 	sundering = 50
 
@@ -1220,7 +1220,7 @@ datum/ammo/bullet/revolver/tp44
 	accuracy = 40
 	accurate_range = 15
 	max_range = 20
-	damage = 75
+	damage = 90
 	penetration = 50
 	sundering = 25
 


### PR DESCRIPTION
I'm proposing this change as a way to make recoiless rifles slightly more useful, as right now, one shell of high explosive equals four shots out of a standard rifle, with only the sundering and slight explosive impact as very minor advantages over said rifles. The main thing they lacked was damage, thus I have slightly buffed it, notably the LE shell by 15. And HE shell by 40. It had a base 100 damage. For example, a standard sadar shell AP shell does about 325 damage.


## Why It's Good For The Game

Currently recoiless rifles are very, very weak. Speaking from experience, a direct hit with a HE shell will only barely damage a T3, remove maybe a quarter of a T2, and sometimes half of a T1. This is a minor change, however it will make them a somewhat better weapon overall, that isn't beaten by simply using a rifle over it.

## Changelog
:cl:
balance: rebalances the RR rifle to do slightly more damage. 140 instead of a base 100 with HE shells. LE shells do 90 instead of 75 with no changes to anything else.
/:cl:
