### PR TITLE
Plasmacutter Now Does Explosive Devastating Rather Than QDel(Object)

### DIFF
--- a/code/game/objects/items/tools/mining_tools.dm
+++ b/code/game/objects/items/tools/mining_tools.dm
@@ -338,5 +338,5 @@
 		return TRUE
 
 	cut_apart(user, O.name, O)
-	qdel(O)
+	O.ex_act(EXPLODE_DEVASTATE)
 	return TRUE


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Plasma cutters now do devastating explosive damage instead of straight qdel object. This fixes issues with hard qdel instead of going through damage pathways such as #7872 Silo Collapse Timer not being called.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Fixes issues with silo collapse timer when plasma cutters are used to destroy silos. Silos however now require multiple charges (5 to be exact) of the plasma cutter in order to destroy as it now inherits plain resin explosive reaction. No more instant delete silos for synths now.

Tadpole furthermore no longer can plasma cut the windows out without the shutters falling, due to actually going through the intended damage pathways.

Otherwise, there are no other practical differences in plasma cutting operation. Plasma cutter remains the instant delete wall tool it always was. However, some objects, e.g. silos and cockpit windows, will require more charges / hits in order to destroy, as their explosive reaction is overridden with reduced values.

## Changelog
:cl:
fix: Fixed plasma cutter and silo damage interaction. Now does explosive devastating damage instead of instant qdel.
fix: Fixed plama cutter and tadpole window interactions. Shutters now fall if the window below it is plasma cut.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
