### PR TITLE
Fix some pronouns not using the pronoun helper

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -313,7 +313,7 @@
 			if((!user.hand && affecting.body_part == ARM_RIGHT) || (user.hand && affecting.body_part == ARM_LEFT))
 				to_chat(user, span_warning("You can't apply a splint to the arm you're using!"))
 				return
-			user.visible_message(span_warning("[user] starts to apply [src] to their [limb]."),
+			user.visible_message(span_warning("[user] starts to apply [src] to [user.p_their()] [limb]."),
 			span_notice("You start to apply [src] to your [limb], hold still."))
 
 		if(affecting.apply_splints(src, user == M ? (applied_splint_health*max(user.skills.getRating("medical") - 1, 0)) : applied_splint_health*user.skills.getRating("medical"), user, M)) // Referenced in external organ helpers.

--- a/code/game/objects/items/tools/flame_tools.dm
+++ b/code/game/objects/items/tools/flame_tools.dm
@@ -186,65 +186,65 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	else if(istype(W, /obj/item/tool/lighter/zippo))
 		var/obj/item/tool/lighter/zippo/Z = W
 		if(Z.heat)
-			light(span_rose("With a flick of their wrist, [user] lights their [name] with [W]."))
+			light(span_rose("With a flick of [user.p_their()] wrist, [user] lights their [name] with [W]."))
 
 	else if(istype(W, /obj/item/flashlight/flare))
 		var/obj/item/flashlight/flare/FL = W
 		if(FL.heat)
-			light(span_notice("[user] lights their [name] with [W]."))
+			light(span_notice("[user] lights [user.p_their()] [name] with [W]."))
 
 	else if(istype(W, /obj/item/explosive/grenade/flare))
 		var/obj/item/explosive/grenade/flare/FL2 = W
 		if(FL2.heat)
-			light(span_notice("[user] lights their [name] with [W]."))
+			light(span_notice("[user] lights [user.p_their()] [name] with [W]."))
 
 	else if(istype(W, /obj/item/tool/lighter))
 		var/obj/item/tool/lighter/L = W
 		if(L.heat)
-			light(span_notice("[user] manages to light their [name] with [W]."))
+			light(span_notice("[user] manages to light [user.p_their()] [name] with [W]."))
 
 	else if(istype(W, /obj/item/tool/match))
 		var/obj/item/tool/match/M = W
 		if(M.heat)
-			light(span_notice("[user] lights their [name] with their [W]."))
+			light(span_notice("[user] lights [user.p_their()] [name] with their [W]."))
 
 	else if(istype(W, /obj/item/weapon/energy/sword))
 		var/obj/item/weapon/energy/sword/S = W
 		if(S.active)
-			light(span_warning("[user] swings their [W], barely missing their nose. They light their [name] in the process."))
+			light(span_warning("[user] swings [user.p_their()] [W], barely missing [user.p_their()] nose. [user.p_they()] light [user.p_their()] [name] in the process."))
 
 	else if(istype(W, /obj/item/assembly/igniter))
-		light(span_notice("[user] fiddles with [W], and manages to light their [name]."))
+		light(span_notice("[user] fiddles with [W], and manages to light [user.p_their()] [name]."))
 
 	else if(istype(W, /obj/item/attachable/attached_gun/flamer))
-		light(span_notice("[user] lights their [src] with the [W]."))
+		light(span_notice("[user] lights [user.p_their()] [src] with the [W]."))
 
 	else if(istype(W, /obj/item/weapon/gun/flamer))
-		light(span_notice("[user] lights their [src] with the pilot light of the [W]."))
+		light(span_notice("[user] lights [user.p_their()] [src] with the pilot light of the [W]."))
 
 	else if(istype(W, /obj/item/weapon/gun))
 		var/obj/item/weapon/gun/G = W
 		if(istype(G, /obj/item/weapon/gun/energy/lasgun))
 			var/obj/item/weapon/gun/energy/lasgun/L = G
 			if(L.cell.charge)
-				light(span_notice("[user] deftly lights their [src] with the [L]'s low power setting."))
+				light(span_notice("[user] deftly lights [user.p_their()] [src] with the [L]'s low power setting."))
 			else
 				to_chat(user, span_warning("You try to light your [src] with the [L] but your power cell has no charge!"))
 		else if(istype(LAZYACCESS(G.attachments, ATTACHMENT_SLOT_UNDER), /obj/item/attachable/attached_gun/flamer))
-			light(span_notice("[user] lights their [src] with the underbarrel [LAZYACCESS(G.attachments, ATTACHMENT_SLOT_UNDER)]."))
+			light(span_notice("[user] lights [user.p_their()] [src] with the underbarrel [LAZYACCESS(G.attachments, ATTACHMENT_SLOT_UNDER)]."))
 
 
 	else if(istype(W, /obj/item/tool/surgery/cautery))
-		light(span_notice("[user] lights their [src] with the [W]."))
+		light(span_notice("[user] lights [user.p_their()] [src] with the [W]."))
 
 	else if(istype(W, /obj/item/clothing/mask/cigarette))
 		var/obj/item/clothing/mask/cigarette/C = W
 		if(C.lit)
-			light(span_notice("[user] lights their [src] with the [C] after a few attempts."))
+			light(span_notice("[user] lights [user.p_their()] [src] with the [C] after a few attempts."))
 
 	else if(istype(W, /obj/item/tool/candle))
 		if(W.heat > 200)
-			light(span_notice("[user] lights their [src] with the [W] after a few attempts."))
+			light(span_notice("[user] lights [user.p_their()] [src] with the [W] after a few attempts."))
 
 	else
 		return ..()
@@ -344,22 +344,22 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		if(isturf(target))
 			var/turf/T = target
 			if(locate(/obj/flamer_fire) in T.contents)
-				light(span_notice("[user] lights their [src] with the burning ground."))
+				light(span_notice("[user] lights [user.p_their()] [src] with the burning ground."))
 				return
 
 		if(isliving(target) && user.a_intent == INTENT_HELP)
 			var/mob/living/M = target
 			if(M.on_fire)
 				if(user == M)
-					light(span_notice("[user] lights their [src] from their own burning body, that's crazy!"))
+					light(span_notice("[user] lights [user.p_their()] [src] from their own burning body, that's crazy!"))
 				else
-					light(span_notice("[user] lights their [src] from the burning body of [M], that's stone cold."))
+					light(span_notice("[user] lights [user.p_their()] [src] from the burning body of [M], that's stone cold."))
 				return
 
 		if(istype(target, /obj/machinery/light))
 			var/obj/machinery/light/fixture = target
 			if(fixture.is_broken())
-				light(span_notice("[user] lights their [src] from the broken light."))
+				light(span_notice("[user] lights [user.p_their()] [src] from the broken light."))
 				return
 	return ..()
 
@@ -563,7 +563,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 						user.apply_damage(2,BURN,"l_hand")
 					else
 						user.apply_damage(2,BURN,"r_hand")
-					user.visible_message(span_notice("After a few attempts, [user] manages to light the [src], they however burn their finger in the process."))
+					user.visible_message(span_notice("After a few attempts, [user] manages to light the [src],  however [user.p_they()] burn [user.p_their()] finger in the process."))
 				playsound(loc, 'sound/items/lighter_on.ogg', 15, 1)
 			set_light_on(TRUE)
 		else

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -82,7 +82,7 @@
 /obj/item/assembly/mousetrap/on_found(mob/finder)
 	if(armed)
 		if(finder)
-			finder.visible_message(span_warning("[finder] accidentally sets off [src], breaking their fingers."), \
+			finder.visible_message(span_warning("[finder] accidentally sets off [src], breaking [finder.p_their()] fingers."), \
 								span_warning("You accidentally trigger [src]!"))
 			triggered(finder, pick(BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_PRECISE_L_HAND))
 			return TRUE	//end the search!

--- a/code/modules/clothing/under/ties.dm
+++ b/code/modules/clothing/under/ties.dm
@@ -70,11 +70,6 @@
 		if(user.a_intent == INTENT_HELP)
 			var/body_part = parse_zone(user.zone_selected)
 			if(body_part)
-				var/their = "their"
-				switch(M.gender)
-					if(MALE)	their = "his"
-					if(FEMALE)	their = "her"
-
 				var/sound = "pulse"
 				var/sound_strength
 
@@ -94,7 +89,7 @@
 						else
 							sound_strength = "hear a weak"
 
-				user.visible_message("[user] places [src] against [M]'s [body_part] and listens attentively.", "You place [src] against [their] [body_part]. You [sound_strength] [sound].")
+				user.visible_message("[user] places [src] against [M]'s [body_part] and listens attentively.", "You place [src] against [M.p_their()] [body_part]. You [sound_strength] [sound].")
 				return
 	return ..(M,user)
 
@@ -515,7 +510,7 @@
 		to_chat(user, "Waving around a badge before swiping an ID would be pretty pointless.")
 		return
 	if(isliving(user))
-		user.visible_message(span_warning(" [user] displays their TGMC Internal Security Legal Authorization Badge.\nIt reads: [stored_name], TGMC Security."),span_warning(" You display your TGMC Internal Security Legal Authorization Badge.\nIt reads: [stored_name], TGMC Security."))
+		user.visible_message(span_warning(" [user] displays [user.p_their()] TGMC Internal Security Legal Authorization Badge.\nIt reads: [stored_name], TGMC Security."),span_warning(" You display your TGMC Internal Security Legal Authorization Badge.\nIt reads: [stored_name], TGMC Security."))
 
 /obj/item/clothing/tie/holobadge/attackby(obj/item/I, mob/user, params)
 	. = ..()
@@ -535,7 +530,7 @@
 
 /obj/item/clothing/tie/holobadge/attack(mob/living/carbon/human/M, mob/living/user)
 	if(isliving(user))
-		user.visible_message(span_warning(" [user] invades [M]'s personal space, thrusting [src] into their face insistently."),span_warning(" You invade [M]'s personal space, thrusting [src] into their face insistently. You are the law."))
+		user.visible_message(span_warning(" [user] invades [M]'s personal space, thrusting [src] into [M.p_their()] face insistently."),span_warning(" You invade [M]'s personal space, thrusting [src] into [M.p_their()] face insistently. You are the law."))
 
 /obj/item/storage/box/holobadge
 	name = "holobadge box"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Seems these were forgotten

## Changelog
:cl:
fix: Some messages will now use pronouns correctly instead of their/they
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
