### PR TITLE
Minor Vent Crawl Buff; Hunters and Larva Can Vent Crawl Faster

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -426,6 +426,8 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 
 //Xeno Defines
 
+#define XENO_DEFAULT_VENT_ENTER_TIME 4.5 SECONDS //Standard time for a xeno to enter a vent.
+#define XENO_DEFAULT_VENT_EXIT_TIME 2 SECONDS //Standard time for a xeno to exit a vent.
 #define XENO_DEFAULT_ACID_PUDDLE_DAMAGE 14 //Standard damage dealt by acid puddles
 #define XENO_ACID_WELL_FILL_TIME 2 SECONDS //How long it takes to add a charge to an acid pool
 #define XENO_ACID_WELL_FILL_COST 200 //Cost in plasma to apply a charge to an acid pool
@@ -529,7 +531,7 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define HUNTER_SILENCE_WINDUP 0.5 SECONDS //Windup of the Hunter's Silence
 #define HUNTER_SILENCE_MULTIPLIER 1.5 //Multiplier of stacks vs Hunter's Mark targets
 #define HUNTER_SILENCE_WHIFF_COOLDOWN 3 SECONDS //If we fail to target anyone with Silence, partial cooldown to prevent spam.
-#define HUNTER_VENT_CRAWL_TIME 2 SECONDS //Hunters can enter vents fast
+#define HUNTER_VENT_CRAWL_TIME 1 SECONDS //Hunters can enter vents fast
 
 //Ravager defines:
 #define RAV_CHARGESPEED 2

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -529,7 +529,7 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define HUNTER_SILENCE_WINDUP 0.5 SECONDS //Windup of the Hunter's Silence
 #define HUNTER_SILENCE_MULTIPLIER 1.5 //Multiplier of stacks vs Hunter's Mark targets
 #define HUNTER_SILENCE_WHIFF_COOLDOWN 3 SECONDS //If we fail to target anyone with Silence, partial cooldown to prevent spam.
-
+#define HUNTER_VENT_CRAWL_TIME 2 SECONDS //Hunters can enter vents fast
 
 //Ravager defines:
 #define RAV_CHARGESPEED 2
@@ -632,6 +632,9 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 
 #define WRAITH_TELEPORT_DEBUFF_STAGGER_STACKS 2 //Stagger and slow stacks applied to adjacent living hostiles before/after a teleport
 #define WRAITH_TELEPORT_DEBUFF_SLOWDOWN_STACKS 3 //Stagger and slow stacks applied to adjacent living hostiles before/after a teleport
+
+//Larva defines
+#define LARVA_VENT_CRAWL_TIME 1 SECONDS //Larva can crawl into vents fast
 
 #define DEFILER_TRANSVITOX_CAP 180 //Max toxin damage transvitox will allow
 

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -531,7 +531,7 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define HUNTER_SILENCE_WINDUP 0.5 SECONDS //Windup of the Hunter's Silence
 #define HUNTER_SILENCE_MULTIPLIER 1.5 //Multiplier of stacks vs Hunter's Mark targets
 #define HUNTER_SILENCE_WHIFF_COOLDOWN 3 SECONDS //If we fail to target anyone with Silence, partial cooldown to prevent spam.
-#define HUNTER_VENT_CRAWL_TIME 1 SECONDS //Hunters can enter vents fast
+#define HUNTER_VENT_CRAWL_TIME 2 SECONDS //Hunters can enter vents fast
 
 //Ravager defines:
 #define RAV_CHARGESPEED 2

--- a/code/_onclick/ventcrawl.dm
+++ b/code/_onclick/ventcrawl.dm
@@ -71,8 +71,7 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, typecacheof(list(
 	if(vent_found)
 		var/datum/pipeline/vent_found_parent = vent_found.parents[1]
 		if(vent_found_parent && (vent_found_parent.members.len || vent_found_parent.other_atmosmch))
-			visible_message(span_notice("[src] begins climbing into the ventilation system...") ,span_notice("You begin climbing into the ventilation system..."))
-			visible_message("[stealthy ? "<span class='notice'>[src] begins climbing into the ventilation system...</span>" : ""]","<span class='notice'>You begin climbing into the ventilation system...</span>")
+			visible_message(span_notice("[stealthy ? "[src] begins climbing into the ventilation system..." : ""]"),span_notice("You begin climbing into the ventilation system..."))
 
 			if(!do_after(src, crawl_time, FALSE, vent_found, BUSY_ICON_GENERIC) || !client || !canmove)
 				return

--- a/code/_onclick/ventcrawl.dm
+++ b/code/_onclick/ventcrawl.dm
@@ -92,7 +92,7 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, typecacheof(list(
 			visible_message(span_notice("[src] scrambles into the ventilation ducts!"),span_notice("You climb into the ventilation ducts."))
 			if(!isxenohunter(src)) //Hunters silently enter/exit vents.
 			visible_message("<span class='notice'>[src] scrambles into the ventilation ducts!</span>","<span class='notice'>You climb into the ventilation ducts.</span>")
-			if(!stealthy) //Hunters silently enter/exit vents.
+			if(!stealthy) //Xenos with stealth vent crawling can silently enter/exit vents.
 				playsound(src, get_sfx("alien_ventpass"), 35, TRUE)
 
 			forceMove(vent_found)

--- a/code/_onclick/ventcrawl.dm
+++ b/code/_onclick/ventcrawl.dm
@@ -40,7 +40,7 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, typecacheof(list(
 
 
 //VENTCRAWLING
-/mob/living/proc/handle_ventcrawl(atom/A)
+/mob/living/proc/handle_ventcrawl(atom/A, crawl_time = 4.5 SECONDS, stealthy = FALSE)
 	if(!can_ventcrawl() || !Adjacent(A) || !canmove)
 		return
 	if(stat)
@@ -72,8 +72,9 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, typecacheof(list(
 		var/datum/pipeline/vent_found_parent = vent_found.parents[1]
 		if(vent_found_parent && (vent_found_parent.members.len || vent_found_parent.other_atmosmch))
 			visible_message(span_notice("[src] begins climbing into the ventilation system...") ,span_notice("You begin climbing into the ventilation system..."))
+			visible_message("[stealthy ? "<span class='notice'>[src] begins climbing into the ventilation system...</span>" : ""]","<span class='notice'>You begin climbing into the ventilation system...</span>")
 
-			if(!do_after(src, 4.5 SECONDS, FALSE, vent_found, BUSY_ICON_GENERIC) || !client || !canmove)
+			if(!do_after(src, crawl_time, FALSE, vent_found, BUSY_ICON_GENERIC) || !client || !canmove)
 				return
 
 			if(iscarbon(src) && can_ventcrawl())//It must have atleast been 1 to get this far
@@ -90,6 +91,8 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, typecacheof(list(
 
 			visible_message(span_notice("[src] scrambles into the ventilation ducts!"),span_notice("You climb into the ventilation ducts."))
 			if(!isxenohunter(src)) //Hunters silently enter/exit vents.
+			visible_message("<span class='notice'>[src] scrambles into the ventilation ducts!</span>","<span class='notice'>You climb into the ventilation ducts.</span>")
+			if(!stealthy) //Hunters silently enter/exit vents.
 				playsound(src, get_sfx("alien_ventpass"), 35, TRUE)
 
 			forceMove(vent_found)

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -246,19 +246,26 @@
 
 
 /obj/machinery/atmospherics/proc/climb_out(mob/living/user, turf/T)
+
 	if(TIMER_COOLDOWN_CHECK(user, COOLDOWN_VENTCRAWL))
 		return FALSE
-	TIMER_COOLDOWN_START(user, COOLDOWN_VENTCRAWL, 2 SECONDS)
-	if(!isxenohunter(user) ) //Hunters silently enter/exit/move through vents.
-		visible_message(span_warning("You hear something squeezing through the ducts."))
-	to_chat(user, span_notice("You begin to climb out of [src]"))
-	if(!do_after(user, 20, FALSE, src))
+	var/silent_crawl = FALSE
+	var/vent_crawl_exit_time = 2 SECONDS
+	if(isxeno(user))
+		var/mob/living/carbon/xenomorph/X = user
+		silent_crawl = X.xeno_caste.silent_vent_crawl
+		vent_crawl_exit_time = X.xeno_caste.vent_exit_speed
+	TIMER_COOLDOWN_START(user, COOLDOWN_VENTCRAWL, vent_crawl_exit_time)
+	if(!silent_crawl) //Xenos with silent crawl can silently enter/exit/move through vents.
+		visible_message("<span class='warning'>You hear something squeezing through the ducts.</span>")
+	to_chat(user, "<span class='notice'>You begin to climb out of [src]</span>")
+	if(!do_after(user, vent_crawl_exit_time, FALSE, src))
 		return FALSE
 	user.remove_ventcrawl()
 	user.forceMove(T)
-	user.visible_message(span_warning("[user] climbs out of [src]."), \
-	span_notice("You climb out of [src]."))
-	if(!isxenohunter(user))
+	user.visible_message("<span class='warning'>[user] climbs out of [src].</span>", \
+	"<span class='notice'>You climb out of [src].</span>")
+	if(!silent_crawl)
 		playsound(src, get_sfx("alien_ventpass"), 35, TRUE)
 
 
@@ -284,7 +291,11 @@
 					user.update_pipe_vision(target_move)
 				user.forceMove(target_move)
 				user.client.eye = target_move  //Byond only updates the eye every tick, This smooths out the movement
-				if(TIMER_COOLDOWN_CHECK(user, COOLDOWN_VENTSOUND))
+				var/silent_crawl = FALSE //Some creatures can move through the vents silently
+				if(isxeno(user))
+					var/mob/living/carbon/xenomorph/X = user
+					silent_crawl = X.xeno_caste.silent_vent_crawl
+				if(TIMER_COOLDOWN_CHECK(user, COOLDOWN_VENTSOUND) || silent_crawl)
 					return
 				TIMER_COOLDOWN_START(user, COOLDOWN_VENTSOUND, 3 SECONDS)
 				playsound(src, pick('sound/effects/alien_ventcrawl1.ogg','sound/effects/alien_ventcrawl2.ogg'), 50, TRUE, -3)

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -257,14 +257,14 @@
 		vent_crawl_exit_time = X.xeno_caste.vent_exit_speed
 	TIMER_COOLDOWN_START(user, COOLDOWN_VENTCRAWL, vent_crawl_exit_time)
 	if(!silent_crawl) //Xenos with silent crawl can silently enter/exit/move through vents.
-		visible_message("<span class='warning'>You hear something squeezing through the ducts.</span>")
-	to_chat(user, "<span class='notice'>You begin to climb out of [src]</span>")
+		visible_message(span_warning("You hear something squeezing through the ducts."))
+	to_chat(user, span_notice("You begin to climb out of [src]"))
 	if(!do_after(user, vent_crawl_exit_time, FALSE, src))
 		return FALSE
 	user.remove_ventcrawl()
 	user.forceMove(T)
-	user.visible_message("<span class='warning'>[user] climbs out of [src].</span>", \
-	"<span class='notice'>You climb out of [src].</span>")
+	user.visible_message(span_warning("[user] climbs out of [src].</span>"), \
+	span_notice("You climb out of [src].</span>"))
 	if(!silent_crawl)
 		playsound(src, get_sfx("alien_ventpass"), 35, TRUE)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
@@ -55,6 +55,11 @@
 		/datum/action/xeno_action/psychic_trace,
 	)
 
+	// *** Vent Crawl Parameters *** //
+	vent_enter_speed = HUNTER_VENT_CRAWL_TIME
+	vent_exit_speed = HUNTER_VENT_CRAWL_TIME
+	silent_vent_crawl = TRUE
+
 /datum/xeno_caste/hunter/young
 	upgrade_name = "Young"
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/larva/castedatum_larva.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/larva/castedatum_larva.dm
@@ -44,6 +44,11 @@
 		/datum/action/xeno_action/xenohide,
 	)
 
+	// *** Vent Crawl Parameters *** //
+	vent_enter_speed = LARVA_VENT_CRAWL_TIME
+	vent_exit_speed = LARVA_VENT_CRAWL_TIME
+	silent_vent_crawl = TRUE
+
 /datum/xeno_caste/larva/young
 	upgrade = XENO_UPGRADE_INVALID
 

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -191,6 +191,13 @@
 	///The iconstate of the plasma bar, format used is "[plasma_icon_state][amount]"
 	var/plasma_icon_state = "plasma"
 
+	///How quickly the caste enters vents
+	var/vent_enter_speed = XENO_DEFAULT_VENT_ENTER_TIME
+	///How quickly the caste enters vents
+	var/vent_exit_speed = XENO_DEFAULT_VENT_EXIT_TIME
+	///Whether the caste enters and crawls through vents silently
+	var/silent_vent_crawl = FALSE
+
 /mob/living/carbon/xenomorph
 	name = "Drone"
 	desc = "What the hell is THAT?"

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -580,6 +580,27 @@
 	if(pipe)
 		handle_ventcrawl(pipe)
 
+// Hunter Vent Crawl
+/mob/living/carbon/xenomorph/hunter/vent_crawl()
+	set name = "Crawl through Vent"
+	set desc = "Enter an air vent and crawl through the pipe system."
+	set category = "Alien"
+	if(!check_state())
+		return
+	var/pipe = start_ventcrawl()
+	if(pipe)
+		handle_ventcrawl(pipe, HUNTER_VENT_CRAWL_TIME, TRUE)
+
+// Larva Vent Crawl
+/mob/living/carbon/xenomorph/larva/vent_crawl()
+	set name = "Crawl through Vent"
+	set desc = "Enter an air vent and crawl through the pipe system."
+	set category = "Alien"
+	if(!check_state())
+		return
+	var/pipe = start_ventcrawl()
+	if(pipe)
+		handle_ventcrawl(pipe, LARVA_VENT_CRAWL_TIME, TRUE)
 
 /mob/living/carbon/xenomorph/verb/toggle_xeno_mobhud()
 	set name = "Toggle Xeno Status HUD"

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -578,29 +578,7 @@
 		return
 	var/pipe = start_ventcrawl()
 	if(pipe)
-		handle_ventcrawl(pipe)
-
-// Hunter Vent Crawl
-/mob/living/carbon/xenomorph/hunter/vent_crawl()
-	set name = "Crawl through Vent"
-	set desc = "Enter an air vent and crawl through the pipe system."
-	set category = "Alien"
-	if(!check_state())
-		return
-	var/pipe = start_ventcrawl()
-	if(pipe)
-		handle_ventcrawl(pipe, HUNTER_VENT_CRAWL_TIME, TRUE)
-
-// Larva Vent Crawl
-/mob/living/carbon/xenomorph/larva/vent_crawl()
-	set name = "Crawl through Vent"
-	set desc = "Enter an air vent and crawl through the pipe system."
-	set category = "Alien"
-	if(!check_state())
-		return
-	var/pipe = start_ventcrawl()
-	if(pipe)
-		handle_ventcrawl(pipe, LARVA_VENT_CRAWL_TIME, TRUE)
+		handle_ventcrawl(pipe, xeno_caste.vent_enter_speed, xeno_caste.silent_vent_crawl)
 
 /mob/living/carbon/xenomorph/verb/toggle_xeno_mobhud()
 	set name = "Toggle Xeno Status HUD"


### PR DESCRIPTION
## About The Pull Request

1: Minor refactor of vent crawling. Some snowflaking removed. Infrastructure added for unique ventcrawl interactions.

2: Hunters can now crawl into and out of vents in 1 second down from 4.5 seconds.

3: Larva can now crawl into and out of vents in 1 second down from 4.5 seconds.

## Why It's Good For The Game

1. Removes snowflakery. 
2. Adds useful infrastructure for ventcrawl.
3. Castes that should be better at ventcrawling are.

## Changelog
:cl:
code: Partial refactor of vent crawling. Snowflaking removed. Infrastructure added for unique ventcrawl interactions, and custom ventcrawl parameters at the caste level.
balance: Hunters can now crawl into vents in 1 second down from 4.5 seconds.
balance: Larva can now crawl into vents in 1 second down from 4.5 seconds.
/:cl: