### PR TITLE
Shotgun Shell Rebalance - Slugs

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -596,9 +596,9 @@ datum/ammo/bullet/revolver/tp44
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
 	shell_speed = 3
 	max_range = 15
-	damage = 80
-	penetration = 40
-	sundering = 7
+	damage = 100
+	penetration = 20
+	sundering = 15
 
 /datum/ammo/bullet/shotgun/slug/on_hit_mob(mob/M,obj/projectile/P)
 	staggerstun(M, P, weaken = 1, stagger = 2, knockback = 1, slowdown = 2)


### PR DESCRIPTION
## About The Pull Request
Brings slugs closer to the other shells in terms of damage, as well as increased sunder at the cost of AP.
## Why It's Good For The Game
Slugs are really bad. They're outperformed at range by flech at every tier of armor except warded crusher due to their low base damage. 

This gives it a niche outside of "pester the enemy xeno with stuns from very far away."
## Changelog
:cl:
balance: increased slug damage and sunder at the cost of AP
/:cl: