### PR TITLE
Ravager super rage nerf

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -289,7 +289,7 @@
 	rage_power = (1-(X.health/X.maxHealth)) * RAVAGER_RAGE_POWER_MULTIPLIER //Calculate the power of our rage; scales with difference between current and max HP
 
 	if(X.health < 0) //If we're at less than 0 HP, it's time to max rage.
-		rage_power = 1
+		rage_power = 0.5
 
 	var/rage_power_radius = CEILING(rage_power * 7, 1) //Define radius of the SFX
 
@@ -302,13 +302,13 @@
 	playsound(X.loc, 'sound/voice/alien_roar2.ogg', clamp(100 * rage_power, 25, 80), 0)
 
 	var/bonus_duration
-	if(rage_power > RAVAGER_RAGE_SUPER_RAGE_THRESHOLD) //If we're super pissed it's time to get crazy
+	if(rage_power >= RAVAGER_RAGE_SUPER_RAGE_THRESHOLD) //If we're super pissed it's time to get crazy
 		var/datum/action/xeno_action/charge = X.actions_by_path[/datum/action/xeno_action/activable/charge]
 		var/datum/action/xeno_action/ravage = X.actions_by_path[/datum/action/xeno_action/activable/ravage]
 		var/datum/action/xeno_action/endure/endure_ability = X.actions_by_path[/datum/action/xeno_action/endure]
 
 		if(endure_ability.endure_duration) //Check if Endure is active
-			endure_ability.endure_threshold = RAVAGER_ENDURE_HP_LIMIT * (1 + rage_power) //Endure crit threshold scales with Rage Power; min -100, max -200
+			endure_ability.endure_threshold = RAVAGER_ENDURE_HP_LIMIT * (1 + rage_power) //Endure crit threshold scales with Rage Power; min -100, max -150
 
 		if(charge)
 			charge.clear_cooldown() //Reset charge cooldown
@@ -326,7 +326,7 @@
 		shake_camera(L, 1 SECONDS, 1)
 		L.Shake(4, 4, 1 SECONDS) //SFX
 
-		if(rage_power > RAVAGER_RAGE_SUPER_RAGE_THRESHOLD) //If we're super pissed it's time to get crazy
+		if(rage_power >= RAVAGER_RAGE_SUPER_RAGE_THRESHOLD) //If we're super pissed it's time to get crazy
 
 			var/obj/screen/plane_master/floor/OT = L.hud_used.plane_masters["[FLOOR_PLANE]"]
 			var/obj/screen/plane_master/game_world/GW = L.hud_used.plane_masters["[GAME_PLANE]"]
@@ -344,7 +344,7 @@
 	X.plasma_stored += rage_plasma //Regain a % of our maximum plasma scaling with rage
 
 	rage_sunder = min(X.sunder, rage_power * 100) //Set our temporary Sunder recovery
-	X.adjust_sunder(-1 * rage_sunder) //Restores up to 100 Sunder temporarily.
+	X.adjust_sunder(-1 * rage_sunder) //Restores up to 50 Sunder temporarily.
 
 	X.xeno_melee_damage_modifier += rage_power  //Set rage melee damage bonus
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes rage power below 0 health to be set to 0.5, instead of 1.0. This halves the sunder recovery, damage bonus, speed boost, and leech strength (stacking with the damage nerf, so a slash that used to heal 60 will now heal 22.5). Endure HP bonus is cut to 3/4ths (now 150 instead of 200). Does nothing to rage above 0 HP.

Also changes super rage threshold checks to still actually work, but that doesn't matter for gameplay.

## Why It's Good For The Game

Effectively everyone I've asked, xeno or marine, has thought that Ravager super rage is way too strong currently. This will still keep rage threatening but prevents Ravagers from outhealing anything other than burst damage like shotguns and artillery, while also taking marines into crit in three hits at movement speeds faster than any T3 should be going. This might be an overcompensation, but the original rage buff that always made the modifier 1.0 definitely was, and the indirect buff of the numerical HP counter seemed to push it even further over the top.

Alternatives: Negative HP rage modifier to a higher number like 0.6, or only removing health leech to increase risk without lowering reward, or keeping rage intact but locking out other abilities while raging so it's harder to get value out of the leech and damage boost. Or just reverting #8180, not that I'm sure that'd even be enough. None of these are currently in the PR, just other possible ideas.

Yes, this is a literal ragenerf. Please laugh.

## Changelog
:cl: TooFewSecrets
balance: Most Ravager super rage stat bonuses halved (rage above 0 HP unaffected). Less damage, speed, lifesteal, sunder recovery, and endure bonus health. Immunities are still given by super rage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
