### PR TITLE
Nukes Impact Mags Supply Pack

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -481,12 +481,6 @@ AMMO
 	cost = 5
 	available_against_xeno_only = TRUE
 
-/datum/supply_packs/ammo/scout_impact
-	name = "TX-8 scout impact magazine"
-	contains = list(/obj/item/ammo_magazine/rifle/tx8/impact)
-	cost = 7
-	available_against_xeno_only = TRUE
-
 /datum/supply_packs/ammo/scout_incendiary
 	name = "TX-8 scout incendiary magazine"
 	contains = list(/obj/item/ammo_magazine/rifle/tx8/incendiary)


### PR DESCRIPTION
## About The Pull Request
Removes TX-8 Impact magazine supply pack. It's in the code still, but it ain't _available_.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ammunition that slows you to a crawl, causes massive screenshake, and makes you completely incapable of reliably fighting back — _on a semi-automatic gun_, isn't really all that **fun and is pretty fucking OD.** 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Remove high-velo impact mags from req.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
