### PR TITLE
Maximum marines alive requirement for hijack

### DIFF
--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -626,6 +626,12 @@
 		if(!(X.hive.hive_flags & HIVE_CAN_HIJACK))
 			to_chat(X, span_warning("Our hive lacks the psychic prowess to hijack the bird."))
 			return
+		var/groundside_humans
+		for(var/N in GLOB.alive_human_list)
+			var/mob/H = N
+			if(H.z != X.z)
+				continue
+			groundside_humans++
 		if(groundside_humans > MAXIMUM_GROUNDSIDE_HUMANS_FOR_HIJACK)
 			to_chat(X, span_xenowarning("There is still prey left to hunt!"))
 			return

--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -1,3 +1,6 @@
+#define MAXIMUM_GROUNDSIDE_HUMANS_FOR_HIJACK 5
+#define MAXIMUM_GROUNDSIDE_HUMANS_FOR_CAPTURE 5
+
 // marine dropships
 /obj/docking_port/stationary/marine_dropship
 	name = "dropship landing zone"
@@ -623,6 +626,9 @@
 		if(!(X.hive.hive_flags & HIVE_CAN_HIJACK))
 			to_chat(X, span_warning("Our hive lacks the psychic prowess to hijack the bird."))
 			return
+		if(groundside_humans > MAXIMUM_GROUNDSIDE_HUMANS_FOR_HIJACK)
+			to_chat(X, span_xenowarning("There is still prey left to hunt!"))
+			return
 		switch(M.mode)
 			if(SHUTTLE_RECHARGING)
 				to_chat(X, span_xenowarning("The bird is still cooling down."))
@@ -644,7 +650,7 @@
 				continue
 			groundside_humans++
 
-		if(groundside_humans > 5)
+		if(groundside_humans > MAXIMUM_GROUNDSIDE_HUMANS_FOR_CAPTURE)
 			to_chat(X, span_xenowarning("There is still prey left to hunt!"))
 			return
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Per title, Lewd, pette also are in support of this

## Why It's Good For The Game
Stealthjack is not good for the xenos who get killed, or the marines that now have to rush shipside because they left a cade open for the last xeno to sneak into fob and prolong the round

## Changelog
:cl:
balance: Added a maximum marines alive requirement for hijack
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
