### PR TITLE
Revert "Crusher has less weed speed"

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -15,7 +15,6 @@
 
 	// *** Speed *** //
 	speed = 0.1
-	weeds_speed_mod = -0.15 // Slightly more than halved weed speed up, if you're of position this bad, bad times.
 
 	// *** Plasma *** //
 	plasma_max = 200


### PR DESCRIPTION
## About The Pull Request
Reverts tgstation/TerraGov-Marine-Corps#7894, at @TiviPlus's request.

## Why It's Good For The Game
Crusher's in an iffy spot balance-wise, Tivi wanted me to make this revert and I'm not particularly opposed to it.

## Changelog
:cl: Lewdcifer
balance: Reverts Crusher speed reduction on weeds.
/:cl: