### PR TITLE
Makes defilers big

### DIFF
--- a/code/game/objects/effects/acid_hole.dm
+++ b/code/game/objects/effects/acid_hole.dm
@@ -47,9 +47,6 @@
 	if(!user.CanReach(src))
 		return
 	if(holed_wall)
-		if(user.mob_size == MOB_SIZE_BIG)
-			expand_hole(user)
-			return
 		use_wall_hole(user)
 
 /obj/effect/acid_hole/proc/expand_hole(mob/living/carbon/xenomorph/user)
@@ -63,7 +60,12 @@
 
 /obj/effect/acid_hole/proc/use_wall_hole(mob/user)
 
-	if(user.mob_size == MOB_SIZE_BIG || user.incapacitated() || user.lying_angle || user.buckled || user.anchored)
+	if(user.incapacitated() || user.lying_angle || user.buckled || user.anchored)
+		return
+
+	var/mob/living/carbon/xenomorph/xuser = user
+	if(user.mob_size == MOB_SIZE_BIG && !CHECK_BITFIELD(xuser.xeno_caste.caste_flags, CASTE_CAN_VENT_CRAWL))
+		expand_hole(xuser)
 		return
 
 	var/mob_dir = get_dir(user, src)

--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/defiler.dm
@@ -11,6 +11,7 @@
 	old_x = -16
 	tier = XENO_TIER_THREE
 	upgrade = XENO_UPGRADE_ZERO
+	mob_size = MOB_SIZE_BIG
 	var/emitting_gas = FALSE
 	inherent_verbs = list(
 		/mob/living/carbon/xenomorph/proc/vent_crawl,

--- a/code/modules/mob/living/carbon/xenomorph/xeno_helpers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_helpers.dm
@@ -1,9 +1,6 @@
 
 /mob/living/carbon/xenomorph/can_ventcrawl()
-	if(mob_size == MOB_SIZE_BIG || !(xeno_caste.caste_flags & CASTE_CAN_VENT_CRAWL))
-		return FALSE
-	else
-		return TRUE
+	return xeno_caste.caste_flags & CASTE_CAN_VENT_CRAWL
 
 /mob/living/carbon/xenomorph/ventcrawl_carry()
 	return TRUE

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -281,7 +281,7 @@ TUNNEL
 	var/distance = get_dist(get_turf(src), get_turf(targettunnel))
 	var/tunnel_time = clamp(distance, HIVELORD_TUNNEL_MIN_TRAVEL_TIME, HIVELORD_TUNNEL_SMALL_MAX_TRAVEL_TIME)
 
-	if(M.mob_size == MOB_SIZE_BIG) //Big xenos take longer
+	if(!CHECK_BITFIELD(M.xeno_caste.caste_flags, CASTE_CAN_VENT_CRAWL)) //Nimble xenos get through faster
 		tunnel_time = clamp(distance * 1.5, HIVELORD_TUNNEL_MIN_TRAVEL_TIME, HIVELORD_TUNNEL_LARGE_MAX_TRAVEL_TIME)
 		M.visible_message("<span class='xenonotice'>[M] begins heaving their huge bulk down into \the [src].</span>", \
 		"<span class='xenonotice'>We begin heaving our monstrous bulk into \the [src] to <b>[targettunnel.tunnel_desc]</b>.</span>")


### PR DESCRIPTION
## About The Pull Request
Changes defiler's mob_size to MOB_SIZE_BIG, which prevents bullet knockback and some stuns but gives them up to a +20% chance to be hit by projectiles.
Changes time to crawl into a hivelord tunnel to depend on whether the xeno can ventcrawl rather than size, which slows down defender, warrior, and shrike.
Allows big xenos to ventcrawl if their caste has the ventcrawl flag, which only affects defiler.
Acid holes let xenos through if they're small or can ventcrawl (again, only affects defiler).

## Why It's Good For The Game
They're visually huge and described in all their text as hulking or bulky, plus they're t3.

## Changelog
:cl:
balance: Defilers are now Big, rendering them easier to shoot but resistant to certain bullet cc effects.
/:cl: