### PR TITLE
Buffs Marksman bullet by 5 damage

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -563,7 +563,7 @@ datum/ammo/bullet/revolver/tp44
 	accurate_range_min = 0
 	accurate_range = 30
 	max_range = 40
-	damage = 65
+	damage = 70
 	scatter = -15
 	penetration = 15
 	sundering = 2


### PR DESCRIPTION
## About The Pull Request

Literally the title. Mostly intended as a buff for BR, but after talking with Splinter this was agreed upon instead. 

## Why It's Good For The Game

Both DMR and BR are not super strong, BR especially. This should help them slightly be a bit more impactful for being such slow firing weapons. 

## Changelog
:cl:

balance: Marksman bullets do 5 more damage, mostly impacting the Battle Rifle and DMR

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
