### PR TITLE
Add more paths to quick create for admins.

### DIFF
--- a/code/modules/admin/panels/game_panel.dm
+++ b/code/modules/admin/panels/game_panel.dm
@@ -67,7 +67,7 @@
 		return
 
 	var/static/list/create_object_forms = list(
-	/obj, /obj/structure, /obj/machinery, /obj/effect, /obj/item, /obj/item/clothing, /obj/item/stack, /obj/item, /obj/item/weapon)
+	/obj, /obj/structure, /obj/machinery, /obj/effect, /obj/item, /obj/item/reagent_containers, /obj/item/clothing, /obj/item/stack, /obj/item, /obj/item/explosive, /obj/item/weapon, /obj/item/weapon/gun, /obj/item/ammo_magazine)
 
 	var/path = input("Select the path of the object you wish to create.", "Path", /obj) in create_object_forms
 	var/html_form = create_object_forms[path]


### PR DESCRIPTION
## About The Pull Request
Just a bit of QoL.

## Changelog
:cl:
admin: expand the quick create paths
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
