### PR TITLE
This unifies the Alt and Ctrl click over fire alarms from the AI into one.

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -9,6 +9,7 @@
 
 	Note that AI have no need for the adjacency proc, and so this proc is a lot cleaner.
 */
+
 /mob/living/silicon/ai/DblClickOn(atom/A, params)
 	if(control_disabled || incapacitated())
 		return
@@ -140,20 +141,15 @@
 
 /* APC */
 /obj/machinery/power/apc/AICtrlClick(mob/living/silicon/ai/user) // turns off/on APCs.
-	if(z != user.z)
-		return
 	toggle_breaker(user)
 
 /* Firealarm */
-/obj/machinery/firealarm/AICtrlClick(mob/living/silicon/ai/user) // turn on the fire alarm
-	if(z != user.z)
-		return
-	alarm()
-
-/obj/machinery/firealarm/AICtrlShiftClick(mob/living/silicon/ai/user) // turn off the fire alarm
-	if(z != user.z)
-		return
-	reset()
+/obj/machinery/firealarm/AICtrlClick(mob/living/silicon/ai/user) // toggle the fire alarm
+	var/area/A = get_area(src)
+	if(A.flags_alarm_state & ALARM_WARNING_FIRE)
+		reset()
+	else
+		alarm()
 
 
 //


### PR DESCRIPTION
## About The Pull Request
Raycon good, wires bad. 

Use ctrl click now.

## Why It's Good For The Game
Easier AI time :)

## Changelog
:cl:
qol: The AI can toggle the fire alarms with ctrl click only now.
/:cl:
