### PR TITLE
Fix the poster bulging downward. As it turns out, there is a weird thing with the direction giving out a pixel offset.

### DIFF
--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -8408,8 +8408,10 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/port_hallway)
 "Bv" = (
-/obj/structure/sign/prop1,
-/turf/closed/wall/mainship,
+/obj/structure/sign/prop1{
+	dir = 1
+	},
+/turf/open/floor/mainship,
 /area/mainship/squads/general)
 "Bx" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -51366,7 +51368,7 @@ qC
 sx
 Nn
 sx
-Bv
+qC
 xr
 wf
 wf
@@ -51624,7 +51626,7 @@ qC
 Ah
 PR
 qC
-jl
+Bv
 CN
 CN
 ob


### PR DESCRIPTION
## About The Pull Request

![image](https://user-images.githubusercontent.com/24830358/126549438-c107a899-84f6-400d-aea7-7d38a1ea198e.png)

Fixes this issue : https://github.com/tgstation/TerraGov-Marine-Corps/issues/7500

## Changelog
:cl:
fix: fixed a misplaced poster.
/:cl:
