### PR TITLE
Lets xenos turn off rail flashlights by slashing the gun

### DIFF
--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -1180,8 +1180,9 @@ and you're good to go.
 
 ///For letting xenos turn off the flashlights on any guns left lying around.
 /obj/item/weapon/gun/attack_alien(mob/living/carbon/xenomorph/X, isrightclick = FALSE)
-	if(flags_gun_features & GUN_FLASHLIGHT_ON)
-		attachments[ATTACHMENT_SLOT_RAIL].turn_light(null, FALSE)
-		playsound(loc, "alien_claw_metal", 25, 1)
-		X.do_attack_animation(src, ATTACK_EFFECT_CLAW)
-		to_chat(X, "<span class='warning'>We disable the metal thing's lights.</span>")
+	if(!CHECK_BITFIELD(flags_gun_features, GUN_FLASHLIGHT_ON))
+		return
+	attachments[ATTACHMENT_SLOT_RAIL].turn_light(null, FALSE)
+	playsound(loc, "alien_claw_metal", 25, 1)
+	X.do_attack_animation(src, ATTACK_EFFECT_CLAW)
+	to_chat(X, "<span class='warning'>We disable the metal thing's lights.</span>")

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -286,7 +286,7 @@
 	if(CHECK_BITFIELD(flags_gun_features, GUN_DEPLOYED_FIRE_ONLY))
 		to_chat(user, "<span class='notice'>[src] cannot be fired by hand and must be deployed.</span>")
 		return
-	
+
 	. = ..()
 
 	if(!.)
@@ -1177,3 +1177,11 @@ and you're good to go.
 		return
 	active_attachable.fire_attachment(target, src, gun_user) //Fire it.
 	last_fired = world.time
+
+///For letting xenos turn off the flashlights on any guns left lying around.
+/obj/item/weapon/gun/attack_alien(mob/living/carbon/xenomorph/X, isrightclick = FALSE)
+	if(flags_gun_features & GUN_FLASHLIGHT_ON)
+		attachments[ATTACHMENT_SLOT_RAIL].turn_light(null, FALSE)
+		playsound(loc, "alien_claw_metal", 25, 1)
+		X.do_attack_animation(src, ATTACK_EFFECT_CLAW)
+		to_chat(X, "<span class='warning'>We disable the metal thing's lights.</span>")

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -1178,7 +1178,7 @@ and you're good to go.
 	active_attachable.fire_attachment(target, src, gun_user) //Fire it.
 	last_fired = world.time
 
-///For letting xenos turn off the flashlights on any guns left lying around.
+//For letting xenos turn off the flashlights on any guns left lying around.
 /obj/item/weapon/gun/attack_alien(mob/living/carbon/xenomorph/X, isrightclick = FALSE)
 	if(!CHECK_BITFIELD(flags_gun_features, GUN_FLASHLIGHT_ON))
 		return


### PR DESCRIPTION
## About The Pull Request
Xenos can now attack floor guns to turn off the rail light if there is one.

## Why It's Good For The Game
Tired of infinite pocket pistols lying around providing light forever until one of the castes with acid clears it. If you want lights to leave around as a marine bring flares.
Closes #7438 

## Changelog
:cl:
add: Slashing guns as a xeno will turn any lights on them off
/:cl: