### PR TITLE
Fixes King Minimap Icon

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/king/king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/king.dm
@@ -119,7 +119,6 @@
 		if(XENO_HIVE_ADMEME)
 			new_caste_type = /mob/living/carbon/xenomorph/king/admeme
 	var/mob/living/carbon/xenomorph/king/kong = new new_caste_type()
-	SSminimaps.add_marker(kong, kong.z, hud_flags = MINIMAP_FLAG_XENO, iconstate = kong.xeno_caste.minimap_icon)
 	RegisterSignal(kong, COMSIG_MOB_LOGIN , .proc/on_king_occupied)
 	if(future_king)
 		future_king.mind.transfer_to(kong)
@@ -135,6 +134,10 @@
 	priority_announce("Warning: Psychic anomaly signature in [myarea] has spiked and begun to move.", "TGMC Intel Division")
 	xeno_message(span_xenoannounce("[occupied] has awakened at [myarea]. Praise the Queen Mother!"), 3, ownerhive)
 	future_king?.offer_mob()
+
+	var/mob/living/carbon/xenomorph/king/kong = occupied
+	SSminimaps.add_marker(kong, kong.z, MINIMAP_FLAG_XENO, kong.xeno_caste.minimap_icon)
+
 	qdel(src)
 
 /obj/structure/resin/king_pod/obj_destruction(damage_flag)

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/king.dm
@@ -134,9 +134,7 @@
 	priority_announce("Warning: Psychic anomaly signature in [myarea] has spiked and begun to move.", "TGMC Intel Division")
 	xeno_message(span_xenoannounce("[occupied] has awakened at [myarea]. Praise the Queen Mother!"), 3, ownerhive)
 	future_king?.offer_mob()
-
 	SSminimaps.add_marker(occupied, occupied.z, MINIMAP_FLAG_XENO, occupied.xeno_caste.minimap_icon)
-
 	qdel(src)
 
 /obj/structure/resin/king_pod/obj_destruction(damage_flag)

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/king.dm
@@ -126,7 +126,7 @@
 	kong.offer_mob()
 
 ///When the king mob is offered and then accepted this proc ejects the king and does announcements
-/obj/structure/resin/king_pod/proc/on_king_occupied(mob/occupied)
+/obj/structure/resin/king_pod/proc/on_king_occupied(mob/living/carbon/xenomorph/king/occupied)
 	SIGNAL_HANDLER
 	UnregisterSignal(occupied, COMSIG_MOB_LOGIN)
 	occupied.forceMove(get_turf(src))
@@ -135,8 +135,7 @@
 	xeno_message(span_xenoannounce("[occupied] has awakened at [myarea]. Praise the Queen Mother!"), 3, ownerhive)
 	future_king?.offer_mob()
 
-	var/mob/living/carbon/xenomorph/king/kong = occupied
-	SSminimaps.add_marker(kong, kong.z, MINIMAP_FLAG_XENO, kong.xeno_caste.minimap_icon)
+	SSminimaps.add_marker(occupied, occupied.z, MINIMAP_FLAG_XENO, occupied.xeno_caste.minimap_icon)
 
 	qdel(src)
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Currently king minimap icons uses, for some reason, queen golden crown instead of the specifically sprited red crown. This fixes the bug by relocating the proc call of set minimap icon to after the king is spawned.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

No longer will there be two queens wandering around on the minimap. The king gets their own specially sprited red crown, as intended.

## Changelog
:cl:
fix: Fixed King minimap icon to proper red crown.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
