### PR TITLE
Nerfs TP-44 revolver fire rate

### DIFF
--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -174,7 +174,7 @@
 		/obj/item/attachable/shoulder_mount,
 	)
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 19,"rail_x" = 13, "rail_y" = 23, "under_x" = 22, "under_y" = 14, "stock_x" = 22, "stock_y" = 19)
-	fire_delay = 0.15 SECONDS
+	fire_delay = 0.18 SECONDS
 	accuracy_mult_unwielded = 0.85
 	accuracy_mult = 1
 	scatter_unwielded = 15

--- a/code/modules/projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/guns/revolvers.dm
@@ -174,7 +174,7 @@
 		/obj/item/attachable/shoulder_mount,
 	)
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 19,"rail_x" = 13, "rail_y" = 23, "under_x" = 22, "under_y" = 14, "stock_x" = 22, "stock_y" = 19)
-	fire_delay = 0.18 SECONDS
+	fire_delay = 0.2 SECONDS
 	accuracy_mult_unwielded = 0.85
 	accuracy_mult = 1
 	scatter_unwielded = 15


### PR DESCRIPTION
## About The Pull Request
![image](https://user-images.githubusercontent.com/59634950/143943057-3a2f1ef6-7569-4f84-a70f-f17aa1f282d9.png)
Apparently, an increased fire delay was supposed to be part of the recently merged TP-44 changes (#8841). This PR aims to actually reduce the fire rate a little bit. Tested it in-game, felt fine.

## Why It's Good For The Game
Gives the TP-44 its intended balancing, makes them a little bit less overpowered than they are currently.

## Changelog
:cl: Lewdcifer
balance: TP-44 fire delay 0.15 > 0.2.
/:cl: