### PR TITLE
nanite tweak

### DIFF
--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -1275,9 +1275,12 @@
 			to_chat(L, span_warning("The pain rapidly subsides. Looks like they've adapted to you."))
 		if(152 to INFINITY)
 			if(volume < 30) //smol injection will self-replicate up to 30u using 240u of blood.
-				L.reagents.add_reagent(/datum/reagent/medicine/research/medicalnanites, 0.25)
+				L.reagents.add_reagent(/datum/reagent/medicine/research/medicalnanites, 0.15)
 				L.blood_volume -= 2
-				
+			
+			if(volume < 35) //allows 10 ticks of healing for 20 points of free heal to lower scratch damage bloodloss amounts.
+				L.reagents.add_reagent(/datum/reagent/medicine/research/medicalnanites, 0.1)
+			
 			if (volume >5 && L.getBruteLoss()) //Unhealed IB wasting nanites is an INTENTIONAL feature.
 				L.heal_limb_damage(2*effect_str, 0)
 				L.adjustToxLoss(0.1*effect_str)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Nanites now have a "safe zone" where they won't cost blood for the first ~20 damage they heal in a given length of time. This should lower the odds of being "scratch damaged" to bloodloss death.

Actual stats are the same below 30u. Above 30u, you gain 0.1 nanites per tick for no cost up to 35u, which will allow 12 total ticks of healing on the way down (11 if it's 2 damagetypes) for 22-24 points of free heal. Below 30u, it starts costing blood again, and it takes 50 ticks to fully recharge your "scratch damage" reservoir.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Nanites aren't lethal if you take scratch damage or if you have other meds, but they can still *succ u* over time.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Nanites now have a "safe zone" where they won't cost blood for the first ~20 damage they heal in a given length of time. This should lower the odds of being "scratch damaged" to bloodloss death.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
