### PR TITLE
Allow the AI to turn fusion reactors on and off.

### DIFF
--- a/code/modules/power/fusion_engine.dm
+++ b/code/modules/power/fusion_engine.dm
@@ -99,10 +99,10 @@
 	if(!ishuman(user))
 		to_chat(user, "<span class='warning'>You have no idea how to use that.</span>")
 		return FALSE
-	interact_hand()
+	interact_hand(user)
 
 /obj/machinery/power/fusion_engine/attack_ai(mob/living/silicon/ai/user)
-	interact_hand()
+	interact_hand(user)
 
 //It is a bit messy to split attack_hand into this proc, but it is the easiest way to have the AI be able to toggle them.
 /obj/machinery/power/fusion_engine/proc/interact_hand(mob/living/user)

--- a/code/modules/power/fusion_engine.dm
+++ b/code/modules/power/fusion_engine.dm
@@ -99,6 +99,13 @@
 	if(!ishuman(user))
 		to_chat(user, "<span class='warning'>You have no idea how to use that.</span>")
 		return FALSE
+	interact_hand()
+
+/obj/machinery/power/fusion_engine/attack_ai(mob/living/silicon/ai/user)
+	interact_hand()
+
+//It is a bit messy to split attack_hand into this proc, but it is the easiest way to have the AI be able to toggle them.
+/obj/machinery/power/fusion_engine/proc/interact_hand(mob/living/user)
 	switch(buildstate)
 		if(FUSION_ENGINE_HEAVY_DAMAGE)
 			to_chat(user, "<span class='info'>Use a blowtorch, then wirecutters, then wrench to repair it.</span>")


### PR DESCRIPTION
## About The Pull Request
Turn it on and off. Basic.
They can't fuel it, so this isn't particularly breaking anything.
## Why It's Good For The Game
Quality of life, especially when the only engineer is dead or SSD.

## Changelog
:cl:
qol: The AI can now turn fusion reactors on and off.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
