### PR TITLE
Removes an extra argument from mob reagent reaction

### DIFF
--- a/code/modules/reagents/reagents.dm
+++ b/code/modules/reagents/reagents.dm
@@ -70,7 +70,7 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	return ..()
 
 /// Applies this reagent to a [/mob/living]
-/datum/reagent/proc/reaction_mob(mob/living/L, method = TOUCH, volume, metabolism, show_message = TRUE, touch_protection = 0)
+/datum/reagent/proc/reaction_mob(mob/living/L, method = TOUCH, volume, show_message = TRUE, touch_protection = 0)
 	if(!istype(L))
 		return FALSE
 	if(method == VAPOR && L.reagents) //foam, spray

--- a/code/modules/reagents/reagents/alcohol.dm
+++ b/code/modules/reagents/reagents/alcohol.dm
@@ -65,7 +65,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 		else
 			to_chat(usr, span_warning("[O]'s ink is smeared by [name], but doesn't wash away!"))
 
-/datum/reagent/consumable/ethanol/reaction_mob(mob/living/L, method = TOUCH, volume, metabolism, show_message = TRUE, touch_protection = 0)
+/datum/reagent/consumable/ethanol/reaction_mob(mob/living/L, method = TOUCH, volume, show_message = TRUE, touch_protection = 0)
 	. = ..()
 	if(method in list(TOUCH, VAPOR, PATCH))
 		L.adjust_fire_stacks(round(volume * 0.65))

--- a/code/modules/reagents/reagents/food.dm
+++ b/code/modules/reagents/reagents/food.dm
@@ -152,7 +152,7 @@
 	agony_start = 3
 	agony_amount = 4
 
-/datum/reagent/consumable/capsaicin/condensed/reaction_mob(mob/living/L, method = TOUCH, volume, metabolism, show_message = TRUE, touch_protection = 0)
+/datum/reagent/consumable/capsaicin/condensed/reaction_mob(mob/living/L, method = TOUCH, volume, show_message = TRUE, touch_protection = 0)
 	. = ..()
 	if(!(method in list(TOUCH, VAPOR)) || !ishuman(L))
 		return

--- a/code/modules/reagents/reagents/other.dm
+++ b/code/modules/reagents/reagents/other.dm
@@ -48,7 +48,7 @@
 		if(!cube.package)
 			cube.Expand()
 
-/datum/reagent/water/reaction_mob(mob/living/L, method = TOUCH, volume, metabolism, show_message = TRUE, touch_protection = 0) //Splashing people with water can help put them out!
+/datum/reagent/water/reaction_mob(mob/living/L, method = TOUCH, volume, show_message = TRUE, touch_protection = 0) //Splashing people with water can help put them out!
 	. = ..()
 	if(method in list(TOUCH, VAPOR))
 		L.adjust_fire_stacks(-(volume / 10))
@@ -432,7 +432,7 @@
 	L.adjustToxLoss(1)
 	return ..()
 
-/datum/reagent/fuel/reaction_mob(mob/living/L, method = TOUCH, volume, metabolism, show_message = TRUE, touch_protection = 0)//Splashing people with welding fuel to make them easy to ignite!
+/datum/reagent/fuel/reaction_mob(mob/living/L, method = TOUCH, volume, show_message = TRUE, touch_protection = 0)//Splashing people with welding fuel to make them easy to ignite!
 	. = ..()
 	if(method in list(TOUCH, VAPOR))
 		L.adjust_fire_stacks(volume / 10)
@@ -466,7 +466,7 @@
 			reaction_obj(C, volume)
 			qdel(C)
 
-/datum/reagent/space_cleaner/reaction_mob(mob/living/L, method = TOUCH, volume, metabolism, show_message = TRUE, touch_protection = 0)
+/datum/reagent/space_cleaner/reaction_mob(mob/living/L, method = TOUCH, volume, show_message = TRUE, touch_protection = 0)
 	. = ..()
 	if(iscarbon(L))
 		var/mob/living/carbon/C = L
@@ -637,7 +637,7 @@
 	color = "#C8A5DC" // rgb: 200, 165, 220
 
 
-/datum/reagent/sterilizine/reaction_mob(mob/living/L, method = TOUCH, volume, metabolism, show_message = TRUE, touch_protection = 0)
+/datum/reagent/sterilizine/reaction_mob(mob/living/L, method = TOUCH, volume, show_message = TRUE, touch_protection = 0)
 	if(!(method in list(TOUCH, VAPOR, PATCH)))
 		return
 	L.germ_level -= min(volume * 20 * touch_protection, L.germ_level)

--- a/code/modules/reagents/reagents/toxin.dm
+++ b/code/modules/reagents/reagents/toxin.dm
@@ -207,7 +207,7 @@
 			tray.check_level_sanity()
 			tray.update_icon()
 
-/datum/reagent/toxin/plantbgone/reaction_mob(mob/living/L, method = TOUCH, volume, metabolism, show_message = TRUE, touch_protection = 0)
+/datum/reagent/toxin/plantbgone/reaction_mob(mob/living/L, method = TOUCH, volume, show_message = TRUE, touch_protection = 0)
 	. = ..()
 	if(!ishuman(L))
 		return
@@ -356,7 +356,7 @@
 	L.take_limb_damage(0, 0.5*effect_str)
 	return ..()
 
-/datum/reagent/toxin/acid/reaction_mob(mob/living/L, method = TOUCH, volume, metabolism, show_message = TRUE, touch_protection = 0)
+/datum/reagent/toxin/acid/reaction_mob(mob/living/L, method = TOUCH, volume, show_message = TRUE, touch_protection = 0)
 	. = ..()
 	if(!(method in list(TOUCH, VAPOR, PATCH)))
 		return


### PR DESCRIPTION
## About The Pull Request
Reaction_mob has an argument named metabolize. It's not used in the declaration or in any children, and I don't know what it would do given that it's called when a reagent comes into contact with a mob. Metabolization is handled by on_mob_life, so that's not it. The only thing that calls reaction_mob is the holder's reaction proc, and it's never used it.

## Why It's Good For The Game
Cleanup.
Also fixes acid hiding the message when it melts your mask/helmet, due to incorrect argument order.

## Changelog
:cl:
fix: Acid will now tell you when it melts your helmet or mask (sulphuric/polytrinic, not xeno acid)
/:cl: