### PR TITLE
T-90/19 semi buff/aim mode adding

### DIFF
--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -69,12 +69,12 @@
 
 	attachable_offset = list("muzzle_x" = 27, "muzzle_y" = 19,"rail_x" = 9, "rail_y" = 20, "under_x" = 21, "under_y" = 14, "stock_x" = 24, "stock_y" = 10)
 
-	accuracy_mult = 1.5
-	accuracy_mult_unwielded = 0.85
+	accuracy_mult = 1.2
+	accuracy_mult_unwielded = 0.95
 	recoil_unwielded = 0
 	scatter = 0
 	fire_delay = 0.15 SECONDS
-	scatter_unwielded = 5 //Made to be better used one handed.
+	scatter_unwielded = 2 //Made to be better used one handed.
 	aim_slowdown = 0.15
 	burst_amount = 5
 	movement_acc_penalty_mult = 0
@@ -115,12 +115,15 @@
 	flags_gun_features = GUN_AUTO_EJECTOR|GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER|GUN_LOAD_INTO_CHAMBER
 	gun_firemode_list = list(GUN_FIREMODE_SEMIAUTO, GUN_FIREMODE_AUTOMATIC)
 	attachable_offset = list("muzzle_x" = 32, "muzzle_y" = 15,"rail_x" = 22, "rail_y" = 22, "under_x" = 17, "under_y" = 15, "stock_x" = 24, "stock_y" = 10)
+	actions_types = list(/datum/action/item_action/aim_mode)
+	aim_fire_delay = 0.05 SECONDS
+	aim_speed_modifier = 0.55
 
 	accuracy_mult = 1.15
-	accuracy_mult_unwielded = 0.8
-	scatter = 0
+	accuracy_mult_unwielded = 0.9
+	scatter = -2
 	fire_delay = 0.15 SECONDS
-	scatter_unwielded = 30
+	scatter_unwielded = 20
 	aim_slowdown = 0.25
 	burst_amount = 0
 

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -95,8 +95,6 @@
 	flags_equip_slot = ITEM_SLOT_BACK
 	wield_delay = 0.5 SECONDS
 	force = 20
-	aim_speed_modifier = 0.4
-	aim_fire_delay = 0.2 SECONDS
 	current_mag = /obj/item/ammo_magazine/smg/standard_smg
 	type_of_casings = null
 	attachable_allowed = list(
@@ -116,7 +114,7 @@
 	gun_firemode_list = list(GUN_FIREMODE_SEMIAUTO, GUN_FIREMODE_AUTOMATIC)
 	attachable_offset = list("muzzle_x" = 32, "muzzle_y" = 15,"rail_x" = 22, "rail_y" = 22, "under_x" = 17, "under_y" = 15, "stock_x" = 24, "stock_y" = 10)
 	actions_types = list(/datum/action/item_action/aim_mode)
-	aim_fire_delay = 0.05 SECONDS
+	aim_fire_delay = 0.1 SECONDS
 	aim_speed_modifier = 0.55
 
 	accuracy_mult = 1.15


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

## T-19 ##
Accuracy mult when wielded reduced by .3, and added .1 to the unwielded accuracy so it fits better into it's designated role as a one handed automatic firearm.
Unwielded scatter reduced from 5 to 2.
## T90 ##

Added Aim mode
0.1 fire delay adding so it has 0.25 fire delay and 0.55 slowdown.
This'll make the T-90 have a better defined niche as a decently fast aim mode chasing weapon, but it'll have rifle fire rate. (IT CAN'T TAKE GYRO SO DON'T COMPLAIN ABOUT IT)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gives both guns better definements in their niche.
T-90 gets aim mode, which it needed a while ago, and T-19 gets better one handed stats.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: T-90 has aim mode, and T-19 has better one handed stats (reduced scatter by 3 and accuracy buff by .1), two handed accuracy reduced from 1.5 to 1.2.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
