### PR TITLE
You can now put the gal-9 extended clip back into the UZI again.

### DIFF
--- a/code/modules/projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/guns/smgs.dm
@@ -341,7 +341,7 @@
 	reload_sound = 'sound/weapons/guns/interact/uzi_reload.ogg'
 	cocked_sound = 'sound/weapons/guns/interact/uzi_cocked.ogg'
 	default_ammo_type = /obj/item/ammo_magazine/smg/uzi
-	allowed_ammo_types = list(/obj/item/ammo_magazine/smg/uzi)
+	allowed_ammo_types = list(/obj/item/ammo_magazine/smg/uzi, /obj/item/ammo_magazine/smg/uzi/extended)
 	attachable_offset = list("muzzle_x" = 30, "muzzle_y" = 20,"rail_x" = 11, "rail_y" = 22, "under_x" = 22, "under_y" = 16, "stock_x" = 22, "stock_y" = 16)
 
 	fire_delay = 0.15 SECONDS


### PR DESCRIPTION
## About The Pull Request
Adds `/obj/item/ammo_magazine/smg/uzi/extended` to the UZI's list of allowed ammo types
Fixes #8794 
~~Reason why this broke is unkown but for whatever reason `allowed_ammo_types` does not allow subtypes of ammo types~~
Reason why this was broken has been identified #8673 that was merged about 2 weeks ago changed the reload proc in such a way that although it would allow `allowed_ammo_types` to be put into a magazine, it did not check for subtypes of those magazines, causing this issue.

This PR has been fully tested on a local build with zero (0) runtimes or errors.
![2021-12-10_13-56-21](https://user-images.githubusercontent.com/17747087/145577868-83ea5a60-d6d1-40d4-8fdd-c668b5e0b540.gif)

## Why It's Good For The Game
This is essential for CLF since they spawn with a backpack full of these clips, also overall not good for an extended clip to not fit into the gun despite being made specifically for that gun.

## Changelog
:cl: Vondiech
fix: You can now put in the extended gal-9 clip into the UZI again.
/:cl: