### PR TITLE
Makes butterfly katana into a more regular sword with a different name

### DIFF
--- a/code/game/objects/effects/landmarks/landmarks.dm
+++ b/code/game/objects/effects/landmarks/landmarks.dm
@@ -286,7 +286,7 @@
 		/obj/item/weapon/baseballbat/metal,
 		/obj/item/weapon/butterfly,
 		/obj/item/weapon/butterfly/switchblade,
-		/obj/item/weapon/butterfly/katana,
+		/obj/item/weapon/katana/samurai,
 	)
 
 /obj/effect/landmark/weapon_spawn/tier2_weapon_spawn

--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -1,3 +1,24 @@
+/* Weapons
+* Contains:
+*		Claymore
+*		Harvester
+*		mercsword
+*		Energy Shield
+*		Energy Shield
+*		Energy Shield
+*		Ceremonial Sword
+*		M2132 machete
+*		Officers sword
+*		Commissars sword
+*		Katana
+*		M5 survival knife
+*		Upp Type 30 survival knife
+*		M11 throwing knife
+*		Unathi duelling knife
+*		Chainsword
+*/
+
+
 /obj/item/weapon/claymore
 	name = "claymore"
 	desc = "What are you standing around staring at this for? Get to killing!"
@@ -243,6 +264,15 @@
 	desc = "A cheap knock-off commonly found in regular knife stores. Can still do some damage."
 	force = 27
 	throwforce = 7
+
+/obj/item/weapon/katana/samurai
+	name = "\improper tachi"
+	desc = "A genuine replica of an ancient blade. This one is in remarkably good condition. It could do some damage to everyone, including yourself."
+	icon_state = "samurai_open"
+	force = 60
+	attack_speed = 12
+	w_class = WEIGHT_CLASS_BULKY
+
 
 /obj/item/weapon/katana/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	playsound(loc, 'sound/weapons/bladeslice.ogg', 25, 1)

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -112,16 +112,6 @@
 	desc = "A classic switchblade with gold engraving. Just holding it makes you feel like a gangster."
 	icon_state = "switchblade"
 
-/obj/item/weapon/butterfly/katana
-	name = "katana"
-	desc = "A ancient weapon from Japan."
-	icon_state = "samurai"
-	force = 50
-
-
-
-
-
 
 /obj/item/weapon/wirerod
 	name = "wired rod"


### PR DESCRIPTION
## About The Pull Request
This also adds a better file description to the file.
We already have three katanas. This is better for fluff reasons. I consulted a 'japanese sword enjoyer' with a big chin regarding the name & possible shape. 

## Why It's Good For The Game
Better fluff & better description.

## Changelog
:cl:
add: Switched a katana type to another sword for fluff reasons. 
code: Added some extra comments to blades.dm
/:cl:

