### PR TITLE
Adds the Functionality For Xeno Buttons To Be Hidden Via Flag On Xeno Action

### DIFF
--- a/code/__DEFINES/actions.dm
+++ b/code/__DEFINES/actions.dm
@@ -18,6 +18,9 @@
 
 #define XACT_KEYBIND_USE_ABILITY (1 << 0) // immediately activate even if selectable
 
+#define XACT_HIVE_PANEL (1 << 0) // usage located in the hive management panel
+#define XACT_BUTTON_HIDDEN (1 << 1) // button not shown in the main game bar
+#define XACT_XENO_TARGET (1 << 2) // action targets other xenos
 
 #define ABILITY_CRASH (1<<0)
 #define ABILITY_DISTRESS (1<<1)

--- a/code/__DEFINES/actions.dm
+++ b/code/__DEFINES/actions.dm
@@ -18,9 +18,7 @@
 
 #define XACT_KEYBIND_USE_ABILITY (1 << 0) // immediately activate even if selectable
 
-#define XACT_HIVE_PANEL (1 << 0) // usage located in the hive management panel
-#define XACT_BUTTON_HIDDEN (1 << 1) // button not shown in the main game bar
-#define XACT_XENO_TARGET (1 << 2) // action targets other xenos
+#define XACT_BUTTON_HIDDEN (1 << 0) // button not shown in the main game bar
 
 #define ABILITY_CRASH (1<<0)
 #define ABILITY_DISTRESS (1<<1)

--- a/code/datums/actions/xeno_action.dm
+++ b/code/datums/actions/xeno_action.dm
@@ -14,6 +14,8 @@
 	var/gamemode_flags = ABILITY_ALL_GAMEMODE
 	///Alternative keybind signal, to use the action differently
 	var/alternate_keybind_signal
+	/// Flags for abilities that are located in Hive Management Panel.
+	var/hive_flags
 
 /datum/action/xeno_action/New(Target)
 	. = ..()
@@ -44,6 +46,10 @@
 	X.xeno_abilities -= src
 	return ..()
 
+/datum/action/xeno_action/should_show()
+	. = ..()
+	if(CHECK_BITFIELD(hive_flags, XACT_BUTTON_HIDDEN))
+		return FALSE
 
 /datum/action/xeno_action/proc/keybind_activation()
 	SIGNAL_HANDLER


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

XACT_BUTTON_HIDDEN hides the button from the main screen button bar. Currently unused by any button but planned for Build Silo, Build Turret, Summon King, Give Leadership, Overwatch, and De-evolve. All of which are being relocated to Hive Management Panel.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

A further atom sized PR for Hive Management Panel. Additional flags may be added later but this is the one actually implemented.

## Changelog
:cl:
code: Adds new functionality to xeno actions that allow certain buttons to be hidden via flag.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
