### PR TITLE
Make it so the AI has a notification for when lasers goes out.

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -38,11 +38,11 @@
 ///Sent when nightfall is casted
 #define COMSIG_GLOB_LIGHT_OFF "item_light_off"
 ///Sent when the floodlight switch is powered
-#define COMSIG_GLOB_FLOODLIGHT_SWITCH "floodlight_switch_power_change"
+#define COMSIG_GLOB_FLOODLIGHT_SWITCH "!floodlight_switch_power_change"
 
 //Signals for fire support
-#define COMSIG_GLOB_OB_LASER_SENT "ob_laser_sent"
-#define COMSIG_GLOB_CAS_LASER_SENT "cas_laser_sent"
+#define COMSIG_GLOB_OB_LASER_CREATED "!ob_laser_sent"
+#define COMSIG_GLOB_CAS_LASER_CREATED "!cas_laser_sent"
 
 //////////////////////////////////////////////////////////////////
 

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -41,7 +41,8 @@
 #define COMSIG_GLOB_FLOODLIGHT_SWITCH "floodlight_switch_power_change"
 
 //Signals for fire support
-#define COMSIG_GLOB_LASER_SENT "ob_laser_sent"
+#define COMSIG_GLOB_OB_LASER_SENT "ob_laser_sent"
+#define COMSIG_GLOB_CAS_LASER_SENT "cas_laser_sent"
 
 //////////////////////////////////////////////////////////////////
 

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -40,6 +40,9 @@
 ///Sent when the floodlight switch is powered
 #define COMSIG_GLOB_FLOODLIGHT_SWITCH "floodlight_switch_power_change"
 
+//Signals for fire support
+#define COMSIG_GLOB_LASER_SENT "ob_laser_sent"
+
 //////////////////////////////////////////////////////////////////
 
 // /datum signals

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -140,8 +140,8 @@
 	. = ..()
 	linked_cam = new(loc, name)
 	GLOB.active_cas_targets += src
-	for(var/mob/living/silicon/ai/AI in GLOB.silicon_mobs)
-		to_chat(AI, "<span class='notice'>CAS laser detected. Target: [AREACOORD_NO_Z(src)]</span>")
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_CAS_LASER_SENT, src)
+
 
 
 /obj/effect/overlay/temp/laser_target/cas/Destroy()
@@ -158,7 +158,7 @@
 
 /obj/effect/overlay/temp/laser_target/OB/Initialize(mapload, named, assigned_squad)
 	. = ..()
-	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_LASER_SENT, src)
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_OB_LASER_SENT, src)
 	GLOB.active_laser_targets += src
 
 /obj/effect/overlay/temp/laser_target/OB/Destroy()

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -140,6 +140,9 @@
 	. = ..()
 	linked_cam = new(loc, name)
 	GLOB.active_cas_targets += src
+	for(var/mob/living/silicon/ai/AI in GLOB.silicon_mobs)
+		to_chat(AI, "<span class='notice'>CAS laser detected. Target: [AREACOORD_NO_Z(src)]</span>")
+
 
 /obj/effect/overlay/temp/laser_target/cas/Destroy()
 	. = ..()
@@ -156,6 +159,9 @@
 /obj/effect/overlay/temp/laser_target/OB/Initialize(mapload, named, assigned_squad)
 	. = ..()
 	GLOB.active_laser_targets += src
+	for(var/mob/living/silicon/ai/AI in GLOB.silicon_mobs)
+		to_chat(AI, "<span class='notice'>Orbital Bombardment laser detected. Target: [AREACOORD_NO_Z(src)]</span>")
+		playsound(AI, 'sound/effects/binoctarget.ogg', 15)
 
 /obj/effect/overlay/temp/laser_target/OB/Destroy()
 	. = ..()

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -140,7 +140,7 @@
 	. = ..()
 	linked_cam = new(loc, name)
 	GLOB.active_cas_targets += src
-	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_CAS_LASER_SENT, src)
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_CAS_LASER_CREATED, src)
 
 
 
@@ -158,7 +158,7 @@
 
 /obj/effect/overlay/temp/laser_target/OB/Initialize(mapload, named, assigned_squad)
 	. = ..()
-	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_OB_LASER_SENT, src)
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_OB_LASER_CREATED, src)
 	GLOB.active_laser_targets += src
 
 /obj/effect/overlay/temp/laser_target/OB/Destroy()

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -142,8 +142,6 @@
 	GLOB.active_cas_targets += src
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_CAS_LASER_CREATED, src)
 
-
-
 /obj/effect/overlay/temp/laser_target/cas/Destroy()
 	. = ..()
 	GLOB.active_cas_targets -= src

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -158,10 +158,8 @@
 
 /obj/effect/overlay/temp/laser_target/OB/Initialize(mapload, named, assigned_squad)
 	. = ..()
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_LASER_SENT, src)
 	GLOB.active_laser_targets += src
-	for(var/mob/living/silicon/ai/AI in GLOB.silicon_mobs)
-		to_chat(AI, "<span class='notice'>Orbital Bombardment laser detected. Target: [AREACOORD_NO_Z(src)]</span>")
-		playsound(AI, 'sound/effects/binoctarget.ogg', 15)
 
 /obj/effect/overlay/temp/laser_target/OB/Destroy()
 	. = ..()

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1,3 +1,4 @@
+///This elevator serves me alone. I have complete control over this entire level. With cameras as my eyes and nodes as my hands, I rule here, insect.
 /mob/living/silicon/ai
 	name = "ARES v3.2"
 	real_name = "ARES v3.2"
@@ -119,12 +120,12 @@
 /mob/living/silicon/ai/proc/receive_laser_ob(datum/source, obj/effect/overlay/temp/laser_target/OB/incoming_laser)
 	SIGNAL_HANDLER
 	to_chat(src, "<span class='notice'>Orbital Bombardment laser detected. Target: [AREACOORD_NO_Z(incoming_laser)] </span>")
-	playsound(src, 'sound/effects/binoctarget.ogg', 15)
+	playsound_local(src, 'sound/effects/binoctarget.ogg', 15)
 
 /mob/living/silicon/ai/proc/receive_laser_cas(datum/source, obj/effect/overlay/temp/laser_target/cas/incoming_laser)
 	SIGNAL_HANDLER
 	to_chat(src, "<span class='notice'>CAS laser detected. Target: [AREACOORD_NO_Z(src)]</span>")
-	playsound(src, 'sound/effects/binoctarget.ogg', 15)
+	playsound_local(src, 'sound/effects/binoctarget.ogg', 15)
 
 /mob/living/silicon/ai/restrained(ignore_checks)
 	return FALSE

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -76,6 +76,7 @@
 
 	RegisterSignal(src, COMSIG_MOB_CLICK_ALT, .proc/send_order)
 	RegisterSignal(src, COMSIG_ORDER_SELECTED, .proc/set_order)
+	RegisterSignal(SSdcs, COMSIG_GLOB_LASER_SENT, .proc/receive_laser)
 
 	var/datum/action/innate/order/attack_order/send_attack_order = new
 	var/datum/action/innate/order/defend_order/send_defend_order = new
@@ -107,6 +108,13 @@
 /mob/living/silicon/ai/proc/set_order(datum/source, datum/action/innate/order/order)
 	SIGNAL_HANDLER
 	current_order = order
+
+
+///Receive fire support laser notifications
+/mob/living/silicon/ai/proc/receive_laser(datum/source, obj/effect/overlay/temp/laser_target/OB/incoming_laser)
+	SIGNAL_HANDLER
+	to_chat(src, "<span class='notice'>Orbital Bombardment laser detected. Target: [AREACOORD_NO_Z(incoming_laser)] </span>")
+	playsound(src, 'sound/effects/binoctarget.ogg', 15)
 
 /mob/living/silicon/ai/restrained(ignore_checks)
 	return FALSE

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -76,7 +76,10 @@
 
 	RegisterSignal(src, COMSIG_MOB_CLICK_ALT, .proc/send_order)
 	RegisterSignal(src, COMSIG_ORDER_SELECTED, .proc/set_order)
-	RegisterSignal(SSdcs, COMSIG_GLOB_LASER_SENT, .proc/receive_laser)
+	RegisterSignal(SSdcs, COMSIG_GLOB_OB_LASER_SENT, .proc/receive_laser_OB)
+	RegisterSignal(SSdcs, COMSIG_GLOB_CAS_LASER_SENT, .proc/receive_laser_CAS)
+
+
 
 	var/datum/action/innate/order/attack_order/send_attack_order = new
 	var/datum/action/innate/order/defend_order/send_defend_order = new
@@ -111,9 +114,14 @@
 
 
 ///Receive fire support laser notifications
-/mob/living/silicon/ai/proc/receive_laser(datum/source, obj/effect/overlay/temp/laser_target/OB/incoming_laser)
+/mob/living/silicon/ai/proc/receive_laser_OB(datum/source, obj/effect/overlay/temp/laser_target/OB/incoming_laser)
 	SIGNAL_HANDLER
 	to_chat(src, "<span class='notice'>Orbital Bombardment laser detected. Target: [AREACOORD_NO_Z(incoming_laser)] </span>")
+	playsound(src, 'sound/effects/binoctarget.ogg', 15)
+
+/mob/living/silicon/ai/proc/receive_laser_CAS(datum/source, obj/effect/overlay/temp/laser_target/cas/incoming_laser)
+	SIGNAL_HANDLER
+	to_chat(src, "<span class='notice'>CAS laser detected. Target: [AREACOORD_NO_Z(src)]</span>")
 	playsound(src, 'sound/effects/binoctarget.ogg', 15)
 
 /mob/living/silicon/ai/restrained(ignore_checks)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -76,8 +76,8 @@
 
 	RegisterSignal(src, COMSIG_MOB_CLICK_ALT, .proc/send_order)
 	RegisterSignal(src, COMSIG_ORDER_SELECTED, .proc/set_order)
-	RegisterSignal(SSdcs, COMSIG_GLOB_OB_LASER_SENT, .proc/receive_laser_OB)
-	RegisterSignal(SSdcs, COMSIG_GLOB_CAS_LASER_SENT, .proc/receive_laser_CAS)
+	RegisterSignal(SSdcs, COMSIG_GLOB_OB_LASER_CREATED, .proc/receive_laser_ob)
+	RegisterSignal(SSdcs, COMSIG_GLOB_CAS_LASER_CREATED, .proc/receive_laser_cas)
 
 
 
@@ -97,6 +97,8 @@
 	QDEL_NULL(track)
 	UnregisterSignal(src, COMSIG_ORDER_SELECTED)
 	UnregisterSignal(src, COMSIG_MOB_CLICK_ALT)
+	UnregisterSignal(SSdcs, COMSIG_GLOB_OB_LASER_CREATED)
+	UnregisterSignal(SSdcs, COMSIG_GLOB_CAS_LASER_CREATED)
 	return ..()
 
 ///Print order visual to all marines squad hud and give them an arrow to follow the waypoint
@@ -114,12 +116,12 @@
 
 
 ///Receive fire support laser notifications
-/mob/living/silicon/ai/proc/receive_laser_OB(datum/source, obj/effect/overlay/temp/laser_target/OB/incoming_laser)
+/mob/living/silicon/ai/proc/receive_laser_ob(datum/source, obj/effect/overlay/temp/laser_target/OB/incoming_laser)
 	SIGNAL_HANDLER
 	to_chat(src, "<span class='notice'>Orbital Bombardment laser detected. Target: [AREACOORD_NO_Z(incoming_laser)] </span>")
 	playsound(src, 'sound/effects/binoctarget.ogg', 15)
 
-/mob/living/silicon/ai/proc/receive_laser_CAS(datum/source, obj/effect/overlay/temp/laser_target/cas/incoming_laser)
+/mob/living/silicon/ai/proc/receive_laser_cas(datum/source, obj/effect/overlay/temp/laser_target/cas/incoming_laser)
 	SIGNAL_HANDLER
 	to_chat(src, "<span class='notice'>CAS laser detected. Target: [AREACOORD_NO_Z(src)]</span>")
 	playsound(src, 'sound/effects/binoctarget.ogg', 15)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There is a noise for the OB one.
I'd like to have the CAS flares link directly to the condor, but i am not certain how to do it.

## Changelog
:cl:
expansion: The AI is now notified when a CAS or OB laser is created or goes out.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
