### PR TITLE
warrior fling distance on grapple toss reduced to 3 from 5

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -231,7 +231,7 @@
 /datum/action/xeno_action/activable/toss
 	name = "Grapple Toss"
 	action_icon_state = "grapple_toss"
-	mechanics_text = "Throw a creature you're grappling up to 5 tiles away."
+	mechanics_text = "Throw a creature you're grappling up to 3 tiles away."
 	ability_name = "grapple toss"
 	plasma_cost = 18
 	cooldown_timer = 20 SECONDS //Shared cooldown with Fling
@@ -256,7 +256,7 @@
 /datum/action/xeno_action/activable/toss/use_ability(atom/A)
 	var/mob/living/carbon/xenomorph/X = owner
 	var/atom/movable/target = owner.pulling
-	var/fling_distance = 5
+	var/fling_distance = 3
 	var/stagger_slow_stacks = 3
 	var/stun_duration = 1 SECONDS
 	var/big_mob_message


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
warrior can fling you literally across slightly more than half a screen with a malleable grab compared to fling itself which requires much more careful coordination and grabbing for a shittier overall ability (fling itself stuns for less time I think too)
This gives you a reason to fling instead of tossing on a grapple considering warriors bread and butter is lunge anyway, so I don't see the need for it to be better than fling in about every aspect outside of rare situations where you're caught with lunge on cooldown.
Also 5 tiles is way too much when comboed which lets you literally throw marines 10 tiles away.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Warrior grapple toss throws you way too many tiles away. Three is more fair and slightly less frustrating to deal with than five.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: warrior grapple toss distance reduced to 3 from 5.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
