### PR TITLE
Xenos can now weed grass

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -507,12 +507,6 @@
 /turf/open/space/is_weedable()
 	return FALSE
 
-/turf/open/ground/grass/is_weedable()
-	return FALSE
-
-/turf/open/floor/plating/ground/dirtgrassborder/is_weedable()
-	return FALSE
-
 /turf/open/ground/river/is_weedable()
 	return FALSE
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows xenos to weed grass/grass edges, like on LV. It's been a requested feature forever, it's time to let the maintainers weigh in on it.

## Why It's Good For The Game

Xenos have a psychic army of minions, the ability to melt solid steel in minutes and can recover their entire civilization from a single larva while going to toe to toe with an army of trained marines, but are powerless to plant weeds on grass. I must fix this logical inconsistency.

## Changelog
:cl:
balance: Xenos can plant weeds on jungle grass.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
