### PR TITLE
sg can buy t-81 instead of smartrifle or machinegun

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -377,6 +377,14 @@
 	new /obj/item/ammo_magazine/rifle/standard_smartrifle(src)
 	new /obj/item/ammo_magazine/rifle/standard_smartrifle(src)
 
+/obj/item/storage/belt/marine/t81/Initialize()
+	. = ..()
+	new /obj/item/ammo_magazine/rifle/autosniper(src)
+	new /obj/item/ammo_magazine/rifle/autosniper(src)
+	new /obj/item/ammo_magazine/rifle/autosniper(src)
+	new /obj/item/ammo_magazine/rifle/autosniper(src)
+	new /obj/item/ammo_magazine/rifle/autosniper(src)
+
 /obj/item/storage/belt/marine/upp
 	name = "\improper Type 41 pattern load rig"
 	desc = "The Type 41 load rig is the standard-issue LBE of the USL pirates. The primary function of this belt is to provide easy access to mags for the Type 71 during operations. Despite being designed for the Type 71 weapon system, the pouches are modular enough to fit other types of ammo and equipment."

--- a/code/game/objects/items/storage/marine_boxes.dm
+++ b/code/game/objects/items/storage/marine_boxes.dm
@@ -51,9 +51,9 @@
 /obj/item/storage/box/t81_system/Initialize(mapload, ...)
 	. = ..()
 	new /obj/item/clothing/glasses/night/m56_goggles(src)
-	new /obj/item/weapon/gun/rifle/standard_autosniper(src)
+	new /obj/item/weapon/gun/rifle/standard_autosniper/sg(src)
 	new /obj/item/storage/belt/marine/t81(src)
-	new /obj/item/ammo_magazine/rifle/autosniper/sg(src)
+	new /obj/item/ammo_magazine/rifle/autosniper(src)
 
 /obj/item/minigun_powerpack
 	name = "\improper T-100 powerpack"

--- a/code/game/objects/items/storage/marine_boxes.dm
+++ b/code/game/objects/items/storage/marine_boxes.dm
@@ -53,7 +53,7 @@
 	new /obj/item/clothing/glasses/night/m56_goggles(src)
 	new /obj/item/weapon/gun/rifle/standard_autosniper(src)
 	new /obj/item/storage/belt/marine/t81(src)
-	new /obj/item/ammo_magazine/rifle/autosniper(src)
+	new /obj/item/ammo_magazine/rifle/autosniper/sg(src)
 
 /obj/item/minigun_powerpack
 	name = "\improper T-100 powerpack"

--- a/code/game/objects/items/storage/marine_boxes.dm
+++ b/code/game/objects/items/storage/marine_boxes.dm
@@ -37,6 +37,24 @@
 	new /obj/item/storage/belt/marine/t25(src)
 	new /obj/item/ammo_magazine/rifle/standard_smartrifle(src)
 
+/obj/item/storage/box/t81_system
+	name = "\improper T-81 smart sniper system"
+	desc = "A large case containing the full T-81 System. Drag this sprite into you to open it up!\nNOTE: You cannot put items back inside this case."
+	icon = 'icons/Marine/marine-weapons.dmi'
+	icon_state = "smartgun_case"
+	w_class = WEIGHT_CLASS_HUGE
+	storage_slots = 5
+	slowdown = 1
+	can_hold = list() //Nada. Once you take the stuff out it doesn't fit back in.
+	foldable = null
+
+/obj/item/storage/box/t81_system/Initialize(mapload, ...)
+	. = ..()
+	new /obj/item/clothing/glasses/night/m56_goggles(src)
+	new /obj/item/weapon/gun/rifle/standard_autosniper(src)
+	new /obj/item/storage/belt/marine/t81(src)
+	new /obj/item/ammo_magazine/rifle/autosniper(src)
+
 /obj/item/minigun_powerpack
 	name = "\improper T-100 powerpack"
 	desc = "A heavy reinforced backpack with support equipment, power cells, and spare rounds for the T-100 Minigun System.\nClick the icon in the top left to reload your M56."

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -628,6 +628,7 @@
 	listed_products = list(
 		/obj/item/storage/box/t26_system = list(CAT_ESS, "T-26 Smartmachinegun Set", 0, "white"),
 		/obj/item/storage/box/t25_system = list(CAT_ESS, "T-25 Smartrifle Set", 0, "white"),
+		/obj/item/storage/box/t81_system = list(CAT_ESS, "T-81 Smartsniper Set", 0, "white"),
 
 
 		/obj/item/attachable/extended_barrel = list(CAT_ATT, "Extended barrel", 0, "orange"),

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1088,6 +1088,7 @@
 	type_of_casings = "cartridge"
 	attachable_allowed = list(
 		/obj/item/attachable/autosniperbarrel,
+		/obj/item/attachable/scope/marine,
 		/obj/item/attachable/scope/nightvision,
 		/obj/item/attachable/extended_barrel,
 		/obj/item/attachable/suppressor,
@@ -1120,7 +1121,7 @@
 
 	starting_attachment_types = list(
 		/obj/item/attachable/autosniperbarrel,
-		/obj/item/attachable/scope,
+		/obj/item/attachable/scope/marine,
 	)
 
 

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1115,6 +1115,15 @@
 	aim_slowdown = 1
 	wield_delay = 1.3 SECONDS
 
+/obj/item/weapon/gun/rifle/standard_autosniper/sg // no nvg for u
+	desc = "The T-81 is the TerraGov Marine Corps's automatic sniper rifle. It is rather well-known for it's night vision scope and IFF ammo, however this one was packed without the former, for cost reasons.. It is mostly used by people who prefer to do more careful shooting than most. Uses 8.6x70mm caseless IFF caliber."
+
+	starting_attachment_types = list(
+		/obj/item/attachable/autosniperbarrel,
+		/obj/item/attachable/scope,
+	)
+
+
 //-------------------------------------------------------
 //TX-11 Rifle, based on the gamer-11
 

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -446,6 +446,12 @@ ATTACHMENTS
 	contains = list(/obj/item/attachable/stock/tactical)
 	cost = 1
 
+/datum/supply_packs/attachments/t81scope
+	name = "T-46 NVG Scope"
+	notes = "Used on T-81s."
+	contains = list(/obj/item/attachable/scope/nightvision)
+	cost = 15
+
 /*******************************************************************************
 AMMO
 *******************************************************************************/


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
sg can buy t-81
no nvg scope though you gotta buy that seperately for 15 points else it'd be overpowered so i added the crate for it
oh and t81 can use normal marine scopes for the 1 in 50000 rounds that it'll matter
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
gives sg more variety
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
expansion: Expands sg content with new gun
balance: t-81 can use normal marine scopes, and sgs can buy t-81s without nvg scopes in their thing instead of t-29s or smartrifles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
