### PR TITLE
Removes AMR NVGs

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -824,7 +824,6 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	attach_icon = "none"
 	desc = "A rail mounted zoom sight scope specialized for the antimaterial Sniper Rifle . Allows zoom by activating the attachment. Can activate its targeting laser while zoomed to take aim for increased damage and penetration. Use F12 if your HUD doesn't come back."
 	scoped_accuracy_mod = SCOPE_RAIL_SNIPER
-	has_nightvision = TRUE
 	flags_attach_features = ATTACH_ACTIVATION
 
 /obj/item/attachable/scope/slavic


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes AMR NVG.
The price is unchanged, even though the 60->75 was the reason it got NVGs, I think it's worth 75 even without the NVG.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
AMR does not need NVGs, the only restricting factor it has ever had is the fact you need to be in light range to even use it, it required support and teamplay to use effectively.
Giving it NVGs removes any team aspect you needed to play with the rifle, M42A spec had NVGs because it was a different time with a much faster TTK overall and marines really badly needed covering fire to stop ravager man with 50 damage from gigafragging them instantly, but now that doesn't exist, so it's fine for the AMR to require teamplay to work at max range.
Price is unchanged.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: AMR no longer has an NVG scope.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
