### PR TITLE
Increase thermobaric req cost from 50 to 80

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -204,7 +204,7 @@ WEAPONS
 /datum/supply_packs/weapons/thermobaric
 	name = "T-57 Thermobaric Launcher"
 	contains = list(/obj/item/weapon/gun/launcher/rocket/m57a4/t57)
-	cost = 50
+	cost = 100
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/specdemo

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -204,7 +204,7 @@ WEAPONS
 /datum/supply_packs/weapons/thermobaric
 	name = "T-57 Thermobaric Launcher"
 	contains = list(/obj/item/weapon/gun/launcher/rocket/m57a4/t57)
-	cost = 100
+	cost = 80
 	available_against_xeno_only = TRUE
 
 /datum/supply_packs/weapons/specdemo


### PR DESCRIPTION
## About The Pull Request
It's worth the same as a normal rocket launcher or other less well-performing weapons. For reference sadar is around 120 points.

## Why It's Good For The Game

It has WP smoke, so xenos have to retreat on the spot if they're not already low health. It's like old thermo but with less damage.

## Changelog
:cl:
balance: Thermobaric rocket launcher req point cost increased from 50 to 80.
/:cl: