### PR TITLE
Defibs now deal 10 heart damage on successful revive

### DIFF
--- a/code/game/objects/items/defibrillator.dm
+++ b/code/game/objects/items/defibrillator.dm
@@ -224,7 +224,7 @@
 
 	var/datum/internal_organ/heart/heart = H.internal_organs_by_name["heart"]
 	if(!issynth(H) && heart && prob(25))
-		heart.take_damage(10) //Allow the defibrilator to possibly worsen heart damage. Still rare enough to just be the "clone damage" of the defib
+		heart.take_damage(5) //Allow the defibrilator to possibly worsen heart damage. Still rare enough to just be the "clone damage" of the defib
 
 	if(!H.has_working_organs())
 		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Defibrillation failed. Patient's general condition does not allow reviving."))

--- a/code/game/objects/items/defibrillator.dm
+++ b/code/game/objects/items/defibrillator.dm
@@ -223,9 +223,6 @@
 		return
 
 	var/datum/internal_organ/heart/heart = H.internal_organs_by_name["heart"]
-	if(!issynth(H) && heart && prob(25))
-		heart.take_damage(5) //Allow the defibrilator to possibly worsen heart damage. Still rare enough to just be the "clone damage" of the defib
-
 	if(!H.has_working_organs())
 		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Defibrillation failed. Patient's general condition does not allow reviving."))
 		return

--- a/code/game/objects/items/defibrillator.dm
+++ b/code/game/objects/items/defibrillator.dm
@@ -223,7 +223,7 @@
 		return
 
 	var/datum/internal_organ/heart/heart = H.internal_organs_by_name["heart"]
-	if(!issynth(H) && heart)
+	if(!issynth(H) && heart && prob(25))
 		heart.take_damage(10) //Allow the defibrilator to possibly worsen heart damage. Still rare enough to just be the "clone damage" of the defib
 
 	if(!H.has_working_organs())
@@ -275,6 +275,7 @@
 	H.regenerate_icons()
 	H.reload_fullscreens()
 	H.flash_act()
+	heart.take_damage(10) //10 heart damage on a successful revive.
 	H.apply_effect(10, EYE_BLUR)
 	H.apply_effect(10, PARALYZE)
 	H.handle_regular_hud_updates()

--- a/code/game/objects/items/defibrillator.dm
+++ b/code/game/objects/items/defibrillator.dm
@@ -223,8 +223,8 @@
 		return
 
 	var/datum/internal_organ/heart/heart = H.internal_organs_by_name["heart"]
-	if(!issynth(H) && heart && prob(25))
-		heart.take_damage(5) //Allow the defibrilator to possibly worsen heart damage. Still rare enough to just be the "clone damage" of the defib
+	if(!issynth(H) && heart)
+		heart.take_damage(10) //Allow the defibrilator to possibly worsen heart damage. Still rare enough to just be the "clone damage" of the defib
 
 	if(!H.has_working_organs())
 		user.visible_message(span_warning("[icon2html(src, viewers(user))] \The [src] buzzes: Defibrillation failed. Patient's general condition does not allow reviving."))


### PR DESCRIPTION
## About The Pull Request
Per title. This PR also removes the 25% probability for 5 heart damage for each defib attempt.

## Why It's Good For The Game
Currently, it's _very_ easy for dead marines to get found thanks to the minimap, and revived with little to no prevalent consequences for dying. This aims to change that by making successful defib attempts deal 10 heart damage, which should be enough to actually punish marines for dying.

## Changelog
:cl: Lewdcifer
balance: 25 percent probability for 5 heart damage per defib removed.
balance: Successfully defibrillating a marine now deals 10 heart damage.
/:cl:
