### PR TITLE
Improved Anti-Shuffle Hug so Carrier Allies Don't Reset Jump Timers

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
@@ -80,7 +80,7 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 		F.throw_at(A, CARRIER_HUGGER_THROW_DISTANCE, CARRIER_HUGGER_THROW_SPEED)
 		F.stat = CONSCIOUS //Hugger is conscious
 		F.leaping = FALSE //Hugger is not leaping
-		F.source = X //Set us as the source
+		F.facehugger_register_source(X) //Set us as the source
 		X.visible_message("<span class='xenowarning'>\The [X] throws something towards \the [A]!</span>", \
 		"<span class='xenowarning'>We throw a facehugger towards \the [A]!</span>")
 		add_cooldown()

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
@@ -64,7 +64,7 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 			to_chat(X, "<span class='warning'>We don't have any facehuggers to use!</span>")
 			return fail_activate()
 
-		F = new X.selected_hugger_type(get_turf(X), X.hivenumber)
+		F = new X.selected_hugger_type(get_turf(X), X.hivenumber, X)
 		X.huggers--
 
 		X.put_in_active_hand(F)
@@ -80,6 +80,7 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 		F.throw_at(A, CARRIER_HUGGER_THROW_DISTANCE, CARRIER_HUGGER_THROW_SPEED)
 		F.stat = CONSCIOUS //Hugger is conscious
 		F.leaping = FALSE //Hugger is not leaping
+		F.source = X //Set us as the source
 		X.visible_message("<span class='xenowarning'>\The [X] throws something towards \the [A]!</span>", \
 		"<span class='xenowarning'>We throw a facehugger towards \the [A]!</span>")
 		add_cooldown()

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -68,7 +68,19 @@
 		hivenumber = input_hivenumber
 
 	if(input_source)
-		source = input_source
+		facehugger_register_source(input_source)
+
+/obj/item/clothing/mask/facehugger/proc/facehugger_register_source(var/mob/living/carbon/xenomorph/S)
+	if(source) //If we have an existing source, unregister
+		UnregisterSignal(source, COMSIG_PARENT_QDELETING)
+
+	source = S //set and register new source
+	RegisterSignal(S, COMSIG_PARENT_QDELETING, .proc/clear_hugger_source)
+
+/obj/item/clothing/mask/facehugger/proc/clear_hugger_source()
+	SIGNAL_HANDLER
+	UnregisterSignal(source, COMSIG_PARENT_QDELETING)
+	source = null
 
 /obj/item/clothing/mask/facehugger/Destroy()
 	. = ..()
@@ -77,7 +89,7 @@
 	remove_danger_overlay() //Remove the danger overlay
 	lifetimer = null
 	jumptimer = null
-	source = null
+	clear_hugger_source()
 
 /obj/item/clothing/mask/facehugger/update_icon()
 	if(stat == DEAD)
@@ -115,6 +127,7 @@
 			deltimer(jumptimer)
 			jumptimer = null
 			remove_danger_overlay() //Remove the exclamation overlay as we pick it up
+			facehugger_register_source(X)
 			return ..() // These can pick up huggers.
 		else
 			return FALSE // The rest can't.
@@ -161,7 +174,7 @@
 	. = ..()
 	// Whena  xeno removes the hugger from storage we don't want to start the active timer until they drop or throw it
 	if(isxeno(user)) //Set the source mob
-		source = user
+		facehugger_register_source(user)
 	if(isxenocarrier(user))
 		go_active(TRUE)
 

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -39,7 +39,8 @@
 	var/leaping = FALSE
 	///What hive this hugger belongs to
 	var/hivenumber = XENO_HIVE_NORMAL
-
+	///The xeno that spawned/threw/dropped the hugger. Used for anti-shuffle
+	var/mob/living/carbon/xenomorph/source
 	///The timer tracking when we die
 	var/lifetimer
 	///The timer tracking when we next jump
@@ -58,13 +59,16 @@
 	var/proximity_time = 0.75 SECONDS
 
 
-/obj/item/clothing/mask/facehugger/Initialize(mapload, input_hivenumber)
+/obj/item/clothing/mask/facehugger/Initialize(mapload, input_hivenumber, input_source)
 	. = ..()
 	if(stat == CONSCIOUS)
 		lifetimer = addtimer(CALLBACK(src, .proc/check_lifecycle), FACEHUGGER_DEATH, TIMER_STOPPABLE)
 
 	if(input_hivenumber)
 		hivenumber = input_hivenumber
+
+	if(input_source)
+		source = input_source
 
 /obj/item/clothing/mask/facehugger/Destroy()
 	. = ..()
@@ -73,6 +77,7 @@
 	remove_danger_overlay() //Remove the danger overlay
 	lifetimer = null
 	jumptimer = null
+	source = null
 
 /obj/item/clothing/mask/facehugger/update_icon()
 	if(stat == DEAD)
@@ -155,6 +160,8 @@
 /obj/item/clothing/mask/facehugger/dropped(mob/user)
 	. = ..()
 	// Whena  xeno removes the hugger from storage we don't want to start the active timer until they drop or throw it
+	if(isxeno(user)) //Set the source mob
+		source = user
 	if(isxenocarrier(user))
 		go_active(TRUE)
 
@@ -305,7 +312,12 @@
 
 /obj/item/clothing/mask/facehugger/Uncross(atom/movable/AM)
 	. = ..()
-	if(. && stat == CONSCIOUS && issamexenohive(AM)) //shuffle hug prevention, if a xeno steps off go_idle()
+	if(!. || stat != CONSCIOUS) //Have to be conscious
+		return
+	if(!source && issamexenohive(AM)) //shuffle hug prevention, if we don't have a source and a xeno from the same hive steps off go_idle()
+		go_idle()
+		return
+	if(source == AM) //shuffle hug prevention, if we have a source and it steps off go_idle()
 		go_idle()
 
 /obj/item/clothing/mask/facehugger/on_found(mob/finder)

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -70,7 +70,7 @@
 	if(input_source)
 		facehugger_register_source(input_source)
 
-/obj/item/clothing/mask/facehugger/proc/facehugger_register_source(var/mob/living/carbon/xenomorph/S)
+/obj/item/clothing/mask/facehugger/proc/facehugger_register_source(mob/living/carbon/xenomorph/S)
 	if(source) //If we have an existing source, unregister
 		UnregisterSignal(source, COMSIG_PARENT_QDELETING)
 

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -70,6 +70,7 @@
 	if(input_source)
 		facehugger_register_source(input_source)
 
+///Registers the source of our facehugger for the purpose of anti-shuffle mechanics
 /obj/item/clothing/mask/facehugger/proc/facehugger_register_source(mob/living/carbon/xenomorph/S)
 	if(source) //If we have an existing source, unregister
 		UnregisterSignal(source, COMSIG_PARENT_QDELETING)
@@ -77,6 +78,7 @@
 	source = S //set and register new source
 	RegisterSignal(S, COMSIG_PARENT_QDELETING, .proc/clear_hugger_source)
 
+///Clears the source of our facehugger for the purpose of anti-shuffle mechanics
 /obj/item/clothing/mask/facehugger/proc/clear_hugger_source()
 	SIGNAL_HANDLER
 	UnregisterSignal(source, COMSIG_PARENT_QDELETING)


### PR DESCRIPTION
## About The Pull Request

Xenos from the same hive as the one that drops or throws a Facehugger no longer reset that Facehugger's jump timer when they leave its tile.

## Why It's Good For The Game

Xenos from the same hive as the one that drops or throws a Facehugger no longer reset that Facehugger's jump timer when they leave its tile.

## Changelog
:cl:
code: Xenos from the same hive as the one that drops or throws a Facehugger no longer reset that Facehugger's jump timer when they leave its tile.
/:cl: