### PR TITLE
Hugger holes now appear above objects and are semi-transparent

### DIFF
--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -49,7 +49,8 @@
 	opacity = FALSE
 	anchored = TRUE
 	max_integrity = 5
-	layer = RESIN_STRUCTURE_LAYER
+	layer = UPPER_ITEM_LAYER
+	alpha = 160
 	destroy_sound = "alien_resin_break"
 	///The hugger inside our trap
 	var/obj/item/clothing/mask/facehugger/hugger = null


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Hugger traps will now appear in a layer above most items. This means that you can't hide them under items anymore. To compensate for this, hugger traps are now also semi-transparent. They're are nowhere near invisible, but shouldn't stick out like a sore thumb either.
![huggertransparent](https://user-images.githubusercontent.com/92129397/139162497-a5949d53-aa10-4c0a-8e23-ef9bbebefa6f.PNG)
<!-- Describe

 The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Closes https://github.com/tgstation/TerraGov-Marine-Corps/issues/5582
Carriers often put hugger traps under objects so it is impossible to see them. The only way you can know if it's there is either by alt-clicking the tile or shift-rightclicking the tile to see what objects are on it. This is sort of an exploit, but I understand why carriers do this because hugger traps are way too easy to spot in the open. This should hopefully appeal to both sides. The alpha value for the hugger trap may need to be tweaked.
-Also side-note: robot race is unaffected by larval huggers. Makes sense logically, but robots already are immune to so many things. Neuro doesn't affect them, they're fire immune, and also can't be hugged. In effect, they have built-in Mimir, Surt, and SWAT mask. Something should be changed since this is a roundstart race.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Hugger traps can no longer be hid under objects. However, they are now semi-transparent.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
