### PR TITLE
Remove Sadar Miniscope

### DIFF
--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -1019,7 +1019,6 @@
 	general_codex_key = "explosive weapons"
 	attachable_allowed = list(
 		/obj/item/attachable/magnetic_harness,
-		/obj/item/attachable/scope/mini,
 	)
 
 	flags_gun_features = GUN_WIELDED_FIRING_ONLY|GUN_AMMO_COUNTER


### PR DESCRIPTION

## About The Pull Request
Removes the miniscope as an attachment option for the sadar.

## Why It's Good For The Game
Removes off-screen one shot kills.

## Changelog
:cl:
balance: Sadar no longer has a miniscope attachment option.
/:cl:
