### PR TITLE
Theseus Escape Pod Fix

### DIFF
--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -1464,7 +1464,7 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/telecomms)
 "alj" = (
-/obj/docking_port/stationary/escape_pod/escape_shuttle,
+/obj/docking_port/stationary/escape_pod,
 /turf/open/floor/plating,
 /area/mainship/hull/port_hull)
 "alw" = (
@@ -13616,7 +13616,7 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/hull/starboard_hull)
 "mrT" = (
-/obj/docking_port/stationary/escape_pod/escape_shuttle,
+/obj/docking_port/stationary/escape_pod,
 /turf/open/floor/plating,
 /area/mainship/hull/starboard_hull)
 "msT" = (
@@ -40580,12 +40580,12 @@ bkQ
 blA
 blA
 blA
+blA
 qNu
 blA
 blA
 blA
 htp
-blA
 blA
 blA
 blA
@@ -40837,12 +40837,12 @@ bjZ
 blA
 blA
 blA
+blA
 qNu
 blA
 blA
 blA
 hjB
-cjW
 cjW
 cjW
 cjW
@@ -41094,8 +41094,8 @@ bkS
 blA
 blA
 blA
-qNu
 blA
+qNu
 blA
 blA
 blA
@@ -41351,8 +41351,8 @@ bYG
 bSh
 cjW
 cjW
+cjW
 cMO
-blA
 blA
 blA
 blA
@@ -42379,8 +42379,8 @@ bYG
 bTE
 cjV
 cjV
+cjV
 cRY
-blA
 blA
 blA
 blA
@@ -42636,8 +42636,8 @@ bkQ
 blA
 blA
 blA
-qNu
 blA
+qNu
 blA
 blA
 blA
@@ -42893,12 +42893,12 @@ bjZ
 blA
 blA
 blA
+blA
 qNu
 blA
 blA
 blA
 hvu
-cjV
 cjV
 cjV
 cjV
@@ -43150,12 +43150,12 @@ bkS
 blA
 blA
 blA
+blA
 qNu
 blA
 blA
 blA
 htp
-blA
 blA
 blA
 blA


### PR DESCRIPTION
changes Theseus aft escape shuttles to pods, as they should be 

<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
oh god oh f**k

## Why It's Good For The Game



## Changelog
:cl:
fix: Theseus Aft Escape Pods have been properly installed, the engineers that installed escape shuttles have been fired.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
