### PR TITLE
Shotgun Shell Rebalance - Buck

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -684,18 +684,18 @@ datum/ammo/bullet/revolver/tp44
 	flags_ammo_behavior = AMMO_BALLISTIC
 	bonus_projectiles_type = /datum/ammo/bullet/shotgun/spread
 	bonus_projectiles_amount = 5
-	bonus_projectiles_scatter = 10
+	bonus_projectiles_scatter = 3
 	accuracy_var_low = 9
 	accuracy_var_high = 9
 	accurate_range = 3
 	max_range = 10
 	damage = 40
-	damage_falloff = 4
+	damage_falloff = 2
 	penetration = 0
 
 
 /datum/ammo/bullet/shotgun/buckshot/on_hit_mob(mob/M,obj/projectile/P)
-	staggerstun(M, P, weaken = 1, stagger = 1, knockback = 2, slowdown = 0.5, max_range = 3)
+	staggerstun(M, P, stagger = 2, slowdown = 0.5, max_range = 3)
 
 /datum/ammo/bullet/shotgun/spread
 	name = "additional buckshot"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -706,7 +706,7 @@ datum/ammo/bullet/revolver/tp44
 	accurate_range = 3
 	max_range = 10
 	damage = 40
-	damage_falloff = 4
+	damage_falloff = 2
 	penetration = 0
 
 //buckshot variant only used by the masterkey shotgun attachment.

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -682,12 +682,12 @@ datum/ammo/bullet/revolver/tp44
 	icon_state = "buckshot"
 	hud_state = "shotgun_buckshot"
 	flags_ammo_behavior = AMMO_BALLISTIC
-	bonus_projectiles_type = /datum/ammo/bullet/shotgun/spread
+	bonus_projectiles_type = /datum/ammo/bullet/shotgun/buckshot/spread
 	bonus_projectiles_amount = 5
 	bonus_projectiles_scatter = 3
 	accuracy_var_low = 9
 	accuracy_var_high = 9
-	accurate_range = 3
+	accurate_range = 5
 	max_range = 10
 	damage = 40
 	damage_falloff = 2
@@ -695,19 +695,11 @@ datum/ammo/bullet/revolver/tp44
 
 
 /datum/ammo/bullet/shotgun/buckshot/on_hit_mob(mob/M,obj/projectile/P)
-	staggerstun(M, P, stagger = 2, slowdown = 0.5, max_range = 3)
+	staggerstun(M, P, stagger = 2, slowdown = 0.5, max_range = 5)
 
-/datum/ammo/bullet/shotgun/spread
+/datum/ammo/bullet/shotgun/buckshot/spread
 	name = "additional buckshot"
 	icon_state = "buckshot"
-	shell_speed = 2
-	accuracy_var_low = 9
-	accuracy_var_high = 9
-	accurate_range = 3
-	max_range = 10
-	damage = 40
-	damage_falloff = 2
-	penetration = 0
 
 //buckshot variant only used by the masterkey shotgun attachment.
 /datum/ammo/bullet/shotgun/buckshot/masterkey

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -701,12 +701,15 @@ datum/ammo/bullet/revolver/tp44
 	name = "additional buckshot"
 	icon_state = "buckshot"
 
+/datum/ammo/bullet/shotgun/buckshot/spread/on_hit_mob(mob/M,obj/projectile/P)
+	staggerstun(M, P, shake = 0)
+
 //buckshot variant only used by the masterkey shotgun attachment.
 /datum/ammo/bullet/shotgun/buckshot/masterkey
-	bonus_projectiles_type = /datum/ammo/bullet/shotgun/spread/masterkey
+	bonus_projectiles_type = /datum/ammo/bullet/shotgun/buckshot/spread/masterkey
 	damage = 25
 
-/datum/ammo/bullet/shotgun/spread/masterkey
+/datum/ammo/bullet/shotgun/buckshot/spread/masterkey
 	damage = 25
 
 /datum/ammo/bullet/shotgun/sx16_buckshot

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -695,11 +695,12 @@ datum/ammo/bullet/revolver/tp44
 
 
 /datum/ammo/bullet/shotgun/buckshot/on_hit_mob(mob/M,obj/projectile/P)
-	staggerstun(M, P, stagger = 2, slowdown = 0.5, max_range = 5)
+	staggerstun(M, P, stagger = 2, knockback = 1, slowdown = 0.5, max_range = 5)
 
 /datum/ammo/bullet/shotgun/buckshot/spread
 	name = "additional buckshot"
 	icon_state = "buckshot"
+	bonus_projectiles_amount = 0
 
 /datum/ammo/bullet/shotgun/buckshot/spread/on_hit_mob(mob/M,obj/projectile/P)
 	staggerstun(M, P, shake = 0)


### PR DESCRIPTION
## About The Pull Request
Buckshot has vastly reduced scatter and damage falloff, as well as increased stagger. In return, it no longer full stuns and has less knockback.
Basically, I took Ren's and MJP's suggestions and I turned it into a PR. 

I'm fully expecting this to be closed immediately, but it's not really my ideas anyways.
## Why It's Good For The Game
Currently, shotgun isn't really that good, especially buckshot. Buckshot is currently just a melee weapon and even then, it does less damage on PB than flech does in most cases.

Even like this, in-game testing shows that it gets outperformed by flech in terms of damage at any reasonable range and armor, with the sole exceptions of runner and drone at point blank range.
## Changelog
:cl:
balance: buckshot now has vastly improved ranged capabilities, as well as increased stagger in return for its hardstun and some knockback.
/:cl: