### PR TITLE
Boiler loses ammo count, glow when firing

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
@@ -176,6 +176,7 @@
 	add_cooldown()
 	X.reset_bombard_pointer()
 	X.set_light_on(FALSE)
+	succeed_activate()
 
 /datum/action/xeno_action/activable/bombard/fail_activate()
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/boiler.dm
@@ -14,27 +14,9 @@
 	upgrade = XENO_UPGRADE_ZERO
 	gib_chance = 100
 	drag_delay = 6 //pulling a big dead xeno is hard
+	light_power = 6
+	light_range = 5
 	var/datum/effect_system/smoke_spread/xeno/smoke
-	//Boiler ammo
-	var/corrosive_ammo = 0
-	var/neuro_ammo = 0
-
-
-///updates the boiler's glow, based on its base glow/color, and its ammo reserves. More green ammo = more green glow; more yellow = more yellow.
-/mob/living/carbon/xenomorph/boiler/proc/update_boiler_glow()
-	var/current_ammo = corrosive_ammo + neuro_ammo
-	var/ammo_glow = BOILER_LUMINOSITY_AMMO * (current_ammo/2)
-	var/glow = CEILING(BOILER_LUMINOSITY_BASE + ammo_glow, 1) 
-	var/color = BOILER_LUMINOSITY_BASE_COLOR
-	if(current_ammo)
-		var/ammo_color = BlendRGB(BOILER_LUMINOSITY_AMMO_CORROSIVE_COLOR, BOILER_LUMINOSITY_AMMO_NEUROTOXIN_COLOR, neuro_ammo/current_ammo)
-		color = BlendRGB(color, ammo_color, (ammo_glow*2)/glow)
-	if(!light_on && glow >= 2)
-		set_light_on(TRUE)
-	else if(glow < 2 && !fire_luminosity)
-		set_light_range_power_color(0, 0)
-		set_light_on(FALSE)
-	set_light_range_power_color(glow, 4, color)
 
 // ***************************************
 // *********** Init
@@ -43,7 +25,6 @@
 	. = ..()
 	smoke = new /datum/effect_system/smoke_spread/xeno/acid(src)
 	ammo = GLOB.ammo_list[/datum/ammo/xeno/boiler_gas]
-	update_boiler_glow()
 	RegisterSignal(src, COMSIG_XENOMORPH_GIBBING, .proc/gib_explode)
 
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
@@ -57,7 +57,6 @@
 		/datum/action/xeno_action/activable/devour,
 		/datum/action/xeno_action/place_acidwell,
 		/datum/action/xeno_action/activable/corrosive_acid/strong,
-		/datum/action/xeno_action/create_boiler_bomb,
 		/datum/action/xeno_action/activable/bombard,
 		/datum/action/xeno_action/toggle_long_range,
 		/datum/action/xeno_action/toggle_bomb,

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -182,10 +182,6 @@
 	. = ..()
 	set_light_on(FALSE) //Reset lighting
 
-/mob/living/carbon/xenomorph/boiler/ExtinguishMob()
-	. = ..()
-	update_boiler_glow()
-
 /mob/living/proc/update_fire()
 	return
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Boiler can no longer stock any ammo, he just fires no matter what.

He will glow in the windup of the shot (2 sec)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Ammo count is just adding a tedious task to do to be able to shoot, without it doing anything balance or fun wise.
It is also a noob trap, sine new players are stocking them and glowing. Everyone that has played at least one time boiler know that you can just make one globule between shots

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Boiler no longer need to have ammo to shoot
balance: Boiler glows when firing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
