### PR TITLE
Fixes vendors duping reagent containers and stacks

### DIFF
--- a/code/game/objects/items/reagent_containers/reagent_container.dm
+++ b/code/game/objects/items/reagent_containers/reagent_container.dm
@@ -68,3 +68,10 @@
 			. += "; [R.name]([R.volume]u)"
 	else
 		. = "No reagents"
+
+///Returns TRUE if the current reagents contain at least everything in the list_reagents, FALSE otherwise
+/obj/item/reagent_containers/proc/has_initial_reagents()
+	for(var/reagent_to_check in list_reagents)
+		if(reagents.get_reagent_amount(reagent_to_check) != list_reagents[reagent_to_check])
+			return FALSE
+	return TRUE

--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -683,6 +683,16 @@
 			if(cell.charge < cell.maxcharge)
 				to_chat(user, span_warning("\The [cell] isn't full. You must recharge it before you can restock it."))
 				return
+		else if(istype(item_to_stock, /obj/item/stack))
+			var/obj/item/stack/stack = item_to_stock
+			if(stack.amount != initial(stack.amount))
+				to_chat(user, span_warning("\The [stack] doesn't have the same count as it started with, [initial(stack.amount)]. You must fix this before you can restock it."))
+				return
+		else if(istype(item_to_stock, /obj/item/reagent_containers))
+			var/obj/item/reagent_containers/holder = item_to_stock
+			if(!holder.has_initial_reagents())
+				to_chat(user, span_warning("\The [holder] doesn't have the medicine it came with in it. You must refill it before you can restock it."))
+				return
 		if(item_to_stock.loc == user) //Inside the mob's inventory
 			if(item_to_stock.flags_item & WIELDED)
 				item_to_stock.unwield(user)


### PR DESCRIPTION
## About The Pull Request
Prevents restocking vending machines with partial stacks and reagent containers(bottles, autoinjectors, etc) that don't have their initial reagents.

## Why It's Good For The Game
Partial restocking allows infinite duping. Anything that should be infinite should be made infinite through the vendor supply list, rather than through bug abuse.

## Changelog
:cl:
fix: Reagent containers which don't have their starting reagents can't be used to restock vending machines
fix: Stacks need to be at their starting stack count to restock vendors.
/:cl: