### PR TITLE
Fix two values I forgot to adjust during the xeno heal change

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
@@ -47,7 +47,7 @@
 /mob/living/carbon/xenomorph/proc/salve_healing() //Slight modification of the heal_wounds proc
 	var/amount = 50	//Smaller than psychic cure, less useful on xenos with large health pools
 	if(recovery_aura)	//Leaving in the recovery aura bonus, not sure if it is too high the way it is
-		amount += recovery_aura * maxHealth * 0.008 // +0.8% max health per recovery level, up to +4%
+		amount += recovery_aura * maxHealth * 0.01 // +1% max health per recovery level, up to +5%
 	var/remainder = max(0, amount - getBruteLoss()) //Heal brute first, apply whatever's left to burns
 	adjustBruteLoss(-amount)
 	adjustFireLoss(-remainder, updating_health = TRUE)

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -103,9 +103,9 @@
 		adjustBruteLoss(XENO_CRIT_DAMAGE - (warding_aura * 0.5)) //Warding can heavily lower the impact of bleedout. Halved at 5.
 
 /mob/living/carbon/xenomorph/proc/heal_wounds(multiplier = XENO_RESTING_HEAL, scaling = FALSE)
-	var/amount = 1 + (maxHealth * 0.0375) // 1 damage + 2% max health, with scaling power.
+	var/amount = 1 + (maxHealth * 0.0375) // 1 damage + 3.75% max health, with scaling power.
 	if(recovery_aura)
-		amount += recovery_aura * maxHealth * 0.008 // +0.8% max health per recovery level, up to +4%
+		amount += recovery_aura * maxHealth * 0.01 // +1% max health per recovery level, up to +5%
 	if(scaling)
 		if(recovery_aura)
 			regen_power = clamp(regen_power + xeno_caste.regen_ramp_amount*30,0,1) //Ignores the cooldown, and gives a 50% boost.


### PR DESCRIPTION
## About The Pull Request
Xeno's main healing proc gets an additive bonus based on recovery pheromone strength. Since it's additive, it should've been increased by 25% in #7377 but I missed it. Whoops.

## Why It's Good For The Game
Minor fix on a merged pr, also updated comments.

## Changelog
:cl:
fix: The recent 25% boost to xeno healing now also includes the gain from recovery pheromones
/:cl: