### PR TITLE
Revert "fixes not being able to shoot on adjacent tiles. (#8066)"

### DIFF
--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -628,7 +628,7 @@ User can be passed as null, (a gun reloading itself for instance), so we need to
 			dual_wield = TRUE
 		if(gun_user.in_throw_mode)
 			return
-		if(gun_user.Adjacent(object) && !isopenturf(object)) //Dealt with by attack code
+		if(gun_user.Adjacent(object)) //Dealt with by attack code
 			return
 	if(QDELETED(object))
 		return


### PR DESCRIPTION
This reverts commit b605c33542ac9f2245204a8b175612dc78a4f29c.

<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Remove being able to shoot on adjacent tile

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I keep shooting at weeds, or in other marines. And i keep seeing people shooting at random

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: No longer shooting at adjacent tiles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
