### PR TITLE
Adds aim mode delay removal to deployed bipod

### DIFF
--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1222,8 +1222,8 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	var/deployment_scatter_mod = -20
 	///bonus to burst scatter applied when the bipod is deployed
 	var/deployment_burst_scatter_mod = -3
-	///bonus to aim mode delay when the bipod is deployed
-	var/deployment_aim_mode_delay_mod = -1
+	///bonus to aim mode delay by % when the bipod is deployed
+	var/deployment_aim_mode_delay_mod = -0.5
 
 /obj/item/attachable/bipod/activate(mob/living/user, turn_off)
 	if(bipod_deployed)

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -1260,7 +1260,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 		master_gun.recoil += deployment_recoil_mod
 		master_gun.scatter += deployment_scatter_mod
 		master_gun.burst_scatter_mult += deployment_burst_scatter_mod
-		master_gun.add_aim_mode_fire_delay(name, initial(master_gun.aim_fire_delay)*deployment_aim_mode_delay_mod)
+		master_gun.add_aim_mode_fire_delay(name, initial(master_gun.aim_fire_delay) * deployment_aim_mode_delay_mod)
 		icon_state = "bipod-on"
 
 	for(var/i in master_gun.actions)

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -151,7 +151,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	master_gun.scatter_unwielded			+= scatter_unwielded_mod
 	master_gun.aim_speed_modifier			+= initial(master_gun.aim_speed_modifier)*aim_mode_movement_mult
 	master_gun.iff_marine_damage_falloff	+= shot_marine_damage_falloff
-	master_gun.add_aim_mode_fire_delay(name, initial(master_gun.aim_fire_delay)*aim_mode_delay_mod)
+	master_gun.add_aim_mode_fire_delay(name, initial(master_gun.aim_fire_delay) * aim_mode_delay_mod)
 	if(delay_mod)
 		master_gun.modify_fire_delay(delay_mod)
 	if(burst_delay_mod)

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -680,6 +680,7 @@ should be alright.
 		if((GUN_FIREMODE_AUTOMATIC in gun_firemode_list) && !(GUN_FIREMODE_AUTOBURST in gun_firemode_list))
 			add_firemode(GUN_FIREMODE_AUTOBURST, user)
 
+///Calculates aim_fire_delay, can't be below 0
 #define RECALCULATE_AIM_MODE_FIRE_DELAY \
 	var/modification_value = 0; \
 	for(var/key in aim_fire_delay_mods) { \
@@ -691,10 +692,12 @@ should be alright.
 		modify_fire_delay(aim_fire_delay - old_delay); \
 	}
 
+///Adds an aim_fire_delay modificatio value
 /obj/item/weapon/gun/proc/add_aim_mode_fire_delay(source, value)
 	aim_fire_delay_mods[source] = value
 	RECALCULATE_AIM_MODE_FIRE_DELAY
 
+///Removes an aim_fire_delay modificatio value
 /obj/item/weapon/gun/proc/remove_aim_mode_fire_delay(source)
 	aim_fire_delay_mods -= source
 	RECALCULATE_AIM_MODE_FIRE_DELAY

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -680,6 +680,25 @@ should be alright.
 		if((GUN_FIREMODE_AUTOMATIC in gun_firemode_list) && !(GUN_FIREMODE_AUTOBURST in gun_firemode_list))
 			add_firemode(GUN_FIREMODE_AUTOBURST, user)
 
+#define RECALCULATE_AIM_MODE_FIRE_DELAY \
+	var/modification_value = 0; \
+	for(var/key in aim_fire_delay_mods) { \
+		modification_value += aim_fire_delay_mods[key]; \
+	}; \
+	var/old_delay = aim_fire_delay; \
+	aim_fire_delay = max(initial(aim_fire_delay) + modification_value, 0); \
+	if(HAS_TRAIT(src, TRAIT_GUN_IS_AIMING)) { \
+		modify_fire_delay(aim_fire_delay - old_delay); \
+	}
+
+/obj/item/weapon/gun/proc/add_aim_mode_fire_delay(source, value)
+	aim_fire_delay_mods[source] = value
+	RECALCULATE_AIM_MODE_FIRE_DELAY
+
+/obj/item/weapon/gun/proc/remove_aim_mode_fire_delay(source)
+	aim_fire_delay_mods -= source
+	RECALCULATE_AIM_MODE_FIRE_DELAY
+
 /obj/item/weapon/gun/proc/toggle_auto_aim_mode(mob/living/carbon/human/user) //determines whether toggle_aim_mode activates at the end of gun/wield proc
 
 	if(CHECK_BITFIELD(flags_item, WIELDED) || CHECK_BITFIELD(flags_item, IS_DEPLOYED)) //if gun is wielded it toggles aim mode directly instead

--- a/code/modules/projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/gun_helpers.dm
@@ -699,6 +699,8 @@ should be alright.
 	aim_fire_delay_mods -= source
 	RECALCULATE_AIM_MODE_FIRE_DELAY
 
+#undef RECALCULATE_AIM_MODE_FIRE_DELAY
+
 /obj/item/weapon/gun/proc/toggle_auto_aim_mode(mob/living/carbon/human/user) //determines whether toggle_aim_mode activates at the end of gun/wield proc
 
 	if(CHECK_BITFIELD(flags_item, WIELDED) || CHECK_BITFIELD(flags_item, IS_DEPLOYED)) //if gun is wielded it toggles aim mode directly instead

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -212,6 +212,8 @@
 	var/iff_marine_damage_falloff = 0
 	///Determines how fire delay is changed when aim mode is active
 	var/aim_fire_delay = 0
+	///Holds the values modifying aim_fire_delay
+	var/list/aim_fire_delay_mods = list()
 	///Determines character slowdown from aim mode. Default is 66%
 	var/aim_speed_modifier = 6
 


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds 50% aim mode delay removal to deployed bipod and support for simple aim mode delay modification.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I think that the idea of a standing marine with no aim mode fire delay from bipod for cover fire is an interesting concept to explore further and plays well around bipod's niche.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:Slotbot
expansion: adds 50% aim mode delay removal to deployed bipod, which combined with red dot reaches 100% (yes, GPMG enjoyers)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
