### PR TITLE
Big-red version 2.2

### DIFF
--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -3272,6 +3272,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
+/obj/effect/ai_node,
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "amk" = (
@@ -3296,6 +3297,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/ai_node,
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "amn" = (
@@ -3335,6 +3337,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "ams" = (
@@ -3703,6 +3706,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "anC" = (
@@ -4074,6 +4078,7 @@
 /area/bigredv2/outside/marshal_office)
 "aoY" = (
 /obj/machinery/light,
+/obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/bigredv2/outside/marshal_office)
 "apa" = (
@@ -5472,6 +5477,7 @@
 "atM" = (
 /obj/structure/cable,
 /obj/structure/window/reinforced,
+/obj/effect/ai_node,
 /turf/open/floor/tile/dark/purple2,
 /area/bigredv2/caves/lambda_lab)
 "atN" = (
@@ -5937,6 +5943,7 @@
 "avp" = (
 /obj/machinery/light,
 /obj/effect/landmark/nuke_spawn,
+/obj/effect/ai_node,
 /turf/open/floor/tile/dark/purple2/corner{
 	dir = 4
 	},
@@ -8162,6 +8169,10 @@
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/tile/blue/whitebluefull,
 /area/bigredv2/outside/medical)
+"aDH" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/dirttosand,
+/area/bigredv2/outside/nw)
 "aDI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/tool/extinguisher,
@@ -9387,6 +9398,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
+/obj/effect/ai_node,
 /turf/open/floor/marking/asteroidwarning{
 	dir = 4
 	},
@@ -9612,6 +9624,7 @@
 /obj/machinery/door/window{
 	dir = 8
 	},
+/obj/effect/ai_node,
 /turf/open/floor/tile/darkgreen/darkgreen2{
 	dir = 9
 	},
@@ -10018,6 +10031,7 @@
 	},
 /area/bigredv2/caves/lambda_lab)
 "aKh" = (
+/obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 6
 	},
@@ -11687,6 +11701,13 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/yellow/full,
 /area/bigredv2/outside/general_store)
+"aSW" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/southeast)
 "aTc" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/floor/marking/asteroidwarning,
@@ -11848,6 +11869,7 @@
 /area/bigredv2/caves/lambda_lab)
 "aTH" = (
 /obj/structure/cable,
+/obj/effect/ai_node,
 /turf/open/floor/tile/darkgreen/darkgreen2/corner{
 	dir = 4
 	},
@@ -12278,6 +12300,7 @@
 	},
 /area/bigredv2/caves/lambda_lab)
 "aVy" = (
+/obj/effect/ai_node,
 /turf/open/floor/tile/darkgreen/darkgreen2{
 	dir = 10
 	},
@@ -13771,6 +13794,7 @@
 /turf/open/floor/asteroidfloor,
 /area/shuttle/drop2/lz2)
 "bew" = (
+/obj/effect/ai_node,
 /turf/open/floor/marking/asteroidwarning{
 	dir = 8
 	},
@@ -14935,6 +14959,10 @@
 	dir = 10
 	},
 /area/bigredv2/outside/c)
+"bjF" = (
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/bigredv2/outside/marshal_office)
 "bjG" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -15939,6 +15967,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/weapon/twohanded/fireaxe,
+/obj/effect/ai_node,
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
 "bow" = (
@@ -15957,6 +15986,7 @@
 /area/bigredv2/outside/filtration_plant)
 "boz" = (
 /obj/effect/decal/cleanable/blood/drip,
+/obj/effect/ai_node,
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/s)
 "boA" = (
@@ -16538,6 +16568,7 @@
 "brm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/tool/weldpack,
+/obj/effect/ai_node,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
 "brn" = (
@@ -18865,6 +18896,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip,
+/obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "bDo" = (
@@ -18892,6 +18924,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/ai_node,
 /turf/open/floor/tile/dark/red2/corner{
 	dir = 8
 	},
@@ -19219,6 +19252,7 @@
 	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "bEK" = (
@@ -19276,10 +19310,22 @@
 "bHv" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/space)
+"bHx" = (
+/obj/effect/ai_node,
+/turf/open/floor/wood,
+/area/bigredv2/caves/lambda_lab)
 "bKc" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/bigredv2/outside/cargo)
+"bKj" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/marking/asteroidwarning,
+/area/bigredv2/outside/nw)
 "bLl" = (
 /obj/structure/table,
 /obj/effect/spawner/random/toolbox,
@@ -19345,6 +19391,13 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/ne)
+"bTI" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/darkish,
+/area/bigredv2/outside/chapel)
 "bXE" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
@@ -19417,10 +19470,27 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/southeast)
+"cko" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/southeast)
 "ckJ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/se)
+"clR" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/outside/c)
+"cnH" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 8
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/chapel{
+	dir = 4
+	},
+/area/bigredv2/outside/chapel)
 "coa" = (
 /obj/structure/rack,
 /obj/item/weapon/gun/shotgun/pump/cmb,
@@ -19434,6 +19504,11 @@
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/south)
+"cpX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/turf/open/floor/tile/red/redtaupecorner,
+/area/bigredv2/outside/marshal_office)
 "csO" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -19447,6 +19522,11 @@
 "ctE" = (
 /turf/open/shuttle/escapepod/five,
 /area/bigredv2/caves/north)
+"cuI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/bigredv2/outside/dorms)
 "cuW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -19464,6 +19544,15 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/south)
+"cvO" = (
+/obj/effect/ai_node,
+/turf/open/floor/marking/asteroidwarning,
+/area/bigredv2/outside/nw)
+"cwo" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/southwest)
 "cxx" = (
 /obj/structure/cable,
 /obj/machinery/computer/communications/bee,
@@ -19488,6 +19577,11 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/northwest)
+"cAY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/bigredv2/outside/marshal_office)
 "cBo" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/filingcabinet,
@@ -19512,6 +19606,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark2,
 /area/bigredv2/caves/southeast)
+"cEA" = (
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/bigredv2/outside/engineering)
 "cFp" = (
 /obj/effect/spawner/gibspawner/human,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -19545,6 +19643,10 @@
 /obj/machinery/computer/communications,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/southeast)
+"cME" = (
+/obj/effect/ai_node,
+/turf/open/floor/asteroidfloor,
+/area/shuttle/drop2/lz2)
 "cMZ" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -19556,6 +19658,10 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/northwest)
+"cRV" = (
+/obj/effect/ai_node,
+/turf/open/floor/bcircuit/anim,
+/area/bigredv2/caves/lambda_lab)
 "cSm" = (
 /obj/structure/cable,
 /turf/open/floor/marking/asteroidwarning,
@@ -19569,6 +19675,10 @@
 /obj/docking_port/stationary/crashmode,
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/se)
+"cTS" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/bigredv2/outside/nw)
 "cUL" = (
 /obj/machinery/light{
 	dir = 1
@@ -19599,6 +19709,11 @@
 /obj/structure/cable,
 /turf/open/floor/prison/darkred/full,
 /area/bigredv2/caves/southeast)
+"cZc" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/west)
 "cZm" = (
 /obj/structure/cable,
 /turf/open/space/basic,
@@ -19608,6 +19723,13 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/east)
+"daR" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/southeast)
 "dbi" = (
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 8
@@ -19650,6 +19772,10 @@
 /obj/effect/landmark/corpsespawner,
 /turf/open/floor/prison/darkred/full,
 /area/bigredv2/caves/southeast)
+"diA" = (
+/obj/effect/ai_node,
+/turf/open/floor/freezer,
+/area/bigredv2/outside/general_offices)
 "djh" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/asteroidfloor,
@@ -19685,6 +19811,10 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/darkred/full,
 /area/bigredv2/caves/southeast)
+"dlI" = (
+/obj/effect/ai_node,
+/turf/open/floor/asteroidfloor,
+/area/bigredv2/outside/c)
 "dmd" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /turf/open/floor,
@@ -19692,6 +19822,11 @@
 "dnl" = (
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/northeast)
+"dnG" = (
+/obj/item/stack/sheet/metal,
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/bigredv2/outside/engineering)
 "dqo" = (
 /obj/structure/cable,
 /turf/open/floor/tile/darkish,
@@ -19699,6 +19834,10 @@
 "dry" = (
 /turf/open/floor/tile/dark/red2/corner,
 /area/bigredv2/caves/south)
+"drW" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/bigredv2/outside/se)
 "dtj" = (
 /obj/structure/toilet{
 	dir = 8
@@ -19711,10 +19850,19 @@
 	},
 /turf/open/floor/freezer,
 /area/mint)
+"dwa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/bigredv2/outside/marshal_office)
 "dwi" = (
 /obj/effect/landmark/corpsespawner/security,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/general_offices)
+"dyL" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/white,
+/area/bigredv2/outside/virology)
 "dyQ" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/cobweb2,
@@ -19767,6 +19915,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/southeast)
+"dFM" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 8
+	},
+/area/bigredv2/caves/lambda_lab)
 "dFO" = (
 /obj/machinery/power/geothermal{
 	name = "Theta G-11 geothermal generator"
@@ -19895,6 +20049,11 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor,
 /area/mint)
+"eaY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/bigredv2/outside/engineering)
 "edO" = (
 /turf/open/floor/carpet,
 /area/bigredv2/outside/bar)
@@ -19925,6 +20084,10 @@
 /obj/item/storage/belt/gun/pistol/m4a3/officer,
 /turf/open/floor/tile/dark/yellow2/corner,
 /area/bigredv2/caves/south)
+"ehP" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/bigredv2/outside/virology)
 "ekm" = (
 /obj/structure/cable,
 /turf/open/floor,
@@ -19964,6 +20127,10 @@
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/southeast)
+"epl" = (
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/mint)
 "eqy" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/wall,
@@ -19971,6 +20138,10 @@
 "erQ" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/bigredv2/caves/lambda_lab)
+"euD" = (
+/obj/effect/ai_node,
+/turf/open/floor/asteroidfloor,
+/area/bigredv2/outside/space_port)
 "euF" = (
 /obj/effect/spawner/gibspawner/human,
 /turf/open/floor/tile/dark,
@@ -20004,6 +20175,14 @@
 "eyz" = (
 /turf/closed/wall/r_wall,
 /area/bigredv2/caves/south)
+"eyM" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/south)
+"ezq" = (
+/obj/effect/ai_node,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/southeast)
 "eCa" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -20120,6 +20299,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/southeast)
+"eRH" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/northeast)
 "eRJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/marking/asteroidwarning{
@@ -20153,6 +20336,16 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/southeast)
+"eXJ" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 10
+	},
+/area/bigredv2/outside/e)
+"eXY" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/bigredv2/outside/nanotrasen_lab/inside)
 "eZl" = (
 /obj/machinery/atmospherics/pipe/manifold/green{
 	dir = 1
@@ -20186,6 +20379,7 @@
 	dir = 1;
 	on = 1
 	},
+/obj/effect/ai_node,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
 "ffS" = (
@@ -20233,6 +20427,10 @@
 	},
 /turf/open/shuttle/escapepod,
 /area/bigredv2/caves/southeast)
+"fpg" = (
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/bigredv2/outside/dorms)
 "fph" = (
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -20266,6 +20464,11 @@
 /obj/effect/landmark/corpsespawner/security,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/southeast)
+"fvC" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/east)
 "fwD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -20292,6 +20495,12 @@
 "fyA" = (
 /turf/closed/wall/r_wall,
 /area/mint)
+"fAw" = (
+/obj/effect/ai_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 4
+	},
+/area/bigredv2/outside/virology)
 "fAx" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -20303,6 +20512,10 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/southeast)
+"fBi" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/outside/se)
 "fBE" = (
 /obj/machinery/computer/rdservercontrol,
 /turf/open/shuttle/escapepod,
@@ -20325,6 +20538,11 @@
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/south)
+"fFc" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/green/whitegreenfull,
+/area/bigredv2/caves/lambda_lab)
 "fGX" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 2
@@ -20344,6 +20562,10 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating,
 /area/bigredv2/caves/north)
+"fHF" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/bigredv2/outside/virology)
 "fIi" = (
 /obj/machinery/door/airlock,
 /obj/structure/cable,
@@ -20355,6 +20577,10 @@
 	dir = 5
 	},
 /area/bigredv2/outside/c)
+"fJe" = (
+/obj/effect/ai_node,
+/turf/closed/wall/r_wall,
+/area/bigredv2/outside/marshal_office)
 "fJR" = (
 /obj/item/clothing/head/warning_cone,
 /turf/open/floor/asteroidfloor,
@@ -20453,6 +20679,10 @@
 "gdw" = (
 /turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/caves/west)
+"gdB" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/cave/rock,
+/area/bigredv2/caves/north)
 "gel" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -20496,6 +20726,15 @@
 /obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"gip" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/bigredv2/outside/nanotrasen_lab/inside)
+"giE" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/shuttle/drop1/lz1)
 "giI" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -20511,6 +20750,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/space_port)
+"gkD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/bigredv2/outside/cargo)
 "glf" = (
 /obj/structure/largecrate/supply/explosives/mines,
 /turf/open/floor/tile/dark,
@@ -20621,10 +20865,24 @@
 	dir = 1
 	},
 /area/bigredv2/outside/space_port)
+"gFu" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/mint)
+"gFR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/bigredv2/outside/space_port)
 "gKf" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/w)
+"gKy" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/northwest)
 "gLt" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -20683,6 +20941,10 @@
 /obj/machinery/atmospherics/pipe/manifold/green,
 /turf/open/floor/prison/darkred/full,
 /area/bigredv2/caves/southeast)
+"gVv" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/darkish,
+/area/bigredv2/outside/marshal_office)
 "gVH" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/lightred/full,
@@ -20706,6 +20968,10 @@
 /obj/effect/landmark/weed_node,
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/northeast)
+"gZB" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/outside/w)
 "gZX" = (
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 1
@@ -20724,6 +20990,10 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/ne)
+"hdP" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/outside/nw)
 "hdW" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -20757,6 +21027,10 @@
 	dir = 1
 	},
 /area/bigredv2/caves/southeast)
+"hgY" = (
+/obj/effect/ai_node,
+/turf/open/shuttle/escapepod/five,
+/area/bigredv2/caves/lambda_lab)
 "hhh" = (
 /obj/structure/cable,
 /turf/open/floor/asteroidfloor,
@@ -20805,12 +21079,24 @@
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
 /area/bigredv2/caves/southeast)
+"hqO" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
+	},
+/area/bigredv2/outside/virology)
 "hqP" = (
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/south)
 "hsK" = (
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/cargo)
+"hsT" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/turf/open/floor/tile/white,
+/area/bigredv2/outside/medical)
 "huj" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/marking/asteroidwarning{
@@ -20890,6 +21176,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/north)
+"hDx" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/bigredv2/outside/se)
 "hDY" = (
 /turf/open/floor/tile/dark/red2/corner{
 	dir = 8
@@ -20918,6 +21208,10 @@
 	},
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/space_port)
+"hJA" = (
+/obj/effect/ai_node,
+/turf/open/floor/mainship/sterile/dark,
+/area/bigredv2/caves/southeast)
 "hJM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/corpsespawner/colonist,
@@ -20937,6 +21231,10 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/northeast)
+"hLW" = (
+/obj/effect/ai_node,
+/turf/open/floor/elevatorshaft,
+/area/bigredv2/caves/lambda_lab)
 "hMv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	on = 1
@@ -21048,11 +21346,25 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/darkred/full,
 /area/bigredv2/caves/southeast)
+"ioN" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/red/redtaupecorner,
+/area/bigredv2/outside/marshal_office)
+"ipm" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/lambda_lab)
 "ipY" = (
 /obj/machinery/power/monitor,
 /obj/structure/cable,
 /obj/structure/table/mainship,
 /turf/open/floor/tile/dark,
+/area/bigredv2/caves/southeast)
+"irg" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/ai_node,
+/turf/open/floor/mainship/sterile/dark,
 /area/bigredv2/caves/southeast)
 "iyl" = (
 /obj/structure/cable,
@@ -21110,6 +21422,11 @@
 /obj/structure/largecrate/supply/weapons/hpr,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/southeast)
+"iKc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/bigredv2/outside/nanotrasen_lab/inside)
 "iKB" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/bigredv2/outside/space_port)
@@ -21117,6 +21434,11 @@
 /obj/structure/largecrate/machine,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/southeast)
+"iLr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/turf/open/floor/tile/white,
+/area/bigredv2/outside/marshal_office)
 "iMZ" = (
 /obj/effect/landmark/corpsespawner/engineer,
 /turf/open/floor/tile/red/redtaupecorner,
@@ -21139,6 +21461,17 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"iOS" = (
+/obj/effect/ai_node,
+/turf/open/ground/jungle/clear,
+/area/bigredv2/outside/nanotrasen_lab/inside)
+"iPN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 1
+	},
+/area/bigredv2/outside/medical)
 "iUZ" = (
 /obj/machinery/light{
 	dir = 1
@@ -21192,6 +21525,14 @@
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/east)
+"jgd" = (
+/obj/effect/decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/southeast)
 "jil" = (
 /turf/open/floor/plating/warning{
 	dir = 4
@@ -21205,6 +21546,19 @@
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/southeast)
+"jmv" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/warning{
+	dir = 10
+	},
+/area/bigredv2/caves/lambda_lab)
+"jng" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 8
+	},
+/area/bigredv2/outside/c)
 "joM" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 4
@@ -21287,6 +21641,10 @@
 	},
 /turf/open/shuttle/escapepod,
 /area/bigredv2/caves/northeast)
+"jFM" = (
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/bigredv2/outside/cargo)
 "jGP" = (
 /obj/structure/largecrate/supply/weapons/sentries,
 /turf/open/floor/tile/dark,
@@ -21421,12 +21779,25 @@
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/mainship/sterile/dark,
 /area/bigredv2/caves/southeast)
+"kdj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/bigredv2/outside/nanotrasen_lab/inside)
 "keE" = (
 /obj/structure/cable,
 /turf/open/floor/tile/dark/red2{
 	dir = 10
 	},
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"kgy" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/mint)
+"kgG" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/bigredv2/caves/northeast)
 "kgL" = (
 /turf/closed/wall,
 /area/mint)
@@ -21452,6 +21823,10 @@
 	},
 /turf/open/floor/prison/darkred/full,
 /area/bigredv2/caves/southeast)
+"kkd" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/bigredv2/outside/nw)
 "klu" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -21459,6 +21834,13 @@
 "knF" = (
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/outside/engineering)
+"kou" = (
+/obj/item/target,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark/red2{
+	dir = 1
+	},
+/area/bigredv2/outside/nanotrasen_lab/inside)
 "kpd" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
@@ -21508,6 +21890,13 @@
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor,
 /area/bigredv2/outside/general_store)
+"kCm" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/ai_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 8
+	},
+/area/bigredv2/outside/s)
 "kCz" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/random/dirt,
@@ -21558,6 +21947,12 @@
 /obj/effect/landmark/corpsespawner/security,
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/virology)
+"kNG" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/north)
 "kNX" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -21584,6 +21979,14 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"kQY" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/green/whitegreen,
+/area/bigredv2/outside/medical)
+"kRa" = (
+/obj/effect/ai_node,
+/turf/open/floor/asteroidfloor,
+/area/bigredv2/outside/e)
 "kRt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
@@ -21601,6 +22004,17 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/shuttle/escapepod,
 /area/bigredv2/caves/southeast)
+"kZk" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/outside/s)
+"lak" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark/yellow2/corner{
+	dir = 8
+	},
+/area/bigredv2/outside/nanotrasen_lab/inside)
 "ldk" = (
 /obj/structure/cable,
 /turf/open/shuttle/escapepod,
@@ -21656,6 +22070,10 @@
 /obj/machinery/door/airlock/multi_tile/mainship/generic,
 /turf/open/shuttle/escapepod,
 /area/bigredv2/caves/southeast)
+"lmm" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/white,
+/area/bigredv2/outside/marshal_office)
 "lmC" = (
 /obj/machinery/light,
 /obj/structure/cargo_container/green{
@@ -21739,6 +22157,10 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/general_store)
+"lzV" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/bigredv2/outside/medical)
 "lAi" = (
 /obj/structure/ship_ammo/rocket/banshee,
 /turf/open/floor/tile/dark,
@@ -21765,6 +22187,15 @@
 	dir = 9
 	},
 /area/shuttle/drop2/lz2)
+"lDO" = (
+/obj/effect/ai_node,
+/turf/open/floor/freezer,
+/area/bigredv2/caves/lambda_lab)
+"lDY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/bigredv2/outside/general_offices)
 "lFw" = (
 /obj/machinery/atmospherics/pipe/manifold4w/green,
 /turf/open/floor/prison/darkred/full,
@@ -21883,6 +22314,10 @@
 	},
 /turf/open/shuttle/escapepod,
 /area/bigredv2/caves/southeast)
+"mej" = (
+/obj/effect/ai_node,
+/turf/open/floor/carpet,
+/area/bigredv2/outside/library)
 "mgD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -21913,6 +22348,15 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/east)
+"mqw" = (
+/obj/effect/ai_node,
+/turf/open/floor/grimy,
+/area/bigredv2/outside/dorms)
+"mra" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/effect/ai_node,
+/turf/closed/mineral/bigred,
+/area/bigredv2/caves/west)
 "mrL" = (
 /obj/structure/largecrate/supply/supplies/metal,
 /turf/open/floor/tile/dark,
@@ -21953,11 +22397,25 @@
 "mAw" = (
 /turf/open/floor/asteroidfloor,
 /area/shuttle/drop2/lz2)
+"mBh" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/ai_node,
+/turf/open/floor/grimy,
+/area/bigredv2/outside/marshal_office)
+"mCu" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/northwest)
 "mCR" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 10
 	},
 /area/shuttle/drop2/lz2)
+"mDt" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/bigredv2/outside/space_port)
 "mDB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -21997,6 +22455,11 @@
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/southwest)
+"mGA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark/yellow2/corner,
+/area/bigredv2/outside/nanotrasen_lab/inside)
 "mGX" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -22017,6 +22480,16 @@
 	dir = 4
 	},
 /area/shuttle/drop2/lz2)
+"mLv" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark/yellow2/corner{
+	dir = 1
+	},
+/area/bigredv2/outside/nanotrasen_lab/inside)
 "mOy" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
@@ -22051,6 +22524,11 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/northwest)
+"mVk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/turf/open/floor/freezer,
+/area/bigredv2/outside/hydroponics)
 "mXK" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 10
@@ -22075,6 +22553,10 @@
 /obj/structure/prop/mainship/mission_planning_system,
 /turf/open/shuttle/escapepod,
 /area/bigredv2/caves/southeast)
+"nbJ" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/purple/taupepurple/corner,
+/area/bigredv2/caves/lambda_lab)
 "nbV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	on = 1
@@ -22196,6 +22678,10 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor,
 /area/mint)
+"nDt" = (
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/bigredv2/outside/filtration_plant)
 "nFd" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -22212,6 +22698,10 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/cargo/arrow,
 /area/bigredv2/caves/lambda_lab)
+"nIl" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/bigredv2/outside/marshal_office)
 "nIZ" = (
 /obj/structure/prop/mainship/hangar_stencil/two,
 /turf/open/floor/marking/asteroidwarning{
@@ -22252,6 +22742,10 @@
 /obj/item/paper/clockresearch1,
 /turf/closed/wall/r_wall,
 /area/bigredv2/caves/southeast)
+"nPN" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/shuttle/drop2/lz2)
 "nQE" = (
 /obj/machinery/atmospherics/pipe/manifold/green,
 /turf/open/floor/tile/dark2,
@@ -22276,6 +22770,10 @@
 "nSc" = (
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/w)
+"nSj" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/southwest)
 "nTN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
@@ -22287,18 +22785,40 @@
 /obj/structure/table/mainship,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/southeast)
+"nZh" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/bigredv2/outside/space_port)
 "oaD" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 8
 	},
 /area/shuttle/drop2/lz2)
+"obL" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/bigredv2/outside/s)
 "ocv" = (
 /turf/open/floor/plating/ground/mars/dirttosand,
 /area/shuttle/drop2/lz2)
+"ofJ" = (
+/obj/effect/ai_node,
+/turf/open/floor/asteroidfloor,
+/area/bigredv2/outside/s)
 "ofL" = (
 /obj/structure/closet/crate/trashcart,
 /turf/open/shuttle/escapepod,
 /area/bigredv2/caves/north)
+"ofX" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/outside/e)
+"ogO" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/turf/open/floor/tile/red/redtaupecorner,
+/area/bigredv2/outside/marshal_office)
 "oiH" = (
 /obj/effect/decal/warning_stripes/thick,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -22313,6 +22833,15 @@
 	},
 /turf/open/floor/wood,
 /area/bigredv2/outside/bar)
+"ojU" = (
+/obj/effect/ai_node,
+/turf/open/ground/river,
+/area/bigredv2/outside/engineering)
+"okb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/bigredv2/outside/hydroponics)
 "olJ" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/mineral/bigred,
@@ -22393,6 +22922,17 @@
 /obj/structure/largecrate/random/case/double,
 /turf/open/shuttle/escapepod,
 /area/bigredv2/caves/southeast)
+"oxD" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 10
+	},
+/area/bigredv2/outside/c)
+"ozt" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/northeast)
 "ozW" = (
 /obj/machinery/door/poddoor/shutters/mainship{
 	dir = 2;
@@ -22408,6 +22948,15 @@
 	},
 /turf/open/floor/prison/darkred/full,
 /area/bigredv2/caves/south)
+"oAW" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 8
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/chapel{
+	dir = 8
+	},
+/area/bigredv2/outside/chapel)
 "oCk" = (
 /turf/closed/wall/r_wall,
 /area/space)
@@ -22488,9 +23037,18 @@
 "oOR" = (
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/east)
+"oPw" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/southeast)
 "oPP" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/mint)
+"oQZ" = (
+/obj/machinery/atmospherics/pipe/manifold/green/hidden,
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/bigredv2/outside/general_offices)
 "oTw" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
@@ -22522,6 +23080,11 @@
 "oWn" = (
 /turf/open/floor/tile/green/whitegreenfull,
 /area/bigredv2/caves/lambda_lab)
+"oWE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/turf/open/floor/asteroidfloor,
+/area/bigredv2/outside/s)
 "oXG" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/shuttle/drop2/lz2)
@@ -22575,6 +23138,14 @@
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/lambda_lab)
+"pfD" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/bigredv2/outside/engineering)
+"pgI" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/outside/ne)
 "pgX" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -22627,11 +23198,21 @@
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/s)
+"pqp" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/bigredv2/caves/lambda_lab)
 "pqC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/nw)
+"pqQ" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 1
+	},
+/area/bigredv2/outside/se)
 "pst" = (
 /obj/effect/decal/warning_stripes/thick,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -22899,6 +23480,10 @@
 "qke" = (
 /turf/open/floor/marking/asteroidwarning,
 /area/mint)
+"qkJ" = (
+/obj/effect/ai_node,
+/turf/closed/mineral/bigred,
+/area/bigredv2/caves/west)
 "qml" = (
 /obj/machinery/light{
 	dir = 1
@@ -23009,6 +23594,10 @@
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/south)
+"qEe" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/bigredv2/outside/w)
 "qEg" = (
 /obj/structure/sign/safety/high_radiation,
 /turf/open/floor,
@@ -23081,6 +23670,11 @@
 	dir = 8
 	},
 /area/bigredv2/outside/virology)
+"qPM" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/floor/freezer,
+/area/bigredv2/outside/virology)
 "qQd" = (
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/tile/dark/purple2/corner{
@@ -23103,12 +23697,24 @@
 /area/bigredv2/outside/dorms)
 "qRX" = (
 /obj/effect/landmark/xeno_turret_spawn,
+/obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/north)
 "qSr" = (
 /obj/structure/cable,
 /turf/open/floor/prison/darkyellow/full,
 /area/bigredv2/caves/southeast)
+"qTD" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark/blue2{
+	dir = 8
+	},
+/area/bigredv2/outside/nanotrasen_lab/inside)
+"qUj" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/bigredv2/outside/virology)
 "qUm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -23126,6 +23732,13 @@
 	dir = 4
 	},
 /turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/southeast)
+"qVB" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
 /area/bigredv2/caves/southeast)
 "qXP" = (
 /obj/effect/decal/cleanable/blood/gibs,
@@ -23220,6 +23833,10 @@
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/northeast)
+"rug" = (
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/bigredv2/outside/general_offices)
 "rvh" = (
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/lambda_lab)
@@ -23228,6 +23845,10 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/mint)
+"rwd" = (
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/bigredv2/outside/hydroponics)
 "rww" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -23246,10 +23867,20 @@
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/general_offices)
+"rxs" = (
+/obj/effect/ai_node,
+/turf/closed/mineral/bigred,
+/area/bigredv2/caves/east)
 "ryA" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/shuttle/escapepod,
 /area/bigredv2/caves/southeast)
+"ryU" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 9
+	},
+/area/bigredv2/outside/c)
 "rAe" = (
 /obj/item/ammo_casing/bullet,
 /obj/item/ammo_casing/bullet,
@@ -23270,6 +23901,15 @@
 "rEB" = (
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/mint)
+"rEI" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/warning,
+/area/bigredv2/caves/lambda_lab)
+"rFg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/turf/open/floor/freezer,
+/area/bigredv2/outside/dorms)
 "rJv" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	name = "\improper Lambda Lab"
@@ -23352,6 +23992,11 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/southeast)
+"rVu" = (
+/obj/machinery/light,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/bigredv2/outside/marshal_office)
 "rVZ" = (
 /turf/open/shuttle/escapepod/five,
 /area/bigredv2/caves/lambda_lab)
@@ -23384,6 +24029,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/shuttle/escapepod,
 /area/bigredv2/caves/northeast)
+"sbB" = (
+/obj/effect/ai_node,
+/turf/open/floor/wood,
+/area/bigredv2/outside/dorms)
 "sbU" = (
 /obj/machinery/light{
 	dir = 4
@@ -23417,6 +24066,15 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/bigredv2/caves/southeast)
+"shX" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/lightred/full,
+/area/mint)
+"sig" = (
+/obj/structure/closet/bombclosetsecurity,
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/bigredv2/outside/marshal_office)
 "sjJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -23465,6 +24123,12 @@
 	dir = 4
 	},
 /area/shuttle/drop2/lz2)
+"svN" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/red/redtaupecorner{
+	dir = 4
+	},
+/area/bigredv2/outside/marshal_office)
 "svV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor/wood,
@@ -23538,6 +24202,14 @@
 /obj/structure/cable,
 /turf/open/floor/prison/darkred/full,
 /area/bigredv2/caves/southeast)
+"sNq" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/white,
+/area/bigredv2/outside/medical)
+"sQa" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/outside/s)
 "sQi" = (
 /obj/effect/landmark/xeno_turret_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -23577,6 +24249,10 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
+"sUj" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/cave/rock,
+/area/bigredv2/caves/east)
 "sVq" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/item/ammo_casing/bullet,
@@ -23602,6 +24278,10 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/c)
+"tag" = (
+/obj/effect/ai_node,
+/turf/open/floor/carpet,
+/area/bigredv2/caves/lambda_lab)
 "tbU" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
@@ -23648,6 +24328,10 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/north)
+"trV" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/bigredv2/caves/lambda_lab)
 "tsZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/marking/asteroidwarning{
@@ -23680,6 +24364,12 @@
 "tvk" = (
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/southwest)
+"twd" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 1
+	},
+/area/bigredv2/outside/nw)
 "twQ" = (
 /obj/effect/spawner/random/tool,
 /turf/open/floor,
@@ -23699,6 +24389,10 @@
 	},
 /turf/open/floor/grimy,
 /area/bigredv2/outside/dorms)
+"txA" = (
+/obj/effect/ai_node,
+/turf/open/floor/engine,
+/area/bigredv2/caves/lambda_lab)
 "txM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/job/survivor,
@@ -23718,6 +24412,15 @@
 /obj/item/ammo_casing/shell,
 /turf/open/floor/mainship/sterile/dark,
 /area/bigredv2/caves/southeast)
+"tBo" = (
+/obj/effect/ai_node,
+/turf/open/floor/asteroidfloor,
+/area/bigredv2/outside/se)
+"tCD" = (
+/obj/effect/ai_node,
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/shuttle/drop2/lz2)
 "tCQ" = (
 /obj/structure/barricade/metal{
 	dir = 8
@@ -23735,6 +24438,10 @@
 	dir = 6
 	},
 /area/bigredv2/outside/ne)
+"tEj" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/north)
 "tEo" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -23772,6 +24479,11 @@
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/tile/white,
 /area/bigredv2/caves/lambda_lab)
+"tKW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/turf/open/floor/tile/white,
+/area/bigredv2/outside/medical)
 "tLL" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno/limb,
 /obj/item/ammo_casing/shell,
@@ -23882,6 +24594,7 @@
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
 	},
+/obj/effect/ai_node,
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
 "uhF" = (
@@ -23953,6 +24666,10 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/southeast)
+"upv" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/bigredv2/caves/lambda_lab)
 "uqm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/corpsespawner/doctor,
@@ -24011,6 +24728,13 @@
 /obj/effect/spawner/gibspawner/human,
 /turf/open/floor/tile/dark2,
 /area/bigredv2/caves/southeast)
+"uDs" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 4
+	},
+/area/bigredv2/outside/w)
 "uHn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -24052,9 +24776,20 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/northeast)
+"uLV" = (
+/obj/effect/ai_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 1
+	},
+/area/bigredv2/outside/nw)
 "uMP" = (
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/east)
+"uNq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/turf/open/floor/marking/asteroidwarning,
+/area/bigredv2/outside/nw)
 "uQz" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/marking/asteroidwarning{
@@ -24088,6 +24823,10 @@
 /obj/structure/sign/safety/hazard,
 /turf/open/floor/marking/asteroidwarning,
 /area/bigredv2/outside/space_port)
+"vbB" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/cave/rock,
+/area/mint)
 "vbQ" = (
 /obj/item/limb/l_arm,
 /turf/open/floor/tile/dark2,
@@ -24110,6 +24849,14 @@
 	},
 /turf/open/floor/prison/darkred/full,
 /area/bigredv2/caves/southeast)
+"vhX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 4
+	},
+/area/shuttle/drop2/lz2)
 "viz" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -24121,6 +24868,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
 /area/bigredv2/caves/south)
+"vmF" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/caves/northwest)
 "voK" = (
 /obj/structure/barricade/metal{
 	dir = 8
@@ -24157,9 +24908,19 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/nw)
+"vwL" = (
+/obj/effect/ai_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 8
+	},
+/area/mint)
 "vwP" = (
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/caves/northwest)
+"vwW" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/east)
 "vxE" = (
 /obj/item/limb/l_hand,
 /obj/item/ammo_casing/bullet{
@@ -24204,9 +24965,22 @@
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/prison/darkred/full,
 /area/bigredv2/caves/southeast)
+"vFJ" = (
+/obj/effect/spawner/gibspawner/human,
+/obj/effect/ai_node,
+/turf/open/floor/prison/darkred/full,
+/area/bigredv2/caves/southeast)
+"vGv" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/bigredv2/outside/general_offices)
 "vHo" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating,
+/area/bigredv2/outside/virology)
+"vIh" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/virology)
 "vIl" = (
 /obj/structure/sign/poster{
@@ -24248,9 +25022,27 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor,
 /area/bigredv2/outside/general_store)
+"vPs" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/bigredv2/outside/marshal_office)
 "vQS" = (
 /turf/open/floor/prison/darkred/full,
 /area/bigredv2/caves/southeast)
+"vRr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark/red2/corner,
+/area/bigredv2/outside/nanotrasen_lab/inside)
+"vRK" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/bigredv2/caves/lambda_lab)
 "vRM" = (
 /obj/effect/decal/warning_stripes/nscenter,
 /obj/machinery/light/built{
@@ -24341,10 +25133,35 @@
 /obj/effect/landmark/xeno_turret_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/east)
+"whM" = (
+/obj/effect/ai_node,
+/turf/open/space/basic,
+/area/bigredv2/outside/admin_building)
+"wid" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/cave/rock,
+/area/bigredv2/caves/southwest)
+"wjy" = (
+/obj/effect/ai_node,
+/turf/open/floor/wood,
+/area/bigredv2/outside/library)
+"wjN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 8
+	},
+/area/bigredv2/outside/nw)
 "wkf" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/mint)
+"wmr" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 6
+	},
+/area/bigredv2/outside/c)
 "wmv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -24416,11 +25233,16 @@
 /obj/effect/decal/cleanable/blood/gibs/xeno/down,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/n)
+"wyN" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/bigredv2/outside/n)
 "wyS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
+/obj/effect/ai_node,
 /turf/open/floor/grimy,
 /area/bigredv2/outside/dorms)
 "wzM" = (
@@ -24445,6 +25267,10 @@
 /obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
+"wEX" = (
+/obj/effect/ai_node,
+/turf/open/floor/wood,
+/area/bigredv2/outside/bar)
 "wFw" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /obj/structure/cable,
@@ -24499,6 +25325,18 @@
 	dir = 4
 	},
 /area/bigredv2/outside/virology)
+"wXR" = (
+/obj/effect/ai_node,
+/turf/open/floor/freezer,
+/area/bigredv2/outside/virology)
+"wXS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/marking/asteroidwarning,
+/area/bigredv2/outside/s)
 "wYu" = (
 /obj/machinery/light{
 	dir = 4
@@ -24519,6 +25357,12 @@
 /obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/general_offices)
+"xcu" = (
+/obj/effect/ai_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 1
+	},
+/area/shuttle/drop2/lz2)
 "xdr" = (
 /obj/machinery/light{
 	dir = 8
@@ -24557,6 +25401,12 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor,
 /area/bigredv2/outside/general_store)
+"xja" = (
+/obj/effect/ai_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 8
+	},
+/area/bigredv2/outside/nw)
 "xjd" = (
 /obj/effect/glowshroom,
 /obj/effect/landmark/lv624/fog_blocker,
@@ -24588,6 +25438,7 @@
 "xnf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/tool,
+/obj/effect/ai_node,
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
 "xni" = (
@@ -24676,6 +25527,10 @@
 /obj/effect/landmark/corpsespawner/security,
 /turf/open/floor,
 /area/bigredv2/outside/general_offices)
+"xCj" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/outside/se)
 "xCx" = (
 /turf/open/space/basic,
 /area/bigredv2/outside/admin_building)
@@ -24686,6 +25541,10 @@
 "xEN" = (
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/south)
+"xFE" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/west)
 "xGI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -24698,6 +25557,10 @@
 /obj/docking_port/stationary/crashmode,
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/northwest)
+"xIR" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/outside/nanotrasen_lab/inside)
 "xIT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/corpsespawner/scientist,
@@ -24784,6 +25647,10 @@
 /obj/item/ashtray/bronze,
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/virology)
+"xWj" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/outside/n)
 "xWD" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -24792,6 +25659,10 @@
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/tile/darkgreen/darkgreen2,
 /area/bigredv2/caves/lambda_lab)
+"xXd" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/bigredv2/outside/c)
 "xYz" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -24799,6 +25670,10 @@
 "ydN" = (
 /turf/open/floor/mainship/orange,
 /area/bigredv2/caves/northeast)
+"ydY" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/cave/rock,
+/area/bigredv2/caves/south)
 "yek" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -24823,6 +25698,11 @@
 	dir = 6
 	},
 /area/bigredv2/outside/space_port)
+"yjC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/bigredv2/outside/engineering)
 "yjP" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -26646,14 +27526,14 @@ jOB
 nRT
 jOB
 nRT
-nRT
+xFE
 jMC
 nRT
 nRT
 nRT
 jOB
-nRT
-nRT
+xFE
+xFE
 nRT
 nRT
 nRT
@@ -26690,7 +27570,7 @@ nRT
 jOB
 nRT
 nRT
-nRT
+xFE
 nRT
 nRT
 nRT
@@ -26856,7 +27736,7 @@ aad
 aad
 aad
 aad
-aad
+mCu
 aad
 nRT
 nRT
@@ -27076,20 +27956,20 @@ aad
 mOy
 aad
 nRT
+xFE
+nRT
+nRT
+nRT
+jOB
+jMC
+nRT
+nRT
+nRT
 nRT
 nRT
 nRT
 nRT
 jOB
-jMC
-nRT
-nRT
-nRT
-nRT
-nRT
-nRT
-nRT
-jOB
 nRT
 nRT
 nRT
@@ -27101,8 +27981,8 @@ jMC
 yhx
 yhx
 yhx
-yhx
-nRT
+qkJ
+xFE
 nRT
 nRT
 nRT
@@ -27333,8 +28213,8 @@ nRT
 nRT
 nRT
 nRT
-gel
-faf
+cZc
+mra
 faf
 faf
 yhx
@@ -27368,7 +28248,7 @@ tvk
 tvk
 puQ
 puQ
-puQ
+nSj
 puQ
 puQ
 puQ
@@ -27474,9 +28354,9 @@ acQ
 acQ
 fyt
 aaf
-aaf
+euD
 gkA
-aaf
+euD
 aaf
 aaf
 jLQ
@@ -27489,7 +28369,7 @@ aad
 aad
 mTF
 aad
-aad
+mCu
 aad
 aad
 aad
@@ -27499,7 +28379,7 @@ aad
 aad
 mAi
 mAi
-aad
+mCu
 aad
 aad
 aad
@@ -27549,7 +28429,7 @@ nRT
 nRT
 nRT
 nRT
-nRT
+xFE
 nRT
 yhx
 yhx
@@ -27585,13 +28465,13 @@ puQ
 puQ
 puQ
 puQ
-puQ
+nSj
 uln
 uln
 puQ
 puQ
 uln
-puQ
+nSj
 uln
 puQ
 hTy
@@ -27710,7 +28590,7 @@ aad
 aad
 aad
 aad
-aad
+mCu
 mAi
 mAi
 aad
@@ -27787,12 +28667,12 @@ puQ
 puQ
 puQ
 puQ
-puQ
+nSj
 puQ
 puQ
 puQ
 uln
-uln
+cwo
 puQ
 puQ
 puQ
@@ -27920,7 +28800,7 @@ aad
 aad
 aad
 aad
-aad
+mCu
 aad
 aad
 aad
@@ -27932,7 +28812,7 @@ aad
 aad
 aad
 mTF
-aad
+mCu
 aad
 aad
 aac
@@ -28198,7 +29078,7 @@ yhx
 yhx
 nRT
 nRT
-nRT
+xFE
 nRT
 jOB
 nRT
@@ -28212,7 +29092,7 @@ nRT
 nRT
 nRT
 nRT
-nRT
+xFE
 nRT
 jOB
 nRT
@@ -28361,7 +29241,7 @@ aac
 aac
 aad
 aad
-aad
+mCu
 aad
 aad
 aad
@@ -28450,7 +29330,7 @@ puQ
 uln
 puQ
 puQ
-puQ
+nSj
 puQ
 dSm
 tvk
@@ -28559,7 +29439,7 @@ afL
 acQ
 aaf
 aaf
-aaf
+euD
 aaf
 aaf
 aaf
@@ -28687,7 +29567,7 @@ puQ
 puQ
 puQ
 uln
-puQ
+nSj
 puQ
 puQ
 puQ
@@ -28820,7 +29700,7 @@ aFs
 aFs
 aFs
 aHZ
-aFv
+vIh
 aFv
 aGr
 aHg
@@ -29196,7 +30076,7 @@ aaf
 aaf
 aaf
 aaf
-aaf
+euD
 aaf
 aaf
 aaf
@@ -29270,7 +30150,7 @@ aUN
 aVD
 aRF
 aWe
-aNc
+dyL
 aMz
 aYB
 aRF
@@ -29446,7 +30326,7 @@ aac
 aad
 aad
 aad
-aad
+mCu
 aac
 aac
 aac
@@ -29461,7 +30341,7 @@ emb
 aRE
 aRE
 emb
-aRE
+ehP
 aRE
 aRE
 aRE
@@ -29477,7 +30357,7 @@ aHj
 aLV
 aMz
 aNc
-aNc
+dyL
 aMz
 aQB
 aRH
@@ -29511,7 +30391,7 @@ oXG
 oXG
 oXG
 oXG
-oXG
+nPN
 oXG
 oXG
 vDI
@@ -29558,7 +30438,7 @@ puQ
 puQ
 uln
 puQ
-dSm
+wid
 puQ
 puQ
 tvk
@@ -29685,7 +30565,7 @@ emb
 bpx
 aMz
 aFv
-aFu
+hqO
 aHh
 aIb
 aHj
@@ -29723,7 +30603,7 @@ oXG
 oXG
 oXG
 oXG
-oXG
+nPN
 oXG
 oXG
 oXG
@@ -30090,7 +30970,7 @@ aac
 aac
 mTF
 aad
-aad
+mCu
 aad
 aad
 aad
@@ -30122,7 +31002,7 @@ aHi
 aHi
 aHj
 aIc
-aJh
+fAw
 aJh
 aJh
 aJh
@@ -30140,7 +31020,7 @@ aNc
 aRH
 aNc
 aRF
-aNc
+dyL
 aRH
 aMz
 oEN
@@ -30191,7 +31071,7 @@ tvk
 tvk
 uln
 puQ
-puQ
+nSj
 dSm
 puQ
 tvk
@@ -30199,7 +31079,7 @@ tvk
 tvk
 puQ
 puQ
-puQ
+nSj
 puQ
 puQ
 dSm
@@ -30319,7 +31199,7 @@ aad
 nyf
 vwP
 vwP
-vwP
+vmF
 vwP
 vwP
 vwP
@@ -30330,7 +31210,7 @@ aRE
 aRE
 aRE
 aRE
-aRE
+ehP
 emb
 aRE
 aRE
@@ -30492,7 +31372,7 @@ ktH
 aae
 gFh
 aai
-aao
+giE
 aao
 aao
 aao
@@ -30514,7 +31394,7 @@ aao
 aao
 aao
 aeh
-aaf
+euD
 aaf
 aaf
 fYS
@@ -30599,7 +31479,7 @@ mAw
 mAw
 mAw
 mAw
-mAw
+cME
 mAw
 mAw
 mAw
@@ -30723,8 +31603,8 @@ aau
 aao
 aao
 aao
-aao
-aao
+giE
+giE
 aao
 aao
 aao
@@ -30748,7 +31628,7 @@ aac
 aac
 aad
 aad
-aad
+mCu
 aad
 nyf
 aeI
@@ -30759,11 +31639,11 @@ vwP
 aMz
 aMz
 aRE
-aRE
-aRE
+ehP
+ehP
 aRE
 emb
-aRE
+ehP
 aRE
 aRE
 aRE
@@ -30791,13 +31671,13 @@ aWi
 aNc
 kMq
 aNc
+dyL
 aNc
 aNc
 aNc
 aNc
 aNc
-aNc
-aNc
+dyL
 vpv
 bqG
 brd
@@ -30987,7 +31867,7 @@ aRE
 aRE
 aMz
 aFs
-aFs
+fHF
 aHh
 aId
 aHZ
@@ -31061,10 +31941,10 @@ tvk
 puQ
 puQ
 puQ
+nSj
 puQ
 puQ
-puQ
-puQ
+nSj
 uln
 dSm
 puQ
@@ -31181,7 +32061,7 @@ aad
 aad
 aad
 aad
-mTF
+gKy
 aad
 aad
 aad
@@ -31214,7 +32094,7 @@ aFv
 aMz
 aNi
 aXy
-aNi
+wXR
 aNi
 aNi
 aSz
@@ -31283,7 +32163,7 @@ puQ
 puQ
 puQ
 puQ
-puQ
+nSj
 puQ
 puQ
 tvk
@@ -31368,8 +32248,8 @@ aao
 aao
 aao
 aao
-aao
-aao
+giE
+giE
 aao
 aao
 aao
@@ -31431,7 +32311,7 @@ aFv
 aMz
 aNi
 aNi
-aNi
+wXR
 aNi
 aNi
 aSA
@@ -31470,7 +32350,7 @@ bie
 bie
 bie
 bie
-bie
+tCD
 bie
 bie
 bie
@@ -31482,7 +32362,7 @@ bie
 bie
 bie
 bsd
-mAw
+cME
 mAw
 mAw
 bmd
@@ -31494,14 +32374,14 @@ puQ
 puQ
 puQ
 puQ
-puQ
+nSj
 puQ
 puQ
 puQ
 puQ
 puQ
 uln
-puQ
+nSj
 dSm
 tvk
 tvk
@@ -31515,7 +32395,7 @@ tvk
 tvk
 tvk
 puQ
-puQ
+nSj
 puQ
 tvk
 tvk
@@ -31621,13 +32501,13 @@ nyf
 nyf
 bOD
 eCI
-aeI
+hdP
 aeI
 aiz
 aMz
 aRE
 aRE
-emb
+qUj
 aRE
 aRE
 aRE
@@ -31647,20 +32527,20 @@ aFv
 aFv
 aMz
 aNi
-aNi
+wXR
 aNi
 aXy
 aNi
 aSz
 aNc
 aNc
-aNc
+dyL
 aWj
 aWT
 aXy
 aWj
 aWT
-aXy
+qPM
 aWj
 aWT
 aXy
@@ -32109,7 +32989,7 @@ yeq
 oXG
 cyp
 qyl
-faR
+xcu
 bhy
 bie
 bie
@@ -32465,7 +33345,7 @@ aah
 aah
 aah
 aah
-aah
+nZh
 aah
 aah
 aah
@@ -32567,7 +33447,7 @@ bie
 bie
 bie
 bse
-mAw
+cME
 mAw
 mAw
 bmd
@@ -32692,7 +33572,7 @@ aae
 cyL
 aeI
 aeI
-aeI
+hdP
 bZF
 aeI
 aeI
@@ -32701,7 +33581,7 @@ aeI
 aeI
 aeI
 aeI
-aeI
+hdP
 aeI
 aiA
 ajy
@@ -32724,8 +33604,8 @@ ajY
 akK
 ahP
 ahP
-ajy
-cuW
+uLV
+bKj
 ahP
 ama
 aeI
@@ -32941,7 +33821,7 @@ aDy
 akK
 ahP
 ahP
-ajy
+uLV
 cuW
 aln
 aeI
@@ -32960,7 +33840,7 @@ aVG
 aWl
 aWV
 aXA
-aXA
+uDs
 aWV
 aXA
 aXA
@@ -32973,7 +33853,7 @@ bdJ
 hhh
 hhh
 hhh
-ume
+vhX
 gMM
 gMM
 gMM
@@ -33025,7 +33905,7 @@ puQ
 puQ
 puQ
 puQ
-puQ
+nSj
 puQ
 dSm
 tvk
@@ -33253,7 +34133,7 @@ tvk
 tvk
 tvk
 puQ
-uln
+cwo
 puQ
 tvk
 tvk
@@ -33348,17 +34228,17 @@ aeI
 aeI
 aeI
 bZF
+hdP
 aeI
 aeI
 aeI
 aeI
 aeI
-aeI
-aiA
+twd
 ajy
 ajx
 ahR
-aln
+aDH
 aeI
 avr
 avU
@@ -33398,7 +34278,7 @@ aXY
 aQF
 aQF
 aQF
-aQF
+gZB
 aQF
 bbJ
 aSB
@@ -33564,14 +34444,14 @@ aiw
 aiw
 aiw
 aiw
-aiw
+xja
 aiw
 aiw
 aiw
 aiw
 aiw
 aqp
-aqp
+wjN
 ajx
 ajx
 akK
@@ -33636,7 +34516,7 @@ mAw
 mAw
 mAw
 mAw
-mAw
+cME
 mAw
 mAw
 mAw
@@ -33761,7 +34641,7 @@ aaK
 aci
 aaK
 aaK
-aaK
+mDt
 aaK
 aaK
 aaK
@@ -33799,7 +34679,7 @@ avT
 avT
 avT
 axZ
-avT
+cTS
 avT
 avT
 avT
@@ -33904,7 +34784,7 @@ tvk
 dSm
 dSm
 puQ
-puQ
+nSj
 tvk
 tvk
 tvk
@@ -34013,7 +34893,7 @@ aln
 aeI
 avr
 avT
-avT
+cTS
 avT
 axZ
 avT
@@ -34329,7 +35209,7 @@ tvk
 tvk
 tvk
 puQ
-puQ
+nSj
 puQ
 qqG
 dSm
@@ -34418,7 +35298,7 @@ aah
 aah
 aah
 aah
-aah
+nZh
 aah
 aah
 aah
@@ -34555,7 +35435,7 @@ tvk
 tvk
 tvk
 puQ
-puQ
+nSj
 tvk
 tvk
 tvk
@@ -34669,7 +35549,7 @@ avT
 axZ
 avT
 mTi
-avT
+cTS
 avT
 avr
 aeI
@@ -34703,7 +35583,7 @@ aXK
 aQF
 dLO
 aSB
-aSB
+qEe
 aSB
 aVG
 bdZ
@@ -34719,7 +35599,7 @@ bij
 uiT
 uiT
 iNl
-uiT
+epl
 uiT
 gVH
 uiT
@@ -34738,12 +35618,12 @@ uec
 pQK
 oMr
 pQK
-pQK
+vwL
 pQK
 oMr
 pQK
 pQK
-pQK
+vwL
 pQK
 djh
 uec
@@ -34893,7 +35773,7 @@ aeI
 aeI
 aeI
 aeI
-aeI
+hdP
 aeI
 aeI
 aeI
@@ -34934,7 +35814,7 @@ bhd
 bhD
 bik
 bhD
-bhb
+shX
 bhb
 bhb
 bhb
@@ -35069,7 +35949,7 @@ aah
 aah
 aah
 aah
-aah
+nZh
 aah
 aah
 aah
@@ -35269,7 +36149,7 @@ bXE
 aae
 aaA
 aaO
-aaP
+gFR
 aaO
 abo
 aaO
@@ -35283,7 +36163,7 @@ aah
 aah
 aah
 abk
-aah
+nZh
 aah
 aah
 aah
@@ -35300,7 +36180,7 @@ ajy
 ajY
 ahR
 ahP
-ahP
+kkd
 ahV
 ahV
 ahP
@@ -35316,7 +36196,7 @@ auF
 avr
 avT
 avT
-avT
+cTS
 ayc
 avT
 fLz
@@ -35327,7 +36207,7 @@ aeI
 aeI
 aeI
 aeI
-aeI
+hdP
 aeI
 aeI
 aeI
@@ -35415,13 +36295,13 @@ tvk
 tvk
 puQ
 puQ
-uln
+cwo
 puQ
 dSm
 tvk
 tvk
 tvk
-dSm
+wid
 puQ
 uln
 tvk
@@ -35503,7 +36383,7 @@ abl
 aah
 aah
 aah
-aah
+nZh
 aah
 aah
 aah
@@ -35762,7 +36642,7 @@ aeI
 aeI
 aeI
 aeI
-aeI
+hdP
 aeI
 aeI
 aeI
@@ -35969,7 +36849,7 @@ avT
 avT
 avT
 ayc
-avT
+cTS
 azo
 aAq
 aAZ
@@ -36016,7 +36896,7 @@ aZO
 blb
 uiT
 uiT
-uiT
+epl
 bim
 gym
 bjh
@@ -36063,7 +36943,7 @@ uln
 dSm
 dSm
 puQ
-puQ
+nSj
 puQ
 puQ
 puQ
@@ -36170,7 +37050,7 @@ akK
 ahP
 ahO
 aeI
-aeI
+hdP
 aeI
 aeI
 aeI
@@ -36248,13 +37128,13 @@ bme
 bme
 xyM
 bmi
-bmi
+cEA
 bmi
 bmi
 vDw
 bmi
 ekm
-bmg
+yjC
 bre
 bmq
 asT
@@ -36278,7 +37158,7 @@ dSm
 mSv
 puQ
 puQ
-dSm
+wid
 puQ
 puQ
 puQ
@@ -36505,7 +37385,7 @@ tvk
 tvk
 tvk
 puQ
-puQ
+nSj
 puQ
 tvk
 tvk
@@ -36693,7 +37573,7 @@ brf
 blJ
 hEq
 oPP
-oPP
+gFu
 mEt
 mEt
 mEt
@@ -36876,7 +37756,7 @@ blb
 blb
 aZO
 blb
-blb
+jFM
 baz
 blb
 aZO
@@ -36887,7 +37767,7 @@ uiT
 xKT
 sJa
 wrc
-uiT
+epl
 uiT
 kgL
 flf
@@ -37034,7 +37914,7 @@ aiz
 ahP
 ajy
 akb
-ahR
+cvO
 aln
 aeI
 aeI
@@ -37104,7 +37984,7 @@ baF
 blb
 bil
 biL
-blb
+jFM
 blb
 jYS
 blb
@@ -37330,10 +38210,10 @@ bli
 blK
 bmg
 bmg
-brN
+dnG
 bmi
 bmg
-bmg
+yjC
 bmi
 blJ
 bmk
@@ -37351,7 +38231,7 @@ mEt
 mEt
 pXc
 pXc
-pXc
+kgy
 syY
 pXc
 pXc
@@ -37439,7 +38319,7 @@ aac
 aac
 aad
 aad
-aad
+mCu
 aad
 aad
 aad
@@ -37481,7 +38361,7 @@ aqr
 aqr
 asz
 aqr
-atR
+iPN
 atR
 avu
 auL
@@ -37556,7 +38436,7 @@ bpz
 bom
 bom
 bom
-bmg
+yjC
 bmi
 bsN
 bsZ
@@ -37592,7 +38472,7 @@ tvk
 puQ
 puQ
 puQ
-puQ
+nSj
 tvk
 tvk
 tvk
@@ -37656,7 +38536,7 @@ aac
 aac
 aac
 aad
-aad
+mCu
 aad
 aad
 aad
@@ -37706,7 +38586,7 @@ awM
 axw
 ayg
 aqw
-awO
+kQY
 aAr
 aBc
 aBc
@@ -37899,7 +38779,7 @@ aeI
 aeI
 aeI
 aiB
-ahP
+kkd
 ajy
 akc
 akL
@@ -38006,7 +38886,7 @@ pXc
 pXc
 pXc
 pXc
-rEB
+vbB
 pXc
 pXc
 puQ
@@ -38097,7 +38977,7 @@ aad
 aad
 aad
 aad
-aad
+mCu
 aad
 aad
 aad
@@ -38409,7 +39289,7 @@ aZO
 blb
 blb
 aZO
-blb
+jFM
 blb
 bdN
 blJ
@@ -38532,7 +39412,7 @@ aac
 aac
 aac
 aad
-aad
+mCu
 aad
 aad
 aad
@@ -38622,7 +39502,7 @@ beV
 bbe
 baC
 bip
-aZO
+gkD
 blb
 blb
 blb
@@ -38773,14 +39653,14 @@ bZF
 aeI
 aiA
 qUm
-akK
+uNq
 ahP
 ahP
 ajz
 amy
 aqv
 aqw
-arR
+tKW
 arR
 atq
 aqz
@@ -38790,7 +39670,7 @@ awc
 awQ
 axy
 atr
-awQ
+hsT
 azt
 awQ
 aBe
@@ -38853,7 +39733,7 @@ bnr
 buD
 bmk
 tux
-bmi
+cEA
 bmi
 bmk
 bqL
@@ -38892,7 +39772,7 @@ tvk
 puQ
 puQ
 puQ
-puQ
+nSj
 uln
 dSm
 uln
@@ -38968,14 +39848,14 @@ aac
 aad
 aad
 aad
-aad
+mCu
 aad
 aad
 hkk
 acp
 adk
 adk
-adk
+cAY
 adS
 aeJ
 afi
@@ -38985,7 +39865,7 @@ adS
 acp
 aeI
 aeI
-aeI
+hdP
 aeI
 aeI
 aiA
@@ -39197,7 +40077,7 @@ adk
 aeJ
 adS
 aeJ
-adS
+bjF
 adk
 acp
 aeI
@@ -39307,7 +40187,7 @@ bty
 bty
 bty
 buD
-buD
+pfD
 buD
 blJ
 blJ
@@ -39521,7 +40401,7 @@ buD
 bmm
 bty
 bty
-bty
+eaY
 buD
 bty
 bty
@@ -39718,7 +40598,7 @@ blJ
 ekm
 ekm
 bmi
-bmi
+cEA
 bmi
 bom
 bmY
@@ -39934,7 +40814,7 @@ blp
 blJ
 bmi
 ekm
-bmi
+cEA
 bmi
 bmi
 bom
@@ -39966,7 +40846,7 @@ blJ
 tvk
 puQ
 puQ
-puQ
+nSj
 puQ
 puQ
 tvk
@@ -40060,14 +40940,14 @@ acC
 acU
 acC
 acD
-acD
+iLr
 acr
 aeL
 aeL
 acp
 agB
 uhF
-aic
+ioN
 acp
 aiY
 afS
@@ -40162,10 +41042,10 @@ yjP
 bmi
 bmi
 bmi
-bmi
+cEA
 bmi
 atk
-btz
+ojU
 btz
 btz
 btz
@@ -40194,7 +41074,7 @@ xEN
 xEN
 xEN
 xEN
-ajG
+ydY
 xEN
 xEN
 hqP
@@ -40289,12 +41169,12 @@ acp
 aiZ
 afS
 afS
-akM
+rVu
 acr
 ame
 ahj
 anx
-afS
+nIl
 akM
 apG
 aqA
@@ -40370,7 +41250,7 @@ bmo
 ekm
 hJM
 bmg
-bmg
+yjC
 bmg
 bmY
 bpH
@@ -40391,7 +41271,7 @@ btz
 btY
 btz
 buD
-btz
+ojU
 btY
 btz
 buD
@@ -40509,7 +41389,7 @@ ake
 aiY
 acr
 ame
-ahj
+cpX
 aer
 afS
 aoT
@@ -40540,7 +41420,7 @@ aHy
 apC
 aHD
 aKk
-aBR
+clR
 aBR
 aBR
 aBR
@@ -40559,13 +41439,13 @@ hlD
 aIp
 aBR
 aBR
-aBR
+clR
 wzM
 aIn
 aIn
 aIn
-aIn
-aIp
+xXd
+wmr
 aBR
 aBR
 aBR
@@ -40766,6 +41646,7 @@ aBR
 aBR
 aBR
 aBR
+clR
 aBR
 aBR
 aBR
@@ -40775,8 +41656,7 @@ aBR
 aBR
 aBR
 aBR
-aBR
-aLd
+ryU
 aIn
 aIn
 aIn
@@ -40922,19 +41802,19 @@ aad
 aad
 pQZ
 acz
-acD
+iLr
 acF
 acO
 acC
 ado
 acC
-acC
+lmm
 acr
 aeL
 aeL
 acp
 agz
-ahm
+vPs
 ahj
 acp
 adh
@@ -41019,7 +41899,7 @@ aBR
 blJ
 bmr
 bom
-bmg
+yjC
 bmi
 bmi
 bnv
@@ -41065,7 +41945,7 @@ hqP
 hqP
 xEN
 xEN
-xEN
+eyM
 xEN
 jWg
 xEN
@@ -41391,8 +42271,8 @@ atW
 atr
 pmf
 arU
-arR
-aqw
+tKW
+sNq
 aqw
 arR
 azA
@@ -41464,7 +42344,7 @@ bmk
 bmg
 bmg
 bmi
-bmg
+yjC
 btf
 btt
 atk
@@ -41486,7 +42366,7 @@ xEN
 xEN
 xEN
 xEN
-xEN
+eyM
 jWg
 hqP
 vKO
@@ -41578,7 +42458,7 @@ acE
 acC
 acN
 acD
-acD
+iLr
 acD
 aem
 acC
@@ -41589,12 +42469,12 @@ ahn
 aic
 acp
 adh
-adh
-adh
+gVv
+gVv
 adh
 acr
 amg
-aic
+ioN
 acp
 acp
 acp
@@ -41734,7 +42614,7 @@ xEN
 jWg
 xYz
 xEN
-ajG
+ydY
 ajG
 dGX
 hqP
@@ -41802,7 +42682,7 @@ aeL
 aeL
 acp
 agz
-ahm
+vPs
 aib
 acp
 acr
@@ -41818,7 +42698,7 @@ aoS
 apG
 aqD
 aqD
-aqD
+lzV
 aqD
 atu
 apC
@@ -41859,7 +42739,7 @@ xCx
 xCx
 xCx
 xCx
-xCx
+whM
 xCx
 xCx
 xCx
@@ -41936,7 +42816,7 @@ hqP
 hqP
 xEN
 xEN
-xEN
+eyM
 xEN
 xEN
 hqP
@@ -42041,7 +42921,7 @@ aqD
 apC
 auL
 arR
-arR
+tKW
 aqw
 aqw
 arR
@@ -42242,7 +43122,7 @@ aiD
 ajc
 aif
 aif
-aif
+ogO
 alr
 ami
 anb
@@ -42291,7 +43171,7 @@ xCx
 xCx
 xCx
 xCx
-xCx
+whM
 xCx
 xCx
 xCx
@@ -42331,7 +43211,7 @@ bqm
 bqQ
 bqQ
 bmg
-bmi
+cEA
 bmg
 bmi
 atk
@@ -42686,7 +43566,7 @@ aoS
 apG
 aqD
 aqD
-aqD
+lzV
 aqD
 aqD
 apC
@@ -42698,7 +43578,7 @@ avz
 apC
 ayS
 azE
-aqw
+sNq
 aqw
 apE
 arl
@@ -42886,7 +43766,7 @@ acP
 acp
 afm
 afS
-afS
+nIl
 afS
 acp
 aiF
@@ -42987,13 +43867,13 @@ blJ
 blJ
 blJ
 buD
-buD
+pfD
 buD
 buD
 buD
 buX
 buD
-bty
+eaY
 bty
 buD
 buD
@@ -43033,7 +43913,7 @@ ajG
 xEN
 xEN
 xEN
-xEN
+eyM
 jWg
 ajG
 xEN
@@ -43100,7 +43980,7 @@ qVr
 qVr
 acP
 acP
-acp
+fJe
 afn
 afS
 agD
@@ -43245,7 +44125,7 @@ xEN
 xEN
 xWD
 xEN
-xEN
+eyM
 xEN
 xEN
 xEN
@@ -43303,8 +44183,8 @@ qVr
 xpB
 xpB
 hBS
-xpB
-xpB
+tEj
+tEj
 xpB
 xpB
 qVr
@@ -43451,26 +44331,14 @@ hqP
 hqP
 xEN
 xEN
-xEN
+eyM
 xEN
 xEN
 ajG
 xEN
 xEN
 xEN
-xEN
-xEN
-xWD
-xEN
-xEN
-xEN
-xEN
-xEN
-xEN
-xEN
-xEN
-xEN
-xEN
+eyM
 xEN
 xWD
 xEN
@@ -43478,6 +44346,18 @@ xEN
 xEN
 xEN
 xEN
+xEN
+xEN
+xEN
+xEN
+xEN
+xEN
+xWD
+xEN
+xEN
+xEN
+xEN
+eyM
 xEN
 xEN
 ajG
@@ -43545,7 +44425,7 @@ afT
 afT
 akk
 aer
-agz
+svN
 amm
 ahj
 any
@@ -43554,7 +44434,7 @@ aoU
 apG
 aqD
 aqD
-aqD
+lzV
 aqD
 aqD
 apC
@@ -43699,7 +44579,7 @@ xEN
 xEN
 xEN
 xEN
-xEN
+eyM
 xEN
 xEN
 xEN
@@ -44181,14 +45061,14 @@ gEU
 qVr
 qVr
 acP
-acP
+xWj
 acP
 acP
 acP
 acp
 afq
 afS
-afT
+dwa
 afS
 acp
 aiK
@@ -44211,7 +45091,7 @@ acP
 acP
 acP
 acP
-acP
+xWj
 acP
 axF
 aqO
@@ -44222,11 +45102,11 @@ acP
 aBR
 aBR
 aBR
+clR
 aBR
 aBR
 aBR
-aBR
-aBR
+clR
 aBR
 aBR
 aLl
@@ -44278,7 +45158,7 @@ aBR
 aBR
 aBR
 aBR
-aBR
+clR
 aBR
 aBR
 blJ
@@ -44294,7 +45174,7 @@ blJ
 bjA
 bjA
 bjH
-bjy
+obL
 bjy
 bjy
 tco
@@ -44428,7 +45308,7 @@ acP
 wxA
 acP
 acP
-acP
+xWj
 acP
 aqO
 aqO
@@ -44489,7 +45369,7 @@ aBR
 aBR
 aBR
 aBR
-aBR
+clR
 aBR
 aBR
 aBR
@@ -44621,7 +45501,7 @@ abd
 abe
 abd
 afU
-afU
+sig
 adS
 adS
 aer
@@ -44641,7 +45521,7 @@ aqI
 aqL
 asa
 rww
-acP
+xWj
 acP
 acP
 acP
@@ -44749,7 +45629,7 @@ bxc
 bww
 bxK
 bxc
-byg
+iKc
 bxd
 bxc
 bxN
@@ -44787,7 +45667,7 @@ hqP
 xEN
 xEN
 jWg
-xEN
+eyM
 xEN
 xEN
 xEN
@@ -44838,12 +45718,12 @@ adR
 aeq
 aeN
 aeq
-adk
+cAY
 adk
 adS
 aii
 adS
-adS
+bjF
 ahm
 ako
 akR
@@ -44857,7 +45737,7 @@ acp
 aqJ
 arp
 acP
-acP
+xWj
 acP
 acP
 acP
@@ -44872,7 +45752,7 @@ azK
 acP
 aBS
 aCN
-aCN
+jng
 aCN
 aFM
 aCN
@@ -44929,12 +45809,12 @@ aKl
 aKl
 aKl
 aKl
-aIm
+oxD
 aBR
 aLd
 aKl
 aIn
-aIn
+xXd
 aMc
 bsX
 bmi
@@ -44944,7 +45824,7 @@ bpJ
 bua
 buo
 buJ
-buJ
+kCm
 buJ
 bvo
 buo
@@ -45125,7 +46005,7 @@ xCx
 xCx
 aHD
 aIn
-aIm
+oxD
 aBR
 aBR
 aBR
@@ -45156,7 +46036,7 @@ aMc
 bmi
 bmi
 bmi
-bmi
+cEA
 ePH
 ekm
 bvA
@@ -45174,12 +46054,12 @@ bvp
 bjw
 bjw
 bjw
-bjw
+ofJ
 bjw
 bwH
 bwM
 bxd
-bxd
+kdj
 bxC
 bxc
 bxV
@@ -45257,7 +46137,7 @@ qVr
 qVr
 xpB
 xpB
-hBS
+kNG
 abq
 xpB
 qVr
@@ -45313,7 +46193,7 @@ asH
 aHD
 aBR
 aBR
-aBR
+clR
 aLl
 aMc
 xCx
@@ -45350,7 +46230,7 @@ aBR
 bhP
 aHD
 aWJ
-aBR
+clR
 wzM
 aBS
 aCN
@@ -45413,12 +46293,12 @@ bwJ
 bwF
 bBd
 bxg
-bxg
+eXY
 bBK
 bwJ
 bCc
 bxo
-bxo
+gip
 bxg
 bCM
 bwF
@@ -45545,8 +46425,8 @@ xCx
 xCx
 xCx
 xCx
-xCx
-xCx
+whM
+whM
 xCx
 xCx
 xCx
@@ -45630,7 +46510,7 @@ bAO
 bwF
 bBc
 bxg
-bxg
+eXY
 bBK
 bwJ
 bCd
@@ -45807,7 +46687,7 @@ brx
 bkt
 btj
 bkE
-bkE
+nDt
 bnk
 bkt
 bjA
@@ -45822,7 +46702,7 @@ bur
 bjy
 bjy
 bvp
-bjw
+ofJ
 bwF
 bwF
 aaY
@@ -45845,14 +46725,14 @@ bAh
 bAx
 bAO
 bwF
-bBd
+kou
 bxg
 bxg
 bBK
 bwJ
 bCe
 bxg
-bxo
+gip
 bxo
 bxg
 bBR
@@ -45927,7 +46807,7 @@ adW
 acp
 adS
 adS
-adk
+cAY
 adk
 ajL
 adS
@@ -46081,7 +46961,7 @@ bxo
 bxo
 bxo
 bxg
-bxo
+gip
 dZF
 bxg
 qvO
@@ -46092,7 +46972,7 @@ xEN
 ajG
 xEN
 jWg
-xEN
+eyM
 xEN
 xEN
 hqP
@@ -46152,7 +47032,7 @@ acp
 aly
 aly
 aly
-adS
+bjF
 aly
 aly
 acr
@@ -46172,7 +47052,7 @@ atA
 azO
 asJ
 asJ
-aua
+cuI
 asJ
 aDQ
 aua
@@ -46265,7 +47145,7 @@ abX
 bwF
 bwP
 acd
-bxF
+qTD
 bxF
 bxF
 xIT
@@ -46293,7 +47173,7 @@ bCW
 bDc
 bxo
 bDc
-bDc
+vRr
 bDc
 bxo
 bDc
@@ -46382,7 +47262,7 @@ aua
 aua
 avC
 aua
-asJ
+fpg
 aua
 ayo
 aua
@@ -46464,13 +47344,13 @@ bkt
 bjA
 bjA
 bjA
-bjA
+kZk
 bjA
 bjA
 tco
 bjA
 bjA
-bjA
+kZk
 blv
 bvp
 bwb
@@ -46577,7 +47457,7 @@ adW
 adW
 aer
 adS
-adS
+bjF
 aiO
 ajg
 ajO
@@ -46591,7 +47471,7 @@ alA
 alA
 acr
 aqM
-aqL
+wyN
 asf
 asH
 asH
@@ -46702,7 +47582,7 @@ byM
 bxg
 bxL
 bxg
-bxo
+gip
 bxg
 byL
 bwF
@@ -46802,10 +47682,10 @@ akt
 acp
 adS
 adk
-adS
+bjF
 adk
 adk
-adS
+bjF
 apI
 acP
 arr
@@ -47002,7 +47882,7 @@ qVr
 gEU
 qVr
 acP
-acP
+xWj
 acP
 acP
 acP
@@ -47223,7 +48103,7 @@ acP
 acP
 acP
 acP
-acP
+xWj
 acP
 acP
 acp
@@ -47299,7 +48179,7 @@ aIn
 aMc
 aHD
 aWJ
-aBR
+clR
 aBR
 aBR
 aBR
@@ -47426,7 +48306,7 @@ aab
 qVr
 abq
 xpB
-xpB
+tEj
 xpB
 xpB
 xpB
@@ -47516,7 +48396,7 @@ bfb
 aMc
 aHD
 aIn
-aIm
+oxD
 aBR
 aBR
 aBR
@@ -47819,7 +48699,7 @@ bCX
 bDT
 bDW
 bDW
-bDW
+lak
 bDm
 bCX
 dZi
@@ -47863,7 +48743,7 @@ xpB
 xpB
 hBS
 xpB
-xpB
+tEj
 abq
 qVr
 qVr
@@ -47928,7 +48808,7 @@ aBR
 aBR
 aBR
 aBR
-aBR
+clR
 aBR
 aLd
 aIn
@@ -47976,11 +48856,11 @@ brZ
 bsF
 asV
 btn
+kZk
 bjA
 bjA
 bjA
-bjA
-bjA
+kZk
 bjH
 bkr
 bkr
@@ -48094,7 +48974,7 @@ qVr
 acP
 acP
 acP
-acP
+xWj
 acP
 acP
 acp
@@ -48104,7 +48984,7 @@ akv
 akT
 alC
 alC
-alC
+mBh
 alC
 aon
 aoY
@@ -48121,11 +49001,11 @@ asJ
 axd
 axd
 asJ
-asJ
+fpg
 azW
 asH
 aBn
-aBW
+rFg
 asH
 asH
 asH
@@ -48139,7 +49019,7 @@ aBR
 aBR
 aBR
 aBR
-aBR
+clR
 aBR
 aBR
 aBR
@@ -48248,7 +49128,7 @@ bxg
 bxg
 bxo
 bxo
-bxg
+eXY
 bxg
 bxA
 bDX
@@ -48312,7 +49192,7 @@ qVr
 acP
 acP
 acP
-acP
+xWj
 acP
 aiQ
 adS
@@ -48512,7 +49392,7 @@ qVr
 abq
 xpB
 xpB
-xpB
+tEj
 xpB
 abq
 qVr
@@ -48602,7 +49482,7 @@ aBR
 aBR
 aBR
 aBR
-aBR
+clR
 aBR
 aBR
 aBR
@@ -48692,7 +49572,7 @@ bxN
 bxN
 bxN
 qGO
-bEK
+mLv
 bCZ
 bwF
 pEh
@@ -48985,7 +49865,7 @@ atz
 atz
 asH
 asJ
-awq
+mqw
 axM
 axM
 qRs
@@ -49054,7 +49934,7 @@ bjw
 bjw
 bjw
 bjw
-bjw
+ofJ
 bjw
 bjw
 boA
@@ -49074,7 +49954,7 @@ hqP
 tco
 bjA
 bjA
-bjA
+kZk
 bjA
 blq
 bjw
@@ -49108,7 +49988,7 @@ bxo
 bxo
 bBr
 bxg
-bxg
+eXY
 bxg
 bBr
 sRT
@@ -49196,7 +50076,7 @@ alF
 acP
 acP
 acP
-acP
+xWj
 asH
 asH
 asH
@@ -49273,7 +50153,7 @@ bjw
 bjw
 bjw
 bjw
-bjw
+ofJ
 bjw
 bjw
 bjw
@@ -49599,7 +50479,7 @@ qVr
 qVr
 qVr
 xpB
-xpB
+tEj
 xpB
 nLh
 nLh
@@ -49646,7 +50526,7 @@ asH
 atY
 atY
 atY
-atY
+sbB
 atY
 aFU
 asH
@@ -49873,7 +50753,7 @@ edO
 aEO
 aEO
 xye
-aEO
+wEX
 aEO
 aEO
 aEO
@@ -49928,7 +50808,7 @@ bpr
 bpc
 boA
 bjw
-btn
+wXS
 bjA
 blv
 btS
@@ -50056,7 +50936,7 @@ mFd
 acP
 acP
 acP
-acP
+xWj
 acP
 anI
 anI
@@ -50087,7 +50967,7 @@ asH
 aHH
 edO
 edO
-aEO
+wEX
 aLs
 xye
 aEO
@@ -50187,7 +51067,7 @@ bzJ
 bwF
 bBl
 bxg
-bxo
+gip
 bBR
 bBY
 bCn
@@ -50212,7 +51092,7 @@ bxS
 bxR
 bxN
 bEM
-bDN
+mGA
 bwF
 vKO
 hqP
@@ -50250,7 +51130,7 @@ qVr
 qVr
 qVr
 xpB
-xpB
+tEj
 xpB
 nLh
 xaU
@@ -50367,7 +51247,7 @@ bjA
 blv
 btS
 bjy
-bjy
+obL
 buu
 buv
 buv
@@ -50475,7 +51355,7 @@ kJi
 nLh
 nLh
 xpB
-xpB
+tEj
 xpB
 qVr
 qVr
@@ -50621,12 +51501,12 @@ bAU
 bwF
 bBn
 bxg
-bxg
+eXY
 bxg
 bBZ
 bxo
 bxo
-bxo
+gip
 bxo
 bxg
 bBK
@@ -50715,7 +51595,7 @@ apc
 apc
 apc
 aop
-apc
+rug
 apc
 apc
 apc
@@ -50938,7 +51818,7 @@ apd
 apd
 apd
 apd
-dmd
+oQZ
 apc
 apc
 ars
@@ -50967,7 +51847,7 @@ azb
 aTg
 aMg
 aHF
-aHF
+dlI
 aWI
 aWJ
 aBR
@@ -51003,7 +51883,7 @@ bmK
 bnp
 bnO
 bkt
-boA
+oWE
 bjw
 bjw
 boA
@@ -51177,7 +52057,7 @@ aKx
 aKx
 aKx
 aKx
-aEO
+wEX
 aEO
 aEO
 azb
@@ -51228,7 +52108,7 @@ bpc
 bpc
 bpc
 bpb
-boA
+oWE
 bjw
 btm
 sWC
@@ -51280,7 +52160,7 @@ bvP
 bvP
 bvP
 bvP
-bvP
+xIR
 bwF
 hqP
 bwF
@@ -51304,7 +52184,7 @@ hqP
 hqP
 xEN
 xEN
-xEN
+eyM
 xEN
 hqP
 aab
@@ -51341,7 +52221,7 @@ qVr
 xpB
 xpB
 jTD
-xpB
+tEj
 xpB
 xpB
 xpB
@@ -51454,7 +52334,7 @@ btP
 ukJ
 buv
 buv
-buv
+sQa
 bue
 hqP
 hqP
@@ -51514,7 +52394,7 @@ bEo
 bEo
 bEG
 byO
-bDN
+mGA
 bwF
 vKO
 hqP
@@ -51581,7 +52461,7 @@ anI
 aos
 ape
 apN
-ape
+diA
 aos
 anI
 asM
@@ -51705,7 +52585,7 @@ bAK
 bAW
 bwF
 bBp
-bBp
+iOS
 bBp
 bBp
 bBp
@@ -51727,7 +52607,7 @@ bER
 bxg
 bDN
 bEv
-bDN
+mGA
 bER
 bDZ
 bCZ
@@ -51929,7 +52809,7 @@ bBp
 bwF
 bvP
 bvP
-bvP
+xIR
 bvP
 bvP
 bwF
@@ -51996,7 +52876,7 @@ uLz
 xpB
 xpB
 xpB
-abq
+gdB
 qoL
 qVr
 qVr
@@ -52020,7 +52900,7 @@ aru
 anI
 asO
 atE
-apc
+rug
 anI
 atE
 aop
@@ -52207,7 +53087,7 @@ qoL
 qVr
 abq
 abq
-xpB
+tEj
 xpB
 uLz
 xpB
@@ -52294,7 +53174,7 @@ bgg
 bgg
 arw
 bjb
-bes
+xCj
 bes
 bes
 bes
@@ -52756,7 +53636,7 @@ btU
 bky
 yek
 bux
-bux
+fBi
 bux
 bux
 bux
@@ -52966,7 +53846,7 @@ bes
 bes
 bes
 bes
-bes
+xCj
 bki
 beq
 btU
@@ -53170,7 +54050,7 @@ bes
 bes
 bes
 bes
-bes
+xCj
 bes
 bes
 bes
@@ -53387,18 +54267,18 @@ bes
 bes
 bes
 bes
+xCj
 bes
 bes
 bes
 bes
-bes
-bes
+xCj
 bpX
 sFO
 bes
 bes
-bes
-bes
+xCj
+xCj
 bes
 bki
 beq
@@ -53424,7 +54304,7 @@ hqP
 xEN
 xEN
 xEN
-xEN
+eyM
 xEN
 xEN
 xEN
@@ -53598,7 +54478,7 @@ aXp
 bjb
 beq
 bhq
-bes
+xCj
 bes
 bes
 bes
@@ -53792,7 +54672,7 @@ aSg
 aSg
 aSg
 aTr
-aTq
+kRa
 aTq
 aXp
 aXp
@@ -53861,7 +54741,7 @@ xEN
 xEN
 jWg
 xEN
-xEN
+eyM
 xEN
 xOd
 xWD
@@ -53972,7 +54852,7 @@ aoB
 arx
 anI
 apU
-apU
+lDY
 aoB
 anI
 amW
@@ -54098,8 +54978,8 @@ jWg
 xEN
 xEN
 xEN
-xEN
-xEN
+eyM
+eyM
 xEN
 ajG
 hqP
@@ -54200,7 +55080,7 @@ ayw
 azc
 anI
 arD
-arD
+pgI
 amZ
 aCf
 aCo
@@ -54216,12 +55096,12 @@ aCZ
 aLE
 aQq
 aOZ
-aCo
+okb
 aMN
 aqV
 aTk
 aUk
-aKP
+ofX
 aKP
 aKP
 aSh
@@ -54378,7 +55258,7 @@ dnl
 kKe
 kKe
 ahw
-vCh
+eRH
 vCh
 vCh
 kKe
@@ -54427,7 +55307,7 @@ aCf
 aBv
 aIz
 wmv
-aIC
+mVk
 aLA
 bQk
 aCZ
@@ -54483,7 +55363,7 @@ bqB
 bqZ
 brD
 brD
-brD
+drW
 brD
 brD
 brD
@@ -54497,7 +55377,7 @@ bux
 bux
 bux
 bux
-bux
+fBi
 bux
 buM
 hqP
@@ -54648,7 +55528,7 @@ aIC
 aLB
 aCZ
 aIE
-aCZ
+rwd
 aIE
 aCZ
 aLE
@@ -54836,7 +55716,7 @@ anI
 aov
 apk
 aoB
-aoB
+vGv
 arz
 anI
 amV
@@ -55191,7 +56071,7 @@ jWg
 xEN
 jWg
 xEN
-xEN
+eyM
 xEN
 xEN
 xEN
@@ -55257,7 +56137,7 @@ vCh
 vCh
 vCh
 vCh
-vCh
+eRH
 vCh
 ahw
 vCh
@@ -55278,7 +56158,7 @@ anK
 anK
 anK
 atE
-apc
+rug
 avJ
 anI
 anI
@@ -55333,7 +56213,7 @@ beq
 bfw
 bhq
 bes
-bes
+xCj
 bes
 bes
 bes
@@ -55346,7 +56226,7 @@ oOR
 oOR
 oOR
 kIY
-bqa
+tBo
 bqa
 bqZ
 brD
@@ -55366,7 +56246,7 @@ bux
 bux
 bux
 bux
-bux
+fBi
 bux
 bux
 buM
@@ -55408,7 +56288,7 @@ xEN
 jWg
 xEN
 xEN
-xEN
+eyM
 xEN
 xEN
 xEN
@@ -55502,7 +56382,7 @@ avL
 arD
 arD
 arD
-arD
+pgI
 aBv
 aCj
 aCo
@@ -55539,7 +56419,7 @@ aVs
 aKP
 aKP
 ber
-beq
+hDx
 beq
 beq
 beq
@@ -55752,7 +56632,7 @@ aKP
 aKP
 aKP
 aKP
-aKP
+ofX
 aKP
 aKP
 bes
@@ -55799,7 +56679,7 @@ bfx
 buM
 bux
 bux
-bux
+fBi
 bux
 bux
 bux
@@ -55859,7 +56739,7 @@ hqP
 xEN
 xEN
 xEN
-xEN
+eyM
 xEN
 hqP
 hqP
@@ -56001,7 +56881,7 @@ bqa
 bqa
 bqZ
 brD
-brD
+drW
 brD
 bfx
 bfx
@@ -56116,7 +56996,7 @@ dnl
 dnl
 dnl
 kKe
-vCh
+eRH
 vCh
 vCh
 vCh
@@ -56259,7 +57139,7 @@ xEN
 xEN
 xEN
 xEN
-xEN
+eyM
 xEN
 xEN
 xEN
@@ -56373,7 +57253,7 @@ arD
 arD
 aBv
 aCZ
-aCZ
+rwd
 aCo
 aEY
 aCZ
@@ -56401,7 +57281,7 @@ aKP
 aKP
 aKP
 aKP
-aKP
+ofX
 aKP
 aKP
 aKP
@@ -56410,7 +57290,7 @@ bes
 bes
 bes
 bes
-bes
+xCj
 bes
 bes
 bes
@@ -56484,7 +57364,7 @@ xEN
 jWg
 xEN
 xEN
-xEN
+eyM
 xEN
 ajG
 xEN
@@ -56555,7 +57435,7 @@ kKe
 vCh
 vCh
 vCh
-vCh
+eRH
 vCh
 vCh
 vCh
@@ -56717,7 +57597,7 @@ xEN
 xEN
 xEN
 xEN
-xEN
+eyM
 xEN
 xEN
 xEN
@@ -56830,6 +57710,7 @@ aKP
 aKP
 aKP
 aKP
+ofX
 aKP
 aKP
 aKP
@@ -56839,7 +57720,6 @@ aKP
 aKP
 aKP
 aKP
-aKP
 bes
 bes
 bes
@@ -56853,7 +57733,7 @@ bes
 bes
 bes
 bes
-bki
+pqQ
 beq
 bkW
 aGo
@@ -56936,7 +57816,7 @@ xEN
 xEN
 xEN
 xEN
-xEN
+eyM
 xEN
 xEN
 xEN
@@ -57210,7 +58090,7 @@ dnl
 vCh
 vCh
 vCh
-ahw
+ozt
 vCh
 vCh
 vCh
@@ -57261,7 +58141,7 @@ aTr
 aTn
 aUk
 aKP
-aKP
+ofX
 aKP
 aKP
 aTr
@@ -57280,7 +58160,7 @@ bes
 bes
 bes
 bes
-bes
+xCj
 bes
 bes
 bes
@@ -57516,7 +58396,7 @@ xJh
 tzo
 tzo
 tzo
-tzo
+vwW
 tzo
 xJh
 tzo
@@ -57556,7 +58436,7 @@ jeY
 jeY
 eve
 fwQ
-eve
+cko
 eve
 eve
 eve
@@ -57671,7 +58551,7 @@ arD
 arD
 arD
 arD
-arD
+pgI
 arD
 aBy
 aDc
@@ -57685,7 +58565,7 @@ aGN
 aGN
 aGN
 aGN
-aGN
+mej
 aGN
 aGN
 aEi
@@ -57883,7 +58763,7 @@ dnl
 arD
 arD
 arD
-arD
+pgI
 arD
 arD
 arD
@@ -58113,7 +58993,7 @@ aEi
 aDg
 aEi
 aEi
-aEi
+wjy
 aEi
 aEi
 aEi
@@ -58151,7 +59031,7 @@ bfx
 bfx
 bes
 bes
-bes
+xCj
 bes
 bes
 bes
@@ -58355,7 +59235,7 @@ aZi
 bap
 baT
 bbF
-bap
+cnH
 baT
 aZi
 aZf
@@ -58554,7 +59434,7 @@ aKO
 aEi
 aDc
 aEi
-aGN
+mej
 aGN
 aQs
 aBy
@@ -58570,7 +59450,7 @@ aYv
 aZg
 aZi
 bar
-baU
+oAW
 bbF
 bar
 baU
@@ -58665,7 +59545,7 @@ wrk
 wrk
 wrk
 szH
-ncd
+irg
 dCk
 ncd
 wqH
@@ -58739,7 +59619,7 @@ dnl
 dnl
 vCh
 vCh
-vCh
+eRH
 vCh
 ahw
 vCh
@@ -58805,7 +59685,7 @@ bes
 bes
 bes
 bes
-bes
+xCj
 bes
 bes
 oOR
@@ -58881,13 +59761,13 @@ cCv
 vQS
 vQS
 vQS
-csO
+aSW
 vQS
 vQS
 vQS
 qhe
 vQS
-vQS
+ezq
 vQS
 vQS
 cCv
@@ -58939,7 +59819,7 @@ vCh
 vCh
 vCh
 vCh
-vCh
+eRH
 vCh
 vCh
 vCh
@@ -59011,7 +59891,7 @@ baU
 aZi
 aZf
 bes
-bes
+xCj
 bes
 bes
 bes
@@ -59323,7 +60203,7 @@ kcV
 wrk
 wrk
 iCy
-wrk
+hJA
 wrk
 wrk
 wrk
@@ -59332,7 +60212,7 @@ kcV
 wrk
 wrk
 wrk
-iCy
+daR
 wrk
 hjc
 csO
@@ -59647,7 +60527,7 @@ aQu
 aTr
 aUp
 aQu
-aVr
+eXJ
 aKP
 aKP
 aSh
@@ -59668,7 +60548,7 @@ bes
 bfx
 bes
 bes
-bes
+xCj
 bes
 bes
 bes
@@ -59836,7 +60716,7 @@ afX
 vCh
 vCh
 ahw
-vCh
+eRH
 vCh
 kKe
 dnl
@@ -59873,7 +60753,7 @@ aZg
 aZi
 bar
 baU
-bbF
+bTI
 bar
 baU
 dqo
@@ -60389,7 +61269,7 @@ jeY
 eve
 eve
 eve
-eve
+cko
 eve
 eve
 eve
@@ -60454,7 +61334,7 @@ dnl
 vCh
 vCh
 vCh
-vCh
+eRH
 vCh
 dnl
 ptP
@@ -60475,7 +61355,7 @@ dnl
 adZ
 ank
 afz
-afy
+vRK
 app
 adZ
 ptP
@@ -60568,7 +61448,7 @@ oOR
 oOR
 oOR
 oOR
-uMP
+sUj
 tzo
 tzo
 tzo
@@ -60606,7 +61486,7 @@ eve
 eve
 eve
 eve
-eve
+cko
 eve
 eve
 eve
@@ -61116,7 +61996,7 @@ afu
 aga
 agK
 ahA
-afu
+lDO
 afu
 ajk
 afz
@@ -61136,7 +62016,7 @@ aaR
 adZ
 abb
 ltt
-auY
+tag
 asq
 arH
 adZ
@@ -61347,7 +62227,7 @@ aoF
 aps
 adZ
 aqZ
-arF
+hLW
 aso
 atd
 atI
@@ -61453,7 +62333,7 @@ xvL
 xvL
 eve
 xvL
-eve
+cko
 eve
 eve
 eve
@@ -61570,7 +62450,7 @@ ate
 atJ
 auk
 auY
-auY
+tag
 awB
 kpd
 adZ
@@ -61983,7 +62863,7 @@ adZ
 abO
 agc
 agc
-agd
+trV
 aim
 adZ
 afy
@@ -61993,7 +62873,7 @@ anL
 afz
 amI
 afz
-afz
+pqp
 tNb
 afy
 adZ
@@ -62120,7 +63000,7 @@ eve
 eve
 eve
 eve
-eve
+cko
 eve
 eve
 eve
@@ -62191,7 +63071,7 @@ vCh
 vCh
 vCh
 vCh
-vCh
+eRH
 dnl
 ptP
 dnl
@@ -62207,7 +63087,7 @@ ajn
 adZ
 afz
 afz
-afz
+pqp
 amI
 afz
 anN
@@ -62448,7 +63328,7 @@ adZ
 aAM
 aAO
 aAO
-aAO
+txA
 adZ
 dnl
 dnl
@@ -62558,7 +63438,7 @@ eve
 eve
 eve
 eve
-eve
+cko
 eve
 eve
 eve
@@ -62645,7 +63525,7 @@ alL
 amJ
 adZ
 alL
-amJ
+jmv
 adZ
 aqb
 aqb
@@ -62657,8 +63537,8 @@ aup
 agd
 aqc
 auY
-aqc
-aqc
+bHx
+bHx
 auY
 adZ
 adZ
@@ -62693,7 +63573,7 @@ vCh
 tzo
 tzo
 xJh
-tzo
+vwW
 tzo
 tzo
 uMP
@@ -62859,7 +63739,7 @@ adZ
 rvh
 adZ
 alM
-amL
+rEI
 adZ
 anP
 amL
@@ -62880,7 +63760,7 @@ ayB
 adZ
 adZ
 aAO
-aAO
+txA
 aAO
 aAO
 adZ
@@ -62944,7 +63824,7 @@ tzo
 xJh
 tzo
 tzo
-tzo
+vwW
 tzo
 tzo
 tzo
@@ -62963,7 +63843,7 @@ tzo
 uMP
 bLJ
 eve
-eve
+cko
 xvL
 eve
 eve
@@ -63168,7 +64048,7 @@ tzo
 tzo
 tzo
 tzo
-tzo
+vwW
 tzo
 ttW
 oOR
@@ -63273,7 +64153,7 @@ dnl
 dnl
 dnl
 vCh
-ahw
+ozt
 vCh
 vCh
 vCh
@@ -63360,7 +64240,7 @@ tzo
 tzo
 tzo
 uMP
-uMP
+sUj
 uMP
 uMP
 uMP
@@ -63385,7 +64265,7 @@ tzo
 xJh
 tzo
 tzo
-tzo
+vwW
 tzo
 tzo
 uMP
@@ -63774,7 +64654,7 @@ kKe
 afY
 vCh
 ahw
-vCh
+eRH
 tzo
 tzo
 oOR
@@ -63802,7 +64682,7 @@ kPf
 tzo
 tzo
 tzo
-uMP
+sUj
 tzo
 tzo
 tzo
@@ -63947,7 +64827,7 @@ alc
 amN
 anr
 anT
-alc
+upv
 alc
 aqe
 adZ
@@ -64161,7 +65041,7 @@ adZ
 akA
 alc
 alc
-alc
+upv
 alc
 anT
 alc
@@ -64521,7 +65401,7 @@ vQS
 vQS
 vQS
 vQS
-vQS
+ezq
 vQS
 csO
 vQS
@@ -64742,7 +65622,7 @@ vQS
 vQS
 csO
 vQS
-vQS
+ezq
 vQS
 vQS
 vQS
@@ -64825,7 +65705,7 @@ ath
 agd
 auu
 avh
-agd
+trV
 agd
 adw
 adZ
@@ -64976,7 +65856,7 @@ csO
 vQS
 vQS
 vQS
-vQS
+ezq
 vQS
 xqW
 sTd
@@ -65327,10 +66207,10 @@ oOR
 tzo
 tzo
 xJh
+vwW
 tzo
 tzo
-tzo
-xJh
+fvC
 tzo
 uMP
 ttZ
@@ -65447,7 +66327,7 @@ dnl
 dnl
 vCh
 vCh
-ahw
+ozt
 vCh
 vCh
 vCh
@@ -65476,7 +66356,7 @@ liQ
 agj
 avk
 avk
-agd
+trV
 awJ
 axt
 adZ
@@ -65501,10 +66381,10 @@ amE
 amE
 amE
 amE
+kgG
 amE
 amE
-amE
-amE
+kgG
 amE
 amE
 aEu
@@ -65680,11 +66560,11 @@ adZ
 akF
 alf
 alf
-alf
+dFM
 anv
 aob
 alf
-alf
+dFM
 aqk
 adZ
 adZ
@@ -65715,7 +66595,7 @@ aIN
 ydN
 amE
 amE
-amE
+kgG
 wSP
 amE
 amE
@@ -65891,7 +66771,7 @@ agi
 agZ
 adZ
 aiq
-agd
+trV
 ajs
 adZ
 akG
@@ -66045,7 +66925,7 @@ jeY
 jeY
 fwQ
 eve
-eve
+cko
 eve
 eve
 jeY
@@ -66100,7 +66980,7 @@ dnl
 vCh
 vCh
 vCh
-ahw
+ozt
 vCh
 vTV
 adZ
@@ -66333,7 +67213,7 @@ ali
 alW
 amT
 alW
-alX
+fFc
 alW
 oWn
 aqn
@@ -66372,7 +67252,7 @@ dnl
 oCk
 vST
 rVZ
-rVZ
+hgY
 rVZ
 bHv
 dnl
@@ -66541,7 +67421,7 @@ afH
 agj
 agd
 ahM
-agd
+trV
 agj
 ajt
 adZ
@@ -66750,7 +67630,7 @@ dnl
 dnl
 vCh
 vCh
-vCh
+eRH
 vCh
 vCh
 vTV
@@ -67005,7 +67885,7 @@ aAU
 aAU
 afv
 aDq
-agj
+ipm
 agd
 aGi
 rNZ
@@ -67051,8 +67931,8 @@ tzo
 tzo
 oOR
 oOR
-oOR
-oOR
+rxs
+rxs
 oOR
 oOR
 oOR
@@ -67095,7 +67975,7 @@ eve
 eve
 eve
 eve
-eve
+cko
 eve
 eve
 eve
@@ -67560,7 +68440,7 @@ jeY
 jeY
 jeY
 eve
-eve
+cko
 eve
 jeY
 jeY
@@ -67667,7 +68547,7 @@ aJQ
 auy
 aLJ
 aMt
-aLK
+cRV
 aLK
 aPq
 aQw
@@ -67693,7 +68573,7 @@ tzo
 tzo
 tzo
 tzo
-tzo
+vwW
 xJh
 tzo
 tzo
@@ -67704,7 +68584,7 @@ oOR
 oOR
 oOR
 oOR
-oOR
+rxs
 oOR
 oOR
 oOR
@@ -67740,8 +68620,8 @@ eve
 eve
 eve
 eve
-eve
-eve
+cko
+cko
 eve
 eve
 eve
@@ -67924,7 +68804,7 @@ oOR
 oOR
 oOR
 oOR
-oOR
+rxs
 oOR
 oOR
 oOR
@@ -67948,7 +68828,7 @@ tzo
 xJh
 tzo
 tzo
-tzo
+vwW
 xJh
 tzo
 tzo
@@ -68013,7 +68893,7 @@ sTd
 pst
 wrk
 vxE
-uad
+jgd
 sTd
 aab
 aaa
@@ -68054,7 +68934,7 @@ dnl
 dnl
 vCh
 ahw
-vCh
+eRH
 hLA
 adZ
 adZ
@@ -68092,7 +68972,7 @@ afv
 aDq
 agd
 agd
-aFo
+nbJ
 eIN
 aFp
 afv
@@ -68388,7 +69268,7 @@ tzo
 tzo
 eve
 eve
-eve
+cko
 eve
 eve
 eve
@@ -68502,7 +69382,7 @@ kKe
 vCh
 vCh
 vCh
-vCh
+eRH
 ahw
 vCh
 vCh
@@ -68589,6 +69469,13 @@ tzo
 tzo
 tzo
 tzo
+vwW
+tzo
+xJh
+tzo
+tzo
+tzo
+vwW
 tzo
 tzo
 xJh
@@ -68596,16 +69483,9 @@ tzo
 tzo
 tzo
 tzo
-tzo
-tzo
-xJh
-tzo
-tzo
-tzo
-tzo
 eve
 eve
-eve
+cko
 eve
 eve
 eve
@@ -68777,7 +69657,7 @@ tzo
 tzo
 xJh
 tzo
-tzo
+vwW
 tzo
 tzo
 tzo
@@ -68812,7 +69692,7 @@ tzo
 tzo
 tzo
 uMP
-tzo
+vwW
 tzo
 tzo
 tzo
@@ -68921,7 +69801,7 @@ vCh
 vCh
 vCh
 vCh
-vCh
+eRH
 vCh
 vCh
 vCh
@@ -68932,7 +69812,7 @@ vCh
 vCh
 vCh
 uLR
-vCh
+eRH
 cfS
 vCh
 vCh
@@ -68987,7 +69867,7 @@ oOR
 tzo
 tzo
 tzo
-tzo
+vwW
 tzo
 tzo
 tzo
@@ -69204,7 +70084,7 @@ tzo
 tzo
 tzo
 tzo
-tzo
+vwW
 xJh
 tzo
 xJh
@@ -69444,7 +70324,7 @@ tzo
 tzo
 tzo
 tzo
-tzo
+vwW
 tzo
 tzo
 tzo
@@ -69572,7 +70452,7 @@ vCh
 vCh
 vCh
 vCh
-vCh
+eRH
 vCh
 vCh
 vCh
@@ -69660,7 +70540,7 @@ tzo
 tzo
 tzo
 tzo
-tzo
+vwW
 tzo
 mqf
 tzo
@@ -69728,7 +70608,7 @@ eve
 eve
 eve
 eve
-eve
+cko
 eve
 jeY
 jeY
@@ -69880,7 +70760,7 @@ tzo
 tzo
 tzo
 tzo
-tzo
+vwW
 tzo
 tzo
 tzo
@@ -69959,7 +70839,7 @@ ePv
 gsZ
 ePv
 vlA
-vlA
+oPw
 vlA
 vlA
 hnZ
@@ -70012,7 +70892,7 @@ vCh
 kKe
 kKe
 vCh
-vCh
+eRH
 vCh
 vCh
 dnl
@@ -70290,7 +71170,7 @@ tzo
 tzo
 tzo
 tzo
-tzo
+vwW
 tzo
 tzo
 uMP
@@ -70467,10 +71347,10 @@ vCh
 vCh
 vCh
 vCh
-vCh
+eRH
 xNf
 uLR
-ahw
+ozt
 vCh
 vCh
 vCh
@@ -70604,7 +71484,7 @@ jeY
 sTd
 coa
 vlA
-dYK
+qVB
 vlA
 lrE
 gsZ
@@ -70657,7 +71537,7 @@ vCh
 vCh
 vCh
 xNf
-vCh
+eRH
 vCh
 vCh
 vCh
@@ -71161,7 +72041,7 @@ tzo
 tzo
 tzo
 tzo
-tzo
+vwW
 tzo
 tzo
 oOR
@@ -71255,7 +72135,7 @@ jeY
 sTd
 nVP
 lHD
-vlA
+oPw
 vlA
 fnW
 gCH
@@ -71334,7 +72214,7 @@ vCh
 vCh
 vCh
 vCh
-vCh
+eRH
 vCh
 xNf
 uLR
@@ -71343,7 +72223,7 @@ vCh
 vCh
 vCh
 vCh
-vCh
+eRH
 vCh
 vCh
 vCh
@@ -71366,7 +72246,7 @@ hLA
 vCh
 vCh
 vCh
-vCh
+eRH
 vCh
 vCh
 ahw
@@ -71481,7 +72361,7 @@ hRb
 ekE
 ekE
 wrk
-wrk
+hJA
 qcC
 tAB
 wrk
@@ -71701,7 +72581,7 @@ lrE
 lrE
 qfQ
 tCQ
-vuE
+vFJ
 uad
 sTd
 aab
@@ -72007,7 +72887,7 @@ vCh
 vCh
 vCh
 ahw
-vCh
+eRH
 vCh
 vCh
 vCh
@@ -72558,7 +73438,7 @@ sTd
 cMC
 fuB
 lHD
-vlA
+oPw
 fAC
 gZX
 hTI

--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -175,10 +175,9 @@
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/space_port)
 "aaQ" = (
-/obj/structure/table,
-/obj/effect/spawner/random/toolbox,
-/obj/effect/spawner/random/tool,
-/turf/open/floor/tile/dark,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/closed/wall/r_wall/unmeltable,
 /area/bigredv2/outside/space_port)
 "aaR" = (
 /obj/structure/cable,
@@ -264,19 +263,14 @@
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/space_port)
 "abg" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/bigredv2/outside/space_port)
-"abh" = (
-/obj/structure/table,
-/obj/effect/spawner/random/toolbox,
 /obj/machinery/door_control{
 	id = "Spaceport";
 	name = "Storm Shutters";
 	pixel_x = 32
 	},
+/turf/open/floor/tile/dark,
+/area/bigredv2/outside/space_port)
+"abh" = (
 /obj/item/tool/pen,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/space_port)
@@ -380,9 +374,8 @@
 /turf/open/floor/plating,
 /area/bigredv2/outside/space_port)
 "abz" = (
-/obj/structure/table,
-/obj/effect/spawner/random/powercell,
-/turf/open/floor/tile/dark,
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
 /area/bigredv2/outside/space_port)
 "abA" = (
 /obj/structure/bed/chair/office/dark,
@@ -390,10 +383,10 @@
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/space_port)
 "abB" = (
-/obj/structure/table,
-/obj/effect/spawner/random/tool,
-/obj/effect/spawner/random/tech_supply,
-/turf/open/floor/tile/dark,
+/obj/machinery/light/built{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
 /area/bigredv2/outside/space_port)
 "abC" = (
 /obj/machinery/light{
@@ -438,8 +431,6 @@
 /turf/open/floor/tile/darkgreen/darkgreen2,
 /area/bigredv2/outside/space_port)
 "abK" = (
-/obj/structure/table,
-/obj/effect/spawner/random/tool,
 /turf/open/floor/tile/darkgreen/darkgreen2{
 	dir = 6
 	},
@@ -473,13 +464,14 @@
 /turf/open/floor/plating,
 /area/bigredv2/outside/space_port)
 "abS" = (
-/obj/effect/decal/cleanable/blood/gibs,
-/obj/structure/window_frame/colony,
-/turf/open/floor/plating,
+/obj/structure/cargo_container{
+	dir = 8
+	},
+/turf/open/shuttle/elevator/grating,
 /area/bigredv2/outside/space_port)
 "abT" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/window_frame/colony,
+/obj/machinery/door/airlock/multi_tile/mainship/generic,
 /turf/open/floor/plating,
 /area/bigredv2/outside/space_port)
 "abU" = (
@@ -920,15 +912,10 @@
 /turf/open/floor/tile/darkish,
 /area/bigredv2/caves/lambda_lab)
 "adx" = (
-/obj/machinery/button/door/open_only/landing_zone{
-	desc = "What could this be for? It Requires an authorized ID or higher to activate";
-	id = "Secure_1"
-	},
-/obj/structure/closet/secure_closet/RD,
-/turf/open/floor/tile/dark/blue2{
-	dir = 1
-	},
-/area/bigredv2/outside/nanotrasen_lab/inside)
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/northwest)
 "ady" = (
 /obj/structure/bed/chair,
 /turf/open/floor/tile/darkish,
@@ -1922,9 +1909,12 @@
 /turf/open/floor/plating/dmg3,
 /area/bigredv2/outside/space_port)
 "ahh" = (
-/obj/structure/girder/reinforced,
-/turf/open/floor/plating/dmg2,
-/area/bigredv2/outside/space_port)
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 1
+	},
+/area/bigredv2/caves/northwest)
 "ahj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/red/redtaupecorner,
@@ -2110,28 +2100,20 @@
 	},
 /area/bigredv2/outside/nw)
 "ahW" = (
-/obj/item/stack/rods,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
+/turf/open/floor/marking/asteroidwarning{
+	dir = 1
 	},
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/bigredv2/outside/nw)
+/area/bigredv2/caves/northwest)
 "ahX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/nw)
 "ahY" = (
-/obj/item/stack/sheet/metal,
-/obj/item/stack/rods,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
+/turf/open/floor/marking/asteroidwarning{
+	dir = 5
 	},
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/bigredv2/outside/nw)
+/area/bigredv2/caves/northwest)
 "ahZ" = (
-/obj/item/stack/rods,
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
@@ -5131,7 +5113,7 @@
 	name = "\improper Cargo Shutters"
 	},
 /turf/open/floor/plating,
-/area/bigredv2/outside/cargo)
+/area/mint)
 "asy" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -5357,11 +5339,11 @@
 /turf/open/floor/plating,
 /area/bigredv2/outside/engineering)
 "atl" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/marking/asteroidwarning{
-	dir = 9
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 2
 	},
-/area/bigredv2/outside/nw)
+/turf/open/floor/tile/dark,
+/area/bigredv2/outside/space_port)
 "atm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/marking/asteroidwarning{
@@ -6631,12 +6613,10 @@
 	},
 /area/bigredv2/outside/nw)
 "axX" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/asteroidfloor,
-/area/bigredv2/outside/nw)
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/marking/asteroidwarning,
+/area/bigredv2/caves/northwest)
 "axY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -6680,10 +6660,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/machinery/light,
 /obj/structure/cable,
-/turf/open/floor/tile/white,
-/area/bigredv2/outside/medical)
+/turf/open/floor/asteroidfloor,
+/area/bigredv2/outside/nw)
 "ayf" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -8136,13 +8115,8 @@
 	},
 /area/bigredv2/outside/nw)
 "aDx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 5
-	},
-/turf/open/floor/asteroidfloor,
-/area/bigredv2/outside/nw)
+/turf/open/floor/marking/asteroidwarning,
+/area/bigredv2/caves/northwest)
 "aDy" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -8653,10 +8627,10 @@
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/virology)
 "aFw" = (
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 9
+/turf/open/floor/marking/asteroidwarning{
+	dir = 6
 	},
-/area/bigredv2/outside/virology)
+/area/bigredv2/caves/northwest)
 "aFx" = (
 /turf/open/floor/tile/blue/whitebluefull,
 /area/bigredv2/outside/medical)
@@ -8919,6 +8893,7 @@
 	},
 /area/bigredv2/caves/west)
 "aGr" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 1
 	},
@@ -10052,6 +10027,7 @@
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/virology)
 "aKj" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 10
 	},
@@ -11568,11 +11544,11 @@
 	},
 /area/bigredv2/caves/lambda_lab)
 "aSn" = (
-/obj/effect/landmark/xeno_turret_spawn,
-/turf/open/floor/tile/dark/blue2{
-	dir = 6
+/obj/structure/cargo_container/green{
+	dir = 1
 	},
-/area/bigredv2/outside/nanotrasen_lab/inside)
+/turf/open/floor/plating/plating_catwalk,
+/area/bigredv2/outside/space_port)
 "aSo" = (
 /obj/structure/curtain/medical,
 /turf/open/floor/tile/green/whitegreen{
@@ -12331,11 +12307,11 @@
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/virology)
 "aVF" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/marking/asteroidwarning{
-	dir = 9
+/obj/structure/cargo_container/green{
+	dir = 1
 	},
-/area/shuttle/drop2/lz2)
+/turf/open/shuttle/elevator/grating,
+/area/bigredv2/outside/space_port)
 "aVG" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 1
@@ -13391,6 +13367,7 @@
 	},
 /area/bigredv2/outside/w)
 "bbK" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/marking/asteroidwarning{
 	dir = 9
 	},
@@ -13474,7 +13451,7 @@
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 1
 	},
-/area/bigredv2/outside/sw)
+/area/mint)
 "bcr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/marking/asteroidwarning{
@@ -14098,6 +14075,7 @@
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
 "bfF" = (
@@ -14378,19 +14356,19 @@
 /area/shuttle/drop2/lz2)
 "bhb" = (
 /turf/open/floor/tile/lightred/full,
-/area/bigredv2/outside/cargo)
+/area/mint)
 "bhc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	on = 1
 	},
 /turf/open/floor/tile/lightred/full,
-/area/bigredv2/outside/cargo)
+/area/mint)
 "bhd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/lightred/full,
-/area/bigredv2/outside/cargo)
+/area/mint)
 "bhg" = (
 /obj/structure/table,
 /obj/effect/spawner/random/toolbox,
@@ -14491,14 +14469,14 @@
 "bhD" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/lightred/full,
-/area/bigredv2/outside/cargo)
+/area/mint)
 "bhE" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor,
-/area/bigredv2/outside/cargo)
+/area/mint)
 "bhG" = (
 /obj/structure/cable,
 /turf/open/floor,
@@ -14645,21 +14623,21 @@
 "bii" = (
 /obj/structure/cable,
 /turf/open/floor/tile/lightred/full,
-/area/bigredv2/outside/cargo)
+/area/mint)
 "bij" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
 	},
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/cargo)
+/area/mint)
 "bik" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/lightred/full,
-/area/bigredv2/outside/cargo)
+/area/mint)
 "bil" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -14673,12 +14651,12 @@
 	},
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/cargo)
+/area/mint)
 "bin" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /obj/structure/cable,
 /turf/open/floor,
-/area/bigredv2/outside/cargo)
+/area/mint)
 "bip" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
@@ -14787,7 +14765,7 @@
 	name = "Colonist Ethan Peser"
 	},
 /turf/open/floor,
-/area/bigredv2/outside/cargo)
+/area/mint)
 "biL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/megaphone,
@@ -14870,12 +14848,12 @@
 	dir = 9
 	},
 /turf/open/floor,
-/area/bigredv2/outside/cargo)
+/area/mint)
 "bjh" = (
 /obj/item/reagent_containers/spray/cleaner,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor,
-/area/bigredv2/outside/cargo)
+/area/mint)
 "bji" = (
 /obj/item/reagent_containers/glass/bottle/tramadol,
 /turf/open/floor,
@@ -14915,7 +14893,7 @@
 /obj/effect/decal/warning_stripes,
 /obj/machinery/constructable_frame/state_2,
 /turf/open/floor,
-/area/bigredv2/outside/cargo)
+/area/mint)
 "bju" = (
 /obj/machinery/door/airlock/mainship/engineering/free_access{
 	name = "\improper Cargo Bay Storage"
@@ -15022,13 +15000,13 @@
 /obj/item/clothing/ears/earmuffs,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor,
-/area/bigredv2/outside/cargo)
+/area/mint)
 "bjQ" = (
 /obj/effect/decal/warning_stripes{
 	icon_state = "W-corner"
 	},
 /turf/open/floor,
-/area/bigredv2/outside/cargo)
+/area/mint)
 "bjR" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/machinery/door/airlock/mainship/engineering/free_access{
@@ -15036,7 +15014,7 @@
 	name = "\improper Cargo Bay Quartermaster"
 	},
 /turf/open/floor,
-/area/bigredv2/outside/cargo)
+/area/mint)
 "bjX" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor,
@@ -15093,22 +15071,23 @@
 /obj/effect/decal/warning_stripes,
 /obj/machinery/constructable_frame,
 /turf/open/floor,
-/area/bigredv2/outside/cargo)
+/area/mint)
 "bkl" = (
 /obj/structure/filingcabinet,
 /turf/open/floor,
-/area/bigredv2/outside/cargo)
+/area/mint)
 "bkm" = (
 /obj/structure/filingcabinet,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor,
-/area/bigredv2/outside/cargo)
+/area/mint)
 "bkn" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor,
-/area/bigredv2/outside/cargo)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/asteroidfloor,
+/area/bigredv2/outside/space_port)
 "bko" = (
 /obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
@@ -15167,11 +15146,11 @@
 	name = "\improper Cargo Bay Quartermaster"
 	},
 /turf/open/floor,
-/area/bigredv2/outside/cargo)
+/area/mint)
 "bkA" = (
 /obj/structure/bed/chair/office/dark,
 /turf/open/floor,
-/area/bigredv2/outside/cargo)
+/area/mint)
 "bkB" = (
 /obj/machinery/computer/arcade,
 /obj/machinery/light{
@@ -15288,7 +15267,7 @@
 /obj/structure/table,
 /obj/machinery/light,
 /turf/open/floor,
-/area/bigredv2/outside/cargo)
+/area/mint)
 "blb" = (
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
@@ -15305,7 +15284,7 @@
 /obj/effect/spawner/random/tool,
 /obj/effect/spawner/random/tool,
 /turf/open/floor,
-/area/bigredv2/outside/cargo)
+/area/mint)
 "ble" = (
 /obj/structure/table,
 /turf/open/floor,
@@ -15314,11 +15293,11 @@
 /obj/structure/table,
 /obj/item/radio/survivor,
 /turf/open/floor,
-/area/bigredv2/outside/cargo)
+/area/mint)
 "blg" = (
 /obj/machinery/computer/ordercomp,
 /turf/open/floor,
-/area/bigredv2/outside/cargo)
+/area/mint)
 "bli" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor,
@@ -15351,12 +15330,9 @@
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
 "blo" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor,
-/area/bigredv2/outside/cargo)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/bigredv2/outside/virology)
 "blp" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/toolbox,
@@ -15404,6 +15380,12 @@
 /obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
+"blA" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/warning{
+	dir = 4
+	},
+/area/bigredv2/outside/virology)
 "blB" = (
 /obj/effect/landmark/start/job/survivor,
 /obj/effect/decal/cleanable/dirt,
@@ -15986,19 +15968,9 @@
 	dir = 5
 	},
 /area/bigredv2/outside/se)
-"boC" = (
-/obj/structure/cable,
-/turf/open/floor/marking/asteroidwarning{
-	dir = 4
-	},
-/area/bigredv2/outside/sw)
 "boD" = (
 /obj/structure/cable,
-/obj/machinery/door/airlock/multi_tile/mainship/generic{
-	dir = 1;
-	name = "\improper Engineering Complex"
-	},
-/turf/open/floor,
+/turf/closed/wall/r_wall,
 /area/bigredv2/outside/engineering)
 "boG" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
@@ -16093,6 +16065,11 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"bph" = (
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 6
+	},
+/area/bigredv2/caves/northwest)
 "bpi" = (
 /obj/machinery/light{
 	dir = 8
@@ -16168,19 +16145,15 @@
 	dir = 5
 	},
 /area/bigredv2/caves/east)
-"bpv" = (
-/turf/open/floor/asteroidfloor,
-/area/bigredv2/outside/sw)
 "bpx" = (
-/turf/open/floor/plating/ground/mars/dirttosand{
-	dir = 6
-	},
-/area/shuttle/drop2/lz2)
+/obj/machinery/light,
+/turf/open/floor/plating,
+/area/bigredv2/outside/virology)
 "bpy" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 5
 	},
-/area/bigredv2/outside/sw)
+/area/mint)
 "bpz" = (
 /obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
@@ -16428,17 +16401,14 @@
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/se)
 "bqG" = (
-/obj/structure/cable,
-/turf/open/floor/marking/asteroidwarning{
-	dir = 1
-	},
-/area/bigredv2/outside/sw)
+/turf/closed/wall/r_wall,
+/area/bigredv2/caves/west)
 "bqH" = (
 /obj/structure/cable,
 /turf/open/floor/marking/asteroidwarning{
 	dir = 5
 	},
-/area/bigredv2/outside/sw)
+/area/mint)
 "bqI" = (
 /obj/machinery/vending/snack{
 	icon_state = "snack-broken"
@@ -16524,10 +16494,10 @@
 /turf/open/floor/marking/asteroidwarning{
 	dir = 4
 	},
-/area/bigredv2/caves/southwest)
+/area/mint)
 "brd" = (
-/turf/open/floor/marking/asteroidwarning,
-/area/bigredv2/outside/sw)
+/turf/closed/mineral/bigred,
+/area/shuttle/drop2/lz2)
 "bre" = (
 /obj/structure/bed/chair,
 /turf/open/floor,
@@ -16632,11 +16602,6 @@
 "brE" = (
 /turf/open/floor/podhatch/floor,
 /area/bigredv2/outside/se)
-"brG" = (
-/turf/open/floor/marking/asteroidwarning{
-	dir = 8
-	},
-/area/bigredv2/outside/sw)
 "brI" = (
 /obj/item/stack/sheet/metal{
 	amount = 30
@@ -16940,7 +16905,7 @@
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 8
 	},
-/area/bigredv2/outside/sw)
+/area/mint)
 "btr" = (
 /obj/machinery/computer/station_alert,
 /obj/structure/table,
@@ -17103,7 +17068,7 @@
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 9
 	},
-/area/bigredv2/outside/sw)
+/area/mint)
 "buD" = (
 /turf/open/floor/plating,
 /area/bigredv2/outside/engineering)
@@ -17134,17 +17099,12 @@
 /turf/open/floor/marking/asteroidwarning{
 	dir = 1
 	},
-/area/bigredv2/caves/southwest)
+/area/mint)
 "buQ" = (
 /turf/open/floor/marking/asteroidwarning{
 	dir = 5
 	},
-/area/bigredv2/caves/southwest)
-"buS" = (
-/turf/open/floor/plating/ground/mars/cavetodirt{
-	dir = 1
-	},
-/area/bigredv2/outside/sw)
+/area/mint)
 "buV" = (
 /obj/machinery/light,
 /turf/open/floor/plating,
@@ -19316,6 +19276,15 @@
 "bHv" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/space)
+"bKc" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/bigredv2/outside/cargo)
+"bLl" = (
+/obj/structure/table,
+/obj/effect/spawner/random/toolbox,
+/turf/open/floor,
+/area/mint)
 "bLJ" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -19337,6 +19306,14 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/bigredv2/caves/southeast)
+"bOD" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/marking/asteroidwarning{
+	dir = 1
+	},
+/area/bigredv2/outside/nw)
 "bQc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
@@ -19376,14 +19353,22 @@
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/northwest)
 "bZF" = (
-/obj/docking_port/stationary/crashmode,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/bigredv2/caves/northwest)
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/outside/nw)
 "caa" = (
 /obj/structure/cable,
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
 /area/bigredv2/caves/southeast)
+"cbC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 8
+	},
+/area/bigredv2/outside/virology)
 "ccx" = (
 /obj/effect/decal/warning_stripes/thick{
 	dir = 1
@@ -19397,6 +19382,11 @@
 /obj/docking_port/stationary/crashmode,
 /turf/closed/wall,
 /area/bigredv2/outside/office_complex)
+"cdF" = (
+/turf/open/floor/marking/asteroidwarning{
+	dir = 1
+	},
+/area/bigredv2/caves/west)
 "ceT" = (
 /obj/machinery/light{
 	dir = 1
@@ -19450,6 +19440,10 @@
 	},
 /turf/open/floor/prison/darkred/full,
 /area/bigredv2/caves/southeast)
+"ctr" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/bigredv2/caves/northwest)
 "ctE" = (
 /turf/open/shuttle/escapepod/five,
 /area/bigredv2/caves/north)
@@ -19501,7 +19495,7 @@
 /area/bigredv2/caves/southeast)
 "cBD" = (
 /turf/open/floor/plating/ground/mars/dirttosand,
-/area/bigredv2/outside/sw)
+/area/mint)
 "cBO" = (
 /obj/machinery/door/airlock/mainship/maint,
 /turf/open/shuttle/escapepod,
@@ -19562,6 +19556,10 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/northwest)
+"cSm" = (
+/obj/structure/cable,
+/turf/open/floor/marking/asteroidwarning,
+/area/bigredv2/outside/nw)
 "cTg" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/structure/bookcase/manuals,
@@ -19577,6 +19575,10 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/bigredv2/caves/southeast)
+"cUN" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/warning,
+/area/bigredv2/outside/virology)
 "cWF" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral/bigred,
@@ -19648,6 +19650,17 @@
 /obj/effect/landmark/corpsespawner,
 /turf/open/floor/prison/darkred/full,
 /area/bigredv2/caves/southeast)
+"djh" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/asteroidfloor,
+/area/mint)
+"djA" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 1;
+	name = "\improper Engineering Complex"
+	},
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/west)
 "djI" = (
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/wood,
@@ -19679,10 +19692,6 @@
 "dnl" = (
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/northeast)
-"dpt" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/closed/mineral/bigred,
-/area/bigredv2/caves/southwest)
 "dqo" = (
 /obj/structure/cable,
 /turf/open/floor/tile/darkish,
@@ -19690,10 +19699,6 @@
 "dry" = (
 /turf/open/floor/tile/dark/red2/corner,
 /area/bigredv2/caves/south)
-"dsH" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/bigredv2/outside/w)
 "dtj" = (
 /obj/structure/toilet{
 	dir = 8
@@ -19705,7 +19710,7 @@
 	dir = 2
 	},
 /turf/open/floor/freezer,
-/area/bigredv2/outside/virology)
+/area/mint)
 "dwi" = (
 /obj/effect/landmark/corpsespawner/security,
 /turf/open/floor/tile/dark,
@@ -19726,6 +19731,10 @@
 /obj/structure/cable,
 /turf/open/shuttle/escapepod,
 /area/bigredv2/caves/southeast)
+"dAz" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/bigredv2/outside/virology)
 "dCk" = (
 /obj/machinery/light{
 	dir = 8
@@ -19782,11 +19791,17 @@
 /turf/open/floor/marking/asteroidwarning{
 	dir = 4
 	},
-/area/bigredv2/outside/w)
+/area/mint)
 "dJV" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/mars/random/cave,
-/area/bigredv2/caves/southwest)
+/area/mint)
+"dKR" = (
+/obj/structure/cable,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 1
+	},
+/area/mint)
 "dLF" = (
 /obj/machinery/power/smes,
 /obj/structure/cable,
@@ -19826,12 +19841,6 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/grimy,
 /area/bigredv2/outside/marshal_office)
-"dWa" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/closed/mineral/bigred,
-/area/bigredv2/caves/west)
 "dWx" = (
 /obj/structure/largecrate/guns,
 /turf/open/shuttle/escapepod,
@@ -19885,7 +19894,7 @@
 /obj/structure/table,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor,
-/area/bigredv2/outside/cargo)
+/area/mint)
 "edO" = (
 /turf/open/floor/carpet,
 /area/bigredv2/outside/bar)
@@ -19901,6 +19910,14 @@
 /obj/structure/sign/safety/medical_supplies,
 /turf/closed/wall/r_wall,
 /area/bigredv2/caves/lambda_lab)
+"efP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 9
+	},
+/area/bigredv2/outside/virology)
 "egQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -19930,7 +19947,11 @@
 /turf/open/floor/marking/asteroidwarning{
 	dir = 1
 	},
-/area/bigredv2/outside/w)
+/area/mint)
+"emb" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/bigredv2/outside/virology)
 "emA" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/structure/cable,
@@ -19946,7 +19967,7 @@
 "eqy" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/wall,
-/area/bigredv2/outside/cargo)
+/area/mint)
 "erQ" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/bigredv2/caves/lambda_lab)
@@ -19993,6 +20014,12 @@
 "eCh" = (
 /turf/open/shuttle/escapepod/five,
 /area/bigredv2/caves/southeast)
+"eCI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/marking/asteroidwarning,
+/area/bigredv2/outside/nw)
 "eCN" = (
 /obj/structure/cable,
 /turf/open/floor/tile/dark/red2/corner{
@@ -20003,6 +20030,10 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/southwest)
+"eFU" = (
+/obj/effect/landmark/xeno_turret_spawn,
+/turf/open/floor/tile/white,
+/area/bigredv2/outside/virology)
 "eGf" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
@@ -20040,6 +20071,10 @@
 /obj/item/ammo_magazine/rifle/famas,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/southeast)
+"eNv" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/bigredv2/outside/s)
 "eOu" = (
 /obj/structure/table,
 /obj/structure/cable,
@@ -20075,10 +20110,11 @@
 	},
 /area/shuttle/drop2/lz2)
 "eRn" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/bigredv2/caves/northwest)
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 1
+	},
+/area/bigredv2/outside/nw)
 "eRD" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/landmark/weed_node,
@@ -20090,6 +20126,10 @@
 	dir = 1
 	},
 /area/shuttle/drop2/lz2)
+"eSm" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/blue/whitebluefull,
+/area/bigredv2/outside/general_store)
 "eTT" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
@@ -20126,7 +20166,7 @@
 	dir = 2
 	},
 /turf/closed/mineral/bigred,
-/area/bigredv2/caves/southwest)
+/area/mint)
 "faf" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral/bigred,
@@ -20161,7 +20201,11 @@
 "fgX" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/wall/r_wall,
-/area/bigredv2/outside/cargo)
+/area/mint)
+"flf" = (
+/obj/structure/window/framed/colony,
+/turf/open/floor/plating,
+/area/mint)
 "flV" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor/plating,
@@ -20222,6 +20266,13 @@
 /obj/effect/landmark/corpsespawner/security,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/southeast)
+"fwD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 10
+	},
+/area/bigredv2/outside/virology)
 "fwQ" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -20238,12 +20289,15 @@
 	},
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/space_port)
+"fyA" = (
+/turf/closed/wall/r_wall,
+/area/mint)
 "fAx" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
 	},
 /turf/open/floor/freezer,
-/area/bigredv2/outside/virology)
+/area/mint)
 "fAC" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/structure/cable,
@@ -20253,6 +20307,9 @@
 /obj/machinery/computer/rdservercontrol,
 /turf/open/shuttle/escapepod,
 /area/bigredv2/caves/southeast)
+"fDe" = (
+/turf/open/floor/plating/warning,
+/area/bigredv2/outside/nw)
 "fDs" = (
 /obj/structure/closet/crate/secure/weapon,
 /obj/structure/cable,
@@ -20317,7 +20374,7 @@
 /obj/effect/spawner/random/tool,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor,
-/area/bigredv2/outside/cargo)
+/area/mint)
 "fNY" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -20329,7 +20386,7 @@
 /turf/open/floor/marking/asteroidwarning{
 	dir = 4
 	},
-/area/bigredv2/caves/southwest)
+/area/mint)
 "fOE" = (
 /obj/structure/sign/safety/breakroom,
 /turf/closed/wall,
@@ -20360,6 +20417,12 @@
 	dir = 6
 	},
 /area/bigredv2/outside/nw)
+"fWe" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 4
+	},
+/area/bigredv2/outside/w)
 "fWy" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
@@ -20387,6 +20450,9 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/southwest)
+"gdw" = (
+/turf/open/floor/marking/asteroidwarning,
+/area/bigredv2/caves/west)
 "gel" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -20479,7 +20545,7 @@
 "grK" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/asteroidfloor,
-/area/bigredv2/outside/w)
+/area/mint)
 "gsZ" = (
 /obj/structure/cable,
 /turf/open/floor/tile/blue/taupeblue{
@@ -20506,6 +20572,12 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/southwest)
+"gym" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/mint)
 "gzC" = (
 /obj/effect/landmark/xeno_resin_door,
 /obj/structure/cable,
@@ -20531,7 +20603,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor,
-/area/bigredv2/outside/engineering)
+/area/mint)
 "gCH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
@@ -20549,6 +20621,10 @@
 	dir = 1
 	},
 /area/bigredv2/outside/space_port)
+"gKf" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/outside/w)
 "gLt" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -20568,11 +20644,6 @@
 	dir = 4
 	},
 /area/shuttle/drop2/lz2)
-"gOG" = (
-/obj/structure/cable,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/open/floor,
-/area/bigredv2/outside/cargo)
 "gON" = (
 /turf/closed/mineral/bigred,
 /area/bigredv2/outside/nw)
@@ -20584,10 +20655,11 @@
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
 "gSk" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/plasteel/medium_stack,
-/turf/open/floor/plating/plating_catwalk,
-/area/bigredv2/outside/space_port)
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 8
+	},
+/area/bigredv2/outside/nw)
 "gSH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/corpsespawner/doctor,
@@ -20595,6 +20667,12 @@
 	dir = 4
 	},
 /area/bigredv2/outside/medical)
+"gTS" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 1
+	},
+/area/mint)
 "gTX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	on = 1
@@ -20605,6 +20683,10 @@
 /obj/machinery/atmospherics/pipe/manifold/green,
 /turf/open/floor/prison/darkred/full,
 /area/bigredv2/caves/southeast)
+"gVH" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/lightred/full,
+/area/mint)
 "gVL" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/mainship/engineering/free_access{
@@ -20642,11 +20724,19 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/ne)
+"hdW" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/caves/west)
 "heW" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"hft" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/mint)
 "hgw" = (
 /obj/effect/decal/warning_stripes/thick{
 	dir = 1
@@ -20721,6 +20811,12 @@
 "hsK" = (
 /turf/closed/wall/r_wall,
 /area/bigredv2/outside/cargo)
+"huj" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 9
+	},
+/area/bigredv2/outside/virology)
 "huI" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall/unmeltable,
@@ -20732,10 +20828,13 @@
 /obj/item/ammo_magazine/rifle/m16,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/southeast)
+"hvv" = (
+/turf/open/floor/tile/white,
+/area/bigredv2/outside/nw)
 "hvV" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/wall,
-/area/bigredv2/outside/cargo)
+/area/mint)
 "hwc" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
@@ -20755,6 +20854,12 @@
 /obj/machinery/computer3/server/rack,
 /turf/open/shuttle/escapepod,
 /area/bigredv2/caves/southeast)
+"hyL" = (
+/obj/structure/cargo_container/horizontal{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/bigredv2/outside/virology)
 "hyP" = (
 /obj/effect/decal/warning_stripes/nscenter,
 /obj/machinery/light/built{
@@ -20771,7 +20876,7 @@
 	dir = 2
 	},
 /turf/closed/mineral/bigred,
-/area/bigredv2/caves/southwest)
+/area/mint)
 "hBm" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 1
@@ -20949,10 +21054,6 @@
 /obj/structure/table/mainship,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/southeast)
-"iug" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/closed/mineral/bigred,
-/area/bigredv2/caves/west)
 "iyl" = (
 /obj/structure/cable,
 /obj/machinery/camera/autoname/mainship/dropship_one{
@@ -21020,9 +21121,22 @@
 /obj/effect/landmark/corpsespawner/engineer,
 /turf/open/floor/tile/red/redtaupecorner,
 /area/bigredv2/outside/office_complex)
+"iNl" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/mint)
 "iNt" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor,
+/area/mint)
+"iNN" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/bigredv2/outside/nw)
+"iNV" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
 "iUZ" = (
@@ -21033,6 +21147,10 @@
 	dir = 1
 	},
 /area/bigredv2/outside/space_port)
+"iVZ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/bot,
+/area/mint)
 "iWB" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -21074,6 +21192,11 @@
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/east)
+"jil" = (
+/turf/open/floor/plating/warning{
+	dir = 4
+	},
+/area/bigredv2/outside/virology)
 "jkn" = (
 /obj/structure/largecrate/random/barrel/red,
 /turf/open/floor/tile/dark,
@@ -21082,6 +21205,11 @@
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/southeast)
+"joM" = (
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 4
+	},
+/area/bigredv2/caves/northwest)
 "joZ" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
@@ -21146,9 +21274,8 @@
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/se)
 "jDW" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/open/floor/plating/ground/mars/dirttosand,
-/area/bigredv2/outside/sw)
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/caves/west)
 "jFi" = (
 /obj/item/analyzer/plant_analyzer,
 /turf/open/floor/prison/darkred/full,
@@ -21164,6 +21291,12 @@
 /obj/structure/largecrate/supply/weapons/sentries,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/southeast)
+"jHC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/bigredv2/outside/general_store)
 "jKb" = (
 /obj/structure/sign/safety/blast_door,
 /obj/structure/cable,
@@ -21214,7 +21347,7 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/mars/random/cave,
-/area/bigredv2/caves/west)
+/area/mint)
 "jSv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -21251,14 +21384,9 @@
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/south)
 "jYS" = (
-/obj/machinery/light/built{
-	dir = 1
-	},
-/obj/structure/rack,
-/obj/item/storage/box/explosive_mines,
-/obj/structure/cable,
-/turf/open/shuttle/elevator/grating,
-/area/bigredv2/outside/space_port)
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor,
+/area/bigredv2/outside/cargo)
 "jZz" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 5
@@ -21285,10 +21413,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/se)
-"kaP" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/closed/mineral/bigred,
-/area/bigredv2/outside/sw)
 "kbu" = (
 /obj/structure/cable,
 /turf/open/shuttle/elevator/grating,
@@ -21297,16 +21421,15 @@
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/mainship/sterile/dark,
 /area/bigredv2/caves/southeast)
-"kel" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/open/floor,
-/area/bigredv2/outside/engineering)
 "keE" = (
 /obj/structure/cable,
 /turf/open/floor/tile/dark/red2{
 	dir = 10
 	},
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"kgL" = (
+/turf/closed/wall,
+/area/mint)
 "kgP" = (
 /obj/effect/landmark/weed_node,
 /obj/structure/cable,
@@ -21535,8 +21658,12 @@
 /area/bigredv2/caves/southeast)
 "lmC" = (
 /obj/machinery/light,
-/obj/structure/cable,
-/obj/item/storage/box/sentry,
+/obj/structure/cargo_container/green{
+	dir = 8
+	},
+/obj/structure/cargo_container/green{
+	dir = 1
+	},
 /turf/open/shuttle/elevator/grating,
 /area/bigredv2/outside/space_port)
 "loj" = (
@@ -21556,13 +21683,9 @@
 /turf/open/shuttle/elevator/grating,
 /area/bigredv2/caves/southeast)
 "lqu" = (
-/obj/structure/cable,
-/obj/machinery/door/poddoor/four_tile_ver{
-	id = "Containmenthangar";
-	name = "Underground Hangar"
-	},
-/turf/open/floor/tile/dark,
-/area/bigredv2/caves/southeast)
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/bigredv2/outside/nw)
 "lqJ" = (
 /obj/machinery/camera{
 	dir = 5
@@ -21609,7 +21732,7 @@
 	dir = 2
 	},
 /turf/open/floor/freezer,
-/area/bigredv2/outside/virology)
+/area/mint)
 "lzk" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
@@ -21703,18 +21826,21 @@
 	},
 /area/bigredv2/outside/nw)
 "lQx" = (
-/obj/machinery/door/airlock/mainship/security/glass/free_access{
-	dir = 2
-	},
 /obj/structure/cable,
 /turf/open/shuttle/elevator/grating,
 /area/bigredv2/caves/north)
+"lRS" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 8
+	},
+/area/bigredv2/outside/w)
 "lVv" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
 	},
 /turf/open/floor/plating/ground/mars/random/dirt,
-/area/bigredv2/outside/w)
+/area/mint)
 "lVR" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/dirttosand,
@@ -21734,10 +21860,19 @@
 /obj/machinery/light,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/southeast)
+"maC" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/caves/northwest)
 "mbT" = (
 /obj/item/trash/sosjerky,
 /turf/open/floor/plating,
 /area/bigredv2/outside/engineering)
+"mca" = (
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/outside/w)
 "mcP" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/mineral/bigred,
@@ -21818,6 +21953,16 @@
 "mAw" = (
 /turf/open/floor/asteroidfloor,
 /area/shuttle/drop2/lz2)
+"mCR" = (
+/turf/open/floor/marking/asteroidwarning{
+	dir = 10
+	},
+/area/shuttle/drop2/lz2)
+"mDB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/bigredv2/outside/nw)
 "mDZ" = (
 /obj/machinery/camera/autoname/mainship/dropship_one{
 	dir = 4;
@@ -21825,10 +21970,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/bigredv2/caves/southeast)
-"mEk" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/open/floor/marking/asteroidwarning,
-/area/bigredv2/outside/sw)
 "mEo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
@@ -21836,6 +21977,9 @@
 	},
 /turf/open/floor/tile/dark/yellow2/corner,
 /area/bigredv2/caves/south)
+"mEt" = (
+/turf/closed/mineral/bigred,
+/area/mint)
 "mEZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -21882,14 +22026,14 @@
 /turf/open/shuttle/escapepod,
 /area/bigredv2/caves/southeast)
 "mQb" = (
-/obj/structure/rack,
-/obj/item/ammo_magazine/shotgun/incendiary,
-/obj/item/ammo_magazine/shotgun/incendiary,
-/obj/item/ammo_magazine/shotgun/incendiary,
-/obj/item/ammo_magazine/shotgun/incendiary,
-/obj/item/ammo_magazine/shotgun/incendiary,
-/turf/open/shuttle/elevator/grating,
-/area/bigredv2/outside/space_port)
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 1
+	},
+/area/bigredv2/outside/nw)
+"mRd" = (
+/turf/open/floor/marking/bot,
+/area/mint)
 "mSl" = (
 /obj/structure/cable,
 /obj/structure/largecrate/random/barrel/blue,
@@ -21899,6 +22043,10 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/southwest)
+"mTi" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/bigredv2/outside/nw)
 "mTF" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -21907,7 +22055,7 @@
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 10
 	},
-/area/bigredv2/outside/sw)
+/area/mint)
 "mXZ" = (
 /obj/docking_port/stationary/crashmode,
 /obj/machinery/light{
@@ -21920,10 +22068,9 @@
 /turf/open/shuttle/escapepod,
 /area/bigredv2/caves/lambda_lab)
 "nag" = (
-/obj/structure/cable,
-/obj/structure/largecrate/supply/supplies/mre,
-/turf/open/shuttle/elevator/grating,
-/area/bigredv2/outside/space_port)
+/obj/effect/landmark/xeno_turret_spawn,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/caves/northwest)
 "nbw" = (
 /obj/structure/prop/mainship/mission_planning_system,
 /turf/open/shuttle/escapepod,
@@ -21958,7 +22105,7 @@
 /turf/open/floor/marking/asteroidwarning{
 	dir = 1
 	},
-/area/bigredv2/outside/sw)
+/area/mint)
 "nts" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
@@ -22004,9 +22151,8 @@
 	},
 /area/bigredv2/caves/south)
 "nyf" = (
-/obj/machinery/miner/damaged,
-/turf/open/floor/plating,
-/area/bigredv2/outside/nw)
+/turf/closed/wall/r_wall,
+/area/bigredv2/caves/northwest)
 "nyk" = (
 /obj/structure/largecrate/random/case,
 /turf/open/shuttle/escapepod,
@@ -22046,6 +22192,10 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"nCq" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor,
+/area/mint)
 "nFd" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -22093,12 +22243,9 @@
 "nOk" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor,
-/area/bigredv2/outside/cargo)
+/area/mint)
 "nOm" = (
-/obj/effect/landmark/lv624/fog_blocker,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
+/obj/machinery/door/airlock/multi_tile/secure2_glass,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/northwest)
 "nPl" = (
@@ -22117,6 +22264,12 @@
 /obj/effect/decal/cleanable/blood/gibs/xeno/limb,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/southeast)
+"nRN" = (
+/obj/structure/cargo_container/horizontal{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/bigredv2/outside/virology)
 "nRT" = (
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/west)
@@ -22185,7 +22338,11 @@
 "oou" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/marking/asteroidwarning,
-/area/bigredv2/outside/w)
+/area/mint)
+"orC" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/bigredv2/outside/engineering)
 "orX" = (
 /obj/machinery/light{
 	dir = 4
@@ -22213,6 +22370,13 @@
 	},
 /turf/open/floor/tile/darkish,
 /area/bigredv2/caves/lambda_lab)
+"otL" = (
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	dir = 1;
+	name = "\improper Engineering Break Room"
+	},
+/turf/open/floor/plating,
+/area/bigredv2/outside/engineering)
 "ouJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -22237,7 +22401,7 @@
 	},
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/mint)
 "oAE" = (
 /obj/machinery/camera{
 	dir = 9
@@ -22271,6 +22435,11 @@
 /obj/structure/window/framed/colony/reinforced/hull,
 /turf/open/floor/plating,
 /area/bigredv2/outside/se)
+"oGN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/plating,
+/area/bigredv2/outside/nw)
 "oIp" = (
 /obj/effect/landmark/corpsespawner/security,
 /turf/open/floor/tile/dark2,
@@ -22293,6 +22462,12 @@
 	},
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
+"oMr" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 8
+	},
+/area/mint)
 "oMP" = (
 /obj/machinery/door/airlock/mainship/secure/free_access{
 	dir = 1;
@@ -22315,7 +22490,7 @@
 /area/bigredv2/caves/east)
 "oPP" = (
 /turf/open/floor/plating/ground/mars/random/sand,
-/area/bigredv2/caves/southwest)
+/area/mint)
 "oTw" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
@@ -22339,6 +22514,11 @@
 /obj/item/weapon/gun/shotgun/pump/cmb,
 /turf/open/floor/tile/dark2,
 /area/bigredv2/caves/southeast)
+"oVV" = (
+/turf/open/floor/marking/asteroidwarning{
+	dir = 5
+	},
+/area/bigredv2/outside/virology)
 "oWn" = (
 /turf/open/floor/tile/green/whitegreenfull,
 /area/bigredv2/caves/lambda_lab)
@@ -22400,6 +22580,11 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/shuttle/escapepod,
 /area/bigredv2/caves/southeast)
+"piB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor,
+/area/bigredv2/outside/engineering)
 "pjz" = (
 /obj/structure/cable,
 /turf/open/floor/marking/asteroidwarning{
@@ -22442,6 +22627,11 @@
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/s)
+"pqC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/asteroidfloor,
+/area/bigredv2/outside/nw)
 "pst" = (
 /obj/effect/decal/warning_stripes/thick,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -22539,6 +22729,13 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/southeast)
+"pKQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 8
+	},
+/area/bigredv2/outside/nw)
 "pNt" = (
 /obj/machinery/camera/autoname/mainship/dropship_one{
 	dir = 8;
@@ -22555,7 +22752,7 @@
 /turf/open/floor/marking/asteroidwarning{
 	dir = 8
 	},
-/area/bigredv2/caves/southwest)
+/area/mint)
 "pQZ" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/r_wall,
@@ -22598,12 +22795,8 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/bigredv2/caves/southeast)
 "pXc" = (
-/obj/structure/cable,
-/obj/structure/window/framed/mainship/gray/toughened/hull{
-	name = "Secure window"
-	},
-/turf/open/floor/tile/dark,
-/area/bigredv2/outside/space_port)
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/mint)
 "pYh" = (
 /obj/effect/landmark/xeno_resin_door,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -22703,6 +22896,15 @@
 /obj/machinery/door/airlock/multi_tile/mainship/generic,
 /turf/open/floor/prison/darkred/full,
 /area/bigredv2/caves/southeast)
+"qke" = (
+/turf/open/floor/marking/asteroidwarning,
+/area/mint)
+"qml" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor,
+/area/mint)
 "qnf" = (
 /obj/effect/decal/warning_stripes/thick,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -22724,7 +22926,7 @@
 	on = 1
 	},
 /turf/open/floor,
-/area/bigredv2/outside/cargo)
+/area/mint)
 "qoL" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/mineral/bigred,
@@ -22769,6 +22971,10 @@
 "qyl" = (
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/shuttle/drop2/lz2)
+"qyC" = (
+/obj/structure/largecrate/random,
+/turf/open/floor/marking/bot,
+/area/mint)
 "qzl" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral/bigred,
@@ -22780,7 +22986,7 @@
 /turf/open/floor/marking/asteroidwarning{
 	dir = 8
 	},
-/area/bigredv2/outside/w)
+/area/mint)
 "qBa" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -22795,6 +23001,10 @@
 	dir = 6
 	},
 /area/shuttle/drop2/lz2)
+"qDc" = (
+/obj/effect/landmark/weed_node,
+/turf/closed/mineral/bigred,
+/area/bigredv2/caves/southwest)
 "qDI" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -22812,7 +23022,7 @@
 /obj/structure/window/framed/colony/reinforced,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating,
-/area/bigredv2/outside/engineering)
+/area/mint)
 "qGO" = (
 /obj/structure/cable,
 /turf/closed/wall,
@@ -22822,9 +23032,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
 	},
-/turf/open/floor/marking/asteroidwarning{
-	dir = 4
-	},
+/turf/open/floor/plating,
 /area/bigredv2/outside/nw)
 "qIi" = (
 /obj/effect/decal/cleanable/dirt,
@@ -22880,12 +23088,9 @@
 	},
 /area/bigredv2/caves/lambda_lab)
 "qQh" = (
-/obj/structure/ladder{
-	height = 2;
-	id = "Lambdashaft"
-	},
-/turf/open/shuttle/escapepod,
-/area/bigredv2/caves/lambda_lab)
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/bigredv2/caves/northwest)
 "qRh" = (
 /turf/open/floor/tile/dark/yellow2/corner{
 	dir = 8
@@ -22964,6 +23169,10 @@
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
+"rid" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor,
+/area/mint)
 "riu" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno/limb,
 /turf/open/floor/mainship/sterile/dark,
@@ -22997,6 +23206,10 @@
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/tile/dark/yellow2/corner,
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"rpl" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/marking/bot,
+/area/mint)
 "rpq" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/item/ammo_casing/bullet,
@@ -23014,7 +23227,7 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
-/area/bigredv2/caves/west)
+/area/mint)
 "rww" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -23054,6 +23267,9 @@
 	},
 /turf/open/shuttle/escapepod,
 /area/bigredv2/caves/southeast)
+"rEB" = (
+/turf/open/floor/plating/ground/mars/random/cave/rock,
+/area/mint)
 "rJv" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	name = "\improper Lambda Lab"
@@ -23068,6 +23284,10 @@
 	},
 /turf/open/floor/tile/dark2,
 /area/bigredv2/caves/southeast)
+"rKW" = (
+/obj/structure/table,
+/turf/open/floor,
+/area/mint)
 "rLF" = (
 /obj/docking_port/stationary/crashmode,
 /turf/open/floor/plating/ground/mars/dirttosand{
@@ -23089,7 +23309,7 @@
 "rNd" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/mineral/bigred,
-/area/bigredv2/outside/w)
+/area/mint)
 "rNZ" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -23113,7 +23333,7 @@
 "rQB" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/mars/random/dirt,
-/area/bigredv2/outside/sw)
+/area/mint)
 "rSn" = (
 /turf/open/space/basic,
 /area/bigredv2/outside/c)
@@ -23127,7 +23347,7 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/mineral/bigred,
-/area/bigredv2/caves/west)
+/area/mint)
 "rVm" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/tile/dark,
@@ -23144,6 +23364,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/darkred/full,
 /area/bigredv2/caves/southeast)
+"rZy" = (
+/obj/structure/cargo_container/horizontal,
+/turf/open/floor/plating,
+/area/bigredv2/outside/virology)
 "rZP" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
@@ -23173,6 +23397,13 @@
 	dir = 1
 	},
 /area/bigredv2/caves/southeast)
+"sfa" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 1;
+	name = "\improper Cargo Bay"
+	},
+/turf/open/floor,
+/area/mint)
 "sfy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -23186,6 +23417,14 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/bigredv2/caves/southeast)
+"sjJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 1
+	},
+/area/bigredv2/outside/nw)
 "skG" = (
 /obj/machinery/computer/shuttle/shuttle_control/dropship,
 /obj/structure/table,
@@ -23231,11 +23470,9 @@
 /turf/open/floor/wood,
 /area/bigredv2/outside/nanotrasen_lab/inside)
 "syY" = (
-/obj/structure/window/framed/mainship/gray/toughened/hull{
-	name = "Secure window"
-	},
-/turf/open/floor/tile/dark,
-/area/bigredv2/outside/space_port)
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/mint)
 "szH" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
@@ -23285,6 +23522,13 @@
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
 /area/bigredv2/caves/south)
+"sJa" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor,
+/area/mint)
 "sLI" = (
 /obj/item/ammo_casing/shell,
 /turf/open/floor/prison/darkred/full,
@@ -23317,6 +23561,10 @@
 "sTd" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/bigredv2/caves/southeast)
+"sTy" = (
+/obj/structure/cable,
+/turf/open/floor/asteroidfloor,
+/area/mint)
 "sTE" = (
 /obj/item/ammo_casing/shell,
 /obj/item/weapon/gun/shotgun/pump/cmb,
@@ -23400,19 +23648,19 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/north)
-"toO" = (
-/obj/effect/landmark/weed_node,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/freezer,
-/area/bigredv2/outside/virology)
 "tsZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/marking/asteroidwarning{
 	dir = 8
 	},
 /area/shuttle/drop2/lz2)
+"ttT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 6
+	},
+/area/bigredv2/outside/nw)
 "ttW" = (
 /obj/effect/landmark/xeno_turret_spawn,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
@@ -23492,10 +23740,20 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/southeast)
+"tGW" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/blue/whitebluefull,
+/area/bigredv2/outside/general_store)
 "tHW" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno/limb,
 /turf/open/floor/tile/dark2,
 /area/bigredv2/caves/southeast)
+"tIE" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/bigredv2/outside/cargo)
 "tIX" = (
 /obj/structure/largecrate/random/barrel/blue,
 /obj/machinery/light{
@@ -23595,7 +23853,7 @@
 /area/bigredv2/caves/east)
 "uec" = (
 /turf/open/floor/asteroidfloor,
-/area/bigredv2/caves/southwest)
+/area/mint)
 "ued" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall,
@@ -23604,7 +23862,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/asteroidfloor,
-/area/bigredv2/outside/w)
+/area/mint)
 "ufT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
@@ -23631,6 +23889,9 @@
 /obj/effect/landmark/corpsespawner/security,
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
+"uiT" = (
+/turf/open/floor,
+/area/mint)
 "uja" = (
 /obj/structure/window/framed/colony/reinforced/hull,
 /obj/docking_port/stationary/crashmode,
@@ -23640,10 +23901,19 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral/bigred,
 /area/bigredv2/outside/s)
+"ukW" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/caves/northwest)
 "uln" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/southwest)
+"ulK" = (
+/turf/open/floor/plating/ground/mars/dirttosand{
+	dir = 5
+	},
+/area/bigredv2/caves/northwest)
 "umd" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/machinery/door/poddoor/mainship{
@@ -23688,11 +23958,20 @@
 /obj/effect/landmark/corpsespawner/doctor,
 /turf/open/floor/tile/green/whitegreencorner,
 /area/bigredv2/outside/medical)
+"uqo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/bigredv2/outside/general_store)
 "uqs" = (
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/southeast)
+"uqU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/asteroidwarning,
+/area/bigredv2/outside/w)
 "utl" = (
 /obj/machinery/floodlight/landing,
 /turf/open/floor/marking/asteroidwarning{
@@ -23704,7 +23983,7 @@
 /obj/effect/spawner/random/technology_scanner,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor,
-/area/bigredv2/outside/cargo)
+/area/mint)
 "uvF" = (
 /obj/structure/cable,
 /turf/open/floor/marking/asteroidwarning{
@@ -23732,6 +24011,11 @@
 /obj/effect/spawner/gibspawner/human,
 /turf/open/floor/tile/dark2,
 /area/bigredv2/caves/southeast)
+"uHn" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/plating/warning,
+/area/bigredv2/outside/nw)
 "uHG" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -23771,6 +24055,12 @@
 "uMP" = (
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/east)
+"uQz" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 4
+	},
+/area/bigredv2/outside/nw)
 "uTl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	on = 1
@@ -23784,7 +24074,7 @@
 "uWF" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/random/cave,
-/area/bigredv2/caves/southwest)
+/area/mint)
 "uWN" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -23808,7 +24098,9 @@
 /turf/open/floor,
 /area/bigredv2/outside/dorms)
 "vgq" = (
-/obj/structure/cable,
+/obj/structure/cargo_container{
+	dir = 1
+	},
 /turf/open/shuttle/elevator/grating,
 /area/bigredv2/outside/space_port)
 "vhj" = (
@@ -23818,6 +24110,10 @@
 	},
 /turf/open/floor/prison/darkred/full,
 /area/bigredv2/caves/southeast)
+"viz" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/cave,
+/area/bigredv2/outside/s)
 "vlA" = (
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/southeast)
@@ -23836,7 +24132,7 @@
 	dir = 2
 	},
 /turf/open/floor/tile/white,
-/area/bigredv2/outside/virology)
+/area/mint)
 "vpT" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark/blue2{
@@ -23856,22 +24152,14 @@
 /obj/effect/spawner/gibspawner/human,
 /turf/open/floor/prison/darkred/full,
 /area/bigredv2/caves/southeast)
-"vvM" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 2
-	},
-/turf/open/floor/plating/ground/mars/random/cave,
-/area/bigredv2/caves/southwest)
 "vwf" = (
-/turf/closed/mineral/bigred,
-/area/bigredv2/outside/space_port)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/asteroidfloor,
+/area/bigredv2/outside/nw)
 "vwP" = (
-/obj/structure/cable,
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	id = "Secure_1"
-	},
-/turf/open/floor/tile/dark,
-/area/bigredv2/outside/space_port)
+/turf/open/floor/plating/ground/mars/random/sand,
+/area/bigredv2/caves/northwest)
 "vxE" = (
 /obj/item/limb/l_hand,
 /obj/item/ammo_casing/bullet{
@@ -23916,6 +24204,10 @@
 /obj/item/ammo_casing/bullet,
 /turf/open/floor/prison/darkred/full,
 /area/bigredv2/caves/southeast)
+"vHo" = (
+/obj/machinery/miner/damaged,
+/turf/open/floor/plating,
+/area/bigredv2/outside/virology)
 "vIl" = (
 /obj/structure/sign/poster{
 	dir = 1
@@ -23952,6 +24244,10 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/east)
+"vNL" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/bigredv2/outside/general_store)
 "vQS" = (
 /turf/open/floor/prison/darkred/full,
 /area/bigredv2/caves/southeast)
@@ -24045,6 +24341,10 @@
 /obj/effect/landmark/xeno_turret_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/east)
+"wkf" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/mint)
 "wmv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -24062,11 +24362,26 @@
 /obj/item/limb/l_hand,
 /turf/open/floor/prison/darkred/full,
 /area/bigredv2/caves/southeast)
+"wpi" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/asteroidfloor,
+/area/bigredv2/outside/nw)
 "wpF" = (
 /obj/item/limb/l_arm,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/mainship/sterile/dark,
 /area/bigredv2/caves/southeast)
+"wpI" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/door/airlock/multi_tile/mainship/medidoor{
+	dir = 1;
+	name = "\improper Medical Clinic"
+	},
+/turf/open/floor/tile/white,
+/area/bigredv2/outside/nw)
 "wpO" = (
 /obj/effect/decal/cleanable/blood/tracks/footprints,
 /turf/open/floor/mainship/sterile/dark,
@@ -24076,6 +24391,10 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/mainship/sterile/dark,
 /area/bigredv2/caves/southeast)
+"wrc" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor,
+/area/mint)
 "wrk" = (
 /turf/open/floor/mainship/sterile/dark,
 /area/bigredv2/caves/southeast)
@@ -24083,6 +24402,16 @@
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/east)
+"wuS" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 4
+	},
+/area/bigredv2/outside/nw)
+"wwx" = (
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/mint)
 "wxA" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno/down,
 /turf/open/floor/plating/ground/mars/random/sand,
@@ -24126,7 +24455,7 @@
 	dir = 2
 	},
 /turf/closed/wall/r_wall,
-/area/bigredv2/outside/virology)
+/area/mint)
 "wKg" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/item/ammo_casing/bullet,
@@ -24156,7 +24485,7 @@
 /turf/open/floor/plating/ground/mars/cavetodirt{
 	dir = 1
 	},
-/area/bigredv2/caves/southwest)
+/area/mint)
 "wVJ" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -24164,15 +24493,18 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
+"wWm" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 4
+	},
+/area/bigredv2/outside/virology)
 "wYu" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/prison/darkred/full,
 /area/bigredv2/caves/south)
-"wZg" = (
-/turf/open/floor/plating/ground/mars/random/dirt,
-/area/bigredv2/outside/sw)
 "wZZ" = (
 /turf/open/floor/plating,
 /area/bigredv2/caves/west)
@@ -24187,6 +24519,12 @@
 /obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/outside/general_offices)
+"xdr" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/asteroidfloor,
+/area/bigredv2/outside/nw)
 "xdX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
@@ -24265,7 +24603,6 @@
 /turf/closed/wall/r_wall/unmeltable,
 /area/bigredv2/outside/telecomm)
 "xpu" = (
-/obj/machinery/door/airlock/mainship/security/glass/free_access,
 /obj/structure/cable,
 /turf/open/floor,
 /area/bigredv2/caves/north)
@@ -24357,10 +24694,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/nanotrasen_lab/inside)
-"xHR" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
-/turf/open/floor/plating/ground/mars/random/sand,
-/area/bigredv2/outside/sw)
 "xHV" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/mineral/bigred,
@@ -24386,6 +24719,12 @@
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /turf/open/floor/tile/dark,
 /area/bigredv2/caves/southeast)
+"xKT" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor,
+/area/mint)
 "xNf" = (
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -24467,6 +24806,10 @@
 "yeq" = (
 /turf/open/floor/marking/asteroidwarning,
 /area/shuttle/drop2/lz2)
+"yfi" = (
+/obj/effect/landmark/xeno_turret_spawn,
+/turf/open/floor/plating/ground/mars/random/dirt,
+/area/bigredv2/outside/virology)
 "yfA" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -26466,9 +26809,9 @@ ktH
 abQ
 huI
 tfF
+abS
 tfF
-tfF
-wdL
+aSn
 quI
 acZ
 ade
@@ -26552,11 +26895,11 @@ nRT
 nRT
 nRT
 jMC
-yhx
-yhx
-yhx
-faf
-yhx
+nRT
+nRT
+nRT
+gel
+nRT
 yhx
 yhx
 jMC
@@ -26682,9 +27025,9 @@ aac
 ktH
 abQ
 iKB
-jYS
+tfF
 vgq
-vgq
+tfF
 lmC
 quI
 ada
@@ -26768,17 +27111,17 @@ nRT
 nRT
 nRT
 jMC
+nRT
+nRT
+jOB
+nRT
+gel
+nRT
 yhx
 yhx
 yhx
 yhx
-faf
-yhx
-yhx
-yhx
-yhx
-yhx
-yhx
+nRT
 yhx
 yhx
 yhx
@@ -26899,10 +27242,10 @@ pOZ
 pOZ
 abQ
 huI
-mQb
 tfF
+vgq
 tfF
-nag
+aVF
 xnF
 ada
 adr
@@ -26985,12 +27328,12 @@ nRT
 ahv
 nRT
 jMC
-yhx
-yhx
-yhx
-yhx
-yhx
-faf
+nRT
+nRT
+nRT
+nRT
+nRT
+gel
 faf
 faf
 faf
@@ -27115,11 +27458,11 @@ aac
 aac
 aac
 aac
-huI
+aaQ
+abB
+tfF
+tfF
 wdL
-tfF
-tfF
-gSk
 xnF
 acQ
 acQ
@@ -27170,7 +27513,7 @@ nRT
 nRT
 nRT
 jOB
-nRT
+mca
 jOB
 jMC
 yhx
@@ -27202,12 +27545,12 @@ nRT
 jOB
 jOB
 jMC
-yhx
-yhx
-yhx
-yhx
-yhx
-yhx
+nRT
+nRT
+nRT
+nRT
+nRT
+nRT
 yhx
 yhx
 yhx
@@ -27332,11 +27675,11 @@ aac
 aac
 aac
 aac
-huI
-pXc
-vwP
-vwP
-syY
+aaQ
+aaM
+aaM
+aaM
+aaM
 xnF
 adb
 ads
@@ -27420,11 +27763,11 @@ nRT
 jMC
 yhx
 yhx
-yhx
-yhx
-yhx
-yhx
-yhx
+nRT
+nRT
+nRT
+nRT
+nRT
 yhx
 yhx
 yhx
@@ -27433,13 +27776,13 @@ yhx
 yhx
 yhx
 yhx
-yhx
-yhx
+nRT
+nRT
 yhx
 tvk
-puQ
-puQ
-puQ
+nRT
+nRT
+nRT
 puQ
 puQ
 puQ
@@ -27549,11 +27892,11 @@ aac
 aac
 aac
 aac
-aae
+abz
 aaf
 aaf
 aaf
-gkA
+bkn
 dDI
 adc
 adt
@@ -27595,11 +27938,11 @@ aad
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
+nyf
+ctr
+ctr
+ctr
+nyf
 yhx
 yhx
 yhx
@@ -27636,27 +27979,27 @@ yhx
 yhx
 yhx
 yhx
-yhx
-yhx
-yhx
-yhx
-yhx
-yhx
+nRT
+nRT
+nRT
+nRT
+nRT
+nRT
 yhx
 yhx
 yhx
 faf
 yhx
+nRT
+nRT
+nRT
+nRT
+nRT
 yhx
-yhx
-yhx
-yhx
-yhx
-yhx
-puQ
-puQ
-dSm
-dSm
+nRT
+nRT
+jMC
+jMC
 uln
 puQ
 puQ
@@ -27766,7 +28109,7 @@ aac
 aac
 aac
 aac
-aae
+abz
 rPj
 aaf
 aaf
@@ -27812,11 +28155,11 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
+ulK
+joM
+joM
+bph
+vwP
 yhx
 yhx
 yhx
@@ -27853,27 +28196,27 @@ yhx
 yhx
 yhx
 yhx
-yhx
-yhx
-yhx
-yhx
-yhx
-yhx
-yhx
+nRT
+nRT
+nRT
+nRT
+jOB
+nRT
+nRT
 yhx
 yhx
 faf
 yhx
-yhx
-yhx
-yhx
-yhx
-yhx
 nRT
-puQ
-uln
-puQ
-puQ
+nRT
+nRT
+nRT
+nRT
+nRT
+nRT
+jOB
+nRT
+nRT
 puQ
 puQ
 puQ
@@ -27983,7 +28326,7 @@ aae
 aae
 aae
 aae
-aae
+abz
 aaf
 aaf
 aaf
@@ -28029,11 +28372,11 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
+vwP
+vwP
+ukW
+vwP
+vwP
 yhx
 yhx
 yhx
@@ -28070,27 +28413,27 @@ yhx
 yhx
 yhx
 yhx
-yhx
-yhx
-yhx
-yhx
-yhx
-yhx
+nRT
+nRT
+nRT
+nRT
+nRT
+nRT
 yhx
 yhx
 yhx
 faf
 yhx
-yhx
 nRT
 nRT
 nRT
 nRT
 nRT
-dSm
-puQ
-puQ
-uln
+nRT
+jMC
+nRT
+nRT
+jOB
 puQ
 puQ
 puQ
@@ -28246,11 +28589,11 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
+vwP
+vwP
+vwP
+vwP
+vwP
 yhx
 yhx
 yhx
@@ -28287,27 +28630,27 @@ yhx
 yhx
 yhx
 yhx
-yhx
-yhx
-yhx
-yhx
-yhx
-yhx
+nRT
+nRT
+nRT
+nRT
+nRT
+nRT
 yhx
 yhx
 yhx
 faf
 yhx
 jMC
+jOB
 nRT
 nRT
 nRT
 nRT
+jOB
 nRT
-uln
-puQ
-puQ
-dSm
+nRT
+jMC
 tvk
 tvk
 tvk
@@ -28461,14 +28804,14 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-yhx
+aMz
+aMz
+aMz
+aRE
+aRE
+aRE
+aMz
+aMz
 yhx
 yhx
 yhx
@@ -28502,18 +28845,18 @@ yhx
 yhx
 yhx
 yhx
-iug
-iug
-iug
-iug
-iug
-iug
-iug
-iug
-iug
-iug
-iug
-iug
+rNd
+rNd
+rNd
+dJV
+dJV
+dJV
+dJV
+dJV
+dJV
+rNd
+rNd
+rNd
 rUT
 rvA
 jRD
@@ -28522,9 +28865,9 @@ rvA
 rvA
 jRD
 dJV
-puQ
-puQ
-dSm
+nRT
+nRT
+jMC
 tvk
 tvk
 tvk
@@ -28678,22 +29021,22 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-yhx
-yhx
-yhx
-yhx
-yhx
+aMz
+aRE
+aRE
+aRE
+aRE
+aRE
+aRE
+aMz
+aMz
+aMz
+aMz
+aMz
 aFs
 aFs
 aFs
-aFs
+yfi
 riz
 qPG
 aFs
@@ -28719,15 +29062,15 @@ yhx
 yhx
 yhx
 yhx
-dWa
+hAR
 yhx
-yhx
-yhx
-yhx
-yhx
-yhx
-yhx
-yhx
+nRT
+nRT
+nRT
+nRT
+nRT
+nRT
+nRT
 yhx
 yhx
 yhx
@@ -28895,21 +29238,21 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-yhx
-yhx
-yhx
-yhx
-yhx
+aMz
+aQz
+aRE
+aRE
+aRE
+aRE
+aRE
+aRE
+nRN
+hyL
+rZy
+aMz
 aFs
 aFs
-aHg
+huj
 aIa
 aJg
 aJg
@@ -28939,15 +29282,15 @@ aMz
 wFG
 yhx
 yhx
-yhx
-yhx
-yhx
-yhx
-yhx
-yhx
-oXG
-oXG
-oXG
+bqG
+nRT
+djA
+hdW
+bqG
+bqG
+gva
+gva
+gva
 oXG
 oXG
 oXG
@@ -29103,6 +29446,7 @@ aac
 aad
 aad
 aad
+aad
 aac
 aac
 aac
@@ -29111,18 +29455,17 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-yhx
-yhx
-yhx
-yhx
+aMz
+aRE
+emb
+aRE
+aRE
+emb
+aRE
+aRE
+aRE
+aRE
+aRE
 aMz
 aFu
 aFs
@@ -29156,10 +29499,10 @@ aNc
 wFG
 yhx
 yhx
-yhx
-yhx
-yhx
-yhx
+bqG
+cdF
+gdw
+jDW
 oXG
 oXG
 oXG
@@ -29320,6 +29663,8 @@ aad
 aad
 aad
 aad
+aad
+aad
 aac
 aac
 aac
@@ -29327,19 +29672,17 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-yhx
-yhx
-yhx
-aeI
+aMz
+aRE
+aRE
+aRE
+aRE
+aRE
+aRE
+aRE
+aRE
+emb
+bpx
 aMz
 aFv
 aFu
@@ -29373,9 +29716,9 @@ aNc
 wFG
 yhx
 yhx
-yhx
-yhx
-yhx
+bqG
+cdF
+gdw
 oXG
 oXG
 oXG
@@ -29390,21 +29733,21 @@ oXG
 oXG
 vDI
 hAR
-dpt
-dpt
-dpt
-dpt
-dpt
-dpt
-dpt
-dpt
-dpt
-dpt
-dpt
-dpt
-dpt
-dpt
-dpt
+rNd
+rNd
+rNd
+rNd
+rNd
+rNd
+rNd
+rNd
+rNd
+rNd
+rNd
+rNd
+rNd
+rNd
+rNd
 tvk
 qzl
 tvk
@@ -29535,28 +29878,28 @@ aad
 mOy
 aad
 aad
+aad
+aad
+aad
+aad
+nyf
 aac
 aac
 aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-yhx
-yhx
-yhx
-aeI
+aMz
+aRE
+nRN
+hyL
+rZy
+aRE
+aRE
+aRE
+aRE
+aRE
+aRE
 aMz
 aFv
 aFv
@@ -29590,9 +29933,9 @@ aNc
 wFG
 yhx
 yhx
-yhx
-yhx
-oXG
+bqG
+cdF
+yeq
 oXG
 oXG
 oXG
@@ -29742,42 +30085,42 @@ aaf
 aaf
 fYS
 aae
-cQC
-aad
-aad
+ktH
+aac
+aac
 mTF
 aad
-mTF
 aad
 aad
+aad
+aad
+aad
+nag
+aad
+aad
+aad
+nyf
 aac
 aac
 aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aeI
-aeI
-aeI
-aeI
-aeI
 aMz
-aFv
-aFw
-aHh
+aRE
+aRE
+aRE
+aRE
+aRE
+aRE
+aRE
+aRE
+aRE
+aRE
+aHg
+aHi
+aHi
+aHj
 aIc
 aJh
 aJh
@@ -29807,9 +30150,9 @@ aQy
 wFG
 yhx
 yhx
-yhx
-oXG
-oXG
+bqG
+faR
+yeq
 oXG
 oXG
 cyp
@@ -29839,9 +30182,9 @@ ocv
 oXG
 bmd
 hAR
-dpt
-dpt
-dpt
+rNd
+rNd
+rNd
 qzl
 tvk
 tvk
@@ -29959,45 +30302,45 @@ aaf
 aaf
 amb
 aae
-cQC
+ktH
+aac
+aac
+aac
 mAi
 aad
+aac
+aac
 aad
-mAi
 aad
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
+aad
+aad
+mTF
+aad
+nyf
+vwP
+vwP
+vwP
+vwP
+vwP
+vwP
 aMz
-aFw
-aFs
+aRE
+aRE
+aRE
+aRE
+aRE
+aRE
+aRE
+emb
+aRE
+aRE
 aHh
+aHj
+aHj
+aHj
 aId
 aFs
-aFs
+dAz
 aFs
 aFs
 aMz
@@ -30022,11 +30365,11 @@ dcO
 aMz
 aMz
 wFG
+bqG
 yhx
-yhx
-oXG
-oXG
-oXG
+gva
+faR
+yeq
 oXG
 cyp
 qyl
@@ -30176,42 +30519,42 @@ aaf
 aaf
 fYS
 aae
-cQC
+ktH
+aac
+aac
+aac
+aad
 aad
 aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aeI
-aeI
-aiz
-aog
-ahO
-aeI
-aeI
-aeI
-aeI
+aad
+aad
+aad
+aad
+nyf
+maC
+vwP
+vwP
+vwP
+vwP
+vwP
 aMz
-aFs
-aFs
-aHh
+aRE
+aRE
+aRE
+aRE
+aRE
+aRE
+aRE
+aRE
+aRE
+aRE
+oVV
+aJh
+wWm
+aHj
 aIe
 aFs
 aFs
@@ -30228,7 +30571,7 @@ aNc
 qvi
 aNc
 aWi
-aNc
+eFU
 aNc
 aSw
 aNc
@@ -30239,11 +30582,11 @@ aRF
 aNc
 bco
 vpv
+bqG
 yhx
-yhx
-oXG
-oXG
-oXG
+gva
+faR
+yeq
 oXG
 fxL
 qyl
@@ -30397,34 +30740,34 @@ ktH
 aac
 aac
 aac
+aad
+aad
 aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+aad
+aad
+aad
+aad
+nyf
 aeI
 aeI
-aac
-aac
-aac
-aac
-aac
-aac
-aeI
-aeI
-aiA
-ahP
-aln
-aeI
-aeI
-aeI
-aeI
+vwP
+vwP
+vwP
+aMz
+aMz
+aRE
+aRE
+aRE
+aRE
+emb
+aRE
+aRE
+aRE
+aRE
+aRE
 aMz
 aFs
 aFs
@@ -30456,11 +30799,11 @@ aNc
 aNc
 aNc
 vpv
-yhx
-oXG
-oXG
-oXG
-oXG
+bqG
+brd
+gva
+faR
+yeq
 oXG
 fxL
 qyl
@@ -30614,34 +30957,34 @@ ktH
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+nOm
+aiw
+ahQ
 aeI
 aeI
 aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aiB
-ahV
-ama
-aeI
-aeI
-aeI
-aeI
+aMz
+aRE
+aRE
+aRE
+aRE
+aRE
+aRE
+aRE
+aRE
+aRE
+aRE
+aRE
 aMz
 aFs
 aFs
@@ -30674,10 +31017,10 @@ aNc
 aNc
 vpv
 aMz
-oXG
-oXG
-oXG
-oXG
+brd
+gva
+faR
+yeq
 oXG
 fxL
 qyl
@@ -30716,7 +31059,7 @@ tvk
 tvk
 tvk
 puQ
-dSm
+puQ
 puQ
 puQ
 puQ
@@ -30832,33 +31175,33 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+aad
+mTF
+aad
+aad
+aad
+aad
+mTF
+aad
+aad
+aad
+ajx
+ahR
 aeI
 aeI
 aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
+aMz
+aRE
+aRE
+aRE
+aRE
+aRE
+aRE
+aRE
+aRE
+aRE
+aRE
+aRE
 aMz
 aFs
 aFs
@@ -30891,13 +31234,13 @@ aMz
 aWj
 lyb
 aMz
-oXG
-oXG
-oXG
-oXG
-oXG
-fxL
-qyl
+brd
+gva
+faR
+yeq
+lCt
+oaD
+mCR
 faR
 bhv
 bie
@@ -30931,8 +31274,8 @@ qzl
 tvk
 tvk
 tvk
-tvk
-tvk
+puQ
+puQ
 puQ
 puQ
 puQ
@@ -31049,33 +31392,33 @@ aac
 aac
 aac
 aac
+aad
+aad
+aad
+aad
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+aad
+aad
+aad
+qQh
+uvF
+cSm
 aeI
+bZF
 aeI
-aeI
-aeI
-aeI
-aiz
-ahO
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
+aMz
+aQz
+aRE
+aRE
+aRE
+nRN
+hyL
+rZy
+aRE
+aRE
+aRE
+bpx
 aMz
 aFs
 aFs
@@ -31108,13 +31451,13 @@ aWj
 aYC
 fAx
 aMz
-oXG
-oXG
-oXG
-oXG
-oXG
-fxL
-qyl
+brd
+gva
+faR
+yeq
+lMc
+vXv
+xSR
 faR
 bhw
 bie
@@ -31142,11 +31485,11 @@ bsd
 mAw
 mAw
 mAw
-gva
-vvM
-mSv
-puQ
-puQ
+bmd
+hAR
+qzl
+tvk
+tvk
 puQ
 puQ
 puQ
@@ -31273,29 +31616,29 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aeI
-aeI
-aeI
-aeI
-aiz
-ahP
-ahP
-aog
-ahO
-aeI
+nyf
+nyf
+nyf
+bOD
+eCI
 aeI
 aeI
 aiz
-aog
-ahO
-aeI
-aeI
+aMz
+aRE
+aRE
+emb
+aRE
+aRE
+aRE
+aRE
+aRE
+aRE
+aRE
+aRE
 aMz
 aFs
-aHg
+huj
 aHi
 aIf
 aJj
@@ -31323,12 +31666,12 @@ aWT
 aXy
 aWj
 aWT
-toO
+fAx
 aMz
-oXG
-oXG
-oXG
-oXG
+brd
+gva
+faR
+yeq
 oXG
 jZz
 qyl
@@ -31359,11 +31702,11 @@ bse
 mAw
 mAw
 mAw
-gva
-vvM
-mSv
-uln
-puQ
+bmd
+hAR
+qzl
+qDc
+tvk
 puQ
 puQ
 puQ
@@ -31493,23 +31836,23 @@ aac
 aac
 aeI
 aeI
-aeI
-aiz
+ajy
+cSm
 aog
 aog
 ahP
-ahP
-ahP
-ahP
-ahP
-aog
-aog
-aog
-ahP
-ahP
-ahP
-aog
-aog
+aMz
+aRE
+aRE
+aRE
+aRE
+vHo
+aRE
+aRE
+aRE
+blA
+jil
+jil
 aMz
 aFs
 aDv
@@ -31542,10 +31885,10 @@ aWj
 aWU
 dtj
 aMz
-oXG
-oXG
-oXG
-oXG
+brd
+gva
+faR
+yeq
 oXG
 oXG
 fxL
@@ -31576,11 +31919,11 @@ bsb
 mAw
 mAw
 mAw
-gva
-vvM
-mSv
-puQ
-puQ
+bmd
+hAR
+qzl
+tvk
+tvk
 puQ
 uln
 puQ
@@ -31710,23 +32053,23 @@ aac
 aac
 aeI
 aeI
-aiz
-ahP
-atl
-aqp
+ajy
+qYD
 aqp
 aiw
 aqp
-aqp
-aiw
-aiw
-aiw
-aiw
-aiw
-aqp
-aiw
-aqp
-aDw
+ahQ
+blo
+blo
+aRE
+aRE
+aRE
+aRE
+aRE
+cUN
+efP
+cbC
+fwD
 aMz
 aMz
 aMz
@@ -31759,10 +32102,10 @@ aMz
 aMz
 wFG
 aMz
-fpw
-fpw
-bgW
-oXG
+gva
+gva
+faR
+yeq
 oXG
 cyp
 qyl
@@ -31797,11 +32140,11 @@ bmd
 hAR
 qzl
 tvk
-tvk
-tvk
-tvk
-tvk
-tvk
+puQ
+puQ
+puQ
+puQ
+puQ
 puQ
 puQ
 puQ
@@ -31926,24 +32269,24 @@ aac
 aac
 aeI
 aeI
-aeI
-aiA
-aoO
-aoN
-aoN
-aoN
-akd
-aiy
-akd
-aiy
+bZF
+ajy
+qYD
+pqC
+pqC
+pqC
+cSm
+eIG
+mDB
+eIG
 qHT
-aAp
-aAp
-aAp
-aAp
-aAp
-aAp
-aDx
+oGN
+oGN
+oGN
+uHn
+sjJ
+anw
+ajX
 aDw
 ahP
 bSC
@@ -31978,8 +32321,8 @@ lVv
 qyl
 qyl
 qyl
-qyl
-fpw
+faR
+yeq
 fpw
 qyl
 qyl
@@ -32014,11 +32357,11 @@ bmd
 hAR
 qzl
 tvk
-tvk
-tvk
-tvk
-tvk
-tvk
+puQ
+puQ
+puQ
+puQ
+puQ
 tvk
 puQ
 puQ
@@ -32144,27 +32487,27 @@ aeI
 aeI
 aeI
 aiz
-aoO
-ajx
-ajx
-ajx
-atm
-ahP
-ahP
 ajy
 ajx
-axX
 ajx
-ahR
-ahP
-ahP
-ahP
-ahP
-aDy
+ajx
+aiy
+atm
+avT
+avT
+avT
+ayc
+avT
+avT
+mTi
+fDe
+ajz
+aoN
+aye
 akK
 ahP
 auF
-aiy
+uQz
 aIi
 ahT
 aln
@@ -32192,11 +32535,11 @@ aSB
 aSB
 aSB
 lVv
-aVF
+lCt
 tsZ
 tsZ
-oaD
-oaD
+mAw
+mAw
 oaD
 oaD
 oaD
@@ -32231,9 +32574,9 @@ bmd
 hAR
 qzl
 tvk
-tvk
-tvk
-tvk
+puQ
+puQ
+puQ
 tvk
 tvk
 tvk
@@ -32350,7 +32693,7 @@ cyL
 aeI
 aeI
 aeI
-aeI
+bZF
 aeI
 aeI
 aeI
@@ -32363,21 +32706,21 @@ aeI
 aiA
 ajy
 aoN
-aoN
+vwf
 atm
 ahP
-ahP
-ahP
-ajy
-aoN
-axX
-aoN
-ahR
-ahP
-ahP
-ahP
-ahP
-qUm
+avr
+avT
+avT
+iNN
+ayc
+iNN
+avT
+avT
+fDe
+ajA
+akd
+ajY
 akK
 ahP
 ahP
@@ -32389,24 +32732,24 @@ aeI
 aHn
 aeI
 aeI
+bZF
 aeI
-aeI
 aQF
 aQF
 aQF
-aQF
+gKf
 sBV
 aUQ
 aWk
 aWk
-aWk
+lRS
 aWk
 aWk
 aWk
 aVI
 aWk
 aWk
-aWk
+lRS
 aVI
 qzU
 faR
@@ -32448,9 +32791,9 @@ bmd
 hAR
 qzl
 tvk
-tvk
-tvk
-tvk
+puQ
+puQ
+puQ
 tvk
 tvk
 tvk
@@ -32575,7 +32918,7 @@ aeI
 aeI
 aeI
 aeI
-aeI
+bZF
 aeI
 aiA
 ajz
@@ -32665,8 +33008,8 @@ bmd
 hAR
 qzl
 tvk
-tvk
-tvk
+puQ
+puQ
 tvk
 tvk
 tvk
@@ -32818,7 +33161,7 @@ ahP
 ajy
 cuW
 aln
-aeI
+bZF
 aeI
 aeI
 gON
@@ -32836,7 +33179,7 @@ aSB
 aSB
 aSB
 aYE
-aYE
+fWe
 aYE
 aYE
 aYE
@@ -32882,8 +33225,8 @@ bmd
 hAR
 qzl
 tvk
-tvk
-tvk
+puQ
+puQ
 tvk
 tvk
 tvk
@@ -33004,7 +33347,7 @@ ahO
 aeI
 aeI
 aeI
-aeI
+bZF
 aeI
 aeI
 aeI
@@ -33030,8 +33373,8 @@ avr
 ahP
 aDy
 ajx
-aqp
-aqp
+pKQ
+aiw
 ajx
 cuW
 ahP
@@ -33098,9 +33441,9 @@ mAw
 bmd
 hAR
 qzl
-tvk
-tvk
-tvk
+puQ
+puQ
+puQ
 tvk
 tvk
 tvk
@@ -33183,10 +33526,10 @@ hzx
 hzx
 hzx
 hzx
-eRn
-eRn
-eRn
-nOm
+eTT
+eTT
+eTT
+bXE
 aae
 aah
 aah
@@ -33216,7 +33559,7 @@ agq
 ahe
 lPV
 aiw
-aiw
+gSk
 aiw
 aiw
 aiw
@@ -33237,7 +33580,7 @@ aeI
 avr
 avT
 avT
-avT
+mTi
 axZ
 avT
 avT
@@ -33315,9 +33658,9 @@ mAw
 bmd
 hAR
 qzl
-tvk
-tvk
-tvk
+puQ
+puQ
+puQ
 tvk
 tvk
 tvk
@@ -33400,10 +33743,10 @@ aac
 aac
 aac
 aac
-aad
-aad
-aad
-nOm
+aac
+aac
+aac
+bXE
 aae
 aaq
 aaK
@@ -33445,7 +33788,7 @@ ajx
 aoN
 ajx
 aoN
-aoN
+vwf
 ajx
 aoN
 ahR
@@ -33491,7 +33834,7 @@ aXH
 aXK
 aQF
 aQF
-aQF
+gKf
 sBV
 lVv
 eRJ
@@ -33532,9 +33875,9 @@ vXv
 bmd
 hAR
 qzl
-tvk
-tvk
-tvk
+puQ
+puQ
+puQ
 tvk
 tvk
 tvk
@@ -33616,11 +33959,11 @@ aac
 aac
 aac
 aac
-aad
-aad
-aad
-aad
-nOm
+aac
+aac
+aac
+aac
+bXE
 aae
 abR
 aaK
@@ -33665,13 +34008,13 @@ aiy
 aiy
 aiy
 akd
-atm
+ttT
 aln
 aeI
 avr
 avT
 avT
-nyf
+avT
 axZ
 avT
 azo
@@ -33695,7 +34038,7 @@ aNo
 aOB
 aOB
 aNo
-aOB
+uqo
 aOB
 aNo
 aOB
@@ -33715,9 +34058,9 @@ faR
 mAw
 bev
 yeq
-qyl
-qyl
-qyl
+gva
+gva
+gva
 hsK
 hsK
 hsK
@@ -33734,24 +34077,24 @@ gva
 gva
 gva
 gva
-bmi
+blJ
 boD
 gva
-qyl
-qyl
-bdJ
-yeq
-qyl
-qyl
-qyl
-bpx
-oXG
-bmd
+wwx
+wwx
+dKR
+qke
+wwx
+wwx
+mEt
+mEt
+mEt
+mEt
 hAR
 qzl
-tvk
-tvk
-tvk
+puQ
+puQ
+puQ
 tvk
 tvk
 tvk
@@ -33832,11 +34175,11 @@ aab
 aac
 aac
 aac
-aad
-aad
-aad
-mTF
-aad
+aac
+aac
+aac
+aac
+aac
 bXE
 aae
 aaw
@@ -33902,7 +34245,7 @@ aeI
 aeI
 aeI
 aeI
-aeI
+bZF
 aeI
 aeI
 ajz
@@ -33916,12 +34259,12 @@ aSD
 aTM
 aUS
 aNo
-aWr
+tGW
 aWY
 aXD
 aMB
 aXH
-aXH
+bKc
 aXK
 aQF
 bbb
@@ -33932,13 +34275,13 @@ elD
 grK
 ueY
 oou
-dsH
-dsH
+rQB
+rQB
 rNd
 fgX
 utH
 utH
-gOG
+iNt
 nOk
 nOk
 nOk
@@ -33947,28 +34290,28 @@ fND
 fND
 eal
 eqy
-kaP
-kaP
-kaP
+rNd
+rNd
+rNd
 ozW
-kel
+nOk
 iNt
 qFg
 rQB
 rQB
 nrI
-mEk
+oou
 rQB
 rQB
-jDW
-xHR
-xHR
-kaP
-dpt
-qzl
-qzl
-qzl
-qzl
+rNd
+rNd
+rNd
+rNd
+rNd
+mSv
+mSv
+mSv
+mSv
 qzl
 qzl
 qzl
@@ -33988,7 +34331,7 @@ tvk
 puQ
 puQ
 puQ
-puQ
+qqG
 dSm
 tvk
 tvk
@@ -34049,11 +34392,11 @@ aab
 aac
 aac
 aac
-aad
-aad
-aad
-aad
-aad
+aac
+aac
+aac
+aac
+aac
 bXE
 aae
 aax
@@ -34088,11 +34431,11 @@ ahP
 ajy
 qYD
 ahR
+lqu
 ahP
 ahP
 ahP
-ahP
-ahP
+lqu
 ahP
 ahP
 ahP
@@ -34104,7 +34447,7 @@ ahP
 aoO
 avr
 avU
-avT
+mTi
 avT
 axZ
 avT
@@ -34150,9 +34493,9 @@ bdZ
 bdZ
 beQ
 aSB
+aSB
 vDI
-vDI
-hsK
+fyA
 bhb
 bhb
 bii
@@ -34163,7 +34506,7 @@ bhb
 bhb
 bhb
 bla
-aXK
+kgL
 bmd
 bmd
 bmd
@@ -34171,21 +34514,21 @@ xyM
 bmi
 ekm
 xyM
-wZg
-wZg
-bqG
-brd
-wZg
-wZg
-wZg
+wwx
+wwx
+dKR
+qke
+wwx
+wwx
+wwx
 mXK
-bme
-bme
 oPP
-tvk
-tvk
-tvk
-tvk
+oPP
+oPP
+pXc
+pXc
+pXc
+pXc
 tvk
 tvk
 tvk
@@ -34266,11 +34609,11 @@ aab
 aac
 aac
 aac
-aad
-aad
-aad
-aad
-aad
+aac
+aac
+aac
+aac
+aac
 bXE
 aae
 aay
@@ -34301,7 +34644,7 @@ agv
 aae
 hwL
 ahV
-ahP
+lqu
 ajy
 qYD
 ajx
@@ -34312,7 +34655,7 @@ aiw
 aiw
 aiw
 aiw
-aiw
+gSk
 aiw
 aiw
 aiw
@@ -34325,12 +34668,12 @@ avT
 avT
 axZ
 avT
-avT
+mTi
 avT
 avT
 avr
 aeI
-aeI
+bZF
 aeI
 aeI
 aeI
@@ -34365,44 +34708,44 @@ aSB
 aVG
 bdZ
 bdZ
-beQ
+uqU
+aSB
 aSB
 vDI
-vDI
-hsK
+fyA
 bhc
-bbe
+rid
 bij
-blb
-blb
-blb
-blb
-blb
-bhb
-blb
-aXK
+uiT
+uiT
+iNl
+uiT
+uiT
+gVH
+uiT
+kgL
 bmd
 bmd
 bmd
 xyM
 bmi
 ekm
-xyM
-wZg
-wZg
-bqG
-bpv
-brG
-brG
-brG
-brG
-brG
-brG
-brG
-brG
-brG
-pQK
+otL
+wkf
+wwx
+dKR
 uec
+pQK
+oMr
+pQK
+pQK
+pQK
+oMr
+pQK
+pQK
+pQK
+pQK
+djh
 uec
 bmk
 bmk
@@ -34483,10 +34826,10 @@ aab
 aac
 aac
 aac
-aad
-aad
-aad
-aad
+aac
+aac
+aac
+aac
 aac
 bXE
 aae
@@ -34516,7 +34859,7 @@ afh
 afM
 agv
 ahg
-ahW
+bQc
 ahX
 aiA
 ajy
@@ -34584,9 +34927,9 @@ bcr
 bew
 beR
 aSB
+aSB
 vDI
-vDI
-hsK
+fyA
 bhd
 bhD
 bik
@@ -34596,31 +34939,31 @@ bhb
 bhb
 bhb
 bhb
-blb
-aXK
+uiT
+kgL
 bmd
 bmd
 bmd
 xyM
-bmi
+orC
 ekm
 xyM
 bpy
-wZg
+wwx
 bqH
-boC
-boC
-boC
-boC
-boC
-boC
-boC
-boC
-boC
-boC
+fOi
+fOi
+fOi
+fOi
+fOi
+fOi
+fOi
+fOi
+fOi
+fOi
 fOi
 buO
-buO
+sTy
 bmk
 bmq
 bvF
@@ -34701,9 +35044,9 @@ aac
 aac
 aac
 aac
-aad
-aad
-aad
+aac
+aac
+aac
 aac
 bXE
 aae
@@ -34751,7 +35094,7 @@ cLe
 cLe
 cLe
 cLe
-cLe
+wuS
 auE
 avt
 avV
@@ -34767,7 +35110,7 @@ aeI
 aeI
 aeI
 aeI
-aeI
+bZF
 aeI
 aeI
 aeI
@@ -34778,7 +35121,7 @@ aMB
 aNm
 gnu
 ouJ
-ouJ
+jHC
 aQM
 kAp
 ouJ
@@ -34803,18 +35146,18 @@ beS
 aSB
 aSB
 vDI
-hsK
-aZs
-aZs
-bil
-aZO
+fyA
+bLl
+bLl
+sJa
+wrc
 bjg
 bjt
 bjQ
 bkk
 bjQ
 bjt
-aXK
+kgL
 bmd
 bmd
 bme
@@ -34822,22 +35165,22 @@ xyM
 bmi
 ekm
 xyM
-bme
+oPP
 bpy
-wZg
-wZg
-wZg
-wZg
-wZg
+wwx
+wwx
+wwx
+wwx
+wwx
 cBD
-bme
-bme
-bme
+oPP
+oPP
+oPP
 bcp
-buS
-puQ
+wUc
+pXc
 buP
-buO
+sTy
 bmk
 bmi
 bmi
@@ -34917,9 +35260,9 @@ aab
 aac
 aac
 aac
-aad
-mTF
-aad
+aac
+aac
+aac
 aac
 aac
 bXE
@@ -34932,7 +35275,7 @@ abo
 aaO
 aaO
 abI
-abS
+aaw
 aah
 ach
 aco
@@ -34950,7 +35293,7 @@ aah
 aah
 agx
 agv
-ahY
+bQc
 aeI
 aiA
 ajy
@@ -35020,18 +35363,18 @@ hsK
 uJV
 uJV
 uJV
-hsK
-aXK
-aXK
-bil
-bbg
+fyA
+kgL
+kgL
+sJa
+sfa
 hvV
-aXK
-aXK
-aXK
+kgL
+kgL
+kgL
 bkz
-aXK
-aXK
+kgL
+kgL
 bmd
 bmd
 bme
@@ -35039,22 +35382,22 @@ xyM
 bmi
 ekm
 blJ
-txn
+blJ
+blJ
 blJ
 blJ
 txn
 txn
-txn
 blJ
 blJ
-bme
-bme
-bmd
-bmd
-bmd
-puQ
+oPP
+oPP
+mEt
+mEt
+mEt
+pXc
 buP
-buO
+sTy
 bvm
 ekm
 ekm
@@ -35134,9 +35477,9 @@ aab
 aac
 aac
 aac
-aad
-aad
-aad
+aac
+aac
+aac
 aac
 aac
 bXE
@@ -35144,7 +35487,7 @@ aae
 aaO
 aaO
 aaO
-abg
+aaO
 aaO
 aaO
 aaP
@@ -35193,7 +35536,7 @@ avT
 avT
 ayc
 avT
-avT
+mTi
 avT
 aBa
 avr
@@ -35205,7 +35548,7 @@ aeI
 aeI
 aeI
 aeI
-aeI
+bZF
 aeI
 ajy
 aMB
@@ -35218,10 +35561,10 @@ aMB
 aMB
 aUY
 aNo
-aNm
+eSm
 aMB
 aXH
-aXH
+bKc
 aYJ
 aZm
 aZL
@@ -35237,18 +35580,18 @@ beT
 blb
 blb
 blb
-blb
-blb
-blb
-bil
-blb
-blb
-beT
-aXK
-aZw
-blb
+nCq
+uiT
+uiT
+sJa
+uiT
+uiT
+xKT
+kgL
+qml
+uiT
 bld
-aXK
+kgL
 bmd
 bme
 bme
@@ -35264,13 +35607,13 @@ bmq
 bob
 bsJ
 blJ
-bme
-bme
-bmd
-bmd
-dSm
-dSm
-buP
+oPP
+hft
+mEt
+mEt
+rEB
+rEB
+gTS
 uec
 bmk
 boI
@@ -35351,22 +35694,22 @@ aab
 aac
 aac
 aac
-aad
-aad
-aad
+aac
+aac
+aac
 aac
 aac
 bXE
 aae
-aaC
-aaQ
-aaQ
+abg
+aaO
+aaO
 abh
 abp
-abz
-abB
+aaO
+aaO
 abK
-abU
+aah
 aah
 ach
 aah
@@ -35394,7 +35737,7 @@ aln
 aeI
 aeI
 aeI
-aeI
+bZF
 aeI
 aeI
 aeI
@@ -35406,7 +35749,7 @@ aeI
 aeI
 avr
 avT
-avT
+mTi
 avT
 ayc
 avT
@@ -35454,17 +35797,17 @@ beU
 bfy
 bfV
 bfF
-baF
-baF
-blb
-bil
-blb
-blb
-blb
-aXK
-blb
+iVZ
+mRd
+uiT
+sJa
+uiT
+uiT
+uiT
+kgL
+uiT
 bkA
-ble
+rKW
 asx
 bme
 bme
@@ -35477,16 +35820,16 @@ bmi
 vDw
 bmi
 bmi
-bmi
+orC
 bmi
 bmi
 asT
-bme
-bme
-bmd
-bmd
-puQ
-dSm
+oPP
+oPP
+mEt
+mEt
+pXc
+rEB
 buP
 uec
 bmk
@@ -35568,17 +35911,17 @@ aab
 aac
 aac
 aac
-aad
-aad
-aad
+aac
+aac
+aac
 aac
 aac
 bXE
 aae
 aae
 aae
-aae
-aae
+aaO
+atl
 aae
 aae
 aae
@@ -35600,14 +35943,15 @@ aah
 aah
 aah
 afM
-ahh
+aae
 bQc
 aeI
 aiA
-ajy
+mQb
 ajY
 ahR
 aln
+bZF
 aeI
 aeI
 aeI
@@ -35615,8 +35959,7 @@ aeI
 aeI
 aeI
 aeI
-aeI
-aeI
+bZF
 aeI
 aeI
 aeI
@@ -35646,7 +35989,7 @@ apv
 aNk
 aOy
 aNo
-aNo
+vNL
 aNo
 aNo
 aNo
@@ -35662,7 +36005,7 @@ aXK
 baA
 uhp
 bgD
-bbe
+tIE
 bbe
 bbe
 bbe
@@ -35671,15 +36014,15 @@ blb
 blb
 aZO
 blb
-blb
-blb
-blb
+uiT
+uiT
+uiT
 bim
-bgD
+gym
 bjh
-bbe
+rid
 bjR
-bbe
+rid
 qny
 blf
 asx
@@ -35688,7 +36031,7 @@ bme
 bme
 xyM
 bmi
-ekm
+iNV
 ekm
 ekm
 bqf
@@ -35698,12 +36041,12 @@ bmg
 bre
 bsK
 blJ
-bme
-bme
-bmd
-bmd
-puQ
-dSm
+oPP
+oPP
+mEt
+mEt
+pXc
+rEB
 buQ
 brc
 bmk
@@ -35785,18 +36128,18 @@ aab
 aac
 aac
 aac
-aad
-aad
-aad
-aad
+aac
+aac
+aac
+aac
 aac
 eTT
 eTT
 eTT
-eTT
-eTT
-eTT
-eTT
+adx
+ahh
+axX
+adx
 eTT
 eTT
 bXE
@@ -35817,7 +36160,7 @@ aae
 aae
 aae
 aae
-vwf
+aae
 bQc
 aeI
 aiA
@@ -35850,7 +36193,7 @@ avT
 avr
 aeI
 aeI
-aeI
+bZF
 aeI
 aeI
 aHn
@@ -35864,7 +36207,7 @@ aNm
 aOy
 cgP
 aNo
-aNo
+vNL
 aNo
 aTQ
 aNo
@@ -35888,16 +36231,16 @@ beU
 bfA
 bfW
 bgq
-bfy
-baF
-blb
-bil
-blb
-aZO
-aZO
-aZN
+qyC
+mRd
+uiT
+sJa
+uiT
+wrc
+wrc
+flf
 bkl
-aZO
+wrc
 blg
 asx
 bme
@@ -35915,21 +36258,21 @@ bmg
 bre
 bmq
 asT
-bme
-bme
-bmd
-bmd
-puQ
-puQ
-dSm
-dSm
-dSm
-dSm
-dSm
-dSm
-dSm
-dSm
-dSm
+oPP
+oPP
+mEt
+mEt
+pXc
+pXc
+rEB
+rEB
+rEB
+rEB
+rEB
+rEB
+rEB
+rEB
+rEB
 dSm
 dSm
 mSv
@@ -36002,18 +36345,18 @@ aab
 aac
 aac
 aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aad
+ahW
+aDx
 aad
-aad
-aad
-aad
-aac
-aac
-aac
-aac
-aac
-aac
-aac
 aac
 aac
 pOZ
@@ -36027,8 +36370,8 @@ eTT
 eTT
 eTT
 eTT
-eRn
-eRn
+eTT
+eTT
 eTT
 pOZ
 pOZ
@@ -36057,10 +36400,10 @@ aeI
 aeI
 avr
 avr
-apG
-aqw
-ayd
-apG
+avr
+hvv
+wpI
+avr
 avr
 avr
 avr
@@ -36105,17 +36448,17 @@ bbe
 bbe
 bbe
 bbe
-bgD
-bbe
+gBV
+rid
 bhE
 bin
 biK
-aZO
-aZO
-aZN
+wrc
+wrc
+flf
 bkl
-blb
-blb
+uiT
+uiT
 asx
 bme
 bme
@@ -36132,22 +36475,22 @@ bmi
 bmi
 bsM
 blJ
-bme
-bme
-bmd
-bmd
-dSm
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
+oPP
+oPP
+mEt
+mEt
+rEB
+pXc
+pXc
+pXc
+pXc
+pXc
+pXc
+pXc
+pXc
+pXc
+pXc
+uln
 puQ
 mSv
 gdc
@@ -36219,22 +36562,6 @@ aab
 aac
 aac
 aac
-aad
-aad
-mTF
-aad
-aad
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
 aac
 aac
 aac
@@ -36244,8 +36571,24 @@ aac
 aac
 aac
 aad
+ahW
+aDx
 aad
-aad
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aac
 hzx
 aac
@@ -36265,32 +36608,32 @@ aeI
 aeI
 aeI
 aeI
-aeI
+bZF
 aeI
 aeI
 aeI
 aeI
 aeI
 uUn
-aeI
-aeI
-apC
-aqw
-arT
-apC
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
-aeI
+ajy
+xdr
+wpi
+ajx
+aye
+ajx
+ajx
+xdr
+ajx
+ahR
 aeI
 aeI
 aeI
 aeI
+bZF
 aeI
 aeI
+aeI
+bZF
 aeI
 ajy
 apv
@@ -36302,7 +36645,7 @@ aMB
 aMB
 aMB
 aPD
-aNo
+vNL
 aPv
 aMB
 aXH
@@ -36322,18 +36665,18 @@ beU
 bfF
 bfX
 baF
-bgE
-baF
-aXK
-bil
-blb
-blb
-blb
-aXK
+rpl
+mRd
+kgL
+sJa
+uiT
+uiT
+uiT
+kgL
 bkm
-blb
-blb
-aXK
+uiT
+uiT
+kgL
 bme
 bme
 bme
@@ -36349,21 +36692,21 @@ fOE
 brf
 blJ
 hEq
-bme
-bme
-bmd
-bmd
-bmd
-dSm
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
+oPP
+oPP
+mEt
+mEt
+mEt
+rEB
+syY
+pXc
+pXc
+pXc
+pXc
+syY
+pXc
+pXc
+pXc
 puQ
 puQ
 gxC
@@ -36436,23 +36779,6 @@ aab
 aac
 aac
 aac
-aad
-aad
-aad
-aad
-aad
-aad
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
 aac
 aac
 aac
@@ -36461,7 +36787,24 @@ aac
 aac
 aac
 aad
+mTF
+ahW
+aDx
 aad
+aad
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aac
 aac
 hzx
@@ -36478,7 +36821,7 @@ ahR
 ahP
 ama
 aeI
-aeI
+bZF
 aeI
 aoO
 aiw
@@ -36489,16 +36832,16 @@ aiw
 aiw
 aiw
 aiw
-aiw
-aiw
-apC
-aqw
+ajx
+ajx
+ajx
+ajx
 aye
-apC
-aiw
-aiw
-aiw
-aiw
+ajx
+ajx
+wpi
+ajx
+ajx
 aiw
 aiw
 aiw
@@ -36539,18 +36882,18 @@ blb
 aZO
 aZO
 blb
-aZO
-blb
-beT
-bil
-aZO
-blb
-blb
-aXK
-aZN
+wrc
+uiT
+xKT
+sJa
+wrc
+uiT
+uiT
+kgL
+flf
 bkz
-aZN
-hsK
+flf
+blJ
 blJ
 blJ
 blJ
@@ -36565,21 +36908,21 @@ ekm
 brI
 bmi
 blJ
-bme
-bme
-bme
-bmd
-bmd
-bmd
-bmd
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
+oPP
+hft
+oPP
+mEt
+mEt
+mEt
+mEt
+pXc
+pXc
+pXc
+pXc
+pXc
+pXc
+pXc
+pXc
 uWF
 puQ
 dSm
@@ -36654,23 +36997,6 @@ aac
 aac
 aac
 aac
-aad
-aad
-aad
-aad
-aad
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
 aac
 aac
 aac
@@ -36678,8 +37004,25 @@ aac
 aac
 aac
 aad
-bZF
 aad
+ahW
+aDx
+aad
+aad
+aad
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+xHV
+aac
 aac
 hzx
 aac
@@ -36763,7 +37106,7 @@ bil
 biL
 blb
 blb
-blb
+jYS
 blb
 blb
 beA
@@ -36782,22 +37125,22 @@ ekm
 bmg
 bmi
 blJ
-bme
-bme
-bme
-bmd
-bmd
-bmd
-bmd
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
+oPP
+oPP
+oPP
+mEt
+mEt
+mEt
+mEt
+pXc
+pXc
+pXc
+pXc
+pXc
+pXc
+pXc
+pXc
+pXc
 puQ
 dSm
 tvk
@@ -36871,32 +37214,32 @@ aac
 aac
 aac
 aac
+aac
+aac
+aac
+aac
+aac
+aac
 aad
 aad
+ahY
+aFw
 aad
-aad
-aad
-aad
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
 mTF
 aad
 aad
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aac
 hzx
 aac
@@ -36904,7 +37247,7 @@ aac
 aac
 aeI
 aeI
-aiA
+eRn
 ahP
 ajy
 akb
@@ -36953,7 +37296,7 @@ lzk
 aSI
 aOB
 aNo
-aNo
+vNL
 aWz
 aMB
 aXH
@@ -37001,20 +37344,20 @@ bmi
 blJ
 blJ
 blJ
-bme
-bme
-bmd
-bmd
-bmd
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
+oPP
+oPP
+mEt
+mEt
+mEt
+pXc
+pXc
+pXc
+syY
+pXc
+pXc
+pXc
+pXc
+pXc
 dSm
 tvk
 tvk
@@ -37088,20 +37431,6 @@ aac
 aac
 aac
 aac
-aad
-aad
-aad
-aad
-aad
-aad
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
 aac
 aac
 aac
@@ -37113,6 +37442,20 @@ aad
 aad
 aad
 aad
+aad
+aad
+aad
+aad
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aac
 aac
 hzx
@@ -37126,7 +37469,7 @@ ahP
 ajz
 akb
 ahR
-ahP
+lqu
 ahO
 aeI
 aeI
@@ -37164,7 +37507,7 @@ aMc
 apv
 aNk
 aOB
-aOB
+uqo
 aOB
 aRP
 aNo
@@ -37218,20 +37561,20 @@ bmi
 bsN
 bsZ
 blJ
-bme
-bme
-bmd
-bmd
-bmd
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
+oPP
+oPP
+mEt
+mEt
+mEt
+pXc
+pXc
+pXc
+pXc
+pXc
+pXc
+pXc
+pXc
+pXc
 puQ
 tvk
 tvk
@@ -37307,29 +37650,29 @@ aac
 aac
 aac
 aac
-aad
-aad
-mTF
-aad
-aad
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
 aac
 aac
 aac
 aac
 aac
 aad
-mTF
-hkk
-hkk
-hkk
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aac
+aac
+aac
+aac
+aac
+hzx
+hzx
+hzx
 hzx
 hzx
 aac
@@ -37384,7 +37727,7 @@ aNo
 aNm
 aQN
 lMT
-aNm
+eSm
 aNm
 aPv
 aNm
@@ -37435,20 +37778,20 @@ bmi
 bmg
 bmi
 asT
-bme
-bme
-bme
-bmd
-bmd
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
+oPP
+oPP
+oPP
+mEt
+mEt
+pXc
+pXc
+pXc
+pXc
+pXc
+pXc
+pXc
+syY
+pXc
 puQ
 tvk
 tvk
@@ -37524,26 +37867,26 @@ aac
 aac
 aac
 aac
-aad
-aad
-aad
-aad
-aad
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
 aac
 aac
 aac
 aac
 aac
 aad
-hkk
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+aad
+mTF
+aad
+aad
+aac
+aac
+hzx
 acp
 acp
 acp
@@ -37646,26 +37989,26 @@ bpO
 bpA
 bop
 lvJ
-gBV
+piB
 bop
-gBV
+piB
 feK
 bta
 pbv
-bme
-bme
-bme
-bmd
-bmd
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
-dSm
-puQ
-puQ
+oPP
+hft
+oPP
+mEt
+mEt
+pXc
+pXc
+pXc
+pXc
+pXc
+pXc
+rEB
+pXc
+pXc
 puQ
 puQ
 tvk
@@ -37742,25 +38085,25 @@ aac
 aac
 aac
 aac
+aac
+aac
+aac
+aad
 aad
 aad
 aad
 aad
 aad
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
 aad
-hkk
+aad
+aad
+aad
+aad
+aad
+aad
+aac
+aac
+hzx
 acp
 adh
 ady
@@ -37770,7 +38113,7 @@ aac
 aac
 aeI
 aeI
-aeI
+bZF
 aeI
 aeI
 aiA
@@ -37872,17 +38215,17 @@ asT
 btp
 btp
 btp
-wZg
-bmd
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
-dSm
-puQ
+wwx
+mEt
+pXc
+pXc
+syY
+pXc
+pXc
+pXc
+pXc
+rEB
+pXc
 puQ
 puQ
 puQ
@@ -37959,23 +38302,23 @@ aac
 aac
 aac
 aac
+aac
+aac
+aac
+aad
+mTF
+aad
+aad
+aad
+aac
+aac
 aad
 aad
 aad
 aad
 aad
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+aad
+aad
 aad
 hkk
 acp
@@ -38057,7 +38400,7 @@ beA
 aXK
 aZO
 aZO
-blb
+jYS
 aXK
 blb
 aZO
@@ -38086,20 +38429,20 @@ bmi
 bmi
 btc
 blJ
-wZg
-wZg
-wZg
-wZg
-wZg
+wwx
+wwx
+wwx
+wwx
+wwx
 wUc
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
-dSm
+pXc
+pXc
+pXc
+pXc
+pXc
+syY
+pXc
+rEB
 puQ
 puQ
 puQ
@@ -38177,21 +38520,21 @@ aac
 aac
 aac
 aac
+aac
+aac
+aac
 aad
 aad
 aad
 aad
+aac
+aac
+aac
+aac
 aad
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+aad
+aad
+aad
 aad
 aad
 hkk
@@ -38214,7 +38557,7 @@ aeI
 aiA
 qUm
 akK
-ahP
+lqu
 ahO
 ajz
 apC
@@ -38303,22 +38646,22 @@ bsn
 bmg
 btd
 blJ
-wZg
-wZg
-wZg
-wZg
+wwx
+wwx
+wwx
+wwx
 buC
-dSm
+rEB
+pXc
+pXc
+pXc
+pXc
+pXc
+pXc
+pXc
+pXc
 puQ
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
-puQ
+uln
 puQ
 puQ
 tvk
@@ -38394,20 +38737,20 @@ aac
 aac
 aac
 aac
+aac
+aac
+aac
 aad
 aad
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aad
 aad
-aad
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
 aad
 mTF
 aad
@@ -38426,7 +38769,7 @@ acp
 aeI
 aeI
 aeI
-aeI
+bZF
 aeI
 aiA
 qUm
@@ -38611,19 +38954,19 @@ aac
 aac
 aac
 aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aad
 aad
-aad
-mTF
-aad
-aad
-aac
-aac
-aac
-aac
-aac
-aac
-aac
 aad
 aad
 aad
@@ -38683,10 +39026,10 @@ aMc
 aMB
 aNr
 dzS
-aOB
+uqo
 aOB
 aOy
-aNo
+vNL
 aNo
 aOB
 aVO
@@ -38829,20 +39172,20 @@ aac
 aac
 aac
 aac
-aad
-aad
-aad
-aad
-aad
-aad
 aac
 aac
 aac
 aac
 aac
+aac
+aac
+aac
+aac
 aad
 aad
-mAi
+aad
+aad
+aad
 aad
 aad
 hkk
@@ -38934,9 +39277,9 @@ biQ
 bcC
 blb
 bjX
-bkn
-bkn
-blo
+blb
+blb
+bdi
 blJ
 gVL
 bmk
@@ -39046,19 +39389,19 @@ aac
 aac
 aac
 aac
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+aac
+aac
+aac
+aac
+aac
+aac
 aac
 aac
 aac
 aad
 aad
 aad
+nag
 aad
 aad
 hkk
@@ -39264,13 +39607,13 @@ aac
 aac
 aac
 aac
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aad
 aad
 mTF
@@ -39407,7 +39750,7 @@ tvk
 puQ
 puQ
 puQ
-puQ
+uln
 puQ
 tvk
 qzl
@@ -39482,9 +39825,9 @@ aac
 aac
 aac
 aac
-aad
-aad
-aad
+aac
+aac
+aac
 aad
 aad
 aad
@@ -39699,8 +40042,8 @@ aac
 aac
 aac
 aac
-aad
-aad
+aac
+aac
 aad
 aad
 aad
@@ -40490,7 +40833,7 @@ buD
 blJ
 xEN
 ajG
-xEN
+jWg
 xEN
 xEN
 xEN
@@ -41144,7 +41487,7 @@ xEN
 xEN
 xEN
 xEN
-xEN
+jWg
 hqP
 vKO
 hqP
@@ -41574,7 +41917,7 @@ buD
 buD
 blJ
 xEN
-ajG
+cvN
 xEN
 xEN
 xEN
@@ -42443,7 +42786,7 @@ blJ
 blJ
 xEN
 xEN
-xEN
+jWg
 xEN
 xEN
 hqP
@@ -43308,7 +43651,7 @@ blJ
 blJ
 blJ
 buv
-buv
+viz
 xEN
 xEN
 xEN
@@ -43521,7 +43864,7 @@ bjA
 blv
 bjy
 bjy
-bjy
+eNv
 bjy
 bud
 buv
@@ -48968,7 +49311,7 @@ byE
 byU
 bze
 bwF
-adx
+bzH
 bzW
 hLo
 bAG
@@ -49406,7 +49749,7 @@ bzI
 bxu
 bAq
 bAH
-aSn
+byA
 bwF
 bBl
 bxg
@@ -54261,7 +54604,7 @@ dnl
 dnl
 kKe
 vCh
-vCh
+vyZ
 vCh
 vCh
 kKe
@@ -57623,7 +57966,7 @@ oOR
 oOR
 oOR
 tzo
-tzo
+whf
 tzo
 tzo
 uMP
@@ -66461,7 +66804,7 @@ adZ
 dnl
 dnl
 oCk
-qQh
+vST
 vST
 nAH
 lsj
@@ -69184,7 +69527,7 @@ aPo
 nBy
 nBy
 nBy
-lqu
+nBy
 lrE
 qgz
 riu


### PR DESCRIPTION


## About The Pull Request

Makes some changes around the Lz's as well as removes some old changed from version 2.1 that are no longer needed.

## Why It's Good For The Game

Lz's had too many attackable positions which made it annoying as hell for marines and not really fair for them. this changes things to still make them attackable but at least gives marines a fair chance. this also changes the south of the lz1 cargo area to make it fairer for Xenos to defend against marine unga balls. also removes some building denial areas until fobs are opened as they were too large. the western caves should at all times be Xeno territory.

## Changelog
:cl:
balance: Both Lz's to make it different and fairer for marines.
balance: south LZ1 cargo area to make it fairer for Xenos.
balance: no-build zones that shouldn't exist in areas where they are not needed.
balance: removes stuff I added in v2.1 such as the supply depot in lz1 that opened when shutters did which wasn't intended and deletes some useless stuff such as ladder i forgot to remove
/:cl:

![image2](https://user-images.githubusercontent.com/64131993/131215474-52881b9a-09f4-4226-9401-032cbc65248f.png)
![image1](https://user-images.githubusercontent.com/64131993/131215476-618f9f2a-d186-4778-866c-58baec301505.png)

