### PR TITLE
Evasion Now Dodges Thrown Objects

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -173,6 +173,8 @@
 #define COMSIG_MOVABLE_UNBUCKLE "unbuckle"						//from base of atom/movable/unbuckle_mob(): (mob, force)
 #define COMSIG_MOVABLE_PRE_THROW "movable_pre_throw"			//from base of atom/movable/throw_at(): (list/args)
 	#define COMPONENT_CANCEL_THROW (1<<0)
+#define COMSIG_MOVABLE_LIVING_IMPACT_THROW "movable_living_impact_throw"	//from base of atom/movable/throw_at(): (/atom/movable); called when a thrown object is checking to hit a living mob
+	#define COMPONENT_LIVING_THROW_HIT (1<<0)
 #define COMSIG_MOVABLE_POST_THROW "movable_post_throw"			//called on tail of atom/movable/throw_at()
 #define COMSIG_MOVABLE_DISPOSING "movable_disposing"			//called when the movable is added to a disposal holder object for disposal movement: (obj/structure/disposalholder/holder, obj/machinery/disposal/source)
 #define COMSIG_MOVABLE_HEAR "movable_hear"						//from base of atom/movable/Hear(): (message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode)

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -173,8 +173,8 @@
 #define COMSIG_MOVABLE_UNBUCKLE "unbuckle"						//from base of atom/movable/unbuckle_mob(): (mob, force)
 #define COMSIG_MOVABLE_PRE_THROW "movable_pre_throw"			//from base of atom/movable/throw_at(): (list/args)
 	#define COMPONENT_CANCEL_THROW (1<<0)
-#define COMSIG_MOVABLE_LIVING_THROW_IMPACT_CHECK "movable_living_throw_impact_check" //from base of /atom/movable/proc/hit_check
-	#define COMPONENT_LIVING_THROW_HIT_CHECK (1<<0)
+#define COMSIG_LIVING_PRE_THROW_IMPACT "movable_living_throw_impact_check" //sent before an item impacts a living mob
+	#define COMPONENT_PRE_THROW_IMPACT_HIT (1<<0)
 #define COMSIG_MOVABLE_POST_THROW "movable_post_throw"			//called on tail of atom/movable/throw_at()
 #define COMSIG_MOVABLE_DISPOSING "movable_disposing"			//called when the movable is added to a disposal holder object for disposal movement: (obj/structure/disposalholder/holder, obj/machinery/disposal/source)
 #define COMSIG_MOVABLE_HEAR "movable_hear"						//from base of atom/movable/Hear(): (message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode)

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -173,8 +173,8 @@
 #define COMSIG_MOVABLE_UNBUCKLE "unbuckle"						//from base of atom/movable/unbuckle_mob(): (mob, force)
 #define COMSIG_MOVABLE_PRE_THROW "movable_pre_throw"			//from base of atom/movable/throw_at(): (list/args)
 	#define COMPONENT_CANCEL_THROW (1<<0)
-#define COMSIG_MOVABLE_LIVING_IMPACT_THROW "movable_living_impact_throw"	//from base of atom/movable/throw_at(): (/atom/movable); called when a thrown object is checking to hit a living mob
-	#define COMPONENT_LIVING_THROW_HIT (1<<0)
+#define COMSIG_MOVABLE_LIVING_THROW_IMPACT_CHECK "movable_living_throw_impact_check" //from base of /atom/movable/proc/hit_check
+	#define COMPONENT_LIVING_THROW_HIT_CHECK (1<<0)
 #define COMSIG_MOVABLE_POST_THROW "movable_post_throw"			//called on tail of atom/movable/throw_at()
 #define COMSIG_MOVABLE_DISPOSING "movable_disposing"			//called when the movable is added to a disposal holder object for disposal movement: (obj/structure/disposalholder/holder, obj/machinery/disposal/source)
 #define COMSIG_MOVABLE_HEAR "movable_hear"						//from base of atom/movable/Hear(): (message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -427,7 +427,7 @@
 			continue
 		if(isliving(A))
 			var/mob/living/L = A
