### PR TITLE
Hard del tracking, disabling and handling changes

### DIFF
--- a/code/__DEFINES/qdel.dm
+++ b/code/__DEFINES/qdel.dm
@@ -1,17 +1,37 @@
-//defines that give qdel hints. these can be given as a return in destory() or by calling
+//! Defines that give qdel hints.
+//!
+//! These can be given as a return in [/atom/proc/Destroy] or by calling [/proc/qdel].
+
+/// `qdel` should queue the object for deletion.
+#define QDEL_HINT_QUEUE 0
+/// `qdel` should let the object live after calling [/atom/proc/Destroy].
+#define QDEL_HINT_LETMELIVE 1
+/// Functionally the same as the above. `qdel` should assume the object will gc on its own, and not check it.
+#define QDEL_HINT_IWILLGC 2
+/// Qdel should assume this object won't GC, and queue a hard delete using a hard reference.
+#define QDEL_HINT_HARDDEL 3
+// Qdel should assume this object won't gc, and hard delete it posthaste.
+#define QDEL_HINT_HARDDEL_NOW 4
 
 
-#define QDEL_HINT_QUEUE 0 //qdel should queue the object for deletion.
-#define QDEL_HINT_LETMELIVE 1 //qdel should let the object live after calling destory.
-#define QDEL_HINT_IWILLGC 2 //functionally the same as the above. qdel should assume the object will gc on its own, and not check it.
-#define QDEL_HINT_HARDDEL 3 //qdel should assume this object won't gc, and queue a hard delete using a hard reference.
-#define QDEL_HINT_HARDDEL_NOW 4 //qdel should assume this object won't gc, and hard del it post haste.
-//defines for the gc_destroyed var
+#ifdef REFERENCE_TRACKING
+/** If REFERENCE_TRACKING is enabled, qdel will call this object's find_references() verb.
+ *
+ * Functionally identical to [QDEL_HINT_QUEUE] if [GC_FAILURE_HARD_LOOKUP] is not enabled in _compiler_options.dm.
+*/
+#define QDEL_HINT_FINDREFERENCE 5
+/// Behavior as [QDEL_HINT_FINDREFERENCE], but only if the GC fails and a hard delete is forced.
+#define QDEL_HINT_IFFAIL_FINDREFERENCE 6
+#endif
 
 #define GC_QUEUE_CHECK 1
 #define GC_QUEUE_HARDDELETE 2
 #define GC_QUEUE_COUNT 2 //increase this when adding more steps.
 
+#define QDEL_ITEM_ADMINS_WARNED (1<<0) //! Set when admins are told about lag causing qdels in this type.
+#define QDEL_ITEM_SUSPENDED_FOR_LAG (1<<1) //! Set when a type can no longer be hard deleted on failure because of lag it causes while this happens.
+
+// Defines for the [gc_destroyed][/datum/var/gc_destroyed] var.
 #define GC_QUEUED_FOR_QUEUING -1
 #define GC_CURRENTLY_BEING_QDELETED -2
 

--- a/code/__DEFINES/time.dm
+++ b/code/__DEFINES/time.dm
@@ -48,6 +48,12 @@ When using time2text(), please use "DDD" to find the weekday. Refrain from using
 
 #define TICKS *world.tick_lag
 
+#define MILLISECONDS * 0.10
+
 #define DS2TICKS(DS) ((DS)/world.tick_lag)
 
 #define TICKS2DS(T) ((T) TICKS)
+
+#define MS2DS(T) ((T) MILLISECONDS)
+
+#define DS2MS(T) ((T) * 100)

--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -35,6 +35,12 @@
 #define testing(msg)
 #endif
 
+#ifdef REFERENCE_TRACKING_LOG
+#define log_reftracker(msg) log_world("## REF SEARCH [msg]")
+#else
+#define log_reftracker(msg)
+#endif
+
 /* Items with private are stripped from public logs. */
 /proc/log_admin(text)
 	LAZYADD(GLOB.admin_log, "\[[stationTimestamp()]\] ADMIN: [text]")

--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -36,7 +36,7 @@
 #endif
 
 #ifdef REFERENCE_TRACKING_LOG
-#define log_reftracker(msg) to_chat(world, "## REF SEARCH [msg]")
+#define log_reftracker(msg) log_world("## REF SEARCH [msg]")
 #else
 #define log_reftracker(msg)
 #endif

--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -36,7 +36,7 @@
 #endif
 
 #ifdef REFERENCE_TRACKING_LOG
-#define log_reftracker(msg) log_world("## REF SEARCH [msg]")
+#define log_reftracker(msg) to_chat(world, "## REF SEARCH [msg]")
 #else
 #define log_reftracker(msg)
 #endif

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -1,4 +1,4 @@
-#define TESTING //By using the testing("message") proc you can create debug-feedback for people with this
+//#define TESTING //By using the testing("message") proc you can create debug-feedback for people with this
 								//uncommented, but not visible in the release version)
 
 //#define DATUMVAR_DEBUGGING_MODE //Enables the ability to cache datum vars and retrieve later for debugging which vars changed.

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -54,10 +54,23 @@
 #define AS as anything
 #endif
 
-#ifdef USE_EXTOOLS
-//#define REFERENCE_TRACKING //Enables extools-powered reference tracking system, letting you see what is
-									//referencing objects that refuse to hard delete
-#endif
+///Used to find the sources of harddels, quite laggy, don't be surpised if it freezes your client for a good while
+//#define REFERENCE_TRACKING
+#ifdef REFERENCE_TRACKING
+
+///Should we be logging our findings or not
+#define REFERENCE_TRACKING_LOG
+
+///Used for doing dry runs of the reference finder, to test for feature completeness
+//#define REFERENCE_TRACKING_DEBUG
+
+///Run a lookup on things hard deleting by default.
+//#define GC_FAILURE_HARD_LOOKUP
+#ifdef GC_FAILURE_HARD_LOOKUP
+#define FIND_REF_NO_CHECK_TICK
+#endif //ifdef GC_FAILURE_HARD_LOOKUP
+
+#endif //ifdef REFERENCE_TRACKING
 
 //Additional code for the above flags.
 #ifdef TESTING

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -1,4 +1,4 @@
-//#define TESTING //By using the testing("message") proc you can create debug-feedback for people with this
+#define TESTING //By using the testing("message") proc you can create debug-feedback for people with this
 								//uncommented, but not visible in the release version)
 
 //#define DATUMVAR_DEBUGGING_MODE //Enables the ability to cache datum vars and retrieve later for debugging which vars changed.
@@ -55,7 +55,7 @@
 #endif
 
 ///Used to find the sources of harddels, quite laggy, don't be surpised if it freezes your client for a good while
-#define REFERENCE_TRACKING
+//#define REFERENCE_TRACKING
 #ifdef REFERENCE_TRACKING
 
 ///Should we be logging our findings or not

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -55,7 +55,7 @@
 #endif
 
 ///Used to find the sources of harddels, quite laggy, don't be surpised if it freezes your client for a good while
-//#define REFERENCE_TRACKING
+#define REFERENCE_TRACKING
 #ifdef REFERENCE_TRACKING
 
 ///Should we be logging our findings or not

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -397,3 +397,12 @@ This maintains a list of ip addresses that are able to bypass topic filtering.
 
 /datum/config_entry/flag/is_automatic_balance_on
 	config_entry_value = TRUE
+
+/datum/config_entry/number/hard_deletes_overrun_threshold
+	integer = FALSE
+	min_val = 0
+	config_entry_value = 0.5
+
+/datum/config_entry/number/hard_deletes_overrun_limit
+	config_entry_value = 0
+	min_val = 0

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -2,7 +2,7 @@
 ## Debugging GC issues
 
 In order to debug `qdel()` failures, there are several tools available.
-To enable these tools, define `TESTING` in [_compile_options.dm](https://github.com/tgstation/-tg-station/blob/master/code/_compile_options.dm).
+To enable these tools, define `TESTING` and 'Destroy' in [_compile_options.dm](https://github.com/tgstation/TerraGov-Marine-Corps/blob/master/code/_compile_options.dm).
 
 First is a verb called "Find References", which lists **every** refererence to an object in the world. This allows you to track down any indirect or obfuscated references that you might have missed.
 

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -2,7 +2,7 @@
 ## Debugging GC issues
 
 In order to debug `qdel()` failures, there are several tools available.
-To enable these tools, define `TESTING` and 'Destroy' in [_compile_options.dm](https://github.com/tgstation/TerraGov-Marine-Corps/blob/master/code/_compile_options.dm).
+To enable these tools, define `TESTING` and 'REFERENCE_TRACKING' in [_compile_options.dm](https://github.com/tgstation/TerraGov-Marine-Corps/blob/master/code/_compile_options.dm).
 
 First is a verb called "Find References", which lists **every** refererence to an object in the world. This allows you to track down any indirect or obfuscated references that you might have missed.
 
@@ -15,9 +15,13 @@ If you have a datum or something you are not destroying directly (say via the si
 the next tool is `QDEL_HINT_FINDREFERENCE`. You can return this in `Destroy()` (where you would normally `return ..()`),
 to print a list of references once it enters the GC queue.
 
+You can define 'GC_FAILURE_HARD_LOOKUP' to check for references on all hard_dels. Defining 'FIND_REF_NO_CHECK_TICK' will cause the game to
+freeze, so do not define this on live.
+
+If you are only using the reference_tracking system, you do not need to define 'TESTING'; All results are logged in runtime logs
+
 Finally is a verb, "Show qdel() Log", which shows the deletion log that the garbage subsystem keeps. This is helpful if you are having race conditions or need to review the order of deletions.
 
-Note that for any of these tools to work `TESTING` must be defined.
 By using these methods of finding references, you can make your life far, far easier when dealing with `qdel()` failures.
 */
 

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -29,24 +29,27 @@ SUBSYSTEM_DEF(garbage)
 	runlevels = RUNLEVELS_DEFAULT | RUNLEVEL_LOBBY
 	init_order = INIT_ORDER_GARBAGE
 
-	var/list/collection_timeout = list(2 MINUTES, 10 SECONDS)	// deciseconds to wait before moving something up in the queue to the next level
+	var/list/collection_timeout = list(2 MINUTES, 10 SECONDS) // deciseconds to wait before moving something up in the queue to the next level
 
 	//Stat tracking
-	var/delslasttick = 0			// number of del()'s we've done this tick
-	var/gcedlasttick = 0			// number of things that gc'ed last tick
+	var/delslasttick = 0 // number of del()'s we've done this tick
+	var/gcedlasttick = 0 // number of things that gc'ed last tick
 	var/totaldels = 0
 	var/totalgcs = 0
 
-	var/highest_del_time = 0
-	var/highest_del_tickusage = 0
+	var/highest_del_ms = 0
+	var/highest_del_type_string = ""
 
 	var/list/pass_counts
 	var/list/fail_counts
 
-	var/list/items = list()			// Holds our qdel_item statistics datums
+	var/list/items = list() // Holds our qdel_item statistics datums
 
 	//Queue
 	var/list/queues
+	#ifdef REFERENCE_TRACKING
+	var/list/reference_find_on_fail = list()
+	#endif
 
 
 /datum/controller/subsystem/garbage/PreInit()
@@ -87,13 +90,18 @@ SUBSYSTEM_DEF(garbage)
 	for(var/path in items)
 		var/datum/qdel_item/I = items[path]
 		dellog += "Path: [path]"
+		if (I.qdel_flags & QDEL_ITEM_SUSPENDED_FOR_LAG)
+			dellog += "\tSUSPENDED FOR LAG"
 		if (I.failures)
 			dellog += "\tFailures: [I.failures]"
 		dellog += "\tqdel() Count: [I.qdels]"
 		dellog += "\tDestroy() Cost: [I.destroy_time]ms"
 		if (I.hard_deletes)
-			dellog += "\tTotal Hard Deletes [I.hard_deletes]"
+			dellog += "\tTotal Hard Deletes: [I.hard_deletes]"
 			dellog += "\tTime Spent Hard Deleting: [I.hard_delete_time]ms"
+			dellog += "\tHighest Time Spent Hard Deleting: [I.hard_delete_max]ms"
+			if (I.hard_deletes_over_threshold)
+				dellog += "\tHard Deletes Over Threshold: [I.hard_deletes_over_threshold]"
 		if (I.slept_destroy)
 			dellog += "\tSleeps: [I.slept_destroy]"
 		if (I.no_respect_force)
@@ -158,33 +166,52 @@ SUBSYSTEM_DEF(garbage)
 			++gcedlasttick
 			++totalgcs
 			pass_counts[level]++
+			#ifdef REFERENCE_TRACKING
+			reference_find_on_fail -= refID //It's deleted we don't care anymore.
+			#endif
 			if (MC_TICK_CHECK)
 				return
 			continue
 
 		// Something's still referring to the qdel'd object.
 		fail_counts[level]++
+
+		#ifdef REFERENCE_TRACKING
+		var/ref_searching = FALSE
+		#endif
+
 		switch (level)
 			if (GC_QUEUE_CHECK)
 				#ifdef REFERENCE_TRACKING
-				D.find_references()
+				if(reference_find_on_fail[refID])
+					INVOKE_ASYNC(D, /datum/proc/find_references)
+					ref_searching = TRUE
+				#ifdef GC_FAILURE_HARD_LOOKUP
+				else
+					INVOKE_ASYNC(D, /datum/proc/find_references)
+					ref_searching = TRUE
+				#endif
+				reference_find_on_fail -= refID
 				#endif
 				var/type = D.type
 				var/datum/qdel_item/I = items[type]
-				#ifdef TESTING
+
 				log_world("## TESTING: GC: -- \ref[D] | [type] was unable to be GC'd --")
+				#ifdef TESTING
 				for(var/c in GLOB.admins) //Using testing() here would fill the logs with ADMIN_VV garbage
 					var/client/admin = c
-					if(!check_other_rights(admin, R_ADMIN, FALSE))
+					if(!check_rights_for(admin, R_ADMIN))
 						continue
 					to_chat(admin, "## TESTING: GC: -- [ADMIN_VV(D)] | [type] was unable to be GC'd --")
-				testing("GC: -- \ref[src] | [type] was unable to be GC'd --")
-				#endif
-				#ifdef REFERENCE_TRACKING
-				GLOB.deletion_failures += D //It should no longer be bothered by the GC, manual deletion only.
-				continue
 				#endif
 				I.failures++
+
+				if (I.qdel_flags & QDEL_ITEM_SUSPENDED_FOR_LAG)
+					#ifdef REFERENCE_TRACKING
+					if(ref_searching)
+						return //ref searching intentionally cancels all further fires while running so things that hold references don't end up getting deleted, so we want to return here instead of continue
+					#endif
+					continue
 			if (GC_QUEUE_HARDDELETE)
 				HardDelete(D)
 				if (MC_TICK_CHECK)
@@ -192,6 +219,11 @@ SUBSYSTEM_DEF(garbage)
 				continue
 
 		Queue(D, level+1)
+
+		#ifdef REFERENCE_TRACKING
+		if(ref_searching)
+			return
+		#endif
 
 		if (MC_TICK_CHECK)
 			return
@@ -215,67 +247,75 @@ SUBSYSTEM_DEF(garbage)
 
 //this is mainly to separate things profile wise.
 /datum/controller/subsystem/garbage/proc/HardDelete(datum/D)
-	var/time = world.timeofday
-	var/tick = TICK_USAGE
-	var/ticktime = world.time
 	++delslasttick
 	++totaldels
 	var/type = D.type
 	var/refID = "\ref[D]"
 
+	var/tick_usage = TICK_USAGE
 	del(D)
-
-	tick = (TICK_USAGE-tick+((world.time-ticktime)/world.tick_lag*100))
+	tick_usage = TICK_USAGE_TO_MS(tick_usage)
 
 	var/datum/qdel_item/I = items[type]
-
 	I.hard_deletes++
-	I.hard_delete_time += TICK_DELTA_TO_MS(tick)
+	I.hard_delete_time += tick_usage
+	if (tick_usage > I.hard_delete_max)
+		I.hard_delete_max = tick_usage
+	if (tick_usage > highest_del_ms)
+		highest_del_ms = tick_usage
+		highest_del_type_string = "[type]"
 
+	var/time = MS2DS(tick_usage)
 
-	if (tick > highest_del_tickusage)
-		highest_del_tickusage = tick
-	time = world.timeofday - time
-	if (!time && TICK_DELTA_TO_MS(tick) > 1)
-		time = TICK_DELTA_TO_MS(tick)/100
-	if (time > highest_del_time)
-		highest_del_time = time
-	if (time > 10)
-		WARNING("Error: [type]([refID]) took longer than 1 second to delete (took [time/10] seconds to delete).")
-		message_admins("Error: [type]([refID]) took longer than 1 second to delete (took [time/10] seconds to delete).")
+	if (time > 0.1 SECONDS)
 		postpone(time)
+	var/threshold = CONFIG_GET(number/hard_deletes_overrun_threshold)
+	if (threshold && (time > threshold SECONDS))
+		if (!(I.qdel_flags & QDEL_ITEM_ADMINS_WARNED))
+			log_game("Error: [type]([refID]) took longer than [threshold] seconds to delete (took [round(time/10, 0.1)] seconds to delete)")
+			message_admins("Error: [type]([refID]) took longer than [threshold] seconds to delete (took [round(time/10, 0.1)] seconds to delete).")
+			I.qdel_flags |= QDEL_ITEM_ADMINS_WARNED
+		I.hard_deletes_over_threshold++
+		var/overrun_limit = CONFIG_GET(number/hard_deletes_overrun_limit)
+		if (overrun_limit && I.hard_deletes_over_threshold >= overrun_limit)
+			I.qdel_flags |= QDEL_ITEM_SUSPENDED_FOR_LAG
 
 /datum/controller/subsystem/garbage/Recover()
 	if (istype(SSgarbage.queues))
 		for (var/i in 1 to SSgarbage.queues.len)
 			queues[i] |= SSgarbage.queues[i]
 
-
+/// Qdel Item: Holds statistics on each type that passes thru qdel
 /datum/qdel_item
-	var/name = ""
-	var/qdels = 0			//Total number of times it's passed thru qdel.
-	var/destroy_time = 0	//Total amount of milliseconds spent processing this type's Destroy()
-	var/failures = 0		//Times it was queued for soft deletion but failed to soft delete.
-	var/hard_deletes = 0 	//Different from failures because it also includes QDEL_HINT_HARDDEL deletions
-	var/hard_delete_time = 0//Total amount of milliseconds spent hard deleting this type.
-	var/no_respect_force = 0//Number of times it's not respected force=TRUE
-	var/no_hint = 0			//Number of times it's not even bother to give a qdel hint
-	var/slept_destroy = 0	//Number of times it's slept in its destroy
+	var/name = "" //!Holds the type as a string for this type
+	var/qdels = 0 //!Total number of times it's passed thru qdel.
+	var/destroy_time = 0 //!Total amount of milliseconds spent processing this type's Destroy()
+	var/failures = 0 //!Times it was queued for soft deletion but failed to soft delete.
+	var/hard_deletes = 0 //!Different from failures because it also includes QDEL_HINT_HARDDEL deletions
+	var/hard_delete_time = 0 //!Total amount of milliseconds spent hard deleting this type.
+	var/hard_delete_max = 0 //!Highest time spent hard_deleting this in ms.
+	var/hard_deletes_over_threshold = 0 //!Number of times hard deletes took longer than the configured threshold
+	var/no_respect_force = 0 //!Number of times it's not respected force=TRUE
+	var/no_hint = 0 //!Number of times it's not even bother to give a qdel hint
+	var/slept_destroy = 0 //!Number of times it's slept in its destroy
+	var/qdel_flags = 0 //!Flags related to this type's trip thru qdel.
 
 /datum/qdel_item/New(mytype)
 	name = "[mytype]"
 
 
-/// Should be treated as a replacement for the 'del' keyword. Datums passed to this will be given a chance to clean up references to allow the GC to collect them.
+/// Should be treated as a replacement for the 'del' keyword.
+///
+/// Datums passed to this will be given a chance to clean up references to allow the GC to collect them.
 /proc/qdel(datum/D, force=FALSE, ...)
 	if(!istype(D))
 		del(D)
 		return
+
 	var/datum/qdel_item/I = SSgarbage.items[D.type]
 	if (!I)
 		I = SSgarbage.items[D.type] = new /datum/qdel_item(D.type)
 	I.qdels++
-
 
 	if(isnull(D.gc_destroyed))
 		if (SEND_SIGNAL(D, COMSIG_PARENT_PREQDELETED, force)) // Give the components a chance to prevent their parent from being deleted
@@ -292,12 +332,12 @@ SUBSYSTEM_DEF(garbage)
 		if(!D)
 			return
 		switch(hint)
-			if (QDEL_HINT_QUEUE)		//qdel should queue the object for deletion.
+			if (QDEL_HINT_QUEUE) //qdel should queue the object for deletion.
 				SSgarbage.Queue(D)
 			if (QDEL_HINT_IWILLGC)
 				D.gc_destroyed = world.time
 				return
-			if (QDEL_HINT_LETMELIVE)	//qdel should let the object live after calling destory.
+			if (QDEL_HINT_LETMELIVE) //qdel should let the object live after calling destory.
 				if(!force)
 					D.gc_destroyed = null //clear the gc variable (important!)
 					return
@@ -314,10 +354,18 @@ SUBSYSTEM_DEF(garbage)
 				I.no_respect_force++
 
 				SSgarbage.Queue(D)
-			if (QDEL_HINT_HARDDEL)		//qdel should assume this object won't gc, and queue a hard delete
+			if (QDEL_HINT_HARDDEL) //qdel should assume this object won't gc, and queue a hard delete
 				SSgarbage.Queue(D, GC_QUEUE_HARDDELETE)
-			if (QDEL_HINT_HARDDEL_NOW)	//qdel should assume this object won't gc, and hard del it post haste.
+			if (QDEL_HINT_HARDDEL_NOW) //qdel should assume this object won't gc, and hard del it post haste.
 				SSgarbage.HardDelete(D)
+			#ifdef REFERENCE_TRACKING
+			if (QDEL_HINT_FINDREFERENCE) //qdel will, if REFERENCE_TRACKING is enabled, display all references to this object, then queue the object for deletion.
+				SSgarbage.Queue(D)
+				D.find_references()
+			if (QDEL_HINT_IFFAIL_FINDREFERENCE) //qdel will, if REFERENCE_TRACKING is enabled and the object fails to collect, display all references to this object.
+				SSgarbage.Queue(D)
+				SSgarbage.reference_find_on_fail["\ref[D]"] = TRUE
+			#endif
 			else
 				#ifdef TESTING
 				if(!I.no_hint)
@@ -327,20 +375,3 @@ SUBSYSTEM_DEF(garbage)
 				SSgarbage.Queue(D)
 	else if(D.gc_destroyed == GC_CURRENTLY_BEING_QDELETED)
 		CRASH("[D.type] destroy proc was called multiple times, likely due to a qdel loop in the Destroy logic")
-
-
-#ifdef REFERENCE_TRACKING
-
-/datum/proc/find_references()
-	testing("Beginning search for references to a [type].")
-	var/list/backrefs = get_back_references(src)
-	for(var/ref in backrefs)
-		var/datum/R = ref
-		if(!istype(R))
-			log_world("## TESTING: Datum reference found, but gone now.")
-			continue
-		log_world("## TESTING: Found [type] \ref[src] in [R.type][R.gc_destroyed ? " (destroyed)" : ""]")
-		message_admins("Found [type] \ref[src] in [R.type][R.gc_destroyed ? " (destroyed)" : ""] [ADMIN_VV(R)]")
-	testing("Completed search for references to a [type].")
-
-#endif

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -45,7 +45,12 @@
 
 	/// A weak reference to another datum
 	var/datum/weakref/weak_reference
-
+    /**
+     * Lazy associative list of currently active cooldowns.
+     *
+     * cooldowns [ COOLDOWN_INDEX ] = add_timer()
+     * add_timer() returns the truthy value of -1 when not stoppable, and else a truthy numeric index
+     */
 	var/list/cooldowns
 
 #ifdef DATUMVAR_DEBUGGING_MODE

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -46,7 +46,12 @@
 	/// A weak reference to another datum
 	var/datum/weakref/weak_reference
 
-	///Lazy associative list of currently active cooldowns.
+	/*
+	* Lazy associative list of currently active cooldowns.
+	*
+	* cooldowns [ COOLDOWN_INDEX ] = add_timer()
+	* add_timer() returns the truthy value of -1 when not stoppable, and else a truthy numeric index
+	*/
 	var/list/cooldowns
 
 #ifdef DATUMVAR_DEBUGGING_MODE
@@ -66,6 +71,14 @@
 	var/list/cached_vars
 #endif
 
+/**
+ * Called when a href for this datum is clicked
+ *
+ * Sends a [COMSIG_TOPIC] signal
+ */
+/datum/Topic(href, href_list[])
+	..()
+	SEND_SIGNAL(src, COMSIG_TOPIC, usr, href_list)
 
 /**
  * Default implementation of clean-up code.
@@ -85,7 +98,6 @@
  */
 /datum/proc/Destroy(force=FALSE, ...)
 	SHOULD_CALL_PARENT(TRUE)
-	SHOULD_NOT_SLEEP(TRUE)
 	tag = null
 	datum_flags &= ~DF_USE_TAG //In case something tries to REF us
 	weak_reference = null	//ensure prompt GCing of weakref.
@@ -114,6 +126,12 @@
 			qdel(C, FALSE, TRUE)
 		dc.Cut()
 
+	clear_signal_refs()
+	//END: ECS SHIT
+
+	return QDEL_HINT_QUEUE
+
+/datum/proc/clear_signal_refs()
 	var/list/lookup = comp_lookup
 	if(lookup)
 		for(var/sig in lookup)
@@ -129,9 +147,6 @@
 
 	for(var/target in signal_procs)
 		UnregisterSignal(target, signal_procs[target])
-	//END: ECS SHIT
-
-	return QDEL_HINT_QUEUE
 
 #ifdef DATUMVAR_DEBUGGING_MODE
 /datum/proc/save_vars()

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -53,6 +53,19 @@
 	var/list/cached_vars
 #endif
 
+#ifdef REFERENCE_TRACKING
+	var/running_find_references
+	var/last_find_references = 0
+	#ifdef REFERENCE_TRACKING_DEBUG
+	///Stores info about where refs are found, used for sanity checks and testing
+	var/list/found_refs
+	#endif
+#endif
+
+#ifdef DATUMVAR_DEBUGGING_MODE
+	var/list/cached_vars
+#endif
+
 
 /**
  * Default implementation of clean-up code.

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -67,10 +67,6 @@
 	#endif
 #endif
 
-#ifdef DATUMVAR_DEBUGGING_MODE
-	var/list/cached_vars
-#endif
-
 /**
  * Called when a href for this datum is clicked
  *
@@ -128,8 +124,12 @@
 
 	clear_signal_refs()
 	//END: ECS SHIT
-
+	#ifdef REFERENCE_TRACKING
+	return QDEL_HINT_IFFAIL_FINDREFERENCE
+	#else
 	return QDEL_HINT_QUEUE
+	#endif
+
 
 /datum/proc/clear_signal_refs()
 	var/list/lookup = comp_lookup

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -46,12 +46,6 @@
 	/// A weak reference to another datum
 	var/datum/weakref/weak_reference
 
-	/*
-	* Lazy associative list of currently active cooldowns.
-	*
-	* cooldowns [ COOLDOWN_INDEX ] = add_timer()
-	* add_timer() returns the truthy value of -1 when not stoppable, and else a truthy numeric index
-	*/
 	var/list/cooldowns
 
 #ifdef DATUMVAR_DEBUGGING_MODE

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -124,11 +124,7 @@
 
 	clear_signal_refs()
 	//END: ECS SHIT
-	#ifdef REFERENCE_TRACKING
-	return QDEL_HINT_IFFAIL_FINDREFERENCE
-	#else
 	return QDEL_HINT_QUEUE
-	#endif
 
 
 /datum/proc/clear_signal_refs()

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -45,12 +45,12 @@
 
 	/// A weak reference to another datum
 	var/datum/weakref/weak_reference
-    /**
-     * Lazy associative list of currently active cooldowns.
-     *
-     * cooldowns [ COOLDOWN_INDEX ] = add_timer()
-     * add_timer() returns the truthy value of -1 when not stoppable, and else a truthy numeric index
-     */
+	/**
+	 * Lazy associative list of currently active cooldowns.
+	 *
+	 * cooldowns [ COOLDOWN_INDEX ] = add_timer()
+	 * add_timer() returns the truthy value of -1 when not stoppable, and else a truthy numeric index
+	 */
 	var/list/cooldowns
 
 #ifdef DATUMVAR_DEBUGGING_MODE

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -12,9 +12,6 @@ GLOBAL_VAR(restart_counter)
 	var/extools = world.GetConfig("env", "EXTOOLS_DLL") || (world.system_type == MS_WINDOWS ? "./byond-extools.dll" : "./libbyond-extools.so")
 	if(fexists(extools))
 		call(extools, "maptick_initialize")()
-#ifdef REFERENCE_TRACKING
-	enable_reference_tracking()
-#endif
 #endif
 	enable_debugger()
 

--- a/code/modules/admin/debug_verbs.dm
+++ b/code/modules/admin/debug_verbs.dm
@@ -655,6 +655,8 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 	for(var/path in SSgarbage.items)
 		var/datum/qdel_item/I = SSgarbage.items[path]
 		dellog += "<li><u>[path]</u><ul>"
+		if (I.qdel_flags & QDEL_ITEM_SUSPENDED_FOR_LAG)
+			dellog += "<li>SUSPENDED FOR LAG</li>"
 		if (I.failures)
 			dellog += "<li>Failures: [I.failures]</li>"
 		dellog += "<li>qdel() Count: [I.qdels]</li>"
@@ -662,6 +664,9 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 		if (I.hard_deletes)
 			dellog += "<li>Total Hard Deletes [I.hard_deletes]</li>"
 			dellog += "<li>Time Spent Hard Deleting: [I.hard_delete_time]ms</li>"
+			dellog += "<li>Highest Time Spent Hard Deleting: [I.hard_delete_max]ms</li>"
+			if (I.hard_deletes_over_threshold)
+				dellog += "<li>Hard Deletes Over Threshold: [I.hard_deletes_over_threshold]</li>"
 		if (I.slept_destroy)
 			dellog += "<li>Sleeps: [I.slept_destroy]</li>"
 		if (I.no_respect_force)

--- a/code/modules/admin/holder.dm
+++ b/code/modules/admin/holder.dm
@@ -359,10 +359,6 @@ GLOBAL_PROTECT(admin_verbs_asay)
 	/datum/admins/proc/view_runtimes,
 	/datum/admins/proc/spatial_agent,
 	/datum/admins/proc/set_xeno_stat_buffs,
-#ifdef REFERENCE_TRACKING
-	/datum/admins/proc/view_refs,
-	/datum/admins/proc/view_del_failures,
-#endif
 	/datum/admins/proc/check_bomb_impacts,
 	/client/proc/toggle_cdn
 	)
@@ -505,7 +501,7 @@ GLOBAL_PROTECT(admin_verbs_spawn)
 			verbs += GLOB.admin_verbs_server
 		if(rights & R_DEBUG)
 			verbs += GLOB.admin_verbs_debug
-		if(rights & R_RUNTIME) 
+		if(rights & R_RUNTIME)
 			verbs += GLOB.admin_verbs_runtimes
 		if(rights & R_PERMISSIONS)
 			verbs += GLOB.admin_verbs_permissions

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2214,9 +2214,3 @@ Status: [status ? status : "Unknown"] | Damage: [health ? health : "None"]
 		var/datum/poll_question/poll = locate(href_list["submitoptionpoll"]) in GLOB.polls
 		poll_option_parse_href(href_list, poll, option)
 
-	#ifdef REFERENCE_TRACKING
-	else if(href_list["delfail_clearnulls"])
-		listclearnulls(GLOB.deletion_failures)
-		view_del_failures()
-		return
-	#endif

--- a/code/modules/admin/verbs/datumvars.dm
+++ b/code/modules/admin/verbs/datumvars.dm
@@ -159,9 +159,6 @@
 	.["Mark Object"] = "?_src_=vars;[HrefToken()];[VV_HK_MARK]=[REF(src)]"
 	.["Delete"] = "?_src_=vars;[HrefToken()];[VV_HK_DELETE]=[REF(src)]"
 	.["Show VV To Player"] = "?_src_=vars;[HrefToken()];[VV_HK_EXPOSE]=[REF(src)]"
-	#ifdef REFERENCE_TRACKING
-	.["View References"] = "?_src_=vars;[HrefToken()];[VV_HK_VIEW_REFERENCES]=[REF(src)]"
-	#endif
 
 
 /client/proc/debug_variables(datum/D in world)
@@ -647,18 +644,6 @@
 		usr.client.holder.delete_atom(D)
 		if(isturf(D))  // show the turf that took its place
 			debug_variables(D)
-
-	#ifdef REFERENCE_TRACKING
-	else if(href_list[VV_HK_VIEW_REFERENCES])
-		if(!check_rights(R_DEBUG))
-			return
-		var/datum/D = locate(href_list[VV_HK_TARGET])
-		if(!D)
-			to_chat(usr, "<span class='warning'>Unable to locate item.</span>")
-			return
-		usr.client.holder.view_refs(D)
-		return
-	#endif
 
 	else if(href_list["regenerateicons"])
 		if(!check_rights(R_DEBUG))

--- a/code/modules/admin/view_variables/reference_tracking.dm
+++ b/code/modules/admin/view_variables/reference_tracking.dm
@@ -9,7 +9,7 @@
 			running_find_references = null
 			//restart the garbage collector
 			SSgarbage.can_fire = TRUE
-			SSgarbage.update_nextfire(reset_time = TRUE)
+			SSgarbage.next_fire = world.time + world.tick_lag
 			return
 
 		if(!skip_alert && tgui_alert(usr,"Running this will lock everything up for about 5 minutes.  Would you like to begin the search?", "Find References", list("Yes", "No")) != "Yes")
@@ -51,7 +51,7 @@
 
 	//restart the garbage collector
 	SSgarbage.can_fire = TRUE
-	SSgarbage.update_nextfire(reset_time = TRUE)
+	SSgarbage.next_fire = world.time + world.tick_lag
 
 /datum/proc/DoSearchVar(potential_container, container_name, recursive_limit = 64, search_time = world.time)
 	#ifdef REFERENCE_TRACKING_DEBUG

--- a/code/modules/admin/view_variables/reference_tracking.dm
+++ b/code/modules/admin/view_variables/reference_tracking.dm
@@ -1,78 +1,140 @@
 #ifdef REFERENCE_TRACKING
 
-GLOBAL_LIST_EMPTY(deletion_failures)
+/datum/proc/find_references(skip_alert)
+	running_find_references = type
+	if(usr?.client)
+		if(usr.client.running_find_references)
+			log_reftracker("CANCELLED search for references to a [usr.client.running_find_references].")
+			usr.client.running_find_references = null
+			running_find_references = null
+			//restart the garbage collector
+			SSgarbage.can_fire = TRUE
+			SSgarbage.update_nextfire(reset_time = TRUE)
+			return
 
-/world/proc/enable_reference_tracking()
-	var/extools = world.GetConfig("env", "EXTOOLS_DLL") || (world.system_type == MS_WINDOWS ? "./byond-extools.dll" : "./libbyond-extools.so")
-	if (fexists(extools))
-		call(extools, "ref_tracking_initialize")()
+		if(!skip_alert && tgui_alert(usr,"Running this will lock everything up for about 5 minutes.  Would you like to begin the search?", "Find References", list("Yes", "No")) != "Yes")
+			running_find_references = null
+			return
 
-/proc/get_back_references(datum/D)
-	CRASH("/proc/get_back_references not hooked by extools, reference tracking will not function!")
+	//this keeps the garbage collector from failing to collect objects being searched for in here
+	SSgarbage.can_fire = FALSE
 
-/proc/get_forward_references(datum/D)
-	CRASH("/proc/get_forward_references not hooked by extools, reference tracking will not function!")
+	if(usr?.client)
+		usr.client.running_find_references = type
 
-/proc/clear_references(datum/D)
-	return
+	log_reftracker("Beginning search for references to a [type].")
 
-/datum/admins/proc/view_refs(atom/D in world) //it actually supports datums as well but byond no likey
-	set category = "Debug"
-	set name = "View References"
+	var/starting_time = world.time
 
-	if(!check_rights(R_DEBUG) || !D)
+	//Time to search the whole game for our ref
+	DoSearchVar(GLOB, "GLOB") //globals
+	log_reftracker("Finished searching globals")
+
+	for(var/datum/thing in world) //atoms (don't beleive its lies)
+		DoSearchVar(thing, "World -> [thing.type]", search_time = starting_time)
+	log_reftracker("Finished searching atoms")
+
+	for(var/datum/thing) //datums
+		DoSearchVar(thing, "Datums -> [thing.type]", search_time = starting_time)
+	log_reftracker("Finished searching datums")
+
+	//Warning, attempting to search clients like this will cause crashes if done on live. Watch yourself
+	for(var/client/thing) //clients
+		DoSearchVar(thing, "Clients -> [thing.type]", search_time = starting_time)
+	log_reftracker("Finished searching clients")
+
+	log_reftracker("Completed search for references to a [type].")
+
+	if(usr?.client)
+		usr.client.running_find_references = null
+	running_find_references = null
+
+	//restart the garbage collector
+	SSgarbage.can_fire = TRUE
+	SSgarbage.update_nextfire(reset_time = TRUE)
+
+/datum/proc/DoSearchVar(potential_container, container_name, recursive_limit = 64, search_time = world.time)
+	#ifdef REFERENCE_TRACKING_DEBUG
+	if(!found_refs)
+		found_refs = list()
+	#endif
+
+	if(usr?.client && !usr.client.running_find_references)
 		return
 
-	var/list/backrefs = get_back_references(D)
-	if(isnull(backrefs))
-		var/datum/browser/popup = new(usr, "ref_view", "<div align='center'>Error</div>")
-		popup.set_content("Reference tracking not enabled")
-		popup.open(FALSE)
+	if(!recursive_limit)
+		log_reftracker("Recursion limit reached. [container_name]")
 		return
 
-	var/list/frontrefs = get_forward_references(D)
-	var/list/dat = list()
-	dat += "<h1>References of \ref[D] - [D]</h1><br><a href='?_src_=vars;[HrefToken(TRUE)];[VV_HK_VIEW_REFERENCES]=TRUE;[VV_HK_TARGET]=[REF(D)]'>\[Refresh\]</a><hr>"
-	dat += "<h3>Back references - these things hold references to this object.</h3>"
-	dat += "<table>"
-	dat += "<tr><th>Ref</th><th>Type</th><th>Variable Name</th><th>Follow</th>"
-	for(var/ref in backrefs)
-		var/datum/R = ref
-		dat += "<tr><td><a href='?_src_=vars;[HrefToken(TRUE)];vars=[REF(R)]'>[REF(R)]</td><td>[R.type]</td><td>[backrefs[R]]</td><td><a href='?_src_=vars;[HrefToken(TRUE)];[VV_HK_VIEW_REFERENCES]=TRUE;[VV_HK_TARGET]=[REF(R)]'>\[Follow\]</a></td></tr>"
-	dat += "</table><hr>"
-	dat += "<h3>Forward references - this object is referencing those things.</h3>"
-	dat += "<table>"
-	dat += "<tr><th>Variable name</th><th>Ref</th><th>Type</th><th>Follow</th>"
-	for(var/ref in frontrefs)
-		var/datum/R = frontrefs[ref]
-		dat += "<tr><td>[ref]</td><td><a href='?_src_=vars;[HrefToken(TRUE)];vars=[REF(R)]'>[REF(R)]</a></td><td>[R.type]</td><td><a href='?_src_=vars;[HrefToken(TRUE)];[VV_HK_VIEW_REFERENCES]=TRUE;[VV_HK_TARGET]=[REF(R)]'>\[Follow\]</a></td></tr>"
-	dat += "</table><hr>"
-	dat = dat.Join()
+	//Check each time you go down a layer. This makes it a bit slow, but it won't effect the rest of the game at all
+	#ifndef FIND_REF_NO_CHECK_TICK
+	CHECK_TICK
+	#endif
 
-	var/datum/browser/popup = new(usr, "ref_view", "<div align='center'>References of \ref[D]</div>")
-	popup.set_content(dat)
-	popup.open(FALSE)
+	if(istype(potential_container, /datum))
+		var/datum/datum_container = potential_container
+		if(datum_container.last_find_references == search_time)
+			return
 
+		datum_container.last_find_references = search_time
+		var/list/vars_list = datum_container.vars
 
-/datum/admins/proc/view_del_failures()
-	set category = "Debug"
-	set name = "View Deletion Failures"
+		for(var/varname in vars_list)
+			#ifndef FIND_REF_NO_CHECK_TICK
+			CHECK_TICK
+			#endif
+			if (varname == "vars" || varname == "vis_locs") //Fun fact, vis_locs don't count for references
+				continue
+			var/variable = vars_list[varname]
 
-	if(!check_rights(R_DEBUG))
-		return
+			if(variable == src)
+				#ifdef REFERENCE_TRACKING_DEBUG
+				found_refs[varname] = TRUE
+				#endif
+				log_reftracker("Found [type] \ref[src] in [datum_container.type]'s \ref[datum_container] [varname] var. [container_name]")
+				continue
 
-	var/list/dat = list("<table>")
-	for(var/t in GLOB.deletion_failures)
-		if(isnull(t))
-			dat += "<tr><td>GC'd Reference | <a href='byond://?src=[REF(src)];[HrefToken(TRUE)];delfail_clearnulls=TRUE'>Clear Nulls</a></td></tr>"
-			continue
-		var/datum/thing = t
-		dat += "<tr><td>\ref[thing] | [thing.type][thing.gc_destroyed ? " (destroyed)" : ""] [ADMIN_VV(thing)]</td></tr>"
-	dat += "</table><hr>"
-	dat = dat.Join()
+			if(islist(variable))
+				DoSearchVar(variable, "[container_name] \ref[datum_container] -> [varname] (list)", recursive_limit - 1, search_time)
 
-	var/datum/browser/popup = new(usr, "del_failures", "<div align='center'>Deletion Failures</div>")
-	popup.set_content(dat)
-	popup.open(FALSE)
+	else if(islist(potential_container))
+		var/normal = IS_NORMAL_LIST(potential_container)
+		var/list/potential_cache = potential_container
+		for(var/element_in_list in potential_cache)
+			#ifndef FIND_REF_NO_CHECK_TICK
+			CHECK_TICK
+			#endif
+			//Check normal entrys
+			if(element_in_list == src)
+				#ifdef REFERENCE_TRACKING_DEBUG
+				found_refs[potential_cache] = TRUE
+				#endif
+				log_reftracker("Found [type] \ref[src] in list [container_name].")
+				continue
+
+			var/assoc_val = null
+			if(!isnum(element_in_list) && normal)
+				assoc_val = potential_cache[element_in_list]
+			//Check assoc entrys
+			if(assoc_val == src)
+				#ifdef REFERENCE_TRACKING_DEBUG
+				found_refs[potential_cache] = TRUE
+				#endif
+				log_reftracker("Found [type] \ref[src] in list [container_name]\[[element_in_list]\]")
+				continue
+			//We need to run both of these checks, since our object could be hiding in either of them
+			//Check normal sublists
+			if(islist(element_in_list))
+				DoSearchVar(element_in_list, "[container_name] -> [element_in_list] (list)", recursive_limit - 1, search_time)
+			//Check assoc sublists
+			if(islist(assoc_val))
+				DoSearchVar(potential_container[element_in_list], "[container_name]\[[element_in_list]\] -> [assoc_val] (list)", recursive_limit - 1, search_time)
+
+/proc/qdel_and_find_ref_if_fail(datum/thing_to_del, force = FALSE)
+	thing_to_del.qdel_and_find_ref_if_fail(force)
+
+/datum/proc/qdel_and_find_ref_if_fail(force = FALSE)
+	SSgarbage.reference_find_on_fail["\ref[src]"] = TRUE
+	qdel(src, force)
 
 #endif

--- a/config/config.txt
+++ b/config/config.txt
@@ -212,3 +212,9 @@ DEFAULT_VIEW 19x15
 ## The alternative square viewport size if you're using a widescreen view size
 ## You probably shouldn't ever be changing this, but it's here if you want to.
 DEFAULT_VIEW_SQUARE 15x15
+
+## How long in seconds after which a hard delete is treated as causing lag. This can be a float and supports a precision as low as nanoseconds.
+#HARD_DELETES_OVERRUN_THRESHOLD 0.5
+
+## Once a typepath causes overrun from hard deletes this many times, stop hard deleting it on garbage collection failures. (set to 0 to disable)
+#HARD_DELETES_OVERRUN_LIMIT 0


### PR DESCRIPTION
This port some improvement on how to handle hard del from tg

https://github.com/tgstation/tgstation/pull/56724 : this was already ported in part, i'm adding the rest here
https://github.com/tgstation/tgstation/pull/57728 : this is better ref tracking. I'm not adding the unit test from this
https://github.com/tgstation/tgstation/pull/58972 : fixed some bugs of the hard del traker
https://github.com/tgstation/tgstation/pull/59371 : this optimized the ref tracker

This needs config update and probably LAA
https://github.com/tgstation/tgstation/pull/59750 : if the same type hard del too much, hard dels on that specific type will be disabled. 

