### PR TITLE
Disallows the masterkey shotgun as an attachment for the TX-15 Auto Shotgun

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -917,7 +917,6 @@
 		/obj/item/attachable/heavy_barrel,
 		/obj/item/attachable/motiondetector,
 		/obj/item/weapon/gun/pistol/plasma_pistol,
-		/obj/item/weapon/gun/shotgun/combat/masterkey,
 		/obj/item/weapon/gun/flamer/mini_flamer,
 		/obj/item/weapon/gun/grenade_launcher/underslung,
 	)


### PR DESCRIPTION
## About The Pull Request
Per title.

## Why It's Good For The Game
The fact that you can have a secondary shotgun, on a shotgun, is already weird enough. You can also fire both _simultaneously_ for some god forsaken reason. You can mix and match flechette, buckshot, and slugs for the imbalanced combination of your choice. All things considered, it's nowhere near balanced and arguably something that shouldn't be allowed.

## Changelog
:cl: Lewdcifer
balance: TX-15 autoshotgun no longer accepts masterkey shotguns.
/:cl: