### PR TITLE
Added dropship equipement to the quick create menu

### DIFF
--- a/code/modules/admin/panels/game_panel.dm
+++ b/code/modules/admin/panels/game_panel.dm
@@ -67,7 +67,7 @@
 		return
 
 	var/static/list/create_object_forms = list(
-	/obj, /obj/structure, /obj/machinery, /obj/effect, /obj/item, /obj/item/reagent_containers, /obj/item/clothing, /obj/item/stack, /obj/item, /obj/item/explosive, /obj/item/weapon, /obj/item/weapon/gun, /obj/item/ammo_magazine)
+	/obj, /obj/structure, /obj/structure/dropship_equipment, /obj/structure/ship_ammo, /obj/machinery, /obj/effect, /obj/item, /obj/item/reagent_containers, /obj/item/clothing, /obj/item/stack, /obj/item, /obj/item/explosive, /obj/item/weapon, /obj/item/weapon/gun, /obj/item/ammo_magazine)
 
 	var/path = input("Select the path of the object you wish to create.", "Path", /obj) in create_object_forms
 	var/html_form = create_object_forms[path]


### PR DESCRIPTION
## About The Pull Request
Ammo and equipment added

## Why It's Good For The Game
Easier testing, easier admining

## Changelog
:cl:
admin: Added dropship equipement to the quick create menu
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
