### PR TITLE
Changes Dark Mode colors to more eye-friendly options

### DIFF
--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -523,7 +523,7 @@ h1.alert, h2.alert{
   color: #6060C9;
 }
 .xenonotice{
-  color: #359980;
+  color: #2C7F5C;
 }
 .boldnotice{
   color: #6666CC;
@@ -534,7 +534,7 @@ h1.alert, h2.alert{
   font-style: italic;
 }
 .xenowarning{
-  color: #359980;
+  color: #2C7F5C;
   font-style: italic;
 }
 .danger{

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -273,12 +273,12 @@ a.popt {
 }
 
 h1, h2, h3, h4, h5, h6 {
-  color: #a4bad6;
+  color: #A4BAD6;
   font-family: Georgia, Verdana, sans-serif;
 }
 
 h1.alert, h2.alert {
-  color: #a4bad6;
+  color: #A4BAD6;
 }
 
 em {
@@ -290,7 +290,7 @@ em {
   font-weight: bold;
 }
 .colorooc	{
-  color: #004ed8;
+  color: #004ED8;
   font-weight: bold;
 }
 
@@ -300,7 +300,7 @@ em {
 }
 
 .hostooc{
-  color: #323232;
+  color: #666666;
   font-weight: bold;
 }
 .projleadooc{
@@ -308,7 +308,7 @@ em {
   font-weight: bold;
 }
 .headcoderooc{
-  color: #000064;
+  color: #4E47B2;
   font-weight: bold;
 }
 .headminooc{
@@ -320,15 +320,15 @@ em {
   font-weight: bold;
 }
 .adminooc {
-  color: #c3324a;
+  color: #C3324A;
   font-weight: bold;
 }
 .trialminooc{
-  color: #f35a32;
+  color: #F35A32;
   font-weight: bold;
 }
 .candiminooc{
-  color: #ff7a4a;
+  color: #FF7A4A;
   font-weight: bold;
 }
 .mentorooc{
@@ -336,23 +336,23 @@ em {
   font-weight: bold;
 }
 .maintainerooc{
-  color: #4a6fde;
+  color: #4A6FDE;
   font-weight: bold;
 }
 .contributorooc{
-  color: #3283ff;
+  color: #3283FF;
   font-weight: bold;
 }
 .otherooc{
-  color: #835a32;
+  color: #835A32;
   font-weight: bold;
 }
 .msay{
-  color: #927c66;
+  color: #927C66;
   font-weight: bold;
 }
 .adminmsay{
-  color: #84664a;
+  color: #84664A;
   font-weight: bold;
 }
 .headminmsay{
@@ -360,34 +360,34 @@ em {
   font-weight: bold;
 }
 .admin {
-  color: #386aff;
+  color: #3269FF;
   font-weight: bold;
 }
 .asay{
-  color: #9611D4;
+  color: #CC1E58;
   font-weight: bold;
 }
 .headminasay{
-  color: #5A0A7F;
+  color: #A5313B;
   font-weight: bold;
 }
 .boldannounce{
-  color: #ff0000;
+  color: #FF0000;
   font-weight: bold;
 }
 .staffpmin{
-  color: red;
+  color: #CC1E1E;
   font-weight: bold;
 }
 .staffpmout	{
-  color: blue;
+  color: #3D5ECC;
   font-weight: bold;
 }
 .adminnotice{
-  color: #3d5bc3;
+  color: #3D5ECC;
 }
 .adminhelp{
-  color: #c51e1e;
+  color: #CC1E1E;
   font-weight: bold;
 }
 
@@ -409,74 +409,74 @@ em {
 }
 
 .deadsay {
-  color: #732FCD;
+  color: #8041D8;
 }
 .radio{
-  color: #008000;
+  color: #158C15;
 }
 .deptradio{
-  color: #ff00ff;
+  color: #B21AB2;
 }
 .comradio{
-  color: #395A9A;
+  color: #3E67B2;
 }
 .syndradio{
-  color: #6D3F40;
+  color: #7F4648;
 }
 .centradio{
-  color: #5C5C8A;
+  color: #636399;
 }
 .airadio{
-  color: #FF00FF;
+  color: #B21AB2;
 }
 
 .casradio{
-  color: #A30000;
+  color: #A51830;
 }
 .engradio{
-  color: #A66300;
+  color: #CC631E;
 }
 .medradio{
-  color: #008160;
+  color: #158C78;
 }
 .sciradio{
-  color: #993399;
+  color: #993599;
 }
 
 .supradio{
-  color: #5F4519;
+  color: #996F2D;
 }
 
 .alpharadio{
-  color: #EA0000;
+  color: #BF2F2F;
 }
 .bravoradio{
-  color: #C68610;
+  color: #CC8814;
 }
 .charlieradio{
-  color: #AA55AA;
+  color: #B259B2;
 }
 .deltaradio	{
-  color: #3A59D9;
+  color: #3656D8;
 }
 
 .binarysay{
-  color: #20c20e;
+  color: #24BF13;
   background-color: #000000;
   display: block;
 }
 .binarysay a{
-  color: #00ff00;
+  color: #56BF56;
 }
 .binarysay a:active, .binarysay a:visited{
-  color: #88ff88;
+  color: #56BF56;
 }
 
 .alert{
-  color: #ff0000;
+  color: #FF0000;
 }
 h1.alert, h2.alert{
-  color: #99aab5;
+  color: #99AAB5;
 }
 .selecteddna{
   color: #FFFFFF;
@@ -484,7 +484,7 @@ h1.alert, h2.alert{
 }
 
 .attack{
-  color: #ff0000;
+  color: #F22424;
 }
 .moderate{
   color: #CC0000;
@@ -493,85 +493,85 @@ h1.alert, h2.alert{
   color: #990000;
 }
 .passive{
-  color: #660000;
+  color: #8C1515;
 }
 
 .scanner{
-  color: #ff0000;}
+  color: #FF0000;}
 .scannerb	{
-  color: #ff0000;
+  color: #FF0000;
   font-weight: bold;
 }
 .scannerburn{
-  color: #ffa500;
+  color: #FFA500;
 }
 .scannerburnb{
-  color: #ffa500;
+  color: #ffA500;
   font-weight: bold;
 }
 .rose{
-  color: #ff5050;
+  color: #FF4C4C;
 }
 .info{
-  color: #6060c9;
+  color: #6666CC;
 }
 .debuginfo{
-  color: #493D26;
+  color: #6C994C;
   font-style: italic;
 }
 .notice{
-  color: #6060c9;
+  color: #6060C9;
 }
 .xenonotice{
-  color: #2a623d;
+  color: #359980;
 }
 .boldnotice{
-  color: #6060c9;
+  color: #6666CC;
   font-weight: bold;
 }
 .warning{
-  color: #ff5f5f;
+  color: #FF5959;
   font-style: italic;
 }
 .xenowarning{
-  color: #2a623d;
+  color: #359980;
   font-style: italic;
 }
 .danger{
-  color: #ff2a2a;
+  color: #FF2626;
   font-weight: bold;
 }
-.userdanger{color: #ff0000;
+.userdanger{color: #FF0000;
 	font-weight: bold;
   font-size: 3em;
 }
 .xenodanger{
-  color: #2a623d;
+  color: #359980;
   font-weight: bold;
 }
 .avoidharm{
-  color:	#72a0e5;
+  color:	#72A0E5;
   font-weight: bold;
 }
 .highdanger{
-  color: #ff0000;
+  color: #FF2626;
   font-weight: bold;
   font-size: 1.5em;
 }
 .xenohighdanger{
-  color: #2a623d;
+  color: #359980;
   font-weight: bold;
   font-size: 1.5em;
 }
 .xenoannounce{
-  color: #1a472a;
+  color: #2C7F5C;
   font-family: book-antiqua;
   font-weight: bold;
   font-style: italic;
   font-size: 1.5em;
 }
 .hivemind{
-  color: #BF39AF;
+  color: #B23593;
   font-weight: bold;
 }
 .xenoqueen{
@@ -592,10 +592,10 @@ h1.alert, h2.alert{
 }
 
 .alien{
-  color: #543354;
+  color: #7F4C7F;
 }
 .newscaster{
-  color: #750000;
+  color: #993D3D;
 }
 
 .role_header{


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Per title. Changes most of the Dark Mode colors in hopes that these will be better for our eyes, and attempts to deal with some atrocities currently present in Dark Mode.

## Why It's Good For The Game

Our old dark mode colors were sometimes too dark, in some cases. This pull request aims to change that for the better.
I figured I should explain this with the assistance of some screenshots.

Firstly, a side-by-side comparison of the old and new colors, respectively:

![image](https://user-images.githubusercontent.com/59634950/128235906-b6d1c9dc-df80-4428-adec-da0f9790c838.png)

The changes are barely noticeable save in some cases, such as the Alpha channel and Fire Support channel, which have much more tame color hues. The same can be said for the Requisitions channel.


Up next, xenomorph alerts/announcements. The top is the new one, and the bottom is the old one.

![image](https://user-images.githubusercontent.com/59634950/128236521-9829c196-f269-4369-93f9-e3d20bada30c.png)

As you can see, I've gone for a more bright option here since I felt it was too dark.
The old color is kept for xenomorph warnings _(hopefully)_ since those don't need to be so noticeable.


I've also taken the liberty of changing the colors for some admin-related stuff, such as asay colors, since there were some major offenders here and there:

![image](https://user-images.githubusercontent.com/59634950/128239929-a7c92e9d-26ad-42dd-8c18-e42956595775.png)

Top are the new colors, bottom are the old ones. Note the dark purple color for lead asay, which has been changed to a different hue.



## Changelog
:cl: Lewdcifer
qol: Changed Dark Mode colors to more eye-friendly alternatives.
/:cl:
