### PR TITLE
tp-44 snub damage buff

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1790,7 +1790,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	icon_state = "tp44_barrel"
 	attach_icon = "tp44_barrel"
 	slot = ATTACHMENT_BARREL_MOD
-	damage_mod = 0.25
+	damage_mod = 0.125
 	scatter_mod = -2.5
 	recoil_unwielded_mod = 0.25
 	damage_falloff_mod = -0.5

--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -359,7 +359,7 @@
 	)
 	attachable_offset = list("muzzle_x" = 26, "muzzle_y" = 19,"rail_x" = 13, "rail_y" = 21, "under_x" = 22, "under_y" = 14, "stock_x" = 22, "stock_y" = 19)
 	fire_delay = 0.15 SECONDS
-	damage_mult = 0.75
+	damage_mult = 0.875
 	damage_falloff_mult = 1.5
 	accuracy_mult_unwielded = 0.85
 	accuracy_mult = 1


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
snub revolvers are trash
like literal trash
the only thing they have over a tp-23 or tp14 is that you therotically deal more damage in a short period of time, but considering you're going to be using them as a sidearm they're still worse than both of those, due to terrible ammo capacity.
35 damage gives them +5 raw damage over the tp-23, atleast.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes TP-44 snubs way less trash, though personally i think we should just split revolver into three guns (snub, revolver and magnum) and get rid of this entire snub thing, it clearly isn't working out.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: snub revolvers do five more damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
