### PR TITLE
Flashlights are now not useless

### DIFF
--- a/code/game/objects/items/marine_gear.dm
+++ b/code/game/objects/items/marine_gear.dm
@@ -8,6 +8,7 @@
 	desc = "A robust flashlight designed to be held in the hand, or attached to a rifle"
 	force = 10 //This is otherwise no different from a normal flashlight minus the flavour.
 	throwforce = 12 //"combat" flashlight
+	resistance_flags = UNACIDABLE
 
 
 /obj/item/coin/marine


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Combat flashlights are now unacidable as a response to #8100
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Combat flashlights are an inferior alternative to flares yet they somehow got nerfed without proper reason. Flares are easier to carry, easier to resupply AND have added utility of burning targets when thrown at them. Flashlights are generally used because of map spawns rather than somebody intentionally packing a whole bag of flashlights (instead of packing flares which is at least 4 times more space efficient I believe).

Now flashlights have a niche instead of becoming obsolete.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Combat flashlight is now unacidable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
