### PR TITLE
Allows T29 SG to mount a miniscope

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -897,6 +897,7 @@
 		/obj/item/attachable/t42barrel,
 		/obj/item/attachable/bipod,
 		/obj/item/attachable/magnetic_harness,
+		/obj/item/attachable/scope/mini,
 		/obj/item/attachable/motiondetector,
 	)
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Lets the T29 Smartmachinegun mount a miniscope
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The game had gradually strengthened the use of aim mode by the changes to Red Dot Sight (+firerate on aim mode) and Gyroscopic Stabilizer (+move speed). Added to the T25's ability to mount a miniscope in addition to the miniscope pr that allows its usage on the move, it left the T29 as a less competitive choice to the T25 smartrifle.

The miniscope should balance itself out by competing with the painfully obvious magharn choice that the SG currently has, which necessitates either losing your gun on knockdown and having it acided, or using a belt slot for the harness locking out the G8 for ammo or something like a lifesaver belt.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: T-29 Smartmachinegun can now mount miniscope
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
