### PR TITLE
Defender Can Charge From Fortify

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -135,15 +135,15 @@
 	if(!do_after(X, 0.5 SECONDS, FALSE, X, BUSY_ICON_GENERIC, extra_checks = CALLBACK(src, .proc/can_use_ability, A, FALSE, XACT_USE_BUSY)))
 		return fail_activate()
 
-	var/mob/living/carbon/xenomorph/defender/D = X
-	if(D.fortify)
-		var/datum/action/xeno_action/fortify/FT = X.actions_by_path[/datum/action/xeno_action/fortify]
-		if(FT.cooldown_id)
+	var/mob/living/carbon/xenomorph/defender/defender = X
+	if(defender.fortify)
+		var/datum/action/xeno_action/fortify/fortify_action = X.actions_by_path[/datum/action/xeno_action/fortify]
+		if(fortify_action.cooldown_id)
 			to_chat(X, "<span class='xenowarning'>We cannot yet untuck ourselves from our fortified stance!</span>")
 			return fail_activate()
 
-		FT.set_fortify(FALSE, TRUE)
-		FT.add_cooldown()
+		fortify_action.set_fortify(FALSE, TRUE)
+		fortify_action.add_cooldown()
 		to_chat(X, "<span class='xenowarning'>We rapidly untuck ourselves, preparing to surge forward.</span>")
 
 	X.visible_message("<span class='danger'>[X] charges towards \the [A]!</span>", \

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -139,15 +139,13 @@
 	if(defender.fortify)
 		var/datum/action/xeno_action/fortify/fortify_action = X.actions_by_path[/datum/action/xeno_action/fortify]
 		if(fortify_action.cooldown_id)
-			to_chat(X, "<span class='xenowarning'>We cannot yet untuck ourselves from our fortified stance!</span>")
+			to_chat(X, span_xenowarning("We cannot yet untuck ourselves from our fortified stance!"))
 			return fail_activate()
 
 		fortify_action.set_fortify(FALSE, TRUE)
 		fortify_action.add_cooldown()
-		to_chat(X, "<span class='xenowarning'>We rapidly untuck ourselves, preparing to surge forward.</span>")
+		to_chat(X, span_xenowarning("We rapidly untuck ourselves, preparing to surge forward."))
 
-	X.visible_message("<span class='danger'>[X] charges towards \the [A]!</span>", \
-	"<span class='danger'>We charge towards \the [A]!</span>" )
 	X.visible_message(span_danger("[X] charges towards \the [A]!"), \
 	span_danger("We charge towards \the [A]!") )
 	X.emote("roar")

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/abilities_defender.dm
@@ -88,7 +88,7 @@
 	ability_name = "charge"
 	cooldown_timer = 10 SECONDS
 	plasma_cost = 80
-	use_state_flags = XACT_USE_CRESTED
+	use_state_flags = XACT_USE_CRESTED|XACT_USE_FORTIFIED
 	keybind_signal = COMSIG_XENOABILITY_FORWARD_CHARGE
 
 /datum/action/xeno_action/activable/forward_charge/proc/charge_complete()
@@ -135,6 +135,19 @@
 	if(!do_after(X, 0.5 SECONDS, FALSE, X, BUSY_ICON_GENERIC, extra_checks = CALLBACK(src, .proc/can_use_ability, A, FALSE, XACT_USE_BUSY)))
 		return fail_activate()
 
+	var/mob/living/carbon/xenomorph/defender/D = X
+	if(D.fortify)
+		var/datum/action/xeno_action/fortify/FT = X.actions_by_path[/datum/action/xeno_action/fortify]
+		if(FT.cooldown_id)
+			to_chat(X, "<span class='xenowarning'>We cannot yet untuck ourselves from our fortified stance!</span>")
+			return fail_activate()
+
+		FT.set_fortify(FALSE, TRUE)
+		FT.add_cooldown()
+		to_chat(X, "<span class='xenowarning'>We rapidly untuck ourselves, preparing to surge forward.</span>")
+
+	X.visible_message("<span class='danger'>[X] charges towards \the [A]!</span>", \
+	"<span class='danger'>We charge towards \the [A]!</span>" )
 	X.visible_message(span_danger("[X] charges towards \the [A]!"), \
 	span_danger("We charge towards \the [A]!") )
 	X.emote("roar")


### PR DESCRIPTION
## About The Pull Request

Defender can now charge from its Fortify stance when both Charge and Fortify are off cooldown.

## Why It's Good For The Game

Makes Fortify more viable and improves its ability to be integrated into Defender combos as a preface/launch point, making Defender play more fluid and flexible.

## Changelog
:cl:
balance: Defender can now charge from its Fortify stance when both Charge and Fortify are off cooldown.
/:cl: