### PR TITLE
Fixes destroyed limbs also being broken

### DIFF
--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -756,8 +756,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(body_part == CHEST)
 		return FALSE
 
-	remove_limb_flags()
-	add_limb_flags(LIMB_BLEEDING | LIMB_DESTROYED)
+	set_limb_flags(LIMB_DESTROYED)
 
 	for(var/i in implants)
 		var/obj/item/embedded_thing = i


### PR DESCRIPTION
## About The Pull Request
Properly clears flags when a limb is removed. This doesn't change behavior at all since nothing a broken limb can do happens if it's destroyed. Also the bleeding flag cleared instantly anyway since a destroyed limb has no wounds.

## Why It's Good For The Game
It annoys me seeing untreatable breaks on med scanners even if they don't do anything. 

## Changelog
:cl:
fix: If your arm gets torn off, it isn't broken any more.
/:cl: