### PR TITLE
Reduces price of Pizza Refill

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1708,7 +1708,7 @@ FACTORY
 /datum/supply_packs/factory/pizzarefill
 	name = "Nanotrasen \"Eat healthy!\" margerita pizza kit refill"
 	contains = list(/obj/item/factory_refill/pizza)
-	cost = 29 //allows a one point profit if all pizzas are processed and sold back to ASRS
+	cost = 28 //allows a two point profit if all pizzas are processed and sold back to ASRS
 
 /datum/supply_packs/factory/smartrifle_ammo_refill
 	name = "Smart rifle bullet parts refill"


### PR DESCRIPTION


## About The Pull Request


reduces cost of pizza refill by one (29 -> 28)



## Why It's Good For The Game

Doubles the profit of the pizza factory, currently it's more of a meme due to it taking more than an hour of constantly restocking to just break even achieving 1~ point per minute, this would halve that to 30 minutes of restocking for 2~ points per minute, making it a bit less of a meme to do

## Changelog
:cl:
balance: reduced cost of pizza refill by 1 point (29->28)
/:cl: