### PR TITLE
Packaged foods now fit in helmets

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -230,6 +230,7 @@
 		/obj/item/clothing/glasses,
 		/obj/item/reagent_containers/food/drinks/flask,
 		/obj/item/reagent_containers/food/snacks,
+		/obj/item/stack/medical/heal_pack,
 	)
 	cant_hold = list(
 		/obj/item/stack,

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -229,6 +229,7 @@
 	bypass_w_limit = list(
 		/obj/item/clothing/glasses,
 		/obj/item/reagent_containers/food/drinks/flask,
+		/obj/item/reagent_containers/food/snacks,
 	)
 	cant_hold = list(
 		/obj/item/stack,

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -230,7 +230,6 @@
 		/obj/item/clothing/glasses,
 		/obj/item/reagent_containers/food/drinks/flask,
 		/obj/item/reagent_containers/food/snacks,
-		/obj/item/stack/medical/heal_pack,
 	)
 	cant_hold = list(
 		/obj/item/stack,


### PR DESCRIPTION
## About The Pull Request
Per title. Stuff like packaged cheeseburgers, burritos, etc. now fit in helmets.

## Why It's Good For The Game
My fucking burrito doesn't fit in the helmet. This has been confirmed as heresy by multiple marine mains and I am inclined to agree. Also, packaged foods have a cool looking icon added onto the helmet when it's inside, so this PR effectively enables
_**f a s h i o n .**_

## Changelog
:cl: Lewdcifer
balance: Packaged foods now fit in helmets.
/:cl: