### PR TITLE
Grav crush does less damage to mobs

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
@@ -106,7 +106,7 @@
 					var/mob/living/carbon/xenomorph/xeno = mob_crushed
 					if(xeno.hive == xeno_owner.hive)
 						continue
-				mob_crushed.ex_act(EXPLODE_DEVASTATE)
+				mob_crushed.ex_act(EXPLODE_LIGHT)
 				continue
 			item.ex_act(EXPLODE_HEAVY)	//crushing without damaging the nearby area
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/abilities_king.dm
@@ -106,6 +106,8 @@
 					var/mob/living/carbon/xenomorph/xeno = mob_crushed
 					if(xeno.hive == xeno_owner.hive)
 						continue
+				mob_crushed.ex_act(EXPLODE_DEVASTATE)
+				continue
 			item.ex_act(EXPLODE_HEAVY)	//crushing without damaging the nearby area
 
 /datum/action/xeno_action/activable/gravity_crush/ai_should_start_consider()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Grav crush will still be strong against cade and such, less against marine

## Why It's Good For The Game

King should be good at one thing : kill the fob. Xeno should not use it while defending, they should prefer silos and turrets. This makes king a more specialsed caste, rather than what it is currently

Alternative to : https://github.com/tgstation/TerraGov-Marine-Corps/pull/7806 
which just give you an arbitrary length which a round should last. This is an half ass solution, if xeno wiped out marines they should be able to finish the fight now ; not 30 minutes later because of some stupid time limit

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Grav crush does less damage to mobs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
