### PR TITLE
Fix Diagonal movement speed

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -141,7 +141,7 @@
 	. = ..()
 
 	if((direct & (direct - 1)) && mob.loc == n) //moved diagonally successfully
-		add_delay *= 2
+		add_delay *= 1.414214 // sqrt(2)
 	move_delay += add_delay
 
 #undef MOVEMENT_DELAY_BUFFER

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -59,8 +59,9 @@
 	else
 		mob.control_object.forceMove(get_step(mob.control_object, direct))
 
-#define MOVEMENT_DELAY_BUFFER 0.75
+#define MOVEMENT_DELAY_BUFFER 0.75 
 #define MOVEMENT_DELAY_BUFFER_DELTA 1.25
+#define DIAGONAL_MOVEMENT_DELAY 1.414 //sqrt(2)
 
 /client/Move(n, direct)
 	if(world.time < move_delay) //do not move anything ahead of this check please
@@ -141,11 +142,12 @@
 	. = ..()
 
 	if((direct & (direct - 1)) && mob.loc == n) //moved diagonally successfully
-		add_delay *= 1.414214 // sqrt(2)
+		add_delay *= DIAGONAL_MOVEMENT_DELAY
 	move_delay += add_delay
 
 #undef MOVEMENT_DELAY_BUFFER
 #undef MOVEMENT_DELAY_BUFFER_DELTA
+#undef DIAGONAL_MOVEMENT_DELAY
 
 ///Process_Spacemove
 ///Called by /client/Move()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes delay on diagonal movement speed geometrically sane instead of just an arbitrary number. Delay on diagonal movement changed to sqrt(2) instead of 2. Port of https://github.com/BeeStation/BeeStation-Hornet/pull/4699/files
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The universe should not punish you for traveling in non-cardinal directions. Enforcing an artificially inflated delay (be it 2 or 1.6) in diagonal movement is noticeable and it can be quite frustrating when what should be a qol feature adds unnecessary time to travel. This should increase maneuverability of both xenos and marines equally, and I don't think this will cause any significant changes in balance (including with respect to bumpslash). 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: changes diagonal movespeed from 2 to sqrt(2)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
