### PR TITLE
Xeno spit shell speeds now 2 up from 1

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1631,7 +1631,7 @@ datum/ammo/bullet/revolver/tp44
 	var/added_spit_delay = 0 //used to make cooldown of the different spits vary.
 	var/spit_cost = 5
 	armor_type = "bio"
-	shell_speed = 1
+	shell_speed = 2
 	accuracy = 40
 	accurate_range = 15
 	max_range = 15


### PR DESCRIPTION

## About The Pull Request

Xeno spits are a little to slow, when you are in a fight where movement is constant, your slow projectiles will miss a lot if they are to slow and not a case of you clicking badly. 

## Why It's Good For The Game

This will make it so xeno spits will be quicker. if you are being chases, all a marine needs to do is zigzag a bit while his bullets will speed to you, whilst yours are easily avoidable which isn't really fair.   marine bullets are a default of 3 whilst xenos was just 1.

## Changelog
:cl:
balance: Xeno default spit now 2 up from 1
/:cl:

