### PR TITLE
Jetpack are now free

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -229,7 +229,7 @@
 		/obj/item/compass = -1,
 		/obj/item/assembly/signaler = -1,
 		/obj/item/weapon/gun/launcher/m81/flare/marine = -1,
-		/obj/item/jetpack_marine = 5,
+		/obj/item/jetpack_marine = 3,
 		),
 	)
 

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -229,6 +229,7 @@
 		/obj/item/compass = -1,
 		/obj/item/assembly/signaler = -1,
 		/obj/item/weapon/gun/launcher/m81/flare/marine = -1,
+		/obj/item/jetpack_marine = -1,
 		),
 	)
 

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -229,7 +229,7 @@
 		/obj/item/compass = -1,
 		/obj/item/assembly/signaler = -1,
 		/obj/item/weapon/gun/launcher/m81/flare/marine = -1,
-		/obj/item/jetpack_marine = -1,
+		/obj/item/jetpack_marine = 5,
 		),
 	)
 

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -938,6 +938,11 @@ CLOTHING
 	)
 	cost = 5
 
+/datum/supply_packs/clothing/jetpack
+	name = "Jetpack"
+	contains = list(/obj/item/jetpack_marine)
+	cost = 12
+
 /*******************************************************************************
 MEDICAL
 *******************************************************************************/

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -938,11 +938,6 @@ CLOTHING
 	)
 	cost = 5
 
-/datum/supply_packs/clothing/jetpack
-	name = "Jetpack"
-	contains = list(/obj/item/jetpack_marine)
-	cost = 12
-
 /*******************************************************************************
 MEDICAL
 *******************************************************************************/


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You can get jetpacks from the utility tab now. 5 of them free, if this is not too much i'll make it widely avaiblable

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Jetpacks are rarely used, despite their low price in req. This is because a lot of the time, you need this extra ammo in the bag, and jetpack is not that interesting in your loadout.

Putting the jetpack for free at the start of the game will allow players to experiment with new builds, and i don't think jetpack is that strong against xenos

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: 3 jetpacks free in vendors
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
