### PR TITLE
Adds rank progression to CMO, adjusts SO ranks, and fixes CSE time for ranks

### DIFF
--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -188,7 +188,7 @@ Make the TGMC proud!"})
 //Staff Officer
 /datum/job/terragov/command/staffofficer
 	title = STAFF_OFFICER
-	paygrade = "O4"
+	paygrade = "O3"
 	comm_title = "SO"
 	total_positions = 4
 	access = list(ACCESS_MARINE_BRIDGE, ACCESS_MARINE_BRIG, ACCESS_MARINE_CARGO, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_ALPHA, ACCESS_MARINE_BRAVO, ACCESS_MARINE_CHARLIE, ACCESS_MARINE_DELTA)
@@ -239,7 +239,9 @@ You are in charge of logistics and the overwatch system. You are also in line to
 	if(!playtime_mins || playtime_mins < 1 )
 		return
 	switch(playtime_mins)
-		if(0 to 3000) // starting
+		if(0 to 1500) // starting
+			new_human.wear_id.paygrade = "O3"
+		if(1501 to 3000) // 25 hrs
 			new_human.wear_id.paygrade = "O4"
 		if(3001 to INFINITY) // 50 hrs
 			new_human.wear_id.paygrade = "O5"
@@ -404,9 +406,9 @@ If you are not piloting, there is an autopilot fallback for command, but don't l
 	switch(playtime_mins)
 		if(0 to 1500) // starting
 			new_human.wear_id.paygrade = "O2"
-		if(1501 to 6000) // 25 hrs
+		if(1501 to 3000) // 25 hrs
 			new_human.wear_id.paygrade = "O3"
-		if(6001 to INFINITY) // 50 hrs
+		if(3001 to INFINITY) // 50 hrs
 			new_human.wear_id.paygrade = "O4"
 
 /datum/job/terragov/engineering/chief/radio_help_message(mob/M)
@@ -661,6 +663,22 @@ A happy ship is a well-functioning ship."})
 	to_chat(M, {"You are the chief medical officer aboard the [SSmapping.configs[SHIP_MAP].map_name], navy officer and supervisor to the medical department.
 You have final authority over the medical department, medications, and treatments.
 Make sure that the doctors and nurses are doing their jobs and keeping the marines healthy and strong."})
+
+/datum/job/terragov/medical/professor/after_spawn(mob/living/carbon/new_mob, mob/user, latejoin = FALSE)
+	. = ..()
+	if(!ishuman(new_mob))
+		return
+	var/mob/living/carbon/human/new_human = new_mob
+	var/playtime_mins = user?.client?.get_exp(title)
+	if(!playtime_mins || playtime_mins < 1 )
+		return
+	switch(playtime_mins)
+		if(0 to 1500) // starting
+			new_human.wear_id.paygrade = "O3"
+		if(1501 to 3000) // 25 hrs
+			new_human.wear_id.paygrade = "O4"
+		if(3001 to INFINITY) // 50 hrs
+			new_human.wear_id.paygrade = "O5"
 
 
 /datum/outfit/job/medical/professor


### PR DESCRIPTION
## About The Pull Request

Basically the title. In order of relevance:

CMOs now have rank progression and a 200 hour CMO will no longer be equal in rank to a 50 hour MO.
O-3 starting rank, O-4 at 25 hours, O-5 at 50 hours

SOs now start as O-3, get O-4 at 25 hours, and O-5 at 50 hours. They're a four slot role and aren't inherently an executive officer, so having them start at O-3 is more reasonable. Also only having two ranks of progression is really weird and I _think_ unique to only SO currently.

Finally, fixes the bug also fixed in #7218 but was presumably closed on account of giving CSE five ranks total and slapping O-6 on a couple jobs as a meme 1000h rank. The bug itself is that CSE is supposed to be O-2 starting, O-3 at 25 hours, and O-4 at 50 hours but is instead O-4 at 100 hours. This PR fixes that and simply adjusts the actual times to match the comments on the side/intended times. 

## Why It's Good For The Game

CMO rank progression has been asked for a while and I think it is very much deserved.

SOs getting more ranks make it easier to distinguish between a brand new SO, a decent SO, and a very seasoned SO. (Not that almost anyone plays SO as is) And also given the job of SO, general ranking structure, and how many there can _potentially_ be on the ship at once, starting them at O-3 is a bit more reasonable.

And the CSE fix is really just for cohesion. It matches a majority of the other 3 rank role progression curves for playtime and was probably just an oversight that it wasn't fixed.

One thing I do want to mention is that I'd like to potentially look into standardizing and making our rank playtimes a bit more uniform, currently they're a little bit all over the place. Ideally I think there should be an agreed upon playtime for _most_ roles to max out, regardless of how many ranks they have. Like 100 or 150 hours for example. Currently, most four rank shipside roles max out at 100h, compared to the three rank roles maxing out at 50h. And the reason I specify _most_ is mainly because I think roles like Marine for example are fine with the current playtime locks they have, despite it not following general trends set by other ranks. Whether I can cover that in the scope of this PR, should wait and open another PR, or not do it at all is up to maintainers, but I'm up for whatever. At least getting this merged would be a win for rank autists everywhere. 

## Changelog
:cl:

add: Adds rank progression to CMO, O-3 starting, O-4 at 25 hours, and O-5 at 50 hours. 
add: Adds O-3 as the starting rank for SO, giving SO a total of three ranks. O-4 at 25 hours and O-5 at 50 hours.
fix: Fixes CSE actual playtime requirements not matching the intended playtime requirements. CSE will now get O-4 at 50 hours as intended. 
/:cl:
