### PR TITLE
fixes a bug that made not having a heart not do much other than make you undefibbable

### DIFF
--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -18,13 +18,13 @@
 		//Blood regeneration if there is some space
 		if(blood_volume < BLOOD_VOLUME_NORMAL)
 			blood_volume += 0.1 // regenerate blood VERY slowly
-
+		
+		heart_multi = initial(heart_multi)
+		
 		// Damaged heart virtually reduces the blood volume, as the blood isn't
 		// being pumped properly anymore.
 		if(species && species.has_organ["heart"])
 			var/datum/internal_organ/heart/heart = internal_organs_by_name["heart"]
-
-			heart_multi = initial(heart_multi)
 
 			if(!heart)
 				heart_multi *= 0.5 //you'd die in seconds but you can't remove internal organs even with varediting.

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -29,7 +29,7 @@
 			if(!heart)
 				heart_multi *= 0.5 //you'd die in seconds but you can't remove internal organs even with varediting.
 
-			if(heart && !(reagents.get_reagent_amount(/datum/reagent/medicine/peridaxon) >= 0.05) && heart.damage > 1)
+			if(heart && reagents.get_reagent_amount(/datum/reagent/medicine/peridaxon) < 0.05 && heart.damage > 1)
 				if(heart.is_broken())
 					heart_multi *= 0.5
 					blood_volume = max(blood_volume - 1.3, 0)

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -24,23 +24,21 @@
 		if(species && species.has_organ["heart"])
 			var/datum/internal_organ/heart/heart = internal_organs_by_name["heart"]
 
+			heart_multi = initial(heart_multi)
+
 			if(!heart)
 				heart_multi *= 0.5 //you'd die in seconds but you can't remove internal organs even with varediting.
 
-			if(!(reagents.get_reagent_amount(/datum/reagent/medicine/peridaxon) >= 0.05) && heart.damage > 1)
-				if(heart.damage < heart.min_bruised_damage)
-					heart_multi = 0.9
-					blood_volume = max(blood_volume - 0.1, 0) //nulls regeneration
-				else if(heart.damage < heart.min_broken_damage)
-					heart_multi = 0.7
-					blood_volume = max(blood_volume - 0.5, 0)
-				else
-					heart_multi = 0.5
+			if(heart && !(reagents.get_reagent_amount(/datum/reagent/medicine/peridaxon) >= 0.05) && heart.damage > 1)
+				if(heart.is_broken())
+					heart_multi *= 0.5
 					blood_volume = max(blood_volume - 1.3, 0)
-			else
-				heart_multi = 1
-
-
+				else if(heart.is_bruised())
+					heart_multi *= 0.7
+					blood_volume = max(blood_volume - 0.5, 0)	
+				else
+					heart_multi *= 0.9
+					blood_volume = max(blood_volume - 0.1, 0) //nulls regeneration
 
 
 


### PR DESCRIPTION
## About The Pull Request

The code for applying the effective blood level reduction for not having a heart no longer has its effect almost immediately overridden by the code that returns your effective blood level to normal if you don't have a damaged heart.

In other words, not having a heart now halves your effective blood level, as it was intended to.

I also made the code for handling damaged hearts use the is_bruised() and is_broken() procs instead of directly checking for damage thresholds. This means that disconnecting someone's heart from the rest of their body via surgery will now impose the same effects on their blood level (and effective blood level) that breaking their heart would.

## Why It's Good For The Game

Code cleanup + not having a heart actually kills you if your blood level isn't dummy high.

## Changelog
:cl: ATHATH
fix: Not having a heart now halves your effective blood level, as it was intended to.
fix: Disconnecting someone's heart from the rest of their body via surgery will now impose the same effects on their blood level (and effective blood level) that breaking their heart would.
/:cl:
