### PR TITLE
Machete damage nerfed back to 60

### DIFF
--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -214,7 +214,7 @@
 	name = "\improper M2132 machete"
 	desc = "Latest issue of the TGMC Machete. Great for clearing out jungle or brush on outlying colonies. Found commonly in the hands of scouts and trackers, but difficult to carry with the usual kit."
 	icon_state = "machete"
-	force = 75
+	force = 60
 	attack_speed = 12
 	w_class = WEIGHT_CLASS_BULKY
 


### PR DESCRIPTION
## About The Pull Request
Per title.

## Why It's Good For The Game
75 melee damage, paired up with a shield, on top of bump attacks. This easily allows you to outperform xenomorphs in melee, which is arguably their main thing.

## Changelog
:cl: Lewdcifer
balance: Machete damage reduced from 75 to 60.
/:cl: