### PR TITLE
Add an extra dropship turret to the sulaco

### DIFF
--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -15718,6 +15718,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/sulaco/maintenance/lower_maint2)
+"mqC" = (
+/obj/structure/dropship_equipment/sentry_holder,
+/turf/open/floor/prison,
+/area/sulaco/hangar)
 "mrg" = (
 /obj/structure/rack,
 /obj/item/circuitboard/computer/arcade,
@@ -62492,7 +62496,7 @@ aPF
 aSN
 gKw
 yfI
-cdy
+mqC
 aUL
 sgS
 mRR


### PR DESCRIPTION
## About The Pull Request
- The sulaco had 2 turrets, the POS has 3, theseus 4, this settles things a bit more

## Changelog
:cl:
tweak: Gave the sulaco three turrets, to bring it up to snuff.
/:cl:

