### PR TITLE
Facehuggers ignore AI monkeys, adds the monkey cubes back to the research lab.

### DIFF
--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -1237,6 +1237,7 @@
 /obj/item/camera,
 /obj/item/tool/extinguisher,
 /obj/item/reagent_containers/spray/cleaner,
+/obj/item/storage/box/monkeycubes,
 /obj/machinery/vending/nanomed,
 /turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/medical_science)

--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -8402,6 +8402,7 @@
 /area/sulaco/research)
 "aRH" = (
 /obj/structure/table/mainship,
+/obj/item/storage/box/monkeycubes,
 /obj/item/tool/extinguisher,
 /obj/effect/decal/warning_stripes/thin{
 	dir = 9
@@ -16045,6 +16046,7 @@
 /obj/item/reagent_containers/food/condiment/peppermill,
 /obj/item/reagent_containers/food/condiment/peppermill,
 /obj/item/reagent_containers/food/condiment/peppermill,
+/obj/item/storage/box/monkeycubes,
 /obj/item/reagent_containers/food/condiment/peppermill,
 /obj/item/reagent_containers/food/condiment/peppermill,
 /obj/machinery/light/small{

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -459,7 +459,7 @@
 
 /mob/living/carbon/human/species/monkey/can_be_facehugged(obj/item/clothing/mask/facehugger/F, check_death = TRUE, check_mask = TRUE, provoked = FALSE)
 	if(mind)
-		return TRUE //facehuggers still attack player monkeys
+		return ..() //facehuggers still attack player monkeys
 	return FALSE //ai monkeys are ignored by facehuggers
 
 /////////////////////////////

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -457,6 +457,8 @@
 
 	return TRUE
 
+/mob/living/carbon/human/species/monkey/can_be_facehugged(obj/item/clothing/mask/facehugger/F, check_death = TRUE, check_mask = TRUE, provoked = FALSE)
+	return FALSE // monkeys are ignored by facehuggers
 
 /////////////////////////////
 // ATTACHING AND IMPREGNATION

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -458,7 +458,9 @@
 	return TRUE
 
 /mob/living/carbon/human/species/monkey/can_be_facehugged(obj/item/clothing/mask/facehugger/F, check_death = TRUE, check_mask = TRUE, provoked = FALSE)
-	return FALSE // monkeys are ignored by facehuggers
+	if(mind)
+		return TRUE //facehuggers still attack player monkeys
+	return FALSE //ai monkeys are ignored by facehuggers
 
 /////////////////////////////
 // ATTACHING AND IMPREGNATION

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1264,6 +1264,12 @@ SUPPLIES
 		/obj/item/paper/janitor,
 	)
 	cost = 5
+	
+/datum/supply_packs/supplies/monkey
+	name = "monkey cube crate"
+	notes = "Contains a box of 5 monkey cubes"
+	contains = list(/obj/item/storage/box/monkeycubes)
+	cost = 30
 
 /*******************************************************************************
 Imports

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1264,12 +1264,6 @@ SUPPLIES
 		/obj/item/paper/janitor,
 	)
 	cost = 5
-	
-/datum/supply_packs/supplies/monkey
-	name = "monkey cube crate"
-	notes = "Contains a box of 5 monkey cubes"
-	contains = list(/obj/item/storage/box/monkeycubes)
-	cost = 30
 
 /*******************************************************************************
 Imports


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This makes facehuggers ignore AI monkeys and puts the monkey cube boxes back in their respective places on each map. Player controlled monkeys are not affected.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Solves the problem presented in #7652 while still allowing for monkey related gimmicks and gives researchers something to do. Reduces the chances of unfair XvX gameplay happening.
It's better than nothing I guess.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Matlap
add: Monkey cubes are now back in research.
bal: Facehuggers will now ignore AI monkeys.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
