### PR TITLE
Queen is Now Slowed Upon Screech

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -109,6 +109,10 @@
 	succeed_activate()
 	add_cooldown()
 
+	// Adds on average 5 seconds of slowdown on the screeching xeno.
+	X.add_movespeed_modifier(type, TRUE, 0, NONE, TRUE, 2)
+	addtimer(CALLBACK(src, .proc/reset_speed), rand(4 SECONDS, 6 SECONDS))
+
 	playsound(X.loc, 'sound/voice/alien_queen_screech.ogg', 75, 0)
 	X.visible_message(span_xenohighdanger("\The [X] emits an ear-splitting guttural roar!"))
 	GLOB.round_statistics.queen_screech++
@@ -125,6 +129,12 @@
 		if(get_dist(L, X) > WORLD_VIEW_NUM)
 			continue
 		L.screech_act(X, WORLD_VIEW_NUM, L in nearby_living)
+
+/datum/action/xeno_action/activable/screech/proc/reset_speed()
+	var/mob/living/carbon/xenomorph/queen/X = owner
+	if(QDELETED(X))
+		return
+	X.remove_movespeed_modifier(type)
 
 /datum/action/xeno_action/activable/screech/ai_should_start_consider()
 	return TRUE


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Adds an on average 5 second slowdown for Queens upon screech.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Screech has been used far too often as a free get-out-of-jail cards by queens who screech then run away. This will encourage more combat queens to follow through with screeching and slashing marines. This slowdown additionally rewards skilled queens who wait to screech until they're right next to a marine.

## Changelog
:cl:
balance: Adds an on average 5 second slowdown on Queens following a screech.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
