### PR TITLE
Improves first aid pouches

### DIFF
--- a/code/game/objects/items/storage/pill_packets.dm
+++ b/code/game/objects/items/storage/pill_packets.dm
@@ -13,6 +13,8 @@
 	name = "Tricordazine pill packet"
 	desc = "This packet containts tricordazine pills. Heals all types of damage slightly. Once you take them out they don't go back in. No more than 2 pills in a short period."
 	pill_type_to_fill = /obj/item/reagent_containers/pill/tricordrazine
+	storage_slots = 6
+	max_storage_space = 6
 
 /obj/item/storage/pill_bottle/packet/paracetamol
 	name = "Paracematol pill packet"
@@ -28,8 +30,29 @@
 	name = "Russian Red pill packet"
 	desc = "This packet containts Russian Red pills. Used for field treatment of critical cases without a medic. Once you take them out they don't go back in.."
 	pill_type_to_fill = /obj/item/reagent_containers/pill/russian_red
-	
+
 /obj/item/storage/pill_bottle/packet/ryetalyn
 	name = "Ryetalyn pill packet"
 	desc = "This packet containts Ryetalyn pills. Used to provide a shield against bloodstream toxins. Once you take them out they don't go back in. No more than 2 pills at once."
 	pill_type_to_fill = /obj/item/reagent_containers/pill/ryetalyn
+
+/obj/item/storage/pill_bottle/packet/bicaridine
+	name = "bicaridine pill packet"
+	desc = "This packet containts bicaridine pills. Used to treat minor lacerations. Once you take them out they don't go back in. No more than 2 pills at once."
+	pill_type_to_fill = /obj/item/reagent_containers/pill/bicaridine
+	storage_slots = 8
+	max_storage_space = 8
+
+/obj/item/storage/pill_bottle/packet/kelotane
+	name = "kelotane pill packet"
+	desc = "This packet containts kelotane pills. Used to treat surface burns. Once you take them out they don't go back in. No more than 2 pills at once."
+	pill_type_to_fill = /obj/item/reagent_containers/pill/kelotane
+	storage_slots = 8
+	max_storage_space = 8
+
+/obj/item/storage/pill_bottle/packet/tramadol
+	name = "tramadol pill packet"
+	desc = "This packet containts tramadol pills. Used as a medium-strength painkiller. Once you take them out they don't go back in. No more than 2 pills at once."
+	pill_type_to_fill = /obj/item/reagent_containers/pill/tramadol
+	storage_slots = 8
+	max_storage_space = 8

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -114,31 +114,28 @@
 	new /obj/item/tool/weldingtool(src)
 
 
-
-
 /obj/item/storage/pouch/firstaid
 	name = "first-aid pouch"
-	desc = "Standard marine first-aid pouch. It can contain autoinjectors, ointments, and bandages."
+	desc = "Standard marine first-aid pouch. It can contain autoinjectors, sets of pills, and bandages."
 	icon_state = "firstaid"
-	storage_slots = 5
+	storage_slots = 6
 	can_hold = list(
-		/obj/item/stack/medical/heal_pack/ointment,
 		/obj/item/reagent_containers/hypospray/autoinjector,
-		/obj/item/stack/medical/heal_pack/gauze,
-		/obj/item/storage/pill_bottle/packet/tricordrazine,
-		/obj/item/stack/medical/splint,
+		/obj/item/stack/medical,
+		/obj/item/storage/pill_bottle,
 	)
 
 /obj/item/storage/pouch/firstaid/full
-	desc = "Standard marine first-aid pouch. Contains a painkiller autoinjector, a soothing pill packet, splints, some ointment, and some bandages."
+	desc = "Standard marine first-aid pouch. Contains basic pills, splints, and an emergency injector."
 
 /obj/item/storage/pouch/firstaid/full/Initialize()
 	. = ..()
-	new /obj/item/stack/medical/heal_pack/ointment (src)
-	new /obj/item/reagent_containers/hypospray/autoinjector/tramadol (src)
-	new /obj/item/storage/pill_bottle/packet/tricordrazine (src)
-	new /obj/item/stack/medical/heal_pack/gauze (src)
-	new /obj/item/stack/medical/splint (src)
+	new /obj/item/storage/pill_bottle/packet/bicaridine(src)
+	new /obj/item/storage/pill_bottle/packet/kelotane(src)
+	new /obj/item/storage/pill_bottle/packet/tramadol(src)
+	new /obj/item/storage/pill_bottle/packet/tricordrazine(src)
+	new /obj/item/stack/medical/splint(src)
+	new /obj/item/reagent_containers/hypospray/autoinjector/inaprovaline(src)
 
 
 /obj/item/storage/pouch/firstaid/injectors


### PR DESCRIPTION
## About The Pull Request
Improves the medical pouch available from the essential vendors for non-corpsman marines.
Changed contents from ointment, gauze, a tram injector, a 4pill trico packet, and splints to 8pill bkt packets, a 6pill trico packet, an inapro autoinjector and still splints.
Increases first aid pouch's max storage slots from 5 to 6, which I'm not inherently wild about but included on request.
Changed the restriction on the pouch's contained items to fit the new contents.

## Why It's Good For The Game
Right now they're real bad. Improving them guarantees a baseline of available meds for latejoiners independent of other people hoarding/resupply methods.

## Changelog
:cl:
balance: Marine healthkit pouches from the starting vendors are improved: they come with bkt pills, more tricord, splints, and an inaprovaline autoinjector. They've also got an extra storage slot.
/:cl: