### PR TITLE
Limits max magazines in med belts

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -125,7 +125,7 @@
 		/obj/item/roller,
 	)
 	storage_type_limits = list(
-		/obj/item/ammo_magazine = 2,
+		/obj/item/ammo_magazine = 3,
 	)
 
 /obj/item/storage/belt/medical/Initialize()

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -124,6 +124,9 @@
 		/obj/item/storage/pill_bottle/packet,
 		/obj/item/roller,
 	)
+	storage_type_limits = list(
+		/obj/item/ammo_magazine = 2,
+	)
 
 /obj/item/storage/belt/medical/Initialize()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Limits the medical belt to only 3 magazines stored.

## Why It's Good For The Game
Currently the dedicated ammo storage belt can hold 5 magazines.
The medical belt can hold 14.
That's kind of absurd.

## Changelog
:cl:
balance: Medical belts can only hold up to three magazines. Their total storage isn't changed.
/:cl: