### PR TITLE
Nerfs Scatter Spit damage

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1937,7 +1937,7 @@ datum/ammo/bullet/revolver/tp44
 
 ///For the Spitter's Scatterspit ability
 /datum/ammo/xeno/acid/heavy/scatter
-	damage = 20
+	damage = 15
 	flags_ammo_behavior = AMMO_XENO|AMMO_EXPLOSIVE|AMMO_SKIPS_ALIENS
 	bonus_projectiles_type = /datum/ammo/xeno/acid/heavy/scatter
 	bonus_projectiles_amount = 6


### PR DESCRIPTION
## About The Pull Request
Per title.

## Why It's Good For The Game
20 damage per acid shot, totalling at 120 if all spits hit, before acid armor. Wack.
This PR changes it to be 15 x 6 = 90. More tame.
You're crippling people without armor and you're doing nothing to people _with_ armor.
A better solution would be to rebalance acid armor instead of shafting certain armor types.

## Changelog
:cl: Lewdcifer
balance: Scatter spit damage per shot 20 > 15.
/:cl: