### PR TITLE
Construction pouches hold one unfolded shovel

### DIFF
--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -644,7 +644,7 @@
 	name = "construction pouch"
 	desc = "It's designed to hold construction materials - glass/metal sheets, metal rods, barbed wire, cable coil, and empty sandbags. It also has a hook for an entrenching tool."
 	storage_slots = 4
-	max_w_class = 3
+	max_w_class = 4
 	icon_state = "construction"
 	can_hold = list(
 		/obj/item/stack/barbed_wire,
@@ -655,12 +655,15 @@
 		/obj/item/stack/sandbags_empty,
 		/obj/item/stack/sandbags,
 	)
+	storage_type_limits = list(
+		/obj/item/tool/shovel/etool = 1,
+	)
 
 /obj/item/storage/pouch/construction/full/Initialize()
 	. = ..()
 	new /obj/item/stack/sandbags_empty/half (src)
 	new /obj/item/stack/barbed_wire/small_stack (src)
-	new /obj/item/tool/shovel/etool (src)
+	INVOKE_ASYNC(src, .proc/handle_item_insertion, new /obj/item/tool/shovel/etool (src))
 
 /obj/item/storage/pouch/construction/equippedengineer/Initialize()
 	. = ..()

--- a/code/game/objects/items/tools/shovel_tools.dm
+++ b/code/game/objects/items/tools/shovel_tools.dm
@@ -137,7 +137,7 @@
 	throwforce = 2
 	item_state = "crowbar"
 	hitsound = "swing_hit"
-	w_class = WEIGHT_CLASS_BULKY //three for unfolded, 3 for folded. This should keep it outside backpacks until its folded, made it 3 because 2 lets you fit in pockets appearntly.
+	w_class = WEIGHT_CLASS_BULKY //4 for unfolded, 3 for folded. This should keep it outside backpacks until its folded, made it 3 because 2 lets you fit in pockets.
 	dirt_overlay = "etool_overlay"
 	dirt_amt_per_dig = 5
 	shovelspeed = 20
@@ -145,7 +145,7 @@
 /obj/item/tool/shovel/etool/update_icon_state()
 	if(folded)
 		icon_state = "etool_c"
-	else if(sharp) 
+	else if(sharp)
 		icon_state = "etool_s"
 	else
 		icon_state = "etool"

--- a/code/game/objects/items/tools/shovel_tools.dm
+++ b/code/game/objects/items/tools/shovel_tools.dm
@@ -137,6 +137,7 @@
 	throwforce = 2
 	item_state = "crowbar"
 	hitsound = "swing_hit"
+	flags_equip_slot = ITEM_SLOT_BELT | ITEM_SLOT_BACK
 	w_class = WEIGHT_CLASS_BULKY //4 for unfolded, 3 for folded. This should keep it outside backpacks until its folded, made it 3 because 2 lets you fit in pockets.
 	dirt_overlay = "etool_overlay"
 	dirt_amt_per_dig = 5


### PR DESCRIPTION
## About The Pull Request
Construction pouch max weight was increased so shovels can now fit inside while unfolded, but each pouch can only hold one.
Also lets you carry one on your back if you so wish.

## Why It's Good For The Game
The shovel is a critical tool to any marine operation, even though it's called an entrenching tool and trenches don't exist. Also this gives ways for engineers to actually carry a sharpened one without sacrificing their toolbelt.

## Changelog
:cl:
add: Top TGMC engineers have figured out how to get the hook on construction pouches to hold an e-tool while it's unfolded.
add: They also discovered a way to carry them on your back.
/:cl: