### PR TITLE
fixes the missing hydro cannon

### DIFF
--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -362,7 +362,7 @@
 		/obj/item/attachable/flamer_nozzle,
 		/obj/item/attachable/flamer_nozzle/wide,
 	)
-	starting_attachment_types = list(/obj/item/attachable/flamer_nozzle, /obj/item/attachable/stock/t84stock)
+	starting_attachment_types = list(/obj/item/attachable/flamer_nozzle, /obj/item/attachable/stock/t84stock, /obj/item/attachable/hydro_cannon)
 	var/last_use
 	///If we are using the hydro cannon when clicking
 	var/hydro_active = FALSE


### PR DESCRIPTION

## About The Pull Request

flamer gets its hydro cannon back

## Why It's Good For The Game


## Changelog
:cl:
fix: fixes the missing hydro cannon on the marine flamer
/:cl:
