### PR TITLE
Increases T-25 Smartrifle damage

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -999,7 +999,7 @@ datum/ammo/bullet/revolver/tp44
 
 /datum/ammo/bullet/smartgun/smartrifle
 	name = "smartrifle bullet"
-	damage = 15
+	damage = 25
 	penetration = 15
 	sundering = 1
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Smartrifle damage from 15 to 25. For comparison rifle bullets deal 25 while mg bullets deal 20 comparing a t12 to a gpmg. Even comparing the t25 to t29, smartrifle has less damage and sunder per second for less mag capacity and req only mags + reloading mags with the ammo box.
For each time the t25 shoots 5 times (0.2) the t29 shoots 4 times (0.25), totaling 75 vs 80 dmg and 5 vs 8 sunder
Hell if I did the math right a t12 on aim mode can out-dps it while having vendor ammo assuming full auto, burst auto is even better and even moreso bfa burst auto since burst  doesn't take into account aim delay. If one wants to go smartrifle he's better off even going normal marine with T18 BFA with no worries about running out of ammo.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This should give it more of a reason to be considered over the smartgun as choice for more damage in exchange of ammo shenanigans and less sunder.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: T-25 Smartrifle damage per hit from 15 to 25
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
