### PR TITLE
Shotgun Slug Stagger and slowdown Nerf.

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -622,7 +622,7 @@ datum/ammo/bullet/revolver/tp44
 	sundering = 15
 
 /datum/ammo/bullet/shotgun/slug/on_hit_mob(mob/M,obj/projectile/P)
-	staggerstun(M, P, weaken = 1, stagger = 2, knockback = 1, slowdown = 2)
+	staggerstun(M, P, weaken = 1, stagger = 1, knockback = 1, slowdown = 0)
 
 
 /datum/ammo/bullet/shotgun/beanbag


### PR DESCRIPTION


## About The Pull Request

Lowers stagger for shotgun slug impact by 1 down from 2. and removes slowdown.

## Why It's Good For The Game

It was possible to stun-lock xenos. Stagger 2 coupled with slowdown 2 is something that should have never been  allowed for this long. the weapon itself is powerful enough with its dmg, pen, sunder. it doesent need to be this powerful. 

Currently New ammo and weapons are being added at a rapid pace whilst nerfs are not being done for the old ammo types which is bad. 

## Changelog
:cl:
balance: stagger reduced to 1 from 2, slowdown is reduced to 0 from 2.
/:cl:

