### PR TITLE
Allows any uniform to be vended from the loadout vendor. This time without any difference in armor.

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -638,6 +638,12 @@ GLOBAL_LIST_INIT(synthetic_clothes_listed_products, list(
 		/obj/item/clothing/mask/gas/tactical/coif = list(CAT_MAS, "Tactical coifed gas mask", 0,"black"),
 	))
 
+
+///Items that should be saved in loadouts no matter what
+GLOBAL_LIST_INIT(bypass_loadout_check_item, typecacheof(list(
+	/obj/item/clothing/under,
+)))
+
 ///Assoc list linking the job title with their specific clothes vendor
 GLOBAL_LIST_INIT(job_specific_clothes_vendor, list(
 	SQUAD_MARINE = GLOB.marine_clothes_listed_products,

--- a/code/datums/loadout/item_representation/uniform_representation.dm
+++ b/code/datums/loadout/item_representation/uniform_representation.dm
@@ -19,7 +19,13 @@
 	. = ..()
 	if(!.)
 		return
-	tie?.install_on_uniform(seller, ., user)
+	var/obj/item/clothing/under/uniform = .
+	uniform.soft_armor = uniform.soft_armor.setRating("melee" = 5, "bullet" = 5, "laser" = 5, "energy" = 5, "bomb" = 5, "bio" = 5, "rad" = 5, "fire" = 5, "acid" = 5)
+	uniform.hard_armor = uniform.hard_armor.setRating("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+	uniform.flags_armor_protection = CHEST|GROIN|LEGS|ARMS
+	uniform.flags_cold_protection = CHEST|GROIN|LEGS|ARMS
+	uniform.flags_heat_protection = CHEST|GROIN|LEGS|ARMS
+	tie?.install_on_uniform(seller, uniform, user)
 
 /datum/item_representation/uniform_representation/get_tgui_data()
 	var/list/tgui_data = list()

--- a/code/datums/loadout/loadout_helper.dm
+++ b/code/datums/loadout/loadout_helper.dm
@@ -9,6 +9,10 @@
 ///Return true if the item was found in a linked vendor and successfully bought
 /proc/buy_item_in_vendor(obj/item/item_to_buy_type, datum/loadout_seller/seller, mob/living/user)
 
+	//Some items are allowed to bypass the buy checks
+	if(is_type_in_typecache(item_to_buy_type, GLOB.bypass_loadout_check_item))
+		return TRUE
+
 	if(seller.faction != FACTION_NEUTRAL && is_type_in_typecache(item_to_buy_type, GLOB.hvh_restricted_items_list))
 		return FALSE
 


### PR DESCRIPTION
## About The Pull Request

Lets any uniform be vended from the loadout vendor.
Any Uniform vended will have the same stats as the default marine uniform. No longer do we have to worry about pmc uniforms roundstart.

## Why It's Good For The Game

People have grown attached to some uniforms. And the only reason they were taken was the balance concerns. This removes the balance concerns and allows people to wear what they want.

## Changelog
:cl:
expansion: Any uniform can be saved in the loadout vendor. Now with standardized armor.
/:cl:
