### PR TITLE
You can't put more than 2 guns(pistol, revolver) in bags anymore

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -12,8 +12,8 @@
 	storage_slots = null
 	max_storage_space = 24
 	access_delay = 1.5 SECONDS
-	cant_hold = list(
-		/obj/item/weapon/gun/pistol,
+	storage_type_limits = list(
+		/obj/item/weapon/gun = 2,
 	)
 
 /obj/item/storage/backpack/should_access_delay(obj/item/item, mob/user, taking_out)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -13,8 +13,7 @@
 	max_storage_space = 24
 	access_delay = 1.5 SECONDS
 	storage_type_limits = list(
-		/obj/item/weapon/gun/pistol = 2,
-		/obj/item/weapon/gun/pistol/standard_pocketpistol = 30,
+		/obj/item/weapon/gun = 2,
 	)
 
 /obj/item/storage/backpack/should_access_delay(obj/item/item, mob/user, taking_out)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -12,6 +12,9 @@
 	storage_slots = null
 	max_storage_space = 24
 	access_delay = 1.5 SECONDS
+	cant_hold = list(
+		/obj/item/weapon/gun/pistol,
+	)
 
 /obj/item/storage/backpack/should_access_delay(obj/item/item, mob/user, taking_out)
 	if(!taking_out) // Always allow items to be tossed in instantly
@@ -149,6 +152,9 @@
 	storage_slots = null
 	max_storage_space = 15
 	access_delay = 0
+	cant_hold = list(
+
+	)
 
 /obj/item/storage/backpack/satchel/withwallet/Initialize(mapload, ...)
 	. = ..()

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -13,7 +13,8 @@
 	max_storage_space = 24
 	access_delay = 1.5 SECONDS
 	storage_type_limits = list(
-		/obj/item/weapon/gun = 2,
+		/obj/item/weapon/gun/pistol = 2,
+		/obj/item/weapon/gun/pistol/standard_pocketpistol = 30,
 	)
 
 /obj/item/storage/backpack/should_access_delay(obj/item/item, mob/user, taking_out)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -152,9 +152,6 @@
 	storage_slots = null
 	max_storage_space = 15
 	access_delay = 0
-	cant_hold = list(
-
-	)
 
 /obj/item/storage/backpack/satchel/withwallet/Initialize(mapload, ...)
 	. = ..()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You can't put more than 2 pistols in bags anymore.

Pistols can be used as a secondary, or you can reload them pretty efficiently with the pistol belt.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

https://media.discordapp.net/attachments/504094319075131402/881174890210820196/sins.PNG?width=874&height=670

Pistols loadout have:
-Incredible DPS. You can kill ancient runner in one sec with tp 23
-Amazing sunder
-Instant reload. Taking a two new pistols from a combat back pack takes half a sec
-Insane speed. Because zero slowdown, no need to wield
-Basically immune to stun. You don't have to wield, you can just take new pistols

And the compromise for that is:
- It's long to make your l... Wait, no longer the case, you can just use loadout vendor
- You have to come to fob to reload quite often. 

That's it.

Pistols in bag are an issue since the beginning, it's time to kill that meme

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: You can't put more than 2 guns in bags anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
