### PR TITLE
Xeno turrets have 10 bullet and laser hardarmor

### DIFF
--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -823,6 +823,7 @@ TUNNEL
 	bound_height = 32
 	obj_integrity = 600
 	max_integrity = 1500
+	hard_armor = list("melee" = 0, "bullet" = 10, "laser" = 10, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	layer =  ABOVE_MOB_LAYER
 	density = TRUE
 	resistance_flags = UNACIDABLE | DROPSHIP_IMMUNE


### PR DESCRIPTION


<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Xeno turrets now have 10 bullet and laser hardarmor.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Getting slightly annoyed by how weak ayy turrets seem to be. They're incapable of slowing a rush, because ungas just gun them down with one GPMG or LMG mag while tanking the damage or dodging or offscreening, or head in and shotgun them. 

This should make it significantly more difficult to just ungarush-shoot them, or offscreen them (due to falloff) while still allowing grenades (which take storage space) to rapidly kill them and fire to reliably, but slowly, kill them.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added new mechanics or gameplay changes
balance: Added 10 bullet and laser hardarmor VS ayy turrets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
