### PR TITLE
PPsh buff

### DIFF
--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -274,7 +274,7 @@
 
 /obj/item/weapon/gun/smg/ppsh
 	name = "\improper PPSh-17b submachinegun"
-	desc = "A design copied all over the years, this SMG boasts a high capacity and fire rate, but suffers in the handling department.
+	desc = "A design copied all over the years, this SMG boasts a high capacity and fire rate, but suffers in the handling department."
 	icon = 'icons/Marine/gun64.dmi'
 	icon_state = "ppsh"
 	item_state = "ppsh"

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -274,7 +274,7 @@
 
 /obj/item/weapon/gun/smg/ppsh
 	name = "\improper PPSh-17b submachinegun"
-	desc = "A replica of a 20th century USSR model submachinegun that many terrorist organizations had copied all over the years. Despite its small-hitting firepower, its reliablity, extreme longevity and high firepower rate proves useful for the hands of the user."
+	desc = "A design copied all over the years, this SMG boasts a high capacity and fire rate, but suffers in the handling department.
 	icon = 'icons/Marine/gun64.dmi'
 	icon_state = "ppsh"
 	item_state = "ppsh"
@@ -289,6 +289,7 @@
 	current_mag = /obj/item/ammo_magazine/smg/ppsh
 	attachable_allowed = list(
 		/obj/item/attachable/compensator,
+		/obj/item/attachable/magnetic_harness,
 		/obj/item/attachable/suppressor,
 		/obj/item/attachable/reddot,
 		/obj/item/attachable/flashlight,
@@ -296,6 +297,10 @@
 
 	flags_gun_features = GUN_CAN_POINTBLANK|GUN_LOAD_INTO_CHAMBER|GUN_AMMO_COUNTER
 	attachable_offset = list("muzzle_x" = 38, "muzzle_y" = 19,"rail_x" = 13, "rail_y" = 21, "under_x" = 26, "under_y" = 15, "stock_x" = 19, "stock_y" = 13)
+	actions_types = list(/datum/action/item_action/aim_mode)
+	aim_fire_delay = 0.125 SECONDS
+	aim_speed_modifier = 2.5
+
 	starting_attachment_types = list(
 		/obj/item/attachable/stock/irremoveable/ppsh,
 	)
@@ -304,10 +309,12 @@
 	burst_amount = 6
 	accuracy_mult = 1.05
 	accuracy_mult_unwielded = 0.65
-	scatter = 25
+	scatter = 16
+	burst_scatter_mult = 1.5
+	burst_delay = 0.15 SECONDS
 	scatter_unwielded = 45
-	aim_slowdown = 0.8
-	wield_delay = 0.8 SECONDS
+	aim_slowdown = 0.6
+	wield_delay = 0.75 SECONDS
 
 
 //-------------------------------------------------------

--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -309,12 +309,11 @@
 	burst_amount = 6
 	accuracy_mult = 1.05
 	accuracy_mult_unwielded = 0.65
-	scatter = 16
-	burst_scatter_mult = 1.5
+	scatter = 18
 	burst_delay = 0.15 SECONDS
 	scatter_unwielded = 45
 	aim_slowdown = 0.6
-	wield_delay = 0.75 SECONDS
+	wield_delay = 0.6 SECONDS
 
 
 //-------------------------------------------------------


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gives PPsh Aim mode.
0.3 and 2.50 slowdown.
0.15 burst delay from 0.2.
Wield delay and aim_slow cut by .2
Scatter cut to 18 from 25.
Gains mag harness.
descrpition changed a bit to not have ussr in it
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes the PPsh feel more like a SMG-stlyle LMG with better handling (.2 less slow/wield than LMG) and higher capacity. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: PPsh has lost some weight, has better handling (0.2 less wield delay and wield speed) and gains aim mode. 0.3 fire delay on aim mode and gained mag harness.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
