### PR TITLE
Add a missing floodlight switch to LV engineering

### DIFF
--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -17369,6 +17369,12 @@
 	dir = 1
 	},
 /area/lv624/ground/jungle2)
+"wux" = (
+/obj/machinery/colony_floodlight_switch{
+	pixel_x = 32
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
 "wvF" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/jungle/vines,
@@ -33335,8 +33341,8 @@ blo
 xSy
 blj
 vTg
-xSy
-bqo
+wux
+pkq
 blj
 wit
 dmG


### PR DESCRIPTION
## About The Pull Request
Just a missing switch which seems to have been forgotten in map change.

## Changelog
:cl:
fix: fixed a missing floodlight in LV engineering
/:cl:
