### PR TITLE
Fix +ASAY permission error for mentors even when they cancel their input

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -478,13 +478,13 @@
 	set name = "asay"
 	set hidden = TRUE
 
+	if(!msg)
+		return
+
 	if(!check_rights(R_ASAY))
 		return
 
 	msg = emoji_parse(copytext_char(sanitize(msg), 1, MAX_MESSAGE_LEN))
-
-	if(!msg)
-		return
 
 	var/list/pinged_admin_clients = check_admin_pings(msg, TRUE)
 	if(length(pinged_admin_clients) && pinged_admin_clients[ADMINSAY_PING_UNDERLINE_NAME_INDEX])


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

This change is safe because `emoji_parse(copytext_char(sanitize(msg), 1, MAX_MESSAGE_LEN))` should not ever make a >1 length `msg` 0.

## Why It's Good For The Game

Less notice spam.

## Changelog
:cl:
fix: Fixed +ASAY permission error displaying even when canceling the input.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
