### PR TITLE
Suicide Vest Buff

### DIFF
--- a/code/game/objects/items/explosives/bombvest.dm
+++ b/code/game/objects/items/explosives/bombvest.dm
@@ -52,7 +52,7 @@
 		if(istype(appendage, /datum/limb/chest) || istype(appendage, /datum/limb/groin) || istype(appendage, /datum/limb/head))
 			continue
 		appendage.droplimb()
-	explosion(loc, 2, 2, 6, 5, 5)
+	explosion(loc, 3, 2, 6, 5, 5)
 	qdel(src)
 
 ///Gets a warcry to scream on Control Click, checks for non allowed warcries.


### PR DESCRIPTION
## About The Pull Request
``explosion(loc, 2, 2, 6, 5, 5)`` -> ``explosion(loc, 3, 2, 6, 5, 5)`` on the suicide vest
essentially makes it kill any ancient T2 and ancient boilers/defilers (which is just a result of boilers/defilers having really low explosion resistance) point-blank.

## Why It's Good For The Game
As of right now the suicide vest can only kill ancient drones, ancient sentinels, and ancient runners at point blank, even young defenders can take one point-blank, this makes the vest feel like it is massively underperforming as in comparison xenos can just stun the user, run away (given most xenos can outrun marines), or kill the user before they can make use of their vest given how little armor it provides, and even if they get hit, most of them can walk off without issue or will just get healed by their allies a couple moments later and run back into the action as if nothing happened while the marine gets all their limbs (except their head) decapped and a massive amount of damage inflicted on their body making it really hard to revive them.

So with this PR i'm making it so that the suicide vest kills ancient T2's and ancient boilers/defilers. warriors/defenders (even the young ones) have enough explosive resistance to survive it so they will still be generally left untouched by this change.

## Changelog
:cl: Vondiech
balance: TGMC has recently given their explosive vests some extra "Cuban Le Pette" powder, with recent tests showing it is now able to kill most T2 Types caught point-blank without issue, and getting caste type "Boilers" and "Defilers" aswell!
/:cl: