### PR TITLE
Protein bar Fixes and Tweaks

### DIFF
--- a/code/game/objects/items/marine_gear.dm
+++ b/code/game/objects/items/marine_gear.dm
@@ -68,8 +68,6 @@
 
 /obj/item/reagent_containers/food/snacks/protein_pack/Initialize()
 	. = ..()
-
-
 	///list of protein bar stats to change
 	var/list/picked = pick(randlist)
 	name = picked[1]

--- a/code/game/objects/items/marine_gear.dm
+++ b/code/game/objects/items/marine_gear.dm
@@ -29,9 +29,9 @@
 	pixel_y = rand(-3,3)
 	pixel_x = rand(-3,3)
 	var/list/randompick = list(
-		/obj/item/reagent_containers/food/snacks/protein_pack_base/one,
-		/obj/item/reagent_containers/food/snacks/protein_pack_base/five,
-		/obj/item/reagent_containers/food/snacks/protein_pack_base/six,
+		/obj/item/reagent_containers/food/snacks/protein_pack,
+		/obj/item/reagent_containers/food/snacks/protein_pack,
+		/obj/item/reagent_containers/food/snacks/protein_pack,
 		/obj/item/reagent_containers/food/snacks/mre_pack/meal1,
 		/obj/item/reagent_containers/food/snacks/mre_pack/meal2,
 		/obj/item/reagent_containers/food/snacks/mre_pack/meal3,
@@ -42,9 +42,7 @@
 	for(var/i in 1 to 7)
 		var/picked = pick(randompick)
 		new picked(src)
-
-
-/obj/item/reagent_containers/food/snacks/protein_pack_base
+/obj/item/reagent_containers/food/snacks/protein_pack
 
 	name = "stale TGMC protein bar"
 	desc = "The most fake looking protein bar you have ever laid eyes on, covered in the a subtitution chocolate. The powder used to make these is a subsitute of a substitute of whey substitute."
@@ -53,83 +51,11 @@
 	w_class = WEIGHT_CLASS_TINY
 	list_reagents = list(/datum/reagent/consumable/nutriment = 8)
 	bitesize = 4
-	tastes = list("nutraloafed food" = 7, "cocoa" = 1)
-	greyscale_config = /datum/greyscale_config/protein
-
-/obj/item/reagent_containers/food/snacks/protein_pack_base/one
-	name = "stale TGMC protein bar"
-	desc = "The most fake looking protein bar you have ever laid eyes on, covered in the a subtitution chocolate. The powder used to make these is a subsitute of a substitute of whey substitute."
-	greyscale_colors = "#f37d43" //default colors
-	list_reagents = list(/datum/reagent/consumable/protein = 8)
-
-/obj/item/reagent_containers/food/snacks/protein_pack_base/two
-	name = "mint TGMC protein bar"
-	desc = "Stale old protien bar, with an almost minty freshness to it, but not fresh enough"
-	greyscale_colors = "#61b36e"
-	list_reagents = list(/datum/reagent/consumable/protein/mint = 8)
-
-/obj/item/reagent_containers/food/snacks/protein_pack_base/three
-	name = "grape TGMC protein bar"
-	desc = "Not the good type of grape flavor, tastes like medicine. Fills you up just as well as any protein bar."
-	greyscale_colors = "#9900ff"
-	tastes = list("artifical grape" = 25)
-	list_reagents = list(/datum/reagent/consumable/protein/grape = 8)
-
-/obj/item/reagent_containers/food/snacks/protein_pack_base/four
-	name = "mystery TGMC protein bar"
-	desc = "Some say they have tasted one of these and tasted their favorite childhood meal, especially for squad marines. Most say this tastes like crayons, though it fills like any other protein bar you've seen."
-	greyscale_colors = "#ffffff"
-	list_reagents = list(/datum/reagent/consumable/protein/mystery = 8)
-
-/obj/item/reagent_containers/food/snacks/protein_pack_base/five
-	name = "dark chocolate TGMC protein bar"
-	desc = "The dark chocolate flavor helps it out a bit, but its still a cheap protein bar."
-	greyscale_colors = "#5a3b1d"
-	list_reagents = list(/datum/reagent/consumable/protein/darkchocolate = 8)
-
-/obj/item/reagent_containers/food/snacks/protein_pack_base/six
-	name = "milk chocolate TGMC protein bar"
-	desc = "A nice milky addition to a otherwise bland protein taste."
-	greyscale_colors = "#efc296"
-	list_reagents = list(/datum/reagent/consumable/protein/milkchocolate = 8)
-
-/obj/item/reagent_containers/food/snacks/protein_pack_base/seven
-	name = "raspberry lime TGMC protein bar"
-	desc = "A flavored protein bar, some might say a bit too strongly flavored for their tastes."
-	greyscale_colors = "#ff0066"
-	list_reagents = list(/datum/reagent/consumable/protein/rasplime = 8)
-
-/obj/item/reagent_containers/food/snacks/protein_pack_base/eight
-	name = "chicken TGMC protein bar"
-	desc = "Protein bar covered with chicken powder one might find in ramen. Get some extra sodium with your protein."
-	greyscale_colors = "#cccc00"
-	list_reagents = list(/datum/reagent/consumable/protein/chicken = 8)
-
-/obj/item/reagent_containers/food/snacks/protein_pack_base/nine
-	name = "blueberry TGMC protein bar"
-	desc = "A nice blueberry crunch into your otherwise stale and boring protein bar."
-	greyscale_colors = "#4e39c5"
-	list_reagents = list(/datum/reagent/consumable/protein/blueberry = 8)
-
-/obj/item/reagent_containers/food/snacks/protein_pack
-	name = "TGMC protein bar"
-	desc = "A protien bar produced for the TGMC, comes in many flavors"// this text is only seen at the vending machine, the actual item should never exist.
-	icon_state = "yummers"
-	filling_color = "#ED1169"
-	w_class = WEIGHT_CLASS_TINY
-	//list_reagents = list(/datum/reagent/consumable/nutriment = 8)
-	bitesize = 4
 	greyscale_config = /datum/greyscale_config/protein
 
 /obj/item/reagent_containers/food/snacks/protein_pack/Initialize()
 	. = ..()
-
-//do something like this
-//var/static/list/options = (list("Stale Protein bar", "Fuck its stale", "stale_protein"), list("Protein Bar", "It's not stale", "stale_protein"))
-//var/static/list/pickedoption = pick(options)
-//name = pickedoption[1]
-//desc = pickedoption[2]
-//icon_state = pickedoption[3]
+	///list of producable protein bars
 	var/list/randlist = list(
 		list("stale TGMC protein bar","The most fake looking protein bar you have ever laid eyes on, covered in the a subtitution chocolate. The powder used to make these is a subsitute of a substitute of whey substitute.","#f37d43",/datum/reagent/consumable/protein),
 		list("mint TGMC protein bar","Stale old protien bar, with an almost minty freshness to it, but not fresh enough","#61b36e",/datum/reagent/consumable/protein/mint),
@@ -141,24 +67,15 @@
 		list("chicken TGMC protein bar","Protein bar covered with chicken powder one might find in ramen. Get some extra sodium with your protein.","#cccc00",/datum/reagent/consumable/protein/chicken),
 		list("blueberry TGMC protein bar","A nice blueberry crunch into your otherwise stale and boring protein bar.","#4e39c5",/datum/reagent/consumable/protein/blueberry)
 	)
+	///list of protein bar stats to change
 	var/list/picked = pick(randlist)
+	///amount of protein mix to put inside protein bars (8 to emulate old protein mec
 	var/protein_to_add = 8 //no magic numbers
 	name = picked[1]
 	desc = picked[2]
 	set_greyscale_colors(picked[3])
 	src.reagents.add_reagent(picked[4],protein_to_add)
-//	var/protein_bar = pick( ///which protein bar gets picked to generated when a protein_pack is spawned.
-//		/obj/item/reagent_containers/food/snacks/protein_pack_base/one,
-//		/obj/item/reagent_containers/food/snacks/protein_pack_base/two,
-//		/obj/item/reagent_containers/food/snacks/protein_pack_base/three,
-//		/obj/item/reagent_containers/food/snacks/protein_pack_base/four,
-//		/obj/item/reagent_containers/food/snacks/protein_pack_base/five,
-//		/obj/item/reagent_containers/food/snacks/protein_pack_base/six,
-//		/obj/item/reagent_containers/food/snacks/protein_pack_base/seven,
-//		/obj/item/reagent_containers/food/snacks/protein_pack_base/eight,
-//		/obj/item/reagent_containers/food/snacks/protein_pack_base/nine)
-//	new protein_bar(src.loc)
-//	qdel(src)
+
 
 /obj/item/reagent_containers/food/snacks/mre_pack
 	name = "\improper generic MRE pack"

--- a/code/game/objects/items/marine_gear.dm
+++ b/code/game/objects/items/marine_gear.dm
@@ -58,7 +58,7 @@
 	///list of producable protein bars
 	var/list/randlist = list(
 		list("stale TGMC protein bar","The most fake looking protein bar you have ever laid eyes on, covered in the a subtitution chocolate. The powder used to make these is a subsitute of a substitute of whey substitute.","#f37d43",/datum/reagent/consumable/protein),
-		list("mint TGMC protein bar","Stale old protien bar, with an almost minty freshness to it, but not fresh enough","#61b36e",/datum/reagent/consumable/protein/mint),
+		list("mint TGMC protein bar","A stale old protein bar, with an almost minty freshness to it, but not fresh enough.","#61b36e",/datum/reagent/consumable/protein/mint),
 		list("grape TGMC protein bar","Not the good type of grape flavor, tastes like medicine. Fills you up just as well as any protein bar.","#9900ff",/datum/reagent/consumable/protein/grape),
 		list("mystery TGMC protein bar","Some say they have tasted one of these and tasted their favorite childhood meal, especially for squad marines. Most say this tastes like crayons, though it fills like any other protein bar you've seen.","#ffffff",/datum/reagent/consumable/protein/mystery),
 		list("dark chocolate TGMC protein bar","The dark chocolate flavor helps it out a bit, but its still a cheap protein bar.","#5a3b1d",/datum/reagent/consumable/protein/darkchocolate),

--- a/code/game/objects/items/marine_gear.dm
+++ b/code/game/objects/items/marine_gear.dm
@@ -114,21 +114,43 @@
 /obj/item/reagent_containers/food/snacks/protein_pack
 	name = "TGMC protein bar"
 	desc = "A protien bar produced for the TGMC, comes in many flavors"// this text is only seen at the vending machine, the actual item should never exist.
+	icon_state = "yummers"
+	filling_color = "#ED1169"
+	w_class = WEIGHT_CLASS_TINY
+	//list_reagents = list(/datum/reagent/consumable/nutriment = 8)
+	bitesize = 4
+	greyscale_config = /datum/greyscale_config/protein
 
 /obj/item/reagent_containers/food/snacks/protein_pack/Initialize()
 	. = ..()
-	var/protein_bar = pick( ///which protein bar gets picked to generated when a protein_pack is spawned.
-		/obj/item/reagent_containers/food/snacks/protein_pack_base/one,
-		/obj/item/reagent_containers/food/snacks/protein_pack_base/two,
-		/obj/item/reagent_containers/food/snacks/protein_pack_base/three,
-		/obj/item/reagent_containers/food/snacks/protein_pack_base/four,
-		/obj/item/reagent_containers/food/snacks/protein_pack_base/five,
-		/obj/item/reagent_containers/food/snacks/protein_pack_base/six,
-		/obj/item/reagent_containers/food/snacks/protein_pack_base/seven,
-		/obj/item/reagent_containers/food/snacks/protein_pack_base/eight,
-		/obj/item/reagent_containers/food/snacks/protein_pack_base/nine)
-	new protein_bar(src.loc)
-	qdel(src)
+
+//do something like this
+//var/static/list/options = (list("Stale Protein bar", "Fuck its stale", "stale_protein"), list("Protein Bar", "It's not stale", "stale_protein"))
+//var/static/list/pickedoption = pick(options)
+//name = pickedoption[1]
+//desc = pickedoption[2]
+//icon_state = pickedoption[3]
+	var/list/randlist = list(
+		list("stale TGMC protein bar","The most fake looking protein bar you have ever laid eyes on, covered in the a subtitution chocolate. The powder used to make these is a subsitute of a substitute of whey substitute.","#f37d43",/datum/reagent/consumable/protein),
+		list("mint TGMC protein bar","Stale old protien bar, with an almost minty freshness to it, but not fresh enough","#61b36e",/datum/reagent/consumable/protein/mint)
+	)
+	var/list/picked = pick(randlist)
+	name = picked[1]
+	desc = picked[2]
+	set_greyscale_colors(picked[3])
+	src.reagents.add_reagent(picked[4],8)
+//	var/protein_bar = pick( ///which protein bar gets picked to generated when a protein_pack is spawned.
+//		/obj/item/reagent_containers/food/snacks/protein_pack_base/one,
+//		/obj/item/reagent_containers/food/snacks/protein_pack_base/two,
+//		/obj/item/reagent_containers/food/snacks/protein_pack_base/three,
+//		/obj/item/reagent_containers/food/snacks/protein_pack_base/four,
+//		/obj/item/reagent_containers/food/snacks/protein_pack_base/five,
+//		/obj/item/reagent_containers/food/snacks/protein_pack_base/six,
+//		/obj/item/reagent_containers/food/snacks/protein_pack_base/seven,
+//		/obj/item/reagent_containers/food/snacks/protein_pack_base/eight,
+//		/obj/item/reagent_containers/food/snacks/protein_pack_base/nine)
+//	new protein_bar(src.loc)
+//	qdel(src)
 
 /obj/item/reagent_containers/food/snacks/mre_pack
 	name = "\improper generic MRE pack"

--- a/code/game/objects/items/marine_gear.dm
+++ b/code/game/objects/items/marine_gear.dm
@@ -74,7 +74,7 @@
 	name = picked[1]
 	desc = picked[2]
 	set_greyscale_colors(picked[3])
-	src.reagents.add_reagent(picked[4],protein_to_add)
+	reagents.add_reagent(picked[4],protein_to_add)
 
 
 /obj/item/reagent_containers/food/snacks/mre_pack

--- a/code/game/objects/items/marine_gear.dm
+++ b/code/game/objects/items/marine_gear.dm
@@ -52,7 +52,6 @@
 	bitesize = 4
 	greyscale_config = /datum/greyscale_config/protein
 	tastes = list(("flavored protein bar") = 1)
-	//list of producable protein bars
 	var/static/list/randlist = list(
 		list("stale TGMC protein bar","The most fake looking protein bar you have ever laid eyes on, covered in the a subtitution chocolate. The powder used to make these is a subsitute of a substitute of whey substitute.","#f37d43",list("nutraloafed food" = 1)),
 		list("mint TGMC protein bar","A stale old protien bar, with an almost minty freshness to it, but not fresh enough","#61b36e",list("minty protein" = 1)),
@@ -67,7 +66,7 @@
 
 /obj/item/reagent_containers/food/snacks/protein_pack/Initialize()
 	. = ..()
-	///list of protein bar stats to change
+	//list of protein bar stats to change
 	var/list/picked = pick(randlist)
 	name = picked[1]
 	desc = picked[2]

--- a/code/game/objects/items/marine_gear.dm
+++ b/code/game/objects/items/marine_gear.dm
@@ -44,39 +44,38 @@
 		new picked(src)
 /obj/item/reagent_containers/food/snacks/protein_pack
 
-	name = "stale TGMC protein bar"
-	desc = "The most fake looking protein bar you have ever laid eyes on, covered in the a subtitution chocolate. The powder used to make these is a subsitute of a substitute of whey substitute."
+	name = "TGMC protein bar"
+	desc = "The most fake looking protein bar you have ever laid eyes on, comes in many flavors"
 	icon_state = "yummers"
 	filling_color = "#ED1169"
 	w_class = WEIGHT_CLASS_TINY
-	list_reagents = list(/datum/reagent/consumable/nutriment = 8)
+	//list_reagents = list(/datum/reagent/consumable/nutriment = 8)
 	bitesize = 4
 	greyscale_config = /datum/greyscale_config/protein
+	tastes = list(("flavored protein bar") = 1)
 
 /obj/item/reagent_containers/food/snacks/protein_pack/Initialize()
 	. = ..()
 	///list of producable protein bars
 	var/list/randlist = list(
-		list("stale TGMC protein bar","The most fake looking protein bar you have ever laid eyes on, covered in the a subtitution chocolate. The powder used to make these is a subsitute of a substitute of whey substitute.","#f37d43","nutraloafed food" = 1),
-		list("mint TGMC protein bar","A stale old protien bar, with an almost minty freshness to it, but not fresh enough","#61b36e","minty protein" = 1),
-		list("grape TGMC protein bar","Not the good type of grape flavor, tastes like medicine. Fills you up just as well as any protein bar.","#9900ff","artifical grape"= 1),
-		list("mystery TGMC protein bar","Some say they have tasted one of these and tasted their favorite childhood meal, especially for squad marines. Most say this tastes like crayons, though it fills like any other protein bar you've seen.","#ffffff","crayons" = 1),
-		list("dark chocolate TGMC protein bar","The dark chocolate flavor helps it out a bit, but its still a cheap protein bar.","#5a3b1d","bitter dark chocolate" = 1),
-		list("milk chocolate TGMC protein bar","A nice milky addition to a otherwise bland protein taste.","#efc296","off flavor milk chocolate" = 1),
-		list("raspberry lime TGMC protein bar","A flavored protein bar, some might say a bit too strongly flavored for their tastes.","#ff0066","sour raspberry and lime" = 1),
-		list("chicken TGMC protein bar","Protein bar covered with chicken powder one might find in ramen. Get some extra sodium with your protein.","#cccc00","powdered chicken" = 1),
-		list("blueberry TGMC protein bar","A nice blueberry crunch into your otherwise stale and boring protein bar.","#4e39c5","blueberry" = 1)
+		list("stale TGMC protein bar","The most fake looking protein bar you have ever laid eyes on, covered in the a subtitution chocolate. The powder used to make these is a subsitute of a substitute of whey substitute.","#f37d43",list("nutraloafed food" = 1)),
+		list("mint TGMC protein bar","A stale old protien bar, with an almost minty freshness to it, but not fresh enough","#61b36e",list("minty protein" = 1)),
+		list("grape TGMC protein bar","Not the good type of grape flavor, tastes like medicine. Fills you up just as well as any protein bar.","#9900ff",list("artifical grape" = 1)),
+		list("mystery TGMC protein bar","Some say they have tasted one of these and tasted their favorite childhood meal, especially for squad marines. Most say this tastes like crayons, though it fills like any other protein bar you've seen.","#ffffff",list("crayons" = 1)),
+		list("dark chocolate TGMC protein bar","The dark chocolate flavor helps it out a bit, but its still a cheap protein bar.","#5a3b1d",list("bitter dark chocolate" = 1)),
+		list("milk chocolate TGMC protein bar","A nice milky addition to a otherwise bland protein taste.","#efc296",list("off flavor milk chocolate"= 1)),
+		list("raspberry lime TGMC protein bar","A flavored protein bar, some might say a bit too strongly flavored for their tastes.","#ff0066",list("sour raspberry and lime" = 1)),
+		list("chicken TGMC protein bar","Protein bar covered with chicken powder one might find in ramen. Get some extra sodium with your protein.","#cccc00",list= ("powdered chicken")),
+		list("blueberry TGMC protein bar","A nice blueberry crunch into your otherwise stale and boring protein bar.","#4e39c5",list("blueberry" = 1))
 	)
 	///list of protein bar stats to change
 	var/list/picked = pick(randlist)
-	///amount of protein mix to put inside protein bars (8 to emulate old protein mec
-	//var/protein_to_add = 8 //no magic numbers
 	name = picked[1]
 	desc = picked[2]
 	set_greyscale_colors(picked[3])
-	//reagents.add_reagent(picked[4],protein_to_add)
 	tastes = picked[4]
-
+	//due the way nutriment works it has to be added like this or the flavor is cached
+	reagents.add_reagent(/datum/reagent/consumable/nutriment, 8, picked[4])
 
 /obj/item/reagent_containers/food/snacks/mre_pack
 	name = "\improper generic MRE pack"

--- a/code/game/objects/items/marine_gear.dm
+++ b/code/game/objects/items/marine_gear.dm
@@ -57,24 +57,25 @@
 	. = ..()
 	///list of producable protein bars
 	var/list/randlist = list(
-		list("stale TGMC protein bar","The most fake looking protein bar you have ever laid eyes on, covered in the a subtitution chocolate. The powder used to make these is a subsitute of a substitute of whey substitute.","#f37d43",/datum/reagent/consumable/protein),
-		list("mint TGMC protein bar","A stale old protein bar, with an almost minty freshness to it, but not fresh enough.","#61b36e",/datum/reagent/consumable/protein/mint),
-		list("grape TGMC protein bar","Not the good type of grape flavor, tastes like medicine. Fills you up just as well as any protein bar.","#9900ff",/datum/reagent/consumable/protein/grape),
-		list("mystery TGMC protein bar","Some say they have tasted one of these and tasted their favorite childhood meal, especially for squad marines. Most say this tastes like crayons, though it fills like any other protein bar you've seen.","#ffffff",/datum/reagent/consumable/protein/mystery),
-		list("dark chocolate TGMC protein bar","The dark chocolate flavor helps it out a bit, but its still a cheap protein bar.","#5a3b1d",/datum/reagent/consumable/protein/darkchocolate),
-		list("milk chocolate TGMC protein bar","A nice milky addition to a otherwise bland protein taste.","#efc296",/datum/reagent/consumable/protein/milkchocolate),
-		list("raspberry lime TGMC protein bar","A flavored protein bar, some might say a bit too strongly flavored for their tastes.","#ff0066",/datum/reagent/consumable/protein/rasplime),
-		list("chicken TGMC protein bar","Protein bar covered with chicken powder one might find in ramen. Get some extra sodium with your protein.","#cccc00",/datum/reagent/consumable/protein/chicken),
-		list("blueberry TGMC protein bar","A nice blueberry crunch into your otherwise stale and boring protein bar.","#4e39c5",/datum/reagent/consumable/protein/blueberry)
+		list("stale TGMC protein bar","The most fake looking protein bar you have ever laid eyes on, covered in the a subtitution chocolate. The powder used to make these is a subsitute of a substitute of whey substitute.","#f37d43","nutraloafed food" = 1),
+		list("mint TGMC protein bar","A stale old protien bar, with an almost minty freshness to it, but not fresh enough","#61b36e","minty protein" = 1),
+		list("grape TGMC protein bar","Not the good type of grape flavor, tastes like medicine. Fills you up just as well as any protein bar.","#9900ff","artifical grape"= 1),
+		list("mystery TGMC protein bar","Some say they have tasted one of these and tasted their favorite childhood meal, especially for squad marines. Most say this tastes like crayons, though it fills like any other protein bar you've seen.","#ffffff","crayons" = 1),
+		list("dark chocolate TGMC protein bar","The dark chocolate flavor helps it out a bit, but its still a cheap protein bar.","#5a3b1d","bitter dark chocolate" = 1),
+		list("milk chocolate TGMC protein bar","A nice milky addition to a otherwise bland protein taste.","#efc296","off flavor milk chocolate" = 1),
+		list("raspberry lime TGMC protein bar","A flavored protein bar, some might say a bit too strongly flavored for their tastes.","#ff0066","sour raspberry and lime" = 1),
+		list("chicken TGMC protein bar","Protein bar covered with chicken powder one might find in ramen. Get some extra sodium with your protein.","#cccc00","powdered chicken" = 1),
+		list("blueberry TGMC protein bar","A nice blueberry crunch into your otherwise stale and boring protein bar.","#4e39c5","blueberry" = 1)
 	)
 	///list of protein bar stats to change
 	var/list/picked = pick(randlist)
 	///amount of protein mix to put inside protein bars (8 to emulate old protein mec
-	var/protein_to_add = 8 //no magic numbers
+	//var/protein_to_add = 8 //no magic numbers
 	name = picked[1]
 	desc = picked[2]
 	set_greyscale_colors(picked[3])
-	reagents.add_reagent(picked[4],protein_to_add)
+	//reagents.add_reagent(picked[4],protein_to_add)
+	tastes = picked[4]
 
 
 /obj/item/reagent_containers/food/snacks/mre_pack

--- a/code/game/objects/items/marine_gear.dm
+++ b/code/game/objects/items/marine_gear.dm
@@ -57,7 +57,7 @@
 /obj/item/reagent_containers/food/snacks/protein_pack/Initialize()
 	. = ..()
 	///list of producable protein bars
-	var/list/randlist = list(
+	var/static/list/randlist = list(
 		list("stale TGMC protein bar","The most fake looking protein bar you have ever laid eyes on, covered in the a subtitution chocolate. The powder used to make these is a subsitute of a substitute of whey substitute.","#f37d43",list("nutraloafed food" = 1)),
 		list("mint TGMC protein bar","A stale old protien bar, with an almost minty freshness to it, but not fresh enough","#61b36e",list("minty protein" = 1)),
 		list("grape TGMC protein bar","Not the good type of grape flavor, tastes like medicine. Fills you up just as well as any protein bar.","#9900ff",list("artifical grape" = 1)),

--- a/code/game/objects/items/marine_gear.dm
+++ b/code/game/objects/items/marine_gear.dm
@@ -53,9 +53,6 @@
 	bitesize = 4
 	greyscale_config = /datum/greyscale_config/protein
 	tastes = list(("flavored protein bar") = 1)
-
-/obj/item/reagent_containers/food/snacks/protein_pack/Initialize()
-	. = ..()
 	///list of producable protein bars
 	var/static/list/randlist = list(
 		list("stale TGMC protein bar","The most fake looking protein bar you have ever laid eyes on, covered in the a subtitution chocolate. The powder used to make these is a subsitute of a substitute of whey substitute.","#f37d43",list("nutraloafed food" = 1)),
@@ -68,6 +65,11 @@
 		list("chicken TGMC protein bar","Protein bar covered with chicken powder one might find in ramen. Get some extra sodium with your protein.","#cccc00",list= ("powdered chicken")),
 		list("blueberry TGMC protein bar","A nice blueberry crunch into your otherwise stale and boring protein bar.","#4e39c5",list("blueberry" = 1))
 	)
+
+/obj/item/reagent_containers/food/snacks/protein_pack/Initialize()
+	. = ..()
+
+
 	///list of protein bar stats to change
 	var/list/picked = pick(randlist)
 	name = picked[1]

--- a/code/game/objects/items/marine_gear.dm
+++ b/code/game/objects/items/marine_gear.dm
@@ -49,7 +49,6 @@
 	icon_state = "yummers"
 	filling_color = "#ED1169"
 	w_class = WEIGHT_CLASS_TINY
-	//list_reagents = list(/datum/reagent/consumable/nutriment = 8)
 	bitesize = 4
 	greyscale_config = /datum/greyscale_config/protein
 	tastes = list(("flavored protein bar") = 1)

--- a/code/game/objects/items/marine_gear.dm
+++ b/code/game/objects/items/marine_gear.dm
@@ -52,7 +52,7 @@
 	bitesize = 4
 	greyscale_config = /datum/greyscale_config/protein
 	tastes = list(("flavored protein bar") = 1)
-	///list of producable protein bars
+	//list of producable protein bars
 	var/static/list/randlist = list(
 		list("stale TGMC protein bar","The most fake looking protein bar you have ever laid eyes on, covered in the a subtitution chocolate. The powder used to make these is a subsitute of a substitute of whey substitute.","#f37d43",list("nutraloafed food" = 1)),
 		list("mint TGMC protein bar","A stale old protien bar, with an almost minty freshness to it, but not fresh enough","#61b36e",list("minty protein" = 1)),

--- a/code/game/objects/items/marine_gear.dm
+++ b/code/game/objects/items/marine_gear.dm
@@ -132,13 +132,21 @@
 //icon_state = pickedoption[3]
 	var/list/randlist = list(
 		list("stale TGMC protein bar","The most fake looking protein bar you have ever laid eyes on, covered in the a subtitution chocolate. The powder used to make these is a subsitute of a substitute of whey substitute.","#f37d43",/datum/reagent/consumable/protein),
-		list("mint TGMC protein bar","Stale old protien bar, with an almost minty freshness to it, but not fresh enough","#61b36e",/datum/reagent/consumable/protein/mint)
+		list("mint TGMC protein bar","Stale old protien bar, with an almost minty freshness to it, but not fresh enough","#61b36e",/datum/reagent/consumable/protein/mint),
+		list("grape TGMC protein bar","Not the good type of grape flavor, tastes like medicine. Fills you up just as well as any protein bar.","#9900ff",/datum/reagent/consumable/protein/grape),
+		list("mystery TGMC protein bar","Some say they have tasted one of these and tasted their favorite childhood meal, especially for squad marines. Most say this tastes like crayons, though it fills like any other protein bar you've seen.","#ffffff",/datum/reagent/consumable/protein/mystery),
+		list("dark chocolate TGMC protein bar","The dark chocolate flavor helps it out a bit, but its still a cheap protein bar.","#5a3b1d",/datum/reagent/consumable/protein/darkchocolate),
+		list("milk chocolate TGMC protein bar","A nice milky addition to a otherwise bland protein taste.","#efc296",/datum/reagent/consumable/protein/milkchocolate),
+		list("raspberry lime TGMC protein bar","A flavored protein bar, some might say a bit too strongly flavored for their tastes.","#ff0066",/datum/reagent/consumable/protein/rasplime),
+		list("chicken TGMC protein bar","Protein bar covered with chicken powder one might find in ramen. Get some extra sodium with your protein.","#cccc00",/datum/reagent/consumable/protein/chicken),
+		list("blueberry TGMC protein bar","A nice blueberry crunch into your otherwise stale and boring protein bar.","#4e39c5",/datum/reagent/consumable/protein/blueberry)
 	)
 	var/list/picked = pick(randlist)
+	var/protein_to_add = 8 //no magic numbers
 	name = picked[1]
 	desc = picked[2]
 	set_greyscale_colors(picked[3])
-	src.reagents.add_reagent(picked[4],8)
+	src.reagents.add_reagent(picked[4],protein_to_add)
 //	var/protein_bar = pick( ///which protein bar gets picked to generated when a protein_pack is spawned.
 //		/obj/item/reagent_containers/food/snacks/protein_pack_base/one,
 //		/obj/item/reagent_containers/food/snacks/protein_pack_base/two,

--- a/code/game/objects/items/marine_gear.dm
+++ b/code/game/objects/items/marine_gear.dm
@@ -52,6 +52,7 @@
 	bitesize = 4
 	greyscale_config = /datum/greyscale_config/protein
 	tastes = list(("flavored protein bar") = 1)
+	///list of protein bar types
 	var/static/list/randlist = list(
 		list("stale TGMC protein bar","The most fake looking protein bar you have ever laid eyes on, covered in the a subtitution chocolate. The powder used to make these is a subsitute of a substitute of whey substitute.","#f37d43",list("nutraloafed food" = 1)),
 		list("mint TGMC protein bar","A stale old protien bar, with an almost minty freshness to it, but not fresh enough","#61b36e",list("minty protein" = 1)),
@@ -66,7 +67,7 @@
 
 /obj/item/reagent_containers/food/snacks/protein_pack/Initialize()
 	. = ..()
-	//list of protein bar stats to change
+	//list of picked variables
 	var/list/picked = pick(randlist)
 	name = picked[1]
 	desc = picked[2]

--- a/code/game/objects/items/reagent_containers/food/snacks.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks.dm
@@ -4,9 +4,6 @@
 	desc = "yummy"
 	icon = 'icons/obj/items/food.dmi'
 	icon_state = null
-	//description of taste
-	var/taste_description = null
-
 	var/bitesize = 1
 	var/bitecount = 0
 	var/trash = null
@@ -14,7 +11,6 @@
 	var/slices_num
 	var/package = FALSE
 	center_of_mass = list("x"=15, "y"=15)
-
 	var/list/tastes // for example list("crisps" = 2, "salt" = 1)
 
 /obj/item/reagent_containers/food/snacks/create_reagents(max_vol, new_flags, list/init_reagents, data)

--- a/code/game/objects/items/reagent_containers/food/snacks.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks.dm
@@ -4,6 +4,9 @@
 	desc = "yummy"
 	icon = 'icons/obj/items/food.dmi'
 	icon_state = null
+	//description of taste
+	var/taste_description = null
+
 	var/bitesize = 1
 	var/bitecount = 0
 	var/trash = null
@@ -11,6 +14,7 @@
 	var/slices_num
 	var/package = FALSE
 	center_of_mass = list("x"=15, "y"=15)
+
 	var/list/tastes // for example list("crisps" = 2, "salt" = 1)
 
 /obj/item/reagent_containers/food/snacks/create_reagents(max_vol, new_flags, list/init_reagents, data)
@@ -22,7 +26,7 @@
 	reagents.my_atom = src
 	for(var/rid in init_reagents)
 		var/amount = list_reagents[rid]
-		if(type == /datum/reagent/consumable/nutriment)
+		if(rid == /datum/reagent/consumable/nutriment)
 			reagents.add_reagent(rid, amount, tastes.Copy())
 		else
 			reagents.add_reagent(rid, amount, data)
@@ -229,7 +233,6 @@
 				N.visible_message(span_warning("[N] nibbles away at [src]."), "")
 			//N.emote("nibbles away at the [src]")
 			N.health = min(N.health + 1, N.maxHealth)
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// FOOD END

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -583,27 +583,14 @@
 	wrenchable = FALSE
 	isshared = TRUE
 	products = list(
-		"Food and Drink" = list(
-			/obj/item/reagent_containers/food/snacks/protein_pack = -1,
-			/obj/item/reagent_containers/food/snacks/mre_pack/meal1 = -1,
-			/obj/item/reagent_containers/food/snacks/mre_pack/meal2 = -1,
-			/obj/item/reagent_containers/food/snacks/mre_pack/meal3 = -1,
-			/obj/item/reagent_containers/food/snacks/mre_pack/meal4 = -1,
-			/obj/item/reagent_containers/food/snacks/mre_pack/meal6 = -1,
-			/obj/item/storage/box/MRE = -1,
-			/obj/item/reagent_containers/food/drinks/flask = -1,
-		),
-		"Protein Bar Supply" = list(
-			/obj/item/reagent_containers/food/snacks/protein_pack_base/one = 20, //wont spawn in loadouts without being in a vendor
-			/obj/item/reagent_containers/food/snacks/protein_pack_base/two = 20,
-			/obj/item/reagent_containers/food/snacks/protein_pack_base/three = 20,
-			/obj/item/reagent_containers/food/snacks/protein_pack_base/four = 20,
-			/obj/item/reagent_containers/food/snacks/protein_pack_base/five = 20,
-			/obj/item/reagent_containers/food/snacks/protein_pack_base/six = 20,
-			/obj/item/reagent_containers/food/snacks/protein_pack_base/seven = 20,
-			/obj/item/reagent_containers/food/snacks/protein_pack_base/eight = 20,
-			/obj/item/reagent_containers/food/snacks/protein_pack_base/nine = 20
-		),
+		/obj/item/reagent_containers/food/snacks/protein_pack = -1,
+		/obj/item/reagent_containers/food/snacks/mre_pack/meal1 = -1,
+		/obj/item/reagent_containers/food/snacks/mre_pack/meal2 = -1,
+		/obj/item/reagent_containers/food/snacks/mre_pack/meal3 = -1,
+		/obj/item/reagent_containers/food/snacks/mre_pack/meal4 = -1,
+		/obj/item/reagent_containers/food/snacks/mre_pack/meal6 = -1,
+		/obj/item/storage/box/MRE = -1,
+		/obj/item/reagent_containers/food/drinks/flask = -1,
 	)
 //Christmas inventory
 /*

--- a/code/modules/reagents/holder.dm
+++ b/code/modules/reagents/holder.dm
@@ -735,7 +735,7 @@
 	return trans_data
 
 
-/datum/reagents/proc/generate_taste_message(minimum_percent=15)
+/datum/reagents/proc/generate_taste_message(minimum_percent=15	)
 	// the lower the minimum percent, the more sensitive the message is.
 	var/list/out = list()
 	var/list/tastes = list() //descriptor = strength

--- a/code/modules/reagents/reagents/food.dm
+++ b/code/modules/reagents/reagents/food.dm
@@ -11,7 +11,6 @@
 	var/nutriment_factor = 1
 	var/adj_temp = 0
 	var/targ_temp = BODYTEMP_NORMAL
-	taste_description = "generic food"
 
 /datum/reagent/consumable/on_mob_life(mob/living/L, metabolism)
 	current_cycle++
@@ -28,7 +27,6 @@
 	description = "All the vitamins, minerals, and carbohydrates the body needs in pure form."
 	nutriment_factor = 15
 	color = "#664330" // rgb: 102, 67, 48
-
 	var/brute_heal = 1
 	var/burn_heal = 0
 	var/blood_gain = 0.4
@@ -47,6 +45,7 @@
 	// taste data can sometimes be ("salt" = 3, "chips" = 1)
 	// and we want it to be in the form ("salt" = 0.75, "chips" = 0.25)
 	// which is called "normalizing"
+
 	if(!supplied_data)
 		supplied_data = data
 
@@ -76,61 +75,7 @@
 	counterlist_normalise(taste_amounts)
 
 	data = taste_amounts
-//various flavors of nutriment for protein bars
-/datum/reagent/consumable/protein
-	name = "Protein Mix"
-	description = "All the vitamins, minerals, and carbohydrates the body with a unique flavor"
-	nutriment_factor = 15
-	color = "#664330" // rgb: 102, 67, 48
-	taste_description = "nutraloafed food"
-	///how much brute damage protein mix can heal on metabolism tic
-	var/brute_heal = 1
-	///how much burn damage protein mix can heal on metabolism tic
-	var/burn_heal = 0
-	///how much blood is gained on metabolism tic
-	var/blood_gain = 0.4
 
-/datum/reagent/consumable/protein/on_mob_life(mob/living/L, metabolism)
-	if(prob(50))
-		L.heal_limb_damage(brute_heal, burn_heal)
-	if(iscarbon(L))
-		var/mob/living/carbon/C = L
-		if(C.blood_volume < BLOOD_VOLUME_NORMAL)
-			C.blood_volume += blood_gain
-
-	return ..()
-
-/datum/reagent/consumable/protein/mint
-	name = "Mint Protein Mix"
-	//taste_description = "minty protein"
-
-/datum/reagent/consumable/protein/grape
-	name = "Grape Protein Mix"
-	//taste_description = "artifical grape"
-
-/datum/reagent/consumable/protein/mystery
-	name = "Crayon Protein Mix"
-	//taste_description = "crayons"
-
-/datum/reagent/consumable/protein/darkchocolate
-	name = "Dark chocolate Protein Mix"
-	//taste_description = "bitter dark chocolate"
-
-/datum/reagent/consumable/protein/milkchocolate
-	name = "Milk Chocolate Protein Mix"
-	//taste_description = "off flavor milk chocolate"
-
-/datum/reagent/consumable/protein/rasplime
-	name = "Raspberry Lime Protein Mix"
-	//taste_description = "sour raspberry and lime"
-
-/datum/reagent/consumable/protein/chicken
-	name = "Chicken Protein Mix"
-	//taste_description = "powdered chicken"
-
-/datum/reagent/consumable/protein/blueberry
-	name = "Blueberry Protein Mix"
-	//taste_description = "blueberry"
 
 /datum/reagent/consumable/sugar
 	name = "Sugar"

--- a/code/modules/reagents/reagents/food.dm
+++ b/code/modules/reagents/reagents/food.dm
@@ -102,35 +102,35 @@
 
 /datum/reagent/consumable/protein/mint
 	name = "Mint Protein Mix"
-	taste_description = "minty protein"
+	//taste_description = "minty protein"
 
 /datum/reagent/consumable/protein/grape
 	name = "Grape Protein Mix"
-	taste_description = "artifical grape"
+	//taste_description = "artifical grape"
 
 /datum/reagent/consumable/protein/mystery
 	name = "Crayon Protein Mix"
-	taste_description = "crayons"
+	//taste_description = "crayons"
 
 /datum/reagent/consumable/protein/darkchocolate
 	name = "Dark chocolate Protein Mix"
-	taste_description = "bitter dark chocolate"
+	//taste_description = "bitter dark chocolate"
 
 /datum/reagent/consumable/protein/milkchocolate
 	name = "Milk Chocolate Protein Mix"
-	taste_description = "off flavor milk chocolate"
+	//taste_description = "off flavor milk chocolate"
 
 /datum/reagent/consumable/protein/rasplime
 	name = "Raspberry Lime Protein Mix"
-	taste_description = "sour raspberry and lime"
+	//taste_description = "sour raspberry and lime"
 
 /datum/reagent/consumable/protein/chicken
 	name = "Chicken Protein Mix"
-	taste_description = "powdered chicken"
+	//taste_description = "powdered chicken"
 
 /datum/reagent/consumable/protein/blueberry
 	name = "Blueberry Protein Mix"
-	taste_description = "blueberry"
+	//taste_description = "blueberry"
 
 /datum/reagent/consumable/sugar
 	name = "Sugar"


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the way protein bars are generated so that they are no longer creating and then deleting a fake protein bar, just to create a real protein bar. As a side effect of this you will no longer be able to purchase specific flavors of protein bars.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Because 
1. the protein bars did not vend into your hands like old protein bars
2. the vendors vended fake protein bars into your hands that you could not see
3. the fake protein bars would prevent you from picking anything up even though they were deleted as soon as they entered your hands
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: You can no longer vend specific flavors of protein bars
fix: Stopped filling your hands with fake protein bars
fix: nutriment has taste as intended
qol: Protein bars now vend into your hands as they should
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
