### PR TITLE
Turrets don't detect stealthed hunters

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -320,6 +320,8 @@
 #define COMSIG_MOB_TOGGLEMOVEINTENT "mob_togglemoveintent"		//drom base of mob/toggle_move_intent(): (new_intent)
 #define COMSIG_MOB_ENABLE_STEALTH "mob_togglestealth"
 	#define STEALTH_ALREADY_ACTIVE (1<<0)
+#define COMSIG_MOB_TURRET_TARGETTED "mob_turret_targetted"
+	#define COMSIG_MOB_TURRET_HIDDEN (1<<0)
 
 //mob/dead/observer
 #define COMSIG_OBSERVER_CLICKON "observer_clickon"				//from mob/dead/observer/ClickOn(): (atom/A, params)

--- a/code/game/objects/machinery/sentries.dm
+++ b/code/game/objects/machinery/sentries.dm
@@ -1014,6 +1014,9 @@
 		if(CHECK_BITFIELD(turret_flags, TURRET_SAFETY) && !isxeno(M)) //When safeties are on, Xenos only.
 			continue
 
+		if(CHECK_BITFIELD(SEND_SIGNAL(M, COMSIG_MOB_TURRET_TARGETTED), COMSIG_MOB_TURRET_HIDDEN))
+			continue
+
 		var/mob/living/carbon/human/H = M
 		if(istype(H) && H.wear_id.iff_signal & iff_signal)
 			continue

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -22,6 +22,7 @@
 	RegisterSignal(L, COMSIG_XENOMORPH_DISARM_HUMAN, .proc/sneak_attack_slash)
 	RegisterSignal(L, COMSIG_XENOMORPH_ZONE_SELECT, .proc/sneak_attack_zone)
 	RegisterSignal(L, COMSIG_XENOMORPH_PLASMA_REGEN, .proc/plasma_regen)
+	RegisterSignal(L, COMSIG_MOB_TURRET_TARGETTED, .proc/hide_from_turrets)
 
 	// TODO: attack_alien() overrides are a mess and need a lot of work to make them require parentcalling
 	RegisterSignal(L, list(
@@ -69,7 +70,8 @@
 		SIGNAL_ADDTRAIT(TRAIT_KNOCKEDOUT),
 		SIGNAL_ADDTRAIT(TRAIT_FLOORED),
 		COMSIG_XENOMORPH_ZONE_SELECT,
-		COMSIG_XENOMORPH_PLASMA_REGEN))
+		COMSIG_XENOMORPH_PLASMA_REGEN,
+		COMSIG_MOB_TURRET_TARGETTED,))
 	return ..()
 
 /datum/action/xeno_action/stealth/can_use_action(silent = FALSE, override_flags)
@@ -205,6 +207,13 @@
 	if(!stealth || !can_sneak_attack)
 		return
 	return COMSIG_ACCURATE_ZONE
+
+///Signalled proc, returns COMSIG_TURRET_TARGET_HIDDEN if in stealth
+/datum/action/xeno_action/stealth/proc/hide_from_turrets()
+	SIGNAL_HANDLER
+	if(!stealth)
+		return
+	return COMSIG_MOB_TURRET_HIDDEN
 
 // ***************************************
 // *********** Pounce/sneak attack


### PR DESCRIPTION
## About The Pull Request
Adds signal call/response for turrets to pass over targets that've hidden themselves and gives it to hunters.

## Why It's Good For The Game
Stealth should hide you from things.

## Changelog
:cl:
add: Hunters in stealth won't get spotted by turrets.
/:cl: