### PR TITLE
Add a suite of notices and information to the AI

### DIFF
--- a/code/game/objects/machinery/camera/camera.dm
+++ b/code/game/objects/machinery/camera/camera.dm
@@ -198,6 +198,11 @@
 			M.reset_perspective(null)
 			to_chat(M, "The screen bursts into static.")
 
+	for(var/mob/living/silicon/ai/AI in GLOB.silicon_mobs)
+		if(!AI.client)
+			continue
+		to_chat(AI, "<span class='notice'>[src] has been desactived at [myarea]</span>")
+
 
 /obj/machinery/camera/update_icon()
 	if(obj_integrity <= 0)

--- a/code/game/objects/machinery/camera/deployable_camera.dm
+++ b/code/game/objects/machinery/camera/deployable_camera.dm
@@ -24,6 +24,9 @@ GLOBAL_VAR_INIT(deployed_cameras, 0)
 /obj/item/deployable_camera/attack_self(mob/user)
 	user.visible_message("<span class='notice'>[user] throws [src] into the air!</span>",
 		"<span class='notice'>You throw [src] into the air!</span>")
+
+	for(var/mob/living/silicon/ai/AI in GLOB.silicon_mobs)
+		to_chat(AI, "<span class='notice'>NOTICE - \"Huginn\" ROC-58 Observer has been deployed at [AREACOORD_NO_Z(user)].</span>")
 	var/obj/machinery/camera/deployable/newcam = new(get_turf(user))
 	var/dat
 	if(ishuman(user))

--- a/code/game/objects/structures/orbital_cannon.dm
+++ b/code/game/objects/structures/orbital_cannon.dm
@@ -566,6 +566,10 @@
 	playsound(loc, 'sound/weapons/guns/fire/tank_smokelauncher.ogg', 70, 1)
 	playsound(loc, 'sound/weapons/guns/fire/pred_plasma_shot.ogg', 70, 1)
 	var/turf/target = locate(T.x + pick(-2,2), T.y + pick(-2,2), T.z)
+	for(var/mob/living/silicon/ai/AI in GLOB.silicon_mobs)
+		if(!AI.client)
+			continue
+		to_chat(AI, "<span class='notice'>NOTICE - \The [src] has fired.</span>")
 	rail_gun_ammo.ammo_count = max(0, rail_gun_ammo.ammo_count - rail_gun_ammo.ammo_used_per_firing)
 	addtimer(CALLBACK(src, /obj/structure/ship_rail_gun/proc/impact_rail_gun, target), 2 SECONDS + (RG_FLY_TIME * (GLOB.current_orbit/3)))
 

--- a/code/game/objects/structures/orbital_cannon.dm
+++ b/code/game/objects/structures/orbital_cannon.dm
@@ -164,6 +164,10 @@
 
 /// Handles the playing of the Orbital Bombardment incoming sound and other visual and auditory effects of the cannon, usually a spiraling whistle noise but can be overridden.
 /obj/structure/orbital_cannon/proc/handle_ob_firing_effects(target, ob_sound = 'sound/effects/OB_incoming.ogg')
+	for(var/mob/living/silicon/ai/AI in GLOB.silicon_mobs)
+		if(!AI.client)
+			continue
+		to_chat(AI, "<span class='warning'>NOTICE - \The [src] has fired.</span>")
 	flick("OBC_firing",src)
 	playsound(loc, 'sound/effects/obfire.ogg', 100, FALSE, 20, 4)
 	for(var/i in hearers(WARHEAD_FALLING_SOUND_RANGE,target))

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -278,6 +278,17 @@
 			return
 
 		stat("System integrity:", "[(health + 100) / 2]%")
+		stat("<BR>- Operation information - <BR>")
+		stat("Current orbit:", "[GLOB.current_orbit]")
+
+		if(!GLOB.marine_main_ship?.orbital_cannon?.chambered_tray)
+			stat("<b>Orbital bombardment status:</b>", "<font color='red'>No ammo chambered in the cannon.</font><br>")
+		else
+			stat("Orbital bombardment warhead:", "[GLOB.marine_main_ship.orbital_cannon.tray.warhead.name] Detected<BR>")
+
+
+		stat("Current alert level:", "[GLOB.marine_main_ship.get_security_level()]")
+
 
 
 /mob/living/silicon/ai/fully_replace_character_name(oldname, newname)

--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -67,6 +67,11 @@
 					visible_message("<span class='notice'>Destination updated, recalculating route.</span>")
 				else
 					visible_message("<span class='notice'>Shuttle departing. Please stand away from the doors.</span>")
+
+					for(var/mob/living/silicon/ai/AI in GLOB.silicon_mobs)
+						if(!AI.client)
+							continue
+						to_chat(AI, "<span class='info'>[src] just took off..</span>")
 			if(1)
 				to_chat(usr, "<span class='warning'>Invalid shuttle requested.</span>")
 				return TRUE

--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -1178,6 +1178,10 @@
 				visible_message("<span class='notice'>Destination updated, recalculating route.</span>")
 			else
 				visible_message("<span class='notice'>Shuttle departing. Please stand away from the doors.</span>")
+				for(var/mob/living/silicon/ai/AI in GLOB.silicon_mobs)
+					if(!AI.client)
+						continue
+					to_chat(AI, "<span class='info'>NOTICE - [M.name] taking off towards [params["destination"]]</span>")
 			return TRUE
 		if(1)
 			to_chat(usr, "<span class='warning'>Invalid shuttle requested.</span>")


### PR DESCRIPTION

## About The Pull Request
If you check the 'Game' tab, you can now see :
- Orbital level
- Orbital canon status
-  Alert level
Maybe in the future:
- Supply points
- Active miners ?
- Active marines ?
- Status of Alamo, Tadpole & Condor ?

Relative to the notifications :
- Add a notice when a camera goes offline
- Add a notice when the railgun fires
- Add a notice when the Alamo takes off.

## Why It's Good For The Game
It drives the feeling of the AI being a more aware presence, just like someone who is literally wired into the ship.
On a more straight forward level, all of this info is already presented on other consoles. 
It mostly saves on having to constantly open this damn camera list to find the weapons room or CIC.

Pretty happy with this ngl!

![image](https://user-images.githubusercontent.com/24830358/124215739-ec85d000-daf4-11eb-90eb-a3bd2afbad14.png)
![image](https://user-images.githubusercontent.com/24830358/124215762-fa3b5580-daf4-11eb-8c89-88766316c133.png)
![image](https://user-images.githubusercontent.com/24830358/124215783-058e8100-daf5-11eb-9537-8d5d4b08d134.png)
![image](https://user-images.githubusercontent.com/24830358/124215808-117a4300-daf5-11eb-9b80-3f4d5ef9da67.png)


## Changelog
:cl:
add: Added notifications to the AI whenever the Alamo moves, the railgun is fired, the OB is fired and when a camera gets slashed.
qol: Added some handy status lines to the 'Game' tab for the AI, like OB status or orbital level.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
