### PR TITLE
Lets xenos lay eggs anywhere

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1013,14 +1013,8 @@
 	var/turf/current_turf = get_turf(owner)
 
 	var/obj/effect/alien/weeds/alien_weeds = locate() in current_turf
-	if(!alien_weeds)
-		to_chat(owner, span_warning("Our eggs wouldn't grow well enough here. Lay them on resin."))
-		return FALSE
 
 	if(!do_after(owner, 3 SECONDS, FALSE, alien_weeds))
-		return FALSE
-
-	if(!current_turf.check_alien_construction(owner) || !current_turf.check_disallow_alien_fortification(owner))
 		return FALSE
 
 	owner.visible_message(span_xenowarning("\The [owner] has laid an egg!"), \


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Removes the resin and resin building checks for laying eggs, letting them lay you anywhere. This does not let you plant them anywhere, only lay them. There's no real reason for these checks, If someone wanted to grief xenos by giving marines free eggs they could just go carrier, store the eggs, retrieve them and throw them at marines.
## Why It's Good For The Game
Just a QoL thing mainly for defiler and carrier
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Let xenos lay eggs anywhere
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
