### PR TITLE
Premed nerf, combatmed buff

### DIFF
--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -203,9 +203,14 @@
 	overdose_threshold = REAGENTS_OVERDOSE
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 
+/datum/reagent/medicine/kelotane/on_mob_add(mob/living/L, metabolism)
+	var/fire_loss = L.getFireLoss()
+	L.heal_limb_damage(0, 0.2*effect_str*fire_loss(+5))
+	to_chat(L, span_warning("Your wounds begin to rapidly knit together!"))
+
 /datum/reagent/medicine/kelotane/on_mob_life(mob/living/L, metabolism)
 	var/target_temp = L.get_standard_bodytemperature()
-	L.heal_limb_damage(0, effect_str)
+
 	if(L.bodytemperature > target_temp)
 		L.adjust_bodytemperature(-2.5*TEMPERATURE_DAMAGE_COEFFICIENT*effect_str, target_temp)
 	if(volume > 10)
@@ -213,7 +218,20 @@
 	if(volume > 20)
 		L.reagent_pain_modifier -= PAIN_REDUCTION_LIGHT
 		L.heal_limb_damage(0, 0.5*effect_str)
+	switch(current_cycle)
+		if(1 to 25)
+			L.heal_limb_damage(0, effect_str)
+		if(26 to 50)
+			L.heal_limb_damage(0, (-0.02 * current_cycle + 1.5)*effect_str)
+		if(51 to INFINITY)
+			L.heal_limb_damage(0, 0.5*effect_str)
 	return ..()
+
+/datum/reagent/medicine/kelotane/on_mob_delete(mob/living/L, metabolism)
+	if(current_cycle > 10)
+		return
+	to_chat(L, span_userdanger("You reel as your medicine stops affecting you!"))
+	L.Paralyze((5*current_cycle)-50)
 
 /datum/reagent/medicine/kelotane/overdose_process(mob/living/L, metabolism)
 	L.apply_damages(effect_str, 0, effect_str)
@@ -307,8 +325,8 @@
 /datum/reagent/medicine/tricordrazine/on_mob_life(mob/living/L, metabolism)
 
 	L.adjustOxyLoss(-0.5*effect_str)
-	L.adjustToxLoss(-0.4*effect_str)
-	L.heal_limb_damage(0.8*effect_str, 0.8*effect_str)
+	L.adjustToxLoss(-0.25*effect_str)
+	L.heal_limb_damage(0.5*effect_str, 0.5*effect_str)
 	if(volume > 10)
 		L.reagent_pain_modifier -= PAIN_REDUCTION_LIGHT
 	if(volume > 20)
@@ -632,15 +650,31 @@
 	overdose_crit_threshold = REAGENTS_OVERDOSE_CRITICAL
 	scannable = TRUE
 
+/datum/reagent/medicine/bicardine/on_mob_add(mob/living/L, metabolism)
+	var/brute_loss = L.getBruteLoss()
+	L.heal_limb_damage(0.2*effect_str*brute_loss(+5), 0)
+	to_chat(L, span_warning("Your wounds begin to rapidly knit together!"))
+
 /datum/reagent/medicine/bicaridine/on_mob_life(mob/living/L, metabolism)
-	L.heal_limb_damage(effect_str, 0)
 	if(volume > 10)
 		L.reagent_pain_modifier -= PAIN_REDUCTION_LIGHT
 	if(volume > 20)
 		L.reagent_pain_modifier -= PAIN_REDUCTION_LIGHT
 		L.heal_limb_damage(0.5*effect_str, 0)
+	switch(current_cycle)
+		if(1 to 25)
+			L.heal_limb_damage(effect_str, 0)
+		if(26 to 50)
+			L.heal_limb_damage((-0.02 * current_cycle + 1.5)*effect_str, 0)
+		if(51 to INFINITY)
+			L.heal_limb_damage(0.5*effect_str, 0)
 	return ..()
 
+/datum/reagent/medicine/bicardine/on_mob_delete(mob/living/L, metabolism)
+	if(current_cycle > 10)
+		return
+	to_chat(L, span_userdanger("You reel as your medicine stops affecting you!"))
+	L.Paralyze((5*current_cycle)-50)
 
 /datum/reagent/medicine/bicaridine/overdose_process(mob/living/L, metabolism)
 	L.apply_damage(effect_str, BURN)


### PR DESCRIPTION

<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes kelotane and bicard to heal based off a curve. The first 5u heals 1/tick as normal, the next 5u heals a decreasing amount from 1.0 to 0.5/tick, and the next 5u and any more heal a flat 0.5/tick. The high-dose bonus (0.5 healrate if above 20u) remains unchanged. 

Also tricord got nerfed to a flat 0.5 healrate (and 0.25 toxheal) rather than 0.8... so it's 100% as good at total damageheal as a specialized med, not 160%.

Autoinjectors will still heal 25 points per inject, pills will now heal 56.25 points per pill (down from 75), and any chained pills will heal 37.5 points per pill.

That's the nerf. The buff is that addition of bicard or kelo now heals 20% of your brute/burn damage (plus five free points) *instantly* upon mob add, which can be substantial if you're hurt. The break-even point for pills to get equal or greater total heal than oldpills is ~68 health, while autoinjectors have the same performance and get the healrate changes as a straight bonus.

To prevent the obvious exploit of "well I'll just drink a buncha water and keep hittin' myself with a 1u bicakelo injector", ungas now get a *five* second stun when bicard and kelo leave your body, reduced by 0.5 seconds per tick it was in you. This can benefit ayys slightly, but in the worst-case scenario of you popping a standard 15u combat autoinjector *while* you're neurotoxined... 

...you still won't get stunned. 

It'll only get you if you have a microdose injector of less than 10u *and* are actively purging, or if you use an injector with less than 2u in it. Now, a *medic* running a microdose setup might be able to heal large quantities of damage rapidly on someone else at the expense of micromanagement and stunning the victim... but that's a different subject and one I'm more-or-less OK with.


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Premed and being on nonstop pills is no longer always the best option. You can now make a choice about whether to be on constant but slower healing, or to be able to burst-heal for more total damage, at the cost of having to take actions to do this.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Kelo and bicard now heal less damage over time, but heal some up-front. Tricord healing cut to 0.5/tick (0.25 tox).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
