### PR TITLE
Tweaks Bull Charge

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -523,7 +523,7 @@
 		if(CHARGE_CRUSH)
 			Paralyze(CHARGE_SPEED(charge_datum) * 20)
 		if(CHARGE_BULL_HEADBUTT)
-			Paralyze(CHARGE_SPEED(charge_datum) * 20)
+			Paralyze(CHARGE_SPEED(charge_datum) * 30)
 
 	if(anchored)
 		charge_datum.do_stop_momentum(FALSE)

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -320,11 +320,11 @@
 
 /datum/action/xeno_action/ready_charge/bull_charge
 	charge_type = CHARGE_BULL
-	speed_per_step = 0.1
-	steps_for_charge = 6
+	speed_per_step = 0.15
+	steps_for_charge = 5
 	max_steps_buildup = 10
 	crush_living_damage = 15
-	plasma_use_multiplier = 1.8
+	plasma_use_multiplier = 2
 
 
 /datum/action/xeno_action/ready_charge/bull_charge/give_action(mob/living/L)
@@ -523,7 +523,7 @@
 		if(CHARGE_CRUSH)
 			Paralyze(CHARGE_SPEED(charge_datum) * 20)
 		if(CHARGE_BULL_HEADBUTT)
-			Paralyze(CHARGE_SPEED(charge_datum) * 60)
+			Paralyze(CHARGE_SPEED(charge_datum) * 40)
 
 	if(anchored)
 		charge_datum.do_stop_momentum(FALSE)

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -523,7 +523,7 @@
 		if(CHARGE_CRUSH)
 			Paralyze(CHARGE_SPEED(charge_datum) * 20)
 		if(CHARGE_BULL_HEADBUTT)
-			Paralyze(CHARGE_SPEED(charge_datum) * 30)
+			Paralyze(CHARGE_SPEED(charge_datum) * 25)
 
 	if(anchored)
 		charge_datum.do_stop_momentum(FALSE)

--- a/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
+++ b/code/modules/mob/living/carbon/xenomorph/charge_crush.dm
@@ -523,7 +523,7 @@
 		if(CHARGE_CRUSH)
 			Paralyze(CHARGE_SPEED(charge_datum) * 20)
 		if(CHARGE_BULL_HEADBUTT)
-			Paralyze(CHARGE_SPEED(charge_datum) * 40)
+			Paralyze(CHARGE_SPEED(charge_datum) * 20)
 
 	if(anchored)
 		charge_datum.do_stop_momentum(FALSE)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Decreases the minimum steps for charge to begin from 6 steps to 5. Increases bull's speed per step from 0.10 to 0.15. Decreases headbutt charge's stun formula to be about 1.8 seconds at most. Plasma mult. increased to 2. 


## Why It's Good For The Game
This caste ain't useable. It really ain't. Just about everything that can be done to be proficient requires such extreme luck that you are better off playing _anything_ else for the sake of simplicity. 6 steps meant constant scoping for lanes, meaning anyone paying any ounce of attention is going to know to move away. Couple this with the fact that Bulls move at such a sluggish pace when charging in **linear path** that punishment is astoundingly simple, even if they are caught offguard. 

## Changelog
:cl:
balance: Tones down the calc for headbutt charge stun to (charge speed x 30) instead of (charge speed x 60)
balance: Bull speed per step on charge increase to 0.15 from 0.10 (~-2 speed at maximum charge)
balance: The minimum steps for Bulls to initiate a charge is now 5 from 6.  
balance: Bull plasma multiplier increased to 2 from 1.8
/:cl: