### PR TITLE
Siloless collaspe is at 45 mintues into a round rather than an hour

### DIFF
--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -142,7 +142,7 @@
 /// This is used to ponderate the number of silo, so to reduces the diminishing returns of having more and more silos
 #define SILO_OUTPUT_PONDERATION 2
 //Time (after round start) before siloless timer can start
-#define MINIMUM_TIME_SILO_LESS_COLLAPSE 40 MINUTES
+#define MINIMUM_TIME_SILO_LESS_COLLAPSE 45 MINUTES
 
 #define INFESTATION_MARINE_DEPLOYMENT 0
 #define INFESTATION_MARINE_CRASHING 1

--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -142,7 +142,7 @@
 /// This is used to ponderate the number of silo, so to reduces the diminishing returns of having more and more silos
 #define SILO_OUTPUT_PONDERATION 2
 //Time (after round start) before siloless timer can start
-#define MINIMUM_TIME_SILO_LESS_COLLAPSE 1 HOURS
+#define MINIMUM_TIME_SILO_LESS_COLLAPSE 40 MINUTES
 
 #define INFESTATION_MARINE_DEPLOYMENT 0
 #define INFESTATION_MARINE_CRASHING 1


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Distress right now for half of the round is literally as bad as hunt is in terms of having no concrete objective for the marines to focus on, and so the xenomorphs are encouraged to not even place a silo at all.
While this stops instant SILO RUSH B this makes it so xenomorphs aleast have to place a silo into a decent portion of the round (Considering most rounds start around at 12:25, it should be atleast be 25 minutes or so before you NEED a silo, rather than 40 minutes.)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes distress more of a objective based game mode rather than just a meme tdm until an hour into the round
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: silo collaspe takes 45 minutes from roundstart to begin happening, rather than an hour
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
