### PR TITLE
Fix Server crashing Signallers Exploit

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -227,7 +227,7 @@
 		/obj/item/weapon/combat_knife = -1,
 		/obj/item/binoculars = -1,
 		/obj/item/compass = -1,
-		/obj/item/assembly/signaler = -1,
+		/obj/item/assembly/signaler = 30,
 		/obj/item/weapon/gun/launcher/m81/flare/marine = -1,
 		),
 	)


### PR DESCRIPTION

## About The Pull Request

Signallers are currently in infinite stock in marine vendors of utility section. This leads to anyone vending few of them and setting up a cursed signal network which if they send signal to sends multiple results in one second and lag crashing the server everytime. This has to be fixed ASAP.

## Why It's Good For The Game

Fixes critical server crashing exploit

## Changelog
:cl:SpaceLove
del: signallers are no longer infinite in utility tab
fix: Fixes server crashing exploit
/:cl:
