### PR TITLE
Disallows the shoulder gun module on the T-152 RPG

### DIFF
--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -550,7 +550,6 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 		/obj/item/attachable/magnetic_harness,
 		/obj/item/attachable/scope/mini,
 		/obj/item/attachable/buildasentry,
-		/obj/item/attachable/shoulder_mount,
 	)
 
 	flags_gun_features = GUN_WIELDED_FIRING_ONLY|GUN_AMMO_COUNTER


### PR DESCRIPTION
## About The Pull Request
Per title.

## Why It's Good For The Game
An incredibly strong weapon with no wield delay and no wield slowdown is not really that balanced.

## Changelog
:cl: Lewdcifer
balance: T-152 RPG no longer accepts the shoulder gun module.
/:cl: