### PR TITLE
Removes roundstart Plasma Cutters

### DIFF
--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -14795,11 +14795,9 @@
 /area/mainship/command/self_destruct)
 "TO" = (
 /obj/structure/rack,
-/obj/item/tool/pickaxe/plasmacutter,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/item/tool/pickaxe/plasmacutter,
 /obj/item/storage/belt/utility/full,
 /obj/item/storage/belt/utility/full,
 /obj/item/tool/weldpack,

--- a/_maps/map_files/Sulaco/Sulaco.dmm
+++ b/_maps/map_files/Sulaco/Sulaco.dmm
@@ -1845,7 +1845,6 @@
 /area/sulaco/medbay/cmo)
 "ahS" = (
 /obj/structure/table/mainship,
-/obj/item/tool/pickaxe/plasmacutter,
 /obj/item/cell/high,
 /obj/item/cell/high,
 /obj/item/clothing/glasses/welding,

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -10502,7 +10502,6 @@
 /area/mainship/hull/port_hull)
 "gas" = (
 /obj/structure/table/mainship,
-/obj/item/tool/pickaxe/plasmacutter,
 /obj/item/cell/high,
 /obj/item/cell/high,
 /obj/item/clothing/glasses/welding,

--- a/_maps/map_files/Twin_Pillars/Twin_Pillars.dmm
+++ b/_maps/map_files/Twin_Pillars/Twin_Pillars.dmm
@@ -1815,11 +1815,9 @@
 /area/mainship/hull/lower_hull)
 "bOh" = (
 /obj/structure/rack,
-/obj/item/tool/pickaxe/plasmacutter,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/item/tool/pickaxe/plasmacutter,
 /obj/item/storage/belt/utility/full,
 /obj/item/storage/belt/utility/full,
 /obj/item/tool/weldpack,
@@ -4071,11 +4069,9 @@
 /area/mainship/command/self_destruct/rebel)
 "dNQ" = (
 /obj/structure/rack,
-/obj/item/tool/pickaxe/plasmacutter,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/item/tool/pickaxe/plasmacutter,
 /obj/item/storage/belt/utility/full,
 /obj/item/storage/belt/utility/full,
 /obj/item/tool/weldpack,

--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -71,7 +71,6 @@ GLOBAL_LIST_INIT(engineer_gear_listed_products, list(
 		/obj/item/stack/sheet/metal/small_stack = list(CAT_ENGSUP, "Metal x10", METAL_PRICE_IN_GEAR_VENDOR, "orange"),
 		/obj/item/stack/sheet/plasteel/small_stack = list(CAT_ENGSUP, "Plasteel x10", PLASTEEL_PRICE_IN_GEAR_VENDOR, "orange"),
 		/obj/item/stack/sandbags_empty/half = list(CAT_ENGSUP, "Sandbags x25", SANDBAG_PRICE_IN_GEAR_VENDOR, "orange"),
-		/obj/item/tool/pickaxe/plasmacutter = list(CAT_ENGSUP, "Plasma cutter", 20, "black"),
 		/obj/item/storage/box/minisentry = list(CAT_ENGSUP, "UA-580 point defense sentry kit", 50, "black"),
 		/obj/item/attachable/buildasentry = list(CAT_ENGSUP, "Build-A-Sentry Attachment", 30, "black"),
 		/obj/item/explosive/plastique = list(CAT_ENGSUP, "Plastique explosive", 2, "black"),


### PR DESCRIPTION
## About The Pull Request
Per title, and a different approach towards nerfing the Plasma Cutter. Leaves it as-is, but makes it so that you have to purchase it from reqs.

## Why It's Good For The Game
The Plasma Cutter has always been a tool that has been too good at its job. It's more easily justifiable if it's locked behind reqs rather than being an item you can just get at the start of a round.

## Changelog
:cl: Lewdcifer
del: Plasma Cutters no longer spawn roundstart.
/:cl: