### PR TITLE
Fix for welding helmet module

### DIFF
--- a/code/modules/modular_armor/helmets.dm
+++ b/code/modules/modular_armor/helmets.dm
@@ -25,12 +25,12 @@
 		DISABLE_BITFIELD(parent.flags_inventory, COVEREYES)
 		DISABLE_BITFIELD(parent.flags_inv_hide, HIDEEYES)
 		DISABLE_BITFIELD(parent.flags_armor_protection, EYES)
-		parent.eye_protection += eye_protection_mod // reset to the users base eye
+		parent.eye_protection -= eye_protection_mod // reset to the users base eye
 	else
 		ENABLE_BITFIELD(parent.flags_inventory, COVEREYES)
 		ENABLE_BITFIELD(parent.flags_inv_hide, HIDEEYES)
 		ENABLE_BITFIELD(parent.flags_armor_protection, EYES)
-		parent.eye_protection -= eye_protection_mod
+		parent.eye_protection += eye_protection_mod
 
 	active = !active
 	SEND_SIGNAL(parent, COMSIG_ITEM_TOGGLE_ACTION, user)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Welding helmet modules currently remove eye protection when toggled on instead of adding it. 

## Why It's Good For The Game

Makes the welding helmet module provide eye protection. 

## Changelog
:cl:
fix: Welding helmet module protects eyes properly. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
