### PR TITLE
Hydro Cannon Fix

### DIFF
--- a/code/datums/actions/item_action.dm
+++ b/code/datums/actions/item_action.dm
@@ -117,7 +117,6 @@
 	RegisterSignal(holder_flamer, COMSIG_ITEM_HYDRO_CANNON_TOGGLED, .proc/update_toggle_button_icon)
 
 /datum/action/item_action/toggle_hydro/action_activate()
-	. = ..()
 	holder_flamer.unique_action(owner)
 
 /datum/action/item_action/toggle_hydro/update_button_icon()

--- a/code/datums/actions/item_action.dm
+++ b/code/datums/actions/item_action.dm
@@ -116,8 +116,6 @@
 	holder_flamer = holder_item
 	RegisterSignal(holder_flamer, COMSIG_ITEM_HYDRO_CANNON_TOGGLED, .proc/update_toggle_button_icon)
 
-/datum/action/item_action/toggle_hydro/action_activate()
-	. = ..()
 
 /datum/action/item_action/toggle_hydro/update_button_icon()
 	button.overlays.Cut()

--- a/code/datums/actions/item_action.dm
+++ b/code/datums/actions/item_action.dm
@@ -117,7 +117,7 @@
 	RegisterSignal(holder_flamer, COMSIG_ITEM_HYDRO_CANNON_TOGGLED, .proc/update_toggle_button_icon)
 
 /datum/action/item_action/toggle_hydro/action_activate()
-	holder_flamer.unique_action(owner)
+	. = ..()
 
 /datum/action/item_action/toggle_hydro/update_button_icon()
 	button.overlays.Cut()

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -304,7 +304,9 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	else
 		to_chat(user, "<span class='warning'>[G] must be in our hands to do this.</span>")
 
-
+/obj/item/attachable/hydro_cannon/ui_action_click(mob/living/user, datum/action/item_action/action, obj/item/weapon/gun/G)
+	if(G == user.get_active_held_item() || G == user.get_inactive_held_item())
+		G.unique_action(user)
 
 
 /obj/item/attachable/proc/activate_attachment(mob/user, turn_off) //This is for activating stuff like flamethrowers, or switching weapon modes.

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1746,7 +1746,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	icon_state = ""
 	attach_icon = ""
 	slot = ATTACHMENT_SLOT_UNDER
-	flags_attach_features = ATTACH_ACTIVATION|ATTACH_UTILITY|GUN_ALLOW_SYNTHETIC
+	flags_attach_features = ATTACH_UTILITY|GUN_ALLOW_SYNTHETIC
 	attachment_action_type = /datum/action/item_action/toggle_hydro
 
 /obj/item/attachable/hydro_cannon/activate_attachment(mob/living/user, turn_off)


### PR DESCRIPTION
Fixes the Hydro Cannon

<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes the hydro cannon hud button. Now you can actually activate the hydro cannon by clicking the hud button. It also removes ATTACH_ACTIVATION from the hydro cannon, so the load from attachment verb will no longer toggle the hydro cannon. Unique action and the hud button will now be the only ways to toggle it, but I'm assuming people defaulted to unique action anyways. 
Fixes #6695 

## Why It's Good For The Game
It just works. That's really it, the hud button didn't work before and now it does. 
## Changelog
:cl:
fix: Fixed Hydro Cannon hud button.
refactor: Hydro Cannon only works via unique action and hud button, not load from attachment.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
