### PR TITLE
Ai can manipulate shuttle doors

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -123,26 +123,26 @@
 
 /* Airlocks */
 /obj/machinery/door/airlock/AICtrlClick(mob/living/silicon/ai/user) // Bolts doors
-	if(z != user.z)
-		return
-
 	if(locked)
-		bolt_raise(usr)
+		bolt_raise(user)
 	else if(hasPower())
-		bolt_drop(usr)
+		bolt_drop(user)
+
+/obj/machinery/door/airlock/dropship_hatch/AICtrlClick(mob/living/silicon/ai/user)
+	return
+
+/obj/machinery/door/airlock/hatch/cockpit/AICtrlClick(mob/living/silicon/ai/user)
+	return
 
 /obj/machinery/door/airlock/AIShiftClick(mob/living/silicon/ai/user)  // Opens and closes doors!
-	if(z != user.z)
-		return
-
-	user_toggle_open(usr)
+	user_toggle_open(user)
 
 
 /* APC */
 /obj/machinery/power/apc/AICtrlClick(mob/living/silicon/ai/user) // turns off/on APCs.
 	if(z != user.z)
 		return
-	toggle_breaker(usr)
+	toggle_breaker(user)
 
 /* Firealarm */
 /obj/machinery/firealarm/AICtrlClick(mob/living/silicon/ai/user) // turn on the fire alarm

--- a/code/game/objects/machinery/doors/airlock.dm
+++ b/code/game/objects/machinery/doors/airlock.dm
@@ -441,19 +441,19 @@
 //		ignite(is_hot(C))
 //	..()
 
-/obj/machinery/door/airlock/open(forced=0)
-	if( operating || welded || locked || !loc)
-		return 0
+/obj/machinery/door/airlock/open(forced = FALSE)
+	if(operating || welded || locked || !loc)
+		return FALSE
 	if(!forced)
 		if(!hasPower() || wires.is_cut(WIRE_OPEN))
-			return 0
+			return FALSE
 	use_power(active_power_usage)	//360 W seems much more appropriate for an actuator moving an industrial door capable of crushing people
 	if(istype(src, /obj/machinery/door/airlock/glass))
-		playsound(src.loc, 'sound/machines/windowdoor.ogg', 25, 1)
+		playsound(loc, 'sound/machines/windowdoor.ogg', 25, 1)
 	else
-		playsound(src.loc, 'sound/machines/airlock.ogg', 25, 0)
-	if(src.closeOther != null && istype(src.closeOther, /obj/machinery/door/airlock/) && !src.closeOther.density)
-		src.closeOther.close()
+		playsound(loc, 'sound/machines/airlock.ogg', 25, 0)
+	if(istype(closeOther, /obj/machinery/door/airlock) && !closeOther.density)
+		closeOther.close()
 	return ..()
 
 /obj/machinery/door/airlock/close(forced = FALSE)
@@ -503,16 +503,16 @@
 	audible_message("You hear a click from the bottom of the door.", null, 1)
 	update_icon()
 
-/obj/machinery/door/airlock/proc/unlock(forced=0)
+/obj/machinery/door/airlock/proc/unlock(forced = FALSE)
 	if (operating || !locked)
 		return
 
 	if(forced || hasPower()) //only can raise bolts if power's on
-		src.locked = 0
+		locked = FALSE
 		audible_message("You hear a click from the bottom of the door.", null, 1)
 		update_icon()
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 /obj/machinery/door/airlock/Initialize(mapload, ...)
 	. = ..()

--- a/code/game/objects/machinery/doors/airlock_types.dm
+++ b/code/game/objects/machinery/doors/airlock_types.dm
@@ -852,6 +852,9 @@
 	no_panel = TRUE
 	not_weldable = TRUE
 
+/obj/machinery/door/airlock/canAIControl(mob/user)
+	return TRUE
+
 /obj/machinery/door/airlock/dropship_hatch/proc/lockdown()
 	unlock()
 	close()
@@ -895,7 +898,9 @@
 	resistance_flags = UNACIDABLE|INDESTRUCTIBLE
 	no_panel = TRUE
 	not_weldable = TRUE
-	aiControlDisabled = TRUE
+
+/obj/machinery/door/airlock/hatch/cockpit/canAIControl(mob/user)
+	return TRUE
 
 /obj/machinery/door/airlock/hatch/cockpit/rebel
 	req_access = list(ACCESS_MARINE_DROPSHIP_REBEL)

--- a/code/game/objects/machinery/doors/airlock_types.dm
+++ b/code/game/objects/machinery/doors/airlock_types.dm
@@ -851,7 +851,6 @@
 	resistance_flags = UNACIDABLE|INDESTRUCTIBLE
 	no_panel = TRUE
 	not_weldable = TRUE
-	aiControlDisabled = TRUE
 
 /obj/machinery/door/airlock/dropship_hatch/proc/lockdown()
 	unlock()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title. It was removed cause ai could lock them to prevent hijack, but you can't interact with doors on grounds, so it's fine.

Remove locking shuttle doors for ai by ctrl clicking

Also clean some src.vars

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Usefull for droids, so they can actually leave the shuttle when controlled by the ai

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Ai can manipuate shuttle doors even groundside, but won't be able to lock them (unless it uses the console)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
