### PR TITLE
Wraith Ability Refactor/Fixes

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
@@ -6,6 +6,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 // ***************************************
 /datum/action/xeno_action/place_warp_shadow
 	name = "Place Warp Shadow"
+	ability_name = "Place Warp Shadow"
 	action_icon_state = "warp_shadow"
 	mechanics_text = "Binds our psychic essence to a spot of our choosing. We can use Hyperposition to swap locations with this essence."
 	plasma_cost = 150
@@ -100,6 +101,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 // ***************************************
 /datum/action/xeno_action/hyperposition
 	name = "Hyperposition"
+	ability_name = "Hyperposition"
 	action_icon_state = "hyperposition"
 	mechanics_text = "We teleport back to our warp shadow after a delay. The delay scales with the distance teleported."
 	plasma_cost = 25
@@ -193,6 +195,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 // ***************************************
 /datum/action/xeno_action/phase_shift
 	name = "Phase Shift"
+	ability_name = "Phase Shift"
 	action_icon_state = "phase_shift"
 	mechanics_text = "We force ourselves temporarily out of sync with reality, allowing us to become incorporeal and move through any physical obstacles for a short duration."
 	plasma_cost = 25
@@ -201,6 +204,17 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	var/turf/starting_turf = null
 	var/phase_shift_active = FALSE
 	var/phase_shift_duration_timer_id
+	var/phase_shift_duration_alert_id
+
+/datum/action/xeno_action/phase_shift/can_use_action(silent = FALSE, override_flags)
+	. = ..()
+	var/turf/T = get_turf(owner)
+	for(var/obj/machinery/door/poddoor/timed_late/containment/shutter_check AS in GLOB.wraith_no_incorporeal_pass_shutters)
+		if(locate(shutter_check) in T)
+			if(!silent)
+				to_chat(owner, span_xenowarning("We can't Phase Shift while in the space of warp protected shutters!"))
+			return FALSE
+
 
 /datum/action/xeno_action/phase_shift/action_activate()
 	. = ..()
@@ -229,7 +243,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 
 	playsound(owner, "sound/effects/ghost.ogg", 25, 0, 1)
 
-	addtimer(CALLBACK(src, .proc/phase_shift_warning), WRAITH_PHASE_SHIFT_DURATION * WRAITH_PHASE_SHIFT_DURATION_WARNING) //Warn them when Phase Shift is about to end
+	phase_shift_duration_alert_id = addtimer(CALLBACK(src, .proc/phase_shift_warning), WRAITH_PHASE_SHIFT_DURATION * WRAITH_PHASE_SHIFT_DURATION_WARNING, TIMER_STOPPABLE) //Warn them when Phase Shift is about to end
 	phase_shift_duration_timer_id = addtimer(CALLBACK(src, .proc/phase_shift_deactivate), WRAITH_PHASE_SHIFT_DURATION, TIMER_STOPPABLE)
 	owner.add_filter("wraith_phase_shift", 4, list("type" = "blur", 5)) //Cool filter appear
 	owner.stop_pulling() //We can't pull things while incorporeal
@@ -249,8 +263,8 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 
 	phase_shift_active = TRUE //Flag phase shift as being active
 	update_button_icon("phase_shift_off") //Set to resync icon while active
-	succeed_activate()
 	plasma_cost = 0 //Toggling is free
+	return succeed_activate()
 
 ///Warns the user when Phase Shift is about to end.
 /datum/action/xeno_action/phase_shift/proc/phase_shift_warning()
@@ -268,6 +282,8 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	if(!phase_shift_active) //If phase shift isn't active, don't deactivate again; generally here for the timed proc.
 		return
 
+	deltimer(phase_shift_duration_timer_id) //Delete any existing timers
+	deltimer(phase_shift_duration_alert_id)
 	phase_shift_active = FALSE //Flag phase shift as being off
 	update_button_icon("phase_shift") //Revert the icon to phase shift
 
@@ -294,45 +310,34 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	var/current_turf = get_turf(ghost)
 	var/block_check //Are we trying to rematerialize in a solid object? Check.
 
-	if(isclosedturf(current_turf) || isspaceturf(current_turf)) //So we rematerialized in a solid wall/space
+	if(isspaceturf(current_turf) || owner.turf_block_check(current_turf)) //So we rematerialized in a solid wall/space or invincible dense object
 		block_check = TRUE
-
-	else
-		for(var/obj/blocker in current_turf) //Check for object based blockers
-			if(blocker.density && !(blocker.flags_atom & ON_BORDER)) //If we find a dense, non-border obj we can't climb it's time to stop
-				if(!isstructure(blocker))
-					block_check = TRUE
-					break
-				var/obj/structure/blocker_structure = blocker
-				if(!blocker_structure.climbable)
-					block_check = TRUE
-					break
 
 	if(block_check) //We tried to rematerialize in a solid object/wall of some kind; return to sender
 		to_chat(ghost, span_highdanger("As we rematerialize in a solid object, we revert to where we slipped out of reality."))
+		resync = TRUE
 		ghost.forceMove(starting_turf)
 		teleport_debuff_aoe(ghost) //Debuff when we reappear
 
 	var/distance = get_dist(current_turf, starting_turf)
 	var/phase_shift_plasma_cost = clamp(distance * 4, 0, 100) //We lose 4 additional plasma per tile travelled, up to a maximum of 100
 	var/plasma_deficit = ghost.plasma_stored - phase_shift_plasma_cost
+	var/cooldown_override
 
-	ghost.use_plasma(phase_shift_plasma_cost) //Pay the extra cost
-
-	ghost.visible_message(span_warning("[ghost] form wavers and becomes opaque."), \
-	"<span class='xenodanger'>We phase back into reality[phase_shift_plasma_cost > 0 ? ", expending [phase_shift_plasma_cost] additional plasma for [distance] tiles travelled." : "."]")
-
-	if(plasma_deficit < 0) //If we don't have enough plasma, we pay in blood and sunder instead.
-		plasma_deficit *= -1 //Normalize to a positive value
-		to_chat(owner, span_highdanger("We haven't enough plasma to safely move back into phase, suffering [plasma_deficit] damage and sunder as our body is torn apart!"))
-		ghost.apply_damages(plasma_deficit)
-		ghost.adjust_sunder(plasma_deficit)
+	if(resync) //If we were shunted back willingly or otherwise this is true
+		cooldown_override = 3 SECONDS //Partial cooldown if we cancelled out of Phase Shift with Resync
+	else
+		ghost.use_plasma(phase_shift_plasma_cost) //Pay the extra cost if we didn't resync
+		ghost.visible_message(span_warning("[ghost] form wavers and becomes opaque."), \
+		"<span class='xenodanger'>We phase back into reality[phase_shift_plasma_cost > 0 ? ", expending [phase_shift_plasma_cost] additional plasma for [distance] tiles travelled." : "."]")
+		if(plasma_deficit < 0) //If we don't have enough plasma, we pay in blood and sunder instead.
+			plasma_deficit *= -1 //Normalize to a positive value
+			to_chat(owner, span_highdanger("We haven't enough plasma to safely move back into phase, suffering [plasma_deficit] damage and sunder as our body is torn apart!"))
+			ghost.apply_damages(plasma_deficit)
+			ghost.adjust_sunder(plasma_deficit)
 
 	starting_turf = null
 	plasma_cost = initial(plasma_cost) //Revert the plasma cost to its initial amount
-	var/cooldown_override
-	if(resync)
-		cooldown_override = 3 SECONDS //Partial cooldown if we cancelled out of Phase Shift with Resync
 	add_cooldown(cooldown_override)
 
 /datum/action/xeno_action/phase_shift/on_cooldown_finish()
@@ -352,6 +357,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 // ***************************************
 /datum/action/xeno_action/resync
 	name = "Resync"
+	ability_name = "Resync"
 	action_icon_state = "resync"
 	mechanics_text = "Resynchronize with realspace, ending Phase Shift's effect and returning you to where the Phase Shift began with minimal cooldown."
 	cooldown_timer = 1 SECONDS //Token for anti-spam
@@ -383,6 +389,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 /datum/action/xeno_action/activable/blink
 	name = "Blink"
 	action_icon_state = "blink"
+	ability_name = "Blink"
 	mechanics_text = "We teleport ourselves a short distance to a location within line of sight."
 	use_state_flags = XABB_TURF_TARGET
 	plasma_cost = 50
@@ -415,11 +422,10 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	if(ignore_blocker) //If we don't care about objects occupying the target square, return TRUE; used for checking pathing through transparents
 		return TRUE
 
-	for(var/atom/blocker as() in T)
-		if(!blocker.CanPass(owner, T))
-			if(!silent)
-				to_chat(owner, span_xenowarning("We can't blink into a solid object!"))
-			return FALSE
+	if(owner.turf_block_check(A, FALSE, TRUE, TRUE, TRUE, TRUE)) //Check if there's anything that blocks us; we only care about Canpass here
+		if(!silent)
+			to_chat(owner, span_xenowarning("We can't blink into a solid object!"))
+		return FALSE
 
 	return TRUE
 
@@ -538,6 +544,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 /datum/action/xeno_action/activable/banish
 	name = "Banish"
 	action_icon_state = "Banish"
+	ability_name = "Banish"
 	mechanics_text = "We banish a target object or creature within line of sight to nullspace for a short duration. Can target onself and allies. Non-friendlies are banished for half as long."
 	use_state_flags = XACT_TARGET_SELF
 	plasma_cost = 100
@@ -702,6 +709,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 // ***************************************
 /datum/action/xeno_action/recall
 	name = "Recall"
+	ability_name = "Recall"
 	action_icon_state = "Recall"
 	mechanics_text = "We recall a target we've banished back from the depths of nullspace."
 	use_state_flags = XACT_USE_NOTTURF|XACT_USE_STAGGERED|XACT_USE_INCAP|XACT_USE_LYING //So we can recall ourselves from nether Brazil
@@ -727,3 +735,30 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	banish_check.banish_deactivate()
 	succeed_activate()
 	add_cooldown()
+
+///Return TRUE if we have a block, return FALSE otherwise
+/atom/proc/turf_block_check(atom/target, ignore_can_pass = FALSE, ignore_density = FALSE, ignore_closed_turf = FALSE, ignore_invulnerable = FALSE, ignore_objects = FALSE)
+	var/turf/T = get_turf(target)
+	for(var/atom/blocker AS in T)
+		if((blocker.flags_atom & ON_BORDER) || blocker == src) //If they're a border entity or ourselves, we don't care
+			continue
+		if(!blocker.CanPass(src, T) && !ignore_can_pass) //If the target atom can't pass and we care about that, we have a block
+			return TRUE
+		if(!blocker.density) //Check if we're dense
+			continue
+		if(!ignore_density) //If we care about all dense atoms or only certain types of dense atoms
+			return TRUE
+		if(isclosedturf(blocker) && !ignore_closed_turf) //If we care about closed turfs
+			return TRUE
+		if((blocker.resistance_flags & INDESTRUCTIBLE) && !ignore_invulnerable) //If we care about dense invulnerable objects
+			return TRUE
+		if(!isobj(blocker) || ignore_objects) //If we care about dense objects
+			continue
+		var/obj/obj_blocker = blocker
+		if(!isstructure(obj_blocker)) //If it's not a structure and we care about objects, we have a block
+			return TRUE
+		var/obj/structure/blocker_structure = obj_blocker
+		if(!blocker_structure.climbable) //If it's a structure and can't be climbed, we have a block
+			return TRUE
+
+	return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
@@ -394,9 +394,6 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	cooldown_timer = 0.5 SECONDS
 	keybind_signal = COMSIG_XENOABILITY_BLINK
 
-/datum/action/xeno_action/activable/blink/can_use_ability(atom/A, silent = FALSE, override_flags)
-	. = ..()
-	var/turf/T = get_turf(A)
 ///Check target Blink turf to see if it can be blinked to
 /datum/action/xeno_action/activable/blink/proc/check_blink_tile(turf/T, ignore_blocker = FALSE, silent = FALSE)
 	if(isclosedturf(T) || isspaceturf(T))
@@ -423,7 +420,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	if(ignore_blocker) //If we don't care about objects occupying the target square, return TRUE; used for checking pathing through transparents
 		return TRUE
 
-	if(owner.turf_block_check(A, FALSE, TRUE, TRUE, TRUE, TRUE)) //Check if there's anything that blocks us; we only care about Canpass here
+	if(turf_block_check(owner, T, FALSE, TRUE, TRUE, TRUE, TRUE)) //Check if there's anything that blocks us; we only care about Canpass here
 		if(!silent)
 			to_chat(owner, span_xenowarning("We can't blink here!"))
 		return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
@@ -169,7 +169,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	owner.forceMove(beacon_turf) //Move to where the beacon was
 	teleport_debuff_aoe(owner) //Apply tele debuff
 
-	var/warp_shadow_dissipate
+	var/warp_shadow_dissipate = FALSE
 	if(turf_block_check(owner, get_turf(shadow), TRUE, TRUE, FALSE, FALSE, FALSE, TRUE)) //Check if there's anything that blocks the warp shadow; we only care about solid walls/objects
 		warp_shadow_dissipate = TRUE
 		warp_shadow_check.clean_warp_shadow() //Remove the warp shadow
@@ -202,12 +202,13 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	var/turf/starting_turf = null
 	var/phase_shift_active = FALSE
 	var/phase_shift_duration_timer_id
+	///Timer for the phase shift duration alerts
 	var/phase_shift_duration_alert_id
 
 /datum/action/xeno_action/phase_shift/can_use_action(silent = FALSE, override_flags)
 	. = ..()
 	var/turf/T = get_turf(owner)
-	for(var/obj/machinery/door/poddoor/shutter_check AS in GLOB.wraith_no_incorporeal_pass_shutters)
+	for(var/shutter_check in GLOB.wraith_no_incorporeal_pass_shutters)
 		if(locate(shutter_check) in T)
 			if(!silent)
 				to_chat(owner, span_xenowarning("We can't Phase Shift while in the space of warp protected shutters!"))
@@ -735,7 +736,7 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 	add_cooldown()
 
 ///Return TRUE if we have a block, return FALSE otherwise
-proc/turf_block_check(atom/subject, atom/target, ignore_can_pass = FALSE, ignore_density = FALSE, ignore_closed_turf = FALSE, ignore_invulnerable = FALSE, ignore_objects = FALSE, ignore_mobs = FALSE, ignore_space = FALSE)
+/proc/turf_block_check(atom/subject, atom/target, ignore_can_pass = FALSE, ignore_density = FALSE, ignore_closed_turf = FALSE, ignore_invulnerable = FALSE, ignore_objects = FALSE, ignore_mobs = FALSE, ignore_space = FALSE)
 	var/turf/T = get_turf(target)
 	if(isspaceturf(T) && !ignore_space)
 		return TRUE

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/wraith.dm
@@ -15,10 +15,7 @@ GLOBAL_LIST_INIT(wraith_no_incorporeal_pass_areas, typecacheof(list(
 	/area/ice_colony/surface/tcomms,
 	/area/ice_colony/surface/requesitions,
 	/area/prison/hangar/civilian,
-	/area/prison/hangar/main,
-	/area/shuttle/dropship/alamo,
-	/area/shuttle/dropship/normandy,
-	/area/shuttle/dropship/triumph)))
+	/area/prison/hangar/main)))
 
 GLOBAL_LIST_INIT(wraith_no_incorporeal_pass_areas_dropship, typecacheof(list(
 	/area/shuttle/dropship/alamo,
@@ -62,7 +59,7 @@ GLOBAL_LIST_INIT(wraith_no_incorporeal_pass_shutters, typecacheof(list(
 	var/area/current_area = get_area(src)
 	if(is_type_in_typecache(target_area, GLOB.wraith_strictly_forbidden_areas)) //We can't enter these period.
 		return FALSE
-	if(is_type_in_typecache(target_area, GLOB.wraith_no_incorporeal_pass_areas) && !is_type_in_typecache(current_area, GLOB.wraith_no_incorporeal_pass_areas)) //If we're incorporeal via Phase Shift and we enter an off-limits area while not in one, it's time to stop
+	if(is_type_in_typecache(target_area, GLOB.wraith_no_incorporeal_pass_areas) && !(is_type_in_typecache(current_area, GLOB.wraith_no_incorporeal_pass_areas) || is_type_in_typecache(current_area, GLOB.wraith_no_incorporeal_pass_areas_dropship))) //If we're incorporeal via Phase Shift and we try to enter a general off-limits area while not in one, it's time to stop
 		return FALSE
 	if(is_type_in_typecache(target_area, GLOB.wraith_no_incorporeal_pass_areas_dropship) && !is_type_in_typecache(current_area, GLOB.wraith_no_incorporeal_pass_areas_dropship) && (SSmonitor.gamestate == GROUNDSIDE)) //If we're incorporeal via Phase Shift and we try to enter an off-limits dropship area while not in one without the dropship being crashed, it's time to stop
 		return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/wraith.dm
@@ -8,7 +8,17 @@ GLOBAL_LIST_INIT(wraith_no_incorporeal_pass_areas, typecacheof(list(
 	/area/shuttle/drop1/lz1,
 	/area/shuttle/drop2/lz2,
 	/area/outpost/lz1,
-	/area/outpost/lz2)))
+	/area/outpost/lz2,
+	/area/bigredv2/outside/space_port,
+	/area/ice_colony/exterior/surface/landing_pad,
+	/area/ice_colony/exterior/surface/landing_pad2,
+	/area/ice_colony/surface/tcomms,
+	/area/ice_colony/surface/requesitions,
+	/area/prison/hangar/civilian,
+	/area/prison/hangar/main,
+	/area/shuttle/dropship/alamo,
+	/area/shuttle/dropship/normandy,
+	/area/shuttle/dropship/triumph)))
 
 GLOBAL_LIST_INIT(wraith_no_incorporeal_pass_areas_dropship, typecacheof(list(
 	/area/shuttle/dropship/alamo,

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/wraith.dm
@@ -10,6 +10,11 @@ GLOBAL_LIST_INIT(wraith_no_incorporeal_pass_areas, typecacheof(list(
 	/area/outpost/lz1,
 	/area/outpost/lz2)))
 
+GLOBAL_LIST_INIT(wraith_no_incorporeal_pass_areas_dropship, typecacheof(list(
+	/area/shuttle/dropship/alamo,
+	/area/shuttle/dropship/normandy,
+	/area/shuttle/dropship/triumph)))
+
 //Don't even think of going in here
 GLOBAL_LIST_INIT(wraith_strictly_forbidden_areas, typecacheof(list(
 	/area/space)))
@@ -48,5 +53,7 @@ GLOBAL_LIST_INIT(wraith_no_incorporeal_pass_shutters, typecacheof(list(
 	if(is_type_in_typecache(target_area, GLOB.wraith_strictly_forbidden_areas)) //We can't enter these period.
 		return FALSE
 	if(is_type_in_typecache(target_area, GLOB.wraith_no_incorporeal_pass_areas) && !is_type_in_typecache(current_area, GLOB.wraith_no_incorporeal_pass_areas)) //If we're incorporeal via Phase Shift and we enter an off-limits area while not in one, it's time to stop
+		return FALSE
+	if(is_type_in_typecache(target_area, GLOB.wraith_no_incorporeal_pass_areas_dropship) && !is_type_in_typecache(current_area, GLOB.wraith_no_incorporeal_pass_areas_dropship) && (SSmonitor.gamestate == GROUNDSIDE)) //If we're incorporeal via Phase Shift and we try to enter an off-limits dropship area while not in one without the dropship being crashed, it's time to stop
 		return FALSE
 	return TRUE


### PR DESCRIPTION
## About The Pull Request

1. Wraiths can no longer use Phase Shift while in the space of a phase blocking shutter, even if it's open.
2. Materializing in a solid object with Phase Shift no longer deducts plasma; it counts as if you had Resynced instead.
3. While the fight is Groundside Wraiths cannot phase shift into dropship area tiles from non-dropship area tiles.
4. General minor improvements to Wraith code.

## Why It's Good For The Game

Fixes some lingering issues with phase shift.

Improves Wraith code quality.

## Changelog
:cl:
fix: Wraiths can no longer use Phase Shift while in the space of a phase blocking shutter, even if it's open.
fix: Materializing in a solid object with Phase Shift no longer deducts plasma; it counts as if you had Resynced instead.
balance: While the fight is Groundside Wraiths cannot phase shift into dropship area tiles from non-dropship area tiles.
refactor: General minor improvements to Wraith code.
/:cl: