### PR TITLE
Crit Drag Oxyloss Increase

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -50,7 +50,7 @@
 #define CARBON_RECOVERY_OXYLOSS -5 //the amount of oxyloss recovery per successful breath tick.
 
 #define CARBON_KO_OXYLOSS 50
-#define HUMAN_CRITDRAG_OXYLOSS 3 //the amount of oxyloss taken per tile a human is dragged by a xeno while unconscious
+#define HUMAN_CRITDRAG_OXYLOSS 10 //the amount of oxyloss taken per tile a human is dragged by a xeno while unconscious
 
 #define HEAT_DAMAGE_LEVEL_1 1 //Amount of damage applied when your body temperature just passes the 360.15k safety point
 #define HEAT_DAMAGE_LEVEL_2 2 //Amount of damage applied when your body temperature passes the 400K point


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Increases the oxyloss from being dragged while in crit. 

Critdrag is extreme at this point in time, with crit marines being dragged excessive lengths to make up for the fact that xenos cannot drag dead bodies in the distress signal game mode. It's quite obvious that the current damage isn't nearly enough to actually limit crit dragging distance, and thus I aim to increase it. 

![crit drag](https://user-images.githubusercontent.com/29074600/125173871-a208f100-e18f-11eb-8911-36a54b3c068f.png)

If crit drag really is meant to be no more than 4 or 5 tiles, then this will make that actually true. The above image is actually on the more conservative end of crit dragging, and doesn't take into account xenos that bump push others in order to move them so much faster than the intended drag speed that they can cross long distances before the target's health properly updates and registers them as dead. 

## Why It's Good For The Game

Less excessive amounts of crit dragging. Xenos can't move dead bodies in distress anyways, and in hunt it doesn't matter because they can. 

## Changelog
:cl:
balance: Crit drag deals more oxyloss. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
