### PR TITLE
Fixes the UGL not having a fire delay by giving it a fire delay of 1 second

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1452,9 +1452,10 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	var/distance = 0
 	var/turf/prev_T
 	playsound(user, 'sound/weapons/guns/fire/flamethrower2.ogg', 50, 1)
+	var/fire_delay = attachment_firing_delay
 	if(!user.skills.getRating("firearms")) //no training in any firearms
-		attachment_firing_delay += 0.3 SECONDS //untrained humans fire more slowly.
-	COOLDOWN_START(src, last_fired, attachment_firing_delay)
+		fire_delay += 0.3 SECONDS //untrained humans fire more slowly.
+	COOLDOWN_START(src, last_fired, fire_delay)
 	for(var/turf/T in turfs)
 		if(T == user.loc)
 			prev_T = T

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1263,7 +1263,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 //The requirement for an attachable being alt fire is AMMO CAPACITY > 0.
 /obj/item/attachable/attached_gun/grenade
 	name = "underslung grenade launcher"
-	desc = "A weapon-mounted, reloadable, one-shot grenade launcher."
+	desc = "A weapon-mounted, reloadable, two-shot grenade launcher."
 	icon_state = "grenade"
 	attach_icon = "grenade_a"
 	w_class = WEIGHT_CLASS_BULKY
@@ -1275,7 +1275,8 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	flags_attach_features = ATTACH_REMOVABLE|ATTACH_ACTIVATION|ATTACH_RELOADABLE|ATTACH_WEAPON
 	///list of grenade types loaded in the UGL
 	var/list/loaded_grenades = list()
-	attachment_firing_delay = 21
+	attachment_firing_delay = 10
+	COOLDOWN_DECLARE(last_fired)
 
 /obj/item/attachable/attached_gun/grenade/unremovable
 	flags_attach_features = ATTACH_ACTIVATION|ATTACH_RELOADABLE|ATTACH_WEAPON
@@ -1322,7 +1323,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	if(get_dist(user,target) > max_range)
 		to_chat(user, span_warning("Too far to fire the attachment!"))
 		return
-	if(current_rounds > 0)
+	if(current_rounds > 0 && COOLDOWN_CHECK(src, last_fired))
 		prime_grenade(target,gun,user)
 
 
@@ -1330,6 +1331,8 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	set waitfor = FALSE
 	var/nade_type = loaded_grenades[1]
 	var/obj/item/explosive/grenade/frag/G = new nade_type (get_turf(gun))
+	var/fire_delay = attachment_firing_delay
+	COOLDOWN_START(src, last_fired, fire_delay)
 	playsound(user.loc, fire_sound, 50, 1)
 	log_explosion("[key_name(user)] fired a grenade [G] from [src] at [AREACOORD(user.loc)].")
 	log_combat(user, src, "fired a grenade [G] from")

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1270,12 +1270,12 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	current_rounds = 0
 	max_rounds = 2
 	max_range = 7
+	attachment_firing_delay = 10
 	slot = ATTACHMENT_SLOT_UNDER
 	fire_sound = 'sound/weapons/guns/fire/underbarrel_grenadelauncher.ogg'
 	flags_attach_features = ATTACH_REMOVABLE|ATTACH_ACTIVATION|ATTACH_RELOADABLE|ATTACH_WEAPON
 	///list of grenade types loaded in the UGL
 	var/list/loaded_grenades = list()
-	attachment_firing_delay = 10
 	COOLDOWN_DECLARE(last_fired)
 
 /obj/item/attachable/attached_gun/grenade/unremovable
@@ -1331,8 +1331,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	set waitfor = FALSE
 	var/nade_type = loaded_grenades[1]
 	var/obj/item/explosive/grenade/frag/G = new nade_type (get_turf(gun))
-	var/fire_delay = attachment_firing_delay
-	COOLDOWN_START(src, last_fired, fire_delay)
+	COOLDOWN_START(src, last_fired, attachment_firing_delay)
 	playsound(user.loc, fire_sound, 50, 1)
 	log_explosion("[key_name(user)] fired a grenade [G] from [src] at [AREACOORD(user.loc)].")
 	log_combat(user, src, "fired a grenade [G] from")
@@ -1356,10 +1355,10 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	current_rounds = 20
 	max_rounds = 20
 	max_range = 4
+	attachment_firing_delay = 25
 	slot = ATTACHMENT_SLOT_UNDER
 	fire_sound = 'sound/weapons/guns/fire/flamethrower3.ogg'
 	flags_attach_features = ATTACH_REMOVABLE|ATTACH_ACTIVATION|ATTACH_RELOADABLE|ATTACH_WEAPON
-	attachment_firing_delay = 25
 	COOLDOWN_DECLARE(last_fired)
 
 
@@ -1453,10 +1452,9 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	var/distance = 0
 	var/turf/prev_T
 	playsound(user, 'sound/weapons/guns/fire/flamethrower2.ogg', 50, 1)
-	var/fire_delay = attachment_firing_delay
 	if(!user.skills.getRating("firearms")) //no training in any firearms
-		fire_delay += 0.3 SECONDS //untrained humans fire more slowly.
-	COOLDOWN_START(src, last_fired, fire_delay)
+		attachment_firing_delay += 0.3 SECONDS //untrained humans fire more slowly.
+	COOLDOWN_START(src, last_fired, attachment_firing_delay)
 	for(var/turf/T in turfs)
 		if(T == user.loc)
 			prev_T = T


### PR DESCRIPTION
## About The Pull Request

So, the underbarrel attachments have had an `attachment_firing_delay` for the longest time but the underbarrel flamer is the only attachment that actually properly uses it. Both the masterkey and the UGL currently have _no_ fire delay what so ever and can just be spam click rapid fired. 

This PR specifically fixes the UGL not having a fire delay and also balances it by giving it a fire delay of 1 second, the masterkey remains untouched for now because it is frankly shit code that I don't want to touch and don't fully understand, and also no one uses it. 1 second may seem high but is still faster than the rotary GL at 1.2 seconds of fire delay, the balance part of this PR is mainly meant to combat impacts being insanely deadly in a UGL due to being able to insta spam two of them and immediately unload with your primary. It's incredibly unfun and incredibly hard to counter or predict/prepare for. 

Even in a world without impacts, the UGL should have a fire delay regardless, and it's obviously intended for it to, just no one made it work properly. This PR also fixes a small typo that lists the UGL as being a single shot launcher. 

## Why It's Good For The Game

Being able to rapid spam two grenades back to back from an underslung launcher while in the middle of firing and being able to fire right after is insanely strong. This brings the UGL a bit more down to earth with the recent re-addition of impacts while also fixing something it was intended to always have presumably, fire delay. 

Anyone who says this completely guts the UGL fails to realize the sheer versatility and power of having short fuse grenades on standby without having to switch hands or weapons, even if you can't rapid fire spam them to instant kill a Xeno. 

## Changelog
:cl:
balance: The UGL now has a fire delay of 1 second
fix: Fixed the UGL not having a fire delay at all
spellcheck: Fixed the UGL description listing it as a single shot launcher
/:cl:
