### PR TITLE
Buffs the Repeater

### DIFF
--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -530,7 +530,7 @@
 	fire_delay = 10
 	accuracy_mult = 1.20
 	accuracy_mult_unwielded = 0.8
-	damage_mult = 2.5
+	damage_mult = 2
 	damage_falloff_mult = 0.5
 	scatter = -5
 	scatter_unwielded = 15

--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -530,7 +530,7 @@
 	fire_delay = 10
 	accuracy_mult = 1.20
 	accuracy_mult_unwielded = 0.8
-	damage_mult = 1.5
+	damage_mult = 2.5
 	damage_falloff_mult = 0.5
 	scatter = -5
 	scatter_unwielded = 15


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Leicester Repeater damage multiplier increased to 2 from 1.5, resulting in 60 damage from 45.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gun got gutted as a result of MJP's revolver ammo nerf. This fixes that. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Leicester Repeater damage multiplier increased to 2x from 1.5x. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
