### PR TITLE
Praetorian Acid Splash all round buff.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/praetorian/castedatum_praetorian.dm
@@ -86,7 +86,7 @@
 	soft_armor = list("melee" = 35, "bullet" = 40, "laser" = 40, "energy" = 40, "bomb" = XENO_BOMB_RESIST_0, "bio" = 33, "rad" = 33, "fire" = 40, "acid" = 33)
 
 	// *** Ranged Attack *** //
-	spit_delay = 1.2 SECONDS
+	spit_delay = 1 SECONDS
 	spit_types = list(/datum/ammo/xeno/toxin/heavy/upgrade1, /datum/ammo/xeno/acid/heavy)
 
 	acid_spray_damage_on_hit = 39

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1832,7 +1832,7 @@ datum/ammo/bullet/revolver/tp44
 	flags_ammo_behavior = AMMO_XENO|AMMO_EXPLOSIVE
 	armor_type = "acid"
 	damage = 18
-	max_range = 8
+	max_range = 10
 	bullet_color = COLOR_PALE_GREEN_GRAY
 	///Duration of the acid puddles
 	var/puddle_duration = 1 SECONDS //Lasts 1-3 seconds
@@ -1849,9 +1849,10 @@ datum/ammo/bullet/revolver/tp44
 
 /datum/ammo/xeno/acid/heavy
 	name = "acid splash"
-	added_spit_delay = 2
-	spit_cost = 70
-	damage = 30
+	added_spit_delay = 1
+	spit_cost = 60
+	shell_speed = 2.1
+	damage = 40
 
 /datum/ammo/xeno/acid/heavy/turret
 	damage = 20


### PR DESCRIPTION

## About The Pull Request

All round buff to Praetorian Acid splash.

## Why It's Good For The Game

Current values leave the ability not bringing anything to the table, its damage is shrugged off, more so by robots who can heal effortlessly with a blowtorch. this aims to make Praetorian more effective in ranged support and keeping marines at bay.

## Changelog
:cl:
balance: praetorian acid splash ability increased.
/:cl:
