### PR TITLE
Inaprovaline heals while unconscious

### DIFF
--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -24,6 +24,11 @@
 		var/mob/living/carbon/C = L
 		if(C.losebreath > 10)
 			C.set_Losebreath(10)
+		if(C.stat == UNCONSCIOUS)
+			C.adjustFireLoss(-0.5*effect_str)
+			C.adjustBruteLoss(-0.5*effect_str)
+			C.adjustToxLoss(-0.5*effect_str)
+			C.adjustOxyLoss(-0.5*effect_str)
 	return ..()
 
 /datum/reagent/medicine/inaprovaline/overdose_process(mob/living/L, metabolism)


### PR DESCRIPTION
## About The Pull Request
Adds minor (0.5 each per tick) healing to inaprovaline, but only while the mob it's in is unconscious. This is only counts below 150 health or when suffocating, it won't work while actively sleeping or sedated.

## Why It's Good For The Game
Inaprovaline's described intent is to help with stabilization of critical patients, but all it does at the moment is prevent passive death by oxloss while in crit. Dexalin is better at this while working against other oxloss sources too. This keeps inaprov situational, since most patients aren't unconscious, but makes it more worth using within its space.

## Changelog
:cl:
balance: Inaprovaline slowly heals patients in critical condition.
/:cl: