### PR TITLE
Neurotoxic Spit Tweaks.

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1729,23 +1729,23 @@ datum/ammo/bullet/revolver/tp44
 
 /datum/ammo/xeno/toxin/heavy //Praetorian
 	name = "neurotoxic splash"
-	added_spit_delay = 13
-	spit_cost = 120
+	added_spit_delay = 0
+	spit_cost = 200
 	damage = 50
-	smoke_strength = 0.75
-	reagent_transfer_amount = 9
+	smoke_strength = 0.8
+	reagent_transfer_amount = 15
 
 /datum/ammo/xeno/toxin/heavy/upgrade1
-	smoke_strength = 0.8
-	reagent_transfer_amount = 10
-
-/datum/ammo/xeno/toxin/heavy/upgrade2
-	smoke_strength = 0.9
+	smoke_strength = 0.85
 	reagent_transfer_amount = 10.5
 
-/datum/ammo/xeno/toxin/heavy/upgrade3
-	smoke_strength = 1
+/datum/ammo/xeno/toxin/heavy/upgrade2
+	smoke_strength = 0.95
 	reagent_transfer_amount = 11
+
+/datum/ammo/xeno/toxin/heavy/upgrade3
+	smoke_strength = 1.5
+	reagent_transfer_amount = 11.5
 
 
 /datum/ammo/xeno/sticky

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1621,19 +1621,19 @@ datum/ammo/bullet/revolver/tp44
 /datum/ammo/xeno/toxin
 	name = "neurotoxic spit"
 	flags_ammo_behavior = AMMO_XENO|AMMO_EXPLOSIVE|AMMO_SKIPS_ALIENS
-	spit_cost = 70
-	added_spit_delay = 3
+	spit_cost = 60
+	added_spit_delay = 0
 	damage_type = STAMINA
 	accurate_range = 5
 	max_range = 10
 	accuracy_var_low = 3
 	accuracy_var_high = 3
-	damage = 45
+	damage = 50
 	stagger_stacks = 1.5
 	slowdown_stacks = 1.5
 	smoke_strength = 0.5
 	smoke_range = 0
-	reagent_transfer_amount = 8
+	reagent_transfer_amount = 9
 
 ///Set up the list of reagents the spit transfers upon impact
 /datum/ammo/xeno/toxin/proc/set_reagents()
@@ -1696,15 +1696,15 @@ datum/ammo/bullet/revolver/tp44
 
 /datum/ammo/xeno/toxin/upgrade1
 	smoke_strength = 0.6
-	reagent_transfer_amount = 8.5
+	reagent_transfer_amount = 9
 
 /datum/ammo/xeno/toxin/upgrade2
 	smoke_strength = 0.7
-	reagent_transfer_amount = 9
+	reagent_transfer_amount = 9.5
 
 /datum/ammo/xeno/toxin/upgrade3
 	smoke_strength = 0.8
-	reagent_transfer_amount = 9.5
+	reagent_transfer_amount = 10
 
 /datum/ammo/xeno/toxin/medium //Queen
 	name = "neurotoxic spatter"
@@ -1731,21 +1731,21 @@ datum/ammo/bullet/revolver/tp44
 	name = "neurotoxic splash"
 	added_spit_delay = 0
 	spit_cost = 150
-	damage = 40
-	smoke_strength = 0.8
-	reagent_transfer_amount = 9
-
-/datum/ammo/xeno/toxin/heavy/upgrade1
-	smoke_strength = 0.85
+	damage = 55
+	smoke_strength = 0.9
 	reagent_transfer_amount = 9.5
 
-/datum/ammo/xeno/toxin/heavy/upgrade2
-	smoke_strength = 0.95
+/datum/ammo/xeno/toxin/heavy/upgrade1
+	smoke_strength = 1
 	reagent_transfer_amount = 10
 
+/datum/ammo/xeno/toxin/heavy/upgrade2
+	smoke_strength = 1.05
+	reagent_transfer_amount = 10.5
+
 /datum/ammo/xeno/toxin/heavy/upgrade3
-	smoke_strength = 1
-	reagent_transfer_amount = 10.5  
+	smoke_strength = 1.1
+	reagent_transfer_amount = 11  
 
 
 /datum/ammo/xeno/sticky

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1621,19 +1621,19 @@ datum/ammo/bullet/revolver/tp44
 /datum/ammo/xeno/toxin
 	name = "neurotoxic spit"
 	flags_ammo_behavior = AMMO_XENO|AMMO_EXPLOSIVE|AMMO_SKIPS_ALIENS
-	spit_cost = 50
+	spit_cost = 70
 	added_spit_delay = 5
 	damage_type = STAMINA
 	accurate_range = 5
 	max_range = 10
 	accuracy_var_low = 3
 	accuracy_var_high = 3
-	damage = 30
+	damage = 40
 	stagger_stacks = 1
 	slowdown_stacks = 1
 	smoke_strength = 0.5
 	smoke_range = 0
-	reagent_transfer_amount = 6.5
+	reagent_transfer_amount = 7
 
 ///Set up the list of reagents the spit transfers upon impact
 /datum/ammo/xeno/toxin/proc/set_reagents()
@@ -1695,58 +1695,57 @@ datum/ammo/bullet/revolver/tp44
 	smoke_system.start()
 
 /datum/ammo/xeno/toxin/upgrade1
-	smoke_strength = 0.55
-	reagent_transfer_amount = 7
-
-/datum/ammo/xeno/toxin/upgrade2
 	smoke_strength = 0.6
-	reagent_transfer_amount = 7.5
-
-/datum/ammo/xeno/toxin/upgrade3
-	smoke_strength = 0.65
 	reagent_transfer_amount = 8
 
+/datum/ammo/xeno/toxin/upgrade2
+	smoke_strength = 0.7
+	reagent_transfer_amount = 8.5
+
+/datum/ammo/xeno/toxin/upgrade3
+	smoke_strength = 0.8
+	reagent_transfer_amount = 9
 
 /datum/ammo/xeno/toxin/medium //Queen
 	name = "neurotoxic spatter"
 	added_spit_delay = 10
-	spit_cost = 75
-	damage = 35
-	smoke_strength = 0.6
-	reagent_transfer_amount = 7.5
-
-/datum/ammo/xeno/toxin/medium/upgrade1
-	smoke_strength = 0.65
+	spit_cost = 85
+	damage = 45
+	smoke_strength = 0.7
 	reagent_transfer_amount = 8
 
-/datum/ammo/xeno/toxin/medium/upgrade2
-	smoke_strength = 0.7
+/datum/ammo/xeno/toxin/medium/upgrade1
+	smoke_strength = 0.75
 	reagent_transfer_amount = 8.5
 
-/datum/ammo/xeno/toxin/medium/upgrade3
-	smoke_strength = 0.75
+/datum/ammo/xeno/toxin/medium/upgrade2
+	smoke_strength = 0.8
 	reagent_transfer_amount = 9
+
+/datum/ammo/xeno/toxin/medium/upgrade3
+	smoke_strength = 0.85
+	reagent_transfer_amount = 9.5
 
 
 /datum/ammo/xeno/toxin/heavy //Praetorian
 	name = "neurotoxic splash"
-	added_spit_delay = 15
-	spit_cost = 100
-	damage = 40
-	smoke_strength = 0.65
-	reagent_transfer_amount = 8.5
-
-/datum/ammo/xeno/toxin/heavy/upgrade1
-	smoke_strength = 0.7
+	added_spit_delay = 13
+	spit_cost = 120
+	damage = 50
+	smoke_strength = 0.75
 	reagent_transfer_amount = 9
 
-/datum/ammo/xeno/toxin/heavy/upgrade2
-	smoke_strength = 0.75
-	reagent_transfer_amount = 9.5
-
-/datum/ammo/xeno/toxin/heavy/upgrade3
+/datum/ammo/xeno/toxin/heavy/upgrade1
 	smoke_strength = 0.8
 	reagent_transfer_amount = 10
+
+/datum/ammo/xeno/toxin/heavy/upgrade2
+	smoke_strength = 0.9
+	reagent_transfer_amount = 10.5
+
+/datum/ammo/xeno/toxin/heavy/upgrade3
+	smoke_strength = 0.10
+	reagent_transfer_amount = 11
 
 
 /datum/ammo/xeno/sticky
@@ -2079,7 +2078,7 @@ datum/ammo/bullet/revolver/tp44
 	name = "flare"
 	ping = null //no bounce off.
 	damage_type = BURN
-	flags_ammo_behavior = AMMO_INCENDIARY
+	flags_ammo_behavior = AMMO_EXPLOSIVE|AMMO_INCENDIARY
 	damage = 15
 	accuracy = 15
 	max_range = 15

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -2078,7 +2078,7 @@ datum/ammo/bullet/revolver/tp44
 	name = "flare"
 	ping = null //no bounce off.
 	damage_type = BURN
-	flags_ammo_behavior = AMMO_EXPLOSIVE|AMMO_INCENDIARY
+	flags_ammo_behavior = AMMO_INCENDIARY
 	damage = 15
 	accuracy = 15
 	max_range = 15

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1622,18 +1622,18 @@ datum/ammo/bullet/revolver/tp44
 	name = "neurotoxic spit"
 	flags_ammo_behavior = AMMO_XENO|AMMO_EXPLOSIVE|AMMO_SKIPS_ALIENS
 	spit_cost = 70
-	added_spit_delay = 5
+	added_spit_delay = 3
 	damage_type = STAMINA
 	accurate_range = 5
 	max_range = 10
 	accuracy_var_low = 3
 	accuracy_var_high = 3
-	damage = 40
-	stagger_stacks = 1
-	slowdown_stacks = 1
+	damage = 450
+	stagger_stacks = 1.5
+	slowdown_stacks = 1.5
 	smoke_strength = 0.5
 	smoke_range = 0
-	reagent_transfer_amount = 7
+	reagent_transfer_amount = 8
 
 ///Set up the list of reagents the spit transfers upon impact
 /datum/ammo/xeno/toxin/proc/set_reagents()
@@ -1696,15 +1696,15 @@ datum/ammo/bullet/revolver/tp44
 
 /datum/ammo/xeno/toxin/upgrade1
 	smoke_strength = 0.6
-	reagent_transfer_amount = 8
+	reagent_transfer_amount = 8.5
 
 /datum/ammo/xeno/toxin/upgrade2
 	smoke_strength = 0.7
-	reagent_transfer_amount = 8.5
+	reagent_transfer_amount = 9
 
 /datum/ammo/xeno/toxin/upgrade3
 	smoke_strength = 0.8
-	reagent_transfer_amount = 9
+	reagent_transfer_amount = 9.5
 
 /datum/ammo/xeno/toxin/medium //Queen
 	name = "neurotoxic spatter"
@@ -1712,19 +1712,19 @@ datum/ammo/bullet/revolver/tp44
 	spit_cost = 85
 	damage = 45
 	smoke_strength = 0.7
-	reagent_transfer_amount = 8
+	reagent_transfer_amount = 8.5
 
 /datum/ammo/xeno/toxin/medium/upgrade1
 	smoke_strength = 0.75
-	reagent_transfer_amount = 8.5
+	reagent_transfer_amount = 9
 
 /datum/ammo/xeno/toxin/medium/upgrade2
 	smoke_strength = 0.8
-	reagent_transfer_amount = 9
+	reagent_transfer_amount = 9.5
 
 /datum/ammo/xeno/toxin/medium/upgrade3
 	smoke_strength = 0.85
-	reagent_transfer_amount = 9.5
+	reagent_transfer_amount = 10
 
 
 /datum/ammo/xeno/toxin/heavy //Praetorian

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1705,6 +1705,25 @@ datum/ammo/bullet/revolver/tp44
 /datum/ammo/xeno/toxin/upgrade3
 	smoke_strength = 0.8
 	reagent_transfer_amount = 10
+	/datum/ammo/xeno/toxin/medium //Queen
+	name = "neurotoxic spatter"
+	added_spit_delay = 10
+	spit_cost = 85
+	damage = 45
+	smoke_strength = 0.7
+	reagent_transfer_amount = 8.5
+
+/datum/ammo/xeno/toxin/medium/upgrade1
+	smoke_strength = 0.75
+	reagent_transfer_amount = 9
+
+/datum/ammo/xeno/toxin/medium/upgrade2
+	smoke_strength = 0.8
+	reagent_transfer_amount = 9.5
+
+/datum/ammo/xeno/toxin/medium/upgrade3
+	smoke_strength = 0.85
+	reagent_transfer_amount = 10
 
 /datum/ammo/xeno/toxin/heavy //Praetorian
 	name = "neurotoxic splash"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1730,22 +1730,22 @@ datum/ammo/bullet/revolver/tp44
 /datum/ammo/xeno/toxin/heavy //Praetorian
 	name = "neurotoxic splash"
 	added_spit_delay = 0
-	spit_cost = 150
-	damage = 55
+	spit_cost = 120
+	damage = 40
 	smoke_strength = 0.9
 	reagent_transfer_amount = 9.5
 
 /datum/ammo/xeno/toxin/heavy/upgrade1
-	smoke_strength = 1
-	reagent_transfer_amount = 10
+	smoke_strength = 0.9
+	reagent_transfer_amount = 9
 
 /datum/ammo/xeno/toxin/heavy/upgrade2
-	smoke_strength = 1.05
-	reagent_transfer_amount = 10.5
+	smoke_strength = 0.95
+	reagent_transfer_amount = 9.5
 
 /datum/ammo/xeno/toxin/heavy/upgrade3
-	smoke_strength = 1.1
-	reagent_transfer_amount = 11  
+	smoke_strength = 1
+	reagent_transfer_amount = 10  
 
 
 /datum/ammo/xeno/sticky

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1731,7 +1731,7 @@ datum/ammo/bullet/revolver/tp44
 	name = "neurotoxic splash"
 	added_spit_delay = 0
 	spit_cost = 200
-	damage = 45
+	damage = 40
 	smoke_strength = 0.8
 	reagent_transfer_amount = 9
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1621,16 +1621,16 @@ datum/ammo/bullet/revolver/tp44
 /datum/ammo/xeno/toxin
 	name = "neurotoxic spit"
 	flags_ammo_behavior = AMMO_XENO|AMMO_EXPLOSIVE|AMMO_SKIPS_ALIENS
-	spit_cost = 60
+	spit_cost = 70
 	added_spit_delay = 0
 	damage_type = STAMINA
 	accurate_range = 5
 	max_range = 10
 	accuracy_var_low = 3
 	accuracy_var_high = 3
-	damage = 50
-	stagger_stacks = 1.5
-	slowdown_stacks = 1.5
+	damage = 40
+	stagger_stacks = 1.1
+	slowdown_stacks = 1.1
 	smoke_strength = 0.5
 	smoke_range = 0
 	reagent_transfer_amount = 9

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1730,8 +1730,8 @@ datum/ammo/bullet/revolver/tp44
 /datum/ammo/xeno/toxin/heavy //Praetorian
 	name = "neurotoxic splash"
 	added_spit_delay = 0
-	spit_cost = 200
-	damage = 40
+	spit_cost = 150
+	damage = 50
 	smoke_strength = 0.8
 	reagent_transfer_amount = 9
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1702,28 +1702,6 @@ datum/ammo/bullet/revolver/tp44
 	smoke_strength = 0.7
 	reagent_transfer_amount = 9.5
 
-/datum/ammo/xeno/toxin/upgrade3
-	smoke_strength = 0.8
-	reagent_transfer_amount = 10
-	/datum/ammo/xeno/toxin/medium //Queen
-	name = "neurotoxic spatter"
-	added_spit_delay = 10
-	spit_cost = 85
-	damage = 45
-	smoke_strength = 0.7
-	reagent_transfer_amount = 8.5
-
-/datum/ammo/xeno/toxin/medium/upgrade1
-	smoke_strength = 0.75
-	reagent_transfer_amount = 9
-
-/datum/ammo/xeno/toxin/medium/upgrade2
-	smoke_strength = 0.8
-	reagent_transfer_amount = 9.5
-
-/datum/ammo/xeno/toxin/medium/upgrade3
-	smoke_strength = 0.85
-	reagent_transfer_amount = 10
 
 /datum/ammo/xeno/toxin/heavy //Praetorian
 	name = "neurotoxic splash"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1706,27 +1706,6 @@ datum/ammo/bullet/revolver/tp44
 	smoke_strength = 0.8
 	reagent_transfer_amount = 10
 
-/datum/ammo/xeno/toxin/medium //Queen
-	name = "neurotoxic spatter"
-	added_spit_delay = 10
-	spit_cost = 85
-	damage = 45
-	smoke_strength = 0.7
-	reagent_transfer_amount = 8.5
-
-/datum/ammo/xeno/toxin/medium/upgrade1
-	smoke_strength = 0.75
-	reagent_transfer_amount = 9
-
-/datum/ammo/xeno/toxin/medium/upgrade2
-	smoke_strength = 0.8
-	reagent_transfer_amount = 9.5
-
-/datum/ammo/xeno/toxin/medium/upgrade3
-	smoke_strength = 0.85
-	reagent_transfer_amount = 10
-
-
 /datum/ammo/xeno/toxin/heavy //Praetorian
 	name = "neurotoxic splash"
 	added_spit_delay = 0

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1633,7 +1633,7 @@ datum/ammo/bullet/revolver/tp44
 	slowdown_stacks = 1.1
 	smoke_strength = 0.5
 	smoke_range = 0
-	reagent_transfer_amount = 9
+	reagent_transfer_amount = 7
 
 ///Set up the list of reagents the spit transfers upon impact
 /datum/ammo/xeno/toxin/proc/set_reagents()
@@ -1696,10 +1696,14 @@ datum/ammo/bullet/revolver/tp44
 
 /datum/ammo/xeno/toxin/upgrade1
 	smoke_strength = 0.6
-	reagent_transfer_amount = 9
+	reagent_transfer_amount = 8
 
 /datum/ammo/xeno/toxin/upgrade2
 	smoke_strength = 0.7
+	reagent_transfer_amount = 9
+	
+/datum/ammo/xeno/toxin/upgrade3
+	smoke_strength = 0.75
 	reagent_transfer_amount = 9.5
 
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1731,21 +1731,21 @@ datum/ammo/bullet/revolver/tp44
 	name = "neurotoxic splash"
 	added_spit_delay = 0
 	spit_cost = 200
-	damage = 50
+	damage = 45
 	smoke_strength = 0.8
-	reagent_transfer_amount = 15
+	reagent_transfer_amount = 9
 
 /datum/ammo/xeno/toxin/heavy/upgrade1
 	smoke_strength = 0.85
-	reagent_transfer_amount = 10.5
+	reagent_transfer_amount = 10
 
 /datum/ammo/xeno/toxin/heavy/upgrade2
 	smoke_strength = 0.95
-	reagent_transfer_amount = 11
+	reagent_transfer_amount = 10.5
 
 /datum/ammo/xeno/toxin/heavy/upgrade3
 	smoke_strength = 1.5
-	reagent_transfer_amount = 11.5
+	reagent_transfer_amount = 11
 
 
 /datum/ammo/xeno/sticky

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1744,7 +1744,7 @@ datum/ammo/bullet/revolver/tp44
 	reagent_transfer_amount = 10.5
 
 /datum/ammo/xeno/toxin/heavy/upgrade3
-	smoke_strength = 0.10
+	smoke_strength = 1
 	reagent_transfer_amount = 11
 
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1628,7 +1628,7 @@ datum/ammo/bullet/revolver/tp44
 	max_range = 10
 	accuracy_var_low = 3
 	accuracy_var_high = 3
-	damage = 450
+	damage = 45
 	stagger_stacks = 1.5
 	slowdown_stacks = 1.5
 	smoke_strength = 0.5
@@ -1731,21 +1731,21 @@ datum/ammo/bullet/revolver/tp44
 	name = "neurotoxic splash"
 	added_spit_delay = 0
 	spit_cost = 150
-	damage = 50
+	damage = 40
 	smoke_strength = 0.8
 	reagent_transfer_amount = 9
 
 /datum/ammo/xeno/toxin/heavy/upgrade1
 	smoke_strength = 0.85
-	reagent_transfer_amount = 10
+	reagent_transfer_amount = 9.5
 
 /datum/ammo/xeno/toxin/heavy/upgrade2
 	smoke_strength = 0.95
-	reagent_transfer_amount = 10.5
+	reagent_transfer_amount = 10
 
 /datum/ammo/xeno/toxin/heavy/upgrade3
-	smoke_strength = 1.5
-	reagent_transfer_amount = 11
+	smoke_strength = 1
+	reagent_transfer_amount = 10.5  
 
 
 /datum/ammo/xeno/sticky


### PR DESCRIPTION
## About The Pull Request

Tweaks neurotoxic spit & the gas it leaves to actually be helpful and effective.

## Why It's Good For The Game

Marines currently are nearly unstoppable unless your entire hive knows what they are doing and are skilled which isn't 24/7. current neuro spits are worthless and easily fixed, marines have so many tools that help crush forward while  Xenos has no real strength to stop other than acid turrets which are only temporary, more so as they cant be built as close to each other anymore.

This tweak allows neurotoxic spit for sentinel, praetorian, queen to be worth something in team battles that slow a marines push and makes them weary rather than having them continue forward unchecked which is hard to deal with. in return I've increased the cost somewhat so this isn't something that can be spammed but used well to assist your team in stopping a marine push as well as pushing forward as well. 

Accounting for spit damage, increased plasma cost, gas strength, this would increase each caste general Neurospit/splash by 30%


## Changelog
:cl:
balance: neurotoxic spit for Sentinel, Praetorian,
balance: After extensive testing the values have been increased slightly and should now be the best they can be without gameplay being unfair.
/:cl:


