### PR TITLE
Simplifies surgical shrapnel removal on head/chest

### DIFF
--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -153,7 +153,9 @@
 /datum/surgery_step/cavity/implant_removal/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected, checks_only)
 	var/datum/internal_organ/brain/sponge = target.internal_organs_by_name["brain"]
 	//potential conflict with brain repair surgery
-	return ..() && (target_zone != "head" || (!sponge || !sponge.damage || sponge.damage>20))
+	var/is_open = affected.surgery_open_stage >= 2 && !(affected.limb_status & LIMB_BLEEDING)
+	var/not_fixing_brain = target_zone != "head" || (!sponge || !sponge.damage || sponge.damage>20) || affected.surgery_open_stage != 3
+	return is_open && not_fixing_brain
 
 /datum/surgery_step/cavity/implant_removal/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message("<span class='notice'>[user] starts poking around inside the incision on [target]'s [affected.display_name] with \the [tool].</span>", \

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -139,7 +139,7 @@
 //////////////////////////////////////////////////////////////////
 
 
-/datum/surgery_step/cavity/implant_removal
+/datum/surgery_step/implant_removal
 	priority = 1
 	allowed_tools = list(
 		/obj/item/tool/surgery/hemostat = 100,
@@ -150,20 +150,16 @@
 	min_duration = HEMOSTAT_REMOVE_MIN_DURATION
 	max_duration = HEMOSTAT_REMOVE_MAX_DURATION
 
-/datum/surgery_step/cavity/implant_removal/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected, checks_only)
-	var/datum/internal_organ/brain/sponge = target.internal_organs_by_name["brain"]
-	//potential conflict with brain repair surgery
-	var/is_open = affected.surgery_open_stage >= 2 && !(affected.limb_status & LIMB_BLEEDING)
-	var/not_fixing_brain = target_zone != "head" || (!sponge || !sponge.damage || sponge.damage>20) || affected.surgery_open_stage != 3
-	return is_open && not_fixing_brain
+/datum/surgery_step/implant_removal/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected, checks_only)
+	return affected.surgery_open_stage >= 2
 
-/datum/surgery_step/cavity/implant_removal/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
+/datum/surgery_step/implant_removal/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message("<span class='notice'>[user] starts poking around inside the incision on [target]'s [affected.display_name] with \the [tool].</span>", \
 	"<span class='notice'>You start poking around inside the incision on [target]'s [affected.display_name] with \the [tool].</span>")
 	target.custom_pain("The pain in your chest is living hell!", 1)
 	..()
 
-/datum/surgery_step/cavity/implant_removal/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
+/datum/surgery_step/implant_removal/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	if(affected.implants.len)
 
 		var/obj/item/implantfound = affected.implants[1]
@@ -182,7 +178,7 @@
 		user.visible_message("<span class='notice'>[user] could not find anything inside [target]'s [affected.display_name], and pulls \the [tool] out.</span>", \
 		"<span class='notice'>You could not find anything inside [target]'s [affected.display_name].</span>")
 
-/datum/surgery_step/cavity/implant_removal/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
+/datum/surgery_step/implant_removal/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/limb/affected)
 	user.visible_message("<span class='warning'>[user]'s hand slips, scraping tissue inside [target]'s [affected.display_name] with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips, scraping tissue inside [target]'s [affected.display_name] with \the [tool]!</span>")
 	affected.createwound(CUT, 20)


### PR DESCRIPTION
## About The Pull Request
Lets you pull shrapnel out of head/chest surgically without opening the bone, you just need to cut/retract or use an incision manager.

## Why It's Good For The Game
There's basically no reason to not just use tweezers and slap in some bic right now, and if you could reach the pieces with tweezers they probably aren't inside the ribcage. With this surgery should be the better option any time you're opening the limb anyway (chest, typically) or there's multiple pieces of shrapnel.

## Changelog
:cl:
qol: You don't need to open the bone to remove shrapnel from head/chest
/:cl:
