### PR TITLE
Fix Blue Crown Leadership Being Deleted On Evo

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -362,11 +362,9 @@
 		// Retaining blue crowned leadership on minimap past evolution.
 		var/datum/xeno_caste/original = /datum/xeno_caste
 		// Xenos with specialized icons (Queen, King, Shrike) do not need to have their icon returned to normal
-		if(new_xeno.xeno_caste.minimap_icon != initial(original.minimap_icon))
-			return
-
-		SSminimaps.remove_marker(new_xeno)
-		SSminimaps.add_marker(new_xeno, new_xeno.z, MINIMAP_FLAG_XENO, new_xeno.xeno_caste.minimap_icon)
+		if(new_xeno.xeno_caste.minimap_icon == initial(original.minimap_icon))	
+			SSminimaps.remove_marker(new_xeno)
+			SSminimaps.add_marker(new_xeno, new_xeno.z, MINIMAP_FLAG_XENO, new_xeno.xeno_caste.minimap_icon)
 
 	if(upgrade == XENO_UPGRADE_THREE)
 		switch(tier)

--- a/code/modules/mob/living/carbon/xenomorph/evolution.dm
+++ b/code/modules/mob/living/carbon/xenomorph/evolution.dm
@@ -359,6 +359,15 @@
 		if(hive.living_xeno_queen)
 			new_xeno.handle_xeno_leader_pheromones(hive.living_xeno_queen)
 
+		// Retaining blue crowned leadership on minimap past evolution.
+		var/datum/xeno_caste/original = /datum/xeno_caste
+		// Xenos with specialized icons (Queen, King, Shrike) do not need to have their icon returned to normal
+		if(new_xeno.xeno_caste.minimap_icon != initial(original.minimap_icon))
+			return
+
+		SSminimaps.remove_marker(new_xeno)
+		SSminimaps.add_marker(new_xeno, new_xeno.z, MINIMAP_FLAG_XENO, new_xeno.xeno_caste.minimap_icon)
+
 	if(upgrade == XENO_UPGRADE_THREE)
 		switch(tier)
 			if(XENO_TIER_TWO)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Adds blue crown leadership check on evolution as well.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Blue crown sticks with xeno, despite evolution. No more need to reset leadership by the queen for magical blue crown.

## Changelog
:cl:
fix: Fixed blue crown xeno for leadership disappearing upon evolution.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
