### PR TITLE
Praetorian teamplay buff, making it more useful as a t3

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -30,6 +30,8 @@
 	playsound(X.loc, 'sound/effects/refill.ogg', 25, 1)
 	X.visible_message(span_xenowarning("\The [X] spews forth a wide cone of acid!"), \
 	span_xenowarning("We spew forth a cone of acid!"), null, 5)
+	
+	start_acid_spray_cone(target, X.xeno_caste.acid_spray_range)
 
 /datum/action/xeno_action/activable/spray_acid/cone/proc/reset_speed()
 	var/mob/living/carbon/xenomorph/spraying_xeno = owner

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -7,7 +7,7 @@
 	mechanics_text = "Spray a cone of dangerous acid at your target."
 	ability_name = "spray acid"
 	plasma_cost = 200
-	cooldown_timer = 30 SECONDS
+	cooldown_timer = 35 SECONDS
 
 /datum/action/xeno_action/activable/spray_acid/cone/use_ability(atom/A)
 	var/mob/living/carbon/xenomorph/X = owner

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -7,7 +7,7 @@
 	mechanics_text = "Spray a cone of dangerous acid at your target."
 	ability_name = "spray acid"
 	plasma_cost = 200
-	cooldown_timer = 35 SECONDS
+	cooldown_timer = 40 SECONDS
 
 /datum/action/xeno_action/activable/spray_acid/cone/use_ability(atom/A)
 	var/mob/living/carbon/xenomorph/X = owner

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -7,7 +7,7 @@
 	mechanics_text = "Spray a cone of dangerous acid at your target."
 	ability_name = "spray acid"
 	plasma_cost = 400
-	cooldown_timer = 20 SECONDS
+	cooldown_timer = 30 SECONDS
 
 /datum/action/xeno_action/activable/spray_acid/cone/use_ability(atom/A)
 	var/mob/living/carbon/xenomorph/X = owner
@@ -31,10 +31,10 @@
 	X.visible_message(span_xenowarning("\The [X] spews forth a wide cone of acid!"), \
 	span_xenowarning("We spew forth a cone of acid!"), null, 5)
 
-	X.add_movespeed_modifier(type, TRUE, 0, NONE, TRUE, 1)
+	X.add_movespeed_modifier(type, TRUE, 0, NONE, TRUE, 0)
 	start_acid_spray_cone(target, X.xeno_caste.acid_spray_range)
 	add_cooldown()
-	addtimer(CALLBACK(src, .proc/reset_speed), rand(1 SECONDS, 1 SECONDS))
+	addtimer(CALLBACK(src, .proc/reset_speed), rand(0 SECONDS, 0 SECONDS))
 
 /datum/action/xeno_action/activable/spray_acid/cone/proc/reset_speed()
 	var/mob/living/carbon/xenomorph/spraying_xeno = owner

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -32,6 +32,7 @@
 	span_xenowarning("We spew forth a cone of acid!"), null, 5)
 	
 	start_acid_spray_cone(target, X.xeno_caste.acid_spray_range)
+	add_cooldown()
 
 /datum/action/xeno_action/activable/spray_acid/cone/proc/reset_speed()
 	var/mob/living/carbon/xenomorph/spraying_xeno = owner

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -6,7 +6,7 @@
 	action_icon_state = "spray_acid"
 	mechanics_text = "Spray a cone of dangerous acid at your target."
 	ability_name = "spray acid"
-	plasma_cost = 400
+	plasma_cost = 200
 	cooldown_timer = 30 SECONDS
 
 /datum/action/xeno_action/activable/spray_acid/cone/use_ability(atom/A)

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -6,8 +6,8 @@
 	action_icon_state = "spray_acid"
 	mechanics_text = "Spray a cone of dangerous acid at your target."
 	ability_name = "spray acid"
-	plasma_cost = 200
-	cooldown_timer = 40 SECONDS
+	plasma_cost = 400
+	cooldown_timer = 20 SECONDS
 
 /datum/action/xeno_action/activable/spray_acid/cone/use_ability(atom/A)
 	var/mob/living/carbon/xenomorph/X = owner
@@ -31,10 +31,10 @@
 	X.visible_message(span_xenowarning("\The [X] spews forth a wide cone of acid!"), \
 	span_xenowarning("We spew forth a cone of acid!"), null, 5)
 
-	X.add_movespeed_modifier(type, TRUE, 0, NONE, TRUE, 2)
+	X.add_movespeed_modifier(type, TRUE, 0, NONE, TRUE, 1)
 	start_acid_spray_cone(target, X.xeno_caste.acid_spray_range)
 	add_cooldown()
-	addtimer(CALLBACK(src, .proc/reset_speed), rand(2 SECONDS, 3 SECONDS))
+	addtimer(CALLBACK(src, .proc/reset_speed), rand(1 SECONDS, 1 SECONDS))
 
 /datum/action/xeno_action/activable/spray_acid/cone/proc/reset_speed()
 	var/mob/living/carbon/xenomorph/spraying_xeno = owner

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -31,11 +31,6 @@
 	X.visible_message(span_xenowarning("\The [X] spews forth a wide cone of acid!"), \
 	span_xenowarning("We spew forth a cone of acid!"), null, 5)
 
-	X.add_movespeed_modifier(type, TRUE, 0, NONE, TRUE, 0)
-	start_acid_spray_cone(target, X.xeno_caste.acid_spray_range)
-	add_cooldown()
-	addtimer(CALLBACK(src, .proc/reset_speed), rand(0 SECONDS, 0 SECONDS))
-
 /datum/action/xeno_action/activable/spray_acid/cone/proc/reset_speed()
 	var/mob/living/carbon/xenomorph/spraying_xeno = owner
 	if(QDELETED(spraying_xeno))

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
@@ -70,7 +70,7 @@
 	upgrade = XENO_UPGRADE_ONE
 
 	// *** Speed *** //
-	speed = -0.4
+	speed = -0.3
 
 	// *** Plasma *** //
 	plasma_max = 850
@@ -105,7 +105,7 @@
 	melee_damage = 20
 
 	// *** Speed *** //
-	speed = -0.5
+	speed = -0.4
 
 	// *** Plasma *** //
 	plasma_max = 900
@@ -141,7 +141,7 @@
 	melee_damage = 20
 
 	// *** Speed *** //
-	speed = -0.6
+	speed = -0.5
 
 	// *** Plasma *** //
 	plasma_max = 950

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
@@ -9,7 +9,7 @@
 	wound_type = "praetorian" //used to match appropriate wound overlays
 
 	// *** Melee Attacks *** //
-	melee_damage = 20
+	melee_damage = 18
 
 	// *** Speed *** //
 	speed = -0.2
@@ -73,11 +73,11 @@
 	speed = -0.4
 
 	// *** Plasma *** //
-	plasma_max = 1000
+	plasma_max = 850
 	plasma_gain = 60
 
 	// *** Health *** //
-	max_health = 345
+	max_health = 340
 
 	// *** Evolution *** //
 	upgrade_threshold = 750
@@ -102,17 +102,17 @@
 	upgrade = XENO_UPGRADE_TWO
 
 	// *** Melee Attacks *** //
-	melee_damage = 23
+	melee_damage = 19
 
 	// *** Speed *** //
 	speed = -0.5
 
 	// *** Plasma *** //
-	plasma_max = 1100
+	plasma_max = 900
 	plasma_gain = 65
 
 	// *** Health *** //
-	max_health = 365
+	max_health = 345
 
 	// *** Evolution *** //
 	upgrade_threshold = 1750
@@ -138,17 +138,17 @@
 	ancient_message = "We are the strongest ranged fighter around. Our spit is devastating and we can fire nearly a constant stream."
 
 	// *** Melee Attacks *** //
-	melee_damage = 23
+	melee_damage = 20
 
 	// *** Speed *** //
 	speed = -0.6
 
 	// *** Plasma *** //
-	plasma_max = 1200
+	plasma_max = 100
 	plasma_gain = 70
 
 	// *** Health *** //
-	max_health = 390
+	max_health = 350
 
 	// *** Evolution *** //
 	upgrade_threshold = 2750

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
@@ -144,7 +144,7 @@
 	speed = -0.6
 
 	// *** Plasma *** //
-	plasma_max = 100
+	plasma_max = 950
 	plasma_gain = 70
 
 	// *** Health *** //

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
@@ -70,27 +70,28 @@
 	upgrade = XENO_UPGRADE_ONE
 
 	// *** Speed *** //
-	speed = -0.3
+	speed = -0.4
 
 	// *** Plasma *** //
-	plasma_max = 900
+	plasma_max = 1000
 	plasma_gain = 60
 
 	// *** Health *** //
-	max_health = 320
+	max_health = 345
 
 	// *** Evolution *** //
 	upgrade_threshold = 750
 
 	// *** Defense *** //
-	soft_armor = list("melee" = 35, "bullet" = 40, "laser" = 40, "energy" = 40, "bomb" = XENO_BOMB_RESIST_0, "bio" = 33, "rad" = 33, "fire" = 40, "acid" = 33)
+	soft_armor = list("melee" = 37, "bullet" = 43, "laser" = 43, "energy" = 43, "bomb" = XENO_BOMB_RESIST_0, "bio" = 33, "rad" = 33, "fire" = 43, "acid" = 33)
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.2 SECONDS
 	spit_types = list(/datum/ammo/xeno/toxin/heavy/upgrade1, /datum/ammo/xeno/acid/heavy)
 
