### PR TITLE
build a sentry nerf

### DIFF
--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -9,6 +9,7 @@
 		slot_l_hand_str = 'icons/mob/items_lefthand_1.dmi',
 		slot_r_hand_str = 'icons/mob/items_righthand_1.dmi',
 		)
+	max_integrity = 250
 	materials = list(/datum/material/metal = 100)
 	w_class 	= 3
 	throwforce 	= 5


### PR DESCRIPTION

## About The Pull Request

Build a sentry health nerf

## Why It's Good For The Game

In our actual state build a sentry is better than normal sentrys in every sense. This PR focus on keeping build a sentry as a quick deploy turret used for supress fire instead of a sentry able to do so and also hold points and work as traps with the rocket sentrys and etc.

## Changelog
:cl:

balance: Build a sentry healh goes from 500 to 250

/:cl:

