### PR TITLE
Removes double healing from most xeno sources

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
@@ -45,7 +45,7 @@
 	add_cooldown()
 
 /mob/living/carbon/xenomorph/proc/salve_healing() //Slight modification of the heal_wounds proc
-	var/amount = 40	//Smaller than psychic cure, less useful on xenos with large health pools
+	var/amount = 50	//Smaller than psychic cure, less useful on xenos with large health pools
 	if(recovery_aura)	//Leaving in the recovery aura bonus, not sure if it is too high the way it is
 		amount += recovery_aura * maxHealth * 0.008 // +0.8% max health per recovery level, up to +4%
 	var/remainder = max(0, amount - getBruteLoss()) //Heal brute first, apply whatever's left to burns

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
@@ -48,6 +48,7 @@
 	var/amount = 40	//Smaller than psychic cure, less useful on xenos with large health pools
 	if(recovery_aura)	//Leaving in the recovery aura bonus, not sure if it is too high the way it is
 		amount += recovery_aura * maxHealth * 0.008 // +0.8% max health per recovery level, up to +4%
+	var/remainder = max(0, amount - getBruteLoss()) //Heal brute first, apply whatever's left to burns
 	adjustBruteLoss(-amount)
-	adjustFireLoss(-amount, updating_health = TRUE)
+	adjustFireLoss(-remainder, updating_health = TRUE)
 	adjust_sunder(-amount/20)

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -119,8 +119,9 @@
 
 	SEND_SIGNAL(src, COMSIG_XENOMORPH_HEALTH_REGEN, src)
 
+	var/remainder = max(0, amount-getBruteLoss())
 	adjustBruteLoss(-amount)
-	adjustFireLoss(-amount)
+	adjustFireLoss(-remainder)
 
 /mob/living/carbon/xenomorph/proc/handle_living_plasma_updates()
 	var/turf/T = loc

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -103,7 +103,7 @@
 		adjustBruteLoss(XENO_CRIT_DAMAGE - (warding_aura * 0.5)) //Warding can heavily lower the impact of bleedout. Halved at 5.
 
 /mob/living/carbon/xenomorph/proc/heal_wounds(multiplier = XENO_RESTING_HEAL, scaling = FALSE)
-	var/amount = 1 + (maxHealth * 0.03) // 1 damage + 2% max health, with scaling power.
+	var/amount = 1 + (maxHealth * 0.0375) // 1 damage + 2% max health, with scaling power.
 	if(recovery_aura)
 		amount += recovery_aura * maxHealth * 0.008 // +0.8% max health per recovery level, up to +4%
 	if(scaling)


### PR DESCRIPTION
## About The Pull Request
All xeno healing aside from hivelord laser calculates an amount to heal and then applies that separately to both brute and burn damage. This makes it apply as much as possible to brute, and then the remainder to burn.
Also increases base healing by 25% to compensate, requested by lewdcifer.

## Why It's Good For The Game
Fixes #7344 
Moderate nerf to xeno sustain against any split damage, usually from grenades or one dude in a crowd with a flamethrower. Might be worth bumping up heal numbers depending on how it pans out.

## Changelog
:cl:
fix: Xeno healing now splits properly between brute and burn instead of doubling, base healing increased 25% to compensate
/:cl: