### PR TITLE
Adds an Art Maintainer role in OOC color code

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -77,6 +77,8 @@
 				display_class = "mentorooc"
 			if("Maintainer")
 				display_class = "maintainerooc"
+			if("Art Maintainer")
+				display_class = "maintainerooc"
 			if("Debugger", "Contributor")
 				display_class = "contributorooc"
 			else


### PR DESCRIPTION
## About The Pull Request
Per title. Uses Maintainer OOC coloring.

## Why It's Good For The Game
Kuro wanted it, I deliver.

## Changelog
:cl: Lewdcifer
add: Art Maintainer role, has same OOC color as Maintainers
/:cl:
