### PR TITLE
Adjusts comment next to CSE rank time to be accurate

### DIFF
--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -406,7 +406,7 @@ If you are not piloting, there is an autopilot fallback for command, but don't l
 			new_human.wear_id.paygrade = "O2"
 		if(1501 to 6000) // 25 hrs
 			new_human.wear_id.paygrade = "O3"
-		if(6001 to INFINITY) // 50 hrs
+		if(6001 to INFINITY) // 100 hrs
 			new_human.wear_id.paygrade = "O4"
 
 /datum/job/terragov/engineering/chief/radio_help_message(mob/M)


### PR DESCRIPTION
## About The Pull Request

Basically the title. The comment next to the CSE rank time for O-4 is now accurate to the actual time, 100h. 

## Why It's Good For The Game

Clarity and giving proper information. 

## Changelog
:cl:

spellcheck: CSE rank time now properly lists 100 hours instead of 50 hours. 

/:cl:

