### PR TITLE
Critdrag

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -50,7 +50,8 @@
 #define CARBON_RECOVERY_OXYLOSS -5 //the amount of oxyloss recovery per successful breath tick.
 
 #define CARBON_KO_OXYLOSS 50
-#define HUMAN_CRITDRAG_OXYLOSS 3 //the amount of oxyloss taken per tile a human is dragged by a xeno while unconscious
+#define HUMAN_CRITDRAG_DAMAGE 5 //the base amount of damage taken per tile a human is dragged by a xeno while unconscious
+#define HUMAN_DEATH_PENALTY 20 //the amount of cloneloss taken per death of a human
 
 #define HEAT_DAMAGE_LEVEL_1 1 //Amount of damage applied when your body temperature just passes the 360.15k safety point
 #define HEAT_DAMAGE_LEVEL_2 2 //Amount of damage applied when your body temperature passes the 400K point

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -54,6 +54,7 @@
 /mob/living/carbon/human/on_death()
 	if(pulledby)
 		pulledby.stop_pulling()
+	adjustCloneLoss(HUMAN_DEATH_PENALTY)
 
 	//Handle species-specific deaths.
 	species.handle_death(src)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -48,7 +48,8 @@
 /mob/living/carbon/human/proc/oncritdrag()
 	SIGNAL_HANDLER
 	if(isxeno(pulledby))
-		adjustOxyLoss(HUMAN_CRITDRAG_OXYLOSS) //take oxy damage per tile dragged
+		adjustOxyLoss(HUMAN_CRITDRAG_DAMAGE /2) //take oxy damage per tile dragged
+		adjustBruteLoss(HUMAN_CRITDRAG_DAMAGE /2) //take brute damage per tile dragged
 
 /mob/living/carbon/update_stat()
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
@@ -450,7 +450,8 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 			if(ishuman(pulled_target))
 				var/mob/living/carbon/human/H = pulled_target
 				if(H.stat == UNCONSCIOUS) //Apply critdrag damage as if they were quickly pulled the same distance
-					H.adjustOxyLoss(HUMAN_CRITDRAG_OXYLOSS * get_dist(H.loc, T))
+					H.adjustOxyLoss(HUMAN_CRITDRAG_DAMAGE /2 * get_dist(H.loc, T))
+					H.adjustBruteLoss(HUMAN_CRITDRAG_DAMAGE /2 * get_dist(H.loc, T))
 
 		to_chat(X, "<span class='xenodanger'>We bring [pulled_target] with us. We won't be ready to blink again for [cooldown_timer * cooldown_mod * 0.1] seconds due to the strain of doing so.</span>")
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Critdrag now kills marines faster, but death is more punishing in general.

Being dragged by a xeno deals 2.5 oxyloss and 2.5 brute damage (up from 3.0/0). Dying in any way gives 20 cloneloss.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Marines won't get dragged offscreen as much. and will be easier to retrieve.
Xenos won't have marines keep popping up like demented jack-in-the-boxes if there's a medic around. Kill someone enough times and he's forced to retreat.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: 20 cloneloss on marine death
balance: critdrag damage upped from 3 to 5
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
