### PR TITLE
Turrets don't detect people in stealth

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -89,6 +89,8 @@
 #define TRAIT_STASIS "stasis"//Subject to the stasis effect
 #define ENDURE_TRAIT "endure" //Ravager Endure ability.
 #define RAGE_TRAIT "rage" //Ravager Rage ability.
+#define CAMO_SMOKE_TRAIT "camosmoke" //From tactical smoke grenades
+#define STEALTH_TRAIT "stealth" //From hunter stealth
 
 //mob traits
 #define TRAIT_KNOCKEDOUT "knockedout" //Forces the user to stay unconscious.
@@ -109,6 +111,7 @@
 #define TRAIT_STAGGERIMMUNE	"stagger_immunity" //Immunity to stagger
 #define TRAIT_SLOWDOWNIMMUNE "slowdown_immunity" //Immunity to slowdown
 #define TRAIT_MUTED "muted" //target is mute and can't speak
+#define TRAIT_TURRET_HIDDEN "turret_hidden" //target gets passed over by turrets choosing a victim
 
 // item traits
 #define TRAIT_T_RAY_VISIBLE "t-ray-visible" // Visible on t-ray scanners if the atom/var/level == 1

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -89,7 +89,6 @@
 #define TRAIT_STASIS "stasis"//Subject to the stasis effect
 #define ENDURE_TRAIT "endure" //Ravager Endure ability.
 #define RAGE_TRAIT "rage" //Ravager Rage ability.
-#define CAMO_SMOKE_TRAIT "camosmoke" //From tactical smoke grenades
 #define STEALTH_TRAIT "stealth" //From hunter stealth
 
 //mob traits

--- a/code/game/objects/machinery/sentries.dm
+++ b/code/game/objects/machinery/sentries.dm
@@ -1013,7 +1013,8 @@
 			continue
 		if(CHECK_BITFIELD(turret_flags, TURRET_SAFETY) && !isxeno(M)) //When safeties are on, Xenos only.
 			continue
-
+		if(HAS_TRAIT(M, TRAIT_TURRET_HIDDEN))
+			continue
 		var/mob/living/carbon/human/H = M
 		if(istype(H) && H.wear_id.iff_signal & iff_signal)
 			continue

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -98,6 +98,7 @@
 	stealth = TRUE
 	RegisterSignal(owner, COMSIG_MOVABLE_MOVED, .proc/handle_stealth)
 	handle_stealth()
+	ADD_TRAIT(owner, TRAIT_TURRET_HIDDEN, STEALTH_TRAIT)
 	addtimer(CALLBACK(src, .proc/sneak_attack_cooldown), HUNTER_POUNCE_SNEAKATTACK_DELAY) //Short delay before we can sneak attack.
 
 /datum/action/xeno_action/stealth/proc/cancel_stealth() //This happens if we take damage, attack, pounce, toggle stealth off, and do other such exciting stealth breaking activities.
@@ -109,6 +110,7 @@
 	UnregisterSignal(owner, COMSIG_MOVABLE_MOVED) //This should be handled on the ability datum or a component.
 	stealth = FALSE
 	can_sneak_attack = FALSE
+	REMOVE_TRAIT(owner, TRAIT_TURRET_HIDDEN, STEALTH_TRAIT)
 	owner.alpha = 255 //no transparency/translucency
 
 /datum/action/xeno_action/stealth/proc/sneak_attack_cooldown()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -500,7 +500,6 @@
 	XI.remove_from_hud(src)
 	var/datum/atom_hud/xeno_reagents/RE = GLOB.huds[DATA_HUD_XENO_REAGENTS]
 	RE.remove_from_hud(src)
-	ADD_TRAIT(src, TRAIT_TURRET_HIDDEN, CAMO_SMOKE_TRAIT)
 
 	smokecloaked = TRUE
 
@@ -517,7 +516,6 @@
 	XI.add_to_hud(src)
 	var/datum/atom_hud/xeno_reagents/RE = GLOB.huds[DATA_HUD_XENO_REAGENTS]
 	RE.add_to_hud(src)
-	REMOVE_TRAIT(src, TRAIT_TURRET_HIDDEN, CAMO_SMOKE_TRAIT)
 
 	smokecloaked = FALSE
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -500,6 +500,7 @@
 	XI.remove_from_hud(src)
 	var/datum/atom_hud/xeno_reagents/RE = GLOB.huds[DATA_HUD_XENO_REAGENTS]
 	RE.remove_from_hud(src)
+	ADD_TRAIT(src, TRAIT_TURRET_HIDDEN, CAMO_SMOKE_TRAIT)
 
 	smokecloaked = TRUE
 
@@ -516,6 +517,7 @@
 	XI.add_to_hud(src)
 	var/datum/atom_hud/xeno_reagents/RE = GLOB.huds[DATA_HUD_XENO_REAGENTS]
 	RE.add_to_hud(src)
+	REMOVE_TRAIT(src, TRAIT_TURRET_HIDDEN, CAMO_SMOKE_TRAIT)
 
 	smokecloaked = FALSE
 

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -976,6 +976,8 @@ TUNNEL
 	for (var/mob/living/nearby_hostile AS in potential_hostiles)
 		if(nearby_hostile.stat == DEAD)
 			continue
+		if(HAS_TRAIT(nearby_hostile, TRAIT_TURRET_HIDDEN))
+			continue
 		buffer_distance = get_dist(nearby_hostile, src)
 		if (distance <= buffer_distance) //If we already found a target that's closer
 			continue


### PR DESCRIPTION
Different implementation of #7494 

## About The Pull Request
Hunter stealth grants a trait that makes turrets not target you as long as it's present.

## Why It's Good For The Game
Getting shot by AI when you're invisible is lame. 

## Changelog
:cl:
balance: Turrets won't target you when you're stealthed via hunter ability.
/:cl: