### PR TITLE
All shuttles are immune to direct cas and ob hit

### DIFF
--- a/code/__DEFINES/area.dm
+++ b/code/__DEFINES/area.dm
@@ -12,3 +12,5 @@
 #define NEAR_FOB (1<<1)
 ///When present, this will prevent the drop pod to land there (usually kill zones)
 #define NO_DROPPOD (1<<2)
+///Make this area immune to cas/ob laser. Explosions can still go through if the ob is called in a nearby area
+#define OB_CAS_IMMUNE (1<<3)

--- a/code/game/area/general.dm
+++ b/code/game/area/general.dm
@@ -43,6 +43,7 @@
 	requires_power = 0
 	dynamic_lighting = DYNAMIC_LIGHTING_DISABLED
 	outside = FALSE
+	flags_area = OB_CAS_IMMUNE
 
 /area/shuttle/arrival
 	name = "Abandoned Arrival Shuttle"

--- a/code/game/objects/items/binoculars.dm
+++ b/code/game/objects/items/binoculars.dm
@@ -203,6 +203,9 @@
 		to_chat(user, span_notice("INITIATING LASER TARGETING. Stand still."))
 		if(!do_after(user, max(1.5 SECONDS, target_acquisition_delay - (2.5 SECONDS * user.skills.getRating("leadership"))), TRUE, TU, BUSY_ICON_GENERIC) || world.time < laser_cooldown || laser)
 			return
+	if(targ_area.flags_area & OB_CAS_IMMUNE)
+		to_chat(user, span_warning("Our payload won't reach this target!"))
+		return
 	switch(mode)
 		if(MODE_CAS)
 			to_chat(user, span_notice("TARGET ACQUIRED. LASER TARGETING IS ONLINE. DON'T MOVE."))

--- a/code/game/objects/machinery/squad_supply/supply_beacon.dm
+++ b/code/game/objects/machinery/squad_supply/supply_beacon.dm
@@ -142,10 +142,13 @@
 	beacon_datum = null
 
 /obj/item/beacon/supply_beacon/activate(mob/living/carbon/human/H)
+	var/area/A = get_area(H)
+	if(A.flags_area & OB_CAS_IMMUNE)
+		to_chat(H, span_warning("Our payload won't reach this target!"))
+		return
 	. = ..()
 	if(!.)
 		return
-	var/area/A = get_area(H)
 	beacon_datum = new /datum/supply_beacon("[H.name] + [A]", loc, H.faction)
 	RegisterSignal(beacon_datum, COMSIG_PARENT_QDELETING, .proc/clean_beacon_datum)
 

--- a/code/modules/shuttle/cas_plane.dm
+++ b/code/modules/shuttle/cas_plane.dm
@@ -316,6 +316,9 @@
 	if(A.ceiling >= CEILING_DEEP_UNDERGROUND)
 		to_chat(source, span_warning("That target is too deep underground!"))
 		return
+	if(A.flags_area & OB_CAS_IMMUNE)
+		to_chat(source, span_warning("Our payload won't reach this target!"))
+		return
 	if(active_weapon.ammo_equipped?.ammo_count <= 0)
 		to_chat(source, span_warning("No ammo remaining!"))
 		return


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

fixes: https://github.com/tgstation/TerraGov-Marine-Corps/issues/7420

All shuttles cannot be targeted by tactical binoculars, ob beacon, or direct cas hit. 

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

If perfectly timed, can kill all the hive without xeno able to do anything.

And anyway, this is only used to delay hijack without xeno having any counters, this is meh

## Changelog
:cl:
balance: All shuttles are immune to direct cas and ob hit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
