### PR TITLE
Icy Cave's addition's and tweak.

### DIFF
--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -785,13 +785,21 @@
 	},
 /area/icy_caves/caves/west)
 "df" = (
-/turf/closed/ice/thin/corner,
-/area/icy_caves/outpost/LZ2)
-"dg" = (
-/turf/closed/ice/thin/corner{
-	dir = 1
+/obj/structure/lattice,
+/obj/structure/dropship_piece/one/front/left,
+/obj/structure/monorail{
+	dir = 5
 	},
-/area/icy_caves/outpost/LZ2)
+/obj/structure/monorail{
+	dir = 9
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/icy_caves/caves/northern)
+"dg" = (
+/obj/structure/dropship_piece/one/front,
+/obj/structure/monorail,
+/turf/open/floor/mainship_hull,
+/area/icy_caves/caves/northern)
 "dh" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 1
@@ -1873,6 +1881,13 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
+"iy" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "iD" = (
 /obj/structure/largecrate/random/barrel/yellow,
 /turf/open/floor/tile/dark,
@@ -1904,17 +1919,16 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/south)
-"iS" = (
-/obj/effect/ai_node,
-/turf/open/floor/mainship_hull/dir{
-	dir = 8
-	},
-/area/icy_caves/caves/northern)
 "iT" = (
 /turf/closed/ice/end{
 	dir = 1
 	},
 /area/icy_caves/outpost/LZ2)
+"iX" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "iZ" = (
 /turf/open/floor/tile/dark/brown2,
 /area/icy_caves/outpost/garage)
@@ -2140,10 +2154,16 @@
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside)
 "kn" = (
-/turf/closed/ice/thin/corner{
-	dir = 8
+/obj/structure/lattice,
+/obj/structure/dropship_piece/one/front/right,
+/obj/structure/monorail{
+	dir = 9
 	},
-/area/icy_caves/outpost/LZ2)
+/obj/structure/monorail{
+	dir = 5
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/icy_caves/caves/northern)
 "ko" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -2182,6 +2202,11 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
+"kt" = (
+/turf/closed/ice/corner{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "ku" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -2402,15 +2427,9 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
 "lu" = (
-/obj/structure/lattice,
-/obj/structure/dropship_piece/one/front/left,
-/obj/structure/monorail{
-	dir = 5
-	},
-/obj/structure/monorail{
-	dir = 9
-	},
-/turf/open/shuttle/escapepod/plain,
+/obj/structure/dropship_piece/one/cockpit/left,
+/obj/structure/dropship_piece/one/cockpit/right,
+/turf/open/shuttle/dropship/floor,
 /area/icy_caves/caves/northern)
 "lv" = (
 /obj/machinery/door/poddoor/two_tile_ver,
@@ -3080,10 +3099,11 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
 "oM" = (
-/turf/closed/ice_rock/singlePart{
-	dir = 5
+/obj/structure/dropship_piece/one/cockpit/left,
+/turf/open/floor/mainship_hull/dir{
+	dir = 8
 	},
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/caves/northern)
 "oO" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -3141,11 +3161,6 @@
 	dir = 9
 	},
 /area/icy_caves/caves/west)
-"pc" = (
-/turf/closed/shuttle/dropship3/transparent{
-	icon_state = "97"
-	},
-/area/icy_caves/caves/northern)
 "pf" = (
 /obj/effect/landmark/corpsespawner/miner{
 	corpseback = /obj/item/storage/backpack/satchel/norm;
@@ -3409,10 +3424,10 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
 "qk" = (
-/turf/closed/ice/corner{
-	dir = 4
+/turf/closed/shuttle/dropship3/transparent{
+	icon_state = "96"
 	},
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/caves/northern)
 "ql" = (
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
@@ -3478,10 +3493,10 @@
 /turf/closed/ice_rock/single,
 /area/icy_caves/caves)
 "qA" = (
-/turf/closed/ice/corner{
-	dir = 1
+/turf/closed/shuttle/dropship3/transparent{
+	icon_state = "97"
 	},
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/caves/northern)
 "qB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor/tile/dark,
@@ -4076,6 +4091,11 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
+"to" = (
+/turf/closed/ice_rock/singlePart{
+	dir = 5
+	},
+/area/icy_caves/outpost/LZ2)
 "tp" = (
 /obj/item/lightstick/anchored,
 /turf/open/floor/tile/dark,
@@ -4264,9 +4284,8 @@
 	},
 /area/icy_caves/outpost/medbay)
 "ul" = (
-/turf/closed/shuttle/dropship3/transparent{
-	icon_state = "96"
-	},
+/obj/structure/dropship_piece/one/corner/middleright,
+/turf/open/shuttle/dropship/floor,
 /area/icy_caves/caves/northern)
 "un" = (
 /obj/effect/decal/cleanable/blood/xtracks,
@@ -4364,9 +4383,8 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
 "uO" = (
-/turf/closed/shuttle/dropship3/transparent{
-	icon_state = "98"
-	},
+/obj/structure/dropship_piece/one/corner/middleleft,
+/turf/open/shuttle/dropship/floor,
 /area/icy_caves/caves/northern)
 "uP" = (
 /obj/effect/decal/warning_stripes/thin{
@@ -4573,10 +4591,10 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
 "vT" = (
-/turf/closed/ice/junction{
-	dir = 1
+/turf/closed/shuttle/dropship3/transparent{
+	icon_state = "98"
 	},
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/caves/northern)
 "vV" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -4618,10 +4636,11 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/northern)
 "wf" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/seven,
+/area/icy_caves/caves/northern)
 "wg" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/freezer,
@@ -4843,10 +4862,11 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/refinery)
 "xs" = (
-/turf/closed/ice/thin/end{
-	dir = 4
+/obj/machinery/light{
+	dir = 1
 	},
-/area/icy_caves/outpost/LZ1)
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern)
 "xu" = (
 /obj/structure/cargo_container/green,
 /turf/open/floor/plating,
@@ -4868,6 +4888,11 @@
 	dir = 9
 	},
 /area/icy_caves/caves)
+"xD" = (
+/turf/closed/ice/corner{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ2)
 "xE" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
@@ -5559,12 +5584,11 @@
 /turf/open/floor/podhatch/floor,
 /area/icy_caves/outpost/engineering)
 "Bt" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 9
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
+/turf/open/shuttle/dropship/seven,
+/area/icy_caves/caves/northern)
 "Bu" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -5616,12 +5640,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
-"BJ" = (
-/obj/effect/ai_node,
-/turf/open/floor/mainship_hull/dir{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
 "BL" = (
 /turf/closed/ice/end{
 	dir = 8
@@ -6319,13 +6337,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
-"FR" = (
-/obj/machinery/door/poddoor/mainship{
-	dir = 1;
-	id = "tcomms"
-	},
-/turf/open/floor/mainship_hull/dir,
-/area/icy_caves/caves/northern)
 "FU" = (
 /obj/structure/cargo_container/ch_red,
 /turf/open/floor/plating,
@@ -6784,6 +6795,12 @@
 "Il" = (
 /turf/closed/ice_rock/southWall,
 /area/icy_caves/caves/northern)
+"Im" = (
+/obj/structure/barricade/guardrail{
+	dir = 1
+	},
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern)
 "In" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -6818,7 +6835,7 @@
 "Iu" = (
 /obj/structure/dropship_piece/one/cockpit/left,
 /turf/open/floor/mainship_hull/dir{
-	dir = 8
+	dir = 4
 	},
 /area/icy_caves/caves/northern)
 "Iv" = (
@@ -7008,6 +7025,11 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
+"Ju" = (
+/turf/closed/ice/junction{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "Jv" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -7613,6 +7635,13 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/LZ1)
+"MA" = (
+/obj/structure/barricade/guardrail,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern)
 "MB" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -7890,6 +7919,9 @@
 	dir = 4
 	},
 /obj/structure/xenoautopsy/tank/escaped,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/shuttle/dropship/seven,
 /area/icy_caves/caves/northern)
 "Ob" = (
@@ -8038,9 +8070,8 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "Pc" = (
-/obj/structure/dropship_piece/one/corner/middleleft,
-/obj/structure/dropship_piece/one/corner/middleright,
-/turf/open/floor/mainship_hull/dir,
+/obj/machinery/door/airlock/multi_tile/mainship/dropshiprear/ds1,
+/turf/open/shuttle/dropship/floor,
 /area/icy_caves/caves/northern)
 "Pd" = (
 /turf/closed/wall,
@@ -8140,6 +8171,11 @@
 	dir = 8
 	},
 /area/icy_caves/caves)
+"PM" = (
+/turf/closed/ice/thin/corner{
+	dir = 8
+	},
+/area/icy_caves/outpost/LZ2)
 "PN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
@@ -8236,6 +8272,9 @@
 "Qn" = (
 /obj/structure/bed/chair/dropship/passenger{
 	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/shuttle/dropship/floor,
 /area/icy_caves/caves/northern)
@@ -8458,15 +8497,10 @@
 /turf/closed/wall/r_wall,
 /area/icy_caves/caves)
 "Rw" = (
-/obj/structure/lattice,
-/obj/structure/dropship_piece/one/front/right,
-/obj/structure/monorail{
-	dir = 9
-	},
-/obj/structure/monorail{
-	dir = 5
-	},
-/turf/open/shuttle/escapepod/plain,
+/obj/structure/dropship_piece/one/cockpit/left,
+/obj/structure/dropship_piece/one/cockpit/right,
+/obj/structure/dropship_piece/one/cockpit/left,
+/turf/open/shuttle/dropship/floor,
 /area/icy_caves/caves/northern)
 "Rx" = (
 /obj/structure/table/reinforced,
@@ -8747,6 +8781,12 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/LZ1)
+"Th" = (
+/obj/structure/dropship_piece/one/corner/middleleft,
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "Tj" = (
 /obj/machinery/light{
 	dir = 8
@@ -8819,6 +8859,12 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
+"TC" = (
+/obj/structure/dropship_piece/one/corner/middleright,
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "TD" = (
 /obj/machinery/camera{
 	dir = 9
@@ -8980,10 +9026,6 @@
 	dir = 8
 	},
 /area/icy_caves/caves/south)
-"Ut" = (
-/obj/effect/spawner/gibspawner/human,
-/turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern)
 "Uu" = (
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/LZ1)
@@ -9090,11 +9132,6 @@
 /obj/item/analyzer,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
-"UZ" = (
-/obj/structure/dropship_piece/one/corner/middleright,
-/obj/structure/dropship_piece/one/corner/middleleft,
-/turf/open/floor/mainship_hull/dir,
-/area/icy_caves/caves/northern)
 "Vb" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 10
@@ -9206,6 +9243,14 @@
 /obj/structure/largecrate/random/secure,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"VG" = (
+/turf/closed/ice/thin/corner,
+/area/icy_caves/outpost/LZ2)
+"VH" = (
+/turf/closed/ice/thin/end{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ1)
 "VI" = (
 /turf/closed/ice/intersection,
 /area/icy_caves/caves/northern)
@@ -9338,6 +9383,11 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/outside/center)
+"Wg" = (
+/turf/closed/ice/thin/corner{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "Wi" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -9579,9 +9629,11 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "Xy" = (
-/obj/structure/dropship_piece/one/front,
-/obj/structure/monorail,
-/turf/open/floor/mainship_hull,
+/obj/machinery/door/poddoor/mainship{
+	dir = 1;
+	id = "tcomms"
+	},
+/turf/open/shuttle/dropship/floor,
 /area/icy_caves/caves/northern)
 "Xz" = (
 /obj/structure/window/framed/colony/reinforced,
@@ -12910,14 +12962,14 @@ jL
 Me
 Me
 Me
-Me
-Me
-Me
-iS
-Me
-Me
-Me
-Me
+oM
+BN
+jc
+BN
+BN
+BN
+BN
+Th
 Iu
 BN
 jc
@@ -13065,14 +13117,14 @@ wT
 Od
 JR
 Od
-JR
-Od
-JR
-Od
-JR
-Od
-JR
-Od
+df
+qk
+wf
+Im
+Wy
+MA
+wf
+wf
 lu
 ul
 Fk
@@ -13221,23 +13273,23 @@ yd
 RM
 cL
 RM
-cL
-RM
-cL
-RM
-cL
-RM
-cL
-RM
+dg
+qA
+xs
+Wy
+Wy
+Wy
+Wy
+Wy
 Xy
-pc
-Ut
+Wy
+Wy
 Wy
 ch
 Wy
 Wy
 GU
-FR
+Wy
 Tt
 BZ
 eM
@@ -13377,14 +13429,14 @@ GN
 YB
 cF
 YB
-cF
-YB
-cF
-YB
-cF
-YB
-cF
-YB
+kn
+vT
+Bt
+Im
+Wy
+GU
+Bt
+Bt
 Rw
 uO
 Qn
@@ -13393,7 +13445,7 @@ XD
 GU
 oz
 oz
-UZ
+Wy
 Tt
 BZ
 dL
@@ -13534,14 +13586,14 @@ IP
 DU
 DU
 DU
-DU
-BJ
-DU
-DU
-DU
-DU
-DU
-DU
+Ss
+KP
+jc
+KP
+KP
+KP
+KP
+TC
 Ss
 KP
 jc
@@ -13962,8 +14014,8 @@ UE
 UE
 UE
 UE
-xs
-xs
+VH
+VH
 Ey
 UE
 UE
@@ -14271,16 +14323,16 @@ Al
 vy
 vy
 Mw
-wf
-wf
-wf
-wf
-wf
+iX
+iX
+iX
+iX
+iX
 Nn
-wf
-wf
+iX
+iX
 Mw
-Bt
+iy
 uw
 uw
 uw
@@ -27501,7 +27553,7 @@ oP
 wa
 CP
 Jm
-df
+VG
 OA
 mh
 yq
@@ -27528,7 +27580,7 @@ OA
 mh
 mh
 mh
-df
+VG
 oP
 iK
 oP
@@ -27683,7 +27735,7 @@ yq
 yB
 yB
 yB
-kn
+PM
 Cq
 oP
 iK
@@ -27815,9 +27867,9 @@ nI
 Wu
 oP
 WQ
-dg
+Wg
 wv
-df
+VG
 oP
 wa
 oP
@@ -27971,9 +28023,9 @@ oP
 Wu
 CP
 wv
-df
-dg
-kn
+VG
+Wg
+PM
 oP
 wa
 ka
@@ -27997,7 +28049,7 @@ fI
 fI
 OA
 wv
-df
+VG
 En
 wa
 oP
@@ -28126,9 +28178,9 @@ wa
 oP
 Wu
 oP
-dg
+Wg
 wv
-df
+VG
 WQ
 nI
 oP
@@ -28283,9 +28335,9 @@ oP
 CZ
 wa
 oP
-dg
+Wg
 yB
-kn
+PM
 nI
 wa
 on
@@ -28305,10 +28357,10 @@ on
 oP
 oP
 tw
-oM
-dg
+to
+Wg
 yB
-kn
+PM
 oP
 En
 wa
@@ -29245,7 +29297,7 @@ wa
 oP
 wa
 oP
-qk
+xD
 Uj
 OJ
 bF
@@ -29401,7 +29453,7 @@ oP
 oP
 wa
 oP
-qA
+kt
 Uj
 GY
 bD
@@ -30181,7 +30233,7 @@ nW
 oP
 wa
 oP
-qk
+xD
 Uj
 NT
 bD
@@ -30337,7 +30389,7 @@ nW
 wa
 wa
 iT
-vT
+Ju
 tv
 KV
 bD
@@ -30492,7 +30544,7 @@ nI
 oP
 wa
 oP
-qk
+xD
 Np
 zl
 bF
@@ -30648,7 +30700,7 @@ oP
 oP
 wa
 oP
-qA
+kt
 mH
 kW
 Yf

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -22,9 +22,6 @@
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/plating/dmg1,
 /area/icy_caves/caves/crashed_ship)
-"af" = (
-/turf/closed/wall/r_wall/unmeltable,
-/area/lv624/lazarus/console)
 "ag" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/effect/landmark/nuke_spawn,
@@ -53,9 +50,14 @@
 /turf/open/floor/plating/dmg1,
 /area/icy_caves/caves/crashed_ship)
 "am" = (
-/obj/machinery/telecomms/relay/preset/telecomms,
-/turf/open/floor/plating/icefloor,
-/area/lv624/lazarus/console)
+/obj/machinery/door/airlock/multi_tile/mainship/generic,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "an" = (
 /obj/structure/xenoautopsy/tank/broken,
 /obj/effect/decal/cleanable/blood/xeno,
@@ -66,10 +68,6 @@
 /obj/effect/landmark/corpsespawner/scientist,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
-"ap" = (
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
 "aq" = (
 /obj/structure/xenoautopsy/tank/broken,
 /turf/open/floor/plating/mainship,
@@ -528,6 +526,17 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/northern)
+"bW" = (
+/obj/structure/cryofeed/right{
+	name = "\improper coolant feed"
+	},
+/turf/open/floor/podhatch/floor{
+	icon_state = "bcircuitoff"
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "bX" = (
 /turf/closed/ice_rock/singlePart,
 /area/icy_caves/caves)
@@ -570,6 +579,14 @@
 	dir = 8
 	},
 /area/icy_caves/caves/northern)
+"ch" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/obj/effect/ai_node,
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "ci" = (
 /turf/closed/ice/thin/junction,
 /area/icy_caves/caves/northern)
@@ -596,6 +613,24 @@
 	dir = 4
 	},
 /area/icy_caves/caves/northern)
+"co" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/mainship/tcomms,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "cp" = (
 /obj/item/lightstick/anchored,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -633,7 +668,10 @@
 /turf/closed/ice/corner{
 	dir = 4
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "cv" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/ice/thin/junction{
@@ -656,6 +694,34 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/ice/end,
 /area/icy_caves/caves/northern)
+"cD" = (
+/obj/item/tool/surgery/circular_saw,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"cE" = (
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 1
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"cF" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 9
+	},
+/obj/structure/monorail{
+	dir = 5
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "cI" = (
 /turf/closed/ice/thin/single,
 /area/icy_caves/caves/northern)
@@ -671,6 +737,13 @@
 	dir = 8
 	},
 /area/icy_caves/caves/northern)
+"cL" = (
+/obj/structure/monorail,
+/turf/open/floor/mainship_hull,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "cM" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/ice,
@@ -695,10 +768,31 @@
 	dir = 1
 	},
 /area/icy_caves/caves/northern)
+"cV" = (
+/turf/open/floor/tile/white/warningstripe{
+	dir = 1
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "cW" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/corner,
-/area/icy_caves/caves/west)
+/obj/machinery/door/poddoor/mainship/indestructible{
+	dir = 2
+	},
+/turf/open/space/basic,
+/area/space)
+"cX" = (
+/obj/structure/largecrate/supply,
+/obj/machinery/camera/autoname/mainship/dropship_one{
+	dir = 8;
+	pixel_x = 16
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "cY" = (
 /turf/closed/ice/thin/corner{
 	dir = 8
@@ -717,7 +811,7 @@
 /turf/closed/ice/thin/junction{
 	dir = 1
 	},
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern)
 "de" = (
 /turf/closed/ice/thin/junction{
 	dir = 1
@@ -738,6 +832,16 @@
 	dir = 1
 	},
 /area/icy_caves/caves/west)
+"di" = (
+/obj/machinery/camera/autoname/mainship/dropship_one{
+	dir = 8;
+	pixel_x = 16
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "dj" = (
 /turf/closed/ice,
 /area/icy_caves/caves/west)
@@ -768,6 +872,25 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
+"ds" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"du" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "dw" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 4
@@ -828,28 +951,29 @@
 /turf/closed/ice/thin/intersection,
 /area/icy_caves/caves/northern)
 "dL" = (
-/obj/structure/closet/crate/science,
-/obj/item/stack/sheet/mineral/phoron/medium_stack,
+/obj/effect/ai_node,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
-"dM" = (
-/obj/machinery/power/apc/drained,
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "dN" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "dO" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
-"dP" = (
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "dQ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -892,14 +1016,13 @@
 "dY" = (
 /turf/closed/ice/thin/end,
 /area/icy_caves/caves/east)
-"dZ" = (
-/obj/machinery/power/port_gen/pacman,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
 "ea" = (
 /obj/effect/landmark/corpsespawner/pmc,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "eb" = (
 /turf/closed/ice/end,
 /area/icy_caves/caves/west)
@@ -911,12 +1034,15 @@
 "ed" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "eg" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plating/ground/ice,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/west)
 "eh" = (
 /obj/effect/decal/cleanable/blood/splatter,
@@ -924,13 +1050,13 @@
 /area/icy_caves/caves/west)
 "ei" = (
 /obj/effect/landmark/corpsespawner/pmc,
-/turf/open/floor/plating/ground/ice,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/west)
 "ej" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plating/ground/ice,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/west)
 "em" = (
 /obj/effect/decal/cleanable/blood,
@@ -991,27 +1117,22 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
 "ev" = (
-/obj/structure/closet/crate,
-/obj/item/storage/box/lightstick/red,
-/obj/item/storage/box/lightstick/red,
-/obj/item/storage/box/lightstick,
-/obj/item/storage/box/lightstick,
-/obj/item/tool/pickaxe/plasmacutter,
-/obj/effect/spawner/random/powercell,
-/obj/item/clothing/glasses/welding,
-/obj/item/explosive/plastique,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "ew" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "ex" = (
 /obj/machinery/door/airlock/mainship/secure/locked/free_access{
 	name = "\improper Mining Storage"
@@ -1021,7 +1142,10 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "ey" = (
 /turf/closed/ice,
 /area/icy_caves/caves/crashed_ship)
@@ -1046,10 +1170,26 @@
 	dir = 9
 	},
 /area/icy_caves/caves/northern)
+"eC" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	name = "Canteen"
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"eD" = (
+/obj/structure/table,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "eF" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/ai_node,
-/turf/open/floor/plating/ground/ice,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/west)
 "eG" = (
 /obj/machinery/light{
@@ -1093,28 +1233,40 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
 "eM" = (
-/obj/structure/closet/crate,
-/obj/item/storage/box/lightstick/red,
-/obj/item/storage/box/lightstick/red,
-/obj/item/storage/box/lightstick,
-/obj/item/storage/box/lightstick,
-/obj/item/tool/pickaxe/plasmacutter,
-/obj/effect/spawner/random/powercell,
-/obj/item/explosive/plastique,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "eN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"eO" = (
+/obj/structure/table/reinforced,
+/obj/item/tool/surgery/scalpel/laser3,
+/obj/item/reagent_containers/spray/pepper,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 8
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "eP" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "eR" = (
 /turf/closed/ice/end{
 	dir = 1
@@ -1122,18 +1274,21 @@
 /area/icy_caves/caves/south)
 "eS" = (
 /obj/machinery/light,
-/turf/open/floor/plating/ground/ice,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/west)
 "eT" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "eU" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/effect/landmark/corpsespawner/pmc,
-/turf/open/floor/plating/ground/ice,
+/turf/open/floor/tile/dark,
 /area/icy_caves/caves/west)
 "eV" = (
 /obj/structure/ore_box,
@@ -1187,13 +1342,28 @@
 /obj/item/storage/firstaid/regular,
 /obj/item/storage/firstaid/fire,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"fc" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "fd" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/powercell,
 /obj/effect/spawner/random/powercell,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "fe" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/tech_supply,
@@ -1204,7 +1374,10 @@
 /obj/item/clothing/glasses/welding,
 /obj/machinery/light/small,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "ff" = (
 /obj/structure/rack,
 /obj/structure/rack,
@@ -1212,7 +1385,10 @@
 /obj/effect/spawner/random/toolbox,
 /obj/item/clothing/glasses/welding,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "fg" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/tool,
@@ -1220,7 +1396,10 @@
 /obj/effect/spawner/random/tool,
 /obj/item/storage/belt/utility/full,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "fh" = (
 /turf/closed/ice/thin/junction,
 /area/icy_caves/caves/south)
@@ -1255,6 +1434,13 @@
 	dir = 1
 	},
 /area/icy_caves/caves/east)
+"fq" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "fs" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -1310,6 +1496,19 @@
 	dir = 9
 	},
 /area/icy_caves/caves/south)
+"fD" = (
+/obj/machinery/power/apc/drained,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "fE" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
@@ -1328,6 +1527,12 @@
 	dir = 1
 	},
 /area/icy_caves/caves/south)
+"fI" = (
+/turf/closed/ice/thin,
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "fK" = (
 /turf/closed/ice/thin/corner{
 	dir = 1
@@ -1478,17 +1683,61 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
+"gK" = (
+/obj/structure/largecrate/supply/explosives,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "gL" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
 	},
 /turf/closed/ice_rock/corners,
 /area/icy_caves/caves)
+"gM" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 5
+	},
+/turf/open/floor/mainship/cargo,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "gN" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/east)
+"gP" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"gQ" = (
+/obj/structure/dropship_piece/one/corner/middleright,
+/turf/open/floor/mainship_hull/dir{
+	dir = 10
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "gS" = (
 /turf/closed/ice/thin/end{
 	dir = 8
@@ -1511,12 +1760,29 @@
 	},
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
+"gZ" = (
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "hb" = (
 /turf/closed/ice/junction,
 /area/icy_caves/caves/south)
 "hc" = (
 /turf/closed/ice/straight,
 /area/icy_caves/caves/east)
+"hd" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 10
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "he" = (
 /turf/closed/ice/junction{
 	dir = 4
@@ -1625,6 +1891,16 @@
 	dir = 8
 	},
 /area/icy_caves/caves/east)
+"hG" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/research_and_development,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 4
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "hI" = (
 /obj/effect/landmark/xeno_resin_door,
 /obj/effect/ai_node,
@@ -1635,6 +1911,11 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
+"hM" = (
+/turf/closed/ice_rock/corners{
+	dir = 10
+	},
+/area/icy_caves/caves/northern)
 "hO" = (
 /turf/closed/ice/thin/single,
 /area/icy_caves/caves/east)
@@ -1646,6 +1927,14 @@
 /obj/structure/ore_box,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
+"hT" = (
+/obj/machinery/vending/medical,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "hU" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/ice,
@@ -1653,6 +1942,15 @@
 "hV" = (
 /turf/closed/ice_rock/singlePart,
 /area/icy_caves/caves/south)
+"hW" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "hX" = (
 /obj/effect/landmark/excavation_site_spawner,
 /obj/effect/ai_node,
@@ -1690,6 +1988,31 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/northern)
+"in" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall/unmeltable,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"io" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
+"ip" = (
+/obj/structure/closet/l3closet/janitor,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "iu" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -1701,7 +2024,17 @@
 /obj/structure/cable,
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"iD" = (
+/obj/structure/largecrate/random/barrel/yellow,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "iG" = (
 /turf/open/floor/tile/dark/yellow2{
 	dir = 4
@@ -1717,13 +2050,33 @@
 	dir = 2
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
+"iN" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "iQ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/south)
+"iS" = (
+/obj/effect/ai_node,
+/turf/open/floor/mainship_hull/dir{
+	dir = 8
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "iT" = (
 /turf/closed/ice/end{
 	dir = 1
@@ -1742,11 +2095,51 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
+"jc" = (
+/obj/machinery/door/poddoor/mainship,
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"jd" = (
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "je" = (
 /turf/closed/ice/thin/corner{
 	dir = 1
 	},
 /area/icy_caves/outpost/outside)
+"jf" = (
+/obj/item/stool,
+/obj/effect/decal/cleanable/vomit,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"jk" = (
+/obj/structure/table/mainship,
+/obj/item/tool/surgery/cautery,
+/obj/item/tool/surgery/retractor,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"jo" = (
+/obj/effect/ai_node,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "jt" = (
 /obj/machinery/floodlight/landing,
 /obj/effect/decal/warning_stripes,
@@ -1778,6 +2171,13 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
+"jC" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "jE" = (
 /obj/structure/table/reinforced,
 /obj/effect/landmark/dropship_console_spawn_lz1,
@@ -1789,12 +2189,27 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
+"jI" = (
+/obj/machinery/computer/intel_computer,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/mining/west)
 "jJ" = (
 /obj/machinery/landinglight/ds1/delayone{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
+"jL" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mainship_hull/dir{
+	dir = 8
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "jM" = (
 /obj/effect/landmark/corpsespawner/miner{
 	corpseback = /obj/item/storage/backpack/satchel/norm;
@@ -1850,6 +2265,25 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/research)
+"jX" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 9
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"jY" = (
+/obj/machinery/door/airlock/mainship/security,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "ka" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -1869,6 +2303,13 @@
 "ke" = (
 /turf/closed/ice/junction,
 /area/icy_caves/outpost/outside)
+"kf" = (
+/obj/machinery/computer3/server/rack,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "kg" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/mining/east)
@@ -1895,6 +2336,14 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside)
+"kn" = (
+/turf/closed/ice/thin/end{
+	dir = 1
+	},
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "ko" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -2039,6 +2488,17 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
+"kR" = (
+/obj/structure/table/mainship,
+/obj/machinery/computer/security/wooden_tv,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "kS" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -2067,6 +2527,15 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/office)
+"kY" = (
+/obj/machinery/power/apc/drained{
+	dir = 4
+	},
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "lc" = (
 /turf/closed/ice/straight{
 	dir = 4
@@ -2138,6 +2607,29 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
+"lu" = (
+/obj/structure/lattice,
+/obj/structure/dropship_piece/one/front/left,
+/obj/structure/monorail{
+	dir = 5
+	},
+/obj/structure/monorail{
+	dir = 9
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"lv" = (
+/obj/machinery/door/poddoor/two_tile_ver,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "lx" = (
 /obj/machinery/light{
 	dir = 8
@@ -2147,7 +2639,10 @@
 "lA" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "lB" = (
 /obj/structure/table,
 /obj/structure/paper_bin,
@@ -2162,7 +2657,10 @@
 /turf/closed/ice/junction{
 	dir = 1
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "lD" = (
 /obj/structure/table,
 /turf/open/floor/tile/dark/brown2{
@@ -2178,6 +2676,12 @@
 	dir = 5
 	},
 /area/icy_caves/caves)
+"lH" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/mining/west)
 "lM" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -2189,6 +2693,17 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/research)
+"lO" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "lP" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
@@ -2201,6 +2716,15 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
+"lR" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "lS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
@@ -2228,6 +2752,15 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
+"ma" = (
+/obj/structure/dropship_piece/one/corner/middleleft,
+/turf/open/floor/mainship_hull/dir{
+	dir = 6
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "mb" = (
 /turf/closed/ice/thin/intersection,
 /area/icy_caves/outpost/LZ1)
@@ -2243,14 +2776,42 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/refinery)
+"mg" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "mh" = (
 /turf/closed/ice/thin/junction{
 	dir = 4
 	},
 /area/icy_caves/outpost/outside)
 "mi" = (
-/turf/closed/ice/thin/end,
-/area/icy_caves/outpost/LZ1)
+/turf/closed/wall/r_wall/unmeltable,
+/area/lv624/lazarus/console)
+"mj" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/obj/machinery/camera/autoname/mainship/dropship_one{
+	dir = 4;
+	pixel_x = -16
+	},
+/turf/open/floor/mainship/tcomms,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "mk" = (
 /obj/docking_port/stationary/marine_dropship/lz2,
 /turf/open/floor/plating,
@@ -2275,6 +2836,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
+"mq" = (
+/obj/machinery/miner/damaged/platinum,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "mr" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
@@ -2294,9 +2862,31 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"mu" = (
+/obj/machinery/vending/security,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "mv" = (
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves)
+/turf/closed/ice_rock/corners,
+/area/space)
+"mw" = (
+/obj/structure/bookcase/manuals/research_and_development,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 9
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "mx" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 8
@@ -2416,6 +3006,14 @@
 /obj/item/storage/donut_box,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
+"mV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "mY" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -2425,6 +3023,13 @@
 /obj/item/storage/firstaid/o2,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
+"mZ" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "nb" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -2508,11 +3113,44 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside)
+"ns" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "nu" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"nv" = (
+/obj/structure/table,
+/obj/item/corncob,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"nw" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"nx" = (
+/obj/structure/window/framed/colony,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/mining/west)
 "ny" = (
 /obj/docking_port/stationary/crashmode,
 /turf/closed/ice_rock/single,
@@ -2521,11 +3159,34 @@
 /obj/docking_port/stationary/crashmode,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
+"nB" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "nD" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/west)
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"nF" = (
+/obj/structure/janitorialcart,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "nH" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -2536,6 +3197,13 @@
 "nI" = (
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/LZ2)
+"nK" = (
+/obj/structure/largecrate/random/barrel/green,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "nL" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/outside/center)
@@ -2585,6 +3253,9 @@
 	dir = 10
 	},
 /area/icy_caves/outpost/garage)
+"od" = (
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/mining/west)
 "of" = (
 /turf/closed/ice/thin/end{
 	dir = 4
@@ -2618,6 +3289,17 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"op" = (
+/obj/structure/prop/mainship/sensor_computer3/sd,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/tcomms,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "or" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/structure/cable,
@@ -2635,6 +3317,16 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
+"oz" = (
+/obj/structure/barricade/guardrail{
+	dir = 8
+	},
+/obj/structure/xenoautopsy/tank,
+/turf/open/shuttle/dropship/seven,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "oA" = (
 /obj/machinery/landinglight/ds1{
 	dir = 1
@@ -2665,6 +3357,13 @@
 /obj/structure/closet/secure_closet/miner,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
+"oM" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "oO" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -2672,10 +3371,45 @@
 "oP" = (
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/LZ2)
+"oQ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 8
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"oR" = (
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 6
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "oS" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
+"oT" = (
+/obj/structure/largecrate/supply/floodlights,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "oU" = (
 /obj/item/tool/pickaxe,
 /obj/structure/rack,
@@ -2688,11 +3422,22 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
+"pa" = (
+/turf/closed/wall,
+/area/icy_caves/outpost/outside)
 "pb" = (
 /turf/closed/ice_rock/corners{
 	dir = 9
 	},
 /area/icy_caves/caves/west)
+"pc" = (
+/turf/closed/shuttle/dropship3/transparent{
+	icon_state = "97"
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "pf" = (
 /obj/effect/landmark/corpsespawner/miner{
 	corpseback = /obj/item/storage/backpack/satchel/norm;
@@ -2714,6 +3459,15 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"ph" = (
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "pj" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
@@ -2722,9 +3476,11 @@
 /turf/closed/ice/straight,
 /area/icy_caves/caves/northern)
 "pl" = (
-/obj/structure/ore_box,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/mining/west)
+/turf/closed/wall/r_wall/unmeltable,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "pm" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/cable,
@@ -2733,7 +3489,10 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "po" = (
 /turf/open/floor/tile/dark/purple2{
 	dir = 4
@@ -2744,6 +3503,15 @@
 	dir = 1
 	},
 /area/icy_caves/caves)
+"pr" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "ps" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/dmg1,
@@ -2752,8 +3520,17 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/tile/dark/brown2,
 /area/icy_caves/outpost/refinery)
+"pu" = (
+/obj/structure/barricade/guardrail{
+	dir = 4
+	},
+/obj/item/clothing/head/warning_cone,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "pw" = (
-/obj/structure/ore_box,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -2796,6 +3573,14 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/outside)
+"pE" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "pF" = (
 /obj/structure/rack,
 /obj/item/weapon/gun/smg/m25,
@@ -2806,18 +3591,69 @@
 /obj/item/ammo_magazine/smg/m25,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"pH" = (
+/turf/closed/ice_rock/corners{
+	dir = 10
+	},
+/area/icy_caves/caves/west)
+"pL" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"pN" = (
+/obj/structure/janitorialcart,
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "pO" = (
 /obj/item/ammo_casing,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"pP" = (
+/obj/structure/closet/crate,
+/obj/item/storage/box/lightstick/red,
+/obj/item/storage/box/lightstick/red,
+/obj/item/storage/box/lightstick,
+/obj/item/storage/box/lightstick,
+/obj/item/tool/pickaxe/plasmacutter,
+/obj/effect/spawner/random/powercell,
+/obj/item/explosive/plastique,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "pR" = (
 /obj/effect/landmark/fob_sentry,
 /turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
+"pS" = (
+/obj/machinery/power/apc/drained{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "pT" = (
 /obj/effect/landmark/fob_sentry,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "pU" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
@@ -2838,10 +3674,18 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside)
+"pZ" = (
+/obj/item/paper/crumpled/bloody,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "qa" = (
-/obj/machinery/miner/damaged,
-/turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside)
+/turf/open/floor/mainship_hull/dir{
+	dir = 8
+	},
+/area/space)
 "qb" = (
 /obj/machinery/conveyor{
 	dir = 5
@@ -2872,7 +3716,10 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "qg" = (
 /obj/structure/closet/secure_closet/miner,
 /turf/open/floor/plating,
@@ -2895,6 +3742,16 @@
 /obj/item/tool/pickaxe,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
+"qk" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "ql" = (
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
@@ -2959,6 +3816,12 @@
 "qz" = (
 /turf/closed/ice_rock/single,
 /area/icy_caves/caves)
+"qA" = (
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "qB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor/tile/dark,
@@ -2988,12 +3851,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
-"qM" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
-	dir = 1
-	},
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside)
 "qN" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
@@ -3011,6 +3868,9 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"qR" = (
+/turf/closed/ice_rock/northWall,
+/area/icy_caves/caves/west)
 "qS" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -3075,6 +3935,14 @@
 "rf" = (
 /turf/closed/ice/thin/end,
 /area/icy_caves/caves/northern)
+"rg" = (
+/turf/open/floor/mainship_hull/dir{
+	dir = 5
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "rh" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/machinery/door/airlock/multi_tile/mainship/research{
@@ -3082,6 +3950,16 @@
 	},
 /turf/open/floor/tile/dark/purple2,
 /area/icy_caves/outpost/research)
+"rk" = (
+/obj/structure/table/reinforced,
+/obj/structure/xenoautopsy,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 1
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "rl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8
@@ -3102,7 +3980,10 @@
 /turf/closed/ice/thin/end{
 	dir = 4
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "rq" = (
 /obj/structure/closet/fireaxecabinet,
 /turf/closed/wall/r_wall,
@@ -3445,6 +4326,14 @@
 	},
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"sG" = (
+/obj/structure/bed/chair,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "sH" = (
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
@@ -3479,6 +4368,16 @@
 /obj/item/weapon/gun/rifle/ak47,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"ta" = (
+/obj/effect/decal/cleanable/vomit,
+/obj/machinery/camera{
+	dir = 5
+	},
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "tb" = (
 /obj/structure/sink,
 /obj/machinery/light{
@@ -3532,6 +4431,10 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
+"tp" = (
+/obj/item/lightstick/anchored,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/west)
 "tq" = (
 /obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/plating/ground/ice,
@@ -3549,12 +4452,19 @@
 	dir = 2
 	},
 /turf/closed/ice/junction,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "tw" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 1
 	},
 /area/icy_caves/outpost/outside)
+"tx" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/refinery)
 "tB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -3582,6 +4492,14 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/engineering)
+"tF" = (
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 4
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "tH" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/research)
@@ -3632,6 +4550,14 @@
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
+"tT" = (
+/obj/structure/table/mainship,
+/obj/machinery/computer/med_data,
+/turf/open/floor/mainship/mono,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "tU" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -3701,6 +4627,22 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/medbay)
+"ul" = (
+/turf/closed/shuttle/dropship3/transparent{
+	icon_state = "96"
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"un" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "uo" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -3723,6 +4665,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/LZ2)
+"uu" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "uv" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/grilledcheese,
@@ -3731,6 +4680,19 @@
 "uw" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
+"ux" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/mass_spectrometer/adv,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "uy" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -3772,11 +4734,22 @@
 /turf/closed/ice/straight{
 	dir = 4
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "uN" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"uO" = (
+/turf/closed/shuttle/dropship3/transparent{
+	icon_state = "98"
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "uP" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -3803,6 +4776,16 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/medbay)
+"uT" = (
+/obj/effect/landmark/weed_node,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "uX" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -3834,6 +4817,15 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
+"ve" = (
+/obj/machinery/power/apc/drained{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "vf" = (
 /turf/closed/ice/thin/intersection,
 /area/icy_caves/outpost/outside)
@@ -3884,6 +4876,13 @@
 	dir = 6
 	},
 /area/icy_caves/outpost/garage)
+"vr" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/closed/ice/thin/straight,
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "vs" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -3894,6 +4893,10 @@
 /obj/structure/bed/roller,
 /turf/open/floor/tile/dark/green2,
 /area/icy_caves/outpost/medbay)
+"vv" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall/r_wall,
+/area/icy_caves/caves/northern)
 "vx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1
@@ -3955,17 +4958,29 @@
 "vR" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice/thin/end,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "vS" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"vT" = (
+/turf/closed/wall/r_wall,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "vV" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
 	},
 /turf/closed/ice/corner,
-/area/icy_caves/caves/east)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "vX" = (
 /obj/item/flashlight,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -4000,10 +5015,24 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/northern)
+"wf" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "wg" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/freezer,
 /area/icy_caves/outpost/dorms)
+"wh" = (
+/obj/structure/morgue/crematorium,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "wi" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/tile/dark/green2{
@@ -4032,6 +5061,23 @@
 	dir = 8
 	},
 /area/icy_caves/caves/northern)
+"wq" = (
+/obj/machinery/light,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"ws" = (
+/obj/machinery/atmospherics/components/unary/cryo_cell,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "wu" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	dir = 1;
@@ -4062,6 +5108,16 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/medbay)
+"wG" = (
+/obj/effect/spawner/gibspawner/human,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "wH" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/tile/dark/brown2,
@@ -4081,7 +5137,18 @@
 "wN" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
+"wO" = (
+/turf/open/floor/mainship/red{
+	dir = 4
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "wP" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -4095,10 +5162,32 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/garage)
+"wT" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 5
+	},
+/obj/structure/monorail{
+	dir = 9
+	},
+/obj/machinery/door/poddoor/mainship/indestructible{
+	dir = 2
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/space)
 "wW" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
+"wY" = (
+/obj/machinery/camera{
+	dir = 5
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "wZ" = (
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
@@ -4152,6 +5241,24 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
+"xo" = (
+/obj/structure/closet/crate,
+/obj/item/storage/box/lightstick/red,
+/obj/item/storage/box/lightstick/red,
+/obj/item/storage/box/lightstick,
+/obj/item/storage/box/lightstick,
+/obj/item/tool/pickaxe/plasmacutter,
+/obj/effect/spawner/random/powercell,
+/obj/item/clothing/glasses/welding,
+/obj/item/explosive/plastique,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "xr" = (
 /obj/machinery/mineral/stacking_machine,
 /obj/machinery/conveyor{
@@ -4159,6 +5266,12 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/refinery)
+"xs" = (
+/turf/closed/ice_rock/corners,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "xu" = (
 /obj/structure/cargo_container/green,
 /turf/open/floor/plating,
@@ -4210,6 +5323,13 @@
 "xR" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
+"xS" = (
+/obj/machinery/computer3/server,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "xT" = (
 /turf/open/floor/tile/dark/green2/corner{
 	dir = 4
@@ -4222,13 +5342,47 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
+"xW" = (
+/obj/structure/largecrate/supply/explosives/mortar_flare,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "xX" = (
 /turf/closed/ice/thin/straight,
 /area/icy_caves/caves/south)
+"xZ" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 2
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "ya" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/ice_rock/single,
 /area/icy_caves/caves)
+"yb" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"yd" = (
+/obj/structure/monorail,
+/obj/machinery/door/poddoor/mainship/indestructible{
+	dir = 2
+	},
+/turf/open/floor/mainship_hull,
+/area/space)
 "yg" = (
 /obj/structure/bookcase/manuals,
 /obj/machinery/light{
@@ -4242,6 +5396,15 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/northern)
+"yi" = (
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "yj" = (
 /obj/structure/closet/crate/secure/weapon,
 /obj/item/weapon/gun/smg/m25,
@@ -4273,6 +5436,13 @@
 "yx" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/engineering)
+"yz" = (
+/obj/structure/bed/chair,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "yB" = (
 /turf/closed/ice/thin/junction{
 	dir = 8
@@ -4289,6 +5459,14 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
+"yF" = (
+/obj/machinery/door/poddoor/mainship/indestructible{
+	dir = 2
+	},
+/turf/open/floor/mainship_hull/dir{
+	dir = 8
+	},
+/area/space)
 "yG" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -4297,6 +5475,15 @@
 	dir = 8
 	},
 /area/icy_caves/caves)
+"yH" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 1
+	},
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "yJ" = (
 /obj/structure/closet/crate/construction,
 /obj/item/cell/hyper,
@@ -4333,20 +5520,23 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/garage)
-"yW" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
+"yV" = (
+/obj/effect/spawner/gibspawner/human,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
 	},
-/turf/closed/ice_rock/singlePart{
-	dir = 6
-	},
-/area/icy_caves/outpost/outside)
-"zb" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
-/turf/closed/ice_rock/fourway,
-/area/icy_caves/outpost/outside)
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"ze" = (
+/obj/structure/largecrate/random/case/double,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "zh" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -4355,6 +5545,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"zi" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/closed/ice_rock/corners{
+	dir = 9
+	},
+/area/icy_caves/caves)
 "zk" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/singleT{
@@ -4368,7 +5566,10 @@
 /turf/closed/ice/corner{
 	dir = 8
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "zm" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/drained,
@@ -4394,6 +5595,21 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark/brown2/corner,
 /area/icy_caves/outpost/garage)
+"zt" = (
+/turf/open/floor/tile/white/warningstripe{
+	dir = 6
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"zu" = (
+/obj/machinery/door/airlock/multi_tile/mainship/secdoor,
+/turf/open/floor/mainship/red/full,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "zw" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
@@ -4414,6 +5630,9 @@
 /obj/structure/ore_box,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/refinery)
+"zB" = (
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/west)
 "zC" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/tile/dark,
@@ -4498,6 +5717,17 @@
 	dir = 9
 	},
 /area/icy_caves/outpost/medbay)
+"zZ" = (
+/obj/machinery/door/airlock/mainship/secure/locked/free_access{
+	dir = 1;
+	id = "safe_room";
+	name = "\improper Lambda Lab Secure Storage"
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Aa" = (
 /obj/item/storage/box/flashbangs,
 /obj/item/storage/box/m94,
@@ -4507,6 +5737,10 @@
 /obj/structure/closet/crate/secure/explosives,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"Ab" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/west)
 "Ad" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -4516,6 +5750,9 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/garage)
+"Ae" = (
+/turf/closed/ice_rock/eastWall,
+/area/icy_caves/caves/northern)
 "Ag" = (
 /obj/machinery/landinglight/ds1/delaytwo{
 	dir = 4
@@ -4551,6 +5788,15 @@
 /obj/machinery/processor,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
+"Aq" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/snow,
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "Ar" = (
 /obj/structure/closet/crate/secure/ammo,
 /obj/item/ammo_magazine/smg/m25,
@@ -4648,6 +5894,12 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/refinery)
+"AJ" = (
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "AK" = (
 /turf/closed/ice/end{
 	dir = 1
@@ -4665,6 +5917,25 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
+"AQ" = (
+/obj/machinery/disposal,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"AR" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 1
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "AS" = (
 /obj/machinery/power/geothermal,
 /obj/machinery/light/small{
@@ -4715,6 +5986,10 @@
 	dir = 4
 	},
 /area/icy_caves/caves)
+"Bb" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/caves/west)
 "Bd" = (
 /obj/machinery/door/airlock/multi_tile/mainship/secdoor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -4727,6 +6002,14 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
+"Bf" = (
+/turf/open/floor/tile/dark/green2{
+	dir = 8
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Bi" = (
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/prison/kitchen,
@@ -4741,6 +6024,15 @@
 	dir = 1
 	},
 /area/icy_caves/caves/east)
+"Bo" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Bq" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/prison/kitchen,
@@ -4748,6 +6040,12 @@
 "Bs" = (
 /turf/open/floor/podhatch/floor,
 /area/icy_caves/outpost/engineering)
+"Bt" = (
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "Bu" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -4778,6 +6076,25 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/east)
+"BB" = (
+/obj/structure/cryofeed,
+/turf/open/floor/podhatch/floor{
+	icon_state = "bcircuitoff"
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"BF" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "BI" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
@@ -4786,6 +6103,15 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
+"BJ" = (
+/obj/effect/ai_node,
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "BL" = (
 /turf/closed/ice/end{
 	dir = 8
@@ -4795,6 +6121,24 @@
 /obj/docking_port/stationary/crashmode,
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/dorms)
+"BN" = (
+/turf/closed/shuttle/dropship3{
+	icon_state = "50"
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"BO" = (
+/obj/machinery/door/airlock/multi_tile/secure{
+	dir = 2
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "BP" = (
 /turf/closed/ice/junction{
 	dir = 4
@@ -4830,6 +6174,15 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"BW" = (
+/obj/structure/bed/chair/comfy{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "BX" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -4839,10 +6192,31 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
 "BY" = (
-/turf/closed/ice/thin/end{
-	dir = 8
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 6
 	},
-/area/icy_caves/outpost/LZ1)
+/obj/structure/monorail{
+	dir = 10
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/space)
+"BZ" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"Ch" = (
+/obj/machinery/computer3/server/rack,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Ci" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
@@ -4856,6 +6230,24 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/research)
+"Cm" = (
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"Cq" = (
+/turf/closed/ice/thin/end{
+	dir = 4
+	},
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "Cs" = (
 /obj/item/ammo_casing,
 /turf/open/floor/wood,
@@ -4877,6 +6269,23 @@
 /obj/item/clothing/shoes/rainbow,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"CH" = (
+/turf/open/floor/mainship_hull/dir{
+	dir = 10
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"CI" = (
+/obj/machinery/door/poddoor/two_tile_ver,
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "CN" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/caves/south)
@@ -4904,12 +6313,22 @@
 	dir = 9
 	},
 /area/icy_caves/outpost/refinery)
+"CX" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "CZ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "Dc" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno/up,
 /turf/open/floor/tile/dark,
@@ -4948,6 +6367,16 @@
 	},
 /turf/open/floor/freezer,
 /area/icy_caves/outpost/dorms)
+"Dm" = (
+/obj/structure/largecrate/random/secure,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Dn" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -4955,6 +6384,18 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside)
+"Do" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Dp" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/singleEnd{
@@ -5001,10 +6442,24 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/single,
 /area/icy_caves/caves)
+"DF" = (
+/obj/structure/largecrate/random/secure,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "DG" = (
 /obj/effect/decal/cleanable/blood/writing,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"DH" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/closed/ice/end{
+	dir = 1
+	},
+/area/icy_caves/caves/northern)
 "DJ" = (
 /turf/open/floor/tile/dark/brown2{
 	dir = 4
@@ -5020,7 +6475,10 @@
 /turf/closed/ice/thin/corner{
 	dir = 8
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "DM" = (
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 10
@@ -5031,6 +6489,21 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"DU" = (
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"DV" = (
+/obj/structure/mopbucket,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "DW" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -5041,6 +6514,14 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/garage)
+"DX" = (
+/turf/closed/ice_rock/corners{
+	dir = 9
+	},
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "DY" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
@@ -5049,6 +6530,15 @@
 	dir = 6
 	},
 /area/icy_caves/caves/west)
+"Ea" = (
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 2
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Eb" = (
 /obj/effect/landmark/excavation_site_spawner,
 /obj/effect/ai_node,
@@ -5073,6 +6563,14 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"Eh" = (
+/obj/machinery/door/poddoor/mainship/indestructible{
+	dir = 2
+	},
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/space)
 "Ej" = (
 /obj/structure/table,
 /obj/item/stack/nanopaste,
@@ -5080,6 +6578,14 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/medbay)
+"Ek" = (
+/obj/structure/table/mainship,
+/obj/item/storage/toolbox/electrical,
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "El" = (
 /obj/structure/table/reinforced,
 /obj/effect/landmark/dropship_console_spawn_lz2,
@@ -5090,7 +6596,10 @@
 	dir = 2
 	},
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "Ep" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
@@ -5116,10 +6625,21 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"Ex" = (
+/obj/effect/decal/cleanable/mucus,
+/obj/structure/table,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Ey" = (
 /obj/effect/landmark/fob_sentry_rebel,
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "Ez" = (
 /obj/structure/bed,
 /turf/open/floor/wood,
@@ -5167,20 +6687,49 @@
 /area/icy_caves/caves/south)
 "EO" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
-/turf/closed/wall/r_wall,
-/area/icy_caves/outpost/outside)
+/turf/closed/ice/thin/junction,
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
+"EP" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "EQ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice/thin/corner{
 	dir = 4
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "ES" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
 	},
 /turf/closed/ice_rock/westWall,
 /area/icy_caves/caves)
+"EU" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"EX" = (
+/obj/structure/largecrate/supply/floodlights,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "EZ" = (
 /obj/item/ammo_casing,
 /obj/structure/cable,
@@ -5219,6 +6768,22 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
+"Fj" = (
+/obj/machinery/atmospherics/components/unary/vent_pump,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"Fk" = (
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Fm" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -5236,6 +6801,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"Fq" = (
+/obj/effect/spawner/gibspawner/human,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Fr" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/tile/dark/purple2{
@@ -5271,9 +6843,31 @@
 	dir = 1
 	},
 /area/icy_caves/caves/northern)
+"Fw" = (
+/turf/open/floor/tile/white/warningstripe{
+	dir = 4
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Fy" = (
 /turf/open/floor/freezer,
 /area/icy_caves/outpost/dorms)
+"FB" = (
+/obj/machinery/light,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"FE" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "FF" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -5317,6 +6911,16 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
+"FR" = (
+/obj/machinery/door/poddoor/mainship{
+	dir = 1;
+	id = "tcomms"
+	},
+/turf/open/floor/mainship_hull/dir,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "FU" = (
 /obj/structure/cargo_container/ch_red,
 /turf/open/floor/plating,
@@ -5357,6 +6961,35 @@
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"Gf" = (
+/obj/effect/spawner/gibspawner/human,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"Gh" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/machinery/power/monitor{
+	name = "Core Power Monitoring"
+	},
+/obj/structure/table/mainship,
+/obj/structure/cable,
+/turf/open/floor/mainship/tcomms,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"Gj" = (
+/obj/machinery/computer/operating,
+/obj/structure/table/reinforced,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Gk" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -5387,12 +7020,23 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/medbay)
+"Gs" = (
+/turf/closed/ice_rock/corners,
+/area/icy_caves/caves/northern)
 "Gu" = (
 /turf/closed/ice,
 /area/icy_caves/outpost/outside)
 "Gw" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/refinery)
+"Gx" = (
+/obj/structure/mopbucket,
+/obj/machinery/power/apc/drained,
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Gz" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/singleT,
@@ -5406,6 +7050,18 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/security)
+"GE" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"GF" = (
+/turf/closed/wall,
+/area/icy_caves/caves/west)
 "GH" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/ice,
@@ -5417,7 +7073,10 @@
 /turf/closed/ice/thin/corner{
 	dir = 1
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "GK" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
@@ -5438,6 +7097,38 @@
 	dir = 4
 	},
 /area/icy_caves/caves)
+"GN" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 9
+	},
+/obj/structure/monorail{
+	dir = 5
+	},
+/obj/machinery/door/poddoor/mainship/indestructible{
+	dir = 2
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/space)
+"GO" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
+"GQ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "GR" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -5452,6 +7143,13 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"GU" = (
+/obj/structure/barricade/guardrail,
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "GV" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -5479,6 +7177,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/engineering)
+"He" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Hf" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/dorms)
@@ -5498,10 +7203,24 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/engineering)
+"Hj" = (
+/obj/structure/table/mainship,
+/obj/machinery/recharger,
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Hl" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "Hm" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -5526,6 +7245,13 @@
 /obj/machinery/light/small,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"Hw" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/closed/wall/r_wall,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "HA" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -5539,10 +7265,13 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "HC" = (
-/turf/closed/ice_rock/singlePart{
+/obj/structure/monorail,
+/obj/structure/lattice,
+/obj/structure/monorail{
 	dir = 4
 	},
-/area/icy_caves/outpost/LZ1)
+/turf/open/floor/mainship_hull,
+/area/space)
 "HE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -5560,13 +7289,24 @@
 /obj/structure/cable,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "HJ" = (
 /obj/machinery/vending/MarineMed/Blood,
 /turf/open/floor/tile/dark/green2{
 	dir = 4
 	},
 /area/icy_caves/outpost/medbay)
+"HL" = (
+/turf/open/floor/mainship_hull/dir{
+	dir = 6
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "HM" = (
 /obj/item/ammo_casing,
 /turf/open/floor/tile/dark/brown2/corner{
@@ -5581,6 +7321,27 @@
 /obj/item/clothing/head/nun_hood,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"HP" = (
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"HQ" = (
+/obj/structure/bed/chair/comfy{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "HR" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -5597,6 +7358,24 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"HT" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"HU" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "HV" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/corners{
@@ -5620,12 +7399,38 @@
 "Ie" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"If" = (
+/obj/effect/decal/warning_stripes/thin,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 6
+	},
+/turf/open/floor/mainship/cargo,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"Ig" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/outside)
 "Ih" = (
 /obj/structure/cargo_container/green{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"Ij" = (
+/obj/structure/largecrate/random/barrel/green,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Ik" = (
 /obj/structure/table,
 /obj/item/storage/box/flashbangs,
@@ -5634,9 +7439,15 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/security)
+"Il" = (
+/turf/closed/ice_rock/southWall,
+/area/icy_caves/caves/northern)
 "Im" = (
 /turf/open/floor/plating/ground/snow,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "In" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -5668,6 +7479,15 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/garage)
+"Iu" = (
+/obj/structure/dropship_piece/one/cockpit/left,
+/turf/open/floor/mainship_hull/dir{
+	dir = 8
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Iv" = (
 /obj/structure/ore_box,
 /turf/open/floor/plating,
@@ -5723,12 +7543,29 @@
 	},
 /turf/open/floor/tile/dark/red2,
 /area/icy_caves/outpost/security)
+"II" = (
+/obj/item/paper/crumpled/bloody/csheet,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "IJ" = (
 /obj/machinery/vending/security,
 /turf/open/floor/tile/dark/red2{
 	dir = 9
 	},
 /area/icy_caves/outpost/security)
+"IK" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "IO" = (
 /obj/structure/closet/crate/construction,
 /obj/item/stack/sheet/metal/medium_stack,
@@ -5740,6 +7577,17 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
+"IP" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "IR" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
@@ -5753,10 +7601,35 @@
 "IT" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
+"IU" = (
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 4
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "IX" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"IY" = (
+/obj/item/tool/surgery/hemostat,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"IZ" = (
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 9
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Je" = (
 /turf/closed/ice/thin/end{
 	dir = 8
@@ -5796,7 +7669,16 @@
 /turf/closed/ice/thin/junction{
 	dir = 4
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
+"Jn" = (
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Jo" = (
 /obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
@@ -5812,7 +7694,10 @@
 /turf/closed/ice/end{
 	dir = 1
 	},
-/area/icy_caves/caves/east)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "Jq" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/tile/dark,
@@ -5859,6 +7744,16 @@
 /obj/item/lightstick/anchored,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
+"JF" = (
+/obj/machinery/vending/cola,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "JH" = (
 /obj/structure/table,
 /obj/item/reagent_containers/spray/pepper,
@@ -5891,6 +7786,19 @@
 	dir = 5
 	},
 /area/icy_caves/caves)
+"JR" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 5
+	},
+/obj/structure/monorail{
+	dir = 9
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "JS" = (
 /obj/structure/closet/crate/freezer/rations,
 /turf/open/floor/tile/dark,
@@ -5901,6 +7809,10 @@
 	dir = 6
 	},
 /area/icy_caves/outpost/medbay)
+"JW" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/outside/center)
 "JX" = (
 /turf/closed/ice/end,
 /area/icy_caves/caves/south)
@@ -5918,6 +7830,12 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/office)
+"Kd" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark/brown2/corner{
+	dir = 1
+	},
+/area/icy_caves/outpost/refinery)
 "Ke" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -6008,12 +7926,24 @@
 "KJ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/snow,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "KK" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 1
 	},
 /area/icy_caves/caves/south)
+"KL" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "KM" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 9
@@ -6025,6 +7955,14 @@
 /obj/item/clothing/suit/hgpirate,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"KP" = (
+/turf/closed/shuttle/dropship3{
+	icon_state = "43"
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "KS" = (
 /turf/open/floor/tile/dark/red2{
 	dir = 5
@@ -6043,6 +7981,17 @@
 "KZ" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/garage)
+"La" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/white/warningstripe{
+	dir = 4
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Lb" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/tile/dark,
@@ -6086,12 +8035,43 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside)
+"Lo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	on = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"Lp" = (
+/turf/open/floor/tile/white/warningstripe,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Lq" = (
 /obj/machinery/power/geothermal,
 /obj/machinery/light/small,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/engineering)
+"Lr" = (
+/obj/item/shard,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 4
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"Ls" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Lt" = (
 /obj/effect/landmark/corpsespawner/miner{
 	corpseback = null;
@@ -6111,6 +8091,13 @@
 "Lv" = (
 /turf/closed/ice/thin,
 /area/icy_caves/outpost/outside)
+"Lw" = (
+/obj/structure/closet/l3closet/virology,
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Lx" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 10
@@ -6141,6 +8128,16 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"LF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "LH" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/colonist,
@@ -6187,7 +8184,10 @@
 /turf/closed/ice/thin/end{
 	dir = 8
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "LQ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -6243,6 +8243,23 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"Me" = (
+/turf/open/floor/mainship_hull/dir{
+	dir = 8
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"Mf" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mainship/red/full,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Mg" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 5
@@ -6288,10 +8305,21 @@
 	dir = 9
 	},
 /area/icy_caves/caves)
+"Mq" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "Ms" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "Mt" = (
 /obj/item/ammo_casing,
 /turf/open/floor/tile/dark/red2{
@@ -6306,12 +8334,45 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"Mv" = (
+/obj/machinery/optable,
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"Mw" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
+"Mx" = (
+/obj/machinery/power/apc/drained{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Mz" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice/corner{
 	dir = 4
 	},
 /area/icy_caves/outpost/LZ1)
+"MA" = (
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "MB" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -6327,6 +8388,11 @@
 	dir = 8
 	},
 /area/icy_caves/caves/south)
+"MH" = (
+/turf/closed/ice/thin/end{
+	dir = 1
+	},
+/area/icy_caves/caves)
 "MJ" = (
 /turf/closed/ice/corner{
 	dir = 1
@@ -6368,6 +8434,14 @@
 /obj/machinery/space_heater,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/office)
+"MT" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/cheeseburger,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "MV" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
@@ -6379,6 +8453,27 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"MX" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 4
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"MY" = (
+/obj/item/reagent_containers/spray/pepper,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 6
+	},
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "MZ" = (
 /obj/machinery/door/airlock/mainship/command/free_access{
 	dir = 1;
@@ -6430,7 +8525,10 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "Np" = (
 /turf/closed/ice/intersection,
 /area/icy_caves/outpost/outside)
@@ -6447,7 +8545,10 @@
 /obj/structure/cable,
 /obj/effect/landmark/fob_sentry,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "Nt" = (
 /obj/item/ammo_magazine/smg/m25,
 /turf/open/floor/tile/dark,
@@ -6488,6 +8589,12 @@
 	},
 /turf/open/floor/tile/dark/brown2/corner,
 /area/icy_caves/outpost/refinery)
+"NH" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/outside)
 "NJ" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -6509,6 +8616,16 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
+"NM" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "NN" = (
 /obj/structure/filingcabinet,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -6540,6 +8657,25 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/outside)
+"NU" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 10
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"NW" = (
+/obj/structure/barricade/guardrail{
+	dir = 4
+	},
+/obj/structure/xenoautopsy/tank/escaped,
+/turf/open/shuttle/dropship/seven,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Ob" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/tile/dark,
@@ -6548,6 +8684,19 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
+"Od" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 6
+	},
+/obj/structure/monorail{
+	dir = 10
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Oe" = (
 /obj/structure/table,
 /turf/open/floor/tile/dark/brown2{
@@ -6598,7 +8747,19 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
+"Ox" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/mainship/tcomms,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Oy" = (
 /obj/docking_port/mobile/crashmode/bigbury,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -6615,7 +8776,10 @@
 "OD" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "OE" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor/tile/dark/brown2,
@@ -6636,9 +8800,10 @@
 /turf/open/floor/wood,
 /area/icy_caves/outpost/office)
 "OI" = (
-/obj/machinery/computer/intel_computer,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/mining/west)
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/space)
 "OJ" = (
 /turf/closed/ice/end,
 /area/icy_caves/outpost/outside)
@@ -6654,6 +8819,12 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside)
+"OP" = (
+/turf/open/floor/mainship/red/full,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "OQ" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/prison/kitchen,
@@ -6665,9 +8836,26 @@
 /obj/structure/cargo_container/gorg,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"Pc" = (
+/obj/structure/dropship_piece/one/corner/middleleft,
+/obj/structure/dropship_piece/one/corner/middleright,
+/turf/open/floor/mainship_hull/dir,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Pd" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/security)
+"Pg" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Pi" = (
 /turf/closed/ice/corner{
 	dir = 8
@@ -6688,6 +8876,15 @@
 	dir = 8
 	},
 /area/icy_caves/caves/south)
+"Pp" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/floor/tile/white/warningstripe{
+	dir = 5
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Pq" = (
 /turf/open/floor/tile/dark/brown2{
 	dir = 8
@@ -6726,7 +8923,10 @@
 /turf/closed/ice/junction{
 	dir = 8
 	},
-/area/icy_caves/caves/east)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "PD" = (
 /turf/closed/ice/corner{
 	dir = 4
@@ -6751,6 +8951,16 @@
 	dir = 8
 	},
 /area/icy_caves/caves)
+"PN" = (
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 8;
+	welded = 1
+	},
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "PO" = (
 /obj/machinery/light,
 /turf/open/floor/tile/dark,
@@ -6795,6 +9005,12 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/office)
+"PZ" = (
+/turf/open/floor/tile/dark/green2,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Qa" = (
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
@@ -6813,6 +9029,14 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/medbay)
+"Qg" = (
+/obj/structure/prop/mainship/sensor_computer2,
+/obj/structure/cable,
+/turf/open/floor/mainship/tcomms,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Qh" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 6
@@ -6829,6 +9053,20 @@
 "Qk" = (
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
+"Qn" = (
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 8
+	},
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"Qo" = (
+/turf/closed/ice_rock/corners{
+	dir = 9
+	},
+/area/icy_caves/caves/northern)
 "Qp" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 8
@@ -6862,6 +9100,15 @@
 /obj/effect/decal/cleanable/blood/writing,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"QD" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mainship/red/full,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "QF" = (
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/plating,
@@ -6905,6 +9152,18 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/outside)
+"QQ" = (
+/obj/structure/bed/chair/comfy{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "QR" = (
 /obj/machinery/light,
 /turf/open/floor/tile/dark/brown2,
@@ -7009,6 +9268,18 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
+"Rt" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Ru" = (
 /obj/structure/table/woodentable,
 /obj/structure/paper_bin,
@@ -7018,6 +9289,30 @@
 "Rv" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/caves)
+"Rw" = (
+/obj/structure/lattice,
+/obj/structure/dropship_piece/one/front/right,
+/obj/structure/monorail{
+	dir = 9
+	},
+/obj/structure/monorail{
+	dir = 5
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"Rx" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/blood,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 4
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Ry" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 8
@@ -7069,6 +9364,21 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
+"RL" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/west)
+"RM" = (
+/obj/structure/monorail,
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 4
+	},
+/turf/open/floor/mainship_hull,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "RN" = (
 /turf/closed/ice_rock/corners{
 	dir = 5
@@ -7112,6 +9422,26 @@
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
+"Se" = (
+/turf/open/floor/mainship/cargo/arrow{
+	dir = 8
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"Sf" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/prison{
+	dir = 10;
+	icon_state = "bright_clean2"
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Sg" = (
 /turf/closed/ice/end{
 	dir = 4
@@ -7121,8 +9451,14 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
-/turf/closed/ice_rock/single,
+/turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/caves)
+"Si" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/outside)
 "Sk" = (
 /obj/machinery/space_heater,
 /turf/open/floor/tile/dark/red2{
@@ -7152,16 +9488,24 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/security)
+"Ss" = (
+/obj/structure/dropship_piece/one/cockpit/right,
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Sv" = (
 /turf/closed/ice_rock/singleT{
 	dir = 4
 	},
 /area/icy_caves/caves/south)
 "Sw" = (
-/turf/closed/ice_rock/singleEnd{
-	dir = 4
-	},
-/area/icy_caves/outpost/LZ1)
+/obj/machinery/telecomms/relay/preset/telecomms,
+/turf/open/floor/plating/icefloor,
+/area/lv624/lazarus/console)
 "Sy" = (
 /turf/open/floor/tile/dark/green2/corner{
 	dir = 8
@@ -7189,18 +9533,13 @@
 "SI" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside)
-"SJ" = (
-/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
-	dir = 2
-	},
-/turf/closed/ice_rock/singlePart{
-	dir = 4
-	},
-/area/icy_caves/outpost/outside)
 "SM" = (
 /obj/structure/closet/crate/internals,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"SO" = (
+/turf/closed/ice_rock/eastWall,
+/area/icy_caves/caves/west)
 "SP" = (
 /turf/closed/ice_rock/singleT{
 	dir = 1
@@ -7231,6 +9570,15 @@
 	},
 /turf/closed/ice_rock/fourway,
 /area/icy_caves/caves)
+"SY" = (
+/obj/structure/bookcase/manuals/research_and_development,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 1
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Tb" = (
 /turf/closed/ice_rock/singleT{
 	dir = 1
@@ -7251,21 +9599,67 @@
 /turf/closed/ice_rock/singleEnd{
 	dir = 8
 	},
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
+"Th" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
+"Tj" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/outside)
 "Tk" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside/center)
+"Tl" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "Tm" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/outside)
+/turf/closed/ice/thin/straight,
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "Tr" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
+"Ts" = (
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"Tt" = (
+/obj/machinery/door/poddoor/shutters/mainship{
+	dir = 2;
+	name = "Monorail Passage Door"
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Tu" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 1
@@ -7279,6 +9673,23 @@
 	dir = 5
 	},
 /area/icy_caves/caves)
+"Tx" = (
+/obj/machinery/door/airlock/multi_tile/mainship/medidoor{
+	name = "\improper Lambda Lab"
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"Tz" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "TB" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/effect/decal/warning_stripes/thin{
@@ -7289,6 +9700,21 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
+"TC" = (
+/turf/open/floor/plating/ground/snow/layer0,
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
+"TD" = (
+/obj/machinery/camera{
+	dir = 9
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "TE" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -7310,6 +9736,12 @@
 "TJ" = (
 /turf/closed/ice/intersection,
 /area/icy_caves/caves/east)
+"TK" = (
+/turf/open/floor/mainship/red,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "TL" = (
 /obj/structure/cargo_container/gorg{
 	dir = 4
@@ -7319,12 +9751,23 @@
 "TM" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/LZ1)
+"TN" = (
+/obj/effect/spawner/gibspawner/human,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "TQ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "TR" = (
 /obj/structure/table/flipped,
 /turf/open/floor/tile/dark/red2{
@@ -7334,7 +9777,10 @@
 "TT" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "TU" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/docking_port/mobile/crashmode/bigbury,
@@ -7358,6 +9804,16 @@
 	dir = 6
 	},
 /area/icy_caves/caves)
+"TZ" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 10
+	},
+/obj/structure/monorail{
+	dir = 6
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/space)
 "Ub" = (
 /turf/open/floor/tile/dark/brown2{
 	dir = 1
@@ -7398,7 +9854,10 @@
 	dir = 2
 	},
 /turf/closed/ice/intersection,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "Uk" = (
 /turf/closed/ice/thin/end,
 /area/icy_caves/caves/south)
@@ -7413,19 +9872,32 @@
 	dir = 1
 	},
 /turf/closed/ice/intersection,
-/area/icy_caves/caves/east)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "Uq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4
 	},
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "Us" = (
 /turf/closed/ice_rock/singleT{
 	dir = 8
 	},
 /area/icy_caves/caves/south)
+"Ut" = (
+/obj/effect/spawner/gibspawner/human,
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Uu" = (
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/LZ1)
@@ -7493,6 +9965,13 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/security)
+"UR" = (
+/obj/structure/largecrate/supply/medicine/medivend,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "US" = (
 /obj/structure/table,
 /obj/item/clothing/suit/chef/classic,
@@ -7504,6 +9983,13 @@
 /obj/item/clothing/shoes/blue,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"UU" = (
+/obj/machinery/atmospherics/pipe/manifold/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "UV" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 8
@@ -7524,6 +10010,14 @@
 /obj/item/analyzer,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
+"UZ" = (
+/obj/structure/dropship_piece/one/corner/middleright,
+/obj/structure/dropship_piece/one/corner/middleleft,
+/turf/open/floor/mainship_hull/dir,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Vb" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 10
@@ -7557,6 +10051,13 @@
 /obj/item/storage/fancy/vials,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/research)
+"Vj" = (
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Vk" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/snow,
@@ -7565,18 +10066,51 @@
 /obj/structure/table,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"Vq" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/thin,
+/obj/effect/decal/warning_stripes/thin{
+	dir = 10
+	},
+/turf/open/floor/mainship/cargo,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Vr" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
 	},
 /turf/closed/ice_rock/southWall,
 /area/icy_caves/caves)
+"Vs" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 5
+	},
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"Vt" = (
+/turf/open/floor/mainship_hull/dir{
+	dir = 9
+	},
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Vu" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice/thin/corner{
 	dir = 1
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "Vx" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -7598,6 +10132,10 @@
 	dir = 4
 	},
 /area/icy_caves/caves/west)
+"VC" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/outside/center)
 "VD" = (
 /obj/structure/largecrate/supply/medicine/iv,
 /turf/open/floor/plating,
@@ -7630,6 +10168,21 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/security)
+"VL" = (
+/obj/effect/decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/thin{
+	dir = 9
+	},
+/turf/open/floor/mainship/cargo,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "VM" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/security)
@@ -7660,6 +10213,15 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"VS" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "VT" = (
 /turf/closed/ice/thin/straight,
 /area/icy_caves/outpost/LZ1)
@@ -7687,6 +10249,14 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"VZ" = (
+/obj/item/shard,
+/obj/effect/decal/cleanable/blood/xtracks,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Wa" = (
 /obj/structure/largecrate/supply/explosives,
 /obj/item/explosive/plastique,
@@ -7699,20 +10269,77 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
+"Wc" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 2;
+	name = "Canteen"
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"Wd" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "We" = (
 /turf/closed/ice/junction{
 	dir = 1
 	},
 /area/icy_caves/outpost/outside/center)
 "Wg" = (
-/obj/effect/landmark/fob_sentry_rebel,
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/outside)
+/turf/closed/ice/thin/straight,
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
+"Wi" = (
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Wj" = (
 /turf/closed/ice/thin/end{
 	dir = 4
 	},
 /area/icy_caves/caves/south)
+"Wm" = (
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"Wp" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"Wr" = (
+/obj/machinery/door/airlock/mainship/maint,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"Ws" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/west)
 "Wt" = (
 /obj/structure/table/reinforced,
 /obj/item/restraints/handcuffs,
@@ -7724,7 +10351,10 @@
 	dir = 1
 	},
 /turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "Ww" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -7733,12 +10363,35 @@
 	dir = 9
 	},
 /area/icy_caves/caves)
+"Wx" = (
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/caves/west)
+"Wy" = (
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "WA" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
 	},
 /turf/closed/ice/thin/end,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
+"WB" = (
+/obj/machinery/vending/dinnerware,
+/obj/machinery/camera/autoname/mainship/dropship_one{
+	dir = 8;
+	pixel_x = 16
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "WD" = (
 /turf/open/floor/plating/ground/snow,
 /area/icy_caves/outpost/LZ1)
@@ -7749,12 +10402,36 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"WF" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"WG" = (
+/turf/closed/ice_rock/corners,
+/area/icy_caves/caves/west)
 "WI" = (
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/outside)
 "WK" = (
 /turf/open/floor/mech_bay_recharge_floor,
 /area/icy_caves/outpost/LZ1)
+"WO" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"WP" = (
+/obj/effect/decal/cleanable/vomit,
+/turf/open/floor/tile/purple/whitepurplefull,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "WQ" = (
 /turf/closed/ice/thin/end{
 	dir = 8
@@ -7780,6 +10457,28 @@
 /obj/item/clothing/head/pirate,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"WW" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"WX" = (
+/obj/machinery/computer3/laptop,
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "WY" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/medbay)
@@ -7801,6 +10500,15 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"Xh" = (
+/obj/structure/bed/chair/comfy{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Xi" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -7874,6 +10582,33 @@
 /obj/item/storage/box/visual/grenade/teargas,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"Xy" = (
+/obj/structure/dropship_piece/one/front,
+/obj/structure/monorail,
+/turf/open/floor/mainship_hull,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"Xz" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
+"XA" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/east)
+"XD" = (
+/obj/item/shard,
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "XF" = (
 /turf/closed/ice/corner,
 /area/icy_caves/caves/west)
@@ -7908,6 +10643,16 @@
 "XJ" = (
 /turf/closed/ice_rock/singleEnd,
 /area/icy_caves/caves/west)
+"XL" = (
+/obj/structure/barricade/guardrail{
+	dir = 4
+	},
+/obj/structure/xenoautopsy/tank/alien,
+/turf/open/shuttle/dropship/seven,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "XM" = (
 /obj/structure/bed/chair,
 /obj/effect/landmark/corpsespawner/colonist,
@@ -7948,7 +10693,10 @@
 /turf/closed/ice/thin/junction{
 	dir = 1
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "XU" = (
 /turf/open/floor/tile/dark/brown2/corner{
 	dir = 1
@@ -7991,6 +10739,13 @@
 	dir = 1
 	},
 /area/icy_caves/caves)
+"Yh" = (
+/obj/machinery/power/apc/drained,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Yi" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/tile/dark/green2{
@@ -8003,6 +10758,15 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
+"Yk" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 5
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Ym" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/swat,
@@ -8025,14 +10789,20 @@
 /turf/closed/ice/thin/junction{
 	dir = 8
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "Yv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "Yw" = (
 /obj/machinery/landinglight/ds1/delayone{
 	dir = 8
@@ -8061,6 +10831,19 @@
 "YA" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/kitchen)
+"YB" = (
+/obj/structure/lattice,
+/obj/structure/monorail{
+	dir = 10
+	},
+/obj/structure/monorail{
+	dir = 6
+	},
+/turf/open/shuttle/escapepod/plain,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "YF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -8072,8 +10855,11 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
-/turf/closed/ice_rock/singleT,
-/area/icy_caves/outpost/outside)
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "YI" = (
 /turf/closed/ice/thin/end{
 	dir = 1
@@ -8098,6 +10884,18 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
+"YP" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "YQ" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/space)
@@ -8113,6 +10911,17 @@
 "YT" = (
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
+"YV" = (
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "YW" = (
 /turf/closed/ice,
 /area/icy_caves/caves/south)
@@ -8178,6 +10987,15 @@
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/LZ1)
+"Zl" = (
+/obj/structure/barricade/guardrail{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "Zm" = (
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/LZ1)
@@ -8248,7 +11066,10 @@
 "ZE" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "ZF" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -8289,10 +11110,20 @@
 	dir = 1
 	},
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/mining{
+	icon_state = "bluenew";
+	name = "can build here"
+	})
 "ZU" = (
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
+"ZV" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/plating/mainship,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 "ZW" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -8311,6 +11142,15 @@
 	dir = 9
 	},
 /area/icy_caves/caves)
+"ZZ" = (
+/obj/structure/morgue{
+	dir = 2
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern{
+	icon_state = "bluenew";
+	name = "Monorail & research"
+	})
 
 (1,1,1) = {"
 YQ
@@ -8470,12 +11310,12 @@ YQ
 "}
 (2,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+mi
+mi
+mi
+mv
+mv
+mv
 Yf
 Yf
 Yf
@@ -8626,6 +11466,12 @@ YQ
 "}
 (3,1,1) = {"
 YQ
+mi
+Sw
+mi
+mv
+mv
+mv
 Yf
 Yf
 Yf
@@ -8653,22 +11499,16 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+WF
+WF
+WF
+WF
+WF
+WF
+vT
+vT
+vT
+vT
 Yf
 Yf
 Yf
@@ -8782,6 +11622,12 @@ YQ
 "}
 (4,1,1) = {"
 YQ
+mi
+mi
+mi
+mv
+mv
+mv
 Yf
 Yf
 Yf
@@ -8809,22 +11655,16 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+WF
+mw
+cE
+ta
+hW
+kY
+Vj
+AJ
+eO
+vT
 Yf
 Yf
 Yf
@@ -8938,6 +11778,12 @@ YQ
 "}
 (5,1,1) = {"
 YQ
+mv
+mv
+mv
+mv
+mv
+mv
 Yf
 Yf
 Yf
@@ -8965,22 +11811,16 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+WF
+SY
+AJ
+AJ
+jf
+Ex
+II
+AJ
+kf
+vT
 Yf
 Yf
 Yf
@@ -9094,6 +11934,12 @@ YQ
 "}
 (6,1,1) = {"
 YQ
+mv
+mv
+mv
+mv
+mv
+mv
 Yf
 Yf
 Yf
@@ -9121,6 +11967,16 @@ Yf
 Yf
 Yf
 Yf
+WF
+AR
+VZ
+AJ
+AJ
+Fq
+AJ
+AJ
+kf
+vT
 Yf
 Yf
 Yf
@@ -9173,40 +12029,24 @@ Yf
 Yf
 Yf
 Yf
+MH
+MH
 Yf
 Yf
+MH
+MH
+re
 Yf
+MH
+MH
 Yf
 Yf
 Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+qy
+qy
 Yf
 Yf
 Yf
@@ -9283,6 +12123,16 @@ Yf
 Yf
 Yf
 Yf
+WF
+rk
+AJ
+WP
+AJ
+AJ
+MY
+gZ
+yH
+vT
 Yf
 Yf
 Yf
@@ -9333,38 +12183,28 @@ Yf
 Yf
 Yf
 Yf
+MH
+YI
+YI
+YI
+ZU
+ZU
+ZU
+GF
+re
+re
+re
+MH
 Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+MH
+MH
+qy
+qy
+qy
+MH
 Yf
 Yf
 Yf
@@ -9372,7 +12212,7 @@ Yf
 Yf
 qy
 RC
-WD
+TM
 UE
 WK
 Yj
@@ -9411,6 +12251,27 @@ Yf
 Yf
 Yf
 Yf
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
 Yf
 Yf
 Yf
@@ -9418,37 +12279,16 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+WF
+ux
+hG
+Rx
+AJ
+AJ
+HU
+AJ
+Lr
+vT
 Yf
 Yf
 Yf
@@ -9500,35 +12340,35 @@ Yf
 Yf
 Yf
 Yf
+ZU
+YI
+ZU
+ZU
+Wx
+Wx
+Bb
+WI
+WI
+WI
+WI
+MH
 Yf
 Yf
 Yf
+MH
+MH
+WI
+WI
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qy
-aG
-Ww
-Sw
+MH
+MH
+MH
+MH
+DX
+kn
+zi
+TM
 UE
 WT
 Yn
@@ -9567,6 +12407,27 @@ Yf
 Yf
 Yf
 Yf
+WF
+Qg
+mj
+GQ
+yb
+vT
+Ls
+eM
+EU
+wY
+eM
+EU
+DF
+nK
+vT
+eM
+EU
+eM
+LF
+eM
+WF
 Yf
 Yf
 Yf
@@ -9574,37 +12435,16 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+WF
+EP
+EP
+vT
+AJ
+AJ
+HU
+AJ
+GE
+vT
 Yf
 Yf
 Yf
@@ -9653,38 +12493,38 @@ Yf
 Yf
 Yf
 Yf
+MH
+MH
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-VU
-qz
+ZU
+ZU
+gx
+ZU
+ZU
+ZU
+Bb
+WI
+pa
+Si
+WI
+WI
+MH
+MH
+MH
+MH
+pa
+Si
+WI
+WI
+MH
+MH
+MH
+Bt
+Bt
+DX
+DX
 Sh
-HC
+TM
 UE
 Xa
 Yn
@@ -9723,57 +12563,57 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-re
-re
-re
-re
-re
-re
+WF
+op
+Ox
+yi
+Dm
+vT
+eM
+eM
+eM
+eM
+He
+eM
+eM
+iD
+vT
+eM
+eM
+eM
+BZ
+eM
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+eM
+He
+vT
+EP
+eM
+YP
+EP
+vT
+vT
+vT
+vT
+vT
+vT
+vT
+vT
+vT
+vT
+vT
+vT
+vT
+vT
+vT
 Yf
 Yf
 Yf
@@ -9810,36 +12650,36 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-aK
-VU
-yW
+YI
+ZU
+ZU
+ZU
+ZU
+ZU
+ZU
+ZU
+Bb
+WI
+Tj
+SI
+SI
+SI
+SI
+SI
+SI
+SI
+SI
+WI
+WI
+WI
+WI
+WI
+WI
+Bt
+Bt
+DX
+Im
+YH
 TM
 UE
 Xq
@@ -9874,62 +12714,62 @@ YQ
 "}
 (11,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-af
-af
-af
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-dy
-dy
-dy
-dy
-dy
-dy
-dy
+pl
+pl
+pl
+pl
+pl
+WF
+Gh
+co
+oR
+lO
+iN
+Tz
+Tz
+Wm
+ph
+Tz
+Tz
+Tz
+Tz
+iN
+Tz
+Tz
+Tz
+UU
+eM
+Xz
+eM
+eM
+wY
+EU
+eM
+eM
+eM
+eM
+eM
+eM
+eM
+cV
+IU
+MX
+Lp
+eM
+eM
+eM
+eM
+EU
+eM
+LF
+eM
+vT
+eM
+Mx
+NM
+xo
+pP
+vT
 bD
 Yf
 Yf
@@ -9966,35 +12806,35 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qy
-XH
-XH
+ZU
+gx
+ez
+ZU
+ZU
+ZU
+ZU
+ZU
+Bb
+WI
+WI
+SI
+SI
+SI
+SI
+SI
+SI
+SI
+SI
+AW
+WI
+WI
+WI
+WI
+WI
+Bt
+Bt
+Bt
+Im
 YH
 TM
 uw
@@ -10030,62 +12870,62 @@ YQ
 "}
 (12,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-af
+pl
+bW
+bW
+bW
+bW
+in
+mu
+yi
+oQ
+yi
+zu
+TK
+eM
+eM
+BZ
+eM
+eM
+eM
+eM
+Wp
+eM
+eM
+eM
+Wd
+Tz
 am
-af
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-dy
+Tz
+Tz
+Tz
+Tz
+TN
+Tz
+Yk
+eM
+eM
+eM
+eM
+Pp
+Fw
+La
+zt
+eM
+eM
+eM
+He
+eM
+eM
+BZ
+eM
+vT
 dL
-dZ
+eM
 ev
 eM
 fb
-dy
+vT
 bD
 Yf
 Yf
@@ -10122,36 +12962,36 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+ZU
+ZU
+ZU
+ZU
+ZU
+ZU
 re
 re
 re
-re
-re
-re
-re
-re
-re
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-re
-qy
-qz
-qz
-qz
-YH
+WI
+WI
+SI
+SI
+WI
+WI
+WI
+WI
+SI
+SI
+WI
+WI
+WI
+WI
+WI
+WI
+fq
+Bt
+Bt
+Bt
+Tm
 TM
 iJ
 WT
@@ -10186,62 +13026,62 @@ YQ
 "}
 (13,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-af
-af
-af
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-dy
-dM
-ap
+pl
+BB
+BB
+BB
+BB
+nw
+Sf
+yi
+wG
+yi
+OP
+TK
+eM
+eM
+BZ
+eM
+dL
+eM
+eM
+eM
+eM
+eM
+eM
+BZ
+eM
+ev
+He
+eM
+eM
+eM
+eM
+eM
+Wi
+Tz
+Tz
+Tz
+Tz
+Tz
+Tz
+UU
+eM
+eM
+eM
+Gf
+eM
+eM
+eM
+BZ
+eM
+zZ
+eM
+eM
 ix
 eN
 fd
-dy
+vT
 bD
 Yf
 Yf
@@ -10278,36 +13118,36 @@ Yf
 Yf
 re
 re
-re
-re
-re
-re
-re
-re
+ZU
+ZU
+ZU
+ZU
+Di
+Di
 lG
 lX
 lG
-lX
-lG
-lX
-lG
-re
-re
-re
-re
-re
-Yf
-Yf
-Yf
-Yf
-qs
-VU
-aG
-aH
-TW
-VU
-qz
-SJ
+AW
+WI
+SI
+SI
+WI
+pD
+WI
+WI
+SI
+SI
+WI
+WI
+WI
+WI
+WI
+WI
+Bt
+Bt
+Bt
+Bt
+YH
 TM
 bU
 Xa
@@ -10342,62 +13182,62 @@ YQ
 "}
 (14,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-dy
+pl
+bW
+bW
+bW
+bW
+nw
+gP
+jo
+yi
+yi
+EP
+eM
+eM
+eM
+BZ
+eM
+eM
+eM
+eM
+EP
+eM
+eM
+eM
+BZ
+eM
+Xz
+eM
+eM
+eM
+eM
+eM
+eM
+pL
+eM
+eM
+eM
+eM
+eM
+eM
+Wi
+Tz
+un
+Tz
+Tz
+Tz
+Tz
+Tz
+HP
+un
+Hw
 dN
-dP
+Tz
 ew
 eP
 fe
-dy
+vT
 bD
 Yf
 Yf
@@ -10431,39 +13271,39 @@ re
 re
 re
 re
-re
-qy
-lX
-mv
-mv
-mv
-bX
-pq
-lG
+ZU
+ZU
+SF
+ZU
+ZU
+ZU
+ZU
+Di
+Mg
 ec
 Vb
 eY
-Vb
-eY
-Vb
-eY
-qz
-qz
-qz
-eY
-re
-re
-re
-re
-re
-qy
-XH
-lX
-aK
-lX
-eY
-Qh
-zb
+Ig
+WI
+SI
+SI
+WI
+WI
+WI
+WI
+SI
+SI
+WI
+WI
+MH
+qs
+WI
+WI
+Bt
+Bt
+Bt
+Wg
+Tf
 Tb
 XW
 Xq
@@ -10498,62 +13338,62 @@ YQ
 "}
 (15,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-dy
+pl
+BB
+BB
+BB
+BB
+WF
+fD
+yi
+Do
+wq
+vT
+Bo
+eM
+eM
+BZ
+eM
+He
+eM
+eM
+vT
+eM
+dL
+eM
+BZ
+eM
+WF
+eM
+eM
+eM
+eM
+eM
+eM
+BZ
+Pg
+ve
+eM
+eM
+eM
+eM
+BZ
+eM
+eM
+Pg
+TD
+eM
+eM
+eM
+eM
+eM
+vT
 dO
 ea
-dQ
+WW
 eT
 ff
-dy
+vT
 bD
 Yf
 Yf
@@ -10586,39 +13426,39 @@ TW
 dj
 Di
 XF
-Di
-XF
-qz
-mv
+DZ
 ZU
 ZU
+SF
+ZU
+gx
 ZU
 ZU
-aG
-eY
+RG
+ec
 fT
 xI
 xI
 xI
+nx
+od
+lH
+nx
 xI
 xI
 xI
-xI
-xI
-xI
-xI
-pq
-aG
-pq
-lG
-lX
-pq
-lG
-XH
-XH
-XH
-qz
-Qp
+SI
+SI
+WI
+MH
+Yf
+Yf
+MH
+WI
+Bt
+Bt
+Bt
+Wg
 Tf
 Ml
 XW
@@ -10654,62 +13494,62 @@ YQ
 "}
 (16,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-dy
+pl
+pl
+pl
+pl
+pl
+vT
+wO
+yi
+Hj
+kR
+vT
+eM
+eM
+dL
+ds
+eM
+eM
+eM
+FB
+vT
+gK
+cX
+eM
+BZ
+eM
+pE
+WF
+WF
+WF
+ev
+BO
+WF
+VS
+vT
+vT
+vT
+vT
+vT
+eM
+YP
+vT
+vT
+vT
+vT
+vT
+Wr
+vT
+vT
+vT
+vT
 nD
 ed
-ZW
-dP
+nB
+eM
 fg
-dy
+vT
 bD
 Yf
 Yf
@@ -10741,39 +13581,39 @@ XH
 qz
 ZU
 gz
-Jg
-Jg
-DK
-ez
-ZU
-ZU
 ZU
 ZU
 ZU
 ez
+SF
 ZU
+ZU
+ZU
+ZU
+ez
+SF
 ZU
 nO
 oI
 wW
-pl
+oI
 pw
-OI
+oI
 pf
 oZ
 oK
 xI
-VU
-lX
-pq
-WS
-eY
-VU
-XH
-aG
-TW
-qz
+SI
+SI
 WI
+MH
+Yf
+Yf
+Yf
+MH
+Bt
+Bt
+Bt
 Wg
 Tm
 Uu
@@ -10810,62 +13650,62 @@ YQ
 "}
 (17,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-dy
-dy
-dy
+mv
+xs
+xs
+xs
+xs
+vT
+jY
+vT
+EP
+EP
+vT
+pu
+vT
+vT
+vT
+eM
+VL
+Vq
+eM
+vT
+vT
+vT
+vT
+BZ
+eM
+WF
+Gs
+WF
+hT
+eM
+eM
+eM
+AQ
+vT
+Gs
+Gs
+Gs
+vT
+eM
+BZ
+vT
+DV
+EX
+jd
+jd
+jd
+vT
+Gs
+Il
+vT
+vT
+vT
 ex
-dy
-dy
-dy
+vT
+vT
+vT
 bh
 Yf
 Yf
@@ -10883,12 +13723,12 @@ eb
 ZU
 ZU
 ZU
+SF
 ZU
 ZU
 ZU
 ZU
-ZU
-ZU
+SF
 ZU
 ZU
 ez
@@ -10897,8 +13737,8 @@ ZU
 ZU
 ZU
 ZU
-gz
-DK
+ZU
+ZU
 ez
 ZU
 dx
@@ -10907,7 +13747,7 @@ gA
 Mg
 ZU
 ZU
-ZU
+SF
 fT
 xI
 oJ
@@ -10919,18 +13759,18 @@ oI
 oI
 oU
 xI
-eY
-bH
-VU
-XH
-aG
-aI
-TW
-qz
-WI
-WI
-WI
-XO
+SI
+SI
+MH
+Yf
+Yf
+Yf
+qs
+qs
+Bt
+Bt
+Bt
+Bt
 TQ
 Uu
 bU
@@ -10966,70 +13806,70 @@ YQ
 "}
 (18,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-lX
-TW
+YQ
+YQ
+pl
+pl
+pl
+vT
+OP
+OP
+OP
+OP
+OP
+OP
+Mf
+OP
+vT
+vT
+Se
+CI
+vT
+vT
+Vt
+CH
+vT
+mg
+eM
+WF
+Gs
+WF
+tT
+eM
+pZ
+IY
+BZ
+vT
+Gs
+Gs
+Gs
+vT
+eM
+Wi
+Ts
+ZV
+ZV
+Vs
+Jn
+Jn
+vT
+Gs
+Il
+bI
+XP
 eg
 ZW
 eU
-VU
-lX
-lG
-bD
-Yf
-Yf
-Yf
-qy
-nM
-nM
+dw
+DZ
+Mg
+qR
+WG
+WG
+WG
+pb
+SD
+SD
 ZU
 ZU
 ZU
@@ -11039,12 +13879,12 @@ ZU
 ZU
 ez
 ZU
-ZU
+SF
 Eb
 ZU
 ZU
 gx
-ZU
+SF
 ez
 ZU
 gx
@@ -11075,18 +13915,18 @@ qo
 qO
 oU
 xI
-VU
-XH
-qH
-TW
-qz
+NH
+SI
 WI
+MH
+MH
+MH
 WI
-WI
-WI
-XO
-XO
-XO
+MH
+Bt
+qA
+qA
+qA
 TQ
 UE
 XW
@@ -11121,71 +13961,71 @@ Yf
 YQ
 "}
 (19,1,1) = {"
-YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-bH
-ZU
-eh
+cW
+qa
+yF
+jL
+Me
+Me
+Me
+Me
+Me
+Me
+iS
+Me
+Me
+Me
+Me
+Iu
+BN
+jc
+jc
+BN
+BN
+BN
+ma
+EP
+BZ
+eM
+WF
+Gs
+WF
+Ch
+eM
+cD
+eM
+pL
+vT
+Gs
+Gs
+Gs
+vT
+Lo
+UU
+vT
+nF
+mZ
+PN
+Lw
+Lw
+vT
+Gs
+Il
+bR
+SR
+RL
 ZW
-ZU
-Vb
-aI
-eY
-bD
-Yf
-Yf
-qy
-lX
-WS
-eY
+zB
+Lx
+Ga
+ec
+qR
+WG
+WG
+pb
+DZ
+Rj
+ec
 gx
 ZU
 ZU
@@ -11218,7 +14058,7 @@ Lx
 ec
 ZU
 ZU
-ZU
+gx
 da
 DK
 xI
@@ -11231,18 +14071,18 @@ pX
 oI
 oU
 xI
-eY
-aG
-eY
+SI
+SI
 WI
 WI
 WI
 WI
 WI
 WI
-WI
-XO
-XO
+Bt
+Bt
+qA
+qA
 TQ
 WD
 XW
@@ -11277,70 +14117,70 @@ Yf
 YQ
 "}
 (20,1,1) = {"
-YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-Vb
-TW
-ZU
+cW
+BY
+wT
+Od
+JR
+Od
+JR
+Od
+JR
+Od
+JR
+Od
+JR
+Od
+lu
+ul
+Fk
+FE
+Wy
+GU
+NW
+XL
+Pc
+Tt
+BZ
+eM
+WF
+Gs
+WF
+WX
+eM
+Gf
+Mv
+ns
+vT
+vT
+vT
+vT
+vT
+eM
+BZ
+vT
+vT
+vT
+vT
+vT
+vT
+vT
+Gs
+Il
+bJ
+XP
+zB
 ZW
-eh
+RL
 ZU
 Di
 XF
-bh
-re
-qy
-aG
-WS
-eY
+pH
+SO
+pb
+RG
+Rj
+ec
 ZU
 ZU
 ZU
@@ -11387,20 +14227,20 @@ qp
 oI
 oK
 xI
+SI
+SI
 XO
-XO
-XO
 WI
 WI
 WI
 WI
 WI
-WI
-AW
-XO
-XO
-TQ
-UE
+Bt
+fq
+qA
+qA
+Aq
+Ml
 gI
 UE
 WD
@@ -11433,69 +14273,69 @@ Yf
 YQ
 "}
 (21,1,1) = {"
-YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-Di
+cW
+HC
+yd
+RM
+cL
+RM
+cL
+RM
+cL
+RM
+cL
+RM
+cL
+RM
+Xy
+pc
+Ut
+Wy
+ch
+Wy
+Wy
+GU
+FR
+Tt
+BZ
+eM
+WF
+Gs
+WF
+xS
+eM
+IY
+jk
+BZ
+vT
+EX
+jd
+ze
+vT
+eM
+BZ
+vT
+Gs
+Gs
+Gs
+Gs
+Gs
+Gs
+Gs
+Il
+PD
 eb
 ei
 ZW
-ZU
+zB
 Xu
 Jg
 DK
-lX
-pq
-lG
+DZ
+dh
+Mg
 fT
-XH
+dD
 ZU
 ez
 ZU
@@ -11541,7 +14381,7 @@ oI
 ig
 wW
 oI
-oI
+jI
 nO
 SI
 SI
@@ -11551,12 +14391,12 @@ WI
 WI
 WI
 WI
-WI
-XO
-XO
-XO
-TQ
-Uu
+Bt
+qA
+qA
+qA
+Tm
+Ml
 Vk
 XW
 bU
@@ -11589,69 +14429,69 @@ Yf
 YQ
 "}
 (22,1,1) = {"
-YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-re
-re
-re
-re
-Yf
-Yf
-re
-re
-qy
-do
+cW
+TZ
+GN
+YB
+cF
+YB
+cF
+YB
+cF
+YB
+cF
+YB
+cF
+YB
+Rw
+uO
+Qn
+Wy
+XD
+GU
+oz
+oz
+UZ
+Tt
+BZ
+dL
+WF
+Gs
+WF
+Gj
+cD
+wY
+eM
+ds
+vT
+Ij
+jd
+jd
+Ea
+He
+BZ
+vT
+Ae
+Ae
+Ae
+Gs
+Gs
+Ae
+Ae
+Qo
+ce
 ZU
-ZU
+zB
 ZW
-ZU
+zB
 Xu
 Jg
 eb
-bH
-qz
-XH
-qz
-qz
+hn
+xa
+dD
+xa
+xa
 ez
 ZU
 DZ
@@ -11704,18 +14544,18 @@ SI
 Za
 XO
 WI
+AW
 WI
-WI
 XO
-XO
-XO
-XO
-XO
+qA
+qA
+qA
+qA
 LP
-UE
-UE
-UE
-WD
+VT
+VT
+VT
+VT
 WD
 uw
 vi
@@ -11728,7 +14568,7 @@ Nr
 jE
 Zm
 bq
-BY
+Ml
 UE
 UE
 UE
@@ -11737,7 +14577,7 @@ uw
 uw
 Zm
 WD
-UE
+Ml
 VU
 VU
 uc
@@ -11745,65 +14585,65 @@ bD
 YQ
 "}
 (23,1,1) = {"
-YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-PD
-pk
+cW
+OI
+Eh
+IP
+DU
+DU
+DU
+DU
+BJ
+DU
+DU
+DU
+DU
+DU
+DU
+Ss
+KP
+jc
+jc
+KP
+KP
+KP
+gQ
+EP
+BZ
+eM
+WF
+Gs
+WF
+ws
+He
+eM
+ZZ
+eM
+vT
+vT
+vT
+vT
+vT
+eM
+BZ
+vT
 cJ
 bA
 Nd
-bh
-qy
-bX
-pq
-TW
-da
+hM
+Qo
+cd
+Tu
+XP
+ot
 eb
-ZU
+zB
 ZW
-ZU
+zB
 Xu
 Jg
 XF
-XH
+dD
 fi
 gp
 Sn
@@ -11840,11 +14680,11 @@ ZU
 ZU
 lj
 ZU
-ZU
+gx
 EB
 EB
 ez
-ZU
+SF
 XO
 XO
 XO
@@ -11863,15 +14703,15 @@ XO
 XO
 XO
 XO
-XO
-WI
-XO
-lW
+qA
+Bt
+qA
+kn
 Yq
 VT
-Nr
-UE
-UE
+VT
+VT
+VT
 Zm
 uw
 vi
@@ -11882,18 +14722,18 @@ UE
 AB
 mb
 Nr
-TM
-TM
+JA
+JA
 JA
 fN
-mi
-UE
+Ml
+Ml
 Zm
 uw
 uw
 Zm
-UE
-aG
+Ml
+XH
 WS
 WS
 Ww
@@ -11902,60 +14742,60 @@ YQ
 "}
 (24,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-re
-qy
-ce
-PD
+YQ
+YQ
+pl
+pl
+pl
+vT
+OP
+OP
+OP
+OP
+OP
+OP
+QD
+OP
+vT
+vT
+tF
+lv
+vT
+vT
+rg
+HL
+vT
+mg
+eM
+WF
+Gs
+WF
+wh
+TD
+Pg
+ZZ
+ve
+vT
+Gs
+Gs
+Ae
+vT
+eM
+BZ
+vT
 cK
 bM
 Fu
-qz
-lX
-TW
+bS
+bI
+XP
 qT
-cW
-dp
+cP
+Sg
 ZU
-eh
+RL
 ZW
-ZU
+zB
 ZU
 dp
 do
@@ -11999,8 +14839,8 @@ Bw
 ZU
 ZU
 cY
-ZU
-ZU
+gx
+SF
 XO
 Za
 Za
@@ -12019,10 +14859,10 @@ XO
 XO
 XO
 XO
-WI
-XO
-XO
-XO
+Bt
+qA
+qA
+qA
 TT
 EQ
 XT
@@ -12043,13 +14883,13 @@ EO
 rp
 Vu
 vR
-TT
-ZE
+vr
+vr
 Hl
 Hl
 ZE
-TT
-TT
+vr
+vr
 PL
 PL
 HV
@@ -12058,60 +14898,60 @@ YQ
 "}
 (25,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qy
-VU
-VU
-qz
-ce
-Sg
+mv
+mv
+mv
+mv
+mv
+vT
+Wr
+vT
+vT
+Zl
+Zl
+Zl
+vT
+vT
+vT
+eM
+gM
+If
+eM
+vT
+vT
+vT
+vT
+BZ
+eM
+WF
+Gs
+WF
+vT
+vT
+vT
+vT
+vT
+vT
+Gs
+Qo
+bP
+vT
+eM
+BZ
+vT
 yh
 SR
 Sg
-aG
-eY
+Io
+eB
 qT
 IC
 dd
+SR
 ZU
-ZU
-ZU
+zB
 ZW
-ZU
+zB
 eh
 ZU
 dp
@@ -12156,7 +14996,7 @@ fz
 ZU
 ZU
 ja
-ZU
+SF
 XO
 XO
 XO
@@ -12176,37 +15016,37 @@ Za
 XO
 XO
 XO
-XO
-XO
-XO
-XO
-of
-of
+qA
+qA
+qA
+qA
+Cq
+Cq
 Ey
-XO
-XO
-SI
-Dn
-Za
-Za
+qA
+qA
+MA
+qk
+TC
+TC
 Im
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-Za
-SI
-SI
-Za
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+TC
+MA
+MA
+TC
 Ey
-XO
-XO
+qA
+qA
 qz
 bD
 Yf
@@ -12214,47 +15054,47 @@ YQ
 "}
 (26,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-qy
-lX
-WS
-WS
-TW
-Sg
-SR
+mv
+mv
+mv
+mv
+mv
+vT
+Jn
+pN
+vT
+eM
+eM
+dL
+LF
+eM
+eM
+eM
+eM
+dL
+eM
+eM
+EU
+pS
+eM
+Wi
+HT
+WF
+Gs
+Gs
+Gs
+Gs
+Gs
+Gs
+Gs
+Ae
+Qo
+bI
+Rh
+vT
+eM
+yV
+vT
 cb
 SR
 SR
@@ -12265,9 +15105,9 @@ cg
 df
 ZU
 ZU
-ZU
+zB
 ZW
-ZU
+zB
 ZU
 gx
 jb
@@ -12280,14 +15120,14 @@ ZU
 ZU
 ZU
 ZU
-ZU
+SF
 ZU
 ZU
 ZU
 ZU
 gx
 ZU
-ZU
+SF
 ZU
 ZU
 ZU
@@ -12309,7 +15149,7 @@ ZU
 dE
 Sn
 xa
-xa
+dE
 ez
 ZU
 ht
@@ -12332,37 +15172,37 @@ CV
 Za
 Za
 Za
-Za
-Za
-Za
-XO
-XO
-XO
-XO
-Za
-Za
-SI
-Dn
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-SI
-SI
-Za
-Za
-Za
-XO
+TC
+TC
+TC
+qA
+qA
+qA
+qA
+TC
+TC
+MA
+qk
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+MA
+MA
+TC
+TC
+TC
+qA
 bF
 Yf
 Yf
@@ -12370,47 +15210,47 @@ YQ
 "}
 (27,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-qy
+mv
+mv
+mv
+mv
+mv
+vT
+oT
+Jn
+vT
+Bo
+eM
+eM
+BZ
+eM
+eM
+eM
+eM
+eM
+eM
+eM
+eM
+eM
+eM
+pL
+eM
+WF
+Gs
+Gs
+Gs
+Gs
+Gs
+Ae
+Qo
 PD
 Ho
-Vb
-eY
-XH
-SR
-SR
-SR
+bJ
+eB
+vT
+eM
+YP
+vT
 yh
 SR
 SR
@@ -12421,9 +15261,9 @@ SR
 dg
 ZU
 gx
-ZU
+zB
 ZW
-ez
+Ws
 ZU
 ZU
 SF
@@ -12436,14 +15276,14 @@ ZU
 ZU
 ZU
 gx
-ZU
+SF
 ZU
 ZU
 ez
 ZU
 ZU
 ZU
-ZU
+SF
 ZU
 ez
 gx
@@ -12488,37 +15328,37 @@ pY
 Al
 vy
 vy
-Al
-vy
-vy
-vy
-vy
-vy
+Mw
+Mq
+Mq
+Mq
+Mq
+Mq
 Nn
-vy
-vy
-Al
+Mq
+Mq
+Mw
 qf
-SI
-SI
-SI
-SI
-SI
-SI
-SI
-Ln
-SI
-SI
-SI
-SI
-SI
-SI
-SI
-Ln
-SI
-SI
-Ln
-XO
+MA
+MA
+MA
+MA
+MA
+MA
+MA
+Th
+MA
+MA
+MA
+MA
+MA
+MA
+MA
+Th
+MA
+MA
+Th
+qA
 bD
 Yf
 Yf
@@ -12526,37 +15366,37 @@ YQ
 "}
 (28,1,1) = {"
 YQ
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qy
+mv
+mv
+mv
+mv
+mv
+vT
+Ek
+uu
+vT
+eM
+eM
+eM
+BZ
+eM
+He
+eM
+eM
+eM
+lR
+lR
+eM
+eM
+eM
+Cm
+eM
+WF
+Gs
+Gs
+Gs
+Gs
+Qo
 PD
 bA
 VI
@@ -12564,9 +15404,9 @@ Ho
 yh
 SR
 SR
-SR
-im
-SR
+eM
+uT
+eM
 yh
 wo
 SR
@@ -12577,7 +15417,7 @@ we
 dg
 ZU
 ZU
-ZU
+zB
 dQ
 eF
 ZU
@@ -12592,7 +15432,7 @@ ZU
 ZU
 ZU
 ZU
-ZU
+SF
 gx
 ZU
 ZU
@@ -12630,7 +15470,7 @@ XO
 XO
 XO
 XO
-qa
+XO
 XO
 XO
 XO
@@ -12644,17 +15484,17 @@ SI
 SI
 SI
 SI
-SI
-SI
-SI
-SI
-SI
-SI
-Dn
-SI
-SI
-SI
-SI
+MA
+MA
+MA
+MA
+MA
+MA
+qk
+MA
+MA
+MA
+MA
 SI
 SI
 SI
@@ -12671,10 +15511,10 @@ SI
 SI
 SI
 SI
-SI
-SI
-SI
-XO
+MA
+MA
+MA
+qA
 bD
 Yf
 Yf
@@ -12687,31 +15527,31 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
+vT
+Gx
+YV
+vT
+eM
+eM
+eM
+Wi
+Tz
+Tz
+Tz
+Tz
+du
+Hw
+Hw
+sG
+Tz
+Tz
+UU
+eM
+WF
+Gs
+Gs
+Gs
+Il
 PD
 Fu
 ot
@@ -12720,9 +15560,9 @@ bl
 yh
 SR
 im
-SR
-bl
-ok
+eM
+Cm
+eM
 cO
 VI
 Nd
@@ -12733,9 +15573,9 @@ SR
 dg
 gx
 ZU
-ZU
+zB
 ZW
-ZU
+zB
 ZU
 ZU
 dx
@@ -12767,7 +15607,7 @@ ZU
 ZU
 ez
 ZU
-ZU
+SF
 ZU
 ZU
 ZU
@@ -12781,7 +15621,7 @@ ZU
 ZU
 YI
 cY
-ZU
+SF
 XO
 XO
 XO
@@ -12791,7 +15631,7 @@ WI
 WI
 WI
 XO
-XO
+np
 XO
 XO
 Za
@@ -12805,12 +15645,12 @@ XO
 XO
 XO
 XO
-SI
-Dn
-Za
-Za
-Za
-Za
+MA
+qk
+TC
+TC
+TC
+TC
 XO
 XO
 XO
@@ -12843,31 +15683,31 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
+vT
+ip
+hd
+Ts
+Tz
+Tz
+Tz
+UU
+eM
+di
+Pg
+eM
+KL
+vT
+vT
+yz
+eM
+eM
+BZ
+eM
+WF
+Gs
+Gs
+Gs
+Il
 ce
 ot
 by
@@ -12876,9 +15716,9 @@ SR
 yh
 SR
 wo
-GH
-SR
-SR
+mq
+BZ
+eM
 yh
 Lm
 by
@@ -12889,9 +15729,9 @@ SR
 DZ
 Mg
 ZU
-ZU
+zB
 ZW
-ZU
+zB
 ZU
 Xu
 Jg
@@ -12923,21 +15763,21 @@ ZU
 ZU
 kE
 ZU
+SF
+ZU
+ZU
+ZU
+gx
 ZU
 ZU
 ZU
 ZU
-ZU
-ZU
-ZU
-ZU
-ZU
-ZU
-ZU
+SF
+gx
 ez
 ZU
 ZU
-ZU
+SF
 ZU
 XO
 AW
@@ -12999,31 +15839,31 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
+vT
+vT
+vT
+WF
+eM
+eM
+eM
+BZ
+vT
+vT
+vT
+xW
+eM
+Rt
+fc
+eM
+eM
+eM
+BZ
+He
+WF
+Gs
+Gs
+Gs
+Il
 ce
 ce
 SR
@@ -13032,10 +15872,10 @@ SR
 yh
 PD
 Fu
-SR
-bl
-SR
-yh
+eM
+Cm
+FB
+vv
 SR
 bl
 im
@@ -13045,9 +15885,9 @@ Io
 Rj
 Rj
 Mg
-ZU
+zB
 ZW
-ZU
+zB
 Xu
 VB
 Jg
@@ -13088,12 +15928,12 @@ ZU
 Qd
 ZU
 ZU
+SF
 ZU
 ZU
 ZU
-ZU
-ZU
-ZU
+gx
+SF
 ZU
 WI
 WI
@@ -13158,28 +15998,28 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qy
+WF
+dL
+eM
+eM
+BZ
+vT
+xs
+vT
+cX
+eM
+eM
+eM
+eM
+eM
+eM
+BZ
+FB
+WF
+Gs
+Gs
+Gs
+Qo
 ce
 Sg
 SR
@@ -13188,9 +16028,9 @@ SR
 kl
 bM
 VI
-Nd
-SR
-wo
+eM
+BZ
+eM
 yh
 yh
 yh
@@ -13201,7 +16041,7 @@ cP
 Lx
 Rj
 ec
-ZU
+zB
 ZW
 eS
 dy
@@ -13263,7 +16103,7 @@ sk
 sx
 Pq
 Pq
-XU
+Kd
 DY
 DY
 gB
@@ -13314,28 +16154,28 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-qz
+WF
+eM
+eM
+eM
+BZ
+vT
+xs
+vT
+UR
+eM
+dL
+eM
+eM
+eM
+eM
+BZ
+eM
+WF
+Gs
+Gs
+Il
+bS
 Sg
 SR
 SR
@@ -13344,9 +16184,9 @@ SR
 cs
 bN
 Lm
-VI
-pk
-VI
+eM
+BZ
+eM
 Ho
 SR
 SR
@@ -13357,9 +16197,9 @@ KU
 EB
 dD
 gx
-ZU
+zB
 ZW
-ZU
+zB
 YI
 ft
 EB
@@ -13470,28 +16310,28 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-VU
+WF
+eM
+eM
+eM
+ns
+vT
+xs
+vT
+vT
+eM
+vT
+vT
+eM
+eM
+Gf
+BZ
+eM
+WF
+Gs
+Gs
+Il
+bP
 qT
 rf
 SR
@@ -13500,10 +16340,10 @@ cj
 ct
 cn
 bN
-Sg
-bN
-Sg
-SR
+eM
+BZ
+eM
+rf
 SR
 im
 SR
@@ -13513,9 +16353,9 @@ qT
 de
 ZU
 ZU
-ZU
+zB
 ZW
-ZU
+zB
 ZU
 dE
 de
@@ -13567,7 +16407,7 @@ eb
 SD
 Gw
 qc
-DY
+tx
 qQ
 RZ
 DY
@@ -13624,30 +16464,30 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-nM
+WF
+WF
+WF
+EP
+eM
+Wc
+BF
+vT
+xs
+xs
+vT
+eM
+vT
+vT
+eM
+eM
+eM
+BZ
+eM
+WF
+Gs
+Gs
+Il
+QZ
 KU
 rf
 SR
@@ -13656,9 +16496,9 @@ SR
 cs
 cn
 cn
-bN
-cn
-qT
+eM
+BZ
+eM
 rf
 SR
 SR
@@ -13669,9 +16509,9 @@ IC
 Bw
 EB
 BQ
-ZU
+zB
 ZW
-gx
+Ab
 ZU
 YI
 de
@@ -13780,41 +16620,41 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-qH
-TW
+WF
+eM
+EU
+eM
+Bf
+Bf
+BZ
+vT
+vT
+vT
+vT
+Bo
+eM
+eM
+eM
+eM
+dL
+BZ
+eM
+WF
+Gs
+Gs
+Il
+cc
+XP
 SR
 SR
 SR
 cj
 cv
 IC
-IC
-bT
-cn
-KU
+ci
+eM
+BZ
+eM
 rf
 SR
 SR
@@ -13825,9 +16665,9 @@ KU
 cY
 dE
 Sn
-ZU
+zB
 ZW
-ZU
+zB
 ZU
 fi
 de
@@ -13936,31 +16776,31 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-qy
-qH
-lG
+WF
+eM
+eM
+dL
+Gf
+eM
+BZ
+eM
+eM
+vT
+eM
+Fj
+Tz
+Tz
+Tz
+Tz
+Tz
+UU
+eM
+WF
+Gs
+Ae
+Qo
+cc
+bL
 bp
 SR
 bl
@@ -13968,9 +16808,9 @@ cj
 cw
 cm
 ci
-Xw
-Xw
-rf
+eM
+BZ
+eM
 SR
 Zb
 SR
@@ -13981,9 +16821,9 @@ PD
 XF
 Di
 eb
-ZU
+zB
 ZW
-ZU
+zB
 YI
 fz
 cY
@@ -14028,7 +16868,7 @@ dp
 gS
 dD
 ZU
-ZU
+gx
 ZU
 dx
 xa
@@ -14092,41 +16932,41 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
+WF
+Xh
+Xh
+eM
+eM
+eM
+HQ
+Xh
+eM
+EP
+eM
+eM
+eM
+eM
+eM
+eM
+eM
+BZ
+FB
+WF
+Il
 PD
 Nd
-Vb
-eY
+bJ
+eB
 SR
 SR
 bI
 XP
 cx
 QK
-cn
-qT
-Zt
-qT
+dF
+Bo
+BZ
+eM
 rf
 PI
 PI
@@ -14137,9 +16977,9 @@ Fu
 da
 DK
 ZU
-ZU
+zB
 ZW
-ZU
+zB
 Xu
 xP
 xP
@@ -14248,27 +17088,27 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
+WF
+MT
+eD
+eM
+eM
+eM
+nv
+MT
+PZ
+eC
+eM
+eM
+eM
+eM
+eM
+eM
+He
+BZ
+eM
+WF
+Il
 ce
 Lm
 Nd
@@ -14280,9 +17120,9 @@ bI
 Tu
 bL
 ci
-cm
-KU
-bT
+eM
+BZ
+eM
 SR
 SR
 SR
@@ -14293,9 +17133,9 @@ Lm
 DK
 ZU
 ZU
-ZU
+zB
 ZW
-ZU
+zB
 ZU
 RG
 fB
@@ -14404,27 +17244,27 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-re
-re
-re
-re
-qy
+WF
+eD
+eD
+eM
+He
+eM
+IK
+eD
+PZ
+eM
+eM
+dL
+eM
+eM
+eM
+eM
+eM
+BZ
+eM
+WF
+Qo
 ce
 PD
 by
@@ -14436,9 +17276,9 @@ Rh
 XP
 QZ
 QK
-QK
-SR
-SR
+eM
+BZ
+eM
 SR
 im
 bl
@@ -14449,9 +17289,9 @@ im
 ZU
 ZU
 ZU
-ZU
+zB
 ZW
-ez
+Ws
 ZU
 RG
 fS
@@ -14483,7 +17323,7 @@ ZU
 ZU
 ZU
 ZU
-ZU
+SF
 ZU
 ZU
 ZU
@@ -14560,26 +17400,26 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-lX
-pq
-TW
-bX
-lG
+WF
+BW
+BW
+eM
+eM
+eM
+QQ
+BW
+eM
+EP
+di
+Pg
+eM
+eM
+eM
+eM
+eM
+BZ
+eM
+WF
 PD
 by
 Sg
@@ -14592,9 +17432,9 @@ bR
 Io
 Rh
 XP
-im
-SR
-SR
+WO
+BZ
+eM
 SR
 SR
 SR
@@ -14605,9 +17445,9 @@ SR
 ZU
 ZU
 ZU
-ZU
+zB
 rP
-ZU
+zB
 RG
 fB
 Rj
@@ -14639,8 +17479,8 @@ ZU
 gx
 ZU
 ZU
-ZU
-ZU
+SF
+gx
 ZU
 ZU
 ZU
@@ -14716,26 +17556,26 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-qs
-bH
-qT
-Ir
-Zt
-XH
+WF
+Yh
+eM
+Fj
+Tz
+Tz
+IZ
+dL
+FB
+WF
+WF
+WF
+WF
+WF
+eM
+eM
+dL
+BZ
+eM
+WF
 ot
 Ho
 SR
@@ -14747,10 +17587,10 @@ cc
 Rh
 XP
 Ry
-SR
-SR
-SR
-SR
+eM
+eM
+BZ
+eM
 bN
 SR
 SR
@@ -14761,9 +17601,9 @@ PD
 XF
 ZU
 ZU
-ZU
+zB
 ZW
-ZU
+zB
 DZ
 Rj
 Rj
@@ -14872,41 +17712,41 @@ Yf
 Yf
 Yf
 Yf
+WF
+eM
+eM
+WB
+JF
+CX
+eM
+eM
+eM
+WF
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-re
-qy
-bH
-KU
-IC
-IC
-Zt
-Sg
+WF
+Bo
+eM
+eM
+BZ
+eM
+Xz
 SR
 SR
 SR
 SR
 SR
+dF
 Io
 ca
 Ry
 bS
 SR
-im
-SR
-SR
-qT
+WO
+eM
+BZ
+eM
 cm
 SR
 SR
@@ -14917,9 +17757,9 @@ VI
 Om
 XF
 ZU
-ZU
+zB
 ZW
-ZU
+zB
 Lx
 Ga
 Ga
@@ -15028,41 +17868,41 @@ Yf
 Yf
 Yf
 Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
-Yf
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
+WF
 Yf
 Yf
 qs
-lX
-pq
-WS
-TW
-KU
-cg
-bT
-SR
-im
-SR
-bP
-SR
-SR
-SR
-bJ
-XP
-SR
-SR
-SR
-SR
-cj
-IC
+WF
+LF
+eM
+eM
+BZ
+eM
+Tx
+eM
+WO
+eM
+eM
+eM
+EU
+eM
+eM
+eM
+eM
+eM
+LF
+eM
+BZ
+WF
 bT
 SR
 SR
@@ -15073,9 +17913,9 @@ by
 Di
 DK
 xa
-ZU
+zB
 ZW
-ZU
+zB
 gx
 ZU
 ZU
@@ -15197,28 +18037,28 @@ Yf
 Yf
 Yf
 qs
-bH
-lX
-eY
-SR
-SR
-SR
-SR
-SR
-SR
-Io
-eB
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-PD
-Nd
-QK
+WF
+NU
+Tz
+Tz
+HP
+Tz
+mV
+Tz
+Tz
+Tz
+Tz
+Tz
+Tz
+Tz
+Tz
+Tz
+Tz
+Tz
+HP
+Tz
+jX
+WF
 SR
 im
 SR
@@ -15229,9 +18069,9 @@ PD
 DK
 dw
 dw
-ZU
+zB
 ZW
-ez
+Ws
 ZU
 ZU
 ZU
@@ -15257,9 +18097,9 @@ Lx
 Mg
 dE
 Sn
-ZU
-ZU
-ZU
+SF
+SF
+SF
 dE
 Bw
 Bw
@@ -15353,28 +18193,28 @@ Yf
 Yf
 Yf
 qs
-bH
-bH
-SR
-bp
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-SR
-bl
-SR
-im
-we
-SR
-SR
-ok
-VI
-VI
-Ho
+WF
+eM
+eM
+dL
+eM
+eM
+pr
+eM
+eM
+eM
+eM
+eM
+dL
+eM
+WO
+jC
+eM
+eM
+DH
+WF
+WF
+WF
 SR
 SR
 SR
@@ -15387,7 +18227,7 @@ Rj
 dy
 ej
 ZW
-ZU
+zB
 fi
 ft
 EB
@@ -15509,13 +18349,13 @@ Yf
 Yf
 re
 qy
-bH
-XH
-SR
-SR
-SR
-PD
-Nd
+WF
+Xz
+ev
+xZ
+Xz
+WF
+WF
 aX
 bN
 bN
@@ -15541,9 +18381,9 @@ Tu
 dh
 Ga
 dD
-ZU
+zB
 ZW
-ZU
+zB
 dE
 Bw
 fz
@@ -15669,7 +18509,7 @@ XH
 SR
 SR
 SR
-PD
+SR
 VI
 VI
 Nd
@@ -15697,9 +18537,9 @@ Tu
 dh
 XJ
 ZU
-ZU
+zB
 ZW
-ZU
+zB
 fi
 Bw
 ft
@@ -15853,9 +18693,9 @@ Zt
 dj
 dx
 ZU
-ZU
+zB
 ZW
-BQ
+tp
 dE
 cY
 dE
@@ -16009,9 +18849,9 @@ QK
 Xu
 Jg
 eb
-ZU
+zB
 ZW
-ZU
+zB
 ZU
 Xu
 xP
@@ -16165,9 +19005,9 @@ Ir
 EB
 do
 dj
-ZU
+zB
 ZW
-ZU
+zB
 ZU
 Xu
 xP
@@ -16321,9 +19161,9 @@ IC
 de
 do
 ZU
-ZU
+zB
 ZW
-ZU
+zB
 DZ
 Mg
 fT
@@ -16477,9 +19317,9 @@ cg
 ME
 xb
 Yp
-ym
+Td
 gG
-ym
+Td
 EM
 fC
 dC
@@ -16633,9 +19473,9 @@ Tu
 fx
 Qw
 MM
-ym
+Td
 gG
-ym
+Td
 YS
 KK
 Iy
@@ -16661,9 +19501,9 @@ dC
 dC
 hb
 Yp
-ym
-ym
-ym
+ij
+ij
+ij
 YS
 gT
 ZB
@@ -16789,9 +19629,9 @@ qT
 Uk
 YK
 ym
-ym
+Td
 gG
-ym
+Td
 ym
 fF
 UL
@@ -16945,9 +19785,9 @@ IC
 Uk
 dz
 ym
-ym
+Td
 gG
-ym
+Td
 ym
 ym
 Wj
@@ -17094,7 +19934,7 @@ ci
 rf
 SR
 SR
-SR
+im
 SR
 cn
 QK
@@ -17279,7 +20119,7 @@ ym
 ym
 ym
 ym
-ym
+Be
 ym
 gX
 ym
@@ -17294,7 +20134,7 @@ li
 lx
 li
 li
-li
+VC
 li
 li
 lx
@@ -17423,7 +20263,7 @@ Td
 Qs
 Td
 Td
-Td
+Qs
 fE
 Td
 Td
@@ -17456,7 +20296,7 @@ my
 my
 my
 my
-my
+JW
 my
 my
 my
@@ -17750,7 +20590,7 @@ Td
 Td
 Td
 Td
-Td
+Qs
 Td
 Td
 Td
@@ -17758,7 +20598,7 @@ Td
 xE
 my
 my
-my
+JW
 my
 my
 my
@@ -17873,7 +20713,7 @@ pk
 Ho
 SR
 SR
-SR
+im
 SR
 SR
 wo
@@ -17891,7 +20731,7 @@ Be
 ym
 ym
 ym
-ym
+Be
 ym
 ym
 ym
@@ -17923,7 +20763,7 @@ li
 li
 li
 li
-li
+VC
 li
 li
 li
@@ -18851,7 +21691,7 @@ Xj
 Je
 ym
 ym
-ym
+Be
 ym
 Wj
 fh
@@ -19165,7 +22005,7 @@ Uk
 ym
 cl
 ym
-ym
+Be
 dT
 Wj
 SA
@@ -19791,7 +22631,7 @@ YW
 hb
 Yp
 ym
-ym
+Be
 ym
 ym
 Ps
@@ -20230,7 +23070,7 @@ Ps
 ym
 ym
 ym
-ym
+Be
 ym
 ym
 ym
@@ -20257,7 +23097,7 @@ YW
 YW
 hb
 JX
-ym
+Be
 ym
 ym
 ym
@@ -20546,7 +23386,7 @@ ST
 ST
 ym
 ym
-ym
+Be
 ym
 ym
 ym
@@ -21026,7 +23866,7 @@ ym
 ym
 gT
 gq
-ym
+Be
 ym
 ym
 fF
@@ -21174,7 +24014,7 @@ ZB
 gq
 ym
 ym
-ym
+Be
 ym
 xb
 MM
@@ -21201,7 +24041,7 @@ JX
 cl
 ym
 ym
-ym
+Be
 ym
 ym
 ym
@@ -21344,7 +24184,7 @@ fx
 ym
 cl
 ym
-ym
+Be
 ym
 ym
 QL
@@ -21362,7 +24202,7 @@ ym
 ym
 ym
 ym
-ym
+Be
 ym
 ym
 ym
@@ -21650,7 +24490,7 @@ ym
 ym
 ym
 ym
-ym
+Be
 ym
 ym
 ym
@@ -21664,7 +24504,7 @@ TH
 ym
 ym
 ym
-ym
+Be
 ym
 ZP
 Ps
@@ -21966,7 +24806,7 @@ Je
 dT
 ym
 ym
-ym
+Be
 ym
 ym
 ym
@@ -22129,7 +24969,7 @@ ym
 Qw
 Yp
 zQ
-ym
+Be
 ym
 YK
 KK
@@ -22296,7 +25136,7 @@ ZB
 fx
 Ps
 ym
-ym
+Be
 ym
 fF
 fW
@@ -22755,7 +25595,7 @@ fp
 TJ
 TV
 YT
-YT
+eK
 JD
 Bn
 xN
@@ -23348,7 +26188,7 @@ YT
 fo
 YT
 YT
-YT
+eK
 YT
 Tr
 dq
@@ -24121,7 +26961,7 @@ SR
 SR
 wo
 YT
-YT
+eK
 Bz
 YT
 YT
@@ -24301,7 +27141,7 @@ fy
 lc
 YT
 YT
-YT
+eK
 YT
 YT
 YT
@@ -24427,7 +27267,7 @@ Xw
 Xw
 rf
 SR
-SR
+im
 SR
 ok
 VI
@@ -24661,10 +27501,10 @@ qG
 qm
 Ee
 tH
-WI
-WI
-WI
-WI
+Bt
+Bt
+Bt
+Bt
 GY
 Gu
 bh
@@ -24777,39 +27617,39 @@ XO
 XO
 XO
 km
-WI
-WI
-WI
-XO
-XO
-XO
-XO
-WI
-WI
-WI
-XO
-XO
-Za
-XO
-XO
-XO
-WI
-WI
-WI
-XO
-km
-XO
-XO
-XO
-WI
-WI
-WI
-WI
-WI
-of
-WI
-WI
-XO
+Bt
+Bt
+Bt
+qA
+qA
+qA
+qA
+Bt
+Bt
+Bt
+qA
+qA
+TC
+qA
+qA
+qA
+Bt
+Bt
+Bt
+qA
+GO
+qA
+qA
+qA
+Bt
+Bt
+Bt
+Bt
+Bt
+Cq
+Bt
+Bt
+qA
 tH
 Ck
 nH
@@ -24817,10 +27657,10 @@ hh
 vM
 fu
 tH
-WI
-WI
-WI
-WI
+Bt
+Bt
+Bt
+Bt
 GZ
 GY
 Gu
@@ -24904,7 +27744,7 @@ YT
 AU
 Bz
 AU
-YT
+eK
 YT
 fR
 gw
@@ -24933,39 +27773,39 @@ XO
 Za
 XO
 XO
-WI
-WI
-XO
-Za
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-WI
-WI
-WI
-WI
-WI
-XO
-Za
-XO
-XO
-WI
+Bt
+Bt
+qA
+TC
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+Bt
+Bt
+Bt
+Bt
+Bt
+qA
+TC
+qA
+qA
+Bt
 OD
-WI
-WI
-WI
-WI
-XO
-XO
-XO
+Bt
+Bt
+Bt
+Bt
+qA
+qA
+qA
 tH
 CC
 jU
@@ -24973,8 +27813,8 @@ UH
 po
 rn
 tH
-WI
-WI
+Bt
+Bt
 xM
 Gu
 bh
@@ -25089,39 +27929,39 @@ XO
 XO
 XO
 XO
-OO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-Za
-XO
-XO
-XO
-WI
-WI
-WI
-XO
-XO
-XO
-XO
-XO
+Tl
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+qA
+TC
+qA
+qA
+qA
+Bt
+Bt
+Bt
+qA
+qA
+qA
+qA
+qA
 tH
 Mh
 kK
@@ -25129,8 +27969,8 @@ rh
 Mh
 tH
 tH
-WI
-WI
+Bt
+Bt
 GZ
 GY
 BL
@@ -25245,48 +28085,48 @@ XO
 Za
 Za
 Za
-Za
-Za
-oO
-Za
-Za
-Za
-Za
-XO
-XO
-Za
-Za
-oO
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
+TC
+TC
+wf
+TC
+TC
+TC
+TC
+qA
+qA
+TC
+TC
+wf
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
 Uq
-SI
-SI
-SI
-XO
-XO
-XO
-XO
-np
-SI
-SI
-SI
-SI
-SI
-SI
-FV
-SI
-XO
-XO
-XO
-WI
-WI
+MA
+MA
+MA
+qA
+qA
+qA
+qA
+oM
+MA
+MA
+MA
+MA
+MA
+MA
+io
+MA
+qA
+qA
+qA
+Bt
+Bt
 AK
 KV
 xM
@@ -25401,49 +28241,49 @@ vy
 vy
 vy
 vy
-vy
-vy
-vy
-vy
-vy
-vy
-vy
-vy
-vy
-vy
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
 Ns
-vy
-vy
-vy
-vy
-vy
-vy
-vy
-vy
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
 Yv
 Ow
-vy
-vy
-vy
-vy
-vy
-vy
-vy
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
 Ns
-vy
-vy
-vy
-vy
-vy
-vy
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
 qf
-SI
-Za
-Za
-Za
-XO
-XO
-WI
+MA
+TC
+TC
+TC
+qA
+qA
+Bt
 BL
 xM
 bD
@@ -25513,7 +28353,7 @@ SR
 SR
 SR
 SR
-SR
+im
 SR
 SR
 SR
@@ -25527,7 +28367,7 @@ AU
 AU
 dI
 eI
-AU
+XA
 AU
 AU
 YT
@@ -25557,11 +28397,11 @@ YT
 XO
 np
 Za
-Za
-Za
-oO
-Za
-Za
+TC
+TC
+wf
+TC
+TC
 lA
 lA
 wN
@@ -25593,12 +28433,12 @@ wN
 wN
 wN
 lA
-XO
-XO
-XO
-Za
-XO
-XO
+qA
+qA
+qA
+TC
+qA
+qA
 AK
 KV
 xM
@@ -25713,11 +28553,11 @@ fo
 WI
 XO
 XO
-XO
-XO
-XO
-Za
-lW
+qA
+qA
+qA
+TC
+kn
 Jm
 jO
 Hh
@@ -25749,14 +28589,14 @@ mh
 jO
 XO
 iK
-XO
-XO
-Lv
-XO
-Za
-XO
-WI
-WI
+qA
+qA
+fI
+qA
+TC
+qA
+Bt
+Bt
 BL
 xM
 Yf
@@ -25869,10 +28709,10 @@ Tc
 WI
 XO
 XO
-XO
-XO
-XO
-Za
+qA
+qA
+qA
+TC
 pR
 GI
 Vc
@@ -25905,13 +28745,13 @@ wm
 of
 XO
 iK
-XO
-WI
-Lv
-XO
-Za
-XO
-XO
+qA
+Bt
+fI
+qA
+TC
+qA
+qA
 AK
 NT
 xM
@@ -26025,11 +28865,11 @@ gt
 fZ
 XO
 WI
-XO
-Lv
-Za
-Za
-WI
+qA
+fI
+TC
+TC
+Bt
 Wu
 oP
 Zx
@@ -26061,12 +28901,12 @@ Lv
 Zx
 XO
 iK
-XO
-XO
-Lv
-XO
-XO
-XO
+qA
+qA
+fI
+qA
+qA
+qA
 AK
 zy
 NT
@@ -26181,11 +29021,11 @@ oW
 RN
 WI
 WI
-WI
-XO
-XO
-Za
-XO
+Bt
+qA
+qA
+TC
+qA
 Wu
 CP
 vf
@@ -26217,13 +29057,13 @@ Hh
 vf
 jO
 En
-Za
-XO
-XO
-XO
-Za
-XO
-WI
+TC
+qA
+qA
+qA
+TC
+qA
+Bt
 GZ
 KV
 bF
@@ -26337,11 +29177,11 @@ Yf
 qs
 WI
 WI
-WI
-XO
-XO
-Za
-XO
+Bt
+qA
+qA
+TC
+qA
 Wu
 oP
 je
@@ -26374,11 +29214,11 @@ vf
 QO
 WA
 pT
-XO
-Za
-XO
-XO
-WI
+qA
+TC
+qA
+qA
+Bt
 lX
 lG
 Gu
@@ -26493,12 +29333,12 @@ Yf
 qs
 WI
 WI
-XO
-Lv
-XO
-XO
-XO
-qM
+qA
+fI
+qA
+qA
+qA
+CZ
 wa
 oP
 je
@@ -26529,11 +29369,11 @@ QO
 wm
 oP
 En
-Za
-Za
-XO
-XO
-WI
+TC
+TC
+qA
+qA
+Bt
 lX
 WS
 eY
@@ -26633,7 +29473,7 @@ YT
 YT
 YT
 YT
-YT
+eK
 YT
 YT
 YT
@@ -26649,12 +29489,12 @@ Yf
 qs
 WI
 WI
-XO
-XO
-np
-XO
-Za
-qM
+qA
+qA
+oM
+qA
+TC
+CZ
 nI
 nI
 nI
@@ -26685,10 +29525,10 @@ nI
 oP
 oP
 iK
-XO
-XO
-XO
-WI
+qA
+qA
+qA
+Bt
 lX
 WS
 eY
@@ -26772,7 +29612,7 @@ XP
 Sg
 SR
 SR
-SR
+im
 YT
 dq
 YT
@@ -26805,11 +29645,11 @@ Yf
 qs
 WI
 XO
-XO
-XO
-XO
-XO
-XO
+qA
+qA
+qA
+qA
+qA
 ZS
 oP
 oP
@@ -26841,9 +29681,9 @@ oP
 Hh
 mI
 iK
-XO
-XO
-WI
+qA
+qA
+Bt
 lX
 WS
 eY
@@ -26997,7 +29837,7 @@ oP
 of
 wa
 En
-XO
+qA
 aG
 pq
 WS
@@ -27393,7 +30233,7 @@ QK
 SR
 SR
 SR
-SR
+im
 SR
 SR
 Zy

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -54,10 +54,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "an" = (
 /obj/structure/xenoautopsy/tank/broken,
 /obj/effect/decal/cleanable/blood/xeno,
@@ -533,10 +530,7 @@
 /turf/open/floor/podhatch/floor{
 	icon_state = "bcircuitoff"
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "bX" = (
 /turf/closed/ice_rock/singlePart,
 /area/icy_caves/caves)
@@ -583,10 +577,7 @@
 /obj/effect/decal/cleanable/blood/xtracks,
 /obj/effect/ai_node,
 /turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "ci" = (
 /turf/closed/ice/thin/junction,
 /area/icy_caves/caves/northern)
@@ -627,10 +618,7 @@
 	dir = 1
 	},
 /turf/open/floor/mainship/tcomms,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "cp" = (
 /obj/item/lightstick/anchored,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
@@ -668,10 +656,7 @@
 /turf/closed/ice/corner{
 	dir = 4
 	},
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "cv" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/ice/thin/junction{
@@ -697,18 +682,12 @@
 "cD" = (
 /obj/item/tool/surgery/circular_saw,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "cE" = (
 /turf/open/floor/tile/purple/whitepurplecorner{
 	dir = 1
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "cF" = (
 /obj/structure/lattice,
 /obj/structure/monorail{
@@ -718,10 +697,7 @@
 	dir = 5
 	},
 /turf/open/shuttle/escapepod/plain,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "cI" = (
 /turf/closed/ice/thin/single,
 /area/icy_caves/caves/northern)
@@ -740,10 +716,7 @@
 "cL" = (
 /obj/structure/monorail,
 /turf/open/floor/mainship_hull,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "cM" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/ice,
@@ -772,10 +745,7 @@
 /turf/open/floor/tile/white/warningstripe{
 	dir = 1
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "cW" = (
 /obj/machinery/door/poddoor/mainship/indestructible{
 	dir = 2
@@ -789,10 +759,7 @@
 	pixel_x = 16
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "cY" = (
 /turf/closed/ice/thin/corner{
 	dir = 8
@@ -818,15 +785,13 @@
 	},
 /area/icy_caves/caves/west)
 "df" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/ice/thin/corner{
-	dir = 8
-	},
-/area/icy_caves/caves/west)
+/turf/closed/ice/thin/corner,
+/area/icy_caves/outpost/LZ2)
 "dg" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/ice,
-/area/icy_caves/caves/west)
+/turf/closed/ice/thin/corner{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "dh" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 1
@@ -838,10 +803,7 @@
 	pixel_x = 16
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "dj" = (
 /turf/closed/ice,
 /area/icy_caves/caves/west)
@@ -877,20 +839,14 @@
 	dir = 8
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "du" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "dw" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 4
@@ -953,27 +909,18 @@
 "dL" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "dN" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "dO" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "dQ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -1019,10 +966,7 @@
 "ea" = (
 /obj/effect/landmark/corpsespawner/pmc,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "eb" = (
 /turf/closed/ice/end,
 /area/icy_caves/caves/west)
@@ -1034,10 +978,7 @@
 "ed" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "eg" = (
 /obj/machinery/light{
 	dir = 8
@@ -1119,20 +1060,14 @@
 "ev" = (
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "ew" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "ex" = (
 /obj/machinery/door/airlock/mainship/secure/locked/free_access{
 	name = "\improper Mining Storage"
@@ -1142,10 +1077,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "ey" = (
 /turf/closed/ice,
 /area/icy_caves/caves/crashed_ship)
@@ -1175,17 +1107,11 @@
 	name = "Canteen"
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "eD" = (
 /obj/structure/table,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "eF" = (
 /obj/effect/landmark/weed_node,
 /obj/effect/ai_node,
@@ -1234,19 +1160,13 @@
 /area/icy_caves/caves/east)
 "eM" = (
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "eN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "eO" = (
 /obj/structure/table/reinforced,
 /obj/item/tool/surgery/scalpel/laser3,
@@ -1254,19 +1174,13 @@
 /turf/open/floor/tile/purple/whitepurplecorner{
 	dir = 8
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "eP" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "eR" = (
 /turf/closed/ice/end{
 	dir = 1
@@ -1279,10 +1193,7 @@
 "eT" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "eU" = (
 /obj/machinery/light{
 	dir = 8
@@ -1342,28 +1253,19 @@
 /obj/item/storage/firstaid/regular,
 /obj/item/storage/firstaid/fire,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "fc" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "fd" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/powercell,
 /obj/effect/spawner/random/powercell,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "fe" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/tech_supply,
@@ -1374,10 +1276,7 @@
 /obj/item/clothing/glasses/welding,
 /obj/machinery/light/small,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "ff" = (
 /obj/structure/rack,
 /obj/structure/rack,
@@ -1385,10 +1284,7 @@
 /obj/effect/spawner/random/toolbox,
 /obj/item/clothing/glasses/welding,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "fg" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/tool,
@@ -1396,10 +1292,7 @@
 /obj/effect/spawner/random/tool,
 /obj/item/storage/belt/utility/full,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "fh" = (
 /turf/closed/ice/thin/junction,
 /area/icy_caves/caves/south)
@@ -1437,10 +1330,7 @@
 "fq" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ1)
 "fs" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -1505,10 +1395,7 @@
 	dir = 10;
 	icon_state = "bright_clean2"
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "fE" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
@@ -1529,10 +1416,7 @@
 /area/icy_caves/caves/south)
 "fI" = (
 /turf/closed/ice/thin,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "fK" = (
 /turf/closed/ice/thin/corner{
 	dir = 1
@@ -1686,10 +1570,7 @@
 "gK" = (
 /obj/structure/largecrate/supply/explosives,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "gL" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -1707,10 +1588,7 @@
 	dir = 5
 	},
 /turf/open/floor/mainship/cargo,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "gN" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -1725,19 +1603,13 @@
 	dir = 10;
 	icon_state = "bright_clean2"
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "gQ" = (
 /obj/structure/dropship_piece/one/corner/middleright,
 /turf/open/floor/mainship_hull/dir{
 	dir = 10
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "gS" = (
 /turf/closed/ice/thin/end{
 	dir = 8
@@ -1764,10 +1636,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "hb" = (
 /turf/closed/ice/junction,
 /area/icy_caves/caves/south)
@@ -1779,10 +1648,7 @@
 	dir = 10
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "he" = (
 /turf/closed/ice/junction{
 	dir = 4
@@ -1897,10 +1763,7 @@
 /turf/open/floor/tile/purple/whitepurple{
 	dir = 4
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "hI" = (
 /obj/effect/landmark/xeno_resin_door,
 /obj/effect/ai_node,
@@ -1931,10 +1794,7 @@
 /obj/machinery/vending/medical,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "hU" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/ice,
@@ -1947,10 +1807,7 @@
 	dir = 8
 	},
 /turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "hX" = (
 /obj/effect/landmark/excavation_site_spawner,
 /obj/effect/ai_node,
@@ -1991,10 +1848,7 @@
 "in" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall/unmeltable,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "io" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -2002,17 +1856,11 @@
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "ip" = (
 /obj/structure/closet/l3closet/janitor,
 /turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "iu" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -2024,17 +1872,11 @@
 /obj/structure/cable,
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "iD" = (
 /obj/structure/largecrate/random/barrel/yellow,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "iG" = (
 /turf/open/floor/tile/dark/yellow2{
 	dir = 4
@@ -2050,18 +1892,12 @@
 	dir = 2
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "iN" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "iQ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -2073,10 +1909,7 @@
 /turf/open/floor/mainship_hull/dir{
 	dir = 8
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "iT" = (
 /turf/closed/ice/end{
 	dir = 1
@@ -2098,16 +1931,10 @@
 "jc" = (
 /obj/machinery/door/poddoor/mainship,
 /turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "jd" = (
 /turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "je" = (
 /turf/closed/ice/thin/corner{
 	dir = 1
@@ -2117,29 +1944,20 @@
 /obj/item/stool,
 /obj/effect/decal/cleanable/vomit,
 /turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "jk" = (
 /obj/structure/table/mainship,
 /obj/item/tool/surgery/cautery,
 /obj/item/tool/surgery/retractor,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "jo" = (
 /obj/effect/ai_node,
 /turf/open/floor/prison{
 	dir = 10;
 	icon_state = "bright_clean2"
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "jt" = (
 /obj/machinery/floodlight/landing,
 /obj/effect/decal/warning_stripes,
@@ -2174,10 +1992,7 @@
 "jC" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "jE" = (
 /obj/structure/table/reinforced,
 /obj/effect/landmark/dropship_console_spawn_lz1,
@@ -2206,10 +2021,7 @@
 /turf/open/floor/mainship_hull/dir{
 	dir = 8
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "jM" = (
 /obj/effect/landmark/corpsespawner/miner{
 	corpseback = /obj/item/storage/backpack/satchel/norm;
@@ -2273,17 +2085,11 @@
 	dir = 9
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "jY" = (
 /obj/machinery/door/airlock/mainship/security,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "ka" = (
 /obj/structure/fence,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -2306,10 +2112,7 @@
 "kf" = (
 /obj/machinery/computer3/server/rack,
 /turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "kg" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/mining/east)
@@ -2337,13 +2140,10 @@
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside)
 "kn" = (
-/turf/closed/ice/thin/end{
-	dir = 1
+/turf/closed/ice/thin/corner{
+	dir = 8
 	},
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "ko" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -2495,10 +2295,7 @@
 	dir = 10;
 	icon_state = "bright_clean2"
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "kS" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -2532,10 +2329,7 @@
 	dir = 4
 	},
 /turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "lc" = (
 /turf/closed/ice/straight{
 	dir = 4
@@ -2617,19 +2411,13 @@
 	dir = 9
 	},
 /turf/open/shuttle/escapepod/plain,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "lv" = (
 /obj/machinery/door/poddoor/two_tile_ver,
 /turf/open/floor/mainship/cargo/arrow{
 	dir = 4
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "lx" = (
 /obj/machinery/light{
 	dir = 8
@@ -2639,10 +2427,7 @@
 "lA" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "lB" = (
 /obj/structure/table,
 /obj/structure/paper_bin,
@@ -2657,10 +2442,7 @@
 /turf/closed/ice/junction{
 	dir = 1
 	},
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "lD" = (
 /obj/structure/table,
 /turf/open/floor/tile/dark/brown2{
@@ -2700,10 +2482,7 @@
 	dir = 10;
 	icon_state = "bright_clean2"
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "lP" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
@@ -2721,10 +2500,7 @@
 	dir = 8
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "lS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
@@ -2757,10 +2533,7 @@
 /turf/open/floor/mainship_hull/dir{
 	dir = 6
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "mb" = (
 /turf/closed/ice/thin/intersection,
 /area/icy_caves/outpost/LZ1)
@@ -2784,15 +2557,12 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "mh" = (
 /turf/closed/ice/thin/junction{
 	dir = 4
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "mi" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/lv624/lazarus/console)
@@ -2808,10 +2578,7 @@
 	pixel_x = -16
 	},
 /turf/open/floor/mainship/tcomms,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "mk" = (
 /obj/docking_port/stationary/marine_dropship/lz2,
 /turf/open/floor/plating,
@@ -2839,10 +2606,7 @@
 "mq" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "mr" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1;
@@ -2868,10 +2632,7 @@
 	dir = 10;
 	icon_state = "bright_clean2"
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "mv" = (
 /turf/closed/ice_rock/corners,
 /area/space)
@@ -2883,10 +2644,7 @@
 /turf/open/floor/tile/purple/whitepurple{
 	dir = 9
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "mx" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 8
@@ -3010,10 +2768,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "mY" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -3026,10 +2781,7 @@
 "mZ" = (
 /obj/effect/decal/cleanable/blood/xtracks,
 /turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "nb" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -3119,10 +2871,7 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "nu" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -3135,18 +2884,12 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "nw" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "nx" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -3159,34 +2902,22 @@
 /obj/docking_port/stationary/crashmode,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "nB" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "nD" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "nF" = (
 /obj/structure/janitorialcart,
 /turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "nH" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -3200,10 +2931,7 @@
 "nK" = (
 /obj/structure/largecrate/random/barrel/green,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "nL" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/outside/center)
@@ -3296,10 +3024,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/mainship/tcomms,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "or" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /obj/structure/cable,
@@ -3323,10 +3048,7 @@
 	},
 /obj/structure/xenoautopsy/tank,
 /turf/open/shuttle/dropship/seven,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "oA" = (
 /obj/machinery/landinglight/ds1{
 	dir = 1
@@ -3358,12 +3080,10 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
 "oM" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/turf/closed/ice_rock/singlePart{
+	dir = 5
+	},
+/area/icy_caves/outpost/LZ2)
 "oO" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -3379,10 +3099,7 @@
 	dir = 10;
 	icon_state = "bright_clean2"
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "oR" = (
 /obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -3392,10 +3109,7 @@
 	dir = 10;
 	icon_state = "bright_clean2"
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "oS" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
@@ -3406,10 +3120,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "oU" = (
 /obj/item/tool/pickaxe,
 /obj/structure/rack,
@@ -3434,10 +3145,7 @@
 /turf/closed/shuttle/dropship3/transparent{
 	icon_state = "97"
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "pf" = (
 /obj/effect/landmark/corpsespawner/miner{
 	corpseback = /obj/item/storage/backpack/satchel/norm;
@@ -3464,10 +3172,7 @@
 	dir = 8
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "pj" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
@@ -3477,10 +3182,7 @@
 /area/icy_caves/caves/northern)
 "pl" = (
 /turf/closed/wall/r_wall/unmeltable,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "pm" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/cable,
@@ -3489,10 +3191,7 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "po" = (
 /turf/open/floor/tile/dark/purple2{
 	dir = 4
@@ -3508,10 +3207,7 @@
 /obj/structure/cable,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "ps" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/dmg1,
@@ -3526,10 +3222,7 @@
 	},
 /obj/item/clothing/head/warning_cone,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "pw" = (
 /obj/machinery/light{
 	dir = 8
@@ -3577,10 +3270,7 @@
 /obj/structure/cable,
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "pF" = (
 /obj/structure/rack,
 /obj/item/weapon/gun/smg/m25,
@@ -3602,17 +3292,11 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "pN" = (
 /obj/structure/janitorialcart,
 /turf/open/floor/plating/plating_catwalk,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "pO" = (
 /obj/item/ammo_casing,
 /turf/open/floor/tile/dark,
@@ -3627,33 +3311,21 @@
 /obj/effect/spawner/random/powercell,
 /obj/item/explosive/plastique,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "pR" = (
 /obj/effect/landmark/fob_sentry,
 /turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "pS" = (
 /obj/machinery/power/apc/drained{
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "pT" = (
 /obj/effect/landmark/fob_sentry,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "pU" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
@@ -3677,10 +3349,7 @@
 "pZ" = (
 /obj/item/paper/crumpled/bloody,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "qa" = (
 /turf/open/floor/mainship_hull/dir{
 	dir = 8
@@ -3716,10 +3385,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "qg" = (
 /obj/structure/closet/secure_closet/miner,
 /turf/open/floor/plating,
@@ -3743,15 +3409,10 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
 "qk" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
+/turf/closed/ice/corner{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "ql" = (
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
@@ -3817,11 +3478,10 @@
 /turf/closed/ice_rock/single,
 /area/icy_caves/caves)
 "qA" = (
-/turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/turf/closed/ice/corner{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "qB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor/tile/dark,
@@ -3939,10 +3599,7 @@
 /turf/open/floor/mainship_hull/dir{
 	dir = 5
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "rh" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/machinery/door/airlock/multi_tile/mainship/research{
@@ -3956,10 +3613,7 @@
 /turf/open/floor/tile/purple/whitepurple{
 	dir = 1
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "rl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8
@@ -3980,10 +3634,7 @@
 /turf/closed/ice/thin/end{
 	dir = 4
 	},
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ1)
 "rq" = (
 /obj/structure/closet/fireaxecabinet,
 /turf/closed/wall/r_wall,
@@ -4330,10 +3981,7 @@
 /obj/structure/bed/chair,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "sH" = (
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
@@ -4374,10 +4022,7 @@
 	dir = 5
 	},
 /turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "tb" = (
 /obj/structure/sink,
 /obj/machinery/light{
@@ -4452,15 +4097,12 @@
 	dir = 2
 	},
 /turf/closed/ice/junction,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "tw" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 1
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "tx" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
@@ -4496,10 +4138,7 @@
 /turf/open/floor/mainship/cargo/arrow{
 	dir = 4
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "tH" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/research)
@@ -4554,10 +4193,7 @@
 /obj/structure/table/mainship,
 /obj/machinery/computer/med_data,
 /turf/open/floor/mainship/mono,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "tU" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -4631,18 +4267,12 @@
 /turf/closed/shuttle/dropship3/transparent{
 	icon_state = "96"
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "un" = (
 /obj/effect/decal/cleanable/blood/xtracks,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "uo" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -4668,10 +4298,7 @@
 "uu" = (
 /obj/effect/decal/cleanable/blood/xtracks,
 /turf/open/floor/plating/plating_catwalk,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "uv" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/grilledcheese,
@@ -4689,10 +4316,7 @@
 /turf/open/floor/tile/purple/whitepurple{
 	dir = 5
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "uy" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -4734,10 +4358,7 @@
 /turf/closed/ice/straight{
 	dir = 4
 	},
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "uN" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/tile/dark,
@@ -4746,10 +4367,7 @@
 /turf/closed/shuttle/dropship3/transparent{
 	icon_state = "98"
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "uP" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -4782,10 +4400,7 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "uX" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -4822,10 +4437,7 @@
 	dir = 8
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "vf" = (
 /turf/closed/ice/thin/intersection,
 /area/icy_caves/outpost/outside)
@@ -4879,10 +4491,7 @@
 "vr" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice/thin/straight,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ1)
 "vs" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -4958,29 +4567,22 @@
 "vR" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice/thin/end,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ1)
 "vS" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
 "vT" = (
-/turf/closed/wall/r_wall,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/turf/closed/ice/junction{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "vV" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
 	},
 /turf/closed/ice/corner,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "vX" = (
 /obj/item/flashlight,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -5016,12 +4618,10 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/northern)
 "wf" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "wg" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/freezer,
@@ -5029,10 +4629,7 @@
 "wh" = (
 /obj/structure/morgue/crematorium,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "wi" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/tile/dark/green2{
@@ -5067,17 +4664,11 @@
 	dir = 10;
 	icon_state = "bright_clean2"
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "ws" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "wu" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	dir = 1;
@@ -5114,10 +4705,7 @@
 	dir = 10;
 	icon_state = "bright_clean2"
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "wH" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/tile/dark/brown2,
@@ -5137,18 +4725,12 @@
 "wN" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "wO" = (
 /turf/open/floor/mainship/red{
 	dir = 4
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "wP" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -5184,10 +4766,7 @@
 	dir = 5
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "wZ" = (
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
@@ -5255,10 +4834,7 @@
 	dir = 8
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "xr" = (
 /obj/machinery/mineral/stacking_machine,
 /obj/machinery/conveyor{
@@ -5267,11 +4843,10 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/refinery)
 "xs" = (
-/turf/closed/ice_rock/corners,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/turf/closed/ice/thin/end{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ1)
 "xu" = (
 /obj/structure/cargo_container/green,
 /turf/open/floor/plating,
@@ -5326,10 +4901,7 @@
 "xS" = (
 /obj/machinery/computer3/server,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "xT" = (
 /turf/open/floor/tile/dark/green2/corner{
 	dir = 4
@@ -5345,10 +4917,7 @@
 "xW" = (
 /obj/structure/largecrate/supply/explosives/mortar_flare,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "xX" = (
 /turf/closed/ice/thin/straight,
 /area/icy_caves/caves/south)
@@ -5358,10 +4927,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "ya" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/ice_rock/single,
@@ -5372,10 +4938,7 @@
 	dir = 10;
 	icon_state = "bright_clean2"
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "yd" = (
 /obj/structure/monorail,
 /obj/machinery/door/poddoor/mainship/indestructible{
@@ -5401,10 +4964,7 @@
 	dir = 10;
 	icon_state = "bright_clean2"
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "yj" = (
 /obj/structure/closet/crate/secure/weapon,
 /obj/item/weapon/gun/smg/m25,
@@ -5439,10 +4999,7 @@
 "yz" = (
 /obj/structure/bed/chair,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "yB" = (
 /turf/closed/ice/thin/junction{
 	dir = 8
@@ -5480,10 +5037,7 @@
 	dir = 1
 	},
 /turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "yJ" = (
 /obj/structure/closet/crate/construction,
 /obj/item/cell/hyper,
@@ -5526,17 +5080,11 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "ze" = (
 /obj/structure/largecrate/random/case/double,
 /turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "zh" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -5566,10 +5114,7 @@
 /turf/closed/ice/corner{
 	dir = 8
 	},
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "zm" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/drained,
@@ -5599,17 +5144,11 @@
 /turf/open/floor/tile/white/warningstripe{
 	dir = 6
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "zu" = (
 /obj/machinery/door/airlock/multi_tile/mainship/secdoor,
 /turf/open/floor/mainship/red/full,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "zw" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
@@ -5724,10 +5263,7 @@
 	name = "\improper Lambda Lab Secure Storage"
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Aa" = (
 /obj/item/storage/box/flashbangs,
 /obj/item/storage/box/m94,
@@ -5793,10 +5329,7 @@
 	dir = 2
 	},
 /turf/open/floor/plating/ground/snow,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ1)
 "Ar" = (
 /obj/structure/closet/crate/secure/ammo,
 /obj/item/ammo_magazine/smg/m25,
@@ -5896,10 +5429,7 @@
 /area/icy_caves/outpost/refinery)
 "AJ" = (
 /turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "AK" = (
 /turf/closed/ice/end{
 	dir = 1
@@ -5923,19 +5453,13 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "AR" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/tile/purple/whitepurple{
 	dir = 1
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "AS" = (
 /obj/machinery/power/geothermal,
 /obj/machinery/light/small{
@@ -6006,10 +5530,7 @@
 /turf/open/floor/tile/dark/green2{
 	dir = 8
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Bi" = (
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/prison/kitchen,
@@ -6029,10 +5550,7 @@
 	dir = 1
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Bq" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/prison/kitchen,
@@ -6041,11 +5559,12 @@
 /turf/open/floor/podhatch/floor,
 /area/icy_caves/outpost/engineering)
 "Bt" = (
-/turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "Bu" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -6081,20 +5600,14 @@
 /turf/open/floor/podhatch/floor{
 	icon_state = "bcircuitoff"
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "BF" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "BI" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
@@ -6108,10 +5621,7 @@
 /turf/open/floor/mainship_hull/dir{
 	dir = 4
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "BL" = (
 /turf/closed/ice/end{
 	dir = 8
@@ -6125,20 +5635,14 @@
 /turf/closed/shuttle/dropship3{
 	icon_state = "50"
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "BO" = (
 /obj/machinery/door/airlock/multi_tile/secure{
 	dir = 2
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "BP" = (
 /turf/closed/ice/junction{
 	dir = 4
@@ -6179,10 +5683,7 @@
 	dir = 8
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "BX" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -6206,17 +5707,11 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Ch" = (
 /obj/machinery/computer3/server/rack,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Ci" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
@@ -6236,18 +5731,12 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Cq" = (
 /turf/closed/ice/thin/end{
 	dir = 4
 	},
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "Cs" = (
 /obj/item/ammo_casing,
 /turf/open/floor/wood,
@@ -6273,19 +5762,13 @@
 /turf/open/floor/mainship_hull/dir{
 	dir = 10
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "CI" = (
 /obj/machinery/door/poddoor/two_tile_ver,
 /turf/open/floor/mainship/cargo/arrow{
 	dir = 8
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "CN" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/caves/south)
@@ -6316,19 +5799,13 @@
 "CX" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "CZ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
 	},
 /turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "Dc" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno/up,
 /turf/open/floor/tile/dark,
@@ -6373,10 +5850,7 @@
 	dir = 10;
 	icon_state = "bright_clean2"
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Dn" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -6392,10 +5866,7 @@
 	dir = 10;
 	icon_state = "bright_clean2"
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Dp" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/singleEnd{
@@ -6445,10 +5916,7 @@
 "DF" = (
 /obj/structure/largecrate/random/secure,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "DG" = (
 /obj/effect/decal/cleanable/blood/writing,
 /turf/open/floor/tile/dark,
@@ -6475,10 +5943,7 @@
 /turf/closed/ice/thin/corner{
 	dir = 8
 	},
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ1)
 "DM" = (
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 10
@@ -6493,17 +5958,11 @@
 /turf/open/floor/mainship_hull/dir{
 	dir = 4
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "DV" = (
 /obj/structure/mopbucket,
 /turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "DW" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -6518,10 +5977,7 @@
 /turf/closed/ice_rock/corners{
 	dir = 9
 	},
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ1)
 "DY" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
@@ -6535,10 +5991,7 @@
 	dir = 2
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Eb" = (
 /obj/effect/landmark/excavation_site_spawner,
 /obj/effect/ai_node,
@@ -6582,10 +6035,7 @@
 /obj/structure/table/mainship,
 /obj/item/storage/toolbox/electrical,
 /turf/open/floor/plating/plating_catwalk,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "El" = (
 /obj/structure/table/reinforced,
 /obj/effect/landmark/dropship_console_spawn_lz2,
@@ -6596,10 +6046,7 @@
 	dir = 2
 	},
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "Ep" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
@@ -6629,17 +6076,11 @@
 /obj/effect/decal/cleanable/mucus,
 /obj/structure/table,
 /turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Ey" = (
 /obj/effect/landmark/fob_sentry_rebel,
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ1)
 "Ez" = (
 /obj/structure/bed,
 /turf/open/floor/wood,
@@ -6688,26 +6129,17 @@
 "EO" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice/thin/junction,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ1)
 "EP" = (
 /obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "EQ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice/thin/corner{
 	dir = 4
 	},
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ1)
 "ES" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -6719,17 +6151,11 @@
 	dir = 8
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "EX" = (
 /obj/structure/largecrate/supply/floodlights,
 /turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "EZ" = (
 /obj/item/ammo_casing,
 /obj/structure/cable,
@@ -6771,19 +6197,13 @@
 "Fj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Fk" = (
 /obj/structure/bed/chair/dropship/passenger{
 	dir = 4
 	},
 /turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Fm" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -6804,10 +6224,7 @@
 "Fq" = (
 /obj/effect/spawner/gibspawner/human,
 /turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Fr" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/tile/dark/purple2{
@@ -6847,27 +6264,18 @@
 /turf/open/floor/tile/white/warningstripe{
 	dir = 4
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Fy" = (
 /turf/open/floor/freezer,
 /area/icy_caves/outpost/dorms)
 "FB" = (
 /obj/machinery/light,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "FE" = (
 /obj/effect/decal/cleanable/blood/xtracks,
 /turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "FF" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -6917,10 +6325,7 @@
 	id = "tcomms"
 	},
 /turf/open/floor/mainship_hull/dir,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "FU" = (
 /obj/structure/cargo_container/ch_red,
 /turf/open/floor/plating,
@@ -6964,10 +6369,7 @@
 "Gf" = (
 /obj/effect/spawner/gibspawner/human,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Gh" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 4
@@ -6978,18 +6380,12 @@
 /obj/structure/table/mainship,
 /obj/structure/cable,
 /turf/open/floor/mainship/tcomms,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Gj" = (
 /obj/machinery/computer/operating,
 /obj/structure/table/reinforced,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Gk" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -7033,10 +6429,7 @@
 /obj/structure/mopbucket,
 /obj/machinery/power/apc/drained,
 /turf/open/floor/plating/plating_catwalk,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Gz" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/singleT,
@@ -7055,10 +6448,7 @@
 	dir = 4
 	},
 /turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "GF" = (
 /turf/closed/wall,
 /area/icy_caves/caves/west)
@@ -7073,10 +6463,7 @@
 /turf/closed/ice/thin/corner{
 	dir = 1
 	},
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "GK" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
@@ -7113,10 +6500,7 @@
 "GO" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "GQ" = (
 /obj/machinery/light{
 	dir = 8
@@ -7125,10 +6509,7 @@
 	dir = 10;
 	icon_state = "bright_clean2"
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "GR" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -7146,10 +6527,7 @@
 "GU" = (
 /obj/structure/barricade/guardrail,
 /turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "GV" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -7180,10 +6558,7 @@
 "He" = (
 /obj/effect/decal/cleanable/blood/xtracks,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Hf" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/dorms)
@@ -7210,17 +6585,11 @@
 	dir = 10;
 	icon_state = "bright_clean2"
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Hl" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ1)
 "Hm" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -7248,10 +6617,7 @@
 "Hw" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/closed/wall/r_wall,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "HA" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -7289,10 +6655,7 @@
 /obj/structure/cable,
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ1)
 "HJ" = (
 /obj/machinery/vending/MarineMed/Blood,
 /turf/open/floor/tile/dark/green2{
@@ -7303,10 +6666,7 @@
 /turf/open/floor/mainship_hull/dir{
 	dir = 6
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "HM" = (
 /obj/item/ammo_casing,
 /turf/open/floor/tile/dark/brown2/corner{
@@ -7326,10 +6686,7 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "HQ" = (
 /obj/structure/bed/chair/comfy{
 	dir = 4
@@ -7338,10 +6695,7 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "HR" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -7363,19 +6717,13 @@
 	dir = 1
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "HU" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
 /turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "HV" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/corners{
@@ -7408,10 +6756,7 @@
 	dir = 6
 	},
 /turf/open/floor/mainship/cargo,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Ig" = (
 /obj/machinery/light{
 	dir = 4
@@ -7427,10 +6772,7 @@
 "Ij" = (
 /obj/structure/largecrate/random/barrel/green,
 /turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Ik" = (
 /obj/structure/table,
 /obj/item/storage/box/flashbangs,
@@ -7442,12 +6784,6 @@
 "Il" = (
 /turf/closed/ice_rock/southWall,
 /area/icy_caves/caves/northern)
-"Im" = (
-/turf/open/floor/plating/ground/snow,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
 "In" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -7484,10 +6820,7 @@
 /turf/open/floor/mainship_hull/dir{
 	dir = 8
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Iv" = (
 /obj/structure/ore_box,
 /turf/open/floor/plating,
@@ -7546,10 +6879,7 @@
 "II" = (
 /obj/item/paper/crumpled/bloody/csheet,
 /turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "IJ" = (
 /obj/machinery/vending/security,
 /turf/open/floor/tile/dark/red2{
@@ -7562,10 +6892,7 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "IO" = (
 /obj/structure/closet/crate/construction,
 /obj/item/stack/sheet/metal/medium_stack,
@@ -7584,10 +6911,7 @@
 /turf/open/floor/mainship_hull/dir{
 	dir = 4
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "IR" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
@@ -7605,10 +6929,7 @@
 /turf/open/floor/tile/purple/whitepurple{
 	dir = 4
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "IX" = (
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/tile/dark,
@@ -7616,20 +6937,14 @@
 "IY" = (
 /obj/item/tool/surgery/hemostat,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "IZ" = (
 /obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Je" = (
 /turf/closed/ice/thin/end{
 	dir = 8
@@ -7669,16 +6984,10 @@
 /turf/closed/ice/thin/junction{
 	dir = 4
 	},
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "Jn" = (
 /turf/open/floor/plating/plating_catwalk,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Jo" = (
 /obj/machinery/door/airlock/mainship/engineering/free_access{
 	dir = 1;
@@ -7694,10 +7003,7 @@
 /turf/closed/ice/end{
 	dir = 1
 	},
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "Jq" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/tile/dark,
@@ -7750,10 +7056,7 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "JH" = (
 /obj/structure/table,
 /obj/item/reagent_containers/spray/pepper,
@@ -7795,10 +7098,7 @@
 	dir = 9
 	},
 /turf/open/shuttle/escapepod/plain,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "JS" = (
 /obj/structure/closet/crate/freezer/rations,
 /turf/open/floor/tile/dark,
@@ -7865,7 +7165,7 @@
 /area/icy_caves/outpost/dorms)
 "Ko" = (
 /turf/closed/ice_rock/singleEnd,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "Kp" = (
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
@@ -7926,10 +7226,7 @@
 "KJ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/snow,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ1)
 "KK" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 1
@@ -7940,10 +7237,7 @@
 	dir = 1
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "KM" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 9
@@ -7959,10 +7253,7 @@
 /turf/closed/shuttle/dropship3{
 	icon_state = "43"
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "KS" = (
 /turf/open/floor/tile/dark/red2{
 	dir = 5
@@ -7988,10 +7279,7 @@
 /turf/open/floor/tile/white/warningstripe{
 	dir = 4
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Lb" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/tile/dark,
@@ -8040,16 +7328,10 @@
 	on = 1
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Lp" = (
 /turf/open/floor/tile/white/warningstripe,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Lq" = (
 /obj/machinery/power/geothermal,
 /obj/machinery/light/small,
@@ -8061,17 +7343,11 @@
 /turf/open/floor/tile/purple/whitepurple{
 	dir = 4
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Ls" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Lt" = (
 /obj/effect/landmark/corpsespawner/miner{
 	corpseback = null;
@@ -8094,10 +7370,7 @@
 "Lw" = (
 /obj/structure/closet/l3closet/virology,
 /turf/open/floor/plating/plating_catwalk,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Lx" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 10
@@ -8134,10 +7407,7 @@
 	on = 1
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "LH" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/colonist,
@@ -8184,10 +7454,7 @@
 /turf/closed/ice/thin/end{
 	dir = 8
 	},
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ1)
 "LQ" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -8247,19 +7514,13 @@
 /turf/open/floor/mainship_hull/dir{
 	dir = 8
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Mf" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/mainship/red/full,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Mg" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 5
@@ -8309,17 +7570,11 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "Ms" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "Mt" = (
 /obj/item/ammo_casing,
 /turf/open/floor/tile/dark/red2{
@@ -8338,41 +7593,26 @@
 /obj/machinery/optable,
 /obj/effect/decal/cleanable/blood/xtracks,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Mw" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ1)
 "Mx" = (
 /obj/machinery/power/apc/drained{
 	dir = 4
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Mz" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice/corner{
 	dir = 4
 	},
 /area/icy_caves/outpost/LZ1)
-"MA" = (
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
 "MB" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -8438,10 +7678,7 @@
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/cheeseburger,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "MV" = (
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
@@ -8460,20 +7697,14 @@
 /turf/open/floor/tile/purple/whitepurple{
 	dir = 4
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "MY" = (
 /obj/item/reagent_containers/spray/pepper,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 6
 	},
 /turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "MZ" = (
 /obj/machinery/door/airlock/mainship/command/free_access{
 	dir = 1;
@@ -8525,13 +7756,10 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ1)
 "Np" = (
 /turf/closed/ice/intersection,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "Nq" = (
 /turf/closed/ice/end{
 	dir = 4
@@ -8545,10 +7773,7 @@
 /obj/structure/cable,
 /obj/effect/landmark/fob_sentry,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "Nt" = (
 /obj/item/ammo_magazine/smg/m25,
 /turf/open/floor/tile/dark,
@@ -8622,10 +7847,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "NN" = (
 /obj/structure/filingcabinet,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -8662,20 +7884,14 @@
 	dir = 10
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "NW" = (
 /obj/structure/barricade/guardrail{
 	dir = 4
 	},
 /obj/structure/xenoautopsy/tank/escaped,
 /turf/open/shuttle/dropship/seven,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Ob" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/tile/dark,
@@ -8693,10 +7909,7 @@
 	dir = 10
 	},
 /turf/open/shuttle/escapepod/plain,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Oe" = (
 /obj/structure/table,
 /turf/open/floor/tile/dark/brown2{
@@ -8747,19 +7960,13 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "Ox" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
 	},
 /turf/open/floor/mainship/tcomms,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Oy" = (
 /obj/docking_port/mobile/crashmode/bigbury,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -8776,10 +7983,7 @@
 "OD" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "OE" = (
 /obj/effect/landmark/corpsespawner/colonist,
 /turf/open/floor/tile/dark/brown2,
@@ -8821,10 +8025,7 @@
 /area/icy_caves/outpost/outside)
 "OP" = (
 /turf/open/floor/mainship/red/full,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "OQ" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/prison/kitchen,
@@ -8840,10 +8041,7 @@
 /obj/structure/dropship_piece/one/corner/middleleft,
 /obj/structure/dropship_piece/one/corner/middleright,
 /turf/open/floor/mainship_hull/dir,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Pd" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/security)
@@ -8852,10 +8050,7 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Pi" = (
 /turf/closed/ice/corner{
 	dir = 8
@@ -8881,10 +8076,7 @@
 /turf/open/floor/tile/white/warningstripe{
 	dir = 5
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Pq" = (
 /turf/open/floor/tile/dark/brown2{
 	dir = 8
@@ -8923,10 +8115,7 @@
 /turf/closed/ice/junction{
 	dir = 8
 	},
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "PD" = (
 /turf/closed/ice/corner{
 	dir = 4
@@ -8957,10 +8146,7 @@
 	welded = 1
 	},
 /turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "PO" = (
 /obj/machinery/light,
 /turf/open/floor/tile/dark,
@@ -9007,10 +8193,7 @@
 /area/icy_caves/outpost/office)
 "PZ" = (
 /turf/open/floor/tile/dark/green2,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Qa" = (
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
@@ -9033,10 +8216,7 @@
 /obj/structure/prop/mainship/sensor_computer2,
 /obj/structure/cable,
 /turf/open/floor/mainship/tcomms,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Qh" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 6
@@ -9058,10 +8238,7 @@
 	dir = 8
 	},
 /turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Qo" = (
 /turf/closed/ice_rock/corners{
 	dir = 9
@@ -9071,7 +8248,7 @@
 /turf/closed/ice_rock/singleEnd{
 	dir = 8
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "Qq" = (
 /turf/closed/ice/corner{
 	dir = 4
@@ -9105,10 +8282,7 @@
 	dir = 4
 	},
 /turf/open/floor/mainship/red/full,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "QF" = (
 /obj/structure/largecrate/random/case/small,
 /turf/open/floor/plating,
@@ -9160,10 +8334,7 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "QR" = (
 /obj/machinery/light,
 /turf/open/floor/tile/dark/brown2,
@@ -9276,10 +8447,7 @@
 	dir = 8
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Ru" = (
 /obj/structure/table/woodentable,
 /obj/structure/paper_bin,
@@ -9299,20 +8467,14 @@
 	dir = 5
 	},
 /turf/open/shuttle/escapepod/plain,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Rx" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/blood,
 /turf/open/floor/tile/purple/whitepurple{
 	dir = 4
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Ry" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 8
@@ -9327,7 +8489,7 @@
 /area/icy_caves/outpost/security)
 "RA" = (
 /turf/closed/ice_rock/singleT,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "RB" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/tile/dark/brown2{
@@ -9375,10 +8537,7 @@
 	dir = 4
 	},
 /turf/open/floor/mainship_hull,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "RN" = (
 /turf/closed/ice_rock/corners{
 	dir = 5
@@ -9392,7 +8551,7 @@
 /area/icy_caves/outpost/dorms)
 "RQ" = (
 /turf/closed/ice_rock/fourway,
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "RS" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/southWall,
@@ -9426,10 +8585,7 @@
 /turf/open/floor/mainship/cargo/arrow{
 	dir = 8
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Sf" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 1
@@ -9438,10 +8594,7 @@
 	dir = 10;
 	icon_state = "bright_clean2"
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Sg" = (
 /turf/closed/ice/end{
 	dir = 4
@@ -9493,10 +8646,7 @@
 /turf/open/floor/mainship_hull/dir{
 	dir = 4
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Sv" = (
 /turf/closed/ice_rock/singleT{
 	dir = 4
@@ -9575,10 +8725,7 @@
 /turf/open/floor/tile/purple/whitepurple{
 	dir = 1
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Tb" = (
 /turf/closed/ice_rock/singleT{
 	dir = 1
@@ -9599,17 +8746,7 @@
 /turf/closed/ice_rock/singleEnd{
 	dir = 8
 	},
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
-"Th" = (
-/obj/effect/ai_node,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ1)
 "Tj" = (
 /obj/machinery/light{
 	dir = 8
@@ -9623,19 +8760,13 @@
 "Tl" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "Tm" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
 /turf/closed/ice/thin/straight,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ1)
 "Tr" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/ice,
@@ -9646,20 +8777,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Tt" = (
 /obj/machinery/door/poddoor/shutters/mainship{
 	dir = 2;
 	name = "Monorail Passage Door"
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Tu" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 1
@@ -9679,17 +8804,11 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Tz" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "TB" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/effect/decal/warning_stripes/thin{
@@ -9700,21 +8819,12 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
-"TC" = (
-/turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
 "TD" = (
 /obj/machinery/camera{
 	dir = 9
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "TE" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
@@ -9738,10 +8848,7 @@
 /area/icy_caves/caves/east)
 "TK" = (
 /turf/open/floor/mainship/red,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "TL" = (
 /obj/structure/cargo_container/gorg{
 	dir = 4
@@ -9755,19 +8862,13 @@
 /obj/effect/spawner/gibspawner/human,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "TQ" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ1)
 "TR" = (
 /obj/structure/table/flipped,
 /turf/open/floor/tile/dark/red2{
@@ -9777,10 +8878,7 @@
 "TT" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ1)
 "TU" = (
 /obj/effect/decal/warning_stripes/thin,
 /obj/docking_port/mobile/crashmode/bigbury,
@@ -9854,10 +8952,7 @@
 	dir = 2
 	},
 /turf/closed/ice/intersection,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "Uk" = (
 /turf/closed/ice/thin/end,
 /area/icy_caves/caves/south)
@@ -9872,20 +8967,14 @@
 	dir = 1
 	},
 /turf/closed/ice/intersection,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "Uq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4
 	},
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "Us" = (
 /turf/closed/ice_rock/singleT{
 	dir = 8
@@ -9894,10 +8983,7 @@
 "Ut" = (
 /obj/effect/spawner/gibspawner/human,
 /turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Uu" = (
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/LZ1)
@@ -9968,10 +9054,7 @@
 "UR" = (
 /obj/structure/largecrate/supply/medicine/medivend,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "US" = (
 /obj/structure/table,
 /obj/item/clothing/suit/chef/classic,
@@ -9986,10 +9069,7 @@
 "UU" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "UV" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 8
@@ -10014,10 +9094,7 @@
 /obj/structure/dropship_piece/one/corner/middleright,
 /obj/structure/dropship_piece/one/corner/middleleft,
 /turf/open/floor/mainship_hull/dir,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Vb" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 10
@@ -10027,7 +9104,7 @@
 /turf/closed/ice/thin/junction{
 	dir = 1
 	},
-/area/icy_caves/outpost/outside)
+/area/icy_caves/outpost/LZ2)
 "Vd" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/ice_rock/corners,
@@ -10054,10 +9131,7 @@
 "Vj" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Vk" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/snow,
@@ -10075,10 +9149,7 @@
 	dir = 10
 	},
 /turf/open/floor/mainship/cargo,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Vr" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -10090,27 +9161,18 @@
 	dir = 5
 	},
 /turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Vt" = (
 /turf/open/floor/mainship_hull/dir{
 	dir = 9
 	},
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Vu" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice/thin/corner{
 	dir = 1
 	},
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ1)
 "Vx" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -10144,9 +9206,6 @@
 /obj/structure/largecrate/random/secure,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
-"VG" = (
-/turf/closed/ice/thin/junction,
-/area/icy_caves/outpost/outside)
 "VI" = (
 /turf/closed/ice/intersection,
 /area/icy_caves/caves/northern)
@@ -10179,10 +9238,7 @@
 	dir = 9
 	},
 /turf/open/floor/mainship/cargo,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "VM" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/security)
@@ -10218,10 +9274,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "VT" = (
 /turf/closed/ice/thin/straight,
 /area/icy_caves/outpost/LZ1)
@@ -10253,10 +9306,7 @@
 /obj/item/shard,
 /obj/effect/decal/cleanable/blood/xtracks,
 /turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Wa" = (
 /obj/structure/largecrate/supply/explosives,
 /obj/item/explosive/plastique,
@@ -10275,40 +9325,25 @@
 	name = "Canteen"
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Wd" = (
 /obj/effect/decal/cleanable/blood/xtracks,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "We" = (
 /turf/closed/ice/junction{
 	dir = 1
 	},
 /area/icy_caves/outpost/outside/center)
-"Wg" = (
-/turf/closed/ice/thin/straight,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
 "Wi" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Wj" = (
 /turf/closed/ice/thin/end{
 	dir = 4
@@ -10318,24 +9353,15 @@
 /obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Wp" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Wr" = (
 /obj/machinery/door/airlock/mainship/maint,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Ws" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
@@ -10351,10 +9377,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "Ww" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -10368,19 +9391,13 @@
 /area/icy_caves/caves/west)
 "Wy" = (
 /turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "WA" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
 	},
 /turf/closed/ice/thin/end,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "WB" = (
 /obj/machinery/vending/dinnerware,
 /obj/machinery/camera/autoname/mainship/dropship_one{
@@ -10388,10 +9405,7 @@
 	pixel_x = 16
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "WD" = (
 /turf/open/floor/plating/ground/snow,
 /area/icy_caves/outpost/LZ1)
@@ -10405,10 +9419,7 @@
 "WF" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "WG" = (
 /turf/closed/ice_rock/corners,
 /area/icy_caves/caves/west)
@@ -10421,17 +9432,11 @@
 "WO" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "WP" = (
 /obj/effect/decal/cleanable/vomit,
 /turf/open/floor/tile/purple/whitepurplefull,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "WQ" = (
 /turf/closed/ice/thin/end{
 	dir = 8
@@ -10464,10 +9469,7 @@
 /obj/structure/cable,
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "WX" = (
 /obj/machinery/computer3/laptop,
 /obj/structure/table/reinforced,
@@ -10475,10 +9477,7 @@
 	dir = 1
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "WY" = (
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/medbay)
@@ -10505,10 +9504,7 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Xi" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -10586,18 +9582,12 @@
 /obj/structure/dropship_piece/one/front,
 /obj/structure/monorail,
 /turf/open/floor/mainship_hull,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Xz" = (
 /obj/structure/window/framed/colony/reinforced,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "XA" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
@@ -10605,10 +9595,7 @@
 "XD" = (
 /obj/item/shard,
 /turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "XF" = (
 /turf/closed/ice/corner,
 /area/icy_caves/caves/west)
@@ -10649,10 +9636,7 @@
 	},
 /obj/structure/xenoautopsy/tank/alien,
 /turf/open/shuttle/dropship/seven,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "XM" = (
 /obj/structure/bed/chair,
 /obj/effect/landmark/corpsespawner/colonist,
@@ -10693,10 +9677,7 @@
 /turf/closed/ice/thin/junction{
 	dir = 1
 	},
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ1)
 "XU" = (
 /turf/open/floor/tile/dark/brown2/corner{
 	dir = 1
@@ -10742,10 +9723,7 @@
 "Yh" = (
 /obj/machinery/power/apc/drained,
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Yi" = (
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/tile/dark/green2{
@@ -10763,10 +9741,7 @@
 	dir = 5
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Ym" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/swat,
@@ -10789,20 +9764,14 @@
 /turf/closed/ice/thin/junction{
 	dir = 8
 	},
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ1)
 "Yv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "Yw" = (
 /obj/machinery/landinglight/ds1/delayone{
 	dir = 8
@@ -10840,10 +9809,7 @@
 	dir = 6
 	},
 /turf/open/shuttle/escapepod/plain,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "YF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -10856,10 +9822,7 @@
 	dir = 2
 	},
 /turf/open/floor/plating/ground/snow/layer2,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ1)
 "YI" = (
 /turf/closed/ice/thin/end{
 	dir = 1
@@ -10892,10 +9855,7 @@
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "YQ" = (
 /turf/closed/wall/r_wall/unmeltable,
 /area/space)
@@ -10918,10 +9878,7 @@
 	on = 1
 	},
 /turf/open/floor/plating/plating_catwalk,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "YW" = (
 /turf/closed/ice,
 /area/icy_caves/caves/south)
@@ -10992,10 +9949,7 @@
 	dir = 8
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "Zm" = (
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/LZ1)
@@ -11066,10 +10020,7 @@
 "ZE" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/open/floor/plating/ground/snow/layer0,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ1)
 "ZF" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -11110,20 +10061,14 @@
 	dir = 1
 	},
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/mining{
-	icon_state = "bluenew";
-	name = "can build here"
-	})
+/area/icy_caves/outpost/LZ2)
 "ZU" = (
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
 "ZV" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/plating/mainship,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 "ZW" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -11147,10 +10092,7 @@
 	dir = 2
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern{
-	icon_state = "bluenew";
-	name = "Monorail & research"
-	})
+/area/icy_caves/caves/northern)
 
 (1,1,1) = {"
 YQ
@@ -11505,10 +10447,10 @@ WF
 WF
 WF
 WF
-vT
-vT
-vT
-vT
+dF
+dF
+dF
+dF
 Yf
 Yf
 Yf
@@ -11664,7 +10606,7 @@ kY
 Vj
 AJ
 eO
-vT
+dF
 Yf
 Yf
 Yf
@@ -11820,7 +10762,7 @@ Ex
 II
 AJ
 kf
-vT
+dF
 Yf
 Yf
 Yf
@@ -11976,7 +10918,7 @@ Fq
 AJ
 AJ
 kf
-vT
+dF
 Yf
 Yf
 Yf
@@ -12132,7 +11074,7 @@ AJ
 MY
 gZ
 yH
-vT
+dF
 Yf
 Yf
 Yf
@@ -12288,7 +11230,7 @@ AJ
 HU
 AJ
 Lr
-vT
+dF
 Yf
 Yf
 Yf
@@ -12366,7 +11308,7 @@ MH
 MH
 MH
 DX
-kn
+AB
 zi
 TM
 UE
@@ -12412,7 +11354,7 @@ Qg
 mj
 GQ
 yb
-vT
+dF
 Ls
 eM
 EU
@@ -12421,7 +11363,7 @@ eM
 EU
 DF
 nK
-vT
+dF
 eM
 EU
 eM
@@ -12438,13 +11380,13 @@ Yf
 WF
 EP
 EP
-vT
+dF
 AJ
 AJ
 HU
 AJ
 GE
-vT
+dF
 Yf
 Yf
 Yf
@@ -12519,8 +11461,8 @@ WI
 MH
 MH
 MH
-Bt
-Bt
+Uu
+Uu
 DX
 DX
 Sh
@@ -12568,7 +11510,7 @@ op
 Ox
 yi
 Dm
-vT
+dF
 eM
 eM
 eM
@@ -12577,7 +11519,7 @@ He
 eM
 eM
 iD
-vT
+dF
 eM
 eM
 eM
@@ -12594,26 +11536,26 @@ WF
 WF
 eM
 He
-vT
+dF
 EP
 eM
 YP
 EP
-vT
-vT
-vT
-vT
-vT
-vT
-vT
-vT
-vT
-vT
-vT
-vT
-vT
-vT
-vT
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
 Yf
 Yf
 Yf
@@ -12675,10 +11617,10 @@ WI
 WI
 WI
 WI
-Bt
-Bt
+Uu
+Uu
 DX
-Im
+WD
 YH
 TM
 UE
@@ -12763,13 +11705,13 @@ EU
 eM
 LF
 eM
-vT
+dF
 eM
 Mx
 NM
 xo
 pP
-vT
+dF
 bD
 Yf
 Yf
@@ -12831,10 +11773,10 @@ WI
 WI
 WI
 WI
-Bt
-Bt
-Bt
-Im
+Uu
+Uu
+Uu
+WD
 YH
 TM
 uw
@@ -12919,13 +11861,13 @@ eM
 eM
 BZ
 eM
-vT
+dF
 dL
 eM
 ev
 eM
 fb
-vT
+dF
 bD
 Yf
 Yf
@@ -12988,9 +11930,9 @@ WI
 WI
 WI
 fq
-Bt
-Bt
-Bt
+Uu
+Uu
+Uu
 Tm
 TM
 iJ
@@ -13081,7 +12023,7 @@ eM
 ix
 eN
 fd
-vT
+dF
 bD
 Yf
 Yf
@@ -13143,10 +12085,10 @@ WI
 WI
 WI
 WI
-Bt
-Bt
-Bt
-Bt
+Uu
+Uu
+Uu
+Uu
 YH
 TM
 bU
@@ -13237,7 +12179,7 @@ Tz
 ew
 eP
 fe
-vT
+dF
 bD
 Yf
 Yf
@@ -13299,10 +12241,10 @@ MH
 qs
 WI
 WI
-Bt
-Bt
-Bt
-Wg
+Uu
+Uu
+Uu
+VT
 Tf
 Tb
 XW
@@ -13348,7 +12290,7 @@ fD
 yi
 Do
 wq
-vT
+dF
 Bo
 eM
 eM
@@ -13357,7 +12299,7 @@ eM
 He
 eM
 eM
-vT
+dF
 eM
 dL
 eM
@@ -13387,13 +12329,13 @@ eM
 eM
 eM
 eM
-vT
+dF
 dO
 ea
 WW
 eT
 ff
-vT
+dF
 bD
 Yf
 Yf
@@ -13455,10 +12397,10 @@ Yf
 Yf
 MH
 WI
-Bt
-Bt
-Bt
-Wg
+Uu
+Uu
+Uu
+VT
 Tf
 Ml
 XW
@@ -13499,12 +12441,12 @@ pl
 pl
 pl
 pl
-vT
+dF
 wO
 yi
 Hj
 kR
-vT
+dF
 eM
 eM
 dL
@@ -13513,7 +12455,7 @@ eM
 eM
 eM
 FB
-vT
+dF
 gK
 cX
 eM
@@ -13527,29 +12469,29 @@ ev
 BO
 WF
 VS
-vT
-vT
-vT
-vT
-vT
+dF
+dF
+dF
+dF
+dF
 eM
 YP
-vT
-vT
-vT
-vT
-vT
+dF
+dF
+dF
+dF
+dF
 Wr
-vT
-vT
-vT
-vT
+dF
+dF
+dF
+dF
 nD
 ed
 nB
 eM
 fg
-vT
+dF
 bD
 Yf
 Yf
@@ -13611,10 +12553,10 @@ Yf
 Yf
 Yf
 MH
-Bt
-Bt
-Bt
-Wg
+Uu
+Uu
+Uu
+VT
 Tm
 Uu
 Vk
@@ -13650,29 +12592,29 @@ YQ
 "}
 (17,1,1) = {"
 YQ
-mv
-xs
-xs
-xs
-xs
-vT
+Gs
+Gs
+Gs
+Gs
+Gs
+dF
 jY
-vT
+dF
 EP
 EP
-vT
+dF
 pu
-vT
-vT
-vT
+dF
+dF
+dF
 eM
 VL
 Vq
 eM
-vT
-vT
-vT
-vT
+dF
+dF
+dF
+dF
 BZ
 eM
 WF
@@ -13683,29 +12625,29 @@ eM
 eM
 eM
 AQ
-vT
+dF
 Gs
 Gs
 Gs
-vT
+dF
 eM
 BZ
-vT
+dF
 DV
 EX
 jd
 jd
 jd
-vT
+dF
 Gs
 Il
-vT
-vT
-vT
+dF
+dF
+dF
 ex
-vT
-vT
-vT
+dF
+dF
+dF
 bh
 Yf
 Yf
@@ -13767,10 +12709,10 @@ Yf
 Yf
 qs
 qs
-Bt
-Bt
-Bt
-Bt
+Uu
+Uu
+Uu
+Uu
 TQ
 Uu
 bU
@@ -13811,7 +12753,7 @@ YQ
 pl
 pl
 pl
-vT
+dF
 OP
 OP
 OP
@@ -13820,15 +12762,15 @@ OP
 OP
 Mf
 OP
-vT
-vT
+dF
+dF
 Se
 CI
-vT
-vT
+dF
+dF
 Vt
 CH
-vT
+dF
 mg
 eM
 WF
@@ -13839,11 +12781,11 @@ eM
 pZ
 IY
 BZ
-vT
+dF
 Gs
 Gs
 Gs
-vT
+dF
 eM
 Wi
 Ts
@@ -13852,7 +12794,7 @@ ZV
 Vs
 Jn
 Jn
-vT
+dF
 Gs
 Il
 bI
@@ -13923,10 +12865,10 @@ MH
 MH
 WI
 MH
-Bt
-qA
-qA
-qA
+Uu
+UE
+UE
+UE
 TQ
 UE
 XW
@@ -13995,20 +12937,20 @@ eM
 cD
 eM
 pL
-vT
+dF
 Gs
 Gs
 Gs
-vT
+dF
 Lo
 UU
-vT
+dF
 nF
 mZ
 PN
 Lw
 Lw
-vT
+dF
 Gs
 Il
 bR
@@ -14079,10 +13021,10 @@ WI
 WI
 WI
 WI
-Bt
-Bt
-qA
-qA
+Uu
+Uu
+UE
+UE
 TQ
 WD
 XW
@@ -14151,20 +13093,20 @@ eM
 Gf
 Mv
 ns
-vT
-vT
-vT
-vT
-vT
+dF
+dF
+dF
+dF
+dF
 eM
 BZ
-vT
-vT
-vT
-vT
-vT
-vT
-vT
+dF
+dF
+dF
+dF
+dF
+dF
+dF
 Gs
 Il
 bJ
@@ -14235,10 +13177,10 @@ WI
 WI
 WI
 WI
-Bt
+Uu
 fq
-qA
-qA
+UE
+UE
 Aq
 Ml
 gI
@@ -14307,14 +13249,14 @@ eM
 IY
 jk
 BZ
-vT
+dF
 EX
 jd
 ze
-vT
+dF
 eM
 BZ
-vT
+dF
 Gs
 Gs
 Gs
@@ -14324,7 +13266,7 @@ Gs
 Gs
 Il
 PD
-eb
+Ho
 ei
 ZW
 zB
@@ -14391,10 +13333,10 @@ WI
 WI
 WI
 WI
-Bt
-qA
-qA
-qA
+Uu
+UE
+UE
+UE
 Tm
 Ml
 Vk
@@ -14463,14 +13405,14 @@ cD
 wY
 eM
 ds
-vT
+dF
 Ij
 jd
 jd
 Ea
 He
 BZ
-vT
+dF
 Ae
 Ae
 Ae
@@ -14480,7 +13422,7 @@ Ae
 Ae
 Qo
 ce
-ZU
+SR
 zB
 ZW
 zB
@@ -14547,10 +13489,10 @@ WI
 AW
 WI
 XO
-qA
-qA
-qA
-qA
+UE
+UE
+UE
+UE
 LP
 VT
 VT
@@ -14619,14 +13561,14 @@ He
 eM
 ZZ
 eM
-vT
-vT
-vT
-vT
-vT
+dF
+dF
+dF
+dF
+dF
 eM
 BZ
-vT
+dF
 cJ
 bA
 Nd
@@ -14636,7 +13578,7 @@ cd
 Tu
 XP
 ot
-eb
+Ho
 zB
 ZW
 zB
@@ -14703,10 +13645,10 @@ XO
 XO
 XO
 XO
-qA
-Bt
-qA
-kn
+UE
+Uu
+UE
+AB
 Yq
 VT
 VT
@@ -14747,7 +13689,7 @@ YQ
 pl
 pl
 pl
-vT
+dF
 OP
 OP
 OP
@@ -14756,15 +13698,15 @@ OP
 OP
 QD
 OP
-vT
-vT
+dF
+dF
 tF
 lv
-vT
-vT
+dF
+dF
 rg
 HL
-vT
+dF
 mg
 eM
 WF
@@ -14775,14 +13717,14 @@ TD
 Pg
 ZZ
 ve
-vT
+dF
 Gs
 Gs
 Ae
-vT
+dF
 eM
 BZ
-vT
+dF
 cK
 bM
 Fu
@@ -14792,7 +13734,7 @@ XP
 qT
 cP
 Sg
-ZU
+SR
 RL
 ZW
 zB
@@ -14859,10 +13801,10 @@ XO
 XO
 XO
 XO
-Bt
-qA
-qA
-qA
+Uu
+UE
+UE
+UE
 TT
 EQ
 XT
@@ -14903,42 +13845,42 @@ mv
 mv
 mv
 mv
-vT
+dF
 Wr
-vT
-vT
+dF
+dF
 Zl
 Zl
 Zl
-vT
-vT
-vT
+dF
+dF
+dF
 eM
 gM
 If
 eM
-vT
-vT
-vT
-vT
+dF
+dF
+dF
+dF
 BZ
 eM
 WF
 Gs
 WF
-vT
-vT
-vT
-vT
-vT
-vT
+dF
+dF
+dF
+dF
+dF
+dF
 Gs
 Qo
 bP
-vT
+dF
 eM
 BZ
-vT
+dF
 yh
 SR
 Sg
@@ -14948,7 +13890,7 @@ qT
 IC
 dd
 SR
-ZU
+SR
 zB
 ZW
 zB
@@ -15016,37 +13958,37 @@ Za
 XO
 XO
 XO
-qA
-qA
-qA
-qA
-Cq
-Cq
+UE
+UE
+UE
+UE
+xs
+xs
 Ey
-qA
-qA
-MA
-qk
-TC
-TC
-Im
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-TC
-MA
-MA
-TC
+UE
+UE
+uw
+vi
+Zm
+Zm
+WD
+UE
+UE
+UE
+UE
+UE
+UE
+UE
+UE
+UE
+UE
+Zm
+uw
+uw
+Zm
 Ey
-qA
-qA
+UE
+UE
 qz
 bD
 Yf
@@ -15059,10 +14001,10 @@ mv
 mv
 mv
 mv
-vT
+dF
 Jn
 pN
-vT
+dF
 eM
 eM
 dL
@@ -15091,10 +14033,10 @@ Ae
 Qo
 bI
 Rh
-vT
+dF
 eM
 yV
-vT
+dF
 cb
 SR
 SR
@@ -15102,9 +14044,9 @@ SR
 cj
 IC
 cg
-df
-ZU
-ZU
+ct
+SR
+SR
 zB
 ZW
 zB
@@ -15172,37 +14114,37 @@ CV
 Za
 Za
 Za
-TC
-TC
-TC
-qA
-qA
-qA
-qA
-TC
-TC
-MA
-qk
-TC
-TC
-TC
-TC
-TC
-TC
-TC
-TC
-TC
-TC
-TC
-TC
-TC
-TC
-MA
-MA
-TC
-TC
-TC
-qA
+Zm
+Zm
+Zm
+UE
+UE
+UE
+UE
+Zm
+Zm
+uw
+vi
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+Zm
+uw
+uw
+Zm
+Zm
+Zm
+UE
 bF
 Yf
 Yf
@@ -15215,10 +14157,10 @@ mv
 mv
 mv
 mv
-vT
+dF
 oT
 Jn
-vT
+dF
 Bo
 eM
 eM
@@ -15247,10 +14189,10 @@ PD
 Ho
 bJ
 eB
-vT
+dF
 eM
 YP
-vT
+dF
 yh
 SR
 SR
@@ -15258,9 +14200,9 @@ im
 bC
 QK
 SR
-dg
-ZU
-gx
+yh
+SR
+im
 zB
 ZW
 Ws
@@ -15329,36 +14271,36 @@ Al
 vy
 vy
 Mw
-Mq
-Mq
-Mq
-Mq
-Mq
+wf
+wf
+wf
+wf
+wf
 Nn
-Mq
-Mq
+wf
+wf
 Mw
-qf
-MA
-MA
-MA
-MA
-MA
-MA
-MA
-Th
-MA
-MA
-MA
-MA
-MA
-MA
-MA
-Th
-MA
-MA
-Th
-qA
+Bt
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+dW
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+dW
+uw
+uw
+dW
+UE
 bD
 Yf
 Yf
@@ -15371,10 +14313,10 @@ mv
 mv
 mv
 mv
-vT
+dF
 Ek
 uu
-vT
+dF
 eM
 eM
 eM
@@ -15414,9 +14356,9 @@ SR
 SR
 bl
 we
-dg
-ZU
-ZU
+yh
+SR
+SR
 zB
 dQ
 eF
@@ -15484,17 +14426,17 @@ SI
 SI
 SI
 SI
-MA
-MA
-MA
-MA
-MA
-MA
-qk
-MA
-MA
-MA
-MA
+uw
+uw
+uw
+uw
+uw
+uw
+vi
+uw
+uw
+uw
+uw
 SI
 SI
 SI
@@ -15511,10 +14453,10 @@ SI
 SI
 SI
 SI
-MA
-MA
-MA
-qA
+uw
+uw
+uw
+UE
 bD
 Yf
 Yf
@@ -15527,10 +14469,10 @@ Yf
 Yf
 Yf
 Yf
-vT
+dF
 Gx
 YV
-vT
+dF
 eM
 eM
 eM
@@ -15570,9 +14512,9 @@ SR
 SR
 SR
 SR
-dg
-gx
-ZU
+yh
+im
+SR
 zB
 ZW
 zB
@@ -15645,12 +14587,12 @@ XO
 XO
 XO
 XO
-MA
-qk
-TC
-TC
-TC
-TC
+uw
+vi
+Zm
+Zm
+Zm
+Zm
 XO
 XO
 XO
@@ -15683,7 +14625,7 @@ Yf
 Yf
 Yf
 Yf
-vT
+dF
 ip
 hd
 Ts
@@ -15696,8 +14638,8 @@ di
 Pg
 eM
 KL
-vT
-vT
+dF
+dF
 yz
 eM
 eM
@@ -15726,9 +14668,9 @@ SR
 SR
 SR
 SR
-DZ
-Mg
-ZU
+bI
+bL
+SR
 zB
 ZW
 zB
@@ -15839,17 +14781,17 @@ Yf
 Yf
 Yf
 Yf
-vT
-vT
-vT
+dF
+dF
+dF
 WF
 eM
 eM
 eM
 BZ
-vT
-vT
-vT
+dF
+dF
+dF
 xW
 eM
 Rt
@@ -15882,9 +14824,9 @@ im
 SR
 bl
 Io
-Rj
-Rj
-Mg
+Rh
+Rh
+bL
 zB
 ZW
 zB
@@ -16003,9 +14945,9 @@ dL
 eM
 eM
 BZ
-vT
-xs
-vT
+dF
+Gs
+dF
 cX
 eM
 eM
@@ -16038,9 +14980,9 @@ yh
 yh
 cN
 cP
-Lx
-Rj
-ec
+bJ
+Rh
+eB
 zB
 ZW
 eS
@@ -16159,9 +15101,9 @@ eM
 eM
 eM
 BZ
-vT
-xs
-vT
+dF
+Gs
+dF
 UR
 eM
 dL
@@ -16194,9 +15136,9 @@ SR
 qT
 bT
 KU
-EB
-dD
-gx
+Zt
+Ry
+im
 zB
 ZW
 zB
@@ -16315,13 +15257,13 @@ eM
 eM
 eM
 ns
-vT
-xs
-vT
-vT
+dF
+Gs
+dF
+dF
 eM
-vT
-vT
+dF
+dF
 eM
 eM
 Gf
@@ -16350,9 +15292,9 @@ SR
 KU
 Zt
 qT
-de
-ZU
-ZU
+cm
+SR
+SR
 zB
 ZW
 zB
@@ -16471,13 +15413,13 @@ EP
 eM
 Wc
 BF
-vT
-xs
-xs
-vT
+dF
+Gs
+Gs
+dF
 eM
-vT
-vT
+dF
+dF
 eM
 eM
 eM
@@ -16506,9 +15448,9 @@ SR
 Zb
 KU
 IC
-Bw
-EB
-BQ
+IC
+Zt
+Zb
 zB
 ZW
 Ab
@@ -16627,10 +15569,10 @@ eM
 Bf
 Bf
 BZ
-vT
-vT
-vT
-vT
+dF
+dF
+dF
+dF
 Bo
 eM
 eM
@@ -16662,9 +15604,9 @@ SR
 SR
 SR
 KU
-cY
-dE
-Sn
+bT
+KU
+rf
 zB
 ZW
 zB
@@ -16785,7 +15727,7 @@ eM
 BZ
 eM
 eM
-vT
+dF
 eM
 Fj
 Tz
@@ -16818,9 +15760,9 @@ SR
 PD
 Nd
 PD
-XF
-Di
-eb
+Nd
+PD
+Ho
 zB
 ZW
 zB
@@ -16974,9 +15916,9 @@ PI
 Lm
 VI
 Fu
-da
-DK
-ZU
+ot
+by
+SR
 zB
 ZW
 zB
@@ -17130,9 +16072,9 @@ SR
 SR
 Sg
 Lm
-DK
-ZU
-ZU
+by
+SR
+SR
 zB
 ZW
 zB
@@ -17286,9 +16228,9 @@ SR
 SR
 SR
 im
-ZU
-ZU
-ZU
+SR
+SR
+SR
 zB
 ZW
 Ws
@@ -17442,9 +16384,9 @@ SR
 SR
 SR
 SR
-ZU
-ZU
-ZU
+SR
+SR
+SR
 zB
 rP
 zB
@@ -17598,9 +16540,9 @@ SR
 wo
 SR
 PD
-XF
-ZU
-ZU
+Nd
+SR
+SR
 zB
 ZW
 zB
@@ -17724,7 +16666,7 @@ eM
 WF
 Yf
 Yf
-Yf
+Gs
 WF
 Bo
 eM
@@ -17754,9 +16696,9 @@ ok
 VI
 bA
 VI
-Om
-XF
-ZU
+bM
+Nd
+SR
 zB
 ZW
 zB
@@ -17880,7 +16822,7 @@ WF
 WF
 Yf
 Yf
-qs
+Il
 WF
 LF
 eM
@@ -17910,9 +16852,9 @@ ok
 VI
 bM
 by
-Di
-DK
-xa
+PD
+by
+bS
 zB
 ZW
 zB
@@ -18036,7 +16978,7 @@ Yf
 Yf
 Yf
 Yf
-qs
+Il
 WF
 NU
 Tz
@@ -18066,9 +17008,9 @@ SR
 Lm
 Nd
 PD
-DK
-dw
-dw
+by
+bP
+bP
 zB
 ZW
 Ws
@@ -27501,10 +26443,10 @@ qG
 qm
 Ee
 tH
-Bt
-Bt
-Bt
-Bt
+nI
+nI
+nI
+nI
 GY
 Gu
 bh
@@ -27617,39 +26559,39 @@ XO
 XO
 XO
 km
-Bt
-Bt
-Bt
-qA
-qA
-qA
-qA
-Bt
-Bt
-Bt
-qA
-qA
-TC
-qA
-qA
-qA
-Bt
-Bt
-Bt
-qA
+nI
+nI
+nI
+oP
+oP
+oP
+oP
+nI
+nI
+nI
+oP
+oP
+wa
+oP
+oP
+oP
+nI
+nI
+nI
+oP
 GO
-qA
-qA
-qA
-Bt
-Bt
-Bt
-Bt
-Bt
+oP
+oP
+oP
+nI
+nI
+nI
+nI
+nI
 Cq
-Bt
-Bt
-qA
+nI
+nI
+oP
 tH
 Ck
 nH
@@ -27657,10 +26599,10 @@ hh
 vM
 fu
 tH
-Bt
-Bt
-Bt
-Bt
+nI
+nI
+nI
+nI
 GZ
 GY
 Gu
@@ -27773,39 +26715,39 @@ XO
 Za
 XO
 XO
-Bt
-Bt
-qA
-TC
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-Bt
-Bt
-Bt
-Bt
-Bt
-qA
-TC
-qA
-qA
-Bt
+nI
+nI
+oP
+wa
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+nI
+nI
+nI
+nI
+nI
+oP
+wa
+oP
+oP
+nI
 OD
-Bt
-Bt
-Bt
-Bt
-qA
-qA
-qA
+nI
+nI
+nI
+nI
+oP
+oP
+oP
 tH
 CC
 jU
@@ -27813,8 +26755,8 @@ UH
 po
 rn
 tH
-Bt
-Bt
+nI
+nI
 xM
 Gu
 bh
@@ -27930,38 +26872,38 @@ XO
 XO
 XO
 Tl
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-qA
-TC
-qA
-qA
-qA
-Bt
-Bt
-Bt
-qA
-qA
-qA
-qA
-qA
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+wa
+oP
+oP
+oP
+nI
+nI
+nI
+oP
+oP
+oP
+oP
+oP
 tH
 Mh
 kK
@@ -27969,8 +26911,8 @@ rh
 Mh
 tH
 tH
-Bt
-Bt
+nI
+nI
 GZ
 GY
 BL
@@ -28085,48 +27027,48 @@ XO
 Za
 Za
 Za
-TC
-TC
-wf
-TC
-TC
-TC
-TC
-qA
-qA
-TC
-TC
-wf
-TC
-TC
-TC
-TC
-TC
-TC
-TC
-TC
+wa
+wa
+uq
+wa
+wa
+wa
+wa
+oP
+oP
+wa
+wa
+uq
+wa
+wa
+wa
+wa
+wa
+wa
+wa
+wa
 Uq
-MA
-MA
-MA
-qA
-qA
-qA
-qA
-oM
-MA
-MA
-MA
-MA
-MA
-MA
+IT
+IT
+IT
+oP
+oP
+oP
+oP
+sT
+IT
+IT
+IT
+IT
+IT
+IT
 io
-MA
-qA
-qA
-qA
-Bt
-Bt
+IT
+oP
+oP
+oP
+nI
+nI
 AK
 KV
 xM
@@ -28277,13 +27219,13 @@ Mq
 Mq
 Mq
 qf
-MA
-TC
-TC
-TC
-qA
-qA
-Bt
+IT
+wa
+wa
+wa
+oP
+oP
+nI
 BL
 xM
 bD
@@ -28397,11 +27339,11 @@ YT
 XO
 np
 Za
-TC
-TC
-wf
-TC
-TC
+wa
+wa
+uq
+wa
+wa
 lA
 lA
 wN
@@ -28433,12 +27375,12 @@ wN
 wN
 wN
 lA
-qA
-qA
-qA
-TC
-qA
-qA
+oP
+oP
+oP
+wa
+oP
+oP
 AK
 KV
 xM
@@ -28553,50 +27495,50 @@ fo
 WI
 XO
 XO
-qA
-qA
-qA
-TC
-kn
+oP
+oP
+oP
+wa
+CP
 Jm
-jO
-Hh
+df
+OA
 mh
-hj
-mI
-Za
-XO
-XO
-XO
-XO
-XO
-XO
-XO
-Dn
-SI
-XO
-XO
-XO
-XO
-XO
-WI
-WI
-WI
-Hh
+yq
+nW
+wa
+oP
+oP
+oP
+oP
+oP
+oP
+oP
+at
+IT
+oP
+oP
+oP
+oP
+oP
+nI
+nI
+nI
+OA
 mh
 mh
 mh
-jO
-XO
+df
+oP
 iK
-qA
-qA
+oP
+oP
 fI
-qA
-TC
-qA
-Bt
-Bt
+oP
+wa
+oP
+nI
+nI
 BL
 xM
 Yf
@@ -28709,17 +27651,17 @@ Tc
 WI
 XO
 XO
-qA
-qA
-qA
-TC
+oP
+oP
+oP
+wa
 pR
 GI
 Vc
-VG
-vf
+qC
+wv
 mh
-mI
+nW
 oP
 wa
 CP
@@ -28738,20 +27680,20 @@ wa
 CP
 yq
 yq
-QO
-QO
-QO
-wm
-of
-XO
+yB
+yB
+yB
+kn
+Cq
+oP
 iK
-qA
-Bt
+oP
+nI
 fI
-qA
-TC
-qA
-qA
+oP
+wa
+oP
+oP
 AK
 NT
 xM
@@ -28865,17 +27807,17 @@ gt
 fZ
 XO
 WI
-qA
+oP
 fI
-TC
-TC
-Bt
+wa
+wa
+nI
 Wu
 oP
-Zx
-je
-vf
-jO
+WQ
+dg
+wv
+df
 oP
 wa
 oP
@@ -28894,19 +27836,19 @@ wa
 oP
 nI
 nI
-Lv
-Lv
-Lv
-Lv
-Zx
-XO
-iK
-qA
-qA
 fI
-qA
-qA
-qA
+fI
+fI
+fI
+WQ
+oP
+iK
+oP
+oP
+fI
+oP
+oP
+oP
 AK
 zy
 NT
@@ -29021,17 +27963,17 @@ oW
 RN
 WI
 WI
-Bt
-qA
-qA
-TC
-qA
+nI
+oP
+oP
+wa
+oP
 Wu
 CP
-vf
-jO
-je
-wm
+wv
+df
+dg
+kn
 oP
 wa
 ka
@@ -29050,20 +27992,20 @@ ka
 ka
 wa
 nI
-Lv
-Lv
-Lv
-Hh
-vf
-jO
+fI
+fI
+fI
+OA
+wv
+df
 En
-TC
-qA
-qA
-qA
-TC
-qA
-Bt
+wa
+oP
+oP
+oP
+wa
+oP
+nI
 GZ
 KV
 bF
@@ -29177,17 +28119,17 @@ Yf
 qs
 WI
 WI
-Bt
-qA
-qA
-TC
-qA
+nI
+oP
+oP
+wa
+oP
 Wu
 oP
-je
-vf
-jO
-Zx
+dg
+wv
+df
+WQ
 nI
 oP
 ka
@@ -29206,19 +28148,19 @@ nb
 ka
 wa
 wa
-Lv
-Lv
-Hh
-vf
-vf
-QO
+fI
+fI
+OA
+wv
+wv
+yB
 WA
 pT
-qA
-TC
-qA
-qA
-Bt
+oP
+wa
+oP
+oP
+nI
 lX
 lG
 Gu
@@ -29333,17 +28275,17 @@ Yf
 qs
 WI
 WI
-qA
+oP
 fI
-qA
-qA
-qA
+oP
+oP
+oP
 CZ
 wa
 oP
-je
-QO
-wm
+dg
+yB
+kn
 nI
 wa
 on
@@ -29363,17 +28305,17 @@ on
 oP
 oP
 tw
-PK
-je
-QO
-wm
+oM
+dg
+yB
+kn
 oP
 En
-TC
-TC
-qA
-qA
-Bt
+wa
+wa
+oP
+oP
+nI
 lX
 WS
 eY
@@ -29489,11 +28431,11 @@ Yf
 qs
 WI
 WI
-qA
-qA
-oM
-qA
-TC
+oP
+oP
+sT
+oP
+wa
 CZ
 nI
 nI
@@ -29525,10 +28467,10 @@ nI
 oP
 oP
 iK
-qA
-qA
-qA
-Bt
+oP
+oP
+oP
+nI
 lX
 WS
 eY
@@ -29645,11 +28587,11 @@ Yf
 qs
 WI
 XO
-qA
-qA
-qA
-qA
-qA
+oP
+oP
+oP
+oP
+oP
 ZS
 oP
 oP
@@ -29678,12 +28620,12 @@ oP
 RA
 Ko
 oP
-Hh
-mI
+OA
+nW
 iK
-qA
-qA
-Bt
+oP
+oP
+nI
 lX
 WS
 eY
@@ -29834,10 +28776,10 @@ sT
 Qp
 oP
 oP
-of
+Cq
 wa
 En
-qA
+oP
 aG
 pq
 WS
@@ -30303,7 +29245,7 @@ wa
 oP
 wa
 oP
-KE
+qk
 Uj
 OJ
 bF
@@ -30459,7 +29401,7 @@ oP
 oP
 wa
 oP
-GZ
+qA
 Uj
 GY
 bD
@@ -30771,7 +29713,7 @@ nI
 nI
 wa
 oP
-AK
+iT
 lC
 xM
 bD
@@ -31083,7 +30025,7 @@ yB
 nW
 wa
 oP
-AK
+iT
 lC
 xM
 bD
@@ -31239,7 +30181,7 @@ nW
 oP
 wa
 oP
-KE
+qk
 Uj
 NT
 bD
@@ -31394,8 +30336,8 @@ yB
 nW
 wa
 wa
-AK
-NT
+iT
+vT
 tv
 KV
 bD
@@ -31550,7 +30492,7 @@ nI
 oP
 wa
 oP
-KE
+qk
 Np
 zl
 bF
@@ -31706,8 +30648,8 @@ oP
 oP
 wa
 oP
-GZ
-KV
+qA
+mH
 kW
 Yf
 Yf

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -676,6 +676,12 @@
 	dir = 4
 	},
 /area/icy_caves/caves/northern)
+"cz" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/seven,
+/area/space)
 "cC" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/ice/end,
@@ -1531,6 +1537,14 @@
 	dir = 4
 	},
 /area/icy_caves/caves/east)
+"gv" = (
+/obj/structure/shuttle/engine/router{
+	dir = 1
+	},
+/obj/structure/dropship_equipment/weapon/heavygun,
+/obj/structure/dropship_equipment/weapon/rocket_pod,
+/turf/open/shuttle/dropship/floor,
+/area/space)
 "gw" = (
 /turf/closed/ice_rock/singleT{
 	dir = 1
@@ -1766,10 +1780,6 @@
 	dir = 8
 	},
 /area/icy_caves/caves/east)
-"hF" = (
-/obj/structure/largecrate/random/barrel/yellow,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "hG" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/research_and_development,
@@ -1913,6 +1923,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/south)
+"iR" = (
+/obj/structure/dropship_piece/one/corner/middleleft,
+/obj/structure/dropship_piece/two/corner/rearleft,
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "iS" = (
 /obj/machinery/door/poddoor/mainship,
 /turf/open/shuttle/dropship/floor,
@@ -2005,13 +2022,6 @@
 /obj/effect/landmark/dropship_console_spawn_lz1,
 /turf/open/floor/plating/ground/snow,
 /area/lv624/lazarus/console)
-"jG" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
 "jH" = (
 /obj/machinery/landinglight/ds1/delaythree{
 	dir = 4
@@ -2417,12 +2427,6 @@
 /obj/structure/largecrate/random/barrel/blue,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
-"lq" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/shuttle/dropship/seven,
-/area/space)
 "lt" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
@@ -2479,14 +2483,6 @@
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/mining/west)
-"lL" = (
-/obj/machinery/camera/autoname/mainship/dropship_one{
-	dir = 8;
-	pixel_x = 16
-	},
-/obj/structure/largecrate/supply/explosives,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "lM" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -3532,11 +3528,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
-"qL" = (
-/turf/closed/ice/thin/corner{
-	dir = 8
-	},
-/area/icy_caves/outpost/LZ2)
 "qN" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
@@ -3691,10 +3682,6 @@
 /obj/item/tool/kitchen/knife,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
-"rw" = (
-/obj/structure/largecrate/supply,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "rx" = (
 /obj/structure/table,
 /obj/item/reagent_containers/dropper,
@@ -4022,6 +4009,13 @@
 /obj/docking_port/stationary/marine_dropship/lz1,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
+"sM" = (
+/obj/structure/dropship_piece/one/corner/middleright,
+/obj/structure/dropship_piece/two/corner/rearright,
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "sN" = (
 /obj/structure/table/flipped,
 /obj/item/flashlight,
@@ -4033,10 +4027,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/freezer,
 /area/icy_caves/outpost/dorms)
-"sS" = (
-/obj/structure/largecrate/random/barrel/green,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "sT" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -4185,6 +4175,10 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/garage)
+"tJ" = (
+/obj/machinery/door/poddoor/mainship/indestructible,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "tK" = (
 /obj/item/ammo_casing,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -4223,6 +4217,10 @@
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
+"tS" = (
+/obj/structure/largecrate/supply,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "tT" = (
 /obj/structure/table/mainship,
 /obj/machinery/computer/med_data,
@@ -4297,12 +4295,6 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/medbay)
-"uk" = (
-/obj/machinery/camera{
-	dir = 5
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "ul" = (
 /obj/structure/dropship_piece/two/corner/rearright,
 /turf/open/shuttle/dropship/floor,
@@ -4544,9 +4536,6 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/r_wall,
 /area/icy_caves/caves/northern)
-"vw" = (
-/turf/closed/ice/thin/corner,
-/area/icy_caves/outpost/LZ2)
 "vx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1
@@ -4586,6 +4575,11 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"vJ" = (
+/turf/closed/ice/corner{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ2)
 "vL" = (
 /obj/effect/decal/cleanable/blood/gibs/robot,
 /turf/open/floor/tile/dark/brown2/corner,
@@ -4723,6 +4717,12 @@
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/refinery)
+"wy" = (
+/obj/machinery/camera{
+	dir = 5
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "wz" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -4781,6 +4781,11 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/garage)
+"wR" = (
+/turf/closed/shuttle/dropship2{
+	icon_state = "24"
+	},
+/area/icy_caves/caves/northern)
 "wT" = (
 /obj/structure/lattice,
 /obj/structure/monorail{
@@ -4809,11 +4814,6 @@
 	dir = 1
 	},
 /area/icy_caves/caves/south)
-"xc" = (
-/turf/closed/ice/corner{
-	dir = 1
-	},
-/area/icy_caves/outpost/LZ2)
 "xf" = (
 /obj/structure/closet/secure_closet/scientist,
 /turf/open/floor/tile/dark/purple2,
@@ -5033,6 +5033,11 @@
 /area/icy_caves/outpost/engineering)
 "yz" = (
 /obj/structure/bed/chair,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"yA" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "yB" = (
@@ -5256,6 +5261,11 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
+"zR" = (
+/turf/closed/ice/junction{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "zS" = (
 /turf/closed/ice/end{
 	dir = 4
@@ -5400,11 +5410,6 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/garage)
-"Aw" = (
-/turf/closed/ice/thin/end{
-	dir = 4
-	},
-/area/icy_caves/outpost/LZ1)
 "Ax" = (
 /obj/structure/table,
 /obj/machinery/light/built{
@@ -5712,7 +5717,7 @@
 /area/icy_caves/outpost/garage)
 "BV" = (
 /turf/closed/ice/thin/corner{
-	dir = 1
+	dir = 8
 	},
 /area/icy_caves/outpost/LZ2)
 "BW" = (
@@ -5778,10 +5783,6 @@
 /obj/item/ammo_casing,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
-"Ct" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "Cx" = (
 /obj/machinery/power/smes/buildable/empty/dist,
 /obj/structure/cable,
@@ -6119,6 +6120,16 @@
 "EB" = (
 /turf/closed/ice/thin/corner,
 /area/icy_caves/caves/west)
+"EC" = (
+/obj/vehicle/multitile/root/cm_armored/tank{
+	dir = 1;
+	layer = 1
+	},
+/obj/structure/dropship_equipment/weapon/laser_beam_gun,
+/obj/effect/turf_overlay/shuttle/heater,
+/obj/structure/dropship_equipment/weapon/rocket_pod,
+/turf/open/shuttle/dropship/floor,
+/area/space)
 "ED" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -6171,6 +6182,9 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/LZ1)
+"ER" = (
+/turf/closed/ice/thin/corner,
+/area/icy_caves/outpost/LZ2)
 "ES" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -6229,13 +6243,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
-"Fk" = (
-/obj/structure/barricade/guardrail,
-/obj/structure/bed/chair/dropship/passenger{
-	dir = 4
-	},
-/turf/open/shuttle/dropship/seven,
-/area/space)
 "Fm" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -6297,11 +6304,6 @@
 	dir = 4
 	},
 /area/icy_caves/caves/northern)
-"Fx" = (
-/turf/closed/shuttle/dropship2{
-	icon_state = "24"
-	},
-/area/icy_caves/caves/northern)
 "Fy" = (
 /turf/open/floor/freezer,
 /area/icy_caves/outpost/dorms)
@@ -6309,6 +6311,19 @@
 /obj/machinery/light,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
+"FC" = (
+/obj/machinery/camera/autoname/mainship/dropship_one{
+	dir = 8;
+	pixel_x = 16
+	},
+/obj/structure/largecrate/supply/explosives,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"FD" = (
+/turf/closed/ice/thin/corner{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "FF" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -6569,6 +6584,11 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/medbay)
+"GW" = (
+/turf/closed/ice_rock/singlePart{
+	dir = 5
+	},
+/area/icy_caves/outpost/LZ2)
 "GX" = (
 /obj/machinery/computer/nuke_disk_generator/blue,
 /turf/open/floor/tile/dark/purple2{
@@ -6636,6 +6656,10 @@
 "Hq" = (
 /turf/closed/ice_rock/fourway,
 /area/icy_caves/caves/east)
+"Hr" = (
+/obj/structure/largecrate/random/barrel/green,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Hu" = (
 /obj/structure/closet/crate/science,
 /turf/open/floor/tile/dark/purple2{
@@ -6872,6 +6896,10 @@
 	dir = 1
 	},
 /area/icy_caves/caves/south)
+"Iz" = (
+/obj/structure/largecrate/random/barrel/yellow,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "IA" = (
 /obj/machinery/light,
 /obj/effect/landmark/excavation_site_spawner,
@@ -7232,6 +7260,13 @@
 	},
 /turf/open/floor/freezer,
 /area/icy_caves/outpost/kitchen)
+"KB" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "KC" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/colonist,
@@ -7300,16 +7335,6 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/outside)
-"KW" = (
-/obj/vehicle/multitile/root/cm_armored/tank{
-	dir = 1;
-	layer = 1
-	},
-/obj/structure/dropship_equipment/weapon/laser_beam_gun,
-/obj/effect/turf_overlay/shuttle/heater,
-/obj/structure/dropship_equipment/weapon/rocket_pod,
-/turf/open/shuttle/dropship/floor,
-/area/space)
 "KZ" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/garage)
@@ -7719,6 +7744,11 @@
 /obj/machinery/space_heater,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/office)
+"MS" = (
+/turf/closed/shuttle/dropship2{
+	icon_state = "25"
+	},
+/area/icy_caves/caves/northern)
 "MT" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/cheeseburger,
@@ -8131,11 +8161,6 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/refinery)
-"Py" = (
-/turf/closed/ice/junction{
-	dir = 1
-	},
-/area/icy_caves/outpost/LZ2)
 "Pz" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -8160,11 +8185,6 @@
 "PD" = (
 /turf/closed/ice/corner{
 	dir = 4
-	},
-/area/icy_caves/caves/northern)
-"PG" = (
-/turf/closed/shuttle/dropship2{
-	icon_state = "25"
 	},
 /area/icy_caves/caves/northern)
 "PI" = (
@@ -8197,11 +8217,6 @@
 /obj/machinery/light,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"PP" = (
-/turf/closed/ice_rock/singlePart{
-	dir = 5
-	},
-/area/icy_caves/outpost/LZ2)
 "PQ" = (
 /obj/item/ammo_casing,
 /obj/item/weapon/gun/smg/m25,
@@ -8285,10 +8300,7 @@
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
 "Qn" = (
-/obj/structure/barricade/guardrail,
-/obj/structure/bed/chair/dropship/passenger{
-	dir = 8
-	},
+/obj/structure/bed/chair/dropship/passenger,
 /turf/open/shuttle/dropship/seven,
 /area/space)
 "Qo" = (
@@ -8310,6 +8322,11 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/south)
+"Qu" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "Qw" = (
 /turf/closed/ice/corner{
 	dir = 4
@@ -8550,10 +8567,6 @@
 	dir = 4
 	},
 /area/icy_caves/caves)
-"RF" = (
-/obj/machinery/door/poddoor/mainship/indestructible,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "RG" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 1
@@ -8627,14 +8640,6 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
-"Sb" = (
-/obj/structure/shuttle/engine/router{
-	dir = 1
-	},
-/obj/structure/dropship_equipment/weapon/heavygun,
-/obj/structure/dropship_equipment/weapon/rocket_pod,
-/turf/open/shuttle/dropship/floor,
-/area/space)
 "Sc" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/mainship,
@@ -8723,6 +8728,11 @@
 	dir = 4
 	},
 /area/icy_caves/caves/south)
+"SB" = (
+/turf/closed/ice/corner{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "SD" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 4
@@ -8732,11 +8742,6 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
-"SG" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
 "SH" = (
 /turf/open/floor/tile/dark/red2{
 	dir = 10
@@ -9281,13 +9286,6 @@
 /obj/structure/xenoautopsy/tank,
 /turf/open/shuttle/dropship/seven,
 /area/icy_caves/caves/northern)
-"VH" = (
-/obj/structure/dropship_piece/one/corner/middleright,
-/obj/structure/dropship_piece/two/corner/rearright,
-/turf/open/floor/mainship_hull/dir{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
 "VI" = (
 /turf/closed/ice/intersection,
 /area/icy_caves/caves/northern)
@@ -9477,6 +9475,11 @@
 "Wy" = (
 /turf/open/shuttle/dropship/floor,
 /area/space)
+"Wz" = (
+/turf/closed/ice/thin/end{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ1)
 "WA" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -9719,11 +9722,6 @@
 "XJ" = (
 /turf/closed/ice_rock/singleEnd,
 /area/icy_caves/caves/west)
-"XK" = (
-/turf/closed/ice/corner{
-	dir = 4
-	},
-/area/icy_caves/outpost/LZ2)
 "XL" = (
 /obj/structure/barricade/guardrail{
 	dir = 1
@@ -10142,23 +10140,15 @@
 /obj/structure/cable,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
+"ZM" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "ZP" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 4
 	},
 /area/icy_caves/caves/south)
-"ZQ" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/window/framed/colony/reinforced,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"ZR" = (
-/obj/structure/dropship_piece/one/corner/middleleft,
-/obj/structure/dropship_piece/two/corner/rearleft,
-/turf/open/floor/mainship_hull/dir{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
 "ZS" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -11466,7 +11456,7 @@ Zl
 EU
 Zl
 nK
-sS
+Hr
 dF
 EU
 Zl
@@ -11622,7 +11612,7 @@ He
 Zl
 Zl
 Zl
-hF
+Iz
 dF
 Zl
 Zl
@@ -11779,7 +11769,7 @@ Tz
 Tz
 Tz
 Tz
-ZQ
+yA
 Tz
 Tz
 UU
@@ -11787,7 +11777,7 @@ Zl
 Xz
 Zl
 Zl
-uk
+wy
 EU
 Zl
 Zl
@@ -11935,7 +11925,7 @@ Zl
 Zl
 Zl
 Zl
-Ct
+ZM
 Zl
 Zl
 Wd
@@ -12560,8 +12550,8 @@ Zl
 Zl
 FB
 dF
-lL
-rw
+FC
+tS
 BZ
 Zl
 pE
@@ -13020,14 +13010,14 @@ iS
 BN
 BN
 BN
-ZR
+iR
 Rw
 BN
 jc
 jc
-RF
-RF
-Fx
+tJ
+tJ
+wR
 ma
 dF
 BZ
@@ -13178,7 +13168,7 @@ TC
 Wg
 Ss
 ul
-Fk
+Qn
 NW
 XD
 GU
@@ -13337,8 +13327,8 @@ pc
 Wy
 Wy
 ch
-KW
-Sb
+EC
+gv
 Wy
 FR
 Zl
@@ -13493,7 +13483,7 @@ uO
 Qn
 NW
 XD
-lq
+cz
 NW
 XL
 UZ
@@ -13505,7 +13495,7 @@ Gs
 WF
 Gj
 cD
-uk
+wy
 Zl
 ds
 dF
@@ -13644,14 +13634,14 @@ iS
 KP
 KP
 KP
-VH
+sM
 Ss
 KP
 jc
 jc
-PG
-PG
-PG
+MS
+MS
+MS
 gQ
 dF
 BZ
@@ -14065,8 +14055,8 @@ UE
 UE
 UE
 UE
-Aw
-Aw
+Wz
+Wz
 Ey
 UE
 UE
@@ -14374,16 +14364,16 @@ Al
 vy
 vy
 Mw
-SG
-SG
-SG
-SG
-SG
+Qu
+Qu
+Qu
+Qu
+Qu
 Nn
-SG
-SG
+Qu
+Qu
 Mw
-jG
+KB
 uw
 uw
 uw
@@ -27604,7 +27594,7 @@ oP
 wa
 CP
 Jm
-vw
+ER
 OA
 mh
 yq
@@ -27631,7 +27621,7 @@ OA
 mh
 mh
 mh
-vw
+ER
 oP
 iK
 oP
@@ -27786,7 +27776,7 @@ yq
 yB
 yB
 yB
-qL
+BV
 Cq
 oP
 iK
@@ -27918,9 +27908,9 @@ nI
 Wu
 oP
 WQ
-BV
+FD
 wv
-vw
+ER
 oP
 wa
 oP
@@ -28074,9 +28064,9 @@ oP
 Wu
 CP
 wv
-vw
+ER
+FD
 BV
-qL
 oP
 wa
 ka
@@ -28100,7 +28090,7 @@ fI
 fI
 OA
 wv
-vw
+ER
 En
 wa
 oP
@@ -28229,9 +28219,9 @@ wa
 oP
 Wu
 oP
-BV
+FD
 wv
-vw
+ER
 WQ
 nI
 oP
@@ -28386,9 +28376,9 @@ oP
 CZ
 wa
 oP
-BV
+FD
 yB
-qL
+BV
 nI
 wa
 on
@@ -28408,10 +28398,10 @@ on
 oP
 oP
 tw
-PP
-BV
+GW
+FD
 yB
-qL
+BV
 oP
 En
 wa
@@ -29348,7 +29338,7 @@ wa
 oP
 wa
 oP
-XK
+vJ
 Uj
 OJ
 bF
@@ -29504,7 +29494,7 @@ oP
 oP
 wa
 oP
-xc
+SB
 Uj
 GY
 bD
@@ -30284,7 +30274,7 @@ nW
 oP
 wa
 oP
-XK
+vJ
 Uj
 NT
 bD
@@ -30440,7 +30430,7 @@ nW
 wa
 wa
 iT
-Py
+zR
 tv
 KV
 bD
@@ -30595,7 +30585,7 @@ nI
 oP
 wa
 oP
-XK
+vJ
 Np
 zl
 bF
@@ -30751,7 +30741,7 @@ oP
 oP
 wa
 oP
-xc
+SB
 mH
 kW
 Yf

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -574,10 +574,11 @@
 	},
 /area/icy_caves/caves/northern)
 "ch" = (
-/obj/effect/decal/cleanable/blood/xtracks,
-/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
 /turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern)
+/area/space)
 "ci" = (
 /turf/closed/ice/thin/junction,
 /area/icy_caves/caves/northern)
@@ -675,6 +676,14 @@
 	dir = 4
 	},
 /area/icy_caves/caves/northern)
+"cy" = (
+/obj/structure/shuttle/engine/router{
+	dir = 1
+	},
+/obj/structure/dropship_equipment/weapon/heavygun,
+/obj/structure/dropship_equipment/weapon/rocket_pod,
+/turf/open/shuttle/dropship/floor,
+/area/space)
 "cC" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/ice/end,
@@ -785,20 +794,21 @@
 	},
 /area/icy_caves/caves/west)
 "df" = (
+/obj/structure/dropship_piece/two/front/left,
+/turf/open/floor/mainship_hull/dir{
+	dir = 8
+	},
+/area/icy_caves/caves/northern)
+"dg" = (
 /obj/structure/lattice,
-/obj/structure/dropship_piece/one/front/left,
 /obj/structure/monorail{
 	dir = 5
 	},
 /obj/structure/monorail{
 	dir = 9
 	},
+/obj/structure/dropship_piece/two/front,
 /turf/open/shuttle/escapepod/plain,
-/area/icy_caves/caves/northern)
-"dg" = (
-/obj/structure/dropship_piece/one/front,
-/obj/structure/monorail,
-/turf/open/floor/mainship_hull,
 /area/icy_caves/caves/northern)
 "dh" = (
 /turf/closed/ice_rock/singlePart{
@@ -1166,9 +1176,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
-"eM" = (
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "eN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4
@@ -1576,8 +1583,9 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "gK" = (
-/obj/structure/largecrate/supply/explosives,
-/turf/open/floor/tile/dark,
+/obj/structure/monorail,
+/obj/structure/dropship_piece/two/front,
+/turf/open/floor/mainship_hull,
 /area/icy_caves/caves/northern)
 "gL" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
@@ -1614,6 +1622,7 @@
 /area/icy_caves/caves/northern)
 "gQ" = (
 /obj/structure/dropship_piece/one/corner/middleright,
+/obj/structure/dropship_piece/two/corner/rearright,
 /turf/open/floor/mainship_hull/dir{
 	dir = 10
 	},
@@ -1750,6 +1759,11 @@
 	},
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
+"hz" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "hA" = (
 /obj/machinery/light{
 	dir = 4
@@ -1821,6 +1835,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/northern)
+"ia" = (
+/turf/closed/shuttle/dropship2{
+	icon_state = "25"
+	},
+/area/icy_caves/caves/northern)
 "ib" = (
 /obj/machinery/light{
 	dir = 1
@@ -1881,17 +1900,6 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
-"iy" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
-"iD" = (
-/obj/structure/largecrate/random/barrel/yellow,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "iG" = (
 /turf/open/floor/tile/dark/yellow2{
 	dir = 4
@@ -1919,16 +1927,15 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/south)
+"iS" = (
+/obj/machinery/door/poddoor/mainship,
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern)
 "iT" = (
 /turf/closed/ice/end{
 	dir = 1
 	},
 /area/icy_caves/outpost/LZ2)
-"iX" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
 "iZ" = (
 /turf/open/floor/tile/dark/brown2,
 /area/icy_caves/outpost/garage)
@@ -1943,7 +1950,7 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
 "jc" = (
-/obj/machinery/door/poddoor/mainship,
+/obj/machinery/door/poddoor/mainship/indestructible,
 /turf/open/shuttle/dropship/floor,
 /area/icy_caves/caves/northern)
 "jd" = (
@@ -2155,13 +2162,13 @@
 /area/icy_caves/outpost/outside)
 "kn" = (
 /obj/structure/lattice,
-/obj/structure/dropship_piece/one/front/right,
 /obj/structure/monorail{
 	dir = 9
 	},
 /obj/structure/monorail{
 	dir = 5
 	},
+/obj/structure/dropship_piece/two/front,
 /turf/open/shuttle/escapepod/plain,
 /area/icy_caves/caves/northern)
 "ko" = (
@@ -2202,11 +2209,6 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
-"kt" = (
-/turf/closed/ice/corner{
-	dir = 1
-	},
-/area/icy_caves/outpost/LZ2)
 "ku" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -2426,11 +2428,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
-"lu" = (
-/obj/structure/dropship_piece/one/cockpit/left,
-/obj/structure/dropship_piece/one/cockpit/right,
-/turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern)
 "lv" = (
 /obj/machinery/door/poddoor/two_tile_ver,
 /turf/open/floor/mainship/cargo/arrow{
@@ -2443,6 +2440,11 @@
 	},
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside/center)
+"lz" = (
+/turf/closed/ice/thin/end{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ1)
 "lA" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -2483,6 +2485,13 @@
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/mining/west)
+"lI" = (
+/obj/structure/dropship_piece/one/corner/middleright,
+/obj/structure/dropship_piece/two/corner/rearright,
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "lM" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -2549,6 +2558,7 @@
 /area/icy_caves/outpost/LZ2)
 "ma" = (
 /obj/structure/dropship_piece/one/corner/middleleft,
+/obj/structure/dropship_piece/two/corner/rearleft,
 /turf/open/floor/mainship_hull/dir{
 	dir = 6
 	},
@@ -2783,6 +2793,17 @@
 /obj/item/storage/donut_box,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
+"mT" = (
+/obj/structure/largecrate/random/barrel/yellow,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"mU" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "mV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -2937,6 +2958,13 @@
 /obj/structure/janitorialcart,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/northern)
+"nG" = (
+/obj/structure/dropship_piece/one/corner/middleleft,
+/obj/structure/dropship_piece/two/corner/rearleft,
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "nH" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -2948,7 +2976,7 @@
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/LZ2)
 "nK" = (
-/obj/structure/largecrate/random/barrel/green,
+/obj/structure/largecrate/random/secure,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "nL" = (
@@ -3061,13 +3089,6 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
-"oz" = (
-/obj/structure/barricade/guardrail{
-	dir = 8
-	},
-/obj/structure/xenoautopsy/tank,
-/turf/open/shuttle/dropship/seven,
-/area/icy_caves/caves/northern)
 "oA" = (
 /obj/machinery/landinglight/ds1{
 	dir = 1
@@ -3099,9 +3120,9 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
 "oM" = (
-/obj/structure/dropship_piece/one/cockpit/left,
+/obj/structure/dropship_piece/two/front/right,
 /turf/open/floor/mainship_hull/dir{
-	dir = 8
+	dir = 4
 	},
 /area/icy_caves/caves/northern)
 "oO" = (
@@ -3149,6 +3170,12 @@
 "oW" = (
 /turf/closed/ice_rock/westWall,
 /area/icy_caves/caves)
+"oX" = (
+/obj/machinery/camera{
+	dir = 5
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "oZ" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -3161,6 +3188,14 @@
 	dir = 9
 	},
 /area/icy_caves/caves/west)
+"pc" = (
+/turf/open/shuttle/dropship/floor,
+/area/icy_caves/caves/northern)
+"pd" = (
+/turf/closed/ice/thin/corner{
+	dir = 8
+	},
+/area/icy_caves/outpost/LZ2)
 "pf" = (
 /obj/effect/landmark/corpsespawner/miner{
 	corpseback = /obj/item/storage/backpack/satchel/norm;
@@ -3424,9 +3459,10 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
 "qk" = (
-/turf/closed/shuttle/dropship3/transparent{
-	icon_state = "96"
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 4
 	},
+/turf/open/shuttle/dropship/seven,
 /area/icy_caves/caves/northern)
 "ql" = (
 /turf/open/floor/plating,
@@ -3493,9 +3529,13 @@
 /turf/closed/ice_rock/single,
 /area/icy_caves/caves)
 "qA" = (
-/turf/closed/shuttle/dropship3/transparent{
-	icon_state = "97"
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 8
 	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/seven,
 /area/icy_caves/caves/northern)
 "qB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump,
@@ -4091,11 +4131,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
-"to" = (
-/turf/closed/ice_rock/singlePart{
-	dir = 5
-	},
-/area/icy_caves/outpost/LZ2)
 "tp" = (
 /obj/item/lightstick/anchored,
 /turf/open/floor/tile/dark,
@@ -4171,6 +4206,11 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/garage)
+"tJ" = (
+/turf/closed/ice/junction{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "tK" = (
 /obj/item/ammo_casing,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -4284,7 +4324,7 @@
 	},
 /area/icy_caves/outpost/medbay)
 "ul" = (
-/obj/structure/dropship_piece/one/corner/middleright,
+/obj/structure/dropship_piece/two/corner/rearright,
 /turf/open/shuttle/dropship/floor,
 /area/icy_caves/caves/northern)
 "un" = (
@@ -4364,6 +4404,11 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"uF" = (
+/turf/closed/ice/corner{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "uH" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/tile/dark/green2{
@@ -4383,7 +4428,7 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
 "uO" = (
-/obj/structure/dropship_piece/one/corner/middleleft,
+/obj/structure/dropship_piece/two/corner/rearleft,
 /turf/open/shuttle/dropship/floor,
 /area/icy_caves/caves/northern)
 "uP" = (
@@ -4590,11 +4635,6 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"vT" = (
-/turf/closed/shuttle/dropship3/transparent{
-	icon_state = "98"
-	},
-/area/icy_caves/caves/northern)
 "vV" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -4636,10 +4676,10 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/northern)
 "wf" = (
-/obj/structure/bed/chair/dropship/passenger{
-	dir = 4
+/obj/structure/barricade/guardrail{
+	dir = 1
 	},
-/turf/open/shuttle/dropship/seven,
+/turf/open/shuttle/dropship/floor,
 /area/icy_caves/caves/northern)
 "wg" = (
 /obj/effect/landmark/start/job/survivor,
@@ -4684,6 +4724,11 @@
 	icon_state = "bright_clean2"
 	},
 /area/icy_caves/caves/northern)
+"wr" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "ws" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/tile/dark,
@@ -4780,12 +4825,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
-"wY" = (
-/obj/machinery/camera{
-	dir = 5
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "wZ" = (
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
@@ -4862,11 +4901,19 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/refinery)
 "xs" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/shuttle/dropship/floor,
+/obj/structure/barricade/guardrail,
+/turf/open/floor/mainship/red/full,
 /area/icy_caves/caves/northern)
+"xt" = (
+/obj/vehicle/multitile/root/cm_armored/tank{
+	dir = 1;
+	layer = 1
+	},
+/obj/structure/dropship_equipment/weapon/laser_beam_gun,
+/obj/effect/turf_overlay/shuttle/heater,
+/obj/structure/dropship_equipment/weapon/rocket_pod,
+/turf/open/shuttle/dropship/floor,
+/area/space)
 "xu" = (
 /obj/structure/cargo_container/green,
 /turf/open/floor/plating,
@@ -4888,11 +4935,6 @@
 	dir = 9
 	},
 /area/icy_caves/caves)
-"xD" = (
-/turf/closed/ice/corner{
-	dir = 4
-	},
-/area/icy_caves/outpost/LZ2)
 "xE" = (
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
@@ -5088,6 +5130,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"yT" = (
+/obj/machinery/camera/autoname/mainship/dropship_one{
+	dir = 8;
+	pixel_x = 16
+	},
+/obj/structure/largecrate/supply/explosives,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "yU" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 9
@@ -5584,10 +5634,9 @@
 /turf/open/floor/podhatch/floor,
 /area/icy_caves/outpost/engineering)
 "Bt" = (
-/obj/structure/bed/chair/dropship/passenger{
-	dir = 8
-	},
-/turf/open/shuttle/dropship/seven,
+/obj/effect/decal/cleanable/blood/xtracks,
+/obj/effect/ai_node,
+/turf/open/shuttle/dropship/floor,
 /area/icy_caves/caves/northern)
 "Bu" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
@@ -5650,8 +5699,8 @@
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/dorms)
 "BN" = (
-/turf/closed/shuttle/dropship3{
-	icon_state = "50"
+/turf/closed/shuttle/dropship2{
+	icon_state = "52"
 	},
 /area/icy_caves/caves/northern)
 "BO" = (
@@ -5779,12 +5828,6 @@
 "CH" = (
 /turf/open/floor/mainship_hull/dir{
 	dir = 10
-	},
-/area/icy_caves/caves/northern)
-"CI" = (
-/obj/machinery/door/poddoor/two_tile_ver,
-/turf/open/floor/mainship/cargo/arrow{
-	dir = 8
 	},
 /area/icy_caves/caves/northern)
 "CN" = (
@@ -5931,10 +5974,6 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/single,
 /area/icy_caves/caves)
-"DF" = (
-/obj/structure/largecrate/random/secure,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "DG" = (
 /obj/effect/decal/cleanable/blood/writing,
 /turf/open/floor/tile/dark,
@@ -6217,11 +6256,12 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "Fk" = (
+/obj/structure/barricade/guardrail,
 /obj/structure/bed/chair/dropship/passenger{
 	dir = 4
 	},
-/turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern)
+/turf/open/shuttle/dropship/seven,
+/area/space)
 "Fm" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -6290,10 +6330,6 @@
 /obj/machinery/light,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
-"FE" = (
-/obj/effect/decal/cleanable/blood/xtracks,
-/turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern)
 "FF" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -6337,6 +6373,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
+"FR" = (
+/turf/closed/shuttle/dropship2/transparent{
+	icon_state = "109"
+	},
+/area/icy_caves/caves/northern)
 "FU" = (
 /obj/structure/cargo_container/ch_red,
 /turf/open/floor/plating,
@@ -6427,6 +6468,10 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/medbay)
+"Gr" = (
+/obj/machinery/door/poddoor/mainship/indestructible,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Gs" = (
 /turf/closed/ice_rock/corners,
 /area/icy_caves/caves/northern)
@@ -6536,9 +6581,11 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
 "GU" = (
-/obj/structure/barricade/guardrail,
-/turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern)
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/shuttle/dropship/seven,
+/area/space)
 "GV" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -6796,9 +6843,7 @@
 /turf/closed/ice_rock/southWall,
 /area/icy_caves/caves/northern)
 "Im" = (
-/obj/structure/barricade/guardrail{
-	dir = 1
-	},
+/obj/item/shard,
 /turf/open/shuttle/dropship/floor,
 /area/icy_caves/caves/northern)
 "In" = (
@@ -6832,12 +6877,6 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/garage)
-"Iu" = (
-/obj/structure/dropship_piece/one/cockpit/left,
-/turf/open/floor/mainship_hull/dir{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
 "Iv" = (
 /obj/structure/ore_box,
 /turf/open/floor/plating,
@@ -7025,11 +7064,6 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
-"Ju" = (
-/turf/closed/ice/junction{
-	dir = 1
-	},
-/area/icy_caves/outpost/LZ2)
 "Jv" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -7152,6 +7186,12 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/office)
+"Kc" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/seven,
+/area/space)
 "Kd" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark/brown2/corner{
@@ -7272,8 +7312,8 @@
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
 "KP" = (
-/turf/closed/shuttle/dropship3{
-	icon_state = "43"
+/turf/closed/shuttle/dropship2{
+	icon_state = "54"
 	},
 /area/icy_caves/caves/northern)
 "KS" = (
@@ -7306,6 +7346,10 @@
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"Lc" = (
+/obj/structure/largecrate/supply,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Ld" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/corners{
@@ -7637,9 +7681,6 @@
 /area/icy_caves/outpost/LZ1)
 "MA" = (
 /obj/structure/barricade/guardrail,
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/open/shuttle/dropship/floor,
 /area/icy_caves/caves/northern)
 "MB" = (
@@ -7915,15 +7956,8 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "NW" = (
-/obj/structure/barricade/guardrail{
-	dir = 4
-	},
-/obj/structure/xenoautopsy/tank/escaped,
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/open/shuttle/dropship/seven,
-/area/icy_caves/caves/northern)
+/area/space)
 "Ob" = (
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/tile/dark,
@@ -8069,10 +8103,6 @@
 /obj/structure/cargo_container/gorg,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
-"Pc" = (
-/obj/machinery/door/airlock/multi_tile/mainship/dropshiprear/ds1,
-/turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern)
 "Pd" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/security)
@@ -8152,6 +8182,10 @@
 	dir = 4
 	},
 /area/icy_caves/caves/northern)
+"PF" = (
+/obj/structure/largecrate/random/barrel/green,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "PI" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/ice,
@@ -8171,11 +8205,6 @@
 	dir = 8
 	},
 /area/icy_caves/caves)
-"PM" = (
-/turf/closed/ice/thin/corner{
-	dir = 8
-	},
-/area/icy_caves/outpost/LZ2)
 "PN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
@@ -8270,14 +8299,12 @@
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
 "Qn" = (
+/obj/structure/barricade/guardrail,
 /obj/structure/bed/chair/dropship/passenger{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern)
+/turf/open/shuttle/dropship/seven,
+/area/space)
 "Qo" = (
 /turf/closed/ice_rock/corners{
 	dir = 9
@@ -8407,6 +8434,11 @@
 	dir = 4
 	},
 /area/icy_caves/caves/northern)
+"Ra" = (
+/turf/closed/ice/thin/corner{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "Rb" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 1
@@ -8497,10 +8529,9 @@
 /turf/closed/wall/r_wall,
 /area/icy_caves/caves)
 "Rw" = (
-/obj/structure/dropship_piece/one/cockpit/left,
-/obj/structure/dropship_piece/one/cockpit/right,
-/obj/structure/dropship_piece/one/cockpit/left,
-/turf/open/shuttle/dropship/floor,
+/turf/closed/shuttle/dropship2{
+	icon_state = "103"
+	},
 /area/icy_caves/caves/northern)
 "Rx" = (
 /obj/structure/table/reinforced,
@@ -8585,6 +8616,11 @@
 /area/icy_caves/outpost/dorms)
 "RQ" = (
 /turf/closed/ice_rock/fourway,
+/area/icy_caves/outpost/LZ2)
+"RR" = (
+/turf/closed/ice/corner{
+	dir = 4
+	},
 /area/icy_caves/outpost/LZ2)
 "RS" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
@@ -8676,9 +8712,8 @@
 	},
 /area/icy_caves/outpost/security)
 "Ss" = (
-/obj/structure/dropship_piece/one/cockpit/right,
-/turf/open/floor/mainship_hull/dir{
-	dir = 4
+/turf/closed/shuttle/dropship2{
+	icon_state = "104"
 	},
 /area/icy_caves/caves/northern)
 "Sv" = (
@@ -8782,9 +8817,14 @@
 	},
 /area/icy_caves/outpost/LZ1)
 "Th" = (
-/obj/structure/dropship_piece/one/corner/middleleft,
-/turf/open/floor/mainship_hull/dir{
-	dir = 4
+/obj/structure/barricade/guardrail{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"Ti" = (
+/turf/closed/shuttle/dropship2{
+	icon_state = "24"
 	},
 /area/icy_caves/caves/northern)
 "Tj" = (
@@ -8816,13 +8856,6 @@
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"Tt" = (
-/obj/machinery/door/poddoor/shutters/mainship{
-	dir = 2;
-	name = "Monorail Passage Door"
-	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "Tu" = (
@@ -8860,10 +8893,14 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
 "TC" = (
-/obj/structure/dropship_piece/one/corner/middleright,
-/turf/open/floor/mainship_hull/dir{
+/obj/structure/barricade/guardrail{
 	dir = 4
 	},
+/obj/structure/xenoautopsy/tank/escaped,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/shuttle/dropship/seven,
 /area/icy_caves/caves/northern)
 "TD" = (
 /obj/machinery/camera{
@@ -9132,6 +9169,12 @@
 /obj/item/analyzer,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
+"UZ" = (
+/obj/structure/dropship_piece/two/front,
+/turf/closed/shuttle/dropship2/transparent{
+	icon_state = "109"
+	},
+/area/icy_caves/caves/northern)
 "Vb" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 10
@@ -9244,13 +9287,12 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "VG" = (
-/turf/closed/ice/thin/corner,
-/area/icy_caves/outpost/LZ2)
-"VH" = (
-/turf/closed/ice/thin/end{
-	dir = 4
+/obj/structure/barricade/guardrail{
+	dir = 8
 	},
-/area/icy_caves/outpost/LZ1)
+/obj/structure/xenoautopsy/tank,
+/turf/open/shuttle/dropship/seven,
+/area/icy_caves/caves/northern)
 "VI" = (
 /turf/closed/ice/intersection,
 /area/icy_caves/caves/northern)
@@ -9384,10 +9426,12 @@
 	},
 /area/icy_caves/outpost/outside/center)
 "Wg" = (
-/turf/closed/ice/thin/corner{
-	dir = 1
+/obj/structure/barricade/guardrail{
+	dir = 4
 	},
-/area/icy_caves/outpost/LZ2)
+/obj/structure/xenoautopsy/tank/alien,
+/turf/open/shuttle/dropship/seven,
+/area/icy_caves/caves/northern)
 "Wi" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 1
@@ -9441,7 +9485,7 @@
 /area/icy_caves/caves/west)
 "Wy" = (
 /turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern)
+/area/space)
 "WA" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -9535,6 +9579,9 @@
 /obj/machinery/landinglight/ds1/delayone,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
+"Xe" = (
+/turf/closed/ice/thin/corner,
+/area/icy_caves/outpost/LZ2)
 "Xf" = (
 /obj/effect/landmark/start/job/survivor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -9645,9 +9692,11 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/east)
 "XD" = (
-/obj/item/shard,
-/turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern)
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/seven,
+/area/space)
 "XF" = (
 /turf/closed/ice/corner,
 /area/icy_caves/caves/west)
@@ -9684,11 +9733,11 @@
 /area/icy_caves/caves/west)
 "XL" = (
 /obj/structure/barricade/guardrail{
-	dir = 4
+	dir = 1
 	},
-/obj/structure/xenoautopsy/tank/alien,
+/obj/structure/dropship_piece/two/front,
 /turf/open/shuttle/dropship/seven,
-/area/icy_caves/caves/northern)
+/area/space)
 "XM" = (
 /obj/structure/bed/chair,
 /obj/effect/landmark/corpsespawner/colonist,
@@ -9862,6 +9911,11 @@
 	},
 /turf/open/shuttle/escapepod/plain,
 /area/icy_caves/caves/northern)
+"YE" = (
+/turf/closed/ice_rock/singlePart{
+	dir = 5
+	},
+/area/icy_caves/outpost/LZ2)
 "YF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -9997,9 +10051,6 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/LZ1)
 "Zl" = (
-/obj/structure/barricade/guardrail{
-	dir = 8
-	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "Zm" = (
@@ -11408,19 +11459,19 @@ GQ
 yb
 dF
 Ls
-eM
+Zl
 EU
-wY
-eM
+Zl
+Zl
 EU
-DF
+Zl
 nK
+PF
 dF
-eM
 EU
-eM
+Zl
 LF
-eM
+Zl
 WF
 Yf
 Yf
@@ -11563,20 +11614,20 @@ Ox
 yi
 Dm
 dF
-eM
-eM
-eM
-eM
+Zl
+Zl
+Zl
+Zl
 He
-eM
-eM
-iD
+Zl
+Zl
+Zl
+mT
 dF
-eM
-eM
-eM
+Zl
+Zl
 BZ
-eM
+Zl
 WF
 WF
 WF
@@ -11586,11 +11637,11 @@ WF
 WF
 WF
 WF
-eM
+Zl
 He
 dF
 EP
-eM
+Zl
 YP
 EP
 dF
@@ -11727,38 +11778,38 @@ Tz
 Tz
 Tz
 Tz
-iN
 Tz
+hz
 Tz
 Tz
 UU
-eM
+Zl
 Xz
-eM
-eM
-wY
+Zl
+Zl
+oX
 EU
-eM
-eM
-eM
-eM
-eM
-eM
-eM
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
 cV
 IU
 MX
 Lp
-eM
-eM
-eM
-eM
+Zl
+Zl
+Zl
+Zl
 EU
-eM
+Zl
 LF
-eM
+Zl
 dF
-eM
+Zl
 Mx
 NM
 xo
@@ -11876,17 +11927,17 @@ oQ
 yi
 zu
 TK
-eM
-eM
+Zl
+Zl
 BZ
-eM
-eM
-eM
-eM
+Zl
+Zl
+Zl
+Zl
 Wp
-eM
-eM
-eM
+Zl
+Zl
+Zl
 Wd
 Tz
 am
@@ -11897,27 +11948,27 @@ Tz
 TN
 Tz
 Yk
-eM
-eM
-eM
-eM
+Zl
+Zl
+Zl
+Zl
 Pp
 Fw
 La
 zt
-eM
-eM
-eM
+Zl
+Zl
+Zl
 He
-eM
-eM
+Zl
+Zl
 BZ
-eM
+Zl
 dF
 dL
-eM
+Zl
 ev
-eM
+Zl
 fb
 dF
 bD
@@ -12032,26 +12083,26 @@ wG
 yi
 OP
 TK
-eM
-eM
+Zl
+Zl
 BZ
-eM
-dL
-eM
-eM
-eM
-eM
-eM
-eM
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
 BZ
-eM
+Zl
 ev
 He
-eM
-eM
-eM
-eM
-eM
+Zl
+Zl
+Zl
+Zl
+Zl
 Wi
 Tz
 Tz
@@ -12060,18 +12111,18 @@ Tz
 Tz
 Tz
 UU
-eM
-eM
-eM
+Zl
+Zl
+Zl
 Gf
-eM
-eM
-eM
+Zl
+Zl
+Zl
 BZ
-eM
+Zl
 zZ
-eM
-eM
+Zl
+Zl
 ix
 eN
 fd
@@ -12187,34 +12238,34 @@ jo
 yi
 yi
 EP
-eM
-eM
-eM
+Zl
+Zl
+Zl
 BZ
-eM
-eM
-eM
-eM
+Zl
+Zl
+Zl
+Zl
+Zl
 EP
-eM
-eM
-eM
+Zl
+Zl
 BZ
-eM
+Zl
 Xz
-eM
-eM
-eM
-eM
-eM
-eM
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
 pL
-eM
-eM
-eM
-eM
-eM
-eM
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
 Wi
 Tz
 un
@@ -12344,43 +12395,43 @@ Do
 wq
 dF
 Bo
-eM
-eM
+Zl
+Zl
 BZ
-eM
+Zl
 He
-eM
-eM
+Zl
+Zl
+Zl
 dF
-eM
 dL
-eM
+Zl
 BZ
-eM
+Zl
 WF
-eM
-eM
-eM
-eM
-eM
-eM
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
 BZ
 Pg
 ve
-eM
-eM
-eM
-eM
+Zl
+Zl
+Zl
+Zl
 BZ
-eM
-eM
+Zl
+Zl
 Pg
 TD
-eM
-eM
-eM
-eM
-eM
+Zl
+Zl
+Zl
+Zl
+Zl
 dF
 dO
 ea
@@ -12489,30 +12540,30 @@ YQ
 (16,1,1) = {"
 YQ
 pl
-pl
-pl
-pl
-pl
+dF
+dF
+dF
+dF
 dF
 wO
 yi
 Hj
 kR
 dF
-eM
-eM
+Zl
+Zl
 dL
 ds
-eM
-eM
-eM
+Zl
+Zl
+Zl
+Zl
 FB
 dF
-gK
-cX
-eM
+yT
+Lc
 BZ
-eM
+Zl
 pE
 WF
 WF
@@ -12526,7 +12577,7 @@ dF
 dF
 dF
 dF
-eM
+Zl
 YP
 dF
 dF
@@ -12541,7 +12592,7 @@ dF
 nD
 ed
 nB
-eM
+Zl
 fg
 dF
 bD
@@ -12659,30 +12710,30 @@ pu
 dF
 dF
 dF
-eM
+Zl
 VL
 Vq
-eM
-dF
+Vq
+Vq
 dF
 dF
 dF
 BZ
-eM
+Zl
 WF
 Gs
 WF
 hT
-eM
-eM
-eM
+Zl
+Zl
+Zl
 AQ
 dF
 Gs
 Gs
 Gs
 dF
-eM
+Zl
 BZ
 dF
 DV
@@ -12802,34 +12853,34 @@ YQ
 YQ
 YQ
 YQ
-pl
-pl
-pl
+dF
+dF
+dF
 dF
 OP
 OP
 OP
-OP
-OP
+Se
+xs
 OP
 Mf
 OP
 dF
 dF
 Se
-CI
-dF
-dF
+Se
+Se
+Se
 Vt
 CH
 dF
 mg
-eM
+Zl
 WF
 Gs
 WF
 tT
-eM
+Zl
 pZ
 IY
 BZ
@@ -12838,7 +12889,7 @@ Gs
 Gs
 Gs
 dF
-eM
+Zl
 Wi
 Ts
 ZV
@@ -12961,33 +13012,33 @@ yF
 jL
 Me
 Me
-Me
-oM
+df
+Rw
+BN
+BN
+iS
+BN
+BN
+BN
+nG
+Rw
 BN
 jc
-BN
-BN
-BN
-BN
-Th
-Iu
-BN
 jc
-jc
-BN
-BN
-BN
+Gr
+Gr
+Ti
 ma
-EP
+dF
 BZ
-eM
+Zl
 WF
 Gs
 WF
 Ch
-eM
+Zl
 cD
-eM
+Zl
 pL
 dF
 Gs
@@ -13117,31 +13168,31 @@ wT
 Od
 JR
 Od
-df
+dg
+FR
 qk
 wf
-Im
-Wy
+pc
 MA
-wf
-wf
-lu
+TC
+Wg
+Ss
 ul
 Fk
-FE
-Wy
+NW
+XD
 GU
 NW
 XL
-Pc
-Tt
+UZ
+Zl
 BZ
-eM
+Zl
 WF
 Gs
 WF
 WX
-eM
+Zl
 Gf
 Mv
 ns
@@ -13150,7 +13201,7 @@ dF
 dF
 dF
 dF
-eM
+Zl
 BZ
 dF
 dF
@@ -13273,31 +13324,31 @@ yd
 RM
 cL
 RM
-dg
-qA
-xs
-Wy
-Wy
-Wy
-Wy
-Wy
+gK
+FR
+pc
+pc
+Bt
+pc
+pc
+MA
 Xy
-Wy
+pc
 Wy
 Wy
 ch
+xt
+cy
 Wy
-Wy
-GU
-Wy
-Tt
+FR
+Zl
 BZ
-eM
+Zl
 WF
 Gs
 WF
 xS
-eM
+Zl
 IY
 jk
 BZ
@@ -13306,7 +13357,7 @@ EX
 jd
 ze
 dF
-eM
+Zl
 BZ
 dF
 Gs
@@ -13430,23 +13481,23 @@ YB
 cF
 YB
 kn
-vT
-Bt
+FR
+qA
+wf
 Im
-Wy
-GU
-Bt
-Bt
+MA
+VG
+VG
 Rw
 uO
 Qn
-Wy
+NW
 XD
-GU
-oz
-oz
-Wy
-Tt
+Kc
+NW
+XL
+UZ
+Zl
 BZ
 dL
 WF
@@ -13454,8 +13505,8 @@ Gs
 WF
 Gj
 cD
-wY
-eM
+oX
+Zl
 ds
 dF
 Ij
@@ -13585,40 +13636,40 @@ Eh
 IP
 DU
 DU
-DU
+oM
+Ss
+KP
+KP
+iS
+KP
+KP
+KP
+lI
 Ss
 KP
 jc
-KP
-KP
-KP
-KP
-TC
-Ss
-KP
 jc
-jc
-KP
-KP
-KP
+ia
+ia
+ia
 gQ
-EP
+dF
 BZ
-eM
+Zl
 WF
 Gs
 WF
 ws
 He
-eM
+Zl
 ZZ
-eM
+Zl
 dF
 dF
 dF
 dF
 dF
-eM
+Zl
 BZ
 dF
 cJ
@@ -13738,15 +13789,15 @@ YQ
 YQ
 YQ
 YQ
-pl
-pl
-pl
+dF
+dF
+dF
 dF
 OP
 OP
-OP
-OP
-OP
+xs
+tF
+xs
 OP
 QD
 OP
@@ -13760,7 +13811,7 @@ rg
 HL
 dF
 mg
-eM
+Zl
 WF
 Gs
 WF
@@ -13774,7 +13825,7 @@ Gs
 Gs
 Ae
 dF
-eM
+Zl
 BZ
 dF
 cK
@@ -13902,21 +13953,21 @@ Wr
 dF
 dF
 Zl
+Th
+Th
+dF
+dF
+dF
 Zl
-Zl
-dF
-dF
-dF
-eM
 gM
 If
-eM
+Zl
 dF
 dF
 dF
 dF
 BZ
-eM
+Zl
 WF
 Gs
 WF
@@ -13930,7 +13981,7 @@ Gs
 Qo
 bP
 dF
-eM
+Zl
 BZ
 dF
 yh
@@ -14014,8 +14065,8 @@ UE
 UE
 UE
 UE
-VH
-VH
+lz
+lz
 Ey
 UE
 UE
@@ -14057,20 +14108,20 @@ dF
 Jn
 pN
 dF
-eM
-eM
+Zl
+Zl
 dL
 LF
-eM
-eM
-eM
-eM
+Zl
+Zl
+Zl
+Zl
 dL
-eM
-eM
+Zl
+Zl
 EU
 pS
-eM
+Zl
 Wi
 HT
 WF
@@ -14086,7 +14137,7 @@ Qo
 bI
 Rh
 dF
-eM
+Zl
 yV
 dF
 cb
@@ -14214,21 +14265,21 @@ oT
 Jn
 dF
 Bo
-eM
-eM
+Zl
+Zl
 BZ
-eM
-eM
-eM
-eM
-eM
-eM
-eM
-eM
-eM
-eM
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
 pL
-eM
+Zl
 WF
 Gs
 Gs
@@ -14242,7 +14293,7 @@ Ho
 bJ
 eB
 dF
-eM
+Zl
 YP
 dF
 yh
@@ -14323,16 +14374,16 @@ Al
 vy
 vy
 Mw
-iX
-iX
-iX
-iX
-iX
+wr
+wr
+wr
+wr
+wr
 Nn
-iX
-iX
+wr
+wr
 Mw
-iy
+mU
 uw
 uw
 uw
@@ -14369,22 +14420,22 @@ dF
 Ek
 uu
 dF
-eM
-eM
-eM
+Zl
+Zl
+Zl
 BZ
-eM
+Zl
 He
-eM
-eM
-eM
+Zl
+Zl
+Zl
 lR
 lR
-eM
-eM
-eM
+Zl
+Zl
+Zl
 Cm
-eM
+Zl
 WF
 Gs
 Gs
@@ -14398,9 +14449,9 @@ Ho
 yh
 SR
 SR
-eM
+Zl
 uT
-eM
+Zl
 yh
 wo
 SR
@@ -14525,9 +14576,9 @@ dF
 Gx
 YV
 dF
-eM
-eM
-eM
+Zl
+Zl
+Zl
 Wi
 Tz
 Tz
@@ -14540,7 +14591,7 @@ sG
 Tz
 Tz
 UU
-eM
+Zl
 WF
 Gs
 Gs
@@ -14554,9 +14605,9 @@ bl
 yh
 SR
 im
-eM
+Zl
 Cm
-eM
+Zl
 cO
 VI
 Nd
@@ -14685,18 +14736,18 @@ Tz
 Tz
 Tz
 UU
-eM
+Zl
 di
 Pg
-eM
+Zl
 KL
 dF
 dF
 yz
-eM
-eM
+Zl
+Zl
 BZ
-eM
+Zl
 WF
 Gs
 Gs
@@ -14712,7 +14763,7 @@ SR
 wo
 mq
 BZ
-eM
+Zl
 yh
 Lm
 by
@@ -14837,20 +14888,20 @@ dF
 dF
 dF
 WF
-eM
-eM
-eM
+Zl
+Zl
+Zl
 BZ
 dF
 dF
 dF
 xW
-eM
+Zl
 Rt
 fc
-eM
-eM
-eM
+Zl
+Zl
+Zl
 BZ
 He
 WF
@@ -14866,7 +14917,7 @@ SR
 yh
 PD
 Fu
-eM
+Zl
 Cm
 FB
 vv
@@ -14994,19 +15045,19 @@ Yf
 Yf
 WF
 dL
-eM
-eM
+Zl
+Zl
 BZ
 dF
 Gs
 dF
 cX
-eM
-eM
-eM
-eM
-eM
-eM
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
 BZ
 FB
 WF
@@ -15022,9 +15073,9 @@ SR
 kl
 bM
 VI
-eM
+Zl
 BZ
-eM
+Zl
 yh
 yh
 yh
@@ -15149,22 +15200,22 @@ Yf
 Yf
 Yf
 WF
-eM
-eM
-eM
+Zl
+Zl
+Zl
 BZ
 dF
 Gs
 dF
 UR
-eM
+Zl
 dL
-eM
-eM
-eM
-eM
+Zl
+Zl
+Zl
+Zl
 BZ
-eM
+Zl
 WF
 Gs
 Gs
@@ -15178,9 +15229,9 @@ SR
 cs
 bN
 Lm
-eM
+Zl
 BZ
-eM
+Zl
 Ho
 SR
 SR
@@ -15305,22 +15356,22 @@ Yf
 Yf
 Yf
 WF
-eM
-eM
-eM
+Zl
+Zl
+Zl
 ns
 dF
 Gs
 dF
 dF
-eM
+Zl
 dF
 dF
-eM
-eM
+Zl
+Zl
 Gf
 BZ
-eM
+Zl
 WF
 Gs
 Gs
@@ -15334,9 +15385,9 @@ cj
 ct
 cn
 bN
-eM
+Zl
 BZ
-eM
+Zl
 rf
 SR
 im
@@ -15462,21 +15513,21 @@ WF
 WF
 WF
 EP
-eM
+Zl
 Wc
 BF
 dF
 Gs
 Gs
 dF
-eM
+Zl
 dF
 dF
-eM
-eM
-eM
+Zl
+Zl
+Zl
 BZ
-eM
+Zl
 WF
 Gs
 Gs
@@ -15490,9 +15541,9 @@ SR
 cs
 cn
 cn
-eM
+Zl
 BZ
-eM
+Zl
 rf
 SR
 SR
@@ -15615,9 +15666,9 @@ Yf
 Yf
 Yf
 WF
-eM
+Zl
 EU
-eM
+Zl
 Bf
 Bf
 BZ
@@ -15626,13 +15677,13 @@ dF
 dF
 dF
 Bo
-eM
-eM
-eM
-eM
+Zl
+Zl
+Zl
+Zl
 dL
 BZ
-eM
+Zl
 WF
 Gs
 Gs
@@ -15646,9 +15697,9 @@ cj
 cv
 IC
 ci
-eM
+Zl
 BZ
-eM
+Zl
 rf
 SR
 SR
@@ -15771,16 +15822,16 @@ Yf
 Yf
 Yf
 WF
-eM
-eM
+Zl
+Zl
 dL
 Gf
-eM
+Zl
 BZ
-eM
-eM
+Zl
+Zl
 dF
-eM
+Zl
 Fj
 Tz
 Tz
@@ -15788,7 +15839,7 @@ Tz
 Tz
 Tz
 UU
-eM
+Zl
 WF
 Gs
 Ae
@@ -15802,9 +15853,9 @@ cj
 cw
 cm
 ci
-eM
+Zl
 BZ
-eM
+Zl
 SR
 Zb
 SR
@@ -15929,20 +15980,20 @@ Yf
 WF
 Xh
 Xh
-eM
-eM
-eM
+Zl
+Zl
+Zl
 HQ
 Xh
-eM
+Zl
 EP
-eM
-eM
-eM
-eM
-eM
-eM
-eM
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
 BZ
 FB
 WF
@@ -15960,7 +16011,7 @@ QK
 dF
 Bo
 BZ
-eM
+Zl
 rf
 PI
 PI
@@ -16085,22 +16136,22 @@ Yf
 WF
 MT
 eD
-eM
-eM
-eM
+Zl
+Zl
+Zl
 nv
 MT
 PZ
 eC
-eM
-eM
-eM
-eM
-eM
-eM
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
 He
 BZ
-eM
+Zl
 WF
 Il
 ce
@@ -16114,9 +16165,9 @@ bI
 Tu
 bL
 ci
-eM
+Zl
 BZ
-eM
+Zl
 SR
 SR
 SR
@@ -16241,22 +16292,22 @@ Yf
 WF
 eD
 eD
-eM
+Zl
 He
-eM
+Zl
 IK
 eD
 PZ
-eM
-eM
+Zl
+Zl
 dL
-eM
-eM
-eM
-eM
-eM
+Zl
+Zl
+Zl
+Zl
+Zl
 BZ
-eM
+Zl
 WF
 Qo
 ce
@@ -16270,9 +16321,9 @@ Rh
 XP
 QZ
 QK
-eM
+Zl
 BZ
-eM
+Zl
 SR
 im
 bl
@@ -16397,22 +16448,22 @@ Yf
 WF
 BW
 BW
-eM
-eM
-eM
+Zl
+Zl
+Zl
 QQ
 BW
-eM
+Zl
 EP
 di
 Pg
-eM
-eM
-eM
-eM
-eM
+Zl
+Zl
+Zl
+Zl
+Zl
 BZ
-eM
+Zl
 WF
 PD
 by
@@ -16428,7 +16479,7 @@ Rh
 XP
 WO
 BZ
-eM
+Zl
 SR
 SR
 SR
@@ -16552,7 +16603,7 @@ Yf
 Yf
 WF
 Yh
-eM
+Zl
 Fj
 Tz
 Tz
@@ -16564,11 +16615,11 @@ WF
 WF
 WF
 WF
-eM
-eM
+Zl
+Zl
 dL
 BZ
-eM
+Zl
 WF
 ot
 Ho
@@ -16581,10 +16632,10 @@ cc
 Rh
 XP
 Ry
-eM
-eM
+Zl
+Zl
 BZ
-eM
+Zl
 bN
 SR
 SR
@@ -16707,24 +16758,24 @@ Yf
 Yf
 Yf
 WF
-eM
-eM
+Zl
+Zl
 WB
 JF
 CX
-eM
-eM
-eM
+Zl
+Zl
+Zl
 WF
 Yf
 Yf
 Gs
 WF
 Bo
-eM
-eM
+Zl
+Zl
 BZ
-eM
+Zl
 Xz
 SR
 SR
@@ -16738,9 +16789,9 @@ Ry
 bS
 SR
 WO
-eM
+Zl
 BZ
-eM
+Zl
 cm
 SR
 SR
@@ -16877,24 +16928,24 @@ Yf
 Il
 WF
 LF
-eM
-eM
+Zl
+Zl
 BZ
-eM
+Zl
 Tx
-eM
+Zl
 WO
-eM
-eM
-eM
+Zl
+Zl
+Zl
 EU
-eM
-eM
-eM
-eM
-eM
+Zl
+Zl
+Zl
+Zl
+Zl
 LF
-eM
+Zl
 BZ
 WF
 bT
@@ -17188,23 +17239,23 @@ Yf
 Yf
 qs
 WF
-eM
-eM
+Zl
+Zl
 dL
-eM
-eM
+Zl
+Zl
 pr
-eM
-eM
-eM
-eM
-eM
+Zl
+Zl
+Zl
+Zl
+Zl
 dL
-eM
+Zl
 WO
 jC
-eM
-eM
+Zl
+Zl
 DH
 WF
 WF
@@ -27553,7 +27604,7 @@ oP
 wa
 CP
 Jm
-VG
+Xe
 OA
 mh
 yq
@@ -27580,7 +27631,7 @@ OA
 mh
 mh
 mh
-VG
+Xe
 oP
 iK
 oP
@@ -27735,7 +27786,7 @@ yq
 yB
 yB
 yB
-PM
+pd
 Cq
 oP
 iK
@@ -27867,9 +27918,9 @@ nI
 Wu
 oP
 WQ
-Wg
+Ra
 wv
-VG
+Xe
 oP
 wa
 oP
@@ -28023,9 +28074,9 @@ oP
 Wu
 CP
 wv
-VG
-Wg
-PM
+Xe
+Ra
+pd
 oP
 wa
 ka
@@ -28049,7 +28100,7 @@ fI
 fI
 OA
 wv
-VG
+Xe
 En
 wa
 oP
@@ -28178,9 +28229,9 @@ wa
 oP
 Wu
 oP
-Wg
+Ra
 wv
-VG
+Xe
 WQ
 nI
 oP
@@ -28335,9 +28386,9 @@ oP
 CZ
 wa
 oP
-Wg
+Ra
 yB
-PM
+pd
 nI
 wa
 on
@@ -28357,10 +28408,10 @@ on
 oP
 oP
 tw
-to
-Wg
+YE
+Ra
 yB
-PM
+pd
 oP
 En
 wa
@@ -29297,7 +29348,7 @@ wa
 oP
 wa
 oP
-xD
+RR
 Uj
 OJ
 bF
@@ -29453,7 +29504,7 @@ oP
 oP
 wa
 oP
-kt
+uF
 Uj
 GY
 bD
@@ -30233,7 +30284,7 @@ nW
 oP
 wa
 oP
-xD
+RR
 Uj
 NT
 bD
@@ -30389,7 +30440,7 @@ nW
 wa
 wa
 iT
-Ju
+tJ
 tv
 KV
 bD
@@ -30544,7 +30595,7 @@ nI
 oP
 wa
 oP
-xD
+RR
 Np
 zl
 bF
@@ -30700,7 +30751,7 @@ oP
 oP
 wa
 oP
-kt
+uF
 mH
 kW
 Yf

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -277,11 +277,6 @@
 	},
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
-"be" = (
-/turf/closed/ice/thin/corner{
-	dir = 8
-	},
-/area/icy_caves/outpost/LZ2)
 "bf" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -1343,10 +1338,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/LZ1)
-"fr" = (
-/obj/structure/largecrate/supply,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "fs" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -1775,6 +1766,10 @@
 	dir = 8
 	},
 /area/icy_caves/caves/east)
+"hF" = (
+/obj/structure/largecrate/random/barrel/yellow,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "hG" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/research_and_development,
@@ -1891,9 +1886,6 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
-"iz" = (
-/turf/closed/ice/thin/corner,
-/area/icy_caves/outpost/LZ2)
 "iG" = (
 /turf/open/floor/tile/dark/yellow2{
 	dir = 4
@@ -2013,6 +2005,13 @@
 /obj/effect/landmark/dropship_console_spawn_lz1,
 /turf/open/floor/plating/ground/snow,
 /area/lv624/lazarus/console)
+"jG" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "jH" = (
 /obj/machinery/landinglight/ds1/delaythree{
 	dir = 4
@@ -2121,11 +2120,6 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
-"kd" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/window/framed/colony/reinforced,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "ke" = (
 /turf/closed/ice/junction,
 /area/icy_caves/outpost/outside)
@@ -2423,6 +2417,12 @@
 /obj/structure/largecrate/random/barrel/blue,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
+"lq" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/seven,
+/area/space)
 "lt" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
@@ -2479,6 +2479,14 @@
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/mining/west)
+"lL" = (
+/obj/machinery/camera/autoname/mainship/dropship_one{
+	dir = 8;
+	pixel_x = 16
+	},
+/obj/structure/largecrate/supply/explosives,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "lM" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -2881,13 +2889,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside)
-"nr" = (
-/obj/structure/dropship_piece/one/corner/middleright,
-/obj/structure/dropship_piece/two/corner/rearright,
-/turf/open/floor/mainship_hull/dir{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
 "ns" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -2941,14 +2942,6 @@
 /obj/structure/janitorialcart,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/northern)
-"nG" = (
-/obj/structure/shuttle/engine/router{
-	dir = 1
-	},
-/obj/structure/dropship_equipment/weapon/heavygun,
-/obj/structure/dropship_equipment/weapon/rocket_pod,
-/turf/open/shuttle/dropship/floor,
-/area/space)
 "nH" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -3168,10 +3161,6 @@
 /area/icy_caves/caves/west)
 "pc" = (
 /turf/open/shuttle/dropship/floor,
-/area/icy_caves/caves/northern)
-"pd" = (
-/obj/structure/largecrate/random/barrel/green,
-/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "pf" = (
 /obj/effect/landmark/corpsespawner/miner{
@@ -3543,6 +3532,11 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
+"qL" = (
+/turf/closed/ice/thin/corner{
+	dir = 8
+	},
+/area/icy_caves/outpost/LZ2)
 "qN" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
@@ -3697,6 +3691,10 @@
 /obj/item/tool/kitchen/knife,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
+"rw" = (
+/obj/structure/largecrate/supply,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "rx" = (
 /obj/structure/table,
 /obj/item/reagent_containers/dropper,
@@ -3756,11 +3754,6 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/engineering)
-"rI" = (
-/turf/closed/shuttle/dropship2{
-	icon_state = "25"
-	},
-/area/icy_caves/caves/northern)
 "rJ" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -4040,6 +4033,10 @@
 /obj/machinery/light/small,
 /turf/open/floor/freezer,
 /area/icy_caves/outpost/dorms)
+"sS" = (
+/obj/structure/largecrate/random/barrel/green,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "sT" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -4218,10 +4215,6 @@
 	dir = 5
 	},
 /area/icy_caves/outpost/garage)
-"tP" = (
-/obj/machinery/door/poddoor/mainship/indestructible,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "tQ" = (
 /obj/structure/largecrate/random,
 /turf/open/floor/plating,
@@ -4304,6 +4297,12 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/medbay)
+"uk" = (
+/obj/machinery/camera{
+	dir = 5
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "ul" = (
 /obj/structure/dropship_piece/two/corner/rearright,
 /turf/open/shuttle/dropship/floor,
@@ -4440,12 +4439,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
-"uW" = (
-/obj/machinery/camera{
-	dir = 5
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "uX" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -4551,6 +4544,9 @@
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/r_wall,
 /area/icy_caves/caves/northern)
+"vw" = (
+/turf/closed/ice/thin/corner,
+/area/icy_caves/outpost/LZ2)
 "vx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1
@@ -4585,11 +4581,6 @@
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
-"vH" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
 "vI" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
@@ -4790,16 +4781,6 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/garage)
-"wR" = (
-/obj/vehicle/multitile/root/cm_armored/tank{
-	dir = 1;
-	layer = 1
-	},
-/obj/structure/dropship_equipment/weapon/laser_beam_gun,
-/obj/effect/turf_overlay/shuttle/heater,
-/obj/structure/dropship_equipment/weapon/rocket_pod,
-/turf/open/shuttle/dropship/floor,
-/area/space)
 "wT" = (
 /obj/structure/lattice,
 /obj/structure/monorail{
@@ -4828,6 +4809,11 @@
 	dir = 1
 	},
 /area/icy_caves/caves/south)
+"xc" = (
+/turf/closed/ice/corner{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "xf" = (
 /obj/structure/closet/secure_closet/scientist,
 /turf/open/floor/tile/dark/purple2,
@@ -5414,6 +5400,11 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/garage)
+"Aw" = (
+/turf/closed/ice/thin/end{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ1)
 "Ax" = (
 /obj/structure/table,
 /obj/machinery/light/built{
@@ -5496,12 +5487,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
-"AO" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/shuttle/dropship/seven,
-/area/space)
 "AQ" = (
 /obj/machinery/disposal,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -5648,11 +5633,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/east)
-"BA" = (
-/turf/closed/ice_rock/singlePart{
-	dir = 5
-	},
-/area/icy_caves/outpost/LZ2)
 "BB" = (
 /obj/structure/cryofeed,
 /turf/open/floor/podhatch/floor{
@@ -5730,6 +5710,11 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"BV" = (
+/turf/closed/ice/thin/corner{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "BW" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
@@ -5784,13 +5769,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
-"Cn" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
 "Cq" = (
 /turf/closed/ice/thin/end{
 	dir = 4
@@ -5800,6 +5778,10 @@
 /obj/item/ammo_casing,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"Ct" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Cx" = (
 /obj/machinery/power/smes/buildable/empty/dist,
 /obj/structure/cable,
@@ -5875,13 +5857,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"Dh" = (
-/obj/structure/dropship_piece/one/corner/middleleft,
-/obj/structure/dropship_piece/two/corner/rearleft,
-/turf/open/floor/mainship_hull/dir{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
 "Di" = (
 /turf/closed/ice/corner{
 	dir = 4
@@ -5960,10 +5935,6 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
-"Dy" = (
-/obj/structure/largecrate/random/barrel/yellow,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "DB" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/ice_rock/singlePart{
@@ -6324,6 +6295,11 @@
 "Fw" = (
 /turf/open/floor/tile/white/warningstripe{
 	dir = 4
+	},
+/area/icy_caves/caves/northern)
+"Fx" = (
+/turf/closed/shuttle/dropship2{
+	icon_state = "24"
 	},
 /area/icy_caves/caves/northern)
 "Fy" = (
@@ -7112,11 +7088,6 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
-"JG" = (
-/turf/closed/ice/corner{
-	dir = 4
-	},
-/area/icy_caves/outpost/LZ2)
 "JH" = (
 /obj/structure/table,
 /obj/item/reagent_containers/spray/pepper,
@@ -7149,14 +7120,6 @@
 	dir = 5
 	},
 /area/icy_caves/caves)
-"JQ" = (
-/obj/machinery/camera/autoname/mainship/dropship_one{
-	dir = 8;
-	pixel_x = 16
-	},
-/obj/structure/largecrate/supply/explosives,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "JR" = (
 /obj/structure/lattice,
 /obj/structure/monorail{
@@ -7258,11 +7221,6 @@
 /obj/item/belt_harness,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
-"Kv" = (
-/turf/closed/shuttle/dropship2{
-	icon_state = "24"
-	},
-/area/icy_caves/caves/northern)
 "Ky" = (
 /obj/machinery/space_heater,
 /turf/open/floor/tile/dark,
@@ -7342,6 +7300,16 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/outside)
+"KW" = (
+/obj/vehicle/multitile/root/cm_armored/tank{
+	dir = 1;
+	layer = 1
+	},
+/obj/structure/dropship_equipment/weapon/laser_beam_gun,
+/obj/effect/turf_overlay/shuttle/heater,
+/obj/structure/dropship_equipment/weapon/rocket_pod,
+/turf/open/shuttle/dropship/floor,
+/area/space)
 "KZ" = (
 /turf/closed/wall,
 /area/icy_caves/outpost/garage)
@@ -8155,11 +8123,6 @@
 	dir = 8
 	},
 /area/icy_caves/caves/south)
-"Pt" = (
-/turf/closed/ice/corner{
-	dir = 1
-	},
-/area/icy_caves/outpost/LZ2)
 "Pu" = (
 /obj/machinery/light{
 	dir = 4
@@ -8168,6 +8131,11 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/refinery)
+"Py" = (
+/turf/closed/ice/junction{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "Pz" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -8192,6 +8160,11 @@
 "PD" = (
 /turf/closed/ice/corner{
 	dir = 4
+	},
+/area/icy_caves/caves/northern)
+"PG" = (
+/turf/closed/shuttle/dropship2{
+	icon_state = "25"
 	},
 /area/icy_caves/caves/northern)
 "PI" = (
@@ -8224,6 +8197,11 @@
 /obj/machinery/light,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"PP" = (
+/turf/closed/ice_rock/singlePart{
+	dir = 5
+	},
+/area/icy_caves/outpost/LZ2)
 "PQ" = (
 /obj/item/ammo_casing,
 /obj/item/weapon/gun/smg/m25,
@@ -8572,6 +8550,10 @@
 	dir = 4
 	},
 /area/icy_caves/caves)
+"RF" = (
+/obj/machinery/door/poddoor/mainship/indestructible,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "RG" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 1
@@ -8645,6 +8627,14 @@
 /obj/effect/landmark/start/job/survivor,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
+"Sb" = (
+/obj/structure/shuttle/engine/router{
+	dir = 1
+	},
+/obj/structure/dropship_equipment/weapon/heavygun,
+/obj/structure/dropship_equipment/weapon/rocket_pod,
+/turf/open/shuttle/dropship/floor,
+/area/space)
 "Sc" = (
 /obj/effect/landmark/xeno_silo_spawn,
 /turf/open/floor/plating/mainship,
@@ -8742,6 +8732,11 @@
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
+"SG" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "SH" = (
 /turf/open/floor/tile/dark/red2{
 	dir = 10
@@ -9246,11 +9241,6 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/LZ1)
-"Vv" = (
-/turf/closed/ice/thin/end{
-	dir = 4
-	},
-/area/icy_caves/outpost/LZ1)
 "Vx" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -9290,6 +9280,13 @@
 	},
 /obj/structure/xenoautopsy/tank,
 /turf/open/shuttle/dropship/seven,
+/area/icy_caves/caves/northern)
+"VH" = (
+/obj/structure/dropship_piece/one/corner/middleright,
+/obj/structure/dropship_piece/two/corner/rearright,
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
 /area/icy_caves/caves/northern)
 "VI" = (
 /turf/closed/ice/intersection,
@@ -9444,10 +9441,6 @@
 "Wm" = (
 /obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"Wp" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "Wr" = (
@@ -9726,6 +9719,11 @@
 "XJ" = (
 /turf/closed/ice_rock/singleEnd,
 /area/icy_caves/caves/west)
+"XK" = (
+/turf/closed/ice/corner{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ2)
 "XL" = (
 /obj/structure/barricade/guardrail{
 	dir = 1
@@ -9783,11 +9781,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/LZ1)
-"XY" = (
-/turf/closed/ice/thin/corner{
-	dir = 1
-	},
-/area/icy_caves/outpost/LZ2)
 "XZ" = (
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 4
@@ -10154,16 +10147,23 @@
 	dir = 4
 	},
 /area/icy_caves/caves/south)
+"ZQ" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"ZR" = (
+/obj/structure/dropship_piece/one/corner/middleleft,
+/obj/structure/dropship_piece/two/corner/rearleft,
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "ZS" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
 	},
 /turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/LZ2)
-"ZT" = (
-/turf/closed/ice/junction{
-	dir = 1
-	},
 /area/icy_caves/outpost/LZ2)
 "ZU" = (
 /turf/open/floor/plating/ground/ice,
@@ -11466,7 +11466,7 @@ Zl
 EU
 Zl
 nK
-pd
+sS
 dF
 EU
 Zl
@@ -11622,7 +11622,7 @@ He
 Zl
 Zl
 Zl
-Dy
+hF
 dF
 Zl
 Zl
@@ -11779,7 +11779,7 @@ Tz
 Tz
 Tz
 Tz
-kd
+ZQ
 Tz
 Tz
 UU
@@ -11787,7 +11787,7 @@ Zl
 Xz
 Zl
 Zl
-uW
+uk
 EU
 Zl
 Zl
@@ -11934,8 +11934,8 @@ Zl
 Zl
 Zl
 Zl
-Wp
 Zl
+Ct
 Zl
 Zl
 Wd
@@ -12560,8 +12560,8 @@ Zl
 Zl
 FB
 dF
-JQ
-fr
+lL
+rw
 BZ
 Zl
 pE
@@ -13020,14 +13020,14 @@ iS
 BN
 BN
 BN
-Dh
+ZR
 Rw
 BN
 jc
 jc
-tP
-tP
-Kv
+RF
+RF
+Fx
 ma
 dF
 BZ
@@ -13337,8 +13337,8 @@ pc
 Wy
 Wy
 ch
-wR
-nG
+KW
+Sb
 Wy
 FR
 Zl
@@ -13493,7 +13493,7 @@ uO
 Qn
 NW
 XD
-AO
+lq
 NW
 XL
 UZ
@@ -13505,7 +13505,7 @@ Gs
 WF
 Gj
 cD
-uW
+uk
 Zl
 ds
 dF
@@ -13644,14 +13644,14 @@ iS
 KP
 KP
 KP
-nr
+VH
 Ss
 KP
 jc
 jc
-rI
-rI
-rI
+PG
+PG
+PG
 gQ
 dF
 BZ
@@ -14065,8 +14065,8 @@ UE
 UE
 UE
 UE
-Vv
-Vv
+Aw
+Aw
 Ey
 UE
 UE
@@ -14374,16 +14374,16 @@ Al
 vy
 vy
 Mw
-vH
-vH
-vH
-vH
-vH
+SG
+SG
+SG
+SG
+SG
 Nn
-vH
-vH
+SG
+SG
 Mw
-Cn
+jG
 uw
 uw
 uw
@@ -27604,7 +27604,7 @@ oP
 wa
 CP
 Jm
-iz
+vw
 OA
 mh
 yq
@@ -27631,7 +27631,7 @@ OA
 mh
 mh
 mh
-iz
+vw
 oP
 iK
 oP
@@ -27786,7 +27786,7 @@ yq
 yB
 yB
 yB
-be
+qL
 Cq
 oP
 iK
@@ -27918,9 +27918,9 @@ nI
 Wu
 oP
 WQ
-XY
+BV
 wv
-iz
+vw
 oP
 wa
 oP
@@ -28074,9 +28074,9 @@ oP
 Wu
 CP
 wv
-iz
-XY
-be
+vw
+BV
+qL
 oP
 wa
 ka
@@ -28100,7 +28100,7 @@ fI
 fI
 OA
 wv
-iz
+vw
 En
 wa
 oP
@@ -28229,9 +28229,9 @@ wa
 oP
 Wu
 oP
-XY
+BV
 wv
-iz
+vw
 WQ
 nI
 oP
@@ -28386,9 +28386,9 @@ oP
 CZ
 wa
 oP
-XY
+BV
 yB
-be
+qL
 nI
 wa
 on
@@ -28408,10 +28408,10 @@ on
 oP
 oP
 tw
-BA
-XY
+PP
+BV
 yB
-be
+qL
 oP
 En
 wa
@@ -29348,7 +29348,7 @@ wa
 oP
 wa
 oP
-JG
+XK
 Uj
 OJ
 bF
@@ -29504,7 +29504,7 @@ oP
 oP
 wa
 oP
-Pt
+xc
 Uj
 GY
 bD
@@ -30284,7 +30284,7 @@ nW
 oP
 wa
 oP
-JG
+XK
 Uj
 NT
 bD
@@ -30440,7 +30440,7 @@ nW
 wa
 wa
 iT
-ZT
+Py
 tv
 KV
 bD
@@ -30595,7 +30595,7 @@ nI
 oP
 wa
 oP
-JG
+XK
 Np
 zl
 bF
@@ -30751,7 +30751,7 @@ oP
 oP
 wa
 oP
-Pt
+xc
 mH
 kW
 Yf

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -277,6 +277,11 @@
 	},
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
+"be" = (
+/turf/closed/ice/thin/corner{
+	dir = 8
+	},
+/area/icy_caves/outpost/LZ2)
 "bf" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
@@ -676,14 +681,6 @@
 	dir = 4
 	},
 /area/icy_caves/caves/northern)
-"cy" = (
-/obj/structure/shuttle/engine/router{
-	dir = 1
-	},
-/obj/structure/dropship_equipment/weapon/heavygun,
-/obj/structure/dropship_equipment/weapon/rocket_pod,
-/turf/open/shuttle/dropship/floor,
-/area/space)
 "cC" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/ice/end,
@@ -1346,6 +1343,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/LZ1)
+"fr" = (
+/obj/structure/largecrate/supply,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "fs" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -1759,11 +1760,6 @@
 	},
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/east)
-"hz" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/window/framed/colony/reinforced,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "hA" = (
 /obj/machinery/light{
 	dir = 4
@@ -1835,11 +1831,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/northern)
-"ia" = (
-/turf/closed/shuttle/dropship2{
-	icon_state = "25"
-	},
-/area/icy_caves/caves/northern)
 "ib" = (
 /obj/machinery/light{
 	dir = 1
@@ -1900,6 +1891,9 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
+"iz" = (
+/turf/closed/ice/thin/corner,
+/area/icy_caves/outpost/LZ2)
 "iG" = (
 /turf/open/floor/tile/dark/yellow2{
 	dir = 4
@@ -2127,6 +2121,11 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
+"kd" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "ke" = (
 /turf/closed/ice/junction,
 /area/icy_caves/outpost/outside)
@@ -2440,11 +2439,6 @@
 	},
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside/center)
-"lz" = (
-/turf/closed/ice/thin/end{
-	dir = 4
-	},
-/area/icy_caves/outpost/LZ1)
 "lA" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -2485,13 +2479,6 @@
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/mining/west)
-"lI" = (
-/obj/structure/dropship_piece/one/corner/middleright,
-/obj/structure/dropship_piece/two/corner/rearright,
-/turf/open/floor/mainship_hull/dir{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
 "lM" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -2793,17 +2780,6 @@
 /obj/item/storage/donut_box,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
-"mT" = (
-/obj/structure/largecrate/random/barrel/yellow,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"mU" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
 "mV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -2905,6 +2881,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/outside)
+"nr" = (
+/obj/structure/dropship_piece/one/corner/middleright,
+/obj/structure/dropship_piece/two/corner/rearright,
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "ns" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -2959,12 +2942,13 @@
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/northern)
 "nG" = (
-/obj/structure/dropship_piece/one/corner/middleleft,
-/obj/structure/dropship_piece/two/corner/rearleft,
-/turf/open/floor/mainship_hull/dir{
-	dir = 4
+/obj/structure/shuttle/engine/router{
+	dir = 1
 	},
-/area/icy_caves/caves/northern)
+/obj/structure/dropship_equipment/weapon/heavygun,
+/obj/structure/dropship_equipment/weapon/rocket_pod,
+/turf/open/shuttle/dropship/floor,
+/area/space)
 "nH" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -3170,12 +3154,6 @@
 "oW" = (
 /turf/closed/ice_rock/westWall,
 /area/icy_caves/caves)
-"oX" = (
-/obj/machinery/camera{
-	dir = 5
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "oZ" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -3192,10 +3170,9 @@
 /turf/open/shuttle/dropship/floor,
 /area/icy_caves/caves/northern)
 "pd" = (
-/turf/closed/ice/thin/corner{
-	dir = 8
-	},
-/area/icy_caves/outpost/LZ2)
+/obj/structure/largecrate/random/barrel/green,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "pf" = (
 /obj/effect/landmark/corpsespawner/miner{
 	corpseback = /obj/item/storage/backpack/satchel/norm;
@@ -3779,6 +3756,11 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/engineering)
+"rI" = (
+/turf/closed/shuttle/dropship2{
+	icon_state = "25"
+	},
+/area/icy_caves/caves/northern)
 "rJ" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/snow/layer1,
@@ -4206,11 +4188,6 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/garage)
-"tJ" = (
-/turf/closed/ice/junction{
-	dir = 1
-	},
-/area/icy_caves/outpost/LZ2)
 "tK" = (
 /obj/item/ammo_casing,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -4241,6 +4218,10 @@
 	dir = 5
 	},
 /area/icy_caves/outpost/garage)
+"tP" = (
+/obj/machinery/door/poddoor/mainship/indestructible,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "tQ" = (
 /obj/structure/largecrate/random,
 /turf/open/floor/plating,
@@ -4404,11 +4385,6 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
-"uF" = (
-/turf/closed/ice/corner{
-	dir = 1
-	},
-/area/icy_caves/outpost/LZ2)
 "uH" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/tile/dark/green2{
@@ -4461,6 +4437,12 @@
 /obj/effect/landmark/weed_node,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
+"uW" = (
+/obj/machinery/camera{
+	dir = 5
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
@@ -4603,6 +4585,11 @@
 /obj/machinery/computer/intel_computer,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/east)
+"vH" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "vI" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
@@ -4724,11 +4711,6 @@
 	icon_state = "bright_clean2"
 	},
 /area/icy_caves/caves/northern)
-"wr" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
 "ws" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/tile/dark,
@@ -4808,6 +4790,16 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/garage)
+"wR" = (
+/obj/vehicle/multitile/root/cm_armored/tank{
+	dir = 1;
+	layer = 1
+	},
+/obj/structure/dropship_equipment/weapon/laser_beam_gun,
+/obj/effect/turf_overlay/shuttle/heater,
+/obj/structure/dropship_equipment/weapon/rocket_pod,
+/turf/open/shuttle/dropship/floor,
+/area/space)
 "wT" = (
 /obj/structure/lattice,
 /obj/structure/monorail{
@@ -4904,16 +4896,6 @@
 /obj/structure/barricade/guardrail,
 /turf/open/floor/mainship/red/full,
 /area/icy_caves/caves/northern)
-"xt" = (
-/obj/vehicle/multitile/root/cm_armored/tank{
-	dir = 1;
-	layer = 1
-	},
-/obj/structure/dropship_equipment/weapon/laser_beam_gun,
-/obj/effect/turf_overlay/shuttle/heater,
-/obj/structure/dropship_equipment/weapon/rocket_pod,
-/turf/open/shuttle/dropship/floor,
-/area/space)
 "xu" = (
 /obj/structure/cargo_container/green,
 /turf/open/floor/plating,
@@ -5130,14 +5112,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
-"yT" = (
-/obj/machinery/camera/autoname/mainship/dropship_one{
-	dir = 8;
-	pixel_x = 16
-	},
-/obj/structure/largecrate/supply/explosives,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "yU" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 9
@@ -5522,6 +5496,12 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/mainship,
 /area/icy_caves/caves/crashed_ship)
+"AO" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/seven,
+/area/space)
 "AQ" = (
 /obj/machinery/disposal,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -5668,6 +5648,11 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/east)
+"BA" = (
+/turf/closed/ice_rock/singlePart{
+	dir = 5
+	},
+/area/icy_caves/outpost/LZ2)
 "BB" = (
 /obj/structure/cryofeed,
 /turf/open/floor/podhatch/floor{
@@ -5799,6 +5784,13 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
+"Cn" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "Cq" = (
 /turf/closed/ice/thin/end{
 	dir = 4
@@ -5883,6 +5875,13 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"Dh" = (
+/obj/structure/dropship_piece/one/corner/middleleft,
+/obj/structure/dropship_piece/two/corner/rearleft,
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "Di" = (
 /turf/closed/ice/corner{
 	dir = 4
@@ -5961,6 +5960,10 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
+"Dy" = (
+/obj/structure/largecrate/random/barrel/yellow,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "DB" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/ice_rock/singlePart{
@@ -6468,10 +6471,6 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/medbay)
-"Gr" = (
-/obj/machinery/door/poddoor/mainship/indestructible,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "Gs" = (
 /turf/closed/ice_rock/corners,
 /area/icy_caves/caves/northern)
@@ -7113,6 +7112,11 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
+"JG" = (
+/turf/closed/ice/corner{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ2)
 "JH" = (
 /obj/structure/table,
 /obj/item/reagent_containers/spray/pepper,
@@ -7145,6 +7149,14 @@
 	dir = 5
 	},
 /area/icy_caves/caves)
+"JQ" = (
+/obj/machinery/camera/autoname/mainship/dropship_one{
+	dir = 8;
+	pixel_x = 16
+	},
+/obj/structure/largecrate/supply/explosives,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "JR" = (
 /obj/structure/lattice,
 /obj/structure/monorail{
@@ -7186,12 +7198,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/office)
-"Kc" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/shuttle/dropship/seven,
-/area/space)
 "Kd" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark/brown2/corner{
@@ -7252,6 +7258,11 @@
 /obj/item/belt_harness,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/security)
+"Kv" = (
+/turf/closed/shuttle/dropship2{
+	icon_state = "24"
+	},
+/area/icy_caves/caves/northern)
 "Ky" = (
 /obj/machinery/space_heater,
 /turf/open/floor/tile/dark,
@@ -7346,10 +7357,6 @@
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"Lc" = (
-/obj/structure/largecrate/supply,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "Ld" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/corners{
@@ -8148,6 +8155,11 @@
 	dir = 8
 	},
 /area/icy_caves/caves/south)
+"Pt" = (
+/turf/closed/ice/corner{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "Pu" = (
 /obj/machinery/light{
 	dir = 4
@@ -8181,10 +8193,6 @@
 /turf/closed/ice/corner{
 	dir = 4
 	},
-/area/icy_caves/caves/northern)
-"PF" = (
-/obj/structure/largecrate/random/barrel/green,
-/turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "PI" = (
 /obj/effect/landmark/xeno_resin_door,
@@ -8434,11 +8442,6 @@
 	dir = 4
 	},
 /area/icy_caves/caves/northern)
-"Ra" = (
-/turf/closed/ice/thin/corner{
-	dir = 1
-	},
-/area/icy_caves/outpost/LZ2)
 "Rb" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 1
@@ -8616,11 +8619,6 @@
 /area/icy_caves/outpost/dorms)
 "RQ" = (
 /turf/closed/ice_rock/fourway,
-/area/icy_caves/outpost/LZ2)
-"RR" = (
-/turf/closed/ice/corner{
-	dir = 4
-	},
 /area/icy_caves/outpost/LZ2)
 "RS" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
@@ -8821,11 +8819,6 @@
 	dir = 8
 	},
 /turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"Ti" = (
-/turf/closed/shuttle/dropship2{
-	icon_state = "24"
-	},
 /area/icy_caves/caves/northern)
 "Tj" = (
 /obj/machinery/light{
@@ -9253,6 +9246,11 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/LZ1)
+"Vv" = (
+/turf/closed/ice/thin/end{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ1)
 "Vx" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 6
@@ -9579,9 +9577,6 @@
 /obj/machinery/landinglight/ds1/delayone,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
-"Xe" = (
-/turf/closed/ice/thin/corner,
-/area/icy_caves/outpost/LZ2)
 "Xf" = (
 /obj/effect/landmark/start/job/survivor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -9788,6 +9783,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/LZ1)
+"XY" = (
+/turf/closed/ice/thin/corner{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "XZ" = (
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 4
@@ -9911,11 +9911,6 @@
 	},
 /turf/open/shuttle/escapepod/plain,
 /area/icy_caves/caves/northern)
-"YE" = (
-/turf/closed/ice_rock/singlePart{
-	dir = 5
-	},
-/area/icy_caves/outpost/LZ2)
 "YF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
@@ -10164,6 +10159,11 @@
 	dir = 1
 	},
 /turf/open/floor/plating/ground/snow/layer1,
+/area/icy_caves/outpost/LZ2)
+"ZT" = (
+/turf/closed/ice/junction{
+	dir = 1
+	},
 /area/icy_caves/outpost/LZ2)
 "ZU" = (
 /turf/open/floor/plating/ground/ice,
@@ -11466,7 +11466,7 @@ Zl
 EU
 Zl
 nK
-PF
+pd
 dF
 EU
 Zl
@@ -11622,7 +11622,7 @@ He
 Zl
 Zl
 Zl
-mT
+Dy
 dF
 Zl
 Zl
@@ -11779,7 +11779,7 @@ Tz
 Tz
 Tz
 Tz
-hz
+kd
 Tz
 Tz
 UU
@@ -11787,7 +11787,7 @@ Zl
 Xz
 Zl
 Zl
-oX
+uW
 EU
 Zl
 Zl
@@ -12560,8 +12560,8 @@ Zl
 Zl
 FB
 dF
-yT
-Lc
+JQ
+fr
 BZ
 Zl
 pE
@@ -13020,14 +13020,14 @@ iS
 BN
 BN
 BN
-nG
+Dh
 Rw
 BN
 jc
 jc
-Gr
-Gr
-Ti
+tP
+tP
+Kv
 ma
 dF
 BZ
@@ -13337,8 +13337,8 @@ pc
 Wy
 Wy
 ch
-xt
-cy
+wR
+nG
 Wy
 FR
 Zl
@@ -13493,7 +13493,7 @@ uO
 Qn
 NW
 XD
-Kc
+AO
 NW
 XL
 UZ
@@ -13505,7 +13505,7 @@ Gs
 WF
 Gj
 cD
-oX
+uW
 Zl
 ds
 dF
@@ -13644,14 +13644,14 @@ iS
 KP
 KP
 KP
-lI
+nr
 Ss
 KP
 jc
 jc
-ia
-ia
-ia
+rI
+rI
+rI
 gQ
 dF
 BZ
@@ -14065,8 +14065,8 @@ UE
 UE
 UE
 UE
-lz
-lz
+Vv
+Vv
 Ey
 UE
 UE
@@ -14374,16 +14374,16 @@ Al
 vy
 vy
 Mw
-wr
-wr
-wr
-wr
-wr
+vH
+vH
+vH
+vH
+vH
 Nn
-wr
-wr
+vH
+vH
 Mw
-mU
+Cn
 uw
 uw
 uw
@@ -27604,7 +27604,7 @@ oP
 wa
 CP
 Jm
-Xe
+iz
 OA
 mh
 yq
@@ -27631,7 +27631,7 @@ OA
 mh
 mh
 mh
-Xe
+iz
 oP
 iK
 oP
@@ -27786,7 +27786,7 @@ yq
 yB
 yB
 yB
-pd
+be
 Cq
 oP
 iK
@@ -27918,9 +27918,9 @@ nI
 Wu
 oP
 WQ
-Ra
+XY
 wv
-Xe
+iz
 oP
 wa
 oP
@@ -28074,9 +28074,9 @@ oP
 Wu
 CP
 wv
-Xe
-Ra
-pd
+iz
+XY
+be
 oP
 wa
 ka
@@ -28100,7 +28100,7 @@ fI
 fI
 OA
 wv
-Xe
+iz
 En
 wa
 oP
@@ -28229,9 +28229,9 @@ wa
 oP
 Wu
 oP
-Ra
+XY
 wv
-Xe
+iz
 WQ
 nI
 oP
@@ -28386,9 +28386,9 @@ oP
 CZ
 wa
 oP
-Ra
+XY
 yB
-pd
+be
 nI
 wa
 on
@@ -28408,10 +28408,10 @@ on
 oP
 oP
 tw
-YE
-Ra
+BA
+XY
 yB
-pd
+be
 oP
 En
 wa
@@ -29348,7 +29348,7 @@ wa
 oP
 wa
 oP
-RR
+JG
 Uj
 OJ
 bF
@@ -29504,7 +29504,7 @@ oP
 oP
 wa
 oP
-uF
+Pt
 Uj
 GY
 bD
@@ -30284,7 +30284,7 @@ nW
 oP
 wa
 oP
-RR
+JG
 Uj
 NT
 bD
@@ -30440,7 +30440,7 @@ nW
 wa
 wa
 iT
-tJ
+ZT
 tv
 KV
 bD
@@ -30595,7 +30595,7 @@ nI
 oP
 wa
 oP
-RR
+JG
 Np
 zl
 bF
@@ -30751,7 +30751,7 @@ oP
 oP
 wa
 oP
-uF
+Pt
 mH
 kW
 Yf

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -676,12 +676,6 @@
 	dir = 4
 	},
 /area/icy_caves/caves/northern)
-"cz" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/shuttle/dropship/seven,
-/area/space)
 "cC" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/ice/end,
@@ -863,6 +857,14 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
+"dv" = (
+/obj/machinery/camera/autoname/mainship/dropship_one{
+	dir = 8;
+	pixel_x = 16
+	},
+/obj/structure/largecrate/supply/explosives,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "dw" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 4
@@ -979,6 +981,11 @@
 "dY" = (
 /turf/closed/ice/thin/end,
 /area/icy_caves/caves/east)
+"dZ" = (
+/turf/closed/shuttle/dropship2{
+	icon_state = "24"
+	},
+/area/icy_caves/caves/northern)
 "ea" = (
 /obj/effect/landmark/corpsespawner/pmc,
 /turf/open/floor/tile/dark,
@@ -1345,9 +1352,15 @@
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/LZ1)
 "fs" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/snow/layer1,
-/area/icy_caves/outpost/LZ1)
+/obj/structure/barricade/guardrail{
+	dir = 1
+	},
+/obj/structure/dropship_piece/two/front,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/shuttle/dropship/seven,
+/area/space)
 "ft" = (
 /turf/closed/ice/thin/junction{
 	dir = 4
@@ -1537,14 +1550,6 @@
 	dir = 4
 	},
 /area/icy_caves/caves/east)
-"gv" = (
-/obj/structure/shuttle/engine/router{
-	dir = 1
-	},
-/obj/structure/dropship_equipment/weapon/heavygun,
-/obj/structure/dropship_equipment/weapon/rocket_pod,
-/turf/open/shuttle/dropship/floor,
-/area/space)
 "gw" = (
 /turf/closed/ice_rock/singleT{
 	dir = 1
@@ -1771,6 +1776,10 @@
 	},
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
+"hB" = (
+/obj/structure/largecrate/supply,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "hD" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno,
 /turf/open/floor/plating/ground/ice,
@@ -1902,10 +1911,9 @@
 	},
 /area/icy_caves/outpost/engineering)
 "iJ" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/lowcharge,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
+/obj/machinery/computer/intel_computer,
+/turf/open/floor/plating,
+/area/icy_caves/outpost/mining/west)
 "iK" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -1923,13 +1931,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/south)
-"iR" = (
-/obj/structure/dropship_piece/one/corner/middleleft,
-/obj/structure/dropship_piece/two/corner/rearleft,
-/turf/open/floor/mainship_hull/dir{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
 "iS" = (
 /obj/machinery/door/poddoor/mainship,
 /turf/open/shuttle/dropship/floor,
@@ -2029,9 +2030,8 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
 "jI" = (
-/obj/machinery/computer/intel_computer,
-/turf/open/floor/plating,
-/area/icy_caves/outpost/mining/west)
+/turf/open/floor/plating/ground/snow/layer2,
+/area/icy_caves/caves)
 "jJ" = (
 /obj/machinery/landinglight/ds1/delayone{
 	dir = 8
@@ -2130,6 +2130,11 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ2)
+"kd" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "ke" = (
 /turf/closed/ice/junction,
 /area/icy_caves/outpost/outside)
@@ -2301,6 +2306,11 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/research)
+"kL" = (
+/turf/closed/ice_rock/singlePart{
+	dir = 5
+	},
+/area/icy_caves/outpost/LZ2)
 "kM" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
 /turf/closed/ice_rock/singlePart{
@@ -2483,6 +2493,11 @@
 	},
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/mining/west)
+"lL" = (
+/turf/closed/ice/thin/corner{
+	dir = 8
+	},
+/area/icy_caves/outpost/LZ2)
 "lM" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -3470,6 +3485,13 @@
 	dir = 10
 	},
 /area/icy_caves/outpost/refinery)
+"qu" = (
+/obj/structure/dropship_piece/one/corner/middleleft,
+/obj/structure/dropship_piece/two/corner/rearleft,
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "qw" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 1
@@ -3830,8 +3852,8 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
 "sb" = (
-/obj/machinery/floodlight/landing,
-/turf/open/floor/tile/dark,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/snow/layer1,
 /area/icy_caves/outpost/LZ1)
 "sc" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
@@ -3983,10 +4005,10 @@
 	},
 /area/icy_caves/outpost/medbay)
 "sD" = (
-/obj/machinery/landinglight/ds1/delaythree{
+/obj/effect/landmark/fob_sentry_rebel,
+/turf/closed/ice_rock/singleEnd{
 	dir = 8
 	},
-/turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
 "sE" = (
 /obj/machinery/light/small{
@@ -4006,16 +4028,10 @@
 /turf/closed/ice/thin/corner,
 /area/icy_caves/caves/east)
 "sK" = (
-/obj/docking_port/stationary/marine_dropship/lz1,
-/turf/open/floor/plating,
+/obj/machinery/power/apc/lowcharge,
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
 /area/icy_caves/outpost/LZ1)
-"sM" = (
-/obj/structure/dropship_piece/one/corner/middleright,
-/obj/structure/dropship_piece/two/corner/rearright,
-/turf/open/floor/mainship_hull/dir{
-	dir = 4
-	},
-/area/icy_caves/caves/northern)
 "sN" = (
 /obj/structure/table/flipped,
 /obj/item/flashlight,
@@ -4175,10 +4191,6 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/garage)
-"tJ" = (
-/obj/machinery/door/poddoor/mainship/indestructible,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "tK" = (
 /obj/item/ammo_casing,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -4217,10 +4229,6 @@
 /obj/effect/decal/warning_stripes/thin,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
-"tS" = (
-/obj/structure/largecrate/supply,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "tT" = (
 /obj/structure/table/mainship,
 /obj/machinery/computer/med_data,
@@ -4326,6 +4334,14 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/LZ2)
+"us" = (
+/obj/structure/shuttle/engine/router{
+	dir = 1
+	},
+/obj/structure/dropship_equipment/weapon/heavygun,
+/obj/structure/dropship_equipment/weapon/rocket_pod,
+/turf/open/shuttle/dropship/floor,
+/area/space)
 "uu" = (
 /obj/effect/decal/cleanable/blood/xtracks,
 /turf/open/floor/plating/plating_catwalk,
@@ -4498,6 +4514,11 @@
 	dir = 10
 	},
 /area/icy_caves/outpost/engineering)
+"vn" = (
+/turf/closed/shuttle/dropship2{
+	icon_state = "25"
+	},
+/area/icy_caves/caves/northern)
 "vo" = (
 /obj/machinery/light{
 	dir = 1
@@ -4575,11 +4596,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
-"vJ" = (
-/turf/closed/ice/corner{
-	dir = 4
-	},
-/area/icy_caves/outpost/LZ2)
 "vL" = (
 /obj/effect/decal/cleanable/blood/gibs/robot,
 /turf/open/floor/tile/dark/brown2/corner,
@@ -4667,6 +4683,10 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/medbay)
+"wj" = (
+/obj/structure/largecrate/random/barrel/yellow,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "wk" = (
 /turf/open/floor/tile/dark/red2/corner,
 /area/icy_caves/outpost/security)
@@ -4717,12 +4737,6 @@
 /obj/structure/window/framed/colony,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/refinery)
-"wy" = (
-/obj/machinery/camera{
-	dir = 5
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "wz" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -4748,10 +4762,7 @@
 /turf/open/floor/tile/dark/brown2,
 /area/icy_caves/outpost/refinery)
 "wL" = (
-/obj/machinery/landinglight/ds1/delaythree{
-	dir = 1
-	},
-/turf/open/floor/plating,
+/turf/open/floor/mech_bay_recharge_floor,
 /area/icy_caves/outpost/LZ1)
 "wM" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -4781,11 +4792,6 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/garage)
-"wR" = (
-/turf/closed/shuttle/dropship2{
-	icon_state = "24"
-	},
-/area/icy_caves/caves/northern)
 "wT" = (
 /obj/structure/lattice,
 /obj/structure/monorail{
@@ -5023,6 +5029,12 @@
 "yq" = (
 /turf/closed/ice/thin/straight,
 /area/icy_caves/outpost/LZ2)
+"yv" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/seven,
+/area/space)
 "yw" = (
 /obj/structure/closet/secure_closet/scientist,
 /obj/machinery/light,
@@ -5033,11 +5045,6 @@
 /area/icy_caves/outpost/engineering)
 "yz" = (
 /obj/structure/bed/chair,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"yA" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/window/framed/colony/reinforced,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
 "yB" = (
@@ -5240,10 +5247,9 @@
 /turf/closed/ice_rock/singlePart,
 /area/icy_caves/caves)
 "zM" = (
-/obj/machinery/landinglight/ds1/delayone{
-	dir = 1
-	},
-/turf/open/floor/plating,
+/obj/machinery/landinglight/ds1/delaytwo,
+/obj/machinery/floodlight/landing,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "zN" = (
 /obj/effect/landmark/excavation_site_spawner,
@@ -5261,11 +5267,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
-"zR" = (
-/turf/closed/ice/junction{
-	dir = 1
-	},
-/area/icy_caves/outpost/LZ2)
 "zS" = (
 /turf/closed/ice/end{
 	dir = 4
@@ -5334,11 +5335,21 @@
 "Ae" = (
 /turf/closed/ice_rock/eastWall,
 /area/icy_caves/caves/northern)
+"Af" = (
+/obj/vehicle/multitile/root/cm_armored/tank{
+	dir = 1;
+	layer = 1
+	},
+/obj/structure/dropship_equipment/weapon/laser_beam_gun,
+/obj/effect/turf_overlay/shuttle/heater,
+/obj/structure/dropship_equipment/weapon/rocket_pod,
+/turf/open/shuttle/dropship/floor,
+/area/space)
 "Ag" = (
-/obj/machinery/landinglight/ds1/delaytwo{
+/obj/machinery/landinglight/ds1/delaythree{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "Ah" = (
 /obj/effect/landmark/corpsespawner/security{
@@ -5460,12 +5471,6 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/office)
-"AH" = (
-/obj/machinery/landinglight/ds1{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/icy_caves/outpost/LZ1)
 "AI" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/tile/dark/brown2/corner{
@@ -5480,6 +5485,11 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/outside)
+"AL" = (
+/turf/closed/ice/corner{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "AM" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/cable,
@@ -5715,11 +5725,6 @@
 	},
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
-"BV" = (
-/turf/closed/ice/thin/corner{
-	dir = 8
-	},
-/area/icy_caves/outpost/LZ2)
 "BW" = (
 /obj/structure/bed/chair/comfy{
 	dir = 8
@@ -5767,6 +5772,12 @@
 	dir = 1
 	},
 /area/icy_caves/outpost/research)
+"Cl" = (
+/obj/machinery/camera{
+	dir = 5
+	},
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Cm" = (
 /obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -5986,6 +5997,13 @@
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
+"DS" = (
+/obj/structure/dropship_piece/one/corner/middleright,
+/obj/structure/dropship_piece/two/corner/rearright,
+/turf/open/floor/mainship_hull/dir{
+	dir = 4
+	},
+/area/icy_caves/caves/northern)
 "DU" = (
 /turf/open/floor/mainship_hull/dir{
 	dir = 4
@@ -6120,16 +6138,6 @@
 "EB" = (
 /turf/closed/ice/thin/corner,
 /area/icy_caves/caves/west)
-"EC" = (
-/obj/vehicle/multitile/root/cm_armored/tank{
-	dir = 1;
-	layer = 1
-	},
-/obj/structure/dropship_equipment/weapon/laser_beam_gun,
-/obj/effect/turf_overlay/shuttle/heater,
-/obj/structure/dropship_equipment/weapon/rocket_pod,
-/turf/open/shuttle/dropship/floor,
-/area/space)
 "ED" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -6182,9 +6190,6 @@
 	dir = 4
 	},
 /area/icy_caves/outpost/LZ1)
-"ER" = (
-/turf/closed/ice/thin/corner,
-/area/icy_caves/outpost/LZ2)
 "ES" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 1
@@ -6243,6 +6248,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
+"Fk" = (
+/obj/structure/barricade/guardrail,
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/seven,
+/area/space)
 "Fm" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 10
@@ -6311,19 +6323,6 @@
 /obj/machinery/light,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
-"FC" = (
-/obj/machinery/camera/autoname/mainship/dropship_one{
-	dir = 8;
-	pixel_x = 16
-	},
-/obj/structure/largecrate/supply/explosives,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
-"FD" = (
-/turf/closed/ice/thin/corner{
-	dir = 1
-	},
-/area/icy_caves/outpost/LZ2)
 "FF" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
@@ -6449,6 +6448,10 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/garage)
+"Gn" = (
+/obj/structure/largecrate/random/barrel/green,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Go" = (
 /turf/open/floor/tile/dark/purple2/corner{
 	dir = 1
@@ -6480,10 +6483,6 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone,
 /turf/closed/ice_rock/singleT,
 /area/icy_caves/caves)
-"GC" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/snow,
-/area/icy_caves/outpost/LZ1)
 "GD" = (
 /turf/open/floor/tile/dark/red2/corner{
 	dir = 1
@@ -6498,6 +6497,11 @@
 "GF" = (
 /turf/closed/wall,
 /area/icy_caves/caves/west)
+"GG" = (
+/turf/closed/ice/thin/corner{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
 "GH" = (
 /obj/machinery/miner/damaged/platinum,
 /turf/open/floor/plating/ground/ice,
@@ -6571,11 +6575,11 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
 "GU" = (
-/obj/machinery/light{
+/obj/machinery/landinglight/ds1/delaythree{
 	dir = 8
 	},
-/turf/open/shuttle/dropship/seven,
-/area/space)
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "GV" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -6584,11 +6588,6 @@
 	dir = 8
 	},
 /area/icy_caves/outpost/medbay)
-"GW" = (
-/turf/closed/ice_rock/singlePart{
-	dir = 5
-	},
-/area/icy_caves/outpost/LZ2)
 "GX" = (
 /obj/machinery/computer/nuke_disk_generator/blue,
 /turf/open/floor/tile/dark/purple2{
@@ -6656,10 +6655,6 @@
 "Hq" = (
 /turf/closed/ice_rock/fourway,
 /area/icy_caves/caves/east)
-"Hr" = (
-/obj/structure/largecrate/random/barrel/green,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "Hu" = (
 /obj/structure/closet/crate/science,
 /turf/open/floor/tile/dark/purple2{
@@ -6702,6 +6697,11 @@
 	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
+"HF" = (
+/turf/closed/ice/corner{
+	dir = 4
+	},
+/area/icy_caves/outpost/LZ2)
 "HG" = (
 /turf/closed/ice/intersection,
 /area/icy_caves/caves/south)
@@ -6896,10 +6896,6 @@
 	dir = 1
 	},
 /area/icy_caves/caves/south)
-"Iz" = (
-/obj/structure/largecrate/random/barrel/yellow,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "IA" = (
 /obj/machinery/light,
 /obj/effect/landmark/excavation_site_spawner,
@@ -7260,13 +7256,6 @@
 	},
 /turf/open/floor/freezer,
 /area/icy_caves/outpost/kitchen)
-"KB" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
 "KC" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/colonist,
@@ -7504,10 +7493,10 @@
 	},
 /area/icy_caves/outpost/garage)
 "LL" = (
-/obj/machinery/landinglight/ds1/delaytwo{
-	dir = 8
+/obj/machinery/landinglight/ds1{
+	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "LO" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -7728,10 +7717,10 @@
 	},
 /area/icy_caves/caves/south)
 "MO" = (
-/obj/machinery/landinglight/ds1{
-	dir = 1
+/obj/machinery/landinglight/ds1/delaytwo{
+	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "MP" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
@@ -7744,11 +7733,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/office)
-"MS" = (
-/turf/closed/shuttle/dropship2{
-	icon_state = "25"
-	},
-/area/icy_caves/caves/northern)
 "MT" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/cheeseburger,
@@ -7853,6 +7837,11 @@
 /obj/item/ammo_magazine/smg/m25,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"Nu" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "Nv" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
@@ -8222,6 +8211,14 @@
 /obj/item/weapon/gun/smg/m25,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
+"PR" = (
+/turf/closed/ice/junction{
+	dir = 1
+	},
+/area/icy_caves/outpost/LZ2)
+"PS" = (
+/turf/closed/ice/thin/corner,
+/area/icy_caves/outpost/LZ2)
 "PT" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
@@ -8272,6 +8269,13 @@
 /obj/effect/landmark/excavation_site_spawner,
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/west)
+"Qe" = (
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/icy_caves/outpost/LZ1)
 "Qf" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark/green2{
@@ -8300,7 +8304,10 @@
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
 "Qn" = (
-/obj/structure/bed/chair/dropship/passenger,
+/obj/structure/barricade/guardrail,
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 8
+	},
 /turf/open/shuttle/dropship/seven,
 /area/space)
 "Qo" = (
@@ -8322,11 +8329,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/south)
-"Qu" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/structure/cable,
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
 "Qw" = (
 /turf/closed/ice/corner{
 	dir = 4
@@ -8667,7 +8669,9 @@
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone{
 	dir = 2
 	},
-/turf/open/floor/plating/ground/snow/layer2,
+/turf/closed/ice_rock/singleEnd{
+	dir = 8
+	},
 /area/icy_caves/caves)
 "Si" = (
 /obj/machinery/light{
@@ -8729,10 +8733,10 @@
 	},
 /area/icy_caves/caves/south)
 "SB" = (
-/turf/closed/ice/corner{
-	dir = 1
+/turf/closed/ice/thin/end{
+	dir = 4
 	},
-/area/icy_caves/outpost/LZ2)
+/area/icy_caves/outpost/LZ1)
 "SD" = (
 /turf/closed/ice_rock/singlePart{
 	dir = 4
@@ -8914,10 +8918,10 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
 "TI" = (
-/obj/machinery/landinglight/ds1/delaytwo{
-	dir = 1
+/obj/machinery/landinglight/ds1/delayone{
+	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "TJ" = (
 /turf/closed/ice/intersection,
@@ -9013,8 +9017,8 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "Ud" = (
-/obj/machinery/floodlight/landing,
-/turf/open/floor/plating/ground/snow/layer2,
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
 "Ug" = (
 /obj/machinery/power/apc/drained,
@@ -9290,8 +9294,8 @@
 /turf/closed/ice/intersection,
 /area/icy_caves/caves/northern)
 "VJ" = (
-/obj/machinery/camera/autoname/lz_camera,
-/turf/open/floor/plating,
+/obj/machinery/landinglight/ds1/delaytwo,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "VK" = (
 /obj/machinery/light{
@@ -9397,7 +9401,7 @@
 /obj/machinery/landinglight/ds1/delayone{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "Wc" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
@@ -9441,6 +9445,10 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/caves/northern)
+"Wp" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "Wr" = (
 /obj/machinery/door/airlock/mainship/maint,
 /turf/open/floor/tile/dark,
@@ -9475,11 +9483,6 @@
 "Wy" = (
 /turf/open/shuttle/dropship/floor,
 /area/space)
-"Wz" = (
-/turf/closed/ice/thin/end{
-	dir = 4
-	},
-/area/icy_caves/outpost/LZ1)
 "WA" = (
 /obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
 	dir = 2
@@ -9515,7 +9518,10 @@
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/outside)
 "WK" = (
-/turf/open/floor/mech_bay_recharge_floor,
+/obj/machinery/landinglight/ds1{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "WO" = (
 /obj/effect/landmark/weed_node,
@@ -9540,8 +9546,10 @@
 /turf/closed/ice_rock/fourway,
 /area/icy_caves/caves)
 "WT" = (
-/obj/machinery/landinglight/ds1/delaytwo,
-/turf/open/floor/plating,
+/obj/machinery/landinglight/ds1/delaytwo{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "WU" = (
 /obj/structure/closet/cabinet,
@@ -9570,8 +9578,10 @@
 /turf/closed/wall/r_wall,
 /area/icy_caves/outpost/medbay)
 "Xa" = (
-/obj/machinery/landinglight/ds1/delayone,
-/turf/open/floor/plating,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/closed/ice/thin/end{
+	dir = 1
+	},
 /area/icy_caves/outpost/LZ1)
 "Xf" = (
 /obj/effect/landmark/start/job/survivor,
@@ -9634,7 +9644,7 @@
 	},
 /area/icy_caves/caves)
 "Xq" = (
-/obj/machinery/landinglight/ds1,
+/obj/docking_port/stationary/marine_dropship/lz1,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
 "Xr" = (
@@ -9642,8 +9652,11 @@
 /turf/open/floor/plating/dmg3,
 /area/icy_caves/caves/crashed_ship)
 "Xs" = (
-/obj/machinery/landinglight/ds1/delaythree,
-/turf/open/floor/plating,
+/obj/machinery/landinglight/ds1/delayone{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "Xu" = (
 /turf/closed/ice/end{
@@ -9748,6 +9761,10 @@
 "XP" = (
 /turf/closed/ice_rock/singleEnd,
 /area/icy_caves/caves/northern)
+"XQ" = (
+/obj/machinery/door/poddoor/mainship/indestructible,
+/turf/open/floor/tile/dark,
+/area/icy_caves/caves/northern)
 "XR" = (
 /obj/structure/closet/crate,
 /obj/item/storage/box/lightstick/red,
@@ -9823,10 +9840,11 @@
 	},
 /area/icy_caves/outpost/medbay)
 "Yj" = (
-/obj/machinery/landinglight/ds1/delaythree{
+/obj/machinery/landinglight/ds1/delaytwo{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/machinery/floodlight/landing,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "Yk" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -9865,9 +9883,7 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ2)
 "Yw" = (
-/obj/machinery/landinglight/ds1/delayone{
-	dir = 8
-	},
+/obj/machinery/landinglight/ds1/delaytwo,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
 "Yx" = (
@@ -10130,20 +10146,17 @@
 /turf/closed/ice/straight,
 /area/icy_caves/caves/south)
 "ZK" = (
-/obj/machinery/landinglight/ds1{
+/obj/machinery/floodlight/landing,
+/obj/machinery/landinglight/ds1/delaytwo{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "ZL" = (
 /obj/machinery/power/apc/drained,
 /obj/structure/cable,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
-"ZM" = (
-/obj/machinery/door/airlock/multi_tile/mainship/generic,
-/turf/open/floor/tile/dark,
-/area/icy_caves/caves/northern)
 "ZP" = (
 /turf/closed/ice_rock/singleEnd{
 	dir = 4
@@ -10787,7 +10800,7 @@ Zk
 Zm
 UE
 UE
-Uu
+fq
 Uu
 qz
 aG
@@ -10937,31 +10950,31 @@ qs
 uA
 TW
 qz
-UE
-WD
-Zm
-Zm
-UE
-UE
-UE
-UE
-UE
-UE
-Uu
-Uu
-Uu
-Uu
-Uu
-Uu
-Uu
-UE
-UE
-UE
-UE
-UE
-Uu
-Uu
-Uu
+wL
+uw
+uw
+uw
+Ag
+Ag
+LL
+Wb
+WT
+Ag
+LL
+Wb
+WT
+Ag
+Wb
+Wb
+WT
+Ag
+LL
+Xs
+WT
+Ag
+LL
+Xs
+Yj
 Vb
 Ww
 bD
@@ -11093,31 +11106,31 @@ qs
 ED
 qz
 UM
-WD
-WD
-WD
-GC
-WD
-UE
-WD
-WD
-WD
-UE
-UE
-UM
-fs
-UE
-UE
-UE
-UE
-UE
-WD
-WD
-GC
-UE
-Uu
+uw
+uw
+uw
+VJ
+Yn
+Yn
 Ud
-Uu
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Ud
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Ud
+Yw
 VU
 uc
 bD
@@ -11248,32 +11261,32 @@ Yf
 qy
 RC
 TM
-UE
-WK
-Yj
-Yj
-AH
-Wb
-Ag
-Yj
-AH
-Wb
-Ag
-Yj
-WK
-Wb
-Ag
-Yj
-AH
-Wb
-Ag
-Yj
-AH
-Wb
-Ag
-WK
-Uu
-Uu
+uw
+uw
+dW
+uw
+VJ
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yw
 qH
 Ww
 bD
@@ -11404,10 +11417,10 @@ DX
 AB
 zi
 TM
-UE
-WT
-Yn
-Yn
+uw
+uw
+uw
+uw
 VJ
 Yn
 Yn
@@ -11416,7 +11429,6 @@ Yn
 Yn
 Yn
 Yn
-VJ
 Yn
 Yn
 Yn
@@ -11425,11 +11437,12 @@ Yn
 Yn
 Yn
 Yn
-VJ
 Yn
-wL
-UE
-UE
+Yn
+Yn
+Yn
+Yn
+Yw
 XH
 Ne
 Yf
@@ -11456,7 +11469,7 @@ Zl
 EU
 Zl
 nK
-Hr
+Gn
 dF
 EU
 Zl
@@ -11559,9 +11572,12 @@ Uu
 DX
 DX
 Sh
-TM
-UE
-Xa
+sK
+bU
+uw
+uw
+uw
+VJ
 Yn
 Yn
 Yn
@@ -11582,10 +11598,7 @@ Yn
 Yn
 Yn
 Yn
-Yn
-MO
-WD
-UE
+Yw
 VU
 Ne
 Yf
@@ -11612,7 +11625,7 @@ He
 Zl
 Zl
 Zl
-Iz
+wj
 dF
 Zl
 Zl
@@ -11713,11 +11726,14 @@ WI
 Uu
 Uu
 DX
-WD
-YH
+Ml
+Tf
 TM
-UE
-Xq
+bU
+uw
+uw
+uw
+VJ
 Yn
 Yn
 Yn
@@ -11738,10 +11754,7 @@ Yn
 Yn
 Yn
 Yn
-Yn
-zM
-UE
-UE
+Yw
 bH
 Ne
 Yf
@@ -11769,7 +11782,7 @@ Tz
 Tz
 Tz
 Tz
-yA
+kd
 Tz
 Tz
 UU
@@ -11777,7 +11790,7 @@ Zl
 Xz
 Zl
 Zl
-wy
+Cl
 EU
 Zl
 Zl
@@ -11862,18 +11875,21 @@ SI
 SI
 AW
 WI
-WI
-WI
-WI
+XO
+XO
+XO
 WI
 Uu
 Uu
 Uu
-WD
-YH
+Ml
+Tf
 TM
+bU
 uw
-Xs
+uw
+uw
+zM
 Yn
 Yn
 Yn
@@ -11884,6 +11900,7 @@ Yn
 Yn
 Yn
 Yn
+Xq
 Yn
 Yn
 Yn
@@ -11893,11 +11910,7 @@ Yn
 Yn
 Yn
 Yn
-Yn
-Yn
-TI
-UE
-UE
+Yw
 bH
 Ne
 Yf
@@ -11924,8 +11937,8 @@ Zl
 Zl
 Zl
 Zl
+Wp
 Zl
-ZM
 Zl
 Zl
 Wd
@@ -12022,14 +12035,17 @@ WI
 WI
 WI
 WI
-fq
+sb
 Uu
 Uu
 Uu
-Tm
+Aq
 TM
-iJ
-WT
+bU
+uw
+uw
+uw
+VJ
 Yn
 Yn
 Yn
@@ -12050,10 +12066,7 @@ Yn
 Yn
 Yn
 Yn
-Yn
-wL
-WD
-UE
+Yw
 bH
 Ne
 Yf
@@ -12185,7 +12198,10 @@ Uu
 YH
 TM
 bU
-Xa
+uw
+uw
+dW
+VJ
 Yn
 Yn
 Yn
@@ -12196,7 +12212,6 @@ Yn
 Yn
 Yn
 Yn
-sK
 Yn
 Yn
 Yn
@@ -12207,9 +12222,7 @@ Yn
 Yn
 Yn
 Yn
-MO
-UE
-UE
+Yw
 bH
 Ne
 Yf
@@ -12337,11 +12350,14 @@ WI
 Uu
 Uu
 Uu
-VT
+Ml
 Tf
 Tb
 XW
-Xq
+uw
+uw
+uw
+VJ
 Yn
 Yn
 Yn
@@ -12362,10 +12378,7 @@ Yn
 Yn
 Yn
 Yn
-Yn
-zM
-UE
-Uu
+Yw
 XH
 Ne
 Yf
@@ -12492,12 +12505,15 @@ MH
 WI
 Uu
 Uu
-Uu
-VT
+sD
+Ml
 Tf
 Ml
 XW
-Xs
+uw
+uw
+uw
+VJ
 Yn
 Yn
 Yn
@@ -12518,10 +12534,7 @@ Yn
 Yn
 Yn
 Yn
-Yn
-TI
-UE
-Uu
+Yw
 VU
 Ne
 Yf
@@ -12550,8 +12563,8 @@ Zl
 Zl
 FB
 dF
-FC
-tS
+dv
+hB
 BZ
 Zl
 pE
@@ -12649,11 +12662,25 @@ MH
 Uu
 Uu
 Uu
-VT
-Tm
+UE
+TQ
 Uu
 Vk
-WT
+uw
+uw
+uw
+VJ
+Yn
+Yn
+Ud
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Ud
 Yn
 Yn
 Yn
@@ -12662,22 +12689,8 @@ Yn
 Yn
 Yn
 Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-wL
-UE
-Uu
+Ud
+Yw
 qH
 Ne
 Yf
@@ -12809,31 +12822,31 @@ Uu
 TQ
 Uu
 bU
-Xa
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
+uw
+uw
+uw
+uw
+GU
 MO
-UE
-Uu
+TI
+WK
+GU
+MO
+TI
+GU
+GU
+MO
+TI
+WK
+GU
+MO
+TI
+WK
+GU
+MO
+MO
+MO
+ZK
 XH
 Ne
 Yf
@@ -12953,11 +12966,11 @@ xI
 NH
 SI
 WI
-MH
-MH
-MH
+jI
+jI
+jI
 WI
-MH
+jI
 Uu
 UE
 UE
@@ -12965,31 +12978,31 @@ UE
 TQ
 UE
 XW
-Xq
-Yn
-Yn
-VJ
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-VJ
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-VJ
-Yn
-zM
-UE
-Uu
+uw
+uw
+uw
+uw
+uw
+uw
+dW
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+dW
+uw
+uw
+uw
+uw
+uw
+uw
+uw
 VU
 Ne
 Yf
@@ -13010,14 +13023,14 @@ iS
 BN
 BN
 BN
-iR
+qu
 Rw
 BN
 jc
 jc
-tJ
-tJ
-wR
+XQ
+XQ
+dZ
 ma
 dF
 BZ
@@ -13121,31 +13134,31 @@ UE
 TQ
 WD
 XW
-WK
-Yw
-Yw
-ZK
-sD
-LL
-Yw
-ZK
-sD
-LL
-Yw
-WK
-sD
-LL
-Yw
-ZK
-sD
-LL
-Yw
-ZK
-sD
-LL
-WK
-UE
-Uu
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
+uw
 qH
 Ne
 Yf
@@ -13168,12 +13181,12 @@ TC
 Wg
 Ss
 ul
-Qn
+Fk
 NW
 XD
-GU
 NW
-XL
+NW
+fs
 UZ
 Zl
 BZ
@@ -13286,9 +13299,9 @@ uw
 uw
 uw
 uw
+dW
 uw
 uw
-sb
 dW
 HE
 uw
@@ -13298,10 +13311,10 @@ uw
 uw
 uw
 HB
-WD
-UE
-UM
-Uu
+uw
+uw
+uw
+uw
 XH
 Ne
 Yf
@@ -13327,8 +13340,8 @@ pc
 Wy
 Wy
 ch
-EC
-gv
+Af
+us
 Wy
 FR
 Zl
@@ -13409,14 +13422,14 @@ ZU
 gz
 XF
 xI
-oZ
+iJ
 oI
 wW
 oI
 ig
 wW
 oI
-jI
+oI
 nO
 SI
 SI
@@ -13454,10 +13467,10 @@ uw
 uw
 uw
 uw
-WD
-WD
-UE
-Uu
+uw
+uw
+uw
+uw
 XH
 uy
 Yf
@@ -13483,7 +13496,7 @@ uO
 Qn
 NW
 XD
-cz
+yv
 NW
 XL
 UZ
@@ -13495,7 +13508,7 @@ Gs
 WF
 Gj
 cD
-wy
+Cl
 Zl
 ds
 dF
@@ -13576,7 +13589,7 @@ xI
 xI
 Za
 SI
-Za
+XO
 XO
 WI
 AW
@@ -13596,8 +13609,8 @@ uw
 vi
 WD
 WD
-WD
-UE
+AB
+AB
 AB
 Nr
 jE
@@ -13611,7 +13624,7 @@ WD
 uw
 uw
 Zm
-WD
+VT
 Ml
 VU
 VU
@@ -13634,14 +13647,14 @@ iS
 KP
 KP
 KP
-sM
+DS
 Ss
 KP
 jc
 jc
-MS
-MS
-MS
+vn
+vn
+vn
 gQ
 dF
 BZ
@@ -13732,7 +13745,7 @@ WI
 WI
 XO
 SI
-Za
+XO
 XO
 XO
 XO
@@ -13752,8 +13765,8 @@ uw
 vi
 Zm
 Zm
-WD
-UE
+Ml
+Ml
 AB
 mb
 Nr
@@ -13763,10 +13776,10 @@ JA
 fN
 Ml
 Ml
-Zm
+VT
 uw
 uw
-Zm
+VT
 Ml
 XH
 WS
@@ -13878,7 +13891,7 @@ gx
 SF
 XO
 Za
-Za
+XO
 Za
 Za
 Dn
@@ -13909,8 +13922,8 @@ HI
 ZE
 ZE
 KJ
-TT
-ZE
+Xa
+Xa
 Vu
 DL
 EO
@@ -13922,7 +13935,7 @@ vr
 vr
 Hl
 Hl
-ZE
+vr
 vr
 vr
 PL
@@ -14036,7 +14049,7 @@ XO
 XO
 XO
 oO
-Za
+XO
 Dn
 SI
 Za
@@ -14055,8 +14068,8 @@ UE
 UE
 UE
 UE
-Wz
-Wz
+SB
+SB
 Ey
 UE
 UE
@@ -14364,16 +14377,16 @@ Al
 vy
 vy
 Mw
-Qu
-Qu
-Qu
-Qu
-Qu
+Nu
+Nu
+Nu
+Nu
+Nu
 Nn
-Qu
-Qu
+Nu
+Nu
 Mw
-KB
+Qe
 uw
 uw
 uw
@@ -27594,7 +27607,7 @@ oP
 wa
 CP
 Jm
-ER
+PS
 OA
 mh
 yq
@@ -27621,7 +27634,7 @@ OA
 mh
 mh
 mh
-ER
+PS
 oP
 iK
 oP
@@ -27776,7 +27789,7 @@ yq
 yB
 yB
 yB
-BV
+lL
 Cq
 oP
 iK
@@ -27908,9 +27921,9 @@ nI
 Wu
 oP
 WQ
-FD
+GG
 wv
-ER
+PS
 oP
 wa
 oP
@@ -28064,9 +28077,9 @@ oP
 Wu
 CP
 wv
-ER
-FD
-BV
+PS
+GG
+lL
 oP
 wa
 ka
@@ -28090,7 +28103,7 @@ fI
 fI
 OA
 wv
-ER
+PS
 En
 wa
 oP
@@ -28219,9 +28232,9 @@ wa
 oP
 Wu
 oP
-FD
+GG
 wv
-ER
+PS
 WQ
 nI
 oP
@@ -28376,9 +28389,9 @@ oP
 CZ
 wa
 oP
-FD
+GG
 yB
-BV
+lL
 nI
 wa
 on
@@ -28398,10 +28411,10 @@ on
 oP
 oP
 tw
-GW
-FD
+kL
+GG
 yB
-BV
+lL
 oP
 En
 wa
@@ -29338,7 +29351,7 @@ wa
 oP
 wa
 oP
-vJ
+HF
 Uj
 OJ
 bF
@@ -29494,7 +29507,7 @@ oP
 oP
 wa
 oP
-SB
+AL
 Uj
 GY
 bD
@@ -30274,7 +30287,7 @@ nW
 oP
 wa
 oP
-vJ
+HF
 Uj
 NT
 bD
@@ -30430,7 +30443,7 @@ nW
 wa
 wa
 iT
-zR
+PR
 tv
 KV
 bD
@@ -30585,7 +30598,7 @@ nI
 oP
 wa
 oP
-vJ
+HF
 Np
 zl
 bF
@@ -30741,7 +30754,7 @@ oP
 oP
 wa
 oP
-SB
+AL
 mH
 kW
 Yf

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -5248,7 +5248,6 @@
 /area/icy_caves/caves)
 "zM" = (
 /obj/machinery/landinglight/ds1/delaytwo,
-/obj/machinery/floodlight/landing,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "zN" = (
@@ -5268,9 +5267,9 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
 "zS" = (
-/turf/closed/ice/end{
-	dir = 4
-	},
+/obj/machinery/landinglight/ds1/delaytwo,
+/obj/machinery/floodlight/landing,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "zT" = (
 /obj/machinery/iv_drip,
@@ -5345,12 +5344,6 @@
 /obj/structure/dropship_equipment/weapon/rocket_pod,
 /turf/open/shuttle/dropship/floor,
 /area/space)
-"Ag" = (
-/obj/machinery/landinglight/ds1/delaythree{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
 "Ah" = (
 /obj/effect/landmark/corpsespawner/security{
 	corpsebelt = /obj/item/weapon/gun/revolver/cmb;
@@ -6575,7 +6568,7 @@
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
 "GU" = (
-/obj/machinery/landinglight/ds1/delaythree{
+/obj/machinery/landinglight/ds1/delayone{
 	dir = 8
 	},
 /turf/open/floor/tile/dark,
@@ -7172,7 +7165,8 @@
 /turf/closed/ice/end,
 /area/icy_caves/caves/south)
 "JY" = (
-/turf/closed/ice/thin/single,
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
 "Ka" = (
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
@@ -7493,7 +7487,7 @@
 	},
 /area/icy_caves/outpost/garage)
 "LL" = (
-/obj/machinery/landinglight/ds1{
+/obj/machinery/landinglight/ds1/delaytwo{
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
@@ -8918,7 +8912,7 @@
 /turf/open/floor/plating/ground/ice,
 /area/icy_caves/caves/south)
 "TI" = (
-/obj/machinery/landinglight/ds1/delayone{
+/obj/machinery/landinglight/ds1/delaythree{
 	dir = 8
 	},
 /turf/open/floor/tile/dark,
@@ -9017,8 +9011,10 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "Ud" = (
-/obj/machinery/camera/autoname/lz_camera,
-/turf/open/floor/plating,
+/obj/machinery/landinglight/ds1/delayone{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "Ug" = (
 /obj/machinery/power/apc/drained,
@@ -9294,7 +9290,9 @@
 /turf/closed/ice/intersection,
 /area/icy_caves/caves/northern)
 "VJ" = (
-/obj/machinery/landinglight/ds1/delaytwo,
+/obj/machinery/landinglight/ds1{
+	dir = 8
+	},
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "VK" = (
@@ -9397,12 +9395,6 @@
 /obj/item/explosive/plastique,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
-"Wb" = (
-/obj/machinery/landinglight/ds1/delayone{
-	dir = 4
-	},
-/turf/open/floor/tile/dark,
-/area/icy_caves/outpost/LZ1)
 "Wc" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 2;
@@ -9518,10 +9510,8 @@
 /turf/open/floor/plating/ground/snow/layer2,
 /area/icy_caves/outpost/outside)
 "WK" = (
-/obj/machinery/landinglight/ds1{
-	dir = 8
-	},
-/turf/open/floor/tile/dark,
+/obj/docking_port/stationary/marine_dropship/lz1,
+/turf/open/floor/plating,
 /area/icy_caves/outpost/LZ1)
 "WO" = (
 /obj/effect/landmark/weed_node,
@@ -9546,7 +9536,7 @@
 /turf/closed/ice_rock/fourway,
 /area/icy_caves/caves)
 "WT" = (
-/obj/machinery/landinglight/ds1/delaytwo{
+/obj/machinery/landinglight/ds1{
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
@@ -9644,18 +9634,20 @@
 	},
 /area/icy_caves/caves)
 "Xq" = (
-/obj/docking_port/stationary/marine_dropship/lz1,
-/turf/open/floor/plating,
+/obj/machinery/landinglight/ds1/delayone{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "Xr" = (
 /obj/effect/landmark/xeno_resin_door,
 /turf/open/floor/plating/dmg3,
 /area/icy_caves/caves/crashed_ship)
 "Xs" = (
-/obj/machinery/landinglight/ds1/delayone{
+/obj/machinery/landinglight/ds1/delaythree{
 	dir = 4
 	},
-/obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/LZ1)
 "Xu" = (
@@ -10801,23 +10793,23 @@ UE
 UE
 fq
 Uu
-qz
-aG
-pq
-aI
-pq
-eY
-zS
-JY
-JY
-zS
-aG
-pq
-aI
-pq
-eY
-XH
-qz
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
+Uu
 lX
 Bu
 bD
@@ -10951,29 +10943,29 @@ TW
 qz
 wL
 uw
-uw
-uw
-Ag
-Ag
-LL
-Wb
+Xs
+Xs
 WT
-Ag
-LL
-Wb
-WT
-Ag
-Wb
-Wb
-WT
-Ag
+Ud
 LL
 Xs
 WT
-Ag
+Ud
 LL
 Xs
+Ud
+Ud
+LL
+Xs
+WT
+Xq
+LL
+Xs
+WT
+Xq
 Yj
+uw
+uw
 Vb
 Ww
 bD
@@ -11106,12 +11098,10 @@ ED
 qz
 UM
 uw
-uw
-uw
-VJ
+zM
 Yn
 Yn
-Ud
+JY
 Yn
 Yn
 Yn
@@ -11119,7 +11109,7 @@ Yn
 Yn
 Yn
 Yn
-Ud
+JY
 Yn
 Yn
 Yn
@@ -11128,8 +11118,10 @@ Yn
 Yn
 Yn
 Yn
-Ud
+JY
 Yw
+uw
+uw
 VU
 uc
 bD
@@ -11262,9 +11254,7 @@ RC
 TM
 uw
 uw
-dW
-uw
-VJ
+zM
 Yn
 Yn
 Yn
@@ -11286,6 +11276,8 @@ Yn
 Yn
 Yn
 Yw
+uw
+uw
 qH
 Ww
 bD
@@ -11418,9 +11410,7 @@ zi
 TM
 uw
 uw
-uw
-uw
-VJ
+zM
 Yn
 Yn
 Yn
@@ -11442,6 +11432,8 @@ Yn
 Yn
 Yn
 Yw
+uw
+uw
 XH
 Ne
 Yf
@@ -11574,9 +11566,7 @@ Sh
 sK
 bU
 uw
-uw
-uw
-VJ
+zM
 Yn
 Yn
 Yn
@@ -11598,6 +11588,8 @@ Yn
 Yn
 Yn
 Yw
+uw
+uw
 VU
 Ne
 Yf
@@ -11730,9 +11722,7 @@ Tf
 TM
 bU
 uw
-uw
-uw
-VJ
+zM
 Yn
 Yn
 Yn
@@ -11754,6 +11744,8 @@ Yn
 Yn
 Yn
 Yw
+uw
+uw
 bH
 Ne
 Yf
@@ -11886,9 +11878,7 @@ Tf
 TM
 bU
 uw
-uw
-uw
-zM
+zS
 Yn
 Yn
 Yn
@@ -11899,7 +11889,7 @@ Yn
 Yn
 Yn
 Yn
-Xq
+WK
 Yn
 Yn
 Yn
@@ -11910,6 +11900,8 @@ Yn
 Yn
 Yn
 Yw
+uw
+uw
 bH
 Ne
 Yf
@@ -12042,9 +12034,7 @@ Aq
 TM
 bU
 uw
-uw
-uw
-VJ
+zM
 Yn
 Yn
 Yn
@@ -12066,6 +12056,8 @@ Yn
 Yn
 Yn
 Yw
+uw
+uw
 bH
 Ne
 Yf
@@ -12198,9 +12190,7 @@ YH
 TM
 bU
 uw
-uw
-dW
-VJ
+zM
 Yn
 Yn
 Yn
@@ -12222,6 +12212,8 @@ Yn
 Yn
 Yn
 Yw
+uw
+uw
 bH
 Ne
 Yf
@@ -12354,9 +12346,7 @@ Tf
 Tb
 XW
 uw
-uw
-uw
-VJ
+zM
 Yn
 Yn
 Yn
@@ -12378,6 +12368,8 @@ Yn
 Yn
 Yn
 Yw
+uw
+uw
 XH
 Ne
 Yf
@@ -12510,9 +12502,7 @@ Tf
 Ml
 XW
 uw
-uw
-uw
-VJ
+zM
 Yn
 Yn
 Yn
@@ -12534,6 +12524,8 @@ Yn
 Yn
 Yn
 Yw
+uw
+uw
 VU
 Ne
 Yf
@@ -12666,12 +12658,10 @@ TQ
 Uu
 Vk
 uw
-uw
-uw
-VJ
+zM
 Yn
 Yn
-Ud
+JY
 Yn
 Yn
 Yn
@@ -12679,7 +12669,7 @@ Yn
 Yn
 Yn
 Yn
-Ud
+JY
 Yn
 Yn
 Yn
@@ -12688,8 +12678,10 @@ Yn
 Yn
 Yn
 Yn
-Ud
+JY
 Yw
+uw
+uw
 qH
 Ne
 Yf
@@ -12823,29 +12815,29 @@ Uu
 bU
 uw
 uw
-uw
-uw
-GU
-MO
 TI
-WK
-GU
 MO
+GU
+VJ
 TI
-GU
-GU
 MO
-TI
-WK
 GU
+TI
+TI
 MO
-TI
-WK
 GU
+VJ
+TI
+MO
+GU
+VJ
+TI
 MO
 MO
 MO
 ZK
+uw
+uw
 XH
 Ne
 Yf

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -9680,9 +9680,8 @@
 /turf/open/floor/plating,
 /area/icy_caves/outpost/garage)
 "Xy" = (
-/obj/machinery/door/poddoor/mainship{
-	dir = 1;
-	id = "tcomms"
+/obj/machinery/door/poddoor/mainship/indestructible{
+	dir = 2
 	},
 /turf/open/shuttle/dropship/floor,
 /area/icy_caves/caves/northern)
@@ -11937,8 +11936,8 @@ Zl
 Zl
 Zl
 Zl
-Wp
 Zl
+Wp
 Zl
 Zl
 Wd
@@ -13946,11 +13945,11 @@ YQ
 "}
 (25,1,1) = {"
 YQ
-mv
-mv
-mv
-mv
-mv
+Yf
+Yf
+Yf
+Yf
+Yf
 dF
 Wr
 dF
@@ -14102,11 +14101,11 @@ YQ
 "}
 (26,1,1) = {"
 YQ
-mv
-mv
-mv
-mv
-mv
+Yf
+Yf
+Yf
+Yf
+Yf
 dF
 Jn
 pN
@@ -14258,11 +14257,11 @@ YQ
 "}
 (27,1,1) = {"
 YQ
-mv
-mv
-mv
-mv
-mv
+Yf
+Yf
+Yf
+Yf
+Yf
 dF
 oT
 Jn
@@ -14414,11 +14413,11 @@ YQ
 "}
 (28,1,1) = {"
 YQ
-mv
-mv
-mv
-mv
-mv
+Yf
+Yf
+Yf
+Yf
+Yf
 dF
 Ek
 uu


### PR DESCRIPTION
## About The Pull Request

New area northeast of caves, Monorail & Research.

## Why It's Good For The Game

More fun spots, cave gameplay constantly on this map is boring.

## Changelog
:cl:
add: new area northeast of caves.
balance: West-LZ1 to make it a bit more open north of it. also made lz1 bigger so marines got more room
balance: the pre shutter open no-build zone has been reduced.
balance: added more weed nodes and doors in caves for quality of life.
/:cl:

Red is the build zone. blue is a no-build zone.
LZ1
![image](https://user-images.githubusercontent.com/64131993/143765475-af133dbf-342f-42da-b130-9979b3591c38.png)
LZ2
![image](https://user-images.githubusercontent.com/64131993/143765557-84b9393c-2f86-4c97-bfc7-9e1685be0e63.png)



LZ1 change.

![image](https://user-images.githubusercontent.com/64131993/143807512-3a99b1ba-a4fc-4d9f-92e5-1719e0596760.png)

New area.

NO you cant access the tank, it's behind indestructible podlocks and it's zoned out. only there for cosmetics

![image](https://user-images.githubusercontent.com/64131993/143768899-151561b5-9bd5-4008-addd-d64e3abf3847.png)



