### PR TITLE
fixes supply beacons not working in every LZ's

### DIFF
--- a/code/game/area/sulaco.dm
+++ b/code/game/area/sulaco.dm
@@ -320,6 +320,7 @@
 /area/shuttle/drop1/lz1
 	name = "Alamo Landing Zone"
 	icon_state = "away1"
+	flags_area = NONE
 
 /area/shuttle/drop2/Enter(atom/movable/arrived, direction)
 	if(istype(arrived, /obj/structure/barricade))
@@ -357,6 +358,7 @@
 /area/shuttle/drop2/lz2
 	name = "Normandy Landing Zone"
 	icon_state = "away2"
+	flags_area = NONE
 
 
 


### PR DESCRIPTION
## About The Pull Request
The OB/CAS prevention flags were stopping them.

## Why It's Good For The Game
Brings back functionality that :b:roke

## Changelog
:cl:
fix: fixes supply beacons not working in every LZ's
/:cl:
