### PR TITLE
Xeno door health buff

### DIFF
--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -120,7 +120,7 @@
 	icon = 'icons/Xeno/Effects.dmi'
 	hardness = 1.5
 	layer = RESIN_STRUCTURE_LAYER
-	max_integrity = 200
+	max_integrity = 100
 	var/close_delay = 10 SECONDS
 
 	tiles_with = list(/turf/closed, /obj/structure/mineral_door/resin)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Xeno door health buffed from 50 to 100. Armor left at 0.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It takes two bullets to kill a door currently, you can shoot them down faster than you can walk with an autofire gun. This gives them the half HP as a wall, but not the armor, so they have less than a quarter the effective HP (walls have an effective 500 HP). Additionally, flamer fire still does a buncha extra damage to doors and should kill them in two ticks.

Now it'll take four bullets to kill a door.

I also do not believe that doors heal.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:

balance: ayy doors aren't paper-machie anymore

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
