### PR TITLE
Buffs the TX-11 by 10 pen and 0.25 sunder

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -497,8 +497,8 @@ datum/ammo/bullet/revolver/tp44
 	name = "high-velocity rifle bullet"
 	hud_state = "hivelo"
 	damage = 20
-	penetration = 10
-	sundering = 1
+	penetration = 20
+	sundering = 1.25
 
 /datum/ammo/bullet/rifle/incendiary
 	name = "incendiary rifle bullet"


### PR DESCRIPTION
## About The Pull Request

After also using the TX-11 for quite a while, it is frankly not very good as well. This seeks to carve it's niche out a bit more as better against higher armored Xenos in terms of both penetration/damage and sunder. 20 penetration puts it on par with other "high velocity" ammunition, while still lacking the damage and pure sunder that they do due to having a larger bullet. This should hopefully further cement the TX-11 as a good gun on aim mode in the middle of an unga ball, doing solid sunder and decent damage against the heftier Xenos. 

## Why It's Good For The Game

The TX-11 isn't very good right now, this hopes to remedy that by cementing it's position as a LSW a little more. It will perform better against _most_ Xenos with the increased penetration, but some castes won't feel it at all due to already having so little armor. The sunder buff is minor but should be noticeable if you're able to really wail on a Xeno with the TX. 

## Changelog
:cl:
balance: TX-11 has 10 more armor penetration and 0.25 more sunder. 
/:cl:
