### PR TITLE
Make the supply beacon from the antenna last 4 minutes instead of 1

### DIFF
--- a/code/modules/modular_armor/helmets.dm
+++ b/code/modules/modular_armor/helmets.dm
@@ -129,7 +129,7 @@
 	if(A && istype(A) && A.ceiling >= CEILING_METAL)
 		to_chat(user, span_warning("You have to be outside or under a glass ceiling to activate this."))
 		return
-	beacon_datum = new /datum/supply_beacon(user.name, user.loc, user.faction, 1 MINUTES)
+	beacon_datum = new /datum/supply_beacon(user.name, user.loc, user.faction, 4 MINUTES)
 	RegisterSignal(beacon_datum, COMSIG_PARENT_QDELETING, .proc/clean_beacon_datum)
 	user.show_message(span_notice("The [src] beeps and states, \"Your current coordinates were registered by the supply console. LONGITUDE [location.x]. LATITUDE [location.y]. Area ID: [get_area(src)]\""), EMOTE_AUDIBLE, span_notice("The [src] vibrates but you can not hear it!"))
 


### PR DESCRIPTION
## About The Pull Request
I hate the back and forth of req being Like
"Turn on your antena"
"I already turned it on"
"Does not work"
"Fine, i am doing it now"
"Stop moving"
"Does not work"
"Ah come on, i just sent it"
"Fuck you, get it at the FOB"
"Asshole!"

This PR should make it a bit easier.

## Changelog
:cl:
qol: Increased antenna beacon duration from one minute to four minutes.
/:cl:
