### PR TITLE
Fix carrier exploit

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
@@ -58,7 +58,7 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 			return succeed_activate()
 
 	var/obj/item/clothing/mask/facehugger/F = X.get_active_held_item()
-	if(!F) //empty active hand
+	if(!istype(F) || F.stat == DEAD) //empty active hand
 		//if no hugger in active hand, we take one from our storage
 		if(!X.huggers)
 			to_chat(X, span_warning("We don't have any facehuggers to use!"))
@@ -69,10 +69,6 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 
 		X.put_in_active_hand(F)
 		to_chat(X, span_xenonotice("We grab one of the facehuggers in our storage. Now sheltering: [X.huggers] / [X.xeno_caste.huggers_max]."))
-
-	if(!istype(F)) //something else in our hand
-		to_chat(X, span_warning("We need a facehugger in our hand to throw one!"))
-		return fail_activate()
 
 	if(!cooldown_id)
 		X.dropItemToGround(F)


### PR DESCRIPTION
Closes : https://github.com/tgstation/TerraGov-Marine-Corps/issues/8740

fix: Fix picking up a dead facehugger as a carrier revive them, and they can be reused normally