### PR TITLE
Fixes unmapped area in Big Red

### DIFF
--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -19437,9 +19437,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/south)
-"cxt" = (
-/turf/open/floor/asteroidfloor,
-/area/space)
 "cyp" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 9
@@ -25483,7 +25480,7 @@ bLG
 aaf
 aaf
 aaf
-cxt
+aaf
 alH
 aae
 cQC


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes this unmapped tile in Big Red LZ1.
![bigredhole](https://user-images.githubusercontent.com/49290523/132080740-80585f38-8757-4ae4-ba89-3fad76f34b7a.png)

## Why It's Good For The Game

Instant death bad. Spacetiles bad. Instant death by unmarked spacetile even worse.

## Changelog
:cl:
fix: Fixed an unmapped area in Big Red LZ.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
