### PR TITLE
silo collaspe starts at 35 minutes rather than 45

### DIFF
--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -139,7 +139,7 @@
 /// This is used to ponderate the number of silo, so to reduces the diminishing returns of having more and more silos
 #define SILO_OUTPUT_PONDERATION 1.75
 //Time (after round start) before siloless timer can start
-#define MINIMUM_TIME_SILO_LESS_COLLAPSE 45 MINUTES
+#define MINIMUM_TIME_SILO_LESS_COLLAPSE 35 MINUTES
 
 #define INFESTATION_MARINE_DEPLOYMENT 0
 #define INFESTATION_MARINE_CRASHING 1


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
the more i've observed and played i've marines need an early game objective to point and give them cohesion so they can go take it
silos rn take too long to be forced to be made, you need miners but you can't hold more than 2, so marines just take the closest miner and whatever is the next closest
xenomorphs make big ass mazes in the same areas and killing it as marine has no payoff since they'll just run off and force you to take 3 or 4 teamfights before you fucking die because by the time they make a silo it'll be mid to late game anyway, as 45 minutes is about mid to late game usually
35 minutes will force silos ten minutes earlier which is probably 15 minutes into the op rather than 25 which allows marines to buddy up and do something in squad based play rather than forcing them into a ungaball to take some random maze full of autism and random ass garbage
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
moves silos from a late game end game meme to being early game (15 minutes after drop, which is usually at 12:25 anyway)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: silo collapse starts at 30 minutes rather than 45
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
