### PR TITLE
Buff Praetorian acid spit

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1823,8 +1823,8 @@ datum/ammo/bullet/revolver/tp44
 
 /datum/ammo/xeno/acid/heavy
 	name = "acid splash"
-	added_spit_delay = 0
-	spit_cost = 150
+	added_spit_delay = 2
+	spit_cost = 90
 	damage = 30
 
 /datum/ammo/xeno/acid/heavy/turret


### PR DESCRIPTION
## About The Pull Request

Make the praetorian have higher sustainability on its spits, while also keeping some of its fire rate.

## Why It's Good For The Game

Praetorian wont constantly run out of spit, but the spits are not super fast or super slow anymore.

Should be more enjoyable to play. You can still actively fire spits and wont have to rest on weeds for two or three times as long as you spend spitting, but you also wont fire so slow that you do minimal damage like the first PR tried to remedy.

## Changelog
:cl:
balance: Praetorian acid spit cost and speed changed to be 90 plasma cost and have +2 delay.
/:cl:
