### PR TITLE
Makes powerloader faster during prep

### DIFF
--- a/code/datums/components/riding/riding_vehicle.dm
+++ b/code/datums/components/riding/riding_vehicle.dm
@@ -96,6 +96,19 @@
 	ride_check_flags = RIDER_NEEDS_LEGS | RIDER_NEEDS_ARMS
 	vehicle_move_delay = 4
 
+/datum/component/riding/vehicle/powerloader/Initialize(mob/living/riding_mob, force, ride_check_flags, potion_boost)
+	. = ..()
+	if(SSmonitor.gamestate != SHUTTERS_CLOSED)
+		return
+	vehicle_move_delay = 0.5
+	RegisterSignal(src, list(COMSIG_GLOB_OPEN_TIMED_SHUTTERS_LATE, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_XENO_HIVEMIND, COMSIG_GLOB_OPEN_SHUTTERS_EARLY, COMSIG_GLOB_TADPOLE_LAUNCHED), .proc/regain_move_delay)
+
+///Returns the loader's movement speed to normal after prep is over
+/datum/component/riding/vehicle/powerloader/proc/regain_move_delay(datum/source)
+	SIGNAL_HANDLER
+	UnregisterSignal(src, list(COMSIG_GLOB_OPEN_TIMED_SHUTTERS_LATE, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_XENO_HIVEMIND, COMSIG_GLOB_OPEN_SHUTTERS_EARLY, COMSIG_GLOB_TADPOLE_LAUNCHED))
+	vehicle_move_delay = initial(vehicle_move_delay)
+
 /datum/component/riding/vehicle/powerloader/handle_specials()
 	. = ..()
 	set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0, 2), TEXT_SOUTH = list(0, 2), TEXT_EAST = list(0, 2), TEXT_WEST = list(0, 2)))


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes loader very fast during prep to make prep take less time. When the shutters drop, its speed returns to normal. This might seem immersion-breaking on one hand, but I think that this could save around 10m of prep and getting to the actual round faster makes up for it.

I'm not sure how harmed xenos would be by marines finishing prep faster, but if it is noticeable I think this can be offset by increasing pre-shutters evolution/aging gains.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It makes the round start and get to the core of the gameplay faster. Currently prep takes a large amount of time and a lot of it is spent performing the same routine every round.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: makes loader much faster during prep
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
