### PR TITLE
Enable neuter gender in prefs

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -404,7 +404,7 @@
 
 	real_name		= reject_bad_name(real_name, TRUE)
 	random_name		= sanitize_integer(random_name, TRUE, TRUE, initial(random_name))
-	gender			= sanitize_gender(gender, TRUE)
+	gender			= sanitize_gender(gender, TRUE, TRUE)
 	age				= sanitize_integer(age, AGE_MIN, AGE_MAX, initial(age))
 	species			= sanitize_inlist(species, GLOB.all_species, initial(species))
 	ethnicity		= sanitize_ethnicity(ethnicity)
@@ -487,7 +487,7 @@
 
 	real_name		= reject_bad_name(real_name, TRUE)
 	random_name		= sanitize_integer(random_name, FALSE, TRUE, initial(random_name))
-	gender			= sanitize_gender(gender, TRUE)
+	gender			= sanitize_gender(gender, TRUE, TRUE)
 	age				= sanitize_integer(age, AGE_MIN, AGE_MAX, initial(age))
 	species			= sanitize_inlist(species, GLOB.all_species, initial(species))
 	ethnicity		= sanitize_ethnicity(ethnicity)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -404,7 +404,7 @@
 
 	real_name		= reject_bad_name(real_name, TRUE)
 	random_name		= sanitize_integer(random_name, TRUE, TRUE, initial(random_name))
-	gender			= sanitize_gender(gender)
+	gender			= sanitize_gender(gender, TRUE)
 	age				= sanitize_integer(age, AGE_MIN, AGE_MAX, initial(age))
 	species			= sanitize_inlist(species, GLOB.all_species, initial(species))
 	ethnicity		= sanitize_ethnicity(ethnicity)
@@ -487,7 +487,7 @@
 
 	real_name		= reject_bad_name(real_name, TRUE)
 	random_name		= sanitize_integer(random_name, FALSE, TRUE, initial(random_name))
-	gender			= sanitize_gender(gender)
+	gender			= sanitize_gender(gender, TRUE)
 	age				= sanitize_integer(age, AGE_MIN, AGE_MAX, initial(age))
 	species			= sanitize_inlist(species, GLOB.all_species, initial(species))
 	ethnicity		= sanitize_ethnicity(ethnicity)

--- a/code/modules/client/preferences_ui.dm
+++ b/code/modules/client/preferences_ui.dm
@@ -270,11 +270,10 @@
 			age = clamp(new_age, AGE_MIN, AGE_MAX)
 
 		if("toggle_gender")
-			if(gender == MALE)
-				gender = FEMALE
+			gender = params["newgender"]
+			if(gender == FEMALE)
 				f_style = "Shaved"
 			else
-				gender = MALE
 				underwear = 1
 
 

--- a/tgui/packages/tgui/interfaces/PlayerPreferences/CharacterCustomization.tsx
+++ b/tgui/packages/tgui/interfaces/PlayerPreferences/CharacterCustomization.tsx
@@ -1,4 +1,5 @@
 import { useBackend } from '../../backend';
+import { capitalize } from 'common/string';
 import { Button, Section, Flex, LabeledList, Box, ColorBox } from '../../components';
 import { TextFieldPreference, ToggleFieldPreference, SelectFieldPreference } from './FieldPreferences';
 import { ProfilePicture } from './ProfilePicture';
@@ -28,6 +29,7 @@ export const CharacterCustomization = (props, context) => {
     };
     return '#' + convert(red) + convert(green) + convert(blue);
   };
+  const genders = ["male", "female", "neuter"];
 
   return (
     <>
@@ -77,15 +79,17 @@ export const CharacterCustomization = (props, context) => {
           <Flex.Item>
             <LabeledList>
               <TextFieldPreference label={'Age'} value={'age'} />
-              <ToggleFieldPreference
-                label={'Gender'}
-                value="gender"
-                leftLabel={'Male'}
-                leftValue="male"
-                rightValue="female"
-                rightLabel={'Female'}
-                action={'toggle_gender'}
-              />
+              <LabeledList.Item label={'Gender'}>
+                {genders.map(thisgender => (
+                  <Button.Checkbox
+                    inline
+                    key={thisgender}
+                    content={capitalize(thisgender)}
+                    checked={data['gender'] === thisgender}
+                    onClick={() => act('toggle_gender', { newgender: thisgender })}
+                  />
+                ))}
+              </LabeledList.Item>
               <SelectFieldPreference
                 label={'Hair style'}
                 value={'h_style'}

--- a/tgui/packages/tgui/interfaces/PlayerPreferences/CharacterCustomization.tsx
+++ b/tgui/packages/tgui/interfaces/PlayerPreferences/CharacterCustomization.tsx
@@ -29,7 +29,7 @@ export const CharacterCustomization = (props, context) => {
     };
     return '#' + convert(red) + convert(green) + convert(blue);
   };
-  const genders = ["male", "female", "neuter"];
+  const genders = ["male", "female", "neuter", "plural"];
 
   return (
     <>


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Unhardcodes gender and enables neuter

## Why It's Good For The Game

Robots are an it not a he or she

And if someone wants to use this they now can

## Changelog
:cl:
add: You can now select Neuter as a gender in preferences, particularily reccomended for robots
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
