### PR TITLE
Fixes unreloadable EORD Thermobaric

### DIFF
--- a/code/game/objects/effects/landmarks/landmarks.dm
+++ b/code/game/objects/effects/landmarks/landmarks.dm
@@ -379,7 +379,6 @@
 	weapon_list = list(
 		/obj/item/weapon/gun/launcher/rocket,
 		/obj/item/weapon/gun/launcher/rocket/m57a4,
-		/obj/item/weapon/gun/launcher/rocket/m57a4/xmas,
 		/obj/item/weapon/gun/minigun,
 		/obj/item/weapon/gun/launcher/m92,
 		/obj/item/weapon/gun/energy/lasgun/pulse,


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Basically this just removes the thermobaric XMAS launcher from the weapon spawn list in the tier 5 weapon spawner landmark. It removes the 50% chance of a thermobaric that spawns in EORD being impossible to reload. 

## Why It's Good For The Game

Because this way we won't get people mhelping during EORD asking why their thermo won't reload. 

## Changelog
:cl:
fix: EORD thermobarics can be reloaded reliably.
/:cl:
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
