### PR TITLE
Super Rage Gives Ravager Bloodborne/Life Leech Slashing

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -298,7 +298,7 @@
 			charge.clear_cooldown() //Reset charge cooldown
 		if(ravage)
 			ravage.clear_cooldown() //Reset ravage cooldown
-		RegisterSignal(X, COMSIG_XENOMORPH_ATTACK_LIVING, .proc/drain_slash) //We can now regain HP by dealing damage
+		RegisterSignal(X, COMSIG_XENOMORPH_ATTACK_LIVING, .proc/drain_slash)
 
 	for(var/turf/affected_tiles AS in RANGE_TURFS(rage_power_radius, X.loc))
 		affected_tiles.Shake(4, 4, 1 SECONDS) //SFX
@@ -356,8 +356,6 @@
 ///Warns the user when his rage is about to end.
 /datum/action/xeno_action/rage/proc/drain_slash(datum/source, mob/living/target, damage, list/damage_mod, list/armor_mod)
 	SIGNAL_HANDLER
-	if(!target) //Sanity
-		return
 	var/mob/living/rager = owner
 	var/brute_damage = rager.getBruteLoss()
 	var/burn_damage = rager.getFireLoss()
@@ -393,7 +391,7 @@
 	REMOVE_TRAIT(X, TRAIT_STUNIMMUNE, RAGE_TRAIT)
 	REMOVE_TRAIT(X, TRAIT_SLOWDOWNIMMUNE, RAGE_TRAIT)
 	REMOVE_TRAIT(X, TRAIT_STAGGERIMMUNE, RAGE_TRAIT)
-	UnregisterSignal(X, COMSIG_XENOMORPH_ATTACK_LIVING) //unregister the signals; party's over
+	UnregisterSignal(X, COMSIG_XENOMORPH_ATTACK_LIVING)
 
 	rage_sunder = 0
 	rage_power = 0


### PR DESCRIPTION
## About The Pull Request

If Rage is used while at less than 0 HP, the Ravager will regain HP whenever it slashes a living target equal to 50% to 100% of the damage dealt depending on Rage Power (how low the Ravager's HP was when Rage was used).

## Why It's Good For The Game

Makes Raging and fighting while at critical HP actually worth the risk outside of strict 1 v 1 scenarios because you now might actually not get instantly deleted via life leech.

## Changelog
:cl:
balance: If Rage is used while at less than 0 HP, the Ravager will regain HP whenever it slashes a living target equal to 50% to 100% of the damage dealt depending on Rage Power (how low the Ravager's HP was when Rage was used).
/:cl: