### PR TITLE
Critdrag and death things

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -50,7 +50,8 @@
 #define CARBON_RECOVERY_OXYLOSS -5 //the amount of oxyloss recovery per successful breath tick.
 
 #define CARBON_KO_OXYLOSS 50
-#define HUMAN_CRITDRAG_OXYLOSS 3 //the amount of oxyloss taken per tile a human is dragged by a xeno while unconscious
+#define HUMAN_CRITDRAG_DAMAGE 5 //the base amount of damage taken per tile a human is dragged by a xeno while unconscious
+#define HUMAN_DEATH_PENALTY 20 //the amount of cloneloss taken per death of a human
 
 #define HEAT_DAMAGE_LEVEL_1 1 //Amount of damage applied when your body temperature just passes the 360.15k safety point
 #define HEAT_DAMAGE_LEVEL_2 2 //Amount of damage applied when your body temperature passes the 400K point

--- a/code/datums/gamemodes/game_mode.dm
+++ b/code/datums/gamemodes/game_mode.dm
@@ -420,6 +420,8 @@ Sensors indicate [numXenosShip || "no"] unknown lifeform signature[numXenosShip 
 		dat += "[GLOB.round_statistics.grenades_thrown] total grenades exploding."
 	else
 		dat += "No grenades exploded."
+	if(GLOB.round_statistics.total_human_deaths)
+		dat += "[GLOB.round_statistics.total_human_deaths] people were killed, among which [GLOB.round_statistics.total_human_revives] were revived. For a [(GLOB.round_statistics.total_human_revives / max(GLOB.round_statistics.total_human_deaths, 1)) * 100]% medical revival rate."
 	if(GLOB.round_statistics.now_pregnant)
 		dat += "[GLOB.round_statistics.now_pregnant] people infected among which [GLOB.round_statistics.total_larva_burst] burst. For a [(GLOB.round_statistics.total_larva_burst / max(GLOB.round_statistics.now_pregnant, 1)) * 100]% successful delivery rate!"
 	if(GLOB.round_statistics.queen_screech)

--- a/code/datums/round_statistics.dm
+++ b/code/datums/round_statistics.dm
@@ -18,6 +18,7 @@ GLOBAL_DATUM_INIT(round_statistics, /datum/round_statistics, new)
 	var/human_bump_attacks = 0
 	var/total_xeno_deaths = 0
 	var/total_human_deaths = 0
+	var/total_human_revives = 0
 	var/total_xenos_created = 0
 	var/total_humans_created = 0
 	var/total_bullet_hits_on_humans = 0

--- a/code/game/objects/items/defibrillator.dm
+++ b/code/game/objects/items/defibrillator.dm
@@ -274,6 +274,8 @@
 	H.updatehealth() //One more time, so it doesn't show the target as dead on HUDs
 	H.dead_ticks = 0 //We reset the DNR time
 	REMOVE_TRAIT(H, TRAIT_PSY_DRAINED, TRAIT_PSY_DRAINED)
+	GLOB.round_statistics.total_human_revives++
+	SSblackbox.record_feedback("tally", "round_statistics", 1, "total_human_revives")
 	to_chat(H, "<span class='notice'>You suddenly feel a spark and your consciousness returns, dragging you back to the mortal plane.</span>")
 
 	notify_ghosts("<b>[user]</b> has brought <b>[H.name]</b> back to life!", source = H, action = NOTIFY_ORBIT)

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -54,7 +54,7 @@
 /mob/living/carbon/human/on_death()
 	if(pulledby)
 		pulledby.stop_pulling()
-		adjustCloneLoss(human_death_penalty)
+		adjustCloneLoss(HUMAN_DEATH_PENALTY)
 
 	//Handle species-specific deaths.
 	species.handle_death(src)

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -54,6 +54,7 @@
 /mob/living/carbon/human/on_death()
 	if(pulledby)
 		pulledby.stop_pulling()
+		adjustCloneLoss(human_death_penalty)
 
 	//Handle species-specific deaths.
 	species.handle_death(src)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -48,7 +48,9 @@
 /mob/living/carbon/human/proc/oncritdrag()
 	SIGNAL_HANDLER
 	if(isxeno(pulledby))
-		adjustOxyLoss(HUMAN_CRITDRAG_OXYLOSS) //take oxy damage per tile dragged
+		adjustOxyLoss(HUMAN_CRITDRAG_DAMAGE /2) //take oxy damage per tile dragged
+		adjustBruteLoss(HUMAN_CRITDRAG_DAMAGE /2) //take brute damage per tile dragged
+
 
 /mob/living/carbon/update_stat()
 	. = ..()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Critdrag now kills marines faster, but death is more punishing in general.

Being dragged by a xeno deals 2.5 oxyloss and 2.5 brute damage (up from 3.0/0). Dying in any way gives 20 cloneloss.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Marines won't get dragged offscreen as much. and will be easier to retrieve.
Xenos won't have marines keep popping up like demented jack-in-the-boxes if there's a medic around. Kill someone enough times and he's forced to retreat.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: 20 cloneloss on marine death
balance: critdrag damage upped from 3 to 5
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
