### PR TITLE
nerfs hlin to more acceptable armor levels

### DIFF
--- a/code/modules/modular_armor/attachables.dm
+++ b/code/modules/modular_armor/attachables.dm
@@ -174,7 +174,7 @@
 	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Uses a complex set of armor plating and compensation to lessen the effect of explosions, at the cost of making the user slower."
 	icon_state = "mod_boomimmune_icon"
 	item_state = "mod_boomimmune"
-	soft_armor = list("bomb" = 95)
+	soft_armor = list("bomb" = 40)
 	slowdown = 0.2
 
 /obj/item/armor_module/attachable/hlin_explosive_armor/do_attach(mob/living/user, obj/item/clothing/suit/modular/parent)


### PR DESCRIPTION
## About The Pull Request

This nerfs Hlin down to about 90% bomb armor with a full suit, so you can self talk about ten grenades instead of.... an infinite amount due to having literal explosive immunity. #7115 was closed for being too drastic at nerfing it to 80% bomb armor, so this compromises between full immunity and a heavy nerf to put it at 90%. 

## Why It's Good For The Game

Hlin, GL, shield is an incredibly strong combo, but even just Hlin and constant GL spam is really, really strong and incredibly annoying to go against. Hlin will still be good and have a niche for GL users, but having literal full immunity is, in my opinion and the opinion of quite a few others, way too strong. 90% reduction is still very good and nothing to scoff at. Being able to tank about ten grenades before going into crit is still very useful for someone spamming grenades.

## Changelog
:cl:
balance: Hlin no longer gives explosive immunity, instead results in about 90 bomb armor. 
/:cl:
