### PR TITLE
Heal speed of Bica/Kelo/Tricord down to x0.75, duration increased to match total over time

### DIFF
--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -202,8 +202,8 @@
 	purge_rate = 1
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
-	effect_str = 0.5
-	custom_metabolism = REAGENTS_METABOLISM * 0.5
+	effect_str = 0.75
+	custom_metabolism = REAGENTS_METABOLISM * 0.75
 
 /datum/reagent/medicine/kelotane/on_mob_life(mob/living/L, metabolism)
 	var/target_temp = L.get_standard_bodytemperature()
@@ -305,8 +305,8 @@
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	taste_description = "grossness"
-	effect_str = 0.5
-	custom_metabolism = REAGENTS_METABOLISM * 0.5
+	effect_str = 0.75
+	custom_metabolism = REAGENTS_METABOLISM * 0.75
 
 /datum/reagent/medicine/tricordrazine/on_mob_life(mob/living/L, metabolism)
 
@@ -635,8 +635,8 @@
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	scannable = TRUE
-	effect_str = 0.5
-	custom_metabolism = REAGENTS_METABOLISM * 0.5
+	effect_str = 0.75
+	custom_metabolism = REAGENTS_METABOLISM * 0.75
 
 /datum/reagent/medicine/bicaridine/on_mob_life(mob/living/L, metabolism)
 	L.heal_limb_damage(effect_str, 0)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Halves healing rate of Bicaridine, Kelotane, and Tricordrazine. Metabolization rate halved to match the per-unit total healing effect.

18/10/2021
- effect_str and custom_metabolism upped to 0.75. Description is from old 0.5 values.
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
A core issue that has been going for a while is that marines can heal while in combat while xenos need to run away from combat and find weeds to rest on, something they can't do if they're getting chased (which the marine can also heal during). This can make it extremely difficult for xenos to do much if the damage they're able to deal is simply not enough to get past that healing effect, while marines can constantly deal damage that will force xenos to fall back. This also affects things like acid turrets, sometimes rendered a 4-second delay tool at most due to marines healing while shooting at it.

Bonefracs and organ damage most of the time only happen way after combat had ended, at which point the xeno either A) Killed the marine, B) Ran, C) Died, making their existence mostly irrelevant to the issue here.

Halving the healing rate will mitigate this somewhat by making mid-combat healing not as extreme, while also keeping the total healing and OD of said reagents the same so as to keep the math intact on a per-unit basis. Marines would hopefully need a resting period to actually heal, rather than fighting and getting healed even over bonefrac thresholds while xenos have to run and subsequently get chased as the marine now heals to full. It'd also make it possible to actually chip away at their health in stalemates, ideally.

Only touches the main three healing chems marines can all pack without chem intervention, doesn't touch meralyne/dermaline/paracetamol.

Should probably be TMd thoroughly before thinking of merging.

## Changelog
:cl:
balance: Effects of Bicaridine, Kelotane, and Tricordrazine halved. Duration doubled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
