### PR TITLE
Miner module buff for reinforcement

### DIFF
--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -284,7 +284,7 @@
 		return
 	if(miner_upgrade_type == MINER_RESISTANT && !(X.mob_size == MOB_SIZE_BIG || X.xeno_caste.caste_flags & CASTE_IS_STRONG) ) //Reinforced miners can't be attacked unless the caste is strong
 		X.visible_message(span_notice("[X]'s claws bounce off of [src]'s reinforced plating."),
-		span_notice("You can't slash through [src]'s reinforced plating!"))
+		span_notice("We can't slash through [src]'s reinforced plating!"))
 		return
 	while(miner_status != MINER_DESTROYED)
 		if(!do_after(X, 3 SECONDS, TRUE, src, BUSY_ICON_DANGER, BUSY_ICON_HOSTILE))

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -282,7 +282,8 @@
 /obj/machinery/miner/attack_alien(mob/living/carbon/xenomorph/X, damage_amount = X.xeno_caste.melee_damage, damage_type = BRUTE, damage_flag = "", effects = TRUE, armor_penetration = 0, isrightclick = FALSE)
 	if(X.status_flags & INCORPOREAL) //Incorporeal xenos cannot attack physically.
 		return
-	if( (miner_upgrade_type == MINER_RESISTANT) && (X.mob_size != MOB_SIZE_BIG) ) //Reinforced miners can't be attacked unless the caste is strong
+	if( (miner_upgrade_type == MINER_RESISTANT) && !((X.mob_size == MOB_SIZE_BIG || X.xeno_caste.caste_flags & CASTE_IS_STRONG)) ) //Reinforced miners can't be attacked unless the caste is strong
+		X.visible_message(span_notice("You can't slash through [src]'s reinforced plating!"))
 		return
 	while(miner_status != MINER_DESTROYED)
 		if(!do_after(X, 3 SECONDS, TRUE, src, BUSY_ICON_DANGER, BUSY_ICON_HOSTILE))

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -90,7 +90,7 @@
 			max_miner_integrity = 300
 			miner_integrity = 300
 		if(MINER_OVERCLOCKED)
-			required_ticks = 50
+			required_ticks = 60
 		if(MINER_AUTOMATED)
 			if(stored_mineral)
 				SSpoints.supply_points[faction] += mineral_value * stored_mineral
@@ -282,8 +282,9 @@
 /obj/machinery/miner/attack_alien(mob/living/carbon/xenomorph/X, damage_amount = X.xeno_caste.melee_damage, damage_type = BRUTE, damage_flag = "", effects = TRUE, armor_penetration = 0, isrightclick = FALSE)
 	if(X.status_flags & INCORPOREAL) //Incorporeal xenos cannot attack physically.
 		return
-	if( (miner_upgrade_type == MINER_RESISTANT) && !((X.mob_size == MOB_SIZE_BIG || X.xeno_caste.caste_flags & CASTE_IS_STRONG)) ) //Reinforced miners can't be attacked unless the caste is strong
-		X.visible_message(span_notice("You can't slash through [src]'s reinforced plating!"))
+	if(miner_upgrade_type == MINER_RESISTANT && !((X.mob_size == MOB_SIZE_BIG || X.xeno_caste.caste_flags & CASTE_IS_STRONG)) ) //Reinforced miners can't be attacked unless the caste is strong
+		X.visible_message(span_notice("[X]'s claws bounce off of [src]'s reinforced plating."),
+		span_notice("You can't slash through [src]'s reinforced plating!"))
 		return
 	while(miner_status != MINER_DESTROYED)
 		if(!do_after(X, 3 SECONDS, TRUE, src, BUSY_ICON_DANGER, BUSY_ICON_HOSTILE))

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -282,7 +282,7 @@
 /obj/machinery/miner/attack_alien(mob/living/carbon/xenomorph/X, damage_amount = X.xeno_caste.melee_damage, damage_type = BRUTE, damage_flag = "", effects = TRUE, armor_penetration = 0, isrightclick = FALSE)
 	if(X.status_flags & INCORPOREAL) //Incorporeal xenos cannot attack physically.
 		return
-	if(miner_upgrade_type == MINER_RESISTANT && !((X.mob_size == MOB_SIZE_BIG || X.xeno_caste.caste_flags & CASTE_IS_STRONG)) ) //Reinforced miners can't be attacked unless the caste is strong
+	if(miner_upgrade_type == MINER_RESISTANT && !(X.mob_size == MOB_SIZE_BIG || X.xeno_caste.caste_flags & CASTE_IS_STRONG) ) //Reinforced miners can't be attacked unless the caste is strong
 		X.visible_message(span_notice("[X]'s claws bounce off of [src]'s reinforced plating."),
 		span_notice("You can't slash through [src]'s reinforced plating!"))
 		return

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -282,7 +282,7 @@
 /obj/machinery/miner/attack_alien(mob/living/carbon/xenomorph/X, damage_amount = X.xeno_caste.melee_damage, damage_type = BRUTE, damage_flag = "", effects = TRUE, armor_penetration = 0, isrightclick = FALSE)
 	if(X.status_flags & INCORPOREAL) //Incorporeal xenos cannot attack physically.
 		return
-	if(MINER_RESISTANT & !CASTE_IS_STRONG) //Reinforced miners can't be attacked unless the caste is strong
+	if( (miner_upgrade_type == MINER_RESISTANT) && (X.mob_size != MOB_SIZE_BIG) ) //Reinforced miners can't be attacked unless the caste is strong
 		return
 	while(miner_status != MINER_DESTROYED)
 		if(!do_after(X, 3 SECONDS, TRUE, src, BUSY_ICON_DANGER, BUSY_ICON_HOSTILE))

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -282,7 +282,7 @@
 /obj/machinery/miner/attack_alien(mob/living/carbon/xenomorph/X, damage_amount = X.xeno_caste.melee_damage, damage_type = BRUTE, damage_flag = "", effects = TRUE, armor_penetration = 0, isrightclick = FALSE)
 	if(X.status_flags & INCORPOREAL) //Incorporeal xenos cannot attack physically.
 		return
-	if(miner_upgrade_type == MINER_RESISTANT && !(X.mob_size == MOB_SIZE_BIG || X.xeno_caste.caste_flags & CASTE_IS_STRONG) ) //Reinforced miners can't be attacked unless the caste is strong
+	if(miner_upgrade_type == MINER_RESISTANT && !(X.mob_size == MOB_SIZE_BIG || X.xeno_caste.caste_flags & CASTE_IS_STRONG))
 		X.visible_message(span_notice("[X]'s claws bounce off of [src]'s reinforced plating."),
 		span_notice("We can't slash through [src]'s reinforced plating!"))
 		return

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -283,12 +283,8 @@
 	if(X.status_flags & INCORPOREAL) //Incorporeal xenos cannot attack physically.
 		return
 	if(miner_upgrade_type == MINER_RESISTANT && !((X.mob_size == MOB_SIZE_BIG || X.xeno_caste.caste_flags & CASTE_IS_STRONG)) ) //Reinforced miners can't be attacked unless the caste is strong
-<<<<<<< HEAD
 		X.visible_message(span_notice("[X]'s claws bounce off of [src]'s reinforced plating."),
 		span_notice("You can't slash through [src]'s reinforced plating!"))
-=======
-		X.visible_message(span_notice("You can't slash through [src]'s reinforced plating!"))
->>>>>>> Miningmakesmefeelgood
 		return
 	while(miner_status != MINER_DESTROYED)
 		if(!do_after(X, 3 SECONDS, TRUE, src, BUSY_ICON_DANGER, BUSY_ICON_HOSTILE))

--- a/code/game/objects/machinery/miner.dm
+++ b/code/game/objects/machinery/miner.dm
@@ -90,7 +90,7 @@
 			max_miner_integrity = 300
 			miner_integrity = 300
 		if(MINER_OVERCLOCKED)
-			required_ticks = 60
+			required_ticks = 50
 		if(MINER_AUTOMATED)
 			if(stored_mineral)
 				SSpoints.supply_points[faction] += mineral_value * stored_mineral
@@ -281,6 +281,8 @@
 
 /obj/machinery/miner/attack_alien(mob/living/carbon/xenomorph/X, damage_amount = X.xeno_caste.melee_damage, damage_type = BRUTE, damage_flag = "", effects = TRUE, armor_penetration = 0, isrightclick = FALSE)
 	if(X.status_flags & INCORPOREAL) //Incorporeal xenos cannot attack physically.
+		return
+	if(MINER_RESISTANT & !CASTE_IS_STRONG) //Reinforced miners can't be attacked unless the caste is strong
 		return
 	while(miner_status != MINER_DESTROYED)
 		if(!do_after(X, 3 SECONDS, TRUE, src, BUSY_ICON_DANGER, BUSY_ICON_HOSTILE))


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reinforcement module for miners now makes them immune to castes without CASTE_STRONG or MOB_SIZE_BIG flag
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I've literally never seen any upgrade other than automation module on miners for months and haven't seen reinforcement module used ever since it got added. The added integrity is practically useless when the miner breaks on the first hit no matter what. So now it needs to be broken by a caste that can break acided walls to make sure fast flanking castes can't just hit and run.

Overclock buff was removed from the PR due to maintainer demand
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Miner reinforcement upgrade protects against non-strong castes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
