### PR TITLE
Give shotgun aimode

### DIFF
--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -25,6 +25,8 @@ can cause issues with ammo types getting mixed up during the burst.
 	wield_delay = 0.6 SECONDS //Shotguns are really easy to put up to fire, since they are designed for CQC (at least compared to a rifle)
 	gun_skill_category = GUN_SKILL_SHOTGUNS
 	flags_item_map_variant = NONE
+	actions_types = list(/datum/action/item_action/aim_mode)
+	aim_fire_delay = 0.3 SECONDS
 
 	fire_delay = 6
 	accuracy_mult = 1.15


### PR DESCRIPTION
## About The Pull Request

PR made to give aimode to shotguns, actually doest work with the tx shotgun and additional bullets

## Why It's Good For The Game

Shotguns kill more marines with FF than xenos. This PR is made with the idea of making it less punishable for marines who get hitted by shotguns (but still deal damage with secondary bullets)).

## Changelog
:cl:

give shotguns aimode 
shotgun aimode dont fully work with secondary bullets ((a fully made feature))
/:cl:
