### PR TITLE
Nerfs A19 Impact Ammo

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -565,7 +565,7 @@ datum/ammo/bullet/revolver/tp44
 	sundering = 5
 
 /datum/ammo/bullet/rifle/tx8/impact/on_hit_mob(mob/M, obj/projectile/P)
-	staggerstun(M, P, max_range = 20, slowdown = 2, knockback = 1, shake = 0)
+	staggerstun(M, P, max_range = 20, slowdown = 1, knockback = 1, shake = 0)
 
 /datum/ammo/bullet/rifle/ak47
 	name = "crude heavy rifle bullet"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -560,12 +560,12 @@ datum/ammo/bullet/revolver/tp44
 	name = "high velocity impact bullet"
 	hud_state = "hivelo_impact"
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
-	damage = 25
+	damage = 30
 	penetration = 45
 	sundering = 5
 
 /datum/ammo/bullet/rifle/tx8/impact/on_hit_mob(mob/M, obj/projectile/P)
-	staggerstun(M, P, max_range = 20, slowdown = 1, knockback = 1, shake = 0)
+	staggerstun(M, P, max_range = 20, slowdown = 2, knockback = 1, shake = 0)
 
 /datum/ammo/bullet/rifle/ak47
 	name = "crude heavy rifle bullet"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -565,7 +565,7 @@ datum/ammo/bullet/revolver/tp44
 	sundering = 5
 
 /datum/ammo/bullet/rifle/tx8/impact/on_hit_mob(mob/M, obj/projectile/P)
-	staggerstun(M, P, max_range = 20, stagger = 2, slowdown = 1, knockback = 1)
+	staggerstun(M, P, max_range = 20, slowdown = 0.5, knockback = 1, shake = 0)
 
 /datum/ammo/bullet/rifle/ak47
 	name = "crude heavy rifle bullet"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -565,7 +565,7 @@ datum/ammo/bullet/revolver/tp44
 	sundering = 5
 
 /datum/ammo/bullet/rifle/tx8/impact/on_hit_mob(mob/M, obj/projectile/P)
-	staggerstun(M, P, max_range = 20, slowdown = 0.5, knockback = 1, shake = 0)
+	staggerstun(M, P, max_range = 20, slowdown = 1, knockback = 1, shake = 0)
 
 /datum/ammo/bullet/rifle/ak47
 	name = "crude heavy rifle bullet"

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -481,6 +481,12 @@ AMMO
 	cost = 5
 	available_against_xeno_only = TRUE
 
+/datum/supply_packs/ammo/scout_impact
+	name = "TX-8 scout impact magazine"
+	contains = list(/obj/item/ammo_magazine/rifle/tx8/impact)
+	cost = 7
+	available_against_xeno_only = TRUE
+
 /datum/supply_packs/ammo/scout_incendiary
 	name = "TX-8 scout incendiary magazine"
 	contains = list(/obj/item/ammo_magazine/rifle/tx8/incendiary)

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -481,12 +481,6 @@ AMMO
 	cost = 5
 	available_against_xeno_only = TRUE
 
-/datum/supply_packs/ammo/scout_impact
-	name = "TX-8 scout impact magazine"
-	contains = list(/obj/item/ammo_magazine/rifle/tx8/impact)
-	cost = 7
-	available_against_xeno_only = TRUE
-
 /datum/supply_packs/ammo/scout_incendiary
 	name = "TX-8 scout incendiary magazine"
 	contains = list(/obj/item/ammo_magazine/rifle/tx8/incendiary)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes stagger and screenshake from A19/TX-8 Scout Rifle impact ammo. Slowdown and knockback are the same. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
If the gun in question was slower firing, I'd get _why_ the ammo is the way it is. But it ain't. The A19 is a pre-burst T-64 with built in IFF, it ain't any **business** having applying 2 stagger stacks, a full slowdown stack on the rate of fire it has. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Deletes stagger and screenshake from A19 impact. 
balance: Damage increase to 30.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
