### PR TITLE
Reduces ravager slash damage

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
@@ -9,7 +9,7 @@
 	wound_type = "ravager" //used to match appropriate wound overlays
 
 	// *** Melee Attacks *** //
-	melee_damage = 26
+	melee_damage = 25
 	attack_delay = 7
 
 	// *** Speed *** //
@@ -84,7 +84,7 @@
 	upgrade = XENO_UPGRADE_TWO
 
 	// *** Melee Attacks *** //
-	melee_damage = 32
+	melee_damage = 28
 
 	// *** Speed *** //
 	speed = -0.9
@@ -110,7 +110,7 @@
 	upgrade = XENO_UPGRADE_THREE
 
 	// *** Melee Attacks *** //
-	melee_damage = 32
+	melee_damage = 28
 
 	// *** Speed *** //
 	speed = -1

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/castedatum_ravager.dm
@@ -9,7 +9,7 @@
 	wound_type = "ravager" //used to match appropriate wound overlays
 
 	// *** Melee Attacks *** //
-	melee_damage = 25
+	melee_damage = 26
 	attack_delay = 7
 
 	// *** Speed *** //
@@ -110,7 +110,7 @@
 	upgrade = XENO_UPGRADE_THREE
 
 	// *** Melee Attacks *** //
-	melee_damage = 28
+	melee_damage = 29
 
 	// *** Speed *** //
 	speed = -1


### PR DESCRIPTION
This is a revival of https://github.com/tgstation/TerraGov-Marine-Corps/pull/7764
I think it was closed too fast and the feedback was apparently some guy yelling in the author DM's.
While i don't really have a horse in this race, i think it is worth having it around for discussion.



.
.
.
## About The Pull Request
As reference, here are the current damage tiers of other similar castes:

Caste: Young / Mature damage - Elder / Ancient damage

Old Ravager: 26 - 32
New Ravager: 25 - 28

Defiler: 23 - 26
Hunter: 21 - 24
King / Queen / Shrike / Prae / Warrior: 20 - 23
Boiler / Wraith / Spitter: 17 - 20

Outliers from this damage increase trend:
Defender: 17 - 21
Bull: 19 - 21


## Why It's Good For The Game

Notice how the current "old" implementation of ravager conducts an increase in melee damage from 26 to 32, a total of 6 points compared to the nearly standardized 3 point increase. This drastic jump in damage by two levels propels it from merely high damaging to far and beyond its contemporaries in the hive and thus making it truly extraordinary in marine slaughtering capacity.

This damage is combined with a button that allows ravagers to increase their effective hitpoints by 33% instantly and a ravage skill that allows for an additional slash and short knockdown that opens up the possibility for even more extremely high damage slashes.

I propose a reduction in base melee damage to return the ravager's attack back to earth from the stratospheric levels reminiscent of bygone era of TGMC where Marines and Xenos conducted a race to the bottom in terms of armor and damage.

This does not affect the other tools available to a ravager. Extremely skilled ravagers may still employ the various combinations in skills and abilities provided in the various ravager mechanic additions that allow them to remain terrors of marine forces. This simply prevents a ravager that exists from round start and thus graduate to elder upon shutters up from dominating marines with little to no skill. Ravager players must now utilize health expansion techniques through endure and rage to deliver the same damage output as current base slashing produces.
Changelog

## Changelog
:cl:
balance: Reduces ravager damage tiers from 26 - 32 to 26 - 29.
/:cl:
