### PR TITLE
Add some monitors for the AI along with some direction signs on POS

### DIFF
--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -287,6 +287,24 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
+"bf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/sign/directions/command{
+	pixel_y = 40
+	},
+/obj/structure/sign/directions/engineering{
+	pixel_y = 24
+	},
+/obj/structure/sign/directions/evac{
+	pixel_y = 32
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/aft_hallway)
 "bg" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -307,6 +325,12 @@
 /obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
+"bj" = (
+/obj/structure/sign/directions/medical{
+	pixel_y = -32
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/aft_hallway)
 "bk" = (
 /obj/machinery/door/poddoor/shutters/mainship/selfdestruct{
 	dir = 1
@@ -1174,6 +1198,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"dZ" = (
+/obj/machinery/status_display,
+/turf/closed/wall/mainship,
+/area/mainship/hull/lower_hull)
 "ea" = (
 /turf/closed/wall/mainship,
 /area/mainship/living/grunt_rnr)
@@ -1807,6 +1835,16 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"gg" = (
+/obj/structure/sign/directions/command{
+	pixel_x = -32
+	},
+/obj/structure/sign/directions/engineering{
+	pixel_x = -32;
+	pixel_y = -8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
 "gh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -2159,6 +2197,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"hs" = (
+/obj/machinery/status_display/ai,
+/turf/closed/wall/mainship/white,
+/area/mainship/medical/medical_science)
 "hw" = (
 /obj/machinery/power/apc/mainship,
 /obj/structure/cable,
@@ -2227,6 +2269,10 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)
+"hM" = (
+/obj/machinery/status_display/ai,
+/turf/closed/wall/mainship,
+/area/mainship/command/cic)
 "hQ" = (
 /obj/machinery/door/airlock/mainship/generic/bathroom{
 	dir = 1
@@ -3015,6 +3061,10 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/mainship/living/port_garden)
+"kz" = (
+/obj/machinery/status_display/ai,
+/turf/closed/wall/mainship/white,
+/area/mainship/medical/operating_room_two)
 "kA" = (
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
@@ -4953,6 +5003,22 @@
 	},
 /turf/open/floor/wood,
 /area/mainship/command/corporateliaison)
+"qL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/sign/directions/medical{
+	dir = 8;
+	pixel_y = 24
+	},
+/obj/structure/sign/directions/supply{
+	pixel_y = 32
+	},
+/turf/open/floor/mainship/floor,
+/area/mainship/hallways/aft_hallway)
 "qM" = (
 /obj/machinery/vending/marine/shared,
 /obj/structure/window/reinforced,
@@ -5703,6 +5769,16 @@
 "tp" = (
 /turf/closed/wall/mainship,
 /area/mainship/shipboard/weapon_room)
+"tr" = (
+/obj/structure/sign/directions/command{
+	pixel_x = -32;
+	pixel_y = 8
+	},
+/obj/structure/sign/directions/engineering{
+	pixel_x = -32
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
 "ts" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -7733,6 +7809,18 @@
 	dir = 8
 	},
 /area/mainship/medical/operating_room_one)
+"zB" = (
+/obj/structure/sign/directions/medical{
+	dir = 1;
+	pixel_x = -32
+	},
+/obj/structure/sign/directions/supply{
+	dir = 1;
+	pixel_x = -32;
+	pixel_y = -8
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
 "zC" = (
 /turf/closed/wall/mainship,
 /area/mainship/engineering/engine_core)
@@ -10005,6 +10093,13 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
+"Hm" = (
+/obj/structure/sign/directions/medical{
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
 "Hn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -11256,6 +11351,10 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
+"KK" = (
+/obj/machinery/status_display/ai,
+/turf/closed/wall/mainship,
+/area/mainship/squads/general)
 "KM" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/mainship/hardened{
@@ -12012,6 +12111,10 @@
 /obj/machinery/light,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"Nq" = (
+/obj/machinery/status_display/ai,
+/turf/closed/wall/mainship,
+/area/mainship/engineering/upper_engineering)
 "Nr" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -13919,6 +14022,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/shipboard/weapon_room)
+"TF" = (
+/obj/machinery/status_display/ai,
+/turf/closed/wall/mainship,
+/area/mainship/squads/req)
 "TG" = (
 /obj/structure/window/framed/mainship,
 /obj/structure/cable,
@@ -14664,6 +14771,23 @@
 "Wl" = (
 /turf/open/floor/mainship/black/full,
 /area/mainship/squads/general)
+"Wm" = (
+/obj/structure/sign/directions/medical{
+	dir = 1;
+	pixel_x = -32;
+	pixel_y = 8
+	},
+/obj/structure/sign/directions/supply{
+	dir = 1;
+	pixel_x = -32;
+	pixel_y = -8
+	},
+/obj/structure/sign/directions/evac{
+	dir = 8;
+	pixel_x = -32
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
 "Wn" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/black{
@@ -15075,6 +15199,10 @@
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /turf/open/floor/mainship/cargo,
 /area/mainship/engineering/engineering_workshop)
+"XL" = (
+/obj/machinery/status_display/ai,
+/turf/closed/wall/mainship/white,
+/area/mainship/medical/lower_medical)
 "XN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -15235,6 +15363,10 @@
 	},
 /turf/open/shuttle/escapepod/four,
 /area/mainship/command/self_destruct)
+"Yk" = (
+/obj/machinery/status_display/ai,
+/turf/closed/wall/mainship,
+/area/mainship/command/airoom)
 "Yl" = (
 /obj/effect/landmark/start/job/squadcorpsman,
 /turf/open/floor/mainship/cargo/arrow{
@@ -41289,7 +41421,7 @@ nD
 nD
 ed
 nD
-nD
+hs
 pC
 nD
 fM
@@ -42810,7 +42942,7 @@ bh
 bh
 QM
 lO
-gd
+bj
 cC
 nO
 AP
@@ -43101,8 +43233,8 @@ gL
 Ko
 Ak
 FD
-gL
-gL
+Wm
+tr
 gL
 AM
 gL
@@ -43297,7 +43429,7 @@ Tz
 Mf
 Sl
 aO
-Mb
+dZ
 ap
 eJ
 aZ
@@ -43839,7 +43971,7 @@ bh
 kJ
 qE
 gd
-bd
+XL
 IL
 ks
 ks
@@ -43861,7 +43993,7 @@ nD
 nD
 nD
 nD
-gL
+Hm
 wj
 gL
 DS
@@ -44104,7 +44236,7 @@ nk
 MT
 fs
 ic
-ic
+kz
 ic
 ic
 ic
@@ -45943,7 +46075,7 @@ HY
 HV
 mQ
 ty
-xD
+hM
 ux
 va
 vr
@@ -46157,7 +46289,7 @@ Tl
 qG
 Tb
 Tb
-qG
+TF
 qG
 qG
 qG
@@ -47744,7 +47876,7 @@ Em
 GA
 tY
 xD
-OE
+Yk
 vw
 tj
 OE
@@ -47754,7 +47886,7 @@ uW
 OK
 OK
 OK
-OK
+Nq
 yC
 Ma
 Hv
@@ -47977,8 +48109,8 @@ jy
 xG
 jy
 AR
-jy
-jy
+zB
+gg
 jy
 jy
 jy
@@ -48463,7 +48595,7 @@ mU
 ih
 mU
 mU
-XN
+bf
 gd
 gd
 kS
@@ -48720,7 +48852,7 @@ jw
 ZE
 AH
 mU
-XN
+qL
 gd
 gd
 gd
@@ -50549,7 +50681,7 @@ kL
 hJ
 qC
 Vb
-qC
+KK
 QO
 qC
 Cp
@@ -52106,7 +52238,7 @@ UN
 xM
 qC
 sQ
-qC
+KK
 qC
 nX
 Mb


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Just a couple monitors stuffed around the place. Mostly to make it more clear whether there is an active AI to both marines & xenos. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
haha funny screen goes bzzzz
![image](https://user-images.githubusercontent.com/24830358/124756924-55be7680-df2d-11eb-9045-5bd668209182.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added some AI panels to the POS & some direction panels
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
