### PR TITLE
Kills Stamina Drain From Tanglefoot

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -27,8 +27,6 @@
 		adjustFireLoss(12)
 		blur_eyes(2)
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_PLASMALOSS))
-		adjustToxLoss(0.25)
-		adjustStaminaLoss(3)
 		blur_eyes(2)
 	if(CHECK_BITFIELD(S.smoke_traits, SMOKE_XENO_ACID))
 		adjustOxyLoss(4 + S.strength * 2)


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Per title. Removes stamina drain and toxin damage from tanglefoot.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You really shouldn't need a gas mask for smoke that _just_ drains plasma from xenos and nothing else — just to mitigate the effects of the very tool that should be aiding you and your team in halting a push by using said smoke. It doesn't do anything meaningful for gameplay and overall just feels like it's there just to be there.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: kills stam drain from tanglefoot. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