-			if((!L.density || L.throwpass) && !(SEND_SIGNAL(A, COMSIG_MOVABLE_LIVING_THROW_IMPACT_CHECK, src) & COMPONENT_LIVING_THROW_HIT_CHECK))
+			if((!L.density || L.throwpass) && !(SEND_SIGNAL(A, COMSIG_LIVING_PRE_THROW_IMPACT, src) & COMPONENT_PRE_THROW_IMPACT_HIT))
 				continue
 			throw_impact(A, speed)
 		if(isobj(A) && A.density && !(A.flags_atom & ON_BORDER) && (!A.throwpass || iscarbon(src)) && !flying)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -427,7 +427,7 @@
 			continue
 		if(isliving(A))
 			var/mob/living/L = A
-			if((!L.density || L.throwpass) && SEND_SIGNAL(A, COMSIG_MOVABLE_LIVING_IMPACT_THROW, src) & COMPONENT_LIVING_THROW_HIT)
+			if((!L.density || L.throwpass) && !(SEND_SIGNAL(A, COMSIG_MOVABLE_LIVING_THROW_IMPACT_CHECK, src) & COMPONENT_LIVING_THROW_HIT_CHECK))
 				continue
 			throw_impact(A, speed)
 		if(isobj(A) && A.density && !(A.flags_atom & ON_BORDER) && (!A.throwpass || iscarbon(src)) && !flying)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -427,7 +427,7 @@
 			continue
 		if(isliving(A))
 			var/mob/living/L = A
-			if(!L.density || L.throwpass)
+			if((!L.density || L.throwpass) && SEND_SIGNAL(A, COMSIG_MOVABLE_LIVING_IMPACT_THROW, src) & COMPONENT_LIVING_THROW_HIT)
 				continue
 			throw_impact(A, speed)
 		if(isobj(A) && A.density && !(A.flags_atom & ON_BORDER) && (!A.throwpass || iscarbon(src)) && !flying)

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -210,6 +210,8 @@
 	var/evade_active = FALSE
 	///Number of successful cooldown clears in a row
 	var/evasion_streak = 0
+	///How much damage we need to dodge to trigger Evasion's cooldown reset
+	var/evasion_stack_target = RUNNER_EVASION_COOLDOWN_REFRESH_THRESHOLD
 	///Whether we clear the streaks; if we scored a streak, we set this to false. Set back to true upon cooldown completion.
 	var/clear_streaks = TRUE
 	///Number of evasion stacks we've accumulated
@@ -241,6 +243,7 @@
 	RegisterSignal(R, COMSIG_XENO_PROJECTILE_HIT, .proc/evasion_dodge) //This is where we actually check to see if we dodge the projectile.
 	RegisterSignal(R, COMSIG_XENOMORPH_FIRE_BURNING, .proc/evasion_burn_check) //Register status effects and fire which impact evasion.
 	RegisterSignal(R, COMSIG_ATOM_BULLET_ACT, .proc/evasion_flamer_hit) //Register status effects and fire which impact evasion.
+	RegisterSignal(R, COMSIG_MOVABLE_LIVING_IMPACT_THROW, .proc/evasion_throw_dodge) //Register status effects and fire which impact evasion.
 
 	evade_active = TRUE //evasion is currently active
 
@@ -295,6 +298,7 @@
 		COMSIG_LIVING_STATUS_STAGGER,
 		COMSIG_XENO_PROJECTILE_HIT,
 		COMSIG_XENOMORPH_FIRE_BURNING,
+		COMSIG_MOVABLE_LIVING_IMPACT_THROW,
 		COMSIG_ATOM_BULLET_ACT
 		))
 
@@ -317,6 +321,25 @@
 
 	return ..()
 
+///Dodging thrown projectiles
+/datum/action/xeno_action/evasion/proc/evasion_throw_dodge(datum/source, atom/movable/proj)
+	SIGNAL_HANDLER
+
+	var/mob/living/carbon/xenomorph/runner/R = owner
+	if(!evade_active) //If evasion is not active we don't dodge
+		return FALSE
+
+	if((R.last_move_time < (world.time - RUNNER_EVASION_RUN_DELAY))) //Gotta keep moving to benefit from evasion!
+		return FALSE
+
+	if(isobj(proj))
+		var/obj/O = proj
+		evasion_stacks += O.throwforce //Add to evasion stacks for the purposes of determining whether or not our cooldown refreshes equal to the thrown force
+
+	evasion_dodge_SFX(proj)
+
+	return COMPONENT_LIVING_THROW_HIT
+
 ///This is where the dodgy magic happens
 /datum/action/xeno_action/evasion/proc/evasion_dodge(datum/source, obj/projectile/proj, cardinal_move, uncrossing)
 	SIGNAL_HANDLER
