### PR TITLE
Fixes new light fixtures being destroyed upon creation

### DIFF
--- a/code/game/objects/items/frames/light_fixtures.dm
+++ b/code/game/objects/items/frames/light_fixtures.dm
@@ -7,13 +7,7 @@
 	icon_state = "tube-construct-item"
 	flags_atom = CONDUCT
 	var/fixture_type = "tube"
-	var/obj/machinery/light/newlight = null
 	var/sheets_refunded = 2
-
-/obj/item/frame/light_fixture/Destroy()
-	QDEL_NULL(newlight)
-	return ..()
-
 
 /obj/item/frame/light_fixture/attackby(obj/item/I, mob/user, params)
 	. = ..()
@@ -38,6 +32,7 @@
 	var/constrloc = usr.loc
 	if (!do_after(usr, 30, TRUE, on_wall, BUSY_ICON_BUILD))
 		return
+	var/obj/machinery/light/newlight
 	switch(fixture_type)
 		if("bulb")
 			newlight = new /obj/machinery/light_construct/small(constrloc)


### PR DESCRIPTION
## About The Pull Request
As title, new light fixtures made out of metal should work now.
Fixes #7801 

## Why It's Good For The Game
Bugfix.

## Changelog
:cl:
fix: You can once again make light fixtures.
/:cl: