### PR TITLE
Powerfist Now Applies a Stun Scaling With Power Level

### DIFF
--- a/code/game/objects/items/weapons/misc.dm
+++ b/code/game/objects/items/weapons/misc.dm
@@ -108,13 +108,7 @@
 	var/atom/throw_target = get_edge_target_turf(M, get_dir(src, get_step_away(M, src)))
 	var/throw_distance = setting * LERP(5 , 2, M.mob_size / MOB_SIZE_BIG)
 	M.throw_at(throw_target, throw_distance, 0.5 + (setting / 2))
-
- 	// Minor stun upon being thrown that scales with power level of the fist.
-	var/stun_multi = isxeno(M) ? 5 : 1 // This is required to make the stun actually do something to xenos other than a flicker of icon.
-	 // Actual stun for xenos mainly occurs during the flight-time following fist attack and results in a practical stun once the xeno stops flying of around half a second.
-	 // Marines on the other hand get knocked over and get up immediately with a stun lasting [setting] seconds.
-	M.apply_effects(setting * stun_multi, 0.1 * setting * stun_multi)
-
+	M.apply_effects(setting, 0.1 * setting)
 	cell.charge -= powerused
 	return ..()
 

--- a/code/game/objects/items/weapons/misc.dm
+++ b/code/game/objects/items/weapons/misc.dm
@@ -108,7 +108,8 @@
 	var/atom/throw_target = get_edge_target_turf(M, get_dir(src, get_step_away(M, src)))
 	var/throw_distance = setting * LERP(5 , 2, M.mob_size / MOB_SIZE_BIG)
 	M.throw_at(throw_target, throw_distance, 0.5 + (setting / 2))
-	M.apply_effects(setting, 0.1 * setting)
+	M.apply_effects(setting, STUN)
+	M.apply_effects(0.1 * setting, WEAKEN)
 	cell.charge -= powerused
 	return ..()
 

--- a/code/game/objects/items/weapons/misc.dm
+++ b/code/game/objects/items/weapons/misc.dm
@@ -108,6 +108,13 @@
 	var/atom/throw_target = get_edge_target_turf(M, get_dir(src, get_step_away(M, src)))
 	var/throw_distance = setting * LERP(5 , 2, M.mob_size / MOB_SIZE_BIG)
 	M.throw_at(throw_target, throw_distance, 0.5 + (setting / 2))
+
+ 	// Minor stun upon being thrown that scales with power level of the fist.
+	var/stun_multi = isxeno(M) ? 5 : 1 // This is required to make the stun actually do something to xenos other than a flicker of icon.
+	 // Actual stun for xenos mainly occurs during the flight-time following fist attack and results in a practical stun once the xeno stops flying of around half a second.
+	 // Marines on the other hand get knocked over and get up immediately with a stun lasting [setting] seconds.
+	M.apply_effects(setting * stun_multi, 0.1 * setting * stun_multi)
+
 	cell.charge -= powerused
 	return ..()
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

A simple addition of a stun that scales with power level of the powerfist being used.

When used on marines, the maximum power level results in very short knockdown that exists only to drop weapons and a stun lasting 3 seconds. The stun time precisely depends on the power level of the powerfist being used.

On xenos, the stun is significantly shorter. As they recieve several reductions in stun time, the exact values could not be determined but testing resulted in approximately 0.5 seconds of stun. I observed that a noticable amount of stun time is actually done while the xeno is flying through the air, resulting in a very short practical stun time once the xeno stops flying. If anything, it gives the xeno in question a very nice scare rather than anything actually debilitating, other than the sudden relocation of course.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Currently, marines hit by powerfists fly multiple screens away and land on their feet with their guns in hand ready to return to fighting with only minor damage thanks to armor blunting the brute damage. Which makes absolutely no sense.

This PR introduces a stun aspect to the power fist that results in marines dropping their weapons near their original position if they do not have a mag harn.

Xenos on the other hand might have a very short icon change for half a second but, since they rarely have anything in their hand, are otherwise unaffected by this PR.

## Changelog
:cl:
add: Powerfist now applies a stun scaling with power level
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
