### PR TITLE
Revert "Powerfist Now Applies a Stun Scaling With Power Level"

### DIFF
--- a/code/game/objects/items/weapons/misc.dm
+++ b/code/game/objects/items/weapons/misc.dm
@@ -108,8 +108,6 @@
 	var/atom/throw_target = get_edge_target_turf(M, get_dir(src, get_step_away(M, src)))
 	var/throw_distance = setting * LERP(5 , 2, M.mob_size / MOB_SIZE_BIG)
 	M.throw_at(throw_target, throw_distance, 0.5 + (setting / 2))
-	M.apply_effects(setting, STUN)
-	M.apply_effects(0.1 * setting, WEAKEN)
 	cell.charge -= powerused
 	return ..()
 


### PR DESCRIPTION
## About the Pull Request
Reverts tgstation/TerraGov-Marine-Corps#8003.

## Why It's Good For the Game
Powerfists stunlock. This is nowhere near healthy for game balance and severely impacts xenos.
No.

## Changelog
:cl: Lewdcifer
balance: Reverts Powerfist Stun.
/:cl: