### PR TITLE
king takes a hundred minutes to possibly get into the game rather than 60

### DIFF
--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -135,7 +135,7 @@
 //How many psy points are gave every 5 second by a cocoon
 #define COCOON_PSY_POINTS_REWARD 2
 
-#define INVOKE_KING_TIME_LOCK 1 HOURS
+#define INVOKE_KING_TIME_LOCK 100 MINUTES
 
 /// How each alive marine contributes to burrower larva output per minute. So with one pool, 15 marines are giving 0.375 points per minute, so it's a new xeno every 22 minutes
 #define SILO_BASE_OUTPUT_PER_MARINE 0.03


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
considering the game usually starts at 12:30 you can literally get king at around 13:05 which is literally 35 minutes into the game
for a stalemate breaker it should take pretty long to get into the game, now it'll take like 60 minutes or so.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
king shouldn't be appearing in early mid game at all, will drive for more interesting rounds.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: king takes 100 minutes to be able to be summoned, rather than 60.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
