### PR TITLE
Buffs Rifle bullets and HV rifle bullets sunder

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -586,7 +586,7 @@ datum/ammo/bullet/revolver/tp44
 	max_range = 15
 	damage = 80
 	penetration = 40
-	sundering = 5
+	sundering = 7
 
 /datum/ammo/bullet/shotgun/slug/on_hit_mob(mob/M,obj/projectile/P)
 	staggerstun(M, P, weaken = 1, stagger = 2, knockback = 1, slowdown = 2)

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -521,7 +521,7 @@ datum/ammo/bullet/revolver/tp44
 	damage = 25
 	accuracy = 10
 	penetration = 20
-	sundering = 2
+	sundering = 2.5
 
 /datum/ammo/bullet/rifle/tx8/impact
 	name = "high velocity impact bullet"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -512,7 +512,7 @@ datum/ammo/bullet/revolver/tp44
 	accurate_range_min = 6
 	damage = 40
 	penetration = 20
-	sundering = 7.5
+	sundering = 10
 
 /datum/ammo/bullet/rifle/tx8/incendiary
 	name = "high velocity incendiary bullet"
@@ -529,7 +529,7 @@ datum/ammo/bullet/revolver/tp44
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
 	damage = 25
 	penetration = 45
-	sundering = 3.5
+	sundering = 5
 
 /datum/ammo/bullet/rifle/tx8/impact/on_hit_mob(mob/M, obj/projectile/P)
 	staggerstun(M, P, max_range = 40, stagger = 2, slowdown = 3.5, knockback = 1)
@@ -944,7 +944,7 @@ datum/ammo/bullet/revolver/tp44
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING|AMMO_SNIPER
 	damage = 80
 	penetration = 30
-	sundering = 5
+	sundering = 7.5
 	accurate_range_min = 2
 	damage_falloff = 0.25
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -472,7 +472,7 @@ datum/ammo/bullet/revolver/tp44
 	accurate_range = 15
 	damage = 25
 	penetration = 5
-	sundering = 0.5
+	sundering = 1
 
 /datum/ammo/bullet/rifle/ap
 	name = "armor-piercing rifle bullet"
@@ -486,7 +486,7 @@ datum/ammo/bullet/revolver/tp44
 	hud_state = "hivelo"
 	damage = 20
 	penetration = 10
-	sundering = 1
+	sundering = 1.5
 
 /datum/ammo/bullet/rifle/incendiary
 	name = "incendiary rifle bullet"
@@ -512,7 +512,7 @@ datum/ammo/bullet/revolver/tp44
 	accurate_range_min = 6
 	damage = 40
 	penetration = 20
-	sundering = 10
+	sundering = 7.5
 
 /datum/ammo/bullet/rifle/tx8/incendiary
 	name = "high velocity incendiary bullet"
@@ -521,7 +521,7 @@ datum/ammo/bullet/revolver/tp44
 	damage = 25
 	accuracy = 10
 	penetration = 20
-	sundering = 2.5
+	sundering = 2
 
 /datum/ammo/bullet/rifle/tx8/impact
 	name = "high velocity impact bullet"
@@ -529,7 +529,7 @@ datum/ammo/bullet/revolver/tp44
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
 	damage = 25
 	penetration = 45
-	sundering = 5
+	sundering = 3.5
 
 /datum/ammo/bullet/rifle/tx8/impact/on_hit_mob(mob/M, obj/projectile/P)
 	staggerstun(M, P, max_range = 40, stagger = 2, slowdown = 3.5, knockback = 1)
@@ -586,7 +586,7 @@ datum/ammo/bullet/revolver/tp44
 	max_range = 15
 	damage = 80
 	penetration = 40
-	sundering = 7
+	sundering = 5
 
 /datum/ammo/bullet/shotgun/slug/on_hit_mob(mob/M,obj/projectile/P)
 	staggerstun(M, P, weaken = 1, stagger = 2, knockback = 1, slowdown = 2)
@@ -944,7 +944,7 @@ datum/ammo/bullet/revolver/tp44
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING|AMMO_SNIPER
 	damage = 80
 	penetration = 30
-	sundering = 7.5
+	sundering = 5
 	accurate_range_min = 2
 	damage_falloff = 0.25
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
 buffs rifle bullets to 1, tx-11 to 1.5
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Rifles orginally dealt next to no sundering because there were next to no ways of recovering sunder in the game, now that recov heals it, hivelord heals a LOT of sunder per heal beam, and many ways of healing it exist that make the 0.5 sunder which used to be quite a bit near irrelevant.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: rifle bullets and high velocity rifle bullets (not tx-8) deal more sunder.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
