### PR TITLE
Jaeger armor changes- 30/40/50

### DIFF
--- a/code/modules/modular_armor/armor_pieces.dm
+++ b/code/modules/modular_armor/armor_pieces.dm
@@ -119,7 +119,7 @@
 	name = "\improper Jaeger Pattern Medium Infantry chestplates"
 	desc = "Designed for use with the Jaeger Combat Exoskeleton. It provides moderate protection and encumbrance when attached and is fairly easy to attach and remove from armor. Click on the armor frame to attach it. This armor appears to be marked as a Infantry armor piece."
 	icon_state = "infantry_chest"
-	soft_armor = list("melee" = 15, "bullet" = 20, "laser" = 20, "energy" = 10, "bomb" = 10, "bio" = 10, "rad" = 10, "fire" = 10, "acid" = 15)
+	soft_armor = list("melee" = 10, "bullet" = 20, "laser" = 20, "energy" = 10, "bomb" = 10, "bio" = 10, "rad" = 10, "fire" = 10, "acid" = 15)
 	slowdown = 0.3
 	greyscale_config = /datum/greyscale_config/modularchest_infantry
 
@@ -127,7 +127,7 @@
 	name = "\improper Jaeger Pattern Light Skirmisher chestplates"
 	desc = "Designed for use with the Jaeger Combat Exoskeleton. It provides minor protection and encumbrance when attached and is fairly easy to attach and remove from armor. Click on the armor frame to attach it. This armor appears to be marked as a Skirmisher armor piece."
 	icon_state = "skirmisher_chest"
-	soft_armor = list("melee" = 10, "bullet" = 15, "laser" = 15, "energy" = 10, "bomb" = 10, "bio" = 10, "rad" = 10, "fire" = 10, "acid" = 10)
+	soft_armor = list("melee" = 0, "bullet" = 15, "laser" = 15, "energy" = 10, "bomb" = 5, "bio" = 10, "rad" = 10, "fire" = 10, "acid" = 10)
 	slowdown = 0.1
 	greyscale_config = /datum/greyscale_config/modularchest_skirmisher
 
@@ -141,7 +141,7 @@
 	name = "\improper Jaeger Pattern Heavy Assault chestplates"
 	desc = "Designed for use with the Jaeger Combat Exoskeleton. It provides high protection and encumbrance when attached and is fairly easy to attach and remove from armor. Click on the armor frame to attach it. This armor appears to be marked as a Assault armor piece."
 	icon_state = "assault_chest"
-	soft_armor = list("melee" = 20, "bullet" = 25, "laser" = 25, "energy" = 10, "bomb" = 10, "bio" = 10, "rad" = 10, "fire" = 10, "acid" = 20)
+	soft_armor = list("melee" = 20, "bullet" = 25, "laser" = 25, "energy" = 10, "bomb" = 15, "bio" = 10, "rad" = 10, "fire" = 10, "acid" = 20)
 	slowdown = 0.5
 	greyscale_config = /datum/greyscale_config/modularchest_assault
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Armor levels assume arms/legs and jumpsuit+jaeger suit (5+5+20+X)
Changes the armor levels from 40/45/50 to 30/40/50, bomb armor changed slightly, 5/10/15
slowdown unchanged.
Chest armor changed to 0/10/20
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Light armor is currently absurd and 35% is barely any kind of a nerf, it'll have 30% with arms, and give sbullet proct, it only has 0.1 slowdown anyway. Has less bomb armor so bomb armor is different per level
Medium armor gets a 5% melee damage nerf, as it has 0.4 less slowdown than heavy. 10 bomb armor.
heavy is unchaged outside of 5 more bomb armor.

There is literally a .6 difference between heavy and light, and the difference is 5%??
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: jaeger armor levels changed to 30/40/50, bomb armor values changed for jaeger, light has 5, medium has 10, heavy has 15.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
