### PR TITLE
Prevents defibbing headless synths

### DIFF
--- a/code/game/objects/items/defibrillator.dm
+++ b/code/game/objects/items/defibrillator.dm
@@ -233,6 +233,12 @@
 		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Patient's brain has decayed too much."))
 		return
 
+	if(H.species.species_flags & DETACHABLE_HEAD)	//But if their head's missing, they're still not coming back
+		var/datum/limb/head/braincase = H.get_limb("head")
+		if(braincase.limb_status & LIMB_DESTROYED)
+			user.visible_message("[icon2html(src, viewers(user))] \The [src] buzzes: Positronic brain missing, cannot reboot.")
+			return
+
 	if(!H.client) //Freak case, no client at all. This is a braindead mob (like a colonist)
 		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: No soul detected, Attempting to revive..."))
 


### PR DESCRIPTION
## About The Pull Request
As title

## Why It's Good For The Game
It's basically funny having a headless dude walking around normally, but it can lead to problems like unfixable organ damage. Plus inconsistencies, like the whole eyes, ears, and mouth still working thing.

## Changelog
:cl:
fix: Beheaded synths need their head actually reattached before they can be revived
/:cl: