### PR TITLE
Pizza factory is a little more profitable

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1708,7 +1708,7 @@ FACTORY
 /datum/supply_packs/factory/pizzarefill
 	name = "Nanotrasen \"Eat healthy!\" margerita pizza kit refill"
 	contains = list(/obj/item/factory_refill/pizza)
-	cost = 29 //allows a one point profit if all pizzas are processed and sold back to ASRS
+	cost = 27 //allows a three point profit if all pizzas are processed and sold back to ASRS
 
 /datum/supply_packs/factory/smartrifle_ammo_refill
 	name = "Smart rifle bullet parts refill"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This raises the profits from selling pizza from 1 point to 3 points.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The cost of the machines for the pizza factory is 30 points so with only 1 point of profit you would need to make and sell pizzas 30 times to recover the initial investment. Considering it takes about a little more than a minute to buy, process and sell a batch of pizza it takes way too long to turn in a meaningful profit and expand the factory.

With this change you would get 3 points of profit per pizza batch so only 10 batches are needed to recover the initial costs which is more reasonable without being OP.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Selling pizza is a little more profitable now! 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
