### PR TITLE
king buff

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/king/castedatum_king.dm
@@ -137,7 +137,7 @@
 	upgrade = XENO_UPGRADE_THREE
 
 	// *** Melee Attacks *** //
-	melee_damage = 23
+	melee_damage = 29
 
 	// *** Speed *** //
 	speed = -0.3


### PR DESCRIPTION

## About The Pull Request

King now got a better damage from elder to ancient.

## Why It's Good For The Game

King is in a pretty poor stage, it is a 2000 psypoints caste with a final meele damage of 23 ((elder damage and ancient damage was the same without any age buff)) now the elder damage will keep on 23 and ancient damage will be 29.

## Changelog
:cl:

balance: Little buff on king meele damage.

/:cl:


