### PR TITLE
Tactical Bino Laze Fix

### DIFF
--- a/code/game/objects/items/binoculars.dm
+++ b/code/game/objects/items/binoculars.dm
@@ -166,7 +166,8 @@
 		to_chat(user, span_warning("[src]'s laser battery is recharging."))
 		return
 
-	if(user.client.eye != src)
+	var/turf/TU = get_turf(A)
+	if(!is_ground_level(user.z) || (get_dist(TU, get_turf(user)) > (zoom_tile_offset + zoom_viewsize + 1) ) )
 		to_chat(user, span_warning("You can't focus properly through \the [src] while looking through something else."))
 		return
 
@@ -182,7 +183,6 @@
 		laz_name += " ([S.name])"
 
 
-	var/turf/TU = get_turf(A)
 	var/area/targ_area = get_area(A)
 	if(!istype(TU))
 		return


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fix #6617. Prevents tactical binos from lazing from out of range or in wrong Z level.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Range checks instead of cam interaction checks will hopefully prevent future bugs.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Tac bino can't laze through cams anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
