### PR TITLE
Sleeping changes

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -126,21 +126,22 @@
 /datum/status_effect/incapacitating/sleeping/tick()
 	if(owner.maxHealth)
 		var/health_ratio = owner.health / owner.maxHealth
-		var/healing = -0.2
+		var/healing = -0.003125 //set for a base of 0.25 healed per 2-second interval asleep in a bed with covers.
 		if((locate(/obj/structure/bed) in owner.loc))
-			healing -= 0.3
+			healing -= 0.00625
 		else if((locate(/obj/structure/table) in owner.loc))
-			healing -= 0.1
+			healing -= 0.003125
 		for(var/obj/item/bedsheet/bedsheet in range(owner.loc,0))
 			if(bedsheet.loc != owner.loc) //bedsheets in your backpack/neck don't give you comfort
 				continue
-			healing -= 0.1
+			healing -= 0.003125
 			break //Only count the first bedsheet
-		if(health_ratio > 0.8)
+		if(health_ratio > -0.5)
 			owner.adjustBruteLoss(healing)
 			owner.adjustFireLoss(healing)
 			owner.adjustToxLoss(healing * 0.5, TRUE, TRUE)
-		owner.adjustStaminaLoss(healing)
+			owner.adjustStaminaLoss(healing * 100)
+			owner.adjustCloneLoss(healing * health_ratio * 0.8)
 	if(human_owner && human_owner.drunkenness)
 		human_owner.drunkenness *= 0.997 //reduce drunkenness by 0.3% per tick, 6% per 2 seconds
 	if(prob(20))

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -1,4 +1,5 @@
 #define TRAIT_STATUS_EFFECT(effect_id) "[effect_id]-trait"
+#define BASE_HEAL_RATE -0.003125
 
 //Largely negative status effects go here, even if they have small benificial effects
 //STUN EFFECTS
@@ -126,15 +127,15 @@
 /datum/status_effect/incapacitating/sleeping/tick()
 	if(owner.maxHealth)
 		var/health_ratio = owner.health / owner.maxHealth
-		var/healing = -0.003125 //set for a base of 0.25 healed per 2-second interval asleep in a bed with covers.
+		var/healing = BASE_HEAL_RATE //set for a base of 0.25 healed per 2-second interval asleep in a bed with covers.
 		if((locate(/obj/structure/bed) in owner.loc))
-			healing -= 0.00625
+			healing += (2 * BASE_HEAL_RATE)
 		else if((locate(/obj/structure/table) in owner.loc))
-			healing -= 0.003125
+			healing += BASE_HEAL_RATE
 		for(var/obj/item/bedsheet/bedsheet in range(owner.loc,0))
 			if(bedsheet.loc != owner.loc) //bedsheets in your backpack/neck don't give you comfort
 				continue
-			healing -= 0.003125
+			healing += BASE_HEAL_RATE
 			break //Only count the first bedsheet
 		if(health_ratio > -0.5)
 			owner.adjustBruteLoss(healing)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

End-user summary- If you sleep on a bed with sheets and are not in crit, you'll heal 0.25 brute, 0.25 burn, 0.125 toxloss, 25 stamina, and a variable amount of cloneloss (-0.1 to 0.2, depending on your overall health). If you sleep on the floor, you get a quarter of those values.


First off, this uses regular ticks, not lifeticks, so there's that. You heal 20 times in the span that chems would heal you once, so let me just get that outta the way. The numbers are bigger than they look to be.

Adjusts health_ratio number to be -0.5 or greater, hence you'll heal if sleeping above crit. If you're crit, you're SOL, and probably also getting eaten by a ravager or something.

Does fancy math to standardize the base healing amount to 0.25 per two seconds when in a bed with a bedsheet on it. Let's see... we want to divide that by 20 to get regular gameticks, so 0.0125, then divide *that* by 4 for 0.003125, and assign as needed to bed, table, floor, and bedsheet. Easy.

So now a standard bed with a bedsheet will heal a base amount of 0.25/2 second interval. Brute and burn stay as is, toxloss stays as is, staminaloss is multiplied by 100 (25, regular staminaheal is usually *higher* than that!), and cloneloss... cloneloss is adjusted to a base healrate of 0.2/ 2 seconds, at 100% hp.

Additionally, the cloneloss recovery rate is tied directly to how healthy you are via your health ratio. This means that if you go to sleep below 0 HP, or keep getting slashed in and out of crit and get unlucky on tickrate, you can end up with trace amounts of cloneloss. Just take a brief nap once healed if it really bothers you to have 0.5835 cloneloss, it'll heal within seconds.

Drunkenness left untouched.



## Why It's Good For The Game

Fixes a broken system, RP uses, way to slowly heal a small amount of cloneloss planetside. Really, mostly RP uses.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
expansion: Added stuff to sleeping. If you sleep on a bed with sheets and are not in crit, you'll heal 0.25 brute, 0.25 burn, 0.125 toxloss, 25 stamina, and a variable amount of cloneloss (-0.1 to 0.2, depending on your overall health). If you sleep on the floor, you get a quarter of those values.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
