### PR TITLE
Lets runners and larva walk through acid holes

### DIFF
--- a/code/game/turfs/walls/walls.dm
+++ b/code/game/turfs/walls/walls.dm
@@ -510,7 +510,7 @@
 		return FALSE
 	var/move_dir = mover.dir
 	var/hole_facing = acided_hole.dir
-	if(((move_dir & hole_facing) | (move_dir & turn(hole_facing, 180)) & move_dir) && mover.flags_pass & PASSTABLE)
+	if(((move_dir & hole_facing) | (move_dir & turn(hole_facing, 180))) && (mover.flags_pass & PASSTABLE))
 		return TRUE
 
 ///Only let them out in the hole's two exits

--- a/code/game/turfs/walls/walls.dm
+++ b/code/game/turfs/walls/walls.dm
@@ -502,3 +502,23 @@
 
 /turf/closed/wall/can_be_dissolved()
 	return !(resistance_flags & INDESTRUCTIBLE)
+
+///Let them in if the atom has PASSTABLE and is in the hole's direction
+/turf/closed/wall/CanAllowThrough(atom/movable/mover, turf/target)
+	. = ..()
+	if(!acided_hole)
+		return FALSE
+	var/move_dir = mover.dir
+	var/hole_facing = acided_hole.dir
+	if(((move_dir & hole_facing) | (move_dir & turn(hole_facing, 180)) & move_dir) && mover.flags_pass & PASSTABLE)
+		return TRUE
+
+///Only let them out in the hole's two exits
+/turf/closed/wall/CheckExit(atom/movable/mover, turf/target)
+	. = ..()
+	if(!acided_hole)
+		return FALSE
+	var/exit_dir = get_dir(src, target)
+	var/exit_options = acided_hole.dir | turn(acided_hole.dir, 180)
+	if(exit_dir & exit_options)
+		return TRUE


### PR DESCRIPTION
## About The Pull Request
Enables moving through the holes in walls vomited acid leaves for entities with the PASSTABLE flag. That's larva and runners plus thrown objects (grenades could already be fake-thrown through, but it's more freeform now) and humans using jetpacks. The last one is kind of weird so maybe worth adding a new flag, but hey. Projectiles can't pass, and you can only pass through in the hole's direction, east/west or north/south.

## Why It's Good For The Game
FSAT
Also one caste enabling another's mobility is good.

## Changelog
:cl:
add: Runners and larvae can pass through acid holes without pausing.
/:cl: