### PR TITLE
T-25 smartrifle minor rework

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1005,9 +1005,9 @@ datum/ammo/bullet/revolver/tp44
 
 /datum/ammo/bullet/smartgun/smartrifle
 	name = "smartrifle bullet"
-	damage = 25
-	penetration = 15
-	sundering = 1
+	damage = 20
+	penetration = 10
+	sundering = 1.5
 
 /datum/ammo/bullet/smartgun/lethal
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -916,15 +916,15 @@
 
 /obj/item/weapon/gun/rifle/standard_smartrifle
 	name = "\improper T-25 smartrifle"
-	desc = "The T-25 is the TGMC's current standard IFF-capable  rifle. It's known for its ability to lay down quick fire support very well. Requires special training and it cannot turn off IFF. It uses 10x26mm ammunition."
+	desc = "The T-25 is the TGMC's current standard IFF-capable rifle. It's known for its ability to lay down quick fire support very well. Requires special training and it cannot turn off IFF. It uses 10x26mm ammunition."
 	icon = 'icons/Marine/gun64.dmi'
 	icon_state = "t25"
 	item_state = "t25"
 	caliber = CALIBER_10x26_CASELESS //codex
-	max_shells = 50 //codex
+	max_shells = 80 //codex
 	force = 35
-	aim_slowdown = 0.55
-	wield_delay = 0.6 SECONDS
+	aim_slowdown = 0.7
+	wield_delay = 0.9 SECONDS
 	fire_sound = "gun_smartgun"
 	dry_fire_sound = 'sound/weapons/guns/fire/m41a_empty.ogg'
 	unload_sound = 'sound/weapons/guns/interact/T42_unload.ogg'

--- a/code/modules/projectiles/magazines/misc.dm
+++ b/code/modules/projectiles/magazines/misc.dm
@@ -57,11 +57,11 @@
 
 /obj/item/ammo_magazine/packet/t25
 	name = "box of 10x26mm (T-25)"
-	desc = "A box containing 200 rounds of 10x26mm caseless tuned for a T-25 smartrifle.."
+	desc = "A box containing 320 rounds of 10x26mm caseless tuned for a T-25 smartrifle.."
 	icon_state = "box_t25"
 	default_ammo = /datum/ammo/bullet/smartgun/smartrifle
 	caliber = CALIBER_10x26_CASELESS
-	max_rounds = 200
+	max_rounds = 320
 
 // pistol packets
 

--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -268,7 +268,7 @@
 	icon_state_mini = "mag_t29"
 
 //-------------------------------------------------------
-//T-25 THING
+//T-25 SMARTRIFLE
 
 /obj/item/ammo_magazine/rifle/standard_smartrifle
 	name = "\improper T-25 magazine (10x26mm)"
@@ -277,7 +277,7 @@
 	icon_state = "t25"
 	w_class = WEIGHT_CLASS_NORMAL
 	default_ammo = /datum/ammo/bullet/smartgun/smartrifle
-	max_rounds = 50
+	max_rounds = 80
 	gun_type = /obj/item/weapon/gun/rifle/standard_smartrifle
 	icon_state_mini = "mag_rifle"
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the T-25 to be less of a Rifle equivalent and moves it more towards being a LMG equivalent.

Ammo capacity- 50->80
Wield delay- 0.6->0.9
Aim slowdown- 0.55->0.7

Damage- 25->20
AP-> 15->10
Sunder 1.5->1


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ammo Capacity
50->80
----
The T-25 should lean more towards a supportive role with this change and I believe giving it higher ammo capacity to trade off the damage/pen and gunstats it lost would be good enough combined with the .5 more sunder I gave it to make it lean towards a supportive stance rather than an aggressive pushing stance with the gun.
Compared to the SMMGs 200, it still loses out 120 bullets, for a faster firerate and better utility options (UGL/Miniflamer) and it still has far better gun stats than the T-29. Aswell as a far larger attachment roster (Bayoent, etc..)
----
Wield delay
0.6->0.9
----
The T-25, with being changed to be more of a LMG rather than an AR equivalent, necessitates 300ms more of wield delay to encourage it into that role, and encourages bringing a backup gun to your existent gun already, I believe this is a good change because it makes T-25s have to stay overall in the back more.
You can improve this to old levels overall by slapping an AGRIP on here, but you sacrifice utility like GLs for it. I believe this is a good overall change.
----
Aim slowdown
0.55->0.7
----
This is necessitated by the increase of the amount of ammo, as the magazines still fit in belts and stuff. I feel that it'll move the T-25 to a more supportive overall role rather than FRAG MAN SG MAN that I didn't intend it going into, and the original 15/15/2 design was pretty trash.
----
Damage
25->20
----
Having the same damage as a T-12 and higher pen is absurd, even if the gun is limited, and has the full roster of attachment options. This is necessary to move the gun to a more supportive stance rather than UNGA BETTER T-12!!!
----
Pen
15->10
----
5 pen has been removed and moved to sundering to move the gun to a more supportive stance.
----
Sunder
1->1.5
-----
This moves the gun to a more supportive role as it crunches up enemy armor for your other teammates to attack into, and makes the gun overall more supportive, it will crunch up armor for the rest of your team to deal with.
----
PACKET
200->320
----
The old packet was 50 times 4, the new packet is 80 times 4, Which is a 120 round increase from the old one. This might not be needed but I believe for consistencies sake to accommodate the higher magazine size, that it is a good change.
----

Overall

This moves the T-25 into a more supportive stance and removes the issue of it literally being the best DPS gun in the game, 30 more rounds to support your team with, it is more of an SAW than a beefed up AR, which it really shouldn't be a beefed up AR, this should hopefully move the gun towards being used as a supportive more mobile role for SG rather than being the main dps man of the entire marine team.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: T-25 reworked, it is more like an LMG than a Assault Rifle. 80 rounds instead of 50, 1.5 sunder instead of 1, 10 pen instead of 15. 0.7 aim slowdown instead of 0.8, 0.9 wield delay instead of 0.6. Packet changed to accomdate the higher amount of ammo, it holds 320 rounds instead of 200.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
