### PR TITLE
Rage Power is Now Maximized While at Negative HP

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -549,7 +549,6 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 #define RAVAGER_RAGE_DURATION							10 SECONDS
 #define RAVAGER_RAGE_WARNING							0.7
 #define RAVAGER_RAGE_POWER_MULTIPLIER					0.5 //How much we multiply our % of missing HP by to determine Rage Power
-#define RAVAGER_RAGE_NEGATIVE_HP_POWER_MULTIPLIER		-0.0075 //How much we multiply our negative HP by to determine Rage Power
 #define RAVAGER_RAGE_MIN_HEALTH_THRESHOLD				0.5 //The maximum % of HP we can have to trigger Rage
 #define RAVAGER_RAGE_SUPER_RAGE_THRESHOLD				0.5 //The minimum amount of Rage Power we need to trigger the bonus Rage effects
 #define RAVAGER_RAGE_ENDURE_INCREASE_PER_SLASH			2 SECONDS //The amount of time each slash during Super Rage increases Endure's duration

--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -284,10 +284,8 @@
 
 	rage_power = (1-(X.health/X.maxHealth)) * RAVAGER_RAGE_POWER_MULTIPLIER //Calculate the power of our rage; scales with difference between current and max HP
 
-	if(X.health < 0) //Gain additional rage with negative HP; gain + 0.0075 rage power per point of negative HP
-		rage_power += X.health * RAVAGER_RAGE_NEGATIVE_HP_POWER_MULTIPLIER
-
-	rage_power = min(1, rage_power) //Cap rage power so that we don't get way too insane.
+	if(X.health < 0) //If we're at less than 0 HP, it's time to max rage.
+		rage_power = 1
 
 	var/rage_power_radius = CEILING(rage_power * 7, 1) //Define radius of the SFX
 


### PR DESCRIPTION
## About The Pull Request

Ravager's Rage now has maximum power when used at any negative HP amount instead of -57 HP or less. This is to make things more consistent and offset the loss of extra critical HP that the original rage power scaling was based on.

## Why It's Good For The Game

Rage Power is now properly adapted to the bonus Critical Hit Points that currently exist. Rage Power scaling is made more consistent and simplified.

## Changelog
:cl:
balance: Ravager's Rage now has maximum power when used at any negative HP amount instead of -57 HP or less.
/:cl: