### PR TITLE
Revert "Powerfist Now Applies a Stun Scaling With Power Level (#8003)"

### DIFF
--- a/code/game/objects/items/weapons/misc.dm
+++ b/code/game/objects/items/weapons/misc.dm
@@ -108,8 +108,6 @@
 	var/atom/throw_target = get_edge_target_turf(M, get_dir(src, get_step_away(M, src)))
 	var/throw_distance = setting * LERP(5 , 2, M.mob_size / MOB_SIZE_BIG)
 	M.throw_at(throw_target, throw_distance, 0.5 + (setting / 2))
-	M.apply_effects(setting, STUN)
-	M.apply_effects(0.1 * setting, WEAKEN)
 	cell.charge -= powerused
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request

Title. This is insane. Just watched it stun lock a Rav to death. Very funny. Contrary to what was said in the PR description this is _not_ barely noticeable or a 0.5 second stun on Xenos, it is insane. 

## Why It's Good For The Game

This is really broken and unfun

## Changelog
:cl:
balance: Powerfist no longer stuns
/:cl:
