### PR TITLE
Research outpost balance changes for crash & tweaks.

### DIFF
--- a/_maps/map_files/Research_Outpost/Research_Outpost.dmm
+++ b/_maps/map_files/Research_Outpost/Research_Outpost.dmm
@@ -308,7 +308,7 @@
 /area/outpost/cargo)
 "bG" = (
 /obj/docking_port/stationary/crashmode,
-/turf/open/floor/plating/asteroidwarning,
+/turf/open/floor/plating/ground/mars/random/sand,
 /area/outpost/yard/central)
 "bI" = (
 /obj/effect/landmark/corpsespawner/scientist{
@@ -1331,7 +1331,6 @@
 /turf/open/floor/tile/dark,
 /area/outpost/brig/wardens_office)
 "he" = (
-/obj/effect/landmark/xeno_resin_door,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 6
@@ -3599,12 +3598,11 @@
 /turf/open/floor/tile/dark/brown2/corner,
 /area/outpost/dormitories)
 "sC" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 4
 	},
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/mineral/bigred,
-/area/outpost/lz2)
+/area/outpost/caves/south)
 "sI" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -3633,6 +3631,9 @@
 /area/outpost/hallway/east)
 "sP" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/effect/landmark/xeno_resin_door,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 1
@@ -4445,8 +4446,8 @@
 /area/outpost/arrivals)
 "xv" = (
 /obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/mars/cavetodirt{
-	dir = 4
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
 	},
 /area/outpost/caves/south)
 "xw" = (
@@ -4664,10 +4665,6 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/dmg1,
 /area/outpost/medbay)
-"yJ" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/mineral/bigred,
-/area/outpost/lz2)
 "yK" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 1
@@ -5631,6 +5628,7 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
 	},
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral/bigred,
 /area/outpost/caves/south_east)
 "Em" = (
@@ -8341,6 +8339,8 @@
 /area/outpost/brig/armoury)
 "RU" = (
 /obj/effect/landmark/xeno_resin_door,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 1
@@ -26660,7 +26660,7 @@ Jb
 Jb
 Jb
 Jb
-iu
+Jb
 Jb
 FH
 sY
@@ -27176,7 +27176,7 @@ SH
 SH
 cc
 na
-Jb
+iu
 Jb
 FH
 sY
@@ -31033,10 +31033,10 @@ aN
 ey
 VB
 aN
-EA
+bG
 EA
 oM
-bG
+CY
 EA
 fG
 VJ
@@ -32875,8 +32875,8 @@ Zc
 Zc
 hK
 Bn
-Bn
-Bn
+hK
+hK
 hK
 hK
 Bn
@@ -33132,9 +33132,9 @@ Zc
 Zc
 Zc
 hK
-hK
-hK
 Bn
+Bn
+hK
 wy
 bA
 xD
@@ -33389,9 +33389,9 @@ Zc
 Zc
 Zc
 Zc
-Zc
-Zc
-xv
+hK
+hK
+xD
 he
 cU
 cU
@@ -33648,8 +33648,8 @@ Vd
 Zc
 Zc
 Zc
-eK
-eK
+sC
+sC
 PR
 gS
 gS
@@ -33908,7 +33908,7 @@ Cy
 Cy
 Cy
 Cy
-EX
+xv
 Zc
 Zc
 gS
@@ -40095,8 +40095,8 @@ hY
 hY
 KR
 LU
-LU
-tN
+Yb
+np
 np
 TD
 Hm
@@ -40105,7 +40105,7 @@ YO
 Hm
 Hm
 Hm
-LU
+Yb
 Yb
 LU
 LU
@@ -40353,18 +40353,18 @@ hY
 hY
 KR
 LU
-LU
 Yb
-LU
+Yb
+Yb
 El
-LU
+Yb
 Vi
 Hm
 Hm
 Yb
 Yb
 Yb
-Yb
+LU
 LU
 LU
 LU
@@ -40612,10 +40612,10 @@ hY
 KR
 KR
 KR
-yJ
+KR
 KR
 eF
-LU
+Yb
 Hm
 Hm
 Yb
@@ -40870,9 +40870,9 @@ hY
 hY
 hY
 hY
-yJ
-yJ
-sC
+KR
+KR
+eF
 Yb
 Yb
 Yb

--- a/_maps/map_files/Research_Outpost/Research_Outpost.dmm
+++ b/_maps/map_files/Research_Outpost/Research_Outpost.dmm
@@ -270,9 +270,10 @@
 	},
 /area/outpost/science/research)
 "bx" = (
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/outpost/yard/west)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall/r_wall,
+/area/outpost/science/xenobiology)
 "bz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -280,6 +281,12 @@
 	},
 /turf/open/floor/tile/dark/brown2/corner,
 /area/outpost/dormitories)
+"bA" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/cavetodirt{
+	dir = 4
+	},
+/area/outpost/caves/south)
 "bC" = (
 /obj/structure/table,
 /turf/open/floor/tile/dark/purple2,
@@ -299,6 +306,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating/asteroidfloor,
 /area/outpost/cargo)
+"bG" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/asteroidwarning,
+/area/outpost/yard/central)
 "bI" = (
 /obj/effect/landmark/corpsespawner/scientist{
 	corpseback = null;
@@ -461,6 +472,7 @@
 /turf/open/floor/tile/dark,
 /area/outpost/cargo/security)
 "cE" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 9
 	},
@@ -511,6 +523,10 @@
 	dir = 8
 	},
 /area/outpost/hallway/central)
+"cU" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/outpost/caves/south)
 "cV" = (
 /obj/machinery/computer/crew,
 /turf/open/floor/tile/dark/blue2,
@@ -650,6 +666,10 @@
 	dir = 5
 	},
 /area/outpost/hallway/south_west)
+"dP" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/asteroidfloor,
+/area/outpost/arrivals)
 "dQ" = (
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 1
@@ -1219,6 +1239,10 @@
 /obj/machinery/landinglight/ds2/delaytwo,
 /turf/open/floor/marking/asteroidwarning,
 /area/outpost/lz1)
+"gH" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/outpost/caves/north_west)
 "gJ" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/marking/asteroidwarning{
@@ -1308,6 +1332,7 @@
 /area/outpost/brig/wardens_office)
 "he" = (
 /obj/effect/landmark/xeno_resin_door,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 6
 	},
@@ -1581,8 +1606,8 @@
 /area/outpost/medbay/storage)
 "iu" = (
 /obj/docking_port/stationary/crashmode,
-/turf/open/floor/plating,
-/area/outpost/lz1)
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/outpost/yard/west)
 "iw" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 5
@@ -2046,9 +2071,12 @@
 /turf/open/floor/tile/dark/purple2,
 /area/outpost/science)
 "kM" = (
+/obj/structure/xenoautopsy/tank/hugger,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/outpost/caves/south_east)
+/turf/open/floor/tile/dark/purple2{
+	dir = 8
+	},
+/area/outpost/science/xenobiology)
 "kN" = (
 /turf/open/floor/plating/asteroidfloor,
 /area/outpost/yard/south)
@@ -2160,6 +2188,11 @@
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/tile/dark,
 /area/outpost/hallway/west)
+"lg" = (
+/obj/structure/cable,
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/tile/dark/red2,
+/area/outpost/brig)
 "lh" = (
 /obj/structure/table,
 /obj/machinery/light/small{
@@ -2184,7 +2217,6 @@
 /obj/machinery/door/airlock/mainship/research/glass/free_access{
 	dir = 1
 	},
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/tile/dark,
 /area/outpost/science/xenobiology)
 "ll" = (
@@ -2491,6 +2523,7 @@
 /area/outpost/medbay/storage)
 "mX" = (
 /obj/effect/landmark/xeno_resin_door,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/dmg3,
 /area/outpost/science/xenobiology)
 "mY" = (
@@ -3283,8 +3316,8 @@
 /area/outpost/yard/central)
 "rj" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/mars/cavetodirt,
-/area/outpost/caves/north_west)
+/turf/open/floor/tile/dark,
+/area/outpost/science/xenobiology)
 "rl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -3305,7 +3338,6 @@
 /area/outpost/caves/north_west)
 "ro" = (
 /obj/structure/window/framed/colony/reinforced,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/tile/dark2,
 /area/outpost/science/xenobiology)
 "rq" = (
@@ -3566,6 +3598,17 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark/brown2/corner,
 /area/outpost/dormitories)
+"sC" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/bigred,
+/area/outpost/lz2)
+"sI" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/outpost/caves/south_east)
 "sK" = (
 /turf/open/floor/marking/asteroidwarning,
 /area/outpost/yard/east)
@@ -3588,6 +3631,13 @@
 	dir = 6
 	},
 /area/outpost/hallway/east)
+"sP" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/mars/cavetodirt{
+	dir = 1
+	},
+/area/outpost/caves/south_east)
 "sT" = (
 /obj/structure/table,
 /obj/machinery/power/apc/drained{
@@ -3751,6 +3801,11 @@
 	dir = 8
 	},
 /area/outpost/hallway/west)
+"tN" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/outpost/caves/south_east)
 "tO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -4424,12 +4479,24 @@
 	dir = 5
 	},
 /area/outpost/yard/north_east)
+"xB" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 4
+	},
+/area/outpost/caves/east)
 "xC" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
 	},
 /turf/open/floor/tile/dark,
 /area/outpost/arrivals/security)
+"xD" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/mars/cavetodirt{
+	dir = 4
+	},
+/area/outpost/caves/south)
 "xG" = (
 /obj/machinery/power/smes/buildable/empty/dist,
 /obj/structure/cable,
@@ -4450,11 +4517,10 @@
 	},
 /area/outpost/lz1)
 "xN" = (
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/marking/asteroidwarning{
-	dir = 8
-	},
-/area/outpost/arrivals)
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/tile/dark,
+/area/outpost/science/xenobiology)
 "xO" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
@@ -4575,9 +4641,9 @@
 	},
 /area/outpost/hallway/northern)
 "ys" = (
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/plating,
-/area/outpost/lz2)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/dmg2,
+/area/outpost/science/xenobiology)
 "yw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -4587,6 +4653,10 @@
 	dir = 5
 	},
 /area/outpost/hallway/east)
+"yz" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating,
+/area/outpost/lz1)
 "yB" = (
 /turf/closed/wall/r_wall,
 /area/outpost/science/security)
@@ -4594,6 +4664,10 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/dmg1,
 /area/outpost/medbay)
+"yJ" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/bigred,
+/area/outpost/lz2)
 "yK" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 1
@@ -4988,6 +5062,10 @@
 	dir = 5
 	},
 /area/outpost/caves/north_west)
+"AW" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/outpost/caves/south_east)
 "AY" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -5004,6 +5082,7 @@
 "Ba" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold4w/green/hidden,
+/obj/docking_port/stationary/crashmode,
 /turf/open/floor/tile/dark/brown2/corner{
 	dir = 1
 	},
@@ -5033,11 +5112,9 @@
 /turf/open/floor/tile/dark,
 /area/outpost/dormitories)
 "Bk" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/mars/cavetodirt{
-	dir = 8
-	},
-/area/outpost/caves/south_east)
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/outpost/caves/north)
 "Bl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -5047,10 +5124,16 @@
 	dir = 8
 	},
 /area/outpost/hallway/central)
-"Bo" = (
+"Bn" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/outpost/caves/south)
+"Bo" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/mars/cavetodirt{
+	dir = 10
+	},
+/area/outpost/caves/north)
 "Bq" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 8
@@ -5213,6 +5296,7 @@
 /area/outpost/caves/east)
 "Ct" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/tile/dark,
 /area/outpost/science/xenobiology)
 "Cu" = (
@@ -5340,6 +5424,12 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/dark,
 /area/outpost/science)
+"Dk" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/mars/cavetodirt{
+	dir = 5
+	},
+/area/outpost/caves/north_west)
 "Dl" = (
 /obj/structure/closet/toolcloset,
 /obj/effect/decal/cleanable/dirt,
@@ -6166,6 +6256,11 @@
 	dir = 10
 	},
 /area/outpost/brig/armoury)
+"HH" = (
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 4
+	},
+/area/outpost/caves/south_east)
 "HI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -6502,6 +6597,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor/tile/dark2,
 /area/outpost/cargo)
+"JA" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/outpost/caves/north_west)
 "JB" = (
 /turf/open/floor/plating/asteroidwarning{
 	dir = 8
@@ -6877,6 +6976,12 @@
 	},
 /turf/open/floor/tile/dark,
 /area/outpost/engineering)
+"Lo" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/mars/cavetodirt{
+	dir = 10
+	},
+/area/outpost/caves/south_east)
 "Ls" = (
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/outpost/caves/east)
@@ -7091,6 +7196,12 @@
 	dir = 4
 	},
 /area/outpost/arrivals)
+"Mt" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/mars/cavetodirt{
+	dir = 1
+	},
+/area/outpost/caves/south)
 "Mu" = (
 /obj/structure/cable,
 /turf/open/floor/tile/dark/brown2{
@@ -7111,6 +7222,10 @@
 	dir = 5
 	},
 /area/outpost/engineering/security)
+"MA" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/outpost/caves/south)
 "MB" = (
 /obj/structure/cable,
 /obj/machinery/light/small,
@@ -8224,6 +8339,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/dark/red2,
 /area/outpost/brig/armoury)
+"RU" = (
+/obj/effect/landmark/xeno_resin_door,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/mars/cavetodirt{
+	dir = 1
+	},
+/area/outpost/caves/south_east)
 "RV" = (
 /turf/closed/mineral/bigred,
 /area/outpost/yard/south)
@@ -8383,6 +8505,7 @@
 /area/outpost/medbay/security)
 "SR" = (
 /obj/effect/landmark/xeno_resin_door,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/outpost/caves/south_east)
 "SS" = (
@@ -8429,6 +8552,7 @@
 /area/outpost/medbay)
 "Ta" = (
 /obj/effect/landmark/xeno_resin_door,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/dmg1,
 /area/outpost/science/xenobiology)
 "Tb" = (
@@ -8689,7 +8813,9 @@
 /area/outpost/caves/north)
 "Ur" = (
 /obj/effect/landmark/lv624/fog_blocker,
-/turf/open/floor/plating/ground/mars/random/cave,
+/turf/open/floor/plating/ground/mars/cavetodirt{
+	dir = 6
+	},
 /area/outpost/caves/north)
 "Us" = (
 /turf/open/floor/tile/dark/blue2/corner{
@@ -8722,6 +8848,12 @@
 	},
 /turf/closed/mineral/bigred,
 /area/outpost/caves/west)
+"UA" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/mars/cavetodirt{
+	dir = 4
+	},
+/area/outpost/caves/north_west)
 "UB" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/colonist,
@@ -8989,13 +9121,14 @@
 	},
 /area/outpost/caves/west)
 "VY" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/outpost/caves/north_west)
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/outpost/caves/north)
 "VZ" = (
-/obj/docking_port/stationary/crashmode,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral/bigred,
-/area/outpost/caves/east)
+/area/outpost/caves/north_west)
 "Wb" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 8
@@ -9060,10 +9193,6 @@
 	dir = 8
 	},
 /area/outpost/science/rd_office)
-"Wq" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/outpost/caves/south)
 "Wr" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/tile/dark/red2{
@@ -9251,6 +9380,12 @@
 	},
 /turf/open/floor/tile/dark/brown2,
 /area/outpost/hallway/south_west)
+"Xq" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/mars/cavetodirt{
+	dir = 9
+	},
+/area/outpost/caves/south)
 "Xt" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -9527,11 +9662,6 @@
 	dir = 10
 	},
 /area/outpost/cargo/security)
-"YM" = (
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 4
-	},
-/area/outpost/caves/south_east)
 "YO" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -18030,7 +18160,7 @@ Ql
 Ql
 Ql
 Ql
-iu
+Ql
 Ql
 Ql
 Ql
@@ -18249,8 +18379,8 @@ wY
 wY
 wY
 wY
-WU
-hX
+wY
+JA
 hX
 uK
 Cp
@@ -18506,9 +18636,9 @@ wY
 Cp
 Cp
 Cp
-rj
+Xc
 hX
-hX
+JA
 hX
 uw
 Cp
@@ -18764,9 +18894,9 @@ Cp
 Cp
 mo
 Cp
-rj
+Xc
 hX
-hX
+JA
 hX
 uw
 Cp
@@ -19022,9 +19152,9 @@ uP
 Cp
 Cp
 Cp
-wY
 WU
-hX
+WU
+JA
 uK
 Cp
 Cp
@@ -19281,8 +19411,8 @@ Cp
 wY
 wY
 wY
-WU
-WU
+wY
+wY
 Cp
 GI
 Cp
@@ -19301,7 +19431,7 @@ Vt
 Zl
 Zl
 Zl
-xN
+Bq
 Bq
 Bq
 Bq
@@ -19319,7 +19449,7 @@ Ql
 Ql
 Ql
 Ql
-Ql
+yz
 Ql
 Ql
 Ql
@@ -19561,7 +19691,7 @@ Zl
 Zl
 Zl
 Zl
-Zl
+dP
 Zl
 RW
 Eb
@@ -19789,9 +19919,9 @@ WU
 WU
 WU
 wY
-VY
-VY
-wY
+Cp
+Cp
+WU
 wY
 WU
 WU
@@ -20046,11 +20176,11 @@ WU
 WU
 WU
 WU
-WU
+wY
 Cp
 Cp
 WU
-WU
+wY
 WU
 WU
 WU
@@ -20304,11 +20434,11 @@ WU
 WU
 WU
 WU
-WU
+VZ
 Cp
 Cp
 WU
-WU
+wY
 WU
 WU
 WU
@@ -20562,11 +20692,11 @@ WU
 WU
 WU
 WU
+gH
 Cp
 Cp
 Cp
-Cp
-WU
+wY
 WU
 WU
 WU
@@ -20613,7 +20743,7 @@ Ql
 Ql
 Ql
 Ql
-iu
+Ql
 WI
 Ql
 Ql
@@ -20820,11 +20950,11 @@ WU
 hX
 hX
 hX
-Ny
+Dk
 hA
 hA
 KY
-Cp
+gH
 WU
 WU
 WU
@@ -21078,11 +21208,11 @@ hX
 hX
 hX
 hX
-hX
-hX
-hX
-Ny
-hA
+JA
+JA
+JA
+Dk
+UA
 hA
 Cp
 WU
@@ -21879,7 +22009,7 @@ cc
 cc
 SH
 SH
-SH
+cc
 zU
 KZ
 KZ
@@ -22137,8 +22267,8 @@ SH
 SH
 SH
 SH
-SH
-SH
+cc
+cc
 KZ
 KZ
 KZ
@@ -22395,8 +22525,8 @@ SH
 SH
 SH
 SH
-SH
-SH
+cc
+cc
 KZ
 KZ
 KZ
@@ -22653,8 +22783,8 @@ SH
 SH
 SH
 SH
-SH
-SH
+cc
+cc
 KZ
 KZ
 SH
@@ -22911,8 +23041,8 @@ SH
 SH
 SH
 SH
-SH
-SH
+cc
+cc
 mx
 mx
 SH
@@ -23169,7 +23299,7 @@ SH
 SH
 SH
 SH
-SH
+cc
 cc
 cc
 cc
@@ -23948,7 +24078,7 @@ Jb
 Jb
 bE
 Jb
-bx
+Jb
 Jb
 Jb
 SH
@@ -25449,9 +25579,9 @@ Fy
 Fy
 Fy
 Fy
-Fy
-Fy
-Fy
+gb
+gb
+gb
 Fy
 Fy
 Fy
@@ -25707,17 +25837,17 @@ Fy
 Fy
 Fy
 Fy
+gb
 Fy
-Fy
-Fy
-Fy
-Fy
-Fy
-Fy
-pi
-pi
-pi
-UN
+gb
+gb
+gb
+gb
+gb
+Bk
+Bk
+Bk
+Bo
 OR
 Fy
 TX
@@ -25965,7 +26095,7 @@ Fy
 Fy
 Fy
 Fy
-Fy
+gb
 Fy
 Fy
 Fy
@@ -25975,7 +26105,7 @@ OR
 PK
 pi
 pi
-pi
+Bk
 Fy
 Fy
 TX
@@ -26223,7 +26353,7 @@ Fy
 Fy
 Fy
 Fy
-Fy
+gb
 Fy
 Fy
 Fy
@@ -26231,9 +26361,9 @@ Fy
 OR
 iH
 pi
+Pb
 pi
-pi
-Fy
+gb
 Fy
 Fy
 TX
@@ -26481,7 +26611,7 @@ Fy
 Fy
 Fy
 Fy
-Fy
+gb
 Fy
 Fy
 Fy
@@ -26491,7 +26621,7 @@ pi
 pi
 pi
 pi
-Fy
+gb
 Fy
 Fy
 TX
@@ -26522,7 +26652,7 @@ SH
 SH
 SH
 SH
-SH
+cc
 hx
 Qq
 Jb
@@ -26530,7 +26660,7 @@ Jb
 Jb
 Jb
 Jb
-Jb
+iu
 Jb
 FH
 sY
@@ -26739,19 +26869,19 @@ Fy
 Fy
 Fy
 Fy
+gb
 Fy
 Fy
-Fy
+Pb
 pi
 pi
+Pb
 pi
 pi
-pi
-pi
-pi
-pi
-Fy
-Fy
+Pb
+Bk
+gb
+gb
 TX
 TX
 TX
@@ -26998,18 +27128,18 @@ Fy
 Fy
 Fy
 gb
-gb
-gb
-Ur
-Ur
-Ur
+Fy
+Fy
+pi
+pi
+pi
 Fy
 pi
 pi
 pi
 pi
 pi
-Fy
+gb
 Fy
 Fy
 Fy
@@ -27260,14 +27390,14 @@ Fy
 pi
 pi
 pi
-gb
 Fy
 Fy
+Fy
 pi
 pi
 pi
 pi
-pi
+Bk
 Fy
 Fy
 Fy
@@ -27518,14 +27648,14 @@ pi
 pi
 Pb
 Fy
-gb
+Fy
 Fy
 Fy
 Fy
 pi
 pi
 pi
-Vh
+Ur
 OR
 OR
 Fy
@@ -27776,14 +27906,14 @@ pi
 GA
 pi
 Fy
-gb
 Fy
 Fy
 Fy
-pi
+Fy
+Pb
 pi
 Co
-OR
+VY
 OR
 OR
 vj
@@ -28034,14 +28164,14 @@ pi
 pi
 pi
 Fy
-gb
+Fy
 Fy
 Fy
 pi
 pi
 pi
 Co
-OR
+VY
 OR
 OR
 vj
@@ -28292,14 +28422,14 @@ pi
 pi
 Pb
 pi
-gb
+Fy
 Fy
 Fy
 pi
 pi
 pi
 Fy
-OR
+VY
 OR
 OR
 vj
@@ -28550,14 +28680,14 @@ Fy
 pi
 pi
 pi
-Ur
-Fy
-pi
-pi
 pi
 Fy
-Fy
-OR
+pi
+Pb
+pi
+gb
+gb
+VY
 OR
 OR
 vj
@@ -28806,14 +28936,14 @@ Fy
 gb
 gb
 gb
-Ur
-Ur
-Ur
+pi
+pi
+Pb
 pi
 pi
 pi
 pi
-Fy
+gb
 Fy
 Fy
 OR
@@ -29063,15 +29193,15 @@ Fy
 Fy
 Fy
 Fy
-Fy
-Fy
+gb
+gb
 pi
 pi
 pi
 pi
 pi
 Fy
-Fy
+gb
 Fy
 Fy
 Fy
@@ -29322,14 +29452,14 @@ Fy
 Fy
 Fy
 Fy
+gb
 Fy
 Fy
-Fy
-pi
-pi
-pi
-pi
-Fy
+Bk
+Bk
+Bk
+Bk
+gb
 Fy
 Fy
 Fy
@@ -29580,10 +29710,10 @@ Fy
 Fy
 Fy
 Fy
-Fy
-Fy
-Fy
-Fy
+gb
+gb
+gb
+gb
 pi
 pi
 Vh
@@ -30906,7 +31036,7 @@ aN
 EA
 EA
 oM
-CY
+bG
 EA
 fG
 VJ
@@ -31454,7 +31584,7 @@ tm
 tm
 gS
 gS
-Uv
+Xq
 gP
 gP
 gP
@@ -31712,11 +31842,11 @@ gS
 gS
 gS
 gS
-wM
-Bo
+Mt
+hK
 nP
 hK
-hK
+MA
 gP
 Zc
 Zc
@@ -31970,10 +32100,10 @@ Zc
 gS
 gS
 Uv
+Bn
 hK
-Bo
 hK
-Wq
+hK
 hK
 gP
 Zc
@@ -32228,8 +32358,8 @@ Zc
 Zc
 gS
 wM
+Bn
 hK
-Bo
 hK
 hK
 nP
@@ -32486,11 +32616,11 @@ Zc
 Zc
 Zc
 hK
+Bn
 hK
-Bo
-Bo
-Bo
-Bo
+hK
+hK
+hK
 gP
 Zc
 Zc
@@ -32744,12 +32874,12 @@ Zc
 Zc
 Zc
 hK
+Bn
+Bn
+Bn
 hK
 hK
-hK
-hK
-hK
-hK
+Bn
 Zc
 Zc
 Zc
@@ -32934,9 +33064,9 @@ VP
 VP
 VP
 VP
-Je
-Je
-Je
+VP
+VP
+VP
 Je
 Je
 mA
@@ -33001,13 +33131,13 @@ Zc
 Zc
 Zc
 Zc
-Zc
 hK
 hK
 hK
+Bn
 wy
-wy
-wy
+bA
+xD
 Zc
 Zc
 Zc
@@ -33194,7 +33324,7 @@ Gn
 ro
 sb
 iY
-iY
+kM
 fc
 Je
 IY
@@ -33263,9 +33393,9 @@ Zc
 Zc
 xv
 he
-gS
-gS
-gS
+cU
+cU
+cU
 gS
 Zc
 Zc
@@ -33452,7 +33582,7 @@ Gn
 lk
 Dv
 Gn
-Gn
+rj
 aO
 Je
 IY
@@ -33710,7 +33840,7 @@ Gn
 ro
 Dv
 Gn
-Gn
+rj
 id
 Je
 Je
@@ -34226,7 +34356,7 @@ Gn
 ro
 Dv
 Gn
-wP
+xN
 uY
 ll
 jh
@@ -34484,7 +34614,7 @@ Gn
 ro
 cC
 qH
-Gn
+rj
 nn
 Je
 Je
@@ -34742,7 +34872,7 @@ Gn
 ro
 eG
 Gn
-Gn
+rj
 uY
 Je
 Af
@@ -35000,7 +35130,7 @@ Gn
 ro
 fp
 Na
-Na
+ys
 Zq
 Je
 RL
@@ -35256,7 +35386,7 @@ VP
 VP
 VP
 VP
-Je
+bx
 Ta
 mX
 Je
@@ -37893,8 +38023,8 @@ Mm
 Hb
 Gm
 eA
-eA
-eA
+Xi
+Xi
 Xi
 LU
 Hm
@@ -38152,7 +38282,7 @@ JI
 Gm
 eA
 eA
-eA
+Xi
 Xi
 LU
 LU
@@ -38398,7 +38528,7 @@ Xi
 ZQ
 Ar
 xg
-xg
+xB
 uo
 xg
 xg
@@ -38410,7 +38540,7 @@ ae
 zf
 eA
 eA
-eA
+Xi
 Xi
 LU
 LU
@@ -38918,13 +39048,13 @@ eA
 HD
 Pg
 Pg
-Pg
+Xi
 wQ
 Hb
 Gm
 Xi
 Xi
-Xi
+Ls
 Ls
 RD
 eA
@@ -39157,7 +39287,7 @@ MZ
 RH
 Py
 iM
-cN
+lg
 XP
 YC
 Bx
@@ -39183,25 +39313,25 @@ Gm
 Xi
 Xi
 Xi
-Xi
-Xi
+Ls
+RD
 eA
 uf
 zK
-YM
 UT
-LU
+UT
+UT
+RU
 SR
-SR
-LU
-LU
-LU
-LU
-LU
-LU
-jk
-UT
-UT
+Yb
+Yb
+Yb
+Yb
+Yb
+Yb
+Lo
+AW
+AW
 cE
 Hm
 Hm
@@ -39433,7 +39563,7 @@ Xi
 Xi
 Xi
 Xi
-VZ
+Xi
 Xi
 RD
 Hb
@@ -39443,24 +39573,24 @@ Xi
 Xi
 Xi
 Xi
-Xi
+wQ
 uf
 uf
-uf
+zK
+HH
+HH
+sP
+Hm
+Hm
+LU
+LU
 LU
 LU
 Hm
 Hm
-Hm
-LU
-Yb
-Yb
-Yb
-kM
-kM
-Bk
 eu
-Hm
+eu
+sI
 Hm
 Hm
 Hm
@@ -39707,18 +39837,18 @@ Mk
 Mk
 Qw
 Qw
-np
+tN
 np
 Hm
 Hm
-kM
+Hm
 Hm
 Hm
 Hm
 Vi
-kM
 Hm
 Hm
+sI
 LU
 LU
 LU
@@ -39966,17 +40096,17 @@ hY
 KR
 LU
 LU
-np
+tN
 np
 TD
-kM
+Hm
 Hm
 YO
 Hm
 Hm
-kM
+Hm
 LU
-LU
+Yb
 LU
 LU
 LU
@@ -40224,17 +40354,17 @@ hY
 KR
 LU
 LU
-LU
+Yb
 LU
 El
-Yb
+LU
 Vi
 Hm
 Hm
 Yb
 Yb
-LU
-LU
+Yb
+Yb
 LU
 LU
 LU
@@ -40482,10 +40612,10 @@ hY
 KR
 KR
 KR
-KR
+yJ
 KR
 eF
-Yb
+LU
 Hm
 Hm
 Yb
@@ -40740,9 +40870,9 @@ hY
 hY
 hY
 hY
-KR
-KR
-eF
+yJ
+yJ
+sC
 Yb
 Yb
 Yb
@@ -41240,7 +41370,7 @@ vo
 vo
 vo
 vo
-ys
+vo
 vo
 vo
 vo
@@ -43823,7 +43953,7 @@ vo
 vo
 vo
 vo
-ys
+vo
 Vz
 vo
 vo


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Balances Crash locations for fairness towards Xenos, removing the chance of location blocking that Xenos cant access, while also widening fog for certain silos so exploiters cant destroy them anymore.

## Why It's Good For The Game

Marines have had it incredibly easy to crash for a long time, no developer has wanted to do anything for it, this is my first step to trying to balance it while making it so that both teams have a fighting challenge against each other. By removing the chance of blockage from inaccessible rocks and the chance of silos being glitch destroyed. Also gives marines more of a challenge and Xenos fairness, at this point, everyone hates crash so I want to try and make it fun again.

## Changelog
:cl:
balance: no more crash locations for canterbury that block the sides in a way that makes it impossible for Xenos to access.
balance: made fogs for silos in crash that could be destroyed via glitching wider so now it will be impossible as marines should not be able to destroy them.
expansion: 3 new canterbury crash locations
balance: removes some rock walls to make new & old crash locations a bit more accessible.
/:cl:

