### PR TITLE
Fix typo with the snapping emote and hugging emote

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -401,7 +401,7 @@
 /datum/emote/living/carbon/human/snap
 	key = "snap"
 	key_third_person = "snaps"
-	message = "snaps their fingers."
+	message = "snaps their fingers"
 	emote_type = EMOTE_AUDIBLE
 	flags_emote = EMOTE_RESTRAINT_CHECK|EMOTE_MUZZLE_IGNORE|EMOTE_ARMS_CHECK
 	sound = 'sound/misc/fingersnap.ogg'
@@ -409,7 +409,7 @@
 /datum/emote/living/carbon/human/hug
 	key = "hug"
 	key_third_person = "hugs"
-	message = "hugs themself."
+	message = "hugs themself"
 	message_param = "hugs %t."
 	flags_emote = EMOTE_RESTRAINT_CHECK
 	emote_type = EMOTE_AUDIBLE


### PR DESCRIPTION
## About The Pull Request
I have no idea why this was happening, but this fixes it.

## Changelog
:cl:
fix: fixed typos in snaps and hugging emotes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
