### PR TITLE
Removes extraneous landing consoles in Big Red dorms

### DIFF
--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -20559,10 +20559,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/south)
-"iLv" = (
-/obj/effect/landmark/dropship_console_spawn_lz2,
-/turf/closed/wall,
-/area/bigredv2/outside/dorms)
 "iMZ" = (
 /obj/effect/landmark/corpsespawner/engineer,
 /turf/open/floor/tile/red/redtaupecorner,
@@ -21003,13 +20999,6 @@
 	dir = 9
 	},
 /area/shuttle/drop2/lz2)
-"lFP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/dropship_console_spawn_lz2,
-/turf/open/floor/marking/asteroidwarning{
-	dir = 8
-	},
-/area/bigredv2/outside/c)
 "lFT" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -21957,11 +21946,6 @@
 /obj/effect/landmark/xeno_resin_wall,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/northeast)
-"rrx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/dropship_console_spawn_lz2,
-/turf/open/floor,
-/area/bigredv2/outside/dorms)
 "rvh" = (
 /turf/closed/mineral/bigred,
 /area/bigredv2/caves/lambda_lab)
@@ -43163,7 +43147,7 @@ acP
 djb
 aCN
 aCN
-lFP
+aCN
 aFM
 aCN
 aHC
@@ -43380,7 +43364,7 @@ asH
 asH
 asH
 asH
-iLv
+asH
 asH
 asH
 aHD
@@ -44465,7 +44449,7 @@ asJ
 aua
 asJ
 aDQ
-rrx
+aua
 aws
 pyW
 aHD


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes a strange row of landing consoles in dorms.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

LZ consoles do not belong in dorms, they belong near landing pads, protected by marines.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Removed some landing consoles accidentally placed in dorms.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
