### PR TITLE
Look sir, synths with access to Binary radio!

### DIFF
--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -113,8 +113,8 @@
 
 
 /datum/language_holder/synthetic
-	languages = list(/datum/language/common)
-	shadow_languages = list(/datum/language/machine, /datum/language/xenocommon)
+	languages = list(/datum/language/common, /datum/language/machine)
+	shadow_languages = list(/datum/language/xenocommon)
 
 
 /datum/language_holder/unathi

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -902,7 +902,6 @@
 	return ..()
 
 /mob/living/carbon/human/species/early_synthetic/binarycheck(mob/H)
-	. = ..()
 	return TRUE
 
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -839,6 +839,10 @@
 	var/datum/atom_hud/AH = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED_SYNTH]
 	AH.add_hud_to(H)
 
+/mob/living/carbon/human/species/synthetic/binarycheck(mob/H)
+	. = ..()
+	return TRUE
+
 
 /datum/species/synthetic/post_species_loss(mob/living/carbon/human/H)
 	var/datum/atom_hud/AH = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED_SYNTH]
@@ -897,6 +901,10 @@
 	var/datum/atom_hud/AH = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED_SYNTH]
 	AH.remove_hud_from(H)
 	return ..()
+
+/mob/living/carbon/human/species/early_synthetic/binarycheck(mob/H)
+	. = ..()
+	return TRUE
 
 
 /mob/living/carbon/human/proc/reset_jitteriness() //todo kill this

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -840,7 +840,6 @@
 	AH.add_hud_to(H)
 
 /mob/living/carbon/human/species/synthetic/binarycheck(mob/H)
-	. = ..()
 	return TRUE
 
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -342,6 +342,7 @@ GLOBAL_LIST_INIT(department_radio_keys_rebel, list(
 	say("#[message]", bubble_type, spans, sanitize, language, ignore_spam, forced)
 
 
+///Returns false by default
 /mob/proc/binarycheck()
 	return FALSE
 

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -1,13 +1,20 @@
 /mob/living/proc/robot_talk(message)
 	log_talk(message, LOG_SAY)
+	//Capitalization
+	message = capitalize(message)
+	//checks for and apply punctuation
+	var/end = copytext(message, length(message))
+	if(!(end in list("!", ".", "?", ":", "\"", "-")))
+		message += "."
+
 	var/desig = "Silicon"
-	if(issilicon(src))
-		var/mob/living/silicon/S = src
+	if(issilicon(src) || issynth(src))
+		var/mob/living/S = src
 		desig = trim_left(S.job.title)
 	var/message_a = say_quote(message)
 	var/rendered = "Robotic Talk, [span_name("[name]")] [span_message("[message_a]")]"
 	for(var/mob/M in GLOB.player_list)
-		if(M.binarycheck())
+		if(binarycheck(M))
 			if(isAI(M))
 				var/renderedAI = span_binarysay("Robotic Talk, <a href='?src=[REF(M)];track=[html_encode(name)]'>[span_name("[name] ([desig])")]</a> [span_message("[message_a]")]")
 				to_chat(M, renderedAI)

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -14,7 +14,7 @@
 	var/message_a = say_quote(message)
 	var/rendered = "Robotic Talk, [span_name("[name]")] [span_message("[message_a]")]"
 	for(var/mob/M in GLOB.player_list)
-		if(binarycheck(M))
+		if(M.binarycheck())
 			if(isAI(M))
 				var/renderedAI = span_binarysay("Robotic Talk, <a href='?src=[REF(M)];track=[html_encode(name)]'>[span_name("[name] ([desig])")]</a> [span_message("[message_a]")]")
 				to_chat(M, renderedAI)


### PR DESCRIPTION
## About The Pull Request
This pull request gives synth access to binary using the :n key. Basically the same thing as cyborgs.
The AI actually has it already, but like, no one can actually listen to it lmao.
This also features a comment a check and general prettying up of this check. 

## Why It's Good For The Game
It gives synths and silicon a bit of their own mini group, distinct from command. Kind of like their own channel. 

## Changelog
:cl:
qol: Brought Binary radio for synths
/:cl:

