### PR TITLE
SO rank changes

### DIFF
--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -188,7 +188,7 @@ Make the TGMC proud!"})
 //Staff Officer
 /datum/job/terragov/command/staffofficer
 	title = STAFF_OFFICER
-	paygrade = "O4"
+	paygrade = "O3"
 	comm_title = "SO"
 	total_positions = 4
 	access = list(ACCESS_MARINE_BRIDGE, ACCESS_MARINE_BRIG, ACCESS_MARINE_CARGO, ACCESS_MARINE_DROPSHIP, ACCESS_MARINE_LOGISTICS, ACCESS_MARINE_ALPHA, ACCESS_MARINE_BRAVO, ACCESS_MARINE_CHARLIE, ACCESS_MARINE_DELTA)
@@ -239,7 +239,9 @@ You are in charge of logistics and the overwatch system. You are also in line to
 	if(!playtime_mins || playtime_mins < 1 )
 		return
 	switch(playtime_mins)
-		if(0 to 3000) // starting
+		if(0 to 1500) // starting
+			new_human.wear_id.paygrade = "O3"
+		if(1501 to 3000) // 25 hrs
 			new_human.wear_id.paygrade = "O4"
 		if(3001 to INFINITY) // 50 hrs
 			new_human.wear_id.paygrade = "O5"


### PR DESCRIPTION
## About The Pull Request

SO now starts at O-3, goes to O-4 at 25 hours, and O-5 at 50 hours. Basically just adds another rank to make them a three rank role instead of their awkward and un-needed position as one of the only two rank roles. Also it's a four slot role so starting them off at O-3 makes for less O-4+ all running around the ship.

## Why It's Good For The Game

Better distinction between novice SOs and very seasoned SOs, also more satisfying rank progression for those who do play SO more.

## Changelog
:cl:
add: Added O-3 to SO as starting rank. SO now gets O-4 at 25 hours and O-5 at 50 hours. 
/:cl:
