### PR TITLE
Queen Psy Points Construction Permissions

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -166,6 +166,13 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define XENO_SLASHING_ALLOWED 1
 #define XENO_SLASHING_RESTRICTED 2
 
+// =============================
+// xeno building
+#define XENO_BUILDING_FORBIDDEN (1<<0)
+#define XENO_BUILDING_SILO (1<<1)
+#define XENO_BUILDING_TURRET (1<<2)
+#define XENO_BUILDING_UNRESTRICTED (XENO_BUILDING_SILO | XENO_BUILDING_TURRET)
+
 //=================================================
 
 ///////////////////HUMAN BLOODTYPES///////////////////

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -168,9 +168,8 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 
 // =============================
 // xeno building
-#define XENO_BUILDING_FORBIDDEN (1<<0)
-#define XENO_BUILDING_SILO (1<<1)
-#define XENO_BUILDING_TURRET (1<<2)
+#define XENO_BUILDING_SILO (1<<0)
+#define XENO_BUILDING_TURRET (1<<1)
 #define XENO_BUILDING_UNRESTRICTED (XENO_BUILDING_SILO | XENO_BUILDING_TURRET)
 
 //=================================================

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1082,6 +1082,11 @@
 		return FALSE
 
 	var/mob/living/carbon/xenomorph/X = owner
+
+	if(!isxenoqueen(X) && !(X.hive.building_allowed & XENO_BUILDING_SILO))
+		to_chat(owner, span_xenowarning("The Queen has forbidden the construction of silos!"))
+		return FALSE
+
 	if(SSpoints.xeno_points_by_hive[X.hivenumber] < psych_cost)
 		to_chat(owner, span_xenowarning("The hive doesn't have the necessary psychic points for you to do that!"))
 		return FALSE
@@ -1137,6 +1142,11 @@
 		return FALSE
 	var/turf/T = get_turf(A)
 	var/mob/living/carbon/xenomorph/X = owner
+
+	if(!isxenoqueen(X) && !(X.hive.building_allowed & XENO_BUILDING_TURRET))
+		to_chat(owner, span_xenowarning("The Queen has forbidden the construction of turrets!"))
+		return FALSE
+
 	var/mob/living/carbon/xenomorph/blocker = locate() in T
 	if(blocker && blocker != X && blocker.stat != DEAD)
 		to_chat(X, span_warning("Can't do that with [blocker] in the way!"))

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1083,7 +1083,8 @@
 
 	var/mob/living/carbon/xenomorph/X = owner
 
-	if(!isxenoqueen(X) && !(X.hive.building_allowed & XENO_BUILDING_SILO))
+	// Shrike and Queen ignore queen building restriction. Resulting in only hivelords being restricted.
+	if(!CHECK_BITFIELD(X.caste_flags, CASTE_IS_INTELLIGENT) && !CHECK_BITFIELD(X.hive.building_allowed, XENO_BUILDING_SILO))
 		to_chat(owner, span_xenowarning("The Queen has forbidden the construction of silos!"))
 		return FALSE
 
@@ -1143,7 +1144,8 @@
 	var/turf/T = get_turf(A)
 	var/mob/living/carbon/xenomorph/X = owner
 
-	if(!isxenoqueen(X) && !(X.hive.building_allowed & XENO_BUILDING_TURRET))
+	// Shrike and Queen ignore queen building restriction. Resulting in only hivelords being restricted.
+	if(!CHECK_BITFIELD(X.caste_flags, CASTE_IS_INTELLIGENT) && !CHECK_BITFIELD(X.hive.building_allowed, XENO_BUILDING_TURRET))
 		to_chat(owner, span_xenowarning("The Queen has forbidden the construction of turrets!"))
 		return FALSE
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1083,8 +1083,7 @@
 
 	var/mob/living/carbon/xenomorph/X = owner
 
-	// Shrike and Queen ignore queen building restriction. Resulting in only hivelords being restricted.
-	if(!CHECK_BITFIELD(X.caste_flags, CASTE_IS_INTELLIGENT) && !CHECK_BITFIELD(X.hive.building_allowed, XENO_BUILDING_SILO))
+	if(!isxenoqueen(X) && !(X.hive.building_allowed & XENO_BUILDING_SILO))
 		to_chat(owner, span_xenowarning("The Queen has forbidden the construction of silos!"))
 		return FALSE
 
@@ -1144,8 +1143,7 @@
 	var/turf/T = get_turf(A)
 	var/mob/living/carbon/xenomorph/X = owner
 
-	// Shrike and Queen ignore queen building restriction. Resulting in only hivelords being restricted.
-	if(!CHECK_BITFIELD(X.caste_flags, CASTE_IS_INTELLIGENT) && !CHECK_BITFIELD(X.hive.building_allowed, XENO_BUILDING_TURRET))
+	if(!isxenoqueen(X) && !(X.hive.building_allowed & XENO_BUILDING_TURRET))
 		to_chat(owner, span_xenowarning("The Queen has forbidden the construction of turrets!"))
 		return FALSE
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -75,6 +75,32 @@
 	message_admins("[ADMIN_TPMONTY(src)] has created a Hive Message.")
 
 // ***************************************
+// *********** Silo and turret permissions
+// ***************************************
+/mob/living/carbon/xenomorph/proc/points_toggle()
+	set name = "Permit/Disallow Psy Points Usage"
+	set desc = "Allows you to permit the hive to use psy points in building silos and/or turrets."
+	set category = "Alien"
+
+	if(stat)
+		to_chat(src, span_warning("We can't do that now."))
+		return
+
+	if(ppoints_delay)
+		to_chat(src, span_warning("We must wait a bit before we can toggle this again."))
+		return
+
+	addtimer(VARSET_CALLBACK(src, ppoints_delay, FALSE), 30 SECONDS)
+
+	ppoints_delay = TRUE
+
+	var/choice = tgui_input_list(src, "Choose what to allow the hive to build.","Building", list("Unrestricted", "Silos", "Turrets", "Forbidden"))
+
+	if(choice == "Unrestricted")
+		to_chat(src, span_xenonotice("We have allowed the unrestricted expediture of psy points for building silos and turrets by others."))
+		xeno_message()
+
+// ***************************************
 // *********** Slashing permissions
 // ***************************************
 /mob/living/carbon/xenomorph/proc/claw_toggle()

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -86,7 +86,7 @@
 		to_chat(src, span_xenowarning("We can't do that now."))
 		return
 
-	if(!isdistressgamemode(SSticker.mode)) // This does not apply during Hunt/Crash where there are no psy points.
+	if(!CHECK_BITFIELD(SSticker.mode.flags_round_type, MODE_PSY_POINTS)) // This does not apply during Hunt/Crash where there are no psy points.
 		to_chat(src, span_xenowarning("We do not use psy points currently."))
 		return
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -115,7 +115,7 @@
 	else if(choice == "Forbidden")
 		to_chat(src, span_xenonotice("We have forbidden the expenditure of psy points by others."))
 		xeno_message("The Queen has <b>forbidden</b> the construction of silos and turrets.")
-		hive.building_allowed = XENO_BUILDING_FORBIDDEN
+		hive.building_allowed = NONE
 
 // ***************************************
 // *********** Slashing permissions

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -78,7 +78,7 @@
 // *********** Silo and turret permissions
 // ***************************************
 /mob/living/carbon/xenomorph/proc/points_toggle()
-	set name = "Permit/Disallow psy points Usage"
+	set name = "Permit/Disallow Psy Points"
 	set desc = "Allows you to permit the hive to use psy points in building silos and/or turrets."
 	set category = "Alien"
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -78,27 +78,44 @@
 // *********** Silo and turret permissions
 // ***************************************
 /mob/living/carbon/xenomorph/proc/points_toggle()
-	set name = "Permit/Disallow Psy Points Usage"
+	set name = "Permit/Disallow psy points Usage"
 	set desc = "Allows you to permit the hive to use psy points in building silos and/or turrets."
 	set category = "Alien"
 
 	if(stat)
-		to_chat(src, span_warning("We can't do that now."))
+		to_chat(src, span_xenowarning("We can't do that now."))
+		return
+
+	if(!isdistressgamemode(SSticker.mode)) // This does not apply during Hunt/Crash where there are no psy points.
+		to_chat(src, span_xenowarning("We do not use psy points currently."))
 		return
 
 	if(ppoints_delay)
-		to_chat(src, span_warning("We must wait a bit before we can toggle this again."))
+		to_chat(src, span_xenowarning("We must wait a bit before we can toggle this again."))
 		return
 
 	addtimer(VARSET_CALLBACK(src, ppoints_delay, FALSE), 30 SECONDS)
 
 	ppoints_delay = TRUE
 
-	var/choice = tgui_input_list(src, "Choose what to allow the hive to build.","Building", list("Unrestricted", "Silos", "Turrets", "Forbidden"))
+	var/choice = tgui_input_list(src, "Choose what to allow the hive to build.","Building", list("Unrestricted", "Only Silos", "Only Turrets", "Forbidden"))
 
 	if(choice == "Unrestricted")
-		to_chat(src, span_xenonotice("We have allowed the unrestricted expediture of psy points for building silos and turrets by others."))
-		xeno_message()
+		to_chat(src, span_xenonotice("We have allowed the unrestricted expenditure of psy points for building silos and turrets by others."))
+		xeno_message("The Queen has permitted the unrestricted construction of <b>both silos and turrets</b>.")
+		hive.building_allowed = XENO_BUILDING_UNRESTRICTED
+	else if(choice == "Only Silos")
+		to_chat(src, span_xenonotice("We have allowed the expenditure of psy points for building silos by others."))
+		xeno_message("The Queen has permitted the construction of <b>only silos</b>.")
+		hive.building_allowed = XENO_BUILDING_SILO
+	else if(choice == "Only Turrets")
+		to_chat(src, span_xenonotice("We have allowed the expenditure of psy points for building turrets by others."))
+		xeno_message("The Queen has permitted the construction of <b>only turrets</b>.")
+		hive.building_allowed = XENO_BUILDING_TURRET
+	else if(choice == "Forbidden")
+		to_chat(src, span_xenonotice("We have forbidden the expenditure of psy points by others."))
+		xeno_message("The Queen has <b>forbidden</b> the construction of silos and turrets.")
+		hive.building_allowed = XENO_BUILDING_FORBIDDEN
 
 // ***************************************
 // *********** Slashing permissions

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
@@ -27,6 +27,7 @@
 		/mob/living/carbon/xenomorph/proc/claw_toggle,
 		/mob/living/carbon/xenomorph/queen/proc/set_orders,
 		/mob/living/carbon/xenomorph/proc/hijack,
+		/mob/living/carbon/xenomorph/proc/points_toggle,
 	)
 
 // ***************************************
@@ -38,6 +39,9 @@
 	hive.RegisterSignal(src, COMSIG_HIVE_XENO_DEATH, /datum/hive_status.proc/on_queen_death)
 	playsound(loc, 'sound/voice/alien_queen_command.ogg', 75, 0)
 
+	// Upon ascension to queen, hive construction permissions default to forbidden.
+	hive.building_allowed = XENO_BUILDING_FORBIDDEN
+	xeno_message("The new Queen has forbidden the rest of the hive from wasting psy points.")
 
 // ***************************************
 // *********** Life overrides
@@ -100,6 +104,9 @@
 	playsound(loc, 'sound/voice/alien_queen_died.ogg', 75, 0)
 
 /mob/living/carbon/xenomorph/queen/xeno_death_alert()
+	// Resets building permissions to unrestricted upon queen death.
+	hive.building_allowed = XENO_BUILDING_UNRESTRICTED
+	xeno_message("With the death of the Queen, we are free from any restrictions on building silos or turrets.")
 	return
 
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
@@ -39,13 +39,6 @@
 	hive.RegisterSignal(src, COMSIG_HIVE_XENO_DEATH, /datum/hive_status.proc/on_queen_death)
 	playsound(loc, 'sound/voice/alien_queen_command.ogg', 75, 0)
 
-	if(!isdistressgamemode(SSticker.mode))
-		return;
-
-	// Upon ascension to queen, hive construction permissions default to forbidden.
-	hive.building_allowed = NONE
-	xeno_message("The new Queen has forbidden the rest of the hive from wasting psy points.")
-
 // ***************************************
 // *********** Life overrides
 // ***************************************

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
@@ -100,8 +100,8 @@
 	playsound(loc, 'sound/voice/alien_queen_died.ogg', 75, 0)
 
 /mob/living/carbon/xenomorph/queen/xeno_death_alert()
-	if(!isdistressgamemode(SSticker.mode))
-		return;
+	if(!CHECK_BITFIELD(SSticker.mode.flags_round_type, MODE_PSY_POINTS))
+		return
 
 	// Resets building permissions to unrestricted upon queen death.
 	hive.building_allowed = XENO_BUILDING_UNRESTRICTED

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
@@ -39,8 +39,11 @@
 	hive.RegisterSignal(src, COMSIG_HIVE_XENO_DEATH, /datum/hive_status.proc/on_queen_death)
 	playsound(loc, 'sound/voice/alien_queen_command.ogg', 75, 0)
 
+	if(!isdistressgamemode(SSticker.mode))
+		return;
+
 	// Upon ascension to queen, hive construction permissions default to forbidden.
-	hive.building_allowed = XENO_BUILDING_FORBIDDEN
+	hive.building_allowed = NONE
 	xeno_message("The new Queen has forbidden the rest of the hive from wasting psy points.")
 
 // ***************************************
@@ -104,6 +107,9 @@
 	playsound(loc, 'sound/voice/alien_queen_died.ogg', 75, 0)
 
 /mob/living/carbon/xenomorph/queen/xeno_death_alert()
+	if(!isdistressgamemode(SSticker.mode))
+		return;
+
 	// Resets building permissions to unrestricted upon queen death.
 	hive.building_allowed = XENO_BUILDING_UNRESTRICTED
 	xeno_message("With the death of the Queen, we are free from any restrictions on building silos or turrets.")

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -4,7 +4,7 @@
 	var/mob/living/carbon/xenomorph/queen/living_xeno_queen
 	var/mob/living/carbon/xenomorph/living_xeno_ruler
 	var/slashing_allowed = XENO_SLASHING_ALLOWED //This initial var allows the queen to turn on or off slashing. Slashing off means harm intent does much less damage.
-	var/building_allowed = XENO_BUILDING_UNRESTRICTED //Initially allows hivelords to build silos and turrets as there is no queen.
+	var/building_allowed = XENO_BUILDING_UNRESTRICTED //Initially allows hivelords and shrikes to build silos and turrets as there is no queen.
 	var/xeno_queen_timer
 	var/xenos_per_queen = 8 //Minimum number of xenos to support a queen.
 	var/hive_orders = "" //What orders should the hive have

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -4,6 +4,7 @@
 	var/mob/living/carbon/xenomorph/queen/living_xeno_queen
 	var/mob/living/carbon/xenomorph/living_xeno_ruler
 	var/slashing_allowed = XENO_SLASHING_ALLOWED //This initial var allows the queen to turn on or off slashing. Slashing off means harm intent does much less damage.
+	var/building_allowed = XENO_BUILDING_UNRESTRICTED //Initially allows hivelords and shrikes to build silos and turrets as there is no queen.
 	var/xeno_queen_timer
 	var/xenos_per_queen = 8 //Minimum number of xenos to support a queen.
 	var/hive_orders = "" //What orders should the hive have

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -4,7 +4,7 @@
 	var/mob/living/carbon/xenomorph/queen/living_xeno_queen
 	var/mob/living/carbon/xenomorph/living_xeno_ruler
 	var/slashing_allowed = XENO_SLASHING_ALLOWED //This initial var allows the queen to turn on or off slashing. Slashing off means harm intent does much less damage.
-	var/building_allowed = XENO_BUILDING_UNRESTRICTED //Initially allows hivelords and shrikes to build silos and turrets as there is no queen.
+	var/building_allowed = XENO_BUILDING_UNRESTRICTED //Initially allows hivelords to build silos and turrets as there is no queen.
 	var/xeno_queen_timer
 	var/xenos_per_queen = 8 //Minimum number of xenos to support a queen.
 	var/hive_orders = "" //What orders should the hive have

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -258,7 +258,7 @@
 	var/obj/structure/xeno/tunnel/start_dig = null
 	var/datum/ammo/xeno/ammo = null //The ammo datum for our spit projectiles. We're born with this, it changes sometimes.
 	var/pslash_delay = 0
-	var/ppoints_delay = 0
+	var/ppoints_delay = 0 //The toggle that stays true during the cooldown of queen psy points permissions settings.
 
 	var/evo_points = 0 //Current # of evolution points. Max is 1000.
 	var/list/upgrades_bought = list()

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -258,7 +258,9 @@
 	var/obj/structure/xeno/tunnel/start_dig = null
 	var/datum/ammo/xeno/ammo = null //The ammo datum for our spit projectiles. We're born with this, it changes sometimes.
 	var/pslash_delay = 0
-	var/ppoints_delay = 0 //The toggle that stays true during the cooldown of queen psy points permissions settings.
+
+	///A toggle that stays true during the cooldown of queen psy points permissions settings.
+	var/ppoints_delay = 0
 
 	var/evo_points = 0 //Current # of evolution points. Max is 1000.
 	var/list/upgrades_bought = list()

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -258,6 +258,7 @@
 	var/obj/structure/xeno/tunnel/start_dig = null
 	var/datum/ammo/xeno/ammo = null //The ammo datum for our spit projectiles. We're born with this, it changes sometimes.
 	var/pslash_delay = 0
+	var/ppoints_delay = 0
 
 	var/evo_points = 0 //Current # of evolution points. Max is 1000.
 	var/list/upgrades_bought = list()

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -225,6 +225,15 @@
 		else
 			stat("Slashing of hosts status:","FORBIDDEN")
 
+	if(hive.building_allowed == XENO_BUILDING_FORBIDDEN)
+		stat("Expenditure of psy points status:", "FORBIDDEN")
+	else if(hive.building_allowed == XENO_BUILDING_SILO)
+		stat("Expenditure of psy points status:", "ONLY SILOS")
+	else if(hive.building_allowed == XENO_BUILDING_TURRET)
+		stat("Expenditure of psy points status:", "ONLY TURRETS")
+	else
+		stat("Expenditure of psy points status:", "UNRESTRICTED")
+
 	//Very weak <= 1.0, weak <= 2.0, no modifier 2-3, strong <= 3.5, very strong <= 4.5
 	var/msg_holder = ""
 	if(frenzy_aura)

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -226,7 +226,7 @@
 			stat("Slashing of hosts status:","FORBIDDEN")
 
 
-	if(isdistressgamemode(SSticker.mode))
+	if(CHECK_BITFIELD(SSticker.mode.flags_round_type, MODE_PSY_POINTS))
 		if(hive.building_allowed == NONE)
 			stat("Expenditure of psy points status:", "FORBIDDEN")
 		else if(hive.building_allowed == XENO_BUILDING_SILO)

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -225,14 +225,16 @@
 		else
 			stat("Slashing of hosts status:","FORBIDDEN")
 
-	if(hive.building_allowed == XENO_BUILDING_FORBIDDEN)
-		stat("Expenditure of psy points status:", "FORBIDDEN")
-	else if(hive.building_allowed == XENO_BUILDING_SILO)
-		stat("Expenditure of psy points status:", "ONLY SILOS")
-	else if(hive.building_allowed == XENO_BUILDING_TURRET)
-		stat("Expenditure of psy points status:", "ONLY TURRETS")
-	else
-		stat("Expenditure of psy points status:", "UNRESTRICTED")
+
+	if(isdistressgamemode(SSticker.mode))
+		if(hive.building_allowed == NONE)
+			stat("Expenditure of psy points status:", "FORBIDDEN")
+		else if(hive.building_allowed == XENO_BUILDING_SILO)
+			stat("Expenditure of psy points status:", "ONLY SILOS")
+		else if(hive.building_allowed == XENO_BUILDING_TURRET)
+			stat("Expenditure of psy points status:", "ONLY TURRETS")
+		else
+			stat("Expenditure of psy points status:", "UNRESTRICTED")
 
 	//Very weak <= 1.0, weak <= 2.0, no modifier 2-3, strong <= 3.5, very strong <= 4.5
 	var/msg_holder = ""


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR proposes a queen only verb that mirrors the now defunct slashing permissions except with psy points usage by the rest of the hive. It gives the queen player options to allow the construction of silos and/or turrets by others in the hive that have the ability to do so (shrikes and hivelords). 

Without a queen, it is unrestricted (as in anyone can build). Upon queen ascension, psy points usage becomes forbidden (only the queen can build silos and turrets). There is an option in the queen's Alien tab to switch modes. Upon queen death, it returns to unrestricted.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

A hivelord can singlehandedly ruin the game for an entire hive by wasting psy points on a silo just outside of FOB and there is nothing the queen or other players can do to stop them. AHelping for a refund or movement of the silo is a bandaid fix that depends on the generosity of the admins responding.

This implements an in-game solution by the leader of the hive. This of course now shifts the responsibility of managing the economy of the hive's psy points to the queen, regardless of actual skill. However, those evolving to queen should already understand that there are immense responsibilities in managing the hive upon taking on the role.

## Changelog
:cl:
add: Added the option for xeno Queens to allow / forbid the creation of psy points consuming constructions (silo and turrets) by others in the hive.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
