### PR TITLE
Gives CAS a signal whenever a new flare/laser is cast.

### DIFF
--- a/code/modules/shuttle/cas_plane.dm
+++ b/code/modules/shuttle/cas_plane.dm
@@ -25,14 +25,22 @@
 /obj/structure/caspart/caschair/Initialize()
 	. = ..()
 	set_cockpit_overlay("cockpit_closed")
+	RegisterSignal(SSdcs, COMSIG_GLOB_CAS_LASER_CREATED, .proc/receive_laser_cas)
 
 /obj/structure/caspart/caschair/Destroy()
 	owner?.chair = null
 	owner = null
+	UnregisterSignal(SSdcs, COMSIG_GLOB_CAS_LASER_CREATED)
 	if(occupant)
 		INVOKE_ASYNC(src, .proc/eject_user, TRUE)
 	QDEL_NULL(cockpit)
 	return ..()
+
+/obj/structure/caspart/caschair/proc/receive_laser_cas(datum/source, obj/effect/overlay/temp/laser_target/cas/incoming_laser)
+	SIGNAL_HANDLER
+	if(occupant)
+		to_chat(occupant, span_notice("CAS laser detected. Target: [AREACOORD_NO_Z(incoming_laser)]"))
+		playsound(src, 'sound/effects/binoctarget.ogg', 15)
 
 ///Handles updating the cockpit overlay
 /obj/structure/caspart/caschair/proc/set_cockpit_overlay(new_state)

--- a/code/modules/shuttle/cas_plane.dm
+++ b/code/modules/shuttle/cas_plane.dm
@@ -38,9 +38,9 @@
 
 /obj/structure/caspart/caschair/proc/receive_laser_cas(datum/source, obj/effect/overlay/temp/laser_target/cas/incoming_laser)
 	SIGNAL_HANDLER
+	playsound(src, 'sound/effects/binoctarget.ogg', 15)
 	if(occupant)
 		to_chat(occupant, span_notice("CAS laser detected. Target: [AREACOORD_NO_Z(incoming_laser)]"))
-		playsound(src, 'sound/effects/binoctarget.ogg', 15)
 
 ///Handles updating the cockpit overlay
 /obj/structure/caspart/caschair/proc/set_cockpit_overlay(new_state)


### PR DESCRIPTION
## About The Pull Request
This is exactly the same thing as the AI gets, except for the CAS bird.
This is a visible message so the PO near his bird can scramble into it and doesn't have to sit in the cockpit forever.

## Why It's Good For The Game
We can finally have CAS Po's stop screaming in command about how they are not getting any flares while the ground is actually covered in them. 

## Changelog
:cl:
qol: Gave the CAS plane an alert for whenever it receives a new valid target (flare/laze)
/:cl:
