### PR TITLE
Crusher  has less weed speed

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -15,6 +15,7 @@
 
 	// *** Speed *** //
 	speed = 0.1
+	weeds_speed_mod = -0.15 // Slightly more than halved weed speed up, if you're of position this bad, bad times.
 
 	// *** Plasma *** //
 	plasma_max = 200
@@ -22,6 +23,7 @@
 
 	// *** Health *** //
 	max_health = 325
+	sunder_recover = 0.1 // Crusher recovers sunder FAR slower than normal castes
 
 	// *** Evolution *** //
 	upgrade_threshold = 250

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -23,7 +23,6 @@
 
 	// *** Health *** //
 	max_health = 325
-	sunder_recover = 0.15 // Crusher recovers sunder FAR slower than normal castes
 
 	// *** Evolution *** //
 	upgrade_threshold = 250

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -23,7 +23,7 @@
 
 	// *** Health *** //
 	max_health = 325
-	sunder_recover = 0.1 // Crusher recovers sunder FAR slower than normal castes
+	sunder_recover = 0.15 // Crusher recovers sunder FAR slower than normal castes
 
 	// *** Evolution *** //
 	upgrade_threshold = 250


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
crusher is a pretty good caste overall, in general i think it's near unpunishable outside of set scenarios or slapping it with a sadar to the fucking face
this should punish crusher far more for being out of position in team fights and make him unable to cycle as effectively
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Crusher is absurd as it is, don't think you can argue against it, it got it's on demand stun back. It deserves a slap.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: crusher is far slower on weeds (-0.15 instead of 0.4)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
