### PR TITLE
T35 stock melee damage buff

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1084,6 +1084,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	desc = "A non-standard heavy stock for the T-35 shotgun. Less quick and more cumbersome than the standard issue stakeout, but reduces recoil and improves accuracy. Allegedly makes a pretty good club in a fight too."
 	slot = ATTACHMENT_SLOT_STOCK
 	wield_delay_mod = 0.4 SECONDS
+	melee_mod = 21
 	icon_state = "t35stock"
 	accuracy_mod = 0.15
 	recoil_mod = -3


### PR DESCRIPTION
## About The Pull Request

Brings T35 stock up from 5 damage bonus to 21. This makes it equivalent to a machete, or at least old machete before it got buffed.
## Why It's Good For The Game

T35 stock is basically worthless in its current state. It doesn't break any thresholds and only really slows you down in both movement and wield speed. This makes it useful out of combat for breaking resin walls.
## Changelog
:cl:
balance: T35 stock now gives 21 force instead of just 5.
/:cl: