### PR TITLE
Adds telecoms to the list of no go places for wraith

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/wraith.dm
@@ -9,6 +9,7 @@ GLOBAL_LIST_INIT(wraith_no_incorporeal_pass_areas, typecacheof(list(
 	/area/shuttle/drop2/lz2,
 	/area/outpost/lz1,
 	/area/outpost/lz2,
+	/area/storage/testroom,
 	/area/bigredv2/outside/space_port,
 	/area/ice_colony/exterior/surface/landing_pad,
 	/area/ice_colony/exterior/surface/landing_pad2,


### PR DESCRIPTION
## About The Pull Request
No one is meant to go there, but this is just an extra check to ensure wraiths can't either.

Fixes #6602

## Changelog
:cl:
fix: Ensures wraiths can't reach planetside telecoms. 
/:cl:


