### PR TITLE
Glowshrooms are destroyable

### DIFF
--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -3499,7 +3499,7 @@
 /turf/open/floor/tile/green/whitegreenfull,
 /area/bigredv2/caves/lambda_lab)
 "amT" = (
-/obj/effect/glowshroom,
+/obj/structure/glowshroom,
 /turf/open/floor/tile/green/whitegreenfull,
 /area/bigredv2/caves/lambda_lab)
 "amU" = (
@@ -3677,7 +3677,7 @@
 	},
 /area/bigredv2/caves/lambda_lab)
 "anv" = (
-/obj/effect/glowshroom,
+/obj/structure/glowshroom,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -4904,12 +4904,12 @@
 /turf/open/floor/marking/delivery,
 /area/bigredv2/caves/lambda_lab)
 "arL" = (
-/obj/effect/glowshroom,
+/obj/structure/glowshroom,
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/northeast)
 "arM" = (
-/obj/effect/glowshroom,
+/obj/structure/glowshroom,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/northeast)
 "arN" = (
@@ -22875,7 +22875,7 @@
 /turf/open/floor,
 /area/bigredv2/outside/general_store)
 "xjd" = (
-/obj/effect/glowshroom,
+/obj/structure/glowshroom,
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/northeast)
@@ -22930,7 +22930,7 @@
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/southeast)
 "xxH" = (
-/obj/effect/glowshroom,
+/obj/structure/glowshroom,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/bigredv2/caves/northeast)

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -8172,7 +8172,7 @@
 /obj/machinery/shower{
 	dir = 4
 	},
-/obj/effect/glowshroom,
+/obj/structure/glowshroom,
 /turf/open/floor/freezer,
 /area/lv624/lazarus/toilet)
 "aUj" = (
@@ -8452,7 +8452,7 @@
 /obj/machinery/shower{
 	dir = 8
 	},
-/obj/effect/glowshroom,
+/obj/structure/glowshroom,
 /turf/open/floor/freezer,
 /area/lv624/lazarus/toilet)
 "aVv" = (
@@ -8540,7 +8540,7 @@
 /turf/closed/gm/dense,
 /area/shuttle/drop2/lz2)
 "aWa" = (
-/obj/effect/glowshroom,
+/obj/structure/glowshroom,
 /turf/open/floor/freezer,
 /area/lv624/lazarus/toilet)
 "aWb" = (

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -1,13 +1,19 @@
 //separate dm since hydro is getting bloated already
 
-/obj/effect/glowshroom
+/obj/structure/glowshroom
 	name = "glowshroom"
+	desc = "Mycena Bregprox, a species of mushroom that glows in the dark."
 	anchored = TRUE
 	opacity = FALSE
 	density = FALSE
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "glowshroomf"
 	layer = ABOVE_TURF_LAYER
+	max_integrity = 30
+	resistance_flags = XENO_DAMAGEABLE
+	hit_sound = 'sound/effects/attackblob.ogg'
+	destroy_sound = null
+	coverage = 0
 
 	var/endurance = 30
 	var/potency = 30
@@ -18,9 +24,7 @@
 	var/lastTick = 0
 	var/spreaded = 1
 
-/obj/effect/glowshroom/single
-
-/obj/effect/glowshroom/Initialize(mapload, ...)
+/obj/structure/glowshroom/Initialize(mapload, ...)
 	. = ..()
 
 	setDir(CalcDir())
@@ -43,7 +47,7 @@
 	lastTick = world.timeofday
 
 
-/obj/effect/glowshroom/proc/CalcDir(turf/location = loc)
+/obj/structure/glowshroom/proc/CalcDir(turf/location = loc)
 	set background = 1
 	var/direction = 16
 
@@ -52,7 +56,7 @@
 		if(iswallturf(newTurf))
 			direction |= wallDir
 
-	for(var/obj/effect/glowshroom/shroom in location)
+	for(var/obj/structure/glowshroom/shroom in location)
 		if(shroom == src)
 			continue
 		if(shroom.floor) //special

--- a/code/game/objects/items/reagent_containers/food/snacks/grown.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks/grown.dm
@@ -515,7 +515,7 @@
 /obj/item/reagent_containers/food/snacks/grown/mushroom/glowshroom/attack_self(mob/user as mob)
 	if(istype(user.loc,/turf/open/space))
 		return
-	var/obj/effect/glowshroom/planted = new /obj/effect/glowshroom(user.loc)
+	var/obj/structure/glowshroom/planted = new /obj/structure/glowshroom(user.loc)
 
 	planted.delay = 50
 	planted.endurance = 100

--- a/code/game/turfs/walls/walls.dm
+++ b/code/game/turfs/walls/walls.dm
@@ -74,7 +74,7 @@
 				T.relativewall()
 
 			//nearby glowshrooms updated
-			for(var/obj/effect/glowshroom/shroom in T)
+			for(var/obj/structure/glowshroom/shroom in T)
 				if(!shroom.floor) //shrooms drop to the floor
 					shroom.floor = 1
 					shroom.icon_state = "glowshroomf"

--- a/code/modules/reagents/reagents/toxin.dm
+++ b/code/modules/reagents/reagents/toxin.dm
@@ -190,7 +190,7 @@
 	if(istype(O,/obj/effect/alien/weeds))
 		var/obj/effect/alien/A = O
 		A.take_damage(min(0.5 * volume))
-	else if(istype(O,/obj/effect/glowshroom)) //even a small amount is enough to kill it
+	else if(istype(O,/obj/structure/glowshroom)) //even a small amount is enough to kill it
 		qdel(O)
 	else if(istype(O,/obj/effect/plantsegment))
 		if(prob(50)) qdel(O) //Kills kudzu too.
@@ -408,7 +408,7 @@
 			L.take_limb_damage(min(6*toxpwr, volume * toxpwr) * touch_protection)
 
 /datum/reagent/toxin/acid/reaction_obj(obj/O, volume)
-	if((istype(O,/obj/item) || istype(O,/obj/effect/glowshroom)) && prob(meltprob * 3))
+	if((istype(O,/obj/item) || istype(O,/obj/structure/glowshroom)) && prob(meltprob * 3))
 		if(!CHECK_BITFIELD(O.resistance_flags, RESIST_ALL))
 			var/obj/effect/decal/cleanable/molten_item/I = new/obj/effect/decal/cleanable/molten_item(O.loc)
 			I.desc = "Looks like this was \an [O] some time ago."


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Converts glowshrooms into a structure instead of an effect. Why were they an effect? Who knows.

Closes #8463 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's kinda dumb to not be able to interact with them, and xenos can't deal with the indestructible light source which is kind of an issue.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: glowshrooms can now be destroyed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
