### PR TITLE
Fixes beer

### DIFF
--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -111,10 +111,10 @@
 	// I dont care about the type of tool, if it triggers multitool act its good enough.
 	hackedcheck = !hackedcheck
 	if(hackedcheck)
-		to_chat(user, emagged_message[0])
+		to_chat(user, emagged_message[1])
 		dispensable_reagents += emagged_reagents
 	else
-		to_chat(user, emagged_message[1])
+		to_chat(user, emagged_message[2])
 		dispensable_reagents -= emagged_reagents
 
 
@@ -178,10 +178,14 @@
 		if("dispense")
 			if(!is_operational() || QDELETED(cell))
 				return
+			if(!beaker)
+				return
 			var/reagent_name = params["reagent"]
 			if(!recording_recipe)
-				var/reagent = GLOB.name2reagent[reagent_name]
-				if(beaker && dispensable_reagents.Find(reagent))
+				var/list/reagents = GLOB.name2reagent[reagent_name]
+				for(var/reagent in reagents)
+					if(!dispensable_reagents.Find(reagent))
+						continue
 					var/datum/reagents/R = beaker.reagents
 					var/free = R.maximum_volume - R.total_volume
 					var/actual = min(amount, (cell.charge * powerefficiency)*10, free)
@@ -192,6 +196,7 @@
 					R.add_reagent(reagent, actual)
 
 					work_animation()
+					break
 			else
 				recording_recipe[reagent_name] += amount
 			. = TRUE

--- a/code/modules/reagents/reagents.dm
+++ b/code/modules/reagents/reagents.dm
@@ -5,7 +5,7 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	for (var/t in subtypesof(/datum/reagent))
 		var/datum/reagent/R = t
 		if (length(initial(R.name)))
-			.[ckey(initial(R.name))] = t
+			LAZYADD(.[ckey(initial(R.name))], t)
 
 /// A single reagent
 /datum/reagent


### PR DESCRIPTION
## About The Pull Request
Reagent dispensers use an associated list of names to reagent datums to determine what to dispense, but this breaks when multiple reagents have the same name. Regular beer and soporific beer, in this case, are both just 'beer'. This changes the name2reagent list to key to a list of reagents with that name, which the dispenser can iterate through to find the right one.
Also fixes an index access error with hacking reagent dispensers. Turns out byond lists don't start at 0.

## Why It's Good For The Game
Fixes

## Changelog
:cl:
fix: Reagent dispensers can produce beer properly now.
fix: Hacking reagent dispensers with a multitool actually works.
/:cl: