### PR TITLE
Unsilo-able combat robots

### DIFF
--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -795,6 +795,10 @@ TUNNEL
 		to_chat(user, span_notice("[victim] has no useful biomass for us."))
 		return
 
+		if(isrobot(victim))
+		to_chat(user, span_notice("[victim] has no useful biomass for us."))
+		return
+
 	visible_message("[user] starts putting [victim] into [src].", 3)
 
 	if(!do_after(user, 20, FALSE, victim, BUSY_ICON_DANGER) || QDELETED(src))


### PR DESCRIPTION
## About The Pull Request

Was exploring the code to and decided to make combat robots unsilo-able since they are machines.

## Why It's Good For The Game

Ensures that robot corpses can't have their non-existent biomass be used for larva generation

## Changelog
:cl:
fix: fixed combat robots being silo-able
code: Added code to xeno_structures.dm so that combat robots can't be put into silos.
/:cl: