### PR TITLE
Rebalances Marine turrets

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1035,10 +1035,10 @@ datum/ammo/bullet/revolver/tp44
 	hud_state_empty = "smartgun_empty"
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING|AMMO_SENTRY
 	accurate_range = 10
-	damage = 30
+	damage = 25
 	penetration = 15
 	damage_falloff = 0.05
-	sundering = 1
+	sundering = 1.25
 
 /datum/ammo/bullet/turret/dumb
 	icon_state = "bullet"
@@ -1051,7 +1051,7 @@ datum/ammo/bullet/revolver/tp44
 	name = "small caliber autocannon bullet"
 	damage = 15
 	penetration = 30
-	sundering = 2
+	sundering = 1.5
 
 
 /datum/ammo/bullet/machinegun //Adding this for the MG Nests (~Art)

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1038,7 +1038,7 @@ datum/ammo/bullet/revolver/tp44
 	damage = 30
 	penetration = 20
 	damage_falloff = 0.05
-	sundering = 1
+	sundering = 0.5
 
 /datum/ammo/bullet/turret/dumb
 	icon_state = "bullet"
@@ -1051,7 +1051,7 @@ datum/ammo/bullet/revolver/tp44
 	name = "small caliber autocannon bullet"
 	damage = 22.5
 	penetration = 30
-	sundering = 0.5
+	sundering = 1
 
 
 /datum/ammo/bullet/machinegun //Adding this for the MG Nests (~Art)

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1050,7 +1050,7 @@ datum/ammo/bullet/revolver/tp44
 /datum/ammo/bullet/turret/mini
 	name = "small caliber autocannon bullet"
 	damage = 22.5
-	penetration = 30
+	penetration = 20
 	sundering = 1
 
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1035,7 +1035,7 @@ datum/ammo/bullet/revolver/tp44
 	hud_state_empty = "smartgun_empty"
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING|AMMO_SENTRY
 	accurate_range = 10
-	damage = 30
+	damage = 25
 	penetration = 20
 	damage_falloff = 0.05
 	sundering = 0.5

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1035,10 +1035,10 @@ datum/ammo/bullet/revolver/tp44
 	hud_state_empty = "smartgun_empty"
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING|AMMO_SENTRY
 	accurate_range = 10
-	damage = 25
-	penetration = 15
+	damage = 30
+	penetration = 20
 	damage_falloff = 0.05
-	sundering = 1.25
+	sundering = 1
 
 /datum/ammo/bullet/turret/dumb
 	icon_state = "bullet"
@@ -1049,9 +1049,9 @@ datum/ammo/bullet/revolver/tp44
 
 /datum/ammo/bullet/turret/mini
 	name = "small caliber autocannon bullet"
-	damage = 15
+	damage = 22.5
 	penetration = 30
-	sundering = 1.5
+	sundering = 0.5
 
 
 /datum/ammo/bullet/machinegun //Adding this for the MG Nests (~Art)

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1035,9 +1035,10 @@ datum/ammo/bullet/revolver/tp44
 	hud_state_empty = "smartgun_empty"
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING|AMMO_SENTRY
 	accurate_range = 10
-	damage = 50
-	penetration = 5
-	damage_falloff = 0.5
+	damage = 30
+	penetration = 15
+	damage_falloff = 0.05
+	sundering = 1
 
 /datum/ammo/bullet/turret/dumb
 	icon_state = "bullet"
@@ -1048,9 +1049,9 @@ datum/ammo/bullet/revolver/tp44
 
 /datum/ammo/bullet/turret/mini
 	name = "small caliber autocannon bullet"
-	damage = 25
-	penetration = 5
-	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SENTRY
+	damage = 15
+	penetration = 30
+	sundering = 2
 
 
 /datum/ammo/bullet/machinegun //Adding this for the MG Nests (~Art)

--- a/code/modules/projectiles/guns/sentries.dm
+++ b/code/modules/projectiles/guns/sentries.dm
@@ -62,9 +62,11 @@
 	desc = "A deployable, semi-automated turret with AI targeting capabilities. Armed with a M30 autocannon and a 25-round box magazine. Use Alt-Click to remove its battery."
 	icon_state = "sentry"
 
-	turret_range = 8
+	turret_range = 7
 	deploy_time = 8 SECONDS
 	max_shells = 50
+	fire_delay = 0.2 SECONDS
+	max_integrity = 400
 
 	ammo = /datum/ammo/bullet/turret
 	current_mag = /obj/item/ammo_magazine/sentry
@@ -124,11 +126,12 @@
 	ammo = /datum/ammo/bullet/turret/mini
 	current_mag = /obj/item/ammo_magazine/minisentry
 
-	fire_delay = 0.3 SECONDS
+	fire_delay = 0.15 SECONDS
 	burst_delay = 0.2 SECONDS
 	burst_amount = 3
 	extra_delay = 0.3 SECONDS
 	scatter = 2
+	max_integrity = 600
 
 	deploy_time = 3 SECONDS
 	gun_firemode_list = list(GUN_FIREMODE_AUTOMATIC, GUN_FIREMODE_AUTOBURST)

--- a/code/modules/projectiles/guns/sentries.dm
+++ b/code/modules/projectiles/guns/sentries.dm
@@ -62,7 +62,6 @@
 	desc = "A deployable, semi-automated turret with AI targeting capabilities. Armed with a M30 autocannon and a 25-round box magazine. Use Alt-Click to remove its battery."
 	icon_state = "sentry"
 
-	turret_range = 7
 	deploy_time = 8 SECONDS
 	max_shells = 50
 	fire_delay = 0.2 SECONDS

--- a/code/modules/projectiles/magazines/sentries.dm
+++ b/code/modules/projectiles/magazines/sentries.dm
@@ -1,11 +1,11 @@
 /obj/item/ammo_magazine/sentry
 	name = "\improper M30 box magazine (10x28mm Caseless)"
-	desc = "A drum of 50 10x28mm caseless rounds for the UA 571-C sentry gun. Just feed it into the sentry gun's ammo port when its ammo is depleted."
+	desc = "A drum of 250 10x28mm caseless rounds for the UA 571-C sentry gun. Just feed it into the sentry gun's ammo port when its ammo is depleted."
 	w_class = WEIGHT_CLASS_BULKY
 	icon_state = "ua571c"
 	flags_magazine = NONE //can't be refilled or emptied by hand
 	caliber = CALIBER_10X28
-	max_rounds = 75
+	max_rounds = 250
 	default_ammo = /datum/ammo/bullet/turret
 	gun_type = /obj/item/weapon/gun/sentry/big_sentry
 
@@ -16,16 +16,16 @@
 	icon_state = "ua580"
 	flags_magazine = NONE //can't be refilled or emptied by hand
 	caliber = CALIBER_10X20
-	max_rounds = 100
+	max_rounds = 300
 	default_ammo = /datum/ammo/bullet/turret/mini
 	gun_type = /obj/item/weapon/gun/sentry/mini
 
 /obj/item/ammo_magazine/sentry_premade/dumb
 	name = "M30 box magazine (10x28mm Caseless)"
-	desc = "A box of 50 10x28mm caseless rounds for the UA 571-C Sentry Gun. Just feed it into the sentry gun's ammo port when its ammo is depleted."
+	desc = "A box of 300 10x28mm caseless rounds for the UA 571-C Sentry Gun. Just feed it into the sentry gun's ammo port when its ammo is depleted."
 	w_class = WEIGHT_CLASS_BULKY
 	flags_magazine = NONE //can't be refilled or emptied by hand
 	caliber = CALIBER_10X28
-	max_rounds = 50
+	max_rounds = 300
 	default_ammo = /datum/ammo/bullet/turret/dumb
 	gun_type = /obj/item/weapon/gun/sentry/premade/dumb


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes up sentry stats, that's it.

Makes all sentries have a range of 7 because offscreen range is utterly silly for a sentry.

Reduced falloff to 0.05 for all sentries.

571 UAC- 30/20/0.5 and 250 rounds. 0.2 fire rate and 400 health
-
Mini Sentry- 22.5/30/1, 300 rounds, 0.15 fire rate and 600 health.
-
Old stats were 50/5/0 and 50 rounds/ 0.7 fire rate, higher health for UAC
25/5/0/0.3 for mini sentry.


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Sentries are in a poor state because they feel more like snipers than actual sentries, this changes them to be more of an automatic support weapon rather than a sniper rifle that you stack 5 of and instagib a xeno because it fires so damn slowly.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Sentry faloff massively reduced. 571 UAC has 250 rounds and 25/15/1.25 and 0.2 fire rate from 0.7. Mini Sentry has 15/30/1.5 and 300 rounds. Sentry health upped to 600 for mini and 400 for UAC. Old stats were 50/5/0 and 0.7 fire rate for big and 25/5/0/0.3 for mini sentry.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
