### PR TITLE
Sterilizine disinfects wounds

### DIFF
--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -455,12 +455,12 @@ Note that amputating the affected organ does in fact remove the infection from t
 	for(var/datum/wound/W in wounds)
 		//Open wounds can become infected
 		if (owner.germ_level > W.germ_level && W.infection_check() && W.damage)
-			W.germ_level += min(1,round(W.damage/20)) //The bigger the wound, the more germs will enter
+			W.germ_level += max(1,round(W.damage/20)) //The bigger the wound, the more germs will enter
 
 		if (antibiotics < MIN_ANTIBIOTICS)
 			//Infected wounds raise the organ's germ level.
 			if (W.germ_level)
-				germ_level += min(1,round(W.germ_level/35))
+				germ_level += max(1,round(W.germ_level/35))
 		else if (W.germ_level && prob(80)) //Antibiotics wont be very effective it the wound is still open
 			germ_level++
 

--- a/code/modules/reagents/reagents/other.dm
+++ b/code/modules/reagents/reagents/other.dm
@@ -641,7 +641,11 @@
 	if(!(method in list(TOUCH, VAPOR, PATCH)))
 		return
 	L.germ_level -= min(volume * 20 * touch_protection, L.germ_level)
-	if((L.getFireLoss() > 30 || L.getBruteLoss() > 30) && prob(10)) // >Spraying space bleach on open wounds
+	if(ishuman(L))
+		var/mob/living/carbon/human/disinfectee = L
+		for(var/datum/limb/nub AS in disinfectee.limbs)
+			nub.disinfect() //Only removes germs from individual external wounds. Won't help with the limb itself having a high germ level.
+	if(prob(L.getFireLoss() + L.getBruteLoss())) // >Spraying space bleach on open wounds
 		if(iscarbon(L))
 			var/mob/living/carbon/C = L
 			if(C.species.species_flags & NO_PAIN)


### PR DESCRIPTION
## About The Pull Request
Makes sterilizine disinfect external wounds when it's sprayed on a human. Wound germs exist distinctly from limb germs, so this will only indirectly help with an existing limb infection. 
Also makes it more likely to be painful, scaling with target's wounds, and replaced two mins in wound germ formula that I'm convinced were mistaken.

## Why It's Good For The Game
Right now sterilizine doesn't do anything space cleaner doesn't do better (except make people scream), but I don't feel like space cleaner needs toning down. This adds a separate use for sterilizine in the same vein without trivializing infected limbs.

## Changelog
:cl:
add: Sprayed sterilizine disinfects existing wounds. It won't help directly with infected limbs though.
balance: Spraying sterilizine on people with existing wounds is more likely to cause pain.
fix: Wounds no longer infect limbs more slowly when you have antibiotics
/:cl: