### PR TITLE
Fultons are now limited use and more expensive, decreases price of ASRS, and adds fultons to SL vendor and operational vendor

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -143,6 +143,7 @@ GLOBAL_LIST_INIT(leader_gear_listed_products, list(
 		/obj/structure/closet/bodybag/tarp = list(CAT_LEDSUP, "V1 thermal-dampening tarp", 5, "black"),
 		/obj/item/storage/box/m94/cas = list(CAT_LEDSUP, "CAS flare box", 10, "orange"),
 		/obj/item/deployable_camera = list(CAT_LEDSUP, "Deployable Overwatch Camera", 2, "orange"),
+		/obj/item/fulton_extraction_pack = list(CAT_LEDSUP, "Fulton Extraction Pack", 25, "orange"),
 	))
 
 GLOBAL_LIST_INIT(smartgunner_gear_listed_products, list(

--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -143,7 +143,7 @@ GLOBAL_LIST_INIT(leader_gear_listed_products, list(
 		/obj/structure/closet/bodybag/tarp = list(CAT_LEDSUP, "V1 thermal-dampening tarp", 5, "black"),
 		/obj/item/storage/box/m94/cas = list(CAT_LEDSUP, "CAS flare box", 10, "orange"),
 		/obj/item/deployable_camera = list(CAT_LEDSUP, "Deployable Overwatch Camera", 2, "orange"),
-		/obj/item/fulton_extraction_pack = list(CAT_LEDSUP, "Fulton Extraction Pack", 22, "orange"),
+		/obj/item/fulton_extraction_pack = list(CAT_LEDSUP, "Fulton Extraction Pack", 20, "orange"),
 	))
 
 GLOBAL_LIST_INIT(smartgunner_gear_listed_products, list(

--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -143,7 +143,7 @@ GLOBAL_LIST_INIT(leader_gear_listed_products, list(
 		/obj/structure/closet/bodybag/tarp = list(CAT_LEDSUP, "V1 thermal-dampening tarp", 5, "black"),
 		/obj/item/storage/box/m94/cas = list(CAT_LEDSUP, "CAS flare box", 10, "orange"),
 		/obj/item/deployable_camera = list(CAT_LEDSUP, "Deployable Overwatch Camera", 2, "orange"),
-		/obj/item/fulton_extraction_pack = list(CAT_LEDSUP, "Fulton Extraction Pack", 25, "orange"),
+		/obj/item/fulton_extraction_pack = list(CAT_LEDSUP, "Fulton Extraction Pack", 22, "orange"),
 	))
 
 GLOBAL_LIST_INIT(smartgunner_gear_listed_products, list(

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -342,6 +342,7 @@
 			/obj/item/bodybag/tarp = 2,
 			/obj/item/explosive/plastique = 2,
 			/obj/item/minerupgrade/automatic = 3,
+			/obj/item/fulton_extraction_pack = 2,
 			/obj/item/clothing/suit/storage/marine/harness/boomvest = 20,
 			/obj/item/radio/headset/mainship/marine/alpha = -1,
 			/obj/item/radio/headset/mainship/marine/bravo = -1,

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -45,7 +45,7 @@ OPERATIONS
 /datum/supply_packs/operations/fulton_extraction_pack
 	name = "fulton extraction pack"
 	contains = list(/obj/item/fulton_extraction_pack)
-	cost = 12
+	cost = 10
 
 /datum/supply_packs/operations/cas_flares
 	name = "CAS flare pack"
@@ -79,6 +79,7 @@ OPERATIONS
 	name = "flare packs"
 	contains = list(/obj/item/storage/box/m94)
 	cost = 1
+
 /datum/supply_packs/operations/tarps
 	name = "V1 thermal-dampening tarp"
 	contains = list(/obj/item/bodybag/tarp)
@@ -93,7 +94,7 @@ OPERATIONS
 /datum/supply_packs/operations/exportpad
 	name = "ASRS Bluespace Export Point"
 	contains = list(/obj/machinery/exportpad)
-	cost = 36
+	cost = 30
 
 /datum/supply_packs/operations/alpha
 	name = "Alpha Supply Crate"

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -45,7 +45,7 @@ OPERATIONS
 /datum/supply_packs/operations/fulton_extraction_pack
 	name = "fulton extraction pack"
 	contains = list(/obj/item/fulton_extraction_pack)
-	cost = 5
+	cost = 12
 
 /datum/supply_packs/operations/cas_flares
 	name = "CAS flare pack"
@@ -93,7 +93,7 @@ OPERATIONS
 /datum/supply_packs/operations/exportpad
 	name = "ASRS Bluespace Export Point"
 	contains = list(/obj/machinery/exportpad)
-	cost = 50
+	cost = 36
 
 /datum/supply_packs/operations/alpha
 	name = "Alpha Supply Crate"

--- a/code/modules/requisitions/fulton.dm
+++ b/code/modules/requisitions/fulton.dm
@@ -38,6 +38,9 @@
 	user.visible_message(span_notice("[user] finishes attaching [src] to [spirited_away] and activates it."),\
 	span_notice("You attach the pack to [spirited_away] and activate it. This looks like it will yield [export_report.points ? export_report.points : "no"] point[export_report.points == 1 ? "" : "s"]."), null, 5)
 	uses --
+	if(uses < 1)
+		usr.temporarilyRemoveItemFromInventory(src)
+		moveToNullspace()
 
 	qdel(spirited_away)
 
@@ -98,6 +101,8 @@
 	holder_obj.pixel_z = initial(pixel_z)
 	holder_obj.vis_contents -= baloon
 	baloon.icon_state = initial(baloon.icon_state)
+	if(uses < 1)
+		qdel(src)
 	active = FALSE
 
 

--- a/code/modules/requisitions/fulton.dm
+++ b/code/modules/requisitions/fulton.dm
@@ -39,7 +39,7 @@
 	span_notice("You attach the pack to [spirited_away] and activate it. This looks like it will yield [export_report.points ? export_report.points : "no"] point[export_report.points == 1 ? "" : "s"]."), null, 5)
 	uses --
 	if(uses < 1)
-		usr.temporarilyRemoveItemFromInventory(src)
+		usr.temporarilyRemoveItemFromInventory(src) //Removes the item without qdeling it, qdeling it this early will break the rest of the procs
 		moveToNullspace()
 
 	qdel(spirited_away)

--- a/code/modules/requisitions/fulton.dm
+++ b/code/modules/requisitions/fulton.dm
@@ -9,7 +9,7 @@
 	///Reference to the balloon vis obj effect
 	var/atom/movable/vis_obj/fulton_baloon/baloon
 	var/obj/effect/fulton_extraction_holder/holder_obj
-	var/uses = 3
+	var/uses = 3 //How many times you can use the fulton before it goes poof
 
 /obj/item/fulton_extraction_pack/examine(mob/user)
 	..()
@@ -37,9 +37,7 @@
 		SSpoints.export_history += export_report
 	user.visible_message(span_notice("[user] finishes attaching [src] to [spirited_away] and activates it."),\
 	span_notice("You attach the pack to [spirited_away] and activate it. This looks like it will yield [export_report.points ? export_report.points : "no"] point[export_report.points == 1 ? "" : "s"]."), null, 5)
-	uses -= 1
-	if(zero_uses())
-		return TRUE
+	uses --
 
 	qdel(spirited_away)
 
@@ -101,12 +99,6 @@
 	holder_obj.vis_contents -= baloon
 	baloon.icon_state = initial(baloon.icon_state)
 	active = FALSE
-
-/obj/item/fulton_extraction_pack/proc/zero_uses()
-	if(uses < 1)
-		qdel(src)
-		return TRUE
-	return FALSE
 
 
 /obj/effect/fulton_extraction_holder

--- a/code/modules/requisitions/fulton.dm
+++ b/code/modules/requisitions/fulton.dm
@@ -40,7 +40,7 @@
 	span_notice("You attach the pack to [spirited_away] and activate it. This looks like it will yield [export_report.points ? export_report.points : "no"] point[export_report.points == 1 ? "" : "s"]."), null, 5)
 	uses--
 	if(uses < 1)
-		usr.temporarilyRemoveItemFromInventory(src) //Removes the item without qdeling it, qdeling it this early will break the rest of the procs
+		user.temporarilyRemoveItemFromInventory(src) //Removes the item without qdeling it, qdeling it this early will break the rest of the procs
 		moveToNullspace()
 
 	qdel(spirited_away)

--- a/code/modules/requisitions/fulton.dm
+++ b/code/modules/requisitions/fulton.dm
@@ -38,7 +38,7 @@
 		SSpoints.export_history += export_report
 	user.visible_message(span_notice("[user] finishes attaching [src] to [spirited_away] and activates it."),\
 	span_notice("You attach the pack to [spirited_away] and activate it. This looks like it will yield [export_report.points ? export_report.points : "no"] point[export_report.points == 1 ? "" : "s"]."), null, 5)
-	uses --
+	uses--
 	if(uses < 1)
 		usr.temporarilyRemoveItemFromInventory(src) //Removes the item without qdeling it, qdeling it this early will break the rest of the procs
 		moveToNullspace()

--- a/code/modules/requisitions/fulton.dm
+++ b/code/modules/requisitions/fulton.dm
@@ -9,10 +9,11 @@
 	///Reference to the balloon vis obj effect
 	var/atom/movable/vis_obj/fulton_baloon/baloon
 	var/obj/effect/fulton_extraction_holder/holder_obj
-	var/uses = 3 //How many times you can use the fulton before it goes poof
+	/// How many times you can use the fulton before it goes poof
+	var/uses = 3
 
 /obj/item/fulton_extraction_pack/examine(mob/user)
-	..()
+	. = ..()
 	to_chat(user, "It has [uses] uses remaining.")
 
 

--- a/code/modules/requisitions/fulton.dm
+++ b/code/modules/requisitions/fulton.dm
@@ -1,6 +1,6 @@
 /obj/item/fulton_extraction_pack
 	name = "fulton extraction pack"
-	desc = "A balloon that can be used to extract equipment or personnel to a Fulton Recovery Beacon. Anything not bolted down can be moved. Link the pack to a beacon by using the pack in hand."
+	desc = "A balloon that can be used to extract equipment or personnel. Anything not bolted down can be moved."
 	icon = 'icons/obj/items/fulton.dmi'
 	icon_state = "extraction_pack"
 	w_class = WEIGHT_CLASS_NORMAL
@@ -9,6 +9,11 @@
 	///Reference to the balloon vis obj effect
 	var/atom/movable/vis_obj/fulton_baloon/baloon
 	var/obj/effect/fulton_extraction_holder/holder_obj
+	var/uses = 3
+
+/obj/item/fulton_extraction_pack/examine(mob/user)
+	..()
+	to_chat(user, "It has [uses] uses remaining.")
 
 
 /obj/item/fulton_extraction_pack/Initialize()
@@ -32,6 +37,9 @@
 		SSpoints.export_history += export_report
 	user.visible_message(span_notice("[user] finishes attaching [src] to [spirited_away] and activates it."),\
 	span_notice("You attach the pack to [spirited_away] and activate it. This looks like it will yield [export_report.points ? export_report.points : "no"] point[export_report.points == 1 ? "" : "s"]."), null, 5)
+	uses -= 1
+	if(zero_uses())
+		return TRUE
 
 	qdel(spirited_away)
 
@@ -93,6 +101,12 @@
 	holder_obj.vis_contents -= baloon
 	baloon.icon_state = initial(baloon.icon_state)
 	active = FALSE
+
+/obj/item/fulton_extraction_pack/proc/zero_uses()
+	if(uses < 1)
+		qdel(src)
+		return TRUE
+	return FALSE
 
 
 /obj/effect/fulton_extraction_holder


### PR DESCRIPTION
## About The Pull Request

Basically everything in the title, fulton gets a price increase from 5 to 10 and is limited to three uses, ASRS gets a hefty price decrease from 50 to 30, the fulton is added to the SL vendor at 22 points, and the req operational vendor has two fultons in it at round start.

## Why It's Good For The Game

The ASRS is literally, completely useless in it's current state due to being completely overshadowed by fultons. This is meant to make the fultons somewhat more reasonably priced for their versatility and limit them as well, while also making the ASRS more appealing. Do you approve the three fulton orders that the Marines put in or just give them an ASRS to use instead? This should make the ASRS much more competitive with fultons, given the unlimited vs limited aspect and the fulton's increase in price. 

Adding it to the SL vendor makes sense, presents a competitive option to just buying the RB pack every round, and is somewhat of a compromise for fultons being made quite a bit more expensive from req, the same principal applies to the operational vendor change. Especially since mining comps are in there as standard, fultons may as well be in there too. 

## Changelog
:cl:
add: Fultons can now be purchased from the SL vendor for 20 points and two fultons are in the req operational vendor at round start
balance: Fultons now cost 10 points from req and have only three uses
balance: The ASRS now costs 30 points from req
/:cl:
