### PR TITLE
Lets fuel puddles catch on fire from most burning things

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -195,6 +195,7 @@
 // /turf signals
 #define COMSIG_TURF_CHANGE "turf_change"						//from base of turf/ChangeTurf(): (path, list/new_baseturfs, flags, list/transferring_comps)
 #define COMSIG_TURF_WEED_REMOVED "turf_weed_removed"
+#define COMSIG_TURF_LANDED "turf_landed"						//From atom/movable/throw_at, sent right after a throw ends
 
 // /obj signals
 #define COMSIG_OBJ_SETANCHORED "obj_setanchored"				//called in /obj/structure/setAnchored(): (value)

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -195,7 +195,7 @@
 // /turf signals
 #define COMSIG_TURF_CHANGE "turf_change"						//from base of turf/ChangeTurf(): (path, list/new_baseturfs, flags, list/transferring_comps)
 #define COMSIG_TURF_WEED_REMOVED "turf_weed_removed"
-#define COMSIG_TURF_LANDED "turf_landed"						//From atom/movable/throw_at, sent right after a throw ends
+#define COMSIG_TURF_THROW_ENDED_HERE "turf_throw_ended_here"						//From atom/movable/throw_at, sent right after a throw ends
 
 // /obj signals
 #define COMSIG_OBJ_SETANCHORED "obj_setanchored"				//called in /obj/structure/setAnchored(): (value)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -529,6 +529,7 @@
 		throw_impact(get_turf(src), speed)
 	if(loc)
 		stop_throw()
+		SEND_SIGNAL(loc, COMSIG_TURF_LANDED, src)
 	SEND_SIGNAL(src, COMSIG_MOVABLE_POST_THROW)
 
 /// Annul all throw var to ensure a clean exit out of throw state

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -529,7 +529,7 @@
 		throw_impact(get_turf(src), speed)
 	if(loc)
 		stop_throw()
-		SEND_SIGNAL(loc, COMSIG_TURF_LANDED, src)
+		SEND_SIGNAL(loc, COMSIG_TURF_THROW_ENDED_HERE, src)
 	SEND_SIGNAL(src, COMSIG_MOVABLE_POST_THROW)
 
 /// Annul all throw var to ensure a clean exit out of throw state

--- a/code/game/objects/effects/decals/Cleanable/fuel.dm
+++ b/code/game/objects/effects/decals/Cleanable/fuel.dm
@@ -79,15 +79,16 @@
 /obj/effect/decal/cleanable/liquid_fuel/attackby(obj/item/I, mob/user, params)
 	. = ..()
 	if(I.damtype == BURN)
-		ignite_fuel()
-		user.visible_message(span_notice("[user] ignites \the [src]"), span_notice("You ignite some fuel on [src]"))
+		ignite_fuel(I)
 		log_attack("[key_name(user)] ignites [src] in fuel in [AREACOORD(user)]")
 
 /obj/effect/decal/cleanable/liquid_fuel/flamer_fire_act()
 	. = ..()
 	ignite_fuel()
 
-/obj/effect/decal/cleanable/liquid_fuel/proc/ignite_fuel()
+/obj/effect/decal/cleanable/liquid_fuel/proc/ignite_fuel(igniter)
+	if(igniter)
+		visible_message(span_warning("[igniter] ignites the spilled fuel!"))
 	new /obj/flamer_fire(loc, fire_lvl, burn_lvl, f_color)
 	var/turf/S = get_turf(src)
 	for(var/D in CARDINAL_DIRS)
@@ -108,8 +109,7 @@
 			return
 	else
 		return
-	visible_message(span_warning("The spilled fuel catches fire!"))
-	ignite_fuel()
+	ignite_fuel(igniter)
 
 ///Wrapper for ignition via signals rather than from crossed
 /obj/effect/decal/cleanable/liquid_fuel/proc/ignite_check_wrapper(signal_source, atom/movable/igniter)

--- a/code/game/objects/effects/decals/Cleanable/fuel.dm
+++ b/code/game/objects/effects/decals/Cleanable/fuel.dm
@@ -78,7 +78,7 @@
 
 /obj/effect/decal/cleanable/liquid_fuel/attackby(obj/item/I, mob/user, params)
 	. = ..()
-	if(I.damtype == "fire")
+	if(I.damtype == BURN)
 		ignite_fuel()
 		user.visible_message(span_notice("[user] ignites \the [src]"), span_notice("You ignite some fuel on [src]"))
 		log_attack("[key_name(user)] ignites [src] in fuel in [AREACOORD(user)]")

--- a/code/game/objects/effects/decals/Cleanable/fuel.dm
+++ b/code/game/objects/effects/decals/Cleanable/fuel.dm
@@ -38,7 +38,7 @@
 	. = ..()
 	if(isitem(AM))
 		var/obj/item/igniter = AM
-		if(igniter.damtype != "fire")
+		if(igniter.damtype != BURN)
 			return
 		addtimer(CALLBACK(src, .proc/crossed_ignite, igniter), 1) //Just to make sure it wasn't thrown over
 	if(isliving(AM))

--- a/code/game/objects/effects/decals/Cleanable/fuel.dm
+++ b/code/game/objects/effects/decals/Cleanable/fuel.dm
@@ -110,7 +110,8 @@
 		var/mob/living/burner_mob = igniter
 		if(!burner_mob.on_fire)
 			return
-	else return
+	else
+		return
 	visible_message(span_warning("The spilled fuel catches fire!"))
 	ignite_fuel()
 

--- a/code/game/objects/effects/decals/Cleanable/fuel.dm
+++ b/code/game/objects/effects/decals/Cleanable/fuel.dm
@@ -35,10 +35,6 @@
 	fuel_spread()
 	RegisterSignal(loc, COMSIG_TURF_LANDED, .proc/ignite_check_wrapper)
 
-/obj/effect/decal/cleanable/liquid_fuel/Destroy()
-	UnregisterSignal(loc, COMSIG_TURF_LANDED)
-	return ..()
-
 /obj/effect/decal/cleanable/liquid_fuel/Crossed(atom/movable/AM)
 	. = ..()
 	if(AM.throwing)

--- a/code/game/objects/effects/decals/Cleanable/fuel.dm
+++ b/code/game/objects/effects/decals/Cleanable/fuel.dm
@@ -34,6 +34,18 @@
 		qdel(other)
 	fuel_spread()
 
+/obj/effect/decal/cleanable/liquid_fuel/Crossed(atom/movable/AM)
+	. = ..()
+	if(isitem(AM))
+		var/obj/item/igniter = AM
+		if(igniter.damtype != "fire")
+			return
+		addtimer(CALLBACK(src, .proc/crossed_ignite, igniter), 1) //Just to make sure it wasn't thrown over
+	if(isliving(AM))
+		var/mob/living/burner_mob = AM
+		if(!burner_mob.on_fire)
+			return
+		addtimer(CALLBACK(src, .proc/crossed_ignite, burner_mob), 1)
 
 /obj/effect/decal/cleanable/liquid_fuel/proc/fuel_spread()
 	//Allows liquid fuels to sometimes flow into other tiles.
@@ -72,7 +84,7 @@
 
 /obj/effect/decal/cleanable/liquid_fuel/attackby(obj/item/I, mob/user, params)
 	. = ..()
-	if(istype(I, /obj/item/tool/lighter))
+	if(I.damtype == "fire")
 		ignite_fuel()
 		user.visible_message(span_notice("[user] ignites \the [src]"), span_notice("You ignite some fuel on [src]"))
 		log_attack("[key_name(user)] ignites [src] in fuel in [AREACOORD(user)]")
@@ -89,6 +101,12 @@
 		for(var/obj/effect/decal/cleanable/liquid_fuel/other in T)
 			INVOKE_NEXT_TICK(other, .proc/ignite_fuel)	//Spread effect
 	qdel(src)
+
+///Ignites when something hot enters our loc, but only if it doesn't immediately leave
+/obj/effect/decal/cleanable/liquid_fuel/proc/crossed_ignite(atom/movable/igniter)
+	if(igniter.loc == loc)
+		visible_message(span_warning("The spilled fuel catches fire!"))
+		ignite_fuel()
 
 /obj/effect/decal/cleanable/liquid_fuel/flamethrower_fuel
 	icon_state = "mustard"

--- a/code/game/objects/effects/decals/Cleanable/fuel.dm
+++ b/code/game/objects/effects/decals/Cleanable/fuel.dm
@@ -33,7 +33,7 @@
 		amount += other.amount
 		qdel(other)
 	fuel_spread()
-	RegisterSignal(loc, COMSIG_TURF_LANDED, .proc/ignite_check_wrapper)
+	RegisterSignal(loc, COMSIG_TURF_THROW_ENDED_HERE, .proc/ignite_check_wrapper)
 
 /obj/effect/decal/cleanable/liquid_fuel/Crossed(atom/movable/AM)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
More specifically, when anything on fire (active welders, lit cigarettes, lighters) lands on or hits them, or when a mob on fire walks over them.

## Why It's Good For The Game
Doesn't make sense that the only things which ignites fuel puddles are existing ground fires and lighters, especially since the lighter didn't even have to be on before. Plus throwing a cigarette to light a fuel spill up is cool.

## Changelog
:cl:
add: Most things on fire will ignite fuel puddles.
/:cl: