### PR TITLE
Make the AI lose control over the dropship doors when the beans hijackk it.

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -124,10 +124,19 @@
 
 /* Airlocks */
 /obj/machinery/door/airlock/AICtrlClick(mob/living/silicon/ai/user) // Bolts doors
+	if(aiControlDisabled)
+		to_chat(user, span_notice("[src] AI remote control has been disabled."))
+		return
 	if(locked)
 		bolt_raise(user)
 	else if(hasPower())
 		bolt_drop(user)
+
+/obj/machinery/door/airlock/AIShiftClick(mob/living/silicon/ai/user)  // Opens and closes doors!
+	if(aiControlDisabled)
+		to_chat(user, span_notice("[src] AI remote control has been disabled."))
+		return
+	user_toggle_open(user)
 
 /obj/machinery/door/airlock/dropship_hatch/AICtrlClick(mob/living/silicon/ai/user)
 	return
@@ -135,8 +144,6 @@
 /obj/machinery/door/airlock/hatch/cockpit/AICtrlClick(mob/living/silicon/ai/user)
 	return
 
-/obj/machinery/door/airlock/AIShiftClick(mob/living/silicon/ai/user)  // Opens and closes doors!
-	user_toggle_open(user)
 
 
 /* APC */

--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -206,13 +206,13 @@
 	switch(side)
 		if("left")
 			for(var/obj/machinery/door/airlock/dropship_hatch/D AS in left_airlocks)
-				D.aiControlDisabled =! 1
+				D.aiControlDisabled =! D.aiControlDisabled
 		if("right")
 			for(var/obj/machinery/door/airlock/dropship_hatch/D AS in right_airlocks)
-				D.aiControlDisabled =! 1
+				D.aiControlDisabled =! D.aiControlDisabled
 		if("rear")
 			for(var/obj/machinery/door/airlock/multi_tile/mainship/dropshiprear/D AS in rear_airlocks)
-				D.aiControlDisabled =! 1
+				D.aiControlDisabled =! D.aiControlDisabled
 
 /obj/docking_port/mobile/marine_dropship/Destroy(force)
 	. = ..()

--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -197,6 +197,23 @@
 				var/obj/machinery/door/airlock/multi_tile/mainship/dropshiprear/D = i
 				D.release()
 
+/obj/docking_port/mobile/marine_dropship/proc/prevent_silicon_intervention()
+	silicon_lock_airlocks("rear")
+	silicon_lock_airlocks("left")
+	silicon_lock_airlocks("right")
+
+/obj/docking_port/mobile/marine_dropship/proc/silicon_lock_airlocks(side)
+	switch(side)
+		if("left")
+			for(var/obj/machinery/door/airlock/dropship_hatch/D AS in left_airlocks)
+				D.aiControlDisabled =! 1
+		if("right")
+			for(var/obj/machinery/door/airlock/dropship_hatch/D AS in right_airlocks)
+				D.aiControlDisabled =! 1
+		if("rear")
+			for(var/obj/machinery/door/airlock/multi_tile/mainship/dropshiprear/D AS in rear_airlocks)
+				D.aiControlDisabled =! 1
+
 /obj/docking_port/mobile/marine_dropship/Destroy(force)
 	. = ..()
 	if(force)
@@ -240,6 +257,7 @@
 /obj/docking_port/mobile/marine_dropship/proc/reset_hijack()
 	if(hijack_state == HIJACK_STATE_CALLED_DOWN || hijack_state == HIJACK_STATE_UNLOCKED)
 		set_hijack_state(HIJACK_STATE_NORMAL)
+		prevent_silicon_intervention()
 
 /obj/docking_port/mobile/marine_dropship/proc/summon_dropship_to(obj/docking_port/stationary/S)
 	if(hijack_state != HIJACK_STATE_NORMAL)
@@ -340,20 +358,17 @@
 			D = M
 	if(is_ground_level(D.z))
 		var/locked_sides = 0
-		for(var/i in D.left_airlocks)
-			var/obj/machinery/door/airlock/dropship_hatch/DH = i
+		for(var/obj/machinery/door/airlock/dropship_hatch/DH AS in D.left_airlocks)
 			if(!DH.locked)
 				continue
 			locked_sides++
 			break
-		for(var/i in D.right_airlocks)
-			var/obj/machinery/door/airlock/dropship_hatch/DH = i
+		for(var/obj/machinery/door/airlock/dropship_hatch/DH AS in D.right_airlocks)
 			if(!DH.locked)
 				continue
 			locked_sides++
 			break
-		for(var/i in D.rear_airlocks)
-			var/obj/machinery/door/airlock/multi_tile/mainship/dropshiprear/DH = i
+		for(var/obj/machinery/door/airlock/dropship_hatch/DH AS in D.rear_airlocks)
 			if(!DH.locked)
 				continue
 			locked_sides++
@@ -377,6 +392,7 @@
 			to_chat(user, span_warning("The bird has left meanwhile, try again."))
 			return FALSE
 		D.unlock_all()
+		D.prevent_silicon_intervention()
 		D.set_hijack_state(HIJACK_STATE_UNLOCKED)
 		D.do_start_hijack_timer(GROUND_LOCKDOWN_TIME)
 		to_chat(user, span_warning("We have overriden the shuttle lockdown!"))

--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -197,13 +197,14 @@
 				var/obj/machinery/door/airlock/multi_tile/mainship/dropshiprear/D = i
 				D.release()
 
+///This proc locks and unlocks the AI control over the dropship doors.
 /obj/docking_port/mobile/marine_dropship/proc/silicon_lock_airlocks(should_lock = TRUE)
 	for(var/obj/machinery/door/airlock/dropship_hatch/D AS in left_airlocks)
-		D.aiControlDisabled =! D.aiControlDisabled
+		D.aiControlDisabled = should_lock
 	for(var/obj/machinery/door/airlock/dropship_hatch/D AS in right_airlocks)
-		D.aiControlDisabled =! D.aiControlDisabled
+		D.aiControlDisabled = should_lock
 	for(var/obj/machinery/door/airlock/multi_tile/mainship/dropshiprear/D AS in rear_airlocks)
-		D.aiControlDisabled =! D.aiControlDisabled
+		D.aiControlDisabled = should_lock
 
 /obj/docking_port/mobile/marine_dropship/Destroy(force)
 	. = ..()
@@ -336,9 +337,9 @@
 #define ALIVE_HUMANS_FOR_CALLDOWN 0.1
 
 /datum/game_mode/proc/can_summon_dropship(mob/user)
-	//if(SSticker.round_start_time + SHUTTLE_HIJACK_LOCK > world.time)
-	//	to_chat(user, span_warning("It's too early to call it. We must wait [DisplayTimeText(SSticker.round_start_time + SHUTTLE_HIJACK_LOCK - world.time, 1)]."))
-	//	return FALSE
+	if(SSticker.round_start_time + SHUTTLE_HIJACK_LOCK > world.time)
+		to_chat(user, span_warning("It's too early to call it. We must wait [DisplayTimeText(SSticker.round_start_time + SHUTTLE_HIJACK_LOCK - world.time, 1)]."))
+		return FALSE
 	if(!is_ground_level(user.z))
 		to_chat(user, span_warning("We can't call the bird from here!"))
 		return FALSE
@@ -449,9 +450,9 @@
 /obj/machinery/computer/shuttle/marine_dropship/attack_alien(mob/living/carbon/xenomorph/X, damage_amount = X.xeno_caste.melee_damage, damage_type = BRUTE, damage_flag = "", effects = TRUE, armor_penetration = 0, isrightclick = FALSE)
 	if(!(X.xeno_caste.caste_flags & CASTE_IS_INTELLIGENT))
 		return
-	//if(SSticker.round_start_time + SHUTTLE_HIJACK_LOCK > world.time)
-	//	to_chat(X, span_xenowarning("It's too early to do this!"))
-	//	return
+	if(SSticker.round_start_time + SHUTTLE_HIJACK_LOCK > world.time)
+		to_chat(X, span_xenowarning("It's too early to do this!"))
+		return
 	var/obj/docking_port/mobile/marine_dropship/M = SSshuttle.getShuttle(shuttleId)
 	var/dat = "Status: [M ? M.getStatusText() : "*Missing*"]<br><br>"
 	if(M)

--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -392,7 +392,6 @@
 			to_chat(user, span_warning("The bird has left meanwhile, try again."))
 			return FALSE
 		D.unlock_all()
-		D.prevent_silicon_intervention()
 		D.set_hijack_state(HIJACK_STATE_UNLOCKED)
 		D.do_start_hijack_timer(GROUND_LOCKDOWN_TIME)
 		to_chat(user, span_warning("We have overriden the shuttle lockdown!"))
@@ -677,6 +676,7 @@
 	to_chat(user, span_danger("A loud alarm erupts from [src]! The fleshy hosts must know that you can access it!"))
 	user.hive.on_shuttle_hijack(crashing_dropship)
 	playsound(src, 'sound/misc/queen_alarm.ogg')
+	crashing_dropship.prevent_silicon_intervention()
 	SSevacuation.flags_scuttle &= ~FLAGS_SDEVAC_TIMELOCK
 	switch(SSshuttle.moveShuttleToDock(shuttleId, crash_target, TRUE))
 		if(0)


### PR DESCRIPTION
## About The Pull Request
It was fun to lock the rear door of the alamo, but this was certainly too OP and unfair to them.

![image](https://user-images.githubusercontent.com/24830358/127936386-707f8e7e-c8a6-40ef-bc29-d206d50678c0.png)


## Why It's Good For The Game
Fairness good.

## Changelog
:cl:
balance: Made the AI unable to use the dropship doors while it is hijacked.
/:cl:
