### PR TITLE
Reduces Bull Stun Timer

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -520,7 +520,7 @@
 		if(CHARGE_CRUSH)
 			Paralyze(CHARGE_SPEED(charge_datum) * 20)
 		if(CHARGE_BULL_HEADBUTT)
-			Paralyze(CHARGE_SPEED(charge_datum) * 60)
+			Paralyze(CHARGE_SPEED(charge_datum) * 30)
 
 	if(anchored)
 		charge_datum.do_stop_momentum(FALSE)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Reduces the multiplier on step for bull stuns.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Bull stun timer is a relic of a period long gone now, where xenos and marines were locked in a perpetual arms race of higher values and even higher reduction multipliers. PRs since then have drastically reduced these values, save one. Bull stun timer remains astronomically high compared to it's contemporaries.

While still significantly more stun timer than it's nearest comparison, the crusher, bull stun timer has been reduces to more reasonable values and allows for counterplay by marines who have been hit by a bull.

## Changelog
:cl:
balance: Reduces bull stun timer multiplier, it is now only 50% larger than crusher.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
