### PR TITLE
Add TS-34 Scopes

### DIFF
--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -425,6 +425,9 @@ can cause issues with ammo types getting mixed up during the burst.
 		/obj/item/attachable/gyro,
 		/obj/item/attachable/flashlight,
 		/obj/item/attachable/magnetic_harness,
+		/obj/item/attachable/scope,
+		/obj/item/attachable/scope/marine,
+		/obj/item/attachable/scope/mini,
 	)
 
 	flags_gun_features = GUN_CAN_POINTBLANK|GUN_INTERNAL_MAG|GUN_AMMO_COUNTER|GUN_WIELDED_FIRING_ONLY


### PR DESCRIPTION

## About The Pull Request
Three lines of code are added to the Double Barrel shotgun, those three lines are adding the scopes to the TS-34. Mini-scope, marine-scope and scope. 

/obj/item/attachable/scope,
/obj/item/attachable/scope/marine,
/obj/item/attachable/scope/mini,

## Why It's Good For The Game
Give a wider range for usage for the TS-34 instead of only being the funny pointblank weapon to insta-crit runners and hunters. Adding these scopes to the TS-34 will make the double barrel shotgun far much viable in other situations than PB. It can be used as a defensive and a support weapon. Double Barrel shotguns were used for hunting and I wouldn't be suprised if hunters sometimes used scopes on them. Thank you

For footage on how the Double Barrel works and looks with a scope check: 
https://youtu.be/51a5YrTYUVc

## Changelog
:cl: Grandpa
expansion: Expands content of an existing thing
code: changed some code
/:cl:


