### PR TITLE
Disable wraith ventcrawling

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/castedatum_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/castedatum_wraith.dm
@@ -32,7 +32,7 @@
 	deevolves_to = /mob/living/carbon/xenomorph/runner
 
 	// *** Flags *** //
-	caste_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_EVOLUTION_ALLOWED|CASTE_CAN_VENT_CRAWL|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER|CAN_BECOME_KING
+	caste_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_EVOLUTION_ALLOWED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER|CAN_BECOME_KING
 
 	// *** Defense *** //
 	soft_armor = list("melee" = 25, "bullet" = 25, "laser" = 5, "energy" = 5, "bomb" = XENO_BOMB_RESIST_0, "bio" = 10, "rad" = 15, "fire" = 15, "acid" = 10)

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/wraith.dm
@@ -31,9 +31,6 @@ GLOBAL_LIST_INIT(wraith_no_incorporeal_pass_shutters, typecacheof(list(
 	old_x = -16
 	tier = XENO_TIER_TWO
 	upgrade = XENO_UPGRADE_ZERO
-	inherent_verbs = list(
-		/mob/living/carbon/xenomorph/proc/vent_crawl,
-	)
 
 /// Returns true or false to allow src to move through the blocker, mover has final say
 /mob/living/carbon/xenomorph/wraith/CanPassThrough(atom/blocker, turf/target, blocker_opinion)

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/wraith.dm
@@ -31,6 +31,10 @@ GLOBAL_LIST_INIT(wraith_no_incorporeal_pass_shutters, typecacheof(list(
 	old_x = -16
 	tier = XENO_TIER_TWO
 	upgrade = XENO_UPGRADE_ZERO
+	mob_size = MOB_SIZE_BIG
+	inherent_verbs = list(
+		/mob/living/carbon/xenomorph/proc/vent_crawl,
+	)
 
 /// Returns true or false to allow src to move through the blocker, mover has final say
 /mob/living/carbon/xenomorph/wraith/CanPassThrough(atom/blocker, turf/target, blocker_opinion)

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/wraith.dm
@@ -31,7 +31,6 @@ GLOBAL_LIST_INIT(wraith_no_incorporeal_pass_shutters, typecacheof(list(
 	old_x = -16
 	tier = XENO_TIER_TWO
 	upgrade = XENO_UPGRADE_ZERO
-	mob_size = MOB_SIZE_BIG
 	inherent_verbs = list(
 		/mob/living/carbon/xenomorph/proc/vent_crawl,
 	)


### PR DESCRIPTION
## About The Pull Request
As it says on the tin.

## Why It's Good For The Game
I do not think that the one xeno which can phase through walls should get access to the vent system, an even faster way to move around the ship and past any sort of defenses. 

## Changelog
:cl:
balance: disabled wraith vent crawl
/:cl:
