### PR TITLE
Nerfs Smartgun and Smartrifle penetration

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1017,13 +1017,13 @@ datum/ammo/bullet/revolver/tp44
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
 	accurate_range = 15
 	damage = 20
-	penetration = 15
+	penetration = 10
 	sundering = 2
 
 /datum/ammo/bullet/smartgun/smartrifle
 	name = "smartrifle bullet"
 	damage = 20
-	penetration = 10
+	penetration = 5
 	sundering = 1.5
 
 /datum/ammo/bullet/smartgun/lethal


### PR DESCRIPTION
## About The Pull Request
Per title. Smartgun penetration reduced to 10 from 15, and Smartrifle penetration reduced to 5 from 10.
Checked with the Project Lead before making this PR, he said he was fine with it.

## Why It's Good For The Game
Makes Smartguns a little bit less oppressive than they are currently.

## Changelog
:cl: Lewdcifer
balance: SG guns nerfed: smartgun penetration 15 > 10, smartrifle penetration 10 > 5.
/:cl: