### PR TITLE
Fixes a fire delay bug.

### DIFF
--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -591,7 +591,6 @@ User can be passed as null, (a gun reloading itself for instance), so we need to
 		ENABLE_BITFIELD(flags_gun_features, GUN_BURST_FIRING)
 		return
 	DISABLE_BITFIELD(flags_gun_features, GUN_BURST_FIRING)
-	extra_delay = fire_delay * 1.5
 
 ///Update the target if you draged your mouse
 /obj/item/weapon/gun/proc/change_target(datum/source, atom/src_object, atom/over_object, turf/src_location, turf/over_location, src_control, over_control, params)


### PR DESCRIPTION
## About The Pull Request

Fixes a bug i discovered.
Step one of bug, acquire gun with semi-auto and burst.
Step two, fire gun on burst.
Step three, switch to semi auto.
Step four, discover that 1.5 times extra fire delay was added to the gun and can no longer be gotten rid of.

## Why It's Good For The Game

Bug fix

## Changelog
:cl:
fix: Fixes a fire delay bug.
/:cl:
