### PR TITLE
Synths don't get guns.

### DIFF
--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -1152,5 +1152,8 @@ and you're good to go.
 	if(!wielded_stable())
 		to_chat(gun_user, "<span class='warning'>[active_attachable] is not ready to fire!</span>")
 		return
+	if(!(flags_gun_features & GUN_ALLOW_SYNTHETIC) && !CONFIG_GET(flag/allow_synthetic_gun_use) && issynth(gun_user))
+		to_chat(gun_user, "<span class='warning'>Your program does not allow you to use this firearm.</span>")
+		return
 	active_attachable.fire_attachment(target, src, gun_user) //Fire it.
 	last_fired = world.time


### PR DESCRIPTION
Synths won't use underbarrel attachments.

<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

No more will synths be able to fire an underbarrel flamer or underbarrel grenade launcher. 
Fixes #7016

## Why It's Good For The Game

Combat synth goes in the bin. 

## Changelog
:cl:
fix: No more underbarrel guns for synthetics. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
