### PR TITLE
Nerfs Metal Foam health

### DIFF
--- a/code/game/objects/effects/effect_system/foam.dm
+++ b/code/game/objects/effects/effect_system/foam.dm
@@ -168,7 +168,7 @@
 	name = "foamed metal"
 	desc = "A lightweight foamed metal wall."
 	resistance_flags = XENO_DAMAGEABLE
-	max_integrity = 200
+	max_integrity = 120
 
 /obj/structure/foamedmetal/fire_act() //flamerwallhacks go BRRR
 	take_damage(10, BURN, "fire")


### PR DESCRIPTION
## About The Pull Request
Per title. Metal Foam health has been decreased from 200 to 120, which takes about roughly 4-6 slashes depending on the caste.

## Why It's Good For The Game
Makes Metal Foam less of a pain to deal with.

## Changelog
:cl: Lewdcifer
balance: Metal Foam health 200 > 120.
/:cl: