### PR TITLE
Xeno Turret Minimum Distance

### DIFF
--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -41,6 +41,7 @@ GLOBAL_LIST_EMPTY(alert_consoles)			// Station alert consoles, /obj/machinery/co
 GLOBAL_LIST_EMPTY(xeno_resin_silo_turfs)
 GLOBAL_LIST_EMPTY(xeno_resin_silos)
 GLOBAL_LIST_EMPTY(xeno_turret_turfs)
+GLOBAL_LIST_EMPTY(xeno_turret_tiles)
 GLOBAL_LIST_EMPTY(xeno_weed_node_turfs)
 GLOBAL_LIST_EMPTY(xeno_resin_wall_turfs)
 GLOBAL_LIST_EMPTY(xeno_resin_door_turfs)

--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -41,7 +41,7 @@ GLOBAL_LIST_EMPTY(alert_consoles)			// Station alert consoles, /obj/machinery/co
 GLOBAL_LIST_EMPTY(xeno_resin_silo_turfs)
 GLOBAL_LIST_EMPTY(xeno_resin_silos)
 GLOBAL_LIST_EMPTY(xeno_turret_turfs)
-GLOBAL_LIST_EMPTY(xeno_turret_tiles)
+GLOBAL_LIST_EMPTY(xeno_resin_turrets)
 GLOBAL_LIST_EMPTY(xeno_weed_node_turfs)
 GLOBAL_LIST_EMPTY(xeno_resin_wall_turfs)
 GLOBAL_LIST_EMPTY(xeno_resin_door_turfs)

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1147,7 +1147,7 @@
 		to_chat(X, "<span class='warning'>We can't build so close to the fog!</span>")
 		return FALSE
 
-	for(var/obj/structure/xeno/resin/xeno_turret/turret AS in GLOB.xeno_turret_tiles)
+	for(var/obj/structure/xeno/resin/xeno_turret/turret AS in GLOB.xeno_resin_turrets)
 		if(get_dist(turret, A) < 6)
 			to_chat(owner, "<span class='xenowarning'>Another turret is too close!</span>")
 			return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1147,7 +1147,7 @@
 		to_chat(X, "<span class='warning'>We can't build so close to the fog!</span>")
 		return FALSE
 
-	for(var/obj/structure/xeno/resin/xeno_turret/turret AS in GLOB.xeno_turret_turfs)
+	for(var/obj/structure/xeno/resin/xeno_turret/turret AS in GLOB.xeno_turret_tiles)
 		if(get_dist(turret, A) < 6)
 			to_chat(owner, "<span class='xenowarning'>Another turret is too close!</span>")
 			return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1147,6 +1147,11 @@
 		to_chat(X, "<span class='warning'>We can't build so close to the fog!</span>")
 		return FALSE
 
+	for(var/obj/structure/xeno/resin/xeno_turret/turret AS in GLOB.xeno_turret_turfs)
+		if(get_dist(turret, A) < 6)
+			to_chat(owner, "<span class='xenowarning'>Another turret is too close!</span>")
+			return FALSE
+
 	if(!alien_weeds)
 		to_chat(X, "<span class='warning'>We can only shape on weeds. We must find some resin before we start building!</span>")
 		return FALSE

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -277,6 +277,7 @@
 	ammo.max_range = range + 2 //To prevent funny gamers to abuse the turrets that easily
 	potential_hostiles = list()
 	associated_hive = GLOB.hive_datums[hivenumber]
+	GLOB.xeno_turret_turfs += loc
 	START_PROCESSING(SSobj, src)
 	AddComponent(/datum/component/automatedfire/xeno_turret_autofire, firerate)
 	RegisterSignal(src, COMSIG_AUTOMATIC_SHOOTER_SHOOT, .proc/shoot)

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -277,7 +277,7 @@
 	ammo.max_range = range + 2 //To prevent funny gamers to abuse the turrets that easily
 	potential_hostiles = list()
 	associated_hive = GLOB.hive_datums[hivenumber]
-	GLOB.xeno_turret_tiles += loc
+	GLOB.xeno_resin_turrets += src
 	START_PROCESSING(SSobj, src)
 	AddComponent(/datum/component/automatedfire/xeno_turret_autofire, firerate)
 	RegisterSignal(src, COMSIG_AUTOMATIC_SHOOTER_SHOOT, .proc/shoot)
@@ -298,7 +298,7 @@
 	return ..()
 
 /obj/structure/xeno/resin/xeno_turret/Destroy()
-	GLOB.xeno_turret_tiles -= loc
+	GLOB.xeno_resin_turrets -= src
 	set_hostile(null)
 	set_last_hostile(null)
 	STOP_PROCESSING(SSobj, src)

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -277,7 +277,7 @@
 	ammo.max_range = range + 2 //To prevent funny gamers to abuse the turrets that easily
 	potential_hostiles = list()
 	associated_hive = GLOB.hive_datums[hivenumber]
-	GLOB.xeno_turret_turfs += loc
+	GLOB.xeno_turret_tiles += loc
 	START_PROCESSING(SSobj, src)
 	AddComponent(/datum/component/automatedfire/xeno_turret_autofire, firerate)
 	RegisterSignal(src, COMSIG_AUTOMATIC_SHOOTER_SHOOT, .proc/shoot)
@@ -298,7 +298,7 @@
 	return ..()
 
 /obj/structure/xeno/resin/xeno_turret/Destroy()
-	GLOB.xeno_turret_turfs -= loc
+	GLOB.xeno_turret_tiles -= loc
 	set_hostile(null)
 	set_last_hostile(null)
 	STOP_PROCESSING(SSobj, src)

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -298,6 +298,7 @@
 	return ..()
 
 /obj/structure/xeno/resin/xeno_turret/Destroy()
+	GLOB.xeno_turret_turfs -= loc
 	set_hostile(null)
 	set_last_hostile(null)
 	STOP_PROCESSING(SSobj, src)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Basically this just adds a minimum distance between xeno turrets, to make it so they can't place them too close to one another. It works like the silo minimum distance but with a shorter distance. In this case, the minimum distance between turrets is 6 tiles. 

## Why It's Good For The Game

Prevents the spamming of large amounts of turrets in a small area. 

## Changelog
:cl:
balance: Xeno turrets can't be built too close to each other. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