-	acid_spray_damage_on_hit = 39
-	acid_spray_structure_damage = 53
+	acid_spray_damage_on_hit = 45
+	acid_spray_damage = 15
+	acid_spray_structure_damage = 45
 
 	// *** Pheromones *** //
 	aura_strength = 3.5
@@ -104,27 +105,28 @@
 	melee_damage = 23
 
 	// *** Speed *** //
-	speed = -0.4
+	speed = -0.5
 
 	// *** Plasma *** //
-	plasma_max = 1000
-	plasma_gain = 70
+	plasma_max = 1100
+	plasma_gain = 65
 
 	// *** Health *** //
-	max_health = 340
+	max_health = 365
 
 	// *** Evolution *** //
 	upgrade_threshold = 1750
 
 	// *** Defense *** //
-	soft_armor = list("melee" = 40, "bullet" = 45, "laser" = 45, "energy" = 45, "bomb" = XENO_BOMB_RESIST_0, "bio" = 35, "rad" = 35, "fire" = 45, "acid" = 35)
+	soft_armor = list("melee" = 43, "bullet" = 47, "laser" = 47, "energy" = 47, "bomb" = XENO_BOMB_RESIST_0, "bio" = 35, "rad" = 35, "fire" = 47, "acid" = 35)
 
 	// *** Ranged Attack *** //
 	spit_delay = 1.1 SECONDS
 	spit_types = list(/datum/ammo/xeno/toxin/heavy/upgrade2, /datum/ammo/xeno/acid/heavy)
 
-	acid_spray_damage_on_hit = 43
-	acid_spray_structure_damage = 61
+	acid_spray_damage_on_hit = 50
+	acid_spray_damage = 20
+	acid_spray_structure_damage = 55
 
 	// *** Pheromones *** //
 	aura_strength = 4
@@ -139,27 +141,28 @@
 	melee_damage = 23
 
 	// *** Speed *** //
-	speed = -0.5
+	speed = -0.6
 
 	// *** Plasma *** //
-	plasma_max = 1000
-	plasma_gain = 80
+	plasma_max = 1200
+	plasma_gain = 70
 
 	// *** Health *** //
-	max_health = 360
+	max_health = 390
 
 	// *** Evolution *** //
 	upgrade_threshold = 2750
 
 	// *** Defense *** //
-	soft_armor = list("melee" = 45, "bullet" = 50, "laser" = 50, "energy" = 50, "bomb" = XENO_BOMB_RESIST_0, "bio" = 38, "rad" = 38, "fire" = 50, "acid" = 38)
+	soft_armor = list("melee" = 50, "bullet" = 50, "laser" = 50, "energy" = 50, "bomb" = XENO_BOMB_RESIST_0, "bio" = 38, "rad" = 38, "fire" = 50, "acid" = 38)
 
 	// *** Ranged Attack *** //
 	spit_delay = 1 SECONDS
 	spit_types = list(/datum/ammo/xeno/toxin/heavy/upgrade3, /datum/ammo/xeno/acid/heavy)
 
-	acid_spray_damage_on_hit = 47
-	acid_spray_structure_damage = 69
+	acid_spray_damage_on_hit = 56
+	acid_spray_damage = 25
+	acid_spray_structure_damage = 60
 
 	// *** Pheromones *** //
 	aura_strength = 4.5

--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
@@ -102,7 +102,7 @@
 	upgrade = XENO_UPGRADE_TWO
 
 	// *** Melee Attacks *** //
-	melee_damage = 19
+	melee_damage = 20
 
 	// *** Speed *** //
 	speed = -0.5


### PR DESCRIPTION
## About The Pull Request

Makes Praetorian more effective and deadlier for the hive as a T3 should

## Why It's Good For The Game

Currently, praetorian's neuro spit does absolutely nothing in helping slow a marine push, this is after 12+ matches with the Neuro tweak PR that increases it by 30, I realize the issue is deep enough that the caste itself is just not up to par.

## Changelog
:cl:
balance: neuro spit delay reduced by 0.1 per tier for a total of 1 second at ancient paired with neuro tweak pr
balance: prae's health tweaked ever so slightly
balance: acid spray damage tweaked, now has proper tick damage code placed rather than default.
balance: Acid spray slow down now REMOVED. serves no more purpose, retains 40-second cooldown.
/:cl:


 
after another round of buffs and debates, this prae is now here. Prae is a T3 mini queen and should  at least retain T3 status, the intention with the delay reduction but increased cost is to assist in slowing marine pushes whilst also allowing a retreat ability as marines can run down a prae pre this pr quite easily.
