### PR TITLE
Fixes adjacent warrior lunge

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -105,7 +105,7 @@
 	lunge_target = A
 	RegisterSignal(lunge_target, COMSIG_PARENT_QDELETING, .proc/clean_lunge_target)
 	RegisterSignal(X, COMSIG_MOVABLE_MOVED, .proc/check_if_lunge_possible)
-	RegisterSignal(X, COMSIG_MOVABLE_POST_THROW, .proc/clean_lunge_target)
+	RegisterSignal(X, COMSIG_MOVABLE_POST_THROW, .proc/finish_lunge)
 	succeed_activate()
 	add_cooldown()
 	X.throw_at(get_step_towards(A, X), 6, 2, X)
@@ -117,6 +117,13 @@
 	if(!lunge_target.Adjacent(source))
 		return
 	lunge_grab(source, lunge_target)
+
+///Do a last check to see if we can grab the target, and then clean up after the throw. Handles an in-place lunge.
+/datum/action/xeno_action/activable/lunge/proc/finish_lunge(datum/source)
+	SIGNAL_HANDLER
+	check_if_lunge_possible(source)
+	if(lunge_target) //Still couldn't get them.
+		clean_lunge_target()
 
 /// Null lunge target and reset throw vars
 /datum/action/xeno_action/activable/lunge/proc/clean_lunge_target()


### PR DESCRIPTION
## About The Pull Request
Warrior lunge doesn't work if you aim it adjacent, since it only does the relevant check when the warrior moves. This adds handling for if the lunge doesn't move you.

## Why It's Good For The Game
Fixes #8821 

## Changelog
:cl:
fix: Lunging at an adjacent target as warrior will grab them.
/:cl: