### PR TITLE
Nerfs T-25 bullet to a middle ground of 20 damage, also reduces melee force to 25 base from 35 base

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1001,7 +1001,7 @@ datum/ammo/bullet/revolver/tp44
 
 /datum/ammo/bullet/smartgun/smartrifle
 	name = "smartrifle bullet"
-	damage = 25
+	damage = 20
 	penetration = 15
 	sundering = 1
 

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -911,7 +911,7 @@
 	item_state = "t25"
 	caliber = CALIBER_10x26_CASELESS //codex
 	max_shells = 50 //codex
-	force = 35
+	force = 25
 	aim_slowdown = 0.55
 	wield_delay = 0.6 SECONDS
 	fire_sound = "gun_smartgun"


### PR DESCRIPTION
## About The Pull Request

Basically the title, #7539 was probably a bit of an overcorrection in terms of smartrifle damage, 20 is a good middle ground. I agree that 15 was too weak but disagree that 25 is more reasonable, it definitely makes it a tad strong.

Also the T-25 has big meme melee force right now while also supporting a bayonet, giving it higher melee force than the T-29 is kind of silly in that regard.

## Why It's Good For The Game

Balance is good, increasing the damage of a gun by 66% that has faster wield delay, fire rate, and probably other factors that I'm missing compared to the T-29 was probably not a good idea. This is why we balance things in increments instead of a huge increase at once. 

## Changelog
:cl:


balance: T-25 now does 20 damage instead of 25, has 25 melee force instead of 35

/:cl:
