### PR TITLE
Grapple Toss Distance is Now 4 Instead of 3 Because 3 Is A Stupid Overnerf

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -256,7 +256,7 @@
 /datum/action/xeno_action/activable/toss/use_ability(atom/A)
 	var/mob/living/carbon/xenomorph/X = owner
 	var/atom/movable/target = owner.pulling
-	var/fling_distance = 3
+	var/fling_distance = 4
 	var/stagger_slow_stacks = 3
 	var/stun_duration = 1 SECONDS
 	var/big_mob_message


### PR DESCRIPTION
## About The Pull Request

Per title.

## Why It's Good For The Game

Per title.

## Changelog
:cl:
balance: Warrior Grapple Toss distance increased from 3 to 4.
/:cl: