### PR TITLE
Hunters hide passively like how runners/larva can

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -213,6 +213,9 @@
 	plasma_cost = 20
 	range = 7
 
+//Don't need to do anything here, just overriding runner's pounce so we maintain layer
+/datum/action/xeno_action/activable/pounce/hunter/prepare_to_pounce()
+
 // ***************************************
 // *********** Haunt
 // ***************************************

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -213,9 +213,6 @@
 	plasma_cost = 20
 	range = 7
 
-//Don't need to do anything here, just overriding runner's pounce so we maintain layer
-/datum/action/xeno_action/activable/pounce/hunter/prepare_to_pounce()
-
 // ***************************************
 // *********** Haunt
 // ***************************************

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/hunter.dm
@@ -12,6 +12,7 @@
 	inherent_verbs = list(
 		/mob/living/carbon/xenomorph/proc/vent_crawl,
 	)
+	layer = XENO_HIDING_LAYER //Hunters just stay hidden on their own.
 
 // ***************************************
 // *********** Death

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -139,8 +139,7 @@
 		return FALSE
 
 /datum/action/xeno_action/activable/pounce/proc/prepare_to_pounce()
-	if(owner.layer == XENO_HIDING_LAYER) //Xeno is currently hiding, unhide him
-		owner.layer = MOB_LAYER
+	owner.layer = initial(owner.layer)
 
 /datum/action/xeno_action/activable/pounce/get_cooldown()
 	var/mob/living/carbon/xenomorph/X = owner


### PR DESCRIPTION
## About The Pull Request
Sets hunter's default layer to XENO_HIDING_LAYER, the same one runners and larva can enter. This puts them below most objects and other mobs.
Adjusts hunter's pounce to not revert their layer the way runner's does, since they can't set it manually.

## Why It's Good For The Game
Stealthy beno, and also I keep getting annoyed at failing to slash people after I pounce them (skill issue).
Just giving them the hide action was an option, but I like this better because hunters already have an action with the same icon (stealth) and naturally staying slightly hidden seemed like a hunter thing.

## Changelog
:cl:
add: Hunters now passively hide behind stuff the way larva and runners can choose to.
/:cl: