### PR TITLE
Disable the OB beeping warning

### DIFF
--- a/code/game/objects/machinery/overwatch.dm
+++ b/code/game/objects/machinery/overwatch.dm
@@ -480,8 +480,6 @@ GLOBAL_LIST_EMPTY(active_cas_targets)
 		message_admins("[ADMIN_TPMONTY(usr)] fired a [warhead_type]for squad [current_squad] in [ADMIN_VERBOSEJMP(T)].")
 	visible_message(span_boldnotice("Orbital bombardment request accepted. Orbital cannons are now calibrating."))
 	send_to_squads("Initializing fire coordinates...")
-	if(selected_target)
-		playsound(selected_target.loc,'sound/effects/alert.ogg', 50, 1, 20)  //mostly used to warn xenos as the new ob sounds have a quiet beginning
 
 	addtimer(CALLBACK(src, .proc/send_to_squads, "Transmitting beacon feed..."), 1.5 SECONDS)
 	addtimer(CALLBACK(src, .proc/send_to_squads, "Calibrating trajectory window..."), 3 SECONDS)


### PR DESCRIPTION
## About The Pull Request
This PR disables the triple beep alert sound we get from OB beacons.

## Why It's Good For The Game
I think this warning is far too obvious for xenomorphs as to when an OB is coming, especially given the rather lenghty time they take to land. This kind of forces them to work as maze removers, which is a little lame in my opinion.

## Changelog
:cl:
balance: removed the OB warning beep
/:cl:

