### PR TITLE
Reduces Observe / Ghost at Post-Round Start Text

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -177,7 +177,7 @@
 	return "\nYou might have to wait a certain time to respawn or be unable to, depending on the game mode!"
 
 /datum/game_mode/infestation/observe_respawn_message()
-	return "\nYou will have to wait at least [SSticker.mode?.respawn_time * 0.1] seconds before being able to respawn as a marine or join the aliens by hopping into the larva queue now!"
+	return "\nYou will have to wait at least [SSticker.mode?.respawn_time * 0.1 / 60] minutes before being able to respawn as a marine!"
 
 /mob/new_player/proc/late_choices()
 	var/list/dat = list("<div class='notice'>Round Duration: [DisplayTimeText(world.time - SSticker.round_start_time)]</div>")


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This removes the overflow text resulting from an extremely long message. Ghosts can spawn as larva immediately upon spawning anyways if they look at the respawn timers.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

The observe warning text no longer overflow into the confirm button. Also, the seconds timer has been changed to a minute unit scale.

OLD
![image](https://user-images.githubusercontent.com/29745705/129293463-1ed5411e-b068-42c4-840b-f76471b4b855.png)

NEW
![image](https://user-images.githubusercontent.com/29745705/129293632-75f458ad-3db2-4af8-9404-5813b1aa43e6.png)

If there was a way to resize the box, I would do that instead. But a quick dive does not allow for size override of the tgui_alert().

## Changelog
:cl:
fix: Reduced observe warning text at post round start.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
