### PR TITLE
Fixes Ice Colony's LZ2 resin wall before shutters exploit

### DIFF
--- a/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -32710,7 +32710,7 @@
 /turf/open/floor/plating/icefloor/warnplate{
 	dir = 1
 	},
-/area/ice_colony/exterior/surface/landing_pad)
+/area/ice_colony/exterior/surface/taxiway)
 "ltv" = (
 /turf/open/floor/plating/ground/snow/layer1,
 /area/ice_colony/exterior/underground/caves/ice_nw)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Well "Exploit" might be a strong word, more like map design oversight. However yesterday Xeno players had no qualms building a solid 10+ tile deep resin wall before the shutters opened, preventing Marine from effectively leaving the FOB in that direction.

The fix is so disgustingly simple its amazing it hasn't been done sooner, by the magic of changing **1** **(ONE)** area tile Xenos can now no longer build on the taxiway until the shutters are opened.

Tested locally and everything seems to be in order.

## Why It's Good For The Game

Fixes a map issue and makes LZ2 slightly less horrible to deal with.

## Changelog
:cl: Joniroq

fix: Fixed a mapping oversight on Ice Colony's LZ2, no more cheesing resin walls right up against the shutters.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
