### PR TITLE
HMG/HSG undeploy in 3 seconds, HMG deploys ~500ms faster.

### DIFF
--- a/code/modules/projectiles/guns/mounted.dm
+++ b/code/modules/projectiles/guns/mounted.dm
@@ -60,7 +60,7 @@
 	)
 
 	deploy_time = 5 SECONDS
-	undeploy_time = 5 SECONDS
+	undeploy_time = 3 SECONDS
 
 	max_integrity = 125
 
@@ -143,8 +143,8 @@
 		/obj/item/attachable/scope/unremovable/heavymachinegun,
 	)
 
-	deploy_time = 8.5 SECONDS
-	undeploy_time = 8.5 SECONDS
+	deploy_time = 8 SECONDS
+	undeploy_time = 3 SECONDS
 
 	max_integrity = 150
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
HMG could use a bit of time shaved off it's deploy, in general if it's moved often and 500~ms less should go a bit to making it feel easier to deploy, could reduce it to 7.5 and shave off a whole second, but I think 8 is fine.
Undeploy is now 3 seconds across the board, and should make HMG esp way better to play with. As moving the gun takes drastically less time.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
HSG and HMG shouldn't take quite this long to undeploy.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: HMG deploys ~500ms faster, and HSG/HMG undeploy far faster. (3 seconds as opposed to 5 and 8.5 respectively)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
