### PR TITLE
Adds stasis check to living

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1,5 +1,5 @@
 /mob/living/proc/Life()
-	if(stat == DEAD || notransform) //If we're dead or notransform don't bother processing life
+	if(stat == DEAD || notransform || HAS_TRAIT(src, TRAIT_STASIS)) //If we're dead or notransform don't bother processing life
 		return
 
 	handle_status_effects() //all special effects, stun, knockdown, jitteryness, hallucination, sleeping, etc


### PR DESCRIPTION
## About The Pull Request
Skips processing of status effects tracked on mob (not datum ones), health updates (shouldn't be changing if they're in stasis), and organs (which then prevents chems metabolizing).

## Why It's Good For The Game
Apparently you still heal through chems while in a stasis bag. This fixes that.
A stasis check could be added to carbon's life too, but it's not necessary because the only thing carbon does is breath and that independently checks stasis.

## Changelog
:cl:
fix: Stasis bags prevent metabolizing chemicals
fix: Some negative status effects will be paused while in stasis, resuming once you leave
/:cl: