### PR TITLE
mosin/svd have aim mode once again

### DIFF
--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -643,8 +643,11 @@ can cause issues with ammo types getting mixed up during the burst.
 		/obj/item/attachable/scope/mosin,
 		/obj/item/attachable/stock/mosin,
 	)
+	actions_types = list(/datum/action/item_action/aim_mode)
+	aim_fire_delay = 0.75 SECONDS
+	aim_speed_modifier = 0.8
 
-	fire_delay = 17.5
+	fire_delay = 1.75 SECONDS
 	accuracy_mult = 1.45
 	accuracy_mult_unwielded = 0.7
 	scatter = -25

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -279,6 +279,9 @@
 	flags_gun_features = GUN_AUTO_EJECTOR|GUN_WIELDED_FIRING_ONLY|GUN_AMMO_COUNTER
 	attachable_offset = list("muzzle_x" = 32, "muzzle_y" = 17,"rail_x" = 22, "rail_y" = 22, "under_x" = 24, "under_y" = 13, "stock_x" = 20, "stock_y" = 14)
 	starting_attachment_types = list(/obj/item/attachable/scope/slavic, /obj/item/attachable/slavicbarrel)
+	actions_types = list(/datum/action/item_action/aim_mode)
+	aim_fire_delay = 0.8 SECONDS
+	aim_speed_modifier = 0.75
 
 	fire_delay = 1.2 SECONDS
 	burst_amount = 1
@@ -913,7 +916,7 @@
 			return
 		finish_windup()
 		return
-	
+
 	addtimer(CALLBACK(src, .proc/finish_windup), delay)
 
 ///Proc that finishes the windup, this fires the gun.


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Mosin/SVD regain aim mode
Mosin has normal fire delay values of 1.75 SECONDS rather than 17.5, since it annoyed me I guess?

Aim mode for mosin is 2.5s between shots, SVD is 2s as it's an import that you have to pay for+magazines.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Mosin/SVD have aim mode again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
