### PR TITLE
Fix Unwielding Breaking Labels

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1,4 +1,5 @@
 /obj/item
+	var/label_name = ""
 	name = "item"
 	icon = 'icons/obj/items/items.dmi'
 	blocks_emissive = EMISSIVE_BLOCK_GENERIC

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -50,6 +50,7 @@
 
 	toggle_wielded(user, TRUE)
 	SEND_SIGNAL(src, COMSIG_ITEM_WIELD, user)
+	label_name = "[name]"
 	name = "[name] (Wielded)"
 	update_item_state(user)
 	place_offhand(user, name)
@@ -62,7 +63,7 @@
 
 	toggle_wielded(user, FALSE)
 	SEND_SIGNAL(src, COMSIG_ITEM_UNWIELD, user)
-	name = initial(name)
+	name = label_name
 	update_item_state(user)
 	remove_offhand(user)
 	return TRUE


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It makes it so your two handed item saves its label upon being wielded and then unwielded. 
Fixes #5819 
![LABELS](https://user-images.githubusercontent.com/29074600/124345452-f1a35780-dba6-11eb-97b5-d060b2f43650.png)

## Why It's Good For The Game

It's no longer a waste of labels to label a gun. 

## Changelog
:cl:
fix: Guns keep labels on unwield now. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
