### PR TITLE
Some T-25 changes

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -922,7 +922,7 @@
 	item_state = "t25"
 	caliber = CALIBER_10x26_CASELESS //codex
 	max_shells = 80 //codex
-	force = 35
+	force = 25
 	aim_slowdown = 0.7
 	wield_delay = 0.9 SECONDS
 	fire_sound = "gun_smartgun"


### PR DESCRIPTION
## About The Pull Request

Nerfs T-25 melee force and sunder but gives it back the 5 pen it lost for some DPS. 60 melee force with bayonet is insane. This honestly still puts the T-25 at a very respectable melee force considering it can also mount bayonet to go up to 50. But rivalling swords is silly. 

Also slightly decreases T-25 sunder to make it so it doesn't have _basically_ the same sunder per second as the T-29. This puts it at 6.25 sunder/s compared to the T-29's 8/s. T-25 still retains better mobility and handling, higher DPS, and a much wider array of attachment options. 

Gives the T-25 back the 5 pen it lost as well to solidify it as more of a killer than the T-29 but not an absolute menace like it used to be. This 5 pen is basically just an increase of 5 DPS. It's not that insane, but it makes the gap between them in terms of DPS in actual practice a bit wider. All together this is in no way some kind of partial revert of the recent T-25 changes, more so just some fine tuning to make the differences between the T-29 and 25 more apparent and carve out their own two niches a bit more. 

## Why It's Good For The Game

60 melee force with bayonet shouldn't be a thing on like any gun, let alone a smartgun, for some reason. This has gone un-nerfed for way too long. T-25 shouldn't really have the same sunder/s as the T-29 but should have a noticeably higher DPS, this remedies that. 

## Changelog
:cl:
balance: T-25 has 10 less base melee force
balance: T-25 has slightly less sunder but gains back 5 penetration
/:cl: