### PR TITLE
Fixes cpr'ing undefibbable bodies

### DIFF
--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -31,12 +31,12 @@
 				help_shake_act(H)
 				return 1
 
-			if((head && (head.flags_inventory & COVERMOUTH)) || (wear_mask && (wear_mask.flags_inventory & COVERMOUTH)))
-				to_chat(H, span_boldnotice("Remove his mask!"))
+			if(HAS_TRAIT(src, TRAIT_UNDEFIBBABLE ))
+				to_chat(H, span_boldnotice("Can't help this one. Body has gone cold."))
 				return FALSE
 
-			if(HAS_TRAIT(H, TRAIT_UNDEFIBBABLE ))
-				to_chat(H, span_boldnotice("Can't help this one. Body has gone cold."))
+			if((head && (head.flags_inventory & COVERMOUTH)) || (wear_mask && (wear_mask.flags_inventory & COVERMOUTH)))
+				to_chat(H, span_boldnotice("Remove his mask!"))
 				return FALSE
 
 			if((H.head && (H.head.flags_inventory & COVERMOUTH)) || (H.wear_mask && (H.wear_mask.flags_inventory & COVERMOUTH)))

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -36,7 +36,7 @@
 				return FALSE
 
 			if((head && (head.flags_inventory & COVERMOUTH)) || (wear_mask && (wear_mask.flags_inventory & COVERMOUTH)))
-				to_chat(H, span_boldnotice("Remove his mask!"))
+				to_chat(H, span_boldnotice("Remove [p_their()] mask!"))
 				return FALSE
 
 			if((H.head && (H.head.flags_inventory & COVERMOUTH)) || (H.wear_mask && (H.wear_mask.flags_inventory & COVERMOUTH)))

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -844,7 +844,7 @@ and you're good to go.
 			user.apply_damage(200, STAMINA)
 		else
 			user.apply_damage(projectile_to_fire.damage * 2.5, projectile_to_fire.ammo.damage_type, "head", 0, TRUE)
-			user.apply_damage(100, OXY)
+			user.apply_damage(200, OXY)
 			if(ishuman(user) && user == M)
 				var/mob/living/carbon/human/HM = user
 				HM.set_undefibbable() //can't be defibbed back from self inflicted gunshot to head


### PR DESCRIPTION
## About The Pull Request
The undefibbable check was on the wrong person, so you couldn't give cpr if you yourself were undefibbable.
Also increases damage from suicide to ensure that you're below health thresholds.

## Why It's Good For The Game
Bugfix

## Changelog
:cl:
fix: Trying to give cpr to someone who's gone cold will fail properly now
fix: Suiciding gives more oxy damage, just so the body meets damage thresholds for cpr checks
/:cl: