### PR TITLE
adds a 5 for 3 railgun ammo pack, railgun rounds reduced to 2

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -503,7 +503,17 @@ AMMO
 /datum/supply_packs/ammo/railgun
 	name = "Railgun round"
 	contains = list(/obj/item/ammo_magazine/railgun)
-	cost = 3
+	cost = 2
+
+/datum/supply_packs/ammo/railgun_pack
+	name = "Railgun round"
+	notes = "Contains three railgun rounds."
+	contains = list(
+		/obj/item/ammo_magazine/railgun,
+		/obj/item/ammo_magazine/railgun,
+		/obj/item/ammo_magazine/railgun,
+	)
+	cost = 5
 
 /datum/supply_packs/ammo/shotguntracker
 	name = "12 Gauge Tracker Shells"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The Railgun, even at 40 points is basically near useless, as you can just keep ordering RR rockets rather than buying railgun rounds for nearly the same effect as the Railgun has way more punishing moments if you miss, and also doesn't fit in webbing or ammo magazine pouches. So I think this is generally fair.

5 points for 3 rounds, 1 shot is 2.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes the railgun more useable rather than being really bad, compared to everything else in the 40-60 point range (autosniper/amr/tx-8)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: you can buy railgun ammo in packs of 3 for 5 points, and one shot is only two from three
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
