### PR TITLE
Halve healrate of Bica/Kelo/Tricord, duration increased to match total over time

### DIFF
--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -199,27 +199,28 @@
 	color = "#D8C58C"
 	scannable = TRUE
 	purge_list = list(/datum/reagent/medicine/ryetalyn)
-	purge_rate = 1
+	purge_rate = 0.5
+	custom_metabolism = REAGENTS_METABOLISM * 0.5
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 
 /datum/reagent/medicine/kelotane/on_mob_life(mob/living/L, metabolism)
 	var/target_temp = L.get_standard_bodytemperature()
-	L.heal_limb_damage(0, effect_str)
+	L.heal_limb_damage(0, 0.5*effect_str)
 	if(L.bodytemperature > target_temp)
 		L.adjust_bodytemperature(-2.5*TEMPERATURE_DAMAGE_COEFFICIENT*effect_str, target_temp)
 	if(volume > 10)
 		L.reagent_pain_modifier -= PAIN_REDUCTION_LIGHT
 	if(volume > 20)
 		L.reagent_pain_modifier -= PAIN_REDUCTION_LIGHT
-		L.heal_limb_damage(0, 0.5*effect_str)
+		L.heal_limb_damage(0, 0.25*effect_str)
 	return ..()
 
 /datum/reagent/medicine/kelotane/overdose_process(mob/living/L, metabolism)
-	L.apply_damages(effect_str, 0, effect_str)
+	L.apply_damages(0.5*effect_str, 0, 0.5*effect_str)
 
 /datum/reagent/medicine/kelotane/overdose_crit_process(mob/living/L, metabolism)
-	L.apply_damages(2*effect_str, 0, 2*effect_str)
+	L.apply_damages(effect_str, 0, effect_str)
 
 /datum/reagent/medicine/dermaline
 	name = "Dermaline"
@@ -299,16 +300,17 @@
 	color = "#B865CC"
 	scannable = TRUE
 	purge_list = list(/datum/reagent/medicine/ryetalyn)
-	purge_rate = 1
+	purge_rate = 0.5
+	custom_metabolism = REAGENTS_METABOLISM * 0.5
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	taste_description = "grossness"
 
 /datum/reagent/medicine/tricordrazine/on_mob_life(mob/living/L, metabolism)
 
-	L.adjustOxyLoss(-0.5*effect_str)
-	L.adjustToxLoss(-0.4*effect_str)
-	L.heal_limb_damage(0.8*effect_str, 0.8*effect_str)
+	L.adjustOxyLoss(-0.25*effect_str)
+	L.adjustToxLoss(-0.2*effect_str)
+	L.heal_limb_damage(0.4*effect_str, 0.4*effect_str)
 	if(volume > 10)
 		L.reagent_pain_modifier -= PAIN_REDUCTION_LIGHT
 	if(volume > 20)
@@ -317,10 +319,10 @@
 
 /datum/reagent/medicine/tricordrazine/overdose_process(mob/living/L, metabolism)
 	L.jitter(5)
-	L.adjustBrainLoss(effect_str, TRUE)
+	L.adjustBrainLoss(0.5*effect_str, TRUE)
 
 /datum/reagent/medicine/tricordrazine/overdose_crit_process(mob/living/L, metabolism)
-	L.apply_damages(3*effect_str, 3*effect_str, 3*effect_str)
+	L.apply_damages(1.5*effect_str, 1.5*effect_str, 1.5*effect_str)
 
 /datum/reagent/medicine/dylovene
 	name = "Dylovene"
@@ -627,26 +629,27 @@
 	description = "Bicaridine is an analgesic medication and can be used to treat blunt trauma."
 	color = "#E8756C"
 	purge_list = list(/datum/reagent/medicine/ryetalyn)
-	purge_rate = 1
+	purge_rate = 0.5
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
+	custom_metabolism = REAGENTS_METABOLISM * 0.5
 	scannable = TRUE
 
 /datum/reagent/medicine/bicaridine/on_mob_life(mob/living/L, metabolism)
-	L.heal_limb_damage(effect_str, 0)
+	L.heal_limb_damage(0.5*effect_str, 0)
 	if(volume > 10)
 		L.reagent_pain_modifier -= PAIN_REDUCTION_LIGHT
 	if(volume > 20)
 		L.reagent_pain_modifier -= PAIN_REDUCTION_LIGHT
-		L.heal_limb_damage(0.5*effect_str, 0)
+		L.heal_limb_damage(0.25*effect_str, 0)
 	return ..()
 
 
 /datum/reagent/medicine/bicaridine/overdose_process(mob/living/L, metabolism)
-	L.apply_damage(effect_str, BURN)
+	L.apply_damage(0.5*effect_str, BURN)
 
 /datum/reagent/medicine/bicaridine/overdose_crit_process(mob/living/L, metabolism)
-	L.apply_damages(effect_str, 3*effect_str, 2*effect_str)
+	L.apply_damages(0.5*effect_str, 1.5*effect_str, effect_str)
 
 /datum/reagent/medicine/meralyne
 	name = "Meralyne"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Halves healing rate of Bicaridine, Kelotane, and Tricordrazine. Metabolization rate halved to match the per-unit total healing effect.
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
A core issue that has been going for a while is that marines can heal while in combat while xenos need to run away from combat and find weeds to rest on, something they can't do if they're getting chased (which the marine can also heal during). This can make it extremely difficult for xenos to do much if the damage they're able to deal is simply not enough to get past that healing effect, while marines can constantly deal damage that will force xenos to fall back. This also affects things like acid turrets, sometimes rendered a 4-second delay tool at most due to marines healing while shooting at it.

Bonefracs and organ damage most of the time only happen way after combat had ended, at which point the xeno either A) Killed the marine, B) Ran, C) Died, making their existence mostly irrelevant to the issue here.

Halving the healing rate will mitigate this somewhat by making mid-combat healing not as extreme, while also keeping the total healing and OD of said reagents the same so as to keep the math intact on a per-unit basis. Marines would hopefully need a resting period to actually heal, rather than fighting and getting healed even over bonefrac thresholds while xenos have to run and subsequently get chased as the marine now heals to full. It'd also make it possible to actually chip away at their health in stalemates, ideally.

Only touches the main three healing chems marines can all pack without chem intervention, doesn't touch meralyne/dermaline/paracetamol.

Should probably be TMd thoroughly before thinking of merging.


## Changelog
:cl:
balance: Effects of Bicaridine, Kelotane, and Tricordrazine halved. Duration doubled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
