### PR TITLE
Update gun_system.dm, revolver.dm. Add accuracy penalty to akimbo. Reduce revolver firerate to 1.4 seconds per magazine.

### DIFF
--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -139,6 +139,12 @@
 	///determines lower accuracy modifier in akimbo
 	var/lower_akimbo_accuracy = 1
 
+	// Akimbo is a gamble against odds. Akimbo should be equivalent to single handed in damage at its worst. Fortune blesses you.
+	///determines upper accuracy multiplier in akimbo 
+	var/upper_akimbo_accuracy_mult = 0.8
+	///determines lower accuracy multiplier in akimbo
+	var/lower_akimbo_accuracy_mult = 0.6
+
 	///If the gun is deployable, the time it takes for the weapon to deploy.
 	var/deploy_time = 0
 	///If the gun is deployable, the time it takes for the weapon to undeploy.
@@ -1060,7 +1066,9 @@ and you're good to go.
 		gun_accuracy_mult = max(0.1, gun_accuracy_mult * burst_accuracy_mult)
 
 	if(dual_wield) //akimbo firing gives terrible accuracy
+		gun_accuracy_mult = gun_accuracy_mult*rand(upper_akimbo_accuracy_mult, lower_akimbo_accuracy_mult) // Used to decrease akimbo accuracy by probalistic median percentage.
 		gun_scatter += 10*rand(upper_akimbo_accuracy, lower_akimbo_accuracy)
+
 
 	if(user)
 		// Apply any skill-based bonuses to accuracy

--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -353,7 +353,7 @@
 		/obj/item/attachable/lace,
 	)
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 19,"rail_x" = 13, "rail_y" = 23, "under_x" = 22, "under_y" = 14, "stock_x" = 22, "stock_y" = 19)
-	fire_delay = 0.15 SECONDS
+	fire_delay = 0.2 SECONDS
 	accuracy_mult_unwielded = 0.85
 	accuracy_mult = 1
 	scatter_unwielded = 15


### PR DESCRIPTION
## About The Pull Request

Revolver fire rate nerf, and upper_akimbo_accuracy_mult and lower_akimbo_accuracy_mult variables to affect the accuracy multiplier for akimbo by a probabilistic median percentage modifier.

Example A: Accuracy of 100% and accuracy modifier of 0.8 to 0.6. This reduces it by 20% to 40%, giving you 80% or 60%.
Example B: Accuracy of 120% and accuracy modifier of 0.8 to 0.6. This reduces it by 20% to 40%, giving you 96% or 72%.
Example C: Accuracy of 150% and accuracy modifier of 0.8 to 0.6. This reduces it by 20% to 40%, giving you 120% or 90%.

## Why It's Good For The Game

Akimbo is a gamble now, if you're lucky it could deal up to 2x as much damage, but it wont deal much less damage than without akimbo.

## Changelog
:cl:
balance: Revolver firerate reduced to 1.4 seconds per magazine, or 5 shots per second.
balance: Akimbo accuracy multiplier set to lower 0.6 and upper 0.8 by default. Feels like equivalent damage to single handed fire now.
code: upper_akimbo_accuracy_mult and lower_akimbo_accuracy_mult variables to affect the accuracy multiplier for akimbo by median percentage.
/:cl:

