### PR TITLE
Fixes up ammo counters for shotguns and revolvers

### DIFF
--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -502,6 +502,7 @@ User can be passed as null, (a gun reloading itself for instance), so we need to
 	span_notice("You load [magazine] into [src]!"), null, 3)
 	if(reload_sound)
 		playsound(user, reload_sound, 25, 1, 5)
+	user.hud_used.update_ammo_hud(user, src)
 	update_icon()
 
 
@@ -524,9 +525,8 @@ User can be passed as null, (a gun reloading itself for instance), so we need to
 	span_notice("You unload [current_mag] from [src]."), null, 4)
 	current_mag.update_icon()
 	current_mag = null
-
+	user.hud_used.update_ammo_hud(user, src)
 	update_icon(user)
-
 	return TRUE
 
 

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -583,6 +583,7 @@ User can be passed as null, (a gun reloading itself for instance), so we need to
 		user?.visible_message(span_notice("[user] cocks [src]."),
 		span_notice("You cock [src]."), null, 4)
 	ready_in_chamber() //This will already check for everything else, loading the next bullet.
+	user.hud_used.update_ammo_hud(user, src)
 
 	return TRUE
 

--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -67,15 +67,14 @@
 /obj/item/weapon/gun/revolver/proc/replace_cylinder(number_to_replace)
 	current_mag.chamber_contents = list()
 	current_mag.chamber_contents.len = current_mag.max_rounds
-	var/i
-	for(i = 1 to current_mag.max_rounds) //We want to make sure to populate the cylinder.
+	for(var/i = 1 to current_mag.max_rounds) //We want to make sure to populate the cylinder.
 		current_mag.chamber_contents[i] = i > number_to_replace ? "empty" : "bullet"
 	current_mag.chamber_position = max(1,number_to_replace)
 
-/obj/item/weapon/gun/revolver/proc/empty_cylinder()
-	var/i
-	for(i = 1 to current_mag.max_rounds)
+/obj/item/weapon/gun/revolver/proc/empty_cylinder(mob/user)
+	for(var/i = 1 to current_mag.max_rounds)
 		current_mag.chamber_contents[i] = "empty"
+	user.hud_used.update_ammo_hud(user, src)
 
 //The cylinder is always emptied out before a reload takes place.
 /obj/item/weapon/gun/revolver/proc/add_to_cylinder(mob/user) //Bullets are added forward.
@@ -122,6 +121,7 @@
 					current_mag.match_ammo(magazine)
 					replace_cylinder(current_mag.current_rounds)
 					playsound(user, reload_sound, 25, 1) // Reloading via speedloader.
+					user.hud_used.update_ammo_hud(user, src)
 			else
 				to_chat(user, span_warning("\The [magazine] doesn't fit!"))
 		else
@@ -150,7 +150,7 @@
 	if(current_mag.chamber_closed) //If it's actually closed.
 		to_chat(user, span_notice("You clear the cylinder of [src]."))
 		make_casing(type_of_casings)
-		empty_cylinder()
+		empty_cylinder(user)
 		current_mag.create_handful(user)
 		current_mag.chamber_closed = !current_mag.chamber_closed
 		russian_roulette = !russian_roulette //Resets the RR variable.

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -64,6 +64,7 @@ can cause issues with ammo types getting mixed up during the burst.
 		cock_gun(user)
 	if(user)
 		playsound(user, reload_sound, 25, 1)
+		user.hud_used.update_ammo_hud(user, src)
 	return TRUE
 
 /obj/item/weapon/gun/shotgun/proc/empty_chamber(mob/user)
@@ -79,6 +80,7 @@ can cause issues with ammo types getting mixed up during the burst.
 	var/obj/item/ammo_magazine/handful/new_handful = retrieve_shell(ammo.type)
 	playsound(user, reload_sound, 25, 1)
 	new_handful.forceMove(get_turf(src))
+	user.hud_used.update_ammo_hud(user, src)
 	return TRUE
 
 
@@ -93,6 +95,7 @@ can cause issues with ammo types getting mixed up during the burst.
 	current_mag.current_rounds--
 	current_mag.chamber_contents[current_mag.chamber_position] = "empty"
 	current_mag.chamber_position--
+	user.hud_used.update_ammo_hud(user, src)
 	return 1
 
 ///Generates a handful of 1 bullet from the gun.
@@ -123,7 +126,7 @@ can cause issues with ammo types getting mixed up during the burst.
 	var/mag_caliber = magazine.default_ammo //Handfuls can get deleted, so we need to keep this on hand for later.
 	if(current_mag.transfer_ammo(magazine,user,1))
 		add_to_tube(user,mag_caliber) //This will check the other conditions.
-
+		user.hud_used.update_ammo_hud(user, src)
 
 /obj/item/weapon/gun/shotgun/unload(mob/user)
 	if(HAS_TRAIT(src, TRAIT_GUN_BURST_FIRING))


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title. The shotgun and revolver ammo counters now line up properly with the rounds in the chamber.

Closes #8386, although I couldn't reproduce the "you can pump it to empty it" part, the guns seem to lock as they should.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Ammo counter being accurate good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The ammo counter for the shotgun and revolvers now works properly 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
