### PR TITLE
Removes Big Red invincible walls

### DIFF
--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -27365,10 +27365,6 @@
 	dir = 6
 	},
 /area/shuttle/drop2/lz2)
-"xTC" = (
-/obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/bigredv2/outside/telecomm)
 "xTT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -30383,7 +30379,7 @@ aaM
 aaM
 aaM
 aaM
-xTC
+rBD
 adb
 ads
 adf


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Replaces some random invincible walls in Big Red's SE caves with regular reinforced walls.
I'm not the author of the map changes that introduced the invincible walls, so I can't tell you why they were needed.

## Why It's Good For The Game

Maintainers want this and I live to make maps changes.

## Changelog
:cl:
balance: Big Red no longer has strange invincible walls in the SE caves complex.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
