### PR TITLE
Bull now gets all charges at Young instead of having them be time gated

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
@@ -72,17 +72,6 @@
 	// *** Defense *** //
 	soft_armor = list("melee" = 30, "bullet" = 40, "laser" = 30, "energy" = 30, "bomb" = XENO_BOMB_RESIST_0, "bio" = 28, "rad" = 28, "fire" = 40, "acid" = 28)
 
-	actions = list(
-		/datum/action/xeno_action/xeno_resting,
-		/datum/action/xeno_action/activable/psydrain,
-		/datum/action/xeno_action/activable/headbite,
-		/datum/action/xeno_action/activable/devour,
-		/datum/action/xeno_action/ready_charge/bull_charge,
-		/datum/action/xeno_action/activable/bull_charge,
-		/datum/action/xeno_action/activable/bull_charge/headbutt,
-		/datum/action/xeno_action/activable/bull_charge/gore,
-	)
-
 /datum/xeno_caste/bull/elder
 	upgrade_name = "Elder"
 	caste_desc = "A bright red alien with a matching temper. It looks pretty strong."
@@ -108,17 +97,6 @@
 	// *** Defense *** //
 	soft_armor = list("melee" = 35, "bullet" = 45, "laser" = 35, "energy" = 35, "bomb" = XENO_BOMB_RESIST_0, "bio" = 30, "rad" = 30, "fire" = 45, "acid" = 30)
 
-	actions = list(
-		/datum/action/xeno_action/xeno_resting,
-		/datum/action/xeno_action/activable/psydrain,
-		/datum/action/xeno_action/activable/headbite,
-		/datum/action/xeno_action/activable/devour,
-		/datum/action/xeno_action/ready_charge/bull_charge,
-		/datum/action/xeno_action/activable/bull_charge,
-		/datum/action/xeno_action/activable/bull_charge/headbutt,
-		/datum/action/xeno_action/activable/bull_charge/gore,
-	)
-
 /datum/xeno_caste/bull/ancient
 	upgrade_name = "Ancient"
 	caste_desc = "The only red it will be seeing is your blood."
@@ -143,14 +121,3 @@
 
 	// *** Defense *** //
 	soft_armor = list("melee" = 40, "bullet" = 50, "laser" = 40, "energy" = 40, "bomb" = XENO_BOMB_RESIST_0, "bio" = 33, "rad" = 33, "fire" = 50, "acid" = 33)
-
-	actions = list(
-		/datum/action/xeno_action/xeno_resting,
-		/datum/action/xeno_action/activable/psydrain,
-		/datum/action/xeno_action/activable/headbite,
-		/datum/action/xeno_action/activable/devour,
-		/datum/action/xeno_action/ready_charge/bull_charge,
-		/datum/action/xeno_action/activable/bull_charge,
-		/datum/action/xeno_action/activable/bull_charge/headbutt,
-		/datum/action/xeno_action/activable/bull_charge/gore,
-	)

--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
@@ -113,6 +113,7 @@
 		/datum/action/xeno_action/ready_charge/bull_charge,
 		/datum/action/xeno_action/activable/bull_charge,
 		/datum/action/xeno_action/activable/bull_charge/headbutt,
+		/datum/action/xeno_action/activable/bull_charge/gore,
 	)
 
 /datum/xeno_caste/bull/ancient

--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
@@ -41,6 +41,8 @@
 		/datum/action/xeno_action/activable/devour,
 		/datum/action/xeno_action/ready_charge/bull_charge,
 		/datum/action/xeno_action/activable/bull_charge,
+		/datum/action/xeno_action/activable/bull_charge/headbutt,
+		/datum/action/xeno_action/activable/bull_charge/gore,
 	)
 
 /datum/xeno_caste/bull/young
@@ -78,6 +80,7 @@
 		/datum/action/xeno_action/ready_charge/bull_charge,
 		/datum/action/xeno_action/activable/bull_charge,
 		/datum/action/xeno_action/activable/bull_charge/headbutt,
+		/datum/action/xeno_action/activable/bull_charge/gore,
 	)
 
 /datum/xeno_caste/bull/elder


### PR DESCRIPTION
## About The Pull Request

Pretty self explanatory, Bull gets all charges at Young instead of Headbutt at Mature and Gore at Ancient. This is a "buff" but is really more of a QoL change, Gore is not so much stronger than Headbutt (in most cases it is not stronger at all) that it should be locked until Ancient. Gore and Headbutt are used in different situations and not getting your other form of charge until Ancient kind of sucks and makes Bull gameplay less interesting until you hit that point. 

## Why It's Good For The Game

Gore is not directly better than Headbutt, it is more of a side grade used in a different situation. Unlocking it at Elder makes more sense, Ancient lock sucks and makes Bull less interesting until you hit Ancient which takes a fair bit of time. This is barely a buff at all.

## Changelog
:cl:
balance: Bull gets all charges at Young instead of time gated to Mature and Ancient
/:cl:
