### PR TITLE
Fixes synths applying racial resistances twice to limb damage

### DIFF
--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -167,13 +167,9 @@
 	if(limb_status & LIMB_DESTROYED)
 		return 0
 
-	if(limb_status & LIMB_ROBOT)
-		if(issynth(owner))
-			brute *= owner.species.brute_mod
-			burn *= owner.species.burn_mod
-		else
-			brute *= 0.50 // half damage for ROBOLIMBS
-			burn *= 0.50 // half damage for ROBOLIMBS
+	if(limb_status & LIMB_ROBOT && !(owner.species.species_flags & IS_SYNTHETIC))
+		brute *= 0.50 // half damage for ROBOLIMBS if you weren't born with them
+		burn *= 0.50 
 
 	//High brute damage or sharp objects may damage internal organs
 	if(internal_organs && ((sharp && brute >= 10) || brute >= 20) && prob(5))


### PR DESCRIPTION
## About The Pull Request
Humans take normal damage through their species' apply_damage proc, which includes reducing it based on their brute/burn_mod. So if limbs apply it too, that's twice.

## Why It's Good For The Game
Fix.

## Changelog
:cl:
fix: Synths don't apply their damage reduction twice anymore.
/:cl: