### PR TITLE
Allow the AI to turn on red alert (without ctrl click now)

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -144,14 +144,6 @@
 		return
 	toggle_breaker(usr)
 
-/* Keycard Authentication Device */
-/obj/machinery/keycard_auth/AICtrlClick(mob/living/silicon/ai/user)
-	if(screen == 2)
-		event_triggered_by = user
-		trigger_event(event)
-		log_game("[key_name(event_triggered_by)] triggered event [event].")
-		message_admins("[ADMIN_TPMONTY(event_triggered_by)] triggered event [event].")
-
 /* Firealarm */
 /obj/machinery/firealarm/AICtrlClick(mob/living/silicon/ai/user) // turn on the fire alarm
 	if(z != user.z)

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -144,6 +144,14 @@
 		return
 	toggle_breaker(usr)
 
+/* Keycard Authentication Device */
+/obj/machinery/keycard_auth/AICtrlClick(mob/living/silicon/ai/user)
+	if(screen == 2)
+		event_triggered_by = user
+		trigger_event(event)
+		log_game("[key_name(event_triggered_by)] triggered event [event].")
+		message_admins("[ADMIN_TPMONTY(event_triggered_by)] triggered event [event].")
+
 /* Firealarm */
 /obj/machinery/firealarm/AICtrlClick(mob/living/silicon/ai/user) // turn on the fire alarm
 	if(z != user.z)

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -12,6 +12,7 @@
 	var/obj/machinery/keycard_auth/event_source
 	var/mob/event_triggered_by
 	var/mob/event_confirmed_by
+	var/synth_activation = 0
 	//1 = select event
 	//2 = authenticate
 	anchored = TRUE
@@ -59,6 +60,10 @@
 	if(.)
 		return
 
+	if(issilicon(user))
+		synth_activation = 1
+
+
 	var/dat
 	dat += "This device is used to trigger some high security events. It requires the simultaneous swipe of two high-level ID cards."
 	dat += "<br><hr><br>"
@@ -75,6 +80,11 @@
 		dat += "Please swipe your card to authorize the following event: <b>[event]</b>"
 		dat += "<p><A href='?src=\ref[src];reset=1'>Back</A>"
 
+	else if(screen == 3)
+		dat += "Do you want to trigger the following event using your Silicon Privileges: <b>[event]</b>"
+		dat += "<p><A href='?src=\ref[src];silicon_activate_event=1'>Activate</A>"
+		dat += "<p><A href='?src=\ref[src];reset=1'>Back</A>"
+
 	var/datum/browser/popup = new(user, "keycard_auth", "<div align='center'>Keycard Authentication Device</div>", 500, 250)
 	popup.set_content(dat)
 	popup.open(FALSE)
@@ -87,7 +97,16 @@
 
 	if(href_list["trigger_event"])
 		event = href_list["trigger_event"]
-		screen = 2
+		if(synth_activation)
+			screen = 3
+		else
+			screen = 2
+
+	if(href_list["silicon_activate_event"])
+		trigger_event(event)
+		log_game("[key_name(event_triggered_by)] triggered event [event].")
+		message_admins("[ADMIN_TPMONTY(event_triggered_by)] triggered event [event].")
+		reset()
 
 	if(href_list["reset"])
 		reset()
@@ -99,6 +118,7 @@
 	event = ""
 	screen = 1
 	confirmed = FALSE
+	synth_activation = 0
 	event_source = null
 	icon_state = "auth_off"
 	event_triggered_by = null

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -12,6 +12,7 @@
 	var/obj/machinery/keycard_auth/event_source
 	var/mob/event_triggered_by
 	var/mob/event_confirmed_by
+	/// Has this event been authorized by a silicon. Most of the time, this means the AI.
 	var/synth_activation = 0
 	//1 = select event
 	//2 = authenticate

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -63,7 +63,6 @@
 	if(issilicon(user))
 		synth_activation = 1
 
-
 	var/dat
 	dat += "This device is used to trigger some high security events. It requires the simultaneous swipe of two high-level ID cards."
 	dat += "<br><hr><br>"


### PR DESCRIPTION
## About The Pull Request
This PR allows the AI to turn on swipe related things such as red alert using ctrl click.

## Why It's Good For The Game
This PR raison d'être is that everyone keeps freaking dying, leaving the CIC deserted at the times we need it the most. 
Being that the AI is pretty much 70% of shipside command at any given game, it seems silly for them not to be able to u

## Changelog
:cl:
expansion: Allows the AI to use keycard devices using ctrl click
/:cl:
