### PR TITLE
Sentry Tweaks

### DIFF
--- a/code/game/objects/machinery/deployable.dm
+++ b/code/game/objects/machinery/deployable.dm
@@ -4,6 +4,8 @@
 	///Since /obj/machinery/deployable aquires its sprites from an item and are set in New(), initial(icon_state) would return null. This var exists as a substitute.
 	var/default_icon_state
 
+	flags_atom = PREVENT_CONTENTS_EXPLOSION
+
 	hud_possible = list(MACHINE_HEALTH_HUD)
 
 /obj/machinery/deployable/Initialize(mapload, _internal_item, deployer)
@@ -16,6 +18,10 @@
 	icon = initial(internal_item.icon)
 	default_icon_state = initial(internal_item.icon_state) + "_deployed"
 	icon_state = default_icon_state
+
+	var/obj/internal_object = _internal_item
+	soft_armor = internal_object.soft_armor
+	hard_armor = internal_object.hard_armor
 
 	prepare_huds()
 	for(var/datum/atom_hud/squad/sentry_status_hud in GLOB.huds) //Add to the squad HUD

--- a/code/game/objects/machinery/deployable.dm
+++ b/code/game/objects/machinery/deployable.dm
@@ -1,12 +1,11 @@
 /obj/machinery/deployable
+	flags_atom = PREVENT_CONTENTS_EXPLOSION
+	hud_possible = list(MACHINE_HEALTH_HUD)
+
 	///Item that is deployed to create src.
 	var/obj/item/internal_item
 	///Since /obj/machinery/deployable aquires its sprites from an item and are set in New(), initial(icon_state) would return null. This var exists as a substitute.
 	var/default_icon_state
-
-	flags_atom = PREVENT_CONTENTS_EXPLOSION
-
-	hud_possible = list(MACHINE_HEALTH_HUD)
 
 /obj/machinery/deployable/Initialize(mapload, _internal_item, deployer)
 	. = ..()
@@ -19,9 +18,8 @@
 	default_icon_state = initial(internal_item.icon_state) + "_deployed"
 	icon_state = default_icon_state
 
-	var/obj/internal_object = _internal_item
-	soft_armor = internal_object.soft_armor
-	hard_armor = internal_object.hard_armor
+	soft_armor = internal_item.soft_armor
+	hard_armor = internal_item.hard_armor
 
 	prepare_huds()
 	for(var/datum/atom_hud/squad/sentry_status_hud in GLOB.huds) //Add to the squad HUD

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -132,7 +132,7 @@
 	///If the gun is deployable, the time it takes for the weapon to undeploy.
 	var/undeploy_time = 0
 	///List of turf/objects/structures that will be ignored in the sentries targeting.
-	var/list/ignored_terrains = list()
+	var/list/ignored_terrains
 	///Flags that the deployed sentry uses upon deployment.
 	var/turret_flags = NONE
 	///Damage threshold for whether a turret will be knocked down.

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -131,6 +131,8 @@
 	var/deploy_time = 0
 	///If the gun is deployable, the time it takes for the weapon to undeploy.
 	var/undeploy_time = 0
+	///List of turf/objects/structures that will be ignored in the sentries targeting.
+	var/list/ignored_terrains = list()
 	///Flags that the deployed sentry uses upon deployment.
 	var/turret_flags = NONE
 	///Damage threshold for whether a turret will be knocked down.

--- a/code/modules/projectiles/guns/mounted.dm
+++ b/code/modules/projectiles/guns/mounted.dm
@@ -63,6 +63,7 @@
 	undeploy_time = 3 SECONDS
 
 	max_integrity = 125
+	soft_armor = list("melee" = 0, "bullet" = 50, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 0, "fire" = 0, "acid" = 0)
 
 ///This and get_ammo_count is to make sure the ammo counter functions.
 /obj/item/weapon/gun/tl102/get_ammo_type()
@@ -147,4 +148,5 @@
 	undeploy_time = 3 SECONDS
 
 	max_integrity = 150
+	soft_armor = list("melee" = 0, "bullet" = 50, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 0, "fire" = 0, "acid" = 0)
 

--- a/code/modules/projectiles/guns/sentries.dm
+++ b/code/modules/projectiles/guns/sentries.dm
@@ -19,7 +19,6 @@
 
 	ignored_terrains = list(
 		/obj/machinery/deployable/mounted,
-		/turf/closed/glass,
 		/obj/machinery/miner,
 	)
 

--- a/code/modules/projectiles/guns/sentries.dm
+++ b/code/modules/projectiles/guns/sentries.dm
@@ -7,6 +7,7 @@
 	reload_sound = 'sound/weapons/guns/interact/smartgun_unload.ogg'
 
 	max_integrity = 200
+	soft_armor = list("melee" = 50, "bullet" = 50, "laser" = 50, "energy" = 50, "bomb" = 50, "bio" = 100, "rad" = 0, "fire" = 80, "acid" = 50)
 
 	fire_delay = 0.6 SECONDS
 	extra_delay = 0.6 SECONDS
@@ -15,6 +16,12 @@
 	scatter_unwielded = 0
 	burst_scatter_mult = 0
 	burst_amount = 4
+
+	ignored_terrains = list(
+		/obj/machinery/deployable/mounted,
+		/turf/closed/glass,
+		/obj/machinery/miner,
+	)
 
 	turret_flags = TURRET_HAS_CAMERA|TURRET_SAFETY|TURRET_ALERTS
 	flags_gun_features = GUN_AUTO_EJECTOR|GUN_AMMO_COUNTER|GUN_LOAD_INTO_CHAMBER|GUN_DEPLOYED_FIRE_ONLY|GUN_WIELDED_FIRING_ONLY|GUN_IS_SENTRY|GUN_IFF

--- a/code/modules/projectiles/mounted.dm
+++ b/code/modules/projectiles/mounted.dm
@@ -6,7 +6,6 @@
 	density = TRUE
 	layer = ABOVE_MOB_LAYER
 	use_power = FALSE
-	soft_armor = list("melee" = 0, "bullet" = 50, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 0, "fire" = 0, "acid" = 0)
 	hud_possible = list(MACHINE_HEALTH_HUD, SENTRY_AMMO_HUD)
 
 ///generates the icon based on how much ammo it has.

--- a/code/modules/projectiles/sentries.dm
+++ b/code/modules/projectiles/sentries.dm
@@ -6,9 +6,6 @@
 	req_one_access = list(ACCESS_MARINE_ENGINEERING, ACCESS_MARINE_ENGPREP, ACCESS_MARINE_LEADER)
 	hud_possible = list(MACHINE_HEALTH_HUD, SENTRY_AMMO_HUD)
 
-
-	soft_armor = list("melee" = 50, "bullet" = 50, "laser" = 50, "energy" = 50, "bomb" = 50, "bio" = 100, "rad" = 0, "fire" = 80, "acid" = 50)
-
 	///Spark system for making sparks
 	var/datum/effect_system/spark_spread/spark_system
 	///Camera for viewing with cam consoles
@@ -32,6 +29,8 @@
 	///Iff signal of the sentry. If the /gun has a set IFF then this will be the same as that. If not the sentry will get its IFF signal from the deployer
 	var/iff_signal = NONE
 
+	var/list/ignored_terrains
+
 //------------------------------------------------------------------
 //Setup and Deletion
 
@@ -47,6 +46,7 @@
 
 	knockdown_threshold = gun.knockdown_threshold
 	range = gun.turret_range
+	ignored_terrains = gun.ignored_terrains
 
 	radio = new(src)
 
@@ -260,6 +260,8 @@
 /obj/machinery/deployable/mounted/sentry/proc/knock_down()
 	if(CHECK_BITFIELD(machine_stat, KNOCKED_DOWN))
 		return
+	var/obj/item/weapon/gun/internal_gun = internal_item 
+	internal_gun.stop_fire() //Comrade sentry has been sent to the gulags. He served the revolution well.
 	visible_message(span_highdanger("The [name] is knocked over!"))
 	sentry_alert(SENTRY_ALERT_FALLEN)
 	ENABLE_BITFIELD(machine_stat, KNOCKED_DOWN)
@@ -404,15 +406,15 @@
 		if(smoke && smoke.opacity)
 			return FALSE
 
-		if(IS_OPAQUE_TURF(T) || T.density && T.throwpass == FALSE)
+		if(IS_OPAQUE_TURF(T) || T.density && T.throwpass == FALSE && !(T.type in ignored_terrains))
 			return FALSE
 
 		for(var/obj/machinery/MA in T)
-			if(MA.density && MA.throwpass == FALSE)
+			if(MA.density && MA.throwpass == FALSE && !(MA.type in ignored_terrains))
 				return FALSE
 
 		for(var/obj/structure/S in T)
-			if(S.density && S.throwpass == FALSE )
+			if(S.density && S.throwpass == FALSE && !(S.type in ignored_terrains))
 				return FALSE
 
 	return TRUE


### PR DESCRIPTION


## About The Pull Request

Fixes Issue #7926 
Also fixes the issue where a sentry will continue blasting its last target while knocked down.

Puts deployed machine armor values as based on the thing it is deployed from.
Adds a list of typepaths that will be of turf the sentry ignores.
These are set to the miners, and other deployed items.

## Why It's Good For The Game

Fixes a pair of bugs. Makes setting armor values item based. Allows for ignoring terrain so we can have cool things in the future like laser sentries that shoot through glass.

## Changelog
:cl:
balance: Sentries can now shoot past other deployed items and Miners.
fix: Fixes the issue with null internal guns on sentries.
fix: Fixes Comrade sentry.
code: Updates /deployable and makes armor values dependent on the deploying item.
/:cl:

