### PR TITLE
drone has resin jelly but on a much higher CD

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
@@ -55,5 +55,5 @@
 
 // Jelly for drones, has a higher CD than Hivelord.
 
-/datum/action/xeno_action/create_jelly/drone
+/datum/action/xeno_action/create_jelly/slow
 	cooldown_timer = 35 SECONDS

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/abilities_drone.dm
@@ -52,3 +52,8 @@
 	adjustBruteLoss(-amount)
 	adjustFireLoss(-remainder, updating_health = TRUE)
 	adjust_sunder(-amount/20)
+
+// Jelly for drones, has a higher CD than Hivelord.
+
+/datum/action/xeno_action/create_jelly/drone
+	cooldown_timer = 35 SECONDS

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
@@ -59,7 +59,7 @@
 		/datum/action/xeno_action/activable/transfer_plasma/drone,
 		/datum/action/xeno_action/activable/corrosive_acid/drone,
 		/datum/action/xeno_action/activable/larval_growth_sting,
-		/datum/action/xeno_action/create_jelly/drone,
+		/datum/action/xeno_action/create_jelly/slow,
 		/datum/action/xeno_action/toggle_pheromones,
 	)
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
@@ -59,6 +59,7 @@
 		/datum/action/xeno_action/activable/transfer_plasma/drone,
 		/datum/action/xeno_action/activable/corrosive_acid/drone,
 		/datum/action/xeno_action/activable/larval_growth_sting,
+		/datum/action/xeno_action/create_jelly/drone,
 		/datum/action/xeno_action/toggle_pheromones,
 	)
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
35 second c/d, it has jelly
compared to 20 for hivelord.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gives the hive the ability to deny fire in more comps without hivelard, but hivelard is still way better at it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: drone has resin jelly, 35 second cooldown
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
