### PR TITLE
Automatic cycle alamo mode

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -1,4 +1,4 @@
-//#define TESTING //By using the testing("message") proc you can create debug-feedback for people with this
+#define TESTING //By using the testing("message") proc you can create debug-feedback for people with this
 								//uncommented, but not visible in the release version)
 
 //#define DATUMVAR_DEBUGGING_MODE //Enables the ability to cache datum vars and retrieve later for debugging which vars changed.

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -1,4 +1,4 @@
-#define TESTING //By using the testing("message") proc you can create debug-feedback for people with this
+//#define TESTING //By using the testing("message") proc you can create debug-feedback for people with this
 								//uncommented, but not visible in the release version)
 
 //#define DATUMVAR_DEBUGGING_MODE //Enables the ability to cache datum vars and retrieve later for debugging which vars changed.

--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -609,6 +609,8 @@
 			. = TRUE
 		if("automation_on")
 			M.automatic_cycle_on = params["automation_on"]
+			if(!M.automatic_cycle_on)
+				M.deltimer(M.cycle_timer)
 		if("cycle_time_change")
 			M.time_between_cycle = params["cycle_time_change"]
 

--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -221,7 +221,7 @@
 	if(crashing)
 		force = TRUE
 
-	if(automatic_cycle_on)
+	if(automatic_cycle_on && destination == new_dock)
 		if(cycle_timer)
 			deltimer(cycle_timer)
 		cycle_timer = addtimer(CALLBACK(src, .proc/prepare_going_to_previous_destination), rechargeTime + time_between_cycle SECONDS - 20 SECONDS, TIMER_STOPPABLE)
@@ -309,7 +309,7 @@
 		return "Control integrity compromised"
 	else if(hijack_state == HIJACK_STATE_UNLOCKED)
 		return "Remote control compromised"
-	return ..() + (timeleft(cycle_timer) ? ("\nAutomatic cycle : [(timeleft(cycle_timer) / 10 + 20)] seconds before departure towards [previous.name]") : "")
+	return ..() + (timeleft(cycle_timer) ? (" Automatic cycle : [round(timeleft(cycle_timer) / 10 + 20, 1)] seconds before departure towards [previous.name]") : "")
 
 
 /obj/docking_port/mobile/marine_dropship/can_move_topic(mob/user)

--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -610,7 +610,7 @@
 		if("automation_on")
 			M.automatic_cycle_on = params["automation_on"]
 			if(!M.automatic_cycle_on)
-				M.deltimer(M.cycle_timer)
+				deltimer(M.cycle_timer)
 		if("cycle_time_change")
 			M.time_between_cycle = params["cycle_time_change"]
 

--- a/code/modules/shuttle/marine_dropship.dm
+++ b/code/modules/shuttle/marine_dropship.dm
@@ -143,6 +143,12 @@
 	var/list/equipments = list()
 
 	var/hijack_state = HIJACK_STATE_NORMAL
+	///If the automatic cycle system is activated
+	var/automatic_cycle_on = FALSE
+	///How long will the shuttle wait to launch again if the automatic mode is on. In seconds
+	var/time_between_cycle = 0
+	///The timer to launch the dropship in automatic mode
+	var/cycle_timer
 
 /obj/docking_port/mobile/marine_dropship/register()
 	. = ..()
@@ -215,7 +221,21 @@
 	if(crashing)
 		force = TRUE
 
+	if(automatic_cycle_on)
+		if(cycle_timer)
+			deltimer(cycle_timer)
+		cycle_timer = addtimer(CALLBACK(src, .proc/prepare_going_to_previous_destination), rechargeTime + time_between_cycle SECONDS - 20 SECONDS, TIMER_STOPPABLE)
+
 	return ..()
+
+///Announce that the dropship will departure soon
+/obj/docking_port/mobile/marine_dropship/proc/prepare_going_to_previous_destination()
+	cycle_timer = addtimer(CALLBACK(src, .proc/go_to_previous_destination), 20 SECONDS, TIMER_STOPPABLE)
+	priority_announce("Dropship taking off in 20 seconds towards [previous.name]", "Dropship Automatic Departure")
+
+///Send the dropship to its previous dock
+/obj/docking_port/mobile/marine_dropship/proc/go_to_previous_destination()
+	SSshuttle.moveShuttle(id, previous.id, TRUE)
 
 /obj/docking_port/mobile/marine_dropship/one
 	name = "Alamo"
@@ -276,6 +296,7 @@
 
 /obj/docking_port/mobile/marine_dropship/proc/set_hijack_state(new_state)
 	hijack_state = new_state
+	deltimer(cycle_timer)
 
 /obj/docking_port/mobile/marine_dropship/on_prearrival()
 	. = ..()
@@ -288,7 +309,7 @@
 		return "Control integrity compromised"
 	else if(hijack_state == HIJACK_STATE_UNLOCKED)
 		return "Remote control compromised"
-	return ..()
+	return ..() + (timeleft(cycle_timer) ? ("\nAutomatic cycle : [(timeleft(cycle_timer) / 10 + 20)] seconds before departure towards [previous.name]") : "")
 
 
 /obj/docking_port/mobile/marine_dropship/can_move_topic(mob/user)
@@ -460,7 +481,7 @@
 		M.unlock_all()
 		dat += "<A href='?src=[REF(src)];abduct=1'>Capture the [M]</A><br>"
 		if(M.hijack_state != HIJACK_STATE_CALLED_DOWN)
-			M.hijack_state = HIJACK_STATE_CALLED_DOWN
+			M.set_hijack_state(HIJACK_STATE_CALLED_DOWN)
 			M.do_start_hijack_timer()
 
 	var/datum/browser/popup = new(X, "computer", M ? M.name : "shuttle", 300, 200)
@@ -499,6 +520,8 @@
 	.["dest_select"] = !(shuttle.mode == SHUTTLE_CALL || shuttle.mode == SHUTTLE_IDLE)
 	.["hijack_state"] = shuttle.hijack_state != HIJACK_STATE_CALLED_DOWN
 	.["ship_status"] = shuttle.getStatusText()
+	.["automatic_cycle_on"] = shuttle.automatic_cycle_on
+	.["time_between_cycle"] = shuttle.time_between_cycle
 
 	var/locked = 0
 	var/reardoor = 0
@@ -584,6 +607,10 @@
 		if("unlock")
 			M.unlock_airlocks(params["unlock"])
 			. = TRUE
+		if("automation_on")
+			M.automatic_cycle_on = params["automation_on"]
+		if("cycle_time_change")
+			M.time_between_cycle = params["cycle_time_change"]
 
 /obj/machinery/computer/shuttle/marine_dropship/Topic(href, href_list)
 	var/obj/docking_port/mobile/marine_dropship/M = SSshuttle.getShuttle(shuttleId)

--- a/tgui/packages/tgui/interfaces/MarineDropship.js
+++ b/tgui/packages/tgui/interfaces/MarineDropship.js
@@ -126,13 +126,3 @@ const NormalOperation = (props, context) => {
     </>
   );
 };
-
-const AutomaticFlight = (props, context) => {
-  const { act, data } = useBackend(context);
-
-  return (
-    <>
-    </>
-  )
-};
-

--- a/tgui/packages/tgui/interfaces/MarineDropship.js
+++ b/tgui/packages/tgui/interfaces/MarineDropship.js
@@ -1,5 +1,5 @@
 import { useBackend } from '../backend';
-import { Box, Button, LabeledList, NoticeBox, Section } from '../components';
+import { Box, Button, LabeledList, NoticeBox, Section, Stack } from '../components';
 import { Window } from '../layouts';
 
 export const MarineDropship = (props, context) => {
@@ -25,6 +25,13 @@ export const MarineDropship = (props, context) => {
 
 const NormalOperation = (props, context) => {
   const { act, data } = useBackend(context);
+  const delayBetweenFlight = [
+    0,
+    15,
+    30,
+    45,
+    60,
+  ];
   const doorLocks = [
     {
       label: "Left",
@@ -46,6 +53,34 @@ const NormalOperation = (props, context) => {
     <>
       <Section title="Ship Status">
         {data.ship_status}
+      </Section>
+      <Section title="Automation Status">
+        <Button
+          onClick={() => act("automation_on", { automation_on: 1 })}
+          selected={data.automatic_cycle_on}>
+          On
+        </Button>
+        <Button
+          onClick={() => act("automation_on", { automation_on: 0 })}
+          selected={!data.automatic_cycle_on}>
+          Off
+        </Button>
+      </Section>
+      <Section title="Cycle Time">
+        <Stack>
+          {delayBetweenFlight.map(time_between_cycle => {
+            return (
+              <Stack.Item
+                key={time_between_cycle}>
+                <Button
+                  onClick={() => act("cycle_time_change", { cycle_time_change: time_between_cycle })}
+                  selected={data.time_between_cycle === time_between_cycle}>
+                  {time_between_cycle ? time_between_cycle + " Seconds" : "Instantanious"}
+                </Button>
+              </Stack.Item>
+            );
+          })}
+        </Stack>
       </Section>
       <Section title="Destinations">
         {data.destinations.map(destination => (
@@ -90,5 +125,14 @@ const NormalOperation = (props, context) => {
       </Section>
     </>
   );
+};
+
+const AutomaticFlight = (props, context) => {
+  const { act, data } = useBackend(context);
+
+  return (
+    <>
+    </>
+  )
 };
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Add an automatic cycle mode to alamo. When arriving to its destination, the shuttle will fly back towards its previous destination after X seconds + the time for the engines to be ready.

This is a bounty for elsa.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Easy to configure system, that prevents the whole "please captain cycle ship". You can disable it easily, so it shouldn't be a balance concern

## Changelog
:cl:
qol: Automatic cycle alamo mode
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
