### PR TITLE
Incin chems rebalance

### DIFF
--- a/code/game/objects/items/explosives/grenades/chem_grenade.dm
+++ b/code/game/objects/items/explosives/grenades/chem_grenade.dm
@@ -290,11 +290,9 @@
 	var/obj/item/reagent_containers/glass/beaker/B1 = new(src)
 	var/obj/item/reagent_containers/glass/beaker/B2 = new(src)
 
-	B1.reagents.add_reagent(/datum/reagent/aluminum, 15)
-	B1.reagents.add_reagent(/datum/reagent/fuel,20)
-	B2.reagents.add_reagent(/datum/reagent/toxin/phoron, 15)
-	B2.reagents.add_reagent(/datum/reagent/toxin/acid, 15)
-	B1.reagents.add_reagent(/datum/reagent/fuel,20)
+	B1.reagents.add_reagent(/datum/reagent/aluminum, 30)
+	B1.reagents.add_reagent(/datum/reagent/toxin/acid,30)
+	B2.reagents.add_reagent(/datum/reagent/toxin/phoron, 60)
 
 	beakers += B1
 	beakers += B2

--- a/code/modules/reagents/reactions/other.dm
+++ b/code/modules/reagents/reactions/other.dm
@@ -268,7 +268,8 @@
 
 /datum/chemical_reaction/napalm/on_reaction(datum/reagents/holder, created_volume, radius)
 	radius = round(sqrt(created_volume * 0.15)) //allows a nice, healthy 3-tile fire if using 2 120u beakers fully filled up.
-	if(radius < 0) radius = 0
+	if(radius < 0)
+		radius = 0
 		flame_radius(radius, get_turf(holder.my_atom))
 
 /datum/chemical_reaction/wpsmoke
@@ -311,6 +312,7 @@
 
 /datum/chemical_reaction/explosive/anfo/on_reaction(datum/reagents/holder, created_volume)
 	var/radius = round(sqrt(created_volume* 0.25), 1) // should be a max of 2 tiles
-	if(radius > 2) radius = 2 //enforced by a hardcap. Sorry!
+	if(radius > 2)
+		radius = 2 //enforced by a hardcap. Sorry!
 		explosion(get_turf(holder.my_atom), heavy_impact_range = radius, small_animation = TRUE)
 

--- a/code/modules/reagents/reactions/other.dm
+++ b/code/modules/reagents/reactions/other.dm
@@ -186,7 +186,7 @@
 
 /datum/chemical_reaction/razorburn
 	name = "Razorburn Gas"
-	required_reagents = list(/datum/reagent/foaming_agent = 1, /datum/reagent/toxin/nanites = 1)
+	required_reagents = list(/datum/reagent/foaming_agent = 5, /datum/reagent/toxin/nanites = 5)
 
 /datum/chemical_reaction/razorburn/on_reaction(datum/reagents/holder, created_volume)
 	var/turf/location = get_turf(holder.my_atom)

--- a/code/modules/reagents/reactions/other.dm
+++ b/code/modules/reagents/reactions/other.dm
@@ -268,7 +268,7 @@
 
 /datum/chemical_reaction/napalm/on_reaction(datum/reagents/holder, created_volume, radius)
 	radius = round(sqrt(created_volume * 0.15)) //allows a nice, healthy 3-tile fire if using 2 120u beakers fully filled up.
-		flame_radius(radius, get_turf(holder.my_atom))
+	flame_radius(radius, get_turf(holder.my_atom))
 
 /datum/chemical_reaction/wpsmoke
 	name = "White Phosphorous smoke"

--- a/code/modules/reagents/reactions/other.dm
+++ b/code/modules/reagents/reactions/other.dm
@@ -230,18 +230,6 @@
 //Explosives and pyrotechnics
 
 
-/datum/chemical_reaction/emp_pulse
-	name = "EMP Pulse"
-	required_reagents = list(/datum/reagent/uranium = 1, /datum/reagent/iron = 1) // Yes, laugh, it's the best recipe I could think of that makes a little bit of sense
-
-/datum/chemical_reaction/emp_pulse/on_reaction(datum/reagents/holder, created_volume)
-	var/location = get_turf(holder.my_atom)
-	// 100 created volume = 4 heavy range & 7 light range. A few tiles smaller than traitor EMP grandes.
-	// 200 created volume = 8 heavy range & 14 light range. 4 tiles larger than traitor EMP grenades.
-	empulse(location, round(created_volume / 24), round(created_volume / 14), 1)
-	holder.clear_reagents()
-
-
 /datum/chemical_reaction/flash_powder
 	name = "Flash powder"
 	required_reagents = list(/datum/reagent/aluminum = 1, /datum/reagent/potassium = 1, /datum/reagent/sulfur = 1)

--- a/code/modules/reagents/reactions/other.dm
+++ b/code/modules/reagents/reactions/other.dm
@@ -268,8 +268,6 @@
 
 /datum/chemical_reaction/napalm/on_reaction(datum/reagents/holder, created_volume, radius)
 	radius = round(sqrt(created_volume * 0.15)) //allows a nice, healthy 3-tile fire if using 2 120u beakers fully filled up.
-	if(radius < 0)
-		radius = 0
 		flame_radius(radius, get_turf(holder.my_atom))
 
 /datum/chemical_reaction/wpsmoke

--- a/code/modules/reagents/reactions/other.dm
+++ b/code/modules/reagents/reactions/other.dm
@@ -133,10 +133,10 @@ datum/chemical_reaction/wpsmoke
 /datum/chemical_reaction/wpsmoke/on_reaction(datum/reagents/holder, created_volume)
 	var/smoke_radius = round(sqrt(created_volume), 1)
 	var/location = get_turf(holder.my_atom)
-	var/datum/effect_system/smoke_spread/phosphorus/S = new(location)
+	var/datum/effect_system/smoke_spread/phosphorus/smoke = new
+	smoke.set_up(smoke_radius, location, 11)
+	smoke.start()
 	playsound(location, 'sound/effects/smoke.ogg', 50, 1, -3)
-	S?.set_up(holder, smoke_radius, location)
-	S?.start()
 	if(holder?.my_atom)
 		holder.clear_reagents()
 

--- a/code/modules/reagents/reactions/other.dm
+++ b/code/modules/reagents/reactions/other.dm
@@ -100,15 +100,9 @@
 
 /datum/chemical_reaction/napalm/on_reaction(datum/reagents/holder, created_volume, radius)
 	var/location = get_turf(holder.my_atom)
-	radius = round(sqrt(created_volume * 0.15)) //allows a nice, healthy fire if using 2 120u beakers fully filled up.
+	radius = round(sqrt(created_volume * 0.0375)) //allows a nice, healthy 3-tile fire if using 2 120u beakers fully filled up.
 	if(radius < 0) radius = 0
-
-	for(var/turf/T in range(radius,location))
-		if(T.density)
-			continue
-		if(istype(T,/turf/open/space))
-			continue
-		T.ignite(5 + rand(0,11))
+	flame_radius(radius, location)
 
 
 /datum/chemical_reaction/chemsmoke
@@ -131,7 +125,7 @@ datum/chemical_reaction/wpsmoke
 	required_reagents = list(/datum/reagent/phosphorus = 2, /datum/reagent/silicon = 1, /datum/reagent/oxygen = 1)
 
 /datum/chemical_reaction/wpsmoke/on_reaction(datum/reagents/holder, created_volume)
-	var/smoke_radius = round(sqrt(created_volume), 1)
+	var/smoke_radius = round(sqrt(created_volume * 0.66), 1)
 	var/location = get_turf(holder.my_atom)
 	var/datum/effect_system/smoke_spread/phosphorus/smoke = new
 	smoke.set_up(smoke_radius, location, 11)

--- a/code/modules/reagents/reactions/other.dm
+++ b/code/modules/reagents/reactions/other.dm
@@ -271,7 +271,7 @@
 	if(radius < 0) radius = 0
 		flame_radius(radius, get_turf(holder.my_atom)
 
-datum/chemical_reaction/wpsmoke
+/datum/chemical_reaction/wpsmoke
 	name = "White Phosphorous smoke"
 	required_reagents = list(/datum/reagent/phosphorus = 2, /datum/reagent/silicon = 1, /datum/reagent/chlorine = 1)
 
@@ -282,7 +282,7 @@ datum/chemical_reaction/wpsmoke
 	smoke.start()
 	playsound(location, 'sound/effects/smoke.ogg', 50, 1, -3)
 
-datum/chemical_reaction/plasmalosssmoke
+/datum/chemical_reaction/plasmalosssmoke
 	name = "Tanglefoot smoke"
 	required_reagents = list(/datum/reagent/toxin/sleeptoxin = 2, /datum/reagent/medicine/synaptizine = 1, /datum/reagent/sulfur = 1)
 
@@ -293,7 +293,7 @@ datum/chemical_reaction/plasmalosssmoke
 	smoke.start()
 	playsound(location, 'sound/effects/smoke.ogg', 50, 1, -3)
 
-datum/chemical_reaction/explosive/gunpowder
+/datum/chemical_reaction/explosive/gunpowder
 	name = "Gunpowder"
 	required_reagents = list(/datum/reagent/potassium = 1, /datum/reagent/oxygen = 3, /datum/reagent/sulfur = 1, /datum/reagent/carbon = 1)
 
@@ -305,7 +305,7 @@ datum/chemical_reaction/explosive/gunpowder
 	explosion(get_turf(holder.my_atom), light_impact_range = radius, small_animation = TRUE)
 
 
-datum/chemical_reaction/explosive/anfo
+/datum/chemical_reaction/explosive/anfo
 	name = "ANFO"
 	required_reagents = list(/datum/reagent/ammonia = 1, /datum/reagent/fuel = 3)
 

--- a/code/modules/reagents/reactions/other.dm
+++ b/code/modules/reagents/reactions/other.dm
@@ -131,8 +131,19 @@ datum/chemical_reaction/wpsmoke
 	smoke.set_up(smoke_radius, location, 11)
 	smoke.start()
 	playsound(location, 'sound/effects/smoke.ogg', 50, 1, -3)
-	if(holder?.my_atom)
-		holder.clear_reagents()
+
+
+datum/chemical_reaction/plasmalosssmoke
+	name = "Tanglefoot smoke"
+	required_reagents = list(/datum/reagent/toxin/sleeptoxin = 2, /datum/reagent/medicine/synaptizine = 1, /datum/reagent/sulfur = 1)
+
+/datum/chemical_reaction/plasmalosssmoke/on_reaction(datum/reagents/holder, created_volume)
+	var/smoke_radius = round(sqrt(created_volume), 1)
+	var/location = get_turf(holder.my_atom)
+	var/datum/effect_system/smoke_spread/plasmaloss/smoke = new
+	smoke.set_up(smoke_radius, location, 11)
+	smoke.start()
+	playsound(location, 'sound/effects/smoke.ogg', 50, 1, -3)
 
 
 /datum/chemical_reaction/chloralhydrate

--- a/code/modules/reagents/reactions/other.dm
+++ b/code/modules/reagents/reactions/other.dm
@@ -269,7 +269,7 @@
 /datum/chemical_reaction/napalm/on_reaction(datum/reagents/holder, created_volume, radius)
 	radius = round(sqrt(created_volume * 0.15)) //allows a nice, healthy 3-tile fire if using 2 120u beakers fully filled up.
 	if(radius < 0) radius = 0
-		flame_radius(radius, get_turf(holder.my_atom)
+		flame_radius(radius, get_turf(holder.my_atom))
 
 /datum/chemical_reaction/wpsmoke
 	name = "White Phosphorous smoke"

--- a/code/modules/reagents/reactions/other.dm
+++ b/code/modules/reagents/reactions/other.dm
@@ -100,7 +100,7 @@
 
 /datum/chemical_reaction/napalm/on_reaction(datum/reagents/holder, created_volume, radius)
 	var/location = get_turf(holder.my_atom)
-	radius = round(sqrt(created_volume))
+	radius = round(sqrt(created_volume * 0.3)) //allows a nice, healthy fire if using 2 120u beakers fully filled up.
 	if(radius < 0) radius = 0
 
 	for(var/turf/T in range(radius,location))

--- a/code/modules/reagents/reactions/other.dm
+++ b/code/modules/reagents/reactions/other.dm
@@ -135,8 +135,6 @@ datum/chemical_reaction/wpsmoke
 	var/location = get_turf(holder.my_atom)
 	var/datum/effect_system/smoke_spread/phosphorus/S = new(location)
 	playsound(location, 'sound/effects/smoke.ogg', 50, 1, -3)
-	smoke.set_up(smoke_radius, location, 11) //stick around longer than standard WP, cause no fire included by default.
-	smoke.start()
 	S?.set_up(holder, smoke_radius, location)
 	S?.start()
 	if(holder?.my_atom)

--- a/code/modules/reagents/reactions/other.dm
+++ b/code/modules/reagents/reactions/other.dm
@@ -110,7 +110,7 @@
 	required_reagents = list(/datum/reagent/potassium = 1, /datum/reagent/consumable/sugar = 1, /datum/reagent/phosphorus = 1)
 
 /datum/chemical_reaction/chemsmoke/on_reaction(datum/reagents/holder, created_volume)
-	var/smoke_radius = round(sqrt(created_volume * 1.5), 1)
+	var/smoke_radius = round(sqrt(created_volume * 0.8), 1)
 	var/location = get_turf(holder.my_atom)
 	var/datum/effect_system/smoke_spread/chem/S = new(location)
 	playsound(location, 'sound/effects/smoke.ogg', 50, 1, -3)

--- a/code/modules/reagents/reactions/other.dm
+++ b/code/modules/reagents/reactions/other.dm
@@ -280,7 +280,7 @@
 	var/datum/effect_system/smoke_spread/phosphorus/smoke = new
 	smoke.set_up(smoke_radius, get_turf(holder.my_atom), 11)
 	smoke.start()
-	playsound(location, 'sound/effects/smoke.ogg', 50, 1, -3)
+	playsound(get_turf(holder.my_atom), 'sound/effects/smoke.ogg', 50, 1, -3)
 
 /datum/chemical_reaction/plasmalosssmoke
 	name = "Tanglefoot smoke"
@@ -291,7 +291,7 @@
 	var/datum/effect_system/smoke_spread/plasmaloss/smoke = new
 	smoke.set_up(smoke_radius, get_turf(holder.my_atom), 11)
 	smoke.start()
-	playsound(location, 'sound/effects/smoke.ogg', 50, 1, -3)
+	playsound(get_turf(holder.my_atom), 'sound/effects/smoke.ogg', 50, 1, -3)
 
 /datum/chemical_reaction/explosive/gunpowder
 	name = "Gunpowder"

--- a/code/modules/reagents/reactions/other.dm
+++ b/code/modules/reagents/reactions/other.dm
@@ -96,13 +96,12 @@
 
 /datum/chemical_reaction/napalm
 	name = "Napalm"
-	required_reagents = list(/datum/reagent/aluminum = 1, /datum/reagent/toxin/phoron = 1, /datum/reagent/toxin/acid = 1 )
+	required_reagents = list(/datum/reagent/aluminum = 1, /datum/reagent/toxin/phoron = 2, /datum/reagent/toxin/acid = 1 )
 
 /datum/chemical_reaction/napalm/on_reaction(datum/reagents/holder, created_volume, radius)
 	var/location = get_turf(holder.my_atom)
-	radius = round(created_volume/45)
+	radius = round(sqrt(created_volume))
 	if(radius < 0) radius = 0
-	if(radius > 3) radius = 3
 
 	for(var/turf/T in range(radius,location))
 		if(T.density)
@@ -120,6 +119,21 @@
 	var/smoke_radius = round(sqrt(created_volume * 1.5), 1)
 	var/location = get_turf(holder.my_atom)
 	var/datum/effect_system/smoke_spread/chem/S = new(location)
+	playsound(location, 'sound/effects/smoke.ogg', 50, 1, -3)
+	S?.set_up(holder, smoke_radius, location)
+	S?.start()
+	if(holder?.my_atom)
+		holder.clear_reagents()
+
+
+datum/chemical_reaction/wpsmoke
+	name = "White Phosphorous smoke"
+	required_reagents = list(/datum/reagent/phosphorus = 2, /datum/reagent/silicon = 1, /datum/reagent/oxygen = 1)
+
+/datum/chemical_reaction/wpsmoke/on_reaction(datum/reagents/holder, created_volume)
+	var/smoke_radius = round(sqrt(created_volume), 1)
+	var/location = get_turf(holder.my_atom)
+	var/datum/effect_system/smoke_spread/phosphorus/S = new(location)
 	playsound(location, 'sound/effects/smoke.ogg', 50, 1, -3)
 	S?.set_up(holder, smoke_radius, location)
 	S?.start()

--- a/code/modules/reagents/reactions/other.dm
+++ b/code/modules/reagents/reactions/other.dm
@@ -100,7 +100,7 @@
 
 /datum/chemical_reaction/napalm/on_reaction(datum/reagents/holder, created_volume, radius)
 	var/location = get_turf(holder.my_atom)
-	radius = round(sqrt(created_volume * 0.3)) //allows a nice, healthy fire if using 2 120u beakers fully filled up.
+	radius = round(sqrt(created_volume * 0.15)) //allows a nice, healthy fire if using 2 120u beakers fully filled up.
 	if(radius < 0) radius = 0
 
 	for(var/turf/T in range(radius,location))

--- a/code/modules/reagents/reactions/other.dm
+++ b/code/modules/reagents/reactions/other.dm
@@ -267,10 +267,9 @@
 	required_reagents = list(/datum/reagent/aluminum = 1, /datum/reagent/toxin/phoron = 2, /datum/reagent/toxin/acid = 1 )
 
 /datum/chemical_reaction/napalm/on_reaction(datum/reagents/holder, created_volume, radius)
-	var/location = get_turf(holder.my_atom)
 	radius = round(sqrt(created_volume * 0.15)) //allows a nice, healthy 3-tile fire if using 2 120u beakers fully filled up.
 	if(radius < 0) radius = 0
-	flame_radius(radius, location)
+		flame_radius(radius, get_turf(holder.my_atom)
 
 datum/chemical_reaction/wpsmoke
 	name = "White Phosphorous smoke"
@@ -278,9 +277,8 @@ datum/chemical_reaction/wpsmoke
 
 /datum/chemical_reaction/wpsmoke/on_reaction(datum/reagents/holder, created_volume)
 	var/smoke_radius = round(sqrt(created_volume * 0.66), 1)
-	var/location = get_turf(holder.my_atom)
 	var/datum/effect_system/smoke_spread/phosphorus/smoke = new
-	smoke.set_up(smoke_radius, location, 11)
+	smoke.set_up(smoke_radius, get_turf(holder.my_atom), 11)
 	smoke.start()
 	playsound(location, 'sound/effects/smoke.ogg', 50, 1, -3)
 
@@ -290,9 +288,8 @@ datum/chemical_reaction/plasmalosssmoke
 
 /datum/chemical_reaction/plasmalosssmoke/on_reaction(datum/reagents/holder, created_volume)
 	var/smoke_radius = round(sqrt(created_volume), 1)
-	var/location = get_turf(holder.my_atom)
 	var/datum/effect_system/smoke_spread/plasmaloss/smoke = new
-	smoke.set_up(smoke_radius, location, 11)
+	smoke.set_up(smoke_radius, get_turf(holder.my_atom), 11)
 	smoke.start()
 	playsound(location, 'sound/effects/smoke.ogg', 50, 1, -3)
 
@@ -302,11 +299,10 @@ datum/chemical_reaction/explosive/gunpowder
 
 /datum/chemical_reaction/explosive/gunpowder/on_reaction(datum/reagents/holder, created_volume)
 	var/radius = round(sqrt(created_volume* 0.5), 1) // should be about equal to the M15, maybe one tile more
-	var/location = get_turf(holder.my_atom)
 	var/datum/effect_system/smoke_spread/bad/smoke = new
-	smoke.set_up((radius - 1), location, 2)
+	smoke.set_up((radius - 1), get_turf(holder.my_atom), 2)
 	smoke.start()
-	explosion(location, light_impact_range = radius, small_animation = TRUE)
+	explosion(get_turf(holder.my_atom), light_impact_range = radius, small_animation = TRUE)
 
 
 datum/chemical_reaction/explosive/anfo
@@ -315,7 +311,6 @@ datum/chemical_reaction/explosive/anfo
 
 /datum/chemical_reaction/explosive/anfo/on_reaction(datum/reagents/holder, created_volume)
 	var/radius = round(sqrt(created_volume* 0.25), 1) // should be a max of 2 tiles
-	var/location = get_turf(holder.my_atom)
 	if(radius > 2) radius = 2 //enforced by a hardcap. Sorry!
-	explosion(location, heavy_impact_range = radius, small_animation = TRUE)
+		explosion(get_turf(holder.my_atom), heavy_impact_range = radius, small_animation = TRUE)
 

--- a/code/modules/reagents/reactions/other.dm
+++ b/code/modules/reagents/reactions/other.dm
@@ -100,7 +100,7 @@
 
 /datum/chemical_reaction/napalm/on_reaction(datum/reagents/holder, created_volume, radius)
 	var/location = get_turf(holder.my_atom)
-	radius = round(sqrt(created_volume * 0.0375)) //allows a nice, healthy 3-tile fire if using 2 120u beakers fully filled up.
+	var/radius = round(sqrt(created_volume * 0.0375)) //allows a nice, healthy 3-tile fire if using 2 120u beakers fully filled up.
 	if(radius < 0) radius = 0
 	flame_radius(radius, location)
 

--- a/code/modules/reagents/reactions/other.dm
+++ b/code/modules/reagents/reactions/other.dm
@@ -100,7 +100,7 @@
 
 /datum/chemical_reaction/napalm/on_reaction(datum/reagents/holder, created_volume, radius)
 	var/location = get_turf(holder.my_atom)
-	var/radius = round(sqrt(created_volume * 0.0375)) //allows a nice, healthy 3-tile fire if using 2 120u beakers fully filled up.
+	radius = round(sqrt(created_volume * 0.15)) //allows a nice, healthy 3-tile fire if using 2 120u beakers fully filled up.
 	if(radius < 0) radius = 0
 	flame_radius(radius, location)
 

--- a/code/modules/reagents/reactions/other.dm
+++ b/code/modules/reagents/reactions/other.dm
@@ -1,14 +1,3 @@
-/datum/chemical_reaction/emp_pulse
-	name = "EMP Pulse"
-	required_reagents = list(/datum/reagent/uranium = 1, /datum/reagent/iron = 1) // Yes, laugh, it's the best recipe I could think of that makes a little bit of sense
-
-/datum/chemical_reaction/emp_pulse/on_reaction(datum/reagents/holder, created_volume)
-	var/location = get_turf(holder.my_atom)
-	// 100 created volume = 4 heavy range & 7 light range. A few tiles smaller than traitor EMP grandes.
-	// 200 created volume = 8 heavy range & 14 light range. 4 tiles larger than traitor EMP grenades.
-	empulse(location, round(created_volume / 24), round(created_volume / 14), 1)
-	holder.clear_reagents()
-
 /datum/chemical_reaction/serotrotium
 	name = "Serotrotium"
 	results = list(/datum/reagent/serotrotium = 1) //Weird emotes, chance of minor drowsiness.
@@ -74,37 +63,6 @@
 	results = list(/datum/reagent/glycerol = 1)
 	required_reagents = list(/datum/reagent/consumable/cornoil = 3, /datum/reagent/toxin/acid = 1)
 
-/datum/chemical_reaction/flash_powder
-	name = "Flash powder"
-	required_reagents = list(/datum/reagent/aluminum = 1, /datum/reagent/potassium = 1, /datum/reagent/sulfur = 1)
-
-/datum/chemical_reaction/flash_powder/on_reaction(datum/reagents/holder, created_volume)
-	var/location = get_turf(holder.my_atom)
-	var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
-	s.set_up(2, 1, location)
-	s.start()
-	for(var/mob/living/carbon/M in viewers(WORLD_VIEW, location))
-		switch(get_dist(M, location))
-			if(0 to 3)
-				if(M.flash_act())
-					M.Paralyze(30 SECONDS)
-
-			if(4 to 5)
-				if(M.flash_act())
-					M.Stun(10 SECONDS)
-
-
-/datum/chemical_reaction/napalm
-	name = "Napalm"
-	required_reagents = list(/datum/reagent/aluminum = 1, /datum/reagent/toxin/phoron = 2, /datum/reagent/toxin/acid = 1 )
-
-/datum/chemical_reaction/napalm/on_reaction(datum/reagents/holder, created_volume, radius)
-	var/location = get_turf(holder.my_atom)
-	radius = round(sqrt(created_volume * 0.15)) //allows a nice, healthy 3-tile fire if using 2 120u beakers fully filled up.
-	if(radius < 0) radius = 0
-	flame_radius(radius, location)
-
-
 /datum/chemical_reaction/chemsmoke
 	name = "Chemsmoke"
 	required_reagents = list(/datum/reagent/potassium = 1, /datum/reagent/consumable/sugar = 1, /datum/reagent/phosphorus = 1)
@@ -118,33 +76,6 @@
 	S?.start()
 	if(holder?.my_atom)
 		holder.clear_reagents()
-
-
-datum/chemical_reaction/wpsmoke
-	name = "White Phosphorous smoke"
-	required_reagents = list(/datum/reagent/phosphorus = 2, /datum/reagent/silicon = 1, /datum/reagent/oxygen = 1)
-
-/datum/chemical_reaction/wpsmoke/on_reaction(datum/reagents/holder, created_volume)
-	var/smoke_radius = round(sqrt(created_volume * 0.66), 1)
-	var/location = get_turf(holder.my_atom)
-	var/datum/effect_system/smoke_spread/phosphorus/smoke = new
-	smoke.set_up(smoke_radius, location, 11)
-	smoke.start()
-	playsound(location, 'sound/effects/smoke.ogg', 50, 1, -3)
-
-
-datum/chemical_reaction/plasmalosssmoke
-	name = "Tanglefoot smoke"
-	required_reagents = list(/datum/reagent/toxin/sleeptoxin = 2, /datum/reagent/medicine/synaptizine = 1, /datum/reagent/sulfur = 1)
-
-/datum/chemical_reaction/plasmalosssmoke/on_reaction(datum/reagents/holder, created_volume)
-	var/smoke_radius = round(sqrt(created_volume), 1)
-	var/location = get_turf(holder.my_atom)
-	var/datum/effect_system/smoke_spread/plasmaloss/smoke = new
-	smoke.set_up(smoke_radius, location, 11)
-	smoke.start()
-	playsound(location, 'sound/effects/smoke.ogg', 50, 1, -3)
-
 
 /datum/chemical_reaction/chloralhydrate
 	name = "Chloral Hydrate"
@@ -294,3 +225,111 @@ datum/chemical_reaction/plasmalosssmoke
 	name = "laughter"
 	results = list(/datum/reagent/consumable/laughter = 5)
 	required_reagents = list(/datum/reagent/consumable/sugar = 1, /datum/reagent/consumable/drink/banana = 1)
+	
+	
+//Explosives and pyrotechnics
+
+
+/datum/chemical_reaction/emp_pulse
+	name = "EMP Pulse"
+	required_reagents = list(/datum/reagent/uranium = 1, /datum/reagent/iron = 1) // Yes, laugh, it's the best recipe I could think of that makes a little bit of sense
+
+/datum/chemical_reaction/emp_pulse/on_reaction(datum/reagents/holder, created_volume)
+	var/location = get_turf(holder.my_atom)
+	// 100 created volume = 4 heavy range & 7 light range. A few tiles smaller than traitor EMP grandes.
+	// 200 created volume = 8 heavy range & 14 light range. 4 tiles larger than traitor EMP grenades.
+	empulse(location, round(created_volume / 24), round(created_volume / 14), 1)
+	holder.clear_reagents()
+
+
+/datum/chemical_reaction/flash_powder
+	name = "Flash powder"
+	required_reagents = list(/datum/reagent/aluminum = 1, /datum/reagent/potassium = 1, /datum/reagent/sulfur = 1)
+
+/datum/chemical_reaction/flash_powder/on_reaction(datum/reagents/holder, created_volume)
+	var/location = get_turf(holder.my_atom)
+	var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
+	s.set_up(2, 1, location)
+	s.start()
+	for(var/mob/living/carbon/M in viewers(WORLD_VIEW, location))
+		switch(get_dist(M, location))
+			if(0 to 3)
+				if(M.flash_act())
+					M.Paralyze(30 SECONDS)
+
+			if(4 to 5)
+				if(M.flash_act())
+					M.Stun(10 SECONDS)
+
+
+/datum/chemical_reaction/napalm
+	name = "Napalm"
+	required_reagents = list(/datum/reagent/aluminum = 1, /datum/reagent/toxin/phoron = 2, /datum/reagent/toxin/acid = 1 )
+
+/datum/chemical_reaction/napalm/on_reaction(datum/reagents/holder, created_volume, radius)
+	var/location = get_turf(holder.my_atom)
+	radius = round(sqrt(created_volume * 0.15)) //allows a nice, healthy 3-tile fire if using 2 120u beakers fully filled up.
+	if(radius < 0) radius = 0
+	flame_radius(radius, location)
+
+datum/chemical_reaction/wpsmoke
+	name = "White Phosphorous smoke"
+	required_reagents = list(/datum/reagent/phosphorus = 2, /datum/reagent/silicon = 1, /datum/reagent/oxygen = 1)
+
+/datum/chemical_reaction/wpsmoke/on_reaction(datum/reagents/holder, created_volume)
+	var/smoke_radius = round(sqrt(created_volume * 0.66), 1)
+	var/location = get_turf(holder.my_atom)
+	var/datum/effect_system/smoke_spread/phosphorus/smoke = new
+	smoke.set_up(smoke_radius, location, 11)
+	smoke.start()
+	playsound(location, 'sound/effects/smoke.ogg', 50, 1, -3)
+
+datum/chemical_reaction/plasmalosssmoke
+	name = "Tanglefoot smoke"
+	required_reagents = list(/datum/reagent/toxin/sleeptoxin = 2, /datum/reagent/medicine/synaptizine = 1, /datum/reagent/sulfur = 1)
+
+/datum/chemical_reaction/plasmalosssmoke/on_reaction(datum/reagents/holder, created_volume)
+	var/smoke_radius = round(sqrt(created_volume), 1)
+	var/location = get_turf(holder.my_atom)
+	var/datum/effect_system/smoke_spread/plasmaloss/smoke = new
+	smoke.set_up(smoke_radius, location, 11)
+	smoke.start()
+	playsound(location, 'sound/effects/smoke.ogg', 50, 1, -3)
+
+datum/chemical_reaction/wpsmoke
+	name = "White Phosphorous smoke"
+	required_reagents = list(/datum/reagent/phosphorus = 2, /datum/reagent/silicon = 1, /datum/reagent/oxygen = 1)
+
+/datum/chemical_reaction/wpsmoke/on_reaction(datum/reagents/holder, created_volume)
+	var/smoke_radius = round(sqrt(created_volume * 0.66), 1)
+	var/location = get_turf(holder.my_atom)
+	var/datum/effect_system/smoke_spread/phosphorus/smoke = new
+	smoke.set_up(smoke_radius, location, 11)
+	smoke.start()
+	playsound(location, 'sound/effects/smoke.ogg', 50, 1, -3)
+
+
+datum/chemical_reaction/explosive/gunpowder
+	name = "Gunpowder"
+	required_reagents = list(/datum/reagent/potassium = 1, /datum/reagent/oxygen = 3, /datum/reagent/sulfur = 1, /datum/reagent/carbon = 1)
+
+/datum/chemical_reaction/explosive/gunpowder/on_reaction(datum/reagents/holder, created_volume)
+	var/radius = round(sqrt(created_volume* 0.5), 1) // should be a max of 1 more tile than the M15
+	var/location = get_turf(holder.my_atom)
+	var/datum/effect_system/smoke_spread/bad/smoke = new
+	smoke.set_up((radius - 1), location, 2)
+	smoke.start()
+	explosion(location, light_impact_range = radius, small_animation = TRUE)
+
+
+datum/chemical_reaction/explosive/anfo
+	name = "ANFO"
+	required_reagents = list(/datum/reagent/ammonia = 1, /datum/reagent/fuel = 3)
+
+/datum/chemical_reaction/explosive/anfo/on_reaction(datum/reagents/holder, created_volume)
+	var/radius = round(sqrt(created_volume* 0.25), 1) // should be a max of 2 tiles
+	var/location = get_turf(holder.my_atom)
+	if(radius > 2) radius = 2 //enforced by a hardcap. Sorry!
+	explosion(location, heavy_impact_range = radius, small_animation = TRUE)
+
+

--- a/code/modules/reagents/reactions/other.dm
+++ b/code/modules/reagents/reactions/other.dm
@@ -135,6 +135,8 @@ datum/chemical_reaction/wpsmoke
 	var/location = get_turf(holder.my_atom)
 	var/datum/effect_system/smoke_spread/phosphorus/S = new(location)
 	playsound(location, 'sound/effects/smoke.ogg', 50, 1, -3)
+	smoke.set_up(smoke_radius, location, 11) //stick around longer than standard WP, cause no fire included by default.
+	smoke.start()
 	S?.set_up(holder, smoke_radius, location)
 	S?.start()
 	if(holder?.my_atom)

--- a/code/modules/reagents/reactions/other.dm
+++ b/code/modules/reagents/reactions/other.dm
@@ -274,7 +274,7 @@
 
 datum/chemical_reaction/wpsmoke
 	name = "White Phosphorous smoke"
-	required_reagents = list(/datum/reagent/phosphorus = 2, /datum/reagent/silicon = 1, /datum/reagent/oxygen = 1)
+	required_reagents = list(/datum/reagent/phosphorus = 2, /datum/reagent/silicon = 1, /datum/reagent/chlorine = 1)
 
 /datum/chemical_reaction/wpsmoke/on_reaction(datum/reagents/holder, created_volume)
 	var/smoke_radius = round(sqrt(created_volume * 0.66), 1)
@@ -296,25 +296,12 @@ datum/chemical_reaction/plasmalosssmoke
 	smoke.start()
 	playsound(location, 'sound/effects/smoke.ogg', 50, 1, -3)
 
-datum/chemical_reaction/wpsmoke
-	name = "White Phosphorous smoke"
-	required_reagents = list(/datum/reagent/phosphorus = 2, /datum/reagent/silicon = 1, /datum/reagent/oxygen = 1)
-
-/datum/chemical_reaction/wpsmoke/on_reaction(datum/reagents/holder, created_volume)
-	var/smoke_radius = round(sqrt(created_volume * 0.66), 1)
-	var/location = get_turf(holder.my_atom)
-	var/datum/effect_system/smoke_spread/phosphorus/smoke = new
-	smoke.set_up(smoke_radius, location, 11)
-	smoke.start()
-	playsound(location, 'sound/effects/smoke.ogg', 50, 1, -3)
-
-
 datum/chemical_reaction/explosive/gunpowder
 	name = "Gunpowder"
 	required_reagents = list(/datum/reagent/potassium = 1, /datum/reagent/oxygen = 3, /datum/reagent/sulfur = 1, /datum/reagent/carbon = 1)
 
 /datum/chemical_reaction/explosive/gunpowder/on_reaction(datum/reagents/holder, created_volume)
-	var/radius = round(sqrt(created_volume* 0.5), 1) // should be a max of 1 more tile than the M15
+	var/radius = round(sqrt(created_volume* 0.5), 1) // should be about equal to the M15, maybe one tile more
 	var/location = get_turf(holder.my_atom)
 	var/datum/effect_system/smoke_spread/bad/smoke = new
 	smoke.set_up((radius - 1), location, 2)
@@ -331,5 +318,4 @@ datum/chemical_reaction/explosive/anfo
 	var/location = get_turf(holder.my_atom)
 	if(radius > 2) radius = 2 //enforced by a hardcap. Sorry!
 	explosion(location, heavy_impact_range = radius, small_animation = TRUE)
-
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Chemical fire now functions properly. WP smoke can now be made chemically. Might look at explosives... but I think that's well-covered by ungas already.

Pre-assembled chem grenades now have a 2-tile radius, same as magic grenades.
Large beaker chem grenades can be made with up to a three-tile radius, one larger than magic fire grenades and one smaller than magic WP grenades.

WP smoke can be made via chemical reaction. A large beaker grenade is about as large as a WP grenade, but has no fire.

Nerfs fuel-air smoke. Radius was too large. It's still big but not "two screens" big.

Adds gunpowder. Chem on par with normal grenades, can be made slightly larger than a M15, but leaves a brief cloud of smoke upon detonation.

Adds ANFO. Chem with heavy explosion, limited to two tiles max, smaller than a normal grenade.

Napalm, WP, gunpowder, and ANFO can be mixed and matched as desired, and will function independently in the same grenade, so you can have explosive fire, mini-WP, a shaped-charge with more damage at the center, or just throw a cloud of WP onto all your normal grenades. Experiment!

Fuel-air mix does *not* mix with other chems, light it with another action. I could fix this, but I'd need to make a snowflake chem and it wouldn't fix actual fuel-air mix so I left it as is. Still very strong VS open terrain.

## Why It's Good For The Game

Chemical fire's been broken for way too long, and it's dumb that the incin grenade spawns one tile of fire. More chemical content and things for people to do better.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: adds chemical WP gas, gunpowder, and ANFO
balance: lowers maximum radius of chemsmoke to around WP-radius. Also raises minimum amount of reactable razorburn to 5/5, from 1/1. 
fix: fixes napalm and napalm grenades
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
