### PR TITLE
Lava won't burn you when you walk diagonally near it

### DIFF
--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -343,6 +343,9 @@
 			if(L.stat == DEAD)
 				continue
 
+			if(L.moving_diagonally == FIRST_DIAG_STEP)
+				continue
+
 			if(!L.on_fire || L.getFireLoss() <= 200)
 				L.take_overall_damage(null, 20, clamp(L.getarmor(null, "fire"), 0, 80))
 				if(!CHECK_BITFIELD(L.flags_pass, PASSFIRE))//Pass fire allow to cross lava without igniting


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Lava shoud not burn you when you are visually not stepping on it. This also mean that diagonally walking in lava will no longer cause 3 (3!!!) times the damage when walking cardinally, but just 1 time

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Lava won't burn you when you walk diagonally near it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
