### PR TITLE
Fixes command being able to send rally orders while dead

### DIFF
--- a/code/datums/actions/order_action.dm
+++ b/code/datums/actions/order_action.dm
@@ -36,6 +36,9 @@
 	if(TIMER_COOLDOWN_CHECK(owner, COOLDOWN_CIC_ORDERS))
 		to_chat(owner, span_warning("Your last order was too recent."))
 		return FALSE
+	if(owner.stat)
+		to_chat(owner, span_warning("You can not issue an order in your current state."))
+		return FALSE
 
 ///Print order visual to all marines squad hud and give them an arrow to follow the waypoint
 /datum/action/innate/order/proc/send_order(atom/target, datum/squad/squad, faction = FACTION_TERRAGOV)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Command can no longer haunt you with rally orders to their corpse.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Command can't haunt you with rally orders from beyond the grave.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
