### PR TITLE
Make it so cameras check for power before notifying the AI

### DIFF
--- a/code/game/objects/machinery/camera/camera.dm
+++ b/code/game/objects/machinery/camera/camera.dm
@@ -198,6 +198,9 @@
 			M.reset_perspective(null)
 			to_chat(M, "The screen bursts into static.")
 
+	if(!powered)
+		return
+
 	for(var/mob/living/silicon/ai/AI in GLOB.silicon_mobs)
 		if(!AI.client)
 			continue

--- a/code/game/objects/machinery/camera/camera.dm
+++ b/code/game/objects/machinery/camera/camera.dm
@@ -198,7 +198,7 @@
 			M.reset_perspective(null)
 			to_chat(M, "The screen bursts into static.")
 
-	if(!powered)
+	if(!powered())
 		return
 
 	for(var/mob/living/silicon/ai/AI in GLOB.silicon_mobs)


### PR DESCRIPTION
## About The Pull Request
Some cameras weren't giving some undeserved info in powerless areas.
 

## Changelog
:cl:
fix: fixed cameras notifying the AI of their demise, despite a lack of power.
/:cl:
