### PR TITLE
Lets you name pill bottles

### DIFF
--- a/code/modules/reagents/machinery/chem_master.dm
+++ b/code/modules/reagents/machinery/chem_master.dm
@@ -184,8 +184,11 @@
 				if(loaded_pill_bottle)
 					to_chat(user, "<span class='warning'>A pill bottle is already loaded into the machine.</span>")
 					return
+				var/bottle_label = reject_bad_text(input(user, "Label:", "Enter desired bottle label.", null) as text|null)
 				var/obj/item/storage/pill_bottle/I = new/obj/item/storage/pill_bottle
 				I.icon_state = "pill_canister"+pillbottlesprite
+				if(bottle_label)
+					I.name = "[bottle_label] pill bottle"
 				loaded_pill_bottle = I
 				to_chat(user, "<span class='notice'>The Chemmaster 3000 sets a pill bottle into the dispenser slot.</span>")
 				updateUsrDialog()

--- a/code/modules/reagents/machinery/chem_master.dm
+++ b/code/modules/reagents/machinery/chem_master.dm
@@ -184,7 +184,7 @@
 				if(loaded_pill_bottle)
 					to_chat(user, "<span class='warning'>A pill bottle is already loaded into the machine.</span>")
 					return
-				var/bottle_label = reject_bad_text(input(user, "Label:", "Enter desired bottle label.", null) as text|null)
+				var/bottle_label = reject_bad_text(input(user, "Label:", "Enter desired bottle label", null) as text|null)
 				var/obj/item/storage/pill_bottle/I = new/obj/item/storage/pill_bottle
 				I.icon_state = "pill_canister"+pillbottlesprite
 				if(bottle_label)


### PR DESCRIPTION
## About The Pull Request
Adds a prompt to the chem master when you dispense a pill bottle to let you name it, the way you can with pills and injectors.

## Why It's Good For The Game
Using the hand labeler afterwards is annoying.

## Changelog
:cl:
add: You can name pill bottles when you dispense them from a chem master
/:cl: