### PR TITLE
Grants Crushers a Minor Scope Ability

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
@@ -8,6 +8,8 @@
 	mechanics_text = "Activates your weapon sight in the direction you are facing. Must remain stationary to use."
 	plasma_cost = 20
 	keybind_signal = COMSIG_XENOABILITY_LONG_RANGE_SIGHT
+	/// Number of visible tiles to zoom in direction of xeno.
+	var/zoom_tileoffset = 11
 
 /datum/action/xeno_action/toggle_long_range/action_activate()
 	var/mob/living/carbon/xenomorph/boiler/X = owner
@@ -20,7 +22,7 @@
 			span_notice("We start focusing your sight to look off into the distance."), null, 5)
 		if(!do_after(X, 1 SECONDS, FALSE, null, BUSY_ICON_GENERIC) || X.is_zoomed)
 			return
-		X.zoom_in(11)
+		X.zoom_in(zoom_tileoffset)
 		..()
 
 // ***************************************

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
@@ -167,4 +167,4 @@
 // *********** Crusher Zoom
 // ***************************************
 /datum/action/xeno_action/toggle_long_range/crusher
-	zoom_tileoffset = 6 // Additional half screen of zoom
+	zoom_tileoffset = 5 // Additional half screen of zoom, same as a miniscope.

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
@@ -162,3 +162,9 @@
 	if(!can_use_ability(target, override_flags = XACT_IGNORE_SELECTED_ABILITY))
 		return ..()
 	return TRUE
+
+// ***************************************
+// *********** Crusher Zoom
+// ***************************************
+/datum/action/xeno_action/toggle_long_range/crusher
+	zoom_tileoffset = 6 // Additional half screen of zoom

--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -47,6 +47,7 @@
 		/datum/action/xeno_action/activable/stomp,
 		/datum/action/xeno_action/ready_charge,
 		/datum/action/xeno_action/activable/cresttoss,
+		/datum/action/xeno_action/toggle_long_range/crusher,
 	)
 
 /datum/xeno_caste/crusher/young


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Inheriting from boiler zoom, this grants a smaller zoom function to crushers to scout for razorwire ahead of their charging lane.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

This PR allows crushers to plan how they'll charge down crusher lanes without immediately dying to marines that can outrun it on weeds.

## Changelog
:cl:
add: Crushers now have a miniscope ability to scout ahead of themselves for razor and marine concentrations.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
