### PR TITLE
you can't refill qc+ and peri+ at marine med

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -588,8 +588,6 @@
 			/obj/item/reagent_containers/hypospray/autoinjector/hypervene = 16,
 			/obj/item/reagent_containers/hypospray/autoinjector/isotonic = 16,
 			/obj/item/reagent_containers/hypospray/autoinjector/quickclot = 16,
-			/obj/item/reagent_containers/hypospray/autoinjector/peridaxon_plus = 0,
-			/obj/item/reagent_containers/hypospray/autoinjector/quickclotplus = 0,
 			/obj/item/reagent_containers/hypospray/autoinjector/synaptizine = 0,
 		),
 		"Heal Pack" = list(


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
can't refill them, too good
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
too good for basically making ib and organ damage irrelevant. spend more points if you want more
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: can't refill qc+ and peri + at marine med
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
