### PR TITLE
Increase buckshot damage falloff to 8 instead of 1.

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -698,7 +698,7 @@ datum/ammo/bullet/revolver/tp44
 	accurate_range = 5
 	max_range = 10
 	damage = 40
-	damage_falloff = 1
+	damage_falloff = 8
 	penetration = 0
 
 


### PR DESCRIPTION
## About The Pull Request

At 40 damage per pellet, ineffective past 5 tiles for a damage reduction of 8 per tile.

Average T3 health: 320, two shot kills T3s.
Pellets per shot: 5
Damage per 5 tiles: 40
Damage per 4 tiles: 80
Damage per 3 tiles: 120
Damage per 2 tiles: 160
Damage per 1 tile: 200



## Why It's Good For The Game

No more long range buckshot, making it CQC specialized while flechette is range specialized. Still probably really effective at 2-3 tiles unlike when the scatter was insanely huge.

## Changelog
:cl:
balance: Buckshot damage falloff increased to 8 from 1.
/:cl:

