### PR TITLE
Acid blood bugfix

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -480,11 +480,11 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define CASTE_QUICK_HEAL_STANDING (1<<11) // Xenomorphs heal standing same if they were resting.
 #define CASTE_CAN_HEAL_WITHOUT_QUEEN (1<<12) // Xenomorphs can heal even without a queen on the same z level
 #define CASTE_INNATE_PLASMA_REGEN (1<<13) // Xenos get full plasma regardless if they are on weeds or not
-#define CASTE_ACID_BLOOD (1<<13) //The acid blood effect which damages humans near xenos that take damage
-#define CASTE_CAN_HOLD_JELLY (1<<14)//whether we can hold fireproof jelly in our hands
-#define CASTE_IS_STRONG (1<<15)//can tear open acided walls without being big
-#define CASTE_CAN_CORRUPT_GENERATOR (1<<16) //Can corrupt a generator
-#define CASTE_IS_BUILDER (1<<17) //whether we are classified as a builder caste
+#define CASTE_ACID_BLOOD (1<<14) //The acid blood effect which damages humans near xenos that take damage
+#define CASTE_CAN_HOLD_JELLY (1<<15)//whether we can hold fireproof jelly in our hands
+#define CASTE_IS_STRONG (1<<16)//can tear open acided walls without being big
+#define CASTE_CAN_CORRUPT_GENERATOR (1<<17) //Can corrupt a generator
+#define CASTE_IS_BUILDER (1<<18) //whether we are classified as a builder caste
 
 //Charge-Crush
 #define CHARGE_OFF 0


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ravagers had acid blood because the CASTE_INNATE_PLASMA_REGEN define had the same number as the CASTE_ACID_BLOOD define. 

## Why It's Good For The Game

Nothing but boilers is supposed to have acid blood. 

## Changelog
:cl:
fix: Ravagers have normal blood now. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
