### PR TITLE
Fix door shooting/hitting logging excessively

### DIFF
--- a/code/game/objects/machinery/doors/airlock.dm
+++ b/code/game/objects/machinery/doors/airlock.dm
@@ -267,15 +267,17 @@
 
 /obj/machinery/door/airlock/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)
 	. = ..()
-	if(is_mainship_level(z)) //log shipside greytiders
+	if(. && is_mainship_level(z)) //log shipside greytiders
 		log_attack("[key_name(proj.firer)] shot [src] with [proj] at [AREACOORD(src)]")
-		msg_admin_ff("[ADMIN_TPMONTY(proj.firer)] shot [src] with [proj] in [ADMIN_VERBOSEJMP(src)].")
+		if(SSmonitor.gamestate != SHIPSIDE)
+			msg_admin_ff("[ADMIN_TPMONTY(proj.firer)] shot [src] with [proj] in [ADMIN_VERBOSEJMP(src)].")
 
 /obj/machinery/door/airlock/attacked_by(obj/item/I, mob/living/user, def_zone)
 	. = ..()
 	if(. && is_mainship_level(z))
 		log_attack("[src] has been hit with [I] at [AREACOORD(src)] by [key_name(user)]")
-		msg_admin_ff("[ADMIN_TPMONTY(user)] hit [src] with [I] in [ADMIN_VERBOSEJMP(src)].")
+		if(SSmonitor.gamestate != SHIPSIDE)
+			msg_admin_ff("[ADMIN_TPMONTY(user)] hit [src] with [I] in [ADMIN_VERBOSEJMP(src)].")
 
 /obj/machinery/door/airlock/attackby(obj/item/I, mob/user, params)
 	. = ..()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Doors will now only log when the bullet impacts and only send the FF message before the hijack ship launches

## Changelog
:cl:
admin: Doors will now only log when the bullet impacts and only send the FF message before the hijack ship launches
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
