### PR TITLE
removes minigun

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -239,12 +239,6 @@ WEAPONS
 	cost = 60
 	available_against_xeno_only = TRUE
 
-/datum/supply_packs/weapons/specminigun
-	name = "MIC-A7 Vindicator Minigun"
-	contains = list(/obj/item/weapon/gun/minigun)
-	cost = MINIGUN_PRICE
-	available_against_xeno_only = TRUE
-
 /datum/supply_packs/weapons/smartgun
 	name = "T-29 Smart Machinegun"
 	contains = list(/obj/item/weapon/gun/rifle/standard_smartmachinegun)
@@ -622,12 +616,6 @@ AMMO
 	name = "Terra Experimental standard battery"
 	contains = list(/obj/item/cell/lasgun/lasrifle/marine)
 	cost = 2
-
-/datum/supply_packs/ammo/minigun
-	name = "Vindicator Minigun Ammo Drum"
-	contains = list(/obj/item/ammo_magazine/minigun)
-	cost = 5
-	available_against_xeno_only = TRUE
 
 /datum/supply_packs/ammo/back_fuel_tank
 	name = "Standard back fuel tank"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
i want to see how much better b18s are suddenly when this pr if ever get's tmc'ed, other than that, the minigun sucks and is the worst gun you could buy in req.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
the minigun is utter trash tier of spec weapon worth and it's only value is that it's fire sound sounds scary-

This thing is in the SADAR levle tier of pricing, and let's compare it to everything else in the game shall we?

A SADAR is nearly the same cost and same effective cost.. And you got the *worst* gun in req instead of a SADAR? Really?

Railgun has better performance value early game and midgame

The TX-8 does more damage and is more consistently decent. Has a better sunder and damage profile than the minigun, too.

The Rifle family does more consistent chasing and damage, doesn't cost points to fire, has mag harness. Is better in most ways other than the minigun having a better damage profile. Also have utility weapons to back them up.

Pocket pistols deal more fucking damage than this thing at point blank, considering i haven't seen a minigun score a kill on a decent queen/ravager in about 3-4 months and i've seen pocket pistols get two in the last week, somehow.

Revolvers even after all the nerfs are better, same with pistols really.

SMGs don't need to be wielded and don't have a dumb fire delay.

AMR is just straight up better and is underrated, same with the IFF sniper really.

Grenade launchers give you more tactical oppurtunity than the FF machine the minigun is, considering how both are one, just take a gl over it.

Shotguns are better than it at cqc, obviously, and don't have the windup and mag harness penalty. Have better damage stats.

GPMG is meh compared to the minigun, it has worse damage stats..  But you get a mag harness and a belt slot to boot, considering you kind of *need* a belt harness to run this thing without it getting qdeled, forcing you to switch to a better overall weapon.

DMR/BR have better overall performance than a minigun, overall, they have a magnetic harness and decent damage stats, and aim mode!

TL-127 doesn't cost eighty points to buy, and effectively 120~ to kit out.

The minigun durning spec era sucked doo doo also and was only ever viable since it was paired with b18 so it got nerfed to being literally irrelevant and is still pretty bad.
I don't really see the point of keeping it anymore.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: minigun is gone from req, forever shafted to the realm of the noobtrap.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