@@ -337,31 +360,37 @@
 	if(!(proj.ammo.flags_ammo_behavior & AMMO_SENTRY) && !R.fire_stacks) //We ignore projectiles from automated sources/sentries for the purpose of contributions towards our cooldown refresh; also fire prevents accumulation of evasion stacks
 		evasion_stacks += proj.damage //Add to evasion stacks for the purposes of determining whether or not our cooldown refreshes
 
-	var/evasion_stack_target = RUNNER_EVASION_COOLDOWN_REFRESH_THRESHOLD * (1 + evasion_streak) //Each streak increases the amount we have to dodge by the initial value
-	R.visible_message(span_warning("[R] effortlessly dodges the [proj.name]!"), \
+	evasion_dodge_SFX(proj)
+
+	return COMPONENT_PROJECTILE_DODGE
+
+///Dodge SFX
+/datum/action/xeno_action/evasion/proc/evasion_dodge_SFX(atom/movable/proj)
+	evasion_stack_target = RUNNER_EVASION_COOLDOWN_REFRESH_THRESHOLD * (1 + evasion_streak) //Each streak increases the amount we have to dodge by the initial value
+
+	var/mob/living/carbon/xenomorph/X = owner
+
+	X.visible_message(span_warning("[X] effortlessly dodges the [proj.name]!"), \
 	span_xenodanger("We effortlessly dodge the [proj.name]![(evasion_stack_target - evasion_stacks) > 0 && evasion_stacks > 0 ? " We must dodge [evasion_stack_target - evasion_stacks] more projectile damage before [src]'s cooldown refreshes." : ""]"))
 
+	X.add_filter("runner_evasion", 2, gauss_blur_filter(5)) //Cool SFX
+	addtimer(CALLBACK(X, /atom.proc/remove_filter, "runner_evasion"), 0.5 SECONDS)
+	X.do_jitter_animation(4000) //Dodgy animation!
 
-	R.add_filter("runner_evasion", 2, gauss_blur_filter(5)) //Cool SFX
-	addtimer(CALLBACK(R, /atom.proc/remove_filter, "runner_evasion"), 0.5 SECONDS)
-	R.do_jitter_animation(4000) //Dodgy animation!
+	if(evasion_stacks >= evasion_stack_target && cooldown_remaining()) //We have more evasion stacks than needed to refresh our cooldown, while being on cooldown.
+		to_chat(X, span_highdanger("Our success spurs us to continue our evasive maneuvers!"))
+		clear_streaks = FALSE //We just scored a streak so we're not clearing our streaks on cooldown finish
+		evasion_streak++ //Increment our streak count
+		clear_cooldown() //Clear our cooldown
+		if(evasion_streak > 3) //Easter egg shoutout
+			to_chat(X, span_xenodanger("Damn we're good."))
 
-	var/turf/T = get_turf(R) //location of after image SFX
+	var/turf/T = get_turf(X) //location of after image SFX
 	playsound(T, pick('sound/effects/throw.ogg','sound/effects/alien_tail_swipe1.ogg', 'sound/effects/alien_tail_swipe2.ogg'), 25, 1) //sound effects
 	var/i = 0
 	var/obj/effect/temp_visual/xenomorph/runner_afterimage/A
 	while(i < 2) //number after images
 		A = new /obj/effect/temp_visual/xenomorph/runner_afterimage(T) //Create the after image.
-		A.pixel_x = pick(rand(R.pixel_x * 3, R.pixel_x * 1.5), rand(0, R.pixel_x * -1)) //Variation on the X position
-		A.dir = R.dir //match the direction of the runner
+		A.pixel_x = pick(rand(X.pixel_x * 3, X.pixel_x * 1.5), rand(0, X.pixel_x * -1)) //Variation on the X position
+		A.dir = X.dir //match the direction of the runner
 		i++
-
-	if(evasion_stacks >= evasion_stack_target && cooldown_remaining()) //We have more evasion stacks than needed to refresh our cooldown, while being on cooldown.
-		to_chat(R, span_highdanger("Our success spurs us to continue our evasive maneuvers!"))
-		clear_streaks = FALSE //We just scored a streak so we're not clearing our streaks on cooldown finish
-		evasion_streak++ //Increment our streak count
-		clear_cooldown() //Clear our cooldown
-		if(evasion_streak > 3) //Easter egg shoutout
-			to_chat(R, span_xenodanger("Damn we're good."))
-
-	return COMPONENT_PROJECTILE_DODGE

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -243,7 +243,7 @@
 	RegisterSignal(R, COMSIG_XENO_PROJECTILE_HIT, .proc/evasion_dodge) //This is where we actually check to see if we dodge the projectile.
 	RegisterSignal(R, COMSIG_XENOMORPH_FIRE_BURNING, .proc/evasion_burn_check) //Register status effects and fire which impact evasion.
 	RegisterSignal(R, COMSIG_ATOM_BULLET_ACT, .proc/evasion_flamer_hit) //Register status effects and fire which impact evasion.
-	RegisterSignal(R, COMSIG_MOVABLE_LIVING_IMPACT_THROW, .proc/evasion_throw_dodge) //Register status effects and fire which impact evasion.
+	RegisterSignal(R, COMSIG_MOVABLE_LIVING_THROW_IMPACT_CHECK, .proc/evasion_throw_dodge) //Register status effects and fire which impact evasion.
 
 	evade_active = TRUE //evasion is currently active
 
@@ -298,7 +298,7 @@
 		COMSIG_LIVING_STATUS_STAGGER,
 		COMSIG_XENO_PROJECTILE_HIT,
 		COMSIG_XENOMORPH_FIRE_BURNING,
-		COMSIG_MOVABLE_LIVING_IMPACT_THROW,
+		COMSIG_MOVABLE_LIVING_THROW_IMPACT_CHECK,
 		COMSIG_ATOM_BULLET_ACT
 		))
 
@@ -336,9 +336,9 @@
 		var/obj/O = proj
 		evasion_stacks += O.throwforce //Add to evasion stacks for the purposes of determining whether or not our cooldown refreshes equal to the thrown force
 
-	evasion_dodge_SFX(proj)
+	evasion_dodge_sfx(proj)
 
-	return COMPONENT_LIVING_THROW_HIT
+	return COMPONENT_LIVING_THROW_HIT_CHECK
 
 ///This is where the dodgy magic happens
 /datum/action/xeno_action/evasion/proc/evasion_dodge(datum/source, obj/projectile/proj, cardinal_move, uncrossing)
@@ -360,12 +360,12 @@
 	if(!(proj.ammo.flags_ammo_behavior & AMMO_SENTRY) && !R.fire_stacks) //We ignore projectiles from automated sources/sentries for the purpose of contributions towards our cooldown refresh; also fire prevents accumulation of evasion stacks
 		evasion_stacks += proj.damage //Add to evasion stacks for the purposes of determining whether or not our cooldown refreshes
 
-	evasion_dodge_SFX(proj)
+	evasion_dodge_sfx(proj)
 
 	return COMPONENT_PROJECTILE_DODGE
 
 ///Dodge SFX
-/datum/action/xeno_action/evasion/proc/evasion_dodge_SFX(atom/movable/proj)
+/datum/action/xeno_action/evasion/proc/evasion_dodge_sfx(atom/movable/proj)
 	evasion_stack_target = RUNNER_EVASION_COOLDOWN_REFRESH_THRESHOLD * (1 + evasion_streak) //Each streak increases the amount we have to dodge by the initial value
 
 	var/mob/living/carbon/xenomorph/X = owner
@@ -387,10 +387,9 @@
 
 	var/turf/T = get_turf(X) //location of after image SFX
 	playsound(T, pick('sound/effects/throw.ogg','sound/effects/alien_tail_swipe1.ogg', 'sound/effects/alien_tail_swipe2.ogg'), 25, 1) //sound effects
-	var/i = 0
 	var/obj/effect/temp_visual/xenomorph/runner_afterimage/A
-	while(i < 2) //number after images
+	for(var/i=0 to 2) //number of after images
 		A = new /obj/effect/temp_visual/xenomorph/runner_afterimage(T) //Create the after image.
 		A.pixel_x = pick(rand(X.pixel_x * 3, X.pixel_x * 1.5), rand(0, X.pixel_x * -1)) //Variation on the X position
 		A.dir = X.dir //match the direction of the runner
-		i++
+


### PR DESCRIPTION
## About The Pull Request

1. Evasion will now dodge thrown objects, including say impact grenades.

## Why It's Good For The Game

1. Evasion gains functionality it should have, and now definitely needs to have in light of impact grenades.

## Changelog
:cl:
balance: Evasion now will dodge thrown objects.
/:cl:
