### PR TITLE
Chemistry access changes

### DIFF
--- a/code/datums/jobs/job/marines.dm
+++ b/code/datums/jobs/job/marines.dm
@@ -210,8 +210,8 @@ Your squaddies will look to you when it comes to construction in the field of ba
 	paygrade = "E3"
 	comm_title = "Med"
 	total_positions = 16
-	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_MEDPREP, ACCESS_MARINE_MEDBAY)
-	minimal_access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_MEDPREP, ACCESS_MARINE_MEDBAY, ACCESS_MARINE_DROPSHIP)
+	access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_MEDPREP, ACCESS_MARINE_MEDBAY, ACCESS_MARINE_CHEMISTRY)
+	minimal_access = list(ACCESS_MARINE_PREP, ACCESS_MARINE_MEDPREP, ACCESS_MARINE_MEDBAY, ACCESS_MARINE_CHEMISTRY, ACCESS_MARINE_DROPSHIP)
 	skills_type = /datum/skills/combat_medic
 	display_order = JOB_DISPLAY_ORDER_SQUAD_CORPSMAN
 	outfit = /datum/outfit/job/marine/corpsman

--- a/code/game/objects/machinery/kitchen/smartfridge.dm
+++ b/code/game/objects/machinery/kitchen/smartfridge.dm
@@ -284,7 +284,6 @@
 	name = "\improper Smart Chemical Storage"
 	desc = "A refrigerated storage unit for medicine and chemical storage."
 	is_secure_fridge = TRUE
-	req_one_access = list(ACCESS_MARINE_MEDBAY, ACCESS_MARINE_CHEMISTRY, ACCESS_MARINE_MEDPREP) //Medics can now access the fridge
 
 /obj/machinery/smartfridge/chemistry/accept_check(obj/item/O as obj)
 	if(istype(O,/obj/item/storage/pill_bottle) || istype(O,/obj/item/reagent_containers))

--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -166,6 +166,14 @@
 	. = ..()
 	if(.)
 		return
+
+	if(ishuman(usr))
+		var/mob/living/carbon/human/user = usr
+		if(!user.skills.getRating("medical"))
+			to_chat(user, span_notice("You start fiddling with \the [src]..."))
+			if(!do_after(user, SKILL_TASK_EASY, TRUE, src, BUSY_ICON_UNSKILLED))
+				return
+
 	switch(action)
 		if("amount")
 			if(!is_operational() || QDELETED(beaker))

--- a/code/modules/reagents/machinery/chem_master.dm
+++ b/code/modules/reagents/machinery/chem_master.dm
@@ -100,6 +100,11 @@
 
 	var/mob/living/carbon/human/user = usr
 
+	if(!user.skills.getRating("medical"))
+		to_chat(user, span_notice("You start fiddling with \the [src]..."))
+		if(!do_after(user, SKILL_TASK_EASY, TRUE, src, BUSY_ICON_UNSKILLED))
+			return
+
 	if (href_list["ejectp"])
 		if(loaded_pill_bottle)
 			loaded_pill_bottle.loc = loc


### PR DESCRIPTION
## About The Pull Request
Makes the smartfridges in medical all-access.
Gives corpsmen chemistry door access.
Adds a delay to using chemistry machines without medical training.

## Why It's Good For The Game
I'm tired of people breaking into chemistry every single round. This starts to address that by making it unnecessary in some cases (corpsmen, using the fridge) and otherwise making it, if not less rewarding, slightly more annoying for the actor.

## Changelog
:cl:
qol: Everyone can use the medbay smartfridges.
balance: Corpsmen have chemistry access now.
balance: Trying to use the chem dispenser/chem master without at least basic medical training will incur delays.
/:cl: