### PR TITLE
Baldur Changes

### DIFF
--- a/code/modules/modular_armor/attachables.dm
+++ b/code/modules/modular_armor/attachables.dm
@@ -34,7 +34,7 @@
 /** Shoulder lamp strength module */
 /obj/item/armor_module/attachable/better_shoulder_lamp
 	name = "\improper Mark 2 Baldur Light Amplification System"
-	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Substantially increases the power output of the Jaeger Combat Exoskeleton's mounted flashlight. Slows you down minorly."
+	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Substantially increases the power output of the Jaeger Combat Exoskeleton's mounted flashlight."
 	icon_state = "mod_lamp_icon"
 	item_state = "mod_lamp"
 	slowdown = 0
@@ -49,10 +49,9 @@
 	return ..()
 
 /obj/item/armor_module/attachable/better_shoulder_lamp/mark1
-	name = "\improper Mark 1 Baldur Light Amplification System"
-	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Substantially increases the power output of the Jaeger Combat Exoskeleton's mounted flashlight. Slows you down minorly."
+	name = "\improper Baldur Light Amplification System"
+	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Substantially increases the power output of the Jaeger Combat Exoskeleton's mounted flashlight."
 	power_boost = 4 /// The boost to armor shoulder light
-	slowdown = 0.1
 
 /** Mini autodoc module */
 /obj/item/armor_module/attachable/valkyrie_autodoc

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -795,13 +795,6 @@ ARMOR
 	)
 	cost = 40
 
-/datum/supply_packs/armor/modular/attachments/lamp
-	name = "Jaeger baldur modules"
-	contains = list(
-		/obj/item/armor_module/attachable/better_shoulder_lamp,
-	)
-	cost = 10
-
 /datum/supply_packs/armor/modular/attachments/valkyrie_autodoc
 	name = "Jaeger valkyrie modules"
 	contains = list(


### PR DESCRIPTION
## About The Pull Request

Effectively removes the Baldur Mark 2 and instead just makes the Baldur the only light amp module. Removes the slowdown from the Baldur Mark 1 and changes the name to suit it, the light amplification remains the same. 

## Why It's Good For The Game

When wanting to run a module with no slowdown, you now have two choices instead of one, either the Vali for self medscan (assuming you aren't running a Vali/Harvester dedicated build), or the Baldur for a somewhat brighter lamp. Both are pretty minor benefits, but for no slowdown that's pretty reasonable. I'd say that if the Vali can have no slowdown and give a self med scan + potentially be really good in a dedicated build, then the Baldur should not have slowdown either. 

## Changelog
:cl:
balance: Baldur no longer gives slowdown and the Baldur Mark 2 is effectively rendered obsolete and removed from req vendor. 
/:cl:
