### PR TITLE
Increases price of T-26 AMR to 75 points

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -242,7 +242,7 @@ WEAPONS
 /datum/supply_packs/weapons/antimaterial
 	name = "T-26 Antimaterial rifle kit"
 	contains = list(/obj/item/weapon/gun/rifle/sniper/antimaterial)
-	cost = 60
+	cost = 75
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/specminigun


### PR DESCRIPTION
## About The Pull Request

Literally just the title. Spoke with one of the more prominent T-26 users as of now and it was quickly agreed that the T-26 is way too cheap ever since NV was added by #7522. So this remedies that by increasing the cost to match the greatly increased effectiveness. 

## Why It's Good For The Game

T-26 is really strong right now since NV was added to it, probably should have had a price increase in that PR, but this fixes that instead. Though a bit late. 

## Changelog
:cl:

balance: T-26 AMR now costs 75 points, up from 60. 

/:cl:
