### PR TITLE
acid wells are now layered above everything else in the tile

### DIFF
--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -798,7 +798,7 @@ TUNNEL
 	opacity = FALSE
 	anchored = TRUE
 	max_integrity = 5
-	layer = RESIN_STRUCTURE_LAYER
+	layer = UPPER_ITEM_LAYER
 
 	hit_sound = "alien_resin_move"
 	destroy_sound = "alien_resin_move"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![image](https://user-images.githubusercontent.com/46353991/125036415-f95c7380-e060-11eb-8073-e4a391ed3cef.png)

hivelord/queen don't need the ability to place traps that have armor piercing and nearly instantly kill you, with literally no cd past the amount of plasma it costs (and plasma isn't really a issue for either caste) and this is annoying to play against as marine because there's literally no tell to it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This isn't interesting or fun to go against considering acid wells have next to no cooldown and thin sticky resin has no noticeable difference from normal sticky at a glance. And sticky in general is annoying to play against.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: acid wells are layered above everything else in the tile other than mobs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
