### PR TITLE
Antimaterial Rifle NV Scope

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -837,6 +837,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	attach_icon = "none"
 	desc = "A rail mounted zoom sight scope specialized for the antimaterial Sniper Rifle . Allows zoom by activating the attachment. Can activate its targeting laser while zoomed to take aim for increased damage and penetration. Use F12 if your HUD doesn't come back."
 	scoped_accuracy_mod = SCOPE_RAIL_SNIPER
+	has_nightvision = TRUE
 	flags_attach_features = ATTACH_ACTIVATION
 
 /obj/item/attachable/scope/slavic


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds nightvision to the antimaterial rifle's scope. 

## Why It's Good For The Game

Makes it a bit less of a hassle to use the comparatively more expensive antimat sniper rifle. Plus this way it will be more of an upgrade compared to the IFF sniper.  The 2.5 second fire delay compared to the IFF sniper's 1.75 second, same damage with the only benefit being more sunder and the laser. The laser which loses its targeting under a stiff breeze and can see an unmoving xeno be targeted and then lose the targeting with it still not having moved. So, NV scope. 

## Changelog
:cl:
balance: Antimaterial rifle has an NV scope now. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
