### PR TITLE
Fix crash maturity not being properly updated

### DIFF
--- a/code/datums/gamemodes/crash.dm
+++ b/code/datums/gamemodes/crash.dm
@@ -224,6 +224,7 @@
 	SIGNAL_HANDLER
 	switch(new_xeno.tier)
 		if(XENO_TIER_ONE)
+			new_xeno.upgrade_xeno(XENO_UPGRADE_ONE) //This is bad, but this works without more refactoring
 			new_xeno.upgrade_xeno(XENO_UPGRADE_TWO)
 		if(XENO_TIER_TWO)
 			new_xeno.upgrade_xeno(XENO_UPGRADE_ONE)

--- a/code/game/objects/items/motion_detector.dm
+++ b/code/game/objects/items/motion_detector.dm
@@ -101,6 +101,14 @@
 /obj/item/attachable/motiondetector/update_icon_state()
 	icon_state = initial(icon_state) + (isnull(operator) ? "" : "_on")
 
+/obj/item/attachable/motiondetector/equipped(mob/user, slot)
+	. = ..()
+	if(!ishandslot(slot))
+		clean_operator()
+
+/obj/item/attachable/motiondetector/removed_from_inventory(mob/user)
+	clean_operator()
+
 /// Signal handler to clean out user vars
 /obj/item/attachable/motiondetector/proc/clean_operator()
 	SIGNAL_HANDLER

--- a/code/modules/mob/living/carbon/xenomorph/xenoupgrade.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoupgrade.dm
@@ -9,6 +9,8 @@
 		span_xenonotice("We begin to twist and contort."))
 		do_jitter_animation(1000)
 	set_datum()
+	if(upgrade_stored < xeno_caste.upgrade_threshold)
+		upgrade_stored = xeno_caste.upgrade_threshold
 	var/selected_ability_type = selected_ability?.type
 
 	for(var/check_existing_actions in xeno_abilities) //Remove xenos actions we shouldn't have


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Maturity has changed, but crash code was never updated

A T1 is propulsed to elder when evolving, but the upgrade_stored stayed at zero, which means that going to ancient is very long

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Crash restored to all of its glory

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fix crash maturity not being properly updated
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
