### PR TITLE
Shitcode the boiler into having a faster ROF depending on the amount of ammo stored

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
@@ -117,7 +117,7 @@
 
 /datum/action/xeno_action/activable/bombard/get_cooldown()
 	var/mob/living/carbon/xenomorph/boiler/X = owner
-	return X.updated_delay
+	return X.xeno_caste.bomb_delay - ((X.neuro_ammo + X.corrosive_ammo) * X.xeno_caste.ammo_multiplier)
 
 /datum/action/xeno_action/activable/bombard/on_cooldown_finish()
 	to_chat(owner, span_notice("We feel your toxin glands swell. We are able to bombard an area again."))

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
@@ -93,6 +93,7 @@
 	else
 		X.neuro_ammo++
 		to_chat(X, span_notice("We prepare a neurotoxic gas globule."))
+	X.updated_delay -= 50
 	X.update_boiler_glow()
 	update_button_icon()
 
@@ -116,7 +117,9 @@
 
 /datum/action/xeno_action/activable/bombard/get_cooldown()
 	var/mob/living/carbon/xenomorph/boiler/X = owner
-	return X.xeno_caste.bomb_delay
+	var/fire_delayyyyyyy = 0
+	fire_delayyyyyyy = (X.updated_delay)
+	return fire_delayyyyyyy
 
 /datum/action/xeno_action/activable/bombard/on_cooldown_finish()
 	to_chat(owner, span_notice("We feel your toxin glands swell. We are able to bombard an area again."))
@@ -233,6 +236,7 @@
 		GLOB.round_statistics.boiler_neuro_smokes++
 		SSblackbox.record_feedback("tally", "round_statistics", 1, "boiler_neuro_smokes")
 		X.neuro_ammo--
+	X.updated_delay += 50
 
 	X.update_boiler_glow()
 	update_button_icon()

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
@@ -93,7 +93,7 @@
 	else
 		X.neuro_ammo++
 		to_chat(X, span_notice("We prepare a neurotoxic gas globule."))
-	X.updated_delay -= 50
+	X.updated_delay -= 10
 	X.update_boiler_glow()
 	update_button_icon()
 
@@ -117,9 +117,7 @@
 
 /datum/action/xeno_action/activable/bombard/get_cooldown()
 	var/mob/living/carbon/xenomorph/boiler/X = owner
-	var/fire_delayyyyyyy = 0
-	fire_delayyyyyyy = (X.updated_delay)
-	return fire_delayyyyyyy
+	return X.updated_delay
 
 /datum/action/xeno_action/activable/bombard/on_cooldown_finish()
 	to_chat(owner, span_notice("We feel your toxin glands swell. We are able to bombard an area again."))
@@ -236,7 +234,7 @@
 		GLOB.round_statistics.boiler_neuro_smokes++
 		SSblackbox.record_feedback("tally", "round_statistics", 1, "boiler_neuro_smokes")
 		X.neuro_ammo--
-	X.updated_delay += 50
+	X.updated_delay += 10
 
 	X.update_boiler_glow()
 	update_button_icon()

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
@@ -93,7 +93,6 @@
 	else
 		X.neuro_ammo++
 		to_chat(X, span_notice("We prepare a neurotoxic gas globule."))
-	X.updated_delay -= 10
 	X.update_boiler_glow()
 	update_button_icon()
 
@@ -234,7 +233,6 @@
 		GLOB.round_statistics.boiler_neuro_smokes++
 		SSblackbox.record_feedback("tally", "round_statistics", 1, "boiler_neuro_smokes")
 		X.neuro_ammo--
-	X.updated_delay += 10
 
 	X.update_boiler_glow()
 	update_button_icon()

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/boiler.dm
@@ -18,8 +18,6 @@
 	//Boiler ammo
 	var/corrosive_ammo = 0
 	var/neuro_ammo = 0
-	///Bombard delay counter
-	var/updated_delay = 0
 
 ///updates the boiler's glow, based on its base glow/color, and its ammo reserves. More green ammo = more green glow; more yellow = more yellow.
 /mob/living/carbon/xenomorph/boiler/proc/update_boiler_glow()
@@ -46,7 +44,6 @@
 	ammo = GLOB.ammo_list[/datum/ammo/xeno/boiler_gas]
 	update_boiler_glow()
 	RegisterSignal(src, COMSIG_XENOMORPH_GIBBING, .proc/gib_explode)
-	updated_delay = xeno_caste.bomb_delay
 
 // ***************************************
 // *********** Gibbing behaviour

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/boiler.dm
@@ -18,7 +18,8 @@
 	//Boiler ammo
 	var/corrosive_ammo = 0
 	var/neuro_ammo = 0
-
+	///Bombard delay counter
+	var/updated_delay = 0
 
 ///updates the boiler's glow, based on its base glow/color, and its ammo reserves. More green ammo = more green glow; more yellow = more yellow.
 /mob/living/carbon/xenomorph/boiler/proc/update_boiler_glow()
@@ -45,7 +46,7 @@
 	ammo = GLOB.ammo_list[/datum/ammo/xeno/boiler_gas]
 	update_boiler_glow()
 	RegisterSignal(src, COMSIG_XENOMORPH_GIBBING, .proc/gib_explode)
-
+	updated_delay = xeno_caste.bomb_delay
 
 // ***************************************
 // *********** Gibbing behaviour

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
@@ -44,6 +44,7 @@
 	max_ammo = 4
 	bomb_strength = 1 //Multiplier to the effectiveness of the boiler glob.
 	bomb_delay = 32 SECONDS
+	ammo_multiplier = 2 SECONDS
 
 	acid_spray_duration = 10 SECONDS
 	acid_spray_damage = 16

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
@@ -43,7 +43,7 @@
 	// *** Boiler Abilities *** //
 	max_ammo = 4
 	bomb_strength = 1 //Multiplier to the effectiveness of the boiler glob.
-	bomb_delay = 30 SECONDS
+	bomb_delay = 32 SECONDS
 
 	acid_spray_duration = 10 SECONDS
 	acid_spray_damage = 16
@@ -100,7 +100,7 @@
 	max_ammo = 5
 	bomb_strength = 1.1
 
-	bomb_delay = 30 SECONDS
+	bomb_delay = 32 SECONDS
 
 /datum/xeno_caste/boiler/elder
 	upgrade_name = "Elder"
@@ -136,7 +136,7 @@
 	max_ammo = 6
 	bomb_strength = 1.2
 
-	bomb_delay = 30 SECONDS
+	bomb_delay = 32 SECONDS
 
 /datum/xeno_caste/boiler/ancient
 	upgrade_name = "Ancient"
@@ -173,4 +173,4 @@
 	max_ammo = 7
 	bomb_strength = 1.3
 
-	bomb_delay = 25 SECONDS
+	bomb_delay = 27 SECONDS

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/castedatum_boiler.dm
@@ -44,7 +44,7 @@
 	max_ammo = 4
 	bomb_strength = 1 //Multiplier to the effectiveness of the boiler glob.
 	bomb_delay = 32 SECONDS
-	ammo_multiplier = 2 SECONDS
+	ammo_multiplier = 1.5 SECONDS
 
 	acid_spray_duration = 10 SECONDS
 	acid_spray_damage = 16

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -141,6 +141,8 @@
 	var/bomb_strength = 0
 	///Delay between firing the bombard ability for boilers
 	var/bomb_delay = 0
+	///Used to reduce cooldown for the boiler
+	var/ammo_multiplier = 0
 
 	// *** Carrier Abilities *** //
 	///maximum amount of huggers a carrier can carry at one time.


### PR DESCRIPTION
## About The Pull Request
This makes the boiler ammo feature _NOT A COMPLETE NOOB TRAP!_
It gives some advantage and a raison to use it, instead of simply gimping xenos while adding complexity.


## Changelog
:cl:
balance: made the boiler bombard cooldown when it has more acid stored
/:cl:
