### PR TITLE
Spitter spray acid ability  fine tune.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/abilities_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/abilities_spitter.dm
@@ -6,8 +6,8 @@
 	action_icon_state = "spray_acid"
 	mechanics_text = "Spray a line of dangerous acid at your target."
 	ability_name = "spray acid"
-	plasma_cost = 250
-	cooldown_timer = 30 SECONDS
+	plasma_cost = 320
+	cooldown_timer = 20 SECONDS
 
 /datum/action/xeno_action/activable/spray_acid/line/use_ability(atom/A)
 	var/mob/living/carbon/xenomorph/X = owner
@@ -18,7 +18,7 @@
 
 	X.face_atom(target) //Face target so we don't look stupid
 
-	if(X.do_actions || !do_after(X, 5, TRUE, target, BUSY_ICON_DANGER))
+	if(X.do_actions || !do_after(X, 0.4, TRUE, target, BUSY_ICON_DANGER))
 		return
 
 	if(!can_use_ability(A, TRUE, override_flags = XACT_IGNORE_SELECTED_ABILITY))
@@ -111,6 +111,7 @@
 	plasma_cost = 280
 	cooldown_timer = 5 SECONDS
 	keybind_signal = COMSIG_XENOABILITY_SCATTER_SPIT
+
 
 /datum/action/xeno_action/activable/scatter_spit/use_ability(atom/target)
 	var/mob/living/carbon/xenomorph/X = owner

--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
@@ -6,6 +6,7 @@
 	caste_type_path = /mob/living/carbon/xenomorph/spitter
 	tier = XENO_TIER_TWO
 	upgrade = XENO_UPGRADE_BASETYPE
+	var/channel_time = 0
 
 	// *** Melee Attacks *** //
 	melee_damage = 17
@@ -41,9 +42,9 @@
 	spit_types = list(/datum/ammo/xeno/acid/medium) //Gotta give them their own version of heavy acid; kludgy but necessary as 100 plasma is way too costly.
 
 	acid_spray_duration = 10 SECONDS
-	acid_spray_damage_on_hit = 35
-	acid_spray_damage = 16
-	acid_spray_structure_damage = 45
+	acid_spray_damage_on_hit = 25
+	acid_spray_damage = 10
+	acid_spray_structure_damage = 35
 
 
 	// *** Abilities *** //
@@ -72,7 +73,7 @@
 
 	// *** Plasma *** //
 	plasma_max = 800
-	plasma_gain = 25
+	plasma_gain = 28
 
 	// *** Health *** //
 	max_health = 270
@@ -102,7 +103,7 @@
 
 	// *** Plasma *** //
 	plasma_max = 875
-	plasma_gain = 28
+	plasma_gain = 30
 
 	// *** Health *** //
 	max_health = 290
@@ -123,6 +124,7 @@
 	caste_desc = "A ranged destruction machine."
 	ancient_message = "We are a master of ranged stuns and damage. Go forth and conquer."
 	upgrade = XENO_UPGRADE_THREE
+	channel_time = 0
 
 	// *** Melee Attacks *** //
 	melee_damage = 20
@@ -132,7 +134,7 @@
 
 	// *** Plasma *** //
 	plasma_max = 925
-	plasma_gain = 30
+	plasma_gain = 33
 
 	// *** Health *** //
 	max_health = 310

--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
@@ -162,7 +162,7 @@
 
 	// *** Plasma *** //
 	plasma_max = 925
-	plasma_gain = 30
+	plasma_gain = 33
 
 	// *** Health *** //
 	max_health = 310


### PR DESCRIPTION
## About The Pull Request

Attempts to find the sweet spot for spray acid on spitter as well as a slight plasma gain tweak.

## Why It's Good For The Game

Currently, acid spray is a stupid ability that you use on SSD marines or people healing. even when you are trying to flee the ability doesn't synergize well with trying to escape. 

Spray acid is much weaker all round and much more expensive but it can now be used in 2 ways. first is a better escape ability where you don't need to stop to pray to god that you don't miss against a marine that runs twice as fast as you. the second is you can better ambush and synergize with scatter-spit and normal spit to put a marine off the battlefield for a bit longer. 

right now marines are able to synergize well with what they have whilst Xenos are left with little room for that. this attempts to change that a bit. trading damage and a higher cost for better utility. 

## Changelog
:cl:
balance: acid spray plasma cost increased from 250 to 320.
balance: cooldown from 30 to 20 seconds
balance: activation time from 5 to 0.4 with channel time at 0, 
balance: weaker damage all round
balance: plasma gain now 28, 30, 33
/:cl

https://user-images.githubusercontent.com/64131993/145232833-d1a0868f-dc75-4b24-847e-a2dbc553d4fe.mp4

:
