### PR TITLE
Removes Queen's Set Leadership Cooldown

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -441,17 +441,10 @@
 		unset_xeno_leader(selected_xeno, feedback)
 		return
 
-	if(xeno_ruler.queen_ability_cooldown > world.time)
-		if(feedback)
-			to_chat(xeno_ruler, span_xenowarning("We're still recovering from our last hive managment ability. We must wait [round((xeno_ruler.queen_ability_cooldown-world.time)*0.1)] seconds."))
-		return
-
 	if(xeno_ruler.xeno_caste.queen_leader_limit <= length(xeno_ruler.hive.xeno_leader_list))
 		if(feedback)
 			to_chat(xeno_ruler, span_xenowarning("We currently have [length(xeno_ruler.hive.xeno_leader_list)] promoted leaders. We may not maintain additional leaders until our power grows."))
 		return
-
-	xeno_ruler.queen_ability_cooldown = world.time + 15 SECONDS
 
 	set_xeno_leader(selected_xeno, feedback)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -415,7 +415,7 @@
 	name = "Choose/Follow Xenomorph Leaders"
 	action_icon_state = "xeno_lead"
 	mechanics_text = "Make a target Xenomorph a leader."
-	plasma_cost = 0
+	plasma_cost = 200
 	keybind_signal = COMSIG_XENOABILITY_XENO_LEADERS
 	use_state_flags = XACT_USE_LYING
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
@@ -21,7 +21,6 @@
 	upgrade = XENO_UPGRADE_ZERO
 
 	var/breathing_counter = 0
-	var/queen_ability_cooldown = 0
 	var/mob/living/carbon/xenomorph/observed_xeno //the Xenomorph the queen is currently overwatching
 	inherent_verbs = list(
 		/mob/living/carbon/xenomorph/proc/claw_toggle,


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This removes the 15 second cooldown between setting leadership.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Leadership cooldown has no logic or reason to exist. It just results in newer, less experienced, queens to accidentally forget to continue to set leadership while waiting for the cooldown to finish; requiring xenos to continuously say "set leaders" or "leadership queen" until they remember.

As to prevent spamming of leadership, it now costs 200 plasma to set leaders.

## Changelog
:cl:
balance: Removes Queen Set Leaders cooldown. Instead makes it cost 200 plasma.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
