### PR TITLE
change /droid/welder_act wording and update droid healthbar again

### DIFF
--- a/code/modules/vehicles/unmanned/unmanned_droid.dm
+++ b/code/modules/vehicles/unmanned/unmanned_droid.dm
@@ -29,31 +29,33 @@
 		STOP_PROCESSING(SSslowprocess, src)
 		user.clear_fullscreen("machine", 5)
 
-/obj/vehicle/unmanned/droid/welder_act(mob/living/user, obj/item/I)
+/obj/vehicle/unmanned/droid/welder_act(mob/living/user, obj/item/I)	//used to heal the droid
 	if(user.do_actions)
 		balloon_alert(user, "Already busy!")
 		return FALSE
 	if(obj_integrity >= max_integrity)
+		balloon_alert(user, "[src] doesn't need repairs")
 		return TRUE
 	if(user.skills.getRating("engineer") < SKILL_ENGINEER_ENGI)
-		balloon_alert_to_viewers("[user] fumbles repairs", ignored_mobs = user)
-		balloon_alert(user, "You fumble repair")
+		balloon_alert_to_viewers("[user] tries to repair [src]" , ignored_mobs = user)
+		balloon_alert(user, "You try to repair [src]")
 		var/fumbling_time = 10 SECONDS - 2 SECONDS * user.skills.getRating("engineer")
 		if(!do_after(user, fumbling_time, TRUE, src, BUSY_ICON_UNSKILLED, extra_checks = CALLBACK(I, /obj/item/tool/weldingtool.proc/isOn)))
 			return FALSE
-	balloon_alert_to_viewers("[user] starts repairs", ignored_mobs = user)
-	balloon_alert(user, "You start repair")
+	balloon_alert_to_viewers("[user] begins repairing [src]", ignored_mobs = user)
+	balloon_alert(user, "You begin repairing [src]")
 	if(!do_after(user, 2 SECONDS, extra_checks = CALLBACK(I, /obj/item/tool/weldingtool.proc/isOn)))
-		balloon_alert_to_viewers("Repairs stopped")
+		balloon_alert_to_viewers("[user] stops repairing [src]")
 		return
 	if(!I.use_tool(src, user, 0, volume=50, amount=1))
 		return TRUE
 	obj_integrity += min(10, max_integrity-obj_integrity)
+	hud_set_machine_health()	//updates the health bar
 	if(obj_integrity == max_integrity)
 		balloon_alert_to_viewers("Fully repaired!")
 	else
 		balloon_alert_to_viewers("[user] repairs", ignored_mobs = user)
-		balloon_alert(user, "You repair damage")
+		balloon_alert(user, "You finish repairing [src]")
 	return TRUE
 
 ///stealth droid, like the normal droid but with stealthing ability on rclick

--- a/code/modules/vehicles/unmanned/unmanned_droid.dm
+++ b/code/modules/vehicles/unmanned/unmanned_droid.dm
@@ -29,33 +29,33 @@
 		STOP_PROCESSING(SSslowprocess, src)
 		user.clear_fullscreen("machine", 5)
 
-/obj/vehicle/unmanned/droid/welder_act(mob/living/user, obj/item/I)	//used to heal the droid
+/obj/vehicle/unmanned/droid/welder_act(mob/living/user, obj/item/I)
 	if(user.do_actions)
-		balloon_alert(user, "Already busy!")
+		balloon_alert(user, "You're already busy!")
 		return FALSE
 	if(obj_integrity >= max_integrity)
-		balloon_alert(user, "[src] doesn't need repairs")
+		balloon_alert(user, "This doesn't need repairs")
 		return TRUE
 	if(user.skills.getRating("engineer") < SKILL_ENGINEER_ENGI)
-		balloon_alert_to_viewers("[user] tries to repair [src]" , ignored_mobs = user)
-		balloon_alert(user, "You try to repair [src]")
+		balloon_alert_to_viewers("[user] tries to repair the droid" , ignored_mobs = user)
+		balloon_alert(user, "You try to repair the droid")
 		var/fumbling_time = 10 SECONDS - 2 SECONDS * user.skills.getRating("engineer")
 		if(!do_after(user, fumbling_time, TRUE, src, BUSY_ICON_UNSKILLED, extra_checks = CALLBACK(I, /obj/item/tool/weldingtool.proc/isOn)))
 			return FALSE
-	balloon_alert_to_viewers("[user] begins repairing [src]", ignored_mobs = user)
-	balloon_alert(user, "You begin repairing [src]")
+	balloon_alert_to_viewers("[user] begins repairing the droid", ignored_mobs = user)
+	balloon_alert(user, "You begin repairing the droid")
 	if(!do_after(user, 2 SECONDS, extra_checks = CALLBACK(I, /obj/item/tool/weldingtool.proc/isOn)))
-		balloon_alert_to_viewers("[user] stops repairing [src]")
+		balloon_alert_to_viewers("[user] stops repairing the droid")
 		return
 	if(!I.use_tool(src, user, 0, volume=50, amount=1))
 		return TRUE
 	obj_integrity += min(10, max_integrity-obj_integrity)
-	hud_set_machine_health()	//updates the health bar
+	hud_set_machine_health()
 	if(obj_integrity == max_integrity)
 		balloon_alert_to_viewers("Fully repaired!")
 	else
-		balloon_alert_to_viewers("[user] repairs", ignored_mobs = user)
-		balloon_alert(user, "You finish repairing [src]")
+		balloon_alert_to_viewers("[user] repairs the droid", ignored_mobs = user)
+		balloon_alert(user, "You finish repairing the droid")
 	return TRUE
 
 ///stealth droid, like the normal droid but with stealthing ability on rclick


### PR DESCRIPTION
Simple enough

<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the alerts and adds an alert for when you try to repair a full hp droid
Droid healthbar updates when the droid gets repaired
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Current alerts sound a bit off. ~~These new ones are a bit large due to [src] but acceptable as long as you play above 800x600
Also you can rename the droid to shitfart14 MK9001 and it'll work~~ (nah nevermind)
The healthbar health being different from the actual health is annoying and confusing
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix:droid healthbar updates when repaired
spellcheck:(I guess?) changed welder_act wording
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
