### PR TITLE
lung damage changes

### DIFF
--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -168,12 +168,23 @@
 				INTERNAL ORGANS TYPES
 ****************************************************/
 
-/datum/internal_organ/heart // This is not set to vital because death immediately occurs in blood.dm if it is removed.
+/datum/internal_organ/heart // This is not set to vital because death immediately occurs in blood.dm if it is removed. Also, all damage effects are handled there.
 	name = "heart"
 	parent_limb = "chest"
 	removed_type = /obj/item/organ/heart
 	robotic_type = /obj/item/organ/heart/prosthetic
 	organ_id = ORGAN_HEART
+
+/datum/internal_organ/heart/process()
+	..()
+	
+	if(!owner.reagents.get_reagent_amount(/datum/reagent/medicine/peridaxon) >= 0.05)
+		if(is_bruised())
+			if(prob(5))
+				spawn owner.emote("me", 1, "grabs at his chest!")
+		else if(is_broken())
+			if(prob(20))
+				spawn owner.emote("me", 1, "clutches his chest!")
 
 /datum/internal_organ/heart/prosthetic //used by synthetic species
 	robotic = ORGAN_ROBOT
@@ -194,12 +205,19 @@
 
 	if(!owner.reagents.get_reagent_amount(/datum/reagent/medicine/peridaxon) >= 0.05)
 		if(is_bruised())
-			if(prob(2))
+			if(prob(5))
 				spawn owner.emote("me", 1, "coughs up blood!")
 				owner.drip(10)
-			if(prob(4))
+			if(prob(15))
 				spawn owner.emote("me", 1, "gasps for air!")
-				owner.Losebreath(15)
+				owner.Losebreath(10)
+		else if(is_broken())
+			if(prob(30))
+				spawn owner.emote("me", 1, "coughs up blood!")
+				owner.drip(10)
+			if(prob(50))
+				spawn owner.emote("me", 1, "gasps for air!")
+				owner.Losebreath(4)
 
 /datum/internal_organ/lungs/prosthetic
 	robotic = ORGAN_ROBOT


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a note that all heart damage effects are handled in blood.dm for clarity.

Adds in a few diagnostic messages for heart damage.

Ups the probability of actually taking consequences from lung damage from 2/4% to 5/15% respectively, but lowers the losebreath slightly.
Adds in actual consequences for exceeding the lung damage broken threshold (30% chance for 5 bloodloss, 50% chance for 4 losebreath).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

More diagnostic messages for heart damage. Lower levels of lung damage are actually noticeable rather than being so low probability that they don't happen. 

If your lungs are turned to swiss cheese, you'll actually die now without treatment instead of just ignoring it.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: lung damage is bad for you now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
