### PR TITLE
Lower praetorian acid spray cost from 400 to 300

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/abilities_praetorian.dm
@@ -6,7 +6,7 @@
 	action_icon_state = "spray_acid"
 	mechanics_text = "Spray a cone of dangerous acid at your target."
 	ability_name = "spray acid"
-	plasma_cost = 400
+	plasma_cost = 300
 	cooldown_timer = 40 SECONDS
 
 /datum/action/xeno_action/activable/spray_acid/cone/use_ability(atom/A)


### PR DESCRIPTION
## About The Pull Request

Lowers prae spray cost from 400 to 300.

## Why It's Good For The Game

So you still have to think about the plasma usage, but you don't have to retreat to regain plasma as soon as you use the spray. Pre-nerf, you can only fire acid spit 5 times if you use acid spray, or neuro 4 times. -1 times if you want to use frenzy pheromones to run away. It also sometimes ends up running out before you get to the guy and slash them, depending on the situation. Though it's still a step up from before, when acid spit costed 150 plasma, and where if you acid sprayed you could only spit 3 times before running out of plasma, which did pretty much nothing.

## Changelog
:cl:
balance: Praetorian acid spray cost is now 300 instead of 400.
/:cl:
