### PR TITLE
Infinite gauze, finite brute kits

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -613,10 +613,10 @@
 			/obj/item/reagent_containers/hypospray/autoinjector/synaptizine = 0,
 		),
 		"Heal Pack" = list(
+			/obj/item/stack/medical/heal_pack/gauze = -1,
+			/obj/item/stack/medical/heal_pack/ointment = -1,
 			/obj/item/stack/medical/heal_pack/advanced/bruise_pack = 32,
-			/obj/item/stack/medical/heal_pack/gauze = 32,
 			/obj/item/stack/medical/heal_pack/advanced/burn_pack = 32,
-			/obj/item/stack/medical/heal_pack/ointment = 32,
 			/obj/item/stack/medical/splint = 16,
 		),
 		"Misc" = list(

--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -689,6 +689,12 @@
 			if(cell.charge < cell.maxcharge)
 				to_chat(user, span_warning("\The [cell] isn't full. You must recharge it before you can restock it."))
 				return
+		else if(istype(item_to_stock, /obj/item/stack))
+			var/obj/item/stack/stack = item_to_stock
+			if(stack.amount != initial(stack.amount))
+				to_chat(user, span_warning("[stack] has been partially used. You must replace the missing amount before you can restock it."))
+				return
+
 		if(item_to_stock.loc == user) //Inside the mob's inventory
 			if(item_to_stock.flags_item & WIELDED)
 				item_to_stock.unwield(user)

--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -689,7 +689,7 @@
 			if(cell.charge < cell.maxcharge)
 				to_chat(user, span_warning("\The [cell] isn't full. You must recharge it before you can restock it."))
 				return
-		else if(istype(item_to_stock, /obj/item/stack))
+		else if(isitemstack(item_to_stock))
 			var/obj/item/stack/stack = item_to_stock
 			if(stack.amount != initial(stack.amount))
 				to_chat(user, span_warning("[stack] has been partially used. You must replace the missing amount before you can restock it."))


### PR DESCRIPTION
## About The Pull Request
Prevents restocking stacks if they don't have the amount the stack initially had.
Gauze and ointment in the marine meds are infinite.

## Why It's Good For The Game
Limiting the better, specialist option while making the general option more available.
If you really need more kits, you can buy 50 of each for 5 req points.

## Changelog
:cl:
balance: Marine meds have infinite gauze and ointment
balance: Stacks can't be restocked in vendors unless they have the count they started with.
/:cl: