### PR TITLE
king timer buff

### DIFF
--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -130,7 +130,7 @@
 //How many psy points are gave every 5 second by a cocoon
 #define COCOON_PSY_POINTS_REWARD 2
 
-#define INVOKE_KING_TIME_LOCK 90 MINUTES
+#define INVOKE_KING_TIME_LOCK 60 MINUTES
 
 /// How each alive marine contributes to burrower larva output per minute. So with one pool, 15 marines are giving 0.375 points per minute, so it's a new xeno every 22 minutes
 #define SILO_BASE_OUTPUT_PER_MARINE 0.035


### PR DESCRIPTION


## About The Pull Request

King inst all this strong anymore and almost doest appear in any round and when it does the round already ended, this PR is made to make king more viable.

## Why It's Good For The Game

Placing king on his way to become something more viable and actually good, making its invoke timer from 90 mins to 60.

## Changelog
:cl:

balance: Lower king time from 90 minutes to 60 minutes.

/:cl:


