### PR TITLE
Condor Minigun Fix

### DIFF
--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -714,6 +714,7 @@
 
 /obj/structure/dropship_equipment/weapon/heavygun/radial_cas
 	name = "Condor Jet Radial minigun"
+	point_cost = 0
 	dropship_equipment_flags = USES_AMMO|IS_WEAPON|IS_INTERACTABLE|IS_NOT_REMOVABLE
 
 /obj/structure/dropship_equipment/weapon/heavygun/radial_cas/Initialize()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This makes the condor radial gun not printable anymore. 
Fixes #6996 

## Why It's Good For The Game

Now nobody will print it and find themselves with an unmovable gun that wasted 400 dropship points. 

## Changelog
:cl:
fix: Condor Radial Minigun no longer printable. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
