### PR TITLE
Self splinting timer delay is 3x instead of 4x

### DIFF
--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -1089,7 +1089,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	var/text2 = span_notice("You finish applying [S] to [target]'s [display_name].")
 
 	if(target == user) //If self splinting, multiply delay by 4
-		delay *= 4
+		delay *= 3
 		text1 = span_warning("[user] successfully applies [S] to their [display_name].")
 		text2 = span_notice("You successfully apply [S] to your [display_name].")
 


### PR DESCRIPTION

## About The Pull Request

Makes the self splinting time delay 3x from 4x

## Why It's Good For The Game

Self splinting timer delay of 3x based on individual's skill. Even if a medic splints themselves it used to be 4x now it should be 3x delay. It also helps marines who are mid combat get splinted a bit quicker if they are carrying splints on their own. 
![image](https://user-images.githubusercontent.com/68121607/134210682-a81b2bb2-503b-40b8-8d7c-afa54b022b67.png)
got it approved by PL as well

## Changelog
:cl:
balance: self splinting delay is now 3x instead of 4x
/:cl:
