### PR TITLE
Make the light replacer small. Because it is too big for its usefulness.

### DIFF
--- a/code/game/objects/items/lightreplacer.dm
+++ b/code/game/objects/items/lightreplacer.dm
@@ -30,6 +30,8 @@
 	flags_atom = CONDUCT
 	flags_equip_slot = ITEM_SLOT_BELT
 
+	w_class = WEIGHT_CLASS_SMALL
+
 	var/max_uses = 50
 	var/uses = 0
 	var/failmsg = ""


### PR DESCRIPTION
## About The Pull Request
This thing isn't very useful, and it basically does not fit in most kits, as many more useful things take priority, leading to it being rarely used. Even when marines take control of places with lights.
You are telling me that this thing is bigger than a roller bed which can teleport people?
You are telling me a shrimp fried this rice?

## Changelog
:cl:
qol: made light replacers smaller 
/:cl:

