### PR TITLE
Lets defilers inject other gasses into eggs, cleans up gas eggs

### DIFF
--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -349,6 +349,13 @@ datum/effect_system/smoke_spread/tactical
 /datum/effect_system/smoke_spread/xeno/neuro/light
 	smoke_type = /obj/effect/particle_effect/smoke/xeno/neuro/light
 
+/datum/effect_system/smoke_spread/xeno/hemodile
+	smoke_type = /obj/effect/particle_effect/smoke/xeno/hemodile
+
+/datum/effect_system/smoke_spread/xeno/transvitox
+	smoke_type = /obj/effect/particle_effect/smoke/xeno/transvitox
+	strength = 0.75
+
 /////////////////////////////////////////////
 // Chem smoke
 /////////////////////////////////////////////

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -456,7 +456,7 @@
 
 	if(!issamexenohive(M))
 		M.do_attack_animation(src, ATTACK_EFFECT_SMASH)
-		M.visible_message("<span class='xenowarning'>[M] crushes \the [src]","<span class='xenowarning'>We crush \the [src]")
+		M.visible_message("<span class='xenowarning'>[M] crushes \the [src].","<span class='xenowarning'>We crush \the [src].")
 		Burst(TRUE)
 		return
 
@@ -625,6 +625,23 @@
 		return FALSE
 	Burst(FALSE)
 	return TRUE
+
+/obj/effect/alien/egg/gas/attack_alien(mob/living/carbon/xenomorph/M, damage_amount = M.xeno_caste.melee_damage, damage_type = BRUTE, damage_flag = "", effects = TRUE, armor_penetration = 0, isrightclick = FALSE)
+	if(status == EGG_DESTROYED)
+		M.visible_message("<span class='xenonotice'>\The [M] clears the hatched egg.</span>", \
+			"<span class='xenonotice'>We clear the hatched egg.</span>")
+		playsound(src.loc, "alien_resin_break", 25)
+		M.plasma_stored++
+		qdel(src)
+		return
+
+	if(!issamexenohive(M) || M.a_intent != INTENT_HELP)
+		M.do_attack_animation(src, ATTACK_EFFECT_SMASH)
+		M.visible_message("<span class='xenowarning'>[M] crushes \the [src].","<span class='xenowarning'>We crush \the [src].")
+		Burst(TRUE)
+		return
+
+	to_chat(M, "<span class='warning'>That egg is filled with gas and has no child to retrieve.</span>")
 /*
 TUNNEL
 */

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -627,13 +627,8 @@
 	return TRUE
 
 /obj/effect/alien/egg/gas/attack_alien(mob/living/carbon/xenomorph/M, damage_amount = M.xeno_caste.melee_damage, damage_type = BRUTE, damage_flag = "", effects = TRUE, armor_penetration = 0, isrightclick = FALSE)
-	if(status == EGG_DESTROYED)
-		M.visible_message("<span class='xenonotice'>\The [M] clears the hatched egg.</span>", \
-			"<span class='xenonotice'>We clear the hatched egg.</span>")
-		playsound(src.loc, "alien_resin_break", 25)
-		M.plasma_stored++
-		qdel(src)
-		return
+	if(status != EGG_GROWN)
+		return ..()
 
 	if(!issamexenohive(M) || M.a_intent != INTENT_HELP)
 		M.do_attack_animation(src, ATTACK_EFFECT_SMASH)

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -417,7 +417,10 @@
 		hugger.hivenumber = hivenumber
 		if(!hugger.stasis)
 			hugger.go_idle(TRUE)
-	addtimer(CALLBACK(src, .proc/Grow), rand(EGG_MIN_GROWTH_TIME, EGG_MAX_GROWTH_TIME))
+	if(status == EGG_GROWING)
+		addtimer(CALLBACK(src, .proc/Grow), rand(EGG_MIN_GROWTH_TIME, EGG_MAX_GROWTH_TIME))
+	else if(status == EGG_GROWN)
+		deploy_egg_triggers()
 
 /obj/effect/alien/egg/Destroy()
 	QDEL_LIST(egg_triggers)
@@ -593,20 +596,27 @@
 
 
 /obj/effect/alien/egg/gas
+	icon = "Egg"
 	hugger_type = null
 	trigger_size = 2
+	status = EGG_GROWN
+	///Holds a typepath for the gas particle to create
+	var/gas_type = /datum/effect_system/smoke_spread/xeno/neuro/medium
+	///Bonus size for certain gasses
+	var/gas_size_bonus = 0
 
 /obj/effect/alien/egg/gas/Burst(kill)
 	var/spread = EGG_GAS_DEFAULT_SPREAD
 	if(kill) // Kill is more violent
 		spread = EGG_GAS_KILL_SPREAD
+	spread += gas_size_bonus
 
 	QDEL_LIST(egg_triggers)
 	update_status(EGG_DESTROYED)
 	flick("Egg Exploding", src)
 	playsound(loc, "sound/effects/alien_egg_burst.ogg", 30)
 
-	var/datum/effect_system/smoke_spread/xeno/neuro/NS = new(src)
+	var/datum/effect_system/smoke_spread/xeno/NS = new gas_type(src)
 	NS.set_up(spread, get_turf(src))
 	NS.start()
 

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -596,7 +596,7 @@
 
 
 /obj/effect/alien/egg/gas
-	icon = "Egg"
+	icon_state = "Egg"
 	hugger_type = null
 	trigger_size = 2
 	status = EGG_GROWN

--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
@@ -147,7 +147,7 @@
 
 /datum/action/xeno_action/activable/inject_egg_neurogas/on_cooldown_finish()
 	playsound(owner.loc, 'sound/effects/xeno_newlarva.ogg', 50, 0)
-	to_chat(owner, "<span class='xenodanger'>We feel our stinger fill with toxins. We can inject an egg again.</span>")
+	to_chat(owner, "<span class='xenodanger'>We feel our stinger fill with toxins. We can inject an egg with gas again.</span>")
 	return ..()
 
 /datum/action/xeno_action/activable/inject_egg_neurogas/use_ability(atom/A)

--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
@@ -123,10 +123,10 @@
 		var/turf/T = get_turf(X)
 		playsound(T, 'sound/effects/smoke.ogg', 25)
 		if(count > 1)
-			N.set_up(smoke_range, T)
+			gas.set_up(smoke_range, T)
 		else //last emission is larger
-			N.set_up(CEILING(smoke_range*1.3,1), T)
-		N.start()
+			gas.set_up(CEILING(smoke_range*1.3,1), T)
+		gas.start()
 		T.visible_message("<span class='danger'>Noxious smoke billows from the hulking xenomorph!</span>")
 		count = max(0,count - 1)
 		sleep(DEFILER_GAS_DELAY)
@@ -136,9 +136,9 @@
 // *********** Inject Egg Neurogas
 // ***************************************
 /datum/action/xeno_action/activable/inject_egg_neurogas
-	name = "Inject Neurogas"
+	name = "Inject Gas"
 	action_icon_state = "inject_egg"
-	mechanics_text = "Inject an egg with neurogas, killing the egg, but filling it full with neurogas ready to explode."
+	mechanics_text = "Inject an egg with toxins, killing the larva, but filling it full with gas ready to explode."
 	ability_name = "inject neurogas"
 	plasma_cost = 100
 	cooldown_timer = 5 SECONDS
@@ -147,13 +147,17 @@
 
 /datum/action/xeno_action/activable/inject_egg_neurogas/on_cooldown_finish()
 	playsound(owner.loc, 'sound/effects/xeno_newlarva.ogg', 50, 0)
-	to_chat(owner, "<span class='xenodanger'>We feel our dorsal vents bristle with neurotoxic gas. We can use Emit Neurogas again.</span>")
+	to_chat(owner, "<span class='xenodanger'>We feel our stinger fill with toxins. We can inject an egg again.</span>")
 	return ..()
 
 /datum/action/xeno_action/activable/inject_egg_neurogas/use_ability(atom/A)
 	var/mob/living/carbon/xenomorph/Defiler/X = owner
 
 	if(!istype(A, /obj/effect/alien/egg))
+		return fail_activate()
+
+	if(istype(A, /obj/effect/alien/egg/gas))
+		to_chat(X, "<span class='warning'>That egg has already been filled with toxic gas.</span>")
 		return fail_activate()
 
 	var/obj/effect/alien/egg/alien_egg = A
@@ -179,7 +183,7 @@
 			newegg.gas_type = /datum/effect_system/smoke_spread/xeno/hemodile
 			newegg.gas_size_bonus = 1
 		if(/datum/reagent/toxin/xeno_transvitox)
-			newegg.gas_type = datum/effect_system/smoke_spread/xeno/transvitox
+			newegg.gas_type = /datum/effect_system/smoke_spread/xeno/transvitox
 			newegg.gas_size_bonus = 2
 	qdel(alien_egg)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
@@ -101,15 +101,18 @@
 	var/mob/living/carbon/xenomorph/Defiler/X = owner
 	set waitfor = FALSE
 	var/smoke_range = 2
-	var/datum/effect_system/smoke_spread/xeno/neuro/medium/N = new(X)
-	N.strength = 1
-	if(X.selected_reagent == /datum/reagent/toxin/xeno_hemodile)
-		N.smoke_type = /obj/effect/particle_effect/smoke/xeno/hemodile
-		smoke_range = 3
-	else if(X.selected_reagent == /datum/reagent/toxin/xeno_transvitox)
-		N.smoke_type = /obj/effect/particle_effect/smoke/xeno/transvitox
-		N.strength = 0.75
-		smoke_range = 4
+	var/datum/effect_system/smoke_spread/xeno/gas
+
+	switch(X.selected_reagent)
+		if(/datum/reagent/toxin/xeno_neurotoxin)
+			gas = new /datum/effect_system/smoke_spread/xeno/neuro/medium(X)
+		if(/datum/reagent/toxin/xeno_hemodile)
+			gas = new /datum/effect_system/smoke_spread/xeno/hemodile(X)
+			smoke_range = 3
+		if(/datum/reagent/toxin/xeno_transvitox)
+			gas = new /datum/effect_system/smoke_spread/xeno/transvitox(X)
+			smoke_range = 4
+
 	while(count)
 		if(X.stagger) //If we got staggered, return
 			to_chat(X, "<span class='xenowarning'>We try to emit toxins but are staggered!</span>")
@@ -168,7 +171,16 @@
 	succeed_activate()
 	add_cooldown()
 
-	new /obj/effect/alien/egg/gas(A.loc)
+	var/obj/effect/alien/egg/gas/newegg = new(A.loc)
+	switch(X.selected_reagent)
+		if(/datum/reagent/toxin/xeno_neurotoxin)
+			newegg.gas_type = /datum/effect_system/smoke_spread/xeno/neuro/medium
+		if(/datum/reagent/toxin/xeno_hemodile)
+			newegg.gas_type = /datum/effect_system/smoke_spread/xeno/hemodile
+			newegg.gas_size_bonus = 1
+		if(/datum/reagent/toxin/xeno_transvitox)
+			newegg.gas_type = datum/effect_system/smoke_spread/xeno/transvitox
+			newegg.gas_size_bonus = 2
 	qdel(alien_egg)
 
 	GLOB.round_statistics.defiler_inject_egg_neurogas++

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -91,7 +91,8 @@
 	remove_danger_overlay() //Remove the danger overlay
 	lifetimer = null
 	jumptimer = null
-	clear_hugger_source()
+	if(source)
+		clear_hugger_source()
 
 /obj/item/clothing/mask/facehugger/update_icon()
 	if(stat == DEAD)

--- a/code/modules/reagents/reagents/toxin.dm
+++ b/code/modules/reagents/reagents/toxin.dm
@@ -566,12 +566,12 @@
 	RegisterSignal(L, COMSIG_HUMAN_DAMAGE_TAKEN, .proc/transvitox_human_damage_taken)
 
 /datum/reagent/toxin/xeno_transvitox/on_mob_life(mob/living/L, metabolism)
-	if(prob(10))
-		to_chat(L, "<span class='warning'>You notice your wounds crusting over with disgusting green ichor.</span>")
-
 	var/fire_loss = L.getFireLoss()
 	if(!fire_loss) //If we have no burn damage, cancel out
 		return ..()
+
+	if(prob(10))
+		to_chat(L, "<span class='warning'>You notice your wounds crusting over with disgusting green ichor.</span>")
 
 	var/tox_cap_multiplier = 1
 


### PR DESCRIPTION
## About The Pull Request
Adds the ability for defilers to inject hemodile and transvitox into eggs for later popping.
Aliens opening gas eggs manually is now intentional instead of a failure to retrieve the hugger.
Fixed a runtime with egg huggers trying to clear their source when they don't have one.
Adjusted transvitox to not mention your wounds crusting over when you do not in fact have any wounds.

## Why It's Good For The Game
Further develops a relatively unused piece of defiler's kit without necessarily adding much new power (neuro is probably still just better than the other two most of the time). 
Bug fixes.

## Changelog
:cl:
add: Defilers can inject hemo and transvit into eggs now if they want.
fix: Injected eggs don't have to grow up a second time
/:cl: