### PR TITLE
Revolvers nerf.

### DIFF
--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -355,13 +355,13 @@
 		/obj/item/attachable/lace,
 	)
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 19,"rail_x" = 13, "rail_y" = 23, "under_x" = 22, "under_y" = 14, "stock_x" = 22, "stock_y" = 19)
-	fire_delay = 0.15 SECONDS
+	fire_delay = 0.25 SECONDS
 	accuracy_mult_unwielded = 0.85
 	accuracy_mult = 1
-	scatter_unwielded = 15
+	scatter_unwielded = 25
 	scatter = 2.5
 	recoil = 0
-	recoil_unwielded = 0.75
+	recoil_unwielded = 1.25
 
 //-------------------------------------------------------
 //M-44, based off the SAA.


### PR DESCRIPTION
## About The Pull Request

It increases revolvers fire delay, scatter unwielded and recoil unwielded. I can adjust values, i take ideas. I dont wanna really kill the revolver just add some sense to akimbo. 

## Why It's Good For The Game

Akimbo has no fire delay and the scatter/recoil its not enough, Its been long due to make since they got nor fire delay and they lack the reload necessity . 

## Changelog
:cl:
Balance: Fire delay from 0.15 to 0.25, Scatter unwielded from15 to 25, and Recoil Unwielded from 0.75 to 1.25.
/:cl:
