### PR TITLE
Revert "Makes buckshot a bit more effective mid range"

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -695,10 +695,10 @@ datum/ammo/bullet/revolver/tp44
 	bonus_projectiles_scatter = 4
 	accuracy_var_low = 9
 	accuracy_var_high = 9
-	accurate_range = 5
+	accurate_range = 3
 	max_range = 10
 	damage = 40
-	damage_falloff = 1
+	damage_falloff = 4
 	penetration = 0
 
 
@@ -711,10 +711,10 @@ datum/ammo/bullet/revolver/tp44
 	shell_speed = 2
 	accuracy_var_low = 9
 	accuracy_var_high = 9
-	accurate_range = 5
+	accurate_range = 3
 	max_range = 10
 	damage = 40
-	damage_falloff = 1
+	damage_falloff = 4
 	penetration = 0
 
 //buckshot variant only used by the masterkey shotgun attachment.


### PR DESCRIPTION
Reverts tgstation/TerraGov-Marine-Corps#8008

## About The Pull Request
Reverts tgstation/TerraGov-Marine-Corps#8008

Closes https://github.com/tgstation/TerraGov-Marine-Corps/pull/8443
Closes https://github.com/tgstation/TerraGov-Marine-Corps/pull/8440

## Why It's Good For The Game
Buckshot has been powercreeped and its time to reel it in


## Changelog
:cl:
balance: buckshot has more falloff
balance: buckshot accurate range(not spread) has been reduced to 3
/:cl: