### PR TITLE
Spitter was to slow. this adjusts it to be more T2 like.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
@@ -11,7 +11,7 @@
 	melee_damage = 17
 
 	// *** Speed *** //
-	speed = -0.3
+	speed = -0.4
 
 	// *** Plasma *** //
 	plasma_max = 650
@@ -70,7 +70,7 @@
 	upgrade = XENO_UPGRADE_ONE
 
 	// *** Speed *** //
-	speed = -0.4
+	speed = -0.6
 
 	// *** Plasma *** //
 	plasma_max = 800
@@ -100,7 +100,7 @@
 	melee_damage = 20
 
 	// *** Speed *** //
-	speed = -0.5
+	speed = -0.7
 
 	// *** Plasma *** //
 	plasma_max = 875
@@ -130,7 +130,7 @@
 	melee_damage = 20
 
 	// *** Speed *** //
-	speed = -0.6
+	speed = -0.8
 
 	// *** Plasma *** //
 	plasma_max = 925


### PR DESCRIPTION


## About The Pull Request

Adjusts Spitter speed.

## Why It's Good For The Game

Spitter was as slow as a large clunky Praetorian whilst being a small Xeno, this adjusts it to be more T2-like in speed.

## Changelog
:cl:
Balance: Spitter speed now  0.6-mature  -0.7-Elder & 0.8-ancient, instead of 0.6 at ancient which is as slow as a large Xeno.
/:cl:


