### PR TITLE
Fix the special force leader incorrectly spawning with a Med hud

### DIFF
--- a/code/datums/jobs/job/special_forces.dm
+++ b/code/datums/jobs/job/special_forces.dm
@@ -81,7 +81,6 @@
 	wear_suit = /obj/item/clothing/suit/armor/bulletproof
 	gloves = /obj/item/clothing/gloves/marine/veteran/PMC
 	head = /obj/item/clothing/head/beret/sec
-	glasses = /obj/item/clothing/glasses/hud/health
 	suit_store = /obj/item/weapon/gun/rifle/famas/freelancermedic
 	r_store = /obj/item/storage/pouch/general/large
 	l_store = /obj/item/storage/pouch/pistol


### PR DESCRIPTION
## About The Pull Request
There was two lines. One adding the medhud and one adding the NVG googles.
This deletes the forgotten line.

## Why It's Good For The Game
Fixes the leader not having lights and it brings them to the same standard as the base guys.

## Changelog
:cl:
fix: Fix the special force leader incorrectly spawning with a Med hud
/:cl:

