### PR TITLE
Rebalance the manned portable railgun

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1066,13 +1066,13 @@ datum/ammo/bullet/revolver/tp44
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
 	shell_speed = 4
 	max_range = 12
-	damage = 250
-	penetration = 70
+	damage = 100
+	penetration = 50
 	sundering = 90
 	bullet_color = COLOR_PULSE_BLUE
 
 /datum/ammo/bullet/railgun/on_hit_mob(mob/M,obj/projectile/P)
-	staggerstun(M, P, weaken = 1, stagger = 6, slowdown = 2, knockback = 2)
+	staggerstun(M, P, weaken = 1, stagger = 2, slowdown = 2, knockback = 4. shake = 0)
 
 /*
 //================================================

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1072,7 +1072,7 @@ datum/ammo/bullet/revolver/tp44
 	bullet_color = COLOR_PULSE_BLUE
 
 /datum/ammo/bullet/railgun/on_hit_mob(mob/M,obj/projectile/P)
-	staggerstun(M, P, weaken = 1, stagger = 2, slowdown = 2, knockback = 4. shake = 0)
+	staggerstun(M, P, weaken = 1, stagger = 2, slowdown = 2, knockback = 3, shake = 0)
 
 /*
 //================================================

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -1185,7 +1185,7 @@
 	reload_sound = 'sound/weapons/guns/interact/sniper_reload.ogg'
 	current_mag = /obj/item/ammo_magazine/railgun
 	force = 40
-	wield_delay = 1 SECONDS //You're not quick drawing this.
+	wield_delay = 3 SECONDS //You're not quick drawing this.
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 18,"rail_x" = 12, "rail_y" = 20, "under_x" = 19, "under_y" = 14, "stock_x" = 19, "stock_y" = 14)
 	attachable_allowed = list(
 		/obj/item/attachable/scope,

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -503,7 +503,7 @@ AMMO
 /datum/supply_packs/ammo/railgun
 	name = "Railgun round"
 	contains = list(/obj/item/ammo_magazine/railgun)
-	cost = 3
+	cost = 5
 
 /datum/supply_packs/ammo/shotguntracker
 	name = "12 Gauge Tracker Shells"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Less damage and AP like RR rockets, but still 2x shell_speed plus the 90 sunder.
Longer wield time.
No more shake on impact, and less stagger, but more knockback.
Ammo cost increase from 3 -> 5.

## Why It's Good For The Game

40 point req weapon should not be a discount SADAR shredding through all tiers of xenos on its own.

## Changelog
:cl:
balance: Rebalanced the manned portable railgun: less damage, more wield time, more knockback, less stagger/shake.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
