### PR TITLE
Wraith stats no longer weaker then a T1 drone.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/castedatum_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/castedatum_wraith.dm
@@ -35,7 +35,7 @@
 	caste_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_EVOLUTION_ALLOWED|CASTE_CAN_VENT_CRAWL|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER|CAN_BECOME_KING
 
 	// *** Defense *** //
-	soft_armor = list("melee" = 25, "bullet" = 25, "laser" = 5, "energy" = 5, "bomb" = XENO_BOMB_RESIST_0, "bio" = 10, "rad" = 15, "fire" = 15, "acid" = 10)
+	soft_armor = list("melee" = 25, "bullet" = 25, "laser" = 15, "energy" = 15, "bomb" = XENO_BOMB_RESIST_0, "bio" = 10, "rad" = 15, "fire" = 15, "acid" = 10)
 
 
 	// *** Abilities *** //
@@ -71,13 +71,13 @@
 	plasma_gain = 20
 
 	// *** Health *** //
-	max_health = 230
+	max_health = 250
 
 	// *** Evolution *** //
 	upgrade_threshold = 240
 
 	// *** Defense *** //
-	soft_armor = list("melee" = 30, "bullet" = 30, "laser" = 10, "energy" = 10, "bomb" = XENO_BOMB_RESIST_0, "bio" = 15, "rad" = 20, "fire" = 20, "acid" = 15)
+	soft_armor = list("melee" = 30, "bullet" = 30, "laser" = 20, "energy" = 20, "bomb" = XENO_BOMB_RESIST_0, "bio" = 15, "rad" = 20, "fire" = 20, "acid" = 15)
 
 
 /datum/xeno_caste/wraith/elder
@@ -97,13 +97,13 @@
 	plasma_gain = 23
 
 	// *** Health *** //
-	max_health = 250
+	max_health = 280
 
 	// *** Evolution *** //
 	upgrade_threshold = 480
 
 	// *** Defense *** //
-	soft_armor = list("melee" = 35, "bullet" = 35, "laser" = 15, "energy" = 15, "bomb" = XENO_BOMB_RESIST_0, "bio" = 18, "rad" = 25, "fire" = 25, "acid" = 18)
+	soft_armor = list("melee" = 35, "bullet" = 35, "laser" = 25, "energy" = 25, "bomb" = XENO_BOMB_RESIST_0, "bio" = 18, "rad" = 25, "fire" = 25, "acid" = 18)
 
 
 /datum/xeno_caste/wraith/ancient
@@ -123,11 +123,11 @@
 	plasma_gain = 25
 
 	// *** Health *** //
-	max_health = 260
+	max_health = 310
 
 	// *** Evolution *** //
 	upgrade_threshold = 480
 
 	// *** Defense *** //
-	soft_armor = list("melee" = 40, "bullet" = 40, "laser" = 20, "energy" = 20, "bomb" = XENO_BOMB_RESIST_0, "bio" = 18, "rad" = 25, "fire" = 30, "acid" = 18)
+	soft_armor = list("melee" = 40, "bullet" = 40, "laser" = 30, "energy" = 30, "bomb" = XENO_BOMB_RESIST_0, "bio" = 18, "rad" = 25, "fire" = 30, "acid" = 18)
 


### PR DESCRIPTION


## About The Pull Request

Wraith's stats were worse than a T1's this fixes that.

## Why It's Good For The Game

Considering that shipside wraith is no longer a thing it means wraith is meant to be more combat-focused, this makes its stat values more meaningful for a T2 it previously had less health than a drone and very bad armor values that weren't bullet.

## Changelog
:cl:
Balance: wraiths health is no longer less than a T1
Balance: Increases Wraiths laser and energy resistance to something that makes more sense instead of underwhelming values
/:cl:
