### PR TITLE
balances sentinel missing tier upgrades.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/castedatum_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/castedatum_sentinel.dm
@@ -117,7 +117,7 @@
 	melee_damage = 17
 
 	// *** Speed *** //
-	speed = 0.9
+	speed = -0.9
 
 	// *** Plasma *** //
 	plasma_max = 600

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/castedatum_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/castedatum_sentinel.dm
@@ -88,7 +88,7 @@
 	melee_damage = 17
 
 	// *** Speed *** //
-	speed = -0.9
+	speed = -0.8
 
 	// *** Plasma *** //
 	plasma_max = 550
@@ -117,7 +117,7 @@
 	melee_damage = 17
 
 	// *** Speed *** //
-	speed = -1
+	speed = 0.9
 
 	// *** Plasma *** //
 	plasma_max = 600

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/castedatum_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/castedatum_sentinel.dm
@@ -133,6 +133,6 @@
 	soft_armor = list("melee" = 26, "bullet" = 26, "laser" = 26, "energy" = 26, "bomb" = XENO_BOMB_RESIST_0, "bio" = 25, "rad" = 25, "fire" = 26, "acid" = 25)
 
 	// *** Ranged Attack *** //
-	spit_delay = 0.9 SECONDS
+	spit_delay = 1 SECONDS
 	spit_types = list(/datum/ammo/xeno/toxin/upgrade3, /datum/ammo/xeno/acid)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/castedatum_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/castedatum_sentinel.dm
@@ -63,7 +63,7 @@
 
 	// *** Plasma *** //
 	plasma_max = 450
-	plasma_gain = 15
+	plasma_gain = 17
 
 	// *** Health *** //
 	max_health = 250
@@ -88,14 +88,14 @@
 	melee_damage = 17
 
 	// *** Speed *** //
-	speed = -0.8
+	speed = -0.9
 
 	// *** Plasma *** //
 	plasma_max = 550
-	plasma_gain = 18
+	plasma_gain = 20
 
 	// *** Health *** //
-	max_health = 275
+	max_health = 260
 
 	// *** Evolution *** //
 	upgrade_threshold = 420
@@ -117,14 +117,14 @@
 	melee_damage = 17
 
 	// *** Speed *** //
-	speed = -0.9
+	speed = -1
 
 	// *** Plasma *** //
 	plasma_max = 600
-	plasma_gain = 20
+	plasma_gain = 23
 
 	// *** Health *** //
-	max_health = 300
+	max_health = 275
 
 	// *** Evolution *** //
 	upgrade_threshold = 660
@@ -133,6 +133,6 @@
 	soft_armor = list("melee" = 26, "bullet" = 26, "laser" = 26, "energy" = 26, "bomb" = XENO_BOMB_RESIST_0, "bio" = 25, "rad" = 25, "fire" = 26, "acid" = 25)
 
 	// *** Ranged Attack *** //
-	spit_delay = 1 SECONDS
+	spit_delay = 0.9 SECONDS
 	spit_types = list(/datum/ammo/xeno/toxin/upgrade3, /datum/ammo/xeno/acid)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/castedatum_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/castedatum_sentinel.dm
@@ -75,7 +75,7 @@
 	soft_armor = list("melee" = 20, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = XENO_BOMB_RESIST_0, "bio" = 20, "rad" = 20, "fire" = 20, "acid" = 20)
 
 	// *** Ranged Attack *** //
-	spit_delay = 1.3 SECONDS
+	spit_delay = 1.2 SECONDS
 	spit_types = list(/datum/ammo/xeno/toxin/upgrade1, /datum/ammo/xeno/acid)
 
 /datum/xeno_caste/sentinel/elder
@@ -88,7 +88,7 @@
 	melee_damage = 17
 
 	// *** Speed *** //
-	speed = -0.8
+	speed = -0.9
 
 	// *** Plasma *** //
 	plasma_max = 550
@@ -104,7 +104,7 @@
 	soft_armor = list("melee" = 23, "bullet" = 23, "laser" = 23, "energy" = 23, "bomb" = XENO_BOMB_RESIST_0, "bio" = 23, "rad" = 23, "fire" = 23, "acid" = 23)
 
 	// *** Ranged Attack *** //
-	spit_delay = 1.3 SECONDS
+	spit_delay = 1.1 SECONDS
 	spit_types = list(/datum/ammo/xeno/toxin/upgrade2, /datum/ammo/xeno/acid)
 
 /datum/xeno_caste/sentinel/ancient
@@ -117,7 +117,7 @@
 	melee_damage = 17
 
 	// *** Speed *** //
-	speed = -0.8
+	speed = -1
 
 	// *** Plasma *** //
 	plasma_max = 600
@@ -133,6 +133,6 @@
 	soft_armor = list("melee" = 26, "bullet" = 26, "laser" = 26, "energy" = 26, "bomb" = XENO_BOMB_RESIST_0, "bio" = 25, "rad" = 25, "fire" = 26, "acid" = 25)
 
 	// *** Ranged Attack *** //
-	spit_delay = 1.3 SECONDS
+	spit_delay = 1 SECONDS
 	spit_types = list(/datum/ammo/xeno/toxin/upgrade3, /datum/ammo/xeno/acid)
 


### PR DESCRIPTION
## About The Pull Request

Sentinel had no upgrades to its speed which stayed at -0.8 from young to ancient & no upgrades in spit delay which stayed at 1.3 from young to ancient, this pr fixes this.

## Why It's Good For The Game

Because each caste needs this balance and deserves a fair upgrade in their values whether they are T1 or T3. this will make sentinel more viable especially when in most situations T2 slots are full.

## Changelog
:cl:
balance: sentinel speed from 0.8 from young to ancient now gives just a -1 for ancient
balance: sentinel spit delay from 1.3 young to ancient now    1.3 young 1.2 mature 1.1 elder and 1 ancient
balance: sentinel shouldn't need 300 hp, now 275 to make it easier to kill due to its annoyance.
balance: changed plasma gain
/:cl:

