### PR TITLE
plant update

### DIFF
--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -743,7 +743,7 @@ GLOBAL_LIST_EMPTY(gene_tag_masks)   // Gene obfuscation for delicious trial and 
 	products = list(/obj/item/reagent_containers/food/snacks/grown/deathberries)
 	packet_icon = "seed-deathberry"
 	plant_icon = "deathberry"
-	chems = list(/datum/reagent/consumable/nutriment = list(1), /datum/reagent/toxin = list(3,3), /datum/reagent/toxin/lexorin = list(1,5))
+	chems = list(/datum/reagent/consumable/nutriment = list(1), /datum/reagent/toxin/lexorin = list(1,5), /datum/reagent/medicine/research/quietus = list(3,5))
 
 	yield = 3
 	potency = 50
@@ -805,7 +805,7 @@ GLOBAL_LIST_EMPTY(gene_tag_masks)   // Gene obfuscation for delicious trial and 
 	mutants = list("killer")
 	packet_icon = "seed-bloodtomato"
 	plant_icon = "bloodtomato"
-	chems = list(/datum/reagent/consumable/nutriment = list(1,10), /datum/reagent/blood = list(1,5))
+	chems = list(/datum/reagent/consumable/nutriment = list(1,10), /datum/reagent/blood = list(1,5), /datum/reagent/medicine/quickclotplus = list (3,5))
 
 	yield = 3
 
@@ -882,7 +882,7 @@ GLOBAL_LIST_EMPTY(gene_tag_masks)   // Gene obfuscation for delicious trial and 
 	packet_icon = "seed-apple"
 	plant_icon = "apple"
 	harvest_repeat = 1
-	chems = list(/datum/reagent/consumable/nutriment = list(1,10))
+	chems = list(/datum/reagent/consumable/nutriment = list(1,10), /datum/reagent/medicine/paracetamol = list(1,2))
 
 	lifespan = 55
 	maturation = 6
@@ -936,7 +936,7 @@ GLOBAL_LIST_EMPTY(gene_tag_masks)   // Gene obfuscation for delicious trial and 
 	mutants = null
 	packet_icon = "seed-ambrosiadeus"
 	plant_icon = "ambrosiadeus"
-	chems = list(/datum/reagent/consumable/nutriment = list(1), /datum/reagent/medicine/bicaridine = list(1,8), /datum/reagent/medicine/synaptizine = list(1,8,1), /datum/reagent/medicine/hyperzine = list(1,10,1), /datum/reagent/space_drugs = list(1,10))
+	chems = list(/datum/reagent/consumable/nutriment = list(1), /datum/reagent/medicine/research/somolent = list(5,10), /datum/reagent/medicine/synaptizine = list(1,8,1), /datum/reagent/medicine/hyperzine = list(1,10,1), /datum/reagent/space_drugs = list(1,10))
 
 //Mushrooms/varieties.
 /datum/seed/mushroom


### PR DESCRIPTION


<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

adds some of the "new" reagants to plants

Quietus added to deathberries.
Quick-clot plus added to blood tomato.
Paracetamol added to apple
Somolent added to Ambrosia deus.

Messsa's Tear and Srandar's hand looked at. Might repurpose those two. But that's a later thing.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

more content for RSR, updates old botany content with the last year of chem changes

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
expansion: 4 plants now have different chems. Deathberries, Blood tomatos, apples, and ambrosia deus now have Quietus, Quick-clot plus, paracetamol, and somolent, respectively.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
