### PR TITLE
Fixes new ticket admin/mentor help message double sanitizing

### DIFF
--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -238,9 +238,9 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 //call this on its own to create a ticket, don't manually assign current_ticket
 //msg is the title of the ticket: usually the ahelp text
 //is_bwoink is TRUE if this ticket was started by an admin PM
-/datum/admin_help/New(msg, client/C, is_bwoink, tickettier)
+/datum/admin_help/New(msg_raw, client/C, is_bwoink, tickettier)
 	//clean the input msg
-	msg = sanitize(copytext_char(msg, 1, MAX_MESSAGE_LEN))
+	var/msg = sanitize(copytext_char(msg_raw, 1, MAX_MESSAGE_LEN))
 	if(!msg || !C || !C.mob)
 		qdel(src)
 		return
@@ -272,7 +272,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 			message_admins("Ticket [TicketHref("#[id]")] created.")
 		marked = usr.client.key
 	else
-		MessageNoRecipient(msg)
+		MessageNoRecipient(msg_raw)
 
 		//send it to TGS if nobody is on and tell us how many were on
 		var/ticket_type = (tier == TICKET_ADMIN) ? "Admin" : "Mentor"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Passes a raw form of the initial message to MessageNoRecipient() which always sanitizes.

Also @TiviPlus this is a port too 😝 https://github.com/tgstation/tgstation/pull/60826

## Why It's Good For The Game

Less HTML encoded garbage in new ticket chat logs.

Before:
![dreamseeker_hjgtoJUATE](https://user-images.githubusercontent.com/64715958/133861974-b4062636-be6c-4959-8255-770310602f39.png)
After:
![dreamseeker_0jLjOtqmzY](https://user-images.githubusercontent.com/64715958/133861981-2d5d5a15-d923-440c-98b3-077bd6e84d9a.png)

## Changelog



:cl:
fix: Fixed new ticket admin/mentor help message double sanitizing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
