### PR TITLE
Praetorian Acid Splash tweak.

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1836,9 +1836,9 @@ datum/ammo/bullet/revolver/tp44
 
 /datum/ammo/xeno/acid/heavy
 	name = "acid splash"
-	added_spit_delay = 8
-	spit_cost = 75
-	damage = 30
+	added_spit_delay = 0
+	spit_cost = 120
+	damage = 45
 
 /datum/ammo/xeno/acid/heavy/turret
 	damage = 20


### PR DESCRIPTION

## About The Pull Request

right now praetorians are only using neuro spit over a 2-second acid splash which is little use, this pr attempts to make it more useful, I don't expect the values to stay as they are as further test merging and in-game testing is required to check if the values are too high or too low.

## Why It's Good For The Game

this will make praetorians acid splash useable and helpful in combat and to slow marine pushes and better assist the hive.


## Changelog
:cl:
balance: acid splash delay changed to 1.2 young, 1.1 mature, 1 elder, and 0.9 ancient. 
balance: acid splash now 150 plasma a shot up from 75 a shot
balance: acid splash damage up from 30 to 45 as it has no regent transfer unlike neuro splash
/:cl:


