### PR TITLE
Reduces shield integrity by 150

### DIFF
--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -137,7 +137,7 @@
 	icon = 'icons/obj/items/weapons.dmi'
 	icon_state = "marine_shield"
 	flags_equip_slot = ITEM_SLOT_BACK
-	max_integrity = 400
+	max_integrity = 250
 	integrity_failure = 100
 	soft_armor = list("melee" = 50, "bullet" = 50, "laser" = 0, "energy" = 100, "bomb" = 15, "bio" = 50, "rad" = 0, "fire" = 0, "acid" = 35)
 	hard_armor = list("melee" = 0, "bullet" = 5, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reduces shield integrity by 150, making it 250 from a previous 400. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Shield is absurdly tough and when combined with certain one handed weapons makes for a deadly combo. The fact that a shield user cannot die to even a ravager without about a minute and a half worth of just constant slashing (assuming the shield marine has not premedded) is pretty absurd to me. Combined with other marines the shield marine also becomes an insane bastion of just negating xeno attacks, blocking them from getting to the more squishier marines. Reducing shield integrity means that shields are still strong, viable and capable, but need to be maintained more often and also makes it actually possible for xenos to break the shield in combat, as previously this seemed to never happen. I'd balance it another way by reducing its defensive values perhaps, but looking at the shield code made me scared. So no thanks.

Xenos are melee focused, having something that nearly entirely nullifies this is stupid. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Reduced shield integrity to 250 from a previous 400.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
