### PR TITLE
Nerfs the Plasma Cutter against resin structures

### DIFF
--- a/code/__DEFINES/objects.dm
+++ b/code/__DEFINES/objects.dm
@@ -92,7 +92,7 @@ GLOBAL_LIST_INIT(restricted_camera_networks, list( //Those networks can only be 
 #define PLASMACUTTER_VHIGH_MOD 3
 #define PLASMACUTTER_CUT_DELAY 30
 #define PLASMACUTTER_RESIN_MULTIPLIER 2
-#define PLASMACUTTER_BASE_COST 2000
+#define PLASMACUTTER_BASE_COST 1000
 
 //MEDEVAC DEFINES
 #define MEDEVAC_COOLDOWN 1500 //150 seconds or 2,5 minutes aka 2 minutes and 30 secs

--- a/code/__DEFINES/objects.dm
+++ b/code/__DEFINES/objects.dm
@@ -91,8 +91,8 @@ GLOBAL_LIST_INIT(restricted_camera_networks, list( //Those networks can only be 
 #define PLASMACUTTER_HIGH_MOD 2
 #define PLASMACUTTER_VHIGH_MOD 3
 #define PLASMACUTTER_CUT_DELAY 30
-#define PLASMACUTTER_RESIN_MULTIPLIER 4
-#define PLASMACUTTER_BASE_COST 1000
+#define PLASMACUTTER_RESIN_MULTIPLIER 2
+#define PLASMACUTTER_BASE_COST 2000
 
 //MEDEVAC DEFINES
 #define MEDEVAC_COOLDOWN 1500 //150 seconds or 2,5 minutes aka 2 minutes and 30 secs


### PR DESCRIPTION
## About The Pull Request
Per title. Damage multiplier against resin reduced to x2 from x4.
Checked with the Project Lead before making the PR, he said he was fine with nerfing the PC, just need him to approve these changes.

## Why It's Good For The Game
Reduces the effectiveness of the Plasma Cutter, which as it stands currently, has proven to be a very oppressive tool against all manner of structures.

## Changelog
:cl: Lewdcifer
balance: Plasma Cutter nerf: damage multiplier against resin x4 > x2.
/:cl: