### PR TITLE
Buffs Engineering Storage Module

### DIFF
--- a/code/modules/clothing/modular_armor/attachments/storage.dm
+++ b/code/modules/clothing/modular_armor/attachments/storage.dm
@@ -147,7 +147,6 @@
 		/obj/item/stack/rods,
 		/obj/item/stack/cable_coil,
 		/obj/item/stack/sandbags_empty,
-		/obj/item/stack/sandbags,
 		/obj/item/stack/razorwire,
 		/obj/item/tool/shovel/etool,
 		/obj/item/tool/wrench,

--- a/code/modules/clothing/modular_armor/attachments/storage.dm
+++ b/code/modules/clothing/modular_armor/attachments/storage.dm
@@ -139,30 +139,37 @@
 
 /obj/item/storage/internal/modular/engineering
 	max_storage_space = 15
-	storage_slots = 4
+	storage_slots = 5
 	max_w_class = WEIGHT_CLASS_BULKY
-	bypass_w_limit = list(
-		/obj/item/stack/barbed_wire,
-		/obj/item/stack/sheet,
-		/obj/item/stack/rods,
-		/obj/item/stack/cable_coil,
-		/obj/item/tool/shovel/etool,
-		/obj/item/stack/sandbags_empty,
-	)
 	can_hold = list(
 		/obj/item/stack/barbed_wire,
 		/obj/item/stack/sheet,
 		/obj/item/stack/rods,
 		/obj/item/stack/cable_coil,
-		/obj/item/tool/shovel/etool,
 		/obj/item/stack/sandbags_empty,
+		/obj/item/stack/sandbags,
+		/obj/item/stack/razorwire,
+		/obj/item/tool/shovel/etool,
 		/obj/item/tool/wrench,
 		/obj/item/tool/weldingtool,
 		/obj/item/tool/wirecutters,
 		/obj/item/tool/crowbar,
 		/obj/item/tool/screwdriver,
+		/obj/item/tool/handheld_charger,
 		/obj/item/multitool,
 		/obj/item/binoculars/tactical/range,
+		/obj/item/explosive/plastique,
+		/obj/item/explosive/grenade/chem_grenade/razorburn_smol,
+		/obj/item/explosive/grenade/chem_grenade/razorburn_large,
+		/obj/item/cell/apc,
+		/obj/item/cell/high,
+		/obj/item/cell/rtg,
+		/obj/item/cell/super,
+		/obj/item/cell/potato,
+		/obj/item/assembly/signaler,
+		/obj/item/detpack,
+		/obj/item/circuitboard,
+		/obj/item/lightreplacer,
 	)
 	cant_hold = list()
 


### PR DESCRIPTION
## About The Pull Request
Title.
Increases the storage slots of the module to 5, same as medical storage module.
The storage module can now hold almost everything only an engineer would use (does not include plasma cutter and miner modules).
(Honestly? The list might be an overkill)

## Why It's Good For The Game
Not even Engineers uses this module, hopefully this will give the module some use.

## Changelog
:cl:
balance: Increases the storage slot of the engineering storage module to 5
The storage module can now hold ~~filled sandbags,~~ razorwire, handheld charger, c4, razorburn grenades, detpack, signaler, circuitboards, and the light replacer
/:cl:
