### PR TITLE
miniflamer burn level and time nerf

### DIFF
--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -15,6 +15,8 @@
 	aim_slowdown = 1.75
 	current_mag = /obj/item/ammo_magazine/flamer_tank
 	var/lit = 0 //Turn the flamer on/off
+	var/burnlevel_mult = 1
+	var/burntime_mult = 1
 	general_codex_key = "flame weapons"
 
 	attachable_allowed = list( //give it some flexibility.
@@ -41,11 +43,13 @@
 	desc = "A weapon-mounted refillable flamethrower attachment.\nIt is designed for short bursts."
 	icon = 'icons/Marine/marine-weapons.dmi'
 	icon_state = "flamethrower"
-	
+
 	flags_gun_features = GUN_UNUSUAL_DESIGN|GUN_AMMO_COUNTER|GUN_WIELDED_FIRING_ONLY|GUN_WIELDED_STABLE_FIRING_ONLY|GUN_IS_ATTACHMENT|GUN_ATTACHMENT_FIRE_ONLY
 	w_class = WEIGHT_CLASS_BULKY
 	fire_delay = 2.5 SECONDS
 	fire_sound = 'sound/weapons/guns/fire/flamethrower3.ogg'
+	burnlevel_mult = 0.5 // 12 and 18 respectively, for fuel types (normal/blue)
+	burntime_mult = 0.5 // 8.5 and 20 respectively. (Normal/blue)
 
 	current_mag = /obj/item/ammo_magazine/flamer_tank/mini
 	attachable_allowed = list()
@@ -258,8 +262,8 @@
 
 	var/datum/ammo/flamethrower/loaded_ammo = ammo
 
-	var/burnlevel = loaded_ammo.burnlevel
-	var/burntime = loaded_ammo.burntime
+	var/burnlevel = loaded_ammo.burnlevel*burnlevel_mult
+	var/burntime = loaded_ammo.burntime*burntime_mult
 	var/fire_color = loaded_ammo.fire_color
 	fire_delay = loaded_ammo.fire_delay
 
@@ -281,7 +285,7 @@
 		if(!current_mag?.current_rounds)
 			break
 		var/range = istype(src, /obj/item/weapon/gun/flamer/mini_flamer) ? 4 : loaded_ammo.max_range //Temporary hardcode range of miniflamer.
-		if(distance > range) 
+		if(distance > range)
 			break
 
 		var/blocked = FALSE


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
adds a multiplier to flamers for their burn levels and time
everything is unchanged but miniflamer which is halved across the board.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
miniflamer is absurd rn
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: miniflamer burntime and level is nerfed by 50%.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
