### PR TITLE
Shotgun wielded speed tweaks

### DIFF
--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -202,6 +202,7 @@ can cause issues with ammo types getting mixed up during the burst.
 	damage_mult = 0.75  //normalizing gun for vendors; damage reduced by 25% to compensate for faster fire rate; still higher DPS than T-32.
 	recoil = 2
 	recoil_unwielded = 4
+	aim_slowdown = 0.4
 
 
 /obj/item/weapon/gun/shotgun/combat/examine_ammo_count(mob/user)
@@ -252,7 +253,6 @@ can cause issues with ammo types getting mixed up during the burst.
 	damage_mult = 0.7  //30% less damage. Faster firerate.
 	recoil = 0 //It has a stock on the sprite.
 	recoil_unwielded = 2
-	aim_slowdown = 0.6
 	wield_delay = 1 SECONDS
 
 /obj/item/weapon/gun/shotgun/combat/masterkey
@@ -303,6 +303,7 @@ can cause issues with ammo types getting mixed up during the burst.
 	scatter_unwielded = 40
 	recoil = 2
 	recoil_unwielded = 4
+	aim_slowdown = 0.6
 
 	///Animation that plays when you eject SPENT shells
 	var/shell_eject_animation = null
@@ -494,6 +495,7 @@ can cause issues with ammo types getting mixed up during the burst.
 	recoil = 2
 	recoil_unwielded = 4
 	pump_delay = 14
+	aim_slowdown = 0.45
 
 /obj/item/weapon/gun/shotgun/pump/ready_in_chamber() //If there wasn't a shell loaded through pump, this returns null.
 	return
@@ -603,6 +605,7 @@ can cause issues with ammo types getting mixed up during the burst.
 	recoil = 0 // It has a stock. It's on the sprite.
 	recoil_unwielded = 0
 	pump_delay = 12
+	aim_slowdown = 0.4
 
 //------------------------------------------------------
 //A hacky bolt action rifle. in here for the "pump" or bolt working action.
@@ -948,7 +951,7 @@ can cause issues with ammo types getting mixed up during the burst.
 	scatter_unwielded = 40
 	recoil = 2
 	recoil_unwielded = 4
-	aim_slowdown = 0.55
+	aim_slowdown = 0.45
 	pump_delay = 14
 
 	placed_overlay_iconstate = "t35"


### PR DESCRIPTION
## About The Pull Request
Tweaks shotgun wielded slowdown. T39 wielded is extremely slow at 0.6, with both less alpha damage and less damage in a full magazine, when compared to something like the T35 at 0.55, or even the Paladin, Mk221, or marine double barrel at 0.35. 

This PR makes the wielded slowdown of shotguns more proportional to their burst damage capabilities, as well as making it so that certain guns, like the V10 and Mk221, aren't just better versions of the T35 and T39 respectively.

Basically, 30% damage malus, aka T39, gets 0.35 slowdown. 25% malus, paladin and Mk221, get 0.4. No damage mod, T35 and V10, get 0.45 slowdown. Double barrels get 0.6 slowdown, which is incidentally old T39 slowdown, due to their fast firerates.

## Why It's Good For The Game
T39 might have an actual niche after this, although the wield time for it is weirdly long because it "comes with a stock already," as if extra accuracy matters.

Also, double barrel is pretty high above the curve in terms of damage output, and the buckshot changes probably aren't helping that. I don't even think this change is going to do shit, since you're unwielded half the time for reloading. It's a start, at least.

## Changelog
:cl:
balance: T39 wielded slowdown buffed from 0.6 to 0.35
balance: Paladin wielded slowdown nerfed from 0.35 to 0.4
balance: Mk221 wielded slowdown nerfed from 0.35 to 0.4
balance: V10 wielded slowdown nerfed from 0.35 to 0.45
balance: T35 wielded slowdown buffed from 0.55 to 0.45
balance: Double barrel wielded slowdown nerfed from 0.35 to 0.6
/:cl: