### PR TITLE
Pillar of spring drop ship crash location fix.

### DIFF
--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -6169,7 +6169,7 @@
 /area/mainship/shipboard/weapon_room)
 "ur" = (
 /obj/docking_port/stationary/marine_dropship/crash_target,
-/turf/open/floor/mainship/floor,
+/turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "us" = (
 /turf/open/floor/mainship/mono,
@@ -14797,7 +14797,6 @@
 /area/mainship/engineering/port_atmos)
 "Vy" = (
 /obj/docking_port/stationary/marine_dropship/hangar/one,
-/obj/docking_port/stationary/marine_dropship/crash_target,
 /turf/open/floor/plating,
 /area/mainship/hallways/hangar)
 "Vz" = (
@@ -45214,7 +45213,7 @@ bn
 se
 eJ
 aT
-bh
+ur
 bh
 bh
 bh
@@ -46253,7 +46252,7 @@ Gm
 MD
 ap
 te
-ur
+eB
 bp
 ao
 fQ


### PR DESCRIPTION


## About The Pull Request

Removes 2 bad hijack crash locations on the alamo and adds 1 new one.

## Why It's Good For The Game

15 Xenos against 30 marines shipside, if you crash on either of those locations, your hive is as good as dead due to marine rush which is incredibly unfair. the new location is added so it's closer to tadpole and much more dangerous for marines, but still, give marines a chance if they rush. the majority of Xenos don't want to hijack anymore because of the often unfair advantage of this.

## Changelog
:cl:
balance: removed 2 alamo crash locations on POS
balance: added one new alamo crash location on pos closer to tadpole
/:cl:

