### PR TITLE
Removes Last Remaining References To Xeno Respawn Timers

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -99,11 +99,6 @@
 		if(O.client.inactivity / 600 > ALIEN_SELECT_AFK_BUFFER + 5)
 			continue
 
-		//Recently dead observers cannot be drafted.
-		var/deathtime = world.time - O.timeofdeath
-		if(deathtime < GLOB.xenorespawntime)
-			continue
-
 		//Aghosted admins don't get picked
 		if(O.mind?.current && isclientedaghost(O.mind.current))
 			continue

--- a/code/_globalvars/admin.dm
+++ b/code/_globalvars/admin.dm
@@ -5,7 +5,6 @@ GLOBAL_VAR_INIT(enter_allowed, TRUE)
 GLOBAL_VAR_INIT(respawn_allowed, TRUE)
 
 GLOBAL_VAR_INIT(respawntime, 30 MINUTES)
-GLOBAL_VAR_INIT(xenorespawntime, 2 MINUTES)
 GLOBAL_VAR_INIT(fileaccess_timer, 0)
 
 GLOBAL_VAR_INIT(custom_info, "")

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -113,8 +113,3 @@
 	config_entry_value = 30 MINUTES
 	max_val = 30 MINUTES
 	min_val = 0
-
-/datum/config_entry/number/xeno_respawn
-	config_entry_value = 30 MINUTES
-	max_val = 30 MINUTES
-	min_val = 0

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -42,8 +42,6 @@ SUBSYSTEM_DEF(ticker)
 /datum/controller/subsystem/ticker/Initialize(timeofday)
 	load_mode()
 
-	GLOB.xenorespawntime = CONFIG_GET(number/xeno_respawn)
-
 	var/all_music = CONFIG_GET(keyed_list/lobby_music)
 	var/key = SAFEPICK(all_music)
 	if(key)

--- a/code/modules/admin/holder.dm
+++ b/code/modules/admin/holder.dm
@@ -433,7 +433,6 @@ GLOBAL_PROTECT(admin_verbs_fun)
 	/datum/admins/proc/toggle_join,
 	/datum/admins/proc/toggle_respawn,
 	/datum/admins/proc/set_respawn_time,
-	/datum/admins/proc/set_xenorespawn_time,
 	/datum/admins/proc/end_round,
 	/datum/admins/proc/delay_start,
 	/datum/admins/proc/delay_end,

--- a/code/modules/admin/server_verbs.dm
+++ b/code/modules/admin/server_verbs.dm
@@ -309,23 +309,6 @@
 	message_admins("[ADMIN_TPMONTY(usr)] set the respawn time to [SSticker.mode?.respawn_time * 0.1] seconds.")
 
 
-/datum/admins/proc/set_xenorespawn_time(time as num)
-	set category = "Server"
-	set name = "Set Xeno Respawn Timer"
-	set desc = "Sets the global xeno respawn timer."
-
-	if(!check_rights(R_SERVER))
-		return
-
-	if(time < 0)
-		return
-
-	GLOB.xenorespawntime = time
-
-	log_admin("[key_name(usr)] set the xeno respawn time to [GLOB.xenorespawntime * 0.1] seconds.")
-	message_admins("[ADMIN_TPMONTY(usr)] set the xeno respawn time to [GLOB.xenorespawntime * 0.1] seconds.")
-
-
 /datum/admins/proc/end_round()
 	set category = "Server"
 	set name = "End Round"

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -332,11 +332,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 			else
 				stat("Respawn timer:", "[(status_value / 60) % 60]:[add_leading(num2text(status_value % 60), 2, "0")]")
 			if(SSticker.mode?.flags_round_type & MODE_INFESTATION)
-				status_value = (timeofdeath + GLOB.xenorespawntime - world.time) * 0.1
-				if(status_value <= 0)
-					stat("Xeno respawn timer:", "<b>READY</b>")
-				else
-					stat("Xeno respawn timer:", "[(status_value / 60) % 60]:[add_leading(num2text(status_value % 60), 2, "0")]")
+				stat("Xeno respawn timer:", "<b>READY</b>") // There is no longer a timer for xeno respawn. It is always READY.
 				if(larva_position)
 					stat("Position in larva candidate queue: ", "[larva_position]")
 				var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -177,7 +177,7 @@
 	return "\nYou might have to wait a certain time to respawn or be unable to, depending on the game mode!"
 
 /datum/game_mode/infestation/observe_respawn_message()
-	return "\nYou will have to wait at least [SSticker.mode?.respawn_time * 0.1] or [GLOB.xenorespawntime * 0.1] seconds before being able to respawn as a marine or alien, respectively!"
+	return "\nYou will have to wait at least [SSticker.mode?.respawn_time * 0.1] seconds before being able to respawn as a marine or join the aliens by hopping into the larva queue now!"
 
 /mob/new_player/proc/late_choices()
 	var/list/dat = list("<div class='notice'>Round Duration: [DisplayTimeText(world.time - SSticker.round_start_time)]</div>")


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Purges the few remnants of xeno respawn timers from the code.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

No longer will the status page lie and say 2 minutes until larva respawn. You can immediately join the queue thanks to #7684.

## Changelog
:cl:
del: Removes remaining references to xeno respawn timers missed earlier.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
