### PR TITLE
Fixes cocoons opening instantly

### DIFF
--- a/code/game/objects/items/cocoon.dm
+++ b/code/game/objects/items/cocoon.dm
@@ -31,7 +31,7 @@
 	victim = _victim
 	victim.forceMove(src)
 	START_PROCESSING(SSslowprocess, src)
-	addtimer(CALLBACK(src, .proc/life_draining_over, TRUE), null, cocoon_life_time)
+	addtimer(CALLBACK(src, .proc/life_draining_over, null, TRUE), cocoon_life_time)
 	RegisterSignal(SSdcs, COMSIG_GLOB_DROPSHIP_HIJACKED, .proc/life_draining_over)
 	new /obj/effect/alien/weeds/node(loc)
 


### PR DESCRIPTION
## About The Pull Request
Closes #7857 
#7823 added a new argument to cocoon's life_draining_over to properly handle it being called from a signal, but didn't put the additional argument in the right place for the non-signal call.

## Why It's Good For The Game
bugfix

## Changelog
:cl:
fix: Cocoons don't open instantly
/:cl: