### PR TITLE
Smoke affects you when you step into it

### DIFF
--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -20,6 +20,8 @@
 	var/datum/effect_system/smoke_spread/cloud // for associated chemical smokes.
 	var/fraction = 0.2
 	var/smoke_can_spread_through = FALSE
+	///Delay in ticks before this smoke can affect a given mob again, applied in living's effect_smoke
+	var/minimum_effect_delay = 1 SECONDS
 
 	//Remove this bit to use the old smoke
 	icon = 'icons/effects/96x96.dmi'

--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -77,8 +77,9 @@
 
 /obj/effect/particle_effect/smoke/Crossed(atom/movable/O)
 	. = ..()
-	if(CHECK_BITFIELD(smoke_traits, SMOKE_CAMO) && isliving(O))
+	if(isliving(O))
 		O.effect_smoke(src)
+		return
 	if(CHECK_BITFIELD(smoke_traits, SMOKE_NERF_BEAM) && istype(O, /obj/projectile))
 		O.effect_smoke(src)
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -241,8 +241,6 @@
 		if(CHECK_BITFIELD(S.smoke_traits, SMOKE_CAMO))
 			smokecloak_off()
 		return
-	if(smoke_delay)
-		return FALSE
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO) && (stat == DEAD || isnestedhost(src)))
 		return FALSE
 	smoke_contact(S)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -245,12 +245,7 @@
 		return FALSE
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO) && (stat == DEAD || isnestedhost(src)))
 		return FALSE
-	smoke_delay = TRUE
-	addtimer(CALLBACK(src, .proc/remove_smoke_delay), 10)
 	smoke_contact(S)
-
-/mob/living/proc/remove_smoke_delay()
-	smoke_delay = FALSE
 
 /mob/living/proc/smoke_contact(obj/effect/particle_effect/smoke/S)
 	var/protection = max(1 - get_permeability_protection() * S.bio_protection, 0)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -243,6 +243,9 @@
 		return
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO) && (stat == DEAD || isnestedhost(src)))
 		return FALSE
+	if(LAZYACCESS(smoke_delays, S.type) > world.time)
+		return FALSE
+	LAZYSET(smoke_delays, S.type, world.time + S.minimum_effect_delay)
 	smoke_contact(S)
 
 /mob/living/proc/smoke_contact(obj/effect/particle_effect/smoke/S)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -97,7 +97,7 @@
 	var/reagent_pain_modifier = 0 //same as above, except can potentially mask damage
 
 	///Lazy assoc list of smoke type mapped to the next world time that smoke can affect this mob
-	var/smoke_delays
+	var/list/smoke_delays
 	var/smokecloaked = FALSE //For the new Smoke Grenade
 
 	var/no_stun = FALSE

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -96,7 +96,6 @@
 	var/reagent_shock_modifier = 0 //negative values reduce shock/pain
 	var/reagent_pain_modifier = 0 //same as above, except can potentially mask damage
 
-	var/smoke_delay = FALSE
 	var/smokecloaked = FALSE //For the new Smoke Grenade
 
 	var/no_stun = FALSE

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -96,6 +96,8 @@
 	var/reagent_shock_modifier = 0 //negative values reduce shock/pain
 	var/reagent_pain_modifier = 0 //same as above, except can potentially mask damage
 
+	///Lazy assoc list of smoke type mapped to the next world time that smoke can affect this mob
+	var/smoke_delays
 	var/smokecloaked = FALSE //For the new Smoke Grenade
 
 	var/no_stun = FALSE


### PR DESCRIPTION
## About The Pull Request
Makes smoke apply its affects when a mob crosses it, in addition to the usual 2 second process tick. Caps the frequency at a value set per smoke type but defaulting at 1 second.
Requested by Zack.
~~Chem smoke has its own internal limit of once per .4s limit per cloud.~~ Not how it works, actually.
Also fixes stacked smoke clouds not both applying effects. Apparently that was broken.

## Why It's Good For The Game
Makes just sprinting through a smoke cloud less free. ~~You still only get about 12 volume of reagents (6 each light and standard neuro) running the full length of a defiler neuro cloud with a gas mask on, but without this change it was about 1.2u.~~

## Changelog
:cl:
balance: Smoke clouds can apply their effects when you walk into one.
fix: Stacked smoke clouds will both apply their effects instead of only one.
/:cl: