### PR TITLE
reduces runner pounce stun time

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -211,6 +211,8 @@
 /datum/action/xeno_action/activable/pounce/hunter
 	plasma_cost = 20
 	range = 7
+	victim_paralyze_time = 2 SECONDS
+	freeze_on_hit_time = 0.5 SECONDS
 
 // ***************************************
 // *********** Haunt

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -79,7 +79,7 @@
 	///How far can we pounce.
 	var/range = 6
 	///For how long will we stun the victim
-	var/victim_paralyze_time = 2 SECONDS
+	var/victim_paralyze_time = 1 SECONDS
 	///For how long will we freeze upon hitting our target
 	var/freeze_on_hit_time = 0.5 SECONDS
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/abilities_runner.dm
@@ -81,7 +81,7 @@
 	///For how long will we stun the victim
 	var/victim_paralyze_time = 1 SECONDS
 	///For how long will we freeze upon hitting our target
-	var/freeze_on_hit_time = 0.5 SECONDS
+	var/freeze_on_hit_time = 0.25 SECONDS
 
 // TODO: merge defender/ravager pounces into this typepath since they are essentially the same thing
 /datum/action/xeno_action/activable/pounce/proc/pounce_complete()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
2 seconds is a long time considering most stuns now stun for like 0.5 to 1 second, reduced the freeze time to 0.25 to compensate though

also touches hunter pounce to still have the same stats as befo
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
brings runner stun in contention with most other stuns in the game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: runner pounce stun time reduced, freeze time reduced
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
