### PR TITLE
Mesons no longer reveal a lighting plane.

### DIFF
--- a/code/modules/clothing/glasses/meson.dm
+++ b/code/modules/clothing/glasses/meson.dm
@@ -11,7 +11,6 @@
 	toggleable = 1
 	darkness_view = 2
 	vision_flags = SEE_TURFS
-	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 
 
 /obj/item/clothing/glasses/meson/prescription


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![unknown](https://user-images.githubusercontent.com/29074600/124838880-b792d680-df55-11eb-8e69-9574f00704e8.png)

Mesons no longer give a modified lighting plane alpha. They still reveal turfs that are lit up or within your light radius, but won't work as some weird night vision analogue. 

## Why It's Good For The Game

No more funni meson stuff. An alternative to #7306 
## Changelog
:cl:
balance: Mesons dont hide darkness slightly anymore, removing a effect that on diagonals each light  showed xenos 2/3 tiles away
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
