### PR TITLE
Changes help intent on xenos to more easily clear fire stacks

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/xenoattacks.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoattacks.dm
@@ -83,7 +83,8 @@
 	switch(X.a_intent)
 		if(INTENT_HELP)
 			if(on_fire)
-				fire_stacks = max(fire_stacks - 1, 0)
+				while(fire_stacks && do_after(user, 5, TRUE, src, BUSY_ICON_FRIENDLY))
+    				fire_stacks = max(fire_stacks - 2, 0)
 				playsound(loc, 'sound/weapons/thudswoosh.ogg', 25, 1, 7)
 				X.visible_message(span_danger("[X] tries to put out the fire on [src]!"), \
 					span_warning("We try to put out the fire on [src]!"), null, 5)

--- a/code/modules/mob/living/carbon/xenomorph/xenoattacks.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoattacks.dm
@@ -83,7 +83,7 @@
 	switch(X.a_intent)
 		if(INTENT_HELP)
 			if(on_fire)
-				while(fire_stacks && do_after(user, 5, TRUE, src, BUSY_ICON_FRIENDLY))
+				while(fire_stacks && do_after(X, 5, TRUE, src, BUSY_ICON_FRIENDLY))
 					fire_stacks = max(fire_stacks - 2, 0)
 				playsound(loc, 'sound/weapons/thudswoosh.ogg', 25, 1, 7)
 				X.visible_message(span_danger("[X] tries to put out the fire on [src]!"), \

--- a/code/modules/mob/living/carbon/xenomorph/xenoattacks.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoattacks.dm
@@ -84,7 +84,7 @@
 		if(INTENT_HELP)
 			if(on_fire)
 				while(fire_stacks && do_after(user, 5, TRUE, src, BUSY_ICON_FRIENDLY))
-    				fire_stacks = max(fire_stacks - 2, 0)
+					fire_stacks = max(fire_stacks - 2, 0)
 				playsound(loc, 'sound/weapons/thudswoosh.ogg', 25, 1, 7)
 				X.visible_message(span_danger("[X] tries to put out the fire on [src]!"), \
 					span_warning("We try to put out the fire on [src]!"), null, 5)


### PR DESCRIPTION
## About The Pull Request
Per title. As a Xenomorph, using help intent on another Xenomorph will more easily remove fire stacks.

## Why It's Good For The Game
Fire stacks have become incredibly oppressive as of late. This is my attempt to tackle part of the issue, and promote teamwork amongst xenomorphs; sticking together will be more of an incentive given this change.
Also changes it so you don't have to mash click to clear fire stacks, which sucks.

## Changelog
:cl: Lewdcifer
balance: Fire stacks will now be more easily cleared by help intent.
/:cl: