### PR TITLE
Revert "Crusher  has less weed speed"

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -15,7 +15,6 @@
 
 	// *** Speed *** //
 	speed = 0.1
-	weeds_speed_mod = -0.15 // Slightly more than halved weed speed up, if you're of position this bad, bad times.
 
 	// *** Plasma *** //
 	plasma_max = 200


### PR DESCRIPTION
Reverts tgstation/TerraGov-Marine-Corps#7894.

Recent rounds have shown that this nerf has made Crushers much harder to play, an unnecessary change given how weak Crushers are currently in the presence of razorwire, sunder, and other aspects.