### PR TITLE
Number of oversight fixes for LZ1

### DIFF
--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -9933,12 +9933,6 @@
 	dir = 9
 	},
 /area/shuttle/drop1/lz1)
-"bef" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
-/turf/open/space/basic,
-/area/lv624/ground/jungle1)
 "beh" = (
 /obj/structure/jungle/vines/heavy,
 /turf/open/ground/grass,
@@ -44141,7 +44135,7 @@ aWs
 tiO
 bjv
 axZ
-bef
+mPv
 bdh
 bdi
 bhQ
@@ -44320,7 +44314,7 @@ usw
 sMv
 yhd
 axZ
-bef
+mPv
 oCY
 bmp
 bdk

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -4840,11 +4840,11 @@
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 8
 	},
-/area/lv624/lazarus/quartstorage/outdoors)
+/area/lv624/ground/compound/ne)
 "aAo" = (
 /obj/structure/fence,
 /turf/open/ground/grass,
-/area/lv624/lazarus/quartstorage/outdoors)
+/area/lv624/ground/compound/n)
 "aAq" = (
 /obj/structure/jungle/vines,
 /turf/open/floor/plating/ground/dirtgrassborder/corner,
@@ -5480,7 +5480,7 @@
 /area/lv624/ground/jungle9)
 "aEA" = (
 /turf/open/floor/plating/ground/dirtgrassborder,
-/area/lv624/lazarus/quartstorage/outdoors)
+/area/lv624/ground/compound/ne)
 "aED" = (
 /obj/structure/jungle/planttop1,
 /obj/structure/jungle/vines,
@@ -5757,7 +5757,7 @@
 "aGq" = (
 /obj/machinery/floodlight/colony,
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/lazarus/quartstorage/outdoors)
+/area/lv624/ground/compound/ne)
 "aGu" = (
 /obj/structure/jungle/plantbot1,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -6227,10 +6227,10 @@
 "aJH" = (
 /obj/structure/jungle/vines,
 /turf/open/ground/grass,
-/area/lv624/lazarus/quartstorage/outdoors)
+/area/lv624/ground/compound/n)
 "aJI" = (
-/turf/open/ground/grass,
-/area/lv624/lazarus/quartstorage/outdoors)
+/turf/closed/gm/dense,
+/area/lv624/ground/compound/n)
 "aJM" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/ground/dirtgrassborder,
@@ -6617,7 +6617,7 @@
 /area/lv624/lazarus/quartstorage)
 "aLU" = (
 /turf/open/floor/plating/ground/dirtgrassborder/corner,
-/area/lv624/lazarus/quartstorage/outdoors)
+/area/lv624/ground/compound/ne)
 "aLV" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -6809,7 +6809,7 @@
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 4
 	},
-/area/lv624/lazarus/quartstorage/outdoors)
+/area/lv624/ground/compound/ne)
 "aMS" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -6957,17 +6957,17 @@
 /turf/open/floor/plating/ground/dirtgrassborder/corner{
 	dir = 8
 	},
-/area/lv624/lazarus/quartstorage/outdoors)
+/area/lv624/ground/compound/ne)
 "aNL" = (
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 1
 	},
-/area/lv624/lazarus/quartstorage/outdoors)
+/area/lv624/ground/compound/ne)
 "aNM" = (
 /turf/open/floor/plating/ground/dirtgrassborder/corner{
 	dir = 4
 	},
-/area/lv624/lazarus/quartstorage/outdoors)
+/area/lv624/ground/compound/ne)
 "aNN" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -8504,18 +8504,11 @@
 	},
 /area/shuttle/drop1/lz1)
 "aVO" = (
-/obj/machinery/button/door/open_only/landing_zone,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 4
 	},
-/turf/open/floor/marking/warning{
-	dir = 4
-	},
-/area/shuttle/drop1/lz1)
+/area/lv624/ground/compound/ne)
 "aVQ" = (
 /obj/structure/cargo_container/horizontal{
 	dir = 4
@@ -11220,7 +11213,7 @@
 /turf/open/floor/plating/ground/dirtgrassborder/corner2{
 	dir = 1
 	},
-/area/lv624/lazarus/quartstorage/outdoors)
+/area/lv624/ground/compound/ne)
 "blP" = (
 /obj/machinery/power/geothermal,
 /obj/structure/lattice,
@@ -13253,7 +13246,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/lazarus/quartstorage/outdoors)
+/area/lv624/ground/compound/ne)
 "eHE" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/dirt,
@@ -13567,7 +13560,7 @@
 "fQW" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/lazarus/quartstorage/outdoors)
+/area/lv624/ground/compound/n)
 "fRf" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -14363,7 +14356,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/lazarus/quartstorage/outdoors)
+/area/lv624/ground/compound/ne)
 "iWp" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/dirtgrassborder{
@@ -16513,7 +16506,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/lazarus/quartstorage/outdoors)
+/area/lv624/ground/compound/ne)
 "rRg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -17084,6 +17077,12 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/sand7)
+"udd" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 8
+	},
+/area/lv624/ground/compound/ne)
 "udq" = (
 /turf/closed/wall/indestructible/mineral,
 /area/lv624/ground/caves/west1)
@@ -17433,6 +17432,19 @@
 	dir = 1
 	},
 /area/lv624/ground/jungle4)
+"vGN" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/button/door/open_only/landing_zone,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/marking/warning{
+	dir = 1
+	},
+/area/shuttle/drop1/lz1)
 "vGS" = (
 /obj/structure/cargo_container/red{
 	dir = 1
@@ -17461,6 +17473,10 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle6)
+"vJH" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor,
+/area/shuttle/drop1/lz1)
 "vKb" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/dirtgrassborder/corner2{
@@ -17489,7 +17505,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/lazarus/quartstorage/outdoors)
+/area/lv624/ground/compound/ne)
 "vNz" = (
 /turf/open/floor,
 /area/storage/testroom)
@@ -17611,6 +17627,14 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/ground/grass,
 /area/lv624/ground/southcargo)
+"wuL" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 4
+	},
+/area/lv624/ground/jungle5)
 "wvF" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/jungle/vines,
@@ -17712,6 +17736,10 @@
 	},
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/engineering)
+"wQQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/ne)
 "wTm" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/dirt,
@@ -43197,7 +43225,7 @@ aTm
 dva
 kZW
 kZW
-aSB
+vGN
 aWs
 aWs
 aWs
@@ -43361,7 +43389,7 @@ aEi
 aEi
 azJ
 azJ
-aJI
+aGg
 aEj
 aEk
 aEk
@@ -43383,7 +43411,7 @@ aWs
 aWs
 aWs
 aWs
-aWs
+vJH
 aWs
 aWs
 aWs
@@ -43539,7 +43567,7 @@ aEi
 aEi
 azJ
 azJ
-aJG
+aJI
 aJH
 aEj
 aEk
@@ -43555,7 +43583,7 @@ aEk
 aTP
 cSo
 aVj
-aVO
+aWV
 aWV
 aWV
 biG
@@ -43717,7 +43745,7 @@ aCG
 azJ
 azJ
 azJ
-aHs
+aFs
 aJH
 aJH
 aEj
@@ -43894,10 +43922,10 @@ aCd
 aCG
 aCd
 azJ
-aAk
-aAk
-aHs
-aJG
+aAb
+aAb
+aFs
+aJI
 aJH
 aDL
 aEj
@@ -44068,17 +44096,17 @@ arW
 asW
 arW
 aAo
-aEA
-aAk
-aAk
+aCA
+aAb
+aAb
 fQW
-aAk
-aAk
-aAk
-aHs
-aJI
-aJI
-aJI
+aAb
+aAb
+aAb
+aFs
+aGg
+aGg
+aHZ
 aLU
 aMO
 aNK
@@ -44247,21 +44275,21 @@ arW
 arW
 arW
 aAo
-aEA
-aAk
-aAk
+aCA
+aAb
+aAb
 puV
 puV
 puV
 puV
 puV
-aJI
-aJI
-aJI
+aGg
+aGg
+aHZ
 aEA
 aGq
 aNL
-azK
+aFa
 vMA
 rOB
 gHn
@@ -44440,9 +44468,9 @@ puV
 puV
 aAn
 aNM
-azK
+aFa
 eHq
-aAk
+aDc
 gHn
 lYR
 aSz
@@ -44617,11 +44645,11 @@ puV
 puV
 puV
 puV
-aJI
-aJI
-azJ
+aHZ
+aHZ
+aEZ
 eHq
-dWQ
+wQQ
 gHn
 lYR
 aSB
@@ -44796,11 +44824,11 @@ puV
 puV
 puV
 puV
-aJI
-aJI
-azK
+aHZ
+aHZ
+aFa
 eHq
-aAk
+aDc
 gHn
 lYR
 aSB
@@ -44975,11 +45003,11 @@ puV
 puV
 puV
 puV
-aJI
-aJI
-azK
+aHZ
+aHZ
+aFa
 eHq
-aAk
+aDc
 gHn
 lYR
 aSB
@@ -45155,10 +45183,10 @@ puV
 puV
 puV
 puV
-aAj
-azJ
+aVO
+aEZ
 eHq
-aAk
+aDc
 jMR
 lYR
 aSB
@@ -45334,10 +45362,10 @@ puV
 puV
 puV
 puV
-aAk
-aAk
+aDc
+aDc
 eHq
-dWQ
+wQQ
 xnH
 lYR
 aUA
@@ -45692,9 +45720,9 @@ puV
 puV
 puV
 puV
-aAk
-aAk
-aAk
+aDc
+aDc
+aDc
 aNL
 wPI
 aJG
@@ -45871,9 +45899,9 @@ puV
 puV
 puV
 puV
-aNN
-aNN
-azJ
+udd
+udd
+aEZ
 aNM
 wPI
 aJG
@@ -46950,7 +46978,7 @@ aAV
 aAV
 aAV
 fCU
-mBe
+aAV
 aVj
 aWV
 aWV
@@ -47128,7 +47156,7 @@ aAV
 aAV
 aAV
 aAV
-aAV
+fCU
 aAV
 qzs
 qzs
@@ -47307,8 +47335,8 @@ aAV
 aAV
 aAV
 aAV
-aAV
-aAV
+fCU
+mBe
 mBe
 mBe
 mBe
@@ -47858,7 +47886,7 @@ aAV
 aAV
 aAV
 ayh
-aAS
+wuL
 vve
 lFY
 azN


### PR DESCRIPTION
## About The Pull Request
Fixes the LZ1 shutters not being properly surrounding the LZ
Make the path north of the LZ into a walkable area, 
Moves the button back into its place, 
Add a tiny light east of the LZ

## Why It's Good For The Game
This fixes things that were broken, which is good.
It also makes the area north of the LZ work for drop pods. I have no clue which it wasn't working before.
Heck, i might add a door there.

## Changelog
:cl:
qol: Made it possible to drop pod north of LV LZ1
fix: fixed a few issues with the LZ
/:cl:


