### PR TITLE
Adds a custom OOC color for a new admin rank

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -65,6 +65,8 @@
 				display_class = "headminooc"
 			if("Headmentor")
 				display_class = "headmentorooc"
+			if("Senior Admin")
+				display_class = "senioradminooc"
 			if("Admin")
 				display_class = "adminooc"
 			if("Trial Admin")

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -319,6 +319,10 @@ em {
   color: #397339;
   font-weight: bold;
 }
+.senioradminooc {
+  color: #CC707F;
+  font-weight: bold;
+}
 .adminooc {
   color: #C3324A;
   font-weight: bold;

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -335,7 +335,10 @@ em {
   color: #004100;
   font-weight: bold;
 }
-
+.senioradminooc {
+  color: #8C3141;
+  font-weight: bold;
+}
 .adminooc	{
   color: #b4001e;
   font-weight: bold;


### PR DESCRIPTION
## About The Pull Request

Per title. A new admin rank, Senior Admin, will be added in-game, and it requires a defined OOC color to account for its existence.

## Why It's Good For The Game

Allows us to give a new rank, as a courtesy, to former leads who have retired but continue to be admins.

## Changelog
:cl:
add: Added a custom OOC color for a new admin rank.
/:cl: