### PR TITLE
Deletes Miniflamer from Laser Carbine

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -563,7 +563,6 @@
 		/obj/item/attachable/magnetic_harness,
 		/obj/item/attachable/scope/marine,
 		/obj/item/attachable/scope/mini,
-		/obj/item/weapon/gun/flamer/mini_flamer,
 		/obj/item/attachable/motiondetector,
 		/obj/item/attachable/buildasentry,
 	)


### PR DESCRIPTION
## About The Pull Request

Did I stutter? Shotguns lost their ability to have mini-flamethrowers attached to them, ergo the laser carbine also gets the boot. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Consistency. Shotguns lost their right to administer a baptism by fire, therefore the laser carbine does as well due to the projectiles being hitscan and quite simply dealing a **truckload** of damage to any mobs within ranges where the miniflamer is optimal.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Revokes the Laser Carbine's license to provide a fire baptism.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
