### PR TITLE
Build a sentry rekted

### DIFF
--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -2703,7 +2703,6 @@
 /area/prison/research/secret/chemistry)
 "ajQ" = (
 /obj/machinery/light/small,
-/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/prison/cellblock/maxsec/north)
 "ajR" = (
@@ -3632,7 +3631,6 @@
 /obj/machinery/flasher{
 	id = "suspended_WWN"
 	},
-/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/maxsec/south)
 "amy" = (
@@ -3654,7 +3652,6 @@
 /obj/machinery/flasher{
 	id = "suspended_WEN"
 	},
-/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/maxsec/south)
 "amB" = (
@@ -3677,7 +3674,6 @@
 /obj/machinery/flasher{
 	id = "suspended_EWN"
 	},
-/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/maxsec/south)
 "amE" = (
@@ -3696,7 +3692,6 @@
 /obj/machinery/flasher{
 	id = "suspended_EEN"
 	},
-/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/maxsec/south)
 "amH" = (
@@ -5338,28 +5333,24 @@
 /obj/machinery/flasher{
 	id = "suspended_WWS"
 	},
-/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/maxsec/south)
 "arD" = (
 /obj/machinery/flasher{
 	id = "suspended_WES"
 	},
-/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/maxsec/south)
 "arE" = (
 /obj/machinery/flasher{
 	id = "suspended_EWS"
 	},
-/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/maxsec/south)
 "arF" = (
 /obj/machinery/flasher{
 	id = "suspended_EES"
 	},
-/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/maxsec/south)
 "arG" = (
@@ -5385,7 +5376,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/medbay/surgery)
 "arL" = (
@@ -6369,7 +6359,6 @@
 	pixel_y = 28
 	},
 /obj/effect/ai_node,
-/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/prison/medbay/morgue)
 "auj" = (
@@ -10167,7 +10156,6 @@
 /turf/open/floor/prison/sterilewhite,
 /area/prison/toilet/research)
 "aFO" = (
-/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/toilet/research)
 "aFP" = (
@@ -10665,7 +10653,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
-/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/prison/quarters/research)
 "aHd" = (
@@ -12264,7 +12251,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
-/obj/effect/landmark/weed_node,
 /turf/open/floor/carpet,
 /area/prison/quarters/research)
 "aLF" = (
@@ -12287,7 +12273,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
-/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/prison/quarters/research)
 "aLI" = (
@@ -14096,7 +14081,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/prison/cleaning)
 "aRm" = (
@@ -17379,7 +17363,6 @@
 /obj/item/storage/box/lights,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/reagent_containers/spray/cleaner,
-/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/hallway/staff)
 "bbv" = (
@@ -17806,7 +17789,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/prison/security/monitoring/highsec)
 "bcW" = (
@@ -23975,7 +23957,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/prison/security/monitoring/highsec)
 "bvs" = (
@@ -27767,7 +27748,6 @@
 "bHp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/red{
 	dir = 1
 	},
@@ -34857,7 +34837,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/prison/security)
 "cdC" = (
@@ -36658,7 +36637,6 @@
 	dir = 9
 	},
 /obj/item/ammo_magazine/pistol/g22,
-/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/prison/security/head)
 "cjr" = (
@@ -36812,7 +36790,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/prison/parole/protective_custody)
 "cjO" = (
@@ -37494,7 +37471,6 @@
 	dir = 10
 	},
 /obj/structure/cable,
-/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/parole/protective_custody)
 "clK" = (
@@ -38025,7 +38001,6 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/prison/parole/protective_custody)
 "cnp" = (
@@ -38292,7 +38267,6 @@
 /area/prison/cellblock/protective)
 "coe" = (
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/protective)
 "cof" = (
@@ -40273,7 +40247,6 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/mediumsec/west)
 "cuL" = (
@@ -40284,7 +40257,6 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/mediumsec/south)
 "cuN" = (
@@ -40699,7 +40671,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/mediumsec/west)
 "cwh" = (
@@ -40826,7 +40797,6 @@
 /area/prison/cellblock/mediumsec/south)
 "cwB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber,
-/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/darkred{
 	dir = 8
 	},
@@ -41224,7 +41194,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood,
-/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/mediumsec/south)
 "cyN" = (
@@ -41532,7 +41501,6 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/mediumsec/south)
 "czH" = (
@@ -41581,7 +41549,6 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/mediumsec/south)
 "czQ" = (
@@ -41791,10 +41758,13 @@
 /turf/open/ground/grass,
 /area/prison/residential/central)
 "cSU" = (
-/obj/effect/ai_node,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/prison/hangar_storage/research)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/turf/open/floor/prison/whitepurple{
+	dir = 1
+	},
+/area/prison/quarters/research)
 "cTQ" = (
 /turf/open/ground/river,
 /area/prison/residential/central)
@@ -41894,10 +41864,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/prison/cellblock/maxsec/south)
-"drU" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/prison/medbay/morgue)
 "dsF" = (
 /obj/structure/monorail{
 	dir = 5
@@ -41970,13 +41936,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/nw)
-"dFj" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/prison/cellblock/highsec/south/north)
 "dMY" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/bright_clean,
@@ -42336,11 +42295,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/medbay)
-"eZs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/wood,
-/area/prison/residential/north)
 "eZF" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/prison/bright_clean/two,
@@ -42352,13 +42306,6 @@
 	},
 /turf/open/floor/wood/broken,
 /area/prison/residential/central)
-"fdk" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/prison/cellblock/highsec/south/north)
 "fej" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
@@ -42445,11 +42392,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/south)
-"fuI" = (
-/obj/effect/decal/warning_stripes/thin,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
-/area/prison/hangar_storage/research)
 "fuY" = (
 /obj/structure/lattice,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
@@ -42468,13 +42410,6 @@
 	dir = 4
 	},
 /area/prison/cellblock/highsec/north/north)
-"fvj" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/prison/cellblock/mediumsec/east)
 "fvE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -42686,13 +42621,6 @@
 /obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/plating,
 /area/prison/research/secret/biolab)
-"geI" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/prison/cellblock/mediumsec/east)
 "gfK" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -42729,10 +42657,6 @@
 /obj/structure/largecrate/random,
 /turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
-"glT" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison/plate,
-/area/prison/cellblock/mediumsec/east)
 "gmZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -42798,13 +42722,6 @@
 /obj/effect/landmark/dropship_console_spawn_lz1,
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/checkpoint/hangar)
-"gsX" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/prison/cellblock/mediumsec/north)
 "gux" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 4;
@@ -42968,12 +42885,6 @@
 /obj/structure/lattice,
 /turf/open/ground/river,
 /area/prison/yard)
-"gRk" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison/darkpurple{
-	dir = 4
-	},
-/area/prison/hangar_storage/research)
 "gSj" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison,
@@ -43297,10 +43208,6 @@
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/monitoring/maxsec/panopticon)
-"iia" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison/sterilewhite,
-/area/prison/residential/north)
 "iib" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk/prison,
@@ -43766,12 +43673,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/cellblock/lowsec/se)
-"jxb" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison/cellstripe{
-	dir = 8
-	},
-/area/prison/cellblock/mediumsec/west)
 "jzd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -44082,7 +43983,6 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/mediumsec/north)
 "kGQ" = (
@@ -44113,10 +44013,6 @@
 /obj/machinery/vending/marine/shared/cigarette/colony,
 /turf/open/floor/prison/darkred/full,
 /area/prison/monorail/east)
-"kPA" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/wood,
-/area/prison/parole/protective_custody)
 "kQt" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/darkred/full,
@@ -44189,20 +44085,6 @@
 	dir = 1
 	},
 /area/prison/cellblock/highsec/south/north)
-"lcG" = (
-/obj/machinery/flasher{
-	id = "panopticon"
-	},
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/prison/cellblock/maxsec/north)
-"ldi" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison/marked,
-/area/prison/hangar_storage/research)
 "ldL" = (
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
@@ -44283,13 +44165,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/ground/grass,
 /area/prison/residential/central)
-"lxP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/prison/execution)
 "lyC" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison/green{
@@ -44421,17 +44296,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/se)
-"lVo" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison/plate,
-/area/prison/cellblock/protective)
-"lXB" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
-/area/prison/hangar_storage/research)
 "lXO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -44982,13 +44846,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/prison/research/secret/biolab)
-"nwK" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison/plate,
-/area/prison/cellblock/highsec/south/north)
 "nzo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -45055,10 +44912,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/red,
 /area/prison/cellblock/highsec/south/north)
-"nGt" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison/kitchen,
-/area/prison/residential/north)
 "nJI" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -45905,16 +45758,6 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/residential/north)
-"qkv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/prison/hallway/entrance)
 "qkA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/landmark/weed_node,
@@ -46146,10 +45989,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/prison/security)
-"ray" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison/darkred,
-/area/prison/security/briefing)
 "raD" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/darkred{
@@ -46711,10 +46550,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/prison/residential/south)
-"syJ" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/prison/cellblock/mediumsec/south)
 "sBo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -46925,10 +46760,6 @@
 	dir = 8
 	},
 /area/prison/cellblock/highsec/south/north)
-"thE" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating/plating_catwalk/prison,
-/area/prison/cellblock/protective)
 "tkT" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/carpet,
@@ -47092,11 +46923,6 @@
 	},
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/sw)
-"tNS" = (
-/obj/structure/cable,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
-/area/prison/hangar_storage/research)
 "tNX" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison/darkred/full,
@@ -47216,12 +47042,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/sw)
-"ugW" = (
-/obj/effect/decal/warning_stripes/thin,
-/obj/effect/ai_node,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/plating,
-/area/prison/hangar_storage/research)
 "uhu" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/plate,
@@ -47493,10 +47313,6 @@
 	},
 /turf/open/floor/plating,
 /area/prison/hangar/civilian)
-"vew" = (
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison,
-/area/prison/hallway/entrance)
 "vfh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -47810,11 +47626,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/hallway/central)
-"vYi" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber,
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison/plate,
-/area/prison/cellblock/maxsec/north)
 "vYn" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -47897,13 +47708,6 @@
 	dir = 4
 	},
 /area/prison/cellblock/mediumsec/south)
-"wkz" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/landmark/weed_node,
-/turf/open/floor/prison/plate,
-/area/prison/cellblock/maxsec/north)
 "wmu" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/darkred{
@@ -53434,11 +53238,11 @@ aab
 aab
 avl
 aHn
-iia
+awm
 aJC
 avN
 aLa
-gay
+axb
 awi
 aRT
 eWq
@@ -54205,11 +54009,11 @@ avl
 avl
 avl
 aym
-nGt
+axG
 aJE
 aKs
 aLb
-eZs
+aLb
 aMB
 aRT
 pkD
@@ -64482,7 +64286,7 @@ rVa
 aAU
 azX
 adf
-vlm
+azX
 azR
 qqY
 aak
@@ -65285,7 +65089,7 @@ baa
 bjS
 bhB
 aYY
-nni
+aYY
 aYY
 aYY
 bhB
@@ -66313,7 +66117,7 @@ vNd
 bjR
 bkr
 aYY
-nni
+aYY
 lnA
 aYY
 bkr
@@ -68889,7 +68693,7 @@ bpj
 bqh
 bqQ
 brD
-sKg
+lnA
 oie
 beY
 bdI
@@ -69164,13 +68968,13 @@ bvA
 byC
 bFT
 bvA
-dFj
+byx
 bwA
 bvA
-dFj
+byx
 bwA
 bvA
-nwK
+bvH
 bwA
 bvA
 bTT
@@ -69936,11 +69740,11 @@ byC
 bFT
 bvA
 bwA
-fdk
+bDG
 bvC
 bvA
 bwA
-fdk
+bDG
 bwA
 bvC
 bvA
@@ -74089,11 +73893,11 @@ cqK
 cqM
 cqK
 cwv
-jxb
+cuJ
 cet
 cqK
 cwv
-jxb
+cuJ
 cet
 cxL
 bWl
@@ -77924,16 +77728,16 @@ cbk
 dSR
 ciA
 caa
-gsX
+cap
 cbA
 ccV
-gsX
+cap
 cbA
 ccV
-gsX
+cap
 cbA
 ccV
-gsX
+cap
 cbA
 ccV
 cnB
@@ -79726,13 +79530,13 @@ caa
 cae
 clq
 ccV
-gsX
+cap
 cbA
 ccV
-gsX
+cap
 cbA
 ccV
-gsX
+cap
 cbA
 ccV
 jnI
@@ -80754,13 +80558,13 @@ ccU
 ckt
 xyg
 ccV
-gsX
+cap
 cnQ
 ccV
 kGj
 cbA
 ccV
-gsX
+cap
 cbA
 ccV
 cnZ
@@ -80791,7 +80595,7 @@ cxz
 ctj
 czk
 czs
-syJ
+ctm
 cvA
 cyw
 bWl
@@ -80990,7 +80794,7 @@ dBh
 aKN
 aKP
 aLs
-aAR
+aKN
 auu
 bPB
 bRe
@@ -82168,15 +81972,15 @@ afA
 afZ
 add
 afe
-lcG
+afz
 aeQ
 add
 afe
-lcG
+afz
 aeQ
 add
 afe
-lcG
+afz
 aeN
 aeQ
 add
@@ -82333,7 +82137,7 @@ cvA
 crr
 czn
 czx
-jLJ
+czK
 czK
 jLJ
 cAc
@@ -82563,7 +82367,7 @@ cdY
 ccV
 csH
 cvA
-bKZ
+cvA
 ctT
 cuY
 cvE
@@ -82789,7 +82593,7 @@ lAp
 aKN
 aKP
 aLs
-aXw
+aKP
 bOx
 bAl
 bIP
@@ -83196,14 +83000,14 @@ adW
 afD
 add
 adX
-vYi
-afD
-add
-wkz
 adW
 afD
 add
-wkz
+adX
+adW
+afD
+add
+adX
 adW
 afD
 add
@@ -84132,7 +83936,7 @@ cxz
 ctl
 czk
 czs
-syJ
+ctm
 cvA
 cyw
 bWl
@@ -86050,11 +85854,11 @@ anP
 nNh
 apt
 apI
-eXD
+apI
 apI
 apK
 apI
-eXD
+apI
 apI
 apK
 auA
@@ -87963,16 +87767,16 @@ coI
 xtT
 cpU
 cve
-glT
-cpU
-fvj
 cqO
 cpU
-fvj
+cqf
+cqO
+cpU
+cqf
 cxm
 cpU
 cqf
-glT
+cqO
 jSF
 cyx
 cyx
@@ -89505,7 +89309,7 @@ coI
 cua
 cwc
 cpY
-xeb
+cpY
 cpU
 cqT
 cqe
@@ -89750,27 +89554,27 @@ ckD
 cjC
 cmx
 cnh
-lVo
+coc
 cav
 car
 cpV
 cqO
-geI
+cwO
 crZ
 csK
 coI
-xtT
+cua
 cpU
 cpU
 cpU
 cpU
-fvj
+cqf
 cqO
 cpU
-fvj
+cqf
 cqO
 cpU
-fvj
+cqf
 cqO
 cqh
 bWl
@@ -90019,7 +89823,7 @@ cpg
 cua
 cwc
 cpY
-xeb
+cpY
 cpU
 cpV
 cpW
@@ -90171,7 +89975,7 @@ apg
 auh
 atJ
 atJ
-drU
+atJ
 atJ
 atJ
 atJ
@@ -90432,7 +90236,7 @@ atJ
 atJ
 hqG
 atJ
-drU
+atJ
 atJ
 atf
 aAt
@@ -90526,22 +90330,22 @@ cht
 car
 cpV
 cqO
-geI
+cwO
 crZ
 csK
 coI
 xtT
 cpU
-xeb
+cpY
 cpU
-xeb
+cpY
 cpU
 cqO
-geI
+cwO
 cpV
 cpU
 cqO
-geI
+cwO
 cpV
 cqh
 bWl
@@ -92063,7 +91867,7 @@ ckH
 sME
 cqS
 cni
-thE
+cod
 bYM
 car
 cqe
@@ -92323,23 +92127,23 @@ cnj
 bYM
 coJ
 car
-fvj
+cqf
 cqO
 cpU
-fvj
+cqf
 cqO
 ctA
-fvj
+cqf
 cuA
 cpU
 cve
-glT
+cqO
 cpU
 cqf
-glT
+cqO
 cpU
 cqf
-glT
+cqO
 cqh
 bWl
 bWl
@@ -93091,7 +92895,7 @@ ckI
 ckJ
 cqS
 cni
-thE
+cod
 bYM
 cpp
 bWl
@@ -94538,7 +94342,7 @@ aab
 aab
 atC
 auo
-gRk
+auo
 avg
 auo
 aqQ
@@ -94802,7 +94606,7 @@ avh
 avh
 avh
 avh
-tNS
+avh
 avh
 avh
 avh
@@ -94885,11 +94689,11 @@ cfu
 bRC
 bQi
 mwK
-kPA
+ciU
 ciU
 bYq
 xBb
-kPA
+ciU
 raF
 chH
 cps
@@ -95823,14 +95627,14 @@ aab
 aab
 atl
 atl
-fuI
+eyC
 atl
 atl
 atl
-lXB
 atl
 atl
-lXB
+atl
+atl
 atl
 pBH
 avh
@@ -96384,11 +96188,11 @@ xAS
 aVT
 aXd
 aYu
-uoO
+dbh
 aVT
 aXd
 aYu
-qFw
+aVa
 aTF
 bug
 bug
@@ -96851,14 +96655,14 @@ aab
 aab
 atl
 atl
-ugW
+mTC
 atl
 atl
 atl
-lXB
+atl
 eul
 atl
-lXB
+atl
 atl
 pBH
 jfX
@@ -97155,11 +96959,11 @@ xAS
 aVT
 aXd
 aYu
-qJG
+boN
 aVT
 aXd
 aYu
-qFw
+aVa
 aTF
 buj
 bvb
@@ -97879,14 +97683,14 @@ aab
 aab
 atl
 atl
-fuI
+eyC
 atl
 atl
 atl
-lXB
 atl
 atl
-lXB
+atl
+atl
 atl
 pBH
 avh
@@ -97895,7 +97699,7 @@ aEB
 sHr
 aHc
 blK
-aJz
+cSU
 aKh
 aED
 aED
@@ -99254,16 +99058,16 @@ bEI
 cfD
 cfD
 rES
-lxP
+chC
 ckR
 ckR
-uwa
+ckR
 ckR
 chQ
 coP
 chQ
 cqr
-qJu
+chQ
 gvs
 crg
 aab
@@ -99423,11 +99227,11 @@ atU
 aur
 auI
 avj
-ldi
+avj
 xwA
 avj
 avj
-cSU
+vsx
 auI
 azU
 aAJ
@@ -101567,12 +101371,12 @@ cfH
 cgO
 chV
 cje
-lzN
 cjY
 cjY
 cjY
 cjY
-ray
+cjY
+coj
 coT
 cpL
 cje
@@ -102594,13 +102398,13 @@ bMu
 cfJ
 coT
 chW
-mJG
+cje
 cjY
 cjY
 cjY
 cjY
 cjY
-ray
+coj
 coT
 cpL
 cje
@@ -103589,7 +103393,7 @@ bjG
 bcz
 urN
 bcz
-vew
+bcz
 bcz
 bcz
 buy
@@ -104106,7 +103910,7 @@ bwl
 bxc
 bxc
 byg
-vew
+bcz
 bnM
 bmM
 bCV
@@ -104349,11 +104153,11 @@ bcN
 bbC
 bnM
 mMl
-vew
 bcz
 bcz
 bcz
-qkv
+bcz
+mMl
 bnM
 bbC
 bmE

--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -368,6 +368,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/prison/cellblock/maxsec/north)
 "adb" = (
@@ -841,6 +842,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/prison/cellblock/maxsec/north)
 "aet" = (
@@ -2123,6 +2125,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/research/secret/bioengineering)
 "aif" = (
@@ -2700,6 +2703,7 @@
 /area/prison/research/secret/chemistry)
 "ajQ" = (
 /obj/machinery/light/small,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/prison/cellblock/maxsec/north)
 "ajR" = (
@@ -3185,6 +3189,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/prison/research/secret)
 "ali" = (
@@ -3627,6 +3632,7 @@
 /obj/machinery/flasher{
 	id = "suspended_WWN"
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/maxsec/south)
 "amy" = (
@@ -3648,6 +3654,7 @@
 /obj/machinery/flasher{
 	id = "suspended_WEN"
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/maxsec/south)
 "amB" = (
@@ -3670,6 +3677,7 @@
 /obj/machinery/flasher{
 	id = "suspended_EWN"
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/maxsec/south)
 "amE" = (
@@ -3688,6 +3696,7 @@
 /obj/machinery/flasher{
 	id = "suspended_EEN"
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/maxsec/south)
 "amH" = (
@@ -3934,6 +3943,7 @@
 	dir = 4
 	},
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/prison/cellblock/maxsec/south)
 "ans" = (
@@ -3971,6 +3981,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/research/secret/chemistry)
 "anw" = (
@@ -4040,6 +4051,7 @@
 	id = "suspended_WWN";
 	pixel_x = 24
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/maxsec/south)
 "anG" = (
@@ -4050,6 +4062,7 @@
 	id = "suspended_WEN";
 	pixel_x = -24
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/maxsec/south)
 "anH" = (
@@ -4096,6 +4109,7 @@
 	id = "suspended_EWN";
 	pixel_x = 24
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/maxsec/south)
 "anN" = (
@@ -4106,6 +4120,7 @@
 	id = "suspended_EEN";
 	pixel_x = -24
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/maxsec/south)
 "anO" = (
@@ -5323,24 +5338,28 @@
 /obj/machinery/flasher{
 	id = "suspended_WWS"
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/maxsec/south)
 "arD" = (
 /obj/machinery/flasher{
 	id = "suspended_WES"
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/maxsec/south)
 "arE" = (
 /obj/machinery/flasher{
 	id = "suspended_EWS"
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/maxsec/south)
 "arF" = (
 /obj/machinery/flasher{
 	id = "suspended_EES"
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/maxsec/south)
 "arG" = (
@@ -5366,6 +5385,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/medbay/surgery)
 "arL" = (
@@ -5688,6 +5708,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/research)
 "asC" = (
@@ -5883,6 +5904,7 @@
 	id = "suspended_WWS";
 	pixel_x = 24
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/maxsec/south)
 "ata" = (
@@ -5893,6 +5915,7 @@
 	id = "suspended_WES";
 	pixel_x = -24
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/maxsec/south)
 "atb" = (
@@ -5903,6 +5926,7 @@
 	id = "suspended_EWS";
 	pixel_x = 24
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/prison/cellblock/maxsec/south)
 "atc" = (
@@ -5913,6 +5937,7 @@
 	id = "suspended_EES";
 	pixel_x = -24
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/maxsec/south)
 "atd" = (
@@ -5995,6 +6020,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/research/RD)
 "atn" = (
@@ -6238,6 +6264,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/red{
 	dir = 5
 	},
@@ -6342,6 +6369,7 @@
 	pixel_y = 28
 	},
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/prison/medbay/morgue)
 "auj" = (
@@ -6934,6 +6962,7 @@
 /area/prison/medbay)
 "awa" = (
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 8
 	},
@@ -7045,6 +7074,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/red/corner{
 	dir = 1
 	},
@@ -7061,6 +7091,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/red{
 	dir = 4
 	},
@@ -7073,6 +7104,7 @@
 	dir = 4
 	},
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/prison/cellblock/maxsec/south)
 "awx" = (
@@ -7344,6 +7376,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/prison/cellblock/maxsec/south)
 "axr" = (
@@ -7627,6 +7660,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/prison/residential/north)
 "ayl" = (
@@ -7936,6 +7970,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 8
 	},
@@ -7971,6 +8006,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/red/corner{
 	dir = 1
 	},
@@ -8015,6 +8051,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/whitegreen/full,
 /area/prison/medbay)
 "azx" = (
@@ -8463,6 +8500,7 @@
 	dir = 6
 	},
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/access/north)
 "aAR" = (
@@ -8481,6 +8519,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/darkred,
 /area/prison/medbay/foyer)
 "aAU" = (
@@ -8527,6 +8566,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/access/north)
 "aAY" = (
@@ -8546,6 +8586,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/north)
 "aBb" = (
@@ -8570,6 +8611,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/prison/cellblock/highsec/north/north)
 "aBe" = (
@@ -8712,6 +8754,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/whitegreen,
 /area/prison/medbay)
 "aBx" = (
@@ -9537,6 +9580,7 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/structure/cable,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/north)
 "aDL" = (
@@ -9547,6 +9591,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/north)
 "aDM" = (
@@ -9620,6 +9665,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/plate,
 /area/prison/recreation/highsec/n)
 "aDY" = (
@@ -10121,6 +10167,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/prison/toilet/research)
 "aFO" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/toilet/research)
 "aFP" = (
@@ -10538,6 +10585,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/research)
 "aGU" = (
@@ -10617,6 +10665,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/prison/quarters/research)
 "aHd" = (
@@ -11033,6 +11082,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/north)
 "aIu" = (
@@ -11386,6 +11436,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/whitepurple{
 	dir = 1
 	},
@@ -11433,6 +11484,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/whitepurple{
 	dir = 1
 	},
@@ -11441,6 +11493,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/whitepurple{
 	dir = 1
 	},
@@ -11464,6 +11517,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/whitepurple{
 	dir = 1
 	},
@@ -12210,6 +12264,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/carpet,
 /area/prison/quarters/research)
 "aLF" = (
@@ -12232,6 +12287,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/prison/quarters/research)
 "aLI" = (
@@ -12938,6 +12994,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/green{
 	dir = 1
 	},
@@ -13056,6 +13113,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/green{
 	dir = 1
 	},
@@ -13175,6 +13233,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/staff)
 "aOI" = (
@@ -13183,6 +13242,7 @@
 "aOJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/staff)
 "aOK" = (
@@ -13197,6 +13257,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/staff)
 "aOM" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/green/corner{
 	dir = 1
 	},
@@ -13279,6 +13340,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/red/corner{
 	dir = 1
 	},
@@ -14017,6 +14079,7 @@
 /area/prison/cleaning)
 "aRi" = (
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/bright_clean,
 /area/prison/cleaning)
 "aRj" = (
@@ -14033,6 +14096,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/prison/cleaning)
 "aRm" = (
@@ -14577,6 +14641,7 @@
 /area/prison/cellblock/highsec/north/south)
 "aTb" = (
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/cellblock/highsec/north/south)
 "aTc" = (
@@ -15198,6 +15263,7 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/green,
 /area/prison/cellblock/lowsec/ne)
 "aUN" = (
@@ -15305,6 +15371,7 @@
 	on = 1
 	},
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/canteen)
 "aVd" = (
@@ -15388,6 +15455,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/green{
 	dir = 1
 	},
@@ -15601,6 +15669,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/bright_clean,
 /area/prison/canteen)
 "aVY" = (
@@ -15616,6 +15685,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/toilet/staff)
 "aWa" = (
@@ -16021,6 +16091,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/staff)
 "aXj" = (
@@ -16211,6 +16282,7 @@
 	dir = 4;
 	on = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/cellblock/highsec/north/south)
 "aXV" = (
@@ -16556,6 +16628,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/red/corner,
 /area/prison/cellblock/highsec/north/south)
 "aZf" = (
@@ -17306,6 +17379,7 @@
 /obj/item/storage/box/lights,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/reagent_containers/spray/cleaner,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/hallway/staff)
 "bbv" = (
@@ -17732,6 +17806,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/prison/security/monitoring/highsec)
 "bcW" = (
@@ -17745,6 +17820,7 @@
 /area/prison/security/monitoring/highsec)
 "bcX" = (
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/red{
 	dir = 1
 	},
@@ -17831,6 +17907,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/bright_clean,
 /area/prison/canteen)
 "bdk" = (
@@ -18243,6 +18320,7 @@
 	dir = 4
 	},
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/entrance)
 "bes" = (
@@ -18269,6 +18347,7 @@
 	dir = 8
 	},
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/entrance)
 "beu" = (
@@ -18945,6 +19024,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/security/monitoring/highsec)
 "bgp" = (
@@ -19091,6 +19171,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/green{
 	dir = 8
 	},
@@ -19350,6 +19431,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/se)
 "bhF" = (
@@ -19421,6 +19503,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/rampbottom{
 	dir = 8
 	},
@@ -19617,6 +19700,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/bright_clean,
 /area/prison/canteen)
 "bim" = (
@@ -19630,18 +19714,20 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/canteen)
 "bin" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/obj/structure/bed/chair{
+	dir = 8
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 4
@@ -19782,6 +19868,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/kitchen,
 /area/prison/kitchen)
 "biD" = (
@@ -20206,6 +20293,7 @@
 	dir = 9
 	},
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/security/monitoring/highsec)
 "bjO" = (
@@ -20590,6 +20678,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/security/monitoring/highsec)
 "bkX" = (
@@ -20657,6 +20746,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/rampbottom{
 	dir = 8
 	},
@@ -20764,6 +20854,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/entrance)
 "bly" = (
@@ -20920,6 +21011,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/red{
 	dir = 4
 	},
@@ -21222,6 +21314,7 @@
 	dir = 10
 	},
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/security/monitoring/highsec)
 "bmX" = (
@@ -21402,6 +21495,7 @@
 	dir = 5
 	},
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/prison/security/monitoring/highsec)
 "bnI" = (
@@ -21550,6 +21644,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/central)
 "bod" = (
@@ -21597,6 +21692,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/prison/security/monitoring/highsec)
 "boj" = (
@@ -21656,6 +21752,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/prison/cellblock/vip)
 "bop" = (
@@ -22313,6 +22410,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/blue{
 	dir = 4
 	},
@@ -22948,6 +23046,7 @@
 	dir = 5
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/blue{
 	dir = 4
 	},
@@ -22971,6 +23070,7 @@
 	dir = 1
 	},
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/prison/security/monitoring/highsec)
 "bst" = (
@@ -23875,6 +23975,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/prison/security/monitoring/highsec)
 "bvs" = (
@@ -24292,6 +24393,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/prison/visitation)
 "bwH" = (
@@ -24439,6 +24541,7 @@
 /obj/structure/disposalpipe/junction/yjunc{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/entrance)
 "bxk" = (
@@ -24611,6 +24714,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/se)
 "bxL" = (
@@ -24867,6 +24971,7 @@
 /area/prison/cellblock/highsec/south/north)
 "byG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/red/corner{
 	dir = 1
 	},
@@ -25106,6 +25211,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/se)
 "bzu" = (
@@ -26344,6 +26450,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/sw)
 "bDx" = (
@@ -26376,6 +26483,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/se)
 "bDC" = (
@@ -27659,6 +27767,7 @@
 "bHp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/red{
 	dir = 1
 	},
@@ -27937,6 +28046,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/red/corner,
 /area/prison/cellblock/highsec/south/north)
 "bIs" = (
@@ -28369,6 +28479,7 @@
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/highsec/south/north)
 "bJH" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/security/checkpoint/highsec/s)
 "bJI" = (
@@ -28634,6 +28745,13 @@
 	dir = 10
 	},
 /area/prison/security/checkpoint/highsec/s)
+"bKz" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/sterilewhite,
+/area/prison/research)
 "bKA" = (
 /turf/open/floor/prison/red{
 	dir = 6
@@ -28960,6 +29078,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/plate,
 /area/prison/recreation/highsec/s)
 "bLI" = (
@@ -29478,6 +29597,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/security)
 "bNk" = (
@@ -30075,6 +30195,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/south)
 "bOY" = (
@@ -30123,6 +30244,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/south)
 "bPd" = (
@@ -30300,6 +30422,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/plate,
 /area/prison/recreation/highsec/s)
 "bPJ" = (
@@ -30471,6 +30594,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/security)
 "bQs" = (
@@ -30913,6 +31037,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/darkred{
 	dir = 8
 	},
@@ -31536,6 +31661,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/south)
 "bTK" = (
@@ -31716,6 +31842,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/bright_clean,
 /area/prison/maintenance/residential/access/south)
 "bUn" = (
@@ -32287,6 +32414,7 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/prison/intake)
 "bWt" = (
@@ -32746,6 +32874,7 @@
 	},
 /area/prison/security)
 "bXX" = (
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/darkred/corners{
 	dir = 4
 	},
@@ -32801,6 +32930,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/south)
 "bYk" = (
@@ -32882,6 +33012,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/bright_clean,
 /area/prison/maintenance/residential/access/south)
 "bYu" = (
@@ -33054,6 +33185,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/prison/engineering)
 "bYS" = (
@@ -33753,6 +33885,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	on = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/plate,
 /area/prison/recreation/medsec)
 "cbn" = (
@@ -33873,6 +34006,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/mediumsec/west)
 "cbC" = (
@@ -34723,6 +34857,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/prison/security)
 "cdC" = (
@@ -34883,6 +35018,7 @@
 	dir = 4;
 	on = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/yellow{
 	dir = 8
 	},
@@ -34938,6 +35074,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/engineering)
 "ceo" = (
@@ -34952,6 +35089,7 @@
 	dir = 1;
 	on = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/plate,
 /area/prison/hallway/engineering)
 "ceq" = (
@@ -35650,6 +35788,7 @@
 "cgC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/darkyellow,
 /area/prison/engineering)
 "cgD" = (
@@ -35891,6 +36030,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/plate,
 /area/prison/recreation/medsec)
 "cht" = (
@@ -36129,6 +36269,7 @@
 /area/prison/security/armory/riot)
 "cic" = (
 /obj/effect/landmark/corpsespawner/prison_security,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/darkred/full,
 /area/prison/security)
 "cid" = (
@@ -36289,6 +36430,7 @@
 	dir = 8;
 	on = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/yellow{
 	dir = 4
 	},
@@ -36516,6 +36658,7 @@
 	dir = 9
 	},
 /obj/item/ammo_magazine/pistol/g22,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/prison/security/head)
 "cjr" = (
@@ -36608,6 +36751,7 @@
 	dir = 1
 	},
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/blue{
 	dir = 4
 	},
@@ -36668,6 +36812,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/prison/parole/protective_custody)
 "cjO" = (
@@ -36708,6 +36853,7 @@
 /area/prison/execution)
 "cjW" = (
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/prison/execution)
 "cjX" = (
@@ -37140,6 +37286,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/red{
 	dir = 4
 	},
@@ -37221,6 +37368,7 @@
 	dir = 1
 	},
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/yellow/corner{
 	dir = 8
 	},
@@ -37346,6 +37494,7 @@
 	dir = 10
 	},
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/parole/protective_custody)
 "clK" = (
@@ -37647,6 +37796,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/prison/disposal)
 "cmF" = (
@@ -37875,6 +38025,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/prison/parole/protective_custody)
 "cnp" = (
@@ -37896,6 +38047,7 @@
 	dir = 9
 	},
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/prison/security/armory/riot)
 "cnt" = (
@@ -38140,6 +38292,7 @@
 /area/prison/cellblock/protective)
 "coe" = (
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/protective)
 "cof" = (
@@ -38249,6 +38402,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/highsec/south/south)
 "cox" = (
@@ -38956,6 +39110,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/prison/disposal)
 "cqX" = (
@@ -38984,6 +39139,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/prison/disposal)
 "crb" = (
@@ -39531,6 +39687,7 @@
 	dir = 6
 	},
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/prison/cellblock/mediumsec/west)
 "csY" = (
@@ -39624,6 +39781,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/yellow/corner{
 	dir = 4
 	},
@@ -39897,11 +40055,13 @@
 /area/prison/cellblock/mediumsec/east)
 "cuc" = (
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/yellow/corner,
 /area/prison/cellblock/mediumsec/east)
 "cue" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/yellow/corner{
 	dir = 8
 	},
@@ -40113,6 +40273,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/mediumsec/west)
 "cuL" = (
@@ -40123,6 +40284,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/mediumsec/south)
 "cuN" = (
@@ -40235,6 +40397,7 @@
 	dir = 5
 	},
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/yellow{
 	dir = 8
 	},
@@ -40536,6 +40699,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/mediumsec/west)
 "cwh" = (
@@ -40662,6 +40826,7 @@
 /area/prison/cellblock/mediumsec/south)
 "cwB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/darkred{
 	dir = 8
 	},
@@ -40913,6 +41078,7 @@
 /area/prison/cellblock/mediumsec/south)
 "cxO" = (
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/yellow{
 	dir = 1
 	},
@@ -41058,6 +41224,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/mediumsec/south)
 "cyN" = (
@@ -41365,6 +41532,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/mediumsec/south)
 "czH" = (
@@ -41413,6 +41581,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/mediumsec/south)
 "czQ" = (
@@ -41528,6 +41697,16 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/central)
+"cKt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/security/briefing)
+"cMk" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/cellblock/highsec/north/south)
 "cMq" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/r_wall/prison_unmeltable,
@@ -41556,6 +41735,13 @@
 "cPY" = (
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/staff)
+"cQf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/plate,
+/area/prison/cellblock/maxsec/north)
 "cQu" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
@@ -41567,6 +41753,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/nw)
+"cQE" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/darkbrown{
+	dir = 1
+	},
+/area/prison/intake)
 "cRI" = (
 /obj/effect/decal/woodsiding{
 	dir = 8
@@ -41598,6 +41790,11 @@
 	},
 /turf/open/ground/grass,
 /area/prison/residential/central)
+"cSU" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/prison/hangar_storage/research)
 "cTQ" = (
 /turf/open/ground/river,
 /area/prison/residential/central)
@@ -41618,6 +41815,10 @@
 "dbh" = (
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/canteen)
+"diW" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/nw)
 "dkA" = (
 /obj/effect/decal/woodsiding{
 	dir = 1
@@ -41642,8 +41843,29 @@
 	},
 /obj/structure/cable,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/access/north)
+"dni" = (
+/obj/structure/cable,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/yellow{
+	dir = 1
+	},
+/area/prison/cellblock/mediumsec/south)
+"dox" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/asteroid,
+/area/prison/residential/central)
 "dqM" = (
 /obj/structure/toilet{
 	dir = 4
@@ -41672,6 +41894,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/prison/cellblock/maxsec/south)
+"drU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/prison/medbay/morgue)
 "dsF" = (
 /obj/structure/monorail{
 	dir = 5
@@ -41685,6 +41911,18 @@
 	icon_state = "bright_clean2"
 	},
 /area/prison/holding/holding1)
+"duu" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/red{
+	dir = 4
+	},
+/area/prison/recreation/highsec/n)
 "dvu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -41732,6 +41970,24 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/nw)
+"dFj" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/cellblock/highsec/south/north)
+"dMY" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/bright_clean,
+/area/prison/laundry)
+"dNU" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/yellow{
+	dir = 4
+	},
+/area/prison/cellblock/mediumsec/east)
 "dOO" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/prison/bright_clean/two,
@@ -41745,14 +42001,24 @@
 /area/prison/cellblock/mediumsec/west)
 "dQA" = (
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/research/secret/bioengineering)
+"dRO" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/plate,
+/area/prison/cellblock/highsec/north/north)
 "dSP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/wood/broken,
 /area/prison/residential/south)
+"dSR" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/plate,
+/area/prison/recreation/medsec)
 "dVE" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -41791,6 +42057,10 @@
 	dir = 4
 	},
 /area/prison/cellblock/highsec/south/north)
+"dYU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/prison/engineering/atmos)
 "eaN" = (
 /obj/effect/decal/woodsiding,
 /obj/effect/decal/woodsiding{
@@ -41802,6 +42072,13 @@
 /obj/machinery/vending/cola,
 /turf/open/floor/prison/darkyellow/full,
 /area/prison/hallway/engineering)
+"edY" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/cellblock/highsec/north/south)
 "eeT" = (
 /obj/machinery/light{
 	dir = 1
@@ -41811,11 +42088,21 @@
 	dir = 1
 	},
 /area/prison/hangar_storage/main)
+"egT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/red{
+	dir = 1
+	},
+/area/prison/cellblock/highsec/north/north)
 "ejA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/wood/broken,
 /area/prison/residential/north)
+"ejP" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/plate,
+/area/prison/hallway/engineering)
 "ejV" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating,
@@ -41836,6 +42123,20 @@
 	dir = 1
 	},
 /area/prison/hangar/civilian)
+"elt" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/security)
 "elG" = (
 /obj/structure/toilet{
 	dir = 1
@@ -41860,6 +42161,12 @@
 	dir = 4
 	},
 /area/prison/research)
+"eqz" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/whitegreen{
+	dir = 1
+	},
+/area/prison/medbay)
 "ern" = (
 /obj/effect/landmark/fob_sentry_rebel,
 /turf/open/floor/plating,
@@ -41892,6 +42199,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/bright_clean,
 /area/prison/hallway/central)
+"evK" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/red{
+	dir = 1
+	},
+/area/prison/cellblock/highsec/south/north)
 "ewf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -41909,6 +42222,16 @@
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/highsec/south/south)
+"eyk" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/hallway/entrance)
 "eyC" = (
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/plating,
@@ -41959,6 +42282,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/kitchen,
 /area/prison/cellblock/highsec/north/south)
+"eIO" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/prison/engineering)
 "eLE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -42005,6 +42332,15 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/prison/command/office)
+"eXD" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/sterilewhite,
+/area/prison/medbay)
+"eZs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/prison/residential/north)
 "eZF" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/prison/bright_clean/two,
@@ -42016,6 +42352,13 @@
 	},
 /turf/open/floor/wood/broken,
 /area/prison/residential/central)
+"fdk" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/cellblock/highsec/south/north)
 "fej" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
@@ -42066,6 +42409,14 @@
 	},
 /turf/open/floor/plating,
 /area/prison/maintenance/research_medbay)
+"flm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/red{
+	dir = 4
+	},
+/area/prison/cellblock/highsec/south/north)
 "foA" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -42088,6 +42439,17 @@
 /obj/item/reagent_containers/glass/bucket/janibucket,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/sw)
+"ftN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/sterilewhite,
+/area/prison/residential/south)
+"fuI" = (
+/obj/effect/decal/warning_stripes/thin,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/prison/hangar_storage/research)
 "fuY" = (
 /obj/structure/lattice,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
@@ -42106,6 +42468,13 @@
 	dir = 4
 	},
 /area/prison/cellblock/highsec/north/north)
+"fvj" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/cellblock/mediumsec/east)
 "fvE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -42263,6 +42632,11 @@
 	},
 /turf/open/floor/plating,
 /area/prison/hangar/main)
+"fWO" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/ne)
 "fYc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -42274,6 +42648,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/prison/cellblock/maxsec/south)
+"gay" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/prison/residential/north)
 "gaZ" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison,
@@ -42308,6 +42686,13 @@
 /obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/plating,
 /area/prison/research/secret/biolab)
+"geI" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/cellblock/mediumsec/east)
 "gfK" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -42344,6 +42729,10 @@
 /obj/structure/largecrate/random,
 /turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
+"glT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/plate,
+/area/prison/cellblock/mediumsec/east)
 "gmZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -42370,6 +42759,10 @@
 /obj/machinery/landinglight/ds2/delaythree,
 /turf/open/floor/plating,
 /area/prison/hangar/civilian)
+"gnD" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/plate,
+/area/prison/cellblock/highsec/south/south)
 "gnJ" = (
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/plating,
@@ -42393,11 +42786,25 @@
 	dir = 10
 	},
 /area/prison/cellblock/mediumsec/east)
+"gsH" = (
+/obj/machinery/flasher{
+	id = "canteen"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/canteen)
 "gsU" = (
 /obj/structure/table/reinforced,
 /obj/effect/landmark/dropship_console_spawn_lz1,
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/checkpoint/hangar)
+"gsX" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/cellblock/mediumsec/north)
 "gux" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 4;
@@ -42445,6 +42852,15 @@
 /obj/machinery/landinglight/ds2,
 /turf/open/floor/plating,
 /area/prison/hangar/civilian)
+"gCS" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/red{
+	dir = 1
+	},
+/area/prison/cellblock/highsec/south/south)
 "gDz" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison/sterilewhite,
@@ -42467,12 +42883,40 @@
 	dir = 4
 	},
 /area/prison/hangar/main)
+"gFW" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/green{
+	dir = 1
+	},
+/area/prison/quarters/staff)
+"gGI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/red,
+/area/prison/cellblock/highsec/north/south)
 "gGZ" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/prison/cellstripe{
 	dir = 8
 	},
 /area/prison/cellblock/highsec/north/south)
+"gIl" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/prison/research/secret)
+"gIS" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/yellow,
+/area/prison/cellblock/mediumsec/north)
 "gIY" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/prison,
@@ -42491,6 +42935,21 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/wood,
 /area/prison/residential/south)
+"gKC" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/blue{
+	dir = 4
+	},
+/area/prison/cellblock/protective)
+"gKQ" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/hallway/east)
 "gMf" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating,
@@ -42509,6 +42968,12 @@
 /obj/structure/lattice,
 /turf/open/ground/river,
 /area/prison/yard)
+"gRk" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/darkpurple{
+	dir = 4
+	},
+/area/prison/hangar_storage/research)
 "gSj" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison,
@@ -42574,6 +43039,11 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/wood,
 /area/prison/library)
+"hjs" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/bright_clean,
+/area/prison/visitation)
 "hlJ" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 2;
@@ -42624,6 +43094,12 @@
 "hyt" = (
 /turf/open/ground/river,
 /area/prison/yard)
+"hyw" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/blue{
+	dir = 8
+	},
+/area/prison/cellblock/protective)
 "hyA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -42667,10 +43143,18 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/green,
 /area/prison/cellblock/lowsec/se)
+"hKe" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/prison/cellblock/highsec/north/south)
 "hKf" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/ground/river,
 /area/prison/hallway/entrance)
+"hKh" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/prison/research/secret)
 "hKD" = (
 /obj/item/ammo_casing,
 /obj/effect/ai_node,
@@ -42714,6 +43198,7 @@
 	dir = 8
 	},
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/yellow{
 	dir = 8
 	},
@@ -42725,6 +43210,27 @@
 	dir = 4
 	},
 /area/prison/cellblock/mediumsec/west)
+"hTQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/sterilewhite,
+/area/prison/residential/central)
+"hVf" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/red{
+	dir = 4
+	},
+/area/prison/cellblock/highsec/north/north)
+"hVl" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/prison/security/monitoring/highsec)
+"hWq" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/cellblock/highsec/south/north)
 "hWY" = (
 /obj/effect/landmark/sensor_tower,
 /turf/open/floor/prison/sterilewhite,
@@ -42791,10 +43297,23 @@
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/monitoring/maxsec/panopticon)
+"iia" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/sterilewhite,
+/area/prison/residential/north)
 "iib" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/staff)
+"iif" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/red{
+	dir = 4
+	},
+/area/prison/cellblock/highsec/north/south)
 "iii" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -42802,6 +43321,13 @@
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/plating,
 /area/prison/hangar/civilian)
+"ijh" = (
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/kitchen,
+/area/prison/cellblock/mediumsec/north)
 "ikd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -42821,6 +43347,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/red/corner,
 /area/prison/cellblock/highsec/south/north)
 "inF" = (
@@ -42858,8 +43385,23 @@
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating,
 /area/prison/cellblock/maxsec/south)
+"iur" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/bright_clean,
+/area/prison/hallway/central)
+"ivI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/red{
+	dir = 4
+	},
+/area/prison/cellblock/highsec/south/north)
 "izu" = (
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/prison/cellblock/maxsec/south)
 "iAQ" = (
@@ -42893,6 +43435,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/north)
 "iFC" = (
@@ -43001,6 +43544,27 @@
 	},
 /turf/open/floor/prison/darkyellow,
 /area/prison/hangar/civilian)
+"iWb" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/prison/security/checkpoint/vip)
+"iWy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/yellow{
+	dir = 8
+	},
+/area/prison/cellblock/mediumsec/north)
 "iWO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -43010,8 +43574,15 @@
 	},
 /obj/structure/cable,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/nw)
+"iWP" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/cellstripe{
+	dir = 4
+	},
+/area/prison/hallway/east)
 "iXj" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -43036,6 +43607,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/prison/residential/central)
+"iZR" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/whitegreen,
+/area/prison/medbay)
 "jax" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/blue,
@@ -43055,11 +43630,28 @@
 /obj/machinery/computer/nuke_disk_generator/red,
 /turf/open/floor/prison,
 /area/prison/security/head)
+"jeJ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/rampbottom{
+	dir = 8
+	},
+/area/prison/hallway/engineering)
 "jeP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/wood/broken,
 /area/prison/chapel)
+"jfO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/nw)
 "jfX" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -43081,6 +43673,13 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/hallway/central)
+"jiU" = (
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/kitchen,
+/area/prison/toilet/canteen)
 "jlg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
@@ -43089,6 +43688,19 @@
 	},
 /turf/open/floor/prison/yellow{
 	dir = 8
+	},
+/area/prison/cellblock/mediumsec/south)
+"jnI" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/yellow{
+	dir = 1
 	},
 /area/prison/cellblock/mediumsec/south)
 "jnN" = (
@@ -43110,6 +43722,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/mediumsec/north)
+"joU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/prison/disposal)
 "joX" = (
 /turf/open/floor/prison/green{
 	dir = 10
@@ -43127,6 +43743,10 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/prison,
 /area/prison/security/monitoring/highsec)
+"jsQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/prison/security/armory/lethal)
 "jtL" = (
 /obj/effect/decal/woodsiding,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -43146,6 +43766,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/cellblock/lowsec/se)
+"jxb" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/cellstripe{
+	dir = 8
+	},
+/area/prison/cellblock/mediumsec/west)
 "jzd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -43222,6 +43848,30 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/yellow,
 /area/prison/cellblock/mediumsec/south)
+"jJJ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/whitepurple{
+	dir = 4
+	},
+/area/prison/research/secret/biolab)
+"jKs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/red{
+	dir = 4
+	},
+/area/prison/cellblock/highsec/north/south)
+"jLw" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/prison/security/monitoring/highsec)
+"jLJ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/prison/security/monitoring/medsec/south)
 "jNw" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/prison,
@@ -43260,6 +43910,27 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/prison,
 /area/prison/cellblock/mediumsec/east)
+"jWH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/bright_clean,
+/area/prison/yard)
+"jWO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/prison/cellblock/vip)
 "jYS" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/prison/bright_clean/two,
@@ -43320,6 +43991,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/prison/cellblock/mediumsec/east)
+"kla" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/hallway/staff)
 "klH" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitegreen,
@@ -43328,6 +44007,15 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/prison,
 /area/prison/residential/south)
+"kmq" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/blue{
+	dir = 4
+	},
+/area/prison/security/checkpoint/vip)
 "knJ" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /obj/effect/ai_node,
@@ -43394,6 +44082,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/mediumsec/north)
 "kGQ" = (
@@ -43424,6 +44113,10 @@
 /obj/machinery/vending/marine/shared/cigarette/colony,
 /turf/open/floor/prison/darkred/full,
 /area/prison/monorail/east)
+"kPA" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/prison/parole/protective_custody)
 "kQt" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/darkred/full,
@@ -43432,6 +44125,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/prison/research/secret)
+"kVd" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/prison/cellblock/mediumsec/west)
 "kWF" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/prison/plate,
@@ -43452,6 +44149,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/east)
+"kXh" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/access/south)
+"kXn" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/prison/cellblock/highsec/south/north)
 "kXs" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/carpet,
@@ -43465,6 +44170,10 @@
 	},
 /turf/open/floor/prison,
 /area/prison/hangar/main)
+"kZK" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/prison/security/armory/riot)
 "laI" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -43480,6 +44189,25 @@
 	dir = 1
 	},
 /area/prison/cellblock/highsec/south/north)
+"lcG" = (
+/obj/machinery/flasher{
+	id = "panopticon"
+	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/cellblock/maxsec/north)
+"ldi" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/marked,
+/area/prison/hangar_storage/research)
+"ldL" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/engineering)
 "leU" = (
 /obj/machinery/light{
 	dir = 4
@@ -43512,6 +44240,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/prison/security/monitoring/highsec)
+"lqu" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/red{
+	dir = 8
+	},
+/area/prison/cellblock/highsec/south/north)
 "lqx" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison/yellow,
@@ -43549,6 +44283,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/ground/grass,
 /area/prison/residential/central)
+"lxP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/prison/execution)
 "lyC" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison/green{
@@ -43561,6 +44302,11 @@
 	dir = 4
 	},
 /area/prison/cellblock/highsec/north/south)
+"lzN" = (
+/obj/structure/bed/chair,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/prison/security/briefing)
 "lAp" = (
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/closed/wall/prison,
@@ -43575,6 +44321,17 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
+"lBF" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/red,
+/area/prison/cellblock/highsec/south/north)
 "lCB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -43589,12 +44346,25 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/platebot,
 /area/prison/pirate)
+"lFc" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/plate,
+/area/prison/recreation/highsec/n)
 "lGC" = (
 /obj/effect/landmark/xeno_turret_spawn,
 /turf/open/floor/prison/yellow/corner{
 	dir = 1
 	},
 /area/prison/cellblock/mediumsec/south)
+"lHw" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/asteroid,
+/area/prison/residential/central)
+"lJG" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/cleanmarked,
+/area/prison/canteen)
 "lKu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -43648,8 +44418,31 @@
 	},
 /obj/structure/cable,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/se)
+"lVo" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/plate,
+/area/prison/cellblock/protective)
+"lXB" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/prison/hangar_storage/research)
+"lXO" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/prison/cellblock/maxsec/south)
 "lZe" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating,
@@ -43698,6 +44491,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/prison/research/secret/dissection)
+"mnK" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/bright_clean,
+/area/prison/medbay/foyer)
 "mnR" = (
 /obj/effect/landmark/weed_node,
 /obj/structure/cable,
@@ -43718,6 +44515,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/carpet,
 /area/prison/command/secretary_office)
+"mpZ" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/bright_clean,
+/area/prison/hallway/east)
 "mrj" = (
 /obj/effect/landmark/corpsespawner/prison_security,
 /turf/open/floor/prison/yellow/corner{
@@ -43738,6 +44540,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/bright_clean,
 /area/prison/medbay/foyer)
+"mtS" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/green{
+	dir = 8
+	},
+/area/prison/cellblock/lowsec/nw)
 "mvn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -43752,6 +44560,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/bright_clean,
 /area/prison/hallway/central)
+"mvv" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/cellstripe{
+	dir = 8
+	},
+/area/prison/cellblock/highsec/south/south)
 "mwh" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/warning_stripes/thin{
@@ -43767,6 +44581,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/wood/broken,
 /area/prison/parole/protective_custody)
+"myy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/sterilewhite,
+/area/prison/residential/north)
 "myF" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison/bright_clean,
@@ -43808,6 +44630,13 @@
 	dir = 1
 	},
 /area/prison/cellblock/mediumsec/north)
+"mBT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/prison/cellblock/maxsec/north)
 "mCn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -43824,6 +44653,7 @@
 /area/prison/hallway/east)
 "mDb" = (
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/yellow{
 	dir = 4
 	},
@@ -43833,6 +44663,10 @@
 	dir = 8
 	},
 /area/prison/maintenance/residential/ne)
+"mJG" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/prison/security/briefing)
 "mKf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -43894,6 +44728,15 @@
 /obj/structure/cable,
 /turf/open/floor/prison/bright_clean,
 /area/prison/hallway/central)
+"mOk" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/red{
+	dir = 4
+	},
+/area/prison/cellblock/highsec/north/south)
 "mOG" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison/sterilewhite,
@@ -44009,6 +44852,14 @@
 "naL" = (
 /turf/open/floor/wood/broken,
 /area/prison/residential/south)
+"ncz" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/sterilewhite,
+/area/prison/residential/north)
 "ndE" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/darkpurple/corner{
@@ -44041,6 +44892,10 @@
 	dir = 5
 	},
 /area/prison/hallway/central)
+"nhU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/bright_clean,
+/area/prison/hallway/east)
 "nie" = (
 /turf/open/floor/plating,
 /area/prison/residential/central)
@@ -44098,6 +44953,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/bright_clean,
 /area/prison/hallway/central)
+"nni" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/prison/security/monitoring/highsec)
 "noS" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -44123,6 +44982,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/prison/research/secret/biolab)
+"nwK" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/plate,
+/area/prison/cellblock/highsec/south/north)
 "nzo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -44143,6 +45009,15 @@
 	},
 /turf/open/floor/prison,
 /area/prison/quarters/security)
+"nDc" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/yellow{
+	dir = 8
+	},
+/area/prison/cellblock/mediumsec/north)
 "nEr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -44161,6 +45036,16 @@
 /obj/item/stack/rods,
 /turf/open/space/sea,
 /area/space)
+"nFe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/red{
+	dir = 4
+	},
+/area/prison/cellblock/highsec/south/north)
 "nFx" = (
 /turf/open/ground/coast/corner2{
 	dir = 1
@@ -44170,12 +45055,31 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/red,
 /area/prison/cellblock/highsec/south/north)
+"nGt" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/kitchen,
+/area/prison/residential/north)
 "nJI" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
+"nKr" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/yellow,
+/area/prison/cellblock/mediumsec/south)
+"nNh" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/prison/maintenance/research_medbay)
 "nOc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -44210,6 +45114,17 @@
 	},
 /turf/open/floor/prison/bright_clean,
 /area/prison/yard)
+"nQc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/access/south)
 "nQm" = (
 /obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 2;
@@ -44242,6 +45157,19 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/prison/hangar/main)
+"nWt" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/security/monitoring/highsec)
+"nZm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/red{
+	dir = 4
+	},
+/area/prison/cellblock/highsec/north/north)
 "nZE" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -44274,6 +45202,12 @@
 /obj/structure/window/framed/prison/reinforced/hull,
 /turf/open/floor/plating,
 /area/prison/hangar/main)
+"ock" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/yellow{
+	dir = 4
+	},
+/area/prison/cellblock/mediumsec/west)
 "oeg" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -44283,6 +45217,17 @@
 	},
 /turf/open/floor/plating,
 /area/prison/maintenance/hangar_barracks)
+"oeD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/green,
+/area/prison/cellblock/lowsec/ne)
 "ofy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 4;
@@ -44300,6 +45245,18 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/space/sea,
 /area/space)
+"ohC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/whitegreen{
+	dir = 10
+	},
+/area/prison/medbay)
 "oie" = (
 /turf/open/floor/prison/darkred,
 /area/prison/security/monitoring/highsec)
@@ -44343,6 +45300,23 @@
 	dir = 1
 	},
 /area/prison/hallway/staff)
+"ori" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/yellow{
+	dir = 8
+	},
+/area/prison/cellblock/mediumsec/south)
+"osS" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/cellblock/highsec/south/north)
 "oti" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison/cleanmarked,
@@ -44413,6 +45387,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/prison/hangar/civilian)
+"oyy" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/darkred{
+	dir = 1
+	},
+/area/prison/security/monitoring/highsec)
 "oyO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable,
@@ -44422,6 +45402,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/nw)
+"ozx" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/blue,
+/area/prison/cellblock/protective)
 "oAL" = (
 /obj/effect/landmark/corpsespawner/prisoner,
 /obj/effect/decal/cleanable/blood/splatter,
@@ -44433,6 +45425,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/bright_clean,
 /area/prison/hallway/east)
+"oCR" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/prison/research/secret/bioengineering)
 "oGc" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/darkpurple,
@@ -44443,6 +45439,17 @@
 	dir = 8
 	},
 /area/prison/cellblock/mediumsec/south)
+"oKS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/ne)
 "oMZ" = (
 /turf/closed/wall/r_wall/prison,
 /area/prison/command/quarters)
@@ -44474,6 +45481,7 @@
 /area/prison/hangar/civilian)
 "oRV" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/highsec/north/north)
 "oSl" = (
@@ -44506,6 +45514,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/nw)
+"pdQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/sterilewhite,
+/area/prison/residential/central)
 "pep" = (
 /obj/structure/prop/mainship/hangar_stencil/two,
 /obj/effect/decal/warning_stripes/thin,
@@ -44545,6 +45563,23 @@
 "pkm" = (
 /turf/open/ground/coast,
 /area/prison/maintenance/residential/access/north)
+"pkz" = (
+/obj/structure/bed/stool,
+/obj/item/paper/prison_station/inmate_handbook,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/prison/intake)
+"pkA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/sw)
 "pkD" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -44571,6 +45606,10 @@
 "puv" = (
 /turf/open/floor/prison,
 /area/prison/security/checkpoint/hangar)
+"puF" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/prison/security/head)
 "pzw" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating,
@@ -44609,6 +45648,15 @@
 	},
 /turf/open/floor/plating,
 /area/prison/hangar_storage/research)
+"pDn" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/red{
+	dir = 4
+	},
+/area/prison/cellblock/highsec/north/north)
 "pDC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -44634,6 +45682,17 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/prison/yellow,
 /area/prison/cellblock/mediumsec/south)
+"pEW" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/sterilewhite,
+/area/prison/residential/north)
 "pFK" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/prison/bright_clean,
@@ -44641,6 +45700,17 @@
 "pIy" = (
 /turf/open/ground/coast/corner2,
 /area/prison/maintenance/residential/access/north)
+"pJW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/prison/cellblock/maxsec/south)
 "pLL" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/prison/bright_clean/two,
@@ -44656,6 +45726,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/yard)
+"pNp" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/yellow/corner,
+/area/prison/cellblock/mediumsec/south)
 "pNt" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -44738,6 +45812,13 @@
 	dir = 4
 	},
 /area/prison/cellblock/highsec/north/north)
+"pXR" = (
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/plate,
+/area/prison/cellblock/maxsec/north)
 "pYg" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/prison/darkyellow{
@@ -44762,6 +45843,16 @@
 	},
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/monitoring/maxsec/panopticon)
+"qbd" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/prison/residential/north)
 "qcr" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/r_wall/prison_unmeltable,
@@ -44792,6 +45883,10 @@
 	},
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/nw)
+"qgg" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/sterilewhite,
+/area/prison/cellblock/highsec/north/south)
 "qhf" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating,
@@ -44810,6 +45905,21 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/residential/north)
+"qkv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/hallway/entrance)
+"qkA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/sterilewhite,
+/area/prison/research/secret/bioengineering)
 "qlN" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/prison/bright_clean/two,
@@ -44821,6 +45931,15 @@
 "qqY" = (
 /turf/closed/wall/r_wall/prison,
 /area/prison/maintenance/residential/access/north)
+"qsb" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/yellow{
+	dir = 1
+	},
+/area/prison/cellblock/mediumsec/south)
 "qsn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -44828,6 +45947,10 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison/bright_clean,
 /area/prison/hallway/central)
+"qtN" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/darkbrown,
+/area/prison/hallway/east)
 "qtT" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison/red/corner{
@@ -44880,12 +46003,20 @@
 	},
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/hallway/entrance)
+"qEG" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/plate,
+/area/prison/toilet/canteen)
 "qFm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/prison/hangar/civilian)
+"qFw" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/bright_clean/two,
+/area/prison/canteen)
 "qFD" = (
 /turf/open/ground/coast/corner2{
 	dir = 4
@@ -44904,6 +46035,21 @@
 	dir = 1
 	},
 /area/prison/cellblock/mediumsec/south)
+"qJu" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/prison/execution)
+"qJG" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/canteen)
 "qKk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -44920,6 +46066,12 @@
 	},
 /turf/open/floor/plating,
 /area/prison/hangar_storage/research)
+"qMn" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/cellstripe{
+	dir = 8
+	},
+/area/prison/hallway/east)
 "qNy" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -44956,11 +46108,31 @@
 /obj/effect/landmark/sensor_tower,
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/yard)
+"qSk" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/red{
+	dir = 1
+	},
+/area/prison/cellblock/highsec/south/south)
 "qST" = (
 /obj/structure/window/reinforced,
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/prison/green,
 /area/prison/quarters/staff)
+"qWz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/blue/full,
+/area/prison/security/checkpoint/vip)
 "qWN" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -44970,6 +46142,20 @@
 	},
 /turf/open/floor/plating,
 /area/prison/hangar/civilian)
+"qZb" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/prison/security)
+"ray" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/darkred,
+/area/prison/security/briefing)
+"raD" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/darkred{
+	dir = 8
+	},
+/area/prison/security)
 "raF" = (
 /turf/open/floor/wood/broken,
 /area/prison/parole/protective_custody)
@@ -44993,6 +46179,12 @@
 /obj/item/tool/mop,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/sw)
+"reE" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/red/corner{
+	dir = 8
+	},
+/area/prison/cellblock/highsec/south/south)
 "reT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -45000,6 +46192,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/bright_clean,
 /area/prison/hallway/central)
+"rfc" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/nw)
 "rfl" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
@@ -45020,6 +46217,25 @@
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/prison/plate,
 /area/prison/recreation/highsec/s)
+"riM" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/bright_clean,
+/area/prison/hallway/central)
+"rkb" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/sw)
 "rlq" = (
 /obj/machinery/light{
 	dir = 4
@@ -45064,6 +46280,10 @@
 "rqK" = (
 /turf/open/floor/prison/rampbottom,
 /area/prison/maintenance/residential/nw)
+"rqN" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/ne)
 "rqR" = (
 /obj/machinery/light,
 /turf/open/floor/prison/kitchen,
@@ -45098,6 +46318,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/prison/cellblock/maxsec/north)
+"rtK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/prison/disposal)
 "rtR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -45129,6 +46356,14 @@
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/plating,
 /area/prison/hangar/main)
+"ryx" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/hallway/entrance)
 "rzd" = (
 /obj/machinery/vending/marine/shared/cigarette/colony,
 /obj/effect/decal/warning_stripes/thin{
@@ -45139,6 +46374,15 @@
 	},
 /turf/open/floor/plating,
 /area/prison/hangar/civilian)
+"rze" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/red{
+	dir = 4
+	},
+/area/prison/cellblock/highsec/south/south)
 "rBG" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/wall/r_wall/prison,
@@ -45150,6 +46394,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/kitchen,
 /area/prison/kitchen)
+"rEk" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/sterilewhite,
+/area/prison/research)
 "rEr" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/prison/sterilewhite,
@@ -45178,6 +46430,10 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/whitepurple/full,
 /area/prison/research/secret/biolab)
+"rFt" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/prison/cellblock/highsec/south/south)
 "rFI" = (
 /obj/effect/landmark/corpsespawner/prison_security,
 /turf/open/floor/prison/bright_clean,
@@ -45201,6 +46457,27 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/bright_clean,
 /area/prison/yard)
+"rIf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/access/north)
+"rKg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/prison/cellblock/maxsec/north)
 "rKR" = (
 /obj/structure/lattice,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
@@ -45219,6 +46496,23 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison,
 /area/prison/cellblock/vip)
+"rOB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/sterilewhite,
+/area/prison/research/secret/bioengineering)
+"rPZ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/yellow{
+	dir = 1
+	},
+/area/prison/cellblock/mediumsec/north)
 "rSZ" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/prison/bright_clean/two,
@@ -45231,6 +46525,10 @@
 	dir = 4
 	},
 /area/prison/cellblock/mediumsec/south)
+"rUP" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/hallway/staff)
 "rVa" = (
 /obj/machinery/light{
 	dir = 1
@@ -45238,11 +46536,21 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/access/north)
+"rYJ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/prison/library)
 "rZh" = (
 /obj/effect/landmark/xeno_resin_door,
 /obj/effect/ai_node,
 /turf/open/floor/prison/cleanmarked,
 /area/prison/yard)
+"rZm" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/green{
+	dir = 4
+	},
+/area/prison/monorail/west)
 "rZE" = (
 /obj/structure/lattice,
 /turf/open/ground/river,
@@ -45263,6 +46571,12 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/r_wall/prison_unmeltable,
 /area/prison/research/secret/biolab)
+"seK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/prison/cellblock/maxsec/north)
 "sgC" = (
 /obj/effect/landmark/xeno_turret_spawn,
 /turf/open/floor/prison/yellow{
@@ -45290,6 +46604,19 @@
 	dir = 4
 	},
 /area/prison/security)
+"skE" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/sterilewhite,
+/area/prison/medbay)
+"slH" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/red{
+	dir = 9
+	},
+/area/prison/cellblock/highsec/south/north)
 "soh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -45374,6 +46701,20 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/red,
 /area/prison/cellblock/highsec/north/north)
+"syI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/prison/residential/south)
+"syJ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/cellblock/mediumsec/south)
 "sBo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -45384,6 +46725,14 @@
 	dir = 4
 	},
 /area/prison/cellblock/protective)
+"sBC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/yellow{
+	dir = 8
+	},
+/area/prison/cellblock/mediumsec/south)
 "sBO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -45425,11 +46774,26 @@
 /obj/effect/ai_node,
 /turf/open/shuttle/blackfloor,
 /area/prison/pirate)
+"sIJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/asteroid,
+/area/prison/residential/central)
 "sJB" = (
 /obj/structure/cable,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/green/corner,
 /area/prison/cellblock/lowsec/se)
+"sKg" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/prison/security/monitoring/highsec)
 "sMg" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -45443,6 +46807,17 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/bright_clean,
 /area/prison/hallway/central)
+"sME" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/blue,
+/area/prison/cellblock/protective)
 "sNc" = (
 /turf/closed/wall/r_wall/prison,
 /area/prison/maintenance/residential/nw)
@@ -45450,6 +46825,26 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/prison/bright_clean,
 /area/prison/hallway/entrance)
+"sOM" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/prison/research/secret)
+"sQF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/yellow{
+	dir = 8
+	},
+/area/prison/cellblock/mediumsec/north)
 "sQS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -45477,6 +46872,10 @@
 "sTZ" = (
 /turf/open/ground/river,
 /area/prison/cellblock/maxsec/south)
+"sWh" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/carpet,
+/area/prison/research/RD)
 "sWQ" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -45486,8 +46885,18 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/hallway/central)
+"sYw" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/red{
+	dir = 1
+	},
+/area/prison/cellblock/highsec/south/north)
 "sZH" = (
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/canteen)
 "tak" = (
@@ -45516,6 +46925,14 @@
 	dir = 8
 	},
 /area/prison/cellblock/highsec/south/north)
+"thE" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/cellblock/protective)
+"tkT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/carpet,
+/area/prison/security/head)
 "tlK" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/wall/prison,
@@ -45534,6 +46951,12 @@
 	},
 /turf/open/floor/wood,
 /area/prison/residential/south)
+"tmz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/prison/cellblock/maxsec/south)
 "tmF" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/ai_node,
@@ -45595,6 +47018,10 @@
 /obj/effect/spawner/modularmap/prison/civressouth,
 /turf/template_noop,
 /area/prison/residential/south)
+"tzx" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/sw)
 "tAo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -45635,6 +47062,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/blue{
 	dir = 5
 	},
@@ -45664,6 +47092,11 @@
 	},
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/sw)
+"tNS" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/prison/hangar_storage/research)
 "tNX" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/prison/darkred/full,
@@ -45677,6 +47110,7 @@
 /area/prison/hangar/civilian)
 "tPY" = (
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/yellow{
 	dir = 8
 	},
@@ -45782,6 +47216,22 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/sw)
+"ugW" = (
+/obj/effect/decal/warning_stripes/thin,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/prison/hangar_storage/research)
+"uhu" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/plate,
+/area/prison/cellblock/maxsec/north)
+"uhB" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/whitepurple/corner{
+	dir = 4
+	},
+/area/prison/research/secret/biolab)
 "ulF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -45810,8 +47260,27 @@
 	dir = 4
 	},
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/research/secret/bioengineering)
+"uoO" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/canteen)
+"upB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/bright_clean,
+/area/prison/hallway/central)
 "uqW" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -45822,6 +47291,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/prison/hallway/entrance)
+"utU" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/prison/cellblock/maxsec/south)
 "uua" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/prison/kitchen,
@@ -45843,12 +47319,29 @@
 /obj/structure/flora/pottedplant/ten,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/nw)
+"uwa" = (
+/obj/structure/bed/chair/comfy,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/prison/execution)
+"uxG" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/prison/residential/central)
+"uzl" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/yellow{
+	dir = 4
+	},
+/area/prison/cellblock/mediumsec/west)
 "uBX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
 /obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/bright_clean,
 /area/prison/medbay/foyer)
 "uCz" = (
@@ -45871,10 +47364,31 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/prison/cellblock/maxsec/north)
+"uGX" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/yellow{
+	dir = 1
+	},
+/area/prison/cellblock/mediumsec/north)
 "uKB" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/research/secret/biolab)
+"uNd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/ne)
 "uQX" = (
 /obj/machinery/vending/marine/shared/cigarette/colony,
 /turf/open/floor/prison,
@@ -45897,6 +47411,16 @@
 	dir = 4
 	},
 /area/prison/cellblock/mediumsec/north)
+"uUQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/sterilewhite,
+/area/prison/residential/north)
+"uUV" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/prison/security/checkpoint/highsec/s)
 "uVo" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/prison/kitchen,
@@ -45947,6 +47471,12 @@
 	},
 /turf/open/floor/plating,
 /area/prison/cellblock/maxsec/south)
+"vcJ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/red{
+	dir = 8
+	},
+/area/prison/cellblock/highsec/south/south)
 "vdD" = (
 /obj/structure/disposaloutlet{
 	dir = 1
@@ -45963,6 +47493,10 @@
 	},
 /turf/open/floor/plating,
 /area/prison/hangar/civilian)
+"vew" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/prison/hallway/entrance)
 "vfh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -45980,6 +47514,10 @@
 /obj/effect/landmark/fob_sentry,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/nw)
+"vfM" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/bright_clean/two,
+/area/prison/hallway/east)
 "vgj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -46011,6 +47549,21 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/prison/cellblock/vip)
+"vhX" = (
+/obj/machinery/shower{
+	pixel_y = 15
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/kitchen,
+/area/prison/toilet/canteen)
+"vlm" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/prison/maintenance/residential/access/north)
+"vma" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/sterilewhite,
+/area/prison/cellblock/highsec/south/north)
 "vmo" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/wood,
@@ -46077,6 +47630,16 @@
 /obj/structure/janitorialcart,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/sw)
+"vxU" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/structure/disposalpipe/junction/flipped{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/bright_clean,
+/area/prison/hallway/central)
 "vBj" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/secure_data,
@@ -46096,6 +47659,11 @@
 "vEh" = (
 /turf/open/floor/wood/broken,
 /area/prison/parole/main)
+"vEl" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/kitchen,
+/area/prison/kitchen)
 "vEU" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/cleanmarked,
@@ -46113,6 +47681,10 @@
 "vGa" = (
 /turf/closed/wall/r_wall/prison,
 /area/prison/yard)
+"vHs" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood/broken,
+/area/prison/library)
 "vHN" = (
 /obj/structure/reagent_dispensers/wallmounted/peppertank,
 /obj/effect/ai_node,
@@ -46134,6 +47706,21 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/darkred/full,
 /area/prison/security/checkpoint/maxsec)
+"vLg" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/plating_catwalk/prison,
+/area/prison/hallway/east)
+"vLM" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/bright_clean,
+/area/prison/visitation)
+"vMY" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/prison/security/monitoring/highsec)
 "vNd" = (
 /obj/machinery/door/airlock/mainship/security/glass/free_access{
 	dir = 2;
@@ -46152,6 +47739,20 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/south)
+"vPs" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/cleanmarked,
+/area/prison/canteen)
 "vPB" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -46209,6 +47810,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/hallway/central)
+"vYi" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/plate,
+/area/prison/cellblock/maxsec/north)
 "vYn" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -46224,6 +47830,19 @@
 	dir = 4
 	},
 /area/prison/medbay)
+"vZI" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/yellow{
+	dir = 4
+	},
+/area/prison/cellblock/mediumsec/north)
+"wax" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/red{
+	dir = 5
+	},
+/area/prison/cellblock/highsec/south/north)
 "wbe" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -46244,6 +47863,10 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating,
 /area/prison/research/secret/biolab)
+"wdC" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/whitegreen/full,
+/area/prison/medbay)
 "wfv" = (
 /obj/effect/landmark/fob_sentry_rebel,
 /turf/open/floor/prison/bright_clean,
@@ -46252,6 +47875,13 @@
 /obj/structure/cable,
 /turf/open/floor/prison/bright_clean,
 /area/prison/hallway/central)
+"wgD" = (
+/obj/machinery/shower{
+	pixel_y = 15
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/kitchen,
+/area/prison/cellblock/mediumsec/north)
 "whB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -46261,6 +47891,25 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/mediumsec/north)
+"wjT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/yellow/corner{
+	dir = 4
+	},
+/area/prison/cellblock/mediumsec/south)
+"wkz" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/plate,
+/area/prison/cellblock/maxsec/north)
+"wmu" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/darkred{
+	dir = 4
+	},
+/area/prison/security)
 "wmU" = (
 /obj/structure/bed/chair,
 /obj/effect/ai_node,
@@ -46287,6 +47936,18 @@
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating,
 /area/prison/security/monitoring/lowsec/sw)
+"woY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/sterilewhite,
+/area/prison/residential/central)
+"wpP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/prison/security/armory/lethal)
 "wpW" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison/green/full,
@@ -46329,6 +47990,15 @@
 	dir = 8
 	},
 /area/prison/medbay)
+"wwH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/darkred{
+	dir = 1
+	},
+/area/prison/security)
 "wxn" = (
 /obj/structure/cable,
 /obj/effect/decal/warning_stripes/thin{
@@ -46368,6 +48038,29 @@
 /obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/prison/residential/south)
+"wHb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/green{
+	dir = 4
+	},
+/area/prison/monorail/west)
+"wHm" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/bright_clean,
+/area/prison/execution)
+"wJg" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/red{
+	dir = 4
+	},
+/area/prison/cellblock/highsec/south/north)
+"wKs" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/plate,
+/area/prison/recreation/medsec)
 "wMM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -46385,6 +48078,19 @@
 	},
 /turf/open/floor/prison,
 /area/prison/hangar/main)
+"wOM" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/yellow{
+	dir = 1
+	},
+/area/prison/cellblock/mediumsec/west)
 "wOX" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
@@ -46394,6 +48100,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/prison/hangar/civilian)
+"wQF" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/prison/hallway/east)
 "wTa" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison/red{
@@ -46429,6 +48139,10 @@
 "xdx" = (
 /turf/closed/wall/r_wall/prison_unmeltable,
 /area/prison/security/checkpoint/hangar)
+"xeb" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/prison/cellblock/mediumsec/east)
 "xeM" = (
 /obj/machinery/door/airlock/mainship/maint/free_access{
 	dir = 2
@@ -46458,6 +48172,15 @@
 	dir = 8
 	},
 /area/prison/security/monitoring/maxsec/panopticon)
+"xqe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/red{
+	dir = 4
+	},
+/area/prison/cellblock/highsec/north/south)
 "xrp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
@@ -46486,6 +48209,10 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/central)
+"xtT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/yellow,
+/area/prison/cellblock/mediumsec/east)
 "xwA" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/prison,
@@ -46508,6 +48235,10 @@
 "xAI" = (
 /turf/closed/wall/r_wall/prison,
 /area/prison/research/secret/biolab)
+"xAS" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/bright_clean,
+/area/prison/canteen)
 "xBb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -46527,6 +48258,16 @@
 /obj/effect/ai_node,
 /turf/open/floor/prison/bright_clean,
 /area/prison/hallway/central)
+"xDM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/prison/recreation/medsec)
 "xFW" = (
 /obj/machinery/gibber,
 /turf/open/floor/prison/kitchen,
@@ -46630,11 +48371,17 @@
 	dir = 1
 	},
 /area/prison/maintenance/staff_research)
+"yeT" = (
+/obj/structure/bed/stool,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/prison/intake)
 "yfh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/machinery/miner/damaged,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/security/monitoring/highsec)
 "yfH" = (
@@ -46670,6 +48417,7 @@
 /area/prison/cellblock/mediumsec/south)
 "yiA" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/weed_node,
 /turf/open/floor/prison/bright_clean,
 /area/prison/laundry)
 "yiF" = (
@@ -46686,6 +48434,13 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/prison/command/quarters)
+"yjo" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison,
+/area/prison/cellblock/vip)
 "yjF" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison/darkyellow{
@@ -51679,19 +53434,19 @@ aab
 aab
 avl
 aHn
-awm
+iia
 aJC
 avN
 aLa
-axb
+gay
 awi
 aRT
 eWq
 aSN
-aSN
+diW
 aSN
 iSZ
-iSZ
+rfc
 rqK
 aSN
 nkA
@@ -51987,7 +53742,7 @@ tKQ
 bEU
 bxf
 iJd
-bxf
+tzx
 tuK
 bwv
 bJA
@@ -52450,11 +54205,11 @@ avl
 avl
 avl
 aym
-axG
+nGt
 aJE
 aKs
 aLb
-aLb
+eZs
 aMB
 aRT
 pkD
@@ -52497,7 +54252,7 @@ jFi
 tvZ
 cTQ
 cOd
-bzT
+rkb
 bxf
 ufB
 cCM
@@ -52762,10 +54517,10 @@ bxf
 hvJ
 bwv
 bGR
-bLL
+kXs
 bMB
 bLL
-bMS
+syI
 bKo
 bLO
 bGU
@@ -52952,7 +54707,7 @@ aab
 aab
 avm
 avL
-axb
+gay
 axb
 axE
 ayQ
@@ -53731,7 +55486,7 @@ ejA
 azi
 aAN
 aBU
-aJJ
+uUQ
 aJJ
 aJJ
 aJJ
@@ -53798,7 +55553,7 @@ bOX
 bCc
 bCc
 bCc
-bCc
+ftN
 bOd
 gKj
 abn
@@ -54039,7 +55794,7 @@ aWq
 aXx
 aWq
 bwv
-bBJ
+pkA
 bxf
 bxf
 frU
@@ -54275,12 +56030,12 @@ beD
 aVP
 wzD
 bhC
-bhC
+dox
 bkL
 bhC
 bhC
 bhC
-xwG
+lHw
 bkL
 bhC
 bhC
@@ -54518,7 +56273,7 @@ uZP
 aRT
 qfo
 aSN
-aTW
+jfO
 aRT
 aWs
 aXy
@@ -54763,7 +56518,7 @@ adO
 aab
 avm
 aHo
-aIu
+ncz
 aBV
 avN
 axG
@@ -55050,12 +56805,12 @@ bga
 bma
 vue
 aYR
-aYR
+uxG
 aYR
 bRi
 bga
 bhC
-bhC
+dox
 bsV
 bdQ
 aWr
@@ -55791,7 +57546,7 @@ aHM
 aLd
 avN
 aHr
-aIw
+pEW
 aJJ
 aJJ
 aJJ
@@ -55799,7 +57554,7 @@ aJJ
 iFv
 aJJ
 aJJ
-aJJ
+uUQ
 aJJ
 aJJ
 aJJ
@@ -55809,13 +57564,13 @@ aWw
 aXC
 aWw
 aWw
-cIe
+woY
 aWw
 aCr
 aKt
 beH
 bgf
-xwG
+lHw
 bhC
 aWr
 aVI
@@ -55826,30 +57581,30 @@ iYA
 bRj
 aWr
 bhC
-bhC
+dox
 uCz
 btA
 bey
 aCr
-aWw
+hTQ
 aWw
 cIe
 aWw
-aWw
+hTQ
 aWw
 bCc
 bhA
 dXU
-bCc
+ftN
 bGZ
 bCc
 bCc
-bCc
+ftN
 ouQ
 bCc
 bCc
 bCc
-bCc
+ftN
 bPd
 bQI
 bGU
@@ -56574,7 +58329,7 @@ aOZ
 aQB
 aRU
 aSR
-aUl
+oKS
 aRU
 aWu
 aXE
@@ -56592,7 +58347,7 @@ bga
 bao
 aYR
 aYR
-aYR
+uxG
 aYR
 bRk
 bga
@@ -56819,7 +58574,7 @@ adO
 aab
 avm
 aAK
-aIz
+myy
 aBV
 avN
 axG
@@ -57358,16 +59113,16 @@ aWr
 aWI
 beG
 bgd
+dox
 bhC
 bhC
 bhC
 bhC
-bhC
-bkL
-bhC
+sIJ
 bhC
 bhC
 bhC
+dox
 aVP
 bRB
 aWI
@@ -57602,7 +59357,7 @@ awr
 avM
 aRU
 aSR
-aUl
+oKS
 aRU
 aWq
 aXG
@@ -58095,7 +59850,7 @@ avN
 avN
 avN
 avN
-ayR
+qbd
 azg
 azg
 avN
@@ -58606,7 +60361,7 @@ aab
 aab
 avm
 avT
-axb
+gay
 axb
 axE
 ayQ
@@ -58681,7 +60436,7 @@ bKo
 bMD
 bSj
 bTL
-bSV
+nQc
 bTL
 bSj
 bLL
@@ -58871,7 +60626,7 @@ avK
 avK
 axJ
 azX
-aAU
+rIf
 azX
 axJ
 azj
@@ -59144,7 +60899,7 @@ aaq
 aaq
 aRU
 aOo
-aUl
+oKS
 aDc
 iqK
 iqK
@@ -59643,7 +61398,7 @@ azX
 aAQ
 aCc
 aEK
-azX
+vlm
 axJ
 avN
 aTU
@@ -59676,7 +61431,7 @@ bbO
 aWr
 blN
 aWI
-blM
+pdQ
 bpd
 aWr
 bbO
@@ -59709,10 +61464,10 @@ bVu
 bGU
 bSj
 bLV
-bSV
+nQc
 bTL
 bTL
-bTL
+kXh
 bSk
 aab
 adO
@@ -59915,10 +61670,10 @@ aaq
 aaq
 aDc
 aSR
-fLv
+fWO
 aSR
 aSR
-aSR
+rqN
 jbN
 aDc
 iqK
@@ -60739,7 +62494,7 @@ adO
 aab
 bTR
 bTL
-bSV
+nQc
 bTL
 bTR
 aab
@@ -60946,10 +62701,10 @@ aat
 aat
 aat
 aDc
-aSR
+rqN
 fLv
 aSR
-jbN
+uNd
 aRU
 bcQ
 bcQ
@@ -61222,19 +62977,19 @@ boc
 bph
 bqd
 bqH
+wHb
 brz
 brz
-brz
-brz
+wHb
 brz
 bvt
 brz
-brz
+wHb
 brz
 byw
 bxp
 bAW
-bAW
+rZm
 bDD
 btc
 aab
@@ -62467,7 +64222,7 @@ adO
 aab
 ayp
 azX
-aAU
+rIf
 azX
 azp
 azX
@@ -62491,12 +64246,12 @@ aaq
 aaq
 bdI
 aZY
-aZY
+jLw
 bbS
 bbS
 bbS
 bdW
-aZY
+jLw
 aZY
 bdC
 bjR
@@ -62727,7 +64482,7 @@ rVa
 aAU
 azX
 adf
-azX
+vlm
 azR
 qqY
 aak
@@ -63530,7 +65285,7 @@ baa
 bjS
 bhB
 aYY
-aYY
+nni
 aYY
 aYY
 bhB
@@ -63566,7 +65321,7 @@ adO
 aab
 bSk
 bTL
-bSV
+nQc
 bTL
 bSk
 aab
@@ -64030,7 +65785,7 @@ aat
 aat
 bdC
 bnh
-bnh
+hVl
 baa
 aXK
 baY
@@ -64266,7 +66021,7 @@ adO
 aab
 ayp
 azX
-aAU
+rIf
 azX
 qqY
 aae
@@ -64295,7 +66050,7 @@ bbU
 bcW
 bdF
 beT
-aYY
+nni
 bhJ
 biR
 bjT
@@ -64316,7 +66071,7 @@ bwy
 bvr
 aYY
 aYY
-aYY
+nni
 aWz
 aab
 aab
@@ -64337,7 +66092,7 @@ adO
 aab
 bTR
 bTL
-bSV
+nQc
 bTL
 bTR
 aab
@@ -64547,7 +66302,7 @@ bng
 bng
 baa
 bab
-bba
+vMY
 oie
 baa
 aaE
@@ -64558,7 +66313,7 @@ vNd
 bjR
 bkr
 aYY
-aYY
+nni
 lnA
 aYY
 bkr
@@ -65108,7 +66863,7 @@ bCe
 bCe
 bSk
 bMP
-bSV
+nQc
 bTL
 bSk
 bTR
@@ -65580,12 +67335,12 @@ aCl
 ibS
 aES
 vNd
-bjR
+oyy
 tTN
 bdC
 bjR
 bkr
-blY
+nWt
 blY
 blY
 blY
@@ -65879,7 +67634,7 @@ byy
 bzz
 bSj
 bTL
-bSV
+nQc
 bTL
 bZI
 bXi
@@ -66390,29 +68145,29 @@ bwz
 bwz
 bwz
 bwz
-bwz
+lqu
 bwz
 bwz
 bYr
 bZJ
 bZT
+vcJ
 bZT
 bZT
 bZT
 bZT
-bZT
-bZT
+vcJ
 bZT
 bZT
 cle
-bZQ
+gnD
 clt
 bZQ
+gnD
 bZQ
 bZQ
 bZQ
-bZQ
-cgi
+reE
 cri
 ceH
 aab
@@ -66583,13 +68338,13 @@ aBc
 aCh
 aCh
 aER
-bDd
+jKs
 kyN
 aTT
 blW
 kyN
 bDd
-kyN
+iif
 kyN
 kyN
 kyN
@@ -66597,14 +68352,14 @@ aPb
 aQD
 aRW
 aRW
-aRW
+xqe
 aRW
 nOU
 aRW
+xqe
 aRW
 aRW
-aRW
-aRW
+xqe
 aSV
 bdM
 bdI
@@ -66625,15 +68380,15 @@ bqJ
 bdI
 cvk
 bvz
-bvz
+ivI
 bvz
 hrX
 bvz
+ivI
 bvz
 bvz
 bvz
-bvz
-bvz
+ivI
 bvz
 laO
 bIq
@@ -66641,7 +68396,7 @@ bvz
 bvz
 bvz
 bvz
-hrX
+nFe
 bvz
 bVv
 bvz
@@ -67123,7 +68878,7 @@ aHw
 bdI
 beY
 bjR
-lnA
+sKg
 biU
 bjX
 bkY
@@ -67134,7 +68889,7 @@ bpj
 bqh
 bqQ
 brD
-lnA
+sKg
 oie
 beY
 bdI
@@ -67170,7 +68925,7 @@ cbb
 bYC
 bZP
 ceL
-ceL
+mvv
 bVk
 cbf
 bZP
@@ -67352,7 +69107,7 @@ azr
 aAe
 oRV
 aGb
-aCi
+hKe
 aET
 aCl
 aEP
@@ -67409,13 +69164,13 @@ bvA
 byC
 bFT
 bvA
-byx
+dFj
 bwA
 bvA
-byx
+dFj
 bwA
 bvA
-bvH
+nwK
 bwA
 bvA
 bTT
@@ -67676,10 +69431,10 @@ bvC
 bvG
 bvA
 bTT
-bKs
+kXn
 bwA
 bZQ
-bYz
+rFt
 cba
 cbf
 cbf
@@ -67879,7 +69634,7 @@ aCl
 aCl
 aCl
 aOG
-aES
+gGI
 aCl
 aFe
 aGb
@@ -67913,7 +69668,7 @@ buv
 bwA
 bvB
 bwC
-buI
+slH
 bvv
 bwC
 bCf
@@ -67921,7 +69676,7 @@ bwA
 buv
 bvA
 byC
-bFT
+lBF
 bvA
 bvA
 bvA
@@ -68181,11 +69936,11 @@ byC
 bFT
 bvA
 bwA
-bDG
+fdk
 bvC
 bvA
 bwA
-bDG
+fdk
 bwA
 bvC
 bvA
@@ -68635,9 +70390,9 @@ aon
 aor
 arZ
 aAe
-aox
+dRO
 aGb
-aCi
+hKe
 aES
 aCl
 aCl
@@ -68650,7 +70405,7 @@ aIs
 aEV
 aCl
 aOF
-aES
+gGI
 aCl
 aFe
 aGb
@@ -68704,10 +70459,10 @@ bwC
 bvA
 bvA
 byC
-bKs
+kXn
 bwA
 bZQ
-bYz
+rFt
 cbc
 cbf
 cdL
@@ -68914,7 +70669,7 @@ aJQ
 aVt
 aWA
 ibS
-aES
+gGI
 aWA
 bbd
 aJQ
@@ -69130,22 +70885,22 @@ aab
 aab
 anA
 amW
-apo
+hVf
 apo
 pXu
 apo
-apo
+hVf
 ase
 asO
 ats
 fvh
-fvh
+nZm
 fvh
 fvh
 fvh
 aws
 ats
-fvh
+nZm
 fvh
 fvh
 fvh
@@ -69154,7 +70909,7 @@ aCk
 kyN
 kyN
 kyN
-kyN
+iif
 bru
 kyN
 kyN
@@ -69198,7 +70953,7 @@ bvA
 bvA
 bvA
 bvA
-byE
+sYw
 nFz
 bvA
 bvA
@@ -69206,7 +70961,7 @@ bvA
 bvA
 bvA
 bHg
-bIw
+osS
 bJE
 cvn
 bLe
@@ -69419,7 +71174,7 @@ aCl
 aLO
 aGb
 aGb
-aDS
+cMk
 aPc
 aES
 aCl
@@ -69699,7 +71454,7 @@ bkb
 bsM
 bmk
 vfh
-vhE
+yjo
 bps
 bsM
 bqU
@@ -70428,7 +72183,7 @@ aos
 aox
 avo
 aon
-arZ
+egT
 aye
 aon
 ayu
@@ -70480,7 +72235,7 @@ bfc
 bfc
 bdN
 bvF
-bwF
+wJg
 bwF
 bwF
 byG
@@ -70488,11 +72243,11 @@ bzE
 xHS
 dYg
 bDF
-xHS
+flm
 xHS
 bHj
 bIG
-ovE
+hWq
 bvw
 bvA
 bxk
@@ -70950,10 +72705,10 @@ aor
 aor
 aBg
 aCp
-aDV
+lFc
 aEY
 aEI
-aDV
+lFc
 aIG
 aBg
 aUY
@@ -71218,7 +72973,7 @@ aCg
 aCg
 aCg
 aNf
-aDS
+cMk
 aPc
 fUv
 aCl
@@ -71241,7 +72996,7 @@ bkc
 bla
 bmh
 bnn
-boa
+jWO
 bpq
 bla
 bqV
@@ -71267,7 +73022,7 @@ bwH
 bxm
 bLf
 bwz
-bwz
+lqu
 bvv
 bOm
 bGN
@@ -71721,10 +73476,10 @@ aor
 aor
 aBg
 aCp
-aDV
+lFc
 aDV
 aGm
-aDV
+lFc
 aIG
 aBg
 aUY
@@ -71816,12 +73571,12 @@ csX
 ctM
 csy
 cuF
-cvv
+uzl
 cvv
 hTA
 cwu
 csy
-sGS
+ock
 sGS
 cxx
 cxM
@@ -72025,7 +73780,7 @@ bvG
 bwA
 bvB
 bwC
-byC
+evK
 bvw
 bwC
 bCf
@@ -72034,7 +73789,7 @@ bvG
 bvA
 byC
 bIl
-ovE
+hWq
 bvw
 bvA
 bxk
@@ -72227,7 +73982,7 @@ apl
 app
 avp
 avU
-arZ
+egT
 asi
 avU
 ayv
@@ -72334,11 +74089,11 @@ cqK
 cqM
 cqK
 cwv
-cuJ
+jxb
 cet
 cqK
 cwv
-cuJ
+jxb
 cet
 cxL
 bWl
@@ -72503,7 +74258,7 @@ aCl
 aCl
 aCl
 aNe
-aDS
+cMk
 aPc
 aES
 aCl
@@ -72512,7 +74267,7 @@ aGb
 aVv
 aCl
 aLO
-aES
+gGI
 aCl
 bbe
 aGb
@@ -72809,7 +74564,7 @@ bwH
 bxm
 bwz
 bwz
-bwz
+lqu
 bwz
 bOn
 bPo
@@ -72821,7 +74576,7 @@ bWY
 bOn
 bZT
 bZT
-bZT
+vcJ
 bZT
 ceS
 cgi
@@ -72994,7 +74749,7 @@ asm
 asX
 aty
 asX
-asX
+pDn
 auN
 asX
 asX
@@ -73002,7 +74757,7 @@ awv
 asm
 bhr
 asX
-asX
+pDn
 asX
 aBi
 aCw
@@ -73011,13 +74766,13 @@ aFb
 aGr
 aFb
 aIK
-aBi
+duu
 aDP
 aDP
-aDP
+mOk
 aDP
 aLN
-aNI
+edY
 aPf
 aQF
 aCl
@@ -73053,7 +74808,7 @@ bvC
 bwA
 bxr
 bvA
-bvF
+wax
 bzH
 bvA
 bCh
@@ -73082,7 +74837,7 @@ bZU
 bZU
 ceZ
 cgj
-bZU
+rze
 bZU
 bZU
 bZU
@@ -73097,7 +74852,7 @@ cqI
 cbB
 crW
 csA
-cmN
+wOM
 ctN
 cuk
 cqM
@@ -73297,7 +75052,7 @@ bhS
 blb
 bmq
 bhX
-boj
+iWb
 bpx
 bqj
 bhS
@@ -73494,7 +75249,7 @@ akF
 ofy
 alD
 akV
-akV
+azh
 akV
 akV
 izu
@@ -73509,7 +75264,7 @@ izu
 akV
 akV
 akV
-akV
+azh
 akV
 akV
 aww
@@ -73548,7 +75303,7 @@ bdc
 bdP
 bfi
 bgI
-bhT
+kmq
 bhT
 mZq
 blc
@@ -73792,7 +75547,7 @@ aDS
 aPc
 fUv
 aDS
-aSZ
+qgg
 aSZ
 aSZ
 aSZ
@@ -73800,7 +75555,7 @@ aXU
 aSZ
 aSZ
 aSZ
-aSZ
+qgg
 bdd
 bdO
 bdO
@@ -73821,19 +75576,19 @@ bgi
 bdO
 bdO
 bvJ
-bwJ
+vma
 bwJ
 bwJ
 bwJ
 bzI
-bwJ
+vma
 bwJ
 bwJ
 bwJ
 ovE
 byC
 bGf
-ovE
+hWq
 bvw
 bLg
 bLS
@@ -73851,7 +75606,7 @@ bZV
 bZQ
 bSm
 bZO
-coz
+qSk
 cgl
 bZO
 ciz
@@ -74005,7 +75760,7 @@ bWl
 bWl
 akF
 akV
-akV
+azh
 alF
 irZ
 akV
@@ -74118,22 +75873,22 @@ bYC
 bYC
 bYC
 bYC
-coA
+gCS
 cba
 cpT
 cqM
-cqM
+kVd
 cqM
 csD
-cmN
+wOM
 ctP
 cul
 cvw
-cvw
+vtJ
 cvP
 cvw
 cvw
-cvw
+vtJ
 cvw
 cvw
 vtJ
@@ -74540,7 +76295,7 @@ sTZ
 sTZ
 sTZ
 akK
-amT
+lXO
 akV
 axM
 ayA
@@ -74559,7 +76314,7 @@ aLi
 aLV
 aJR
 aLO
-aDS
+cMk
 aPc
 fUv
 aDS
@@ -74568,10 +76323,10 @@ aSZ
 aSZ
 mOG
 aXX
+qgg
 aSZ
 aSZ
-aSZ
-aSZ
+qgg
 eDY
 bdO
 bfl
@@ -74592,12 +76347,12 @@ bgL
 btH
 bdO
 bvJ
-bwJ
+vma
 bwJ
 bwJ
 bwJ
 bzL
-bwJ
+vma
 bwJ
 bwJ
 rEr
@@ -74839,7 +76594,7 @@ bki
 bhU
 bbi
 bns
-bol
+qWz
 bpw
 bhU
 bki
@@ -74869,10 +76624,10 @@ bMI
 bMI
 bOq
 bPt
-bQV
+dMY
 bSA
 bSA
-bQV
+dMY
 bXc
 bOq
 bYC
@@ -75019,19 +76774,19 @@ afc
 aqM
 ade
 ads
-ads
+seK
 ads
 rfl
 ads
-ads
+seK
 ads
 ade
 ads
-cPB
+mBT
 ajd
 ajJ
 ads
-ads
+seK
 ael
 akK
 axS
@@ -75136,7 +76891,7 @@ bZS
 cmc
 ccK
 cnO
-coz
+qSk
 cba
 cnO
 ciy
@@ -75146,14 +76901,14 @@ bYC
 bYC
 bYC
 bYC
-coz
+qSk
 cba
 bZW
 cqI
 cbB
 crW
 csA
-cmN
+wOM
 ctN
 cqK
 cuK
@@ -75568,7 +77323,7 @@ and
 xhO
 axS
 akK
-amT
+lXO
 akV
 axM
 auw
@@ -75803,7 +77558,7 @@ aje
 aem
 add
 acL
-adc
+rKg
 akK
 ayM
 xhO
@@ -75924,7 +77679,7 @@ ccV
 caq
 bXn
 ccV
-cnz
+dni
 ctS
 cun
 cuL
@@ -76037,7 +77792,7 @@ bWl
 bWl
 acK
 acO
-adc
+rKg
 acO
 add
 adY
@@ -76154,31 +77909,31 @@ bMM
 bNB
 bOq
 bPt
-bQV
+dMY
 rby
 bSo
 yiA
 bXc
 bOq
 bZY
-cbk
+wKs
 cbk
 cbk
 lRN
 cbk
-lRN
+dSR
 ciA
 caa
-cap
+gsX
 cbA
 ccV
-cap
+gsX
 cbA
 ccV
-cap
+gsX
 cbA
 ccV
-cap
+gsX
 cbA
 ccV
 cnB
@@ -76403,7 +78158,7 @@ bFh
 aqp
 bHu
 bIy
-bwN
+uUV
 bKw
 aqp
 bFh
@@ -76596,7 +78351,7 @@ and
 xhO
 axS
 akK
-amT
+lXO
 akV
 axM
 ayI
@@ -76808,7 +78563,7 @@ bWl
 bWl
 acK
 acO
-adc
+rKg
 acO
 add
 aep
@@ -76955,23 +78710,23 @@ csE
 ctg
 mrj
 cuo
-cuP
+bOu
 cuP
 pBe
 cuP
-cuP
+bOu
 cuP
 cuP
 cwA
-cuP
+bOu
 cuP
 oHP
 oHP
-cuP
+bOu
 cuP
 cuP
 cvR
-cyQ
+wjT
 cvA
 cta
 cvA
@@ -77087,7 +78842,7 @@ afe
 afy
 ajL
 add
-acO
+atp
 adc
 akK
 axS
@@ -77197,16 +78952,16 @@ cgs
 chr
 ciA
 caa
-caj
+uGX
 clp
 cmo
 cmo
-cmo
+vZI
 cmo
 sqQ
 cmo
 cmo
-cmo
+vZI
 cmo
 cmo
 cth
@@ -77478,7 +79233,7 @@ cun
 cuR
 cwk
 cun
-cxz
+lim
 ctj
 cun
 cwk
@@ -77696,10 +79451,10 @@ aLs
 aKP
 bPx
 bQV
-bQV
+dMY
 bQV
 bSs
-bQV
+dMY
 bXc
 bOq
 caa
@@ -77963,7 +79718,7 @@ cab
 caa
 caa
 bTF
-ceU
+xDM
 caa
 caa
 ciC
@@ -77971,16 +79726,16 @@ caa
 cae
 clq
 ccV
-cap
+gsX
 cbA
 ccV
-cap
+gsX
 cbA
 ccV
-cap
+gsX
 cbA
 ccV
-cnB
+jnI
 ctT
 cun
 cuM
@@ -78482,7 +80237,7 @@ caa
 caa
 caa
 caa
-cae
+rPZ
 clq
 ccV
 ccV
@@ -78987,7 +80742,7 @@ bUo
 bVI
 bNc
 bXe
-cae
+rPZ
 bYw
 ccU
 cdX
@@ -78999,13 +80754,13 @@ ccU
 ckt
 xyg
 ccV
-cap
+gsX
 cnQ
 ccV
 kGj
 cbA
 ccV
-cap
+gsX
 cbA
 ccV
 cnZ
@@ -79036,7 +80791,7 @@ cxz
 ctj
 czk
 czs
-ctm
+syJ
 cvA
 cyw
 bWl
@@ -79265,7 +81020,7 @@ ccV
 ckq
 cln
 ccV
-cnB
+jnI
 ctT
 cun
 cuV
@@ -79454,7 +81209,7 @@ aYe
 aVB
 bai
 aPw
-aQR
+mtS
 aQR
 aYd
 aQR
@@ -79463,7 +81218,7 @@ aQR
 aVA
 bko
 blf
-aKP
+aXw
 aKP
 aPu
 aKP
@@ -79510,7 +81265,7 @@ cdY
 ccV
 cdY
 ccV
-cae
+rPZ
 bYx
 ccV
 cuy
@@ -79658,7 +81413,7 @@ ajk
 afY
 add
 acO
-adc
+rKg
 akK
 axS
 axS
@@ -79895,7 +81650,7 @@ atp
 adc
 acO
 add
-adY
+pXR
 aez
 aeP
 add
@@ -80150,7 +81905,7 @@ bWl
 acK
 acO
 adc
-acO
+atp
 add
 aep
 aey
@@ -80413,15 +82168,15 @@ afA
 afZ
 add
 afe
-afz
+lcG
 aeQ
 add
 afe
-afz
+lcG
 aeQ
 add
 afe
-afz
+lcG
 aeN
 aeQ
 add
@@ -80493,7 +82248,7 @@ bkp
 aNp
 aXY
 aWR
-boA
+jWH
 aWR
 bql
 brf
@@ -80578,9 +82333,9 @@ cvA
 crr
 czn
 czx
+jLJ
 czK
-czK
-czK
+jLJ
 cAc
 cAf
 cAe
@@ -80686,7 +82441,7 @@ ajg
 aex
 add
 acO
-adc
+rKg
 akK
 ayM
 xhO
@@ -80940,7 +82695,7 @@ add
 add
 add
 ajl
-ajK
+cQf
 add
 acO
 sQS
@@ -81180,7 +82935,7 @@ acM
 adu
 uGW
 add
-aer
+uhu
 aex
 add
 adB
@@ -81441,14 +83196,14 @@ adW
 afD
 add
 adX
+vYi
+afD
+add
+wkz
 adW
 afD
 add
-adX
-adW
-afD
-add
-adX
+wkz
 adW
 afD
 add
@@ -81714,7 +83469,7 @@ acO
 adc
 ahr
 acO
-adc
+rKg
 akK
 axS
 xhO
@@ -81824,7 +83579,7 @@ cfo
 cfp
 ccV
 cae
-bYx
+gIS
 ccV
 cuy
 cby
@@ -82075,9 +83830,9 @@ cak
 cbw
 ccV
 ceb
-cfp
+ijh
 ccV
-ceb
+wgD
 cfp
 ccV
 ckv
@@ -82093,7 +83848,7 @@ cao
 cbz
 ccV
 cnB
-ctT
+nKr
 cun
 cuS
 cvd
@@ -82226,7 +83981,7 @@ acO
 acO
 ajo
 ajT
-acO
+atp
 acO
 sQS
 akK
@@ -82377,7 +84132,7 @@ cxz
 ctl
 czk
 czs
-ctm
+syJ
 cvA
 cyw
 bWl
@@ -82875,7 +84630,7 @@ cun
 cun
 cun
 cun
-cxN
+qsb
 ctj
 cun
 cun
@@ -82999,10 +84754,10 @@ agL
 agL
 agL
 agt
-akV
+azh
 akV
 alF
-akV
+azh
 akV
 amv
 ani
@@ -83037,7 +84792,7 @@ aGF
 aCW
 aKN
 aLs
-bnE
+iur
 aKP
 aKP
 aKP
@@ -83103,9 +84858,9 @@ cae
 bYx
 ccV
 ceb
-cfp
+ijh
 ccV
-ceb
+wgD
 cfp
 ccV
 cae
@@ -83121,7 +84876,7 @@ caq
 bXn
 ccV
 cnB
-ctT
+nKr
 cun
 ccB
 cuL
@@ -83261,22 +85016,22 @@ als
 alJ
 alo
 alo
-alo
+tmz
 alo
 pWz
-anB
+pJW
 amC
 amC
 dvu
 amC
-amC
+utU
 amC
 arB
 amC
+utU
 amC
 amC
-amC
-amC
+utU
 amC
 awH
 axq
@@ -83366,7 +85121,7 @@ cfo
 cfp
 ccV
 cae
-bYx
+gIS
 ccV
 cap
 cbA
@@ -83510,7 +85265,7 @@ agX
 agL
 agJ
 ajp
-agL
+vVg
 agL
 agL
 agt
@@ -84134,7 +85889,7 @@ ced
 uGx
 ccW
 ccW
-ciH
+nDc
 ccW
 caf
 clw
@@ -84142,32 +85897,32 @@ njY
 njY
 njY
 njY
-fKC
+iWy
 njY
 njY
 njY
-njY
+sQF
 csJ
 ctp
 qdw
 cuu
-cvb
+ori
 cvb
 cvb
 ewf
+ori
 cvb
 cvb
-cvb
-cvb
+ori
 cvb
 oiK
 xrp
+sBC
 cyr
 cyr
 cyr
 cyr
-cyr
-cyr
+sBC
 cyr
 cyX
 cyr
@@ -84292,14 +86047,14 @@ agL
 agL
 agt
 anP
-anJ
+nNh
 apt
 apI
-apI
+eXD
 apI
 apK
 apI
-apI
+eXD
 apI
 apK
 auA
@@ -84316,7 +86071,7 @@ apK
 aIj
 apK
 apM
-aqY
+skE
 aHW
 aJa
 aFx
@@ -84330,7 +86085,7 @@ aQX
 aQX
 qsn
 aQX
-aMh
+riM
 aMj
 aNu
 aNu
@@ -84406,7 +86161,7 @@ ccU
 ccU
 cdX
 cot
-ctX
+pNp
 cuv
 cvc
 cvc
@@ -84544,7 +86299,7 @@ akL
 ahk
 agL
 agL
-agL
+vVg
 agL
 agL
 agt
@@ -84827,7 +86582,7 @@ azl
 azD
 aqv
 aqv
-aBv
+ohC
 apK
 aFw
 aGI
@@ -85177,7 +86932,7 @@ cap
 cbA
 ccV
 cnB
-ctT
+nKr
 cun
 cuM
 cvA
@@ -85541,14 +87296,14 @@ bWl
 rrt
 acF
 acF
-acF
+wcU
 acF
 acF
 acF
 acX
 adh
 adx
-adG
+uKB
 aeh
 aeF
 adG
@@ -85577,20 +87332,20 @@ agJ
 agJ
 agt
 akm
-anJ
+nNh
 apt
 apM
 apI
 avY
+wdC
 avY
-avY
+apI
+apI
+eXD
 apI
 apI
 apI
-apI
-apI
-apI
-apI
+eXD
 apI
 apI
 axZ
@@ -85598,11 +87353,11 @@ azw
 avY
 avY
 ayj
-aub
+iZR
 aEn
 aFz
 aFz
-aFz
+mnK
 aGK
 aJT
 aKN
@@ -85615,7 +87370,7 @@ aAR
 aKN
 gWy
 aTv
-aUI
+oeD
 aTS
 aWV
 aPE
@@ -86205,19 +87960,19 @@ cqO
 ccw
 cqd
 coI
-cua
+xtT
 cpU
 cve
+glT
+cpU
+fvj
 cqO
 cpU
-cqf
-cqO
-cpU
-cqf
+fvj
 cxm
 cpU
 cqf
-cqO
+glT
 jSF
 cyx
 cyx
@@ -86311,10 +88066,10 @@ bWl
 bWl
 rrt
 acF
+wcU
 acF
 acF
-acF
-acF
+wcU
 acF
 acZ
 adk
@@ -86343,7 +88098,7 @@ ahR
 ahk
 agL
 agL
-agL
+vVg
 agL
 agL
 agt
@@ -86373,11 +88128,11 @@ apK
 apK
 aFC
 aGC
-aFz
+mnK
 aJe
 aJT
 aKN
-aLs
+upB
 aKP
 aKN
 aNr
@@ -86576,11 +88331,11 @@ acF
 acX
 adq
 adx
-adK
+uhB
 aej
 aeH
 aeW
-aeI
+jJJ
 aeI
 aeY
 agt
@@ -86700,7 +88455,7 @@ bTb
 cas
 sBo
 cdd
-bTb
+gKC
 bTb
 bTb
 bTb
@@ -86871,7 +88626,7 @@ arH
 ast
 apP
 atj
-aub
+iZR
 apK
 auT
 apL
@@ -87131,10 +88886,10 @@ atF
 auc
 apK
 auU
-apM
+eqz
 awd
 awO
-apI
+eXD
 ayb
 apK
 azI
@@ -87144,7 +88899,7 @@ aDk
 apK
 aFC
 aGC
-aFz
+mnK
 aJe
 aJT
 aKN
@@ -87223,12 +88978,12 @@ chB
 bTa
 clA
 cmv
-bTa
+hyw
 clG
 bUA
 cpn
 cpY
-cpY
+xeb
 cpY
 cpY
 csL
@@ -87238,7 +88993,7 @@ cux
 cqR
 cqR
 ctz
-iHZ
+dNU
 cqR
 cqR
 sgC
@@ -87653,7 +89408,7 @@ awP
 apK
 azJ
 awM
-apI
+eXD
 aDm
 apK
 aFD
@@ -87720,7 +89475,7 @@ aOj
 bPX
 bPY
 bRu
-bRv
+rYJ
 bUC
 bRv
 bUC
@@ -87728,14 +89483,14 @@ bRv
 bUC
 cbD
 bUC
-bRv
+rYJ
 bUC
 bPX
 chu
 ciN
 cjH
 ckC
-tQo
+ozx
 cht
 cht
 cht
@@ -87750,7 +89505,7 @@ coI
 cua
 cwc
 cpY
-cpY
+xeb
 cpU
 cqT
 cqe
@@ -87981,7 +89736,7 @@ bRv
 bUC
 bRv
 bUC
-bRv
+rYJ
 bUC
 bRv
 fwZ
@@ -87995,27 +89750,27 @@ ckD
 cjC
 cmx
 cnh
-coc
+lVo
 cav
 car
 cpV
 cqO
-cwO
+geI
 crZ
 csK
 coI
-cua
+xtT
 cpU
 cpU
 cpU
 cpU
-cqf
+fvj
 cqO
 cpU
-cqf
+fvj
 cqO
 cpU
-cqf
+fvj
 cqO
 cqh
 bWl
@@ -88264,7 +90019,7 @@ cpg
 cua
 cwc
 cpY
-cpY
+xeb
 cpU
 cpV
 cpW
@@ -88416,7 +90171,7 @@ apg
 auh
 atJ
 atJ
-atJ
+drU
 atJ
 atJ
 atJ
@@ -88651,7 +90406,7 @@ afv
 aiI
 aiw
 ajG
-akC
+sOM
 aka
 alg
 alz
@@ -88677,7 +90432,7 @@ atJ
 atJ
 hqG
 atJ
-atJ
+drU
 atJ
 atf
 aAt
@@ -88690,7 +90445,7 @@ uBX
 aIb
 aKc
 aKS
-aKm
+vxU
 aKP
 aKN
 gWy
@@ -88763,7 +90518,7 @@ chv
 chv
 cvX
 bXv
-cjC
+sME
 cht
 cht
 cht
@@ -88771,22 +90526,22 @@ cht
 car
 cpV
 cqO
-cwO
+geI
 crZ
 csK
 coI
-cua
+xtT
 cpU
-cpY
+xeb
 cpU
-cpY
+xeb
 cpU
 cqO
-cwO
+geI
 cpV
 cpU
 cqO
-cwO
+geI
 cpV
 cqh
 bWl
@@ -88901,7 +90656,7 @@ afJ
 ahd
 ahn
 agq
-aiV
+rOB
 agq
 aiu
 afw
@@ -89523,11 +91278,11 @@ bTf
 bUE
 bRv
 fwZ
-bRv
+rYJ
 bUC
-bRv
+rYJ
 bUC
-bRv
+rYJ
 fwZ
 bPX
 chx
@@ -89686,11 +91441,11 @@ alB
 alP
 ama
 ama
-ama
+gIl
 anq
 anZ
 akD
-ama
+gIl
 aqa
 aqD
 arj
@@ -89699,7 +91454,7 @@ asB
 ath
 atM
 aum
-atM
+bKz
 auX
 avy
 awg
@@ -89718,7 +91473,7 @@ aIe
 aJh
 aAv
 aIH
-aLs
+upB
 aKP
 aKN
 kxw
@@ -89776,7 +91531,7 @@ aKN
 bPX
 bQd
 bRv
-hXd
+vHs
 bPY
 bRv
 bUC
@@ -89924,7 +91679,7 @@ aeZ
 afr
 afO
 agp
-agp
+qkA
 agp
 agp
 agp
@@ -89934,7 +91689,7 @@ agq
 aiy
 afm
 aiW
-ajG
+hKh
 akg
 kRr
 aiZ
@@ -90305,10 +92060,10 @@ bQi
 bQi
 bQi
 ckH
-cjC
+sME
 cqS
 cni
-cod
+thE
 bYM
 car
 cqe
@@ -90568,23 +92323,23 @@ cnj
 bYM
 coJ
 car
-cqf
+fvj
 cqO
 cpU
-cqf
+fvj
 cqO
 ctA
-cqf
+fvj
 cuA
 cpU
 cve
-cqO
+glT
 cpU
 cqf
-cqO
+glT
 cpU
 cqf
-cqO
+glT
 cqh
 bWl
 bWl
@@ -90767,7 +92522,7 @@ aKP
 aOb
 aKP
 aKP
-aKP
+aXw
 aKP
 aPu
 aKN
@@ -91061,7 +92816,7 @@ aKN
 bQi
 bHo
 cuT
-cuT
+ldL
 ycx
 bVX
 bUF
@@ -91076,7 +92831,7 @@ ceY
 ciR
 bQi
 bXv
-cjC
+sME
 cmx
 cnh
 coc
@@ -91207,24 +92962,24 @@ aab
 bWl
 aeZ
 afw
-afS
+oCR
 afv
 afS
 afw
 afS
-afS
+oCR
 afw
-afS
+oCR
 afv
 afM
 aiK
 ajG
-ajG
+hKh
 aiM
 aiI
 akS
 ajG
-ajG
+hKh
 alS
 amb
 amp
@@ -91234,7 +92989,7 @@ aof
 apb
 amb
 aqg
-aqH
+sWh
 arp
 arT
 asF
@@ -91242,7 +92997,7 @@ atm
 atQ
 arm
 avE
-ava
+rEk
 avE
 avB
 awU
@@ -91336,7 +93091,7 @@ ckI
 ckJ
 cqS
 cni
-cod
+thE
 bYM
 cpp
 bWl
@@ -91582,7 +93337,7 @@ bRC
 bYS
 bYv
 bXx
-bXx
+eIO
 bXx
 cbJ
 cgB
@@ -92611,7 +94366,7 @@ bUF
 bUF
 bUF
 ccl
-bXx
+eIO
 cfs
 cft
 chG
@@ -92625,7 +94380,7 @@ chH
 chH
 cpt
 cqk
-cjR
+joU
 crz
 cse
 csP
@@ -92783,7 +94538,7 @@ aab
 aab
 atC
 auo
-auo
+gRk
 avg
 auo
 aqQ
@@ -92811,11 +94566,11 @@ aPQ
 aRj
 aSs
 aTF
-aVa
+qFw
 aVT
 aXd
 aYu
-dbh
+uoO
 aVT
 aXd
 aYu
@@ -92830,7 +94585,7 @@ aVX
 aVT
 aXd
 aYu
-dbh
+uoO
 aVT
 aXd
 aYu
@@ -93047,7 +94802,7 @@ avh
 avh
 avh
 avh
-avh
+tNS
 avh
 avh
 avh
@@ -93091,7 +94846,7 @@ dbh
 aVT
 aXd
 aYu
-aVa
+qFw
 aTF
 bjU
 bua
@@ -93130,11 +94885,11 @@ cfu
 bRC
 bQi
 mwK
-ciU
+kPA
 ciU
 bYq
 xBb
-ciU
+kPA
 raF
 chH
 cps
@@ -93376,7 +95131,7 @@ bQj
 bRH
 bTl
 bUK
-bWk
+dYU
 bXC
 bYZ
 bRM
@@ -93597,11 +95352,11 @@ bef
 bik
 bef
 bef
-aXf
+xAS
 aVT
 aXd
 aYu
-dbh
+uoO
 aVT
 aXd
 aYu
@@ -93639,7 +95394,7 @@ bQg
 bRM
 ecN
 cdf
-cbW
+ejP
 cfw
 cgF
 chH
@@ -93839,15 +95594,15 @@ aPV
 aOt
 aOt
 aOt
-aVa
+qFw
 aWa
 aXd
 aYu
-aZu
+gsH
 aVT
 aXd
 aYu
-aXf
+xAS
 dbh
 dbh
 dbh
@@ -93862,7 +95617,7 @@ aZu
 aVT
 aXd
 aYu
-aVa
+qFw
 aTF
 bue
 bue
@@ -94068,14 +95823,14 @@ aab
 aab
 atl
 atl
-eyC
+fuI
 atl
 atl
 atl
+lXB
 atl
 atl
-atl
-atl
+lXB
 atl
 pBH
 avh
@@ -94404,7 +96159,7 @@ bQj
 bRK
 bTl
 bUK
-bWk
+dYU
 bXE
 bZd
 bRM
@@ -94618,22 +96373,22 @@ dbh
 aVT
 aXd
 aYu
-aXf
+xAS
 bef
 bfD
 bef
 bin
 bjr
 bkC
-aXf
+xAS
 aVT
 aXd
 aYu
-dbh
+uoO
 aVT
 aXd
 aYu
-aVa
+qFw
 aTF
 bug
 bug
@@ -95096,14 +96851,14 @@ aab
 aab
 atl
 atl
-mTC
+ugW
 atl
 atl
 atl
-atl
+lXB
 eul
 atl
-atl
+lXB
 atl
 pBH
 jfX
@@ -95389,22 +97144,22 @@ sZH
 baq
 aXd
 aYu
-aXf
+xAS
 bei
 bei
 bdk
-bio
+vPs
 bei
 bei
-aXf
+xAS
 aVT
 aXd
 aYu
-boN
+qJG
 aVT
 aXd
 aYu
-aVa
+qFw
 aTF
 buj
 bvb
@@ -95443,11 +97198,11 @@ cfA
 cgJ
 chL
 cja
-cjP
+rtK
 ckO
 clN
 cjP
-cjP
+rtK
 cjP
 coN
 cnp
@@ -95633,7 +97388,7 @@ aLH
 aMt
 aMT
 aDA
-aOv
+gFW
 aPW
 aRn
 aSw
@@ -95946,7 +97701,7 @@ bQj
 bRM
 bRM
 bUT
-bWk
+dYU
 bWk
 bWk
 bRM
@@ -96124,14 +97879,14 @@ aab
 aab
 atl
 atl
-eyC
+fuI
 atl
 atl
 atl
+lXB
 atl
 atl
-atl
-atl
+lXB
 atl
 pBH
 avh
@@ -96152,11 +97907,11 @@ aPW
 aRn
 aSw
 aOt
-aVa
+qFw
 aVT
 aXd
 aYu
-aZu
+gsH
 baq
 aXd
 aYu
@@ -96178,12 +97933,12 @@ aYu
 aVa
 btt
 bul
-bvd
+vLM
 bwa
 bwW
 bwZ
 byc
-bvd
+vLM
 bAn
 btt
 bAA
@@ -96424,15 +98179,15 @@ bhd
 bjt
 aTF
 aTF
-bdk
+lJG
 aVT
 aXd
 aYv
-boN
+qJG
 aVT
 aXd
 aYu
-aVa
+qFw
 btt
 bul
 bvd
@@ -96723,20 +98478,20 @@ bRP
 bRM
 cbY
 cdl
-cbY
+jeJ
 cbY
 cfD
 mof
 chQ
-chQ
+qJu
 ckR
 ckR
-ckR
+uwa
 ckR
 chQ
 coP
 cmB
-cqp
+wHm
 cqp
 crH
 crg
@@ -96931,7 +98686,7 @@ dbh
 aVT
 aXd
 aYu
-aXf
+xAS
 bdl
 bfH
 bhf
@@ -96949,12 +98704,12 @@ aYu
 aVa
 btt
 bul
-wCb
+hjs
 bvd
 bwX
 bwX
 bwX
-bvd
+vLM
 bys
 wCb
 bCQ
@@ -97180,11 +98935,11 @@ aQb
 aRn
 aSw
 aOt
-aVa
+qFw
 aVT
 aXd
 aYu
-dbh
+uoO
 aVT
 aXd
 aYu
@@ -97195,15 +98950,15 @@ bhg
 bix
 biF
 bdl
-aXf
+xAS
 aVT
 aXd
 aYu
-boN
+qJG
 aVT
 aXd
 aYu
-aVa
+qFw
 btt
 bul
 bvd
@@ -97499,16 +99254,16 @@ bEI
 cfD
 cfD
 rES
-chC
+lxP
 ckR
 ckR
-ckR
+uwa
 ckR
 chQ
 coP
 chQ
 cqr
-chQ
+qJu
 gvs
 crg
 aab
@@ -97668,11 +99423,11 @@ atU
 aur
 auI
 avj
-avj
+ldi
 xwA
 avj
 avj
-vsx
+cSU
 auI
 azU
 aAJ
@@ -97720,12 +99475,12 @@ bmF
 bmF
 btt
 bum
-bvd
+vLM
 bwa
 bwW
 bwZ
 byc
-bvd
+vLM
 bAr
 btt
 bAA
@@ -97992,23 +99747,23 @@ bEA
 bEI
 bEA
 bEs
-bEA
+vLg
 bEA
 bJs
 bEA
+vLg
 bEA
 bEA
 bEA
-bEA
-bEG
+gKQ
 bEA
 bEA
 bXP
 bZn
-bEA
+vLg
 bIN
 bEA
-bEI
+wQF
 bYl
 cfF
 cgM
@@ -98220,7 +99975,7 @@ bdl
 bek
 beE
 bem
-biB
+vEl
 bjx
 bhm
 bdl
@@ -98244,7 +99999,7 @@ bvd
 btt
 bCH
 bCH
-bCH
+vfM
 bCH
 bBC
 bCS
@@ -98273,12 +100028,12 @@ chQ
 cjW
 ckR
 ckR
-ckR
+uwa
 ckR
 chQ
 coP
 cpG
-cqp
+wHm
 cqp
 crI
 crg
@@ -98491,12 +100246,12 @@ bnG
 boV
 btt
 bul
-bvd
+vLM
 bvd
 bwX
 bwX
 bwX
-bvd
+vLM
 bvd
 btt
 bCI
@@ -98742,7 +100497,7 @@ bmH
 bmH
 bmH
 bfF
-bpU
+qEG
 bmH
 bmH
 bmH
@@ -99023,10 +100778,10 @@ bEs
 hYR
 bLt
 bMk
-bNb
+cQE
 bNQ
 bNQ
-bQl
+pkz
 bNQ
 bTx
 bVa
@@ -99035,7 +100790,7 @@ bXS
 bZp
 caG
 cbs
-bMu
+qZb
 cev
 bQp
 cgN
@@ -99235,13 +100990,13 @@ aOJ
 aQi
 aRu
 aRD
-aRD
+kla
 aRu
 aWc
 aXi
 aYw
 aZy
-aRD
+kla
 aRu
 bax
 bdn
@@ -99262,7 +101017,7 @@ bmH
 bmH
 btt
 bjW
-bvd
+vLM
 bwc
 btt
 bxC
@@ -99529,13 +101284,13 @@ bAt
 btt
 bCS
 bAA
-oAY
+mpZ
 bAA
 bAA
-bAA
+nhU
 bEs
 oAY
-bAA
+nhU
 bMm
 bNb
 bNR
@@ -99558,12 +101313,12 @@ cjf
 cjZ
 cjZ
 cjZ
-cjZ
+cKt
 cjf
 cok
 cjf
 cpK
-cje
+mJG
 crh
 aab
 aab
@@ -99812,12 +101567,12 @@ cfH
 cgO
 chV
 cje
+lzN
 cjY
 cjY
 cjY
 cjY
-cjY
-coj
+ray
 coT
 cpL
 cje
@@ -100023,17 +101778,17 @@ biD
 bem
 bkF
 bdl
-bmK
+vhX
 bpg
 boX
 bpU
-bpU
+qEG
 boX
 bpg
-bsS
+jiU
 btt
 bup
-bvd
+vLM
 buK
 bwZ
 bxF
@@ -100300,18 +102055,18 @@ bAw
 btt
 bCS
 bAA
-bAA
+nhU
 bEI
 bHQ
-bHQ
+iWP
 bEs
 bEI
 bLu
 bMk
-bNb
+cQE
 bNQ
 bNQ
-bNQ
+yeT
 bQl
 bTx
 bUZ
@@ -100516,7 +102271,7 @@ aIo
 aMy
 aHh
 aKg
-cPY
+rUP
 aQk
 aRz
 aSz
@@ -100820,7 +102575,7 @@ bHR
 bHR
 bIM
 bEI
-bLu
+qtN
 bMk
 bNd
 bNd
@@ -100834,18 +102589,18 @@ bNd
 bZp
 bRq
 ccb
-bNS
+wmu
 bMu
 cfJ
 coT
 chW
-cje
+mJG
 cjY
 cjY
 cjY
 cjY
 cjY
-coj
+ray
 coT
 cpL
 cje
@@ -101080,13 +102835,13 @@ bEI
 bLu
 bLv
 bNe
-bMs
+raD
 bON
 bNe
 bRT
 bON
 bNe
-bMs
+raD
 bON
 bZp
 bRw
@@ -101105,7 +102860,7 @@ cje
 coj
 cje
 cpM
-cje
+mJG
 crh
 aab
 aab
@@ -101312,15 +103067,15 @@ qDV
 bdp
 bdp
 bdp
-bdp
+ryx
 brq
 bcB
 bdp
-bjE
+eyk
 bus
 bvh
 bwj
-bdp
+ryx
 bdp
 bdp
 bxj
@@ -101328,10 +103083,10 @@ bAz
 bbC
 bCS
 bAA
-bAA
+nhU
 bEI
 bHS
-bHS
+qMn
 bIN
 bEI
 bLu
@@ -101357,7 +103112,7 @@ cje
 cjY
 cjY
 cjY
-cjY
+lzN
 cjY
 coj
 cje
@@ -101548,10 +103303,10 @@ aOM
 aQo
 aRu
 aRD
-aRD
+kla
 aRu
 aRD
-aRD
+kla
 aYB
 aZD
 bav
@@ -101834,7 +103589,7 @@ bjG
 bcz
 urN
 bcz
-bcz
+vew
 bcz
 bcz
 buy
@@ -102098,28 +103853,28 @@ bjD
 bnM
 bbC
 bCS
-bEI
+wQF
 bFJ
 bEI
+wQF
 bEI
 bEI
 bEI
-bEI
-bEI
+wQF
 neV
-bNg
+wwH
 bMu
 bMu
 bMu
-bMu
+qZb
 oRr
 bMu
 bMu
-bMu
+qZb
 bMu
 bMu
 rsn
-bMu
+qZb
 bMu
 bQp
 cgT
@@ -102351,7 +104106,7 @@ bwl
 bxc
 bxc
 byg
-bcz
+vew
 bnM
 bmM
 bCV
@@ -102381,7 +104136,7 @@ bMu
 bQp
 cgT
 vHN
-cib
+kZK
 cib
 ckV
 clR
@@ -102594,11 +104349,11 @@ bcN
 bbC
 bnM
 mMl
+vew
 bcz
 bcz
 bcz
-bcz
-mMl
+qkv
 bnM
 bbC
 bmE
@@ -103147,7 +104902,7 @@ bXX
 bWx
 bMu
 cci
-bMu
+qZb
 bMu
 cfN
 cgT
@@ -103156,7 +104911,7 @@ cjk
 cgT
 cgT
 clT
-cib
+kZK
 cib
 cib
 coX
@@ -104185,7 +105940,7 @@ cgY
 cgY
 clV
 cid
-cid
+jsQ
 cid
 coY
 aab
@@ -104424,7 +106179,7 @@ bDa
 tlV
 cdA
 bNY
-bMu
+qZb
 bTB
 bVi
 bXZ
@@ -104433,7 +106188,7 @@ bZt
 caN
 bXZ
 bLz
-ccg
+elt
 cfH
 cgZ
 cie
@@ -104951,11 +106706,11 @@ cdu
 bWz
 cgY
 fHL
-cid
+jsQ
 cid
 cla
 clY
-clY
+wpP
 bZv
 cjn
 coY
@@ -105717,7 +107472,7 @@ bYf
 bZy
 caS
 ccs
-bZz
+puF
 cdw
 cfQ
 bWz
@@ -105971,7 +107726,7 @@ bNm
 bNm
 bNm
 jdI
-bZx
+tkT
 caT
 bZx
 bZz

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -9,6 +9,7 @@
 		slot_l_hand_str = 'icons/mob/items_lefthand_1.dmi',
 		slot_r_hand_str = 'icons/mob/items_righthand_1.dmi',
 		)
+	max_integrity = 250
 	materials = list(/datum/material/metal = 100)
 	w_class 	= 3
 	throwforce 	= 5


### PR DESCRIPTION


## About The Pull Request

Build a sentry health tweak

## Why It's Good For The Game

For now build a sentry got more damage than normal sentrys, same/more health and also more ammo, being able to be carried in pockets, this is supposed to make the build a sentry something made for quick deploy but not the better choice for holding places like normal sentrys.

## Changelog
:cl:

balance: Nerf build a sentry health from 500 to 250

/:cl:


