### PR TITLE
Buff xeno number per marines

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -143,7 +143,7 @@ MEDICAL_DOCTOR, MEDICAL_RESEARCHER, SQUAD_LEADER, SQUAD_SMARTGUNNER, SQUAD_CORPS
 // how much a job is going to contribute towards burrowed larva. see config for points required to larva. old balance was 1 larva per 3 humans.
 #define LARVA_POINTS_SHIPSIDE 1
 #define LARVA_POINTS_SHIPSIDE_STRONG 1.5
-#define LARVA_POINTS_REGULAR 3
+#define LARVA_POINTS_REGULAR 3.25
 #define LARVA_POINTS_STRONG 6
 
 #define SURVIVOR_POINTS_REGULAR 1


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Make each squad marine give more xeno

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

I suspect https://github.com/tgstation/TerraGov-Marine-Corps/pull/7184 gonna nerf xeno in high pop too much, while it won't help xeno in small pop at all.

Since the former pr is removing some sustain from xeno (less silos), it's important to give them more xeno at the start to compensate for the loss they'll always suffer early game

## Changelog
:cl:
balance: Marine spawning give more xeno points
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
