### PR TITLE
Make command aura permanent for SL and above

### DIFF
--- a/code/datums/jobs/squads.dm
+++ b/code/datums/jobs/squads.dm
@@ -304,7 +304,7 @@ GLOBAL_LIST_EMPTY(helmetmarkings_sl)
 
 	//Handle aSL skill level and radio
 	if(!ismarineleaderjob(squad_leader.job))
-		squad_leader.skills = squad_leader.skills.setRating(leadership = SKILL_LEAD_EXPERT)
+		squad_leader.skills = squad_leader.skills.setRating(leadership = SKILL_LEAD_TRAINED)
 		squad_leader.comm_title = "aSL"
 		var/obj/item/card/id/ID = squad_leader.get_idcard()
 		if(istype(ID))

--- a/code/modules/mob/living/carbon/human/life/handle_status_effects.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_status_effects.dm
@@ -17,7 +17,7 @@
 	if(command_aura)
 		command_aura_tick--
 
-		if(command_aura_tick < 1 || IsMute()) //Null the command aura if we're muted or its duration is over
+		if( (command_aura_tick < 1 && skills.getRating("leadership") < 3) || IsMute()) //Null the command aura if we're muted or its duration is over
 			command_aura = null
 
 		if(stat == CONSCIOUS) //Must be conscious


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Command aura is now permanent if you are a non aSL command staff.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This is a straight up buff and I didn't balance the numbers at all if maintainers want to test this as is its probably fine though. Discussion about balance can take place both here and discord if you want something changed.

This has been talked about for some while and I wanted to see if discussion could be stimulated more by a bit of testing. I've nerfed aSL leadership skill down to 2 to make the check simpler and make this less similar to xeno pheros. Also tested and made sure one person can only give one aura.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Command staff order auras are now permanent
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
