### PR TITLE
Toning down infections

### DIFF
--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -478,11 +478,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 		//Infected wounds raise the organ's germ level steadily over time. Can outpace antibiotics if it gets bad enough.
 		if (W.germ_level)
-			if(!antibiotics)
-				germ_level += round((W.germ_level + 10)/30) //One point per tick at 20, then another every 30
-			else if(prob(W.germ_level - 20)) //Light infections mostly won't pass to the limb with spaceacillin, heavy ones will pass much more slowly.
-				germ_level++
-
+			germ_level += round((W.germ_level + 10)/35) //One point per tick at 20, then another every 35
 
 /datum/limb/proc/handle_germ_effects()
 	var/spaceacillin = owner.reagents.get_reagent_amount(/datum/reagent/medicine/spaceacillin)

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -67,7 +67,7 @@
 	///INTERNAL germs inside the organ, this is BAD if it's greater than INFECTION_LEVEL_ONE
 	var/germ_level = 0
 	///Keeps track of the last time the limb bothered its owner about infection to prevent spam.
-	var/next_infection_message
+	COOLDOWN_DECLARE(next_infection_message)
 	///What % of the body does this limb cover. Make sure that the sum is always 100.
 	var/cover_index = 0
 

--- a/code/modules/organs/wound.dm
+++ b/code/modules/organs/wound.dm
@@ -126,7 +126,7 @@
 /datum/wound/proc/infection_check()
 	if(damage < 10)	//small cuts, tiny bruises, and moderate burns shouldn't be infectable.
 		return NONE
-	if(is_treated() && damage < 25)	//anything less than a flesh wound (or equivalent) isn't infectable if treated properly
+	if(is_treated() && (damage < 25 || !prob(damage * 2))) //Small treated wounds can't be infected, medium ones are just less likely
 		return NONE
 	if(disinfected)
 		germ_level = 0	//reset this, just in case
@@ -181,6 +181,10 @@
 
 	desc = desc_list[current_stage]
 	min_damage = damage_list[current_stage]
+
+	bandaged = FALSE
+	disinfected = FALSE
+	salved = FALSE
 
 	// returns whether this wound can absorb the given amount of damage.
 	// this will prevent large amounts of damage being trapped in less severe wound types

--- a/code/modules/organs/wound.dm
+++ b/code/modules/organs/wound.dm
@@ -175,7 +175,7 @@
 	damage += initial_damage
 	bleed_timer += damage
 
-	var/damage_per_wound = initial_damage / amount
+	var/damage_per_wound = damage / amount
 	while(current_stage > 1 && damage_list[current_stage - 1] <= damage_per_wound)
 		current_stage--
 


### PR DESCRIPTION
## About The Pull Request
Tuning for wound/limb infection.
Wounds gaining germs is unchanged, but once they're closed they'll slowly clear out their own infection if it's not too high. Kitting helps here.
Slightly rescaled how fast wound germs transfer to the limb: a minimum amount are required so a fresh wound won't start transferring instantly.
Infected limbs are now much more apparent to their player, with repeating messages the same way broken bones show up. These're suppressed if you have spaceacillin in you.
Health analyzers have a lower threshold for detecting infected wounds.

Also a minor fix with wounds not changing their current state correctly when they worsen. Shouldn't affect function at all, just how they show up on examine.

## Why It's Good For The Game
They're a bit excessive right now. This might be too much, but there's plenty of knobs to tune back up later.

## Changelog
:cl:
qol: Infected limbs are less subtle to their owner.
balance: Wounds with smaller amounts of germs will now disinfect passively over time. Treatment speeds this up.
balance: Fresh wounds won't immediately start infecting the limb they're on.
fix: Wounds that worsen now do so more visibly.
/:cl: