### PR TITLE
Organ damage

### DIFF
--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -36,7 +36,7 @@
 					blood_volume = max(blood_volume - 0.5, 0)
 				else
 					heart_multi = 0.5
-					blood_volume = max(blood_volume - 1.3, 0)
+					blood_volume = max(blood_volume - ((heart.damage/30) + 0.3), 0)
 			else
 				heart_multi = 1
 

--- a/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
+++ b/code/modules/mob/living/carbon/human/life/handle_disabilities.dm
@@ -12,11 +12,11 @@
 				to_chat(src, span_danger("It becomes hard to see for some reason."))
 				blur_eyes(10)
 		if(7 to 9)
-			if((hand && get_held_item()) && getBrainLoss())
+			if((hand && get_held_item()) && getBrainLoss() >= 5)
 				to_chat(src, span_danger("Your hand won't respond properly, you drop what you're holding."))
 				drop_held_item()
 		if(10 to 12)
-			if(!lying_angle && getBrainLoss())
+			if(!lying_angle && getBrainLoss() >= 5)
 				to_chat(src, span_danger("Your legs won't respond properly, you fall down."))
 				set_resting(TRUE)
 

--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -109,21 +109,14 @@
 				take_damage(1, prob(30))
 
 	//Process natural and assisted healing
-	var/peridaxon = owner.reagents.has_reagent(/datum/reagent/medicine/peridaxon)
-	var/inaprovaline = owner.reagents.has_reagent(/datum/reagent/medicine/inaprovaline)
-	var/organ_heal_chance = 0
-	var/organ_hurt_chance = 0
-	organ_heal_chance = 20 + (20*peridaxon) + (10*inaprovaline) - (2*damage)
-	if(prob(organ_heal_chance))
-		heal_organ_damage(0.2)
-
+	if(prob(20 + (20*(owner.reagents.has_reagent(/datum/reagent/medicine/peridaxon, 0.05))) + (10*(owner.reagents.has_reagent(/datum/reagent/medicine/inaprovaline, 0.05))) - (2*damage)))
+		heal_organ_damage(0.2) //20% base chance, +20% if inaprov, +10% if peridaxon, -2% per point of damage
 	//And process natural hurting
 	if(owner.reagents.get_reagent_amount(/datum/reagent/medicine/peridaxon) >= 0.05)
 		return
 	if(is_broken())
-		organ_hurt_chance = (2*damage) - (40*inaprovaline)
-		if(prob(organ_hurt_chance))
-			take_damage(0.2)
+		if(prob((2*damage) - (40*(owner.reagents.has_reagent(/datum/reagent/medicine/inaprovaline, 0.05)))))
+			take_damage(0.2) //60% base chance +2% per point of damage over 30, -40% if inaprov is in you, blocked fully if peridaxon is in you.
 
 /datum/internal_organ/proc/take_damage(amount, silent= FALSE)
 	if(SSticker.mode?.flags_round_type & MODE_NO_PERMANENT_WOUNDS)
@@ -234,7 +227,7 @@
 			owner.drip(10)
 		if(prob(50))
 			owner.emote("me", 1, "gasps for air!")
-			owner.Losebreath(2 + (damage/30))
+			owner.Losebreath(1 + (damage/10))
 
 /datum/internal_organ/lungs/prosthetic
 	robotic = ORGAN_ROBOT

--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -108,6 +108,23 @@
 			if (prob(3))	//about once every 30 seconds
 				take_damage(1, prob(30))
 
+	//Process natural and assisted healing
+	var/peridaxon = owner.reagents.has_reagent(/datum/reagent/medicine/peridaxon)
+	var/inaprovaline = owner.reagents.has_reagent(/datum/reagent/medicine/inaprovaline)
+	var/organ_heal_chance = 0
+	var/organ_hurt_chance = 0
+	organ_heal_chance = 20 + (20*peridaxon) + (10*inaprovaline) - (2*damage)
+	if(prob(organ_heal_chance))
+		heal_organ_damage(0.2)
+
+	//And process natural hurting
+	if(owner.reagents.get_reagent_amount(/datum/reagent/medicine/peridaxon) >= 0.05)
+		return
+	if(is_broken())
+		organ_hurt_chance = (2*damage) - (40*inaprovaline)
+		if(prob(organ_hurt_chance))
+			take_damage(0.2)
+
 /datum/internal_organ/proc/take_damage(amount, silent= FALSE)
 	if(SSticker.mode?.flags_round_type & MODE_NO_PERMANENT_WOUNDS)
 		return
@@ -217,7 +234,7 @@
 			owner.drip(10)
 		if(prob(50))
 			owner.emote("me", 1, "gasps for air!")
-			owner.Losebreath(4)
+			owner.Losebreath(2 + (damage/30))
 
 /datum/internal_organ/lungs/prosthetic
 	robotic = ORGAN_ROBOT
@@ -253,7 +270,7 @@
 			else
 				var/datum/internal_organ/O = pick(owner.internal_organs)
 				if(O)
-					O.take_damage(0.2  * PROCESS_ACCURACY, TRUE)
+					O.take_damage((0.2 * PROCESS_ACCURACY), TRUE)
 
 		// Heal a bit if needed and we're not busy. This allows recovery from low amounts of toxins.
 		if(!owner.drunkenness && owner.getToxLoss() <= 15 && min_bruised_damage > damage > 0)

--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -114,8 +114,7 @@
 	//And process natural hurting
 	if(owner.reagents.get_reagent_amount(/datum/reagent/medicine/peridaxon) >= 0.05)
 		return
-	if(is_broken())
-		if(prob((2*damage) - (40*(owner.reagents.has_reagent(/datum/reagent/medicine/inaprovaline, 0.05)))))
+	if(is_broken() && (prob((2*damage) - (40*(owner.reagents.has_reagent(/datum/reagent/medicine/inaprovaline, 0.05))))))
 			take_damage(0.2) //60% base chance +2% per point of damage over 30, -40% if inaprov is in you, blocked fully if peridaxon is in you.
 
 /datum/internal_organ/proc/take_damage(amount, silent= FALSE)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Organs now have a percentage chance to heal 0.2 damage per tick. This chance starts at 20%, gains +20% if peri is present in the bloodstream, +10 if inaprov is present in the bloodstream, and loses 2% for every point of damage taken.

Thus if you have peri and inaprov in your bloodstream, you could theoretically heal from 25 (24.5 actually) organ damage (at a 1% chance per tick for 0.2 heal, granted, but it *could* happen), and will more likely likely be able to gradually heal from ~10-15 points of damage, given 10-15 minutes or so. That's the positive side.

The negative side is if you have a broken organ (30+ damage), it now has a chance to get worse. If you have a broken organ, and you do *not* have peri in you, you roll a chance for it to worsen. The chance starts at 60%, gains 2% per point of damage, and loses 40% if you have inaprov in your bloodstream. If the percentage chance passes, gain 0.2 damage.

Additionally, some organ damages were uncapped when broken. In addition to the base 1.3 bloodloss for a broken heart, there's an additional 0.03 bloodloss per point of damage. Lung damage deals 0.1 losebreath per point above 30, set to begin at 41 damage due to the way losebreath works, so there's some grace damage there. Liver and kidneys were already uncapped, so they're good.

Brain damage was *not* uncapped, but the minimum threshold for a force-rest or item drop was raised from *any amount* to five. You're welcome.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Better organ damage mechanics. If you aren't badly hurt, it'll go away with time and maybe a little medicine. If you *are* badly hurt and can't get to treatment, it'll kill you off quicker without you lingering forever in crit/nearcrit.

also now getting scratched once in the head won't make you drop your shit and collapse over and over again forever. Unless it actually *was* that bad.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: rebalanced organ damage. Small amounts (10 or less) will autoheal over time, and peri and inaprov can help with this process. Organs that are broken (30+ damage) and not stabilized with peri will get worse over time, though inaprov can mitigate the damage partially.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
