### PR TITLE
Carrier can use non-combat abilities while resting.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
@@ -88,6 +88,7 @@
 	mechanics_text = "Store an egg on your body for future use. The egg has to be unplanted."
 	ability_name = "retrieve egg"
 	keybind_signal = COMSIG_XENOABILITY_RETRIEVE_EGG
+	use_state_flags = XACT_USE_LYING
 
 /datum/action/xeno_action/activable/retrieve_egg/use_ability(atom/A)
 	var/mob/living/carbon/xenomorph/carrier/X = owner
@@ -144,6 +145,7 @@
 	mechanics_text = "Place a hole on weeds that can be filled with a hugger. Activates when a marine steps on it."
 	plasma_cost = 400
 	keybind_signal = COMSIG_XENOABILITY_PLACE_TRAP
+	use_state_flags = XACT_USE_LYING
 
 /datum/action/xeno_action/place_trap/can_use_action(silent = FALSE, override_flags)
 	. = ..()
@@ -188,6 +190,7 @@
 	plasma_cost = 200
 	cooldown_timer = 10 SECONDS
 	keybind_signal = COMSIG_XENOABILITY_SPAWN_HUGGER
+	use_state_flags = XACT_USE_LYING
 
 /datum/action/xeno_action/spawn_hugger/on_cooldown_finish()
 	to_chat(owner, "<span class='xenodanger'>We can now spawn another young one.</span>")


### PR DESCRIPTION
QOL change to help carrier optimize spawning huggers and plasma usage.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Carrier can use non-combat abilities while resting. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
qol: Helps carrier optimize using non-combat abilities by letting them be usable while resting.


## Changelog
Carrier can use:
Retrieve egg
Spawn hugger
Place trap
While resting.
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
