### PR TITLE
Chem rework 7: a few researchchems and balance tweaks

### DIFF
--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -874,7 +874,7 @@ While the Corporate Liaison is not your boss, it would be wise to consult them o
 	glasses = /obj/item/clothing/glasses/hud/health
 	mask = /obj/item/clothing/mask/surgical
 	suit_store = /obj/item/flashlight/pen
-	r_store = /obj/item/storage/pouch/medkit/full
+	r_store = /obj/item/reagent_containers/glass/bottle/lemoline
 	l_store = /obj/item/storage/pouch/autoinjector/advanced/full
 	back = /obj/item/storage/backpack/marine/satchel
 

--- a/code/game/objects/items/defibrillator.dm
+++ b/code/game/objects/items/defibrillator.dm
@@ -222,8 +222,8 @@
 		return
 
 	var/datum/internal_organ/heart/heart = H.internal_organs_by_name["heart"]
-	if(!issynth(H) && heart && prob(25))
-		heart.take_damage(5) //Allow the defibrilator to possibly worsen heart damage. Still rare enough to just be the "clone damage" of the defib
+	if(!issynth(H) && heart)
+		heart.take_damage(5) //Deals heart damage every defib. After six shocks, you gotta send them up for surgery. No more medic circles.
 
 	if(!H.has_working_organs())
 		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Defibrillation failed. Patient's general condition does not allow reviving."))

--- a/code/modules/reagents/reactions/medical.dm
+++ b/code/modules/reagents/reactions/medical.dm
@@ -226,6 +226,6 @@
 
 /datum/chemical_reaction/stimulum
 	name = "Stimulum"
-	results = list(/datum/reagent/medicine/research/stimulum = 1)
+	results = list(/datum/reagent/medicine/research/stimulon = 1)
 	required_reagents = list(/datum/reagent/medicine/synaptizine = 10, /datum/reagent/medicine/arithrazine = 20, /datum/reagent/consumable/nutriment = 20, /datum/reagent/medicine/lemoline = 20)
 

--- a/code/modules/reagents/reactions/medical.dm
+++ b/code/modules/reagents/reactions/medical.dm
@@ -169,7 +169,7 @@
 
 /datum/chemical_reaction/lemoline
 	name = "Lemoline catalysis"
-	results = list(/datum/reagent/medicine/lemoline = 2)
+	results = list(/datum/reagent/medicine/lemoline = 4) //3 to one multiplication ratio
 	required_reagents = list(/datum/reagent/medicine/lemoline = 1, /datum/reagent/consumable/larvajelly = 1)
 
 // Cloning chemicals

--- a/code/modules/reagents/reactions/medical.dm
+++ b/code/modules/reagents/reactions/medical.dm
@@ -30,7 +30,7 @@
 	results = list(/datum/reagent/medicine/bicaridine = 2)
 	required_reagents = list(/datum/reagent/medicine/inaprovaline = 1, /datum/reagent/carbon = 1)
 
-/datum/chemical_reaction/meralime
+/datum/chemical_reaction/meraline
 	name = "Meralyne"
 	results = list(/datum/reagent/medicine/meralyne = 3)
 	required_reagents = list(/datum/reagent/medicine/inaprovaline = 1, /datum/reagent/medicine/bicaridine = 1, /datum/reagent/iron = 1, /datum/reagent/medicine/lemoline = 1)
@@ -169,7 +169,7 @@
 
 /datum/chemical_reaction/lemoline
 	name = "Lemoline catalysis"
-	results = list(/datum/reagent/medicine/lemoline = 4) //3 to one multiplication ratio
+	results = list(/datum/reagent/medicine/lemoline = 5) //4 to one multiplication ratio
 	required_reagents = list(/datum/reagent/medicine/lemoline = 1, /datum/reagent/consumable/larvajelly = 1)
 
 // Cloning chemicals
@@ -189,12 +189,12 @@
 	required_reagents = list(/datum/reagent/virilyth = 1, /datum/reagent/medicine/kelotane = 1)
 
 /datum/chemical_reaction/dupl_tramadol
-	name = "Duplicate Bicaridine"
+	name = "Duplicate Tramadol"
 	results = list(/datum/reagent/medicine/tramadol = 2)
 	required_reagents = list(/datum/reagent/virilyth = 1, /datum/reagent/medicine/tramadol = 1)
 
 /datum/chemical_reaction/dupl_dylovene
-	name = "Duplicate Bicaridine"
+	name = "Duplicate Dylovene"
 	results = list(/datum/reagent/medicine/dylovene = 2)
 	required_reagents = list(/datum/reagent/virilyth = 1, /datum/reagent/medicine/dylovene = 1)
 
@@ -210,12 +210,22 @@
 
 /datum/chemical_reaction/somolent
 	name = "Somolent"
-	results = list(/datum/reagent/medicine/research/somolent = 5)
-	required_reagents = list(/datum/reagent/toxin/sleeptoxin = 1, /datum/reagent/medicine/tricordrazine = 1, /datum/reagent/consumable/drink/doctor_delight = 1, /datum/reagent/medicine/paracetamol = 1, /datum/reagent/medicine/lemoline = 1)
-
+	results = list(/datum/reagent/medicine/research/somolent = 4)
+	required_reagents = list(/datum/reagent/toxin/sleeptoxin = 1, /datum/reagent/medicine/tricordrazine = 1, /datum/reagent/consumable/drink/doctor_delight = 1, /datum/reagent/medicine/paracetamol = 1)
+	required_catalysts = list(/datum/reagent/medicine/lemoline = 5)
+	
 /datum/chemical_reaction/medicalnanites
 	name = "Medical Nanites"
 	results = list(/datum/reagent/medicine/research/medicalnanites = 1)
 	required_reagents = list(/datum/reagent/toxin/nanites = 10, /datum/reagent/radium = 5, /datum/reagent/iron = 100, /datum/reagent/medicine/lemoline = 5)
 
+/datum/chemical_reaction/cryotox
+	name = "Cryotox"
+	results = list(/datum/reagent/medicine/research/cryotox = 15)
+	required_reagents = list(/datum/reagent/medicine/cryoxadone = 2, /datum/reagent/medicine/leporazine = 2, /datum/reagent/consumable/drink/cold/ice = 10, /datum/reagent/medicine/lemoline = 1)
+
+/datum/chemical_reaction/stimulum
+	name = "Stimulum"
+	results = list(/datum/reagent/medicine/research/stimulum = 1)
+	required_reagents = list(/datum/reagent/medicine/synaptizine = 10, /datum/reagent/medicine/arithrazine = 20, /datum/reagent/consumable/nutriment = 20, /datum/reagent/medicine/lemoline = 20)
 

--- a/code/modules/reagents/reactions/medical.dm
+++ b/code/modules/reagents/reactions/medical.dm
@@ -219,11 +219,6 @@
 	results = list(/datum/reagent/medicine/research/medicalnanites = 1)
 	required_reagents = list(/datum/reagent/toxin/nanites = 10, /datum/reagent/radium = 5, /datum/reagent/iron = 100, /datum/reagent/medicine/lemoline = 5)
 
-/datum/chemical_reaction/cryotox
-	name = "Cryotox"
-	results = list(/datum/reagent/medicine/research/cryotox = 15)
-	required_reagents = list(/datum/reagent/medicine/cryoxadone = 2, /datum/reagent/medicine/leporazine = 2, /datum/reagent/consumable/drink/cold/ice = 10, /datum/reagent/medicine/lemoline = 1)
-
 /datum/chemical_reaction/stimulum
 	name = "Stimulum"
 	results = list(/datum/reagent/medicine/research/stimulon = 1)

--- a/code/modules/reagents/reactions/medical.dm
+++ b/code/modules/reagents/reactions/medical.dm
@@ -202,3 +202,20 @@
 	name = "Bihexajuline"
 	results = list(/datum/reagent/medicine/bihexajuline = 5)
 	required_reagents = list(/datum/reagent/medicine/bicaridine = 2, /datum/reagent/consumable/drink/milk = 1, /datum/reagent/iron = 2)
+
+/datum/chemical_reaction/quietus
+	name = "Quietus"
+	results = list(/datum/reagent/medicine/research/quietus = 1)
+	required_reagents = list(/datum/reagent/toxin/chloralhydrate = 3, /datum/reagent/medicine/dylovene = 1, /datum/reagent/medicine/lemoline = 3)
+
+/datum/chemical_reaction/somolent
+	name = "Somolent"
+	results = list(/datum/reagent/medicine/research/somolent = 5)
+	required_reagents = list(/datum/reagent/toxin/sleeptoxin = 1, /datum/reagent/medicine/tricordrazine = 1, /datum/reagent/consumable/drink/doctor_delight = 1, /datum/reagent/medicine/paracetamol = 1, /datum/reagent/medicine/lemoline = 1)
+
+/datum/chemical_reaction/medicalnanites
+	name = "Medical Nanites"
+	results = list(/datum/reagent/medicine/research/medicalnanites = 1)
+	required_reagents = list(/datum/reagent/toxin/nanites = 10, /datum/reagent/radium = 5, /datum/reagent/iron = 100, /datum/reagent/medicine/lemoline = 5)
+
+

--- a/code/modules/reagents/reactions/medical.dm
+++ b/code/modules/reagents/reactions/medical.dm
@@ -15,12 +15,6 @@
 	required_reagents = list(/datum/reagent/oxygen = 2, /datum/reagent/toxin/phoron = 0.1)
 	required_catalysts = list(/datum/reagent/toxin/phoron = 5)
 
-/datum/chemical_reaction/dermaline
-	name = "Dermaline"
-	results = list(/datum/reagent/medicine/dermaline = 3)
-	required_reagents = list(/datum/reagent/oxygen = 1, /datum/reagent/phosphorus = 1, /datum/reagent/medicine/kelotane = 1)
-	required_catalysts = list(/datum/reagent/consumable/larvajelly = 5)
-
 /datum/chemical_reaction/dermalime
 	name = "Dermaline"
 	results = list(/datum/reagent/medicine/dermaline = 3)
@@ -35,12 +29,6 @@
 	name = "Bicaridine"
 	results = list(/datum/reagent/medicine/bicaridine = 2)
 	required_reagents = list(/datum/reagent/medicine/inaprovaline = 1, /datum/reagent/carbon = 1)
-
-/datum/chemical_reaction/meralyne
-	name = "Meralyne"
-	results = list(/datum/reagent/medicine/meralyne = 3)
-	required_reagents = list(/datum/reagent/medicine/inaprovaline = 1, /datum/reagent/medicine/bicaridine = 1, /datum/reagent/iron = 1)
-	required_catalysts = list(/datum/reagent/consumable/larvajelly = 5)
 
 /datum/chemical_reaction/meralime
 	name = "Meralyne"
@@ -177,7 +165,12 @@
 	name = "Neuraline"
 	results = list(/datum/reagent/medicine/neuraline = 4, /datum/reagent/toxin/zombiepowder = 1)
 	required_reagents = list(/datum/reagent/medicine/synaptizine = 1, /datum/reagent/medicine/arithrazine = 1, /datum/reagent/medicine/tricordrazine = 2, /datum/reagent/consumable/larvajellyprepared = 1)
-	required_catalysts = list(/datum/reagent/consumable/larvajelly = 5)
+	required_catalysts = list(/datum/reagent/medicine/lemoline = 5)
+
+/datum/chemical_reaction/lemoline
+	name = "Lemoline catalysis"
+	results = list(/datum/reagent/medicine/lemoline = 2)
+	required_reagents = list(/datum/reagent/medicine/lemoline = 1, /datum/reagent/consumable/larvajelly = 1)
 
 // Cloning chemicals
 /datum/chemical_reaction/expanded_biomass

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1257,7 +1257,7 @@
 				L.heal_limb_damage(2*effect_str, 0)
 				holder.remove_reagent(/datum/reagent/medicine/research/medicalnanites, 1)
 				
-			var/burn_loss = L.getBurnLoss()
+			var/burn_loss = L.getFireLoss()
 			if(!burn_loss) //If we have no burn damage, cancel out
 				return ..()
 			else if (volume > 5) //And if there's enough remaining, heal some damage and remove some nanites.

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1216,9 +1216,9 @@
 				L.adjustStaminaLoss(1*effect_str)
 	return ..()
 	
-	/datum/reagent/medicine/research/quietus/on_mob_delete(mob/living/L, metabolism)
-		to_chat(L, span_danger("You convulse as your body violently rejects the suicide drug!"))
-		L.adjustToxLoss(30*effect_str)
+/datum/reagent/medicine/research/quietus/on_mob_delete(mob/living/L, metabolism)
+	to_chat(L, span_danger("You convulse as your body violently rejects the suicide drug!"))
+	L.adjustToxLoss(30*effect_str)
 	
 	
 

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1285,13 +1285,16 @@
 
 /datum/reagent/medicine/research/cryotox
 	name = "Cryotox"
-	description = "A toxin that massively lowers internal body temperature."
+	description = "A toxin that suspends most body processes and chemical intake. Length of suspension depends on initial dose injection."
 	color = "#C8A5DC"
+	custom_metabolism = 15 //rapidly remove all of it from you once the stasis clears
 	scannable = TRUE
 	taste_description = "freezing"
 
 /datum/reagent/medicine/research/cryotox/on_mob_add(mob/living/L, metabolism)
-		L.adjust_bodytemperature(-30*TEMPERATURE_DAMAGE_COEFFICIENT*effect_str, 100)
+	to_chat(L, span_userdanger("You feel your bodily processes slow, then halt!"))
+	ADD_TRAIT(L, TRAIT_STASIS)
+	addtimer(CALLBACK(REMOVE_TRAIT(L, TRAIT_STASIS)), (10 SECONDS* volume))
 	return ..()
 	
 	

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1281,21 +1281,6 @@
 
 /datum/reagent/medicine/research/medicalnanites/overdose_process(mob/living/L, metabolism)
 	L.adjustToxLoss(effect_str) //softcap VS injecting massive amounts of medical nanites for the healing factor with no downsides. Still doable if you're clever about it.
-
-
-/datum/reagent/medicine/research/cryotox
-	name = "Cryotox"
-	description = "A toxin that suspends most body processes and chemical intake. Length of suspension depends on initial dose injection."
-	color = "#C8A5DC"
-	custom_metabolism = 15 //rapidly remove all of it from you once the stasis clears
-	scannable = TRUE
-	taste_description = "freezing"
-
-/datum/reagent/medicine/research/cryotox/on_mob_add(mob/living/L, metabolism)
-	to_chat(L, span_userdanger("You feel your bodily processes slow, then halt!"))
-	ADD_TRAIT(L, TRAIT_STASIS, STASIS_BAG_TRAIT)
-	addtimer(CALLBACK(REMOVE_TRAIT(L, TRAIT_STASIS, STASIS_BAG_TRAIT)), (10 SECONDS* volume))
-	return ..()
 	
 	
 /datum/reagent/medicine/research/stimulon

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1293,8 +1293,8 @@
 
 /datum/reagent/medicine/research/cryotox/on_mob_add(mob/living/L, metabolism)
 	to_chat(L, span_userdanger("You feel your bodily processes slow, then halt!"))
-	ADD_TRAIT(L, TRAIT_STASIS)
-	addtimer(CALLBACK(REMOVE_TRAIT(L, TRAIT_STASIS)), (10 SECONDS* volume))
+	ADD_TRAIT(L, TRAIT_STASIS, STASIS_BAG_TRAIT)
+	addtimer(CALLBACK(REMOVE_TRAIT(L, TRAIT_STASIS, STASIS_BAG_TRAIT)), (10 SECONDS* volume))
 	return ..()
 	
 	

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1292,8 +1292,8 @@
 
 /datum/reagent/medicine/research/cryotox/on_mob_add(mob/living/L, metabolism)
 	var/target_temp = L.get_standard_bodytemperature()
-	if(L.bodytemperature > target_temp - 200)
-		L.adjust_bodytemperature(-30*TEMPERATURE_DAMAGE_COEFFICIENT*effect_str, target_temp)
+	if(L.bodytemperature > (target_temp - 200))
+		L.adjust_bodytemperature(-30*TEMPERATURE_DAMAGE_COEFFICIENT*effect_str, (target_temp - 200))
 	return ..()
 	
 	
@@ -1314,15 +1314,15 @@
 
 /datum/reagent/medicine/research/stimulon/on_mob_life(mob/living/L, metabolism)
 	L.adjustStaminaLoss(1*effect_str)
-	L.take_limb_damage(rand(0.5*effect_str, 3*effect_str), 0)
-	L.adjustCloneLoss(rand (0, 0.05) * effect_str * current_cycle)
+	L.take_limb_damage(rand(0.5*effect_str, 4*effect_str), 0)
+	L.adjustCloneLoss(rand (0, 5) * effect_str * current_cycle *0.01)
 	if(prob(2))
 		L.emote(pick("twitch","blink_r","shiver"))
 	if(volume < 100) //THERE IS NO "MINIMUM SAFE DOSE" MUAHAHAHA!
 		L.reagents.add_reagent(/datum/reagent/medicine/research/stimulon, 0.25)
 	if(current_cycle > 25)
 		if(prob(5))
-			to_chat(L, span_userdanger("You start to ache. Maybe you should get rid of this drug?"))
+			to_chat(L, span_danger("You start to ache. Maybe you should get rid of this drug?"))
 	return ..()
 
 

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -327,7 +327,7 @@
 	description = "Dylovene is a broad-spectrum antitoxin."
 	color = "#A8F59C"
 	scannable = TRUE
-	purge_list = list(/datum/reagent/toxin, /datum/reagent/toxin/xeno_neurotoxin, /datum/reagent/consumable/drink/atomiccoffee, /datum/reagent/medicine/paracetamol, /datum/reagent/medicine/larvaway)
+	purge_list = list(/datum/reagent/toxin, /datum/reagent/medicine/research/stimulon, /datum/reagent/medicine/paracetamol, /datum/reagent/medicine/larvaway)
 	purge_rate = 1
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
@@ -1250,7 +1250,7 @@
 	overdose_threshold = REAGENTS_OVERDOSE * 1.2 //slight buffer to keep you safe
 
 /datum/reagent/medicine/research/medicalnanites/on_mob_add(mob/living/L, metabolism)
-	to_chat(L, span_danger("You feel like you should stay near medical help until this shot settles in."))
+	to_chat(L, span_userdanger("You feel like you should stay near medical help until this shot settles in."))
 
 /datum/reagent/medicine/research/medicalnanites/on_mob_life(mob/living/L, metabolism)
 	switch(current_cycle)
@@ -1289,10 +1289,14 @@
 	color = "#C8A5DC"
 	scannable = TRUE
 	taste_description = "freezing"
-	adj_temp = 30
-	targ_temp = 100
 
-
+/datum/reagent/medicine/research/cryotox/on_mob_add(mob/living/L, metabolism)
+	var/target_temp = L.get_standard_bodytemperature()
+	if(L.bodytemperature > target_temp - 200)
+		L.adjust_bodytemperature(-30*TEMPERATURE_DAMAGE_COEFFICIENT*effect_str, target_temp)
+	return ..()
+	
+	
 /datum/reagent/medicine/research/stimulon
 	name = "Stimulon"
 	description = "A chemical designed to boost running by driving your body beyond it's normal limits. Can have unpredictable side effects, caution recommended."
@@ -1301,6 +1305,7 @@
 	scannable = TRUE
 
 /datum/reagent/medicine/research/stimulon/on_mob_add(mob/living/L, metabolism)
+	to_chat(L, span_userdanger("You feel jittery and fast! Time to MOVE!"))
 	. = ..()
 	L.add_movespeed_modifier(type, TRUE, 0, NONE, TRUE, -1)
 
@@ -1314,7 +1319,10 @@
 	if(prob(2))
 		L.emote(pick("twitch","blink_r","shiver"))
 	if(volume < 100) //THERE IS NO "MINIMUM SAFE DOSE" MUAHAHAHA!
-		L.reagents.add_reagent(/datum/reagent/medicine/research/stimulon, 0.1)
+		L.reagents.add_reagent(/datum/reagent/medicine/research/stimulon, 0.25)
+	if(current_cycle > 25)
+		if(prob(5))
+			to_chat(L, span_userdanger("You start to ache. Maybe you should get rid of this drug?"))
 	return ..()
 
 

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1250,10 +1250,7 @@
 				L.reagents.add_reagent(/datum/reagent/medicine/research/medicalnanites, 0.5)
 				L.blood_volume -= 2
 				
-			var/brute_loss = L.getBruteLoss()
-			if(!brute_loss) //If we have no brute damage, cancel out
-				return ..()
-			else if (volume > 5) //And if there's enough remaining, heal some damage and remove some nanites.
+			if (volume >5 && L.getBruteLoss()) //If there's no bruteloss, don't waste shit. Also, don't heal if it'd bring you below 5u reserve nanites.
 				L.heal_limb_damage(2*effect_str, 0)
 				holder.remove_reagent(/datum/reagent/medicine/research/medicalnanites, 1)
 				

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1257,10 +1257,7 @@
 				L.heal_limb_damage(2*effect_str, 0)
 				holder.remove_reagent(/datum/reagent/medicine/research/medicalnanites, 1)
 				
-			var/burn_loss = L.getFireLoss()
-			if(!burn_loss) //If we have no burn damage, cancel out
-				return ..()
-			else if (volume > 5) //And if there's enough remaining, heal some damage and remove some nanites.
+			if (volume > 5 && L.getFireLoss())
 				L.heal_limb_damage(0, 2*effect_str)
 				holder.remove_reagent(/datum/reagent/medicine/research/medicalnanites, 1)
 	return ..()

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1220,7 +1220,7 @@
 	taste_description = "naptime"
 
 /datum/reagent/medicine/research/somolent/on_mob_life(mob/living/L, metabolism)
-	if(cycle > 50)
+	if(current_cycle > 50)
 		return ..()
 	if(L.stat == UNCONSCIOUS)
 		L.heal_limb_damage(0.2*current_cycle*effect_str, 0.2*current_cycle*effect_str)

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1291,9 +1291,7 @@
 	taste_description = "freezing"
 
 /datum/reagent/medicine/research/cryotox/on_mob_add(mob/living/L, metabolism)
-	var/target_temp = L.get_standard_bodytemperature()
-	if(L.bodytemperature > (target_temp - 200))
-		L.adjust_bodytemperature(-30*TEMPERATURE_DAMAGE_COEFFICIENT*effect_str, (target_temp - 200))
+		L.adjust_bodytemperature(-30*TEMPERATURE_DAMAGE_COEFFICIENT*effect_str, 100)
 	return ..()
 	
 	
@@ -1320,8 +1318,8 @@
 		L.emote(pick("twitch","blink_r","shiver"))
 	if(volume < 100) //THERE IS NO "MINIMUM SAFE DOSE" MUAHAHAHA!
 		L.reagents.add_reagent(/datum/reagent/medicine/research/stimulon, 0.25)
-	if(current_cycle > 25)
-		if(prob(5))
+	if(current_cycle > 20)
+		if(prob(10))
 			to_chat(L, span_danger("You start to ache. Maybe you should get rid of this drug?"))
 	return ..()
 

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1196,7 +1196,7 @@
 	name = "Quietus"
 	description = "This is a latent poison, designed to quickly and painlessly kill you in the event that you become unable to fight. Never washes out on it's own, must be purged."
 	color = "#19C832"
-	custom_metabolism = REAGENTS_METABOLISM * 0
+	custom_metabolism = 0
 	taste_description = "Victory"
 
 /datum/reagent/medicine/research/quietus/on_mob_life(mob/living/L, metabolism)
@@ -1220,12 +1220,12 @@
 	taste_description = "naptime"
 
 /datum/reagent/medicine/research/somolent/on_mob_life(mob/living/L, metabolism)
-	switch(current_cycle)
-		if(1 to 50)
-			if(L.stat == UNCONSCIOUS)
-				L.heal_limb_damage(0.2*current_cycle*effect_str, 0.2*current_cycle*effect_str)
-			if(prob(5))
-				to_chat(L, span_notice("You feel as though you should be sleeping for the medicine to work."))
+	if(cycle > 50)
+		return ..()
+	if(L.stat == UNCONSCIOUS)
+		L.heal_limb_damage(0.2*current_cycle*effect_str, 0.2*current_cycle*effect_str)
+		if(prob(5))
+			to_chat(L, span_notice("You feel as though you should be sleeping for the medicine to work."))
 	return ..()
 
 
@@ -1233,7 +1233,7 @@
 	name = "Medical nanites"
 	description = "These are a batch of construction nanites altered for in-vivo replication. They can heal wounds using the iron present in the bloodstream. Medical care is recommended during injection."
 	color = "#19C832"
-	custom_metabolism = REAGENTS_METABOLISM * 0
+	custom_metabolism = 0
 	taste_description = "metal, followed by mild burning"
 	overdose_threshold = REAGENTS_OVERDOSE * 1.2 //slight buffer to keep you safe
 

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -47,7 +47,7 @@
 	scannable = TRUE
 	custom_metabolism = REAGENTS_METABOLISM * 0.125
 	purge_list = list(/datum/reagent/toxin)
-	purge_rate = 5
+	purge_rate = 3
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 
@@ -307,8 +307,8 @@
 /datum/reagent/medicine/tricordrazine/on_mob_life(mob/living/L, metabolism)
 
 	L.adjustOxyLoss(-0.5*effect_str)
-	L.adjustToxLoss(-0.4*effect_str)
-	L.heal_limb_damage(0.8*effect_str, 0.8*effect_str)
+	L.adjustToxLoss(-0.25*effect_str)
+	L.heal_limb_damage(0.5*effect_str, 0.5*effect_str)
 	if(volume > 10)
 		L.reagent_pain_modifier -= PAIN_REDUCTION_LIGHT
 	if(volume > 20)
@@ -1060,11 +1060,11 @@
 			if(prob(25))
 				L.adjustStaminaLoss(0.5*effect_str)
 		if(101 to 200)
-			L.adjustToxLoss(effect_str)
+			L.adjustToxLoss(0.75*effect_str)
 			if(prob(25))
 				L.adjustStaminaLoss(20*effect_str)
 		if(201 to INFINITY)
-			L.adjustToxLoss(3*effect_str)
+			L.adjustToxLoss(1.5*effect_str)
 	return ..()
 
 /datum/reagent/medicine/larvaway/overdose_process(mob/living/L, metabolism)
@@ -1250,7 +1250,7 @@
 	overdose_threshold = REAGENTS_OVERDOSE * 1.2 //slight buffer to keep you safe
 
 /datum/reagent/medicine/research/medicalnanites/on_mob_add(mob/living/L, metabolism)
-	to_chat(L, span_warning("You feel like you should stay near medical help until this shot settles in."))
+	to_chat(L, span_danger("You feel like you should stay near medical help until this shot settles in."))
 
 /datum/reagent/medicine/research/medicalnanites/on_mob_life(mob/living/L, metabolism)
 	switch(current_cycle)
@@ -1265,17 +1265,57 @@
 			to_chat(L, span_warning("The pain rapidly subsides. Looks like they've adapted to you."))
 		if(152 to INFINITY)
 			if(volume < 30) //smol injection will self-replicate up to 30u using 60u of blood.
-				L.reagents.add_reagent(/datum/reagent/medicine/research/medicalnanites, 0.5)
-				L.blood_volume -= 2
+				L.reagents.add_reagent(/datum/reagent/medicine/research/medicalnanites, 0.25)
+				L.blood_volume -= 1
 				
 			if (volume >5 && L.getBruteLoss()) //Unhealed IB wasting nanites is an INTENTIONAL feature.
 				L.heal_limb_damage(2*effect_str, 0)
+				L.adjustToxLoss(0.1*effect_str)
 				holder.remove_reagent(/datum/reagent/medicine/research/medicalnanites, 1)
 				
 			if (volume > 5 && L.getFireLoss())
 				L.heal_limb_damage(0, 2*effect_str)
+				L.adjustToxLoss(0.1*effect_str)
 				holder.remove_reagent(/datum/reagent/medicine/research/medicalnanites, 1)
 	return ..()
 
 /datum/reagent/medicine/research/medicalnanites/overdose_process(mob/living/L, metabolism)
 	L.adjustToxLoss(effect_str) //softcap VS injecting massive amounts of medical nanites for the healing factor with no downsides. Still doable if you're clever about it.
+
+
+/datum/reagent/medicine/research/cryotox
+	name = "Cryotox"
+	description = "A toxin that massively lowers internal body temperature."
+	color = "#C8A5DC"
+	scannable = TRUE
+	taste_description = "freezing"
+	adj_temp = 30
+	targ_temp = 100
+
+
+/datum/reagent/medicine/research/stimulon
+	name = "Stimulon"
+	description = "A chemical designed to boost running by driving your body beyond it's normal limits. Can have unpredictable side effects, caution recommended."
+	color = "#19C832"
+	custom_metabolism = 0
+	scannable = TRUE
+
+/datum/reagent/medicine/research/stimulon/on_mob_add(mob/living/L, metabolism)
+	. = ..()
+	L.add_movespeed_modifier(type, TRUE, 0, NONE, TRUE, -1)
+
+/datum/reagent/medicine/research/stimulon/on_mob_delete(mob/living/L, metabolism)
+	L.remove_movespeed_modifier(type)
+
+/datum/reagent/medicine/research/stimulon/on_mob_life(mob/living/L, metabolism)
+	L.adjustStaminaLoss(1*effect_str)
+	L.take_limb_damage(rand(0.5*effect_str, 3*effect_str), 0)
+	L.adjustCloneLoss(rand (0, 0.05) * effect_str * current_cycle)
+	if(prob(2))
+		L.emote(pick("twitch","blink_r","shiver"))
+	if(volume < 100) //THERE IS NO "MINIMUM SAFE DOSE" MUAHAHAHA!
+		L.reagents.add_reagent(/datum/reagent/medicine/research/stimulon, 0.1)
+	return ..()
+
+
+

--- a/code/modules/reagents/reagents/other.dm
+++ b/code/modules/reagents/reagents/other.dm
@@ -35,7 +35,7 @@
 	overdose_threshold = REAGENTS_OVERDOSE * 2
 	custom_metabolism = REAGENTS_METABOLISM * 5 //1.0/tick
 	purge_list = list(/datum/reagent/toxin, /datum/reagent/medicine, /datum/reagent/consumable)
-	purge_rate = 1
+	purge_rate = 0.2
 	taste_description = "water"
 
 /datum/reagent/water/reaction_turf(turf/T, volume)

--- a/code/modules/reagents/reagents/toxin.dm
+++ b/code/modules/reagents/reagents/toxin.dm
@@ -47,7 +47,7 @@
 	name = "Unstable mutagen"
 	description = "Might cause unpredictable mutations. Keep away from children."
 	color = "#13BC5E" // rgb: 19, 188, 94
-	toxpwr = 0
+	toxpwr = 2
 	taste_description = "slime"
 	taste_multi = 0.9
 
@@ -93,10 +93,9 @@
 	description = "A highly toxic chemical."
 	color = "#CF3600" // rgb: 207, 54, 0
 	toxpwr = 3
-	custom_metabolism = REAGENTS_METABOLISM * 2
 
 /datum/reagent/toxin/cyanide/on_mob_life(mob/living/L, metabolism)
-	L.adjustOxyLoss(2*effect_str)
+	L.adjustOxyLoss(0.5 * effect_str * current_cycle)
 	if(current_cycle > 10)
 		L.Sleeping(40)
 	return ..()
@@ -189,7 +188,7 @@
 /datum/reagent/toxin/plantbgone/reaction_obj(obj/O, volume)
 	if(istype(O,/obj/effect/alien/weeds))
 		var/obj/effect/alien/A = O
-		A.take_damage(min(0.5 * volume))
+		A.take_damage(min(5 * volume))
 	else if(istype(O,/obj/effect/glowshroom)) //even a small amount is enough to kill it
 		qdel(O)
 	else if(istype(O,/obj/effect/plantsegment))
@@ -256,7 +255,6 @@
 	reagent_state = SOLID
 	color = "#000067" // rgb: 0, 0, 103
 	toxpwr = 0
-	custom_metabolism = REAGENTS_METABOLISM * 0.5
 	overdose_threshold = REAGENTS_OVERDOSE/2
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL/2
 
@@ -461,7 +459,7 @@
 			power = (2*effect_str) //While stamina loss is going, stamina regen apparently doesn't happen, so I can keep this smaller.
 			L.reagent_pain_modifier -= PAIN_REDUCTION_LIGHT
 		if(21 to 45)
-			power = (6*effect_str)
+			power = (8*effect_str)
 			L.reagent_pain_modifier -= PAIN_REDUCTION_HEAVY
 			L.jitter(4) //Shows that things are bad
 		if(46 to INFINITY)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Slight changes to some chems, addition of four new chems for researchpeeps, and a defib change.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Toxins-

Neurotoxin effects in middle stage upped from 6 staminaloss to 8. Marines appear to have no issues handling it, and it's been unchanged since disarm was deleted.

Weedkiller buffed, should reliably kill weeds now.

Cyanide buffed. Should reliably kill now, still unobtainable.

Unstable mutagen changed, now it's poisonous.

Meds-
Water purgerate lowered from 1/tick to 0.2/tick. Everyone had a water bottle and was completely invalidating ayychems at no cost with a sip or two. Now, it takes longer.

Ryetalin toxin purgerate reduced to three from 5. Was too good.

Tricord adjusted to 0.5 brute and burnheal rather than 0.8. Toxheal lowered to 0.25 from 0.5. It now has 100% the healrate dedicated meds rather than 160%.

Larvaway toxin damage lowered, was too punishing.

Defib heart damage chance changed from 25% to 100%. It's 5 heart damage, and marines are pretty strong as-is. Maybe this will make them a bit less immortal.

Antitoxin no longer purges neuro at double-speed (or atomic coffee at all). Instead, it purges at normal speed.

Researchchems-

4 Researchchems added as of now, more may show up as I think of them. All researchchems require lemoline, which is req-purchasable or made from larval jelly. Larval jelly depreciated somewhat, recipes moved to lemoline to prevent duplication. Researcher spawns with a single 10u bottle of lemoline.

Quietus-

A chemical that causes rapid, large amounts of oxyloss upon a patient entering critical condition. It causes trace stamina damage upon initial injection for 2 minutes, warns the recipient once, then becomes latent. No OD given as generally having more of this is *worse* for you.

Under normal conditions, it only has a 5% chance/tick of doing one stamina damage. Upon the patient becoming unconscious for any reason, the chemical deals 25 oxyloss/tick, which should prevent bodydragging. Note that defibrilation sets the unconscious flag for a few seconds, more-or-less requiring dex+ or hypervene to allow a revive. This may require a rework to function properly, we'll see once it gets live testing.

If it's purged out, it deals 30 toxin damage upfront, and a message letting you know what happened so you know you're back in bodydrag meta.


Somolent-

A chemical that heals rapidly, as long as the player is unconscious or sleeping. It heals 0.2 points of brute and burn per tick, multiplied by cycle counter, capped at 10 of each via cycle counter. Post-cap it shuts off, as it should already have fully healed the target. No OD as the requirement to sleep is stringent enough. The chemical does not put players to sleep, but can and should be combined with chems that do.

A 2.5u inject heals 3 damage (of both types, for all these listed stats), a 5u inject heals 11 damage, a 7.5u inject heals 24 damage (and is now outhealing other, stacked chems), and a 10u inject 42 damage. A 15u inject heals a total of 93 damage of both types while it processes, and takes 25 ticks to do this. More than that heals progressively faster.


Medical nanites- 

These are designed to allow use of blood as a secondary health bar. Upon implantation of any amount, they cause a significant amount of damage over approximately five minutes. Once they settle down and are functional, they build up to 30u at 0.5u/tick, using 2 blood/tick to do so.

Upon taking either brute or burn damage while there are more than 5u of medical nanites, they heal 2 points per tick of each, using 1u/tick of nanites, for a total heal ratio of 1 point of damage healed per two units of blood. OD is at 36u, with 1 pt/tick of toxin damage, and should not be reachable normally.

~~Cryotox-~~

~~It gradually sets a person's bodytemp to 100 degrees, allowing cryogenic treatments to work. Nothing special here.~~
~~Would have been too OP. Now it sets stasis same as a bag for 10 seconds per unit initially injected.~~
Would have been incredibly annoying for almost no benefit, chem deleted. 4 it is.

Stimulon-

Oh boy. Increases movespeed by one while in the body. No OD threshold, and does not metabolize.

Passively increases by 0.2u/tick for every tick it's present in the body. Causes a random amount between 0.5 and 3 brute damage per tick. Also, causes a random amount between 0 and 0.05 genetic damage, multiplied by the current cycle. Purged by antitox.

## Why It's Good For The Game


Things for RSR to do. More chems with niche effects. Semi-annual med rebalance. Minimizes the number of immortal marines.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds 4 new chems
balance: rebalances many chems listed in PR body, and defibs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
