### PR TITLE
ZX buff

### DIFF
--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -992,7 +992,7 @@ can cause issues with ammo types getting mixed up during the burst.
 	wield_delay = 0.75 SECONDS
 	burst_amount = 2
 	burst_delay = 0.01 SECONDS //basically instantaneous two shots
-	extra_delay = 1.25 SECONDS
+	extra_delay = 0.5 SECONDS
 	scatter = 2
-	burst_scatter_mult = 6 // 2x6=12
+	burst_scatter_mult = 4 // 2x4=8
 	accuracy_mult = 1


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
shotgun normal ammo got nerfed, ZX getting minor buffs seems oaky now
extra fire dealy on burst reduced from 3 seconds to 2.25. Still pretty long.
Burst fire spread reduced from 12 to 8.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
ZX is around 120 points, so this is better priced overall. Though Req prices in general need some changing.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: ZX burst fire fire dealy reduced to 2.25 from 3, burst spread reduced.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
