### PR TITLE
Triumph Intercoms

### DIFF
--- a/_maps/shuttles/triumph.dmm
+++ b/_maps/shuttles/triumph.dmm
@@ -92,7 +92,7 @@
 /turf/open/shuttle/dropship/floor,
 /area/shuttle/dropship/triumph)
 "at" = (
-/obj/item/radio/intercom/dropship{
+/obj/item/radio/intercom/dropship/triumph{
 	pixel_x = 21;
 	pixel_y = 16
 	},
@@ -182,7 +182,7 @@
 /turf/open/shuttle/dropship/floor,
 /area/shuttle/dropship/triumph)
 "aJ" = (
-/obj/item/radio/intercom/dropship,
+/obj/item/radio/intercom/dropship/triumph,
 /turf/open/shuttle/dropship{
 	icon_state = "rasputin6"
 	},
@@ -196,7 +196,7 @@
 	},
 /area/shuttle/dropship/triumph)
 "aM" = (
-/obj/item/radio/intercom/dropship,
+/obj/item/radio/intercom/dropship/triumph,
 /turf/open/shuttle/dropship/seven,
 /area/shuttle/dropship/triumph)
 "aN" = (
@@ -333,7 +333,7 @@
 	},
 /area/shuttle/dropship/triumph)
 "bk" = (
-/obj/item/radio/intercom/dropship,
+/obj/item/radio/intercom/dropship/triumph,
 /turf/open/shuttle/dropship/five,
 /area/shuttle/dropship/triumph)
 "bl" = (

--- a/code/game/objects/items/radio/intercom.dm
+++ b/code/game/objects/items/radio/intercom.dm
@@ -104,3 +104,7 @@
 /obj/item/radio/intercom/dropship/normandy
 	name = "\improper Normandy dropship intercom"
 	frequency = FREQ_DROPSHIP_2
+
+/obj/item/radio/intercom/dropship/triumph
+	name = "\improper Triumph dropship intercom"
+	frequency = FREQ_DROPSHIP_2


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a new intercom type for the rebel dropship the Triumph and replaces the Alamo dropship intercoms that are currently on it with the Triumph intercoms. It uses the previously unused Normandy intercom frequency. 

## Why It's Good For The Game

Makes the intercom match the dropship. 

## Changelog
:cl:
fix: Triumph shuttle has appropriate intercoms.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
