### PR TITLE
Buffes drone speed on weeds and lowers its damage to 16/16/18/18

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
@@ -13,7 +13,7 @@
 
 	// *** Speed *** //
 	speed = -0.8
-	weeds_speed_mod = -0.1
+	weeds_speed_mod = -0.4
 
 	// *** Plasma *** //
 	plasma_max = 750

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
@@ -13,7 +13,7 @@
 
 	// *** Speed *** //
 	speed = -0.8
-	weeds_speed_mod = -0.4
+	weeds_speed_mod = -0.1
 
 	// *** Plasma *** //
 	plasma_max = 750

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
@@ -99,7 +99,7 @@
 	upgrade = XENO_UPGRADE_TWO
 
 	// *** Melee Attacks *** //
-	melee_damage = 16
+	melee_damage = 18
 
 	// *** Speed *** //
 	speed = -1.0

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
@@ -99,7 +99,7 @@
 	upgrade = XENO_UPGRADE_TWO
 
 	// *** Melee Attacks *** //
-	melee_damage = 20
+	melee_damage = 16
 
 	// *** Speed *** //
 	speed = -1.0
@@ -127,7 +127,7 @@
 	upgrade = XENO_UPGRADE_THREE
 
 	// *** Melee Attacks *** //
-	melee_damage = 20
+	melee_damage = 18
 
 	// *** Speed *** //
 	speed = -1.2


### PR DESCRIPTION
## About The Pull Request

Drones speed were nerfed due to being used for the insta larval sting which was nerfed later.

## Why It's Good For The Game

Bringing back their speed on weed will help them prepare and maze/support and do a bit of combat in exchange for damage.

## Changelog
:cl:
Balance: Drone weed speed: from -0.1 to  -0.4 and damages from : 16/16/20/20 to 16/16/18/18
/:cl:
