### PR TITLE
Reverts old MJP sentries change that literally killed sentries, with less sunder.

### DIFF
--- a/code/game/objects/machinery/sentries.dm
+++ b/code/game/objects/machinery/sentries.dm
@@ -235,8 +235,8 @@
 	var/max_burst = 6
 	var/min_burst = 2
 	var/atom/target = null
-	obj_integrity = 150
-	max_integrity = 150
+	obj_integrity = 300
+	max_integrity = 300
 	soft_armor = list("melee" = 50, "bullet" = 50, "laser" = 50, "energy" = 50, "bomb" = 50, "bio" = 100, "rad" = 0, "fire" = 80, "acid" = 50)
 	machine_stat = 0 //Used just like mob.stat
 	var/datum/effect_system/spark_spread/spark_system //The spark system, used for generating... sparks?
@@ -1198,8 +1198,8 @@
 	burst_size = 3
 	min_burst = 2
 	max_burst = 5
-	obj_integrity = 100
-	max_integrity = 100
+	obj_integrity = 200
+	max_integrity = 200
 	rounds = 500
 	rounds_max = 500
 	knockdown_threshold = 100 //lighter, not as well secured.

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1019,9 +1019,9 @@ datum/ammo/bullet/revolver/tp44
 	accurate_range = 10
 	accuracy_var_low = 3
 	accuracy_var_high = 3
-	damage = 20
+	damage = 40
 	penetration = 10
-	sundering = 3 //small damage big sunder
+	sundering = 2
 	damage_falloff = 0.5 //forgot to add this
 
 /datum/ammo/bullet/turret/dumb
@@ -1029,7 +1029,7 @@ datum/ammo/bullet/revolver/tp44
 
 /datum/ammo/bullet/turret/gauss
 	name = "heavy gauss turret slug"
-	damage = 25
+	damage = 30
 	penetration = 30
 	accurate_range = 3
 	sundering = 0
@@ -1037,9 +1037,9 @@ datum/ammo/bullet/revolver/tp44
 
 /datum/ammo/bullet/turret/mini
 	name = "small caliber autocannon bullet"
-	damage = 15
+	damage = 35
 	penetration = 10
-	sundering = 2
+	sundering = 0
 
 
 /datum/ammo/bullet/machinegun //Adding this for the MG Nests (~Art)

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1021,7 +1021,7 @@ datum/ammo/bullet/revolver/tp44
 	accuracy_var_high = 3
 	damage = 40
 	penetration = 10
-	sundering = 2
+	sundering = 0
 	damage_falloff = 0.5 //forgot to add this
 
 /datum/ammo/bullet/turret/dumb


### PR DESCRIPTION
This reverts commit 23a7c4a6a8bdac6cb02547d60e96e51649b5938d.

<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Just reverts #5216  with some slight changes so they dont overwhelm too much.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
ever since sentries have been completely shit and doens't even do anything other than alert marines, they literally have a SMG bullet damage with a ULTRA LONG burst fire delay, making them LITERALLY DO NOTHING against xenos, as if it was not enough, THEY DIE TO 4 T12 shots from FRIENDLY FIRE.

this brings the old sentry damage back, but removes sunder so theyre not effective as a very long term deterrent, only as momentarily, by not causing sunder, which lasts longer than damage does(somewhat).

also raises their health, which keeps them from exploding to any shit, they however still knockdown to the treshold they'd explode from before, so if left unattended a sentry is just as easy to break as it was before.

This should make sentries better and not nearly useless, so marines don't need to watch a barricade with 1(one) xeno harassing it since sentries cant deal with it at all, yet they can be easily taken down if unattended by some coordination.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: sentries now have more health so they dont die as easily, they however suffer knockdown at the old health value(which dindt happen because it died at same time)
balance: sentries now have quite more damage so they have a fair DPS, but they don't get sunder.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
