### PR TITLE
Scatter spit Range, Scatter, Damage

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1902,7 +1902,7 @@ datum/ammo/bullet/revolver/tp44
 
 ///For the Spitter's Scatterspit ability
 /datum/ammo/xeno/acid/heavy/scatter
-	damage = 10
+	damage = 25
 	flags_ammo_behavior = AMMO_XENO|AMMO_EXPLOSIVE|AMMO_SKIPS_ALIENS
 	bonus_projectiles_type = /datum/ammo/xeno/acid/heavy/scatter
 	bonus_projectiles_amount = 6

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1902,12 +1902,12 @@ datum/ammo/bullet/revolver/tp44
 
 ///For the Spitter's Scatterspit ability
 /datum/ammo/xeno/acid/heavy/scatter
-	damage = 25
+	damage = 20
 	flags_ammo_behavior = AMMO_XENO|AMMO_EXPLOSIVE|AMMO_SKIPS_ALIENS
 	bonus_projectiles_type = /datum/ammo/xeno/acid/heavy/scatter
 	bonus_projectiles_amount = 6
 	bonus_projectiles_scatter = 2
-	max_range = 10
+	max_range = 8
 	puddle_duration = 1 SECONDS //Lasts 2-4 seconds
 
 /datum/ammo/xeno/boiler_gas

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1906,8 +1906,8 @@ datum/ammo/bullet/revolver/tp44
 	flags_ammo_behavior = AMMO_XENO|AMMO_EXPLOSIVE|AMMO_SKIPS_ALIENS
 	bonus_projectiles_type = /datum/ammo/xeno/acid/heavy/scatter
 	bonus_projectiles_amount = 6
-	bonus_projectiles_scatter = 3
-	max_range = 8
+	bonus_projectiles_scatter = 2
+	max_range = 10
 	puddle_duration = 1 SECONDS //Lasts 2-4 seconds
 
 /datum/ammo/xeno/boiler_gas


### PR DESCRIPTION
## About The Pull Request

Changes scatter spit  scatter rate and damage

## Why It's Good For The Game

Scatter spit isn't very good right now, it does little damage even if you manage to PB people. right now its a mosquito bite. and when you get in the range you are oftentimes punished by losing half your hp to marine fire just to use the ability. this at least makes it more usable. 

this should help make Spitter more useful as its spit damage even at ancient does little damage that is including the 15%+ per maturity.  

Abilities like this are overlooked and their damage is considered "ok" but people don't take into account acid armor, not to mention the projectile's speed is quite slow compared to marine bullets.

the ability will now be useful.

## Changelog
:cl:
balance: scatter is now 2
balance: projectile damage is now 20 from 10.
/:cl:
