### PR TITLE
Give T-25 Smartrifle PB and burst fire

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1030,7 +1030,7 @@
 	attachable_offset = list("muzzle_x" = 42, "muzzle_y" = 17,"rail_x" = 15, "rail_y" = 21, "under_x" = 24, "under_y" = 14, "stock_x" = 12, "stock_y" = 13)
 	fire_delay = 0.2 SECONDS
 	burst_amount = 3
-	burst_delay = 0.15
+	burst_delay = 0.2
 	accuracy_mult_unwielded = 0.5
 	accuracy_mult = 1.2
 	scatter = -5

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1031,6 +1031,7 @@
 	fire_delay = 0.2 SECONDS
 	burst_amount = 3
 	burst_delay = 0.2
+	extra_delay = 1 SECONDS
 	accuracy_mult_unwielded = 0.5
 	accuracy_mult = 1.2
 	scatter = -5

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1024,12 +1024,13 @@
 		/obj/item/attachable/motiondetector,
 	)
 
-	flags_gun_features = GUN_AMMO_COUNTER|GUN_WIELDED_FIRING_ONLY|GUN_IFF
-	gun_firemode_list = list(GUN_FIREMODE_SEMIAUTO, GUN_FIREMODE_AUTOMATIC)
+	flags_gun_features = GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER|GUN_WIELDED_FIRING_ONLY|GUN_IFF
+	gun_firemode_list = list(GUN_FIREMODE_SEMIAUTO, GUN_FIREMODE_BURSTFIRE, GUN_FIREMODE_AUTOMATIC, GUN_FIREMODE_AUTOBURST)
 	gun_skill_category = GUN_SKILL_SMARTGUN //Uses SG skill for the penalties.
 	attachable_offset = list("muzzle_x" = 42, "muzzle_y" = 17,"rail_x" = 15, "rail_y" = 21, "under_x" = 24, "under_y" = 14, "stock_x" = 12, "stock_y" = 13)
 	fire_delay = 0.2 SECONDS
-	burst_amount = 0
+	burst_amount = 3
+	burst_delay = 0.15
 	accuracy_mult_unwielded = 0.5
 	accuracy_mult = 1.2
 	scatter = -5


### PR DESCRIPTION


<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Read title

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Rifles have burst fire and PB, therefore it makes sense to give T-25 the same. I swear, this is not a powercreep and not just double downing that T-25 is T-12+. It can be balance since T-25 hits hard already, but T-25 is already an unga weapon.

T-25 has 80 total rounds, and burst fire shoots 3 bullets, so one mag will have 26 burst fire with the remainer of 2 bullets UNTIL you include the round in the chamber, which in the SECOND mag ASSUMING you save the one round in the chamber is 27 burst fire.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
expansion: Gives T-25 burst fire and PB
balance: T-25 has burst capacity, therefore will punch harder if aimed well.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
