### PR TITLE
Imager Goggles

### DIFF
--- a/code/modules/clothing/glasses/night.dm
+++ b/code/modules/clothing/glasses/night.dm
@@ -67,6 +67,6 @@
 	icon_state = "securityhud"
 	deactive_state = "degoggles_sec"
 	actions_types = list(/datum/action/item_action/toggle)
-	toggleable = 1
+	toggleable = TRUE
 	darkness_view = 2
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE

--- a/code/modules/clothing/glasses/night.dm
+++ b/code/modules/clothing/glasses/night.dm
@@ -61,7 +61,7 @@
 	lighting_alpha = LIGHTING_PLANE_ALPHA_INVISIBLE
 	flags_item = NODROP|DELONDROP
 
-/obj/item/clothing/glasses/imager_goggles
+/obj/item/clothing/glasses/night/imager_goggles
 	name = "optical imager goggles"
 	desc = "Uses image scanning to increase visibility of even the most dimly lit surroundings except total darkness"
 	icon_state = "securityhud"

--- a/code/modules/clothing/glasses/night.dm
+++ b/code/modules/clothing/glasses/night.dm
@@ -60,3 +60,13 @@
 	darkness_view = 7
 	lighting_alpha = LIGHTING_PLANE_ALPHA_INVISIBLE
 	flags_item = NODROP|DELONDROP
+
+/obj/item/clothing/glasses/imager_goggles
+	name = "optical imager goggles"
+	desc = "Uses image scanning to increase visibility of even the most dimly lit surroundings except total darkness"
+	icon_state = "securityhud"
+	deactive_state = "degoggles_sec"
+	actions_types = list(/datum/action/item_action/toggle)
+	toggleable = 1
+	darkness_view = 2
+	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -644,7 +644,7 @@ ARMOR
 /datum/supply_packs/armor/imager_goggle
 	name = "Optical Imager Goggles"
 	contains = list(/obj/item/clothing/glasses/night/imager_goggles)
-	cost = 3
+	cost = 5
 
 /datum/supply_packs/armor/riot
 	name = "Heavy Riot Armor Set"

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -644,7 +644,7 @@ ARMOR
 /datum/supply_packs/armor/imager_goggle
 	name = "Optical Imager Goggles"
 	contains = list(/obj/item/clothing/glasses/night/imager_goggles)
-	cost = 5
+	cost = 3
 
 /datum/supply_packs/armor/riot
 	name = "Heavy Riot Armor Set"

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -643,7 +643,7 @@ ARMOR
 
 /datum/supply_packs/armor/imager_goggle
 	name = "Optical Imager Goggles"
-	contains = list(/obj/item/clothing/glasses/imager_goggles)
+	contains = list(/obj/item/clothing/glasses/night/imager_goggles)
 	cost = 5
 
 /datum/supply_packs/armor/riot

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -641,6 +641,11 @@ ARMOR
 	contains = list(/obj/item/clothing/mask/gas/swat)
 	cost = 5
 
+/datum/supply_packs/armor/imager_goggle
+	name = "Optical Imager Goggles"
+	contains = list(/obj/item/clothing/glasses/imager_goggles)
+	cost = 5
+
 /datum/supply_packs/armor/riot
 	name = "Heavy Riot Armor Set"
 	contains = list(


### PR DESCRIPTION

<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
An alternative to mesons. Req only. Name, price and icon are open to discussion.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I really like the pseudo nightvision properties of meson but it seems others disagree for various reasons. Now its a req item with nothing but the light alpha adjustment. I believe this is a much better alternative than adding night vision to marines and should stay in the game.
A terribly cropped image for clarity.
![imaging](https://user-images.githubusercontent.com/23219460/125427079-0f320003-bb0e-42af-968e-da9b702275d3.png)

This PR is intended to be implemented with either #7306 or #7307
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
expansion: Added meson-like goggles to req
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
