### PR TITLE
You can have multiple ammo huds

### DIFF
--- a/code/_onclick/hud/_defines.dm
+++ b/code/_onclick/hud/_defines.dm
@@ -83,7 +83,10 @@
 #define UI_STAMINA "EAST-1:28,CENTER-2:13"
 #define ui_health "EAST-1:28,CENTER-1:15"
 #define ui_internal "EAST-1:28,CENTER:17"
-#define ui_ammo "EAST-1:28,CENTER+1:25"
+#define ui_ammo1 "EAST-1:28,CENTER+1:25"
+#define ui_ammo2 "EAST-1:28,CENTER+2:27"
+#define ui_ammo3 "EAST-1:28,CENTER+3:29"
+#define ui_ammo4 "EAST-1:28,CENTER+4:31"
 
 									//borgs
 #define ui_borg_health "EAST-1:28,6:13" //borgs have the health display where humans have the bodytemp indicator.

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -1,4 +1,4 @@
-
+#define MAXHUD_POSSIBLE 4
 /*
 	The hud datum
 	Used to show and hide huds for all the different mob types,
@@ -50,7 +50,7 @@
 	var/obj/screen/gun_move_icon
 	var/obj/screen/gun_run_icon
 
-	var/obj/screen/ammo
+	var/list/obj/screen/ammo_hud_list = list()
 
 	var/list/static_inventory = list() //the screen objects which are static
 	var/list/toggleable_inventory = list() //the screen objects which can be hidden
@@ -131,7 +131,7 @@
 
 	QDEL_LIST_ASSOC_VAL(plane_masters)
 
-	ammo = null
+	QDEL_LIST(ammo_hud_list)
 
 	mymob = null
 
@@ -246,11 +246,6 @@
 		return FALSE
 	hidden_inventory_update(screenmob)
 
-	if(hud_version == HUD_STYLE_STANDARD)
-		screenmob.client.screen += ammo
-		var/obj/screen/ammo/A = ammo
-		A.update_hud(screenmob)
-
 
 /datum/hud/proc/hidden_inventory_update(mob/viewer)
 	return
@@ -258,6 +253,29 @@
 /datum/hud/proc/persistent_inventory_update(mob/viewer)
 	return
 
+/datum/hud/proc/add_ammo_hud(mob/living/user, obj/item/weapon/gun/G)
+	if(length(ammo_hud_list) >= MAXHUD_POSSIBLE)
+		return
+	var/obj/screen/ammo/ammo_hud = new
+	ammo_hud_list[G] = ammo_hud
+	ammo_hud.screen_loc = ammo_hud.ammo_screen_loc_list[length(ammo_hud_list)]
+	ammo_hud.add_hud(user, G)
+	ammo_hud.update_hud(user, G)
+
+/datum/hud/proc/remove_ammo_hud(mob/living/user, obj/item/weapon/gun/G)
+	var/obj/screen/ammo/ammo_hud = ammo_hud_list[G]
+	ammo_hud.remove_hud(user, G)
+	qdel(ammo_hud)
+	ammo_hud_list -= G
+	var/i = 1
+	for(var/key in ammo_hud_list)
+		ammo_hud = ammo_hud_list[key]
+		ammo_hud.screen_loc = ammo_hud.ammo_screen_loc_list[i]
+		i++
+
+/datum/hud/proc/update_ammo_hud(mob/living/user, obj/item/weapon/gun/G)
+	var/obj/screen/ammo/ammo_hud = ammo_hud_list[G]
+	ammo_hud?.update_hud(user, G)
 
 /obj/screen/action_button/MouseEntered(location, control, params)
 	if (!usr.client?.prefs?.tooltips)

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -253,6 +253,7 @@
 /datum/hud/proc/persistent_inventory_update(mob/viewer)
 	return
 
+///Add an ammo hud to the user informing of the ammo count of G
 /datum/hud/proc/add_ammo_hud(mob/living/user, obj/item/weapon/gun/G)
 	if(length(ammo_hud_list) >= MAXHUD_POSSIBLE)
 		return
@@ -262,6 +263,7 @@
 	ammo_hud.add_hud(user, G)
 	ammo_hud.update_hud(user, G)
 
+///Remove the ammo hud related to the gun G from the user
 /datum/hud/proc/remove_ammo_hud(mob/living/user, obj/item/weapon/gun/G)
 	var/obj/screen/ammo/ammo_hud = ammo_hud_list[G]
 	ammo_hud.remove_hud(user, G)
@@ -273,6 +275,7 @@
 		ammo_hud.screen_loc = ammo_hud.ammo_screen_loc_list[i]
 		i++
 
+///Update the ammo hud related to the gun G
 /datum/hud/proc/update_ammo_hud(mob/living/user, obj/item/weapon/gun/G)
 	var/obj/screen/ammo/ammo_hud = ammo_hud_list[G]
 	ammo_hud?.update_hud(user, G)

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -219,8 +219,6 @@
 	zone_sel.update_icon(owner)
 	static_inventory += zone_sel
 
-	ammo = new /obj/screen/ammo()
-
 
 /mob/living/carbon/human/verb/toggle_hotkey_verbs()
 	set category = "OOC"

--- a/code/_onclick/hud/screen_objects/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects/screen_objects.dm
@@ -676,19 +676,21 @@
 	name = "ammo"
 	icon = 'icons/mob/ammoHUD.dmi'
 	icon_state = "ammo"
-	screen_loc = ui_ammo
+	screen_loc = ui_ammo1
 	var/warned = FALSE
+	///List of possible screen locs
+	var/static/list/ammo_screen_loc_list = list(ui_ammo1, ui_ammo2, ui_ammo3 ,ui_ammo4)
 
 
 /obj/screen/ammo/proc/add_hud(mob/living/user, obj/item/weapon/gun/G)
 
-	if(!G)
+	if(isnull(G))
 		CRASH("/obj/screen/ammo/proc/add_hud() has been called from [src] without the required param of G")
 
 	if(!user?.client)
 		return
 
-	if((user.get_active_held_item() != G && user.get_inactive_held_item() != G && !CHECK_BITFIELD(G.flags_item, IS_DEPLOYED)) || !G.hud_enabled || !CHECK_BITFIELD(G.flags_gun_features, GUN_AMMO_COUNTER))
+	if(!CHECK_BITFIELD(G.flags_gun_features, GUN_AMMO_COUNTER))
 		return
 
 	user.client.screen += src
@@ -702,7 +704,7 @@
 	if(!user?.client?.screen.Find(src))
 		return
 
-	if(!G || !(G.flags_gun_features & GUN_AMMO_COUNTER) || !G.hud_enabled || !G.get_ammo_type() || isnull(G.get_ammo_count()))
+	if(!G || !(G.flags_gun_features & GUN_AMMO_COUNTER) || !G.get_ammo_type() || isnull(G.get_ammo_count()))
 		remove_hud(user)
 		return
 

--- a/code/game/objects/items/storage/marine_boxes.dm
+++ b/code/game/objects/items/storage/marine_boxes.dm
@@ -86,7 +86,6 @@
 	else
 		user.visible_message("[user.name]'s powerpack servos begin automatically feeding an ammo belt into the T-100 Minigun.","The powerpack servos begin automatically feeding a fresh ammo belt into the T-100 Minigun.")
 	var/reload_duration = 5 SECONDS
-	var/obj/screen/ammo/A = user.hud_used.ammo
 	if(automatic)
 		if(!autoload_check(user, reload_duration, mygun, src) || !pcell)
 			to_chat(user, "The automated reload process was interrupted!")
@@ -94,7 +93,7 @@
 			reloading = FALSE
 			return TRUE
 		reload(user, mygun, TRUE)
-		A.update_hud(user)
+		user.hud_used.update_ammo_hud(user, src)
 		return TRUE
 	if(user.skills.getRating("firearms") > 0)
 		reload_duration = max(reload_duration - 1 SECONDS * user.skills.getRating("firearms"), 3 SECONDS)
@@ -104,7 +103,7 @@
 		reloading = FALSE
 		return TRUE
 	reload(user, mygun)
-	A.update_hud(user)
+	user.hud_used.update_ammo_hud(user, src)
 	return TRUE
 
 /obj/item/minigun_powerpack/attack_hand(mob/living/user)

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -768,29 +768,6 @@ should be alright.
 
 
 
-/mob/living/carbon/human/verb/toggle_ammo_hud()
-	set category = "Weapons"
-	set name = "Toggle Ammo HUD"
-	set desc = "Toggles the Ammo HUD for this weapon."
-
-	var/obj/item/weapon/gun/G = get_active_firearm(usr)
-	if(!G)
-		return
-	G.toggle_ammo_hud()
-
-
-/obj/item/weapon/gun/verb/toggle_ammo_hud()
-	set category = null
-	set name = "Toggle Ammo HUD (Weapon)"
-	set desc = "Toggles the Ammo HUD for this weapon."
-
-	hud_enabled = !hud_enabled
-	var/obj/screen/ammo/A = usr.hud_used.ammo
-	hud_enabled ? A.add_hud(usr, src) : A.remove_hud(usr, src)
-	A.update_hud(usr)
-	to_chat(usr, span_notice("[hud_enabled ? "You enable the Ammo HUD for this weapon." : "You disable the Ammo HUD for this weapon."]"))
-
-
 /obj/item/weapon/gun/item_action_slot_check(mob/user, slot)
 	if(slot != SLOT_L_HAND && slot != SLOT_R_HAND && !CHECK_BITFIELD(flags_item, IS_DEPLOYED))
 		return FALSE

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -248,9 +248,7 @@
 
 	//load_into_chamber()
 
-	if(user)
-		var/obj/screen/ammo/A = user.hud_used.ammo //The ammo HUD
-		A.update_hud(user)
+	user?.hud_used.update_ammo_hud(user, src)
 
 	return TRUE
 
@@ -515,9 +513,7 @@
 	update_icon()
 
 	to_chat(user, initial(choice.message_to_user))
-
-	var/obj/screen/ammo/A = user.hud_used.ammo //The ammo HUD
-	A.update_hud(user)
+	user.hud_used.update_ammo_hud(user, src)
 
 /obj/item/weapon/gun/energy/lasgun/lasrifle/update_item_state(mob/user) //Without this override icon states for wielded guns won't show. because lasgun overrides and this has no charge icons
 	item_state = "[initial(icon_state)][flags_item & WIELDED ? "_w" : ""]"

--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -41,7 +41,7 @@
 	desc = "A weapon-mounted refillable flamethrower attachment.\nIt is designed for short bursts."
 	icon = 'icons/Marine/marine-weapons.dmi'
 	icon_state = "flamethrower"
-	
+
 	flags_gun_features = GUN_UNUSUAL_DESIGN|GUN_AMMO_COUNTER|GUN_WIELDED_FIRING_ONLY|GUN_WIELDED_STABLE_FIRING_ONLY|GUN_IS_ATTACHMENT|GUN_ATTACHMENT_FIRE_ONLY
 	w_class = WEIGHT_CLASS_BULKY
 	fire_delay = 2.5 SECONDS
@@ -167,7 +167,7 @@
 		light_pilot(user,TRUE)
 
 	update_icon()
-
+	user.hud_used.update_ammo_hud(user, src)
 	return TRUE
 
 /obj/item/weapon/gun/flamer/unload(mob/user, reload_override = 0, drop_override = 0)
@@ -218,8 +218,7 @@
 	light_pilot(user,TRUE)
 	playsound(user, reload_sound, 25, 1, 5)
 	update_icon(user)
-	var/obj/screen/ammo/A = user.hud_used.ammo
-	A.update_hud(user, src)
+	user?.hud_used.update_ammo_hud(user, src)
 
 
 /**Proced when unlinking the back fuel tank, making the flamer unlit and unable to fire
@@ -235,9 +234,7 @@
 	playsound(user, unload_sound, 25, 1)
 	light_pilot(user,FALSE)
 	update_icon(user)
-	var/obj/screen/ammo/A = user.hud_used.ammo
-	A.update_hud(user, src)
-
+	user?.hud_used.update_ammo_hud(user, src)
 
 /obj/item/weapon/gun/flamer/removed_from_inventory(mob/user)
 	. = ..()
@@ -281,7 +278,7 @@
 		if(!current_mag?.current_rounds)
 			break
 		var/range = istype(src, /obj/item/weapon/gun/flamer/mini_flamer) ? 4 : loaded_ammo.max_range //Temporary hardcode range of miniflamer.
-		if(distance > range) 
+		if(distance > range)
 			break
 
 		var/blocked = FALSE
@@ -316,8 +313,7 @@
 		sleep(1)
 	if(!user)
 		return
-	var/obj/screen/ammo/A = user.hud_used.ammo
-	A.update_hud(user, src)
+	user.hud_used.update_ammo_hud(user, src)
 
 /obj/item/weapon/gun/flamer/proc/flame_turf(turf/T, mob/living/user, heat, burn, f_color = "red")
 	if(!istype(T))
@@ -477,8 +473,7 @@
 		hydro_active = FALSE
 		if (current_mag?.current_rounds > 0)
 			light_pilot(user, TRUE)
-	var/obj/screen/ammo/A = user.hud_used.ammo
-	A.update_hud(user, src)
+	user.hud_used.update_ammo_hud(user, src)
 	SEND_SIGNAL(src, COMSIG_ITEM_HYDRO_CANNON_TOGGLED)
 	return TRUE
 
@@ -507,8 +502,7 @@
 		light_pilot(user,TRUE)
 	playsound(user, reload_sound, 25, 1, 5)
 	update_icon(user)
-	var/obj/screen/ammo/A = user.hud_used.ammo
-	A.update_hud(user, src)
+	user.hud_used.update_ammo_hud(user, src)
 
 /obj/item/weapon/gun/flamer/big_flamer/marinestandard/Fire()
 	if(!target)
@@ -518,8 +512,7 @@
 		water_count -= 7//reagents is not updated in this proc, we need water_count for a updated HUD
 		last_fired = world.time
 		last_use = world.time
-		var/obj/screen/ammo/A = gun_user.hud_used.ammo
-		A.update_hud(gun_user, src)
+		gun_user.hud_used.update_ammo_hud(gun_user, src)
 		return
 	if(gun_user?.skills.getRating("firearms") < 0)
 		switch(windup_checked)
@@ -547,8 +540,7 @@
 		water_count = reagents.maximum_volume
 		to_chat(user, span_notice("\The [src]'s hydro cannon is refilled with water."))
 		playsound(src.loc, 'sound/effects/refill.ogg', 25, 1, 3)
-		var/obj/screen/ammo/A = user.hud_used.ammo
-		A.update_hud(user, src)
+		user.hud_used.update_ammo_hud(user, src)
 		return
 
 /obj/item/weapon/gun/flamer/big_flamer/marinestandard/get_ammo_count()

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -537,9 +537,7 @@ can cause issues with ammo types getting mixed up during the burst.
 	playsound(src, pump_sound, 25, 1)
 	recent_pump = world.time
 	if(in_chamber) //Lock only if we have ammo loaded.
-		pump_lock = TRUE
-		var/obj/screen/ammo/A = user.hud_used.ammo
-		A.update_hud(user)
+		user.hud_used.update_ammo_hud(user, src)
 
 	return TRUE
 

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -577,8 +577,7 @@
 		to_chat(gun_user, span_warning("The grenade launcher is empty."))
 		return
 	fire_grenade(target, gun_user)
-	var/obj/screen/ammo/A = gun_user.hud_used.ammo
-	A.update_hud(gun_user)
+	gun_user.hud_used.update_ammo_hud(gun_user, src)
 
 
 //Doesn't use most of any of these. Listed for reference.

--- a/code/modules/projectiles/mounted.dm
+++ b/code/modules/projectiles/mounted.dm
@@ -134,9 +134,6 @@
 
 	for(var/datum/action/action AS in gun.actions)
 		action.give_action(operator)
-	var/obj/screen/ammo/hud = operator.hud_used.ammo
-	hud.add_hud(operator, internal_item)
-	hud.update_hud(operator, internal_item)
 
 	gun.set_gun_user(operator)
 
@@ -236,8 +233,6 @@
 
 	for(var/datum/action/action AS in gun.actions)
 		action.remove_action(operator)
-	var/obj/screen/ammo/hud = operator.hud_used.ammo
-	hud.remove_hud(operator)
 
 	for(var/key in gun.attachments_by_slot)
 		var/obj/item/attachable = gun.attachments_by_slot[key]


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

For akimbos, and attachments. Also fixes : https://github.com/tgstation/TerraGov-Marine-Corps/issues/7558

![image](https://user-images.githubusercontent.com/25491240/134092314-668d57ea-3f32-408e-914a-d021f11e7254.png)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Knowing how much ammo you have is pretty cool IMO

## Changelog
:cl:
qol: You can have multiple ammo huds
del: Remove the ability to disable ammo hud
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
