### PR TITLE
Clicking a resin floor as xeno won't trigger attack delay

### DIFF
--- a/code/_onclick/xeno.dm
+++ b/code/_onclick/xeno.dm
@@ -2,7 +2,7 @@
 	if(lying_angle)
 		return FALSE
 
-	if(!isopenturf(A)) //We don't care about open turfs; they don't trigger our melee click cooldown
+	if(!(isopenturf(A) || istype(A, /obj/effect/alien/weeds))) //We don't care about open turfs; they don't trigger our melee click cooldown
 		changeNext_move(xeno_caste ? xeno_caste.attack_delay : CLICK_CD_MELEE)
 
 	var/atom/S = A.handle_barriers(src)


### PR DESCRIPTION
## About The Pull Request
There's an attack delay after clicking most things as a xeno, but this isn't triggered by open turfs. Since resin floors are basically the equivalent of an open turf anywhere xeno-controlled, this removes the delay after clicking them too.

## Why It's Good For The Game
Functional consistency.

## Changelog
:cl:
fix: Xenos don't have an attack delay after clicking on weeds, the same way they don't after clicking normal floors.
/:cl: