### PR TITLE
Lazy click drag fix

### DIFF
--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -6,7 +6,7 @@
 	almost anything into a trash can.
 */
 /atom/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)
-	if(!usr || !over || QDELETED(src) || src_location == over_location || src_control == over_control)
+	if(!usr || !over || QDELETED(src))
 		return
 	if(!Adjacent(usr) || !over.Adjacent(usr))
 		return // should stop you from dragging through windows
@@ -54,7 +54,7 @@
 		return
 	var/list/L = params2list(params)
 	if(L["middle"])
-		if(src_object && (src_location != over_location || src_object != over_object || src_control != over_control))
+		if(src_object && src_location != over_location)
 			middragtime = world.time
 			middragatom = src_object
 		else
@@ -65,8 +65,8 @@
 	SEND_SIGNAL(src, COMSIG_CLIENT_MOUSEDRAG, src_object, over_object, src_location, over_location, src_control, over_control, params)
 
 /client/MouseDrop(src_object, over_object, src_location, over_location, src_control, over_control, params)
-	if(src_location == over_location && src_control == over_control && src_object == over_object)
-		Click(over_location, over_control, params)
+	if(src_control == over_control && src_object == over_object)
+		usr.ClickOn(over_object, over_location, params)
 	if(middragatom == src_object)
 		middragtime = 0
 		middragatom = null

--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -65,7 +65,7 @@
 	SEND_SIGNAL(src, COMSIG_CLIENT_MOUSEDRAG, src_object, over_object, src_location, over_location, src_control, over_control, params)
 
 /client/MouseDrop(src_object, over_object, src_location, over_location, src_control, over_control, params)
-	if(src_control == over_control && src_object == over_object)
+	if(src_object == over_object)
 		usr.ClickOn(over_object, over_location, params)
 	if(middragatom == src_object)
 		middragtime = 0

--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -67,6 +67,7 @@
 /client/MouseDrop(src_object, over_object, src_location, over_location, src_control, over_control, params)
 	if(src_object == over_object)
 		usr.ClickOn(over_object, over_location, params)
+		return
 	if(middragatom == src_object)
 		middragtime = 0
 		middragatom = null

--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -6,7 +6,7 @@
 	almost anything into a trash can.
 */
 /atom/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)
-	if(!usr || !over || QDELETED(src))
+	if(!usr || !over || QDELETED(src) || src_location == over_location || src_control == over_control)
 		return
 	if(!Adjacent(usr) || !over.Adjacent(usr))
 		return // should stop you from dragging through windows
@@ -54,7 +54,7 @@
 		return
 	var/list/L = params2list(params)
 	if(L["middle"])
-		if(src_object && src_location != over_location)
+		if(src_object && (src_location != over_location || src_object != over_object || src_control != over_control))
 			middragtime = world.time
 			middragatom = src_object
 		else
@@ -65,6 +65,8 @@
 	SEND_SIGNAL(src, COMSIG_CLIENT_MOUSEDRAG, src_object, over_object, src_location, over_location, src_control, over_control, params)
 
 /client/MouseDrop(src_object, over_object, src_location, over_location, src_control, over_control, params)
+	if(src_location == over_location && src_control == over_control && src_object == over_object)
+		Click(over_location, over_control, params)
 	if(middragatom == src_object)
 		middragtime = 0
 		middragatom = null


### PR DESCRIPTION
## About The Pull Request

If you click drag an object onto itself, it'll click on the object. No problems in-game after some testing.

## Why It's Good For The Game

Less missed clicks, you can click on moving targets properly, and you don't need to have esoteric knowledge to have an advantage over other players.

## Changelog
:cl:
code: Click dragging an object onto itself will click on the object instead of doing nothing.
/:cl:

https://user-images.githubusercontent.com/22848292/134054555-a8249378-9a44-41b5-95fc-850d4c00011e.mp4


