### PR TITLE
Buffs BR damage by 2.5 and reduces falloff by 0.2

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -247,7 +247,7 @@
 	aim_slowdown = 0.55
 	wield_delay = 0.7 SECONDS
 	force = 20
-	max_shells = 40 //codex
+	max_shells = 35 //codex
 	current_mag = /obj/item/ammo_magazine/rifle/standard_br
 	attachable_allowed = list(
 		/obj/item/attachable/suppressor,

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -282,7 +282,7 @@
 	aim_speed_modifier = 3
 
 	fire_delay = 0.35 SECONDS
-	damage_mult = 0.5 //uses the marksman bullet, like the DMR.
+	damage_mult = 0.6 //uses the marksman bullet, like the DMR. This equals to 39 damage per shot
 	accuracy_mult = 1.25
 	scatter = -10
 	burst_amount = 1

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -247,7 +247,7 @@
 	aim_slowdown = 0.55
 	wield_delay = 0.7 SECONDS
 	force = 20
-	max_shells = 10 //codex
+	max_shells = 40 //codex
 	current_mag = /obj/item/ammo_magazine/rifle/standard_br
 	attachable_allowed = list(
 		/obj/item/attachable/suppressor,
@@ -282,10 +282,11 @@
 	aim_speed_modifier = 3
 
 	fire_delay = 0.35 SECONDS
-	damage_mult = 0.6 //uses the marksman bullet, like the DMR. This equals to 39 damage per shot
+	damage_mult = 0.54 //uses the marksman bullet, like the DMR. This equals to about 35 damage per shot
 	accuracy_mult = 1.25
 	scatter = -10
 	burst_amount = 1
+	damage_falloff_mult = 0.6
 
 //-------------------------------------------------------
 //M412 Pulse Rifle

--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -102,7 +102,7 @@
 	icon_state = "t64"
 	w_class = WEIGHT_CLASS_NORMAL
 	default_ammo = /datum/ammo/bullet/rifle/standard_dmr
-	max_rounds = 40
+	max_rounds = 35
 	gun_type = /obj/item/weapon/gun/rifle/standard_br
 	icon_state_mini = "mag_rifle_big"
 
@@ -113,7 +113,7 @@
 	icon_state = "t64_incin"
 	w_class = WEIGHT_CLASS_NORMAL
 	default_ammo = /datum/ammo/bullet/rifle/standard_dmr/incendiary
-	max_rounds = 40
+	max_rounds = 35
 	gun_type = /obj/item/weapon/gun/rifle/standard_br
 	icon_state_mini = "mag_rifle_big_red"
 

--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -102,7 +102,7 @@
 	icon_state = "t64"
 	w_class = WEIGHT_CLASS_NORMAL
 	default_ammo = /datum/ammo/bullet/rifle/standard_dmr
-	max_rounds = 35
+	max_rounds = 40
 	gun_type = /obj/item/weapon/gun/rifle/standard_br
 	icon_state_mini = "mag_rifle_big"
 
@@ -113,7 +113,7 @@
 	icon_state = "t64_incin"
 	w_class = WEIGHT_CLASS_NORMAL
 	default_ammo = /datum/ammo/bullet/rifle/standard_dmr/incendiary
-	max_rounds = 35
+	max_rounds = 40
 	gun_type = /obj/item/weapon/gun/rifle/standard_br
 	icon_state_mini = "mag_rifle_big_red"
 


### PR DESCRIPTION
## About The Pull Request

After having used the BR a fair amount, I am still a firm believer that the BR is not very good. This PR hopes to remedy that by buffing it's base damage slightly, reducing it's falloff by 0.2 since it's a flat reduction and falloff is currently shared with the marksman bullet, meaning the BR suffers much more from falloff than the DMR.

All together this should make the BR much more competitive, especially with the potentially incoming addition of the Skirmish Rifle which may otherwise step on it's toes a fair amount.

## Why It's Good For The Game

The BR is underused and not that good compared to either using a T12 or a DMR. With the Skirmish Rifle likely on the horizon as well, without some buffs the BR may just become completely obsolete. This reduces it's incredibly crippling 0.5 damage falloff to 0.3, and also gives it just a bit more base damage.

## Changelog
:cl:
balance: BR now has +2.5 damage, and -0.2 damage falloff.
/:cl:
