### PR TITLE
Buff zombies health regen

### DIFF
--- a/code/modules/mob/living/carbon/human/husk.dm
+++ b/code/modules/mob/living/carbon/human/husk.dm
@@ -25,7 +25,7 @@
 	///Time before resurrecting if dead
 	var/revive_time = 1 MINUTES
 	///How much burn and burn damage can you heal every Life tick (half a sec)
-	var/heal_rate = 5
+	var/heal_rate = 10
 
 /datum/species/husk/on_species_gain(mob/living/carbon/human/H, datum/species/old_species)
 	. = ..()
@@ -59,6 +59,8 @@
 			else if (istype(limb, /datum/limb/hand/r_hand))
 				H.equip_to_slot_or_del(new /obj/item/weapon/husk_claw, SLOT_R_HAND)
 			H.update_body()
+		else if(limb.limb_status & LIMB_BROKEN && prob(20))
+			limb.remove_limb_flags(LIMB_BROKEN | LIMB_SPLINTED | LIMB_STABILIZED)
 
 	if(H.health != total_health)
 		H.heal_limbs(heal_rate)
@@ -139,7 +141,7 @@
 /datum/species/husk/tank
 	name = "Tank husk"
 	slowdown = 1
-	heal_rate = 10
+	heal_rate = 20
 	total_health = 250
 
 /datum/species/husk/tank/on_species_gain(mob/living/carbon/human/H, datum/species/old_species)
@@ -153,5 +155,5 @@
 /datum/species/husk/strong
 	name = "Strong husk" //These are husks created from marines, they are stronger, but of course rarer
 	slowdown = -0.5
-	heal_rate = 10
+	heal_rate = 20
 	total_health = 200

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -424,7 +424,6 @@
 	if(should_zombify)
 		set_species("Strong husk")
 		faction = FACTION_XENO
-		heal_limbs(- health)
 	heal_limbs(- health)
 	set_stat(CONSCIOUS)
 	overlay_fullscreen_timer(0.5 SECONDS, 10, "roundstart1", /obj/screen/fullscreen/black)

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -247,7 +247,7 @@
 /mob/living/carbon/human/proc/heal_limbs(health_to_heal)
 	var/proportion_to_heal = (health_to_heal < (species.total_health - health)) ? (health_to_heal / (species.total_health - health)) : 1
 	for(var/datum/limb/limb AS in limbs)
-		limb.heal_limb_damage(limb.brute_dam * proportion_to_heal, limb.burn_dam * proportion_to_heal, limb.brute_dam * proportion_to_heal)
+		limb.heal_limb_damage(limb.brute_dam * proportion_to_heal, limb.burn_dam * proportion_to_heal, limb.brute_dam * proportion_to_heal, TRUE)
 	updatehealth()
 
 /mob/living/proc/on_revive()

--- a/code/modules/organs/limbs.dm
+++ b/code/modules/organs/limbs.dm
@@ -169,7 +169,7 @@
 
 	if(limb_status & LIMB_ROBOT && !(owner.species.species_flags & IS_SYNTHETIC))
 		brute *= 0.50 // half damage for ROBOLIMBS if you weren't born with them
-		burn *= 0.50 
+		burn *= 0.50
 
 	//High brute damage or sharp objects may damage internal organs
 	if(internal_organs && ((sharp && brute >= 10) || brute >= 20) && prob(5))
@@ -269,11 +269,11 @@
 
 		// heal brute damage
 		if(W.damage_type == CUT || W.damage_type == BRUISE)
-			brute = W.heal_wound_damage(brute)
+			brute = W.heal_wound_damage(brute, internal)
 		else if(W.damage_type == BURN)
-			burn = W.heal_wound_damage(burn)
+			burn = W.heal_wound_damage(burn, internal)
 		else if(internal)
-			brute = W.heal_wound_damage(brute)
+			brute = W.heal_wound_damage(brute, internal)
 
 	//Sync the organ's damage with its wounds
 	update_damages()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Zombies properly heal internal wounds
Double the heal rate
Zombies heal from broken bones

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Zombies are still very much paper against marines, but they are more of a threat in groups. Playing zombie will also be more enjoyable

## Changelog
:cl:
fix: Zombies properly heal internal wounds
balance: Double the healing rate of zombies
fix: Zombies can heal from broken bone (has no effect on balance)
fix: Fix a runtime that could prevent human zombies from resurrecting
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
