### PR TITLE
Buffs the Mantis Armblade implant

### DIFF
--- a/code/game/objects/items/implants/implant_items.dm
+++ b/code/game/objects/items/implants/implant_items.dm
@@ -67,10 +67,19 @@
 	desc = "A wicked-looking folding blade capable of being concealed within a human's arm."
 	icon_state = "armblade"
 	item_state = "armblade"
-	force = 60
+	force = 75
+	attack_speed = 8
 	flags_atom = CONDUCT
 	flags_equip_slot = NONE
 	w_class = WEIGHT_CLASS_BULKY //not needed but just in case why not
 	sharp = IS_SHARP_ITEM_BIG
 	hitsound = 'sound/weapons/slash.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	
+/obj/item/weapon/mantisblade/equipped(mob/user, slot)
+	. = ..()
+	toggle_item_bump_attack(user, TRUE)
+
+/obj/item/weapon/mantisblade/dropped(mob/user)
+	. = ..()
+	toggle_item_bump_attack(user, FALSE)


### PR DESCRIPTION
## About The Pull Request
Per title. Attack force has been increased to 75, on par with the machete, and its attack speed has been increased to 8 from the average 12 for all melee weapons. Additionally, it can now bump attack, but note that bump attacks do not respect attack speed, so you can only really benefit from the attack speed by mashing click like your life depends on it.

Consulted with David beforehand, he said he was okay with buffing it, just need him to give me the O.K. in regards to the changes I've made.

## Why It's Good For The Game
The armblade is a T3/T4 reward, and despite this, it's incredibly underwhelming. With 60 force and no bump attack, it is arguably a worse alternative compared to the machete and the vali sword. This PR aims to amend that by making it just a little bit better than its normally accessible counterparts, and to make it well worth the T3/T4 reward.

## Changelog
:cl: Lewdcifer
balance: Mantis Armblade implant; 60 > 75 force, 12 > 8 attack speed (faster). Can now bump attack.
/:cl: