### PR TITLE
Reduce shield effectiveness against xenos, melee 50 to 20, acid 35 to 15

### DIFF
--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -139,10 +139,10 @@
 	flags_equip_slot = ITEM_SLOT_BACK
 	max_integrity = 400
 	integrity_failure = 100
-	soft_armor = list("melee" = 50, "bullet" = 50, "laser" = 0, "energy" = 100, "bomb" = 15, "bio" = 50, "rad" = 0, "fire" = 0, "acid" = 35)
+	soft_armor = list("melee" = 20, "bullet" = 50, "laser" = 0, "energy" = 100, "bomb" = 15, "bio" = 50, "rad" = 0, "fire" = 0, "acid" = 15)
 	hard_armor = list("melee" = 0, "bullet" = 5, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	force = 20
-	slowdown = 0.5
+	slowdown = 0.2
 
 
 /obj/item/weapon/shield/riot/marine/update_icon_state()

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -137,7 +137,7 @@
 	icon = 'icons/obj/items/weapons.dmi'
 	icon_state = "marine_shield"
 	flags_equip_slot = ITEM_SLOT_BACK
-	max_integrity = 400
+	max_integrity = 300
 	integrity_failure = 100
 	soft_armor = list("melee" = 20, "bullet" = 50, "laser" = 0, "energy" = 100, "bomb" = 15, "bio" = 50, "rad" = 0, "fire" = 0, "acid" = 15)
 	hard_armor = list("melee" = 0, "bullet" = 5, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -137,7 +137,7 @@
 	icon = 'icons/obj/items/weapons.dmi'
 	icon_state = "marine_shield"
 	flags_equip_slot = ITEM_SLOT_BACK
-	max_integrity = 300
+	max_integrity = 400
 	integrity_failure = 100
 	soft_armor = list("melee" = 20, "bullet" = 50, "laser" = 0, "energy" = 100, "bomb" = 15, "bio" = 50, "rad" = 0, "fire" = 0, "acid" = 15)
 	hard_armor = list("melee" = 0, "bullet" = 5, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -142,7 +142,7 @@
 	soft_armor = list("melee" = 20, "bullet" = 50, "laser" = 0, "energy" = 100, "bomb" = 15, "bio" = 50, "rad" = 0, "fire" = 0, "acid" = 15)
 	hard_armor = list("melee" = 0, "bullet" = 5, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	force = 20
-	slowdown = 0.2
+	slowdown = 0.5
 
 
 /obj/item/weapon/shield/riot/marine/update_icon_state()


### PR DESCRIPTION
## About The Pull Request

No more immortal ungas who literally CANNOT die unless you stun them or break their shield, and that's just with one shield. Though apparently melee is now viable enough to drop a T3 xeno down to near death in 3 hits or a ttk of 4 hits using the harvester, though that's unrelated to this PR and I am not sure how it does that. Unsurprisingly it pairs well with melee, which is singlehanded.

Generally, the only way to kill a person with a shield without dying before you can even harm them slightly requires multiple xenos to focus the guy at the same time with stuns, unless the guy using the shield doesn't have a weapon. Seriously, you can out heal xeno damage using chems with a shield and heavy tyr armor. This is disruptive to gameplay, and doesn't feel fun to play against. 

And double shield, although a meme, makes you actually unkillable without a stun. Most stuns only last enough for maybe one and a half slashes, so if you wanna kill a guy with a shield without going through their integrity which they can just repair with a welding tool between engagements, you need a stun for every slash and a half practically, or to get one of those ridiculously long stuns that last long enough to crit the guy before he gets up. Rocket Tag moment.

Yes, you can probably still die if you run around solo with shields and don't retreat, but it can require 2 or more xenos depending on caste type to kill you until your shields break, so it's much less likely.

And yes, it has a valid tactic of absorbing damage for other marines if xenos target you, but when you have a quarter of the marines with shields all still capable of doing damage themselves, it just turns into being very durable armor at the cost of having to carry a welding tool and welding goggles.

## Why It's Good For The Game

So people stop stacking every armor item in the game with shields so they only take about 1.5 to 2 brute per slash or 0.5 if you use two shields. Shields can still absorb bullets and nullify them entirely though.

## Changelog
:cl:
balance: Shield melee armor 50 to 20, acid armor 35 to 15
/:cl:
