### PR TITLE
Fixes buckling to beds and carrying mobs

### DIFF
--- a/code/game/buckling.dm
+++ b/code/game/buckling.dm
@@ -58,7 +58,7 @@
 	buckling_mob.setDir(dir)
 	LAZYADD(buckled_mobs, buckling_mob)
 	if(buckle_lying != -1)
-		ADD_TRAIT(buckling_mob, TRAIT_IMMOBILE, BUCKLE_TRAIT)
+		ADD_TRAIT(buckling_mob, TRAIT_FLOORED, BUCKLE_TRAIT)
 	buckling_mob.throw_alert("buckled", /obj/screen/alert/restrained/buckled)
 	post_buckle_mob(buckling_mob, silent)
 
@@ -84,7 +84,7 @@
 	buckled_mob.reset_glide_size()
 	buckled_mob.anchored = initial(buckled_mob.anchored)
 	if(buckle_lying != -1)
-		REMOVE_TRAIT(buckled_mob, TRAIT_IMMOBILE, BUCKLE_TRAIT)
+		REMOVE_TRAIT(buckled_mob, TRAIT_FLOORED, BUCKLE_TRAIT)
 	buckled_mob.clear_alert("buckled")
 	LAZYREMOVE(buckled_mobs, buckled_mob)
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -4,7 +4,7 @@
 		return TRUE
 	if(ismob(mover) && CHECK_BITFIELD(mover.flags_pass, PASSMOB))
 		return TRUE
-	return (!mover.density || !density || lying_angle)
+	return . || (!mover.density || !density || lying_angle) //Parent handles buckling - if someone's strapped to us it can pass.
 
 
 /client/verb/swap_hand()

--- a/code/modules/vehicles/ridden.dm
+++ b/code/modules/vehicles/ridden.dm
@@ -2,7 +2,7 @@
 	name = "ridden vehicle"
 	buckle_flags = CAN_BUCKLE|BUCKLE_PREVENTS_PULL
 	max_buckled_mobs = 1
-	buckle_lying = 0
+	buckle_lying = -1
 	flags_pass = PASSTABLE
 	COOLDOWN_DECLARE(message_cooldown)
 


### PR DESCRIPTION
## About The Pull Request
Turns out that the reason you couldn't move with people on your back is because you'd move initially, they'd try to move, they'd bump into you, they'd fail to move due to bumping into you, and then you'd fail to move due to them failing to move.
Fixes #8168, #8166, and #7917

## Why It's Good For The Game
Fixes.

## Changelog
:cl:
fix: People buckled to beds will lie down.
fix: You can move while carrying someone on your back.
/:cl: