### PR TITLE
Xeno health and sunder are now displayed in game panel

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -222,14 +222,12 @@
 	else //Upgrade process finished or impossible
 		stat("Upgrade Progress:", "(FINISHED)")
 
-	if(xeno_caste.max_health > 0)
-		stat("Health:", "[health]/[xeno_caste.max_health]")
+	stat("Health:", "[health]/[xeno_caste.max_health]")
 
 	if(xeno_caste.plasma_max > 0)
 		stat("Plasma:", "[plasma_stored]/[xeno_caste.plasma_max]")
 
-	if(xeno_caste.max_health > 0)
-		stat("Sunder:", "[sunder]/[100]")
+	stat("Sunder:", "[sunder]/[100]")
 
 	//Very weak <= 1.0, weak <= 2.0, no modifier 2-3, strong <= 3.5, very strong <= 4.5
 	var/msg_holder = ""

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -222,8 +222,14 @@
 	else //Upgrade process finished or impossible
 		stat("Upgrade Progress:", "(FINISHED)")
 
+	if(xeno_caste.max_health > 0)
+		stat("Health:", "[health]/[xeno_caste.max_health]")
+
 	if(xeno_caste.plasma_max > 0)
 		stat("Plasma:", "[plasma_stored]/[xeno_caste.plasma_max]")
+
+	if(xeno_caste.max_health > 0)
+		stat("Sunder:", "[sunder]/[100]")
 
 	//Very weak <= 1.0, weak <= 2.0, no modifier 2-3, strong <= 3.5, very strong <= 4.5
 	var/msg_holder = ""

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -227,7 +227,7 @@
 	if(xeno_caste.plasma_max > 0)
 		stat("Plasma:", "[plasma_stored]/[xeno_caste.plasma_max]")
 
-	stat("Sunder:", "[sunder]/[100]")
+	stat("Sunder:", "[100-sunder]% armor left")
 
 	//Very weak <= 1.0, weak <= 2.0, no modifier 2-3, strong <= 3.5, very strong <= 4.5
 	var/msg_holder = ""


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Health and sunder stats added to game panel.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Plasma is already displayed in game panel, so it would be nice to have health and sunder displayed.
![healthsunder](https://user-images.githubusercontent.com/92129397/141027740-5d59f7ec-7476-48ef-9e6a-9c76b9104408.PNG)
<!-- Please add a short description of why you think these changes w
ould benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Health and sunder stats added to xeno gamepanel.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
