### PR TITLE
Hivemind respawn fix

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
@@ -105,9 +105,6 @@
 /mob/living/carbon/xenomorph/hivemind/update_icons()
 	return FALSE
 
-/mob/living/carbon/xenomorph/hivemind/set_lying_angle()
-	CRASH("Something caused a hivemind to change its lying angle. Add checks to prevent that.")
-
 /mob/living/carbon/xenomorph/hivemind/DblClickOn(atom/A, params)
 	if(!istype(A, /obj/effect/alien/weeds))
 		return

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
@@ -169,7 +169,7 @@
 	parent.playsound_local(parent, get_sfx("alien_help"), 30, TRUE)
 	to_chat(parent, "<span class='xenohighdanger'>Your core has been destroyed!</span>")
 	xeno_message("A sudden tremor ripples through the hive... \the [parent] has been slain!", "xenoannounce", 5, parent.hivenumber)
-	parent.ghostize()
+	parent.death()
 	if(!QDELETED(parent))
 		QDEL_NULL(parent)
 	else

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
@@ -105,6 +105,9 @@
 /mob/living/carbon/xenomorph/hivemind/update_icons()
 	return FALSE
 
+/mob/living/carbon/xenomorph/hivemind/set_lying_angle()
+	CRASH("Something caused a hivemind to change its lying angle. Add checks to prevent that.")
+
 /mob/living/carbon/xenomorph/hivemind/DblClickOn(atom/A, params)
 	if(!istype(A, /obj/effect/alien/weeds))
 		return
@@ -166,7 +169,8 @@
 	parent.playsound_local(parent, get_sfx("alien_help"), 30, TRUE)
 	to_chat(parent, "<span class='xenohighdanger'>Your core has been destroyed!</span>")
 	xeno_message("A sudden tremor ripples through the hive... \the [parent] has been slain!", "xenoannounce", 5, parent.hivenumber)
-	parent.death()
+	parent.timeofdeath = world.time
+	parent.ghostize()
 	if(!QDELETED(parent))
 		QDEL_NULL(parent)
 	else


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes hiveminds getting immediate respawns on core destruction. Ghostize wasn't properly setting the respawn timer, but DEATH does. And so death they get. 
Fixes #4653
## Why It's Good For The Game

It fixes an unintended behavior. 

## Changelog
:cl:
fix: Hiveminds don't get fast respawns from dying. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
