### PR TITLE
warrior plasma at young upped, warrior plasma upped across the board

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -56,7 +56,7 @@
 	action_icon_state = "lunge"
 	mechanics_text = "Pounce up to 5 tiles and grab a target, knocking them down and putting them in your grasp."
 	ability_name = "lunge"
-	plasma_cost = 25
+	plasma_cost = 30
 	cooldown_timer = 20 SECONDS
 	keybind_signal = COMSIG_XENOABILITY_LUNGE
 	target_flags = XABB_MOB_TARGET
@@ -141,7 +141,7 @@
 	action_icon_state = "fling"
 	mechanics_text = "Knock a target flying up to 5 tiles away."
 	ability_name = "fling"
-	plasma_cost = 18
+	plasma_cost = 25
 	cooldown_timer = 20 SECONDS //Shared cooldown with Grapple Toss
 	keybind_signal = COMSIG_XENOABILITY_FLING
 	target_flags = XABB_MOB_TARGET
@@ -233,7 +233,7 @@
 	action_icon_state = "grapple_toss"
 	mechanics_text = "Throw a creature you're grappling up to 3 tiles away."
 	ability_name = "grapple toss"
-	plasma_cost = 18
+	plasma_cost = 30
 	cooldown_timer = 20 SECONDS //Shared cooldown with Fling
 	keybind_signal = COMSIG_XENOABILITY_GRAPPLE_TOSS
 	target_flags = XABB_TURF_TARGET
@@ -309,7 +309,7 @@
 	action_icon_state = "punch"
 	mechanics_text = "Strike a target up to 1 tile away, inflicting stamina damage, stagger and slowdown. Deals double damage, stagger and slowdown to grappled targets. Deals quadruple damage to structures and machinery."
 	ability_name = "punch"
-	plasma_cost = 12
+	plasma_cost = 20
 	cooldown_timer = 10 SECONDS
 	keybind_signal = COMSIG_XENOABILITY_PUNCH
 	target_flags = XABB_MOB_TARGET

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/castedatum_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/castedatum_warrior.dm
@@ -15,7 +15,7 @@
 	speed = -0.2
 
 	// *** Plasma *** //
-	plasma_max = 80
+	plasma_max = 100
 	plasma_gain = 8
 
 	// *** Health *** //
@@ -65,7 +65,7 @@
 	speed = -0.4
 
 	// *** Plasma *** //
-	plasma_max = 100
+	plasma_max = 110
 	plasma_gain = 10
 
 	// *** Health *** //
@@ -94,7 +94,7 @@
 	speed = -0.45
 
 	// *** Plasma *** //
-	plasma_max = 115
+	plasma_max = 120
 	plasma_gain = 11
 
 	// *** Health *** //
@@ -123,7 +123,7 @@
 	speed = -0.5
 
 	// *** Plasma *** //
-	plasma_max = 120
+	plasma_max = 130
 	plasma_gain = 12
 
 	// *** Health *** //


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
warrior plasma changed across the board
lunge 25->30
fling->15->25
grapple toss->30
punch 12->20
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This makes warrior actually have to manage plasma, as it can only combo once and a half at ancient, considering warrior in general is an incredibly safe caste with agility, as it still has decent defensive stats, I don't see an issue with this overall.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: warrior plasma upped, abilities have more plasma cost across the board
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
