### PR TITLE
Closet based ghost bullying fix

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -262,6 +262,10 @@
 
 
 /obj/structure/closet/MouseDrop_T(atom/movable/O, mob/user)
+	if(!isliving(user))
+		return
+	if(isxenohivemind(user))
+		return
 	if(!opened)
 		return
 	if(!isturf(O.loc))


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds checks to stuffing things into closet so ghosts/hiveminds can't do it. 

## Why It's Good For The Game

No more ghost bullying. The hivemind bit is to be thorough since testing indicated they could do it. 

## Changelog
:cl:
fix: The veil has been pushed back closed. Ghosts can no longer interact with the living. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
