### PR TITLE
Disable the antena module beeping to cull spam.

### DIFF
--- a/code/modules/modular_armor/helmets.dm
+++ b/code/modules/modular_armor/helmets.dm
@@ -116,7 +116,6 @@
 
 /obj/item/helmet_module/antenna/toggle_module(mob/living/user, obj/item/clothing/head/modular/parent)
 	var/turf/location = get_turf(src)
-	playsound(user, 'sound/machines/twobeep.ogg', 60, 1)
 	if(beacon_datum)
 		UnregisterSignal(beacon_datum, COMSIG_PARENT_QDELETING)
 		QDEL_NULL(beacon_datum)


### PR DESCRIPTION
## About The Pull Request
This just removes the noise from this module. You can spam it, but only your own feed will get filled.

## Why It's Good For The Game
Spammers suck, and the noise is too distinct for a cooldown to really make it less annoying.

## Changelog
:cl:

qol: disable antenna module beeping due to spam.

/:cl:
