### PR TITLE
Nerfs T-21 sunder

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -502,7 +502,7 @@ datum/ammo/bullet/revolver/tp44
 	hud_state = "hivelo"
 	damage = 30
 	penetration = 10
-	sundering = 1.5
+	sundering = 1
 
 /datum/ammo/bullet/rifle/incendiary
 	name = "incendiary rifle bullet"


### PR DESCRIPTION
## About The Pull Request

Nerfs SR/T-21 from 1.5 sunder to 1 sunder. This still puts it at double T-12 sunder and a respectable 4 sunder/s, but not it's previously kind of overtuned 6 sunder/s. It retains it's high DPS but just loses some sunder to make it not so good at everything.

## Why It's Good For The Game

T-21 is a tad overtuned right now, I think the biggest offender without gutting the gun is sunder. This seeks to address that.

## Changelog
:cl:
balance: T-21 has it's sunder reduced from 1.5 to 1
/:cl:
