### PR TITLE
Gives names to berets and headbands

### DIFF
--- a/code/modules/clothing/head/head.dm
+++ b/code/modules/clothing/head/head.dm
@@ -42,7 +42,7 @@
 
 
 /obj/item/clothing/head/tgmcberet
-	name = "\improper TGMC beret"
+	name = "\improper Dark gray beret"
 	desc = "A hat typically worn by the field-officers of the TGMC. Occasionally they find their way down the ranks into the hands of squad-leaders and decorated grunts."
 	icon = 'icons/obj/clothing/cm_hats.dmi'
 	item_icons = list(
@@ -55,34 +55,42 @@
 	flags_armor_features = ARMOR_NO_DECAP
 
 /obj/item/clothing/head/tgmcberet/tan
+	name = "\improper Tan beret"
 	icon_state = "berettan"
 	flags_item_map_variant = (ITEM_JUNGLE_VARIANT|ITEM_ICE_VARIANT)
 
 /obj/item/clothing/head/tgmcberet/red
+	name = "\improper Red badged beret"
 	icon_state = "beretred"
 	flags_item_map_variant = NONE
 
 /obj/item/clothing/head/tgmcberet/red2
+	name = "\improper Red beret"
 	icon_state = "beretred2"
 	flags_item_map_variant = NONE
 
 /obj/item/clothing/head/tgmcberet/bloodred
+	name = "\improper Blood red beret"
 	icon_state = "bloodred_beret"
 	flags_item_map_variant = NONE
 
 /obj/item/clothing/head/tgmcberet/blueberet
+	name = "\improper Blue beret"
 	icon_state = "blue_beret"
 	flags_item_map_variant = NONE
 
 /obj/item/clothing/head/tgmcberet/darkgreen
+	name = "\improper Dark green beret"
 	icon_state = "darkgreen_beret"
 	flags_item_map_variant = NONE
 
 /obj/item/clothing/head/tgmcberet/green
+	name = "\improper Green beret"
 	icon_state = "beretgreen"
 	flags_item_map_variant = NONE
 
 /obj/item/clothing/head/tgmcberet/snow
+	name = "\improper White beret"
 	icon_state = "beretsnow"
 	flags_item_map_variant = NONE
 
@@ -163,7 +171,7 @@
 	soft_armor = list("melee" = 15, "bullet" = 15, "laser" = 15, "energy" = 15, "bomb" = 10, "bio" = 5, "rad" = 0, "fire" = 5, "acid" = 5)
 
 /obj/item/clothing/head/headband
-	name = "\improper TGMC headband"
+	name = "\improper Cyan headband"
 	desc = "A rag typically worn by the less-orthodox weapons operators in the TGMC. While it offers no protection, it is certainly comfortable to wear compared to the standard helmet. Comes in two stylish colors."
 	icon = 'icons/obj/clothing/cm_hats.dmi'
 	item_icons = list(
@@ -173,15 +181,16 @@
 	icon_state = "headband"
 
 /obj/item/clothing/head/headband/red
+	name = "\improper Red headband"
 	icon_state = "headbandred"
 
 /obj/item/clothing/head/headband/rambo
-	name = "headband"
+	name = "\improper Vivid red headband"
 	desc = "It flutters in the face of the wind, defiant and unrestrained, like the man who wears it."
 	icon_state = "headband_rambo"
 
 /obj/item/clothing/head/headband/snake
-	name = "headband"
+	name = "\improper Black headband"
 	desc = "A replica of the headband of a legendary soldier. Sadly it doesn't offer infinite ammo. Yet."
 	icon_state = "headband_snake"
 


### PR DESCRIPTION
## About The Pull Request
Per title. Berets and headbands had shared names; this PR gives each item its own name.

## Why It's Good For The Game
Since they all had the same exact name, it can be very difficult to differentiate each item in a vendor. This PR amends that.

## Changelog
:cl: Lewdcifer
fix: Berets and headbands no longer share names.
/:cl: