### PR TITLE
mild buckshot nerf because it's funny

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -691,13 +691,13 @@ datum/ammo/bullet/revolver/tp44
 	hud_state = "shotgun_buckshot"
 	flags_ammo_behavior = AMMO_BALLISTIC
 	bonus_projectiles_type = /datum/ammo/bullet/shotgun/spread
-	bonus_projectiles_amount = 5
-	bonus_projectiles_scatter = 4
+	bonus_projectiles_amount = 4
+	bonus_projectiles_scatter = 5
 	accuracy_var_low = 9
 	accuracy_var_high = 9
 	accurate_range = 5
 	max_range = 10
-	damage = 40
+	damage = 44
 	damage_falloff = 1
 	penetration = 0
 
@@ -713,7 +713,7 @@ datum/ammo/bullet/revolver/tp44
 	accuracy_var_high = 9
 	accurate_range = 5
 	max_range = 10
-	damage = 40
+	damage = 44
 	damage_falloff = 1
 	penetration = 0
 

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -236,6 +236,8 @@ can cause issues with ammo types getting mixed up during the burst.
 		/obj/item/attachable/compensator,
 		/obj/item/attachable/magnetic_harness,
 		/obj/item/weapon/gun/pistol/plasma_pistol,
+		/obj/item/weapon/gun/shotgun/combat/masterkey,
+		/obj/item/weapon/gun/launcher/m92/mini_grenade,
 		/obj/item/attachable/motiondetector,
 	)
 
@@ -476,6 +478,7 @@ can cause issues with ammo types getting mixed up during the burst.
 		/obj/item/attachable/magnetic_harness,
 		/obj/item/attachable/stock/shotgun,
 		/obj/item/weapon/gun/pistol/plasma_pistol,
+		/obj/item/weapon/gun/shotgun/combat/masterkey,
 	)
 
 	flags_gun_features = GUN_CAN_POINTBLANK|GUN_INTERNAL_MAG|GUN_AMMO_COUNTER|GUN_WIELDED_FIRING_ONLY|GUN_PUMP_REQUIRED
@@ -929,6 +932,8 @@ can cause issues with ammo types getting mixed up during the burst.
 		/obj/item/attachable/stock/t35stock,
 		/obj/item/attachable/motiondetector,
 		/obj/item/weapon/gun/pistol/plasma_pistol,
+		/obj/item/weapon/gun/shotgun/combat/masterkey,
+		/obj/item/weapon/gun/flamer/mini_flamer,
 		/obj/item/attachable/buildasentry,
 	)
 

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -236,7 +236,6 @@ can cause issues with ammo types getting mixed up during the burst.
 		/obj/item/attachable/compensator,
 		/obj/item/attachable/magnetic_harness,
 		/obj/item/weapon/gun/pistol/plasma_pistol,
-		/obj/item/weapon/gun/launcher/m92/mini_grenade,
 		/obj/item/attachable/motiondetector,
 	)
 

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -236,7 +236,6 @@ can cause issues with ammo types getting mixed up during the burst.
 		/obj/item/attachable/compensator,
 		/obj/item/attachable/magnetic_harness,
 		/obj/item/weapon/gun/pistol/plasma_pistol,
-		/obj/item/weapon/gun/shotgun/combat/masterkey,
 		/obj/item/weapon/gun/launcher/m92/mini_grenade,
 		/obj/item/attachable/motiondetector,
 	)
@@ -478,7 +477,6 @@ can cause issues with ammo types getting mixed up during the burst.
 		/obj/item/attachable/magnetic_harness,
 		/obj/item/attachable/stock/shotgun,
 		/obj/item/weapon/gun/pistol/plasma_pistol,
-		/obj/item/weapon/gun/shotgun/combat/masterkey,
 	)
 
 	flags_gun_features = GUN_CAN_POINTBLANK|GUN_INTERNAL_MAG|GUN_AMMO_COUNTER|GUN_WIELDED_FIRING_ONLY|GUN_PUMP_REQUIRED
@@ -932,8 +930,6 @@ can cause issues with ammo types getting mixed up during the burst.
 		/obj/item/attachable/stock/t35stock,
 		/obj/item/attachable/motiondetector,
 		/obj/item/weapon/gun/pistol/plasma_pistol,
-		/obj/item/weapon/gun/shotgun/combat/masterkey,
-		/obj/item/weapon/gun/flamer/mini_flamer,
 		/obj/item/attachable/buildasentry,
 	)
 


### PR DESCRIPTION
## About The Pull Request
buckshot is cracked rn, this makes it slightly less cracked
also for some reason, the pellets shoot out asymmetrically because it had an odd number of pellets shot around the main one.

this is what ren asked for btw
## Why It's Good For The Game
buckshot op, plz nerf

this slight change makes it so that you get hit by 3 pellets at 4 tile range instead of 5 pellets, as well as making it so that bayo+buck+stock pb doesn't one shot elder runners. you have to wait less to actually play the game now

also we should remove flech

## Changelog
:cl:
balance: buckshot total damage lowered from 240 to 220, spread increased from 4 to 5, and individual bullet damage increased slightly from 40 to 44.
/:cl: