### PR TITLE
Randomly break groundmap fence lines at round start

### DIFF
--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -121,6 +121,10 @@
 /obj/structure/fence/Initialize(mapload, start_dir)
 	. = ..()
 
+	if(prob(80))
+		obj_integrity = 0
+		deconstruct(FALSE)
+
 	if(start_dir)
 		setDir(start_dir)
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

## Why It's Good For The Game

Dovetails nicely with the recent fence health buff since they are even more annoying to clear out before shutters now.

Makes xeno prep less unfun.

## Changelog
:cl:
qol: Some groundmap fences start broken, so xenos do not need to slash them all to get around during prep.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
