### PR TITLE
Makes Pizza Sliceable

### DIFF
--- a/code/game/objects/items/reagent_containers/food/snacks.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks.dm
@@ -173,7 +173,7 @@
 /obj/item/reagent_containers/food/snacks/sliceable/attackby(obj/item/I, mob/user, params)
 	. = ..()
 
-	if(I.sharp != IS_SHARP_ITEM_ACCURATE || I.sharp != IS_SHARP_ITEM_BIG)
+	if(I.sharp == IS_NOT_SHARP_ITEM)
 		if(I.w_class >= WEIGHT_CLASS_SMALL)
 			return
 		if(!user.transferItemToLoc(I, src))
@@ -184,12 +184,12 @@
 		to_chat(user, "<span class='notice'>You slip [I] inside of [src].</span>")
 		return
 
-	if(!isturf(loc) || !(locate(/obj/structure/table) in loc) || !istype(loc, /obj/item/tool/kitchen/tray))
+	if(!isturf(loc) || !(locate(/obj/structure/table) in loc))
 		to_chat(user, "<span class='warning'>You cannot slice [src] here! You need a table or at least a tray to do it.</span>")
 		return
 
 	user.visible_message("<span class='notice'>[user] slices \the [src] with [I]!</span>", \
-		"<span class='notice'>You crudely \the [src] with your [I]!</span>")
+		"<span class='notice'>You crudely slice \the [src] with your [I]!</span>")
 
 	var/reagents_per_slice = reagents.total_volume / slices_num
 

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -193,6 +193,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	master_gun.recoil						+= recoil_mod
 	master_gun.recoil_unwielded				+= recoil_unwielded_mod
 	master_gun.force						+= melee_mod
+	master_gun.sharp						+= sharp
 	master_gun.aim_slowdown					+= aim_speed_mod
 	master_gun.wield_delay					+= wield_delay_mod
 	master_gun.burst_scatter_mult			+= burst_scatter_mod
@@ -258,6 +259,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	master_gun.recoil						-= recoil_mod
 	master_gun.recoil_unwielded				-= recoil_unwielded_mod
 	master_gun.force						-= melee_mod
+	master_gun.sharp						-= sharp
 	master_gun.aim_slowdown					-= aim_speed_mod
 	master_gun.wield_delay					-= wield_delay_mod
 	master_gun.burst_scatter_mult			-= burst_scatter_mod


### PR DESCRIPTION
Makes pizza sliceably by sharp objects and not sliceable by objects that aren't sharp. Also makes attachables add their sharpness to the gun when attached. The only attachables with sharpness that isn't 0 are bayonets, so this makes a bayoneted gun able to slice pizza.

<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes pizza sliceable and adds a new attachment stat change. Basically attachments will now transfer their sharp to the gun when attached and remove it when taken off. So you can slice pizza with a gun if it has a bayonet on. 

## Why It's Good For The Game

Pizza will now be sliceable. 

## Changelog
:cl:
add: Attachments now transfer their sharp to the gun. 
fix: Pizza and other foods are now sliceable. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
