### PR TITLE
Fixes pill packet sprites not showing

### DIFF
--- a/code/game/objects/items/storage/pill_packets.dm
+++ b/code/game/objects/items/storage/pill_packets.dm
@@ -12,7 +12,7 @@
 
 /obj/item/storage/pill_bottle/packet/tricordrazine
 	name = "Tricordazine pill packet"
-	icon_state = "tric-packet"
+	icon_state = "tric_packet"
 	desc = "This packet containts tricordazine pills. Heals all types of damage slightly. Once you take them out they don't go back in. No more than 2 pills in a short period."
 	pill_type_to_fill = /obj/item/reagent_containers/pill/tricordrazine
 	storage_slots = 6
@@ -40,7 +40,7 @@
 
 /obj/item/storage/pill_bottle/packet/bicaridine
 	name = "bicaridine pill packet"
-	icon_state = "bic-packet"
+	icon_state = "bic_packet"
 	desc = "This packet containts bicaridine pills. Used to treat minor lacerations. Once you take them out they don't go back in. No more than 2 pills at once."
 	pill_type_to_fill = /obj/item/reagent_containers/pill/bicaridine
 	storage_slots = 8
@@ -48,7 +48,7 @@
 
 /obj/item/storage/pill_bottle/packet/kelotane
 	name = "kelotane pill packet"
-	icon_state = "kelo-packet"
+	icon_state = "kelo_packet"
 	desc = "This packet containts kelotane pills. Used to treat surface burns. Once you take them out they don't go back in. No more than 2 pills at once."
 	pill_type_to_fill = /obj/item/reagent_containers/pill/kelotane
 	storage_slots = 8
@@ -56,7 +56,7 @@
 
 /obj/item/storage/pill_bottle/packet/tramadol
 	name = "tramadol pill packet"
-	icon_state = "tram-packet"
+	icon_state = "tram_packet"
 	desc = "This packet containts tramadol pills. Used as a medium-strength painkiller. Once you take them out they don't go back in. No more than 2 pills at once."
 	pill_type_to_fill = /obj/item/reagent_containers/pill/tramadol
 	storage_slots = 8


### PR DESCRIPTION
## About The Pull Request
Changes the dashes in the icon_state to underscores

Caused by #8916 adding these in but then mistakenly putting in dashes instead of underscores, causing the issues.
Fixes #8927 

This PR has been fully tested on a local build with zero (0) runtimes or errors.
![dreamseeker_2021-12-09_14-09-58](https://user-images.githubusercontent.com/17747087/145402561-a499ced3-3f2b-490f-a39e-e25c81c11b19.png)

## Why It's Good For The Game
This fixes pill packet sprites in firstaid pouches so they are visible, invisible pill packet sprites are considred widely to be not good.

## Changelog
:cl: Vondiech
fix: Pill packets are now visible again with the new sprites that were added to them.
/:cl: