### PR TITLE
Removes Transvitox Having Fractional Strength for Some Reason

### DIFF
--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -354,7 +354,6 @@ datum/effect_system/smoke_spread/tactical
 
 /datum/effect_system/smoke_spread/xeno/transvitox
 	smoke_type = /obj/effect/particle_effect/smoke/xeno/transvitox
-	strength = 0.75
 
 /////////////////////////////////////////////
 // Chem smoke


### PR DESCRIPTION
## About The Pull Request

Transvitox no longer has fractional gas reagent transfer strength for some reason.

## Why It's Good For The Game

Transvitox's effect does not justify an arbitrary nerf to its reagent transfer strength as probably the weakest of the xeno toxins, while the others do not have compromised reagent transfer strength.

## Changelog
:cl:
fix: Transvitox no longer has fractional gas reagent transfer strength for some reason.
balance: Transvitox no longer has fractional gas reagent transfer strength for some reason.
/:cl: