### PR TITLE
Sharpening an Entrenching Tool reduces the amount of time it takes to dig

### DIFF
--- a/code/game/objects/items/tools/shovel_tools.dm
+++ b/code/game/objects/items/tools/shovel_tools.dm
@@ -67,9 +67,6 @@
 		return
 
 	if(isturf(target))
-		if (sharp)
-			shovelspeed = 10
-			
 		if(!dirt_amt)
 			var/turf/T = target
 			var/turfdirt = T.get_dirt_type()
@@ -182,6 +179,7 @@
 		return
 	sharp = IS_SHARP_ITEM_SIMPLE
 	name = "sharpened " + name
+	shovelspeed = 10
 	force = 60
 	update_icon()
 

--- a/code/game/objects/items/tools/shovel_tools.dm
+++ b/code/game/objects/items/tools/shovel_tools.dm
@@ -67,6 +67,9 @@
 		return
 
 	if(isturf(target))
+		if (sharp)
+			shovelspeed = 10
+			
 		if(!dirt_amt)
 			var/turf/T = target
 			var/turfdirt = T.get_dirt_type()

--- a/code/game/objects/items/tools/shovel_tools.dm
+++ b/code/game/objects/items/tools/shovel_tools.dm
@@ -157,7 +157,7 @@
 		return
 	folded = !folded
 	if(folded)
-		w_class = WEIGHT_CLASS_NORMAL
+		w_class = WEIGHT_CLASS_SMALL
 		force = 2
 	else
 		w_class = WEIGHT_CLASS_BULKY


### PR DESCRIPTION
## About The Pull Request
Title.
Shovel speed from 20 to 10 if the etool is sharpened. Can be 15 as well.

## Why It's Good For The Game
The only time I've seen someone use the sharpened etool is when a squad marine was using it to oneshot weeds.

## Changelog
:cl:
balance: Buffs shovel speed of sharpened etool from 20 to 10
/:cl:
