### PR TITLE
Remplace the hivemind heal with a weaker, faster & easier to employ version.

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -581,6 +581,7 @@
 #define COMSIG_XENOABILITY_CALL_OF_THE_BURROWED "xenoability_call_of_the_burrowed"
 #define COMSIG_XENOABILITY_PSYCHIC_FLING "xenoability_psychic_fling"
 #define COMSIG_XENOABILITY_PSYCHIC_CURE "xenoability_psychic_cure"
+#define COMSIG_XENOABILITY_HIVEMIND_HEAL "xenoability_hivemind_heal"
 #define COMSIG_XENOABILITY_UNRELENTING_FORCE "xenoability_unrelenting_force"
 #define COMSIG_XENOABILITY_UNRELENTING_FORCE_SELECT "xenoability_unrelenting_force_select"
 //#define COMSIG_XENOABILITY_NIGHTFALL "xenoability_nightfall"

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -579,6 +579,12 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define SHRIKE_CURE_HEAL_MULTIPLIER 10
 #define SHRIKE_HEAL_RANGE 3
 
+//Hivemind defines
+
+#define HIVEMIND_HEAL_MULTIPLIER 2
+#define HIVEMIND_HEAL_RANGE 6
+
+
 //Drone defines
 
 //Runner defines

--- a/code/datums/keybinding/xeno.dm
+++ b/code/datums/keybinding/xeno.dm
@@ -489,6 +489,12 @@
 	description = "Imbues a target xeno with healing energy, restoring extra Sunder and Health once every 2 seconds up to 5 times whenever it regenerates normally. 60 second duration."
 	keybind_signal = COMSIG_XENOABILITY_HEALING_INFUSION
 
+/datum/keybinding/xeno/hivemind_heal
+	name = "hivemind_heal"
+	full_name = "Hivemind: Hivemind Heal"
+	description = ""
+	keybind_signal = COMSIG_XENOABILITY_HIVEMIND_HEAL
+
 /datum/keybinding/xeno/scatter_spit
 	name = "scatter_spit"
 	full_name = "Spitter: Scatter Spit"

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/abilities_hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/abilities_hivemind.dm
@@ -5,3 +5,80 @@
 
 /datum/action/xeno_action/return_to_core/action_activate()
 	SEND_SIGNAL(owner, COMSIG_XENOMORPH_CORE_RETURN)
+
+// ***************************************
+// *********** Hivemind healing
+// ***************************************
+/datum/action/xeno_action/activable/hivemind_heal
+	name = "Hivemind Heal"
+	action_icon_state = "heal_xeno"
+	mechanics_text = "Heal."
+	cooldown_timer = 1 MINUTES
+	plasma_cost = 200
+	keybind_signal = COMSIG_XENOABILITY_HIVEMIND_HEAL
+	var/heal_range = HIVEMIND_HEAL_RANGE
+	target_flags = XABB_MOB_TARGET
+
+
+/datum/action/xeno_action/activable/hivemind_heal/on_cooldown_finish()
+	to_chat(owner, "<span class='notice'>We gather enough mental strength to cure sisters again.</span>")
+	return ..()
+
+
+/datum/action/xeno_action/activable/hivemind_heal/can_use_ability(atom/target, silent = FALSE, override_flags)
+	. = ..()
+	if(!.)
+		return FALSE
+	if(QDELETED(target))
+		return FALSE
+	if(!check_distance(target, silent))
+		return FALSE
+	if(!isxeno(target))
+		return FALSE
+	var/mob/living/carbon/xenomorph/patient = target
+	if(!CHECK_BITFIELD(use_state_flags|override_flags, XACT_IGNORE_DEAD_TARGET) && patient.stat == DEAD)
+		if(!silent)
+			to_chat(owner, "<span class='warning'>It's too late. This sister won't be coming back.</span>")
+		return FALSE
+
+
+/datum/action/xeno_action/activable/hivemind_heal/proc/check_distance(atom/target, silent)
+	var/dist = get_dist(owner, target)
+	if(dist > heal_range)
+		to_chat(owner, "<span class='warning'>Too far for our reach... We need to be [dist - heal_range] steps closer!</span>")
+		return FALSE
+	return TRUE
+
+
+/datum/action/xeno_action/activable/hivemind_heal/use_ability(atom/target)
+	if(owner.do_actions)
+		return FALSE
+
+	if(!do_mob(owner, target, 0.3 SECONDS, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL))
+		return FALSE
+
+	GLOB.round_statistics.psychic_cures++
+	SSblackbox.record_feedback("tally", "round_statistics", 1, "psychic_cures")
+	owner.visible_message("<span class='xenowarning'>A strange psychic aura is suddenly emitted from \the [owner]!</span>", \
+	"<span class='xenowarning'>We cure [target] with the power of our mind!</span>")
+	target.visible_message("<span class='xenowarning'>[target] suddenly shimmers in a chill light.</span>", \
+	"<span class='xenowarning'>We feel a sudden soothing chill.</span>")
+
+	playsound(target,'sound/effects/magic.ogg', 75, 1)
+	new /obj/effect/temp_visual/telekinesis(get_turf(target))
+	var/mob/living/carbon/xenomorph/patient = target
+	patient.heal_wounds(HIVEMIND_HEAL_MULTIPLIER)
+	if(patient.health > 0) //If they are not in crit after the heal, let's remove evil debuffs.
+		patient.SetUnconscious(0)
+		patient.SetStun(0)
+		patient.SetParalyzed(0)
+		patient.set_stagger(0)
+		patient.set_slowdown(0)
+	patient.updatehealth()
+
+	owner.changeNext_move(CLICK_CD_RANGE)
+
+	log_combat(owner, patient, "psychically cured")
+
+	succeed_activate()
+	add_cooldown()

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/castedatum_hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/castedatum_hivemind.dm
@@ -72,7 +72,7 @@
 		/datum/action/xeno_action/return_to_core,
 		/datum/action/xeno_action/plant_weeds/slow,
 		/datum/action/xeno_action/psychic_whisper,
-		/datum/action/xeno_action/activable/psychic_cure,
+		/datum/action/xeno_action/activable/hivemind_heal,
 		/datum/action/xeno_action/activable/rally_hive/hivemind,
 	)
 
@@ -96,7 +96,7 @@
 		/datum/action/xeno_action/return_to_core,
 		/datum/action/xeno_action/plant_weeds/slow,
 		/datum/action/xeno_action/psychic_whisper,
-		/datum/action/xeno_action/activable/psychic_cure,
+		/datum/action/xeno_action/activable/hivemind_heal,
 		/datum/action/xeno_action/toggle_pheromones,
 		/datum/action/xeno_action/activable/rally_hive/hivemind,
 	)
@@ -121,7 +121,7 @@
 		/datum/action/xeno_action/return_to_core,
 		/datum/action/xeno_action/plant_weeds/slow,
 		/datum/action/xeno_action/psychic_whisper,
-		/datum/action/xeno_action/activable/psychic_cure,
+		/datum/action/xeno_action/activable/hivemind_heal,
 		/datum/action/xeno_action/toggle_pheromones,
 		/datum/action/xeno_action/activable/secrete_resin/slow,
 		/datum/action/xeno_action/activable/rally_hive/hivemind,


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This is basically just the shrike heal but retextured. You get more range and it applies faster than the shrike healing, but it is much weaker. (Multiplier is 2 instead of 10)

## Why It's Good For The Game
I believe this is one way to make the hivemind more of a distinct evo choice than other xenos, while also not breaking balance by denying too many kids. This won't save you if people are actively shooting at you. 

I would really be happy to see this test merged to see how players work around it.

## Changelog
:cl:
balance: rebalanced the hivemind heal into a weaker but faster to use version.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
