### PR TITLE
Make stacks show how much there are in inventory

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -51,7 +51,7 @@
 		loc?.recalculate_storage_space() //No need to do icon updates if there are no changes.
 
 
-/obj/item/stack/update_icon()
+/obj/item/stack/update_icon_state()
 	if(!number_of_extra_variants)
 		return
 	var/ratio = round((amount * (number_of_extra_variants + 1)) / max_amount)
@@ -60,6 +60,14 @@
 		return
 	ratio = min(ratio + 1, number_of_extra_variants + 1)
 	icon_state = "[initial(icon_state)]_[ratio]"
+
+/obj/item/stack/update_overlays()
+	. = ..()
+	if(isturf(loc))
+		return
+	var/mutable_appearance/number = mutable_appearance()
+	number.maptext = MAPTEXT(amount)
+	. += number
 
 
 /obj/item/stack/Destroy()
@@ -72,6 +80,14 @@
 	. = ..()
 	if(amount > 1)
 		to_chat(user, "There are [amount] [singular_name]\s in the [stack_name].")
+
+/obj/item/stack/equipped(mob/user, slot)
+	. = ..()
+	update_icon()
+
+/obj/item/stack/dropped(mob/user, slot)
+	. = ..()
+	update_icon()
 
 /obj/item/stack/interact(mob/user, recipes_sublist)
 	. = ..()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
https://cdn.discordapp.com/attachments/500801682058379265/896746849627676752/Change_Me_-_Debugdalus_2021-10-10_15-10-50.mp4

## Changelog
:cl:
qol: stacks now show how many items there are when in your inventory
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
