### PR TITLE
machete/officer sword have bump and +15 more force

### DIFF
--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -214,7 +214,7 @@
 	name = "\improper M2132 machete"
 	desc = "Latest issue of the TGMC Machete. Great for clearing out jungle or brush on outlying colonies. Found commonly in the hands of scouts and trackers, but difficult to carry with the usual kit."
 	icon_state = "machete"
-	force = 70
+	force = 75
 	attack_speed = 12
 	w_class = WEIGHT_CLASS_BULKY
 
@@ -233,7 +233,7 @@
 	desc = "This appears to be a rather old blade that has been well taken care of, it is probably a family heirloom. Oddly despite its probable non-combat purpose it is sharpened and not blunt."
 	icon_state = "officer_sword"
 	item_state = "officer_sword"
-	force = 70
+	force = 75
 	attack_speed = 12
 	w_class = WEIGHT_CLASS_BULKY
 

--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -214,9 +214,17 @@
 	name = "\improper M2132 machete"
 	desc = "Latest issue of the TGMC Machete. Great for clearing out jungle or brush on outlying colonies. Found commonly in the hands of scouts and trackers, but difficult to carry with the usual kit."
 	icon_state = "machete"
-	force = 60
+	force = 70
 	attack_speed = 12
 	w_class = WEIGHT_CLASS_BULKY
+
+/obj/item/weapon/claymore/mercsword/machete/equipped(mob/user, slot)
+	. = ..()
+	toggle_item_bump_attack(user, TRUE)
+
+/obj/item/weapon/claymore/mercsword/machete/dropped(mob/user)
+	. = ..()
+	toggle_item_bump_attack(user, FALSE)
 
 //FC's sword.
 
@@ -225,9 +233,17 @@
 	desc = "This appears to be a rather old blade that has been well taken care of, it is probably a family heirloom. Oddly despite its probable non-combat purpose it is sharpened and not blunt."
 	icon_state = "officer_sword"
 	item_state = "officer_sword"
-	force = 60
+	force = 70
 	attack_speed = 12
 	w_class = WEIGHT_CLASS_BULKY
+
+/obj/item/weapon/claymore/mercsword/machete/equipped(mob/user, slot)
+	. = ..()
+	toggle_item_bump_attack(user, TRUE)
+
+/obj/item/weapon/claymore/mercsword/machete/dropped(mob/user)
+	. = ..()
+	toggle_item_bump_attack(user, FALSE)
 
 /obj/item/weapon/claymore/mercsword/commissar_sword
 	name = "\improper commissars sword"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Machete and Officer sword get 15 more force for 75, and bump attacks.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes machete more viable and gives it an edge over vali usage, considering it has NO utility in the game rn considering you can 2 shot weeds with a bayoneted gun and not sacrifice anything, and vali has bump attacks already. I don't see the point of not just letting this happen.
Makes the machete into an option you can pick over the spear, which doesn't have bump (though I might give it bump) for +1 reach and more damage if you wield it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: machete/officer sword have bump attacks and deal 15 more damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
