### PR TITLE
Adds more stages of health self examinatoin

### DIFF
--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -218,19 +218,27 @@
 				status += "bruised"
 			if(20 to 40)
 				status += "battered"
-			if(40 to INFINITY)
+			if(40 to 60)
 				status += "mangled"
+			if(60 to 100)
+				status += "brutalized"
+			if(100 to INFINITY)
+				status += "eviscerated"
 
 		if(brutedamage > 0 && burndamage > 0)
 			status += " and "
 
 		switch(burndamage)
-			if(1 to 10)
+			if(1 to 20)
 				status += "numb"
-			if(10 to 40)
+			if(20 to 40)
 				status += "blistered"
-			if(40 to INFINITY)
+			if(40 to 60)
 				status += "peeling away"
+			if(60 to 100)
+				status += "searing away"
+			if(100 to INFINITY)
+				status += "burnt to a crisp"
 
 		if(!status)
 			status = "OK"

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -223,7 +223,7 @@
 			if(60 to 100)
 				status += "brutalized"
 			if(100 to INFINITY)
-				status += "eviscerated"
+				status += "mutilated"
 
 		if(brutedamage > 0 && burndamage > 0)
 			status += " and "


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Marines should be able to tell what the general damage to their body is better than the current system which barely tells you anything since it genericizes past 40 brute/burn
this adds 60 to 100 and 100+
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
marines can tell how eviscerated they are
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: marines have more messages telling them the severity of their wounds when they self examine
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
