### PR TITLE
Updates storage modules desc to reflect no slowdown

### DIFF
--- a/code/modules/modular_armor/storage.dm
+++ b/code/modules/modular_armor/storage.dm
@@ -71,7 +71,7 @@
 /** General storage */
 /obj/item/armor_module/storage/general
 	name = "General Purpose Storage module"
-	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Certainly not as specialised as any other storage modules, but definitely able to hold some larger things, like binoculars, maps, and motion detectors. Looks like it might slow you down a bit."
+	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Certainly not as specialised as any other storage modules, but definitely able to hold some larger things, like binoculars, maps, and motion detectors."
 	icon_state = "mod_general_bag"
 	storage_type =  /obj/item/storage/internal/modular/general
 
@@ -120,7 +120,7 @@
 
 /obj/item/armor_module/storage/engineering
 	name = "Engineering Storage module"
-	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Can hold about as much as a tool pouch, and sometimes small spools of things like barbed wire, or an entrenching tool. Looks like it might slow you down a bit."
+	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Can hold about as much as a tool pouch, and sometimes small spools of things like barbed wire, or an entrenching tool."
 	icon_state = "mod_engineer_bag"
 	storage_type =  /obj/item/storage/internal/modular/engineering
 
@@ -155,7 +155,7 @@
 
 /obj/item/armor_module/storage/medical
 	name = "Medical Storage module"
-	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Can hold a substantial variety of medical supplies and apparatus, but cannot hold as much as a medkit could. Looks like it might slow you down a bit."
+	desc = "Designed for mounting on the Jaeger Combat Exoskeleton. Can hold a substantial variety of medical supplies and apparatus, but cannot hold as much as a medkit could."
 	icon_state = "mod_medic_bag"
 	storage_type =  /obj/item/storage/internal/modular/medical
 


### PR DESCRIPTION
## About The Pull Request

Ever since #6858, storage modules don't actually slowdown at all, this updates their descriptions to properly reflect that and be less misleading and potentially confusing to newer players.

## Why It's Good For The Game

Clarity and accurate information is good.

## Changelog
:cl:
spellcheck: Description of Jaeger storage modules updated to reflect the fact that they no longer slow you down.
/:cl:
