### PR TITLE
Replaces ryetalin in combat injectors with dylovene

### DIFF
--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -47,9 +47,9 @@
 	icon_state = "autoinjector-4"
 	volume = 30
 	list_reagents = list(
-		/datum/reagent/medicine/ryetalyn = 5,
 		/datum/reagent/medicine/bicaridine = 10,
 		/datum/reagent/medicine/kelotane = 10,
+		/datum/reagent/medicine/dylovene = 5,
 		/datum/reagent/medicine/tramadol = 5,
 	)
 

--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -47,10 +47,10 @@
 	icon_state = "autoinjector-4"
 	volume = 30
 	list_reagents = list(
+		/datum/reagent/medicine/ryetalyn = 5,
 		/datum/reagent/medicine/bicaridine = 10,
 		/datum/reagent/medicine/kelotane = 10,
 		/datum/reagent/medicine/tramadol = 5,
-		/datum/reagent/medicine/ryetalyn = 5,
 	)
 
 /obj/item/reagent_containers/hypospray/autoinjector/combat_advanced


### PR DESCRIPTION
## About The Pull Request
The other ingredients in a combat injector (bkt) purge ryetalin, so you'd get either one or zero ticks of it working before it got removed. Replacing rye with dylo makes it more reliable as a low-grade purgative option. It also adds minor toxin healing, which isn't super important but isn't otherwise available in base marine loadout supplies.

## Why It's Good For The Game
An injector having ingredients that purge each other is a little wack and led to cases where one reagent would just never apply.

## Changelog
:cl:
fix: Combat injectors have dylovene instead of ryetalin, so they'll purge toxins more reliably.
/:cl: