### PR TITLE
Makes buckshot a bit more effective mid range

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -694,7 +694,7 @@ datum/ammo/bullet/revolver/tp44
 	accurate_range = 5
 	max_range = 10
 	damage = 40
-	damage_falloff = 3
+	damage_falloff = 1
 	penetration = 0
 
 
@@ -710,7 +710,7 @@ datum/ammo/bullet/revolver/tp44
 	accurate_range = 5
 	max_range = 10
 	damage = 40
-	damage_falloff = 3
+	damage_falloff = 1
 	penetration = 0
 
 //buckshot variant only used by the masterkey shotgun attachment.

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -691,10 +691,10 @@ datum/ammo/bullet/revolver/tp44
 	bonus_projectiles_scatter = 10
 	accuracy_var_low = 9
 	accuracy_var_high = 9
-	accurate_range = 3
+	accurate_range = 5
 	max_range = 10
 	damage = 40
-	damage_falloff = 4
+	damage_falloff = 3
 	penetration = 0
 
 
@@ -707,10 +707,10 @@ datum/ammo/bullet/revolver/tp44
 	shell_speed = 2
 	accuracy_var_low = 9
 	accuracy_var_high = 9
-	accurate_range = 3
+	accurate_range = 5
 	max_range = 10
 	damage = 40
-	damage_falloff = 4
+	damage_falloff = 3
 	penetration = 0
 
 //buckshot variant only used by the masterkey shotgun attachment.


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
increases the buckshot accurate range to 5 and reduces falloff by 1

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Buckshot is kinda weird in a way that it is very good(only against low armor classes) at PB and trash at everything else, its supposed to be bad as range goes on but, not only it spreads, hitting less pellets due to it, but it also loses a lot of damage and misses alot after 3 tiles, now this maxes it hit more at a higher range but it will still hit 1 or 2 pellets due to spread anyway

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: buckshot has less falloff
balance: buckshot accurate range(not spread) has been increased to 5 tiles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
