### PR TITLE
Fixes energy weapon ammo counter

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -352,6 +352,7 @@
 		if(reload_sound)
 			playsound(user, reload_sound, 25, 1, 5)
 		update_icon(user)
+		user.hud_used.update_ammo_hud(user, src)
 	else
 		cell.loc = src
 		update_icon()
@@ -369,14 +370,16 @@
 		cell.loc = get_turf(src) //Drop it on the ground.
 	else
 		user.put_in_hands(cell)
-
-	playsound(loc, unload_sound, 25, 1, 5)
-	user?.visible_message(span_notice("[user] unloads [cell] from [src]."),
-	span_notice("You unload [cell] from [src]."), null, 4)
 	cell.update_icon()
-	set_cell(null)
-	update_icon(user)
-
+	if(user)
+		user.visible_message(span_notice("[user] unloads [cell] from [src]."), span_notice("You unload [cell] from [src]."), null, 4)
+		set_cell(null)
+		playsound(user, unload_sound, 25, 1, 5)
+		update_icon(user)
+		user.hud_used.update_ammo_hud(user, src)
+	else
+		set_cell(null)
+		update_icon()
 	return TRUE
 
 //-------------------------------------------------------


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes ammo counter for energy guns because I didn't notice their procs don't call parents.

I forgot this. Wanted to do it as part of a bigger PR coming up but was told to atomise. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Ammo counter working is neat.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: ammo counter works for energy weapons
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
