### PR TITLE
Bull Stuff

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
@@ -9,7 +9,7 @@
 	wound_type = "bull" //used to match appropriate wound overlays
 
 	// *** Melee Attacks *** //
-	melee_damage = 19
+	melee_damage = 20
 
 	// *** Speed *** //
 	speed = -0.7
@@ -19,7 +19,7 @@
 	plasma_gain = 10
 
 	// *** Health *** //
-	max_health = 250
+	max_health = 275
 
 	// *** Evolution *** //
 	evolution_threshold = 180
@@ -32,7 +32,7 @@
 	caste_flags = CASTE_CAN_BE_QUEEN_HEALED|CASTE_EVOLUTION_ALLOWED|CASTE_CAN_BE_GIVEN_PLASMA|CASTE_CAN_BE_LEADER|CAN_BECOME_KING
 
 	// *** Defense *** //
-	soft_armor = list("melee" = 25, "bullet" = 35, "laser" = 25, "energy" = 25, "bomb" = XENO_BOMB_RESIST_0, "bio" = 25, "rad" = 25, "fire" = 35, "acid" = 25)
+	soft_armor = list("melee" = 30, "bullet" = 35, "laser" = 30, "energy" = 25, "bomb" = XENO_BOMB_RESIST_0, "bio" = 25, "rad" = 25, "fire" = 35, "acid" = 25)
 
 	actions = list(
 		/datum/action/xeno_action/xeno_resting,
@@ -64,13 +64,13 @@
 	plasma_gain = 13
 
 	// *** Health *** //
-	max_health = 275
+	max_health = 300
 
 	// *** Evolution *** //
 	upgrade_threshold = 360
 
 	// *** Defense *** //
-	soft_armor = list("melee" = 30, "bullet" = 40, "laser" = 30, "energy" = 30, "bomb" = XENO_BOMB_RESIST_0, "bio" = 28, "rad" = 28, "fire" = 40, "acid" = 28)
+	soft_armor = list("melee" = 35, "bullet" = 40, "laser" = 35, "energy" = 30, "bomb" = XENO_BOMB_RESIST_0, "bio" = 28, "rad" = 28, "fire" = 40, "acid" = 28)
 
 /datum/xeno_caste/bull/elder
 	upgrade_name = "Elder"
@@ -79,7 +79,7 @@
 	upgrade = XENO_UPGRADE_TWO
 
 	// *** Melee Attacks *** //
-	melee_damage = 21
+	melee_damage = 23
 
 	// *** Speed *** //
 	speed = -0.7
@@ -89,13 +89,13 @@
 	plasma_gain = 16
 
 	// *** Health *** //
-	max_health = 300
+	max_health = 325
 
 	// *** Evolution *** //
 	upgrade_threshold = 840
 
 	// *** Defense *** //
-	soft_armor = list("melee" = 35, "bullet" = 45, "laser" = 35, "energy" = 35, "bomb" = XENO_BOMB_RESIST_0, "bio" = 30, "rad" = 30, "fire" = 45, "acid" = 30)
+	soft_armor = list("melee" = 40, "bullet" = 45, "laser" = 40, "energy" = 35, "bomb" = XENO_BOMB_RESIST_0, "bio" = 30, "rad" = 30, "fire" = 45, "acid" = 30)
 
 /datum/xeno_caste/bull/ancient
 	upgrade_name = "Ancient"
@@ -104,7 +104,7 @@
 	upgrade = XENO_UPGRADE_THREE
 
 	// *** Melee Attacks *** //
-	melee_damage = 21
+	melee_damage = 23
 
 	// *** Speed *** //
 	speed = -0.8
@@ -114,10 +114,10 @@
 	plasma_gain = 18
 
 	// *** Health *** //
-	max_health = 325
+	max_health = 350
 
 	// *** Evolution *** //
 	upgrade_threshold = 1320
 
 	// *** Defense *** //
-	soft_armor = list("melee" = 40, "bullet" = 50, "laser" = 40, "energy" = 40, "bomb" = XENO_BOMB_RESIST_0, "bio" = 33, "rad" = 33, "fire" = 50, "acid" = 33)
+	soft_armor = list("melee" = 45, "bullet" = 50, "laser" = 45, "energy" = 40, "bomb" = XENO_BOMB_RESIST_0, "bio" = 33, "rad" = 33, "fire" = 50, "acid" = 33)

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -523,7 +523,7 @@
 		if(CHARGE_CRUSH)
 			Paralyze(CHARGE_SPEED(charge_datum) * 20)
 		if(CHARGE_BULL_HEADBUTT)
-			Paralyze(CHARGE_SPEED(charge_datum) * 60)
+			Paralyze(CHARGE_SPEED(charge_datum) * 40)
 
 	if(anchored)
 		charge_datum.do_stop_momentum(FALSE)


### PR DESCRIPTION
## About The Pull Request

Big thing is that this nerfs Bull headbutt stun down from 6s to 4s, putting it roughly on par with Forward Charge on Defender. Packaged with this is some minor buffs. Bull gets melee damage and health at Ancient on par with Warrior, but the health curve is not as good as Warrior for the earlier maturities. Bull also gets +5 melee and laser resist, bullet resist and anything else is untouched. 

Overall this should pan out to not really be a nerf or a buff for Bull, it should be at about the same level power wise as before. But depending on who you ask that is either "alright" or "dog shit", so. 

## Why It's Good For The Game

A six second stun is crazy unfun and frankly, _bullshit._ After having played with it a lot it is really funny but not balanced or fair and should not exist. However just nerfing the stun means Bull becomes even more meme tier. 

The survivability buffs put it closer to Warrior in terms of survivability but Warrior has a better health curve, better armor, and Agility is an amazing escape. Bull currently can feel like mega paper due to it's stats and survivability _especially_ against lasers. The melee buff is two fold, it is partially a QoL buff. Bull, unlike Crusher, cannot fuck with terrain, walls, objects, etc. while charging, which results in having to break tables and other things by hand to make a lane. 20 damage is the breakpoint and the difference between, for example, three hits to break a table and two. The 1 damage difference has almost no impact in combat but will help Bull's early game be less click intensive and CBT. The 2 damage difference at Elder+ is an alright little buff, the biggest impact it will have is that you lose out on less damage if you solo headbutt charge someone compared to before and Gore will become a bit more useful due to hitting a tad harder. 

## Changelog
:cl:
balance: Bull has +25 health at all maturity levels, +5 laser and melee armor, and +1 melee damage at Young/Mature and +2 melee damage at Elder/Ancient
balance: Bull headbutt charge now stuns for 4 seconds instead of 6 seconds.
/:cl:

