### PR TITLE
Fixes Minerva Drop Pod Doors

### DIFF
--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -378,6 +378,10 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/starboard_hull)
+"bk" = (
+/obj/docking_port/stationary/marine_dropship/crash_target,
+/turf/open/floor/plating,
+/area/mainship/hallways/hangar)
 "bl" = (
 /obj/machinery/door/airlock/mainship/maint,
 /obj/structure/cable,
@@ -580,6 +584,12 @@
 	dir = 1
 	},
 /area/mainship/hallways/hangar)
+"bS" = (
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 2
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/shipboard/port_missiles)
 "bT" = (
 /obj/machinery/dropship_part_fabricator,
 /turf/open/floor/mainship/cargo,
@@ -1173,15 +1183,6 @@
 /obj/structure/janitorialcart,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/port_hull)
-"eo" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/glass/bucket/janibucket,
-/obj/item/tool/wet_sign,
-/obj/item/tool/wet_sign,
-/obj/item/tool/wet_sign,
-/obj/item/storage/bag/trash,
-/turf/open/floor/mainship/mono,
-/area/mainship/hull/port_hull)
 "ep" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating/plating_catwalk,
@@ -1303,6 +1304,11 @@
 "eJ" = (
 /turf/open/floor/wood,
 /area/mainship/living/pilotbunks)
+"eK" = (
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 5
+	},
+/area/mainship/medical/chemistry)
 "eM" = (
 /obj/machinery/door/airlock/mainship/maint{
 	dir = 8
@@ -1346,6 +1352,10 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hull/port_hull)
+"eV" = (
+/obj/structure/sign/custodian,
+/turf/closed/wall/mainship,
+/area/mainship/hull/starboard_hull)
 "eW" = (
 /obj/structure/table/woodentable,
 /obj/machinery/computer/skills,
@@ -1922,10 +1932,13 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/corporateliaison)
-"gV" = (
-/obj/machinery/light{
-	dir = 8
+"gU" = (
+/obj/machinery/vending/medical,
+/turf/open/floor/mainship/sterile/purple/corner{
+	dir = 1
 	},
+/area/mainship/medical/chemistry)
+"gV" = (
 /obj/machinery/door_control/unmeltable{
 	id = "tadstorage";
 	name = "Tadpole Storage Door Control";
@@ -2172,7 +2185,9 @@
 /area/mainship/hull/starboard_hull)
 "hX" = (
 /obj/structure/table,
-/turf/open/floor/plating,
+/turf/open/floor/mainship/green{
+	dir = 8
+	},
 /area/mainship/hull/starboard_hull)
 "hY" = (
 /obj/structure/cable,
@@ -3327,6 +3342,9 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
+"mq" = (
+/turf/closed/wall/mainship,
+/area/mainship/shipboard/starboard_missiles)
 "mr" = (
 /obj/vehicle/ridden/powerloader,
 /turf/open/floor/mainship/cargo,
@@ -3335,6 +3353,7 @@
 /obj/machinery/computer/camera_advanced/overwatch/bravo{
 	name = "Delta Overwatch Console"
 	},
+/obj/structure/table/reinforced,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "mu" = (
@@ -4742,6 +4761,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"qY" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/starboard_hull)
 "qZ" = (
 /obj/machinery/holopad,
 /turf/open/floor/mainship/mono,
@@ -4905,6 +4930,9 @@
 /obj/structure/sign/evac,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/evacuation)
+"rG" = (
+/turf/closed/wall/mainship,
+/area/mainship/shipboard/port_missiles)
 "rH" = (
 /obj/structure/closet/secure_closet/guncabinet/incendiary,
 /obj/machinery/light,
@@ -4989,6 +5017,12 @@
 	dir = 4
 	},
 /area/mainship/medical/lower_medical)
+"sc" = (
+/obj/structure/table/mainship,
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 4
+	},
+/area/mainship/medical/chemistry)
 "sd" = (
 /obj/structure/sink{
 	dir = 8;
@@ -6125,6 +6159,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/squads/req)
+"wd" = (
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 6
+	},
+/area/mainship/medical/chemistry)
 "we" = (
 /turf/open/floor/mainship/blue/corner{
 	dir = 1
@@ -7758,6 +7798,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
+"Bh" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/glass/bucket/janibucket,
+/obj/item/tool/wet_sign,
+/obj/item/tool/wet_sign,
+/obj/item/tool/wet_sign,
+/obj/item/storage/bag/trash,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/port_hull)
 "Bj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -8455,6 +8504,10 @@
 	},
 /turf/open/floor/freezer,
 /area/mainship/living/cafeteria_starboard)
+"DQ" = (
+/obj/structure/sign/custodian,
+/turf/closed/wall/mainship,
+/area/mainship/hull/port_hull)
 "DR" = (
 /obj/machinery/light{
 	dir = 4
@@ -8654,6 +8707,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/freezer,
 /area/mainship/living/cafeteria_starboard)
+"EA" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/port_hallway)
 "EB" = (
 /obj/item/radio/intercom/general{
 	dir = 8
@@ -9404,7 +9462,7 @@
 	},
 /obj/item/clothing/tie/red,
 /obj/item/megaphone,
-/turf/open/floor/mainship/mono,
+/turf/open/floor/wood,
 /area/mainship/living/numbertwobunks)
 "GQ" = (
 /obj/structure/disposalpipe/trunk{
@@ -9767,7 +9825,9 @@
 /area/mainship/living/bridgebunks)
 "Ij" = (
 /obj/structure/table/mainship,
-/turf/open/floor/mainship/sterile/dark,
+/turf/open/floor/mainship/sterile/purple/corner{
+	dir = 4
+	},
 /area/mainship/medical/chemistry)
 "Ik" = (
 /obj/structure/rack,
@@ -9787,7 +9847,9 @@
 	},
 /obj/structure/table/mainship,
 /obj/item/paper/chemistry,
-/turf/open/floor/mainship/sterile/dark,
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 1
+	},
 /area/mainship/medical/chemistry)
 "Io" = (
 /obj/structure/cable,
@@ -9802,7 +9864,7 @@
 "Iq" = (
 /obj/structure/table/mainship,
 /obj/machinery/computer/med_data/laptop,
-/turf/open/floor/mainship/sterile/dark,
+/turf/open/floor/mainship/sterile/purple/corner,
 /area/mainship/medical/chemistry)
 "Ir" = (
 /obj/machinery/disposal,
@@ -9815,18 +9877,24 @@
 /area/mainship/medical/chemistry)
 "It" = (
 /obj/machinery/vending/medical,
-/turf/open/floor/mainship/sterile/dark,
+/turf/open/floor/mainship/sterile/purple/corner{
+	dir = 8
+	},
 /area/mainship/medical/chemistry)
 "Iu" = (
 /obj/machinery/chem_dispenser,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/mainship/sterile/dark,
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 1
+	},
 /area/mainship/medical/chemistry)
 "Iv" = (
 /obj/machinery/chem_master,
-/turf/open/floor/mainship/sterile/dark,
+/turf/open/floor/mainship/sterile/purple/corner{
+	dir = 4
+	},
 /area/mainship/medical/chemistry)
 "Iw" = (
 /turf/open/floor/mainship/sterile/purple/corner{
@@ -10092,7 +10160,9 @@
 	pixel_x = -5;
 	pixel_y = 5
 	},
-/turf/open/floor/mainship/sterile/dark,
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 8
+	},
 /area/mainship/medical/chemistry)
 "Jq" = (
 /obj/structure/bed/stool{
@@ -10110,7 +10180,9 @@
 	},
 /obj/item/reagent_containers/glass/beaker/bluespace,
 /obj/item/reagent_containers/glass/beaker/large,
-/turf/open/floor/mainship/sterile/dark,
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 4
+	},
 /area/mainship/medical/chemistry)
 "Js" = (
 /turf/open/floor/mainship/sterile/purple/side{
@@ -10400,7 +10472,7 @@
 /obj/machinery/door/airlock/mainship/maint{
 	name = "\improper Core Hatch"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/medical/chemistry)
 "Kl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
@@ -10410,9 +10482,7 @@
 /area/mainship/medical/chemistry)
 "Km" = (
 /obj/effect/ai_node,
-/turf/open/floor/mainship/sterile/purple/side{
-	dir = 1
-	},
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/chemistry)
 "Ko" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
@@ -10636,13 +10706,13 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/mainship/sterile/purple/corner{
+/turf/open/floor/mainship/sterile/purple/side{
 	dir = 8
 	},
 /area/mainship/medical/chemistry)
 "Lg" = (
 /obj/structure/cable,
-/turf/open/floor/mainship/sterile/purple/side,
+/turf/open/floor/mainship/sterile/dark,
 /area/mainship/medical/chemistry)
 "Lh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -10656,7 +10726,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/mainship/sterile/purple/side,
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 10
+	},
 /area/mainship/medical/chemistry)
 "Lk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -10825,6 +10897,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/starboard_hallway)
+"LO" = (
+/obj/structure/janitorialcart,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/starboard_hull)
 "LQ" = (
 /obj/structure/sign/vacuum,
 /turf/closed/wall/mainship,
@@ -10887,7 +10963,9 @@
 "Md" = (
 /obj/structure/table/mainship,
 /obj/machinery/computer/med_data,
-/turf/open/floor/mainship/sterile/dark,
+/turf/open/floor/mainship/sterile/purple/corner{
+	dir = 8
+	},
 /area/mainship/medical/chemistry)
 "Me" = (
 /obj/structure/ship_ammo/rocket/banshee,
@@ -10897,12 +10975,12 @@
 /obj/machinery/light,
 /obj/structure/table/mainship,
 /obj/item/paper/chemistry,
-/turf/open/floor/mainship/sterile/dark,
+/turf/open/floor/mainship/sterile/purple/side,
 /area/mainship/medical/chemistry)
 "Mg" = (
 /obj/machinery/chem_dispenser,
 /obj/machinery/light,
-/turf/open/floor/mainship/sterile/dark,
+/turf/open/floor/mainship/sterile/purple/side,
 /area/mainship/medical/chemistry)
 "Mi" = (
 /obj/machinery/disposal,
@@ -11579,6 +11657,14 @@
 /obj/structure/closet/toolcloset,
 /turf/open/floor/mainship/orange,
 /area/mainship/engineering/engineering_workshop)
+"Ow" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/docking_port/stationary/marine_dropship/crash_target,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hallways/hangar)
 "Ox" = (
 /obj/machinery/power/apc/mainship,
 /obj/structure/cable,
@@ -11793,6 +11879,10 @@
 	},
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/engineering/engineering_workshop)
+"Pi" = (
+/obj/machinery/chem_master,
+/turf/open/floor/mainship/sterile/purple/corner,
+/area/mainship/medical/chemistry)
 "Pj" = (
 /obj/structure/table/mainship,
 /obj/item/clothing/suit/storage/hazardvest,
@@ -12129,7 +12219,7 @@
 	},
 /area/mainship/engineering/port_atmos)
 "Qs" = (
-/turf/closed/wall/mainship/outer,
+/turf/closed/wall/mainship,
 /area/mainship/hallways/port_hallway)
 "Qt" = (
 /obj/machinery/door/airlock/multi_tile/mainship/comdoor{
@@ -12451,6 +12541,7 @@
 /obj/machinery/computer/camera_advanced/overwatch/bravo{
 	name = "Alpha Overwatch Console"
 	},
+/obj/structure/table/reinforced,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "RB" = (
@@ -12458,6 +12549,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/table/reinforced,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "RC" = (
@@ -12563,6 +12655,12 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/mainship/engineering/ce_room)
+"RY" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/port_hull)
 "RZ" = (
 /obj/machinery/autolathe,
 /turf/open/floor/mainship/orange{
@@ -12919,6 +13017,13 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
+"Tv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/dark,
+/area/mainship/medical/chemistry)
 "Tw" = (
 /obj/structure/dropship_equipment/mg_holder,
 /turf/open/floor/mainship/cargo,
@@ -13080,6 +13185,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/command/airoom)
+"Ua" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/mainship/sterile/purple/side{
+	dir = 6
+	},
+/area/mainship/medical/chemistry)
 "Ub" = (
 /obj/structure/cable,
 /obj/machinery/door_control/ai/exterior{
@@ -13282,6 +13396,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/table/reinforced,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "UN" = (
@@ -14109,6 +14224,15 @@
 	},
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/airoom)
+"XX" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/glass/bucket/janibucket,
+/obj/item/tool/wet_sign,
+/obj/item/tool/wet_sign,
+/obj/item/tool/wet_sign,
+/obj/item/storage/bag/trash,
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/hull/starboard_hull)
 "XY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -14399,6 +14523,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/airoom)
+"YV" = (
+/obj/structure/table/mainship,
+/turf/open/floor/mainship/sterile/purple/corner{
+	dir = 1
+	},
+/area/mainship/medical/chemistry)
 "YW" = (
 /obj/machinery/light,
 /obj/structure/window/reinforced/toughened{
@@ -14549,6 +14679,12 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/self_destruct)
+"Zy" = (
+/obj/machinery/door/airlock/mainship/maint{
+	dir = 2
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/mainship/shipboard/starboard_missiles)
 "Zz" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -16191,11 +16327,11 @@ XE
 XE
 XE
 XE
+hs
 XE
 XE
 XE
-XE
-XE
+hs
 XE
 XE
 XE
@@ -16391,11 +16527,11 @@ mV
 nW
 pb
 qr
-nV
-XE
-XE
-XE
-XE
+kd
+fD
+fD
+fD
+fD
 XE
 XE
 XE
@@ -16489,11 +16625,11 @@ mW
 kJ
 pd
 qs
-nV
-XE
-XE
-XE
-XE
+bS
+Ek
+RY
+Ek
+fD
 XE
 XE
 XE
@@ -16587,11 +16723,11 @@ mY
 nZ
 pf
 qs
-nV
-XE
-XE
-hs
-XE
+rG
+en
+Bh
+Ek
+fD
 XE
 hs
 XE
@@ -16685,10 +16821,10 @@ kd
 kd
 ph
 qs
-kd
-va
-va
-fD
+rG
+DQ
+gQ
+Ej
 fD
 fD
 fD
@@ -18290,9 +18426,9 @@ Qq
 Qq
 Qq
 mS
-Qq
-Qq
-Qq
+XA
+XA
+XA
 XE
 hr
 ZK
@@ -18336,7 +18472,7 @@ YB
 XE
 XE
 fD
-eo
+Bh
 eQ
 fD
 Le
@@ -18453,7 +18589,7 @@ kT
 kq
 tr
 uJ
-vy
+EA
 wm
 xr
 co
@@ -19076,7 +19212,7 @@ Qq
 yK
 Qq
 Qq
-Qq
+XA
 XE
 hr
 ZK
@@ -19456,8 +19592,8 @@ EM
 hK
 iw
 jl
-Qw
-Qw
+Wg
+Wg
 SO
 UH
 Wg
@@ -19499,12 +19635,12 @@ ZK
 YB
 XE
 VS
-OS
-OS
 VS
-OS
-OS
-OS
+VS
+VS
+VS
+VS
+VS
 aW
 bv
 NA
@@ -19554,7 +19690,7 @@ fx
 hz
 iw
 jk
-Qw
+Wg
 Rw
 SR
 UI
@@ -19652,7 +19788,7 @@ HQ
 hz
 iw
 jk
-Qw
+Wg
 Rx
 SS
 UK
@@ -19740,9 +19876,9 @@ ES
 FZ
 GQ
 HQ
-Ij
+YV
 Jp
-Iw
+Js
 Lf
 Jp
 Md
@@ -19750,7 +19886,7 @@ HQ
 hz
 iw
 jk
-Qw
+Wg
 RA
 SV
 UK
@@ -19840,7 +19976,7 @@ GR
 HQ
 Im
 Jq
-Ix
+Jt
 Lg
 Jq
 Mf
@@ -19848,7 +19984,7 @@ HQ
 hK
 iw
 jl
-Qw
+Wg
 RB
 SW
 UN
@@ -19937,16 +20073,16 @@ Gb
 GS
 HQ
 Iq
-Ij
-Ix
-Lg
-Ij
+sc
+eK
+wd
+sc
 Ij
 HQ
 hz
 iw
 jk
-Qw
+Wg
 RE
 SX
 UO
@@ -20044,7 +20180,7 @@ HQ
 Nz
 Ob
 jk
-Qw
+Wg
 RG
 SZ
 UK
@@ -20105,7 +20241,7 @@ fg
 fg
 fg
 OS
-VC
+bO
 iy
 VC
 kq
@@ -20132,9 +20268,9 @@ EX
 Ep
 Ep
 HQ
-It
+gU
 Jp
-Ix
+Kr
 Lj
 Jp
 It
@@ -20142,7 +20278,7 @@ HQ
 NC
 iw
 jk
-Qw
+Wg
 UM
 Tb
 UP
@@ -20233,14 +20369,14 @@ HQ
 Iu
 Jq
 Km
-Lj
+Tv
 Jq
 Mg
 HQ
 hD
 iw
 jk
-Qw
+Wg
 ms
 Tc
 UR
@@ -20328,17 +20464,17 @@ EZ
 Gh
 GW
 HQ
-Iv
+Pi
 Jr
-Ix
-Lj
+eK
+Ua
 Jr
 Iv
 HQ
 NE
 iw
 jl
-Qw
+Wg
 RI
 Td
 UT
@@ -20436,7 +20572,7 @@ HQ
 NF
 Oc
 jk
-Qw
+Wg
 RJ
 Ti
 UU
@@ -20534,8 +20670,8 @@ HQ
 hz
 iw
 jk
-Qw
-Qw
+Wg
+Wg
 Tj
 UV
 Wg
@@ -20627,9 +20763,9 @@ Jt
 Ks
 Lm
 LC
-Mk
-MU
-vw
+Ml
+HQ
+hK
 iw
 jk
 Qx
@@ -20725,9 +20861,9 @@ Ju
 Ku
 Lo
 LD
-Ml
-HQ
-hK
+Mk
+MU
+vw
 iw
 jk
 Qx
@@ -20926,8 +21062,8 @@ HQ
 hy
 iw
 jk
-Qw
-Qw
+Wg
+Wg
 Tj
 UV
 Wg
@@ -21092,7 +21228,7 @@ js
 js
 js
 js
-js
+Ow
 js
 js
 js
@@ -22069,7 +22205,7 @@ ez
 ez
 ez
 ez
-ez
+bk
 ez
 ez
 ez
@@ -23625,7 +23761,7 @@ bo
 Am
 WS
 Io
-dk
+WS
 SA
 SA
 SA
@@ -23723,7 +23859,7 @@ Vo
 Vo
 FJ
 Io
-WS
+dk
 SA
 Ir
 eF
@@ -26877,10 +27013,10 @@ kE
 kE
 qi
 rz
-kE
-Hr
-Hr
-Hr
+mq
+eV
+QM
+eM
 Hr
 Hr
 aO
@@ -26975,11 +27111,11 @@ nS
 oX
 qj
 rz
-pa
-RC
-XE
-XE
-XE
+mq
+LO
+XX
+WD
+Hr
 RC
 XE
 XE
@@ -27073,11 +27209,11 @@ nT
 lS
 qk
 rz
-pa
-XE
-XE
-XE
-XE
+Zy
+WD
+qY
+WD
+Hr
 XE
 XE
 XE
@@ -27171,11 +27307,11 @@ nU
 oY
 ql
 rA
-pa
-XE
-XE
-XE
-XE
+kE
+Hr
+Hr
+Hr
+Hr
 XE
 XE
 XE
@@ -27363,11 +27499,11 @@ Zl
 XE
 XE
 XE
+RC
 XE
 XE
 XE
-XE
-XE
+RC
 XE
 XE
 XE

--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -7355,6 +7355,10 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine,
 /area/mainship/engineering/port_atmos)
+"zM" = (
+/obj/structure/sign/safety/EVA,
+/turf/closed/wall/mainship,
+/area/mainship/living/grunt_rnr)
 "zN" = (
 /obj/machinery/vending/nanomed,
 /turf/open/floor/mainship/sterile/corner,
@@ -10017,6 +10021,7 @@
 /area/mainship/engineering/port_atmos)
 "IS" = (
 /obj/structure/toilet,
+/obj/machinery/camera/autoname/mainship,
 /turf/open/floor/mainship/mono,
 /area/mainship/living/grunt_rnr)
 "IT" = (
@@ -11152,10 +11157,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/living/grunt_rnr)
-"MB" = (
-/obj/structure/sign/safety/EVA,
-/turf/closed/wall/mainship,
-/area/mainship/hallways/starboard_hallway)
 "MC" = (
 /obj/machinery/suit_storage_unit/carbon_unit,
 /obj/machinery/camera/autoname/mainship{
@@ -11263,10 +11264,6 @@
 /obj/machinery/door/airlock/mainship/maint,
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
-"Nh" = (
-/obj/machinery/suit_storage_unit/carbon_unit,
-/turf/open/floor/mainship/mono,
-/area/mainship/hallways/starboard_hallway)
 "Ni" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating/plating_catwalk,
@@ -11283,7 +11280,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/starboard_hallway)
 "Nm" = (
 /obj/structure/cable,
@@ -26543,9 +26540,9 @@ xg
 IQ
 JS
 IQ
-IQ
+zM
 LQ
-MB
+MI
 Ne
 NO
 Pn
@@ -26644,7 +26641,7 @@ JR
 IQ
 LR
 MC
-Nh
+by
 NO
 Pn
 Ql

--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -3331,6 +3331,12 @@
 /obj/vehicle/ridden/powerloader,
 /turf/open/floor/mainship/cargo,
 /area/mainship/squads/req)
+"ms" = (
+/obj/machinery/computer/camera_advanced/overwatch/bravo{
+	name = "Delta Overwatch Console"
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/command/cic)
 "mu" = (
 /turf/open/floor/mainship/cargo/arrow{
 	dir = 4
@@ -5484,6 +5490,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/mainship/sterile/side{
 	dir = 4
 	},
@@ -6908,6 +6917,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/mainship/sterile/side{
 	dir = 4
 	},
@@ -9034,6 +9046,12 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/mainship/living/evacuation)
+"FJ" = (
+/obj/machinery/door_control/mainship/droppod{
+	pixel_y = 30
+	},
+/turf/open/floor/mainship/mono,
+/area/mainship/hallways/starboard_hallway)
 "FK" = (
 /obj/effect/decal/warning_stripes/thin{
 	dir = 8
@@ -12430,7 +12448,9 @@
 /turf/open/floor/mainship/mono,
 /area/mainship/command/telecomms)
 "RA" = (
-/obj/machinery/computer/camera_advanced/overwatch/bravo,
+/obj/machinery/computer/camera_advanced/overwatch/bravo{
+	name = "Alpha Overwatch Console"
+	},
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "RB" = (
@@ -13254,6 +13274,15 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/mainship/floor,
+/area/mainship/command/cic)
+"UM" = (
+/obj/machinery/computer/camera_advanced/overwatch/bravo{
+	name = "Charlie Overwatch Console"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "UN" = (
 /obj/structure/bed/chair/office/dark{
@@ -20114,7 +20143,7 @@ NC
 iw
 jk
 Qw
-RB
+UM
 Tb
 UP
 Wl
@@ -20212,7 +20241,7 @@ hD
 iw
 jk
 Qw
-RA
+ms
 Tc
 UR
 Wn
@@ -23692,7 +23721,7 @@ TY
 AQ
 Vo
 Vo
-WS
+FJ
 Io
 WS
 SA


### PR DESCRIPTION
## About The Pull Request

Somehow during all of Minerva's testing, nobody noticed that the Drop Pod Bay didn't have an external access button.
Also, I didn't notice it.
PR to fix that, and a few other assorted post-launch issues.

## Why It's Good For The Game

People like to use Drop Pods, this allows for that without admin intervention.

## Changelog
:cl:
fix: Adds exterior access button to Minerva's Drop Pod doors.
/:cl:
