### PR TITLE
Fixes PoS research doors

### DIFF
--- a/code/game/objects/machinery/doors/airlock_types.dm
+++ b/code/game/objects/machinery/doors/airlock_types.dm
@@ -340,7 +340,7 @@
 	icon = 'icons/obj/doors/mainship/securedoor.dmi'
 	req_access = list(ACCESS_MARINE_BRIDGE)
 
-/obj/machinery/door/airlock/mainship/secure/rebel 
+/obj/machinery/door/airlock/mainship/secure/rebel
 	req_access = list(ACCESS_MARINE_BRIDGE_REBEL)
 
 /obj/machinery/door/airlock/mainship/secure/free_access
@@ -550,7 +550,7 @@
 	icon = 'icons/obj/doors/mainship/medidoor.dmi'
 	req_access = list(ACCESS_MARINE_RESEARCH)
 
-/obj/machinery/door/airlock/mainship/research
+/obj/machinery/door/airlock/mainship/research/rebel
 	req_access = list(ACCESS_MARINE_RESEARCH_REBEL)
 
 /obj/machinery/door/airlock/mainship/research/free_access
@@ -676,7 +676,7 @@
 	opacity = FALSE
 	glass = TRUE
 
-/obj/machinery/door/airlock/mainship/marine/general/sl/rebel 
+/obj/machinery/door/airlock/mainship/marine/general/sl/rebel
 	req_access = list(ACCESS_MARINE_LEADER_REBEL)
 
 /obj/machinery/door/airlock/mainship/marine/general/spec


### PR DESCRIPTION

## About The Pull Request
Fixes PoS research Pen doors, which was broken by a certain pr

## Why It's Good For The Game

Bruh

## Changelog
:cl:

fix: PoS research doors should now be accessible.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
