### PR TITLE
QC+ and peri+ now cause cloneloss

### DIFF
--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -723,7 +723,7 @@
 	custom_metabolism = REAGENTS_METABOLISM * 2.5
 
 /datum/reagent/medicine/quickclotplus/on_mob_add(mob/living/L, metabolism)
-	if(TIMER_COOLDOWN_CHECK(L, "name))
+	if(TIMER_COOLDOWN_CHECK(L, name))
 		return
 	L.adjustCloneLoss(5*effect_str)
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

QC+ and Peri+ now cause 5 points of cloneloss each dose, subtracted immediately once dosed. There is a thirty-second timer upon it finishing metabolising before this damage can be re-applied, allowing for multiple doses in one treatment session with no additional damage.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

IB and organ damage have become a thing of the past over the last 6 months or so. They don't exist in any capacity because I added these two drugs. No, you don't need a medic to use them, medbay gets looted for the injectors all the time.

Now that I've added a way to slowly heal cloneloss on the field, these two can do smol quantities of cloneloss as a side effect. They will still remove the "perma" damage that has actual consequences, but they won't just let you laugh off getting your chest caved in with 0 damage.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: makes ungas sad
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
