### PR TITLE
adds bowl, abuzar and aleksey to the slab of victory memorial 

### DIFF
--- a/code/game/objects/structures/prop.dm
+++ b/code/game/objects/structures/prop.dm
@@ -137,6 +137,10 @@
 	resistance_flags = UNACIDABLE
 	var/list/fallen_list
 
+/obj/structure/prop/mainship/ship_memorial/Initialize()
+	. = ..()
+	LAZYADD(fallen_list, "Aleksey, Bowl and Abuzar in toolbox tournament 2021")
+
 /obj/structure/prop/mainship/ship_memorial/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/dogtag))
 		var/obj/item/dogtag/D = I


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
expansion: Aleks bowl and abuzar have been added to the slab victory tournament every round in honor of their participation of toolbox tournament 2021
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
