### PR TITLE
Improve scatterspit and spitter normal spit.

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1827,12 +1827,12 @@ datum/ammo/bullet/revolver/tp44
 	sound_hit 	 = "acid_hit"
 	sound_bounce	= "acid_bounce"
 	damage_type = BURN
-	added_spit_delay = 5
+	added_spit_delay = 4
 	spit_cost = 50
 	flags_ammo_behavior = AMMO_XENO|AMMO_EXPLOSIVE
 	armor_type = "acid"
 	damage = 18
-	max_range = 8
+	max_range = 10
 	bullet_color = COLOR_PALE_GREEN_GRAY
 	///Duration of the acid puddles
 	var/puddle_duration = 1 SECONDS //Lasts 1-3 seconds
@@ -1844,7 +1844,8 @@ datum/ammo/bullet/revolver/tp44
 
 /datum/ammo/xeno/acid/medium
 	name = "acid spatter"
-	damage = 30
+	damage = 35
+	shell_speed = 3.5
 	flags_ammo_behavior = AMMO_XENO
 
 /datum/ammo/xeno/acid/passthrough
@@ -1902,12 +1903,12 @@ datum/ammo/bullet/revolver/tp44
 
 ///For the Spitter's Scatterspit ability
 /datum/ammo/xeno/acid/heavy/scatter
-	damage = 10
+	damage = 15
 	flags_ammo_behavior = AMMO_XENO|AMMO_EXPLOSIVE|AMMO_SKIPS_ALIENS
 	bonus_projectiles_type = /datum/ammo/xeno/acid/heavy/scatter
-	bonus_projectiles_amount = 6
-	bonus_projectiles_scatter = 3
-	max_range = 8
+	bonus_projectiles_amount = 5
+	bonus_projectiles_scatter = 2
+	max_range = 10
 	puddle_duration = 1 SECONDS //Lasts 2-4 seconds
 
 /datum/ammo/xeno/boiler_gas


### PR DESCRIPTION

## About The Pull Request

After testing the current plasma capacity as well as the current auto fire mode of spitter, right now you can at best get 2 spits on a marine that does little to no dmg at ancient before they chase and fire at you.  

the same can be said about scatter spit. the moment you get close enough you will be shot at. with marines having tactical sensors  as well as the damage of scatter-spit and it spread this bring nothing to assist your hive.

## Why It's Good For The Game

This Pr aims to make spitter a stronger force to be reckoned with as it reaches Elder and ancient.  scatter spit range increased to 10 up from 8 which gives it more fair distance. the dmg has been increased by an extra 5 per projectile and 1 projectile has been removed. spread is also closer.

The normal spit for spitter has had the shell speed increased and is now 3.5 so now it is quicker and more viable to exchange fire with marines while the damage has been increased to 35 up from 30 from young. at ancient the damage is now 50.75 as opposed to 43.5. base spit delay has been lowered to 4 down from 5

currently, marines are hitting harder or being able to shoot in different ways that deal more damage, whilst xenos have more or less remained the same.

## Changelog
:cl:
balance: adjusted values of scatter spit.
balance: adjusted values of xeno spit medium.
/:cl:

