### PR TITLE
Cigarette Chem Fix. 

### DIFF
--- a/code/game/objects/items/tools/flame_tools.dm
+++ b/code/game/objects/items/tools/flame_tools.dm
@@ -167,7 +167,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	var/chem_volume = 30
 	var/list/list_reagents = list(/datum/reagent/nicotine = 15)
 	/// the quantity that will be transmited each 2 seconds
-	var/transquantity = 0.1
+	var/transquantity = 1
 	flags_armor_protection = NONE
 
 /obj/item/clothing/mask/cigarette/Initialize()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Increases the transquantity of the base cigarette so that chems will transfer at a functional rate. Before this the rate was so slow that if you put say, a single healing chem in the cigarette's 30u limit which is already half filled by nicotine, it would transfer 0.05 of each reagent per tick and thus do nothing. With transquantity at 1 it transfers 0.5u per tick of nicotine and 0.5u of whatever chem or mix of chems you add to take up the other half of the cigarette's chem volume. 
Fixes #6372 

## Why It's Good For The Game

It makes it so you can put chems into a regular cigarette via dipping it in a bottle or injecting it and have them properly transfer to you when smoking it. 

## Changelog
:cl:
fix: Non-Chemrette cigarettes now transfer chems properly. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
