### PR TITLE
Medvac supplypack[Req] cost change

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1072,7 +1072,7 @@ MEDICAL
 		/obj/item/roller/medevac,
 		/obj/item/medevac_beacon,
 	)
-	cost = 50
+	cost = 35
 	containertype = /obj/structure/closet/crate/secure/surgery
 	access = ACCESS_MARINE_MEDBAY
 


### PR DESCRIPTION

## About The Pull Request

Changes the medvac supplypack[beacon and stretcher] cost to 35 from 50.

## Why It's Good For The Game

As we are moving more towards balance trade offs between healing reagents that forces a marine or any combtant to hold off from fighting and go groundside for the better reasons, I believe even though medvac stretcher is a limited item for the most part, lowering its cost should help people transport faster and more efficiently. 35 is still costly for just medvac of one, but it's reasonable.

## Changelog
:cl:SpaceLove
balance: Cost of Req medvac supply pack is now 35 instead of 40
/:cl:
