### PR TITLE
Requisition can export cold marines

### DIFF
--- a/code/game/objects/structures/prop.dm
+++ b/code/game/objects/structures/prop.dm
@@ -126,6 +126,7 @@
 	bound_height = 96
 	resistance_flags = UNACIDABLE
 
+GLOBAL_LIST_EMPTY(fallen_list)
 
 /obj/structure/prop/mainship/ship_memorial
 	name = "slab of victory"
@@ -135,16 +136,13 @@
 	bound_width = 64
 	bound_height = 32
 	resistance_flags = UNACIDABLE
-	var/list/fallen_list
 
 /obj/structure/prop/mainship/ship_memorial/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/dogtag))
 		var/obj/item/dogtag/D = I
 		if(D.fallen_names)
 			to_chat(user, span_notice("You add [D] to [src]."))
-			if(!fallen_list)
-				fallen_list = list()
-			fallen_list += D.fallen_names
+			GLOB.fallen_list += D.fallen_names
 			qdel(D)
 		return TRUE
 	else
@@ -152,13 +150,13 @@
 
 /obj/structure/prop/mainship/ship_memorial/examine(mob/user)
 	. = ..()
-	if((isobserver(user) || ishuman(user)) && fallen_list)
+	if((isobserver(user) || ishuman(user)) && GLOB.fallen_list.len)
 		var/faltext = ""
-		for(var/i = 1 to fallen_list.len)
-			if(i != fallen_list.len)
-				faltext += "[fallen_list[i]], "
+		for(var/i = 1 to GLOB.fallen_list.len)
+			if(i != GLOB.fallen_list.len)
+				faltext += "[GLOB.fallen_list[i]], "
 			else
-				faltext += fallen_list[i]
+				faltext += GLOB.fallen_list[i]
 		to_chat(user, "[span_notice("To our fallen soldiers:")] <b>[faltext]</b>.")
 
 

--- a/code/modules/reqs/supply.dm
+++ b/code/modules/reqs/supply.dm
@@ -108,7 +108,11 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 						continue
 				if(ishuman(a))
 					var/mob/living/carbon/human/human_to_sell = a
-					if(human_to_sell.stat == DEAD && can_sell_human_body(human_to_sell, faction))
+					if(human_to_sell.stat != DEAD)
+						return FALSE
+					if(istype(human_to_sell.loc, /obj/structure/closet/coffin))
+						continue
+					if(can_sell_human_body(human_to_sell, faction))
 						continue
 				if(is_type_in_typecache(a, GLOB.blacklisted_cargo_types))
 					return FALSE
@@ -195,7 +199,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 
 /datum/export_report/New(_points, _export_name, _faction)
 	points = _points
-	export_name = _export_name 
+	export_name = _export_name
 	faction = _faction
 
 /obj/docking_port/mobile/supply/proc/sell()
@@ -466,7 +470,8 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		if("send")
 			if(supply_shuttle.mode == SHUTTLE_IDLE && is_mainship_level(supply_shuttle.z))
 				if (!supply_shuttle.check_blacklist())
-					to_chat(usr, "For safety reasons, the Automated Storage and Retrieval System cannot store live, friendlies, classified nuclear weaponry or homing beacons.")
+					to_chat(usr, "For safety reasons, the Automated Storage and Retrieval System cannot store live animals, classified nuclear weaponry, or homing beacons. " \
+					+ "Additionally, any marines sent for funeral proceedings must be stored in a coffin.")
 					playsound(supply_shuttle.return_center_turf(), 'sound/machines/buzz-two.ogg', 50, 0)
 				else
 					playsound(supply_shuttle.return_center_turf(), 'sound/machines/elevator_move.ogg', 50, 0)

--- a/code/modules/reqs/supply.dm
+++ b/code/modules/reqs/supply.dm
@@ -110,7 +110,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 					var/mob/living/carbon/human/human_to_sell = a
 					if(human_to_sell.stat != DEAD)
 						return FALSE
-					if(istype(human_to_sell.loc, /obj/structure/closet/coffin))
+					if(istype(human_to_sell.loc, /obj/structure/closet/coffin) && human_to_sell.faction == faction)
 						continue
 					if(can_sell_human_body(human_to_sell, faction))
 						continue
@@ -208,9 +208,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		for(var/atom/movable/AM in shuttle_area)
 			if(AM.anchored)
 				continue
-			var/datum/export_report = AM.supply_export(faction)
-			if(export_report)
-				SSpoints.export_history += export_report
+			AM.supply_export(faction)
 			qdel(AM)
 
 /obj/item/supplytablet

--- a/code/modules/reqs/supply.dm
+++ b/code/modules/reqs/supply.dm
@@ -110,7 +110,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 					var/mob/living/carbon/human/human_to_sell = a
 					if(human_to_sell.stat != DEAD)
 						return FALSE
-					if(istype(human_to_sell.loc, /obj/structure/closet/coffin) && human_to_sell.faction == faction)
+					if(istype(human_to_sell.loc, /obj/structure/closet/coffin) && (human_to_sell.faction == faction) && HAS_TRAIT(human_to_sell, TRAIT_UNDEFIBBABLE))
 						continue
 					if(can_sell_human_body(human_to_sell, faction))
 						continue
@@ -469,7 +469,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 			if(supply_shuttle.mode == SHUTTLE_IDLE && is_mainship_level(supply_shuttle.z))
 				if (!supply_shuttle.check_blacklist())
 					to_chat(usr, "For safety reasons, the Automated Storage and Retrieval System cannot store live animals, classified nuclear weaponry, or homing beacons. " \
-					+ "Additionally, any marines sent for funeral proceedings must be stored in a coffin.")
+					+ "Additionally, any marines sent for funeral proceedings must be stored in a coffin and free of any lingering vitals.")
 					playsound(supply_shuttle.return_center_turf(), 'sound/machines/buzz-two.ogg', 50, 0)
 				else
 					playsound(supply_shuttle.return_center_turf(), 'sound/machines/elevator_move.ogg', 50, 0)

--- a/code/modules/requisitions/supply_export.dm
+++ b/code/modules/requisitions/supply_export.dm
@@ -1,5 +1,6 @@
 /atom/movable/proc/supply_export(faction_selling)
-	return 0
+	for(var/atom/movable/thing_inside in contents)
+		thing_inside.supply_export(faction_selling)
 
 
 /mob/living/carbon/xenomorph/supply_export(faction_selling)
@@ -15,15 +16,18 @@
 		if(XENO_TIER_FOUR)
 			. = 100
 	SSpoints.supply_points[faction_selling] += .
-	return new /datum/export_report(., name, faction_selling)
+	SSpoints.export_history += new /datum/export_report(., name, faction_selling)
 
 /mob/living/carbon/xenomorph/shrike/supply_export(faction_selling)
 	SSpoints.supply_points[faction_selling] += 50
-	return new /datum/export_report(50, name, faction_selling)
+	SSpoints.export_history += new /datum/export_report(50, name, faction_selling)
 
 
 /mob/living/carbon/human/supply_export(faction_selling)
-	switch(job.job_category)
+	if(faction == faction_selling)
+		burial_export(faction_selling)
+		return
+	else switch(job.job_category)
 		if(JOB_CAT_ENGINEERING || JOB_CAT_MEDICAL || JOB_CAT_REQUISITIONS)
 			. = 20
 		if(JOB_CAT_MARINE)
@@ -33,7 +37,100 @@
 		if(JOB_CAT_COMMAND)
 			. = 100
 	SSpoints.supply_points[faction_selling] += .
-	return new /datum/export_report(., name, faction_selling)
+	SSpoints.export_history += new /datum/export_report(., name, faction_selling)
+
+/**Calculates return value of properly prepared corpses, returns a number
+ *
+ * Checks for:
+ **Five minute defib timer
+ **Any brute or burn damage, including internal bleeding
+ **Any limbs requiring repair, bearing an open surgical incision, or carrying high germs
+ **Eye damage or disfigurement
+ **Shrapnel
+ **Full dress uniform: torso, hat, gloves, boots
+ */
+/mob/living/carbon/human/proc/burial_export(faction_selling)
+	var/report_name = name
+	var/list/problems = new()
+	var/payout = 0
+
+	switch(job.job_category)
+		if(JOB_CAT_ENGINEERING || JOB_CAT_MEDICAL || JOB_CAT_REQUISITIONS)
+			payout = 5	//Shipside crew shouldn't be dying in any situation where you can still use requisitions.
+		if(JOB_CAT_MARINE)
+			payout = 20
+		if(JOB_CAT_SILICON)
+			payout = 50	//Silicons can get recycled so they're worth extra
+		if(JOB_CAT_COMMAND)
+			payout = 30
+
+	if(!HAS_TRAIT(src, TRAIT_UNDEFIBBABLE))
+		problems += "lingering vitals"
+		payout = 0
+
+	var/damaged_limbs = 0
+	var/surgery_limbs = 0
+	var/infected_limbs = 0
+	var/tissue_damage = 0
+	for(var/datum/limb/test_limb AS in limbs)
+		if(test_limb.limb_status & (LIMB_BLEEDING|LIMB_BROKEN|LIMB_DESTROYED|LIMB_NECROTIZED|LIMB_AMPUTATED|LIMB_MUTATED))
+			damaged_limbs++
+		if(test_limb.surgery_open_stage)
+			surgery_limbs++
+		if(test_limb.germ_level > INFECTION_LEVEL_ONE)
+			infected_limbs++
+		tissue_damage += test_limb.brute_dam + test_limb.burn_dam
+	if(damaged_limbs)
+		payout -= 3 * damaged_limbs
+		problems += "damaged limbs"
+	if(surgery_limbs)
+		payout -= 5 * surgery_limbs
+		problems += "ongoing surgery"
+	if(infected_limbs)
+		payout -= 3 * infected_limbs
+		problems += "infection"
+	if(tissue_damage > 10)
+		payout -= round(tissue_damage/10)
+		problems += "tissue damage"
+
+
+	if(internal_organs_by_name["eyes"]?.damage)
+		payout -= 3
+		problems |= "ocular damage"
+	if(get_limb("head")?.disfigured)
+		payout -= 10
+		problems += "disfigurement"
+	if(LAZYLEN(embedded_objects))
+		payout -= 5
+		problems += "embedded shrapnel"
+
+	var/bad_fashion
+	//Full dress uniform. Other things being present is fine, but replacing the uniform will naturally remove almost all of it.
+	if(!istype(w_uniform, /obj/item/clothing/under/whites))
+		payout -= 5
+		bad_fashion = TRUE
+	if(!istype(head, /obj/item/clothing/head/white_dress))
+		payout -= 5
+		bad_fashion = TRUE
+	if(!istype(gloves, /obj/item/clothing/gloves/white))
+		payout -= 5
+		bad_fashion = TRUE
+	if(!istype(shoes, /obj/item/clothing/shoes/white))
+		payout -= 5
+		bad_fashion = TRUE
+	if(bad_fashion)
+		problems += "improper dress"
+
+	if(problems.len)
+		report_name += " \[DISCREPANCIES: "
+		for(var/messup in problems)
+			report_name += messup + ", "
+		report_name = copytext(report_name, 1, -2) + "\]"
+		payout = max(payout, 0)
+
+	SSpoints.supply_points[faction_selling] += payout
+	SSpoints.export_history += new /datum/export_report(payout, report_name, faction_selling)
+
 
 /// Return TRUE if the relation between the two factions are bad enough that a bounty is on the human_to_sell head
 /proc/can_sell_human_body(mob/living/carbon/human/human_to_sell, seller_faction)

--- a/code/modules/requisitions/supply_export.dm
+++ b/code/modules/requisitions/supply_export.dm
@@ -46,6 +46,7 @@
  **Any brute or burn damage, including internal bleeding
  **Any limbs requiring repair, bearing an open surgical incision, or carrying high germs
  **Eye damage or disfigurement
+ **Missing synth head, on top of the normal missing limb penalty
  **Shrapnel
  **Full dress uniform: torso, hat, gloves, boots
  **Suicide
@@ -103,6 +104,12 @@
 	if(skullcase.disfigured)
 		payout -= 10
 		problems += "disfigurement"
+
+	//No refunds on broken synths
+	if((species.species_flags & DETACHABLE_HEAD) && (skullcase.limb_status & LIMB_DESTROYED))
+		payout = 0
+		problems += "positronic brain absent"
+
 	if(LAZYLEN(embedded_objects))
 		payout -= 5
 		problems += "embedded shrapnel"

--- a/code/modules/requisitions/supply_export.dm
+++ b/code/modules/requisitions/supply_export.dm
@@ -95,11 +95,12 @@
 		payout -= round(tissue_damage/10)
 		problems += "tissue damage"
 
-
-	if(internal_organs_by_name["eyes"]?.damage)
+	var/datum/internal_organ/eyes/peepers = internal_organs_by_name["eyes"]
+	if(peepers.damage)
 		payout -= 3
 		problems |= "ocular damage"
-	if(get_limb("head")?.disfigured)
+	var/datum/limb/head/skullcase = get_limb("head")
+	if(skullcase.disfigured)
 		payout -= 10
 		problems += "disfigurement"
 	if(LAZYLEN(embedded_objects))

--- a/code/modules/requisitions/supply_export.dm
+++ b/code/modules/requisitions/supply_export.dm
@@ -53,7 +53,7 @@
  */
 /mob/living/carbon/human/proc/burial_export(faction_selling)
 	var/report_name = name
-	var/list/problems = new()
+	var/list/problems = list()
 	var/payout = 0
 
 	switch(job.job_category)

--- a/code/modules/requisitions/supply_export.dm
+++ b/code/modules/requisitions/supply_export.dm
@@ -42,7 +42,6 @@
 /**Calculates return value of properly prepared corpses, handles point payout and export logging.
  *
  * Checks for:
- **Five minute defib timer
  **Any brute or burn damage, including internal bleeding
  **Any limbs requiring repair, bearing an open surgical incision, or carrying high germs
  **Eye damage or disfigurement
@@ -66,10 +65,6 @@
 			payout = 50	//Silicons can get recycled so they're worth extra
 		if(JOB_CAT_COMMAND)
 			payout = 30
-
-	if(!HAS_TRAIT(src, TRAIT_UNDEFIBBABLE))
-		problems += "lingering vitals"
-		payout = 0
 
 	var/damaged_limbs = 0
 	var/surgery_limbs = 0

--- a/code/modules/requisitions/supply_export.dm
+++ b/code/modules/requisitions/supply_export.dm
@@ -48,6 +48,8 @@
  **Eye damage or disfigurement
  **Shrapnel
  **Full dress uniform: torso, hat, gloves, boots
+ **Suicide
+ **Dogtag in memorial, if they've got one
  */
 /mob/living/carbon/human/proc/burial_export(faction_selling)
 	var/report_name = name
@@ -120,6 +122,16 @@
 		bad_fashion = TRUE
 	if(bad_fashion)
 		problems += "improper dress"
+
+	if(istype(wear_id, /obj/item/card/id/dogtag))
+		var/obj/item/card/id/dogtag/our_tag = wear_id
+		if((!our_tag.dogtag_taken) || (!GLOB.fallen_list.Find(our_tag.registered_name)))
+			payout = 0
+			problems += "marine not memorialized"
+
+	if(suiciding)
+		payout = 0
+		problems += "non-combat death"
 
 	if(problems.len)
 		report_name += " \[DISCREPANCIES: "

--- a/code/modules/requisitions/supply_export.dm
+++ b/code/modules/requisitions/supply_export.dm
@@ -22,7 +22,7 @@
 	SSpoints.supply_points[faction_selling] += 50
 	SSpoints.export_history += new /datum/export_report(50, name, faction_selling)
 
-
+///Only handles sale for humans not belonging to the supplied faction, otherwise delegates to burial_export()
 /mob/living/carbon/human/supply_export(faction_selling)
 	if(faction == faction_selling)
 		burial_export(faction_selling)
@@ -39,7 +39,7 @@
 	SSpoints.supply_points[faction_selling] += .
 	SSpoints.export_history += new /datum/export_report(., name, faction_selling)
 
-/**Calculates return value of properly prepared corpses, returns a number
+/**Calculates return value of properly prepared corpses, handles point payout and export logging.
  *
  * Checks for:
  **Five minute defib timer
@@ -49,7 +49,7 @@
  **Missing synth head, on top of the normal missing limb penalty
  **Shrapnel
  **Full dress uniform: torso, hat, gloves, boots
- **Suicide
+ **Suicide/export before shutters open
  **Dogtag in memorial, if they've got one
  */
 /mob/living/carbon/human/proc/burial_export(faction_selling)
@@ -137,7 +137,7 @@
 			payout = 0
 			problems += "marine not memorialized"
 
-	if(suiciding)
+	if(suiciding || SSmonitor.gamestate == SHUTTERS_CLOSED)
 		payout = 0
 		problems += "non-combat death"
 

--- a/code/modules/requisitions/supply_export.dm
+++ b/code/modules/requisitions/supply_export.dm
@@ -27,7 +27,7 @@
 	if(faction == faction_selling)
 		burial_export(faction_selling)
 		return
-	else switch(job.job_category)
+	switch(job.job_category)
 		if(JOB_CAT_ENGINEERING || JOB_CAT_MEDICAL || JOB_CAT_REQUISITIONS)
 			. = 20
 		if(JOB_CAT_MARINE)


### PR DESCRIPTION
## About The Pull Request
Requisition can put marines in coffins (make them out of wood) and ship them off to receive points, with penalties for remaining damage and not dressing them in formal wear. The export report lists any reductions applied.
Marines are worth 20 points each if they're in perfect condition, anyone in command is 30, and synths are 50 because TerraGov can recycle them for another op and you'd be better off reviving them anyway (it's probably still too high). All other shipside staff is only worth 5 at most.
Also enables exporting things which're inside other things.

Todo: 
~~make sure their dogtag's been added to the slab of victory~~
Testing

## Why It's Good For The Game
Gives med docs and requisition something to do during downtime, encourages recovery of perma corpses.

## Changelog
:cl:
add: Humans who've been dead for five minutes can be sent down the req elevator in a coffin. TerraGov will reward you with req points if they're fixed up and dressed in formal wear.
/:cl: