### PR TITLE
Silo collapse timer increased to 10 minutes, and starts at the 1 hour mark instead of 45 minutes.

### DIFF
--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -138,7 +138,7 @@
 /// This is used to ponderate the number of silo, so to reduces the diminishing returns of having more and more silos
 #define SILO_OUTPUT_PONDERATION 1.75
 //Time (after round start) before siloless timer can start
-#define MINIMUM_TIME_SILO_LESS_COLLAPSE 45 MINUTES
+#define MINIMUM_TIME_SILO_LESS_COLLAPSE 60 MINUTES
 
 #define INFESTATION_MARINE_DEPLOYMENT 0
 #define INFESTATION_MARINE_CRASHING 1

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -802,7 +802,7 @@ to_chat will check for valid clients itself already so no need to double check f
 		return
 
 	xeno_message("We don't have any silos! The hive will collapse if nothing is done", "xenoannounce", 6, TRUE)
-	D.siloless_hive_timer = addtimer(CALLBACK(D, /datum/game_mode.proc/siloless_hive_collapse), 5 MINUTES, TIMER_STOPPABLE)
+	D.siloless_hive_timer = addtimer(CALLBACK(D, /datum/game_mode.proc/siloless_hive_collapse), 10 MINUTES, TIMER_STOPPABLE)
 
 /**
  * Add a mob to the candidate queue, the first mobs of the queue will have priority on new larva spots


### PR DESCRIPTION
## About The Pull Request

So marines don't unga rush the pin pointer objective and win in 15 minutes after shutters open despite xenos being alive. It should be an optional objective for preventing long rounds like king instead of rushing the silo when shutters open with the entire marine team and winning despite all of the xenos still being alive.

Affects a file that #8450 modifies.

## Why It's Good For The Game

The 10 minute collapse timer helps prevent those rounds where all of the xenos are still alive (14 vs 40) and still lose because xenos can't beat 40 marines all rushing silos as soon as shutters open. Xenos are the only team to lose despite still being alive, even marines still have to be killed off completely to lose.

No more round ending while you're still alive before you've even spent as much time playing the round as you spent preparing for the round.

## Changelog
:cl:
balance: Silo collapse timer starting at 13:00 instead of 12:45, silo collapse takes 10 minutes instead of 5.
/:cl: