### PR TITLE
Lets you choose the type of camo for PAS-11 and M-10 armor

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -825,7 +825,7 @@
 			/obj/item/facepaint/green = -1,
 		),
 		"Helmets" = list(
-			/obj/item/clothing/head/helmet/marine = -1,
+			/obj/item/clothing/head/helmet/marine/standard = -1,
 			/obj/item/clothing/head/helmet/marine/heavy = -1,
 			/obj/item/clothing/head/modular/marine/skirmisher = -1,
 			/obj/item/clothing/head/modular/marine = -1,

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -305,6 +305,28 @@
 /obj/item/clothing/head/helmet/marine/standard
 	flags_item_map_variant = (ITEM_JUNGLE_VARIANT|ITEM_ICE_VARIANT|ITEM_PRISON_VARIANT|ITEM_ICE_PROTECTION)
 
+/obj/item/clothing/head/helmet/marine/standard/attack_self(mob/user)
+
+	///List of colors for the M-10 and their respective icon states
+	var/static/list/helmet_colors = list(
+		"classic" = "helmet",
+		"snow" = "s_helmet",
+		"black" = "k_helmet",
+		"green" = "m_helmet",
+	)
+
+	. = ..()
+	if(.)
+		return
+
+	if(!do_after(user, 3 SECONDS, TRUE, src, BUSY_ICON_GENERIC))
+		return TRUE
+
+	var/new_icon = tgui_input_list(user, "Pick a color", "Pick color", helmet_colors)
+	if(!new_icon)
+		return
+	icon_state = helmet_colors[new_icon]
+
 /obj/item/clothing/head/helmet/marine/tech
 	name = "\improper M10 technician helmet"
 	flags_item_map_variant = (ITEM_JUNGLE_VARIANT|ITEM_ICE_VARIANT|ITEM_PRISON_VARIANT|ITEM_ICE_PROTECTION)

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -304,9 +304,6 @@
 
 /obj/item/clothing/head/helmet/marine/standard
 	flags_item_map_variant = (ITEM_JUNGLE_VARIANT|ITEM_ICE_VARIANT|ITEM_PRISON_VARIANT|ITEM_ICE_PROTECTION)
-
-/obj/item/clothing/head/helmet/marine/standard/attack_self(mob/user)
-
 	///List of colors for the M-10 and their respective icon states
 	var/static/list/helmet_colors = list(
 		"classic" = "helmet",
@@ -314,6 +311,8 @@
 		"black" = "k_helmet",
 		"green" = "m_helmet",
 	)
+
+/obj/item/clothing/head/helmet/marine/standard/attack_self(mob/user)
 
 	. = ..()
 	if(.)

--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -1,6 +1,5 @@
 // MARINE STORAGE ARMOR
 
-
 /obj/item/clothing/suit/storage/marine
 	name = "\improper M3 pattern marine armor"
 	desc = "A standard TerraGov Marine Corps M3 Pattern Chestplate. Protects the chest from ballistic rounds, bladed objects and accidents. It has a small leather pouch strapped to it for limited storage."
@@ -274,7 +273,28 @@
 	soft_armor = list("melee" = 40, "bullet" = 60, "laser" = 60, "energy" = 45, "bomb" = 45, "bio" = 45, "rad" = 45, "fire" = 45, "acid" = 50)
 	slowdown = 0.5 //a bit less
 	light_range = 6
+	
+/obj/item/clothing/suit/storage/marine/pasvest/attack_self(mob/user)
 
+	///List of colors for the PAS-11 and their respective icon states
+	var/static/list/vest_colors = list(
+		"classic" = "2",
+		"snow" = "s_2",
+		"black" = "k_2",
+		"green" = "m_2",
+	)
+
+	. = ..()
+	if(.)
+		return
+
+	if(!do_after(user, 3 SECONDS, TRUE, src, BUSY_ICON_GENERIC))
+		return TRUE
+
+	var/new_icon = tgui_input_list(user, "Pick a color", "Pick color", vest_colors)
+	if(!new_icon)
+		return
+	icon_state = vest_colors[new_icon]
 
 //===========================SPECIALIST================================
 

--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -273,9 +273,6 @@
 	soft_armor = list("melee" = 40, "bullet" = 60, "laser" = 60, "energy" = 45, "bomb" = 45, "bio" = 45, "rad" = 45, "fire" = 45, "acid" = 50)
 	slowdown = 0.5 //a bit less
 	light_range = 6
-	
-/obj/item/clothing/suit/storage/marine/pasvest/attack_self(mob/user)
-
 	///List of colors for the PAS-11 and their respective icon states
 	var/static/list/vest_colors = list(
 		"classic" = "2",
@@ -283,6 +280,8 @@
 		"black" = "k_2",
 		"green" = "m_2",
 	)
+	
+/obj/item/clothing/suit/storage/marine/pasvest/attack_self(mob/user)
 
 	. = ..()
 	if(.)


### PR DESCRIPTION
## About The Pull Request

Allows you to choose the camo sprite for the PAS-11 armour vest and M-10 standard helmet. You do this by using it in hand, waiting 3 seconds and choosing whichever colour you want from the menu. 

## Why It's Good For The Game

Lets you be tacticool