### PR TITLE
Fix window weeds not updating after the frame is gone [UTMOST PRIORITY]

### DIFF
--- a/code/game/objects/structures/window_frame.dm
+++ b/code/game/objects/structures/window_frame.dm
@@ -56,10 +56,10 @@
 /obj/structure/window_frame/Destroy()
 	density = FALSE
 	update_nearby_icons()
-	for(var/obj/effect/alien/weeds/weedwall/WW in loc)
-		qdel(WW)
+	var/obj/effect/alien/weeds/weedwall/window_wall_weeds = locate() in loc
+	if(window_wall_weeds)
+		qdel(window_wall_weeds)
 		new /obj/effect/alien/weeds(loc)
-		break
 	return ..()
 
 /obj/structure/window_frame/attackby(obj/item/I, mob/user, params)

--- a/code/game/objects/structures/window_frame.dm
+++ b/code/game/objects/structures/window_frame.dm
@@ -56,6 +56,10 @@
 /obj/structure/window_frame/Destroy()
 	density = FALSE
 	update_nearby_icons()
+	for(var/obj/effect/alien/weeds/weedwall/WW in loc)
+		qdel(WW)
+		new /obj/effect/alien/weeds(loc)
+		break
 	return ..()
 
 /obj/structure/window_frame/attackby(obj/item/I, mob/user, params)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![9ayLZiqPrq](https://user-images.githubusercontent.com/64715958/124051161-d54dc200-d9d0-11eb-89ea-09ce912f15f9.gif)

## Why It's Good For The Game

Annoying guessing game of is there a frame there or not goes away. (except if badmins del windows)

## Changelog
:cl:
fix: Fixed window weeds not updating after the frame is gone.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
