### PR TITLE
Fixes ahealing dead xenos

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -163,8 +163,6 @@
 
 
 /mob/living/carbon/xenomorph/adjustBruteLoss(amount, updating_health = FALSE)
-	if(stat == DEAD)
-		return
 
 	var/list/amount_mod = list()
 	SEND_SIGNAL(src, COMSIG_XENOMORPH_BRUTE_DAMAGE, amount, amount_mod)
@@ -178,8 +176,6 @@
 
 
 /mob/living/carbon/xenomorph/adjustFireLoss(amount, updating_health = FALSE)
-	if(stat == DEAD)
-		return
 
 	var/list/amount_mod = list()
 	SEND_SIGNAL(src, COMSIG_XENOMORPH_BURN_DAMAGE, amount, amount_mod)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The two checks being removed in this were what was preventing dead xenos from being ahealed properly. This will not allow you to stack damage on dead xenos, because there's already a check for if a xeno is dead in the take damage proc that stops things from moving on to adjustBruteLoss or adjustFireLoss. 
Fixes #7348 

## Why It's Good For The Game

Allows admins to heal dead xenos without having to resort to transforming them into the same caste and then re-upgrade them. 

## Changelog
:cl:
fix: Admins can aheal dead xenos again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
