### PR TITLE
Removes the T-60 GPMG from vendors, adds unlimited T-27 MMGs.

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -137,9 +137,7 @@
 		"Machinegun" = list(
 			/obj/item/weapon/gun/rifle/standard_lmg = -1,
 			/obj/item/ammo_magazine/standard_lmg = -1,
-			/obj/item/weapon/gun/rifle/standard_gpmg = -1,
-			/obj/item/ammo_magazine/standard_gpmg = -1,
-			/obj/item/weapon/gun/standard_mmg = 5,
+			/obj/item/weapon/gun/standard_mmg = -1,
 			/obj/item/ammo_magazine/standard_mmg = -1,
 		),
 		"Sidearm" = list(


### PR DESCRIPTION
## About The Pull Request

Removes the T-60 GPMG from vendors, replaces it with the T-27 MMG.

## Why It's Good For The Game

The T-60 is good for precisely 2 things:
1. Holding chokepoints.
2. Disintegrating anything within a 15 mile radius in unga charges using massed aimed fire.

The former is better suited for the T-27 (from a balance, gameplay, and fun perspective), and the latter is bullshit to deal with and unfun.

## Changelog
:cl:
del: Removed the T-60 from marine shared weapons vendors.
balance: Unlimited T-27s in marine shared weapons vendors.
/:cl:
