### PR TITLE
Whiskey Outpost QOL update

### DIFF
--- a/_maps/map_files/Whiskey_Outpost/Whiskey_Outpost_v2.dmm
+++ b/_maps/map_files/Whiskey_Outpost/Whiskey_Outpost_v2.dmm
@@ -512,10 +512,6 @@
 	dir = 8
 	},
 /area/whiskey_outpost)
-"cm" = (
-/obj/structure/jungle/vines,
-/turf/open/ground/jungle,
-/area/whiskey_outpost/outside/west)
 "cn" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/open/ground/grass,
@@ -1861,15 +1857,6 @@
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/ground/river,
 /area/whiskey_outpost/outside/east)
-"hI" = (
-/obj/machinery/door/poddoor/four_tile_hor{
-	desc = "No escape.";
-	id = "escape";
-	name = "Exit Shield";
-	resistance_flags = 3
-	},
-/turf/open/ground/river,
-/area/whiskey_outpost)
 "hJ" = (
 /turf/open/ground/grass/beach,
 /area/whiskey_outpost/outside/west)
@@ -2777,7 +2764,7 @@
 	name = "King Moth"
 	},
 /turf/open/floor/rcircuit,
-/area/whiskey_outpost/outside/north)
+/area/whiskey_outpost)
 "mW" = (
 /obj/effect/landmark/start/job/squadmarine,
 /turf/open/floor/plating,
@@ -4136,7 +4123,7 @@
 	name = "Princess Slime"
 	},
 /turf/open/floor/rcircuit,
-/area/whiskey_outpost/outside/north)
+/area/whiskey_outpost)
 "sS" = (
 /obj/machinery/light{
 	dir = 1
@@ -4930,11 +4917,6 @@
 "BR" = (
 /turf/closed/wall/indestructible/mineral,
 /area/whiskey_outpost)
-"BU" = (
-/obj/structure/table/woodentable,
-/obj/item/coin/gold,
-/turf/open/floor/plating/asteroidfloor,
-/area/whiskey_outpost/outside/west)
 "BX" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/claymore/mercsword/captain,
@@ -5043,7 +5025,7 @@
 	name = "SunoBux"
 	},
 /turf/open/floor/prison,
-/area/whiskey_outpost/outside/north)
+/area/whiskey_outpost)
 "CA" = (
 /obj/effect/landmark/start/job/squadmarine,
 /turf/open/ground/jungle/path,
@@ -5069,7 +5051,7 @@
 	name = "Jester Moth"
 	},
 /turf/open/floor/prison,
-/area/whiskey_outpost/outside/north)
+/area/whiskey_outpost)
 "CK" = (
 /obj/item/weapon/gun/tl102/hsg_nest{
 	dir = 4
@@ -5585,12 +5567,6 @@
 /obj/effect/ai_node,
 /turf/open/ground/jungle,
 /area/whiskey_outpost/outside/west)
-"Io" = (
-/turf/closed/banish_space{
-	desc = "You realize the truth. There is no escape";
-	name = "End of the world"
-	},
-/area/whiskey_outpost/outside/north)
 "Ip" = (
 /obj/item/tool/lighter/random,
 /obj/structure/table/mainship,
@@ -5682,11 +5658,6 @@
 /obj/machinery/vending/marine/shared,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
-"Je" = (
-/obj/structure/bed,
-/obj/item/bedsheet/captain,
-/turf/open/floor/plating/asteroidfloor,
-/area/whiskey_outpost/outside/west)
 "Jf" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirt,
@@ -6004,10 +5975,6 @@
 /obj/structure/barricade/sandbags,
 /turf/open/floor/plating/ground/dirt,
 /area/whiskey_outpost/outside/north)
-"MA" = (
-/obj/structure/mineral_door/iron,
-/turf/open/floor/plating/ground/dirt,
-/area/whiskey_outpost/outside/west)
 "MB" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -6076,11 +6043,6 @@
 	dir = 4
 	},
 /turf/open/ground/river,
-/area/whiskey_outpost/outside/west)
-"NJ" = (
-/obj/item/weapon/twohanded/glaive,
-/obj/structure/rack,
-/turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost/outside/west)
 "NL" = (
 /obj/machinery/light{
@@ -6157,10 +6119,6 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/whiskey_outpost/outside/north)
-"Oj" = (
-/obj/structure/fence,
-/turf/open/ground/river,
-/area/whiskey_outpost)
 "Ok" = (
 /obj/item/weapon/gun/sentry/premade,
 /turf/open/floor/plating/asteroidfloor,
@@ -6195,7 +6153,7 @@
 	name = "Queen Moth"
 	},
 /turf/open/floor/rcircuit,
-/area/whiskey_outpost/outside/north)
+/area/whiskey_outpost)
 "Oy" = (
 /obj/machinery/floodlight/outpost,
 /turf/open/floor/plating,
@@ -6296,9 +6254,6 @@
 /obj/structure/barricade/plasteel,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost/outside/east)
-"PF" = (
-/turf/closed/wall/r_wall/unmeltable,
-/area/whiskey_outpost)
 "PG" = (
 /obj/item/roller,
 /turf/open/floor/mainship/sterile/dark,
@@ -6724,26 +6679,15 @@
 /obj/effect/landmark/start/job/squadmarine,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
-"Vf" = (
-/turf/open/floor/prison,
-/area/whiskey_outpost/outside/north)
 "Vh" = (
 /obj/effect/ai_node,
 /turf/open/ground/jungle,
 /area/whiskey_outpost/outside/east)
-"Vl" = (
-/obj/structure/jungle/vines/heavy,
-/turf/open/floor/plating/ground/dirtgrassborder,
-/area/whiskey_outpost/outside/west)
 "Vq" = (
 /turf/open/floor/plating/asteroidwarning{
 	dir = 6
 	},
 /area/whiskey_outpost)
-"VB" = (
-/obj/structure/jungle/vines/heavy,
-/turf/open/ground/jungle,
-/area/whiskey_outpost/outside/west)
 "VD" = (
 /obj/structure/barricade/sandbags{
 	dir = 4
@@ -6778,9 +6722,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirt,
 /area/whiskey_outpost/outside/east)
-"VS" = (
-/turf/open/ground/river,
-/area/whiskey_outpost)
 "Wf" = (
 /obj/machinery/door/airlock/mainship/command{
 	dir = 2;
@@ -6788,7 +6729,7 @@
 	name = "Court Of The Moth King"
 	},
 /turf/open/floor/prison,
-/area/whiskey_outpost/outside/north)
+/area/whiskey_outpost)
 "Wm" = (
 /obj/effect/landmark/start/job/squadsmartgunner,
 /turf/open/floor/plating/asteroidfloor,
@@ -6994,10 +6935,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost/outside/south)
-"Yw" = (
-/obj/structure/jungle/vines,
-/turf/open/floor/plating/ground/dirtgrassborder/corner,
-/area/whiskey_outpost/outside/west)
 "Yy" = (
 /obj/structure/platform_decoration{
 	dir = 1
@@ -7067,10 +7004,6 @@
 /obj/structure/largecrate/guns,
 /turf/open/floor/plating/platebot,
 /area/whiskey_outpost)
-"ZB" = (
-/obj/structure/jungle/vines/heavy,
-/turf/open/floor/plating/ground/dirt,
-/area/whiskey_outpost/outside/west)
 "ZP" = (
 /obj/structure/barricade/metal,
 /obj/structure/barricade/metal{
@@ -12222,9 +12155,9 @@ hy
 hw
 hw
 hw
-cm
-VB
-Yw
+hB
+hB
+hB
 hB
 hB
 hB
@@ -12375,11 +12308,11 @@ hy
 hw
 hw
 hB
-cm
-VB
-Vl
-ZB
-hm
+hB
+hB
+hB
+hB
+hB
 hB
 hB
 hB
@@ -12530,10 +12463,10 @@ hB
 hB
 hB
 hB
-Vl
-hm
-hm
-hm
+hB
+hB
+hB
+hB
 hB
 hB
 hB
@@ -12684,9 +12617,9 @@ hB
 hB
 hB
 hB
-hm
-hm
-hm
+hB
+hB
+hB
 hB
 hB
 hB
@@ -12838,8 +12771,8 @@ hB
 hB
 hB
 hB
-hm
-hm
+hB
+hB
 hB
 hB
 hB
@@ -12991,8 +12924,8 @@ hB
 hB
 hB
 hB
-MA
-MA
+hB
+hB
 hB
 hB
 hB
@@ -13143,9 +13076,9 @@ hB
 hB
 hB
 hB
-hm
-hm
-hm
+hB
+hB
+hB
 hB
 hB
 hB
@@ -13293,12 +13226,12 @@ hB
 hB
 hB
 hB
-Je
-hX
-hX
-hm
-hm
-hm
+hB
+hB
+hB
+hB
+hB
+hB
 hB
 hB
 hB
@@ -13446,11 +13379,11 @@ hB
 hB
 hB
 hB
-BU
-hX
-hX
-hX
-hZ
+hB
+hB
+hB
+hB
+hB
 hB
 hB
 hB
@@ -13600,9 +13533,9 @@ hB
 hB
 hB
 hB
-NJ
-hX
-hX
+hB
+hB
+hB
 hB
 hB
 hB
@@ -23962,10 +23895,10 @@ aS
 aS
 aS
 aS
-PF
-PF
-PF
-PF
+aS
+aS
+aS
+aS
 cx
 cx
 cx
@@ -24115,10 +24048,10 @@ aS
 aS
 aS
 aS
-PF
-JZ
-hI
-Oj
+aS
+aS
+aS
+cx
 cx
 cx
 cx
@@ -24268,10 +24201,10 @@ aS
 aS
 aS
 aS
-PF
-JZ
-VS
-Oj
+aS
+aS
+aS
+cx
 cx
 cx
 cx
@@ -24421,10 +24354,10 @@ aS
 aS
 aS
 aS
-PF
-JZ
-VS
-Oj
+aS
+aS
+aS
+cx
 cx
 cJ
 cx
@@ -24574,10 +24507,10 @@ aS
 aS
 aS
 aS
-PF
-JZ
-VS
-Oj
+aS
+aS
+aS
+cx
 cx
 cx
 cx
@@ -24727,10 +24660,10 @@ aS
 aS
 aS
 aS
-PF
-PF
-PF
-PF
+aS
+aS
+aS
+aS
 cx
 cx
 cx
@@ -25475,7 +25408,7 @@ Xz
 Xz
 Xz
 Xz
-aS
+Xz
 aS
 aS
 aS
@@ -25628,8 +25561,8 @@ Xz
 Xz
 Xz
 Xz
-aS
-aS
+Xz
+Xz
 aS
 aS
 aS
@@ -25930,12 +25863,12 @@ mv
 (124,1,1) = {"
 mv
 Xz
-Io
-Io
-Io
-Io
-Io
-Io
+JZ
+JZ
+JZ
+JZ
+JZ
+JZ
 Xz
 aS
 aS
@@ -26083,12 +26016,12 @@ mv
 (125,1,1) = {"
 mv
 Xz
-Io
+JZ
 sQ
-Vf
-Vf
+HQ
+HQ
 Cy
-Io
+JZ
 Xz
 Xz
 aS
@@ -26236,11 +26169,11 @@ mv
 (126,1,1) = {"
 mv
 Xz
-Io
+JZ
 mV
-Vf
-Vf
-Vf
+HQ
+HQ
+HQ
 Wf
 Xz
 Xz
@@ -26389,12 +26322,12 @@ mv
 (127,1,1) = {"
 mv
 Xz
-Io
+JZ
 Ov
-Vf
-Vf
+HQ
+HQ
 CJ
-Io
+JZ
 Xz
 Xz
 Xz
@@ -26542,12 +26475,12 @@ mv
 (128,1,1) = {"
 mv
 Xz
-Io
-Io
-Io
-Io
-Io
-Io
+JZ
+JZ
+JZ
+JZ
+JZ
+JZ
 Xz
 Xz
 Xz

--- a/_maps/map_files/Whiskey_Outpost/Whiskey_Outpost_v2.dmm
+++ b/_maps/map_files/Whiskey_Outpost/Whiskey_Outpost_v2.dmm
@@ -17,54 +17,59 @@
 /area/whiskey_outpost)
 "ag" = (
 /obj/item/clothing/suit/storage/marine/smartgunner/fancy,
-/obj/structure/table,
+/obj/structure/table/woodentable,
 /turf/open/floor/wood,
 /area/whiskey_outpost)
 "ah" = (
-/obj/structure/table,
-/obj/item/weapon/claymore/mercsword{
-	desc = "A fancy ceremonial sword passed down from generation to generation. Has the name Chang printed along the blade";
-	name = "Ceremonial Sword"
-	},
-/obj/item/reagent_containers/pill/cyanide,
+/obj/structure/bed,
+/obj/item/bedsheet/captain,
+/obj/structure/curtain/open,
+/obj/effect/landmark/start/job/staffofficer,
 /turf/open/floor/wood,
 /area/whiskey_outpost)
 "ai" = (
 /obj/structure/bed,
 /obj/item/bedsheet/captain,
 /obj/effect/landmark/start/job/fieldcommander,
+/obj/structure/curtain/open,
 /turf/open/floor/wood,
 /area/whiskey_outpost)
 "ak" = (
 /turf/closed/mineral,
 /area/whiskey_outpost)
 "al" = (
-/obj/machinery/door/airlock/mainship/command/FCDRquarters{
-	dir = 1
+/obj/machinery/door/airlock/mainship/command{
+	dir = 2;
+	name = "\improper Command Bunks"
 	},
 /turf/open/floor/wood,
 /area/whiskey_outpost)
 "at" = (
 /obj/machinery/computer/camera_advanced/overwatch,
-/turf/open/floor/tile/dark,
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "au" = (
 /obj/structure/bed/chair/office/light{
 	dir = 8
 	},
-/obj/effect/landmark/start/job/staffofficer,
-/turf/open/floor/tile/dark,
+/obj/machinery/light,
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "av" = (
-/obj/structure/filingcabinet,
-/turf/open/floor/tile/dark,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1;
+	pixel_y = 1
+	},
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "ax" = (
 /obj/machinery/vending/snack,
-/turf/open/floor/tile/dark,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "ay" = (
-/obj/structure/table,
 /obj/item/storage/box/nt_mre,
 /obj/item/flashlight,
 /obj/item/binoculars,
@@ -74,10 +79,20 @@
 /obj/structure/paper_bin,
 /obj/item/folder/blue,
 /obj/item/tool/pen,
-/turf/open/floor/tile/dark,
+/obj/structure/table/mainship,
+/obj/item/toy/plush/rouny{
+	desc = "A plushie depicting a rouny, made to commemorate the battle of Whiskey Outpost. Wait... Isnt that today?"
+	},
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "az" = (
-/turf/open/floor/tile/dark,
+/obj/structure/filingcabinet,
+/turf/open/floor/prison,
+/area/whiskey_outpost)
+"aA" = (
+/obj/effect/landmark/start/job/shiptech,
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/whiskey_outpost)
 "aB" = (
 /obj/machinery/power/terminal{
@@ -104,33 +119,17 @@
 "aG" = (
 /turf/open/floor,
 /area/whiskey_outpost)
-"aJ" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/tile/dark,
-/area/whiskey_outpost)
 "aK" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
-"aL" = (
-/obj/structure/rack,
-/obj/item/big_ammo_box/smg,
-/obj/item/big_ammo_box/smg,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/big_ammo_box/smg,
-/turf/open/floor/plating/asteroidfloor,
-/area/whiskey_outpost)
 "aN" = (
 /obj/structure/cable,
-/obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/tool/extinguisher/mini,
+/obj/structure/table/mainship,
 /turf/open/floor/tile/yellow,
 /area/whiskey_outpost)
 "aO" = (
@@ -185,12 +184,12 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 4
 	},
-/turf/open/floor/tile/dark,
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "aZ" = (
 /obj/machinery/computer/communications,
-/obj/structure/table,
-/turf/open/floor/tile/dark,
+/obj/structure/table/mainship,
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "ba" = (
 /obj/machinery/light{
@@ -209,8 +208,8 @@
 /area/whiskey_outpost)
 "bc" = (
 /obj/machinery/computer/marine_card,
-/obj/structure/table,
-/turf/open/floor/tile/dark,
+/obj/structure/table/mainship,
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "bd" = (
 /turf/closed/wall,
@@ -218,11 +217,6 @@
 "be" = (
 /obj/structure/largecrate/supply/explosives/grenades,
 /turf/open/floor/plating/asteroidfloor,
-/area/whiskey_outpost)
-"bf" = (
-/turf/open/floor/plating/warning{
-	dir = 1
-	},
 /area/whiskey_outpost)
 "bg" = (
 /obj/structure/barricade/metal{
@@ -262,7 +256,7 @@
 	dir = 2;
 	name = "\improper Combat Information Center"
 	},
-/turf/open/floor/tile/dark,
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "bm" = (
 /obj/item/lightstick/red/anchored,
@@ -313,25 +307,25 @@
 	},
 /area/whiskey_outpost)
 "bw" = (
-/obj/structure/table,
 /obj/item/storage/firstaid/adv{
 	pixel_x = 5;
 	pixel_y = 5
 	},
 /obj/item/storage/surgical_tray,
 /obj/item/reagent_containers/spray/surgery,
+/obj/structure/table/mainship,
 /turf/open/floor/mainship/sterile/side{
 	dir = 8
 	},
 /area/whiskey_outpost)
 "by" = (
-/obj/structure/table,
 /obj/item/storage/firstaid/adv{
 	pixel_x = 5;
 	pixel_y = 5
 	},
 /obj/item/storage/surgical_tray,
 /obj/item/reagent_containers/spray/surgery,
+/obj/structure/table/mainship,
 /turf/open/floor/mainship/sterile/side{
 	dir = 4
 	},
@@ -341,7 +335,6 @@
 /turf/closed/wall,
 /area/whiskey_outpost)
 "bA" = (
-/obj/structure/table,
 /obj/item/healthanalyzer,
 /obj/item/healthanalyzer,
 /obj/item/healthanalyzer,
@@ -356,6 +349,7 @@
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/reagent_containers/spray/cleaner,
+/obj/structure/table/mainship,
 /turf/open/floor/mainship/sterile,
 /area/whiskey_outpost)
 "bB" = (
@@ -372,19 +366,19 @@
 /turf/open/floor/tile/whiteyellow/full,
 /area/whiskey_outpost)
 "bD" = (
-/obj/structure/table,
 /obj/machinery/recharger,
+/obj/structure/table/mainship,
 /turf/open/floor/mainship/sterile,
 /area/whiskey_outpost)
 "bE" = (
-/obj/structure/table/reinforced,
 /obj/machinery/door/window/secure/req{
 	dir = 1
 	},
 /obj/machinery/door/window{
 	dir = 2
 	},
-/turf/open/floor/plating/asteroidfloor,
+/obj/structure/table/mainship,
+/turf/open/floor/tile/dark,
 /area/whiskey_outpost)
 "bF" = (
 /obj/machinery/iv_drip,
@@ -413,8 +407,8 @@
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
 "bL" = (
-/obj/structure/table,
 /obj/item/clothing/suit/surgical,
+/obj/structure/table/mainship,
 /turf/open/floor/mainship/sterile/corner{
 	dir = 8
 	},
@@ -435,20 +429,12 @@
 /obj/machinery/autodoc_console,
 /turf/open/floor/mainship/sterile,
 /area/whiskey_outpost)
-"bQ" = (
-/obj/machinery/door/airlock/mainship/medical/or/or1,
-/turf/open/floor/mainship/sterile/dark,
-/area/whiskey_outpost)
 "bS" = (
 /obj/machinery/sleep_console,
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/mainship/sterile,
-/area/whiskey_outpost)
-"bT" = (
-/obj/structure/window/framed/colony,
-/turf/open/floor/plating,
 /area/whiskey_outpost)
 "bU" = (
 /obj/machinery/vending/MarineMed,
@@ -490,12 +476,12 @@
 	},
 /area/whiskey_outpost)
 "cg" = (
-/obj/structure/table,
 /obj/item/storage/firstaid/toxin,
 /obj/item/storage/firstaid/toxin{
 	pixel_x = 5;
 	pixel_y = 5
 	},
+/obj/structure/table/mainship,
 /turf/open/floor/mainship/sterile,
 /area/whiskey_outpost)
 "ci" = (
@@ -510,24 +496,36 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/whiskey_outpost)
 "ck" = (
-/obj/machinery/vending/cigarette/colony,
-/turf/open/floor/tile/dark,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/machinery/door_control/unmeltable{
+	id = "sekritbunker";
+	name = "Shelter access";
+	pixel_x = 27
+	},
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "cl" = (
 /turf/open/floor/mainship/orange{
 	dir = 8
 	},
 /area/whiskey_outpost)
+"cm" = (
+/obj/structure/jungle/vines,
+/turf/open/ground/jungle,
+/area/whiskey_outpost/outside/west)
 "cn" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/open/ground/grass,
 /area/whiskey_outpost/outside/north)
 "co" = (
 /obj/effect/decal/warning_stripes/thin,
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/conveyor_switch{
+	id = "reqtorio"
 	},
-/turf/open/floor/plating/asteroidfloor,
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "cp" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -540,22 +538,22 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
 	},
-/turf/open/floor/plating/asteroidfloor,
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "cr" = (
-/obj/structure/table,
 /obj/item/storage/box/pillbottles,
 /obj/item/storage/box/pillbottles,
 /obj/item/storage/box/pillbottles,
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/table/mainship,
+/obj/item/reagent_containers/glass/beaker/noreact,
 /turf/open/floor/mainship/sterile/side{
 	dir = 4
 	},
 /area/whiskey_outpost)
 "cs" = (
-/obj/structure/table,
 /obj/item/storage/belt/combatLifesaver,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/glasses/hud/health,
@@ -563,6 +561,7 @@
 /obj/item/storage/belt/combatLifesaver,
 /obj/item/storage/belt/medical,
 /obj/item/storage/belt/medical,
+/obj/structure/table/mainship,
 /turf/open/floor/mainship/sterile,
 /area/whiskey_outpost)
 "cu" = (
@@ -575,7 +574,6 @@
 	},
 /area/whiskey_outpost)
 "cv" = (
-/obj/structure/table,
 /obj/item/storage/box/masks,
 /obj/item/storage/box/gloves{
 	pixel_x = 5;
@@ -585,6 +583,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/table/mainship,
 /turf/open/floor/mainship/sterile,
 /area/whiskey_outpost)
 "cw" = (
@@ -607,16 +606,15 @@
 /turf/open/ground/grass,
 /area/whiskey_outpost/outside/north)
 "cC" = (
-/obj/structure/table,
 /obj/item/storage/firstaid/adv,
 /obj/item/storage/firstaid/adv{
 	pixel_x = 5;
 	pixel_y = 5
 	},
+/obj/structure/table/mainship,
 /turf/open/floor/mainship/sterile,
 /area/whiskey_outpost)
 "cD" = (
-/obj/structure/table,
 /obj/item/storage/pill_bottle/peridaxon,
 /obj/item/storage/pill_bottle/peridaxon{
 	pixel_x = 5
@@ -632,10 +630,10 @@
 /obj/item/defibrillator,
 /obj/item/defibrillator,
 /obj/item/defibrillator,
+/obj/structure/table/mainship,
 /turf/open/floor/mainship/sterile,
 /area/whiskey_outpost)
 "cE" = (
-/obj/structure/table,
 /obj/item/storage/pill_bottle/alkysine,
 /obj/item/storage/pill_bottle/alkysine{
 	pixel_y = 10
@@ -647,10 +645,10 @@
 	pixel_x = -5;
 	pixel_y = 10
 	},
+/obj/structure/table/mainship,
 /turf/open/floor/mainship/sterile,
 /area/whiskey_outpost)
 "cF" = (
-/obj/structure/table,
 /obj/item/storage/firstaid/fire,
 /obj/item/storage/firstaid/fire{
 	pixel_x = 5;
@@ -659,6 +657,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/table/mainship,
 /turf/open/floor/mainship/sterile,
 /area/whiskey_outpost)
 "cG" = (
@@ -667,9 +666,8 @@
 /turf/open/floor/mainship/sterile,
 /area/whiskey_outpost)
 "cH" = (
-/obj/structure/rack,
-/obj/structure/largecrate/supply/supplies/metal,
-/turf/open/floor/plating/asteroidfloor,
+/obj/structure/closet/secure_closet/req_officer,
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "cJ" = (
 /obj/structure/flora/ausbushes/reedbush,
@@ -685,28 +683,7 @@
 	dir = 4
 	},
 /area/whiskey_outpost/outside/north)
-"cM" = (
-/obj/structure/bed/chair,
-/obj/effect/landmark/start/job/squadmarine,
-/turf/open/floor/plating/asteroidwarning{
-	dir = 9
-	},
-/area/whiskey_outpost)
-"cN" = (
-/obj/structure/bed/chair,
-/obj/effect/landmark/start/job/squadcorpsman,
-/turf/open/floor/plating/asteroidwarning{
-	dir = 1
-	},
-/area/whiskey_outpost)
 "cO" = (
-/turf/open/floor/plating/asteroidwarning{
-	dir = 1
-	},
-/area/whiskey_outpost)
-"cP" = (
-/obj/structure/bed/chair,
-/obj/effect/landmark/start/job/squadmarine,
 /turf/open/floor/plating/asteroidwarning{
 	dir = 1
 	},
@@ -717,7 +694,7 @@
 /area/whiskey_outpost/outside/west)
 "cR" = (
 /obj/machinery/vending/coffee,
-/turf/open/floor/tile/dark,
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "cS" = (
 /obj/effect/decal/warning_stripes/thin,
@@ -725,7 +702,7 @@
 /area/whiskey_outpost)
 "cT" = (
 /obj/structure/bed/chair/office/dark,
-/turf/open/floor/tile/dark,
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "cU" = (
 /obj/structure/largecrate/supply/supplies/sandbags,
@@ -746,13 +723,6 @@
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/open/ground/river,
 /area/whiskey_outpost/outside/north)
-"cY" = (
-/obj/structure/bed/chair,
-/obj/effect/landmark/start/job/squadmarine,
-/turf/open/floor/plating/asteroidwarning{
-	dir = 5
-	},
-/area/whiskey_outpost)
 "cZ" = (
 /turf/open/floor/plating/warning{
 	dir = 9
@@ -784,13 +754,6 @@
 "dg" = (
 /obj/structure/bed/roller,
 /turf/open/floor/plating/asteroidfloor,
-/area/whiskey_outpost)
-"dh" = (
-/obj/structure/bed/chair,
-/obj/effect/landmark/start/job/squadengineer,
-/turf/open/floor/plating/asteroidwarning{
-	dir = 8
-	},
 /area/whiskey_outpost)
 "dj" = (
 /turf/open/ground/coast,
@@ -879,7 +842,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/asteroidplating,
-/area/whiskey_outpost)
+/area/whiskey_outpost/outside/north)
 "dG" = (
 /obj/effect/attach_point/electronics/dropship1,
 /obj/structure/dropship_piece/one/weapon/rightleft,
@@ -899,33 +862,26 @@
 /obj/machinery/landinglight/ds1/delaythree,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
-"dP" = (
-/turf/closed/shuttle/re_corner/notdense{
-	dir = 8
-	},
-/area/whiskey_outpost/outside/north)
 "dQ" = (
-/turf/closed/wall,
-/area/whiskey_outpost/outside/north)
-"dR" = (
-/turf/closed/shuttle/re_corner/notdense,
+/obj/structure/window/framed/wood/reinforced,
+/turf/open/floor/wood,
 /area/whiskey_outpost/outside/north)
 "dU" = (
-/turf/open/floor,
+/turf/open/floor/wood,
 /area/whiskey_outpost/outside/north)
 "dV" = (
 /obj/structure/bed,
-/turf/open/floor,
+/turf/open/floor/wood,
 /area/whiskey_outpost/outside/north)
 "dW" = (
-/obj/structure/table,
-/turf/open/floor,
+/obj/structure/xenoautopsy/tank/hugger,
+/turf/open/floor/wood,
 /area/whiskey_outpost/outside/north)
 "dX" = (
-/obj/structure/table,
 /obj/item/storage/pill_bottle/happy,
-/obj/item/tool/minihoe,
-/turf/open/floor,
+/obj/structure/table/woodentable,
+/obj/item/xenos_claw,
+/turf/open/floor/wood,
 /area/whiskey_outpost/outside/north)
 "dZ" = (
 /turf/open/ground/coast{
@@ -933,19 +889,20 @@
 	},
 /area/whiskey_outpost/outside/north)
 "ea" = (
-/turf/closed/shuttle/re_corner/notdense{
-	dir = 1
-	},
-/area/whiskey_outpost/outside/north)
-"eb" = (
-/turf/closed/shuttle/re_corner/notdense{
-	dir = 4
-	},
+/turf/closed/wall/wood,
 /area/whiskey_outpost/outside/north)
 "ec" = (
 /obj/item/lightstick/red/anchored,
 /turf/open/floor/plating/ground/dirt,
 /area/whiskey_outpost/outside/north)
+"ed" = (
+/obj/item/weapon/gun/tl102/hsg_nest{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroidwarning{
+	dir = 8
+	},
+/area/whiskey_outpost)
 "ee" = (
 /obj/machinery/marine_selector/clothes/medic,
 /turf/open/floor/mainship/red{
@@ -1004,7 +961,7 @@
 /area/whiskey_outpost)
 "es" = (
 /obj/item/lightstick/red/anchored,
-/turf/open/ground/jungle,
+/turf/open/ground/jungle/path,
 /area/whiskey_outpost/outside/east)
 "et" = (
 /obj/machinery/vending/engineering,
@@ -1030,8 +987,12 @@
 	},
 /area/whiskey_outpost)
 "eA" = (
-/obj/structure/table,
 /obj/item/storage/fancy/cigarettes/luckystars,
+/obj/structure/table/mainship,
+/obj/item/reagent_containers/food/drinks/bottle/whiskey{
+	desc = "A premium single-malt whiskey. To celebrate your impending doom";
+	name = "\improper Whiskey Outpost Whiskey"
+	},
 /turf/open/floor/tile/whiteyellow/full,
 /area/whiskey_outpost)
 "eC" = (
@@ -1040,7 +1001,11 @@
 	},
 /area/whiskey_outpost)
 "eD" = (
-/obj/structure/table,
+/obj/structure/table/mainship,
+/obj/item/reagent_containers/food/drinks/bottle/whiskey{
+	desc = "A premium single-malt whiskey. To celebrate your impending doom";
+	name = "\improper Whiskey Outpost Whiskey"
+	},
 /turf/open/floor/tile/whiteyellow/full,
 /area/whiskey_outpost)
 "eE" = (
@@ -1093,8 +1058,8 @@
 /turf/open/floor/marking/bot,
 /area/whiskey_outpost)
 "eP" = (
-/obj/structure/table,
 /obj/item/tool/lighter/zippo,
+/obj/structure/table/mainship,
 /turf/open/floor/tile/whiteyellow/full,
 /area/whiskey_outpost)
 "eR" = (
@@ -1118,13 +1083,12 @@
 /turf/open/floor/marking/bot,
 /area/whiskey_outpost)
 "eV" = (
-/obj/structure/table,
 /obj/item/storage/toolbox/electrical,
 /obj/item/storage/toolbox/electrical,
+/obj/structure/table/mainship,
 /turf/open/floor,
 /area/whiskey_outpost)
 "eW" = (
-/obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/clothing/glasses/welding,
@@ -1132,6 +1096,7 @@
 /obj/item/clothing/glasses/welding,
 /obj/item/clothing/glasses/welding,
 /obj/item/clothing/glasses/welding,
+/obj/structure/table/mainship,
 /turf/open/floor,
 /area/whiskey_outpost)
 "eX" = (
@@ -1154,20 +1119,23 @@
 	dir = 5
 	},
 /area/whiskey_outpost/outside/north)
-"fa" = (
-/obj/structure/bed/chair,
-/obj/effect/landmark/start/job/squadmarine,
-/turf/open/floor/plating/asteroidfloor,
-/area/whiskey_outpost)
 "fb" = (
-/obj/structure/table,
 /obj/item/storage/box/tgmc_mre,
+/obj/structure/table/mainship,
+/obj/item/reagent_containers/food/drinks/bottle/whiskey{
+	desc = "A premium single-malt whiskey. To celebrate your impending doom";
+	name = "\improper Whiskey Outpost Whiskey"
+	},
 /turf/open/floor/tile/whiteyellow/full,
 /area/whiskey_outpost)
 "fc" = (
-/obj/structure/table,
 /obj/item/storage/donut_box,
 /obj/item/tool/lighter/zippo,
+/obj/structure/table/mainship,
+/obj/item/reagent_containers/food/drinks/bottle/whiskey{
+	desc = "A premium single-malt whiskey. To celebrate your impending doom";
+	name = "\improper Whiskey Outpost Whiskey"
+	},
 /turf/open/floor/tile/whiteyellow/full,
 /area/whiskey_outpost)
 "fd" = (
@@ -1203,8 +1171,8 @@
 /turf/open/floor/marking/bot,
 /area/whiskey_outpost)
 "ff" = (
-/obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
+/obj/structure/table/mainship,
 /turf/open/floor,
 /area/whiskey_outpost)
 "fg" = (
@@ -1258,14 +1226,9 @@
 	},
 /turf/open/floor/marking/bot,
 /area/whiskey_outpost)
-"fi" = (
-/obj/structure/bed/chair,
-/obj/effect/landmark/start/job/squadsmartgunner,
-/turf/open/floor/plating/asteroidfloor,
-/area/whiskey_outpost)
 "fk" = (
-/obj/structure/table,
 /obj/item/storage/fancy/cigarettes/kpack,
+/obj/structure/table/mainship,
 /turf/open/floor/tile/whiteyellow/full,
 /area/whiskey_outpost)
 "fl" = (
@@ -1384,12 +1347,12 @@
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
 "fw" = (
-/obj/structure/table,
 /obj/item/storage/bible{
 	desc = "As the legendary US Army chaplain once said, 'There are no Athiests in fancy offices'.";
 	name = "Holy Bible"
 	},
 /obj/item/tool/lighter/random,
+/obj/structure/table/mainship,
 /turf/open/floor/tile/whiteyellow/full,
 /area/whiskey_outpost)
 "fx" = (
@@ -1457,9 +1420,9 @@
 	},
 /area/whiskey_outpost)
 "fK" = (
-/obj/structure/table,
 /obj/item/storage/fancy/cigarettes/luckystars,
 /obj/item/tool/lighter/zippo,
+/obj/structure/table/mainship,
 /turf/open/floor/tile/whiteyellow/full,
 /area/whiskey_outpost)
 "fL" = (
@@ -1529,9 +1492,9 @@
 /turf/open/floor/tile/whiteyellow/full,
 /area/whiskey_outpost)
 "gb" = (
-/obj/structure/table,
 /obj/item/storage/fancy/cigarettes/kpack,
 /obj/item/tool/lighter/random,
+/obj/structure/table/mainship,
 /turf/open/floor/tile/whiteyellow/full,
 /area/whiskey_outpost)
 "gc" = (
@@ -1542,9 +1505,6 @@
 "gd" = (
 /turf/open/floor/plating/ground/dirtgrassborder/corner2,
 /area/whiskey_outpost/outside/north)
-"ge" = (
-/turf/open/floor/plating,
-/area/whiskey_outpost/outside/south)
 "gf" = (
 /turf/open/ground/coast/corner2{
 	dir = 1
@@ -1593,13 +1553,9 @@
 /obj/structure/closet/secure_closet/medical2,
 /turf/open/floor/mainship/sterile/side,
 /area/whiskey_outpost)
-"gr" = (
-/obj/structure/platform,
-/turf/open/floor/plating/asteroidfloor,
-/area/whiskey_outpost)
 "gs" = (
-/obj/structure/table,
 /obj/item/clothing/suit/surgical,
+/obj/structure/table/mainship,
 /turf/open/floor/mainship/sterile/corner{
 	dir = 4
 	},
@@ -1640,7 +1596,7 @@
 /turf/open/ground/jungle,
 /area/whiskey_outpost/outside/south)
 "gA" = (
-/obj/structure/platform_decoration,
+/obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
 "gB" = (
@@ -1650,6 +1606,16 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/ground/jungle,
 /area/whiskey_outpost/outside/south)
+"gC" = (
+/obj/effect/decal/warning_stripes/thin,
+/obj/machinery/door_control/unmeltable{
+	id = "sekritbunker";
+	name = "Shelter access";
+	pixel_x = 27;
+	pixel_y = -27
+	},
+/turf/open/floor/prison/plate,
+/area/whiskey_outpost)
 "gD" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/mineral,
@@ -1705,10 +1671,16 @@
 /area/whiskey_outpost/outside/south)
 "gO" = (
 /obj/structure/table/mainship,
-/obj/item/attachable/extended_barrel,
-/obj/item/attachable/extended_barrel,
-/obj/item/attachable/scope,
-/turf/open/floor/tile/dark,
+/obj/item/unmanned_vehicle_remote{
+	pixel_x = -5;
+	pixel_y = -2
+	},
+/obj/item/unmanned_vehicle_remote{
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/obj/item/unmanned_vehicle_remote,
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "gP" = (
 /obj/structure/largecrate/supply/supplies/sandbags,
@@ -1767,6 +1739,15 @@
 /obj/effect/spawner/gibspawner/human,
 /turf/open/ground/jungle,
 /area/whiskey_outpost/outside/south)
+"hf" = (
+/obj/structure/rack,
+/obj/item/storage/box/visual/magazine/compact/standard_smg/full,
+/obj/item/storage/box/visual/magazine/compact/standard_smg/full,
+/obj/item/storage/box/visual/magazine/compact/standard_smg/full,
+/obj/item/storage/box/visual/magazine/compact/standard_smg/full,
+/obj/item/storage/box/visual/magazine/compact/standard_smg/full,
+/turf/open/floor/prison,
+/area/whiskey_outpost)
 "hg" = (
 /turf/open/floor/plating/ground/dirt,
 /area/whiskey_outpost/outside/east)
@@ -1775,15 +1756,12 @@
 	dir = 4
 	},
 /area/whiskey_outpost/outside/east)
-"hi" = (
-/turf/open/ground/jungle,
-/area/space)
 "hj" = (
-/obj/structure/grille/broken,
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 1
 	},
-/turf/open/ground/jungle,
+/obj/structure/fence,
+/turf/open/ground/jungle/impenetrable/nobush,
 /area/whiskey_outpost/outside/south)
 "hk" = (
 /turf/open/ground/grass,
@@ -1884,8 +1862,14 @@
 /turf/open/ground/river,
 /area/whiskey_outpost/outside/east)
 "hI" = (
-/turf/closed/wall/indestructible/mineral,
-/area/space)
+/obj/machinery/door/poddoor/four_tile_hor{
+	desc = "No escape.";
+	id = "escape";
+	name = "Exit Shield";
+	resistance_flags = 3
+	},
+/turf/open/ground/river,
+/area/whiskey_outpost)
 "hJ" = (
 /turf/open/ground/grass/beach,
 /area/whiskey_outpost/outside/west)
@@ -2023,24 +2007,6 @@
 /obj/structure/barricade/metal,
 /turf/open/floor/plating/warning,
 /area/whiskey_outpost/outside/east)
-"iu" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/structure/platform{
-	dir = 4
-	},
-/turf/open/floor/plating/asteroidfloor,
-/area/whiskey_outpost)
-"iv" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/structure/platform{
-	dir = 8
-	},
-/turf/open/floor/plating/asteroidfloor,
-/area/whiskey_outpost)
 "iw" = (
 /turf/open/ground/grass/beach/corner{
 	dir = 4
@@ -2213,6 +2179,9 @@
 /area/whiskey_outpost/outside/east)
 "jj" = (
 /obj/machinery/marine_selector/clothes,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
 "jk" = (
@@ -2279,7 +2248,6 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/whiskey_outpost)
 "jx" = (
-/obj/structure/table,
 /obj/item/storage/firstaid/adv,
 /obj/item/storage/firstaid/adv{
 	pixel_x = 5;
@@ -2289,6 +2257,7 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
+/obj/structure/table/mainship,
 /turf/open/floor/mainship/sterile,
 /area/whiskey_outpost)
 "jy" = (
@@ -2314,25 +2283,9 @@
 	icon_state = "70"
 	},
 /area/whiskey_outpost/outside/east)
-"jH" = (
-/turf/closed/shuttle/re_corner/jungle{
-	dir = 8
-	},
-/area/whiskey_outpost/outside/west)
 "jI" = (
 /obj/machinery/vending/MarineMed,
 /turf/open/floor/mainship/sterile/dark,
-/area/whiskey_outpost)
-"jK" = (
-/obj/effect/landmark/start/job/squadmarine,
-/turf/open/floor/plating/warning{
-	dir = 4
-	},
-/area/whiskey_outpost)
-"jN" = (
-/obj/structure/bed/chair,
-/obj/effect/landmark/start/job/squadcorpsman,
-/turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
 "jP" = (
 /obj/structure/dropship_piece/one/wing/left/bottom,
@@ -2370,38 +2323,48 @@
 /obj/item/storage/box/m94,
 /turf/open/floor/plating/ground/dirt,
 /area/whiskey_outpost/outside/east)
+"kf" = (
+/obj/item/lightstick/red/anchored,
+/obj/structure/largecrate/supply/supplies/metal,
+/turf/open/ground/jungle/path,
+/area/whiskey_outpost/outside/east)
 "kg" = (
 /obj/item/storage/box/explosive_mines,
 /turf/open/floor/plating,
 /area/whiskey_outpost)
 "ki" = (
-/obj/structure/largecrate/supply/weapons/flamers,
-/turf/open/floor/plating/asteroidfloor,
+/obj/structure/closet/crate,
+/obj/item/clothing/glasses/night/imager_goggles,
+/obj/item/clothing/glasses/night/imager_goggles,
+/obj/item/clothing/glasses/night/imager_goggles,
+/obj/item/clothing/glasses/night/imager_goggles,
+/obj/item/clothing/glasses/night/imager_goggles,
+/obj/item/clothing/glasses/night/imager_goggles,
+/obj/item/clothing/glasses/night/imager_goggles,
+/obj/item/clothing/glasses/night/imager_goggles,
+/obj/item/clothing/glasses/night/imager_goggles,
+/obj/item/clothing/glasses/night/imager_goggles,
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "kj" = (
 /obj/effect/landmark/start/job/shiptech,
 /turf/open/floor,
 /area/whiskey_outpost)
 "kk" = (
-/obj/structure/closet/secure_closet/guncabinet/mp_armory,
-/turf/open/floor/tile/dark,
+/obj/vehicle/unmanned/droid,
+/obj/item/uav_turret/droid,
+/turf/open/floor/prison/marked,
 /area/whiskey_outpost)
-"kl" = (
-/turf/closed/shuttle/re_corner/jungle{
-	dir = 1
-	},
-/area/whiskey_outpost)
-"km" = (
-/turf/closed/shuttle/re_corner/jungle{
-	dir = 4
-	},
-/area/whiskey_outpost/outside/west)
 "kn" = (
 /turf/open/floor/plating/ground/dirt,
 /area/whiskey_outpost/outside/south)
 "kp" = (
-/obj/structure/closet/secure_closet/guncabinet/m41aMK1,
-/turf/open/floor/tile/dark,
+/obj/vehicle/unmanned/droid,
+/obj/item/uav_turret/droid,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/prison/marked,
 /area/whiskey_outpost)
 "kq" = (
 /turf/open/floor/tile/damaged/three,
@@ -2459,16 +2422,19 @@
 "kH" = (
 /turf/open/ground/coast/corner,
 /area/whiskey_outpost/outside/east)
+"kJ" = (
+/obj/item/weapon/gun/tl102/hsg_nest,
+/turf/open/floor/plating/warning,
+/area/whiskey_outpost)
 "kL" = (
 /turf/open/floor/plating/dmg2,
 /area/whiskey_outpost/outside/east)
-"kM" = (
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark,
-/area/whiskey_outpost)
 "kN" = (
-/obj/structure/closet/secure_closet/staff_officer,
-/turf/open/floor/tile/dark,
+/obj/machinery/vending/uniform_supply,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "kO" = (
 /obj/machinery/light{
@@ -2484,31 +2450,9 @@
 	dir = 1
 	},
 /area/whiskey_outpost/outside/east)
-"kS" = (
-/obj/structure/bed/chair,
-/obj/effect/landmark/start/job/squadmarine,
-/turf/open/floor/plating/asteroidwarning{
-	dir = 4
-	},
-/area/whiskey_outpost)
-"kU" = (
-/turf/open/floor/plating/warning,
-/area/whiskey_outpost/outside/east)
 "kV" = (
 /turf/open/ground/jungle/impenetrable/nobush,
 /area/whiskey_outpost/outside/south)
-"kW" = (
-/obj/structure/bed/chair,
-/obj/effect/landmark/start/job/squadmarine,
-/turf/open/floor/plating/asteroidwarning{
-	dir = 10
-	},
-/area/whiskey_outpost)
-"kX" = (
-/obj/structure/bed/chair,
-/obj/effect/landmark/start/job/squadmarine,
-/turf/open/floor/plating/asteroidwarning,
-/area/whiskey_outpost)
 "kY" = (
 /obj/item/lightstick/red/anchored,
 /turf/open/floor/plating/ground/dirt,
@@ -2529,11 +2473,6 @@
 "ld" = (
 /turf/open/ground/grass/beach,
 /area/whiskey_outpost/outside/south)
-"le" = (
-/turf/open/ground/grass/beach/corner{
-	dir = 8
-	},
-/area/whiskey_outpost/outside/south)
 "lf" = (
 /turf/open/ground/jungle,
 /area/whiskey_outpost/outside/south)
@@ -2542,13 +2481,6 @@
 	dir = 4
 	},
 /area/whiskey_outpost/outside/south)
-"lh" = (
-/obj/structure/bed/chair,
-/obj/effect/landmark/start/job/squadengineer,
-/turf/open/floor/plating/asteroidwarning{
-	dir = 6
-	},
-/area/whiskey_outpost)
 "li" = (
 /obj/structure/lattice,
 /turf/open/ground/coast{
@@ -2589,23 +2521,21 @@
 	},
 /area/whiskey_outpost/outside/south)
 "lq" = (
-/obj/structure/grille/fence/east_west,
+/obj/structure/fence,
 /turf/open/ground/jungle/impenetrable/nobush,
 /area/whiskey_outpost/outside/south)
 "lr" = (
 /obj/structure/sign/prop1,
-/turf/closed/wall,
-/area/whiskey_outpost/outside/south)
-"ls" = (
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/whiskey_outpost/outside/south)
 "lt" = (
-/turf/open/floor,
-/area/whiskey_outpost/outside/south)
-"lu" = (
-/obj/structure/grille/fence/east_west,
-/turf/open/ground/jungle,
-/area/whiskey_outpost/outside/south)
+/obj/structure/table/mainship,
+/obj/machinery/computer/camera_advanced,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/whiskey_outpost)
 "lv" = (
 /turf/open/floor/plating/ground/dirtgrassborder/corner{
 	dir = 8
@@ -2633,27 +2563,28 @@
 /turf/open/ground/river,
 /area/whiskey_outpost/outside/south)
 "lC" = (
-/obj/effect/spawner/gibspawner/human,
-/turf/open/floor,
-/area/whiskey_outpost/outside/south)
+/obj/structure/table/mainship,
+/turf/open/floor/tile/dark,
+/area/whiskey_outpost)
 "lD" = (
-/obj/structure/table,
 /obj/structure/paper_bin,
 /obj/item/tool/pen,
 /obj/item/folder/white,
-/turf/open/floor,
-/area/whiskey_outpost/outside/south)
+/obj/structure/table/mainship,
+/turf/open/floor/tile/dark,
+/area/whiskey_outpost)
+"lE" = (
+/obj/structure/bed/chair/comfy,
+/obj/item/toy/plush/moth{
+	name = "King Moth"
+	},
+/turf/open/floor/plating/asteroidfloor,
+/area/whiskey_outpost/outside/west)
 "lF" = (
 /turf/closed/shuttle/dropship1/transparent{
 	icon_state = "53"
 	},
 /area/whiskey_outpost/outside/east)
-"lG" = (
-/obj/structure/grille/broken,
-/obj/effect/decal/cleanable/blood/writing,
-/obj/item/shard,
-/turf/open/floor/plating,
-/area/whiskey_outpost/outside/south)
 "lJ" = (
 /obj/structure/lattice,
 /turf/open/ground/river,
@@ -2705,10 +2636,6 @@
 /obj/effect/landmark/start/job/squadmarine,
 /turf/open/floor/tile/whiteyellow/full,
 /area/whiskey_outpost)
-"lT" = (
-/obj/structure/grille/broken,
-/turf/open/ground/jungle,
-/area/whiskey_outpost/outside/south)
 "lU" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -2725,8 +2652,13 @@
 /area/whiskey_outpost)
 "lW" = (
 /obj/structure/rack,
+/obj/item/mortal_shell/plasmaloss,
+/obj/item/mortal_shell/plasmaloss,
+/obj/item/mortal_shell/plasmaloss,
+/obj/item/mortal_shell/plasmaloss,
+/obj/item/mortal_shell/plasmaloss,
 /turf/open/floor/plating/asteroidplating,
-/area/whiskey_outpost)
+/area/whiskey_outpost/outside/north)
 "lX" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -2797,15 +2729,19 @@
 "ml" = (
 /turf/closed/wall/r_wall,
 /area/whiskey_outpost/outside/south)
+"mm" = (
+/obj/machinery/floodlightcombat,
+/turf/open/floor/prison,
+/area/whiskey_outpost)
+"mq" = (
+/obj/structure/largecrate/guns/russian,
+/turf/open/floor/prison,
+/area/whiskey_outpost)
 "ms" = (
 /obj/machinery/landinglight/ds1/delaytwo{
 	dir = 4
 	},
 /turf/open/floor/plating/asteroidfloor,
-/area/whiskey_outpost)
-"mt" = (
-/obj/effect/landmark/start/job/squadmarine,
-/turf/open/floor/plating,
 /area/whiskey_outpost)
 "mv" = (
 /turf/open/space/basic,
@@ -2831,6 +2767,18 @@
 "mG" = (
 /obj/effect/landmark/start/job/squadmarine,
 /turf/open/floor/mainship/sterile/dark,
+/area/whiskey_outpost)
+"mJ" = (
+/obj/structure/table/mainship,
+/obj/item/reagent_containers/food/snacks/human/burger{
+	desc = "A burger made by moffdonalds.";
+	name = "BigMoff Burger"
+	},
+/obj/item/weapon/gun/energy/lasgun/pulse{
+	anchored = 1;
+	desc = "Hah, Did you really think you were getting a pulse rifle?"
+	},
+/turf/open/floor/rcircuit,
 /area/whiskey_outpost)
 "mO" = (
 /turf/closed/shuttle/dropship1/transparent{
@@ -2977,21 +2925,6 @@
 	},
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
-"ny" = (
-/obj/structure/platform{
-	dir = 4
-	},
-/obj/structure/platform{
-	dir = 8
-	},
-/turf/open/floor/stairs/rampbottom,
-/area/whiskey_outpost)
-"nz" = (
-/obj/structure/platform{
-	dir = 1
-	},
-/turf/open/floor/plating/asteroidfloor,
-/area/whiskey_outpost)
 "nA" = (
 /obj/structure/platform,
 /turf/open/ground/coast{
@@ -3016,12 +2949,6 @@
 	dir = 9
 	},
 /area/whiskey_outpost/outside/north)
-"nF" = (
-/obj/structure/platform_decoration{
-	dir = 1
-	},
-/turf/open/floor/plating/asteroidfloor,
-/area/whiskey_outpost)
 "nG" = (
 /obj/structure/platform,
 /turf/open/ground/coast{
@@ -3497,18 +3424,6 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/whiskey_outpost/outside/north)
-"pn" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/turf/open/floor/plating/asteroidfloor,
-/area/whiskey_outpost)
-"po" = (
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/floor/plating/asteroidfloor,
-/area/whiskey_outpost)
 "pp" = (
 /obj/structure/platform,
 /obj/structure/platform{
@@ -3519,15 +3434,6 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/whiskey_outpost/outside/north)
-"pq" = (
-/obj/structure/platform_decoration{
-	dir = 8
-	},
-/obj/structure/platform_decoration{
-	dir = 4
-	},
-/turf/open/floor/plating/asteroidfloor,
-/area/whiskey_outpost)
 "pt" = (
 /obj/structure/platform{
 	dir = 1
@@ -3545,7 +3451,7 @@
 /obj/item/mortal_shell/incendiary,
 /obj/item/mortal_shell/incendiary,
 /turf/open/floor/plating/asteroidplating,
-/area/whiskey_outpost)
+/area/whiskey_outpost/outside/north)
 "pv" = (
 /obj/structure/rack,
 /obj/item/mortal_shell/he,
@@ -3554,7 +3460,7 @@
 /obj/item/mortal_shell/he,
 /obj/item/mortal_shell/he,
 /turf/open/floor/plating/asteroidplating,
-/area/whiskey_outpost)
+/area/whiskey_outpost/outside/north)
 "px" = (
 /obj/structure/largecrate/random/barrel/white,
 /turf/open/floor/plating/asteroidfloor,
@@ -3602,6 +3508,15 @@
 /obj/structure/largecrate/supply/explosives/mortar_flare,
 /turf/open/floor/plating,
 /area/whiskey_outpost)
+"pI" = (
+/obj/item/weapon/wirerod{
+	anchored = 1;
+	desc = "A TV antenna so the princess can watch reality TV. Warranty void if used to watch anything other than reality TV";
+	name = "TV Antenna"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/whiskey_outpost/outside/west)
 "pJ" = (
 /obj/structure/platform{
 	dir = 8
@@ -3628,6 +3543,7 @@
 /obj/effect/decal/warning_stripes/thick{
 	dir = 8
 	},
+/obj/structure/largecrate/supply/explosives/mortar_incend,
 /turf/open/floor/plating,
 /area/whiskey_outpost)
 "pQ" = (
@@ -3652,6 +3568,7 @@
 /obj/effect/decal/warning_stripes/thick{
 	dir = 10
 	},
+/obj/structure/largecrate/supply/explosives/mortar_he,
 /turf/open/floor/plating,
 /area/whiskey_outpost)
 "pU" = (
@@ -3719,35 +3636,18 @@
 /obj/machinery/conveyor{
 	id = "lower_garbage"
 	},
-/turf/open/floor/plating/mainship/striped{
-	dir = 4
-	},
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "qi" = (
-/obj/structure/rack,
-/obj/item/stack/barbed_wire/full,
-/obj/item/stack/barbed_wire/full,
-/obj/item/stack/barbed_wire/full,
-/obj/item/stack/barbed_wire/full,
-/obj/item/stack/barbed_wire/full,
-/obj/item/stack/barbed_wire/full,
-/obj/item/stack/barbed_wire/full,
-/obj/item/stack/barbed_wire/full,
-/obj/item/stack/barbed_wire/full,
-/obj/item/stack/barbed_wire/full,
-/obj/item/stack/barbed_wire/full,
-/obj/item/stack/barbed_wire/full,
-/obj/item/stack/barbed_wire/full,
-/obj/item/stack/barbed_wire/full,
-/obj/item/stack/barbed_wire/full,
-/turf/open/floor/plating/asteroidfloor,
+/obj/structure/closet/secure_closet/shiptech,
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "qk" = (
 /obj/machinery/conveyor{
 	id = "lower_garbage"
 	},
 /obj/structure/plasticflaps,
-/turf/open/floor/plating/asteroidfloor,
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "ql" = (
 /turf/open/floor/plating/warning{
@@ -3805,14 +3705,14 @@
 /area/whiskey_outpost)
 "qx" = (
 /obj/machinery/door/airlock/mainship/marine/requisitions,
-/turf/open/floor/plating/asteroidfloor,
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "qy" = (
 /obj/structure/rack,
-/obj/item/big_ammo_box/ap,
-/obj/item/big_ammo_box/ap,
-/obj/item/big_ammo_box/ap,
-/turf/open/floor/plating/asteroidfloor,
+/obj/item/big_ammo_box/smg,
+/obj/item/big_ammo_box/smg,
+/obj/item/big_ammo_box/smg,
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "qz" = (
 /obj/machinery/chem_dispenser,
@@ -3827,23 +3727,23 @@
 	},
 /area/whiskey_outpost)
 "qB" = (
-/obj/structure/table,
 /obj/machinery/reagentgrinder,
 /obj/item/stack/sheet/mineral/phoron{
-	amount = 25;
+	amount = 50;
 	pixel_x = 3;
 	pixel_y = 3
 	},
+/obj/structure/table/mainship,
 /turf/open/floor/mainship/sterile/side{
 	dir = 1
 	},
 /area/whiskey_outpost)
 "qC" = (
-/obj/structure/table,
 /obj/item/storage/box/syringes,
 /obj/item/reagent_containers/dropper,
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/glass/beaker/large,
+/obj/structure/table/mainship,
 /turf/open/floor/mainship/sterile/corner,
 /area/whiskey_outpost)
 "qD" = (
@@ -3929,6 +3829,9 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/whiskey_outpost/outside/north)
+"qQ" = (
+/turf/closed/wall/indestructible/mineral,
+/area/whiskey_outpost/outside/east)
 "qR" = (
 /turf/open/floor/plating/asteroidwarning{
 	dir = 8
@@ -3957,8 +3860,9 @@
 	},
 /area/whiskey_outpost)
 "qY" = (
-/obj/structure/table,
 /obj/item/tool/hand_labeler,
+/obj/item/reagent_containers/glass/beaker/bluespace,
+/obj/structure/table/mainship,
 /obj/item/reagent_containers/glass/beaker/bluespace,
 /turf/open/floor/mainship/sterile/side,
 /area/whiskey_outpost)
@@ -3969,34 +3873,41 @@
 	},
 /area/whiskey_outpost)
 "rb" = (
-/obj/structure/rack,
-/turf/open/floor/plating/asteroidfloor,
+/obj/machinery/vending/marine/cargo_supply,
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "rc" = (
+/obj/item/storage/box/minisentry,
+/obj/item/storage/box/minisentry,
+/obj/item/storage/box/minisentry,
+/obj/item/storage/box/minisentry,
+/obj/item/storage/box/minisentry,
 /obj/structure/rack,
-/obj/item/storage/box/minisentry,
-/obj/item/storage/box/minisentry,
-/turf/open/floor/plating/asteroidfloor,
+/obj/item/ammo_magazine/flamer_tank/large/X,
+/obj/item/ammo_magazine/flamer_tank/large/X,
+/obj/item/ammo_magazine/flamer_tank/backtank/X,
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "rd" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/machinery/conveyor_switch{
-	id = "lower_garbage"
-	},
-/turf/open/floor/plating/asteroidfloor,
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "rf" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/floor/plating/asteroidfloor,
+/obj/machinery/light,
+/obj/machinery/conveyor_switch{
+	id = "lower_garbage"
+	},
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "rg" = (
 /obj/structure/bed/chair/office/dark,
-/obj/effect/landmark/start/job/shiptech,
-/turf/open/floor/plating/asteroidfloor,
+/obj/effect/landmark/start/job/requisitionsofficer,
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "rh" = (
 /obj/structure/barricade/metal{
@@ -4017,7 +3928,6 @@
 	},
 /area/whiskey_outpost)
 "rj" = (
-/obj/structure/table,
 /obj/item/storage/box/beakers{
 	pixel_x = 5;
 	pixel_y = 5
@@ -4025,6 +3935,7 @@
 /obj/item/storage/box/gloves,
 /obj/item/mass_spectrometer,
 /obj/item/reagent_containers/spray/cleaner,
+/obj/structure/table/mainship,
 /turf/open/floor/mainship/sterile/corner{
 	dir = 4
 	},
@@ -4033,17 +3944,19 @@
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
 "rl" = (
+/obj/item/factory_refill/phosnade,
+/obj/item/factory_refill/phosnade,
+/obj/item/factory_refill/phosnade,
+/obj/item/factory_refill/phosnade,
+/obj/item/factory_refill/phosnade,
 /obj/structure/rack,
-/obj/item/attachable/motiondetector,
-/obj/item/attachable/motiondetector,
-/obj/item/attachable/motiondetector,
-/obj/item/attachable/motiondetector,
-/obj/item/attachable/motiondetector,
-/turf/open/floor/plating/asteroidfloor,
-/area/whiskey_outpost)
-"rm" = (
-/obj/structure/largecrate/supply/powerloader,
-/turf/open/floor/plating/asteroidfloor,
+/obj/item/factory_refill/phosnade,
+/obj/item/factory_refill/phosnade,
+/obj/item/factory_refill/phosnade,
+/obj/item/factory_refill/phosnade,
+/obj/item/factory_refill/phosnade,
+/obj/item/paper/factoryhowto,
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "ro" = (
 /obj/structure/largecrate/supply/weapons/hpr,
@@ -4068,10 +3981,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/vending/marine,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/machinery/vending/marine/shared,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
 "rs" = (
@@ -4145,7 +4058,6 @@
 	},
 /area/whiskey_outpost)
 "sa" = (
-/obj/structure/table,
 /obj/item/storage/firstaid/toxin,
 /obj/item/storage/firstaid/toxin{
 	pixel_x = 5;
@@ -4158,8 +4070,16 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/table/mainship,
 /turf/open/floor/mainship/sterile,
 /area/whiskey_outpost)
+"sf" = (
+/obj/machinery/floodlightcombat,
+/turf/open/floor/plating,
+/area/whiskey_outpost/outside/north)
+"sg" = (
+/turf/closed/wall/indestructible/mineral,
+/area/whiskey_outpost/outside/west)
 "sj" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/asteroidwarning{
@@ -4192,7 +4112,7 @@
 /area/whiskey_outpost/outside/west)
 "st" = (
 /obj/structure/flora/tree/jungle/small,
-/turf/open/ground/jungle,
+/turf/open/ground/jungle/path,
 /area/whiskey_outpost/outside/east)
 "su" = (
 /obj/structure/flora/tree/jungle,
@@ -4200,7 +4120,7 @@
 /area/whiskey_outpost/outside/west)
 "sv" = (
 /obj/structure/flora/tree/jungle,
-/turf/open/ground/jungle,
+/turf/open/ground/jungle/path,
 /area/whiskey_outpost/outside/east)
 "sw" = (
 /obj/structure/flora/tree/jungle/small,
@@ -4220,6 +4140,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/machinery/loadout_vendor,
 /turf/open/floor/mainship/orange{
 	dir = 4
 	},
@@ -4235,6 +4156,19 @@
 /obj/structure/barricade/sandbags,
 /turf/open/ground/jungle,
 /area/whiskey_outpost/outside/north)
+"sK" = (
+/obj/machinery/shower,
+/obj/structure/curtain/open/shower,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/whiskey_outpost)
+"sL" = (
+/obj/effect/decal/warning_stripes/thin,
+/turf/open/floor/prison/plate,
+/area/whiskey_outpost)
+"sM" = (
+/obj/item/stack/barbed_wire/full,
+/turf/open/floor/plating/asteroidfloor,
+/area/whiskey_outpost/outside/west)
 "sO" = (
 /obj/structure/largecrate/supply/supplies/plasteel,
 /turf/open/floor/plating/asteroidfloor,
@@ -4266,8 +4200,14 @@
 	dir = 4
 	},
 /area/whiskey_outpost/outside/west)
+"tp" = (
+/obj/structure/bed,
+/obj/item/bedsheet/captain,
+/obj/structure/curtain/open,
+/obj/effect/landmark/start/job/captain,
+/turf/open/floor/wood,
+/area/whiskey_outpost)
 "tr" = (
-/obj/structure/table,
 /obj/item/storage/belt/combatLifesaver,
 /obj/item/storage/belt/medical,
 /obj/item/storage/belt/medical,
@@ -4276,6 +4216,7 @@
 /obj/item/clothing/glasses/hud/health,
 /obj/item/healthanalyzer,
 /obj/item/healthanalyzer,
+/obj/structure/table/mainship,
 /turf/open/floor/mainship/sterile,
 /area/whiskey_outpost)
 "tN" = (
@@ -4305,11 +4246,75 @@
 /obj/item/weapon/gun/launcher/rocket,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
+"tP" = (
+/obj/structure/largecrate/supply/medicine/blood,
+/turf/open/floor/prison,
+/area/whiskey_outpost)
+"tR" = (
+/obj/structure/closet/crate/explosives,
+/obj/item/explosive/grenade/stick,
+/obj/item/explosive/grenade/stick,
+/obj/item/explosive/grenade/stick,
+/obj/item/explosive/grenade/stick,
+/obj/item/explosive/grenade/stick,
+/obj/item/explosive/grenade/stick,
+/obj/item/explosive/grenade/stick,
+/obj/item/explosive/grenade/stick,
+/obj/item/explosive/grenade/stick,
+/obj/item/explosive/grenade/stick,
+/obj/item/explosive/grenade/upp,
+/obj/item/explosive/grenade/upp,
+/obj/item/explosive/grenade/upp,
+/obj/item/explosive/grenade/phosphorus/upp,
+/obj/item/explosive/grenade/phosphorus/upp,
+/obj/item/explosive/grenade/phosphorus/upp,
+/obj/item/explosive/grenade/phosphorus/upp,
+/turf/open/floor/prison,
+/area/whiskey_outpost)
+"tS" = (
+/obj/structure/barricade/sandbags{
+	pixel_y = -6
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/whiskey_outpost/outside/north)
+"tT" = (
+/obj/effect/landmark/start/job/medicalofficer,
+/obj/vehicle/ridden/wheelchair,
+/turf/open/floor/mainship/sterile/dark,
+/area/whiskey_outpost)
 "tU" = (
 /turf/open/floor/mainship/red{
 	dir = 8
 	},
 /area/whiskey_outpost)
+"tX" = (
+/obj/structure/closet/crate/secure/ammo,
+/obj/item/big_ammo_box/ap,
+/obj/item/storage/box/visual/magazine/compact/tx15/flechette/full,
+/obj/item/storage/box/visual/magazine/compact/tx15/slug/full,
+/obj/item/storage/box/visual/magazine/compact/standard_smg/full,
+/obj/item/storage/box/visual/magazine/compact/standard_smg/full,
+/obj/item/storage/box/visual/magazine/compact/standard_revolver/full,
+/obj/item/storage/box/visual/magazine/compact/standard_pistol/full,
+/obj/item/storage/box/visual/magazine/compact/standard_machinepistol/full,
+/obj/item/storage/box/visual/magazine/compact/standard_lmg/full,
+/obj/item/storage/box/visual/magazine/compact/standard_lmg/full,
+/obj/item/storage/box/visual/magazine/compact/standard_heavypistol/full,
+/obj/item/storage/box/visual/magazine/compact/standard_gpmg/full,
+/obj/item/storage/box/visual/magazine/compact/standard_gpmg/full,
+/obj/item/storage/box/visual/magazine/compact/standard_dmr/full,
+/obj/item/storage/box/visual/magazine/compact/standard_dmr/full,
+/obj/item/storage/box/visual/magazine/compact/standard_carbine/full,
+/obj/item/storage/box/visual/magazine/compact/standard_carbine/full,
+/obj/item/storage/box/visual/magazine/compact/standard_br/full,
+/obj/item/storage/box/visual/magazine/compact/standard_assaultrifle/full,
+/obj/item/storage/box/visual/magazine/compact/plasma_pistol/full,
+/obj/item/storage/box/visual/magazine/compact/mosin/full,
+/obj/item/storage/box/visual/magazine/compact/lasrifle/marine/full,
+/obj/item/storage/box/visual/magazine/compact/lasrifle/full,
+/obj/item/storage/box/visual/magazine/compact/chamberedrifle/full,
+/turf/open/ground/grass,
+/area/whiskey_outpost/outside/west)
 "tZ" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/emerald{
@@ -4320,6 +4325,15 @@
 /obj/effect/ai_node,
 /turf/open/ground/grass,
 /area/whiskey_outpost/outside/north)
+"ud" = (
+/obj/structure/sign/poster,
+/turf/closed/wall/r_wall,
+/area/whiskey_outpost)
+"ug" = (
+/obj/vehicle/unmanned/heavy,
+/obj/item/uav_turret/heavy,
+/turf/open/floor/prison/marked,
+/area/whiskey_outpost)
 "uk" = (
 /obj/machinery/marine_selector/clothes/leader,
 /turf/open/floor/mainship/blue{
@@ -4330,11 +4344,19 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirt,
 /area/whiskey_outpost/outside/north)
+"uo" = (
+/obj/structure/largecrate/supply/supplies/metal,
+/turf/open/floor/plating/asteroidfloor,
+/area/whiskey_outpost/outside/west)
 "uw" = (
 /obj/machinery/door/window/right{
 	dir = 8
 	},
 /turf/open/floor/mainship/blue,
+/area/whiskey_outpost)
+"uy" = (
+/obj/machinery/washing_machine,
+/turf/open/floor/prison/plate,
 /area/whiskey_outpost)
 "uE" = (
 /obj/structure/bed,
@@ -4348,6 +4370,14 @@
 /obj/structure/largecrate/supply/floodlights,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
+"uI" = (
+/obj/item/instrument/musicalmoth{
+	anchored = 1;
+	desc = "This little moth has been tasked with entertaining the moth king. He is not very good at it.";
+	name = "Jester Moth"
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/whiskey_outpost/outside/west)
 "uJ" = (
 /obj/machinery/computer/crew,
 /turf/open/floor/mainship/sterile,
@@ -4360,16 +4390,35 @@
 /obj/structure/largecrate/supply/supplies/sandbags,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
+"uS" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/whiskey_outpost/outside/east)
 "uU" = (
 /obj/machinery/floodlight/outpost,
 /turf/open/floor/plating/asteroidplating,
+/area/whiskey_outpost/outside/north)
+"uX" = (
+/obj/item/weapon/gun/tl102/hsg_nest,
+/turf/open/floor/plating/ground/dirt,
+/area/whiskey_outpost/outside/south)
+"vb" = (
+/obj/structure/sink{
+	dir = 1
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/whiskey_outpost)
+"vc" = (
+/obj/machinery/door/airlock/mainship/security/free_access{
+	name = "Vehicle Storage"
+	},
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "vl" = (
-/obj/structure/largecrate/supply/ammo/standard_smg,
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plating/asteroidfloor,
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "vo" = (
 /obj/structure/barricade/metal{
@@ -4383,8 +4432,14 @@
 /area/whiskey_outpost)
 "vs" = (
 /obj/effect/ai_node,
-/turf/open/floor,
+/turf/open/floor/wood,
 /area/whiskey_outpost/outside/north)
+"vy" = (
+/obj/machinery/conveyor{
+	id = "reqtorio"
+	},
+/turf/open/floor/prison,
+/area/whiskey_outpost)
 "vz" = (
 /obj/structure/platform_decoration{
 	dir = 4
@@ -4398,6 +4453,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost/outside/north)
+"vH" = (
+/obj/item/storage/box/sentry{
+	pixel_x = 9;
+	pixel_y = 11
+	},
+/obj/item/storage/box/sentry,
+/turf/open/floor/plating/asteroidfloor,
+/area/whiskey_outpost/outside/west)
 "vM" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	name = "\improper Recreation Area"
@@ -4408,6 +4471,24 @@
 /obj/item/storage/box/explosive_mines,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost/outside/west)
+"vU" = (
+/obj/item/weapon/gun/tl102/hsg_nest,
+/turf/open/floor/plating/warning,
+/area/whiskey_outpost/outside/east)
+"vW" = (
+/obj/item/toy/plush/snake{
+	anchored = 1;
+	desc = "This snake defends the castle of the moth."       ;
+	name = "Snake Knight"
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/whiskey_outpost/outside/west)
+"vX" = (
+/obj/machinery/conveyor{
+	id = "reqtorio"
+	},
+/turf/open/floor/plating,
+/area/whiskey_outpost)
 "wc" = (
 /obj/machinery/marine_selector/clothes,
 /obj/structure/window/reinforced{
@@ -4432,14 +4513,20 @@
 /obj/structure/barricade/sandbags{
 	dir = 8
 	},
-/obj/structure/barricade/sandbags,
+/obj/structure/barricade/sandbags{
+	pixel_y = -6
+	},
 /turf/open/floor/plating/asteroidplating,
+/area/whiskey_outpost/outside/north)
+"wj" = (
+/obj/structure/largecrate/supply/weapons/hpr,
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "wt" = (
 /obj/machinery/marine_selector/clothes{
 	lock_flags = 0
 	},
-/turf/open/floor/plating/asteroidfloor,
+/turf/open/ground/jungle/path,
 /area/whiskey_outpost)
 "wu" = (
 /obj/structure/barricade/sandbags,
@@ -4481,6 +4568,12 @@
 /obj/item/weapon/gun/launcher/rocket,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
+"wJ" = (
+/obj/structure/barricade/sandbags{
+	pixel_y = -6
+	},
+/turf/open/floor/plating/warning,
+/area/whiskey_outpost/outside/east)
 "wO" = (
 /obj/structure/barricade/metal{
 	dir = 8
@@ -4499,8 +4592,10 @@
 /turf/open/floor/plating/platebot,
 /area/whiskey_outpost)
 "xh" = (
-/obj/machinery/vending/marine,
-/turf/open/floor/tile/dark,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "xj" = (
 /obj/machinery/light{
@@ -4537,10 +4632,12 @@
 	dir = 4
 	},
 /area/whiskey_outpost)
-"xP" = (
-/obj/machinery/miner/damaged/platinum,
-/turf/open/floor/plating/ground/dirt,
-/area/whiskey_outpost/outside/east)
+"xM" = (
+/obj/machinery/door/airlock/mainship/marine/requisitions{
+	dir = 1
+	},
+/turf/open/floor/prison,
+/area/whiskey_outpost)
 "xQ" = (
 /obj/machinery/marine_selector/clothes,
 /obj/structure/window/reinforced,
@@ -4563,11 +4660,23 @@
 /obj/item/lightstick/red/anchored,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost/outside/south)
+"xW" = (
+/obj/structure/cable,
+/obj/machinery/computer/security/wooden_tv{
+	desc = "An old TV hooked into cable. May or may not work.";
+	name = "Old TV"
+	},
+/turf/open/floor/plating/asteroidfloor,
+/area/whiskey_outpost/outside/west)
 "yd" = (
 /obj/structure/largecrate/supply/medicine/medkits,
 /turf/open/floor/plating/asteroidwarning{
 	dir = 4
 	},
+/area/whiskey_outpost)
+"yf" = (
+/obj/machinery/door/airlock/mainship/generic/bathroom,
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "yj" = (
 /obj/machinery/light{
@@ -4608,7 +4717,9 @@
 /turf/open/floor/plating/ground/dirt,
 /area/whiskey_outpost/outside/north)
 "yN" = (
-/obj/structure/barricade/sandbags,
+/obj/structure/barricade/sandbags{
+	pixel_y = -6
+	},
 /turf/open/floor/plating/warning,
 /area/whiskey_outpost)
 "yQ" = (
@@ -4639,7 +4750,9 @@
 /turf/open/floor/plating,
 /area/whiskey_outpost/outside/north)
 "zo" = (
-/obj/structure/barricade/sandbags,
+/obj/structure/barricade/sandbags{
+	pixel_y = -6
+	},
 /turf/open/floor/plating/ground/dirtgrassborder/corner2,
 /area/whiskey_outpost/outside/north)
 "zw" = (
@@ -4650,21 +4763,24 @@
 /turf/open/floor/mainship,
 /area/whiskey_outpost)
 "zz" = (
-/obj/structure/table,
 /obj/item/storage/toolbox/electrical,
 /obj/item/storage/toolbox/electrical,
 /obj/effect/ai_node,
+/obj/structure/table/mainship,
 /turf/open/floor,
 /area/whiskey_outpost)
 "zI" = (
-/obj/structure/barricade/sandbags,
 /obj/effect/ai_node,
+/obj/structure/barricade/sandbags{
+	pixel_y = -6
+	},
 /turf/open/floor/plating/ground/dirt,
 /area/whiskey_outpost/outside/north)
 "zM" = (
 /obj/structure/sign/greencross/star{
 	pixel_y = 32
 	},
+/obj/structure/largecrate/supply/explosives/mines,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost/outside/west)
 "zP" = (
@@ -4675,11 +4791,30 @@
 /obj/item/mortal_shell/flare,
 /obj/item/mortal_shell/flare,
 /turf/open/floor/plating/asteroidplating,
-/area/whiskey_outpost)
+/area/whiskey_outpost/outside/north)
+"zW" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/ground/grass,
+/area/whiskey_outpost/outside/south)
 "zX" = (
+/obj/structure/table/mainship,
+/obj/item/fuelCell/full,
+/obj/item/fuelCell/full,
+/obj/item/fuelCell/full,
+/obj/item/fuelCell/full,
+/obj/item/fuelCell/full,
+/obj/item/fuelCell/full,
+/obj/item/fuelCell/full,
+/obj/item/fuelCell/full,
+/obj/item/fuelCell/full,
+/obj/item/fuelCell/full,
 /turf/open/floor/tile/yellow{
 	dir = 5
 	},
+/area/whiskey_outpost)
+"Ab" = (
+/obj/machinery/loadout_vendor,
+/turf/open/ground/jungle/path,
 /area/whiskey_outpost)
 "Af" = (
 /obj/structure/barricade/plasteel,
@@ -4693,10 +4828,6 @@
 	dir = 9
 	},
 /area/whiskey_outpost)
-"Aq" = (
-/obj/machinery/miner/damaged/platinum,
-/turf/open/floor/plating/ground/dirt,
-/area/whiskey_outpost/outside/north)
 "As" = (
 /obj/structure/platform{
 	dir = 4
@@ -4705,14 +4836,43 @@
 	dir = 1
 	},
 /area/whiskey_outpost/outside/west)
+"Au" = (
+/obj/machinery/light,
+/obj/vehicle/ridden/motorbike{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroidfloor,
+/area/whiskey_outpost)
+"Ay" = (
+/obj/item/weapon/gun/tl102/hsg_nest,
+/turf/open/floor/plating/asteroidwarning,
+/area/whiskey_outpost)
+"AB" = (
+/turf/open/ground/jungle/path,
+/area/whiskey_outpost/outside/west)
+"AE" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/mainship,
+/area/whiskey_outpost)
+"AH" = (
+/obj/machinery/door_control/unmeltable{
+	desc = "Huh... What could this possibly control?";
+	id = "escape";
+	name = "Weird Button";
+	pixel_x = -22
+	},
+/turf/open/ground/grass,
+/area/whiskey_outpost)
 "AJ" = (
-/obj/machinery/vending/marine,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/machinery/vending/marine/shared,
 /turf/open/floor/tile/whiteyellow/full,
 /area/whiskey_outpost)
 "AL" = (
@@ -4723,11 +4883,6 @@
 	dir = 8
 	},
 /turf/open/floor/mainship,
-/area/whiskey_outpost)
-"AM" = (
-/turf/closed/shuttle/re_corner/jungle{
-	dir = 4
-	},
 /area/whiskey_outpost)
 "AO" = (
 /obj/item/quikdeploy/cade/plasteel,
@@ -4755,13 +4910,6 @@
 "AQ" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
-/area/whiskey_outpost/outside/west)
-"AR" = (
-/obj/machinery/vending/marine,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/tile/whiteyellow/full,
 /area/whiskey_outpost)
 "AV" = (
 /obj/structure/platform{
@@ -4788,15 +4936,12 @@
 /area/whiskey_outpost)
 "Bd" = (
 /obj/structure/cable,
+/obj/machinery/power/port_gen/pacman/super{
+	power_gen = 25000
+	},
 /turf/open/floor/tile/yellow{
 	dir = 1
 	},
-/area/whiskey_outpost)
-"Bg" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
 /area/whiskey_outpost)
 "Bh" = (
 /obj/structure/platform{
@@ -4804,6 +4949,14 @@
 	},
 /turf/open/ground/river,
 /area/whiskey_outpost/outside/west)
+"Bo" = (
+/obj/structure/bed,
+/obj/item/bedsheet/captain,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/prison/plate,
+/area/whiskey_outpost)
 "By" = (
 /obj/structure/platform_decoration{
 	dir = 1
@@ -4812,9 +4965,14 @@
 	dir = 1
 	},
 /area/whiskey_outpost/outside/west)
-"BA" = (
-/turf/closed/wall/r_wall,
-/area/space)
+"BH" = (
+/obj/machinery/computer/camera_advanced/overwatch,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 5;
+	pixel_y = 1
+	},
+/turf/open/floor/prison,
+/area/whiskey_outpost)
 "BK" = (
 /obj/machinery/marine_selector/clothes/engi,
 /obj/structure/window/reinforced,
@@ -4822,6 +4980,17 @@
 	dir = 8
 	},
 /area/whiskey_outpost)
+"BM" = (
+/obj/machinery/vending/marine/shared,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/prison,
+/area/whiskey_outpost)
+"BO" = (
+/obj/item/storage/box/sentry,
+/turf/open/ground/jungle,
+/area/whiskey_outpost/outside/west)
 "BQ" = (
 /obj/effect/ai_node,
 /turf/open/ground/jungle,
@@ -4829,9 +4998,17 @@
 "BR" = (
 /turf/closed/wall/indestructible/mineral,
 /area/whiskey_outpost)
+"BX" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/claymore/mercsword/captain,
+/turf/open/floor/wood,
+/area/whiskey_outpost)
 "BZ" = (
-/turf/closed/mineral,
-/area/space)
+/obj/machinery/factory/heater{
+	anchored = 1
+	},
+/turf/open/floor/prison,
+/area/whiskey_outpost)
 "Cd" = (
 /obj/structure/bed,
 /obj/machinery/light{
@@ -4843,10 +5020,19 @@
 	dir = 1
 	},
 /area/whiskey_outpost)
+"Cf" = (
+/obj/structure/platform_decoration{
+	dir = 4
+	},
+/turf/open/ground/coast{
+	dir = 6
+	},
+/area/whiskey_outpost/outside/north)
 "Ch" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/machinery/loadout_vendor,
 /turf/open/floor/mainship/blue{
 	dir = 4
 	},
@@ -4859,18 +5045,26 @@
 /obj/structure/largecrate/supply/weapons/standard_smg,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
+"Ck" = (
+/obj/structure/largecrate/supply/weapons/flamers,
+/turf/open/floor/prison,
+/area/whiskey_outpost)
 "Cl" = (
 /obj/machinery/light,
+/obj/structure/reagent_dispensers/beerkeg{
+	desc = "Contains copius amounts of whiskey to null the pain";
+	list_reagents = list(/datum/reagent/consumable/ethanol/whiskey = 1000);
+	name = "Whiskey Keg"
+	},
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 5;
+	pixel_y = 5
+	},
 /turf/open/floor/tile/whiteyellow/full,
 /area/whiskey_outpost)
 "Cp" = (
-/obj/structure/rack,
-/obj/item/storage/box/visual/magazine/compact/standard_carbine/full,
-/obj/item/storage/box/visual/magazine/compact/standard_carbine/full,
-/obj/item/storage/box/visual/magazine/compact/standard_carbine/full,
-/obj/item/storage/box/visual/magazine/compact/standard_carbine/full,
-/obj/item/storage/box/visual/magazine/compact/standard_carbine/full,
-/turf/open/floor/plating/asteroidfloor,
+/obj/structure/largecrate/supply/explosives/mines,
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "Cq" = (
 /obj/structure/barricade/plasteel,
@@ -4881,16 +5075,56 @@
 /obj/machinery/light,
 /turf/open/floor/mainship/sterile/dark,
 /area/whiskey_outpost)
+"Cv" = (
+/obj/item/storage/box/sentry,
+/turf/open/ground/jungle/path,
+/area/whiskey_outpost/outside/west)
+"CA" = (
+/obj/effect/landmark/start/job/squadmarine,
+/turf/open/ground/jungle/path,
+/area/whiskey_outpost/outside/west)
+"CB" = (
+/turf/closed/banish_space{
+	desc = "You realize the truth. There is no escape";
+	name = "End of the world"
+	},
+/area/whiskey_outpost/outside/south)
+"CD" = (
+/obj/item/quikdeploy/cade/plasteel,
+/obj/item/quikdeploy/cade/plasteel,
+/obj/item/quikdeploy/cade/plasteel,
+/obj/item/quikdeploy/cade/plasteel,
+/obj/item/quikdeploy/cade/plasteel,
+/turf/open/ground/jungle/path,
+/area/whiskey_outpost/outside/west)
 "CH" = (
 /obj/structure/barricade/plasteel{
 	dir = 1
 	},
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
+"CK" = (
+/obj/item/weapon/gun/tl102/hsg_nest{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroidwarning{
+	dir = 4
+	},
+/area/whiskey_outpost)
 "CL" = (
 /obj/structure/dropship_piece/one/rearwing/lefttop,
 /turf/open/ground/jungle,
 /area/whiskey_outpost/outside/south)
+"CR" = (
+/obj/structure/table/woodentable,
+/obj/item/toy/dice,
+/obj/item/toy/dice/d20,
+/obj/item/toy/deck,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/prison/plate,
+/area/whiskey_outpost)
 "CT" = (
 /obj/structure/platform_decoration,
 /obj/structure/platform_decoration{
@@ -4906,12 +5140,24 @@
 	dir = 5
 	},
 /area/whiskey_outpost)
+"CW" = (
+/obj/item/storage/toolbox/mechanical,
+/turf/open/ground/jungle/path,
+/area/whiskey_outpost/outside/east)
 "CZ" = (
 /obj/structure/platform{
 	dir = 4
 	},
 /turf/open/ground/river,
 /area/whiskey_outpost/outside/west)
+"Df" = (
+/obj/structure/reagent_dispensers/beerkeg{
+	desc = "Contains copius amounts of whiskey to null the pain";
+	list_reagents = list(/datum/reagent/consumable/ethanol/whiskey = 1000);
+	name = "Whiskey Keg"
+	},
+/turf/open/floor/plating/asteroidfloor,
+/area/whiskey_outpost)
 "Dl" = (
 /obj/machinery/light,
 /obj/structure/closet/crate,
@@ -4928,30 +5174,43 @@
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
 "Do" = (
-/obj/machinery/vending/marine,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/machinery/vending/marine/shared,
 /turf/open/floor/plating/asteroidfloor,
+/area/whiskey_outpost)
+"Dq" = (
+/obj/structure/barricade/sandbags{
+	pixel_y = -6
+	},
+/turf/open/floor/plating/warning,
+/area/whiskey_outpost/outside/west)
+"Ds" = (
+/obj/effect/ai_node,
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk/prison,
 /area/whiskey_outpost)
 "Dx" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
-"DC" = (
-/obj/structure/barricade/metal,
-/obj/structure/barricade/metal{
-	dir = 8
+"DH" = (
+/obj/machinery/factory/cutter{
+	anchored = 1
 	},
-/turf/open/floor/plating/warning{
-	dir = 10
-	},
-/area/whiskey_outpost/outside/east)
+/turf/open/floor/prison,
+/area/whiskey_outpost)
 "DO" = (
 /obj/structure/window/reinforced,
+/obj/machinery/loadout_vendor,
 /turf/open/floor/mainship/blue{
 	dir = 4
 	},
+/area/whiskey_outpost)
+"DQ" = (
+/obj/structure/largecrate/supply/floodlights,
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "DR" = (
 /obj/structure/barricade/sandbags,
@@ -4967,26 +5226,27 @@
 	},
 /area/whiskey_outpost)
 "DW" = (
-/obj/structure/rack,
-/obj/item/storage/box/visual/magazine/compact/standard_smg/full,
-/obj/item/storage/box/visual/magazine/compact/standard_smg/full,
-/obj/item/storage/box/visual/magazine/compact/standard_smg/full,
-/obj/item/storage/box/visual/magazine/compact/standard_smg/full,
-/obj/item/storage/box/visual/magazine/compact/standard_smg/full,
-/turf/open/floor/plating/asteroidfloor,
+/obj/structure/largecrate/supply/ammo/standard_smg,
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "DZ" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost/outside/north)
+"Ek" = (
+/obj/structure/closet/secure_closet/guncabinet/lmg,
+/turf/open/floor/prison/plate,
+/area/whiskey_outpost)
 "Eo" = (
 /obj/structure/dropship_piece/one/rearwing/leftbottom,
 /turf/open/ground/jungle,
 /area/whiskey_outpost/outside/south)
 "Er" = (
-/obj/structure/barricade/sandbags,
 /obj/structure/barricade/sandbags{
 	dir = 4
+	},
+/obj/structure/barricade/sandbags{
+	pixel_y = -6
 	},
 /turf/open/floor/plating/asteroidwarning{
 	dir = 6
@@ -5001,20 +5261,16 @@
 	},
 /area/whiskey_outpost)
 "Ez" = (
-/obj/structure/table,
 /obj/item/storage/firstaid/regular,
 /obj/item/storage/firstaid/regular,
 /obj/item/storage/firstaid/regular,
+/obj/structure/table/mainship,
 /turf/open/floor/mainship/sterile,
 /area/whiskey_outpost)
 "ED" = (
 /turf/open/floor/mainship/orange{
 	dir = 4
 	},
-/area/whiskey_outpost)
-"EF" = (
-/obj/machinery/vending/uniform_supply,
-/turf/open/floor/tile/dark,
 /area/whiskey_outpost)
 "EG" = (
 /obj/machinery/vending/marine_medic,
@@ -5026,26 +5282,52 @@
 	},
 /area/whiskey_outpost)
 "EH" = (
-/obj/structure/barricade/sandbags,
 /obj/structure/barricade/sandbags{
 	dir = 8
 	},
+/obj/structure/barricade/sandbags{
+	pixel_y = -6
+	},
 /turf/open/floor/plating/ground/dirt,
 /area/whiskey_outpost/outside/north)
+"EI" = (
+/obj/item/storage/box/explosive_mines/large,
+/turf/open/floor/plating/asteroidfloor,
+/area/whiskey_outpost/outside/west)
 "EL" = (
 /obj/item/storage/box/explosive_mines,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost/outside/east)
 "ER" = (
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 50
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 50
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 50
+	},
 /obj/structure/cable,
 /turf/open/floor/tile/yellow{
 	dir = 9
 	},
 /area/whiskey_outpost)
+"ET" = (
+/obj/item/bedsheet/captain,
+/obj/structure/bed,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
+	},
+/turf/open/floor/prison/plate,
+/area/whiskey_outpost)
 "EU" = (
-/obj/structure/barricade/sandbags,
 /obj/structure/barricade/sandbags{
 	dir = 4
+	},
+/obj/structure/barricade/sandbags{
+	pixel_y = -6
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/whiskey_outpost/outside/east)
@@ -5066,6 +5348,12 @@
 	dir = 4
 	},
 /area/whiskey_outpost)
+"Fa" = (
+/obj/machinery/outputter{
+	anchored = 1
+	},
+/turf/open/floor/prison,
+/area/whiskey_outpost)
 "Fb" = (
 /obj/machinery/marine_selector/clothes,
 /obj/structure/window/reinforced,
@@ -5075,9 +5363,11 @@
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
 "Fi" = (
-/obj/structure/barricade/sandbags,
 /obj/structure/platform{
 	dir = 8
+	},
+/obj/structure/barricade/sandbags{
+	pixel_y = -6
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/whiskey_outpost/outside/north)
@@ -5090,6 +5380,11 @@
 	},
 /turf/open/ground/grass/beach,
 /area/whiskey_outpost/outside/west)
+"Fm" = (
+/obj/structure/largecrate/supply/explosives/mortar_incend,
+/obj/structure/cable,
+/turf/open/floor/prison,
+/area/whiskey_outpost)
 "Ft" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/asteroidfloor,
@@ -5112,8 +5407,10 @@
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost/outside/north)
 "FL" = (
-/obj/structure/barricade/sandbags,
 /obj/effect/ai_node,
+/obj/structure/barricade/sandbags{
+	pixel_y = -6
+	},
 /turf/open/floor/plating/ground/dirt,
 /area/whiskey_outpost/outside/east)
 "FM" = (
@@ -5126,20 +5423,55 @@
 	},
 /area/whiskey_outpost)
 "FR" = (
-/obj/structure/barricade/sandbags,
 /obj/structure/barricade/sandbags{
 	dir = 8
+	},
+/obj/structure/barricade/sandbags{
+	pixel_y = -6
 	},
 /turf/open/floor/plating/warning{
 	dir = 10
 	},
 /area/whiskey_outpost)
+"FW" = (
+/obj/effect/ai_node,
+/turf/open/floor/prison,
+/area/whiskey_outpost)
+"Gi" = (
+/obj/item/quikdeploy/cade,
+/obj/item/quikdeploy/cade,
+/obj/item/quikdeploy/cade,
+/obj/item/quikdeploy/cade,
+/obj/item/quikdeploy/cade,
+/obj/item/quikdeploy/cade,
+/obj/item/quikdeploy/cade,
+/obj/item/quikdeploy/cade,
+/obj/item/quikdeploy/cade,
+/obj/item/quikdeploy/cade,
+/obj/item/quikdeploy/cade,
+/obj/item/quikdeploy/cade,
+/obj/item/quikdeploy/cade,
+/obj/item/quikdeploy/cade,
+/obj/item/quikdeploy/cade,
+/obj/item/quikdeploy/cade,
+/obj/item/quikdeploy/cade,
+/obj/item/quikdeploy/cade,
+/obj/item/quikdeploy/cade,
+/obj/item/quikdeploy/cade,
+/turf/open/ground/jungle/path,
+/area/whiskey_outpost/outside/west)
 "Gs" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/conveyor{
+	id = "reqtorio"
 	},
-/turf/open/floor/plating/asteroidwarning{
-	dir = 6
+/obj/structure/plasticflaps,
+/turf/open/floor/prison,
+/area/whiskey_outpost)
+"Gw" = (
+/obj/machinery/floodlight/landing/testroom,
+/turf/closed/banish_space{
+	desc = "You realize the truth. There is no escape";
+	name = "End of the world"
 	},
 /area/whiskey_outpost)
 "Gx" = (
@@ -5151,10 +5483,16 @@
 /obj/machinery/vending/MarineMed/Blood,
 /turf/open/floor/mainship/sterile/dark,
 /area/whiskey_outpost)
+"GD" = (
+/obj/structure/largecrate/supply/supplies/water,
+/turf/open/floor/prison/plate,
+/area/whiskey_outpost)
 "GG" = (
-/obj/structure/barricade/sandbags,
 /obj/structure/barricade/sandbags{
 	dir = 4
+	},
+/obj/structure/barricade/sandbags{
+	pixel_y = -6
 	},
 /turf/open/floor/plating/warning,
 /area/whiskey_outpost)
@@ -5164,22 +5502,26 @@
 /turf/open/floor/plating/warning,
 /area/whiskey_outpost/outside/west)
 "GV" = (
-/obj/machinery/power/geothermal,
 /obj/structure/cable,
+/obj/machinery/power/fusion_engine/preset,
 /turf/open/floor/tile/yellow{
 	dir = 6
 	},
 /area/whiskey_outpost)
+"GZ" = (
+/obj/structure/largecrate/supply/supplies/metal,
+/turf/open/floor/prison,
+/area/whiskey_outpost)
+"Ha" = (
+/obj/item/binoculars/tactical,
+/turf/open/floor/plating/asteroidplating,
+/area/whiskey_outpost/outside/north)
 "Hj" = (
 /obj/machinery/marine_selector/clothes,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /turf/open/floor/plating/asteroidfloor,
-/area/whiskey_outpost)
-"Hk" = (
-/obj/item/stack/medical/bruise_pack,
-/turf/open/floor/plating,
 /area/whiskey_outpost)
 "Hq" = (
 /obj/effect/ai_node,
@@ -5196,6 +5538,18 @@
 /obj/structure/jungle/plantbot1/alien,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost/outside/west)
+"HC" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/ground/river,
+/area/whiskey_outpost)
+"HE" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/prison,
+/area/whiskey_outpost)
 "HF" = (
 /obj/structure/bed,
 /obj/machinery/light{
@@ -5218,13 +5572,42 @@
 	dir = 9
 	},
 /area/whiskey_outpost)
-"HT" = (
-/obj/machinery/marine_selector/clothes,
-/obj/structure/window/reinforced{
+"HJ" = (
+/obj/machinery/floodlight/outpost,
+/turf/open/ground/grass,
+/area/whiskey_outpost/outside/south)
+"HN" = (
+/obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/largecrate/supply/explosives/grenades,
+/turf/open/floor/prison,
+/area/whiskey_outpost)
+"HQ" = (
+/turf/open/floor/prison,
+/area/whiskey_outpost)
+"HT" = (
 /obj/structure/window/reinforced,
+/obj/machinery/computer/cryopod{
+	dir = 8
+	},
 /turf/open/floor/tile/whiteyellow/full,
+/area/whiskey_outpost)
+"HU" = (
+/obj/item/weapon/gun/tl102/hsg_nest,
+/turf/open/floor/plating/warning,
+/area/whiskey_outpost/outside/west)
+"HW" = (
+/turf/closed/wall/r_wall,
+/area/whiskey_outpost/outside/west)
+"HZ" = (
+/obj/structure/rack,
+/obj/item/storage/box/visual/magazine/compact/standard_carbine/full,
+/obj/item/storage/box/visual/magazine/compact/standard_carbine/full,
+/obj/item/storage/box/visual/magazine/compact/standard_carbine/full,
+/obj/item/storage/box/visual/magazine/compact/standard_carbine/full,
+/obj/item/storage/box/visual/magazine/compact/standard_carbine/full,
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "Ib" = (
 /obj/structure/bed,
@@ -5235,25 +5618,39 @@
 /turf/open/floor/mainship/sterile/dark,
 /area/whiskey_outpost)
 "If" = (
-/obj/structure/barricade/sandbags,
 /obj/structure/barricade/sandbags{
 	dir = 8
 	},
+/obj/structure/barricade/sandbags{
+	pixel_y = -6
+	},
 /turf/open/floor/plating/ground/dirt,
 /area/whiskey_outpost/outside/east)
+"Ij" = (
+/obj/structure/jungle/vines,
+/turf/open/floor/plating/ground/dirt,
+/area/whiskey_outpost/outside/west)
 "In" = (
 /obj/effect/ai_node,
 /turf/open/ground/jungle,
 /area/whiskey_outpost/outside/west)
 "Ip" = (
-/obj/structure/table,
 /obj/item/tool/lighter/random,
+/obj/structure/table/mainship,
+/obj/item/reagent_containers/food/drinks/bottle/whiskey{
+	desc = "A premium single-malt whiskey. To celebrate your impending doom";
+	name = "\improper Whiskey Outpost Whiskey"
+	},
 /turf/open/floor/tile/whiteyellow/full,
 /area/whiskey_outpost)
 "Iq" = (
 /obj/machinery/vending/uniform_supply,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
+"Is" = (
+/obj/item/lightstick/red/anchored,
+/turf/open/ground/jungle/impenetrable/nobush,
+/area/whiskey_outpost/outside/south)
 "Iv" = (
 /obj/structure/barricade/sandbags{
 	dir = 1
@@ -5264,6 +5661,32 @@
 /turf/open/floor/plating/asteroidwarning{
 	dir = 9
 	},
+/area/whiskey_outpost)
+"Iw" = (
+/obj/structure/rack,
+/obj/item/weapon/twohanded/glaive{
+	desc = "A war glaive for the lizard king's champion."
+	},
+/turf/open/floor/plating/asteroidfloor,
+/area/whiskey_outpost/outside/west)
+"Iy" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/item/reagent_containers/jerrycan,
+/obj/item/reagent_containers/jerrycan{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/jerrycan,
+/turf/open/floor/plating/asteroidfloor,
+/area/whiskey_outpost)
+"IB" = (
+/obj/item/roller/medevac{
+	pixel_y = -6
+	},
+/obj/item/roller/medevac,
+/obj/item/medevac_beacon,
+/obj/item/medevac_beacon,
+/turf/open/floor/mainship/sterile/dark,
 /area/whiskey_outpost)
 "IN" = (
 /obj/effect/landmark/start/job/squadcorpsman,
@@ -5288,14 +5711,36 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost/outside/west)
+"Ja" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/closet/crate/explosives,
+/obj/item/storage/box/visual/grenade/razorburn,
+/obj/item/storage/box/visual/grenade/razorburn,
+/obj/item/storage/box/visual/grenade/M15,
+/obj/item/storage/box/visual/grenade/phosphorus,
+/obj/item/explosive/grenade/incendiary/molotov,
+/obj/item/explosive/grenade/incendiary/molotov,
+/turf/open/floor/prison,
+/area/whiskey_outpost)
 "Jb" = (
-/obj/machinery/vending/marine,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/structure/window/reinforced,
+/obj/machinery/vending/marine/shared,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
+"Je" = (
+/obj/structure/bed/chair/comfy,
+/obj/item/toy/plush/slime{
+	anchored = 1;
+	desc = "The adopted daughter of king moth, One day she will inherit the whole kingdom";
+	name = "Princess Slime"
+	},
+/turf/open/floor/plating/asteroidfloor,
+/area/whiskey_outpost/outside/west)
 "Jf" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirt,
@@ -5305,9 +5750,12 @@
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost/outside/east)
 "Jj" = (
-/obj/structure/table,
-/obj/item/storage/fancy/cigarettes/lady_finger,
+/obj/structure/closet/secure_closet/staff_officer,
 /turf/open/floor/wood,
+/area/whiskey_outpost)
+"Jq" = (
+/obj/structure/largecrate/supply/supplies/mre,
+/turf/open/floor/prison/plate,
 /area/whiskey_outpost)
 "Jt" = (
 /obj/structure/barricade/plasteel,
@@ -5322,6 +5770,11 @@
 /obj/item/weapon/gun/sentry/premade,
 /turf/open/floor/plating/platebot,
 /area/whiskey_outpost/outside/west)
+"JA" = (
+/obj/item/storage/box/m94/cas,
+/obj/item/stack/barbed_wire/full,
+/turf/open/floor/plating,
+/area/whiskey_outpost/outside/west)
 "JB" = (
 /obj/machinery/light{
 	dir = 1
@@ -5331,7 +5784,7 @@
 	},
 /area/whiskey_outpost)
 "JD" = (
-/obj/machinery/vending/marine,
+/obj/machinery/vending/marine/shared,
 /turf/open/floor/plating,
 /area/whiskey_outpost)
 "JP" = (
@@ -5354,6 +5807,12 @@
 /obj/effect/ai_node,
 /turf/open/ground/grass,
 /area/whiskey_outpost/outside/west)
+"JZ" = (
+/turf/closed/banish_space{
+	desc = "You realize the truth. There is no escape";
+	name = "End of the world"
+	},
+/area/whiskey_outpost)
 "Kg" = (
 /obj/structure/largecrate/supply/weapons/standard_smg,
 /turf/open/floor/plating,
@@ -5407,6 +5866,10 @@
 	dir = 5
 	},
 /area/whiskey_outpost)
+"KL" = (
+/obj/structure/cable,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/whiskey_outpost)
 "KM" = (
 /obj/structure/bed,
 /obj/item/bedsheet/purple,
@@ -5422,6 +5885,15 @@
 /obj/structure/barricade/plasteel,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost/outside/west)
+"KS" = (
+/obj/structure/rack,
+/obj/item/attachable/motiondetector,
+/obj/item/attachable/motiondetector,
+/obj/item/attachable/motiondetector,
+/obj/item/attachable/motiondetector,
+/obj/item/attachable/motiondetector,
+/turf/open/floor/prison,
+/area/whiskey_outpost)
 "Lc" = (
 /obj/effect/landmark/dropship_start_location,
 /obj/effect/ai_node,
@@ -5430,16 +5902,27 @@
 "Lj" = (
 /turf/open/floor/asteroidfloor,
 /area/whiskey_outpost/outside/east)
+"Ln" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/ground/river,
+/area/whiskey_outpost)
 "Lo" = (
 /obj/item/storage/box/sentry,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost/outside/west)
 "Lq" = (
-/obj/structure/barricade/sandbags,
+/obj/structure/barricade/sandbags{
+	pixel_y = -6
+	},
 /turf/open/floor/plating/ground/dirt,
 /area/whiskey_outpost/outside/south)
+"Lr" = (
+/obj/structure/largecrate/supply/supplies/tables_racks,
+/turf/open/floor/prison,
+/area/whiskey_outpost)
 "Lt" = (
-/obj/structure/table,
 /obj/item/storage/firstaid/fire,
 /obj/item/storage/firstaid/fire{
 	pixel_x = 5;
@@ -5452,20 +5935,40 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
+/obj/structure/table/mainship,
 /turf/open/floor/mainship/sterile,
 /area/whiskey_outpost)
+"Lv" = (
+/obj/structure/closet/secure_closet/guncabinet/incendiary,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 10
+	},
+/turf/open/floor/prison/plate,
+/area/whiskey_outpost)
 "Lz" = (
-/obj/machinery/vending/marine,
 /obj/structure/window/reinforced,
+/obj/machinery/vending/marine/shared,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
 "LF" = (
-/obj/structure/barricade/sandbags,
 /obj/structure/barricade/sandbags{
 	dir = 4
 	},
+/obj/structure/barricade/sandbags{
+	pixel_y = -6
+	},
 /turf/open/floor/plating/ground/dirt,
 /area/whiskey_outpost/outside/north)
+"LK" = (
+/obj/vehicle/ridden/motorbike{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroidfloor,
+/area/whiskey_outpost)
+"LS" = (
+/obj/structure/jungle/vines,
+/turf/closed/mineral,
+/area/whiskey_outpost/outside/west)
 "LX" = (
 /obj/structure/barricade/sandbags{
 	dir = 4
@@ -5496,10 +5999,32 @@
 /obj/item/quikdeploy/cade/plasteel,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
+"Me" = (
+/obj/item/stack/barbed_wire/full,
+/obj/item/stack/barbed_wire/full,
+/turf/open/floor/plating/asteroidfloor,
+/area/whiskey_outpost/outside/east)
 "Mf" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/plating/ground/dirt,
 /area/whiskey_outpost/outside/east)
+"Mg" = (
+/obj/structure/rack,
+/obj/item/big_ammo_box/ap,
+/obj/item/big_ammo_box/ap,
+/obj/item/big_ammo_box/ap,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/prison,
+/area/whiskey_outpost)
+"Mh" = (
+/obj/machinery/vending/marine/shared,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroidfloor,
+/area/whiskey_outpost)
 "Mj" = (
 /obj/structure/platform_decoration{
 	dir = 1
@@ -5525,11 +6050,11 @@
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost/outside/east)
 "Mr" = (
-/obj/machinery/vending/marine,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/machinery/vending/marine/shared,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
 "Mt" = (
@@ -5543,6 +6068,10 @@
 /obj/structure/barricade/sandbags,
 /turf/open/floor/plating/ground/dirt,
 /area/whiskey_outpost/outside/north)
+"MA" = (
+/obj/structure/mineral_door/iron,
+/turf/open/floor/plating/ground/dirt,
+/area/whiskey_outpost/outside/west)
 "MB" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -5550,12 +6079,34 @@
 	},
 /turf/open/floor/mainship,
 /area/whiskey_outpost)
+"MG" = (
+/obj/machinery/vending/armor_supply,
+/turf/open/floor/prison,
+/area/whiskey_outpost)
+"MO" = (
+/obj/structure/window/reinforced,
+/turf/open/floor/mainship,
+/area/whiskey_outpost)
+"MP" = (
+/obj/structure/cable,
+/turf/closed/mineral,
+/area/whiskey_outpost/outside/west)
+"MS" = (
+/obj/structure/bed/chair/office/light{
+	dir = 8
+	},
+/turf/open/floor/prison,
+/area/whiskey_outpost)
 "MV" = (
 /obj/structure/platform{
 	dir = 8
 	},
 /obj/structure/platform,
 /turf/open/ground/river,
+/area/whiskey_outpost/outside/west)
+"MZ" = (
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/plating,
 /area/whiskey_outpost/outside/west)
 "Nd" = (
 /obj/machinery/power/smes/buildable,
@@ -5570,12 +6121,37 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/whiskey_outpost)
+"Ny" = (
+/obj/structure/toilet{
+	pixel_y = 4
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/mainship/sterile/dark,
+/area/whiskey_outpost)
+"NA" = (
+/obj/structure/largecrate/supply/explosives/mortar_incend,
+/turf/open/floor/prison,
+/area/whiskey_outpost)
+"NE" = (
+/obj/item/storage/box/sentry,
+/turf/open/ground/jungle,
+/area/whiskey_outpost/outside/east)
 "NG" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/structure/platform{
 	dir = 4
 	},
 /turf/open/ground/river,
+/area/whiskey_outpost/outside/west)
+"NJ" = (
+/obj/item/toy/plush/snake{
+	anchored = 1;
+	desc = "This snake defends the castle of the moth."       ;
+	name = "Snake Knight"
+	},
+/turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost/outside/west)
 "NL" = (
 /obj/machinery/light{
@@ -5589,6 +6165,50 @@
 /obj/item/storage/box/sentry,
 /turf/open/floor/plating/platebot,
 /area/whiskey_outpost)
+"NO" = (
+/obj/structure/xenoautopsy/tank/alien,
+/turf/open/floor/wood,
+/area/whiskey_outpost/outside/north)
+"NY" = (
+/obj/machinery/cryopod/right,
+/turf/open/floor/tile/whiteyellow/full,
+/area/whiskey_outpost)
+"NZ" = (
+/obj/structure/table/mainship,
+/obj/item/reagent_containers/food/drinks/bottle/whiskey{
+	desc = "A premium single-malt whiskey. To celebrate your impending doom";
+	name = "\improper Whiskey Outpost Whiskey"
+	},
+/obj/item/reagent_containers/food/drinks/bottle/whiskey{
+	desc = "A premium single-malt whiskey. To celebrate your impending doom";
+	name = "\improper Whiskey Outpost Whiskey"
+	},
+/obj/item/reagent_containers/food/drinks/bottle/whiskey{
+	desc = "A premium single-malt whiskey. To celebrate your impending doom";
+	name = "\improper Whiskey Outpost Whiskey"
+	},
+/obj/item/reagent_containers/food/drinks/bottle/whiskey{
+	desc = "A premium single-malt whiskey. To celebrate your impending doom";
+	name = "\improper Whiskey Outpost Whiskey"
+	},
+/obj/item/reagent_containers/food/drinks/bottle/whiskey{
+	desc = "A premium single-malt whiskey. To celebrate your impending doom";
+	name = "\improper Whiskey Outpost Whiskey"
+	},
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/tool/lighter{
+	pixel_x = -8;
+	pixel_y = 6
+	},
+/obj/item/storage/fancy/cigarettes/dromedaryco{
+	pixel_x = -5
+	},
+/obj/item/toy/deck/kotahi,
+/turf/open/ground/grass,
+/area/whiskey_outpost/outside/west)
 "Oa" = (
 /obj/machinery/marine_selector/gear/engi,
 /turf/open/floor/mainship/emerald{
@@ -5602,10 +6222,16 @@
 /turf/open/ground/grass/beach,
 /area/whiskey_outpost/outside/west)
 "Oh" = (
-/obj/structure/barricade/sandbags,
 /obj/structure/platform_decoration,
+/obj/structure/barricade/sandbags{
+	pixel_y = -6
+	},
 /turf/open/floor/plating/ground/dirt,
 /area/whiskey_outpost/outside/north)
+"Oj" = (
+/obj/structure/fence,
+/turf/open/ground/river,
+/area/whiskey_outpost)
 "Ok" = (
 /obj/item/weapon/gun/sentry/premade,
 /turf/open/floor/plating/asteroidfloor,
@@ -5630,8 +6256,23 @@
 /obj/structure/barricade/metal{
 	dir = 8
 	},
-/obj/structure/largecrate/supply/explosives/mines,
+/obj/vehicle/ridden/powerloader,
 /turf/open/floor/plating/asteroidfloor,
+/area/whiskey_outpost)
+"Oy" = (
+/obj/machinery/floodlight/outpost,
+/turf/open/floor/plating,
+/area/whiskey_outpost/outside/east)
+"OC" = (
+/obj/structure/bed/chair/office/light{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/effect/landmark/start/job/staffofficer,
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "OD" = (
 /obj/structure/bed,
@@ -5647,8 +6288,19 @@
 	},
 /area/whiskey_outpost)
 "OI" = (
+/obj/item/mortar_kit,
 /turf/open/floor/plating/asteroidplating,
+/area/whiskey_outpost/outside/north)
+"OQ" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/wood,
 /area/whiskey_outpost)
+"OR" = (
+/obj/effect/ai_node,
+/turf/open/ground/jungle/path,
+/area/whiskey_outpost/outside/west)
 "OS" = (
 /obj/structure/barricade/sandbags{
 	dir = 8
@@ -5660,9 +6312,15 @@
 	dir = 8
 	},
 /area/whiskey_outpost)
+"OW" = (
+/obj/machinery/vending/uniform_supply,
+/turf/open/floor/prison,
+/area/whiskey_outpost)
 "OY" = (
-/obj/structure/barricade/sandbags,
 /obj/item/weapon/gun/sentry/premade,
+/obj/structure/barricade/sandbags{
+	pixel_y = -6
+	},
 /turf/open/floor/plating/ground/dirtgrassborder/corner2{
 	dir = 4
 	},
@@ -5671,9 +6329,24 @@
 /obj/machinery/door/window,
 /turf/open/floor/mainship/cargo,
 /area/whiskey_outpost)
+"Pe" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/ground/river,
+/area/whiskey_outpost)
 "Pi" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/plating,
+/area/whiskey_outpost)
+"Pj" = (
+/turf/open/ground/jungle/path,
+/area/whiskey_outpost/outside/east)
+"Pp" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
 /area/whiskey_outpost)
 "Pt" = (
 /obj/item/storage/box/m94,
@@ -5692,10 +6365,17 @@
 /obj/structure/barricade/plasteel,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost/outside/east)
+"PF" = (
+/turf/closed/wall/r_wall/unmeltable,
+/area/whiskey_outpost)
 "PG" = (
 /obj/item/roller,
 /turf/open/floor/mainship/sterile/dark,
 /area/whiskey_outpost)
+"PH" = (
+/obj/effect/ai_node,
+/turf/open/ground/jungle/impenetrable/nobush,
+/area/whiskey_outpost/outside/south)
 "PK" = (
 /obj/structure/platform_decoration{
 	dir = 8
@@ -5723,20 +6403,45 @@
 	},
 /area/whiskey_outpost)
 "Ql" = (
-/obj/structure/barricade/sandbags,
 /obj/structure/platform_decoration{
 	dir = 1
 	},
 /obj/structure/barricade/sandbags{
 	dir = 4
 	},
+/obj/structure/barricade/sandbags{
+	pixel_y = -6
+	},
 /turf/open/floor/plating/ground/dirt,
 /area/whiskey_outpost/outside/north)
+"Qr" = (
+/obj/item/storage/box/explosive_mines/large,
+/turf/open/floor/plating,
+/area/whiskey_outpost/outside/east)
 "Qv" = (
 /obj/structure/barricade/sandbags{
 	dir = 4
 	},
 /turf/open/floor/plating/asteroidplating,
+/area/whiskey_outpost/outside/north)
+"QB" = (
+/obj/structure/rack,
+/obj/item/stack/barbed_wire/full,
+/obj/item/stack/barbed_wire/full,
+/obj/item/stack/barbed_wire/full,
+/obj/item/stack/barbed_wire/full,
+/obj/item/stack/barbed_wire/full,
+/obj/item/stack/barbed_wire/full,
+/obj/item/stack/barbed_wire/full,
+/obj/item/stack/barbed_wire/full,
+/obj/item/stack/barbed_wire/full,
+/obj/item/stack/barbed_wire/full,
+/obj/item/stack/barbed_wire/full,
+/obj/item/stack/barbed_wire/full,
+/obj/item/stack/barbed_wire/full,
+/obj/item/stack/barbed_wire/full,
+/obj/item/stack/barbed_wire/full,
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "QH" = (
 /obj/structure/cable,
@@ -5763,11 +6468,19 @@
 	dir = 10
 	},
 /area/whiskey_outpost)
+"QY" = (
+/obj/structure/largecrate/supply/supplies/water,
+/turf/open/floor/prison,
+/area/whiskey_outpost)
 "Rb" = (
 /obj/effect/attach_point/electronics/dropship1,
 /obj/structure/dropship_piece/one/weapon/leftright,
 /turf/open/floor/plating/ground/dirt,
 /area/whiskey_outpost/outside/east)
+"Rh" = (
+/obj/structure/closet/crate/explosives,
+/turf/open/floor/prison,
+/area/whiskey_outpost)
 "Rl" = (
 /obj/structure/barricade/sandbags{
 	dir = 8
@@ -5776,6 +6489,7 @@
 /area/whiskey_outpost/outside/north)
 "Rm" = (
 /obj/structure/window/reinforced,
+/obj/machinery/loadout_vendor,
 /turf/open/floor/mainship/orange{
 	dir = 4
 	},
@@ -5786,14 +6500,38 @@
 	},
 /turf/open/ground/river,
 /area/whiskey_outpost/outside/east)
+"Rp" = (
+/obj/machinery/factory/former{
+	anchored = 1
+	},
+/turf/open/floor/prison,
+/area/whiskey_outpost)
+"Ru" = (
+/obj/machinery/floodlight/outpost,
+/turf/open/floor/plating,
+/area/whiskey_outpost/outside/west)
+"Ry" = (
+/turf/open/floor/plating/asteroidplating,
+/area/whiskey_outpost/outside/north)
+"RA" = (
+/obj/machinery/door/poddoor/mainship{
+	dir = 2;
+	id = "sekritbunker";
+	name = "\improper Emergency Shelter"
+	},
+/turf/open/floor/prison/plate,
+/area/whiskey_outpost)
+"RC" = (
+/obj/machinery/light/small,
+/turf/open/floor/wood,
+/area/whiskey_outpost)
 "RE" = (
 /obj/structure/cable,
 /turf/open/floor,
 /area/whiskey_outpost)
-"RO" = (
-/obj/machinery/floodlight/outpost,
-/obj/structure/barricade/metal,
-/turf/open/floor/plating/warning,
+"RN" = (
+/obj/structure/largecrate/supply/explosives/mines,
+/turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost/outside/west)
 "RQ" = (
 /obj/effect/landmark/start/job/squadspecialist,
@@ -5814,23 +6552,60 @@
 	dir = 5
 	},
 /area/whiskey_outpost)
+"Se" = (
+/turf/closed/wall/r_wall,
+/area/whiskey_outpost/outside/east)
+"Sg" = (
+/obj/structure/table/woodentable,
+/obj/item/reagent_containers/pill/cyanide{
+	pixel_x = -3;
+	pixel_y = -4
+	},
+/obj/item/reagent_containers/pill/cyanide{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/pill/cyanide{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/item/reagent_containers/pill/cyanide,
+/turf/open/floor/prison/plate,
+/area/whiskey_outpost)
 "Si" = (
 /turf/open/floor/plating/asteroidwarning{
 	dir = 9
 	},
 /area/whiskey_outpost)
+"Sj" = (
+/obj/item/toy/plush/rouny{
+	desc = "A sekrit rooner to remind you that suno redesigned this map on 21-09-2021";
+	name = "Sekrit Rooner"
+	},
+/turf/open/floor/plating/asteroidfloor,
+/area/whiskey_outpost/outside/north)
 "Sk" = (
-/obj/structure/barricade/sandbags,
 /obj/structure/barricade/sandbags{
 	dir = 4
 	},
+/obj/structure/barricade/sandbags{
+	pixel_y = -6
+	},
 /turf/open/floor/plating/asteroidplating,
-/area/whiskey_outpost)
+/area/whiskey_outpost/outside/north)
+"Sl" = (
+/obj/structure/jungle/vines,
+/obj/structure/jungle/vines,
+/obj/structure/jungle/vines,
+/turf/open/ground/jungle,
+/area/whiskey_outpost/outside/west)
 "Sn" = (
 /obj/structure/barricade/sandbags{
 	dir = 8
 	},
-/obj/structure/barricade/sandbags,
+/obj/structure/barricade/sandbags{
+	pixel_y = -6
+	},
 /turf/open/floor/plating/asteroidwarning{
 	dir = 8
 	},
@@ -5844,6 +6619,18 @@
 /obj/effect/ai_node,
 /turf/open/ground/jungle,
 /area/whiskey_outpost/outside/south)
+"Sz" = (
+/obj/machinery/door/poddoor/four_tile_hor{
+	desc = "No escape.";
+	id = null;
+	name = "Exit Shield";
+	resistance_flags = 3
+	},
+/turf/open/floor/plating/asteroidfloor,
+/area/whiskey_outpost/outside/south)
+"SB" = (
+/turf/open/floor/prison/plate,
+/area/whiskey_outpost)
 "SD" = (
 /obj/structure/largecrate/supply/weapons/standard_carbine,
 /turf/open/floor/plating/asteroidwarning{
@@ -5873,7 +6660,9 @@
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
 "SR" = (
-/obj/structure/barricade/sandbags,
+/obj/structure/barricade/sandbags{
+	pixel_y = -6
+	},
 /turf/open/floor/plating/asteroidwarning,
 /area/whiskey_outpost/outside/north)
 "SS" = (
@@ -5881,9 +6670,11 @@
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost/outside/east)
 "Ta" = (
-/obj/structure/barricade/sandbags,
+/obj/structure/barricade/sandbags{
+	pixel_y = -6
+	},
 /turf/open/floor/plating/asteroidplating,
-/area/whiskey_outpost)
+/area/whiskey_outpost/outside/north)
 "Tc" = (
 /obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 2
@@ -5892,9 +6683,17 @@
 	icon_state = "dark_sterile"
 	},
 /area/whiskey_outpost)
-"Td" = (
-/turf/open/ground/grass/beach/corner,
-/area/whiskey_outpost/outside/south)
+"Te" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/item/instrument/musicalmoth{
+	anchored = 1;
+	desc = "Legends say this moth guards the only escape from whiskey outpost. Too bad there is no escape.";
+	name = "Secret Moth"
+	},
+/turf/open/floor/rcircuit,
+/area/whiskey_outpost)
 "Th" = (
 /obj/structure/barricade/sandbags{
 	dir = 4
@@ -5908,13 +6707,7 @@
 /turf/open/floor/mainship/orange,
 /area/whiskey_outpost)
 "Tx" = (
-/obj/structure/table,
-/obj/item/fuelCell/full,
-/obj/item/fuelCell/full,
-/obj/item/fuelCell/full,
-/obj/item/fuelCell/full,
-/obj/item/fuelCell/full,
-/obj/item/fuelCell/full,
+/obj/machinery/fuelcell_recycler,
 /turf/open/floor/tile/yellow{
 	dir = 4
 	},
@@ -5924,8 +6717,8 @@
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
 "TJ" = (
-/obj/machinery/power/geothermal,
 /obj/structure/cable,
+/obj/machinery/power/fusion_engine/preset,
 /turf/open/floor/tile/yellow{
 	dir = 4
 	},
@@ -5935,8 +6728,8 @@
 /turf/open/floor/asteroidfloor,
 /area/whiskey_outpost/outside/east)
 "TL" = (
-/obj/machinery/vending/marine,
-/turf/open/floor/plating/asteroidfloor,
+/obj/machinery/vending/marine/shared,
+/turf/open/ground/jungle/path,
 /area/whiskey_outpost)
 "TP" = (
 /obj/structure/barricade/sandbags,
@@ -5950,13 +6743,23 @@
 /obj/structure/platform{
 	dir = 4
 	},
-/obj/structure/barricade/sandbags,
+/obj/structure/barricade/sandbags{
+	pixel_y = -6
+	},
 /turf/open/floor/plating/ground/dirt,
 /area/whiskey_outpost/outside/north)
 "TX" = (
 /obj/item/lightstick/red/anchored,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost/outside/north)
+"Uj" = (
+/obj/item/weapon/gun/tl102/hsg_nest{
+	dir = 8
+	},
+/turf/open/floor/plating/warning{
+	dir = 8
+	},
+/area/whiskey_outpost)
 "Uk" = (
 /obj/structure/largecrate/supply/weapons/shotgun,
 /turf/open/floor/plating/asteroidfloor,
@@ -5965,6 +6768,13 @@
 /obj/structure/barricade/sandbags,
 /turf/open/shuttle/dropship/eight,
 /area/whiskey_outpost/outside/east)
+"Uu" = (
+/obj/machinery/door/airlock/mainship/maint/free_access{
+	dir = 2;
+	name = "\improper Security Checkpoint"
+	},
+/turf/open/floor/tile/dark,
+/area/whiskey_outpost)
 "Uv" = (
 /obj/machinery/light{
 	dir = 8
@@ -5974,11 +6784,43 @@
 	dir = 4
 	},
 /area/whiskey_outpost)
+"UB" = (
+/obj/structure/cable,
+/turf/open/floor/prison,
+/area/whiskey_outpost)
 "UL" = (
-/obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/item/tool/hand_labeler,
-/turf/open/floor/plating/asteroidfloor,
+/obj/structure/table/mainship,
+/obj/item/toy/plush/rouny{
+	desc = "A plushie depicting a rouny, made to commemorate the battle of Whiskey Outpost. Wait... Isnt that today?"
+	},
+/obj/item/toy/plush/rouny{
+	desc = "A plushie depicting a rouny, made to commemorate the battle of Whiskey Outpost. Wait... Isnt that today?"
+	},
+/turf/open/floor/prison,
+/area/whiskey_outpost)
+"UN" = (
+/obj/structure/table/mainship,
+/obj/item/tool/handheld_charger,
+/obj/item/minerupgrade/automatic{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/minerupgrade/automatic{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/minerupgrade/overclock,
+/obj/item/minerupgrade/overclock,
+/turf/open/floor/prison,
+/area/whiskey_outpost)
+"US" = (
+/obj/structure/bed/chair/office/light{
+	dir = 8
+	},
+/obj/effect/landmark/start/job/staffofficer,
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "UU" = (
 /obj/structure/barricade/sandbags,
@@ -5989,15 +6831,26 @@
 /obj/effect/ai_node,
 /turf/open/ground/jungle,
 /area/whiskey_outpost/outside/east)
+"Vl" = (
+/obj/structure/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder,
+/area/whiskey_outpost/outside/west)
 "Vq" = (
 /turf/open/floor/plating/asteroidwarning{
 	dir = 6
 	},
 /area/whiskey_outpost)
+"VB" = (
+/obj/structure/jungle/vines,
+/obj/structure/jungle/vines,
+/turf/open/ground/jungle,
+/area/whiskey_outpost/outside/west)
 "VD" = (
-/obj/structure/barricade/sandbags,
 /obj/structure/barricade/sandbags{
 	dir = 4
+	},
+/obj/structure/barricade/sandbags{
+	pixel_y = -6
 	},
 /turf/open/floor/plating/warning{
 	dir = 6
@@ -6011,6 +6864,10 @@
 	dir = 1
 	},
 /area/whiskey_outpost/outside/north)
+"VI" = (
+/obj/item/storage/box/explosive_mines/large,
+/turf/open/floor/plating/asteroidfloor,
+/area/whiskey_outpost/outside/east)
 "VJ" = (
 /obj/structure/cable,
 /turf/open/floor/tile/yellow{
@@ -6022,17 +6879,44 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/dirt,
 /area/whiskey_outpost/outside/east)
+"VS" = (
+/turf/open/ground/river,
+/area/whiskey_outpost)
 "Wm" = (
 /obj/effect/landmark/start/job/squadsmartgunner,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
 "Wq" = (
-/obj/structure/table,
 /obj/item/defibrillator,
 /obj/item/defibrillator,
 /obj/item/defibrillator,
 /obj/machinery/recharger,
+/obj/structure/table/mainship,
 /turf/open/floor/mainship/sterile,
+/area/whiskey_outpost)
+"Ws" = (
+/obj/structure/closet/crate/construction{
+	desc = "A crate used to ferry explosives to and from the frontlines. Has an unusually high capacity";
+	mob_storage_capacity = 5;
+	name = "High Explosive Crate";
+	storage_capacity = 200
+	},
+/obj/item/storage/box/visual/grenade/phosphorus,
+/obj/item/storage/box/visual/grenade/phosphorus,
+/obj/item/weapon/gun/launcher/m92/standardmarine,
+/obj/item/weapon/gun/launcher/m92/standardmarine,
+/obj/item/attachable/scope/mini,
+/obj/item/attachable/scope/mini,
+/obj/item/weapon/gun/launcher/m81/flare/marine{
+	desc = "A very tiny flaregun that fires flares equipped with long range irons. This one has been modified to fire WP grenades for some reason. What madman would do this?";
+	grenade_type_allowed = /obj/item/explosive/grenade/phosphorus;
+	name = "Modified M30E2 flare gun"
+	},
+/obj/item/explosive/grenade/phosphorus,
+/obj/item/explosive/grenade/phosphorus,
+/turf/open/floor/plating/warning{
+	dir = 1
+	},
 /area/whiskey_outpost)
 "WA" = (
 /obj/structure/window/framed/colony/reinforced,
@@ -6046,15 +6930,30 @@
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost/outside/west)
+"WF" = (
+/turf/open/ground/grass,
+/area/whiskey_outpost/outside/south)
 "WR" = (
 /obj/effect/ai_node,
-/turf/open/floor/plating/warning,
+/turf/open/floor/plating,
 /area/whiskey_outpost/outside/west)
 "WU" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /turf/open/floor/mainship/red,
+/area/whiskey_outpost)
+"Xd" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/turf/open/ground/coast/corner,
+/area/whiskey_outpost/outside/north)
+"Xf" = (
+/obj/structure/bed/chair/sofa/right{
+	dir = 8
+	},
+/turf/open/floor/prison/plate,
 /area/whiskey_outpost)
 "Xh" = (
 /obj/effect/decal/cleanable/blood/writing{
@@ -6071,6 +6970,15 @@
 /turf/open/floor/plating/asteroidwarning{
 	dir = 8
 	},
+/area/whiskey_outpost)
+"Xm" = (
+/obj/machinery/conveyor{
+	id = "reqtorio"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/prison,
 /area/whiskey_outpost)
 "Xo" = (
 /obj/structure/barricade/sandbags,
@@ -6141,6 +7049,12 @@
 	dir = 4
 	},
 /area/whiskey_outpost)
+"XQ" = (
+/obj/structure/bed/chair/sofa/left{
+	dir = 8
+	},
+/turf/open/floor/prison/plate,
+/area/whiskey_outpost)
 "XW" = (
 /obj/machinery/marine_selector/gear/smartgun,
 /obj/structure/window/reinforced{
@@ -6150,10 +7064,34 @@
 	dir = 4
 	},
 /area/whiskey_outpost)
+"XY" = (
+/obj/item/roller/medevac,
+/obj/item/roller/medevac{
+	pixel_y = -6
+	},
+/obj/item/medevac_beacon,
+/obj/item/medevac_beacon,
+/turf/open/floor/mainship/sterile/dark,
+/area/whiskey_outpost)
+"Ya" = (
+/obj/item/lightstick/red/anchored,
+/turf/open/ground/jungle/path,
+/area/whiskey_outpost/outside/west)
+"Yc" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/open/ground/grass,
+/area/whiskey_outpost/outside/west)
 "Yi" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost/outside/south)
+"Yw" = (
+/obj/structure/jungle/vines,
+/obj/structure/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder/corner,
+/area/whiskey_outpost/outside/west)
 "Yy" = (
 /obj/structure/platform_decoration{
 	dir = 1
@@ -6172,7 +7110,7 @@
 /obj/item/mortal_shell/smoke,
 /obj/item/mortal_shell/smoke,
 /turf/open/floor/plating/asteroidplating,
-/area/whiskey_outpost)
+/area/whiskey_outpost/outside/north)
 "YG" = (
 /obj/machinery/light{
 	dir = 1
@@ -6180,11 +7118,14 @@
 /obj/effect/landmark/start/job/squadcorpsman,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
-"YM" = (
-/obj/structure/barricade/sandbags,
-/obj/structure/barricade/sandbags,
-/turf/open/floor/plating/ground/dirt,
-/area/whiskey_outpost/outside/north)
+"YJ" = (
+/obj/item/storage/toolbox/mechanical,
+/turf/open/ground/jungle/path,
+/area/whiskey_outpost/outside/west)
+"YO" = (
+/obj/machinery/light/small,
+/turf/open/ground/river,
+/area/whiskey_outpost)
 "YQ" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/platform_decoration{
@@ -6206,7 +7147,6 @@
 	},
 /area/whiskey_outpost)
 "Ze" = (
-/obj/machinery/vending/marine,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -6214,23 +7154,17 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/vending/marine/shared,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
 "Zj" = (
 /obj/machinery/miner/damaged/platinum,
-/turf/open/ground/jungle,
+/turf/open/ground/grass,
 /area/whiskey_outpost/outside/west)
 "Zt" = (
 /obj/structure/largecrate/guns,
 /turf/open/floor/plating/platebot,
 /area/whiskey_outpost)
-"Zv" = (
-/obj/structure/platform{
-	dir = 8
-	},
-/obj/structure/barricade/sandbags,
-/turf/open/floor/plating/ground/dirt,
-/area/whiskey_outpost/outside/north)
 "ZP" = (
 /obj/structure/barricade/metal,
 /obj/structure/barricade/metal{
@@ -6242,16 +7176,23 @@
 /obj/structure/sign/greencross/star{
 	pixel_y = 32
 	},
-/turf/open/ground/jungle,
+/obj/structure/largecrate/supply/ammo/sentry,
+/obj/item/stack/razorwire/full,
+/obj/item/stack/razorwire/full,
+/obj/item/stack/razorwire/full,
+/obj/item/stack/razorwire/full,
+/turf/open/ground/jungle/path,
 /area/whiskey_outpost/outside/east)
 "ZS" = (
 /obj/structure/largecrate/supply/supplies/plasteel,
 /turf/open/floor/plating,
 /area/whiskey_outpost/outside/north)
 "ZT" = (
-/obj/structure/barricade/sandbags,
 /obj/structure/barricade/sandbags{
 	dir = 8
+	},
+/obj/structure/barricade/sandbags{
+	pixel_y = -6
 	},
 /turf/open/floor/plating/asteroidwarning{
 	dir = 10
@@ -7487,141 +8428,141 @@ mv
 "}
 (9,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+sg
+sg
+sg
+sg
+sg
+sg
+sg
+sg
+sg
+sg
+sg
+sg
+sg
+sg
+sg
+sg
+sg
+sg
+sg
+sg
+sg
+sg
+sg
+sg
+sg
+sg
+sg
+sg
+sg
+sg
+sg
+sg
+sg
+sg
+sg
+sg
+sg
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
 mv
 mv
 mv
@@ -7640,25 +8581,7 @@ mv
 "}
 (10,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
 aS
 aS
 aS
@@ -7683,98 +8606,116 @@ aS
 aS
 aS
 aS
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -7793,25 +8734,25 @@ mv
 "}
 (11,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 aS
 dm
 dm
@@ -7854,80 +8795,80 @@ hB
 hB
 hB
 hB
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -7946,25 +8887,25 @@ mv
 "}
 (12,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 aS
 dm
 dm
@@ -7980,9 +8921,9 @@ dm
 dm
 dm
 dm
-dP
-dQ
-dQ
+ea
+ea
+ea
 ea
 dm
 dm
@@ -8013,34 +8954,33 @@ hB
 hB
 hB
 hB
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
 hB
 hB
 hB
 hB
 hB
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
+hB
 kz
 kz
 kz
@@ -8049,38 +8989,39 @@ kz
 kz
 kz
 kz
-hI
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -8099,18 +9040,7 @@ mv
 "}
 (13,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
 aS
 aS
 aS
@@ -8119,8 +9049,13 @@ aS
 aS
 aS
 aS
-dm
-dm
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 aS
 aS
 aS
@@ -8128,15 +9063,21 @@ aS
 dm
 dm
 aS
+aS
+aS
+aS
+dm
+dm
+aS
 dm
 dm
 dm
 dm
 dm
-dQ
-dU
+ea
+NO
 dW
-dQ
+ea
 dm
 dm
 dm
@@ -8178,10 +9119,11 @@ hB
 hB
 hB
 hB
-hB
 bd
 bd
 bd
+bd
+bd
 hB
 hB
 hB
@@ -8190,9 +9132,8 @@ hB
 hB
 hB
 hB
-kz
-kz
-kz
+hB
+hB
 kz
 kz
 lf
@@ -8203,37 +9144,37 @@ lf
 lf
 kz
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -8252,18 +9193,18 @@ mv
 "}
 (14,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-hI
-hI
-hI
-hI
-hI
-hI
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 aS
 aS
 aS
@@ -8343,9 +9284,9 @@ hB
 hB
 hw
 hw
-lf
-lf
-Td
+hw
+hw
+if
 lp
 lp
 lp
@@ -8356,37 +9297,37 @@ lg
 lf
 lf
 kz
-hI
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -8405,12 +9346,12 @@ mv
 "}
 (15,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
 aS
 aS
 aS
@@ -8442,7 +9383,7 @@ dm
 dQ
 dU
 dU
-dQ
+ea
 dm
 dm
 dm
@@ -8497,8 +9438,8 @@ iN
 hw
 hw
 hw
-lf
-ld
+hw
+hJ
 kA
 lk
 kA
@@ -8510,36 +9451,36 @@ lf
 lf
 kz
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -8558,28 +9499,9 @@ mv
 "}
 (16,1,1) = {"
 mv
-hI
-hI
-hI
-hI
-hI
-hI
+Xz
 aS
 aS
-aS
-aS
-aS
-aS
-aS
-aS
-dm
-dm
-dm
-dm
-dm
-dm
-dm
-dm
 aS
 aS
 aS
@@ -8592,10 +9514,29 @@ aS
 aS
 aS
 dm
-dQ
+dm
+dm
+dm
+dm
+dm
+dm
+dm
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+dm
+ea
 dV
 dX
-dQ
+ea
 dn
 dm
 dm
@@ -8636,7 +9577,7 @@ ix
 hw
 hw
 hw
-jH
+bd
 bd
 gF
 gF
@@ -8646,12 +9587,12 @@ hw
 PW
 hw
 PW
-mz
+iN
 hw
 hw
 hw
-lf
-le
+hw
+hK
 lj
 lj
 kA
@@ -8663,36 +9604,36 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -8711,11 +9652,11 @@ mv
 "}
 (17,1,1) = {"
 mv
-hI
+Xz
 aS
 aS
 aS
-aS
+ac
 aS
 aS
 aS
@@ -8745,10 +9686,10 @@ aS
 aS
 aS
 dm
-dR
-dQ
-dQ
-eb
+ea
+ea
+ea
+ea
 dm
 dm
 dm
@@ -8793,18 +9734,18 @@ Fz
 jI
 gF
 gF
-mt
-qm
+gF
+yN
 hw
 hw
 PW
 PW
-mz
+iN
 hw
 hw
 hw
-lf
-lf
+hw
+hw
 lf
 lf
 ld
@@ -8816,36 +9757,36 @@ lf
 lf
 lf
 kz
-hI
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -8864,12 +9805,12 @@ mv
 "}
 (18,1,1) = {"
 mv
-hI
+Xz
 aS
 aS
 aS
-aS
-aS
+AH
+dm
 aS
 dm
 dm
@@ -8941,11 +9882,11 @@ hq
 ix
 ek
 hw
-jH
+bd
 bd
 bN
 gF
-Hk
+gF
 gF
 yN
 hw
@@ -8957,7 +9898,7 @@ hw
 hw
 hw
 hw
-lf
+hw
 lf
 lf
 ld
@@ -8970,35 +9911,35 @@ lf
 lf
 kz
 kz
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -9017,7 +9958,7 @@ mv
 "}
 (19,1,1) = {"
 mv
-hI
+Xz
 aS
 aS
 dm
@@ -9104,8 +10045,8 @@ bd
 cQ
 hw
 hw
-Ci
-ZY
+PW
+HU
 hw
 hw
 hw
@@ -9144,14 +10085,14 @@ kz
 kz
 kz
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -9170,7 +10111,7 @@ mv
 "}
 (20,1,1) = {"
 mv
-hI
+Xz
 aS
 aS
 aS
@@ -9249,7 +10190,7 @@ hX
 hX
 bd
 SF
-jK
+bq
 bq
 bq
 bq
@@ -9291,20 +10232,20 @@ lf
 lf
 lf
 lf
-lf
-lf
-lf
-lf
-lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -9323,7 +10264,7 @@ mv
 "}
 (21,1,1) = {"
 mv
-hI
+Xz
 aS
 aS
 aS
@@ -9429,7 +10370,7 @@ lf
 lf
 lf
 lf
-kV
+lq
 lf
 lf
 gD
@@ -9447,17 +10388,17 @@ lf
 lf
 lf
 lf
-lf
-lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -9476,7 +10417,7 @@ mv
 "}
 (22,1,1) = {"
 mv
-hI
+Xz
 aS
 aS
 aS
@@ -9563,7 +10504,7 @@ Af
 hX
 PW
 PW
-Ci
+PW
 Cq
 hw
 hw
@@ -9582,7 +10523,7 @@ lf
 lf
 lf
 lf
-lf
+lq
 lf
 lf
 gx
@@ -9601,16 +10542,16 @@ lf
 lf
 lf
 lf
-lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -9629,7 +10570,7 @@ mv
 "}
 (23,1,1) = {"
 mv
-hI
+Xz
 aS
 aS
 aS
@@ -9735,7 +10676,7 @@ lf
 lf
 lf
 lf
-lT
+lq
 lf
 lf
 gx
@@ -9754,16 +10695,16 @@ lf
 lf
 lf
 lf
-lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -9782,7 +10723,7 @@ mv
 "}
 (24,1,1) = {"
 mv
-hI
+Xz
 aS
 aS
 dm
@@ -9888,7 +10829,7 @@ lf
 lf
 lf
 lf
-lT
+lq
 lf
 lf
 gx
@@ -9907,16 +10848,16 @@ lf
 lf
 lf
 lf
-lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -9935,7 +10876,7 @@ mv
 "}
 (25,1,1) = {"
 mv
-hI
+Xz
 aS
 aS
 dm
@@ -10062,14 +11003,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -10088,7 +11029,7 @@ mv
 "}
 (26,1,1) = {"
 mv
-hI
+Xz
 aS
 aS
 dm
@@ -10194,7 +11135,7 @@ lf
 lf
 lf
 lf
-lu
+lq
 lf
 lf
 gx
@@ -10215,14 +11156,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -10241,7 +11182,7 @@ mv
 "}
 (27,1,1) = {"
 mv
-hI
+Xz
 aS
 aS
 aS
@@ -10261,7 +11202,7 @@ rs
 rs
 qd
 OS
-qR
+ed
 Sn
 qt
 rs
@@ -10320,7 +11261,7 @@ hw
 hw
 bd
 NM
-mt
+gF
 gF
 gF
 gF
@@ -10328,8 +11269,8 @@ yN
 hw
 hw
 hw
-Ci
-ZY
+PW
+HU
 hw
 hw
 hw
@@ -10347,7 +11288,7 @@ lf
 lf
 lf
 lf
-kV
+lq
 lf
 lf
 gx
@@ -10368,14 +11309,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -10394,7 +11335,7 @@ mv
 "}
 (28,1,1) = {"
 mv
-hI
+Xz
 aS
 aS
 aS
@@ -10474,10 +11415,10 @@ hw
 Fz
 yG
 gF
-Hk
 gF
-mt
-qm
+gF
+gF
+yN
 hw
 hw
 hw
@@ -10500,7 +11441,7 @@ lf
 lf
 lf
 lf
-lf
+lq
 lf
 lf
 gD
@@ -10521,14 +11462,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -10547,7 +11488,7 @@ mv
 "}
 (29,1,1) = {"
 mv
-hI
+Xz
 aS
 aS
 aS
@@ -10674,14 +11615,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -10700,7 +11641,7 @@ mv
 "}
 (30,1,1) = {"
 mv
-hI
+Xz
 aS
 aS
 aS
@@ -10827,14 +11768,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -10853,7 +11794,7 @@ mv
 "}
 (31,1,1) = {"
 mv
-hI
+Xz
 aS
 aS
 aS
@@ -10980,14 +11921,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -11006,7 +11947,7 @@ mv
 "}
 (32,1,1) = {"
 mv
-hI
+Xz
 aS
 aS
 aS
@@ -11094,7 +12035,7 @@ hw
 hw
 PW
 PW
-mz
+iN
 hw
 hw
 hw
@@ -11133,14 +12074,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -11159,7 +12100,7 @@ mv
 "}
 (33,1,1) = {"
 mv
-hI
+Xz
 aS
 aS
 aS
@@ -11222,10 +12163,9 @@ hy
 hk
 sr
 hw
-hB
-hB
-hB
-hB
+LS
+LS
+LS
 hB
 hB
 hB
@@ -11240,7 +12180,8 @@ hB
 bd
 bd
 bd
-km
+bd
+bd
 hw
 In
 PW
@@ -11252,7 +12193,7 @@ hw
 hw
 if
 ik
-lg
+iw
 lf
 lf
 ld
@@ -11286,14 +12227,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -11312,7 +12253,7 @@ mv
 "}
 (34,1,1) = {"
 mv
-hI
+Xz
 aS
 aS
 aS
@@ -11374,11 +12315,11 @@ ho
 hy
 hw
 hw
-hB
-hB
-hB
-hB
-hB
+cm
+Sl
+VB
+Yw
+LS
 hB
 hB
 hB
@@ -11405,7 +12346,7 @@ hw
 hw
 hK
 hR
-kz
+hB
 lf
 lf
 ld
@@ -11439,14 +12380,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -11465,7 +12406,7 @@ mv
 "}
 (35,1,1) = {"
 mv
-hI
+Xz
 aS
 aS
 aS
@@ -11527,12 +12468,12 @@ ho
 hy
 hw
 hw
-hB
-hB
-hB
-hB
-hB
-hB
+LS
+VB
+Sl
+Vl
+hm
+hZ
 hB
 hB
 hB
@@ -11558,7 +12499,7 @@ hB
 hw
 hw
 hB
-kz
+hB
 kz
 kz
 kz
@@ -11592,14 +12533,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -11618,7 +12559,7 @@ mv
 "}
 (36,1,1) = {"
 mv
-hI
+Xz
 aS
 aS
 aS
@@ -11668,7 +12609,7 @@ fs
 fs
 of
 HH
-bo
+Uj
 FR
 nk
 bW
@@ -11680,13 +12621,13 @@ ho
 hy
 hB
 hB
-hB
-hB
-hB
-hB
-hB
-hB
-hB
+LS
+LS
+LS
+Vl
+Ij
+hm
+hm
 hB
 hB
 hB
@@ -11711,7 +12652,7 @@ hB
 hB
 hB
 hB
-kz
+hB
 kz
 kz
 kz
@@ -11745,14 +12686,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -11771,7 +12712,7 @@ mv
 "}
 (37,1,1) = {"
 mv
-hI
+Xz
 aS
 aS
 aS
@@ -11821,7 +12762,7 @@ fs
 fs
 of
 rE
-mt
+gF
 yN
 nk
 cy
@@ -11837,9 +12778,9 @@ hB
 hB
 hB
 hB
-hB
-hB
-hB
+pI
+hm
+hm
 hB
 hB
 hB
@@ -11864,7 +12805,7 @@ hB
 hB
 hB
 hB
-kz
+hB
 kz
 kz
 kz
@@ -11898,14 +12839,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -11924,7 +12865,7 @@ mv
 "}
 (38,1,1) = {"
 mv
-hI
+Xz
 aS
 aS
 bW
@@ -11990,9 +12931,9 @@ hB
 hB
 hB
 hB
-hB
-hB
-hB
+MP
+vW
+vW
 hB
 hB
 hB
@@ -12051,14 +12992,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -12077,7 +13018,7 @@ mv
 "}
 (39,1,1) = {"
 mv
-hI
+Xz
 aS
 aS
 bW
@@ -12142,10 +13083,10 @@ hB
 hB
 hB
 hB
-hB
-hB
-hB
-hB
+MP
+MP
+MA
+MA
 hB
 hB
 hB
@@ -12204,14 +13145,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -12230,7 +13171,7 @@ mv
 "}
 (40,1,1) = {"
 mv
-hI
+Xz
 aS
 aS
 bW
@@ -12295,10 +13236,10 @@ hB
 hB
 hB
 hB
-hB
-hB
-hB
-hB
+MP
+uI
+hm
+hm
 hB
 hB
 hB
@@ -12357,14 +13298,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -12383,7 +13324,7 @@ mv
 "}
 (41,1,1) = {"
 mv
-hI
+Xz
 aS
 aS
 bW
@@ -12446,12 +13387,12 @@ hB
 hB
 hB
 hB
-hB
-hB
-hB
-hB
-hB
-hB
+Je
+hX
+xW
+hm
+hm
+hm
 hB
 hB
 hB
@@ -12510,14 +13451,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -12536,7 +13477,7 @@ mv
 "}
 (42,1,1) = {"
 mv
-hI
+Xz
 aS
 aS
 bW
@@ -12598,12 +13539,12 @@ hB
 hB
 hB
 hB
-hB
-hB
-hB
-hB
-hB
-hB
+lE
+hX
+hX
+hX
+hX
+hZ
 hB
 hB
 hB
@@ -12663,14 +13604,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -12689,7 +13630,7 @@ mv
 "}
 (43,1,1) = {"
 mv
-hI
+Xz
 aS
 aS
 bW
@@ -12735,7 +13676,7 @@ bW
 bW
 bW
 bW
-Aq
+bW
 bW
 bW
 aS
@@ -12753,9 +13694,9 @@ hB
 hB
 hB
 hB
-hB
-hB
-hB
+NJ
+Iw
+NJ
 hB
 hB
 hB
@@ -12816,14 +13757,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -12842,7 +13783,7 @@ mv
 "}
 (44,1,1) = {"
 mv
-hI
+Xz
 aS
 aS
 aS
@@ -12969,14 +13910,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -12995,7 +13936,7 @@ mv
 "}
 (45,1,1) = {"
 mv
-hI
+Xz
 aS
 aS
 aS
@@ -13122,14 +14063,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -13148,7 +14089,7 @@ mv
 "}
 (46,1,1) = {"
 mv
-hI
+Xz
 aS
 aS
 ew
@@ -13275,14 +14216,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -13301,7 +14242,7 @@ mv
 "}
 (47,1,1) = {"
 mv
-hI
+Xz
 aS
 aS
 dj
@@ -13311,18 +14252,18 @@ aS
 aS
 aS
 aS
-Xz
-Xz
-Xz
-Xz
-Xz
-Xz
-Xz
-Xz
-Xz
-Xz
-Xz
-Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 aS
 bW
 bW
@@ -13428,14 +14369,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -13454,7 +14395,7 @@ mv
 "}
 (48,1,1) = {"
 mv
-hI
+Xz
 aS
 ew
 dk
@@ -13463,19 +14404,19 @@ aS
 aS
 aS
 aS
-hI
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 aS
 ng
 ng
@@ -13493,7 +14434,7 @@ ne
 ng
 qP
 Iv
-qR
+ed
 ZT
 nm
 ng
@@ -13507,7 +14448,7 @@ bW
 cy
 bW
 bW
-Mz
+tS
 dj
 cx
 cx
@@ -13551,7 +14492,7 @@ kz
 kz
 kz
 kz
-lf
+kV
 lf
 lf
 lf
@@ -13581,14 +14522,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -13607,28 +14548,28 @@ mv
 "}
 (49,1,1) = {"
 mv
-hI
+Xz
 aS
 dj
 cX
 ei
 aS
-hI
-hI
-hI
-hI
-mv
-mv
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-BR
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+ak
 ak
 Oq
 rt
@@ -13660,7 +14601,7 @@ bW
 bW
 bW
 bW
-Mz
+tS
 ex
 gt
 cx
@@ -13701,10 +14642,10 @@ hB
 kz
 kz
 kz
-lf
-lf
+kV
+kV
 lq
-lf
+kV
 lf
 lf
 lf
@@ -13734,14 +14675,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -13760,32 +14701,32 @@ mv
 "}
 (50,1,1) = {"
 mv
-hI
+Xz
 aS
 ex
 eu
 ej
 aS
-hI
-mv
-mv
-mv
-mv
-mv
-hI
+aS
+aS
+aS
 ac
 ac
 ac
 ac
 ac
-BZ
-BZ
-BZ
-ak
-TL
-OH
-rk
-rk
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+cZ
+ql
 rk
 rk
 rk
@@ -13853,11 +14794,11 @@ hB
 hB
 kz
 kz
-lf
-lf
-lf
+WF
 kV
-lf
+kV
+lq
+kV
 lf
 lf
 lf
@@ -13887,14 +14828,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -13913,30 +14854,32 @@ mv
 "}
 (51,1,1) = {"
 mv
-hI
+Xz
 aS
 aS
 aS
 aS
 aS
-hI
-mv
-mv
-mv
-mv
-mv
-hI
+aS
+aS
+aS
 ac
+Ck
+Mg
+QB
+Rh
 ki
 vl
-ro
-ac
+Fa
+Xm
+DH
+vy
 BZ
-BZ
-BZ
-ak
-jj
+Xm
+Rp
 Gs
+vX
+qm
 rk
 rk
 rk
@@ -13947,17 +14890,15 @@ rk
 rk
 rk
 rk
-rk
-rk
-rk
-bd
-bd
-bT
-bT
-bd
-bT
-bT
-bd
+Iy
+ac
+ac
+WA
+WA
+ac
+WA
+WA
+ac
 Mr
 rk
 pz
@@ -13967,7 +14908,7 @@ bW
 bW
 cK
 bW
-Mz
+tS
 dj
 cx
 hq
@@ -14004,14 +14945,14 @@ hw
 hB
 hB
 hB
-lf
-lf
-lf
-lf
+WF
+WF
+WF
+WF
+kV
+lq
 lf
 kV
-lf
-lf
 lf
 lf
 lf
@@ -14040,14 +14981,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -14066,32 +15007,32 @@ mv
 "}
 (52,1,1) = {"
 mv
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 ac
-qr
-rk
+Cp
+wj
+DQ
+Fm
+HQ
+HQ
 rl
 ac
 ac
+WA
+WA
+WA
 ac
 ac
-ac
-ac
-ac
-cZ
-ql
+Ws
+qm
 rk
 IN
 rk
@@ -14102,15 +15043,15 @@ rk
 Wm
 rk
 rk
-aR
-bd
-AR
-el
+Au
+ac
+NY
+NY
 HT
 AJ
 el
 yt
-bd
+ac
 pM
 mj
 pD
@@ -14120,7 +15061,7 @@ bW
 bW
 bW
 bW
-YM
+tS
 dj
 cx
 hq
@@ -14154,17 +15095,17 @@ hw
 hw
 hw
 hw
+PW
+Ru
 hB
-hB
-hB
-lf
-lf
-lf
-lf
-lf
+WF
+WF
+kV
+WF
+kV
 lq
 lf
-lf
+kV
 lf
 lf
 lf
@@ -14193,14 +15134,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -14219,51 +15160,51 @@ mv
 "}
 (53,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 ac
-rm
-rk
+mm
+NA
+GZ
+aA
+HQ
+HQ
 cH
 ac
 rc
-rk
+HQ
 co
-rk
+HQ
 qh
 qk
 sy
 qm
 rk
 yw
-cM
-dh
-kW
 rk
 rk
+Si
+qR
+OH
 rk
 yw
 rk
-rk
-bT
+LK
+WA
 el
 el
 el
 el
 el
 el
-bd
+ac
 Fb
 rk
 pD
@@ -14308,14 +15249,14 @@ hw
 hw
 hw
 PW
-ZY
-hB
-lf
-lf
-lf
-lf
-lf
+PW
+HW
+WF
+WF
 kV
+kV
+kV
+lq
 lf
 lf
 lf
@@ -14346,14 +15287,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -14372,26 +15313,26 @@ mv
 "}
 (54,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 ac
-aL
-rk
+HZ
+NA
+Ck
+KL
+HQ
+HQ
 qi
 ac
 rb
-rk
+HQ
 cq
 rd
 rf
@@ -14400,23 +15341,23 @@ da
 qn
 rk
 rk
-cN
-fa
-kX
+rk
+rk
+cO
 gA
-iu
-iu
-pn
+pM
 rk
 rk
-bT
+rk
+LK
+WA
 el
 lS
 lS
 lY
 lS
 lS
-bT
+WA
 rk
 rk
 pD
@@ -14461,16 +15402,16 @@ In
 hw
 hw
 PW
-RO
-hw
-lf
-lf
-lf
-lf
-lf
+PW
+Dq
+WF
+WF
 kV
-lf
-lf
+WF
+kV
+lq
+kV
+kV
 lf
 lf
 lf
@@ -14499,14 +15440,14 @@ Hq
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -14525,51 +15466,51 @@ mv
 "}
 (55,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 ac
-jr
-yw
-rk
-rk
-rk
-rk
-yw
-rk
+hf
+QY
+mm
+Ds
+HQ
+HQ
+HQ
+xM
+HQ
+HQ
+FW
+HQ
 rg
 bE
 bg
 rk
 rk
 rk
-cP
-fi
-kX
-gr
-cZ
-bo
-nz
 rk
 rk
-bd
+KJ
+dH
+Vq
+rk
+rk
+rk
+rk
+ac
 Py
 fc
 eP
 eA
 fb
 fK
-bT
+WA
 rk
 rk
 pD
@@ -14578,8 +15519,8 @@ bW
 of
 bd
 gE
-mt
-qm
+gF
+kJ
 oD
 cJ
 hq
@@ -14614,15 +15555,15 @@ bm
 hw
 hw
 PW
-iN
-hw
-lf
-lf
-lf
-lf
-lf
+PW
+Dq
+WF
+WF
+WF
+WF
+kV
 lq
-lf
+kV
 lf
 lf
 lf
@@ -14652,14 +15593,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -14678,41 +15619,41 @@ mv
 "}
 (56,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 ac
-be
-rk
+GZ
+tP
+mq
+UB
+HQ
+HQ
 Cp
 ac
-rk
-rk
-rk
-rk
-rk
+OW
+HQ
+HQ
+HQ
+UN
 ac
 bs
 rk
 mj
 rk
-cO
 rk
-pM
-gr
-bf
-ny
-pq
+rk
+rk
+rk
+rk
+rk
+rk
 rk
 rk
 we
@@ -14722,7 +15663,7 @@ lX
 lV
 lU
 lU
-bT
+WA
 jr
 rk
 pD
@@ -14745,18 +15686,18 @@ hG
 hL
 hk
 hk
-hw
+AB
 PW
 iN
+AB
+AB
 hw
 hw
-hw
-hw
-hw
-bm
-hw
-hw
-hw
+AB
+Ya
+AB
+AB
+AB
 hw
 hw
 hw
@@ -14767,15 +15708,15 @@ hw
 hw
 hw
 PW
-iN
-hw
-lf
-lf
-lf
-lf
-lf
+PW
+Dq
+WF
+WF
+WF
+WF
 kV
-lf
+lq
+kV
 Hq
 lf
 lf
@@ -14805,14 +15746,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -14831,41 +15772,41 @@ mv
 "}
 (57,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 ac
+tR
+HN
+Lr
+KS
 qy
-fm
+Ja
 DW
 ac
-rk
-fm
-rk
-rk
+MG
+HE
+HQ
+HQ
 UL
 ac
 bs
 rk
 rk
 rk
-cP
-fa
-kX
-gr
-da
-bq
-nz
+rk
+rk
+Si
+qR
+OH
+rk
+rk
 yw
 rk
 Gx
@@ -14875,7 +15816,7 @@ zi
 el
 el
 Cl
-bd
+ac
 TF
 rk
 pz
@@ -14884,8 +15825,8 @@ fs
 of
 bd
 gE
-mt
-qm
+gF
+kJ
 oD
 cx
 hq
@@ -14898,37 +15839,37 @@ hy
 hk
 hk
 hk
-hw
+AB
 PW
 Cq
-hw
+AB
 hX
-hw
-hw
-hw
+AB
+AB
+AB
 hX
-hw
+AB
 hX
 hX
+AB
+AB
+AB
 hw
 hw
 hw
-hw
-hw
-hw
-hw
+BO
 hw
 hw
 Ci
 WR
-hw
-lf
-lf
-lf
-lf
-lf
+HU
+WF
+WF
+WF
 kV
-lf
+kV
+lq
+kV
 lf
 lf
 lf
@@ -14958,14 +15899,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -14984,18 +15925,18 @@ mv
 "}
 (58,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+ac
+ac
+ac
 ac
 ac
 ac
@@ -15012,23 +15953,23 @@ bs
 rk
 rk
 rk
-cP
-jN
-kX
-nF
-iv
-iv
-po
 rk
 rk
-bd
+cO
+gA
+pM
+rk
+rk
+rk
+rk
+ac
 bC
 lS
 lS
 lS
 mg
 lS
-bT
+WA
 Uk
 rk
 pD
@@ -15051,21 +15992,21 @@ hz
 hx
 iI
 hk
-hw
+AB
 PW
 Cq
 hX
-hw
-hw
-hw
+AB
+AB
+AB
 WE
-hw
-hw
+AB
+AB
 hX
 hX
 hX
 hX
-bm
+Ya
 hX
 hw
 hw
@@ -15073,14 +16014,36 @@ hw
 hw
 hw
 PW
-iN
-hw
-lf
-lf
-lf
-lf
-lf
+PW
+Dq
+WF
+WF
+WF
+kV
+kV
 lq
+kV
+lf
+lf
+lf
+lf
+lf
+lf
+kz
+lf
+lf
+lf
+gx
+gx
+gx
+gx
+lf
+lf
+lf
+lf
+lf
+lf
+lf
 lf
 lf
 lf
@@ -15089,36 +16052,14 @@ lf
 lf
 lf
 kz
-lf
-lf
-lf
-gx
-gx
-gx
-gx
-lf
-lf
-lf
-lf
-lf
-lf
-lf
-lf
-lf
-lf
-lf
-lf
-lf
-lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -15137,19 +16078,19 @@ mv
 "}
 (59,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-ac
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+ak
+ak
 uQ
 Cj
 sO
@@ -15165,23 +16106,23 @@ rk
 yw
 rk
 rk
-cY
-kS
-lh
+rk
+rk
+KJ
+dH
+Vq
 rk
 rk
 rk
 rk
-rk
-rk
-bT
+WA
 el
 eD
 Ip
 fw
 fk
 gb
-bT
+WA
 rk
 rk
 pD
@@ -15191,7 +16132,7 @@ FD
 ns
 ns
 ns
-Zv
+Fi
 pi
 cx
 hq
@@ -15204,38 +16145,38 @@ hm
 hy
 JX
 hk
-hw
+AB
 hX
 Cq
-In
-bm
+OR
+Ya
 hX
 hX
-hw
-hw
-hw
-hw
+AB
+AB
+AB
+AB
 hX
 hX
-hw
-hw
-hw
-hw
+AB
+AB
+AB
+AB
 hw
 hw
 hw
 hw
 PW
-iN
-hw
-lf
-lf
-lf
-lf
-lf
+PW
+Dq
+WF
+WF
+WF
 kV
-lf
-lf
+kV
+lq
+kV
+kV
 lf
 lf
 lf
@@ -15264,14 +16205,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -15290,19 +16231,19 @@ mv
 "}
 (60,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-ac
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+Sj
+ak
+ak
 gG
 QH
 QH
@@ -15327,14 +16268,14 @@ rk
 rk
 rk
 rk
-bT
+WA
 el
 lV
 lU
 mb
 lU
 lU
-bT
+WA
 uQ
 rk
 pz
@@ -15344,7 +16285,7 @@ bW
 bW
 bW
 bW
-Mz
+tS
 dj
 cx
 hq
@@ -15356,39 +16297,39 @@ hm
 hm
 hy
 hk
-hw
-hw
+AB
+AB
 PW
 GR
+AB
+AB
 hw
 hw
 hw
-hw
-hw
-hw
-hw
-hw
-hw
-hw
-hw
+AB
+AB
+AB
+AB
+AB
+AB
 hX
 YU
-hw
+AB
 hw
 hw
 hw
 bm
 PW
-iN
-hw
-lf
-lf
-lf
-lf
+PW
+Dq
+WF
+WF
+WF
+WF
+kV
+lq
 lf
 kV
-lf
-lf
 lf
 lf
 lf
@@ -15417,14 +16358,14 @@ lf
 lf
 lf
 kz
-hI
-hI
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -15443,19 +16384,19 @@ mv
 "}
 (61,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-hI
-ac
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+fs
+aS
+ak
+rk
 QH
 rk
 rk
@@ -15480,14 +16421,14 @@ rk
 rk
 rk
 fv
-bd
+ac
 eT
 eF
 fl
 fd
 fY
 fx
-bd
+ac
 uQ
 rk
 pD
@@ -15497,7 +16438,7 @@ um
 bW
 bW
 bW
-Mz
+tS
 dj
 cx
 hq
@@ -15519,29 +16460,29 @@ hw
 hw
 bm
 hw
-hw
-In
-hw
-hw
-hw
+AB
+OR
+AB
+AB
+AB
 vP
 hX
+AB
+AB
+AB
 hw
-hw
-hw
-hw
-In
+OR
 PW
-iN
-hw
-lf
-lf
-lf
-lf
-lf
+PW
+Dq
+WF
+WF
+kV
+WF
+kV
 lq
 lf
-lf
+kV
 lf
 lf
 lf
@@ -15571,13 +16512,13 @@ lf
 lf
 kz
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -15596,18 +16537,18 @@ mv
 "}
 (62,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-BA
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+ac
 ac
 EX
 AQ
@@ -15633,14 +16574,14 @@ rk
 mj
 rk
 ib
-bd
-bd
+ac
+ac
 WA
 WA
-bd
-bT
-bT
-bd
+ac
+WA
+WA
+ac
 uQ
 Wm
 pD
@@ -15663,7 +16604,7 @@ hm
 hy
 hk
 hX
-hw
+AB
 PW
 iN
 hw
@@ -15672,27 +16613,27 @@ hw
 hw
 hw
 hw
-hw
-hw
-hw
-hw
-hw
+AB
+AB
+AB
+AB
+AB
 hX
-hw
+AB
 hX
-hw
-hw
-hw
-hw
+AB
+AB
+AB
+AB
 PW
-iN
-hw
-lf
-lf
-lf
-lf
-lf
+PW
+Dq
+WF
+WF
 kV
+WF
+kV
+lq
 lf
 lf
 lf
@@ -15724,13 +16665,13 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -15749,18 +16690,18 @@ mv
 "}
 (63,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-BA
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+ac
 ER
 VJ
 Nd
@@ -15802,7 +16743,7 @@ bW
 fs
 fS
 gc
-Mz
+tS
 bW
 dj
 cx
@@ -15828,24 +16769,24 @@ hw
 hw
 hB
 Zj
-hw
-hw
-hw
-hw
-hw
-hw
-hw
-hw
-hw
+hk
+AB
+AB
+AB
+AB
+AB
+AB
+YJ
+Cv
 PW
-iN
-hw
-lf
-lf
-lf
-lf
-lf
+PW
+Dq
+WF
+WF
+WF
 kV
+kV
+lq
 lf
 lf
 lf
@@ -15877,13 +16818,13 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -15902,18 +16843,18 @@ mv
 "}
 (64,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-BA
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+ac
 Bd
 aG
 Hs
@@ -15924,7 +16865,7 @@ aW
 bk
 bk
 bM
-bQ
+gK
 bk
 bk
 bP
@@ -15955,7 +16896,7 @@ bW
 fs
 fX
 gH
-Mz
+tS
 bW
 dj
 cX
@@ -15981,25 +16922,25 @@ hB
 hB
 hB
 hB
-hw
-hw
-hw
-hw
+hk
+hk
+hk
+hk
 RT
-hw
+AB
 hX
-hw
-hw
+AB
+AB
 PW
-iN
-hw
-lf
-lf
-lf
-lf
-lf
+PW
+Dq
+WF
+WF
+WF
+kV
+kV
 lq
-lf
+kV
 lf
 lf
 lf
@@ -16030,13 +16971,13 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -16055,18 +16996,18 @@ mv
 "}
 (65,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-BA
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+ac
+ud
+ac
+ac
 AW
 ij
 RE
@@ -16108,7 +17049,7 @@ nj
 bW
 fX
 gH
-Mz
+tS
 bW
 dj
 cx
@@ -16134,24 +17075,24 @@ hB
 hB
 hB
 hB
-hw
-hw
-hw
-hw
-hw
-Lo
+Yc
+NZ
+Yc
+tX
+hk
+vH
 Pt
-hw
-hw
+AB
+Gi
 PW
-iN
-hw
-lf
-lf
-lf
-lf
-lf
-lf
+PW
+Dq
+WF
+WF
+WF
+kV
+kV
+lq
 lf
 lf
 lf
@@ -16183,13 +17124,13 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -16208,18 +17149,18 @@ mv
 "}
 (66,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-BA
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+ac
+Ny
+vb
+ac
 JB
 aG
 RE
@@ -16261,7 +17202,7 @@ nk
 bW
 fX
 gH
-Mz
+tS
 bW
 dj
 cx
@@ -16274,10 +17215,8 @@ TP
 hz
 hx
 hX
-hw
-hw
-hB
-hB
+AB
+AB
 hB
 hB
 hB
@@ -16287,25 +17226,27 @@ hB
 hB
 hB
 bd
+bd
+bd
 WA
 WA
 WA
 bd
-kl
-hX
-hX
-hw
-hw
+bd
+uo
+EI
+AB
+CD
 PW
-iN
-hw
-lf
-lf
-lf
-lf
-lf
-lf
-lf
+PW
+Dq
+WF
+WF
+WF
+WF
+kV
+lq
+kV
 lf
 lf
 lf
@@ -16336,13 +17277,13 @@ lf
 lf
 lf
 kz
-hI
-hI
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -16361,18 +17302,18 @@ mv
 "}
 (67,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-BA
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+ac
+sK
+bk
+ac
 zX
 Tx
 TJ
@@ -16409,7 +17350,7 @@ UU
 rk
 rk
 pN
-pM
+Ay
 nk
 bW
 fX
@@ -16427,9 +17368,9 @@ TP
 hX
 hX
 hX
-hw
-hw
-hw
+AB
+AB
+AB
 hB
 hB
 hB
@@ -16437,7 +17378,7 @@ hB
 hB
 hB
 hB
-hB
+bd
 bd
 bF
 bN
@@ -16448,17 +17389,17 @@ bd
 TL
 hX
 vP
-bm
+Ya
 Ci
-ZY
-hw
-lf
-lf
-lf
-lf
-lf
+PW
+HU
+WF
+WF
+WF
+WF
+kV
 lq
-lf
+kV
 lf
 lf
 lf
@@ -16490,12 +17431,12 @@ lf
 lf
 kz
 kz
-hI
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -16514,18 +17455,18 @@ mv
 "}
 (68,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-BA
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+ac
+ac
+yf
+ac
 ac
 ac
 ac
@@ -16580,9 +17521,9 @@ YQ
 hX
 hX
 hk
-hw
-hw
-hw
+AB
+AB
+AB
 hB
 hB
 hB
@@ -16600,18 +17541,18 @@ Ct
 bd
 wt
 hX
-hX
+EI
 hX
 PW
-iN
-hw
-lf
-lf
-lf
-lf
-lf
+PW
+Dq
+WF
+WF
 kV
-lf
+kV
+kV
+lq
+kV
 lf
 lf
 lf
@@ -16643,12 +17584,12 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -16667,22 +17608,22 @@ mv
 "}
 (69,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-hI
-hI
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 ac
-at
+uy
+SB
+Bo
+Sg
+ET
+ac
+BH
 at
 at
 at
@@ -16733,8 +17674,8 @@ hX
 hX
 IZ
 hw
-hw
-hw
+AB
+AB
 hB
 hB
 hB
@@ -16751,19 +17692,19 @@ bk
 bk
 bk
 WA
-hw
-my
-hw
-hX
+Ab
+CA
+AB
+Pt
+JA
 PW
-iN
-hw
-lf
-lf
-lf
-lf
-lf
+Dq
+WF
+WF
+WF
 kV
+kV
+lq
 lf
 lf
 lf
@@ -16796,12 +17737,12 @@ lf
 lf
 lf
 kz
-hI
-hI
-hI
-hI
-hI
-hI
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -16820,24 +17761,24 @@ mv
 "}
 (70,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 ac
-au
-au
-au
+GD
+HQ
+HQ
+HQ
+sL
+RA
+OC
+MS
+US
 au
 ac
 bk
@@ -16885,9 +17826,9 @@ hX
 hX
 hX
 hy
-hw
-hw
-hw
+AB
+AB
+AB
 hB
 hB
 hB
@@ -16904,18 +17845,18 @@ bk
 cb
 bk
 bz
-hX
+RN
 vP
 hX
-hw
+AB
 PW
-iN
-hw
-lf
-lf
-lf
-fO
-lf
+PW
+Dq
+WF
+WF
+WF
+Is
+kV
 lr
 lf
 lf
@@ -16929,7 +17870,7 @@ lf
 lf
 lf
 lf
-ma
+lf
 lf
 lf
 lf
@@ -16954,7 +17895,7 @@ kz
 kz
 kz
 kz
-hI
+qq
 mv
 mv
 mv
@@ -16973,25 +17914,25 @@ mv
 "}
 (71,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 ac
+Jq
+HQ
+FW
+HQ
+sL
+RA
 av
-kM
-az
-az
+FW
+HQ
+HQ
 bl
 th
 bk
@@ -17038,9 +17979,9 @@ hX
 hX
 hX
 hy
-hw
-hw
-hw
+AB
+AB
+AB
 hB
 IZ
 hX
@@ -17059,17 +18000,17 @@ Kn
 bd
 zM
 hX
-hX
-hw
+sM
+AB
 PW
-iN
-hw
-lf
-lf
-lf
-lf
-lf
-lf
+PW
+Dq
+WF
+WF
+WF
+kV
+kV
+kV
 Om
 lf
 lf
@@ -17077,7 +18018,7 @@ lf
 lf
 lf
 lf
-lf
+hd
 lf
 lf
 lf
@@ -17105,9 +18046,9 @@ ml
 ml
 ml
 ml
-kz
-kz
-hI
+ml
+ml
+qq
 mv
 mv
 mv
@@ -17126,24 +18067,24 @@ mv
 "}
 (72,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 ac
+SB
+HQ
+HQ
+HQ
+gC
+RA
 ck
-az
-az
+HQ
+HQ
 aY
 ac
 aV
@@ -17193,7 +18134,7 @@ gZ
 gZ
 gZ
 st
-iB
+Pj
 Mo
 Mo
 Ji
@@ -17211,19 +18152,19 @@ bk
 bk
 Jt
 hX
-hX
+Lo
 PW
 hX
+MZ
 PW
-Cq
-hX
+KO
 Om
-lf
-lf
-lf
-lf
-lf
-lf
+WF
+kV
+WF
+kV
+kV
+kV
 Om
 Om
 Om
@@ -17252,15 +18193,15 @@ Om
 Om
 Om
 Om
+lf
 Om
 Om
 Om
 Om
 Om
-Om
-Om
-kz
-hI
+Sz
+CB
+qq
 mv
 mv
 mv
@@ -17279,24 +18220,24 @@ mv
 "}
 (73,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-hI
-hI
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+ac
+Xf
+XQ
+CR
+Ek
+Lv
 ac
 ac
-aJ
-az
+HQ
+HQ
 aZ
 ac
 bn
@@ -17304,8 +18245,8 @@ bk
 bk
 bS
 bk
-bk
-bk
+IB
+XY
 bk
 cS
 rk
@@ -17345,8 +18286,8 @@ gZ
 gZ
 il
 gZ
-iB
-iB
+Pj
+Pj
 gZ
 hc
 hc
@@ -17368,20 +18309,20 @@ gZ
 gZ
 ww
 gZ
-Ol
-gZ
-lf
+uS
+PD
+WF
 Om
-lf
-lf
+WF
+WF
 Om
-lf
+kV
 Om
 Yi
 lf
 lf
 lf
-hd
+lf
 Om
 Om
 Om
@@ -17410,10 +18351,10 @@ Om
 Om
 Om
 Om
-lf
 Om
-kz
-hI
+Om
+CB
+qq
 mv
 mv
 mv
@@ -17432,33 +18373,33 @@ mv
 "}
 (74,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+ac
+ac
+ac
 ac
 ac
 ac
 ac
 ax
-az
-az
+HQ
+HQ
 ay
 ac
-bT
+WA
 bV
-bT
+WA
 ac
-bT
-bT
-bT
+WA
+WA
+WA
 cp
 ac
 SL
@@ -17498,7 +18439,7 @@ pj
 hg
 gZ
 gZ
-iB
+Pj
 iz
 hc
 hc
@@ -17518,17 +18459,17 @@ mG
 Jt
 Pv
 gZ
+Me
 gZ
 gZ
 gZ
 PD
-gZ
-lf
+WF
 Om
-lf
+WF
 Om
 Om
-lf
+kV
 Om
 Om
 lf
@@ -17561,12 +18502,12 @@ Om
 Om
 Om
 Om
-lf
 Om
 Om
 Om
-kz
-hI
+Om
+CB
+qq
 mv
 mv
 mv
@@ -17585,23 +18526,23 @@ mv
 "}
 (75,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 ac
+ah
+Jj
 Jj
 ah
 ac
 cR
-az
+HQ
 cT
 bc
 ac
@@ -17652,7 +18593,7 @@ Mf
 gZ
 iq
 gZ
-iB
+Pj
 iB
 hc
 hc
@@ -17674,16 +18615,16 @@ Pv
 Mp
 es
 gZ
-PD
 gZ
+PD
 xV
 Om
-lf
-lf
-lf
-lf
-lf
-lf
+WF
+kV
+kV
+kV
+kV
+kV
 lf
 lf
 Om
@@ -17710,16 +18651,16 @@ Om
 Om
 lf
 lf
+lf
+Om
+lf
+lf
 Om
 Om
 Om
 Om
-Om
-Om
-Om
-Om
-kz
-hI
+CB
+qq
 mv
 mv
 mv
@@ -17738,31 +18679,31 @@ mv
 "}
 (76,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 ac
+OQ
+ae
 ae
 ae
 al
-az
-az
-az
+HQ
+HQ
+HQ
 kN
 ac
 qA
 bk
 qY
-bT
-cV
+WA
+tT
 bk
 bk
 bk
@@ -17786,13 +18727,13 @@ rk
 rk
 rk
 pN
-pM
+Ay
 nk
 um
 bW
 fS
 gc
-Mz
+tS
 bW
 dj
 hH
@@ -17803,9 +18744,9 @@ hg
 hg
 Mf
 il
-iB
+Pj
 gZ
-iB
+Pj
 iB
 hc
 hc
@@ -17822,22 +18763,22 @@ bk
 Kn
 bd
 bz
-es
+kf
 gZ
-gZ
+VI
 gZ
 Pv
-it
-iB
-lf
-lf
-gN
-lf
-lf
-ls
-ge
-ge
-ls
+Pv
+wJ
+WF
+WF
+HJ
+kV
+kV
+ac
+WA
+WA
+ac
 lf
 fO
 lf
@@ -17872,7 +18813,7 @@ ml
 ml
 ml
 ml
-hI
+qq
 mv
 mv
 mv
@@ -17891,25 +18832,25 @@ mv
 "}
 (77,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 ac
 af
 ae
+ae
+RC
 ac
-EF
-az
-az
-kN
+HQ
+HQ
+HQ
+BM
 ac
 qB
 bk
@@ -17928,13 +18869,13 @@ rk
 rk
 rk
 rk
-bd
-bd
+ac
+ac
 WA
 WA
 WA
-bd
-bd
+ac
+ac
 rk
 rk
 rk
@@ -17957,8 +18898,8 @@ hg
 Mf
 il
 gZ
-iB
-iB
+Pj
+Pj
 iB
 hc
 hc
@@ -17975,29 +18916,29 @@ bk
 bk
 Wq
 bd
-iB
+Ab
 gZ
 gZ
-iB
+Pj
 Pv
-it
-iB
-lf
-lf
-lf
-lf
-lf
-ls
+Pv
+wJ
+WF
+WF
+WF
+kV
+kV
+ac
 lt
 lC
-lG
-lN
-lN
-lN
-lN
-lN
-lN
-lN
+WA
+lf
+lf
+lf
+lf
+lf
+lf
+hd
 lN
 lN
 lN
@@ -18025,7 +18966,7 @@ kz
 kz
 kz
 kz
-hI
+qq
 mv
 mv
 mv
@@ -18044,22 +18985,22 @@ mv
 "}
 (78,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 ac
+tp
+BX
 ag
 ai
 ac
-az
+HQ
 az
 xh
 gO
@@ -18081,13 +19022,13 @@ rk
 rk
 rk
 aR
-bd
+ac
 ep
 eH
 eU
 fe
 fn
-bd
+ac
 jq
 rk
 rk
@@ -18111,8 +19052,8 @@ Mf
 il
 gZ
 gZ
-iB
-iB
+Pj
+Pj
 hc
 hc
 hc
@@ -18133,22 +19074,22 @@ gZ
 sV
 gZ
 Pv
-it
-iB
-lf
-lf
-lf
-lf
-lf
-lt
-lt
+Pv
+wJ
+WF
+WF
+kV
+WF
+kV
+Uu
+Pp
 lD
-ge
+WA
 lf
 lf
 lf
 lf
-hd
+lf
 lf
 lf
 lf
@@ -18173,12 +19114,12 @@ lf
 lf
 kz
 kz
-hI
-hI
-hI
-hI
+kz
+kz
+kz
+kz
+kz
 qq
-hI
 mv
 mv
 mv
@@ -18197,22 +19138,22 @@ mv
 "}
 (79,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 ac
 ac
 ac
 ac
-az
+ac
+ac
+vc
 ac
 ac
 ac
@@ -18234,7 +19175,7 @@ rk
 rk
 rk
 gi
-bd
+ac
 eq
 eI
 eI
@@ -18264,8 +19205,8 @@ hg
 il
 iq
 gZ
-iB
-iB
+Pj
+Pj
 hc
 hc
 hc
@@ -18273,7 +19214,7 @@ hc
 hc
 hc
 hc
-hc
+bd
 bd
 Lt
 Ez
@@ -18282,21 +19223,21 @@ bU
 bn
 bd
 wt
-iB
+Pj
 gZ
 gZ
+Qr
 Pv
-it
-iB
-lf
-lf
-lf
-lf
-lf
-ls
-ge
-ge
-ls
+wJ
+WF
+WF
+kV
+kV
+kV
+ac
+WA
+WA
+ac
 lf
 lf
 lf
@@ -18325,13 +19266,13 @@ lf
 lf
 kz
 kz
-hI
-hI
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -18350,22 +19291,22 @@ mv
 "}
 (80,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-hI
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 ac
 kk
-az
+HQ
 ac
 aP
 bB
@@ -18405,7 +19346,7 @@ fs
 bW
 bW
 bW
-Mz
+tS
 dj
 cx
 gU
@@ -18418,7 +19359,7 @@ im
 is
 iz
 gZ
-iB
+Pj
 io
 Pv
 hc
@@ -18426,27 +19367,27 @@ hc
 hc
 hc
 hc
-hc
-hc
+bd
+bd
 bd
 WA
 WA
 WA
 bd
-AM
-iB
-iB
-iB
-iB
+bd
+Pj
+Pj
+Pj
+Pj
 mW
-kU
-iB
-lf
-lf
-lf
-lf
-lf
-lu
+Pv
+vU
+WF
+WF
+WF
+kV
+kV
+lq
 lf
 lf
 lf
@@ -18477,14 +19418,14 @@ lf
 lf
 lf
 kz
-hI
-hI
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -18503,22 +19444,22 @@ mv
 "}
 (81,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 ac
 kp
-Bg
+HQ
 ac
 rk
 rk
@@ -18558,7 +19499,7 @@ bW
 bW
 bW
 bW
-Mz
+tS
 dj
 cx
 gU
@@ -18571,8 +19512,8 @@ hg
 il
 iq
 gZ
-iB
-iB
+Pj
+Pj
 Pv
 it
 iB
@@ -18584,23 +19525,23 @@ hc
 iB
 iB
 iB
-iB
-iB
-iB
-iB
+Pj
+Pj
+Pj
+Pj
 gZ
 EL
-iB
+CW
 Pv
-it
-iB
-lf
-lf
-lf
-lf
-lf
+Pv
+wJ
+WF
+WF
+WF
 kV
-lf
+kV
+lq
+kV
 lf
 lf
 lf
@@ -18630,14 +19571,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -18656,22 +19597,22 @@ mv
 "}
 (82,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-hI
-hI
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 ac
-ac
-ac
+ug
+HQ
 ac
 ba
 bb
@@ -18693,7 +19634,7 @@ yr
 rk
 rk
 gj
-bd
+ac
 bG
 eJ
 eJ
@@ -18711,7 +19652,7 @@ bW
 bW
 bW
 bW
-Mz
+tS
 dj
 cx
 gU
@@ -18723,9 +19664,9 @@ hg
 Jf
 il
 iq
-iB
+Pj
 gZ
-iB
+Pj
 Pv
 it
 iB
@@ -18735,25 +19676,25 @@ iB
 hc
 hc
 iB
-iB
-iB
-iB
-iB
+Pj
+Pj
+Pj
+Pj
 gZ
 sv
 gZ
 gZ
-iB
+Pj
 Pv
-it
-iB
-lf
-lf
-lf
-lf
-lf
+Pv
+wJ
+WF
+WF
 kV
-lf
+kV
+kV
+lq
+kV
 lf
 lf
 lf
@@ -18783,14 +19724,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -18809,50 +19750,50 @@ mv
 "}
 (83,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-BZ
-bd
-bd
-bd
-bd
-bd
-bd
-bd
-bd
-bd
-bd
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
 Iq
 rk
 rk
-bd
-bd
+ac
+ac
 WA
-bd
-bd
-bd
-bd
-bd
-bd
-bd
+ac
+ac
+ac
+ac
+ac
+ac
+ac
 rk
 rk
 aR
-bd
+ac
 et
 eK
 eX
 fg
 fr
-bd
+ac
 sS
 rk
 rk
@@ -18864,7 +19805,7 @@ bW
 cw
 bW
 bW
-YM
+tS
 dj
 cx
 gU
@@ -18877,36 +19818,36 @@ hg
 il
 iq
 iq
-iB
+Pj
 gZ
 Pv
 it
 iB
 iB
-iB
-iB
-iB
-iB
-iB
-iB
-iB
-iB
+Pj
+Pj
+Pj
+Pj
+Pj
+Pj
+Pj
+Pj
 gZ
-iB
-iB
-iB
+Pj
+Pj
+Pj
 gZ
-iB
+Pj
 Pv
-it
-iB
-lf
-lf
-lf
-lf
-lf
+Pv
+wJ
+WF
+WF
+kV
+kV
+kV
 lq
-lf
+kV
 lf
 lf
 lf
@@ -18936,14 +19877,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -18962,18 +19903,18 @@ mv
 "}
 (84,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-BZ
-bd
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+ac
 Am
 tU
 xU
@@ -18982,11 +19923,11 @@ BK
 AY
 cd
 ee
-bd
+ac
 bK
 rk
 aR
-bd
+ac
 eE
 YY
 Kp
@@ -18995,17 +19936,17 @@ eR
 EG
 kO
 jT
-bd
+ac
 YG
 rk
 lQ
-bd
-bd
+ac
+ac
 WA
 WA
 WA
-bd
-bd
+ac
+ac
 rk
 rk
 mj
@@ -19030,36 +19971,36 @@ hg
 il
 iq
 iq
-iB
+Pj
 gZ
 Pv
 it
-iB
-iB
-iB
-iB
-iB
-iB
-iB
-iB
-iB
-iB
+Pj
+Pj
+Pj
+Pj
+Pj
+Pj
+Pj
+Pj
+Pj
+Pj
 gZ
-iB
-iB
-iB
-iB
-iB
+Pj
+Pj
+Pj
+Pj
+Pj
 Pv
-it
-iB
-lf
-lf
-sw
-lf
-lf
+Pv
+wJ
+WF
+WF
+zW
+WF
 kV
-lf
+lq
+kV
 lf
 hd
 lN
@@ -19089,14 +20030,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -19115,18 +20056,18 @@ mv
 "}
 (85,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-BZ
-bd
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+ac
 HF
 fR
 Mk
@@ -19139,7 +20080,7 @@ WA
 rk
 rk
 IN
-bd
+ac
 KM
 fR
 Mk
@@ -19183,36 +20124,36 @@ hg
 il
 iq
 iq
-iB
-iB
+Pj
+Pj
 Pv
 yq
-iB
+Pj
 gZ
-iB
-iB
+Pj
+Pj
 st
-iB
-iB
+Pj
+Pj
 gZ
 gZ
-iB
+Pj
 gZ
 SS
 gZ
-iB
-iB
-iB
+Pj
+Pj
+Pj
 Pv
-it
-iB
-lf
-lf
-lf
-lf
-lf
+Pv
+wJ
+WF
+WF
+WF
+WF
 kV
-lf
+lq
+kV
 lf
 lf
 lf
@@ -19242,14 +20183,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -19268,18 +20209,18 @@ mv
 "}
 (86,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-BZ
-bd
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+ac
 OD
 ci
 ci
@@ -19292,7 +20233,7 @@ vM
 rk
 rk
 rk
-bd
+ac
 CU
 gg
 tZ
@@ -19322,8 +20263,8 @@ fs
 of
 bd
 gE
-mt
-qm
+gF
+kJ
 oD
 cx
 gU
@@ -19336,34 +20277,34 @@ hg
 im
 is
 io
-iB
+Pj
 gZ
 Pv
 Ol
-iB
-iB
+Pj
+Pj
 gZ
-iB
-iB
+Pj
+Pj
 gZ
 gZ
-iB
-iB
-iB
-iB
-iB
-iB
-iB
-iB
+Pj
+Pj
+Pj
+Pj
+Pj
+Pj
+Pj
+Pj
 iB
 Pv
-it
-iB
-lf
-lf
-lf
-lf
-lf
+Pv
+wJ
+WF
+WF
+WF
+WF
+kV
 lq
 lf
 lf
@@ -19395,14 +20336,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -19421,18 +20362,18 @@ mv
 "}
 (87,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-BZ
-bd
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+ac
 uE
 cl
 cl
@@ -19445,7 +20386,7 @@ rk
 rk
 yw
 rk
-bd
+ac
 Et
 gh
 gh
@@ -19464,7 +20405,7 @@ xt
 dw
 pp
 rP
-dH
+CK
 Er
 pb
 nt
@@ -19494,31 +20435,31 @@ is
 Pv
 yq
 gZ
-iB
+Pj
 gZ
 Mp
-iB
-iB
-iB
-iB
+Pj
+Pj
+Pj
+Pj
 gZ
-iB
-iB
-iB
-iB
-iB
+Pj
+Pj
+Pj
+Pj
 iB
 iB
 iB
 Pv
-DC
-lf
-lf
-lf
-lf
-lf
-lf
-lf
+Pv
+wJ
+WF
+WF
+kV
+kV
+kV
+lq
+kV
 lf
 lf
 lf
@@ -19548,14 +20489,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -19574,37 +20515,37 @@ mv
 "}
 (88,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-BZ
-bd
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+ac
 Cd
 fR
 AL
 zw
-AL
-zw
+AE
+MO
 AL
 Tv
 WA
 rk
 rk
 rk
-bd
+ac
 XI
 fR
 AL
 zw
-AL
-zw
+AE
+MO
 AL
 uw
 WA
@@ -19628,8 +20569,8 @@ bW
 of
 bd
 gE
-mt
-qm
+gF
+kJ
 oD
 cx
 gU
@@ -19646,32 +20587,32 @@ hg
 il
 Pv
 it
-iB
-iB
-iB
-iB
-iB
-iB
+Pj
+Pj
+Pj
+Pj
+Pj
+Pj
 hc
 hc
 hc
+Pj
 iB
 iB
 iB
 iB
 iB
 iB
-iB
-em
+Oy
 Pv
-it
-lf
-lf
-lf
-lf
-lf
+vU
+WF
+WF
+WF
 kV
-lf
+kV
+lq
+kV
 lf
 lf
 lf
@@ -19701,14 +20642,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -19727,18 +20668,18 @@ mv
 "}
 (89,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-BZ
-bd
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+ac
 xu
 ED
 XW
@@ -19747,11 +20688,11 @@ sB
 Rm
 EY
 QJ
-bd
+ac
 bK
 rk
 aR
-bd
+ac
 IY
 XE
 FM
@@ -19760,7 +20701,7 @@ Ch
 DO
 XO
 uk
-bd
+ac
 bK
 rk
 rk
@@ -19801,12 +20742,12 @@ Pv
 it
 iB
 iB
-iB
-iB
-iB
-iB
-iB
-iB
+Pj
+Pj
+Pj
+Pj
+Pj
+Pj
 em
 iB
 iB
@@ -19815,17 +20756,17 @@ iB
 iB
 iB
 iB
-iB
+Pv
 Xr
-kU
-lf
-lf
-lf
-lf
-lf
+wJ
+WF
+WF
+WF
+kV
+kV
 lq
-lf
-lf
+kV
+kV
 lf
 lf
 lf
@@ -19854,14 +20795,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -19880,40 +20821,40 @@ mv
 "}
 (90,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-BZ
-bd
-bd
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+ac
+ac
 WA
-bd
-bd
-bd
-bd
-bd
-bd
-bd
+ac
+ac
+ac
+ac
+ac
+ac
+ac
 rk
 bJ
 rk
-bd
-bd
+ac
+ac
 WA
-bd
-bd
-bd
-bd
-bd
-bd
-bd
+ac
+ac
+ac
+ac
+ac
+ac
+ac
 rk
 bX
 bX
@@ -19933,10 +20874,10 @@ cw
 bW
 nw
 ns
-Zv
-ns
-ns
-pi
+Fi
+Xd
+pE
+Cf
 cx
 gX
 gU
@@ -19967,17 +20908,17 @@ iB
 iB
 iB
 iB
-iB
-iB
+NE
 Pv
-it
-lf
-lf
-lf
-lf
-Hq
-lf
-lf
+Pv
+wJ
+WF
+WF
+WF
+kV
+PH
+lq
+kV
 gN
 lf
 lf
@@ -20007,14 +20948,14 @@ Hq
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -20033,20 +20974,20 @@ mv
 "}
 (91,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-hI
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+ak
 gS
-rk
+Df
 sO
 zg
 aK
@@ -20086,7 +21027,7 @@ bW
 bW
 bW
 bW
-Mz
+tS
 dj
 cx
 cx
@@ -20121,16 +21062,16 @@ iB
 iB
 iB
 iB
-iB
 Pv
-it
-lf
-lf
-lf
-lf
-lf
-lf
-lf
+Pv
+wJ
+WF
+WF
+kV
+kV
+kV
+lq
+kV
 lf
 lf
 lf
@@ -20160,14 +21101,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -20186,25 +21127,25 @@ mv
 "}
 (92,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-BZ
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+ak
+ak
+ak
+ak
+ak
+ak
+ak
+ak
 hu
 pH
 pQ
@@ -20251,7 +21192,7 @@ gU
 hP
 hg
 hg
-xP
+hg
 hg
 hg
 iJ
@@ -20274,16 +21215,16 @@ iB
 iB
 iB
 iB
-iB
-hc
-hc
+Pv
+Oy
+Se
 kz
 kz
 kz
-lf
-lf
+kV
+kV
 lq
-lf
+kV
 lf
 lf
 lf
@@ -20313,14 +21254,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -20339,25 +21280,25 @@ mv
 "}
 (93,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-BZ
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+ak
 pG
 Qd
 pV
@@ -20390,7 +21331,7 @@ fS
 gc
 bW
 bW
-Mz
+tS
 ew
 cW
 dk
@@ -20433,10 +21374,10 @@ hc
 kz
 kz
 kz
-lf
-lf
 kV
-lf
+kV
+lq
+kV
 lf
 lf
 lf
@@ -20466,14 +21407,14 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -20492,34 +21433,34 @@ mv
 "}
 (94,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-hI
-BZ
-BZ
-BZ
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+ak
+ak
+ak
+ak
 pR
 JP
 pZ
 rk
-OI
-OI
+Ry
+Ry
 OI
 OI
 Ta
@@ -20587,10 +21528,10 @@ kz
 kz
 kz
 kz
-lf
 kV
-lf
-lf
+lq
+kV
+kV
 lf
 lf
 lf
@@ -20619,14 +21560,14 @@ lf
 kz
 kz
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -20645,36 +21586,36 @@ mv
 "}
 (95,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-hI
-hI
-BZ
-BZ
-BZ
-BZ
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+ak
+ak
+ak
 ak
 aT
 lW
-OI
-OI
-OI
+Ha
+Ry
+Ha
 Ta
 rk
 rk
@@ -20723,8 +21664,8 @@ hc
 hc
 hc
 hc
-iB
-iB
+iD
+iD
 hc
 hc
 hc
@@ -20742,9 +21683,9 @@ kz
 kz
 kz
 kz
-lf
-lf
-lf
+kV
+kV
+kV
 lf
 lf
 lf
@@ -20770,16 +21711,16 @@ lf
 lf
 kz
 kz
-hI
-hI
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -20798,35 +21739,35 @@ mv
 "}
 (96,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-BZ
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+ak
 ak
 pu
-OI
-OI
+Ry
+Ha
 uU
 Ta
 rk
@@ -20847,7 +21788,7 @@ bW
 bW
 bW
 bW
-Mz
+tS
 dj
 cx
 cx
@@ -20876,8 +21817,8 @@ hc
 hc
 hc
 hc
-iB
-iB
+hg
+hg
 hc
 hc
 hc
@@ -20923,16 +21864,16 @@ lf
 lf
 kz
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -20951,36 +21892,36 @@ mv
 "}
 (97,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 ak
 pv
-OI
-OI
-OI
+Ry
+Ha
+Ry
 Ta
 rk
 py
@@ -21000,7 +21941,7 @@ bW
 bW
 bW
 bW
-YM
+tS
 dj
 cx
 cx
@@ -21029,8 +21970,8 @@ hc
 hc
 hc
 hc
-iB
-iB
+hg
+hg
 hc
 hc
 hc
@@ -21076,16 +22017,16 @@ lf
 kz
 kz
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -21104,34 +22045,34 @@ mv
 "}
 (98,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 ak
 zP
-OI
+Ry
 OI
 OI
 Ta
@@ -21139,7 +22080,7 @@ rk
 rk
 rk
 pN
-pM
+Ay
 nk
 bW
 bW
@@ -21181,9 +22122,9 @@ hc
 hc
 hc
 hc
-iB
-iB
-iB
+hg
+hg
+hg
 hc
 hc
 hc
@@ -21226,19 +22167,19 @@ lf
 lf
 lf
 kz
-hI
-hI
-hI
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -21257,31 +22198,31 @@ mv
 "}
 (99,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 ak
 YB
 Qv
@@ -21334,8 +22275,8 @@ gU
 hc
 hc
 hc
-iD
-iD
+hg
+hg
 hc
 hc
 hc
@@ -21379,19 +22320,19 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -21410,31 +22351,31 @@ mv
 "}
 (100,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 ak
 ak
 jj
@@ -21532,19 +22473,19 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -21563,34 +22504,34 @@ mv
 "}
 (101,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 ak
-ak
-TL
+Mh
 Vq
 rk
 rk
@@ -21685,19 +22626,19 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -21716,32 +22657,32 @@ mv
 "}
 (102,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-ak
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 ak
 ak
 rk
@@ -21838,19 +22779,19 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -21869,33 +22810,33 @@ mv
 "}
 (103,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-ak
-ak
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 ak
 rk
 pz
@@ -21991,19 +22932,19 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -22022,33 +22963,33 @@ mv
 "}
 (104,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-ak
-ak
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 ak
 sO
 pD
@@ -22144,19 +23085,19 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -22175,33 +23116,33 @@ mv
 "}
 (105,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-ak
-ak
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 ak
 ak
 ak
@@ -22297,19 +23238,19 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -22328,31 +23269,31 @@ mv
 "}
 (106,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 aS
 aS
 aS
@@ -22450,19 +23391,19 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -22481,31 +23422,31 @@ mv
 "}
 (107,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 aS
 aS
 aS
@@ -22530,7 +23471,7 @@ fs
 bW
 bW
 bW
-Mz
+tS
 gu
 gu
 gu
@@ -22603,19 +23544,19 @@ lf
 lf
 lf
 kz
-hI
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -22634,31 +23575,31 @@ mv
 "}
 (108,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 aS
 aS
 aS
@@ -22757,18 +23698,18 @@ lf
 lf
 kz
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -22787,31 +23728,31 @@ mv
 "}
 (109,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 aS
 aS
 cx
@@ -22880,7 +23821,7 @@ hb
 hP
 kn
 kn
-kn
+uX
 kn
 ll
 Hq
@@ -22910,18 +23851,18 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -22940,31 +23881,31 @@ mv
 "}
 (110,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 aS
 cx
 cx
@@ -23063,18 +24004,18 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -23093,32 +24034,32 @@ mv
 "}
 (111,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
 aS
+aS
+aS
+aS
+aS
+PF
+PF
+PF
+PF
+PF
+PF
+PF
+PF
+PF
+PF
+PF
+PF
+PF
+PF
+PF
+PF
+PF
+PF
+PF
+PF
 cx
 cx
 cx
@@ -23142,7 +24083,7 @@ fy
 fy
 fU
 bW
-bW
+tS
 gv
 gv
 gv
@@ -23216,18 +24157,18 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -23246,32 +24187,32 @@ mv
 "}
 (112,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
 aS
+aS
+aS
+aS
+aS
+PF
+VS
+VS
+VS
+VS
+VS
+VS
+Ln
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+Ln
+VS
+VS
+hI
+Oj
 cx
 cx
 cx
@@ -23369,18 +24310,18 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -23399,32 +24340,32 @@ mv
 "}
 (113,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
 aS
+aS
+aS
+aS
+aS
+PF
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+Oj
 cx
 cx
 cx
@@ -23443,11 +24384,11 @@ bW
 bW
 fu
 fA
-fE
-fE
-fE
+sf
+sf
+sf
 fV
-Mz
+tS
 ew
 dk
 cx
@@ -23522,18 +24463,18 @@ Hq
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -23552,32 +24493,32 @@ mv
 "}
 (114,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
 aS
+aS
+aS
+aS
+aS
+PF
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+Oj
 cx
 cJ
 cx
@@ -23600,7 +24541,7 @@ fC
 fC
 fC
 fV
-Mz
+tS
 dj
 cx
 cx
@@ -23675,18 +24616,18 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -23705,32 +24646,32 @@ mv
 "}
 (115,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
 aS
+aS
+aS
+aS
+aS
+PF
+VS
+VS
+VS
+VS
+VS
+VS
+Pe
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+Pe
+VS
+VS
+VS
+Oj
 cx
 cx
 cx
@@ -23753,7 +24694,7 @@ ZS
 zj
 fC
 fV
-Mz
+tS
 dj
 cx
 cx
@@ -23828,18 +24769,18 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -23858,32 +24799,32 @@ mv
 "}
 (116,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
 aS
+aS
+aS
+aS
+aS
+PF
+VS
+VS
+VS
+VS
+PF
+PF
+PF
+PF
+PF
+PF
+PF
+PF
+PF
+PF
+PF
+PF
+PF
+PF
+PF
 cx
 cx
 cx
@@ -23906,7 +24847,7 @@ fC
 fG
 fL
 fV
-Mz
+tS
 dj
 cx
 cx
@@ -23981,18 +24922,18 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -24011,31 +24952,31 @@ mv
 "}
 (117,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+PF
+VS
+VS
+VS
+VS
+PF
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 aS
 cx
 cx
@@ -24059,7 +25000,7 @@ fC
 fH
 fM
 fV
-Mz
+tS
 dj
 cx
 cx
@@ -24134,18 +25075,18 @@ lf
 lf
 lf
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -24164,44 +25105,44 @@ mv
 "}
 (118,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
 aS
 aS
+aS
+aS
+aS
+PF
+HC
+VS
+VS
+YO
+PF
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 cx
 cx
 cx
 cx
 cx
 aS
-hI
-hI
-hI
-hI
-hI
+aS
+aS
+aS
+aS
+aS
 aS
 bW
 bW
@@ -24287,18 +25228,18 @@ kz
 kz
 kz
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -24317,32 +25258,18 @@ mv
 "}
 (119,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+PF
+VS
+VS
+VS
+VS
+PF
 aS
 aS
 aS
@@ -24350,11 +25277,25 @@ aS
 aS
 aS
 aS
-hI
-mv
-mv
-mv
-hI
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 aS
 aS
 bW
@@ -24367,9 +25308,9 @@ fD
 fW
 bW
 aS
-hI
-hI
-hI
+aS
+aS
+aS
 aS
 aS
 aS
@@ -24424,34 +25365,34 @@ lf
 lf
 lf
 gx
-hi
-hi
-kz
-lf
-lf
-lf
-lf
-lf
 lf
 lf
 kz
+lf
+lf
+lf
+lf
+lf
+lf
+lf
 kz
 kz
-hI
-hI
-hI
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -24470,45 +25411,45 @@ mv
 "}
 (120,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-mv
-mv
-mv
-hI
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+PF
+VS
+VS
+VS
+VS
+PF
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 aS
 aS
 aS
@@ -24520,14 +25461,14 @@ bW
 bW
 bW
 aS
-hI
-mv
-hI
-hI
-hI
-hI
-hI
-hI
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+hc
 hc
 hc
 hc
@@ -24588,23 +25529,23 @@ lf
 lf
 lf
 kz
-hI
-hI
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -24623,47 +25564,18 @@ mv
 "}
 (121,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-hI
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+PF
+VS
+VS
+VS
+VS
+PF
 aS
 aS
 aS
@@ -24673,14 +25585,43 @@ aS
 aS
 aS
 aS
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+hc
 hc
 hc
 hc
@@ -24741,23 +25682,23 @@ kz
 kz
 kz
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -24776,66 +25717,66 @@ mv
 "}
 (122,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-hI
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+PF
+VS
+VS
+VS
+VS
+PF
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+hc
+hc
+hc
 hc
 hc
 hc
@@ -24881,36 +25822,36 @@ lf
 lf
 lf
 kz
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -24929,67 +25870,67 @@ mv
 "}
 (123,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+PF
+VS
+VS
+VS
+VS
+PF
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+hc
+hc
+hc
+hc
 hc
 hc
 hc
@@ -25034,36 +25975,36 @@ kz
 kz
 kz
 kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -25082,67 +26023,63 @@ mv
 "}
 (124,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+PF
+VS
+VS
+VS
+VS
+PF
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 hc
 hc
 hc
@@ -25150,13 +26087,17 @@ hc
 hc
 hc
 hc
-hI
-hI
-hI
-hI
-hI
-hI
-hI
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
 hc
 hc
 hg
@@ -25180,43 +26121,43 @@ kz
 kz
 kz
 kz
-hI
-hI
-hI
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
 qq
-kz
-kz
-kz
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
 mv
 mv
 mv
@@ -25235,82 +26176,82 @@ mv
 "}
 (125,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-mv
-mv
-mv
-mv
-mv
-hI
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+PF
+HC
+VS
+VS
+YO
+PF
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
 hc
 hg
 hg
@@ -25322,10 +26263,10 @@ gU
 hc
 hc
 hc
-hI
-hI
-hI
-hI
+hc
+hc
+hc
+hc
 kz
 kz
 kz
@@ -25333,43 +26274,43 @@ kz
 kz
 kz
 kz
-hI
-mv
-mv
-hI
-hI
-hI
-hI
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -25388,82 +26329,82 @@ mv
 "}
 (126,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+PF
+HQ
+HQ
+HQ
+HQ
+PF
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
 hc
 hg
 ie
@@ -25473,56 +26414,56 @@ ih
 hE
 gU
 hc
-hI
-hI
-hI
-mv
-mv
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+hc
+hc
+hc
+hc
+hc
+hc
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -25541,82 +26482,82 @@ mv
 "}
 (127,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+PF
+HQ
+Te
+mJ
+HQ
+PF
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
 hc
 hg
 kc
@@ -25626,56 +26567,56 @@ hc
 hc
 hc
 hc
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+hc
+hc
+hc
+hc
+hc
+hc
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -25694,82 +26635,63 @@ mv
 "}
 (128,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
+Xz
+aS
+aS
+aS
+aS
+aS
+PF
+Gw
+JZ
+JZ
+Gw
+PF
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 hc
 hc
 hc
@@ -25777,58 +26699,77 @@ hc
 hc
 hc
 hc
-hI
-hI
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+hc
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+qq
 mv
 mv
 mv
@@ -25847,141 +26788,141 @@ mv
 "}
 (129,1,1) = {"
 mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-hI
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
-mv
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+BR
+BR
+BR
+BR
+BR
+BR
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+qQ
+qQ
+qQ
+qQ
+qQ
+qQ
+qQ
+qQ
+qQ
+qQ
+qQ
+qQ
+qQ
+qQ
+qQ
+qQ
+qQ
+qQ
+qQ
+qQ
+qQ
+qQ
+qQ
+qQ
+qQ
+qQ
+qQ
+qQ
+qQ
+qQ
+qQ
+qQ
+qQ
+qQ
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
+qq
 mv
 mv
 mv

--- a/_maps/map_files/Whiskey_Outpost/Whiskey_Outpost_v2.dmm
+++ b/_maps/map_files/Whiskey_Outpost/Whiskey_Outpost_v2.dmm
@@ -2337,13 +2337,6 @@
 /obj/item/clothing/glasses/night/imager_goggles,
 /obj/item/clothing/glasses/night/imager_goggles,
 /obj/item/clothing/glasses/night/imager_goggles,
-/obj/item/clothing/glasses/night/imager_goggles,
-/obj/item/clothing/glasses/night/imager_goggles,
-/obj/item/clothing/glasses/night/imager_goggles,
-/obj/item/clothing/glasses/night/imager_goggles,
-/obj/item/clothing/glasses/night/imager_goggles,
-/obj/item/clothing/glasses/night/imager_goggles,
-/obj/item/clothing/glasses/night/imager_goggles,
 /turf/open/floor/prison,
 /area/whiskey_outpost)
 "kj" = (
@@ -3947,14 +3940,7 @@
 /obj/item/factory_refill/phosnade,
 /obj/item/factory_refill/phosnade,
 /obj/item/factory_refill/phosnade,
-/obj/item/factory_refill/phosnade,
-/obj/item/factory_refill/phosnade,
 /obj/structure/rack,
-/obj/item/factory_refill/phosnade,
-/obj/item/factory_refill/phosnade,
-/obj/item/factory_refill/phosnade,
-/obj/item/factory_refill/phosnade,
-/obj/item/factory_refill/phosnade,
 /obj/item/paper/factoryhowto,
 /turf/open/floor/prison,
 /area/whiskey_outpost)

--- a/_maps/map_files/Whiskey_Outpost/Whiskey_Outpost_v2.dmm
+++ b/_maps/map_files/Whiskey_Outpost/Whiskey_Outpost_v2.dmm
@@ -2334,9 +2334,6 @@
 /area/whiskey_outpost)
 "ki" = (
 /obj/structure/closet/crate,
-/obj/item/clothing/glasses/night/imager_goggles,
-/obj/item/clothing/glasses/night/imager_goggles,
-/obj/item/clothing/glasses/night/imager_goggles,
 /turf/open/floor/prison,
 /area/whiskey_outpost)
 "kj" = (
@@ -2566,13 +2563,6 @@
 /obj/structure/table/mainship,
 /turf/open/floor/tile/dark,
 /area/whiskey_outpost)
-"lE" = (
-/obj/structure/bed/chair/comfy,
-/obj/item/toy/plush/moth{
-	name = "King Moth"
-	},
-/turf/open/floor/plating/asteroidfloor,
-/area/whiskey_outpost/outside/west)
 "lF" = (
 /turf/closed/shuttle/dropship1/transparent{
 	icon_state = "53"
@@ -2761,18 +2751,6 @@
 /obj/effect/landmark/start/job/squadmarine,
 /turf/open/floor/mainship/sterile/dark,
 /area/whiskey_outpost)
-"mJ" = (
-/obj/structure/table/mainship,
-/obj/item/reagent_containers/food/snacks/human/burger{
-	desc = "A burger made by moffdonalds.";
-	name = "BigMoff Burger"
-	},
-/obj/item/weapon/gun/energy/lasgun/pulse{
-	anchored = 1;
-	desc = "Hah, Did you really think you were getting a pulse rifle?"
-	},
-/turf/open/floor/rcircuit,
-/area/whiskey_outpost)
 "mO" = (
 /turf/closed/shuttle/dropship1/transparent{
 	icon_state = "48"
@@ -2792,6 +2770,14 @@
 /obj/structure/dropship_piece/one/engine/righttop,
 /turf/open/floor/plating/ground/dirt,
 /area/whiskey_outpost/outside/south)
+"mV" = (
+/obj/structure/bed/chair,
+/obj/item/toy/plush/moth{
+	desc = "King of the moth kingdom";
+	name = "King Moth"
+	},
+/turf/open/floor/rcircuit,
+/area/whiskey_outpost/outside/north)
 "mW" = (
 /obj/effect/landmark/start/job/squadmarine,
 /turf/open/floor/plating,
@@ -3501,15 +3487,6 @@
 /obj/structure/largecrate/supply/explosives/mortar_flare,
 /turf/open/floor/plating,
 /area/whiskey_outpost)
-"pI" = (
-/obj/item/weapon/wirerod{
-	anchored = 1;
-	desc = "A TV antenna so the princess can watch reality TV. Warranty void if used to watch anything other than reality TV";
-	name = "TV Antenna"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating/ground/dirt,
-/area/whiskey_outpost/outside/west)
 "pJ" = (
 /obj/structure/platform{
 	dir = 8
@@ -3872,13 +3849,7 @@
 "rc" = (
 /obj/item/storage/box/minisentry,
 /obj/item/storage/box/minisentry,
-/obj/item/storage/box/minisentry,
-/obj/item/storage/box/minisentry,
-/obj/item/storage/box/minisentry,
 /obj/structure/rack,
-/obj/item/ammo_magazine/flamer_tank/large/X,
-/obj/item/ammo_magazine/flamer_tank/large/X,
-/obj/item/ammo_magazine/flamer_tank/backtank/X,
 /turf/open/floor/prison,
 /area/whiskey_outpost)
 "rd" = (
@@ -3937,8 +3908,6 @@
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
 "rl" = (
-/obj/item/factory_refill/phosnade,
-/obj/item/factory_refill/phosnade,
 /obj/item/factory_refill/phosnade,
 /obj/structure/rack,
 /obj/item/paper/factoryhowto,
@@ -4159,6 +4128,15 @@
 /obj/structure/largecrate/supply/supplies/plasteel,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
+"sQ" = (
+/obj/structure/bed/chair,
+/obj/item/toy/plush/slime{
+	anchored = 1;
+	desc = "The adopted daughter of king moth, One day she will inherit the whole kingdom";
+	name = "Princess Slime"
+	},
+/turf/open/floor/rcircuit,
+/area/whiskey_outpost/outside/north)
 "sS" = (
 /obj/machinery/light{
 	dir = 1
@@ -4356,14 +4334,6 @@
 /obj/structure/largecrate/supply/floodlights,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
-"uI" = (
-/obj/item/instrument/musicalmoth{
-	anchored = 1;
-	desc = "This little moth has been tasked with entertaining the moth king. He is not very good at it.";
-	name = "Jester Moth"
-	},
-/turf/open/floor/plating/ground/dirt,
-/area/whiskey_outpost/outside/west)
 "uJ" = (
 /obj/machinery/computer/crew,
 /turf/open/floor/mainship/sterile,
@@ -4461,14 +4431,6 @@
 /obj/item/weapon/gun/tl102/hsg_nest,
 /turf/open/floor/plating/warning,
 /area/whiskey_outpost/outside/east)
-"vW" = (
-/obj/item/toy/plush/snake{
-	anchored = 1;
-	desc = "This snake defends the castle of the moth."       ;
-	name = "Snake Knight"
-	},
-/turf/open/floor/plating/ground/dirt,
-/area/whiskey_outpost/outside/west)
 "vX" = (
 /obj/machinery/conveyor{
 	id = "reqtorio"
@@ -4646,14 +4608,6 @@
 /obj/item/lightstick/red/anchored,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost/outside/south)
-"xW" = (
-/obj/structure/cable,
-/obj/machinery/computer/security/wooden_tv{
-	desc = "An old TV hooked into cable. May or may not work.";
-	name = "Old TV"
-	},
-/turf/open/floor/plating/asteroidfloor,
-/area/whiskey_outpost/outside/west)
 "yd" = (
 /obj/structure/largecrate/supply/medicine/medkits,
 /turf/open/floor/plating/asteroidwarning{
@@ -4842,15 +4796,6 @@
 	},
 /turf/open/floor/mainship,
 /area/whiskey_outpost)
-"AH" = (
-/obj/machinery/door_control/unmeltable{
-	desc = "Huh... What could this possibly control?";
-	id = "escape";
-	name = "Weird Button";
-	pixel_x = -22
-	},
-/turf/open/ground/grass,
-/area/whiskey_outpost)
 "AJ" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -4941,6 +4886,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/item/toy/plush/therapy_green,
 /turf/open/floor/prison/plate,
 /area/whiskey_outpost)
 "By" = (
@@ -4984,6 +4930,11 @@
 "BR" = (
 /turf/closed/wall/indestructible/mineral,
 /area/whiskey_outpost)
+"BU" = (
+/obj/structure/table/woodentable,
+/obj/item/coin/gold,
+/turf/open/floor/plating/asteroidfloor,
+/area/whiskey_outpost/outside/west)
 "BX" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/claymore/mercsword/captain,
@@ -5065,16 +5016,38 @@
 /obj/item/storage/box/sentry,
 /turf/open/ground/jungle/path,
 /area/whiskey_outpost/outside/west)
+"Cy" = (
+/obj/structure/closet/crate,
+/obj/item/coin/gold{
+	name = "SunoBux"
+	},
+/obj/item/coin/gold{
+	name = "SunoBux"
+	},
+/obj/item/coin/gold{
+	name = "SunoBux"
+	},
+/obj/item/coin/gold{
+	name = "SunoBux"
+	},
+/obj/item/coin/uranium{
+	name = "SunoBux"
+	},
+/obj/item/coin/uranium{
+	name = "SunoBux"
+	},
+/obj/item/coin/diamond{
+	name = "SunoBux"
+	},
+/obj/item/coin/gold{
+	name = "SunoBux"
+	},
+/turf/open/floor/prison,
+/area/whiskey_outpost/outside/north)
 "CA" = (
 /obj/effect/landmark/start/job/squadmarine,
 /turf/open/ground/jungle/path,
 /area/whiskey_outpost/outside/west)
-"CB" = (
-/turf/closed/banish_space{
-	desc = "You realize the truth. There is no escape";
-	name = "End of the world"
-	},
-/area/whiskey_outpost/outside/south)
 "CD" = (
 /obj/item/quikdeploy/cade/plasteel,
 /obj/item/quikdeploy/cade/plasteel,
@@ -5089,6 +5062,14 @@
 	},
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
+"CJ" = (
+/obj/item/instrument/musicalmoth{
+	anchored = 1;
+	desc = "This little moth has been tasked with entertaining the moth king. He is not very good at it.";
+	name = "Jester Moth"
+	},
+/turf/open/floor/prison,
+/area/whiskey_outpost/outside/north)
 "CK" = (
 /obj/item/weapon/gun/tl102/hsg_nest{
 	dir = 4
@@ -5306,6 +5287,7 @@
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
 	},
+/obj/item/toy/plush/farwa,
 /turf/open/floor/prison/plate,
 /area/whiskey_outpost)
 "EU" = (
@@ -5453,13 +5435,6 @@
 /obj/structure/plasticflaps,
 /turf/open/floor/prison,
 /area/whiskey_outpost)
-"Gw" = (
-/obj/machinery/floodlight/landing/testroom,
-/turf/closed/banish_space{
-	desc = "You realize the truth. There is no escape";
-	name = "End of the world"
-	},
-/area/whiskey_outpost)
 "Gx" = (
 /turf/open/floor{
 	icon_state = "cafeteria"
@@ -5524,12 +5499,6 @@
 /obj/structure/jungle/plantbot1/alien,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost/outside/west)
-"HC" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/ground/river,
-/area/whiskey_outpost)
 "HE" = (
 /obj/machinery/light{
 	dir = 4
@@ -5612,14 +5581,16 @@
 	},
 /turf/open/floor/plating/ground/dirt,
 /area/whiskey_outpost/outside/east)
-"Ij" = (
-/obj/structure/jungle/vines,
-/turf/open/floor/plating/ground/dirt,
-/area/whiskey_outpost/outside/west)
 "In" = (
 /obj/effect/ai_node,
 /turf/open/ground/jungle,
 /area/whiskey_outpost/outside/west)
+"Io" = (
+/turf/closed/banish_space{
+	desc = "You realize the truth. There is no escape";
+	name = "End of the world"
+	},
+/area/whiskey_outpost/outside/north)
 "Ip" = (
 /obj/item/tool/lighter/random,
 /obj/structure/table/mainship,
@@ -5648,13 +5619,6 @@
 	dir = 9
 	},
 /area/whiskey_outpost)
-"Iw" = (
-/obj/structure/rack,
-/obj/item/weapon/twohanded/glaive{
-	desc = "A war glaive for the lizard king's champion."
-	},
-/turf/open/floor/plating/asteroidfloor,
-/area/whiskey_outpost/outside/west)
 "Iy" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/item/reagent_containers/jerrycan,
@@ -5719,12 +5683,8 @@
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
 "Je" = (
-/obj/structure/bed/chair/comfy,
-/obj/item/toy/plush/slime{
-	anchored = 1;
-	desc = "The adopted daughter of king moth, One day she will inherit the whole kingdom";
-	name = "Princess Slime"
-	},
+/obj/structure/bed,
+/obj/item/bedsheet/captain,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost/outside/west)
 "Jf" = (
@@ -5888,12 +5848,6 @@
 "Lj" = (
 /turf/open/floor/asteroidfloor,
 /area/whiskey_outpost/outside/east)
-"Ln" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/ground/river,
-/area/whiskey_outpost)
 "Lo" = (
 /obj/item/storage/box/sentry,
 /turf/open/floor/plating/asteroidfloor,
@@ -5951,10 +5905,6 @@
 	},
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
-"LS" = (
-/obj/structure/jungle/vines,
-/turf/closed/mineral,
-/area/whiskey_outpost/outside/west)
 "LX" = (
 /obj/structure/barricade/sandbags{
 	dir = 4
@@ -6073,10 +6023,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/mainship,
 /area/whiskey_outpost)
-"MP" = (
-/obj/structure/cable,
-/turf/closed/mineral,
-/area/whiskey_outpost/outside/west)
 "MS" = (
 /obj/structure/bed/chair/office/light{
 	dir = 8
@@ -6132,11 +6078,8 @@
 /turf/open/ground/river,
 /area/whiskey_outpost/outside/west)
 "NJ" = (
-/obj/item/toy/plush/snake{
-	anchored = 1;
-	desc = "This snake defends the castle of the moth."       ;
-	name = "Snake Knight"
-	},
+/obj/item/weapon/twohanded/glaive,
+/obj/structure/rack,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost/outside/west)
 "NL" = (
@@ -6245,6 +6188,14 @@
 /obj/vehicle/ridden/powerloader,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
+"Ov" = (
+/obj/structure/bed/chair,
+/obj/item/toy/plush/moth{
+	desc = "Queen of the moth kingdom";
+	name = "Queen Moth"
+	},
+/turf/open/floor/rcircuit,
+/area/whiskey_outpost/outside/north)
 "Oy" = (
 /obj/machinery/floodlight/outpost,
 /turf/open/floor/plating,
@@ -6314,12 +6265,6 @@
 "Pc" = (
 /obj/machinery/door/window,
 /turf/open/floor/mainship/cargo,
-/area/whiskey_outpost)
-"Pe" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/ground/river,
 /area/whiskey_outpost)
 "Pi" = (
 /obj/machinery/vending/tool,
@@ -6563,13 +6508,6 @@
 	dir = 9
 	},
 /area/whiskey_outpost)
-"Sj" = (
-/obj/item/toy/plush/rouny{
-	desc = "A sekrit rooner to remind you that suno redesigned this map on 21-09-2021";
-	name = "Sekrit Rooner"
-	},
-/turf/open/floor/plating/asteroidfloor,
-/area/whiskey_outpost/outside/north)
 "Sk" = (
 /obj/structure/barricade/sandbags{
 	dir = 4
@@ -6579,12 +6517,6 @@
 	},
 /turf/open/floor/plating/asteroidplating,
 /area/whiskey_outpost/outside/north)
-"Sl" = (
-/obj/structure/jungle/vines,
-/obj/structure/jungle/vines,
-/obj/structure/jungle/vines,
-/turf/open/ground/jungle,
-/area/whiskey_outpost/outside/west)
 "Sn" = (
 /obj/structure/barricade/sandbags{
 	dir = 8
@@ -6608,12 +6540,12 @@
 "Sz" = (
 /obj/machinery/door/poddoor/four_tile_hor{
 	desc = "No escape.";
-	id = null;
+	id = "escape";
 	name = "Exit Shield";
 	resistance_flags = 3
 	},
 /turf/open/floor/plating/asteroidfloor,
-/area/whiskey_outpost/outside/south)
+/area/whiskey_outpost)
 "SB" = (
 /turf/open/floor/prison/plate,
 /area/whiskey_outpost)
@@ -6668,17 +6600,6 @@
 /turf/open/floor/mainship{
 	icon_state = "dark_sterile"
 	},
-/area/whiskey_outpost)
-"Te" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/item/instrument/musicalmoth{
-	anchored = 1;
-	desc = "Legends say this moth guards the only escape from whiskey outpost. Too bad there is no escape.";
-	name = "Secret Moth"
-	},
-/turf/open/floor/rcircuit,
 /area/whiskey_outpost)
 "Th" = (
 /obj/structure/barricade/sandbags{
@@ -6789,16 +6710,6 @@
 "UN" = (
 /obj/structure/table/mainship,
 /obj/item/tool/handheld_charger,
-/obj/item/minerupgrade/automatic{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/item/minerupgrade/automatic{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/item/minerupgrade/overclock,
-/obj/item/minerupgrade/overclock,
 /turf/open/floor/prison,
 /area/whiskey_outpost)
 "US" = (
@@ -6813,12 +6724,15 @@
 /obj/effect/landmark/start/job/squadmarine,
 /turf/open/floor/plating/asteroidfloor,
 /area/whiskey_outpost)
+"Vf" = (
+/turf/open/floor/prison,
+/area/whiskey_outpost/outside/north)
 "Vh" = (
 /obj/effect/ai_node,
 /turf/open/ground/jungle,
 /area/whiskey_outpost/outside/east)
 "Vl" = (
-/obj/structure/jungle/vines,
+/obj/structure/jungle/vines/heavy,
 /turf/open/floor/plating/ground/dirtgrassborder,
 /area/whiskey_outpost/outside/west)
 "Vq" = (
@@ -6827,8 +6741,7 @@
 	},
 /area/whiskey_outpost)
 "VB" = (
-/obj/structure/jungle/vines,
-/obj/structure/jungle/vines,
+/obj/structure/jungle/vines/heavy,
 /turf/open/ground/jungle,
 /area/whiskey_outpost/outside/west)
 "VD" = (
@@ -6868,6 +6781,14 @@
 "VS" = (
 /turf/open/ground/river,
 /area/whiskey_outpost)
+"Wf" = (
+/obj/machinery/door/airlock/mainship/command{
+	dir = 2;
+	locked = 1;
+	name = "Court Of The Moth King"
+	},
+/turf/open/floor/prison,
+/area/whiskey_outpost/outside/north)
 "Wm" = (
 /obj/effect/landmark/start/job/squadsmartgunner,
 /turf/open/floor/plating/asteroidfloor,
@@ -7075,7 +6996,6 @@
 /area/whiskey_outpost/outside/south)
 "Yw" = (
 /obj/structure/jungle/vines,
-/obj/structure/jungle/vines,
 /turf/open/floor/plating/ground/dirtgrassborder/corner,
 /area/whiskey_outpost/outside/west)
 "Yy" = (
@@ -7108,10 +7028,6 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/ground/jungle/path,
 /area/whiskey_outpost/outside/west)
-"YO" = (
-/obj/machinery/light/small,
-/turf/open/ground/river,
-/area/whiskey_outpost)
 "YQ" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/platform_decoration{
@@ -7151,6 +7067,10 @@
 /obj/structure/largecrate/guns,
 /turf/open/floor/plating/platebot,
 /area/whiskey_outpost)
+"ZB" = (
+/obj/structure/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirt,
+/area/whiskey_outpost/outside/west)
 "ZP" = (
 /obj/structure/barricade/metal,
 /obj/structure/barricade/metal{
@@ -9642,7 +9562,7 @@ Xz
 aS
 aS
 aS
-ac
+aS
 aS
 aS
 aS
@@ -9795,7 +9715,7 @@ Xz
 aS
 aS
 aS
-AH
+dm
 dm
 aS
 dm
@@ -12149,9 +12069,9 @@ hy
 hk
 sr
 hw
-LS
-LS
-LS
+hB
+hB
+hB
 hB
 hB
 hB
@@ -12301,11 +12221,11 @@ ho
 hy
 hw
 hw
+hw
 cm
-Sl
 VB
 Yw
-LS
+hB
 hB
 hB
 hB
@@ -12454,12 +12374,12 @@ ho
 hy
 hw
 hw
-LS
+hB
+cm
 VB
-Sl
 Vl
+ZB
 hm
-hZ
 hB
 hB
 hB
@@ -12607,11 +12527,11 @@ ho
 hy
 hB
 hB
-LS
-LS
-LS
+hB
+hB
+hB
 Vl
-Ij
+hm
 hm
 hm
 hB
@@ -12764,7 +12684,7 @@ hB
 hB
 hB
 hB
-pI
+hm
 hm
 hm
 hB
@@ -12917,9 +12837,9 @@ hB
 hB
 hB
 hB
-MP
-vW
-vW
+hB
+hm
+hm
 hB
 hB
 hB
@@ -13069,8 +12989,8 @@ hB
 hB
 hB
 hB
-MP
-MP
+hB
+hB
 MA
 MA
 hB
@@ -13222,8 +13142,8 @@ hB
 hB
 hB
 hB
-MP
-uI
+hB
+hm
 hm
 hm
 hB
@@ -13375,7 +13295,7 @@ hB
 hB
 Je
 hX
-xW
+hX
 hm
 hm
 hm
@@ -13525,8 +13445,8 @@ hB
 hB
 hB
 hB
-lE
-hX
+hB
+BU
 hX
 hX
 hX
@@ -13681,8 +13601,8 @@ hB
 hB
 hB
 NJ
-Iw
-NJ
+hX
+hX
 hB
 hB
 hB
@@ -16227,7 +16147,7 @@ aS
 aS
 aS
 aS
-Sj
+fs
 ak
 ak
 gG
@@ -18032,9 +17952,9 @@ ml
 ml
 ml
 ml
-ml
-ml
-qq
+ac
+ac
+BR
 mv
 mv
 mv
@@ -18186,8 +18106,8 @@ Om
 Om
 Om
 Sz
-CB
-qq
+JZ
+BR
 mv
 mv
 mv
@@ -18338,9 +18258,9 @@ Om
 Om
 Om
 Om
-Om
-CB
-qq
+rk
+JZ
+BR
 mv
 mv
 mv
@@ -18491,9 +18411,9 @@ Om
 Om
 Om
 Om
-Om
-CB
-qq
+rk
+JZ
+BR
 mv
 mv
 mv
@@ -18644,9 +18564,9 @@ lf
 Om
 Om
 Om
-Om
-CB
-qq
+rk
+JZ
+BR
 mv
 mv
 mv
@@ -18797,9 +18717,9 @@ ml
 ml
 ml
 ml
-ml
-ml
-qq
+ac
+ac
+BR
 mv
 mv
 mv
@@ -24026,22 +23946,22 @@ aS
 aS
 aS
 aS
-PF
-PF
-PF
-PF
-PF
-PF
-PF
-PF
-PF
-PF
-PF
-PF
-PF
-PF
-PF
-PF
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 PF
 PF
 PF
@@ -24179,24 +24099,24 @@ aS
 aS
 aS
 aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 PF
-VS
-VS
-VS
-VS
-VS
-VS
-Ln
-VS
-VS
-VS
-VS
-VS
-VS
-VS
-Ln
-VS
-VS
+JZ
 hI
 Oj
 cx
@@ -24332,24 +24252,24 @@ aS
 aS
 aS
 aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 PF
-VS
-VS
-VS
-VS
-VS
-VS
-VS
-VS
-VS
-VS
-VS
-VS
-VS
-VS
-VS
-VS
-VS
+JZ
 VS
 Oj
 cx
@@ -24485,24 +24405,24 @@ aS
 aS
 aS
 aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 PF
-VS
-VS
-VS
-VS
-VS
-VS
-VS
-VS
-VS
-VS
-VS
-VS
-VS
-VS
-VS
-VS
-VS
+JZ
 VS
 Oj
 cx
@@ -24633,29 +24553,29 @@ mv
 (115,1,1) = {"
 mv
 Xz
+Xz
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 aS
 aS
 aS
 aS
 aS
 PF
-VS
-VS
-VS
-VS
-VS
-VS
-Pe
-VS
-VS
-VS
-VS
-VS
-VS
-VS
-Pe
-VS
-VS
+JZ
 VS
 Oj
 cx
@@ -24786,27 +24706,27 @@ mv
 (116,1,1) = {"
 mv
 Xz
+Xz
 aS
 aS
 aS
 aS
 aS
-PF
-VS
-VS
-VS
-VS
-PF
-PF
-PF
-PF
-PF
-PF
-PF
-PF
-PF
-PF
-PF
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
 PF
 PF
 PF
@@ -24939,17 +24859,17 @@ mv
 (117,1,1) = {"
 mv
 Xz
+Xz
+Xz
 aS
 aS
 aS
 aS
 aS
-PF
-VS
-VS
-VS
-VS
-PF
+aS
+aS
+aS
+aS
 aS
 aS
 aS
@@ -25092,17 +25012,17 @@ mv
 (118,1,1) = {"
 mv
 Xz
+Xz
+Xz
 aS
 aS
 aS
 aS
 aS
-PF
-HC
-VS
-VS
-YO
-PF
+aS
+aS
+aS
+aS
 aS
 aS
 aS
@@ -25245,17 +25165,17 @@ mv
 (119,1,1) = {"
 mv
 Xz
+Xz
+Xz
+Xz
 aS
 aS
 aS
 aS
 aS
-PF
-VS
-VS
-VS
-VS
-PF
+aS
+aS
+aS
 aS
 aS
 aS
@@ -25398,17 +25318,17 @@ mv
 (120,1,1) = {"
 mv
 Xz
+Xz
+Xz
+Xz
+Xz
 aS
 aS
 aS
 aS
 aS
-PF
-VS
-VS
-VS
-VS
-PF
+aS
+aS
 aS
 aS
 aS
@@ -25551,17 +25471,17 @@ mv
 (121,1,1) = {"
 mv
 Xz
+Xz
+Xz
+Xz
+Xz
 aS
 aS
 aS
 aS
 aS
-PF
-VS
-VS
-VS
-VS
-PF
+aS
+aS
 aS
 aS
 aS
@@ -25704,17 +25624,17 @@ mv
 (122,1,1) = {"
 mv
 Xz
+Xz
+Xz
+Xz
+Xz
 aS
 aS
 aS
 aS
 aS
-PF
-VS
-VS
-VS
-VS
-PF
+aS
+aS
 aS
 aS
 aS
@@ -25857,17 +25777,17 @@ mv
 (123,1,1) = {"
 mv
 Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
 aS
 aS
 aS
 aS
-aS
-PF
-VS
-VS
-VS
-VS
-PF
 aS
 aS
 aS
@@ -26010,17 +25930,17 @@ mv
 (124,1,1) = {"
 mv
 Xz
+Io
+Io
+Io
+Io
+Io
+Io
+Xz
 aS
 aS
 aS
 aS
-aS
-PF
-VS
-VS
-VS
-VS
-PF
 aS
 aS
 aS
@@ -26163,17 +26083,17 @@ mv
 (125,1,1) = {"
 mv
 Xz
+Io
+sQ
+Vf
+Vf
+Cy
+Io
+Xz
+Xz
 aS
 aS
 aS
-aS
-aS
-PF
-HC
-VS
-VS
-YO
-PF
 aS
 aS
 aS
@@ -26316,17 +26236,17 @@ mv
 (126,1,1) = {"
 mv
 Xz
+Io
+mV
+Vf
+Vf
+Vf
+Wf
+Xz
+Xz
 aS
 aS
 aS
-aS
-aS
-PF
-HQ
-HQ
-HQ
-HQ
-PF
 aS
 aS
 aS
@@ -26469,17 +26389,17 @@ mv
 (127,1,1) = {"
 mv
 Xz
+Io
+Ov
+Vf
+Vf
+CJ
+Io
+Xz
+Xz
+Xz
 aS
 aS
-aS
-aS
-aS
-PF
-HQ
-Te
-mJ
-HQ
-PF
 aS
 aS
 aS
@@ -26622,18 +26542,18 @@ mv
 (128,1,1) = {"
 mv
 Xz
-aS
-aS
-aS
-aS
-aS
-PF
-Gw
-JZ
-JZ
-Gw
-PF
-aS
+Io
+Io
+Io
+Io
+Io
+Io
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
 aS
 aS
 aS
@@ -26780,12 +26700,12 @@ Xz
 Xz
 Xz
 Xz
-BR
-BR
-BR
-BR
-BR
-BR
+Xz
+Xz
+Xz
+Xz
+Xz
+Xz
 Xz
 Xz
 Xz


### PR DESCRIPTION
## About The Pull Request

All the features in excruciating detail : 
- Added a few QOL changes to whiskey outpost, changes include paths, sandbags, loadout vendors, corrected gun vendors.
- Added a bunker for command to hide out in if things get too rough. Oh and also gave them some unmanned vehicles. (Added captain spawn planetside too)
- Gives cargonia a WP factory to either cause immense amounts of FF or defeat the xenos.
- Replaced briefing with 2 plat miners for easy access and beacuse nobody ever uses briefing.
- Gives the marines a few bikes for fast transit.
- Puts HSG nests back in their rightful place.
- Gives the marines some more metal and razorwire and stuff like that.
- Made the forest shack a bit nicer. For when you just want to hide from all the xenos.
- Fixed the little security checkpoint, Now even the xenos have to suffer trough kafkaesque bureaucracy.
- Added cryo, Let the poor marines sleep for gods sake!
- Added a few _**SECRETS**_ scattered about
- Entombed rouny in the walls. Free him!
- Made sandbags nicer.
- Fixed the god damn mortar pit.
- Removed spec prep. Rest in peace.

## Why It's Good For The Game
Because whiskey outpost needed a fix.
Also fixing a bunch of oversights and such i guess.
Also adds more rouny plushies, Which is always good for the game.

## Changelog
:cl:
add: Made whiskey outpost MUCH nicer.
/:cl:
