### PR TITLE
Transvitox Bonus Damage Now Applies to Converted Burn Damage Too

### DIFF
--- a/code/modules/reagents/reagents/toxin.dm
+++ b/code/modules/reagents/reagents/toxin.dm
@@ -591,7 +591,7 @@
 		dam = fire_loss
 
 	L.heal_limb_damage(burn = dam, updating_health = TRUE) //Heal damage equal to toxin damage dealt; heal before applying toxin damage so we don't flash kill the target
-	L.adjustToxLoss(dam)
+	L.adjustToxLoss(dam * (1 + 0.1 * tox_cap_multiplier)) //Apply toxin damage. Deal extra toxin damage equal to 10% * the tox cap multiplier
 
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request

Transvitox bonus damage now also applies to burn damage converted as well as brute damage dealt to a victim under its effects.

## Why It's Good For The Game

Transvitox is easily the weakest xeno chem and has been notably underwhelming in practice thus far; this should help boost it a little, while also making its behaviour more consistent.

## Changelog
:cl:
balance: Transvitox bonus damage now also applies to burn damage converted as well as brute damage dealt to a victim under its effects.
/:cl: