### PR TITLE
Removes stealthing and renames to afkmode

### DIFF
--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -128,7 +128,7 @@
 
 	else
 		for(var/client/C in GLOB.admins)
-			if(check_other_rights(C, R_ADMIN, FALSE) && !C.holder.fakekey)
+			if(check_other_rights(C, R_ADMIN, FALSE))
 				msg += "\t[C] - [C.holder.rank]\n"
 				num_admins_online++
 			else if(is_mentor(C))

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -52,7 +52,7 @@
 
 /datum/admins/proc/stealth_mode()
 	set category = "Admin"
-	set name = "Stealth Mode"
+	set name = "Afkmode"
 	set desc = "Allows you to change your ckey for non-admins to see."
 
 	if(!check_rights(R_ADMIN))


### PR DESCRIPTION
## About The Pull Request

Renames Stealthmode to Afkmode as it's proper use. Stealthmode serves no purpose. As well as stealthmode will no longer hide admin's name fromm staffwho in order to prevent players from freaking out. 

Hopefully this works for you @lKiseki 

## Why It's Good For The Game

To prevent player spamming pings. Named as it's only one reasonable use

## Changelog
:cl:
admin: Stealthmode renamed to afkmode. Doesn't hide admin's name from staffwho anymore.
/:cl:

