### PR TITLE
TP-14 Standard Pistol Nerf

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -228,7 +228,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage = 20
 	penetration = 5
 	accurate_range = 5
-	sundering = 0.4
+	sundering = 1
 
 /datum/ammo/bullet/pistol/tiny
 	name = "light pistol bullet"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -228,7 +228,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage = 20
 	penetration = 5
 	accurate_range = 5
-	sundering = 1.65
+	sundering = 0.5
 
 /datum/ammo/bullet/pistol/tiny
 	name = "light pistol bullet"
@@ -264,7 +264,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	hud_state = "pistol_hollow"
 	accuracy = -15
 	shrapnel_chance = 45
-	sundering = 2
+	sundering = 0.6
 
 /datum/ammo/bullet/pistol/hollow/on_hit_mob(mob/M,obj/projectile/P)
 	staggerstun(M, P, stagger = 1, slowdown = 0.5, knockback = 1)

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -228,7 +228,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage = 20
 	penetration = 5
 	accurate_range = 5
-	sundering = 0.2
+	sundering = 0.4
 
 /datum/ammo/bullet/pistol/tiny
 	name = "light pistol bullet"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -228,7 +228,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	damage = 20
 	penetration = 5
 	accurate_range = 5
-	sundering = 0.5
+	sundering = 0.2
 
 /datum/ammo/bullet/pistol/tiny
 	name = "light pistol bullet"
@@ -264,7 +264,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	hud_state = "pistol_hollow"
 	accuracy = -15
 	shrapnel_chance = 45
-	sundering = 0.6
+	sundering = 2
 
 /datum/ammo/bullet/pistol/hollow/on_hit_mob(mob/M,obj/projectile/P)
 	staggerstun(M, P, stagger = 1, slowdown = 0.5, knockback = 1)

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -70,7 +70,7 @@
 	scatter_unwielded = 0
 	recoil = -2
 	recoil_unwielded = -2
-	upper_akimbo_accuracy = 6
+	upper_akimbo_accuracy = 5
 	lower_akimbo_accuracy = 4
 
 //-------------------------------------------------------

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -70,8 +70,8 @@
 	scatter_unwielded = 0
 	recoil = -2
 	recoil_unwielded = -2
-	upper_akimbo_accuracy = 10
-	lower_akimbo_accuracy = 9
+	upper_akimbo_accuracy = 7
+	lower_akimbo_accuracy = 6
 
 //-------------------------------------------------------
 //TX-7 Plasma Pistol

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -70,8 +70,8 @@
 	scatter_unwielded = 0
 	recoil = -2
 	recoil_unwielded = -2
-	upper_akimbo_accuracy = 7
-	lower_akimbo_accuracy = 5
+	upper_akimbo_accuracy = 6
+	lower_akimbo_accuracy = 4
 
 //-------------------------------------------------------
 //TX-7 Plasma Pistol

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -70,8 +70,8 @@
 	scatter_unwielded = 0
 	recoil = -2
 	recoil_unwielded = -2
-	upper_akimbo_accuracy = 5
-	lower_akimbo_accuracy = 4
+	upper_akimbo_accuracy = 4
+	lower_akimbo_accuracy = 3
 
 //-------------------------------------------------------
 //TX-7 Plasma Pistol

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -70,8 +70,8 @@
 	scatter_unwielded = 0
 	recoil = -2
 	recoil_unwielded = -2
-	upper_akimbo_accuracy = 9
-	lower_akimbo_accuracy = 7
+	upper_akimbo_accuracy = 11
+	lower_akimbo_accuracy = 10
 
 //-------------------------------------------------------
 //TX-7 Plasma Pistol

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -56,7 +56,7 @@
 	icon_state = "tp14"
 	item_state = "tp14"
 	caliber = CALIBER_9X19 //codex
-	max_shells = 21 //codex
+	max_shells = 14 //codex
 	fire_sound = 'sound/weapons/guns/fire/tp14.ogg'
 	reload_sound = 'sound/weapons/guns/interact/tp14_reload.ogg'
 	current_mag = /obj/item/ammo_magazine/pistol/standard_pistol
@@ -70,8 +70,8 @@
 	scatter_unwielded = 0
 	recoil = -2
 	recoil_unwielded = -2
-	upper_akimbo_accuracy = 4
-	lower_akimbo_accuracy = 3
+	upper_akimbo_accuracy = 10
+	lower_akimbo_accuracy = 9
 
 //-------------------------------------------------------
 //TX-7 Plasma Pistol

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -70,8 +70,8 @@
 	scatter_unwielded = 0
 	recoil = -2
 	recoil_unwielded = -2
-	upper_akimbo_accuracy = 4
-	lower_akimbo_accuracy = 3
+	upper_akimbo_accuracy = 5
+	lower_akimbo_accuracy = 4
 
 //-------------------------------------------------------
 //TX-7 Plasma Pistol

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -70,8 +70,8 @@
 	scatter_unwielded = 0
 	recoil = -2
 	recoil_unwielded = -2
-	upper_akimbo_accuracy = 11
-	lower_akimbo_accuracy = 10
+	upper_akimbo_accuracy = 5
+	lower_akimbo_accuracy = 4
 
 //-------------------------------------------------------
 //TX-7 Plasma Pistol

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -56,7 +56,7 @@
 	icon_state = "tp14"
 	item_state = "tp14"
 	caliber = CALIBER_9X19 //codex
-	max_shells = 14 //codex
+	max_shells = 21 //codex
 	fire_sound = 'sound/weapons/guns/fire/tp14.ogg'
 	reload_sound = 'sound/weapons/guns/interact/tp14_reload.ogg'
 	current_mag = /obj/item/ammo_magazine/pistol/standard_pistol

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -71,7 +71,7 @@
 	recoil = -2
 	recoil_unwielded = -2
 	upper_akimbo_accuracy = 7
-	lower_akimbo_accuracy = 6
+	lower_akimbo_accuracy = 5
 
 //-------------------------------------------------------
 //TX-7 Plasma Pistol

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -71,7 +71,7 @@
 	recoil = -2
 	recoil_unwielded = -2
 	upper_akimbo_accuracy = 5
-	lower_akimbo_accuracy = 4
+	lower_akimbo_accuracy = 3
 
 //-------------------------------------------------------
 //TX-7 Plasma Pistol

--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -70,8 +70,8 @@
 	scatter_unwielded = 0
 	recoil = -2
 	recoil_unwielded = -2
-	upper_akimbo_accuracy = 5
-	lower_akimbo_accuracy = 3
+	upper_akimbo_accuracy = 9
+	lower_akimbo_accuracy = 7
 
 //-------------------------------------------------------
 //TX-7 Plasma Pistol

--- a/code/modules/projectiles/magazines/pistols.dm
+++ b/code/modules/projectiles/magazines/pistols.dm
@@ -7,7 +7,7 @@
 	desc = "A pistol magazine."
 	caliber = CALIBER_9X19
 	icon_state = "tp14"
-	max_rounds = 21
+	max_rounds = 14
 	w_class = WEIGHT_CLASS_SMALL
 	default_ammo = /datum/ammo/bullet/pistol
 	gun_type = /obj/item/weapon/gun/pistol/standard_pistol

--- a/code/modules/projectiles/magazines/pistols.dm
+++ b/code/modules/projectiles/magazines/pistols.dm
@@ -7,7 +7,7 @@
 	desc = "A pistol magazine."
 	caliber = CALIBER_9X19
 	icon_state = "tp14"
-	max_rounds = 14
+	max_rounds = 21
 	w_class = WEIGHT_CLASS_SMALL
 	default_ammo = /datum/ammo/bullet/pistol
 	gun_type = /obj/item/weapon/gun/pistol/standard_pistol


### PR DESCRIPTION
## About The Pull Request

I can try targeting akimbo more effectively while retaining the pistol's original design if this nerf is too harsh, but this is just a basic nerf on the TP-14 to guarantee that it is no longer melting xenos so easily.

## Why It's Good For The Game

Testing in-game pre-nerf: 
The akimbo pistol can reduce a 500 health Ancient Empress to 80 health in 42 shots. 
The pistol can empty its mag in 3 seconds with a fire rate of 8 shots per second.
It deals 69.3 sunder from 42 shots.
After nerf:
It reduces Ancient Empress to 44 health in 42 shots. Still takes 3 seconds.
It deals 42 sunder from 42 shots.

Yes, I think I tested poorly to get an increase in damage after the nerf, but it's still weaker anyways purely statistically.

Now the sunder is less insane, at 16 sunder per second for akimbo. It can still laser beam right now though, so I will be adding another modifier for akimbo to make it have a miss chance in another PR and apply it to TP-14 first.



## Changelog
:cl:
balance: The TP-14 sunder is reduced to 1 from 1.65, and its akimbo scatter range from (30 to 40) to (40 to 50). This will come out as 5 to 15 with attachments instead of -5 to 5.
/:cl:
