### PR TITLE
Larva now start growing again if the mob they're in is defibbed

### DIFF
--- a/code/game/objects/items/defibrillator.dm
+++ b/code/game/objects/items/defibrillator.dm
@@ -278,6 +278,11 @@
 	SSblackbox.record_feedback("tally", "round_statistics", 1, "total_human_revives")
 	to_chat(H, "<span class='notice'>You suddenly feel a spark and your consciousness returns, dragging you back to the mortal plane.</span>")
 
+	if(CHECK_BITFIELD(H.status_flags, XENO_HOST))
+		var/obj/item/alien_embryo/friend = locate() in H
+		START_PROCESSING(SSobj, friend)
+		H.visible_message("<span class ='warning'>Something inside [H] writhes about with new life!</span>", "<span class ='warning'>Something inside you writhes about with new life!</span>")
+
 	notify_ghosts("<b>[user]</b> has brought <b>[H.name]</b> back to life!", source = H, action = NOTIFY_ORBIT)
 
 /obj/item/defibrillator/civi

--- a/code/game/objects/items/defibrillator.dm
+++ b/code/game/objects/items/defibrillator.dm
@@ -281,7 +281,6 @@
 	if(CHECK_BITFIELD(H.status_flags, XENO_HOST))
 		var/obj/item/alien_embryo/friend = locate() in H
 		START_PROCESSING(SSobj, friend)
-		H.visible_message("<span class ='warning'>Something inside [H] writhes about with new life!</span>", "<span class ='warning'>Something inside you writhes about with new life!</span>")
 
 	notify_ghosts("<b>[user]</b> has brought <b>[H.name]</b> back to life!", source = H, action = NOTIFY_ORBIT)
 

--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -54,12 +54,7 @@
 		affected_mob = null
 		return PROCESS_KILL
 
-	if(affected_mob.stat == DEAD)//DEAD CODE TO BE REMOVED
-		if(ishuman(affected_mob))
-			if(!HAS_TRAIT(affected_mob, TRAIT_UNDEFIBBABLE)) 
-				var/mob/living/carbon/xenomorph/larva/L = locate() in affected_mob
-				L?.initiate_burst(affected_mob)
-				return PROCESS_KILL
+	if(affected_mob.stat == DEAD)
 		var/mob/living/carbon/xenomorph/larva/L = locate() in affected_mob
 		L?.initiate_burst(affected_mob)
 		return PROCESS_KILL


### PR DESCRIPTION
## About The Pull Request
Makes larvae start processing again on host defib. Defibber gets a direct warning that their patient has an embryo.

## Why It's Good For The Game
Currently, if you die and get ressed with an embryo it'll stay at its current state of growth and never progress, making you immune to larval facehuggers forever. This's bad. The other options were either destroying the embryo on any death, which's bad because murder should not be a medical treatment, and letting growth continue through death, which seemed just a bit too much.

## Changelog
:cl:
fix: Larva now start growing again if their host stops being dead.
/:cl:
