### PR TITLE
Update ooc.dm. Adds two new OOC verbs for team-based OOC.

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -501,6 +501,8 @@
 #define COMSIG_KB_CLIENT_SCREENSHOT_DOWN "keybinding_client_screenshot_down"
 #define COMSIG_KB_CLIENT_MINIMALHUD_DOWN "keybinding_client_minimalhud_down"
 #define COMSIG_KB_CLIENT_OOC_DOWN "keybinding_client_ooc_down"
+#define COMSIG_KB_CLIENT_XOOC_DOWN "keybinding_client_xooc_down"
+#define COMSIG_KB_CLIENT_MOOC_DOWN "keybinding_client_mooc_down"
 #define COMSIG_KB_CLIENT_LOOC_DOWN "keybinding_client_looc_down"
 #define COMSIG_KB_LIVING_RESIST_DOWN "keybinding_living_resist_down"
 #define COMSIG_KB_MOB_FACENORTH_DOWN "keybinding_mob_facenorth_down"

--- a/code/datums/keybinding/client.dm
+++ b/code/datums/keybinding/client.dm
@@ -64,6 +64,34 @@
 	return TRUE
 
 
+/datum/keybinding/client/xooc
+	name = "xooc"
+	full_name = "XOOC"
+	description = "Speak in XOOC"
+	keybind_signal = COMSIG_KB_CLIENT_XOOC_DOWN
+
+/datum/keybinding/client/xooc/down(client/user)
+	. = ..()
+	if(.)
+		return
+	user.xooc_wrapper()
+	return TRUE
+
+
+/datum/keybinding/client/mooc
+	name = "mooc"
+	full_name = "MOOC"
+	description = "Speak in MOOC"
+	keybind_signal = COMSIG_KB_CLIENT_MOOC_DOWN
+
+/datum/keybinding/client/mooc/down(client/user)
+	. = ..()
+	if(.)
+		return
+	user.mooc_wrapper()
+	return TRUE
+
+
 /datum/keybinding/client/looc
 	name = "looc"
 	full_name = "LOOC"

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -181,7 +181,7 @@
 
 	// Send chat message to admins
 	for(var/client/C AS in GLOB.admins)
-		if(!check_other_rights(C, R_ADMIN, FALSE)) // Check if the client is still an admin. Potentially useless if the list already adds
+		if(!check_other_rights(C, R_ADMIN, FALSE)) // Check if the client is still an admin.
 			continue
 		var/display_name = mob.name
 		if(admin && !(mob in GLOB.xeno_mob_list)) // If the verb caller is an admin and is not a xeno mob, use their ckey instead.

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -107,6 +107,179 @@
 			to_chat(C, "<span class='[display_class]'>[span_prefix("OOC: [display_name]")]: <span class='message linkify'>[msg]</span></span>", avoid_highlighting = avoid_highlight)
 
 
+/client/verb/xooc_wrapper()
+	set hidden = TRUE
+	var/message = input("", "XOOC \"text\"") as null|text
+	ooc(message)
+
+
+/client/verb/xooc(msg as text)
+	set name = "XOOC"
+	set category = "OOC"
+
+	var/admin = check_rights(R_ADMIN, FALSE)
+
+	if(!mob)
+		return
+	if(IsGuestKey(key))
+		to_chat(src, "Guests may not use XOOC.")
+		return
+	//if(mob.stat == DEAD && !admin)
+	//	to_chat(src, span_warning("You must be alive to use XOOC."))
+	//	return
+	//if(!(mob in GLOB.xeno_mob_list) && !admin)
+	//	to_chat(src, span_warning("You must be a human to use XOOC."))
+	//	return
+
+	msg = copytext_char(sanitize(msg), 1, MAX_MESSAGE_LEN)
+
+	if(!msg)
+		return
+	if(NON_ASCII_CHECK(msg))
+		return
+
+	msg = emoji_parse(msg)
+
+	if(!(prefs.toggles_chat & CHAT_OOC))
+		to_chat(src, span_warning("You have OOC muted."))
+		return
+
+	if(!check_rights(R_ADMIN, FALSE))
+		if(!GLOB.ooc_allowed)
+			to_chat(src, span_warning("OOC is globally muted"))
+			return
+		if(prefs.muted & MUTE_OOC)
+			to_chat(src, span_warning("You cannot use OOC (muted)."))
+			return
+		if(handle_spam_prevention(msg, MUTE_OOC))
+			return
+		if(findtext(msg, "byond://"))
+			to_chat(src, span_danger("Advertising other servers is not allowed."))
+			log_admin_private("[key_name(usr)] has attempted to advertise in OOC: [msg]")
+			message_admins("[ADMIN_TPMONTY(usr)] has attempted to advertise in OOC: [msg]")
+			return
+
+	if(is_banned_from(ckey, "OOC"))
+		to_chat(src, span_warning("You have been banned from OOC."))
+		return
+
+	mob.log_talk(msg, LOG_OOC)
+
+	for(var/client/C in GLOB.clients)
+		if(!(C.prefs.toggles_chat & CHAT_OOC))
+			continue
+		if(!(C.mob in GLOB.xeno_mob_list) && !(C.mob in GLOB.observer_list) || check_other_rights(C, R_ADMIN, FALSE))
+			continue
+
+		var/display_name = mob.name
+		if(admin && !(mob in GLOB.xeno_mob_list))
+			display_name = mob.key
+
+		// Admins open straight to player panel
+		if(check_other_rights(C, R_ADMIN, FALSE))
+			display_name = "<a class='hidelink' href='?_src_=holder;[HrefToken(TRUE)];playerpanel=[REF(usr)]'>[display_name]</a>"
+		var/avoid_highlight = C == src
+		to_chat(C, "<font color='#665544'>[span_ooc("<span class='prefix'>XOOC: [display_name]")]: <span class='message linkify'>[msg]</span></span></font>", avoid_highlighting = avoid_highlight)
+
+	for(var/client/C in GLOB.admins)
+		if(!check_other_rights(C, R_ADMIN, FALSE) && (C.mob in GLOB.xeno_mob_list) && (C.mob in GLOB.observer_list))
+			continue
+		var/display_name = mob.name
+		if(admin && !(mob in GLOB.xeno_mob_list))
+			display_name = mob.key
+		if(check_other_rights(C, R_ADMIN, FALSE))
+			display_name = "<a class='hidelink' href='?_src_=holder;[HrefToken(TRUE)];playerpanel=[REF(usr)]'>[display_name]</a>"
+		var/avoid_highlight = C == src
+		to_chat(C, "<font color='#665544'>[span_ooc("<span class='prefix'>XOOC: [display_name]")]: <span class='message linkify'>[msg]</span></span></font>", avoid_highlighting = avoid_highlight)
+
+
+/client/verb/mooc_wrapper()
+	set hidden = TRUE
+	var/message = input("", "MOOC \"text\"") as null|text
+	ooc(message)
+
+
+/client/verb/mooc(msg as text)
+	set name = "MOOC"
+	set category = "OOC"
+
+	var/admin = check_rights(R_ADMIN, FALSE)
+
+	if(!mob)
+		return
+	if(IsGuestKey(key))
+		to_chat(src, "Guests may not use MOOC.")
+		return
+	//if(mob.stat == DEAD && !admin)
+	//	to_chat(src, span_warning("You must be alive to use MOOC."))
+	//	return
+	//if(!(mob in GLOB.human_mob_list) && !admin)
+	//	to_chat(src, span_warning("You must be a human to use MOOC."))
+	//	return
+
+	msg = copytext_char(sanitize(msg), 1, MAX_MESSAGE_LEN)
+
+	if(!msg)
+		return
+	if(NON_ASCII_CHECK(msg))
+		return
+
+	msg = emoji_parse(msg)
+
+	if(!(prefs.toggles_chat & CHAT_OOC))
+		to_chat(src, span_warning("You have OOC muted."))
+		return
+
+	if(!check_rights(R_ADMIN, FALSE))
+		if(!GLOB.ooc_allowed)
+			to_chat(src, span_warning("OOC is globally muted"))
+			return
+		if(prefs.muted & MUTE_OOC)
+			to_chat(src, span_warning("You cannot use OOC (muted)."))
+			return
+		if(handle_spam_prevention(msg, MUTE_OOC))
+			return
+		if(findtext(msg, "byond://"))
+			to_chat(src, span_danger("Advertising other servers is not allowed."))
+			log_admin_private("[key_name(usr)] has attempted to advertise in OOC: [msg]")
+			message_admins("[ADMIN_TPMONTY(usr)] has attempted to advertise in OOC: [msg]")
+			return
+
+	if(is_banned_from(ckey, "OOC"))
+		to_chat(src, span_warning("You have been banned from OOC."))
+		return
+
+	mob.log_talk(msg, LOG_OOC)
+
+	for(var/client/C in GLOB.clients)
+		if(!(C.prefs.toggles_chat & CHAT_OOC))
+			continue
+		if(!(C.mob in GLOB.human_mob_list) && !(C.mob in GLOB.observer_list) || check_other_rights(C, R_ADMIN, FALSE))
+			continue
+
+		var/display_name = mob.name
+		if(admin && !(mob in GLOB.human_mob_list))
+			display_name = mob.key
+
+		// Admins open straight to player panel
+		if(check_other_rights(C, R_ADMIN, FALSE))
+			display_name = "<a class='hidelink' href='?_src_=holder;[HrefToken(TRUE)];playerpanel=[REF(usr)]'>[display_name]</a>"
+		var/avoid_highlight = C == src
+		to_chat(C, "<font color='#665544'>[span_ooc("<span class='prefix'>MOOC: [display_name]")]: <span class='message linkify'>[msg]</span></span></font>", avoid_highlighting = avoid_highlight)
+
+	for(var/client/C in GLOB.admins)
+		if(!check_other_rights(C, R_ADMIN, FALSE) && (C.mob in GLOB.human_mob_list) && (C.mob in GLOB.observer_list))
+			continue
+		var/display_name = mob.name
+		if(admin && !(mob in GLOB.human_mob_list))
+			display_name = mob.key
+		if(check_other_rights(C, R_ADMIN, FALSE))
+			display_name = "<a class='hidelink' href='?_src_=holder;[HrefToken(TRUE)];playerpanel=[REF(usr)]'>[display_name]</a>"
+		var/avoid_highlight = C == src
+		to_chat(C, "<font color='#665544'>[span_ooc("<span class='prefix'>MOOC: [display_name]")]: <span class='message linkify'>[msg]</span></span></font>", avoid_highlighting = avoid_highlight)
+
+
+
 /client/verb/looc_wrapper()
 	set hidden = TRUE
 	var/message = input("", "LOOC \"text\"") as null|text

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -110,7 +110,7 @@
 /client/verb/xooc_wrapper()
 	set hidden = TRUE
 	var/message = input("", "XOOC \"text\"") as null|text
-	ooc(message)
+	xooc(message)
 
 
 /client/verb/xooc(msg as text) // Same as MOOC, but for xenos.
@@ -197,7 +197,7 @@
 /client/verb/mooc_wrapper()
 	set hidden = TRUE
 	var/message = input("", "MOOC \"text\"") as null|text
-	ooc(message)
+	mooc(message)
 
 
 /client/verb/mooc(msg as text) // Same as XOOC, but for humans.

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -127,7 +127,7 @@
 	if(mob.stat == DEAD && !admin)
 		to_chat(src, span_warning("You must be alive to use XOOC."))
 		return
-	if(!(mob AS in GLOB.xeno_mob_list) && !admin)
+	if(!(mob in GLOB.xeno_mob_list) && !admin)
 		to_chat(src, span_warning("You must be a xeno to use XOOC."))
 		return
 
@@ -169,11 +169,11 @@
 	for(var/client/C AS in GLOB.clients)
 		if(!(C.prefs.toggles_chat & CHAT_OOC))
 			continue
-		if(!(C.mob AS in GLOB.xeno_mob_list) && !(C.mob AS in GLOB.observer_list) || check_other_rights(C, R_ADMIN, FALSE)) // If the client is a xeno, an observer, and not an admin.
+		if(!(C.mob in GLOB.xeno_mob_list) && !(C.mob in GLOB.observer_list) || check_other_rights(C, R_ADMIN, FALSE)) // If the client is a xeno, an observer, and not an admin.
 			continue
 
 		var/display_name = mob.name
-		if(admin && !(mob AS in GLOB.xeno_mob_list)) // If the verb caller is an admin and is not a xeno mob, use their ckey instead.
+		if(admin && !(mob in GLOB.xeno_mob_list)) // If the verb caller is an admin and is not a xeno mob, use their ckey instead.
 			display_name = mob.key
 
 		var/avoid_highlight = C == src
@@ -181,10 +181,10 @@
 
 	// Send chat message to admins
 	for(var/client/C AS in GLOB.admins)
-		if(!check_other_rights(C, R_ADMIN, FALSE)) // Check if the client is still an admin.
+		if(!check_other_rights(C, R_ADMIN, FALSE)) // Check if the client is still an admin. Potentially useless if the list already adds
 			continue
 		var/display_name = mob.name
-		if(admin && !(mob AS in GLOB.xeno_mob_list)) // If the verb caller is an admin and is not a xeno mob, use their ckey instead.
+		if(admin && !(mob in GLOB.xeno_mob_list)) // If the verb caller is an admin and is not a xeno mob, use their ckey instead.
 			display_name = mob.key
 
 		// Replace display_name with itself and turn it into a clickable player panel href for admins.
@@ -214,7 +214,7 @@
 	if(mob.stat == DEAD && !admin)
 		to_chat(src, span_warning("You must be alive to use MOOC."))
 		return
-	if(!(mob AS in GLOB.human_mob_list) && !admin)
+	if(!(mob in GLOB.human_mob_list) && !admin)
 		to_chat(src, span_warning("You must be a human to use MOOC."))
 		return
 
@@ -256,11 +256,11 @@
 	for(var/client/C AS in GLOB.clients)
 		if(!(C.prefs.toggles_chat & CHAT_OOC))
 			continue
-		if(!(C.mob AS in GLOB.human_mob_list) && !(C.mob AS in GLOB.observer_list) || check_other_rights(C, R_ADMIN, FALSE)) // If the client is a human, an observer, and not an admin.
+		if(!(C.mob in GLOB.human_mob_list) && !(C.mob in GLOB.observer_list) || check_other_rights(C, R_ADMIN, FALSE)) // If the client is a human, an observer, and not an admin.
 			continue
 
 		var/display_name = mob.name
-		if(admin && !(mob AS in GLOB.human_mob_list)) // If the verb caller is an admin and is not a human mob, use their ckey instead.
+		if(admin && !(mob in GLOB.human_mob_list)) // If the verb caller is an admin and is not a human mob, use their ckey instead.
 			display_name = mob.key
 
 		var/avoid_highlight = C == src
@@ -273,7 +273,7 @@
 		if(!check_other_rights(C, R_ADMIN, FALSE)) // Check if the client is still an admin.
 			continue
 		var/display_name = mob.name
-		if(admin && !(mob AS in GLOB.human_mob_list)) // If the verb caller is an admin and is not a human mob, use their ckey instead.
+		if(admin && !(mob in GLOB.human_mob_list)) // If the verb caller is an admin and is not a human mob, use their ckey instead.
 			display_name = mob.key
 
 		// Replace display_name with itself and turn it into a clickable player panel href for admins.

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -127,7 +127,7 @@
 	if(mob.stat == DEAD && !admin)
 		to_chat(src, span_warning("You must be alive to use XOOC."))
 		return
-	if(!(mob in GLOB.xeno_mob_list) && !admin)
+	if(!(mob AS in GLOB.xeno_mob_list) && !admin)
 		to_chat(src, span_warning("You must be a xeno to use XOOC."))
 		return
 
@@ -169,29 +169,29 @@
 	for(var/client/C AS in GLOB.clients)
 		if(!(C.prefs.toggles_chat & CHAT_OOC))
 			continue
-		if(!(C.mob in GLOB.xeno_mob_list) && !(C.mob in GLOB.observer_list) || check_other_rights(C, R_ADMIN, FALSE)) // If the client is a xeno, an observer, and not an admin.
+		if(!(C.mob AS in GLOB.xeno_mob_list) && !(C.mob AS in GLOB.observer_list) || check_other_rights(C, R_ADMIN, FALSE)) // If the client is a xeno, an observer, and not an admin.
 			continue
 
 		var/display_name = mob.name
-		if(admin && !(mob in GLOB.xeno_mob_list)) // If the verb caller is an admin and is not a xeno mob, use their ckey instead.
+		if(admin && !(mob AS in GLOB.xeno_mob_list)) // If the verb caller is an admin and is not a xeno mob, use their ckey instead.
 			display_name = mob.key
 
 		var/avoid_highlight = C == src
-		to_chat(C, "<font color='#665544'>[span_ooc("<span class='prefix'>XOOC: [display_name]")]: <span class='message linkify'>[msg]</span></span></font>", avoid_highlighting = avoid_highlight)
+		to_chat(C, "<font color='#334455'>[span_ooc("<span class='prefix'>XOOC: [display_name]")]: <span class='message linkify'>[msg]</span></span></font>", avoid_highlighting = avoid_highlight)
 
 	// Send chat message to admins
 	for(var/client/C AS in GLOB.admins)
-		if(!check_other_rights(C, R_ADMIN, FALSE) && (C.mob in GLOB.xeno_mob_list) && (C.mob in GLOB.observer_list)) // If the client is an admin, not a xeno, and not an observer.
+		if(!check_other_rights(C, R_ADMIN, FALSE)) // Check if the client is still an admin.
 			continue
 		var/display_name = mob.name
-		if(admin && !(mob in GLOB.xeno_mob_list)) // If the verb caller is an admin and is not a xeno mob, use their ckey instead.
+		if(admin && !(mob AS in GLOB.xeno_mob_list)) // If the verb caller is an admin and is not a xeno mob, use their ckey instead.
 			display_name = mob.key
 
 		// Replace display_name with itself and turn it into a clickable player panel href for admins.
 		if(check_other_rights(C, R_ADMIN, FALSE))
 			display_name = "<a class='hidelink' href='?_src_=holder;[HrefToken(TRUE)];playerpanel=[REF(usr)]'>[display_name]</a>"
 		var/avoid_highlight = C == src
-		to_chat(C, "<font color='#665544'>[span_ooc("<span class='prefix'>XOOC: [display_name]")]: <span class='message linkify'>[msg]</span></span></font>", avoid_highlighting = avoid_highlight)
+		to_chat(C, "<font color='#334455'>[span_ooc("<span class='prefix'>XOOC: [display_name]")]: <span class='message linkify'>[msg]</span></span></font>", avoid_highlighting = avoid_highlight)
 
 
 /client/verb/mooc_wrapper()
@@ -214,7 +214,7 @@
 	if(mob.stat == DEAD && !admin)
 		to_chat(src, span_warning("You must be alive to use MOOC."))
 		return
-	if(!(mob in GLOB.human_mob_list) && !admin)
+	if(!(mob AS in GLOB.human_mob_list) && !admin)
 		to_chat(src, span_warning("You must be a human to use MOOC."))
 		return
 
@@ -256,11 +256,11 @@
 	for(var/client/C AS in GLOB.clients)
 		if(!(C.prefs.toggles_chat & CHAT_OOC))
 			continue
-		if(!(C.mob in GLOB.human_mob_list) && !(C.mob in GLOB.observer_list) || check_other_rights(C, R_ADMIN, FALSE)) // If the client is a human, an observer, and not an admin.
+		if(!(C.mob AS in GLOB.human_mob_list) && !(C.mob AS in GLOB.observer_list) || check_other_rights(C, R_ADMIN, FALSE)) // If the client is a human, an observer, and not an admin.
 			continue
 
 		var/display_name = mob.name
-		if(admin && !(mob in GLOB.human_mob_list)) // If the verb caller is an admin and is not a human mob, use their ckey instead.
+		if(admin && !(mob AS in GLOB.human_mob_list)) // If the verb caller is an admin and is not a human mob, use their ckey instead.
 			display_name = mob.key
 
 		var/avoid_highlight = C == src
@@ -270,10 +270,10 @@
 	for(var/client/C AS in GLOB.admins)
 		if(!(C.prefs.toggles_chat & CHAT_OOC))
 			continue
-		if(!check_other_rights(C, R_ADMIN, FALSE) && (C.mob in GLOB.human_mob_list) && (C.mob in GLOB.observer_list)) // If the client is still an admin, not a human, and not an observer.
+		if(!check_other_rights(C, R_ADMIN, FALSE)) // Check if the client is still an admin.
 			continue
 		var/display_name = mob.name
-		if(admin && !(mob in GLOB.human_mob_list)) // If the verb caller is an admin and is not a human mob, use their ckey instead.
+		if(admin && !(mob AS in GLOB.human_mob_list)) // If the verb caller is an admin and is not a human mob, use their ckey instead.
 			display_name = mob.key
 
 		// Replace display_name with itself and turn it into a clickable player panel href for admins.
@@ -281,7 +281,6 @@
 			display_name = "<a class='hidelink' href='?_src_=holder;[HrefToken(TRUE)];playerpanel=[REF(usr)]'>[display_name]</a>"
 		var/avoid_highlight = C == src
 		to_chat(C, "<font color='#665544'>[span_ooc("<span class='prefix'>MOOC: [display_name]")]: <span class='message linkify'>[msg]</span></span></font>", avoid_highlighting = avoid_highlight)
-
 
 
 /client/verb/looc_wrapper()

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -268,6 +268,8 @@
 		to_chat(C, "<font color='#665544'>[span_ooc("<span class='prefix'>MOOC: [display_name]")]: <span class='message linkify'>[msg]</span></span></font>", avoid_highlighting = avoid_highlight)
 
 	for(var/client/C in GLOB.admins)
+		if(!(C.prefs.toggles_chat & CHAT_OOC))
+			continue
 		if(!check_other_rights(C, R_ADMIN, FALSE) && (C.mob in GLOB.human_mob_list) && (C.mob in GLOB.observer_list))
 			continue
 		var/display_name = mob.name

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -113,7 +113,7 @@
 	ooc(message)
 
 
-/client/verb/xooc(msg as text)
+/client/verb/xooc(msg as text) // Same as MOOC, but for xenos.
 	set name = "XOOC"
 	set category = "OOC"
 
@@ -124,12 +124,12 @@
 	if(IsGuestKey(key))
 		to_chat(src, "Guests may not use XOOC.")
 		return
-	//if(mob.stat == DEAD && !admin)
-	//	to_chat(src, span_warning("You must be alive to use XOOC."))
-	//	return
-	//if(!(mob in GLOB.xeno_mob_list) && !admin)
-	//	to_chat(src, span_warning("You must be a human to use XOOC."))
-	//	return
+	if(mob.stat == DEAD && !admin)
+		to_chat(src, span_warning("You must be alive to use XOOC."))
+		return
+	if(!(mob in GLOB.xeno_mob_list) && !admin)
+		to_chat(src, span_warning("You must be a human to use XOOC."))
+		return
 
 	msg = copytext_char(sanitize(msg), 1, MAX_MESSAGE_LEN)
 
@@ -199,7 +199,7 @@
 	ooc(message)
 
 
-/client/verb/mooc(msg as text)
+/client/verb/mooc(msg as text) // Same as XOOC, but for humans.
 	set name = "MOOC"
 	set category = "OOC"
 
@@ -210,12 +210,12 @@
 	if(IsGuestKey(key))
 		to_chat(src, "Guests may not use MOOC.")
 		return
-	//if(mob.stat == DEAD && !admin)
-	//	to_chat(src, span_warning("You must be alive to use MOOC."))
-	//	return
-	//if(!(mob in GLOB.human_mob_list) && !admin)
-	//	to_chat(src, span_warning("You must be a human to use MOOC."))
-	//	return
+	if(mob.stat == DEAD && !admin)
+		to_chat(src, span_warning("You must be alive to use MOOC."))
+		return
+	if(!(mob in GLOB.human_mob_list) && !admin)
+		to_chat(src, span_warning("You must be a human to use MOOC."))
+		return
 
 	msg = copytext_char(sanitize(msg), 1, MAX_MESSAGE_LEN)
 

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -176,6 +176,7 @@
 		if(admin && !(mob in GLOB.xeno_mob_list)) // If the verb caller is an admin and is not a xeno mob, use their ckey instead.
 			display_name = mob.key
 
+		var/avoid_highlight = C == src
 		to_chat(C, "<font color='#665544'>[span_ooc("<span class='prefix'>XOOC: [display_name]")]: <span class='message linkify'>[msg]</span></span></font>", avoid_highlighting = avoid_highlight)
 
 	// Send chat message to admins

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -86,7 +86,7 @@
 		if(CONFIG_GET(flag/allow_admin_ooccolor))
 			display_colour = prefs.ooccolor
 
-	for(var/client/C in GLOB.clients)
+	for(var/client/C AS in GLOB.clients)
 		if(!(C.prefs.toggles_chat & CHAT_OOC))
 			continue
 
@@ -348,7 +348,7 @@
 		for(var/mob/M in range(mob))
 			to_chat(M, message)
 
-	for(var/client/C in GLOB.admins)
+	for(var/client/C AS in GLOB.admins)
 		if(!check_other_rights(C, R_ADMIN, FALSE) || C.mob == mob)
 			continue
 		if(C.prefs.toggles_chat & CHAT_LOOC)

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -169,7 +169,7 @@
 	for(var/client/C AS in GLOB.clients)
 		if(!(C.prefs.toggles_chat & CHAT_OOC))
 			continue
-		if(!(C.mob in GLOB.xeno_mob_list) && !(C.mob in GLOB.observer_list) || check_other_rights(C, R_ADMIN, FALSE)) // If the client is a xeno, an observer, or not an admin.
+		if(!(C.mob in GLOB.xeno_mob_list) && !(C.mob in GLOB.observer_list) || check_other_rights(C, R_ADMIN, FALSE)) // If the client is a xeno, an observer, and not an admin.
 			continue
 
 		var/display_name = mob.name
@@ -256,7 +256,7 @@
 	for(var/client/C AS in GLOB.clients)
 		if(!(C.prefs.toggles_chat & CHAT_OOC))
 			continue
-		if(!(C.mob in GLOB.human_mob_list) && !(C.mob in GLOB.observer_list) || check_other_rights(C, R_ADMIN, FALSE)) // If the client is a human, an observer, or not an admin.
+		if(!(C.mob in GLOB.human_mob_list) && !(C.mob in GLOB.observer_list) || check_other_rights(C, R_ADMIN, FALSE)) // If the client is a human, an observer, and not an admin.
 			continue
 
 		var/display_name = mob.name
@@ -270,7 +270,7 @@
 	for(var/client/C AS in GLOB.admins)
 		if(!(C.prefs.toggles_chat & CHAT_OOC))
 			continue
-		if(!check_other_rights(C, R_ADMIN, FALSE) && (C.mob in GLOB.human_mob_list) && (C.mob in GLOB.observer_list)) // If the client is still an admin, not a xeno, and not an observer.
+		if(!check_other_rights(C, R_ADMIN, FALSE) && (C.mob in GLOB.human_mob_list) && (C.mob in GLOB.observer_list)) // If the client is still an admin, not a human, and not an observer.
 			continue
 		var/display_name = mob.name
 		if(admin && !(mob in GLOB.human_mob_list)) // If the verb caller is an admin and is not a human mob, use their ckey instead.

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -176,10 +176,6 @@
 		if(admin && !(mob in GLOB.xeno_mob_list)) // If the verb caller is an admin and is not a xeno mob, use their ckey instead.
 			display_name = mob.key
 
-		// Replace display_name with itself and turn it into a clickable player panel href for admins.
-		if(check_other_rights(C, R_ADMIN, FALSE))
-			display_name = "<a class='hidelink' href='?_src_=holder;[HrefToken(TRUE)];playerpanel=[REF(usr)]'>[display_name]</a>"
-		var/avoid_highlight = C == src
 		to_chat(C, "<font color='#665544'>[span_ooc("<span class='prefix'>XOOC: [display_name]")]: <span class='message linkify'>[msg]</span></span></font>", avoid_highlighting = avoid_highlight)
 
 	// Send chat message to admins

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -128,7 +128,7 @@
 		to_chat(src, span_warning("You must be alive to use XOOC."))
 		return
 	if(!(mob in GLOB.xeno_mob_list) && !admin)
-		to_chat(src, span_warning("You must be a human to use XOOC."))
+		to_chat(src, span_warning("You must be a xeno to use XOOC."))
 		return
 
 	msg = copytext_char(sanitize(msg), 1, MAX_MESSAGE_LEN)

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -165,28 +165,32 @@
 
 	mob.log_talk(msg, LOG_OOC)
 
-	for(var/client/C in GLOB.clients)
+	// Send chat message to non-admins
+	for(var/client/C AS in GLOB.clients)
 		if(!(C.prefs.toggles_chat & CHAT_OOC))
 			continue
-		if(!(C.mob in GLOB.xeno_mob_list) && !(C.mob in GLOB.observer_list) || check_other_rights(C, R_ADMIN, FALSE))
+		if(!(C.mob in GLOB.xeno_mob_list) && !(C.mob in GLOB.observer_list) || check_other_rights(C, R_ADMIN, FALSE)) // If the client is a xeno, an observer, or not an admin.
 			continue
 
 		var/display_name = mob.name
-		if(admin && !(mob in GLOB.xeno_mob_list))
+		if(admin && !(mob in GLOB.xeno_mob_list)) // If the verb caller is an admin and is not a xeno mob, use their ckey instead.
 			display_name = mob.key
 
-		// Admins open straight to player panel
+		// Replace display_name with itself and turn it into a clickable player panel href for admins.
 		if(check_other_rights(C, R_ADMIN, FALSE))
 			display_name = "<a class='hidelink' href='?_src_=holder;[HrefToken(TRUE)];playerpanel=[REF(usr)]'>[display_name]</a>"
 		var/avoid_highlight = C == src
 		to_chat(C, "<font color='#665544'>[span_ooc("<span class='prefix'>XOOC: [display_name]")]: <span class='message linkify'>[msg]</span></span></font>", avoid_highlighting = avoid_highlight)
 
-	for(var/client/C in GLOB.admins)
-		if(!check_other_rights(C, R_ADMIN, FALSE) && (C.mob in GLOB.xeno_mob_list) && (C.mob in GLOB.observer_list))
+	// Send chat message to admins
+	for(var/client/C AS in GLOB.admins)
+		if(!check_other_rights(C, R_ADMIN, FALSE) && (C.mob in GLOB.xeno_mob_list) && (C.mob in GLOB.observer_list)) // If the client is an admin, not a xeno, and not an observer.
 			continue
 		var/display_name = mob.name
-		if(admin && !(mob in GLOB.xeno_mob_list))
+		if(admin && !(mob in GLOB.xeno_mob_list)) // If the verb caller is an admin and is not a xeno mob, use their ckey instead.
 			display_name = mob.key
+
+		// Replace display_name with itself and turn it into a clickable player panel href for admins.
 		if(check_other_rights(C, R_ADMIN, FALSE))
 			display_name = "<a class='hidelink' href='?_src_=holder;[HrefToken(TRUE)];playerpanel=[REF(usr)]'>[display_name]</a>"
 		var/avoid_highlight = C == src
@@ -251,30 +255,31 @@
 
 	mob.log_talk(msg, LOG_OOC)
 
-	for(var/client/C in GLOB.clients)
+	// Send chat message to non-admins
+	for(var/client/C AS in GLOB.clients)
 		if(!(C.prefs.toggles_chat & CHAT_OOC))
 			continue
-		if(!(C.mob in GLOB.human_mob_list) && !(C.mob in GLOB.observer_list) || check_other_rights(C, R_ADMIN, FALSE))
+		if(!(C.mob in GLOB.human_mob_list) && !(C.mob in GLOB.observer_list) || check_other_rights(C, R_ADMIN, FALSE)) // If the client is a human, an observer, or not an admin.
 			continue
 
 		var/display_name = mob.name
-		if(admin && !(mob in GLOB.human_mob_list))
+		if(admin && !(mob in GLOB.human_mob_list)) // If the verb caller is an admin and is not a human mob, use their ckey instead.
 			display_name = mob.key
 
-		// Admins open straight to player panel
-		if(check_other_rights(C, R_ADMIN, FALSE))
-			display_name = "<a class='hidelink' href='?_src_=holder;[HrefToken(TRUE)];playerpanel=[REF(usr)]'>[display_name]</a>"
 		var/avoid_highlight = C == src
 		to_chat(C, "<font color='#665544'>[span_ooc("<span class='prefix'>MOOC: [display_name]")]: <span class='message linkify'>[msg]</span></span></font>", avoid_highlighting = avoid_highlight)
 
-	for(var/client/C in GLOB.admins)
+	// Send chat message to admins
+	for(var/client/C AS in GLOB.admins)
 		if(!(C.prefs.toggles_chat & CHAT_OOC))
 			continue
-		if(!check_other_rights(C, R_ADMIN, FALSE) && (C.mob in GLOB.human_mob_list) && (C.mob in GLOB.observer_list))
+		if(!check_other_rights(C, R_ADMIN, FALSE) && (C.mob in GLOB.human_mob_list) && (C.mob in GLOB.observer_list)) // If the client is still an admin, not a xeno, and not an observer.
 			continue
 		var/display_name = mob.name
-		if(admin && !(mob in GLOB.human_mob_list))
+		if(admin && !(mob in GLOB.human_mob_list)) // If the verb caller is an admin and is not a human mob, use their ckey instead.
 			display_name = mob.key
+
+		// Replace display_name with itself and turn it into a clickable player panel href for admins.
 		if(check_other_rights(C, R_ADMIN, FALSE))
 			display_name = "<a class='hidelink' href='?_src_=holder;[HrefToken(TRUE)];playerpanel=[REF(usr)]'>[display_name]</a>"
 		var/avoid_highlight = C == src


### PR DESCRIPTION
## About The Pull Request

Copies prefs and spans and bans from OOC because I don't know how to touch those, and since it involves preferences and possibly database stuff: I don't think we modify those until changes are fully merged permanently.

I'm not entirely sure about the safety of the admin-related checks since I didn't look into all of the admin code, but when I tested in-game alone (I don't know how to get multiple clients on a local server), it was fine.

## Why It's Good For The Game

So people can talk to their entire team through OOC means.

## Changelog
:cl:
add: Adds Team OOC, two new verbs in the OOC tab called XOOC and MOOC for Xeno and Marine.
code: Modified ooc.dm, adding two new verbs.
admin: XOOC and MOOC should have clickable player panel links for admins, and admins can see XOOC and MOOC chat and talk in them.
/:cl:

Screenshot, 2 sequential tests for admin and non-admin, and for observer/human/xeno: For debug, verbs were made callable with no checks. Observer Team OOC as non-admin is not supposed to happen, so your key wont be revealed if it does happen.
![dreamseeker_2XPuBEcgtn](https://user-images.githubusercontent.com/22848292/132949696-62c6406a-05b3-4787-bdce-ac52e49bf417.png)
