### PR TITLE
TX-11 Buffs

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -60,7 +60,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 	return
 
 ///Special effects for leaving a turf. Only called if the projectile has AMMO_LEAVE_TURF enabled
-/datum/ammo/proc/on_leave_turf(turf/T, atom/firer)	
+/datum/ammo/proc/on_leave_turf(turf/T, atom/firer)
 	return
 
 /datum/ammo/proc/knockback(mob/victim, obj/projectile/proj, max_range = 2)
@@ -519,6 +519,7 @@ datum/ammo/bullet/revolver/tp44
 	damage = 20
 	penetration = 20
 	sundering = 1.25
+	shell_speed = 3
 
 /datum/ammo/bullet/rifle/heavy
 	name = "heavy rifle bullet"
@@ -1959,7 +1960,7 @@ datum/ammo/bullet/revolver/tp44
 	icon_state = "boiler_gas2"
 	ping = "ping_x"
 	///Key used for icon stuff during bombard ammo selection.
-	var/icon_key = BOILER_GLOB_NEURO	
+	var/icon_key = BOILER_GLOB_NEURO
 	///This text will show up when a boiler selects this ammo. Span proc should be applied when this var is used.
 	var/select_text = "We will now fire neurotoxic gas. This is nonlethal."
 	flags_ammo_behavior = AMMO_XENO|AMMO_SKIPS_ALIENS|AMMO_EXPLOSIVE
@@ -1981,7 +1982,7 @@ datum/ammo/bullet/revolver/tp44
 	///Does the gas spread have a fixed range? -1 for no, 0+ for a fixed range. This prevents scaling from caste age.
 	var/fixed_spread_range = -1
 	///Which type is the smoke we leave on passed tiles, provided the projectile has AMMO_LEAVE_TURF enabled?
-	var/passed_turf_smoke_type = /datum/effect_system/smoke_spread/xeno/neuro/light	
+	var/passed_turf_smoke_type = /datum/effect_system/smoke_spread/xeno/neuro/light
 	///We're going to reuse one smoke spread system repeatedly to cut down on processing.
 	var/datum/effect_system/smoke_spread/xeno/trail_spread_system
 
@@ -2115,7 +2116,7 @@ datum/ammo/bullet/revolver/tp44
 	damage = 75
 	penetration = 60
 	reagent_transfer_amount = 55
-	passed_turf_smoke_type = /datum/effect_system/smoke_spread/xeno/neuro/light	
+	passed_turf_smoke_type = /datum/effect_system/smoke_spread/xeno/neuro/light
 	hit_paralyze_time = 2 SECONDS
 	hit_eye_blur = 16
 	hit_drowsyness = 18

--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -519,7 +519,6 @@ datum/ammo/bullet/revolver/tp44
 	damage = 20
 	penetration = 20
 	sundering = 1.25
-	shell_speed = 3
 
 /datum/ammo/bullet/rifle/heavy
 	name = "heavy rifle bullet"

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1210,6 +1210,7 @@
 		/obj/item/attachable/stock/irremoveable/tx11,
 		/obj/item/attachable/magnetic_harness,
 		/obj/item/attachable/motiondetector,
+		/obj/item/attachable/scope/marine,
 	)
 
 	flags_gun_features = GUN_AMMO_COUNTER
@@ -1220,7 +1221,7 @@
 	aim_fire_delay = 0.125 SECONDS
 
 	fire_delay = 0.225 SECONDS
-	extra_delay = 0.5 SECONDS
+	extra_delay = 0.25 SECONDS
 	burst_amount = 3
 	burst_delay = 0.05 SECONDS
 	accuracy_mult_unwielded = 0.5


### PR DESCRIPTION
## About The Pull Request
TX-11 extra delay reduced to 0.25 from 0.5. 
TX-11 scope zoom offset increased to 7 from 5.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bad gun is now stronger. 
In other news. The zoom offset is to atleast provide a reason to keep it on the gun rather than ditch it. May or may not be necessary with burst changes...
The burst delay on the other hand is...necessary. Currently its **genuinely** awkward and 60 true damage or not, a gun like this is not strong enough to justify a 0.5 second delay. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: TX-11 extra delay decreased to 0.25 from 0.5.
balance: TX-11 scope zoom increased to 7 from 5. Stop littering. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
