### PR TITLE
Gives the special forces a freaking riot shield on a breacher role. Awesome.

### DIFF
--- a/code/datums/emergency_calls/special_forces.dm
+++ b/code/datums/emergency_calls/special_forces.dm
@@ -1,5 +1,5 @@
 /datum/emergency_call/special_forces
-	name = "Local System special forces"
+	name = "Local System Special Forces"
 	base_probability = 15
 	alignement_factor = -1
 
@@ -31,6 +31,12 @@
 		var/datum/job/J = SSjob.GetJobType(/datum/job/special_forces/leader)
 		H.apply_assigned_role_to_spawn(J)
 		to_chat(H, "<p style='font-size:1.5em'><span class='notice'>You are the Special Forces captain assigned to lead this group in responding to the TGMC distress signal sent nearby. Keep your team in one piece and get the job done!</notice></p>")
+		return
+
+	if(prob(30))
+		var/datum/job/J = SSjob.GetJobType(/datum/job/special_forces/breacher)
+		H.apply_assigned_role_to_spawn(J)
+		to_chat(H, "<p style='font-size:1.5em'>[span_notice("You are a specially trained member of this special force group directed to investigate the TGMC distress signal sent nearby. Be the vanguard of your squad!")]</p>")
 		return
 
 

--- a/code/datums/jobs/job/special_forces.dm
+++ b/code/datums/jobs/job/special_forces.dm
@@ -14,6 +14,7 @@
 /datum/outfit/job/special_forces/standard
 	name = "Special Response Force Standard"
 	jobtype = /datum/job/special_forces/standard
+
 	glasses = /obj/item/clothing/glasses/night
 	id = /obj/item/card/id/silver
 	belt = /obj/item/storage/belt/marine
@@ -28,7 +29,6 @@
 	r_store = /obj/item/storage/pouch/pistol
 	l_store = /obj/item/storage/pouch/firstaid/full
 	back = /obj/item/storage/backpack/lightpack
-
 
 /datum/outfit/job/special_forces/standard/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
@@ -55,9 +55,52 @@
 	H.equip_to_slot_or_del(new /obj/item/weapon/gun/pistol/g22, SLOT_IN_R_POUCH)
 
 	H.equip_to_slot_or_del(new /obj/item/clothing/tie/storage/black_vest, SLOT_L_HAND)
-	H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/tactical/coif , SLOT_R_HAND)
 
 
+//Special Force breacher
+/datum/job/special_forces/breacher
+	title = "Special Response Force Breacher"
+	outfit = /datum/outfit/job/special_forces/breacher
+
+/datum/outfit/job/special_forces/breacher
+	name = "Special Response Force Breacher"
+	jobtype = /datum/job/special_forces/breacher
+
+	glasses = /obj/item/clothing/glasses/night
+	id = /obj/item/card/id/silver
+	belt = /obj/item/storage/belt/gun/pistol/standard_pistol
+	ears = /obj/item/radio/headset/distress/dutch
+	mask = /obj/item/clothing/mask/balaclava
+	w_uniform = /obj/item/clothing/under/syndicate/tacticool
+	shoes = /obj/item/clothing/shoes/combat
+	wear_suit = /obj/item/clothing/suit/armor/bulletproof
+	gloves = /obj/item/clothing/gloves/marine/veteran/PMC
+	head = /obj/item/clothing/head/helmet/marine/tech
+	suit_store = /obj/item/weapon/gun/pistol/standard_heavypistol/suppressed
+	r_store = /obj/item/storage/pouch/firstaid/injectors/full
+	l_store = /obj/item/storage/pouch/firstaid/full
+	back = /obj/item/storage/backpack/lightpack
+
+/datum/outfit/job/special_forces/breacher/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	. = ..()
+
+	H.equip_to_slot_or_del(new /obj/item/clothing/glasses/mgoggles, SLOT_IN_HEAD)
+
+	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/pistol/standard_heavypistol, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/pistol/standard_heavypistol, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/pistol/standard_heavypistol, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/pistol/standard_heavypistol, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/pistol/standard_heavypistol, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/pistol/standard_heavypistol, SLOT_IN_BELT)
+
+	H.equip_to_slot_or_del(new /obj/item/explosive/plastique, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/tool/crowbar/red, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/explosive/grenade/cloakbomb, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/explosive/grenade/cloakbomb, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/combat, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/combat, SLOT_IN_BACKPACK)
+
+	H.equip_to_slot_or_del(new /obj/item/weapon/shield/riot/metal, SLOT_R_HAND)
 
 
 //Special forces Leader
@@ -96,7 +139,6 @@
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/famas, SLOT_IN_BELT)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/famas, SLOT_IN_BELT)
 
-	H.equip_to_slot_or_del(new /obj/item/healthanalyzer, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/revolver/standard_revolver, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/revolver/standard_revolver, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/tool/screwdriver, SLOT_IN_BACKPACK)
@@ -104,6 +146,8 @@
 	H.equip_to_slot_or_del(new /obj/item/multitool, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/tool/crowbar, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/explosive/grenade/incendiary, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/explosive/grenade/incendiary, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/explosive/grenade/cloakbomb, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/combat, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/combat, SLOT_IN_BACKPACK)
 

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -29,6 +29,8 @@
 	destroy_sound = 'sound/effects/glassbr3.ogg'
 	var/cooldown = 0 //shield bash cooldown. based on world.time
 
+/obj/item/weapon/shield/riot/metal
+	icon_state = "metal"
 
 /obj/item/weapon/shield/riot/examine(mob/user, distance, infix, suffix)
 	. = ..()

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -176,6 +176,9 @@
 	recoil = -2
 	recoil_unwielded = -2
 
+/obj/item/weapon/gun/pistol/standard_heavypistol/suppressed
+	starting_attachment_types = list(/obj/item/attachable/suppressor, /obj/item/attachable/flashlight) //Tacticool
+
 //-------------------------------------------------------
 //M1911
 
@@ -426,7 +429,7 @@
 	cocked_sound = 'sound/weapons/guns/interact/hp_cocked.ogg'
 	current_mag = /obj/item/ammo_magazine/pistol/highpower
 	force = 10
-	
+
 	flags_gun_features = GUN_AUTO_EJECTOR|GUN_CAN_POINTBLANK|GUN_LOAD_INTO_CHAMBER|GUN_AMMO_COUNTER
 	attachable_offset = list("muzzle_x" = 27, "muzzle_y" = 20,"rail_x" = 8, "rail_y" = 22, "under_x" = 18, "under_y" = 15, "stock_x" = 16, "stock_y" = 15)
 


### PR DESCRIPTION
## About The Pull Request
This PR contains stuff for the special force ERT and some shield tweak : 
- Breacher role, who comes with a pistol and a riot shield. Probably weaker than the average guy thanks to a lack of a mag harness.
- The shield is like the basic SS13 polymer shield, but it is made of metal. 
- Removed the health analyser from the leader given he doesn't have the skills for it. Gave him grenades instead.


## Why It's Good For The Game
Leader has gear that he can use.
Breacher makes the ERT closer to the SWAT feeling i've been trying to achieve.

## Changelog
:cl:
expansion: Expanded the special force ERT to have a shield wielding guy. 
/:cl:

