### PR TITLE
Fixes Quick Equip Gun Insertion Into Storage Failing To De-Register Firing Action

### DIFF
--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -373,7 +373,7 @@
 		if(SLOT_IN_SUIT)
 			var/obj/item/clothing/suit/storage/S = wear_suit
 			var/obj/item/storage/internal/T = S.pockets
-			T.handle_item_insertion(W, FALSE)
+			T.handle_item_insertion(W, FALSE, src)
 			T.close(src)
 		if(SLOT_IN_BELT)
 			var/obj/item/storage/belt/S = belt
@@ -381,13 +381,13 @@
 		if(SLOT_IN_HEAD)
 			var/obj/item/clothing/head/helmet/marine/S = head
 			var/obj/item/storage/internal/T = S.pockets
-			T.handle_item_insertion(W, FALSE)
+			T.handle_item_insertion(W, FALSE, src)
 			T.close(src)
 		if(SLOT_IN_ACCESSORY)
 			var/obj/item/clothing/under/U = w_uniform
 			var/obj/item/clothing/tie/storage/T = U.hastie
 			var/obj/item/storage/internal/S = T.hold
-			S.handle_item_insertion(W, FALSE)
+			S.handle_item_insertion(W, FALSE, src)
 			S.close(src)
 		if(SLOT_IN_HOLSTER)
 			var/obj/item/storage/S = belt


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Several proc calls were missing user override, resulting in wrong fallthrough logic in if chain at storage handle_item_insertion(). This response does not null out gun_user, allowing players to fire pistols while the gun exists in storage.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

No more super Ocelot with pistols firing from jumpsuit, armor, and helmet storage.

Fixes #6901

## Changelog
:cl:
fix: Fixes quick equip gun insertion into various storages failing to de-register user firing action.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
