### PR TITLE
adds a new bucket with an uzi and cmb revolver, and buffs and restats them

### DIFF
--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -26,6 +26,7 @@ SUBSYSTEM_DEF(persistence)
 		/datum/season_datum/weapons/guns/pistol_seasonal_two,
 		/datum/season_datum/weapons/guns/rifle_seasonal_two,
 		/datum/season_datum/weapons/guns/pistol_seasonal_three,
+		/datum/season_datum/weapons/guns/copsandrobbers_seasonal,
 		)
 	)
 	///The saved list of custom outfits names
@@ -189,3 +190,14 @@ SUBSYSTEM_DEF(persistence)
 		/obj/item/weapon/gun/pistol/highpower = -1,
 		/obj/item/ammo_magazine/pistol/highpower = -1,
 		)
+
+/datum/season_datum/weapons/guns/copsandrobbers_seasonal
+	name = "cops and robbers"
+	description = "A Revolver and a classic SMG. Truly cops and robbers."
+	item_list = list(
+		/obj/item/weapon/gun/smg/uzi = -1,
+		/obj/item/ammo_magazine/smg/uzi = -1,
+		/obj/item/weapon/gun/revolver/cmb = -1,
+		/obj/item/ammo_magazine/revolver/cmb = -1,
+		)
+

--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -531,8 +531,8 @@
 	)
 	attachable_offset = list("muzzle_x" = 29, "muzzle_y" = 22,"rail_x" = 11, "rail_y" = 25, "under_x" = 20, "under_y" = 18, "stock_x" = 20, "stock_y" = 18)
 
-	fire_delay = 1.2 SECONDS
+	fire_delay = 0.15 SECONDS
 	burst_amount = 3
-	burst_delay = 0.5 SECONDS
+	burst_delay = 0.1 SECONDS
 	scatter_unwielded = 20
 	damage_mult = 1.05

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -311,8 +311,8 @@
 //GENERIC UZI //Based on the uzi submachinegun, of course.
 
 /obj/item/weapon/gun/smg/uzi
-	name = "\improper GAL9 submachinegun"
-	desc = "A cheap, reliable design and manufacture make this ubiquitous submachinegun useful despite the age. Put the fire mode to full auto for maximum firepower."
+	name = "\improper MP-2 submachinegun"
+	desc = "A cheap, reliable design and manufacture make this ubiquitous submachinegun useful despite the age. Put the fire selector to full auto for maximum firepower. Use two if you really want to go ham."
 	icon_state = "uzi"
 	item_state = "uzi"
 	caliber = CALIBER_9X19 //codex
@@ -324,10 +324,11 @@
 	current_mag = /obj/item/ammo_magazine/smg/uzi
 	attachable_offset = list("muzzle_x" = 30, "muzzle_y" = 20,"rail_x" = 11, "rail_y" = 22, "under_x" = 22, "under_y" = 16, "stock_x" = 22, "stock_y" = 16)
 
-	fire_delay = 0.175 SECONDS
+	fire_delay = 0.15 SECONDS
 	burst_amount = 4
-	accuracy_mult_unwielded = 0.85
-	scatter = 15
-	scatter_unwielded = 60
+	accuracy_mult_unwielded = 0.9
+	accuracy_mult = 1
+	scatter = 0
+	scatter_unwielded = 10
 	aim_slowdown = 0.15
-	wield_delay = 0.5 SECONDS
+	wield_delay = 0.2 SECONDS


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
UZI is built to be used one handed and akimbo, use it to your hearts content. Renamed from GAL-9 since gal-9 sounds dumb, renamed to MP-2
CMB is tp-44 fire rate considering it's an autorevolver and fires revolver/small so it does less damage, also has a 2 round burst mode if you want to get cool or something.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Adds new bucket and makes shitty old guns viable again.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
expansion: new seasonal bucket with uzi and cmb revolver
balance: cmb now has tp-44 fire rate, now has a 2 round burst with 0.1 fire delay. Uzi buffed to fire as fast as normal smgs and is built for one handed use.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
