### PR TITLE
Gives Berets a NO_DECAP flag

### DIFF
--- a/code/modules/clothing/head/head.dm
+++ b/code/modules/clothing/head/head.dm
@@ -52,6 +52,7 @@
 	icon_state = "beret"
 	soft_armor = list("melee" = 15, "bullet" = 15, "laser" = 15, "energy" = 15, "bomb" = 10, "bio" = 5, "rad" = 0, "fire" = 5, "acid" = 5)
 	flags_item_map_variant = NONE
+	flags_armor_features = ARMOR_NO_DECAP
 
 /obj/item/clothing/head/tgmcberet/tan
 	icon_state = "berettan"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Read the title and ask me what else it could possibly be about? Marine berets get the ARMOR_NO_DECAP, preventing decapitations. This does not mean you **won't** go down just as fast, you're just NOT permenantly removed from the round.

Very certain there are better ways to approach this issue, but I am not familiar with such approaches therefore this is the best I can and will be able to do
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Being **severely** punished with a decapitation just because you want to spruce up your own fashion is actually pretty lame, not gonna front? Berets already have extremely awful armor stats to boot, meaning the result kind of stays the same anyway — you died. Why twist the knife in further with a "fuck you, you're outta the round for good"? Might as well just remove them (and similar hat items that ain't helmets) if the players using them are being given such treatment. 

Also picking on some dude's fashion is fucking uncool, but that's besides the very off-track point; I don't think xenos should be getting an easy clap, one permenantly dead Marine, **and** free psy points in just one runner pounce. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Berets get a ARMOR_NO_DECAP too. Have fun snowflakes, you're still going to die a horrible, unceromoneous death because they still get crap armor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
