### PR TITLE
Lets you clear a single recipe from dispensers

### DIFF
--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -168,6 +168,7 @@
 	.["recipes"] = user.client.prefs.chem_macros
 
 	.["recordingRecipe"] = recording_recipe
+	.["clearingRecipe"] = clearing_recipe
 
 /obj/machinery/chem_dispenser/ui_act(action, list/params)
 	. = ..()
@@ -177,6 +178,8 @@
 	if(needs_medical_training && ishuman(usr))
 		var/mob/living/carbon/human/user = usr
 		if(!user.skills.getRating("medical"))
+			if(user.do_actions)
+				return
 			to_chat(user, span_notice("You start fiddling with \the [src]..."))
 			if(!do_after(user, SKILL_TASK_EASY, TRUE, src, BUSY_ICON_UNSKILLED))
 				return
@@ -258,17 +261,21 @@
 		if("clear_recipes")
 			if(!is_operational())
 				return
-			var/confirm_clear = tgui_alert(usr, "Clear all recipes?", null, list("Yes","No", "Only one"))
-			if(confirm_clear == "Only one")
-				clearing_recipe = TRUE
+			if(clearing_recipe)
+				clearing_recipe = FALSE
 				return TRUE
-			if(confirm_clear == "Yes")
-				usr.client.prefs.chem_macros = list()
-				usr.client.prefs.save_preferences()
+			var/confirm_clear = tgui_alert(usr, "Clear all recipes?", null, list("Yes","No", "Only one"))
+			switch(confirm_clear)
+				if("Only one")
+					clearing_recipe = TRUE
+				if("Yes")
+					usr.client.prefs.chem_macros = list()
+					usr.client.prefs.save_preferences()
 			. = TRUE
 		if("record_recipe")
 			if(!is_operational())
 				return
+			clearing_recipe = FALSE
 			recording_recipe = list()
 			. = TRUE
 		if("save_recording")

--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -228,11 +228,9 @@
 			if(!is_operational() || QDELETED(cell))
 				return
 			if(clearing_recipe)
-				var/actually_clear = tgui_alert(usr, "Clear recipe [params["recipe"]]?", null, list("Yes","No"))
-				if(actually_clear == "Yes")
+				if(tgui_alert(usr, "Clear recipe [params["recipe"]]?", null, list("Yes","No")) == "Yes")
 					usr.client.prefs.chem_macros.Remove(params["recipe"])
 					usr.client.prefs.save_preferences()
-				clearing_recipe = FALSE
 				return TRUE
 			var/list/chemicals_to_dispense = usr.client.prefs.chem_macros[params["recipe"]]
 			if(!LAZYLEN(chemicals_to_dispense))
@@ -264,8 +262,7 @@
 			if(clearing_recipe)
 				clearing_recipe = FALSE
 				return TRUE
-			var/confirm_clear = tgui_alert(usr, "Clear all recipes?", null, list("Yes","No", "Only one"))
-			switch(confirm_clear)
+			switch(tgui_alert(usr, "Clear all recipes?", null, list("Yes","No", "Only one")))
 				if("Only one")
 					clearing_recipe = TRUE
 				if("Yes")

--- a/tgui/packages/tgui/interfaces/ChemDispenser.js
+++ b/tgui/packages/tgui/interfaces/ChemDispenser.js
@@ -53,7 +53,7 @@ export const ChemDispenser = (props, context) => {
               {!recording && (
                 <Box inline mx={1}>
                   <Button
-                    color="transparent"
+                    color={data.clearingRecipe ? "red" : "transparent"}
                     content="Clear recipes"
                     onClick={() => act('clear_recipes')} />
                 </Box>


### PR DESCRIPTION
## About The Pull Request
As title. Hit the delete recipes button, choose 'only one', and then press the recipe you wanna clear.
Also fixes a bug with dispenser fumble checks.

## Why It's Good For The Game
Being able to clear a specific recipe is better than having to clear all recipes if you want to remove one and then readd all the others.

## Changelog
:cl:
add: You can choose to only remove a single chem recipe instead of all of them when using a dispenser.
fix: You can't start fiddling with a chem dispenser while you're busy doing something else.
/:cl: