### PR TITLE
Big Red V2.1 - Big additions.

### DIFF
--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -19340,9 +19340,6 @@
 	dir = 8
 	},
 /obj/item/ammo_casing/bullet,
-/obj/machinery/marine_turret/premade{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark2,
 /area/bigredv2/caves/south)
@@ -20278,7 +20275,7 @@
 /turf/open/shuttle/escapepod,
 /area/bigredv2/caves/south)
 "gfg" = (
-/obj/structure/xeno/resin/xeno_turret,
+/obj/effect/landmark/xeno_turret_spawn,
 /turf/open/floor/tile/dark2,
 /area/bigredv2/caves/south)
 "ggp" = (
@@ -20519,9 +20516,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/marine_turret/premade{
-	dir = 8
-	},
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 1
 	},
@@ -20732,6 +20726,14 @@
 	},
 /turf/open/shuttle/escapepod,
 /area/bigredv2/caves/north)
+"ifQ" = (
+/obj/effect/decal/warning_stripes/nscenter,
+/obj/machinery/light/built{
+	dir = 8
+	},
+/obj/effect/landmark/xeno_turret_spawn,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/northeast)
 "igD" = (
 /turf/open/shuttle/elevator/grating,
 /area/bigredv2/caves/south)
@@ -64067,7 +64069,7 @@ aJH
 adZ
 dnl
 vCh
-vCh
+vyZ
 ahw
 vCh
 kKe
@@ -64409,8 +64411,8 @@ aab
 jeY
 jeY
 bHv
-gfg
 utr
+gfg
 tfr
 utr
 qdE
@@ -64505,7 +64507,7 @@ fYE
 sbj
 fYE
 fYE
-hyP
+ifQ
 fYE
 sbj
 fYE

--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -3989,6 +3989,15 @@
 /obj/structure/rack,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/general_offices)
+"aoD" = (
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 2
+	},
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "aoE" = (
 /obj/item/stool,
 /obj/structure/cable,
@@ -11070,7 +11079,10 @@
 "aPo" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall/unmeltable,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "aPq" = (
 /obj/machinery/door/airlock/mainship/research/glass/free_access{
 	dir = 1;
@@ -13801,6 +13813,15 @@
 	dir = 8
 	},
 /area/bigredv2/outside/cargo)
+"bey" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "bez" = (
 /obj/machinery/autolathe,
 /turf/open/floor,
@@ -17134,6 +17155,14 @@
 	dir = 1
 	},
 /area/bigredv2/outside/sw)
+"buT" = (
+/obj/effect/landmark/weed_node,
+/obj/structure/cable,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "buV" = (
 /obj/machinery/light,
 /turf/open/floor/plating,
@@ -19305,11 +19334,13 @@
 "bHv" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/space)
-"bKh" = (
-/obj/structure/cable,
-/obj/effect/landmark/corpsespawner/engineer,
-/turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+"bIZ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "bLJ" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -19324,6 +19355,15 @@
 	},
 /turf/open/floor/prison/darkred/full,
 /area/bigredv2/caves/south)
+"bOy" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 10
+	},
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "bQc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
@@ -19342,7 +19382,10 @@
 /obj/item/ammo_casing/bullet,
 /obj/structure/cable,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "bSC" = (
 /obj/machinery/light{
 	dir = 8
@@ -19351,10 +19394,6 @@
 	dir = 1
 	},
 /area/bigredv2/outside/nw)
-"bTi" = (
-/obj/structure/largecrate/supply/ammo/m41a,
-/turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
 "bTs" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -19375,11 +19414,13 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/security,
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "ccP" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/wall,
@@ -19391,7 +19432,10 @@
 /obj/structure/largecrate/supply/ammo/m41a,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "cfH" = (
 /obj/machinery/miner/damaged/platinum,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -19411,35 +19455,60 @@
 /area/bigredv2/outside/bar)
 "cin" = (
 /obj/structure/largecrate/supply/ammo/m41a_box,
+/obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "ckJ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/se)
+"clx" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/closed/wall/r_wall/unmeltable,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "coa" = (
 /obj/structure/rack,
 /obj/item/weapon/gun/shotgun/pump/cmb,
 /obj/item/ammo_magazine/shotgun/flechette,
 /obj/item/ammo_magazine/shotgun/flechette,
+/obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "cov" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/south)
+"coI" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "csO" = (
-/obj/machinery/door/airlock/mainship/research/glass/free_access,
-/turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "ctE" = (
 /turf/open/shuttle/escapepod/five,
 /area/bigredv2/caves/north)
-"cur" = (
-/obj/structure/window/framed/colony/reinforced,
-/turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
 "cuW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -19479,7 +19548,10 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/filingcabinet,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "cBD" = (
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/bigredv2/outside/sw)
@@ -19500,7 +19572,10 @@
 /obj/structure/table/mainship,
 /obj/machinery/computer/emails,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "cLe" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/marking/asteroidwarning{
@@ -19514,12 +19589,18 @@
 /obj/structure/table/mainship,
 /obj/machinery/computer/security/marinemainship_network,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "cMC" = (
 /obj/structure/table/mainship,
 /obj/machinery/computer/communications,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "cMZ" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -19531,11 +19612,21 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/northwest)
+"cSH" = (
+/obj/machinery/light,
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "cTg" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/structure/bookcase/manuals,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "cTr" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/wall/r_wall,
@@ -19555,6 +19646,14 @@
 "cXu" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/bigredv2/outside/se)
+"cYb" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "cZm" = (
 /obj/structure/cable,
 /turf/open/space/basic,
@@ -19564,11 +19663,21 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/east)
+"daq" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "dbi" = (
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 8
 	},
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "dcO" = (
 /obj/machinery/door/airlock/mainship/research/free_access{
 	name = "\improper Virology Lab Administration"
@@ -19580,19 +19689,15 @@
 /obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
-"ddi" = (
-/turf/closed/wall/r_wall,
-/area/bigredv2/caves/southeast)
 "deb" = (
 /obj/structure/cable,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
-"det" = (
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "dhn" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/cobweb,
@@ -19600,7 +19705,10 @@
 	dir = 1
 	},
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "dhB" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -19638,6 +19746,13 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/southwest)
+"dpu" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "dqo" = (
 /obj/structure/cable,
 /turf/open/floor/tile/darkish,
@@ -19669,17 +19784,24 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "dzS" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor,
 /area/bigredv2/outside/general_store)
 "dzW" = (
-/obj/structure/ladder{
-	id = "ladder1"
+/obj/machinery/power/apc/high{
+	name = "Theta main area power controller"
 	},
+/obj/structure/cable,
 /turf/open/shuttle/escapepod,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "dCr" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -19700,11 +19822,20 @@
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "dFO" = (
-/obj/structure/closet/crate/trashcart,
+/obj/machinery/power/geothermal{
+	name = "Theta G-11 geothermal generator"
+	},
+/obj/structure/cable,
 /turf/open/shuttle/escapepod,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "dGd" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -19728,9 +19859,13 @@
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/southwest)
 "dLF" = (
-/obj/structure/closet/crate/secure/weapon,
+/obj/machinery/power/smes,
+/obj/structure/cable,
 /turf/open/shuttle/escapepod,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "dLO" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 9
@@ -19740,8 +19875,12 @@
 /obj/structure/rack,
 /obj/item/explosive/grenade/flashbang,
 /obj/item/explosive/grenade/flashbang,
+/obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "dPu" = (
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/e)
@@ -19757,6 +19896,16 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/grimy,
 /area/bigredv2/outside/marshal_office)
+"dTY" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/computer3/server/rack,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "dWa" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -19778,7 +19927,10 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "dZi" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/yellow2/corner{
@@ -19794,6 +19946,13 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
+"ecc" = (
+/obj/structure/bed/chair/dropship,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "edO" = (
 /turf/open/floor/carpet,
 /area/bigredv2/outside/bar)
@@ -19823,12 +19982,18 @@
 "ekC" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "ekE" = (
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 4
 	},
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "eli" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
@@ -19839,18 +20004,38 @@
 	dir = 1
 	},
 /area/bigredv2/outside/w)
+"elV" = (
+/obj/effect/landmark/corpsespawner,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "emA" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/structure/cable,
 /turf/open/shuttle/elevator/grating,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "eoX" = (
 /obj/structure/cable,
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
+"eqs" = (
+/obj/structure/largecrate/guns,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "eqy" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/wall,
@@ -19861,7 +20046,10 @@
 "euF" = (
 /obj/effect/spawner/gibspawner/human,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "eve" = (
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/southeast)
@@ -19882,7 +20070,10 @@
 /obj/structure/closet/secure_closet/security,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "exJ" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 8
@@ -19893,7 +20084,10 @@
 /area/bigredv2/caves/south)
 "eCh" = (
 /turf/open/shuttle/escapepod/five,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "eCN" = (
 /obj/structure/cable,
 /turf/open/floor/tile/dark/red2/corner{
@@ -19924,9 +20118,6 @@
 /obj/machinery/computer/nuke_disk_generator/blue,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
-"eKa" = (
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/south)
 "eKb" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -19937,19 +20128,23 @@
 /obj/item/ammo_magazine/rifle/famas,
 /obj/item/ammo_magazine/rifle/famas,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
-"eMX" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/hyper{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "eOu" = (
 /obj/structure/table,
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"eOZ" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/weed_node,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "ePu" = (
 /obj/effect/decal/warning_stripes/thick{
 	dir = 1
@@ -19957,11 +20152,17 @@
 /obj/structure/cable,
 /obj/item/ammo_casing/shell,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "ePv" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "ePH" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -19988,13 +20189,25 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "eRJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/marking/asteroidwarning{
 	dir = 1
 	},
 /area/shuttle/drop2/lz2)
+"eTn" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "eTT" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
@@ -20014,14 +20227,20 @@
 	},
 /turf/open/floor/tile/whiteyellow/full,
 /area/bigredv2/outside/office_complex)
+"eXq" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "eXF" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/southeast)
-"eYb" = (
-/obj/machinery/light,
-/turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
 "eZF" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
@@ -20038,10 +20257,14 @@
 	dir = 1
 	},
 /area/shuttle/drop2/lz2)
-"fcT" = (
-/obj/structure/sign/safety/ladder,
-/turf/closed/wall/r_wall,
-/area/bigredv2/caves/south)
+"fdu" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "feK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -20064,6 +20287,16 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/cargo)
+"fhb" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 2
+	},
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "flV" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor/plating,
@@ -20084,7 +20317,10 @@
 /obj/machinery/door/airlock/external,
 /obj/item/tape/engineering,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "fph" = (
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -20112,12 +20348,18 @@
 	pixel_x = 16
 	},
 /turf/closed/wall/r_wall,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "fuB" = (
 /obj/structure/cable,
 /obj/effect/landmark/corpsespawner/security,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "fwQ" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -20134,6 +20376,13 @@
 	},
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/space_port)
+"fzQ" = (
+/obj/structure/girder,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "fAx" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -20144,7 +20393,10 @@
 /obj/structure/window/framed/colony/reinforced,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "fDs" = (
 /obj/structure/closet/crate/secure/weapon,
 /obj/structure/cable,
@@ -20171,7 +20423,10 @@
 /obj/machinery/door/airlock,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "fIW" = (
 /obj/effect/landmark/dropship_start_location,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -20182,6 +20437,14 @@
 /obj/item/clothing/head/warning_cone,
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/se)
+"fKy" = (
+/obj/structure/cable,
+/obj/structure/largecrate/random/barrel/blue,
+/turf/open/floor/prison/darkyellow/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "fLz" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating,
@@ -20219,7 +20482,10 @@
 	dir = 1
 	},
 /turf/open/shuttle/escapepod,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "fVb" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
@@ -20273,11 +20539,20 @@
 "gfc" = (
 /obj/structure/largecrate,
 /turf/open/shuttle/escapepod,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "gfg" = (
 /obj/effect/landmark/xeno_turret_spawn,
-/turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "ggp" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -20315,10 +20590,23 @@
 "glf" = (
 /obj/structure/largecrate/supply/explosives/mines,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "glC" = (
 /turf/open/floor/tile/dark/yellow2/corner,
 /area/bigredv2/caves/south)
+"gmF" = (
+/obj/machinery/door/airlock/mainship/maint,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "gnu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -20334,7 +20622,10 @@
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 1
 	},
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "gqM" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor,
@@ -20352,14 +20643,20 @@
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 1
 	},
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "gva" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/drop2/lz2)
 "gvo" = (
 /obj/effect/decal/cleanable/blood/gibs,
-/turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "gwV" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -20368,7 +20665,10 @@
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 1
 	},
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "gxC" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
@@ -20383,7 +20683,10 @@
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 8
 	},
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "gBm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/framed/colony/reinforced,
@@ -20401,7 +20704,10 @@
 	welded = 1
 	},
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "gEU" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral/bigred,
@@ -20418,7 +20724,17 @@
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 4
 	},
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
+"gMF" = (
+/obj/structure/largecrate/random/case/double,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "gMM" = (
 /obj/structure/cable,
 /turf/open/floor/marking/asteroidwarning{
@@ -20472,7 +20788,10 @@
 /obj/structure/cable,
 /obj/item/weapon/gun/rifle/m16,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "gYG" = (
 /obj/effect/landmark/weed_node,
 /turf/closed/mineral/bigred,
@@ -20481,7 +20800,10 @@
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 1
 	},
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "hbe" = (
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/floor/asteroidfloor,
@@ -20510,7 +20832,10 @@
 /obj/structure/cable,
 /obj/machinery/light,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "hgL" = (
 /obj/structure/cable,
 /obj/machinery/light{
@@ -20519,7 +20844,10 @@
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 1
 	},
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "hhh" = (
 /obj/structure/cable,
 /turf/open/floor/asteroidfloor,
@@ -20530,17 +20858,33 @@
 	name = "Maintenance Hatch"
 	},
 /turf/open/shuttle/elevator/grating,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
+"hiC" = (
+/obj/machinery/atmospherics/pipe/manifold4w/green,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "hjc" = (
 /obj/effect/landmark/weed_node,
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/south)
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "hjE" = (
 /obj/machinery/door/airlock,
 /obj/structure/cable,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "hkk" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -20550,6 +20894,24 @@
 	dir = 5
 	},
 /area/bigredv2/outside/c)
+"hog" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
+"hoI" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "hqP" = (
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/south)
@@ -20566,7 +20928,10 @@
 /obj/item/ammo_magazine/rifle/m16,
 /obj/item/ammo_magazine/rifle/m16,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "hvV" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/wall,
@@ -20574,7 +20939,10 @@
 "hwc" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "hwL" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -20650,6 +21018,16 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/north)
+"hKM" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4;
+	on = 1
+	},
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "hLo" = (
 /obj/structure/cable,
 /turf/open/floor/tile/dark/blue2{
@@ -20670,12 +21048,33 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/east)
+"hOG" = (
+/obj/effect/landmark/xeno_resin_door,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "hRb" = (
 /obj/structure/cable,
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 4
 	},
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
+"hRM" = (
+/obj/effect/landmark/weed_node,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "hSh" = (
 /obj/machinery/door/airlock,
 /obj/structure/cable,
@@ -20683,7 +21082,10 @@
 /obj/structure/cable,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "hTy" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -20693,7 +21095,10 @@
 /obj/structure/cable,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "hUm" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -20711,7 +21116,10 @@
 /obj/structure/cable,
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "hXl" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -20736,15 +21144,17 @@
 /area/bigredv2/caves/northeast)
 "igD" = (
 /turf/open/shuttle/elevator/grating,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "igK" = (
 /obj/machinery/power/apc/weak,
 /turf/open/shuttle/elevator/grating,
-/area/bigredv2/caves/south)
-"ihM" = (
-/obj/effect/landmark/corpsespawner/engineer,
-/turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "iiY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
@@ -20759,14 +21169,33 @@
 	},
 /obj/structure/cable,
 /turf/open/shuttle/elevator/grating,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "ilD" = (
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/wood,
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "ipY" = (
+/obj/machinery/power/monitor,
+/obj/structure/cable,
+/obj/structure/table/mainship,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
+"iqL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8;
+	welded = 1
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "iug" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/mineral/bigred,
@@ -20797,7 +21226,10 @@
 	dir = 1
 	},
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "iCt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/docking_port/stationary/crashmode,
@@ -20820,14 +21252,20 @@
 "iJf" = (
 /obj/structure/largecrate/supply/weapons/hpr,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "iKB" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/bigredv2/caves/northwest)
 "iKL" = (
 /obj/structure/largecrate/machine,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "iMZ" = (
 /obj/effect/landmark/corpsespawner/engineer,
 /turf/open/floor/tile/red/redtaupecorner,
@@ -20854,13 +21292,26 @@
 	},
 /area/bigredv2/outside/s)
 "iXG" = (
-/obj/machinery/vending/medical,
-/turf/open/shuttle/elevator/grating,
-/area/bigredv2/caves/northwest)
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/southeast)
+"iXU" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "iYa" = (
 /obj/item/paper,
-/turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 9
+	},
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "jcs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -20886,7 +21337,10 @@
 "jkn" = (
 /obj/structure/largecrate/random/barrel/red,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "jlx" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -20899,7 +21353,10 @@
 /obj/structure/largecrate/random/barrel/blue,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "jsp" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -20910,11 +21367,17 @@
 "juh" = (
 /obj/effect/spawner/gibspawner/human,
 /turf/open/shuttle/elevator/grating,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "juu" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/shuttle/elevator/grating,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "juA" = (
 /obj/machinery/power/monitor,
 /turf/open/floor/plating,
@@ -20922,7 +21385,10 @@
 "juU" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/shuttle/elevator/grating,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "jwU" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 2
@@ -20934,7 +21400,10 @@
 "jAz" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /turf/open/shuttle/elevator/grating,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "jAB" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/weed_node,
@@ -20954,8 +21423,11 @@
 /area/bigredv2/outside/sw)
 "jFi" = (
 /obj/item/analyzer/plant_analyzer,
-/turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "jFz" = (
 /obj/effect/decal/warning_stripes/nscenter,
 /obj/machinery/light/built{
@@ -20966,7 +21438,20 @@
 "jGP" = (
 /obj/structure/largecrate/supply/weapons/sentries,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
+"jHx" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/corpsespawner,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "jKb" = (
 /obj/structure/sign/safety/blast_door,
 /obj/structure/cable,
@@ -20981,7 +21466,10 @@
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 8
 	},
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "jKs" = (
 /obj/effect/spawner/gibspawner/human,
 /turf/open/floor/tile/dark/red2/corner,
@@ -21000,7 +21488,10 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "jMC" = (
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/west)
@@ -21095,7 +21586,14 @@
 "kbu" = (
 /obj/structure/cable,
 /turf/open/shuttle/elevator/grating,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
+"kcY" = (
+/obj/structure/girder/displaced,
+/turf/open/floor/tile/damaged/five,
+/area/bigredv2/caves/southeast)
 "kel" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor,
@@ -21133,10 +21631,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/bigredv2/caves/lambda_lab)
-"kpD" = (
-/obj/item/paper/janitor,
-/turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
 "kpV" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
@@ -21164,7 +21658,10 @@
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/structure/cable,
 /turf/open/shuttle/elevator/grating,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "kAp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -21186,7 +21683,10 @@
 "kHY" = (
 /obj/structure/ship_ammo/rocket/napalm,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "kIY" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 1
@@ -21215,13 +21715,23 @@
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/east)
 "kOh" = (
-/turf/closed/wall/indestructible/mineral,
-/area/bigredv2/caves/southeast)
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "kOq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/lightreplacer,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"kOG" = (
+/obj/machinery/door/airlock/mainship/maint,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "kPf" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -21238,10 +21748,21 @@
 	},
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/medical)
+"kTu" = (
+/obj/effect/landmark/xeno_resin_door,
+/obj/structure/cable,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "kXR" = (
 /obj/structure/ship_ammo/rocket/widowmaker,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "ldk" = (
 /obj/structure/cable,
 /turf/open/shuttle/escapepod,
@@ -21259,19 +21780,35 @@
 "lgf" = (
 /obj/structure/closet/crate/secure/gear,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "lgt" = (
 /obj/structure/largecrate/supply/supplies/sandbags,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "lgV" = (
 /obj/structure/grille/broken,
 /turf/open/floor/mainship/empty,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "lhy" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/north)
+"lic" = (
+/obj/machinery/computer/rdservercontrol,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "liu" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral/bigred,
@@ -21292,10 +21829,18 @@
 /obj/effect/landmark/corpsespawner/engineer,
 /turf/open/floor/plating,
 /area/bigredv2/outside/engineering)
+"lmq" = (
+/obj/effect/decal/cleanable/blood/gibs/body,
+/obj/structure/cable,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "lmC" = (
 /obj/machinery/light,
-/obj/structure/largecrate/supply/supplies/mre,
 /obj/structure/cable,
+/obj/item/storage/box/sentry,
 /turf/open/shuttle/elevator/grating,
 /area/bigredv2/caves/northwest)
 "loj" = (
@@ -21313,7 +21858,10 @@
 "lpn" = (
 /obj/machinery/light,
 /turf/open/shuttle/elevator/grating,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "lqu" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/four_tile_ver{
@@ -21321,7 +21869,10 @@
 	name = "Underground Hangar"
 	},
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "lqJ" = (
 /obj/machinery/camera{
 	dir = 5
@@ -21331,7 +21882,10 @@
 "lrg" = (
 /obj/structure/ship_ammo/rocket/fatty,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "lsj" = (
 /obj/structure/closet/l3closet/virology,
 /turf/open/shuttle/escapepod,
@@ -21344,7 +21898,10 @@
 /obj/structure/cable,
 /obj/structure/dropship_equipment/weapon/rocket_pod,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "lvJ" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
@@ -21375,7 +21932,10 @@
 "lAi" = (
 /obj/structure/ship_ammo/rocket/banshee,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "lAq" = (
 /obj/structure/sign/safety/maintenance{
 	dir = 1
@@ -21392,16 +21952,22 @@
 	},
 /obj/item/ammo_magazine/rifle/m16,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "lCt" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 9
 	},
 /area/shuttle/drop2/lz2)
-"lFK" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/south)
+"lCu" = (
+/obj/structure/largecrate/random/case,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "lFT" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -21412,7 +21978,10 @@
 "lHD" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "lHZ" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -21421,6 +21990,25 @@
 /obj/structure/sign/prop1,
 /turf/open/floor,
 /area/bigredv2/outside/office_complex)
+"lIZ" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
+"lKe" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 5
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "lKZ" = (
 /turf/open/shuttle/escapepod,
 /area/bigredv2/caves/north)
@@ -21445,11 +22033,17 @@
 "lNk" = (
 /obj/structure/largecrate/supply/supplies/flares,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/southeast)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "lPS" = (
 /obj/structure/largecrate/random/barrel/green,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/southeast)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "lPV" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -21461,10 +22055,6 @@
 "lQx" = (
 /obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 2
-	},
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2;
-	id = "Secure_1"
 	},
 /obj/structure/cable,
 /turf/open/shuttle/elevator/grating,
@@ -21493,11 +22083,24 @@
 /obj/structure/cable,
 /obj/machinery/light,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/southeast)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "mbT" = (
 /obj/item/trash/sosjerky,
 /turf/open/floor/plating,
 /area/bigredv2/outside/engineering)
+"mcd" = (
+/obj/structure/cable,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "mcP" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/mineral/bigred,
@@ -21514,6 +22117,9 @@
 "mlt" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/caves/north)
+"mly" = (
+/turf/closed/wall/r_wall,
+/area/bigredv2/caves/southeast)
 "mpz" = (
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/bigredv2/outside/se)
@@ -21524,7 +22130,10 @@
 "mrL" = (
 /obj/structure/largecrate/supply/supplies/metal,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/southeast)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "msI" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -21536,16 +22145,30 @@
 /obj/structure/largecrate/supply/supplies/plasteel,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/southeast)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
+"mwU" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "mxH" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/landmark/corpsespawner/security,
 /turf/open/floor/carpet,
 /area/bigredv2/outside/library)
 "mxP" = (
-/obj/structure/largecrate/random/barrel/blue,
-/turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/turf/closed/wall/r_wall,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "myA" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/blood/gibs,
@@ -21558,7 +22181,10 @@
 	welded = 1
 	},
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "mAi" = (
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/northwest)
@@ -21570,8 +22196,11 @@
 	dir = 4;
 	pixel_x = -16
 	},
-/turf/closed/wall/r_wall/unmeltable,
-/area/space)
+/turf/closed/wall/r_wall,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "mEk" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/marking/asteroidwarning,
@@ -21624,9 +22253,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/northwest)
-"mPE" = (
-/turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/southeast)
 "mQb" = (
 /obj/structure/rack,
 /obj/item/ammo_magazine/shotgun/incendiary,
@@ -21654,9 +22280,8 @@
 /turf/open/shuttle/escapepod,
 /area/bigredv2/caves/lambda_lab)
 "nag" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/metal/large_stack,
 /obj/structure/cable,
+/obj/structure/largecrate/supply/supplies/mre,
 /turf/open/shuttle/elevator/grating,
 /area/bigredv2/caves/northwest)
 "nbV" = (
@@ -21668,7 +22293,10 @@
 "ncd" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/southeast)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "ndz" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -21683,6 +22311,23 @@
 /obj/structure/ore_box,
 /turf/open/shuttle/escapepod,
 /area/bigredv2/caves/lambda_lab)
+"nqq" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
+"nru" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "nrI" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
@@ -21707,7 +22352,10 @@
 /obj/structure/cable,
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "nvs" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -21756,9 +22404,11 @@
 /area/bigredv2/caves/lambda_lab)
 "nBy" = (
 /obj/structure/cable,
-/obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "nCe" = (
 /obj/structure/bookcase/manuals/research_and_development,
 /obj/structure/cable,
@@ -21803,8 +22453,14 @@
 "nMb" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno/body,
 /obj/structure/cable,
-/turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "nOk" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor,
@@ -21818,14 +22474,18 @@
 /area/bigredv2/caves/northwest)
 "nPl" = (
 /obj/item/paper/clockresearch1,
-/turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/turf/closed/wall/r_wall,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "nQE" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/manifold/green,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "nQS" = (
 /obj/effect/decal/warning_stripes/thick{
 	dir = 1
@@ -21833,7 +22493,10 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood/gibs/xeno/limb,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "nRT" = (
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/west)
@@ -21846,9 +22509,20 @@
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
 "nVP" = (
-/obj/item/tool/pickaxe,
+/obj/structure/cable,
+/obj/machinery/computer/emails,
+/obj/structure/table/mainship,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
+"nWE" = (
+/turf/open/lavaland/catwalk,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "oaD" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 8
@@ -21867,7 +22541,10 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "ojx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -21875,6 +22552,15 @@
 	},
 /turf/open/floor/wood,
 /area/bigredv2/outside/bar)
+"okr" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "olJ" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/mineral/bigred,
@@ -21905,7 +22591,10 @@
 /obj/item/explosive/grenade/drainbomb,
 /obj/item/explosive/grenade/drainbomb,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "oto" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -21952,11 +22641,38 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/e)
+"oCu" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 9
+	},
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "oDD" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 6
 	},
 /area/bigredv2/outside/space_port)
+"oEm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
+"oEr" = (
+/obj/machinery/atmospherics/pipe/manifold/green,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "oEN" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/tile/white,
@@ -22017,6 +22733,29 @@
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"oUf" = (
+/obj/effect/landmark/corpsespawner,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
+"oUj" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 5
+	},
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
+"oVG" = (
+/obj/machinery/r_n_d/server,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "oVQ" = (
 /obj/effect/decal/warning_stripes/thick,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -22024,7 +22763,10 @@
 	},
 /obj/item/weapon/gun/shotgun/pump/cmb,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "oWn" = (
 /turf/open/floor/tile/green/whitegreenfull,
 /area/bigredv2/caves/lambda_lab)
@@ -22041,7 +22783,10 @@
 	dir = 1
 	},
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "pbv" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/machinery/door/poddoor/shutters/mainship{
@@ -22081,14 +22826,26 @@
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/lambda_lab)
-"pgV" = (
-/obj/effect/decal/warning_stripes/thick,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
+"pgW" = (
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
+"phD" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
+"piE" = (
+/obj/effect/landmark/corpsespawner/security,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "pjz" = (
 /obj/structure/cable,
 /turf/open/floor/marking/asteroidwarning{
@@ -22103,7 +22860,10 @@
 /obj/structure/cable,
 /obj/item/limb/r_foot,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "pmf" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/landmark/corpsespawner/security,
@@ -22131,7 +22891,10 @@
 /obj/structure/cable,
 /obj/item/weapon/gun/rifle/famas,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "psH" = (
 /obj/structure/rack,
 /obj/item/storage/belt/gun/revolver,
@@ -22160,6 +22923,16 @@
 	},
 /turf/open/floor/plating,
 /area/bigredv2/outside/dorms)
+"pzS" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "pzX" = (
 /obj/structure/largecrate,
 /obj/structure/cable,
@@ -22175,7 +22948,10 @@
 	dir = 8
 	},
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "pEd" = (
 /obj/effect/decal/warning_stripes/thick,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -22184,17 +22960,14 @@
 /obj/structure/cable,
 /obj/item/weapon/gun/rifle/m16,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "pEh" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall,
 /area/bigredv2/caves/south)
-"pFP" = (
-/obj/structure/rack,
-/obj/item/weapon/gun/launcher/rocket/m57a4/t57,
-/obj/item/ammo_magazine/rocket/m57a4,
-/turf/open/floor/plating/plating_catwalk,
-/area/bigredv2/caves/northwest)
 "pHZ" = (
 /obj/effect/decal/warning_stripes/thick,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -22203,7 +22976,10 @@
 /obj/structure/cable,
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "pJO" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -22214,12 +22990,32 @@
 	pixel_x = 16
 	},
 /obj/structure/cable,
-/turf/closed/wall/r_wall/unmeltable,
-/area/space)
+/turf/closed/wall/r_wall,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "pOZ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/northwest)
+"pPX" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 1;
+	on = 1
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
+"pQo" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "pQK" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 8
@@ -22258,14 +23054,20 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "pVB" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
 /obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "pXc" = (
 /obj/structure/cable,
 /obj/structure/window/framed/mainship/gray/toughened/hull{
@@ -22291,14 +23093,19 @@
 	pixel_x = -16
 	},
 /obj/structure/cable,
-/turf/closed/wall/r_wall/unmeltable,
-/area/bigredv2/caves/south)
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "qbh" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/commander,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "qcp" = (
 /obj/structure/cable,
 /turf/open/floor/tile/chapel{
@@ -22312,11 +23119,25 @@
 /obj/structure/cable,
 /obj/item/ammo_casing/shell,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
+"qcY" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/closed/wall/r_wall/unmeltable,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "qdE" = (
 /obj/item/analyzer,
-/turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "qeE" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -22346,7 +23167,10 @@
 	},
 /obj/item/ammo_casing/shell,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "qgg" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -22360,9 +23184,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/landmark/corpsespawner/security,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "qnf" = (
 /obj/effect/decal/warning_stripes/thick,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -22373,7 +23199,10 @@
 	dir = 1
 	},
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "qnu" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/darkgreen/darkgreen2/corner,
@@ -22393,6 +23222,30 @@
 /obj/effect/landmark/xeno_turret_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/southwest)
+"qsC" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
+"qsG" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
+"qtr" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/closed/wall/r_wall,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "qtI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	on = 1
@@ -22405,9 +23258,11 @@
 	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood/writing,
-/obj/machinery/power/apc/high,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "quI" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/bigredv2/outside/telecomm)
@@ -22423,6 +23278,13 @@
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/north)
+"qwT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "qxt" = (
 /obj/item/trash/candy,
 /turf/open/floor,
@@ -22460,14 +23322,23 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/south)
-"qDZ" = (
-/obj/effect/landmark/corpsespawner/security,
-/turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
 "qEg" = (
 /obj/structure/sign/safety/high_radiation,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"qEi" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8;
+	on = 1
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "qFg" = (
 /obj/machinery/door/poddoor/shutters/mainship{
 	dir = 2;
@@ -22516,7 +23387,10 @@
 	welded = 1
 	},
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "qKE" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -22577,11 +23451,18 @@
 "qVr" = (
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/north)
+"qVN" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/southeast)
 "qXP" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/structure/cable,
-/turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "qYD" = (
 /obj/structure/cable,
 /turf/open/floor/asteroidfloor,
@@ -22613,23 +23494,34 @@
 /turf/open/floor/tile/yellow/full,
 /area/bigredv2/outside/hydroponics)
 "rde" = (
-/obj/effect/landmark/corpsespawner/commander,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "rdw" = (
 /turf/open/floor/prison/darkred/full,
 /area/bigredv2/caves/south)
+"rel" = (
+/obj/machinery/atmospherics/pipe/manifold/green{
+	dir = 1
+	},
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "rfg" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
-"rhf" = (
-/turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/south)
 "riu" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno/limb,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "riz" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 8
@@ -22637,8 +23529,11 @@
 /area/bigredv2/outside/virology)
 "rjr" = (
 /obj/item/paper/prison_station/warden_note,
-/turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "rkk" = (
 /obj/machinery/light,
 /turf/open/floor/plating,
@@ -22648,20 +23543,18 @@
 /turf/open/floor/tile/dark/yellow2/corner,
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "rpq" = (
-/obj/effect/landmark/corpsespawner/security,
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "rpV" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/northeast)
-"rqU" = (
-/obj/effect/landmark/corpsespawner/scientist,
-/turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
 "rvh" = (
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/lambda_lab)
@@ -22688,11 +23581,21 @@
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/general_offices)
+"ryO" = (
+/obj/structure/cable,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "rAe" = (
 /obj/item/ammo_casing/bullet,
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "rBN" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -22715,7 +23618,10 @@
 	dir = 8
 	},
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "rLF" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -22777,7 +23683,10 @@
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "rZP" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
@@ -22799,7 +23708,10 @@
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 1
 	},
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "sfy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -22812,7 +23724,17 @@
 	pixel_y = 9
 	},
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
+"sjC" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "skG" = (
 /obj/machinery/computer/shuttle/shuttle_control/dropship,
 /obj/structure/table,
@@ -22834,7 +23756,10 @@
 /obj/item/limb/head,
 /obj/machinery/light,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "soj" = (
 /obj/machinery/power/apc/drained{
 	dir = 8
@@ -22844,6 +23769,15 @@
 	dir = 4
 	},
 /area/shuttle/drop2/lz2)
+"ssh" = (
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 2
+	},
+/turf/open/floor/prison/darkyellow/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "svV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor/wood,
@@ -22854,6 +23788,15 @@
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/space_port)
+"szr" = (
+/obj/structure/cable,
+/obj/machinery/computer/communications/bee,
+/obj/structure/table/mainship,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "sAq" = (
 /obj/structure/cable,
 /turf/closed/mineral/bigred,
@@ -22861,17 +23804,32 @@
 "sBJ" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "sBV" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 1
 	},
 /area/bigredv2/outside/w)
+"sBX" = (
+/obj/structure/bed/chair/dropship{
+	dir = 4
+	},
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "sCz" = (
 /obj/item/limb/r_foot,
 /obj/item/ammo_casing/shell,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "sEN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -22900,7 +23858,10 @@
 "sLI" = (
 /obj/item/ammo_casing/shell,
 /turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "sQi" = (
 /obj/effect/landmark/xeno_turret_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -22919,13 +23880,19 @@
 /turf/open/floor/tile/dark/red2,
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "sTd" = (
-/turf/closed/wall/indestructible/mineral,
-/area/bigredv2/caves/south)
+/turf/closed/wall/r_wall/unmeltable,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "sTE" = (
 /obj/item/ammo_casing/shell,
 /obj/item/weapon/gun/shotgun/pump/cmb,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "sUd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -22937,11 +23904,17 @@
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "sWk" = (
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "sWC" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -22965,21 +23938,36 @@
 "tco" = (
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/s)
+"tdv" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "tfr" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
-/turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "tfF" = (
 /turf/open/shuttle/elevator/grating,
 /area/bigredv2/caves/northwest)
 "tjb" = (
 /turf/open/floor/tile/damaged/five,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "tjQ" = (
-/obj/effect/landmark/corpsespawner/security,
 /obj/effect/decal/cleanable/blood/gibs/up,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "tku" = (
 /turf/closed/wall/indestructible/mineral,
 /area/storage/testroom)
@@ -23008,6 +23996,16 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/north)
+"tny" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/largecrate/random/case/double,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "toO" = (
 /obj/effect/landmark/weed_node,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
@@ -23015,6 +24013,12 @@
 	},
 /turf/open/floor/freezer,
 /area/bigredv2/outside/virology)
+"tqK" = (
+/turf/open/floor/tile/damaged/panel,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "tsZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/marking/asteroidwarning{
@@ -23064,25 +24068,46 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/grimy,
 /area/bigredv2/outside/dorms)
+"tyh" = (
+/obj/machinery/atmospherics/pipe/manifold/green{
+	dir = 8
+	},
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "tyD" = (
-/obj/effect/landmark/corpsespawner/scientist,
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "tzo" = (
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/east)
 "tzW" = (
-/obj/structure/ladder{
-	height = 1;
-	id = "Lambdashaft"
-	},
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/south)
+/turf/open/floor/prison/darkyellow/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "tAB" = (
 /obj/item/ammo_casing/shell,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
+"tCw" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "tCQ" = (
 /obj/structure/barricade/metal{
 	dir = 8
@@ -23090,11 +24115,17 @@
 /obj/item/ammo_casing/shell,
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "tDh" = (
 /obj/effect/landmark/weed_node,
-/turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/turf/open/floor/prison/darkyellow/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "tDX" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 6
@@ -23108,7 +24139,19 @@
 "tHW" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno/limb,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
+"tHZ" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/multi_tile/mainship/generic,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "tJA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -23124,11 +24167,21 @@
 /obj/effect/decal/cleanable/blood/gibs/xeno/limb,
 /obj/item/ammo_casing/shell,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "tNb" = (
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/plating,
 /area/bigredv2/caves/lambda_lab)
+"tSF" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "tUS" = (
 /obj/machinery/door/airlock/mainship/security/glass/free_access,
 /turf/open/floor,
@@ -23149,7 +24202,10 @@
 /obj/item/ammo_casing/bullet,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "tZR" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/xeno_resin_wall,
@@ -23161,7 +24217,10 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "uan" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/marking/asteroidwarning{
@@ -23173,7 +24232,10 @@
 /obj/item/ammo_casing/shell,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "udd" = (
 /obj/machinery/power/apc/drained{
 	dir = 4
@@ -23187,6 +24249,13 @@
 	dir = 1
 	},
 /area/bigredv2/caves/east)
+"udL" = (
+/obj/structure/prop/mainship/mission_planning_system,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "uec" = (
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/caves/southwest)
@@ -23262,7 +24331,19 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
+"upD" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "uqm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/corpsespawner/doctor,
@@ -23272,16 +24353,16 @@
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "utl" = (
 /obj/machinery/floodlight/landing,
 /turf/open/floor/marking/asteroidwarning{
 	dir = 5
 	},
 /area/shuttle/drop2/lz2)
-"utr" = (
-/turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
 "utH" = (
 /obj/structure/table,
 /obj/effect/spawner/random/technology_scanner,
@@ -23296,8 +24377,11 @@
 /area/bigredv2/outside/nw)
 "uwD" = (
 /obj/effect/landmark/corpsespawner/engineer,
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/south)
+/turf/open/floor/prison/darkyellow/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "uxP" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall,
@@ -23305,8 +24389,11 @@
 "uyC" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /obj/structure/cable,
-/turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "uyQ" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -23314,7 +24401,18 @@
 "uCk" = (
 /obj/effect/spawner/gibspawner/human,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
+"uHf" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/multi_tile/mainship/generic,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "uHG" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -23326,6 +24424,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor,
 /area/bigredv2/outside/hydroponics)
+"uIf" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "uJV" = (
 /obj/machinery/door/poddoor/shutters/mainship{
 	id = "Cargonia";
@@ -23338,7 +24445,13 @@
 /obj/item/ammo_casing/shell,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
+"uKS" = (
+/turf/open/floor/tile/damaged/five,
+/area/bigredv2/caves/southeast)
 "uLz" = (
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -23346,11 +24459,23 @@
 "uLC" = (
 /obj/item/ammo_casing/shell,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "uLR" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/northeast)
+"uMk" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 6
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "uMP" = (
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/east)
@@ -23360,6 +24485,15 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
+"uTK" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "uUn" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -23384,7 +24518,20 @@
 "vbQ" = (
 /obj/item/limb/l_arm,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
+"vcC" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	on = 1;
+	welded = 1
+	},
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "veE" = (
 /obj/structure/table,
 /obj/effect/spawner/random/toolbox,
@@ -23395,9 +24542,11 @@
 /turf/open/shuttle/elevator/grating,
 /area/bigredv2/caves/northwest)
 "vlA" = (
-/obj/effect/landmark/corpsespawner/security,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "vlT" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
@@ -23407,7 +24556,10 @@
 	dir = 8
 	},
 /turf/open/floor/tile/damaged/five,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "vpv" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -23422,23 +24574,23 @@
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "vry" = (
 /obj/machinery/light,
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/south)
+/obj/structure/cable,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "vsq" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/c)
-"vtS" = (
-/obj/machinery/camera/autoname/mainship/dropship_one{
-	dir = 8;
-	pixel_x = 16
-	},
-/turf/closed/wall/r_wall/unmeltable,
-/area/space)
 "vuE" = (
 /obj/effect/spawner/gibspawner/human,
 /turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "vvM" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -23448,6 +24600,16 @@
 "vwf" = (
 /turf/closed/mineral/bigred,
 /area/bigredv2/outside/space_port)
+"vwv" = (
+/obj/docking_port/stationary/crashmode,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "vwP" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
@@ -23463,7 +24625,10 @@
 	pixel_y = 9
 	},
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "vyZ" = (
 /obj/effect/landmark/xeno_turret_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -23472,7 +24637,10 @@
 /obj/effect/decal/cleanable/blood/gibs/xeno/limb,
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "vAP" = (
 /obj/docking_port/stationary/crashmode,
 /obj/structure/cable,
@@ -23498,7 +24666,20 @@
 /obj/item/weapon/gun/rifle/famas,
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
+"vFT" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "vIl" = (
 /obj/structure/sign/poster{
 	dir = 1
@@ -23511,12 +24692,9 @@
 	},
 /area/bigredv2/caves/northeast)
 "vKc" = (
-/obj/structure/ladder{
-	height = 1;
-	id = "ladder1"
-	},
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/north)
+/obj/structure/girder,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/southeast)
 "vKO" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral/bigred,
@@ -23532,12 +24710,22 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/east)
-"vQS" = (
+"vNo" = (
+/obj/structure/largecrate/random/barrel/blue,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/turf/open/floor/prison/darkyellow/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
+"vQS" = (
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "vRM" = (
 /obj/effect/decal/warning_stripes/nscenter,
 /obj/machinery/light/built{
@@ -23576,7 +24764,10 @@
 /obj/item/ammo_casing/shell,
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "vXv" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 4
@@ -23587,29 +24778,47 @@
 /obj/item/ammo_casing/shell,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "wbU" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno/body,
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "wdk" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /obj/structure/cable,
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/south)
 "wdL" = (
-/obj/item/storage/box/sentry,
 /turf/open/floor/plating/plating_catwalk,
 /area/bigredv2/caves/northwest)
+"wel" = (
+/obj/structure/cable,
+/turf/open/floor/prison/darkyellow/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "weF" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "wff" = (
 /obj/effect/decal/cleanable/blood/tracks/footprints,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "wfD" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/darkish,
@@ -23623,6 +24832,17 @@
 /obj/effect/landmark/xeno_turret_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/east)
+"wjl" = (
+/obj/effect/landmark/xeno_resin_door,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "wmv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -23639,24 +24859,45 @@
 "wnO" = (
 /obj/item/limb/l_hand,
 /turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "wpF" = (
 /obj/item/limb/l_arm,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "wpO" = (
 /obj/effect/decal/cleanable/blood/tracks/footprints,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "wrk" = (
-/obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "wsS" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/east)
+"wtd" = (
+/obj/machinery/atmospherics/pipe/manifold/green{
+	dir = 1
+	},
+/obj/effect/landmark/corpsespawner,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "wxA" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno/down,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -23673,10 +24914,22 @@
 	dir = 1
 	},
 /area/bigredv2/outside/c)
+"wAY" = (
+/obj/structure/bed/chair/dropship{
+	dir = 8
+	},
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "wBY" = (
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/tile/damaged/four,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "wCi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -23698,7 +24951,10 @@
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "wQg" = (
 /obj/structure/cable,
 /obj/machinery/light,
@@ -23776,12 +25032,18 @@
 	},
 /obj/structure/cable,
 /turf/open/shuttle/elevator/grating,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "xiz" = (
 /obj/effect/landmark/corpsespawner/security,
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "xiT" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor,
@@ -23798,7 +25060,18 @@
 "xjA" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
+"xjJ" = (
+/obj/structure/cable,
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "xlj" = (
 /obj/effect/decal/warning_stripes/thick{
 	dir = 8
@@ -23809,7 +25082,18 @@
 	pixel_x = 16
 	},
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
+"xmO" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/bed/chair/dropship,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "xnf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/tool,
@@ -23817,8 +25101,31 @@
 /area/bigredv2/outside/cargo)
 "xni" = (
 /obj/machinery/miner/damaged/platinum,
-/turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
+"xnp" = (
+/obj/effect/landmark/weed_node,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
+"xnv" = (
+/obj/structure/cable,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "xnD" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/wall,
@@ -23829,9 +25136,6 @@
 /area/bigredv2/outside/telecomm)
 "xpu" = (
 /obj/machinery/door/airlock/mainship/security/glass/free_access,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	id = "Secure_1"
-	},
 /obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/caves/north)
@@ -23848,8 +25152,11 @@
 /area/bigredv2/outside/hydroponics)
 "xqW" = (
 /obj/structure/cable,
-/turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "xrJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	on = 1
@@ -23860,6 +25167,14 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/east)
+"xtF" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "xtN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
@@ -23871,7 +25186,10 @@
 /obj/effect/landmark/corpsespawner/scientist,
 /obj/machinery/light,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "xvL" = (
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/southeast)
@@ -23900,7 +25218,10 @@
 	dir = 1
 	},
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "xAO" = (
 /obj/effect/landmark/corpsespawner/security,
 /turf/open/floor,
@@ -23951,7 +25272,10 @@
 	},
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "xNf" = (
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -23960,6 +25284,14 @@
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/south)
+"xPH" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/corpsespawner,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "xPT" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -23971,6 +25303,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/space_port)
+"xRc" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "xRF" = (
 /obj/effect/decal/warning_stripes/thick{
 	dir = 1
@@ -23978,7 +25317,10 @@
 /obj/structure/cable,
 /obj/machinery/light,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "xRR" = (
 /obj/machinery/light{
 	dir = 1
@@ -23992,7 +25334,10 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood/gibs/xeno/body,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/south)
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "xSR" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 6
@@ -24023,6 +25368,13 @@
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/south)
+"ycc" = (
+/obj/effect/landmark/weed_node,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "ydN" = (
 /turf/open/floor/mainship/orange,
 /area/bigredv2/caves/northeast)
@@ -24053,6 +25405,16 @@
 /obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"yjY" = (
+/obj/machinery/door/airlock/mainship/generic,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/lambda_lab{
+	icon_state = "anospectro";
+	name = "Theta Lab"
+	})
 "ykI" = (
 /obj/structure/cable,
 /turf/open/floor/plating/warning{
@@ -24076,167 +25438,167 @@ aaa
 aaa
 aaa
 aaa
-aaa
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
+aab
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
 cZm
 cZm
 cZm
@@ -24401,59 +25763,59 @@ aab
 aab
 aab
 aab
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
 aaa
 aaa
 aaa
@@ -24618,59 +25980,59 @@ yhx
 tvk
 tvk
 aab
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
 aaa
 aaa
 aaa
@@ -26031,7 +27393,7 @@ aac
 ktH
 abQ
 huI
-iXG
+tfF
 tfF
 tfF
 wdL
@@ -26682,7 +28044,7 @@ vWE
 vWE
 aac
 huI
-pFP
+wdL
 tfF
 tfF
 gSk
@@ -28179,9 +29541,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (20,1,1) = {"
 aaa
@@ -28396,9 +29758,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (21,1,1) = {"
 aaa
@@ -28613,9 +29975,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (22,1,1) = {"
 aaa
@@ -28830,9 +30192,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (23,1,1) = {"
 aaa
@@ -29047,9 +30409,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (24,1,1) = {"
 aaa
@@ -29264,9 +30626,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (25,1,1) = {"
 aaa
@@ -29481,9 +30843,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (26,1,1) = {"
 aaa
@@ -29698,9 +31060,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (27,1,1) = {"
 aaa
@@ -29915,9 +31277,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (28,1,1) = {"
 aaa
@@ -30132,9 +31494,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (29,1,1) = {"
 aaa
@@ -30349,9 +31711,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (30,1,1) = {"
 aaa
@@ -30566,9 +31928,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (31,1,1) = {"
 aaa
@@ -30783,9 +32145,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (32,1,1) = {"
 aaa
@@ -31000,9 +32362,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (33,1,1) = {"
 aaa
@@ -31217,9 +32579,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (34,1,1) = {"
 aaa
@@ -31434,9 +32796,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (35,1,1) = {"
 aaa
@@ -31651,9 +33013,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (36,1,1) = {"
 aaa
@@ -31868,9 +33230,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (37,1,1) = {"
 aaa
@@ -32085,9 +33447,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (38,1,1) = {"
 aaa
@@ -32302,9 +33664,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (39,1,1) = {"
 aaa
@@ -32519,9 +33881,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (40,1,1) = {"
 aaa
@@ -32736,9 +34098,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (41,1,1) = {"
 aaa
@@ -32953,9 +34315,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (42,1,1) = {"
 aaa
@@ -33170,9 +34532,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (43,1,1) = {"
 aaa
@@ -33387,9 +34749,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (44,1,1) = {"
 aaa
@@ -33604,9 +34966,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (45,1,1) = {"
 aaa
@@ -33821,9 +35183,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (46,1,1) = {"
 aaa
@@ -34038,9 +35400,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (47,1,1) = {"
 aaa
@@ -34255,9 +35617,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (48,1,1) = {"
 aaa
@@ -34472,9 +35834,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (49,1,1) = {"
 aaa
@@ -34689,9 +36051,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (50,1,1) = {"
 aaa
@@ -34906,9 +36268,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (51,1,1) = {"
 aaa
@@ -35123,9 +36485,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (52,1,1) = {"
 aaa
@@ -35340,9 +36702,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (53,1,1) = {"
 aaa
@@ -35557,9 +36919,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (54,1,1) = {"
 aaa
@@ -35774,9 +37136,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (55,1,1) = {"
 aaa
@@ -35991,9 +37353,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (56,1,1) = {"
 aaa
@@ -36208,9 +37570,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (57,1,1) = {"
 aaa
@@ -36425,9 +37787,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (58,1,1) = {"
 aaa
@@ -36642,9 +38004,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (59,1,1) = {"
 aaa
@@ -36859,9 +38221,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (60,1,1) = {"
 aaa
@@ -37076,9 +38438,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (61,1,1) = {"
 aaa
@@ -37293,9 +38655,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (62,1,1) = {"
 aaa
@@ -37510,9 +38872,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (63,1,1) = {"
 aaa
@@ -37727,9 +39089,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (64,1,1) = {"
 aaa
@@ -37944,9 +39306,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (65,1,1) = {"
 aaa
@@ -38161,9 +39523,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (66,1,1) = {"
 aaa
@@ -38378,9 +39740,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (67,1,1) = {"
 aaa
@@ -38595,9 +39957,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (68,1,1) = {"
 aaa
@@ -38812,9 +40174,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (69,1,1) = {"
 aaa
@@ -39029,9 +40391,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (70,1,1) = {"
 aaa
@@ -39246,9 +40608,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (71,1,1) = {"
 aaa
@@ -39463,9 +40825,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (72,1,1) = {"
 aaa
@@ -39680,9 +41042,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-cZm
+aab
+aab
+qOl
 "}
 (73,1,1) = {"
 aaa
@@ -39898,8 +41260,8 @@ aab
 aab
 aab
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (74,1,1) = {"
 aaa
@@ -40115,8 +41477,8 @@ hqP
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (75,1,1) = {"
 aaa
@@ -40332,8 +41694,8 @@ hqP
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (76,1,1) = {"
 aaa
@@ -40549,8 +41911,8 @@ hqP
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (77,1,1) = {"
 aaa
@@ -40766,8 +42128,8 @@ hqP
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (78,1,1) = {"
 aaa
@@ -40983,8 +42345,8 @@ hqP
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (79,1,1) = {"
 aaa
@@ -41200,8 +42562,8 @@ hqP
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (80,1,1) = {"
 aaa
@@ -41417,8 +42779,8 @@ hqP
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (81,1,1) = {"
 aaa
@@ -41634,8 +42996,8 @@ hqP
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (82,1,1) = {"
 aaa
@@ -41851,8 +43213,8 @@ hqP
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (83,1,1) = {"
 aaa
@@ -42068,8 +43430,8 @@ hqP
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (84,1,1) = {"
 aaa
@@ -42285,8 +43647,8 @@ hqP
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (85,1,1) = {"
 aaa
@@ -42502,8 +43864,8 @@ hqP
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (86,1,1) = {"
 aaa
@@ -42719,8 +44081,8 @@ hqP
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (87,1,1) = {"
 aaa
@@ -42936,8 +44298,8 @@ hqP
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (88,1,1) = {"
 aaa
@@ -43153,8 +44515,8 @@ hqP
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (89,1,1) = {"
 aaa
@@ -43370,8 +44732,8 @@ hqP
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (90,1,1) = {"
 aaa
@@ -43587,8 +44949,8 @@ hqP
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (91,1,1) = {"
 aaa
@@ -43804,8 +45166,8 @@ hqP
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (92,1,1) = {"
 aaa
@@ -44021,8 +45383,8 @@ hqP
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (93,1,1) = {"
 aaa
@@ -44238,8 +45600,8 @@ hqP
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (94,1,1) = {"
 aaa
@@ -44455,8 +45817,8 @@ hqP
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (95,1,1) = {"
 aaa
@@ -44672,8 +46034,8 @@ hqP
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (96,1,1) = {"
 aaa
@@ -44889,8 +46251,8 @@ hqP
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (97,1,1) = {"
 aaa
@@ -45106,8 +46468,8 @@ hqP
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (98,1,1) = {"
 aaa
@@ -45323,8 +46685,8 @@ hqP
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (99,1,1) = {"
 aaa
@@ -45540,8 +46902,8 @@ hqP
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (100,1,1) = {"
 aaa
@@ -45757,8 +47119,8 @@ hqP
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (101,1,1) = {"
 aaa
@@ -45974,8 +47336,8 @@ hqP
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (102,1,1) = {"
 aaa
@@ -46191,8 +47553,8 @@ xEN
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (103,1,1) = {"
 aaa
@@ -46408,8 +47770,8 @@ xEN
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (104,1,1) = {"
 aaa
@@ -46625,8 +47987,8 @@ xEN
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (105,1,1) = {"
 aaa
@@ -46842,8 +48204,8 @@ wYu
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (106,1,1) = {"
 aaa
@@ -47059,8 +48421,8 @@ vlT
 rWh
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (107,1,1) = {"
 aaa
@@ -47276,8 +48638,8 @@ eCN
 nhk
 fqj
 qOl
-cZm
-cZm
+qOl
+qOl
 "}
 (108,1,1) = {"
 aaa
@@ -47493,8 +48855,8 @@ unB
 rWh
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (109,1,1) = {"
 aaa
@@ -47710,8 +49072,8 @@ eyz
 rWh
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (110,1,1) = {"
 aaa
@@ -47927,8 +49289,8 @@ egQ
 rWh
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (111,1,1) = {"
 aaa
@@ -48144,8 +49506,8 @@ psH
 xJp
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (112,1,1) = {"
 aaa
@@ -48361,8 +49723,8 @@ eyz
 xJp
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (113,1,1) = {"
 aaa
@@ -48578,8 +49940,8 @@ hDY
 xJp
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (114,1,1) = {"
 aaa
@@ -48795,8 +50157,8 @@ eyz
 xJp
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (115,1,1) = {"
 aaa
@@ -49012,8 +50374,8 @@ lqJ
 rdw
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (116,1,1) = {"
 aaa
@@ -49229,8 +50591,8 @@ xEN
 cFp
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (117,1,1) = {"
 aaa
@@ -49446,8 +50808,8 @@ jWg
 xEN
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (118,1,1) = {"
 aaa
@@ -49488,7 +50850,7 @@ qVr
 gEU
 qVr
 bHv
-vKc
+lKZ
 ctE
 ctE
 ctE
@@ -49663,8 +51025,8 @@ xEN
 xEN
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (119,1,1) = {"
 aaa
@@ -49880,8 +51242,8 @@ xEN
 xEN
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (120,1,1) = {"
 aaa
@@ -50097,8 +51459,8 @@ xEN
 jWg
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (121,1,1) = {"
 aaa
@@ -50314,8 +51676,8 @@ xEN
 xEN
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (122,1,1) = {"
 aaa
@@ -50531,8 +51893,8 @@ xEN
 xEN
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (123,1,1) = {"
 aaa
@@ -50748,8 +52110,8 @@ xEN
 xEN
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (124,1,1) = {"
 aaa
@@ -50965,8 +52327,8 @@ xEN
 xEN
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (125,1,1) = {"
 aaa
@@ -51182,8 +52544,8 @@ xEN
 xEN
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (126,1,1) = {"
 aaa
@@ -51399,8 +52761,8 @@ xEN
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (127,1,1) = {"
 aaa
@@ -51616,8 +52978,8 @@ xEN
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (128,1,1) = {"
 aaa
@@ -51833,8 +53195,8 @@ xEN
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (129,1,1) = {"
 aaa
@@ -52050,8 +53412,8 @@ xEN
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (130,1,1) = {"
 aaa
@@ -52267,8 +53629,8 @@ xEN
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (131,1,1) = {"
 aaa
@@ -52484,8 +53846,8 @@ xEN
 xEN
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (132,1,1) = {"
 aaa
@@ -52701,8 +54063,8 @@ xEN
 xEN
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (133,1,1) = {"
 aaa
@@ -52918,8 +54280,8 @@ xEN
 xEN
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (134,1,1) = {"
 aaa
@@ -53135,8 +54497,8 @@ xEN
 xEN
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (135,1,1) = {"
 aaa
@@ -53352,8 +54714,8 @@ xEN
 xEN
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (136,1,1) = {"
 aaa
@@ -53569,8 +54931,8 @@ xEN
 xEN
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (137,1,1) = {"
 aaa
@@ -53592,8 +54954,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -53786,8 +55148,8 @@ xEN
 xEN
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (138,1,1) = {"
 aaa
@@ -53809,8 +55171,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -54003,8 +55365,8 @@ xEN
 xEN
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (139,1,1) = {"
 aaa
@@ -54026,8 +55388,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -54220,8 +55582,8 @@ jWg
 xEN
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (140,1,1) = {"
 aaa
@@ -54243,8 +55605,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -54437,8 +55799,8 @@ xEN
 xEN
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (141,1,1) = {"
 aaa
@@ -54460,8 +55822,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -54654,8 +56016,8 @@ xEN
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (142,1,1) = {"
 aaa
@@ -54677,8 +56039,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -54871,8 +56233,8 @@ xEN
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (143,1,1) = {"
 aaa
@@ -54894,8 +56256,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -55088,8 +56450,8 @@ hqP
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (144,1,1) = {"
 aaa
@@ -55111,8 +56473,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -55305,8 +56667,8 @@ hqP
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (145,1,1) = {"
 aaa
@@ -55328,8 +56690,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -55522,8 +56884,8 @@ hqP
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (146,1,1) = {"
 aaa
@@ -55545,8 +56907,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -55739,8 +57101,8 @@ hqP
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (147,1,1) = {"
 aaa
@@ -55762,8 +57124,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -55956,8 +57318,8 @@ hqP
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (148,1,1) = {"
 aaa
@@ -55979,8 +57341,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -56173,8 +57535,8 @@ hqP
 hqP
 hqP
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (149,1,1) = {"
 aaa
@@ -56196,8 +57558,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -56390,8 +57752,8 @@ jeY
 jeY
 jeY
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (150,1,1) = {"
 aaa
@@ -56413,8 +57775,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -56578,7 +57940,7 @@ eve
 eve
 fwQ
 eve
-eve
+jeY
 jeY
 jeY
 jeY
@@ -56607,8 +57969,8 @@ jeY
 jeY
 jeY
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (151,1,1) = {"
 aaa
@@ -56630,8 +57992,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -56793,9 +58155,9 @@ jeY
 eve
 eve
 fwQ
-eve
-eve
-fwQ
+jeY
+jeY
+jeY
 jeY
 jeY
 jeY
@@ -56824,8 +58186,8 @@ jeY
 jeY
 jeY
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (152,1,1) = {"
 aaa
@@ -56847,8 +58209,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -57010,9 +58372,9 @@ jeY
 eve
 eve
 eve
-eve
-eve
-eve
+jeY
+jeY
+jeY
 jeY
 jeY
 jeY
@@ -57041,8 +58403,8 @@ jeY
 jeY
 jeY
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (153,1,1) = {"
 aaa
@@ -57064,8 +58426,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -57228,25 +58590,25 @@ fwQ
 eve
 eve
 eve
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
 eve
 eve
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
+uKS
 eve
-eve
-eve
-eve
-eve
+qVN
 jeY
 jeY
 jeY
@@ -57258,8 +58620,8 @@ jeY
 jeY
 jeY
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (154,1,1) = {"
 aaa
@@ -57281,8 +58643,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -57445,8 +58807,8 @@ eve
 eve
 eve
 eve
-eve
-eve
+sTd
+sTd
 jeY
 jeY
 jeY
@@ -57460,10 +58822,10 @@ jeY
 jeY
 jeY
 jeY
-pJO
-pJO
-pJO
-pJO
+sjC
+sjC
+sjC
+sjC
 jeY
 jeY
 jeY
@@ -57475,8 +58837,8 @@ jeY
 jeY
 jeY
 aab
-aaa
-cZm
+aab
+qOl
 "}
 (155,1,1) = {"
 aaa
@@ -57498,8 +58860,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -57658,42 +59020,42 @@ jeY
 jeY
 jeY
 jeY
-pJO
-pJO
-pJO
-pJO
-pJO
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-eve
-fwQ
 eve
 eve
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
+eve
+eve
+sTd
+aPo
+aPo
+aPo
+aPo
+aPo
+aPo
+aPo
+aPo
+aPo
+aPo
+aPo
+aPo
+aPo
+aPo
+aPo
+fzQ
+tqK
+pgW
+aPo
+aPo
+aPo
+aPo
+aPo
+aPo
+aPo
+aPo
+aPo
+aPo
+aPo
 aab
-aaa
-cZm
+qOl
 "}
 (156,1,1) = {"
 aaa
@@ -57715,8 +59077,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -57877,40 +59239,40 @@ jeY
 jeY
 eve
 eve
+fwQ
 eve
 eve
-eve
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-eve
-eve
-eve
-eve
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
+iXU
+wrk
+hoI
+wrk
+wrk
+wrk
+wrk
+uMk
+ncd
+pzS
+ncd
+qsG
+ncd
+ncd
+pzS
+ncd
+ncd
+ncd
+ncd
+lKe
+dpu
+wrk
+wrk
+wrk
+hoI
+wrk
+wrk
+wrk
+aPo
 aab
-aaa
-cZm
+qOl
 "}
 (157,1,1) = {"
 aaa
@@ -57932,8 +59294,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -58097,37 +59459,37 @@ eve
 onX
 eve
 eve
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-eve
-eve
-eve
-eve
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
+daq
+vQS
+vQS
+oUf
+vQS
+vQS
+vQS
+csO
+vQS
+vQS
+vQS
+phD
+vQS
+vQS
+vQS
+vQS
+oUf
+vQS
+vQS
+rel
+fdu
+nqq
+hRM
+nqq
+xPH
+nqq
+nqq
+oUj
+aPo
 aab
-aaa
-cZm
+qOl
 "}
 (158,1,1) = {"
 aaa
@@ -58149,8 +59511,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -58314,37 +59676,37 @@ eve
 eve
 eve
 eve
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-eve
-eve
-eve
-fwQ
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
+daq
+vQS
+hjc
+vQS
+hjc
+vQS
+vQS
+jHx
+vQS
+vQS
+hjc
+vQS
+vQS
+vQS
+vQS
+vQS
+hjc
+vQS
+vQS
+csO
+vQS
+vQS
+vQS
+vQS
+vQS
+vQS
+vQS
+csO
+aPo
 aab
-aaa
-cZm
+qOl
 "}
 (159,1,1) = {"
 aaa
@@ -58366,8 +59728,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -58531,37 +59893,37 @@ eve
 eve
 eve
 eve
-jeY
-jeY
-olJ
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-eve
-fwQ
-eve
-eve
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
+iXU
+wrk
+vwv
+wrk
+wrk
+wrk
+wrk
+csO
+wrk
+qsC
+wrk
+dpu
+wrk
+wrk
+qsC
+wrk
+wrk
+wrk
+wrk
+qEi
+dpu
+wrk
+wrk
+wrk
+qsC
+wrk
+hjc
+csO
+aPo
 aab
-aaa
-cZm
+qOl
 "}
 (160,1,1) = {"
 aaa
@@ -58583,8 +59945,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -58747,38 +60109,38 @@ eve
 eve
 fwQ
 eve
-eve
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-eve
-eve
-eve
-eve
-jeY
-jeY
-jeY
+sTd
+aPo
+aPo
+aPo
+aPo
+aPo
+aPo
+iXU
+hOG
+iXU
+tdv
+aPo
+aPo
+aPo
+aPo
+xjJ
+ryO
+fhb
+tdv
+aPo
+aPo
+aPo
+aPo
+aPo
+aPo
+aPo
+clx
+vQS
+csO
+aPo
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
-cZm
+qOl
 "}
 (161,1,1) = {"
 aaa
@@ -58800,8 +60162,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -58964,7 +60326,25 @@ eve
 eve
 eve
 eve
-eve
+sTd
+jeY
+jeY
+jeY
+jeY
+jeY
+aPo
+wrk
+csO
+wrk
+tdv
+jeY
+jeY
+jeY
+aPo
+kOh
+kOh
+kOh
+mxP
 jeY
 jeY
 jeY
@@ -58972,30 +60352,12 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-eve
-eve
-eve
-eve
-jeY
-jeY
-jeY
+aPo
+vQS
+csO
+aPo
 aab
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cZm
+qOl
 "}
 (162,1,1) = {"
 aaa
@@ -59017,8 +60379,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -59187,6 +60549,19 @@ jeY
 jeY
 jeY
 jeY
+aPo
+uTK
+csO
+cSH
+tdv
+jeY
+jeY
+jeY
+aPo
+kOh
+elV
+kOh
+mxP
 jeY
 jeY
 jeY
@@ -59194,25 +60569,12 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-eve
-eve
-eve
-eve
-jeY
-jeY
-jeY
+aPo
+vQS
+eXq
+aPo
 aab
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cZm
+qOl
 "}
 (163,1,1) = {"
 aaa
@@ -59234,8 +60596,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -59404,6 +60766,19 @@ jeY
 jeY
 jeY
 jeY
+aPo
+mxP
+yjY
+mxP
+tdv
+jeY
+jeY
+jeY
+aPo
+uIf
+ycc
+kOh
+mxP
 jeY
 jeY
 jeY
@@ -59411,25 +60786,12 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-eve
-eve
-fwQ
-eve
-jeY
-jeY
-jeY
+aPo
+vQS
+csO
+aPo
 aab
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cZm
+qOl
 "}
 (164,1,1) = {"
 aaa
@@ -59451,8 +60813,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -59616,7 +60978,24 @@ eve
 eve
 eve
 eve
-eve
+jeY
+jeY
+jeY
+jeY
+jeY
+aPo
+wrk
+xnp
+wrk
+tdv
+jeY
+jeY
+jeY
+aPo
+gfc
+kOh
+xRc
+mxP
 jeY
 jeY
 jeY
@@ -59624,29 +61003,12 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-eve
-eve
-eve
-eve
-jeY
-jeY
-jeY
+aPo
+vQS
+csO
+aPo
 aab
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cZm
+qOl
 "}
 (165,1,1) = {"
 aaa
@@ -59668,8 +61030,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -59833,7 +61195,24 @@ eve
 eve
 eve
 eve
-eve
+jeY
+jeY
+jeY
+jeY
+jeY
+aPo
+wrk
+csO
+wrk
+tdv
+jeY
+jeY
+jeY
+aPo
+gMF
+kOh
+kOh
+mxP
 jeY
 jeY
 jeY
@@ -59841,29 +61220,12 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-eve
-fwQ
-eve
-jeY
-jeY
-jeY
-jeY
+aPo
+vcC
+oEr
+aPo
 aab
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cZm
+qOl
 "}
 (166,1,1) = {"
 aaa
@@ -59885,8 +61247,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -60050,7 +61412,24 @@ fwQ
 eve
 eve
 eve
-eve
+jeY
+jeY
+jeY
+jeY
+jeY
+aPo
+wrk
+rel
+pPX
+tdv
+jeY
+jeY
+jeY
+aPo
+gfc
+kOh
+kOh
+mxP
 jeY
 jeY
 jeY
@@ -60058,29 +61437,12 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-eve
-eve
-eve
-eve
-jeY
-jeY
-jeY
-jeY
+aPo
+upD
+csO
+aPo
 aab
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cZm
+qOl
 "}
 (167,1,1) = {"
 aaa
@@ -60102,8 +61464,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -60267,37 +61629,37 @@ eve
 eve
 eve
 eve
-eve
-eve
-eve
 jeY
 jeY
 jeY
 jeY
 jeY
+aPo
+uTK
+csO
+cSH
+tdv
 jeY
 jeY
 jeY
-jeY
-jeY
-eve
-eve
-eve
-eve
-jeY
-jeY
-jeY
-jeY
+aPo
+mxP
+kOG
+mxP
+mxP
+sTd
+sTd
+sTd
+sTd
+sTd
+sTd
+sTd
+tdv
+vQS
+csO
+aPo
 aab
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cZm
+qOl
 "}
 (168,1,1) = {"
 aaa
@@ -60319,8 +61681,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -60484,37 +61846,37 @@ eve
 eve
 eve
 eve
-fwQ
-eve
-eve
-eve
-eve
 jeY
 jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-eve
-eve
-eve
-eve
-eve
-jeY
+aPo
+wrk
+csO
+wrk
+tdv
 jeY
 jeY
 jeY
+aPo
+udL
+kOh
+kOh
+mxP
+mwU
+kOh
+kOh
+kOh
+kOh
+kOh
+xRc
+uHf
+vQS
+nru
+aPo
 aab
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cZm
+qOl
 "}
 (169,1,1) = {"
 aaa
@@ -60536,8 +61898,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -60701,37 +62063,37 @@ eve
 eve
 eve
 eve
-eve
-eve
-eve
-eve
-eve
-eve
-eve
-eve
-eve
-jeY
-jeY
-jeY
-eve
-eve
-eve
-eve
-eve
 jeY
 jeY
 jeY
 jeY
+jeY
+aPo
+wrk
+csO
+wrk
+tdv
+jeY
+jeY
+jeY
+aPo
+dTY
+ycc
+kOh
+aoD
+kOh
+kOh
+ycc
+kOh
+elV
+kOh
+kOh
+ryO
+vQS
+csO
+aPo
 aab
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cZm
+qOl
 "}
 (170,1,1) = {"
 aaa
@@ -60753,8 +62115,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -60918,37 +62280,37 @@ eve
 eve
 eve
 eve
-eve
-eve
-eve
-eve
-eve
-eve
-eve
-eve
-eve
-eve
-eve
-eve
-eve
-fwQ
-eve
-eve
-eve
 jeY
 jeY
 jeY
 jeY
+jeY
+aPo
+mxP
+yjY
+mxP
+tdv
+jeY
+jeY
+jeY
+aPo
+lic
+hog
+hKM
+sTd
+kOh
+kOh
+eqs
+eqs
+okr
+ycc
+kOh
+tdv
+vQS
+eXq
+aPo
 aab
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cZm
+qOl
 "}
 (171,1,1) = {"
 aaa
@@ -60970,8 +62332,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -61110,7 +62472,7 @@ xvL
 eve
 xvL
 eve
-eve
+iXG
 eve
 jeY
 jeY
@@ -61135,37 +62497,37 @@ eve
 eve
 eve
 eve
-eve
-eve
-eve
-eve
-eve
-fwQ
-eve
-fwQ
-eve
-eve
-eve
-eve
-eve
-eve
-eve
-eve
 jeY
 jeY
 jeY
 jeY
+jeY
+aPo
+bIZ
+csO
+wrk
+tdv
+jeY
+jeY
+jeY
+aPo
+oVG
+kOh
+eTn
+aPo
+aPo
+aPo
+aPo
+aPo
+aPo
+aPo
+aPo
+tdv
+vQS
+csO
+aPo
 aab
-aab
-aaa
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-cZm
+qOl
 "}
 (172,1,1) = {"
 aaa
@@ -61187,8 +62549,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -61352,37 +62714,37 @@ eve
 eve
 eve
 eve
-eve
-eve
-eve
-eve
-eve
+jeY
+jeY
+jeY
+jeY
+jeY
+aPo
+uTK
+csO
+cSH
+tdv
+sTd
+sTd
+sTd
+aPo
+sTd
+sTd
+gmF
+aPo
 jeY
 jeY
 jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-aab
-aaa
-aaa
-aab
-bHv
-bHv
-bHv
-bHv
-bHv
-bHv
-cZm
+aPo
+tdv
+xqW
+oEm
+aPo
+sTd
+qOl
 "}
 (173,1,1) = {"
 aaa
@@ -61404,8 +62766,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -61569,37 +62931,37 @@ eve
 eve
 eve
 eve
-eve
-eve
-eve
-eve
-eve
+jeY
+jeY
+jeY
+jeY
+jeY
+aPo
+wrk
+csO
+wrk
+tdv
+kOh
+kOh
+kOh
+aoD
+kOh
+kOh
+eTn
+aPo
 jeY
 jeY
 jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-aab
-aab
-aab
-aab
-aab
-aaa
-aaa
-aab
-bHv
+aPo
 tzW
-eCh
-eCh
-eCh
-bHv
-cZm
+vQS
+csO
+xqW
+sTd
+qOl
 "}
 (174,1,1) = {"
 aaa
@@ -61621,8 +62983,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -61787,36 +63149,36 @@ eve
 eve
 eve
 jeY
-eve
-eve
-eve
-eve
+jeY
+jeY
+jeY
+jeY
+aPo
+wrk
+wtd
+ncd
+tHZ
+lIZ
+eOZ
+xtF
+qcY
+lIZ
+eOZ
+oCu
+aPo
 jeY
 jeY
 jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-aab
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aab
-bHv
-eKa
+aPo
+tzW
 hjc
-eKa
+csO
 vry
-bHv
-cZm
+sTd
+qOl
 "}
 (175,1,1) = {"
 aaa
@@ -61838,8 +63200,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -62008,32 +63370,32 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
+aPo
+wrk
+csO
+wrk
+ryO
 kOh
-aab
-aaa
-aaa
-aaa
-aab
-aab
-aab
-aab
-bHv
+kOh
+kOh
+aPo
+kOh
+kOh
+kOh
+aPo
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+aPo
 uwD
-eKa
-eKa
-eKa
-bHv
-cZm
+vQS
+csO
+xqW
+sTd
+qOl
 "}
 (176,1,1) = {"
 aaa
@@ -62055,8 +63417,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -62225,32 +63587,32 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
-aaa
-aaa
-aaa
-aab
-bHv
-bHv
-bHv
-bHv
-bHv
-cur
+aPo
+wrk
 csO
-cur
-bHv
-cZm
+wrk
+tdv
+mxP
+mxP
+mxP
+tdv
+mxP
+kOh
+elV
+aPo
+jeY
+jeY
+mly
+tdv
+tdv
+tdv
+tdv
+tzW
+vQS
+csO
+xqW
+sTd
+qOl
 "}
 (177,1,1) = {"
 aaa
@@ -62272,8 +63634,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -62436,38 +63798,38 @@ eve
 eve
 eve
 eve
-eve
+sTd
 jeY
 jeY
 jeY
 jeY
 jeY
+aPo
+uTK
+xnp
+cSH
+aPo
 jeY
 jeY
 jeY
+tdv
+sTd
+kOh
+kOh
+aPo
 jeY
 jeY
-aab
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aab
-aab
-aab
-aab
-bHv
-utr
-utr
-utr
-utr
-utr
-tDh
-utr
-bHv
-cZm
+mly
+fKy
+tzW
+uwD
+ssh
+tzW
+vQS
+xnp
+xqW
+sTd
+qOl
 "}
 (178,1,1) = {"
 aaa
@@ -62489,8 +63851,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -62652,39 +64014,39 @@ eve
 eve
 eve
 eve
-eve
-eve
+sTd
+sTd
 jeY
 jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-aab
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aab
-jeY
-jeY
-bHv
-bHv
+aPo
 mxP
+yjY
+mxP
+aPo
+jeY
+jeY
+jeY
+tdv
+tny
+kOh
+kOh
+aPo
+jeY
+jeY
+mxP
+wel
+vNo
 tDh
-kpD
-utr
-utr
-utr
-utr
-bHv
-cZm
+mxP
+tzW
+vQS
+csO
+xqW
+sTd
+qOl
 "}
 (179,1,1) = {"
 aaa
@@ -62706,8 +64068,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -62869,39 +64231,39 @@ eve
 fwQ
 eve
 eve
-eve
-eve
+sTd
+sTd
 jeY
 jeY
 jeY
 jeY
 jeY
+aPo
+wrk
+csO
+wrk
+aPo
 jeY
 jeY
 jeY
+tdv
+lCu
+kOh
+kOh
+aPo
 jeY
 jeY
-aab
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aab
-jeY
-jeY
-bHv
 mxP
-utr
-utr
-utr
-utr
-utr
-utr
-utr
-bHv
-cZm
+mxP
+mxP
+mxP
+mxP
+vQS
+vQS
+csO
+xqW
+sTd
+qOl
 "}
 (180,1,1) = {"
 aaa
@@ -62923,8 +64285,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -63086,39 +64448,39 @@ eve
 eve
 eve
 eve
-eve
-eve
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-aab
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aab
-jeY
-jeY
-bHv
-utr
-utr
-utr
-ihM
-utr
-utr
-utr
-tDh
-bHv
-cZm
+vFT
+aPo
+aPo
+aPo
+aPo
+aPo
+aPo
+aPo
+kTu
+wjl
+kTu
+tdv
+tdv
+tdv
+tdv
+coI
+tdv
+ryO
+fhb
+clx
+aPo
+aPo
+tdv
+vQS
+vQS
+vQS
+vQS
+vQS
+vQS
+csO
+buT
+sTd
+qOl
 "}
 (181,1,1) = {"
 aaa
@@ -63140,8 +64502,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -63303,39 +64665,39 @@ eve
 eve
 eve
 eve
-eve
-eve
-jeY
-jeY
-jeY
-jeY
-jeY
-aab
-aab
-aab
-aab
-aab
-aab
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aab
-jeY
-jeY
-bHv
+bey
+pQo
+wrk
+wrk
+wrk
+hoI
+wrk
+wrk
+wrk
+csO
+wrk
+hoI
+wrk
+wrk
+wrk
+mcd
+wrk
+wrk
+wrk
+wrk
+hoI
+wrk
+wrk
 vQS
-utr
+vQS
 jFi
-utr
-utr
-utr
-utr
-eYb
-bHv
-cZm
+wAY
+wAY
+vQS
+csO
+vry
+sTd
+qOl
 "}
 (182,1,1) = {"
 aaa
@@ -63357,8 +64719,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -63520,39 +64882,39 @@ eve
 eve
 eve
 eve
-eve
-eve
-jeY
-jeY
-jeY
-jeY
-jeY
-aab
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aab
-jeY
-jeY
-bHv
-utr
-utr
-utr
-utr
-utr
-utr
+bOy
+cYb
+nqq
+nqq
+nqq
+hRM
+nqq
+nqq
+nqq
+hiC
+nqq
+hRM
+nqq
+nqq
+nqq
+tCw
+nqq
+nqq
+xPH
+nqq
+nqq
+nqq
+nqq
+nqq
+tyh
+nqq
+qtr
+qtr
+xmO
 iYa
-tfr
-bHv
-cZm
+lmq
+sTd
+qOl
 "}
 (183,1,1) = {"
 aaa
@@ -63574,8 +64936,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -63735,41 +65097,41 @@ eve
 eve
 eve
 eve
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-aab
-aab
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aab
-jeY
-jeY
-vtS
+eve
+eve
+eve
+tSF
+vQS
+vQS
+vQS
+vQS
+vQS
+vQS
+vQS
+csO
+vQS
+vQS
+vQS
+vQS
+vQS
+buT
+vQS
+vQS
+vQS
+hjc
+vQS
+vQS
+vQS
 gvo
-utr
-tDh
+csO
+hjc
 nPl
-utr
-utr
-utr
-utr
-bHv
-cZm
+mxP
+ecc
+vQS
+xqW
+sTd
+qOl
 "}
 (184,1,1) = {"
 aaa
@@ -63791,8 +65153,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -63950,43 +65312,43 @@ eve
 fwQ
 eve
 eve
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-aab
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aab
-jeY
-jeY
-bHv
-utr
-utr
-utr
-utr
-utr
-utr
-utr
-utr
-bHv
-cZm
+eve
+eve
+eve
+eve
+eve
+tSF
+vQS
+vQS
+oUf
+vQS
+vQS
+vQS
+vQS
+csO
+vQS
+vQS
+vQS
+vQS
+vQS
+xqW
+vQS
+vQS
+vQS
+vQS
+vQS
+vQS
+vQS
+vQS
+csO
+vQS
+sBX
+sBX
+vQS
+vQS
+xqW
+sTd
+qOl
 "}
 (185,1,1) = {"
 aaa
@@ -64008,8 +65370,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -64169,41 +65531,41 @@ fwQ
 eve
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-aab
-aab
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aab
-jeY
-jeY
-bHv
-utr
-utr
-utr
-utr
-utr
-utr
-utr
-utr
-bHv
-cZm
+eve
+eve
+eve
+pQo
+wrk
+wrk
+wrk
+qsC
+wrk
+wrk
+wrk
+iqL
+wrk
+qsC
+wrk
+wrk
+wrk
+xnv
+wrk
+wrk
+wrk
+wrk
+qsC
+wrk
+wrk
+vQS
+csO
+vQS
+vQS
+vQS
+vQS
+vQS
+xqW
+sTd
+qOl
 "}
 (186,1,1) = {"
 aaa
@@ -64225,8 +65587,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -64386,41 +65748,41 @@ eve
 eve
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-aab
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aab
-jeY
-jeY
-bHv
-utr
+eve
+eve
+eve
+tdv
+tdv
+tdv
+aPo
+tdv
+tdv
+aPo
+aPo
+coI
+tdv
+tdv
+tdv
+tdv
+tdv
+tdv
+tdv
+tdv
+tdv
+tdv
+tdv
+tdv
+aPo
+vQS
 gfg
 tfr
-utr
+vQS
 qdE
-utr
-utr
-utr
-bHv
-cZm
+vQS
+vQS
+xqW
+sTd
+qOl
 "}
 (187,1,1) = {"
 aaa
@@ -64442,8 +65804,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -64604,40 +65966,40 @@ eve
 jeY
 jeY
 jeY
+eve
+sTd
+sTd
 jeY
 jeY
 jeY
 jeY
 jeY
 jeY
-aab
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aab
 jeY
 jeY
-bHv
-vQS
-utr
+jeY
+jeY
+jeY
+jeY
+eve
+eve
+jeY
+jeY
+jeY
+xEp
+jeY
+jeY
+sTd
+upD
+csO
 rjr
-tDh
+hjc
 xni
-utr
-tDh
-eYb
-bHv
-cZm
+vQS
+hjc
+vry
+sTd
+qOl
 "}
 (188,1,1) = {"
 aaa
@@ -64659,8 +66021,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -64822,39 +66184,39 @@ jeY
 jeY
 jeY
 jeY
+sTd
+sTd
 jeY
 jeY
 jeY
 jeY
 jeY
-aab
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aab
 jeY
 jeY
-bHv
-utr
-utr
-qDZ
-utr
-utr
-utr
-utr
-utr
-bHv
-cZm
+jeY
+eve
+eve
+eve
+eve
+eve
+eve
+jeY
+jeY
+jeY
+xEp
+jeY
+jeY
+sTd
+vQS
+csO
+vQS
+vQS
+vQS
+vQS
+vQS
+vQS
+sTd
+qOl
 "}
 (189,1,1) = {"
 aaa
@@ -64876,8 +66238,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -65040,29 +66402,29 @@ jeY
 jeY
 jeY
 jeY
+sTd
 jeY
 jeY
 jeY
 jeY
-aab
-aaa
-aaa
-aaa
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-qOl
+jeY
+jeY
+jeY
+jeY
+eve
+eve
+eve
+eve
+fwQ
+eve
+jeY
+jeY
+jeY
 xEp
 xEp
-mFd
+xEp
 aPo
+xqW
 nMb
 qXP
 uyC
@@ -65070,8 +66432,8 @@ xqW
 qbd
 xqW
 xqW
-mFd
-cZm
+aPo
+qOl
 "}
 (190,1,1) = {"
 aaa
@@ -65093,8 +66455,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -65261,34 +66623,34 @@ jeY
 jeY
 jeY
 jeY
-aab
-aaa
-aaa
-aaa
-cZm
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aab
+jeY
+jeY
+jeY
+jeY
+jeY
+fwQ
+eve
+eve
+eve
+eve
+jeY
+jeY
+jeY
+jeY
+jeY
 jeY
 xEp
-bHv
+sTd
 myA
 nQE
 rde
 uCk
 xuX
-bHv
-bHv
-bHv
-bHv
-aaa
+sTd
+sTd
+sTd
+sTd
+aab
 "}
 (191,1,1) = {"
 aaa
@@ -65310,8 +66672,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -65478,34 +66840,34 @@ jeY
 jeY
 jeY
 jeY
-aab
-aaa
-aaa
-aaa
-cZm
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aab
+jeY
+jeY
+jeY
+jeY
+eve
+eve
+eve
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
 jeY
 xEp
-bHv
-bHv
+sTd
+sTd
 oiH
-rdw
-rdw
+vQS
+vQS
 xyY
-bHv
+sTd
 aab
 aab
 aab
-aaa
+aab
 "}
 (192,1,1) = {"
 aaa
@@ -65527,8 +66889,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -65695,30 +67057,30 @@ jeY
 jeY
 jeY
 jeY
-aab
-aaa
-aaa
-aaa
-cZm
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aab
+jeY
+jeY
+jeY
+eve
+eve
+eve
+eve
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
 jeY
 xEp
 jeY
-bHv
+sTd
 oiH
-rhf
-rhf
+wrk
+wrk
 xyY
-bHv
+sTd
 aab
 aaa
 aaa
@@ -65744,8 +67106,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -65912,30 +67274,30 @@ jeY
 jeY
 jeY
 jeY
-aab
-aaa
-aaa
-aaa
-cZm
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aab
+jeY
+jeY
+jeY
+eve
+eve
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
 jeY
 xEp
 jeY
-bHv
+sTd
 oVQ
 riu
 uKa
 xJu
-bHv
+sTd
 aab
 aaa
 aaa
@@ -65961,8 +67323,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -66129,30 +67491,30 @@ jeY
 jeY
 jeY
 jeY
-aab
-aaa
-aaa
-aaa
-cZm
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aab
+jeY
+jeY
+jeY
+fwQ
+eve
+eve
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
 jeY
 xEp
 jeY
-bHv
+sTd
 oZb
-rdw
-rdw
+vQS
+vQS
 xRF
-bHv
+sTd
 aab
 aaa
 aaa
@@ -66178,8 +67540,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -66346,30 +67708,30 @@ jeY
 jeY
 jeY
 jeY
-aab
-aaa
-aaa
-aaa
-cZm
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aab
+jeY
+jeY
+eve
+eve
+eve
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
 jeY
 xEp
 jeY
-bHv
-pgV
+sTd
+qgz
 rpq
 uLC
 xSt
-bHv
+sTd
 aab
 aaa
 aaa
@@ -66395,8 +67757,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -66563,30 +67925,30 @@ jeY
 jeY
 jeY
 jeY
-aab
-aaa
-aaa
-aaa
-cZm
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aab
+jeY
+jeY
+eve
+eve
+eve
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
 jeY
 xEp
 jeY
-bHv
-pgV
+sTd
+qgz
 rAe
 vbQ
 uad
-bHv
+sTd
 aab
 aaa
 aaa
@@ -66612,8 +67974,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -66780,30 +68142,30 @@ jeY
 jeY
 jeY
 jeY
-aab
-aaa
-aaa
-aab
-qOl
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-hqP
-fqj
-hqP
-bHv
+jeY
+jeY
+eve
+eve
+eve
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+xEp
+jeY
+sTd
 pkI
 rKr
 voK
 dFp
-bHv
+sTd
 aab
 aaa
 aaa
@@ -66829,8 +68191,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -66986,7 +68348,7 @@ fwQ
 eve
 eve
 fwQ
-eve
+vKc
 loN
 jeY
 jeY
@@ -66997,30 +68359,30 @@ jeY
 jeY
 jeY
 jeY
-aab
-aaa
-aaa
-aab
-fqj
-hqP
-hqP
-hqP
-hqP
-hqP
-hqP
-hqP
-hqP
-hqP
-hqP
-hqP
-fqj
-hqP
-bHv
-pgV
+jeY
+jeY
+eve
+eve
+eve
+eve
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+xEp
+jeY
+sTd
+qgz
 rYD
 vuE
 gXn
-bHv
+sTd
 aab
 aaa
 aaa
@@ -67046,8 +68408,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -67214,30 +68576,30 @@ jeY
 jeY
 jeY
 jeY
-aab
-aaa
-aaa
-aab
-fqj
-hqP
-hqP
-hqP
-hqP
-hqP
-hqP
-hqP
-hqP
-hqP
-hqP
-hqP
-fqj
-hqP
-bHv
+jeY
+jeY
+eve
+eve
+eve
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+xEp
+jeY
+sTd
 pst
-rhf
+wrk
 vxE
 uad
-bHv
+sTd
 aab
 aaa
 aaa
@@ -67263,8 +68625,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -67419,8 +68781,8 @@ eve
 fwQ
 eve
 eve
-eve
-jeY
+vKc
+kcY
 loN
 jeY
 jeY
@@ -67431,30 +68793,30 @@ jeY
 jeY
 jeY
 jeY
-aab
-aaa
-aaa
-aab
-fqj
-hqP
-hqP
-hqP
-hqP
-hqP
-hqP
-hqP
-hqP
-hqP
-hqP
-hqP
-fqj
-hqP
-bHv
+jeY
+jeY
+eve
+eve
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+xEp
+jeY
+sTd
 pAs
 shI
 vzg
 uad
-bHv
+sTd
 aab
 aaa
 aaa
@@ -67480,8 +68842,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -67635,43 +68997,43 @@ tZR
 eve
 eve
 eve
+jeY
+jeY
+eve
+mGX
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+eve
 eve
 jeY
 jeY
-loN
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-aab
-aaa
-aaa
-aab
-fqj
-hqP
-hqP
-hqP
-bHv
-bHv
-bHv
-bHv
-bHv
-bHv
-xJp
-xJp
+sTd
+sTd
+sTd
+sTd
+sTd
+sTd
+sTd
+sTd
 aPo
-xJp
-bHv
+sTd
+mxP
 oZb
-rdw
+vQS
 vFE
 xRF
-bHv
+sTd
 aab
 aaa
 aaa
@@ -67697,8 +69059,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -67853,27 +69215,27 @@ eve
 eve
 jeY
 jeY
-jeY
-jeY
-loN
-jeY
-jeY
-jeY
+eve
+eve
+mGX
 jeY
 jeY
 jeY
 jeY
 jeY
 jeY
-aab
-aaa
-aaa
-aab
-fqj
-hqP
-hqP
-hqP
-bHv
+jeY
+jeY
+jeY
+jeY
+eve
+fwQ
+eve
+jeY
+jeY
+jeY
+jeY
+sTd
 dzW
 eCh
 eCh
@@ -67883,12 +69245,12 @@ igD
 juh
 kbu
 igD
-bHv
-pgV
+mxP
+qgz
 sBJ
 vWM
 uad
-bHv
+sTd
 aab
 aaa
 aaa
@@ -67914,8 +69276,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 ptp
 ptp
@@ -68069,43 +69431,43 @@ tZR
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-loN
-jeY
-jeY
-jeY
-jeY
+eve
+eve
+fwQ
+mGX
 jeY
 jeY
 jeY
 jeY
 jeY
-aab
-aaa
-aaa
-aab
-fqj
-hqP
-hqP
-hqP
-bHv
+jeY
+jeY
+jeY
+jeY
+jeY
+eve
+eve
+eve
+jeY
+jeY
+jeY
+jeY
+nWE
 dFO
-eKa
-eKa
+kOh
+kOh
 fQH
-bHv
+mxP
 igK
 juu
 emA
 lgV
-bHv
-pgV
+mxP
+qgz
 sCz
 vYr
 ccx
-bHv
+sTd
 aab
 aaa
 aaa
@@ -68131,8 +69493,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -68285,44 +69647,44 @@ jeY
 loN
 loN
 loN
-loN
-loN
-loN
-loN
-loN
+mGX
+mGX
+mGX
+mGX
+mGX
 jeY
 jeY
 jeY
 jeY
+eve
+eve
+eve
+eve
+jeY
+jeY
+eve
+eve
+eve
 jeY
 jeY
 jeY
 jeY
-jeY
-aab
-aaa
-aaa
-aab
-fqj
-hqP
-hqP
-hqP
-bHv
+sTd
 dLF
-eKa
-eKa
+kOh
+xRc
 gfc
 pNt
 ijF
 juU
 kbu
 lpn
-bHv
+mxP
 pEd
-qDZ
-utr
+piE
+rde
 uad
-bHv
+sTd
 aab
 aaa
 aaa
@@ -68348,8 +69710,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -68501,45 +69863,45 @@ jeY
 jeY
 jeY
 jeY
+eve
+eve
+eve
+eve
+eve
+eve
+eve
 jeY
 jeY
 jeY
+eve
+eve
+eve
 jeY
 jeY
+eve
+eve
+eve
+eve
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-aab
-aaa
-aaa
-aab
-fqj
-hqP
-xJp
-xJp
-bHv
-bHv
-bHv
-bHv
-bHv
-mFd
+sTd
+sTd
+mxP
+tdv
+mxP
+mxP
+mxP
+aPo
 xiw
 jAz
 kzI
 igD
 mDZ
-pgV
+qgz
 sLI
-rdw
+vQS
 nuE
-bHv
+sTd
 aab
 aaa
 aaa
@@ -68565,8 +69927,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -68721,42 +70083,42 @@ jeY
 jeY
 jeY
 jeY
+eve
+eve
+eve
+eve
 jeY
 jeY
 jeY
+eve
+eve
+eve
+eve
+eve
+eve
+eve
+eve
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-aab
-aaa
-aaa
-aab
-fqj
-hqP
-xJp
+sTd
 osi
 hvr
 dPa
 eLI
-xJp
-xJp
-mFd
-det
-det
-det
+sTd
+sTd
+aPo
+nBy
+nBy
+nBy
 lqu
-bHv
-pgV
+mxP
+qgz
 riu
 wbU
 nQS
-bHv
+sTd
 aab
 aaa
 aaa
@@ -68782,8 +70144,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -68938,42 +70300,42 @@ jeY
 jeY
 jeY
 jeY
+eve
+eve
+eve
+eve
 jeY
 jeY
 jeY
 jeY
+eve
+eve
+eve
+eve
+eve
+eve
+eve
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-aab
-aaa
-aaa
-aab
-fqj
-hqP
-xJp
+sTd
 glf
-ipY
-ipY
-ipY
-eyz
+vlA
+nBy
+vlA
+mxP
 gok
-eyz
+mxP
 iAa
-ipY
+vlA
 kHY
 lrg
-bHv
-pgV
+mxP
+qgz
 sTE
 wpF
 uad
-bHv
+sTd
 aab
 aaa
 aaa
@@ -68999,8 +70361,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -69155,42 +70517,42 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-aab
-aaa
-aaa
-aab
-fqj
-hqP
-xJp
-bTi
-rqU
-ipY
-ipY
+eve
+eve
+eve
+eve
+eve
+fwQ
+eve
+eve
+eve
+eve
+eve
+eve
+eve
+eve
+eve
+eve
+eve
+eve
+mxP
+vlA
+vlA
+nBy
+vlA
 ePv
 gsZ
 ePv
-ipY
-ipY
-ipY
-ipY
-mFd
+vlA
+vlA
+vlA
+vlA
+tdv
 oZb
 sVq
 sLI
 xRF
-bHv
+sTd
 aab
 aaa
 aaa
@@ -69216,8 +70578,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -69372,42 +70734,42 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-aab
-aaa
-aaa
-aab
-fqj
-hqP
+eve
+eve
+eve
+eve
+eve
+eve
+eve
+eve
+fwQ
+eve
+eve
+eve
+eve
+eve
+fwQ
+eve
+xEp
+xEp
 aPo
 ceT
-det
+nBy
 uqs
-det
+nBy
 fIi
 gwV
 hjE
 nBy
-bKh
-det
+nBy
+nBy
 luM
-mFd
+tdv
 pHZ
 sWk
-qDZ
+rde
 uad
-bHv
+sTd
 aab
 aaa
 aaa
@@ -69433,8 +70795,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -69589,42 +70951,42 @@ jeY
 jeY
 jeY
 jeY
+eve
 jeY
 jeY
 jeY
 jeY
 jeY
+eve
+eve
+eve
 jeY
 jeY
 jeY
 jeY
 jeY
+eve
+eve
+xEp
 jeY
-jeY
-aab
-aaa
-aaa
-aab
-fqj
-hqP
-xJp
+sTd
 cin
-ipY
-ipY
-ipY
+vlA
+vlA
+vlA
 ePv
 gsZ
 ePv
-ipY
-ipY
+vlA
+vlA
 kXR
 lAi
-bHv
+mxP
 pHZ
 tjb
 weF
 uad
-bHv
+sTd
 aab
 aaa
 aaa
@@ -69650,8 +71012,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -69818,30 +71180,30 @@ jeY
 jeY
 jeY
 jeY
-aab
-aaa
-aaa
-aab
-fqj
-hqP
-xJp
+jeY
+jeY
+eve
+jeY
+xEp
+jeY
+sTd
 coa
-ipY
+vlA
 dYK
-ipY
-eyz
+vlA
+mxP
 gsZ
-eyz
+mxP
 iJf
 jGP
 dYK
-ipY
-bHv
+vlA
+mxP
 tXf
 tjQ
 wff
 uad
-bHv
+sTd
 aab
 aaa
 aaa
@@ -69867,8 +71229,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -70035,30 +71397,30 @@ jeY
 jeY
 jeY
 jeY
-aab
-aaa
-aaa
-aab
-fqj
-hqP
-xJp
-xJp
-eyz
-eyz
-eyz
-eyz
+jeY
+jeY
+jeY
+jeY
+xEp
+jeY
+sTd
+aPo
+mxP
+mxP
+mxP
+mxP
 gsZ
-eyz
-eyz
-eyz
-eyz
-eyz
+mxP
+mxP
+mxP
+mxP
+mxP
 mDZ
 pVl
-rdw
+vQS
 wnO
 ePu
-bHv
+sTd
 aab
 aaa
 aaa
@@ -70084,8 +71446,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -70252,30 +71614,30 @@ jeY
 jeY
 jeY
 jeY
-aab
-aaa
-aaa
-aab
-fqj
-hqP
+jeY
+jeY
+jeY
+jeY
+xEp
+jeY
 sTd
 ipY
 dbi
 dbi
 dbi
-fcT
+mxP
 gAX
 dbi
 dbi
 jKd
 dbi
-rhf
-mPE
+wrk
+wrk
 pVB
 tyD
 wpF
 uad
-bHv
+sTd
 aab
 aaa
 aaa
@@ -70301,8 +71663,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -70469,30 +71831,30 @@ jeY
 jeY
 jeY
 jeY
-aab
-aaa
-aaa
-aab
-fqj
-hqP
+jeY
+jeY
+jeY
+jeY
+xEp
+jeY
 sTd
 nVP
 lHD
-ipY
-ipY
+vlA
+vlA
 fnW
 gCH
 hwc
 hwc
 hwc
 eRD
-lFK
+ncd
 ncd
 qbh
-rhf
+wrk
 wpO
 smb
-bHv
+sTd
 aab
 aaa
 aaa
@@ -70518,8 +71880,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -70686,14 +72048,14 @@ jeY
 jeY
 jeY
 jeY
-aab
-aaa
-aaa
-aab
-fqj
-hqP
+jeY
+jeY
+jeY
+jeY
+xEp
+jeY
 sTd
-ipY
+szr
 ekE
 ekE
 ekE
@@ -70703,13 +72065,13 @@ hRb
 hRb
 ekE
 ekE
-rhf
-mPE
+wrk
+wrk
 qcC
 tAB
 wrk
 uad
-bHv
+sTd
 aab
 aaa
 aaa
@@ -70735,8 +72097,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -70904,29 +72266,29 @@ aab
 aab
 aab
 aab
-aaa
-aaa
+aab
+aab
 aab
 qOl
 aab
-xJp
-xJp
-eyz
-eli
-eyz
-eyz
+sTd
+sTd
+mxP
+tdv
+mxP
+mxP
 gZX
-eli
-eli
-eyz
-eyz
-ddi
-bHv
+tdv
+tdv
+mxP
+mxP
+mxP
+mxP
 qfQ
 tCQ
 vuE
 uad
-bHv
+sTd
 aab
 aaa
 aaa
@@ -70952,8 +72314,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -71124,26 +72486,26 @@ aaa
 aaa
 aaa
 aaa
-cZm
+qOl
 aab
-xJp
+sTd
 cBo
 deb
 eoX
-eMX
-eli
+nBy
+tdv
 gZX
-eli
+tdv
 iKL
-ipY
+vlA
 lgf
 lNk
-bHv
+mxP
 qgz
-tDh
+qwT
 wBY
 uad
-bHv
+sTd
 aab
 aaa
 aaa
@@ -71169,8 +72531,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -71341,26 +72703,26 @@ aaa
 aaa
 aaa
 aaa
-cZm
+qOl
 aab
-xJp
+sTd
 cHL
-det
+nBy
 euF
 vlA
 fAC
 gZX
 fAC
-ipY
-ipY
-rqU
+vlA
+vlA
+vlA
 lPS
-bHv
-pgV
+mxP
+qgz
 vbQ
 bRs
 lBJ
-bHv
+sTd
 aab
 aaa
 aaa
@@ -71386,8 +72748,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -71558,26 +72920,26 @@ aaa
 aaa
 aaa
 aaa
-cZm
+qOl
 aab
-xJp
+sTd
 cLi
 dhn
-ipY
-ipY
+vlA
+vlA
 fIi
 scd
 hSh
-det
+nBy
 uqs
-det
+nBy
 lZp
-mFd
-pgV
+tdv
+qgz
 tHW
 wKg
 uad
-bHv
+sTd
 aab
 aaa
 aaa
@@ -71603,8 +72965,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -71775,26 +73137,26 @@ aaa
 aaa
 aaa
 aaa
-cZm
+qOl
 aab
-xJp
+sTd
 cMC
 fuB
 lHD
-ipY
+vlA
 fAC
 gZX
 hTI
-rqU
+vlA
 ekC
-ipY
+vlA
 mrL
-bHv
-pgV
+mxP
+qgz
 tLL
 xiz
 nuE
-bHv
+sTd
 aab
 aaa
 aaa
@@ -71820,8 +73182,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -71992,26 +73354,26 @@ aaa
 aaa
 aaa
 aaa
-cZm
+qOl
 aab
-xJp
+sTd
 cTg
 dyQ
 exf
 exf
-eli
+tdv
 hgL
 hVy
 jkn
-ipY
+vlA
 lgt
 mrL
-bHv
+mxP
 qnf
 ucI
 xjA
 hgw
-bHv
+sTd
 aab
 aaa
 aaa
@@ -72037,8 +73399,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -72209,26 +73571,26 @@ aaa
 aaa
 aaa
 aaa
-cZm
+qOl
 aab
-xJp
-xJp
-xJp
-xJp
-xJp
-xJp
-xJp
-xJp
+sTd
+sTd
+sTd
+sTd
+sTd
+sTd
+sTd
+sTd
 jpN
 jMk
 lgt
 mwK
-bHv
+mxP
 quA
 upn
 xlj
 qJF
-bHv
+sTd
 aab
 aaa
 aaa
@@ -72254,8 +73616,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 dnl
 dnl
@@ -72426,26 +73788,26 @@ aaa
 aaa
 aaa
 aaa
-cZm
+qOl
 aab
-bHv
-bHv
-bHv
-bHv
-bHv
-bHv
-bHv
-bHv
-bHv
-bHv
-bHv
-bHv
-bHv
-bHv
-bHv
-bHv
-bHv
-bHv
+sTd
+sTd
+sTd
+sTd
+sTd
+sTd
+sTd
+sTd
+sTd
+sTd
+sTd
+sTd
+sTd
+sTd
+sTd
+sTd
+sTd
+sTd
 aab
 aaa
 aaa
@@ -72471,8 +73833,8 @@ aaa
 aaa
 aaa
 aaa
-cZm
-aaa
+qOl
+aab
 aab
 aab
 aab
@@ -72643,7 +74005,7 @@ aaa
 aaa
 aaa
 aaa
-cZm
+qOl
 aab
 aab
 aab
@@ -72688,6 +74050,113 @@ aaa
 aaa
 aaa
 aaa
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
+qOl
 cZm
 cZm
 cZm
@@ -72753,114 +74222,7 @@ cZm
 cZm
 cZm
 cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
-cZm
+qOl
 aaa
 aaa
 aaa

--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -11079,10 +11079,7 @@
 "aPo" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall/unmeltable,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "aPq" = (
 /obj/machinery/door/airlock/mainship/research/glass/free_access{
 	dir = 1;
@@ -14176,6 +14173,13 @@
 "bfR" = (
 /turf/open/floor/tile/whiteyellow/full,
 /area/bigredv2/outside/office_complex)
+"bfU" = (
+/obj/machinery/door/airlock/mainship/maint,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/southeast)
 "bfV" = (
 /obj/structure/largecrate/random,
 /obj/effect/decal/cleanable/dirt,
@@ -15309,6 +15313,13 @@
 "blb" = (
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
+"blc" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/southeast)
 "bld" = (
 /obj/structure/table,
 /obj/effect/spawner/random/tech_supply,
@@ -19355,15 +19366,13 @@
 	},
 /turf/open/floor/prison/darkred/full,
 /area/bigredv2/caves/south)
-"bOy" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 10
+"bOf" = (
+/obj/structure/cable,
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/southeast)
 "bQc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
@@ -19382,10 +19391,7 @@
 /obj/item/ammo_casing/bullet,
 /obj/structure/cable,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "bSC" = (
 /obj/machinery/light{
 	dir = 8
@@ -19409,6 +19415,11 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/northwest)
+"caa" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/bigredv2/caves/southeast)
 "ccx" = (
 /obj/effect/decal/warning_stripes/thick{
 	dir = 1
@@ -19417,10 +19428,7 @@
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "ccP" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/wall,
@@ -19432,10 +19440,7 @@
 /obj/structure/largecrate/supply/ammo/m41a,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "cfH" = (
 /obj/machinery/miner/damaged/platinum,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -19457,22 +19462,11 @@
 /obj/structure/largecrate/supply/ammo/m41a_box,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "ckJ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/se)
-"clx" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/closed/wall/r_wall/unmeltable,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "coa" = (
 /obj/structure/rack,
 /obj/item/weapon/gun/shotgun/pump/cmb,
@@ -19480,32 +19474,18 @@
 /obj/item/ammo_magazine/shotgun/flechette,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "cov" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/south)
-"coI" = (
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "csO" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
 /turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "ctE" = (
 /turf/open/shuttle/escapepod/five,
 /area/bigredv2/caves/north)
@@ -19526,6 +19506,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/south)
+"cxx" = (
+/obj/structure/cable,
+/obj/machinery/computer/communications/bee,
+/obj/structure/table/mainship,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/southeast)
 "cyp" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 9
@@ -19548,17 +19534,26 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/filingcabinet,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "cBD" = (
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/bigredv2/outside/sw)
+"cBO" = (
+/obj/machinery/door/airlock/mainship/maint,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/southeast)
 "cCg" = (
 /obj/structure/cable,
 /turf/open/floor/tile/dark/blue2,
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"cCv" = (
+/obj/effect/landmark/corpsespawner,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/southeast)
+"cCM" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/southeast)
 "cFp" = (
 /obj/effect/spawner/gibspawner/human,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -19572,10 +19567,7 @@
 /obj/structure/table/mainship,
 /obj/machinery/computer/emails,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "cLe" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/marking/asteroidwarning{
@@ -19589,18 +19581,12 @@
 /obj/structure/table/mainship,
 /obj/machinery/computer/security/marinemainship_network,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "cMC" = (
 /obj/structure/table/mainship,
 /obj/machinery/computer/communications,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "cMZ" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -19612,25 +19598,21 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/northwest)
-"cSH" = (
-/obj/machinery/light,
-/turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "cTg" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/structure/bookcase/manuals,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "cTr" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/se)
+"cUL" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/southeast)
 "cWF" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral/bigred,
@@ -19646,14 +19628,11 @@
 "cXu" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/bigredv2/outside/se)
-"cYb" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/effect/landmark/xeno_resin_door,
+"cYr" = (
+/obj/effect/landmark/weed_node,
+/obj/structure/cable,
 /turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "cZm" = (
 /obj/structure/cable,
 /turf/open/space/basic,
@@ -19663,21 +19642,11 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/east)
-"daq" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "dbi" = (
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 8
 	},
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "dcO" = (
 /obj/machinery/door/airlock/mainship/research/free_access{
 	name = "\improper Virology Lab Administration"
@@ -19694,10 +19663,7 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "dhn" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/cobweb,
@@ -19705,10 +19671,7 @@
 	dir = 1
 	},
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "dhB" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -19716,6 +19679,11 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor,
 /area/bigredv2/outside/dorms)
+"diq" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/corpsespawner,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/southeast)
 "djI" = (
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/wood,
@@ -19735,6 +19703,11 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor,
 /area/bigredv2/outside/general_store)
+"dlq" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/southeast)
 "dmd" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /turf/open/floor,
@@ -19746,13 +19719,6 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/southwest)
-"dpu" = (
-/obj/structure/window/framed/colony/reinforced,
-/turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "dqo" = (
 /obj/structure/cable,
 /turf/open/floor/tile/darkish,
@@ -19784,10 +19750,7 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "dzS" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor,
@@ -19798,10 +19761,14 @@
 	},
 /obj/structure/cable,
 /turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
+"dCk" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/southeast)
 "dCr" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -19815,6 +19782,10 @@
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/southeast)
+"dEz" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/southeast)
 "dFp" = (
 /obj/effect/decal/warning_stripes/thick{
 	dir = 1
@@ -19822,20 +19793,14 @@
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "dFO" = (
 /obj/machinery/power/geothermal{
 	name = "Theta G-11 geothermal generator"
 	},
 /obj/structure/cable,
 /turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "dGd" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -19862,28 +19827,29 @@
 /obj/machinery/power/smes,
 /obj/structure/cable,
 /turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "dLO" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 9
 	},
 /area/bigredv2/outside/w)
+"dMG" = (
+/obj/structure/largecrate/random/case/double,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/southeast)
 "dPa" = (
 /obj/structure/rack,
 /obj/item/explosive/grenade/flashbang,
 /obj/item/explosive/grenade/flashbang,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "dPu" = (
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/e)
+"dPw" = (
+/turf/open/lavaland/catwalk,
+/area/bigredv2/caves/southeast)
 "dPK" = (
 /obj/effect/landmark/start/job/xenomorph,
 /obj/effect/landmark/weed_node,
@@ -19896,22 +19862,16 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/grimy,
 /area/bigredv2/outside/marshal_office)
-"dTY" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/computer3/server/rack,
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "dWa" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
 	},
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/west)
+"dWx" = (
+/obj/structure/largecrate/guns,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/southeast)
 "dWD" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -19922,37 +19882,46 @@
 	},
 /turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/nw)
+"dXy" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	on = 1;
+	welded = 1
+	},
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/southeast)
 "dYK" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "dZi" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/yellow2/corner{
 	dir = 8
 	},
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"dZr" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4;
+	on = 1
+	},
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/southeast)
 "dZF" = (
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"dZV" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/southeast)
 "eal" = (
 /obj/structure/table,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
-"ecc" = (
-/obj/structure/bed/chair/dropship,
-/turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "edO" = (
 /turf/open/floor/carpet,
 /area/bigredv2/outside/bar)
@@ -19982,18 +19951,12 @@
 "ekC" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "ekE" = (
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 4
 	},
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "eli" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
@@ -20004,38 +19967,18 @@
 	dir = 1
 	},
 /area/bigredv2/outside/w)
-"elV" = (
-/obj/effect/landmark/corpsespawner,
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "emA" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/structure/cable,
 /turf/open/shuttle/elevator/grating,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "eoX" = (
 /obj/structure/cable,
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
-"eqs" = (
-/obj/structure/largecrate/guns,
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "eqy" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/wall,
@@ -20046,10 +19989,7 @@
 "euF" = (
 /obj/effect/spawner/gibspawner/human,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "eve" = (
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/southeast)
@@ -20070,10 +20010,7 @@
 /obj/structure/closet/secure_closet/security,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "exJ" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 8
@@ -20082,12 +20019,16 @@
 "eyz" = (
 /turf/closed/wall/r_wall,
 /area/bigredv2/caves/south)
+"eCa" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/corpsespawner,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/southeast)
 "eCh" = (
 /turf/open/shuttle/escapepod/five,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "eCN" = (
 /obj/structure/cable,
 /turf/open/floor/tile/dark/red2/corner{
@@ -20102,6 +20043,12 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/west)
+"eHA" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/southeast)
 "eIG" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -20128,23 +20075,12 @@
 /obj/item/ammo_magazine/rifle/famas,
 /obj/item/ammo_magazine/rifle/famas,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "eOu" = (
 /obj/structure/table,
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/bigredv2/outside/nanotrasen_lab/inside)
-"eOZ" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/effect/landmark/weed_node,
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "ePu" = (
 /obj/effect/decal/warning_stripes/thick{
 	dir = 1
@@ -20152,17 +20088,11 @@
 /obj/structure/cable,
 /obj/item/ammo_casing/shell,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "ePv" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "ePH" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -20189,25 +20119,13 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "eRJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/marking/asteroidwarning{
 	dir = 1
 	},
 /area/shuttle/drop2/lz2)
-"eTn" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "eTT" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
@@ -20227,19 +20145,16 @@
 	},
 /turf/open/floor/tile/whiteyellow/full,
 /area/bigredv2/outside/office_complex)
-"eXq" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "eXF" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
+/area/bigredv2/caves/southeast)
+"eZl" = (
+/obj/machinery/atmospherics/pipe/manifold/green{
+	dir = 1
+	},
+/obj/effect/landmark/corpsespawner,
+/turf/open/floor/prison/darkred/full,
 /area/bigredv2/caves/southeast)
 "eZF" = (
 /obj/effect/landmark/lv624/fog_blocker,
@@ -20257,14 +20172,10 @@
 	dir = 1
 	},
 /area/shuttle/drop2/lz2)
-"fdu" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic,
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
+"fdM" = (
+/obj/structure/bed/chair/dropship,
 /turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "feK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -20287,16 +20198,6 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/cargo)
-"fhb" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/multi_tile/mainship/generic{
-	dir = 2
-	},
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "flV" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor/plating,
@@ -20317,10 +20218,13 @@
 /obj/machinery/door/airlock/external,
 /obj/item/tape/engineering,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
+"foR" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/southeast)
 "fph" = (
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -20348,18 +20252,12 @@
 	pixel_x = 16
 	},
 /turf/closed/wall/r_wall,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "fuB" = (
 /obj/structure/cable,
 /obj/effect/landmark/corpsespawner/security,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "fwQ" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -20376,13 +20274,6 @@
 	},
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/space_port)
-"fzQ" = (
-/obj/structure/girder,
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "fAx" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -20393,19 +20284,32 @@
 /obj/structure/window/framed/colony/reinforced,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
+"fBE" = (
+/obj/machinery/computer/rdservercontrol,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/southeast)
 "fDs" = (
 /obj/structure/closet/crate/secure/weapon,
 /obj/structure/cable,
 /turf/open/shuttle/escapepod,
 /area/bigredv2/caves/north)
+"fEo" = (
+/obj/machinery/atmospherics/pipe/manifold/green{
+	dir = 8
+	},
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/southeast)
 "fES" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/south)
+"fGX" = (
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 2
+	},
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/southeast)
 "fHd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -20423,10 +20327,7 @@
 /obj/machinery/door/airlock,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "fIW" = (
 /obj/effect/landmark/dropship_start_location,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -20437,14 +20338,6 @@
 /obj/item/clothing/head/warning_cone,
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/se)
-"fKy" = (
-/obj/structure/cable,
-/obj/structure/largecrate/random/barrel/blue,
-/turf/open/floor/prison/darkyellow/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "fLz" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating,
@@ -20482,10 +20375,13 @@
 	dir = 1
 	},
 /turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
+"fSc" = (
+/obj/structure/bed/chair/dropship{
+	dir = 8
+	},
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/southeast)
 "fVb" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
@@ -20507,6 +20403,10 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
+"fYf" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/southeast)
 "fYE" = (
 /obj/effect/decal/warning_stripes/nscenter,
 /turf/open/shuttle/escapepod,
@@ -20539,20 +20439,14 @@
 "gfc" = (
 /obj/structure/largecrate,
 /turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "gfg" = (
 /obj/effect/landmark/xeno_turret_spawn,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
 /turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "ggp" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -20590,23 +20484,10 @@
 "glf" = (
 /obj/structure/largecrate/supply/explosives/mines,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "glC" = (
 /turf/open/floor/tile/dark/yellow2/corner,
 /area/bigredv2/caves/south)
-"gmF" = (
-/obj/machinery/door/airlock/mainship/maint,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "gnu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -20622,10 +20503,7 @@
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 1
 	},
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "gqM" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor,
@@ -20643,20 +20521,14 @@
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 1
 	},
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "gva" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/drop2/lz2)
 "gvo" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "gwV" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -20665,14 +20537,16 @@
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 1
 	},
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "gxC" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/southwest)
+"gzC" = (
+/obj/effect/landmark/xeno_resin_door,
+/obj/structure/cable,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/southeast)
 "gAT" = (
 /obj/structure/table,
 /obj/item/storage/belt/gun/pistol,
@@ -20683,10 +20557,7 @@
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 8
 	},
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "gBm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/framed/colony/reinforced,
@@ -20704,10 +20575,7 @@
 	welded = 1
 	},
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "gEU" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral/bigred,
@@ -20717,6 +20585,11 @@
 	dir = 1
 	},
 /area/bigredv2/outside/space_port)
+"gLt" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/closed/wall/r_wall/unmeltable,
+/area/bigredv2/caves/southeast)
 "gLN" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -20724,17 +20597,7 @@
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 4
 	},
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
-"gMF" = (
-/obj/structure/largecrate/random/case/double,
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "gMM" = (
 /obj/structure/cable,
 /turf/open/floor/marking/asteroidwarning{
@@ -20774,6 +20637,10 @@
 	},
 /turf/open/floor/wood,
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"gUa" = (
+/obj/machinery/atmospherics/pipe/manifold/green,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/southeast)
 "gVL" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/mainship/engineering/free_access{
@@ -20788,10 +20655,7 @@
 /obj/structure/cable,
 /obj/item/weapon/gun/rifle/m16,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "gYG" = (
 /obj/effect/landmark/weed_node,
 /turf/closed/mineral/bigred,
@@ -20800,10 +20664,7 @@
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 1
 	},
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "hbe" = (
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/floor/asteroidfloor,
@@ -20832,10 +20693,7 @@
 /obj/structure/cable,
 /obj/machinery/light,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "hgL" = (
 /obj/structure/cable,
 /obj/machinery/light{
@@ -20844,10 +20702,7 @@
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 1
 	},
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "hhh" = (
 /obj/structure/cable,
 /turf/open/floor/asteroidfloor,
@@ -20858,33 +20713,21 @@
 	name = "Maintenance Hatch"
 	},
 /turf/open/shuttle/elevator/grating,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
-"hiC" = (
-/obj/machinery/atmospherics/pipe/manifold4w/green,
-/turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "hjc" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "hjE" = (
 /obj/machinery/door/airlock,
 /obj/structure/cable,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
+"hjN" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/southeast)
 "hkk" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -20894,24 +20737,20 @@
 	dir = 5
 	},
 /area/bigredv2/outside/c)
-"hog" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
-"hoI" = (
+"hnC" = (
 /obj/machinery/light{
-	dir = 8
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8;
+	on = 1
 	},
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
+"hnZ" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/bigredv2/caves/southeast)
 "hqP" = (
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/south)
@@ -20928,10 +20767,7 @@
 /obj/item/ammo_magazine/rifle/m16,
 /obj/item/ammo_magazine/rifle/m16,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "hvV" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/wall,
@@ -20939,10 +20775,7 @@
 "hwc" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "hwL" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -20951,6 +20784,13 @@
 	dir = 4
 	},
 /area/bigredv2/outside/nw)
+"hxV" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/computer3/server/rack,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/southeast)
 "hyP" = (
 /obj/effect/decal/warning_stripes/nscenter,
 /obj/machinery/light/built{
@@ -21018,16 +20858,6 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/north)
-"hKM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 4;
-	on = 1
-	},
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "hLo" = (
 /obj/structure/cable,
 /turf/open/floor/tile/dark/blue2{
@@ -21048,33 +20878,12 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/east)
-"hOG" = (
-/obj/effect/landmark/xeno_resin_door,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "hRb" = (
 /obj/structure/cable,
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 4
 	},
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
-"hRM" = (
-/obj/effect/landmark/weed_node,
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "hSh" = (
 /obj/machinery/door/airlock,
 /obj/structure/cable,
@@ -21082,10 +20891,7 @@
 /obj/structure/cable,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "hTy" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -21095,10 +20901,7 @@
 /obj/structure/cable,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "hUm" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -21106,6 +20909,10 @@
 /obj/effect/landmark/corpsespawner/security,
 /turf/open/floor,
 /area/bigredv2/outside/general_offices)
+"hUp" = (
+/obj/structure/cable,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/southeast)
 "hVb" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -21116,10 +20923,7 @@
 /obj/structure/cable,
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "hXl" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -21144,17 +20948,14 @@
 /area/bigredv2/caves/northeast)
 "igD" = (
 /turf/open/shuttle/elevator/grating,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "igK" = (
 /obj/machinery/power/apc/weak,
 /turf/open/shuttle/elevator/grating,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
+"iix" = (
+/turf/open/floor/tile/damaged/five,
+/area/bigredv2/caves/southeast)
 "iiY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
@@ -21169,33 +20970,21 @@
 	},
 /obj/structure/cable,
 /turf/open/shuttle/elevator/grating,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "ilD" = (
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/wood,
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"inA" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/southeast)
 "ipY" = (
 /obj/machinery/power/monitor,
 /obj/structure/cable,
 /obj/structure/table/mainship,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
-"iqL" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 8;
-	welded = 1
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "iug" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/mineral/bigred,
@@ -21226,15 +21015,18 @@
 	dir = 1
 	},
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "iCt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor,
 /area/bigredv2/outside/office_complex)
+"iCy" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/southeast)
 "iEL" = (
 /obj/machinery/power/geothermal,
 /obj/structure/cable,
@@ -21252,20 +21044,14 @@
 "iJf" = (
 /obj/structure/largecrate/supply/weapons/hpr,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "iKB" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/bigredv2/caves/northwest)
 "iKL" = (
 /obj/structure/largecrate/machine,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "iMZ" = (
 /obj/effect/landmark/corpsespawner/engineer,
 /turf/open/floor/tile/red/redtaupecorner,
@@ -21295,23 +21081,13 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/southeast)
-"iXU" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "iYa" = (
 /obj/item/paper,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
 	},
 /turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "jcs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -21337,10 +21113,7 @@
 "jkn" = (
 /obj/structure/largecrate/random/barrel/red,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "jlx" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -21353,10 +21126,13 @@
 /obj/structure/largecrate/random/barrel/blue,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
+"jrt" = (
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 2
+	},
+/turf/open/floor/prison/darkyellow/full,
+/area/bigredv2/caves/southeast)
 "jsp" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -21367,17 +21143,11 @@
 "juh" = (
 /obj/effect/spawner/gibspawner/human,
 /turf/open/shuttle/elevator/grating,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "juu" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/shuttle/elevator/grating,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "juA" = (
 /obj/machinery/power/monitor,
 /turf/open/floor/plating,
@@ -21385,10 +21155,7 @@
 "juU" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/shuttle/elevator/grating,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "jwU" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 2
@@ -21400,10 +21167,7 @@
 "jAz" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /turf/open/shuttle/elevator/grating,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "jAB" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/weed_node,
@@ -21424,10 +21188,7 @@
 "jFi" = (
 /obj/item/analyzer/plant_analyzer,
 /turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "jFz" = (
 /obj/effect/decal/warning_stripes/nscenter,
 /obj/machinery/light/built{
@@ -21438,20 +21199,7 @@
 "jGP" = (
 /obj/structure/largecrate/supply/weapons/sentries,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
-"jHx" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/effect/landmark/corpsespawner,
-/turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "jKb" = (
 /obj/structure/sign/safety/blast_door,
 /obj/structure/cable,
@@ -21466,10 +21214,7 @@
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 8
 	},
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "jKs" = (
 /obj/effect/spawner/gibspawner/human,
 /turf/open/floor/tile/dark/red2/corner,
@@ -21488,10 +21233,7 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "jMC" = (
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/west)
@@ -21586,13 +21328,10 @@
 "kbu" = (
 /obj/structure/cable,
 /turf/open/shuttle/elevator/grating,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
-"kcY" = (
-/obj/structure/girder/displaced,
-/turf/open/floor/tile/damaged/five,
+/area/bigredv2/caves/southeast)
+"kcV" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/mainship/sterile/dark,
 /area/bigredv2/caves/southeast)
 "kel" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
@@ -21620,6 +21359,12 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor,
 /area/bigredv2/outside/general_offices)
+"kjW" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/southeast)
 "klu" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -21654,14 +21399,22 @@
 	dir = 4
 	},
 /area/bigredv2/outside/virology)
+"kxh" = (
+/obj/structure/girder/displaced,
+/turf/open/floor/tile/damaged/five,
+/area/bigredv2/caves/southeast)
+"kyV" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 1;
+	on = 1
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/southeast)
 "kzI" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/structure/cable,
 /turf/open/shuttle/elevator/grating,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "kAp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -21683,10 +21436,12 @@
 "kHY" = (
 /obj/structure/ship_ammo/rocket/napalm,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
+"kII" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/bed/chair/dropship,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/southeast)
 "kIY" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 1
@@ -21706,6 +21461,12 @@
 "kKe" = (
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/northeast)
+"kKI" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 5
+	},
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/southeast)
 "kMq" = (
 /obj/effect/landmark/corpsespawner/security,
 /turf/open/floor/tile/white,
@@ -21716,26 +21477,21 @@
 /area/bigredv2/caves/east)
 "kOh" = (
 /turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "kOq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/lightreplacer,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
-"kOG" = (
-/obj/machinery/door/airlock/mainship/maint,
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "kPf" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/east)
+"kPO" = (
+/obj/effect/landmark/weed_node,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/southeast)
 "kQy" = (
 /obj/effect/landmark/xeno_resin_door,
 /obj/effect/landmark/lv624/fog_blocker,
@@ -21748,21 +21504,16 @@
 	},
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/medical)
-"kTu" = (
-/obj/effect/landmark/xeno_resin_door,
-/obj/structure/cable,
-/turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "kXR" = (
 /obj/structure/ship_ammo/rocket/widowmaker,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
+"kXT" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/multi_tile/mainship/generic,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/southeast)
 "ldk" = (
 /obj/structure/cable,
 /turf/open/shuttle/escapepod,
@@ -21780,35 +21531,19 @@
 "lgf" = (
 /obj/structure/closet/crate/secure/gear,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "lgt" = (
 /obj/structure/largecrate/supply/supplies/sandbags,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "lgV" = (
 /obj/structure/grille/broken,
 /turf/open/floor/mainship/empty,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "lhy" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/north)
-"lic" = (
-/obj/machinery/computer/rdservercontrol,
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "liu" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral/bigred,
@@ -21829,14 +21564,11 @@
 /obj/effect/landmark/corpsespawner/engineer,
 /turf/open/floor/plating,
 /area/bigredv2/outside/engineering)
-"lmq" = (
-/obj/effect/decal/cleanable/blood/gibs/body,
+"llp" = (
 /obj/structure/cable,
-/turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/obj/machinery/door/airlock/multi_tile/mainship/generic,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/southeast)
 "lmC" = (
 /obj/machinery/light,
 /obj/structure/cable,
@@ -21858,10 +21590,7 @@
 "lpn" = (
 /obj/machinery/light,
 /turf/open/shuttle/elevator/grating,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "lqu" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/four_tile_ver{
@@ -21869,10 +21598,7 @@
 	name = "Underground Hangar"
 	},
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "lqJ" = (
 /obj/machinery/camera{
 	dir = 5
@@ -21882,10 +21608,10 @@
 "lrg" = (
 /obj/structure/ship_ammo/rocket/fatty,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
+"lrE" = (
+/turf/closed/wall/r_wall,
+/area/bigredv2/caves/southeast)
 "lsj" = (
 /obj/structure/closet/l3closet/virology,
 /turf/open/shuttle/escapepod,
@@ -21898,10 +21624,7 @@
 /obj/structure/cable,
 /obj/structure/dropship_equipment/weapon/rocket_pod,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "lvJ" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
@@ -21932,10 +21655,7 @@
 "lAi" = (
 /obj/structure/ship_ammo/rocket/banshee,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "lAq" = (
 /obj/structure/sign/safety/maintenance{
 	dir = 1
@@ -21952,22 +21672,16 @@
 	},
 /obj/item/ammo_magazine/rifle/m16,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "lCt" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 9
 	},
 /area/shuttle/drop2/lz2)
-"lCu" = (
-/obj/structure/largecrate/random/case,
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+"lFw" = (
+/obj/machinery/atmospherics/pipe/manifold4w/green,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/southeast)
 "lFT" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -21978,10 +21692,7 @@
 "lHD" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "lHZ" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -21990,25 +21701,6 @@
 /obj/structure/sign/prop1,
 /turf/open/floor,
 /area/bigredv2/outside/office_complex)
-"lIZ" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
-"lKe" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 5
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "lKZ" = (
 /turf/open/shuttle/escapepod,
 /area/bigredv2/caves/north)
@@ -22033,17 +21725,11 @@
 "lNk" = (
 /obj/structure/largecrate/supply/supplies/flares,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "lPS" = (
 /obj/structure/largecrate/random/barrel/green,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "lPV" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -22083,28 +21769,21 @@
 /obj/structure/cable,
 /obj/machinery/light,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "mbT" = (
 /obj/item/trash/sosjerky,
 /turf/open/floor/plating,
 /area/bigredv2/outside/engineering)
-"mcd" = (
-/obj/structure/cable,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "mcP" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/east)
+"meb" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/southeast)
 "mgD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -22114,12 +21793,20 @@
 /obj/effect/landmark/corpsespawner/security,
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
+"mie" = (
+/obj/machinery/door/airlock/mainship/generic,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/southeast)
+"mik" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/southeast)
 "mlt" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/caves/north)
-"mly" = (
-/turf/closed/wall/r_wall,
-/area/bigredv2/caves/southeast)
 "mpz" = (
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/bigredv2/outside/se)
@@ -22130,10 +21817,7 @@
 "mrL" = (
 /obj/structure/largecrate/supply/supplies/metal,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "msI" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -22145,30 +21829,12 @@
 /obj/structure/largecrate/supply/supplies/plasteel,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
-"mwU" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "mxH" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/landmark/corpsespawner/security,
 /turf/open/floor/carpet,
 /area/bigredv2/outside/library)
-"mxP" = (
-/turf/closed/wall/r_wall,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "myA" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/blood/gibs,
@@ -22181,10 +21847,7 @@
 	welded = 1
 	},
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "mAi" = (
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/northwest)
@@ -22197,10 +21860,7 @@
 	pixel_x = -16
 	},
 /turf/closed/wall/r_wall,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "mEk" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/marking/asteroidwarning,
@@ -22253,6 +21913,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/northwest)
+"mPX" = (
+/obj/structure/girder,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/southeast)
 "mQb" = (
 /obj/structure/rack,
 /obj/item/ammo_magazine/shotgun/incendiary,
@@ -22262,6 +21926,11 @@
 /obj/item/ammo_magazine/shotgun/incendiary,
 /turf/open/shuttle/elevator/grating,
 /area/bigredv2/caves/northwest)
+"mSl" = (
+/obj/structure/cable,
+/obj/structure/largecrate/random/barrel/blue,
+/turf/open/floor/prison/darkyellow/full,
+/area/bigredv2/caves/southeast)
 "mSv" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -22275,6 +21944,13 @@
 	dir = 10
 	},
 /area/bigredv2/outside/sw)
+"mXZ" = (
+/obj/docking_port/stationary/crashmode,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/southeast)
 "mYm" = (
 /obj/machinery/light,
 /turf/open/shuttle/escapepod,
@@ -22284,6 +21960,10 @@
 /obj/structure/largecrate/supply/supplies/mre,
 /turf/open/shuttle/elevator/grating,
 /area/bigredv2/caves/northwest)
+"nbw" = (
+/obj/structure/prop/mainship/mission_planning_system,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/southeast)
 "nbV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	on = 1
@@ -22293,10 +21973,7 @@
 "ncd" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "ndz" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -22311,23 +21988,6 @@
 /obj/structure/ore_box,
 /turf/open/shuttle/escapepod,
 /area/bigredv2/caves/lambda_lab)
-"nqq" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
-"nru" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "nrI" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
@@ -22352,10 +22012,7 @@
 /obj/structure/cable,
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "nvs" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -22386,6 +22043,16 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating,
 /area/bigredv2/outside/nw)
+"nyk" = (
+/obj/structure/largecrate/random/case,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/southeast)
+"nyZ" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 10
+	},
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/southeast)
 "nzp" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -22398,6 +22065,10 @@
 /obj/effect/landmark/corpsespawner/doctor,
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/medical)
+"nAr" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/southeast)
 "nAH" = (
 /obj/effect/landmark/weed_node,
 /turf/open/shuttle/escapepod,
@@ -22405,10 +22076,7 @@
 "nBy" = (
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "nCe" = (
 /obj/structure/bookcase/manuals/research_and_development,
 /obj/structure/cable,
@@ -22457,10 +22125,7 @@
 	dir = 4
 	},
 /turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "nOk" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor,
@@ -22475,17 +22140,11 @@
 "nPl" = (
 /obj/item/paper/clockresearch1,
 /turf/closed/wall/r_wall,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "nQE" = (
 /obj/machinery/atmospherics/pipe/manifold/green,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "nQS" = (
 /obj/effect/decal/warning_stripes/thick{
 	dir = 1
@@ -22493,10 +22152,7 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood/gibs/xeno/limb,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "nRT" = (
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/west)
@@ -22513,16 +22169,7 @@
 /obj/machinery/computer/emails,
 /obj/structure/table/mainship,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
-"nWE" = (
-/turf/open/lavaland/catwalk,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "oaD" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 8
@@ -22541,10 +22188,7 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "ojx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -22552,18 +22196,16 @@
 	},
 /turf/open/floor/wood,
 /area/bigredv2/outside/bar)
-"okr" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "olJ" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/mineral/bigred,
+/area/bigredv2/caves/southeast)
+"onn" = (
+/obj/structure/cable,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/dark,
 /area/bigredv2/caves/southeast)
 "onX" = (
 /obj/effect/landmark/start/job/xenomorph,
@@ -22591,10 +22233,7 @@
 /obj/item/explosive/grenade/drainbomb,
 /obj/item/explosive/grenade/drainbomb,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "oto" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -22619,6 +22258,13 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/south)
+"owV" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/largecrate/random/case/double,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/southeast)
 "ozW" = (
 /obj/machinery/door/poddoor/shutters/mainship{
 	dir = 2;
@@ -22641,46 +22287,30 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/e)
-"oCu" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 9
-	},
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "oDD" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 6
 	},
 /area/bigredv2/outside/space_port)
-"oEm" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
-"oEr" = (
-/obj/machinery/atmospherics/pipe/manifold/green,
-/turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "oEN" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/virology)
+"oFn" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 2
+	},
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/southeast)
 "oGC" = (
 /obj/structure/window/framed/colony/reinforced/hull,
 /turf/open/floor/plating,
 /area/bigredv2/outside/se)
+"oIp" = (
+/obj/effect/landmark/corpsespawner/security,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/southeast)
 "oLB" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/xeno_resin_door,
@@ -22733,29 +22363,10 @@
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
-"oUf" = (
-/obj/effect/landmark/corpsespawner,
-/turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
-"oUj" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 5
-	},
-/turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
-"oVG" = (
-/obj/machinery/r_n_d/server,
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+"oUc" = (
+/obj/machinery/light,
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/southeast)
 "oVQ" = (
 /obj/effect/decal/warning_stripes/thick,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -22763,10 +22374,7 @@
 	},
 /obj/item/weapon/gun/shotgun/pump/cmb,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "oWn" = (
 /turf/open/floor/tile/green/whitegreenfull,
 /area/bigredv2/caves/lambda_lab)
@@ -22783,10 +22391,7 @@
 	dir = 1
 	},
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "pbv" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/machinery/door/poddoor/shutters/mainship{
@@ -22826,26 +22431,11 @@
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/lambda_lab)
-"pgW" = (
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
-"phD" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic,
-/turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
-"piE" = (
-/obj/effect/landmark/corpsespawner/security,
-/turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+"pgX" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/southeast)
 "pjz" = (
 /obj/structure/cable,
 /turf/open/floor/marking/asteroidwarning{
@@ -22860,10 +22450,11 @@
 /obj/structure/cable,
 /obj/item/limb/r_foot,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
+"pld" = (
+/obj/machinery/r_n_d/server,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/southeast)
 "pmf" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/landmark/corpsespawner/security,
@@ -22873,6 +22464,10 @@
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/elevatorshaft,
 /area/bigredv2/caves/lambda_lab)
+"pnH" = (
+/obj/effect/landmark/weed_node,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/southeast)
 "pod" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -22891,10 +22486,7 @@
 /obj/structure/cable,
 /obj/item/weapon/gun/rifle/famas,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "psH" = (
 /obj/structure/rack,
 /obj/item/storage/belt/gun/revolver,
@@ -22907,6 +22499,12 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/northeast)
+"ptq" = (
+/obj/machinery/atmospherics/pipe/manifold/green{
+	dir = 1
+	},
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/southeast)
 "ptP" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral/bigred,
@@ -22923,16 +22521,6 @@
 	},
 /turf/open/floor/plating,
 /area/bigredv2/outside/dorms)
-"pzS" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "pzX" = (
 /obj/structure/largecrate,
 /obj/structure/cable,
@@ -22948,10 +22536,7 @@
 	dir = 8
 	},
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "pEd" = (
 /obj/effect/decal/warning_stripes/thick,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -22960,14 +22545,23 @@
 /obj/structure/cable,
 /obj/item/weapon/gun/rifle/m16,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "pEh" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall,
 /area/bigredv2/caves/south)
+"pEP" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/closed/wall/r_wall/unmeltable,
+/area/bigredv2/caves/southeast)
+"pFH" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/southeast)
 "pHZ" = (
 /obj/effect/decal/warning_stripes/thick,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -22976,10 +22570,7 @@
 /obj/structure/cable,
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "pJO" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -22991,31 +22582,11 @@
 	},
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "pOZ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/northwest)
-"pPX" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 1;
-	on = 1
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
-"pQo" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "pQK" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 8
@@ -23054,20 +22625,14 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "pVB" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
 /obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "pXc" = (
 /obj/structure/cable,
 /obj/structure/window/framed/mainship/gray/toughened/hull{
@@ -23075,6 +22640,13 @@
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/northwest)
+"pYh" = (
+/obj/effect/landmark/xeno_resin_door,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/southeast)
 "pYU" = (
 /obj/machinery/floodlight/landing,
 /turf/open/floor/marking/asteroidwarning{
@@ -23094,18 +22666,12 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "qbh" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "qcp" = (
 /obj/structure/cable,
 /turf/open/floor/tile/chapel{
@@ -23119,25 +22685,11 @@
 /obj/structure/cable,
 /obj/item/ammo_casing/shell,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
-"qcY" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/closed/wall/r_wall/unmeltable,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "qdE" = (
 /obj/item/analyzer,
 /turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "qeE" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -23167,10 +22719,7 @@
 	},
 /obj/item/ammo_casing/shell,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "qgg" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -23185,10 +22734,11 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
+"qhe" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/southeast)
 "qnf" = (
 /obj/effect/decal/warning_stripes/thick,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -23199,10 +22749,7 @@
 	dir = 1
 	},
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "qnu" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/darkgreen/darkgreen2/corner,
@@ -23222,30 +22769,6 @@
 /obj/effect/landmark/xeno_turret_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/southwest)
-"qsC" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
-"qsG" = (
-/obj/structure/window/framed/colony/reinforced,
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
-"qtr" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/closed/wall/r_wall,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "qtI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	on = 1
@@ -23259,10 +22782,7 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood/writing,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "quI" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/bigredv2/outside/telecomm)
@@ -23278,13 +22798,6 @@
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/north)
-"qwT" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "qxt" = (
 /obj/item/trash/candy,
 /turf/open/floor,
@@ -23326,19 +22839,6 @@
 /obj/structure/sign/safety/high_radiation,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
-"qEi" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 8;
-	on = 1
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "qFg" = (
 /obj/machinery/door/poddoor/shutters/mainship{
 	dir = 2;
@@ -23387,10 +22887,7 @@
 	welded = 1
 	},
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "qKE" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -23439,6 +22936,10 @@
 /obj/effect/landmark/xeno_turret_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/north)
+"qSr" = (
+/obj/structure/cable,
+/turf/open/floor/prison/darkyellow/full,
+/area/bigredv2/caves/southeast)
 "qUm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -23451,18 +22952,17 @@
 "qVr" = (
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/north)
-"qVN" = (
-/obj/structure/girder/reinforced,
-/turf/open/floor/plating/ground/mars/random/cave,
+"qVy" = (
+/obj/structure/bed/chair/dropship{
+	dir = 4
+	},
+/turf/open/floor/prison/darkred/full,
 /area/bigredv2/caves/southeast)
 "qXP" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/structure/cable,
 /turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "qYD" = (
 /obj/structure/cable,
 /turf/open/floor/asteroidfloor,
@@ -23495,22 +22995,10 @@
 /area/bigredv2/outside/hydroponics)
 "rde" = (
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "rdw" = (
 /turf/open/floor/prison/darkred/full,
 /area/bigredv2/caves/south)
-"rel" = (
-/obj/machinery/atmospherics/pipe/manifold/green{
-	dir = 1
-	},
-/turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "rfg" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor,
@@ -23518,10 +23006,7 @@
 "riu" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno/limb,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "riz" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 8
@@ -23530,14 +23015,23 @@
 "rjr" = (
 /obj/item/paper/prison_station/warden_note,
 /turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "rkk" = (
 /obj/machinery/light,
 /turf/open/floor/plating,
 /area/bigredv2/outside/space_port)
+"rkN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/southeast)
+"rml" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/weed_node,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/southeast)
 "rnW" = (
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/tile/dark/yellow2/corner,
@@ -23546,10 +23040,7 @@
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "rpV" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/xeno_resin_wall,
@@ -23581,27 +23072,27 @@
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/general_offices)
-"ryO" = (
-/obj/structure/cable,
+"ryA" = (
+/obj/effect/landmark/xeno_resin_door,
 /turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "rAe" = (
 /obj/item/ammo_casing/bullet,
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "rBN" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/bigredv2/outside/nw)
+"rEl" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/southeast)
 "rJv" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	name = "\improper Lambda Lab"
@@ -23618,16 +23109,17 @@
 	dir = 8
 	},
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "rLF" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 10
 	},
 /area/bigredv2/outside/c)
+"rMR" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/closed/wall/r_wall,
+/area/bigredv2/caves/southeast)
 "rMV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -23667,11 +23159,21 @@
 "rSn" = (
 /turf/open/space/basic,
 /area/bigredv2/outside/c)
+"rUx" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/southeast)
 "rUT" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/west)
+"rVm" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/southeast)
 "rVZ" = (
 /turf/open/shuttle/escapepod/five,
 /area/bigredv2/caves/lambda_lab)
@@ -23683,13 +23185,17 @@
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "rZP" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
+/area/bigredv2/caves/southeast)
+"saC" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8;
+	welded = 1
+	},
+/turf/open/floor/mainship/sterile/dark,
 /area/bigredv2/caves/southeast)
 "sbj" = (
 /obj/effect/decal/warning_stripes/nscenter,
@@ -23708,10 +23214,7 @@
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 1
 	},
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "sfy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -23724,22 +23227,17 @@
 	pixel_y = 9
 	},
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
-"sjC" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "skG" = (
 /obj/machinery/computer/shuttle/shuttle_control/dropship,
 /obj/structure/table,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/console)
+"skH" = (
+/obj/structure/cable,
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/southeast)
 "slo" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
@@ -23756,10 +23254,11 @@
 /obj/item/limb/head,
 /obj/machinery/light,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
+"snZ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/southeast)
 "soj" = (
 /obj/machinery/power/apc/drained{
 	dir = 8
@@ -23769,15 +23268,6 @@
 	dir = 4
 	},
 /area/shuttle/drop2/lz2)
-"ssh" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2
-	},
-/turf/open/floor/prison/darkyellow/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "svV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor/wood,
@@ -23788,15 +23278,12 @@
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/space_port)
-"szr" = (
-/obj/structure/cable,
-/obj/machinery/computer/communications/bee,
-/obj/structure/table/mainship,
-/turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+"szH" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 6
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/southeast)
 "sAq" = (
 /obj/structure/cable,
 /turf/closed/mineral/bigred,
@@ -23804,32 +23291,17 @@
 "sBJ" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "sBV" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 1
 	},
 /area/bigredv2/outside/w)
-"sBX" = (
-/obj/structure/bed/chair/dropship{
-	dir = 4
-	},
-/turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "sCz" = (
 /obj/item/limb/r_foot,
 /obj/item/ammo_casing/shell,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "sEN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -23858,10 +23330,12 @@
 "sLI" = (
 /obj/item/ammo_casing/shell,
 /turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
+"sMk" = (
+/obj/effect/decal/cleanable/blood/gibs/body,
+/obj/structure/cable,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/southeast)
 "sQi" = (
 /obj/effect/landmark/xeno_turret_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -23879,20 +23353,17 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark/red2,
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"sSZ" = (
+/turf/open/floor/tile/damaged/panel,
+/area/bigredv2/caves/southeast)
 "sTd" = (
 /turf/closed/wall/r_wall/unmeltable,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "sTE" = (
 /obj/item/ammo_casing/shell,
 /obj/item/weapon/gun/shotgun/pump/cmb,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "sUd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -23904,17 +23375,11 @@
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "sWk" = (
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "sWC" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -23938,36 +23403,17 @@
 "tco" = (
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/s)
-"tdv" = (
-/obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "tfr" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "tfF" = (
 /turf/open/shuttle/elevator/grating,
 /area/bigredv2/caves/northwest)
-"tjb" = (
-/turf/open/floor/tile/damaged/five,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "tjQ" = (
 /obj/effect/decal/cleanable/blood/gibs/up,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "tku" = (
 /turf/closed/wall/indestructible/mineral,
 /area/storage/testroom)
@@ -23996,16 +23442,6 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/north)
-"tny" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/largecrate/random/case/double,
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "toO" = (
 /obj/effect/landmark/weed_node,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
@@ -24013,12 +23449,6 @@
 	},
 /turf/open/floor/freezer,
 /area/bigredv2/outside/virology)
-"tqK" = (
-/turf/open/floor/tile/damaged/panel,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "tsZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/marking/asteroidwarning{
@@ -24068,46 +23498,20 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/grimy,
 /area/bigredv2/outside/dorms)
-"tyh" = (
-/obj/machinery/atmospherics/pipe/manifold/green{
-	dir = 8
-	},
-/turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "tyD" = (
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "tzo" = (
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/east)
 "tzW" = (
 /turf/open/floor/prison/darkyellow/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "tAB" = (
 /obj/item/ammo_casing/shell,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
-"tCw" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "tCQ" = (
 /obj/structure/barricade/metal{
 	dir = 8
@@ -24115,17 +23519,11 @@
 /obj/item/ammo_casing/shell,
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "tDh" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/darkyellow/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "tDX" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 6
@@ -24139,19 +23537,14 @@
 "tHW" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno/limb,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
-"tHZ" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/multi_tile/mainship/generic,
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
+"tIX" = (
+/obj/structure/largecrate/random/barrel/blue,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/prison/darkyellow/full,
+/area/bigredv2/caves/southeast)
 "tJA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -24167,21 +23560,16 @@
 /obj/effect/decal/cleanable/blood/gibs/xeno/limb,
 /obj/item/ammo_casing/shell,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
+"tMt" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/southeast)
 "tNb" = (
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/plating,
 /area/bigredv2/caves/lambda_lab)
-"tSF" = (
-/obj/effect/landmark/xeno_resin_door,
-/turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "tUS" = (
 /obj/machinery/door/airlock/mainship/security/glass/free_access,
 /turf/open/floor,
@@ -24202,10 +23590,7 @@
 /obj/item/ammo_casing/bullet,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "tZR" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/xeno_resin_wall,
@@ -24217,25 +23602,26 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "uan" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/marking/asteroidwarning{
 	dir = 4
 	},
 /area/bigredv2/outside/c)
+"ubN" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 9
+	},
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/southeast)
 "ucI" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/item/ammo_casing/shell,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "udd" = (
 /obj/machinery/power/apc/drained{
 	dir = 4
@@ -24249,13 +23635,6 @@
 	dir = 1
 	},
 /area/bigredv2/caves/east)
-"udL" = (
-/obj/structure/prop/mainship/mission_planning_system,
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "uec" = (
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/caves/southwest)
@@ -24275,6 +23654,14 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
+"ugo" = (
+/obj/effect/landmark/xeno_resin_door,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/southeast)
 "uhp" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
@@ -24316,6 +23703,12 @@
 	dir = 4
 	},
 /area/shuttle/drop2/lz2)
+"umt" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/southeast)
 "umT" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -24331,19 +23724,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
-"upD" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "uqm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/corpsespawner/doctor,
@@ -24353,10 +23734,7 @@
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "utl" = (
 /obj/machinery/floodlight/landing,
 /turf/open/floor/marking/asteroidwarning{
@@ -24378,10 +23756,7 @@
 "uwD" = (
 /obj/effect/landmark/corpsespawner/engineer,
 /turf/open/floor/prison/darkyellow/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "uxP" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall,
@@ -24390,10 +23765,7 @@
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /obj/structure/cable,
 /turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "uyQ" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -24401,18 +23773,7 @@
 "uCk" = (
 /obj/effect/spawner/gibspawner/human,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
-"uHf" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/multi_tile/mainship/generic,
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "uHG" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -24424,15 +23785,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor,
 /area/bigredv2/outside/hydroponics)
-"uIf" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "uJV" = (
 /obj/machinery/door/poddoor/shutters/mainship{
 	id = "Cargonia";
@@ -24445,12 +23797,6 @@
 /obj/item/ammo_casing/shell,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
-"uKS" = (
-/turf/open/floor/tile/damaged/five,
 /area/bigredv2/caves/southeast)
 "uLz" = (
 /obj/effect/landmark/xeno_resin_wall,
@@ -24459,23 +23805,11 @@
 "uLC" = (
 /obj/item/ammo_casing/shell,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "uLR" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/northeast)
-"uMk" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 6
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "uMP" = (
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/east)
@@ -24485,15 +23819,6 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
-"uTK" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "uUn" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -24518,20 +23843,7 @@
 "vbQ" = (
 /obj/item/limb/l_arm,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
-"vcC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	on = 1;
-	welded = 1
-	},
-/turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "veE" = (
 /obj/structure/table,
 /obj/effect/spawner/random/toolbox,
@@ -24541,12 +23853,16 @@
 /obj/structure/cable,
 /turf/open/shuttle/elevator/grating,
 /area/bigredv2/caves/northwest)
+"vhj" = (
+/obj/effect/landmark/weed_node,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/southeast)
 "vlA" = (
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "vlT" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
@@ -24556,10 +23872,7 @@
 	dir = 8
 	},
 /turf/open/floor/tile/damaged/five,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "vpv" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -24576,10 +23889,7 @@
 /obj/machinery/light,
 /obj/structure/cable,
 /turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "vsq" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/marking/asteroidwarning,
@@ -24587,10 +23897,7 @@
 "vuE" = (
 /obj/effect/spawner/gibspawner/human,
 /turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "vvM" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -24600,16 +23907,6 @@
 "vwf" = (
 /turf/closed/mineral/bigred,
 /area/bigredv2/outside/space_port)
-"vwv" = (
-/obj/docking_port/stationary/crashmode,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "vwP" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
@@ -24625,10 +23922,7 @@
 	pixel_y = 9
 	},
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "vyZ" = (
 /obj/effect/landmark/xeno_turret_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -24637,10 +23931,7 @@
 /obj/effect/decal/cleanable/blood/gibs/xeno/limb,
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "vAP" = (
 /obj/docking_port/stationary/crashmode,
 /obj/structure/cable,
@@ -24666,20 +23957,7 @@
 /obj/item/weapon/gun/rifle/famas,
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
-"vFT" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 4;
-	on = 1
-	},
-/turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "vIl" = (
 /obj/structure/sign/poster{
 	dir = 1
@@ -24691,6 +23969,12 @@
 	dir = 4
 	},
 /area/bigredv2/caves/northeast)
+"vJm" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/southeast)
 "vKc" = (
 /obj/structure/girder,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -24710,22 +23994,9 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/east)
-"vNo" = (
-/obj/structure/largecrate/random/barrel/blue,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/prison/darkyellow/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "vQS" = (
 /turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "vRM" = (
 /obj/effect/decal/warning_stripes/nscenter,
 /obj/machinery/light/built{
@@ -24733,6 +24004,15 @@
 	},
 /turf/open/shuttle/escapepod,
 /area/bigredv2/caves/northeast)
+"vSn" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 5
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/southeast)
 "vST" = (
 /turf/open/shuttle/escapepod,
 /area/bigredv2/caves/lambda_lab)
@@ -24764,10 +24044,7 @@
 /obj/item/ammo_casing/shell,
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "vXv" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 4
@@ -24778,18 +24055,12 @@
 /obj/item/ammo_casing/shell,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "wbU" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno/body,
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "wdk" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /obj/structure/cable,
@@ -24798,27 +24069,14 @@
 "wdL" = (
 /turf/open/floor/plating/plating_catwalk,
 /area/bigredv2/caves/northwest)
-"wel" = (
-/obj/structure/cable,
-/turf/open/floor/prison/darkyellow/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "weF" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "wff" = (
 /obj/effect/decal/cleanable/blood/tracks/footprints,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "wfD" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/darkish,
@@ -24832,17 +24090,6 @@
 /obj/effect/landmark/xeno_turret_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/east)
-"wjl" = (
-/obj/effect/landmark/xeno_resin_door,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "wmv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -24859,45 +24106,28 @@
 "wnO" = (
 /obj/item/limb/l_hand,
 /turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "wpF" = (
 /obj/item/limb/l_arm,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "wpO" = (
 /obj/effect/decal/cleanable/blood/tracks/footprints,
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
+"wqH" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/southeast)
 "wrk" = (
 /turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "wsS" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/east)
-"wtd" = (
-/obj/machinery/atmospherics/pipe/manifold/green{
-	dir = 1
-	},
-/obj/effect/landmark/corpsespawner,
-/turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "wxA" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno/down,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -24914,22 +24144,17 @@
 	dir = 1
 	},
 /area/bigredv2/outside/c)
-"wAY" = (
-/obj/structure/bed/chair/dropship{
-	dir = 8
-	},
-/turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "wBY" = (
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/tile/damaged/four,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
+"wBZ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/southeast)
 "wCi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -24951,10 +24176,7 @@
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "wQg" = (
 /obj/structure/cable,
 /obj/machinery/light,
@@ -25032,18 +24254,12 @@
 	},
 /obj/structure/cable,
 /turf/open/shuttle/elevator/grating,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "xiz" = (
 /obj/effect/landmark/corpsespawner/security,
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "xiT" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor,
@@ -25060,18 +24276,7 @@
 "xjA" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
-"xjJ" = (
-/obj/structure/cable,
-/obj/structure/window/framed/colony/reinforced,
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "xlj" = (
 /obj/effect/decal/warning_stripes/thick{
 	dir = 8
@@ -25082,18 +24287,11 @@
 	pixel_x = 16
 	},
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
-"xmO" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/bed/chair/dropship,
-/turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
+"xne" = (
+/obj/effect/landmark/corpsespawner,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/southeast)
 "xnf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/tool,
@@ -25102,30 +24300,7 @@
 "xni" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
-"xnp" = (
-/obj/effect/landmark/weed_node,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
-"xnv" = (
-/obj/structure/cable,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "xnD" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/wall,
@@ -25153,10 +24328,7 @@
 "xqW" = (
 /obj/structure/cable,
 /turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "xrJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	on = 1
@@ -25167,14 +24339,6 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/east)
-"xtF" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "xtN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
@@ -25186,10 +24350,7 @@
 /obj/effect/landmark/corpsespawner/scientist,
 /obj/machinery/light,
 /turf/open/floor/tile/dark2,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "xvL" = (
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/southeast)
@@ -25218,10 +24379,7 @@
 	dir = 1
 	},
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "xAO" = (
 /obj/effect/landmark/corpsespawner/security,
 /turf/open/floor,
@@ -25272,10 +24430,7 @@
 	},
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "xNf" = (
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -25284,14 +24439,6 @@
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/south)
-"xPH" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/effect/landmark/corpsespawner,
-/turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "xPT" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -25303,13 +24450,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/space_port)
-"xRc" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "xRF" = (
 /obj/effect/decal/warning_stripes/thick{
 	dir = 1
@@ -25317,10 +24457,7 @@
 /obj/structure/cable,
 /obj/machinery/light,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "xRR" = (
 /obj/machinery/light{
 	dir = 1
@@ -25334,10 +24471,7 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood/gibs/xeno/body,
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
+/area/bigredv2/caves/southeast)
 "xSR" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 6
@@ -25368,13 +24502,6 @@
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/south)
-"ycc" = (
-/obj/effect/landmark/weed_node,
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "ydN" = (
 /turf/open/floor/mainship/orange,
 /area/bigredv2/caves/northeast)
@@ -25405,16 +24532,6 @@
 /obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
-"yjY" = (
-/obj/machinery/door/airlock/mainship/generic,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "ykI" = (
 /obj/structure/cable,
 /turf/open/floor/plating/warning{
@@ -58606,9 +57723,9 @@ jeY
 jeY
 eve
 eve
-uKS
+iix
 eve
-qVN
+dEz
 jeY
 jeY
 jeY
@@ -58822,10 +57939,10 @@ jeY
 jeY
 jeY
 jeY
-sjC
-sjC
-sjC
-sjC
+pJO
+pJO
+pJO
+pJO
 jeY
 jeY
 jeY
@@ -59040,9 +58157,9 @@ aPo
 aPo
 aPo
 aPo
-fzQ
-tqK
-pgW
+mPX
+sSZ
+eve
 aPo
 aPo
 aPo
@@ -59242,31 +58359,31 @@ eve
 fwQ
 eve
 eve
-iXU
+hjN
 wrk
-hoI
-wrk
-wrk
-wrk
-wrk
-uMk
-ncd
-pzS
-ncd
-qsG
-ncd
-ncd
-pzS
-ncd
-ncd
-ncd
-ncd
-lKe
-dpu
+vJm
 wrk
 wrk
 wrk
-hoI
+wrk
+szH
+ncd
+dCk
+ncd
+wqH
+ncd
+ncd
+dCk
+ncd
+ncd
+ncd
+ncd
+vSn
+kcV
+wrk
+wrk
+wrk
+vJm
 wrk
 wrk
 wrk
@@ -59459,10 +58576,10 @@ eve
 onX
 eve
 eve
-daq
+ryA
 vQS
 vQS
-oUf
+cCv
 vQS
 vQS
 vQS
@@ -59470,23 +58587,23 @@ csO
 vQS
 vQS
 vQS
-phD
+qhe
 vQS
 vQS
 vQS
 vQS
-oUf
+cCv
 vQS
 vQS
-rel
-fdu
-nqq
-hRM
-nqq
-xPH
-nqq
-nqq
-oUj
+ptq
+dZV
+fYf
+kPO
+fYf
+diq
+fYf
+fYf
+kKI
 aPo
 aab
 qOl
@@ -59676,14 +58793,14 @@ eve
 eve
 eve
 eve
-daq
+ryA
 vQS
 hjc
 vQS
 hjc
 vQS
 vQS
-jHx
+eCa
 vQS
 vQS
 hjc
@@ -59893,31 +59010,31 @@ eve
 eve
 eve
 eve
-iXU
+hjN
 wrk
-vwv
+mXZ
 wrk
 wrk
 wrk
 wrk
 csO
 wrk
-qsC
+iCy
 wrk
-dpu
-wrk
-wrk
-qsC
+kcV
 wrk
 wrk
-wrk
-wrk
-qEi
-dpu
+iCy
 wrk
 wrk
 wrk
-qsC
+wrk
+hnC
+kcV
+wrk
+wrk
+wrk
+iCy
 wrk
 hjc
 csO
@@ -60116,18 +59233,18 @@ aPo
 aPo
 aPo
 aPo
-iXU
-hOG
-iXU
-tdv
+hjN
+pYh
+hjN
+hnZ
 aPo
 aPo
 aPo
 aPo
-xjJ
-ryO
-fhb
-tdv
+skH
+hUp
+oFn
+hnZ
 aPo
 aPo
 aPo
@@ -60135,7 +59252,7 @@ aPo
 aPo
 aPo
 aPo
-clx
+gLt
 vQS
 csO
 aPo
@@ -60336,7 +59453,7 @@ aPo
 wrk
 csO
 wrk
-tdv
+hnZ
 jeY
 jeY
 jeY
@@ -60344,7 +59461,7 @@ aPo
 kOh
 kOh
 kOh
-mxP
+lrE
 jeY
 jeY
 jeY
@@ -60550,18 +59667,18 @@ jeY
 jeY
 jeY
 aPo
-uTK
+cUL
 csO
-cSH
-tdv
+oUc
+hnZ
 jeY
 jeY
 jeY
 aPo
 kOh
-elV
+xne
 kOh
-mxP
+lrE
 jeY
 jeY
 jeY
@@ -60571,7 +59688,7 @@ jeY
 jeY
 aPo
 vQS
-eXq
+pFH
 aPo
 aab
 qOl
@@ -60767,18 +59884,18 @@ jeY
 jeY
 jeY
 aPo
-mxP
-yjY
-mxP
-tdv
+lrE
+mie
+lrE
+hnZ
 jeY
 jeY
 jeY
 aPo
-uIf
-ycc
+eHA
+pnH
 kOh
-mxP
+lrE
 jeY
 jeY
 jeY
@@ -60985,17 +60102,17 @@ jeY
 jeY
 aPo
 wrk
-xnp
+vhj
 wrk
-tdv
+hnZ
 jeY
 jeY
 jeY
 aPo
 gfc
 kOh
-xRc
-mxP
+mik
+lrE
 jeY
 jeY
 jeY
@@ -61204,15 +60321,15 @@ aPo
 wrk
 csO
 wrk
-tdv
+hnZ
 jeY
 jeY
 jeY
 aPo
-gMF
+dMG
 kOh
 kOh
-mxP
+lrE
 jeY
 jeY
 jeY
@@ -61221,8 +60338,8 @@ jeY
 jeY
 jeY
 aPo
-vcC
-oEr
+dXy
+gUa
 aPo
 aab
 qOl
@@ -61419,9 +60536,9 @@ jeY
 jeY
 aPo
 wrk
-rel
-pPX
-tdv
+ptq
+kyV
+hnZ
 jeY
 jeY
 jeY
@@ -61429,7 +60546,7 @@ aPo
 gfc
 kOh
 kOh
-mxP
+lrE
 jeY
 jeY
 jeY
@@ -61438,7 +60555,7 @@ jeY
 jeY
 jeY
 aPo
-upD
+kjW
 csO
 aPo
 aab
@@ -61635,18 +60752,18 @@ jeY
 jeY
 jeY
 aPo
-uTK
+cUL
 csO
-cSH
-tdv
+oUc
+hnZ
 jeY
 jeY
 jeY
 aPo
-mxP
-kOG
-mxP
-mxP
+lrE
+cBO
+lrE
+lrE
 sTd
 sTd
 sTd
@@ -61654,7 +60771,7 @@ sTd
 sTd
 sTd
 sTd
-tdv
+hnZ
 vQS
 csO
 aPo
@@ -61855,25 +60972,25 @@ aPo
 wrk
 csO
 wrk
-tdv
+hnZ
 jeY
 jeY
 jeY
 aPo
-udL
+nbw
 kOh
 kOh
-mxP
-mwU
+lrE
+meb
 kOh
 kOh
 kOh
 kOh
 kOh
-xRc
-uHf
+mik
+llp
 vQS
-nru
+blc
 aPo
 aab
 qOl
@@ -62072,23 +61189,23 @@ aPo
 wrk
 csO
 wrk
-tdv
+hnZ
 jeY
 jeY
 jeY
 aPo
-dTY
-ycc
+hxV
+pnH
 kOh
-aoD
-kOh
-kOh
-ycc
-kOh
-elV
+fGX
 kOh
 kOh
-ryO
+pnH
+kOh
+xne
+kOh
+kOh
+hUp
 vQS
 csO
 aPo
@@ -62286,28 +61403,28 @@ jeY
 jeY
 jeY
 aPo
-mxP
-yjY
-mxP
-tdv
+lrE
+mie
+lrE
+hnZ
 jeY
 jeY
 jeY
 aPo
-lic
-hog
-hKM
+fBE
+foR
+dZr
 sTd
 kOh
 kOh
-eqs
-eqs
-okr
-ycc
+dWx
+dWx
+rEl
+pnH
 kOh
-tdv
+hnZ
 vQS
-eXq
+pFH
 aPo
 aab
 qOl
@@ -62503,17 +61620,17 @@ jeY
 jeY
 jeY
 aPo
-bIZ
+snZ
 csO
 wrk
-tdv
+hnZ
 jeY
 jeY
 jeY
 aPo
-oVG
+pld
 kOh
-eTn
+umt
 aPo
 aPo
 aPo
@@ -62522,7 +61639,7 @@ aPo
 aPo
 aPo
 aPo
-tdv
+hnZ
 vQS
 csO
 aPo
@@ -62720,17 +61837,17 @@ jeY
 jeY
 jeY
 aPo
-uTK
+cUL
 csO
-cSH
-tdv
+oUc
+hnZ
 sTd
 sTd
 sTd
 aPo
 sTd
 sTd
-gmF
+bfU
 aPo
 jeY
 jeY
@@ -62739,9 +61856,9 @@ jeY
 jeY
 jeY
 aPo
-tdv
+hnZ
 xqW
-oEm
+rkN
 aPo
 sTd
 qOl
@@ -62940,14 +62057,14 @@ aPo
 wrk
 csO
 wrk
-tdv
+hnZ
 kOh
 kOh
 kOh
-aoD
+fGX
 kOh
 kOh
-eTn
+umt
 aPo
 jeY
 jeY
@@ -63155,16 +62272,16 @@ jeY
 jeY
 aPo
 wrk
-wtd
+eZl
 ncd
-tHZ
-lIZ
-eOZ
-xtF
-qcY
-lIZ
-eOZ
-oCu
+kXT
+nAr
+rml
+pgX
+pEP
+nAr
+rml
+ubN
 aPo
 jeY
 jeY
@@ -63374,7 +62491,7 @@ aPo
 wrk
 csO
 wrk
-ryO
+hUp
 kOh
 kOh
 kOh
@@ -63591,22 +62708,22 @@ aPo
 wrk
 csO
 wrk
-tdv
-mxP
-mxP
-mxP
-tdv
-mxP
+hnZ
+lrE
+lrE
+lrE
+hnZ
+lrE
 kOh
-elV
+xne
 aPo
 jeY
 jeY
-mly
-tdv
-tdv
-tdv
-tdv
+lrE
+hnZ
+hnZ
+hnZ
+hnZ
 tzW
 vQS
 csO
@@ -63805,28 +62922,28 @@ jeY
 jeY
 jeY
 aPo
-uTK
-xnp
-cSH
+cUL
+vhj
+oUc
 aPo
 jeY
 jeY
 jeY
-tdv
+hnZ
 sTd
 kOh
 kOh
 aPo
 jeY
 jeY
-mly
-fKy
+lrE
+mSl
 tzW
 uwD
-ssh
+jrt
 tzW
 vQS
-xnp
+vhj
 xqW
 sTd
 qOl
@@ -64022,25 +63139,25 @@ jeY
 jeY
 jeY
 aPo
-mxP
-yjY
-mxP
+lrE
+mie
+lrE
 aPo
 jeY
 jeY
 jeY
-tdv
-tny
+hnZ
+owV
 kOh
 kOh
 aPo
 jeY
 jeY
-mxP
-wel
-vNo
+lrE
+qSr
+tIX
 tDh
-mxP
+lrE
 tzW
 vQS
 csO
@@ -64246,18 +63363,18 @@ aPo
 jeY
 jeY
 jeY
-tdv
-lCu
+hnZ
+nyk
 kOh
 kOh
 aPo
 jeY
 jeY
-mxP
-mxP
-mxP
-mxP
-mxP
+lrE
+lrE
+lrE
+lrE
+lrE
 vQS
 vQS
 csO
@@ -64448,7 +63565,7 @@ eve
 eve
 eve
 eve
-vFT
+wBZ
 aPo
 aPo
 aPo
@@ -64456,21 +63573,21 @@ aPo
 aPo
 aPo
 aPo
-kTu
-wjl
-kTu
-tdv
-tdv
-tdv
-tdv
-coI
-tdv
-ryO
-fhb
-clx
+gzC
+ugo
+gzC
+hnZ
+hnZ
+hnZ
+hnZ
+caa
+hnZ
+hUp
+oFn
+gLt
 aPo
 aPo
-tdv
+hnZ
 vQS
 vQS
 vQS
@@ -64478,7 +63595,7 @@ vQS
 vQS
 vQS
 csO
-buT
+cYr
 sTd
 qOl
 "}
@@ -64665,34 +63782,34 @@ eve
 eve
 eve
 eve
-bey
-pQo
+rUx
+rVm
 wrk
 wrk
 wrk
-hoI
+vJm
 wrk
 wrk
 wrk
 csO
 wrk
-hoI
+vJm
 wrk
 wrk
 wrk
-mcd
+onn
 wrk
 wrk
 wrk
 wrk
-hoI
+vJm
 wrk
 wrk
 vQS
 vQS
 jFi
-wAY
-wAY
+fSc
+fSc
 vQS
 csO
 vry
@@ -64882,37 +63999,37 @@ eve
 eve
 eve
 eve
-bOy
-cYb
-nqq
-nqq
-nqq
-hRM
-nqq
-nqq
-nqq
-hiC
-nqq
-hRM
-nqq
-nqq
-nqq
-tCw
-nqq
-nqq
-xPH
-nqq
-nqq
-nqq
-nqq
-nqq
-tyh
-nqq
-qtr
-qtr
-xmO
+nyZ
+dlq
+fYf
+fYf
+fYf
+kPO
+fYf
+fYf
+fYf
+lFw
+fYf
+kPO
+fYf
+fYf
+fYf
+tMt
+fYf
+fYf
+diq
+fYf
+fYf
+fYf
+fYf
+fYf
+fEo
+fYf
+rMR
+rMR
+kII
 iYa
-lmq
+sMk
 sTd
 qOl
 "}
@@ -65100,7 +64217,7 @@ eve
 eve
 eve
 eve
-tSF
+inA
 vQS
 vQS
 vQS
@@ -65114,7 +64231,7 @@ vQS
 vQS
 vQS
 vQS
-buT
+cYr
 vQS
 vQS
 vQS
@@ -65126,8 +64243,8 @@ gvo
 csO
 hjc
 nPl
-mxP
-ecc
+lrE
+fdM
 vQS
 xqW
 sTd
@@ -65317,10 +64434,10 @@ eve
 eve
 eve
 eve
-tSF
+inA
 vQS
 vQS
-oUf
+cCv
 vQS
 vQS
 vQS
@@ -65342,8 +64459,8 @@ vQS
 vQS
 csO
 vQS
-sBX
-sBX
+qVy
+qVy
 vQS
 vQS
 xqW
@@ -65534,26 +64651,26 @@ jeY
 eve
 eve
 eve
-pQo
+rVm
 wrk
 wrk
 wrk
-qsC
+iCy
 wrk
 wrk
 wrk
-iqL
+saC
 wrk
-qsC
-wrk
-wrk
-wrk
-xnv
+iCy
 wrk
 wrk
 wrk
+bOf
 wrk
-qsC
+wrk
+wrk
+wrk
+iCy
 wrk
 wrk
 vQS
@@ -65751,27 +64868,27 @@ jeY
 eve
 eve
 eve
-tdv
-tdv
-tdv
+hnZ
+hnZ
+hnZ
 aPo
-tdv
-tdv
+hnZ
+hnZ
 aPo
 aPo
-coI
-tdv
-tdv
-tdv
-tdv
-tdv
-tdv
-tdv
-tdv
-tdv
-tdv
-tdv
-tdv
+caa
+hnZ
+hnZ
+hnZ
+hnZ
+hnZ
+hnZ
+hnZ
+hnZ
+hnZ
+hnZ
+hnZ
+hnZ
 aPo
 vQS
 gfg
@@ -65990,7 +65107,7 @@ xEp
 jeY
 jeY
 sTd
-upD
+kjW
 csO
 rjr
 hjc
@@ -68782,7 +67899,7 @@ fwQ
 eve
 eve
 vKc
-kcY
+kxh
 loN
 jeY
 jeY
@@ -69028,7 +68145,7 @@ sTd
 sTd
 aPo
 sTd
-mxP
+lrE
 oZb
 vQS
 vFE
@@ -69245,7 +68362,7 @@ igD
 juh
 kbu
 igD
-mxP
+lrE
 qgz
 sBJ
 vWM
@@ -69452,17 +68569,17 @@ jeY
 jeY
 jeY
 jeY
-nWE
+dPw
 dFO
 kOh
 kOh
 fQH
-mxP
+lrE
 igK
 juu
 emA
 lgV
-mxP
+lrE
 qgz
 sCz
 vYr
@@ -69672,16 +68789,16 @@ jeY
 sTd
 dLF
 kOh
-xRc
+mik
 gfc
 pNt
 ijF
 juU
 kbu
 lpn
-mxP
+lrE
 pEd
-piE
+oIp
 rde
 uad
 sTd
@@ -69886,11 +69003,11 @@ jeY
 jeY
 sTd
 sTd
-mxP
-tdv
-mxP
-mxP
-mxP
+lrE
+hnZ
+lrE
+lrE
+lrE
 aPo
 xiw
 jAz
@@ -70113,7 +69230,7 @@ nBy
 nBy
 nBy
 lqu
-mxP
+lrE
 qgz
 riu
 wbU
@@ -70323,14 +69440,14 @@ glf
 vlA
 nBy
 vlA
-mxP
+lrE
 gok
-mxP
+lrE
 iAa
 vlA
 kHY
 lrg
-mxP
+lrE
 qgz
 sTE
 wpF
@@ -70535,7 +69652,7 @@ eve
 eve
 eve
 eve
-mxP
+lrE
 vlA
 vlA
 nBy
@@ -70547,7 +69664,7 @@ vlA
 vlA
 vlA
 vlA
-tdv
+hnZ
 oZb
 sVq
 sLI
@@ -70764,7 +69881,7 @@ nBy
 nBy
 nBy
 luM
-tdv
+hnZ
 pHZ
 sWk
 rde
@@ -70981,9 +70098,9 @@ vlA
 vlA
 kXR
 lAi
-mxP
+lrE
 pHZ
-tjb
+iix
 weF
 uad
 sTd
@@ -71191,14 +70308,14 @@ coa
 vlA
 dYK
 vlA
-mxP
+lrE
 gsZ
-mxP
+lrE
 iJf
 jGP
 dYK
 vlA
-mxP
+lrE
 tXf
 tjQ
 wff
@@ -71405,16 +70522,16 @@ xEp
 jeY
 sTd
 aPo
-mxP
-mxP
-mxP
-mxP
+lrE
+lrE
+lrE
+lrE
 gsZ
-mxP
-mxP
-mxP
-mxP
-mxP
+lrE
+lrE
+lrE
+lrE
+lrE
 mDZ
 pVl
 vQS
@@ -71625,7 +70742,7 @@ ipY
 dbi
 dbi
 dbi
-mxP
+lrE
 gAX
 dbi
 dbi
@@ -72055,7 +71172,7 @@ jeY
 xEp
 jeY
 sTd
-szr
+cxx
 ekE
 ekE
 ekE
@@ -72273,17 +71390,17 @@ qOl
 aab
 sTd
 sTd
-mxP
-tdv
-mxP
-mxP
+lrE
+hnZ
+lrE
+lrE
 gZX
-tdv
-tdv
-mxP
-mxP
-mxP
-mxP
+hnZ
+hnZ
+lrE
+lrE
+lrE
+lrE
 qfQ
 tCQ
 vuE
@@ -72493,16 +71610,16 @@ cBo
 deb
 eoX
 nBy
-tdv
+hnZ
 gZX
-tdv
+hnZ
 iKL
 vlA
 lgf
 lNk
-mxP
+lrE
 qgz
-qwT
+cCM
 wBY
 uad
 sTd
@@ -72717,7 +71834,7 @@ vlA
 vlA
 vlA
 lPS
-mxP
+lrE
 qgz
 vbQ
 bRs
@@ -72934,7 +72051,7 @@ nBy
 uqs
 nBy
 lZp
-tdv
+hnZ
 qgz
 tHW
 wKg
@@ -73151,7 +72268,7 @@ vlA
 ekC
 vlA
 mrL
-mxP
+lrE
 qgz
 tLL
 xiz
@@ -73361,14 +72478,14 @@ cTg
 dyQ
 exf
 exf
-tdv
+hnZ
 hgL
 hVy
 jkn
 vlA
 lgt
 mrL
-mxP
+lrE
 qnf
 ucI
 xjA
@@ -73585,7 +72702,7 @@ jpN
 jMk
 lgt
 mwK
-mxP
+lrE
 quA
 upn
 xlj

--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -368,6 +368,7 @@
 /obj/structure/cargo_container{
 	dir = 8
 	},
+/obj/structure/cargo_container,
 /turf/open/floor/plating,
 /area/bigredv2/outside/space_port)
 "abx" = (
@@ -395,9 +396,11 @@
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/space_port)
 "abC" = (
-/obj/machinery/light,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/asteroidfloor,
-/area/bigredv2/outside/space_port)
+/area/space)
 "abD" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plating,
@@ -460,11 +463,9 @@
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/lambda_lab)
 "abQ" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/asteroidfloor,
-/area/bigredv2/outside/space_port)
+/obj/structure/cable,
+/turf/closed/mineral/bigred,
+/area/bigredv2/caves/northwest)
 "abR" = (
 /obj/structure/sign/safety/vent{
 	dir = 1
@@ -919,6 +920,11 @@
 /turf/open/floor/tile/darkish,
 /area/bigredv2/caves/lambda_lab)
 "adx" = (
+/obj/machinery/button/door/open_only/landing_zone{
+	desc = "What could this be for? It Requires an authorized ID or higher to activate";
+	id = "Secure_1"
+	},
+/obj/structure/closet/secure_closet/RD,
 /turf/open/floor/tile/dark/blue2{
 	dir = 1
 	},
@@ -2619,10 +2625,8 @@
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "ajT" = (
-/turf/open/floor/marking/asteroidwarning{
-	dir = 5
-	},
-/area/bigredv2/outside/n)
+/turf/closed/wall/r_wall,
+/area/bigredv2/caves/northwest)
 "ajU" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -2733,6 +2737,10 @@
 /obj/item/clothing/suit/armor/riot,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/marshal_office)
+"akl" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/south)
 "akm" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -5699,6 +5707,7 @@
 	name = "Observation Shutters";
 	pixel_y = 28
 	},
+/obj/structure/cable,
 /turf/open/floor/tile/dark/purple2/corner,
 /area/bigredv2/caves/lambda_lab)
 "auE" = (
@@ -9560,6 +9569,7 @@
 	},
 /area/bigredv2/caves/lambda_lab)
 "aIQ" = (
+/obj/structure/cable,
 /turf/open/floor/podhatch/floor{
 	icon_state = "damaged5"
 	},
@@ -9808,10 +9818,9 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/turf/open/floor/tile/dark/purple2,
+/turf/open/floor/mainship/cargo/arrow,
 /area/bigredv2/caves/lambda_lab)
 "aJJ" = (
-/obj/structure/cable,
 /obj/machinery/light/built,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -9832,7 +9841,6 @@
 /turf/open/floor/tile/dark/purple2,
 /area/bigredv2/caves/lambda_lab)
 "aJL" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -9843,7 +9851,6 @@
 /turf/open/floor/tile/dark/purple2,
 /area/bigredv2/caves/lambda_lab)
 "aJM" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -11060,6 +11067,10 @@
 	},
 /turf/open/floor/carpet,
 /area/bigredv2/outside/library)
+"aPo" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall/unmeltable,
+/area/bigredv2/caves/south)
 "aPq" = (
 /obj/machinery/door/airlock/mainship/research/glass/free_access{
 	dir = 1;
@@ -11559,6 +11570,12 @@
 	dir = 5
 	},
 /area/bigredv2/caves/lambda_lab)
+"aSn" = (
+/obj/effect/landmark/xeno_turret_spawn,
+/turf/open/floor/tile/dark/blue2{
+	dir = 6
+	},
+/area/bigredv2/outside/nanotrasen_lab/inside)
 "aSo" = (
 /obj/structure/curtain/medical,
 /turf/open/floor/tile/green/whitegreen{
@@ -12019,6 +12036,11 @@
 	},
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/caves/lambda_lab)
+"aUv" = (
+/obj/structure/window/framed/colony,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/bigredv2/outside/nanotrasen_lab/inside)
 "aUx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -17976,7 +17998,6 @@
 	},
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "bzH" = (
-/obj/structure/closet/secure_closet/RD,
 /turf/open/floor/tile/dark/blue2{
 	dir = 1
 	},
@@ -18052,6 +18073,7 @@
 /obj/structure/bed/chair/office/light{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/tile/dark/blue2{
 	dir = 5
 	},
@@ -18204,6 +18226,7 @@
 "bAG" = (
 /obj/structure/table,
 /obj/effect/spawner/random/technology_scanner,
+/obj/structure/cable,
 /turf/open/floor/tile/dark/blue2{
 	dir = 6
 	},
@@ -18291,6 +18314,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/tile/darkgreen/darkgreen2/corner,
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "bBb" = (
@@ -18347,6 +18371,7 @@
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "bBk" = (
 /obj/structure/filingcabinet/medical,
+/obj/structure/cable,
 /turf/open/floor/tile/dark/red2{
 	dir = 1
 	},
@@ -18911,6 +18936,7 @@
 "bDu" = (
 /obj/structure/table,
 /obj/item/book/manual/nuclear,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "bDv" = (
@@ -18965,6 +18991,7 @@
 "bDI" = (
 /obj/structure/table,
 /obj/item/computer3_part/storage/hdd/big,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "bDJ" = (
@@ -19145,6 +19172,7 @@
 /obj/structure/table,
 /obj/item/tool/pen,
 /obj/item/paper_bundle,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "bEu" = (
@@ -19270,10 +19298,32 @@
 /obj/structure/cable,
 /turf/open/floor/tile/darkish,
 /area/bigredv2/outside/chapel)
+"bHk" = (
+/obj/structure/cable,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab)
+"bHv" = (
+/turf/closed/wall/r_wall/unmeltable,
+/area/space)
+"bKh" = (
+/obj/structure/cable,
+/obj/effect/landmark/corpsespawner/engineer,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "bLJ" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/southeast)
+"bMl" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/tile/dark/yellow2/corner,
+/area/bigredv2/caves/south)
+"bNb" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/south)
 "bQc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
@@ -19285,6 +19335,17 @@
 /obj/effect/landmark/corpsespawner/engineer,
 /turf/open/floor/tile/yellow/full,
 /area/bigredv2/outside/hydroponics)
+"bRs" = (
+/obj/structure/barricade/metal{
+	dir = 8
+	},
+/obj/item/ammo_casing/bullet,
+/obj/machinery/marine_turret/premade{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "bSC" = (
 /obj/machinery/light{
 	dir = 8
@@ -19293,6 +19354,10 @@
 	dir = 1
 	},
 /area/bigredv2/outside/nw)
+"bTi" = (
+/obj/structure/largecrate/supply/ammo/m41a,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "bTs" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -19308,10 +19373,28 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/northwest)
+"ccx" = (
+/obj/effect/decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/effect/landmark/corpsespawner/security,
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "ccP" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/wall,
 /area/bigredv2/outside/office_complex)
+"ceT" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/largecrate/supply/ammo/m41a,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "cfH" = (
 /obj/machinery/miner/damaged/platinum,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -19329,14 +19412,36 @@
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/floor/wood,
 /area/bigredv2/outside/bar)
+"cin" = (
+/obj/structure/largecrate/supply/ammo/m41a_box,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "ckJ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/se)
+"coa" = (
+/obj/structure/rack,
+/obj/item/weapon/gun/shotgun/pump/cmb,
+/obj/item/ammo_magazine/shotgun/flechette,
+/obj/item/ammo_magazine/shotgun/flechette,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "cov" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/south)
+"csO" = (
+/obj/machinery/door/airlock/mainship/research/glass/free_access,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
+"ctE" = (
+/turf/open/shuttle/escapepod/five,
+/area/bigredv2/caves/north)
+"cur" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/tile/dark2,
 /area/bigredv2/caves/south)
 "cuW" = (
 /obj/structure/cable,
@@ -19368,20 +19473,56 @@
 	dir = 10
 	},
 /area/bigredv2/outside/nw)
+"czd" = (
+/obj/structure/cable,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/closed/mineral/bigred,
+/area/bigredv2/caves/northwest)
+"cBo" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/filingcabinet,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "cBD" = (
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/bigredv2/outside/sw)
+"cCg" = (
+/obj/structure/cable,
+/turf/open/floor/tile/dark/blue2,
+/area/bigredv2/outside/nanotrasen_lab/inside)
+"cFp" = (
+/obj/effect/spawner/gibspawner/human,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/south)
 "cGZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor,
 /area/bigredv2/outside/hydroponics)
+"cHL" = (
+/obj/structure/table/mainship,
+/obj/machinery/computer/emails,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "cLe" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/marking/asteroidwarning{
 	dir = 4
 	},
 /area/bigredv2/outside/nw)
+"cLi" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/table/mainship,
+/obj/machinery/computer/security/marinemainship_network,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
+"cMC" = (
+/obj/structure/table/mainship,
+/obj/machinery/computer/communications,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "cMZ" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -19393,6 +19534,11 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/northwest)
+"cTg" = (
+/obj/effect/decal/cleanable/cobweb2,
+/obj/structure/bookcase/manuals,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "cTr" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/wall/r_wall,
@@ -19412,11 +19558,20 @@
 "cXu" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/bigredv2/outside/se)
+"cZm" = (
+/obj/structure/cable,
+/turf/open/space/basic,
+/area/space)
 "cZO" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/east)
+"dbi" = (
+/turf/open/floor/tile/blue/taupeblue{
+	dir = 8
+	},
+/area/bigredv2/caves/south)
 "dcO" = (
 /obj/machinery/door/airlock/mainship/research/free_access{
 	name = "\improper Virology Lab Administration"
@@ -19428,6 +19583,27 @@
 /obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"ddi" = (
+/turf/closed/wall/r_wall,
+/area/bigredv2/caves/southeast)
+"deb" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
+"det" = (
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
+"dhn" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/bed/chair/reinforced{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "dhB" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -19469,6 +19645,9 @@
 /obj/structure/cable,
 /turf/open/floor/tile/darkish,
 /area/bigredv2/outside/chapel)
+"dry" = (
+/turf/open/floor/tile/dark/red2/corner,
+/area/bigredv2/caves/south)
 "dsH" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -19489,19 +19668,46 @@
 /obj/effect/landmark/corpsespawner/security,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/general_offices)
+"dyQ" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/cobweb2,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "dzS" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor,
 /area/bigredv2/outside/general_store)
+"dzW" = (
+/obj/structure/ladder{
+	id = "ladder1"
+	},
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/south)
 "dCr" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/northeast)
+"dDI" = (
+/obj/structure/cable,
+/turf/closed/wall,
+/area/bigredv2/outside/telecomm)
 "dDP" = (
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/southeast)
+"dFp" = (
+/obj/effect/decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
+"dFO" = (
+/obj/structure/closet/crate/trashcart,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/south)
 "dGd" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -19524,11 +19730,21 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/southwest)
+"dLF" = (
+/obj/structure/closet/crate/secure/weapon,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/south)
 "dLO" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 9
 	},
 /area/bigredv2/outside/w)
+"dPa" = (
+/obj/structure/rack,
+/obj/item/explosive/grenade/flashbang,
+/obj/item/explosive/grenade/flashbang,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "dPu" = (
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/e)
@@ -19560,6 +19776,12 @@
 	},
 /turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/nw)
+"dYK" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "dZi" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/yellow2/corner{
@@ -19590,23 +19812,80 @@
 /obj/structure/sign/safety/medical_supplies,
 /turf/closed/wall/r_wall,
 /area/bigredv2/caves/lambda_lab)
+"egQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/storage/belt/gun/pistol/m4a3/full,
+/obj/item/storage/belt/gun/pistol/m4a3/officer,
+/turf/open/floor/tile/dark/yellow2/corner,
+/area/bigredv2/caves/south)
 "ekm" = (
 /obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"ekC" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
+"ekE" = (
+/turf/open/floor/tile/blue/taupeblue{
+	dir = 4
+	},
+/area/bigredv2/caves/south)
+"eli" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/bigredv2/caves/south)
 "elD" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/marking/asteroidwarning{
 	dir = 1
 	},
 /area/bigredv2/outside/w)
+"emA" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/structure/cable,
+/turf/open/shuttle/elevator/grating,
+/area/bigredv2/caves/south)
+"eoX" = (
+/obj/structure/cable,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "eqy" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/wall,
 /area/bigredv2/outside/cargo)
+"erQ" = (
+/turf/closed/wall/r_wall/unmeltable,
+/area/bigredv2/caves/lambda_lab)
+"euF" = (
+/obj/effect/spawner/gibspawner/human,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "eve" = (
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/southeast)
+"ewt" = (
+/obj/structure/cable,
+/obj/machinery/light/built,
+/turf/open/floor/tile/dark/purple2,
+/area/bigredv2/caves/lambda_lab)
+"ewZ" = (
+/obj/structure/table,
+/obj/machinery/computer/pod/old{
+	name = "Personal Computer"
+	},
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/bigredv2/outside/nanotrasen_lab/inside)
+"exf" = (
+/obj/structure/closet/secure_closet/security,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "exJ" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 8
@@ -19614,6 +19893,15 @@
 /area/bigredv2/outside/e)
 "eyz" = (
 /turf/closed/wall/r_wall,
+/area/bigredv2/caves/south)
+"eCh" = (
+/turf/open/shuttle/escapepod/five,
+/area/bigredv2/caves/south)
+"eCN" = (
+/obj/structure/cable,
+/turf/open/floor/tile/dark/red2/corner{
+	dir = 8
+	},
 /area/bigredv2/caves/south)
 "eDS" = (
 /obj/effect/landmark/xeno_resin_door,
@@ -19639,10 +19927,44 @@
 /obj/machinery/computer/nuke_disk_generator/blue,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"eKa" = (
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/south)
 "eKb" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/bigredv2/outside/filtration_plant)
+"eLI" = (
+/obj/structure/rack,
+/obj/item/weapon/gun/rifle/famas,
+/obj/item/ammo_magazine/rifle/famas,
+/obj/item/ammo_magazine/rifle/famas,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
+"eMX" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/hyper{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
+"eOu" = (
+/obj/structure/table,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/bigredv2/outside/nanotrasen_lab/inside)
+"ePu" = (
+/obj/effect/decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/item/ammo_casing/shell,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
+"ePv" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "ePH" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -19665,6 +19987,11 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/northwest)
+"eRD" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "eRJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/marking/asteroidwarning{
@@ -19694,6 +20021,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/southeast)
+"eYb" = (
+/obj/machinery/light,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "eZF" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
@@ -19710,6 +20041,10 @@
 	dir = 1
 	},
 /area/shuttle/drop2/lz2)
+"fcT" = (
+/obj/structure/sign/safety/ladder,
+/turf/closed/wall/r_wall,
+/area/bigredv2/caves/south)
 "feK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -19718,6 +20053,12 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"ffS" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
+	},
+/area/bigredv2/caves/northeast)
 "fgF" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor,
@@ -19742,6 +20083,11 @@
 	},
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/virology)
+"fnW" = (
+/obj/machinery/door/airlock/external,
+/obj/item/tape/engineering,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "fph" = (
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -19751,10 +20097,30 @@
 	dir = 8
 	},
 /area/shuttle/drop2/lz2)
+"fqj" = (
+/obj/structure/cable,
+/turf/closed/mineral/bigred,
+/area/bigredv2/caves/south)
 "fra" = (
 /obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/virology)
+"frg" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/north)
+"fse" = (
+/obj/machinery/camera/autoname/mainship/dropship_one{
+	dir = 8;
+	pixel_x = 16
+	},
+/turf/closed/wall/r_wall,
+/area/bigredv2/caves/south)
+"fuB" = (
+/obj/structure/cable,
+/obj/effect/landmark/corpsespawner/security,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "fwQ" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -19777,6 +20143,16 @@
 	},
 /turf/open/floor/freezer,
 /area/bigredv2/outside/virology)
+"fAC" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
+"fDs" = (
+/obj/structure/closet/crate/secure/weapon,
+/obj/structure/cable,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/north)
 "fES" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -19790,6 +20166,15 @@
 /obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"fHD" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating,
+/area/bigredv2/caves/north)
+"fIi" = (
+/obj/machinery/door/airlock,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "fIW" = (
 /obj/effect/landmark/dropship_start_location,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -19832,6 +20217,12 @@
 /obj/structure/sign/safety/breakroom,
 /turf/closed/wall,
 /area/bigredv2/outside/engineering)
+"fQH" = (
+/obj/structure/bed/chair/reinforced{
+	dir = 1
+	},
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/south)
 "fVb" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
@@ -19853,10 +20244,18 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
+"fYE" = (
+/obj/effect/decal/warning_stripes/nscenter,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/northeast)
 "fYS" = (
 /obj/structure/cable,
 /turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/space_port)
+"gcG" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/bigredv2/outside/nanotrasen_lab/inside)
 "gdc" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
@@ -19874,12 +20273,20 @@
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
 /area/bigredv2/outside/telecomm)
+"gfc" = (
+/obj/structure/largecrate,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/south)
+"gfg" = (
+/obj/structure/xeno/resin/xeno_turret,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "ggp" = (
-/obj/machinery/button/door/open_only/landing_zone,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/machinery/button/door/open_only/landing_zone,
 /turf/open/floor/plating,
 /area/bigredv2/outside/space_port)
 "ggJ" = (
@@ -19908,6 +20315,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/space_port)
+"glf" = (
+/obj/structure/largecrate/supply/explosives/mines,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
+"glC" = (
+/turf/open/floor/tile/dark/yellow2/corner,
+/area/bigredv2/caves/south)
 "gnu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -19915,6 +20329,19 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/general_store)
+"gok" = (
+/obj/structure/cable,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/tile/blue/taupeblue{
+	dir = 1
+	},
+/area/bigredv2/caves/south)
+"gqM" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor,
+/area/bigredv2/outside/marshal_office)
 "gqX" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -19923,18 +20350,61 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/w)
+"gsZ" = (
+/obj/structure/cable,
+/turf/open/floor/tile/blue/taupeblue{
+	dir = 1
+	},
+/area/bigredv2/caves/south)
 "gva" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/drop2/lz2)
+"gvo" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
+"gwV" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/blue/taupeblue{
+	dir = 1
+	},
+/area/bigredv2/caves/south)
 "gxC" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/southwest)
+"gAT" = (
+/obj/structure/table,
+/obj/item/storage/belt/gun/pistol,
+/turf/open/floor/tile/dark/red2/corner,
+/area/bigredv2/caves/south)
+"gAX" = (
+/obj/structure/cable,
+/turf/open/floor/tile/blue/taupeblue{
+	dir = 8
+	},
+/area/bigredv2/caves/south)
+"gBm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor,
+/area/bigredv2/outside/marshal_office)
 "gBV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"gCH" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	on = 1;
+	welded = 1
+	},
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "gEU" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral/bigred,
@@ -19944,6 +20414,14 @@
 	dir = 1
 	},
 /area/bigredv2/outside/space_port)
+"gLN" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/blue/taupeblue{
+	dir = 4
+	},
+/area/bigredv2/caves/south)
 "gMM" = (
 /obj/structure/cable,
 /turf/open/floor/marking/asteroidwarning{
@@ -19965,6 +20443,11 @@
 /obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"gSk" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/plasteel/medium_stack,
+/turf/open/floor/plating/plating_catwalk,
+/area/bigredv2/caves/northwest)
 "gSH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/corpsespawner/doctor,
@@ -19985,10 +20468,23 @@
 	},
 /turf/open/floor/plating,
 /area/bigredv2/outside/engineering)
+"gXn" = (
+/obj/effect/decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/item/weapon/gun/rifle/m16,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "gYG" = (
 /obj/effect/landmark/weed_node,
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/northeast)
+"gZX" = (
+/turf/open/floor/tile/blue/taupeblue{
+	dir = 1
+	},
+/area/bigredv2/caves/south)
 "hbe" = (
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/floor/asteroidfloor,
@@ -20007,10 +20503,50 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"hgw" = (
+/obj/effect/decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 5
+	},
+/obj/structure/cable,
+/obj/machinery/light,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
+"hgL" = (
+/obj/structure/cable,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/marine_turret/premade{
+	dir = 8
+	},
+/turf/open/floor/tile/blue/taupeblue{
+	dir = 1
+	},
+/area/bigredv2/caves/south)
 "hhh" = (
 /obj/structure/cable,
 /turf/open/floor/asteroidfloor,
 /area/shuttle/drop2/lz2)
+"hia" = (
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	dir = 2;
+	name = "Maintenance Hatch"
+	},
+/turf/open/shuttle/elevator/grating,
+/area/bigredv2/caves/south)
+"hjc" = (
+/obj/effect/landmark/weed_node,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/south)
+"hjE" = (
+/obj/machinery/door/airlock,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "hkk" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -20026,10 +20562,25 @@
 "hsK" = (
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/cargo)
+"huI" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall/unmeltable,
+/area/bigredv2/caves/northwest)
+"hvr" = (
+/obj/structure/rack,
+/obj/item/weapon/gun/rifle/m16,
+/obj/item/ammo_magazine/rifle/m16,
+/obj/item/ammo_magazine/rifle/m16,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "hvV" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/wall,
 /area/bigredv2/outside/cargo)
+"hwc" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "hwL" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -20038,6 +20589,13 @@
 	dir = 4
 	},
 /area/bigredv2/outside/nw)
+"hyP" = (
+/obj/effect/decal/warning_stripes/nscenter,
+/obj/machinery/light/built{
+	dir = 8
+	},
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/northeast)
 "hzx" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral/bigred,
@@ -20061,6 +20619,11 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/north)
+"hDY" = (
+/turf/open/floor/tile/dark/red2/corner{
+	dir = 8
+	},
+/area/bigredv2/caves/south)
 "hEq" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/wall/r_wall,
@@ -20077,11 +20640,11 @@
 /turf/open/floor/plating,
 /area/bigredv2/outside/cargo)
 "hIH" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/shuttle/shuttle_control/dropship,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/table/reinforced,
-/obj/machinery/computer/shuttle/shuttle_control/dropship,
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/space_port)
 "hJM" = (
@@ -20093,6 +20656,12 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/north)
+"hLo" = (
+/obj/structure/cable,
+/turf/open/floor/tile/dark/blue2{
+	dir = 4
+	},
+/area/bigredv2/outside/nanotrasen_lab/inside)
 "hLA" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -20107,10 +20676,30 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/east)
+"hRb" = (
+/obj/structure/cable,
+/turf/open/floor/tile/blue/taupeblue{
+	dir = 4
+	},
+/area/bigredv2/caves/south)
+"hSh" = (
+/obj/machinery/door/airlock,
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "hTy" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/southwest)
+"hTI" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "hUm" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -20123,6 +20712,12 @@
 /obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/general_offices)
+"hVy" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/bigredv2/caves/south)
 "hXl" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -20131,6 +20726,23 @@
 	dir = 6
 	},
 /area/bigredv2/outside/nw)
+"iaU" = (
+/obj/structure/bed/chair/reinforced{
+	dir = 1
+	},
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/north)
+"igD" = (
+/turf/open/shuttle/elevator/grating,
+/area/bigredv2/caves/south)
+"igK" = (
+/obj/machinery/power/apc/weak,
+/turf/open/shuttle/elevator/grating,
+/area/bigredv2/caves/south)
+"ihM" = (
+/obj/effect/landmark/corpsespawner/engineer,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "iiY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
@@ -20138,14 +20750,33 @@
 	},
 /turf/open/floor/wood,
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"ijF" = (
+/obj/effect/decal/cleanable/blood/gibs/core,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/shuttle/elevator/grating,
+/area/bigredv2/caves/south)
 "ilD" = (
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/wood,
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"ipY" = (
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "iug" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/west)
+"iyl" = (
+/obj/structure/cable,
+/obj/machinery/camera/autoname/mainship/dropship_one{
+	dir = 8;
+	pixel_x = 16
+	},
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/north)
 "iyn" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/xeno_resin_door,
@@ -20157,6 +20788,14 @@
 	dir = 9
 	},
 /area/shuttle/drop2/lz2)
+"iAa" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/mecha_wreckage/ripley/lv624,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "iCt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/docking_port/stationary/crashmode,
@@ -20167,11 +20806,26 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/bigredv2/outside/filtration_plant)
+"iFA" = (
+/obj/structure/cable,
+/turf/open/floor/tile/dark/yellow2/corner,
+/area/bigredv2/outside/nanotrasen_lab/inside)
 "iFE" = (
 /obj/structure/cable,
 /obj/machinery/light,
 /turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/space_port)
+"iJf" = (
+/obj/structure/largecrate/supply/weapons/hpr,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
+"iKB" = (
+/turf/closed/wall/r_wall/unmeltable,
+/area/bigredv2/caves/northwest)
+"iKL" = (
+/obj/structure/largecrate/machine,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "iMZ" = (
 /obj/effect/landmark/corpsespawner/engineer,
 /turf/open/floor/tile/red/redtaupecorner,
@@ -20198,11 +20852,13 @@
 	},
 /area/bigredv2/outside/s)
 "iXG" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/asteroidfloor,
-/area/bigredv2/outside/space_port)
+/obj/machinery/vending/medical,
+/turf/open/shuttle/elevator/grating,
+/area/bigredv2/caves/northwest)
+"iYa" = (
+/obj/item/paper,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "jcs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -20225,6 +20881,10 @@
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/east)
+"jkn" = (
+/obj/structure/largecrate/random/barrel/red,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "jlx" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -20233,12 +20893,45 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
 /area/bigredv2/caves/south)
+"jpN" = (
+/obj/structure/largecrate/random/barrel/blue,
+/obj/effect/decal/cleanable/cobweb2,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "jsp" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/nw)
 "jtk" = (
 /turf/open/floor/plating,
+/area/bigredv2/caves/south)
+"juh" = (
+/obj/effect/spawner/gibspawner/human,
+/turf/open/shuttle/elevator/grating,
+/area/bigredv2/caves/south)
+"juu" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/open/shuttle/elevator/grating,
+/area/bigredv2/caves/south)
+"juA" = (
+/obj/machinery/power/monitor,
+/turf/open/floor/plating,
+/area/bigredv2/caves/north)
+"juU" = (
+/obj/effect/decal/cleanable/blood/gibs/body,
+/turf/open/shuttle/elevator/grating,
+/area/bigredv2/caves/south)
+"jwU" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 2
+	},
+/turf/open/floor/tile/dark/yellow2/corner{
+	dir = 8
+	},
+/area/bigredv2/caves/south)
+"jAz" = (
+/obj/effect/decal/cleanable/blood/gibs/xeno,
+/turf/open/shuttle/elevator/grating,
 /area/bigredv2/caves/south)
 "jAB" = (
 /obj/effect/landmark/weed_node,
@@ -20257,16 +20950,55 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/bigredv2/outside/sw)
+"jFi" = (
+/obj/item/analyzer/plant_analyzer,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
+"jFz" = (
+/obj/effect/decal/warning_stripes/nscenter,
+/obj/machinery/light/built{
+	dir = 1
+	},
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/northeast)
+"jGP" = (
+/obj/structure/largecrate/supply/weapons/sentries,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "jKb" = (
 /obj/structure/sign/safety/blast_door,
+/obj/structure/cable,
 /turf/open/floor/tile/dark/purple2/corner{
 	dir = 4
 	},
 /area/bigredv2/caves/lambda_lab)
+"jKd" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/tile/blue/taupeblue{
+	dir = 8
+	},
+/area/bigredv2/caves/south)
+"jKs" = (
+/obj/effect/spawner/gibspawner/human,
+/turf/open/floor/tile/dark/red2/corner,
+/area/bigredv2/caves/south)
 "jLQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/space_port)
+"jMk" = (
+/obj/machinery/camera/autoname/mainship/dropship_one{
+	dir = 8;
+	pixel_x = 16
+	},
+/obj/structure/largecrate/random/barrel/blue,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "jMC" = (
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/west)
@@ -20292,6 +21024,11 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/general_offices)
+"jSE" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/structure/cable,
+/turf/open/floor/tile/dark/yellow2/corner,
+/area/bigredv2/caves/south)
 "jTB" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -20299,6 +21036,13 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/general_offices)
+"jTD" = (
+/turf/open/floor/plating,
+/area/bigredv2/caves/north)
+"jUU" = (
+/obj/machinery/miner/damaged/platinum,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/north)
 "jWg" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -20307,6 +21051,15 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/south)
+"jYS" = (
+/obj/machinery/light/built{
+	dir = 1
+	},
+/obj/structure/rack,
+/obj/item/storage/box/explosive_mines,
+/obj/structure/cable,
+/turf/open/shuttle/elevator/grating,
+/area/bigredv2/caves/northwest)
 "jZz" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 5
@@ -20321,6 +21074,11 @@
 	dir = 10
 	},
 /area/shuttle/drop2/lz2)
+"jZH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/bigredv2/outside/nanotrasen_lab/inside)
 "jZM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
@@ -20332,10 +21090,27 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/mineral/bigred,
 /area/bigredv2/outside/sw)
+"kbu" = (
+/obj/structure/cable,
+/turf/open/shuttle/elevator/grating,
+/area/bigredv2/caves/south)
 "kel" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"keE" = (
+/obj/structure/cable,
+/turf/open/floor/tile/dark/red2{
+	dir = 10
+	},
+/area/bigredv2/outside/nanotrasen_lab/inside)
+"kgP" = (
+/obj/effect/landmark/weed_node,
+/obj/structure/cable,
+/turf/open/floor/tile/dark/yellow2/corner{
+	dir = 1
+	},
+/area/bigredv2/outside/nanotrasen_lab/inside)
 "khf" = (
 /obj/structure/table,
 /obj/item/tool/pen/red,
@@ -20356,6 +21131,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/bigredv2/caves/lambda_lab)
+"kpD" = (
+/obj/item/paper/janitor,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "kpV" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
@@ -20366,6 +21145,10 @@
 	},
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/northwest)
+"kvz" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/space)
 "kvX" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -20375,6 +21158,11 @@
 	dir = 4
 	},
 /area/bigredv2/outside/virology)
+"kzI" = (
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/obj/structure/cable,
+/turf/open/shuttle/elevator/grating,
+/area/bigredv2/caves/south)
 "kAp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -20389,11 +21177,23 @@
 /obj/structure/largecrate/random,
 /turf/open/floor/marking/bot,
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"kGJ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/south)
+"kHY" = (
+/obj/structure/ship_ammo/rocket/napalm,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "kIY" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 1
 	},
 /area/bigredv2/caves/east)
+"kJi" = (
+/obj/machinery/door/airlock/mainship/maint/free_access,
+/turf/open/floor/plating,
+/area/bigredv2/caves/north)
 "kJK" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 10
@@ -20412,6 +21212,9 @@
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/east)
+"kOh" = (
+/turf/closed/wall/indestructible/mineral,
+/area/bigredv2/caves/southeast)
 "kOq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/lightreplacer,
@@ -20433,10 +21236,36 @@
 	},
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/medical)
+"kXR" = (
+/obj/structure/ship_ammo/rocket/widowmaker,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
+"ldk" = (
+/obj/structure/cable,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/north)
+"ldl" = (
+/obj/structure/cable,
+/turf/open/floor/tile/dark/purple2/corner{
+	dir = 4
+	},
+/area/bigredv2/caves/lambda_lab)
 "len" = (
 /obj/item/stack/sheet/metal,
 /turf/open/floor/plating/dmg1,
 /area/bigredv2/outside/space_port)
+"lgf" = (
+/obj/structure/closet/crate/secure/gear,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
+"lgt" = (
+/obj/structure/largecrate/supply/supplies/sandbags,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
+"lgV" = (
+/obj/structure/grille/broken,
+/turf/open/floor/mainship/empty,
+/area/bigredv2/caves/south)
 "lhy" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -20461,6 +21290,12 @@
 /obj/effect/landmark/corpsespawner/engineer,
 /turf/open/floor/plating,
 /area/bigredv2/outside/engineering)
+"lmC" = (
+/obj/machinery/light,
+/obj/structure/largecrate/supply/supplies/mre,
+/obj/structure/cable,
+/turf/open/shuttle/elevator/grating,
+/area/bigredv2/caves/northwest)
 "loj" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/engine/cult,
@@ -20473,10 +21308,41 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/southeast)
+"lpn" = (
+/obj/machinery/light,
+/turf/open/shuttle/elevator/grating,
+/area/bigredv2/caves/south)
+"lqu" = (
+/obj/structure/cable,
+/obj/machinery/door/poddoor/four_tile_ver{
+	id = "Containmenthangar";
+	name = "Underground Hangar"
+	},
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
+"lqJ" = (
+/obj/machinery/camera{
+	dir = 5
+	},
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/south)
+"lrg" = (
+/obj/structure/ship_ammo/rocket/fatty,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
+"lsj" = (
+/obj/structure/closet/l3closet/virology,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab)
 "ltt" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/carpet,
 /area/bigredv2/caves/lambda_lab)
+"luM" = (
+/obj/structure/cable,
+/obj/structure/dropship_equipment/weapon/rocket_pod,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "lvJ" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
@@ -20504,17 +21370,36 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/general_store)
+"lAi" = (
+/obj/structure/ship_ammo/rocket/banshee,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "lAq" = (
 /obj/structure/sign/safety/maintenance{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/bigredv2/caves/lambda_lab)
+"lBJ" = (
+/obj/effect/decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/structure/barricade/metal{
+	dir = 8
+	},
+/obj/item/ammo_magazine/rifle/m16,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "lCt" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 9
 	},
 /area/shuttle/drop2/lz2)
+"lFK" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/south)
 "lFT" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -20522,6 +21407,10 @@
 	dir = 8
 	},
 /area/bigredv2/outside/chapel)
+"lHD" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "lHZ" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -20530,6 +21419,9 @@
 /obj/structure/sign/prop1,
 /turf/open/floor,
 /area/bigredv2/outside/office_complex)
+"lKZ" = (
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/north)
 "lLO" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark/purple2{
@@ -20548,6 +21440,14 @@
 	},
 /turf/open/floor/tile/blue/whitebluefull,
 /area/bigredv2/outside/general_store)
+"lNk" = (
+/obj/structure/largecrate/supply/supplies/flares,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/southeast)
+"lPS" = (
+/obj/structure/largecrate/random/barrel/green,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/southeast)
 "lPV" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -20556,6 +21456,17 @@
 	dir = 10
 	},
 /area/bigredv2/outside/nw)
+"lQx" = (
+/obj/machinery/door/airlock/mainship/security/glass/free_access{
+	dir = 2
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2;
+	id = "Secure_1"
+	},
+/obj/structure/cable,
+/turf/open/shuttle/elevator/grating,
+/area/bigredv2/caves/north)
 "lVv" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -20566,6 +21477,21 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/bigredv2/outside/c)
+"lYg" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/tile/dark/yellow2/corner{
+	dir = 1
+	},
+/area/bigredv2/outside/nanotrasen_lab/inside)
+"lZp" = (
+/obj/structure/cable,
+/obj/machinery/light,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/southeast)
 "mbT" = (
 /obj/item/trash/sosjerky,
 /turf/open/floor/plating,
@@ -20593,6 +21519,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/east)
+"mrL" = (
+/obj/structure/largecrate/supply/supplies/metal,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/southeast)
 "msI" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -20600,21 +21530,57 @@
 /obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"mwK" = (
+/obj/structure/largecrate/supply/supplies/plasteel,
+/obj/effect/decal/cleanable/cobweb2,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/southeast)
 "mxH" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/landmark/corpsespawner/security,
 /turf/open/floor/carpet,
 /area/bigredv2/outside/library)
+"mxP" = (
+/obj/structure/largecrate/random/barrel/blue,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
+"myA" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/effect/decal/cleanable/blood/gibs/xeno,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	on = 1;
+	welded = 1
+	},
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "mAi" = (
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/northwest)
 "mAw" = (
 /turf/open/floor/asteroidfloor,
 /area/shuttle/drop2/lz2)
+"mDZ" = (
+/obj/machinery/camera/autoname/mainship/dropship_one{
+	dir = 4;
+	pixel_x = -16
+	},
+/turf/closed/wall/r_wall/unmeltable,
+/area/space)
 "mEk" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/sw)
+"mEo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 2
+	},
+/turf/open/floor/tile/dark/yellow2/corner,
+/area/bigredv2/caves/south)
 "mEZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -20623,6 +21589,10 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
+"mFd" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall/unmeltable,
+/area/space)
 "mGy" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/xeno_resin_wall,
@@ -20652,6 +21622,18 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/northwest)
+"mPE" = (
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/southeast)
+"mQb" = (
+/obj/structure/rack,
+/obj/item/ammo_magazine/shotgun/incendiary,
+/obj/item/ammo_magazine/shotgun/incendiary,
+/obj/item/ammo_magazine/shotgun/incendiary,
+/obj/item/ammo_magazine/shotgun/incendiary,
+/obj/item/ammo_magazine/shotgun/incendiary,
+/turf/open/shuttle/elevator/grating,
+/area/bigredv2/caves/northwest)
 "mSv" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -20665,17 +21647,40 @@
 	dir = 10
 	},
 /area/bigredv2/outside/sw)
+"mYm" = (
+/obj/machinery/light,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab)
+"nag" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/metal/large_stack,
+/obj/structure/cable,
+/turf/open/shuttle/elevator/grating,
+/area/bigredv2/caves/northwest)
 "nbV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	on = 1
 	},
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
+"ncd" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/southeast)
 "ndz" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/general_offices)
+"nhk" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/unmeltable,
+/area/bigredv2/caves/south)
+"nmh" = (
+/obj/structure/ore_box,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab)
 "nrI" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
@@ -20687,6 +21692,20 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
 /area/bigredv2/caves/north)
+"ntG" = (
+/obj/structure/cargo_container{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/bigredv2/outside/space_port)
+"nuE" = (
+/obj/effect/decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "nvs" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -20705,6 +21724,14 @@
 /obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"nvX" = (
+/obj/structure/cable,
+/obj/structure/table,
+/obj/machinery/computer/security,
+/turf/open/floor/tile/dark/red2/corner{
+	dir = 8
+	},
+/area/bigredv2/caves/south)
 "nyf" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating,
@@ -20721,6 +21748,20 @@
 /obj/effect/landmark/corpsespawner/doctor,
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/medical)
+"nAH" = (
+/obj/effect/landmark/weed_node,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab)
+"nBy" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
+"nCe" = (
+/obj/structure/bookcase/manuals/research_and_development,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/bigredv2/outside/nanotrasen_lab/inside)
 "nFd" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -20733,17 +21774,35 @@
 	},
 /turf/open/floor/tile/darkish,
 /area/bigredv2/caves/lambda_lab)
+"nFJ" = (
+/obj/structure/cable,
+/turf/open/floor/mainship/cargo/arrow,
+/area/bigredv2/caves/lambda_lab)
 "nIZ" = (
 /obj/structure/prop/mainship/hangar_stencil/two,
 /turf/open/floor/marking/asteroidwarning{
 	dir = 10
 	},
 /area/shuttle/drop2/lz2)
+"nJq" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark/red2/corner{
+	dir = 8
+	},
+/area/bigredv2/caves/south)
 "nJs" = (
 /obj/structure/table,
 /obj/item/alienjar,
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/virology)
+"nLh" = (
+/turf/closed/wall/r_wall,
+/area/bigredv2/caves/north)
+"nMb" = (
+/obj/effect/decal/cleanable/blood/gibs/xeno/body,
+/obj/structure/cable,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "nOk" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor,
@@ -20755,6 +21814,24 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/northwest)
+"nPl" = (
+/obj/item/paper/clockresearch1,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
+"nQE" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 5
+	},
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
+"nQS" = (
+/obj/effect/decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood/gibs/xeno/limb,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "nRT" = (
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/west)
@@ -20766,6 +21843,10 @@
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
+"nVP" = (
+/obj/item/tool/pickaxe,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "oaD" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 8
@@ -20774,6 +21855,17 @@
 "ocv" = (
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/shuttle/drop2/lz2)
+"ofL" = (
+/obj/structure/closet/crate/trashcart,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/north)
+"oiH" = (
+/obj/effect/decal/warning_stripes/thick,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "ojx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -20806,6 +21898,12 @@
 	},
 /turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/virology)
+"osi" = (
+/obj/structure/rack,
+/obj/item/explosive/grenade/drainbomb,
+/obj/item/explosive/grenade/drainbomb,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "oto" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -20839,6 +21937,15 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating,
 /area/bigredv2/outside/engineering)
+"oAE" = (
+/obj/machinery/camera{
+	dir = 9
+	},
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/south)
+"oCk" = (
+/turf/closed/wall/r_wall,
+/area/space)
 "oCl" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -20897,6 +22004,10 @@
 "oPP" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/caves/southwest)
+"oTw" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/bigredv2/caves/lambda_lab)
 "oTU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
@@ -20904,12 +22015,31 @@
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"oVQ" = (
+/obj/effect/decal/warning_stripes/thick,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/item/weapon/gun/shotgun/pump/cmb,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "oWn" = (
 /turf/open/floor/tile/green/whitegreenfull,
 /area/bigredv2/caves/lambda_lab)
 "oXG" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/shuttle/drop2/lz2)
+"oZb" = (
+/obj/effect/decal/warning_stripes/thick,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "pbv" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/machinery/door/poddoor/shutters/mainship{
@@ -20932,6 +22062,12 @@
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/southwest)
+"pcY" = (
+/obj/structure/closet/secure_closet/security,
+/turf/open/floor/tile/dark/red2/corner{
+	dir = 8
+	},
+/area/bigredv2/caves/south)
 "pdW" = (
 /obj/machinery/floodlight/landing,
 /turf/open/floor/marking/asteroidwarning{
@@ -20943,12 +22079,29 @@
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/lambda_lab)
+"pgV" = (
+/obj/effect/decal/warning_stripes/thick,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "pjz" = (
 /obj/structure/cable,
 /turf/open/floor/marking/asteroidwarning{
 	dir = 5
 	},
 /area/shuttle/drop2/lz2)
+"pkI" = (
+/obj/effect/decal/warning_stripes/thick,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/item/limb/r_foot,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "pmf" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/landmark/corpsespawner/security,
@@ -20968,6 +22121,23 @@
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/s)
+"pst" = (
+/obj/effect/decal/warning_stripes/thick,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/item/weapon/gun/rifle/famas,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
+"psH" = (
+/obj/structure/rack,
+/obj/item/storage/belt/gun/revolver,
+/obj/item/storage/belt/gun/pistol/m4a3/officer,
+/turf/open/floor/tile/dark/red2/corner{
+	dir = 8
+	},
+/area/bigredv2/caves/south)
 "ptp" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral/bigred,
@@ -20988,10 +22158,62 @@
 	},
 /turf/open/floor/plating,
 /area/bigredv2/outside/dorms)
+"pzX" = (
+/obj/structure/largecrate,
+/obj/structure/cable,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/north)
+"pAs" = (
+/obj/effect/decal/warning_stripes/thick,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/barricade/metal{
+	dir = 8
+	},
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
+"pEd" = (
+/obj/effect/decal/warning_stripes/thick,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/item/weapon/gun/rifle/m16,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
+"pEh" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/wall/r_wall,
+/area/bigredv2/caves/south)
+"pFP" = (
+/obj/structure/rack,
+/obj/item/weapon/gun/launcher/rocket/m57a4/t57,
+/obj/item/ammo_magazine/rocket/m57a4,
+/turf/open/floor/plating/plating_catwalk,
+/area/bigredv2/caves/northwest)
+"pHZ" = (
+/obj/effect/decal/warning_stripes/thick,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "pJO" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/southeast)
+"pNt" = (
+/obj/machinery/camera/autoname/mainship/dropship_one{
+	dir = 8;
+	pixel_x = 16
+	},
+/obj/structure/cable,
+/turf/closed/wall/r_wall/unmeltable,
+/area/space)
 "pOZ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/mineral/bigred,
@@ -21024,6 +22246,31 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/south)
+"pVl" = (
+/obj/effect/decal/warning_stripes/thick,
+/obj/effect/decal/warning_stripes/thick{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
+"pVB" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/south)
+"pXc" = (
+/obj/structure/cable,
+/obj/structure/window/framed/mainship/gray/toughened/hull{
+	name = "Secure window"
+	},
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/northwest)
 "pYU" = (
 /obj/machinery/floodlight/landing,
 /turf/open/floor/marking/asteroidwarning{
@@ -21036,12 +22283,38 @@
 	},
 /turf/open/floor/wood,
 /area/bigredv2/outside/library)
+"qbd" = (
+/obj/machinery/camera/autoname/mainship/dropship_one{
+	dir = 4;
+	pixel_x = -16
+	},
+/obj/structure/cable,
+/turf/closed/wall/r_wall/unmeltable,
+/area/bigredv2/caves/south)
+"qbh" = (
+/obj/machinery/atmospherics/pipe/manifold/green/hidden,
+/obj/structure/cable,
+/obj/effect/landmark/corpsespawner/commander,
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/south)
 "qcp" = (
 /obj/structure/cable,
 /turf/open/floor/tile/chapel{
 	dir = 1
 	},
 /area/bigredv2/outside/chapel)
+"qcC" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/item/ammo_casing/shell,
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/south)
+"qdE" = (
+/obj/item/analyzer,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "qeE" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -21058,6 +22331,20 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
+"qfQ" = (
+/obj/effect/decal/warning_stripes/thick{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/barricade/metal{
+	dir = 8
+	},
+/obj/item/ammo_casing/shell,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "qgg" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -21065,6 +22352,26 @@
 /obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/general_offices)
+"qgz" = (
+/obj/effect/decal/warning_stripes/thick,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/landmark/corpsespawner/security,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
+"qnf" = (
+/obj/effect/decal/warning_stripes/thick,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 10
+	},
+/obj/structure/cable,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "qnu" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/darkgreen/darkgreen2/corner,
@@ -21090,6 +22397,18 @@
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/medical)
+"quA" = (
+/obj/effect/decal/warning_stripes/thick{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood/writing,
+/obj/machinery/power/apc/high,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
+"quI" = (
+/turf/closed/wall/r_wall/unmeltable,
+/area/bigredv2/outside/telecomm)
 "qvi" = (
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/tile/white,
@@ -21121,6 +22440,14 @@
 	dir = 8
 	},
 /area/bigredv2/outside/w)
+"qBa" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/tile/dark/yellow2/corner,
+/area/bigredv2/outside/nanotrasen_lab/inside)
 "qBd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/marking/asteroidwarning{
@@ -21130,6 +22457,10 @@
 "qDI" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/south)
+"qDZ" = (
+/obj/effect/landmark/corpsespawner/security,
+/turf/open/floor/tile/dark2,
 /area/bigredv2/caves/south)
 "qEg" = (
 /obj/structure/sign/safety/high_radiation,
@@ -21145,6 +22476,10 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating,
 /area/bigredv2/outside/engineering)
+"qGO" = (
+/obj/structure/cable,
+/turf/closed/wall,
+/area/bigredv2/outside/nanotrasen_lab/inside)
 "qHT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -21159,14 +22494,42 @@
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"qIK" = (
+/obj/machinery/door/airlock/mainship/security/glass{
+	dir = 2
+	},
+/turf/open/floor/tile/dark/yellow2/corner,
+/area/bigredv2/outside/nanotrasen_lab/inside)
 "qIY" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/northeast)
+"qJF" = (
+/obj/effect/decal/warning_stripes/thick{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8;
+	welded = 1
+	},
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "qKE" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/se)
+"qMi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor,
+/area/bigredv2/outside/marshal_office)
+"qOl" = (
+/obj/structure/cable,
+/turf/closed/wall/indestructible/mineral,
+/area/space)
 "qPG" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -21179,6 +22542,18 @@
 	dir = 4
 	},
 /area/bigredv2/caves/lambda_lab)
+"qQh" = (
+/obj/structure/ladder{
+	height = 2;
+	id = "Lambdashaft"
+	},
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab)
+"qRh" = (
+/turf/open/floor/tile/dark/yellow2/corner{
+	dir = 8
+	},
+/area/bigredv2/caves/south)
 "qRs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/corpsespawner/chef,
@@ -21200,10 +22575,20 @@
 "qVr" = (
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/north)
+"qXP" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/structure/cable,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "qYD" = (
 /obj/structure/cable,
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/nw)
+"qYM" = (
+/obj/effect/landmark/weed_node,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/bigredv2/outside/nanotrasen_lab/inside)
 "qZn" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 1
@@ -21217,20 +22602,41 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/general_offices)
+"raF" = (
+/turf/open/floor/asteroidfloor,
+/area/space)
 "rdd" = (
 /obj/structure/table,
 /obj/item/trash/tray,
 /turf/open/floor/tile/yellow/full,
 /area/bigredv2/outside/hydroponics)
+"rde" = (
+/obj/effect/landmark/corpsespawner/commander,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
+"rdw" = (
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/south)
 "rfg" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
+"rhf" = (
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/south)
+"riu" = (
+/obj/effect/decal/cleanable/blood/gibs/xeno/limb,
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/south)
 "riz" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 8
 	},
 /area/bigredv2/outside/virology)
+"rjr" = (
+/obj/item/paper/prison_station/warden_note,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "rkk" = (
 /obj/machinery/light,
 /turf/open/floor/plating,
@@ -21239,11 +22645,21 @@
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/tile/dark/yellow2/corner,
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"rpq" = (
+/obj/effect/landmark/corpsespawner/security,
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "rpV" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/northeast)
+"rqU" = (
+/obj/effect/landmark/corpsespawner/scientist,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "rvh" = (
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/lambda_lab)
@@ -21270,12 +22686,34 @@
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/general_offices)
+"rAe" = (
+/obj/item/ammo_casing/bullet,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "rBN" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/bigredv2/outside/nw)
+"rJv" = (
+/obj/machinery/door/airlock/multi_tile/mainship/medidoor{
+	name = "\improper Lambda Lab"
+	},
+/turf/open/floor/tile/dark/purple2/corner{
+	dir = 1
+	},
+/area/bigredv2/caves/lambda_lab)
+"rJW" = (
+/turf/open/floor/asteroidfloor,
+/area/bigredv2/caves/northwest)
+"rKr" = (
+/obj/structure/barricade/metal{
+	dir = 8
+	},
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "rLF" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -21308,6 +22746,12 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/east)
+"rPj" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/asteroidfloor,
+/area/bigredv2/caves/northwest)
 "rQB" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -21320,10 +22764,27 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/west)
+"rVZ" = (
+/turf/open/shuttle/escapepod/five,
+/area/bigredv2/caves/lambda_lab)
+"rWh" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/unmeltable,
+/area/bigredv2/caves/south)
+"rYD" = (
+/obj/effect/decal/cleanable/blood/gibs/xeno,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/south)
 "rZP" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/southeast)
+"sbj" = (
+/obj/effect/decal/warning_stripes/nscenter,
+/obj/effect/landmark/weed_node,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/northeast)
 "sbU" = (
 /obj/machinery/light{
 	dir = 4
@@ -21331,16 +22792,47 @@
 /obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"scd" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/blue/taupeblue{
+	dir = 1
+	},
+/area/bigredv2/caves/south)
 "sfy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor,
 /area/bigredv2/outside/general_offices)
+"shI" = (
+/obj/item/ammo_casing/bullet{
+	icon_state = "casing_10";
+	pixel_x = 29;
+	pixel_y = 9
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/south)
 "skG" = (
 /obj/machinery/computer/shuttle/shuttle_control/dropship,
 /obj/structure/table,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/console)
+"slo" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating,
+/area/bigredv2/caves/north)
+"slM" = (
+/obj/structure/cable,
+/turf/closed/mineral/bigred,
+/area/bigredv2/caves/north)
+"smb" = (
+/obj/effect/decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/item/limb/head,
+/obj/machinery/light,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "soj" = (
 /obj/machinery/power/apc/drained{
 	dir = 8
@@ -21354,11 +22846,30 @@
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor/wood,
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"syY" = (
+/obj/structure/window/framed/mainship/gray/toughened/hull{
+	name = "Secure window"
+	},
+/turf/open/floor/tile/dark,
+/area/bigredv2/outside/space_port)
+"sAq" = (
+/obj/structure/cable,
+/turf/closed/mineral/bigred,
+/area/bigredv2/caves/northeast)
+"sBJ" = (
+/obj/effect/decal/cleanable/blood/gibs/xeno,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "sBV" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 1
 	},
 /area/bigredv2/outside/w)
+"sCz" = (
+/obj/item/limb/r_foot,
+/obj/item/ammo_casing/shell,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "sEN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -21379,9 +22890,39 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/general_offices)
+"sIU" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/bigredv2/caves/south)
+"sLI" = (
+/obj/item/ammo_casing/shell,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/south)
 "sQi" = (
 /obj/effect/landmark/xeno_turret_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/south)
+"sRQ" = (
+/obj/structure/cable,
+/obj/structure/bed/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark/red2/corner{
+	dir = 8
+	},
+/area/bigredv2/caves/south)
+"sRT" = (
+/obj/structure/cable,
+/turf/open/floor/tile/dark/red2,
+/area/bigredv2/outside/nanotrasen_lab/inside)
+"sTd" = (
+/turf/closed/wall/indestructible/mineral,
+/area/bigredv2/caves/south)
+"sTE" = (
+/obj/item/ammo_casing/shell,
+/obj/item/weapon/gun/shotgun/pump/cmb,
+/turf/open/floor/mainship/sterile/dark,
 /area/bigredv2/caves/south)
 "sUd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -21390,10 +22931,23 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
+"sVq" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/south)
+"sWk" = (
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "sWC" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/s)
+"sYG" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/bigredv2/caves/northeast)
 "sZi" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor,
@@ -21409,6 +22963,21 @@
 "tco" = (
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/s)
+"tfr" = (
+/obj/effect/decal/cleanable/blood/gibs/body,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
+"tfF" = (
+/turf/open/shuttle/elevator/grating,
+/area/bigredv2/caves/northwest)
+"tjb" = (
+/turf/open/floor/tile/damaged/five,
+/area/bigredv2/caves/south)
+"tjQ" = (
+/obj/effect/landmark/corpsespawner/security,
+/obj/effect/decal/cleanable/blood/gibs/up,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "tku" = (
 /turf/closed/wall/indestructible/mineral,
 /area/storage/testroom)
@@ -21493,9 +23062,37 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/grimy,
 /area/bigredv2/outside/dorms)
+"tyD" = (
+/obj/effect/landmark/corpsespawner/scientist,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/south)
 "tzo" = (
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/east)
+"tzW" = (
+/obj/structure/ladder{
+	height = 1;
+	id = "Lambdashaft"
+	},
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/south)
+"tAB" = (
+/obj/item/ammo_casing/shell,
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/south)
+"tCQ" = (
+/obj/structure/barricade/metal{
+	dir = 8
+	},
+/obj/item/ammo_casing/shell,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/south)
+"tDh" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "tDX" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 6
@@ -21506,6 +23103,10 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/southeast)
+"tHW" = (
+/obj/effect/decal/cleanable/blood/gibs/xeno/limb,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "tJA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -21517,10 +23118,19 @@
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/tile/white,
 /area/bigredv2/caves/lambda_lab)
+"tLL" = (
+/obj/effect/decal/cleanable/blood/gibs/xeno/limb,
+/obj/item/ammo_casing/shell,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "tNb" = (
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/plating,
 /area/bigredv2/caves/lambda_lab)
+"tUS" = (
+/obj/machinery/door/airlock/mainship/security/glass/free_access,
+/turf/open/floor,
+/area/bigredv2/outside/marshal_office)
 "tVO" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -21528,17 +23138,46 @@
 /obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/general_offices)
+"tXf" = (
+/obj/effect/decal/warning_stripes/thick,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/item/ammo_casing/bullet,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "tZR" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/southeast)
+"uad" = (
+/obj/effect/decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "uan" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/marking/asteroidwarning{
 	dir = 4
 	},
 /area/bigredv2/outside/c)
+"ucI" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/item/ammo_casing/shell,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
+"udd" = (
+/obj/machinery/power/apc/drained{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/bigredv2/caves/north)
 "udw" = (
 /obj/structure/fence,
 /obj/effect/landmark/lv624/fog_blocker,
@@ -21589,6 +23228,16 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/southwest)
+"umd" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/machinery/door/poddoor/mainship{
+	dir = 2;
+	id = "sci_br";
+	name = "\improper Lambda Observation Shutters"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/bigredv2/caves/lambda_lab)
 "ume" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -21601,17 +23250,36 @@
 /obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
+"unB" = (
+/obj/machinery/light,
+/turf/open/floor/tile/dark/red2/corner,
+/area/bigredv2/caves/south)
+"upn" = (
+/obj/effect/decal/warning_stripes/thick{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "uqm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/corpsespawner/doctor,
 /turf/open/floor/tile/green/whitegreencorner,
 /area/bigredv2/outside/medical)
+"uqs" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "utl" = (
 /obj/machinery/floodlight/landing,
 /turf/open/floor/marking/asteroidwarning{
 	dir = 5
 	},
 /area/shuttle/drop2/lz2)
+"utr" = (
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "utH" = (
 /obj/structure/table,
 /obj/effect/spawner/random/technology_scanner,
@@ -21624,13 +23292,26 @@
 	dir = 1
 	},
 /area/bigredv2/outside/nw)
+"uwD" = (
+/obj/effect/landmark/corpsespawner/engineer,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/south)
 "uxP" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/se)
+"uyC" = (
+/obj/effect/decal/cleanable/blood/gibs/xeno,
+/obj/structure/cable,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "uyQ" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/south)
+"uCk" = (
+/obj/effect/spawner/gibspawner/human,
+/turf/open/floor/tile/dark2,
 /area/bigredv2/caves/south)
 "uHG" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
@@ -21651,10 +23332,19 @@
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
 /area/bigredv2/outside/cargo)
+"uKa" = (
+/obj/item/ammo_casing/shell,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/south)
 "uLz" = (
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/north)
+"uLC" = (
+/obj/item/ammo_casing/shell,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "uLR" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -21689,11 +23379,33 @@
 /obj/structure/sign/safety/hazard,
 /turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/space_port)
+"vbQ" = (
+/obj/item/limb/l_arm,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "veE" = (
 /obj/structure/table,
 /obj/effect/spawner/random/toolbox,
 /turf/open/floor,
 /area/bigredv2/outside/dorms)
+"vgq" = (
+/obj/structure/cable,
+/turf/open/shuttle/elevator/grating,
+/area/bigredv2/caves/northwest)
+"vlA" = (
+/obj/effect/landmark/corpsespawner/security,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
+"vlT" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall,
+/area/bigredv2/caves/south)
+"voK" = (
+/obj/structure/barricade/metal{
+	dir = 8
+	},
+/turf/open/floor/tile/damaged/five,
+/area/bigredv2/caves/south)
 "vpv" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -21706,10 +23418,25 @@
 	dir = 4
 	},
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"vry" = (
+/obj/machinery/light,
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/south)
 "vsq" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/c)
+"vtS" = (
+/obj/machinery/camera/autoname/mainship/dropship_one{
+	dir = 8;
+	pixel_x = 16
+	},
+/turf/closed/wall/r_wall/unmeltable,
+/area/space)
+"vuE" = (
+/obj/effect/spawner/gibspawner/human,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/south)
 "vvM" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -21719,10 +23446,31 @@
 "vwf" = (
 /turf/closed/mineral/bigred,
 /area/bigredv2/outside/space_port)
+"vwP" = (
+/obj/structure/cable,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	id = "Secure_1"
+	},
+/turf/open/floor/tile/dark,
+/area/bigredv2/outside/space_port)
+"vxE" = (
+/obj/item/limb/l_hand,
+/obj/item/ammo_casing/bullet{
+	icon_state = "casing_10";
+	pixel_x = 29;
+	pixel_y = 9
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/south)
 "vyZ" = (
 /obj/effect/landmark/xeno_turret_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/northeast)
+"vzg" = (
+/obj/effect/decal/cleanable/blood/gibs/xeno/limb,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/south)
 "vAP" = (
 /obj/docking_port/stationary/crashmode,
 /obj/structure/cable,
@@ -21743,12 +23491,30 @@
 "vDI" = (
 /turf/closed/mineral/bigred,
 /area/bigredv2/outside/w)
+"vFE" = (
+/obj/item/ammo_casing/shell,
+/obj/item/weapon/gun/rifle/famas,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/south)
 "vIl" = (
 /obj/structure/sign/poster{
 	dir = 1
 	},
 /turf/open/floor/wood,
 /area/bigredv2/caves/lambda_lab)
+"vJk" = (
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
+	},
+/area/bigredv2/caves/northeast)
+"vKc" = (
+/obj/structure/ladder{
+	height = 1;
+	id = "ladder1"
+	},
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/north)
 "vKO" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral/bigred,
@@ -21764,6 +23530,22 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/east)
+"vQS" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
+"vRM" = (
+/obj/effect/decal/warning_stripes/nscenter,
+/obj/machinery/light/built{
+	dir = 4
+	},
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/northeast)
+"vST" = (
+/turf/open/shuttle/escapepod,
+/area/bigredv2/caves/lambda_lab)
 "vTU" = (
 /obj/effect/landmark/weed_node,
 /turf/open/ground/jungle/clear,
@@ -21785,11 +23567,47 @@
 	},
 /turf/open/floor/wood,
 /area/bigredv2/outside/library)
+"vWE" = (
+/turf/closed/mineral/bigred,
+/area/space)
+"vWM" = (
+/obj/item/ammo_casing/shell,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "vXv" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 4
 	},
 /area/shuttle/drop2/lz2)
+"vYr" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/item/ammo_casing/shell,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
+"wbU" = (
+/obj/effect/decal/cleanable/blood/gibs/xeno/body,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/south)
+"wdk" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/structure/cable,
+/turf/closed/mineral/bigred,
+/area/bigredv2/caves/south)
+"wdL" = (
+/obj/item/storage/box/sentry,
+/turf/open/floor/plating/plating_catwalk,
+/area/bigredv2/caves/northwest)
+"weF" = (
+/obj/effect/decal/cleanable/blood/xeno,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
+"wff" = (
+/obj/effect/decal/cleanable/blood/tracks/footprints,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "wfD" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/darkish,
@@ -21816,6 +23634,23 @@
 	dir = 1
 	},
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"wnO" = (
+/obj/item/limb/l_hand,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/south)
+"wpF" = (
+/obj/item/limb/l_arm,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/south)
+"wpO" = (
+/obj/effect/decal/cleanable/blood/tracks/footprints,
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/south)
+"wrk" = (
+/obj/effect/landmark/corpsespawner/scientist,
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/south)
 "wsS" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -21836,18 +23671,32 @@
 	dir = 1
 	},
 /area/bigredv2/outside/c)
+"wBY" = (
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/tile/damaged/four,
+/area/bigredv2/caves/south)
 "wCi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
+"wFw" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/structure/cable,
+/turf/closed/mineral/bigred,
+/area/bigredv2/caves/northeast)
 "wFG" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
 	},
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/virology)
+"wKg" = (
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "wQg" = (
 /obj/structure/cable,
 /obj/machinery/light,
@@ -21860,17 +23709,42 @@
 	},
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/space_port)
+"wSe" = (
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/north)
+"wSP" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/bigredv2/caves/northeast)
 "wUc" = (
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 1
 	},
 /area/bigredv2/caves/southwest)
+"wVJ" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/bigredv2/outside/nanotrasen_lab/inside)
+"wYu" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/south)
 "wZg" = (
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/bigredv2/outside/sw)
 "wZZ" = (
 /turf/open/floor/plating,
 /area/bigredv2/caves/west)
+"xaU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/bigredv2/caves/north)
 "xbs" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -21889,6 +23763,23 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/freezer,
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"xiw" = (
+/obj/machinery/door_control{
+	active_power_usage = 0;
+	id = "Containmenthangar";
+	idle_power_usage = 0;
+	name = "Underground Hangar";
+	pixel_x = 1;
+	pixel_y = 25
+	},
+/obj/structure/cable,
+/turf/open/shuttle/elevator/grating,
+/area/bigredv2/caves/south)
+"xiz" = (
+/obj/effect/landmark/corpsespawner/security,
+/obj/item/ammo_casing/bullet,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "xiT" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor,
@@ -21902,15 +23793,46 @@
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/c)
+"xjA" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
+"xlj" = (
+/obj/effect/decal/warning_stripes/thick{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/camera/autoname/mainship/dropship_one{
+	dir = 8;
+	pixel_x = 16
+	},
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "xnf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/tool,
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
+"xni" = (
+/obj/machinery/miner/damaged/platinum,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "xnD" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/wall,
 /area/bigredv2/outside/dorms)
+"xnF" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall/unmeltable,
+/area/bigredv2/outside/telecomm)
+"xpu" = (
+/obj/machinery/door/airlock/mainship/security/glass/free_access,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	id = "Secure_1"
+	},
+/obj/structure/cable,
+/turf/open/floor,
+/area/bigredv2/caves/north)
 "xpB" = (
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/north)
@@ -21922,6 +23844,10 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/hydroponics)
+"xqW" = (
+/obj/structure/cable,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "xrJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	on = 1
@@ -21939,6 +23865,11 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"xuX" = (
+/obj/effect/landmark/corpsespawner/scientist,
+/obj/machinery/light,
+/turf/open/floor/tile/dark2,
+/area/bigredv2/caves/south)
 "xvL" = (
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/southeast)
@@ -21962,6 +23893,12 @@
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating,
 /area/bigredv2/outside/engineering)
+"xyY" = (
+/obj/effect/decal/warning_stripes/thick{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "xAO" = (
 /obj/effect/landmark/corpsespawner/security,
 /turf/open/floor,
@@ -21969,6 +23906,10 @@
 "xCx" = (
 /turf/open/space/basic,
 /area/bigredv2/outside/admin_building)
+"xEp" = (
+/obj/structure/cable,
+/turf/closed/mineral/bigred,
+/area/bigredv2/caves/southeast)
 "xEN" = (
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/south)
@@ -21999,6 +23940,16 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/east)
+"xJp" = (
+/turf/closed/wall/r_wall/unmeltable,
+/area/bigredv2/caves/south)
+"xJu" = (
+/obj/effect/decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/gibs/xeno,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "xNf" = (
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -22007,6 +23958,10 @@
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/south)
+"xPT" = (
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/bigredv2/outside/nanotrasen_lab/inside)
 "xQm" = (
 /obj/machinery/light{
 	dir = 8
@@ -22014,12 +23969,28 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/space_port)
+"xRF" = (
+/obj/effect/decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/light,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "xRR" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/tile/darkish,
 /area/bigredv2/outside/chapel)
+"xSt" = (
+/obj/effect/decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood/gibs/xeno/body,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/south)
 "xSR" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 6
@@ -22050,6 +24021,9 @@
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/south)
+"ydN" = (
+/turf/open/floor/mainship/orange,
+/area/bigredv2/caves/northeast)
 "yek" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -22101,205 +24075,205 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
 "}
 (2,1,1) = {"
 aaa
@@ -22318,6 +24292,7 @@ aab
 aab
 aab
 aab
+qOl
 aab
 aab
 aab
@@ -22424,8 +24399,6 @@ aab
 aab
 aab
 aab
-aab
-aaa
 aaa
 aaa
 aaa
@@ -22517,6 +24490,7 @@ aaa
 aaa
 aaa
 aaa
+cZm
 "}
 (3,1,1) = {"
 aaa
@@ -22535,7 +24509,7 @@ aac
 aac
 aac
 aac
-aac
+abQ
 aac
 aac
 aac
@@ -22733,7 +24707,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (4,1,1) = {"
 aaa
@@ -22745,14 +24719,14 @@ tku
 aac
 aac
 aac
+vWE
+vWE
+vWE
 aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
+abQ
 aac
 aac
 aac
@@ -22950,7 +24924,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (5,1,1) = {"
 aaa
@@ -22962,14 +24936,14 @@ tku
 aac
 aac
 aac
+vWE
+vWE
+vWE
 aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
+abQ
 aac
 aac
 aac
@@ -23167,7 +25141,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (6,1,1) = {"
 aaa
@@ -23179,14 +25153,14 @@ aac
 aac
 aac
 aac
+vWE
+vWE
+vWE
 aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
+abQ
 aac
 aac
 aac
@@ -23384,7 +25358,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (7,1,1) = {"
 aaa
@@ -23401,12 +25375,12 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
+pOZ
+pOZ
+czd
+pOZ
+pOZ
+pOZ
 pOZ
 pOZ
 pOZ
@@ -23601,7 +25575,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (8,1,1) = {"
 aaa
@@ -23616,15 +25590,15 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+vWE
 aac
 ktH
+aac
+abQ
+aac
+aac
+aac
+aac
 acA
 acA
 acA
@@ -23818,7 +25792,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (9,1,1) = {"
 aaa
@@ -23835,14 +25809,14 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
 ktH
-acA
+aac
+huI
+iKB
+iKB
+iKB
+iKB
+quI
 acY
 adq
 adH
@@ -24035,7 +26009,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (10,1,1) = {"
 aaa
@@ -24052,14 +26026,14 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
 ktH
-acA
+abQ
+huI
+iXG
+tfF
+tfF
+wdL
+quI
 acZ
 ade
 ade
@@ -24252,7 +26226,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (11,1,1) = {"
 aaa
@@ -24269,14 +26243,14 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
 ktH
-acA
+abQ
+iKB
+jYS
+vgq
+vgq
+lmC
+quI
 ada
 ade
 ade
@@ -24469,7 +26443,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (12,1,1) = {"
 aaa
@@ -24480,20 +26454,20 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
 ktH
-acA
+pOZ
+pOZ
+pOZ
+pOZ
+pOZ
+pOZ
+abQ
+huI
+mQb
+tfF
+tfF
+nag
+xnF
 ada
 adr
 ade
@@ -24686,7 +26660,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (13,1,1) = {"
 aaa
@@ -24697,20 +26671,20 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-pOZ
-pOZ
-pOZ
 ktH
-acA
+vWE
+vWE
+vWE
+vWE
+vWE
+vWE
+aac
+huI
+pFP
+tfF
+tfF
+gSk
+xnF
 acQ
 acQ
 acQ
@@ -24903,7 +26877,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (14,1,1) = {"
 aaa
@@ -24914,20 +26888,20 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
 ktH
-aae
-aae
-aae
-acA
+vWE
+vWE
+vWE
+vWE
+vwf
+vWE
+aac
+huI
+pXc
+vwP
+vwP
+syY
+xnF
 adb
 ads
 adf
@@ -25120,7 +27094,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (15,1,1) = {"
 aaa
@@ -25131,20 +27105,20 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
 ktH
-aae
-abQ
+vWE
+vWE
+vWE
+vWE
+vwf
+vWE
+aac
+ajT
+rJW
+aaf
+aaf
 gkA
-acQ
+dDI
 adc
 adt
 adt
@@ -25337,7 +27311,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (16,1,1) = {"
 aaa
@@ -25348,17 +27322,17 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
 ktH
-aae
+vWE
+vWE
+vWE
+vWE
+vwf
+vWE
+aac
+ajT
+rPj
+aaf
 aaf
 acJ
 acR
@@ -25554,7 +27528,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (17,1,1) = {"
 aaa
@@ -25565,17 +27539,17 @@ aac
 aac
 aac
 aac
-pOZ
-pOZ
-pOZ
-pOZ
-pOZ
-pOZ
-pOZ
-pOZ
-pOZ
 ktH
+oCk
 aae
+aae
+aae
+aae
+oCk
+ajT
+ajT
+rJW
+aaf
 aaf
 aas
 acQ
@@ -25771,7 +27745,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (18,1,1) = {"
 aaa
@@ -25783,16 +27757,16 @@ aac
 aac
 aac
 ktH
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+oCk
+raF
+aaf
+aaf
+abC
+raF
+aaf
+aaf
+aaf
+aaf
 aaf
 acJ
 acQ
@@ -25988,7 +27962,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (19,1,1) = {"
 aaa
@@ -26001,12 +27975,12 @@ aac
 aac
 ktH
 aae
-big
+ahe
 ahe
 oLG
 aaf
 aaf
-iXG
+aaf
 aaf
 aaf
 aaf
@@ -26205,7 +28179,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (20,1,1) = {"
 aaa
@@ -26222,7 +28196,7 @@ gFh
 aaf
 jLQ
 aaf
-abC
+aaf
 aae
 hIH
 aaf
@@ -26422,7 +28396,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (21,1,1) = {"
 aaa
@@ -26440,7 +28414,7 @@ aam
 oDD
 aaf
 aaf
-abQ
+aaf
 aaf
 aaf
 aaf
@@ -26639,7 +28613,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (22,1,1) = {"
 aaa
@@ -26856,7 +28830,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (23,1,1) = {"
 aaa
@@ -27073,7 +29047,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (24,1,1) = {"
 aaa
@@ -27290,7 +29264,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (25,1,1) = {"
 aaa
@@ -27507,7 +29481,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (26,1,1) = {"
 aaa
@@ -27724,7 +29698,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (27,1,1) = {"
 aaa
@@ -27941,7 +29915,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (28,1,1) = {"
 aaa
@@ -28158,7 +30132,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (29,1,1) = {"
 aaa
@@ -28375,7 +30349,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (30,1,1) = {"
 aaa
@@ -28592,7 +30566,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (31,1,1) = {"
 aaa
@@ -28809,7 +30783,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (32,1,1) = {"
 aaa
@@ -29026,7 +31000,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (33,1,1) = {"
 aaa
@@ -29243,7 +31217,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (34,1,1) = {"
 aaa
@@ -29460,7 +31434,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (35,1,1) = {"
 aaa
@@ -29677,7 +31651,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (36,1,1) = {"
 aaa
@@ -29698,8 +31672,8 @@ aaH
 aaH
 aah
 abk
-abu
-abk
+aah
+ntG
 aah
 abu
 aaH
@@ -29894,7 +31868,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (37,1,1) = {"
 aaa
@@ -29915,8 +31889,8 @@ aaI
 aaI
 aah
 abl
+aah
 abv
-abl
 aah
 abv
 aaI
@@ -30111,7 +32085,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (38,1,1) = {"
 aaa
@@ -30132,8 +32106,8 @@ aaJ
 aaJ
 aah
 abm
-abw
-abm
+aah
+abv
 aah
 abw
 aaJ
@@ -30328,7 +32302,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (39,1,1) = {"
 aaa
@@ -30545,7 +32519,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (40,1,1) = {"
 aaa
@@ -30762,7 +32736,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (41,1,1) = {"
 aaa
@@ -30979,7 +32953,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (42,1,1) = {"
 aaa
@@ -31196,7 +33170,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (43,1,1) = {"
 aaa
@@ -31413,7 +33387,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (44,1,1) = {"
 aaa
@@ -31425,7 +33399,7 @@ aac
 aad
 aad
 aad
-aad
+mTF
 aad
 bXE
 aae
@@ -31630,7 +33604,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (45,1,1) = {"
 aaa
@@ -31847,7 +33821,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (46,1,1) = {"
 aaa
@@ -32064,7 +34038,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (47,1,1) = {"
 aaa
@@ -32281,7 +34255,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (48,1,1) = {"
 aaa
@@ -32498,7 +34472,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (49,1,1) = {"
 aaa
@@ -32508,7 +34482,7 @@ aac
 aac
 aac
 aad
-aad
+mTF
 aad
 aac
 aac
@@ -32715,7 +34689,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (50,1,1) = {"
 aaa
@@ -32932,7 +34906,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (51,1,1) = {"
 aaa
@@ -33149,7 +35123,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (52,1,1) = {"
 aaa
@@ -33366,7 +35340,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (53,1,1) = {"
 aaa
@@ -33583,7 +35557,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (54,1,1) = {"
 aaa
@@ -33800,7 +35774,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (55,1,1) = {"
 aaa
@@ -33811,7 +35785,7 @@ aac
 aac
 aad
 aad
-aad
+mTF
 aad
 aad
 aac
@@ -34017,7 +35991,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (56,1,1) = {"
 aaa
@@ -34234,7 +36208,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (57,1,1) = {"
 aaa
@@ -34451,7 +36425,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (58,1,1) = {"
 aaa
@@ -34484,7 +36458,7 @@ aac
 aac
 aac
 aac
-aad
+mTF
 aad
 aad
 aac
@@ -34668,7 +36642,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (59,1,1) = {"
 aaa
@@ -34885,7 +36859,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (60,1,1) = {"
 aaa
@@ -34899,9 +36873,9 @@ aac
 aac
 aad
 aad
+mTF
 aad
 aad
-aad
 aac
 aac
 aac
@@ -34916,7 +36890,7 @@ aac
 aac
 aac
 aad
-aad
+mTF
 hkk
 hkk
 hkk
@@ -35102,7 +37076,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (61,1,1) = {"
 aaa
@@ -35319,7 +37293,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (62,1,1) = {"
 aaa
@@ -35536,7 +37510,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (63,1,1) = {"
 aaa
@@ -35753,7 +37727,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (64,1,1) = {"
 aaa
@@ -35970,7 +37944,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (65,1,1) = {"
 aaa
@@ -35999,7 +37973,7 @@ aac
 aac
 aac
 aad
-aad
+mTF
 aad
 hkk
 acp
@@ -36187,7 +38161,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (66,1,1) = {"
 aaa
@@ -36204,7 +38178,7 @@ aac
 aad
 aad
 aad
-aad
+mTF
 aad
 aad
 aac
@@ -36404,7 +38378,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (67,1,1) = {"
 aaa
@@ -36621,7 +38595,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (68,1,1) = {"
 aaa
@@ -36838,7 +38812,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (69,1,1) = {"
 aaa
@@ -36863,7 +38837,7 @@ aad
 aad
 aad
 aad
-aad
+mTF
 aad
 aad
 hkk
@@ -37055,7 +39029,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (70,1,1) = {"
 aaa
@@ -37272,7 +39246,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (71,1,1) = {"
 aaa
@@ -37489,7 +39463,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (72,1,1) = {"
 aaa
@@ -37509,7 +39483,7 @@ aac
 aad
 aad
 aad
-aad
+mTF
 aad
 aad
 aad
@@ -37706,7 +39680,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (73,1,1) = {"
 aaa
@@ -37923,7 +39897,7 @@ aab
 aab
 aab
 aaa
-aaa
+cZm
 "}
 (74,1,1) = {"
 aaa
@@ -38140,7 +40114,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (75,1,1) = {"
 aaa
@@ -38164,7 +40138,7 @@ aad
 aad
 aad
 aad
-aad
+mTF
 aad
 aad
 pQZ
@@ -38357,7 +40331,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (76,1,1) = {"
 aaa
@@ -38574,7 +40548,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (77,1,1) = {"
 aaa
@@ -38791,7 +40765,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (78,1,1) = {"
 aaa
@@ -39008,7 +40982,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (79,1,1) = {"
 aaa
@@ -39225,7 +41199,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (80,1,1) = {"
 aaa
@@ -39249,7 +41223,7 @@ aac
 aac
 mAi
 aad
-aad
+mTF
 aad
 mAi
 pQZ
@@ -39442,7 +41416,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (81,1,1) = {"
 aaa
@@ -39659,7 +41633,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (82,1,1) = {"
 aaa
@@ -39876,7 +41850,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (83,1,1) = {"
 aaa
@@ -40093,7 +42067,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (84,1,1) = {"
 aaa
@@ -40310,7 +42284,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (85,1,1) = {"
 aaa
@@ -40527,7 +42501,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (86,1,1) = {"
 aaa
@@ -40549,7 +42523,7 @@ qVr
 qVr
 xpB
 xpB
-xpB
+hBS
 xpB
 xpB
 xpB
@@ -40744,7 +42718,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (87,1,1) = {"
 aaa
@@ -40961,7 +42935,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (88,1,1) = {"
 aaa
@@ -41178,7 +43152,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (89,1,1) = {"
 aaa
@@ -41202,7 +43176,7 @@ qVr
 xpB
 xpB
 abq
-xpB
+hBS
 xpB
 xpB
 qVr
@@ -41395,7 +43369,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (90,1,1) = {"
 aaa
@@ -41612,7 +43586,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (91,1,1) = {"
 aaa
@@ -41829,7 +43803,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (92,1,1) = {"
 aaa
@@ -42046,7 +44020,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (93,1,1) = {"
 aaa
@@ -42263,7 +44237,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (94,1,1) = {"
 aaa
@@ -42480,7 +44454,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (95,1,1) = {"
 aaa
@@ -42504,7 +44478,7 @@ qVr
 qVr
 xpB
 xpB
-xpB
+hBS
 abq
 xpB
 qVr
@@ -42697,7 +44671,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (96,1,1) = {"
 aaa
@@ -42914,7 +44888,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (97,1,1) = {"
 aaa
@@ -43131,7 +45105,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (98,1,1) = {"
 aaa
@@ -43348,7 +45322,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (99,1,1) = {"
 aaa
@@ -43565,7 +45539,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (100,1,1) = {"
 aaa
@@ -43782,7 +45756,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (101,1,1) = {"
 aaa
@@ -43999,7 +45973,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (102,1,1) = {"
 aaa
@@ -44211,12 +46185,12 @@ xEN
 xEN
 xEN
 xEN
-hqP
+xEN
 hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (103,1,1) = {"
 aaa
@@ -44428,12 +46402,12 @@ hqP
 xEN
 xEN
 jWg
-hqP
+xEN
 hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (104,1,1) = {"
 aaa
@@ -44644,13 +46618,13 @@ vKO
 hqP
 xEN
 xEN
+akl
 xEN
-hqP
 hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (105,1,1) = {"
 aaa
@@ -44859,15 +46833,15 @@ bwF
 bwF
 vKO
 hqP
-xEN
-jWg
-xEN
-hqP
+oAE
+kGJ
+rdw
+wYu
 hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (106,1,1) = {"
 aaa
@@ -45075,16 +47049,16 @@ bCX
 bDm
 bwF
 vKO
-hqP
-xEN
-xEN
-xEN
-xEN
-hqP
+eyz
+vlT
+bMl
+mEo
+vlT
+rWh
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (107,1,1) = {"
 aaa
@@ -45108,7 +47082,7 @@ qVr
 xpB
 xpB
 xpB
-xpB
+hBS
 xpB
 xpB
 abq
@@ -45291,17 +47265,17 @@ bEh
 bEJ
 bCZ
 bwF
-vKO
-hqP
-xEN
-xEN
-xEN
-xEN
-hqP
-hqP
-aab
-aaa
-aaa
+wdk
+eli
+nvX
+sRQ
+eCN
+eCN
+nhk
+fqj
+qOl
+cZm
+cZm
 "}
 (108,1,1) = {"
 aaa
@@ -45504,21 +47478,21 @@ bzS
 bzS
 bzS
 bzS
-bxN
-bEK
-bCZ
-bwF
-vKO
-hqP
-xEN
-xEN
-xEN
-xEN
-xEN
+qGO
+lYg
+iFA
+gcG
+sIU
+eyz
+gAT
+dry
+jKs
+unB
+rWh
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (109,1,1) = {"
 aaa
@@ -45695,7 +47669,7 @@ bwJ
 bwJ
 bAD
 bwF
-bwF
+gcG
 bya
 qnu
 byM
@@ -45721,21 +47695,21 @@ bBp
 bBp
 vTU
 bBp
-bzS
+aUv
 bEK
 bEO
-bwF
-vKO
-hqP
-xEN
-jWg
-xEN
-jWg
-xEN
+qIK
+jSE
+glC
+hDY
+nJq
+hDY
+eyz
+rWh
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (110,1,1) = {"
 aaa
@@ -45912,7 +47886,7 @@ bxF
 bxF
 bxt
 bAR
-bwF
+gcG
 bxN
 bzS
 bBF
@@ -45938,21 +47912,21 @@ bxN
 bxN
 bxN
 bxN
-bxN
+qGO
 bEK
 bCZ
 bwF
-vKO
-hqP
-xEN
-xEN
-xEN
-xEN
-xEN
+pEh
+eyz
+bMl
+bMl
+bMl
+egQ
+rWh
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (111,1,1) = {"
 aaa
@@ -45996,8 +47970,8 @@ acP
 acP
 acP
 acp
-ajj
-adk
+adS
+qMi
 aer
 akS
 alE
@@ -46129,7 +48103,7 @@ bBr
 bCu
 oTU
 bAS
-bwF
+gcG
 bBh
 bBq
 byM
@@ -46141,35 +48115,35 @@ bCt
 bCt
 bCS
 bBq
-bBJ
-bxN
-bxS
+keE
+qGO
+xPT
 bDu
-bDA
+ewZ
 bDI
-bxN
-bDV
-bDZ
-bxN
-bDo
+qGO
+kgP
+qBa
+qGO
+nCe
 bEs
-bDA
-bEB
-bxN
+ewZ
+eOu
+qGO
 bEK
 bEP
 bwF
 vKO
-hqP
-xEN
-xEN
-xEN
-xEN
-xEN
+eyz
+pcY
+hDY
+hDY
+psH
+xJp
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (112,1,1) = {"
 aaa
@@ -46213,7 +48187,7 @@ acP
 acP
 acP
 acp
-acp
+tUS
 acp
 acp
 akU
@@ -46346,7 +48320,7 @@ bzV
 bAo
 bAF
 bAS
-bwF
+gcG
 bBi
 bxg
 bxs
@@ -46358,7 +48332,7 @@ bxg
 bxg
 bxg
 bBr
-bBK
+sRT
 bxN
 bDo
 bxS
@@ -46377,16 +48351,16 @@ bEK
 bCZ
 bwF
 vKO
-hqP
-xEN
-xEN
-xEN
-jWg
-xEN
+eyz
+pcY
+hDY
+hDY
+eyz
+xJp
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (113,1,1) = {"
 aaa
@@ -46429,9 +48403,9 @@ qVr
 acP
 acP
 acP
-acP
-acP
-ajT
+acp
+adk
+acp
 akw
 akw
 alF
@@ -46560,10 +48534,10 @@ bze
 bwF
 adx
 bzW
-bxu
+hLo
 bAG
-bAS
-bwF
+cCg
+gcG
 bBj
 bxg
 xGI
@@ -46575,7 +48549,7 @@ bxo
 bxo
 bxg
 bxg
-bBK
+sRT
 bxN
 bDp
 svV
@@ -46594,16 +48568,16 @@ bEK
 bCZ
 bwF
 vKO
-hqP
-xEN
-jWg
-xEN
-xEN
-xEN
+eyz
+hDY
+nJq
+hDY
+hDY
+xJp
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (114,1,1) = {"
 aaa
@@ -46629,15 +48603,15 @@ qVr
 qVr
 abq
 xpB
-xpB
+hBS
 abq
-qVr
-qVr
-qVr
-qVr
-qVr
-qVr
-gEU
+xpB
+xpB
+xpB
+xpB
+xpB
+xpB
+frg
 qVr
 qVr
 qVr
@@ -46646,9 +48620,9 @@ qVr
 acP
 acP
 acP
-acP
-acP
-acP
+gqM
+adk
+gBm
 acP
 acP
 acP
@@ -46780,19 +48754,19 @@ bBr
 bxg
 bxg
 bAS
-bwF
+gcG
 bBk
-bxg
-bBr
-bxg
-bxg
-bxg
-bCu
-bxg
-bCu
-bxg
-bxo
-bBK
+bxZ
+qYM
+bxZ
+bxZ
+bxZ
+wVJ
+bxZ
+wVJ
+bxZ
+jZH
+sRT
 bxN
 bxS
 bxS
@@ -46811,16 +48785,16 @@ bEK
 rnW
 bwF
 vKO
-hqP
-hqP
-xEN
-xEN
-xEN
-xEN
+eyz
+eyz
+qRh
+jwU
+eyz
+xJp
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (115,1,1) = {"
 aaa
@@ -46847,14 +48821,14 @@ qVr
 qVr
 xpB
 xpB
-abq
-qVr
-qVr
-qVr
-qVr
-qVr
-qVr
-qVr
+xpB
+nLh
+nLh
+nLh
+nLh
+nLh
+xpB
+xpB
 gEU
 qVr
 qVr
@@ -46863,13 +48837,13 @@ qVr
 qVr
 acP
 acP
+gqM
+adk
+gBm
 acP
 acP
 acP
-acP
-acP
-acP
-acP
+rww
 acP
 acP
 acP
@@ -46996,7 +48970,7 @@ bzI
 bxu
 bAq
 bAH
-byA
+aSn
 bwF
 bBl
 bxg
@@ -47029,15 +49003,15 @@ bEO
 bwF
 vKO
 hqP
-hqP
-xEN
-xEN
-xEN
-xEN
+bNb
+rdw
+rdw
+lqJ
+rdw
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (116,1,1) = {"
 aaa
@@ -47065,14 +49039,14 @@ qVr
 acc
 abY
 acc
-qVr
-qVr
-qVr
-qVr
-qVr
-qVr
-qVr
-qVr
+nLh
+juA
+jTD
+udd
+nLh
+xpB
+hBS
+xpB
 gEU
 qVr
 qVr
@@ -47080,9 +49054,9 @@ qVr
 qVr
 qVr
 acP
-acP
-acP
-acP
+acp
+adS
+acp
 acP
 acP
 acP
@@ -47246,15 +49220,15 @@ bDN
 bwF
 vKO
 hqP
-hqP
 xEN
 xEN
 xEN
 xEN
+cFp
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (117,1,1) = {"
 aaa
@@ -47282,27 +49256,27 @@ qVr
 xpB
 xpB
 xpB
-abq
-qVr
-qVr
-qVr
-qVr
-qVr
-qVr
-qVr
+slo
+jTD
+jUU
+jTD
+nLh
+xpB
+xpB
+xpB
 qVr
 gEU
 qVr
 qVr
-qVr
-qVr
-qVr
+bHv
+bHv
+bHv
+bHv
+xpu
+mFd
 acP
 acP
 acP
-acP
-acP
-rww
 acP
 acP
 anI
@@ -47463,7 +49437,7 @@ bDN
 bwF
 vKO
 hqP
-hqP
+xEN
 xEN
 jWg
 jWg
@@ -47471,7 +49445,7 @@ xEN
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (118,1,1) = {"
 aaa
@@ -47499,24 +49473,24 @@ qVr
 xpB
 xpB
 xpB
+nLh
+xaU
+jTD
+jTD
+nLh
 xpB
-abq
-abq
-qVr
-qVr
-qVr
-qVr
-qVr
+xpB
+xpB
 qVr
 qVr
 gEU
 qVr
-qVr
-qVr
-qVr
-qVr
-acP
-acP
+bHv
+vKc
+ctE
+ctE
+ctE
+lQx
 acP
 acP
 acP
@@ -47688,7 +49662,7 @@ xEN
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (119,1,1) = {"
 aaa
@@ -47716,24 +49690,24 @@ qVr
 xpB
 xpB
 hBS
+nLh
+nLh
+kJi
+nLh
+nLh
 xpB
 xpB
-hBS
-abq
-qVr
-qVr
-qVr
-qVr
+xpB
 qVr
 qVr
 qVr
 gEU
-qVr
-qVr
-qVr
-qVr
-qVr
-qVr
+bHv
+ofL
+lKZ
+lKZ
+iaU
+mFd
 acP
 acP
 acP
@@ -47898,14 +49872,14 @@ bwF
 vKO
 hqP
 hqP
-xEN
+hqP
 xEN
 xEN
 xEN
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (120,1,1) = {"
 aaa
@@ -47927,30 +49901,30 @@ aaa
 aab
 qVr
 qVr
-qVr
-qVr
-qVr
-qVr
-xpB
-xpB
-abq
-xpB
-xpB
-xpB
-abq
-abq
-abq
-qVr
-qVr
-qVr
-qVr
-qVr
-gEU
-qVr
-qVr
-qVr
-qVr
-qVr
+slM
+slM
+slM
+slM
+wSe
+wSe
+wSe
+wSe
+wSe
+wSe
+wSe
+wSe
+wSe
+wSe
+slM
+slM
+slM
+slM
+mFd
+fDs
+ldk
+iyl
+pzX
+mFd
 acP
 acP
 acP
@@ -48115,14 +50089,14 @@ bwF
 vKO
 hqP
 hqP
-xEN
+hqP
 xEN
 xEN
 jWg
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (121,1,1) = {"
 aaa
@@ -48144,30 +50118,30 @@ aaa
 aab
 qVr
 qVr
+slM
 qVr
 qVr
 qVr
 qVr
-qVr
-xpB
-xpB
-xpB
-xpB
-xpB
-xpB
-xpB
-abq
-qVr
-qVr
+jTD
+jTD
+jTD
+jTD
+jTD
+jTD
+jTD
+jTD
+jTD
 qVr
 qVr
 qVr
 qVr
-gEU
-qVr
-qVr
-qVr
-qVr
+bHv
+bHv
+bHv
+bHv
+bHv
+bHv
 acP
 acP
 acP
@@ -48332,14 +50306,14 @@ bwF
 vKO
 hqP
 hqP
-xEN
+hqP
 jWg
 xEN
 xEN
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (122,1,1) = {"
 aaa
@@ -48361,7 +50335,7 @@ aaa
 aab
 qVr
 qVr
-qVr
+slM
 qVr
 qVr
 qVr
@@ -48371,8 +50345,8 @@ qoL
 tnm
 hKr
 tnm
-tnm
-tnm
+fHD
+fHD
 tnm
 hKr
 qoL
@@ -48556,7 +50530,7 @@ xEN
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (123,1,1) = {"
 aaa
@@ -48578,7 +50552,7 @@ aaa
 aab
 qVr
 qVr
-qVr
+slM
 qVr
 qVr
 qVr
@@ -48587,7 +50561,7 @@ qVr
 qVr
 xpB
 xpB
-abq
+jTD
 xpB
 xpB
 xpB
@@ -48773,7 +50747,7 @@ xEN
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (124,1,1) = {"
 aaa
@@ -48795,20 +50769,20 @@ aaa
 aab
 qVr
 qVr
-qVr
+slM
 qVr
 qVr
 qVr
 qoL
 qVr
 qVr
+jTD
 xpB
 xpB
 xpB
 xpB
 xpB
-xpB
-xpB
+jTD
 abq
 qoL
 qVr
@@ -48990,7 +50964,7 @@ xEN
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (125,1,1) = {"
 aaa
@@ -49012,7 +50986,7 @@ aaa
 aab
 qVr
 qVr
-qVr
+slM
 qVr
 qVr
 qVr
@@ -49207,7 +51181,7 @@ xEN
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (126,1,1) = {"
 aaa
@@ -49229,7 +51203,7 @@ aaa
 aab
 qVr
 qVr
-qVr
+slM
 qVr
 qVr
 qVr
@@ -49424,7 +51398,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (127,1,1) = {"
 aaa
@@ -49446,7 +51420,7 @@ aaa
 aab
 qVr
 qVr
-qVr
+slM
 qVr
 qVr
 qVr
@@ -49641,7 +51615,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (128,1,1) = {"
 aaa
@@ -49663,7 +51637,7 @@ aaa
 aab
 qVr
 qVr
-qVr
+slM
 qVr
 qVr
 qVr
@@ -49858,7 +51832,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (129,1,1) = {"
 aaa
@@ -49880,7 +51854,7 @@ aaa
 aab
 qVr
 qVr
-qVr
+slM
 qVr
 qVr
 qVr
@@ -50075,7 +52049,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (130,1,1) = {"
 aaa
@@ -50097,7 +52071,7 @@ aaa
 aab
 qVr
 qVr
-qVr
+slM
 qVr
 qVr
 qVr
@@ -50292,7 +52266,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (131,1,1) = {"
 aaa
@@ -50314,7 +52288,7 @@ aaa
 aab
 qVr
 qVr
-qVr
+slM
 qVr
 qVr
 qVr
@@ -50509,7 +52483,7 @@ xEN
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (132,1,1) = {"
 aaa
@@ -50531,7 +52505,7 @@ aaa
 aab
 qVr
 qVr
-qVr
+slM
 qVr
 dnl
 dnl
@@ -50726,7 +52700,7 @@ xEN
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (133,1,1) = {"
 aaa
@@ -50748,7 +52722,7 @@ aaa
 aab
 qVr
 qVr
-qVr
+slM
 qVr
 dnl
 dnl
@@ -50943,7 +52917,7 @@ xEN
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (134,1,1) = {"
 aaa
@@ -50965,7 +52939,7 @@ aaa
 aab
 qVr
 qVr
-qVr
+slM
 qVr
 dnl
 dnl
@@ -51160,7 +53134,7 @@ xEN
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (135,1,1) = {"
 aaa
@@ -51182,7 +53156,7 @@ aaa
 aab
 qVr
 qVr
-qVr
+slM
 qVr
 dnl
 dnl
@@ -51377,7 +53351,7 @@ xEN
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (136,1,1) = {"
 aaa
@@ -51399,7 +53373,7 @@ aaa
 aab
 aab
 aab
-aab
+qOl
 aab
 aab
 dnl
@@ -51594,7 +53568,7 @@ xEN
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (137,1,1) = {"
 aaa
@@ -51616,7 +53590,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -51811,7 +53785,7 @@ xEN
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (138,1,1) = {"
 aaa
@@ -51833,7 +53807,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -52028,7 +54002,7 @@ xEN
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (139,1,1) = {"
 aaa
@@ -52050,7 +54024,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -52245,7 +54219,7 @@ xEN
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (140,1,1) = {"
 aaa
@@ -52267,7 +54241,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -52462,7 +54436,7 @@ xEN
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (141,1,1) = {"
 aaa
@@ -52484,7 +54458,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -52679,7 +54653,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (142,1,1) = {"
 aaa
@@ -52701,7 +54675,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -52896,7 +54870,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (143,1,1) = {"
 aaa
@@ -52918,7 +54892,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -53113,7 +55087,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (144,1,1) = {"
 aaa
@@ -53135,7 +55109,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -53330,7 +55304,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (145,1,1) = {"
 aaa
@@ -53352,7 +55326,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -53547,7 +55521,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (146,1,1) = {"
 aaa
@@ -53569,7 +55543,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -53764,7 +55738,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (147,1,1) = {"
 aaa
@@ -53786,7 +55760,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -53981,7 +55955,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (148,1,1) = {"
 aaa
@@ -54003,7 +55977,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -54198,7 +56172,7 @@ hqP
 hqP
 aab
 aaa
-aaa
+cZm
 "}
 (149,1,1) = {"
 aaa
@@ -54220,7 +56194,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -54415,7 +56389,7 @@ jeY
 jeY
 aab
 aaa
-aaa
+cZm
 "}
 (150,1,1) = {"
 aaa
@@ -54437,7 +56411,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -54632,7 +56606,7 @@ jeY
 jeY
 aab
 aaa
-aaa
+cZm
 "}
 (151,1,1) = {"
 aaa
@@ -54654,7 +56628,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -54849,7 +56823,7 @@ jeY
 jeY
 aab
 aaa
-aaa
+cZm
 "}
 (152,1,1) = {"
 aaa
@@ -54871,7 +56845,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -55066,7 +57040,7 @@ jeY
 jeY
 aab
 aaa
-aaa
+cZm
 "}
 (153,1,1) = {"
 aaa
@@ -55088,7 +57062,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -55283,7 +57257,7 @@ jeY
 jeY
 aab
 aaa
-aaa
+cZm
 "}
 (154,1,1) = {"
 aaa
@@ -55305,7 +57279,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -55500,7 +57474,7 @@ jeY
 jeY
 aab
 aaa
-aaa
+cZm
 "}
 (155,1,1) = {"
 aaa
@@ -55522,7 +57496,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -55717,7 +57691,7 @@ jeY
 jeY
 aab
 aaa
-aaa
+cZm
 "}
 (156,1,1) = {"
 aaa
@@ -55739,7 +57713,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -55934,7 +57908,7 @@ jeY
 jeY
 aab
 aaa
-aaa
+cZm
 "}
 (157,1,1) = {"
 aaa
@@ -55956,7 +57930,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -56151,7 +58125,7 @@ jeY
 jeY
 aab
 aaa
-aaa
+cZm
 "}
 (158,1,1) = {"
 aaa
@@ -56173,7 +58147,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -56183,7 +58157,7 @@ dnl
 dnl
 vCh
 vCh
-cfS
+vCh
 vCh
 vCh
 vCh
@@ -56368,7 +58342,7 @@ jeY
 jeY
 aab
 aaa
-aaa
+cZm
 "}
 (159,1,1) = {"
 aaa
@@ -56390,7 +58364,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -56585,7 +58559,7 @@ jeY
 jeY
 aab
 aaa
-aaa
+cZm
 "}
 (160,1,1) = {"
 aaa
@@ -56607,7 +58581,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -56802,7 +58776,7 @@ aab
 aab
 aab
 aaa
-aaa
+cZm
 "}
 (161,1,1) = {"
 aaa
@@ -56824,7 +58798,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -57019,7 +58993,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (162,1,1) = {"
 aaa
@@ -57041,7 +59015,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -57236,7 +59210,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (163,1,1) = {"
 aaa
@@ -57258,7 +59232,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -57453,7 +59427,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (164,1,1) = {"
 aaa
@@ -57475,7 +59449,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -57670,7 +59644,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (165,1,1) = {"
 aaa
@@ -57692,7 +59666,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -57887,7 +59861,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (166,1,1) = {"
 aaa
@@ -57909,7 +59883,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -58104,7 +60078,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (167,1,1) = {"
 aaa
@@ -58126,7 +60100,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -58321,7 +60295,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (168,1,1) = {"
 aaa
@@ -58343,7 +60317,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -58538,7 +60512,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (169,1,1) = {"
 aaa
@@ -58560,7 +60534,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -58755,7 +60729,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (170,1,1) = {"
 aaa
@@ -58777,7 +60751,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -58958,7 +60932,7 @@ eve
 fwQ
 eve
 eve
-jeY
+eve
 jeY
 jeY
 jeY
@@ -58972,7 +60946,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 "}
 (171,1,1) = {"
 aaa
@@ -58994,7 +60968,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -59179,17 +61153,17 @@ jeY
 jeY
 jeY
 jeY
-jeY
+aab
 aab
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+cZm
 "}
 (172,1,1) = {"
 aaa
@@ -59211,7 +61185,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -59381,17 +61355,16 @@ eve
 eve
 eve
 eve
-eve
-eve
-eve
-eve
-eve
-eve
-bLJ
-eve
-eve
-eve
-eve
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
 jeY
 jeY
 jeY
@@ -59400,13 +61373,14 @@ jeY
 aab
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aab
+bHv
+bHv
+bHv
+bHv
+bHv
+bHv
+cZm
 "}
 (173,1,1) = {"
 aaa
@@ -59428,7 +61402,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -59598,32 +61572,32 @@ eve
 eve
 eve
 eve
-eve
-eve
-eve
-eve
-eve
-fwQ
-eve
-eve
-eve
-eve
-eve
+jeY
+jeY
+jeY
+jeY
+jeY
+jeY
 jeY
 jeY
 jeY
 jeY
 jeY
 aab
+aab
+aab
+aab
+aab
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aab
+bHv
+tzW
+eCh
+eCh
+eCh
+bHv
+cZm
 "}
 (174,1,1) = {"
 aaa
@@ -59645,7 +61619,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -59815,16 +61789,11 @@ eve
 eve
 eve
 eve
-eve
-eve
-eve
-eve
-eve
-eve
-eve
-eve
-eve
-eve
+jeY
+jeY
+jeY
+jeY
+jeY
 jeY
 jeY
 jeY
@@ -59838,9 +61807,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aab
+bHv
+eKa
+hjc
+eKa
+vry
+bHv
+cZm
 "}
 (175,1,1) = {"
 aaa
@@ -59862,7 +61836,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -60032,15 +62006,6 @@ jeY
 jeY
 jeY
 jeY
-eve
-eve
-eve
-eve
-eve
-eve
-eve
-eve
-eve
 jeY
 jeY
 jeY
@@ -60048,16 +62013,25 @@ jeY
 jeY
 jeY
 jeY
+jeY
+jeY
+jeY
+kOh
 aab
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aab
+aab
+aab
+aab
+bHv
+uwD
+eKa
+eKa
+eKa
+bHv
+cZm
 "}
 (176,1,1) = {"
 aaa
@@ -60079,7 +62053,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -60254,27 +62228,27 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
+aab
+aab
+aab
+aab
+aab
 aab
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aab
+bHv
+bHv
+bHv
+bHv
+bHv
+cur
+csO
+cur
+bHv
+cZm
 "}
 (177,1,1) = {"
 aaa
@@ -60296,7 +62270,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -60455,23 +62429,12 @@ eve
 eve
 eve
 eve
+jeY
 eve
 eve
 eve
 eve
 eve
-eve
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
 jeY
 jeY
 jeY
@@ -60489,9 +62452,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aab
+aab
+aab
+aab
+bHv
+utr
+utr
+utr
+utr
+utr
+tDh
+utr
+bHv
+cZm
 "}
 (178,1,1) = {"
 aaa
@@ -60513,7 +62487,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -60688,17 +62662,6 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
 aab
 aaa
 aaa
@@ -60706,9 +62669,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aab
+jeY
+jeY
+bHv
+bHv
+mxP
+tDh
+kpD
+utr
+utr
+utr
+utr
+bHv
+cZm
 "}
 (179,1,1) = {"
 aaa
@@ -60730,7 +62704,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -60905,17 +62879,6 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
 aab
 aaa
 aaa
@@ -60923,9 +62886,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aab
+jeY
+jeY
+bHv
+mxP
+utr
+utr
+utr
+utr
+utr
+utr
+utr
+bHv
+cZm
 "}
 (180,1,1) = {"
 aaa
@@ -60947,7 +62921,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -61122,17 +63096,6 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
 aab
 aaa
 aaa
@@ -61140,9 +63103,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aab
+jeY
+jeY
+bHv
+utr
+utr
+utr
+ihM
+utr
+utr
+utr
+tDh
+bHv
+cZm
 "}
 (181,1,1) = {"
 aaa
@@ -61164,7 +63138,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -61334,22 +63308,11 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
+aab
+aab
+aab
+aab
+aab
 aab
 aaa
 aaa
@@ -61357,9 +63320,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aab
+jeY
+jeY
+bHv
+vQS
+utr
+jFi
+utr
+utr
+utr
+utr
+eYb
+bHv
+cZm
 "}
 (182,1,1) = {"
 aaa
@@ -61381,7 +63355,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -61551,22 +63525,6 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
 aab
 aaa
 aaa
@@ -61577,6 +63535,22 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aab
+jeY
+jeY
+bHv
+utr
+utr
+utr
+utr
+utr
+utr
+iYa
+tfr
+bHv
+cZm
 "}
 (183,1,1) = {"
 aaa
@@ -61598,7 +63572,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -61767,23 +63741,7 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
+aab
 aab
 aaa
 aaa
@@ -61794,6 +63752,22 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aab
+jeY
+jeY
+vtS
+gvo
+utr
+tDh
+nPl
+utr
+utr
+utr
+utr
+bHv
+cZm
 "}
 (184,1,1) = {"
 aaa
@@ -61815,7 +63789,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -61984,23 +63958,6 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
 aab
 aaa
 aaa
@@ -62011,6 +63968,23 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aab
+jeY
+jeY
+bHv
+utr
+utr
+utr
+utr
+utr
+utr
+utr
+utr
+bHv
+cZm
 "}
 (185,1,1) = {"
 aaa
@@ -62032,7 +64006,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -62200,24 +64174,7 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
+aab
 aab
 aaa
 aaa
@@ -62228,6 +64185,23 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aab
+jeY
+jeY
+bHv
+utr
+utr
+utr
+utr
+utr
+utr
+utr
+utr
+bHv
+cZm
 "}
 (186,1,1) = {"
 aaa
@@ -62249,7 +64223,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -62308,19 +64282,19 @@ aoK
 aIN
 ahC
 adZ
-dnl
-kKe
-vCh
-vCh
-vCh
-kKe
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
+aEu
+aEu
+aEu
+aEu
+aEu
+aEu
+aEu
+aEu
+aEu
+aEu
+aEu
+aEu
+aEu
 dnl
 dnl
 dnl
@@ -62417,24 +64391,6 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
 aab
 aaa
 aaa
@@ -62445,6 +64401,24 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aab
+jeY
+jeY
+bHv
+gfg
+utr
+tfr
+utr
+qdE
+utr
+utr
+utr
+bHv
+cZm
 "}
 (187,1,1) = {"
 aaa
@@ -62466,7 +64440,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -62523,21 +64497,21 @@ aGg
 asv
 aHP
 wfD
-ahC
+ewt
 adZ
-dnl
-dnl
-vCh
-dnl
-vCh
-vCh
-kKe
-kKe
-dnl
-dnl
-dnl
-dnl
-dnl
+jFz
+fYE
+fYE
+sbj
+fYE
+fYE
+hyP
+fYE
+sbj
+fYE
+fYE
+hyP
+aEu
 dnl
 dnl
 dnl
@@ -62634,24 +64608,6 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
 aab
 aaa
 aaa
@@ -62662,6 +64618,24 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aab
+jeY
+jeY
+bHv
+vQS
+utr
+rjr
+tDh
+xni
+utr
+tDh
+eYb
+bHv
+cZm
 "}
 (188,1,1) = {"
 aaa
@@ -62683,7 +64657,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -62740,21 +64714,21 @@ adZ
 ahL
 aHQ
 aHP
-ahC
-adZ
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-vCh
-dnl
-dnl
-dnl
-dnl
-dnl
+nFJ
+rJv
+ydN
+wSP
+amE
+amE
+amE
+amE
+amE
+amE
+amE
+amE
+amE
+amE
+aEu
 dnl
 dnl
 dnl
@@ -62851,24 +64825,6 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
 aab
 aaa
 aaa
@@ -62879,6 +64835,24 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aab
+jeY
+jeY
+bHv
+utr
+utr
+qDZ
+utr
+utr
+utr
+utr
+utr
+bHv
+cZm
 "}
 (189,1,1) = {"
 aaa
@@ -62900,7 +64874,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -62955,23 +64929,23 @@ dnl
 dnl
 adZ
 adZ
-ahL
+ldl
 aHQ
 aJI
-adZ
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
+aIN
+ydN
+amE
+amE
+amE
+wSP
+amE
+amE
+vJk
+ffS
+vJk
+vJk
+amE
+aEu
 dnl
 dnl
 dnl
@@ -63068,34 +65042,34 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
 aab
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+qOl
+xEp
+xEp
+mFd
+aPo
+nMb
+qXP
+uyC
+xqW
+qbd
+xqW
+xqW
+mFd
+cZm
 "}
 (190,1,1) = {"
 aaa
@@ -63117,7 +65091,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -63176,19 +65150,19 @@ adZ
 aIP
 aJJ
 adZ
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
+jFz
+fYE
+fYE
+fYE
+fYE
+fYE
+vRM
+fYE
+fYE
+fYE
+fYE
+vRM
+aEu
 dnl
 dnl
 dnl
@@ -63275,25 +65249,7 @@ mGX
 tEo
 mGX
 mGX
-mGX
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
+loN
 jeY
 jeY
 jeY
@@ -63307,11 +65263,29 @@ aab
 aaa
 aaa
 aaa
+cZm
 aaa
 aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aab
+jeY
+xEp
+bHv
+myA
+nQE
+rde
+uCk
+xuX
+bHv
+bHv
+bHv
+bHv
 aaa
 "}
 (191,1,1) = {"
@@ -63334,7 +65308,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -63375,37 +65349,37 @@ adZ
 auy
 avl
 adZ
-adZ
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-adZ
+oTw
+sAq
+sAq
+sAq
+sAq
+sAq
+sAq
+sAq
+sAq
+sAq
+sAq
+sAq
+sAq
+sAq
+oTw
 aIQ
 aJK
-adZ
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
+oTw
+sYG
+sYG
+sYG
+sYG
+sYG
+sYG
+kvz
+bHk
+bHk
+bHk
+bHk
+bHv
+aEu
 dnl
 ptP
 ptP
@@ -63493,24 +65467,6 @@ pJO
 pJO
 dDP
 loN
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
 jeY
 jeY
 jeY
@@ -63524,11 +65480,29 @@ aab
 aaa
 aaa
 aaa
+cZm
 aaa
 aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aab
+jeY
+xEp
+bHv
+bHv
+oiH
+rdw
+rdw
+xyY
+bHv
+aab
+aab
+aab
 aaa
 "}
 (192,1,1) = {"
@@ -63551,7 +65525,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -63591,8 +65565,8 @@ dnl
 adZ
 auz
 avm
-adZ
-dnl
+oTw
+sAq
 ptP
 vTV
 vCh
@@ -63616,12 +65590,12 @@ dnl
 dnl
 dnl
 dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
+oCk
+vST
+rVZ
+rVZ
+rVZ
+bHv
 dnl
 ptP
 dnl
@@ -63719,31 +65693,31 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
 aab
 aaa
 aaa
 aaa
+cZm
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aab
+jeY
+xEp
+jeY
+bHv
+oiH
+rhf
+rhf
+xyY
+bHv
+aab
 aaa
 aaa
 aaa
@@ -63768,7 +65742,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -63808,7 +65782,7 @@ vTV
 atP
 auA
 avn
-atP
+umd
 vTV
 kKe
 kKe
@@ -63833,12 +65807,12 @@ dnl
 dnl
 dnl
 dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
+oCk
+erQ
+nmh
+vST
+mYm
+bHv
 dnl
 ptP
 dnl
@@ -63936,31 +65910,31 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
 aab
 aaa
 aaa
 aaa
+cZm
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aab
+jeY
+xEp
+jeY
+bHv
+oVQ
+riu
+uKa
+xJu
+bHv
+aab
 aaa
 aaa
 aaa
@@ -63985,7 +65959,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -64025,7 +65999,7 @@ arL
 atP
 auB
 avo
-atP
+umd
 hLA
 vCh
 cfS
@@ -64050,12 +66024,12 @@ adZ
 adZ
 dnl
 dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
+oCk
+qQh
+vST
+nAH
+lsj
+bHv
 dnl
 ptP
 dnl
@@ -64153,31 +66127,31 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
 aab
 aaa
 aaa
 aaa
+cZm
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aab
+jeY
+xEp
+jeY
+bHv
+oZb
+rdw
+rdw
+xRF
+bHv
+aab
 aaa
 aaa
 aaa
@@ -64202,7 +66176,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -64242,7 +66216,7 @@ vTV
 adZ
 auC
 avp
-adZ
+oTw
 xjd
 kKe
 axU
@@ -64267,12 +66241,12 @@ aMr
 adZ
 adZ
 dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
+oCk
+bHv
+bHv
+bHv
+bHv
+bHv
 dnl
 ptP
 dnl
@@ -64370,31 +66344,31 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
 aab
 aaa
 aaa
 aaa
+cZm
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aab
+jeY
+xEp
+jeY
+bHv
+pgV
+rpq
+uLC
+xSt
+bHv
+aab
 aaa
 aaa
 aaa
@@ -64419,7 +66393,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -64459,7 +66433,7 @@ vTV
 atP
 auB
 avq
-atP
+umd
 hLA
 vCh
 vCh
@@ -64587,31 +66561,31 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
 aab
 aaa
 aaa
 aaa
+cZm
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aab
+jeY
+xEp
+jeY
+bHv
+pgV
+rAe
+vbQ
+uad
+bHv
+aab
 aaa
 aaa
 aaa
@@ -64636,7 +66610,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -64676,7 +66650,7 @@ hLA
 atP
 auA
 avn
-atP
+umd
 vTV
 vCh
 arM
@@ -64804,31 +66778,31 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
 aab
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aab
+qOl
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+hqP
+fqj
+hqP
+bHv
+pkI
+rKr
+voK
+dFp
+bHv
+aab
 aaa
 aaa
 aaa
@@ -64853,7 +66827,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -64893,7 +66867,7 @@ hLA
 adZ
 auD
 jKb
-adZ
+oTw
 ptP
 dnl
 arM
@@ -65021,31 +66995,31 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
 aab
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aab
+fqj
+hqP
+hqP
+hqP
+hqP
+hqP
+hqP
+hqP
+hqP
+hqP
+hqP
+hqP
+fqj
+hqP
+bHv
+pgV
+rYD
+vuE
+gXn
+bHv
+aab
 aaa
 aaa
 aaa
@@ -65070,7 +67044,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -65108,7 +67082,7 @@ vCh
 vCh
 hLA
 adZ
-adZ
+oTw
 adZ
 adZ
 ptP
@@ -65238,31 +67212,31 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
 aab
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aab
+fqj
+hqP
+hqP
+hqP
+hqP
+hqP
+hqP
+hqP
+hqP
+hqP
+hqP
+hqP
+fqj
+hqP
+bHv
+pst
+rhf
+vxE
+uad
+bHv
+aab
 aaa
 aaa
 aaa
@@ -65287,7 +67261,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -65325,7 +67299,7 @@ vCh
 dnl
 dnl
 ptP
-ptP
+wFw
 ptP
 ptP
 dnl
@@ -65455,31 +67429,31 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
 aab
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aab
+fqj
+hqP
+hqP
+hqP
+hqP
+hqP
+hqP
+hqP
+hqP
+hqP
+hqP
+hqP
+fqj
+hqP
+bHv
+pAs
+shI
+vzg
+uad
+bHv
+aab
 aaa
 aaa
 aaa
@@ -65504,7 +67478,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -65542,7 +67516,7 @@ dnl
 dnl
 dnl
 dnl
-dnl
+sAq
 dnl
 dnl
 dnl
@@ -65672,31 +67646,31 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
 aab
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aab
+fqj
+hqP
+hqP
+hqP
+bHv
+bHv
+bHv
+bHv
+bHv
+bHv
+xJp
+xJp
+aPo
+xJp
+bHv
+oZb
+rdw
+vFE
+xRF
+bHv
+aab
 aaa
 aaa
 aaa
@@ -65721,7 +67695,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -65759,7 +67733,7 @@ dnl
 dnl
 dnl
 dnl
-dnl
+sAq
 dnl
 dnl
 dnl
@@ -65889,31 +67863,31 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
 aab
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aab
+fqj
+hqP
+hqP
+hqP
+bHv
+dzW
+eCh
+eCh
+eCh
+hia
+igD
+juh
+kbu
+igD
+bHv
+pgV
+sBJ
+vWM
+uad
+bHv
+aab
 aaa
 aaa
 aaa
@@ -65938,7 +67912,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 ptp
@@ -65976,7 +67950,7 @@ dnl
 dnl
 dnl
 dnl
-dnl
+sAq
 dnl
 dnl
 dnl
@@ -66106,31 +68080,31 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
 aab
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aab
+fqj
+hqP
+hqP
+hqP
+bHv
+dFO
+eKa
+eKa
+fQH
+bHv
+igK
+juu
+emA
+lgV
+bHv
+pgV
+sCz
+vYr
+ccx
+bHv
+aab
 aaa
 aaa
 aaa
@@ -66155,7 +68129,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -66187,13 +68161,13 @@ vCh
 vCh
 vCh
 kKe
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
-dnl
+sAq
+sAq
+sAq
+sAq
+sAq
+sAq
+sAq
 dnl
 dnl
 dnl
@@ -66323,31 +68297,31 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
 aab
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aab
+fqj
+hqP
+hqP
+hqP
+bHv
+dLF
+eKa
+eKa
+gfc
+pNt
+ijF
+juU
+kbu
+lpn
+bHv
+pEd
+qDZ
+utr
+uad
+bHv
+aab
 aaa
 aaa
 aaa
@@ -66372,7 +68346,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -66404,7 +68378,7 @@ vCh
 vCh
 kKe
 dnl
-dnl
+sAq
 dnl
 ptp
 ptp
@@ -66540,31 +68514,31 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
 aab
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aab
+fqj
+hqP
+xJp
+xJp
+bHv
+bHv
+bHv
+bHv
+bHv
+mFd
+xiw
+jAz
+kzI
+igD
+mDZ
+pgV
+sLI
+rdw
+nuE
+bHv
+aab
 aaa
 aaa
 aaa
@@ -66589,7 +68563,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -66621,7 +68595,7 @@ vCh
 dnl
 dnl
 dnl
-dnl
+sAq
 dnl
 ptp
 dnl
@@ -66757,31 +68731,31 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
 aab
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aab
+fqj
+hqP
+xJp
+osi
+hvr
+dPa
+eLI
+xJp
+xJp
+mFd
+det
+det
+det
+lqu
+bHv
+pgV
+riu
+wbU
+nQS
+bHv
+aab
 aaa
 aaa
 aaa
@@ -66806,7 +68780,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -66838,7 +68812,7 @@ dnl
 dnl
 dnl
 dnl
-dnl
+sAq
 dnl
 ptp
 dnl
@@ -66974,31 +68948,31 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
 aab
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aab
+fqj
+hqP
+xJp
+glf
+ipY
+ipY
+ipY
+eyz
+gok
+eyz
+iAa
+ipY
+kHY
+lrg
+bHv
+pgV
+sTE
+wpF
+uad
+bHv
+aab
 aaa
 aaa
 aaa
@@ -67023,7 +68997,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -67055,7 +69029,7 @@ dnl
 dnl
 dnl
 dnl
-dnl
+sAq
 dnl
 ptp
 dnl
@@ -67191,31 +69165,31 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
 aab
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aab
+fqj
+hqP
+xJp
+bTi
+rqU
+ipY
+ipY
+ePv
+gsZ
+ePv
+ipY
+ipY
+ipY
+ipY
+mFd
+oZb
+sVq
+sLI
+xRF
+bHv
+aab
 aaa
 aaa
 aaa
@@ -67240,7 +69214,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -67272,7 +69246,7 @@ dnl
 dnl
 dnl
 dnl
-dnl
+sAq
 dnl
 ptp
 vCh
@@ -67408,31 +69382,31 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
 aab
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aab
+fqj
+hqP
+aPo
+ceT
+det
+uqs
+det
+fIi
+gwV
+hjE
+nBy
+bKh
+det
+luM
+mFd
+pHZ
+sWk
+qDZ
+uad
+bHv
+aab
 aaa
 aaa
 aaa
@@ -67457,7 +69431,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -67489,7 +69463,7 @@ dnl
 dnl
 dnl
 dnl
-dnl
+sAq
 dnl
 ptp
 vCh
@@ -67625,31 +69599,31 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
 aab
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aab
+fqj
+hqP
+xJp
+cin
+ipY
+ipY
+ipY
+ePv
+gsZ
+ePv
+ipY
+ipY
+kXR
+lAi
+bHv
+pHZ
+tjb
+weF
+uad
+bHv
+aab
 aaa
 aaa
 aaa
@@ -67674,7 +69648,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -67706,7 +69680,7 @@ dnl
 dnl
 dnl
 dnl
-dnl
+sAq
 dnl
 ptp
 vCh
@@ -67842,31 +69816,31 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
 aab
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aab
+fqj
+hqP
+xJp
+coa
+ipY
+dYK
+ipY
+eyz
+gsZ
+eyz
+iJf
+jGP
+dYK
+ipY
+bHv
+tXf
+tjQ
+wff
+uad
+bHv
+aab
 aaa
 aaa
 aaa
@@ -67891,7 +69865,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -67923,7 +69897,7 @@ dnl
 dnl
 dnl
 dnl
-dnl
+sAq
 dnl
 ptp
 vCh
@@ -68059,31 +70033,31 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
 aab
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aab
+fqj
+hqP
+xJp
+xJp
+eyz
+eyz
+eyz
+eyz
+gsZ
+eyz
+eyz
+eyz
+eyz
+eyz
+mDZ
+pVl
+rdw
+wnO
+ePu
+bHv
+aab
 aaa
 aaa
 aaa
@@ -68108,7 +70082,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -68140,7 +70114,7 @@ dnl
 dnl
 dnl
 dnl
-dnl
+sAq
 dnl
 ptp
 vCh
@@ -68276,31 +70250,31 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
 aab
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aab
+fqj
+hqP
+sTd
+ipY
+dbi
+dbi
+dbi
+fcT
+gAX
+dbi
+dbi
+jKd
+dbi
+rhf
+mPE
+pVB
+tyD
+wpF
+uad
+bHv
+aab
 aaa
 aaa
 aaa
@@ -68325,7 +70299,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -68357,7 +70331,7 @@ dnl
 dnl
 dnl
 dnl
-dnl
+sAq
 dnl
 nvs
 vCh
@@ -68493,31 +70467,31 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
 aab
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aab
+fqj
+hqP
+sTd
+nVP
+lHD
+ipY
+ipY
+fnW
+gCH
+hwc
+hwc
+hwc
+eRD
+lFK
+ncd
+qbh
+rhf
+wpO
+smb
+bHv
+aab
 aaa
 aaa
 aaa
@@ -68542,7 +70516,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -68574,7 +70548,7 @@ dnl
 dnl
 dnl
 dnl
-dnl
+sAq
 dnl
 nvs
 vCh
@@ -68710,31 +70684,31 @@ jeY
 jeY
 jeY
 jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
-jeY
 aab
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aab
+fqj
+hqP
+sTd
+ipY
+ekE
+ekE
+ekE
+fse
+gLN
+hRb
+hRb
+ekE
+ekE
+rhf
+mPE
+qcC
+tAB
+wrk
+uad
+bHv
+aab
 aaa
 aaa
 aaa
@@ -68759,7 +70733,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -68791,7 +70765,7 @@ dnl
 dnl
 dnl
 dnl
-dnl
+sAq
 dnl
 ptp
 dnl
@@ -68928,30 +70902,30 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aab
+qOl
+aab
+xJp
+xJp
+eyz
+eli
+eyz
+eyz
+gZX
+eli
+eli
+eyz
+eyz
+ddi
+bHv
+qfQ
+tCQ
+vuE
+uad
+bHv
+aab
 aaa
 aaa
 aaa
@@ -68976,7 +70950,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -69008,7 +70982,7 @@ dnl
 dnl
 dnl
 dnl
-dnl
+sAq
 dnl
 ptp
 dnl
@@ -69148,27 +71122,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cZm
+aab
+xJp
+cBo
+deb
+eoX
+eMX
+eli
+gZX
+eli
+iKL
+ipY
+lgf
+lNk
+bHv
+qgz
+tDh
+wBY
+uad
+bHv
+aab
 aaa
 aaa
 aaa
@@ -69193,7 +71167,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -69225,7 +71199,7 @@ dnl
 dnl
 dnl
 dnl
-dnl
+sAq
 dnl
 ptp
 dnl
@@ -69365,27 +71339,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cZm
+aab
+xJp
+cHL
+det
+euF
+vlA
+fAC
+gZX
+fAC
+ipY
+ipY
+rqU
+lPS
+bHv
+pgV
+vbQ
+bRs
+lBJ
+bHv
+aab
 aaa
 aaa
 aaa
@@ -69410,7 +71384,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -69442,7 +71416,7 @@ dnl
 dnl
 dnl
 dnl
-dnl
+sAq
 dnl
 ptp
 ptp
@@ -69582,27 +71556,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cZm
+aab
+xJp
+cLi
+dhn
+ipY
+ipY
+fIi
+scd
+hSh
+det
+uqs
+det
+lZp
+mFd
+pgV
+tHW
+wKg
+uad
+bHv
+aab
 aaa
 aaa
 aaa
@@ -69627,7 +71601,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -69659,7 +71633,7 @@ dnl
 dnl
 dnl
 dnl
-dnl
+sAq
 dnl
 dnl
 dnl
@@ -69799,27 +71773,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cZm
+aab
+xJp
+cMC
+fuB
+lHD
+ipY
+fAC
+gZX
+hTI
+rqU
+ekC
+ipY
+mrL
+bHv
+pgV
+tLL
+xiz
+nuE
+bHv
+aab
 aaa
 aaa
 aaa
@@ -69844,7 +71818,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -69876,7 +71850,7 @@ dnl
 dnl
 dnl
 dnl
-dnl
+sAq
 dnl
 dnl
 dnl
@@ -70016,27 +71990,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cZm
+aab
+xJp
+cTg
+dyQ
+exf
+exf
+eli
+hgL
+hVy
+jkn
+ipY
+lgt
+mrL
+bHv
+qnf
+ucI
+xjA
+hgw
+bHv
+aab
 aaa
 aaa
 aaa
@@ -70061,7 +72035,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -70093,7 +72067,7 @@ dnl
 dnl
 dnl
 dnl
-dnl
+sAq
 dnl
 dnl
 dnl
@@ -70233,27 +72207,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cZm
+aab
+xJp
+xJp
+xJp
+xJp
+xJp
+xJp
+xJp
+xJp
+jpN
+jMk
+lgt
+mwK
+bHv
+quA
+upn
+xlj
+qJF
+bHv
+aab
 aaa
 aaa
 aaa
@@ -70278,7 +72252,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cZm
 aaa
 aab
 dnl
@@ -70310,7 +72284,7 @@ dnl
 dnl
 dnl
 dnl
-dnl
+sAq
 dnl
 dnl
 dnl
@@ -70450,27 +72424,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cZm
+aab
+bHv
+bHv
+bHv
+bHv
+bHv
+bHv
+bHv
+bHv
+bHv
+bHv
+bHv
+bHv
+bHv
+bHv
+bHv
+bHv
+bHv
+bHv
+aab
 aaa
 aaa
 aaa
@@ -70495,9 +72469,8 @@ aaa
 aaa
 aaa
 aaa
+cZm
 aaa
-aaa
-aab
 aab
 aab
 aab
@@ -70528,6 +72501,7 @@ aab
 aab
 aab
 aab
+qOl
 aab
 aab
 aab
@@ -70584,25 +72558,6 @@ aab
 aab
 aab
 aab
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -70686,8 +72641,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+cZm
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
 aaa
 aaa
 aaa
@@ -70712,179 +72686,179 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
+cZm
 aaa
 aaa
 aaa

--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -3989,15 +3989,6 @@
 /obj/structure/rack,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/general_offices)
-"aoD" = (
-/obj/machinery/door/airlock/mainship/maint{
-	dir = 2
-	},
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "aoE" = (
 /obj/item/stool,
 /obj/structure/cable,
@@ -13810,15 +13801,6 @@
 	dir = 8
 	},
 /area/bigredv2/outside/cargo)
-"bey" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "bez" = (
 /obj/machinery/autolathe,
 /turf/open/floor,
@@ -17166,14 +17148,6 @@
 	dir = 1
 	},
 /area/bigredv2/outside/sw)
-"buT" = (
-/obj/effect/landmark/weed_node,
-/obj/structure/cable,
-/turf/open/floor/prison/darkred/full,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "buV" = (
 /obj/machinery/light,
 /turf/open/floor/plating,
@@ -19345,13 +19319,6 @@
 "bHv" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/space)
-"bIZ" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/mainship/sterile/dark,
-/area/bigredv2/caves/lambda_lab{
-	icon_state = "anospectro";
-	name = "Theta Lab"
-	})
 "bLJ" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/mars/random/cave,

--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -400,7 +400,7 @@
 	dir = 8
 	},
 /turf/open/floor/asteroidfloor,
-/area/space)
+/area/bigredv2/outside/space_port)
 "abD" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/plating,
@@ -2624,9 +2624,6 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
-"ajT" = (
-/turf/closed/wall/r_wall,
-/area/bigredv2/caves/northwest)
 "ajU" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -20590,7 +20587,7 @@
 /obj/structure/rack,
 /obj/item/stack/sheet/plasteel/medium_stack,
 /turf/open/floor/plating/plating_catwalk,
-/area/bigredv2/caves/northwest)
+/area/bigredv2/outside/space_port)
 "gSH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/corpsespawner/doctor,
@@ -20727,7 +20724,7 @@
 "huI" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall/unmeltable,
-/area/bigredv2/caves/northwest)
+/area/bigredv2/outside/space_port)
 "hvr" = (
 /obj/structure/rack,
 /obj/item/weapon/gun/rifle/m16,
@@ -21014,7 +21011,7 @@
 /area/bigredv2/caves/southeast)
 "iKB" = (
 /turf/closed/wall/r_wall/unmeltable,
-/area/bigredv2/caves/northwest)
+/area/bigredv2/outside/space_port)
 "iKL" = (
 /obj/structure/largecrate/machine,
 /turf/open/floor/tile/dark,
@@ -21261,7 +21258,7 @@
 /obj/item/storage/box/explosive_mines,
 /obj/structure/cable,
 /turf/open/shuttle/elevator/grating,
-/area/bigredv2/caves/northwest)
+/area/bigredv2/outside/space_port)
 "jZz" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 5
@@ -21541,7 +21538,7 @@
 /obj/structure/cable,
 /obj/item/storage/box/sentry,
 /turf/open/shuttle/elevator/grating,
-/area/bigredv2/caves/northwest)
+/area/bigredv2/outside/space_port)
 "loj" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/engine/cult,
@@ -21892,7 +21889,7 @@
 /obj/item/ammo_magazine/shotgun/incendiary,
 /obj/item/ammo_magazine/shotgun/incendiary,
 /turf/open/shuttle/elevator/grating,
-/area/bigredv2/caves/northwest)
+/area/bigredv2/outside/space_port)
 "mSl" = (
 /obj/structure/cable,
 /obj/structure/largecrate/random/barrel/blue,
@@ -21926,7 +21923,7 @@
 /obj/structure/cable,
 /obj/structure/largecrate/supply/supplies/mre,
 /turf/open/shuttle/elevator/grating,
-/area/bigredv2/caves/northwest)
+/area/bigredv2/outside/space_port)
 "nbw" = (
 /obj/structure/prop/mainship/mission_planning_system,
 /turf/open/shuttle/escapepod,
@@ -22606,7 +22603,7 @@
 	name = "Secure window"
 	},
 /turf/open/floor/tile/dark,
-/area/bigredv2/caves/northwest)
+/area/bigredv2/outside/space_port)
 "pYh" = (
 /obj/effect/landmark/xeno_resin_door,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -22952,9 +22949,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/general_offices)
-"raF" = (
-/turf/open/floor/asteroidfloor,
-/area/space)
 "rdd" = (
 /obj/structure/table,
 /obj/item/trash/tray,
@@ -23068,9 +23062,6 @@
 	dir = 1
 	},
 /area/bigredv2/caves/lambda_lab)
-"rJW" = (
-/turf/open/floor/asteroidfloor,
-/area/bigredv2/caves/northwest)
 "rKr" = (
 /obj/structure/barricade/metal{
 	dir = 8
@@ -23118,7 +23109,7 @@
 	dir = 1
 	},
 /turf/open/floor/asteroidfloor,
-/area/bigredv2/caves/northwest)
+/area/bigredv2/outside/space_port)
 "rQB" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -23376,7 +23367,7 @@
 /area/bigredv2/caves/southeast)
 "tfF" = (
 /turf/open/shuttle/elevator/grating,
-/area/bigredv2/caves/northwest)
+/area/bigredv2/outside/space_port)
 "tjQ" = (
 /obj/effect/decal/cleanable/blood/gibs/up,
 /turf/open/floor/tile/dark2,
@@ -23819,7 +23810,7 @@
 "vgq" = (
 /obj/structure/cable,
 /turf/open/shuttle/elevator/grating,
-/area/bigredv2/caves/northwest)
+/area/bigredv2/outside/space_port)
 "vhj" = (
 /obj/effect/landmark/weed_node,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -24004,9 +23995,6 @@
 	},
 /turf/open/floor/wood,
 /area/bigredv2/outside/library)
-"vWE" = (
-/turf/closed/mineral/bigred,
-/area/space)
 "vWM" = (
 /obj/item/ammo_casing/shell,
 /obj/item/ammo_casing/bullet,
@@ -24035,7 +24023,7 @@
 /area/bigredv2/caves/south)
 "wdL" = (
 /turf/open/floor/plating/plating_catwalk,
-/area/bigredv2/caves/northwest)
+/area/bigredv2/outside/space_port)
 "weF" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/tile/dark2,
@@ -25167,9 +25155,9 @@ tku
 aac
 aac
 aac
-vWE
-vWE
-vWE
+aac
+aac
+aac
 aac
 aac
 aac
@@ -25384,9 +25372,9 @@ tku
 aac
 aac
 aac
-vWE
-vWE
-vWE
+aac
+aac
+aac
 aac
 aac
 aac
@@ -25601,9 +25589,9 @@ aac
 aac
 aac
 aac
-vWE
-vWE
-vWE
+aac
+aac
+aac
 aac
 aac
 aac
@@ -26038,7 +26026,7 @@ aac
 aac
 aac
 aac
-vWE
+aac
 aac
 ktH
 aac
@@ -27120,12 +27108,12 @@ aac
 aac
 aac
 ktH
-vWE
-vWE
-vWE
-vWE
-vWE
-vWE
+aac
+aac
+aac
+aac
+aac
+aac
 aac
 huI
 wdL
@@ -27337,12 +27325,12 @@ aac
 aac
 aac
 ktH
-vWE
-vWE
-vWE
-vWE
-vwf
-vWE
+aac
+aac
+aac
+aac
+aac
+aac
 aac
 huI
 pXc
@@ -27554,15 +27542,15 @@ aac
 aac
 aac
 ktH
-vWE
-vWE
-vWE
-vWE
-vwf
-vWE
 aac
-ajT
-rJW
+aac
+aac
+aac
+aac
+aac
+aac
+aae
+aaf
 aaf
 aaf
 gkA
@@ -27771,14 +27759,14 @@ aac
 aac
 aac
 ktH
-vWE
-vWE
-vWE
-vWE
-vwf
-vWE
 aac
-ajT
+aac
+aac
+aac
+aac
+aac
+aac
+aae
 rPj
 aaf
 aaf
@@ -27988,15 +27976,15 @@ aac
 aac
 aac
 ktH
-oCk
 aae
 aae
 aae
 aae
-oCk
-ajT
-ajT
-rJW
+aae
+aae
+aae
+aae
+aaf
 aaf
 aaf
 aas
@@ -28205,12 +28193,12 @@ aac
 aac
 aac
 ktH
-oCk
-raF
+aae
+aaf
 aaf
 aaf
 abC
-raF
+aaf
 aaf
 aaf
 aaf


### PR DESCRIPTION
## About The Pull Request

Adds more buildings and some features to big red.

## Why It's Good For The Game

This gives marines a reason to explore the map to access new storage of supplies in LZ1 as well as to access an underground Nanotrasen facility. This gives a nice RP addition to it and hopefully won't just mean marines rush Xenos. Xenos gains access quickly via lambda to this underground facility or at least most of it as only marines can access the other entrance without Xeno interruption. the underground facility allows Xenos a silo/hive spot that makes more sense but at the same time, they have less freedom to flee or run so it needs to be protected well. 

I think the players will really enjoy the process and cosmetic feel of the new additions. Both entrances cannot be camped as the main marine one has a large hangar door that won't allow Xenos access inside. though it should prove a challenge to combat a prepared smart hive.

Also, an issue we currently have is that most of the big maps are not used, I hope to change that slowly but surely so we all have more fun. I do plan to continue adding changes to Big Red as I learn how to code better for instance a third underground chamber and a revamp of how the facility is accessed.


## Changelog
:cl:
fix: weird blue and green cargo container glitch

add: a small miner building in north caves

add: supply chamber in lz1 that can't be accessed until button in eta lab directors office is activated

add: button in eta lab directors office that can only be used by field commander or higher via their id card

add: a building that leads to an underground facility that cannot easily be accessed by marines until the button in eta lab director's office is activated. though a good enough marine squad can use the lambda Xeno entrance that is always open.

add: medium size underground facility

add: lambda entrance to the underground facility
/:cl:

images


![Theta lab](https://user-images.githubusercontent.com/64131993/128393058-15cc1220-b098-4fd4-bd7a-a7fe58264709.png)
