### PR TITLE
Fixes loadout saved guns/armor with illegal attachments being vended.

### DIFF
--- a/code/datums/components/attachment_handler.dm
+++ b/code/datums/components/attachment_handler.dm
@@ -67,6 +67,11 @@
 				return
 		if(!do_attach(attachment, attacher, attachment_data))
 			return
+	
+	var/slot = attachment_data[SLOT]
+	if(!attacher && (!(slot in slots) || !(attachment.type in attachables_allowed))) //No more black market attachment combos.
+		QDEL_NULL(attachment)
+		return
 
 	finish_handle_attachment(attachment, attachment_data, attacher)
 


### PR DESCRIPTION

## About The Pull Request
Title.
T35 got miniflamer removed from it. You can still vend t35-miniflamer. This PR fixes it.


## Why It's Good For The Game
Black market attachment combos die.


## Changelog
:cl:
fix: Fixes loadout saved guns/armor with illegal attachments being vended.
/:cl:

