### PR TITLE
somebody left X tile in LZ1, this removes X tile from LZ1

### DIFF
--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -19437,9 +19437,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/south)
-"cxt" = (
-/turf/open/floor/asteroidfloor,
-/area/space)
 "cyp" = (
 /turf/open/floor/plating/ground/mars/dirttosand{
 	dir = 9
@@ -25483,7 +25480,7 @@ bLG
 aaf
 aaf
 aaf
-cxt
+aaf
 alH
 aae
 cQC


### PR DESCRIPTION


## About The Pull Request

removes instagib tile from lz1

## Why It's Good For The Game

no one gets insta gibbed

## Changelog
:cl:
fix: removes X zone tile from lz1
/:cl:

![image](https://user-images.githubusercontent.com/64131993/132091267-5b490bb4-2884-4766-8ee0-3c5a3af9a351.png)

