### PR TITLE
Fixes medevac beacons not displaying the linked bed's location properly

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -602,16 +602,18 @@ GLOBAL_LIST_EMPTY(activated_medevac_stretchers)
 		details +=("<b>It's currently unpowered.</b></br>")
 	else
 		details +=("<b>It's currently powered.</b></br>")
+	var/turf/bed_location
+	var/teleport_time
 	if(linked_bed_deployed)
-		details +=("It's linked to a medvac bed located at: [get_area(linked_bed_deployed)]. Coordinates: (X: [linked_bed_deployed.x], Y: [linked_bed_deployed.y]).</br>")
-		var/teleport_time = linked_bed_deployed.last_teleport
-		if(world.time < teleport_time)
-			details +=("The linked bed's bluespace engine is currently recharging. <b>The interface displays: [round(teleport_time - world.time) * 0.1] seconds until it has recharged.</b></br>")
+		bed_location = get_turf(linked_bed_deployed)
+		teleport_time = linked_bed_deployed.last_teleport
 	else if(linked_bed)
-		details +=("It's linked to a medvac bed located at: [get_area(linked_bed)]. Coordinates: (X: [linked_bed.x], Y: [linked_bed.y]).</br>")
-		var/teleport_time = linked_bed.last_teleport
+		bed_location = get_turf(linked_bed)
+		teleport_time = linked_bed.last_teleport
+	if(bed_location)
+		details += "It's linked to a medvac bed located at: [get_area(bed_location)]. Coordinates: (X: [bed_location.x], Y: [bed_location.y]).</br>"
 		if(world.time < teleport_time)
-			details +=("The linked bed's bluespace engine is currently recharging. <b>The interface displays: [round(teleport_time - world.time) * 0.1] seconds until it has recharged.</b></br>")
+			details += "The linked bed's bluespace engine is currently recharging. <b>The interface displays: [round(teleport_time - world.time) * 0.1] seconds until it has recharged.</b></br>"
 	else
 		details +=("It's not currently linked to a medvac bed.</br>")
 


### PR DESCRIPTION
## About The Pull Request
If you examine a medvac beacon it'll tell you where the bed it's linked to is, but due to just trying to get the x/y coords directly this fails and gives 0s whenever a bed is in storage. This fixes that.

## Why It's Good For The Game
Bugfix.

## Changelog
:cl:
fix: Medevac beacons reliably relay linked bed coordinates instead of sometimes saying they're at 0/0.
/:cl: