### PR TITLE
Adjusts req Jaeger module names to accurately reflect their modules. Slight point cost reduction for Mimir mk2 helmet and Baldur mk2

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -790,44 +790,45 @@ ARMOR
 	cost = 40
 
 /datum/supply_packs/armor/modular/attachments/lamp
-	name = "Jaeger baldur modules"
+	name = "Jaeger baldur mark 2 module"
 	contains = list(
 		/obj/item/armor_module/attachable/better_shoulder_lamp,
 	)
-	cost = 10
+	cost = 8
 
 /datum/supply_packs/armor/modular/attachments/valkyrie_autodoc
-	name = "Jaeger valkyrie modules"
+	name = "Jaeger valkyrie autodoc module"
 	contains = list(
 		/obj/item/armor_module/attachable/valkyrie_autodoc,
 	)
 	cost = 12
 
 /datum/supply_packs/armor/modular/attachments/fire_proof
-	name = "Jaeger surt modules"
+	name = "Jaeger surt fireproof module"
 	contains = list(
 		/obj/item/armor_module/attachable/fire_proof,
 	)
 	cost = 12
 
 /datum/supply_packs/armor/modular/attachments/tyr_extra_armor
-	name = "Jaeger tyr mark 2 modules"
+	name = "Jaeger tyr mark 2 module"
 	contains = list(
 		/obj/item/armor_module/attachable/tyr_extra_armor,
 	)
 	cost = 12
 
 /datum/supply_packs/armor/modular/attachments/mimir_environment_protection
-	name = "Jaeger mimir module"
+	name = "Jaeger mimir mark 2 module"
 	contains = list(
 		/obj/item/armor_module/attachable/mimir_environment_protection,
 	)
 	cost = 12
 
 /datum/supply_packs/armor/modular/attachments/mimir_helmet_protection
-	name = "Jaeger helmet mimir module"
+	name = "Jaeger helmet mimir mark 2 module"
 	contains = list(/obj/item/helmet_module/attachable/mimir_environment_protection)
-	cost = 5
+	cost = 4
+
 /datum/supply_packs/armor/modular/attachments/generic_helmet_modules
 	name = "Generic Jaeger helmet modules"
 	contains = list(
@@ -839,6 +840,7 @@ ARMOR
 		/obj/item/helmet_module/antenna,
 	)
 	cost = 5
+
 /datum/supply_packs/armor/modular/attachments/hlin_bombimmune
 	name = "Jaeger Hlin module"
 	contains = list(/obj/item/armor_module/attachable/hlin_explosive_armor)


### PR DESCRIPTION
## About The Pull Request

Basically the very long title. Adjusts the names of some of the req Jaeger modules to either be more specific or specify that you are ordering the Mark 2 and not the Mark 1 for a whopping twelve req points. This is unironically a salt PR because I was ordering a Mimir Mark 2 but got my ordered denied because the SO running req said "You didn't order the Mark 2 man", then we didn't have enough points by the time of deployment and I never got my Mimir Mark 2. Sad.

The helmet cost adjustment is just to bring a full Mimir Mark 2 set to a more even 16 points, though I've also considered just bundling them like how the closet gives it to you, helmet and chest module for like 15 points. And then the Baldur cost adjustment is just because I think almost no one runs Baldur Mark 2 despite it being pretty funny to be a walking beacon of light, this should promote more people to. 

## Why It's Good For The Game

Clarity is always very good, especially helpful to new ROs, new players wanting to order upgraded modules, and random ship side people doing req for the first time. The cost adjustments are just to make those module sets more competitive with the Valk and Tyr 2, which I believe generally dominate the choices of non-Surt/Hlin users. 

## Changelog
:cl:

balance: 1 req point cost reduction for Mimir Mark 2 helmet module, 2 req point cost reduction for Baldur Mark 2
spellcheck: Adjusts names of Jaeger modules in the req console to more accurately reflect the actual item you are getting.

/:cl:
