### PR TITLE
Disables CLF

### DIFF
--- a/code/datums/emergency_calls/clf.dm
+++ b/code/datums/emergency_calls/clf.dm
@@ -1,7 +1,7 @@
 //Colonial Liberation Front
 /datum/emergency_call/clf
 	name = "CLF Cell"
-	base_probability = 20
+	base_probability = 0
 	alignement_factor = 0
 
 


### PR DESCRIPTION
## About The Pull Request

Disables CLF

## Why It's Good For The Game

CLF calls serve no purpose whatsoever. They are a joke ERT. They come with no helmets either. Their entire loadout is useless. It's unnecessary to have them use up the ERT call even if it's supposed to be a hostile one. Enabling CLF was kind of a balance change which currently helps xenos deal with ERT much much easier than even SOM. Xenoes shouldn't have a very easy shipside win when they already have a much easier win as capture. This was a balance change that never got tested and got merged.

P.S. TGMC rules also don't find the CLF faction viable so enabling it would be very confusing for players and admins as to whom they should support because they are not recognized and validated by Server rules. Shouldn't have something that rules don't allow either.
![image](https://user-images.githubusercontent.com/68121607/130086384-110f8cdd-bffd-47a8-823e-a3d2466de499.png)

## Changelog
:cl: SpaceLove
balance: Disabled CLF ERT
/:cl: