### PR TITLE
Fixes Ravager vampirism

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -479,11 +479,10 @@
 	SIGNAL_HANDLER
 	if(!leech_count)
 		return
-	var/count = leech_count
 	//heals 10% extra per leeched
-	count /= 10
-	count += 1
-	heal_data += count
+	var/heal_mod = 1 + (leech_count/10)
+	
+	heal_data[1] = (heal_data[1] * heal_mod)
 
 ///Adds the slashed mob to tracked damage mobs
 /datum/action/xeno_action/vampirism/proc/on_slash(datum/source, mob/living/target, damage, list/damage_mod, list/armor_mod)

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -116,9 +116,8 @@
 
 	var/list/heal_data = list(amount)
 	SEND_SIGNAL(src, COMSIG_XENOMORPH_HEALTH_REGEN, heal_data)
-
 	var/remainder = max(0, heal_data[1]-getBruteLoss())
-	adjustBruteLoss(-amount)
+	adjustBruteLoss(-heal_data[1])
 	adjustFireLoss(-remainder)
 
 /mob/living/carbon/xenomorph/proc/handle_living_plasma_updates()


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. It's supposed to give them 10% additional healing from any sources per currently leeched target, but didn't work due to two seperate small issues (one in the heal proc itself, one in vampirism code) (Notice, this "any sources" still only is "those that use heal_wounds()", others get skipped but that has been the case initially too)
This fixes those issues and therefore makes it work properly*.

*The Ravager's heal abilities during enrage do not use heal_wounds() so this doesn't apply to them still. Adding the used comsig to them on the other hand would make them also trigger other things that hook into it e.g. hivelord's healing infusion. Unsure which of the two states is preferred so I didn't touch this logic as of now.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Things working instead of breaking seems kinda good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed Ravager primordial vampirism not working.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
