### PR TITLE
Warrior Punch Can Target But Doesn't Damage Unacidable; Other Fixes

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -376,7 +376,7 @@
 /obj/machinery/punch_act(mob/living/carbon/xenomorph/X, damage, target_zone) //Break open the machine
 	X.do_attack_animation(src, ATTACK_EFFECT_YELLOWPUNCH)
 	X.do_attack_animation(src, ATTACK_EFFECT_DISARM2)
-	if(!CHECK_BITFIELD(resistance_flags, UNACIDABLE)) //If we can't acid it, we can't damage it
+	if(!CHECK_BITFIELD(resistance_flags, UNACIDABLE) || resistance_flags == (UNACIDABLE|XENO_DAMAGEABLE)) //If it's acidable or we can't acid it but it has the xeno damagable flag, we can damage it
 		attack_generic(X, damage * 4, BRUTE, "", FALSE) //Deals 4 times regular damage to machines
 	X.visible_message(span_xenodanger("\The [X] smashes [src] with a devastating punch!"), \
 		span_xenodanger("We smash [src] with a devastating punch!"), visible_message_flags = COMBAT_MESSAGE)

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -325,7 +325,7 @@
 	if(!.)
 		return
 
-	if(A.resistance_flags & (UNACIDABLE|INDESTRUCTIBLE)) //no bolting down indestructible airlocks
+	if(A.resistance_flags & (INDESTRUCTIBLE|CRUSHER_IMMUNE)) //no bolting down indestructible airlocks
 		if(!silent)
 			to_chat(owner, span_xenodanger("We cannot damage this target!"))
 		return FALSE
@@ -376,7 +376,8 @@
 /obj/machinery/punch_act(mob/living/carbon/xenomorph/X, damage, target_zone) //Break open the machine
 	X.do_attack_animation(src, ATTACK_EFFECT_YELLOWPUNCH)
 	X.do_attack_animation(src, ATTACK_EFFECT_DISARM2)
-	attack_generic(X, damage * 4, BRUTE, "", FALSE) //Deals 4 times regular damage to machines
+	if(!CHECK_BITFIELD(resistance_flags, UNACIDABLE)) //If we can't acid it, we can't damage it
+		attack_generic(X, damage * 4, BRUTE, "", FALSE) //Deals 4 times regular damage to machines
 	X.visible_message(span_xenodanger("\The [X] smashes [src] with a devastating punch!"), \
 		span_xenodanger("We smash [src] with a devastating punch!"), visible_message_flags = COMBAT_MESSAGE)
 	playsound(src, pick('sound/effects/bang.ogg','sound/effects/metal_crash.ogg','sound/effects/meteorimpact.ogg'), 50, 1)
@@ -399,6 +400,10 @@
 	return ..()
 
 /obj/machinery/light/punch_act(mob/living/carbon/xenomorph/X)
+	. = ..()
+	attack_alien(X) //Smash it
+
+/obj/machinery/camera/punch_act(mob/living/carbon/xenomorph/X)
 	. = ..()
 	attack_alien(X) //Smash it
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -405,7 +405,13 @@
 
 /obj/machinery/camera/punch_act(mob/living/carbon/xenomorph/X)
 	. = ..()
-	attack_alien(X) //Smash it
+	var/datum/effect_system/spark_spread/sparks = new //Avoid the slash text, go direct to sparks
+	sparks.set_up(2, 0, src)
+	sparks.attach(src)
+	sparks.start()
+
+	deactivate()
+	visible_message(span_danger("\The [src]'s wires snap apart in a rain of sparks!")) //Smash it
 
 /obj/machinery/power/apc/punch_act(mob/living/carbon/xenomorph/X)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

1. Warrior Punch can target unacidable objects, but won't damage them.
2. Warrior Punch can now break cameras appropriately.

## Why It's Good For The Game

Fixes Warrior Punch to work as intended.

Fixes: https://github.com/tgstation/TerraGov-Marine-Corps/pull/7615

## Changelog
:cl:
fix: Warrior Punch can target unacidable objects, but won't damage them.
fix: Warrior Punch can now break cameras appropriately.
/:cl: