### PR TITLE
Gives hunter a % armor piercing vs staggered targets

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -508,6 +508,6 @@
 // *********** Passive: stagger armor penetration.
 // ***************************************
 /mob/living/carbon/human/attack_alien_harm(mob/living/carbon/xenomorph/hunter/X, list/armor_mod)
-	if(src.stagger >= 1) //src is the slashed human.
+	if(stagger >= 1)
 		armor_mod += 8 //this is armor piercing .8 is 8%, 8 is around 25.5%.
 	return ..()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR gives Hunters a 25.5% AP vs staggered targets (unless my math is worse than I thought 8.2 brute vs heavy armor and mk2 tyr, 11 when staggered.)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Hunter is supposed to be a squishy damage dealer backliner. Some of the abilities in his kit already gives stagger so why not combo with a passive that makes him deadlier against disoriented marines.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds hunter passive: 25% ap against staggered enemies.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
