### PR TITLE
no more underbarrel guns for shotgun (except plasma pistol, you're fine)

### DIFF
--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -236,7 +236,6 @@ can cause issues with ammo types getting mixed up during the burst.
 		/obj/item/attachable/compensator,
 		/obj/item/attachable/magnetic_harness,
 		/obj/item/weapon/gun/pistol/plasma_pistol,
-		/obj/item/weapon/gun/launcher/m92/mini_grenade,
 		/obj/item/attachable/motiondetector,
 	)
 

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -236,7 +236,6 @@ can cause issues with ammo types getting mixed up during the burst.
 		/obj/item/attachable/compensator,
 		/obj/item/attachable/magnetic_harness,
 		/obj/item/weapon/gun/pistol/plasma_pistol,
-		/obj/item/weapon/gun/shotgun/combat/masterkey,
 		/obj/item/weapon/gun/launcher/m92/mini_grenade,
 		/obj/item/attachable/motiondetector,
 	)
@@ -478,7 +477,6 @@ can cause issues with ammo types getting mixed up during the burst.
 		/obj/item/attachable/magnetic_harness,
 		/obj/item/attachable/stock/shotgun,
 		/obj/item/weapon/gun/pistol/plasma_pistol,
-		/obj/item/weapon/gun/shotgun/combat/masterkey,
 	)
 
 	flags_gun_features = GUN_CAN_POINTBLANK|GUN_INTERNAL_MAG|GUN_AMMO_COUNTER|GUN_WIELDED_FIRING_ONLY|GUN_PUMP_REQUIRED
@@ -932,8 +930,6 @@ can cause issues with ammo types getting mixed up during the burst.
 		/obj/item/attachable/stock/t35stock,
 		/obj/item/attachable/motiondetector,
 		/obj/item/weapon/gun/pistol/plasma_pistol,
-		/obj/item/weapon/gun/shotgun/combat/masterkey,
-		/obj/item/weapon/gun/flamer/mini_flamer,
 		/obj/item/attachable/buildasentry,
 	)
 


### PR DESCRIPTION
## About The Pull Request

Removes all UBF, masterkey, and underbarrel GLs from the main shotguns, barring Mk221's underbarrel GL.
## Why It's Good For The Game

Super burst damage on top of super burst damage with no real regard for fire delay is kinda wack and leads to people deleting xenos in like half a second.

I did this for pette btw.
## Changelog
:cl:
balance: masterkey, underbarrel flamer, and underbarrel GL for t39, t35, and v10 are now gone
/:cl: