### PR TITLE
Makes necrosis do stuff

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -184,8 +184,8 @@
 			var/mob/living/carbon/snapper = user
 			var/datum/limb/left_hand = snapper.get_limb("l_hand")
 			var/datum/limb/right_hand = snapper.get_limb("r_hand")
-			if((left_hand.limb_status & LIMB_DESTROYED) && (right_hand.limb_status & LIMB_DESTROYED))
-				to_chat(user, span_notice("You cannot [key] without an arm."))
+			if((!left_hand.is_usable()) && (!right_hand.is_usable()))
+				to_chat(user, span_notice("You cannot [key] without a working hand."))
 				return FALSE
 
 		if((flags_emote & EMOTE_RESTRAINT_CHECK) && user.restrained())

--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -28,15 +28,15 @@
 		var/datum/limb/right_hand = driver.get_limb("r_hand")
 		var/working_hands = 2
 		move_delay = initial(move_delay)
-		if(!left_hand || (left_hand.limb_status & LIMB_DESTROYED))
+		if(!left_hand?.is_usable())
 			move_delay += 4 //harder to move a wheelchair with a single hand
 			working_hands--
-		else if((left_hand.limb_status & LIMB_BROKEN) && !(left_hand.limb_status & LIMB_SPLINTED) && !(left_hand.limb_status & LIMB_STABILIZED))
+		else if(left_hand.is_broken())
 			move_delay++
-		if(!right_hand || (right_hand.limb_status & LIMB_DESTROYED))
+		if(!right_hand?.is_usable())
 			move_delay += 4
 			working_hands--
-		else if((right_hand.limb_status & LIMB_BROKEN) && !(right_hand.limb_status & LIMB_SPLINTED) && !(right_hand.limb_status & LIMB_STABILIZED))
+		else if(right_hand.is_broken())
 			move_delay += 2
 		if(!working_hands)
 			return // No hands to drive your chair? Tough luck!

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -241,6 +241,8 @@
 			status += " <b>(STABILIZED)</b>"
 		if(org.limb_status & LIMB_MUTATED)
 			status = "weirdly shapen."
+		if(org.limb_status & LIMB_NECROTIZED)
+			status = "rotting"
 		if(org.limb_status & LIMB_DESTROYED)
 			status = "MISSING!"
 

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -112,13 +112,13 @@
 
 /mob/living/carbon/human/put_in_l_hand(obj/item/W)
 	var/datum/limb/O = get_limb("l_hand")
-	if(!O || !O.is_usable())
+	if(!O?.is_usable())
 		return FALSE
 	. = ..()
 
 /mob/living/carbon/human/put_in_r_hand(obj/item/W)
 	var/datum/limb/O = get_limb("r_hand")
-	if(!O || !O.is_usable())
+	if(!O?.is_usable())
 		return FALSE
 	. = ..()
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -934,11 +934,11 @@
 
 	// Check if they have a functioning hand.
 	var/datum/limb/E = user.get_limb("l_hand")
-	if(E && !(E.limb_status & LIMB_DESTROYED))
+	if(E?.is_usable())
 		return TRUE
 
 	E = user.get_limb("r_hand")
-	if(E && !(E.limb_status & LIMB_DESTROYED))
+	if(E?.is_usable())
 		return TRUE
 	return FALSE
 

--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -74,7 +74,7 @@
 	if(ishuman(src))
 		var/mob/living/carbon/human/M = src
 		for(var/datum/limb/O in M.limbs)
-			if((O.limb_status & LIMB_DESTROYED) && !(O.limb_status & LIMB_AMPUTATED))
+			if(((O.limb_status & LIMB_DESTROYED) && !(O.limb_status & LIMB_AMPUTATED)) || O.limb_status & LIMB_NECROTIZED)
 				traumatic_shock += 40
 			else if(O.limb_status & LIMB_BROKEN || O.surgery_open_stage)
 				if(O.limb_status & LIMB_SPLINTED || O.limb_status & LIMB_STABILIZED)

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -1045,7 +1045,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 	if(!is_usable())
 		owner.dropItemToGround(c_hand)
-		owner.emote("me", 1, "drop[owner.p_s] what [owner.p_they()] [owner.p_were()] holding in [owner.p_their()] [hand_name], [owner.p_their()] [display_name] unresponsive!")
+		owner.emote("me", 1, "drop[owner.p_s()] what [owner.p_they()] [owner.p_were()] holding in [owner.p_their()] [hand_name], [owner.p_their()] [display_name] unresponsive!")
 		return
 	if(is_broken())
 		if(prob(15))

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -1043,11 +1043,16 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if (!c_hand)
 		return
 
+	if(!is_usable())
+		owner.dropItemToGround(c_hand)
+		owner.emote("me", 1, "drop[owner.p_s] what [owner.p_they()] [owner.p_were()] holding in [owner.p_their()] [hand_name], [owner.p_their()] [display_name] unresponsive!")
+		return
 	if(is_broken())
 		if(prob(15))
 			owner.dropItemToGround(c_hand)
 			var/emote_scream = pick("screams in pain and", "lets out a sharp cry and", "cries out and")
 			owner.emote("me", 1, "[(owner.species && owner.species.species_flags & NO_PAIN) ? "" : emote_scream ] drops what they were holding in their [hand_name]!")
+			return
 	if(is_malfunctioning())
 		if(prob(5))
 			owner.dropItemToGround(c_hand)


### PR DESCRIPTION
## About The Pull Request
Necrosis is supposed to cripple any limb it's on and make it nonfunctional, but right now it doesn't actually do that in a bunch of cases. This fixes that by replacing relevant things that check for a LIMB_DESTROYED flag with is_usable(), which checks for necrosis.
You can still walk with necrotized legs/feet because that's tied into inventory code and needs to be handled a little separately.

## Why It's Good For The Game
Bugfix.

## Changelog
:cl:
fix: You can't hold stuff in a necrotic arm.
fix: Necrotic limbs hurt the same way amputated ones do.
fix: Dead fingers can't snap.
fix: Dead hands can't roll a wheelchair.
add: You can tell if any of your limbs are dead when checking yourself for wounds.
/:cl: