### PR TITLE
Nerfs DB damage to 85% per shot

### DIFF
--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -441,7 +441,7 @@ can cause issues with ammo types getting mixed up during the burst.
 	accuracy_mult_unwielded = 0.85
 	scatter = 10
 	scatter_unwielded = 40
-	damage_mult = 0.8
+	damage_mult = 0.85
 	recoil = 2
 	recoil_unwielded = 4
 

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -441,6 +441,7 @@ can cause issues with ammo types getting mixed up during the burst.
 	accuracy_mult_unwielded = 0.85
 	scatter = 10
 	scatter_unwielded = 40
+	damage_mult = 0.8
 	recoil = 2
 	recoil_unwielded = 4
 


### PR DESCRIPTION
## About The Pull Request
See title

## Why It's Good For The Game

Shotgun is very strong nowadays. I tried to nerf buck, but that got thrown under the bus like an unwanted baby, so hopefully this helps to address to problem. Also, DB was super strong for ages and it's about time it got what was coming to it.

I should probably nerf the parent DB, the colonist one that you can find in Big Red bar and such that shoots faster, but I want to see what the maintainers have to say about it.

Some numbers for you nerds out there.
After testing various things for various reasons, I've found that I can only reload DB fast enough to be on par with a T35 on average. Since I have much more DB experience than the average person, this will likely lead to DB having lower DPS than T35 overall in exchange for higher alpha damage.
## Changelog
:cl:
balance: marine DB damage mod reduced to 85% from 100%.
/:cl: