### PR TITLE
Pain rebalance

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -6,12 +6,11 @@
 
 
 //Pain or shock reduction for different reagents
-#define PAIN_REDUCTION_VERY_LIGHT -10 //alkysine
-#define PAIN_REDUCTION_LIGHT -25 //inaprovaline
-#define PAIN_REDUCTION_MEDIUM -40 //synaptizine
-#define PAIN_REDUCTION_HEAVY -50 //paracetamol
-#define PAIN_REDUCTION_VERY_HEAVY -80 //tramadol
-#define PAIN_REDUCTION_FULL -200 //oxycodone, neuraline
+#define PAIN_REDUCTION_VERY_LIGHT -5 //alkysine
+#define PAIN_REDUCTION_LIGHT -15 //inaprovaline
+#define PAIN_REDUCTION_MEDIUM -25 //synaptizine
+#define PAIN_REDUCTION_HEAVY -35 //paracetamol
+#define PAIN_REDUCTION_VERY_HEAVY -50 //tramadol
 
 
 //Nutrition

--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -261,11 +261,11 @@
 		/datum/reagent/medicine/rezadone = 15,
 	)
 
-/obj/item/reagent_containers/hypospray/autoinjector/hydrocodone //made for debugging
-	name = "hydrocodone autoinjector"
-	desc = "An auto-injector loaded with hydrocodone."
+/obj/item/reagent_containers/hypospray/autoinjector/pain //made for debugging
+	name = "liquid pain autoinjector"
+	desc = "An auto-injector loaded with liquid pain. Ow."
 	icon_state = "autoinjector-6"
-	amount_per_transfer_from_this = 4
+	amount_per_transfer_from_this = 20
 	volume = 100
 
-	list_reagents = list(/datum/reagent/medicine/hydrocodone = 100)
+	list_reagents = list(/datum/reagent/toxin/pain = 100)

--- a/code/modules/mob/living/carbon/human/life/handle_shock.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_shock.dm
@@ -7,11 +7,11 @@
 		return //Godmode or some other pain reducers. //Analgesic avoids all traumatic shock temporarily
 
 	switch(traumatic_shock)
-		if(200 to INFINITY)
-			adjustShock_Stage(5) //All of these adjust shock_stage based on traumatic_shock
+		if(200 to INFINITY) //All of these adjust shock_stage based on traumatic_shock
+			adjustShock_Stage(5+((traumatic_shock-200)*0.2)) //Uncapped max gain of shock_stage, depending on traumatic_shock.
 
 		if(150 to 200)
-			adjustShock_Stage(2)
+			adjustShock_Stage(1+((traumatic_shock-150)*0.08)) //smooth ramp from 1 to 5
 
 		if(100 to 150)
 			adjustShock_Stage(1)
@@ -33,7 +33,6 @@
 		if(30 to 39)
 			if(prob(20))
 				to_chat(src, span_danger("[pick("It hurts so much", "You really need some painkillers", "Dear god, the pain")]!"))
-			blur_eyes(2)
 			stuttering = max(stuttering, 5)
 		if(40 to 59)
 			if(prob(20))
@@ -47,9 +46,6 @@
 				emote("me", 1, " is having trouble standing.")
 			blur_eyes(2)
 			stuttering = max(stuttering, 5)
-			if(prob(2))
-				if(!lying_angle)
-					emote("me", 1, " is having trouble standing.")
 			adjust_stagger(3, FALSE, 3)
 			add_slowdown(3)
 			if(prob(20))

--- a/code/modules/mob/living/carbon/human/life/handle_shock.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_shock.dm
@@ -2,28 +2,28 @@
 
 /mob/living/carbon/human/handle_shock()
 	. = ..()
-	if(status_flags & GODMODE || analgesic || (species && species.species_flags & NO_PAIN) || stat == DEAD)
+	if(status_flags & GODMODE || analgesic || (species && species.species_flags & NO_PAIN))
 		setShock_Stage(0)
 		return //Godmode or some other pain reducers. //Analgesic avoids all traumatic shock temporarily
 
 	switch(traumatic_shock)
 		if(200 to INFINITY)
-			setShock_Stage(max(shock_stage + 5, 150)) //Indescribable pain. At this point, you will immediately be knocked down, with shock stage set to 150.
+			adjustShock_Stage(5) //All of these adjust shock_stage based on traumatic_shock
 
 		if(150 to 200)
-			adjustShock_Stage(2) //If their shock exceeds 150, add more to their shock stage, regardless of health.
+			adjustShock_Stage(2)
 
 		if(100 to 150)
-			adjustShock_Stage(1) //If their shock exceeds 100, add more to their shock stage, regardless of health.
+			adjustShock_Stage(1)
 
-		if(75 to 100)
-			setShock_Stage(min(shock_stage - 1, 120)) //No greater than 120
+		if(0 to 35)
+			adjustShock_Stage(-1)
 
-		if(50 to 75)
-			setShock_Stage(min(shock_stage - 2, 80))
+		if(-40 to 0)
+			adjustShock_Stage(-2)
 
-		if(-INFINITY to 50)
-			setShock_Stage(min(shock_stage - 5, 60)) //When we have almost no pain remaining. No greater than 60, reduced by 10 each time.
+		if(-INFINITY to -40)
+			adjustShock_Stage(-5)
 
 	//This just adds up effects together at each step, with a few small exceptions. Preferable to copy and paste rather than have a billion if statements.
 	switch(shock_stage)

--- a/code/modules/mob/living/carbon/human/life/handle_shock.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_shock.dm
@@ -23,7 +23,7 @@
 			adjustShock_Stage(-2)
 
 		if(-INFINITY to -30)
-			adjustShock_Stage(-4+((traumatic_shock+30)*0.2) //uncapped heal, 1 extra point per 5 traumatic_shock above threshold.
+			adjustShock_Stage(-4+((traumatic_shock+30)*0.2)) //uncapped heal, 1 extra point per 5 traumatic_shock above threshold.
 
 	//This just adds up effects together at each step, with a few small exceptions. Preferable to copy and paste rather than have a billion if statements.
 	switch(shock_stage)

--- a/code/modules/mob/living/carbon/human/life/handle_shock.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_shock.dm
@@ -16,14 +16,14 @@
 		if(100 to 150)
 			adjustShock_Stage(1)
 
-		if(0 to 35)
+		if(5 to 35)
 			adjustShock_Stage(-1)
 
-		if(-40 to 0)
+		if(-30 to 5)
 			adjustShock_Stage(-2)
 
-		if(-INFINITY to -40)
-			adjustShock_Stage(-5)
+		if(-INFINITY to -30)
+			adjustShock_Stage(-4+((traumatic_shock+30)*0.2) //uncapped heal, 1 extra point per 5 traumatic_shock above threshold.
 
 	//This just adds up effects together at each step, with a few small exceptions. Preferable to copy and paste rather than have a billion if statements.
 	switch(shock_stage)
@@ -37,7 +37,7 @@
 		if(40 to 59)
 			if(prob(20))
 				to_chat(src, span_danger("[pick("The pain is excruciating", "Please, just end the pain", "Your whole body is going numb")]!"))
-			blur_eyes(2)
+			blur_eyes(1)
 			stuttering = max(stuttering, 5)
 			adjust_stagger(1, FALSE, 1)
 			add_slowdown(1)

--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -29,22 +29,22 @@
 	adjust_pain_speed_mod(.)
 
 
-/mob/living/carbon/proc/adjust_pain_speed_mod(old_shock_stage)
-	switch(shock_stage)
-		if(0 to 10)
-			if(old_shock_stage <= 10)
+/mob/living/carbon/proc/adjust_pain_speed_mod(old_traumatic_shock)
+	switch(traumatic_shock)
+		if(0 to 100)
+			if(old_traumatic_shock <= 100)
 				return
 			remove_movespeed_modifier(MOVESPEED_ID_PAIN)
-		if(10 to 30)
-			if(old_shock_stage > 10 || old_shock_stage <= 30)
+		if(100 to 125)
+			if(old_traumatic_shock > 100 || old_traumatic_shock <= 125)
 				return
 			add_movespeed_modifier(MOVESPEED_ID_PAIN, TRUE, 0, NONE, TRUE, 1)
-		if(30 to 50)
-			if(old_shock_stage > 30 || old_shock_stage <= 50)
+		if(125 to 150)
+			if(old_traumatic_shock > 125 || old_traumatic_shock <= 150)
 				return
 			add_movespeed_modifier(MOVESPEED_ID_PAIN, TRUE, 0, NONE, TRUE, 2)
-		if(50 to INFINITY)
-			if(old_shock_stage > 50)
+		if(150 to INFINITY)
+			if(old_traumatic_shock > 150)
 				return
 			add_movespeed_modifier(MOVESPEED_ID_PAIN, TRUE, 0, NONE, TRUE, 3)
 

--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -29,22 +29,22 @@
 	adjust_pain_speed_mod(.)
 
 
-/mob/living/carbon/proc/adjust_pain_speed_mod(old_traumatic_shock)
-	switch(traumatic_shock)
+/mob/living/carbon/proc/adjust_pain_speed_mod(old_shock_stage)
+	switch(shock_stage)
 		if(0 to 100)
-			if(old_traumatic_shock <= 100)
+			if(old_shock_stage <= 100)
 				return
 			remove_movespeed_modifier(MOVESPEED_ID_PAIN)
 		if(100 to 125)
-			if(old_traumatic_shock > 100 || old_traumatic_shock <= 125)
+			if(old_shock_stage > 100 || old_shock_stage <= 125)
 				return
 			add_movespeed_modifier(MOVESPEED_ID_PAIN, TRUE, 0, NONE, TRUE, 1)
 		if(125 to 150)
-			if(old_traumatic_shock > 125 || old_traumatic_shock <= 150)
+			if(old_shock_stage > 125 || old_shock_stage <= 150)
 				return
 			add_movespeed_modifier(MOVESPEED_ID_PAIN, TRUE, 0, NONE, TRUE, 2)
 		if(150 to INFINITY)
-			if(old_traumatic_shock > 150)
+			if(old_shock_stage > 150)
 				return
 			add_movespeed_modifier(MOVESPEED_ID_PAIN, TRUE, 0, NONE, TRUE, 3)
 

--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -93,7 +93,6 @@
 			traumatic_shock -= 20 + M.protection_aura * 20 //-40 pain for SLs, -80 for Commanders
 
 	traumatic_shock += reagent_pain_modifier
-	traumatic_shock = max(0, traumatic_shock)	//stuff below this has the potential to mask damage
 
 	return traumatic_shock
 

--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -4,7 +4,7 @@
 /mob/living/carbon/proc/adjustTraumatic_Shock(amount)
 	if(status_flags & GODMODE)
 		return FALSE	//godmode
-	traumatic_shock = clamp(traumatic_shock+amount,0,maxHealth*2)
+	traumatic_shock = clamp(traumatic_shock+amount,-100,maxHealth*2)
 
 /mob/living/carbon/proc/setTraumatic_Shock(amount)
 	if(status_flags & GODMODE)

--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -29,22 +29,22 @@
 	adjust_pain_speed_mod(.)
 
 
-/mob/living/carbon/proc/adjust_pain_speed_mod(old_pain)
+/mob/living/carbon/proc/adjust_pain_speed_mod(old_shock_stage)
 	switch(shock_stage)
 		if(0 to 10)
-			if(old_pain <= 10)
+			if(old_shock_stage <= 10)
 				return
 			remove_movespeed_modifier(MOVESPEED_ID_PAIN)
 		if(10 to 30)
-			if(old_pain > 10 || old_pain <= 30)
+			if(old_shock_stage > 10 || old_shock_stage <= 30)
 				return
 			add_movespeed_modifier(MOVESPEED_ID_PAIN, TRUE, 0, NONE, TRUE, 1)
 		if(30 to 50)
-			if(old_pain > 30 || old_pain <= 50)
+			if(old_shock_stage > 30 || old_shock_stage <= 50)
 				return
 			add_movespeed_modifier(MOVESPEED_ID_PAIN, TRUE, 0, NONE, TRUE, 2)
 		if(50 to INFINITY)
-			if(old_pain > 50)
+			if(old_shock_stage > 50)
 				return
 			add_movespeed_modifier(MOVESPEED_ID_PAIN, TRUE, 0, NONE, TRUE, 3)
 
@@ -77,10 +77,10 @@
 			if(((O.limb_status & LIMB_DESTROYED) && !(O.limb_status & LIMB_AMPUTATED)) || O.limb_status & LIMB_NECROTIZED)
 				traumatic_shock += 40
 			else if(O.limb_status & LIMB_BROKEN || O.surgery_open_stage)
-				if(O.limb_status & LIMB_SPLINTED || O.limb_status & LIMB_STABILIZED)
+				if(O.limb_status & LIMB_SPLINTED)
 					traumatic_shock += 15
 				else
-					traumatic_shock += 30
+					traumatic_shock += 25
 			if(O.germ_level >= INFECTION_LEVEL_ONE)
 				traumatic_shock += O.germ_level * 0.05
 
@@ -94,9 +94,6 @@
 
 	traumatic_shock += reagent_pain_modifier
 	traumatic_shock = max(0, traumatic_shock)	//stuff below this has the potential to mask damage
-
-	traumatic_shock += 1.5 //not affected by reagent shock reduction
-
 
 	return traumatic_shock
 

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -130,8 +130,10 @@
 
 /datum/reagent/medicine/oxycodone/on_mob_life(mob/living/L, metabolism)
 	L.reagent_pain_modifier += PAIN_REDUCTION_VERY_HEAVY
-	//L.adjustShock_Stage(-1*effect_str)
 	L.apply_damage(0.2*effect_str, TOX)
+	if(iscarbon(L))
+		var/mob/living/carbon/C = L
+		C.adjustShock_Stage(-1*effect_str)
 	return ..()
 
 /datum/reagent/medicine/oxycodone/overdose_process(mob/living/L, metabolism)
@@ -163,7 +165,9 @@
 
 /datum/reagent/medicine/hydrocodone/on_mob_life(mob/living/L, metabolism)
 	L.reagent_pain_modifier += PAIN_REDUCTION_VERY_HEAVY
-	//L.adjustShock_Stage(-1*effect_str)
+	if(iscarbon(L))
+		var/mob/living/carbon/C = L
+		C.adjustShock_Stage(-1*effect_str)
 	return ..()
 
 /datum/reagent/medicine/hydrocodone/overdose_process(mob/living/L, metabolism)
@@ -442,7 +446,6 @@
 
 /datum/reagent/medicine/neuraline/on_mob_life(mob/living/L)
 	L.reagent_shock_modifier += (2 * PAIN_REDUCTION_VERY_HEAVY)
-	//L.adjustShock_Stage(-volume * effect_str)
 	L.adjustDrowsyness(-5)
 	L.dizzy(-5)
 	L.stuttering = max(L.stuttering-5, 0)
@@ -458,6 +461,9 @@
 	L.adjustStaminaLoss(-30*effect_str)
 	L.heal_limb_damage(7.5*effect_str, 7.5*effect_str)
 	L.adjustToxLoss(3.75*effect_str)
+	if(iscarbon(L))
+		var/mob/living/carbon/C = L
+		C.adjustShock_Stage(-volume*effect_str)
 	return ..()
 
 /datum/reagent/medicine/neuraline/overdose_process(mob/living/L, metabolism)
@@ -519,7 +525,9 @@
 	L.heal_limb_damage(10*effect_str, 10*effect_str)
 	L.adjustToxLoss(-2.5*effect_str)
 	L.adjustCloneLoss(effect_str)
-	//L.adjustShock_Stage(-5*effect_str)
+	if(iscarbon(L))
+		var/mob/living/carbon/C = L
+		C.adjustShock_Stage(-5*effect_str)
 	return ..()
 
 /datum/reagent/medicine/russian_red/overdose_process(mob/living/L, metabolism)

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -133,7 +133,7 @@
 	L.apply_damage(0.2*effect_str, TOX)
 	if(iscarbon(L))
 		var/mob/living/carbon/C = L
-		C.setShock_Stage(min(shock_stage - 1*effect_str, 150) //you can still paincrit if under ludicrous situations, but you can't go into deep shock
+		C.setShock_Stage(min(shock_stage - 1*effect_str, 150)) //you can still paincrit if under ludicrous situations, but you can't go into deep shock
 	return ..()
 
 /datum/reagent/medicine/oxycodone/overdose_process(mob/living/L, metabolism)
@@ -167,7 +167,7 @@
 	L.reagent_pain_modifier += PAIN_REDUCTION_VERY_HEAVY
 	if(iscarbon(L))
 		var/mob/living/carbon/C = L
-		C.setShock_Stage(min(shock_stage - 1*effect_str, 150) //you can still paincrit if under ludicrous situations, but you can't go into deep shock
+		C.setShock_Stage(min(shock_stage - 1*effect_str, 150)) //you can still paincrit if under ludicrous situations, but you can't go into deep shock
 	return ..()
 
 /datum/reagent/medicine/hydrocodone/overdose_process(mob/living/L, metabolism)
@@ -463,7 +463,7 @@
 	L.adjustToxLoss(3.75*effect_str)
 	if(iscarbon(L))
 		var/mob/living/carbon/C = L
-		C.setShock_Stage(min(shock_stage - volume*effect_str, 150) //will pull a target out of deep paincrit instantly, if he's in it
+		C.setShock_Stage(min(shock_stage - volume*effect_str, 150)) //will pull a target out of deep paincrit instantly, if he's in it
 	return ..()
 
 /datum/reagent/medicine/neuraline/overdose_process(mob/living/L, metabolism)
@@ -527,7 +527,7 @@
 	L.adjustCloneLoss(effect_str)
 	if(iscarbon(L))
 		var/mob/living/carbon/C = L
-		C.setShock_Stage(min(shock_stage - 5*effect_str, 150) //removes a target from deep paincrit instantly
+		C.setShock_Stage(min(shock_stage - 5*effect_str, 150)) //removes a target from deep paincrit instantly
 	return ..()
 
 /datum/reagent/medicine/russian_red/overdose_process(mob/living/L, metabolism)

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -141,7 +141,7 @@
 
 /datum/reagent/medicine/oxycodone/overdose_crit_process(mob/living/L, metabolism)
 	L.apply_damage(3*effect_str, TOX)
-	L.reagent_pain_modifier += PAIN_REDUCTION_FULL
+	L.reagent_pain_modifier += PAIN_REDUCTION_VERY_HEAVY
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
 		var/datum/internal_organ/heart/E = H.internal_organs_by_name["heart"]

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -133,7 +133,7 @@
 	L.apply_damage(0.2*effect_str, TOX)
 	if(iscarbon(L))
 		var/mob/living/carbon/C = L
-		C.setShock_Stage(min(shock_stage - 1*effect_str, 150)) //you can still paincrit if under ludicrous situations, but you can't go into deep shock
+		C.setShock_Stage(min(C.shock_stage - 1*effect_str, 150)) //you can still paincrit if under ludicrous situations, but you can't go into deep shock
 	return ..()
 
 /datum/reagent/medicine/oxycodone/overdose_process(mob/living/L, metabolism)
@@ -167,7 +167,7 @@
 	L.reagent_pain_modifier += PAIN_REDUCTION_VERY_HEAVY
 	if(iscarbon(L))
 		var/mob/living/carbon/C = L
-		C.setShock_Stage(min(shock_stage - 1*effect_str, 150)) //you can still paincrit if under ludicrous situations, but you can't go into deep shock
+		C.setShock_Stage(min(C.shock_stage - 1*effect_str, 150)) //you can still paincrit if under ludicrous situations, but you can't go into deep shock
 	return ..()
 
 /datum/reagent/medicine/hydrocodone/overdose_process(mob/living/L, metabolism)
@@ -463,7 +463,7 @@
 	L.adjustToxLoss(3.75*effect_str)
 	if(iscarbon(L))
 		var/mob/living/carbon/C = L
-		C.setShock_Stage(min(shock_stage - volume*effect_str, 150)) //will pull a target out of deep paincrit instantly, if he's in it
+		C.setShock_Stage(min(C.shock_stage - volume*effect_str, 150)) //will pull a target out of deep paincrit instantly, if he's in it
 	return ..()
 
 /datum/reagent/medicine/neuraline/overdose_process(mob/living/L, metabolism)
@@ -527,7 +527,7 @@
 	L.adjustCloneLoss(effect_str)
 	if(iscarbon(L))
 		var/mob/living/carbon/C = L
-		C.setShock_Stage(min(shock_stage - 5*effect_str, 150)) //removes a target from deep paincrit instantly
+		C.setShock_Stage(min(C.shock_stage - 5*effect_str, 150)) //removes a target from deep paincrit instantly
 	return ..()
 
 /datum/reagent/medicine/russian_red/overdose_process(mob/living/L, metabolism)

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -129,7 +129,8 @@
 	to_chat(L, span_userdanger("You feel a burst of energy revitalize you all of a sudden! You can do anything!"))
 
 /datum/reagent/medicine/oxycodone/on_mob_life(mob/living/L, metabolism)
-	L.reagent_pain_modifier += PAIN_REDUCTION_FULL
+	L.reagent_pain_modifier += PAIN_REDUCTION_VERY_HEAVY
+	L.adjustShock_Stage(-1*effect_str)
 	L.apply_damage(0.2*effect_str, TOX)
 	return ..()
 
@@ -161,7 +162,8 @@
 	scannable = TRUE
 
 /datum/reagent/medicine/hydrocodone/on_mob_life(mob/living/L, metabolism)
-	L.reagent_pain_modifier += PAIN_REDUCTION_FULL
+	L.reagent_pain_modifier += PAIN_REDUCTION_VERY_HEAVY
+	L.adjustShock_Stage(-1*effect_str)
 	return ..()
 
 /datum/reagent/medicine/hydrocodone/overdose_process(mob/living/L, metabolism)
@@ -209,7 +211,7 @@
 	if(L.bodytemperature > target_temp)
 		L.adjust_bodytemperature(-2.5*TEMPERATURE_DAMAGE_COEFFICIENT*effect_str, target_temp)
 	if(volume > 10)
-		L.reagent_pain_modifier -= PAIN_REDUCTION_LIGHT
+		L.reagent_pain_modifier -= PAIN_REDUCTION_VERY_LIGHT
 	if(volume > 20)
 		L.reagent_pain_modifier -= PAIN_REDUCTION_LIGHT
 		L.heal_limb_damage(0, 0.5*effect_str)
@@ -310,7 +312,7 @@
 	L.adjustToxLoss(-0.4*effect_str)
 	L.heal_limb_damage(0.8*effect_str, 0.8*effect_str)
 	if(volume > 10)
-		L.reagent_pain_modifier -= PAIN_REDUCTION_LIGHT
+		L.reagent_pain_modifier -= PAIN_REDUCTION_VERY_LIGHT
 	if(volume > 20)
 		L.reagent_pain_modifier -= PAIN_REDUCTION_LIGHT
 	return ..()
@@ -439,7 +441,8 @@
 	scannable = FALSE
 
 /datum/reagent/medicine/neuraline/on_mob_life(mob/living/L)
-	L.reagent_shock_modifier += PAIN_REDUCTION_FULL
+	L.reagent_shock_modifier += (2 * PAIN_REDUCTION_VERY_HEAVY)
+	L.adjustShock_Stage(-volume * effect_str)
 	L.adjustDrowsyness(-5)
 	L.dizzy(-5)
 	L.stuttering = max(L.stuttering-5, 0)
@@ -516,6 +519,7 @@
 	L.heal_limb_damage(10*effect_str, 10*effect_str)
 	L.adjustToxLoss(-2.5*effect_str)
 	L.adjustCloneLoss(effect_str)
+	L.adjustShock_Stage(-5*effect_str)
 	return ..()
 
 /datum/reagent/medicine/russian_red/overdose_process(mob/living/L, metabolism)
@@ -635,7 +639,7 @@
 /datum/reagent/medicine/bicaridine/on_mob_life(mob/living/L, metabolism)
 	L.heal_limb_damage(effect_str, 0)
 	if(volume > 10)
-		L.reagent_pain_modifier -= PAIN_REDUCTION_LIGHT
+		L.reagent_pain_modifier -= PAIN_REDUCTION_VERY_LIGHT
 	if(volume > 20)
 		L.reagent_pain_modifier -= PAIN_REDUCTION_LIGHT
 		L.heal_limb_damage(0.5*effect_str, 0)
@@ -724,7 +728,7 @@
 				if (X.update_icon())
 					X.owner.UpdateDamageIcon(1)
 	L.reagents.add_reagent(/datum/reagent/toxin,5)
-	L.reagent_shock_modifier -= PAIN_REDUCTION_FULL
+	L.reagent_shock_modifier -= PAIN_REDUCTION_VERY_HEAVY
 	L.adjustStaminaLoss(15*effect_str)
 	return ..()
 
@@ -1127,7 +1131,7 @@
 	L.apply_damages(2*effect_str, 2*effect_str)
 	if(prob(50)) //violent vomiting
 		L.vomit()
-	L.reagent_shock_modifier -= PAIN_REDUCTION_FULL //Unlimited agony.
+	L.reagent_shock_modifier -= PAIN_REDUCTION_VERY_HEAVY * 4 //Unlimited agony.
 
 
 /datum/reagent/medicine/roulettium
@@ -1138,7 +1142,7 @@
 	taste_description = "Poor life choices"
 
 /datum/reagent/medicine/roulettium/on_mob_life(mob/living/L, metabolism)
-	L.reagent_shock_modifier += PAIN_REDUCTION_FULL
+	L.reagent_shock_modifier += PAIN_REDUCTION_VERY_HEAVY * 4
 	L.adjustToxLoss(-30*effect_str)
 	L.heal_limb_damage(30*effect_str, 30*effect_str)
 	L.adjustStaminaLoss(-30*effect_str)

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -130,7 +130,7 @@
 
 /datum/reagent/medicine/oxycodone/on_mob_life(mob/living/L, metabolism)
 	L.reagent_pain_modifier += PAIN_REDUCTION_VERY_HEAVY
-	L.adjustShock_Stage(-1*effect_str)
+	//L.adjustShock_Stage(-1*effect_str)
 	L.apply_damage(0.2*effect_str, TOX)
 	return ..()
 
@@ -163,7 +163,7 @@
 
 /datum/reagent/medicine/hydrocodone/on_mob_life(mob/living/L, metabolism)
 	L.reagent_pain_modifier += PAIN_REDUCTION_VERY_HEAVY
-	L.adjustShock_Stage(-1*effect_str)
+	//L.adjustShock_Stage(-1*effect_str)
 	return ..()
 
 /datum/reagent/medicine/hydrocodone/overdose_process(mob/living/L, metabolism)
@@ -442,7 +442,7 @@
 
 /datum/reagent/medicine/neuraline/on_mob_life(mob/living/L)
 	L.reagent_shock_modifier += (2 * PAIN_REDUCTION_VERY_HEAVY)
-	L.adjustShock_Stage(-volume * effect_str)
+	//L.adjustShock_Stage(-volume * effect_str)
 	L.adjustDrowsyness(-5)
 	L.dizzy(-5)
 	L.stuttering = max(L.stuttering-5, 0)
@@ -519,7 +519,7 @@
 	L.heal_limb_damage(10*effect_str, 10*effect_str)
 	L.adjustToxLoss(-2.5*effect_str)
 	L.adjustCloneLoss(effect_str)
-	L.adjustShock_Stage(-5*effect_str)
+	//L.adjustShock_Stage(-5*effect_str)
 	return ..()
 
 /datum/reagent/medicine/russian_red/overdose_process(mob/living/L, metabolism)

--- a/code/modules/reagents/reagents/medical.dm
+++ b/code/modules/reagents/reagents/medical.dm
@@ -133,7 +133,7 @@
 	L.apply_damage(0.2*effect_str, TOX)
 	if(iscarbon(L))
 		var/mob/living/carbon/C = L
-		C.adjustShock_Stage(-1*effect_str)
+		C.setShock_Stage(min(shock_stage - 1*effect_str, 150) //you can still paincrit if under ludicrous situations, but you can't go into deep shock
 	return ..()
 
 /datum/reagent/medicine/oxycodone/overdose_process(mob/living/L, metabolism)
@@ -167,7 +167,7 @@
 	L.reagent_pain_modifier += PAIN_REDUCTION_VERY_HEAVY
 	if(iscarbon(L))
 		var/mob/living/carbon/C = L
-		C.adjustShock_Stage(-1*effect_str)
+		C.setShock_Stage(min(shock_stage - 1*effect_str, 150) //you can still paincrit if under ludicrous situations, but you can't go into deep shock
 	return ..()
 
 /datum/reagent/medicine/hydrocodone/overdose_process(mob/living/L, metabolism)
@@ -463,7 +463,7 @@
 	L.adjustToxLoss(3.75*effect_str)
 	if(iscarbon(L))
 		var/mob/living/carbon/C = L
-		C.adjustShock_Stage(-volume*effect_str)
+		C.setShock_Stage(min(shock_stage - volume*effect_str, 150) //will pull a target out of deep paincrit instantly, if he's in it
 	return ..()
 
 /datum/reagent/medicine/neuraline/overdose_process(mob/living/L, metabolism)
@@ -527,7 +527,7 @@
 	L.adjustCloneLoss(effect_str)
 	if(iscarbon(L))
 		var/mob/living/carbon/C = L
-		C.adjustShock_Stage(-5*effect_str)
+		C.setShock_Stage(min(shock_stage - 5*effect_str, 150) //removes a target from deep paincrit instantly
 	return ..()
 
 /datum/reagent/medicine/russian_red/overdose_process(mob/living/L, metabolism)

--- a/code/modules/reagents/reagents/toxin.dm
+++ b/code/modules/reagents/reagents/toxin.dm
@@ -317,6 +317,17 @@
 			L.Unconscious(10 SECONDS)
 	return ..()
 
+/datum/reagent/toxin/pain
+	name = "Liquid Pain"
+	description = "This is a chemical used to simulate specific pain levels for testing. Pain is equal to the total volume."
+	custom_metabolism = 0
+	toxpwr = 0
+	taste_description = "ow ow ow"
+
+/datum/reagent/toxin/pain/on_mob_life(mob/living/L, metabolism)
+	L.reagent_pain_modifier -= volume
+	return ..()
+
 /datum/reagent/toxin/beer2	//disguised as normal beer
 	name = "Beer"
 	description = "An alcoholic beverage made from malted grains, hops, yeast, and water. The fermentation appears to be incomplete." //If the players manage to analyze this, they deserve to know something is wrong.

--- a/code/modules/reagents/reagents/toxin.dm
+++ b/code/modules/reagents/reagents/toxin.dm
@@ -325,7 +325,7 @@
 	taste_description = "ow ow ow"
 
 /datum/reagent/toxin/pain/on_mob_life(mob/living/L, metabolism)
-	L.reagent_pain_modifier -= volume
+	L.reagent_pain_modifier = volume
 	return ..()
 
 /datum/reagent/toxin/beer2	//disguised as normal beer

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -155,9 +155,7 @@ proc/do_surgery(mob/living/carbon/M, mob/living/user, obj/item/tool)
 							multipler += 0.15
 						if(PAIN_REDUCTION_HEAVY to PAIN_REDUCTION_VERY_HEAVY)
 							multipler += 0.25
-						if(PAIN_REDUCTION_VERY_HEAVY to PAIN_REDUCTION_FULL)
-							multipler += 0.40
-						if(PAIN_REDUCTION_FULL to INFINITY)
+						if(PAIN_REDUCTION_VERY_HEAVY to INFINITY)
 							multipler += 0.45
 					if(M.shock_stage > 100) //Being near to unconsious is good in this case
 						multipler += 0.25


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR should rework all of pain and shock, but before I do that, I need to understand it (and ideally let everyone ELSE understand it too). 

**So, to start, here's the CURRENT status of pain and how pain works before I start tweaking things-**

All ticks are 2-second lifeticks.

Pain is handled in /code/modules/mob/living/carbon/shock.dm

This file takes all of your direct physical damage, adds it up based on a ratio (1.2 points per burn, 1 point per brute and cloneloss, and 0.75 per point of oxyloss or toxloss) and then adds the total amount of chemical pain (handled in reagants, usually negative) together, *then* adds the total amount of limb pain (40 if necrotized or delimbed, then 30 per break, unless splinted or valk'd, then it's 15 per), THEN adds 1.5 pain per point of organ damage (and 0.05 per germ if you have an infection),  THEN subtracts 40-80 pain for Hold orders... and that's pretty much it.

This blob of code generates your traumatic_shock var, which does nothing directly. Let's jump to-

code/modules/mob/living/carbon/human/life/handle_shock.dm

-which is where most of the effects are handled. This takes your traumatic_shock and uses it to increment your shock_stage  based on a list. If your traumatic_shock is below 99, you have no issues, and in fact gradually *lose* shock_stage (reference example- An unsplinted broken chest and 60 damage is 90 traumatic_shock, so you'll never gain *any* shock_stage!).

The magic numbers are 100 to 150 which adds 1 to shock_stage, 150-200 which adds 2 to shock_stage, and 200+, which *immediately* sets you to 150, and adds 5 per tick. That's how you *get* shock_stage, which is the "mechanical" part of pain.

So, shock_stage. Shock_stage is handled in two places. The first one is back in carbon/shock.dm. It adds and removes a movedelay from 1 to 2 to 3 (10 shock_stage-30, 30-50, 50+) as shock_stage changes. The second one is in life/handle_shock.dm. It sends *scary messages* if you're below 30 shock_stage, adds a bit of eye blur at 30-40, then it starts adding gradually escalating stagger and slowdown up until 150, where you get a one second stun every 10 seconds.

Shock_stage is also capped to 200 and resets on death.

That is how pain *currently* works. Here are the big takeaways-

-*Big dick 80 painkiller Tramadol* is too strong and needs to be nerfed lower. Maybe 50 or so, gotta do math and compare the defines.
-The *instant* jump to 150 shock_stage if over 200 pain needs to be removed, or pushed higher. It's the only dammed thing in the system that functions at all right now.
-Shock_stage takes way too long to climb, *and* you have to be in constant unrelenting agony the whole time or it just fades away
-Instead of nerfing painkillers, I can double the effect that damage has on traumatic_shock (proportionately, I'd also double the shock_stage increment thresholds).

oh and i added a hypo of liquid pain for ease of testing exact numbers

**Alright, here are the SUMMARIZED net changes-**

-All jumps in shock_state from just *existing* have been removed. You won't insta-shockcrit just because your pain got too high, but your shock also won't auto-lower unless you're very close to healed (counting painkiller boost, about 70-100 damage to start). However, all of the 4 meds that can lower your shock_state will try to set it to 150 if it's above 150, allowing quicker escape from paincrit.

-The traumatic_shock checkpoints have been altered to assume that everyone has access to Tramadol, coincidentally mirroring the fact that everyone has had access to Tramadol for months now and are generally lower. The breakpoints are 100 or more traumatic_shock for starting to go up in shock_state, and 35 or less traumatic_shock for starting to go down in shock_state. Some of these breakpoints are below 0, because painkillers gonna kill pain.

-Bonebreak traumatic_shock was reduced to 25 from thirty, but stabilization no longer reduces pain on them. You can still splint it while it's stabilized if you want the pain reduction, but you already got the free 24/7 trama injector.

-Pain defines were vastly lowered on the whole, and full_painkiller was removed. Now, the highest define is PAIN_REDUCTION_VERY_HEAVY at 50. A few chemicals have multiples of VERY_HEAVY, but there's no longer an easy way to just remove *everything* in one go.

-Chemical painkillers (and pain CAUSERS!) were reduced across the board to bring them more on the scale of damage, rather than just overriding any possible amount of damage that you'd be alive with.
Highlights are the bicard/kelo/tricord pill pain got lowered, oxycodone and hydrocodone got lowered from 200 to 50 (we know you'll mix it with Tramadol for an effective 100), Neuraline got lowered from 200 to 100, and QC+ now only causes 50, not 200. Plus ayy neurotoxin and anything define-based (like alcohol) lost a lot of punch.

-Dying no longer resets your shock_stage. You need to actually heal the damage rather than just taking a dirtnap.

-4 chems (oxycodone, hydrocodone, neuraline, and RR) directly reduce your shock stage, and will set your shock_stage to 150 if it was higher than that.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Pain's borked and doesn't work as intended, or really at all. This should hopefully bring it more in-line with the current state of gameplay.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:

balance: Rebalanced pain. It now takes slightly longer to affect you in any way, but it takes more than just popping a pill of Tramadol while missing an arm and having 100 damage to make it go away instantly. Yes, this would have worked before.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
