### PR TITLE
Changes rifle bucket 2 to a M412 and a HK-11 and new smg bucket

### DIFF
--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -32,6 +32,7 @@ SUBSYSTEM_DEF(persistence)
 		/datum/season_datum/weapons/guns/rifle_seasonal_two,
 		/datum/season_datum/weapons/guns/pistol_seasonal_three,
 		/datum/season_datum/weapons/guns/copsandrobbers_seasonal,
+		/datum/season_datum/weapons/guns/smg_seasonal,
 		)
 	)
 	///The saved list of custom outfits names
@@ -176,11 +177,13 @@ SUBSYSTEM_DEF(persistence)
 		)
 
 /datum/season_datum/weapons/guns/rifle_seasonal_two
-	name = "UZI"
-	description = "Uzi guns at vendors, get your uzi today!"
+	name = "Pulse Rifles"
+	description = "A failed classic and it's eventual successor."
 	item_list = list(
-		/obj/item/weapon/gun/smg/uzi = -1,
-		/obj/item/ammo_magazine/smg/uzi = -1,
+		/obj/item/weapon/gun/rifle/m412 = -1,
+		/obj/item/ammo_magazine/rifle = -1,
+		/obj/item/weapon/gun/rifle/m41a = -1,
+		/obj/item/ammo_magazine/rifle/m41a = -1,
 		)
 
 /datum/season_datum/weapons/guns/pistol_seasonal_one
@@ -221,5 +224,15 @@ SUBSYSTEM_DEF(persistence)
 		/obj/item/ammo_magazine/smg/uzi = -1,
 		/obj/item/weapon/gun/revolver/cmb = -1,
 		/obj/item/ammo_magazine/revolver/cmb = -1,
+		)
+
+/datum/season_datum/weapons/guns/smg_seasonal
+	name = "SMGs"
+	description = "Two different SMGs. A classic and a new guy."
+	item_list = list(
+		/obj/item/weapon/gun/smg/m25 = -1,
+		/obj/item/ammo_magazine/smg/m25 = -1,
+		/obj/item/weapon/gun/smg/mp7 = -1,
+		/obj/item/ammo_magazine/smg/mp7 = -1,
 		)
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Swaps rifle bucket 2 from an uzi to a M412 and a HK-11.
SMG bucket with MP27 and MR25
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes Rifle bucket 2 more unique, there's already a free m412 and it's barely different from the normal AR, and the HK-11 is a pretty odd sidegrade to the LMG effectively with it's stats overall. And is locked to the UGL.

The MP-27 could use some testing as I think it's pretty bad overall. And the MR-25 is a SMG sidegrade, fires slower and has more in the magazine.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
expansion: seasonal gun bucket expanded-rifle bucket 2 has a M412 and HK-11 rather than just an Uzi. And added a new bucket with an MR-25 and the MP-27
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
