### PR TITLE
Fixes t-ray scanners not showing wires

### DIFF
--- a/code/game/objects/items/scanners.dm
+++ b/code/game/objects/items/scanners.dm
@@ -42,7 +42,7 @@ REAGENT SCANNER
 
 		for(var/obj/O in T.contents)
 
-			if(O.level != 1)
+			if(!HAS_TRAIT(O, TRAIT_T_RAY_VISIBLE))
 				continue
 
 			if(O.invisibility == INVISIBILITY_MAXIMUM)

--- a/code/modules/atmospherics/machinery/pipes/pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipes.dm
@@ -11,6 +11,10 @@
 	. = ..()
 	add_atom_colour(pipe_color, FIXED_COLOUR_PRIORITY)
 
+/obj/machinery/atmospherics/pipe/Initialize()
+	. = ..()
+	AddElement(/datum/element/undertile, TRAIT_T_RAY_VISIBLE)
+
 /obj/machinery/atmospherics/pipe/nullifyNode(i)
 	var/obj/machinery/atmospherics/oldN = nodes[i]
 	..()

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -564,6 +564,7 @@
 	. = ..()
 	base_icon_state = icon_state
 	GLOB.disposal_list += src
+	AddElement(/datum/element/undertile, TRAIT_T_RAY_VISIBLE)
 
 
 //Pipe is deleted


### PR DESCRIPTION
## About The Pull Request
There's an element for hiding under tiles and displaying t-ray-scannable objects but the scanner itself, uh. Didn't use it. At all. Fixes that, plus adds the element to atmos/disposals pipes. 

## Why It's Good For The Game
Fixes

## Changelog
:cl:
fix: T-ray scanners show cables
fix: The atmos/disposals pipes that show up on t-ray will now actually be there when you crowbar up the floor tile.
/:cl: