### PR TITLE
Fix cross z lazing

### DIFF
--- a/code/game/objects/items/binoculars.dm
+++ b/code/game/objects/items/binoculars.dm
@@ -169,7 +169,7 @@
 	var/turf/TU = get_turf(A)
 	var/distance = get_dist(TU, get_turf(user))
 	var/zoom_screen_size = zoom_tile_offset + zoom_viewsize + 1
-	if(TU.z != user.z || (distance > zoom_screen_size))
+	if(TU.z != user.z || distance == -1 || (distance > zoom_screen_size))
 		to_chat(user, span_warning("You can't focus properly through \the [src] while looking through something else."))
 		return
 


### PR DESCRIPTION
Getdist just adds +1 on z, will overflow and return -1, and isgroundlevel doesnt fix crosscam laz