### PR TITLE
Make it possible to put down the mortar using the activate hotkey

### DIFF
--- a/code/game/objects/machinery/mortar.dm
+++ b/code/game/objects/machinery/mortar.dm
@@ -247,6 +247,9 @@
 	. = ..()
 	AddElement(/datum/element/deployable_item, /obj/machinery/deployable/mortar, 5 SECONDS)
 
+/obj/item/mortar_kit/attack_self(mob/user)
+	unique_action(user)
+
 /obj/item/mortar_kit/unique_action(mob/user)
 	var/area/current_area = get_area(src)
 	if(current_area.ceiling >= CEILING_METAL)


### PR DESCRIPTION
## About The Pull Request
Z  = good

## Why It's Good For The Game
QoL 

## Changelog
:cl:
qol: You can now use Z to activate your mortar. Simple QOL.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
