### PR TITLE
Ravager gains fury when damaged and passive regen reduced.

### DIFF
--- a/code/datums/elements/plasma_on_attack.dm
+++ b/code/datums/elements/plasma_on_attack.dm
@@ -12,6 +12,10 @@
 	RegisterSignal(target, COMSIG_XENOMORPH_ATTACK_LIVING, .proc/damage_dealt)
 	src.damage_plasma_multiplier = damage_plasma_multiplier
 
+/datum/element/plasma_on_attack/Detach(datum/source, force)
+	. = ..()
+	UnregisterSignal(source, COMSIG_XENOMORPH_ATTACK_LIVING)
+
 ///Gives plasma when damage is caused on living mob.
 /datum/element/plasma_on_attack/proc/damage_dealt(datum/source, mob/living/attacked, damage)
 	SIGNAL_HANDLER

--- a/code/datums/elements/plasma_on_attacked.dm
+++ b/code/datums/elements/plasma_on_attacked.dm
@@ -1,0 +1,23 @@
+/datum/element/plasma_on_attacked
+	element_flags = ELEMENT_BESPOKE
+	id_arg_index = 2
+
+	///the multiplier of plasma gained via receiving damage.
+	var/damage_plasma_multiplier = 1
+
+/datum/element/plasma_on_attacked/Attach(datum/target, damage_plasma_multiplier)
+	. = ..()
+	if(!isxeno(target))
+		return ELEMENT_INCOMPATIBLE
+	RegisterSignal(target, COMSIG_XENOMORPH_TAKING_DAMAGE, .proc/damage_suffered)
+	src.damage_plasma_multiplier = damage_plasma_multiplier
+
+/datum/element/plasma_on_attacked/Detach(datum/source, force)
+	. = ..()
+	UnregisterSignal(source, COMSIG_XENOMORPH_TAKING_DAMAGE)
+
+
+/datum/element/plasma_on_attacked/proc/damage_suffered(datum/source, damage)
+	SIGNAL_HANDLER
+	var/mob/living/carbon/xenomorph/furious = source
+	furious.gain_plasma(damage * damage_plasma_multiplier)

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
@@ -17,7 +17,7 @@
 
 	// *** Plasma *** //
 	plasma_max = 600
-	plasma_gain = 20
+	plasma_gain = 5
 	plasma_regen_limit = 0.5
 	plasma_icon_state = "fury"
 
@@ -65,7 +65,7 @@
 
 	// *** Plasma *** //
 	plasma_max = 700 //Enables using either both abilities at once or one after another
-	plasma_gain = 25
+	plasma_gain = 5
 
 	// *** Health *** //
 	max_health = 310
@@ -90,7 +90,7 @@
 
 	// *** Plasma *** //
 	plasma_max = 750
-	plasma_gain = 30
+	plasma_gain = 10
 	plasma_regen_limit = 0.6
 
 	// *** Health *** //
@@ -116,7 +116,7 @@
 
 	// *** Plasma *** //
 	plasma_max = 800
-	plasma_gain = 35
+	plasma_gain = 15
 
 	// *** Health *** //
 	max_health = 350

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/ravager.dm
@@ -17,6 +17,7 @@
 /mob/living/carbon/xenomorph/ravager/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/plasma_on_attack, 1.5)
+	AddElement(/datum/element/plasma_on_attacked, 0.5)
 
 // ***************************************
 // *********** Mob overrides

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -335,6 +335,7 @@
 #include "code\datums\elements\limb_support.dm"
 #include "code\datums\elements\pathfinder.dm"
 #include "code\datums\elements\plasma_on_attack.dm"
+#include "code\datums\elements\plasma_on_attacked.dm"
 #include "code\datums\elements\scalping.dm"
 #include "code\datums\elements\shrapnel_removal.dm"
 #include "code\datums\elements\special_clothing_overlay.dm"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ravager now gets fury when attacked, 50% of the damage received and their passive regen is severely reduced

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This makes ravager less do nothing against suppression, making them able to reciprocate while we reduce its plasma regen so they dont regen quickly around without being actively in combat.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
expansion: Ravager now also gets fury on receiving damage.
balance: Ravager Passive fury regen has been severely reduced.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
