### PR TITLE
Gives Crusher the Regenerate Skin ability

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -45,6 +45,7 @@
 		/datum/action/xeno_action/activable/stomp,
 		/datum/action/xeno_action/ready_charge,
 		/datum/action/xeno_action/activable/cresttoss,
+		/datum/action/xeno_action/activable/regenerate_skin,
 	)
 
 /datum/xeno_caste/crusher/on_caste_applied(mob/xenomorph)


### PR DESCRIPTION
## About The Pull Request
Per title.

## Why It's Good For The Game
Hoo boy, here we go. I'm going to offer a good enough explanation for the general public.
The intention here is not to powercreep, moreso resolve one of the major glaring issues in Crusher gameplay. You could call it powercreep anyways, though, I guess.

Crusher is a T3 caste that is intended to be a tank. But, quite honestly, it has issues soaking up damage in crowds. So why does this happen, then? The issue is tied to the Sunder mechanic. It has like 80 armor at best, so it's not a matter of armor. It has 370 health at best, which is pretty good, so it's also not a matter of health. It's simply Sunder -- a slow-moving xenomorph is unable to respond properly to damage coming its way, which means it gets sundered very easily, which in turn translates to big damage.
You can tell that increasing armor or health aren't really proper solutions here.

I feel that this might just be the solution we're looking for. This gives Crusher an appropriate response against Sunder, which is an incredibly punishing mechanic towards this caste specifically, to the point that it cripples it big time in terms of gameplay.

If need be, I am willing to compromise by providing an exchange in other aspects, like reducing Crusher's armor or health, or maybe giving Regenerate Skin a wind-up specifically for Crusher, which would make it less of a combat option and moreso something it'd use in its downtime; but I feel that Crusher has needed this sort of help for the longest while, a proper response towards Sunder besides sitting there and crying for several minutes. It'd be more enjoyable in terms of gameplay this way, I feel.

Thank you for coming to my TED Talk.

## Changelog
:cl: Lewdcifer
balance: Crusher now has Regenerate Skin.
/:cl: