### PR TITLE
Buffs Incendiary Slugs

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -651,8 +651,8 @@ datum/ammo/bullet/revolver/tp44
 	damage_type = BRUTE
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_INCENDIARY|AMMO_SUNDERING
 	max_range = 15
-	damage = 80
-	penetration = 25
+	damage = 65
+	penetration = 15
 	sundering = 2
 	bullet_color = COLOR_TAN_ORANGE
 

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -657,8 +657,7 @@ datum/ammo/bullet/revolver/tp44
 	bullet_color = COLOR_TAN_ORANGE
 
 /datum/ammo/bullet/shotgun/incendiary/on_hit_mob(mob/M, obj/projectile/P)
-	staggerstun(M, P, shake = 1, slowdown = 1, weaken = 1)
-	drop_flame(get_turf(M))
+	staggerstun(M, P, shake = 1, knockback = 2, slowdown = 1)
 
 /datum/ammo/bullet/shotgun/flechette
 	name = "shotgun flechette shell"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -650,23 +650,15 @@ datum/ammo/bullet/revolver/tp44
 	hud_state = "shotgun_fire"
 	damage_type = BRUTE
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_INCENDIARY|AMMO_SUNDERING
-	accuracy = -10
 	max_range = 15
-	damage = 40
-	penetration = 20
+	damage = 80
+	penetration = 25
 	sundering = 2
 	bullet_color = COLOR_TAN_ORANGE
 
-/datum/ammo/bullet/shotgun/incendiary/on_hit_mob(mob/victim, obj/projectile/proj)
-	airburst(victim, proj)
-	knockback(victim, proj)
-
-/datum/ammo/bullet/shotgun/incendiary/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	airburst(target_obj, proj)
-
-/datum/ammo/bullet/shotgun/incendiary/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	airburst(target_turf, proj)
-
+/datum/ammo/bullet/shotgun/incendiary/on_hit_mob(mob/M, obj/projectile/P)
+	staggerstun(M, P, shake = 1, slowdown = 1, weaken = 1)
+	drop_flame(get_turf(M))
 
 /datum/ammo/bullet/shotgun/flechette
 	name = "shotgun flechette shell"

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -657,7 +657,7 @@ datum/ammo/bullet/revolver/tp44
 	bullet_color = COLOR_TAN_ORANGE
 
 /datum/ammo/bullet/shotgun/incendiary/on_hit_mob(mob/M, obj/projectile/P)
-	staggerstun(M, P, shake = 1, knockback = 2, slowdown = 1)
+	staggerstun(M, P, shake = 0, knockback = 2, slowdown = 1)
 
 /datum/ammo/bullet/shotgun/flechette
 	name = "shotgun flechette shell"


### PR DESCRIPTION
## About The Pull Request
Incendiary slugs now deal significantly more damage. Knockback and airburst procs removed. Inflicte slowdown and knockback (2) to targets. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
There was absolutely no reason to use this ammo. The damage was absolutely awful **because** airburst was literally causing it to do **30%** of its base. It was outperformed by weapons that had ammunition or modes that could achieve the same effect except significantly better. **There was also an accuracy malus that really did not need to exist, especially when you consider that this is on a slow firing gun. No other ammunition like this has this drawback, and they are completely capable of constantly applying fire stacks. So therefore, I have given up and decided that drawback is to be deleted.**
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Incendiary slugs now deal 65 damage, 10 AP. 
balance: incendiary slugs are now as accurate as regular bullets. 
code: Removes airburst from incendiary slugs. Adds staggerstun to them. 
balance: Incendiary slugs knockback by 2 and slow. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
